### PR TITLE
feat: add datasource dedup command (#264)

### DIFF
--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -43,6 +43,7 @@ import {
   cmdDatasourceAdd,
   cmdDatasourceList,
   cmdDatasourceRemove,
+  cmdDatasourceDedup,
   cmdCapabilityList,
   cmdCapabilityRemove,
 } from "./cli/commands/config.js";
@@ -289,7 +290,7 @@ export class CLIRunner {
       const dsSubcommand = argv[1];
 
       if (!dsSubcommand) {
-        logger.error("Error: datasource subcommand required. Available: datasource add, datasource list, datasource remove");
+        logger.error("Error: datasource subcommand required. Available: datasource add, datasource list, datasource remove, datasource dedup");
         return 1;
       }
 
@@ -305,8 +306,12 @@ export class CLIRunner {
         return cmdDatasourceRemove(this.stateManager, argv.slice(2));
       }
 
+      if (dsSubcommand === "dedup") {
+        return cmdDatasourceDedup(this.stateManager);
+      }
+
       logger.error(`Unknown datasource subcommand: "${dsSubcommand}"`);
-      logger.error("Available: datasource add, datasource list, datasource remove");
+      logger.error("Available: datasource add, datasource list, datasource remove, datasource dedup");
       return 1;
     }
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -8,6 +8,7 @@ import { writeJsonFile, readJsonFile } from "../../utils/json-io.js";
 
 import { StateManager } from "../../state-manager.js";
 import { CharacterConfigManager } from "../../traits/character-config.js";
+
 import { loadProviderConfig, saveProviderConfig } from "../../llm/provider-config.js";
 import type { ProviderConfig } from "../../llm/provider-config.js";
 import { buildLLMClient } from "../../llm/provider-factory.js";
@@ -368,6 +369,78 @@ export async function cmdDatasourceRemove(
   await fsp.unlink(configPath);
   console.log(`Data source "${id}" removed.`);
 
+  return 0;
+}
+
+export async function cmdDatasourceDedup(stateManager: StateManager): Promise<number> {
+  const datasourcesDir = getDatasourcesDir(stateManager.getBaseDir());
+
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(datasourcesDir);
+  } catch {
+    console.log("No datasources directory found. Nothing to deduplicate.");
+    return 0;
+  }
+
+  const jsonFiles = entries.filter((e) => e.endsWith(".json")).sort();
+  if (jsonFiles.length === 0) {
+    console.log("No datasources found. Nothing to deduplicate.");
+    return 0;
+  }
+
+  // Load configs with their filenames
+  const configs: Array<{ file: string; cfg: Record<string, unknown> }> = [];
+  for (const file of jsonFiles) {
+    try {
+      const raw = await fsp.readFile(path.join(datasourcesDir, file), "utf-8");
+      configs.push({ file, cfg: JSON.parse(raw) as Record<string, unknown> });
+    } catch {
+      // Skip unreadable files
+    }
+  }
+
+  // Build dedup key: type + sorted dimension names
+  function dedupKey(cfg: Record<string, unknown>): string {
+    const type = (cfg["type"] as string | undefined) ?? "unknown";
+    let dims: string[] = [];
+    if (type === "shell") {
+      const commands = (cfg["connection"] as Record<string, unknown> | undefined)?.["commands"];
+      dims = commands ? Object.keys(commands as Record<string, unknown>).sort() : [];
+    } else if (type === "file_existence") {
+      const dimMapping = cfg["dimension_mapping"];
+      dims = dimMapping ? Object.keys(dimMapping as Record<string, unknown>).sort() : [];
+    }
+    return `${type}::${dims.join(",")}`;
+  }
+
+  // Group by dedup key; first entry (oldest by sorted filename) is the keeper
+  const seen = new Map<string, string>(); // key → first filename
+  const toRemove: string[] = [];
+
+  for (const { file, cfg } of configs) {
+    const key = dedupKey(cfg);
+    if (seen.has(key)) {
+      toRemove.push(file);
+    } else {
+      seen.set(key, file);
+    }
+  }
+
+  if (toRemove.length === 0) {
+    console.log("No duplicate datasources found.");
+    return 0;
+  }
+
+  for (const file of toRemove) {
+    try {
+      await fsp.unlink(path.join(datasourcesDir, file));
+    } catch (err) {
+      getCliLogger().error(formatOperationError(`remove duplicate datasource "${file}"`, err));
+    }
+  }
+
+  console.log(`Removed ${toRemove.length} duplicate datasource(s).`);
   return 0;
 }
 

