### PR TITLE
fix: pass constraints through infer and raw goal creation paths

### DIFF
--- a/src/cli/commands/goal-dispatch.ts
+++ b/src/cli/commands/goal-dispatch.ts
@@ -115,11 +115,16 @@ export async function dispatchGoalCommand(
 
           if (accepted) {
             const rawDims = inferred.map((d) => `${d.name}:${d.type}:${d.value}`);
+            const inferConstraints = addValues.constraint ?? [];
+            if (addValues.workspace) {
+              inferConstraints.push(`workspace_path:${addValues.workspace}`);
+            }
             return await cmdGoalAddRaw(stateManager, {
               title: inferTitle,
               description: description || inferTitle,
               rawDimensions: rawDims,
               parent_id: addValues.parent,
+              constraints: inferConstraints,
             });
           }
           // If rejected, fall through to refine mode
@@ -136,7 +141,11 @@ export async function dispatchGoalCommand(
         );
         return 1;
       }
-      return await cmdGoalAddRaw(stateManager, { title, description, rawDimensions, parent_id: addValues.parent });
+      const rawConstraints = addValues.constraint ?? [];
+      if (addValues.workspace) {
+        rawConstraints.push(`workspace_path:${addValues.workspace}`);
+      }
+      return await cmdGoalAddRaw(stateManager, { title, description, rawDimensions, parent_id: addValues.parent, constraints: rawConstraints });
     }
 
     // Refine/negotiate mode: requires description


### PR DESCRIPTION
## Summary
- `goal-dispatch.ts` had 3 code paths for goal creation: **infer** (dimension inference → accept), **raw** (--dim flag), and **refine** (GoalRefiner)
- Only the refine path passed `--workspace` constraint to the goal
- Both infer and raw paths called `cmdGoalAddRaw` without constraints, silently dropping `workspace_path:`
- Fix: thread constraints (including workspace_path) through all 3 paths

This was the final missing piece — constraints now flow from CLI through all goal creation paths to observation/adapter.

## Test plan
- [x] 5005 tests pass
- [ ] Mac Mini dogfooding: verify constraints persist and gap decreases

🤖 Generated with [Claude Code](https://claude.com/claude-code)