### PR TITLE
fix: dogfooding round 13 — goal tree, archive, portfolio CLI bugs

### DIFF
--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -122,12 +122,12 @@ export class CLIRunner {
     const subcommand = argv[0];
 
     if (subcommand === "run") {
-      let values: { goal?: string; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean };
+      let values: { goal?: string[]; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean };
       try {
         ({ values } = parseArgs({
           args: argv.slice(1),
           options: {
-            goal: { type: "string" },
+            goal: { type: "string", multiple: true },
             "max-iterations": { type: "string" },
             adapter: { type: "string" },
             tree: { type: "boolean" },
@@ -135,17 +135,22 @@ export class CLIRunner {
             verbose: { type: "boolean" },
           },
           strict: false,
-        }) as { values: { goal?: string; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean } });
+        }) as { values: { goal?: string[]; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean } });
       } catch (err) {
         logger.error(formatOperationError("parse run command arguments", err));
         values = {};
       }
 
-      const goalId = values.goal;
-      if (!goalId || typeof goalId !== "string") {
+      const goalIds = values.goal ?? [];
+      if (goalIds.length === 0) {
         logger.error("Error: --goal <id> is required for `tavori run`.");
         return 1;
       }
+      if (goalIds.length > 1) {
+        logger.error("Error: only one --goal is supported per `tavori run`. Run separately for each goal, or use --tree for tree traversal.");
+        return 1;
+      }
+      const goalId = goalIds[0];
 
       const loopConfig: LoopConfig = {};
       if (values["max-iterations"] !== undefined) {

--- a/src/cli/commands/goal-write.ts
+++ b/src/cli/commands/goal-write.ts
@@ -306,7 +306,7 @@ export async function cmdGoalArchive(
 
   console.log(`Goal "${goalId}" archived successfully.`);
   console.log(`  Title:  ${goal.title}`);
-  console.log(`  Status: ${goal.status}`);
+  console.log(`  Status: archived`);
   return 0;
 }
 

--- a/src/loop/tree-loop-runner.ts
+++ b/src/loop/tree-loop-runner.ts
@@ -17,8 +17,14 @@ export async function runTreeIteration(
 ): Promise<LoopIterationResult> {
   const orchestrator = deps.treeLoopOrchestrator!;
 
-  // 0. Auto-decompose (or refine) if root has no children yet
+  // 0. Auto-decompose (or refine) if root has no children yet.
+  // If root already has children (e.g. resumed session), reset all nodes to "idle"
+  // so that stale "running" statuses from a prior run do not block node selection.
   const rootGoalForDecomp = await deps.stateManager.loadGoal(rootId);
+  if (rootGoalForDecomp && rootGoalForDecomp.children_ids.length > 0 && loopIndex === 0) {
+    const defaultConfig = { min_specificity: 0.7, max_depth: 3, parallel_loop_limit: 3, auto_prune_threshold: 0.3 };
+    await deps.treeLoopOrchestrator?.startTreeExecution(rootId, defaultConfig);
+  }
   if (rootGoalForDecomp && rootGoalForDecomp.children_ids.length === 0) {
     const defaultConfig = { min_specificity: 0.7, max_depth: 3, parallel_loop_limit: 3, auto_prune_threshold: 0.3 };
     if (deps.goalRefiner) {
@@ -95,9 +101,20 @@ export async function runTreeIteration(
     }
   }
 
-  // 4. If the node's goal is now completed, call onNodeCompleted
+  // 4. If the node's goal is now completed, call onNodeCompleted.
+  // Otherwise reset loop_status to "idle" so the node remains eligible for
+  // future iterations (the eligibility filter skips "running" nodes).
   if (result.completionJudgment.is_complete) {
     await orchestrator.onNodeCompleted(selectedNodeId);
+  } else {
+    const nodeGoal = await deps.stateManager.loadGoal(selectedNodeId);
+    if (nodeGoal) {
+      await deps.stateManager.saveGoal({
+        ...nodeGoal,
+        loop_status: "idle",
+        updated_at: new Date().toISOString(),
+      });
+    }
   }
 
   return result;

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -137,7 +137,29 @@ export class StateManager {
     try {
       await fsp.access(dir);
     } catch {
-      return false;
+      // After the active goals check fails, try archive directory
+      const archiveDir = path.join(this.baseDir, "archive", goalId);
+      try {
+        await fsp.access(archiveDir);
+        // Load archived goal to get children_ids before deleting
+        const archiveGoalPath = path.join(archiveDir, "goal", "goal.json");
+        let archivedGoal: Goal | null = null;
+        try {
+          const raw = await this.atomicRead<unknown>(archiveGoalPath);
+          if (raw !== null) archivedGoal = GoalSchema.parse(raw);
+        } catch {
+          this.logger?.warn(`[StateManager] Skipping children of archived "${goalId}": goal.json unreadable`);
+        }
+        if (archivedGoal !== null) {
+          for (const childId of archivedGoal.children_ids) {
+            await this.deleteGoal(childId, _visited);
+          }
+        }
+        await fsp.rm(archiveDir, { recursive: true, force: true });
+        return true;
+      } catch {
+        return false;
+      }
     }
 
     // Recursively delete children first (depth-first)


### PR DESCRIPTION
## Summary
- Fix archive output showing stale "Status: active" instead of "archived" (#256)
- Fix `goal remove` failing for archived goals with "Goal not found" (#257)
- Add recursive child deletion for archived goal trees (reviewer finding)
- Reject multiple `--goal` flags with clear error instead of silent last-wins (#258)
- Fix tree mode `loop_status` stuck "running", preventing task generation (#260)
- Guard `startTreeExecution` to run only on first iteration (reviewer finding)

## Issues Fixed
Fixes #256, Fixes #257, Fixes #258, Fixes #260

## Test Results
224 related tests pass, 4627 total pass (5 pre-existing flaky/env failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)