### PR TITLE
feat(tui): braille checkerboard spinner

### DIFF
--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -7,7 +7,7 @@
 import React, { useCallback, useState } from "react";
 import { Box, Text, useInput, useStdout } from "ink";
 import TextInput from "ink-text-input";
-import Spinner from "ink-spinner";
+import { CheckerboardSpinner } from "./checkerboard-spinner.js";
 import {
   renderMarkdownLines,
   splitMarkdownLineToRows,
@@ -639,7 +639,7 @@ export function Chat({
 
         {isProcessing && (
           <Box>
-            <Spinner type="dots" />
+            <CheckerboardSpinner />
             <Text> </Text>
             <ShimmerText>{`${spinnerVerb}...`}</ShimmerText>
           </Box>

--- a/src/interface/tui/checkerboard-spinner.tsx
+++ b/src/interface/tui/checkerboard-spinner.tsx
@@ -1,0 +1,23 @@
+import React, { useState, useEffect } from "react";
+import { Text } from "ink";
+
+/**
+ * Checkerboard braille spinner — 4-phase animation using Unicode braille grid.
+ * Ported from https://github.com/gunnargray-dev/unicode-animations
+ */
+
+const frames = ["⢕⢕⢕", "⡪⡪⡪", "⢊⠔⡡", "⡡⢊⠔"];
+const interval = 250;
+
+export function CheckerboardSpinner(): React.ReactElement {
+  const [frame, setFrame] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setFrame((prev) => (prev === frames.length - 1 ? 0 : prev + 1));
+    }, interval);
+    return () => clearInterval(timer);
+  }, []);
+
+  return <Text>{frames[frame]}</Text>;
+}

--- a/src/interface/tui/dashboard.tsx
+++ b/src/interface/tui/dashboard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, Text } from "ink";
-import Spinner from "ink-spinner";
+import { CheckerboardSpinner } from "./checkerboard-spinner.js";
 import type { LoopState, DimensionProgress } from "./use-loop.js";
 import { theme, statusColor, progressColor } from "./theme.js";
 
@@ -106,7 +106,7 @@ export function Dashboard({ state }: DashboardProps) {
         <Text>{"  "}</Text>
         {state.status === "running" ? (
           <Text color={theme.success}>
-            <Spinner type="dots" />
+            <CheckerboardSpinner />
             {" " + statusLabel("running")}
           </Text>
         ) : (


### PR DESCRIPTION
## Summary
- Replace ink-spinner dots with braille checkerboard animation from [unicode-animations](https://github.com/gunnargray-dev/unicode-animations)
- 4-phase braille pattern (`⢕⢕⢕` → `⡪⡪⡪` → `⢊⠔⡡` → `⡡⢊⠔`) at 250ms interval
- Applied to both chat and dashboard spinners

## Test plan
- [x] Verified on Mac Mini — animation renders correctly
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/interface/tui/` — 8 files, 138 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)