### PR TITLE
fix: improve dogfood reliability — goalRefiner, workspace, LLM logs

### DIFF
--- a/src/cli-runner.ts
+++ b/src/cli-runner.ts
@@ -174,13 +174,18 @@ export class CLIRunner {
           await this.stateManager.saveGoal(goal);
         }
       } else {
-        // No --workspace flag: check if goal already has workspace_path constraint
+        // No --workspace flag: auto-detect from cwd or use existing constraint
         const goal = await this.stateManager.loadGoal(goalId);
         if (goal) {
           const wpPrefix = "workspace_path:";
           const existing = goal.constraints.find((c) => c.startsWith(wpPrefix));
           if (existing) {
             resolvedWorkspace = existing.slice(wpPrefix.length);
+          } else {
+            // Auto-add workspace_path from cwd so observation can read real files
+            goal.constraints.push(`${wpPrefix}${process.cwd()}`);
+            await this.stateManager.saveGoal(goal);
+            resolvedWorkspace = process.cwd();
           }
         }
       }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -222,6 +222,26 @@ export async function buildDeps(
     rankDimensions: DriveScorer.rankDimensions,
   };
 
+  const goalNegotiator = new GoalNegotiator(
+    stateManager,
+    llmClient,
+    ethicsGate,
+    observationEngine,
+    characterConfig,
+    satisficingJudge,
+    goalTreeManager,
+    adapterRegistry.getAdapterCapabilities()
+  );
+
+  const goalRefiner = new GoalRefiner(
+    stateManager,
+    llmClient,
+    observationEngine,
+    goalNegotiator,
+    goalTreeManager,
+    ethicsGate,
+  );
+
   const coreLoop = new CoreLoop({
     stateManager,
     observationEngine,
@@ -245,27 +265,8 @@ export async function buildDeps(
     logger,
     contextProvider,
     onProgress,
+    goalRefiner,
   }, config);
-
-  const goalNegotiator = new GoalNegotiator(
-    stateManager,
-    llmClient,
-    ethicsGate,
-    observationEngine,
-    characterConfig,
-    satisficingJudge,
-    goalTreeManager,
-    adapterRegistry.getAdapterCapabilities()
-  );
-
-  const goalRefiner = new GoalRefiner(
-    stateManager,
-    llmClient,
-    observationEngine,
-    goalNegotiator,
-    goalTreeManager,
-    ethicsGate,
-  );
 
   return { coreLoop, goalNegotiator, goalRefiner, reportingEngine, stateManager, driveSystem, llmClient };
 }

