### PR TITLE
feat(runtime): add runtime_journal_v2 Phase 0 foundation

### DIFF
--- a/src/interface/cli/__tests__/cli-daemon-status.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-status.test.ts
@@ -165,6 +165,7 @@ describe("cmdDaemonStatus", () => {
     expect(output).toContain("5m (adaptive sleep: off)");
     expect(output).toContain("10 per cycle");
     expect(output).toContain("Proactive:     off");
+    expect(output).toContain("Runtime journal: off");
     expect(output).toContain("enabled");
   });
 
@@ -183,6 +184,8 @@ describe("cmdDaemonStatus", () => {
       check_interval_ms: 120_000, // 2 min
       iterations_per_cycle: 5,
       proactive_mode: true,
+      runtime_journal_v2: true,
+      runtime_root: "/tmp/pulseed-runtime",
       adaptive_sleep: { enabled: true },
       crash_recovery: { enabled: true, max_retries: 5 },
     };
@@ -195,7 +198,64 @@ describe("cmdDaemonStatus", () => {
     expect(output).toContain("2m (adaptive sleep: on)");
     expect(output).toContain("5 per cycle");
     expect(output).toContain("Proactive:     on");
+    expect(output).toContain("Runtime journal: on");
+    expect(output).toContain("/tmp/pulseed-runtime");
     expect(output).toContain("0/5 retries used");
+  });
+
+  it("falls back to daemon.json when daemon-config.json is absent", async () => {
+    const state = {
+      pid: 999999999,
+      started_at: "2026-01-01T00:00:00.000Z",
+      last_loop_at: null,
+      loop_count: 0,
+      active_goals: [],
+      status: "stopped",
+      crash_count: 0,
+      last_error: null,
+    };
+    const config = {
+      check_interval_ms: 180_000,
+      iterations_per_cycle: 3,
+      runtime_journal_v2: true,
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+    fs.writeFileSync(path.join(tmpDir, "daemon.json"), JSON.stringify(config));
+
+    await cmdDaemonStatus([]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("3m (adaptive sleep: off)");
+    expect(output).toContain("3 per cycle");
+    expect(output).toContain("Runtime journal: on");
+  });
+
+  it("prefers daemon.json over daemon-config.json when both exist", async () => {
+    const state = {
+      pid: 999999999,
+      started_at: "2026-01-01T00:00:00.000Z",
+      last_loop_at: null,
+      loop_count: 0,
+      active_goals: [],
+      status: "stopped",
+      crash_count: 0,
+      last_error: null,
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon.json"),
+      JSON.stringify({ iterations_per_cycle: 7, runtime_journal_v2: true })
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon-config.json"),
+      JSON.stringify({ iterations_per_cycle: 2, runtime_journal_v2: false })
+    );
+
+    await cmdDaemonStatus([]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("7 per cycle");
+    expect(output).toContain("Runtime journal: on");
   });
 
   it("shows last cycle relative time when last_loop_at is present", async () => {

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -162,24 +162,15 @@ export async function cmdStart(
     process.exit(1);
   }
 
-  const configuredPort = daemonConfig && typeof (daemonConfig as Record<string, unknown>).event_server_port === "number"
-    ? (daemonConfig as Record<string, unknown>).event_server_port as number
-    : undefined;
-  const eventServer = new EventServer(
-    deps.driveSystem,
-    configuredPort !== undefined ? { port: configuredPort } : undefined,
-    logger
-  );
-  notificationDispatcher.setRealtimeSink(async (report) => {
-    eventServer.broadcast("notification_report", {
-      id: report.id,
-      report_type: report.report_type,
-      goal_id: report.goal_id,
-      title: report.title,
-      content: report.content,
-      generated_at: report.generated_at,
-    });
-  });
+  // Gap 2: Create EventServer for event-driven wake-ups (only if config specifies a port)
+  let eventServer: EventServer | undefined;
+  if (daemonConfig && typeof (daemonConfig as Record<string, unknown>).event_server_port === "number") {
+    eventServer = new EventServer(
+      deps.driveSystem,
+      { port: (daemonConfig as Record<string, unknown>).event_server_port as number },
+      logger
+    );
+  }
 
   // Gap 4: Create CronScheduler for scheduled tasks
   const cronScheduler = new CronScheduler(baseDir);
@@ -193,9 +184,6 @@ export async function cmdStart(
     coreLoop: deps.coreLoop,
     stateManager: deps.stateManager,
     notificationDispatcher,
-    hookManager: deps.hookManager,
-    memoryLifecycle: deps.memoryLifecycleManager,
-    knowledgeManager: deps.knowledgeManager,
   });
   await scheduleEngine.loadEntries();
 
@@ -206,11 +194,10 @@ export async function cmdStart(
     pidManager,
     logger,
     config: daemonConfig,
-    eventServer,
+    ...(eventServer ? { eventServer } : {}),
     llmClient: deps.llmClient,
     cronScheduler,
     scheduleEngine,
-    reportingEngine: deps.reportingEngine,
   });
 
   logger.info(`Starting PulSeed daemon for goals: ${goalIds.join(", ")}`);
@@ -263,8 +250,11 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   }
 
   // Load daemon config for config section display
-  const configPath = path.join(baseDir, "daemon-config.json");
-  const configRaw = await readJsonFileOrNull(configPath);
+  const configPath = path.join(baseDir, "daemon.json");
+  const legacyConfigPath = path.join(baseDir, "daemon-config.json");
+  const configRaw =
+    (await readJsonFileOrNull(configPath)) ??
+    (await readJsonFileOrNull(legacyConfigPath));
   const configParsed = configRaw !== null ? DaemonConfigSchema.safeParse(configRaw) : null;
   const cfg = configParsed?.success ? configParsed.data : DaemonConfigSchema.parse({});
 
@@ -303,6 +293,10 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   lines.push(`  Interval:      ${intervalMin}m (adaptive sleep: ${adaptiveSleep})`);
   lines.push(`  Iterations:    ${cfg.iterations_per_cycle} per cycle`);
   lines.push(`  Proactive:     ${proactive}`);
+  lines.push(`  Runtime journal: ${cfg.runtime_journal_v2 ? "on" : "off"}`);
+  if (cfg.runtime_journal_v2 && cfg.runtime_root) {
+    lines.push(`  Runtime root:  ${cfg.runtime_root}`);
+  }
   lines.push(`  Crash recovery: ${crashEnabled} (${data.crash_count}/${maxRetries} retries used)`);
 
   lines.push("");

--- a/src/runtime/__tests__/approval-store.test.ts
+++ b/src/runtime/__tests__/approval-store.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { ApprovalStore } from "../store/approval-store.js";
+import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
+import { ApprovalRecordSchema } from "../store/runtime-schemas.js";
+
+describe("ApprovalStore", () => {
+  let tmpDir: string;
+  let store: ApprovalStore;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    store = new ApprovalStore(tmpDir);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  function makeApproval(overrides: Record<string, unknown> = {}) {
+    return ApprovalRecordSchema.parse({
+      approval_id: "approval-1",
+      goal_id: "goal-1",
+      request_envelope_id: "msg-1",
+      correlation_id: "corr-1",
+      state: "pending",
+      created_at: 1,
+      expires_at: 2,
+      payload: { prompt: "approve?" },
+      ...overrides,
+    });
+  }
+
+  function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  it("creates directories and stores pending approvals", async () => {
+    await store.ensureReady();
+    const record = makeApproval();
+    const saved = await store.savePending(record);
+    expect(saved.state).toBe("pending");
+    expect(await store.load("approval-1")).not.toBeNull();
+    expect(fs.existsSync(path.join(tmpDir, "approvals", "pending", "approval-1.json"))).toBe(true);
+  });
+
+  it("resolves a pending approval into the resolved directory", async () => {
+    await store.savePending(makeApproval());
+    const resolved = await store.resolvePending("approval-1", {
+      state: "approved",
+      resolved_at: 10,
+      response_channel: "chat-1",
+      payload: { decision: "yes" },
+    });
+
+    expect(resolved?.state).toBe("approved");
+    expect(await store.loadPending("approval-1")).toBeNull();
+    expect(await store.loadResolved("approval-1")).not.toBeNull();
+    expect(await store.load("approval-1")).toMatchObject({ state: "approved" });
+  });
+
+  it("listPending hides approvals that already have a resolved record", async () => {
+    const pending = makeApproval({ approval_id: "approval-1" });
+    await store.savePending(pending);
+    await store.saveResolved({ ...pending, state: "approved", resolved_at: 10 });
+
+    const pendingList = await store.listPending();
+    expect(pendingList).toEqual([]);
+    expect(await store.loadPending("approval-1")).not.toBeNull();
+    expect(await store.loadResolved("approval-1")).not.toBeNull();
+  });
+
+  it("keeps the resolved record authoritative after restart-like re-save", async () => {
+    const pending = makeApproval();
+    await store.savePending(pending);
+    await store.resolvePending("approval-1", { state: "denied" });
+
+    const reloaded = new ApprovalStore(tmpDir);
+    const overwritten = await reloaded.savePending(pending);
+
+    expect(overwritten.state).toBe("denied");
+    expect(await reloaded.loadPending("approval-1")).toBeNull();
+    expect(await reloaded.listResolved()).toHaveLength(1);
+  });
+
+  it("serializes concurrent resolvePending calls and avoids overwrite or throw", async () => {
+    await store.savePending(makeApproval());
+
+    const [first, second] = await Promise.all([
+      store.resolvePending("approval-1", { state: "approved", resolved_at: 11 }),
+      store.resolvePending("approval-1", { state: "denied", resolved_at: 12 }),
+    ]);
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(first?.approval_id).toBe("approval-1");
+    expect(second?.approval_id).toBe("approval-1");
+    expect(await store.loadPending("approval-1")).toBeNull();
+    expect(await store.listResolved()).toHaveLength(1);
+    expect((await store.loadResolved("approval-1"))?.state).toMatch(/approved|denied/);
+  });
+
+  it("keeps resolvePending authoritative when savePending races with it", async () => {
+    const pending = makeApproval();
+    const pendingPath = path.join(tmpDir, "approvals", "pending", "approval-1.json");
+    const resolvedPath = path.join(tmpDir, "approvals", "resolved", "approval-1.json");
+    const originalJournal = (store as any).journal;
+    const originalSave = originalJournal.save.bind(originalJournal);
+
+    await originalSave(pendingPath, ApprovalRecordSchema, pending);
+
+    let releasePendingSave: (() => void) | undefined;
+    let pendingSaveEntered = false;
+    const pendingSaveGate = new Promise<void>((resolve) => {
+      releasePendingSave = resolve;
+    });
+
+    originalJournal.save = async (filePath: string, schema: unknown, value: unknown) => {
+      if (filePath === pendingPath) {
+        pendingSaveEntered = true;
+        await pendingSaveGate;
+      }
+      return originalSave(filePath, schema, value);
+    };
+
+    try {
+      const savePromise = store.savePending(pending);
+
+      for (let i = 0; i < 100; i += 1) {
+        if (pendingSaveEntered) break;
+        await sleep(1);
+      }
+      expect(pendingSaveEntered).toBe(true);
+
+      const resolvePromise = store.resolvePending("approval-1", { state: "approved", resolved_at: 10 });
+
+      await sleep(20);
+      expect(await Promise.race([resolvePromise.then(() => true), sleep(1).then(() => false)])).toBe(false);
+
+      releasePendingSave?.();
+
+      const [, resolved] = await Promise.all([savePromise, resolvePromise]);
+      expect(resolved?.state).toBe("approved");
+      expect(await store.loadPending("approval-1")).toBeNull();
+      expect(await store.loadResolved("approval-1")).toMatchObject({ state: "approved" });
+      expect(fs.existsSync(pendingPath)).toBe(false);
+      expect(fs.existsSync(resolvedPath)).toBe(true);
+    } finally {
+      originalJournal.save = originalSave;
+      releasePendingSave?.();
+    }
+  });
+});

--- a/src/runtime/__tests__/daemon-runner.test.ts
+++ b/src/runtime/__tests__/daemon-runner.test.ts
@@ -807,6 +807,83 @@ describe("DaemonRunner", () => {
       expect(eventServer.start).toHaveBeenCalledOnce();
     });
 
+    it("initializes runtime journal foundation when enabled", async () => {
+      const eventServer = makeEventServerMock();
+      const deps = makeDeps(tmpDir, {
+        config: { check_interval_ms: 50, runtime_journal_v2: true },
+        eventServer: eventServer as unknown as DaemonDeps["eventServer"],
+      });
+      const daemon = new DaemonRunner(deps);
+      currentDaemon = daemon;
+
+      const startPromise = daemon.start(["goal-1"]);
+      currentStartPromise = startPromise;
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      daemon.stop();
+      await startPromise;
+
+      const runtimeDir = path.join(tmpDir, "runtime");
+      expect(fs.existsSync(path.join(runtimeDir, "approvals", "pending"))).toBe(true);
+      expect(fs.existsSync(path.join(runtimeDir, "outbox"))).toBe(true);
+      expect(fs.existsSync(path.join(runtimeDir, "health", "daemon.json"))).toBe(true);
+
+      const daemonHealth = JSON.parse(
+        fs.readFileSync(path.join(runtimeDir, "health", "daemon.json"), "utf-8")
+      );
+      expect(daemonHealth.details.runtime_journal_v2).toBe(true);
+      expect(daemonHealth.details.phase).toBe("foundation_only");
+    });
+
+    it("anchors a relative runtime_root to the daemon base dir instead of process cwd", async () => {
+      const eventServer = makeEventServerMock();
+      const otherCwd = makeTempDir();
+      const originalCwd = process.cwd();
+      process.chdir(otherCwd);
+      try {
+        const deps = makeDeps(tmpDir, {
+          config: {
+            check_interval_ms: 50,
+            runtime_journal_v2: true,
+            runtime_root: "runtime-v2",
+          },
+          eventServer: eventServer as unknown as DaemonDeps["eventServer"],
+        });
+        const daemon = new DaemonRunner(deps);
+        currentDaemon = daemon;
+
+        const startPromise = daemon.start(["goal-1"]);
+        currentStartPromise = startPromise;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        daemon.stop();
+        await startPromise;
+
+        expect(fs.existsSync(path.join(tmpDir, "runtime-v2", "health", "daemon.json"))).toBe(true);
+        expect(fs.existsSync(path.join(otherCwd, "runtime-v2", "health", "daemon.json"))).toBe(false);
+      } finally {
+        process.chdir(originalCwd);
+        fs.rmSync(otherCwd, { recursive: true, force: true });
+      }
+    });
+
+    it("does not leave a stale PID file when runtime journal initialization fails", async () => {
+      const eventServer = makeEventServerMock();
+      const blockedPath = path.join(tmpDir, "not-a-directory");
+      fs.writeFileSync(blockedPath, "block");
+
+      const deps = makeDeps(tmpDir, {
+        config: {
+          check_interval_ms: 50,
+          runtime_journal_v2: true,
+          runtime_root: path.join("not-a-directory", "child"),
+        },
+        eventServer: eventServer as unknown as DaemonDeps["eventServer"],
+      });
+      const daemon = new DaemonRunner(deps);
+
+      await expect(daemon.start(["goal-1"])).rejects.toThrow();
+      expect(fs.existsSync(path.join(tmpDir, "pulseed.pid"))).toBe(false);
+    });
+
     it("should stop EventServer on daemon stop", async () => {
       const eventServer = makeEventServerMock();
       const deps = makeDeps(tmpDir, {

--- a/src/runtime/__tests__/goal-lease-manager.test.ts
+++ b/src/runtime/__tests__/goal-lease-manager.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
+import { GoalLeaseManager } from "../goal-lease-manager.js";
+
+describe("GoalLeaseManager", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) cleanupTempDir(tmpDir);
+  });
+
+  it("acquire writes a goal lease record and read returns it", async () => {
+    tmpDir = makeTempDir();
+    const manager = new GoalLeaseManager(tmpDir, 1_000);
+
+    const record = await manager.acquire("goal-1", {
+      workerId: "worker-a",
+      ownerToken: "owner-a",
+      attemptId: "attempt-a",
+      now: 1000,
+    });
+
+    expect(record).not.toBeNull();
+    expect(record!.goal_id).toBe("goal-1");
+    expect(record!.lease_until).toBe(2000);
+    expect(await manager.read("goal-1")).toEqual(record);
+  });
+
+  it("blocks a second active acquire for the same goal", async () => {
+    tmpDir = makeTempDir();
+    const manager = new GoalLeaseManager(tmpDir, 1_000);
+
+    const first = await manager.acquire("goal-1", {
+      workerId: "worker-a",
+      ownerToken: "owner-a",
+      attemptId: "attempt-a",
+      now: 1000,
+    });
+
+    const second = await manager.acquire("goal-1", {
+      workerId: "worker-b",
+      ownerToken: "owner-b",
+      attemptId: "attempt-b",
+      now: 1500,
+    });
+
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+  });
+
+  it("renew extends the lease only for the matching owner", async () => {
+    tmpDir = makeTempDir();
+    const manager = new GoalLeaseManager(tmpDir, 1_000);
+
+    const acquired = await manager.acquire("goal-1", {
+      workerId: "worker-a",
+      ownerToken: "owner-a",
+      attemptId: "attempt-a",
+      now: 1000,
+    });
+
+    const renewed = await manager.renew("goal-1", "owner-a", { now: 1500, leaseMs: 2_000 });
+    expect(renewed).not.toBeNull();
+    expect(renewed!.lease_until).toBe(3500);
+    expect(renewed!.attempt_id).toBe(acquired!.attempt_id);
+    expect(await manager.renew("goal-1", "wrong-owner", { now: 1600 })).toBeNull();
+  });
+
+  it("release removes the lease only for the matching owner", async () => {
+    tmpDir = makeTempDir();
+    const manager = new GoalLeaseManager(tmpDir, 1_000);
+
+    const acquired = await manager.acquire("goal-1", {
+      workerId: "worker-a",
+      ownerToken: "owner-a",
+      attemptId: "attempt-a",
+      now: 1000,
+    });
+
+    expect(await manager.release("goal-1", "wrong-owner")).toBe(false);
+    expect(await manager.read("goal-1")).not.toBeNull();
+
+    expect(await manager.release("goal-1", acquired!.owner_token)).toBe(true);
+    expect(await manager.read("goal-1")).toBeNull();
+  });
+
+  it("acquire reclaims an expired lease", async () => {
+    tmpDir = makeTempDir();
+    const manager = new GoalLeaseManager(tmpDir, 1_000);
+
+    await manager.acquire("goal-1", {
+      workerId: "worker-a",
+      ownerToken: "owner-a",
+      attemptId: "attempt-a",
+      now: 1000,
+    });
+
+    const reclaimed = await manager.acquire("goal-1", {
+      workerId: "worker-b",
+      ownerToken: "owner-b",
+      attemptId: "attempt-b",
+      now: 2500,
+    });
+
+    expect(reclaimed).not.toBeNull();
+    expect(reclaimed!.owner_token).toBe("owner-b");
+  });
+
+  it("reapStale removes only expired goal leases", async () => {
+    tmpDir = makeTempDir();
+    const manager = new GoalLeaseManager(tmpDir, 1_000);
+
+    await manager.acquire("goal-live", {
+      workerId: "worker-a",
+      ownerToken: "owner-a",
+      attemptId: "attempt-a",
+      leaseMs: 5_000,
+      now: 1000,
+    });
+    await manager.acquire("goal-dead", {
+      workerId: "worker-b",
+      ownerToken: "owner-b",
+      attemptId: "attempt-b",
+      now: 1000,
+    });
+
+    const removed = await manager.reapStale(2500);
+    expect(removed.map((record) => record.goal_id)).toEqual(["goal-dead"]);
+    expect(await manager.read("goal-live")).not.toBeNull();
+    expect(await manager.read("goal-dead")).toBeNull();
+  });
+
+  it("does not leave tmp files after writes", async () => {
+    tmpDir = makeTempDir();
+    const manager = new GoalLeaseManager(tmpDir, 1_000);
+
+    await manager.acquire("goal-1", {
+      workerId: "worker-a",
+      ownerToken: "owner-a",
+      attemptId: "attempt-a",
+      now: 1000,
+    });
+    await manager.renew("goal-1", "owner-a", { now: 1100 });
+
+    const goalDir = path.join(tmpDir, "leases", "goal");
+    const files = fs.readdirSync(goalDir);
+    expect(files.some((file) => file.includes(".tmp"))).toBe(false);
+  });
+
+  it("resolves a relative runtime root to an absolute path", async () => {
+    tmpDir = makeTempDir();
+    const relativeRoot = path.relative(process.cwd(), tmpDir);
+    const manager = new GoalLeaseManager(relativeRoot, 1_000);
+
+    await manager.acquire("goal-1", {
+      workerId: "worker-a",
+      ownerToken: "owner-a",
+      attemptId: "attempt-a",
+      now: 1000,
+    });
+
+    expect(fs.existsSync(path.join(tmpDir, "leases", "goal", "goal-1.json"))).toBe(true);
+  });
+});

--- a/src/runtime/__tests__/health-store.test.ts
+++ b/src/runtime/__tests__/health-store.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { RuntimeHealthStore } from "../store/health-store.js";
+import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
+import { RuntimeHealthSnapshotSchema } from "../store/runtime-schemas.js";
+
+describe("RuntimeHealthStore", () => {
+  let tmpDir: string;
+  let store: RuntimeHealthStore;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    store = new RuntimeHealthStore(tmpDir);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  it("saves and loads a combined health snapshot", async () => {
+    const snapshot = RuntimeHealthSnapshotSchema.parse({
+      status: "degraded",
+      leader: true,
+      checked_at: 123,
+      components: {
+        gateway: "ok",
+        queue: "degraded",
+      },
+      details: { lag: 3 },
+    });
+
+    await store.saveSnapshot(snapshot);
+    const daemonPath = path.join(tmpDir, "health", "daemon.json");
+    const componentsPath = path.join(tmpDir, "health", "components.json");
+
+    expect(fs.existsSync(daemonPath)).toBe(true);
+    expect(fs.existsSync(componentsPath)).toBe(true);
+
+    const loaded = await store.loadSnapshot();
+    expect(loaded).toMatchObject(snapshot);
+  });
+
+  it("returns null for a partial health state", async () => {
+    await store.saveDaemonHealth({
+      status: "ok",
+      leader: false,
+      checked_at: 1,
+    });
+    expect(await store.loadSnapshot()).toBeNull();
+  });
+
+  it("loads the individual health records", async () => {
+    await store.saveDaemonHealth({
+      status: "ok",
+      leader: true,
+      checked_at: 1,
+    });
+    await store.saveComponentsHealth({
+      checked_at: 2,
+      components: { gateway: "ok", queue: "ok" },
+    });
+
+    expect(await store.loadDaemonHealth()).toMatchObject({ leader: true });
+    expect(await store.loadComponentsHealth()).toMatchObject({ components: { gateway: "ok" } });
+  });
+});

--- a/src/runtime/__tests__/leader-lock-manager.test.ts
+++ b/src/runtime/__tests__/leader-lock-manager.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
+import { LeaderLockManager } from "../leader-lock-manager.js";
+
+describe("LeaderLockManager", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) cleanupTempDir(tmpDir);
+  });
+
+  it("acquire writes a durable record and read returns it", async () => {
+    tmpDir = makeTempDir();
+    const manager = new LeaderLockManager(tmpDir, 1_000);
+
+    const record = await manager.acquire({ now: 1000, ownerToken: "leader-a" });
+
+    expect(record).not.toBeNull();
+    expect(record!.owner_token).toBe("leader-a");
+    expect(record!.lease_until).toBe(2000);
+
+    const loaded = await manager.read();
+    expect(loaded).toEqual(record);
+    expect(fs.existsSync(path.join(tmpDir, "leader", "leader.json"))).toBe(true);
+  });
+
+  it("renew extends the lease only for the current owner", async () => {
+    tmpDir = makeTempDir();
+    const manager = new LeaderLockManager(tmpDir, 1_000);
+
+    const acquired = await manager.acquire({ now: 1000, ownerToken: "leader-a" });
+    const renewed = await manager.renew("leader-a", { now: 1500, leaseMs: 2_000 });
+
+    expect(renewed).not.toBeNull();
+    expect(renewed!.owner_token).toBe(acquired!.owner_token);
+    expect(renewed!.lease_until).toBe(3500);
+    expect(await manager.renew("wrong-owner", { now: 1600 })).toBeNull();
+  });
+
+  it("release removes the record only for the matching owner", async () => {
+    tmpDir = makeTempDir();
+    const manager = new LeaderLockManager(tmpDir, 1_000);
+
+    const acquired = await manager.acquire({ now: 1000, ownerToken: "leader-a" });
+    expect(await manager.release("wrong-owner")).toBe(false);
+    expect(await manager.read()).not.toBeNull();
+
+    expect(await manager.release(acquired!.owner_token)).toBe(true);
+    expect(await manager.read()).toBeNull();
+  });
+
+  it("acquire reclaims a stale leader lock", async () => {
+    tmpDir = makeTempDir();
+    const manager = new LeaderLockManager(tmpDir, 1_000);
+
+    const stalePath = path.join(tmpDir, "leader", "leader.json");
+    await fsp.mkdir(path.dirname(stalePath), { recursive: true });
+    await fsp.writeFile(
+      stalePath,
+      JSON.stringify({
+        owner_token: "stale-owner",
+        pid: process.pid,
+        acquired_at: 100,
+        last_renewed_at: 100,
+        lease_until: 150,
+      }),
+      "utf-8"
+    );
+
+    const acquired = await manager.acquire({ now: 200, ownerToken: "leader-b" });
+    expect(acquired).not.toBeNull();
+    expect(acquired!.owner_token).toBe("leader-b");
+    expect(await manager.read()).toEqual(acquired);
+  });
+
+  it("reapStale removes expired lock files", async () => {
+    tmpDir = makeTempDir();
+    const manager = new LeaderLockManager(tmpDir, 1_000);
+
+    await manager.acquire({ now: 1000, ownerToken: "leader-a" });
+    expect(await manager.reapStale(1500)).toBeNull();
+    expect(await manager.reapStale(2500)).not.toBeNull();
+    expect(await manager.read()).toBeNull();
+  });
+
+  it("does not leave tmp files after writes", async () => {
+    tmpDir = makeTempDir();
+    const manager = new LeaderLockManager(tmpDir, 1_000);
+
+    await manager.acquire({ now: 1000, ownerToken: "leader-a" });
+    await manager.renew("leader-a", { now: 1100 });
+
+    const files = fs.readdirSync(path.join(tmpDir, "leader"));
+    expect(files.some((file) => file.includes(".tmp"))).toBe(false);
+  });
+
+  it("resolves a relative runtime root to an absolute path", async () => {
+    tmpDir = makeTempDir();
+    const relativeRoot = path.relative(process.cwd(), tmpDir);
+    const manager = new LeaderLockManager(relativeRoot, 1_000);
+
+    await manager.acquire({ now: 1000, ownerToken: "leader-a" });
+
+    expect(fs.existsSync(path.join(tmpDir, "leader", "leader.json"))).toBe(true);
+  });
+});

