### PR TITLE
fix: propagate --max to improve goal run iterations (#299)

### DIFF
--- a/src/cli/commands/suggest.ts
+++ b/src/cli/commands/suggest.ts
@@ -248,7 +248,7 @@ export async function cmdImprove(
     const loopDeps = await buildDeps(
       stateManager,
       characterConfigManager,
-      undefined,
+      { maxIterations: maxSuggestions },
       buildAutoApprovalFn(),
       loopLogger,
       buildProgressHandler()

--- a/tests/cli-improve.test.ts
+++ b/tests/cli-improve.test.ts
@@ -517,6 +517,36 @@ describe("improve subcommand — loop execution", () => {
     expect(mockRun).toHaveBeenCalledWith("goal-yes");
   });
 
+  it("propagates --max to CoreLoop maxIterations when --yes is provided", async () => {
+    const goal = makeGoal({ id: "goal-max-propagate" });
+    const mockSuggest = vi.fn().mockResolvedValue([makeSuggestion()]);
+    const mockNegotiate = vi.fn().mockResolvedValue(makeNegotiationResult(goal));
+    const mockRun = vi.fn().mockResolvedValue(makeLoopResult({ goalId: "goal-max-propagate" }));
+
+    vi.mocked(GoalNegotiator).mockImplementation(() => ({
+      suggestGoals: mockSuggest,
+      negotiate: mockNegotiate,
+    } as unknown as GoalNegotiator));
+
+    vi.mocked(CoreLoop).mockImplementation(() => ({
+      run: mockRun,
+      stop: vi.fn(),
+    } as unknown as CoreLoop));
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("improve", ".", "--max", "2", "--yes");
+    consoleSpy.mockRestore();
+
+    expect(code).toBe(0);
+    // CoreLoop should have been constructed with maxIterations: 2
+    const ctorCalls = vi.mocked(CoreLoop).mock.calls;
+    // The last CoreLoop instance is the one used for the loop (buildDeps is called twice)
+    const loopCtorCall = ctorCalls[ctorCalls.length - 1];
+    expect(loopCtorCall).toBeDefined();
+    const loopConfig = loopCtorCall![1] as { maxIterations?: number } | undefined;
+    expect(loopConfig?.maxIterations).toBe(2);
+  });
+
   it("exits with code 0 and prints completion message after loop with --auto", async () => {
     const goal = makeGoal({ id: "goal-loop-done" });
     const mockSuggest = vi.fn().mockResolvedValue([makeSuggestion()]);


### PR DESCRIPTION
## Summary
- `seedpulse improve . --max 2 --yes` was running the internal goal loop with the default 100 iterations instead of the user-specified value
- `buildDeps` for the loop was called with `undefined` config; now passes `{ maxIterations: maxSuggestions }` so the CoreLoop respects `--max`
- Added a test verifying that `CoreLoop` is constructed with `maxIterations` equal to the `--max` value

## Test plan
- [ ] `npx vitest run tests/cli-improve` — all 15 tests pass
- [ ] `npm run build` — clean compile

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)