### PR TITLE
fix: limit knowledge gap detection to first iteration only

### DIFF
--- a/src/loop/core-loop-phases.ts
+++ b/src/loop/core-loop-phases.ts
@@ -315,11 +315,16 @@ export async function scoreDrivesAndCheckKnowledge(
           Math.max(gapVector.gaps.length, 1),
       };
 
-      // Skip knowledge gap detection when observations are purely self-report
-      // (no data sources configured). confidence <= 0.3 means all observations are
-      // LLM self-report only; running gap detection here would block task execution
-      // every iteration without any way to improve confidence.
-      const gapSignal = (observationContext.confidence <= 0.3 || !Number.isFinite(observationContext.confidence))
+      // Skip knowledge gap detection when:
+      // 1. Observations are purely self-report (confidence <= 0.3, no data sources)
+      // 2. Not the first iteration — prevents repeated gap detection from blocking
+      //    task execution every loop. Gap detection runs once; after that, let the
+      //    normal task cycle proceed.
+      const skipGapDetection =
+        observationContext.confidence <= 0.3 ||
+        !Number.isFinite(observationContext.confidence) ||
+        loopIndex > 0;
+      const gapSignal = skipGapDetection
         ? null
         : await ctx.deps.knowledgeManager.detectKnowledgeGap(observationContext);
       if (gapSignal !== null) {


### PR DESCRIPTION
## Summary
- Knowledge gap detection now only runs on `loopIndex=0` (first iteration)
- Subsequent iterations skip gap detection and proceed to normal task execution

## Context
Follow-up to PR #372. Even after raising the threshold to `<= 0.3`, data sources brought confidence to 0.45, which re-enabled gap detection. Every iteration generated an acquisition task and returned early — Codex never executed.

## Test plan
- [x] 184 core-loop tests pass
- [x] Build clean
- [ ] Re-run Mac Mini dogfooding

🤖 Generated with [Claude Code](https://claude.com/claude-code)