--- a/src/runtime/__tests__/outbox-store.test.ts
+++ b/src/runtime/__tests__/outbox-store.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { OutboxStore } from "../store/outbox-store.js";
+import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
+import { OutboxRecordSchema } from "../store/runtime-schemas.js";
+
+describe("OutboxStore", () => {
+  let tmpDir: string;
+  let store: OutboxStore;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    store = new OutboxStore(tmpDir);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  function makeRecord(seq: number, eventType = "event") {
+    return OutboxRecordSchema.parse({
+      seq,
+      event_type: eventType,
+      goal_id: "goal-1",
+      correlation_id: "corr-1",
+      created_at: seq,
+      payload: { seq },
+    });
+  }
+
+  it("appends outbox entries with padded sequence numbers", async () => {
+    await store.ensureReady();
+    const first = await store.append({
+      event_type: "goal_activated",
+      goal_id: "goal-1",
+      correlation_id: "corr-1",
+      created_at: 1,
+      payload: { kind: "first" },
+    });
+
+    expect(first.seq).toBe(1);
+    expect(fs.existsSync(path.join(tmpDir, "outbox", "000000000001.json"))).toBe(true);
+    expect(await store.load(1)).toMatchObject({ event_type: "goal_activated" });
+  });
+
+  it("loads and filters records in sequence order", async () => {
+    await store.save(makeRecord(2, "second"));
+    await store.save(makeRecord(1, "first"));
+
+    const all = await store.list();
+    expect(all.map((record) => record.seq)).toEqual([1, 2]);
+    expect((await store.loadLatest())?.seq).toBe(2);
+    expect((await store.list(1)).map((record) => record.seq)).toEqual([2]);
+  });
+
+  it("returns the next sequence after the highest existing entry", async () => {
+    await store.save(makeRecord(4, "fourth"));
+    expect(await store.nextSeq()).toBe(5);
+  });
+
+  it("two store instances append distinct seq values without overwriting", async () => {
+    const storeA = new OutboxStore(tmpDir);
+    const storeB = new OutboxStore(tmpDir);
+    await Promise.all([
+      storeA.append({
+        event_type: "alpha",
+        goal_id: "goal-1",
+        correlation_id: "corr-a",
+        created_at: 1,
+        payload: { source: "a" },
+      }),
+      storeB.append({
+        event_type: "beta",
+        goal_id: "goal-1",
+        correlation_id: "corr-b",
+        created_at: 2,
+        payload: { source: "b" },
+      }),
+    ]);
+
+    const listed = await store.list();
+    expect(listed).toHaveLength(2);
+    expect(listed.map((record) => record.seq)).toEqual([1, 2]);
+    expect(new Set(listed.map((record) => record.event_type))).toEqual(new Set(["alpha", "beta"]));
+  });
+});

