### PR TITLE
fix: preserve observation score when no context (closes #315)

### DIFF
--- a/src/execution/task-verifier.ts
+++ b/src/execution/task-verifier.ts
@@ -483,6 +483,10 @@ export async function handleVerdict(
                 continue;
               }
               dim.current_value = clampDimensionUpdate(prev, update.new_value, deps.logger, String(dim.name));
+              // RC-3: Update confidence and last_observed_layer so gap-calculator
+              // uses the verifier's confidence rather than stale observation confidence.
+              dim.confidence = verificationResult.confidence ?? 0.70;
+              dim.last_observed_layer = "mechanical";
             }
             // Update last_updated for the primary dimension
             if (dim.name === task.primary_dimension) {
@@ -523,6 +527,9 @@ export async function handleVerdict(
                   continue;
                 }
                 dim.current_value = clampDimensionUpdate(prev, update.new_value, deps.logger, String(dim.name));
+                // RC-3: Update confidence and last_observed_layer for partial verdicts too.
+                dim.confidence = verificationResult.confidence ?? 0.70;
+                dim.last_observed_layer = "mechanical";
               }
             }
             await deps.stateManager.writeRaw(`goals/${task.goal_id}/goal.json`, goal);

--- a/src/observation/observation-llm.ts
+++ b/src/observation/observation-llm.ts
@@ -167,6 +167,16 @@ export async function observeWithLLM(
       confidence: 0.1,
       notes: "Skipped: no context available, existing value preserved.",
     });
+    // RC-2: Apply the skip entry so state reflects the preserved value.
+    try {
+      await applyObservation(goalId, skipEntry);
+    } catch (persistErr) {
+      throw new ObservationPersistenceError(
+        `Failed to persist skip observation for dimension "${dimensionName}": ${persistErr instanceof Error ? persistErr.message : String(persistErr)}`,
+        skipEntry,
+        persistErr instanceof Error ? persistErr : new Error(String(persistErr)),
+      );
+    }
     return skipEntry;
   }
 
