### PR TITLE
feat: proactive foundation (Phase A)

### DIFF
--- a/docs/design/cc-inspired-improvements.md
+++ b/docs/design/cc-inspired-improvements.md
@@ -1,0 +1,308 @@
+# PulSeed Improvement Plan — Inspired by Claude Code Architecture
+
+> Date: 2026-04-01
+> Source: Claude Code source analysis (KAIROS, orchestration, autonomous features, tool/plugin system)
+> Goal: "常駐AIエージェントはPulSeedだけと対話すれば十分"
+
+## Executive Summary
+
+Claude Code's KAIROS subsystem is a proactive "assistant mode" that transforms a reactive CLI into an always-on autonomous agent — exactly what PulSeed aspires to be at a higher level. Key adoptable patterns: (1) **Proactive Tick Loop** for idle-time initiative, (2) **MCP dual-role** (client+server) for universal tool integration, (3) **Hook lifecycle events** for deep extensibility, (4) **Dream/catch-up/morning-checkin** scheduled self-reflection, and (5) **BriefTool** pattern for unsolicited user updates. PulSeed's unique strength — the goal→gap→drive→satisfice loop — has no equivalent in Claude Code and should remain the core differentiator.
+
+---
+
+## Part 1: What Claude Code Does That PulSeed Should Adopt
+
+### 1.1 Proactive Tick Loop (Impact: ★★★★★)
+
+**What CC does:**
+- KAIROS injects `<tick>` XML prompts into the conversation while idle
+- Agent is instructed: "do whatever seems most useful, or call Sleep"
+- `SleepTool` provides explicit pacing — agent decides when to rest
+- Context-blocked flag prevents runaway error loops
+- `sleep_progress` is ephemeral (not sent to API) to avoid context pollution
+
+**What PulSeed should do:**
+- PulSeed already has CoreLoop's observe→gap→score→task→execute→verify cycle
+- **Add idle-tick injection** between CoreLoop cycles: when no active tasks exist, inject a `<tick>` to the LLM asking "given current goals and state, what should I proactively work on?"
+- This bridges the gap between PulSeed's structured loop and CC's freeform initiative
+- Implement `SleepScheduler` — adaptive sleep duration based on:
+  - Time of day (night = longer sleep)
+  - Goal urgency (high-gap goals = shorter sleep)
+  - Recent activity (many completions = check for new work)
+  - Token budget (low budget = longer sleep)
+
+**Complexity:** Medium — hooks into existing CoreLoop idle path
+
+---
+
+### 1.2 MCP Dual-Role Integration (Impact: ★★★★★)
+
+**What CC does:**
+- Acts as MCP **client** — connects to external MCP servers (Slack, Gmail, Calendar, memory, etc.)
+- Acts as MCP **server** — exposes itself as an MCP server for other tools to consume
+- `ToolSearchTool` provides deferred/lazy tool discovery
+- Tool naming: `mcp__<server>__<tool>`
+
+**What PulSeed should do:**
+- **PulSeed as MCP client**: Connect to MCP servers for:
+  - Slack/Gmail/Calendar (notifications, context gathering)
+  - GitHub (issue tracking, PR status)
+  - Custom data sources (replaces current DataSourceAdapter)
+- **PulSeed as MCP server**: Expose PulSeed's capabilities as MCP tools:
+  - `pulseed_goal_status` — query goal progress
+  - `pulseed_create_goal` — create new goals
+  - `pulseed_observe` — trigger observation
+  - `pulseed_knowledge_query` — semantic knowledge search
+- This makes PulSeed **the hub** — any MCP-compatible agent can consume PulSeed's orchestration
+- Replace current `DataSourceAdapter` with MCP client protocol (backwards-compatible adapter wrapper)
+
+**Complexity:** Large — new protocol layer, but MCP SDK exists
+
+---
+
+### 1.3 Scheduled Self-Reflection (Impact: ★★★★☆)
+
+**What CC does:**
+- KAIROS installs 3 permanent cron tasks:
+  - `catch-up` — review what happened since last check
+  - `morning-checkin` — daily planning/prioritization
+  - `dream` — background memory consolidation
+- Cron scheduler: 1s polling, chokidar file-watch, per-project lock
+- Jitter: 10% period variance (load-shedding)
+- 7-day auto-expiry (except `permanent: true`)
+
+**What PulSeed should do:**
+- **Morning Planning**: Daily goal review → re-prioritize → suggest new goals
+  - "Your test coverage goal is at 82% (target 90%). 3 uncovered files identified."
+  - "Issue #247 has been open 5 days. Should I investigate?"
+- **Evening Catch-up**: Summarize day's progress, flag stalls, update knowledge
+- **Dream (Memory Consolidation)**: Run KnowledgeManager consolidation, update VectorIndex, prune stale knowledge, generate hypotheses
+- **Weekly Review**: Cross-goal portfolio analysis, strategy effectiveness scoring
+- PulSeed already has `MemoryLifecycleManager` — wire it to cron-scheduled dream cycles
+- Add `CronScheduler` module (simple: node-cron or custom, with jitter)
+
+**Complexity:** Medium — infrastructure exists, needs scheduling + prompt design
+
+---
+
+### 1.4 Hook Lifecycle System (Impact: ★★★★☆)
+
+**What CC does:**
+- 27 lifecycle hook events (PreToolUse, PostToolUse, SessionStart, SessionEnd, etc.)
+- 4 hook types: command (shell), prompt (LLM), http, agent (mini-verifier)
+- Hooks can approve/deny/modify tool input, inject context, mutate output
+- Conditional execution via `if` field with permission rule syntax
+- Agent-scoped hooks via frontmatter
+
+**What PulSeed should do:**
+- Current plugin system (`PluginLoader`, `NotifierRegistry`) is output-only (notifications)
+- **Expand to lifecycle hooks:**
+  - `PreObserve` / `PostObserve` — modify observation before/after LLM call
+  - `PreTaskCreate` / `PostTaskCreate` — validate/enrich task creation
+  - `PreExecute` / `PostExecute` — approve/log adapter invocations
+  - `PreGapCalculation` / `PostGapCalculation` — inject custom gap modifiers
+  - `GoalStateChange` — react to goal completion/stall/failure
+  - `LoopCycleStart` / `LoopCycleEnd` — per-cycle instrumentation
+- Hook types: shell command, HTTP webhook, TypeScript function
+- This enables: CI/CD integration, external monitoring, custom approval flows, Slack notifications on goal completion
+
+**Complexity:** Medium — extend existing plugin architecture
+
+---
+
+### 1.5 BriefTool / Proactive Notification (Impact: ★★★☆☆)
+
+**What CC does:**
+- `SendUserMessage` / `BriefTool` — surfaces unsolicited updates to users
+- `status: 'proactive'` distinguishes unsolicited vs. reply messages
+- In brief view, normal output is hidden — only BriefTool messages shown
+
+**What PulSeed should do:**
+- Current `NotificationDispatcher` sends notifications but is fire-and-forget
+- **Add proactive update channel:**
+  - Priority levels: `info` (progress), `warning` (stall detected), `action_required` (needs approval)
+  - Delivery targets: TUI toast, Web UI push, Slack DM, email digest
+  - Smart batching: don't spam — aggregate low-priority updates into periodic digests
+  - User preference: configurable notification frequency per goal/priority
+- Wire into scheduled self-reflection outputs
+
+**Complexity:** Small-Medium — extends existing NotificationDispatcher
+
+---
+
+### 1.6 Remote Trigger API (Impact: ★★★☆☆)
+
+**What CC does:**
+- `RemoteTriggerTool` — external systems can wake/trigger the agent
+- Bridge system enables `remote-control` via WebSocket
+- `control_request` messages from IDE/Web trigger actions
+
+**What PulSeed should do:**
+- **HTTP trigger endpoint**: `POST /api/trigger` with payload:
+  - `{ event: "github_push", repo: "...", data: {...} }`
+  - `{ event: "slack_mention", channel: "...", message: "..." }`
+  - `{ event: "schedule", task: "morning_checkin" }`
+- PulSeed daemon receives trigger → maps to goal/task → executes
+- This makes PulSeed reactive to external events (GitHub webhooks, Slack bot, CI failures)
+- Integrate with existing `EventServer` module
+
+**Complexity:** Medium — extends DaemonRunner + EventServer
+
+---
+
+### 1.7 Agent Definition via Markdown Frontmatter (Impact: ★★☆☆☆)
+
+**What CC does:**
+- `.claude/agents/*.md` files define custom agents
+- Frontmatter specifies: tools, model, permissions, MCP servers, hooks, memory scope
+- Priority: builtin → plugin → user → project → flag → policy
+
+**What PulSeed should do:**
+- Current adapter configuration is in `~/.pulseed/provider.json` (flat config)
+- **Add `.pulseed/agents/*.md` for custom agent profiles:**
+  - Define agent capabilities, preferred tools, cost budget, specialization
+  - Example: `research-agent.md` with `model: gpt-5.4-mini`, `tools: [web_search, file_read]`
+  - Example: `code-agent.md` with `model: claude-opus`, `tools: [shell, file_edit]`, `budget: 50000_tokens`
+- Lower barrier for users to define domain-specific agents
+
+**Complexity:** Small — config parsing + adapter selection
+
+---
+
+## Part 2: What PulSeed Already Does (Validation)
+
+| Capability | Claude Code | PulSeed | Comparison |
+|-----------|-------------|---------|------------|
+| Core loop | Reactive (user→response) + KAIROS tick | Observe→gap→score→task→execute→verify | **PulSeed stronger** — structured, goal-driven |
+| Multi-agent | Coordinator/Swarm/Fork patterns | AdapterLayer + multi-strategy portfolio | **Comparable** — different abstraction level |
+| Session persistence | `~/.claude/sessions/` | `~/.pulseed/` state files | **Comparable** |
+| Knowledge/Memory | Auto-memory + MEMORY.md + dream | KnowledgeManager + VectorIndex + hierarchical memory | **PulSeed stronger** — semantic, hierarchical |
+| Trust/Safety | Permission modes + EthicsGate-like hooks | TrustManager + EthicsGate + approval flows | **PulSeed stronger** — quantified trust balance |
+| Goal management | None (user-driven) | GoalTree + negotiation + decomposition | **PulSeed unique** |
+| Gap detection | None | GapCalculator + 5 threshold types | **PulSeed unique** |
+| Drive/Motivation | None | DriveSystem + DriveScorer | **PulSeed unique** |
+| Satisficing | None | SatisficingJudge | **PulSeed unique** |
+| Stall detection | None | StallDetector + strategy rotation | **PulSeed unique** |
+| Plugin system | Rich (tools, agents, skills, hooks, MCP) | PluginLoader + NotifierRegistry | **CC stronger** |
+| Tool extensibility | 27 lifecycle hooks, MCP dual-role | DataSourceAdapter, limited hooks | **CC much stronger** |
+
+---
+
+## Part 3: PulSeed's Unique Strengths (Preserve & Amplify)
+
+1. **Goal→Gap→Drive loop** — No equivalent in CC. This IS PulSeed's moat.
+2. **Quantified trust** — CC has binary permission modes; PulSeed has [-100,+100] asymmetric scoring.
+3. **Satisficing** — CC optimizes endlessly; PulSeed knows when to stop.
+4. **Strategy rotation** — CC has no concept of trying alternative approaches on stall.
+5. **Portfolio management** — CC manages one task at a time; PulSeed orchestrates parallel goal pursuit.
+6. **Knowledge graph + embeddings** — CC has flat memory; PulSeed has hierarchical semantic memory.
+
+---
+
+## Architecture: PulSeed as "The Single Interface"
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    USER INTERFACE                         │
+│  TUI (Ink)  │  Web UI (Next.js)  │  Slack Bot  │  API   │
+└──────────────────────┬──────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────┐
+│                  PULSEED CORE                            │
+│                                                          │
+│  ┌─────────┐  ┌──────────┐  ┌───────────┐              │
+│  │ CronSch │  │ CoreLoop │  │ TriggerAPI│              │
+│  │ eduler  │──│ observe  │──│ (HTTP/WS) │              │
+│  │         │  │ →gap→    │  │           │              │
+│  │ morning │  │ score→   │  │ GitHub WH │              │
+│  │ catchup │  │ task→    │  │ Slack evt │              │
+│  │ dream   │  │ execute→ │  │ CI/CD     │              │
+│  │ weekly  │  │ verify   │  │           │              │
+│  └─────────┘  └──────────┘  └───────────┘              │
+│       │            │              │                      │
+│  ┌────▼────────────▼──────────────▼─────┐               │
+│  │         HOOK LIFECYCLE               │               │
+│  │  Pre/PostObserve, Pre/PostExecute,   │               │
+│  │  GoalStateChange, LoopCycle*         │               │
+│  └──────────────────────────────────────┘               │
+│                    │                                     │
+│  ┌─────────────────▼────────────────────┐               │
+│  │          MCP CLIENT LAYER            │               │
+│  │  Slack │ Gmail │ Calendar │ GitHub   │               │
+│  │  Custom DataSources (via MCP)        │               │
+│  └──────────────────────────────────────┘               │
+│                    │                                     │
+│  ┌─────────────────▼────────────────────┐               │
+│  │         ADAPTER LAYER                │               │
+│  │  Claude Code │ Claude API │ Codex    │               │
+│  │  Custom Agents (.pulseed/agents/)    │               │
+│  └──────────────────────────────────────┘               │
+│                                                          │
+│  ┌──────────────────────────────────────┐               │
+│  │        MCP SERVER LAYER              │               │
+│  │  Expose: goal_status, create_goal,   │               │
+│  │  observe, knowledge_query, trigger   │               │
+│  │  → Any MCP client can consume        │               │
+│  └──────────────────────────────────────┘               │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Implementation Phases
+
+### Phase A: Foundation (2-3 weeks)
+| # | Item | Complexity | Dependencies |
+|---|------|-----------|--------------|
+| A1 | CronScheduler module | Small | None |
+| A2 | Scheduled self-reflection prompts (morning/evening/dream) | Medium | A1 |
+| A3 | Proactive tick injection in CoreLoop idle path | Medium | None |
+| A4 | SleepScheduler (adaptive sleep duration) | Small | A3 |
+
+### Phase B: Integration Hub (3-4 weeks)
+| # | Item | Complexity | Dependencies |
+|---|------|-----------|--------------|
+| B1 | MCP client layer (replace DataSourceAdapter) | Large | None |
+| B2 | MCP server layer (expose PulSeed as MCP server) | Medium | None |
+| B3 | Hook lifecycle system (Pre/Post events) | Medium | None |
+| B4 | Remote trigger API (HTTP endpoint) | Medium | None |
+
+### Phase C: Intelligence (2-3 weeks)
+| # | Item | Complexity | Dependencies |
+|---|------|-----------|--------------|
+| C1 | Proactive notification channel (smart batching) | Medium | A2, B3 |
+| C2 | Agent definition via Markdown frontmatter | Small | None |
+| C3 | Weekly review automation | Small | A1, A2 |
+| C4 | External event → goal/task mapping | Medium | B4 |
+
+### Phase D: Polish (1-2 weeks)
+| # | Item | Complexity | Dependencies |
+|---|------|-----------|--------------|
+| D1 | Slack bot integration (via MCP) | Medium | B1 |
+| D2 | Notification preferences UI (Web UI) | Small | C1 |
+| D3 | Agent profile marketplace concept | Small | C2 |
+
+---
+
+## Key Design Decisions to Make
+
+1. **CronScheduler implementation**: node-cron vs custom (CC uses custom 1s poll + chokidar)
+2. **MCP SDK choice**: `@modelcontextprotocol/sdk` (same as CC) — standard, well-maintained
+3. **Hook execution model**: sync (block loop) vs async (fire-and-forget) vs hybrid (configurable)
+4. **Trigger authentication**: API key vs JWT vs mTLS for remote trigger endpoint
+5. **Notification aggregation window**: how long to batch before sending digest?
+
+---
+
+## Summary: The "Single Interface" Vision
+
+After these improvements, PulSeed becomes:
+
+1. **Proactive** — doesn't wait for commands; plans mornings, catches up evenings, dreams at night
+2. **Connected** — consumes any MCP server (Slack, Gmail, GitHub, custom tools)
+3. **Consumable** — exposes itself as MCP server; any agent can use PulSeed's orchestration
+4. **Extensible** — 10+ lifecycle hooks for custom integrations
+5. **Reactive** — HTTP/WS triggers let external events wake PulSeed
+6. **Self-aware** — scheduled reflection keeps knowledge fresh and goals prioritized
+
+The user interacts with PulSeed. PulSeed orchestrates everything else.

