### PR TITLE
docs: add OpenClaw integration visibility for ClawCon

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ seedpulse status
 
 That's it. SeedPulse assesses feasibility, decomposes the goal into measurable dimensions, delegates tasks to agents, and tracks progress automatically.
 
+> **Using OpenClaw?** Install the official plugin for seamless integration — see [`@seedpulse/openclaw-plugin`](openclaw-plugin/README.md).
+
 ## What is SeedPulse?
 
 SeedPulse is a **task discovery engine**. You give it a long-term goal — "double revenue in 6 months," "keep my dog healthy" — and it pursues it autonomously. It observes, calculates the gap, generates tasks, delegates to AI agents, and verifies results. Then it loops.
@@ -84,6 +86,14 @@ SeedPulse tracks revenue metrics, identifies growth opportunities, delegates res
 SeedPulse monitors health indicators, schedules vet checkups, tracks nutrition, and escalates to you when human judgment is needed.
 
 *Demo coming soon*
+
+### OpenClaw Integration
+
+> "Migrate all source files from CommonJS to ESM with TypeScript"
+
+SeedPulse detects the goal in your OpenClaw conversation, spawns agent sessions, tracks file-by-file migration progress, and auto-completes when done.
+
+*Demo coming soon* — [ClawCon 2026](https://clawcon.dev)
 
 ## How It Works
 
@@ -139,6 +149,7 @@ npm run test:changed
 
 | Adapter | Type | Use Case |
 |---------|------|----------|
+| `openclaw_gateway` | OpenClaw Gateway plugin (bidirectional) | `@seedpulse/openclaw-plugin` |
 | `claude_code_cli` | CLI | Code execution, file operations |
 | `openai_codex_cli` | CLI | Code execution, file operations |
 | `browser_use_cli` | CLI | Web browsing, scraping, form filling |
@@ -147,6 +158,15 @@ npm run test:changed
 | `a2a` | A2A Protocol | Remote agent delegation |
 
 Custom adapters can be added as [plugins](docs/design/plugin-development-guide.md) in `~/.seedpulse/plugins/`.
+
+## Plugins & Integrations
+
+| Plugin | Description | Status |
+|--------|-------------|--------|
+| [`@seedpulse/openclaw-plugin`](openclaw-plugin/) | OpenClaw Gateway — goal detection, agent orchestration, progress tracking | ✅ Stable |
+| [`@seedpulse/slack-notifier`](plugins/slack-notifier/) | Slack notifications for goal events | ✅ Stable |
+
+See [Plugin Development Guide](docs/design/plugin-development-guide.md) for creating custom plugins.
 
 ## Programmatic Usage
 

--- a/openclaw-plugin/README.md
+++ b/openclaw-plugin/README.md
@@ -1,5 +1,9 @@
 # @seedpulse/openclaw-plugin
 
+OpenClaw handles the conversation. SeedPulse handles long-running goals.
+
+This plugin connects [SeedPulse](https://github.com/my-name-is-yu/SeedPulse) to [OpenClaw](https://openclaw.dev) via the Gateway API, giving your OpenClaw sessions autonomous goal tracking, agent orchestration, and progress observation — without changing how you use OpenClaw.
+
 SeedPulse goal-driven orchestration as an OpenClaw Gateway plugin.
 
 The plugin hooks into the **Gateway lifecycle** via `SeedPulseEngine` — automatically detecting goals in user messages, launching `seedpulse run` in the background, and streaming progress back into the session.
@@ -27,6 +31,7 @@ OpenClaw will call `activate(api)` at startup.
 ## Prerequisites
 
 - SeedPulse CLI must be in your `$PATH`, or set `SEEDPULSE_CLI_PATH` to the full path.
+- SeedPulse CLI installed globally — see [main README](../README.md#quick-start)
 - SeedPulse uses `~/.seedpulse/` for state persistence. No extra configuration needed for basic use.
 
 ## Configuration
@@ -56,11 +61,7 @@ For provider settings (which LLM to use), create `~/.seedpulse/provider.json`:
 When a session begins, the engine queries `~/.seedpulse/goals/` for any active goals. If found, it sends a resume message and restarts the background `seedpulse run` process.
 
 ```
-Before (old plugin):
-  [SeedPulse] このセッションのアクティブゴール: Refactor auth module (id: goal_abc123)
-
-After (SeedPulseEngine):
-  🔄 前回のゴールを引き継ぎます: Refactor auth module（残gap: 28.0%）
+[SeedPulse] Resuming active goal: Refactor auth module (id: goal_abc123, gap remaining: 28.0%)
 ```
 
 #### `onMessage` — goal detection and automatic orchestration
@@ -72,16 +73,12 @@ Every user message is classified by `detectGoal()` (rule-based fast path, LLM fa
 4. Polls `~/.seedpulse/goals/<goalId>/state.json` every 3s and streams progress
 
 ```
-Before (old plugin):
-  (no goal detection — user had to create goals manually with seedpulse CLI)
-
-After (SeedPulseEngine):
-  User: "テストカバレッジを90%以上にしたい"
-  Plugin: 🎯 ゴール設定: テストカバレッジを90%以上にしたい
-          📐 計測次元: numeric_target
-  Plugin: 📊 [1/10] Run test suite | gap: 28.0%
-  Plugin: 📊 [2/10] Fix uncovered branches | gap: 15.3%
-  Plugin: ✅ ゴール達成！
+User: "Increase test coverage to 90%+"
+Plugin: Goal detected: Increase test coverage to 90%+
+        Dimensions: numeric_target
+Plugin: [1/10] Run test suite | gap: 28.0%
+Plugin: [2/10] Fix uncovered branches | gap: 15.3%
+Plugin: Goal complete.
 ```
 
 #### `onSessionEnd` — clean state reset
@@ -97,25 +94,52 @@ Resets engine state. SeedPulse state is already persisted automatically to `~/.s
 ## Demo scenario
 
 ```
+User: "Migrate this repository's TypeScript fully to ESM"
+
+Plugin -> detectGoal(): isGoal=true, dimensions=["migration"]
+
+Plugin: Goal detected: Migrate TypeScript to ESM
+        Dimensions: migration
+
+[seedpulse negotiate runs in background -> creates structured goal]
+[seedpulse run --adapter openclaw_gateway starts in background]
+[OpenClaw receives tasks from SeedPulse and executes them]
+
+Plugin: [1/10] Update tsconfig.json for ESM | gap: 82.0%
+Plugin: [3/10] Fix .js extension imports | gap: 45.1%
+Plugin: [7/10] Verify build passes | gap: 12.3%
+Plugin: Goal complete.
+
+User: "seedpulse_status"
+Plugin: (returns current seedpulse status output)
+```
+
+---
+
+<details><summary>日本語版</summary>
+
+```
 User: "このリポジトリのTypeScriptをESMに完全移行してほしい"
 
 Plugin → detectGoal(): isGoal=true, dimensions=["migration"]
 
-Plugin: 🎯 ゴール設定: TypeScriptをESMに完全移行
-        📐 計測次元: migration
+Plugin: ゴール設定: TypeScriptをESMに完全移行
+        計測次元: migration
 
 [seedpulse negotiate runs in background → creates structured goal]
 [seedpulse run --adapter openclaw_gateway starts in background]
 [OpenClaw receives tasks from SeedPulse and executes them]
 
-Plugin: 📊 [1/10] Update tsconfig.json for ESM | gap: 82.0%
-Plugin: 📊 [3/10] Fix .js extension imports | gap: 45.1%
-Plugin: 📊 [7/10] Verify build passes | gap: 12.3%
-Plugin: ✅ ゴール達成！
+Plugin: [1/10] Update tsconfig.json for ESM | gap: 82.0%
+Plugin: [3/10] Fix .js extension imports | gap: 45.1%
+Plugin: [7/10] Verify build passes | gap: 12.3%
+Plugin: ゴール達成！
 
 User: "seedpulse_status"
 Plugin: (returns current seedpulse status output)
 ```
+
+</details>
 
 ## Design notes
 

--- a/openclaw-plugin/package.json
+++ b/openclaw-plugin/package.json
@@ -5,7 +5,7 @@
   "openclaw": {
     "extensions": ["src/index.ts"]
   },
-  "keywords": ["openclaw", "plugin", "seedpulse", "orchestration", "goal-driven"],
+  "keywords": ["openclaw", "plugin", "seedpulse", "orchestration", "goal-driven", "ai-agent", "autonomous", "llm", "gateway"],
   "author": "SeedPulse",
   "license": "MIT",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "llm",
     "ai-agent",
     "multi-agent",
-    "typescript"
+    "typescript",
+    "openclaw",
+    "gateway"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add OpenClaw callout in Quick Start, demo section, adapter table row, and new Plugins & Integrations section to main README
- Polish openclaw-plugin README with English intro paragraph, English demo (Japanese collapsed), remove legacy before/after framing
- Add `openclaw`/`gateway` keywords to root and plugin package.json for npm discoverability

## Context
ClawCon 2026 (3/30-4/3) — positioning SeedPulse as OpenClaw-friendly. The main README previously had zero OpenClaw mentions despite a fully working integration.

## Test plan
- [ ] Verify all relative links render correctly on GitHub
- [ ] Confirm adapter table and plugin table display properly
- [ ] Check collapsed Japanese `<details>` block works

Also filed #322 for stale `tavori` references in slack-notifier plugin (out of scope for this PR).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)