### PR TITLE
fix: monotonic floor for synthetic dims + clearTimeout on API success (#286, #287)

### DIFF
--- a/src/llm/openai-client.ts
+++ b/src/llm/openai-client.ts
@@ -132,6 +132,13 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
           // The TypeScript types for the Responses API are not yet in the openai
           // package typings, so we cast through unknown to access this endpoint.
           const responsesApi = (this.client as unknown as { responses: { create: (params: Record<string, unknown>) => Promise<unknown> } }).responses;
+          let timer: ReturnType<typeof setTimeout>;
+          const timeout = new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () => reject(new LLMError(`OpenAILLMClient: Responses API timed out after ${DEFAULT_LLM_TIMEOUT_MS}ms`)),
+              DEFAULT_LLM_TIMEOUT_MS
+            );
+          });
           const resp = await Promise.race([
             responsesApi.create({
               model,
@@ -139,13 +146,9 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
               max_output_tokens: max_tokens,
               ...(isReasoningModel(model) ? {} : { temperature }),
             }),
-            new Promise<never>((_, reject) =>
-              setTimeout(
-                () => reject(new LLMError(`OpenAILLMClient: Responses API timed out after ${DEFAULT_LLM_TIMEOUT_MS}ms`)),
-                DEFAULT_LLM_TIMEOUT_MS
-              )
-            ),
+            timeout,
           ]) as Record<string, unknown>;
+          clearTimeout(timer!);
 
           const content =
             typeof resp["output_text"] === "string"

--- a/src/observation/observation-apply.ts
+++ b/src/observation/observation-apply.ts
@@ -78,7 +78,7 @@ export async function applyObservation(
     if (
       dim.threshold.type === 'min' &&
       effectiveValue < dim.current_value &&
-      entry.confidence < (dim.confidence ?? 0)
+      entry.confidence < (dim.confidence ?? 1)
     ) {
       effectiveValue = dim.current_value;
     }


### PR DESCRIPTION
## Summary
- Fix monotonic floor disabled for null-confidence dimensions: use `?? 1` instead of `?? 0` (#286)
- Fix setTimeout leak in OpenAI Responses API fallback: clearTimeout after Promise.race resolves (#287)

## Issues Fixed
Fixes #286, Fixes #287

## Test Results
4682+ tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)