### PR TITLE
fix: improve dogfood reliability — prompt hardening + LLM progress logs

### DIFF
--- a/src/goal/goal-tree-manager.ts
+++ b/src/goal/goal-tree-manager.ts
@@ -248,10 +248,12 @@ export class GoalTreeManager {
           },
         });
       } else {
+        this.logger?.info(`[LLM] ${new Date().toISOString()} calling goal_specificity_evaluation goalId=${goal.id}`);
         const response = await this.llmClient.sendMessage(
           [{ role: "user", content: prompt }],
           { temperature: 0 }
         );
+        this.logger?.info(`[LLM] ${new Date().toISOString()} done goal_specificity_evaluation goalId=${goal.id}`);
         parsed = this.llmClient.parseJSON(
           response.content,
           SpecificityResponseSchema
@@ -404,10 +406,12 @@ export class GoalTreeManager {
         });
         subgoalSpecs = subgoalSpecs.slice(0, maxChildren);
       } else {
+        this.logger?.info(`[LLM] ${new Date().toISOString()} calling goal_decomposition goalId=${goal.id}`);
         const subgoalResponse = await this.llmClient.sendMessage(
           [{ role: "user", content: subgoalPrompt }],
           { temperature: 0 }
         );
+        this.logger?.info(`[LLM] ${new Date().toISOString()} done goal_decomposition goalId=${goal.id}`);
         // Normalize hypothesis field: LLMs may use "title", "description", "goal", etc.
         // Pre-parse to fix missing hypothesis keys before passing to parseJSON.
         let contentToPass = subgoalResponse.content;
@@ -601,10 +605,12 @@ export class GoalTreeManager {
           });
           coverage = { covers_parent: raw.covers_parent, missing_dimensions: raw.missing_dimensions ?? [], reasoning: raw.reasoning };
         } else {
+          this.logger?.info(`[LLM] ${new Date().toISOString()} calling goal_coverage_validation goalId=${parent.id}`);
           const coverageResponse = await this.llmClient.sendMessage(
             [{ role: "user", content: coveragePrompt }],
             { temperature: 0 }
           );
+          this.logger?.info(`[LLM] ${new Date().toISOString()} done goal_coverage_validation goalId=${parent.id}`);
           const raw = this.llmClient.parseJSON(
             coverageResponse.content,
             CoverageResponseSchema

--- a/src/goal/refiner-prompts.ts
+++ b/src/goal/refiner-prompts.ts
@@ -59,5 +59,7 @@ Return JSON:
 }
 
 When is_measurable is false, set "dimensions" to null.
-For "present" threshold_type, always set "threshold_value" to null.`;
+For "present" threshold_type, always set "threshold_value" to null.
+
+IMPORTANT: Respond with ONLY the JSON object above. Do not return an array, do not wrap in markdown, do not include any other text.`;
 }


### PR DESCRIPTION
## Summary
- **Bug 1 fix**: Leaf test prompt now explicitly instructs LLM to return JSON object only (not array/strategy format), reducing `[parseJSON] validation failed` errors during goal refinement
- **Bug 2 fix**: Added `[LLM]` progress logs before/after all LLM calls in GoalTreeManager (specificity evaluation, decomposition, coverage validation) so users can see what the system is waiting for instead of a frozen terminal

## Context
Dogfood run (`pulseed run --goal <id> --tree`) appeared to hang for 6+ minutes with no output after a parseJSON error. Root cause: (1) LLM returned strategy-format array instead of LeafTestResult object, (2) subsequent LLM calls had no progress indicators.

## Test plan
- [x] All 5391 tests pass
- [x] Build succeeds
- [ ] Re-run dogfood: `pulseed run --goal <id> --yes --tree` → verify progress logs appear and no parse errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)