### PR TITLE
fix: wire --workspace flag through CLI to adapter execution directory

### DIFF
--- a/src/adapters/claude-code-cli.ts
+++ b/src/adapters/claude-code-cli.ts
@@ -44,10 +44,12 @@ export class ClaudeCodeCLIAdapter implements IAdapter {
       spawnArgs.push("--allowedTools", task.allowed_tools.join(","));
     }
 
+    // Per-task cwd override (from workspace_path: constraint) takes priority over constructor workDir.
+    const cwd = task.cwd ?? this.workDir;
     const result = await spawnWithTimeout(
       this.cliPath,
       spawnArgs,
-      { cwd: this.workDir, stdinData: task.prompt },
+      { cwd, stdinData: task.prompt },
       task.timeout_ms
     );
 

--- a/src/adapters/openai-codex.ts
+++ b/src/adapters/openai-codex.ts
@@ -79,10 +79,12 @@ export class OpenAICodexCLIAdapter implements IAdapter {
     }
 
     // NOTE: --path is NOT supported by codex-cli 0.114.0; use cwd instead
+    // Per-task cwd override (from workspace_path: constraint) takes priority over constructor repoPath.
+    const cwd = task.cwd ?? this.repoPath;
     const result = await spawnWithTimeout(
       this.cliPath,
       spawnArgs,
-      { cwd: this.repoPath, env: process.env, stdinData: task.prompt },
+      { cwd, env: process.env, stdinData: task.prompt },
       task.timeout_ms
     );
 

