### PR TITLE
fix: ensure Codex adapter produces file-modifying tasks

### DIFF
--- a/src/execution/task-executor.ts
+++ b/src/execution/task-executor.ts
@@ -167,6 +167,9 @@ export async function executeTask(
           "[TaskLifecycle] Adapter reported success but no files were modified",
           { taskId: task.id }
         );
+        result.success = false;
+        result.error = "No files were modified";
+        result.stopped_reason = "completed";
       }
 
       if (changedFiles.length > 0) {

--- a/src/execution/task-prompt-builder.ts
+++ b/src/execution/task-prompt-builder.ts
@@ -84,6 +84,9 @@ Gap Analysis:
 - Generate specific, actionable issues only\n`;
   } else if (adapterType === "openai_codex_cli" || adapterType === "claude_code_cli") {
     adapterSection = `\nExecution context: CLI code agent in sandbox.
+You MUST produce implementation tasks that modify or create files.
+The executing agent will run in a code sandbox with full file access.
+Tasks should involve writing code, fixing bugs, adding tests, or editing configuration — NOT analysis or planning.
 Constraints:
 - No git commit/push/merge operations
 - Success criteria must use file checks only (e.g., "file X exists")


### PR DESCRIPTION
## Summary
- Task prompt builder now includes positive instruction for CLI adapters: tasks MUST modify/create files, not just analyze
- Task executor treats zero file changes as failure (`success=false`) to trigger retry/strategy pivot

## Context
During Mac Mini dogfooding (C3), Codex CLI was executing tasks but making zero code changes — the prompt only had constraints ("don't do X") without telling it to actually modify files, and zero-change results were silently accepted as success.

## Test plan
- [x] task-prompt-builder tests pass (20/20)
- [x] Build clean
- [ ] Re-run Mac Mini dogfooding to verify Codex now makes file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)