### PR TITLE
Refactor chat system prompt sections

### DIFF
--- a/src/base/config/__tests__/identity-loader.test.ts
+++ b/src/base/config/__tests__/identity-loader.test.ts
@@ -233,4 +233,12 @@ I prefer concise answers.`;
     expect(result).toContain(DEFAULT_ROOT.trim());
     expect(result.length).toBeGreaterThan(0);
   });
+
+  it("default root text prefers direct tool execution over delegate-only behavior", () => {
+    noFiles();
+    const result = getUserFacingIdentity();
+    expect(result).toContain("I use available tools directly when that moves the goal forward safely");
+    expect(result).not.toContain("I orchestrate, I don't execute tasks directly");
+    expect(result).not.toContain("I always delegate to agents and observe results");
+  });
 });

--- a/src/base/config/config-metadata.ts
+++ b/src/base/config/config-metadata.ts
@@ -5,6 +5,7 @@ export {
   CONFIG_METADATA,
   buildConfigKeyDescription,
   buildConfigToolDescription,
+  configChangeRequiresApproval,
   MutationToolMeta,
   MUTATION_TOOL_METADATA,
   buildMutationToolDescription,

--- a/src/base/config/identity-loader.ts
+++ b/src/base/config/identity-loader.ts
@@ -39,12 +39,13 @@ export const DEFAULT_ROOT = `# How I Work
 
 ## Boundaries
 - I'm not a general-purpose assistant — I help you pursue goals
-- I orchestrate, I don't execute tasks directly
-- I always delegate to agents and observe results
+- I use available tools directly when that moves the goal forward safely
+- I delegate when specialization, parallelism, or context isolation would help
 
 ## Interaction Style
 - Be concise and direct
-- Ask clarifying questions rather than assuming
+- Inspect the available context before asking avoidable questions
+- Ask clarifying questions when requirements are ambiguous or risky
 - Show progress and results, not process details
 `;
 

--- a/src/base/config/tool-metadata.ts
+++ b/src/base/config/tool-metadata.ts
@@ -14,6 +14,7 @@ export interface ConfigKeyMeta {
   risks: string[];
   revert: string;
   appliesAt: "next_session" | "immediate";
+  requiresExplicitApproval?: boolean;
 }
 
 export const CONFIG_METADATA: Record<string, ConfigKeyMeta> = {
@@ -39,8 +40,31 @@ export const CONFIG_METADATA: Record<string, ConfigKeyMeta> = {
     ],
     revert: "pulseed config set daemon_mode false、または TUI内で /settings からOFFに切り替え",
     appliesAt: "next_session",
+    requiresExplicitApproval: true,
+  },
+  no_flicker: {
+    label: "No Flicker UI",
+    description: "TUIの描画更新を抑えて端末のちらつきを減らす表示設定",
+    type: "boolean",
+    effects: [
+      "TUIの描画挙動が変わる",
+      "端末によってはちらつきが減る",
+    ],
+    requirements: [
+      "TUIセッションで使用すること",
+    ],
+    risks: [
+      "端末によっては体感差がない場合がある",
+    ],
+    revert: "pulseed config set no_flicker false、または TUI内で設定を戻す",
+    appliesAt: "immediate",
+    requiresExplicitApproval: false,
   },
 };
+
+export function configChangeRequiresApproval(key: string): boolean {
+  return CONFIG_METADATA[key]?.requiresExplicitApproval ?? false;
+}
 
 /** Build a rich description string for a single config key. */
 export function buildConfigKeyDescription(key: string): string {
@@ -48,20 +72,22 @@ export function buildConfigKeyDescription(key: string): string {
   if (!m) return `Unknown config key: ${key}`;
   const bullet = (arr: string[]) => arr.map(s => `- ${s}`).join("\n");
   const timing = m.appliesAt === "next_session" ? "次のセッション（再起動後）から適用" : "即座に適用";
+  const approval = m.requiresExplicitApproval ? "明示的なユーザー確認が必要" : "通常は即時変更してよい";
   return [`## ${m.label} (${key})`, m.description, "", "### 効果", bullet(m.effects), "",
     "### 必要な環境", bullet(m.requirements), "", "### リスク", bullet(m.risks), "",
-    "### 元に戻す方法", m.revert, "", "### 適用タイミング", timing].join("\n");
+    "### 元に戻す方法", m.revert, "", "### 適用タイミング", timing, "",
+    "### 承認要件", approval].join("\n");
 }
 
 /** Build the full tool description with all config keys' metadata injected. */
 export function buildConfigToolDescription(): string {
   const descs = Object.keys(CONFIG_METADATA).map(k => buildConfigKeyDescription(k)).join("\n\n---\n\n");
   return ["PulSeedの設定を変更する。", "",
-    "【重要ルール】このツールを呼ぶ前に、必ず以下の手順を踏むこと：",
-    "1. 変更する設定の『効果』『必要な環境』『リスク』『元に戻す方法』『適用タイミング』をすべてユーザーに説明する",
-    "2. ユーザーの明示的な同意（『はい』『OK』『大丈夫』等）を得る",
-    "3. 同意を得てからこのツールを呼び出す",
-    "4. 同意が得られない場合は呼び出さない", "",
+    "【重要ルール】このツールを呼ぶ前に、以下を守ること：",
+    "1. 変更する設定の『効果』『必要な環境』『リスク』『元に戻す方法』『適用タイミング』を説明する",
+    "2. 承認要件が『明示的なユーザー確認が必要』の設定では、同意を得てから呼び出す",
+    "3. 低リスク設定は簡潔に説明したうえで、そのまま実行してよい",
+    "4. ランタイムが追加の承認を要求した場合はそれに従う", "",
     "【利用可能な設定キー】", "", descs].join("\n");
 }
 

