### PR TITLE
fix: cleanup orphaned datasources + per-iteration CoreLoop log (#348, #349)

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -411,7 +411,8 @@ export async function cmdDatasourceDedup(stateManager: StateManager): Promise<nu
       const dimMapping = cfg["dimension_mapping"];
       dims = dimMapping ? Object.keys(dimMapping as Record<string, unknown>).sort() : [];
     }
-    return `${type}::${dims.join(",")}`;
+    const scopeGoalId = (cfg["scope_goal_id"] as string | undefined) ?? "";
+    return `${type}::${dims.join(",")}::${scopeGoalId}`;
   }
 
   // Group by dedup key; first entry (oldest by sorted filename) is the keeper

--- a/src/cli/commands/goal-write.ts
+++ b/src/cli/commands/goal-write.ts
@@ -2,7 +2,7 @@
 
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
-import { getReportsDir } from "../../utils/paths.js";
+import { getReportsDir, getDatasourcesDir } from "../../utils/paths.js";
 import { readJsonFile } from "../../utils/json-io.js";
 
 import { StateManager } from "../../state-manager.js";
@@ -361,6 +361,35 @@ export async function cmdCleanup(stateManager: StateManager): Promise<number> {
       console.log(`  ${f}`);
     }
     console.log("(These can be removed manually from ~/.pulseed/reports/)");
+  }
+
+  // Remove orphaned datasources (scoped to deleted goals)
+  const datasourcesDir = getDatasourcesDir(baseDir);
+  let datasourcesDirExists = false;
+  try { await fsp.access(datasourcesDir); datasourcesDirExists = true; } catch { /* not found */ }
+
+  if (datasourcesDirExists) {
+    let orphanedCount = 0;
+    try {
+      const dsFiles = (await fsp.readdir(datasourcesDir)).filter((f) => f.endsWith(".json"));
+      for (const file of dsFiles) {
+        const filePath = path.join(datasourcesDir, file);
+        try {
+          const raw = JSON.parse(await fsp.readFile(filePath, "utf-8")) as { scope_goal_id?: string };
+          if (raw.scope_goal_id && !activeGoalIds.has(raw.scope_goal_id)) {
+            await fsp.unlink(filePath);
+            orphanedCount++;
+          }
+        } catch (err) {
+          getCliLogger().error(formatOperationError(`read datasource "${file}"`, err));
+        }
+      }
+    } catch (err) {
+      getCliLogger().error(formatOperationError(`scan datasources directory "${datasourcesDir}"`, err));
+    }
+    if (orphanedCount > 0) {
+      console.log(`\nRemoved ${orphanedCount} orphaned datasource(s) for deleted goals.`);
+    }
   }
 
   // Deduplicate datasources

