### PR TITLE
fix(chat): log errors in executeWithTools catch block (#487)

### DIFF
--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -293,8 +293,10 @@ export class ChatRunner {
           tools,
           ...(systemPrompt ? { system: systemPrompt } : {}),
         });
-      } catch {
-        return "Sorry, I encountered an error processing your request.";
+      } catch (err) {
+        console.error("[chat-runner] executeWithTools error:", err);
+        const hint = err instanceof Error ? `: ${err.message}` : "";
+        return `Sorry, I encountered an error processing your request${hint}.`;
       }
 
       // No tool calls — return the text content


### PR DESCRIPTION
## Summary
- Log errors to stderr in `executeWithTools` catch block instead of silently swallowing them
- Include error message in user-facing response for diagnostics

Closes #487

## Test plan
- [x] Build clean
- [x] 21/21 chat-runner tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)