### PR TITLE
refactor: rename TaskHistoryEntry to StallTaskHistoryEntry (#426)

### DIFF
--- a/src/drive/stall-detector.ts
+++ b/src/drive/stall-detector.ts
@@ -67,7 +67,7 @@ const NO_CHANGE_PATTERNS = ["no changes made", "no modifications", "nothing to c
 
 // ─── Exported interfaces ───
 
-export interface TaskHistoryEntry {
+export interface StallTaskHistoryEntry {
   strategy_id: string | null;
   output: string;
 }
@@ -158,7 +158,7 @@ export class StallDetector {
    * Detect repetitive patterns in task execution history.
    * Checks for: identical_actions, oscillating, no_change patterns.
    */
-  detectRepetitivePatterns(taskHistory: TaskHistoryEntry[]): RepetitivePatternResult {
+  detectRepetitivePatterns(taskHistory: StallTaskHistoryEntry[]): RepetitivePatternResult {
     if (taskHistory.length < REPETITIVE_WINDOW) {
       return { isRepetitive: false, pattern: null, confidence: 0 };
     }

--- a/tests/stall-detector-repetitive.test.ts
+++ b/tests/stall-detector-repetitive.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import { StateManager } from "../src/state-manager.js";
 import { StallDetector } from "../src/drive/stall-detector.js";
-import type { TaskHistoryEntry } from "../src/drive/stall-detector.js";
+import type { StallTaskHistoryEntry } from "../src/drive/stall-detector.js";
 import { makeTempDir } from "./helpers/temp-dir.js";
 
 let tempDir: string;
@@ -21,7 +21,7 @@ afterEach(() => {
 
 describe("detectRepetitivePatterns", () => {
   it("returns not repetitive when history is too short", () => {
-    const history: TaskHistoryEntry[] = [
+    const history: StallTaskHistoryEntry[] = [
       { strategy_id: "s1", output: "did something" },
       { strategy_id: "s1", output: "did something" },
     ];
@@ -32,7 +32,7 @@ describe("detectRepetitivePatterns", () => {
 
   it("detects identical_actions when same strategy and similar output repeated 3+ times", () => {
     const output = "Ran the test suite and updated 3 files with the same approach each time.";
-    const history: TaskHistoryEntry[] = [
+    const history: StallTaskHistoryEntry[] = [
       { strategy_id: "strategy-abc", output },
       { strategy_id: "strategy-abc", output },
       { strategy_id: "strategy-abc", output },
@@ -44,7 +44,7 @@ describe("detectRepetitivePatterns", () => {
   });
 
   it("detects oscillating pattern when outputs alternate A→B→A→B", () => {
-    const history: TaskHistoryEntry[] = [
+    const history: StallTaskHistoryEntry[] = [
       { strategy_id: "s1", output: "output-alpha" },
       { strategy_id: "s2", output: "output-beta" },
       { strategy_id: "s1", output: "output-alpha" },
@@ -57,7 +57,7 @@ describe("detectRepetitivePatterns", () => {
   });
 
   it("detects no_change when outputs repeatedly say no changes made", () => {
-    const history: TaskHistoryEntry[] = [
+    const history: StallTaskHistoryEntry[] = [
       { strategy_id: "s1", output: "Checked files. No changes made." },
       { strategy_id: "s1", output: "Reviewed code. No changes made to the codebase." },
       { strategy_id: "s2", output: "Inspected state. No changes made at this time." },
@@ -69,7 +69,7 @@ describe("detectRepetitivePatterns", () => {
   });
 
   it("returns not repetitive for genuinely different outputs", () => {
-    const history: TaskHistoryEntry[] = [
+    const history: StallTaskHistoryEntry[] = [
       { strategy_id: "s1", output: "Updated authentication module with OAuth2 support" },
       { strategy_id: "s2", output: "Refactored database layer to use connection pooling" },
       { strategy_id: "s3", output: "Added rate limiting middleware to API endpoints" },
@@ -81,7 +81,7 @@ describe("detectRepetitivePatterns", () => {
 
   it("does not flag identical_actions when strategy_id is null", () => {
     const output = "Ran command. Exit code 0.";
-    const history: TaskHistoryEntry[] = [
+    const history: StallTaskHistoryEntry[] = [
       { strategy_id: null, output },
       { strategy_id: null, output },
       { strategy_id: null, output },


### PR DESCRIPTION
## Summary
- Rename `TaskHistoryEntry` → `StallTaskHistoryEntry` in `src/drive/stall-detector.ts` to resolve name collision with the internal `TaskHistoryEntry` in `src/execution/task-generation.ts`
- Update import in `tests/stall-detector-repetitive.test.ts`

## Test plan
- [x] 118 stall-detector tests pass
- [x] `tsc` build passes with no type errors

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)