### PR TITLE
feat: enrich task prompts with parent goal context and issue content

### DIFF
--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -105,7 +105,15 @@ export async function buildDeps(
     async (goalId: string) => {
       try {
         const goal = await stateManager.loadGoal(goalId);
-        return goal?.description;
+        if (!goal) return undefined;
+        let desc = goal.description;
+        if (goal.parent_id) {
+          const parent = await stateManager.loadGoal(goal.parent_id);
+          if (parent?.description) {
+            desc = `${desc}\n${parent.description}`;
+          }
+        }
+        return desc;
       } catch (err) {
         getCliLogger().error(formatOperationError(`resolve workspace context goal description for "${goalId}"`, err));
         return undefined;

--- a/src/execution/issue-context-fetcher.ts
+++ b/src/execution/issue-context-fetcher.ts
@@ -1,0 +1,84 @@
+// ─── fetchIssueContext ───
+//
+// Extracts GitHub issue numbers from goal text and fetches their content via
+// `gh issue view`. Returns formatted context for inclusion in task prompts.
+// On any failure, returns empty string (graceful degradation).
+
+import { execFileNoThrow } from "../utils/execFileNoThrow.js";
+
+const MAX_ISSUES = 3;
+const MAX_BODY_CHARS = 3000;
+const FETCH_TIMEOUT_MS = 10000;
+
+interface GhIssueJson {
+  title: string;
+  body: string;
+}
+
+/**
+ * Extract unique GitHub issue numbers from text.
+ * Skips hex-color-like tokens (non-digit characters after #).
+ *
+ * Matches #NNN preceded by start-of-string, whitespace, or opening paren,
+ * and NOT followed by any non-digit word character.
+ * This avoids matching hex colors like #fff, #abc123, or #1a2b3c.
+ */
+export function extractIssueNumbers(text: string): number[] {
+  // Regex is defined locally to avoid shared `lastIndex` state bugs with /g flag
+  const issueRefRe = /(?:^|[\s(])#(\d+)(?![a-zA-Z])/g;
+  const seen = new Set<number>();
+  const results: number[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = issueRefRe.exec(text)) !== null) {
+    const num = parseInt(match[1], 10);
+    if (!seen.has(num)) {
+      seen.add(num);
+      results.push(num);
+    }
+  }
+  return results;
+}
+
+/**
+ * Fetch a single GitHub issue and format it for prompt inclusion.
+ * Returns null on any failure.
+ */
+async function fetchIssue(num: number): Promise<string | null> {
+  try {
+    const result = await execFileNoThrow(
+      "gh",
+      ["issue", "view", String(num), "--json", "title,body"],
+      { timeoutMs: FETCH_TIMEOUT_MS }
+    );
+    if (result.exitCode !== 0 || !result.stdout.trim()) {
+      return null;
+    }
+    const parsed = JSON.parse(result.stdout) as GhIssueJson;
+    const title = parsed.title ?? "";
+    const body = (parsed.body ?? "").slice(0, MAX_BODY_CHARS);
+    return `## Referenced Issue #${num}\nTitle: ${title}\n${body}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract GitHub issue numbers from `text`, fetch their content via `gh`,
+ * and return formatted context for use in task prompts.
+ *
+ * - Deduplicates issue numbers.
+ * - Processes at most 3 issues (first ones found).
+ * - Returns empty string on any failure.
+ */
+export async function fetchIssueContext(text: string): Promise<string> {
+  try {
+    const nums = extractIssueNumbers(text).slice(0, MAX_ISSUES);
+    if (nums.length === 0) return "";
+
+    const parts = await Promise.all(nums.map(fetchIssue));
+    const valid = parts.filter((p): p is string => p !== null);
+    return valid.join("\n\n");
+  } catch {
+    return "";
+  }
+}

--- a/src/execution/task-prompt-builder.ts
+++ b/src/execution/task-prompt-builder.ts
@@ -21,6 +21,17 @@ export async function buildTaskGenerationPrompt(
 ): Promise<string> {
   // Load goal context to enrich the prompt
   const goal = await stateManager.loadGoal(goalId);
+
+  // Load parent goal chain (max 3 levels)
+  const parentChain: Array<{ title: string; description: string }> = [];
+  let current = goal;
+  for (let i = 0; i < 3 && current?.parent_id; i++) {
+    const parent = await stateManager.loadGoal(current.parent_id);
+    if (!parent) break;
+    parentChain.push({ title: parent.title, description: parent.description });
+    current = parent;
+  }
+
   const dim = goal?.dimensions.find((d) => d.name === targetDimension);
 
   // Build goal context section
@@ -152,12 +163,32 @@ Constraints:
     // no failure context — skip injection
   }
 
+  // Parent Goal Context section
+  const parentSection = parentChain.length > 0
+    ? `## Parent Goal Context\n${parentChain.map((p, i) => `${"  ".repeat(i)}Goal: ${p.title}\n${"  ".repeat(i)}Description: ${p.description}`).join("\n")}`
+    : "";
+
+  // Referenced Issue section (dynamic import — graceful when absent)
+  let issueSection = "";
+  try {
+    const { fetchIssueContext } = await import("./issue-context-fetcher.js");
+    const allText = [goal?.title, goal?.description, ...parentChain.map(p => `${p.title} ${p.description}`)].filter(Boolean).join(" ");
+    issueSection = await fetchIssueContext(allText);
+  } catch {
+    // issue-context-fetcher not available
+  }
+
+  // Task Purpose section
+  const purposeSection = goal
+    ? `## Task Purpose\nThis task addresses dimension "${targetDimension}" of subgoal "${goal.title}"${parentChain.length > 0 ? `, which is part of the parent goal "${parentChain[0].title}"` : ""}.`
+    : "";
+
   const reflectionsSection = reflections ? `\n${reflections}\n` : "";
   const lessonsSection = lessons ? `\n${lessons}\n` : "";
 
   return `${goalSection}
 ${dimensionSection}
-${repoSection}${adapterSection}${knowledgeSection}${workspaceSection}${existingTasksSection}${failureContextSection}${reflectionsSection}${lessonsSection}
+${parentSection ? `${parentSection}\n` : ""}${issueSection ? `${issueSection}\n` : ""}${purposeSection ? `${purposeSection}\n` : ""}${repoSection}${adapterSection}${knowledgeSection}${workspaceSection}${existingTasksSection}${failureContextSection}${reflectionsSection}${lessonsSection}
 Requirements:
 - Specific to actual project (goal, description, repo context)
 - No generic improvements unless in goal description

--- a/src/tui/entry.ts
+++ b/src/tui/entry.ts
@@ -59,9 +59,26 @@ async function buildDeps() {
     async (goalId: string) => {
       try {
         const goal = await stateManager.loadGoal(goalId);
-        return goal?.description;
+        if (!goal) return undefined;
+        let desc = goal.description;
+        if (goal.parent_id) {
+          const parent = await stateManager.loadGoal(goal.parent_id);
+          if (parent?.description) {
+            desc = `${desc}\n${parent.description}`;
+          }
+        }
+        return desc;
       } catch (err) {
         getCliLogger().error(`[pulseed] Failed to resolve goal description for "${goalId}": ${err instanceof Error ? err.message : String(err)}`);
+        return undefined;
+      }
+    },
+    async (goalId: string) => {
+      try {
+        const goal = await stateManager.loadGoal(goalId);
+        return goal?.constraints;
+      } catch (err) {
+        getCliLogger().error(`[pulseed] Failed to resolve goal constraints for "${goalId}": ${err instanceof Error ? err.message : String(err)}`);
         return undefined;
       }
     }

--- a/src/utils/execFileNoThrow.ts
+++ b/src/utils/execFileNoThrow.ts
@@ -1,0 +1,60 @@
+// ─── execFileNoThrow ───
+//
+// Thin wrapper around Node's execFile that never throws.
+// Returns { stdout, stderr, exitCode } on success/failure,
+// and { stdout: "", stderr: <message>, exitCode: null } on spawn errors.
+
+import { execFile } from "node:child_process";
+
+export interface ExecFileResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+export interface ExecFileOptions {
+  /** Timeout in milliseconds. Default: 10000 */
+  timeoutMs?: number;
+  /** Working directory for the child process. */
+  cwd?: string;
+  /** Environment variables. Default: process.env */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Run a command with execFile and return its result without throwing.
+ * On any error (spawn failure, timeout, non-zero exit), the error is
+ * captured in the returned object rather than thrown.
+ */
+export async function execFileNoThrow(
+  cmd: string,
+  args: string[],
+  options: ExecFileOptions = {}
+): Promise<ExecFileResult> {
+  const { timeoutMs = 10000, cwd, env } = options;
+
+  return new Promise<ExecFileResult>((resolve) => {
+    execFile(
+      cmd,
+      args,
+      {
+        timeout: timeoutMs,
+        cwd,
+        env,
+        maxBuffer: 1024 * 1024, // 1 MB
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          // error.code is the exit code for non-zero exits; null for spawn errors
+          const exitCode =
+            typeof (error as NodeJS.ErrnoException & { code?: number }).code === "number"
+              ? (error as NodeJS.ErrnoException & { code?: number }).code!
+              : null;
+          resolve({ stdout: stdout ?? "", stderr: stderr ?? error.message, exitCode });
+          return;
+        }
+        resolve({ stdout, stderr, exitCode: 0 });
+      }
+    );
+  });
+}

--- a/tests/issue-context-fetcher.test.ts
+++ b/tests/issue-context-fetcher.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { extractIssueNumbers, fetchIssueContext } from "../src/execution/issue-context-fetcher.js";
+
+// ─── Mock execFileNoThrow ───
+vi.mock("../src/utils/execFileNoThrow.js", () => ({
+  execFileNoThrow: vi.fn(),
+}));
+
+import { execFileNoThrow } from "../src/utils/execFileNoThrow.js";
+const mockExec = vi.mocked(execFileNoThrow);
+
+// ─── extractIssueNumbers ───
+describe("extractIssueNumbers", () => {
+  it("extracts a bare issue number", () => {
+    expect(extractIssueNumbers("#123")).toEqual([123]);
+  });
+
+  it("extracts from prose text", () => {
+    expect(extractIssueNumbers("Fix #456 and close #789")).toEqual([456, 789]);
+  });
+
+  it("extracts from 'issue #NNN' pattern", () => {
+    expect(extractIssueNumbers("See issue #101")).toEqual([101]);
+  });
+
+  it("extracts from parenthetical reference", () => {
+    expect(extractIssueNumbers("(#202)")).toEqual([202]);
+  });
+
+  it("does NOT match hex color #fff", () => {
+    expect(extractIssueNumbers("color: #fff")).toEqual([]);
+  });
+
+  it("does NOT match hex color #abc123", () => {
+    expect(extractIssueNumbers("background: #abc123")).toEqual([]);
+  });
+
+  it("does NOT match mixed hex like #1a2b3c", () => {
+    expect(extractIssueNumbers("#1a2b3c")).toEqual([]);
+  });
+
+  it("deduplicates repeated issue numbers", () => {
+    expect(extractIssueNumbers("#42 and again #42")).toEqual([42]);
+  });
+
+  it("returns empty array when no issues found", () => {
+    expect(extractIssueNumbers("no issues here")).toEqual([]);
+  });
+
+  it("handles multiple issues in one string", () => {
+    const result = extractIssueNumbers("refs #1, #2, #3, #4");
+    expect(result).toEqual([1, 2, 3, 4]);
+  });
+});
+
+// ─── fetchIssueContext ───
+describe("fetchIssueContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty string when no issue numbers found", async () => {
+    const result = await fetchIssueContext("no issues in this text");
+    expect(result).toBe("");
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+
+  it("returns formatted context for a single issue", async () => {
+    mockExec.mockResolvedValueOnce({
+      stdout: JSON.stringify({ title: "Fix the bug", body: "Detailed description" }),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await fetchIssueContext("Fix #123 now");
+    expect(result).toContain("## Referenced Issue #123");
+    expect(result).toContain("Title: Fix the bug");
+    expect(result).toContain("Detailed description");
+  });
+
+  it("returns formatted context for multiple issues", async () => {
+    mockExec
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ title: "Issue one", body: "Body one" }),
+        stderr: "",
+        exitCode: 0,
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ title: "Issue two", body: "Body two" }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+    const result = await fetchIssueContext("See #10 and #20");
+    expect(result).toContain("## Referenced Issue #10");
+    expect(result).toContain("## Referenced Issue #20");
+  });
+
+  it("limits to first 3 issues", async () => {
+    mockExec.mockResolvedValue({
+      stdout: JSON.stringify({ title: "T", body: "B" }),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    await fetchIssueContext("#1 #2 #3 #4 #5");
+    expect(mockExec).toHaveBeenCalledTimes(3);
+  });
+
+  it("gracefully degrades when execFileNoThrow throws", async () => {
+    mockExec.mockRejectedValueOnce(new Error("gh not found"));
+    const result = await fetchIssueContext("Fix #99");
+    expect(result).toBe("");
+  });
+
+  it("gracefully degrades when gh returns non-zero exit code", async () => {
+    mockExec.mockResolvedValueOnce({
+      stdout: "",
+      stderr: "not found",
+      exitCode: 1,
+    });
+    const result = await fetchIssueContext("Fix #99");
+    expect(result).toBe("");
+  });
+
+  it("gracefully degrades when JSON parse fails", async () => {
+    mockExec.mockResolvedValueOnce({
+      stdout: "not valid json",
+      stderr: "",
+      exitCode: 0,
+    });
+    const result = await fetchIssueContext("Fix #99");
+    expect(result).toBe("");
+  });
+
+  it("truncates long issue body to 3000 chars", async () => {
+    const longBody = "x".repeat(5000);
+    mockExec.mockResolvedValueOnce({
+      stdout: JSON.stringify({ title: "Long issue", body: longBody }),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await fetchIssueContext("#77");
+    // The body in result should be truncated; full 5000 char body should not appear
+    expect(result).not.toContain("x".repeat(3001));
+    expect(result).toContain("x".repeat(100)); // partial body is present
+  });
+
+  it("deduplicates issue numbers before fetching", async () => {
+    mockExec.mockResolvedValue({
+      stdout: JSON.stringify({ title: "Dup", body: "body" }),
+      stderr: "",
+      exitCode: 0,
+    });
+
+    await fetchIssueContext("#55 and #55 again #55");
+    expect(mockExec).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips failed issues and returns context for successful ones", async () => {
+    mockExec
+      .mockResolvedValueOnce({
+        stdout: "",
+        stderr: "not found",
+        exitCode: 1,
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ title: "Good issue", body: "Good body" }),
+        stderr: "",
+        exitCode: 0,
+      });
+
+    const result = await fetchIssueContext("#1 #2");
+    expect(result).not.toContain("## Referenced Issue #1");
+    expect(result).toContain("## Referenced Issue #2");
+    expect(result).toContain("Good issue");
+  });
+});

--- a/tests/task-prompt-builder.test.ts
+++ b/tests/task-prompt-builder.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { buildTaskGenerationPrompt } from "../src/execution/task-prompt-builder.js";
+import type { StateManager } from "../src/state-manager.js";
+
+// Mock issue-context-fetcher so dynamic import in buildTaskGenerationPrompt is controlled
+vi.mock("../src/execution/issue-context-fetcher.js", () => ({
+  fetchIssueContext: vi.fn(async () => ""),
+}));
+
+import { fetchIssueContext } from "../src/execution/issue-context-fetcher.js";
+const mockFetchIssueContext = vi.mocked(fetchIssueContext);
+
+// Minimal Goal shape used in tests
+function makeGoal(overrides: {
+  id: string;
+  title: string;
+  description?: string;
+  parent_id?: string | null;
+}) {
+  return {
+    id: overrides.id,
+    title: overrides.title,
+    description: overrides.description ?? "",
+    parent_id: overrides.parent_id ?? null,
+    dimensions: [],
+    status: "active" as const,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    threshold_type: "min" as const,
+    threshold_value: 0,
+    current_value: null,
+    confidence: 0.5,
+    tags: [],
+  };
+}
+
+function makeMockStateManager(goals: Record<string, ReturnType<typeof makeGoal>>): StateManager {
+  return {
+    loadGoal: vi.fn(async (id: string) => goals[id] ?? null),
+    readRaw: vi.fn(async () => null),
+  } as unknown as StateManager;
+}
+
+describe("buildTaskGenerationPrompt — parent goal chain", () => {
+  it("includes parent goal chain section when goal has parent_id", async () => {
+    const parent = makeGoal({ id: "parent-1", title: "Parent Goal", description: "Parent description" });
+    const child = makeGoal({ id: "child-1", title: "Child Goal", description: "Child description", parent_id: "parent-1" });
+    const sm = makeMockStateManager({ "parent-1": parent, "child-1": child });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "child-1", "coverage");
+
+    expect(prompt).toContain("## Parent Goal Context");
+    expect(prompt).toContain("Goal: Parent Goal");
+    expect(prompt).toContain("Description: Parent description");
+  });
+
+  it("does not include parent goal chain section when goal has no parent_id", async () => {
+    const goal = makeGoal({ id: "root-1", title: "Root Goal" });
+    const sm = makeMockStateManager({ "root-1": goal });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "root-1", "coverage");
+
+    expect(prompt).not.toContain("## Parent Goal Context");
+  });
+
+  it("stops parent chain at 3 levels", async () => {
+    const level3 = makeGoal({ id: "l3", title: "Level 3", description: "desc3" });
+    const level2 = makeGoal({ id: "l2", title: "Level 2", description: "desc2", parent_id: "l3" });
+    const level1 = makeGoal({ id: "l1", title: "Level 1", description: "desc1", parent_id: "l2" });
+    const level0 = makeGoal({ id: "l0", title: "Level 0", description: "desc0", parent_id: "l1" });
+    // l3 also has a parent — should NOT be loaded
+    const level4 = makeGoal({ id: "l4", title: "Level 4 (should not appear)", description: "desc4" });
+    const goals = { l0: level0, l1: level1, l2: level2, l3: { ...level3, parent_id: "l4" }, l4: level4 };
+
+    const sm = makeMockStateManager(goals as Record<string, ReturnType<typeof makeGoal>>);
+
+    const prompt = await buildTaskGenerationPrompt(sm, "l0", "coverage");
+
+    expect(prompt).toContain("Goal: Level 1");
+    expect(prompt).toContain("Goal: Level 2");
+    expect(prompt).toContain("Goal: Level 3");
+    expect(prompt).not.toContain("Level 4 (should not appear)");
+  });
+
+  it("handles gracefully when a parent goal does not exist", async () => {
+    const child = makeGoal({ id: "child-2", title: "Child Goal", parent_id: "missing-parent" });
+    const sm = makeMockStateManager({ "child-2": child });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "child-2", "coverage");
+
+    // parent chain section should be absent (loadGoal returned null, chain is empty)
+    expect(prompt).not.toContain("## Parent Goal Context");
+    // prompt should still be generated without throwing
+    expect(prompt).toContain("Goal: Child Goal");
+  });
+});
+
+describe("buildTaskGenerationPrompt — task purpose section", () => {
+  it("includes task purpose section with dimension and subgoal title", async () => {
+    const goal = makeGoal({ id: "g1", title: "My Subgoal" });
+    const sm = makeMockStateManager({ "g1": goal });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "g1", "test_coverage");
+
+    expect(prompt).toContain("## Task Purpose");
+    expect(prompt).toContain('dimension "test_coverage"');
+    expect(prompt).toContain('"My Subgoal"');
+  });
+
+  it("includes parent goal title in task purpose when parent exists", async () => {
+    const parent = makeGoal({ id: "p1", title: "Grand Goal" });
+    const child = makeGoal({ id: "c1", title: "Sub Task", parent_id: "p1" });
+    const sm = makeMockStateManager({ "p1": parent, "c1": child });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "c1", "velocity");
+
+    expect(prompt).toContain("## Task Purpose");
+    expect(prompt).toContain('"Grand Goal"');
+    expect(prompt).toContain(', which is part of the parent goal "Grand Goal"');
+  });
+
+  it("omits parent goal from task purpose when no parent", async () => {
+    const goal = makeGoal({ id: "g2", title: "Standalone Goal" });
+    const sm = makeMockStateManager({ "g2": goal });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "g2", "quality");
+
+    expect(prompt).toContain("## Task Purpose");
+    expect(prompt).not.toContain("which is part of the parent goal");
+  });
+});
+
+describe("buildTaskGenerationPrompt — section ordering", () => {
+  it("places parent chain and task purpose before adapter section", async () => {
+    const parent = makeGoal({ id: "par", title: "Parent" });
+    const child = makeGoal({ id: "ch", title: "Child", parent_id: "par" });
+    const sm = makeMockStateManager({ "par": parent, "ch": child });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "ch", "dim", undefined, "github_issue");
+
+    const parentChainIdx = prompt.indexOf("## Parent Goal Context");
+    const taskPurposeIdx = prompt.indexOf("## Task Purpose");
+    const adapterIdx = prompt.indexOf("Execution context:");
+
+    expect(parentChainIdx).toBeGreaterThan(-1);
+    expect(taskPurposeIdx).toBeGreaterThan(parentChainIdx);
+    expect(adapterIdx).toBeGreaterThan(taskPurposeIdx);
+  });
+});
+
+describe("buildTaskGenerationPrompt — referenced issue section", () => {
+  beforeEach(() => {
+    mockFetchIssueContext.mockReset();
+    // Default: no issue context
+    mockFetchIssueContext.mockResolvedValue("");
+  });
+
+  it("includes issue content in prompt when fetchIssueContext returns content", async () => {
+    const issueContent = "## Referenced Issue #42\nTitle: Fix the regression\nSome body text here.";
+    mockFetchIssueContext.mockResolvedValue(issueContent);
+
+    const goal = makeGoal({ id: "g-issue", title: "Goal with issue ref #42" });
+    const sm = makeMockStateManager({ "g-issue": goal });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "g-issue", "coverage");
+
+    expect(prompt).toContain("## Referenced Issue #42");
+    expect(prompt).toContain("Title: Fix the regression");
+    expect(prompt).toContain("Some body text here.");
+  });
+
+  it("does not produce double heading when fetchIssueContext returns formatted content", async () => {
+    const issueContent = "## Referenced Issue #99\nTitle: Double heading check\nBody.";
+    mockFetchIssueContext.mockResolvedValue(issueContent);
+
+    const goal = makeGoal({ id: "g-double", title: "Double heading goal #99" });
+    const sm = makeMockStateManager({ "g-double": goal });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "g-double", "quality");
+
+    // Should appear exactly once — not wrapped in an additional outer heading
+    const occurrences = (prompt.match(/## Referenced Issue/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  it("does not include any issue section when fetchIssueContext returns empty string", async () => {
+    mockFetchIssueContext.mockResolvedValue("");
+
+    const goal = makeGoal({ id: "g-no-issue", title: "Goal without issues" });
+    const sm = makeMockStateManager({ "g-no-issue": goal });
+
+    const prompt = await buildTaskGenerationPrompt(sm, "g-no-issue", "coverage");
+
+    expect(prompt).not.toContain("## Referenced Issue");
+  });
+});


### PR DESCRIPTION
## Summary
- Task prompts now include **parent goal chain** (up to 3 levels) so agents understand the full context behind subgoals
- **GitHub issue content** is automatically fetched when `#NNN` patterns are found in goal text (`gh issue view`)
- **Task purpose statement** links each task to its subgoal and parent goal
- **Workspace keyword extraction** now uses parent goal descriptions for better file discovery

Closes #406

## Test plan
- [x] 31 new tests (20 for issue-context-fetcher, 11 for task-prompt-builder)
- [x] Full suite: 5391 passed
- [ ] Dogfood: `pulseed run "Fix issue #364"` → verify subgoal prompts contain issue body

🤖 Generated with [Claude Code](https://claude.com/claude-code)