--- a/src/runtime/__tests__/runtime-store-basics.test.ts
+++ b/src/runtime/__tests__/runtime-store-basics.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
+import {
+  createRuntimeStorePaths,
+  ensureRuntimeStorePaths,
+  encodeRuntimePathSegment,
+  runtimeDateKey,
+} from "../store/runtime-paths.js";
+import {
+  RuntimeJournal,
+  listRuntimeJson,
+  loadRuntimeJson,
+  moveRuntimeJson,
+  saveRuntimeJson,
+} from "../store/runtime-journal.js";
+import {
+  RuntimeEnvelopeSchema,
+  RuntimeQueueRecordSchema,
+  summarizeRuntimeHealthStatus,
+} from "../store/runtime-schemas.js";
+
+describe("runtime store basics", () => {
+  let tmpDir: string;
+  let paths = createRuntimeStorePaths();
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    paths = createRuntimeStorePaths(tmpDir);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  it("resolves the runtime root and derived paths", () => {
+    expect(paths.rootDir).toBe(path.resolve(tmpDir));
+    expect(paths.approvalPendingPath("approval-1")).toBe(
+      path.join(tmpDir, "approvals", "pending", "approval-1.json")
+    );
+    expect(paths.outboxRecordPath(12)).toBe(path.join(tmpDir, "outbox", "000000000012.json"));
+    const goalId = "goal%/a";
+    expect(paths.goalLeasePath(goalId)).toBe(
+      path.join(tmpDir, "leases", "goal", `${encodeRuntimePathSegment(goalId)}.json`)
+    );
+    expect(paths.completedByIdempotencyPath("danger/with/slash")).toMatch(
+      /completed\/by-idempotency\/[a-f0-9]{64}\.json$/
+    );
+  });
+
+  it("creates the runtime directory layout", async () => {
+    await ensureRuntimeStorePaths(paths);
+    expect(fs.existsSync(paths.leaderDir)).toBe(true);
+    expect(fs.existsSync(paths.approvalsPendingDir)).toBe(true);
+    expect(fs.existsSync(paths.outboxDir)).toBe(true);
+    expect(fs.existsSync(paths.healthDir)).toBe(true);
+  });
+
+  it("formats date buckets deterministically", () => {
+    expect(runtimeDateKey(new Date("2026-04-09T12:34:56.000Z"))).toBe("2026-04-09");
+  });
+
+  it("writes, reads, lists, moves, and removes runtime JSON records", async () => {
+    const journal = new RuntimeJournal(paths);
+    await journal.ensureReady();
+
+    const recordPath = paths.approvalPendingPath("a-1");
+    const record = {
+      approval_id: "a-1",
+      request_envelope_id: "msg-1",
+      correlation_id: "corr-1",
+      state: "pending" as const,
+      created_at: 1,
+      expires_at: 2,
+      payload: { note: "hello" },
+    };
+
+    await saveRuntimeJson(recordPath, RuntimeQueueRecordSchema, {
+      message_id: "msg-1",
+      state: "queued",
+      available_at: 1,
+      attempt: 0,
+      updated_at: 1,
+    });
+    const queueRecord = await loadRuntimeJson(recordPath, RuntimeQueueRecordSchema);
+    expect(queueRecord?.message_id).toBe("msg-1");
+
+    const listDir = path.join(tmpDir, "custom");
+    await fs.promises.mkdir(listDir, { recursive: true });
+    await saveRuntimeJson(path.join(listDir, "b.json"), RuntimeEnvelopeSchema, {
+      message_id: "m2",
+      kind: "event",
+      name: "beta",
+      source: "test",
+      priority: "normal",
+      payload: {},
+      created_at: 2,
+      attempt: 0,
+    });
+    await saveRuntimeJson(path.join(listDir, "a.json"), RuntimeEnvelopeSchema, {
+      message_id: "m1",
+      kind: "event",
+      name: "alpha",
+      source: "test",
+      priority: "normal",
+      payload: {},
+      created_at: 1,
+      attempt: 0,
+    });
+
+    const listed = await listRuntimeJson(listDir, RuntimeEnvelopeSchema);
+    expect(listed.map((r) => r.message_id)).toEqual(["m1", "m2"]);
+
+    const moveSource = path.join(listDir, "move.json");
+    const moveTarget = path.join(listDir, "nested", "moved.json");
+    await saveRuntimeJson(moveSource, RuntimeEnvelopeSchema, {
+      message_id: "m3",
+      kind: "system",
+      name: "move",
+      source: "test",
+      priority: "low",
+      payload: {},
+      created_at: 3,
+      attempt: 0,
+    });
+    await moveRuntimeJson(moveSource, moveTarget);
+    expect(fs.existsSync(moveSource)).toBe(false);
+    expect(fs.existsSync(moveTarget)).toBe(true);
+
+    await journal.remove(moveTarget);
+    expect(fs.existsSync(moveTarget)).toBe(false);
+
+    expect(record.approval_id).toBe("a-1");
+  });
+
+  it("summarizes component health correctly", () => {
+    expect(summarizeRuntimeHealthStatus({ gateway: "ok", queue: "ok" })).toBe("ok");
+    expect(summarizeRuntimeHealthStatus({ gateway: "ok", queue: "degraded" })).toBe("degraded");
+    expect(summarizeRuntimeHealthStatus({ gateway: "ok", queue: "failed" })).toBe("failed");
+  });
+});

--- a/src/runtime/daemon-runner.ts
+++ b/src/runtime/daemon-runner.ts
@@ -25,6 +25,10 @@ import { EventBus } from "./queue/event-bus.js";
 import { CommandBus } from "./queue/command-bus.js";
 import { LoopSupervisor } from "./executor/index.js";
 import { PulSeedEventSchema } from "../base/types/drive.js";
+import { ApprovalStore, OutboxStore, RuntimeHealthStore, createRuntimeStorePaths } from "./store/index.js";
+import { LeaderLockManager } from "./leader-lock-manager.js";
+import { GoalLeaseManager } from "./goal-lease-manager.js";
+import { JournalBackedQueue } from "./queue/journal-backed-queue.js";
 
 // Re-exports for callers that imported these from daemon-runner
 export { generateCronEntry } from "./daemon-signals.js";
