### PR TITLE
feat: add daemon status command and --detach flag

### DIFF
--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -49,7 +49,7 @@ import {
   cmdCapabilityList,
   cmdCapabilityRemove,
 } from "./cli/commands/config.js";
-import { cmdStart, cmdStop, cmdCron } from "./cli/commands/daemon.js";
+import { cmdStart, cmdStop, cmdCron, cmdDaemonStatus } from "./cli/commands/daemon.js";
 import { cmdSuggest, cmdImprove } from "./cli/commands/suggest.js";
 import { cmdSetup } from "./cli/commands/setup.js";
 import { cmdKnowledgeList, cmdKnowledgeSearch, cmdKnowledgeStats } from "./cli/commands/knowledge.js";
@@ -279,6 +279,19 @@ export class CLIRunner {
     if (subcommand === "start") {
       await cmdStart(this.stateManager, this.characterConfigManager, argv.slice(1));
       return 0;
+    }
+
+    if (subcommand === "daemon") {
+      const daemonSubcommand = argv[1];
+
+      if (daemonSubcommand === "status") {
+        await cmdDaemonStatus(argv.slice(2));
+        return 0;
+      }
+
+      logger.error(`Unknown daemon subcommand: "${daemonSubcommand ?? ""}"`);
+      logger.error("Available: daemon status");
+      return 1;
     }
 
     if (subcommand === "stop") {

--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -1,6 +1,11 @@
-// ─── pulseed daemon commands (start, stop, cron) ───
+// ─── pulseed daemon commands (start, stop, cron, status) ───
 
 import { parseArgs } from "node:util";
+import { spawn } from "node:child_process";
+import * as path from "node:path";
+import { readJsonFileOrNull } from "../../utils/json-io.js";
+import { DaemonStateSchema } from "../../types/daemon.js";
+import type { DaemonState } from "../../types/daemon.js";
 
 import { StateManager } from "../../state-manager.js";
 import { CharacterConfigManager } from "../../traits/character-config.js";
@@ -17,7 +22,7 @@ export async function cmdStart(
   characterConfigManager: CharacterConfigManager,
   args: string[]
 ): Promise<void> {
-  let values: { "api-key"?: string; config?: string; goal?: string[] };
+  let values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean };
   try {
     ({ values } = parseArgs({
       args,
@@ -25,9 +30,10 @@ export async function cmdStart(
         "api-key": { type: "string" },
         config: { type: "string" },
         goal: { type: "string", multiple: true },
+        detach: { type: "boolean", short: "d" },
       },
       strict: false,
-    }) as { values: { "api-key"?: string; config?: string; goal?: string[] } });
+    }) as { values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean } });
   } catch (err) {
     getCliLogger().error(formatOperationError("parse start command arguments", err));
     values = {};
@@ -38,6 +44,30 @@ export async function cmdStart(
   if (goalIds.length === 0) {
     getCliLogger().error("Error: at least one --goal is required for daemon mode");
     process.exit(1);
+  }
+
+  // --detach: spawn a detached child and exit immediately
+  if (values.detach) {
+    const scriptPath = process.argv[1]!;
+    // Reconstruct args from parsed values (never include --detach)
+    const childArgs = ["start"];
+    for (const g of goalIds) childArgs.push("--goal", g);
+
+    const child = spawn(process.execPath, [scriptPath, ...childArgs], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", (err) => {
+      console.error(`Failed to start daemon: ${err.message}`);
+      process.exit(1);
+    });
+    child.unref();
+    if (child.pid == null) {
+      console.error("Failed to start daemon: no PID assigned");
+      process.exit(1);
+    }
+    console.log(`Daemon started in background (PID: ${child.pid})`);
+    process.exit(0);
   }
 
   const deps = await buildDeps(stateManager, characterConfigManager);
@@ -63,6 +93,60 @@ export async function cmdStart(
 
   logger.info(`Starting PulSeed daemon for goals: ${goalIds.join(", ")}`);
   await daemon.start(goalIds);
+}
+
+export async function cmdDaemonStatus(_args: string[]): Promise<void> {
+  const baseDir = getPulseedDirPath();
+  const statePath = path.join(baseDir, "daemon-state.json");
+
+  const raw = await readJsonFileOrNull(statePath);
+  if (raw === null) {
+    console.log("No daemon state found");
+    return;
+  }
+  const parsed = DaemonStateSchema.safeParse(raw);
+  if (!parsed.success) {
+    console.error(`Invalid daemon state: ${parsed.error.message}`);
+    return;
+  }
+  const data: DaemonState = parsed.data;
+
+  // Check if the PID is actually running
+  let alive = false;
+  try {
+    process.kill(data.pid, 0);
+    alive = true;
+  } catch {
+    alive = false;
+  }
+
+  const status = alive ? "running" : "stopped";
+  const lines: string[] = [
+    `Status:      ${status}`,
+    `PID:         ${data.pid}`,
+    `Active goals: ${data.active_goals.join(", ") || "(none)"}`,
+    `Loop count:  ${data.loop_count}`,
+    `Crash count: ${data.crash_count}`,
+  ];
+
+  if (data.started_at) {
+    const uptimeMs = alive ? Date.now() - new Date(data.started_at).getTime() : null;
+    lines.push(`Started at:  ${data.started_at}`);
+    if (uptimeMs !== null) {
+      const uptimeSec = Math.floor(uptimeMs / 1000);
+      lines.push(`Uptime:      ${uptimeSec}s`);
+    }
+  }
+
+  if (data.last_loop_at) {
+    lines.push(`Last loop:   ${data.last_loop_at}`);
+  }
+
+  if (data.last_error) {
+    lines.push(`Last error:  ${data.last_error}`);
+  }
+
+  console.log(lines.join("\n"));
 }
 
 export async function cmdStop(_args: string[]): Promise<void> {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -43,6 +43,7 @@ Usage:
   pulseed tui                          Launch the interactive TUI
   pulseed start --goal <id>            Start daemon mode for one or more goals
   pulseed stop                         Stop the running daemon
+  pulseed daemon status                Show running daemon status
   pulseed cron --goal <id>             Print crontab entry for a goal
   pulseed config character             Show or update character configuration
   pulseed datasource add <type>        Register a new data source (file | http_api)
@@ -66,6 +67,10 @@ Options (pulseed run):
   --adapter <type>                    Adapter: claude_api | claude_code_cli | github_issue (default: claude_api)
   --tree                              Enable tree mode (iterate across all tree nodes)
   --yes, -y                           Auto-approve all tasks (skip approval prompts)
+
+Options (pulseed start):
+  --goal <id>                         Goal ID to run (repeatable, required)
+  --detach, -d                        Run daemon in background (detached process)
 
 Options (pulseed improve):
   --auto                              Full auto mode (select best suggestion, run loop)

--- a/tests/cli-daemon-status.test.ts
+++ b/tests/cli-daemon-status.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { makeTempDir, cleanupTempDir } from "./helpers/temp-dir.js";
+
+// ─── cmdDaemonStatus tests ───
+
+// We test the command by importing it and mocking paths.getPulseedDirPath
+// so it points to a temp directory we control.
+
+vi.mock("../src/utils/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/utils/paths.js")>();
+  return {
+    ...actual,
+    getPulseedDirPath: vi.fn(() => "/tmp/pulseed-test-placeholder"),
+  };
+});
+
+import { getPulseedDirPath } from "../src/utils/paths.js";
+import { cmdDaemonStatus } from "../src/cli/commands/daemon.js";
+
+describe("cmdDaemonStatus", () => {
+  let tmpDir: string;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir("pulseed-status-test-");
+    vi.mocked(getPulseedDirPath).mockReturnValue(tmpDir);
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    cleanupTempDir(tmpDir);
+  });
+
+  it("prints 'No daemon state found' when state file does not exist", async () => {
+    await cmdDaemonStatus([]);
+
+    expect(consoleSpy).toHaveBeenCalledWith("No daemon state found");
+  });
+
+  it("shows stopped status when PID is not running", async () => {
+    // Write a state file with a PID that is almost certainly not running
+    const state = {
+      pid: 999999999,
+      started_at: "2026-01-01T00:00:00.000Z",
+      last_loop_at: null,
+      loop_count: 5,
+      active_goals: ["goal-a", "goal-b"],
+      status: "running",
+      crash_count: 1,
+      last_error: null,
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+
+    await cmdDaemonStatus([]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Status:      stopped");
+    expect(output).toContain("PID:         999999999");
+    expect(output).toContain("goal-a");
+    expect(output).toContain("goal-b");
+    expect(output).toContain("Loop count:  5");
+    expect(output).toContain("Crash count: 1");
+  });
+
+  it("shows running status when PID is the current process", async () => {
+    // Use our own PID — guaranteed to be running
+    const state = {
+      pid: process.pid,
+      started_at: new Date(Date.now() - 60_000).toISOString(),
+      last_loop_at: new Date().toISOString(),
+      loop_count: 10,
+      active_goals: ["goal-x"],
+      status: "running",
+      crash_count: 0,
+      last_error: null,
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+
+    await cmdDaemonStatus([]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Status:      running");
+    expect(output).toContain(`PID:         ${process.pid}`);
+    expect(output).toContain("Uptime:");
+    expect(output).toContain("Loop count:  10");
+    expect(output).toContain("Crash count: 0");
+  });
+
+  it("shows last_error when present", async () => {
+    const state = {
+      pid: 999999999,
+      started_at: "2026-01-01T00:00:00.000Z",
+      last_loop_at: null,
+      loop_count: 0,
+      active_goals: [],
+      status: "crashed",
+      crash_count: 3,
+      last_error: "something went wrong",
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+
+    await cmdDaemonStatus([]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Last error:  something went wrong");
+  });
+
+  it("handles empty active_goals gracefully", async () => {
+    const state = {
+      pid: 999999999,
+      started_at: "2026-01-01T00:00:00.000Z",
+      last_loop_at: null,
+      loop_count: 0,
+      active_goals: [],
+      status: "stopped",
+      crash_count: 0,
+      last_error: null,
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+
+    await cmdDaemonStatus([]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Active goals: (none)");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `pulseed daemon status` — reads daemon-state.json (Zod validated), checks PID liveness, displays status
- Add `--detach` / `-d` flag to `pulseed start` — spawns detached child with error handling
- Add help text for new command and flag
- 5 new tests for daemon status

## Test plan
- [x] `npm run build` — 0 errors
- [x] `npx vitest run tests/cli-daemon-status.test.ts` — 5/5 pass
- [x] `npx vitest run` — 5009 tests pass, no regressions
- [ ] Manual: `pulseed daemon status` with no running daemon
- [ ] Manual: `pulseed start --detach --goal test` on Mac Mini

🤖 Generated with [Claude Code](https://claude.com/claude-code)