--- a/src/reflection/dream-consolidation.ts
+++ b/src/reflection/dream-consolidation.ts
@@ -1,0 +1,78 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { writeJsonFileAtomic } from "../utils/json-io.js";
+import type { StateManager } from "../state-manager.js";
+import type { MemoryLifecycleManager } from "../knowledge/memory-lifecycle.js";
+import type { KnowledgeManager } from "../knowledge/knowledge-manager.js";
+import type { ConsolidationReport } from "./types.js";
+import { ConsolidationReportSchema } from "./types.js";
+
+// ─── Helpers ───
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ─── Main ───
+
+export async function runDreamConsolidation(deps: {
+  stateManager: StateManager;
+  memoryLifecycle?: MemoryLifecycleManager;
+  knowledgeManager?: KnowledgeManager;
+  baseDir: string;
+}): Promise<ConsolidationReport> {
+  const { stateManager, memoryLifecycle, knowledgeManager, baseDir } = deps;
+  const date = todayISO();
+  const now = new Date().toISOString();
+
+  const goalIds = await stateManager.listGoalIds();
+  let entriesCompressed = 0;
+  let staleEntriesFound = 0;
+  let revalidationTasksCreated = 0;
+
+  // Compress short-term memory to long-term for each goal
+  const dataTypes = ["experience_log", "observation", "strategy", "task", "knowledge"] as const;
+  if (memoryLifecycle) {
+    for (const goalId of goalIds) {
+      for (const dataType of dataTypes) {
+        try {
+          const result = await memoryLifecycle.compressToLongTerm(goalId, dataType);
+          entriesCompressed += result.entries_compressed ?? 0;
+        } catch {
+          // Continue with other goals/types if one fails
+        }
+      }
+    }
+  }
+
+  // Check for stale knowledge entries and generate revalidation tasks
+  if (knowledgeManager) {
+    try {
+      const staleEntries = await knowledgeManager.getStaleEntries();
+      staleEntriesFound = staleEntries.length;
+
+      if (staleEntries.length > 0) {
+        const tasks = await knowledgeManager.generateRevalidationTasks(staleEntries);
+        revalidationTasksCreated = tasks.length;
+      }
+    } catch {
+      // Non-fatal — continue
+    }
+  }
+
+  const report = ConsolidationReportSchema.parse({
+    date,
+    created_at: now,
+    goals_consolidated: goalIds.length,
+    entries_compressed: entriesCompressed,
+    stale_entries_found: staleEntriesFound,
+    revalidation_tasks_created: revalidationTasksCreated,
+  });
+
+  // Persist report
+  const reflectionsDir = path.join(baseDir, "reflections");
+  await fsp.mkdir(reflectionsDir, { recursive: true });
+  await writeJsonFileAtomic(path.join(reflectionsDir, `dream-${date}.json`), report);
+
+  return report;
+}