@@ -76,9 +80,6 @@ export interface DaemonDeps {
   supervisor?: LoopSupervisor;
   /** Factory to create fresh CoreLoop instances for LoopSupervisor workers. */
   coreLoopFactory?: () => CoreLoop;
-  reportingEngine?: {
-    generateNotification(type: string, context: { goalId: string; message: string; details?: string }): Promise<unknown>;
-  };
 }
 
 export class DaemonRunner {
@@ -112,7 +113,13 @@ export class DaemonRunner {
   private cronScheduleInterval: ReturnType<typeof setInterval> | null = null;
   private shutdownResolve: (() => void) | null = null;
   private readonly deps: DaemonDeps;
-  private reportingEngine: DaemonDeps["reportingEngine"];
+  private runtimeRoot: string | null = null;
+  private approvalStore: ApprovalStore | null = null;
+  private outboxStore: OutboxStore | null = null;
+  private runtimeHealthStore: RuntimeHealthStore | null = null;
+  private leaderLockManager: LeaderLockManager | null = null;
+  private goalLeaseManager: GoalLeaseManager | null = null;
+  private journalQueue: JournalBackedQueue | null = null;
 
   constructor(deps: DaemonDeps) {
     this.deps = deps;
@@ -130,7 +137,6 @@ export class DaemonRunner {
     this.commandBus = deps.commandBus;
     this.supervisor = deps.supervisor ?? null;
     this.lastProactiveTickAt = Date.now();
-    this.reportingEngine = deps.reportingEngine;
 
     // Parse config with defaults via DaemonConfigSchema.parse()
     this.config = DaemonConfigSchema.parse(deps.config ?? {});
@@ -141,6 +147,19 @@ export class DaemonRunner {
     // Pre-compute log paths used by rotateLog
     this.logDir = path.join(this.baseDir, this.config.log_dir);
     this.logPath = path.join(this.logDir, "pulseed.log");
+
+    if (this.config.runtime_journal_v2) {
+      this.runtimeRoot = this.resolveRuntimeRoot();
+      const runtimePaths = createRuntimeStorePaths(this.runtimeRoot);
+      this.approvalStore = new ApprovalStore(runtimePaths);
+      this.outboxStore = new OutboxStore(runtimePaths);
+      this.runtimeHealthStore = new RuntimeHealthStore(runtimePaths);
+      this.leaderLockManager = new LeaderLockManager(this.runtimeRoot);
+      this.goalLeaseManager = new GoalLeaseManager(this.runtimeRoot);
+      this.journalQueue = new JournalBackedQueue({
+        journalPath: path.join(this.runtimeRoot, "queue.json"),
+      });
+    }
 
     // Initialize daemon state
     this.state = DaemonStateSchema.parse({
@@ -153,6 +172,16 @@ export class DaemonRunner {
       crash_count: 0,
       last_error: null,
     });
+  }
+
+  private resolveRuntimeRoot(): string {
+    const configuredRoot = this.config.runtime_root;
+    if (!configuredRoot || configuredRoot.trim() === "") {
+      return path.join(this.baseDir, "runtime");
+    }
+    return path.isAbsolute(configuredRoot)
+      ? configuredRoot
+      : path.resolve(this.baseDir, configuredRoot);
   }
 
   // ─── Public API ───
@@ -171,12 +200,13 @@ export class DaemonRunner {
       );
     }
 
-    // 2. Write PID file
-    await this.pidManager.writePID();
-
-    // 2b. Rotate log if needed, then check for crash recovery marker
+    // 2. Rotate log if needed, then check for crash recovery marker
     await this.rotateLog();
     await this.checkCrashRecovery();
+    await this.initializeRuntimeFoundation();
+
+    // 2b. Publish PID only after startup prerequisites succeed.
+    await this.pidManager.writePID();
 
     // 2c. Start EventServer (always-on) and file watcher
     if (!this.eventServer) {
@@ -229,20 +259,12 @@ export class DaemonRunner {
     if (!this.approvalFn && this.eventServer) {
       const es = this.eventServer;
       this.approvalFn = async (task: Record<string, unknown>): Promise<boolean> => {
-        const goalId = String(task["goal_id"] ?? "unknown");
-        const description = String(task["description"] ?? "");
-        const action = String(task["action"] ?? "");
-        void this.reportingEngine?.generateNotification("approval_required", {
-          goalId,
-          message: description || "A task requires approval",
-          details: action ? `Requested action: ${action}` : undefined,
-        });
         return es.requestApproval(
-          goalId,
+          String(task["goal_id"] ?? "unknown"),
           {
             id: String(task["id"] ?? ""),
-            description,
-            action,
+            description: String(task["description"] ?? ""),
+            action: String(task["action"] ?? ""),
           }
         );
       };
@@ -395,6 +417,40 @@ export class DaemonRunner {
         this.logger.info("EventServer stopped");
       }
     }
+  }
+
+  private async initializeRuntimeFoundation(): Promise<void> {
+    if (!this.config.runtime_journal_v2) return;
+
+    await Promise.all([
+      this.approvalStore?.ensureReady(),
+      this.outboxStore?.ensureReady(),
+      this.runtimeHealthStore?.ensureReady(),
+    ]);
+
+    await this.runtimeHealthStore?.saveSnapshot({
+      status: "degraded",
+      leader: false,
+      checked_at: Date.now(),
+      components: {
+        gateway: "degraded",
+        queue: "degraded",
+        leases: "ok",
+        approval: "ok",
+        outbox: "ok",
+        supervisor: "degraded",
+      },
+      details: {
+        runtime_journal_v2: true,
+        runtime_root: this.runtimeRoot,
+        phase: "foundation_only",
+      },
+    });
+
+    this.logger.info("Runtime journal foundation initialized", {
+      runtime_root: this.runtimeRoot,
+      queue_path: this.runtimeRoot ? path.join(this.runtimeRoot, "queue.json") : undefined,
+    });
   }
 
   /** Expose approvalFn for callers (e.g. cmdStart) to wire into TaskLifecycle */

--- a/src/runtime/goal-lease-manager.ts
+++ b/src/runtime/goal-lease-manager.ts
@@ -1,0 +1,246 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { writeJsonFileAtomic, readJsonFileOrNull } from "../base/utils/json-io.js";
+
+export interface GoalLeaseRecord {
+  goal_id: string;
+  owner_token: string;
+  attempt_id: string;
+  worker_id: string;
+  lease_until: number;
+  acquired_at: number;
+  last_renewed_at: number;
+}
+
+export interface GoalLeaseAcquireOptions {
+  workerId: string;
+  ownerToken?: string;
+  attemptId?: string;
+  leaseMs?: number;
+  now?: number;
+}
+
+export interface GoalLeaseRenewOptions {
+  leaseMs?: number;
+  now?: number;
+}
+
+const DEFAULT_LEASE_MS = 30_000;
+const MUTEX_RETRY_DELAY_MS = 10;
+const MUTEX_MAX_ATTEMPTS = 50;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function isProcessAlive(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureDir(dirPath: string): Promise<void> {
+  await fsp.mkdir(dirPath, { recursive: true });
+}
+
+async function writeMutexPid(mutexDir: string): Promise<void> {
+  await fsp.writeFile(path.join(mutexDir, "pid"), String(process.pid), "utf-8");
+}
+
+async function clearStaleMutex(mutexDir: string): Promise<boolean> {
+  try {
+    const pidText = await fsp.readFile(path.join(mutexDir, "pid"), "utf-8");
+    const pid = Number.parseInt(pidText.trim(), 10);
+    if (!Number.isFinite(pid) || !(await isProcessAlive(pid))) {
+      await fsp.rm(mutexDir, { recursive: true, force: true });
+      return true;
+    }
+  } catch {
+    await fsp.rm(mutexDir, { recursive: true, force: true });
+    return true;
+  }
+
+  return false;
+}
+
+async function acquireMutex(mutexDir: string): Promise<void> {
+  await ensureDir(path.dirname(mutexDir));
+
+  for (let attempt = 0; attempt < MUTEX_MAX_ATTEMPTS; attempt++) {
+    try {
+      await fsp.mkdir(mutexDir);
+      await writeMutexPid(mutexDir);
+      return;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw err;
+      }
+
+      if (!(await clearStaleMutex(mutexDir))) {
+        await sleep(MUTEX_RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  throw new Error(`Timed out waiting for mutex: ${mutexDir}`);
+}
+
+async function releaseMutex(mutexDir: string): Promise<void> {
+  await fsp.rm(mutexDir, { recursive: true, force: true });
+}
+
+async function withMutex<T>(mutexDir: string, fn: () => Promise<T>): Promise<T> {
+  await acquireMutex(mutexDir);
+  try {
+    return await fn();
+  } finally {
+    await releaseMutex(mutexDir);
+  }
+}
+
+function safeGoalId(goalId: string): string {
+  return encodeURIComponent(goalId);
+}
+
+function isGoalLeaseRecord(value: unknown): value is GoalLeaseRecord {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Partial<GoalLeaseRecord>;
+  return (
+    typeof record.goal_id === "string" &&
+    typeof record.owner_token === "string" &&
+    typeof record.attempt_id === "string" &&
+    typeof record.worker_id === "string" &&
+    typeof record.lease_until === "number" &&
+    typeof record.acquired_at === "number" &&
+    typeof record.last_renewed_at === "number"
+  );
+}
+
+export class GoalLeaseManager {
+  private readonly leasesDir: string;
+  private readonly defaultLeaseMs: number;
+
+  constructor(runtimeRoot: string, defaultLeaseMs = DEFAULT_LEASE_MS) {
+    runtimeRoot = path.resolve(runtimeRoot);
+    this.leasesDir = path.join(runtimeRoot, "leases", "goal");
+    this.defaultLeaseMs = defaultLeaseMs;
+  }
+
+  private recordPath(goalId: string): string {
+    return path.join(this.leasesDir, `${safeGoalId(goalId)}.json`);
+  }
+
+  private mutexPath(goalId: string): string {
+    return `${this.recordPath(goalId)}.lock`;
+  }
+
+  private buildRecord(goalId: string, opts: GoalLeaseAcquireOptions, now: number): GoalLeaseRecord {
+    const leaseMs = opts.leaseMs ?? this.defaultLeaseMs;
+    return {
+      goal_id: goalId,
+      owner_token: opts.ownerToken ?? randomUUID(),
+      attempt_id: opts.attemptId ?? randomUUID(),
+      worker_id: opts.workerId,
+      lease_until: now + leaseMs,
+      acquired_at: now,
+      last_renewed_at: now,
+    };
+  }
+
+  private async readRaw(goalId: string): Promise<GoalLeaseRecord | null> {
+    const raw = await readJsonFileOrNull<unknown>(this.recordPath(goalId));
+    return isGoalLeaseRecord(raw) ? raw : null;
+  }
+
+  async acquire(goalId: string, opts: GoalLeaseAcquireOptions): Promise<GoalLeaseRecord | null> {
+    const now = opts.now ?? Date.now();
+
+    return withMutex(this.mutexPath(goalId), async () => {
+      const current = await this.readRaw(goalId);
+      if (current && current.lease_until > now) {
+        return null;
+      }
+
+      const record = this.buildRecord(goalId, opts, now);
+      await writeJsonFileAtomic(this.recordPath(goalId), record);
+      return record;
+    });
+  }
+
+  async renew(
+    goalId: string,
+    ownerToken: string,
+    opts: GoalLeaseRenewOptions = {}
+  ): Promise<GoalLeaseRecord | null> {
+    const now = opts.now ?? Date.now();
+    const leaseMs = opts.leaseMs ?? this.defaultLeaseMs;
+
+    return withMutex(this.mutexPath(goalId), async () => {
+      const current = await this.readRaw(goalId);
+      if (!current || current.owner_token !== ownerToken || current.lease_until <= now) {
+        return null;
+      }
+
+      const renewed: GoalLeaseRecord = {
+        ...current,
+        lease_until: now + leaseMs,
+        last_renewed_at: now,
+      };
+      await writeJsonFileAtomic(this.recordPath(goalId), renewed);
+      return renewed;
+    });
+  }
+
+  async release(goalId: string, ownerToken: string): Promise<boolean> {
+    return withMutex(this.mutexPath(goalId), async () => {
+      const current = await this.readRaw(goalId);
+      if (!current || current.owner_token !== ownerToken) {
+        return false;
+      }
+
+      await fsp.rm(this.recordPath(goalId), { force: true });
+      return true;
+    });
+  }
+
+  async read(goalId: string): Promise<GoalLeaseRecord | null> {
+    return this.readRaw(goalId);
+  }
+
+  async reapStale(now = Date.now()): Promise<GoalLeaseRecord[]> {
+    await ensureDir(this.leasesDir);
+    let entries: string[] = [];
+    try {
+      entries = await fsp.readdir(this.leasesDir);
+    } catch {
+      return [];
+    }
+
+    const removed: GoalLeaseRecord[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith(".json")) continue;
+
+      let goalId: string;
+      try {
+        goalId = decodeURIComponent(entry.slice(0, -5));
+      } catch {
+        continue;
+      }
+      await withMutex(this.mutexPath(goalId), async () => {
+        const current = await this.readRaw(goalId);
+        if (!current || current.lease_until > now) {
+          return;
+        }
+
+        removed.push(current);
+        await fsp.rm(this.recordPath(goalId), { force: true });
+      });
+    }
+
+    return removed;
+  }
+}

--- a/src/runtime/leader-lock-manager.ts
+++ b/src/runtime/leader-lock-manager.ts
@@ -1,0 +1,204 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { writeJsonFileAtomic, readJsonFileOrNull } from "../base/utils/json-io.js";
+
+export interface LeaderLockRecord {
+  owner_token: string;
+  pid: number;
+  acquired_at: number;
+  last_renewed_at: number;
+  lease_until: number;
+}
+
+export interface LeaderLockAcquireOptions {
+  ownerToken?: string;
+  leaseMs?: number;
+  now?: number;
+}
+
+export interface LeaderLockRenewOptions {
+  leaseMs?: number;
+  now?: number;
+}
+
+const DEFAULT_LEASE_MS = 30_000;
+const MUTEX_RETRY_DELAY_MS = 10;
+const MUTEX_MAX_ATTEMPTS = 50;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function isProcessAlive(pid: number): Promise<boolean> {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureDir(dirPath: string): Promise<void> {
+  await fsp.mkdir(dirPath, { recursive: true });
+}
+
+async function writeMutexPid(mutexDir: string): Promise<void> {
+  await fsp.writeFile(path.join(mutexDir, "pid"), String(process.pid), "utf-8");
+}
+
+async function clearStaleMutex(mutexDir: string): Promise<boolean> {
+  try {
+    const pidText = await fsp.readFile(path.join(mutexDir, "pid"), "utf-8");
+    const pid = Number.parseInt(pidText.trim(), 10);
+    if (!Number.isFinite(pid) || !(await isProcessAlive(pid))) {
+      await fsp.rm(mutexDir, { recursive: true, force: true });
+      return true;
+    }
+  } catch {
+    await fsp.rm(mutexDir, { recursive: true, force: true });
+    return true;
+  }
+
+  return false;
+}
+
+async function acquireMutex(mutexDir: string): Promise<void> {
+  await ensureDir(path.dirname(mutexDir));
+
+  for (let attempt = 0; attempt < MUTEX_MAX_ATTEMPTS; attempt++) {
+    try {
+      await fsp.mkdir(mutexDir);
+      await writeMutexPid(mutexDir);
+      return;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw err;
+      }
+
+      if (!(await clearStaleMutex(mutexDir))) {
+        await sleep(MUTEX_RETRY_DELAY_MS);
+      }
+    }
+  }
+
+  throw new Error(`Timed out waiting for mutex: ${mutexDir}`);
+}
+
+async function releaseMutex(mutexDir: string): Promise<void> {
+  await fsp.rm(mutexDir, { recursive: true, force: true });
+}
+
+async function withMutex<T>(mutexDir: string, fn: () => Promise<T>): Promise<T> {
+  await acquireMutex(mutexDir);
+  try {
+    return await fn();
+  } finally {
+    await releaseMutex(mutexDir);
+  }
+}
+
+function isLeaderLockRecord(value: unknown): value is LeaderLockRecord {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Partial<LeaderLockRecord>;
+  return (
+    typeof record.owner_token === "string" &&
+    typeof record.pid === "number" &&
+    typeof record.acquired_at === "number" &&
+    typeof record.last_renewed_at === "number" &&
+    typeof record.lease_until === "number"
+  );
+}
+
+export class LeaderLockManager {
+  private readonly recordPath: string;
+  private readonly mutexPath: string;
+  private readonly defaultLeaseMs: number;
+
+  constructor(runtimeRoot: string, defaultLeaseMs = DEFAULT_LEASE_MS) {
+    runtimeRoot = path.resolve(runtimeRoot);
+    this.recordPath = path.join(runtimeRoot, "leader", "leader.json");
+    this.mutexPath = `${this.recordPath}.lock`;
+    this.defaultLeaseMs = defaultLeaseMs;
+  }
+
+  private buildRecord(ownerToken: string, leaseMs: number, now: number): LeaderLockRecord {
+    return {
+      owner_token: ownerToken,
+      pid: process.pid,
+      acquired_at: now,
+      last_renewed_at: now,
+      lease_until: now + leaseMs,
+    };
+  }
+
+  private async readRaw(): Promise<LeaderLockRecord | null> {
+    const raw = await readJsonFileOrNull<unknown>(this.recordPath);
+    return isLeaderLockRecord(raw) ? raw : null;
+  }
+
+  async acquire(opts: LeaderLockAcquireOptions = {}): Promise<LeaderLockRecord | null> {
+    const now = opts.now ?? Date.now();
+    const leaseMs = opts.leaseMs ?? this.defaultLeaseMs;
+    const ownerToken = opts.ownerToken ?? randomUUID();
+
+    return withMutex(this.mutexPath, async () => {
+      const current = await this.readRaw();
+      if (current && current.lease_until > now) {
+        return null;
+      }
+
+      const record = this.buildRecord(ownerToken, leaseMs, now);
+      await writeJsonFileAtomic(this.recordPath, record);
+      return record;
+    });
+  }
+
+  async renew(ownerToken: string, opts: LeaderLockRenewOptions = {}): Promise<LeaderLockRecord | null> {
+    const now = opts.now ?? Date.now();
+    const leaseMs = opts.leaseMs ?? this.defaultLeaseMs;
+
+    return withMutex(this.mutexPath, async () => {
+      const current = await this.readRaw();
+      if (!current || current.owner_token !== ownerToken || current.lease_until <= now) {
+        return null;
+      }
+
+      const renewed: LeaderLockRecord = {
+        ...current,
+        last_renewed_at: now,
+        lease_until: now + leaseMs,
+      };
+      await writeJsonFileAtomic(this.recordPath, renewed);
+      return renewed;
+    });
+  }
+
+  async release(ownerToken: string): Promise<boolean> {
+    return withMutex(this.mutexPath, async () => {
+      const current = await this.readRaw();
+      if (!current || current.owner_token !== ownerToken) {
+        return false;
+      }
+
+      await fsp.rm(this.recordPath, { force: true });
+      return true;
+    });
+  }
+
+  async read(): Promise<LeaderLockRecord | null> {
+    return this.readRaw();
+  }
+
+  async reapStale(now = Date.now()): Promise<LeaderLockRecord | null> {
+    return withMutex(this.mutexPath, async () => {
+      const current = await this.readRaw();
+      if (!current || current.lease_until > now) {
+        return null;
+      }
+
+      await fsp.rm(this.recordPath, { force: true });
+      return current;
+    });
+  }
+}

--- a/src/runtime/queue/__tests__/journal-backed-queue.test.ts
+++ b/src/runtime/queue/__tests__/journal-backed-queue.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createEnvelope } from '../../types/envelope.js';
+import { JournalBackedQueue } from '../journal-backed-queue.js';
+
+describe('JournalBackedQueue', () => {
+  let tmpDir: string;
+  let journalPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pulseed-journal-queue-'));
+    journalPath = path.join(tmpDir, 'queue.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('accepts, claims, renews, and acks with durable state', () => {
+    const queue = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const envelope = createEnvelope({ type: 'event', name: 'job', source: 'test', payload: {}, priority: 'high' });
+
+    expect(queue.accept(envelope)).toEqual({
+      accepted: true,
+      duplicate: false,
+      messageId: envelope.id,
+    });
+
+    const claim = queue.claim('worker-a', 5_000);
+    expect(claim?.messageId).toBe(envelope.id);
+    expect(claim?.attempt).toBe(1);
+
+    const renewed = queue.renew(claim!.claimToken, 10_000);
+    expect(renewed?.leaseUntil).toBe(11_000);
+
+    expect(queue.ack(claim!.claimToken)).toBe(true);
+    expect(queue.size()).toBe(0);
+    expect(queue.inflightSize()).toBe(0);
+
+    const reloaded = new JournalBackedQueue({ journalPath, now: () => 2_000 });
+    expect(reloaded.get(envelope.id)?.status).toBe('completed');
+    expect(reloaded.snapshot().completed).toContain(envelope.id);
+  });
+
+  it('replaces older pending entries that share the same dedupe_key', () => {
+    const queue = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const first = createEnvelope({
+      type: 'event',
+      name: 'job',
+      source: 'test',
+      payload: { version: 1 },
+      priority: 'normal',
+      dedupe_key: 'logical-job',
+    });
+    const second = createEnvelope({
+      type: 'event',
+      name: 'job',
+      source: 'test',
+      payload: { version: 2 },
+      priority: 'high',
+      dedupe_key: 'logical-job',
+    });
+
+    expect(queue.accept(first)).toEqual({
+      accepted: true,
+      duplicate: false,
+      messageId: first.id,
+    });
+
+    expect(queue.accept(second)).toEqual({
+      accepted: true,
+      duplicate: false,
+      messageId: second.id,
+    });
+
+    expect(queue.get(first.id)).toBeUndefined();
+    expect(queue.size()).toBe(1);
+    expect(queue.snapshot().pending.high).toEqual([second.id]);
+
+    const claim = queue.claim('worker-a', 5_000);
+    expect(claim?.messageId).toBe(second.id);
+    expect(claim?.envelope.payload).toEqual({ version: 2 });
+  });
+
+  it('rejects duplicate dedupe_key while the original item is inflight', () => {
+    const queue = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const original = createEnvelope({
+      type: 'event',
+      name: 'job',
+      source: 'test',
+      payload: { version: 1 },
+      priority: 'normal',
+      dedupe_key: 'logical-job',
+    });
+    const retry = createEnvelope({
+      type: 'event',
+      name: 'job',
+      source: 'test',
+      payload: { version: 2 },
+      priority: 'normal',
+      dedupe_key: 'logical-job',
+    });
+
+    queue.accept(original);
+    expect(queue.claim('worker-a', 5_000)).not.toBeNull();
+
+    expect(queue.accept(retry)).toEqual({
+      accepted: false,
+      duplicate: true,
+      messageId: original.id,
+    });
+    expect(queue.size()).toBe(0);
+    expect(queue.inflightSize()).toBe(1);
+  });
+
+  it('allows a dedupe_key to be accepted again after completion', () => {
+    const queue = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const first = createEnvelope({
+      type: 'event',
+      name: 'job',
+      source: 'test',
+      payload: { version: 1 },
+      priority: 'normal',
+      dedupe_key: 'logical-job',
+    });
+    const second = createEnvelope({
+      type: 'event',
+      name: 'job',
+      source: 'test',
+      payload: { version: 2 },
+      priority: 'normal',
+      dedupe_key: 'logical-job',
+    });
+
+    queue.accept(first);
+    const claim = queue.claim('worker-a', 5_000)!;
+    expect(queue.ack(claim.claimToken)).toBe(true);
+
+    expect(queue.accept(second)).toEqual({
+      accepted: true,
+      duplicate: false,
+      messageId: second.id,
+    });
+    expect(queue.get(second.id)?.status).toBe('pending');
+    expect(queue.size()).toBe(1);
+  });
+
+  it('nacks back to pending and deadletters after max attempts', () => {
+    const queue = new JournalBackedQueue({ journalPath, maxAttempts: 2, now: () => 1_000 });
+    const envelope = createEnvelope({ type: 'command', name: 'job', source: 'test', payload: {}, priority: 'normal' });
+    queue.accept(envelope);
+
+    const first = queue.claim('worker-a', 1_000)!;
+    expect(queue.nack(first.claimToken, 'boom')).toBe(true);
+    expect(queue.size()).toBe(1);
+
+    const second = queue.claim('worker-a', 1_000)!;
+    expect(second.attempt).toBe(2);
+    expect(queue.nack(second.claimToken, 'boom', true)).toBe(true);
+    expect(queue.get(envelope.id)?.status).toBe('deadletter');
+    expect(queue.snapshot().deadletter).toContain(envelope.id);
+  });
+
+  it('requeues deadlettered items back to pending', () => {
+    const queue = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const envelope = createEnvelope({ type: 'event', name: 'job', source: 'test', payload: {}, priority: 'low' });
+    queue.accept(envelope);
+
+    const claim = queue.claim('worker-a', 1_000)!;
+    queue.deadletter(claim.messageId, 'manual stop');
+    expect(queue.get(envelope.id)?.status).toBe('deadletter');
+
+    expect(queue.requeue(envelope.id)).toBe(true);
+    expect(queue.get(envelope.id)?.status).toBe('pending');
+    expect(queue.size()).toBe(1);
+  });
+
+  it('reloads under lock so two instances sharing a journal path do not clobber each other', () => {
+    const queueA = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const queueB = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const first = createEnvelope({ type: 'event', name: 'first', source: 'test', payload: {}, priority: 'high' });
+    const second = createEnvelope({ type: 'event', name: 'second', source: 'test', payload: {}, priority: 'high' });
+
+    expect(queueA.accept(first).accepted).toBe(true);
+    expect(queueB.accept(second).accepted).toBe(true);
+
+    const reloaded = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    expect(reloaded.size()).toBe(2);
+
+    const claimA = queueA.claim('worker-a', 5_000);
+    const claimB = queueB.claim('worker-b', 5_000);
+
+    expect([claimA?.messageId, claimB?.messageId].sort()).toEqual([first.id, second.id].sort());
+    expect(queueA.ack(claimA!.claimToken)).toBe(true);
+    expect(queueB.ack(claimB!.claimToken)).toBe(true);
+
+    const final = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    expect(final.snapshot().completed).toEqual(expect.arrayContaining([first.id, second.id]));
+  });
+
+  it('read APIs reflect writes from another queue instance', () => {
+    const writer = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const reader = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const envelope = createEnvelope({ type: 'event', name: 'observed', source: 'test', payload: {}, priority: 'critical' });
+
+    writer.accept(envelope);
+
+    expect(reader.size()).toBe(1);
+    expect(reader.get(envelope.id)?.status).toBe('pending');
+
+    const claim = writer.claim('worker-a', 5_000)!;
+    expect(reader.inflightSize()).toBe(1);
+    expect(reader.snapshot().inflight[claim.claimToken]?.messageId).toBe(envelope.id);
+  });
+
+  it('fences expired claims from renew/ack/nack before sweeper runs', () => {
+    let now = 1_000;
+    const queue = new JournalBackedQueue({ journalPath, now: () => now });
+    const envelope = createEnvelope({ type: 'command', name: 'job', source: 'test', payload: {}, priority: 'normal' });
+    queue.accept(envelope);
+
+    const claim = queue.claim('worker-a', 100)!;
+    now = 1_200;
+
+    expect(queue.renew(claim.claimToken, 100)).toBeNull();
+    expect(queue.ack(claim.claimToken)).toBe(false);
+    expect(queue.nack(claim.claimToken, 'late')).toBe(false);
+
+    const reloaded = new JournalBackedQueue({ journalPath, now: () => now });
+    expect(reloaded.get(envelope.id)?.status).toBe('inflight');
+    expect(reloaded.inflightSize()).toBe(1);
+  });
+
+  it('reclaims an orphaned lock directory with missing owner metadata', () => {
+    const lockPath = `${journalPath}.lock`;
+    fs.mkdirSync(lockPath, { recursive: true });
+
+    const queue = new JournalBackedQueue({ journalPath, now: () => 1_000 });
+    const envelope = createEnvelope({ type: 'event', name: 'orphan-lock', source: 'test', payload: {}, priority: 'normal' });
+
+    expect(queue.accept(envelope).accepted).toBe(true);
+    expect(queue.size()).toBe(1);
+    expect(queue.get(envelope.id)?.status).toBe('pending');
+  });
+});

--- a/src/runtime/queue/__tests__/queue-claim-sweeper.test.ts
+++ b/src/runtime/queue/__tests__/queue-claim-sweeper.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createEnvelope } from '../../types/envelope.js';
+import { JournalBackedQueue } from '../journal-backed-queue.js';
+import { QueueClaimSweeper } from '../queue-claim-sweeper.js';
+
+describe('QueueClaimSweeper', () => {
+  let tmpDir: string;
+  let journalPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pulseed-claim-sweeper-'));
+    journalPath = path.join(tmpDir, 'queue.json');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reclaims expired claims back to pending', () => {
+    let now = 1_000;
+    const queue = new JournalBackedQueue({ journalPath, maxAttempts: 3, now: () => now });
+    const sweeper = new QueueClaimSweeper({ queue, intervalMs: 50 });
+    const envelope = createEnvelope({ type: 'event', name: 'job', source: 'test', payload: {}, priority: 'normal' });
+
+    queue.accept(envelope);
+    const claim = queue.claim('worker-a', 100)!;
+    now = 1_200;
+
+    const result = sweeper.sweep(now);
+    expect(result.reclaimed).toBe(1);
+    expect(result.deadlettered).toBe(0);
+    expect(queue.get(envelope.id)?.status).toBe('pending');
+    expect(queue.size()).toBe(1);
+    expect(queue.inflightSize()).toBe(0);
+  });
+
+  it('deadletters expired claims at max attempts', () => {
+    let now = 1_000;
+    const queue = new JournalBackedQueue({ journalPath, maxAttempts: 1, now: () => now });
+    const sweeper = new QueueClaimSweeper({ queue });
+    const envelope = createEnvelope({ type: 'command', name: 'job', source: 'test', payload: {}, priority: 'critical' });
+
+    queue.accept(envelope);
+    queue.claim('worker-a', 100);
+    now = 1_200;
+
+    const result = sweeper.sweep(now);
+    expect(result.reclaimed).toBe(0);
+    expect(result.deadlettered).toBe(1);
+    expect(queue.get(envelope.id)?.status).toBe('deadletter');
+    expect(queue.snapshot().deadletter).toContain(envelope.id);
+  });
+});

--- a/src/runtime/queue/index.ts
+++ b/src/runtime/queue/index.ts
@@ -3,3 +3,15 @@ export { EventBus } from './event-bus.js';
 export type { EventBusOptions } from './event-bus.js';
 export { CommandBus } from './command-bus.js';
 export type { CommandBusOptions } from './command-bus.js';
+export { JournalBackedQueue } from './journal-backed-queue.js';
+export type {
+  JournalBackedQueueOptions,
+  JournalBackedQueueAcceptResult,
+  JournalBackedQueueClaim,
+  JournalBackedQueueSweepResult,
+  JournalBackedQueueSnapshot,
+  JournalBackedQueueRecord,
+  JournalBackedQueueClaimRecord,
+} from './journal-backed-queue.js';
+export { QueueClaimSweeper } from './queue-claim-sweeper.js';
+export type { QueueClaimSweeperOptions } from './queue-claim-sweeper.js';

--- a/src/runtime/queue/journal-backed-queue.ts
+++ b/src/runtime/queue/journal-backed-queue.ts
@@ -1,0 +1,614 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { Envelope, EnvelopePriority } from '../types/envelope.js';
+
+export interface JournalBackedQueueOptions {
+  journalPath: string;
+  defaultLeaseMs?: number;
+  maxAttempts?: number;
+  now?: () => number;
+}
+
+export interface JournalBackedQueueAcceptResult {
+  accepted: boolean;
+  duplicate: boolean;
+  messageId: string;
+}
+
+export interface JournalBackedQueueClaim {
+  claimToken: string;
+  messageId: string;
+  workerId: string;
+  leaseUntil: number;
+  attempt: number;
+  envelope: Envelope;
+}
+
+export interface JournalBackedQueueSweepResult {
+  reclaimed: number;
+  deadlettered: number;
+  expiredClaimTokens: string[];
+}
+
+export interface JournalBackedQueueSnapshot {
+  pending: Record<EnvelopePriority, string[]>;
+  inflight: Record<string, JournalBackedQueueClaimRecord>;
+  completed: string[];
+  deadletter: string[];
+}
+
+export interface JournalBackedQueueRecord {
+  envelope: Envelope;
+  status: 'pending' | 'inflight' | 'completed' | 'deadletter';
+  attempt: number;
+  createdAt: number;
+  updatedAt: number;
+  workerId?: string;
+  claimToken?: string;
+  leaseUntil?: number;
+  deadletterReason?: string;
+  completedAt?: number;
+}
+
+export interface JournalBackedQueueClaimRecord {
+  messageId: string;
+  workerId: string;
+  leaseUntil: number;
+  attempt: number;
+  claimedAt: number;
+}
+
+interface JournalBackedQueueState {
+  version: 1;
+  records: Record<string, JournalBackedQueueRecord>;
+  pending: Record<EnvelopePriority, string[]>;
+  inflight: Record<string, JournalBackedQueueClaimRecord>;
+}
+
+const PRIORITY_ORDER: EnvelopePriority[] = ['critical', 'high', 'normal', 'low'];
+const LOCK_STALE_MS = 30_000;
+const LOCK_WAIT_MS = 10;
+const LOCK_TIMEOUT_MS = 10_000;
+
+function emptyPending(): Record<EnvelopePriority, string[]> {
+  return {
+    critical: [],
+    high: [],
+    normal: [],
+    low: [],
+  };
+}
+
+function clonePending(pending: Record<EnvelopePriority, string[]>): Record<EnvelopePriority, string[]> {
+  return {
+    critical: [...pending.critical],
+    high: [...pending.high],
+    normal: [...pending.normal],
+    low: [...pending.low],
+  };
+}
+
+function atomicWriteJson(filePath: string, data: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const tmpPath = `${filePath}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // Ignore cleanup failures.
+    }
+    throw err;
+  }
+}
+
+function readJsonOrNull<T>(filePath: string): T | null {
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function sleepMs(ms: number): void {
+  if (ms <= 0) return;
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+interface JournalLockHandle {
+  release(): void;
+}
+
+function acquireJournalLock(lockPath: string): JournalLockHandle {
+  const ownerPath = path.join(lockPath, 'owner.json');
+  const ownerId = randomUUID();
+  const startedAt = Date.now();
+
+  for (;;) {
+    try {
+      fs.mkdirSync(lockPath);
+      atomicWriteJson(ownerPath, {
+        ownerId,
+        pid: process.pid,
+        acquiredAt: startedAt,
+      });
+      return {
+        release: () => {
+          try {
+            fs.rmSync(lockPath, { recursive: true, force: true });
+          } catch {
+            // Ignore lock cleanup failures.
+          }
+        },
+      };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') throw err;
+
+      const owner = readJsonOrNull<{ acquiredAt?: number }>(ownerPath);
+      if (owner?.acquiredAt === undefined || Date.now() - owner.acquiredAt > LOCK_STALE_MS) {
+        try {
+          fs.rmSync(lockPath, { recursive: true, force: true });
+          continue;
+        } catch {
+          // Another process may have won the race. Fall through to retry.
+        }
+      }
+
+      if (Date.now() - startedAt > LOCK_TIMEOUT_MS) {
+        throw new Error(`Timed out acquiring journal lock at ${lockPath}`);
+      }
+
+      sleepMs(LOCK_WAIT_MS);
+    }
+  }
+}
+
+function isExpired(envelope: Envelope, now: number): boolean {
+  const ttl = envelope.ttl_ms ?? 300_000;
+  return envelope.created_at + ttl <= now;
+}
+
+function buildEmptyState(): JournalBackedQueueState {
+  return {
+    version: 1,
+    records: {},
+    pending: emptyPending(),
+    inflight: {},
+  };
+}
+
+function normalizeState(state: JournalBackedQueueState): JournalBackedQueueState {
+  const normalized = buildEmptyState();
+  normalized.version = 1;
+  normalized.records = {};
+
+  for (const [messageId, record] of Object.entries(state.records ?? {})) {
+    if (!record?.envelope?.id) continue;
+    normalized.records[messageId] = { ...record };
+  }
+
+  normalized.pending = emptyPending();
+  for (const priority of PRIORITY_ORDER) {
+    const ids = state.pending?.[priority] ?? [];
+    for (const messageId of ids) {
+      const record = normalized.records[messageId];
+      if (!record || record.status !== 'pending') continue;
+      normalized.pending[priority].push(messageId);
+    }
+  }
+
+  normalized.inflight = {};
+  for (const [claimToken, claim] of Object.entries(state.inflight ?? {})) {
+    const record = normalized.records[claim.messageId];
+    if (!record || record.status !== 'inflight' || record.claimToken !== claimToken) continue;
+    normalized.inflight[claimToken] = { ...claim };
+  }
+
+  for (const [messageId, record] of Object.entries(normalized.records)) {
+    if (record.status === 'pending') {
+      const priority = record.envelope.priority;
+      if (!normalized.pending[priority].includes(messageId)) {
+        normalized.pending[priority].push(messageId);
+      }
+    }
+    if (record.status === 'inflight' && record.claimToken) {
+      normalized.inflight[record.claimToken] = {
+        messageId,
+        workerId: record.workerId ?? '',
+        leaseUntil: record.leaseUntil ?? 0,
+        attempt: record.attempt,
+        claimedAt: record.updatedAt,
+      };
+    }
+  }
+
+  return normalized;
+}
+
+export class JournalBackedQueue {
+  private readonly journalPath: string;
+  private readonly lockPath: string;
+  private readonly defaultLeaseMs: number;
+  private readonly maxAttempts: number;
+  private readonly now: () => number;
+  private state: JournalBackedQueueState;
+
+  constructor(options: JournalBackedQueueOptions) {
+    this.journalPath = options.journalPath;
+    this.lockPath = `${options.journalPath}.lock`;
+    this.defaultLeaseMs = options.defaultLeaseMs ?? 60_000;
+    this.maxAttempts = options.maxAttempts ?? 3;
+    this.now = options.now ?? Date.now;
+    this.state = this.loadFromDisk();
+  }
+
+  accept(envelope: Envelope): JournalBackedQueueAcceptResult {
+    return this.withLockedState<JournalBackedQueueAcceptResult>((state) => {
+      const existing = state.records[envelope.id];
+      if (existing) {
+        return {
+          result: { accepted: false, duplicate: true, messageId: envelope.id },
+          dirty: false,
+        };
+      }
+
+      if (isExpired(envelope, this.now())) {
+        return {
+          result: { accepted: false, duplicate: false, messageId: envelope.id },
+          dirty: false,
+        };
+      }
+
+      if (envelope.dedupe_key) {
+        const activeDedupeRecords = Object.entries(state.records).filter(([, record]) => {
+          return (
+            record.envelope.dedupe_key === envelope.dedupe_key &&
+            record.status !== 'completed' &&
+            record.status !== 'deadletter'
+          );
+        });
+
+        const inflightMatch = activeDedupeRecords.find(([, record]) => record.status === 'inflight');
+        if (inflightMatch) {
+          return {
+            result: {
+              accepted: false,
+              duplicate: true,
+              messageId: inflightMatch[0],
+            },
+            dirty: false,
+          };
+        }
+
+        for (const [messageId] of activeDedupeRecords) {
+          delete state.records[messageId];
+          this.removePending(state, messageId);
+        }
+      }
+
+      state.records[envelope.id] = {
+        envelope,
+        status: 'pending',
+        attempt: 0,
+        createdAt: this.now(),
+        updatedAt: this.now(),
+      };
+      state.pending[envelope.priority].push(envelope.id);
+      return {
+        result: { accepted: true, duplicate: false, messageId: envelope.id },
+        dirty: true,
+      };
+    });
+  }
+
+  claim(workerId: string, leaseMs = this.defaultLeaseMs): JournalBackedQueueClaim | null {
+    return this.withLockedState((state) => {
+      let dirty = false;
+      for (const priority of PRIORITY_ORDER) {
+        const bucket = state.pending[priority];
+        while (bucket.length > 0) {
+          const messageId = bucket.shift()!;
+          const record = state.records[messageId];
+          if (!record || record.status !== 'pending') continue;
+          if (isExpired(record.envelope, this.now())) {
+            record.status = 'deadletter';
+            record.deadletterReason = 'expired before claim';
+            record.updatedAt = this.now();
+            dirty = true;
+            continue;
+          }
+
+          const claimToken = randomUUID();
+          const attempt = record.attempt + 1;
+          const leaseUntil = this.now() + leaseMs;
+          record.status = 'inflight';
+          record.attempt = attempt;
+          record.workerId = workerId;
+          record.claimToken = claimToken;
+          record.leaseUntil = leaseUntil;
+          record.updatedAt = this.now();
+
+          state.inflight[claimToken] = {
+            messageId,
+            workerId,
+            leaseUntil,
+            attempt,
+            claimedAt: this.now(),
+          };
+          return {
+            result: {
+              claimToken,
+              messageId,
+              workerId,
+              leaseUntil,
+              attempt,
+              envelope: record.envelope,
+            },
+            dirty: true,
+          };
+        }
+      }
+
+      return { result: null, dirty };
+    });
+  }
+
+  renew(claimToken: string, leaseMs = this.defaultLeaseMs): JournalBackedQueueClaim | null {
+    return this.withLockedState((state) => {
+      const claim = state.inflight[claimToken];
+      if (!claim) return { result: null, dirty: false };
+
+      const record = state.records[claim.messageId];
+      if (!record || record.status !== 'inflight' || record.claimToken !== claimToken) {
+        delete state.inflight[claimToken];
+        return { result: null, dirty: true };
+      }
+
+      if (this.isLeaseExpired(record, claimToken)) {
+        return { result: null, dirty: false };
+      }
+
+      const leaseUntil = this.now() + leaseMs;
+      claim.leaseUntil = leaseUntil;
+      claim.claimedAt = this.now();
+      record.leaseUntil = leaseUntil;
+      record.updatedAt = this.now();
+      return {
+        result: {
+          claimToken,
+          messageId: claim.messageId,
+          workerId: claim.workerId,
+          leaseUntil,
+          attempt: claim.attempt,
+          envelope: record.envelope,
+        },
+        dirty: true,
+      };
+    });
+  }
+
+  ack(claimToken: string): boolean {
+    return this.withLockedState((state) => {
+      const claim = state.inflight[claimToken];
+      if (!claim) return { result: false, dirty: false };
+
+      const record = state.records[claim.messageId];
+      if (!record || record.status !== 'inflight' || record.claimToken !== claimToken) {
+        return { result: false, dirty: false };
+      }
+
+      if (this.isLeaseExpired(record, claimToken)) {
+        return { result: false, dirty: false };
+      }
+
+      record.status = 'completed';
+      record.completedAt = this.now();
+      record.updatedAt = this.now();
+      delete record.workerId;
+      delete record.claimToken;
+      delete record.leaseUntil;
+      delete state.inflight[claimToken];
+      return { result: true, dirty: true };
+    });
+  }
+
+  nack(claimToken: string, reason: string, requeue = true): boolean {
+    return this.withLockedState((state) => {
+      const claim = state.inflight[claimToken];
+      if (!claim) return { result: false, dirty: false };
+
+      const record = state.records[claim.messageId];
+      if (!record || record.status !== 'inflight' || record.claimToken !== claimToken) {
+        return { result: false, dirty: false };
+      }
+
+      if (this.isLeaseExpired(record, claimToken)) {
+        return { result: false, dirty: false };
+      }
+
+      delete state.inflight[claimToken];
+      delete record.workerId;
+      delete record.claimToken;
+      delete record.leaseUntil;
+      record.updatedAt = this.now();
+      if (!requeue || record.attempt >= this.maxAttempts) {
+        record.status = 'deadletter';
+        record.deadletterReason = reason;
+        return { result: true, dirty: true };
+      }
+
+      record.status = 'pending';
+      state.pending[record.envelope.priority].push(record.envelope.id);
+      return { result: true, dirty: true };
+    });
+  }
+
+  requeue(messageId: string): boolean {
+    return this.withLockedState((state) => {
+      const record = state.records[messageId];
+      if (!record) return { result: false, dirty: false };
+      if (record.status === 'completed') return { result: false, dirty: false };
+      if (record.status === 'pending') return { result: true, dirty: false };
+
+      if (record.status === 'inflight' && record.claimToken) {
+        delete state.inflight[record.claimToken];
+      }
+
+      delete record.workerId;
+      delete record.claimToken;
+      delete record.leaseUntil;
+      delete record.deadletterReason;
+      record.status = 'pending';
+      record.updatedAt = this.now();
+      state.pending[record.envelope.priority].push(messageId);
+      return { result: true, dirty: true };
+    });
+  }
+
+  deadletter(messageId: string, reason: string): boolean {
+    return this.withLockedState((state) => {
+      const record = state.records[messageId];
+      if (!record) return { result: false, dirty: false };
+
+      if (record.status === 'inflight' && record.claimToken) {
+        delete state.inflight[record.claimToken];
+      }
+
+      this.removePending(state, messageId);
+      delete record.workerId;
+      delete record.claimToken;
+      delete record.leaseUntil;
+      record.status = 'deadletter';
+      record.deadletterReason = reason;
+      record.updatedAt = this.now();
+      return { result: true, dirty: true };
+    });
+  }
+
+  sweepExpiredClaims(now = this.now()): JournalBackedQueueSweepResult {
+    return this.withLockedState((state) => {
+      const expiredClaimTokens: string[] = [];
+      let reclaimed = 0;
+      let deadlettered = 0;
+
+      for (const [claimToken, claim] of Object.entries({ ...state.inflight })) {
+        if (claim.leaseUntil > now) continue;
+        const record = state.records[claim.messageId];
+        expiredClaimTokens.push(claimToken);
+        delete state.inflight[claimToken];
+
+        if (!record || record.status !== 'inflight' || record.claimToken !== claimToken) {
+          continue;
+        }
+
+        delete record.workerId;
+        delete record.claimToken;
+        delete record.leaseUntil;
+        record.updatedAt = now;
+
+        if (record.attempt >= this.maxAttempts) {
+          record.status = 'deadletter';
+          record.deadletterReason = 'lease expired';
+          deadlettered += 1;
+          continue;
+        }
+
+        record.status = 'pending';
+        state.pending[record.envelope.priority].push(record.envelope.id);
+        reclaimed += 1;
+      }
+
+      return {
+        result: { reclaimed, deadlettered, expiredClaimTokens },
+        dirty: expiredClaimTokens.length > 0,
+      };
+    });
+  }
+
+  snapshot(): JournalBackedQueueSnapshot {
+    this.refresh();
+    const completed: string[] = [];
+    const deadletter: string[] = [];
+    for (const record of Object.values(this.state.records)) {
+      if (record.status === 'completed') completed.push(record.envelope.id);
+      if (record.status === 'deadletter') deadletter.push(record.envelope.id);
+    }
+
+    return {
+      pending: clonePending(this.state.pending),
+      inflight: { ...this.state.inflight },
+      completed,
+      deadletter,
+    };
+  }
+
+  get(messageId: string): JournalBackedQueueRecord | undefined {
+    this.refresh();
+    return this.state.records[messageId] ? { ...this.state.records[messageId] } : undefined;
+  }
+
+  size(): number {
+    this.refresh();
+    return PRIORITY_ORDER.reduce((total, priority) => total + this.state.pending[priority].length, 0);
+  }
+
+  inflightSize(): number {
+    this.refresh();
+    return Object.keys(this.state.inflight).length;
+  }
+
+  private load(): JournalBackedQueueState {
+    const raw = readJsonOrNull<JournalBackedQueueState>(this.journalPath);
+    if (!raw || raw.version !== 1) {
+      return buildEmptyState();
+    }
+    return normalizeState(raw);
+  }
+
+  private loadFromDisk(): JournalBackedQueueState {
+    return this.load();
+  }
+
+  private refresh(): void {
+    this.state = this.loadFromDisk();
+  }
+
+  private persist(state: JournalBackedQueueState): void {
+    atomicWriteJson(this.journalPath, state);
+  }
+
+  private withLockedState<T>(mutator: (state: JournalBackedQueueState) => { result: T; dirty: boolean }): T {
+    const lock = acquireJournalLock(this.lockPath);
+    try {
+      const state = this.loadFromDisk();
+      const { result, dirty } = mutator(state);
+      if (dirty) {
+        this.persist(state);
+      }
+      this.state = state;
+      return result;
+    } finally {
+      lock.release();
+    }
+  }
+
+  private isLeaseExpired(record: JournalBackedQueueRecord, claimToken: string): boolean {
+    return record.claimToken === claimToken && (record.leaseUntil ?? 0) <= this.now();
+  }
+
+  private removePending(state: JournalBackedQueueState, messageId: string): void {
+    for (const priority of PRIORITY_ORDER) {
+      const bucket = state.pending[priority];
+      const index = bucket.indexOf(messageId);
+      if (index >= 0) {
+        bucket.splice(index, 1);
+        return;
+      }
+    }
+  }
+}

--- a/src/runtime/queue/queue-claim-sweeper.ts
+++ b/src/runtime/queue/queue-claim-sweeper.ts
@@ -1,0 +1,36 @@
+import { JournalBackedQueue, JournalBackedQueueSweepResult } from './journal-backed-queue.js';
+
+export interface QueueClaimSweeperOptions {
+  queue: JournalBackedQueue;
+  intervalMs?: number;
+}
+
+export class QueueClaimSweeper {
+  private readonly queue: JournalBackedQueue;
+  private readonly intervalMs: number;
+  private timer: NodeJS.Timeout | null;
+
+  constructor(options: QueueClaimSweeperOptions) {
+    this.queue = options.queue;
+    this.intervalMs = options.intervalMs ?? 5_000;
+    this.timer = null;
+  }
+
+  sweep(now?: number): JournalBackedQueueSweepResult {
+    return this.queue.sweepExpiredClaims(now);
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      this.queue.sweepExpiredClaims();
+    }, this.intervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+}

--- a/src/runtime/store/approval-store.ts
+++ b/src/runtime/store/approval-store.ts
@@ -1,0 +1,143 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { RuntimeJournal } from "./runtime-journal.js";
+import {
+  ApprovalRecordSchema,
+  ApprovalStateSchema,
+  type ApprovalRecord,
+  type ApprovalState,
+} from "./runtime-schemas.js";
+import {
+  createRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+
+export interface ApprovalResolutionInput {
+  state: Exclude<ApprovalState, "pending">;
+  resolved_at?: number;
+  response_channel?: string;
+  payload?: unknown;
+}
+
+export class ApprovalStore {
+  private readonly paths: RuntimeStorePaths;
+  private readonly journal: RuntimeJournal;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+    this.journal = new RuntimeJournal(this.paths);
+  }
+
+  private async sleep(ms: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private lockPath(approvalId: string): string {
+    return path.join(this.paths.approvalsDir, "locks", `${approvalId}.lock`);
+  }
+
+  private async withApprovalLock<T>(approvalId: string, fn: () => Promise<T>): Promise<T> {
+    const lockPath = this.lockPath(approvalId);
+    const staleAfterMs = 30_000;
+
+    for (;;) {
+      try {
+        await fsp.mkdir(path.dirname(lockPath), { recursive: true });
+        const handle = await fsp.open(lockPath, "wx");
+        await handle.writeFile(JSON.stringify({ pid: process.pid, acquired_at: Date.now() }));
+        try {
+          return await fn();
+        } finally {
+          await handle.close();
+          await fsp.unlink(lockPath).catch(() => undefined);
+        }
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+
+        try {
+          const stat = await fsp.stat(lockPath);
+          if (Date.now() - stat.mtimeMs > staleAfterMs) {
+            await fsp.unlink(lockPath);
+            continue;
+          }
+        } catch (staleErr) {
+          if ((staleErr as NodeJS.ErrnoException).code === "ENOENT") continue;
+          throw staleErr;
+        }
+
+        await this.sleep(10);
+      }
+    }
+  }
+
+  async ensureReady(): Promise<void> {
+    await this.journal.ensureReady();
+  }
+
+  async load(approvalId: string): Promise<ApprovalRecord | null> {
+    return (await this.loadResolved(approvalId)) ?? (await this.loadPending(approvalId));
+  }
+
+  async loadPending(approvalId: string): Promise<ApprovalRecord | null> {
+    return this.journal.load(this.paths.approvalPendingPath(approvalId), ApprovalRecordSchema);
+  }
+
+  async loadResolved(approvalId: string): Promise<ApprovalRecord | null> {
+    return this.journal.load(this.paths.approvalResolvedPath(approvalId), ApprovalRecordSchema);
+  }
+
+  async listPending(): Promise<ApprovalRecord[]> {
+    const pending = await this.journal.list(this.paths.approvalsPendingDir, ApprovalRecordSchema);
+    const filtered: ApprovalRecord[] = [];
+    for (const record of pending) {
+      const resolved = await this.loadResolved(record.approval_id);
+      if (resolved === null) filtered.push(record);
+    }
+    return filtered;
+  }
+
+  async listResolved(): Promise<ApprovalRecord[]> {
+    return this.journal.list(this.paths.approvalsResolvedDir, ApprovalRecordSchema);
+  }
+
+  async savePending(record: ApprovalRecord): Promise<ApprovalRecord> {
+    const parsed = ApprovalRecordSchema.parse({ ...record, state: "pending" });
+    return this.withApprovalLock(parsed.approval_id, async () => {
+      const resolved = await this.loadResolved(parsed.approval_id);
+      if (resolved !== null) return resolved;
+      await this.journal.save(this.paths.approvalPendingPath(parsed.approval_id), ApprovalRecordSchema, parsed);
+      return parsed;
+    });
+  }
+
+  async saveResolved(record: ApprovalRecord): Promise<ApprovalRecord> {
+    const parsed = ApprovalRecordSchema.parse({
+      ...record,
+      state: ApprovalStateSchema.parse(record.state),
+      resolved_at: record.resolved_at ?? Date.now(),
+    });
+    await this.journal.save(this.paths.approvalResolvedPath(parsed.approval_id), ApprovalRecordSchema, parsed);
+    return parsed;
+  }
+
+  async resolvePending(approvalId: string, update: ApprovalResolutionInput): Promise<ApprovalRecord | null> {
+    return this.withApprovalLock(approvalId, async () => {
+      const current = await this.loadPending(approvalId);
+      if (current === null) return this.loadResolved(approvalId);
+
+      const resolved = ApprovalRecordSchema.parse({
+        ...current,
+        ...update,
+        approval_id: current.approval_id,
+        state: ApprovalStateSchema.parse(update.state),
+        resolved_at: update.resolved_at ?? Date.now(),
+      });
+      await this.saveResolved(resolved);
+      await this.journal.remove(this.paths.approvalPendingPath(approvalId));
+      return resolved;
+    });
+  }
+}

--- a/src/runtime/store/health-store.ts
+++ b/src/runtime/store/health-store.ts
@@ -1,0 +1,87 @@
+import { RuntimeJournal } from "./runtime-journal.js";
+import {
+  RuntimeComponentsHealthSchema,
+  RuntimeDaemonHealthSchema,
+  RuntimeHealthSnapshotSchema,
+  summarizeRuntimeHealthStatus,
+  type RuntimeComponentsHealth,
+  type RuntimeDaemonHealth,
+  type RuntimeHealthSnapshot,
+} from "./runtime-schemas.js";
+import {
+  createRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+
+export class RuntimeHealthStore {
+  private readonly paths: RuntimeStorePaths;
+  private readonly journal: RuntimeJournal;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+    this.journal = new RuntimeJournal(this.paths);
+  }
+
+  async ensureReady(): Promise<void> {
+    await this.journal.ensureReady();
+  }
+
+  async loadDaemonHealth(): Promise<RuntimeDaemonHealth | null> {
+    return this.journal.load(this.paths.daemonHealthPath, RuntimeDaemonHealthSchema);
+  }
+
+  async saveDaemonHealth(health: RuntimeDaemonHealth): Promise<RuntimeDaemonHealth> {
+    const parsed = RuntimeDaemonHealthSchema.parse(health);
+    await this.journal.save(this.paths.daemonHealthPath, RuntimeDaemonHealthSchema, parsed);
+    return parsed;
+  }
+
+  async loadComponentsHealth(): Promise<RuntimeComponentsHealth | null> {
+    return this.journal.load(this.paths.componentsHealthPath, RuntimeComponentsHealthSchema);
+  }
+
+  async saveComponentsHealth(health: RuntimeComponentsHealth): Promise<RuntimeComponentsHealth> {
+    const parsed = RuntimeComponentsHealthSchema.parse(health);
+    await this.journal.save(this.paths.componentsHealthPath, RuntimeComponentsHealthSchema, parsed);
+    return parsed;
+  }
+
+  async loadSnapshot(): Promise<RuntimeHealthSnapshot | null> {
+    const [daemon, components] = await Promise.all([
+      this.loadDaemonHealth(),
+      this.loadComponentsHealth(),
+    ]);
+    if (daemon === null || components === null) return null;
+    return RuntimeHealthSnapshotSchema.parse({
+      status: daemon.status,
+      leader: daemon.leader,
+      checked_at: Math.max(daemon.checked_at, components.checked_at),
+      components: components.components,
+      details: daemon.details,
+    });
+  }
+
+  async saveSnapshot(snapshot: RuntimeHealthSnapshot): Promise<RuntimeHealthSnapshot> {
+    const parsed = RuntimeHealthSnapshotSchema.parse(snapshot);
+    await Promise.all([
+      this.saveDaemonHealth({
+        status: parsed.status,
+        leader: parsed.leader,
+        checked_at: parsed.checked_at,
+        details: parsed.details,
+      }),
+      this.saveComponentsHealth({
+        checked_at: parsed.checked_at,
+        components: parsed.components,
+      }),
+    ]);
+    return parsed;
+  }
+
+  summarizeStatus(components: Record<string, RuntimeHealthSnapshot["status"]>): RuntimeHealthSnapshot["status"] {
+    return summarizeRuntimeHealthStatus(components);
+  }
+}

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -1,0 +1,54 @@
+export {
+  createRuntimeStorePaths,
+  ensureRuntimeStorePaths,
+  resolveRuntimeRootPath,
+  runtimeDateKey,
+} from "./runtime-paths.js";
+export type { RuntimeStorePaths } from "./runtime-paths.js";
+
+export {
+  RuntimeJournal,
+  ensureRuntimeDirectory,
+  listRuntimeJson,
+  loadRuntimeJson,
+  moveRuntimeJson,
+  removeRuntimeJson,
+  saveRuntimeJson,
+} from "./runtime-journal.js";
+
+export {
+  RuntimeEnvelopeKindSchema,
+  RuntimeEnvelopePrioritySchema,
+  RuntimeEnvelopeSchema,
+  RuntimeQueueStateSchema,
+  RuntimeQueueRecordSchema,
+  GoalLeaseRecordSchema,
+  ApprovalStateSchema,
+  ApprovalRecordSchema,
+  OutboxRecordSchema,
+  RuntimeHealthStatusSchema,
+  RuntimeDaemonHealthSchema,
+  RuntimeComponentsHealthSchema,
+  RuntimeHealthSnapshotSchema,
+  summarizeRuntimeHealthStatus,
+} from "./runtime-schemas.js";
+export type {
+  RuntimeEnvelope,
+  RuntimeEnvelopeKind,
+  RuntimeEnvelopePriority,
+  RuntimeQueueState,
+  RuntimeQueueRecord,
+  GoalLeaseRecord,
+  ApprovalState,
+  ApprovalRecord,
+  OutboxRecord,
+  RuntimeHealthStatus,
+  RuntimeDaemonHealth,
+  RuntimeComponentsHealth,
+  RuntimeHealthSnapshot,
+} from "./runtime-schemas.js";
+
+export { ApprovalStore } from "./approval-store.js";
+export type { ApprovalResolutionInput } from "./approval-store.js";
+export { OutboxStore } from "./outbox-store.js";
+export { RuntimeHealthStore } from "./health-store.js";

--- a/src/runtime/store/outbox-store.ts
+++ b/src/runtime/store/outbox-store.ts
@@ -1,0 +1,108 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { RuntimeJournal } from "./runtime-journal.js";
+import { OutboxRecordSchema, type OutboxRecord } from "./runtime-schemas.js";
+import {
+  createRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+
+interface AppendLock {
+  release(): Promise<void>;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class OutboxStore {
+  private readonly paths: RuntimeStorePaths;
+  private readonly journal: RuntimeJournal;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+    this.journal = new RuntimeJournal(this.paths);
+  }
+
+  async ensureReady(): Promise<void> {
+    await this.journal.ensureReady();
+  }
+
+  async load(seq: number): Promise<OutboxRecord | null> {
+    return this.journal.load(this.paths.outboxRecordPath(seq), OutboxRecordSchema);
+  }
+
+  async loadLatest(): Promise<OutboxRecord | null> {
+    const records = await this.list();
+    return records.at(-1) ?? null;
+  }
+
+  async list(afterSeq = 0): Promise<OutboxRecord[]> {
+    const records = await this.journal.list(this.paths.outboxDir, OutboxRecordSchema);
+    if (afterSeq <= 0) return records;
+    return records.filter((record) => record.seq > afterSeq);
+  }
+
+  async nextSeq(): Promise<number> {
+    const latest = await this.loadLatest();
+    return latest === null ? 1 : latest.seq + 1;
+  }
+
+  async save(record: OutboxRecord): Promise<OutboxRecord> {
+    const parsed = OutboxRecordSchema.parse(record);
+    await this.journal.save(this.paths.outboxRecordPath(parsed.seq), OutboxRecordSchema, parsed);
+    return parsed;
+  }
+
+  private async acquireAppendLock(): Promise<AppendLock> {
+    const lockPath = path.join(this.paths.outboxDir, ".append.lock");
+    const staleAfterMs = 30_000;
+
+    for (;;) {
+      try {
+        await fs.mkdir(this.paths.outboxDir, { recursive: true });
+        const handle = await fs.open(lockPath, "wx");
+        await handle.writeFile(
+          JSON.stringify({
+            pid: process.pid,
+            acquired_at: Date.now(),
+          })
+        );
+        return {
+          release: async () => {
+            await handle.close();
+            await fs.unlink(lockPath).catch(() => undefined);
+          },
+        };
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+
+        try {
+          const stat = await fs.stat(lockPath);
+          if (Date.now() - stat.mtimeMs > staleAfterMs) {
+            await fs.unlink(lockPath);
+            continue;
+          }
+        } catch (staleErr) {
+          if ((staleErr as NodeJS.ErrnoException).code === "ENOENT") continue;
+          throw staleErr;
+        }
+
+        await sleep(10);
+      }
+    }
+  }
+
+  async append(record: Omit<OutboxRecord, "seq">): Promise<OutboxRecord> {
+    const lock = await this.acquireAppendLock();
+    try {
+      const seq = await this.nextSeq();
+      return await this.save({ ...record, seq });
+    } finally {
+      await lock.release();
+    }
+  }
+}

--- a/src/runtime/store/runtime-journal.ts
+++ b/src/runtime/store/runtime-journal.ts
@@ -1,0 +1,93 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../../base/utils/json-io.js";
+import type { RuntimeStorePaths } from "./runtime-paths.js";
+import { ensureRuntimeStorePaths } from "./runtime-paths.js";
+import type { z } from "zod";
+
+export async function ensureRuntimeDirectory(dirPath: string): Promise<void> {
+  await fsp.mkdir(dirPath, { recursive: true });
+}
+
+export async function loadRuntimeJson<T>(
+  filePath: string,
+  schema: z.ZodType<T>
+): Promise<T | null> {
+  const raw = await readJsonFileOrNull<unknown>(filePath);
+  if (raw === null) return null;
+  const parsed = schema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+export async function saveRuntimeJson<T>(
+  filePath: string,
+  schema: z.ZodType<T>,
+  value: T
+): Promise<T> {
+  const parsed = schema.parse(value);
+  await writeJsonFileAtomic(filePath, parsed);
+  return parsed;
+}
+
+export async function removeRuntimeJson(filePath: string): Promise<void> {
+  try {
+    await fsp.unlink(filePath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw err;
+  }
+}
+
+export async function listRuntimeJson<T>(
+  dirPath: string,
+  schema: z.ZodType<T>
+): Promise<T[]> {
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dirPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const files = entries.filter((entry) => entry.endsWith(".json")).sort();
+  const records: T[] = [];
+  for (const fileName of files) {
+    const record = await loadRuntimeJson(path.join(dirPath, fileName), schema);
+    if (record !== null) records.push(record);
+  }
+  return records;
+}
+
+export async function moveRuntimeJson(sourcePath: string, targetPath: string): Promise<void> {
+  await fsp.mkdir(path.dirname(targetPath), { recursive: true });
+  await fsp.rename(sourcePath, targetPath);
+}
+
+export class RuntimeJournal {
+  constructor(private readonly paths: RuntimeStorePaths) {}
+
+  async ensureReady(): Promise<void> {
+    await ensureRuntimeStorePaths(this.paths);
+  }
+
+  async load<T>(filePath: string, schema: z.ZodType<T>): Promise<T | null> {
+    return loadRuntimeJson(filePath, schema);
+  }
+
+  async save<T>(filePath: string, schema: z.ZodType<T>, value: T): Promise<T> {
+    return saveRuntimeJson(filePath, schema, value);
+  }
+
+  async list<T>(dirPath: string, schema: z.ZodType<T>): Promise<T[]> {
+    return listRuntimeJson(dirPath, schema);
+  }
+
+  async remove(filePath: string): Promise<void> {
+    await removeRuntimeJson(filePath);
+  }
+
+  async move(sourcePath: string, targetPath: string): Promise<void> {
+    await moveRuntimeJson(sourcePath, targetPath);
+  }
+}

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -1,0 +1,148 @@
+import { createHash } from "node:crypto";
+import * as path from "node:path";
+import * as fsp from "node:fs/promises";
+import { getPulseedDirPath } from "../../base/utils/paths.js";
+
+export interface RuntimeStorePaths {
+  rootDir: string;
+  leaderDir: string;
+  leaderPath: string;
+  inboxDir: string;
+  claimsDir: string;
+  completedDir: string;
+  completedByIdempotencyDir: string;
+  completedByMessageDir: string;
+  approvalsDir: string;
+  approvalsPendingDir: string;
+  approvalsResolvedDir: string;
+  outboxDir: string;
+  leasesDir: string;
+  goalLeasesDir: string;
+  dlqDir: string;
+  healthDir: string;
+  daemonHealthPath: string;
+  componentsHealthPath: string;
+  inboxBucketDir(dateKey: string): string;
+  inboxRecordPath(dateKey: string, messageId: string): string;
+  approvalPendingPath(approvalId: string): string;
+  approvalResolvedPath(approvalId: string): string;
+  outboxRecordPath(seq: number): string;
+  goalLeasePath(goalId: string): string;
+  completedByIdempotencyPath(idempotencyKey: string): string;
+  completedByMessagePath(messageId: string): string;
+  dlqPath(dateKey: string): string;
+}
+
+function recordFileName(recordId: string): string {
+  return `${recordId}.json`;
+}
+
+function outboxFileName(seq: number): string {
+  return `${String(seq).padStart(12, "0")}.json`;
+}
+
+export function encodeRuntimePathSegment(value: string): string {
+  return encodeURIComponent(value);
+}
+
+function hashedRecordFileName(value: string): string {
+  const digest = createHash("sha256").update(value).digest("hex");
+  return `${digest}.json`;
+}
+
+export function resolveRuntimeRootPath(runtimeRoot?: string): string {
+  return runtimeRoot ? path.resolve(runtimeRoot) : path.join(getPulseedDirPath(), "runtime");
+}
+
+export function runtimeDateKey(timestamp: number | Date = Date.now()): string {
+  const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
+  return date.toISOString().slice(0, 10);
+}
+
+export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths {
+  const rootDir = resolveRuntimeRootPath(runtimeRoot);
+  const leaderDir = path.join(rootDir, "leader");
+  const inboxDir = path.join(rootDir, "inbox");
+  const claimsDir = path.join(rootDir, "claims");
+  const completedDir = path.join(rootDir, "completed");
+  const completedByIdempotencyDir = path.join(completedDir, "by-idempotency");
+  const completedByMessageDir = path.join(completedDir, "by-message");
+  const approvalsDir = path.join(rootDir, "approvals");
+  const approvalsPendingDir = path.join(approvalsDir, "pending");
+  const approvalsResolvedDir = path.join(approvalsDir, "resolved");
+  const outboxDir = path.join(rootDir, "outbox");
+  const leasesDir = path.join(rootDir, "leases");
+  const goalLeasesDir = path.join(leasesDir, "goal");
+  const dlqDir = path.join(rootDir, "dlq");
+  const healthDir = path.join(rootDir, "health");
+
+  return {
+    rootDir,
+    leaderDir,
+    leaderPath: path.join(leaderDir, "leader.json"),
+    inboxDir,
+    claimsDir,
+    completedDir,
+    completedByIdempotencyDir,
+    completedByMessageDir,
+    approvalsDir,
+    approvalsPendingDir,
+    approvalsResolvedDir,
+    outboxDir,
+    leasesDir,
+    goalLeasesDir,
+    dlqDir,
+    healthDir,
+    daemonHealthPath: path.join(healthDir, "daemon.json"),
+    componentsHealthPath: path.join(healthDir, "components.json"),
+    inboxBucketDir(dateKey: string) {
+      return path.join(inboxDir, dateKey);
+    },
+    inboxRecordPath(dateKey: string, messageId: string) {
+      return path.join(inboxDir, dateKey, recordFileName(messageId));
+    },
+    approvalPendingPath(approvalId: string) {
+      return path.join(approvalsPendingDir, recordFileName(approvalId));
+    },
+    approvalResolvedPath(approvalId: string) {
+      return path.join(approvalsResolvedDir, recordFileName(approvalId));
+    },
+    outboxRecordPath(seq: number) {
+      return path.join(outboxDir, outboxFileName(seq));
+    },
+    goalLeasePath(goalId: string) {
+      return path.join(goalLeasesDir, `${encodeRuntimePathSegment(goalId)}.json`);
+    },
+    completedByIdempotencyPath(idempotencyKey: string) {
+      return path.join(completedByIdempotencyDir, hashedRecordFileName(idempotencyKey));
+    },
+    completedByMessagePath(messageId: string) {
+      return path.join(completedByMessageDir, recordFileName(messageId));
+    },
+    dlqPath(dateKey: string) {
+      return path.join(dlqDir, `${dateKey}.jsonl`);
+    },
+  };
+}
+
+export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise<void> {
+  await Promise.all(
+    [
+      paths.rootDir,
+      paths.leaderDir,
+      paths.inboxDir,
+      paths.claimsDir,
+      paths.completedDir,
+      paths.completedByIdempotencyDir,
+      paths.completedByMessageDir,
+      paths.approvalsDir,
+      paths.approvalsPendingDir,
+      paths.approvalsResolvedDir,
+      paths.outboxDir,
+      paths.leasesDir,
+      paths.goalLeasesDir,
+      paths.dlqDir,
+      paths.healthDir,
+    ].map((dir) => fsp.mkdir(dir, { recursive: true }))
+  );
+}

--- a/src/runtime/store/runtime-schemas.ts
+++ b/src/runtime/store/runtime-schemas.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+
+export const RuntimeEnvelopeKindSchema = z.enum(["event", "command", "approval", "system"]);
+export type RuntimeEnvelopeKind = z.infer<typeof RuntimeEnvelopeKindSchema>;
+
+export const RuntimeEnvelopePrioritySchema = z.enum(["critical", "high", "normal", "low"]);
+export type RuntimeEnvelopePriority = z.infer<typeof RuntimeEnvelopePrioritySchema>;
+
+export const RuntimeEnvelopeSchema = z.object({
+  message_id: z.string(),
+  kind: RuntimeEnvelopeKindSchema,
+  name: z.string(),
+  source: z.string(),
+  goal_id: z.string().optional(),
+  correlation_id: z.string().optional(),
+  idempotency_key: z.string().optional(),
+  dedupe_key: z.string().optional(),
+  priority: RuntimeEnvelopePrioritySchema,
+  payload: z.unknown(),
+  created_at: z.number().int().nonnegative(),
+  ttl_ms: z.number().int().positive().optional(),
+  attempt: z.number().int().nonnegative().default(0),
+});
+export type RuntimeEnvelope = z.infer<typeof RuntimeEnvelopeSchema>;
+
+export const RuntimeQueueStateSchema = z.enum([
+  "accepted",
+  "queued",
+  "claimed",
+  "retry_wait",
+  "completed",
+  "deadletter",
+  "cancelled",
+]);
+export type RuntimeQueueState = z.infer<typeof RuntimeQueueStateSchema>;
+
+export const RuntimeQueueRecordSchema = z.object({
+  message_id: z.string(),
+  state: z.enum(["queued", "claimed", "retry_wait", "completed", "deadletter", "cancelled"]),
+  available_at: z.number().int().nonnegative(),
+  claimed_by: z.string().optional(),
+  lease_until: z.number().int().nonnegative().optional(),
+  attempt: z.number().int().nonnegative().default(0),
+  last_error: z.string().optional(),
+  updated_at: z.number().int().nonnegative(),
+});
+export type RuntimeQueueRecord = z.infer<typeof RuntimeQueueRecordSchema>;
+
+export const GoalLeaseRecordSchema = z.object({
+  goal_id: z.string(),
+  owner_token: z.string(),
+  attempt_id: z.string(),
+  worker_id: z.string(),
+  lease_until: z.number().int().nonnegative(),
+  acquired_at: z.number().int().nonnegative(),
+  last_renewed_at: z.number().int().nonnegative(),
+});
+export type GoalLeaseRecord = z.infer<typeof GoalLeaseRecordSchema>;
+
+export const ApprovalStateSchema = z.enum(["pending", "approved", "denied", "expired", "cancelled"]);
+export type ApprovalState = z.infer<typeof ApprovalStateSchema>;
+
+export const ApprovalRecordSchema = z.object({
+  approval_id: z.string(),
+  goal_id: z.string().optional(),
+  request_envelope_id: z.string(),
+  correlation_id: z.string(),
+  state: ApprovalStateSchema,
+  created_at: z.number().int().nonnegative(),
+  expires_at: z.number().int().nonnegative(),
+  resolved_at: z.number().int().nonnegative().optional(),
+  response_channel: z.string().optional(),
+  payload: z.unknown(),
+});
+export type ApprovalRecord = z.infer<typeof ApprovalRecordSchema>;
+
+export const OutboxRecordSchema = z.object({
+  seq: z.number().int().positive(),
+  event_type: z.string(),
+  goal_id: z.string().optional(),
+  correlation_id: z.string().optional(),
+  created_at: z.number().int().nonnegative(),
+  payload: z.unknown(),
+});
+export type OutboxRecord = z.infer<typeof OutboxRecordSchema>;
+
+export const RuntimeHealthStatusSchema = z.enum(["ok", "degraded", "failed"]);
+export type RuntimeHealthStatus = z.infer<typeof RuntimeHealthStatusSchema>;
+
+export const RuntimeDaemonHealthSchema = z.object({
+  status: RuntimeHealthStatusSchema,
+  leader: z.boolean(),
+  checked_at: z.number().int().nonnegative(),
+  details: z.record(z.unknown()).optional(),
+});
+export type RuntimeDaemonHealth = z.infer<typeof RuntimeDaemonHealthSchema>;
+
+export const RuntimeComponentsHealthSchema = z.object({
+  checked_at: z.number().int().nonnegative(),
+  components: z.record(RuntimeHealthStatusSchema),
+});
+export type RuntimeComponentsHealth = z.infer<typeof RuntimeComponentsHealthSchema>;
+
+export const RuntimeHealthSnapshotSchema = z.object({
+  status: RuntimeHealthStatusSchema,
+  leader: z.boolean(),
+  checked_at: z.number().int().nonnegative(),
+  components: z.record(RuntimeHealthStatusSchema),
+  details: z.record(z.unknown()).optional(),
+});
+export type RuntimeHealthSnapshot = z.infer<typeof RuntimeHealthSnapshotSchema>;
+
+export function summarizeRuntimeHealthStatus(
+  components: Record<string, RuntimeHealthStatus>
+): RuntimeHealthStatus {
+  const statuses = Object.values(components);
+  if (statuses.includes("failed")) return "failed";
+  if (statuses.includes("degraded")) return "degraded";
+  return "ok";
+}

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -5,6 +5,8 @@ export const DaemonConfigSchema = z.object({
   check_interval_ms: z.number().int().positive().default(300_000), // 5 min default
   pid_file: z.string().default("pulseed.pid"),
   log_dir: z.string().default("logs"),
+  runtime_journal_v2: z.boolean().default(false),
+  runtime_root: z.string().optional(),
   log_rotation: z.object({
     max_size_mb: z.number().positive().default(10),
     max_files: z.number().int().positive().default(5),


### PR DESCRIPTION
## Summary

Introduce the Phase 0 foundation for `runtime_journal_v2`.

This change adds the durable runtime primitives needed for long-lived self-healing work, without cutting over the existing daemon execution path yet.

## What changed

- add runtime journal store primitives
  - `RuntimeJournal`
  - runtime path/schema helpers
  - `ApprovalStore`
  - `OutboxStore`
  - `RuntimeHealthStore`
- add execution coordination primitives
  - `LeaderLockManager`
  - `GoalLeaseManager`
  - `JournalBackedQueue`
  - `QueueClaimSweeper`
- wire daemon foundation initialization behind `runtime_journal_v2`
- add daemon config support for:
  - `runtime_journal_v2`
  - `runtime_root`
- extend `daemon status` output to show runtime journal configuration
- add focused tests for the new runtime foundation
- fix review findings around queue dedupe behavior and approval pending/resolve locking

## Scope

This PR is intentionally Phase 0 only.

It establishes the storage, lease, lock, queue, and health foundation, but does not yet replace the existing runtime execution flow with the journal-backed path.

## Non-goals

- no full executor cutover
- no gateway/approval/outbox end-to-end migration yet
- no public design docs update yet

## Why

PulSeed needs long-running runtime recovery with durable coordination and no duplicate execution. This PR lays the base needed for later phases:

- durable runtime state
- fenced ownership
- queue claim/renew/ack primitives
- health snapshots and recovery-oriented metadata

## Validation

- `npx vitest run src/runtime/__tests__/approval-store.test.ts src/runtime/queue/__tests__/journal-backed-queue.test.ts src/runtime/queue/__tests__/queue-claim-sweeper.test.ts src/runtime/__tests__/runtime-store-basics.test.ts src/runtime/__tests__/health-store.test.ts src/runtime/__tests__/leader-lock-manager.test.ts src/runtime/__tests__/goal-lease-manager.test.ts src/runtime/__tests__/daemon-runner.test.ts src/interface/cli/__tests__/cli-daemon-status.test.ts`
- `npx tsc -p tsconfig.json --noEmit --pretty false --incremental false --skipLibCheck true`

## Notes

- Runtime recovery gaps in the pre-existing queue/command path are tracked in #607.