--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -128,7 +128,7 @@ export class CLIRunner {
     const subcommand = argv[0];
 
     if (subcommand === "run") {
-      let values: { goal?: string[]; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean };
+      let values: { goal?: string[]; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean; workspace?: string };
       try {
         ({ values } = parseArgs({
           args: argv.slice(1),
@@ -139,9 +139,10 @@ export class CLIRunner {
             tree: { type: "boolean" },
             yes: { type: "boolean", short: "y" },
             verbose: { type: "boolean" },
+            workspace: { type: "string" },
           },
           strict: false,
-        }) as { values: { goal?: string[]; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean } });
+        }) as { values: { goal?: string[]; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean; workspace?: string } });
       } catch (err) {
         logger.error(formatOperationError("parse run command arguments", err));
         values = {};
@@ -157,6 +158,21 @@ export class CLIRunner {
         return 1;
       }
       const goalId = goalIds[0];
+
+      // Add workspace_path constraint to goal if --workspace is provided
+      if (values.workspace) {
+        const goal = await this.stateManager.loadGoal(goalId);
+        if (goal) {
+          const wpPrefix = "workspace_path:";
+          const existingIdx = goal.constraints.findIndex((c) => c.startsWith(wpPrefix));
+          if (existingIdx >= 0) {
+            goal.constraints[existingIdx] = `${wpPrefix}${values.workspace}`;
+          } else {
+            goal.constraints.push(`${wpPrefix}${values.workspace}`);
+          }
+          await this.stateManager.saveGoal(goal);
+        }
+      }
 
       const loopConfig: LoopConfig = {};
       if (values["max-iterations"] !== undefined) {
@@ -180,7 +196,8 @@ export class CLIRunner {
         loopConfig,
         globalYes || values.yes,
         values.verbose,
-        activeCoreLoopRef
+        activeCoreLoopRef,
+        values.workspace,
       );
       this.activeCoreLoop = activeCoreLoopRef.value;
       return result;

--- a/src/cli/commands/goal-dispatch.ts
+++ b/src/cli/commands/goal-dispatch.ts
@@ -54,6 +54,7 @@ export async function dispatchGoalCommand(
       constraint?: string[];
       yes?: boolean;
       parent?: string;
+      workspace?: string;
     } = {};
     try {
       const parsed = parseArgs({
@@ -67,6 +68,7 @@ export async function dispatchGoalCommand(
           constraint: { type: "string", multiple: true },
           yes: { type: "boolean", short: "y" },
           parent: { type: "string" },
+          workspace: { type: "string" },
         },
         allowPositionals: true,
         strict: false,
@@ -145,6 +147,10 @@ export async function dispatchGoalCommand(
 
     const deadline = addValues.deadline;
     const constraints = addValues.constraint ?? [];
+    // Add workspace_path constraint when --workspace is provided
+    if (addValues.workspace) {
+      constraints.push(`workspace_path:${addValues.workspace}`);
+    }
     const noRefine = addValues["no-refine"] ?? false;
     return await cmdGoalAdd(stateManager, characterConfigManager, description, {
       deadline,

--- a/src/cli/commands/goal-raw.ts
+++ b/src/cli/commands/goal-raw.ts
@@ -12,7 +12,7 @@ import {
 
 export async function cmdGoalAddRaw(
   stateManager: StateManager,
-  opts: { title?: string; description?: string; rawDimensions: string[]; parent_id?: string }
+  opts: { title?: string; description?: string; rawDimensions: string[]; parent_id?: string; constraints?: string[] }
 ): Promise<number> {
   const title = opts.title || opts.description;
   if (!title) {
@@ -74,7 +74,7 @@ export async function cmdGoalAddRaw(
     dimensions,
     gap_aggregation: "max" as const,
     dimension_mapping: null,
-    constraints: [],
+    constraints: opts.constraints ?? [],
     children_ids: [],
     target_date: null,
     origin: "manual" as const,

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -41,7 +41,8 @@ export async function cmdRun(
   loopConfig?: LoopConfig,
   autoApprove?: boolean,
   verbose?: boolean,
-  activeCoreLoopRef?: { value: import("../../core-loop.js").CoreLoop | null }
+  activeCoreLoopRef?: { value: import("../../core-loop.js").CoreLoop | null },
+  workspacePath?: string,
 ): Promise<number> {
   try {
     await ensureProviderConfig();
@@ -63,7 +64,7 @@ export async function cmdRun(
 
   let deps: Awaited<ReturnType<typeof buildDeps>>;
   try {
-    deps = await buildDeps(stateManager, characterConfigManager, loopConfig, approvalFn, logger, onProgress);
+    deps = await buildDeps(stateManager, characterConfigManager, loopConfig, approvalFn, logger, onProgress, workspacePath);
   } catch (err) {
     rl?.close();
     logger.error(formatOperationError("initialise dependencies", err));

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -55,7 +55,8 @@ export async function buildDeps(
   config?: LoopConfig,
   approvalFn?: (task: Task) => Promise<boolean>,
   logger?: Logger,
-  onProgress?: (event: ProgressEvent) => void
+  onProgress?: (event: ProgressEvent) => void,
+  workspacePath?: string,
 ) {
   const characterConfig = await characterConfigManager.load();
   const llmClient = await buildLLMClient();
@@ -99,7 +100,7 @@ export async function buildDeps(
   }
 
   const contextProvider = createWorkspaceContextProvider(
-    { workDir: process.cwd() },
+    { workDir: workspacePath ?? process.cwd() },
     async (goalId: string) => {
       try {
         const goal = await stateManager.loadGoal(goalId);

--- a/src/execution/adapter-layer.ts
+++ b/src/execution/adapter-layer.ts
@@ -18,6 +18,8 @@ export interface AgentTask {
   adapter_type: string;
   /** Tool/capability allowlist — locked at task creation, immutable during execution */
   allowed_tools?: readonly string[];
+  /** Working directory override for the agent process (e.g., target workspace path) */
+  cwd?: string;
 }
 
 export interface AgentResult {

--- a/src/execution/task-executor.ts
+++ b/src/execution/task-executor.ts
@@ -45,6 +45,18 @@ export async function executeTask(
 ): Promise<AgentResult> {
   const { stateManager, sessionManager, logger, execFileSyncFn } = deps;
 
+  // Resolve workspace path from goal constraints (workspace_path:<path>)
+  let workspaceCwd: string | undefined;
+  try {
+    const goal = await stateManager.loadGoal(task.goal_id);
+    const wpConstraint = goal?.constraints.find((c) => c.startsWith("workspace_path:"));
+    if (wpConstraint) {
+      workspaceCwd = wpConstraint.slice("workspace_path:".length);
+    }
+  } catch {
+    // Non-fatal: fall back to process.cwd()
+  }
+
   // Create execution session
   const session = await sessionManager.createSession(
     "task_execution",
@@ -106,6 +118,7 @@ export async function executeTask(
     timeout_ms: timeoutMs,
     adapter_type: adapter.adapterType,
     ...(allowedTools !== undefined ? { allowed_tools: allowedTools } : {}),
+    ...(workspaceCwd !== undefined ? { cwd: workspaceCwd } : {}),
   };
 
   // Update task status to running
@@ -155,8 +168,9 @@ export async function executeTask(
   // and annotate result.filesChanged from the same git diff --name-only call.
   if (result.success) {
     try {
+      const gitCwd = workspaceCwd ?? process.cwd();
       const diffOutput = execFileSyncFn("git", ["diff", "--name-only"], {
-        cwd: process.cwd(),
+        cwd: gitCwd,
         encoding: "utf-8",
       }).trim();
 
@@ -164,7 +178,7 @@ export async function executeTask(
       let untrackedOutput = "";
       try {
         untrackedOutput = execFileSyncFn("git", ["ls-files", "--others", "--exclude-standard"], {
-          cwd: process.cwd(),
+          cwd: gitCwd,
           encoding: "utf-8",
         }).trim();
       } catch {
@@ -202,7 +216,7 @@ export async function executeTask(
 
         if (protectedChanges.length > 0) {
           execFileSyncFn("git", ["checkout", "--", ...protectedChanges], {
-            cwd: process.cwd(),
+            cwd: gitCwd,
             encoding: "utf-8",
           });
           result.output = (result.output || "") +


### PR DESCRIPTION
## Summary
- Add `--workspace` CLI flag to both `goal add` and `run` commands
- Workspace stored as `workspace_path:<path>` goal constraint (reuses existing observation convention)
- `task-executor` resolves workspace from goal constraints → sets `AgentTask.cwd`
- Both Codex CLI and Claude Code CLI adapters use per-task `cwd` override
- Context provider and git operations also use workspace path

Root cause: Codex CLI always executed in PulSeed's directory instead of target workspace, so created files were invisible to observation engine.

## Test plan
- [x] 5005 tests pass (full suite)
- [ ] Mac Mini dogfooding: `pulseed goal add "..." --workspace /tmp/test && pulseed run --goal <id>` → verify files created in `/tmp/test`
- [ ] Verify gap decreases after task execution in correct workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)