### PR TITLE
feat: land schedule automation, capability acquisition, and knowledge integration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -215,6 +215,9 @@ Common flags available across multiple commands. Run `pulseed <command> --help` 
 | `pulseed start --goal <id>` | Start daemon mode for continuous looping |
 | `pulseed stop` | Stop the running daemon |
 | `pulseed cron --goal <id>` | Print a crontab entry for scheduled runs |
+| `pulseed schedule list/add/remove` | Manage persisted schedule entries |
+| `pulseed schedule presets` | List reusable schedule presets such as `daily_brief` and `weekly_review` |
+| `pulseed schedule suggestions list/apply/reject/dismiss` | Review and materialize dream-generated schedule suggestions |
 | `pulseed tui` | Launch the interactive terminal UI |
 | `pulseed setup` | Interactive provider and adapter setup wizard |
 | `pulseed datasource add/list/remove` | Manage data sources |
@@ -229,3 +232,20 @@ pulseed setup --provider openai --model gpt-5.4-mini --adapter openai_codex_cli
 ```
 
 Use `--provider`, `--model`, and `--adapter` to run setup non-interactively (useful in CI or scripts).
+
+### Postgres datasource
+
+PulSeed ships a first-party `database` datasource backed by `psql`. A working
+`psql` binary must be available in `$PATH` for health checks and query
+execution.
+
+```bash
+pulseed datasource add database \
+  --name "Prod analytics" \
+  --connection-string postgresql://localhost:5432/analytics \
+  --dimension open_issue_count \
+  --query "SELECT count(*) FROM issues WHERE state = 'open'"
+```
+
+This stores the SQL in `dimension_mapping`, so the observation layer can read
+`open_issue_count` without custom glue code.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -148,6 +148,17 @@ TUI is not a replacement for CLI mode but a complement to it. The loop execution
 - Execution interval can be configured per goal (see drive-system.md scheduling design)
 - Process management (PID file, logs) is handled by the daemon layer
 
+PulSeed now also persists first-class schedule entries under the same runtime state. Common workflows can be created from reusable presets with `pulseed schedule presets` and `pulseed schedule add --preset <name>`, and dream-generated schedule suggestions can be reviewed with `pulseed schedule suggestions <list|apply|reject|dismiss>`.
+
+Schedule presets are available through `pulseed schedule presets` and `pulseed schedule add --preset <key>`.
+
+- `daily_brief` depends on an LLM client and notification delivery
+- `weekly_review` depends on an LLM client and notification delivery
+- `dream_consolidation` depends on memory and knowledge consolidation services
+- `goal_probe` depends on a registered data source
+
+Dream-generated schedule suggestions are reviewable through `pulseed schedule suggestions list` and can be `apply`/`reject`/`dismiss`ed. Applied suggestions record provenance on the resulting schedule entry so later surfaces can explain where the schedule came from.
+
 ### Phase 2b: cron Entry Generation
 
 **`pulseed cron`** outputs a crontab entry the user can add to their shell.

--- a/src/interface/chat/__tests__/chat-schedule-integration.test.ts
+++ b/src/interface/chat/__tests__/chat-schedule-integration.test.ts
@@ -235,4 +235,57 @@ describe("ChatRunner schedule integration", () => {
     );
     expect(vi.mocked(scheduleEngine.addEntry)).toHaveBeenCalledOnce();
   });
+
+  it("supports preset-based schedule creation through the chat tool path", async () => {
+    const createdEntry = makeScheduleEntry({ name: "Daily brief" });
+    const scheduleEngine = makeScheduleEngine();
+    vi.mocked(scheduleEngine.addEntry).mockResolvedValue(createdEntry);
+    const registry = buildRegistry(scheduleEngine);
+    const approvalFn = vi.fn().mockResolvedValue(true);
+    const llmClient = {
+      supportsToolCalling: () => true,
+      sendMessage: vi.fn()
+        .mockResolvedValueOnce({
+          content: "",
+          tool_calls: [
+            {
+              id: "tool-call-1",
+              function: {
+                name: "create_schedule",
+                arguments: JSON.stringify({
+                  preset: "daily_brief",
+                }),
+              },
+            },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "tool_use",
+        })
+        .mockResolvedValueOnce({
+          content: "Created preset schedule",
+          tool_calls: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "completed",
+        }),
+    };
+
+    const runner = new ChatRunner(makeDeps({
+      registry,
+      llmClient: llmClient as never,
+      approvalFn,
+    }));
+
+    await runner.execute("create a daily brief schedule", "/tmp");
+
+    expect(vi.mocked(scheduleEngine.addEntry)).toHaveBeenCalledWith(expect.objectContaining({
+      metadata: expect.objectContaining({
+        source: "preset",
+        preset_key: "daily_brief",
+      }),
+      cron: expect.objectContaining({
+        reflection_kind: "morning_planning",
+      }),
+    }));
+    expect(approvalFn).toHaveBeenCalledOnce();
+  });
 });

--- a/src/interface/chat/__tests__/event-subscriber.test.ts
+++ b/src/interface/chat/__tests__/event-subscriber.test.ts
@@ -266,6 +266,33 @@ describe("EventSubscriber", () => {
 
       expect(received).toHaveLength(0);
     });
+
+    it("formats proactive report notifications from SSE", () => {
+      const sub = makeSubscriber("goal-abc", "normal");
+      const received: TendNotification[] = [];
+      sub.on("notification", (n: TendNotification) => received.push(n));
+
+      const raw = `event: notification_report\ndata: {"report_type":"daily_summary","title":"Morning Planning — 2026-04-08"}`;
+      (sub as any).parseSSEMessage(raw);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].message).toContain("Morning Planning");
+      expect(received[0].reportType).toBe("daily_summary");
+    });
+
+    it("formats approval_required events as actionable approvals", () => {
+      const sub = makeSubscriber("goal-abc", "normal");
+      const received: TendNotification[] = [];
+      sub.on("notification", (n: TendNotification) => received.push(n));
+
+      const raw = `event: approval_required\ndata: {"requestId":"approval-123","task":{"description":"Approve daily brief dispatch","action":"dispatch_notification"}}`;
+      (sub as any).parseSSEMessage(raw);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].type).toBe("approval");
+      expect(received[0].requestId).toBe("approval-123");
+      expect(received[0].message).toContain("Approve daily brief dispatch");
+    });
   });
 
   describe("goalId truncation", () => {

--- a/src/interface/chat/event-subscriber.ts
+++ b/src/interface/chat/event-subscriber.ts
@@ -1,13 +1,15 @@
 import { EventEmitter } from "node:events";
 
 export interface TendNotification {
-  type: "progress" | "stall" | "complete" | "error";
+  type: "progress" | "stall" | "complete" | "error" | "approval";
   goalId: string;
   message: string;
   iteration?: number;
   maxIterations?: number;
   gap?: number;
   previousGap?: number;
+  requestId?: string;
+  reportType?: string;
 }
 
 export type NotificationVerbosity = "verbose" | "normal" | "quiet";
@@ -19,6 +21,13 @@ interface RawProgressEvent {
   gap?: number;
   taskDescription?: string;
   skipReason?: string;
+}
+
+interface RawNotificationReport {
+  report_type?: string;
+  title?: string;
+  content?: string;
+  goal_id?: string | null;
 }
 
 export class EventSubscriber extends EventEmitter {
@@ -177,6 +186,52 @@ export class EventSubscriber extends EventEmitter {
       }
 
       return null;
+    }
+
+    if (eventType === "notification_report") {
+      const report = data as RawNotificationReport;
+      if (report.report_type === "approval_request") {
+        return null;
+      }
+      const title = report.title ?? report.report_type ?? "Notification";
+      const prefix = report.report_type === "weekly_report"
+        ? "🗓"
+        : report.report_type === "daily_summary"
+          ? "📰"
+          : report.report_type === "urgent_alert"
+            ? "⚠️"
+            : "🔔";
+      return {
+        type: "progress",
+        goalId: this.goalId,
+        reportType: report.report_type,
+        message: `${prefix} [tend] ${shortId}: ${title}`,
+      };
+    }
+
+    if (eventType === "approval_required") {
+      const ev = data as {
+        requestId?: string;
+        goalId?: string;
+        task?: { description?: string; action?: string };
+      };
+      const description = ev.task?.description ?? ev.task?.action ?? "A task requires approval";
+      return {
+        type: "approval",
+        goalId: this.goalId,
+        requestId: ev.requestId,
+        message: `🛂 [tend] ${shortId}: Approval required — ${description}`,
+      };
+    }
+
+    if (eventType === "approval_resolved") {
+      const ev = data as { approved?: boolean };
+      const decision = ev.approved ? "approved" : "rejected";
+      return {
+        type: "progress",
+        goalId: this.goalId,
+        message: `🧾 [tend] ${shortId}: Approval ${decision}`,
+      };
     }
 
     // CoreLoop completion broadcast

--- a/src/interface/cli/__tests__/datasource-command.test.ts
+++ b/src/interface/cli/__tests__/datasource-command.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { StateManager } from "../../../base/state/state-manager.js";
+import { getDatasourcesDir } from "../../../base/utils/paths.js";
+import { cmdDatasourceAdd } from "../commands/config.js";
+import { createCliDataSourceAdapter } from "../setup.js";
+import { PostgresDataSourceAdapter } from "../../../platform/observation/data-source-adapter.js";
+
+describe("cmdDatasourceAdd(database)", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-datasource-command-"));
+    stateManager = new StateManager(tmpDir);
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it("writes a database datasource config with a dimension mapping", async () => {
+    const exitCode = await cmdDatasourceAdd(stateManager, [
+      "database",
+      "--connection-string",
+      "postgresql://localhost:5432/analytics",
+      "--dimension",
+      "open_issue_count",
+      "--query",
+      "SELECT count(*) FROM issues WHERE state = 'open'",
+    ]);
+
+    expect(exitCode).toBe(0);
+
+    const datasourcesDir = getDatasourcesDir(stateManager.getBaseDir());
+    const [filename] = fs.readdirSync(datasourcesDir);
+    const saved = JSON.parse(
+      fs.readFileSync(path.join(datasourcesDir, filename!), "utf-8")
+    ) as {
+      type: string;
+      connection_string?: string;
+      dimension_mapping?: Record<string, string>;
+    };
+
+    expect(saved.type).toBe("database");
+    expect(saved.connection_string).toBe("postgresql://localhost:5432/analytics");
+    expect(saved.dimension_mapping).toEqual({
+      open_issue_count: "SELECT count(*) FROM issues WHERE state = 'open'",
+    });
+  });
+
+  it("accepts postgres as an alias for database", async () => {
+    const exitCode = await cmdDatasourceAdd(stateManager, [
+      "postgres",
+      "--connection-string",
+      "postgresql://localhost:5432/app",
+      "--query",
+      "SELECT 1",
+    ]);
+
+    expect(exitCode).toBe(0);
+
+    const datasourcesDir = getDatasourcesDir(stateManager.getBaseDir());
+    const [filename] = fs.readdirSync(datasourcesDir);
+    const saved = JSON.parse(
+      fs.readFileSync(path.join(datasourcesDir, filename!), "utf-8")
+    ) as { type: string };
+
+    expect(saved.type).toBe("database");
+  });
+});
+
+describe("createCliDataSourceAdapter", () => {
+  it("maps database datasources to PostgresDataSourceAdapter", () => {
+    const adapter = createCliDataSourceAdapter({
+      id: "db-source",
+      name: "Analytics DB",
+      type: "database",
+      connection: {},
+      connection_string: "postgresql://localhost:5432/analytics",
+      dimension_mapping: {
+        open_issue_count: "SELECT count(*) FROM issues WHERE state = 'open'",
+      },
+      enabled: true,
+      created_at: new Date().toISOString(),
+    });
+
+    expect(adapter).toBeInstanceOf(PostgresDataSourceAdapter);
+  });
+});

--- a/src/interface/cli/__tests__/datasource-command.test.ts
+++ b/src/interface/cli/__tests__/datasource-command.test.ts
@@ -42,6 +42,7 @@ describe("cmdDatasourceAdd(database)", () => {
     const saved = JSON.parse(
       fs.readFileSync(path.join(datasourcesDir, filename!), "utf-8")
     ) as {
+      id: string;
       type: string;
       connection_string?: string;
       dimension_mapping?: Record<string, string>;
@@ -50,6 +51,7 @@ describe("cmdDatasourceAdd(database)", () => {
     expect(saved.type).toBe("database");
     expect(saved.connection_string).toBe("postgresql://localhost:5432/analytics");
     expect(saved.dimension_mapping).toEqual({
+      [saved.id!]: "SELECT count(*) FROM issues WHERE state = 'open'",
       open_issue_count: "SELECT count(*) FROM issues WHERE state = 'open'",
     });
   });

--- a/src/interface/cli/__tests__/schedule-command.test.ts
+++ b/src/interface/cli/__tests__/schedule-command.test.ts
@@ -1,0 +1,73 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cmdSchedule } from "../commands/schedule.js";
+import { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import type { StateManager } from "../../../base/state/state-manager.js";
+
+function makeStateManager(baseDir: string): StateManager {
+  return {
+    getBaseDir: () => baseDir,
+  } as unknown as StateManager;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("cmdSchedule", () => {
+  it("adds a preset-backed schedule entry", async () => {
+    const tempDir = makeTempDir("schedule-command-");
+    try {
+      vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await cmdSchedule(makeStateManager(tempDir), ["add", "--preset", "daily_brief"]);
+
+      const engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      expect(engine.getEntries()).toHaveLength(1);
+      expect(engine.getEntries()[0]?.metadata).toEqual(expect.objectContaining({
+        source: "preset",
+        preset_key: "daily_brief",
+      }));
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  });
+
+  it("applies a dream suggestion through the CLI flow", async () => {
+    const tempDir = makeTempDir("schedule-command-suggestion-");
+    try {
+      vi.spyOn(console, "log").mockImplementation(() => {});
+      await fs.mkdir(path.join(tempDir, "dream"), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, "dream", "schedule-suggestions.json"),
+        JSON.stringify({
+          generated_at: "2026-04-08T00:00:00.000Z",
+          suggestions: [
+            {
+              id: "dream-1",
+              type: "goal_trigger",
+              goalId: "goal-123",
+              confidence: 0.9,
+              reason: "Morning runs perform best.",
+              proposal: "0 9 * * *",
+              status: "pending",
+            },
+          ],
+        }),
+        "utf8",
+      );
+
+      await cmdSchedule(makeStateManager(tempDir), ["suggestions", "apply", "dream-1"]);
+
+      const engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      expect(engine.getEntries()).toHaveLength(1);
+      expect(engine.getEntries()[0]?.goal_trigger?.goal_id).toBe("goal-123");
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  });
+});

--- a/src/interface/cli/__tests__/schedule-command.test.ts
+++ b/src/interface/cli/__tests__/schedule-command.test.ts
@@ -36,6 +36,33 @@ describe("cmdSchedule", () => {
     }
   });
 
+  it("passes probe_dimension through the goal_probe preset", async () => {
+    const tempDir = makeTempDir("schedule-command-goal-probe-");
+    try {
+      vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await cmdSchedule(makeStateManager(tempDir), [
+        "add",
+        "--preset",
+        "goal_probe",
+        "--data-source-id",
+        "db-source",
+        "--probe-dimension",
+        "open_issue_count",
+      ]);
+
+      const engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      expect(engine.getEntries()).toHaveLength(1);
+      expect(engine.getEntries()[0]?.probe).toEqual(expect.objectContaining({
+        data_source_id: "db-source",
+        probe_dimension: "open_issue_count",
+      }));
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  });
+
   it("applies a dream suggestion through the CLI flow", async () => {
     const tempDir = makeTempDir("schedule-command-suggestion-");
     try {

--- a/src/interface/cli/commands/config.ts
+++ b/src/interface/cli/commands/config.ts
@@ -212,19 +212,28 @@ export async function cmdDatasourceAdd(
   stateManager: StateManager,
   argv: string[]
 ): Promise<number> {
-  const type = argv[0];
-  if (!type) {
+  const rawType = argv[0];
+  if (!rawType) {
     getCliLogger().error("Error: type is required. Usage: pulseed datasource add <type> [options]");
-    getCliLogger().error("  Types: file, http_api, github_issue, file_existence");
+    getCliLogger().error("  Types: file, http_api, database, github_issue, file_existence");
     return 1;
   }
 
-  if (type !== "file" && type !== "http_api" && type !== "github_issue" && type !== "file_existence") {
-    getCliLogger().error(`Error: unsupported type "${type}". Supported: file, http_api, github_issue, file_existence`);
+  const type = rawType === "postgres" ? "database" : rawType;
+
+  if (type !== "file" && type !== "http_api" && type !== "database" && type !== "github_issue" && type !== "file_existence") {
+    getCliLogger().error(`Error: unsupported type "${rawType}". Supported: file, http_api, database, postgres, github_issue, file_existence`);
     return 1;
   }
 
-  let values: { name?: string; path?: string; url?: string };
+  let values: {
+    name?: string;
+    path?: string;
+    url?: string;
+    "connection-string"?: string;
+    dimension?: string;
+    query?: string;
+  };
   try {
     ({ values } = parseArgs({
       args: argv.slice(1),
@@ -232,9 +241,21 @@ export async function cmdDatasourceAdd(
         name: { type: "string" },
         path: { type: "string" },
         url: { type: "string" },
+        "connection-string": { type: "string" },
+        dimension: { type: "string" },
+        query: { type: "string" },
       },
       strict: false,
-    }) as { values: { name?: string; path?: string; url?: string } });
+    }) as {
+      values: {
+        name?: string;
+        path?: string;
+        url?: string;
+        "connection-string"?: string;
+        dimension?: string;
+        query?: string;
+      };
+    });
   } catch (err) {
     getCliLogger().error(formatOperationError(`parse datasource add arguments for type "${type}"`, err));
     values = {};
@@ -249,6 +270,8 @@ export async function cmdDatasourceAdd(
         ? `file_existence:${values.path ?? id}`
         : type === "github_issue"
           ? `github_issue:${id}`
+          : type === "database"
+            ? `database:${values.dimension ?? id}`
           : `http_api:${values.url ?? id}`);
 
   const connection: Record<string, string> = {};
@@ -268,6 +291,26 @@ export async function cmdDatasourceAdd(
     extraConfig = { filePaths: { file_exists: values.path } };
   } else if (type === "github_issue") {
     // No connection params needed — uses `gh` CLI
+  } else if (type === "database") {
+    const connectionString = values["connection-string"] ?? values.url;
+    if (!connectionString) {
+      getCliLogger().error("Error: --connection-string or --url is required for database data source");
+      return 1;
+    }
+    if (!values.query) {
+      getCliLogger().error("Error: --query is required for database data source");
+      return 1;
+    }
+    const dimensionName = values.dimension ?? "value";
+    extraConfig = {
+      connection_string: values["connection-string"],
+      dimension_mapping: {
+        [dimensionName]: values.query,
+      },
+    };
+    if (values.url) {
+      connection["url"] = values.url;
+    }
   } else {
     if (!values.url) {
       getCliLogger().error("Error: --url is required for http_api data source");
@@ -297,6 +340,9 @@ export async function cmdDatasourceAdd(
   console.log(`  ID:   ${id}`);
   console.log(`  Type: ${type}`);
   console.log(`  Name: ${name}`);
+  if (type === "database") {
+    console.log(`  Query dimension: ${values.dimension ?? "value"}`);
+  }
 
   return 0;
 }

--- a/src/interface/cli/commands/config.ts
+++ b/src/interface/cli/commands/config.ts
@@ -271,7 +271,7 @@ export async function cmdDatasourceAdd(
         : type === "github_issue"
           ? `github_issue:${id}`
           : type === "database"
-            ? `database:${values.dimension ?? id}`
+            ? `database:${values.dimension ?? "value"}`
           : `http_api:${values.url ?? id}`);
 
   const connection: Record<string, string> = {};
@@ -303,8 +303,9 @@ export async function cmdDatasourceAdd(
     }
     const dimensionName = values.dimension ?? "value";
     extraConfig = {
-      connection_string: values["connection-string"],
+      connection_string: connectionString,
       dimension_mapping: {
+        [id]: values.query,
         [dimensionName]: values.query,
       },
     };

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -162,15 +162,24 @@ export async function cmdStart(
     process.exit(1);
   }
 
-  // Gap 2: Create EventServer for event-driven wake-ups (only if config specifies a port)
-  let eventServer: EventServer | undefined;
-  if (daemonConfig && typeof (daemonConfig as Record<string, unknown>).event_server_port === "number") {
-    eventServer = new EventServer(
-      deps.driveSystem,
-      { port: (daemonConfig as Record<string, unknown>).event_server_port as number },
-      logger
-    );
-  }
+  const configuredPort = daemonConfig && typeof (daemonConfig as Record<string, unknown>).event_server_port === "number"
+    ? (daemonConfig as Record<string, unknown>).event_server_port as number
+    : undefined;
+  const eventServer = new EventServer(
+    deps.driveSystem,
+    configuredPort !== undefined ? { port: configuredPort } : undefined,
+    logger
+  );
+  notificationDispatcher.setRealtimeSink(async (report) => {
+    eventServer.broadcast("notification_report", {
+      id: report.id,
+      report_type: report.report_type,
+      goal_id: report.goal_id,
+      title: report.title,
+      content: report.content,
+      generated_at: report.generated_at,
+    });
+  });
 
   // Gap 4: Create CronScheduler for scheduled tasks
   const cronScheduler = new CronScheduler(baseDir);
@@ -184,6 +193,9 @@ export async function cmdStart(
     coreLoop: deps.coreLoop,
     stateManager: deps.stateManager,
     notificationDispatcher,
+    hookManager: deps.hookManager,
+    memoryLifecycle: deps.memoryLifecycleManager,
+    knowledgeManager: deps.knowledgeManager,
   });
   await scheduleEngine.loadEntries();
 
@@ -194,10 +206,11 @@ export async function cmdStart(
     pidManager,
     logger,
     config: daemonConfig,
-    ...(eventServer ? { eventServer } : {}),
+    eventServer,
     llmClient: deps.llmClient,
     cronScheduler,
     scheduleEngine,
+    reportingEngine: deps.reportingEngine,
   });
 
   logger.info(`Starting PulSeed daemon for goals: ${goalIds.join(", ")}`);

--- a/src/interface/cli/commands/schedule.ts
+++ b/src/interface/cli/commands/schedule.ts
@@ -1,6 +1,13 @@
 import { parseArgs } from "node:util";
 import { ScheduleEngine } from "../../../runtime/schedule-engine.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
+import {
+  buildSchedulePresetEntry,
+  listSchedulePresetDefinitions,
+  type SchedulePresetInput,
+} from "../../../runtime/schedule-presets.js";
+import { DreamScheduleSuggestionStore } from "../../../platform/dream/dream-schedule-suggestions.js";
+import type { ScheduleTriggerInput } from "../../../runtime/types/schedule.js";
 
 export async function cmdSchedule(
   stateManager: StateManager,
@@ -18,11 +25,17 @@ export async function cmdSchedule(
       return await scheduleAdd(engine, argv.slice(1));
     case "remove":
       return await scheduleRemove(engine, argv.slice(1));
+    case "presets":
+      return schedulePresetList();
+    case "suggestions":
+      return await scheduleSuggestions(baseDir, engine, argv.slice(1));
     default:
-      console.log("Usage: pulseed schedule <list|add|remove>");
-      console.log("  list              List all schedule entries");
-      console.log("  add               Add a heartbeat entry");
-      console.log("  remove <id>       Remove a schedule entry");
+      console.log("Usage: pulseed schedule <list|add|remove|presets|suggestions>");
+      console.log("  list                              List all schedule entries");
+      console.log("  add                               Add a heartbeat entry or preset");
+      console.log("  remove <id>                       Remove a schedule entry");
+      console.log("  presets                           List reusable schedule presets");
+      console.log("  suggestions <list|apply|reject|dismiss>  Review dream-generated suggestions");
   }
 }
 
@@ -32,12 +45,82 @@ async function scheduleList(engine: ScheduleEngine): Promise<void> {
     console.log("No schedule entries.");
     return;
   }
-  for (const e of entries) {
-    const status = e.enabled ? "enabled" : "disabled";
-    const layer = e.layer;
-    const schedule = e.trigger.type === "cron" ? e.trigger.expression : `every ${e.trigger.seconds}s`;
-    const lastFired = e.last_fired_at ?? "never";
-    console.log(`  ${e.id.slice(0, 8)}  [${layer}] ${e.name}  (${schedule})  ${status}  last: ${lastFired}`);
+  for (const entry of entries) {
+    const status = entry.enabled ? "enabled" : "disabled";
+    const schedule = entry.trigger.type === "cron"
+      ? entry.trigger.expression
+      : `every ${entry.trigger.seconds}s`;
+    const lastFired = entry.last_fired_at ?? "never";
+    const source = entry.metadata?.source
+      ? `${entry.metadata.source}${entry.metadata.preset_key ? `:${entry.metadata.preset_key}` : ""}`
+      : "manual";
+    console.log(
+      `  ${entry.id.slice(0, 8)}  [${entry.layer}] ${entry.name}  (${schedule})  ${status}  source: ${source}  last: ${lastFired}`
+    );
+  }
+}
+
+function resolveOptionalTrigger(values: { cron?: string; interval?: string }): ScheduleTriggerInput | undefined {
+  if (values.cron) {
+    return { type: "cron", expression: values.cron, timezone: "UTC" };
+  }
+  if (values.interval) {
+    return { type: "interval", seconds: parseInt(values.interval, 10), jitter_factor: 0 };
+  }
+  return undefined;
+}
+
+function buildPresetInput(values: Record<string, unknown>): SchedulePresetInput {
+  const preset = String(values.preset ?? "");
+  const trigger = resolveOptionalTrigger({
+    cron: typeof values.cron === "string" ? values.cron : undefined,
+    interval: typeof values.interval === "string" ? values.interval : undefined,
+  });
+  const common = {
+    preset,
+    name: typeof values.name === "string" ? values.name : undefined,
+    enabled: true,
+    ...(trigger ? { trigger } : {}),
+  };
+
+  switch (preset) {
+    case "daily_brief":
+    case "weekly_review":
+    case "dream_consolidation":
+      return {
+        ...common,
+        preset,
+        context_sources: Array.isArray(values["context-source"])
+          ? (values["context-source"] as string[])
+          : typeof values["context-source"] === "string"
+            ? [values["context-source"] as string]
+            : [],
+      };
+    case "goal_probe":
+      if (typeof values["data-source-id"] !== "string" || values["data-source-id"].length === 0) {
+        throw new Error("--data-source-id is required for the goal_probe preset");
+      }
+      return {
+        ...common,
+        preset: "goal_probe",
+        data_source_id: values["data-source-id"] as string,
+        query_params: {},
+        detector_mode: (typeof values["detector-mode"] === "string"
+          ? values["detector-mode"]
+          : "diff") as "threshold" | "diff" | "presence",
+        threshold_value: typeof values["threshold-value"] === "string"
+          ? parseFloat(values["threshold-value"] as string)
+          : undefined,
+        baseline_window: typeof values["baseline-window"] === "string"
+          ? parseInt(values["baseline-window"] as string, 10)
+          : 5,
+        llm_on_change: values["llm-on-change"] !== false,
+        llm_prompt_template: typeof values["llm-prompt-template"] === "string"
+          ? values["llm-prompt-template"] as string
+          : undefined,
+      };
+    default:
+      throw new Error(`Unknown preset: ${preset}`);
   }
 }
 
@@ -46,6 +129,7 @@ async function scheduleAdd(engine: ScheduleEngine, argv: string[]): Promise<void
     args: argv,
     options: {
       name: { type: "string" },
+      preset: { type: "string" },
       type: { type: "string", default: "http" },
       url: { type: "string" },
       host: { type: "string" },
@@ -56,9 +140,23 @@ async function scheduleAdd(engine: ScheduleEngine, argv: string[]): Promise<void
       cron: { type: "string" },
       interval: { type: "string" },
       threshold: { type: "string", default: "3" },
+      "data-source-id": { type: "string" },
+      "detector-mode": { type: "string" },
+      "threshold-value": { type: "string" },
+      "baseline-window": { type: "string" },
+      "llm-on-change": { type: "boolean", default: true },
+      "llm-prompt-template": { type: "string" },
+      "context-source": { type: "string", multiple: true },
     },
     strict: false,
   });
+
+  if (values.preset) {
+    const presetInput = buildPresetInput(values);
+    const entry = await engine.addEntry(buildSchedulePresetEntry(presetInput));
+    console.log(`Added preset schedule entry: ${entry.id} (${entry.name})`);
+    return;
+  }
 
   if (!values.name) {
     console.error("Error: --name is required");
@@ -83,6 +181,10 @@ async function scheduleAdd(engine: ScheduleEngine, argv: string[]): Promise<void
     layer: "heartbeat",
     trigger,
     enabled: true,
+    metadata: {
+      source: "manual",
+      dependency_hints: [],
+    },
     heartbeat: {
       check_type: checkType,
       check_config: checkConfig,
@@ -100,13 +202,82 @@ async function scheduleRemove(engine: ScheduleEngine, argv: string[]): Promise<v
     console.error("Error: schedule entry ID is required");
     return;
   }
-  // Support short IDs (first 8 chars)
   const entries = engine.getEntries();
-  const match = entries.find(e => e.id === id || e.id.startsWith(id));
+  const match = entries.find((entry) => entry.id === id || entry.id.startsWith(id));
   if (!match) {
     console.error(`No schedule entry found matching: ${id}`);
     return;
   }
   await engine.removeEntry(match.id);
   console.log(`Removed schedule entry: ${match.id} (${match.name})`);
+}
+
+function schedulePresetList(): void {
+  const definitions = listSchedulePresetDefinitions();
+  for (const definition of definitions) {
+    const trigger = definition.defaultTrigger.type === "cron"
+      ? definition.defaultTrigger.expression
+      : `every ${definition.defaultTrigger.seconds}s`;
+    console.log(`${definition.key}`);
+    console.log(`  ${definition.description}`);
+    console.log(`  default trigger: ${trigger}`);
+    console.log(`  dependencies: ${definition.dependencyHints.join(", ") || "none"}`);
+  }
+}
+
+async function scheduleSuggestions(
+  baseDir: string,
+  engine: ScheduleEngine,
+  argv: string[],
+): Promise<void> {
+  const store = new DreamScheduleSuggestionStore(baseDir);
+  const action = argv[0] ?? "list";
+
+  switch (action) {
+    case "list": {
+      const suggestions = await store.list();
+      if (suggestions.length === 0) {
+        console.log("No dream schedule suggestions.");
+        return;
+      }
+      for (const suggestion of suggestions) {
+        console.log(
+          `  ${suggestion.id.slice(0, 8)}  [${suggestion.status}] ${suggestion.type}  goal=${suggestion.goalId ?? "-"}  proposal=${suggestion.proposal}`
+        );
+        console.log(`    ${suggestion.reason}`);
+        if (suggestion.applied_entry_id) {
+          console.log(`    applied entry: ${suggestion.applied_entry_id}`);
+        }
+      }
+      return;
+    }
+    case "apply": {
+      const id = argv[1];
+      if (!id) {
+        console.error("Error: dream suggestion ID is required");
+        return;
+      }
+      const { entry, duplicate } = await store.applySuggestion(id, engine);
+      console.log(
+        duplicate
+          ? `Matched existing schedule entry: ${entry.id} (${entry.name})`
+          : `Applied dream suggestion to schedule entry: ${entry.id} (${entry.name})`
+      );
+      return;
+    }
+    case "reject":
+    case "dismiss": {
+      const id = argv[1];
+      if (!id) {
+        console.error("Error: dream suggestion ID is required");
+        return;
+      }
+      const reason = argv.slice(2).join(" ").trim() || undefined;
+      const suggestion = await store.markDecision(id, action === "reject" ? "rejected" : "dismissed", reason);
+      console.log(`Marked dream suggestion ${suggestion.id} as ${suggestion.status}`);
+      return;
+    }
+    default:
+      console.error("Usage: pulseed schedule suggestions <list|apply|reject|dismiss> [id]");
+  }
 }

--- a/src/interface/cli/commands/schedule.ts
+++ b/src/interface/cli/commands/schedule.ts
@@ -104,6 +104,9 @@ function buildPresetInput(values: Record<string, unknown>): SchedulePresetInput 
         ...common,
         preset: "goal_probe",
         data_source_id: values["data-source-id"] as string,
+        probe_dimension: typeof values["probe-dimension"] === "string"
+          ? values["probe-dimension"] as string
+          : undefined,
         query_params: {},
         detector_mode: (typeof values["detector-mode"] === "string"
           ? values["detector-mode"]
@@ -144,6 +147,7 @@ async function scheduleAdd(engine: ScheduleEngine, argv: string[]): Promise<void
       "detector-mode": { type: "string" },
       "threshold-value": { type: "string" },
       "baseline-window": { type: "string" },
+      "probe-dimension": { type: "string" },
       "llm-on-change": { type: "boolean", default: true },
       "llm-prompt-template": { type: "string" },
       "context-source": { type: "string", multiple: true },

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -10,7 +10,7 @@ import { readJsonFile } from "../../base/utils/json-io.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import type { DataSourceConfig } from "../../base/types/data-source.js";
 import type { IDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
-import { FileDataSourceAdapter, HttpApiDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
+import { FileDataSourceAdapter, HttpApiDataSourceAdapter, PostgresDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
 import { GitHubIssueDataSourceAdapter } from "../../adapters/datasources/github-issue-datasource.js";
 import { FileExistenceDataSourceAdapter } from "../../adapters/datasources/file-existence-datasource.js";
 import { ShellDataSourceAdapter } from "../../adapters/datasources/shell-datasource.js";
@@ -51,6 +51,37 @@ import { HookManager } from "../../runtime/hook-manager.js";
 import { getCliLogger } from "./cli-logger.js";
 import { formatOperationError } from "./utils.js";
 
+export function createCliDataSourceAdapter(cfg: DataSourceConfig): IDataSourceAdapter | null {
+  if (cfg.type === "file") {
+    return new FileDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "http_api") {
+    return new HttpApiDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "database") {
+    return new PostgresDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "github_issue") {
+    return new GitHubIssueDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "file_existence") {
+    return new FileExistenceDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "shell") {
+    const adapter = new ShellDataSourceAdapter(
+      cfg.id,
+      (cfg.connection.commands ?? {}) as Record<string, import("../../adapters/datasources/shell-datasource.js").ShellCommandSpec>,
+      cfg.connection?.path ?? process.cwd()
+    );
+    if (cfg.scope_goal_id) {
+      (adapter.config as Record<string, unknown>).scope_goal_id = cfg.scope_goal_id;
+    }
+    return adapter;
+  }
+
+  return null;
+}
+
 export async function buildDeps(
   stateManager: StateManager,
   characterConfigManager: CharacterConfigManager,
@@ -75,25 +106,11 @@ export async function buildDeps(
       const files = (await fsp.readdir(dsDir)).filter(f => f.endsWith('.json'));
       for (const file of files) {
         const cfg = await readJsonFile<DataSourceConfig>(path.join(dsDir, file));
-        if (cfg.type === 'file') {
-          dataSources.push(new FileDataSourceAdapter(cfg));
-        } else if (cfg.type === 'http_api') {
-          dataSources.push(new HttpApiDataSourceAdapter(cfg));
-        } else if (cfg.type === 'github_issue' || cfg.type === 'custom' || cfg.type === 'database') {
-          dataSources.push(new GitHubIssueDataSourceAdapter(cfg));
-        } else if (cfg.type === 'file_existence') {
-          dataSources.push(new FileExistenceDataSourceAdapter(cfg));
-        } else if (cfg.type === 'shell') {
-          const adapter = new ShellDataSourceAdapter(
-            cfg.id,
-            (cfg.connection.commands ?? {}) as Record<string, import("../../adapters/datasources/shell-datasource.js").ShellCommandSpec>,
-            cfg.connection?.path ?? process.cwd()
-          );
-          // Propagate scope_goal_id from datasource config for dimension matching
-          if (cfg.scope_goal_id) {
-            (adapter.config as Record<string, unknown>).scope_goal_id = cfg.scope_goal_id;
-          }
+        const adapter = createCliDataSourceAdapter(cfg);
+        if (adapter) {
           dataSources.push(adapter);
+        } else {
+          getCliLogger().warn(`[pulseed] Unsupported built-in datasource type "${cfg.type}" in ${file}; skipping`);
         }
       }
     }
@@ -271,5 +288,16 @@ export async function buildDeps(
 
   coreLoop.setTimeHorizonEngine(new TimeHorizonEngine());
 
-  return { coreLoop, goalNegotiator, goalRefiner, reportingEngine, stateManager, driveSystem, llmClient };
+  return {
+    coreLoop,
+    goalNegotiator,
+    goalRefiner,
+    reportingEngine,
+    stateManager,
+    driveSystem,
+    llmClient,
+    hookManager,
+    memoryLifecycleManager,
+    knowledgeManager,
+  };
 }

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -50,7 +50,7 @@ Usage:
   pulseed config set <key> <value>     Set a configuration value
   pulseed config get <key>             Get a configuration value
   pulseed config character             Show or update character configuration
-  pulseed datasource add <type>        Register a new data source (file | http_api)
+  pulseed datasource add <type>        Register a new data source (file | http_api | database)
   pulseed datasource list              List all registered data sources
   pulseed datasource remove <id>       Remove a data source by ID
   pulseed capability list              List all registered capabilities
@@ -116,6 +116,9 @@ Options (pulseed datasource add):
   --name <name>                       Human-readable name for the data source
   --path <path>                       File path (required for type=file)
   --url <url>                         HTTP URL (required for type=http_api)
+  --connection-string <dsn>           Postgres DSN (required for type=database unless --url is used)
+  --dimension <name>                  Dimension name mapped by the datasource query (type=database)
+  --query <sql>                       SQL query or scalar expression (required for type=database)
 
 Options (pulseed provider set):
   --llm <provider>                    LLM provider: anthropic | openai | ollama | codex
@@ -141,6 +144,7 @@ Examples:
   pulseed config character --caution-level 3
   pulseed datasource add file --path /path/to/metrics.json --name "My Metrics"
   pulseed datasource add http_api --url https://api.example.com/metrics --name "API"
+  pulseed datasource add database --connection-string postgresql://localhost/app --dimension open_issue_count --query "SELECT count(*) FROM issues WHERE state = 'open'"
   pulseed datasource list
   pulseed datasource remove ds_1234567890
 `.trim());

