### PR TITLE
feat(chat): add schedule management tools for chat-native operations

### DIFF
--- a/src/interface/chat/__tests__/chat-schedule-integration.test.ts
+++ b/src/interface/chat/__tests__/chat-schedule-integration.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { z } from "zod";
+
+import { ChatRunner } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { StateManager } from "../../../base/state/state-manager.js";
+import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
+import { ToolRegistry } from "../../../tools/registry.js";
+import { createBuiltinTools } from "../../../tools/builtin/index.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import { ScheduleEntrySchema } from "../../../runtime/types/schedule.js";
+
+vi.mock("../../../platform/observation/context-provider.js", () => ({
+  resolveGitRoot: (cwd: string) => cwd,
+  buildChatContext: async () => "",
+}));
+
+vi.mock("../grounding.js", () => ({
+  buildStaticSystemPrompt: () => "",
+  buildDynamicContextPrompt: async () => "",
+}));
+
+function makeMockStateManager(): StateManager {
+  return {
+    writeRaw: vi.fn().mockResolvedValue(undefined),
+    readRaw: vi.fn().mockResolvedValue(null),
+    listGoalIds: vi.fn().mockResolvedValue([]),
+    loadGoal: vi.fn().mockResolvedValue(null),
+  } as unknown as StateManager;
+}
+
+function makeMockAdapter(): IAdapter {
+  return {
+    adapterType: "mock",
+    execute: vi.fn().mockResolvedValue({
+      success: true,
+      output: "",
+      error: null,
+      exit_code: 0,
+      elapsed_ms: 1,
+      stopped_reason: "completed",
+    }),
+  } as unknown as IAdapter;
+}
+
+function makeScheduleEntry(overrides: Partial<z.input<typeof ScheduleEntrySchema>> = {}) {
+  return ScheduleEntrySchema.parse({
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "daily digest",
+    layer: "cron",
+    trigger: { type: "cron", expression: "0 9 * * *", timezone: "UTC" },
+    enabled: true,
+    cron: {
+      prompt_template: "Summarize the latest activity.",
+      context_sources: ["memory://daily"],
+      output_format: "notification",
+      max_tokens: 1200,
+    },
+    baseline_results: [],
+    created_at: "2026-04-08T00:00:00.000Z",
+    updated_at: "2026-04-08T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-04-09T09:00:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+    ...overrides,
+  });
+}
+
+function makeScheduleEngine(entries: ReturnType<typeof makeScheduleEntry>[] = []) {
+  return {
+    getEntries: vi.fn().mockReturnValue(entries),
+    getDueEntries: vi.fn().mockResolvedValue(entries),
+    addEntry: vi.fn().mockResolvedValue(makeScheduleEntry()),
+    updateEntry: vi.fn().mockResolvedValue(null),
+    removeEntry: vi.fn().mockResolvedValue(false),
+  } as unknown as ScheduleEngine;
+}
+
+function buildRegistry(scheduleEngine: ScheduleEngine): ToolRegistry {
+  const stateManager = makeMockStateManager();
+  const trustManager = {
+    getBalance: vi.fn().mockResolvedValue({ balance: 0 }),
+    setOverride: vi.fn().mockResolvedValue(undefined),
+  };
+  const registry = new ToolRegistry();
+
+  for (const tool of createBuiltinTools({
+    stateManager,
+    trustManager: trustManager as never,
+    registry,
+    scheduleEngine,
+  })) {
+    registry.register(tool);
+  }
+
+  return registry;
+}
+
+function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
+  return {
+    stateManager: makeMockStateManager(),
+    adapter: makeMockAdapter(),
+    ...overrides,
+  };
+}
+
+describe("ChatRunner schedule integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("exposes schedule tools when the registry is built with a ScheduleEngine", async () => {
+    const registry = buildRegistry(makeScheduleEngine());
+    const llmClient = {
+      supportsToolCalling: () => true,
+      sendMessage: vi.fn().mockImplementation(async (_messages, options) => ({
+        content: JSON.stringify({
+          seenTools: (options?.tools ?? []).map((tool: { function: { name: string } }) => tool.function.name),
+        }),
+        tool_calls: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+        stop_reason: "completed",
+      })),
+    };
+
+    const runner = new ChatRunner(makeDeps({ registry, llmClient: llmClient as never }));
+    const result = await runner.execute("show me the available tools", "/tmp");
+    const parsed = JSON.parse(result.output) as { seenTools: string[] };
+
+    expect(parsed.seenTools).toContain("list_schedules");
+    expect(registry.get("create_schedule")).toBeDefined();
+    expect(registry.get("list_schedules")).toBeDefined();
+  });
+
+  it("runs list_schedules through the chat tool execution path", async () => {
+    const entry = makeScheduleEntry();
+    const scheduleEngine = makeScheduleEngine([entry]);
+    const registry = buildRegistry(scheduleEngine);
+    const llmClient = {
+      supportsToolCalling: () => true,
+      sendMessage: vi.fn()
+        .mockResolvedValueOnce({
+          content: "",
+          tool_calls: [
+            {
+              id: "tool-call-1",
+              function: {
+                name: "list_schedules",
+                arguments: JSON.stringify({}),
+              },
+            },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "tool_use",
+        })
+        .mockResolvedValueOnce({
+          content: "Listed schedules",
+          tool_calls: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "completed",
+        }),
+    };
+
+    const runner = new ChatRunner(makeDeps({ registry, llmClient: llmClient as never }));
+    await runner.execute("list schedules", "/tmp");
+
+    expect(vi.mocked(scheduleEngine.getEntries)).toHaveBeenCalledTimes(1);
+    const secondCallMessages = llmClient.sendMessage.mock.calls[1]?.[0] as Array<{ role: string; content: string }>;
+    const toolResultMessage = secondCallMessages.find(
+      (message) => message.role === "user" && message.content.startsWith("Tool result for list_schedules:\n"),
+    );
+
+    expect(toolResultMessage).toBeDefined();
+    expect(toolResultMessage?.content).toContain(entry.id);
+    expect(toolResultMessage?.content).toContain(entry.name);
+  });
+
+  it("routes create_schedule through approvalFn before executing", async () => {
+    const createdEntry = makeScheduleEntry({ id: "22222222-2222-4222-8222-222222222222", name: "heartbeat check" });
+    const scheduleEngine = makeScheduleEngine();
+    vi.mocked(scheduleEngine.addEntry).mockResolvedValue(createdEntry);
+    const registry = buildRegistry(scheduleEngine);
+    const approvalFn = vi.fn().mockResolvedValue(true);
+    const llmClient = {
+      supportsToolCalling: () => true,
+      sendMessage: vi.fn()
+        .mockResolvedValueOnce({
+          content: "",
+          tool_calls: [
+            {
+              id: "tool-call-1",
+              function: {
+                name: "create_schedule",
+                arguments: JSON.stringify({
+                  name: "heartbeat check",
+                  layer: "heartbeat",
+                  trigger: { type: "interval", seconds: 30 },
+                  heartbeat: {
+                    check_type: "http",
+                    check_config: { url: "https://example.com/health" },
+                  },
+                }),
+              },
+            },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "tool_use",
+        })
+        .mockResolvedValueOnce({
+          content: "Created schedule",
+          tool_calls: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "completed",
+        }),
+    };
+
+    const runner = new ChatRunner(makeDeps({
+      registry,
+      llmClient: llmClient as never,
+      approvalFn,
+    }));
+
+    await runner.execute("create a schedule", "/tmp");
+
+    expect(approvalFn).toHaveBeenCalledOnce();
+    expect(approvalFn).toHaveBeenCalledWith(
+      "Creating a persistent schedule changes background automation and requires approval",
+    );
+    expect(vi.mocked(scheduleEngine.addEntry)).toHaveBeenCalledOnce();
+  });
+});

--- a/src/interface/cli/commands/chat.ts
+++ b/src/interface/cli/commands/chat.ts
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useEffect } from "react";
 import { render, useApp } from "ink";
 import { parseArgs } from "node:util";
 import { randomUUID } from "node:crypto";
+import { createInterface } from "node:readline";
 
 import { StateManager } from "../../../base/state/state-manager.js";
 import { ensureProviderConfig } from "../ensure-api-key.js";
@@ -18,9 +19,36 @@ import { ObservationEngine } from "../../../platform/observation/observation-eng
 import { GoalNegotiator } from "../../../orchestrator/goal/goal-negotiator.js";
 import { EscalationHandler } from "../../chat/escalation.js";
 import { DaemonClient, isDaemonRunning } from "../../../runtime/daemon-client.js";
+import { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import { TrustManager } from "../../../platform/traits/trust-manager.js";
+import { ToolRegistry } from "../../../tools/registry.js";
+import { createBuiltinTools } from "../../../tools/builtin/index.js";
 import { applyChatEventToMessages } from "../../chat/chat-event-state.js";
 
 const logger = getCliLogger();
+
+async function promptChatApproval(reason: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return false;
+
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (approved: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(approved);
+    };
+
+    rl.question(`\n⚠ Approval required: ${reason}\nProceed? [y/N] `, (answer) => {
+      const normalized = answer.trim().toLowerCase();
+      finish(normalized === "y" || normalized === "yes");
+      rl.close();
+    });
+
+    rl.once("close", () => finish(false));
+  });
+}
 
 // ─── Interactive REPL component ───
 
