### PR TITLE
fix: add maxRetries to rmSync cleanup for Node 22 ENOTEMPTY flaky

### DIFF
--- a/tests/adapters/openclaw-datasource.test.ts
+++ b/tests/adapters/openclaw-datasource.test.ts
@@ -33,7 +33,7 @@ describe("OpenClawDataSourceAdapter", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(sessionDir, { recursive: true, force: true });
+    fs.rmSync(sessionDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── connect / disconnect / healthCheck ───

--- a/tests/adapters/shell-datasource.test.ts
+++ b/tests/adapters/shell-datasource.test.ts
@@ -27,7 +27,7 @@ describe("ShellDataSourceAdapter", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // 1. observe() with output_type "number" via echo
@@ -233,6 +233,6 @@ describe("ShellDataSourceAdapter", () => {
     expect(entry.goal_id).toBe(goal.id);
     expect(entry.dimension_name).toBe("todo_count");
 
-    fs.rmSync(stateDir, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 });

--- a/tests/capability-dependency.test.ts
+++ b/tests/capability-dependency.test.ts
@@ -41,7 +41,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── resolveDependencies ───

--- a/tests/capability-detector-detect.test.ts
+++ b/tests/capability-detector-detect.test.ts
@@ -98,7 +98,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── detectDeficiency ───

--- a/tests/capability-detector-escalate.test.ts
+++ b/tests/capability-detector-escalate.test.ts
@@ -90,7 +90,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── escalateToUser ───

--- a/tests/capability-detector-goal.test.ts
+++ b/tests/capability-detector-goal.test.ts
@@ -57,7 +57,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── detectGoalCapabilityGap ───
@@ -257,7 +257,7 @@ describe("matchPluginsForGoal", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function makePluginLoader(pluginStates: Array<{

--- a/tests/capability-detector-verify.test.ts
+++ b/tests/capability-detector-verify.test.ts
@@ -78,7 +78,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── verifyAcquiredCapability ───

--- a/tests/character-config.test.ts
+++ b/tests/character-config.test.ts
@@ -23,7 +23,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── CharacterConfigSchema validation ───

--- a/tests/character-separation.test.ts
+++ b/tests/character-separation.test.ts
@@ -19,7 +19,7 @@ import { createMockLLMClient } from "./helpers/mock-llm.js";
 import { makeTempDir } from "./helpers/temp-dir.js";
 
 function removeDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 // Extreme character configs for boundary testing

--- a/tests/cli-capability.test.ts
+++ b/tests/cli-capability.test.ts
@@ -151,7 +151,7 @@ afterEach(() => {
     process.env.ANTHROPIC_API_KEY = origApiKey;
   }
   delete process.env.PULSEED_LLM_PROVIDER;
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   vi.clearAllMocks();
   vi.restoreAllMocks();
 });

--- a/tests/cli-improve.test.ts
+++ b/tests/cli-improve.test.ts
@@ -197,7 +197,7 @@ afterEach(() => {
   }
   delete process.env.PULSEED_LLM_PROVIDER;
 
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   vi.clearAllMocks();
 });
 

--- a/tests/cli-knowledge.test.ts
+++ b/tests/cli-knowledge.test.ts
@@ -162,7 +162,7 @@ afterEach(() => {
     process.env.ANTHROPIC_API_KEY = origApiKey;
   }
   delete process.env.PULSEED_LLM_PROVIDER;
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   vi.clearAllMocks();
   vi.restoreAllMocks();
 });

--- a/tests/cli-plugin.test.ts
+++ b/tests/cli-plugin.test.ts
@@ -149,7 +149,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   vi.clearAllMocks();
   vi.restoreAllMocks();
 });

--- a/tests/cli-runner-datasource-auto.test.ts
+++ b/tests/cli-runner-datasource-auto.test.ts
@@ -153,7 +153,7 @@ afterEach(() => {
     process.env.ANTHROPIC_API_KEY = origApiKey;
   }
   delete process.env.PULSEED_LLM_PROVIDER;
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   vi.clearAllMocks();
 });
 

--- a/tests/cli-runner-integration.test.ts
+++ b/tests/cli-runner-integration.test.ts
@@ -87,7 +87,7 @@ afterEach(() => {
     process.env.ANTHROPIC_API_KEY = origApiKey;
   }
   delete process.env.PULSEED_LLM_PROVIDER;
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   vi.clearAllMocks();
 });
 

--- a/tests/cli-runner.test.ts
+++ b/tests/cli-runner.test.ts
@@ -229,7 +229,7 @@ afterEach(() => {
   }
   delete process.env.PULSEED_LLM_PROVIDER;
 
-  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ENOTEMPTY on Node 20 CI — ignore */ }
+  try { fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 }); } catch { /* ENOTEMPTY on Node 20 CI — ignore */ }
   vi.clearAllMocks();
 });
 
@@ -1116,7 +1116,7 @@ describe("directory initialisation", () => {
       expect(fs.existsSync(path.join(freshDir, "reports"))).toBe(true);
       expect(fs.existsSync(path.join(freshDir, "events"))).toBe(true);
     } finally {
-      fs.rmSync(freshDir, { recursive: true, force: true });
+      fs.rmSync(freshDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     }
   });
 });