--- a/src/orchestrator/loop/__tests__/core-loop-capability.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-capability.test.ts
@@ -8,6 +8,7 @@ import {
   type DriveScorerModule,
   type ReportingEngine,
 } from "../core-loop.js";
+import { handleCapabilityAcquisition } from "../core-loop-capability.js";
 import { StateManager } from "../../../base/state/state-manager.js";
 import type { ObservationEngine } from "../../../platform/observation/observation-engine.js";
 import type { TaskLifecycle, TaskCycleResult } from "../../execution/task/task-lifecycle.js";
@@ -156,6 +157,7 @@ function createMockCapabilityDetector() {
   return {
     detectDeficiency: vi.fn(),
     detectGoalCapabilityGap: vi.fn(),
+    recommendAcquisition: vi.fn().mockReturnValue([]),
     planAcquisition: vi.fn(),
     verifyAcquiredCapability: vi.fn().mockResolvedValue("pass"),
     registerCapability: vi.fn().mockResolvedValue(undefined),
@@ -458,5 +460,62 @@ describe("CoreLoop — capability_acquiring handler", () => {
 
     // escalateToUser should have been called after 3 adapter failures
     expect(mocks.capabilityDetector.escalateToUser).toHaveBeenCalledTimes(1);
+  });
+
+  it("includes a recommended plugin path in the acquisition prompt when available", async () => {
+    const { mocks } = createMockDeps(tmpDir);
+    mocks.capabilityDetector.recommendAcquisition.mockReturnValue([
+      {
+        pluginName: "postgres-datasource",
+        installSource: "examples/plugins/postgres-datasource",
+        rationale: "Use the bundled Postgres datasource plugin.",
+        verificationHint: "Load the plugin and check its datasource health.",
+        requiresApproval: false,
+      },
+    ]);
+
+    await handleCapabilityAcquisition(
+      makeAcquisitionTask(),
+      "goal-1",
+      mocks.adapter,
+      mocks.capabilityDetector as unknown as CapabilityDetector,
+      new Map(),
+      undefined
+    );
+
+    const executeCall = (mocks.adapter.execute as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(executeCall.prompt).toContain("postgres-datasource");
+    expect(executeCall.prompt).toContain("examples/plugins/postgres-datasource");
+  });
+
+  it("returns a replan signal after successful capability acquisition", async () => {
+    const { mocks } = createMockDeps(tmpDir);
+    mocks.capabilityDetector.recommendAcquisition.mockReturnValue([
+      {
+        pluginName: "postgres-datasource",
+        installSource: "examples/plugins/postgres-datasource",
+        rationale: "Use the bundled Postgres datasource plugin.",
+        verificationHint: "Load the plugin and check its datasource health.",
+        requiresApproval: false,
+      },
+    ]);
+
+    const outcome = await handleCapabilityAcquisition(
+      makeAcquisitionTask(),
+      "goal-1",
+      mocks.adapter,
+      mocks.capabilityDetector as unknown as CapabilityDetector,
+      new Map(),
+      undefined
+    );
+
+    expect(outcome).toEqual(
+      expect.objectContaining({
+        capabilityName: "docker",
+        replanRequired: true,
+        recommendedPlugin: "postgres-datasource",
+        recommendationSource: "examples/plugins/postgres-datasource",
+      })
+    );
   });
 });

--- a/src/orchestrator/loop/core-loop-capability.ts
+++ b/src/orchestrator/loop/core-loop-capability.ts
@@ -10,6 +10,13 @@ import type { IAdapter } from "../execution/adapter-layer.js";
 import type { CapabilityDetector } from "../../platform/observation/capability-detector.js";
 import type { CapabilityAcquisitionTask } from "../../base/types/capability.js";
 
+export interface CapabilityAcquisitionOutcome {
+  capabilityName: string;
+  replanRequired: boolean;
+  recommendationSource?: string;
+  recommendedPlugin?: string;
+}
+
 /** Handle the "capability_acquiring" action from TaskLifecycle.
  * Delegates acquisition to an adapter, verifies the result, and registers
  * the capability on success. Retries up to 3 times before escalating. */
@@ -20,27 +27,44 @@ export async function handleCapabilityAcquisition(
   capabilityDetector: CapabilityDetector | undefined,
   capabilityAcquisitionFailures: Map<string, number>,
   logger: Logger | undefined
-): Promise<void> {
-  if (!capabilityDetector) {
-    logger?.warn("CoreLoop: capability_acquiring action received but no capabilityDetector configured — skipping");
-    return;
-  }
-
+): Promise<CapabilityAcquisitionOutcome> {
   const capName = acquisitionTask.gap.missing_capability.name;
   const capType = acquisitionTask.gap.missing_capability.type;
 
+  if (!capabilityDetector) {
+    logger?.warn("CoreLoop: capability_acquiring action received but no capabilityDetector configured — skipping");
+    return { capabilityName: capName, replanRequired: false };
+  }
+
+  const recommendation = capabilityDetector.recommendAcquisition(acquisitionTask.gap)[0];
+
+  try {
+    await capabilityDetector.setCapabilityStatus(capName, capType, "requested");
+  } catch {
+    // Non-fatal.
+  }
+
   logger?.info("CoreLoop: handling capability acquisition", { capName, capType, method: acquisitionTask.method });
+
+  const recommendationBlock = recommendation
+    ? `\nRecommended acquisition path:\n` +
+      `- Plugin: ${recommendation.pluginName}\n` +
+      `- Install source: ${recommendation.installSource}\n` +
+      `- Verification hint: ${recommendation.verificationHint}\n`
+    : "";
 
   const prompt =
     `Capability Acquisition Task\n` +
     `Method: ${acquisitionTask.method}\n` +
     `Description: ${acquisitionTask.task_description}\n` +
     `Success criteria: ${acquisitionTask.success_criteria.join("; ")}\n\n` +
+    recommendationBlock +
     `Instructions: Please acquire or set up the capability "${capName}" (${capType}). ` +
     `Follow the method "${acquisitionTask.method}" and ensure the success criteria are met.`;
 
   let agentResult;
   try {
+    await capabilityDetector.setCapabilityStatus(capName, capType, "acquiring");
     agentResult = await adapter.execute({ prompt, timeout_ms: 120000, adapter_type: adapter.adapterType });
   } catch (err) {
     logger?.error("CoreLoop: adapter execution failed during capability acquisition", {
@@ -48,7 +72,12 @@ export async function handleCapabilityAcquisition(
       error: err instanceof Error ? err.message : String(err),
     });
     await recordCapabilityFailure(capabilityDetector, acquisitionTask, goalId, capabilityAcquisitionFailures, logger);
-    return;
+    return {
+      capabilityName: capName,
+      replanRequired: false,
+      recommendationSource: recommendation?.installSource,
+      recommendedPlugin: recommendation?.pluginName,
+    };
   }
 
   const capability = {
@@ -72,7 +101,12 @@ export async function handleCapabilityAcquisition(
       error: err instanceof Error ? err.message : String(err),
     });
     await recordCapabilityFailure(capabilityDetector, acquisitionTask, goalId, capabilityAcquisitionFailures, logger);
-    return;
+    return {
+      capabilityName: capName,
+      replanRequired: false,
+      recommendationSource: recommendation?.installSource,
+      recommendedPlugin: recommendation?.pluginName,
+    };
   }
 
   if (verificationResult === "pass") {
@@ -84,12 +118,28 @@ export async function handleCapabilityAcquisition(
         acquired_at: new Date().toISOString(),
       });
       await capabilityDetector.setCapabilityStatus(capName, capType, "available");
-      logger?.info("CoreLoop: capability acquired and registered successfully", { capName });
+      logger?.info("CoreLoop: capability acquired and registered successfully", {
+        capName,
+        replanRequired: true,
+        recommendedPlugin: recommendation?.pluginName,
+      });
+      return {
+        capabilityName: capName,
+        replanRequired: true,
+        recommendationSource: recommendation?.installSource,
+        recommendedPlugin: recommendation?.pluginName,
+      };
     } catch (err) {
       logger?.error("CoreLoop: failed to register capability after verification pass", {
         capName,
         error: err instanceof Error ? err.message : String(err),
       });
+      return {
+        capabilityName: capName,
+        replanRequired: false,
+        recommendationSource: recommendation?.installSource,
+        recommendedPlugin: recommendation?.pluginName,
+      };
     }
   } else if (verificationResult === "escalate") {
     capabilityAcquisitionFailures.delete(capName);
@@ -97,6 +147,13 @@ export async function handleCapabilityAcquisition(
   } else {
     await recordCapabilityFailure(capabilityDetector, acquisitionTask, goalId, capabilityAcquisitionFailures, logger);
   }
+
+  return {
+    capabilityName: capName,
+    replanRequired: false,
+    recommendationSource: recommendation?.installSource,
+    recommendedPlugin: recommendation?.pluginName,
+  };
 }
 
 /** Records a capability acquisition failure and escalates after 3 consecutive failures. */

