### PR TITLE
feat(cli): launch TUI by default when no subcommand given

### DIFF
--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -61,8 +61,9 @@ export async function dispatchCommand(
 ): Promise<number> {
   if (argv.length === 0) {
     await ensureProviderConfig();
-    printUsage();
-    return 1;
+    const { startTUI } = await import("../tui/entry.js");
+    await startTUI();
+    return 0;
   }
 
   const subcommand = argv[0];

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -24,6 +24,7 @@ export function printUsage(): void {
 PulSeed — AI agent orchestrator
 
 Usage:
+  pulseed                                               Launch interactive TUI (default)
   pulseed run --goal <id>              Run CoreLoop for a goal
   pulseed improve [path]               Analyze path, suggest goals, and optionally run improvement loop
   pulseed suggest "<context>"          Suggest improvement goals for a project context


### PR DESCRIPTION
## Summary
- `pulseed` (no args) now launches the interactive TUI instead of printing usage
- Matches the convention used by Claude Code, Codex, Hermes, and Aider (bare command = interactive mode)
- `pulseed tui` still works as an explicit alias
- Updated usage text to reflect the new default

## Test plan
- [ ] Run `pulseed` with no arguments → TUI should launch
- [ ] Run `pulseed tui` → TUI should still launch (alias)
- [ ] Run `pulseed --help` → should print usage with TUI listed as default
- [ ] Run `pulseed run --goal <id>` → should still work as before
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)