### PR TITLE
feat(tools): add StrategyManager workspace context + per-iteration cache (Phase 4-B)

### DIFF
--- a/src/orchestrator/strategy/strategy-workspace.ts
+++ b/src/orchestrator/strategy/strategy-workspace.ts
@@ -77,7 +77,12 @@ export async function buildWorkspaceContext(
 }
 
 function isStringRecord(val: unknown): val is Record<string, string> {
-  return typeof val === "object" && val !== null;
+  return (
+    typeof val === "object" &&
+    val !== null &&
+    !Array.isArray(val) &&
+    Object.values(val as Record<string, unknown>).every((v) => typeof v === "string")
+  );
 }
 
 // --- WorkspaceContextCache ---


### PR DESCRIPTION
## Summary

- Adds `strategy-workspace.ts` with `WorkspaceContext`, `buildWorkspaceContext()`, `WorkspaceContextCache`, and `formatWorkspaceContext()` (169 lines, new file)
- Wires `ToolExecutor` into `StrategyManagerBase` via `setToolExecutor()` (DI injection, non-breaking)
- Injects workspace context into `generateCandidates()` via optional `toolContext` parameter — existing callers are unaffected
- Extends `buildGenerationPrompt()` to embed workspace context block at the top of the strategy LLM prompt
- Cache keyed by `iteration` number: re-builds on iteration advance, `invalidate()` on task completion

## Design alignment

Implements §7 of `docs/design/core/tool-system.md`:
- §7.1 Grounding context flow (Glob + Read + Shell, 5 parallel calls via `executeBatch`)
- §7.2 `WorkspaceContext` interface + `buildWorkspaceContext()`
- §7.4 `WorkspaceContextCache` with iteration-keyed caching and invalidation

## Test plan

- [x] `buildWorkspaceContext`: happy path, all-fail fallback, malformed JSON graceful handling, trailing newline filtering, 5-call batch assertion
- [x] `WorkspaceContextCache`: first get, cache hit on same iteration, rebuild on advance, invalidate, isValid
- [x] `formatWorkspaceContext`: header, fields, empty input, 20-entry source preview truncation
- [x] `StrategyManager` integration: executeBatch called, no-executor skip, no-context skip, same-iteration cache hit, iteration-advance rebuild, non-fatal on tool exception
- [x] 25 new tests — all pass
- [x] Full suite: 289 test files, 5860 tests — all pass
- [x] TypeScript build: `npx tsc -p tsconfig.build.json --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)