### PR TITLE
fix: include _present suffix in file existence datasource pattern

### DIFF
--- a/src/cli/commands/goal-utils.ts
+++ b/src/cli/commands/goal-utils.ts
@@ -201,7 +201,7 @@ export async function autoRegisterFileExistenceDataSources(
 ): Promise<void> {
   try {
     const fileExistenceDims = dimensions.filter((d) =>
-      /_exists$|_file$|file_existence/.test(d.name)
+      /_exists$|_file$|_present$|file_existence/.test(d.name)
     );
     if (fileExistenceDims.length === 0) return;
 


### PR DESCRIPTION
## Summary
- One-line regex fix: `/_exists$|_file$|file_existence/` → `/_exists$|_file$|_present$|file_existence/`
- LLM-inferred dimension names like `hello_ts_file_present` were not matched by the auto-registration pattern
- Without matching, no FileExistenceDataSource was registered → no mechanical observation → gap stayed at 1.00

🤖 Generated with [Claude Code](https://claude.com/claude-code)