--- a/tests/cli/goal-utils.test.ts
+++ b/tests/cli/goal-utils.test.ts
@@ -20,7 +20,7 @@ describe("autoRegisterFileExistenceDataSources — dedup by path and scope_goal_
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function writeDatasource(filename: string, cfg: Record<string, unknown>): void {

--- a/tests/core-loop-auto-decompose.test.ts
+++ b/tests/core-loop-auto-decompose.test.ts
@@ -294,7 +294,7 @@ describe("CoreLoop auto-decompose (issue #295)", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("skips decomposition when autoDecompose is false", async () => {

--- a/tests/core-loop-capability.test.ts
+++ b/tests/core-loop-capability.test.ts
@@ -313,7 +313,7 @@ describe("CoreLoop — capability_acquiring handler", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("successful acquire -> verify(pass) -> register cycle", async () => {

--- a/tests/core-loop-checkpoint.test.ts
+++ b/tests/core-loop-checkpoint.test.ts
@@ -260,7 +260,7 @@ describe("CoreLoop §4.8 checkpoint", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── 1. Checkpoint saved after successful verify cycle ───

--- a/tests/core-loop-drive-context.test.ts
+++ b/tests/core-loop-drive-context.test.ts
@@ -311,7 +311,7 @@ describe("CoreLoop", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── buildDriveContext ───

--- a/tests/core-loop-flow.test.ts
+++ b/tests/core-loop-flow.test.ts
@@ -322,7 +322,7 @@ describe("CoreLoop", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── Consecutive error limit ───

--- a/tests/core-loop-integration.test.ts
+++ b/tests/core-loop-integration.test.ts
@@ -57,7 +57,7 @@ class MockAdapter implements IAdapter {
 // ─── Helpers ───
 
 function removeTempDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 function makeGoal(id: string): Goal {

--- a/tests/core-loop-integrations.test.ts
+++ b/tests/core-loop-integrations.test.ts
@@ -322,7 +322,7 @@ describe("CoreLoop", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── KnowledgeManager integration ───

--- a/tests/core-loop-iteration.test.ts
+++ b/tests/core-loop-iteration.test.ts
@@ -307,7 +307,7 @@ describe("CoreLoop", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── runOneIteration ───

--- a/tests/core-loop-orchestrator-regression.test.ts
+++ b/tests/core-loop-orchestrator-regression.test.ts
@@ -251,7 +251,7 @@ describe("CoreLoop orchestrator regression", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("handles score override ordering in live execution and records the emitted task cycle", async () => {

--- a/tests/core-loop-reporting.test.ts
+++ b/tests/core-loop-reporting.test.ts
@@ -322,7 +322,7 @@ describe("CoreLoop", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── Report generation ───

--- a/tests/core-loop-stall-refine.test.ts
+++ b/tests/core-loop-stall-refine.test.ts
@@ -241,7 +241,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── Tests ───

--- a/tests/core-loop-tree.test.ts
+++ b/tests/core-loop-tree.test.ts
@@ -307,7 +307,7 @@ describe("CoreLoop tree mode (14B)", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   const mockStateAggregator = {
@@ -513,7 +513,7 @@ describe("CoreLoop tree mode (14C)", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function createTreeLoopOrchestratorMock(nodeId = "node-id-1") {

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -121,7 +121,7 @@ describe("core functionality", () => {
       expect(observationLog?.entries[0]?.layer).toBe("self_report");
       expect(observationLog?.entries[0]?.extracted_value).toBe(2);
     } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     }
   });
 
@@ -235,7 +235,7 @@ describe("core functionality", () => {
       expect(persisted?.work_description).toBe("Add unit tests for coverage scoring");
       expect(persisted?.status).toBe("pending");
     } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     }
   });
 
@@ -358,7 +358,7 @@ After`;
 
       expect(judge.applyProgressCeiling(0.95, 0.6)).toBe(0.85);
     } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     }
   });
 });

--- a/tests/cross-goal-portfolio-phase2.test.ts
+++ b/tests/cross-goal-portfolio-phase2.test.ts
@@ -102,7 +102,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── calculateMomentum ───

--- a/tests/cross-goal-portfolio.test.ts
+++ b/tests/cross-goal-portfolio.test.ts
@@ -111,7 +111,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── calculateGoalPriorities ───

--- a/tests/daemon-runner-shutdown.test.ts
+++ b/tests/daemon-runner-shutdown.test.ts
@@ -94,7 +94,7 @@ describe("DaemonRunner — Graceful Shutdown + Crash Recovery", () => {
       await currentStartPromise.catch(() => {});
       currentStartPromise = null;
     }
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     process.removeAllListeners("SIGINT");
     process.removeAllListeners("SIGTERM");
   });

--- a/tests/daemon-runner.test.ts
+++ b/tests/daemon-runner.test.ts
@@ -105,7 +105,7 @@ describe("DaemonRunner", () => {
       await currentStartPromise.catch(() => {});
       currentStartPromise = null;
     }
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     // Remove any process signal listeners that may have been registered
     process.removeAllListeners("SIGINT");
     process.removeAllListeners("SIGTERM");

--- a/tests/data-source-adapter.test.ts
+++ b/tests/data-source-adapter.test.ts
@@ -80,7 +80,7 @@ describe("FileDataSourceAdapter", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("reads JSON file and extracts value by expression", async () => {

--- a/tests/data-source-hotplug.test.ts
+++ b/tests/data-source-hotplug.test.ts
@@ -117,7 +117,7 @@ describe("ObservationEngine addDataSource / removeDataSource", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("addDataSource makes the adapter available via getDataSources()", () => {

--- a/tests/decision-record.test.ts
+++ b/tests/decision-record.test.ts
@@ -51,7 +51,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ═══════════════════════════════════════════════════════

--- a/tests/drive-score-adapter.test.ts
+++ b/tests/drive-score-adapter.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ═══════════════════════════════════════════════════════

--- a/tests/drive-system.test.ts
+++ b/tests/drive-system.test.ts
@@ -243,7 +243,7 @@ describe("DriveSystem", () => {
         const result = await anotherDs.readEventQueue();
         expect(result).toEqual([]);
       } finally {
-        fs.rmSync(anotherTmp, { recursive: true, force: true });
+        fs.rmSync(anotherTmp, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
       }
     });
   });
@@ -268,7 +268,7 @@ describe("DriveSystem", () => {
       const eventsDir = path.join(tmpDir, "events");
       const archiveDir = path.join(eventsDir, "archive");
       // Remove archive dir
-      fs.rmSync(archiveDir, { recursive: true, force: true });
+      fs.rmSync(archiveDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 
       writeEventFile(eventsDir, "evt.json", makeEvent());
       await driveSystem.archiveEvent("evt.json");
@@ -398,7 +398,7 @@ describe("DriveSystem", () => {
 
     it("creates schedule directory if it does not exist", async () => {
       const scheduleDir = path.join(tmpDir, "schedule");
-      fs.rmSync(scheduleDir, { recursive: true, force: true });
+      fs.rmSync(scheduleDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 
       const goalId = randomUUID();
       const schedule = driveSystem.createDefaultSchedule(goalId, 1);

--- a/tests/duplicate-task-guard.test.ts
+++ b/tests/duplicate-task-guard.test.ts
@@ -89,7 +89,7 @@ describe("generateTask — duplicate guard (§4.2)", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function makeDeps(llmClient: ReturnType<typeof createMockLLMClient>) {

--- a/tests/e2e/milestone2-d1-readme.test.ts
+++ b/tests/e2e/milestone2-d1-readme.test.ts
@@ -46,7 +46,7 @@ import { makeTempDir } from "../helpers/temp-dir.js";
 const fakeGitContextFetcher = () => "File: README.md\n# Project\nInstallation guide and usage examples.";
 
 function removeTempDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 // ─── Observation method config ───

--- a/tests/e2e/milestone2-d2-e2e-loop.test.ts
+++ b/tests/e2e/milestone2-d2-e2e-loop.test.ts
@@ -65,7 +65,7 @@ class MockAdapter implements IAdapter {
 const fakeGitContextFetcher = () => "File: tests/e2e-test.ts\n// e2e test passing with full coverage";
 
 function removeTempDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 function makeFileExistenceConfig(

--- a/tests/e2e/milestone2-d3-npm-publish.test.ts
+++ b/tests/e2e/milestone2-d3-npm-publish.test.ts
@@ -69,7 +69,7 @@ class MockAdapter implements IAdapter {
 // ─── Helpers ───
 
 function removeTempDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 const llmMethod: ObservationMethod = {

--- a/tests/e2e/milestone4-daemon.test.ts
+++ b/tests/e2e/milestone4-daemon.test.ts
@@ -28,7 +28,7 @@ import { makeTempDir } from "../helpers/temp-dir.js";
 // ─── Helpers ───
 
 function removeTempDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 /** Create a minimal CoreLoop mock that returns a completed LoopResult */

--- a/tests/e2e/milestone5-semantic.test.ts
+++ b/tests/e2e/milestone5-semantic.test.ts
@@ -47,7 +47,7 @@ import { makeTempDir } from "../helpers/temp-dir.js";
 // ─── Helpers ───
 
 function removeTempDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 function extractJSON(text: string): string {

--- a/tests/e2e/milestone7-goal-tree.test.ts
+++ b/tests/e2e/milestone7-goal-tree.test.ts
@@ -35,7 +35,7 @@ import { makeTempDir } from "../helpers/temp-dir.js";
 // ─── Helpers ───
 
 function removeTempDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 function extractJSON(text: string): string {

--- a/tests/e2e/r1-core-loop-executes.test.ts
+++ b/tests/e2e/r1-core-loop-executes.test.ts
@@ -310,7 +310,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── R1-1 E2E: task cycle reaches execute() for an unsatisfied goal ───

--- a/tests/e2e/r3-adapter-execution.test.ts
+++ b/tests/e2e/r3-adapter-execution.test.ts
@@ -205,7 +205,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── Test 1: successful pipeline ───

--- a/tests/e2e/r3-feedback-loop.test.ts
+++ b/tests/e2e/r3-feedback-loop.test.ts
@@ -274,7 +274,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── R3-1: verifyTask dimension_updates applied via handleVerdict ───

--- a/tests/e2e/r7-iterative-improvement.test.ts
+++ b/tests/e2e/r7-iterative-improvement.test.ts
@@ -57,7 +57,7 @@ vi.setConfig({ testTimeout: 15000 });
 const fakeGitContextFetcher = () => "File: src/main.ts\nconst quality = 0.85; // measured";
 
 function removeTempDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 // ─── Mock DataSource (marks dimensions as observable so LLM gets independent_review confidence) ───

--- a/tests/e2e/r8-error-resilience.test.ts
+++ b/tests/e2e/r8-error-resilience.test.ts
@@ -269,7 +269,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── R8-1: Adapter execution failure + retry ───

--- a/tests/e2e/r9-strategy-switching.test.ts
+++ b/tests/e2e/r9-strategy-switching.test.ts
@@ -69,7 +69,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── Tests ───

--- a/tests/ethics-gate-core.test.ts
+++ b/tests/ethics-gate-core.test.ts
@@ -38,7 +38,7 @@ describe("EthicsGate", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── check() — verdict pass ───

--- a/tests/ethics-gate-layer1.test.ts
+++ b/tests/ethics-gate-layer1.test.ts
@@ -33,7 +33,7 @@ describe("EthicsGate", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── JSON parse failure — conservative fallback ───

--- a/tests/event-file-watcher.test.ts
+++ b/tests/event-file-watcher.test.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
 
 afterEach(() => {
   server.stopFileWatcher();
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── isWatching() ───

--- a/tests/event-server.test.ts
+++ b/tests/event-server.test.ts
@@ -116,7 +116,7 @@ afterEach(async () => {
   if (server.isRunning()) {
     await server.stop();
   }
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── start / stop ───

--- a/tests/execution/task-verifier.test.ts
+++ b/tests/execution/task-verifier.test.ts
@@ -55,7 +55,7 @@ describe("Task verifier malformed JSON regression", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("logs malformed JSON, falls back to fail, and continues with a later valid response", async () => {

--- a/tests/failure-context-injection.test.ts
+++ b/tests/failure-context-injection.test.ts
@@ -24,7 +24,7 @@ describe("buildTaskGenerationPrompt — failure context injection (§4.7)", () =
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("does not include failure context when no last-failure-context.json exists", async () => {
@@ -149,7 +149,7 @@ describe("§4.7 round-trip: handleVerdict writes, buildTaskGenerationPrompt read
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function makeTask(overrides: Partial<Task> = {}): Task {

--- a/tests/file-existence-datasource.test.ts
+++ b/tests/file-existence-datasource.test.ts
@@ -29,7 +29,7 @@ describe("FileExistenceDataSourceAdapter", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("returns value=1 when the mapped file exists", async () => {

--- a/tests/goal-dependency-graph.test.ts
+++ b/tests/goal-dependency-graph.test.ts
@@ -43,7 +43,7 @@ describe("GoalDependencyGraph", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── addEdge ───

--- a/tests/goal-negotiator-character.test.ts
+++ b/tests/goal-negotiator-character.test.ts
@@ -57,7 +57,7 @@ describe("GoalNegotiator CharacterConfig integration", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("constructor without characterConfig is backwards compatible (no error)", () => {

--- a/tests/goal-negotiator-core.test.ts
+++ b/tests/goal-negotiator-core.test.ts
@@ -61,7 +61,7 @@ describe("GoalNegotiator", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── EthicsRejectedError ───

--- a/tests/goal-negotiator-decompose.test.ts
+++ b/tests/goal-negotiator-decompose.test.ts
@@ -150,7 +150,7 @@ describe("GoalNegotiator", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── decompose() ───

--- a/tests/goal-negotiator-negotiate.test.ts
+++ b/tests/goal-negotiator-negotiate.test.ts
@@ -79,7 +79,7 @@ describe("GoalNegotiator", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── negotiate() — Dimension Decomposition ───

--- a/tests/goal-negotiator-suggest-filter.test.ts
+++ b/tests/goal-negotiator-suggest-filter.test.ts
@@ -47,7 +47,7 @@ function makeDeps(llmResponses: string[]) {
 }
 
 function cleanup(tmpDir: string) {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 // ─── Tests ───

--- a/tests/goal-negotiator-suggest.test.ts
+++ b/tests/goal-negotiator-suggest.test.ts
@@ -59,7 +59,7 @@ function makeDeps(llmResponses: string[]) {
 }
 
 function cleanup(tmpDir: string) {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 }
 
 // ─── Tests ───

--- a/tests/goal-tree-concreteness.test.ts
+++ b/tests/goal-tree-concreteness.test.ts
@@ -128,7 +128,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── 1. scoreConcreteness() ───

--- a/tests/goal-tree-manager.test.ts
+++ b/tests/goal-tree-manager.test.ts
@@ -153,7 +153,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── 1. Specificity Evaluation ───

--- a/tests/goal-tree-quality.test.ts
+++ b/tests/goal-tree-quality.test.ts
@@ -48,7 +48,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   vi.restoreAllMocks();
 });
 

--- a/tests/goalNegotiator.test.ts
+++ b/tests/goalNegotiator.test.ts
@@ -48,7 +48,7 @@ describe("GoalNegotiator lightweight unit coverage", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   async function negotiateGoal(args: {

--- a/tests/guardrail-integration.test.ts
+++ b/tests/guardrail-integration.test.ts
@@ -210,7 +210,7 @@ describe("TaskLifecycle guardrail integration", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // Default mock execFileSyncFn: simulates a changed file so the post-execution

--- a/tests/helpers/temp-dir.ts
+++ b/tests/helpers/temp-dir.ts
@@ -7,5 +7,5 @@ export function makeTempDir(prefix = "pulseed-test-"): string {
 }
 
 export function cleanupTempDir(dir: string): void {
-  fs.rmSync(dir, { recursive: true, force: true });
+  fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 }

--- a/tests/knowledge-graph.test.ts
+++ b/tests/knowledge-graph.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ═══════════════════════════════════════════════════════

--- a/tests/knowledge-manager-phase2.test.ts
+++ b/tests/knowledge-manager-phase2.test.ts
@@ -52,7 +52,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ═══════════════════════════════════════════════════════

--- a/tests/knowledge-manager.test.ts
+++ b/tests/knowledge-manager.test.ts
@@ -51,7 +51,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ═══════════════════════════════════════════════════════

--- a/tests/learning-cross-goal.test.ts
+++ b/tests/learning-cross-goal.test.ts
@@ -77,7 +77,7 @@ describe("LearningPipeline — extractCrossGoalPatterns", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("should identify patterns across 2+ goals with similar delta values", async () => {
@@ -260,7 +260,7 @@ describe("LearningPipeline — sharePatternsAcrossGoals", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("should apply matching patterns to target goals", async () => {
@@ -412,7 +412,7 @@ describe("KnowledgeTransfer — storePattern / retrievePatterns", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("should roundtrip: stored pattern is returned by retrievePatterns", () => {

--- a/tests/learning-pipeline-extraction.test.ts
+++ b/tests/learning-pipeline-extraction.test.ts
@@ -137,7 +137,7 @@ describe("LearningPipeline", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── 1. パターン分析（analyzeLogs）───

--- a/tests/learning-pipeline-feedback.test.ts
+++ b/tests/learning-pipeline-feedback.test.ts
@@ -118,7 +118,7 @@ describe("LearningPipeline", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── 2. フィードバック生成（generateFeedback）───

--- a/tests/learning-pipeline-persistence.test.ts
+++ b/tests/learning-pipeline-persistence.test.ts
@@ -135,7 +135,7 @@ describe("LearningPipeline", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── 6. 永続化（getPatterns, savePatterns, getFeedbackEntries, saveFeedbackEntries）───

--- a/tests/learning-pipeline-phase2.test.ts
+++ b/tests/learning-pipeline-phase2.test.ts
@@ -74,7 +74,7 @@ describe("LearningPipeline Phase 2 — Structural Feedback", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── 1. recordStructuralFeedback() ───

--- a/tests/learning-pipeline-sharing.test.ts
+++ b/tests/learning-pipeline-sharing.test.ts
@@ -90,7 +90,7 @@ describe("LearningPipeline", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── 4. クロスゴール共有（sharePatternAcrossGoals）───

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   vi.restoreAllMocks();
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ═══════════════════════════════════════════════════════

--- a/tests/m16-integration.test.ts
+++ b/tests/m16-integration.test.ts
@@ -100,7 +100,7 @@ describe("Flow 1: KnowledgeTransfer end-to-end pipeline", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("detects candidates, applies transfer, evaluates effect, and updates trust", async () => {
@@ -288,7 +288,7 @@ describe("Flow 4: updateMetaPatternsIncremental", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("processes new patterns only and updates lastAggregatedAt", async () => {

--- a/tests/memory-lifecycle-phase2.test.ts
+++ b/tests/memory-lifecycle-phase2.test.ts
@@ -87,7 +87,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ═══════════════════════════════════════════════════════

--- a/tests/memory-lifecycle.test.ts
+++ b/tests/memory-lifecycle.test.ts
@@ -32,7 +32,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore cleanup race */ }
+  try { fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 }); } catch { /* ignore cleanup race */ }
 });
 
 // ═══════════════════════════════════════════════════════

--- a/tests/memory-selection.test.ts
+++ b/tests/memory-selection.test.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── Backward compatibility (no activeGoalIds) ───

--- a/tests/negotiate-context.test.ts
+++ b/tests/negotiate-context.test.ts
@@ -62,7 +62,7 @@ describe("gatherNegotiationContext", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("returns workspace info for a real directory with TypeScript files", async () => {
@@ -158,7 +158,7 @@ describe("negotiate() with workspaceContext", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("passes workspaceContext to the LLM decomposition call", async () => {

--- a/tests/observation-crossvalidation-override.test.ts
+++ b/tests/observation-crossvalidation-override.test.ts
@@ -76,7 +76,7 @@ describe("Cross-validation confidence penalty on LLM hallucination", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("applies confidence penalty when LLM claims 1.0 but mechanical returns 0", async () => {
@@ -249,7 +249,7 @@ describe("observation-apply value bounds validation", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("clamps present-type dimension values to [0, 1]", async () => {

--- a/tests/observation-engine-context.test.ts
+++ b/tests/observation-engine-context.test.ts
@@ -61,7 +61,7 @@ describe("createWorkspaceContextProvider", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("returns workspace context with keyword-matched files", async () => {
@@ -165,7 +165,7 @@ describe("ObservationEngine contextProvider integration", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("contextProvider receives goalId and dimensionName", async () => {

--- a/tests/observation-engine-crossvalidation.test.ts
+++ b/tests/observation-engine-crossvalidation.test.ts
@@ -77,7 +77,7 @@ describe("ObservationEngine cross-validation", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── Test 1: crossValidationEnabled=false (default): LLM NOT called when DataSource succeeds ───

--- a/tests/observation-engine-dedup.test.ts
+++ b/tests/observation-engine-dedup.test.ts
@@ -32,7 +32,7 @@ describe("ObservationEngine dimension name dedup normalization", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // Access the private method via casting for unit tests

--- a/tests/observation-engine-llm.test.ts
+++ b/tests/observation-engine-llm.test.ts
@@ -95,7 +95,7 @@ describe("ObservationEngine LLM observation", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── Test 1: observeWithLLM returns independent_review observation ───

--- a/tests/observation-engine-prompt.test.ts
+++ b/tests/observation-engine-prompt.test.ts
@@ -96,7 +96,7 @@ describe("observeWithLLM prompt quality", () => {
     const promptContent = mockLLM.capturedMessages[0]!.content;
     expect(promptContent).toContain("FEW-SHOT CALIBRATION");
 
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("prompt contains CRITICAL RULES section", async () => {
@@ -122,7 +122,7 @@ describe("observeWithLLM prompt quality", () => {
     const promptContent = mockLLM.capturedMessages[0]!.content;
     expect(promptContent).toContain("CRITICAL RULES");
 
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("when workspace context is absent, prompt contains Score MUST be 0.0 warning", async () => {
@@ -151,7 +151,7 @@ describe("observeWithLLM prompt quality", () => {
     const promptContent = mockLLM.capturedMessages[0]!.content;
     expect(promptContent).toContain("Score MUST be 0.0");
 
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("when workspace context is present, prompt contains the context content", async () => {
@@ -179,7 +179,7 @@ describe("observeWithLLM prompt quality", () => {
     const promptContent = mockLLM.capturedMessages[0]!.content;
     expect(promptContent).toContain(workspaceContent);
 
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("prompt contains previous score value when provided", async () => {
@@ -205,7 +205,7 @@ describe("observeWithLLM prompt quality", () => {
     const promptContent = mockLLM.capturedMessages[0]!.content;
     expect(promptContent).toContain("0.42");
 
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("prompt contains Previous score: none when no previous score", async () => {
@@ -231,7 +231,7 @@ describe("observeWithLLM prompt quality", () => {
     const promptContent = mockLLM.capturedMessages[0]!.content;
     expect(promptContent).toContain("Previous score: none");
 
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("prompt does NOT contain Japanese characters", async () => {
@@ -258,7 +258,7 @@ describe("observeWithLLM prompt quality", () => {
     // Japanese Unicode block: U+3000-U+9FFF
     expect(promptContent).not.toMatch(/[\u3000-\u9FFF]/);
 
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("mock LLM returning score 0.0 produces extracted value 0.0 for min threshold value 0", async () => {
@@ -284,7 +284,7 @@ describe("observeWithLLM prompt quality", () => {
 
     expect(entry.extracted_value).toBe(0.0);
 
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("mock LLM returning score 1.0 produces extracted value matching target threshold for min threshold > 1", async () => {
@@ -344,6 +344,6 @@ describe("observeWithLLM prompt quality", () => {
     // score=1.0 * threshold.value=100 => 100
     expect(entry.extracted_value).toBe(100);
 
-    fs.rmSync(tmpDir, { recursive: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 });

--- a/tests/observation-engine.test.ts
+++ b/tests/observation-engine.test.ts
@@ -69,7 +69,7 @@ describe("ObservationEngine", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── applyProgressCeiling ───
@@ -683,7 +683,7 @@ describe("observeFromDataSource", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("creates observation entry from data source query result", async () => {

--- a/tests/observation-llm-guard.test.ts
+++ b/tests/observation-llm-guard.test.ts
@@ -44,7 +44,7 @@ describe("Guard 3: Score-evidence consistency check (§4.3)", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── Test 1: No evidence + LLM returns score > 0.0 → score kept, confidence capped at 0.1 ───
@@ -173,7 +173,7 @@ describe("RC-1: Preserve previous score when no context but previousScore is kno
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("preserves previousScore with confidence=0.30 when no context and previousScore is known", async () => {
@@ -242,7 +242,7 @@ describe("RC-2: applyObservation called in no_context_existing_value skip path",
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("calls applyObservation when skipping due to no context with existing value", async () => {
@@ -315,7 +315,7 @@ describe("Root Cause B: confidence tier when sourceAvailable=false", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("uses independent_review tier (0.70) when sourceAvailable=false but context is available", async () => {
@@ -504,7 +504,7 @@ describe("readWorkspaceFiles", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("returns formatted content for readable files", async () => {
@@ -568,7 +568,7 @@ describe("Workspace file fallback: reads files when git diff is empty", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("uses workspace files as context when git diff is empty and workspacePath is provided", async () => {

--- a/tests/pid-manager.test.ts
+++ b/tests/pid-manager.test.ts
@@ -16,7 +16,7 @@ describe("PIDManager", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── constructor / getPath ───

--- a/tests/plugin-loader.test.ts
+++ b/tests/plugin-loader.test.ts
@@ -484,7 +484,7 @@ describe("PluginLoader.getPluginState and updatePluginState", () => {
   });
 
   afterEach(() => {
-    fsSync.rmSync(tmpDir, { recursive: true, force: true });
+    fsSync.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("getPluginState returns null for unknown plugin", () => {

--- a/tests/r1-core-loop-completion.test.ts
+++ b/tests/r1-core-loop-completion.test.ts
@@ -233,7 +233,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 describe("R1-1: task cycle always runs within an iteration", () => {

--- a/tests/regression/json-parse-failures.test.ts
+++ b/tests/regression/json-parse-failures.test.ts
@@ -68,7 +68,7 @@ describe("json parse failure regressions", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("drive-system watcher skips malformed JSON and still delivers later valid events", async () => {

--- a/tests/reporting-engine.test.ts
+++ b/tests/reporting-engine.test.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── generateExecutionSummary ───

--- a/tests/satisficing-judge-convergence.test.ts
+++ b/tests/satisficing-judge-convergence.test.ts
@@ -17,7 +17,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── Helper ───

--- a/tests/satisficing-judge-dimension-satisfied.test.ts
+++ b/tests/satisficing-judge-dimension-satisfied.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── isDimensionSatisfied ───

--- a/tests/satisficing-judge-double-confirm.test.ts
+++ b/tests/satisficing-judge-double-confirm.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── P0 Guard 4: Double-Confirmation Guard ───

--- a/tests/satisficing-judge-goal-complete.test.ts
+++ b/tests/satisficing-judge-goal-complete.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── isGoalComplete ───

--- a/tests/satisficing-judge-propagation-phase2.test.ts
+++ b/tests/satisficing-judge-propagation-phase2.test.ts
@@ -45,7 +45,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── propagateSubgoalCompletion Phase 2 (dimension_mapping aggregation) ───

--- a/tests/satisficing-judge-threshold-propagation.test.ts
+++ b/tests/satisficing-judge-threshold-propagation.test.ts
@@ -46,7 +46,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── detectThresholdAdjustmentNeeded ───

--- a/tests/satisficing-judge-tree-convergence.test.ts
+++ b/tests/satisficing-judge-tree-convergence.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── Helpers ───

--- a/tests/satisficing-judge-undershoot.test.ts
+++ b/tests/satisficing-judge-undershoot.test.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── Tests ───

--- a/tests/session-manager-phase2.test.ts
+++ b/tests/session-manager-phase2.test.ts
@@ -27,7 +27,7 @@ describe("SessionManager Phase 2", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── estimateTokens ───

--- a/tests/session-manager.test.ts
+++ b/tests/session-manager.test.ts
@@ -23,7 +23,7 @@ describe("SessionManager", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── createSession ───

--- a/tests/shell-datasource-auto.test.ts
+++ b/tests/shell-datasource-auto.test.ts
@@ -38,7 +38,7 @@ describe("autoRegisterShellDataSources", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("creates a shell datasource config for todo_count dimension", async () => {
@@ -254,7 +254,7 @@ describe("autoRegisterFileExistenceDataSources — dedup", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("does not create a duplicate file_existence datasource for the same dimension, path, and goalId", async () => {

--- a/tests/stall-detector-analysis.test.ts
+++ b/tests/stall-detector-analysis.test.ts
@@ -30,7 +30,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── analyzeStallCause ───

--- a/tests/stall-detector-repetitive.test.ts
+++ b/tests/stall-detector-repetitive.test.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 describe("detectRepetitivePatterns", () => {

--- a/tests/stall-detector.test.ts
+++ b/tests/stall-detector.test.ts
@@ -24,7 +24,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── checkDimensionStall ───
@@ -611,7 +611,7 @@ describe("StallDetector CharacterConfig integration", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tempDir2, { recursive: true, force: true });
+    fs.rmSync(tempDir2, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("constructor without characterConfig is backwards compatible (no error)", () => {
@@ -912,7 +912,7 @@ describe("StallDetector with ProgressPredictor", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("works as before (no predictor) — no regression for normal stall detection", () => {

--- a/tests/state-aggregator.test.ts
+++ b/tests/state-aggregator.test.ts
@@ -53,7 +53,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── Helper: build a parent with N children ───

--- a/tests/state-manager.test.ts
+++ b/tests/state-manager.test.ts
@@ -25,7 +25,7 @@ describe("StateManager", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   describe("directory structure", () => {
@@ -127,7 +127,7 @@ describe("StateManager", async () => {
     it("listGoalIds re-throws non-ENOENT errors", async () => {
       // Remove the goals dir and replace it with a file to cause ENOTDIR
       const goalsDir = path.join(tmpDir, "goals");
-      fs.rmSync(goalsDir, { recursive: true, force: true });
+      fs.rmSync(goalsDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
       fs.writeFileSync(goalsDir, "not a directory");
 
       await expect(manager.listGoalIds()).rejects.toThrow();
@@ -156,14 +156,14 @@ describe("StateManager", async () => {
       await expect(manager.deleteGoalTree("bad-id")).rejects.toThrow();
 
       // Restore for afterEach cleanup
-      fs.rmSync(treeDir, { recursive: true, force: true });
+      fs.rmSync(treeDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     });
 
     it("goalExists re-throws non-ENOENT errors (ENOTDIR via file as dir)", async () => {
       // Make goals/<goalId> a regular file — then fsp.access(goals/<goalId>/goal.json)
       // fails with ENOTDIR because it tries to traverse into a non-directory
       const goalEntry = path.join(tmpDir, "goals", "badgoal-exists");
-      fs.rmSync(goalEntry, { recursive: true, force: true });
+      fs.rmSync(goalEntry, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
       fs.writeFileSync(goalEntry, "not a dir");
 
       await expect(manager.goalExists("badgoal-exists")).rejects.toThrow();
@@ -961,7 +961,7 @@ describe("StateManager", async () => {
     it("listGoalIds propagates non-ENOENT errors", async () => {
       // Remove the goals directory then replace it with a file — readdir will fail with ENOTDIR
       const goalsDir = path.join(tmpDir, "goals");
-      fs.rmSync(goalsDir, { recursive: true, force: true });
+      fs.rmSync(goalsDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
       fs.writeFileSync(goalsDir, "not-a-directory");
 
       await expect(manager.listGoalIds()).rejects.toThrow();

--- a/tests/strategy-auto-template.test.ts
+++ b/tests/strategy-auto-template.test.ts
@@ -54,7 +54,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   vi.clearAllMocks();
 });
 

--- a/tests/strategy-manager-core.test.ts
+++ b/tests/strategy-manager-core.test.ts
@@ -67,7 +67,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── generateCandidates ───

--- a/tests/strategy-manager-phase2.test.ts
+++ b/tests/strategy-manager-phase2.test.ts
@@ -64,7 +64,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── Phase 2 methods ───

--- a/tests/strategy-manager-stall.test.ts
+++ b/tests/strategy-manager-stall.test.ts
@@ -70,7 +70,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── onStallDetected ───

--- a/tests/strategy-template-embedding.test.ts
+++ b/tests/strategy-template-embedding.test.ts
@@ -81,7 +81,7 @@ describe("StrategyTemplateRegistry — embedding-based recommendation", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── indexTemplates ───

--- a/tests/strategy-template-registry.test.ts
+++ b/tests/strategy-template-registry.test.ts
@@ -85,7 +85,7 @@ describe("StrategyTemplateRegistry", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── registerTemplate ───

--- a/tests/suggest-output-schema.test.ts
+++ b/tests/suggest-output-schema.test.ts
@@ -124,7 +124,7 @@ afterEach(() => {
     process.env.ANTHROPIC_API_KEY = origApiKey;
   }
   delete process.env.PULSEED_LLM_PROVIDER;
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   vi.clearAllMocks();
 });
 

--- a/tests/task-lifecycle-cycle.test.ts
+++ b/tests/task-lifecycle-cycle.test.ts
@@ -236,7 +236,7 @@ describe("TaskLifecycle", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function createLifecycle(

--- a/tests/task-lifecycle-dimension.test.ts
+++ b/tests/task-lifecycle-dimension.test.ts
@@ -127,7 +127,7 @@ describe("TaskLifecycle", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function createLifecycle(

--- a/tests/task-lifecycle-ethics.test.ts
+++ b/tests/task-lifecycle-ethics.test.ts
@@ -154,7 +154,7 @@ describe("TaskLifecycle", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function createLifecycle(

--- a/tests/task-lifecycle-execution.test.ts
+++ b/tests/task-lifecycle-execution.test.ts
@@ -127,7 +127,7 @@ describe("TaskLifecycle", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // Default mock execFileSyncFn: simulates "some-file.ts" as a changed file

--- a/tests/task-lifecycle-generation.test.ts
+++ b/tests/task-lifecycle-generation.test.ts
@@ -112,7 +112,7 @@ describe("TaskLifecycle", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function createLifecycle(

--- a/tests/task-lifecycle-healthcheck.test.ts
+++ b/tests/task-lifecycle-healthcheck.test.ts
@@ -108,7 +108,7 @@ describe("TaskLifecycle — post-execution health check", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     vi.restoreAllMocks();
   });
 

--- a/tests/task-lifecycle-verdict.test.ts
+++ b/tests/task-lifecycle-verdict.test.ts
@@ -108,7 +108,7 @@ describe("TaskLifecycle", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function createLifecycle(

--- a/tests/task-lifecycle-verification.test.ts
+++ b/tests/task-lifecycle-verification.test.ts
@@ -123,7 +123,7 @@ describe("TaskLifecycle", async () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function createLifecycle(

--- a/tests/task-lifecycle.test.ts
+++ b/tests/task-lifecycle.test.ts
@@ -149,7 +149,7 @@ describe("TaskLifecycle — uncovered branches", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   function createLifecycle(

--- a/tests/task-verifier-guards.test.ts
+++ b/tests/task-verifier-guards.test.ts
@@ -148,7 +148,7 @@ describe("P0 Guard 2: progress-verdict contradiction", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   async function setupGoalState(
@@ -413,7 +413,7 @@ describe("§4.6: runLLMReview Zod validation", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("valid JSON with enum verdict 'pass' — parsed correctly via Zod", async () => {
@@ -512,7 +512,7 @@ describe("§4.7: handleVerdict failure context save/clear", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   async function setupGoalState(dimName: string, currentValue: number): Promise<void> {
@@ -642,7 +642,7 @@ describe("RC-3: handleVerdict updates confidence and last_observed_layer on dime
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   async function setupGoalWithDim(dimName: string, currentValue: number): Promise<void> {
@@ -741,7 +741,7 @@ describe("Root Cause C: dimension_updates scaling", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("min threshold: delta is scaled by threshold.value — pass verdict adds 0.2 * value", async () => {

--- a/tests/telegram-bot-plugin.test.ts
+++ b/tests/telegram-bot-plugin.test.ts
@@ -44,7 +44,7 @@ describe("config — loadConfig", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("loads valid config successfully", () => {
@@ -500,7 +500,7 @@ describe("TelegramBotPlugin", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     vi.unstubAllGlobals();
   });
 

--- a/tests/tree-loop-orchestrator.test.ts
+++ b/tests/tree-loop-orchestrator.test.ts
@@ -80,7 +80,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore cleanup race */ }
+  try { fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 }); } catch { /* ignore cleanup race */ }
 });
 
 // ─── Helper: save a goal and return it ───

--- a/tests/trigger-api.test.ts
+++ b/tests/trigger-api.test.ts
@@ -66,7 +66,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   if (server.isRunning()) await server.stop();
-  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── POST /triggers ───

--- a/tests/trigger-mapper.test.ts
+++ b/tests/trigger-mapper.test.ts
@@ -32,14 +32,14 @@ describe("TriggerMapper.loadMappings", () => {
     expect(result.action).toBe("observe");
     expect(result.goal_id).toBe("g1");
     expect(result.source).toBe("mapping");
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("does not throw when mappings file is missing", async () => {
     const tmpDir = makeTempDir();
     const mapper = new TriggerMapper(tmpDir);
     await expect(mapper.loadMappings()).resolves.toBeUndefined();
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 });
 
@@ -64,7 +64,7 @@ describe("TriggerMapper.resolve — explicit mapping match", () => {
     expect(result.action).toBe("create_task");
     expect(result.goal_id).toBe("g-ci");
     expect(result.source).toBe("mapping");
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 });
 
@@ -79,7 +79,7 @@ describe("TriggerMapper.resolve — trigger.goal_id fallback", () => {
     );
     expect(result.action).toBe("observe");
     expect(result.goal_id).toBe("goal-fallback");
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 });
 
@@ -98,7 +98,7 @@ describe("TriggerMapper.resolve — LLM fallback", () => {
     expect(result.source).toBe("llm");
     expect(result.goal_id).toBe("g-llm");
     expect(result.action).toBe("observe");
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("does not call LLM on second resolve with same source/event_type (cache hit)", async () => {
@@ -116,7 +116,7 @@ describe("TriggerMapper.resolve — LLM fallback", () => {
     await mapper.resolve(trigger, goals); // second call — should hit cache
 
     expect(mockLLM.callCount).toBe(1);
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 });
 
@@ -132,7 +132,7 @@ describe("TriggerMapper.resolve — no mapping, no LLM", () => {
     expect(result.action).toBe("none");
     expect(result.goal_id).toBeNull();
     expect(result.source).toBe("default");
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 });
 
@@ -151,6 +151,6 @@ describe("TriggerMapper.clearCache", () => {
     expect(mapper.getCacheSize()).toBe(1);
     mapper.clearCache();
     expect(mapper.getCacheSize()).toBe(0);
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 });

--- a/tests/trust-manager.test.ts
+++ b/tests/trust-manager.test.ts
@@ -27,7 +27,7 @@ describe("TrustManager", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   // ─── getBalance ───
@@ -471,7 +471,7 @@ describe("plugin trust", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("recordPluginSuccess increases trust_score by 3 and increments counts", async () => {

--- a/tests/tui/use-loop.test.ts
+++ b/tests/tui/use-loop.test.ts
@@ -160,7 +160,7 @@ describe("LoopController", async () => {
 
   afterEach(() => {
     vi.useRealTimers();
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("initial state is idle", () => {

--- a/tests/types/goal-tree-integration.test.ts
+++ b/tests/types/goal-tree-integration.test.ts
@@ -44,7 +44,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  fs.rmSync(tempDir, { recursive: true, force: true });
+  fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
 // ─── judgeTreeCompletion ───

--- a/tests/unit/example.test.ts
+++ b/tests/unit/example.test.ts
@@ -96,7 +96,7 @@ afterEach(() => {
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir && fs.existsSync(dir)) {
-      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     }
   }
 });

--- a/tests/unit/goalNegotiator.test.ts
+++ b/tests/unit/goalNegotiator.test.ts
@@ -162,7 +162,7 @@ describe("GoalNegotiator helper coverage", () => {
 
   afterEach(() => {
     for (const dir of tempDirs) {
-      fs.rmSync(dir, { recursive: true, force: true });
+      fs.rmSync(dir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     }
   });
 

--- a/tests/vector-index.test.ts
+++ b/tests/vector-index.test.ts
@@ -17,7 +17,7 @@ describe("VectorIndex", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("add() creates entry and increases size", async () => {

--- a/tests/web/api-decisions.test.ts
+++ b/tests/web/api-decisions.test.ts
@@ -41,7 +41,7 @@ describe('GET /api/decisions', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it('returns empty array when decisions directory does not exist', async () => {

--- a/tests/web/api-goals.test.ts
+++ b/tests/web/api-goals.test.ts
@@ -75,7 +75,7 @@ describe('GET /api/goals', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it('returns array of goals', async () => {
@@ -114,7 +114,7 @@ describe('GET /api/goals/:id', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it('returns a single goal by id', async () => {
@@ -143,7 +143,7 @@ describe('GET /api/goals/:id/gap-history', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it('returns gap history array', async () => {
@@ -161,7 +161,7 @@ describe('GET /api/goals/:id/tasks', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it('returns empty tasks when directory does not exist', async () => {

--- a/tests/web/api-sessions.test.ts
+++ b/tests/web/api-sessions.test.ts
@@ -31,7 +31,7 @@ describe('GET /api/sessions', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it('returns empty array when sessions directory does not exist', async () => {

--- a/tests/workspace-context.test.ts
+++ b/tests/workspace-context.test.ts
@@ -27,7 +27,7 @@ describe("createWorkspaceContextProvider — external file reading", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(workDir, { recursive: true, force: true });
+    fs.rmSync(workDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("reads a /tmp/ file mentioned in goal description", async () => {
@@ -170,7 +170,7 @@ describe("createWorkspaceContextProvider — relative path exact match", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpWorkDir, { recursive: true, force: true });
+    fs.rmSync(tmpWorkDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("includes src/index.ts when mentioned in goal description", async () => {
@@ -229,7 +229,7 @@ describe("createWorkspaceContextProvider — small workspace fast path", () => {
   });
 
   afterEach(() => {
-    fs.rmSync(tmpWorkDir, { recursive: true, force: true });
+    fs.rmSync(tmpWorkDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("includes all files when workspace has a single file (hello.ts)", async () => {
@@ -313,8 +313,8 @@ describe("createWorkspaceContextProvider — dynamic workDir from goal constrain
   });
 
   afterEach(() => {
-    fs.rmSync(defaultWorkDir, { recursive: true, force: true });
-    fs.rmSync(goalWorkDir, { recursive: true, force: true });
+    fs.rmSync(defaultWorkDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
+    fs.rmSync(goalWorkDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("uses default workDir when no getGoalConstraints is provided", async () => {
@@ -390,7 +390,7 @@ describe("createWorkspaceContextProvider — Phase 3 grep content match", () => 
   });
 
   afterEach(() => {
-    fs.rmSync(tmpWorkDir, { recursive: true, force: true });
+    fs.rmSync(tmpWorkDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("finds a file by content when its name does not match any keyword", async () => {
@@ -423,7 +423,7 @@ describe("createWorkspaceContextProvider — existing workspace behavior unchang
   });
 
   afterEach(() => {
-    fs.rmSync(tmpWorkDir, { recursive: true, force: true });
+    fs.rmSync(tmpWorkDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
   it("includes README.md and package.json in output", async () => {


### PR DESCRIPTION
## Summary
- Node 22 changed `fs.rmSync` behavior — `recursive: true` can throw `ENOTEMPTY` due to race conditions during directory cleanup
- Added `maxRetries: 3, retryDelay: 100` to all `rmSync({ recursive: true })` calls across 147 test files
- Also fixed 9 calls in `observation-engine-prompt.test.ts` missing `force: true`

## Root Cause
Node 22's `rmSync` with `recursive: true` no longer silently retries on `ENOTEMPTY`. The built-in `maxRetries` option handles this gracefully.

## Test plan
- [x] Build passes
- [x] All 5670 tests pass locally (Node 20)
- [ ] CI Node 22 should now pass (previously flaky on `memory-selection.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)