### PR TITLE
fix: allow exact slash commands to submit in TUI

### DIFF
--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getMatchingSuggestions } from "../chat.js";
+
+describe("getMatchingSuggestions", () => {
+  it("hides suggestions for an exact slash command so enter can submit", () => {
+    expect(getMatchingSuggestions("/help", [])).toEqual([]);
+    expect(getMatchingSuggestions("/config", [])).toEqual([]);
+  });
+
+  it("keeps suggestions for partial slash commands", () => {
+    const matches = getMatchingSuggestions("/he", []);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches[0]?.name).toBe("/help");
+  });
+
+  it("hides goal suggestions when a goal arg is fully typed", () => {
+    expect(getMatchingSuggestions("/run improve-tests", ["improve-tests"])).toEqual([]);
+    expect(getMatchingSuggestions("/start Improve-Tests", ["improve-tests"])).toEqual([]);
+  });
+
+  it("keeps goal suggestions for partial goal args", () => {
+    const matches = getMatchingSuggestions("/run improve", ["improve-tests"]);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      name: "/run",
+      description: "improve-tests",
+      type: "goal",
+    });
+  });
+});

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -212,16 +212,31 @@ const COMMANDS: Suggestion[] = [
 /** Commands that accept a goal name as argument */
 const GOAL_ARG_COMMANDS = ["/run ", "/start "];
 
-function getMatchingSuggestions(
+function isExactCommandMatch(input: string): boolean {
+  const normalized = input.trim().toLowerCase();
+  return COMMANDS.some((cmd) => {
+    if (cmd.name.toLowerCase() === normalized) return true;
+    return cmd.aliases.some((alias) => {
+      const normalizedAlias = alias.startsWith("/") ? alias : `/${alias}`;
+      return normalizedAlias.toLowerCase() === normalized;
+    });
+  });
+}
+
+export function getMatchingSuggestions(
   input: string,
   goalNames: string[],
 ): Suggestion[] {
   if (!input.startsWith("/")) return [];
+  if (isExactCommandMatch(input)) return [];
 
   // Check if user typed a command that expects a goal name argument
   for (const prefix of GOAL_ARG_COMMANDS) {
     if (input.startsWith(prefix)) {
       const goalQuery = input.slice(prefix.length);
+      if (goalNames.some((goal) => goal.toLowerCase() === goalQuery.toLowerCase())) {
+        return [];
+      }
       const matchedGoals = fuzzyFilter(goalQuery, goalNames, (g) => g, 6);
       return matchedGoals.map((g) => ({
         name: prefix.trimEnd(),


### PR DESCRIPTION
## Summary
- hide slash-command suggestions when the command is already an exact match
- hide /run and /start goal suggestions when the goal argument is already fully typed
- add regression tests for exact-match and partial-match suggestion behavior

## Testing
- npx vitest run src/interface/tui/__tests__/chat.test.ts src/interface/tui/__tests__/fuzzy.test.ts

Closes #556
Replaces #557