### PR TITLE
fix: retry HTTP 429 rate-limit responses with extended backoff

### DIFF
--- a/src/llm/base-llm-client.ts
+++ b/src/llm/base-llm-client.ts
@@ -20,6 +20,43 @@ export const MAX_RETRY_ATTEMPTS = 3;
 /** Exponential backoff delays in milliseconds: 1s, 2s, 4s */
 export const RETRY_DELAYS_MS = [1000, 2000, 4000];
 
+/** Extended backoff delays for HTTP 429 rate-limit responses (up to 5 retries) */
+export const RATE_LIMIT_RETRY_DELAYS_MS = [2000, 8000, 16000, 32000, 60000];
+
+/**
+ * Returns true if the error represents an HTTP 429 rate-limit response.
+ */
+export function isRateLimitError(err: unknown): boolean {
+  if (err != null && typeof err === "object" && "status" in err) {
+    if ((err as { status: unknown }).status === 429) return true;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("429") || /rate.?limit/i.test(msg);
+}
+
+/**
+ * Returns the retry delay in milliseconds for a rate-limit error.
+ * Respects the Retry-After header when present, otherwise falls back to
+ * RATE_LIMIT_RETRY_DELAYS_MS[attemptIndex].
+ * Adds jitter (±50%) to avoid thundering-herd.
+ */
+export function getRateLimitRetryDelay(err: unknown, attemptIndex: number): number {
+  // Check for Retry-After header
+  if (err != null && typeof err === "object" && "headers" in err) {
+    const headers = (err as { headers: unknown }).headers;
+    if (headers != null && typeof headers === "object" && "retry-after" in headers) {
+      const retryAfter = (headers as Record<string, unknown>)["retry-after"];
+      const seconds = typeof retryAfter === "string" ? parseFloat(retryAfter) : Number(retryAfter);
+      if (!isNaN(seconds) && seconds > 0) {
+        const delay = seconds * 1000;
+        return delay * (0.5 + Math.random());
+      }
+    }
+  }
+  const base = RATE_LIMIT_RETRY_DELAYS_MS[attemptIndex] ?? RATE_LIMIT_RETRY_DELAYS_MS[RATE_LIMIT_RETRY_DELAYS_MS.length - 1]!;
+  return base * (0.5 + Math.random());
+}
+
 // ─── JSON extraction utility ───
 
 /**

--- a/src/llm/llm-client.ts
+++ b/src/llm/llm-client.ts
@@ -1,7 +1,7 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { ZodSchema } from "zod";
 import { sleep } from "../utils/sleep.js";
-import { BaseLLMClient, DEFAULT_MAX_TOKENS, DEFAULT_LLM_TIMEOUT_MS, MAX_RETRY_ATTEMPTS, RETRY_DELAYS_MS, extractJSON } from "./base-llm-client.js";
+import { BaseLLMClient, DEFAULT_MAX_TOKENS, DEFAULT_LLM_TIMEOUT_MS, MAX_RETRY_ATTEMPTS, RETRY_DELAYS_MS, RATE_LIMIT_RETRY_DELAYS_MS, isRateLimitError, getRateLimitRetryDelay, extractJSON } from "./base-llm-client.js";
 import type { ModelTier, ParseJSONMessage, ParseJSONOptions } from "./base-llm-client.js";
 import { LLMError } from "../utils/errors.js";
 import { GuardrailRunner } from "../guardrail-runner.js";
@@ -81,6 +81,7 @@ export class LLMClient extends BaseLLMClient implements ILLMClient {
   /**
    * Send a message to the Anthropic API with retry logic.
    * Retries up to MAX_RETRY_ATTEMPTS times with exponential backoff.
+   * Retries up to RATE_LIMIT_RETRY_DELAYS_MS.length times on HTTP 429 with extended backoff.
    */
   async sendMessage(
     messages: LLMMessage[],
@@ -113,8 +114,10 @@ export class LLMClient extends BaseLLMClient implements ILLMClient {
 
     let lastError: unknown;
     let result: LLMResponse | undefined;
+    let normalAttempts = 0;
+    let rateLimitAttempts = 0;
 
-    for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt++) {
+    while (normalAttempts < MAX_RETRY_ATTEMPTS) {
       try {
         const response = await this.client.messages.create(
           {
@@ -143,6 +146,14 @@ export class LLMClient extends BaseLLMClient implements ILLMClient {
         };
         break;
       } catch (err) {
+        lastError = err;
+        // Rate limit: retry with extended backoff (does not count against normalAttempts)
+        if (isRateLimitError(err) && rateLimitAttempts < RATE_LIMIT_RETRY_DELAYS_MS.length) {
+          await sleep(getRateLimitRetryDelay(err, rateLimitAttempts));
+          rateLimitAttempts++;
+          continue;
+        }
+        // Other 4xx client errors: throw immediately
         if (
           err instanceof Error &&
           "status" in err &&
@@ -150,11 +161,11 @@ export class LLMClient extends BaseLLMClient implements ILLMClient {
           err.status >= 400 &&
           err.status < 500
         ) {
-          throw err; // client error, no retry
+          throw err;
         }
-        lastError = err;
-        if (attempt < MAX_RETRY_ATTEMPTS - 1) {
-          await sleep(RETRY_DELAYS_MS[attempt] ?? 1000);
+        normalAttempts++;
+        if (normalAttempts < MAX_RETRY_ATTEMPTS) {
+          await sleep(RETRY_DELAYS_MS[normalAttempts - 1] ?? 1000);
         }
       }
     }

--- a/src/llm/ollama-client.ts
+++ b/src/llm/ollama-client.ts
@@ -1,4 +1,4 @@
-import { BaseLLMClient, DEFAULT_MAX_TOKENS, DEFAULT_LLM_TIMEOUT_MS, MAX_RETRY_ATTEMPTS, RETRY_DELAYS_MS } from "./base-llm-client.js";
+import { BaseLLMClient, DEFAULT_MAX_TOKENS, DEFAULT_LLM_TIMEOUT_MS, MAX_RETRY_ATTEMPTS, RETRY_DELAYS_MS, RATE_LIMIT_RETRY_DELAYS_MS, isRateLimitError, getRateLimitRetryDelay } from "./base-llm-client.js";
 import { type ILLMClient, type LLMMessage, type LLMRequestOptions, type LLMResponse } from "./llm-client.js";
 import { sleep } from "../utils/sleep.js";
 import { LLMError } from "../utils/errors.js";
@@ -38,6 +38,7 @@ export class OllamaLLMClient extends BaseLLMClient implements ILLMClient {
   /**
    * Send a message to Ollama's OpenAI-compatible chat completions endpoint.
    * Retries up to MAX_RETRY_ATTEMPTS times with exponential backoff on network errors.
+   * Retries up to RATE_LIMIT_RETRY_DELAYS_MS.length times on HTTP 429 with extended backoff.
    */
   async sendMessage(
     messages: LLMMessage[],
@@ -67,8 +68,10 @@ export class OllamaLLMClient extends BaseLLMClient implements ILLMClient {
 
     const url = `${this.baseUrl}/v1/chat/completions`;
     let lastError: unknown;
+    let normalAttempts = 0;
+    let rateLimitAttempts = 0;
 
-    for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt++) {
+    while (normalAttempts < MAX_RETRY_ATTEMPTS) {
       try {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), DEFAULT_LLM_TIMEOUT_MS);
@@ -118,14 +121,21 @@ export class OllamaLLMClient extends BaseLLMClient implements ILLMClient {
         };
       } catch (err) {
         lastError = err;
-        // Only retry on network/fetch errors, not on HTTP 4xx client errors
+        // Rate limit: retry with extended backoff (does not count against normalAttempts)
+        if (isRateLimitError(err) && rateLimitAttempts < RATE_LIMIT_RETRY_DELAYS_MS.length) {
+          await sleep(getRateLimitRetryDelay(err, rateLimitAttempts));
+          rateLimitAttempts++;
+          continue;
+        }
+        // Only retry on network/fetch errors, not on HTTP 4xx client errors (excluding 429)
         const isNetworkError =
           err instanceof TypeError ||
           (err instanceof Error &&
             !err.message.startsWith("OllamaLLMClient: HTTP 4"));
 
-        if (attempt < MAX_RETRY_ATTEMPTS - 1 && isNetworkError) {
-          await sleep(RETRY_DELAYS_MS[attempt] ?? 1000);
+        normalAttempts++;
+        if (normalAttempts < MAX_RETRY_ATTEMPTS && isNetworkError) {
+          await sleep(RETRY_DELAYS_MS[normalAttempts - 1] ?? 1000);
         } else if (!isNetworkError) {
           throw err;
         }

--- a/src/llm/openai-client.ts
+++ b/src/llm/openai-client.ts
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import { BaseLLMClient, DEFAULT_MAX_TOKENS, DEFAULT_LLM_TIMEOUT_MS, MAX_RETRY_ATTEMPTS, RETRY_DELAYS_MS } from "./base-llm-client.js";
+import { BaseLLMClient, DEFAULT_MAX_TOKENS, DEFAULT_LLM_TIMEOUT_MS, MAX_RETRY_ATTEMPTS, RETRY_DELAYS_MS, RATE_LIMIT_RETRY_DELAYS_MS, isRateLimitError, getRateLimitRetryDelay } from "./base-llm-client.js";
 import { type ILLMClient, type LLMMessage, type LLMRequestOptions, type LLMResponse } from "./llm-client.js";
 import { sleep } from "../utils/sleep.js";
 import { LLMError } from "../utils/errors.js";
@@ -61,6 +61,7 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
   /**
    * Send a message to the OpenAI chat completions API with retry logic.
    * Retries up to MAX_RETRY_ATTEMPTS times with exponential backoff on network errors.
+   * Retries up to RATE_LIMIT_RETRY_DELAYS_MS.length times on HTTP 429 with extended backoff.
    *
    * For reasoning models (o1, o3, o4), temperature is omitted as it is not supported.
    * System prompt is sent as a "developer" role message, prepended to the messages array.
@@ -92,8 +93,10 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
     };
 
     let lastError: unknown;
+    let normalAttempts = 0;
+    let rateLimitAttempts = 0;
 
-    for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt++) {
+    while (normalAttempts < MAX_RETRY_ATTEMPTS) {
       try {
         try {
           const response = await this.client.chat.completions.create(createParams, { timeout: DEFAULT_LLM_TIMEOUT_MS });
@@ -167,14 +170,21 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
         }
       } catch (err) {
         lastError = err;
-        // Only retry on network/transient errors, not on HTTP 4xx client errors
+        // Rate limit: retry with extended backoff (does not count against normalAttempts)
+        if (isRateLimitError(err) && rateLimitAttempts < RATE_LIMIT_RETRY_DELAYS_MS.length) {
+          await sleep(getRateLimitRetryDelay(err, rateLimitAttempts));
+          rateLimitAttempts++;
+          continue;
+        }
+        // Only retry on network/transient errors, not on HTTP 4xx client errors (excluding 429)
         const isNetworkError =
           err instanceof TypeError ||
           (err instanceof Error &&
             !err.message.startsWith("OpenAILLMClient: HTTP 4"));
 
-        if (attempt < MAX_RETRY_ATTEMPTS - 1 && isNetworkError) {
-          await sleep(RETRY_DELAYS_MS[attempt] ?? 1000);
+        normalAttempts++;
+        if (normalAttempts < MAX_RETRY_ATTEMPTS && isNetworkError) {
+          await sleep(RETRY_DELAYS_MS[normalAttempts - 1] ?? 1000);
         } else if (!isNetworkError) {
           throw err;
         }

--- a/tests/llm-client-send-message.test.ts
+++ b/tests/llm-client-send-message.test.ts
@@ -163,4 +163,39 @@ describe("LLMClient.sendMessage", () => {
     await expectation;
     expect(createMock).toHaveBeenCalledTimes(3);
   });
+
+  it("retries on HTTP 429 with extended backoff and eventually succeeds", async () => {
+    const { LLMClient } = await import("../src/llm/llm-client.js");
+    const rateLimitErr = Object.assign(new Error("Too Many Requests"), { status: 429 });
+    createMock
+      .mockRejectedValueOnce(rateLimitErr)
+      .mockRejectedValueOnce(rateLimitErr)
+      .mockResolvedValueOnce({
+        content: [{ type: "text", text: "success after rate limit" }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        stop_reason: "end_turn",
+      });
+
+    const client = new LLMClient("sk-ant-test");
+    const responsePromise = client.sendMessage([{ role: "user", content: "rate limited" }]);
+
+    await vi.runAllTimersAsync();
+    const response = await responsePromise;
+
+    expect(createMock).toHaveBeenCalledTimes(3);
+    expect(response.content).toBe("success after rate limit");
+  });
+
+  it("does not retry on HTTP 400 or 403", async () => {
+    const { LLMClient } = await import("../src/llm/llm-client.js");
+    for (const status of [400, 403]) {
+      createMock.mockReset();
+      const clientErr = Object.assign(new Error(`HTTP ${status}`), { status });
+      createMock.mockRejectedValueOnce(clientErr);
+
+      const client = new LLMClient("sk-ant-test");
+      await expect(client.sendMessage([{ role: "user", content: "bad" }])).rejects.toThrow();
+      expect(createMock).toHaveBeenCalledTimes(1);
+    }
+  });
 });

--- a/tests/llm-client.test.ts
+++ b/tests/llm-client.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { z } from "zod";
 import { MockLLMClient, LLMClient } from "../src/llm/llm-client.js";
 import type { ILLMClient } from "../src/llm/llm-client.js";
-import { extractJSON } from "../src/llm/base-llm-client.js";
+import { extractJSON, isRateLimitError, getRateLimitRetryDelay, RATE_LIMIT_RETRY_DELAYS_MS } from "../src/llm/base-llm-client.js";
 
 // ─── MockLLMClient ───
 
@@ -392,6 +392,72 @@ describe("MockLLMClient", () => {
         warnSpy.mockRestore();
       }
     });
+  });
+});
+
+// ─── isRateLimitError / getRateLimitRetryDelay ───
+
+describe("isRateLimitError", () => {
+  it("returns true for error with status 429", () => {
+    const err = Object.assign(new Error("Too Many Requests"), { status: 429 });
+    expect(isRateLimitError(err)).toBe(true);
+  });
+
+  it("returns true for error message containing '429'", () => {
+    expect(isRateLimitError(new Error("HTTP 429 Too Many Requests"))).toBe(true);
+  });
+
+  it("returns true for error message containing 'rate limit' (case-insensitive)", () => {
+    expect(isRateLimitError(new Error("Rate Limit exceeded"))).toBe(true);
+    expect(isRateLimitError(new Error("rate limit hit"))).toBe(true);
+  });
+
+  it("returns false for other 4xx errors", () => {
+    expect(isRateLimitError(Object.assign(new Error("Unauthorized"), { status: 401 }))).toBe(false);
+    expect(isRateLimitError(Object.assign(new Error("Forbidden"), { status: 403 }))).toBe(false);
+    expect(isRateLimitError(new Error("Bad Request"))).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+    expect(isRateLimitError("string error")).toBe(false);
+  });
+});
+
+describe("getRateLimitRetryDelay", () => {
+  it("adds jitter so delay is not exactly the base value", () => {
+    // Run multiple times to statistically verify jitter is applied
+    const base = RATE_LIMIT_RETRY_DELAYS_MS[0]!;
+    const err = Object.assign(new Error("429"), { status: 429 });
+    const delays = Array.from({ length: 10 }, () => getRateLimitRetryDelay(err, 0));
+    // With jitter factor of (0.5 + Math.random()), delay is in [base*0.5, base*1.5]
+    for (const d of delays) {
+      expect(d).toBeGreaterThanOrEqual(base * 0.5);
+      expect(d).toBeLessThanOrEqual(base * 1.5);
+    }
+    // At least one delay should differ (probability of all being equal is astronomically low)
+    const allSame = delays.every((d) => d === delays[0]);
+    expect(allSame).toBe(false);
+  });
+
+  it("respects Retry-After header when present", () => {
+    const err = Object.assign(new Error("429"), {
+      status: 429,
+      headers: { "retry-after": "10" },
+    });
+    const delay = getRateLimitRetryDelay(err, 0);
+    // 10 seconds * jitter factor (0.5..1.5)
+    expect(delay).toBeGreaterThanOrEqual(5000);
+    expect(delay).toBeLessThanOrEqual(15000);
+  });
+
+  it("falls back to RATE_LIMIT_RETRY_DELAYS_MS when no Retry-After header", () => {
+    const err = Object.assign(new Error("429"), { status: 429 });
+    const delay = getRateLimitRetryDelay(err, 2);
+    const base = RATE_LIMIT_RETRY_DELAYS_MS[2]!;
+    expect(delay).toBeGreaterThanOrEqual(base * 0.5);
+    expect(delay).toBeLessThanOrEqual(base * 1.5);
   });
 });
 


### PR DESCRIPTION
## Summary
- HTTP 429 (rate limit) responses were incorrectly treated as non-retryable 4xx client errors across all LLM clients
- Added separate rate-limit retry budget (up to 5 retries with 2s/8s/16s/32s/60s backoff + jitter) that doesn't consume the normal retry budget
- Respects `Retry-After` header when present
- Applied consistently to all 3 LLM clients (Anthropic, OpenAI, Ollama)

Closes #427

## Changes
- `src/llm/base-llm-client.ts` — Added `isRateLimitError()`, `getRateLimitRetryDelay()`, `RATE_LIMIT_RETRY_DELAYS_MS`
- `src/llm/llm-client.ts` — Anthropic client: separate rate-limit retry loop
- `src/llm/openai-client.ts` — OpenAI client: same pattern
- `src/llm/ollama-client.ts` — Ollama client: same pattern
- `tests/llm-client.test.ts` — Tests for `isRateLimitError`, `getRateLimitRetryDelay` (jitter, Retry-After)
- `tests/llm-client-send-message.test.ts` — Tests for 429 retry success, 400/403 immediate throw

## Test plan
- [x] All 5599 tests pass
- [x] New tests cover: 429 retry → success, 400/403 no retry, jitter range, Retry-After header

🤖 Generated with [Claude Code](https://claude.com/claude-code)