--- a/src/reflection/evening-catchup.ts
+++ b/src/reflection/evening-catchup.ts
@@ -1,0 +1,140 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { writeJsonFileAtomic } from "../utils/json-io.js";
+import type { StateManager } from "../state-manager.js";
+import type { ILLMClient } from "../llm/llm-client.js";
+import type { INotificationDispatcher } from "../runtime/notification-dispatcher.js";
+import { z } from "zod";
+import type { CatchupReport, GoalSummary } from "./types.js";
+import { CatchupReportSchema } from "./types.js";
+
+// ─── LLM response schema ───
+
+const LLMCatchupResponseSchema = z.object({
+  progress_summary: z.string(),
+  completions: z.array(z.string()).default([]),
+  stalls: z.array(z.string()).default([]),
+  concerns: z.array(z.string()).default([]),
+});
+
+// ─── Helpers ───
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function loadGoalSummaries(stateManager: StateManager): Promise<GoalSummary[]> {
+  const goalIds = await stateManager.listGoalIds();
+  const summaries: GoalSummary[] = [];
+
+  for (const id of goalIds) {
+    const goal = await stateManager.loadGoal(id);
+    if (!goal || goal.status !== "active") continue;
+
+    const gapHistory = await stateManager.loadGapHistory(id);
+    const latest = gapHistory.at(-1);
+    const gapScore = latest
+      ? Math.max(...latest.gap_vector.map((g) => g.normalized_weighted_gap))
+      : 0;
+
+    summaries.push({
+      goal_id: goal.id,
+      title: goal.title,
+      status: goal.status,
+      gap_score: Math.min(1, Math.max(0, gapScore)),
+      stall_level: 0,
+      dimensions_count: goal.dimensions.length,
+    });
+  }
+
+  return summaries;
+}
+
+// ─── Main ───
+
+export async function runEveningCatchup(deps: {
+  stateManager: StateManager;
+  llmClient: ILLMClient;
+  baseDir: string;
+  notificationDispatcher?: INotificationDispatcher;
+}): Promise<CatchupReport> {
+  const { stateManager, llmClient, baseDir, notificationDispatcher } = deps;
+  const date = todayISO();
+  const now = new Date().toISOString();
+
+  const goalSummaries = await loadGoalSummaries(stateManager);
+
+  let progressSummary = "No active goals to review.";
+  let completions: string[] = [];
+  let stalls: string[] = [];
+  let concerns: string[] = [];
+
+  if (goalSummaries.length > 0) {
+    // Load morning report if available for comparison
+    const morningPath = path.join(baseDir, "reflections", `morning-${date}.json`);
+    let morningData: unknown = null;
+    try {
+      const raw = await fsp.readFile(morningPath, "utf-8");
+      morningData = JSON.parse(raw);
+    } catch {
+      // No morning report available
+    }
+
+    const prompt = `You are PulSeed's evening catch-up assistant. Review today's goal progress.
+
+Current goal state:
+${JSON.stringify(goalSummaries, null, 2)}
+
+${morningData ? `Morning plan:\n${JSON.stringify(morningData, null, 2)}\n` : ""}
+
+Summarize the day's progress. List any completions, stalls, or concerns.
+
+Respond with JSON:
+{ "progress_summary": string, "completions": [string], "stalls": [string], "concerns": [string] }`;
+
+    try {
+      const response = await llmClient.sendMessage([{ role: "user", content: prompt }]);
+      const parsed = llmClient.parseJSON(response.content, LLMCatchupResponseSchema);
+      progressSummary = parsed.progress_summary;
+      completions = parsed.completions ?? [];
+      stalls = parsed.stalls ?? [];
+      concerns = parsed.concerns ?? [];
+    } catch {
+      // LLM error — return partial report
+      progressSummary = "Unable to generate summary due to LLM error.";
+    }
+  }
+
+  const report = CatchupReportSchema.parse({
+    date,
+    created_at: now,
+    goals_reviewed: goalSummaries.length,
+    progress_summary: progressSummary,
+    completions,
+    stalls,
+    concerns,
+  });
+
+  // Persist report
+  const reflectionsDir = path.join(baseDir, "reflections");
+  await fsp.mkdir(reflectionsDir, { recursive: true });
+  await writeJsonFileAtomic(path.join(reflectionsDir, `evening-${date}.json`), report);
+
+  // Notify
+  if (notificationDispatcher && goalSummaries.length > 0) {
+    const now2 = new Date().toISOString();
+    await notificationDispatcher.dispatch({
+      id: `evening-catchup-${date}`,
+      report_type: "daily_summary",
+      goal_id: null,
+      title: `Evening Catch-up — ${date}`,
+      content: progressSummary,
+      verbosity: "standard",
+      generated_at: now2,
+      delivered_at: null,
+      read: false,
+    });
+  }
+
+  return report;
+}

--- a/src/reflection/index.ts
+++ b/src/reflection/index.ts
@@ -1,0 +1,15 @@
+export { runMorningPlanning } from "./morning-planning.js";
+export { runEveningCatchup } from "./evening-catchup.js";
+export { runDreamConsolidation } from "./dream-consolidation.js";
+export type {
+  GoalSummary,
+  PlanningReport,
+  CatchupReport,
+  ConsolidationReport,
+} from "./types.js";
+export {
+  GoalSummarySchema,
+  PlanningReportSchema,
+  CatchupReportSchema,
+  ConsolidationReportSchema,
+} from "./types.js";

--- a/src/reflection/morning-planning.ts
+++ b/src/reflection/morning-planning.ts
@@ -1,0 +1,133 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { writeJsonFileAtomic } from "../utils/json-io.js";
+import type { StateManager } from "../state-manager.js";
+import type { ILLMClient } from "../llm/llm-client.js";
+import type { INotificationDispatcher } from "../runtime/notification-dispatcher.js";
+import { z } from "zod";
+import type { PlanningReport, GoalSummary } from "./types.js";
+import { PlanningReportSchema } from "./types.js";
+
+// ─── LLM response schema ───
+
+const LLMPlanningResponseSchema = z.object({
+  priorities: z.array(
+    z.object({
+      goal_id: z.string(),
+      priority: z.enum(["high", "medium", "low"]),
+      reasoning: z.string(),
+    })
+  ),
+  suggestions: z.array(z.string()).default([]),
+  concerns: z.array(z.string()).default([]),
+});
+
+// ─── Helpers ───
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function aggregateGapScore(gaps: Array<{ normalized_weighted_gap: number }>): number {
+  if (gaps.length === 0) return 0;
+  return Math.max(...gaps.map((g) => g.normalized_weighted_gap));
+}
+
+async function buildGoalSummaries(stateManager: StateManager): Promise<GoalSummary[]> {
+  const goalIds = await stateManager.listGoalIds();
+  const summaries: GoalSummary[] = [];
+
+  for (const id of goalIds) {
+    const goal = await stateManager.loadGoal(id);
+    if (!goal || goal.status !== "active") continue;
+
+    const gapHistory = await stateManager.loadGapHistory(id);
+    const latest = gapHistory.at(-1);
+    const gapScore = latest ? aggregateGapScore(latest.gap_vector) : 0;
+
+    summaries.push({
+      goal_id: goal.id,
+      title: goal.title,
+      status: goal.status,
+      gap_score: Math.min(1, Math.max(0, gapScore)),
+      stall_level: 0,
+      dimensions_count: goal.dimensions.length,
+    });
+  }
+
+  return summaries;
+}
+
+// ─── Main ───
+
+export async function runMorningPlanning(deps: {
+  stateManager: StateManager;
+  llmClient: ILLMClient;
+  baseDir: string;
+  notificationDispatcher?: INotificationDispatcher;
+}): Promise<PlanningReport> {
+  const { stateManager, llmClient, baseDir, notificationDispatcher } = deps;
+  const date = todayISO();
+  const now = new Date().toISOString();
+
+  const goalSummaries = await buildGoalSummaries(stateManager);
+
+  let priorities: PlanningReport["priorities"] = [];
+  let suggestions: string[] = [];
+  let concerns: string[] = [];
+
+  if (goalSummaries.length > 0) {
+    const prompt = `You are PulSeed's morning planner. Review these active goals and create a daily plan.
+
+Goals:
+${JSON.stringify(goalSummaries, null, 2)}
+
+For each goal, assign priority (high/medium/low) with reasoning.
+List any suggestions for new actions or concerns.
+
+Respond with JSON matching this schema:
+{ "priorities": [{"goal_id": string, "priority": "high"|"medium"|"low", "reasoning": string}], "suggestions": [string], "concerns": [string] }`;
+
+    try {
+      const response = await llmClient.sendMessage([{ role: "user", content: prompt }]);
+      const parsed = llmClient.parseJSON(response.content, LLMPlanningResponseSchema);
+      priorities = parsed.priorities;
+      suggestions = parsed.suggestions ?? [];
+      concerns = parsed.concerns ?? [];
+    } catch {
+      // LLM error — return partial report with empty priorities
+    }
+  }
+
+  const report = PlanningReportSchema.parse({
+    date,
+    created_at: now,
+    goals_reviewed: goalSummaries.length,
+    priorities,
+    suggestions,
+    concerns,
+  });
+
+  // Persist report
+  const reflectionsDir = path.join(baseDir, "reflections");
+  await fsp.mkdir(reflectionsDir, { recursive: true });
+  await writeJsonFileAtomic(path.join(reflectionsDir, `morning-${date}.json`), report);
+
+  // Notify
+  if (notificationDispatcher && goalSummaries.length > 0) {
+    const now2 = new Date().toISOString();
+    await notificationDispatcher.dispatch({
+      id: `morning-planning-${date}`,
+      report_type: "daily_summary",
+      goal_id: null,
+      title: `Morning Planning — ${date}`,
+      content: `Reviewed ${goalSummaries.length} goals. ${concerns.length} concern(s).`,
+      verbosity: "standard",
+      generated_at: now2,
+      delivered_at: null,
+      read: false,
+    });
+  }
+
+  return report;
+}

--- a/src/reflection/types.ts
+++ b/src/reflection/types.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+// ─── GoalSummary ───
+
+export const GoalSummarySchema = z.object({
+  goal_id: z.string(),
+  title: z.string(),
+  status: z.string(),
+  gap_score: z.number().min(0).max(1),
+  stall_level: z.number().int().min(0).max(3),
+  dimensions_count: z.number().int().min(0),
+});
+export type GoalSummary = z.infer<typeof GoalSummarySchema>;
+
+// ─── PlanningReport ───
+
+export const PlanningReportSchema = z.object({
+  date: z.string(),
+  created_at: z.string(),
+  goals_reviewed: z.number().int().min(0),
+  priorities: z.array(
+    z.object({
+      goal_id: z.string(),
+      priority: z.enum(["high", "medium", "low"]),
+      reasoning: z.string(),
+    })
+  ),
+  suggestions: z.array(z.string()),
+  concerns: z.array(z.string()),
+});
+export type PlanningReport = z.infer<typeof PlanningReportSchema>;
+
+// ─── CatchupReport ───
+
+export const CatchupReportSchema = z.object({
+  date: z.string(),
+  created_at: z.string(),
+  goals_reviewed: z.number().int().min(0),
+  progress_summary: z.string(),
+  completions: z.array(z.string()),
+  stalls: z.array(z.string()),
+  concerns: z.array(z.string()),
+});
+export type CatchupReport = z.infer<typeof CatchupReportSchema>;
+
+// ─── ConsolidationReport ───
+
+export const ConsolidationReportSchema = z.object({
+  date: z.string(),
+  created_at: z.string(),
+  goals_consolidated: z.number().int().min(0),
+  entries_compressed: z.number().int().min(0),
+  stale_entries_found: z.number().int().min(0),
+  revalidation_tasks_created: z.number().int().min(0),
+});
+export type ConsolidationReport = z.infer<typeof ConsolidationReportSchema>;

