### PR TITLE
fix: dogfooding — TS 5.9.3 build fix + improve hang issue filed

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "rootDir": "src",
     "strict": true,
     "esModuleInterop": true,
+    "types": ["estree", "js-yaml", "node", "node-fetch", "nodemailer", "prop-types", "react"],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "declaration": true,


### PR DESCRIPTION
## Summary
- Fix TypeScript 5.9.3 build failure caused by phantom `'X 2'` type references (TS2688)
- Add explicit `types` array to tsconfig.json compilerOptions

## Issues
- Fixes #346 (TS build error)
- Filed #345 (improve command hangs on LLM timeout — not fixed in this PR, needs investigation)

## PR #344 Verification
Dogfooding confirmed PR #344 (subgoal curriculum ordering) is working correctly:
- 89 unit/integration tests pass for `subgoal-curriculum.ts` and `tree-loop-orchestrator.ts`
- `estimateDifficulty()`, `curriculumSort()`, and `_selectEligibleNodeId()` integration is correct
- Gap clamping to [0,1] prevents `weighted_avg` aggregation distortion

## Test Results
4901 tests pass (231 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)