### PR TITLE
fix: propagate force flag for tree decomposition (#415)

### DIFF
--- a/src/goal/goal-refiner.ts
+++ b/src/goal/goal-refiner.ts
@@ -200,7 +200,7 @@ export class GoalRefiner {
     }
 
     // ── Stopping condition c: already has validated dimensions ──
-    if (hasValidatedDimensions(goal)) {
+    if (!config.force && hasValidatedDimensions(goal)) {
       return {
         goal,
         leaf: true,

--- a/src/goal/refiner-prompts.ts
+++ b/src/goal/refiner-prompts.ts
@@ -61,5 +61,7 @@ Return JSON:
 When is_measurable is false, set "dimensions" to null.
 For "present" threshold_type, always set "threshold_value" to null.
 
+If the goal spans multiple files or multiple independent targets, prefer decomposition into per-file subgoals. A goal with more than 3 dimensions affecting different files should almost always be decomposed rather than treated as a single leaf.
+
 IMPORTANT: Respond with ONLY the JSON object above. Do not return an array, do not wrap in markdown, do not include any other text.`;
 }

--- a/src/goal/tree-loop-orchestrator.ts
+++ b/src/goal/tree-loop-orchestrator.ts
@@ -102,7 +102,7 @@ export class TreeLoopOrchestrator {
 
     if (this.goalRefiner) {
       try {
-        await this.goalRefiner.refine(goalId);
+        await this.goalRefiner.refine(goalId, options?.force ? { force: true } : undefined);
       } catch {
         // Non-fatal: fall back to raw decompose if refiner errors
         try {

--- a/src/types/goal-refiner.ts
+++ b/src/types/goal-refiner.ts
@@ -11,6 +11,7 @@ export const RefineConfigSchema = z.object({
   feasibilityCheck: z.boolean().default(true),
   minSpecificity: z.number().min(0).max(1).default(0.7),
   maxChildrenPerNode: z.number().int().min(1).default(5),
+  force: z.boolean().optional(),
 });
 export type RefineConfig = z.infer<typeof RefineConfigSchema>;
 

--- a/tests/tree-loop-orchestrator.test.ts
+++ b/tests/tree-loop-orchestrator.test.ts
@@ -1039,7 +1039,7 @@ describe("ensureGoalRefined — GoalRefiner integration", () => {
     await orchestratorWithRefiner.ensureGoalRefined(goal.id);
 
     expect(mockRefiner.refine).toHaveBeenCalledOnce();
-    expect(mockRefiner.refine).toHaveBeenCalledWith(goal.id);
+    expect(mockRefiner.refine).toHaveBeenCalledWith(goal.id, undefined);
   });
 
   it("does NOT call refiner.refine() when goal already has children", async () => {


### PR DESCRIPTION
## Summary
- Propagate `force` flag from `ensureGoalRefined()` through to `goalRefiner.refine()` — was being dropped at the call site in `tree-loop-orchestrator.ts`
- Skip `hasValidatedDimensions()` short-circuit when `force=true`, allowing LLM decomposition to proceed
- Add decomposition guidance to refiner prompt for multi-file goals
- Add `force` field to `RefineConfigSchema`

## Root Cause
`hasValidatedDimensions(goal)` returned `true` for goals with mechanical-confidence dimensions, causing `refine()` to return `leaf: true` before the LLM prompt was ever sent. The `force` flag passed by tree mode was silently dropped.

## Test plan
- [x] Build passes (`npm run build`)
- [x] All related tests pass (102 goal-refiner/tree tests)
- [x] 3 pre-existing failures in `regression/json-parse-failures.test.ts` — unrelated to this change

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)