### PR TITLE
fix: wire workspace path through observation engine and datasource registration

### DIFF
--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -160,17 +160,28 @@ export class CLIRunner {
       const goalId = goalIds[0];
 
       // Add workspace_path constraint to goal if --workspace is provided
-      if (values.workspace) {
+      let resolvedWorkspace = values.workspace;
+      if (resolvedWorkspace) {
         const goal = await this.stateManager.loadGoal(goalId);
         if (goal) {
           const wpPrefix = "workspace_path:";
           const existingIdx = goal.constraints.findIndex((c) => c.startsWith(wpPrefix));
           if (existingIdx >= 0) {
-            goal.constraints[existingIdx] = `${wpPrefix}${values.workspace}`;
+            goal.constraints[existingIdx] = `${wpPrefix}${resolvedWorkspace}`;
           } else {
-            goal.constraints.push(`${wpPrefix}${values.workspace}`);
+            goal.constraints.push(`${wpPrefix}${resolvedWorkspace}`);
           }
           await this.stateManager.saveGoal(goal);
+        }
+      } else {
+        // No --workspace flag: check if goal already has workspace_path constraint
+        const goal = await this.stateManager.loadGoal(goalId);
+        if (goal) {
+          const wpPrefix = "workspace_path:";
+          const existing = goal.constraints.find((c) => c.startsWith(wpPrefix));
+          if (existing) {
+            resolvedWorkspace = existing.slice(wpPrefix.length);
+          }
         }
       }
 
@@ -197,7 +208,7 @@ export class CLIRunner {
         globalYes || values.yes,
         values.verbose,
         activeCoreLoopRef,
-        values.workspace,
+        resolvedWorkspace,
       );
       this.activeCoreLoop = activeCoreLoopRef.value;
       return result;

--- a/src/cli/commands/goal-raw.ts
+++ b/src/cli/commands/goal-raw.ts
@@ -105,7 +105,7 @@ export async function cmdGoalAddRaw(
     }
   }
 
-  await autoRegisterFileExistenceDataSources(stateManager, dimensions, title, goalId);
+  await autoRegisterFileExistenceDataSources(stateManager, dimensions, title, goalId, opts.constraints);
   await autoRegisterShellDataSources(stateManager, dimensions, goalId);
 
   console.log(`Goal registered successfully!`);

--- a/src/cli/commands/goal-utils.ts
+++ b/src/cli/commands/goal-utils.ts
@@ -196,23 +196,14 @@ export async function autoRegisterFileExistenceDataSources(
   stateManager: StateManager,
   dimensions: Array<{ name: string; label?: string }>,
   goalDescription: string,
-  goalId: string
+  goalId: string,
+  constraints?: string[]
 ): Promise<void> {
   try {
     const fileExistenceDims = dimensions.filter((d) =>
       /_exists$|_file$|file_existence/.test(d.name)
     );
     if (fileExistenceDims.length === 0) return;
-
-    const nonFileExistenceDims = dimensions.filter((d) =>
-      !/_exists$|_file$|file_existence/.test(d.name)
-    );
-    if (nonFileExistenceDims.length >= 1) {
-      getCliLogger().info(
-        `[auto] Skipping FileExistenceDataSource auto-registration: goal has ${nonFileExistenceDims.length} non-FileExistence dimensions that should take priority`
-      );
-      return;
-    }
 
     const filePathPattern = /\b([\w.\-/]+\.\w{1,10})\b/g;
     const candidateFiles: string[] = [];
@@ -275,13 +266,17 @@ export async function autoRegisterFileExistenceDataSources(
       return;
     }
 
+    const workspacePath = constraints
+      ?.find((c) => c.startsWith("workspace_path:"))
+      ?.slice("workspace_path:".length) ?? process.cwd();
+
     const dimKeys = Object.keys(dimensionMapping).sort().join("_");
     const id = `ds_auto_${goalId}_${dimKeys}`;
     const config = {
       id,
       name: `auto:file_existence (${Object.values(dimensionMapping).join(", ")})`,
       type: "file_existence",
-      connection: { path: process.cwd() },
+      connection: { path: workspacePath },
       dimension_mapping: dimensionMapping,
       scope_goal_id: goalId,
       enabled: true,

--- a/src/cli/commands/goal-write.ts
+++ b/src/cli/commands/goal-write.ts
@@ -145,7 +145,7 @@ export async function cmdGoalAdd(
   for (const leafId of leafIds) {
     const leafGoal = await stateManager.loadGoal(leafId);
     if (leafGoal && leafGoal.dimensions.length > 0) {
-      await autoRegisterFileExistenceDataSources(stateManager, leafGoal.dimensions, leafGoal.description, leafId);
+      await autoRegisterFileExistenceDataSources(stateManager, leafGoal.dimensions, leafGoal.description, leafId, leafGoal.constraints);
       await autoRegisterShellDataSources(stateManager, leafGoal.dimensions, leafId);
     }
   }
@@ -208,7 +208,7 @@ async function cmdGoalAddLegacyNegotiate(
       }
     }
 
-    await autoRegisterFileExistenceDataSources(stateManager, goal.dimensions, goal.description, goal.id);
+    await autoRegisterFileExistenceDataSources(stateManager, goal.dimensions, goal.description, goal.id, goal.constraints);
     await autoRegisterShellDataSources(stateManager, goal.dimensions, goal.id);
 
     console.log(`Goal registered successfully!`);

--- a/src/observation/observation-engine.ts
+++ b/src/observation/observation-engine.ts
@@ -344,7 +344,10 @@ export class ObservationEngine {
                 JSON.stringify(dim.threshold),
                 ctx,
                 null, // no previousScore — bypass jump suppression for cross-validation
-                true // dryRun — do NOT write to state
+                true, // dryRun — do NOT write to state
+                undefined,
+                undefined,
+                workspacePath
               );
               const llmValue = typeof llmEntry.extracted_value === "number" ? llmEntry.extracted_value : 0;
               const result = this.crossValidate(goalId, dim.name, mechanicalValue, llmValue);
@@ -444,7 +447,8 @@ export class ObservationEngine {
             previousScore,
             undefined, // dryRun
             typeof dim.current_value === "number" ? dim.current_value : null,
-            !!dataSource
+            !!dataSource,
+            workspacePath
           );
           continue;
         } catch (err) {
@@ -559,7 +563,8 @@ export class ObservationEngine {
     previousScore?: number | null,
     dryRun?: boolean,
     currentValue?: number | null,
-    sourceAvailable?: boolean
+    sourceAvailable?: boolean,
+    workspacePath?: string
   ): Promise<ObservationLogEntry> {
     if (!this.llmClient) {
       throw new Error("observeWithLLM: llmClient is not configured");
@@ -580,7 +585,8 @@ export class ObservationEngine {
       undefined, // dimensionHistory
       undefined, // gateway
       currentValue,
-      sourceAvailable
+      sourceAvailable,
+      workspacePath
     );
   }
 

--- a/src/observation/observation-llm.ts
+++ b/src/observation/observation-llm.ts
@@ -21,17 +21,19 @@ import type { IPromptGateway } from "../prompt/gateway.js";
  *
  * @param options   Engine options (may contain gitContextFetcher override).
  * @param maxChars  Maximum characters to return (default: 3000).
+ * @param cwd       Working directory for git commands (defaults to process.cwd()).
  */
-export async function fetchGitDiffContext(options: ObservationEngineOptions, maxChars = 3000): Promise<string> {
+export async function fetchGitDiffContext(options: ObservationEngineOptions, maxChars = 3000, cwd?: string): Promise<string> {
   // Allow test injection via options
   if (options.gitContextFetcher) {
     return options.gitContextFetcher(maxChars);
   }
 
+  const execOptions = { timeout: 10000, encoding: "utf8" as const, ...(cwd ? { cwd } : {}) };
   const parts: string[] = [];
 
   try {
-    const { stdout: stat } = await execFile("git", ["diff", "--stat"], { timeout: 10000, encoding: "utf8" });
+    const { stdout: stat } = await execFile("git", ["diff", "--stat"], execOptions);
     if (stat.trim()) {
       parts.push("[git diff --stat]");
       parts.push(stat.trim());
@@ -41,7 +43,7 @@ export async function fetchGitDiffContext(options: ObservationEngineOptions, max
   }
 
   try {
-    const { stdout: diff } = await execFile("git", ["diff"], { timeout: 10000, encoding: "utf8" });
+    const { stdout: diff } = await execFile("git", ["diff"], execOptions);
     if (diff.trim()) {
       parts.push("[git diff]");
       // Reserve space: subtract what we've already accumulated
@@ -93,6 +95,7 @@ function inferDirection(history: Array<{ value: number }>): string {
  * @param dryRun             If true, do not write to state.
  * @param logger             Optional logger.
  * @param dimensionHistory   Optional history of prior observations for this dimension.
+ * @param workspacePath      Optional workspace directory for git diff fallback.
  */
 export async function observeWithLLM(
   goalId: string,
@@ -110,7 +113,8 @@ export async function observeWithLLM(
   dimensionHistory?: Array<{ value: number; timestamp?: string; date?: string }>,
   gateway?: IPromptGateway,
   currentValue?: number | null,
-  sourceAvailable?: boolean
+  sourceAvailable?: boolean,
+  workspacePath?: string
 ): Promise<ObservationLogEntry> {
   logger?.info(
     `[ObservationEngine] LLM observation for dimension "${dimensionLabel}" (goal: ${goalId})`
@@ -119,7 +123,7 @@ export async function observeWithLLM(
   // Resolve workspace context: use provided context, fall back to git diff, or warn.
   let resolvedContext = workspaceContext;
   if (!resolvedContext || resolvedContext.trim().length === 0) {
-    const gitCtx = await fetchGitDiffContext(options, 3000);
+    const gitCtx = await fetchGitDiffContext(options, 3000, workspacePath);
     if (gitCtx.trim().length > 0) {
       resolvedContext = gitCtx;
       logger?.info(


### PR DESCRIPTION
## Summary
- **Fix B**: `autoRegisterFileExistenceDataSources()` no longer aborts when goal has mixed dimension types — registers for matching dimensions only
- **Fix A**: `FileExistenceDataSource` reads `workspace_path:` constraint from goal instead of `process.cwd()`
- **Fix C**: `fetchGitDiffContext()` accepts and uses workspace `cwd` for `git diff`
- **Fix D**: `cli-runner.ts` auto-resolves workspace from goal constraints when `--workspace` CLI flag omitted on `run`

Root cause: observation engine had no awareness of the target workspace — file existence checks, git diff, and context provider all pointed at PulSeed's own directory.

## Test plan
- [x] 5005 tests pass (1 pre-existing flake)
- [ ] Mac Mini dogfooding: verify gap decreases after task creates files in workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)