### PR TITLE
feat(tui): always route non-command input through ChatRunner

### DIFF
--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -151,6 +151,7 @@ export function App({
 
   const handleInput = useCallback(
     async (input: string) => {
+      if (isProcessing) return;
       // Dismiss report overlay on any input
       if (reportToShow !== null) {
         setReportToShow(null);
@@ -246,7 +247,7 @@ export function App({
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         setMessages((prev) => [
-          ...prev,
+          ...prev.slice(0, -1),
           {
             role: "pulseed" as const,
             text: `Error: ${message}`,

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -212,6 +212,7 @@ async function buildDeps() {
     const provConfig = await loadProviderConfig();
     const adapterType = provConfig.adapter ?? "claude_code_cli";
     const adapter = adapterRegistry.getAdapter(adapterType);
+    // Note: escalationHandler omitted — TUI handles /track via ActionHandler
     chatRunner = new ChatRunner({ stateManager, adapter, llmClient, trustManager });
   } catch (err) {
     getCliLogger().warn(`[pulseed] ChatRunner init failed — free-form chat disabled: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary
- TUI (`pulseed tui`) now routes free-form text through `ChatRunner.execute()`, enabling live LLM-powered chat
- Slash commands (`/run`, `/start`, `/stop`, `/status`, `/report`, `/goals`, `/help`, `/dashboard`) still use existing `IntentRecognizer → ActionHandler`
- Shows "Thinking..." placeholder while awaiting LLM response

## Changes
- `src/interface/tui/entry.ts` — Construct `ChatRunner` in `buildDeps()` and pass as prop to `<App>`
- `src/interface/tui/app.tsx` — Split `handleInput`: `/` prefix → ActionHandler, else → `chatRunner.execute()`
  - Added `isProcessing` guard to prevent concurrent submissions
  - "Thinking..." placeholder properly cleaned up on error

## Test plan
- [x] Build clean
- [x] 89/89 TUI tests pass
- [ ] Manual test: `pulseed tui` → type free text → get LLM response

🤖 Generated with [Claude Code](https://claude.com/claude-code)