### PR TITLE
feat: grep-based content matching for observation context

### DIFF
--- a/src/observation/workspace-context.ts
+++ b/src/observation/workspace-context.ts
@@ -1,6 +1,11 @@
+import { execFile } from "node:child_process";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { promisify } from "node:util";
+import { dimensionNameToSearchTerms } from "./context-provider.js";
+
+const execFileAsync = promisify(execFile);
 
 export interface WorkspaceContextOptions {
   workDir: string;
@@ -273,6 +278,34 @@ export function createWorkspaceContextProvider(
         ...selected,
         ...contentMatched.slice(0, neededFromCandidates - selected.length),
       ];
+    }
+
+    // Phase 3: grep content match — find files whose content contains dimension-derived terms
+    // but weren't caught by filename or keyword matching above
+    if (selected.length < neededFromCandidates) {
+      const searchTerms = dimensionNameToSearchTerms(dimensionName);
+      const alreadySelected = new Set([
+        ...alwaysIncludePaths, ...pathMatchedPaths, ...dimHintPaths, ...selected,
+      ]);
+      const grepMatched: string[] = [];
+      for (const term of searchTerms) {
+        try {
+          const { stdout } = await execFileAsync(
+            "grep",
+            ["-rl", "--include=*.ts", "--include=*.js", "--include=*.json", term, effectiveWorkDir],
+            { timeout: 5000 }
+          );
+          for (const fp of stdout.trim().split("\n").filter(Boolean)) {
+            if (!alreadySelected.has(fp) && !grepMatched.includes(fp)) {
+              grepMatched.push(fp);
+            }
+          }
+        } catch {
+          // grep returns exit 1 for zero matches — silently ignore
+        }
+      }
+      const slotsLeft = neededFromCandidates - selected.length;
+      selected = [...selected, ...grepMatched.slice(0, slotsLeft)];
     }
 
     // Read always-include files first

--- a/tests/workspace-context.test.ts
+++ b/tests/workspace-context.test.ts
@@ -382,6 +382,37 @@ describe("createWorkspaceContextProvider — dynamic workDir from goal constrain
   });
 });
 
+describe("createWorkspaceContextProvider — Phase 3 grep content match", () => {
+  let tmpWorkDir: string;
+
+  beforeEach(() => {
+    tmpWorkDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-ws-grep-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpWorkDir, { recursive: true, force: true });
+  });
+
+  it("finds a file by content when its name does not match any keyword", async () => {
+    // Create enough files to exceed the small workspace fast path (>10)
+    for (let i = 1; i <= 10; i++) {
+      fs.writeFileSync(path.join(tmpWorkDir, `unrelated${i}.ts`), `// file ${i}`, "utf-8");
+    }
+    // This file's name ("impl.ts") has no keyword match, but its content contains "TODO"
+    fs.writeFileSync(path.join(tmpWorkDir, "impl.ts"), "// TODO: finish this implementation", "utf-8");
+
+    const provider = createWorkspaceContextProvider(
+      { workDir: tmpWorkDir },
+      () => "Track todo count in the project"
+    );
+
+    // dimension "todo_count" → dimensionNameToSearchTerms → ["TODO"]
+    const result = await provider("goal-grep-1", "todo_count");
+    expect(result).toContain("impl.ts");
+    expect(result).toContain("TODO: finish this implementation");
+  });
+});
+
 describe("createWorkspaceContextProvider — existing workspace behavior unchanged", () => {
   let tmpWorkDir: string;
 


### PR DESCRIPTION
## Summary
- Add Phase 3 grep content match to `workspace-context.ts` — searches file contents using dimension-derived search terms via `grep -rl`
- Reuses existing `dimensionNameToSearchTerms()` from `context-provider.ts`
- Deduplicates against already-selected files and respects budget cap
- Grep failures are silently caught (non-fatal)

## Impact
Observation can now find files containing relevant code patterns (e.g., `JSON.parse`, `try/catch`) even when filenames don't match dimension keywords — significantly improves accuracy for code-level dimensions.

## Test plan
- [x] Build passes (`npm run build`)
- [x] 26/26 workspace-context tests pass (25 existing + 1 new grep test)
- [x] New test verifies: file with non-matching name but matching content is found by Phase 3

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)