### PR TITLE
fix: inherit parent constraints in decomposed subgoals

### DIFF
--- a/src/goal/goal-decomposer.ts
+++ b/src/goal/goal-decomposer.ts
@@ -145,7 +145,7 @@ export async function decompose(
       dimensions,
       gap_aggregation: "max",
       dimension_mapping: null,
-      constraints: [],
+      constraints: parentGoal.constraints ?? [],
       children_ids: [],
       target_date: null,
       origin: "decomposition",


### PR DESCRIPTION
## Summary
- One-line fix: `constraints: []` → `constraints: parentGoal.constraints ?? []` in `goal-decomposer.ts`
- Child subgoals now inherit parent's constraints (including `workspace_path:`)
- Without this, leaf goals lose workspace awareness → observation/datasource use wrong directory

## Test plan
- [x] 5005 tests pass
- [ ] Mac Mini dogfooding: verify constraints persist through decomposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)