--- a/src/interface/chat/__tests__/chat-grounding.test.ts
+++ b/src/interface/chat/__tests__/chat-grounding.test.ts
@@ -43,6 +43,7 @@ import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adap
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import { spawnWithTimeout } from "../../../adapters/spawn-helper.js";
+import { clearIdentityCache } from "../../../base/config/identity-loader.js";
 
 // ─── Shared helpers ───
 
@@ -89,10 +90,14 @@ describe("buildSystemPrompt (grounding.ts)", () => {
 
   beforeEach(async () => {
     tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-grounding-test-"));
+    process.env["PULSEED_HOME"] = tmpDir;
+    clearIdentityCache();
   });
 
   afterEach(async () => {
     await fsp.rm(tmpDir, { recursive: true, force: true });
+    delete process.env["PULSEED_HOME"];
+    clearIdentityCache();
   });
 
   it("includes Seedy identity text", async () => {
@@ -100,14 +105,19 @@ describe("buildSystemPrompt (grounding.ts)", () => {
     const prompt = await buildSystemPrompt({ stateManager: sm, homeDir: tmpDir });
 
     expect(prompt).toContain("Seedy");
-    expect(prompt).toContain("goals");
+    expect(prompt).toContain("You run PulSeed");
   });
 
-  it("includes identity system content", async () => {
+  it("includes fixed policy sections", async () => {
     const sm = makeMockStateManager();
     const prompt = await buildSystemPrompt({ stateManager: sm, homeDir: tmpDir });
 
-    expect(prompt).toContain("Seedy");
+    expect(prompt).toContain("## Identity");
+    expect(prompt).toContain("## Execution Bias");
+    expect(prompt).toContain("## Tooling Policy");
+    expect(prompt).toContain("## Communication Policy");
+    expect(prompt).toContain("## Safety And Approval");
+    expect(prompt).toContain("## Dynamic Context");
     expect(prompt.length).toBeGreaterThan(0);
   });
 
@@ -125,6 +135,7 @@ describe("buildSystemPrompt (grounding.ts)", () => {
     expect(prompt).toContain("goal-1");
     expect(prompt).toContain("Fix prod bug");
     expect(prompt).toContain("goal-2");
+    expect(prompt).toContain("### Current Goals");
   });
 
   it("shows 'No goals configured yet' when no goals", async () => {
@@ -155,6 +166,7 @@ describe("buildSystemPrompt (grounding.ts)", () => {
 
     expect(prompt).toContain("slack-notifier");
     expect(prompt).toContain("github-issues");
+    expect(prompt).toContain("### Installed Plugins");
   });
 
   it("shows 'none' when plugins directory is absent", async () => {
@@ -177,6 +189,7 @@ describe("buildSystemPrompt (grounding.ts)", () => {
 
     expect(prompt).toContain("claude-sonnet-4");
     expect(prompt).toContain("claude_api");
+    expect(prompt).toContain("### Provider");
   });
 
   it("shows 'not configured' when provider.json is absent", async () => {

--- a/src/interface/chat/__tests__/chat-grounding.test.ts
+++ b/src/interface/chat/__tests__/chat-grounding.test.ts
@@ -87,16 +87,22 @@ function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
 
 describe("buildSystemPrompt (grounding.ts)", () => {
   let tmpDir: string;
+  let originalPulseedHome: string | undefined;
 
   beforeEach(async () => {
     tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-grounding-test-"));
+    originalPulseedHome = process.env["PULSEED_HOME"];
     process.env["PULSEED_HOME"] = tmpDir;
     clearIdentityCache();
   });
 
   afterEach(async () => {
     await fsp.rm(tmpDir, { recursive: true, force: true });
-    delete process.env["PULSEED_HOME"];
+    if (originalPulseedHome === undefined) {
+      delete process.env["PULSEED_HOME"];
+    } else {
+      process.env["PULSEED_HOME"] = originalPulseedHome;
+    }
     clearIdentityCache();
   });
 
@@ -118,7 +124,26 @@ describe("buildSystemPrompt (grounding.ts)", () => {
     expect(prompt).toContain("## Communication Policy");
     expect(prompt).toContain("## Safety And Approval");
     expect(prompt).toContain("## Dynamic Context");
+    expect(prompt).toContain("Platform operating policy overrides persona and customization text if they conflict.");
     expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  it("aligns default identity text with direct tool execution", async () => {
+    const sm = makeMockStateManager();
+    const prompt = await buildSystemPrompt({ stateManager: sm, homeDir: tmpDir });
+
+    expect(prompt).toContain("I use available tools directly when that moves the goal forward safely");
+    expect(prompt).not.toContain("I orchestrate, I don't execute tasks directly");
+    expect(prompt).not.toContain("I always delegate to agents and observe results");
+  });
+
+  it("limits explicit approval guidance to high-impact actions", async () => {
+    const sm = makeMockStateManager();
+    const prompt = await buildSystemPrompt({ stateManager: sm, homeDir: tmpDir });
+
+    expect(prompt).toContain("Proceed without asking first for routine reads, searches, tests, diffs, and ordinary local code edits.");
+    expect(prompt).toContain("Before high-impact configuration changes");
+    expect(prompt).not.toContain("Require explicit user approval before applying configuration changes.");
   });
 
   it("shows goals from stateManager", async () => {
@@ -421,19 +446,35 @@ describe("ChatRunner — grounding integration", () => {
     expect(task.system_prompt.length).toBeGreaterThan(0);
   });
 
-  it("caches system_prompt across turns — buildSystemPrompt called once per session", async () => {
+  it("rebuilds dynamic context across turns while reusing static prompt", async () => {
     const adapter = makeMockAdapter();
-    const stateManager = makeMockStateManager();
+    let currentIds = ["goal-1"];
+    const goals: Record<string, { title: string; status: string; loop_status: string }> = {
+      "goal-1": { title: "First goal", status: "active", loop_status: "running" },
+      "goal-2": { title: "Second goal", status: "pending", loop_status: "idle" },
+    };
+    const stateManager = {
+      listGoalIds: vi.fn().mockImplementation(async () => currentIds),
+      loadGoal: vi.fn().mockImplementation(async (id: string) => goals[id] ?? null),
+      writeRaw: vi.fn().mockResolvedValue(undefined),
+      readRaw: vi.fn().mockResolvedValue(null),
+    } as unknown as StateManager;
     const runner = new ChatRunner(makeDeps({ adapter, stateManager }));
 
     runner.startSession("/repo");
     await runner.execute("Turn 1", "/repo");
+    currentIds = ["goal-2"];
     await runner.execute("Turn 2", "/repo");
-    await runner.execute("Turn 3", "/repo");
 
-    // listGoalIds is called by buildSystemPrompt; should only be called once (caching)
+    const firstTask = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    const secondTask = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls[1][0];
     const listGoalIdsMock = stateManager.listGoalIds as ReturnType<typeof vi.fn>;
-    expect(listGoalIdsMock).toHaveBeenCalledTimes(1);
+    expect(listGoalIdsMock).toHaveBeenCalledTimes(2);
+    expect(firstTask.system_prompt).toContain("## Identity");
+    expect(secondTask.system_prompt).toContain("## Identity");
+    expect(firstTask.system_prompt).toContain("First goal");
+    expect(secondTask.system_prompt).toContain("Second goal");
+    expect(secondTask.system_prompt).not.toContain("First goal");
   });
 
   it("includes conversation history in prompt for subsequent turns", async () => {
@@ -481,8 +522,7 @@ describe("ChatRunner — grounding integration", () => {
     expect(exactMsg1).toBeUndefined();
   });
 
-  it("does not set system_prompt on AgentTask when buildSystemPrompt fails", async () => {
-    // stateManager that makes buildSystemPrompt throw → cachedSystemPrompt = ""
+  it("falls back to static system_prompt when dynamic context build fails", async () => {
     const sm = {
       listGoalIds: vi.fn().mockRejectedValue(new Error("fail")),
       loadGoal: vi.fn(),
@@ -496,7 +536,8 @@ describe("ChatRunner — grounding integration", () => {
     await runner.execute("Hello", "/repo");
 
     const task = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    // When buildSystemPrompt throws, cachedSystemPrompt = "" → no system_prompt key on task
-    expect(task.system_prompt).toBeUndefined();
+    expect(task.system_prompt).toBeDefined();
+    expect(task.system_prompt).toContain("## Identity");
+    expect(task.system_prompt).not.toContain("## Dynamic Context");
   });
 });

--- a/src/interface/chat/__tests__/self-knowledge-mutation-tools.test.ts
+++ b/src/interface/chat/__tests__/self-knowledge-mutation-tools.test.ts
@@ -221,29 +221,38 @@ describe("handleMutationToolCall — archive_goal", () => {
 // ─── delete_goal ───
 
 describe("handleMutationToolCall — delete_goal", () => {
-  it("deletes a goal without requiring approvalFn (LLM conversational confirmation)", async () => {
+  it("returns error when no approvalFn is configured", async () => {
     const sm = makeStateManager({ deleteGoal: vi.fn().mockResolvedValue(true) });
-    // No approvalFn provided — should succeed because approvalLevel is "none"
     const deps = makeDeps({ stateManager: sm });
     const result = await handleMutationToolCall("delete_goal", { goal_id: "g1" }, deps);
-    const parsed = JSON.parse(result) as { success: boolean };
-    expect(parsed.success).toBe(true);
-    expect(sm.deleteGoal).toHaveBeenCalledWith("g1");
+    const parsed = JSON.parse(result) as { error: string };
+    expect(parsed.error).toContain("approval");
+    expect(sm.deleteGoal).not.toHaveBeenCalled();
   });
 
-  it("does not call approvalFn even when one is provided", async () => {
+  it("deletes a goal when approval is granted", async () => {
     const sm = makeStateManager({ deleteGoal: vi.fn().mockResolvedValue(true) });
     const approvalFn = vi.fn().mockResolvedValue(true);
     const deps = makeDeps({ stateManager: sm, approvalFn });
     const result = await handleMutationToolCall("delete_goal", { goal_id: "g1" }, deps);
     const parsed = JSON.parse(result) as { success: boolean };
     expect(parsed.success).toBe(true);
-    expect(approvalFn).not.toHaveBeenCalled();
+    expect(approvalFn).toHaveBeenCalled();
+  });
+
+  it("returns error when user denies approval", async () => {
+    const sm = makeStateManager({ deleteGoal: vi.fn().mockResolvedValue(true) });
+    const approvalFn = vi.fn().mockResolvedValue(false);
+    const deps = makeDeps({ stateManager: sm, approvalFn });
+    const result = await handleMutationToolCall("delete_goal", { goal_id: "g1" }, deps);
+    const parsed = JSON.parse(result) as { error: string };
+    expect(parsed.error).toContain("denied");
+    expect(sm.deleteGoal).not.toHaveBeenCalled();
   });
 
   it("returns error when goal is not found", async () => {
     const sm = makeStateManager({ deleteGoal: vi.fn().mockResolvedValue(false) });
-    const deps = makeDeps({ stateManager: sm });
+    const deps = makeDeps({ stateManager: sm, approvalFn: vi.fn().mockResolvedValue(true) });
     const result = await handleMutationToolCall("delete_goal", { goal_id: "nonexistent" }, deps);
     const parsed = JSON.parse(result) as { error: string };
     expect(parsed.error).toContain("not found");
@@ -336,13 +345,38 @@ describe("handleMutationToolCall — update_config", () => {
   });
 
   it("succeeds and reports updated key/value (daemon_mode)", async () => {
-    const deps = makeDeps();
+    const deps = makeDeps({ approvalFn: vi.fn().mockResolvedValue(true) });
     const result = await handleMutationToolCall("update_config", { key: "daemon_mode", value: true }, deps);
     const parsed = JSON.parse(result) as { success: boolean; key: string; value: unknown; message: string };
     expect(parsed.success).toBe(true);
     expect(parsed.key).toBe("daemon_mode");
     expect(parsed.value).toBe(true);
     expect(parsed.message).toContain("daemon_mode");
+  });
+
+  it("returns error when no approvalFn is configured for a valid change", async () => {
+    const deps = makeDeps();
+    const result = await handleMutationToolCall("update_config", { key: "daemon_mode", value: true }, deps);
+    const parsed = JSON.parse(result) as { error: string };
+    expect(parsed.error).toContain("approval");
+  });
+
+  it("returns error when user denies approval for a valid change", async () => {
+    const deps = makeDeps({ approvalFn: vi.fn().mockResolvedValue(false) });
+    const result = await handleMutationToolCall("update_config", { key: "daemon_mode", value: true }, deps);
+    const parsed = JSON.parse(result) as { error: string };
+    expect(parsed.error).toContain("denied");
+  });
+
+  it("allows routine config changes without approval", async () => {
+    const approvalFn = vi.fn().mockResolvedValue(true);
+    const deps = makeDeps({ approvalFn });
+    const result = await handleMutationToolCall("update_config", { key: "no_flicker", value: true }, deps);
+    const parsed = JSON.parse(result) as { success: boolean; key: string; value: boolean };
+    expect(parsed.success).toBe(true);
+    expect(parsed.key).toBe("no_flicker");
+    expect(parsed.value).toBe(true);
+    expect(approvalFn).not.toHaveBeenCalled();
   });
 });
 
@@ -452,10 +486,23 @@ describe("handleMutationToolCall — approval config override", () => {
     expect(approvalFn).toHaveBeenCalled();
   });
 
-  it("delete_goal does not require approvalFn by default (approval level none)", async () => {
+  it("delete_goal requires approvalFn by default", async () => {
     const sm = makeStateManager({ deleteGoal: vi.fn().mockResolvedValue(true) });
     const approvalFn = vi.fn().mockResolvedValue(true);
     const deps = makeDeps({ stateManager: sm, approvalFn });
+    await handleMutationToolCall("delete_goal", { goal_id: "g1" }, deps);
+    expect(approvalFn).toHaveBeenCalled();
+    expect(sm.deleteGoal).toHaveBeenCalledWith("g1");
+  });
+
+  it("can override delete_goal to skip approval via approvalConfig", async () => {
+    const sm = makeStateManager({ deleteGoal: vi.fn().mockResolvedValue(true) });
+    const approvalFn = vi.fn().mockResolvedValue(true);
+    const deps = makeDeps({
+      stateManager: sm,
+      approvalFn,
+      approvalConfig: { delete_goal: "none" },
+    });
     await handleMutationToolCall("delete_goal", { goal_id: "g1" }, deps);
     expect(approvalFn).not.toHaveBeenCalled();
     expect(sm.deleteGoal).toHaveBeenCalledWith("g1");

--- a/src/interface/chat/__tests__/self-knowledge-tools.test.ts
+++ b/src/interface/chat/__tests__/self-knowledge-tools.test.ts
@@ -143,6 +143,8 @@ describe("handleSelfKnowledgeToolCall — get_trust_state", () => {
     expect(parsed.high_trust_threshold).toBe(20);
     expect(parsed.ethics_gate_level).toBe("L1");
     expect(parsed.execution_boundary).toBeDefined();
+    expect(parsed.execution_boundary).toContain("uses available tools directly");
+    expect(parsed.execution_boundary).toContain("Explicit confirmation is required");
     expect(parsed.trust_balance_range).toEqual([-100, 100]);
   });
 });
@@ -269,6 +271,8 @@ describe("handleSelfKnowledgeToolCall — get_architecture", () => {
     const result = await handleSelfKnowledgeToolCall("get_architecture", {}, deps);
     const parsed = JSON.parse(result) as { architecture: string };
     expect(parsed.architecture.toLowerCase()).toContain("execution boundary");
+    expect(parsed.architecture).toContain("uses available tools directly");
+    expect(parsed.architecture).toContain("require explicit confirmation");
   });
 });
 

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -10,7 +10,7 @@ import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { ChatHistory } from "./chat-history.js";
 import { buildChatContext, resolveGitRoot } from "../../platform/observation/context-provider.js";
 import type { EscalationHandler } from "./escalation.js";
-import { buildSystemPrompt } from "./grounding.js";
+import { buildDynamicContextPrompt, buildStaticSystemPrompt } from "./grounding.js";
 import { verifyChatAction } from "./chat-verifier.js";
 import type { ApprovalLevel } from "./self-knowledge-mutation-tools.js";
 import type { ToolRegistry } from "../../tools/registry.js";
@@ -100,8 +100,8 @@ export class ChatRunner {
   private sessionActive = false;
   /** Deferred tools activated by ToolSearch results — included in tool definitions for subsequent turns. */
   private activatedTools: Set<string> = new Set();
-  /** Cached system prompt — built once per session, reused across turns. */
-  private cachedSystemPrompt: string | null = null;
+  /** Cached static system prompt — reused across turns; dynamic context is rebuilt each turn. */
+  private cachedStaticSystemPrompt: string | null = null;
   /** Pending /tend state awaiting user confirmation (Y/n). */
   private pendingTend: { goalId: string; maxIterations?: number } | null = null;
   /** Active EventSubscriber instances keyed by goalId. */
@@ -350,14 +350,26 @@ export class ChatRunner {
     // Persist-before-execute: user message written to disk first
     await history.appendUserMessage(input);
 
-    // Build grounding system prompt on first turn, cache for session
-    if (this.cachedSystemPrompt === null) {
+    // Build static grounding once per session; dynamic context is rebuilt each turn.
+    if (this.cachedStaticSystemPrompt === null) {
       try {
-        this.cachedSystemPrompt = await buildSystemPrompt({ stateManager: this.deps.stateManager });
+        this.cachedStaticSystemPrompt = buildStaticSystemPrompt();
       } catch {
-        this.cachedSystemPrompt = "";
+        this.cachedStaticSystemPrompt = "";
       }
     }
+
+    let dynamicSystemPrompt = "";
+    try {
+      dynamicSystemPrompt = await buildDynamicContextPrompt({ stateManager: this.deps.stateManager });
+    } catch {
+      dynamicSystemPrompt = "";
+    }
+
+    const systemPrompt = [this.cachedStaticSystemPrompt, dynamicSystemPrompt]
+      .filter((section) => section && section.trim().length > 0)
+      .join("\n\n")
+      .trim();
 
     // Build conversation history from prior turns (last 10)
     const messages = history.getMessages();
@@ -379,7 +391,7 @@ export class ChatRunner {
     // Use llmClient with self-knowledge tools when available (function calling path)
     // Skip executeWithTools for clients that don't support tool calling (e.g. CodexLLMClient)
     if (this.deps.llmClient && this.deps.llmClient.supportsToolCalling?.() !== false) {
-      const toolResult = await this.executeWithTools(prompt, this.cachedSystemPrompt ?? undefined);
+      const toolResult = await this.executeWithTools(prompt, systemPrompt || undefined);
       const elapsed_ms = Date.now() - start;
       await history.appendAssistantMessage(toolResult);
       return { success: true, output: toolResult, elapsed_ms };
@@ -390,7 +402,7 @@ export class ChatRunner {
       timeout_ms: timeoutMs,
       adapter_type: this.deps.adapter.adapterType,
       cwd,
-      ...(this.cachedSystemPrompt ? { system_prompt: this.cachedSystemPrompt } : {}),
+      ...(systemPrompt ? { system_prompt: systemPrompt } : {}),
     };
     const resolvedTimeoutMs = task.timeout_ms ?? DEFAULT_TIMEOUT_MS;
     const adapterPromise = this.deps.adapter.execute(task);

--- a/src/interface/chat/grounding.ts
+++ b/src/interface/chat/grounding.ts
@@ -1,20 +1,18 @@
 // ─── Chat Grounding ───
 //
 // Builds a system prompt that gives the LLM self-knowledge about PulSeed:
-// identity, current state (goals, plugins, provider).
+// identity, operating rules, and current state (goals, plugins, provider).
 
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import type { StateManager } from "../../base/state/state-manager.js";
-import { getUserFacingIdentity, getAgentName } from "../../base/config/identity-loader.js";
+import { getAgentName, getUserFacingIdentity, loadIdentity } from "../../base/config/identity-loader.js";
 
 export interface GroundingOptions {
   stateManager: StateManager;
   /** Base directory for PulSeed config files. Defaults to ~/.pulseed */
   homeDir?: string;
 }
-
-// ─── Helpers ───
 
 async function readPlugins(homeDir: string): Promise<string[]> {
   const pluginsDir = path.join(homeDir, "plugins");
@@ -55,7 +53,77 @@ async function buildGoalsBlock(stateManager: StateManager): Promise<string> {
   return lines.length > 0 ? lines.join("\n") : "No goals configured yet.";
 }
 
-// ─── Main export ───
+function buildIdentitySection(): string {
+  const { name } = loadIdentity();
+
+  return [
+    "## Identity",
+    `You are ${name}.`,
+    "You run PulSeed, an AI goal pursuit orchestration system.",
+    "",
+    "Your role is to help the user make concrete progress by inspecting the workspace, using tools, delegating work when useful, and executing the next valid step.",
+    "",
+    getUserFacingIdentity().trim(),
+  ].join("\n");
+}
+
+function buildExecutionBiasSection(): string {
+  return [
+    "## Execution Bias",
+    "- If the next step is clear and safe, do it in the same turn.",
+    "- Do not stop at analysis when execution is possible.",
+    "- Inspect files, code, and state before asking avoidable questions.",
+    "- Prefer subagents for parallel exploration and context isolation when that reduces context pollution.",
+    "- Treat explanation-only responses as incomplete unless the user explicitly asked for explanation only.",
+  ].join("\n");
+}
+
+function buildToolingPolicySection(): string {
+  return [
+    "## Tooling Policy",
+    "- Tool schemas are the source of truth for capabilities, arguments, and constraints.",
+    "- Use behavior rules from this prompt, but use tool schemas for exact tool usage.",
+    "- Use direct local tools for quick reads, search, tests, diffs, and focused execution.",
+    "- Use background execution only for long-running tasks.",
+    "- Choose the narrowest tool that can complete the task correctly.",
+  ].join("\n");
+}
+
+function buildCommunicationPolicySection(): string {
+  return [
+    "## Communication Policy",
+    "- Keep pre-tool messages short and factual.",
+    "- Do not give long preambles before routine tool calls.",
+    "- Prefer action first, then concise reporting.",
+    "- Progress updates should be brief and relevant.",
+    "- Do not narrate internal process details at length unless they matter to the user's decision.",
+  ].join("\n");
+}
+
+function buildSafetySection(name: string): string {
+  return [
+    "## Safety And Approval",
+    "- Before changing configuration, explain the effect, required environment, risks, and rollback path.",
+    "- Require explicit user approval before applying configuration changes.",
+    "- Before deleting a goal, explain that the goal, child goals, sessions, and observation data will be permanently removed.",
+    "- Before goal deletion, explicitly state that the action is irreversible and require explicit user approval.",
+    `- Stay focused on goals — you're here to help them grow (${name}).`,
+  ].join("\n");
+}
+
+function buildDynamicContextSection(goalsBlock: string, pluginsLine: string, provider: string): string {
+  return [
+    "## Dynamic Context",
+    "### Current Goals",
+    goalsBlock,
+    "",
+    "### Installed Plugins",
+    `Installed: ${pluginsLine}`,
+    "",
+    "### Provider",
+    provider,
+  ].join("\n");
+}
 
 export async function buildSystemPrompt(options: GroundingOptions): Promise<string> {
   const homeDir = options.homeDir ?? path.join(
@@ -70,41 +138,14 @@ export async function buildSystemPrompt(options: GroundingOptions): Promise<stri
   ]);
 
   const pluginsLine = plugins.length > 0 ? plugins.join(", ") : "none";
-  const identity = getUserFacingIdentity();
   const name = getAgentName();
 
-  return `
-${identity}
-
----
-
-## Current State
-### Goals
-${goalsBlock}
-
-### Plugins
-Installed: ${pluginsLine}
-
-### Provider
-${provider}
-
-## Safety Instructions
-- 設定変更について：
-  ユーザーが設定の変更を求めた場合、update_configツールを使用できます。
-  ただし、ツールを呼ぶ前に必ず以下を行ってください：
-  1. 変更内容の効果・必要環境・リスク・元に戻す方法を丁寧に説明する
-  2. ユーザーの明示的な同意を得る（「はい」「OK」「大丈夫」など）
-  3. 同意が得られてからツールを呼び出す
-  ユーザーが迷っている場合や、リスクを理解していない様子であれば、追加説明をしてください。
-- ゴール削除について：
-  ユーザーがゴールの削除を求めた場合、delete_goalツールを使用できます。
-  ただし、ツールを呼ぶ前に必ず以下の手順を踏んでください：
-  1. 削除対象のゴールと、その子ゴール・セッション・観測データがすべて完全削除されることを説明する
-  2. リスクを列挙する（元に戻せない、ゴールIDは再利用不可、実行中セッションは強制終了など）
-  3. この操作は取り消せないことを明示する
-  4. ユーザーの明示的な確認（「はい」「削除する」など）を得る
-  5. 確認を得てからツールを呼び出す
-  ユーザーが迷っている場合や削除の影響を理解していない様子であれば、追加説明をしてください。
-- Stay focused on goals — you're here to help them grow (${name})
-`.trim();
+  return [
+    buildIdentitySection(),
+    buildExecutionBiasSection(),
+    buildToolingPolicySection(),
+    buildCommunicationPolicySection(),
+    buildSafetySection(name),
+    buildDynamicContextSection(goalsBlock, pluginsLine, provider),
+  ].join("\n\n").trim();
 }

--- a/src/interface/chat/grounding.ts
+++ b/src/interface/chat/grounding.ts
@@ -14,6 +14,13 @@ export interface GroundingOptions {
   homeDir?: string;
 }
 
+function resolveHomeDir(homeDir?: string): string {
+  return homeDir ?? path.join(
+    process.env["HOME"] ?? process.env["USERPROFILE"] ?? "/tmp",
+    ".pulseed"
+  );
+}
+
 async function readPlugins(homeDir: string): Promise<string[]> {
   const pluginsDir = path.join(homeDir, "plugins");
   try {
@@ -60,9 +67,11 @@ function buildIdentitySection(): string {
     "## Identity",
     `You are ${name}.`,
     "You run PulSeed, an AI goal pursuit orchestration system.",
+    "Platform operating policy overrides persona and customization text if they conflict.",
     "",
-    "Your role is to help the user make concrete progress by inspecting the workspace, using tools, delegating work when useful, and executing the next valid step.",
+    "Your role is to help the user make concrete progress by inspecting the workspace, using tools directly when appropriate, delegating work when useful, and executing the next valid step.",
     "",
+    "### Persona And Customization",
     getUserFacingIdentity().trim(),
   ].join("\n");
 }
@@ -73,7 +82,8 @@ function buildExecutionBiasSection(): string {
     "- If the next step is clear and safe, do it in the same turn.",
     "- Do not stop at analysis when execution is possible.",
     "- Inspect files, code, and state before asking avoidable questions.",
-    "- Prefer subagents for parallel exploration and context isolation when that reduces context pollution.",
+    "- Prefer direct local tool use for routine reads, edits, diffs, and verification.",
+    "- Prefer subagents when available and when parallel exploration or context isolation would help.",
     "- Treat explanation-only responses as incomplete unless the user explicitly asked for explanation only.",
   ].join("\n");
 }
@@ -103,10 +113,13 @@ function buildCommunicationPolicySection(): string {
 function buildSafetySection(name: string): string {
   return [
     "## Safety And Approval",
-    "- Before changing configuration, explain the effect, required environment, risks, and rollback path.",
-    "- Require explicit user approval before applying configuration changes.",
+    "- Use tools directly by default for safe, reversible, goal-advancing work.",
+    "- Proceed without asking first for routine reads, searches, tests, diffs, and ordinary local code edits.",
+    "- Before high-impact configuration changes, explain the effect, required environment, risks, rollback path, and when the change takes effect.",
+    "- Ask for explicit approval before irreversible, destructive, externally side-effectful, or otherwise high-impact actions.",
     "- Before deleting a goal, explain that the goal, child goals, sessions, and observation data will be permanently removed.",
-    "- Before goal deletion, explicitly state that the action is irreversible and require explicit user approval.",
+    "- Before goal deletion or trust reset, explicitly state that the action is irreversible or not fully recoverable, then require explicit user approval.",
+    "- If a tool or runtime requires approval, obtain it once and then continue.",
     `- Stay focused on goals — you're here to help them grow (${name}).`,
   ].join("\n");
 }
@@ -125,19 +138,7 @@ function buildDynamicContextSection(goalsBlock: string, pluginsLine: string, pro
   ].join("\n");
 }
 
-export async function buildSystemPrompt(options: GroundingOptions): Promise<string> {
-  const homeDir = options.homeDir ?? path.join(
-    process.env["HOME"] ?? process.env["USERPROFILE"] ?? "/tmp",
-    ".pulseed"
-  );
-
-  const [goalsBlock, plugins, provider] = await Promise.all([
-    buildGoalsBlock(options.stateManager),
-    readPlugins(homeDir),
-    readProvider(homeDir),
-  ]);
-
-  const pluginsLine = plugins.length > 0 ? plugins.join(", ") : "none";
+export function buildStaticSystemPrompt(): string {
   const name = getAgentName();
 
   return [
@@ -146,6 +147,25 @@ export async function buildSystemPrompt(options: GroundingOptions): Promise<stri
     buildToolingPolicySection(),
     buildCommunicationPolicySection(),
     buildSafetySection(name),
-    buildDynamicContextSection(goalsBlock, pluginsLine, provider),
+  ].join("\n\n").trim();
+}
+
+export async function buildDynamicContextPrompt(options: GroundingOptions): Promise<string> {
+  const homeDir = resolveHomeDir(options.homeDir);
+
+  const [goalsBlock, plugins, provider] = await Promise.all([
+    buildGoalsBlock(options.stateManager),
+    readPlugins(homeDir),
+    readProvider(homeDir),
+  ]);
+
+  const pluginsLine = plugins.length > 0 ? plugins.join(", ") : "none";
+  return buildDynamicContextSection(goalsBlock, pluginsLine, provider).trim();
+}
+
+export async function buildSystemPrompt(options: GroundingOptions): Promise<string> {
+  return [
+    buildStaticSystemPrompt(),
+    await buildDynamicContextPrompt(options),
   ].join("\n\n").trim();
 }

--- a/src/interface/chat/mutation-tool-defs.ts
+++ b/src/interface/chat/mutation-tool-defs.ts
@@ -10,7 +10,7 @@ export const DEFAULT_APPROVAL: Record<string, ApprovalLevel> = {
   set_goal: "none",
   update_goal: "none",
   archive_goal: "required",
-  delete_goal: "none",
+  delete_goal: "required",
   toggle_plugin: "required",
   update_config: "none",
   reset_trust: "required",

--- a/src/interface/chat/self-knowledge-mutation-tools.ts
+++ b/src/interface/chat/self-knowledge-mutation-tools.ts
@@ -1,3 +1,4 @@
+import { configChangeRequiresApproval } from "../../base/config/config-metadata.js";
 import { getConfigKeys, updateGlobalConfig } from "../../base/config/global-config.js";
 
 export type { ApprovalLevel, MutationToolDeps } from "./mutation-tool-defs.js";
@@ -148,7 +149,14 @@ async function handleDeleteGoal(
     return JSON.stringify({ error: "goal_id is required" });
   }
 
-  // No checkApproval — LLM handles confirmation conversationally (approvalLevel: "none")
+  const approval = await checkApproval(
+    "delete_goal",
+    `Delete goal permanently: ${goalId}`,
+    deps
+  );
+  if (!approval.approved) {
+    return JSON.stringify({ error: approval.error });
+  }
 
   try {
     const deleted = await deps.stateManager.deleteGoal(goalId);
@@ -192,7 +200,7 @@ async function handleTogglePlugin(
 
 async function handleUpdateConfig(
   args: Record<string, unknown>,
-  _deps: MutationToolDeps
+  deps: MutationToolDeps
 ): Promise<string> {
   const key = args.key;
   const value = args.value;
@@ -212,7 +220,23 @@ async function handleUpdateConfig(
     });
   }
 
-  // Apply the change (no checkApproval — LLM handled confirmation conversationally)
+  if (configChangeRequiresApproval(key)) {
+    const level = deps.approvalConfig?.["update_config"] ?? "required";
+    if (level === "required") {
+      if (!deps.approvalFn) {
+        return JSON.stringify({
+          error: "This operation requires approval but no approval handler is configured",
+        });
+      }
+      const approved = await deps.approvalFn(
+        `Update high-impact config "${key}" to ${JSON.stringify(value)}`
+      );
+      if (!approved) {
+        return JSON.stringify({ error: "User denied the operation" });
+      }
+    }
+  }
+
   try {
     const updated = await updateGlobalConfig({ [key]: value });
     const newValue = (updated as Record<string, unknown>)[key];

--- a/src/interface/chat/self-knowledge-tools.ts
+++ b/src/interface/chat/self-knowledge-tools.ts
@@ -162,7 +162,7 @@ async function handleGetTrustState(deps: SelfKnowledgeDeps): Promise<string> {
     high_trust_threshold: 20,
     ethics_gate_level: "L1",
     execution_boundary:
-      `${getAgentName()} always delegates. Direct actions are LLM calls (for thinking) and state read/write only.`,
+      `${getAgentName()} uses available tools directly for safe, goal-advancing work. Explicit confirmation is required before destructive or otherwise high-risk actions.`,
   });
 }
 
@@ -215,7 +215,7 @@ function handleGetArchitecture(): string {
 ## Core Concept
 4-element model: Goal (with thresholds) -> Current State (observation + confidence) -> Gap -> Constraints
 Core loop: observe -> gap -> score -> task -> execute -> verify (NEVER STOP)
-Execution boundary: ${name} always delegates. Direct actions are LLM calls (for thinking) and state read/write only.
+Execution boundary: ${name} uses available tools directly for safe, goal-advancing work. Destructive or otherwise high-risk actions require explicit confirmation first.
 
 ## Layer Structure
 - Layer 0:  StateManager, AdapterLayer (no dependencies)

--- a/src/interface/cli/__tests__/setup-shared.test.ts
+++ b/src/interface/cli/__tests__/setup-shared.test.ts
@@ -172,6 +172,12 @@ describe("ROOT_PRESETS", () => {
     // Content should start with a markdown heading
     expect(preset.content.trimStart()).toMatch(/^#/);
   });
+
+  it.each(PRESET_KEYS)("preset %s avoids delegate-only wording", (key) => {
+    const preset = ROOT_PRESETS[key];
+    expect(preset.content.toLowerCase()).not.toContain("always delegate");
+    expect(preset.content.toLowerCase()).not.toContain("delegate always");
+  });
 });
 
 // ─── Constants sanity checks ───

--- a/src/interface/cli/commands/presets/root-presets.ts
+++ b/src/interface/cli/commands/presets/root-presets.ts
@@ -11,11 +11,12 @@ export const ROOT_PRESETS = {
 
 ## Boundaries
 - Goal pursuit only — not a general assistant
-- Always delegate to agents, observe results
+- Use tools directly when the next safe step is clear
+- Delegate when parallel exploration or specialization would help
 
 ## Interaction Style
 - Concise and direct
-- Ask before assuming
+- Inspect context first; ask only when ambiguity or risk remains
 - Show results, not process
 `,
   },
@@ -31,13 +32,14 @@ export const ROOT_PRESETS = {
 
 ## Boundaries
 - Goal orchestration scope only
-- Always delegate; present observations clearly
+- Use tools directly when it moves the work forward safely
+- Delegate when a specialist or parallel branch would be better
 
 ## Interaction Style
 - Step-by-step reasoning shown explicitly
 - Acknowledge alternatives and trade-offs
 - Structured responses with clear sections
-- Confirm understanding before acting
+- Confirm before destructive or high-risk actions
 `,
   },
   caveman: {
@@ -49,7 +51,8 @@ export const ROOT_PRESETS = {
 - No internals. No explanations unless asked.
 
 ## Boundaries
-- Goal pursuit only. Delegate always.
+- Goal pursuit only. Act direct when safe.
+- Ask before destructive or risky moves.
 
 ## Style
 - Drop articles. Use fragments.

--- a/src/tools/mutation/UpdateConfigTool/UpdateConfigTool.ts
+++ b/src/tools/mutation/UpdateConfigTool/UpdateConfigTool.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata, ToolDescriptionContext } from "../../types.js";
+import { configChangeRequiresApproval } from "../../../base/config/config-metadata.js";
 import { getConfigKeys, updateGlobalConfig } from "../../../base/config/global-config.js";
 import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
 
@@ -67,7 +68,14 @@ export class UpdateConfigTool implements ITool<UpdateConfigInput, unknown> {
     }
   }
 
-  async checkPermissions(): Promise<PermissionCheckResult> {
+  async checkPermissions(input: UpdateConfigInput, context: ToolCallContext): Promise<PermissionCheckResult> {
+    if (context.preApproved) return { status: "allowed" };
+    if (configChangeRequiresApproval(input.key)) {
+      return {
+        status: "needs_approval",
+        reason: "This configuration change is high impact and requires user confirmation",
+      };
+    }
     return { status: "allowed" };
   }
 


### PR DESCRIPTION
## Summary
- split chat grounding into explicit system prompt sections
- keep Seedy as the agent identity while adding execution/tooling/communication sections
- update grounding tests to assert the new sectioned prompt structure

## Testing
- pnpm vitest run src/interface/chat/__tests__/chat-grounding.test.ts