### PR TITLE
fix: dogfooding round 8 — goal tree bugs (#210-#214)

### DIFF
--- a/src/cli/commands/goal-dispatch.ts
+++ b/src/cli/commands/goal-dispatch.ts
@@ -53,6 +53,7 @@ export async function dispatchGoalCommand(
       deadline?: string;
       constraint?: string[];
       yes?: boolean;
+      parent?: string;
     } = {};
     try {
       const parsed = parseArgs({
@@ -65,6 +66,7 @@ export async function dispatchGoalCommand(
           deadline: { type: "string" },
           constraint: { type: "string", multiple: true },
           yes: { type: "boolean", short: "y" },
+          parent: { type: "string" },
         },
         allowPositionals: true,
         strict: false,
@@ -89,7 +91,7 @@ export async function dispatchGoalCommand(
         );
         return 1;
       }
-      return await cmdGoalAddRaw(stateManager, { title, description, rawDimensions });
+      return await cmdGoalAddRaw(stateManager, { title, description, rawDimensions, parent_id: addValues.parent });
     }
 
     // Refine/negotiate mode: requires description

--- a/src/cli/commands/goal-raw.ts
+++ b/src/cli/commands/goal-raw.ts
@@ -12,7 +12,7 @@ import {
 
 export async function cmdGoalAddRaw(
   stateManager: StateManager,
-  opts: { title?: string; description?: string; rawDimensions: string[] }
+  opts: { title?: string; description?: string; rawDimensions: string[]; parent_id?: string }
 ): Promise<number> {
   const title = opts.title || opts.description;
   if (!title) {
@@ -65,7 +65,7 @@ export async function cmdGoalAddRaw(
 
   const goal = {
     id: goalId,
-    parent_id: null,
+    parent_id: opts.parent_id ?? null,
     node_type: "goal" as const,
     title,
     description: opts.description || title,
@@ -91,6 +91,19 @@ export async function cmdGoalAddRaw(
   };
 
   await stateManager.saveGoal(goal);
+
+  if (opts.parent_id) {
+    const parent = await stateManager.loadGoal(opts.parent_id);
+    if (parent) {
+      await stateManager.saveGoal({
+        ...parent,
+        children_ids: [...parent.children_ids, goalId],
+        updated_at: now,
+      });
+    } else {
+      getCliLogger().warn(`Warning: parent goal not found: ${opts.parent_id}. Goal saved without parent link.`);
+    }
+  }
 
   await autoRegisterFileExistenceDataSources(stateManager, dimensions, title, goalId);
   await autoRegisterShellDataSources(stateManager, dimensions, goalId);

--- a/src/cli/commands/goal-read.ts
+++ b/src/cli/commands/goal-read.ts
@@ -201,8 +201,14 @@ export async function cmdGoalShow(stateManager: StateManager, goalId: string): P
     console.log(`Children:    ${goal.children_ids.length} subgoal(s)`);
     for (const childId of goal.children_ids) {
       const shortId = childId.substring(0, 8);
-      const childGoal = await stateManager.loadGoal(childId);
-      const childTitle = childGoal ? childGoal.title : "(unknown)";
+      let childTitle = "(error reading goal)";
+      try {
+        const childGoal = await stateManager.loadGoal(childId);
+        if (childGoal) childTitle = childGoal.title;
+        else childTitle = "(unknown)";
+      } catch {
+        // keep fallback title
+      }
       console.log(`  - ${shortId}... — ${childTitle}`);
     }
   }

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -129,13 +129,30 @@ export class StateManager {
     return GoalSchema.parse(archiveRaw);
   }
 
-  async deleteGoal(goalId: string): Promise<boolean> {
+  async deleteGoal(goalId: string, _visited = new Set<string>()): Promise<boolean> {
+    if (_visited.has(goalId)) return false;
+    _visited.add(goalId);
+
     const dir = path.join(this.baseDir, "goals", goalId);
     try {
       await fsp.access(dir);
     } catch {
       return false;
     }
+
+    // Recursively delete children first (depth-first)
+    let goal: Goal | null = null;
+    try {
+      goal = await this.loadGoal(goalId);
+    } catch {
+      this.logger?.warn(`[StateManager] Skipping children of "${goalId}": goal.json unreadable`);
+    }
+    if (goal !== null) {
+      for (const childId of goal.children_ids) {
+        await this.deleteGoal(childId, _visited);
+      }
+    }
+
     await fsp.rm(dir, { recursive: true, force: true });
     return true;
   }
@@ -153,12 +170,28 @@ export class StateManager {
    *
    * Returns true if the goal was archived, false if the goal was not found.
    */
-  async archiveGoal(goalId: string): Promise<boolean> {
+  async archiveGoal(goalId: string, _visited = new Set<string>()): Promise<boolean> {
+    if (_visited.has(goalId)) return false;
+    _visited.add(goalId);
+
     const goalDir = path.join(this.baseDir, "goals", goalId);
     try {
       await fsp.access(goalDir);
     } catch {
       return false;
+    }
+
+    // Recursively archive children first (depth-first)
+    let goal: Goal | null = null;
+    try {
+      goal = await this.loadGoal(goalId);
+    } catch {
+      this.logger?.warn(`[StateManager] Skipping children of "${goalId}": goal.json unreadable`);
+    }
+    if (goal !== null) {
+      for (const childId of goal.children_ids) {
+        await this.archiveGoal(childId, _visited);
+      }
     }
 
     const archiveBase = path.join(this.baseDir, "archive", goalId);
@@ -168,6 +201,18 @@ export class StateManager {
     const archiveGoalDir = path.join(archiveBase, "goal");
     await fsp.cp(goalDir, archiveGoalDir, { recursive: true });
     await fsp.rm(goalDir, { recursive: true, force: true });
+
+    // Update status to "archived" in the archived goal.json (Bug 5)
+    const archivedGoalJsonPath = path.join(archiveGoalDir, "goal.json");
+    try {
+      const archivedRaw = await this.atomicRead<unknown>(archivedGoalJsonPath);
+      if (archivedRaw !== null) {
+        const archivedGoal = GoalSchema.parse(archivedRaw);
+        await this.atomicWrite(archivedGoalJsonPath, { ...archivedGoal, status: "archived" });
+      }
+    } catch {
+      this.logger?.warn(`[StateManager] Could not update status to "archived" for "${goalId}": goal.json unreadable`);
+    }
 
     // Move tasks/<goalId>/ → archive/<goalId>/tasks/ (if exists)
     const tasksDir = path.join(this.baseDir, "tasks", goalId);

--- a/tests/e2e/r1-core-loop-executes.test.ts
+++ b/tests/e2e/r1-core-loop-executes.test.ts
@@ -494,6 +494,6 @@ describe("R1-3 E2E: loadGoal() returns archived goals via archive fallback path"
     expect(loaded!.dimensions).toHaveLength(1);
     expect(loaded!.dimensions[0]!.name).toBe("quality");
     expect(loaded!.dimensions[0]!.current_value).toBe(0.0);
-    expect(loaded!.status).toBe("active");
+    expect(loaded!.status).toBe("archived");
   });
 });

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -654,5 +654,73 @@ describe("StateManager", async () => {
     it("loadGoal returns null for a goal that was never saved nor archived", async () => {
       expect(await manager.loadGoal("never-existed")).toBeNull();
     });
+
+    it("archiveGoal cascades to children — both parent and child appear in archive", async () => {
+      const child = makeGoal({ id: "arc-child", parent_id: "arc-parent" });
+      const parent = makeGoal({ id: "arc-parent", children_ids: ["arc-child"] });
+      await manager.saveGoal(child);
+      await manager.saveGoal(parent);
+
+      const result = await manager.archiveGoal("arc-parent");
+      expect(result).toBe(true);
+
+      // Both parent and child directories should be in the archive
+      expect(fs.existsSync(path.join(tmpDir, "archive", "arc-parent", "goal", "goal.json"))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, "archive", "arc-child", "goal", "goal.json"))).toBe(true);
+
+      // Both should have status "archived"
+      const parentArchived = await manager.loadGoal("arc-parent");
+      expect(parentArchived?.status).toBe("archived");
+      const childArchived = await manager.loadGoal("arc-child");
+      expect(childArchived?.status).toBe("archived");
+    });
+
+    it("archiveGoal tolerates corrupt child — succeeds without throwing", async () => {
+      const child = makeGoal({ id: "arc-corrupt-child", parent_id: "arc-corrupt-parent" });
+      const parent = makeGoal({ id: "arc-corrupt-parent", children_ids: ["arc-corrupt-child"] });
+      await manager.saveGoal(child);
+      await manager.saveGoal(parent);
+
+      // Corrupt the child's goal.json with invalid JSON
+      const childGoalPath = path.join(tmpDir, "goals", "arc-corrupt-child", "goal.json");
+      fs.writeFileSync(childGoalPath, "{ not valid json ~~~");
+
+      // archiveGoal on the parent should succeed despite the corrupt child
+      await expect(manager.archiveGoal("arc-corrupt-parent")).resolves.toBe(true);
+
+      // Parent archive should exist
+      expect(fs.existsSync(path.join(tmpDir, "archive", "arc-corrupt-parent", "goal", "goal.json"))).toBe(true);
+    });
+  });
+
+  describe("deleteGoal cascade", async () => {
+    it("deleteGoal cascades to children — both parent and child directories removed", async () => {
+      const child = makeGoal({ id: "del-child", parent_id: "del-parent" });
+      const parent = makeGoal({ id: "del-parent", children_ids: ["del-child"] });
+      await manager.saveGoal(child);
+      await manager.saveGoal(parent);
+
+      const result = await manager.deleteGoal("del-parent");
+      expect(result).toBe(true);
+
+      expect(await manager.goalExists("del-parent")).toBe(false);
+      expect(await manager.goalExists("del-child")).toBe(false);
+    });
+
+    it("deleteGoal tolerates corrupt child — succeeds without throwing", async () => {
+      const child = makeGoal({ id: "del-corrupt-child", parent_id: "del-corrupt-parent" });
+      const parent = makeGoal({ id: "del-corrupt-parent", children_ids: ["del-corrupt-child"] });
+      await manager.saveGoal(child);
+      await manager.saveGoal(parent);
+
+      // Corrupt the child's goal.json with invalid JSON
+      const childGoalPath = path.join(tmpDir, "goals", "del-corrupt-child", "goal.json");
+      fs.writeFileSync(childGoalPath, "{ not valid json ~~~");
+
+      // deleteGoal on the parent should succeed despite the corrupt child
+      await expect(manager.deleteGoal("del-corrupt-parent")).resolves.toBe(true);
+
+      expect(await manager.goalExists("del-corrupt-parent")).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- **#210**: `goal show` now displays children for manually-added child goals (via `--parent`)
- **#211**: Child goal description no longer shows parent ID instead of actual description
- **#212**: `goal archive` cascades to all descendant goals
- **#213**: `goal remove` cascades to all descendant goals  
- **#214**: Archived goals now correctly have `status: "archived"`
- Added cycle guard (visited set) and corrupt-JSON tolerance to cascade recursion
- Added 4 new cascade tests

## Issues Fixed
#210, #211, #212, #213, #214

## Test Results
4595 tests (+6 new), 4591 pass (4 pre-existing OpenAI E2E failures — API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)