### PR TITLE
fix: fallback to exact dimension name when normalization fails

### DIFF
--- a/src/observation/observation-apply.ts
+++ b/src/observation/observation-apply.ts
@@ -28,7 +28,11 @@ export async function applyObservation(
   }
 
   const safeName = normalizeDimensionName(entry.dimension_name);
-  const dimIndex = goal.dimensions.findIndex((d) => d.name === safeName);
+  let dimIndex = goal.dimensions.findIndex((d) => d.name === safeName);
+  // Fallback: try exact name if normalization changed it and didn't match
+  if (dimIndex === -1 && safeName !== entry.dimension_name) {
+    dimIndex = goal.dimensions.findIndex((d) => d.name === entry.dimension_name);
+  }
   if (dimIndex === -1) {
     throw new Error(
       `applyObservation: dimension "${entry.dimension_name}" not found in goal "${goalId}"`


### PR DESCRIPTION
## Summary
- When `normalizeDimensionName` strips trailing `_\d+` and the result doesn't match any dimension, try the original name as fallback
- Fixes dimension names containing legitimate numbers (e.g., `assertion_checks_1_plus_1_equals_2`) being corrupted by normalization

## Context
During dogfooding, observation for dimension `assertion_checks_1_plus_1_equals_2` failed with "not found" because normalization stripped the trailing `_2`, producing `assertion_checks_1_plus_1_equals` which didn't match.

## Test plan
- [x] 138 observation tests pass
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)