### PR TITLE
feat: force goal decomposition on first daemon iteration

### DIFF
--- a/src/core-loop.ts
+++ b/src/core-loop.ts
@@ -198,7 +198,7 @@ export class CoreLoop {
 
       const iterationResult = this.config.treeMode && this.deps.treeLoopOrchestrator
         ? await this.runTreeIteration(goalId, loopIndex, nodeConsumedMap)
-        : await this.runOneIteration(goalId, loopIndex);
+        : await this.runOneIteration(goalId, loopIndex, loopIndex === startLoopIndex);
       // Carry forward gapAggregate from the previous iteration when this one was skipped,
       // so callers always see a meaningful value rather than the default 0.
       if (iterationResult.skipped && iterations.length >= 1) {
@@ -332,7 +332,8 @@ export class CoreLoop {
    */
   async runOneIteration(
     goalId: string,
-    loopIndex: number
+    loopIndex: number,
+    isFirstIteration?: boolean
   ): Promise<LoopIterationResult> {
     const startTime = Date.now();
     const ctx: PhaseCtx = { deps: this.deps, config: this.config, logger: this.logger };
@@ -347,7 +348,7 @@ export class CoreLoop {
     if (!loadedGoal) return result;
     let goal = loadedGoal;
 
-    await phaseAutoDecompose(goalId, goal, this.deps, this.config, this.logger, this.decomposedGoals);
+    await phaseAutoDecompose(goalId, goal, this.deps, this.config, this.logger, this.decomposedGoals, isFirstIteration);
 
     // After decomposition: if children were created, reload and switch to tree mode
     // so subsequent iterations use runTreeIteration instead of runOneIteration.
@@ -427,7 +428,7 @@ export class CoreLoop {
     }
     const { gapVector, gapAggregate, skipTaskGeneration } = gapResult;
 
-    this.logger?.info(`[iter ${loopIndex}] gap: ${gapAggregate.toFixed(2)} | ${gapVector.gaps.map(g => `${g.dimension_name}=${g.normalized_weighted_gap.toFixed(2)}`).join(', ')}`);
+    this.logger?.info(`[iter ${loopIndex}] gap: ${gapAggregate.toFixed(2)} | ${(gapVector.gaps ?? []).map((g: any) => `${g.dimension_name}=${g.normalized_weighted_gap.toFixed(2)}`).join(', ')}`);
 
     // 4. Drive scoring + knowledge gap check (skip when gap=0 — no task needed)
     let driveScores: import("./types/drive.js").DriveScore[] = [];

--- a/src/goal/tree-loop-orchestrator.ts
+++ b/src/goal/tree-loop-orchestrator.ts
@@ -83,15 +83,15 @@ export class TreeLoopOrchestrator {
    * Falls back to GoalTreeManager.decomposeGoal() if refiner is absent.
    * No-op if the goal already has children or validated dimensions.
    */
-  async ensureGoalRefined(goalId: string): Promise<void> {
+  async ensureGoalRefined(goalId: string, options?: { force?: boolean }): Promise<void> {
     const goal = await this.stateManager.loadGoal(goalId);
     if (!goal) return;
 
     // Already has children — no refinement needed
     if (goal.children_ids.length > 0) return;
 
-    // Already has validated dimensions — no refinement needed
-    if (hasValidatedDimensions(goal)) return;
+    // Already has validated dimensions — no refinement needed (skip check when forced)
+    if (!options?.force && hasValidatedDimensions(goal)) return;
 
     const defaultDecompConfig: GoalDecompositionConfig = {
       max_depth: this.config.max_depth,

--- a/src/loop/core-loop-phases.ts
+++ b/src/loop/core-loop-phases.ts
@@ -87,7 +87,8 @@ export async function phaseAutoDecompose(
   deps: CoreLoopDeps,
   config: ResolvedLoopConfig,
   logger: Logger | undefined,
-  decomposedGoals?: Set<string>
+  decomposedGoals?: Set<string>,
+  isFirstIteration?: boolean
 ): Promise<void> {
   if (config.autoDecompose === false) return;
   if (!deps.treeLoopOrchestrator) return;
@@ -114,10 +115,15 @@ export async function phaseAutoDecompose(
     return;
   }
 
-  logger?.info("[CoreLoop] phaseAutoDecompose: decomposing abstract goal", { goalId });
+  const force = isFirstIteration === true;
+  if (force) {
+    logger?.info("[decompose] forcing goal decomposition on first iteration", { goalId });
+  } else {
+    logger?.info("[CoreLoop] phaseAutoDecompose: decomposing abstract goal", { goalId });
+  }
   decomposedGoals?.add(goalId);
   try {
-    await deps.treeLoopOrchestrator.ensureGoalRefined(goalId);
+    await deps.treeLoopOrchestrator.ensureGoalRefined(goalId, { force });
   } catch (err) {
     logger?.warn("[CoreLoop] phaseAutoDecompose: ensureGoalRefined failed (non-fatal)", {
       goalId,

--- a/tests/core-loop-auto-decompose.test.ts
+++ b/tests/core-loop-auto-decompose.test.ts
@@ -349,7 +349,7 @@ describe("CoreLoop auto-decompose (issue #295)", () => {
     await loop.runOneIteration("goal-1", 0);
 
     // Specificity check is internal to ensureGoalRefined, so it is still called
-    expect(orchestratorMock.ensureGoalRefined).toHaveBeenCalledWith("goal-1");
+    expect(orchestratorMock.ensureGoalRefined).toHaveBeenCalledWith("goal-1", { force: false });
   });
 
   it("calls ensureGoalRefined when goal is abstract", async () => {
@@ -362,7 +362,7 @@ describe("CoreLoop auto-decompose (issue #295)", () => {
     const loop = new CoreLoop(deps, { maxIterations: 1, delayBetweenLoopsMs: 0 });
     await loop.runOneIteration("goal-1", 0);
 
-    expect(orchestratorMock.ensureGoalRefined).toHaveBeenCalledWith("goal-1");
+    expect(orchestratorMock.ensureGoalRefined).toHaveBeenCalledWith("goal-1", { force: false });
   });
 
   it("only decomposes on first iteration", async () => {
@@ -377,7 +377,7 @@ describe("CoreLoop auto-decompose (issue #295)", () => {
 
     // ensureGoalRefined should be called exactly once across all iterations
     expect(orchestratorMock.ensureGoalRefined).toHaveBeenCalledTimes(1);
-    expect(orchestratorMock.ensureGoalRefined).toHaveBeenCalledWith("goal-1");
+    expect(orchestratorMock.ensureGoalRefined).toHaveBeenCalledWith("goal-1", { force: true });
   });
 
   it("skips decomposition for non-root goals (decomposition_depth > 0)", async () => {
@@ -407,6 +407,6 @@ describe("CoreLoop auto-decompose (issue #295)", () => {
     const result = await loop.runOneIteration("goal-1", 0);
 
     expect(result.error).toBeNull();
-    expect(orchestratorMock.ensureGoalRefined).toHaveBeenCalledWith("goal-1");
+    expect(orchestratorMock.ensureGoalRefined).toHaveBeenCalledWith("goal-1", { force: false });
   });
 });


### PR DESCRIPTION
## Summary
- `ensureGoalRefined` now accepts `{ force: true }` to bypass the `hasValidatedDimensions` check
- `phaseAutoDecompose` passes `force=true` on the first iteration of each run
- Fixes root cause of dogfood failure: manual-origin goals were never decomposed (Issue #406)
- Also fixes null-safety in gap-score monitoring log (`gapVector.gaps` could be undefined)

## Root cause
`hasValidatedDimensions()` returns `true` for `origin: "manual"` goals, causing `ensureGoalRefined` to bail before any decomposition. All `goal add` goals have `origin: "manual"`.

## Files changed
- `src/goal/tree-loop-orchestrator.ts` — `force` option on `ensureGoalRefined`
- `src/loop/core-loop-phases.ts` — `isFirstIteration` param, force logic
- `src/core-loop.ts` — pass `isFirstIteration` from run loop + gap log null-safety
- `tests/core-loop-auto-decompose.test.ts` — updated expectations

## Test plan
- [x] `npm run build` — clean
- [x] 25/25 core-loop tests pass
- [ ] Dogfood re-run to verify decomposition fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)