@@ -246,12 +256,24 @@ export async function observeWithLLM(
   // If no evidence (no context, no git diff), LLM score > 0.0 is unreliable.
   // Skip this check in dryRun (cross-validation) mode — the caller needs the
   // raw LLM score to compare against the mechanical value.
+  // RC-1: When no context but a previousScore is known from observation history,
+  // preserve the previous score with degraded confidence rather than forcing 0.0.
+  // "No context" means "can't verify", not "definitely zero".
   let score = parsed.score;
+  let scorePreservedFromPrevious = false;
   if (!hasContext && score > 0.0 && !dryRun) {
-    logger?.warn(
-      `score overridden to 0.0 (no evidence available, LLM returned ${score})`
-    );
-    score = 0.0;
+    if (typeof previousScore === "number" && Number.isFinite(previousScore)) {
+      score = previousScore;
+      scorePreservedFromPrevious = true;
+      logger?.warn(
+        `score preserved from previous observation (no context): ${previousScore.toFixed(3)}`
+      );
+    } else {
+      logger?.warn(
+        `score overridden to 0.0 (no evidence available, LLM returned ${score})`
+      );
+      score = 0.0;
+    }
   }
 
   // §3.3: Observation score jump suppression (±0.4/cycle)
@@ -262,10 +284,10 @@ export async function observeWithLLM(
   let resolvedConfidence: number;
   if (sourceAvailable === false) {
     resolvedLayer = "self_report";
-    resolvedConfidence = hasContext ? 0.30 : 0.10;
+    resolvedConfidence = hasContext ? 0.30 : (scorePreservedFromPrevious ? 0.30 : 0.10);
   } else {
     resolvedLayer = "independent_review";
-    resolvedConfidence = hasContext ? 0.70 : 0.10;
+    resolvedConfidence = hasContext ? 0.70 : (scorePreservedFromPrevious ? 0.30 : 0.10);
   }
   if (
     typeof previousScore === "number" &&

--- a/tests/observation-llm-guard.test.ts
+++ b/tests/observation-llm-guard.test.ts
@@ -159,3 +159,144 @@ describe("Guard 3: Score-evidence consistency check (§4.3)", () => {
     expect(warnMsg).toContain("0.6");
   });
 });
+
+// ─── RC-1: Preserve previous score when no context ─────────────────────────
+
+describe("RC-1: Preserve previous score when no context but previousScore is known", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir("seedpulse-rc1-");
+    noopApply.mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("preserves previousScore with confidence=0.30 when no context and previousScore is known", async () => {
+    const gitContextFetcher = vi.fn().mockReturnValue("");
+    const mockLLMClient = createMockLLMClient(0.8, "looks done");
+    const logger = makeLogger();
+
+    const entry = await observeWithLLM(
+      "goal-rc1",
+      "dim1",
+      "Improve code quality",
+      "Code Quality",
+      JSON.stringify({ type: "min", value: 1.0 }),
+      mockLLMClient,
+      { gitContextFetcher },
+      noopApply,
+      undefined, // workspaceContext: none
+      0.55, // previousScore is known
+      false, // dryRun=false so guard fires
+      logger
+    );
+
+    // Score should be preserved from previousScore, not forced to 0.0
+    expect(entry.extracted_value).toBeCloseTo(0.55);
+    expect(entry.confidence).toBe(0.30);
+    const warnMsg = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(warnMsg).toContain("score preserved from previous observation (no context)");
+  });
+
+  it("still forces 0.0 when no context and no previousScore", async () => {
+    const gitContextFetcher = vi.fn().mockReturnValue("");
+    const mockLLMClient = createMockLLMClient(0.8, "looks done");
+    const logger = makeLogger();
+
+    const entry = await observeWithLLM(
+      "goal-rc1-noprev",
+      "dim1",
+      "Improve code quality",
+      "Code Quality",
+      JSON.stringify({ type: "min", value: 1.0 }),
+      mockLLMClient,
+      { gitContextFetcher },
+      noopApply,
+      undefined,
+      null, // no previousScore
+      false,
+      logger
+    );
+
+    expect(entry.extracted_value).toBe(0.0);
+    expect(entry.confidence).toBe(0.10);
+    const warnMsg = (logger.warn as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(warnMsg).toContain("score overridden to 0.0");
+  });
+});
+
+// ─── RC-2: applyObservation called on no-context skip path ─────────────────
+
+describe("RC-2: applyObservation called in no_context_existing_value skip path", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir("seedpulse-rc2-");
+    noopApply.mockReset();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("calls applyObservation when skipping due to no context with existing value", async () => {
+    const gitContextFetcher = vi.fn().mockReturnValue("");
+    const mockLLMClient = createMockLLMClient(0.0, "no context");
+    const logger = makeLogger();
+
+    await observeWithLLM(
+      "goal-rc2",
+      "dim1",
+      "Improve code quality",
+      "Code Quality",
+      JSON.stringify({ type: "min", value: 1.0 }),
+      mockLLMClient,
+      { gitContextFetcher },
+      noopApply,
+      undefined, // workspaceContext: none
+      null,      // previousScore: none so skip path applies
+      false,     // dryRun
+      logger,
+      undefined, // dimensionHistory
+      undefined, // gateway
+      0.42,      // currentValue exists
+      true       // sourceAvailable
+    );
+
+    // applyObservation must be called once with the preserved value
+    expect(noopApply).toHaveBeenCalledTimes(1);
+    const calledEntry = noopApply.mock.calls[0][1] as ObservationLogEntry;
+    expect(calledEntry.extracted_value).toBe(0.42);
+    expect(calledEntry.raw_result).toMatchObject({ reason: "no_context_existing_value" });
+  });
+
+  it("does NOT call applyObservation when dryRun=true on skip path", async () => {
+    const gitContextFetcher = vi.fn().mockReturnValue("");
+    const mockLLMClient = createMockLLMClient(0.0, "no context");
+
+    await observeWithLLM(
+      "goal-rc2-dryrun",
+      "dim1",
+      "Improve code quality",
+      "Code Quality",
+      JSON.stringify({ type: "min", value: 1.0 }),
+      mockLLMClient,
+      { gitContextFetcher },
+      noopApply,
+      undefined, // workspaceContext
+      null,      // previousScore
+      true,      // dryRun=true → skip path condition (!dryRun) is false, LLM path runs
+      undefined, // logger
+      undefined, // dimensionHistory
+      undefined, // gateway
+      0.42       // currentValue
+    );
+
+    // dryRun=true means the skip path condition (!dryRun) is false, so LLM path runs.
+    // applyObservation is also skipped in LLM path when dryRun=true.
+    expect(noopApply).not.toHaveBeenCalled();
+  });
+});

--- a/tests/task-verifier-guards.test.ts
+++ b/tests/task-verifier-guards.test.ts
@@ -623,3 +623,102 @@ describe("§4.5 checkDimensionDirection", () => {
     expect(result).toBe(true);
   });
 });