--- a/src/execution/task-generation.ts
+++ b/src/execution/task-generation.ts
@@ -284,6 +284,7 @@ export async function generateTask(
   if (deps.gateway) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      console.log(`  [LLM] Calling LLM for task generation (${targetDimension})...`);
       generated = await deps.gateway.execute({
         purpose: "task_generation",
         goalId,
@@ -292,6 +293,7 @@ export async function generateTask(
         responseSchema: LLMGeneratedTaskSchema as z.ZodSchema<ReturnType<typeof LLMGeneratedTaskSchema.parse>>,
         maxTokens: 2048,
       });
+      console.log(`  [LLM] Task generation complete (${targetDimension}).`);
     } catch (err) {
       deps.logger?.error(
         "Task generation failed: PromptGateway.execute() error.",
@@ -300,6 +302,7 @@ export async function generateTask(
       throw err;
     }
   } else {
+    console.log(`  [LLM] Calling LLM for task generation (${targetDimension})...`);
     const response = await deps.llmClient.sendMessage(
       [{ role: "user", content: prompt }],
       {
@@ -309,6 +312,7 @@ export async function generateTask(
         model_tier: 'main',
       }
     );
+    console.log(`  [LLM] Task generation complete (${targetDimension}).`);
     try {
       generated = deps.llmClient.parseJSON(response.content, LLMGeneratedTaskSchema) as ReturnType<typeof LLMGeneratedTaskSchema.parse>;
     } catch (err) {
@@ -453,6 +457,7 @@ export async function generateTaskGroup(
   let raw: z.infer<typeof LLMTaskGroupSchema>;
   if (gateway) {
     try {
+      console.log(`  [LLM] Calling LLM for task group decomposition (${context.targetDimension})...`);
       raw = await gateway.execute({
         purpose: "task_generation",
         goalId: context.goalId,
@@ -461,6 +466,7 @@ export async function generateTaskGroup(
         responseSchema: LLMTaskGroupSchema as z.ZodSchema<z.infer<typeof LLMTaskGroupSchema>>,
         maxTokens: 4096,
       });
+      console.log(`  [LLM] Task group decomposition complete (${context.targetDimension}).`);
     } catch (err) {
       logger?.error("generateTaskGroup: PromptGateway.execute() failed", { error: String(err) });
       return null;
@@ -468,6 +474,7 @@ export async function generateTaskGroup(
   } else {
     let response: { content: string };
     try {
+      console.log(`  [LLM] Calling LLM for task group decomposition (${context.targetDimension})...`);
       response = await llmClient.sendMessage(
         [{ role: "user", content: prompt }],
         {
@@ -476,6 +483,7 @@ export async function generateTaskGroup(
           model_tier: 'main',
         }
       );
+      console.log(`  [LLM] Task group decomposition complete (${context.targetDimension}).`);
     } catch (err) {
       logger?.error("generateTaskGroup: LLM call failed", { error: String(err) });
       return null;

--- a/src/observation/observation-llm.ts
+++ b/src/observation/observation-llm.ts
@@ -300,17 +300,21 @@ export async function observeWithLLM(
     } catch (err) {
       // Fallback to direct LLM call if gateway fails
       logger?.warn(`[ObservationEngine] PromptGateway failed for "${dimensionLabel}", falling back to direct LLM: ${String(err)}`);
+      console.log(`  [LLM] Calling LLM for observation (fallback) "${dimensionLabel}"...`);
       const response = await llmClient.sendMessage(
         [{ role: "user", content: prompt }],
         { system: OBSERVATION_SYSTEM_PROMPT, max_tokens: 512, temperature: 0, model_tier: 'light' }
       );
+      console.log(`  [LLM] Observation (fallback) complete for "${dimensionLabel}".`);
       parsed = llmClient.parseJSON(response.content, LLMObservationResponseSchema);
     }
   } else {
+    console.log(`  [LLM] Calling LLM for observation "${dimensionLabel}"...`);
     const response = await llmClient.sendMessage(
       [{ role: "user", content: prompt }],
       { system: OBSERVATION_SYSTEM_PROMPT, max_tokens: 512, temperature: 0, model_tier: 'light' }
     );
+    console.log(`  [LLM] Observation complete for "${dimensionLabel}".`);
     parsed = llmClient.parseJSON(response.content, LLMObservationResponseSchema);
   }
 


### PR DESCRIPTION
## Summary
- **goalRefiner wiring**: moved `goalNegotiator`/`goalRefiner` creation before `CoreLoop` in `setup.ts` and added `goalRefiner` to CoreLoop deps — tree decomposition was silently skipped
- **workspace auto-detect**: when `--workspace` is omitted in `pulseed run`, auto-add `workspace_path:<cwd>` constraint so observation engine can read real files
- **[LLM] progress logs**: added `[LLM]` console logs before/after LLM calls in `observation-llm.ts` (2 paths) and `task-generation.ts` (4 paths) to match existing pattern in `goal-tree-manager.ts`

## Root Cause
Discovered during dogfood run of issue #364. The loop ran 3 iterations but made zero progress (gap=1.00) because:
1. Tree decomposition never fired (goalRefiner not in deps)
2. Observation had empty context (no workspace_path)
3. No visibility into which LLM call was hanging

## Test plan
- [x] `npm run build` — no errors
- [x] `npx vitest run` — 5394 tests pass (262 files)
- [ ] Re-run dogfood: `pulseed run --goal <id> --yes --tree` and verify [LLM] logs appear + observation reads real files

🤖 Generated with [Claude Code](https://claude.com/claude-code)