--- a/src/runtime/cron-scheduler.ts
+++ b/src/runtime/cron-scheduler.ts
@@ -1,0 +1,105 @@
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { CronExpressionParser } from "cron-parser";
+import { writeJsonFileAtomic, readJsonFileOrNull } from "../utils/json-io.js";
+import { CronTaskSchema, CronTaskListSchema, type CronTask } from "../types/cron.js";
+
+const TASKS_FILE = "scheduled-tasks.json";
+const EXPIRY_DAYS = 7;
+const JITTER_FACTOR = 0.05; // ±5%
+
+export class CronScheduler {
+  private tasksPath: string;
+
+  constructor(baseDir: string) {
+    this.tasksPath = path.join(baseDir, TASKS_FILE);
+  }
+
+  async loadTasks(): Promise<CronTask[]> {
+    const raw = await readJsonFileOrNull(this.tasksPath);
+    if (raw === null) return [];
+    const result = CronTaskListSchema.safeParse(raw);
+    return result.success ? result.data : [];
+  }
+
+  async saveTasks(tasks: CronTask[]): Promise<void> {
+    await writeJsonFileAtomic(this.tasksPath, tasks);
+  }
+
+  async addTask(task: Omit<CronTask, "id" | "created_at">): Promise<CronTask> {
+    const tasks = await this.loadTasks();
+    const newTask = CronTaskSchema.parse({
+      ...task,
+      id: randomUUID(),
+      created_at: new Date().toISOString(),
+    });
+    tasks.push(newTask);
+    await this.saveTasks(tasks);
+    return newTask;
+  }
+
+  async removeTask(id: string): Promise<boolean> {
+    const tasks = await this.loadTasks();
+    const filtered = tasks.filter((t) => t.id !== id);
+    if (filtered.length === tasks.length) return false;
+    await this.saveTasks(filtered);
+    return true;
+  }
+
+  async getDueTasks(): Promise<CronTask[]> {
+    const tasks = await this.loadTasks();
+    const now = new Date();
+    const due: CronTask[] = [];
+
+    for (const task of tasks) {
+      if (!task.enabled) continue;
+      if (!isDue(task, now)) continue;
+      due.push(task);
+    }
+
+    return due;
+  }
+
+  async markFired(id: string): Promise<void> {
+    const tasks = await this.loadTasks();
+    const updated = tasks.map((t) =>
+      t.id === id ? { ...t, last_fired_at: new Date().toISOString() } : t
+    );
+    await this.saveTasks(updated);
+  }
+
+  async expireOldTasks(): Promise<void> {
+    const tasks = await this.loadTasks();
+    const cutoff = Date.now() - EXPIRY_DAYS * 24 * 60 * 60 * 1000;
+    const kept = tasks.filter(
+      (t) => t.permanent || new Date(t.created_at).getTime() >= cutoff
+    );
+    await this.saveTasks(kept);
+  }
+}
+
+// ─── Helpers ───
+
+function isDue(task: CronTask, now: Date): boolean {
+  try {
+    const interval = CronExpressionParser.parse(task.cron, { currentDate: now });
+    const prevFire = interval.prev();
+
+    // Apply ±5% jitter based on cron interval width
+    const nextFire = interval.next();
+    const intervalMs = nextFire.getTime() - prevFire.getTime();
+    const jitterMs = intervalMs * JITTER_FACTOR * (Math.random() * 2 - 1);
+    const adjustedPrev = new Date(prevFire.getTime() + jitterMs);
+
+    // If never fired, task is due if the adjusted prev fire is in the past
+    if (task.last_fired_at === null) {
+      return adjustedPrev.getTime() <= now.getTime();
+    }
+
+    // Task is due if it hasn't been fired since the last scheduled time
+    const lastFired = new Date(task.last_fired_at).getTime();
+    return lastFired < adjustedPrev.getTime();
+  } catch {
+    return false;
+  }
+}

--- a/src/runtime/daemon-runner.ts
+++ b/src/runtime/daemon-runner.ts
@@ -12,6 +12,8 @@ import type { EventServer } from "./event-server.js";
 import type { PulSeedEvent } from "../types/drive.js";
 import type { DaemonConfig, DaemonState } from "../types/daemon.js";
 import { DaemonConfigSchema, DaemonStateSchema } from "../types/daemon.js";
+import type { ILLMClient } from "../llm/llm-client.js";
+import { z } from "zod";
 
 // ─── ShutdownMarker ───
 //