--- a/src/cli/commands/goal-utils.ts
+++ b/src/cli/commands/goal-utils.ts
@@ -132,7 +132,7 @@ interface DatasourceConfig {
  * Load all existing datasource configs from the datasources directory.
  * Returns an empty array if the directory does not exist or cannot be read.
  */
-async function loadExistingDatasources(datasourcesDir: string): Promise<DatasourceConfig[]> {
+export async function loadExistingDatasources(datasourcesDir: string): Promise<DatasourceConfig[]> {
   let entries: string[];
   try {
     entries = await fsp.readdir(datasourcesDir);

--- a/src/cli/commands/goal-write.ts
+++ b/src/cli/commands/goal-write.ts
@@ -17,6 +17,7 @@ import {
   autoRegisterFileExistenceDataSources,
   autoRegisterShellDataSources,
 } from "./goal-utils.js";
+import { cmdDatasourceDedup } from "./config.js";
 import type { RefineResult } from "../../types/goal-refiner.js";
 
 // ─── Display helpers ───
@@ -371,6 +372,9 @@ export async function cmdCleanup(stateManager: StateManager): Promise<number> {
     }
     console.log("(These can be removed manually from ~/.seedpulse/reports/)");
   }
+
+  // Deduplicate datasources
+  await cmdDatasourceDedup(stateManager);
 
   return 0;
 }

--- a/tests/datasource-dedup.test.ts
+++ b/tests/datasource-dedup.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { cmdDatasourceDedup } from "../src/cli/commands/config.js";
+import { makeTempDir, cleanupTempDir } from "./helpers/temp-dir.js";
+
+// ─── Minimal StateManager stub ───
+
+function makeFakeStateManager(baseDir: string) {
+  return { getBaseDir: () => baseDir };
+}
+
+// ─── Helpers ───
+
+function writeDatasource(datasourcesDir: string, filename: string, cfg: Record<string, unknown>): void {
+  fs.mkdirSync(datasourcesDir, { recursive: true });
+  fs.writeFileSync(path.join(datasourcesDir, filename), JSON.stringify(cfg));
+}
+
+function listFiles(datasourcesDir: string): string[] {
+  if (!fs.existsSync(datasourcesDir)) return [];
+  return fs.readdirSync(datasourcesDir).filter((f) => f.endsWith(".json")).sort();
+}
+
+// ─── Tests ───
+
+describe("cmdDatasourceDedup", () => {
+  let tmpDir: string;
+  let datasourcesDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    datasourcesDir = path.join(tmpDir, "datasources");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  it("returns 0 and prints no-op message when datasources dir does not exist", async () => {
+    const sm = makeFakeStateManager(tmpDir);
+    const result = await cmdDatasourceDedup(sm as never);
+    expect(result).toBe(0);
+    // Dir was never created
+    expect(fs.existsSync(datasourcesDir)).toBe(false);
+  });
+
+  it("returns 0 when no duplicate datasources exist", async () => {
+    writeDatasource(datasourcesDir, "ds_shell_a.json", {
+      id: "ds_shell_a",
+      type: "shell",
+      connection: { commands: { todo_count: {}, test_count: {} } },
+    });
+    writeDatasource(datasourcesDir, "ds_file_b.json", {
+      id: "ds_file_b",
+      type: "file_existence",
+      dimension_mapping: { readme_exists: "README.md" },
+    });
+
+    const sm = makeFakeStateManager(tmpDir);
+    const result = await cmdDatasourceDedup(sm as never);
+    expect(result).toBe(0);
+    expect(listFiles(datasourcesDir)).toHaveLength(2);
+  });
+
+  it("removes duplicate shell datasources and keeps the first (alphabetically sorted)", async () => {
+    // ds_a comes first alphabetically — should be kept
+    writeDatasource(datasourcesDir, "ds_a_shell.json", {
+      id: "ds_a_shell",
+      type: "shell",
+      connection: { commands: { todo_count: {}, test_count: {} } },
+    });
+    writeDatasource(datasourcesDir, "ds_b_shell.json", {
+      id: "ds_b_shell",
+      type: "shell",
+      connection: { commands: { test_count: {}, todo_count: {} } }, // same dims, different order
+    });
+
+    const sm = makeFakeStateManager(tmpDir);
+    const result = await cmdDatasourceDedup(sm as never);
+    expect(result).toBe(0);
+
+    const remaining = listFiles(datasourcesDir);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toBe("ds_a_shell.json");
+  });
+
+  it("removes duplicate file_existence datasources and keeps the first", async () => {
+    writeDatasource(datasourcesDir, "ds_1_fe.json", {
+      id: "ds_1_fe",
+      type: "file_existence",
+      dimension_mapping: { src_exists: "src/", readme_exists: "README.md" },
+    });
+    writeDatasource(datasourcesDir, "ds_2_fe.json", {
+      id: "ds_2_fe",
+      type: "file_existence",
+      dimension_mapping: { readme_exists: "README.md", src_exists: "src/" }, // same dims
+    });
+
+    const sm = makeFakeStateManager(tmpDir);
+    const result = await cmdDatasourceDedup(sm as never);
+    expect(result).toBe(0);
+
+    const remaining = listFiles(datasourcesDir);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toBe("ds_1_fe.json");
+  });
+
+  it("only removes duplicates within same type — does not cross types", async () => {
+    // A shell and a file_existence datasource that happen to have same dim names
+    // should NOT be treated as duplicates of each other
+    writeDatasource(datasourcesDir, "ds_shell.json", {
+      id: "ds_shell",
+      type: "shell",
+      connection: { commands: { test_count: {} } },
+    });
+    writeDatasource(datasourcesDir, "ds_fe.json", {
+      id: "ds_fe",
+      type: "file_existence",
+      dimension_mapping: { test_count: "tests/" },
+    });
+
+    const sm = makeFakeStateManager(tmpDir);
+    const result = await cmdDatasourceDedup(sm as never);
+    expect(result).toBe(0);
+
+    // Both should remain — different types
+    expect(listFiles(datasourcesDir)).toHaveLength(2);
+  });
+
+  it("handles multiple duplicates in the same group correctly", async () => {
+    for (let i = 1; i <= 4; i++) {
+      writeDatasource(datasourcesDir, `ds_shell_${i}.json`, {
+        id: `ds_shell_${i}`,
+        type: "shell",
+        connection: { commands: { todo_count: {} } },
+      });
+    }
+
+    const sm = makeFakeStateManager(tmpDir);
+    const result = await cmdDatasourceDedup(sm as never);
+    expect(result).toBe(0);
+
+    const remaining = listFiles(datasourcesDir);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toBe("ds_shell_1.json");
+  });
+
+  it("returns 0 when datasources directory is empty", async () => {
+    fs.mkdirSync(datasourcesDir, { recursive: true });
+    const sm = makeFakeStateManager(tmpDir);
+    const result = await cmdDatasourceDedup(sm as never);
+    expect(result).toBe(0);
+    expect(listFiles(datasourcesDir)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `seedpulse datasource dedup` CLI command to detect and remove duplicate datasources (same type + dimension set)
- Integrate dedup into `seedpulse cleanup` so it runs automatically alongside goal archival
- Export `loadExistingDatasources()` from goal-utils for reuse

Closes #264

## Test plan
- [x] 7 new tests in `tests/datasource-dedup.test.ts` (no duplicates, shell dedup, file_existence dedup, cross-type, multiple groups, empty dir, missing dir)
- [x] All 4689 existing tests pass
- [x] Build passes (`tsc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)