### PR TITLE
fix: OpenClaw plugin critical review fixes

### DIFF
--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -5,7 +5,6 @@
   "openclaw": {
     "extensions": ["src/index.ts"]
   },
-  "main": "src/index.ts",
   "keywords": ["openclaw", "plugin", "seedpulse", "orchestration", "goal-driven"],
   "author": "SeedPulse",
   "license": "MIT",

--- a/openclaw-plugin/src/goal-detector.ts
+++ b/openclaw-plugin/src/goal-detector.ts
@@ -42,7 +42,8 @@ Respond in JSON:
 
 async function llmDetect(msg: string, client: ILLMClient): Promise<GoalDetectionResult> {
   const res = await client.sendMessage([{ role: "user", content: buildPrompt(msg) }], { system: SYSTEM });
-  const raw = JSON.parse(res.content) as Partial<GoalDetectionResult>;
+  const cleaned = res.content.replace(/^```(?:json)?\s*/i, "").replace(/\s*```\s*$/, "").trim();
+  const raw = JSON.parse(cleaned) as Partial<GoalDetectionResult>;
   return {
     isGoal: raw.isGoal === true,
     description: typeof raw.description === "string" ? raw.description : undefined,

--- a/openclaw-plugin/src/index.ts
+++ b/openclaw-plugin/src/index.ts
@@ -61,6 +61,7 @@ interface GoalState {
 }
 
 async function readGoalState(goalId: string): Promise<GoalState | null> {
+  if (!/^[a-zA-Z0-9_-]+$/.test(goalId)) return null;
   try { return JSON.parse(await readFile(join(SEEDPULSE_DIR, "goals", goalId, "state.json"), "utf8")) as GoalState; }
   catch { return null; }
 }
@@ -99,6 +100,7 @@ class SeedPulseEngine {
     this.goalId = top.id;
     this.running = true;
     this.proc = spawn(SEEDPULSE_CLI, ["run", "--goal", top.id, "--adapter", "openclaw_gateway", "--yes"], { stdio: "ignore" });
+    this.proc.on("error", (e) => { this.api.log.error("SeedPulse: resume run error", e); this.running = false; this.clearPoll(); });
     this.poll(session.sessionKey, top.id);
     this.api.log.info(`SeedPulse: resumed goal ${top.id}`);
   }
@@ -147,7 +149,7 @@ class SeedPulseEngine {
     catch (err) { this.api.log.error("SeedPulse: parse negotiate failed", err); this.running = false; return; }
     this.goalId = goal.id;
     this.proc = spawn(SEEDPULSE_CLI, ["run", "--goal", goal.id, "--adapter", "openclaw_gateway", "--yes"], { stdio: "ignore" });
-    this.proc.on("error", (e) => { this.api.log.error("SeedPulse: run error", e); this.running = false; });
+    this.proc.on("error", (e) => { this.api.log.error("SeedPulse: run error", e); this.running = false; this.clearPoll(); });
     this.poll(sessionKey, goal.id);
   }
 

--- a/openclaw-plugin/src/openclaw-agent-adapter.ts
+++ b/openclaw-plugin/src/openclaw-agent-adapter.ts
@@ -2,13 +2,10 @@
 // Wraps OpenClaw's Pi Agent as a SeedPulse IAdapter.
 // CoreLoop sends tasks by posting messages and polling for new assistant replies.
 
-// Local type definitions — no seedpulse import (independent package)
-
+// Minimal local type definitions (plugin uses peerDependencies, not relative paths)
 interface AgentTask {
   prompt: string;
   timeout_ms: number;
-  adapter_type: string;
-  allowed_tools?: readonly string[];
 }
 
 interface AgentResult {
@@ -17,14 +14,11 @@ interface AgentResult {
   error: string | null;
   exit_code: number | null;
   elapsed_ms: number;
-  stopped_reason: "completed" | "timeout" | "error";
-  filesChanged?: boolean;
+  stopped_reason: string;
 }
 
 interface IAdapter {
   execute(task: AgentTask): Promise<AgentResult>;
-  readonly adapterType: string;
-  readonly capabilities?: readonly string[];
 }
 
 interface OpenClawPluginApi {
@@ -72,11 +66,10 @@ export class OpenClawAgentAdapter implements IAdapter {
         return { success: false, output: "", error: "Timeout waiting for OpenClaw response", exit_code: null, elapsed_ms: elapsed, stopped_reason: "timeout" };
       }
 
-      const hasError = /\b(error|failed|exception|cannot|unable)\b/i.test(response);
       return {
-        success: !hasError,
+        success: true,
         output: response,
-        error: hasError ? "Task execution reported errors" : null,
+        error: null,
         exit_code: null,
         elapsed_ms: elapsed,
         stopped_reason: "completed",


### PR DESCRIPTION
## Summary
- Spawn error handling: `.on("error")` + `clearPoll()` for `resumeGoals()` and `startGoal()`
- Path traversal guard: goalId regex validation in `readGoalState()`
- LLM response: markdown fence stripping before JSON.parse
- Adapter fix: `success: true` (adapter doesn't judge content), minimal local interfaces (no broken relative paths)
- Remove redundant `console.warn` and invalid `"main"` field

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] 38 OpenClaw tests pass
- [x] `npm run build` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)