### PR TITLE
fix: detect untracked files in post-execution change check

### DIFF
--- a/src/execution/task-executor.ts
+++ b/src/execution/task-executor.ts
@@ -160,7 +160,21 @@ export async function executeTask(
         encoding: "utf-8",
       }).trim();
 
-      const changedFiles = diffOutput ? diffOutput.split("\n") : [];
+      // Also detect new (untracked) files — git diff alone misses them
+      let untrackedOutput = "";
+      try {
+        untrackedOutput = execFileSyncFn("git", ["ls-files", "--others", "--exclude-standard"], {
+          cwd: process.cwd(),
+          encoding: "utf-8",
+        }).trim();
+      } catch {
+        // git ls-files failure is non-fatal
+      }
+
+      const changedFiles = [
+        ...(diffOutput ? diffOutput.split("\n") : []),
+        ...(untrackedOutput ? untrackedOutput.split("\n") : []),
+      ];
       result.filesChanged = changedFiles.length > 0;
       if (!result.filesChanged) {
         logger?.warn(


### PR DESCRIPTION
## Summary
- Add `git ls-files --others --exclude-standard` to detect new (untracked) files after Codex execution
- Previously only `git diff --name-only` was used, which misses newly created files

## Context
During dogfooding, Codex correctly created `tests/hello-smoke.test.ts` but the change check reported "no files modified" because the new file was untracked. This caused the task to be marked as failed despite successful execution.

## Test plan
- [x] task-lifecycle-execution tests pass (20/20)
- [x] Build clean
- [ ] Re-run Mac Mini dogfooding

🤖 Generated with [Claude Code](https://claude.com/claude-code)