--- a/src/orchestrator/loop/core-loop-phases-b.ts
+++ b/src/orchestrator/loop/core-loop-phases-b.ts
@@ -29,6 +29,7 @@ import {
   expandKnowledgeEntriesWithGraph,
   mergeWorkingMemorySelections,
 } from "../execution/context/context-builder.js";
+import type { CapabilityAcquisitionOutcome } from "./core-loop-capability.js";
 
 // ─── Phase 5 ───
 
@@ -505,7 +506,7 @@ export function checkDependencyBlock(
 
 /** Callbacks passed to runTaskCycleWithContext to keep mutable state and side-effects on CoreLoop. */
 export interface LoopCallbacks {
-  handleCapabilityAcquisition: (task: unknown, goalId: string, adapter: unknown) => Promise<void>;
+  handleCapabilityAcquisition: (task: unknown, goalId: string, adapter: unknown) => Promise<CapabilityAcquisitionOutcome | void>;
   incrementTransferCounter: () => number;
   tryGenerateReport: (goalId: string, loopIndex: number, result: LoopIterationResult, goal: Goal) => void;
 }
@@ -728,7 +729,22 @@ export async function runTaskCycleWithContext(
 
     // Handle capability_acquiring
     if (taskResult.action === "capability_acquiring" && taskResult.acquisition_task) {
-      await handleCapabilityAcquisition(taskResult.acquisition_task, goalId, adapter);
+      const acquisitionOutcome = await handleCapabilityAcquisition(taskResult.acquisition_task, goalId, adapter);
+      if (acquisitionOutcome?.replanRequired) {
+        ctx.logger?.info("CoreLoop: capability acquisition requested replanning", {
+          capabilityName: acquisitionOutcome.capabilityName,
+          replanRequired: acquisitionOutcome.replanRequired,
+          recommendationSource: acquisitionOutcome.recommendationSource,
+          recommendedPlugin: acquisitionOutcome.recommendedPlugin,
+        });
+        ctx.deps.onProgress?.({
+          iteration: loopIndex + 1,
+          maxIterations: ctx.config.maxIterations,
+          phase: "Generating task...",
+          gap: result.gapAggregate,
+          taskDescription: `Replanning after capability acquisition: ${acquisitionOutcome.capabilityName}`,
+        });
+      }
     }
 
     // Portfolio: record task completion

--- a/src/platform/dream/__tests__/dream-analyzer.test.ts
+++ b/src/platform/dream/__tests__/dream-analyzer.test.ts
@@ -177,9 +177,18 @@ describe("DreamAnalyzer", () => {
 
       const scheduleSuggestions = JSON.parse(
         await fs.promises.readFile(path.join(tempDir, "dream", "schedule-suggestions.json"), "utf8")
-      ) as { suggestions: Array<{ goalId?: string; proposal: string }> };
+      ) as { suggestions: Array<{ goalId?: string; proposal: string; type: string }> };
       expect(scheduleSuggestions.suggestions).toEqual([
-        expect.objectContaining({ goalId: goalB, proposal: "0 3 * * *" }),
+        expect.objectContaining({
+          goalId: goalB,
+          proposal: "0 3 * * *",
+          type: "goal_trigger",
+          trigger: {
+            type: "cron",
+            expression: "0 3 * * *",
+            timezone: "UTC",
+          },
+        }),
       ]);
 
       const watermarks = JSON.parse(

--- a/src/platform/dream/__tests__/dream-schedule-suggestions.test.ts
+++ b/src/platform/dream/__tests__/dream-schedule-suggestions.test.ts
@@ -1,0 +1,156 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import { DreamScheduleSuggestionStore } from "../dream-schedule-suggestions.js";
+
+describe("DreamScheduleSuggestionStore", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = makeTempDir("dream-suggestions-");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tempDir);
+  });
+
+  async function writeSuggestions(payload: unknown): Promise<void> {
+    await fs.mkdir(path.join(tempDir, "dream"), { recursive: true });
+    await fs.writeFile(
+      path.join(tempDir, "dream", "schedule-suggestions.json"),
+      JSON.stringify(payload, null, 2),
+      "utf8",
+    );
+  }
+
+  it("normalizes legacy suggestions into pending review items", async () => {
+    await writeSuggestions({
+      generated_at: "2026-04-08T00:00:00.000Z",
+      suggestions: [
+        {
+          type: "goal_trigger",
+          goalId: "goal-1",
+          proposal: "0 9 * * *",
+          reason: "Manual execution clusters around 09:00 UTC.",
+          confidence: 0.8,
+        },
+      ],
+    });
+
+    const store = new DreamScheduleSuggestionStore(tempDir);
+    const suggestions = await store.list();
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]?.id).toBeTruthy();
+    expect(suggestions[0]?.status).toBe("pending");
+  });
+
+  it("applies a pending dream suggestion into a real schedule entry", async () => {
+    await writeSuggestions({
+      generated_at: "2026-04-08T00:00:00.000Z",
+      suggestions: [
+        {
+          id: "dream-1",
+          type: "goal_trigger",
+          goalId: "goal-1",
+          name: "Dream goal trigger: goal-1",
+          trigger: { type: "cron", expression: "0 9 * * *", timezone: "UTC" },
+          proposal: "0 9 * * *",
+          reason: "Manual execution clusters around 09:00 UTC.",
+          confidence: 0.8,
+          status: "pending",
+        },
+      ],
+    });
+
+    const store = new DreamScheduleSuggestionStore(tempDir);
+    const engine = new ScheduleEngine({ baseDir: tempDir });
+    await engine.loadEntries();
+
+    const result = await store.applySuggestion("dream-1", engine);
+
+    expect(result.duplicate).toBe(false);
+    expect(result.entry.layer).toBe("goal_trigger");
+    expect(result.entry.goal_trigger?.goal_id).toBe("goal-1");
+    expect(result.entry.metadata).toEqual(expect.objectContaining({
+      source: "dream",
+      dream_suggestion_id: "dream-1",
+    }));
+
+    const suggestions = await store.list();
+    expect(suggestions[0]).toEqual(expect.objectContaining({
+      id: "dream-1",
+      status: "applied",
+      applied_entry_id: result.entry.id,
+    }));
+  });
+
+  it("reuses an equivalent existing schedule entry instead of duplicating it", async () => {
+    await writeSuggestions({
+      generated_at: "2026-04-08T00:00:00.000Z",
+      suggestions: [
+        {
+          id: "dream-dup",
+          type: "goal_trigger",
+          goalId: "goal-1",
+          name: "Dream goal trigger: goal-1",
+          trigger: { type: "cron", expression: "0 9 * * *", timezone: "UTC" },
+          proposal: "0 9 * * *",
+          reason: "Manual execution clusters around 09:00 UTC.",
+          confidence: 0.8,
+          status: "pending",
+        },
+      ],
+    });
+
+    const engine = new ScheduleEngine({ baseDir: tempDir });
+    await engine.loadEntries();
+    const existing = await engine.addEntry({
+      name: "Existing goal trigger",
+      layer: "goal_trigger",
+      trigger: { type: "cron", expression: "0 9 * * *", timezone: "UTC" },
+      enabled: true,
+      metadata: {
+        source: "manual",
+        dependency_hints: [],
+      },
+      goal_trigger: {
+        goal_id: "goal-1",
+        max_iterations: 10,
+        skip_if_active: true,
+      },
+    });
+
+    const store = new DreamScheduleSuggestionStore(tempDir);
+    const result = await store.applySuggestion("dream-dup", engine);
+
+    expect(result.duplicate).toBe(true);
+    expect(result.entry.id).toBe(existing.id);
+    expect(engine.getEntries()).toHaveLength(1);
+  });
+
+  it("marks suggestions as rejected or dismissed", async () => {
+    await writeSuggestions({
+      generated_at: "2026-04-08T00:00:00.000Z",
+      suggestions: [
+        {
+          id: "dream-reject",
+          type: "goal_trigger",
+          goalId: "goal-1",
+          proposal: "0 9 * * *",
+          reason: "Manual execution clusters around 09:00 UTC.",
+          confidence: 0.8,
+          status: "pending",
+        },
+      ],
+    });
+
+    const store = new DreamScheduleSuggestionStore(tempDir);
+    const rejected = await store.markDecision("dream-reject", "rejected", "not useful");
+
+    expect(rejected.status).toBe("rejected");
+    expect(rejected.decision_reason).toBe("not useful");
+  });
+});

