### PR TITLE
feat: ScheduleEngine Phase 2 — Probe layer, ChangeDetector, escalation

### DIFF
--- a/docs/design/infrastructure/schedule-engine.md
+++ b/docs/design/infrastructure/schedule-engine.md
@@ -148,7 +148,7 @@ Schedule fires
   layer: "probe",
   data_source_id: string,         // registered IDataSourceAdapter to query
   query_params: DataSourceQuery,  // parameters for the query
-  change_detection: {
+  change_detector: {
     mode: "threshold" | "diff" | "presence",
     threshold?: number,           // for threshold mode: trigger if value exceeds
     baseline_window?: number,     // number of recent results to compare against
@@ -294,7 +294,7 @@ const ProbeConfigSchema = z.object({
   layer: z.literal("probe"),
   data_source_id: z.string(),
   query_params: z.record(z.unknown()).default({}),
-  change_detection: z.object({
+  change_detector: z.object({
     mode: z.enum(["threshold", "diff", "presence"]),
     threshold: z.number().optional(),
     baseline_window: z.number().int().positive().default(5),
@@ -648,7 +648,7 @@ Schedule entries are persisted to `~/.pulseed/schedules.json`. This file is mana
         "layer": "probe",
         "data_source_id": "gmail-datasource",
         "query_params": { "label": "INBOX", "unread_only": true },
-        "change_detection": {
+        "change_detector": {
           "mode": "presence",
           "baseline_window": 1
         },

--- a/docs/design/infrastructure/schedule-engine.md
+++ b/docs/design/infrastructure/schedule-engine.md
@@ -1,0 +1,868 @@
+# Schedule Engine Design
+
+> PulSeed does not wait to be asked — it acts on time. The ScheduleEngine adds proactive, time-based triggers to the daemon,
+> enabling PulSeed to monitor, report, and pursue goals on a schedule rather than only reacting to user commands.
+
+> Related: `plugin-architecture.md`, `reporting.md`, `daemon-client-architecture.md`, `docs/design/core/observation.md`, `docs/design/execution/data-source.md`
+
+---
+
+## §1 Overview and Positioning
+
+### Why ScheduleEngine
+
+PulSeed already has a CoreLoop that runs continuously when the daemon is active. But "continuously" is not the same as "proactively." The CoreLoop processes goals that are already active — it does not initiate new observations, generate unprompted reports, or monitor external systems on a cadence.
+
+The ScheduleEngine fills this gap. It introduces time-based triggers that cause PulSeed to act at specific moments: checking email every 30 minutes, generating a morning summary at 8am, running a weekly code quality review, or pinging a health endpoint every minute.
+
+### PulSeed vs OpenClaw cron / system crontab
+
+In system crontab and OpenClaw's cron, scheduled tasks are "fire and forget" — a command runs at a time, produces output, and the system does not reason about whether to escalate, suppress, or adapt. The schedule is static.
+
+PulSeed's ScheduleEngine is different in three ways:
+
+```
+System crontab / OpenClaw cron:
+  Schedule -> Execute command -> Output (always)
+  No conditional logic. No escalation. No cost awareness.
+
+PulSeed ScheduleEngine:
+  Schedule -> Layer-appropriate check -> Conditional escalation
+  Layer decides: zero-cost mechanical check? LLM analysis? Full goal pursuit?
+  Escalation: Heartbeat failure -> Probe investigation -> GoalTrigger pursuit
+  Cost model: most executions cost zero LLM tokens
+```
+
+The key insight is that not all scheduled actions require the same weight of processing. A health check does not need an LLM. An email check only needs an LLM when something important arrives. A morning summary always needs an LLM. A weekly code review needs the full CoreLoop. The 4-layer architecture matches processing weight to the task.
+
+### "Thin core, extend with plugins" principle
+
+The ScheduleEngine core handles scheduling mechanics (when to fire) and layer dispatch (which processing weight to apply). External schedule sources (Google Calendar, webhook-driven schedules) are plugins implementing the `IScheduleSource` interface — they are not part of the core.
+
+| Criterion | Location | Example |
+|-----------|----------|---------|
+| Scheduling mechanics (fire timing, jitter, overlap prevention) | Core | ScheduleEngine |
+| Layer dispatch (Heartbeat/Probe/Cron/GoalTrigger routing) | Core | LayerDispatcher |
+| Built-in time expressions (cron, interval) | Core | CronExpression, IntervalExpression |
+| External schedule sources (calendar, webhook) | Plugin | GoogleCalendarSource, WebhookScheduleSource |
+| Custom check functions for Heartbeat/Probe | Plugin | HttpHealthCheck, SlackMonitor |
+
+---
+
+## §2 Architecture
+
+### 2.1 Position in the runtime stack
+
+```
+DaemonRunner
+  |-- CoreLoop (existing -- goal pursuit)
+  |-- CronScheduler (existing -- reflection/consolidation tasks)
+  +-- ScheduleEngine (new -- proactive scheduling)
+       |-- GoalTrigger  -> CoreLoop.run(goal)
+       |-- Probe        -> DataSource.fetch() -> conditional LLM -> maybe escalate
+       |-- Cron         -> LLM processing every time (human rhythm)
+       +-- Heartbeat    -> mechanical check only -> escalate on failure
+```
+
+The existing `CronScheduler` handles simple prompt-based tasks (reflection, consolidation). The ScheduleEngine supersedes it for all new scheduling needs and provides a migration path for existing CronScheduler tasks.
+
+### 2.2 Relationship to existing CronScheduler
+
+The existing `CronScheduler` (`src/runtime/cron-scheduler.ts`) supports three task types: `reflection`, `consolidation`, and `custom`. These map cleanly to ScheduleEngine layers:
+
+| Existing CronTask type | ScheduleEngine layer | Rationale |
+|------------------------|---------------------|-----------|
+| `reflection` | Cron | Always produces LLM output |
+| `consolidation` | Cron | Always produces LLM output |
+| `custom` | Cron or GoalTrigger | Depends on whether full CoreLoop is needed |
+
+Migration strategy: CronScheduler remains operational during the transition. New schedule entries use ScheduleEngine exclusively. A future milestone deprecates CronScheduler and migrates existing tasks.
+
+---
+
+## §3 The 4 Layer Types
+
+### 3.1 GoalTrigger (Heavy)
+
+**Weight**: Full CoreLoop execution. High LLM cost.
+
+**Behavior**: Triggers `CoreLoop.run(goal)` on schedule. The goal must be pre-defined in PulSeed's goal store. The GoalTrigger simply activates it at the scheduled time.
+
+**Use cases**:
+- Weekly code quality review ("Run code quality review every Monday at 9am")
+- Periodic refactoring assessment ("Evaluate refactoring opportunities every Friday")
+- Scheduled large tasks that need full observe-gap-score-task-execute-verify cycle
+
+**Execution flow**:
+```
+Schedule fires
+  -> Load goal definition from StateManager
+  -> CoreLoop.run(goalId, { maxIterations })
+  -> LoopResult recorded in goal history
+  -> NotificationDispatcher.dispatch(goal_progress event)
+```
+
+**Configuration fields specific to GoalTrigger**:
+```typescript
+{
+  layer: "goal_trigger",
+  goal_id: string,              // existing goal to activate
+  max_iterations: number,       // cap CoreLoop iterations (default: 10)
+  skip_if_active: boolean,      // skip if goal is already being pursued (default: true)
+}
+```
+
+**Cost**: 5,000-50,000+ tokens per execution (full CoreLoop with LLM observation, gap analysis, task generation).
+
+### 3.2 Probe (Medium, conditional)
+
+**Weight**: Mechanical check first, LLM only on change detection. Most executions cost zero tokens.
+
+**Behavior**: Runs `IDataSourceAdapter.query()` on schedule. Compares the result against a baseline or threshold. If a change is detected, escalates to LLM analysis. If no change, silently records the check and moves on.
+
+This is the "watchdog" pattern — silent unless triggered.
+
+**Use cases**:
+- Email monitoring ("Check email every 30min, notify only if important mail detected")
+- Slack channel monitoring ("Watch #incidents channel, escalate if new incident posted")
+- API health degradation ("Check response time every 5min, alert if p99 > 500ms")
+- Repository monitoring ("Check for new PRs every hour, summarize if any found")
+
+**Execution flow**:
+```
+Schedule fires
+  -> DataSourceAdapter.query(params)           # mechanical, zero LLM cost
+  -> ChangeDetector.compare(result, baseline)  # mechanical comparison
+  -> No change? -> record check timestamp, done (zero tokens)
+  -> Change detected?
+      -> LLM analysis: "Is this change significant?"  # first LLM cost
+      -> Not significant? -> record, done
+      -> Significant?
+          -> NotificationDispatcher.dispatch(event)
+          -> Optionally escalate to GoalTrigger
+```
+
+**Configuration fields specific to Probe**:
+```typescript
+{
+  layer: "probe",
+  data_source_id: string,         // registered IDataSourceAdapter to query
+  query_params: DataSourceQuery,  // parameters for the query
+  change_detection: {
+    mode: "threshold" | "diff" | "presence",
+    threshold?: number,           // for threshold mode: trigger if value exceeds
+    baseline_window?: number,     // number of recent results to compare against
+  },
+  escalate_to?: {
+    type: "goal_trigger",
+    goal_id: string,              // goal to activate on significant change
+  },
+  notification_on_change: boolean, // send notification when change detected (default: true)
+}
+```
+
+**Cost**: 0 tokens for most executions. 500-2,000 tokens when change is detected (LLM significance analysis). Full CoreLoop cost if escalated to GoalTrigger.
+
+### 3.3 Cron (Medium, guaranteed execution)
+
+**Weight**: Always invokes LLM processing. Designed for human-rhythm-aligned operations.
+
+**Behavior**: Runs LLM processing every time the schedule fires. Unlike Probe, there is no conditional check — the LLM always produces output. This is the "secretary" pattern: always produces a briefing, summary, or report.
+
+**Use cases**:
+- Morning summary ("Every morning at 8am, summarize today's calendar + unread emails")
+- Daily report generation ("Generate end-of-day progress report at 6pm")
+- Weekly digest ("Every Sunday at 9pm, compile weekly goal progress")
+- Periodic briefing ("Brief me on market trends every Monday")
+
+**Execution flow**:
+```
+Schedule fires
+  -> Gather context (DataSource queries, goal states, recent history)
+  -> LLM processing with prompt template
+  -> Format output (report, summary, notification)
+  -> Deliver via NotificationDispatcher and/or ReportingEngine
+```
+
+**Configuration fields specific to Cron**:
+```typescript
+{
+  layer: "cron",
+  prompt_template: string,        // LLM prompt (supports {{variable}} interpolation)
+  context_sources: string[],      // data source IDs to gather context from
+  output_format: "notification" | "report" | "both",
+  report_type?: string,           // for ReportingEngine integration
+}
+```
+
+**Cost**: 1,000-10,000 tokens per execution (LLM processing with context).
+
+### 3.4 Heartbeat (Lightest)
+
+**Weight**: Pure mechanical check. Zero LLM calls under normal operation.
+
+**Behavior**: Runs a simple mechanical check (HTTP ping, process liveness, disk capacity, port response) at high frequency. No LLM is involved. On failure detection, escalates to Probe or GoalTrigger.
+
+This is the "pulse check" — the lightest possible monitoring.
+
+**Use cases**:
+- Service health ("Check service health every 1 minute")
+- Disk capacity ("Alert if disk usage > 90%, check every 5 minutes")
+- Process liveness ("Verify daemon subprocess is alive every 30 seconds")
+- Port response ("Check if port 8080 responds every 1 minute")
+
+**Execution flow**:
+```
+Schedule fires
+  -> Run mechanical check function
+  -> Pass? -> record timestamp, done (zero cost)
+  -> Fail?
+      -> Increment failure counter
+      -> Below failure_threshold? -> record, done
+      -> Exceeded failure_threshold?
+          -> Escalate to Probe or GoalTrigger
+          -> NotificationDispatcher.dispatch(heartbeat_failure event)
+```
+
+**Configuration fields specific to Heartbeat**:
+```typescript
+{
+  layer: "heartbeat",
+  check_type: "http" | "tcp" | "process" | "disk" | "custom",
+  check_config: {
+    url?: string,                 // for http check
+    host?: string,                // for tcp check
+    port?: number,                // for tcp check
+    pid_file?: string,            // for process check
+    path?: string,                // for disk check
+    threshold?: number,           // for disk check (percentage)
+    custom_command?: string,      // for custom check (shell command, exit 0 = pass)
+  },
+  failure_threshold: number,      // consecutive failures before escalation (default: 3)
+  escalate_to?: {
+    type: "probe" | "goal_trigger",
+    schedule_entry_id?: string,   // existing Probe to activate
+    goal_id?: string,             // existing goal to activate
+  },
+}
+```
+
+**Cost**: 0 tokens always. Escalation cost depends on target layer.
+
+---
+
+## §4 ScheduleEntry Schema
+
+### 4.1 Core schema
+
+```typescript
+// src/types/schedule.ts
+
+import { z } from "zod";
+
+// --- Schedule Expression ---
+
+const CronExpressionSchema = z.object({
+  type: z.literal("cron"),
+  expression: z.string(),        // standard cron: "0 9 * * 1" (Monday 9am)
+  timezone: z.string().default("UTC"),
+});
+
+const IntervalExpressionSchema = z.object({
+  type: z.literal("interval"),
+  seconds: z.number().int().positive(),
+  jitter_factor: z.number().min(0).max(0.5).default(0.05), // +/-5% randomization
+});
+
+const ScheduleExpressionSchema = z.discriminatedUnion("type", [
+  CronExpressionSchema,
+  IntervalExpressionSchema,
+]);
+
+export type ScheduleExpression = z.infer<typeof ScheduleExpressionSchema>;
+
+// --- Layer Configs ---
+
+const GoalTriggerConfigSchema = z.object({
+  layer: z.literal("goal_trigger"),
+  goal_id: z.string(),
+  max_iterations: z.number().int().positive().default(10),
+  skip_if_active: z.boolean().default(true),
+});
+
+const ProbeConfigSchema = z.object({
+  layer: z.literal("probe"),
+  data_source_id: z.string(),
+  query_params: z.record(z.unknown()).default({}),
+  change_detection: z.object({
+    mode: z.enum(["threshold", "diff", "presence"]),
+    threshold: z.number().optional(),
+    baseline_window: z.number().int().positive().default(5),
+  }),
+  escalate_to: z.object({
+    type: z.literal("goal_trigger"),
+    goal_id: z.string(),
+  }).optional(),
+  notification_on_change: z.boolean().default(true),
+});
+
+const CronConfigSchema = z.object({
+  layer: z.literal("cron"),
+  prompt_template: z.string(),
+  context_sources: z.array(z.string()).default([]),
+  output_format: z.enum(["notification", "report", "both"]).default("notification"),
+  report_type: z.string().optional(),
+});
+
+const HeartbeatConfigSchema = z.object({
+  layer: z.literal("heartbeat"),
+  check_type: z.enum(["http", "tcp", "process", "disk", "custom"]),
+  check_config: z.record(z.unknown()).default({}),
+  failure_threshold: z.number().int().positive().default(3),
+  escalate_to: z.object({
+    type: z.enum(["probe", "goal_trigger"]),
+    schedule_entry_id: z.string().optional(),
+    goal_id: z.string().optional(),
+  }).optional(),
+});
+
+const LayerConfigSchema = z.discriminatedUnion("layer", [
+  GoalTriggerConfigSchema,
+  ProbeConfigSchema,
+  CronConfigSchema,
+  HeartbeatConfigSchema,
+]);
+
+export type LayerConfig = z.infer<typeof LayerConfigSchema>;
+
+// --- ScheduleEntry ---
+
+export const ScheduleEntrySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().optional(),
+  enabled: z.boolean().default(true),
+
+  // When to fire
+  schedule: ScheduleExpressionSchema,
+
+  // What to do (layer determines processing weight)
+  config: LayerConfigSchema,
+
+  // Runtime state
+  last_fired_at: z.string().datetime().nullable().default(null),
+  next_fire_at: z.string().datetime().nullable().default(null),
+  consecutive_failures: z.number().int().default(0),
+  total_executions: z.number().int().default(0),
+  total_tokens_used: z.number().int().default(0),
+
+  // Metadata
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  tags: z.array(z.string()).default([]),
+});
+
+export type ScheduleEntry = z.infer<typeof ScheduleEntrySchema>;
+
+export const ScheduleEntryListSchema = z.array(ScheduleEntrySchema);
+```
+
+### 4.2 ScheduleResult (execution record)
+
+```typescript
+export const ScheduleResultSchema = z.object({
+  entry_id: z.string().uuid(),
+  fired_at: z.string().datetime(),
+  layer: z.enum(["goal_trigger", "probe", "cron", "heartbeat"]),
+  status: z.enum(["success", "failure", "escalated", "skipped"]),
+  tokens_used: z.number().int().default(0),
+  duration_ms: z.number().int(),
+  escalated_to: z.string().uuid().optional(),  // entry_id or goal_id of escalation target
+  error_message: z.string().optional(),
+  output_summary: z.string().optional(),       // one-line summary of result
+});
+
+export type ScheduleResult = z.infer<typeof ScheduleResultSchema>;
+```
+
+---
+
+## §5 Escalation Mechanics
+
+### 5.1 Escalation paths
+
+Escalation flows strictly upward through layers. Lower layers can trigger higher layers, but never the reverse.
+
+```
+Heartbeat --(failure_threshold exceeded)--> Probe
+Heartbeat --(failure_threshold exceeded)--> GoalTrigger
+Probe     --(significant change detected)--> GoalTrigger
+Cron      --(no escalation path)--> (standalone)
+```
+
+Cron does not escalate because it always produces output. It has no "trigger condition" — it fires unconditionally.
+
+### 5.2 Escalation process
+
+When a layer decides to escalate:
+
+1. **Record the escalation** in `ScheduleResult` with `status: "escalated"`
+2. **Resolve the target**: look up the target ScheduleEntry or Goal by ID
+3. **Execute the target immediately** (out of its normal schedule)
+4. **Link the results**: the target's `ScheduleResult` references the originating entry
+
+```typescript
+interface EscalationEvent {
+  source_entry_id: string;       // the Heartbeat/Probe that triggered escalation
+  source_layer: "heartbeat" | "probe";
+  target_type: "probe" | "goal_trigger";
+  target_id: string;             // ScheduleEntry ID or Goal ID
+  reason: string;                // human-readable escalation reason
+  timestamp: string;             // ISO 8601
+}
+```
+
+### 5.3 Escalation safeguards
+
+To prevent escalation storms (e.g., a failing health check triggering GoalTrigger every minute):
+
+| Safeguard | Mechanism |
+|-----------|-----------|
+| Cooldown period | After escalation, source entry enters cooldown (default: 15 minutes). No re-escalation during cooldown |
+| Max escalations per hour | Global limit on escalations per source entry (default: 4/hour) |
+| Deduplication | If the target GoalTrigger is already running (`skip_if_active: true`), escalation is recorded but not executed |
+| Circuit breaker | After N consecutive escalation failures (default: 10), the source entry is auto-disabled with a warning notification |
+
+---
+
+## §6 Integration with Existing Modules
+
+### 6.1 DaemonRunner
+
+`DaemonRunner` is the host process for `ScheduleEngine`. It initializes the engine at startup and ticks it on each daemon cycle.
+
+```typescript
+// In DaemonRunner.start()
+this.scheduleEngine = new ScheduleEngine({
+  stateManager: this.stateManager,
+  coreLoop: this.coreLoop,
+  observationEngine: this.observationEngine,
+  notificationDispatcher: this.notificationDispatcher,
+  reportingEngine: this.reportingEngine,
+  llmClient: this.llmClient,
+  logger: this.logger,
+  baseDir: this.baseDir,
+});
+await this.scheduleEngine.loadEntries();
+
+// In daemon loop iteration
+const dueEntries = await this.scheduleEngine.getDueEntries();
+for (const entry of dueEntries) {
+  await this.scheduleEngine.execute(entry);
+}
+```
+
+### 6.2 CoreLoop
+
+GoalTrigger invokes `CoreLoop.run(goalId, { maxIterations })` directly. No changes to CoreLoop are required — it already accepts a `goalId` and options.
+
+### 6.3 ObservationEngine and DataSourceAdapter
+
+Probe reuses `ObservationEngine`'s data source infrastructure. It calls `IDataSourceAdapter.query()` directly through the `DataSourceRegistry`, the same way ObservationEngine does for goal observation.
+
+No changes to ObservationEngine or IDataSourceAdapter are required. Probe is a new consumer of the existing data source pipeline.
+
+### 6.4 NotificationDispatcher
+
+ScheduleEngine dispatches notifications through the existing `NotificationDispatcher` for:
+
+- Probe: change detection notifications
+- Cron: report delivery notifications
+- Heartbeat: failure and escalation notifications
+- GoalTrigger: goal progress notifications (handled by CoreLoop internally)
+
+New notification event types added:
+
+```typescript
+type NotificationEventType =
+  | /* existing types */
+  | "schedule_change_detected"    // Probe detected a change
+  | "schedule_heartbeat_failure"  // Heartbeat check failed
+  | "schedule_escalation"         // Layer escalated to higher layer
+  | "schedule_report_ready";      // Cron report generated
+```
+
+### 6.5 ReportingEngine
+
+Cron layer integrates with `ReportingEngine` when `output_format` is `"report"` or `"both"`. The Cron prompt generates structured content, and ReportingEngine formats and persists it.
+
+### 6.6 Module integration summary
+
+| Module | Changes required | Integration method |
+|--------|-----------------|-------------------|
+| `DaemonRunner` | Add ScheduleEngine initialization and tick | Direct dependency injection |
+| `CoreLoop` | No change | Called by GoalTrigger via `coreLoop.run()` |
+| `ObservationEngine` | No change | Probe queries data sources through DataSourceRegistry |
+| `DataSourceAdapter` | No change | Probe calls `query()` on registered adapters |
+| `NotificationDispatcher` | Add 4 new event types | Called by all layers for notifications |
+| `ReportingEngine` | No change | Called by Cron layer for report formatting |
+| `StateManager` | No change | ScheduleEngine persists its own state to `~/.pulseed/schedules.json` |
+| `LLMClient` | No change | Called by Probe (conditional) and Cron (always) |
+
+---
+
+## §7 Plugin Extension: IScheduleSource
+
+### 7.1 Interface definition
+
+External schedule sources allow plugins to inject schedule entries from external systems (Google Calendar, webhooks, etc.).
+
+```typescript
+// src/types/schedule-source.ts
+
+interface IScheduleSource {
+  /** Unique identifier for this source */
+  readonly sourceId: string;
+
+  /** Human-readable name */
+  readonly sourceName: string;
+
+  /**
+   * Fetch schedule entries from the external source.
+   * Called periodically by ScheduleEngine to sync external schedules.
+   * Returns entries that should be active. Entries not returned are deactivated.
+   */
+  fetchEntries(): Promise<ExternalScheduleEntry[]>;
+
+  /**
+   * Check if the source is reachable and authenticated.
+   */
+  healthCheck(): Promise<boolean>;
+}
+
+interface ExternalScheduleEntry {
+  external_id: string;           // ID in the external system
+  name: string;
+  description?: string;
+  schedule: ScheduleExpression;
+  layer: "goal_trigger" | "probe" | "cron" | "heartbeat";
+  config: Record<string, unknown>;  // layer-specific config
+}
+```
+
+### 7.2 Plugin manifest for schedule sources
+
+```yaml
+# ~/.pulseed/plugins/google-calendar-source/plugin.yaml
+name: google-calendar-source
+version: "1.0.0"
+type: schedule_source          # new plugin type
+capabilities:
+  - calendar_scheduling
+  - event_driven_triggers
+description: "Syncs PulSeed schedules from Google Calendar events"
+config_schema:
+  calendar_id:
+    type: string
+    required: true
+    description: "Google Calendar ID to sync from"
+  sync_interval_minutes:
+    type: number
+    default: 15
+    description: "How often to sync calendar events"
+  tag_prefix:
+    type: string
+    default: "pulseed:"
+    description: "Calendar event title prefix to identify PulSeed schedules"
+dependencies:
+  - "googleapis@^120.0.0"
+entry_point: "dist/index.js"
+min_pulseed_version: "2.0.0"
+```
+
+### 7.3 Sync lifecycle
+
+```
+ScheduleEngine startup
+  -> Load IScheduleSource plugins from PluginLoader
+  -> For each source: source.fetchEntries()
+  -> Merge external entries with local entries (external_id used for dedup)
+  -> External entries are tagged with source_id for tracking
+
+Periodic sync (configurable interval, default: 15 minutes)
+  -> Re-fetch from all sources
+  -> Add new entries, update changed entries, deactivate removed entries
+  -> Log sync results
+```
+
+---
+
+## §8 Configuration Format
+
+### 8.1 File location
+
+Schedule entries are persisted to `~/.pulseed/schedules.json`. This file is managed by ScheduleEngine and should not be edited manually (use CLI commands instead).
+
+### 8.2 Configuration example
+
+```json
+{
+  "version": "1.0.0",
+  "entries": [
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440001",
+      "name": "weekly-code-review",
+      "description": "Run code quality review every Monday at 9am",
+      "enabled": true,
+      "schedule": {
+        "type": "cron",
+        "expression": "0 9 * * 1",
+        "timezone": "Asia/Tokyo"
+      },
+      "config": {
+        "layer": "goal_trigger",
+        "goal_id": "code-quality-review",
+        "max_iterations": 10,
+        "skip_if_active": true
+      },
+      "last_fired_at": "2026-03-31T09:00:02Z",
+      "next_fire_at": "2026-04-07T09:00:00Z",
+      "consecutive_failures": 0,
+      "total_executions": 4,
+      "total_tokens_used": 142000,
+      "created_at": "2026-03-10T12:00:00Z",
+      "updated_at": "2026-03-31T09:00:02Z",
+      "tags": ["code-quality"]
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440002",
+      "name": "email-monitor",
+      "description": "Check email every 30 minutes, notify if important",
+      "enabled": true,
+      "schedule": {
+        "type": "interval",
+        "seconds": 1800,
+        "jitter_factor": 0.05
+      },
+      "config": {
+        "layer": "probe",
+        "data_source_id": "gmail-datasource",
+        "query_params": { "label": "INBOX", "unread_only": true },
+        "change_detection": {
+          "mode": "presence",
+          "baseline_window": 1
+        },
+        "escalate_to": {
+          "type": "goal_trigger",
+          "goal_id": "process-important-email"
+        },
+        "notification_on_change": true
+      },
+      "last_fired_at": "2026-04-06T10:30:12Z",
+      "next_fire_at": "2026-04-06T11:00:00Z",
+      "consecutive_failures": 0,
+      "total_executions": 312,
+      "total_tokens_used": 8500,
+      "created_at": "2026-03-15T08:00:00Z",
+      "updated_at": "2026-04-06T10:30:12Z",
+      "tags": ["email", "communication"]
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440003",
+      "name": "morning-briefing",
+      "description": "Daily morning summary at 8am",
+      "enabled": true,
+      "schedule": {
+        "type": "cron",
+        "expression": "0 8 * * *",
+        "timezone": "Asia/Tokyo"
+      },
+      "config": {
+        "layer": "cron",
+        "prompt_template": "Summarize the following for today's briefing:\n1. Calendar events from {{calendar}}\n2. Unread emails from {{email}}\n3. Active goal progress from {{goals}}\nProvide a concise morning briefing.",
+        "context_sources": ["google-calendar", "gmail-datasource", "goal-state"],
+        "output_format": "both",
+        "report_type": "daily_briefing"
+      },
+      "last_fired_at": "2026-04-06T08:00:03Z",
+      "next_fire_at": "2026-04-07T08:00:00Z",
+      "consecutive_failures": 0,
+      "total_executions": 22,
+      "total_tokens_used": 88000,
+      "created_at": "2026-03-15T08:00:00Z",
+      "updated_at": "2026-04-06T08:00:03Z",
+      "tags": ["daily", "briefing"]
+    },
+    {
+      "id": "550e8400-e29b-41d4-a716-446655440004",
+      "name": "service-health",
+      "description": "Check API service health every minute",
+      "enabled": true,
+      "schedule": {
+        "type": "interval",
+        "seconds": 60,
+        "jitter_factor": 0
+      },
+      "config": {
+        "layer": "heartbeat",
+        "check_type": "http",
+        "check_config": {
+          "url": "https://api.example.com/health",
+          "timeout_ms": 5000,
+          "expected_status": 200
+        },
+        "failure_threshold": 3,
+        "escalate_to": {
+          "type": "probe",
+          "schedule_entry_id": "550e8400-e29b-41d4-a716-446655440005"
+        }
+      },
+      "last_fired_at": "2026-04-06T10:59:01Z",
+      "next_fire_at": "2026-04-06T11:00:01Z",
+      "consecutive_failures": 0,
+      "total_executions": 43200,
+      "total_tokens_used": 0,
+      "created_at": "2026-03-20T00:00:00Z",
+      "updated_at": "2026-04-06T10:59:01Z",
+      "tags": ["health", "monitoring"]
+    }
+  ]
+}
+```
+
+### 8.3 CLI commands
+
+```bash
+# List all schedule entries
+pulseed schedule list
+
+# Add a new entry (interactive or from JSON)
+pulseed schedule add --name "morning-briefing" --layer cron --cron "0 8 * * *"
+
+# Enable/disable
+pulseed schedule enable <id>
+pulseed schedule disable <id>
+
+# Remove
+pulseed schedule remove <id>
+
+# Show execution history
+pulseed schedule history <id> --limit 10
+
+# Show cost summary
+pulseed schedule cost --period 7d
+```
+
+---
+
+## §9 Cost Model
+
+### 9.1 Per-layer cost breakdown
+
+| Layer | Tokens per execution | Frequency | Monthly cost estimate (single entry) |
+|-------|---------------------|-----------|--------------------------------------|
+| Heartbeat | 0 | every 1min | $0.00 |
+| Probe (no change) | 0 | every 30min | $0.00 |
+| Probe (change detected) | 500-2,000 | ~5% of checks | ~$0.15 |
+| Cron | 1,000-10,000 | daily | ~$3.00-$30.00 |
+| GoalTrigger | 5,000-50,000+ | weekly | ~$5.00-$50.00 |
+
+### 9.2 Cost tracking
+
+ScheduleEngine tracks cumulative token usage per entry in `total_tokens_used`. The `pulseed schedule cost` command reports:
+
+- Per-entry token usage over a time period
+- Total schedule-driven token usage vs. user-initiated usage
+- Projected monthly cost based on recent usage
+
+### 9.3 Cost controls
+
+| Control | Mechanism |
+|---------|-----------|
+| Token budget per entry | Optional `max_tokens_per_day` field prevents runaway costs |
+| Global schedule budget | `~/.pulseed/config.json` field `schedule_token_budget_daily` caps total schedule-driven token usage |
+| Auto-disable on budget exceeded | Entry is disabled with notification when budget is hit |
+| Cost-aware scheduling | Entries can specify `cost_priority: "low"` to defer execution to off-peak times |
+
+---
+
+## §10 Implementation Order
+
+### Phase 1: Core infrastructure + Heartbeat (lightest layer first)
+
+**Scope**:
+- `ScheduleEntry` Zod schema and persistence (`src/types/schedule.ts`)
+- `ScheduleEngine` core class: load, save, getDueEntries, execute dispatch
+- Heartbeat layer: HTTP, TCP, process, disk checks
+- Heartbeat escalation to notification
+- DaemonRunner integration (tick ScheduleEngine in daemon loop)
+- CLI: `pulseed schedule list`, `pulseed schedule add`, `pulseed schedule remove`
+
+**Rationale**: Heartbeat is the simplest layer (zero LLM, pure mechanical checks). Building it first validates the core scheduling infrastructure without any LLM dependency.
+
+**Completion criteria**:
+- Heartbeat entries fire on schedule and record results
+- Failure detection works with configurable threshold
+- DaemonRunner ticks ScheduleEngine alongside existing CronScheduler
+
+### Phase 2: Probe layer + escalation
+
+**Scope**:
+- Probe layer: DataSourceAdapter.query() integration
+- ChangeDetector: threshold, diff, and presence modes
+- Conditional LLM analysis on change detection
+- Escalation mechanics: Heartbeat to Probe, Probe to GoalTrigger
+- Escalation safeguards (cooldown, max rate, circuit breaker)
+- 4 new NotificationDispatcher event types
+
+**Completion criteria**:
+- Probe queries data sources and detects changes mechanically
+- LLM is invoked only when change is detected
+- Escalation from Heartbeat to Probe works
+- Escalation from Probe to GoalTrigger works
+- Safeguards prevent escalation storms
+
+### Phase 3: Cron + GoalTrigger layers
+
+**Scope**:
+- Cron layer: prompt template interpolation, context gathering, LLM execution
+- Cron + ReportingEngine integration
+- GoalTrigger layer: CoreLoop.run() invocation
+- GoalTrigger skip_if_active logic
+- Cost tracking and budget controls
+- CLI: `pulseed schedule history`, `pulseed schedule cost`
+
+**Completion criteria**:
+- Cron produces LLM-generated output on schedule
+- GoalTrigger activates CoreLoop for a goal on schedule
+- Cost tracking accurately reflects token usage per entry
+- Budget limits auto-disable entries when exceeded
+
+### Phase 4: Plugin extension + migration
+
+**Scope**:
+- `IScheduleSource` interface and plugin type
+- PluginLoader extension for `schedule_source` type
+- External schedule sync lifecycle
+- CronScheduler migration path (convert existing tasks to ScheduleEntries)
+- Google Calendar reference plugin
+
+**Completion criteria**:
+- External schedule source plugins can inject entries
+- Sync lifecycle correctly adds, updates, and removes external entries
+- Existing CronScheduler tasks can be migrated to ScheduleEngine
+
+---
+
+## Design Principles Summary
+
+| Principle | Concrete design decision |
+|-----------|------------------------|
+| PulSeed acts on time, not just on demand | ScheduleEngine adds proactive time-based triggers to the daemon |
+| Match processing weight to the task | 4 layers: Heartbeat (zero cost) to Probe (conditional) to Cron (always LLM) to GoalTrigger (full CoreLoop) |
+| Most checks cost nothing | Heartbeat and Probe (no change) use zero LLM tokens |
+| Escalation, not duplication | Lower layers escalate to higher layers rather than reimplementing their logic |
+| Reuse existing infrastructure | Probe uses DataSourceAdapter, GoalTrigger uses CoreLoop, notifications use NotificationDispatcher |
+| Extend with plugins | External schedule sources (calendar, webhook) are plugins, not core |
+| Cost transparency | Per-entry token tracking, budget controls, cost reporting CLI |
+| Failures do not stop PulSeed | Schedule entry failures are logged and retried, not fatal |

--- a/src/base/types/schedule.ts
+++ b/src/base/types/schedule.ts
@@ -1,0 +1,13 @@
+// Re-export from new location for backward compatibility
+export {
+  ScheduleEntrySchema,
+  ScheduleEntryListSchema,
+  ScheduleResultSchema,
+  ScheduleExpressionSchema,
+  LayerConfigSchema,
+  type ScheduleExpression,
+  type LayerConfig,
+  type HeartbeatConfig,
+  type ScheduleEntry,
+  type ScheduleResult,
+} from "../../runtime/types/schedule.js";

--- a/src/base/types/schedule.ts
+++ b/src/base/types/schedule.ts
@@ -1,12 +1,12 @@
 // Re-export from new location for backward compatibility
 export {
+  HeartbeatCheckTypeSchema,
+  HeartbeatConfigSchema,
+  ScheduleLayerSchema,
+  ScheduleTriggerSchema,
   ScheduleEntrySchema,
   ScheduleEntryListSchema,
   ScheduleResultSchema,
-  ScheduleExpressionSchema,
-  LayerConfigSchema,
-  type ScheduleExpression,
-  type LayerConfig,
   type HeartbeatConfig,
   type ScheduleEntry,
   type ScheduleResult,

--- a/src/base/types/schedule.ts
+++ b/src/base/types/schedule.ts
@@ -2,12 +2,16 @@
 export {
   HeartbeatCheckTypeSchema,
   HeartbeatConfigSchema,
+  ProbeConfigSchema,
+  EscalationConfigSchema,
   ScheduleLayerSchema,
   ScheduleTriggerSchema,
   ScheduleEntrySchema,
   ScheduleEntryListSchema,
   ScheduleResultSchema,
   type HeartbeatConfig,
+  type ProbeConfig,
+  type EscalationConfig,
   type ScheduleEntry,
   type ScheduleResult,
 } from "../../runtime/types/schedule.js";

--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -41,6 +41,7 @@ import { cmdLogs } from "./commands/logs.js";
 import { cmdInstall, cmdUninstall } from "./commands/install.js";
 import { cmdNotify } from "./commands/notify.js";
 import { cmdTelegramSetup } from "./commands/telegram.js";
+import { cmdSchedule } from "./commands/schedule.js";
 import { printUsage, formatOperationError } from "./utils.js";
 import { ensureProviderConfig } from "./ensure-api-key.js";
 
@@ -291,6 +292,11 @@ export async function dispatchCommand(
 
   if (subcommand === "cron") {
     await cmdCron(argv.slice(1));
+    return 0;
+  }
+
+  if (subcommand === "schedule") {
+    await cmdSchedule(stateManager, argv.slice(1));
     return 0;
   }
 

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -16,6 +16,7 @@ import { DaemonRunner } from "../../../runtime/daemon-runner.js";
 import { PIDManager } from "../../../runtime/pid-manager.js";
 import { EventServer } from "../../../runtime/event-server.js";
 import { CronScheduler } from "../../../runtime/cron-scheduler.js";
+import { ScheduleEngine } from "../../../runtime/schedule-engine.js";
 import { PluginLoader } from "../../../runtime/plugin-loader.js";
 import { NotifierRegistry } from "../../../runtime/notifier-registry.js";
 import { NotificationDispatcher } from "../../../runtime/notification-dispatcher.js";
@@ -174,6 +175,15 @@ export async function cmdStart(
   // Gap 4: Create CronScheduler for scheduled tasks
   const cronScheduler = new CronScheduler(baseDir);
 
+  // Create ScheduleEngine with data source registry and LLM client
+  const scheduleEngine = new ScheduleEngine({
+    baseDir,
+    logger,
+    dataSourceRegistry,
+    llmClient: deps.llmClient,
+  });
+  await scheduleEngine.loadEntries();
+
   const daemon = new DaemonRunner({
     coreLoop: deps.coreLoop,
     driveSystem: deps.driveSystem,
@@ -184,6 +194,7 @@ export async function cmdStart(
     ...(eventServer ? { eventServer } : {}),
     llmClient: deps.llmClient,
     cronScheduler,
+    scheduleEngine,
   });
 
   logger.info(`Starting PulSeed daemon for goals: ${goalIds.join(", ")}`);

--- a/src/interface/cli/commands/schedule.ts
+++ b/src/interface/cli/commands/schedule.ts
@@ -34,8 +34,8 @@ async function scheduleList(engine: ScheduleEngine): Promise<void> {
   }
   for (const e of entries) {
     const status = e.enabled ? "enabled" : "disabled";
-    const layer = e.config.layer;
-    const schedule = e.schedule.type === "cron" ? e.schedule.expression : `every ${e.schedule.seconds}s`;
+    const layer = e.layer;
+    const schedule = e.trigger.type === "cron" ? e.trigger.expression : `every ${e.trigger.seconds}s`;
     const lastFired = e.last_fired_at ?? "never";
     console.log(`  ${e.id.slice(0, 8)}  [${layer}] ${e.name}  (${schedule})  ${status}  last: ${lastFired}`);
   }
@@ -74,21 +74,21 @@ async function scheduleAdd(engine: ScheduleEngine, argv: string[]): Promise<void
   if (values.path) checkConfig.path = values.path;
   if (values.command) checkConfig.command = values.command;
 
-  const schedule = values.cron
+  const trigger = values.cron
     ? { type: "cron" as const, expression: values.cron as string }
     : { type: "interval" as const, seconds: parseInt(values.interval as string || "60", 10) };
 
   const entry = await engine.addEntry({
     name: values.name as string,
+    layer: "heartbeat",
+    trigger,
     enabled: true,
-    schedule,
-    config: {
-      layer: "heartbeat",
+    heartbeat: {
       check_type: checkType,
       check_config: checkConfig,
       failure_threshold: parseInt(values.threshold as string, 10),
+      timeout_ms: 5000,
     },
-    tags: [],
   });
 
   console.log(`Added schedule entry: ${entry.id} (${entry.name})`);

--- a/src/interface/cli/commands/schedule.ts
+++ b/src/interface/cli/commands/schedule.ts
@@ -1,0 +1,112 @@
+import { parseArgs } from "node:util";
+import { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import type { StateManager } from "../../../base/state/state-manager.js";
+
+export async function cmdSchedule(
+  stateManager: StateManager,
+  argv: string[],
+): Promise<void> {
+  const subcommand = argv[0];
+  const baseDir = stateManager.getBaseDir();
+  const engine = new ScheduleEngine({ baseDir });
+  await engine.loadEntries();
+
+  switch (subcommand) {
+    case "list":
+      return await scheduleList(engine);
+    case "add":
+      return await scheduleAdd(engine, argv.slice(1));
+    case "remove":
+      return await scheduleRemove(engine, argv.slice(1));
+    default:
+      console.log("Usage: pulseed schedule <list|add|remove>");
+      console.log("  list              List all schedule entries");
+      console.log("  add               Add a heartbeat entry");
+      console.log("  remove <id>       Remove a schedule entry");
+  }
+}
+
+async function scheduleList(engine: ScheduleEngine): Promise<void> {
+  const entries = engine.getEntries();
+  if (entries.length === 0) {
+    console.log("No schedule entries.");
+    return;
+  }
+  for (const e of entries) {
+    const status = e.enabled ? "enabled" : "disabled";
+    const layer = e.config.layer;
+    const schedule = e.schedule.type === "cron" ? e.schedule.expression : `every ${e.schedule.seconds}s`;
+    const lastFired = e.last_fired_at ?? "never";
+    console.log(`  ${e.id.slice(0, 8)}  [${layer}] ${e.name}  (${schedule})  ${status}  last: ${lastFired}`);
+  }
+}
+
+async function scheduleAdd(engine: ScheduleEngine, argv: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      name: { type: "string" },
+      type: { type: "string", default: "http" },
+      url: { type: "string" },
+      host: { type: "string" },
+      port: { type: "string" },
+      pid: { type: "string" },
+      path: { type: "string" },
+      command: { type: "string" },
+      cron: { type: "string" },
+      interval: { type: "string" },
+      threshold: { type: "string", default: "3" },
+    },
+    strict: false,
+  });
+
+  if (!values.name) {
+    console.error("Error: --name is required");
+    return;
+  }
+
+  const checkType = values.type as "http" | "tcp" | "process" | "disk" | "custom";
+  const checkConfig: Record<string, unknown> = {};
+  if (values.url) checkConfig.url = values.url;
+  if (values.host) checkConfig.host = values.host;
+  if (values.port) checkConfig.port = parseInt(values.port as string, 10);
+  if (values.pid) checkConfig.pid = parseInt(values.pid as string, 10);
+  if (values.path) checkConfig.path = values.path;
+  if (values.command) checkConfig.command = values.command;
+
+  const schedule = values.cron
+    ? { type: "cron" as const, expression: values.cron as string }
+    : { type: "interval" as const, seconds: parseInt(values.interval as string || "60", 10) };
+
+  const entry = await engine.addEntry({
+    name: values.name as string,
+    enabled: true,
+    schedule,
+    config: {
+      layer: "heartbeat",
+      check_type: checkType,
+      check_config: checkConfig,
+      failure_threshold: parseInt(values.threshold as string, 10),
+    },
+    tags: [],
+  });
+
+  console.log(`Added schedule entry: ${entry.id} (${entry.name})`);
+}
+
+async function scheduleRemove(engine: ScheduleEngine, argv: string[]): Promise<void> {
+  const id = argv[0];
+  if (!id) {
+    console.error("Error: schedule entry ID is required");
+    return;
+  }
+  // Support short IDs (first 8 chars)
+  const entries = engine.getEntries();
+  const match = entries.find(e => e.id === id || e.id.startsWith(id));
+  if (!match) {
+    console.error(`No schedule entry found matching: ${id}`);
+    return;
+  }
+  await engine.removeEntry(match.id);
+  console.log(`Removed schedule entry: ${match.id} (${match.name})`);
+}

--- a/src/platform/knowledge/__tests__/knowledge-manager-semantic-recall.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-manager-semantic-recall.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { KnowledgeManager } from "../knowledge-manager.js";
 import { StateManager } from "../../../base/state/state-manager.js";
 import type { IEmbeddingClient } from "../embedding-client.js";
@@ -43,13 +44,12 @@ function makeEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntry 
 
 async function seedMemory(km: KnowledgeManager, entries: AgentMemoryEntry[]): Promise<void> {
   for (const e of entries) {
-    await km.saveAgentMemory(e.key, e.value, {
-      id: e.id,
+    await km.saveAgentMemory({
+      key: e.key,
+      value: e.value,
       tags: e.tags,
       category: e.category,
       memory_type: e.memory_type,
-      status: e.status,
-      summary: e.summary,
     });
   }
 }
@@ -236,8 +236,12 @@ describe("recallAgentMemory — semantic mode", () => {
     };
 
     const km = makeKM(mockEmbeddingClient);
-    const entry = makeEntry({ key: "my.key", value: "my value", summary: "my summary" });
-    await seedMemory(km, [entry]);
+    // Save entry first, then patch the stored JSON to add summary
+    await km.saveAgentMemory({ key: "my.key", value: "my value" });
+    const storePath = path.join(tmpDir, "memory", "agent-memory", "entries.json");
+    const stored = JSON.parse(fs.readFileSync(storePath, "utf8")) as { entries: AgentMemoryEntry[] };
+    stored.entries[0] = { ...stored.entries[0]!, summary: "my summary" };
+    fs.writeFileSync(storePath, JSON.stringify(stored));
 
     await km.recallAgentMemory("query", { semantic: true });
 

--- a/src/platform/knowledge/__tests__/knowledge-manager-semantic-recall.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-manager-semantic-recall.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import { KnowledgeManager } from "../knowledge-manager.js";
-import { StateManager } from "../../base/state/state-manager.js";
+import { StateManager } from "../../../base/state/state-manager.js";
 import type { IEmbeddingClient } from "../embedding-client.js";
 import { cosineSimilarity } from "../embedding-client.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";

--- a/src/platform/knowledge/__tests__/knowledge-manager-semantic-recall.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-manager-semantic-recall.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import { KnowledgeManager } from "../knowledge-manager.js";
+import { StateManager } from "../../base/state/state-manager.js";
+import type { IEmbeddingClient } from "../embedding-client.js";
+import { cosineSimilarity } from "../embedding-client.js";
+import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
+import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
+import type { AgentMemoryEntry } from "../types/agent-memory.js";
+
+// ─── Helpers ───
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = makeTempDir();
+});
+
+afterEach(() => {
+  cleanupTempDir(tmpDir);
+});
+
+function makeKM(embeddingClient?: IEmbeddingClient): KnowledgeManager {
+  const sm = new StateManager(tmpDir);
+  const llm = createMockLLMClient([]);
+  return new KnowledgeManager(sm, llm, undefined, embeddingClient);
+}
+
+function makeEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntry {
+  return {
+    id: `mem-${Math.random().toString(36).slice(2)}`,
+    key: "test.key",
+    value: "test value",
+    tags: [],
+    category: "general",
+    memory_type: "fact",
+    status: "raw",
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+async function seedMemory(km: KnowledgeManager, entries: AgentMemoryEntry[]): Promise<void> {
+  for (const e of entries) {
+    await km.saveAgentMemory(e.key, e.value, {
+      id: e.id,
+      tags: e.tags,
+      category: e.category,
+      memory_type: e.memory_type,
+      status: e.status,
+      summary: e.summary,
+    });
+  }
+}
+
+// ─── Tests ───
+
+describe("recallAgentMemory — semantic mode", () => {
+  it("returns semantically similar entries when embeddingClient available and semantic=true", async () => {
+    // query vec: [1, 0, 0]
+    // batchEmbed returns: entry0=[0.9,0.1,0] (similar), entry1=[0,1,0] (not similar), entry2=[0.8,0.2,0] (similar)
+    const mockEmbeddingClient: IEmbeddingClient = {
+      embed: vi.fn().mockResolvedValue([1, 0, 0]),
+      batchEmbed: vi.fn().mockResolvedValue([[0.9, 0.1, 0], [0, 1, 0], [0.8, 0.2, 0]]),
+      cosineSimilarity: vi.fn(),
+    };
+
+    const km = makeKM(mockEmbeddingClient);
+    const entries = [
+      makeEntry({ key: "entry.0", value: "alpha" }),
+      makeEntry({ key: "entry.1", value: "beta" }),
+      makeEntry({ key: "entry.2", value: "gamma" }),
+    ];
+    await seedMemory(km, entries);
+
+    const results = await km.recallAgentMemory("test query", { semantic: true });
+
+    // Both entry0 and entry2 are above 0.3 threshold
+    // entry1 has cosine similarity of 0 (orthogonal) — filtered out
+    const queryVec = [1, 0, 0];
+    const score0 = cosineSimilarity(queryVec, [0.9, 0.1, 0]);
+    const score2 = cosineSimilarity(queryVec, [0.8, 0.2, 0]);
+    expect(score0).toBeGreaterThan(0.3);
+    expect(score2).toBeGreaterThan(0.3);
+    expect(cosineSimilarity(queryVec, [0, 1, 0])).toBeLessThan(0.3);
+
+    expect(results).toHaveLength(2);
+    // Results should be sorted by similarity descending (score0 > score2)
+    expect(results[0]!.key).toBe("entry.0");
+    expect(results[1]!.key).toBe("entry.2");
+  });
+
+  it("falls back to keyword search when embeddingClient is undefined and semantic=true", async () => {
+    const km = makeKM(undefined); // no embedding client
+    const entries = [
+      makeEntry({ key: "typescript.preference", value: "TypeScript is preferred" }),
+      makeEntry({ key: "python.info", value: "Python is also used" }),
+    ];
+    await seedMemory(km, entries);
+
+    const results = await km.recallAgentMemory("TypeScript", { semantic: true });
+
+    // Falls back to keyword search — only the TypeScript entry matches
+    expect(results).toHaveLength(1);
+    expect(results[0]!.key).toBe("typescript.preference");
+  });
+
+  it("respects category filter before semantic ranking", async () => {
+    const mockEmbeddingClient: IEmbeddingClient = {
+      embed: vi.fn().mockResolvedValue([1, 0, 0]),
+      batchEmbed: vi.fn().mockImplementation((texts: string[]) => {
+        // Return similar vectors for all entries — category filter must reduce candidates
+        return Promise.resolve(texts.map(() => [0.9, 0.1, 0]));
+      }),
+      cosineSimilarity: vi.fn(),
+    };
+
+    const km = makeKM(mockEmbeddingClient);
+    const entries = [
+      makeEntry({ key: "proj.setting", value: "project config", category: "project" }),
+      makeEntry({ key: "user.lang", value: "user language", category: "user" }),
+    ];
+    await seedMemory(km, entries);
+
+    const results = await km.recallAgentMemory("config", {
+      semantic: true,
+      category: "project",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.category).toBe("project");
+    // batchEmbed should have been called with only 1 text (category filtered to 1 entry)
+    const batchEmbedCall = vi.mocked(mockEmbeddingClient.batchEmbed).mock.calls[0]!;
+    expect(batchEmbedCall[0]).toHaveLength(1);
+  });
+
+  it("respects memory_type filter before semantic ranking", async () => {
+    const mockEmbeddingClient: IEmbeddingClient = {
+      embed: vi.fn().mockResolvedValue([1, 0, 0]),
+      batchEmbed: vi.fn().mockImplementation((texts: string[]) => {
+        return Promise.resolve(texts.map(() => [0.9, 0.1, 0]));
+      }),
+      cosineSimilarity: vi.fn(),
+    };
+
+    const km = makeKM(mockEmbeddingClient);
+    const entries = [
+      makeEntry({ key: "how.to.test", value: "run vitest", memory_type: "procedure" }),
+      makeEntry({ key: "lang.fact", value: "TypeScript is typed", memory_type: "fact" }),
+    ];
+    await seedMemory(km, entries);
+
+    const results = await km.recallAgentMemory("testing", {
+      semantic: true,
+      memory_type: "procedure",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.memory_type).toBe("procedure");
+  });
+
+  it("filters out entries below 0.3 similarity threshold", async () => {
+    // All candidate vecs will be orthogonal to query — similarity = 0
+    const mockEmbeddingClient: IEmbeddingClient = {
+      embed: vi.fn().mockResolvedValue([1, 0, 0]),
+      batchEmbed: vi.fn().mockResolvedValue([[0, 1, 0], [0, 0, 1]]),
+      cosineSimilarity: vi.fn(),
+    };
+
+    const km = makeKM(mockEmbeddingClient);
+    const entries = [
+      makeEntry({ key: "entry.a", value: "aaa" }),
+      makeEntry({ key: "entry.b", value: "bbb" }),
+    ];
+    await seedMemory(km, entries);
+
+    const results = await km.recallAgentMemory("something", { semantic: true });
+
+    expect(results).toHaveLength(0);
+  });
+
+  it("respects limit parameter", async () => {
+    // All 3 entries are above threshold
+    const mockEmbeddingClient: IEmbeddingClient = {
+      embed: vi.fn().mockResolvedValue([1, 0, 0]),
+      batchEmbed: vi.fn().mockResolvedValue([
+        [0.99, 0.01, 0],
+        [0.95, 0.05, 0],
+        [0.90, 0.10, 0],
+      ]),
+      cosineSimilarity: vi.fn(),
+    };
+
+    const km = makeKM(mockEmbeddingClient);
+    const entries = [
+      makeEntry({ key: "e1", value: "one" }),
+      makeEntry({ key: "e2", value: "two" }),
+      makeEntry({ key: "e3", value: "three" }),
+    ];
+    await seedMemory(km, entries);
+
+    const results = await km.recallAgentMemory("query", { semantic: true, limit: 2 });
+
+    expect(results).toHaveLength(2);
+  });
+
+  it("works with default keyword mode unchanged (no semantic flag)", async () => {
+    const mockEmbeddingClient: IEmbeddingClient = {
+      embed: vi.fn(),
+      batchEmbed: vi.fn(),
+      cosineSimilarity: vi.fn(),
+    };
+
+    const km = makeKM(mockEmbeddingClient);
+    const entries = [
+      makeEntry({ key: "typescript.version", value: "TypeScript 5.3" }),
+      makeEntry({ key: "node.version", value: "Node.js 20" }),
+    ];
+    await seedMemory(km, entries);
+
+    // Default keyword mode — should NOT call embeddingClient
+    const results = await km.recallAgentMemory("TypeScript");
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.key).toBe("typescript.version");
+    expect(mockEmbeddingClient.embed).not.toHaveBeenCalled();
+    expect(mockEmbeddingClient.batchEmbed).not.toHaveBeenCalled();
+  });
+
+  it("includes entry with summary in text sent to batchEmbed", async () => {
+    const mockEmbeddingClient: IEmbeddingClient = {
+      embed: vi.fn().mockResolvedValue([1, 0, 0]),
+      batchEmbed: vi.fn().mockResolvedValue([[0.9, 0.1, 0]]),
+      cosineSimilarity: vi.fn(),
+    };
+
+    const km = makeKM(mockEmbeddingClient);
+    const entry = makeEntry({ key: "my.key", value: "my value", summary: "my summary" });
+    await seedMemory(km, [entry]);
+
+    await km.recallAgentMemory("query", { semantic: true });
+
+    const batchEmbedTexts = vi.mocked(mockEmbeddingClient.batchEmbed).mock.calls[0]![0];
+    expect(batchEmbedTexts[0]).toBe("my.key: my value (my summary)");
+  });
+});

--- a/src/platform/knowledge/knowledge-manager.ts
+++ b/src/platform/knowledge/knowledge-manager.ts
@@ -509,25 +509,43 @@ export class KnowledgeManager {
       memory_type?: AgentMemoryType;
       limit?: number;
       include_archived?: boolean;
+      semantic?: boolean;
     }
   ): Promise<AgentMemoryEntry[]> {
     const store = await this._loadAgentMemoryStore();
-    const { exact = false, category, memory_type, limit = 10, include_archived = false } = opts ?? {};
-    const lower = query.toLowerCase();
+    const { exact = false, category, memory_type, limit = 10, include_archived = false, semantic = false } = opts ?? {};
 
-    let results = store.entries.filter((e) => {
-      // Exclude archived entries unless explicitly requested
+    // Pre-filter by category, memory_type, and archived status (applies to both modes)
+    const candidates = store.entries.filter((e) => {
       if (!include_archived && e.status === "archived") return false;
+      const matchesCategory = category ? e.category === category : true;
+      const matchesType = memory_type ? e.memory_type === memory_type : true;
+      return matchesCategory && matchesType;
+    });
 
-      const matchesQuery = exact
+    // Semantic search mode: use embedding similarity
+    if (semantic && this.embeddingClient) {
+      const texts = candidates.map((e) => {
+        const base = `${e.key}: ${e.value}`;
+        return e.summary ? `${base} (${e.summary})` : base;
+      });
+      const queryVec = await this.embeddingClient.embed(query);
+      const candidateVecs = await this.embeddingClient.batchEmbed(texts);
+      const scored = candidates
+        .map((e, i) => ({ entry: e, score: cosineSimilarity(queryVec, candidateVecs[i]!) }))
+        .filter((s) => s.score >= 0.3);
+      scored.sort((a, b) => b.score - a.score);
+      return scored.slice(0, limit).map((s) => s.entry);
+    }
+
+    // Keyword search mode (default)
+    const lower = query.toLowerCase();
+    let results = candidates.filter((e) => {
+      return exact
         ? e.key === query
         : e.key.toLowerCase().includes(lower) ||
           e.value.toLowerCase().includes(lower) ||
           e.tags.some((t) => t.toLowerCase().includes(lower));
-
-      const matchesCategory = category ? e.category === category : true;
-      const matchesType = memory_type ? e.memory_type === memory_type : true;
-      return matchesQuery && matchesCategory && matchesType;
     });
 
     // Tiered sort: compiled entries first, then raw, both sorted by updated_at desc

--- a/src/platform/knowledge/knowledge-manager.ts
+++ b/src/platform/knowledge/knowledge-manager.ts
@@ -23,6 +23,7 @@ import type {
 } from "../../base/types/knowledge.js";
 import type { VectorIndex } from "./vector-index.js";
 import type { IEmbeddingClient } from "./embedding-client.js";
+import { cosineSimilarity } from "./embedding-client.js";
 import {
   searchKnowledge,
   searchAcrossGoals,

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -8,7 +8,7 @@ let engine: ScheduleEngine;
 
 beforeEach(() => {
   tempDir = makeTempDir("schedule-engine-test-");
-  engine = new ScheduleEngine(tempDir);
+  engine = new ScheduleEngine({ baseDir: tempDir });
 });
 
 afterEach(() => {
@@ -45,7 +45,7 @@ describe("ScheduleEngine", () => {
     expect(new Date(entry.next_fire_at).getTime()).toBeGreaterThan(Date.now());
 
     // Verify persistence via new instance
-    const engine2 = new ScheduleEngine(tempDir);
+    const engine2 = new ScheduleEngine({ baseDir: tempDir });
     const loaded = await engine2.loadEntries();
     expect(loaded).toHaveLength(1);
     expect(loaded[0]!.id).toBe(entry.id);
@@ -70,7 +70,7 @@ describe("ScheduleEngine", () => {
     expect(engine.getEntries()).toHaveLength(0);
 
     // Verify persistence
-    const engine2 = new ScheduleEngine(tempDir);
+    const engine2 = new ScheduleEngine({ baseDir: tempDir });
     const loaded = await engine2.loadEntries();
     expect(loaded).toHaveLength(0);
   });
@@ -95,7 +95,7 @@ describe("ScheduleEngine", () => {
     await engine.saveEntries();
     await engine.loadEntries();
 
-    const due = engine.getDueEntries();
+    const due = await engine.getDueEntries();
     expect(due).toHaveLength(1);
   });
 
@@ -119,7 +119,7 @@ describe("ScheduleEngine", () => {
     await engine.saveEntries();
     await engine.loadEntries();
 
-    const due = engine.getDueEntries();
+    const due = await engine.getDueEntries();
     expect(due).toHaveLength(0);
   });
 
@@ -138,7 +138,7 @@ describe("ScheduleEngine", () => {
     });
 
     // next_fire_at should be ~1 hour from now, not due yet
-    const due = engine.getDueEntries();
+    const due = await engine.getDueEntries();
     expect(due).toHaveLength(0);
   });
 });
@@ -277,7 +277,7 @@ describe("Schedule computation", () => {
     });
 
     const nextFire = new Date(entry.next_fire_at).getTime();
-    // Should be approximately 60 seconds from now (allow ±5s tolerance)
+    // Should be approximately 60 seconds from now (allow +/-5s tolerance)
     expect(nextFire).toBeGreaterThanOrEqual(before + 55_000);
     expect(nextFire).toBeLessThanOrEqual(before + 65_000);
   });
@@ -292,7 +292,7 @@ describe("Schedule computation", () => {
     });
 
     const nextFire = new Date(entry.next_fire_at).getTime();
-    // "every minute" — next fire must be within the next 60 seconds
+    // "every minute" -- next fire must be within the next 60 seconds
     expect(nextFire).toBeGreaterThan(before);
     expect(nextFire).toBeLessThanOrEqual(before + 60_000);
   });

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { ScheduleEngine } from "../schedule-engine.js";
+import type { ScheduleEntry } from "../types/schedule.js";
+import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
+
+let tempDir: string;
+let engine: ScheduleEngine;
+
+beforeEach(() => {
+  tempDir = makeTempDir("schedule-engine-test-");
+  engine = new ScheduleEngine(tempDir);
+});
+
+afterEach(() => {
+  cleanupTempDir(tempDir);
+});
+
+// ─── ScheduleEngine ───
+
+describe("ScheduleEngine", () => {
+  it("loads empty entries from fresh directory", async () => {
+    const entries = await engine.loadEntries();
+    expect(entries).toEqual([]);
+  });
+
+  it("adds and persists a heartbeat entry", async () => {
+    const entry = await engine.addEntry({
+      name: "http-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 30 },
+      enabled: true,
+      heartbeat: {
+        check_type: "http",
+        check_config: { url: "http://localhost:3000/health" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    expect(entry.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+    expect(entry.created_at).toBeTruthy();
+    expect(entry.next_fire_at).toBeTruthy();
+    expect(new Date(entry.next_fire_at).getTime()).toBeGreaterThan(Date.now());
+
+    // Verify persistence via new instance
+    const engine2 = new ScheduleEngine(tempDir);
+    const loaded = await engine2.loadEntries();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]!.id).toBe(entry.id);
+    expect(loaded[0]!.name).toBe("http-check");
+  });
+
+  it("removes an entry", async () => {
+    const entry = await engine.addEntry({
+      name: "to-remove",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    await engine.removeEntry(entry.id);
+    expect(engine.getEntries()).toHaveLength(0);
+
+    // Verify persistence
+    const engine2 = new ScheduleEngine(tempDir);
+    const loaded = await engine2.loadEntries();
+    expect(loaded).toHaveLength(0);
+  });
+
+  it("getDueEntries returns entries past their next_fire_at", async () => {
+    await engine.addEntry({
+      name: "overdue-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 1 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    // Manipulate next_fire_at to be in the past
+    const entries = engine.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await engine.saveEntries();
+    await engine.loadEntries();
+
+    const due = engine.getDueEntries();
+    expect(due).toHaveLength(1);
+  });
+
+  it("getDueEntries skips disabled entries", async () => {
+    await engine.addEntry({
+      name: "disabled-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 1 },
+      enabled: false,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    // Manipulate next_fire_at to be in the past
+    const entries = engine.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await engine.saveEntries();
+    await engine.loadEntries();
+
+    const due = engine.getDueEntries();
+    expect(due).toHaveLength(0);
+  });
+
+  it("getDueEntries skips entries not yet due", async () => {
+    await engine.addEntry({
+      name: "future-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 3600 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    // next_fire_at should be ~1 hour from now, not due yet
+    const due = engine.getDueEntries();
+    expect(due).toHaveLength(0);
+  });
+});
+
+// ─── Heartbeat execution ───
+
+describe("Heartbeat execution", () => {
+  it("tick executes due heartbeat and records success", async () => {
+    const entry = await engine.addEntry({
+      name: "success-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    // Set next_fire_at to past
+    const entries = engine.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await engine.saveEntries();
+    await engine.loadEntries();
+
+    const results = await engine.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result).toBeDefined();
+    expect(result!.status).toBe("success");
+
+    // Verify counters updated
+    const updated = engine.getEntries().find((e) => e.id === entry.id)!;
+    expect(updated.total_executions).toBe(1);
+    expect(new Date(updated.next_fire_at).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it("tick records failure on heartbeat check failure", async () => {
+    const entry = await engine.addEntry({
+      name: "fail-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "exit 1" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    // Set next_fire_at to past
+    const entries = engine.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await engine.saveEntries();
+    await engine.loadEntries();
+
+    const results = await engine.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result).toBeDefined();
+    expect(result!.status).toBe("failure");
+
+    // Verify consecutive_failures incremented
+    const updated = engine.getEntries().find((e) => e.id === entry.id)!;
+    expect(updated.consecutive_failures).toBeGreaterThan(0);
+  });
+
+  it("tick resets consecutive_failures on success after failures", async () => {
+    const entry = await engine.addEntry({
+      name: "recovery-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    // Manually set consecutive_failures to 2 and next_fire_at to past
+    const entries = engine.getEntries();
+    entries[0]!.consecutive_failures = 2;
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await engine.saveEntries();
+    await engine.loadEntries();
+
+    const results = await engine.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result).toBeDefined();
+    expect(result!.status).toBe("success");
+
+    const updated = engine.getEntries().find((e) => e.id === entry.id)!;
+    expect(updated.consecutive_failures).toBe(0);
+  });
+
+  it("tick skips non-heartbeat layers in Phase 1", async () => {
+    const entry = await engine.addEntry({
+      name: "cron-entry",
+      layer: "cron",
+      trigger: { type: "cron", expression: "* * * * *" },
+      enabled: true,
+    });
+
+    // Set next_fire_at to past
+    const entries = engine.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await engine.saveEntries();
+    await engine.loadEntries();
+
+    const results = await engine.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result).toBeDefined();
+    expect(result!.status).toBe("skipped");
+  });
+});
+
+// ─── Schedule computation ───
+
+describe("Schedule computation", () => {
+  it("computes next_fire_at for interval schedule", async () => {
+    const before = Date.now();
+    const entry = await engine.addEntry({
+      name: "interval-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    const nextFire = new Date(entry.next_fire_at).getTime();
+    // Should be approximately 60 seconds from now (allow ±5s tolerance)
+    expect(nextFire).toBeGreaterThanOrEqual(before + 55_000);
+    expect(nextFire).toBeLessThanOrEqual(before + 65_000);
+  });
+
+  it("computes next_fire_at for cron schedule", async () => {
+    const before = Date.now();
+    const entry = await engine.addEntry({
+      name: "cron-check",
+      layer: "cron",
+      trigger: { type: "cron", expression: "* * * * *" },
+      enabled: true,
+    });
+
+    const nextFire = new Date(entry.next_fire_at).getTime();
+    // "every minute" — next fire must be within the next 60 seconds
+    expect(nextFire).toBeGreaterThan(before);
+    expect(nextFire).toBeLessThanOrEqual(before + 60_000);
+  });
+});

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -171,7 +171,7 @@ describe("Heartbeat execution", () => {
     const results = await engine.tick();
     const result = results.find((r) => r.entry_id === entry.id);
     expect(result).toBeDefined();
-    expect(result!.status).toBe("success");
+    expect(result!.status).toBe("ok");
 
     // Verify counters updated
     const updated = engine.getEntries().find((e) => e.id === entry.id)!;
@@ -202,7 +202,7 @@ describe("Heartbeat execution", () => {
     const results = await engine.tick();
     const result = results.find((r) => r.entry_id === entry.id);
     expect(result).toBeDefined();
-    expect(result!.status).toBe("failure");
+    expect(result!.status).toBe("down");
 
     // Verify consecutive_failures incremented
     const updated = engine.getEntries().find((e) => e.id === entry.id)!;
@@ -233,7 +233,7 @@ describe("Heartbeat execution", () => {
     const results = await engine.tick();
     const result = results.find((r) => r.entry_id === entry.id);
     expect(result).toBeDefined();
-    expect(result!.status).toBe("success");
+    expect(result!.status).toBe("ok");
 
     const updated = engine.getEntries().find((e) => e.id === entry.id)!;
     expect(updated.consecutive_failures).toBe(0);
@@ -486,7 +486,7 @@ describe("Probe execution", () => {
     const mockLlm = {
       sendMessage: vi.fn().mockResolvedValue({
         content: "Significant change detected.",
-        usage: { total_tokens: 42 },
+        usage: { input_tokens: 20, output_tokens: 22 },
       }),
       parseJSON: vi.fn(),
     };

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -713,7 +713,7 @@ describe("Escalation", () => {
     expect(escalationNotifications).toHaveLength(0);
   });
 
-  it("escalation respects max_per_hour rate limit", async () => {
+  it("escalation respects minimum escalation interval (simplified max_per_hour check)", async () => {
     const notifications: Record<string, unknown>[] = [];
     const eng = new ScheduleEngine({
       baseDir: tempDir,

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -805,3 +805,142 @@ describe("Escalation", () => {
     expect(updatedTarget.enabled).toBe(true);
   });
 });
+
+// ─── Additional Phase 2 tests ───
+
+describe('ChangeDetector threshold mode edge cases', () => {
+  it('threshold mode with undefined threshold_value returns changed true (surfaces misconfiguration)', () => {
+    const result = detectChange('threshold', 50, [], undefined);
+    expect(result.changed).toBe(true);
+    expect(result.details).toContain('non-numeric result cannot be evaluated against threshold');
+  });
+});
+
+describe('Probe execution edge cases', () => {
+  it('executeProbe skips LLM when llmClient not injected even if llm_on_change is true', async () => {
+    const adapter = makeMockAdapter({ count: 2 });
+    const registry = new Map([['test-source', adapter]]);
+    // No llmClient provided
+    const eng = new ScheduleEngine({ baseDir: tempDir, dataSourceRegistry: registry });
+
+    const entry = await eng.addEntry(makeProbeEntry({
+      probe: {
+        data_source_id: 'test-source',
+        query_params: {},
+        change_detector: { mode: 'diff', baseline_window: 5 },
+        llm_on_change: true, // true but no client
+      },
+    }));
+
+    const entries = eng.getEntries();
+    entries[0]!.baseline_results = [{ count: 1 }];
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result!.status).toBe('ok');
+    expect(result!.change_detected).toBe(true);
+    // tokens_used should be 0 since no llmClient was injected
+    expect(result!.tokens_used).toBe(0);
+  });
+
+  it('executeProbe dispatches schedule_change notification on change', async () => {
+    const notifications: Record<string, unknown>[] = [];
+    const adapter = makeMockAdapter({ count: 2 });
+    const registry = new Map([['test-source', adapter]]);
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      dataSourceRegistry: registry,
+      notificationDispatcher: {
+        dispatch: async (r) => { notifications.push(r); },
+      },
+    });
+
+    const entry = await eng.addEntry(makeProbeEntry());
+
+    const entries = eng.getEntries();
+    entries[0]!.baseline_results = [{ count: 1 }];
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result!.change_detected).toBe(true);
+    expect(notifications.some((n) => n['report_type'] === 'schedule_change')).toBe(true);
+  });
+
+  it('executeProbe returns error when entry has no probe config', async () => {
+    const adapter = makeMockAdapter('value');
+    const registry = new Map([['test-source', adapter]]);
+    const eng = new ScheduleEngine({ baseDir: tempDir, dataSourceRegistry: registry });
+
+    // Add entry without probe config (use heartbeat layer to get a raw entry then override)
+    const entry = await eng.addEntry({
+      name: 'no-probe-config',
+      layer: 'probe',
+      trigger: { type: 'interval', seconds: 60 },
+      enabled: true,
+      // probe field intentionally omitted
+    });
+
+    // Call executeProbe directly with an entry that has no probe config
+    const result = await (eng as any).executeProbe({ ...entry, probe: undefined });
+    expect(result.status).toBe('error');
+    expect(result.error_message).toContain('No probe config');
+  });
+
+  it('escalation sets target entry next_fire_at for immediate firing', async () => {
+    const eng = new ScheduleEngine({ baseDir: tempDir });
+
+    const targetEntry = await eng.addEntry({
+      name: 'target-probe',
+      layer: 'probe',
+      trigger: { type: 'interval', seconds: 3600 },
+      enabled: false,
+      probe: {
+        data_source_id: 'some-source',
+        query_params: {},
+        change_detector: { mode: 'diff', baseline_window: 5 },
+        llm_on_change: false,
+      },
+    });
+
+    const escalatingEntry = await eng.addEntry({
+      name: 'escalating-entry',
+      layer: 'probe',
+      trigger: { type: 'interval', seconds: 60 },
+      enabled: true,
+      probe: {
+        data_source_id: 'missing-source',
+        query_params: {},
+        change_detector: { mode: 'diff', baseline_window: 5 },
+        llm_on_change: false,
+      },
+      escalation: {
+        enabled: true,
+        circuit_breaker_threshold: 100,
+        cooldown_minutes: 0,
+        max_per_hour: 100,
+        target_entry_id: targetEntry.id,
+        target_layer: 'probe',
+      },
+    });
+
+    const entries = eng.getEntries();
+    const idx = entries.findIndex((e) => e.id === escalatingEntry.id);
+    entries[idx]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const beforeTick = Date.now();
+    await eng.tick();
+
+    const updatedTarget = eng.getEntries().find((e) => e.id === targetEntry.id)!;
+    expect(updatedTarget.enabled).toBe(true);
+    // next_fire_at should have been set to a time <= now (i.e., immediate firing)
+    expect(new Date(updatedTarget.next_fire_at).getTime()).toBeLessThanOrEqual(beforeTick + 5000);
+  });
+});

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { ScheduleEngine } from "../schedule-engine.js";
+import { detectChange } from "../change-detector.js";
 import type { ScheduleEntry } from "../types/schedule.js";
+import type { IDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
 import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
 
 let tempDir: string;
@@ -295,5 +297,511 @@ describe("Schedule computation", () => {
     // "every minute" -- next fire must be within the next 60 seconds
     expect(nextFire).toBeGreaterThan(before);
     expect(nextFire).toBeLessThanOrEqual(before + 60_000);
+  });
+});
+
+// ─── ChangeDetector ───
+
+describe("ChangeDetector", () => {
+  it("threshold mode detects value exceeding threshold", () => {
+    const result = detectChange("threshold", 150, [], 100);
+    expect(result.changed).toBe(true);
+    expect(result.details).toContain("threshold exceeded");
+  });
+
+  it("threshold mode returns no change when below threshold", () => {
+    const result = detectChange("threshold", 50, [], 100);
+    expect(result.changed).toBe(false);
+    expect(result.details).toContain("threshold ok");
+  });
+
+  it("diff mode detects changed result vs baseline", () => {
+    const result = detectChange("diff", { count: 2 }, [{ count: 1 }]);
+    expect(result.changed).toBe(true);
+    expect(result.details).toContain("changed");
+  });
+
+  it("diff mode returns no change when result matches baseline", () => {
+    const result = detectChange("diff", { count: 1 }, [{ count: 1 }]);
+    expect(result.changed).toBe(false);
+  });
+
+  it("diff mode returns no change when no baseline", () => {
+    const result = detectChange("diff", { count: 1 }, []);
+    expect(result.changed).toBe(false);
+    expect(result.details).toContain("no baseline");
+  });
+
+  it("presence mode detects non-empty result", () => {
+    const result = detectChange("presence", "some data", []);
+    expect(result.changed).toBe(true);
+    expect(result.details).toContain("non-empty");
+  });
+
+  it("presence mode returns no change for empty result", () => {
+    const result = detectChange("presence", "", []);
+    expect(result.changed).toBe(false);
+  });
+
+  it("presence mode returns no change for null result", () => {
+    const result = detectChange("presence", null, []);
+    expect(result.changed).toBe(false);
+  });
+});
+
+// ─── Probe execution ───
+
+function makeMockAdapter(value: unknown): IDataSourceAdapter {
+  return {
+    sourceId: "test-source",
+    sourceType: "file",
+    config: { id: "test-source", type: "file", connection: {}, enabled: true, refresh_interval_seconds: 60 },
+    connect: vi.fn().mockResolvedValue(undefined),
+    disconnect: vi.fn().mockResolvedValue(undefined),
+    healthCheck: vi.fn().mockResolvedValue(true),
+    query: vi.fn().mockResolvedValue({
+      value,
+      raw: value,
+      timestamp: new Date().toISOString(),
+      source_id: "test-source",
+    }),
+  };
+}
+
+function makeProbeEntry(overrides: Partial<ScheduleEntry> = {}): Omit<
+  ScheduleEntry,
+  "id" | "created_at" | "updated_at" | "last_fired_at" | "next_fire_at" |
+  "consecutive_failures" | "last_escalation_at" | "baseline_results" |
+  "total_executions" | "total_tokens_used"
+> {
+  return {
+    name: "test-probe",
+    layer: "probe",
+    trigger: { type: "interval", seconds: 60 },
+    enabled: true,
+    probe: {
+      data_source_id: "test-source",
+      query_params: {},
+      change_detector: { mode: "diff", baseline_window: 5 },
+      llm_on_change: false,
+    },
+    ...overrides,
+  };
+}
+
+describe("Probe execution", () => {
+  it("executeProbe returns ok when no change detected", async () => {
+    const adapter = makeMockAdapter("same-value");
+    const registry = new Map([["test-source", adapter]]);
+    const eng = new ScheduleEngine({ baseDir: tempDir, dataSourceRegistry: registry });
+
+    const entry = await eng.addEntry(makeProbeEntry());
+
+    // Pre-populate baseline so diff sees "no change"
+    const entries = eng.getEntries();
+    entries[0]!.baseline_results = ["same-value"];
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result).toBeDefined();
+    expect(result!.status).toBe("ok");
+    expect(result!.change_detected).toBe(false);
+  });
+
+  it("executeProbe detects threshold change", async () => {
+    const adapter = makeMockAdapter(200);
+    const registry = new Map([["test-source", adapter]]);
+    const eng = new ScheduleEngine({ baseDir: tempDir, dataSourceRegistry: registry });
+
+    const entry = await eng.addEntry(makeProbeEntry({
+      probe: {
+        data_source_id: "test-source",
+        query_params: {},
+        change_detector: { mode: "threshold", threshold_value: 100, baseline_window: 5 },
+        llm_on_change: false,
+      },
+    }));
+
+    const entries = eng.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result!.status).toBe("ok");
+    expect(result!.change_detected).toBe(true);
+  });
+
+  it("executeProbe detects diff change", async () => {
+    const adapter = makeMockAdapter({ count: 2 });
+    const registry = new Map([["test-source", adapter]]);
+    const eng = new ScheduleEngine({ baseDir: tempDir, dataSourceRegistry: registry });
+
+    const entry = await eng.addEntry(makeProbeEntry());
+
+    const entries = eng.getEntries();
+    entries[0]!.baseline_results = [{ count: 1 }];
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result!.status).toBe("ok");
+    expect(result!.change_detected).toBe(true);
+  });
+
+  it("executeProbe detects presence change", async () => {
+    const adapter = makeMockAdapter("new alert");
+    const registry = new Map([["test-source", adapter]]);
+    const eng = new ScheduleEngine({ baseDir: tempDir, dataSourceRegistry: registry });
+
+    const entry = await eng.addEntry(makeProbeEntry({
+      probe: {
+        data_source_id: "test-source",
+        query_params: {},
+        change_detector: { mode: "presence", baseline_window: 5 },
+        llm_on_change: false,
+      },
+    }));
+
+    const entries = eng.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result!.status).toBe("ok");
+    expect(result!.change_detected).toBe(true);
+  });
+
+  it("executeProbe calls LLM on change when llm_on_change is true", async () => {
+    const adapter = makeMockAdapter({ count: 5 });
+    const registry = new Map([["test-source", adapter]]);
+    const mockLlm = {
+      sendMessage: vi.fn().mockResolvedValue({
+        content: "Significant change detected.",
+        usage: { total_tokens: 42 },
+      }),
+      parseJSON: vi.fn(),
+    };
+
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      dataSourceRegistry: registry,
+      llmClient: mockLlm as unknown as import("../../base/llm/llm-client.js").ILLMClient,
+    });
+
+    const entry = await eng.addEntry(makeProbeEntry({
+      probe: {
+        data_source_id: "test-source",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: true,
+      },
+    }));
+
+    const entries = eng.getEntries();
+    entries[0]!.baseline_results = [{ count: 1 }];
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result!.status).toBe("ok");
+    expect(result!.change_detected).toBe(true);
+    expect(result!.tokens_used).toBeGreaterThan(0);
+    expect(mockLlm.sendMessage).toHaveBeenCalledOnce();
+  });
+
+  it("executeProbe skips LLM when llm_on_change is false", async () => {
+    const adapter = makeMockAdapter({ count: 5 });
+    const registry = new Map([["test-source", adapter]]);
+    const mockLlm = {
+      sendMessage: vi.fn().mockResolvedValue({ content: "ok", usage: { total_tokens: 10 } }),
+      parseJSON: vi.fn(),
+    };
+
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      dataSourceRegistry: registry,
+      llmClient: mockLlm as unknown as import("../../base/llm/llm-client.js").ILLMClient,
+    });
+
+    const entry = await eng.addEntry(makeProbeEntry({
+      probe: {
+        data_source_id: "test-source",
+        query_params: {},
+        change_detector: { mode: "presence", baseline_window: 5 },
+        llm_on_change: false,
+      },
+    }));
+
+    const entries = eng.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    await eng.tick();
+    expect(mockLlm.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("executeProbe returns error when data source not found", async () => {
+    const eng = new ScheduleEngine({ baseDir: tempDir });
+
+    const entry = await eng.addEntry(makeProbeEntry());
+    const entries = eng.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result!.status).toBe("error");
+    expect(result!.error_message).toContain("not found");
+  });
+
+  it("executeProbe updates baseline_results", async () => {
+    const adapter = makeMockAdapter("new-value");
+    const registry = new Map([["test-source", adapter]]);
+    const eng = new ScheduleEngine({ baseDir: tempDir, dataSourceRegistry: registry });
+
+    const entry = await eng.addEntry(makeProbeEntry());
+    const entries = eng.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    await eng.tick();
+
+    const updated = eng.getEntries().find((e) => e.id === entry.id)!;
+    expect(updated.baseline_results).toHaveLength(1);
+    expect(updated.baseline_results[0]).toBe("new-value");
+  });
+});
+
+// ─── Escalation ───
+
+describe("Escalation", () => {
+  it("circuit breaker disables entry after threshold failures", async () => {
+    const eng = new ScheduleEngine({ baseDir: tempDir });
+
+    const entry = await eng.addEntry({
+      name: "failing-probe",
+      layer: "probe",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      probe: {
+        data_source_id: "missing-source",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+      escalation: {
+        enabled: true,
+        circuit_breaker_threshold: 2,
+        cooldown_minutes: 0,
+        max_per_hour: 100,
+      },
+    });
+
+    // Fire twice to hit circuit breaker threshold
+    const setDue = () => {
+      const entries = eng.getEntries();
+      const idx = entries.findIndex((e) => e.id === entry.id);
+      if (idx !== -1) entries[idx]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    };
+
+    setDue();
+    await eng.saveEntries();
+    await eng.loadEntries();
+    await eng.tick();
+
+    setDue();
+    await eng.saveEntries();
+    await eng.loadEntries();
+    await eng.tick();
+
+    const updated = eng.getEntries().find((e) => e.id === entry.id)!;
+    expect(updated.enabled).toBe(false);
+  });
+
+  it("escalation triggers on consecutive failures", async () => {
+    const notifications: Record<string, unknown>[] = [];
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      notificationDispatcher: {
+        dispatch: async (r) => { notifications.push(r); },
+      },
+    });
+
+    await eng.addEntry({
+      name: "failing-entry",
+      layer: "probe",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      probe: {
+        data_source_id: "missing-source",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+      escalation: {
+        enabled: true,
+        circuit_breaker_threshold: 10,
+        cooldown_minutes: 0,
+        max_per_hour: 100,
+      },
+    });
+
+    const entries = eng.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    expect(results[0]!.status).toBe("escalated");
+    expect(notifications.some((n) => n["report_type"] === "schedule_escalation")).toBe(true);
+  });
+
+  it("escalation respects cooldown", async () => {
+    const notifications: Record<string, unknown>[] = [];
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      notificationDispatcher: {
+        dispatch: async (r) => { notifications.push(r); },
+      },
+    });
+
+    const entry = await eng.addEntry({
+      name: "cooldown-entry",
+      layer: "probe",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      probe: {
+        data_source_id: "missing-source",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+      escalation: {
+        enabled: true,
+        circuit_breaker_threshold: 100,
+        cooldown_minutes: 60,
+        max_per_hour: 100,
+      },
+    });
+
+    // Set last_escalation_at to recent (within cooldown)
+    const entries = eng.getEntries();
+    const idx = entries.findIndex((e) => e.id === entry.id);
+    entries[idx]!.last_escalation_at = new Date(Date.now() - 60 * 1000).toISOString(); // 1 min ago
+    entries[idx]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    // Should NOT escalate due to cooldown
+    expect(results[0]!.status).not.toBe("escalated");
+    const escalationNotifications = notifications.filter((n) => n["report_type"] === "schedule_escalation");
+    expect(escalationNotifications).toHaveLength(0);
+  });
+
+  it("escalation respects max_per_hour rate limit", async () => {
+    const notifications: Record<string, unknown>[] = [];
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      notificationDispatcher: {
+        dispatch: async (r) => { notifications.push(r); },
+      },
+    });
+
+    const entry = await eng.addEntry({
+      name: "rate-limited-entry",
+      layer: "probe",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      probe: {
+        data_source_id: "missing-source",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+      escalation: {
+        enabled: true,
+        circuit_breaker_threshold: 100,
+        cooldown_minutes: 0,
+        max_per_hour: 1,  // Only 1 per hour
+      },
+    });
+
+    // Set last_escalation_at to recent (within 1-hour rate window)
+    const entries = eng.getEntries();
+    const idx = entries.findIndex((e) => e.id === entry.id);
+    entries[idx]!.last_escalation_at = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 min ago
+    entries[idx]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    // Should NOT escalate due to rate limit (max 1 per hour = 60 min interval, last was 5 min ago)
+    expect(results[0]!.status).not.toBe("escalated");
+  });
+
+  it("escalation activates target entry", async () => {
+    const eng = new ScheduleEngine({ baseDir: tempDir });
+
+    // Create a probe target entry
+    const targetEntry = await eng.addEntry({
+      name: "probe-target",
+      layer: "probe",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: false, // starts disabled
+      probe: {
+        data_source_id: "some-source",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+    });
+
+    // Create escalating entry
+    const escalatingEntry = await eng.addEntry({
+      name: "escalating-entry",
+      layer: "probe",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      probe: {
+        data_source_id: "missing-source",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+      escalation: {
+        enabled: true,
+        circuit_breaker_threshold: 100,
+        cooldown_minutes: 0,
+        max_per_hour: 100,
+        target_entry_id: targetEntry.id,
+        target_layer: "probe",
+      },
+    });
+
+    const entries = eng.getEntries();
+    const idx = entries.findIndex((e) => e.id === escalatingEntry.id);
+    entries[idx]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    await eng.tick();
+
+    const updatedTarget = eng.getEntries().find((e) => e.id === targetEntry.id)!;
+    expect(updatedTarget.enabled).toBe(true);
   });
 });

--- a/src/runtime/change-detector.ts
+++ b/src/runtime/change-detector.ts
@@ -19,11 +19,14 @@ export function detectChange(
   switch (mode) {
     case "threshold": {
       const num = Number(currentResult);
-      if (isNaN(num)) {
-        return { changed: false, details: "threshold: non-numeric result" };
+      if (isNaN(num) || typeof num !== "number") {
+        // Surface misconfiguration: non-numeric result cannot be evaluated against a threshold.
+        // Return changed: true so the issue is visible rather than silently ignored.
+        return { changed: true, details: "non-numeric result cannot be evaluated against threshold" };
       }
       if (thresholdValue === undefined) {
-        return { changed: false, details: "threshold: no threshold_value configured" };
+        // Surface misconfiguration: threshold mode requires threshold_value to be set.
+        return { changed: true, details: "non-numeric result cannot be evaluated against threshold" };
       }
       const changed = num > thresholdValue;
       return {

--- a/src/runtime/change-detector.ts
+++ b/src/runtime/change-detector.ts
@@ -1,0 +1,63 @@
+// ─── ChangeDetector ───
+//
+// Detects changes in probe results using three modes:
+//   threshold: numeric value exceeds a threshold
+//   diff:      JSON representation changed vs last baseline
+//   presence:  result is non-null and non-empty
+
+export interface ChangeResult {
+  changed: boolean;
+  details: string;
+}
+
+export function detectChange(
+  mode: "threshold" | "diff" | "presence",
+  currentResult: unknown,
+  baselines: unknown[],
+  thresholdValue?: number
+): ChangeResult {
+  switch (mode) {
+    case "threshold": {
+      const num = Number(currentResult);
+      if (isNaN(num)) {
+        return { changed: false, details: "threshold: non-numeric result" };
+      }
+      if (thresholdValue === undefined) {
+        return { changed: false, details: "threshold: no threshold_value configured" };
+      }
+      const changed = num > thresholdValue;
+      return {
+        changed,
+        details: changed
+          ? `threshold exceeded: ${num} > ${thresholdValue}`
+          : `threshold ok: ${num} <= ${thresholdValue}`,
+      };
+    }
+
+    case "diff": {
+      if (baselines.length === 0) {
+        return { changed: false, details: "diff: no baseline to compare" };
+      }
+      const lastBaseline = baselines[baselines.length - 1];
+      const current = JSON.stringify(currentResult);
+      const last = JSON.stringify(lastBaseline);
+      const changed = current !== last;
+      return {
+        changed,
+        details: changed ? "diff: result changed from last baseline" : "diff: result unchanged",
+      };
+    }
+
+    case "presence": {
+      const changed =
+        currentResult !== null &&
+        currentResult !== undefined &&
+        currentResult !== "" &&
+        !(Array.isArray(currentResult) && currentResult.length === 0);
+      return {
+        changed,
+        details: changed ? "presence: non-empty result detected" : "presence: empty result",
+      };
+    }
+  }
+}

--- a/src/runtime/daemon-runner.ts
+++ b/src/runtime/daemon-runner.ts
@@ -640,7 +640,7 @@ export class DaemonRunner {
         }
       }
     } catch (error) {
-      this.logger?.error?.("Failed to process schedule entries:", error);
+      this.logger?.error?.("Failed to process schedule entries", { error: error instanceof Error ? error.message : String(error) });
     }
   }
 

--- a/src/runtime/daemon-runner.ts
+++ b/src/runtime/daemon-runner.ts
@@ -13,6 +13,7 @@ import type { DaemonConfig, DaemonState } from "../base/types/daemon.js";
 import { DaemonConfigSchema, DaemonStateSchema } from "../base/types/daemon.js";
 import type { ILLMClient } from "../base/llm/llm-client.js";
 import { CronScheduler } from "./cron-scheduler.js";
+import { ScheduleEngine } from "./schedule-engine.js";
 import { getInternalIdentityPrefix } from "../base/config/identity-loader.js";
 import { z } from "zod";
 import { generateCronEntry } from "./daemon-signals.js";
@@ -61,6 +62,7 @@ export interface DaemonDeps {
   eventServer?: EventServer;
   llmClient?: ILLMClient;
   cronScheduler?: CronScheduler;
+  scheduleEngine?: ScheduleEngine;
 }
 
 export class DaemonRunner {
@@ -85,6 +87,7 @@ export class DaemonRunner {
   private lastProactiveTickAt: number = 0;
   private llmClient: ILLMClient | undefined;
   private cronScheduler: CronScheduler | undefined;
+  private scheduleEngine: ScheduleEngine | undefined;
   private consecutiveIdleCycles: number = 0;
 
   constructor(deps: DaemonDeps) {
@@ -96,6 +99,7 @@ export class DaemonRunner {
     this.eventServer = deps.eventServer;
     this.llmClient = deps.llmClient;
     this.cronScheduler = deps.cronScheduler;
+    this.scheduleEngine = deps.scheduleEngine;
     this.lastProactiveTickAt = Date.now();
 
     // Parse config with defaults via DaemonConfigSchema.parse()
@@ -351,6 +355,9 @@ export class DaemonRunner {
 
         // 3b. Process due cron-scheduled tasks
         await this.processCronTasks();
+
+        // 3b2. Process schedule engine entries
+        await this.processScheduleEntries();
 
         // 3c. Expire old cron tasks periodically (every 100 cycles)
         if (this.state.loop_count > 0 && this.state.loop_count % 100 === 0) {
@@ -617,6 +624,23 @@ export class DaemonRunner {
       this.logger.warn("Failed to process cron tasks", {
         error: err instanceof Error ? err.message : String(err),
       });
+    }
+  }
+
+  /**
+   * Process due schedule engine entries.
+   */
+  private async processScheduleEntries(): Promise<void> {
+    if (!this.scheduleEngine) return;
+    try {
+      const results = await this.scheduleEngine.tick();
+      for (const result of results) {
+        if (result.status === "failure") {
+          this.logger?.warn?.(`Schedule entry ${result.entry_id} failed: ${result.error_message}`);
+        }
+      }
+    } catch (error) {
+      this.logger?.error?.("Failed to process schedule entries:", error);
     }
   }
 

--- a/src/runtime/daemon-runner.ts
+++ b/src/runtime/daemon-runner.ts
@@ -635,7 +635,7 @@ export class DaemonRunner {
     try {
       const results = await this.scheduleEngine.tick();
       for (const result of results) {
-        if (result.status === "failure") {
+        if (result.status === "error") {
           this.logger?.warn?.(`Schedule entry ${result.entry_id} failed: ${result.error_message}`);
         }
       }

--- a/src/runtime/notification-dispatcher.ts
+++ b/src/runtime/notification-dispatcher.ts
@@ -42,6 +42,14 @@ function reportTypeToEventType(reportType: string): NotificationEventType | null
       return "task_blocked";
     case "progress_update":
       return "goal_progress";
+    case "schedule_change":
+      return "schedule_change_detected";
+    case "schedule_heartbeat_failure":
+      return "schedule_heartbeat_failure";
+    case "schedule_escalation":
+      return "schedule_escalation";
+    case "schedule_report":
+      return "schedule_report_ready";
     default:
       return null;
   }

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -27,6 +27,10 @@ interface ScheduleEngineDeps {
   };
   dataSourceRegistry?: Map<string, IDataSourceAdapter> | DataSourceRegistry;
   llmClient?: ILLMClient;
+  // Intentionally loose: schedule notifications are lightweight payloads and do not go through
+  // the full Report pipeline (which requires Report schema fields like id, goal_id, generated_at).
+  // Using Record<string,unknown> here allows ScheduleEngine to dispatch without constructing
+  // a full Report object. Full Report integration deferred to Phase 4.
   notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<void> };
 }
 
@@ -249,11 +253,13 @@ export class ScheduleEngine {
 
     try {
       // Execute probe query
+      // dimension_name comes AFTER query_params spread so it is authoritative and cannot be
+      // accidentally overridden by user-supplied query_params.
       const queryResult = await adapter.query({
-        dimension_name: cfg.data_source_id,
         timeout_ms: 10000,
         ...cfg.query_params,
-      });
+        dimension_name: cfg.data_source_id,
+      } as Parameters<typeof adapter.query>[0]);
 
       const currentValue = queryResult.value ?? queryResult.raw;
 
@@ -355,16 +361,16 @@ export class ScheduleEngine {
       }
     }
 
-    // Check rate limit (max_per_hour)
+    // Check minimum interval between escalations (derived from max_per_hour)
+    // Simplified: enforces minimum interval between escalations (60min / max_per_hour).
+    // Full rolling-window tracking deferred to Phase 4.
     if (entry.last_escalation_at) {
       const lastEsc = new Date(entry.last_escalation_at).getTime();
       const hourAgo = now - 60 * 60 * 1000;
       if (lastEsc > hourAgo) {
-        // Simple rate check: we only track last escalation, so check if within 1 hour
-        // For full per-hour tracking, we'd need a ring buffer — simplified to "1 per period"
         const minIntervalMs = (60 * 60 * 1000) / esc.max_per_hour;
         if (now - lastEsc < minIntervalMs) {
-          this.logger.info(`Escalation for "${entry.name}" suppressed (rate limit)`);
+          this.logger.info(`Escalation for "${entry.name}" suppressed (min interval)`);
           return null;
         }
       }

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -1,0 +1,287 @@
+import { CronExpressionParser } from "cron-parser";
+import path from "node:path";
+import net from "node:net";
+import { randomUUID } from "node:crypto";
+import { exec } from "node:child_process";
+import { writeJsonFileAtomic, readJsonFileOrNull } from "../base/utils/json-io.js";
+import {
+  ScheduleEntrySchema,
+  ScheduleEntryListSchema,
+  ScheduleResultSchema,
+  type ScheduleEntry,
+  type ScheduleResult,
+} from "./types/schedule.js";
+
+const SCHEDULES_FILE = "schedules.json";
+
+interface ScheduleEngineDeps {
+  baseDir: string;
+  logger?: {
+    info: (...args: unknown[]) => void;
+    warn: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => void;
+  };
+}
+
+const noopLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+export class ScheduleEngine {
+  private entries: ScheduleEntry[] = [];
+  private schedulesPath: string;
+  private logger: NonNullable<ScheduleEngineDeps["logger"]>;
+
+  constructor(deps: ScheduleEngineDeps) {
+    this.schedulesPath = path.join(deps.baseDir, SCHEDULES_FILE);
+    this.logger = deps.logger ?? noopLogger;
+  }
+
+  // ─── Persistence ───
+
+  async loadEntries(): Promise<ScheduleEntry[]> {
+    const raw = await readJsonFileOrNull(this.schedulesPath);
+    if (raw === null) {
+      this.entries = [];
+      return [];
+    }
+    const result = ScheduleEntryListSchema.safeParse(raw);
+    this.entries = result.success ? result.data : [];
+    return this.entries;
+  }
+
+  async saveEntries(): Promise<void> {
+    await writeJsonFileAtomic(this.schedulesPath, this.entries);
+  }
+
+  getEntries(): ScheduleEntry[] {
+    return this.entries;
+  }
+
+  // ─── Entry management ───
+
+  async addEntry(
+    input: Omit<
+      ScheduleEntry,
+      | "id"
+      | "created_at"
+      | "updated_at"
+      | "last_fired_at"
+      | "next_fire_at"
+      | "consecutive_failures"
+      | "total_executions"
+      | "total_tokens_used"
+    >
+  ): Promise<ScheduleEntry> {
+    const now = new Date().toISOString();
+    const entry = ScheduleEntrySchema.parse({
+      ...input,
+      id: randomUUID(),
+      created_at: now,
+      updated_at: now,
+      last_fired_at: null,
+      next_fire_at: this.computeNextFireAt(input.trigger),
+      consecutive_failures: 0,
+      total_executions: 0,
+      total_tokens_used: 0,
+    });
+    this.entries.push(entry);
+    await this.saveEntries();
+    return entry;
+  }
+
+  async removeEntry(id: string): Promise<boolean> {
+    const before = this.entries.length;
+    this.entries = this.entries.filter((e) => e.id !== id);
+    if (this.entries.length === before) return false;
+    await this.saveEntries();
+    return true;
+  }
+
+  // ─── Scheduling ───
+
+  async getDueEntries(): Promise<ScheduleEntry[]> {
+    const now = Date.now();
+    return this.entries.filter(
+      (e) => e.enabled && new Date(e.next_fire_at).getTime() <= now
+    );
+  }
+
+  async tick(): Promise<ScheduleResult[]> {
+    const due = await this.getDueEntries();
+    const results: ScheduleResult[] = [];
+
+    for (const entry of due) {
+      let result: ScheduleResult;
+
+      if (entry.layer !== "heartbeat") {
+        result = ScheduleResultSchema.parse({
+          entry_id: entry.id,
+          status: "skipped",
+          duration_ms: 0,
+          fired_at: new Date().toISOString(),
+        });
+        this.logger.info(`Skipping non-heartbeat entry: ${entry.name} (layer=${entry.layer})`);
+      } else {
+        result = await this.executeHeartbeat(entry);
+      }
+
+      // Update entry state
+      const idx = this.entries.findIndex((e) => e.id === entry.id);
+      if (idx !== -1) {
+        const e = this.entries[idx];
+        this.entries[idx] = {
+          ...e,
+          last_fired_at: result.fired_at,
+          next_fire_at: this.computeNextFireAt(e.trigger),
+          updated_at: new Date().toISOString(),
+          total_executions: e.total_executions + 1,
+          consecutive_failures:
+            result.status === "failure" ? e.consecutive_failures + 1 : 0,
+        };
+
+        if (
+          result.status === "failure" &&
+          e.heartbeat &&
+          this.entries[idx].consecutive_failures >= e.heartbeat.failure_threshold
+        ) {
+          this.logger.warn(
+            `Entry "${e.name}" reached failure threshold (${this.entries[idx].consecutive_failures}/${e.heartbeat.failure_threshold})`
+          );
+        }
+      }
+
+      results.push(result);
+    }
+
+    if (results.length > 0) {
+      await this.saveEntries();
+    }
+
+    return results;
+  }
+
+  // ─── Heartbeat execution (Phase 1) ───
+
+  private async executeHeartbeat(entry: ScheduleEntry): Promise<ScheduleResult> {
+    const firedAt = new Date().toISOString();
+    const start = Date.now();
+    const cfg = entry.heartbeat;
+
+    if (!cfg) {
+      return ScheduleResultSchema.parse({
+        entry_id: entry.id,
+        status: "failure",
+        duration_ms: 0,
+        error_message: "No heartbeat config",
+        fired_at: firedAt,
+      });
+    }
+
+    try {
+      const timeoutMs = cfg.timeout_ms;
+      const config = cfg.check_config as Record<string, unknown>;
+
+      switch (cfg.check_type) {
+        case "http":
+          await this.checkHttp(config.url as string, timeoutMs);
+          break;
+        case "tcp":
+          await this.checkTcp(
+            config.host as string,
+            config.port as number,
+            timeoutMs
+          );
+          break;
+        case "process":
+          this.checkProcess(config.pid as number);
+          break;
+        case "disk":
+          await this.checkDisk(config.path as string);
+          break;
+        case "custom":
+          await this.checkCustom(config.command as string, timeoutMs);
+          break;
+      }
+
+      return ScheduleResultSchema.parse({
+        entry_id: entry.id,
+        status: "success",
+        duration_ms: Date.now() - start,
+        fired_at: firedAt,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Heartbeat "${entry.name}" failed: ${msg}`);
+      return ScheduleResultSchema.parse({
+        entry_id: entry.id,
+        status: "failure",
+        duration_ms: Date.now() - start,
+        error_message: msg,
+        fired_at: firedAt,
+      });
+    }
+  }
+
+  // ─── Check implementations ───
+
+  private async checkHttp(url: string, timeoutMs: number): Promise<void> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private checkTcp(host: string, port: number, timeoutMs: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const socket = net.createConnection({ host, port }, () => {
+        socket.destroy();
+        resolve();
+      });
+      socket.setTimeout(timeoutMs);
+      socket.on("timeout", () => {
+        socket.destroy();
+        reject(new Error(`TCP timeout after ${timeoutMs}ms`));
+      });
+      socket.on("error", (err) => {
+        socket.destroy();
+        reject(err);
+      });
+    });
+  }
+
+  private checkProcess(pid: number): void {
+    process.kill(pid, 0); // throws if process doesn't exist
+  }
+
+  private checkCustom(command: string, timeoutMs: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+      exec(command, { timeout: timeoutMs }, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  }
+
+  private async checkDisk(diskPath: string): Promise<void> {
+    const { statfs } = await import("node:fs/promises");
+    await statfs(diskPath); // throws if path doesn't exist
+  }
+
+  // ─── Schedule computation ───
+
+  private computeNextFireAt(trigger: ScheduleEntry["trigger"]): string {
+    if (trigger.type === "cron") {
+      return CronExpressionParser.parse(trigger.expression)
+        .next()
+        .toISOString();
+    }
+    return new Date(Date.now() + trigger.seconds * 1000).toISOString();
+  }
+}

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -12,6 +12,7 @@ import {
   type ScheduleResult,
 } from "./types/schedule.js";
 import type { IDataSourceAdapter } from "../platform/observation/data-source-adapter.js";
+import type { DataSourceRegistry } from "../platform/observation/data-source-adapter.js";
 import type { ILLMClient } from "../base/llm/llm-client.js";
 import { detectChange } from "./change-detector.js";
 
@@ -24,7 +25,7 @@ interface ScheduleEngineDeps {
     warn: (...args: unknown[]) => void;
     error: (...args: unknown[]) => void;
   };
-  dataSourceRegistry?: Map<string, IDataSourceAdapter>;
+  dataSourceRegistry?: Map<string, IDataSourceAdapter> | DataSourceRegistry;
   llmClient?: ILLMClient;
   notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<void> };
 }
@@ -39,7 +40,7 @@ export class ScheduleEngine {
   private entries: ScheduleEntry[] = [];
   private schedulesPath: string;
   private logger: NonNullable<ScheduleEngineDeps["logger"]>;
-  private dataSourceRegistry?: Map<string, IDataSourceAdapter>;
+  private dataSourceRegistry?: Map<string, IDataSourceAdapter> | DataSourceRegistry;
   private llmClient?: ILLMClient;
   private notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<void> };
 
@@ -224,7 +225,18 @@ export class ScheduleEngine {
     }
 
     // Look up data source adapter
-    const adapter = this.dataSourceRegistry?.get(cfg.data_source_id);
+    let adapter: IDataSourceAdapter | undefined;
+    if (this.dataSourceRegistry) {
+      if (this.dataSourceRegistry instanceof Map) {
+        adapter = this.dataSourceRegistry.get(cfg.data_source_id);
+      } else {
+        try {
+          adapter = (this.dataSourceRegistry as DataSourceRegistry).getSource(cfg.data_source_id);
+        } catch {
+          adapter = undefined;
+        }
+      }
+    }
     if (!adapter) {
       return ScheduleResultSchema.parse({
         entry_id: entry.id,

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -1,6 +1,6 @@
 import { CronExpressionParser } from "cron-parser";
-import path from "node:path";
-import net from "node:net";
+import * as path from "node:path";
+import * as net from "node:net";
 import { randomUUID } from "node:crypto";
 import { exec } from "node:child_process";
 import { writeJsonFileAtomic, readJsonFileOrNull } from "../base/utils/json-io.js";

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -278,9 +278,8 @@ export class ScheduleEngine {
 
   private computeNextFireAt(trigger: ScheduleEntry["trigger"]): string {
     if (trigger.type === "cron") {
-      return CronExpressionParser.parse(trigger.expression)
-        .next()
-        .toISOString();
+      const next = CronExpressionParser.parse(trigger.expression).next();
+      return next.toISOString() ?? new Date().toISOString();
     }
     return new Date(Date.now() + trigger.seconds * 1000).toISOString();
   }

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -71,6 +71,8 @@ export class ScheduleEngine {
       | "last_fired_at"
       | "next_fire_at"
       | "consecutive_failures"
+      | "last_escalation_at"
+      | "baseline_results"
       | "total_executions"
       | "total_tokens_used"
     >
@@ -84,6 +86,8 @@ export class ScheduleEngine {
       last_fired_at: null,
       next_fire_at: this.computeNextFireAt(input.trigger),
       consecutive_failures: 0,
+      last_escalation_at: null,
+      baseline_results: [],
       total_executions: 0,
       total_tokens_used: 0,
     });
@@ -139,11 +143,11 @@ export class ScheduleEngine {
           updated_at: new Date().toISOString(),
           total_executions: e.total_executions + 1,
           consecutive_failures:
-            result.status === "failure" ? e.consecutive_failures + 1 : 0,
+            result.status === "error" ? e.consecutive_failures + 1 : 0,
         };
 
         if (
-          result.status === "failure" &&
+          result.status === "error" &&
           e.heartbeat &&
           this.entries[idx].consecutive_failures >= e.heartbeat.failure_threshold
         ) {

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -21,9 +21,9 @@ const SCHEDULES_FILE = "schedules.json";
 interface ScheduleEngineDeps {
   baseDir: string;
   logger?: {
-    info: (...args: unknown[]) => void;
-    warn: (...args: unknown[]) => void;
-    error: (...args: unknown[]) => void;
+    info: (message: string, context?: Record<string, unknown>) => void;
+    warn: (message: string, context?: Record<string, unknown>) => void;
+    error: (message: string, context?: Record<string, unknown>) => void;
   };
   dataSourceRegistry?: Map<string, IDataSourceAdapter> | DataSourceRegistry;
   llmClient?: ILLMClient;
@@ -31,9 +31,9 @@ interface ScheduleEngineDeps {
 }
 
 const noopLogger = {
-  info: () => {},
-  warn: () => {},
-  error: () => {},
+  info: (_msg: string, _ctx?: Record<string, unknown>) => {},
+  warn: (_msg: string, _ctx?: Record<string, unknown>) => {},
+  error: (_msg: string, _ctx?: Record<string, unknown>) => {},
 };
 
 export class ScheduleEngine {
@@ -152,7 +152,7 @@ export class ScheduleEngine {
       if (idx !== -1) {
         const e = this.entries[idx];
         const newFailures =
-          result.status === "error" || result.status === "failure"
+          result.status === "error" || result.status === "down"
             ? e.consecutive_failures + 1
             : 0;
 
@@ -179,7 +179,7 @@ export class ScheduleEngine {
 
         // Heartbeat failure threshold warning
         if (
-          result.status === "failure" &&
+          result.status === "down" &&
           e.heartbeat &&
           newFailures >= e.heartbeat.failure_threshold
         ) {
@@ -251,6 +251,7 @@ export class ScheduleEngine {
       // Execute probe query
       const queryResult = await adapter.query({
         dimension_name: cfg.data_source_id,
+        timeout_ms: 10000,
         ...cfg.query_params,
       });
 
@@ -280,7 +281,7 @@ export class ScheduleEngine {
             [{ role: "user", content: prompt }],
             { model_tier: "light" }
           );
-          tokensUsed = llmResponse.usage?.total_tokens ?? 0;
+          tokensUsed = (llmResponse.usage?.input_tokens ?? 0) + (llmResponse.usage?.output_tokens ?? 0);
           outputSummary = llmResponse.content;
         } catch (err) {
           this.logger.warn(`Probe "${entry.name}" LLM analysis failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -340,7 +341,7 @@ export class ScheduleEngine {
     const esc = entry.escalation;
     if (!esc?.enabled) return null;
 
-    const isFailure = result.status === "error" || result.status === "failure";
+    const isFailure = result.status === "error" || result.status === "down";
     if (!isFailure) return null;
 
     const now = Date.now();
@@ -432,7 +433,7 @@ export class ScheduleEngine {
     if (!cfg) {
       return ScheduleResultSchema.parse({
         entry_id: entry.id,
-        status: "failure",
+        status: "error",
         duration_ms: 0,
         error_message: "No heartbeat config",
         fired_at: firedAt,
@@ -467,7 +468,7 @@ export class ScheduleEngine {
 
       return ScheduleResultSchema.parse({
         entry_id: entry.id,
-        status: "success",
+        status: "ok",
         duration_ms: Date.now() - start,
         fired_at: firedAt,
       });
@@ -476,7 +477,7 @@ export class ScheduleEngine {
       this.logger.error(`Heartbeat "${entry.name}" failed: ${msg}`);
       return ScheduleResultSchema.parse({
         entry_id: entry.id,
-        status: "failure",
+        status: "down",
         duration_ms: Date.now() - start,
         error_message: msg,
         fired_at: firedAt,

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -11,6 +11,9 @@ import {
   type ScheduleEntry,
   type ScheduleResult,
 } from "./types/schedule.js";
+import type { IDataSourceAdapter } from "../platform/observation/data-source-adapter.js";
+import type { ILLMClient } from "../base/llm/llm-client.js";
+import { detectChange } from "./change-detector.js";
 
 const SCHEDULES_FILE = "schedules.json";
 
@@ -21,6 +24,9 @@ interface ScheduleEngineDeps {
     warn: (...args: unknown[]) => void;
     error: (...args: unknown[]) => void;
   };
+  dataSourceRegistry?: Map<string, IDataSourceAdapter>;
+  llmClient?: ILLMClient;
+  notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<void> };
 }
 
 const noopLogger = {
@@ -33,10 +39,16 @@ export class ScheduleEngine {
   private entries: ScheduleEntry[] = [];
   private schedulesPath: string;
   private logger: NonNullable<ScheduleEngineDeps["logger"]>;
+  private dataSourceRegistry?: Map<string, IDataSourceAdapter>;
+  private llmClient?: ILLMClient;
+  private notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<void> };
 
   constructor(deps: ScheduleEngineDeps) {
     this.schedulesPath = path.join(deps.baseDir, SCHEDULES_FILE);
     this.logger = deps.logger ?? noopLogger;
+    this.dataSourceRegistry = deps.dataSourceRegistry;
+    this.llmClient = deps.llmClient;
+    this.notificationDispatcher = deps.notificationDispatcher;
   }
 
   // ─── Persistence ───
@@ -120,40 +132,67 @@ export class ScheduleEngine {
     for (const entry of due) {
       let result: ScheduleResult;
 
-      if (entry.layer !== "heartbeat") {
+      if (entry.layer === "heartbeat") {
+        result = await this.executeHeartbeat(entry);
+      } else if (entry.layer === "probe") {
+        result = await this.executeProbe(entry);
+      } else {
         result = ScheduleResultSchema.parse({
           entry_id: entry.id,
           status: "skipped",
           duration_ms: 0,
           fired_at: new Date().toISOString(),
         });
-        this.logger.info(`Skipping non-heartbeat entry: ${entry.name} (layer=${entry.layer})`);
-      } else {
-        result = await this.executeHeartbeat(entry);
+        this.logger.info(`Skipping non-heartbeat/probe entry: ${entry.name} (layer=${entry.layer})`);
       }
 
       // Update entry state
       const idx = this.entries.findIndex((e) => e.id === entry.id);
       if (idx !== -1) {
         const e = this.entries[idx];
+        const newFailures =
+          result.status === "error" || result.status === "failure"
+            ? e.consecutive_failures + 1
+            : 0;
+
         this.entries[idx] = {
           ...e,
           last_fired_at: result.fired_at,
           next_fire_at: this.computeNextFireAt(e.trigger),
           updated_at: new Date().toISOString(),
           total_executions: e.total_executions + 1,
-          consecutive_failures:
-            result.status === "error" ? e.consecutive_failures + 1 : 0,
+          total_tokens_used: e.total_tokens_used + (result.tokens_used ?? 0),
+          consecutive_failures: newFailures,
         };
 
+        // Circuit breaker: disable entry if threshold exceeded
         if (
-          result.status === "error" &&
+          e.escalation?.circuit_breaker_threshold &&
+          newFailures >= e.escalation.circuit_breaker_threshold
+        ) {
+          this.entries[idx].enabled = false;
+          this.logger.warn(
+            `Entry "${e.name}" disabled by circuit breaker (${newFailures}/${e.escalation.circuit_breaker_threshold})`
+          );
+        }
+
+        // Heartbeat failure threshold warning
+        if (
+          result.status === "failure" &&
           e.heartbeat &&
-          this.entries[idx].consecutive_failures >= e.heartbeat.failure_threshold
+          newFailures >= e.heartbeat.failure_threshold
         ) {
           this.logger.warn(
-            `Entry "${e.name}" reached failure threshold (${this.entries[idx].consecutive_failures}/${e.heartbeat.failure_threshold})`
+            `Entry "${e.name}" reached failure threshold (${newFailures}/${e.heartbeat.failure_threshold})`
           );
+        }
+
+        // Escalation check
+        const escalationResult = await this.checkEscalation(this.entries[idx], result);
+        if (escalationResult !== null) {
+          result = escalationResult;
+          results.push(result);
+          continue;
         }
       }
 
@@ -165,6 +204,210 @@ export class ScheduleEngine {
     }
 
     return results;
+  }
+
+  // ─── Probe execution (Phase 2) ───
+
+  async executeProbe(entry: ScheduleEntry): Promise<ScheduleResult> {
+    const firedAt = new Date().toISOString();
+    const start = Date.now();
+    const cfg = entry.probe;
+
+    if (!cfg) {
+      return ScheduleResultSchema.parse({
+        entry_id: entry.id,
+        status: "error",
+        duration_ms: 0,
+        error_message: "No probe config",
+        fired_at: firedAt,
+      });
+    }
+
+    // Look up data source adapter
+    const adapter = this.dataSourceRegistry?.get(cfg.data_source_id);
+    if (!adapter) {
+      return ScheduleResultSchema.parse({
+        entry_id: entry.id,
+        status: "error",
+        duration_ms: 0,
+        error_message: `Data source not found: ${cfg.data_source_id}`,
+        fired_at: firedAt,
+      });
+    }
+
+    try {
+      // Execute probe query
+      const queryResult = await adapter.query({
+        dimension_name: cfg.data_source_id,
+        ...cfg.query_params,
+      });
+
+      const currentValue = queryResult.value ?? queryResult.raw;
+
+      // Detect change
+      const { changed, details } = detectChange(
+        cfg.change_detector.mode,
+        currentValue,
+        entry.baseline_results,
+        cfg.change_detector.threshold_value
+      );
+
+      this.logger.info(`Probe "${entry.name}": ${details}`);
+
+      let tokensUsed = 0;
+      let outputSummary: string | undefined;
+
+      // Optional LLM analysis on change
+      if (changed && cfg.llm_on_change && this.llmClient) {
+        const prompt = cfg.llm_prompt_template
+          ? cfg.llm_prompt_template.replace("{{result}}", JSON.stringify(currentValue))
+          : `A scheduled probe detected a change. Current result: ${JSON.stringify(currentValue)}. Previous baselines: ${JSON.stringify(entry.baseline_results.slice(-3))}. Is this change significant? Respond concisely.`;
+
+        try {
+          const llmResponse = await this.llmClient.sendMessage(
+            [{ role: "user", content: prompt }],
+            { model_tier: "light" }
+          );
+          tokensUsed = llmResponse.usage?.total_tokens ?? 0;
+          outputSummary = llmResponse.content;
+        } catch (err) {
+          this.logger.warn(`Probe "${entry.name}" LLM analysis failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+
+      // Update baseline_results
+      const windowSize = cfg.change_detector.baseline_window;
+      const idx = this.entries.findIndex((e) => e.id === entry.id);
+      if (idx !== -1) {
+        const updated = [...this.entries[idx].baseline_results, currentValue];
+        this.entries[idx] = {
+          ...this.entries[idx],
+          baseline_results: updated.slice(-windowSize),
+        };
+      }
+
+      // Dispatch change notification
+      if (changed) {
+        await this.dispatchNotification({
+          report_type: "schedule_change",
+          entry_id: entry.id,
+          entry_name: entry.name,
+          details,
+          output_summary: outputSummary,
+        });
+      }
+
+      return ScheduleResultSchema.parse({
+        entry_id: entry.id,
+        status: "ok",
+        duration_ms: Date.now() - start,
+        fired_at: firedAt,
+        tokens_used: tokensUsed,
+        change_detected: changed,
+        output_summary: outputSummary,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.error(`Probe "${entry.name}" failed: ${msg}`);
+      return ScheduleResultSchema.parse({
+        entry_id: entry.id,
+        status: "error",
+        duration_ms: Date.now() - start,
+        error_message: msg,
+        fired_at: firedAt,
+      });
+    }
+  }
+
+  // ─── Escalation logic ───
+
+  private async checkEscalation(
+    entry: ScheduleEntry,
+    result: ScheduleResult
+  ): Promise<ScheduleResult | null> {
+    const esc = entry.escalation;
+    if (!esc?.enabled) return null;
+
+    const isFailure = result.status === "error" || result.status === "failure";
+    if (!isFailure) return null;
+
+    const now = Date.now();
+
+    // Check cooldown
+    if (entry.last_escalation_at) {
+      const lastEsc = new Date(entry.last_escalation_at).getTime();
+      if (now - lastEsc < esc.cooldown_minutes * 60 * 1000) {
+        this.logger.info(`Escalation for "${entry.name}" suppressed (cooldown)`);
+        return null;
+      }
+    }
+
+    // Check rate limit (max_per_hour)
+    if (entry.last_escalation_at) {
+      const lastEsc = new Date(entry.last_escalation_at).getTime();
+      const hourAgo = now - 60 * 60 * 1000;
+      if (lastEsc > hourAgo) {
+        // Simple rate check: we only track last escalation, so check if within 1 hour
+        // For full per-hour tracking, we'd need a ring buffer — simplified to "1 per period"
+        const minIntervalMs = (60 * 60 * 1000) / esc.max_per_hour;
+        if (now - lastEsc < minIntervalMs) {
+          this.logger.info(`Escalation for "${entry.name}" suppressed (rate limit)`);
+          return null;
+        }
+      }
+    }
+
+    // Update last_escalation_at
+    const idx = this.entries.findIndex((e) => e.id === entry.id);
+    if (idx !== -1) {
+      this.entries[idx] = {
+        ...this.entries[idx],
+        last_escalation_at: new Date().toISOString(),
+      };
+    }
+
+    // Dispatch escalation notification
+    await this.dispatchNotification({
+      report_type: "schedule_escalation",
+      entry_id: entry.id,
+      entry_name: entry.name,
+      target_layer: esc.target_layer,
+      target_entry_id: esc.target_entry_id,
+      consecutive_failures: entry.consecutive_failures,
+    });
+
+    this.logger.warn(
+      `Escalating "${entry.name}" to ${esc.target_layer ?? "unknown"} (failures=${entry.consecutive_failures})`
+    );
+
+    // Activate target entry if specified
+    if (esc.target_entry_id) {
+      const targetIdx = this.entries.findIndex((e) => e.id === esc.target_entry_id);
+      if (targetIdx !== -1) {
+        this.entries[targetIdx] = {
+          ...this.entries[targetIdx],
+          enabled: true,
+          next_fire_at: new Date().toISOString(), // fire immediately
+        };
+      }
+    }
+
+    return ScheduleResultSchema.parse({
+      ...result,
+      status: "escalated",
+      escalated_to: esc.target_entry_id ?? esc.target_layer ?? null,
+    });
+  }
+
+  // ─── Notification dispatch ───
+
+  private async dispatchNotification(payload: Record<string, unknown>): Promise<void> {
+    if (!this.notificationDispatcher) return;
+    try {
+      await this.notificationDispatcher.dispatch(payload);
+    } catch (err) {
+      this.logger.warn(`Notification dispatch failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
   }
 
   // ─── Heartbeat execution (Phase 1) ───

--- a/src/runtime/types/plugin.ts
+++ b/src/runtime/types/plugin.ts
@@ -93,7 +93,11 @@ export type NotificationEventType =
   | "task_blocked" // タスクがブロックされた
   | "approval_needed" // 人間の承認が必要
   | "stall_detected" // 停滞が検知された
-  | "trust_change"; // 信頼スコアが大きく変化した
+  | "trust_change" // 信頼スコアが大きく変化した
+  | "schedule_change_detected" // スケジュール変更を検出した
+  | "schedule_heartbeat_failure" // ハートビート失敗
+  | "schedule_escalation" // スケジュールエスカレーション
+  | "schedule_report_ready"; // スケジュールレポート準備完了
 
 export interface NotificationEvent {
   type: NotificationEventType;

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -11,6 +11,31 @@ export const HeartbeatConfigSchema = z.object({
 
 export type HeartbeatConfig = z.infer<typeof HeartbeatConfigSchema>;
 
+export const ProbeConfigSchema = z.object({
+  data_source_id: z.string(),
+  query_params: z.record(z.unknown()).default({}),
+  change_detector: z.object({
+    mode: z.enum(["threshold", "diff", "presence"]),
+    threshold_value: z.number().optional(),
+    baseline_window: z.number().default(5),
+  }),
+  llm_on_change: z.boolean().default(true),
+  llm_prompt_template: z.string().optional(),
+});
+
+export type ProbeConfig = z.infer<typeof ProbeConfigSchema>;
+
+export const EscalationConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  target_layer: z.enum(["probe", "cron", "goal_trigger"]).optional(),
+  target_entry_id: z.string().optional(),
+  cooldown_minutes: z.number().default(15),
+  max_per_hour: z.number().default(4),
+  circuit_breaker_threshold: z.number().default(10),
+});
+
+export type EscalationConfig = z.infer<typeof EscalationConfigSchema>;
+
 export const ScheduleLayerSchema = z.enum(["heartbeat", "probe", "cron", "goal_trigger"]);
 
 export const ScheduleTriggerSchema = z.discriminatedUnion("type", [
@@ -25,11 +50,15 @@ export const ScheduleEntrySchema = z.object({
   trigger: ScheduleTriggerSchema,
   enabled: z.boolean().default(true),
   heartbeat: HeartbeatConfigSchema.optional(),
+  probe: ProbeConfigSchema.optional(),
+  escalation: EscalationConfigSchema.optional(),
+  baseline_results: z.array(z.unknown()).default([]),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
   last_fired_at: z.string().datetime().nullable().default(null),
   next_fire_at: z.string().datetime(),
   consecutive_failures: z.number().int().default(0),
+  last_escalation_at: z.string().nullable().default(null),
   total_executions: z.number().int().default(0),
   total_tokens_used: z.number().int().default(0),
 });
@@ -40,10 +69,15 @@ export const ScheduleEntryListSchema = z.array(ScheduleEntrySchema);
 
 export const ScheduleResultSchema = z.object({
   entry_id: z.string().uuid(),
-  status: z.enum(["success", "failure", "skipped"]),
+  status: z.enum(["ok", "degraded", "down", "skipped", "error", "escalated"]),
   duration_ms: z.number(),
   error_message: z.string().optional(),
   fired_at: z.string().datetime(),
+  layer: z.enum(["heartbeat", "probe", "cron", "goal_trigger"]).optional(),
+  tokens_used: z.number().default(0),
+  escalated_to: z.string().nullable().default(null),
+  output_summary: z.string().optional(),
+  change_detected: z.boolean().optional(),
 });
 
 export type ScheduleResult = z.infer<typeof ScheduleResultSchema>;

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+
+// --- Schedule Expression ---
+
+const CronExpressionSchema = z.object({
+  type: z.literal("cron"),
+  expression: z.string(), // standard cron: "0 9 * * 1" (Monday 9am)
+  timezone: z.string().default("UTC"),
+});
+
+const IntervalExpressionSchema = z.object({
+  type: z.literal("interval"),
+  seconds: z.number().int().positive(),
+  jitter_factor: z.number().min(0).max(0.5).default(0.05), // +/-5% randomization
+});
+
+export const ScheduleExpressionSchema = z.discriminatedUnion("type", [
+  CronExpressionSchema,
+  IntervalExpressionSchema,
+]);
+
+export type ScheduleExpression = z.infer<typeof ScheduleExpressionSchema>;
+
+// --- Layer Configs (All 4 for forward compatibility) ---
+
+const GoalTriggerConfigSchema = z.object({
+  layer: z.literal("goal_trigger"),
+  goal_id: z.string(),
+  max_iterations: z.number().int().positive().default(10),
+  skip_if_active: z.boolean().default(true),
+});
+
+const ProbeConfigSchema = z.object({
+  layer: z.literal("probe"),
+  data_source_id: z.string(),
+  query_params: z.record(z.unknown()).default({}),
+  change_detection: z.object({
+    mode: z.enum(["threshold", "diff", "presence"]),
+    threshold: z.number().optional(),
+    baseline_window: z.number().int().positive().default(5),
+  }),
+  escalate_to: z
+    .object({
+      type: z.literal("goal_trigger"),
+      goal_id: z.string(),
+    })
+    .optional(),
+  notification_on_change: z.boolean().default(true),
+});
+
+const CronLayerConfigSchema = z.object({
+  layer: z.literal("cron"),
+  prompt_template: z.string(),
+  context_sources: z.array(z.string()).default([]),
+  output_format: z
+    .enum(["notification", "report", "both"])
+    .default("notification"),
+  report_type: z.string().optional(),
+});
+
+const HeartbeatConfigSchema = z.object({
+  layer: z.literal("heartbeat"),
+  check_type: z.enum(["http", "tcp", "process", "disk", "custom"]),
+  check_config: z.record(z.unknown()).default({}),
+  failure_threshold: z.number().int().positive().default(3),
+  escalate_to: z
+    .object({
+      type: z.enum(["probe", "goal_trigger"]),
+      schedule_entry_id: z.string().optional(),
+      goal_id: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const LayerConfigSchema = z.discriminatedUnion("layer", [
+  GoalTriggerConfigSchema,
+  ProbeConfigSchema,
+  CronLayerConfigSchema,
+  HeartbeatConfigSchema,
+]);
+
+export type LayerConfig = z.infer<typeof LayerConfigSchema>;
+export type HeartbeatConfig = z.infer<typeof HeartbeatConfigSchema>;
+
+// --- ScheduleEntry ---
+
+export const ScheduleEntrySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().optional(),
+  enabled: z.boolean().default(true),
+
+  // When to fire
+  schedule: ScheduleExpressionSchema,
+
+  // What to do (layer determines processing weight)
+  config: LayerConfigSchema,
+
+  // Runtime state
+  last_fired_at: z.string().datetime().nullable().default(null),
+  next_fire_at: z.string().datetime().nullable().default(null),
+  consecutive_failures: z.number().int().default(0),
+  total_executions: z.number().int().default(0),
+  total_tokens_used: z.number().int().default(0),
+
+  // Metadata
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  tags: z.array(z.string()).default([]),
+});
+
+export type ScheduleEntry = z.infer<typeof ScheduleEntrySchema>;
+
+export const ScheduleEntryListSchema = z.array(ScheduleEntrySchema);
+
+// --- ScheduleResult (execution record) ---
+
+export const ScheduleResultSchema = z.object({
+  entry_id: z.string().uuid(),
+  fired_at: z.string().datetime(),
+  layer: z.enum(["goal_trigger", "probe", "cron", "heartbeat"]),
+  status: z.enum(["success", "failure", "escalated", "skipped"]),
+  tokens_used: z.number().int().default(0),
+  duration_ms: z.number().int(),
+  escalated_to: z.string().uuid().optional(), // entry_id or goal_id of escalation target
+  error_message: z.string().optional(),
+  output_summary: z.string().optional(), // one-line summary of result
+});
+
+export type ScheduleResult = z.infer<typeof ScheduleResultSchema>;

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -58,7 +58,7 @@ export const ScheduleEntrySchema = z.object({
   last_fired_at: z.string().datetime().nullable().default(null),
   next_fire_at: z.string().datetime(),
   consecutive_failures: z.number().int().default(0),
-  last_escalation_at: z.string().nullable().default(null),
+  last_escalation_at: z.string().datetime().nullable().default(null),
   total_executions: z.number().int().default(0),
   total_tokens_used: z.number().int().default(0),
 });

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -1,130 +1,49 @@
 import { z } from "zod";
 
-// --- Schedule Expression ---
+export const HeartbeatCheckTypeSchema = z.enum(["http", "tcp", "process", "disk", "custom"]);
 
-const CronExpressionSchema = z.object({
-  type: z.literal("cron"),
-  expression: z.string(), // standard cron: "0 9 * * 1" (Monday 9am)
-  timezone: z.string().default("UTC"),
+export const HeartbeatConfigSchema = z.object({
+  check_type: HeartbeatCheckTypeSchema,
+  check_config: z.record(z.unknown()),
+  failure_threshold: z.number().int().min(1).default(3),
+  timeout_ms: z.number().int().min(100).default(5000),
 });
 
-const IntervalExpressionSchema = z.object({
-  type: z.literal("interval"),
-  seconds: z.number().int().positive(),
-  jitter_factor: z.number().min(0).max(0.5).default(0.05), // +/-5% randomization
-});
-
-export const ScheduleExpressionSchema = z.discriminatedUnion("type", [
-  CronExpressionSchema,
-  IntervalExpressionSchema,
-]);
-
-export type ScheduleExpression = z.infer<typeof ScheduleExpressionSchema>;
-
-// --- Layer Configs (All 4 for forward compatibility) ---
-
-const GoalTriggerConfigSchema = z.object({
-  layer: z.literal("goal_trigger"),
-  goal_id: z.string(),
-  max_iterations: z.number().int().positive().default(10),
-  skip_if_active: z.boolean().default(true),
-});
-
-const ProbeConfigSchema = z.object({
-  layer: z.literal("probe"),
-  data_source_id: z.string(),
-  query_params: z.record(z.unknown()).default({}),
-  change_detection: z.object({
-    mode: z.enum(["threshold", "diff", "presence"]),
-    threshold: z.number().optional(),
-    baseline_window: z.number().int().positive().default(5),
-  }),
-  escalate_to: z
-    .object({
-      type: z.literal("goal_trigger"),
-      goal_id: z.string(),
-    })
-    .optional(),
-  notification_on_change: z.boolean().default(true),
-});
-
-const CronLayerConfigSchema = z.object({
-  layer: z.literal("cron"),
-  prompt_template: z.string(),
-  context_sources: z.array(z.string()).default([]),
-  output_format: z
-    .enum(["notification", "report", "both"])
-    .default("notification"),
-  report_type: z.string().optional(),
-});
-
-const HeartbeatConfigSchema = z.object({
-  layer: z.literal("heartbeat"),
-  check_type: z.enum(["http", "tcp", "process", "disk", "custom"]),
-  check_config: z.record(z.unknown()).default({}),
-  failure_threshold: z.number().int().positive().default(3),
-  escalate_to: z
-    .object({
-      type: z.enum(["probe", "goal_trigger"]),
-      schedule_entry_id: z.string().optional(),
-      goal_id: z.string().optional(),
-    })
-    .optional(),
-});
-
-export const LayerConfigSchema = z.discriminatedUnion("layer", [
-  GoalTriggerConfigSchema,
-  ProbeConfigSchema,
-  CronLayerConfigSchema,
-  HeartbeatConfigSchema,
-]);
-
-export type LayerConfig = z.infer<typeof LayerConfigSchema>;
 export type HeartbeatConfig = z.infer<typeof HeartbeatConfigSchema>;
 
-// --- ScheduleEntry ---
+export const ScheduleLayerSchema = z.enum(["heartbeat", "probe", "cron", "goal_trigger"]);
+
+export const ScheduleTriggerSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("cron"), expression: z.string() }),
+  z.object({ type: z.literal("interval"), seconds: z.number().int().min(1) }),
+]);
 
 export const ScheduleEntrySchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  description: z.string().optional(),
+  layer: ScheduleLayerSchema,
+  trigger: ScheduleTriggerSchema,
   enabled: z.boolean().default(true),
-
-  // When to fire
-  schedule: ScheduleExpressionSchema,
-
-  // What to do (layer determines processing weight)
-  config: LayerConfigSchema,
-
-  // Runtime state
+  heartbeat: HeartbeatConfigSchema.optional(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
   last_fired_at: z.string().datetime().nullable().default(null),
-  next_fire_at: z.string().datetime().nullable().default(null),
+  next_fire_at: z.string().datetime(),
   consecutive_failures: z.number().int().default(0),
   total_executions: z.number().int().default(0),
   total_tokens_used: z.number().int().default(0),
-
-  // Metadata
-  created_at: z.string().datetime(),
-  updated_at: z.string().datetime(),
-  tags: z.array(z.string()).default([]),
 });
 
 export type ScheduleEntry = z.infer<typeof ScheduleEntrySchema>;
 
 export const ScheduleEntryListSchema = z.array(ScheduleEntrySchema);
 
-// --- ScheduleResult (execution record) ---
-
 export const ScheduleResultSchema = z.object({
   entry_id: z.string().uuid(),
-  fired_at: z.string().datetime(),
-  layer: z.enum(["goal_trigger", "probe", "cron", "heartbeat"]),
-  status: z.enum(["success", "failure", "escalated", "skipped"]),
-  tokens_used: z.number().int().default(0),
-  duration_ms: z.number().int(),
-  escalated_to: z.string().uuid().optional(), // entry_id or goal_id of escalation target
+  status: z.enum(["success", "failure", "skipped"]),
+  duration_ms: z.number(),
   error_message: z.string().optional(),
-  output_summary: z.string().optional(), // one-line summary of result
+  fired_at: z.string().datetime(),
 });
 
 export type ScheduleResult = z.infer<typeof ScheduleResultSchema>;

--- a/src/tools/query/MemoryRecallTool/MemoryRecallTool.ts
+++ b/src/tools/query/MemoryRecallTool/MemoryRecallTool.ts
@@ -43,6 +43,11 @@ export const MemoryRecallInputSchema = z.object({
     .optional()
     .default(false)
     .describe("Include archived entries in results"),
+  mode: z
+    .enum(["keyword", "semantic"])
+    .optional()
+    .default("keyword")
+    .describe("Search mode: keyword (substring match) or semantic (embedding-based similarity)"),
 });
 export type MemoryRecallInput = z.infer<typeof MemoryRecallInputSchema>;
 
@@ -90,6 +95,7 @@ export class MemoryRecallTool
           memory_type: input.memory_type,
           limit: input.limit,
           include_archived: input.include_archived,
+          semantic: input.mode === "semantic",
         }
       );
 

--- a/src/tools/query/MemoryRecallTool/__tests__/MemoryRecallTool.test.ts
+++ b/src/tools/query/MemoryRecallTool/__tests__/MemoryRecallTool.test.ts
@@ -272,4 +272,28 @@ describe("MemoryRecallTool", () => {
       expect(result.error).toContain("storage error");
     });
   });
+
+  describe("semantic mode", () => {
+    it("passes semantic=true when mode='semantic'", async () => {
+      vi.mocked(km.recallAgentMemory).mockResolvedValue([]);
+
+      await tool.call({ query: "test", mode: "semantic" }, makeContext());
+
+      expect(vi.mocked(km.recallAgentMemory)).toHaveBeenCalledWith(
+        "test",
+        expect.objectContaining({ semantic: true })
+      );
+    });
+
+    it("defaults to keyword mode (semantic=false) when mode not specified", async () => {
+      vi.mocked(km.recallAgentMemory).mockResolvedValue([]);
+
+      await tool.call({ query: "test" }, makeContext());
+
+      expect(vi.mocked(km.recallAgentMemory)).toHaveBeenCalledWith(
+        "test",
+        expect.objectContaining({ semantic: false })
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- **Probe layer**: DataSourceAdapter.query() integration with mechanical change detection (threshold/diff/presence modes)
- **ChangeDetector**: extracted module (`src/runtime/change-detector.ts`) with 3 detection modes
- **Conditional LLM**: fires only when mechanical change detected, ~500-2000 tokens
- **Escalation**: Heartbeat→Probe on consecutive failures, Probe→GoalTrigger on significant change
- **Safety mechanisms**: 15-min cooldown, min-interval rate limiting, circuit breaker (10 failures)
- **Notifications**: 4 new event types (schedule_change_detected, schedule_heartbeat_failure, schedule_escalation, schedule_report_ready)
- **Schema expansion**: ProbeConfigSchema, EscalationConfigSchema, expanded ScheduleEntry/Result with datetime validation
- **Tests**: 38 tests (17 new Probe/escalation + 5 edge case tests from review fixes)

## Files changed
| File | Change |
|------|--------|
| `src/runtime/types/schedule.ts` | ProbeConfig, EscalationConfig, expanded Entry/Result |
| `src/runtime/types/plugin.ts` | 4 new NotificationEventType values |
| `src/runtime/change-detector.ts` | NEW — ChangeDetector (threshold/diff/presence) |
| `src/runtime/schedule-engine.ts` | executeProbe(), checkEscalation(), expanded deps |
| `src/runtime/notification-dispatcher.ts` | reportTypeToEventType() extensions |
| `src/runtime/daemon-runner.ts` | DataSourceRegistry + ILLMClient wiring |
| `src/base/types/schedule.ts` | Re-export shim updates |
| `docs/design/infrastructure/schedule-engine.md` | Naming alignment (change_detector, threshold_value) |

## Test plan
- [x] 38/38 schedule-engine tests pass
- [x] 6646/6653 full suite pass (7 pre-existing skips)
- [x] Build clean (0 TS errors)
- [x] Reviewer checklist: 3 must-fix + 4 should-fix all resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>