### PR TITLE
fix: correct adapter table and remove dead external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ SeedPulse monitors health indicators, schedules vet checkups, tracks nutrition, 
 
 SeedPulse detects the goal in your OpenClaw conversation, spawns agent sessions, tracks file-by-file migration progress, and auto-completes when done.
 
-*Demo coming soon* — [ClawCon 2026](https://clawcon.dev)
+*Demo coming soon* — ClawCon 2026
 
 ## How It Works
 
@@ -149,7 +149,7 @@ npm run test:changed
 
 | Adapter | Type | Use Case |
 |---------|------|----------|
-| `openclaw_gateway` | OpenClaw Gateway plugin (bidirectional) | `@seedpulse/openclaw-plugin` |
+| `openclaw_gateway` | OpenClaw Gateway | Goal detection, agent orchestration, progress tracking |
 | `claude_code_cli` | CLI | Code execution, file operations |
 | `openai_codex_cli` | CLI | Code execution, file operations |
 | `browser_use_cli` | CLI | Web browsing, scraping, form filling |

--- a/openclaw-plugin/README.md
+++ b/openclaw-plugin/README.md
@@ -2,7 +2,7 @@
 
 OpenClaw handles the conversation. SeedPulse handles long-running goals.
 
-This plugin connects [SeedPulse](https://github.com/my-name-is-yu/SeedPulse) to [OpenClaw](https://openclaw.dev) via the Gateway API, giving your OpenClaw sessions autonomous goal tracking, agent orchestration, and progress observation — without changing how you use OpenClaw.
+This plugin connects [SeedPulse](https://github.com/my-name-is-yu/SeedPulse) to OpenClaw via the Gateway API, giving your OpenClaw sessions autonomous goal tracking, agent orchestration, and progress observation — without changing how you use OpenClaw.
 
 SeedPulse goal-driven orchestration as an OpenClaw Gateway plugin.
 


### PR DESCRIPTION
## Summary
- Fix openclaw_gateway row in Supported Adapters table: Use Case column had package name instead of functional description
- Remove dead links to `clawcon.dev` and `openclaw.dev` (domains time out, not yet live)

## Test plan
- [ ] Verify adapter table renders correctly on GitHub
- [ ] Confirm no broken links remain in changed files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)