### PR TITLE
feat: add GoalLoop guard for bounded goal execution

### DIFF
--- a/src/orchestrator/goal-loop.ts
+++ b/src/orchestrator/goal-loop.ts
@@ -1,0 +1,112 @@
+export type GoalLoopStopCode =
+  | "completed"
+  | "max_iterations"
+  | "max_wall_time_cap_seconds";
+
+export interface GoalLoopStopReason {
+  code: GoalLoopStopCode;
+  message: string;
+  detail: {
+    iteration: number;
+    elapsed_ms: number;
+    max_iterations: number;
+    max_wall_time_cap_seconds: number;
+  };
+}
+
+export interface GoalLoopStepResult<T = void> {
+  done?: boolean;
+  value?: T;
+}
+
+export interface GoalLoopConfig {
+  maxIterations: number;
+  maxWallTimeCapSeconds: number;
+  nowMs?: () => number;
+}
+
+export interface GoalLoopRunResult<T = void> {
+  iterations: number;
+  elapsedMs: number;
+  value?: T;
+  stopReason: GoalLoopStopReason;
+}
+
+export class GoalLoop<T = void> {
+  private readonly config: GoalLoopConfig;
+  private readonly nowMs: () => number;
+
+  constructor(config: GoalLoopConfig) {
+    this.config = config;
+    this.nowMs = config.nowMs ?? (() => Date.now());
+  }
+
+  async run(step: (iteration: number) => Promise<GoalLoopStepResult<T>>): Promise<GoalLoopRunResult<T>> {
+    const startedAtMs = this.nowMs();
+    let lastValue: T | undefined;
+    let iteration = 0;
+
+    while (iteration < this.config.maxIterations) {
+      iteration += 1;
+
+      const stepResult = await step(iteration);
+      if (typeof stepResult.value !== "undefined") {
+        lastValue = stepResult.value;
+      }
+
+      const elapsedMs = this.nowMs() - startedAtMs;
+      if (stepResult.done === true) {
+        return {
+          iterations: iteration,
+          elapsedMs,
+          value: lastValue,
+          stopReason: {
+            code: "completed",
+            message: "Goal loop completed by step result.",
+            detail: {
+              iteration,
+              elapsed_ms: elapsedMs,
+              max_iterations: this.config.maxIterations,
+              max_wall_time_cap_seconds: this.config.maxWallTimeCapSeconds,
+            },
+          },
+        };
+      }
+
+      if (elapsedMs >= this.config.maxWallTimeCapSeconds * 1000) {
+        return {
+          iterations: iteration,
+          elapsedMs,
+          value: lastValue,
+          stopReason: {
+            code: "max_wall_time_cap_seconds",
+            message: "Goal loop stopped because max wall-time cap was reached.",
+            detail: {
+              iteration,
+              elapsed_ms: elapsedMs,
+              max_iterations: this.config.maxIterations,
+              max_wall_time_cap_seconds: this.config.maxWallTimeCapSeconds,
+            },
+          },
+        };
+      }
+    }
+
+    const elapsedMs = this.nowMs() - startedAtMs;
+    return {
+      iterations: iteration,
+      elapsedMs,
+      value: lastValue,
+      stopReason: {
+        code: "max_iterations",
+        message: "Goal loop stopped because max iterations were reached.",
+        detail: {
+          iteration,
+          elapsed_ms: elapsedMs,
+          max_iterations: this.config.maxIterations,
+          max_wall_time_cap_seconds: this.config.maxWallTimeCapSeconds,
+        },
+      },
+    };
+  }
+}

--- a/tests/orchestrator/goal-loop-guard.test.ts
+++ b/tests/orchestrator/goal-loop-guard.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { GoalLoop } from "../../src/orchestrator/goal-loop.js";
+
+describe("GoalLoop guard rails", () => {
+  it("stops within 5 iterations with a structured max_iterations stop reason", async () => {
+    const loop = new GoalLoop({
+      maxIterations: 5,
+      maxWallTimeCapSeconds: 120,
+      nowMs: () => 0,
+    });
+
+    const result = await loop.run(async () => ({ done: false }));
+
+    expect(result.iterations).toBe(5);
+    expect(result.stopReason).toEqual({
+      code: "max_iterations",
+      message: "Goal loop stopped because max iterations were reached.",
+      detail: {
+        iteration: 5,
+        elapsed_ms: 0,
+        max_iterations: 5,
+        max_wall_time_cap_seconds: 120,
+      },
+    });
+  });
+
+  it("stops at the 120-second wall-time cap with a structured stop reason", async () => {
+    let nowMs = 0;
+    const loop = new GoalLoop({
+      maxIterations: 100,
+      maxWallTimeCapSeconds: 120,
+      nowMs: () => nowMs,
+    });
+
+    const result = await loop.run(async () => {
+      nowMs += 30_000;
+      return { done: false };
+    });
+
+    expect(result.iterations).toBe(4);
+    expect(result.elapsedMs).toBe(120_000);
+    expect(result.stopReason).toEqual({
+      code: "max_wall_time_cap_seconds",
+      message: "Goal loop stopped because max wall-time cap was reached.",
+      detail: {
+        iteration: 4,
+        elapsed_ms: 120_000,
+        max_iterations: 100,
+        max_wall_time_cap_seconds: 120,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `GoalLoop<T>` — standalone loop guard with `maxIterations` and `maxWallTimeCapSeconds` stop conditions
- Designed for future orchestrator layer that wraps `CoreLoop.run()` per goal with wall-time budgets
- Standalone utility — no changes to existing CoreLoop or DaemonRunner

## Files
- `src/orchestrator/goal-loop.ts` (new)
- `tests/orchestrator/goal-loop-guard.test.ts` (new, 2 tests)

## Test plan
- [x] `npm run build` — 0 errors
- [x] `npx vitest run tests/orchestrator/` — 2/2 pass
- [x] `npx vitest run` — no regressions (5002 pass, 2 pre-existing flakes in event-file-watcher)

🤖 Generated with [Claude Code](https://claude.com/claude-code)