### PR TITLE
fix: dogfooding round 3 — range dimension parse + goal decomposition verification

### DIFF
--- a/src/cli/commands/goal-infer.ts
+++ b/src/cli/commands/goal-infer.ts
@@ -31,7 +31,7 @@ function buildInferPrompt(title: string): string {
 Threshold types:
 - min: value must be >= X (e.g. test coverage >= 80%)
 - max: value must be <= X (e.g. bug count <= 5)
-- range: value must be between low-high (e.g. "10-20")
+- range: value must be between low,high (e.g. "10,20")
 - present: boolean check — something must exist (value: "true" or "false")
 - match: exact match required (e.g. status must equal "published")
 

--- a/src/cli/commands/goal-utils.ts
+++ b/src/cli/commands/goal-utils.ts
@@ -92,7 +92,9 @@ export function buildThreshold(spec: RawDimensionSpec): Threshold | null {
 
   if (spec.type === "range") {
     if (!spec.value) return null;
-    const [lowStr, highStr] = spec.value.split(",");
+    let parts = spec.value.split(",");
+    if (parts.length < 2) parts = spec.value.split("-");
+    const [lowStr, highStr] = parts;
     const low = parseFloat(lowStr ?? "");
     const high = parseFloat(highStr ?? "");
     if (isNaN(low) || isNaN(high)) return null;

--- a/tests/cli/goal-utils.test.ts
+++ b/tests/cli/goal-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { buildThreshold } from "../../src/cli/commands/goal-utils.js";
+
+describe("buildThreshold", () => {
+  describe("range type", () => {
+    it("parses comma-separated range", () => {
+      expect(buildThreshold({ name: "x", type: "range", value: "7,9" })).toEqual({
+        type: "range",
+        low: 7,
+        high: 9,
+      });
+    });
+
+    it("parses hyphen-separated range", () => {
+      expect(buildThreshold({ name: "x", type: "range", value: "7-9" })).toEqual({
+        type: "range",
+        low: 7,
+        high: 9,
+      });
+    });
+
+    it("parses decimal comma-separated range", () => {
+      expect(buildThreshold({ name: "x", type: "range", value: "10.5,20.5" })).toEqual({
+        type: "range",
+        low: 10.5,
+        high: 20.5,
+      });
+    });
+
+    it("returns null when value is missing", () => {
+      expect(buildThreshold({ name: "x", type: "range", value: undefined })).toBeNull();
+    });
+
+    it("returns null when value is not parseable", () => {
+      expect(buildThreshold({ name: "x", type: "range", value: "abc" })).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- range型dimension閾値（例: `7-9`）が`goal add`でパースエラーになる問題を修正 (#314)
- `buildThreshold()`でcomma分割に加えhyphenフォールバックを追加
- LLMプロンプトをcomma形式に統一

## Issues Fixed
Fixes #314

## Issues Filed (investigation only)
- #315 — runループでgap/confidenceが固定値（設計改善、コンテキストなし時の観測フォールバック）
- #316 — improve negotiateタイムアウト（LLM応答遅延 or パースリトライ）
- #317 — range hyphenフォールバックの負数エッジケース（低優先度）

## Dogfooding Results

| Scenario | Result |
|----------|--------|
| 曖昧ゴール → dimension自動推論 | ✅ 5 dimensions正常推論 |
| 曖昧ゴール → run | ⚠️ gap/confidence固定 (#315) |
| 非SWゴール suggest | ⚠️ README.mdリーク残存 (#312/#313) |
| SWゴール suggest | ✅ 具体的で実用的な提案 |
| improve → negotiate | ⚠️ タイムアウト (#316) |
| 非SWゴール goal add (range) | 🐛 パースエラー → 修正済み (#314) |

## Test Results
4739 tests pass (unit/integration), 5 E2E failures (APIキー期限切れ — pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)