@@ -50,6 +52,7 @@ export interface DaemonDeps {
   logger: Logger;
   config?: Partial<DaemonConfig>;
   eventServer?: EventServer;
+  llmClient?: ILLMClient;
 }
 
 export class DaemonRunner {
@@ -68,6 +71,9 @@ export class DaemonRunner {
   private sleepAbortController: AbortController | null = null;
   private currentGoalIds: string[] = [];
   private currentLoopIndex = 0;
+  private lastProactiveTickAt: number = 0;
+  private llmClient: ILLMClient | undefined;
+  private consecutiveIdleCycles: number = 0;
 
   constructor(deps: DaemonDeps) {
     this.coreLoop = deps.coreLoop;
@@ -76,6 +82,8 @@ export class DaemonRunner {
     this.pidManager = deps.pidManager;
     this.logger = deps.logger;
     this.eventServer = deps.eventServer;
+    this.llmClient = deps.llmClient;
+    this.lastProactiveTickAt = Date.now();
 
     // Parse config with defaults via DaemonConfigSchema.parse()
     this.config = DaemonConfigSchema.parse(deps.config ?? {});
@@ -271,9 +279,28 @@ export class DaemonRunner {
         // 3. Save state
         await this.saveDaemonState();
 
-        // 4. Wait for next check interval
+        // 4. Proactive tick: fire when no goals activated and proactive_mode is enabled
+        if (this.running && activeGoals.length === 0) {
+          await this.proactiveTick();
+        }
+
+        // 5. Track idle cycles for adaptive sleep
+        if (activeGoals.length > 0) {
+          this.consecutiveIdleCycles = 0;
+        } else {
+          this.consecutiveIdleCycles++;
+        }
+
+        // 6. Wait for next check interval
         if (this.running) {
-          const intervalMs = this.getNextInterval(goalIds);
+          const baseIntervalMs = this.getNextInterval(goalIds);
+          const maxGapScore = await this.getMaxGapScore(goalIds);
+          const intervalMs = this.calculateAdaptiveInterval(
+            baseIntervalMs,
+            activeGoals.length,
+            maxGapScore,
+            this.consecutiveIdleCycles
+          );
           this.logger.debug(`Sleeping for ${intervalMs}ms until next check`);
           await this.sleep(intervalMs);
         }
@@ -503,6 +530,139 @@ export class DaemonRunner {
       event_type: event.type,
     });
     this.sleepAbortController?.abort();
+  }
+
+  // ─── Private: Proactive Tick ───
+
+  // Zod schema for the LLM proactive action response
+  private static readonly ProactiveResponseSchema = z.object({
+    action: z.enum(["suggest_goal", "investigate", "preemptive_check", "sleep"]),
+    details: z.record(z.string(), z.unknown()).optional(),
+  });
+
+  /**
+   * Ask the LLM for a proactive action when no goals were activated this cycle.
+   * Fires only if proactive_mode is enabled and enough time has passed since last tick.
+   * Errors are caught and logged — they never affect the daemon loop.
+   */
+  private async proactiveTick(): Promise<void> {
+    if (!this.config.proactive_mode) return;
+    if (!this.llmClient) return;
+    if (Date.now() - this.lastProactiveTickAt < this.config.proactive_interval_ms) return;
+
+    try {
+      // Build a brief summary of all tracked goals from daemon state
+      const goalSummaries = this.state.active_goals.length > 0
+        ? this.state.active_goals.map((id) => `- ${id}`).join("\n")
+        : "(no active goals)";
+
+      const prompt = `You are PulSeed's proactive engine. Given the current state of all goals:\n${goalSummaries}\n\nDecide what action to take:\n- "suggest_goal": A new goal should be created (provide title + description)\n- "investigate": Something needs investigation (provide what and why)\n- "preemptive_check": Run a pre-emptive observation (provide goal_id)\n- "sleep": Nothing needs attention right now\n\nRespond with JSON: { "action": "...", "details": { ... } }`;
+
+      const response = await this.llmClient.sendMessage(
+        [{ role: "user", content: prompt }],
+        { model_tier: "light" }
+      );
+
+      const parsed = DaemonRunner.ProactiveResponseSchema.safeParse(
+        this.llmClient.parseJSON(response.content, DaemonRunner.ProactiveResponseSchema)
+      );
+
+      if (!parsed.success) {
+        this.logger.warn("Proactive tick: failed to parse LLM response", {
+          raw: response.content,
+          error: parsed.error.message,
+        });
+        this.lastProactiveTickAt = Date.now();
+        return;
+      }
+
+      const { action, details } = parsed.data;
+
+      if (action === "sleep") {
+        this.logger.debug("Proactive tick: LLM decided to sleep");
+      } else {
+        this.logger.info(`Proactive tick: action=${action}`, { details });
+      }
+    } catch (err) {
+      this.logger.warn("Proactive tick: LLM error (ignored)", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    this.lastProactiveTickAt = Date.now();
+  }
+
+  // ─── Private: Adaptive Sleep ───
+
+  /**
+   * Get the highest gap score across all active goals.
+   * Falls back to 0 if no gap data is available.
+   */
+  private async getMaxGapScore(goalIds: string[]): Promise<number> {
+    let max = 0;
+    for (const goalId of goalIds) {
+      try {
+        const schedule = await this.driveSystem.getSchedule(goalId);
+        if (schedule && typeof (schedule as Record<string, unknown>)["last_gap_score"] === "number") {
+          const score = (schedule as Record<string, unknown>)["last_gap_score"] as number;
+          if (score > max) max = score;
+        }
+      } catch {
+        // Non-fatal — just use 0 for this goal
+      }
+    }
+    return max;
+  }
+
+  /**
+   * Calculate the adaptive sleep interval based on time-of-day, urgency, and activity.
+   * Returns baseInterval unchanged if adaptive_sleep is disabled.
+   */
+  calculateAdaptiveInterval(
+    baseInterval: number,
+    goalsActivatedThisCycle: number,
+    maxGapScore: number,
+    consecutiveIdleCycles: number
+  ): number {
+    const cfg = this.config.adaptive_sleep;
+    if (!cfg.enabled) return baseInterval;
+
+    // 1. Time-of-day factor
+    const hour = new Date().getHours();
+    const { night_start_hour, night_end_hour, night_multiplier } = cfg;
+    let timeOfDayFactor: number;
+    if (night_start_hour > night_end_hour) {
+      // Spans midnight: night is [night_start_hour, 24) ∪ [0, night_end_hour)
+      timeOfDayFactor = (hour >= night_start_hour || hour < night_end_hour) ? night_multiplier : 1.0;
+    } else {
+      // Same-day range
+      timeOfDayFactor = (hour >= night_start_hour && hour < night_end_hour) ? night_multiplier : 1.0;
+    }
+
+    // 2. Urgency factor
+    let urgencyFactor: number;
+    if (maxGapScore >= 0.8) {
+      urgencyFactor = 0.5;
+    } else if (maxGapScore >= 0.5) {
+      urgencyFactor = 0.75;
+    } else {
+      urgencyFactor = 1.0;
+    }
+
+    // 3. Activity factor
+    let activityFactor: number;
+    if (goalsActivatedThisCycle > 0) {
+      activityFactor = 0.75;
+    } else if (consecutiveIdleCycles >= 5) {
+      activityFactor = 1.5;
+    } else {
+      activityFactor = 1.0;
+    }
+
+    // 4. Apply factors and clamp
+    const effective = baseInterval * timeOfDayFactor * urgencyFactor * activityFactor;
+    const clamped = Math.max(cfg.min_interval_ms, Math.min(cfg.max_interval_ms, effective));
+    return Math.round(clamped);
   }
 
   // ─── Private: Shutdown Marker ───

--- a/src/types/cron.ts
+++ b/src/types/cron.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const CronTaskSchema = z.object({
+  id: z.string().uuid(),
+  cron: z.string(),
+  prompt: z.string(),
+  type: z.enum(["reflection", "consolidation", "custom"]),
+  enabled: z.boolean().default(true),
+  last_fired_at: z.string().datetime().nullable(),
+  permanent: z.boolean(),
+  created_at: z.string().datetime(),
+});
+
+export type CronTask = z.infer<typeof CronTaskSchema>;
+
+export const CronTaskListSchema = z.array(CronTaskSchema);

--- a/src/types/daemon.ts
+++ b/src/types/daemon.ts
@@ -16,6 +16,16 @@ export const DaemonConfigSchema = z.object({
     graceful_shutdown_timeout_ms: z.number().int().positive().optional(),
   }).default({}),
   goal_intervals: z.record(z.string(), z.number().int().positive()).optional(), // goal_id -> interval_ms override
+  proactive_mode: z.boolean().default(false),
+  proactive_interval_ms: z.number().default(3_600_000), // 1 hour minimum between proactive ticks
+  adaptive_sleep: z.object({
+    enabled: z.boolean().default(false),
+    min_interval_ms: z.number().default(60_000),      // 1 minute minimum
+    max_interval_ms: z.number().default(1_800_000),    // 30 minutes maximum
+    night_start_hour: z.number().default(22),           // 22:00
+    night_end_hour: z.number().default(7),              // 07:00
+    night_multiplier: z.number().default(2.0),          // 2x interval at night
+  }).default({}),
 });
 export type DaemonConfig = z.infer<typeof DaemonConfigSchema>;
 

--- a/tests/cron-scheduler.test.ts
+++ b/tests/cron-scheduler.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { CronScheduler } from "../src/runtime/cron-scheduler.js";
+import { makeTempDir, cleanupTempDir } from "./helpers/temp-dir.js";
+
+let tempDir: string;
+let scheduler: CronScheduler;
+
+beforeEach(() => {
+  tempDir = makeTempDir("cron-test-");
+  scheduler = new CronScheduler(tempDir);
+});
+
+afterEach(() => {
+  cleanupTempDir(tempDir);
+});
+
+// ─── addTask ───
+
+describe("addTask", () => {
+  it("assigns id and created_at automatically", async () => {
+    const task = await scheduler.addTask({
+      cron: "0 9 * * *",
+      prompt: "daily reflection",
+      type: "reflection",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+
+    expect(task.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(task.created_at).toBeTruthy();
+    expect(new Date(task.created_at).getTime()).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("persists added task", async () => {
+    await scheduler.addTask({
+      cron: "0 9 * * *",
+      prompt: "test",
+      type: "custom",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+
+    const tasks = await scheduler.loadTasks();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]!.prompt).toBe("test");
+  });
+
+  it("defaults enabled to true", async () => {
+    const task = await scheduler.addTask({
+      cron: "0 9 * * *",
+      prompt: "test",
+      type: "custom",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+    expect(task.enabled).toBe(true);
+  });
+});
+
+// ─── removeTask ───
+
+describe("removeTask", () => {
+  it("removes existing task and returns true", async () => {
+    const task = await scheduler.addTask({
+      cron: "0 9 * * *",
+      prompt: "to remove",
+      type: "custom",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+
+    const result = await scheduler.removeTask(task.id);
+    expect(result).toBe(true);
+    const tasks = await scheduler.loadTasks();
+    expect(tasks).toHaveLength(0);
+  });
+
+  it("returns false for non-existent id", async () => {
+    const result = await scheduler.removeTask("00000000-0000-0000-0000-000000000000");
+    expect(result).toBe(false);
+  });
+});
+
+// ─── getDueTasks ───
+
+describe("getDueTasks", () => {
+  it("returns task with last_fired_at=null (never fired)", async () => {
+    // A task that fires every minute with null last_fired_at is always due
+    await scheduler.addTask({
+      cron: "* * * * *",
+      prompt: "every minute",
+      type: "custom",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+
+    const due = await scheduler.getDueTasks();
+    expect(due).toHaveLength(1);
+  });
+
+  it("returns task whose last_fired_at is before previous cron fire time", async () => {
+    // Add a task with last_fired_at 2 minutes ago (should be due for * * * * *)
+    const twoMinutesAgo = new Date(Date.now() - 2 * 60 * 1000).toISOString();
+    await scheduler.addTask({
+      cron: "* * * * *",
+      prompt: "overdue",
+      type: "custom",
+      enabled: true,
+      last_fired_at: twoMinutesAgo,
+      permanent: false,
+    });
+
+    const due = await scheduler.getDueTasks();
+    expect(due).toHaveLength(1);
+  });
+
+  it("does not return task fired recently", async () => {
+    // last_fired_at = now (fired just now, next fire is ~1 minute away)
+    const now = new Date().toISOString();
+    await scheduler.addTask({
+      cron: "* * * * *",
+      prompt: "just fired",
+      type: "custom",
+      enabled: true,
+      last_fired_at: now,
+      permanent: false,
+    });
+
+    const due = await scheduler.getDueTasks();
+    expect(due).toHaveLength(0);
+  });
+
+  it("does not return disabled task", async () => {
+    await scheduler.addTask({
+      cron: "* * * * *",
+      prompt: "disabled",
+      type: "custom",
+      enabled: false,
+      last_fired_at: null,
+      permanent: false,
+    });
+
+    const due = await scheduler.getDueTasks();
+    expect(due).toHaveLength(0);
+  });
+
+  it("jitter does not prevent tasks from firing within reasonable window (2x interval)", async () => {
+    // A task that runs every minute, never fired — should virtually always be due
+    await scheduler.addTask({
+      cron: "* * * * *",
+      prompt: "jitter test",
+      type: "custom",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+
+    // Run getDueTasks multiple times — jitter is ±5% of 60s = ±3s max
+    // With last_fired_at=null a task should always be due
+    let dueCount = 0;
+    for (let i = 0; i < 10; i++) {
+      const due = await scheduler.getDueTasks();
+      dueCount += due.length;
+    }
+    expect(dueCount).toBe(10);
+  });
+});
+
+// ─── markFired ───
+
+describe("markFired", () => {
+  it("updates last_fired_at to approximately now", async () => {
+    const before = Date.now();
+    const task = await scheduler.addTask({
+      cron: "* * * * *",
+      prompt: "mark me",
+      type: "custom",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+
+    await scheduler.markFired(task.id);
+    const tasks = await scheduler.loadTasks();
+    const updated = tasks.find((t) => t.id === task.id)!;
+    expect(updated.last_fired_at).not.toBeNull();
+    expect(new Date(updated.last_fired_at!).getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  it("task no longer due immediately after being marked fired", async () => {
+    const task = await scheduler.addTask({
+      cron: "* * * * *",
+      prompt: "fire then check",
+      type: "custom",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+
+    await scheduler.markFired(task.id);
+    const due = await scheduler.getDueTasks();
+    expect(due.find((t) => t.id === task.id)).toBeUndefined();
+  });
+});
+
+// ─── expireOldTasks ───
+
+describe("expireOldTasks", () => {
+  it("removes non-permanent tasks older than 7 days", async () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const tasks = await scheduler.loadTasks();
+    // Directly save a task with old created_at
+    const oldTask = {
+      id: "11111111-1111-1111-1111-111111111111",
+      cron: "0 9 * * *",
+      prompt: "old task",
+      type: "custom" as const,
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+      created_at: eightDaysAgo,
+    };
+    await scheduler.saveTasks([...tasks, oldTask]);
+
+    await scheduler.expireOldTasks();
+    const remaining = await scheduler.loadTasks();
+    expect(remaining.find((t) => t.id === oldTask.id)).toBeUndefined();
+  });
+
+  it("keeps permanent tasks regardless of age", async () => {
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+    const permanentTask = {
+      id: "22222222-2222-2222-2222-222222222222",
+      cron: "0 9 * * *",
+      prompt: "permanent task",
+      type: "consolidation" as const,
+      enabled: true,
+      last_fired_at: null,
+      permanent: true,
+      created_at: eightDaysAgo,
+    };
+    await scheduler.saveTasks([permanentTask]);
+
+    await scheduler.expireOldTasks();
+    const remaining = await scheduler.loadTasks();
+    expect(remaining.find((t) => t.id === permanentTask.id)).toBeDefined();
+  });
+
+  it("keeps recent non-permanent tasks", async () => {
+    const task = await scheduler.addTask({
+      cron: "0 9 * * *",
+      prompt: "recent",
+      type: "reflection",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+
+    await scheduler.expireOldTasks();
+    const remaining = await scheduler.loadTasks();
+    expect(remaining.find((t) => t.id === task.id)).toBeDefined();
+  });
+});
+
+// ─── Persistence ───
+
+describe("persistence", () => {
+  it("save/load round-trip preserves all fields", async () => {
+    const task = await scheduler.addTask({
+      cron: "30 8 * * 1",
+      prompt: "weekly monday",
+      type: "reflection",
+      enabled: true,
+      last_fired_at: null,
+      permanent: true,
+    });
+
+    const scheduler2 = new CronScheduler(tempDir);
+    const tasks = await scheduler2.loadTasks();
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]).toMatchObject({
+      id: task.id,
+      cron: "30 8 * * 1",
+      prompt: "weekly monday",
+      type: "reflection",
+      enabled: true,
+      last_fired_at: null,
+      permanent: true,
+    });
+  });
+
+  it("returns empty array when file does not exist", async () => {
+    const tasks = await scheduler.loadTasks();
+    expect(tasks).toEqual([]);
+  });
+
+  it("multiple tasks survive round-trip", async () => {
+    await scheduler.addTask({
+      cron: "0 9 * * *",
+      prompt: "task 1",
+      type: "reflection",
+      enabled: true,
+      last_fired_at: null,
+      permanent: false,
+    });
+    await scheduler.addTask({
+      cron: "0 18 * * *",
+      prompt: "task 2",
+      type: "consolidation",
+      enabled: false,
+      last_fired_at: null,
+      permanent: true,
+    });
+
+    const scheduler2 = new CronScheduler(tempDir);
+    const tasks = await scheduler2.loadTasks();
+    expect(tasks).toHaveLength(2);
+    expect(tasks.map((t) => t.prompt).sort()).toEqual(["task 1", "task 2"]);
+  });
+});

--- a/tests/daemon-runner.test.ts
+++ b/tests/daemon-runner.test.ts
@@ -928,4 +928,440 @@ describe("DaemonRunner", () => {
       await expect(startPromise).resolves.toBeUndefined();
     });
   });
+
+  // ─── Proactive Tick ───
+
+  describe("proactive tick", () => {
+    function makeLLMClientMock(action: string, details: Record<string, unknown> = {}) {
+      const response = JSON.stringify({ action, details });
+      return {
+        sendMessage: vi.fn().mockResolvedValue({
+          content: response,
+          usage: { input_tokens: 10, output_tokens: 10 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn().mockReturnValue({ action, details }),
+      };
+    }
+
+    it("should fire proactive tick when no goals activated and interval elapsed", async () => {
+      const llmClient = makeLLMClientMock("sleep");
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 50,
+          proactive_mode: true,
+          proactive_interval_ms: 0, // always eligible
+        },
+        llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      });
+      // No goals should activate
+      (deps.driveSystem as { shouldActivate: ReturnType<typeof vi.fn> }).shouldActivate.mockReturnValue(false);
+
+      const daemon = new DaemonRunner(deps);
+      currentDaemon = daemon;
+      const startPromise = daemon.start(["goal-1"]);
+      currentStartPromise = startPromise;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      daemon.stop();
+      await startPromise;
+
+      expect(llmClient.sendMessage).toHaveBeenCalled();
+    });
+
+    it("should NOT fire proactive tick when proactive_mode is false", async () => {
+      const llmClient = makeLLMClientMock("sleep");
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 50,
+          proactive_mode: false,
+          proactive_interval_ms: 0,
+        },
+        llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      });
+      (deps.driveSystem as { shouldActivate: ReturnType<typeof vi.fn> }).shouldActivate.mockReturnValue(false);
+
+      const daemon = new DaemonRunner(deps);
+      currentDaemon = daemon;
+      const startPromise = daemon.start(["goal-1"]);
+      currentStartPromise = startPromise;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      daemon.stop();
+      await startPromise;
+
+      expect(llmClient.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("should NOT fire proactive tick when interval has not elapsed", async () => {
+      const llmClient = makeLLMClientMock("sleep");
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 50,
+          proactive_mode: true,
+          proactive_interval_ms: 9_999_999, // far future
+        },
+        llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      });
+      (deps.driveSystem as { shouldActivate: ReturnType<typeof vi.fn> }).shouldActivate.mockReturnValue(false);
+
+      const daemon = new DaemonRunner(deps);
+      currentDaemon = daemon;
+      const startPromise = daemon.start(["goal-1"]);
+      currentStartPromise = startPromise;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      daemon.stop();
+      await startPromise;
+
+      expect(llmClient.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("should NOT fire proactive tick when goals were activated", async () => {
+      const llmClient = makeLLMClientMock("sleep");
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 50,
+          proactive_mode: true,
+          proactive_interval_ms: 0,
+        },
+        llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      });
+      // Goals DO activate
+      (deps.driveSystem as { shouldActivate: ReturnType<typeof vi.fn> }).shouldActivate.mockReturnValue(true);
+
+      const daemon = new DaemonRunner(deps);
+      currentDaemon = daemon;
+      const startPromise = daemon.start(["goal-1"]);
+      currentStartPromise = startPromise;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      daemon.stop();
+      await startPromise;
+
+      expect(llmClient.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("should catch LLM error in proactive tick and not crash the daemon", async () => {
+      const llmClient = {
+        sendMessage: vi.fn().mockRejectedValue(new Error("LLM timeout")),
+        parseJSON: vi.fn(),
+      };
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 50,
+          proactive_mode: true,
+          proactive_interval_ms: 0,
+        },
+        llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      });
+      (deps.driveSystem as { shouldActivate: ReturnType<typeof vi.fn> }).shouldActivate.mockReturnValue(false);
+
+      const daemon = new DaemonRunner(deps);
+      currentDaemon = daemon;
+      const startPromise = daemon.start(["goal-1"]);
+      currentStartPromise = startPromise;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      daemon.stop();
+
+      // Daemon must resolve cleanly despite LLM error
+      await expect(startPromise).resolves.toBeUndefined();
+    });
+
+    it("should log suggest_goal action from proactive tick", async () => {
+      const llmClient = makeLLMClientMock("suggest_goal", { title: "New goal", description: "Do something" });
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 50,
+          proactive_mode: true,
+          proactive_interval_ms: 0,
+        },
+        llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      });
+      (deps.driveSystem as { shouldActivate: ReturnType<typeof vi.fn> }).shouldActivate.mockReturnValue(false);
+
+      const daemon = new DaemonRunner(deps);
+      currentDaemon = daemon;
+      const startPromise = daemon.start(["goal-1"]);
+      currentStartPromise = startPromise;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      daemon.stop();
+      await startPromise;
+
+      expect(llmClient.sendMessage).toHaveBeenCalled();
+    });
+
+    it("should handle investigate action from proactive tick without crashing", async () => {
+      const llmClient = makeLLMClientMock("investigate", { what: "goal-1 stalled", why: "no progress" });
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 50,
+          proactive_mode: true,
+          proactive_interval_ms: 0,
+        },
+        llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      });
+      (deps.driveSystem as { shouldActivate: ReturnType<typeof vi.fn> }).shouldActivate.mockReturnValue(false);
+
+      const daemon = new DaemonRunner(deps);
+      currentDaemon = daemon;
+      const startPromise = daemon.start(["goal-1"]);
+      currentStartPromise = startPromise;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      daemon.stop();
+
+      await expect(startPromise).resolves.toBeUndefined();
+    });
+
+    it("should handle preemptive_check action from proactive tick without crashing", async () => {
+      const llmClient = makeLLMClientMock("preemptive_check", { goal_id: "goal-1" });
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 50,
+          proactive_mode: true,
+          proactive_interval_ms: 0,
+        },
+        llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      });
+      (deps.driveSystem as { shouldActivate: ReturnType<typeof vi.fn> }).shouldActivate.mockReturnValue(false);
+
+      const daemon = new DaemonRunner(deps);
+      currentDaemon = daemon;
+      const startPromise = daemon.start(["goal-1"]);
+      currentStartPromise = startPromise;
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      daemon.stop();
+
+      await expect(startPromise).resolves.toBeUndefined();
+    });
+  });
+
+  // ─── Adaptive Sleep ───
+
+  describe("adaptive sleep", () => {
+    function makeDaemonWithAdaptiveSleep(overrides: Record<string, unknown> = {}): DaemonRunner {
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 300_000,
+          adaptive_sleep: {
+            enabled: true,
+            min_interval_ms: 60_000,
+            max_interval_ms: 1_800_000,
+            night_start_hour: 22,
+            night_end_hour: 7,
+            night_multiplier: 2.0,
+            ...overrides,
+          },
+        },
+      });
+      return new DaemonRunner(deps);
+    }
+
+    it("should return base interval unchanged when adaptive_sleep is disabled", () => {
+      const deps = makeDeps(tmpDir, { config: { check_interval_ms: 300_000 } });
+      const daemon = new DaemonRunner(deps);
+      const result = daemon.calculateAdaptiveInterval(300_000, 0, 0, 0);
+      expect(result).toBe(300_000);
+    });
+
+    it("should return base interval when enabled and all factors are neutral (daytime, low gap, no idle)", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 12; }
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // timeOfDay=1.0, urgency=1.0, activity=1.0 → 300000
+        const result = daemon.calculateAdaptiveInterval(300_000, 0, 0.3, 0);
+        expect(result).toBe(300_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should apply night multiplier when current hour is in night range (after midnight)", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 23; } // 23:00 within [22, 7)
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // timeOfDay=2.0, urgency=1.0, activity=1.0 → 600000
+        const result = daemon.calculateAdaptiveInterval(300_000, 0, 0.3, 0);
+        expect(result).toBe(600_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should apply night multiplier for early morning hours", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 3; } // 03:00 within [22, 7)
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // timeOfDay=2.0, urgency=1.0, activity=1.0 → 600000
+        const result = daemon.calculateAdaptiveInterval(300_000, 0, 0.3, 0);
+        expect(result).toBe(600_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should not apply night multiplier during daytime", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 14; }
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // timeOfDay=1.0, urgency=1.0, activity=1.0 → 300000
+        const result = daemon.calculateAdaptiveInterval(300_000, 0, 0.3, 0);
+        expect(result).toBe(300_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should apply 0.5 urgency factor for high gap score (>= 0.8)", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 12; }
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // timeOfDay=1.0, urgency=0.5, activity=1.0 → 150000
+        const result = daemon.calculateAdaptiveInterval(300_000, 0, 0.9, 0);
+        expect(result).toBe(150_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should apply 0.75 urgency factor for medium gap score (0.5 to 0.8)", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 12; }
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // timeOfDay=1.0, urgency=0.75, activity=1.0 → 225000
+        const result = daemon.calculateAdaptiveInterval(300_000, 0, 0.6, 0);
+        expect(result).toBe(225_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should apply 0.75 activity factor when goals were activated this cycle", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 12; }
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // timeOfDay=1.0, urgency=1.0, activity=0.75 → 225000
+        const result = daemon.calculateAdaptiveInterval(300_000, 2, 0.3, 0);
+        expect(result).toBe(225_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should apply 1.5 activity factor after 5 or more consecutive idle cycles", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 12; }
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // timeOfDay=1.0, urgency=1.0, activity=1.5 → 450000
+        const result = daemon.calculateAdaptiveInterval(300_000, 0, 0.3, 5);
+        expect(result).toBe(450_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should clamp result to min_interval_ms when too small", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 12; }
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep({ min_interval_ms: 120_000 });
+        // 50000 * 1.0 * 0.5 * 0.75 = 18750 → clamped to 120000
+        const result = daemon.calculateAdaptiveInterval(50_000, 2, 0.9, 0);
+        expect(result).toBe(120_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should clamp result to max_interval_ms when too large", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 23; } // night: 2.0
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep({ max_interval_ms: 1_800_000 });
+        // 1000000 * 2.0 * 1.0 * 1.5 = 3000000 → clamped to 1800000
+        const result = daemon.calculateAdaptiveInterval(1_000_000, 0, 0.3, 10);
+        expect(result).toBe(1_800_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should multiply all factors correctly", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 23; } // night: 2.0
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // 400000 * 2.0 * 0.75 * 0.75 = 450000, within [60000, 1800000]
+        const result = daemon.calculateAdaptiveInterval(400_000, 1, 0.6, 0);
+        expect(result).toBe(450_000);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+
+    it("should return an integer result", () => {
+      const realDate = globalThis.Date;
+      const mockDate = class extends realDate {
+        getHours() { return 12; }
+      } as typeof Date;
+      globalThis.Date = mockDate;
+
+      try {
+        const daemon = makeDaemonWithAdaptiveSleep();
+        // 100001 * 0.75 = 75000.75 → rounded to integer
+        const result = daemon.calculateAdaptiveInterval(100_001, 0, 0.6, 0);
+        expect(Number.isInteger(result)).toBe(true);
+      } finally {
+        globalThis.Date = realDate;
+      }
+    });
+  });
 });

--- a/tests/reflection/dream-consolidation.test.ts
+++ b/tests/reflection/dream-consolidation.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { makeTempDir, cleanupTempDir } from "../helpers/temp-dir.js";
+import { runDreamConsolidation } from "../../src/reflection/dream-consolidation.js";
+
+// ─── Fixtures ───
+
+function makeStateManager(goalIds: string[]) {
+  return {
+    listGoalIds: vi.fn().mockResolvedValue(goalIds),
+  };
+}
+
+function makeMemoryLifecycle(compressedCount = 5) {
+  return {
+    compressToLongTerm: vi.fn().mockResolvedValue({
+      success: true,
+      entries_compressed: compressedCount,
+      lessons_created: 1,
+    }),
+  };
+}
+
+function makeKnowledgeManager(staleCount = 2) {
+  const staleEntries = Array.from({ length: staleCount }, (_, i) => ({
+    id: `stale-${i}`,
+    key: `key-${i}`,
+    value: "info",
+    source: "test",
+    created_at: new Date().toISOString(),
+    revalidation_due_at: new Date(Date.now() - 1000).toISOString(),
+  }));
+
+  return {
+    getStaleEntries: vi.fn().mockResolvedValue(staleEntries),
+    generateRevalidationTasks: vi.fn().mockResolvedValue(
+      staleEntries.map((e) => ({ id: e.id, type: "knowledge_acquisition" }))
+    ),
+  };
+}
+
+// ─── Tests ───
+
+describe("runDreamConsolidation", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) cleanupTempDir(tmpDir);
+  });
+
+  it("happy path with all deps: returns full ConsolidationReport", async () => {
+    tmpDir = makeTempDir();
+    const stateManager = makeStateManager(["g1", "g2"]);
+    const memoryLifecycle = makeMemoryLifecycle(3);
+    const knowledgeManager = makeKnowledgeManager(2);
+
+    const report = await runDreamConsolidation({
+      stateManager: stateManager as never,
+      memoryLifecycle: memoryLifecycle as never,
+      knowledgeManager: knowledgeManager as never,
+      baseDir: tmpDir,
+    });
+
+    expect(report.goals_consolidated).toBe(2);
+    expect(report.entries_compressed).toBe(30); // 3 per data type * 5 types * 2 goals
+    expect(report.stale_entries_found).toBe(2);
+    expect(report.revalidation_tasks_created).toBe(2);
+    expect(report.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("no goals: returns zero counts", async () => {
+    tmpDir = makeTempDir();
+    const stateManager = makeStateManager([]);
+    const memoryLifecycle = makeMemoryLifecycle();
+    const knowledgeManager = makeKnowledgeManager(0);
+
+    const report = await runDreamConsolidation({
+      stateManager: stateManager as never,
+      memoryLifecycle: memoryLifecycle as never,
+      knowledgeManager: knowledgeManager as never,
+      baseDir: tmpDir,
+    });
+
+    expect(report.goals_consolidated).toBe(0);
+    expect(report.entries_compressed).toBe(0);
+    expect(memoryLifecycle.compressToLongTerm).not.toHaveBeenCalled();
+  });
+
+  it("without memoryLifecycle: skips compression", async () => {
+    tmpDir = makeTempDir();
+    const stateManager = makeStateManager(["g1"]);
+
+    const report = await runDreamConsolidation({
+      stateManager: stateManager as never,
+      baseDir: tmpDir,
+    });
+
+    expect(report.entries_compressed).toBe(0);
+    expect(report.goals_consolidated).toBe(1);
+  });
+
+  it("without knowledgeManager: skips stale check", async () => {
+    tmpDir = makeTempDir();
+    const stateManager = makeStateManager(["g1"]);
+    const memoryLifecycle = makeMemoryLifecycle(2);
+
+    const report = await runDreamConsolidation({
+      stateManager: stateManager as never,
+      memoryLifecycle: memoryLifecycle as never,
+      baseDir: tmpDir,
+    });
+
+    expect(report.stale_entries_found).toBe(0);
+    expect(report.revalidation_tasks_created).toBe(0);
+  });
+
+  it("persists report to file", async () => {
+    tmpDir = makeTempDir();
+    const stateManager = makeStateManager(["g1"]);
+
+    const report = await runDreamConsolidation({
+      stateManager: stateManager as never,
+      baseDir: tmpDir,
+    });
+
+    const filePath = path.join(tmpDir, "reflections", `dream-${report.date}.json`);
+    expect(fs.existsSync(filePath)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    expect(content.goals_consolidated).toBe(1);
+  });
+
+  it("memoryLifecycle error on one data type: continues with others", async () => {
+    tmpDir = makeTempDir();
+    const stateManager = makeStateManager(["g1", "g2"]);
+    const memoryLifecycle = {
+      compressToLongTerm: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("compression failed"))
+        .mockResolvedValue({ success: true, entries_compressed: 2, lessons_created: 1 }),
+    };
+
+    const report = await runDreamConsolidation({
+      stateManager: stateManager as never,
+      memoryLifecycle: memoryLifecycle as never,
+      baseDir: tmpDir,
+    });
+
+    // first call (g1/experience_log) fails, remaining 9 calls succeed with 2 each
+    expect(report.entries_compressed).toBe(18);
+    expect(report.goals_consolidated).toBe(2);
+  });
+});

--- a/tests/reflection/evening-catchup.test.ts
+++ b/tests/reflection/evening-catchup.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { makeTempDir, cleanupTempDir } from "../helpers/temp-dir.js";
+import { createMockLLMClient } from "../helpers/mock-llm.js";
+import { runEveningCatchup } from "../../src/reflection/evening-catchup.js";
+import type { Goal } from "../../src/types/goal.js";
+
+// ─── Fixtures ───
+
+function makeGoal(id: string, overrides: Partial<Goal> = {}): Goal {
+  return {
+    id,
+    parent_id: null,
+    node_type: "goal",
+    title: `Goal ${id}`,
+    description: "",
+    status: "active",
+    dimensions: [
+      {
+        name: "progress",
+        label: "Progress",
+        current_value: 0.5,
+        threshold: { type: "min", value: 1.0 },
+        confidence: 0.8,
+        observation_method: { type: "self_report" },
+        last_updated: null,
+        history: [],
+        weight: 1.0,
+        uncertainty_weight: null,
+        state_integrity: "ok",
+        dimension_mapping: null,
+      },
+    ],
+    gap_aggregation: "max",
+    dimension_mapping: null,
+    constraints: [],
+    children_ids: [],
+    target_date: null,
+    origin: null,
+    pace_snapshot: null,
+    deadline: null,
+    confidence_flag: null,
+    user_override: false,
+    feasibility_note: null,
+    uncertainty_weight: 1.0,
+    decomposition_depth: 0,
+    specificity_score: null,
+    loop_status: "idle",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeStateManager(goals: Goal[]) {
+  return {
+    listGoalIds: vi.fn().mockResolvedValue(goals.map((g) => g.id)),
+    loadGoal: vi.fn().mockImplementation(async (id: string) => goals.find((g) => g.id === id) ?? null),
+    loadGapHistory: vi.fn().mockResolvedValue([]),
+  };
+}
+
+const VALID_LLM_RESPONSE = JSON.stringify({
+  progress_summary: "Good progress made today.",
+  completions: ["g1 dimension met"],
+  stalls: [],
+  concerns: [],
+});
+
+// ─── Tests ───
+
+describe("runEveningCatchup", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) cleanupTempDir(tmpDir);
+  });
+
+  it("happy path: returns a valid CatchupReport", async () => {
+    tmpDir = makeTempDir();
+    const goals = [makeGoal("g1"), makeGoal("g2")];
+    const stateManager = makeStateManager(goals);
+    const llmClient = createMockLLMClient([VALID_LLM_RESPONSE]);
+
+    const report = await runEveningCatchup({
+      stateManager: stateManager as never,
+      llmClient,
+      baseDir: tmpDir,
+    });
+
+    expect(report.goals_reviewed).toBe(2);
+    expect(report.progress_summary).toBe("Good progress made today.");
+    expect(report.completions).toEqual(["g1 dimension met"]);
+    expect(report.stalls).toHaveLength(0);
+    expect(report.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("empty goals: returns default report", async () => {
+    tmpDir = makeTempDir();
+    const stateManager = makeStateManager([]);
+    const llmClient = createMockLLMClient([]);
+
+    const report = await runEveningCatchup({
+      stateManager: stateManager as never,
+      llmClient,
+      baseDir: tmpDir,
+    });
+
+    expect(report.goals_reviewed).toBe(0);
+    expect(report.progress_summary).toBe("No active goals to review.");
+    expect(llmClient.callCount).toBe(0);
+  });
+
+  it("persists report to file", async () => {
+    tmpDir = makeTempDir();
+    const goals = [makeGoal("g1")];
+    const stateManager = makeStateManager(goals);
+    const llmClient = createMockLLMClient([VALID_LLM_RESPONSE]);
+
+    const report = await runEveningCatchup({
+      stateManager: stateManager as never,
+      llmClient,
+      baseDir: tmpDir,
+    });
+
+    const filePath = path.join(tmpDir, "reflections", `evening-${report.date}.json`);
+    expect(fs.existsSync(filePath)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    expect(content.goals_reviewed).toBe(1);
+  });
+
+  it("LLM error: returns partial report without crashing", async () => {
+    tmpDir = makeTempDir();
+    const goals = [makeGoal("g1")];
+    const stateManager = makeStateManager(goals);
+    const llmClient = {
+      callCount: 0,
+      sendMessage: vi.fn().mockRejectedValue(new Error("LLM unavailable")),
+      parseJSON: vi.fn(),
+    };
+
+    const report = await runEveningCatchup({
+      stateManager: stateManager as never,
+      llmClient: llmClient as never,
+      baseDir: tmpDir,
+    });
+
+    expect(report.goals_reviewed).toBe(1);
+    expect(report.progress_summary).toBe("Unable to generate summary due to LLM error.");
+  });
+
+  it("calls notificationDispatcher when goals present", async () => {
+    tmpDir = makeTempDir();
+    const goals = [makeGoal("g1")];
+    const stateManager = makeStateManager(goals);
+    const llmClient = createMockLLMClient([VALID_LLM_RESPONSE]);
+    const dispatcher = { dispatch: vi.fn().mockResolvedValue([]) };
+
+    await runEveningCatchup({
+      stateManager: stateManager as never,
+      llmClient,
+      baseDir: tmpDir,
+      notificationDispatcher: dispatcher as never,
+    });
+
+    expect(dispatcher.dispatch).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/reflection/morning-planning.test.ts
+++ b/tests/reflection/morning-planning.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { makeTempDir, cleanupTempDir } from "../helpers/temp-dir.js";
+import { createMockLLMClient } from "../helpers/mock-llm.js";
+import { runMorningPlanning } from "../../src/reflection/morning-planning.js";
+import type { Goal } from "../../src/types/goal.js";
+
+// ─── Fixtures ───
+
+function makeGoal(id: string, overrides: Partial<Goal> = {}): Goal {
+  return {
+    id,
+    parent_id: null,
+    node_type: "goal",
+    title: `Goal ${id}`,
+    description: "",
+    status: "active",
+    dimensions: [
+      {
+        name: "progress",
+        label: "Progress",
+        current_value: 0.3,
+        threshold: { type: "min", value: 1.0 },
+        confidence: 0.8,
+        observation_method: { type: "self_report" },
+        last_updated: null,
+        history: [],
+        weight: 1.0,
+        uncertainty_weight: null,
+        state_integrity: "ok",
+        dimension_mapping: null,
+      },
+    ],
+    gap_aggregation: "max",
+    dimension_mapping: null,
+    constraints: [],
+    children_ids: [],
+    target_date: null,
+    origin: null,
+    pace_snapshot: null,
+    deadline: null,
+    confidence_flag: null,
+    user_override: false,
+    feasibility_note: null,
+    uncertainty_weight: 1.0,
+    decomposition_depth: 0,
+    specificity_score: null,
+    loop_status: "idle",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeStateManager(goals: Goal[]) {
+  return {
+    listGoalIds: vi.fn().mockResolvedValue(goals.map((g) => g.id)),
+    loadGoal: vi.fn().mockImplementation(async (id: string) => goals.find((g) => g.id === id) ?? null),
+    loadGapHistory: vi.fn().mockResolvedValue([]),
+  };
+}
+
+const VALID_LLM_RESPONSE = JSON.stringify({
+  priorities: [{ goal_id: "g1", priority: "high", reasoning: "Most urgent" }],
+  suggestions: ["Focus on testing"],
+  concerns: ["Deadline approaching"],
+});
+
+// ─── Tests ───
+
+describe("runMorningPlanning", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) cleanupTempDir(tmpDir);
+  });
+
+  it("happy path: returns a valid PlanningReport", async () => {
+    tmpDir = makeTempDir();
+    const goals = [makeGoal("g1")];
+    const stateManager = makeStateManager(goals);
+    const llmClient = createMockLLMClient([VALID_LLM_RESPONSE]);
+
+    const report = await runMorningPlanning({
+      stateManager: stateManager as never,
+      llmClient,
+      baseDir: tmpDir,
+    });
+
+    expect(report.goals_reviewed).toBe(1);
+    expect(report.priorities).toHaveLength(1);
+    expect(report.priorities[0]?.goal_id).toBe("g1");
+    expect(report.priorities[0]?.priority).toBe("high");
+    expect(report.suggestions).toEqual(["Focus on testing"]);
+    expect(report.concerns).toEqual(["Deadline approaching"]);
+    expect(report.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("empty goals: returns report with zero goals reviewed", async () => {
+    tmpDir = makeTempDir();
+    const stateManager = makeStateManager([]);
+    const llmClient = createMockLLMClient([]);
+
+    const report = await runMorningPlanning({
+      stateManager: stateManager as never,
+      llmClient,
+      baseDir: tmpDir,
+    });
+
+    expect(report.goals_reviewed).toBe(0);
+    expect(report.priorities).toHaveLength(0);
+    expect(llmClient.callCount).toBe(0); // No LLM call when no goals
+  });
+
+  it("persists report to file", async () => {
+    tmpDir = makeTempDir();
+    const goals = [makeGoal("g1")];
+    const stateManager = makeStateManager(goals);
+    const llmClient = createMockLLMClient([VALID_LLM_RESPONSE]);
+
+    const report = await runMorningPlanning({
+      stateManager: stateManager as never,
+      llmClient,
+      baseDir: tmpDir,
+    });
+
+    const filePath = path.join(tmpDir, "reflections", `morning-${report.date}.json`);
+    expect(fs.existsSync(filePath)).toBe(true);
+    const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    expect(content.goals_reviewed).toBe(1);
+  });
+
+  it("LLM error: returns partial report without crashing", async () => {
+    tmpDir = makeTempDir();
+    const goals = [makeGoal("g1")];
+    const stateManager = makeStateManager(goals);
+    // Mock LLM that throws
+    const llmClient = {
+      callCount: 0,
+      sendMessage: vi.fn().mockRejectedValue(new Error("LLM timeout")),
+      parseJSON: vi.fn(),
+    };
+
+    const report = await runMorningPlanning({
+      stateManager: stateManager as never,
+      llmClient: llmClient as never,
+      baseDir: tmpDir,
+    });
+
+    expect(report.goals_reviewed).toBe(1);
+    expect(report.priorities).toHaveLength(0); // Empty due to LLM error
+  });
+
+  it("calls notificationDispatcher when goals present", async () => {
+    tmpDir = makeTempDir();
+    const goals = [makeGoal("g1")];
+    const stateManager = makeStateManager(goals);
+    const llmClient = createMockLLMClient([VALID_LLM_RESPONSE]);
+    const dispatcher = { dispatch: vi.fn().mockResolvedValue([]) };
+
+    await runMorningPlanning({
+      stateManager: stateManager as never,
+      llmClient,
+      baseDir: tmpDir,
+      notificationDispatcher: dispatcher as never,
+    });
+
+    expect(dispatcher.dispatch).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary
- **A1: CronScheduler** — Internal cron scheduler for daemon-mode scheduled tasks (`cron-parser` based, jitter, 7-day auto-expiry)
- **A2: Self-Reflection** — Morning planning, evening catchup, dream consolidation routines (LLM-driven daily review + memory compression)
- **A3: Proactive Tick** — LLM-driven idle-time initiative in DaemonRunner (opt-in via `proactive_mode: true`)
- **A4: Adaptive Sleep** — Time-of-day, urgency, and activity-based interval adjustment (opt-in via `adaptive_sleep.enabled: true`)
- **Design doc** — `docs/design/cc-inspired-improvements.md` with full CC→PulSeed improvement plan (Phases A-D)

Inspired by Claude Code's KAIROS (assistant mode) architecture.

## Test plan
- [ ] `npx vitest run tests/cron-scheduler.test.ts` — 18 tests
- [ ] `npx vitest run tests/reflection/` — 16 tests
- [ ] `npx vitest run tests/daemon-runner.test.ts` — 71 tests
- [ ] `npm run build` — clean
- [ ] Full suite: 5091/5092 pass (1 flaky pre-existing `event-file-watcher`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)