### PR TITLE
fix: pass config.model to Anthropic LLMClient (#184)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,9 +90,11 @@ rm -rf ~/.pulseed
 {
   "provider": "openai | anthropic | ollama",
   "model": "<model-name>",
-  "apiKey": "<your-api-key>"
+  "api_key": "<your-api-key>"
 }
 ```
+
+The `model` field is respected by **all providers** (openai, anthropic, and ollama). If omitted, each provider falls back to its default model.
 
 ### OpenAI example
 
@@ -100,7 +102,7 @@ rm -rf ~/.pulseed
 {
   "provider": "openai",
   "model": "gpt-5.4-mini",
-  "apiKey": "sk-..."
+  "api_key": "sk-..."
 }
 ```
 
@@ -110,13 +112,13 @@ rm -rf ~/.pulseed
 {
   "provider": "anthropic",
   "model": "claude-opus-4-5",
-  "apiKey": "sk-ant-..."
+  "api_key": "sk-ant-..."
 }
 ```
 
 ### Ollama (local LLM) example
 
-No API key is needed. The `baseUrl` field overrides the default `http://localhost:11434`.
+No API key is needed. The `base_url` field overrides the default `http://localhost:11434`.
 
 ```json
 {
@@ -131,7 +133,7 @@ To connect to Ollama on a remote machine:
 {
   "provider": "ollama",
   "model": "qwen3:4b",
-  "baseUrl": "http://192.168.1.50:11434"
+  "base_url": "http://192.168.1.50:11434"
 }
 ```
 

--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -63,8 +63,9 @@ export { extractJSON, DEFAULT_MAX_TOKENS };
 export class LLMClient extends BaseLLMClient implements ILLMClient {
   private readonly client: Anthropic;
   private guardrailRunner?: GuardrailRunner;
+  private readonly defaultModel: string;
 
-  constructor(apiKey: string, guardrailRunner?: GuardrailRunner, lightModel?: string) {
+  constructor(apiKey: string, guardrailRunner?: GuardrailRunner, lightModel?: string, model?: string) {
     super();
     if (!apiKey) {
       throw new LLMError(
@@ -74,6 +75,7 @@ export class LLMClient extends BaseLLMClient implements ILLMClient {
     this.client = new Anthropic({ apiKey });
     this.guardrailRunner = guardrailRunner;
     this.lightModel = lightModel;
+    this.defaultModel = model ?? DEFAULT_MODEL;
   }
 
   /**
@@ -84,7 +86,7 @@ export class LLMClient extends BaseLLMClient implements ILLMClient {
     messages: LLMMessage[],
     options?: LLMRequestOptions
   ): Promise<LLMResponse> {
-    const model = this.resolveEffectiveModel(options?.model ?? DEFAULT_MODEL, options?.model_tier);
+    const model = this.resolveEffectiveModel(options?.model ?? this.defaultModel, options?.model_tier);
     const max_tokens = options?.max_tokens ?? DEFAULT_MAX_TOKENS;
     const temperature = options?.temperature ?? DEFAULT_TEMPERATURE;
     let system = options?.system;

--- a/src/llm/provider-factory.ts
+++ b/src/llm/provider-factory.ts
@@ -77,7 +77,7 @@ export async function buildLLMClient(): Promise<ILLMClient> {
           "ANTHROPIC_API_KEY is not set.\nSet it via: export ANTHROPIC_API_KEY=sk-ant-..."
         );
       }
-      return new LLMClient(config.api_key, undefined, config.light_model);
+      return new LLMClient(config.api_key, undefined, config.light_model, config.model);
 
     default:
       // Unknown provider falls back to OpenAI

--- a/tests/provider-factory.test.ts
+++ b/tests/provider-factory.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // ─── Mock heavy dependencies so no real clients are constructed ───
 
@@ -47,6 +47,7 @@ vi.mock("../src/llm/provider-config.js", () => ({
 }));
 
 import { buildLLMClient } from "../src/llm/provider-factory.js";
+import { LLMClient } from "../src/llm/llm-client.js";
 
 // ─── Tests ───
 
@@ -87,6 +88,24 @@ describe("buildLLMClient — early API key validation", () => {
       });
 
       await expect(buildLLMClient()).resolves.not.toThrow();
+    });
+
+    it("passes config.model to LLMClient constructor", async () => {
+      const MockedLLMClient = vi.mocked(LLMClient);
+      MockedLLMClient.mockClear();
+
+      mockLoadProviderConfig.mockResolvedValue({
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        adapter: "claude_api",
+        api_key: "sk-ant-test",
+      });
+
+      await buildLLMClient();
+
+      expect(MockedLLMClient).toHaveBeenCalledOnce();
+      // constructor: (apiKey, guardrailRunner, lightModel, model)
+      expect(MockedLLMClient).toHaveBeenCalledWith("sk-ant-test", undefined, undefined, "claude-opus-4-5");
     });
   });
 


### PR DESCRIPTION
## Summary
- Anthropic's `config.model` was silently ignored — `LLMClient` constructor had no `model` parameter, so `provider.json` model setting was a no-op for Anthropic provider
- Added optional `model` param to `LLMClient` constructor (backward compatible)
- `provider-factory.ts` now passes `config.model` to `LLMClient`
- Fixed stale camelCase keys in `docs/configuration.md` (`apiKey` → `api_key`, `baseUrl` → `base_url`)

Partial fix for #184 — addresses the core bug. Full provider/model unified format refactor deferred.

## Test plan
- [x] `npx vitest run tests/provider-factory.test.ts` — 12/12 pass
- [x] `npx vitest run tests/llm-client.test.ts` — 41/41 pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)