### PR TITLE
fix(#366): replace unsafe as any[] casts in context-assembler

### DIFF
--- a/src/prompt/context-assembler.ts
+++ b/src/prompt/context-assembler.ts
@@ -245,7 +245,7 @@ export class ContextAssembler {
 
   private buildCurrentState(goalState: any): string {
     if (!goalState?.dimensions?.length) return "";
-    const dims = ((goalState.dimensions as Dimension[]) ?? []).map((d: Dimension) => ({
+    const dims = (goalState.dimensions as Array<Dimension & { gap?: number }>).map((d) => ({
       name: d.name,
       current: d.current_value,
       target: d.threshold?.value,


### PR DESCRIPTION
## Summary
- Replace `as any[]` casts with proper `as Dimension[]` typing on `goalState.dimensions` in `context-assembler.ts` (lines 247, 260, 413)
- Add `import type { Dimension }` and tighten callback parameter types from `any` to `Dimension`
- Closes #366

## Resolved Issues (4 bugs triaged)
| Issue | Resolution |
|-------|-----------|
| #366 | Fixed in this PR |
| #388 | Already fixed by PR #387 (closed) |
| #365 | Already fixed in current code (closed) |
| #363 | Already fixed in current code (closed) |

## Test plan
- [x] `npx vitest run tests/prompt/context-assembler.test.ts` — 22 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)