### PR TITLE
fix: dogfooding — suggest template leak and improve loop hang (#353, #354)

### DIFF
--- a/src/cli/commands/suggest.ts
+++ b/src/cli/commands/suggest.ts
@@ -106,9 +106,9 @@ export async function cmdSuggest(
 
   console.log("Generating goal suggestions...\n");
 
-  let suggestions: unknown;
+  let suggestRaw: unknown;
   try {
-    suggestions = await generateSuggestOutput(
+    suggestRaw = await generateSuggestOutput(
       deps.goalNegotiator.suggestGoals.bind(deps.goalNegotiator),
       context,
       { maxSuggestions, existingGoals: existingTitles, repoPath: targetPath, capabilityDetector }
@@ -122,6 +122,7 @@ export async function cmdSuggest(
     return 1;
   }
 
+  const suggestions = Array.isArray(suggestRaw) ? { suggestions: suggestRaw } : suggestRaw;
   const finalPayload = normalizeSuggestPayload(suggestions, targetPath, targetPath, context, maxSuggestions, repoFiles, isSoftware);
   console.log(JSON.stringify(finalPayload, null, 2));
 
@@ -178,9 +179,9 @@ export async function cmdImprove(
   const repoFiles: string[] = [];
   const isSoftware = looksLikeSoftwareGoal(context);
 
-  let rawSuggestions: unknown;
+  let rawSuggestOutput: unknown;
   try {
-    rawSuggestions = await generateSuggestOutput(
+    rawSuggestOutput = await generateSuggestOutput(
       deps.goalNegotiator.suggestGoals.bind(deps.goalNegotiator),
       context,
       { maxSuggestions, existingGoals: existingTitles, repoPath: targetPath, capabilityDetector }
@@ -194,6 +195,7 @@ export async function cmdImprove(
     return 1;
   }
 
+  const rawSuggestions = Array.isArray(rawSuggestOutput) ? { suggestions: rawSuggestOutput } : rawSuggestOutput;
   const normalizedPayload = normalizeSuggestPayload(rawSuggestions, targetPath, targetPath, context, maxSuggestions, repoFiles, isSoftware);
   const suggestions = normalizedPayload.suggestions;
 

--- a/src/prompt/purposes/strategy.ts
+++ b/src/prompt/purposes/strategy.ts
@@ -9,17 +9,45 @@ import { z } from "zod";
 export const STRATEGY_SYSTEM_PROMPT = `Generate candidate strategies for achieving the goal.
 Consider past lessons, strategy templates from similar goals, and the current gap.
 Each strategy should have a testable hypothesis and a clear approach.
-Prefer strategies that have succeeded on similar goals when templates are available.`;
+Prefer strategies that have succeeded on similar goals when templates are available.
 
-export const StrategyResponseSchema = z.object({
-  candidates: z.array(
-    z.object({
-      hypothesis: z.string(),
-      approach: z.string(),
-      estimated_impact: z.number().min(0).max(1).optional(),
-      rationale: z.string().optional(),
-    })
-  ),
-});
+Respond with a JSON array (NOT a wrapped object). The array must contain 1-2 strategy objects.
+Each object must have these fields:
+- "hypothesis": string (the core bet/approach)
+- "expected_effect": array of { "dimension": string, "direction": "increase"|"decrease", "magnitude": "small"|"medium"|"large" }
+- "resource_estimate": { "sessions": number, "duration": { "value": number, "unit": "minutes"|"hours"|"days"|"weeks" }, "llm_calls": number|null }
+- "allocation": number between 0 and 1
+
+Example format:
+[
+  {
+    "hypothesis": "...",
+    "expected_effect": [{ "dimension": "...", "direction": "increase", "magnitude": "medium" }],
+    "resource_estimate": { "sessions": 3, "duration": { "value": 2, "unit": "hours" }, "llm_calls": null },
+    "allocation": 0.5
+  }
+]`;
+
+export const StrategyResponseSchema = z.array(
+  z.object({
+    hypothesis: z.string(),
+    expected_effect: z.array(
+      z.object({
+        dimension: z.string(),
+        direction: z.enum(["increase", "decrease"]),
+        magnitude: z.enum(["small", "medium", "large"]),
+      })
+    ),
+    resource_estimate: z.object({
+      sessions: z.number(),
+      duration: z.object({
+        value: z.number(),
+        unit: z.enum(["minutes", "hours", "days", "weeks"]),
+      }),
+      llm_calls: z.number().nullable().default(null),
+    }),
+    allocation: z.number().min(0).max(1).default(0),
+  })
+);
 
 export type StrategyResponse = z.infer<typeof StrategyResponseSchema>;

--- a/src/strategy/strategy-helpers.ts
+++ b/src/strategy/strategy-helpers.ts
@@ -41,6 +41,26 @@ export const StrategyArraySchema = z.array(
   })
 );
 
+/**
+ * Unwrap a potentially-wrapped LLM response before schema validation.
+ * LLMs may return a wrapper object instead of a bare array. This function
+ * checks common wrapper keys, then falls back to single-key unwrapping.
+ */
+export function unwrapStrategyResponse(raw: unknown): unknown {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return raw;
+  }
+  const record = raw as Record<string, unknown>;
+  for (const key of ["candidates", "strategies", "data", "results", "items"]) {
+    if (Array.isArray(record[key])) return record[key];
+  }
+  const keys = Object.keys(record);
+  if (keys.length === 1 && Array.isArray(record[keys[0]!])) {
+    return record[keys[0]!];
+  }
+  return raw;
+}
+
 // ─── LLM prompt builder ───
 
 export function buildGenerationPrompt(

--- a/src/strategy/strategy-manager-base.ts
+++ b/src/strategy/strategy-manager-base.ts
@@ -15,6 +15,7 @@ import {
   StrategyArraySchema,
   buildGenerationPrompt,
   detectStrategyGap,
+  unwrapStrategyResponse,
 } from "./strategy-helpers.js";
 
 /**
@@ -84,10 +85,12 @@ export class StrategyManagerBase {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let strategiesRaw: any[];
     if (this.promptGateway) {
+      // Wrap the schema to unwrap any LLM wrapper object before array validation.
+      const unwrappingSchema = z.unknown().transform(unwrapStrategyResponse).pipe(StrategyArraySchema);
       strategiesRaw = await this.promptGateway.execute({
         purpose: "strategy_generation",
         goalId,
-        responseSchema: StrategyArraySchema,
+        responseSchema: unwrappingSchema,
         additionalContext: {
           prompt,
           primaryDimension,
@@ -106,11 +109,10 @@ export class StrategyManagerBase {
           model_tier: 'main',
         }
       );
-      // Parse and validate the LLM response
-      strategiesRaw = this.llmClient.parseJSON(
-        response.content,
-        StrategyArraySchema
-      );
+      // Parse and validate the LLM response.
+      // Unwrap { candidates: [...] } shape in case the LLM returns a wrapped object.
+      const parsed = this.llmClient.parseJSON(response.content, z.unknown());
+      strategiesRaw = StrategyArraySchema.parse(unwrapStrategyResponse(parsed));
     }
 
     const now = new Date().toISOString();
@@ -314,7 +316,10 @@ export class StrategyManagerBase {
           pastStrategies,
         }
       );
-    } catch {
+    } catch (err) {
+      this.logger?.warn(
+        `[StrategyManager] generateCandidates failed during stall recovery for goal "${goalId}": ${err instanceof Error ? err.message : String(err)}`
+      );
       return null;
     }
 

--- a/tests/strategy-helpers-unwrap.test.ts
+++ b/tests/strategy-helpers-unwrap.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { unwrapStrategyResponse } from "../src/strategy/strategy-helpers.js";
+
+describe("unwrapStrategyResponse", () => {
+  it("passes through a bare array unchanged", () => {
+    const arr = [{ hypothesis: "test" }];
+    expect(unwrapStrategyResponse(arr)).toBe(arr);
+  });
+
+  it("unwraps { candidates: [...] }", () => {
+    const arr = [1, 2, 3];
+    expect(unwrapStrategyResponse({ candidates: arr })).toBe(arr);
+  });
+
+  it("unwraps { strategies: [...] }", () => {
+    const arr = [{ hypothesis: "a" }];
+    expect(unwrapStrategyResponse({ strategies: arr })).toBe(arr);
+  });
+
+  it("unwraps { data: [...] }", () => {
+    const arr = ["x"];
+    expect(unwrapStrategyResponse({ data: arr })).toBe(arr);
+  });
+
+  it("unwraps { results: [...] }", () => {
+    const arr = [42];
+    expect(unwrapStrategyResponse({ results: arr })).toBe(arr);
+  });
+
+  it("unwraps { items: [...] }", () => {
+    const arr = [{ id: 1 }];
+    expect(unwrapStrategyResponse({ items: arr })).toBe(arr);
+  });
+
+  it("unwraps a single-key object whose value is an array", () => {
+    const arr = ["a", "b"];
+    expect(unwrapStrategyResponse({ someUnknownKey: arr })).toBe(arr);
+  });
+
+  it("does NOT unwrap a multi-key object", () => {
+    const obj = { a: [1], b: [2] };
+    expect(unwrapStrategyResponse(obj)).toBe(obj);
+  });
+
+  it("passes through null unchanged", () => {
+    expect(unwrapStrategyResponse(null)).toBeNull();
+  });
+
+  it("passes through undefined unchanged", () => {
+    expect(unwrapStrategyResponse(undefined)).toBeUndefined();
+  });
+
+  it("passes through a string unchanged", () => {
+    expect(unwrapStrategyResponse("hello")).toBe("hello");
+  });
+
+  it("passes through a number unchanged", () => {
+    expect(unwrapStrategyResponse(42)).toBe(42);
+  });
+
+  it("does NOT unwrap when known key value is not an array", () => {
+    const obj = { candidates: "not-an-array" };
+    expect(unwrapStrategyResponse(obj)).toBe(obj);
+  });
+});


### PR DESCRIPTION
## Summary
- **#353**: `suggest` command leaked prompt template text ("by updating README.md to deliver a verifiable improvement.") into every step — fixed by wrapping `suggestGoals()` result as `{suggestions:[...]}` to use primary schema path
- **#354**: `improve` loop hung after parseJSON validation failures — fixed by aligning strategy system prompt with StrategyArraySchema, adding resilient `unwrapStrategyResponse` helper, and surfacing errors in `onStallDetected`

## Issues Fixed
Fixes #353, Fixes #354

## Test Results
4923 tests pass (+13 new for unwrapStrategyResponse)

## Test plan
- [ ] Run `pulseed suggest "A Node.js project" --max 2` — steps should not contain "by updating README.md"
- [ ] Run `pulseed improve . --max 2 --yes` — should not hang on parseJSON failures
- [ ] Run `npx vitest run tests/strategy-helpers-unwrap.test.ts` — 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)