### PR TITLE
fix: skip knowledge gap detection when only self-report observations

### DIFF
--- a/src/loop/core-loop-phases.ts
+++ b/src/loop/core-loop-phases.ts
@@ -315,10 +315,11 @@ export async function scoreDrivesAndCheckKnowledge(
           Math.max(gapVector.gaps.length, 1),
       };
 
-      // Skip knowledge gap detection when there's no observation data at all.
-      // confidence === 0 means no observation was performed yet; distinct from a real
-      // low-confidence observation (> 0 but < 0.3) where gap detection is useful.
-      const gapSignal = (observationContext.confidence === 0 || !Number.isFinite(observationContext.confidence))
+      // Skip knowledge gap detection when observations are purely self-report
+      // (no data sources configured). confidence <= 0.3 means all observations are
+      // LLM self-report only; running gap detection here would block task execution
+      // every iteration without any way to improve confidence.
+      const gapSignal = (observationContext.confidence <= 0.3 || !Number.isFinite(observationContext.confidence))
         ? null
         : await ctx.deps.knowledgeManager.detectKnowledgeGap(observationContext);
       if (gapSignal !== null) {


### PR DESCRIPTION
## Summary
- Skip `detectKnowledgeGap` when average observation confidence <= 0.3 (all LLM self-report, no data sources)
- Prevents knowledge gap check from blocking task execution every iteration

## Context
During Mac Mini dogfooding, knowledge gap detection was firing every iteration (confidence=0.30 from LLM-only observations), generating acquisition tasks and returning early — Codex never got a chance to execute real tasks. Changed threshold from `=== 0` to `<= 0.3`.

## Test plan
- [x] 184 core-loop tests pass
- [x] Build clean
- [ ] Re-run Mac Mini dogfooding to verify tasks reach Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)