### PR TITLE
fix(chat): surface adapter error in output when output is empty

### DIFF
--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -234,6 +234,10 @@ export class ChatRunner {
       ...(this.cachedSystemPrompt ? { system_prompt: this.cachedSystemPrompt } : {}),
     };
     let result = await this.deps.adapter.execute(task);
+    // Surface adapter errors into output when output is empty
+    if (!result.output && result.error) {
+      result = { ...result, output: `Error: ${result.error}` };
+    }
     const elapsed_ms = Date.now() - start;
 
     // Verification loop: check if git has uncommitted changes; if so, run tests


### PR DESCRIPTION
## Summary
- When adapter returns empty output with error field (e.g., codex failing outside git repo), error was invisible to user — showed "(no response)"
- Now surfaces `result.error` in output for visibility

## Test plan
- [x] Build clean, 21/21 chat-runner tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)