### PR TITLE
refactor: break circular type dependencies

### DIFF
--- a/src/base/state/checkpoint-trust-port.ts
+++ b/src/base/state/checkpoint-trust-port.ts
@@ -1,0 +1,3 @@
+export interface CheckpointTrustPort {
+  setOverride(domain: string, balance: number, reason: string): Promise<void>;
+}

--- a/src/base/state/state-manager.ts
+++ b/src/base/state/state-manager.ts
@@ -11,7 +11,7 @@ import type { ObservationLog, ObservationLogEntry } from "../types/state.js";
 import type { GapHistoryEntry } from "../types/gap.js";
 import type { PaceSnapshot } from "../types/goal.js";
 import { LoopCheckpointSchema } from "../types/checkpoint.js";
-import type { TrustManager } from "../../platform/traits/trust-manager.js";
+import type { CheckpointTrustPort } from "./checkpoint-trust-port.js";
 import { initDirs, atomicWrite, atomicRead } from "./state-persistence.js";
 import { acquireLock, releaseLock } from "./state-lock.js";
 import { appendWALRecord, replayWAL, compactWAL } from "./state-wal.js";
@@ -617,7 +617,7 @@ export class StateManager {
   async restoreFromCheckpoint(
     goalId: string,
     adapterType: string,
-    trustManager?: TrustManager
+    trustManager?: CheckpointTrustPort
   ): Promise<number> {
     try {
       const raw = await this.atomicRead<unknown>(

--- a/src/orchestrator/execution/__tests__/result-reconciler.test.ts
+++ b/src/orchestrator/execution/__tests__/result-reconciler.test.ts
@@ -4,7 +4,7 @@ import {
   buildReconciliationPrompt,
 } from "../result-reconciler.js";
 import type { ReconcilerDeps } from "../result-reconciler.js";
-import type { SubtaskResult } from "../parallel-executor.js";
+import type { SubtaskResult } from "../parallel-execution-types.js";
 
 // ─── Helpers ───
 

--- a/src/orchestrator/execution/parallel-execution-types.ts
+++ b/src/orchestrator/execution/parallel-execution-types.ts
@@ -1,0 +1,6 @@
+export interface SubtaskResult {
+  task_id: string;
+  verdict: "pass" | "partial" | "fail";
+  output: string;
+  error?: string;
+}

--- a/src/orchestrator/execution/parallel-executor.ts
+++ b/src/orchestrator/execution/parallel-executor.ts
@@ -10,16 +10,11 @@ import type { TaskGroup } from "../../base/types/index.js";
 import type { AgentTask } from "./adapter-layer.js";
 import type { PipelineExecutor } from "./pipeline-executor.js";
 import { reconcileResults } from "./result-reconciler.js";
+import type { SubtaskResult } from "./parallel-execution-types.js";
 import { durationToMs } from "./task/task-executor.js";
 
 // ─── Result Types ───
-
-export interface SubtaskResult {
-  task_id: string;
-  verdict: "pass" | "partial" | "fail";
-  output: string;
-  error?: string;
-}
+export type { SubtaskResult } from "./parallel-execution-types.js";
 
 export interface ParallelExecutionResult {
   results: SubtaskResult[];

--- a/src/orchestrator/execution/result-reconciler.ts
+++ b/src/orchestrator/execution/result-reconciler.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import type { IPromptGateway } from "../../prompt/gateway.js";
 import type { Logger } from "../../runtime/logger.js";
-import type { SubtaskResult } from "./parallel-executor.js";
+import type { SubtaskResult } from "./parallel-execution-types.js";
 
 // ─── Types ───
 

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -37,8 +37,7 @@ import { AdapterRegistry } from "../adapter-layer.js";
 export type { AgentTask, AgentResult, IAdapter };
 export { AdapterRegistry };
 
-import type { TaskPipeline, TaskDomain } from "../../../base/types/pipeline.js";
-import type { ObservationEngine } from "../../../platform/observation/observation-engine.js";
+import type { TaskPipeline } from "../../../base/types/pipeline.js";
 
 export { LLMGeneratedTaskSchema } from "./task-generation.js";
 import { generateTask as _generateTask } from "./task-generation.js";
@@ -47,6 +46,7 @@ import { executeTaskWithGuards, verifyExecutionWithGitDiff } from "./task-execut
 import { runPreExecutionChecks } from "./task-approval.js";
 import { checkIrreversibleApproval as _checkIrreversibleApproval } from "./task-approval-check.js";
 import { runPipelineTaskCycle as runPipelineTaskCycleFn } from "./task-pipeline-cycle.js";
+import type { PipelineCycleOptions } from "./task-pipeline-types.js";
 import type { KnowledgeTransfer } from "../../../platform/knowledge/transfer/knowledge-transfer.js";
 import type { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
 import { buildEnrichedKnowledgeContext } from "./task-context-enricher.js";
@@ -63,6 +63,12 @@ import {
 } from "../../../platform/dream/dream-activation.js";
 
 export type { TaskCycleResult } from "./task-execution-types.js";
+export type {
+  PipelineCycleDeps,
+  PipelineCycleOptions,
+  SelectTargetDimensionFn,
+  GenerateTaskFn,
+} from "./task-pipeline-types.js";
 import type { TaskCycleResult } from "./task-execution-types.js";
 import { createSkippedTaskResult } from "./task-execution-types.js";
 
@@ -402,14 +408,7 @@ export class TaskLifecycle {
     driveContext: DriveContext,
     adapter: IAdapter,
     pipeline: TaskPipeline,
-    options?: {
-      knowledgeContext?: string;
-      existingTasks?: string[];
-      workspaceContext?: string;
-      observationEngine?: ObservationEngine;
-      domain?: TaskDomain;
-      adapterRegistry?: AdapterRegistry;
-    }
+    options?: PipelineCycleOptions
   ): Promise<TaskCycleResult> {
     return runPipelineTaskCycleFn(
       {

--- a/src/orchestrator/execution/task/task-pipeline-cycle.ts
+++ b/src/orchestrator/execution/task/task-pipeline-cycle.ts
@@ -1,49 +1,28 @@
-import type { Logger } from "../../../runtime/logger.js";
-import type { StateManager } from "../../../base/state/state-manager.js";
-import type { SessionManager } from "../session-manager.js";
-import type { ILLMClient } from "../../../base/llm/llm-client.js";
-import type { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
-import type { EthicsGate } from "../../../platform/traits/ethics-gate.js";
-import type { CapabilityDetector } from "../../../platform/observation/capability-detector.js";
-import type { Task, VerificationResult } from "../../../base/types/task.js";
+import type { VerificationResult } from "../../../base/types/task.js";
 import type { GapVector } from "../../../base/types/gap.js";
 import type { DriveContext } from "../../../base/types/drive.js";
 import type { Dimension } from "../../../base/types/goal.js";
-import type { TaskPipeline, TaskDomain } from "../../../base/types/pipeline.js";
+import type { TaskPipeline } from "../../../base/types/pipeline.js";
 import type { AgentTask, IAdapter } from "../adapter-layer.js";
 import { AdapterRegistry } from "../adapter-layer.js";
-import type { ObservationEngine, TaskObservationContext } from "../../../platform/observation/observation-engine.js";
-import type { TaskCycleResult } from "./task-lifecycle.js";
+import type { TaskObservationContext } from "../../../platform/observation/observation-engine.js";
+import type { TaskCycleResult } from "./task-execution-types.js";
 import { createSkippedTaskResult } from "./task-execution-types.js";
 import { PipelineExecutor } from "../pipeline-executor.js";
 import { runPreExecutionChecks } from "./task-approval.js";
 import { durationToMs } from "./task-executor.js";
 import { generateReflection, saveReflectionAsKnowledge } from "../reflection-generator.js";
+import type {
+  PipelineCycleDeps,
+  PipelineCycleOptions,
+} from "./task-pipeline-types.js";
 
-// ─── PipelineCycleDeps ───
-
-export interface PipelineCycleDeps {
-  stateManager: StateManager;
-  sessionManager: SessionManager;
-  llmClient: ILLMClient;
-  ethicsGate?: EthicsGate;
-  capabilityDetector?: CapabilityDetector;
-  approvalFn: (task: Task) => Promise<boolean>;
-  adapterRegistry?: AdapterRegistry;
-  logger?: Logger;
-  knowledgeManager?: KnowledgeManager;
-  checkIrreversibleApproval: (task: Task) => Promise<boolean>;
-  selectTargetDimension: (gapVector: GapVector, driveContext: DriveContext, dimensions?: Dimension[]) => string;
-  generateTask: (
-    goalId: string,
-    targetDimension: string,
-    strategyId: string | undefined,
-    knowledgeContext?: string,
-    adapterType?: string,
-    existingTasks?: string[],
-    workspaceContext?: string
-  ) => Promise<Task | null>;
-}
+export type {
+  PipelineCycleDeps,
+  PipelineCycleOptions,
+  SelectTargetDimensionFn,
+  GenerateTaskFn,
+} from "./task-pipeline-types.js";
 
 // ─── runPipelineTaskCycle ───
 
@@ -60,14 +39,7 @@ export async function runPipelineTaskCycle(
   driveContext: DriveContext,
   adapter: IAdapter,
   pipeline: TaskPipeline,
-  options?: {
-    knowledgeContext?: string;
-    existingTasks?: string[];
-    workspaceContext?: string;
-    observationEngine?: ObservationEngine;
-    domain?: TaskDomain;
-    adapterRegistry?: AdapterRegistry;
-  }
+  options?: PipelineCycleOptions
 ): Promise<TaskCycleResult> {
   // 1. Select target dimension
   let goalDimensions: Dimension[] | undefined;

--- a/src/orchestrator/execution/task/task-pipeline-types.ts
+++ b/src/orchestrator/execution/task/task-pipeline-types.ts
@@ -1,0 +1,54 @@
+import type { StateManager } from "../../../base/state/state-manager.js";
+import type { ILLMClient } from "../../../base/llm/llm-client.js";
+import type { SessionManager } from "../session-manager.js";
+import type { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
+import type { EthicsGate } from "../../../platform/traits/ethics-gate.js";
+import type { CapabilityDetector } from "../../../platform/observation/capability-detector.js";
+import type { Task } from "../../../base/types/task.js";
+import type { GapVector } from "../../../base/types/gap.js";
+import type { DriveContext } from "../../../base/types/drive.js";
+import type { Dimension } from "../../../base/types/goal.js";
+import type { TaskDomain } from "../../../base/types/pipeline.js";
+import type { AdapterRegistry } from "../adapter-layer.js";
+import type { ObservationEngine } from "../../../platform/observation/observation-engine.js";
+import type { Logger } from "../../../runtime/logger.js";
+
+export type SelectTargetDimensionFn = (
+  gapVector: GapVector,
+  driveContext: DriveContext,
+  dimensions?: Dimension[]
+) => string;
+
+export type GenerateTaskFn = (
+  goalId: string,
+  targetDimension: string,
+  strategyId: string | undefined,
+  knowledgeContext?: string,
+  adapterType?: string,
+  existingTasks?: string[],
+  workspaceContext?: string
+) => Promise<Task | null>;
+
+export interface PipelineCycleOptions {
+  knowledgeContext?: string;
+  existingTasks?: string[];
+  workspaceContext?: string;
+  observationEngine?: ObservationEngine;
+  domain?: TaskDomain;
+  adapterRegistry?: AdapterRegistry;
+}
+
+export interface PipelineCycleDeps {
+  stateManager: StateManager;
+  sessionManager: SessionManager;
+  llmClient: ILLMClient;
+  ethicsGate?: EthicsGate;
+  capabilityDetector?: CapabilityDetector;
+  approvalFn: (task: Task) => Promise<boolean>;
+  adapterRegistry?: AdapterRegistry;
+  logger?: Logger;
+  knowledgeManager?: KnowledgeManager;
+  checkIrreversibleApproval: (task: Task) => Promise<boolean>;
+  selectTargetDimension: SelectTargetDimensionFn;
+  generateTask: GenerateTaskFn;
+}

--- a/src/orchestrator/goal/goal-negotiator.ts
+++ b/src/orchestrator/goal/goal-negotiator.ts
@@ -33,19 +33,21 @@ import { EthicsRejectedError } from "./negotiator-context.js";
 export { gatherNegotiationContext, EthicsRejectedError } from "./negotiator-context.js";
 export type { GoalSuggestion } from "./goal-suggest.js";
 import {
-  DEFAULT_TIME_HORIZON_DAYS,
-  REALISTIC_TARGET_ACCELERATION_FACTOR,
-  FEASIBILITY_RATIO_THRESHOLD_REALISTIC,
-  getFeasibilityThreshold,
   runDecompositionStep,
   buildInitialBaseline,
   buildRenegotiationBaseline,
-  evaluateQualitatively,
   runCapabilityCheckStep,
   determineResponseType,
   buildNegotiationResponse,
   estimateChangeRate,
 } from "./negotiator-steps.js";
+import {
+  DEFAULT_TIME_HORIZON_DAYS,
+  REALISTIC_TARGET_ACCELERATION_FACTOR,
+  FEASIBILITY_RATIO_THRESHOLD_REALISTIC,
+  getFeasibilityThreshold,
+  evaluateQualitatively,
+} from "./negotiator-feasibility.js";
 
 // ─── GoalNegotiator ───
 

--- a/src/orchestrator/goal/goal-refiner.ts
+++ b/src/orchestrator/goal/goal-refiner.ts
@@ -27,7 +27,10 @@ import type {
   RefineResult,
 } from "../../base/types/goal-refiner.js";
 import { buildLeafTestPrompt } from "./refiner-prompts.js";
-import { evaluateQualitatively, DEFAULT_TIME_HORIZON_DAYS } from "./negotiator-steps.js";
+import {
+  DEFAULT_TIME_HORIZON_DAYS,
+  evaluateQualitatively,
+} from "./negotiator-feasibility.js";
 
 // ─── Conversion helpers ───
 

--- a/src/orchestrator/goal/negotiator-feasibility.ts
+++ b/src/orchestrator/goal/negotiator-feasibility.ts
@@ -1,0 +1,86 @@
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+import type { IPromptGateway } from "../../prompt/gateway.js";
+import { FeasibilityResultSchema } from "../../base/types/negotiation.js";
+import type { FeasibilityResult } from "../../base/types/negotiation.js";
+import type { CharacterConfig } from "../../base/types/character.js";
+import {
+  buildFeasibilityPrompt,
+  QualitativeFeasibilitySchema,
+} from "./negotiator-prompts.js";
+
+export const FEASIBILITY_RATIO_THRESHOLD_REALISTIC = 1.5;
+export const REALISTIC_TARGET_ACCELERATION_FACTOR = 1.3;
+export const DEFAULT_TIME_HORIZON_DAYS = 90;
+
+export function getFeasibilityThreshold(characterConfig: CharacterConfig): number {
+  return 1.5 + characterConfig.caution_level * 0.5;
+}
+
+export async function evaluateQualitatively(
+  llmClient: ILLMClient,
+  dimensionName: string,
+  goalDescription: string,
+  baselineValue: number | string | boolean | null,
+  thresholdValue: number | string | boolean | (number | string)[] | null,
+  timeHorizonDays: number,
+  gateway?: IPromptGateway
+): Promise<FeasibilityResult> {
+  const prompt = buildFeasibilityPrompt(
+    dimensionName,
+    goalDescription,
+    baselineValue,
+    thresholdValue,
+    timeHorizonDays
+  );
+
+  try {
+    let parsed: {
+      assessment: string;
+      confidence: string;
+      reasoning: string;
+      key_assumptions: string[];
+      main_risks: string[];
+    };
+    if (gateway) {
+      parsed = await gateway.execute({
+        purpose: "negotiation_feasibility",
+        responseSchema: QualitativeFeasibilitySchema,
+        additionalContext: {
+          prompt,
+          dimensionName,
+          goalDescription,
+          baselineValue: String(baselineValue),
+          thresholdValue: String(thresholdValue),
+          timeHorizonDays: String(timeHorizonDays),
+        },
+      });
+    } else {
+      const response = await llmClient.sendMessage(
+        [{ role: "user", content: prompt }],
+        { temperature: 0, model_tier: "main" }
+      );
+      parsed = llmClient.parseJSON(response.content, QualitativeFeasibilitySchema);
+    }
+    return FeasibilityResultSchema.parse({
+      dimension: dimensionName,
+      path: "qualitative",
+      feasibility_ratio: null,
+      assessment: parsed.assessment,
+      confidence: parsed.confidence,
+      reasoning: parsed.reasoning,
+      key_assumptions: parsed.key_assumptions,
+      main_risks: parsed.main_risks,
+    });
+  } catch {
+    return FeasibilityResultSchema.parse({
+      dimension: dimensionName,
+      path: "qualitative",
+      feasibility_ratio: null,
+      assessment: "ambitious",
+      confidence: "low",
+      reasoning: "Failed to parse feasibility assessment, defaulting to ambitious.",
+      key_assumptions: [],
+      main_risks: ["Unable to assess feasibility"],
+    });
+  }
+}

--- a/src/orchestrator/goal/negotiator-steps.ts
+++ b/src/orchestrator/goal/negotiator-steps.ts
@@ -22,12 +22,9 @@ import type {
   NegotiationResponse,
 } from "../../base/types/negotiation.js";
 import type { Dimension } from "../../base/types/goal.js";
-import type { CharacterConfig } from "../../base/types/character.js";
 import {
   buildDecompositionPrompt,
-  buildFeasibilityPrompt,
   buildResponsePrompt,
-  QualitativeFeasibilitySchema,
 } from "./negotiator-prompts.js";
 import {
   buildCapabilityCheckPrompt,
@@ -37,18 +34,16 @@ import {
   deduplicateDimensionKeys,
   findBestDimensionMatch,
 } from "./goal-validation.js";
-
-// ─── Constants ───
-
-export const FEASIBILITY_RATIO_THRESHOLD_REALISTIC = 1.5;
-export const REALISTIC_TARGET_ACCELERATION_FACTOR = 1.3;
-export const DEFAULT_TIME_HORIZON_DAYS = 90;
+import { REALISTIC_TARGET_ACCELERATION_FACTOR } from "./negotiator-feasibility.js";
+export {
+  DEFAULT_TIME_HORIZON_DAYS,
+  FEASIBILITY_RATIO_THRESHOLD_REALISTIC,
+  getFeasibilityThreshold,
+  evaluateQualitatively,
+  REALISTIC_TARGET_ACCELERATION_FACTOR,
+} from "./negotiator-feasibility.js";
 
 // ─── getFeasibilityThreshold ───
-
-export function getFeasibilityThreshold(characterConfig: CharacterConfig): number {
-  return 1.5 + characterConfig.caution_level * 0.5;
-}
 
 // ─── Step 2: Dimension Decomposition ───
 
@@ -158,71 +153,6 @@ export function buildRenegotiationBaseline(
       method: "existing_observation",
     };
   });
-}
-
-// ─── Step 4: Qualitative Feasibility Evaluation ───
-
-export async function evaluateQualitatively(
-  llmClient: ILLMClient,
-  dimensionName: string,
-  goalDescription: string,
-  baselineValue: number | string | boolean | null,
-  thresholdValue: number | string | boolean | (number | string)[] | null,
-  timeHorizonDays: number,
-  gateway?: IPromptGateway
-): Promise<FeasibilityResult> {
-  const prompt = buildFeasibilityPrompt(
-    dimensionName,
-    goalDescription,
-    baselineValue,
-    thresholdValue,
-    timeHorizonDays
-  );
-
-  try {
-    let parsed: { assessment: string; confidence: string; reasoning: string; key_assumptions: string[]; main_risks: string[] };
-    if (gateway) {
-      parsed = await gateway.execute({
-        purpose: "negotiation_feasibility",
-        responseSchema: QualitativeFeasibilitySchema,
-        additionalContext: {
-          prompt,
-          dimensionName,
-          goalDescription,
-          baselineValue: String(baselineValue),
-          thresholdValue: String(thresholdValue),
-          timeHorizonDays: String(timeHorizonDays),
-        },
-      });
-    } else {
-      const response = await llmClient.sendMessage(
-        [{ role: "user", content: prompt }],
-        { temperature: 0, model_tier: 'main' }
-      );
-      parsed = llmClient.parseJSON(response.content, QualitativeFeasibilitySchema);
-    }
-    return FeasibilityResultSchema.parse({
-      dimension: dimensionName,
-      path: "qualitative",
-      feasibility_ratio: null,
-      assessment: parsed.assessment,
-      confidence: parsed.confidence,
-      reasoning: parsed.reasoning,
-      key_assumptions: parsed.key_assumptions,
-      main_risks: parsed.main_risks,
-    });
-  } catch {
-    return FeasibilityResultSchema.parse({
-      dimension: dimensionName,
-      path: "qualitative",
-      feasibility_ratio: null,
-      assessment: "ambitious",
-      confidence: "low",
-      reasoning: "Failed to parse feasibility assessment, defaulting to ambitious.",
-      key_assumptions: [],
-      main_risks: ["Unable to assess feasibility"],
-    });
-  }
 }
 
 // ─── Step 4b: Capability Check ───

--- a/src/orchestrator/loop/core-loop-types.ts
+++ b/src/orchestrator/loop/core-loop-types.ts
@@ -1,17 +1,16 @@
-import { CuriosityEngine } from "../../platform/traits/curiosity-engine.js";
+import type { CuriosityEngine } from "../../platform/traits/curiosity-engine.js";
 import type { IterationBudget } from "./iteration-budget.js";
 import type { Logger } from "../../runtime/logger.js";
 import type { StrategyTemplateRegistry } from "../strategy/strategy-template-registry.js";
 import type { TrustManager } from "../../platform/traits/trust-manager.js";
 import type { KnowledgeTransfer } from "../../platform/knowledge/transfer/knowledge-transfer.js";
-import type { TransferCandidate } from "../../base/types/cross-portfolio.js";
 import type { CrossGoalPortfolio } from "../strategy/cross-goal-portfolio.js";
 import type { GoalTreeManager } from "../goal/goal-tree-manager.js";
 import type { StateAggregator } from "../goal/state-aggregator.js";
 import type { TreeLoopOrchestrator } from "../goal/tree-loop-orchestrator.js";
 import type { StateManager } from "../../base/state/state-manager.js";
 import type { ObservationEngine } from "../../platform/observation/observation-engine.js";
-import type { TaskLifecycle, TaskCycleResult } from "../execution/task/task-lifecycle.js";
+import type { TaskLifecycle } from "../execution/task/task-lifecycle.js";
 import type { SatisficingJudge } from "../../platform/drive/satisficing-judge.js";
 import type { StallDetector } from "../../platform/drive/stall-detector.js";
 import type { StrategyManager } from "../strategy/strategy-manager.js";
@@ -19,22 +18,22 @@ import type { DriveSystem } from "../../platform/drive/drive-system.js";
 import type { AdapterRegistry, IAdapter } from "../execution/adapter-layer.js";
 import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
 import type { CapabilityDetector } from "../../platform/observation/capability-detector.js";
-import type { CapabilityAcquisitionTask } from "../../base/types/capability.js";
 import type { PortfolioManager } from "../strategy/portfolio-manager.js";
 import type { GoalDependencyGraph } from "../goal/goal-dependency-graph.js";
 import type { LearningPipeline } from "../../platform/knowledge/learning/learning-pipeline.js";
-import { DriveScoreAdapter } from "../../platform/knowledge/memory/memory-lifecycle.js";
-import type { MemoryLifecycleManager } from "../../platform/knowledge/memory/memory-lifecycle.js";
+import type { DriveScoreAdapter, MemoryLifecycleManager } from "../../platform/knowledge/memory/memory-lifecycle.js";
 import type { ParallelExecutor } from "../execution/parallel-executor.js";
 import type { GoalRefiner } from "../goal/goal-refiner.js";
 import type { Goal } from "../../base/types/goal.js";
 import type { GapVector } from "../../base/types/gap.js";
 import type { DriveContext, DriveScore } from "../../base/types/drive.js";
-import type { CompletionJudgment } from "../../base/types/satisficing.js";
-import type { StallReport, StallAnalysis } from "../../base/types/stall.js";
 import type { ToolExecutor } from "../../tools/executor.js";
 import type { ToolRegistry } from "../../tools/registry.js";
-import type { VerificationLayer1Result } from "./verification-layer1.js";
+export type {
+  LoopIterationResult,
+  LoopResult,
+} from "./loop-result-types.js";
+export { makeEmptyIterationResult } from "./loop-result-types.js";
 
 
 // ─── GapCalculator module interface (pure functions) ───
@@ -143,92 +142,6 @@ export interface LoopConfig {
    * Default: 20.
    */
   consolidationRawThreshold?: number;
-}
-
-// ─── Result types ───
-
-export interface LoopIterationResult {
-  loopIndex: number;
-  goalId: string;
-  gapAggregate: number;
-  driveScores: DriveScore[];
-  taskResult: TaskCycleResult | null;
-  stallDetected: boolean;
-  stallReport: StallReport | null;
-  /** M14-S2: cause analysis result when a stall is detected */
-  stallAnalysis?: StallAnalysis;
-  pivotOccurred: boolean;
-  completionJudgment: CompletionJudgment;
-  elapsedMs: number;
-  error: string | null;
-  /** Alerts for milestones that are at_risk or behind (optional) */
-  milestoneAlerts?: Array<{ goalId: string; status: string; pace_ratio: number }>;
-  /** Transfer candidates detected from cross-goal knowledge (suggestion-only, Phase 1) */
-  transfer_candidates?: TransferCandidate[];
-  /** Total tokens consumed by LLM calls during this iteration (task generation + verification). */
-  tokensUsed?: number;
-  /**
-   * When true, this iteration was skipped because no meaningful state change was
-   * detected (Pillar 2: State Diff + Loop Skip). Only observation ran; gap
-   * calculation, task generation, execution, and verification were bypassed.
-   */
-  skipped?: boolean;
-  /** Reason for the skip, when skipped=true. */
-  skipReason?: string;
-  /** Result from Phase 7 tool-based verification (Layer 1). Present when toolExecutor is set and task has success_criteria. */
-  toolVerification?: VerificationLayer1Result;
-  /** Tool-based workspace evidence gathered during stall detection (Phase 6). */
-  toolStallEvidence?: import("./stall-evidence.js").StallEvidence;
-  /** True when stall detection was suppressed by an active WaitStrategy plateau_until. */
-  waitSuppressed?: boolean;
-  /** True when a WaitStrategy reached its wait_until expiry this iteration. */
-  waitExpired?: boolean;
-  /** Strategy ID of the active WaitStrategy, if any. */
-  waitStrategyId?: string;
-}
-
-/**
- * Factory that returns a zeroed-out LoopIterationResult for the given goalId
- * and loopIndex. Accepts optional overrides for fields that vary per call-site.
- */
-export function makeEmptyIterationResult(
-  goalId: string,
-  loopIndex: number,
-  overrides?: Partial<LoopIterationResult>
-): LoopIterationResult {
-  return {
-    loopIndex,
-    goalId,
-    gapAggregate: 0,
-    driveScores: [],
-    taskResult: null,
-    stallDetected: false,
-    stallReport: null,
-    pivotOccurred: false,
-    completionJudgment: {
-      is_complete: false,
-      blocking_dimensions: [],
-      low_confidence_dimensions: [],
-      needs_verification_task: false,
-      checked_at: new Date().toISOString(),
-    },
-    elapsedMs: 0,
-    error: null,
-    ...overrides,
-  };
-}
-
-export interface LoopResult {
-  goalId: string;
-  totalIterations: number;
-  finalStatus: "completed" | "stalled" | "max_iterations" | "error" | "stopped";
-  iterations: LoopIterationResult[];
-  startedAt: string;
-  completedAt: string;
-  /** Human-readable explanation when finalStatus is "error" */
-  errorMessage?: string;
-  /** Total tokens consumed across all iterations */
-  tokensUsed?: number;
 }
 
 // ─── Dependencies ───

--- a/src/orchestrator/loop/core-loop.ts
+++ b/src/orchestrator/loop/core-loop.ts
@@ -6,12 +6,11 @@ import { saveLoopCheckpoint, restoreLoopCheckpoint } from "./checkpoint-manager-
 import { runPostLoopHooks } from "./post-loop-hooks.js";
 import { generateLoopReport } from "./loop-report-helper.js";
 
-import { makeEmptyIterationResult } from "./core-loop-types.js";
+import { makeEmptyIterationResult } from "./loop-result-types.js";
+import type { LoopIterationResult, LoopResult } from "./loop-result-types.js";
 import type {
   LoopConfig,
   ResolvedLoopConfig,
-  LoopIterationResult,
-  LoopResult,
   CoreLoopDeps,
 } from "./core-loop-types.js";
 import {
@@ -52,13 +51,16 @@ export type {
   ReportingEngine,
   LoopConfig,
   ResolvedLoopConfig,
-  LoopIterationResult,
-  LoopResult,
   CoreLoopDeps,
   ProgressEvent,
   ProgressPhase,
 } from "./core-loop-types.js";
-export { buildDriveContext, makeEmptyIterationResult } from "./core-loop-types.js";
+export type {
+  LoopIterationResult,
+  LoopResult,
+} from "./loop-result-types.js";
+export { buildDriveContext } from "./core-loop-types.js";
+export { makeEmptyIterationResult } from "./loop-result-types.js";
 
 const DEFAULT_CONFIG: Required<Omit<LoopConfig, "iterationBudget">> = {
   maxIterations: 100,

--- a/src/orchestrator/loop/loop-result-types.ts
+++ b/src/orchestrator/loop/loop-result-types.ts
@@ -1,0 +1,90 @@
+import type { DriveScore } from "../../base/types/drive.js";
+import type { CompletionJudgment } from "../../base/types/satisficing.js";
+import type { StallAnalysis, StallReport } from "../../base/types/stall.js";
+import type { TransferCandidate } from "../../base/types/cross-portfolio.js";
+import type { TaskCycleResult } from "../execution/task/task-execution-types.js";
+import type { VerificationLayer1Result } from "./verification-layer1.js";
+
+export interface LoopIterationResult {
+  loopIndex: number;
+  goalId: string;
+  gapAggregate: number;
+  driveScores: DriveScore[];
+  taskResult: TaskCycleResult | null;
+  stallDetected: boolean;
+  stallReport: StallReport | null;
+  /** M14-S2: cause analysis result when a stall is detected */
+  stallAnalysis?: StallAnalysis;
+  pivotOccurred: boolean;
+  completionJudgment: CompletionJudgment;
+  elapsedMs: number;
+  error: string | null;
+  /** Alerts for milestones that are at_risk or behind (optional) */
+  milestoneAlerts?: Array<{ goalId: string; status: string; pace_ratio: number }>;
+  /** Transfer candidates detected from cross-goal knowledge (suggestion-only, Phase 1) */
+  transfer_candidates?: TransferCandidate[];
+  /** Total tokens consumed by LLM calls during this iteration (task generation + verification). */
+  tokensUsed?: number;
+  /**
+   * When true, this iteration was skipped because no meaningful state change was
+   * detected (Pillar 2: State Diff + Loop Skip). Only observation ran; gap
+   * calculation, task generation, execution, and verification were bypassed.
+   */
+  skipped?: boolean;
+  /** Reason for the skip, when skipped=true. */
+  skipReason?: string;
+  /** Result from Phase 7 tool-based verification (Layer 1). Present when toolExecutor is set and task has success_criteria. */
+  toolVerification?: VerificationLayer1Result;
+  /** Tool-based workspace evidence gathered during stall detection (Phase 6). */
+  toolStallEvidence?: import("./stall-evidence.js").StallEvidence;
+  /** True when stall detection was suppressed by an active WaitStrategy plateau_until. */
+  waitSuppressed?: boolean;
+  /** True when a WaitStrategy reached its wait_until expiry this iteration. */
+  waitExpired?: boolean;
+  /** Strategy ID of the active WaitStrategy, if any. */
+  waitStrategyId?: string;
+}
+
+/**
+ * Factory that returns a zeroed-out LoopIterationResult for the given goalId
+ * and loopIndex. Accepts optional overrides for fields that vary per call-site.
+ */
+export function makeEmptyIterationResult(
+  goalId: string,
+  loopIndex: number,
+  overrides?: Partial<LoopIterationResult>
+): LoopIterationResult {
+  return {
+    loopIndex,
+    goalId,
+    gapAggregate: 0,
+    driveScores: [],
+    taskResult: null,
+    stallDetected: false,
+    stallReport: null,
+    pivotOccurred: false,
+    completionJudgment: {
+      is_complete: false,
+      blocking_dimensions: [],
+      low_confidence_dimensions: [],
+      needs_verification_task: false,
+      checked_at: new Date().toISOString(),
+    },
+    elapsedMs: 0,
+    error: null,
+    ...overrides,
+  };
+}
+
+export interface LoopResult {
+  goalId: string;
+  totalIterations: number;
+  finalStatus: "completed" | "stalled" | "max_iterations" | "error" | "stopped";
+  iterations: LoopIterationResult[];
+  startedAt: string;
+  completedAt: string;
+  /** Human-readable explanation when finalStatus is "error" */
+  errorMessage?: string;
+  /** Total tokens consumed across all iterations */
+  tokensUsed?: number;
+}

--- a/src/platform/dream/__tests__/dream-log-collector.test.ts
+++ b/src/platform/dream/__tests__/dream-log-collector.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { DreamLogCollector } from "../dream-log-collector.js";
 import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
-import type { LoopIterationResult } from "../../../orchestrator/loop/core-loop-types.js";
+import type { LoopIterationResult } from "../../../orchestrator/loop/loop-result-types.js";
 
 function makeIterationResult(goalId: string): LoopIterationResult {
   return {

--- a/src/platform/dream/dream-log-collector.ts
+++ b/src/platform/dream/dream-log-collector.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { randomUUID } from "node:crypto";
 import { writeJsonFileAtomic } from "../../base/utils/json-io.js";
 import type { Logger } from "../../runtime/logger.js";
-import type { LoopIterationResult, LoopResult } from "../../orchestrator/loop/core-loop-types.js";
+import type { LoopIterationResult, LoopResult } from "../../orchestrator/loop/loop-result-types.js";
 import type { DriveScore } from "../../base/types/drive.js";
 import {
   EventLogSchema,

--- a/src/reporting/report-formatters.ts
+++ b/src/reporting/report-formatters.ts
@@ -1,6 +1,6 @@
 import type { Report } from "../base/types/report.js";
 import type { CharacterConfig } from "../base/types/character.js";
-import type { ExecutionSummaryParams, NotificationType, NotificationContext } from "./reporting-engine.js";
+import type { ExecutionSummaryParams, NotificationType, NotificationContext } from "./reporting-types.js";
 
 // ─── getVerbosityLevel ───
 

--- a/src/reporting/reporting-engine.ts
+++ b/src/reporting/reporting-engine.ts
@@ -13,32 +13,11 @@ import {
   buildExecutionSummaryContent,
   buildNotificationContent,
 } from "./report-formatters.js";
-
-// ─── Types ───
-
-export type ExecutionSummaryParams = {
-  goalId: string;
-  loopIndex: number;
-  observation: { dimensionName: string; progress: number; confidence: number }[];
-  gapAggregate: number;
-  taskResult: { taskId: string; action: string; dimension: string } | null;
-  stallDetected: boolean;
-  pivotOccurred: boolean;
-  elapsedMs: number;
-};
-
-export type NotificationType =
-  | "urgent"
-  | "approval_required"
-  | "stall_escalation"
-  | "completed"
-  | "capability_insufficient";
-
-export type NotificationContext = {
-  goalId: string;
-  message: string;
-  details?: string;
-};
+import type {
+  ExecutionSummaryParams,
+  NotificationContext,
+  NotificationType,
+} from "./reporting-types.js";
 
 // ─── ReportingEngine ───
 
@@ -546,4 +525,9 @@ export class ReportingEngine {
 }
 
 // ─── Re-exports ───
+export type {
+  ExecutionSummaryParams,
+  NotificationContext,
+  NotificationType,
+} from "./reporting-types.js";
 export { formatReportForCLI, buildExecutionSummaryContent, buildNotificationContent } from "./report-formatters.js";

--- a/src/reporting/reporting-types.ts
+++ b/src/reporting/reporting-types.ts
@@ -1,0 +1,23 @@
+export type ExecutionSummaryParams = {
+  goalId: string;
+  loopIndex: number;
+  observation: { dimensionName: string; progress: number; confidence: number }[];
+  gapAggregate: number;
+  taskResult: { taskId: string; action: string; dimension: string } | null;
+  stallDetected: boolean;
+  pivotOccurred: boolean;
+  elapsedMs: number;
+};
+
+export type NotificationType =
+  | "urgent"
+  | "approval_required"
+  | "stall_escalation"
+  | "completed"
+  | "capability_insufficient";
+
+export type NotificationContext = {
+  goalId: string;
+  message: string;
+  details?: string;
+};


### PR DESCRIPTION
## Summary
- extract shared loop, reporting, execution, and goal feasibility types into neutral modules
- replace type-only cross-module imports in state, reporting, task pipeline, and parallel execution paths
- keep existing public import surfaces via targeted type re-exports where needed

## Verification
- npx madge --circular --extensions ts src
- npx vitest run src/platform/dream/__tests__/dream-log-collector.test.ts src/orchestrator/loop/__tests__/core-loop-types.test.ts src/orchestrator/loop/__tests__/core-loop-checkpoint.test.ts src/reporting/__tests__/reporting-engine.test.ts src/orchestrator/execution/__tests__/parallel-executor.test.ts src/orchestrator/execution/__tests__/result-reconciler.test.ts
- npx vitest run src/orchestrator/execution/__tests__/task-lifecycle.test.ts src/orchestrator/execution/__tests__/task-lifecycle-cycle.test.ts src/orchestrator/execution/__tests__/task-lifecycle-cycle-helpers.test.ts
- npx vitest run src/orchestrator/goal/__tests__/goal-negotiator-character.test.ts src/orchestrator/goal/__tests__/goal-negotiator-negotiate.test.ts src/orchestrator/goal/__tests__/goal-refiner.refine.test.ts