### PR TITLE
fix: force tree decomposition + dimension-aware observation context

### DIFF
--- a/src/loop/tree-loop-runner.ts
+++ b/src/loop/tree-loop-runner.ts
@@ -33,13 +33,14 @@ export async function runTreeIteration(
   let decomposed = false;
   if (rootGoalForDecomp && rootGoalForDecomp.children_ids.length === 0) {
     const defaultConfig = { min_specificity: 0.7, max_depth: 3, parallel_loop_limit: 3, auto_prune_threshold: 0.3 };
-    if (deps.goalRefiner) {
+    if (deps.treeLoopOrchestrator) {
       try {
-        logger?.info("CoreLoop: refining goal tree via GoalRefiner", { rootId });
-        const refineResult = await deps.goalRefiner.refine(rootId);
-        logger?.info("CoreLoop: refinement complete", { rootId, leaf: refineResult.leaf });
-        await deps.treeLoopOrchestrator?.startTreeExecution(rootId, defaultConfig);
-        decomposed = true;
+        logger?.info("CoreLoop: refining goal tree via ensureGoalRefined (force=true)", { rootId });
+        await deps.treeLoopOrchestrator.ensureGoalRefined(rootId, { force: true });
+        await deps.treeLoopOrchestrator.startTreeExecution(rootId, defaultConfig);
+        const rootAfterRefine = await deps.stateManager.loadGoal(rootId);
+        decomposed = (rootAfterRefine?.children_ids.length ?? 0) > 0;
+        logger?.info("CoreLoop: refinement complete", { rootId, decomposed });
       } catch (err) {
         logger?.warn("CoreLoop: refinement failed, falling back to flat iteration", { rootId, err });
       }
@@ -48,7 +49,7 @@ export async function runTreeIteration(
         logger?.info("CoreLoop: auto-decomposing goal tree", { rootId });
         const decompResult = await deps.goalTreeManager.decomposeGoal(rootId, defaultConfig);
         logger?.info("CoreLoop: decomposition complete", { rootId, childCount: decompResult.children.length });
-        await deps.treeLoopOrchestrator?.startTreeExecution(rootId, defaultConfig);
+        await orchestrator.startTreeExecution(rootId, defaultConfig);
         decomposed = true;
       } catch (err) {
         logger?.warn("CoreLoop: decomposition failed, falling back to flat iteration", { rootId, err });

--- a/src/observation/workspace-context.ts
+++ b/src/observation/workspace-context.ts
@@ -226,22 +226,33 @@ export function createWorkspaceContextProvider(
       return parts.join("\n\n");
     }
 
-    // Small workspace fast path: include ALL files when total count is small
-    if (allFiles.length <= SMALL_WORKSPACE_FILE_LIMIT) {
-      for (const fp of allFiles) {
-        const rel = path.relative(workDir, fp);
-        const content = await readFileSection(fp, maxCharsPerFile);
-        if (content) {
-          parts.push(`## ${rel}\n\`\`\`\n${content}\n\`\`\``);
-        }
+    // Dimension-name derived file hints: extract segments and match kebab-case filenames
+    // e.g. "try_catch_added_in_drive_system_event_watcher" → find "drive-system.ts"
+    const dimSegments = dimensionName
+      .toLowerCase()
+      .split("_")
+      .filter((w) => w.length >= 4 && !STOPWORDS.has(w));
+    const dimHintPaths: string[] = [];
+    if (dimSegments.length >= 2) {
+      for (let i = 0; i < dimSegments.length - 1; i++) {
+        const pattern = `${dimSegments[i]}-${dimSegments[i + 1]}`;
+        const matched = allFiles.filter((fp) => path.basename(fp).toLowerCase().includes(pattern));
+        dimHintPaths.push(...matched);
       }
-      return parts.join("\n\n");
+    }
+    // Also try single segments for direct matches (e.g. "verifier" → "task-verifier.ts")
+    for (const seg of dimSegments) {
+      if (seg.length >= 5) {
+        const matched = allFiles.filter((fp) => path.basename(fp).toLowerCase().includes(seg) && !dimHintPaths.includes(fp));
+        dimHintPaths.push(...matched);
+      }
     }
 
     // Separate already-included from candidates
     const alwaysSet = new Set(alwaysIncludePaths);
     const pathMatchSet = new Set(pathMatchedPaths);
-    const candidates = allFiles.filter((fp) => !alwaysSet.has(fp) && !pathMatchSet.has(fp));
+    const dimHintSet = new Set(dimHintPaths);
+    const candidates = allFiles.filter((fp) => !alwaysSet.has(fp) && !pathMatchSet.has(fp) && !dimHintSet.has(fp));
 
     // Phase 1: filename match
     const nameMatched = candidates.filter((fp) => fileMatchesKeywords(fp, keywords));
@@ -249,7 +260,7 @@ export function createWorkspaceContextProvider(
     // Phase 2: content match (only if we still need more)
     // alwaysInclude and pathMatch are treated as priority (outside maxFiles cap),
     // so keyword-match fills remaining slots up to maxFiles
-    const neededFromCandidates = Math.max(0, maxFiles - alwaysIncludePaths.length - pathMatchedPaths.length);
+    const neededFromCandidates = Math.max(0, maxFiles - alwaysIncludePaths.length - pathMatchedPaths.length - dimHintPaths.length);
     let selected = nameMatched.slice(0, neededFromCandidates);
 
     if (selected.length < neededFromCandidates) {
@@ -275,6 +286,15 @@ export function createWorkspaceContextProvider(
 
     // Read explicit path-matched files (priority, same as alwaysInclude)
     for (const fp of pathMatchedPaths) {
+      const rel = path.relative(effectiveWorkDir, fp);
+      const content = await readFileSection(fp, maxCharsPerFile);
+      if (content) {
+        parts.push(`## ${rel}\n\`\`\`\n${content}\n\`\`\``);
+      }
+    }
+
+    // Read dimension-hint matched files (priority)
+    for (const fp of dimHintPaths) {
       const rel = path.relative(effectiveWorkDir, fp);
       const content = await readFileSection(fp, maxCharsPerFile);
       if (content) {


### PR DESCRIPTION
## Summary
- **Tree decomposition force**: `runTreeIteration` now uses `ensureGoalRefined(rootId, { force: true })` instead of `goalRefiner.refine()` — the `hasValidatedDimensions` guard was silently skipping decomposition on goals with user-defined dimensions
- **Dimension-aware file selection**: extract kebab-case segments from dimension names (e.g. `try_catch_added_in_drive_system_event_watcher` → `drive-system`) and include matching source files as priority observation context
- **Dead code removal**: removed duplicate small-workspace fast path in workspace-context.ts

## Root Cause
After PR #411 and #412, dogfood still showed:
1. Tree decomposition not firing — `goalRefiner.refine()` was called without `force`, so `hasValidatedDimensions` returned true and skipped refinement
2. Observation reporting "no code evidence" — keyword matching only checked filenames against generic words like "try", "catch", missing the actual target files

## Test plan
- [x] `npm run build` — no errors
- [x] `npx vitest run` — 5391 pass (3 flaky event-file-watcher failures, pre-existing)
- [ ] Re-run dogfood and verify: tree/ directory created, observation notes mention actual source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)