+
+// ─── RC-3: Verifier dimension_updates update confidence and last_observed_layer ───
+
+describe("RC-3: handleVerdict updates confidence and last_observed_layer on dimension_updates", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+  let sessionManager: SessionManager;
+  let trustManager: TrustManager;
+  let stallDetector: StallDetector;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    stateManager = new StateManager(tmpDir);
+    sessionManager = new SessionManager(stateManager);
+    trustManager = new TrustManager(stateManager);
+    stallDetector = new StallDetector(stateManager);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function setupGoalWithDim(dimName: string, currentValue: number): Promise<void> {
+    await stateManager.writeRaw("goals/goal-1/goal.json", {
+      id: "goal-1", title: "Test", status: "active",
+      dimensions: [{
+        name: dimName, label: dimName, current_value: currentValue,
+        threshold: { type: "min", value: 1.0 }, last_updated: null,
+        confidence: 0.4, last_observed_layer: "self_report",
+      }],
+      created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+    });
+  }
+
+  it("pass verdict: updates confidence and last_observed_layer to mechanical when dimension_update applied", async () => {
+    const deps = makeDeps(stateManager, sessionManager, trustManager, stallDetector);
+    const task = makeTask();
+    await setupGoalWithDim("dim", 0.5);
+
+    const vr = makeVerificationResult({
+      verdict: "pass",
+      confidence: 0.85,
+      dimension_updates: [{ dimension_name: "dim", previous_value: 0.5, new_value: 0.7, confidence: 0.85 }],
+    });
+
+    await handleVerdict(deps, task, vr);
+
+    const goalData = await stateManager.readRaw("goals/goal-1/goal.json") as Record<string, unknown>;
+    const dims = goalData.dimensions as Array<Record<string, unknown>>;
+    const dim = dims.find((d) => d.name === "dim")!;
+    expect(dim.current_value as number).toBeCloseTo(0.7, 10);
+    expect(dim.confidence as number).toBe(0.85);
+    expect(dim.last_observed_layer as string).toBe("mechanical");
+  });
+
+  it("partial verdict: updates confidence and last_observed_layer to mechanical when dimension_update applied", async () => {
+    const deps = makeDeps(stateManager, sessionManager, trustManager, stallDetector);
+    const task = makeTask({
+      success_criteria: [{ description: "Manual check", verification_method: "Manual review", is_blocking: true }],
+    });
+    await setupGoalWithDim("dim", 0.4);
+
+    const vr = makeVerificationResult({
+      verdict: "partial",
+      confidence: 0.75,
+      dimension_updates: [{ dimension_name: "dim", previous_value: 0.4, new_value: 0.6, confidence: 0.75 }],
+    });
+
+    await handleVerdict(deps, task, vr);
+
+    const goalData = await stateManager.readRaw("goals/goal-1/goal.json") as Record<string, unknown>;
+    const dims = goalData.dimensions as Array<Record<string, unknown>>;
+    const dim = dims.find((d) => d.name === "dim")!;
+    expect(dim.current_value as number).toBeCloseTo(0.6, 10);
+    expect(dim.confidence as number).toBe(0.75);
+    expect(dim.last_observed_layer as string).toBe("mechanical");
+  });
+
+  it("pass verdict with no dimension_updates: confidence and last_observed_layer unchanged", async () => {
+    const deps = makeDeps(stateManager, sessionManager, trustManager, stallDetector);
+    const task = makeTask();
+    await setupGoalWithDim("dim", 0.5);
+
+    const vr = makeVerificationResult({
+      verdict: "pass",
+      confidence: 0.9,
+      dimension_updates: [],
+    });
+
+    await handleVerdict(deps, task, vr);
+
+    const goalData = await stateManager.readRaw("goals/goal-1/goal.json") as Record<string, unknown>;
+    const dims = goalData.dimensions as Array<Record<string, unknown>>;
+    const dim = dims.find((d) => d.name === "dim")!;
+    // No update applied: confidence and last_observed_layer remain as set originally
+    expect(dim.confidence as number).toBe(0.4);
+    expect(dim.last_observed_layer as string).toBe("self_report");
+  });
+});


### PR DESCRIPTION
## Summary
- **RC-1**: When no workspace context but `previousScore` exists, preserve previous score with degraded confidence (0.30) instead of forcing 0.0. Guards NaN with `Number.isFinite()`
- **RC-2**: Skip path now calls `applyObservation` with `ObservationPersistenceError` wrapping so state is persisted
- **RC-3**: Task verifier `dimension_updates` now update `dim.confidence` and `dim.last_observed_layer="mechanical"`

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] 38 targeted tests pass (observation-llm-guard + task-verifier-guards)
- [x] 7 new tests added (4 RC-1/RC-2 + 3 RC-3)
- [x] Full suite: 4785 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)