@@ -157,6 +185,19 @@ export async function cmdChat(
     const llmClient = await buildLLMClient();
     const adapterRegistry = await buildAdapterRegistry(llmClient);
     const adapter = adapterRegistry.getAdapter(adapterType);
+    const pulseedDir = process.env["PULSEED_DIR"] ?? `${process.env["HOME"] ?? "~"}/.pulseed`;
+    const trustManager = new TrustManager(stateManager);
+    const scheduleEngine = new ScheduleEngine({ baseDir: pulseedDir });
+    await scheduleEngine.loadEntries();
+    const registry = new ToolRegistry();
+    for (const tool of createBuiltinTools({
+      stateManager,
+      trustManager,
+      registry,
+      scheduleEngine,
+    })) {
+      registry.register(tool);
+    }
 
     // Build escalation + tend deps (optional — /track and /tend work only when LLM is available)
     let escalationHandler: EscalationHandler | undefined;
@@ -176,7 +217,6 @@ export async function cmdChat(
     let daemonClient: DaemonClient | undefined;
     let daemonBaseUrl: string | undefined;
     try {
-      const pulseedDir = process.env["PULSEED_DIR"] ?? `${process.env["HOME"] ?? "~"}/.pulseed`;
       const daemonInfo = await isDaemonRunning(pulseedDir);
       if (daemonInfo.running) {
         daemonClient = new DaemonClient({ host: "127.0.0.1", port: daemonInfo.port });
@@ -195,6 +235,8 @@ export async function cmdChat(
       goalNegotiator: goalNegotiatorForTend,
       daemonClient,
       daemonBaseUrl,
+      registry,
+      approvalFn: promptChatApproval,
     });
 
     // Non-interactive: single turn

--- a/src/interface/cli/commands/chat.ts
+++ b/src/interface/cli/commands/chat.ts
@@ -185,7 +185,7 @@ export async function cmdChat(
     const llmClient = await buildLLMClient();
     const adapterRegistry = await buildAdapterRegistry(llmClient);
     const adapter = adapterRegistry.getAdapter(adapterType);
-    const pulseedDir = process.env["PULSEED_DIR"] ?? `${process.env["HOME"] ?? "~"}/.pulseed`;
+    const pulseedDir = stateManager.getBaseDir();
     const trustManager = new TrustManager(stateManager);
     const scheduleEngine = new ScheduleEngine({ baseDir: pulseedDir });
     await scheduleEngine.loadEntries();

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -8,6 +8,7 @@
 import os from "os";
 import path from "path";
 import { execFileSync } from "child_process";
+import { randomUUID } from "node:crypto";
 
 import { StateManager } from "../../base/state/state-manager.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
@@ -89,6 +90,7 @@ async function buildDeps() {
   const { StateAggregator } = await import("../../orchestrator/goal/state-aggregator.js");
   const { GoalDependencyGraph } = await import("../../orchestrator/goal/goal-dependency-graph.js");
   const { TreeLoopOrchestrator } = await import("../../orchestrator/goal/tree-loop-orchestrator.js");
+  const { ScheduleEngine } = await import("../../runtime/schedule-engine.js");
   const { MemoryLifecycleManager, DriveScoreAdapter } = await import("../../platform/knowledge/memory/memory-lifecycle.js");
   const { CharacterConfigManager } = await import("../../platform/traits/character-config.js");
   const { ChatRunner } = await import("../../interface/chat/chat-runner.js");
@@ -104,8 +106,10 @@ async function buildDeps() {
   const llmClient = await buildLLMClient();
   const trustManager = new TrustManager(stateManager);
   const driveSystem = new DriveSystem(stateManager);
+  const scheduleEngine = new ScheduleEngine({ baseDir: stateManager.getBaseDir() });
+  await scheduleEngine.loadEntries();
   const toolRegistry = new ToolRegistry();
-  for (const tool of createBuiltinTools({ stateManager, trustManager })) {
+  for (const tool of createBuiltinTools({ stateManager, trustManager, registry: toolRegistry, scheduleEngine })) {
     toolRegistry.register(tool);
   }
 
@@ -172,13 +176,47 @@ async function buildDeps() {
   let requestApproval: ((req: ApprovalRequest) => void) | null = null;
   const pendingApprovals: ApprovalRequest[] = [];
 
-  const approvalFn = (task: Task): Promise<boolean> => {
+  const enqueueApproval = (task: Task): Promise<boolean> => {
     return new Promise((resolve) => {
+      const request = { task, resolve };
       if (requestApproval) {
-        requestApproval({ task, resolve });
+        requestApproval(request);
       } else {
-        pendingApprovals.push({ task, resolve });
+        pendingApprovals.push(request);
       }
+    });
+  };
+
+  const approvalFn = (task: Task): Promise<boolean> => enqueueApproval(task);
+
+  const chatToolApprovalFn = async (description: string): Promise<boolean> => {
+    return enqueueApproval({
+      id: randomUUID(),
+      goal_id: "chat-tool-approval",
+      strategy_id: null,
+      target_dimensions: ["approval"],
+      primary_dimension: "approval",
+      work_description: description,
+      rationale: "Requested by chat tool execution",
+      approach: "Wait for explicit approval before continuing the chat tool call.",
+      success_criteria: [],
+      scope_boundary: {
+        in_scope: ["Approve or reject the pending chat tool action."],
+        out_of_scope: ["Execute any work beyond the requested chat tool action."],
+        blast_radius: "Limited to whether the pending chat tool call proceeds.",
+      },
+      constraints: [],
+      plateau_until: null,
+      estimated_duration: null,
+      consecutive_failure_count: 0,
+      reversibility: "unknown",
+      task_category: "normal",
+      status: "pending",
+      started_at: null,
+      completed_at: null,
+      timeout_at: null,
+      heartbeat_at: null,
+      created_at: new Date().toISOString(),
     });
   };
 
@@ -278,7 +316,15 @@ async function buildDeps() {
     const provConfig = await loadProviderConfig();
     const adapterType = provConfig.adapter ?? "claude_code_cli";
     const adapter = adapterRegistry.getAdapter(adapterType);
-    chatRunner = new ChatRunner({ stateManager, adapter, llmClient, trustManager, registry: toolRegistry, toolExecutor });
+    chatRunner = new ChatRunner({
+      stateManager,
+      adapter,
+      llmClient,
+      trustManager,
+      registry: toolRegistry,
+      toolExecutor,
+      approvalFn: chatToolApprovalFn,
+    });
   } catch (err) {
     getCliLogger().warn(`[pulseed] ChatRunner init failed — free-form chat disabled: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -14,6 +14,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
   cleanupTempDir(tempDir);
 });
 
@@ -75,6 +77,232 @@ describe("ScheduleEngine", () => {
     const engine2 = new ScheduleEngine({ baseDir: tempDir });
     const loaded = await engine2.loadEntries();
     expect(loaded).toHaveLength(0);
+  });
+
+  it("updateEntry returns null when entry is not found", async () => {
+    const updated = await engine.updateEntry("missing-id", {
+      name: "updated-name",
+    });
+
+    expect(updated).toBeNull();
+  });
+
+  it("updateEntry throws on empty patch", async () => {
+    const entry = await engine.addEntry({
+      name: "empty-patch-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    await expect(engine.updateEntry(entry.id, {})).rejects.toThrow("No updatable fields provided");
+  });
+
+  it("updateEntry updates allowed fields, clears escalation, and persists", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T00:00:00.000Z"));
+
+    const entry = await engine.addEntry({
+      name: "updatable-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+      escalation: {
+        enabled: true,
+        target_layer: "cron",
+        cooldown_minutes: 10,
+        max_per_hour: 3,
+        circuit_breaker_threshold: 5,
+      },
+    });
+
+    vi.setSystemTime(new Date("2026-04-08T01:02:03.000Z"));
+
+    const updated = await engine.updateEntry(entry.id, {
+      name: "updated-check",
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo changed" },
+        failure_threshold: 5,
+        timeout_ms: 9000,
+      },
+      escalation: null,
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.name).toBe("updated-check");
+    expect(updated!.heartbeat).toEqual({
+      check_type: "custom",
+      check_config: { command: "echo changed" },
+      failure_threshold: 5,
+      timeout_ms: 9000,
+    });
+    expect(updated!.escalation).toBeUndefined();
+    expect(updated!.updated_at).toBe("2026-04-08T01:02:03.000Z");
+    expect(updated!.created_at).toBe(entry.created_at);
+
+    const engine2 = new ScheduleEngine({ baseDir: tempDir });
+    const loaded = await engine2.loadEntries();
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]!.name).toBe("updated-check");
+    expect(loaded[0]!.heartbeat).toEqual({
+      check_type: "custom",
+      check_config: { command: "echo changed" },
+      failure_threshold: 5,
+      timeout_ms: 9000,
+    });
+    expect(loaded[0]!.escalation).toBeUndefined();
+  });
+
+  it("updateEntry recomputes next_fire_at when trigger changes", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T00:00:00.000Z"));
+
+    const entry = await engine.addEntry({
+      name: "trigger-update-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    vi.setSystemTime(new Date("2026-04-08T00:10:00.000Z"));
+
+    const updated = await engine.updateEntry(entry.id, {
+      trigger: { type: "interval", seconds: 3600, jitter_factor: 0 },
+    });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.trigger).toEqual({ type: "interval", seconds: 3600, jitter_factor: 0 });
+    expect(updated!.next_fire_at).toBe("2026-04-08T01:10:00.000Z");
+    expect(updated!.next_fire_at).not.toBe(entry.next_fire_at);
+  });
+
+  it("updateEntry recomputes next_fire_at when re-enabling an entry", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T02:00:00.000Z"));
+
+    const entry = await engine.addEntry({
+      name: "resume-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+      enabled: false,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    const entries = engine.getEntries();
+    entries[0]!.next_fire_at = "2026-04-07T00:00:00.000Z";
+    await engine.saveEntries();
+
+    const updated = await engine.updateEntry(entry.id, { enabled: true });
+
+    expect(updated).not.toBeNull();
+    expect(updated!.enabled).toBe(true);
+    expect(updated!.next_fire_at).toBe("2026-04-08T02:01:00.000Z");
+    expect(updated!.next_fire_at).not.toBe("2026-04-07T00:00:00.000Z");
+  });
+
+  it("updateEntry rejects layer config updates that do not match the entry layer", async () => {
+    const entry = await engine.addEntry({
+      name: "layer-mismatch-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    await expect(engine.updateEntry(entry.id, {
+      probe: {
+        data_source_id: "source-1",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+    })).rejects.toThrow("Cannot update probe config for heartbeat entry");
+  });
+
+  it("updateEntry revalidates the merged entry", async () => {
+    const entry = await engine.addEntry({
+      name: "validation-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    await expect(engine.updateEntry(entry.id, {
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo bad" },
+        failure_threshold: 0,
+        timeout_ms: 5000,
+      },
+    })).rejects.toThrow();
+
+    expect(engine.getEntries().find((candidate) => candidate.id === entry.id)!.heartbeat).toEqual(
+      entry.heartbeat
+    );
+  });
+
+  it("updateEntry restores in-memory entries when save fails", async () => {
+    const entry = await engine.addEntry({
+      name: "save-rollback-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    vi.spyOn(engine, "saveEntries").mockRejectedValueOnce(new Error("save failed"));
+
+    await expect(engine.updateEntry(entry.id, {
+      name: "should-not-stick",
+    })).rejects.toThrow("save failed");
+
+    expect(engine.getEntries().find((candidate) => candidate.id === entry.id)!.name).toBe(
+      "save-rollback-check"
+    );
+
+    const engine2 = new ScheduleEngine({ baseDir: tempDir });
+    const loaded = await engine2.loadEntries();
+    expect(loaded.find((candidate) => candidate.id === entry.id)!.name).toBe("save-rollback-check");
   });
 
   it("getDueEntries returns entries past their next_fire_at", async () => {

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -8,6 +8,11 @@ import {
   ScheduleEntrySchema,
   ScheduleEntryListSchema,
   ScheduleResultSchema,
+  type CronConfig,
+  type EscalationConfig,
+  type GoalTriggerConfig,
+  type HeartbeatConfig,
+  type ProbeConfig,
   type ScheduleEntry,
   type ScheduleEntryInput,
   type ScheduleResult,
@@ -44,6 +49,17 @@ const noopLogger = {
   warn: (_msg: string, _ctx?: Record<string, unknown>) => {},
   error: (_msg: string, _ctx?: Record<string, unknown>) => {},
 };
+
+export type ScheduleEntryUpdateInput = Partial<{
+  name: string;
+  enabled: boolean;
+  trigger: ScheduleTriggerInput;
+  heartbeat: HeartbeatConfig;
+  probe: ProbeConfig;
+  cron: CronConfig;
+  goal_trigger: GoalTriggerConfig;
+  escalation: EscalationConfig | null;
+}>;
 
 export class ScheduleEngine {
   private entries: ScheduleEntry[] = [];
@@ -134,6 +150,82 @@ export class ScheduleEngine {
     if (this.entries.length === before) return false;
     await this.saveEntries();
     return true;
+  }
+
+  async updateEntry(
+    id: string,
+    patch: ScheduleEntryUpdateInput
+  ): Promise<ScheduleEntry | null> {
+    const idx = this.entries.findIndex((entry) => entry.id === id);
+    if (idx === -1) return null;
+
+    const hasUpdatableFields =
+      patch.name !== undefined ||
+      patch.enabled !== undefined ||
+      patch.trigger !== undefined ||
+      patch.heartbeat !== undefined ||
+      patch.probe !== undefined ||
+      patch.cron !== undefined ||
+      patch.goal_trigger !== undefined ||
+      patch.escalation !== undefined;
+
+    if (!hasUpdatableFields) {
+      throw new Error("No updatable fields provided");
+    }
+
+    const current = this.entries[idx]!;
+    const layerConfigFields = [
+      ["heartbeat", patch.heartbeat],
+      ["probe", patch.probe],
+      ["cron", patch.cron],
+      ["goal_trigger", patch.goal_trigger],
+    ] as const;
+
+    for (const [field, value] of layerConfigFields) {
+      if (value === undefined) continue;
+      if (current.layer !== field) {
+        throw new Error(`Cannot update ${field} config for ${current.layer} entry`);
+      }
+    }
+
+    const nextEntry: ScheduleEntryInput = { ...current };
+
+    if (patch.name !== undefined) nextEntry.name = patch.name;
+    if (patch.enabled !== undefined) nextEntry.enabled = patch.enabled;
+    if (patch.trigger !== undefined) nextEntry.trigger = patch.trigger;
+    if (patch.heartbeat !== undefined) nextEntry.heartbeat = patch.heartbeat;
+    if (patch.probe !== undefined) nextEntry.probe = patch.probe;
+    if (patch.cron !== undefined) nextEntry.cron = patch.cron;
+    if (patch.goal_trigger !== undefined) nextEntry.goal_trigger = patch.goal_trigger;
+
+    if (patch.escalation !== undefined) {
+      if (patch.escalation === null) {
+        delete nextEntry.escalation;
+      } else {
+        nextEntry.escalation = patch.escalation;
+      }
+    }
+
+    if (patch.trigger !== undefined || (current.enabled === false && patch.enabled === true)) {
+      nextEntry.next_fire_at = this.computeNextFireAt(nextEntry.trigger);
+    }
+
+    nextEntry.updated_at = new Date().toISOString();
+
+    const parsedEntry = ScheduleEntrySchema.parse(nextEntry);
+    const previousEntries = this.entries;
+    const nextEntries = [...this.entries];
+    nextEntries[idx] = parsedEntry;
+    this.entries = nextEntries;
+
+    try {
+      await this.saveEntries();
+    } catch (error) {
+      this.entries = previousEntries;
+      throw error;
+    }
+
+    return parsedEntry;
   }
 
   // ─── Scheduling ───

--- a/src/tools/builtin/index.ts
+++ b/src/tools/builtin/index.ts
@@ -52,6 +52,13 @@ export { WritePulseedFileTool } from "../fs/WritePulseedFileTool/WritePulseedFil
 export { AskHumanTool } from "../interaction/AskHumanTool/AskHumanTool.js";
 export { CreatePlanTool } from "../interaction/CreatePlanTool/CreatePlanTool.js";
 export { ReadPlanTool } from "../interaction/ReadPlanTool/ReadPlanTool.js";
+export { CreateScheduleTool } from "../schedule/CreateScheduleTool/CreateScheduleTool.js";
+export { GetScheduleTool } from "../schedule/GetScheduleTool/GetScheduleTool.js";
+export { ListSchedulesTool } from "../schedule/ListSchedulesTool/ListSchedulesTool.js";
+export { PauseScheduleTool } from "../schedule/PauseScheduleTool/PauseScheduleTool.js";
+export { RemoveScheduleTool } from "../schedule/RemoveScheduleTool/RemoveScheduleTool.js";
+export { ResumeScheduleTool } from "../schedule/ResumeScheduleTool/ResumeScheduleTool.js";
+export { UpdateScheduleTool } from "../schedule/UpdateScheduleTool/UpdateScheduleTool.js";
 
 import { GlobTool } from "../fs/GlobTool/GlobTool.js";
 import { GrepTool } from "../fs/GrepTool/GrepTool.js";
@@ -105,6 +112,13 @@ import { WritePulseedFileTool } from "../fs/WritePulseedFileTool/WritePulseedFil
 import { AskHumanTool } from "../interaction/AskHumanTool/AskHumanTool.js";
 import { CreatePlanTool } from "../interaction/CreatePlanTool/CreatePlanTool.js";
 import { ReadPlanTool } from "../interaction/ReadPlanTool/ReadPlanTool.js";
+import { CreateScheduleTool } from "../schedule/CreateScheduleTool/CreateScheduleTool.js";
+import { GetScheduleTool } from "../schedule/GetScheduleTool/GetScheduleTool.js";
+import { ListSchedulesTool } from "../schedule/ListSchedulesTool/ListSchedulesTool.js";
+import { PauseScheduleTool } from "../schedule/PauseScheduleTool/PauseScheduleTool.js";
+import { RemoveScheduleTool } from "../schedule/RemoveScheduleTool/RemoveScheduleTool.js";
+import { ResumeScheduleTool } from "../schedule/ResumeScheduleTool/ResumeScheduleTool.js";
+import { UpdateScheduleTool } from "../schedule/UpdateScheduleTool/UpdateScheduleTool.js";
 import type { AdapterRegistry } from "../../orchestrator/execution/adapter-layer.js";
 import type { SessionManager } from "../../orchestrator/execution/session-manager.js";
 import type { ObservationEngine } from "../../platform/observation/observation-engine.js";
@@ -113,6 +127,7 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
 import type { ToolRegistry } from "../registry.js";
 import type { PluginLoader } from "../../runtime/plugin-loader.js";
+import type { ScheduleEngine } from "../../runtime/schedule-engine.js";
 import type { TrustManager } from "../../platform/traits/trust-manager.js";
 
 export interface BuiltinToolDeps {
@@ -125,6 +140,7 @@ export interface BuiltinToolDeps {
   sessionManager?: SessionManager;
   observationEngine?: ObservationEngine;
   llmCall?: (prompt: string) => Promise<string>;
+  scheduleEngine?: ScheduleEngine;
 }
 
 /** All built-in tools, sorted alphabetically by name. */
@@ -218,6 +234,18 @@ export function createBuiltinTools(deps?: BuiltinToolDeps): ITool[] {
   if (deps?.observationEngine) {
     tools.push(new QueryDataSourceTool(deps.observationEngine));
     tools.push(new ObserveGoalTool(deps.observationEngine));
+  }
+
+  if (deps?.scheduleEngine) {
+    tools.push(
+      new ListSchedulesTool(deps.scheduleEngine),
+      new GetScheduleTool(deps.scheduleEngine),
+      new CreateScheduleTool(deps.scheduleEngine),
+      new UpdateScheduleTool(deps.scheduleEngine),
+      new RemoveScheduleTool(deps.scheduleEngine),
+      new PauseScheduleTool(deps.scheduleEngine),
+      new ResumeScheduleTool(deps.scheduleEngine),
+    );
   }
 
   // File and interaction tools (no deps)

--- a/src/tools/schedule/CreateScheduleTool/CreateScheduleTool.ts
+++ b/src/tools/schedule/CreateScheduleTool/CreateScheduleTool.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import type {
+  ITool,
+  ToolResult,
+  ToolCallContext,
+  PermissionCheckResult,
+  ToolMetadata,
+  ToolDescriptionContext,
+} from "../../types.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import {
+  CronConfigSchema,
+  EscalationConfigSchema,
+  GoalTriggerConfigSchema,
+  HeartbeatConfigSchema,
+  ProbeConfigSchema,
+  ScheduleTriggerSchema,
+  type ScheduleEntry,
+} from "../../../runtime/types/schedule.js";
+import { DESCRIPTION } from "./prompt.js";
+import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
+
+const BaseCreateScheduleInputSchema = z.object({
+  name: z.string().min(1, "name is required"),
+  trigger: ScheduleTriggerSchema,
+  enabled: z.boolean().default(true),
+  escalation: EscalationConfigSchema.optional(),
+});
+
+export const CreateScheduleInputSchema = z.discriminatedUnion("layer", [
+  BaseCreateScheduleInputSchema.extend({
+    layer: z.literal("heartbeat"),
+    heartbeat: HeartbeatConfigSchema,
+  }),
+  BaseCreateScheduleInputSchema.extend({
+    layer: z.literal("probe"),
+    probe: ProbeConfigSchema,
+  }),
+  BaseCreateScheduleInputSchema.extend({
+    layer: z.literal("cron"),
+    cron: CronConfigSchema,
+  }),
+  BaseCreateScheduleInputSchema.extend({
+    layer: z.literal("goal_trigger"),
+    goal_trigger: GoalTriggerConfigSchema,
+  }),
+]);
+
+export type CreateScheduleInput = z.infer<typeof CreateScheduleInputSchema>;
+
+export interface CreateScheduleOutput {
+  entry: ScheduleEntry;
+}
+
+export class CreateScheduleTool implements ITool<CreateScheduleInput, CreateScheduleOutput> {
+  readonly metadata: ToolMetadata = {
+    name: "create_schedule",
+    aliases: [],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 4000,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = CreateScheduleInputSchema;
+
+  constructor(private readonly scheduleEngine: ScheduleEngine) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: CreateScheduleInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+
+    try {
+      const entry = await this.scheduleEngine.addEntry(input);
+
+      return {
+        success: true,
+        data: { entry },
+        summary: `Created schedule: ${entry.name} (${entry.layer})`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: null,
+        summary: "CreateScheduleTool failed: " + (err as Error).message,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(
+    _input: CreateScheduleInput,
+    _context: ToolCallContext,
+  ): Promise<PermissionCheckResult> {
+    return {
+      status: "needs_approval",
+      reason: "Creating a persistent schedule changes background automation and requires approval",
+    };
+  }
+
+  isConcurrencySafe(_input: CreateScheduleInput): boolean {
+    return false;
+  }
+}

--- a/src/tools/schedule/CreateScheduleTool/constants.ts
+++ b/src/tools/schedule/CreateScheduleTool/constants.ts
@@ -1,0 +1,4 @@
+export const TAGS = ["schedule", "mutation", "automation"] as const;
+export const CATEGORY = "schedule";
+export const READ_ONLY = false;
+export const PERMISSION_LEVEL = "write_local" as const;

--- a/src/tools/schedule/CreateScheduleTool/prompt.ts
+++ b/src/tools/schedule/CreateScheduleTool/prompt.ts
@@ -1,0 +1,1 @@
+export const DESCRIPTION = `Create a persistent schedule entry for the heartbeat, probe, cron, or goal_trigger layer.`;

--- a/src/tools/schedule/GetScheduleTool/GetScheduleTool.ts
+++ b/src/tools/schedule/GetScheduleTool/GetScheduleTool.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import { DESCRIPTION } from "./prompt.js";
+import { TAGS, PERMISSION_LEVEL, MAX_OUTPUT_CHARS } from "./constants.js";
+
+export const GetScheduleInputSchema = z.object({
+  schedule_id: z.string().min(1),
+});
+export type GetScheduleInput = z.infer<typeof GetScheduleInputSchema>;
+
+function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
+  const exact = entries.find((entry) => entry.id === scheduleId);
+  if (exact) {
+    return exact;
+  }
+
+  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+  if (matches.length > 1) {
+    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
+  }
+
+  return null;
+}
+
+export class GetScheduleTool implements ITool<GetScheduleInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "get_schedule",
+    aliases: ["read_schedule", "show_schedule"],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: true,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: MAX_OUTPUT_CHARS,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = GetScheduleInputSchema;
+
+  constructor(private readonly scheduleEngine: ScheduleEngine) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: GetScheduleInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+
+    try {
+      const entry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
+
+      if (!entry) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      return {
+        success: true,
+        data: { entry },
+        summary: `Schedule ${entry.id}: ${entry.name} (${entry.layer})`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: null,
+        summary: `GetScheduleTool failed: ${(err as Error).message}`,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(
+    _input: GetScheduleInput,
+    _context?: ToolCallContext,
+  ): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(_input?: GetScheduleInput): boolean {
+    return true;
+  }
+}

--- a/src/tools/schedule/GetScheduleTool/constants.ts
+++ b/src/tools/schedule/GetScheduleTool/constants.ts
@@ -1,0 +1,5 @@
+export const TAGS = ["observe", "schedule", "self-grounding"] as const;
+export const CATEGORY = "schedule";
+export const MAX_OUTPUT_CHARS = 8000;
+export const READ_ONLY = true;
+export const PERMISSION_LEVEL = "read_only" as const;

--- a/src/tools/schedule/GetScheduleTool/prompt.ts
+++ b/src/tools/schedule/GetScheduleTool/prompt.ts
@@ -1,0 +1,1 @@
+export const DESCRIPTION = "Fetch one PulSeed schedule entry by exact ID or unique ID prefix. Returns the full stored schedule entry JSON.";

--- a/src/tools/schedule/ListSchedulesTool/ListSchedulesTool.ts
+++ b/src/tools/schedule/ListSchedulesTool/ListSchedulesTool.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import { ScheduleLayerSchema, type ScheduleEntry } from "../../../runtime/types/schedule.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import { DESCRIPTION } from "./prompt.js";
+import { TAGS, PERMISSION_LEVEL, MAX_OUTPUT_CHARS } from "./constants.js";
+
+export const ListSchedulesInputSchema = z.object({
+  layer: ScheduleLayerSchema.optional(),
+  enabled: z.boolean().optional(),
+  due_only: z.boolean().default(false),
+});
+export type ListSchedulesInput = z.infer<typeof ListSchedulesInputSchema>;
+
+type ListScheduleEntrySummary = Pick<
+  ScheduleEntry,
+  "id" | "name" | "layer" | "enabled" | "next_fire_at" | "last_fired_at"
+> & {
+  trigger_type: ScheduleEntry["trigger"]["type"];
+};
+
+export class ListSchedulesTool implements ITool<ListSchedulesInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "list_schedules",
+    aliases: ["get_schedules", "show_schedules"],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: true,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: MAX_OUTPUT_CHARS,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = ListSchedulesInputSchema;
+
+  constructor(private readonly scheduleEngine: ScheduleEngine) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: ListSchedulesInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+
+    try {
+      const entries = input.due_only
+        ? await this.scheduleEngine.getDueEntries()
+        : this.scheduleEngine.getEntries();
+
+      const filtered = entries.filter((entry) => {
+        if (input.layer && entry.layer !== input.layer) {
+          return false;
+        }
+        if (typeof input.enabled === "boolean" && entry.enabled !== input.enabled) {
+          return false;
+        }
+        return true;
+      });
+
+      const data = {
+        entries: filtered.map<ListScheduleEntrySummary>((entry) => ({
+          id: entry.id,
+          name: entry.name,
+          layer: entry.layer,
+          enabled: entry.enabled,
+          trigger_type: entry.trigger.type,
+          next_fire_at: entry.next_fire_at,
+          last_fired_at: entry.last_fired_at,
+        })),
+      };
+
+      return {
+        success: true,
+        data,
+        summary:
+          filtered.length === 0
+            ? "No schedule entries found"
+            : `Found ${filtered.length} schedule entr${filtered.length === 1 ? "y" : "ies"}`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: null,
+        summary: `ListSchedulesTool failed: ${(err as Error).message}`,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(
+    _input: ListSchedulesInput,
+    _context?: ToolCallContext,
+  ): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(_input?: ListSchedulesInput): boolean {
+    return true;
+  }
+}

--- a/src/tools/schedule/ListSchedulesTool/constants.ts
+++ b/src/tools/schedule/ListSchedulesTool/constants.ts
@@ -1,0 +1,5 @@
+export const TAGS = ["observe", "schedule", "self-grounding"] as const;
+export const CATEGORY = "schedule";
+export const MAX_OUTPUT_CHARS = 8000;
+export const READ_ONLY = true;
+export const PERMISSION_LEVEL = "read_only" as const;

--- a/src/tools/schedule/ListSchedulesTool/prompt.ts
+++ b/src/tools/schedule/ListSchedulesTool/prompt.ts
@@ -1,0 +1,1 @@
+export const DESCRIPTION = "List schedule entries managed by PulSeed. Supports filtering by layer, enabled state, and due-only schedules.";

--- a/src/tools/schedule/PauseScheduleTool/PauseScheduleTool.ts
+++ b/src/tools/schedule/PauseScheduleTool/PauseScheduleTool.ts
@@ -1,0 +1,140 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import { DESCRIPTION } from "./prompt.js";
+import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
+
+export const PauseScheduleInputSchema = z.object({
+  schedule_id: z.string().min(1),
+});
+export type PauseScheduleInput = z.infer<typeof PauseScheduleInputSchema>;
+
+export interface PauseScheduleOutput {
+  entry: ScheduleEntry;
+}
+
+function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
+  const exact = entries.find((entry) => entry.id === scheduleId);
+  if (exact) {
+    return exact;
+  }
+
+  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+  if (matches.length > 1) {
+    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
+  }
+
+  return null;
+}
+
+export class PauseScheduleTool implements ITool<PauseScheduleInput, PauseScheduleOutput> {
+  readonly metadata: ToolMetadata = {
+    name: "pause_schedule",
+    aliases: ["disable_schedule"],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 4000,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = PauseScheduleInputSchema;
+
+  constructor(private readonly scheduleEngine: ScheduleEngine) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: PauseScheduleInput, context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+
+    try {
+      if (!context.preApproved) {
+        const approved = await context.approvalFn({
+          toolName: this.metadata.name,
+          input,
+          reason: `Pause schedule: ${input.schedule_id}`,
+          permissionLevel: "write_local",
+          isDestructive: false,
+          reversibility: "reversible",
+        });
+        if (!approved) {
+          return {
+            success: false,
+            data: null,
+            summary: "Schedule pause denied by user",
+            error: "User denied schedule pause",
+            durationMs: Date.now() - startTime,
+          };
+        }
+      }
+
+      const existingEntry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
+      if (!existingEntry) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      const entry = await this.scheduleEngine.updateEntry(existingEntry.id, { enabled: false });
+      if (!entry) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      return {
+        success: true,
+        data: { entry },
+        summary: `Paused schedule: ${entry.name}`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: null,
+        summary: `PauseScheduleTool failed: ${(err as Error).message}`,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(
+    _input: PauseScheduleInput,
+    context: ToolCallContext,
+  ): Promise<PermissionCheckResult> {
+    if (context.preApproved) return { status: "allowed" };
+    return {
+      status: "needs_approval",
+      reason: "Pausing a persistent schedule changes background automation and requires approval",
+    };
+  }
+
+  isConcurrencySafe(_input: PauseScheduleInput): boolean {
+    return false;
+  }
+}

--- a/src/tools/schedule/PauseScheduleTool/PauseScheduleTool.ts
+++ b/src/tools/schedule/PauseScheduleTool/PauseScheduleTool.ts
@@ -60,30 +60,10 @@ export class PauseScheduleTool implements ITool<PauseScheduleInput, PauseSchedul
     return DESCRIPTION;
   }
 
-  async call(input: PauseScheduleInput, context: ToolCallContext): Promise<ToolResult> {
+  async call(input: PauseScheduleInput, _context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
 
     try {
-      if (!context.preApproved) {
-        const approved = await context.approvalFn({
-          toolName: this.metadata.name,
-          input,
-          reason: `Pause schedule: ${input.schedule_id}`,
-          permissionLevel: "write_local",
-          isDestructive: false,
-          reversibility: "reversible",
-        });
-        if (!approved) {
-          return {
-            success: false,
-            data: null,
-            summary: "Schedule pause denied by user",
-            error: "User denied schedule pause",
-            durationMs: Date.now() - startTime,
-          };
-        }
-      }
-
       const existingEntry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
       if (!existingEntry) {
         return {

--- a/src/tools/schedule/PauseScheduleTool/constants.ts
+++ b/src/tools/schedule/PauseScheduleTool/constants.ts
@@ -1,0 +1,4 @@
+export const TAGS = ["schedule", "mutation", "automation"] as const;
+export const CATEGORY = "schedule";
+export const READ_ONLY = false;
+export const PERMISSION_LEVEL = "write_local" as const;

--- a/src/tools/schedule/PauseScheduleTool/prompt.ts
+++ b/src/tools/schedule/PauseScheduleTool/prompt.ts
@@ -1,0 +1,1 @@
+export const DESCRIPTION = "Disable a PulSeed schedule entry without deleting it so the automation stops firing until resumed.";

--- a/src/tools/schedule/RemoveScheduleTool/RemoveScheduleTool.ts
+++ b/src/tools/schedule/RemoveScheduleTool/RemoveScheduleTool.ts
@@ -1,0 +1,150 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import { DESCRIPTION } from "./prompt.js";
+import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
+
+export const RemoveScheduleInputSchema = z.object({
+  schedule_id: z.string().min(1),
+});
+export type RemoveScheduleInput = z.infer<typeof RemoveScheduleInputSchema>;
+
+export interface RemoveScheduleOutput {
+  removed: true;
+  entry: {
+    id: string;
+    name: string;
+  };
+}
+
+function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
+  const exact = entries.find((entry) => entry.id === scheduleId);
+  if (exact) {
+    return exact;
+  }
+
+  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+  if (matches.length > 1) {
+    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
+  }
+
+  return null;
+}
+
+export class RemoveScheduleTool implements ITool<RemoveScheduleInput, RemoveScheduleOutput> {
+  readonly metadata: ToolMetadata = {
+    name: "remove_schedule",
+    aliases: ["delete_schedule"],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: READ_ONLY,
+    isDestructive: true,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 4000,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = RemoveScheduleInputSchema;
+
+  constructor(private readonly scheduleEngine: ScheduleEngine) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: RemoveScheduleInput, context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+
+    try {
+      if (!context.preApproved) {
+        const approved = await context.approvalFn({
+          toolName: this.metadata.name,
+          input,
+          reason: `Remove schedule: ${input.schedule_id}. This cannot be undone.`,
+          permissionLevel: "write_local",
+          isDestructive: true,
+          reversibility: "irreversible",
+        });
+        if (!approved) {
+          return {
+            success: false,
+            data: null,
+            summary: "Schedule removal denied by user",
+            error: "User denied schedule removal",
+            durationMs: Date.now() - startTime,
+          };
+        }
+      }
+
+      const existingEntry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
+      if (!existingEntry) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      const removed = await this.scheduleEngine.removeEntry(existingEntry.id);
+      if (!removed) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      return {
+        success: true,
+        data: {
+          removed: true,
+          entry: {
+            id: existingEntry.id,
+            name: existingEntry.name,
+          },
+        },
+        summary: `Removed schedule: ${existingEntry.name}`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: null,
+        summary: `RemoveScheduleTool failed: ${(err as Error).message}`,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(
+    _input: RemoveScheduleInput,
+    context: ToolCallContext,
+  ): Promise<PermissionCheckResult> {
+    if (context.preApproved) return { status: "allowed" };
+    return {
+      status: "needs_approval",
+      reason: "Removing a persistent schedule is irreversible and requires approval",
+    };
+  }
+
+  isConcurrencySafe(_input: RemoveScheduleInput): boolean {
+    return false;
+  }
+}

--- a/src/tools/schedule/RemoveScheduleTool/RemoveScheduleTool.ts
+++ b/src/tools/schedule/RemoveScheduleTool/RemoveScheduleTool.ts
@@ -64,30 +64,10 @@ export class RemoveScheduleTool implements ITool<RemoveScheduleInput, RemoveSche
     return DESCRIPTION;
   }
 
-  async call(input: RemoveScheduleInput, context: ToolCallContext): Promise<ToolResult> {
+  async call(input: RemoveScheduleInput, _context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
 
     try {
-      if (!context.preApproved) {
-        const approved = await context.approvalFn({
-          toolName: this.metadata.name,
-          input,
-          reason: `Remove schedule: ${input.schedule_id}. This cannot be undone.`,
-          permissionLevel: "write_local",
-          isDestructive: true,
-          reversibility: "irreversible",
-        });
-        if (!approved) {
-          return {
-            success: false,
-            data: null,
-            summary: "Schedule removal denied by user",
-            error: "User denied schedule removal",
-            durationMs: Date.now() - startTime,
-          };
-        }
-      }
-
       const existingEntry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
       if (!existingEntry) {
         return {

--- a/src/tools/schedule/RemoveScheduleTool/constants.ts
+++ b/src/tools/schedule/RemoveScheduleTool/constants.ts
@@ -1,0 +1,4 @@
+export const TAGS = ["schedule", "mutation", "automation", "destructive"] as const;
+export const CATEGORY = "schedule";
+export const READ_ONLY = false;
+export const PERMISSION_LEVEL = "write_local" as const;

--- a/src/tools/schedule/RemoveScheduleTool/prompt.ts
+++ b/src/tools/schedule/RemoveScheduleTool/prompt.ts
@@ -1,0 +1,1 @@
+export const DESCRIPTION = "Permanently delete a PulSeed schedule entry. This removes the stored automation rule and cannot be undone.";

--- a/src/tools/schedule/ResumeScheduleTool/ResumeScheduleTool.ts
+++ b/src/tools/schedule/ResumeScheduleTool/ResumeScheduleTool.ts
@@ -1,0 +1,140 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import { DESCRIPTION } from "./prompt.js";
+import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
+
+export const ResumeScheduleInputSchema = z.object({
+  schedule_id: z.string().min(1),
+});
+export type ResumeScheduleInput = z.infer<typeof ResumeScheduleInputSchema>;
+
+export interface ResumeScheduleOutput {
+  entry: ScheduleEntry;
+}
+
+function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
+  const exact = entries.find((entry) => entry.id === scheduleId);
+  if (exact) {
+    return exact;
+  }
+
+  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+  if (matches.length > 1) {
+    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
+  }
+
+  return null;
+}
+
+export class ResumeScheduleTool implements ITool<ResumeScheduleInput, ResumeScheduleOutput> {
+  readonly metadata: ToolMetadata = {
+    name: "resume_schedule",
+    aliases: ["enable_schedule"],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 4000,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = ResumeScheduleInputSchema;
+
+  constructor(private readonly scheduleEngine: ScheduleEngine) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: ResumeScheduleInput, context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+
+    try {
+      if (!context.preApproved) {
+        const approved = await context.approvalFn({
+          toolName: this.metadata.name,
+          input,
+          reason: `Resume schedule: ${input.schedule_id}`,
+          permissionLevel: "write_local",
+          isDestructive: false,
+          reversibility: "reversible",
+        });
+        if (!approved) {
+          return {
+            success: false,
+            data: null,
+            summary: "Schedule resume denied by user",
+            error: "User denied schedule resume",
+            durationMs: Date.now() - startTime,
+          };
+        }
+      }
+
+      const existingEntry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
+      if (!existingEntry) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      const entry = await this.scheduleEngine.updateEntry(existingEntry.id, { enabled: true });
+      if (!entry) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      return {
+        success: true,
+        data: { entry },
+        summary: `Resumed schedule: ${entry.name}`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: null,
+        summary: `ResumeScheduleTool failed: ${(err as Error).message}`,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(
+    _input: ResumeScheduleInput,
+    context: ToolCallContext,
+  ): Promise<PermissionCheckResult> {
+    if (context.preApproved) return { status: "allowed" };
+    return {
+      status: "needs_approval",
+      reason: "Resuming a persistent schedule changes background automation and requires approval",
+    };
+  }
+
+  isConcurrencySafe(_input: ResumeScheduleInput): boolean {
+    return false;
+  }
+}

--- a/src/tools/schedule/ResumeScheduleTool/ResumeScheduleTool.ts
+++ b/src/tools/schedule/ResumeScheduleTool/ResumeScheduleTool.ts
@@ -60,30 +60,10 @@ export class ResumeScheduleTool implements ITool<ResumeScheduleInput, ResumeSche
     return DESCRIPTION;
   }
 
-  async call(input: ResumeScheduleInput, context: ToolCallContext): Promise<ToolResult> {
+  async call(input: ResumeScheduleInput, _context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
 
     try {
-      if (!context.preApproved) {
-        const approved = await context.approvalFn({
-          toolName: this.metadata.name,
-          input,
-          reason: `Resume schedule: ${input.schedule_id}`,
-          permissionLevel: "write_local",
-          isDestructive: false,
-          reversibility: "reversible",
-        });
-        if (!approved) {
-          return {
-            success: false,
-            data: null,
-            summary: "Schedule resume denied by user",
-            error: "User denied schedule resume",
-            durationMs: Date.now() - startTime,
-          };
-        }
-      }
-
       const existingEntry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
       if (!existingEntry) {
         return {

--- a/src/tools/schedule/ResumeScheduleTool/constants.ts
+++ b/src/tools/schedule/ResumeScheduleTool/constants.ts
@@ -1,0 +1,4 @@
+export const TAGS = ["schedule", "mutation", "automation"] as const;
+export const CATEGORY = "schedule";
+export const READ_ONLY = false;
+export const PERMISSION_LEVEL = "write_local" as const;

--- a/src/tools/schedule/ResumeScheduleTool/prompt.ts
+++ b/src/tools/schedule/ResumeScheduleTool/prompt.ts
@@ -1,0 +1,1 @@
+export const DESCRIPTION = "Re-enable a paused PulSeed schedule entry and let the engine compute a fresh next fire time.";

--- a/src/tools/schedule/UpdateScheduleTool/UpdateScheduleTool.ts
+++ b/src/tools/schedule/UpdateScheduleTool/UpdateScheduleTool.ts
@@ -1,0 +1,189 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import {
+  ScheduleEngine,
+  type ScheduleEntryUpdateInput,
+} from "../../../runtime/schedule-engine.js";
+import {
+  CronConfigSchema,
+  EscalationConfigSchema,
+  GoalTriggerConfigSchema,
+  HeartbeatConfigSchema,
+  ProbeConfigSchema,
+  ScheduleTriggerSchema,
+  type ScheduleEntry,
+} from "../../../runtime/types/schedule.js";
+import { DESCRIPTION } from "./prompt.js";
+import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
+
+const hasAtLeastOnePatchField = (
+  input: z.infer<typeof UpdateScheduleInputSchemaBase>,
+): boolean =>
+  input.name !== undefined ||
+  input.enabled !== undefined ||
+  input.trigger !== undefined ||
+  input.heartbeat !== undefined ||
+  input.probe !== undefined ||
+  input.cron !== undefined ||
+  input.goal_trigger !== undefined ||
+  input.escalation !== undefined;
+
+const UpdateScheduleInputSchemaBase = z.object({
+  schedule_id: z.string().min(1),
+  name: z.string().min(1).optional(),
+  enabled: z.boolean().optional(),
+  trigger: ScheduleTriggerSchema.optional(),
+  heartbeat: HeartbeatConfigSchema.optional(),
+  probe: ProbeConfigSchema.optional(),
+  cron: CronConfigSchema.optional(),
+  goal_trigger: GoalTriggerConfigSchema.optional(),
+  escalation: EscalationConfigSchema.nullish(),
+});
+
+export const UpdateScheduleInputSchema = UpdateScheduleInputSchemaBase.refine(
+  hasAtLeastOnePatchField,
+  {
+    message: "At least one patch field must be provided",
+  },
+);
+
+export type UpdateScheduleInput = z.infer<typeof UpdateScheduleInputSchema>;
+
+export interface UpdateScheduleOutput {
+  entry: ScheduleEntry;
+}
+
+function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
+  const exact = entries.find((entry) => entry.id === scheduleId);
+  if (exact) {
+    return exact;
+  }
+
+  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+  if (matches.length > 1) {
+    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
+  }
+
+  return null;
+}
+
+export class UpdateScheduleTool implements ITool<UpdateScheduleInput, UpdateScheduleOutput> {
+  readonly metadata: ToolMetadata = {
+    name: "update_schedule",
+    aliases: ["edit_schedule"],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 4000,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = UpdateScheduleInputSchema;
+
+  constructor(private readonly scheduleEngine: ScheduleEngine) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: UpdateScheduleInput, context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+
+    try {
+      if (!context.preApproved) {
+        const approved = await context.approvalFn({
+          toolName: this.metadata.name,
+          input,
+          reason: `Update schedule: ${input.schedule_id}`,
+          permissionLevel: "write_local",
+          isDestructive: false,
+          reversibility: "reversible",
+        });
+        if (!approved) {
+          return {
+            success: false,
+            data: null,
+            summary: "Schedule update denied by user",
+            error: "User denied schedule update",
+            durationMs: Date.now() - startTime,
+          };
+        }
+      }
+
+      const existingEntry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
+      if (!existingEntry) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      const patch: ScheduleEntryUpdateInput = {};
+      if (input.name !== undefined) patch.name = input.name;
+      if (input.enabled !== undefined) patch.enabled = input.enabled;
+      if (input.trigger !== undefined) patch.trigger = input.trigger;
+      if (input.heartbeat !== undefined) patch.heartbeat = input.heartbeat;
+      if (input.probe !== undefined) patch.probe = input.probe;
+      if (input.cron !== undefined) patch.cron = input.cron;
+      if (input.goal_trigger !== undefined) patch.goal_trigger = input.goal_trigger;
+      if (input.escalation !== undefined) patch.escalation = input.escalation;
+
+      const entry = await this.scheduleEngine.updateEntry(existingEntry.id, patch);
+      if (!entry) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      return {
+        success: true,
+        data: { entry },
+        summary: `Updated schedule: ${entry.name} (${entry.layer})`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: null,
+        summary: `UpdateScheduleTool failed: ${(err as Error).message}`,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(
+    _input: UpdateScheduleInput,
+    context: ToolCallContext,
+  ): Promise<PermissionCheckResult> {
+    if (context.preApproved) return { status: "allowed" };
+    return {
+      status: "needs_approval",
+      reason: "Updating a persistent schedule changes background automation and requires approval",
+    };
+  }
+
+  isConcurrencySafe(_input: UpdateScheduleInput): boolean {
+    return false;
+  }
+}

--- a/src/tools/schedule/UpdateScheduleTool/UpdateScheduleTool.ts
+++ b/src/tools/schedule/UpdateScheduleTool/UpdateScheduleTool.ts
@@ -99,30 +99,10 @@ export class UpdateScheduleTool implements ITool<UpdateScheduleInput, UpdateSche
     return DESCRIPTION;
   }
 
-  async call(input: UpdateScheduleInput, context: ToolCallContext): Promise<ToolResult> {
+  async call(input: UpdateScheduleInput, _context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
 
     try {
-      if (!context.preApproved) {
-        const approved = await context.approvalFn({
-          toolName: this.metadata.name,
-          input,
-          reason: `Update schedule: ${input.schedule_id}`,
-          permissionLevel: "write_local",
-          isDestructive: false,
-          reversibility: "reversible",
-        });
-        if (!approved) {
-          return {
-            success: false,
-            data: null,
-            summary: "Schedule update denied by user",
-            error: "User denied schedule update",
-            durationMs: Date.now() - startTime,
-          };
-        }
-      }
-
       const existingEntry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
       if (!existingEntry) {
         return {

--- a/src/tools/schedule/UpdateScheduleTool/constants.ts
+++ b/src/tools/schedule/UpdateScheduleTool/constants.ts
@@ -1,0 +1,4 @@
+export const TAGS = ["schedule", "mutation", "automation"] as const;
+export const CATEGORY = "schedule";
+export const READ_ONLY = false;
+export const PERMISSION_LEVEL = "write_local" as const;

--- a/src/tools/schedule/UpdateScheduleTool/prompt.ts
+++ b/src/tools/schedule/UpdateScheduleTool/prompt.ts
@@ -1,0 +1,1 @@
+export const DESCRIPTION = "Update mutable fields on an existing PulSeed schedule entry, including trigger, enabled state, layer config, and escalation settings.";

--- a/src/tools/schedule/__tests__/GetScheduleTool.test.ts
+++ b/src/tools/schedule/__tests__/GetScheduleTool.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GetScheduleTool } from "../GetScheduleTool/GetScheduleTool.js";
+import type { ToolCallContext } from "../../types.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+
+function makeContext(): ToolCallContext {
+  return {
+    cwd: "/tmp",
+    goalId: "test-goal",
+    trustBalance: 50,
+    preApproved: false,
+    approvalFn: async () => false,
+  };
+}
+
+function makeEntry(
+  id: string,
+  overrides: Partial<ScheduleEntry> = {},
+): ScheduleEntry {
+  return {
+    id,
+    name: `Schedule ${id}`,
+    layer: "heartbeat",
+    trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+    enabled: true,
+    heartbeat: {
+      check_type: "http",
+      check_config: { url: "https://example.com" },
+      failure_threshold: 3,
+      timeout_ms: 5000,
+    },
+    probe: undefined,
+    escalation: undefined,
+    baseline_results: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-01-01T01:00:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+    cron: undefined,
+    goal_trigger: undefined,
+    ...overrides,
+  };
+}
+
+describe("GetScheduleTool", () => {
+  let scheduleEngine: ScheduleEngine;
+  let tool: GetScheduleTool;
+
+  beforeEach(() => {
+    scheduleEngine = {
+      getEntries: vi.fn().mockReturnValue([]),
+    } as unknown as ScheduleEngine;
+    tool = new GetScheduleTool(scheduleEngine);
+  });
+
+  it("returns metadata with schedule tags", () => {
+    expect(tool.metadata.name).toBe("get_schedule");
+    expect(tool.metadata.tags).toContain("schedule");
+    expect(tool.metadata.isReadOnly).toBe(true);
+  });
+
+  it("description returns non-empty string", () => {
+    expect(tool.description()).toContain("schedule");
+  });
+
+  it("checkPermissions returns allowed", async () => {
+    const result = await tool.checkPermissions({ schedule_id: "abc" }, makeContext());
+    expect(result.status).toBe("allowed");
+  });
+
+  it("isConcurrencySafe returns true", () => {
+    expect(tool.isConcurrencySafe({ schedule_id: "abc" })).toBe(true);
+  });
+
+  it("returns the full entry for an exact id match", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", {
+        layer: "cron",
+        trigger: { type: "cron", expression: "0 * * * *", timezone: "UTC" },
+        cron: {
+          prompt_template: "Summarize status",
+          context_sources: ["notes"],
+          output_format: "report",
+          max_tokens: 2000,
+        },
+        heartbeat: undefined,
+      }),
+    ]);
+
+    const result = await tool.call(
+      { schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" },
+      makeContext(),
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as { entry: ScheduleEntry };
+    expect(data.entry.id).toBe("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+    expect(data.entry.layer).toBe("cron");
+  });
+
+  it("resolves a unique id prefix", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      makeEntry("cccccccc-cccc-4ccc-8ccc-cccccccccccc"),
+    ]);
+
+    const result = await tool.call({ schedule_id: "bbbbbbbb" }, makeContext());
+
+    expect(result.success).toBe(true);
+    const data = result.data as { entry: ScheduleEntry };
+    expect(data.entry.id).toBe("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+  });
+
+  it("returns failure when the schedule is missing", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+    ]);
+
+    const result = await tool.call({ schedule_id: "missing" }, makeContext());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing");
+  });
+
+  it("returns failure when the schedule id prefix is ambiguous", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("eeee0000-0000-4000-8000-000000000000"),
+      makeEntry("eeee1111-1111-4111-8111-111111111111"),
+    ]);
+
+    const result = await tool.call({ schedule_id: "eeee" }, makeContext());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ambiguous");
+  });
+
+  it("handles schedule engine errors gracefully", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockImplementation(() => {
+      throw new Error("engine unavailable");
+    });
+
+    const result = await tool.call({ schedule_id: "abc" }, makeContext());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("engine unavailable");
+  });
+});

--- a/src/tools/schedule/__tests__/ListSchedulesTool.test.ts
+++ b/src/tools/schedule/__tests__/ListSchedulesTool.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ListSchedulesTool } from "../ListSchedulesTool/ListSchedulesTool.js";
+import type { ToolCallContext } from "../../types.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+
+function makeContext(): ToolCallContext {
+  return {
+    cwd: "/tmp",
+    goalId: "test-goal",
+    trustBalance: 50,
+    preApproved: false,
+    approvalFn: async () => false,
+  };
+}
+
+function makeEntry(
+  id: string,
+  overrides: Partial<ScheduleEntry> = {},
+): ScheduleEntry {
+  return {
+    id,
+    name: `Schedule ${id}`,
+    layer: "heartbeat",
+    trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+    enabled: true,
+    heartbeat: {
+      check_type: "http",
+      check_config: { url: "https://example.com" },
+      failure_threshold: 3,
+      timeout_ms: 5000,
+    },
+    probe: undefined,
+    escalation: undefined,
+    baseline_results: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-01-01T01:00:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+    cron: undefined,
+    goal_trigger: undefined,
+    ...overrides,
+  };
+}
+
+describe("ListSchedulesTool", () => {
+  let scheduleEngine: ScheduleEngine;
+  let tool: ListSchedulesTool;
+
+  beforeEach(() => {
+    scheduleEngine = {
+      getEntries: vi.fn().mockReturnValue([]),
+      getDueEntries: vi.fn().mockResolvedValue([]),
+    } as unknown as ScheduleEngine;
+    tool = new ListSchedulesTool(scheduleEngine);
+  });
+
+  it("returns metadata with schedule tags", () => {
+    expect(tool.metadata.name).toBe("list_schedules");
+    expect(tool.metadata.tags).toContain("schedule");
+    expect(tool.metadata.isReadOnly).toBe(true);
+  });
+
+  it("description returns non-empty string", () => {
+    expect(tool.description()).toContain("schedule");
+  });
+
+  it("checkPermissions returns allowed", async () => {
+    const result = await tool.checkPermissions({ due_only: false }, makeContext());
+    expect(result.status).toBe("allowed");
+  });
+
+  it("isConcurrencySafe returns true", () => {
+    expect(tool.isConcurrencySafe({ due_only: false })).toBe(true);
+  });
+
+  it("returns filtered schedule summaries from getEntries", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("11111111-1111-1111-1111-111111111111"),
+      makeEntry("22222222-2222-2222-2222-222222222222", {
+        layer: "probe",
+        enabled: false,
+        trigger: { type: "cron", expression: "0 * * * *", timezone: "UTC" },
+        probe: {
+          data_source_id: "source-1",
+          query_params: {},
+          change_detector: { mode: "diff", baseline_window: 5 },
+          llm_on_change: true,
+        },
+        heartbeat: undefined,
+      }),
+    ]);
+
+    const result = await tool.call(
+      { layer: "probe", enabled: false, due_only: false },
+      makeContext(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(scheduleEngine.getEntries).toHaveBeenCalledTimes(1);
+    expect(scheduleEngine.getDueEntries).not.toHaveBeenCalled();
+
+    const data = result.data as {
+      entries: Array<{ id: string; trigger_type: string; enabled: boolean }>;
+    };
+    expect(data.entries).toHaveLength(1);
+    expect(data.entries[0]).toMatchObject({
+      id: "22222222-2222-2222-2222-222222222222",
+      trigger_type: "cron",
+      enabled: false,
+    });
+  });
+
+  it("uses getDueEntries when due_only is true", async () => {
+    vi.mocked(scheduleEngine.getDueEntries).mockResolvedValue([
+      makeEntry("33333333-3333-3333-3333-333333333333", {
+        last_fired_at: "2026-01-01T00:30:00.000Z",
+      }),
+    ]);
+
+    const result = await tool.call({ due_only: true }, makeContext());
+
+    expect(result.success).toBe(true);
+    expect(scheduleEngine.getDueEntries).toHaveBeenCalledTimes(1);
+    expect(scheduleEngine.getEntries).not.toHaveBeenCalled();
+
+    const data = result.data as {
+      entries: Array<{ id: string; last_fired_at: string | null }>;
+    };
+    expect(data.entries[0]?.id).toBe("33333333-3333-3333-3333-333333333333");
+    expect(data.entries[0]?.last_fired_at).toBe("2026-01-01T00:30:00.000Z");
+  });
+
+  it("returns an empty result when nothing matches", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("44444444-4444-4444-4444-444444444444", { layer: "cron" }),
+    ]);
+
+    const result = await tool.call({ layer: "probe", due_only: false }, makeContext());
+
+    expect(result.success).toBe(true);
+    const data = result.data as { entries: unknown[] };
+    expect(data.entries).toHaveLength(0);
+    expect(result.summary).toContain("No schedule entries");
+  });
+
+  it("handles schedule engine errors gracefully", async () => {
+    vi.mocked(scheduleEngine.getDueEntries).mockRejectedValue(new Error("engine unavailable"));
+
+    const result = await tool.call({ due_only: true }, makeContext());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("engine unavailable");
+  });
+});

--- a/src/tools/schedule/__tests__/create-schedule.test.ts
+++ b/src/tools/schedule/__tests__/create-schedule.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  CreateScheduleTool,
+  CreateScheduleInputSchema,
+  type CreateScheduleOutput,
+} from "../CreateScheduleTool/CreateScheduleTool.js";
+import type { ToolCallContext } from "../../types.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import { ScheduleEntrySchema } from "../../../runtime/types/schedule.js";
+
+function makeContext(): ToolCallContext {
+  return {
+    cwd: "/tmp",
+    goalId: "test-goal",
+    trustBalance: 50,
+    preApproved: false,
+    approvalFn: async () => false,
+  };
+}
+
+function makeScheduleEntry() {
+  return ScheduleEntrySchema.parse({
+    id: "11111111-1111-4111-8111-111111111111",
+    name: "daily digest",
+    layer: "cron",
+    trigger: { type: "cron", expression: "0 9 * * *", timezone: "UTC" },
+    enabled: true,
+    cron: {
+      prompt_template: "Summarize the latest activity.",
+      context_sources: ["memory://daily"],
+      output_format: "notification",
+      max_tokens: 1200,
+    },
+    escalation: {
+      enabled: true,
+      target_layer: "goal_trigger",
+      target_entry_id: "22222222-2222-4222-8222-222222222222",
+      cooldown_minutes: 15,
+      max_per_hour: 4,
+      circuit_breaker_threshold: 10,
+    },
+    baseline_results: [],
+    created_at: "2026-04-08T00:00:00.000Z",
+    updated_at: "2026-04-08T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-04-09T09:00:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+  });
+}
+
+describe("CreateScheduleTool", () => {
+  it("has correct metadata", () => {
+    const tool = new CreateScheduleTool({ addEntry: vi.fn() } as unknown as ScheduleEngine);
+
+    expect(tool.metadata.name).toBe("create_schedule");
+    expect(tool.metadata.permissionLevel).toBe("write_local");
+    expect(tool.metadata.isReadOnly).toBe(false);
+    expect(tool.metadata.isDestructive).toBe(false);
+    expect(tool.metadata.tags).toContain("schedule");
+  });
+
+  it("description returns non-empty string", () => {
+    const tool = new CreateScheduleTool({ addEntry: vi.fn() } as unknown as ScheduleEngine);
+
+    expect(tool.description()).toBeTruthy();
+  });
+
+  it("checkPermissions returns needs_approval", async () => {
+    const tool = new CreateScheduleTool({ addEntry: vi.fn() } as unknown as ScheduleEngine);
+    const input = CreateScheduleInputSchema.parse({
+      name: "heartbeat check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 30 },
+      heartbeat: {
+        check_type: "http",
+        check_config: { url: "https://example.com/health" },
+      },
+    });
+
+    const result = await tool.checkPermissions(input, makeContext());
+
+    expect(result.status).toBe("needs_approval");
+    if (result.status === "needs_approval") {
+      expect(result.reason).toContain("persistent schedule");
+    }
+  });
+
+  it("isConcurrencySafe returns false", () => {
+    const tool = new CreateScheduleTool({ addEntry: vi.fn() } as unknown as ScheduleEngine);
+    const input = CreateScheduleInputSchema.parse({
+      name: "probe watcher",
+      layer: "probe",
+      trigger: { type: "interval", seconds: 60 },
+      probe: {
+        data_source_id: "source-1",
+        query_params: {},
+        change_detector: { mode: "presence", baseline_window: 5 },
+      },
+    });
+
+    expect(tool.isConcurrencySafe(input)).toBe(false);
+  });
+
+  it("applies enabled=true by default at schema level", () => {
+    const parsed = CreateScheduleInputSchema.parse({
+      name: "daily digest",
+      layer: "cron",
+      trigger: { type: "cron", expression: "0 9 * * *" },
+      cron: {
+        prompt_template: "Summarize the latest activity.",
+      },
+    });
+
+    expect(parsed.enabled).toBe(true);
+  });
+
+  it("rejects mismatched layer and config at schema level", () => {
+    const parsed = CreateScheduleInputSchema.safeParse({
+      name: "bad input",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 15 },
+      probe: {
+        data_source_id: "source-1",
+        query_params: {},
+        change_detector: { mode: "presence", baseline_window: 5 },
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("calls scheduleEngine.addEntry with the validated input and returns the entry", async () => {
+    const entry = makeScheduleEntry();
+    const addEntry = vi.fn().mockResolvedValue(entry);
+    const tool = new CreateScheduleTool({ addEntry } as unknown as ScheduleEngine);
+    const input = CreateScheduleInputSchema.parse({
+      name: "daily digest",
+      layer: "cron",
+      trigger: { type: "cron", expression: "0 9 * * *" },
+      cron: {
+        prompt_template: "Summarize the latest activity.",
+        context_sources: ["memory://daily"],
+        output_format: "notification",
+        max_tokens: 1200,
+      },
+      escalation: {
+        enabled: true,
+        target_layer: "goal_trigger",
+        target_entry_id: "22222222-2222-4222-8222-222222222222",
+      },
+    });
+
+    const result = await tool.call(input, makeContext());
+
+    expect(addEntry).toHaveBeenCalledTimes(1);
+    expect(addEntry).toHaveBeenCalledWith(input);
+    expect(result.success).toBe(true);
+    expect(result.summary).toContain("daily digest");
+    expect((result.data as CreateScheduleOutput).entry).toEqual(entry);
+  });
+
+  it("returns a failure result when scheduleEngine.addEntry throws", async () => {
+    const addEntry = vi.fn().mockRejectedValue(new Error("disk full"));
+    const tool = new CreateScheduleTool({ addEntry } as unknown as ScheduleEngine);
+    const input = CreateScheduleInputSchema.parse({
+      name: "goal resume",
+      layer: "goal_trigger",
+      trigger: { type: "interval", seconds: 300 },
+      enabled: false,
+      goal_trigger: {
+        goal_id: "goal-123",
+        max_iterations: 3,
+        skip_if_active: true,
+      },
+    });
+
+    const result = await tool.call(input, makeContext());
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("disk full");
+    expect(result.summary).toContain("disk full");
+  });
+});

--- a/src/tools/schedule/__tests__/create-schedule.test.ts
+++ b/src/tools/schedule/__tests__/create-schedule.test.ts
@@ -8,13 +8,14 @@ import type { ToolCallContext } from "../../types.js";
 import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
 import { ScheduleEntrySchema } from "../../../runtime/types/schedule.js";
 
-function makeContext(): ToolCallContext {
+function makeContext(overrides: Partial<ToolCallContext> = {}): ToolCallContext {
   return {
     cwd: "/tmp",
     goalId: "test-goal",
     trustBalance: 50,
     preApproved: false,
     approvalFn: async () => false,
+    ...overrides,
   };
 }
 
@@ -140,6 +141,7 @@ describe("CreateScheduleTool", () => {
     const entry = makeScheduleEntry();
     const addEntry = vi.fn().mockResolvedValue(entry);
     const tool = new CreateScheduleTool({ addEntry } as unknown as ScheduleEngine);
+    const approvalFn = vi.fn().mockResolvedValue(false);
     const input = CreateScheduleInputSchema.parse({
       name: "daily digest",
       layer: "cron",
@@ -157,10 +159,11 @@ describe("CreateScheduleTool", () => {
       },
     });
 
-    const result = await tool.call(input, makeContext());
+    const result = await tool.call(input, makeContext({ approvalFn }));
 
     expect(addEntry).toHaveBeenCalledTimes(1);
     expect(addEntry).toHaveBeenCalledWith(input);
+    expect(approvalFn).not.toHaveBeenCalled();
     expect(result.success).toBe(true);
     expect(result.summary).toContain("daily digest");
     expect((result.data as CreateScheduleOutput).entry).toEqual(entry);

--- a/src/tools/schedule/__tests__/pause-schedule.test.ts
+++ b/src/tools/schedule/__tests__/pause-schedule.test.ts
@@ -1,0 +1,194 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PauseScheduleInputSchema,
+  PauseScheduleTool,
+  type PauseScheduleOutput,
+} from "../PauseScheduleTool/PauseScheduleTool.js";
+import type { ToolCallContext } from "../../types.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+
+function makeContext(overrides: Partial<ToolCallContext> = {}): ToolCallContext {
+  return {
+    cwd: "/tmp",
+    goalId: "test-goal",
+    trustBalance: 50,
+    preApproved: false,
+    approvalFn: async () => false,
+    ...overrides,
+  };
+}
+
+function makeEntry(
+  id: string,
+  overrides: Partial<ScheduleEntry> = {},
+): ScheduleEntry {
+  return {
+    id,
+    name: `Schedule ${id}`,
+    layer: "heartbeat",
+    trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+    enabled: true,
+    heartbeat: {
+      check_type: "http",
+      check_config: { url: "https://example.com/health" },
+      failure_threshold: 3,
+      timeout_ms: 5000,
+    },
+    probe: undefined,
+    cron: undefined,
+    goal_trigger: undefined,
+    escalation: undefined,
+    baseline_results: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-01-01T00:01:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+    ...overrides,
+  };
+}
+
+describe("PauseScheduleTool", () => {
+  let scheduleEngine: ScheduleEngine;
+  let tool: PauseScheduleTool;
+
+  beforeEach(() => {
+    scheduleEngine = {
+      getEntries: vi.fn().mockReturnValue([]),
+      updateEntry: vi.fn(),
+    } as unknown as ScheduleEngine;
+    tool = new PauseScheduleTool(scheduleEngine);
+  });
+
+  it("has correct metadata", () => {
+    expect(tool.metadata.name).toBe("pause_schedule");
+    expect(tool.metadata.permissionLevel).toBe("write_local");
+    expect(tool.metadata.isDestructive).toBe(false);
+    expect(tool.metadata.tags).toContain("schedule");
+  });
+
+  it("description returns non-empty string", () => {
+    expect(tool.description()).toContain("Disable");
+  });
+
+  it("checkPermissions returns needs_approval when not pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      PauseScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+      makeContext(),
+    );
+
+    expect(result.status).toBe("needs_approval");
+  });
+
+  it("checkPermissions returns allowed when pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      PauseScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.status).toBe("allowed");
+  });
+
+  it("isConcurrencySafe returns false", () => {
+    expect(
+      tool.isConcurrencySafe(
+        PauseScheduleInputSchema.parse({
+          schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns failure when the user denies approval", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+    ]);
+
+    const result = await tool.call(
+      PauseScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+      }),
+      makeContext({
+        approvalFn: vi.fn().mockResolvedValue(false),
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("denied");
+    expect(scheduleEngine.updateEntry).not.toHaveBeenCalled();
+  });
+
+  it("resolves a unique prefix and pauses the canonical schedule id", async () => {
+    const entry = makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", {
+      name: "Heartbeat watch",
+      enabled: false,
+    });
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+    ]);
+    vi.mocked(scheduleEngine.updateEntry).mockResolvedValue(entry);
+
+    const result = await tool.call(
+      PauseScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+      }),
+      makeContext({
+        approvalFn: vi.fn().mockResolvedValue(true),
+      }),
+    );
+
+    expect(scheduleEngine.updateEntry).toHaveBeenCalledTimes(1);
+    expect(scheduleEngine.updateEntry).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      { enabled: false },
+    );
+    expect(result.success).toBe(true);
+    expect((result.data as PauseScheduleOutput).entry).toEqual(entry);
+  });
+
+  it("returns failure when the schedule id prefix is ambiguous", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("eeee0000-0000-4000-8000-000000000000"),
+      makeEntry("eeee1111-1111-4111-8111-111111111111"),
+    ]);
+
+    const result = await tool.call(
+      PauseScheduleInputSchema.parse({
+        schedule_id: "eeee",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ambiguous");
+  });
+
+  it("returns failure when the schedule is missing", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+    ]);
+
+    const result = await tool.call(
+      PauseScheduleInputSchema.parse({
+        schedule_id: "missing",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing");
+  });
+});

--- a/src/tools/schedule/__tests__/pause-schedule.test.ts
+++ b/src/tools/schedule/__tests__/pause-schedule.test.ts
@@ -111,26 +111,7 @@ describe("PauseScheduleTool", () => {
     ).toBe(false);
   });
 
-  it("returns failure when the user denies approval", async () => {
-    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
-      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
-    ]);
-
-    const result = await tool.call(
-      PauseScheduleInputSchema.parse({
-        schedule_id: "aaaaaaaa",
-      }),
-      makeContext({
-        approvalFn: vi.fn().mockResolvedValue(false),
-      }),
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("denied");
-    expect(scheduleEngine.updateEntry).not.toHaveBeenCalled();
-  });
-
-  it("resolves a unique prefix and pauses the canonical schedule id", async () => {
+  it("resolves a unique prefix and pauses the canonical schedule id without prompting again", async () => {
     const entry = makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", {
       name: "Heartbeat watch",
       enabled: false,
@@ -140,16 +121,16 @@ describe("PauseScheduleTool", () => {
       makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
     ]);
     vi.mocked(scheduleEngine.updateEntry).mockResolvedValue(entry);
+    const approvalFn = vi.fn().mockResolvedValue(false);
 
     const result = await tool.call(
       PauseScheduleInputSchema.parse({
         schedule_id: "aaaaaaaa",
       }),
-      makeContext({
-        approvalFn: vi.fn().mockResolvedValue(true),
-      }),
+      makeContext({ approvalFn }),
     );
 
+    expect(approvalFn).not.toHaveBeenCalled();
     expect(scheduleEngine.updateEntry).toHaveBeenCalledTimes(1);
     expect(scheduleEngine.updateEntry).toHaveBeenCalledWith(
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",

--- a/src/tools/schedule/__tests__/remove-schedule.test.ts
+++ b/src/tools/schedule/__tests__/remove-schedule.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  RemoveScheduleInputSchema,
+  RemoveScheduleTool,
+  type RemoveScheduleOutput,
+} from "../RemoveScheduleTool/RemoveScheduleTool.js";
+import type { ToolCallContext } from "../../types.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+
+function makeContext(overrides: Partial<ToolCallContext> = {}): ToolCallContext {
+  return {
+    cwd: "/tmp",
+    goalId: "test-goal",
+    trustBalance: 50,
+    preApproved: false,
+    approvalFn: async () => false,
+    ...overrides,
+  };
+}
+
+function makeEntry(
+  id: string,
+  overrides: Partial<ScheduleEntry> = {},
+): ScheduleEntry {
+  return {
+    id,
+    name: `Schedule ${id}`,
+    layer: "heartbeat",
+    trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+    enabled: true,
+    heartbeat: {
+      check_type: "http",
+      check_config: { url: "https://example.com/health" },
+      failure_threshold: 3,
+      timeout_ms: 5000,
+    },
+    probe: undefined,
+    cron: undefined,
+    goal_trigger: undefined,
+    escalation: undefined,
+    baseline_results: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-01-01T00:01:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+    ...overrides,
+  };
+}
+
+describe("RemoveScheduleTool", () => {
+  let scheduleEngine: ScheduleEngine;
+  let tool: RemoveScheduleTool;
+
+  beforeEach(() => {
+    scheduleEngine = {
+      getEntries: vi.fn().mockReturnValue([]),
+      removeEntry: vi.fn(),
+    } as unknown as ScheduleEngine;
+    tool = new RemoveScheduleTool(scheduleEngine);
+  });
+
+  it("has correct metadata", () => {
+    expect(tool.metadata.name).toBe("remove_schedule");
+    expect(tool.metadata.permissionLevel).toBe("write_local");
+    expect(tool.metadata.isDestructive).toBe(true);
+    expect(tool.metadata.tags).toContain("destructive");
+  });
+
+  it("description returns non-empty string", () => {
+    expect(tool.description()).toContain("delete");
+  });
+
+  it("checkPermissions returns needs_approval when not pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      RemoveScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+      makeContext(),
+    );
+
+    expect(result.status).toBe("needs_approval");
+  });
+
+  it("checkPermissions returns allowed when pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      RemoveScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.status).toBe("allowed");
+  });
+
+  it("isConcurrencySafe returns false", () => {
+    expect(
+      tool.isConcurrencySafe(
+        RemoveScheduleInputSchema.parse({
+          schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns failure when the user denies approval", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+    ]);
+
+    const result = await tool.call(
+      RemoveScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+      }),
+      makeContext({
+        approvalFn: vi.fn().mockResolvedValue(false),
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("denied");
+    expect(scheduleEngine.removeEntry).not.toHaveBeenCalled();
+  });
+
+  it("resolves a unique prefix, looks up the name, and removes the canonical id", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", { name: "Digest schedule" }),
+      makeEntry("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+    ]);
+    vi.mocked(scheduleEngine.removeEntry).mockResolvedValue(true);
+
+    const result = await tool.call(
+      RemoveScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+      }),
+      makeContext({
+        approvalFn: vi.fn().mockResolvedValue(true),
+      }),
+    );
+
+    expect(scheduleEngine.removeEntry).toHaveBeenCalledTimes(1);
+    expect(scheduleEngine.removeEntry).toHaveBeenCalledWith("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      removed: true,
+      entry: {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        name: "Digest schedule",
+      },
+    } satisfies RemoveScheduleOutput);
+  });
+
+  it("returns failure when the schedule id prefix is ambiguous", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("eeee0000-0000-4000-8000-000000000000"),
+      makeEntry("eeee1111-1111-4111-8111-111111111111"),
+    ]);
+
+    const result = await tool.call(
+      RemoveScheduleInputSchema.parse({
+        schedule_id: "eeee",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ambiguous");
+  });
+
+  it("returns failure when the schedule is missing", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+    ]);
+
+    const result = await tool.call(
+      RemoveScheduleInputSchema.parse({
+        schedule_id: "missing",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing");
+  });
+
+  it("returns failure when removeEntry returns false", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+    ]);
+    vi.mocked(scheduleEngine.removeEntry).mockResolvedValue(false);
+
+    const result = await tool.call(
+      RemoveScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("aaaaaaaa");
+  });
+});

--- a/src/tools/schedule/__tests__/remove-schedule.test.ts
+++ b/src/tools/schedule/__tests__/remove-schedule.test.ts
@@ -111,41 +111,22 @@ describe("RemoveScheduleTool", () => {
     ).toBe(false);
   });
 
-  it("returns failure when the user denies approval", async () => {
-    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
-      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
-    ]);
-
-    const result = await tool.call(
-      RemoveScheduleInputSchema.parse({
-        schedule_id: "aaaaaaaa",
-      }),
-      makeContext({
-        approvalFn: vi.fn().mockResolvedValue(false),
-      }),
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("denied");
-    expect(scheduleEngine.removeEntry).not.toHaveBeenCalled();
-  });
-
-  it("resolves a unique prefix, looks up the name, and removes the canonical id", async () => {
+  it("resolves a unique prefix, looks up the name, and removes the canonical id without prompting again", async () => {
     vi.mocked(scheduleEngine.getEntries).mockReturnValue([
       makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", { name: "Digest schedule" }),
       makeEntry("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
     ]);
     vi.mocked(scheduleEngine.removeEntry).mockResolvedValue(true);
+    const approvalFn = vi.fn().mockResolvedValue(false);
 
     const result = await tool.call(
       RemoveScheduleInputSchema.parse({
         schedule_id: "aaaaaaaa",
       }),
-      makeContext({
-        approvalFn: vi.fn().mockResolvedValue(true),
-      }),
+      makeContext({ approvalFn }),
     );
 
+    expect(approvalFn).not.toHaveBeenCalled();
     expect(scheduleEngine.removeEntry).toHaveBeenCalledTimes(1);
     expect(scheduleEngine.removeEntry).toHaveBeenCalledWith("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
     expect(result.success).toBe(true);

--- a/src/tools/schedule/__tests__/resume-schedule.test.ts
+++ b/src/tools/schedule/__tests__/resume-schedule.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ResumeScheduleInputSchema,
+  ResumeScheduleTool,
+  type ResumeScheduleOutput,
+} from "../ResumeScheduleTool/ResumeScheduleTool.js";
+import type { ToolCallContext } from "../../types.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+
+function makeContext(overrides: Partial<ToolCallContext> = {}): ToolCallContext {
+  return {
+    cwd: "/tmp",
+    goalId: "test-goal",
+    trustBalance: 50,
+    preApproved: false,
+    approvalFn: async () => false,
+    ...overrides,
+  };
+}
+
+function makeEntry(
+  id: string,
+  overrides: Partial<ScheduleEntry> = {},
+): ScheduleEntry {
+  return {
+    id,
+    name: `Schedule ${id}`,
+    layer: "cron",
+    trigger: { type: "cron", expression: "0 9 * * *", timezone: "UTC" },
+    enabled: false,
+    heartbeat: undefined,
+    probe: undefined,
+    cron: {
+      prompt_template: "Summarize daily changes.",
+      context_sources: ["memory://daily"],
+      output_format: "notification",
+      max_tokens: 1200,
+    },
+    goal_trigger: undefined,
+    escalation: undefined,
+    baseline_results: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-01-02T09:00:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+    ...overrides,
+  };
+}
+
+describe("ResumeScheduleTool", () => {
+  let scheduleEngine: ScheduleEngine;
+  let tool: ResumeScheduleTool;
+
+  beforeEach(() => {
+    scheduleEngine = {
+      getEntries: vi.fn().mockReturnValue([]),
+      updateEntry: vi.fn(),
+    } as unknown as ScheduleEngine;
+    tool = new ResumeScheduleTool(scheduleEngine);
+  });
+
+  it("has correct metadata", () => {
+    expect(tool.metadata.name).toBe("resume_schedule");
+    expect(tool.metadata.permissionLevel).toBe("write_local");
+    expect(tool.metadata.isDestructive).toBe(false);
+    expect(tool.metadata.tags).toContain("automation");
+  });
+
+  it("description returns non-empty string", () => {
+    expect(tool.description()).toContain("Re-enable");
+  });
+
+  it("checkPermissions returns needs_approval when not pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      ResumeScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+      makeContext(),
+    );
+
+    expect(result.status).toBe("needs_approval");
+  });
+
+  it("checkPermissions returns allowed when pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      ResumeScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.status).toBe("allowed");
+  });
+
+  it("isConcurrencySafe returns false", () => {
+    expect(
+      tool.isConcurrencySafe(
+        ResumeScheduleInputSchema.parse({
+          schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns failure when the user denies approval", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+    ]);
+
+    const result = await tool.call(
+      ResumeScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+      }),
+      makeContext({
+        approvalFn: vi.fn().mockResolvedValue(false),
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("denied");
+    expect(scheduleEngine.updateEntry).not.toHaveBeenCalled();
+  });
+
+  it("resolves a unique prefix and resumes the canonical schedule id", async () => {
+    const entry = makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", {
+      name: "Morning digest",
+      enabled: true,
+      next_fire_at: "2026-01-03T09:00:00.000Z",
+    });
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+    ]);
+    vi.mocked(scheduleEngine.updateEntry).mockResolvedValue(entry);
+
+    const result = await tool.call(
+      ResumeScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+      }),
+      makeContext({
+        approvalFn: vi.fn().mockResolvedValue(true),
+      }),
+    );
+
+    expect(scheduleEngine.updateEntry).toHaveBeenCalledTimes(1);
+    expect(scheduleEngine.updateEntry).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      { enabled: true },
+    );
+    expect(result.success).toBe(true);
+    expect((result.data as ResumeScheduleOutput).entry).toEqual(entry);
+    expect(((result.data as ResumeScheduleOutput).entry.next_fire_at)).toBe("2026-01-03T09:00:00.000Z");
+  });
+
+  it("returns failure when the schedule id prefix is ambiguous", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("eeee0000-0000-4000-8000-000000000000"),
+      makeEntry("eeee1111-1111-4111-8111-111111111111"),
+    ]);
+
+    const result = await tool.call(
+      ResumeScheduleInputSchema.parse({
+        schedule_id: "eeee",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ambiguous");
+  });
+
+  it("returns failure when the schedule is missing", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+    ]);
+
+    const result = await tool.call(
+      ResumeScheduleInputSchema.parse({
+        schedule_id: "missing",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing");
+  });
+});

--- a/src/tools/schedule/__tests__/resume-schedule.test.ts
+++ b/src/tools/schedule/__tests__/resume-schedule.test.ts
@@ -111,26 +111,7 @@ describe("ResumeScheduleTool", () => {
     ).toBe(false);
   });
 
-  it("returns failure when the user denies approval", async () => {
-    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
-      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
-    ]);
-
-    const result = await tool.call(
-      ResumeScheduleInputSchema.parse({
-        schedule_id: "aaaaaaaa",
-      }),
-      makeContext({
-        approvalFn: vi.fn().mockResolvedValue(false),
-      }),
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("denied");
-    expect(scheduleEngine.updateEntry).not.toHaveBeenCalled();
-  });
-
-  it("resolves a unique prefix and resumes the canonical schedule id", async () => {
+  it("resolves a unique prefix and resumes the canonical schedule id without prompting again", async () => {
     const entry = makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", {
       name: "Morning digest",
       enabled: true,
@@ -141,16 +122,16 @@ describe("ResumeScheduleTool", () => {
       makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
     ]);
     vi.mocked(scheduleEngine.updateEntry).mockResolvedValue(entry);
+    const approvalFn = vi.fn().mockResolvedValue(false);
 
     const result = await tool.call(
       ResumeScheduleInputSchema.parse({
         schedule_id: "aaaaaaaa",
       }),
-      makeContext({
-        approvalFn: vi.fn().mockResolvedValue(true),
-      }),
+      makeContext({ approvalFn }),
     );
 
+    expect(approvalFn).not.toHaveBeenCalled();
     expect(scheduleEngine.updateEntry).toHaveBeenCalledTimes(1);
     expect(scheduleEngine.updateEntry).toHaveBeenCalledWith(
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",

--- a/src/tools/schedule/__tests__/update-schedule.test.ts
+++ b/src/tools/schedule/__tests__/update-schedule.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  UpdateScheduleInputSchema,
+  UpdateScheduleTool,
+  type UpdateScheduleOutput,
+} from "../UpdateScheduleTool/UpdateScheduleTool.js";
+import type { ToolCallContext } from "../../types.js";
+import type {
+  ScheduleEngine,
+  ScheduleEntryUpdateInput,
+} from "../../../runtime/schedule-engine.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+
+function makeContext(overrides: Partial<ToolCallContext> = {}): ToolCallContext {
+  return {
+    cwd: "/tmp",
+    goalId: "test-goal",
+    trustBalance: 50,
+    preApproved: false,
+    approvalFn: async () => false,
+    ...overrides,
+  };
+}
+
+function makeEntry(
+  id: string,
+  overrides: Partial<ScheduleEntry> = {},
+): ScheduleEntry {
+  return {
+    id,
+    name: `Schedule ${id}`,
+    layer: "cron",
+    trigger: { type: "cron", expression: "0 9 * * *", timezone: "UTC" },
+    enabled: true,
+    heartbeat: undefined,
+    probe: undefined,
+    cron: {
+      prompt_template: "Summarize daily changes.",
+      context_sources: ["memory://daily"],
+      output_format: "notification",
+      max_tokens: 1200,
+    },
+    goal_trigger: undefined,
+    escalation: {
+      enabled: true,
+      target_layer: "goal_trigger",
+      target_entry_id: "99999999-9999-4999-8999-999999999999",
+      cooldown_minutes: 15,
+      max_per_hour: 4,
+      circuit_breaker_threshold: 10,
+    },
+    baseline_results: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-01-01T09:00:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+    ...overrides,
+  };
+}
+
+describe("UpdateScheduleTool", () => {
+  let scheduleEngine: ScheduleEngine;
+  let tool: UpdateScheduleTool;
+
+  beforeEach(() => {
+    scheduleEngine = {
+      getEntries: vi.fn().mockReturnValue([]),
+      updateEntry: vi.fn(),
+    } as unknown as ScheduleEngine;
+    tool = new UpdateScheduleTool(scheduleEngine);
+  });
+
+  it("has correct metadata", () => {
+    expect(tool.metadata.name).toBe("update_schedule");
+    expect(tool.metadata.permissionLevel).toBe("write_local");
+    expect(tool.metadata.isReadOnly).toBe(false);
+    expect(tool.metadata.isDestructive).toBe(false);
+    expect(tool.metadata.tags).toContain("schedule");
+  });
+
+  it("description returns non-empty string", () => {
+    expect(tool.description()).toContain("schedule");
+  });
+
+  it("requires at least one patch field", () => {
+    const parsed = UpdateScheduleInputSchema.safeParse({
+      schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepts escalation=null as a valid patch", () => {
+    const parsed = UpdateScheduleInputSchema.parse({
+      schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      escalation: null,
+    });
+
+    expect(parsed.escalation).toBeNull();
+  });
+
+  it("checkPermissions returns needs_approval when not pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      UpdateScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        enabled: false,
+      }),
+      makeContext(),
+    );
+
+    expect(result.status).toBe("needs_approval");
+    if (result.status === "needs_approval") {
+      expect(result.reason).toContain("background automation");
+    }
+  });
+
+  it("checkPermissions returns allowed when pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      UpdateScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        enabled: false,
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.status).toBe("allowed");
+  });
+
+  it("isConcurrencySafe returns false", () => {
+    expect(
+      tool.isConcurrencySafe(
+        UpdateScheduleInputSchema.parse({
+          schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          enabled: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns failure when the user denies approval", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+    ]);
+
+    const result = await tool.call(
+      UpdateScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+        enabled: false,
+      }),
+      makeContext({
+        approvalFn: vi.fn().mockResolvedValue(false),
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("denied");
+    expect(scheduleEngine.updateEntry).not.toHaveBeenCalled();
+  });
+
+  it("resolves a unique prefix and passes the patch to updateEntry", async () => {
+    const entry = makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", {
+      name: "Morning digest",
+      enabled: false,
+      escalation: undefined,
+    });
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      entry,
+      makeEntry("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+    ]);
+    vi.mocked(scheduleEngine.updateEntry).mockResolvedValue(entry);
+    const approvalFn = vi.fn().mockResolvedValue(true);
+    const input = UpdateScheduleInputSchema.parse({
+      schedule_id: "aaaaaaaa",
+      name: "Morning digest",
+      enabled: false,
+      trigger: { type: "interval", seconds: 300 },
+      cron: {
+        prompt_template: "Summarize the latest activity.",
+        context_sources: ["memory://daily"],
+        output_format: "report",
+        max_tokens: 2000,
+      },
+      escalation: null,
+    });
+
+    const result = await tool.call(input, makeContext({ approvalFn }));
+
+    expect(approvalFn).toHaveBeenCalledTimes(1);
+    expect(scheduleEngine.updateEntry).toHaveBeenCalledTimes(1);
+    expect(scheduleEngine.updateEntry).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      {
+        name: "Morning digest",
+        enabled: false,
+        trigger: { type: "interval", seconds: 300, jitter_factor: 0 },
+        cron: {
+          prompt_template: "Summarize the latest activity.",
+          context_sources: ["memory://daily"],
+          output_format: "report",
+          max_tokens: 2000,
+        },
+        escalation: null,
+      } satisfies ScheduleEntryUpdateInput,
+    );
+    expect(result.success).toBe(true);
+    expect((result.data as UpdateScheduleOutput).entry).toEqual(entry);
+  });
+
+  it("returns failure when the schedule id prefix is ambiguous", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("eeee0000-0000-4000-8000-000000000000"),
+      makeEntry("eeee1111-1111-4111-8111-111111111111"),
+    ]);
+
+    const result = await tool.call(
+      UpdateScheduleInputSchema.parse({
+        schedule_id: "eeee",
+        enabled: false,
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ambiguous");
+  });
+
+  it("returns failure when the schedule is missing", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+    ]);
+
+    const result = await tool.call(
+      UpdateScheduleInputSchema.parse({
+        schedule_id: "missing",
+        enabled: false,
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing");
+  });
+
+  it("surfaces updateEntry errors cleanly", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+    ]);
+    vi.mocked(scheduleEngine.updateEntry).mockRejectedValue(new Error("invalid merged entry"));
+
+    const result = await tool.call(
+      UpdateScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+        enabled: false,
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("invalid merged entry");
+  });
+});

--- a/src/tools/schedule/__tests__/update-schedule.test.ts
+++ b/src/tools/schedule/__tests__/update-schedule.test.ts
@@ -145,27 +145,7 @@ describe("UpdateScheduleTool", () => {
     ).toBe(false);
   });
 
-  it("returns failure when the user denies approval", async () => {
-    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
-      makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
-    ]);
-
-    const result = await tool.call(
-      UpdateScheduleInputSchema.parse({
-        schedule_id: "aaaaaaaa",
-        enabled: false,
-      }),
-      makeContext({
-        approvalFn: vi.fn().mockResolvedValue(false),
-      }),
-    );
-
-    expect(result.success).toBe(false);
-    expect(result.error).toContain("denied");
-    expect(scheduleEngine.updateEntry).not.toHaveBeenCalled();
-  });
-
-  it("resolves a unique prefix and passes the patch to updateEntry", async () => {
+  it("resolves a unique prefix and passes the patch to updateEntry without prompting again", async () => {
     const entry = makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", {
       name: "Morning digest",
       enabled: false,
@@ -176,7 +156,7 @@ describe("UpdateScheduleTool", () => {
       makeEntry("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
     ]);
     vi.mocked(scheduleEngine.updateEntry).mockResolvedValue(entry);
-    const approvalFn = vi.fn().mockResolvedValue(true);
+    const approvalFn = vi.fn().mockResolvedValue(false);
     const input = UpdateScheduleInputSchema.parse({
       schedule_id: "aaaaaaaa",
       name: "Morning digest",
@@ -193,7 +173,7 @@ describe("UpdateScheduleTool", () => {
 
     const result = await tool.call(input, makeContext({ approvalFn }));
 
-    expect(approvalFn).toHaveBeenCalledTimes(1);
+    expect(approvalFn).not.toHaveBeenCalled();
     expect(scheduleEngine.updateEntry).toHaveBeenCalledTimes(1);
     expect(scheduleEngine.updateEntry).toHaveBeenCalledWith(
       "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",


### PR DESCRIPTION
## Summary
- Add 7 chat-callable schedule tools (`list_schedules`, `get_schedule`, `create_schedule`, `update_schedule`, `remove_schedule`, `pause_schedule`, `resume_schedule`) that operate through `ScheduleEngine` instead of direct JSON editing
- Add `ScheduleEngine.updateEntry()` for validated partial updates with rollback
- Wire `ToolRegistry` + `approvalFn` into both CLI chat (`cmdChat`) and TUI chat so schedule operations are accessible from chat mode
- Mutation tools require approval; read-only tools execute immediately

Closes #569, closes #570

## Changes
- `src/runtime/schedule-engine.ts` — add `updateEntry(id, patch)` with validation, recomputation, and rollback
- `src/tools/schedule/` — 7 new tools (21 files), each following existing `ITool` pattern
- `src/tools/builtin/index.ts` — register schedule tools when `scheduleEngine` provided
- `src/interface/cli/commands/chat.ts` — build `ToolRegistry` + `ScheduleEngine` + TTY approval prompt
- `src/interface/tui/entry.ts` — add `ScheduleEngine` to builtin tools + bridge approval overlay

## Test plan
- [x] `ScheduleEngine.updateEntry()` — 8 new tests (not-found, empty patch, field updates, trigger recomputation, resume recomputation, layer mismatch, validation, save rollback)
- [x] 7 tool test files — 65 tests covering metadata, permissions, approval gating, ID resolution, happy paths, error paths
- [x] ChatRunner integration — 3 tests (tool discovery, list execution, create approval flow)
- [x] All 147 schedule-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)