### PR TITLE
feat: structured monitoring logs for daemon execution path

### DIFF
--- a/src/core-loop.ts
+++ b/src/core-loop.ts
@@ -427,6 +427,8 @@ export class CoreLoop {
     }
     const { gapVector, gapAggregate, skipTaskGeneration } = gapResult;
 
+    this.logger?.info(`[iter ${loopIndex}] gap: ${gapAggregate.toFixed(2)} | ${gapVector.gaps.map(g => `${g.dimension_name}=${g.normalized_weighted_gap.toFixed(2)}`).join(', ')}`);
+
     // 4. Drive scoring + knowledge gap check (skip when gap=0 — no task needed)
     let driveScores: import("./types/drive.js").DriveScore[] = [];
     let highDissatisfactionDimensions: string[] = [];
@@ -449,6 +451,10 @@ export class CoreLoop {
     // is_complete=false (e.g. waiting for double-confirmation), stall detection
     // must still fire so the loop can escalate rather than spin indefinitely.
     await detectStallsAndRebalance(ctx, goalId, goal, result);
+
+    if (result.stallDetected && result.stallReport) {
+      this.logger?.warn(`[iter ${loopIndex}] stall detected: ${result.stallReport.stall_type}`, { escalation: result.stallReport.escalation_level });
+    }
 
     // When gap=0, SatisficingJudge in Phase 5 is the authority on completion.
     // If it says not complete (e.g. low confidence), continue the loop normally

--- a/src/execution/task-lifecycle.ts
+++ b/src/execution/task-lifecycle.ts
@@ -314,6 +314,7 @@ export class TaskLifecycle {
       return createSkippedTaskResult(goalId, targetDimension);
     }
     void this.hookManager?.emit("PostTaskCreate", { goal_id: goalId, data: { task_id: task.id } });
+    this.logger?.info(`[task] created: ${task.work_description?.substring(0, 120)}`, { taskId: task.id });
 
     // 4. Pre-execution checks: ethics, capability, irreversible approval
     const preCheckResult = await runPreExecutionChecks(
@@ -332,6 +333,7 @@ export class TaskLifecycle {
     void this.hookManager?.emit("PreExecute", { goal_id: goalId, data: { task_id: task.id } });
     const executionResult = await this.executeTask(task, adapter, workspaceContext);
     void this.hookManager?.emit("PostExecute", { goal_id: goalId, data: { task_id: task.id, success: executionResult.success } });
+    this.logger?.info(`[task] executed: ${executionResult.success ? 'success' : 'failed'}`, { taskId: task.id });
     this.logger?.debug(`[DEBUG-TL] Execution result: success=${executionResult.success}, stopped=${executionResult.stopped_reason}, error=${executionResult.error}, output=${executionResult.output?.substring(0, 200)}`);
 
     // 4b. Post-execution health check (opt-in)
@@ -354,6 +356,7 @@ export class TaskLifecycle {
 
     // 6. Handle verdict
     const verdictResult = await this.handleVerdict(taskForVerification, verificationResult);
+    this.logger?.info(`[task] verdict: ${verdictResult.action}`, { taskId: task.id });
 
     // Save checkpoint on task completion/interruption
     const adapterType = adapter?.adapterType ?? 'unknown';

--- a/src/execution/task-verifier.ts
+++ b/src/execution/task-verifier.ts
@@ -629,11 +629,13 @@ export async function handleFailure(
   if (updatedTask.reversibility === "reversible") {
     // Attempt revert
     const revertSuccess = await attemptRevert(deps, updatedTask);
+    deps.logger?.warn(`[task] revert attempted`, { taskId: task.id, success: revertSuccess });
     if (revertSuccess) {
       await appendTaskHistory(deps, task.goal_id, updatedTask);
       return { action: "discard", task: updatedTask };
     }
     // Revert failed — set state_integrity to "uncertain" and escalate
+    deps.logger?.error(`[task] revert FAILED`, { taskId: task.id });
     await setDimensionIntegrity(deps, task.goal_id, task.primary_dimension, "uncertain");
     await appendTaskHistory(deps, task.goal_id, updatedTask);
     return { action: "escalate", task: updatedTask };

--- a/src/observation/observation-engine.ts
+++ b/src/observation/observation-engine.ts
@@ -518,6 +518,7 @@ export class ObservationEngine {
       });
 
       await this.applyObservation(goalId, entry);
+      this.logger?.info(`[observe] ${dim.name}=${entry.extracted_value} (confidence=${entry.confidence})`);
       void this.hookManager?.emit("PostObserve", { goal_id: goalId, dimension: dim.name, data: { value: entry.extracted_value, confidence: entry.confidence } });
     }
   }


### PR DESCRIPTION
## Summary
- 8 log statements across 4 files for daemon monitoring via `tail -40`
- Each iteration now tells a story: gap score → task created → executed → verdict → observed values
- Stall detection (warn) and revert attempts (warn/error) also logged

## Files changed
- `src/core-loop.ts` — gap score + stall detection logs
- `src/execution/task-lifecycle.ts` — task created/executed/verdict logs
- `src/execution/task-verifier.ts` — revert attempt/failure logs
- `src/observation/observation-engine.ts` — observation value logs

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run tests/core-loop-integration.test.ts tests/daemon-runner.test.ts` — 77/77 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)