--- a/src/core-loop.ts
+++ b/src/core-loop.ts
@@ -330,6 +330,8 @@ export class CoreLoop {
     // Default result (filled in progressively)
     const result: LoopIterationResult = makeEmptyIterationResult(goalId, loopIndex);
 
+    this.logger?.info(`[CoreLoop] iteration ${loopIndex + 1} starting`, { goalId, loopIndex });
+
     // 1. Load goal + tree aggregation
     const loadedGoal = await loadGoalWithAggregation(ctx, goalId, result, startTime);
     if (!loadedGoal) return result;

--- a/tests/cleanup-orphan-datasource.test.ts
+++ b/tests/cleanup-orphan-datasource.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { cmdCleanup } from "../src/cli/commands/goal-write.js";
+import { makeTempDir, cleanupTempDir } from "./helpers/temp-dir.js";
+
+// ─── Minimal StateManager stub ───
+
+function makeFakeStateManager(baseDir: string, goalIds: string[] = []) {
+  return {
+    getBaseDir: () => baseDir,
+    listGoalIds: async () => goalIds,
+    loadGoal: async (_id: string) => null,
+    archiveGoal: async (_id: string) => true,
+  };
+}
+
+// ─── Helpers ───
+
+function writeDatasource(datasourcesDir: string, filename: string, cfg: Record<string, unknown>): void {
+  fs.mkdirSync(datasourcesDir, { recursive: true });
+  fs.writeFileSync(path.join(datasourcesDir, filename), JSON.stringify(cfg));
+}
+
+function listFiles(datasourcesDir: string): string[] {
+  if (!fs.existsSync(datasourcesDir)) return [];
+  return fs.readdirSync(datasourcesDir).filter((f) => f.endsWith(".json")).sort();
+}
+
+// ─── Tests ───
+
+describe("cmdCleanup — orphaned datasource removal", () => {
+  let tmpDir: string;
+  let datasourcesDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    datasourcesDir = path.join(tmpDir, "datasources");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  it("removes orphaned datasource when scope_goal_id points to non-existent goal", async () => {
+    writeDatasource(datasourcesDir, "ds_orphan.json", {
+      id: "ds_orphan",
+      type: "shell",
+      scope_goal_id: "goal-deleted-123",
+      connection: { commands: { test_count: {} } },
+    });
+
+    const sm = makeFakeStateManager(tmpDir, []); // no active goals
+    const result = await cmdCleanup(sm as never);
+    expect(result).toBe(0);
+    expect(listFiles(datasourcesDir)).toHaveLength(0);
+  });
+
+  it("keeps datasource when scope_goal_id points to an existing active goal", async () => {
+    writeDatasource(datasourcesDir, "ds_valid.json", {
+      id: "ds_valid",
+      type: "shell",
+      scope_goal_id: "goal-active-456",
+      connection: { commands: { test_count: {} } },
+    });
+
+    const sm = makeFakeStateManager(tmpDir, ["goal-active-456"]);
+    const result = await cmdCleanup(sm as never);
+    expect(result).toBe(0);
+    expect(listFiles(datasourcesDir)).toHaveLength(1);
+    expect(listFiles(datasourcesDir)[0]).toBe("ds_valid.json");
+  });
+
+  it("keeps manual datasource that has no scope_goal_id", async () => {
+    writeDatasource(datasourcesDir, "ds_manual.json", {
+      id: "ds_manual",
+      type: "file_existence",
+      dimension_mapping: { readme_exists: "README.md" },
+    });
+
+    const sm = makeFakeStateManager(tmpDir, []); // no active goals
+    const result = await cmdCleanup(sm as never);
+    expect(result).toBe(0);
+    expect(listFiles(datasourcesDir)).toHaveLength(1);
+    expect(listFiles(datasourcesDir)[0]).toBe("ds_manual.json");
+  });
+
+  it("does not crash when datasources directory does not exist", async () => {
+    // datasourcesDir is never created
+    const sm = makeFakeStateManager(tmpDir, []);
+    const result = await cmdCleanup(sm as never);
+    expect(result).toBe(0);
+    expect(fs.existsSync(datasourcesDir)).toBe(false);
+  });
+
+  it("handles mix: removes only orphaned scoped datasources, keeps valid and manual ones", async () => {
+    writeDatasource(datasourcesDir, "ds_orphan.json", {
+      id: "ds_orphan",
+      type: "shell",
+      scope_goal_id: "goal-gone",
+      connection: { commands: { test_count: {} } },
+    });
+    writeDatasource(datasourcesDir, "ds_valid.json", {
+      id: "ds_valid",
+      type: "shell",
+      scope_goal_id: "goal-alive",
+      connection: { commands: { test_count: {} } },
+    });
+    writeDatasource(datasourcesDir, "ds_manual.json", {
+      id: "ds_manual",
+      type: "file_existence",
+      dimension_mapping: { readme_exists: "README.md" },
+    });
+
+    const sm = makeFakeStateManager(tmpDir, ["goal-alive"]);
+    const result = await cmdCleanup(sm as never);
+    expect(result).toBe(0);
+
+    const remaining = listFiles(datasourcesDir);
+    expect(remaining).toHaveLength(2);
+    expect(remaining).toContain("ds_valid.json");
+    expect(remaining).toContain("ds_manual.json");
+    expect(remaining).not.toContain("ds_orphan.json");
+  });
+});


### PR DESCRIPTION
## Summary
- `pulseed cleanup` now detects and removes datasources whose `scope_goal_id` references a deleted goal (manual datasources without `scope_goal_id` are preserved)
- Fix dedup key in `cmdDatasourceDedup` to include `scope_goal_id` — prevents incorrectly merging scoped datasources for different goals with identical dimensions
- Add `[CoreLoop] iteration N starting` log line before first LLM call in `runOneIteration()` for timeout diagnosis

## Issues Fixed
Fixes #348, Fixes #349

## Changes
| File | Change |
|------|--------|
| `src/cli/commands/goal-write.ts` | Add orphaned datasource removal in `cmdCleanup` |
| `src/cli/commands/config.ts` | Include `scope_goal_id` in dedup key |
| `src/core-loop.ts` | Add iteration-start log line |
| `tests/cleanup-orphan-datasource.test.ts` | NEW — 5 tests |

## Test Results
4905 tests pass (+5), 232 test files (+1)
1 pre-existing flaky failure (daemon-runner timeout — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)