--- a/src/platform/dream/dream-analyzer.ts
+++ b/src/platform/dream/dream-analyzer.ts
@@ -12,8 +12,10 @@ import {
 } from "../../prompt/purposes/dream.js";
 import {
   DreamPatternResponseSchema,
+  DreamRunReportSchema,
   ImportanceEntrySchema,
   IterationLogSchema,
+  ScheduleSuggestionSchema,
   ScheduleSuggestionFileSchema,
   SessionLogSchema,
   type DreamLogConfig,
@@ -128,7 +130,9 @@ export class DreamAnalyzer {
       completedPhases.push("C");
     }
 
-    return {
+    const normalizedSuggestions = suggestions.map((suggestion) => ScheduleSuggestionSchema.parse(suggestion));
+
+    return DreamRunReportSchema.parse({
       tier: options.tier,
       phasesCompleted: completedPhases,
       goalsProcessed: selectedGoalIds,
@@ -138,8 +142,8 @@ export class DreamAnalyzer {
       partial,
       stats: ingestion.stats,
       learnedPatterns: patterns,
-      suggestions,
-    };
+      suggestions: normalizedSuggestions,
+    });
   }
 
   private async resolveGoalIds(requested?: string[]): Promise<string[]> {
@@ -540,11 +544,18 @@ export class DreamAnalyzer {
       if (!best || best[1] < 3) continue;
       const [hour, count] = best;
       suggestions.push({
-        type: "cron",
+        type: "goal_trigger",
         goalId,
+        name: `Dream goal trigger: ${goalId}`,
+        trigger: {
+          type: "cron",
+          expression: `0 ${hour} * * *`,
+          timezone: "UTC",
+        },
         confidence: Math.min(0.95, 0.55 + count * 0.08),
         reason: `Manual execution clusters around ${hour.toString().padStart(2, "0")}:00 UTC.`,
         proposal: `0 ${hour} * * *`,
+        status: "pending",
       });
     }
     return suggestions;

--- a/src/platform/dream/dream-schedule-suggestions.ts
+++ b/src/platform/dream/dream-schedule-suggestions.ts
@@ -1,0 +1,257 @@
+import { randomUUID } from "node:crypto";
+import * as path from "node:path";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../../base/utils/json-io.js";
+import { ScheduleEngine } from "../../runtime/schedule-engine.js";
+import {
+  ScheduleTriggerSchema,
+  type ScheduleEntry,
+  type ScheduleEntryInput,
+  type ScheduleTriggerInput,
+} from "../../runtime/types/schedule.js";
+import {
+  ScheduleSuggestionFileSchema,
+  ScheduleSuggestionSchema,
+  type ScheduleSuggestion,
+} from "./dream-types.js";
+
+const DREAM_SCHEDULE_SUGGESTIONS_FILE = path.join("dream", "schedule-suggestions.json");
+
+type CreateScheduleEntryInput = Omit<
+  ScheduleEntryInput,
+  | "id"
+  | "created_at"
+  | "updated_at"
+  | "last_fired_at"
+  | "next_fire_at"
+  | "consecutive_failures"
+  | "last_escalation_at"
+  | "baseline_results"
+  | "total_executions"
+  | "total_tokens_used"
+  | "max_tokens_per_day"
+  | "tokens_used_today"
+  | "budget_reset_at"
+  | "escalation_timestamps"
+>;
+
+export interface ResolvedScheduleSuggestion extends ScheduleSuggestion {
+  id: string;
+  status: "pending" | "applied" | "rejected" | "dismissed";
+}
+
+function normalizeSuggestion(input: ScheduleSuggestion): ResolvedScheduleSuggestion {
+  return {
+    ...input,
+    id: input.id ?? randomUUID(),
+    status: input.status ?? "pending",
+  };
+}
+
+function normalizeTrigger(trigger: ScheduleTriggerInput): ScheduleTriggerInput {
+  const parsed = ScheduleTriggerSchema.parse(trigger);
+  return parsed.type === "cron"
+    ? { type: "cron", expression: parsed.expression, timezone: parsed.timezone }
+    : { type: "interval", seconds: parsed.seconds, jitter_factor: parsed.jitter_factor };
+}
+
+function resolveSuggestionTrigger(suggestion: ResolvedScheduleSuggestion): ScheduleTriggerInput {
+  if (suggestion.trigger) {
+    return normalizeTrigger(suggestion.trigger);
+  }
+  const trimmed = suggestion.proposal.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Dream suggestion does not include a trigger proposal");
+  }
+  return {
+    type: "cron",
+    expression: trimmed,
+    timezone: "UTC",
+  };
+}
+
+function triggersEqual(left: ScheduleTriggerInput, right: ScheduleTriggerInput): boolean {
+  const a = normalizeTrigger(left);
+  const b = normalizeTrigger(right);
+  if (a.type !== b.type) return false;
+  if (a.type === "cron" && b.type === "cron") {
+    return a.expression === b.expression && (a.timezone ?? "UTC") === (b.timezone ?? "UTC");
+  }
+  if (a.type === "interval" && b.type === "interval") {
+    return a.seconds === b.seconds && (a.jitter_factor ?? 0) === (b.jitter_factor ?? 0);
+  }
+  return false;
+}
+
+function entriesEquivalent(existing: ScheduleEntry, candidate: CreateScheduleEntryInput): boolean {
+  if (existing.layer !== candidate.layer) return false;
+  if (!triggersEqual(existing.trigger, candidate.trigger)) return false;
+
+  if (existing.metadata?.dream_suggestion_id && existing.metadata.dream_suggestion_id === candidate.metadata?.dream_suggestion_id) {
+    return true;
+  }
+
+  if (existing.layer === "goal_trigger" && candidate.layer === "goal_trigger") {
+    return existing.goal_trigger?.goal_id === candidate.goal_trigger?.goal_id;
+  }
+
+  if (existing.layer === "cron" && candidate.layer === "cron") {
+    return existing.name === candidate.name && existing.cron?.report_type === candidate.cron?.report_type;
+  }
+
+  if (existing.layer === "probe" && candidate.layer === "probe") {
+    return existing.probe?.data_source_id === candidate.probe?.data_source_id;
+  }
+
+  return existing.name === candidate.name;
+}
+
+function buildEntryFromSuggestion(suggestion: ResolvedScheduleSuggestion): CreateScheduleEntryInput {
+  const trigger = resolveSuggestionTrigger(suggestion);
+
+  if ((suggestion.type === "goal_trigger" || suggestion.type === "cron") && suggestion.goalId) {
+    return {
+      name: suggestion.name ?? `Dream goal trigger: ${suggestion.goalId}`,
+      layer: "goal_trigger",
+      trigger,
+      enabled: true,
+      metadata: {
+        source: "dream",
+        dream_suggestion_id: suggestion.id,
+        dependency_hints: ["core_loop", "state_manager"],
+        note: suggestion.reason,
+      },
+      goal_trigger: {
+        goal_id: suggestion.goalId,
+        max_iterations: 10,
+        skip_if_active: true,
+      },
+    };
+  }
+
+  return {
+    name: suggestion.name ?? "Dream scheduled follow-up",
+    layer: "cron",
+    trigger,
+    enabled: true,
+    metadata: {
+      source: "dream",
+      dream_suggestion_id: suggestion.id,
+      dependency_hints: ["llm_client", "notification_dispatcher"],
+      note: suggestion.reason,
+    },
+    cron: {
+      job_kind: "prompt",
+      prompt_template: `Review this dream-generated schedule suggestion and act if appropriate:\n${suggestion.reason}`,
+      context_sources: [],
+      output_format: "notification",
+      report_type: "dream_schedule_followup",
+      max_tokens: 800,
+    },
+  };
+}
+
+export class DreamScheduleSuggestionStore {
+  private readonly filePath: string;
+
+  constructor(private readonly baseDir: string) {
+    this.filePath = path.join(baseDir, DREAM_SCHEDULE_SUGGESTIONS_FILE);
+  }
+
+  async load(): Promise<{ generated_at: string; suggestions: ResolvedScheduleSuggestion[] }> {
+    const raw = await readJsonFileOrNull(this.filePath);
+    if (raw === null) {
+      return {
+        generated_at: new Date(0).toISOString(),
+        suggestions: [],
+      };
+    }
+
+    const parsed = ScheduleSuggestionFileSchema.parse(raw);
+    return {
+      generated_at: parsed.generated_at,
+      suggestions: parsed.suggestions.map(normalizeSuggestion),
+    };
+  }
+
+  async list(): Promise<ResolvedScheduleSuggestion[]> {
+    const data = await this.load();
+    return data.suggestions;
+  }
+
+  async save(suggestions: ResolvedScheduleSuggestion[], generatedAt?: string): Promise<void> {
+    await writeJsonFileAtomic(this.filePath, {
+      generated_at: generatedAt ?? new Date().toISOString(),
+      suggestions: suggestions.map((suggestion) => ScheduleSuggestionSchema.parse(suggestion)),
+    });
+  }
+
+  async resolveSuggestion(idOrPrefix: string): Promise<ResolvedScheduleSuggestion | null> {
+    const suggestions = await this.list();
+    return suggestions.find((item) => item.id === idOrPrefix || item.id.startsWith(idOrPrefix)) ?? null;
+  }
+
+  async markDecision(
+    idOrPrefix: string,
+    status: "rejected" | "dismissed",
+    reason?: string,
+  ): Promise<ResolvedScheduleSuggestion> {
+    const data = await this.load();
+    const index = data.suggestions.findIndex((item) => item.id === idOrPrefix || item.id.startsWith(idOrPrefix));
+    if (index === -1) {
+      throw new Error(`Dream suggestion not found: ${idOrPrefix}`);
+    }
+
+    const current = data.suggestions[index]!;
+    if (current.status === "applied") {
+      throw new Error(`Dream suggestion ${current.id} was already applied`);
+    }
+
+    const next: ResolvedScheduleSuggestion = {
+      ...current,
+      status,
+      decided_at: new Date().toISOString(),
+      decision_reason: reason,
+    };
+    data.suggestions[index] = next;
+    await this.save(data.suggestions, data.generated_at);
+    return next;
+  }
+
+  async applySuggestion(
+    idOrPrefix: string,
+    scheduleEngine: ScheduleEngine,
+  ): Promise<{ suggestion: ResolvedScheduleSuggestion; entry: ScheduleEntry; duplicate: boolean }> {
+    const data = await this.load();
+    const index = data.suggestions.findIndex((item) => item.id === idOrPrefix || item.id.startsWith(idOrPrefix));
+    if (index === -1) {
+      throw new Error(`Dream suggestion not found: ${idOrPrefix}`);
+    }
+
+    const suggestion = data.suggestions[index]!;
+    if (suggestion.status === "applied") {
+      throw new Error(`Dream suggestion ${suggestion.id} was already applied`);
+    }
+    if (suggestion.status === "rejected" || suggestion.status === "dismissed") {
+      throw new Error(`Dream suggestion ${suggestion.id} is already ${suggestion.status}`);
+    }
+
+    const entryInput = buildEntryFromSuggestion(suggestion);
+    const existing = scheduleEngine.getEntries().find((entry) => entriesEquivalent(entry, entryInput));
+    const entry = existing ?? await scheduleEngine.addEntry(entryInput);
+    const nextSuggestion: ResolvedScheduleSuggestion = {
+      ...suggestion,
+      status: "applied",
+      applied_entry_id: entry.id,
+      decided_at: new Date().toISOString(),
+      decision_reason: existing ? "matched_existing_schedule" : suggestion.decision_reason,
+    };
+    data.suggestions[index] = nextSuggestion;
+    await this.save(data.suggestions, data.generated_at);
+
+    return {
+      suggestion: nextSuggestion,
+      entry,
+      duplicate: Boolean(existing),
+    };
+  }
+}

--- a/src/platform/dream/dream-types.ts
+++ b/src/platform/dream/dream-types.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { LearnedPatternSchema } from "../knowledge/types/learning.js";
+import { ScheduleTriggerSchema } from "../../runtime/types/schedule.js";
 
 export const DreamSourceSchema = z.enum([
   "observation",
@@ -284,13 +285,21 @@ export const DreamPatternResponseSchema = z.object({
 export type DreamPatternResponse = z.infer<typeof DreamPatternResponseSchema>;
 
 export const ScheduleSuggestionSchema = z.object({
+  id: z.string().min(1).optional(),
   type: z.enum(["cron", "goal_trigger", "cleanup", "dream_cron"]),
   goalId: z.string().optional(),
+  name: z.string().optional(),
+  trigger: ScheduleTriggerSchema.optional(),
   confidence: z.number().min(0).max(1),
   reason: z.string(),
   proposal: z.string(),
+  status: z.enum(["pending", "applied", "rejected", "dismissed"]).default("pending"),
+  applied_entry_id: z.string().optional(),
+  decided_at: z.string().optional(),
+  decision_reason: z.string().optional(),
 });
 
+export type ScheduleSuggestionInput = z.input<typeof ScheduleSuggestionSchema>;
 export type ScheduleSuggestion = z.infer<typeof ScheduleSuggestionSchema>;
 
 export const ScheduleSuggestionFileSchema = z.object({

--- a/src/platform/knowledge/__tests__/knowledge-transfer-auto-apply.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-transfer-auto-apply.test.ts
@@ -106,6 +106,28 @@ describe("KnowledgeTransfer.autoApplyHighConfidenceTransfers", () => {
     expect(applied.length).toBeGreaterThan(0);
   });
 
+  it("does not re-apply the same transfer on a later auto-apply run", async () => {
+    const highConfPattern = makePattern({ confidence: 0.9, applicable_domains: ["testing"] });
+    const llmClient = createMockLLMClient([ADAPTATION_RESPONSE]);
+    const kt = new KnowledgeTransfer({
+      llmClient,
+      knowledgeManager: {} as any,
+      vectorIndex,
+      learningPipeline: makeMockLearningPipeline({ goal_a: [highConfPattern] }),
+      ethicsGate: makeMockEthicsGate("pass"),
+      stateManager,
+      transferTrust: makeMockTransferTrust(0.8),
+    });
+
+    const firstRun = await kt.autoApplyHighConfidenceTransfers("goal_b");
+    expect(firstRun.filter((c) => c.state === "applied")).toHaveLength(1);
+    expect(kt.getTransferResults()).toHaveLength(1);
+
+    const secondRun = await kt.autoApplyHighConfidenceTransfers("goal_b");
+    expect(secondRun).toHaveLength(0);
+    expect(kt.getTransferResults()).toHaveLength(1);
+  });
+
   it("keeps as proposed when confidence < 0.85", async () => {
     const lowConfPattern = makePattern({ confidence: 0.75, applicable_domains: ["testing"] });
     const llmClient = createMockLLMClient([ADAPTATION_RESPONSE, ADAPTATION_RESPONSE, ADAPTATION_RESPONSE]);

--- a/src/platform/knowledge/__tests__/knowledge-transfer-persistence.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-transfer-persistence.test.ts
@@ -110,4 +110,114 @@ describe("KnowledgeTransfer snapshot persistence", () => {
     expect(snapshot.results[0]!.transfer_id).toBe(applyResult.transfer_id);
     expect(snapshot.effectiveness_records[0]!.transfer_id).toBe(applyResult.transfer_id);
   });
+
+  it("refreshes an already-loaded snapshot when forceRefresh is requested", async () => {
+    const tmpDir = makeTmpDir();
+    const stateManager = new StateManager(tmpDir);
+    const vectorIndex = new VectorIndex(
+      path.join(tmpDir, "vectors.json"),
+      new MockEmbeddingClient()
+    );
+    const pattern = makePattern({
+      pattern_id: "pat_refresh",
+      source_goal_ids: ["goal_b"],
+      confidence: 0.85,
+    });
+
+    await stateManager.writeRaw("goals/goal_a/state.json", { gap: 0.8 });
+    await stateManager.writeRaw("goals/goal_b/state.json", { gap: 0.4 });
+
+    const kt = new KnowledgeTransfer({
+      llmClient: createMockLLMClient([ADAPTATION_RESPONSE]),
+      knowledgeManager: makeMockKnowledgeManager(),
+      vectorIndex,
+      learningPipeline: makeMockLearningPipeline({ goal_b: [pattern] }),
+      ethicsGate: makeMockEthicsGate(),
+      stateManager,
+    });
+
+    const candidates = await kt.detectTransferOpportunities("goal_a");
+    expect(candidates).toHaveLength(1);
+
+    const initialSnapshot = await kt.listTransferSnapshot();
+    expect(initialSnapshot.transfers).toHaveLength(1);
+
+    const rawSnapshot = await stateManager.readRaw("knowledge-transfer/snapshot.json");
+    expect(rawSnapshot).not.toBeNull();
+    const snapshotObject = rawSnapshot as {
+      transfers: Array<Record<string, unknown>>;
+      results: Array<Record<string, unknown>>;
+      effectiveness_records: Array<Record<string, unknown>>;
+      apply_contexts: Record<string, unknown>;
+      pattern_trackers: Record<string, unknown>;
+    };
+
+    snapshotObject.transfers.push({
+      ...initialSnapshot.transfers[0]!,
+      candidate_id: "tc_external_refresh",
+      proposed_at: new Date().toISOString(),
+    });
+
+    await stateManager.writeRaw("knowledge-transfer/snapshot.json", snapshotObject);
+
+    const staleSnapshot = await kt.listTransferSnapshot();
+    expect(staleSnapshot.transfers).toHaveLength(1);
+
+    const refreshedSnapshot = await kt.listTransferSnapshot({ forceRefresh: true });
+    expect(refreshedSnapshot.transfers).toHaveLength(2);
+    expect(refreshedSnapshot.transfers.some((candidate) => candidate.candidate_id === "tc_external_refresh")).toBe(true);
+  });
+
+  it("does not create duplicate candidates for the same source pattern and target goal", async () => {
+    const tmpDir = makeTmpDir();
+    const stateManager1 = new StateManager(tmpDir);
+    const vectorIndex1 = new VectorIndex(
+      path.join(tmpDir, "vectors.json"),
+      new MockEmbeddingClient()
+    );
+    const pattern = makePattern({
+      pattern_id: "pat_repeat",
+      source_goal_ids: ["goal_b"],
+      confidence: 0.85,
+    });
+
+    await stateManager1.writeRaw("goals/goal_a/state.json", { gap: 0.7 });
+    await stateManager1.writeRaw("goals/goal_b/state.json", { gap: 0.4 });
+
+    const kt1 = new KnowledgeTransfer({
+      llmClient: createMockLLMClient([]),
+      knowledgeManager: makeMockKnowledgeManager(),
+      vectorIndex: vectorIndex1,
+      learningPipeline: makeMockLearningPipeline({ goal_b: [pattern] }),
+      ethicsGate: makeMockEthicsGate(),
+      stateManager: stateManager1,
+    });
+
+    const firstPass = await kt1.detectTransferOpportunities("goal_a");
+    expect(firstPass).toHaveLength(1);
+    expect(kt1.getTransferCandidates()).toHaveLength(1);
+
+    const stateManager2 = new StateManager(tmpDir);
+    const vectorIndex2 = new VectorIndex(
+      path.join(tmpDir, "vectors.json"),
+      new MockEmbeddingClient()
+    );
+    const kt2 = new KnowledgeTransfer({
+      llmClient: createMockLLMClient([]),
+      knowledgeManager: makeMockKnowledgeManager(),
+      vectorIndex: vectorIndex2,
+      learningPipeline: makeMockLearningPipeline({ goal_b: [pattern] }),
+      ethicsGate: makeMockEthicsGate(),
+      stateManager: stateManager2,
+    });
+
+    const secondPass = await kt2.detectTransferOpportunities("goal_a");
+    expect(secondPass).toHaveLength(1);
+    expect(secondPass[0]!.candidate_id).toBe(firstPass[0]!.candidate_id);
+    expect(kt2.getTransferCandidates()).toHaveLength(1);
+
+    const snapshot = await kt2.listTransferSnapshot();
+    expect(snapshot.transfers).toHaveLength(1);
+    expect(snapshot.transfers[0]!.candidate_id).toBe(firstPass[0]!.candidate_id);
+  });
 });

--- a/src/platform/knowledge/__tests__/knowledge-transfer-persistence.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-transfer-persistence.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { KnowledgeTransfer } from "../transfer/knowledge-transfer.js";
+import { StateManager } from "../../../base/state/state-manager.js";
+import { VectorIndex } from "../vector-index.js";
+import { MockEmbeddingClient } from "../embedding-client.js";
+import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
+import type { LearnedPattern } from "../../../base/types/learning.js";
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "kt-persist-"));
+}
+
+function makePattern(overrides: Partial<LearnedPattern> = {}): LearnedPattern {
+  return {
+    pattern_id: overrides.pattern_id ?? "pat_1",
+    type: overrides.type ?? "scope_sizing",
+    description: overrides.description ?? "When blocked, reduce scope",
+    confidence: overrides.confidence ?? 0.8,
+    evidence_count: overrides.evidence_count ?? 5,
+    source_goal_ids: overrides.source_goal_ids ?? ["goal_a"],
+    applicable_domains: overrides.applicable_domains ?? ["testing"],
+    embedding_id: overrides.embedding_id ?? null,
+    created_at: overrides.created_at ?? new Date().toISOString(),
+    last_applied_at: overrides.last_applied_at ?? null,
+  };
+}
+
+function makeMockKnowledgeManager() {
+  return {} as any;
+}
+
+function makeMockEthicsGate() {
+  return {
+    check: async () => ({
+      verdict: "pass" as const,
+      reasoning: "Approved",
+      confidence: 0.9,
+    }),
+  } as any;
+}
+
+function makeMockLearningPipeline(patternsPerGoal: Record<string, LearnedPattern[]>) {
+  return {
+    getPatterns: (goalId: string) => patternsPerGoal[goalId] ?? [],
+  } as any;
+}
+
+const ADAPTATION_RESPONSE = JSON.stringify({
+  adaptation_description: "Adapted pattern for target context",
+  adapted_content: "Reduce scope when blocked in target domain",
+  success: true,
+});
+
+describe("KnowledgeTransfer snapshot persistence", () => {
+  it("restores transfer history from disk in a fresh instance", async () => {
+    const tmpDir = makeTmpDir();
+    const stateManager1 = new StateManager(tmpDir);
+    const vectorIndex1 = new VectorIndex(
+      path.join(tmpDir, "vectors.json"),
+      new MockEmbeddingClient()
+    );
+    const pattern = makePattern({
+      pattern_id: "pat_snapshot",
+      source_goal_ids: ["goal_b"],
+      confidence: 0.85,
+    });
+
+    await stateManager1.writeRaw("goals/goal_a/state.json", { gap: 0.8 });
+    await stateManager1.writeRaw("goals/goal_b/state.json", { gap: 0.4 });
+
+    const kt1 = new KnowledgeTransfer({
+      llmClient: createMockLLMClient([ADAPTATION_RESPONSE]),
+      knowledgeManager: makeMockKnowledgeManager(),
+      vectorIndex: vectorIndex1,
+      learningPipeline: makeMockLearningPipeline({ goal_b: [pattern] }),
+      ethicsGate: makeMockEthicsGate(),
+      stateManager: stateManager1,
+    });
+
+    const candidates = await kt1.detectTransferOpportunities("goal_a");
+    expect(candidates).toHaveLength(1);
+
+    const applyResult = await kt1.applyTransfer(candidates[0]!.candidate_id, "goal_a");
+    await stateManager1.writeRaw("goals/goal_a/state.json", { gap: 0.2 });
+    const effectiveness = await kt1.evaluateTransferEffect(applyResult.transfer_id);
+    expect(effectiveness.effectiveness).toBe("positive");
+
+    const stateManager2 = new StateManager(tmpDir);
+    const vectorIndex2 = new VectorIndex(
+      path.join(tmpDir, "vectors.json"),
+      new MockEmbeddingClient()
+    );
+    const kt2 = new KnowledgeTransfer({
+      llmClient: createMockLLMClient([]),
+      knowledgeManager: makeMockKnowledgeManager(),
+      vectorIndex: vectorIndex2,
+      learningPipeline: makeMockLearningPipeline({}),
+      ethicsGate: makeMockEthicsGate(),
+      stateManager: stateManager2,
+    });
+
+    const snapshot = await kt2.listTransferSnapshot();
+    expect(snapshot.transfers).toHaveLength(1);
+    expect(snapshot.results).toHaveLength(1);
+    expect(snapshot.effectiveness_records).toHaveLength(1);
+    expect(snapshot.transfers[0]!.candidate_id).toBe(candidates[0]!.candidate_id);
+    expect(snapshot.results[0]!.transfer_id).toBe(applyResult.transfer_id);
+    expect(snapshot.effectiveness_records[0]!.transfer_id).toBe(applyResult.transfer_id);
+  });
+});

--- a/src/platform/knowledge/transfer/knowledge-transfer-apply.ts
+++ b/src/platform/knowledge/transfer/knowledge-transfer-apply.ts
@@ -18,6 +18,10 @@ import { detectTransferOpportunities } from "./knowledge-transfer-detect.js";
 import type { DetectDeps } from "./knowledge-transfer-detect.js";
 import type { PatternEffectivenessTracker } from "./knowledge-transfer-types.js";
 
+function isAutoApplicableCandidate(candidate: TransferCandidate): boolean {
+  return candidate.state === "pending" || candidate.state === "proposed";
+}
+
 // ─── Deps ───
 
 export interface ApplyDeps {
@@ -192,6 +196,10 @@ export async function autoApplyHighConfidenceTransfers(
   const processed: TransferCandidate[] = [];
 
   for (const candidate of detectedCandidates) {
+    if (!isAutoApplicableCandidate(candidate)) {
+      continue;
+    }
+
     // Get trust score for the candidate's domain pair
     let sourcePattern = null;
     try {

--- a/src/platform/knowledge/transfer/knowledge-transfer-detect.ts
+++ b/src/platform/knowledge/transfer/knowledge-transfer-detect.ts
@@ -34,6 +34,10 @@ function findExistingCandidate(
   return null;
 }
 
+function isReusableCandidateState(candidate: TransferCandidate): boolean {
+  return candidate.state === "pending" || candidate.state === "proposed";
+}
+
 // ─── Deps ───
 
 export interface DetectDeps {
@@ -197,7 +201,9 @@ export async function detectTransferOpportunities(
       source_item_id: pattern.pattern_id,
     });
     if (existingCandidate) {
-      newCandidates.push(existingCandidate);
+      if (isReusableCandidateState(existingCandidate)) {
+        newCandidates.push(existingCandidate);
+      }
       continue;
     }
     const candidate = TransferCandidateSchema.parse({

--- a/src/platform/knowledge/transfer/knowledge-transfer-detect.ts
+++ b/src/platform/knowledge/transfer/knowledge-transfer-detect.ts
@@ -9,6 +9,31 @@ import type { LearnedPattern } from "../../../base/types/learning.js";
 import type { TransferTrustManager } from "./transfer-trust.js";
 import type { PatternEffectivenessTracker } from "./knowledge-transfer-types.js";
 
+function buildCandidateDedupKey(candidate: Pick<
+  TransferCandidate,
+  "type" | "source_goal_id" | "target_goal_id" | "source_item_id"
+>): string {
+  return [
+    candidate.type,
+    candidate.source_goal_id,
+    candidate.target_goal_id,
+    candidate.source_item_id,
+  ].join("::");
+}
+
+function findExistingCandidate(
+  candidates: Map<string, TransferCandidate>,
+  candidate: Pick<TransferCandidate, "type" | "source_goal_id" | "target_goal_id" | "source_item_id">
+): TransferCandidate | null {
+  const key = buildCandidateDedupKey(candidate);
+  for (const existing of candidates.values()) {
+    if (buildCandidateDedupKey(existing) === key) {
+      return existing;
+    }
+  }
+  return null;
+}
+
 // ─── Deps ───
 
 export interface DetectDeps {
@@ -165,6 +190,16 @@ export async function detectTransferOpportunities(
       continue;
     }
     seenPatternIds.add(pattern.pattern_id);
+    const existingCandidate = findExistingCandidate(candidates, {
+      type: "pattern",
+      source_goal_id: sourceGoalId,
+      target_goal_id: goalId,
+      source_item_id: pattern.pattern_id,
+    });
+    if (existingCandidate) {
+      newCandidates.push(existingCandidate);
+      continue;
+    }
     const candidate = TransferCandidateSchema.parse({
       candidate_id: `tc_${randomUUID()}`,
       source_goal_id: sourceGoalId,

--- a/src/platform/knowledge/transfer/knowledge-transfer.ts
+++ b/src/platform/knowledge/transfer/knowledge-transfer.ts
@@ -215,12 +215,16 @@ export class KnowledgeTransfer {
     return getEffectivenessRecords(this.effectivenessRecords);
   }
 
-  async listTransferSnapshot(): Promise<{
+  async listTransferSnapshot(options?: { forceRefresh?: boolean }): Promise<{
     transfers: TransferCandidate[];
     results: TransferResult[];
     effectiveness_records: TransferEffectivenessRecord[];
   }> {
-    await this.ensureSnapshotLoaded();
+    if (options?.forceRefresh) {
+      await this.loadSnapshot();
+    } else {
+      await this.ensureSnapshotLoaded();
+    }
     return this.buildTransferSnapshot();
   }
 
@@ -275,6 +279,10 @@ export class KnowledgeTransfer {
       this.snapshotLoadPromise = this.loadSnapshot();
     }
     await this.snapshotLoadPromise;
+  }
+
+  async refreshSnapshot(): Promise<void> {
+    await this.loadSnapshot();
   }
 
   private async loadSnapshot(): Promise<void> {

--- a/src/platform/knowledge/transfer/knowledge-transfer.ts
+++ b/src/platform/knowledge/transfer/knowledge-transfer.ts
@@ -5,12 +5,19 @@ import type { VectorIndex } from "../vector-index.js";
 import type { LearningPipeline } from "../learning/learning-pipeline.js";
 import type { EthicsGate } from "../../traits/ethics-gate.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
+import { z } from "zod";
 import type {
   TransferCandidate,
   TransferResult,
   TransferEffectivenessRecord,
 } from "../../../base/types/cross-portfolio.js";
+import {
+  TransferCandidateSchema,
+  TransferResultSchema,
+  TransferEffectivenessSchema,
+} from "../../../base/types/cross-portfolio.js";
 import type { CrossGoalPattern, StructuralFeedbackType } from "../../../base/types/learning.js";
+import { LearnedPatternSchema } from "../../../base/types/learning.js";
 import { TransferTrustManager } from "./transfer-trust.js";
 import type { TransferContext, PatternEffectivenessTracker } from "./knowledge-transfer-types.js";
 
@@ -50,9 +57,12 @@ import type { MetaDeps } from "./knowledge-transfer-meta.js";
  * - knowledge-transfer-evaluate.ts — effectiveness evaluation + trust update
  * - knowledge-transfer-meta.ts    — meta-pattern aggregation (batch + incremental)
  *
- * Stored in-memory (Map/array). No file persistence for MVP.
+ * State is kept in-memory and mirrored to a persisted snapshot so other
+ * processes can read transfer history without sharing process-local memory.
  */
 export class KnowledgeTransfer {
+  private static readonly SNAPSHOT_PATH = "knowledge-transfer/snapshot.json";
+
   private readonly detectDeps: DetectDeps;
   private readonly applyDeps: ApplyDeps;
   private readonly metaDeps: MetaDeps;
@@ -79,6 +89,9 @@ export class KnowledgeTransfer {
 
   /** Timestamp of last incremental meta-pattern aggregation (ISO string) */
   private lastAggregatedAt: string | null = null;
+
+  private snapshotLoaded = false;
+  private snapshotLoadPromise: Promise<void> | null = null;
 
   constructor(deps: {
     llmClient: ILLMClient;
@@ -123,27 +136,42 @@ export class KnowledgeTransfer {
   // ─── Detect ───
 
   async detectTransferOpportunities(goalId: string): Promise<TransferCandidate[]> {
-    return detectTransferOpportunities(goalId, this.detectDeps, this.candidates, this.patternTrackers);
+    await this.ensureSnapshotLoaded();
+    const result = await detectTransferOpportunities(goalId, this.detectDeps, this.candidates, this.patternTrackers);
+    await this.persistSnapshot();
+    return result;
   }
 
   // ─── Apply ───
 
   async applyTransfer(candidateId: string, targetGoalId: string): Promise<TransferResult> {
-    return applyTransfer(candidateId, targetGoalId, this.applyDeps, this.candidates, this.results, this.applyContexts);
+    await this.ensureSnapshotLoaded();
+    const result = await applyTransfer(candidateId, targetGoalId, this.applyDeps, this.candidates, this.results, this.applyContexts);
+    await this.persistSnapshot();
+    return result;
   }
 
   async autoApplyHighConfidenceTransfers(goalId: string): Promise<TransferCandidate[]> {
-    return autoApplyHighConfidenceTransfers(goalId, this.applyDeps, this.detectDeps, this.candidates, this.results, this.applyContexts, this.patternTrackers);
+    await this.ensureSnapshotLoaded();
+    const result = await autoApplyHighConfidenceTransfers(goalId, this.applyDeps, this.detectDeps, this.candidates, this.results, this.applyContexts, this.patternTrackers);
+    await this.persistSnapshot();
+    return result;
   }
 
   async detectCandidatesRealtime(goalId: string): Promise<{ candidates: TransferCandidate[]; contextSnippets: string[] }> {
-    return detectCandidatesRealtime(goalId, this.detectDeps, this.candidates, this.patternTrackers);
+    await this.ensureSnapshotLoaded();
+    const result = await detectCandidatesRealtime(goalId, this.detectDeps, this.candidates, this.patternTrackers);
+    await this.persistSnapshot();
+    return result;
   }
 
   // ─── Evaluate ───
 
   async evaluateTransferEffect(transferId: string): Promise<TransferEffectivenessRecord> {
-    return evaluateTransferEffect(transferId, this.applyDeps.stateManager, this.transferTrust, this.results, this.applyContexts, this.effectivenessRecords, this.candidates, this.patternTrackers);
+    await this.ensureSnapshotLoaded();
+    const result = await evaluateTransferEffect(transferId, this.applyDeps.stateManager, this.transferTrust, this.results, this.applyContexts, this.effectivenessRecords, this.candidates, this.patternTrackers);
+    await this.persistSnapshot();
+    return result;
   }
 
   // ─── Meta ───
@@ -187,6 +215,15 @@ export class KnowledgeTransfer {
     return getEffectivenessRecords(this.effectivenessRecords);
   }
 
+  async listTransferSnapshot(): Promise<{
+    transfers: TransferCandidate[];
+    results: TransferResult[];
+    effectiveness_records: TransferEffectivenessRecord[];
+  }> {
+    await this.ensureSnapshotLoaded();
+    return this.buildTransferSnapshot();
+  }
+
   getAppliedTransferCount(): number {
     return getAppliedTransferCount(this.candidates);
   }
@@ -196,6 +233,99 @@ export class KnowledgeTransfer {
   }
 
   // ─── Private Persistence Helpers ───
+
+  private static readonly SnapshotSchema = z.object({
+    transfers: z.array(TransferCandidateSchema).default([]),
+    results: z.array(TransferResultSchema).default([]),
+    effectiveness_records: z.array(TransferEffectivenessSchema).default([]),
+    apply_contexts: z.record(
+      z.string(),
+      z.object({
+        candidate: TransferCandidateSchema,
+        gap_at_apply: z.number(),
+        source_pattern: LearnedPatternSchema.nullable(),
+      })
+    ).default({}),
+    pattern_trackers: z.record(
+      z.string(),
+      z.object({
+        consecutive_non_positive: z.number().int().min(0),
+        invalidated: z.boolean(),
+      })
+    ).default({}),
+  });
+
+  private buildTransferSnapshot(): {
+    transfers: TransferCandidate[];
+    results: TransferResult[];
+    effectiveness_records: TransferEffectivenessRecord[];
+  } {
+    return {
+      transfers: Array.from(this.candidates.values()),
+      results: Array.from(this.results.values()),
+      effectiveness_records: getEffectivenessRecords(this.effectivenessRecords),
+    };
+  }
+
+  private async ensureSnapshotLoaded(): Promise<void> {
+    if (this.snapshotLoaded) {
+      return;
+    }
+    if (!this.snapshotLoadPromise) {
+      this.snapshotLoadPromise = this.loadSnapshot();
+    }
+    await this.snapshotLoadPromise;
+  }
+
+  private async loadSnapshot(): Promise<void> {
+    try {
+      const raw = await this.applyDeps.stateManager.readRaw(KnowledgeTransfer.SNAPSHOT_PATH);
+      if (raw && typeof raw === "object") {
+        const snapshot = KnowledgeTransfer.SnapshotSchema.parse(raw);
+        this.candidates.clear();
+        for (const candidate of snapshot.transfers) {
+          this.candidates.set(candidate.candidate_id, candidate);
+        }
+        this.results.clear();
+        for (const result of snapshot.results) {
+          this.results.set(result.transfer_id, result);
+        }
+        this.effectivenessRecords.clear();
+        for (const record of snapshot.effectiveness_records) {
+          this.effectivenessRecords.set(record.transfer_id, record);
+        }
+        this.applyContexts.clear();
+        for (const [transferId, context] of Object.entries(snapshot.apply_contexts)) {
+          this.applyContexts.set(transferId, context);
+        }
+        this.patternTrackers.clear();
+        for (const [patternId, tracker] of Object.entries(snapshot.pattern_trackers)) {
+          this.patternTrackers.set(patternId, tracker);
+        }
+      }
+    } catch {
+      // non-fatal: start from an empty snapshot
+    } finally {
+      this.snapshotLoaded = true;
+      this.snapshotLoadPromise = null;
+    }
+  }
+
+  private async persistSnapshot(): Promise<void> {
+    if (!this.snapshotLoaded) {
+      return;
+    }
+    const snapshot = {
+      ...this.buildTransferSnapshot(),
+      apply_contexts: Object.fromEntries(this.applyContexts.entries()),
+      pattern_trackers: Object.fromEntries(this.patternTrackers.entries()),
+    };
+    try {
+      await this.applyDeps.stateManager.writeRaw(KnowledgeTransfer.SNAPSHOT_PATH, snapshot);
+    } catch {
+      // non-fatal: in-memory state remains authoritative for this process
+    }
+  }
 
   private async _loadLastAggregatedAt(): Promise<string | null> {
     if (this.lastAggregatedAt !== null) return this.lastAggregatedAt;

--- a/src/platform/observation/__tests__/capability-detector-escalate.test.ts
+++ b/src/platform/observation/__tests__/capability-detector-escalate.test.ts
@@ -362,4 +362,21 @@ describe("planAcquisition", () => {
     expect(result.gap.missing_capability.name).toBe("Stripe API");
     expect(result.gap.missing_capability.type).toBe("service");
   });
+
+  it("adds recommendation guidance when the gap matches a known datasource plugin", () => {
+    const llm = createMockLLMClient([]);
+    const detector = new CapabilityDetector(stateManager, llm, reportingEngine);
+
+    const gap = makeGap({
+      missing_capability: { name: "postgres analytics", type: "data_source" },
+      reason: "Need to read from the analytics database",
+    });
+    const result = detector.planAcquisition(gap);
+
+    expect(result.task_description).toContain("postgres-datasource");
+    expect(result.task_description).toContain("examples/plugins/postgres-datasource");
+    expect(result.success_criteria).toContain(
+      "follow-up replanning is triggered after the capability becomes available"
+    );
+  });
 });

--- a/src/platform/observation/__tests__/data-source-adapter.test.ts
+++ b/src/platform/observation/__tests__/data-source-adapter.test.ts
@@ -5,6 +5,7 @@ import {
   getNestedValue,
   FileDataSourceAdapter,
   HttpApiDataSourceAdapter,
+  PostgresDataSourceAdapter,
   DataSourceRegistry,
 } from "../data-source-adapter.js";
 import type { DataSourceConfig } from "../../../base/types/data-source.js";
@@ -420,6 +421,88 @@ describe("HttpApiDataSourceAdapter", () => {
     const result = await adapter.query({ dimension_name: "x", timeout_ms: 5000 });
 
     expect(result.value).toBeNull();
+  });
+});
+
+describe("PostgresDataSourceAdapter", () => {
+  function makeDatabaseConfig(overrides: Partial<DataSourceConfig> = {}): DataSourceConfig {
+    return makeConfig({
+      id: "pg-source",
+      name: "Analytics DB",
+      type: "database",
+      connection: {},
+      connection_string: "postgresql://localhost:5432/analytics",
+      dimension_mapping: {
+        open_issue_count: "SELECT count(*) FROM issues WHERE state = 'open'",
+      },
+      ...overrides,
+    });
+  }
+
+  it("runs configured SQL and parses a scalar value", async () => {
+    const runner = vi.fn().mockResolvedValue({
+      stdout: "42\n",
+      stderr: "",
+      code: 0,
+    });
+    const adapter = new PostgresDataSourceAdapter(makeDatabaseConfig(), runner);
+
+    const result = await adapter.query({
+      dimension_name: "open_issue_count",
+      timeout_ms: 5000,
+    });
+
+    expect(runner).toHaveBeenCalledWith(
+      "postgresql://localhost:5432/analytics",
+      "SELECT count(*) FROM issues WHERE state = 'open'",
+      5000
+    );
+    expect(result.value).toBe(42);
+    expect(result.metadata?.query).toBe("SELECT count(*) FROM issues WHERE state = 'open'");
+  });
+
+  it("wraps scalar expressions in a SELECT statement", async () => {
+    const runner = vi.fn().mockResolvedValue({
+      stdout: "7\n",
+      stderr: "",
+      code: 0,
+    });
+    const adapter = new PostgresDataSourceAdapter(
+      makeDatabaseConfig({
+        dimension_mapping: {
+          open_issue_count: "count(*)",
+        },
+      }),
+      runner
+    );
+
+    const result = await adapter.query({
+      dimension_name: "open_issue_count",
+      timeout_ms: 5000,
+    });
+
+    expect(runner).toHaveBeenCalledWith(
+      "postgresql://localhost:5432/analytics",
+      "SELECT (count(*)) AS value",
+      5000
+    );
+    expect(result.value).toBe(7);
+  });
+
+  it("healthCheck returns true when SELECT 1 succeeds", async () => {
+    const runner = vi.fn().mockResolvedValue({
+      stdout: "1\n",
+      stderr: "",
+      code: 0,
+    });
+    const adapter = new PostgresDataSourceAdapter(makeDatabaseConfig(), runner);
+
+    await expect(adapter.healthCheck()).resolves.toBe(true);
+    expect(runner).toHaveBeenCalledWith(
+      "postgresql://localhost:5432/analytics",
+      "SELECT 1",
+      5000
+    );
   });
 });
 

--- a/src/platform/observation/capability-detector.ts
+++ b/src/platform/observation/capability-detector.ts
@@ -45,6 +45,61 @@ import {
 
 const CONSECUTIVE_FAILURE_THRESHOLD = 3;
 
+export interface CapabilityAcquisitionRecommendation {
+  pluginName: string;
+  installSource: string;
+  rationale: string;
+  verificationHint: string;
+  requiresApproval: boolean;
+}
+
+const ACQUISITION_RECOMMENDATION_RULES: Array<{
+  pluginName: string;
+  installSource: string;
+  capabilityTypes: Capability["type"][];
+  patterns: RegExp[];
+  rationale: string;
+  verificationHint: string;
+  requiresApproval: boolean;
+}> = [
+  {
+    pluginName: "postgres-datasource",
+    installSource: "examples/plugins/postgres-datasource",
+    capabilityTypes: ["data_source", "service"],
+    patterns: [/\bpostgres\b/i, /\bpostgresql\b/i, /\banalytics_db\b/i, /\bdatabase\b/i, /\bsql\b/i],
+    rationale: "Use the first-party Postgres datasource plugin for structured SQL observation.",
+    verificationHint: "Load the plugin, configure a DSN, and confirm datasource health checks succeed.",
+    requiresApproval: false,
+  },
+  {
+    pluginName: "mysql-datasource",
+    installSource: "examples/plugins/mysql-datasource",
+    capabilityTypes: ["data_source", "service"],
+    patterns: [/\bmysql\b/i],
+    rationale: "Use the first-party MySQL datasource plugin when the gap targets MySQL-backed data.",
+    verificationHint: "Load the plugin, configure the database, and confirm datasource connectivity.",
+    requiresApproval: false,
+  },
+  {
+    pluginName: "jira-datasource",
+    installSource: "examples/plugins/jira-datasource",
+    capabilityTypes: ["service", "data_source"],
+    patterns: [/\bjira\b/i],
+    rationale: "Use the first-party Jira datasource plugin instead of bespoke API glue.",
+    verificationHint: "Load the plugin, configure Jira credentials, and verify plugin/API health.",
+    requiresApproval: false,
+  },
+  {
+    pluginName: "websocket-datasource",
+    installSource: "examples/plugins/websocket-datasource",
+    capabilityTypes: ["service", "data_source"],
+    patterns: [/\bwebsocket\b/i, /\bws\b/i],
+    rationale: "Use the first-party WebSocket datasource plugin for realtime observation.",
+    verificationHint: "Load the plugin, connect to the event stream, and confirm health checks pass.",
+    requiresApproval: false,
+  },
+];
+
 // ─── LLM response schema for deficiency detection ───
 
 const DeficiencyResponseSchema = z.union([
@@ -370,6 +425,28 @@ export class CapabilityDetector {
     return consecutiveFailures >= CONSECUTIVE_FAILURE_THRESHOLD;
   }
 
+  recommendAcquisition(gap: CapabilityGap): CapabilityAcquisitionRecommendation[] {
+    const haystack = [
+      gap.missing_capability.name,
+      gap.reason,
+      gap.impact_description,
+      ...gap.alternatives,
+    ].join(" ");
+
+    return ACQUISITION_RECOMMENDATION_RULES
+      .filter((rule) =>
+        rule.capabilityTypes.includes(gap.missing_capability.type) &&
+        rule.patterns.some((pattern) => pattern.test(haystack))
+      )
+      .map((rule) => ({
+        pluginName: rule.pluginName,
+        installSource: rule.installSource,
+        rationale: rule.rationale,
+        verificationHint: rule.verificationHint,
+        requiresApproval: rule.requiresApproval,
+      }));
+  }
+
   // ─── planAcquisition ───
 
   /**
@@ -379,6 +456,7 @@ export class CapabilityDetector {
   planAcquisition(gap: CapabilityGap): CapabilityAcquisitionTask {
     const capabilityName = gap.missing_capability.name;
     const capabilityType = gap.missing_capability.type;
+    const recommendation = this.recommendAcquisition(gap)[0];
 
     let method: CapabilityAcquisitionTask["method"];
     let task_description: string;
@@ -410,14 +488,29 @@ export class CapabilityDetector {
         `Impact if unavailable: ${gap.impact_description}`;
     }
 
+    if (recommendation) {
+      task_description +=
+        ` Recommended acquisition path: install plugin "${recommendation.pluginName}" from ` +
+        `"${recommendation.installSource}". ${recommendation.rationale} ` +
+        `Verification hint: ${recommendation.verificationHint}`;
+    }
+
+    const successCriteria = [
+      "capability registered in registry",
+      `${capabilityName} is operational and accessible`,
+    ];
+    if (recommendation) {
+      successCriteria.push(
+        `recommended plugin "${recommendation.pluginName}" is installed or otherwise made available`,
+        "follow-up replanning is triggered after the capability becomes available"
+      );
+    }
+
     return CapabilityAcquisitionTaskSchema.parse({
       gap,
       method,
       task_description,
-      success_criteria: [
-        "capability registered in registry",
-        `${capabilityName} is operational and accessible`,
-      ],
+      success_criteria: successCriteria,
       verification_attempts: 0,
       max_verification_attempts: 3,
     });

--- a/src/platform/observation/data-source-adapter.ts
+++ b/src/platform/observation/data-source-adapter.ts
@@ -5,6 +5,7 @@
 // multiple adapter instances.
 
 import * as fsp from "node:fs/promises";
+import { spawn } from "node:child_process";
 import { ValidationError } from "../../base/utils/errors.js";
 import type {
   DataSourceType,
@@ -229,6 +230,183 @@ export class HttpApiDataSourceAdapter implements IDataSourceAdapter {
       return false;
     } finally {
       clearTimeout(timer);
+    }
+  }
+}
+
+// ─── PostgresDataSourceAdapter ───
+
+function parseScalarResult(text: string): number | string | boolean | null {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed === "null") return null;
+  if (trimmed === "true") return true;
+  if (trimmed === "false") return false;
+  if (/^[-+]?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/.test(trimmed)) {
+    const num = Number(trimmed);
+    if (!Number.isNaN(num)) return num;
+  }
+  return trimmed;
+}
+
+function buildPsqlArgs(connectionString: string, sql: string): string[] {
+  return [
+    "-X",
+    "-q",
+    "-t",
+    "-A",
+    "-v",
+    "ON_ERROR_STOP=1",
+    "-d",
+    connectionString,
+    "-c",
+    sql,
+  ];
+}
+
+function normalizeSqlExpression(expression: string): string {
+  const trimmed = expression.trim();
+  if (/^(select|with)\b/i.test(trimmed)) {
+    return trimmed;
+  }
+  return `SELECT (${trimmed}) AS value`;
+}
+
+function runPsql(connectionString: string, sql: string, timeoutMs: number): Promise<{ stdout: string; stderr: string; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("psql", buildPsqlArgs(connectionString, sql), {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      reject(new Error("PostgresDataSourceAdapter: query timed out"));
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf-8");
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf-8");
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || `psql exited with code ${code ?? "unknown"}`));
+        return;
+      }
+      resolve({ stdout, stderr, code });
+    });
+  });
+}
+
+export class PostgresDataSourceAdapter implements IDataSourceAdapter {
+  readonly sourceId: string;
+  readonly sourceType: DataSourceType = "database";
+  readonly config: DataSourceConfig;
+  private readonly runner: typeof runPsql;
+
+  constructor(config: DataSourceConfig, runner: typeof runPsql = runPsql) {
+    this.config = config;
+    this.sourceId = config.id;
+    this.runner = runner;
+  }
+
+  private resolveConnectionString(): string | undefined {
+    const direct = this.config.connection_string?.trim();
+    if (direct) return direct;
+    const url = this.config.connection.url?.trim();
+    if (url) return url;
+    return undefined;
+  }
+
+  private resolveQueryExpression(params: DataSourceQuery): string | undefined {
+    const mapped = this.config.dimension_mapping?.[params.dimension_name];
+    const expression = params.expression ?? mapped;
+    if (!expression || !expression.trim()) {
+      return undefined;
+    }
+    return expression;
+  }
+
+  async connect(): Promise<void> {
+    const healthy = await this.healthCheck();
+    if (!healthy) {
+      throw new Error(`PostgresDataSourceAdapter [${this.sourceId}]: health check failed`);
+    }
+  }
+
+  async query(params: DataSourceQuery): Promise<DataSourceResult> {
+    const connectionString = this.resolveConnectionString();
+    if (!connectionString) {
+      throw new ValidationError(`PostgresDataSourceAdapter [${this.sourceId}]: connection_string is required`);
+    }
+
+    const expression = this.resolveQueryExpression(params);
+    if (!expression) {
+      return {
+        value: null,
+        raw: [],
+        timestamp: new Date().toISOString(),
+        source_id: this.sourceId,
+        metadata: {
+          error: `No SQL expression configured for dimension "${params.dimension_name}"`,
+        },
+      };
+    }
+
+    const sql = normalizeSqlExpression(expression);
+    try {
+      const result = await this.runner(connectionString, sql, params.timeout_ms ?? 10_000);
+      const lines = result.stdout.split(/\r?\n/).map((line) => line.trim()).filter((line) => line.length > 0);
+      const firstRow = lines[0] ?? "";
+      const [firstCell = ""] = firstRow.split("\t");
+
+      return {
+        value: parseScalarResult(firstCell),
+        raw: lines,
+        timestamp: new Date().toISOString(),
+        source_id: this.sourceId,
+        metadata: {
+          query: sql,
+        },
+      };
+    } catch (error) {
+      return {
+        value: null,
+        raw: [],
+        timestamp: new Date().toISOString(),
+        source_id: this.sourceId,
+        metadata: {
+          query: sql,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      };
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    // no-op
+  }
+
+  async healthCheck(): Promise<boolean> {
+    const connectionString = this.resolveConnectionString();
+    if (!connectionString) return false;
+
+    try {
+      await this.runner(connectionString, "SELECT 1", 5_000);
+      return true;
+    } catch {
+      return false;
     }
   }
 }

--- a/src/runtime/__tests__/notification-dispatcher.test.ts
+++ b/src/runtime/__tests__/notification-dispatcher.test.ts
@@ -78,6 +78,19 @@ describe("NotificationDispatcher — constructor", () => {
   });
 });
 
+describe("dispatch() — realtime sink", () => {
+  it("forwards dispatched reports to the realtime sink", async () => {
+    const sink = vi.fn().mockResolvedValue(undefined);
+    const dispatcher = new NotificationDispatcher({ channels: [] });
+    dispatcher.setRealtimeSink(sink);
+
+    await dispatcher.dispatch(createMockReport({ report_type: "daily_summary" }));
+
+    expect(sink).toHaveBeenCalledOnce();
+    expect(sink).toHaveBeenCalledWith(expect.objectContaining({ report_type: "daily_summary" }));
+  });
+});
+
 // ─── dispatch() with no channels ───
 
 describe("dispatch() — no channels", () => {

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { ScheduleEngine } from "../schedule-engine.js";
 import { detectChange } from "../change-detector.js";
 import type { ScheduleEntry, ScheduleEntryInput } from "../types/schedule.js";
@@ -1373,6 +1375,89 @@ describe("Cron execution (Phase 3)", () => {
     expect(result.status).toBe("error");
     expect(result.error_message).toContain("No cron config");
   });
+
+  it("executeCron runs morning_planning reflection jobs", async () => {
+    const notificationDispatcher = { dispatch: vi.fn().mockResolvedValue([]) };
+    const llmClient = {
+      sendMessage: vi.fn().mockResolvedValue({
+        content: JSON.stringify({
+          priorities: [],
+          suggestions: ["Focus on review"],
+          concerns: [],
+        }),
+        usage: { input_tokens: 10, output_tokens: 5 },
+      }),
+      parseJSON: vi.fn().mockImplementation((content: string, schema: { parse: (value: unknown) => unknown }) => schema.parse(JSON.parse(content))),
+    };
+    const stateManager = {
+      listGoalIds: vi.fn().mockResolvedValue([]),
+      loadGoal: vi.fn(),
+      loadGapHistory: vi.fn(),
+    };
+
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      llmClient: llmClient as unknown as import("../../base/llm/llm-client.js").ILLMClient,
+      stateManager: stateManager as any,
+      notificationDispatcher,
+    });
+
+    const entry = await eng.addEntry(makeCronEntry({
+      cron: {
+        job_kind: "reflection",
+        reflection_kind: "morning_planning",
+        prompt_template: "ignored",
+        context_sources: [],
+        output_format: "notification",
+        max_tokens: 1000,
+      },
+    }));
+
+    const result = await (eng as any).executeCron(entry);
+
+    expect(result.status).toBe("ok");
+    expect(result.output_summary).toContain("Morning planning completed");
+    expect(notificationDispatcher.dispatch).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tempDir, "reflections"))).toBe(true);
+  });
+
+  it("executeCron runs dream_consolidation reflection jobs without llmClient", async () => {
+    const stateManager = {
+      listGoalIds: vi.fn().mockResolvedValue(["goal-1"]),
+    };
+    const memoryLifecycle = {
+      compressToLongTerm: vi.fn().mockResolvedValue({ entries_compressed: 2 }),
+    };
+    const knowledgeManager = {
+      getStaleEntries: vi.fn().mockResolvedValue([]),
+      generateRevalidationTasks: vi.fn().mockResolvedValue([]),
+    };
+
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      stateManager: stateManager as any,
+      memoryLifecycle: memoryLifecycle as any,
+      knowledgeManager: knowledgeManager as any,
+    });
+
+    const entry = await eng.addEntry(makeCronEntry({
+      cron: {
+        job_kind: "reflection",
+        reflection_kind: "dream_consolidation",
+        prompt_template: "ignored",
+        context_sources: [],
+        output_format: "report",
+        max_tokens: 1000,
+      },
+    }));
+
+    const result = await (eng as any).executeCron(entry);
+
+    expect(result.status).toBe("ok");
+    expect(result.output_summary).toContain("Dream consolidation completed");
+    expect(memoryLifecycle.compressToLongTerm).toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tempDir, "reflections"))).toBe(true);
+  });
 });
 
 // ─── Phase 3: GoalTrigger execution ───
@@ -1406,7 +1491,7 @@ describe("GoalTrigger execution (Phase 3)", () => {
     const eng = new ScheduleEngine({
       baseDir: tempDir,
       coreLoop: mockCoreLoop,
-      stateManager: mockStateManager,
+      stateManager: mockStateManager as any,
     });
 
     const entry = await eng.addEntry(makeGoalTriggerEntry());
@@ -1428,7 +1513,7 @@ describe("GoalTrigger execution (Phase 3)", () => {
     const eng = new ScheduleEngine({
       baseDir: tempDir,
       coreLoop: mockCoreLoop,
-      stateManager: mockStateManager,
+      stateManager: mockStateManager as any,
     });
 
     const entry = await eng.addEntry(makeGoalTriggerEntry({

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -720,6 +720,35 @@ describe("Probe execution", () => {
     expect(result!.change_detected).toBe(true);
   });
 
+  it("executeProbe uses probe_dimension when provided", async () => {
+    const adapter = makeMockAdapter(3);
+    const registry = new Map([["test-source", adapter]]);
+    const eng = new ScheduleEngine({ baseDir: tempDir, dataSourceRegistry: registry });
+
+    const entry = await eng.addEntry(makeProbeEntry({
+      probe: {
+        data_source_id: "test-source",
+        probe_dimension: "open_issue_count",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+    }));
+
+    const entries = eng.getEntries();
+    entries[0]!.baseline_results = [1];
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id);
+    expect(result!.status).toBe("ok");
+    expect(adapter.query).toHaveBeenCalledWith(expect.objectContaining({
+      dimension_name: "open_issue_count",
+    }));
+  });
+
   it("executeProbe calls LLM on change when llm_on_change is true", async () => {
     const adapter = makeMockAdapter({ count: 5 });
     const registry = new Map([["test-source", adapter]]);
@@ -1390,9 +1419,18 @@ describe("Cron execution (Phase 3)", () => {
       parseJSON: vi.fn().mockImplementation((content: string, schema: { parse: (value: unknown) => unknown }) => schema.parse(JSON.parse(content))),
     };
     const stateManager = {
-      listGoalIds: vi.fn().mockResolvedValue([]),
-      loadGoal: vi.fn(),
-      loadGapHistory: vi.fn(),
+      listGoalIds: vi.fn().mockResolvedValue(["goal-1"]),
+      loadGoal: vi.fn().mockResolvedValue({
+        id: "goal-1",
+        title: "Refine planning",
+        status: "active",
+        dimensions: [{ id: "d-1" }],
+      }),
+      loadGapHistory: vi.fn().mockResolvedValue([
+        {
+          gap_vector: [{ normalized_weighted_gap: 0.4 }],
+        },
+      ]),
     };
 
     const eng = new ScheduleEngine({
@@ -1413,11 +1451,20 @@ describe("Cron execution (Phase 3)", () => {
       },
     }));
 
-    const result = await (eng as any).executeCron(entry);
+    const entries = eng.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+    const result = results.find((r) => r.entry_id === entry.id)!;
+    const updatedEntry = eng.getEntries().find((e) => e.id === entry.id)!;
 
     expect(result.status).toBe("ok");
     expect(result.output_summary).toContain("Morning planning completed");
-    expect(notificationDispatcher.dispatch).not.toHaveBeenCalled();
+    expect(result.tokens_used).toBe(15);
+    expect(updatedEntry.tokens_used_today).toBe(15);
+    expect(notificationDispatcher.dispatch).toHaveBeenCalledOnce();
     expect(fs.existsSync(path.join(tempDir, "reflections"))).toBe(true);
   });
 

--- a/src/runtime/__tests__/schedule-presets.test.ts
+++ b/src/runtime/__tests__/schedule-presets.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  SchedulePresetInputSchema,
+  buildSchedulePresetEntry,
+  getSchedulePresetDefinition,
+  listSchedulePresetDefinitions,
+} from "../schedule-presets.js";
+
+describe("schedule-presets", () => {
+  it("lists the supported reusable presets", () => {
+    expect(listSchedulePresetDefinitions().map((definition) => definition.key)).toEqual([
+      "daily_brief",
+      "weekly_review",
+      "dream_consolidation",
+      "goal_probe",
+    ]);
+  });
+
+  it("builds the daily brief preset as a reflection cron entry", () => {
+    const entry = buildSchedulePresetEntry(SchedulePresetInputSchema.parse({
+      preset: "daily_brief",
+    }));
+
+    expect(entry).toEqual(expect.objectContaining({
+      name: "Daily brief",
+      layer: "cron",
+      metadata: expect.objectContaining({
+        source: "preset",
+        preset_key: "daily_brief",
+      }),
+      cron: expect.objectContaining({
+        job_kind: "reflection",
+        reflection_kind: "morning_planning",
+        output_format: "notification",
+      }),
+    }));
+  });
+
+  it("builds the goal probe preset as a probe entry", () => {
+    const entry = buildSchedulePresetEntry(SchedulePresetInputSchema.parse({
+      preset: "goal_probe",
+      data_source_id: "source-1",
+      detector_mode: "threshold",
+      threshold_value: 0.8,
+      baseline_window: 7,
+    }));
+
+    expect(entry).toEqual(expect.objectContaining({
+      name: "Goal probe",
+      layer: "probe",
+      metadata: expect.objectContaining({
+        source: "preset",
+        preset_key: "goal_probe",
+      }),
+      probe: expect.objectContaining({
+        data_source_id: "source-1",
+        change_detector: expect.objectContaining({
+          mode: "threshold",
+          threshold_value: 0.8,
+          baseline_window: 7,
+        }),
+      }),
+    }));
+  });
+
+  it("uses the preset default trigger when none is provided", () => {
+    const definition = getSchedulePresetDefinition("weekly_review");
+    const entry = buildSchedulePresetEntry(SchedulePresetInputSchema.parse({
+      preset: "weekly_review",
+    }));
+
+    expect(entry.trigger).toEqual(definition.defaultTrigger);
+  });
+
+  it("rejects missing required preset input", () => {
+    const parsed = SchedulePresetInputSchema.safeParse({
+      preset: "goal_probe",
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/src/runtime/__tests__/schedule-presets.test.ts
+++ b/src/runtime/__tests__/schedule-presets.test.ts
@@ -40,6 +40,7 @@ describe("schedule-presets", () => {
     const entry = buildSchedulePresetEntry(SchedulePresetInputSchema.parse({
       preset: "goal_probe",
       data_source_id: "source-1",
+      probe_dimension: "open_issue_count",
       detector_mode: "threshold",
       threshold_value: 0.8,
       baseline_window: 7,
@@ -54,6 +55,7 @@ describe("schedule-presets", () => {
       }),
       probe: expect.objectContaining({
         data_source_id: "source-1",
+        probe_dimension: "open_issue_count",
         change_detector: expect.objectContaining({
           mode: "threshold",
           threshold_value: 0.8,

--- a/src/runtime/daemon-runner.ts
+++ b/src/runtime/daemon-runner.ts
@@ -76,6 +76,9 @@ export interface DaemonDeps {
   supervisor?: LoopSupervisor;
   /** Factory to create fresh CoreLoop instances for LoopSupervisor workers. */
   coreLoopFactory?: () => CoreLoop;
+  reportingEngine?: {
+    generateNotification(type: string, context: { goalId: string; message: string; details?: string }): Promise<unknown>;
+  };
 }
 
 export class DaemonRunner {
@@ -109,6 +112,7 @@ export class DaemonRunner {
   private cronScheduleInterval: ReturnType<typeof setInterval> | null = null;
   private shutdownResolve: (() => void) | null = null;
   private readonly deps: DaemonDeps;
+  private reportingEngine: DaemonDeps["reportingEngine"];
 
   constructor(deps: DaemonDeps) {
     this.deps = deps;
@@ -126,6 +130,7 @@ export class DaemonRunner {
     this.commandBus = deps.commandBus;
     this.supervisor = deps.supervisor ?? null;
     this.lastProactiveTickAt = Date.now();
+    this.reportingEngine = deps.reportingEngine;
 
     // Parse config with defaults via DaemonConfigSchema.parse()
     this.config = DaemonConfigSchema.parse(deps.config ?? {});
@@ -224,12 +229,20 @@ export class DaemonRunner {
     if (!this.approvalFn && this.eventServer) {
       const es = this.eventServer;
       this.approvalFn = async (task: Record<string, unknown>): Promise<boolean> => {
+        const goalId = String(task["goal_id"] ?? "unknown");
+        const description = String(task["description"] ?? "");
+        const action = String(task["action"] ?? "");
+        void this.reportingEngine?.generateNotification("approval_required", {
+          goalId,
+          message: description || "A task requires approval",
+          details: action ? `Requested action: ${action}` : undefined,
+        });
         return es.requestApproval(
-          String(task["goal_id"] ?? "unknown"),
+          goalId,
           {
             id: String(task["id"] ?? ""),
-            description: String(task["description"] ?? ""),
-            action: String(task["action"] ?? ""),
+            description,
+            action,
           }
         );
       };

--- a/src/runtime/notification-dispatcher.ts
+++ b/src/runtime/notification-dispatcher.ts
@@ -64,6 +64,7 @@ export class NotificationDispatcher implements INotificationDispatcher {
   private notifierRegistry?: NotifierRegistry;
   private readonly logger?: Logger;
   private batcher?: NotificationBatcher;
+  private realtimeSink?: (report: Report) => void | Promise<void>;
 
   constructor(config?: Partial<NotificationConfig>, notifierRegistry?: NotifierRegistry, logger?: Logger) {
     this.config = NotificationConfigSchema.parse(config ?? {});
@@ -84,6 +85,10 @@ export class NotificationDispatcher implements INotificationDispatcher {
   /** Flush batcher and stop the timer. Call on shutdown. */
   async stop(): Promise<void> {
     await this.batcher?.stop();
+  }
+
+  setRealtimeSink(sink: ((report: Report) => void | Promise<void>) | undefined): void {
+    this.realtimeSink = sink;
   }
 
   /** Dispatch report to all configured channels */
@@ -148,6 +153,14 @@ export class NotificationDispatcher implements INotificationDispatcher {
 
     // Route to NotifierRegistry plugins (additive, failures don't affect core dispatch)
     await this.dispatchToPluginNotifiers(report);
+
+    if (this.realtimeSink) {
+      try {
+        await this.realtimeSink(report);
+      } catch (err) {
+        this.logger?.warn?.(`[NotificationDispatcher] realtime sink failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
 
     return results;
   }

--- a/src/runtime/schedule-engine-layers.ts
+++ b/src/runtime/schedule-engine-layers.ts
@@ -6,19 +6,34 @@ import {
   ScheduleResultSchema,
   type ScheduleEntry,
   type ScheduleResult,
+  type ReflectionJobKind,
 } from "./types/schedule.js";
 import type { IDataSourceAdapter } from "../platform/observation/data-source-adapter.js";
 import type { DataSourceRegistry } from "../platform/observation/data-source-adapter.js";
 import type { ILLMClient } from "../base/llm/llm-client.js";
+import type { StateManager } from "../base/state/state-manager.js";
+import type { HookManager } from "./hook-manager.js";
+import type { MemoryLifecycleManager } from "../platform/knowledge/memory/memory-lifecycle.js";
+import type { KnowledgeManager } from "../platform/knowledge/knowledge-manager.js";
 import { detectChange } from "./change-detector.js";
+import {
+  runDreamConsolidation,
+  runEveningCatchup,
+  runMorningPlanning,
+  runWeeklyReview,
+} from "../reflection/index.js";
 
 interface LayerDeps {
+  baseDir?: string;
   dataSourceRegistry?: Map<string, IDataSourceAdapter> | DataSourceRegistry;
   llmClient?: ILLMClient;
   notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<any> };
   coreLoop?: { run(goalId: string, options?: { maxIterations?: number }): Promise<any> };
-  stateManager?: { loadGoal(goalId: string): Promise<any> };
+  stateManager?: StateManager;
   reportingEngine?: { generateNotification(type: string, context: Record<string, unknown>): Promise<any> };
+  hookManager?: HookManager;
+  memoryLifecycle?: MemoryLifecycleManager;
+  knowledgeManager?: KnowledgeManager;
   logger: {
     info: (msg: string, ctx?: Record<string, unknown>) => void;
     warn: (msg: string, ctx?: Record<string, unknown>) => void;
@@ -38,6 +53,99 @@ async function getAdapter(
     return (registry as DataSourceRegistry).getSource(sourceId);
   } catch {
     return undefined;
+  }
+}
+
+function summarizeReflection(kind: ReflectionJobKind, report: Record<string, unknown>): string {
+  switch (kind) {
+    case "morning_planning":
+      return `Morning planning completed (${report["goals_reviewed"] ?? 0} goals reviewed)`;
+    case "evening_catchup":
+      return `Evening catch-up completed (${report["goals_reviewed"] ?? 0} goals reviewed)`;
+    case "weekly_review":
+      return `Weekly review completed (${report["goals_reviewed"] ?? 0} goals reviewed)`;
+    case "dream_consolidation":
+      return `Dream consolidation completed (${report["goals_consolidated"] ?? 0} goals consolidated)`;
+  }
+}
+
+async function executeReflectionCron(
+  entry: ScheduleEntry,
+  deps: LayerDeps,
+  firedAt: string,
+  start: number,
+  kind: ReflectionJobKind,
+): Promise<ScheduleResult> {
+  if (!deps.baseDir || !deps.stateManager) {
+    return ScheduleResultSchema.parse({
+      entry_id: entry.id,
+      status: "error",
+      duration_ms: 0,
+      error_message: "Reflection cron requires baseDir and stateManager",
+      fired_at: firedAt,
+    });
+  }
+
+  try {
+    let report: Record<string, unknown>;
+
+    switch (kind) {
+      case "morning_planning":
+        if (!deps.llmClient) throw new Error("Reflection cron requires llmClient for morning_planning");
+        report = await runMorningPlanning({
+          stateManager: deps.stateManager,
+          llmClient: deps.llmClient,
+          baseDir: deps.baseDir,
+          notificationDispatcher: deps.notificationDispatcher,
+          hookManager: deps.hookManager,
+        }) as unknown as Record<string, unknown>;
+        break;
+      case "evening_catchup":
+        if (!deps.llmClient) throw new Error("Reflection cron requires llmClient for evening_catchup");
+        report = await runEveningCatchup({
+          stateManager: deps.stateManager,
+          llmClient: deps.llmClient,
+          baseDir: deps.baseDir,
+          notificationDispatcher: deps.notificationDispatcher,
+          hookManager: deps.hookManager,
+        }) as unknown as Record<string, unknown>;
+        break;
+      case "weekly_review":
+        if (!deps.llmClient) throw new Error("Reflection cron requires llmClient for weekly_review");
+        report = await runWeeklyReview({
+          stateManager: deps.stateManager,
+          llmClient: deps.llmClient,
+          baseDir: deps.baseDir,
+          notificationDispatcher: deps.notificationDispatcher,
+        }) as unknown as Record<string, unknown>;
+        break;
+      case "dream_consolidation":
+        report = await runDreamConsolidation({
+          stateManager: deps.stateManager,
+          memoryLifecycle: deps.memoryLifecycle,
+          knowledgeManager: deps.knowledgeManager,
+          baseDir: deps.baseDir,
+        }) as unknown as Record<string, unknown>;
+        break;
+    }
+
+    return ScheduleResultSchema.parse({
+      entry_id: entry.id,
+      status: "ok",
+      duration_ms: Date.now() - start,
+      fired_at: firedAt,
+      output_summary: summarizeReflection(kind, report),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    deps.logger.error(`Cron "${entry.name}" reflection failed: ${msg}`);
+    return ScheduleResultSchema.parse({
+      entry_id: entry.id,
+      status: "error",
+      duration_ms: Date.now() - start,
+      error_message: msg,
+      fired_at: firedAt,
+    });
   }
 }
 
@@ -69,6 +177,19 @@ export async function executeCron(entry: ScheduleEntry, deps: LayerDeps): Promis
   }
 
   try {
+    if (cfg.job_kind === "reflection") {
+      if (!cfg.reflection_kind) {
+        return ScheduleResultSchema.parse({
+          entry_id: entry.id,
+          status: "error",
+          duration_ms: 0,
+          error_message: "Reflection cron is missing reflection_kind",
+          fired_at: firedAt,
+        });
+      }
+      return executeReflectionCron(entry, deps, firedAt, start, cfg.reflection_kind);
+    }
+
     // Gather context from data sources
     const contextMap: Record<string, string> = {};
     for (const sourceId of cfg.context_sources) {
@@ -191,7 +312,7 @@ export async function executeGoalTrigger(entry: ScheduleEntry, deps: LayerDeps):
   if (cfg.skip_if_active && deps.stateManager) {
     try {
       const goal = await deps.stateManager.loadGoal(cfg.goal_id);
-      if (goal && (goal.status === "active" || goal.status === "running")) {
+      if (goal && goal.status === "active") {
         deps.logger.info(`GoalTrigger "${entry.name}" skipped: goal ${cfg.goal_id} is already active`);
         return ScheduleResultSchema.parse({
           entry_id: entry.id,

--- a/src/runtime/schedule-engine-layers.ts
+++ b/src/runtime/schedule-engine-layers.ts
@@ -69,6 +69,36 @@ function summarizeReflection(kind: ReflectionJobKind, report: Record<string, unk
   }
 }
 
+function withTokenAccountingClient(
+  llmClient: ILLMClient,
+  recordTokens: (tokens: number) => void
+): ILLMClient {
+  return {
+    async sendMessage(messages, options) {
+      const response = await llmClient.sendMessage(messages, options);
+      recordTokens((response.usage?.input_tokens ?? 0) + (response.usage?.output_tokens ?? 0));
+      return response;
+    },
+    async sendMessageStream(messages, options, handlers) {
+      if (!llmClient.sendMessageStream) {
+        return llmClient.sendMessage(messages, options);
+      }
+      const response = await llmClient.sendMessageStream(messages, options, handlers);
+      recordTokens((response.usage?.input_tokens ?? 0) + (response.usage?.output_tokens ?? 0));
+      return response;
+    },
+    parseJSON: ((content: string, schema: unknown, options?: unknown) => {
+      if (options === undefined) {
+        return llmClient.parseJSON(content as never, schema as never);
+      }
+      return llmClient.parseJSON(content as never, schema as never, options as never);
+    }) as ILLMClient["parseJSON"],
+    supportsToolCalling() {
+      return llmClient.supportsToolCalling?.() ?? true;
+    },
+  };
+}
+
 async function executeReflectionCron(
   entry: ScheduleEntry,
   deps: LayerDeps,
@@ -88,13 +118,17 @@ async function executeReflectionCron(
 
   try {
     let report: Record<string, unknown>;
+    let tokensUsed = 0;
+    const recordTokens = (tokens: number) => {
+      tokensUsed += tokens;
+    };
 
     switch (kind) {
       case "morning_planning":
         if (!deps.llmClient) throw new Error("Reflection cron requires llmClient for morning_planning");
         report = await runMorningPlanning({
           stateManager: deps.stateManager,
-          llmClient: deps.llmClient,
+          llmClient: withTokenAccountingClient(deps.llmClient, recordTokens),
           baseDir: deps.baseDir,
           notificationDispatcher: deps.notificationDispatcher,
           hookManager: deps.hookManager,
@@ -104,7 +138,7 @@ async function executeReflectionCron(
         if (!deps.llmClient) throw new Error("Reflection cron requires llmClient for evening_catchup");
         report = await runEveningCatchup({
           stateManager: deps.stateManager,
-          llmClient: deps.llmClient,
+          llmClient: withTokenAccountingClient(deps.llmClient, recordTokens),
           baseDir: deps.baseDir,
           notificationDispatcher: deps.notificationDispatcher,
           hookManager: deps.hookManager,
@@ -114,7 +148,7 @@ async function executeReflectionCron(
         if (!deps.llmClient) throw new Error("Reflection cron requires llmClient for weekly_review");
         report = await runWeeklyReview({
           stateManager: deps.stateManager,
-          llmClient: deps.llmClient,
+          llmClient: withTokenAccountingClient(deps.llmClient, recordTokens),
           baseDir: deps.baseDir,
           notificationDispatcher: deps.notificationDispatcher,
         }) as unknown as Record<string, unknown>;
@@ -134,6 +168,7 @@ async function executeReflectionCron(
       status: "ok",
       duration_ms: Date.now() - start,
       fired_at: firedAt,
+      tokens_used: tokensUsed,
       output_summary: summarizeReflection(kind, report),
     });
   } catch (err) {
@@ -392,13 +427,15 @@ export async function executeProbe(entry: ScheduleEntry, deps: LayerDeps): Promi
   }
 
   try {
+    const dimensionName = cfg.probe_dimension
+      ?? (typeof cfg.query_params.dimension_name === "string" ? cfg.query_params.dimension_name : undefined)
+      ?? cfg.data_source_id;
+
     // Execute probe query
-    // dimension_name comes AFTER query_params spread so it is authoritative and cannot be
-    // accidentally overridden by user-supplied query_params.
     const queryResult = await adapter.query({
       timeout_ms: 10000,
       ...cfg.query_params,
-      dimension_name: cfg.data_source_id,
+      dimension_name: dimensionName,
     } as Parameters<typeof adapter.query>[0]);
 
     const currentValue = queryResult.value ?? queryResult.raw;

--- a/src/runtime/schedule-engine.ts
+++ b/src/runtime/schedule-engine.ts
@@ -4,6 +4,7 @@ import * as net from "node:net";
 import { randomUUID } from "node:crypto";
 import { exec } from "node:child_process";
 import { writeJsonFileAtomic, readJsonFileOrNull } from "../base/utils/json-io.js";
+import type { StateManager } from "../base/state/state-manager.js";
 import {
   ScheduleEntrySchema,
   ScheduleEntryListSchema,
@@ -22,6 +23,9 @@ import { executeCron, executeGoalTrigger, executeProbe } from "./schedule-engine
 import type { IDataSourceAdapter } from "../platform/observation/data-source-adapter.js";
 import type { DataSourceRegistry } from "../platform/observation/data-source-adapter.js";
 import type { ILLMClient } from "../base/llm/llm-client.js";
+import type { HookManager } from "./hook-manager.js";
+import type { MemoryLifecycleManager } from "../platform/knowledge/memory/memory-lifecycle.js";
+import type { KnowledgeManager } from "../platform/knowledge/knowledge-manager.js";
 
 const SCHEDULES_FILE = "schedules.json";
 
@@ -40,8 +44,11 @@ interface ScheduleEngineDeps {
   // a full Report object. Full Report integration deferred to Phase 4.
   notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<any> };
   coreLoop?: { run(goalId: string, options?: { maxIterations?: number }): Promise<any> };
-  stateManager?: { loadGoal(goalId: string): Promise<any> };
+  stateManager?: StateManager;
   reportingEngine?: { generateNotification(type: string, context: Record<string, unknown>): Promise<any> };
+  hookManager?: HookManager;
+  memoryLifecycle?: MemoryLifecycleManager;
+  knowledgeManager?: KnowledgeManager;
 }
 
 const noopLogger = {
@@ -63,16 +70,21 @@ export type ScheduleEntryUpdateInput = Partial<{
 
 export class ScheduleEngine {
   private entries: ScheduleEntry[] = [];
+  private baseDir: string;
   private schedulesPath: string;
   private logger: NonNullable<ScheduleEngineDeps["logger"]>;
   private dataSourceRegistry?: Map<string, IDataSourceAdapter> | DataSourceRegistry;
   private llmClient?: ILLMClient;
   private notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<any> };
   private coreLoop?: { run(goalId: string, options?: { maxIterations?: number }): Promise<any> };
-  private stateManager?: { loadGoal(goalId: string): Promise<any> };
+  private stateManager?: StateManager;
   private reportingEngine?: { generateNotification(type: string, context: Record<string, unknown>): Promise<any> };
+  private hookManager?: HookManager;
+  private memoryLifecycle?: MemoryLifecycleManager;
+  private knowledgeManager?: KnowledgeManager;
 
   constructor(deps: ScheduleEngineDeps) {
+    this.baseDir = deps.baseDir;
     this.schedulesPath = path.join(deps.baseDir, SCHEDULES_FILE);
     this.logger = deps.logger ?? noopLogger;
     this.dataSourceRegistry = deps.dataSourceRegistry;
@@ -81,6 +93,9 @@ export class ScheduleEngine {
     this.coreLoop = deps.coreLoop;
     this.stateManager = deps.stateManager;
     this.reportingEngine = deps.reportingEngine;
+    this.hookManager = deps.hookManager;
+    this.memoryLifecycle = deps.memoryLifecycle;
+    this.knowledgeManager = deps.knowledgeManager;
   }
 
   // ─── Persistence ───
@@ -368,12 +383,16 @@ export class ScheduleEngine {
 
   private layerDeps() {
     return {
+      baseDir: this.baseDir,
       dataSourceRegistry: this.dataSourceRegistry,
       llmClient: this.llmClient,
       notificationDispatcher: this.notificationDispatcher,
       coreLoop: this.coreLoop,
       stateManager: this.stateManager,
       reportingEngine: this.reportingEngine,
+      hookManager: this.hookManager,
+      memoryLifecycle: this.memoryLifecycle,
+      knowledgeManager: this.knowledgeManager,
       logger: this.logger,
     };
   }

--- a/src/runtime/schedule-presets.ts
+++ b/src/runtime/schedule-presets.ts
@@ -1,0 +1,211 @@
+import { z } from "zod";
+import {
+  ScheduleTriggerSchema,
+  type ScheduleEntryInput,
+  type ScheduleTriggerInput,
+} from "./types/schedule.js";
+
+type CreateScheduleEntryInput = Omit<
+  ScheduleEntryInput,
+  | "id"
+  | "created_at"
+  | "updated_at"
+  | "last_fired_at"
+  | "next_fire_at"
+  | "consecutive_failures"
+  | "last_escalation_at"
+  | "baseline_results"
+  | "total_executions"
+  | "total_tokens_used"
+  | "max_tokens_per_day"
+  | "tokens_used_today"
+  | "budget_reset_at"
+  | "escalation_timestamps"
+>;
+
+const RecordSchema = z.record(z.string(), z.unknown());
+
+const SchedulePresetBaseSchema = z.object({
+  name: z.string().min(1).optional(),
+  enabled: z.boolean().default(true),
+  trigger: ScheduleTriggerSchema.optional(),
+});
+
+export const DailyBriefPresetInputSchema = SchedulePresetBaseSchema.extend({
+  preset: z.literal("daily_brief"),
+  context_sources: z.array(z.string()).default([]),
+});
+
+export const WeeklyReviewPresetInputSchema = SchedulePresetBaseSchema.extend({
+  preset: z.literal("weekly_review"),
+  context_sources: z.array(z.string()).default([]),
+});
+
+export const DreamConsolidationPresetInputSchema = SchedulePresetBaseSchema.extend({
+  preset: z.literal("dream_consolidation"),
+  context_sources: z.array(z.string()).default([]),
+});
+
+export const GoalProbePresetInputSchema = SchedulePresetBaseSchema.extend({
+  preset: z.literal("goal_probe"),
+  data_source_id: z.string().min(1),
+  query_params: RecordSchema.default({}),
+  detector_mode: z.enum(["threshold", "diff", "presence"]).default("diff"),
+  threshold_value: z.number().optional(),
+  baseline_window: z.number().int().min(1).default(5),
+  llm_on_change: z.boolean().default(true),
+  llm_prompt_template: z.string().optional(),
+});
+
+export const SchedulePresetInputSchema = z.discriminatedUnion("preset", [
+  DailyBriefPresetInputSchema,
+  WeeklyReviewPresetInputSchema,
+  DreamConsolidationPresetInputSchema,
+  GoalProbePresetInputSchema,
+]);
+
+export type SchedulePresetInput = z.input<typeof SchedulePresetInputSchema>;
+type ParsedSchedulePresetInput = z.infer<typeof SchedulePresetInputSchema>;
+export type SchedulePresetKey = SchedulePresetInput["preset"];
+
+export interface SchedulePresetDefinition {
+  key: SchedulePresetKey;
+  title: string;
+  description: string;
+  defaultTrigger: ScheduleTriggerInput;
+  dependencyHints: string[];
+}
+
+const PRESET_DEFINITIONS: Record<SchedulePresetKey, SchedulePresetDefinition> = {
+  daily_brief: {
+    key: "daily_brief",
+    title: "Daily brief",
+    description: "Runs the morning planning reflection and delivers a concise daily briefing.",
+    defaultTrigger: { type: "cron", expression: "0 9 * * *", timezone: "UTC" },
+    dependencyHints: ["llm_client", "notification_dispatcher"],
+  },
+  weekly_review: {
+    key: "weekly_review",
+    title: "Weekly review",
+    description: "Runs the weekly reflection review and emits a report plus notification.",
+    defaultTrigger: { type: "cron", expression: "0 9 * * 1", timezone: "UTC" },
+    dependencyHints: ["llm_client", "notification_dispatcher"],
+  },
+  dream_consolidation: {
+    key: "dream_consolidation",
+    title: "Dream consolidation",
+    description: "Runs overnight consolidation for memory and stale knowledge cleanup.",
+    defaultTrigger: { type: "cron", expression: "0 2 * * *", timezone: "UTC" },
+    dependencyHints: ["memory_lifecycle", "knowledge_manager"],
+  },
+  goal_probe: {
+    key: "goal_probe",
+    title: "Goal probe",
+    description: "Polls a data source and triggers change detection for goal-relevant signals.",
+    defaultTrigger: { type: "interval", seconds: 3600, jitter_factor: 0 },
+    dependencyHints: ["data_source_registry"],
+  },
+};
+
+function cloneTrigger(trigger: ScheduleTriggerInput): ScheduleTriggerInput {
+  return trigger.type === "cron"
+    ? { type: "cron", expression: trigger.expression, timezone: trigger.timezone ?? "UTC" }
+    : { type: "interval", seconds: trigger.seconds, jitter_factor: trigger.jitter_factor ?? 0 };
+}
+
+export function listSchedulePresetDefinitions(): SchedulePresetDefinition[] {
+  return Object.values(PRESET_DEFINITIONS).map((definition) => ({
+    ...definition,
+    defaultTrigger: cloneTrigger(definition.defaultTrigger),
+    dependencyHints: [...definition.dependencyHints],
+  }));
+}
+
+export function getSchedulePresetDefinition(key: SchedulePresetKey): SchedulePresetDefinition {
+  const definition = PRESET_DEFINITIONS[key];
+  return {
+    ...definition,
+    defaultTrigger: cloneTrigger(definition.defaultTrigger),
+    dependencyHints: [...definition.dependencyHints],
+  };
+}
+
+function resolveTrigger(input: ParsedSchedulePresetInput): ScheduleTriggerInput {
+  return input.trigger ? input.trigger : cloneTrigger(PRESET_DEFINITIONS[input.preset].defaultTrigger);
+}
+
+export function buildSchedulePresetEntry(input: SchedulePresetInput): CreateScheduleEntryInput {
+  const parsed = SchedulePresetInputSchema.parse(input);
+  const definition = PRESET_DEFINITIONS[parsed.preset];
+  const base = {
+    name: parsed.name ?? definition.title,
+    enabled: parsed.enabled,
+    trigger: resolveTrigger(parsed),
+    metadata: {
+      source: "preset" as const,
+      preset_key: parsed.preset,
+      dependency_hints: [...definition.dependencyHints],
+    },
+  };
+
+  switch (parsed.preset) {
+    case "daily_brief":
+      return {
+        ...base,
+        layer: "cron",
+        cron: {
+          job_kind: "reflection",
+          reflection_kind: "morning_planning",
+          prompt_template: "Run the daily brief reflection workflow.",
+          context_sources: parsed.context_sources,
+          output_format: "notification",
+          report_type: "daily_brief",
+          max_tokens: 1200,
+        },
+      };
+    case "weekly_review":
+      return {
+        ...base,
+        layer: "cron",
+        cron: {
+          job_kind: "reflection",
+          reflection_kind: "weekly_review",
+          prompt_template: "Run the weekly review reflection workflow.",
+          context_sources: parsed.context_sources,
+          output_format: "both",
+          report_type: "weekly_review",
+          max_tokens: 2000,
+        },
+      };
+    case "dream_consolidation":
+      return {
+        ...base,
+        layer: "cron",
+        cron: {
+          job_kind: "reflection",
+          reflection_kind: "dream_consolidation",
+          prompt_template: "Run the dream consolidation workflow.",
+          context_sources: parsed.context_sources,
+          output_format: "report",
+          report_type: "dream_consolidation",
+          max_tokens: 1200,
+        },
+      };
+    case "goal_probe":
+      return {
+        ...base,
+        layer: "probe",
+        probe: {
+          data_source_id: parsed.data_source_id,
+          query_params: parsed.query_params,
+          change_detector: {
+            mode: parsed.detector_mode,
+            threshold_value: parsed.threshold_value,
+            baseline_window: parsed.baseline_window,
+          },
+          llm_on_change: parsed.llm_on_change,
+          llm_prompt_template: parsed.llm_prompt_template,
+        },
+      };
+  }
+}

--- a/src/runtime/schedule-presets.ts
+++ b/src/runtime/schedule-presets.ts
@@ -49,6 +49,7 @@ export const DreamConsolidationPresetInputSchema = SchedulePresetBaseSchema.exte
 export const GoalProbePresetInputSchema = SchedulePresetBaseSchema.extend({
   preset: z.literal("goal_probe"),
   data_source_id: z.string().min(1),
+  probe_dimension: z.string().optional(),
   query_params: RecordSchema.default({}),
   detector_mode: z.enum(["threshold", "diff", "presence"]).default("diff"),
   threshold_value: z.number().optional(),
@@ -197,6 +198,7 @@ export function buildSchedulePresetEntry(input: SchedulePresetInput): CreateSche
         layer: "probe",
         probe: {
           data_source_id: parsed.data_source_id,
+          probe_dimension: parsed.probe_dimension,
           query_params: parsed.query_params,
           change_detector: {
             mode: parsed.detector_mode,

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -25,12 +25,31 @@ export const ProbeConfigSchema = z.object({
 
 export type ProbeConfig = z.infer<typeof ProbeConfigSchema>;
 
+export const ReflectionJobKindSchema = z.enum([
+  "morning_planning",
+  "evening_catchup",
+  "weekly_review",
+  "dream_consolidation",
+]);
+
+export type ReflectionJobKind = z.infer<typeof ReflectionJobKindSchema>;
+
 export const CronConfigSchema = z.object({
+  job_kind: z.enum(["prompt", "reflection"]).default("prompt"),
+  reflection_kind: ReflectionJobKindSchema.optional(),
   prompt_template: z.string(),
   context_sources: z.array(z.string()).default([]),
   output_format: z.enum(['notification', 'report', 'both']).default('notification'),
   report_type: z.string().optional(),
   max_tokens: z.number().default(4000),
+}).superRefine((value, ctx) => {
+  if (value.job_kind === "reflection" && !value.reflection_kind) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["reflection_kind"],
+      message: "reflection_kind is required when job_kind is reflection",
+    });
+  }
 });
 
 export type CronConfig = z.infer<typeof CronConfigSchema>;
@@ -43,7 +62,15 @@ export const GoalTriggerConfigSchema = z.object({
 
 export type GoalTriggerConfig = z.infer<typeof GoalTriggerConfigSchema>;
 
+export const ScheduleEntryMetadataSchema = z.object({
+  source: z.enum(["manual", "preset", "dream"]).default("manual"),
+  preset_key: z.string().optional(),
+  dream_suggestion_id: z.string().optional(),
+  dependency_hints: z.array(z.string()).default([]),
+  note: z.string().optional(),
+});
 
+export type ScheduleEntryMetadata = z.infer<typeof ScheduleEntryMetadataSchema>;
 
 export const EscalationConfigSchema = z.object({
   enabled: z.boolean().default(false),
@@ -70,6 +97,7 @@ export const ScheduleEntrySchema = z.object({
   layer: ScheduleLayerSchema,
   trigger: ScheduleTriggerSchema,
   enabled: z.boolean().default(true),
+  metadata: ScheduleEntryMetadataSchema.optional(),
   heartbeat: HeartbeatConfigSchema.optional(),
   probe: ProbeConfigSchema.optional(),
   escalation: EscalationConfigSchema.optional(),

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -13,6 +13,7 @@ export type HeartbeatConfig = z.infer<typeof HeartbeatConfigSchema>;
 
 export const ProbeConfigSchema = z.object({
   data_source_id: z.string(),
+  probe_dimension: z.string().optional(),
   query_params: z.record(z.unknown()).default({}),
   change_detector: z.object({
     mode: z.enum(["threshold", "diff", "presence"]),

--- a/src/tools/schedule/CreateScheduleTool/CreateScheduleTool.ts
+++ b/src/tools/schedule/CreateScheduleTool/CreateScheduleTool.ts
@@ -17,6 +17,10 @@ import {
   ScheduleTriggerSchema,
   type ScheduleEntry,
 } from "../../../runtime/types/schedule.js";
+import {
+  SchedulePresetInputSchema,
+  buildSchedulePresetEntry,
+} from "../../../runtime/schedule-presets.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
 
@@ -27,7 +31,7 @@ const BaseCreateScheduleInputSchema = z.object({
   escalation: EscalationConfigSchema.optional(),
 });
 
-export const CreateScheduleInputSchema = z.discriminatedUnion("layer", [
+const ExplicitCreateScheduleInputSchema = z.discriminatedUnion("layer", [
   BaseCreateScheduleInputSchema.extend({
     layer: z.literal("heartbeat"),
     heartbeat: HeartbeatConfigSchema,
@@ -44,6 +48,11 @@ export const CreateScheduleInputSchema = z.discriminatedUnion("layer", [
     layer: z.literal("goal_trigger"),
     goal_trigger: GoalTriggerConfigSchema,
   }),
+]);
+
+export const CreateScheduleInputSchema = z.union([
+  ExplicitCreateScheduleInputSchema,
+  SchedulePresetInputSchema,
 ]);
 
 export type CreateScheduleInput = z.infer<typeof CreateScheduleInputSchema>;
@@ -78,7 +87,9 @@ export class CreateScheduleTool implements ITool<CreateScheduleInput, CreateSche
     const startTime = Date.now();
 
     try {
-      const entry = await this.scheduleEngine.addEntry(input);
+      const entry = await this.scheduleEngine.addEntry(
+        "preset" in input ? buildSchedulePresetEntry(input) : input
+      );
 
       return {
         success: true,

--- a/src/tools/schedule/CreateScheduleTool/prompt.ts
+++ b/src/tools/schedule/CreateScheduleTool/prompt.ts
@@ -1,1 +1,1 @@
-export const DESCRIPTION = `Create a persistent schedule entry for the heartbeat, probe, cron, or goal_trigger layer.`;
+export const DESCRIPTION = `Create a persistent schedule entry for the heartbeat, probe, cron, or goal_trigger layer, or use a reusable preset such as daily_brief, weekly_review, dream_consolidation, or goal_probe.`;

--- a/src/tools/schedule/__tests__/GetScheduleTool.test.ts
+++ b/src/tools/schedule/__tests__/GetScheduleTool.test.ts
@@ -87,6 +87,7 @@ describe("GetScheduleTool", () => {
         layer: "cron",
         trigger: { type: "cron", expression: "0 * * * *", timezone: "UTC" },
         cron: {
+          job_kind: "prompt",
           prompt_template: "Summarize status",
           context_sources: ["notes"],
           output_format: "report",

--- a/src/tools/schedule/__tests__/create-schedule.test.ts
+++ b/src/tools/schedule/__tests__/create-schedule.test.ts
@@ -169,6 +169,32 @@ describe("CreateScheduleTool", () => {
     expect((result.data as CreateScheduleOutput).entry).toEqual(entry);
   });
 
+  it("expands preset inputs before calling scheduleEngine.addEntry", async () => {
+    const entry = makeScheduleEntry();
+    const addEntry = vi.fn().mockResolvedValue(entry);
+    const tool = new CreateScheduleTool({ addEntry } as unknown as ScheduleEngine);
+    const input = CreateScheduleInputSchema.parse({
+      preset: "daily_brief",
+    });
+
+    const result = await tool.call(input, makeContext());
+
+    expect(addEntry).toHaveBeenCalledTimes(1);
+    expect(addEntry).toHaveBeenCalledWith(expect.objectContaining({
+      name: "Daily brief",
+      layer: "cron",
+      metadata: expect.objectContaining({
+        source: "preset",
+        preset_key: "daily_brief",
+      }),
+      cron: expect.objectContaining({
+        job_kind: "reflection",
+        reflection_kind: "morning_planning",
+      }),
+    }));
+    expect(result.success).toBe(true);
+  });
+
   it("returns a failure result when scheduleEngine.addEntry throws", async () => {
     const addEntry = vi.fn().mockRejectedValue(new Error("disk full"));
     const tool = new CreateScheduleTool({ addEntry } as unknown as ScheduleEngine);

--- a/src/tools/schedule/__tests__/resume-schedule.test.ts
+++ b/src/tools/schedule/__tests__/resume-schedule.test.ts
@@ -32,6 +32,7 @@ function makeEntry(
     heartbeat: undefined,
     probe: undefined,
     cron: {
+      job_kind: "prompt",
       prompt_template: "Summarize daily changes.",
       context_sources: ["memory://daily"],
       output_format: "notification",

--- a/src/tools/schedule/__tests__/update-schedule.test.ts
+++ b/src/tools/schedule/__tests__/update-schedule.test.ts
@@ -35,6 +35,7 @@ function makeEntry(
     heartbeat: undefined,
     probe: undefined,
     cron: {
+      job_kind: "prompt",
       prompt_template: "Summarize daily changes.",
       context_sources: ["memory://daily"],
       output_format: "notification",
@@ -163,6 +164,7 @@ describe("UpdateScheduleTool", () => {
       enabled: false,
       trigger: { type: "interval", seconds: 300 },
       cron: {
+        job_kind: "prompt",
         prompt_template: "Summarize the latest activity.",
         context_sources: ["memory://daily"],
         output_format: "report",
@@ -182,6 +184,7 @@ describe("UpdateScheduleTool", () => {
         enabled: false,
         trigger: { type: "interval", seconds: 300, jitter_factor: 0 },
         cron: {
+          job_kind: "prompt",
           prompt_template: "Summarize the latest activity.",
           context_sources: ["memory://daily"],
           output_format: "report",

--- a/tests/web/api-knowledge.test.ts
+++ b/tests/web/api-knowledge.test.ts
@@ -11,19 +11,73 @@ vi.mock('next/server', () => ({
   NextRequest: class {},
 }));
 
+const mockSearchKnowledge = vi.fn();
+const mockListKnowledgeTransfers = vi.fn();
+
+vi.mock('../../web/src/lib/pulseed-client', () => ({
+  searchKnowledge: (...args: unknown[]) => mockSearchKnowledge(...args),
+  listKnowledgeTransfers: (...args: unknown[]) => mockListKnowledgeTransfers(...args),
+}));
+
 const { GET: getTransfers } = await import('../../web/src/app/api/knowledge/transfers/route.js');
 const { POST: postSearch } = await import('../../web/src/app/api/knowledge/search/route.js');
 
 describe('GET /api/knowledge/transfers', () => {
-  it('returns transfers array (placeholder)', async () => {
+  it('returns transfers plus transfer results and effectiveness metadata', async () => {
+    mockListKnowledgeTransfers.mockResolvedValueOnce({
+      transfers: [
+        {
+          candidate_id: 'tc_1',
+          source_goal_id: 'goal-a',
+          target_goal_id: 'goal-b',
+          type: 'pattern',
+          source_item_id: 'pattern-1',
+          similarity_score: 0.91,
+          estimated_benefit: 'Reuses a proven structure',
+          state: 'proposed',
+          domain_tag_match: true,
+          adapted_content: null,
+          effectiveness_score: null,
+          proposed_at: null,
+          applied_at: null,
+          invalidated_at: null,
+          result: {
+            transfer_id: 'tr_1',
+            candidate_id: 'tc_1',
+            applied_at: '2026-04-08T00:00:00.000Z',
+            adaptation_description: 'Adapted pattern for target',
+            success: true,
+          },
+          effectiveness: null,
+        },
+      ],
+      results: [
+        {
+          transfer_id: 'tr_1',
+          candidate_id: 'tc_1',
+          applied_at: '2026-04-08T00:00:00.000Z',
+          adaptation_description: 'Adapted pattern for target',
+          success: true,
+        },
+      ],
+      effectiveness_records: [],
+    });
+
     const res = await getTransfers();
     const body = await res.json();
     expect(Array.isArray(body.transfers)).toBe(true);
-    expect(body.transfers).toHaveLength(0);
-    expect(typeof body.message).toBe('string');
+    expect(body.transfers).toHaveLength(1);
+    expect(body.transfers[0].result.transfer_id).toBe('tr_1');
+    expect(Array.isArray(body.results)).toBe(true);
+    expect(Array.isArray(body.effectiveness_records)).toBe(true);
   });
 
   it('has status 200', async () => {
+    mockListKnowledgeTransfers.mockResolvedValueOnce({
+      transfers: [],
+      results: [],
+      effectiveness_records: [],
+    });
     const res = await getTransfers();
     expect(res.status).toBe(200);
   });
@@ -36,18 +90,41 @@ describe('POST /api/knowledge/search', () => {
     } as import('next/server').NextRequest;
   }
 
-  it('returns search results (placeholder) with query', async () => {
+  it('returns provenance-rich search results with query', async () => {
+    mockSearchKnowledge.mockResolvedValueOnce([
+      {
+        entry_id: 'entry-1',
+        question: 'How do I reduce scope?',
+        answer: 'Trim to the critical path.',
+        sources: [{ type: 'expert', reference: 'playbook', reliability: 'high' }],
+        confidence: 0.92,
+        acquired_at: '2026-04-08T00:00:00.000Z',
+        acquisition_task_id: 'task-1',
+        superseded_by: null,
+        tags: ['scope', 'planning'],
+        embedding_id: 'entry-1',
+        source_goal_ids: ['goal-a'],
+        domain_stability: 'moderate',
+        revalidation_due_at: null,
+        similarity: 0.98,
+      },
+    ]);
+
     const res = await postSearch(makeRequest({ query: 'test query', topK: 3 }));
     const body = await res.json();
     expect(Array.isArray(body.results)).toBe(true);
-    expect(body.message).toContain('test query');
-    expect(body.message).toContain('topK=3');
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].sources[0].reference).toBe('playbook');
+    expect(body.results[0].source_goal_ids).toEqual(['goal-a']);
+    expect(body.query).toBe('test query');
+    expect(body.topK).toBe(3);
   });
 
   it('uses default topK=5 when not specified', async () => {
+    mockSearchKnowledge.mockResolvedValueOnce([]);
     const res = await postSearch(makeRequest({ query: 'my query' }));
     const body = await res.json();
-    expect(body.message).toContain('topK=5');
+    expect(body.topK).toBe(5);
   });
 
   it('returns 400 when query is missing', async () => {

--- a/web/src/app/api/decisions/route.ts
+++ b/web/src/app/api/decisions/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import { homedir } from 'os';
+import { getStateManager } from '../../../lib/pulseed-client';
+
+interface DecisionEntry {
+  id: string;
+  goal_id: string;
+  goal_name?: string;
+  decision: string;
+  timestamp: string;
+  strategy_id?: string;
+  what_worked?: string[];
+  what_failed?: string[];
+  suggested_next?: string[];
+}
+
+export async function GET() {
+  try {
+    const decisionsDir = join(homedir(), '.pulseed', 'decisions');
+    const sm = getStateManager();
+    const decisions: DecisionEntry[] = [];
+
+    // Try reading from ~/.pulseed/decisions/ directory
+    let files: string[];
+    try {
+      files = await readdir(decisionsDir);
+    } catch {
+      files = [];
+    }
+
+    for (const file of files.filter((f) => f.endsWith('.json'))) {
+      try {
+        const content = await readFile(join(decisionsDir, file), 'utf-8');
+        const record = JSON.parse(content);
+        if (record.decision) {
+          // Resolve goal name
+          let goalName: string | undefined;
+          try {
+            const goal = await sm.loadGoal(record.goal_id);
+            goalName = (goal as Record<string, unknown>)?.name as string | undefined;
+          } catch { /* ignore */ }
+
+          decisions.push({
+            id: record.id || file.replace('.json', ''),
+            goal_id: record.goal_id,
+            goal_name: goalName,
+            decision: record.decision,
+            timestamp: record.timestamp || '',
+            strategy_id: record.strategy_id,
+            what_worked: record.what_worked,
+            what_failed: record.what_failed,
+            suggested_next: record.suggested_next,
+          });
+        }
+      } catch { /* skip malformed */ }
+    }
+
+    // Sort by timestamp descending, limit to 10
+    decisions.sort((a, b) => {
+      const ta = new Date(a.timestamp).getTime() || 0;
+      const tb = new Date(b.timestamp).getTime() || 0;
+      return tb - ta;
+    });
+
+    return NextResponse.json(decisions.slice(0, 10));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/events/route.ts
+++ b/web/src/app/api/events/route.ts
@@ -1,0 +1,142 @@
+/**
+ * SSE endpoint — polls PulSeed state every 2s and pushes changes to the client.
+ * M18.4: real-time event stream for the dashboard.
+ */
+import { getStateManager } from '../../../lib/pulseed-client';
+
+const POLL_INTERVAL_MS = 2000;
+const HEARTBEAT_INTERVAL_MS = 30000;
+
+function hashState(data: unknown): string {
+  const str = JSON.stringify(data);
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0; // Convert to 32bit integer
+  }
+  return String(hash);
+}
+
+function sseMessage(data: unknown): Uint8Array {
+  return new TextEncoder().encode(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+interface GoalState {
+  id: string;
+  status: string;
+  trust?: number;
+  gap?: number;
+  updatedAt?: string;
+  [key: string]: unknown;
+}
+
+export async function GET(request: Request) {
+  const { signal } = request;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      let pollTimer: ReturnType<typeof setInterval> | null = null;
+      let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+      function enqueue(data: unknown) {
+        try {
+          controller.enqueue(sseMessage(data));
+        } catch {
+          // Controller may be closed; ignore
+        }
+      }
+
+      function close() {
+        if (pollTimer) clearInterval(pollTimer);
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
+        try {
+          controller.close();
+        } catch {
+          // Already closed
+        }
+      }
+
+      // Clean up when client disconnects
+      signal.addEventListener('abort', close);
+
+      // Send connected event
+      enqueue({ type: 'connected' });
+
+      // Track previous state hashes keyed by goalId
+      const prevHashes = new Map<string, string>();
+      let prevGoalListHash = '';
+
+      async function poll() {
+        if (signal.aborted) return;
+
+        try {
+          const sm = getStateManager();
+          const goalIds: string[] = await sm.listGoalIds();
+
+          // Detect new/removed goals
+          const currentGoalListHash = hashState(goalIds.slice().sort());
+          if (currentGoalListHash !== prevGoalListHash) {
+            prevGoalListHash = currentGoalListHash;
+          }
+
+          for (const id of goalIds) {
+            if (signal.aborted) break;
+
+            const goal = await sm.loadGoal(id) as GoalState | null;
+            if (!goal) continue;
+
+            const hash = hashState(goal);
+            const prev = prevHashes.get(id);
+
+            if (hash !== prev) {
+              prevHashes.set(id, hash);
+              enqueue({
+                type: 'goal_updated',
+                goalId: id,
+                data: goal,
+              });
+
+              // Also emit specific change events for trust/gap if they differ
+              if (prev !== undefined) {
+                const prevGoal = JSON.parse(JSON.stringify(goal)) as GoalState;
+                // We only have the current value — emit anyway for subscribers
+                if (goal.trust !== undefined) {
+                  enqueue({ type: 'trust_changed', goalId: id, trust: goal.trust });
+                }
+                if (goal.gap !== undefined) {
+                  enqueue({ type: 'gap_changed', goalId: id, gap: goal.gap });
+                }
+                void prevGoal; // suppress unused var warning
+              }
+            }
+          }
+        } catch {
+          // StateManager may not be available; skip poll
+        }
+      }
+
+      // Initial poll
+      await poll();
+
+      // Recurring poll
+      pollTimer = setInterval(() => {
+        void poll();
+      }, POLL_INTERVAL_MS);
+
+      // Heartbeat to keep connection alive
+      heartbeatTimer = setInterval(() => {
+        enqueue({ type: 'heartbeat' });
+      }, HEARTBEAT_INTERVAL_MS);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/web/src/app/api/goals/[id]/gap-history/route.ts
+++ b/web/src/app/api/goals/[id]/gap-history/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getStateManager } from '../../../../../lib/pulseed-client';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const sm = getStateManager();
+    const history = await sm.loadGapHistory(id);
+    return NextResponse.json(history);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/goals/[id]/route.ts
+++ b/web/src/app/api/goals/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getStateManager } from '../../../../lib/pulseed-client';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const sm = getStateManager();
+    const goal = await sm.loadGoal(id);
+    if (!goal) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json(goal);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/goals/[id]/tasks/route.ts
+++ b/web/src/app/api/goals/[id]/tasks/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import { homedir } from 'os';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const tasksDir = join(homedir(), '.pulseed', 'tasks', id);
+
+    let files: string[];
+    try {
+      files = await readdir(tasksDir);
+    } catch {
+      return NextResponse.json({ tasks: [] });
+    }
+
+    const tasks: Array<Record<string, unknown>> = [];
+    for (const file of files.filter((f) => f.endsWith('.json'))) {
+      try {
+        const content = await readFile(join(tasksDir, file), 'utf-8');
+        tasks.push(JSON.parse(content));
+      } catch {
+        // Skip malformed files
+      }
+    }
+
+    // Sort by created_at descending (most recent first)
+    tasks.sort((a, b) => {
+      const aTime = a.created_at ? new Date(String(a.created_at)).getTime() : 0;
+      const bTime = b.created_at ? new Date(String(b.created_at)).getTime() : 0;
+      return bTime - aTime;
+    });
+
+    return NextResponse.json({ tasks });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/goals/route.ts
+++ b/web/src/app/api/goals/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { getStateManager } from '../../../lib/pulseed-client';
+
+export async function GET() {
+  try {
+    const sm = getStateManager();
+    const goalIds = await sm.listGoalIds();
+    const goals = await Promise.all(
+      goalIds.map((id: string) => sm.loadGoal(id))
+    );
+    return NextResponse.json(goals.filter(Boolean));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/knowledge/patterns/route.ts
+++ b/web/src/app/api/knowledge/patterns/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from 'next/server';
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import { homedir } from 'os';
+
+interface LearnedPattern {
+  pattern_id: string;
+  type: string;
+  description: string;
+  confidence: number;
+  evidence_count: number;
+  source_goal_ids: string[];
+  applicable_domains: string[];
+  created_at: string;
+  last_applied_at: string | null;
+}
+
+export async function GET() {
+  try {
+    const learningDir = join(homedir(), '.pulseed', 'learning');
+    let files: string[];
+    try {
+      files = await readdir(learningDir);
+    } catch {
+      return NextResponse.json({ patterns: [] });
+    }
+
+    const patternFiles = files.filter((f) => f.endsWith('_patterns.json'));
+    const allPatterns: LearnedPattern[] = [];
+
+    for (const file of patternFiles) {
+      try {
+        const content = await readFile(join(learningDir, file), 'utf-8');
+        const data = JSON.parse(content);
+        const patterns: LearnedPattern[] = Array.isArray(data) ? data : [];
+        allPatterns.push(...patterns);
+      } catch {
+        // Skip malformed files
+      }
+    }
+
+    // Sort by confidence descending
+    allPatterns.sort((a, b) => b.confidence - a.confidence);
+
+    return NextResponse.json({ patterns: allPatterns });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/knowledge/search/route.ts
+++ b/web/src/app/api/knowledge/search/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { searchKnowledge } from '../../../../lib/pulseed-client';
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { query, topK = 5 } = body;
+    if (!query || typeof query !== 'string') {
+      return NextResponse.json({ error: 'query is required' }, { status: 400 });
+    }
+
+    const normalizedTopK =
+      typeof topK === 'number' && Number.isFinite(topK) && topK > 0
+        ? Math.min(Math.floor(topK), 20)
+        : 5;
+    const results = await searchKnowledge(query, normalizedTopK);
+
+    return NextResponse.json({
+      query,
+      topK: normalizedTopK,
+      results,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/knowledge/transfers/route.ts
+++ b/web/src/app/api/knowledge/transfers/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { listKnowledgeTransfers } from '../../../../lib/pulseed-client';
+
+export async function GET() {
+  try {
+    const snapshot = await listKnowledgeTransfers();
+    return NextResponse.json({
+      transfers: snapshot.transfers,
+      results: snapshot.results,
+      effectiveness_records: snapshot.effectiveness_records,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/reports/[goalId]/route.ts
+++ b/web/src/app/api/reports/[goalId]/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getReportingEngine } from '../../../../lib/pulseed-client';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ goalId: string }> }
+) {
+  try {
+    const { goalId } = await params;
+    const re = getReportingEngine();
+    const reports = await re.listReports(goalId);
+    return NextResponse.json(reports);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/sessions/route.ts
+++ b/web/src/app/api/sessions/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import { homedir } from 'os';
+
+export async function GET() {
+  try {
+    const sessionsDir = join(homedir(), '.pulseed', 'sessions');
+
+    let files: string[];
+    try {
+      files = await readdir(sessionsDir);
+    } catch {
+      return NextResponse.json([]);
+    }
+
+    const sessions = [];
+    for (const file of files.filter((f) => f.endsWith('.json'))) {
+      try {
+        const content = await readFile(join(sessionsDir, file), 'utf-8');
+        sessions.push(JSON.parse(content));
+      } catch {
+        // Skip malformed files
+      }
+    }
+
+    return NextResponse.json(sessions);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/settings/plugins/route.ts
+++ b/web/src/app/api/settings/plugins/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const PLUGINS_DIR = path.join(os.homedir(), '.pulseed', 'plugins');
+
+interface PluginInfo {
+  name: string;
+  version: string;
+  type: string;
+  description: string;
+  status: 'loaded' | 'error' | 'disabled';
+}
+
+async function readPluginManifest(pluginDir: string): Promise<PluginInfo | null> {
+  // Try plugin.json then plugin.yaml (yaml parsing skipped — read raw json only for simplicity)
+  const jsonPath = path.join(pluginDir, 'plugin.json');
+  try {
+    const raw = await fsp.readFile(jsonPath, 'utf-8');
+    const manifest = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      name: String(manifest.name ?? path.basename(pluginDir)),
+      version: String(manifest.version ?? '0.0.0'),
+      type: String(manifest.type ?? 'unknown'),
+      description: String(manifest.description ?? ''),
+      status: 'loaded',
+    };
+  } catch {
+    return {
+      name: path.basename(pluginDir),
+      version: '—',
+      type: 'unknown',
+      description: 'Manifest unreadable',
+      status: 'error',
+    };
+  }
+}
+
+export async function GET() {
+  try {
+    const entries = await fsp.readdir(PLUGINS_DIR, { withFileTypes: true });
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => path.join(PLUGINS_DIR, e.name));
+
+    const plugins = await Promise.all(dirs.map(readPluginManifest));
+    return NextResponse.json({ plugins: plugins.filter(Boolean) });
+  } catch {
+    // Plugins directory doesn't exist
+    return NextResponse.json({ plugins: [] });
+  }
+}

--- a/web/src/app/api/settings/provider/route.ts
+++ b/web/src/app/api/settings/provider/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import * as fsp from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+const PROVIDER_CONFIG_PATH = path.join(os.homedir(), '.pulseed', 'provider.json');
+
+function maskApiKey(key: string | undefined): string | undefined {
+  if (!key) return undefined;
+  if (key.length <= 4) return '****';
+  return key.slice(0, 4) + '****';
+}
+
+export async function GET() {
+  try {
+    const raw = await fsp.readFile(PROVIDER_CONFIG_PATH, 'utf-8');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const config = JSON.parse(raw) as Record<string, any>;
+
+    // Mask API key before returning (new flat format)
+    if (config.api_key) {
+      config.api_key = maskApiKey(config.api_key);
+    }
+    // Also handle legacy nested format in case file hasn't been migrated yet
+    if (config.anthropic?.api_key) {
+      config.anthropic.api_key = maskApiKey(config.anthropic.api_key);
+    }
+    if (config.openai?.api_key) {
+      config.openai.api_key = maskApiKey(config.openai.api_key);
+    }
+
+    return NextResponse.json({ config, exists: true });
+  } catch {
+    // File doesn't exist or is unreadable — return defaults
+    return NextResponse.json({
+      config: {
+        provider: 'openai',
+        model: 'gpt-5.4-mini',
+        adapter: 'openai_codex_cli',
+      },
+      exists: false,
+    });
+  }
+}

--- a/web/src/app/api/strategies/[goalId]/route.ts
+++ b/web/src/app/api/strategies/[goalId]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { readdir, readFile } from 'fs/promises';
+import { join } from 'path';
+import { homedir } from 'os';
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ goalId: string }> }
+) {
+  try {
+    const { goalId } = await params;
+    const strategiesDir = join(homedir(), '.pulseed', 'strategies', goalId);
+
+    let files: string[];
+    try {
+      files = await readdir(strategiesDir);
+    } catch {
+      return NextResponse.json({ strategies: [] });
+    }
+
+    const strategies = [];
+    for (const file of files.filter((f) => f.endsWith('.json'))) {
+      try {
+        const content = await readFile(join(strategiesDir, file), 'utf-8');
+        strategies.push(JSON.parse(content));
+      } catch {
+        // Skip malformed files
+      }
+    }
+
+    return NextResponse.json({ strategies });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/web/src/lib/pulseed-client.ts
+++ b/web/src/lib/pulseed-client.ts
@@ -163,7 +163,7 @@ export async function searchKnowledge(
 
 export async function listKnowledgeTransfers(): Promise<KnowledgeTransferSnapshot> {
   const knowledgeTransfer = await getKnowledgeTransfer();
-  const snapshot = await knowledgeTransfer.listTransferSnapshot();
+  const snapshot = await knowledgeTransfer.listTransferSnapshot({ forceRefresh: true });
   const transfers = snapshot.transfers;
   const results = snapshot.results;
   const effectivenessRecords = snapshot.effectiveness_records;

--- a/web/src/lib/pulseed-client.ts
+++ b/web/src/lib/pulseed-client.ts
@@ -1,0 +1,189 @@
+/**
+ * Server-side only singleton accessors for PulSeed core modules.
+ * Web route handlers use this file so they do not depend on build-time `dist/`
+ * artifacts.
+ */
+import path from 'node:path';
+import { StateManager } from '../../../src/base/state/state-manager.js';
+import type { ILLMClient } from '../../../src/base/llm/llm-client.js';
+import { ReportingEngine } from '../../../src/reporting/reporting-engine.js';
+import { KnowledgeManager } from '../../../src/platform/knowledge/knowledge-manager.js';
+import { VectorIndex } from '../../../src/platform/knowledge/vector-index.js';
+import { MockEmbeddingClient, OpenAIEmbeddingClient } from '../../../src/platform/knowledge/embedding-client.js';
+import { LearningPipeline } from '../../../src/platform/knowledge/learning/learning-pipeline.js';
+import { KnowledgeTransfer } from '../../../src/platform/knowledge/transfer/knowledge-transfer.js';
+import { TransferTrustManager } from '../../../src/platform/knowledge/transfer/transfer-trust.js';
+import type { SharedKnowledgeEntry } from '../../../src/platform/knowledge/types/knowledge.js';
+import type {
+  TransferCandidate,
+  TransferEffectivenessRecord,
+  TransferResult,
+} from '../../../src/orchestrator/strategy/types/cross-portfolio.js';
+
+type KnowledgeSearchHit = SharedKnowledgeEntry & { similarity: number };
+
+type KnowledgeTransferItem = TransferCandidate & {
+  result: TransferResult | null;
+  effectiveness: TransferEffectivenessRecord | null;
+};
+
+type KnowledgeTransferSnapshot = {
+  transfers: KnowledgeTransferItem[];
+  results: TransferResult[];
+  effectiveness_records: TransferEffectivenessRecord[];
+};
+
+let stateManager: InstanceType<typeof StateManager> | null = null;
+let reportingEngine: InstanceType<typeof ReportingEngine> | null = null;
+let embeddingClient: MockEmbeddingClient | OpenAIEmbeddingClient | null = null;
+let vectorIndexPromise: Promise<VectorIndex | null> | null = null;
+let knowledgeManagerPromise: Promise<KnowledgeManager> | null = null;
+let knowledgeTransferPromise: Promise<KnowledgeTransfer> | null = null;
+
+function createNoopLLMClient(): ILLMClient {
+  return {
+    async sendMessage() {
+      return {
+        content: '',
+        usage: { input_tokens: 0, output_tokens: 0 },
+        stop_reason: 'end_turn',
+      };
+    },
+    parseJSON<T>(content: string, schema: { parse: (input: unknown) => T }): T {
+      return schema.parse(JSON.parse(content) as unknown);
+    },
+    supportsToolCalling: () => false,
+  } as ILLMClient;
+}
+
+function getEmbeddingClient(): MockEmbeddingClient | OpenAIEmbeddingClient {
+  if (!embeddingClient) {
+    embeddingClient = process.env.OPENAI_API_KEY
+      ? new OpenAIEmbeddingClient(process.env.OPENAI_API_KEY)
+      : new MockEmbeddingClient();
+  }
+  return embeddingClient;
+}
+
+async function getVectorIndex(): Promise<VectorIndex | null> {
+  if (!vectorIndexPromise) {
+    vectorIndexPromise = (async () => {
+      const baseDir = getStateManager().getBaseDir();
+      const indexPath = path.join(baseDir, 'memory', 'vector-index.json');
+      const client = getEmbeddingClient();
+      try {
+        return await VectorIndex.create(indexPath, client);
+      } catch {
+        try {
+          return new VectorIndex(indexPath, client);
+        } catch {
+          return null;
+        }
+      }
+    })();
+  }
+  return vectorIndexPromise;
+}
+
+async function getKnowledgeManager(): Promise<KnowledgeManager> {
+  if (!knowledgeManagerPromise) {
+    knowledgeManagerPromise = (async () => {
+      const state = getStateManager();
+      const vectorIndex = await getVectorIndex();
+      return new KnowledgeManager(
+        state,
+        createNoopLLMClient(),
+        vectorIndex ?? undefined,
+        getEmbeddingClient()
+      );
+    })();
+  }
+  return knowledgeManagerPromise;
+}
+
+async function getKnowledgeTransfer(): Promise<KnowledgeTransfer> {
+  if (!knowledgeTransferPromise) {
+    knowledgeTransferPromise = (async () => {
+      const state = getStateManager();
+      const vectorIndex = await getVectorIndex();
+      const knowledgeManager = await getKnowledgeManager();
+      const learningPipeline = new LearningPipeline(
+        createNoopLLMClient(),
+        vectorIndex,
+        state
+      );
+      const transferTrust = new TransferTrustManager({ stateManager: state });
+      const ethicsGate = {
+        check: async () => ({
+          verdict: 'pass' as const,
+          reasoning: 'web knowledge listing',
+          confidence: 1,
+        }),
+      };
+
+      return new KnowledgeTransfer({
+        llmClient: createNoopLLMClient(),
+        knowledgeManager,
+        vectorIndex,
+        learningPipeline,
+        ethicsGate: ethicsGate as never,
+        stateManager: state,
+        transferTrust,
+      });
+    })();
+  }
+  return knowledgeTransferPromise;
+}
+
+export function getStateManager(): InstanceType<typeof StateManager> {
+  if (!stateManager) {
+    stateManager = new StateManager();
+  }
+  return stateManager;
+}
+
+export function getReportingEngine(): InstanceType<typeof ReportingEngine> {
+  if (!reportingEngine) {
+    reportingEngine = new ReportingEngine(getStateManager());
+  }
+  return reportingEngine;
+}
+
+export async function searchKnowledge(
+  query: string,
+  topK: number = 5
+): Promise<KnowledgeSearchHit[]> {
+  const knowledgeManager = await getKnowledgeManager();
+  const results = await knowledgeManager.searchByEmbedding(query, topK);
+  return results.map(({ entry, similarity }) => ({
+    ...entry,
+    similarity,
+  }));
+}
+
+export async function listKnowledgeTransfers(): Promise<KnowledgeTransferSnapshot> {
+  const knowledgeTransfer = await getKnowledgeTransfer();
+  const transfers = knowledgeTransfer.getTransferCandidates();
+  const results = knowledgeTransfer.getTransferResults();
+  const effectivenessRecords = knowledgeTransfer.getEffectivenessRecords();
+
+  const resultsByCandidateId = new Map(results.map((result) => [result.candidate_id, result]));
+  const effectivenessByTransferId = new Map(
+    effectivenessRecords.map((record) => [record.transfer_id, record])
+  );
+
+  return {
+    transfers: transfers.map((candidate) => {
+      const result = resultsByCandidateId.get(candidate.candidate_id) ?? null;
+      return {
+        ...candidate,
+        result,
+        effectiveness: result
+          ? effectivenessByTransferId.get(result.transfer_id) ?? null
+          : null,
+      };
+    }),
+    results,
+    effectiveness_records: effectivenessRecords,
+  };
+}

--- a/web/src/lib/pulseed-client.ts
+++ b/web/src/lib/pulseed-client.ts
@@ -163,9 +163,10 @@ export async function searchKnowledge(
 
 export async function listKnowledgeTransfers(): Promise<KnowledgeTransferSnapshot> {
   const knowledgeTransfer = await getKnowledgeTransfer();
-  const transfers = knowledgeTransfer.getTransferCandidates();
-  const results = knowledgeTransfer.getTransferResults();
-  const effectivenessRecords = knowledgeTransfer.getEffectivenessRecords();
+  const snapshot = await knowledgeTransfer.listTransferSnapshot();
+  const transfers = snapshot.transfers;
+  const results = snapshot.results;
+  const effectivenessRecords = snapshot.effectiveness_records;
 
   const resultsByCandidateId = new Map(results.map((result) => [result.candidate_id, result]));
   const effectivenessByTransferId = new Map(

--- a/web/src/lib/seedpulse-client.ts
+++ b/web/src/lib/seedpulse-client.ts
@@ -1,0 +1,1 @@
+export * from './pulseed-client';


### PR DESCRIPTION
## Summary
- add schedule presets, dream schedule suggestion storage, and CLI/chat flows for #571 and #572
- execute reflection schedule jobs and surface proactive notifications/approvals through daemon SSE/chat for #573 and #574
- add a first-party Postgres datasource plus capability acquisition recommendations/replan signaling for #575 and #576
- replace placeholder web knowledge search/transfer handlers with core-backed integrations for #577

## Testing
- npm test -- --run src/runtime/__tests__/schedule-presets.test.ts src/platform/dream/__tests__/dream-schedule-suggestions.test.ts src/tools/schedule/__tests__/create-schedule.test.ts src/interface/chat/__tests__/chat-schedule-integration.test.ts src/platform/dream/__tests__/dream-analyzer.test.ts src/interface/chat/__tests__/event-subscriber.test.ts src/runtime/__tests__/notification-dispatcher.test.ts src/runtime/__tests__/schedule-engine.test.ts src/platform/observation/__tests__/data-source-adapter.test.ts src/interface/cli/__tests__/datasource-command.test.ts src/platform/observation/__tests__/capability-detector-escalate.test.ts src/orchestrator/loop/__tests__/core-loop-capability.test.ts tests/web/api-knowledge.test.ts
- npx tsc -p tsconfig.json --noEmit
- npx tsc -p web/tsconfig.json --noEmit

Closes #571
Closes #572
Closes #573
Closes #574
Closes #575
Closes #576
Closes #577