### PR TITLE
fix: skip jump suppression for present/match binary dimensions

### DIFF
--- a/src/observation/observation-llm.ts
+++ b/src/observation/observation-llm.ts
@@ -351,7 +351,9 @@ export async function observeWithLLM(
   try {
     const th = JSON.parse(thresholdDescription);
     isBinaryThreshold = th.type === "present" || th.type === "match";
-  } catch { /* keep false */ }
+  } catch (err) {
+    logger?.warn(`[ObservationEngine] Failed to parse thresholdDescription for binary check: ${String(err)}`);
+  }
 
   let resolvedLayer: "self_report" | "independent_review";
   let resolvedConfidence: number;
@@ -370,7 +372,7 @@ export async function observeWithLLM(
     resolvedConfidence = hasContext ? 0.70 : (scorePreservedFromPrevious ? 0.30 : 0.10);
   }
   if (
-    !isBinaryThreshold &&
+    !(isBinaryThreshold && hasContext) &&
     typeof previousScore === "number" &&
     previousScore !== null &&
     Math.abs(score - previousScore) > MAX_SCORE_DELTA

--- a/tests/observation-llm-guard.test.ts
+++ b/tests/observation-llm-guard.test.ts
@@ -467,6 +467,31 @@ describe("§3.3: Jump suppression bypass for present/match threshold types", () 
       expect.stringContaining("score jump suppressed")
     );
   });
+
+  it("match threshold: 0→1 jump IS suppressed when no workspace evidence", async () => {
+    const gitContextFetcher = vi.fn().mockReturnValue("");
+    const mockLLM = createMockLLMClient(1.0, "Target found");
+    const logger = makeLogger();
+    const entry = await observeWithLLM(
+      "goal1",
+      "greet_exported",
+      "Create hello.ts",
+      "greet exported",
+      JSON.stringify({ type: "match", value: "export function greet" }),
+      mockLLM,
+      { gitContextFetcher },
+      noopApply,
+      undefined, // contextOutput — no evidence
+      0.0,       // previousScore
+      true,
+      logger
+    );
+    // With no evidence, binary bypass should NOT apply — jump suppression fires
+    expect(entry.extracted_value).toBe(0.0);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("score jump suppressed")
+    );
+  });
 });
 
 // ─── readWorkspaceFiles helper ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Score jump suppression (§3.3, ±0.4/cycle limit) was blocking valid 0→1 transitions for `present` and `match` dimensions
- These dimension types are binary — the natural transition when a task completes is 0→1 (delta=1.0), which exceeds the 0.4 limit
- This caused `match` dimensions to stay permanently at score=0 even after the target was achieved

## Root Cause
In dogfooding, `greet_function_exported` (match type) showed:
- LLM reason: "hello.ts contains export function greet, so the target is achieved"
- LLM score: 0 (suppressed from 1.0 because |1.0 - 0.0| > 0.4)
- Result: gap=1.00 permanently stuck

## Fix
Parse `thresholdDescription` to detect `present`/`match` types and skip jump suppression for these binary dimensions. Continuous dimensions (`min`/`max`/`range`) retain the ±0.4 suppression as intended.

## Test plan
- [x] match threshold: 0→1 jump NOT suppressed
- [x] present threshold: 0→1 jump NOT suppressed
- [x] min threshold: 0→1 jump still suppressed (existing behavior preserved)
- [x] 20/20 observation-llm-guard tests pass
- [x] Full suite: 5024 pass (2 flaky timeout in event-file-watcher — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>