### PR TITLE
fix: wire daemon start CLI flags (check-interval-ms, iterations-per-cycle)

### DIFF
--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -24,7 +24,7 @@ export async function cmdStart(
   characterConfigManager: CharacterConfigManager,
   args: string[]
 ): Promise<void> {
-  let values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean };
+  let values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string };
   try {
     ({ values } = parseArgs({
       args,
@@ -33,9 +33,11 @@ export async function cmdStart(
         config: { type: "string" },
         goal: { type: "string", multiple: true },
         detach: { type: "boolean", short: "d" },
+        "check-interval-ms": { type: "string" },
+        "iterations-per-cycle": { type: "string" },
       },
       strict: false,
-    }) as { values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean } });
+    }) as { values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string } });
   } catch (err) {
     getCliLogger().error(formatOperationError("parse start command arguments", err));
     values = {};
@@ -54,6 +56,8 @@ export async function cmdStart(
     // Reconstruct args from parsed values (never include --detach)
     const childArgs = ["start"];
     for (const g of goalIds) childArgs.push("--goal", g);
+    if (values["check-interval-ms"]) childArgs.push("--check-interval-ms", values["check-interval-ms"]);
+    if (values["iterations-per-cycle"]) childArgs.push("--iterations-per-cycle", values["iterations-per-cycle"]);
 
     const child = spawn(process.execPath, [scriptPath, ...childArgs], {
       detached: true,
@@ -87,6 +91,26 @@ export async function cmdStart(
       getCliLogger().error(formatOperationError(`parse daemon config from "${values.config}"`, err));
       process.exit(1);
     }
+  }
+
+  // Merge CLI flag overrides into daemonConfig
+  if (values["check-interval-ms"]) {
+    const parsed = parseInt(values["check-interval-ms"], 10);
+    if (isNaN(parsed) || parsed <= 0) {
+      getCliLogger().error("--check-interval-ms must be a positive integer");
+      process.exit(1);
+    }
+    daemonConfig = daemonConfig ?? {};
+    daemonConfig.check_interval_ms = parsed;
+  }
+  if (values["iterations-per-cycle"]) {
+    const parsed = parseInt(values["iterations-per-cycle"], 10);
+    if (isNaN(parsed) || parsed <= 0) {
+      getCliLogger().error("--iterations-per-cycle must be a positive integer");
+      process.exit(1);
+    }
+    daemonConfig = daemonConfig ?? {};
+    daemonConfig.iterations_per_cycle = parsed;
   }
 
   const deps = await buildDeps(stateManager, characterConfigManager);

--- a/src/types/daemon.ts
+++ b/src/types/daemon.ts
@@ -16,7 +16,7 @@ export const DaemonConfigSchema = z.object({
     graceful_shutdown_timeout_ms: z.number().int().positive().optional(),
   }).default({}),
   goal_intervals: z.record(z.string(), z.number().int().positive()).optional(), // goal_id -> interval_ms override
-  iterations_per_cycle: z.number().int().positive().default(1), // max CoreLoop iterations per daemon cycle
+  iterations_per_cycle: z.number().int().positive().default(10), // max CoreLoop iterations per daemon cycle
   proactive_mode: z.boolean().default(false),
   proactive_interval_ms: z.number().default(3_600_000), // 1 hour minimum between proactive ticks
   adaptive_sleep: z.object({

--- a/tests/daemon-runner.test.ts
+++ b/tests/daemon-runner.test.ts
@@ -193,7 +193,7 @@ describe("DaemonRunner", () => {
       daemon.stop();
       await startPromise;
 
-      expect((deps.coreLoop as { run: ReturnType<typeof vi.fn> }).run).toHaveBeenCalledWith("goal-1", { maxIterations: 1 });
+      expect((deps.coreLoop as { run: ReturnType<typeof vi.fn> }).run).toHaveBeenCalledWith("goal-1", { maxIterations: 10 });
     });
 
     it("should skip goals that shouldActivate returns false for", async () => {
@@ -544,7 +544,7 @@ describe("DaemonRunner", () => {
 
       expect((deps.coreLoop as { run: ReturnType<typeof vi.fn> }).run).toHaveBeenCalledWith(
         "goal-fast",
-        { maxIterations: 1 }
+        { maxIterations: 10 }
       );
     });
   });
@@ -1372,7 +1372,7 @@ describe("DaemonRunner", () => {
   // ─── iterations_per_cycle / per-cycle budget ───
 
   describe("iterations_per_cycle", () => {
-    it("should call CoreLoop.run with { maxIterations: 1 } by default", async () => {
+    it("should call CoreLoop.run with { maxIterations: 10 } by default", async () => {
       const deps = makeDeps(tmpDir, { config: { check_interval_ms: 50 } });
       const daemon = new DaemonRunner(deps);
       currentDaemon = daemon;
@@ -1384,7 +1384,7 @@ describe("DaemonRunner", () => {
       await startPromise;
 
       const runMock = (deps.coreLoop as { run: ReturnType<typeof vi.fn> }).run;
-      expect(runMock).toHaveBeenCalledWith("goal-1", { maxIterations: 1 });
+      expect(runMock).toHaveBeenCalledWith("goal-1", { maxIterations: 10 });
     });
 
     it("should call CoreLoop.run with { maxIterations: N } when iterations_per_cycle is configured", async () => {


### PR DESCRIPTION
## Summary
- `--check-interval-ms` and `--iterations-per-cycle` flags were silently ignored by `daemon start` because `parseArgs` never declared them
- Added parseInt validation with user-friendly error messages for invalid inputs
- Forward both flags through the `--detach` child process path
- Raised `iterations_per_cycle` default from 1 to 10 for practical dogfooding use

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run tests/daemon-runner.test.ts` — 74/74 pass
- [ ] Manual: `node dist/cli-runner.js daemon start --goal <id> --check-interval-ms 30000 --yes` confirms 30s interval in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)