### PR TITLE
fix: pass full description to file existence datasource auto-registration

### DIFF
--- a/src/cli/commands/goal-raw.ts
+++ b/src/cli/commands/goal-raw.ts
@@ -105,7 +105,7 @@ export async function cmdGoalAddRaw(
     }
   }
 
-  await autoRegisterFileExistenceDataSources(stateManager, dimensions, title, goalId, opts.constraints);
+  await autoRegisterFileExistenceDataSources(stateManager, dimensions, opts.description || title, goalId, opts.constraints);
   await autoRegisterShellDataSources(stateManager, dimensions, goalId);
 
   console.log(`Goal registered successfully!`);


### PR DESCRIPTION
## Summary
- `goal-raw.ts` passed `title` (short label) instead of full `description` to `autoRegisterFileExistenceDataSources`
- File path regex couldn't find `hello.ts` in the title → no DataSource → no mechanical observation
- One-line fix: `title` → `opts.description || title`

🤖 Generated with [Claude Code](https://claude.com/claude-code)