### PR TITLE
Refactor state, runtime, and prompt coordinators

### DIFF
--- a/src/base/state/state-manager-goal-write.ts
+++ b/src/base/state/state-manager-goal-write.ts
@@ -1,0 +1,88 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { acquireLock, releaseLock } from "./state-lock.js";
+import { appendWALRecord, compactWAL } from "./state-wal.js";
+import { writeSnapshot } from "./state-snapshot.js";
+import type { Goal } from "../types/goal.js";
+import type { StateWriteFence, StateWriteFenceContext } from "./state-manager.js";
+
+export interface GoalWriteCoordinatorOptions {
+  baseDir: string;
+  walEnabled: boolean;
+  loadGoal: (goalId: string) => Promise<Goal | null>;
+}
+
+export class GoalWriteCoordinator {
+  private readonly baseDir: string;
+  private readonly walEnabled: boolean;
+  private readonly loadGoal: (goalId: string) => Promise<Goal | null>;
+  private readonly writeCount = new Map<string, number>();
+  private readonly writeFences = new Map<string, StateWriteFence>();
+
+  constructor(options: GoalWriteCoordinatorOptions) {
+    this.baseDir = options.baseDir;
+    this.walEnabled = options.walEnabled;
+    this.loadGoal = options.loadGoal;
+  }
+
+  setWriteFence(goalId: string, fence: StateWriteFence): void {
+    this.writeFences.set(goalId, fence);
+  }
+
+  clearWriteFence(goalId: string): void {
+    this.writeFences.delete(goalId);
+  }
+
+  async assertWriteFence(goalId: string, op: string, data: unknown): Promise<void> {
+    const fence = this.writeFences.get(goalId);
+    if (!fence) return;
+    await fence({ goalId, op, data } satisfies StateWriteFenceContext);
+  }
+
+  async goalDir(goalId: string): Promise<string> {
+    const dir = path.join(this.baseDir, "goals", goalId);
+    try {
+      await fsp.mkdir(dir, { recursive: true });
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return dir;
+      throw err;
+    }
+    return dir;
+  }
+
+  /** Wrap a goal write with lock + WAL + snapshot cycle. */
+  async protectedWrite(
+    goalId: string,
+    op: string,
+    data: unknown,
+    writeFn: () => Promise<void>,
+  ): Promise<void> {
+    if (!this.walEnabled) {
+      await this.assertWriteFence(goalId, op, data);
+      await writeFn();
+      return;
+    }
+
+    await acquireLock(goalId, this.baseDir);
+    try {
+      await this.assertWriteFence(goalId, op, data);
+      const ts = new Date().toISOString();
+      await appendWALRecord(goalId, this.baseDir, { op, data, ts });
+      await writeFn();
+      await appendWALRecord(goalId, this.baseDir, {
+        op: "commit",
+        ref_ts: ts,
+        ts: new Date().toISOString(),
+      });
+      this.writeCount.set(goalId, (this.writeCount.get(goalId) || 0) + 1);
+      const count = this.writeCount.get(goalId)!;
+      if (count % 50 === 0) {
+        const fullGoal = await this.loadGoal(goalId);
+        if (fullGoal !== null) await writeSnapshot(goalId, this.baseDir, fullGoal);
+      }
+      if (count % 100 === 0) await compactWAL(goalId, this.baseDir);
+    } finally {
+      await releaseLock(goalId, this.baseDir);
+    }
+  }
+}

--- a/src/base/state/state-manager-wal.ts
+++ b/src/base/state/state-manager-wal.ts
@@ -1,0 +1,103 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import type { Logger } from "../../runtime/logger.js";
+import { atomicWrite } from "./state-persistence.js";
+import { replayWAL } from "./state-wal.js";
+import type { WALIntent } from "./state-wal.js";
+
+export interface StateManagerWALRecoveryOptions {
+  baseDir: string;
+  logger?: Logger;
+  listGoalIds: () => Promise<string[]>;
+}
+
+export async function recoverStateManagerWAL(
+  options: StateManagerWALRecoveryOptions,
+): Promise<void> {
+  const { baseDir, logger, listGoalIds } = options;
+  let goalIds: string[];
+  try {
+    goalIds = await listGoalIds();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw err;
+  }
+
+  for (const goalId of goalIds) {
+    const replayed = await replayWAL(goalId, baseDir, async (intent) => {
+      await replayStateManagerIntent(baseDir, intent, logger);
+    });
+    if (replayed > 0) {
+      logger?.info(`[StateManager] Replayed ${replayed} WAL entries for goal ${goalId}`);
+    }
+  }
+}
+
+/** Map a WAL intent op back to the appropriate file write. */
+export async function replayStateManagerIntent(
+  baseDir: string,
+  intent: WALIntent,
+  logger?: Logger,
+): Promise<void> {
+  const data = intent.data as Record<string, unknown>;
+  switch (intent.op) {
+    case "save_goal": {
+      const goalId = data?.id as string;
+      if (goalId) {
+        const dir = path.join(baseDir, "goals", goalId);
+        await fsp.mkdir(dir, { recursive: true });
+        await atomicWrite(path.join(dir, "goal.json"), data);
+      }
+      break;
+    }
+    case "save_observation": {
+      const goalId = data?.goal_id as string;
+      if (goalId) {
+        const dir = path.join(baseDir, "goals", goalId);
+        await fsp.mkdir(dir, { recursive: true });
+        await atomicWrite(path.join(dir, "observations.json"), data);
+      }
+      break;
+    }
+    case "append_observation": {
+      const goalId = data?.goal_id as string;
+      if (goalId) {
+        const dir = path.join(baseDir, "goals", goalId);
+        await fsp.mkdir(dir, { recursive: true });
+        await atomicWrite(path.join(dir, "observations.json"), data);
+      }
+      break;
+    }
+    case "save_gap_history":
+    case "append_gap_entry": {
+      const goalId = data?.goalId as string;
+      if (goalId) {
+        const dir = path.join(baseDir, "goals", goalId);
+        await fsp.mkdir(dir, { recursive: true });
+        await atomicWrite(path.join(dir, "gap-history.json"), data?.entries ?? data);
+      }
+      break;
+    }
+    case "save_pace_snapshot": {
+      const goalId = data?.id as string;
+      if (goalId) {
+        const dir = path.join(baseDir, "goals", goalId);
+        await fsp.mkdir(dir, { recursive: true });
+        await atomicWrite(path.join(dir, "goal.json"), data);
+      }
+      break;
+    }
+    case "write_raw": {
+      const relativePath = data?.path as string;
+      const payload = data?.payload;
+      if (relativePath && payload !== undefined) {
+        const resolved = path.resolve(baseDir, relativePath);
+        await fsp.mkdir(path.dirname(resolved), { recursive: true });
+        await atomicWrite(resolved, payload);
+      }
+      break;
+    }
+    default:
+      logger?.warn(`[StateManager] Unknown WAL intent op: ${intent.op}`);
+  }
+}

--- a/src/base/state/state-manager.ts
+++ b/src/base/state/state-manager.ts
@@ -13,10 +13,8 @@ import type { PaceSnapshot } from "../types/goal.js";
 import { LoopCheckpointSchema } from "../types/checkpoint.js";
 import type { CheckpointTrustPort } from "./checkpoint-trust-port.js";
 import { initDirs, atomicWrite, atomicRead } from "./state-persistence.js";
-import { acquireLock, releaseLock } from "./state-lock.js";
-import { appendWALRecord, replayWAL, compactWAL } from "./state-wal.js";
-import type { WALIntent } from "./state-wal.js";
-import { writeSnapshot } from "./state-snapshot.js";
+import { GoalWriteCoordinator } from "./state-manager-goal-write.js";
+import { recoverStateManagerWAL } from "./state-manager-wal.js";
 
 export { initDirs, atomicWrite, atomicRead };
 
@@ -47,13 +45,17 @@ export class StateManager {
   private readonly baseDir: string;
   private readonly logger?: Logger;
   private readonly walEnabled: boolean;
-  private writeCount: Map<string, number> = new Map();
-  private readonly writeFences: Map<string, StateWriteFence> = new Map();
+  private readonly goalWriteCoordinator: GoalWriteCoordinator;
 
   constructor(baseDir?: string, logger?: Logger, options?: { walEnabled?: boolean }) {
     this.baseDir = baseDir ?? getPulseedDirPath();
     this.logger = logger;
     this.walEnabled = options?.walEnabled ?? true;
+    this.goalWriteCoordinator = new GoalWriteCoordinator({
+      baseDir: this.baseDir,
+      walEnabled: this.walEnabled,
+      loadGoal: (goalId) => this.loadGoal(goalId),
+    });
   }
 
   /** Create required subdirectories. Must be called after construction before first use. */
@@ -69,86 +71,11 @@ export class StateManager {
    * Depends on initDirs() having been called first (to ensure goals/ exists).
    */
   private async recoverWAL(): Promise<void> {
-    let goalIds: string[];
-    try {
-      goalIds = await this.listGoalIds();
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
-      throw err;
-    }
-    for (const goalId of goalIds) {
-      const replayed = await replayWAL(goalId, this.baseDir, async (intent) => {
-        await this.replayIntent(intent);
-      });
-      if (replayed > 0) {
-        this.logger?.info(`[StateManager] Replayed ${replayed} WAL entries for goal ${goalId}`);
-      }
-    }
-  }
-
-  /** Map a WAL intent op back to the appropriate file write. */
-  private async replayIntent(intent: WALIntent): Promise<void> {
-    const data = intent.data as Record<string, unknown>;
-    switch (intent.op) {
-      case "save_goal": {
-        const goalId = data?.id as string;
-        if (goalId) {
-          const dir = path.join(this.baseDir, "goals", goalId);
-          await fsp.mkdir(dir, { recursive: true });
-          await atomicWrite(path.join(dir, "goal.json"), data);
-        }
-        break;
-      }
-      case "save_observation": {
-        const goalId = data?.goal_id as string;
-        if (goalId) {
-          const dir = path.join(this.baseDir, "goals", goalId);
-          await fsp.mkdir(dir, { recursive: true });
-          await atomicWrite(path.join(dir, "observations.json"), data);
-        }
-        break;
-      }
-      case "append_observation": {
-        const goalId = data?.goal_id as string;
-        if (goalId) {
-          const dir = path.join(this.baseDir, "goals", goalId);
-          await fsp.mkdir(dir, { recursive: true });
-          await atomicWrite(path.join(dir, "observations.json"), data);
-        }
-        break;
-      }
-      case "save_gap_history":
-      case "append_gap_entry": {
-        const goalId = data?.goalId as string;
-        if (goalId) {
-          const dir = path.join(this.baseDir, "goals", goalId);
-          await fsp.mkdir(dir, { recursive: true });
-          await atomicWrite(path.join(dir, "gap-history.json"), data?.entries ?? data);
-        }
-        break;
-      }
-      case "save_pace_snapshot": {
-        const goalId = data?.id as string;
-        if (goalId) {
-          const dir = path.join(this.baseDir, "goals", goalId);
-          await fsp.mkdir(dir, { recursive: true });
-          await atomicWrite(path.join(dir, "goal.json"), data);
-        }
-        break;
-      }
-      case "write_raw": {
-        const relativePath = data?.path as string;
-        const payload = data?.payload;
-        if (relativePath && payload !== undefined) {
-          const resolved = path.resolve(this.baseDir, relativePath);
-          await fsp.mkdir(path.dirname(resolved), { recursive: true });
-          await atomicWrite(resolved, payload);
-        }
-        break;
-      }
-      default:
-        this.logger?.warn(`[StateManager] Unknown WAL intent op: ${intent.op}`);
-    }
+    await recoverStateManagerWAL({
+      baseDir: this.baseDir,
+      logger: this.logger,
+      listGoalIds: () => this.listGoalIds(),
+    });
   }
 
   /** Returns the base directory path */
@@ -157,28 +84,19 @@ export class StateManager {
   }
 
   setWriteFence(goalId: string, fence: StateWriteFence): void {
-    this.writeFences.set(goalId, fence);
+    this.goalWriteCoordinator.setWriteFence(goalId, fence);
   }
 
   clearWriteFence(goalId: string): void {
-    this.writeFences.delete(goalId);
+    this.goalWriteCoordinator.clearWriteFence(goalId);
   }
 
   private async assertWriteFence(goalId: string, op: string, data: unknown): Promise<void> {
-    const fence = this.writeFences.get(goalId);
-    if (!fence) return;
-    await fence({ goalId, op, data });
+    await this.goalWriteCoordinator.assertWriteFence(goalId, op, data);
   }
 
   private async goalDir(goalId: string): Promise<string> {
-    const dir = path.join(this.baseDir, "goals", goalId);
-    try {
-      await fsp.mkdir(dir, { recursive: true });
-    } catch (err: unknown) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return dir;
-      throw err;
-    }
-    return dir;
+    return this.goalWriteCoordinator.goalDir(goalId);
   }
 
   // ─── Atomic Write / Read (delegated to state-persistence) ───
@@ -193,28 +111,7 @@ export class StateManager {
 
   /** Wrap a goal write with lock + WAL + snapshot cycle. */
   private async protectedWrite(goalId: string, op: string, data: unknown, writeFn: () => Promise<void>): Promise<void> {
-    if (!this.walEnabled) {
-      await this.assertWriteFence(goalId, op, data);
-      await writeFn();
-      return;
-    }
-    await acquireLock(goalId, this.baseDir);
-    try {
-      await this.assertWriteFence(goalId, op, data);
-      const ts = new Date().toISOString();
-      await appendWALRecord(goalId, this.baseDir, { op, data, ts });
-      await writeFn();
-      await appendWALRecord(goalId, this.baseDir, { op: "commit", ref_ts: ts, ts: new Date().toISOString() });
-      this.writeCount.set(goalId, (this.writeCount.get(goalId) || 0) + 1);
-      const count = this.writeCount.get(goalId)!;
-      if (count % 50 === 0) {
-        const fullGoal = await this.loadGoal(goalId);
-        if (fullGoal !== null) await writeSnapshot(goalId, this.baseDir, fullGoal);
-      }
-      if (count % 100 === 0) await compactWAL(goalId, this.baseDir);
-    } finally {
-      await releaseLock(goalId, this.baseDir);
-    }
+    await this.goalWriteCoordinator.protectedWrite(goalId, op, data, writeFn);
   }
 
   // ─── Goal CRUD ───

--- a/src/prompt/__tests__/context-assembler.test.ts
+++ b/src/prompt/__tests__/context-assembler.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { ContextAssembler } from "../context-assembler.js";
-import type { ContextAssemblerDeps } from "../context-assembler.js";
+import type { ContextAssemblerDeps, ContextAssemblerGoalState } from "../context-assembler.js";
 
-const makeGoalState = (overrides: Record<string, any> = {}) => ({
+type TestLesson = NonNullable<Awaited<ReturnType<NonNullable<ContextAssemblerDeps["memoryLifecycle"]>["selectForWorkingMemory"]>>["lessons"]>[number];
+
+const makeGoalState = (overrides: Partial<ContextAssemblerGoalState> = {}): ContextAssemblerGoalState & { id: string } => ({
   id: "goal-1",
   title: "Increase test coverage",
   description: "Get to 90% coverage",
@@ -226,7 +228,7 @@ describe("ContextAssembler", () => {
   });
 
   describe("context rot prevention — lesson stale filtering", () => {
-    const makeLesson = (overrides: Record<string, any> = {}) => ({
+    const makeLesson = (overrides: Partial<TestLesson> = {}): TestLesson => ({
       lesson: "Some lesson",
       relevance_tags: ["MEDIUM"],
       last_accessed: new Date().toISOString(),

--- a/src/prompt/context-assembler.ts
+++ b/src/prompt/context-assembler.ts
@@ -48,9 +48,78 @@ export interface AssembledContext {
   totalTokensUsed: number;
 }
 
+export interface ContextAssemblerGoalState {
+  title?: string;
+  description?: string;
+  dimensions?: GoalDimensionState[];
+  active_strategy?: {
+    hypothesis?: string;
+  };
+}
+
+interface GoalDimensionState {
+  name: string;
+  current_value: string | number | boolean | null;
+  threshold?: GoalThreshold;
+  gap?: number;
+  history?: GoalDimensionHistoryEntry[];
+}
+
+interface GoalDimensionHistoryEntry {
+  timestamp: string;
+  value: string | number | boolean | null;
+}
+
+type GoalThreshold =
+  | Dimension["threshold"]
+  | {
+      value: string | number | boolean;
+    };
+
+interface WorkingMemorySelection {
+  shortTerm: unknown[];
+  lessons: LessonEntry[];
+}
+
+interface LessonEntry {
+  lesson?: string;
+  content?: string;
+  relevance_tags?: string[];
+  last_accessed?: string;
+  access_count?: number;
+}
+
+interface KnowledgeEntry {
+  question?: string;
+  answer?: string;
+  content?: string;
+  confidence?: number;
+}
+
+interface ReflectionEntry {
+  why_it_worked_or_failed?: string;
+  what_to_do_differently?: string;
+  what_was_attempted?: string;
+}
+
+interface StrategyTemplateEntry {
+  hypothesis_pattern: string;
+  effectiveness_score: number;
+  similarity?: number;
+  score?: number;
+  created_at?: string;
+  createdAt?: string;
+}
+
+interface TaskResultEntry {
+  task_description: string;
+  outcome: string;
+  success: boolean;
+}
+
 export interface ContextAssemblerDeps {
   stateManager?: {
-    loadGoalState(goalId: string): Promise<any | null>;
+    loadGoalState(goalId: string): Promise<ContextAssemblerGoalState | null>;
   };
   memoryLifecycle?: {
     selectForWorkingMemory(
@@ -58,18 +127,18 @@ export interface ContextAssemblerDeps {
       dims: string[],
       tags: string[],
       max?: number
-    ): Promise<{ shortTerm: any[]; lessons: any[] }>;
+    ): Promise<WorkingMemorySelection>;
     selectForWorkingMemorySemantic?(
       goalId: string,
       query: string,
       dims: string[],
       tags: string[],
       max?: number
-    ): Promise<{ shortTerm: any[]; lessons: any[] }>;
+    ): Promise<WorkingMemorySelection>;
   };
   knowledgeManager?: {
-    getRelevantKnowledge?(goalId: string): Promise<any[]>;
-    loadKnowledge?(goalId: string, tags?: string[]): Promise<any[]>;
+    getRelevantKnowledge?(goalId: string): Promise<KnowledgeEntry[]>;
+    loadKnowledge?(goalId: string, tags?: string[]): Promise<KnowledgeEntry[]>;
   };
   contextProvider?: {
     buildWorkspaceContextItems?(
@@ -77,8 +146,8 @@ export interface ContextAssemblerDeps {
       dimensionName: string
     ): Promise<Array<{ label: string; content: string }>>;
   };
-  reflectionGetter?: (goalId: string, limit?: number) => Promise<any[]>;
-  strategyTemplateSearch?: (query: string, topK?: number) => Promise<any[]>;
+  reflectionGetter?: (goalId: string, limit?: number) => Promise<ReflectionEntry[]>;
+  strategyTemplateSearch?: (query: string, topK?: number) => Promise<StrategyTemplateEntry[]>;
   vectorIndex?: {
     search(
       query: string,
@@ -185,7 +254,7 @@ export class ContextAssembler {
   private async assembleSlot(
     slot: ContextSlot,
     goalId: string | undefined,
-    goalState: any,
+    goalState: ContextAssemblerGoalState | null,
     dims: string[],
     additionalContext?: Record<string, string>
   ): Promise<string> {
@@ -235,7 +304,7 @@ export class ContextAssembler {
 
   // ─── Individual slot builders ────────────────────────────────────────────────
 
-  private buildGoalDefinition(goalState: any): string {
+  private buildGoalDefinition(goalState: ContextAssemblerGoalState | null): string {
     if (!goalState) return "";
     return formatGoalContext(
       { title: goalState.title, description: goalState.description },
@@ -243,16 +312,20 @@ export class ContextAssembler {
     );
   }
 
-  private buildCurrentState(goalState: any): string {
+  private buildCurrentState(goalState: ContextAssemblerGoalState | null): string {
     if (!goalState?.dimensions?.length) return "";
-    const getThresholdTarget = (t: Dimension["threshold"]): string | number | undefined => {
+    const getThresholdTarget = (t?: GoalThreshold): string | number | undefined => {
       if (!t) return undefined;
+      if (!("type" in t)) {
+        const value = t.value;
+        return typeof value === "boolean" ? String(value) : value;
+      }
       if (t.type === "range") return `${t.low}–${t.high}`;
       if (t.type === "present") return "present";
       const v = t.value;
       return typeof v === "boolean" ? String(v) : v;
     };
-    const dims = (goalState.dimensions as Array<Dimension & { gap?: number }>).map((d) => ({
+    const dims = goalState.dimensions.map((d) => ({
       name: d.name,
       current: d.current_value,
       target: getThresholdTarget(d.threshold),
@@ -261,11 +334,11 @@ export class ContextAssembler {
     return formatCurrentState(dims);
   }
 
-  private buildDimensionHistory(goalState: any): string {
+  private buildDimensionHistory(goalState: ContextAssemblerGoalState | null): string {
     if (!goalState?.dimensions?.length) return "";
 
     const allHistory: Array<{ timestamp: string; score: number }> = [];
-    for (const dim of ((goalState.dimensions as Dimension[]) ?? [])) {
+    for (const dim of goalState.dimensions) {
       if (dim.history?.length) {
         for (const h of dim.history) {
           allHistory.push({ timestamp: h.timestamp, score: typeof h.value === "number" ? h.value : 0 });
@@ -280,8 +353,8 @@ export class ContextAssembler {
     if (!raw) return "";
 
     try {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) {
+      const parsed: unknown = JSON.parse(raw);
+      if (isTaskResultEntryArray(parsed)) {
         return formatTaskResults(parsed);
       }
     } catch {
@@ -296,7 +369,7 @@ export class ContextAssembler {
     const reflections = await this.deps.reflectionGetter(goalId, 5);
     if (!reflections?.length) return "";
     return formatReflections(
-      reflections.map((r: any) => ({
+      reflections.map((r) => ({
         what_failed: r.why_it_worked_or_failed,
         suggestion: r.what_to_do_differently,
         content: r.what_was_attempted,
@@ -316,7 +389,7 @@ export class ContextAssembler {
     if (lessons.length > budgetedMax) {
       const cutoffMs = CONTEXT_FRESHNESS_DAYS * 24 * 60 * 60 * 1000;
       const now = Date.now();
-      const fresh = lessons.filter((l: any) => {
+      const fresh = lessons.filter((l) => {
         const lastAccessed = l.last_accessed ? new Date(l.last_accessed).getTime() : 0;
         const accessCount = l.access_count ?? 0;
         const isStale = (now - lastAccessed) > cutoffMs && accessCount < 2;
@@ -329,7 +402,7 @@ export class ContextAssembler {
     }
 
     return formatLessons(
-      lessons.map((l: any) => ({
+      lessons.map((l) => ({
         importance: l.relevance_tags?.includes("HIGH")
           ? "HIGH"
           : l.relevance_tags?.includes("LOW")
@@ -343,7 +416,7 @@ export class ContextAssembler {
   private async buildKnowledge(goalId: string): Promise<string> {
     if (!this.deps.knowledgeManager && !this.deps.vectorIndex) return "";
 
-    let entries: any[] = [];
+    let entries: KnowledgeEntry[] = [];
 
     if (this.deps.knowledgeManager?.getRelevantKnowledge) {
       entries = await this.deps.knowledgeManager.getRelevantKnowledge(goalId);
@@ -358,7 +431,7 @@ export class ContextAssembler {
     return formatKnowledge(entries);
   }
 
-  private async buildStrategyTemplates(goalState: any): Promise<string> {
+  private async buildStrategyTemplates(goalState: ContextAssemblerGoalState | null): Promise<string> {
     if (!this.deps.strategyTemplateSearch) return "";
     const query = goalState?.active_strategy?.hypothesis ?? goalState?.title ?? "";
     if (!query) return "";
@@ -367,7 +440,7 @@ export class ContextAssembler {
 
     if (this.deps.vectorIndex) {
       // Vector search: apply cosine similarity threshold
-      templates = templates.filter((t: any) => {
+      templates = templates.filter((t) => {
         const sim = t.similarity ?? t.score ?? 1;
         return sim >= KNOWLEDGE_SIMILARITY_THRESHOLD;
       });
@@ -375,7 +448,7 @@ export class ContextAssembler {
       // No vector search: deprioritize templates older than 30 days
       const cutoffMs = STRATEGY_TEMPLATE_FRESHNESS_DAYS * 24 * 60 * 60 * 1000;
       const now = Date.now();
-      const fresh = templates.filter((t: any) => {
+      const fresh = templates.filter((t) => {
         const created = t.created_at ?? t.createdAt;
         if (!created) return true; // no date means keep
         return (now - new Date(created).getTime()) <= cutoffMs;
@@ -406,7 +479,7 @@ export class ContextAssembler {
 
   // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-  private async loadGoalState(goalId: string | undefined): Promise<any | null> {
+  private async loadGoalState(goalId: string | undefined): Promise<ContextAssemblerGoalState | null> {
     if (!goalId || !this.deps.stateManager) return null;
     try {
       return await this.deps.stateManager.loadGoalState(goalId);
@@ -415,10 +488,10 @@ export class ContextAssembler {
     }
   }
 
-  private extractDimensionNames(goalState: any, dimensionName?: string): string[] {
+  private extractDimensionNames(goalState: ContextAssemblerGoalState | null, dimensionName?: string): string[] {
     if (dimensionName) return [dimensionName];
     if (!goalState?.dimensions?.length) return [];
-    return ((goalState.dimensions as Dimension[]) ?? []).map((d: Dimension) => d.name);
+    return goalState.dimensions.map((d) => d.name);
   }
 
   private enforceBudget(
@@ -478,4 +551,18 @@ export class ContextAssembler {
     // Restore original slot order (by priority ascending = natural order)
     return result.sort((a, b) => a.slotDef.priority - b.slotDef.priority);
   }
+}
+
+function isTaskResultEntryArray(value: unknown): value is TaskResultEntry[] {
+  return Array.isArray(value) && value.every(isTaskResultEntry);
+}
+
+function isTaskResultEntry(value: unknown): value is TaskResultEntry {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<TaskResultEntry>;
+  return (
+    typeof candidate.task_description === "string" &&
+    typeof candidate.outcome === "string" &&
+    typeof candidate.success === "boolean"
+  );
 }

--- a/src/runtime/daemon-runner-lifecycle.ts
+++ b/src/runtime/daemon-runner-lifecycle.ts
@@ -1,0 +1,87 @@
+import type { EventServer } from "./event-server.js";
+import type { Logger } from "./logger.js";
+
+interface DaemonStatusSnapshot {
+  status: string;
+  activeGoals: string[];
+  loopCount: number;
+  startedAt: string;
+}
+
+interface DaemonStatusHeartbeatOptions {
+  eventServer: EventServer | undefined;
+  getSnapshot: () => DaemonStatusSnapshot;
+}
+
+interface ProcessShutdownCoordinatorOptions {
+  logger: Logger;
+  gracefulShutdownTimeoutMs: number;
+  onShutdown: () => void;
+  onForceStop: () => void;
+}
+
+export function startDaemonStatusHeartbeat(
+  options: DaemonStatusHeartbeatOptions
+): () => void {
+  const timer = setInterval(() => {
+    const { eventServer } = options;
+    const snapshot = options.getSnapshot();
+    if (!eventServer || snapshot.status !== "running") {
+      return;
+    }
+
+    void eventServer.broadcast?.("daemon_status", {
+      status: snapshot.status,
+      activeGoals: snapshot.activeGoals,
+      loopCount: snapshot.loopCount,
+      uptime: Date.now() - new Date(snapshot.startedAt).getTime(),
+    });
+  }, 30_000);
+
+  return () => {
+    clearInterval(timer);
+  };
+}
+
+export class ProcessShutdownCoordinator {
+  private shutdownHandler: (() => void) | null = null;
+  private forceStopTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(private readonly options: ProcessShutdownCoordinatorOptions) {}
+
+  activate(): void {
+    const shutdown = (): void => {
+      if (this.shutdownHandler === null) {
+        return;
+      }
+      if (this.forceStopTimer !== null) {
+        return;
+      }
+
+      this.options.onShutdown();
+      this.forceStopTimer = setTimeout(() => {
+        this.options.logger.warn(
+          `Graceful shutdown timeout (${this.options.gracefulShutdownTimeoutMs}ms) exceeded, forcing stop`
+        );
+        this.options.onForceStop();
+      }, this.options.gracefulShutdownTimeoutMs);
+    };
+
+    this.shutdownHandler = shutdown;
+    process.on("SIGTERM", shutdown);
+    process.on("SIGINT", shutdown);
+  }
+
+  dispose(): void {
+    if (this.forceStopTimer !== null) {
+      clearTimeout(this.forceStopTimer);
+      this.forceStopTimer = null;
+    }
+
+    if (this.shutdownHandler) {
+      process.removeListener("SIGTERM", this.shutdownHandler);
+      process.removeListener("SIGINT", this.shutdownHandler);
+      this.shutdownHandler = null;
+    }
+  }
+}

--- a/src/runtime/daemon-runner.ts
+++ b/src/runtime/daemon-runner.ts
@@ -31,6 +31,14 @@ import { QueueClaimSweeper } from "./queue/queue-claim-sweeper.js";
 import { ApprovalBroker } from "./approval-broker.js";
 import { CommandDispatcher } from "./command-dispatcher.js";
 import { EventDispatcher } from "./event-dispatcher.js";
+import {
+  RuntimeOwnershipCoordinator,
+  type RuntimeHealthComponents,
+} from "./daemon-runtime-ownership.js";
+import {
+  ProcessShutdownCoordinator,
+  startDaemonStatusHeartbeat,
+} from "./daemon-runner-lifecycle.js";
 
 // Re-exports for callers that imported these from daemon-runner
 export { generateCronEntry } from "./daemon-signals.js";
@@ -104,7 +112,6 @@ export class DaemonRunner {
   private baseDir: string;
   private logDir: string;
   private logPath: string;
-  private shutdownHandler: (() => void) | null = null;
   private eventServer: EventServer | undefined;
   private approvalFn: ((task: Record<string, unknown>) => Promise<boolean>) | undefined;
   private sleepAbortController: AbortController | null = null;
@@ -127,6 +134,8 @@ export class DaemonRunner {
   private supervisor: LoopSupervisor | null = null;
   private cronScheduleInterval: ReturnType<typeof setInterval> | null = null;
   private shutdownResolve: (() => void) | null = null;
+  private shutdownCoordinator: ProcessShutdownCoordinator | null = null;
+  private stopStatusHeartbeat: (() => void) | null = null;
   private readonly deps: DaemonDeps;
   private runtimeRoot: string | null = null;
   private approvalStore: ApprovalStore | null = null;
@@ -139,17 +148,7 @@ export class DaemonRunner {
   private approvalBroker: ApprovalBroker | null = null;
   private commandDispatcher: CommandDispatcher | null = null;
   private eventDispatcher: EventDispatcher | null = null;
-  private leaderOwnerToken: string | null = null;
-  private leaderHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
-  private runtimeHealthPhase = "disabled";
-  private runtimeHealthComponents: {
-    gateway: "ok" | "degraded";
-    queue: "ok" | "degraded";
-    leases: "ok" | "degraded";
-    approval: "ok" | "degraded";
-    outbox: "ok" | "degraded";
-    supervisor: "ok" | "degraded";
-  } | null = null;
+  private runtimeOwnership: RuntimeOwnershipCoordinator;
 
   constructor(deps: DaemonDeps) {
     this.deps = deps;
@@ -193,6 +192,15 @@ export class DaemonRunner {
     });
     this.queueClaimSweeper = new QueueClaimSweeper({
       queue: this.journalQueue,
+    });
+    this.runtimeOwnership = new RuntimeOwnershipCoordinator({
+      runtimeRoot: this.runtimeRoot,
+      logger: this.logger,
+      approvalStore: this.approvalStore,
+      outboxStore: this.outboxStore,
+      runtimeHealthStore: this.runtimeHealthStore,
+      leaderLockManager: this.leaderLockManager,
+      onLeadershipLost: (reason) => this.failRuntimeLeadership(reason),
     });
 
     // Initialize daemon state
@@ -316,44 +324,29 @@ export class DaemonRunner {
         };
       }
 
-      // Start heartbeat (every 30s)
-      const heartbeatInterval = setInterval(() => {
-        if (this.eventServer && this.state.status === "running") {
-          void this.eventServer.broadcast?.("daemon_status", {
-            status: this.state.status,
-            activeGoals: this.state.active_goals,
-            loopCount: this.state.loop_count,
-            uptime: Date.now() - new Date(this.state.started_at).getTime(),
-          });
-        }
-      }, 30_000);
+      this.stopStatusHeartbeat = startDaemonStatusHeartbeat({
+        eventServer: this.eventServer,
+        getSnapshot: () => ({
+          status: this.state.status,
+          activeGoals: this.state.active_goals,
+          loopCount: this.state.loop_count,
+          startedAt: this.state.started_at,
+        }),
+      });
 
       this.driveSystem.startWatcher((event) => this.onEventReceived(event));
 
-      // 3. Set up signal handlers for graceful shutdown
       this.shuttingDown = false;
       const shutdownTimeout = this.config.crash_recovery.graceful_shutdown_timeout_ms ?? 30_000;
-      let forceStopTimer: ReturnType<typeof setTimeout> | null = null;
-
-      const shutdown = (): void => {
-        if (this.shuttingDown) return;
-        this.shuttingDown = true;
-        this.logger.info("Shutting down gracefully...");
-        this.running = false;
-        this.state.status = "stopping";
-        this.state.interrupted_goals = [...this.state.active_goals];
-        this.shutdownResolve?.();
-        this.sleepAbortController?.abort();
-        forceStopTimer = setTimeout(() => {
-          this.logger.warn(
-            `Graceful shutdown timeout (${shutdownTimeout}ms) exceeded, forcing stop`
-          );
+      this.shutdownCoordinator = new ProcessShutdownCoordinator({
+        logger: this.logger,
+        gracefulShutdownTimeoutMs: shutdownTimeout,
+        onShutdown: () => this.beginGracefulShutdown(),
+        onForceStop: () => {
           this.running = false;
-        }, shutdownTimeout);
-      };
-      this.shutdownHandler = shutdown;
-      process.on("SIGTERM", shutdown);
-      process.on("SIGINT", shutdown);
+        },
+      });
+      this.shutdownCoordinator.activate();
 
       // 4. Restore state from previous interrupted run
       const mergedGoalIds = await this.restoreState(goalIds);
@@ -486,20 +479,11 @@ export class DaemonRunner {
           cleanupHandled = true;
         }
       } finally {
-        // Cancel the force-stop timer if it's still pending
-        if (forceStopTimer !== null) {
-          clearTimeout(forceStopTimer);
-          forceStopTimer = null;
-        }
         this.queueClaimSweeper?.stop();
-        // Remove signal handlers
-        if (this.shutdownHandler) {
-          process.removeListener("SIGTERM", this.shutdownHandler);
-          process.removeListener("SIGINT", this.shutdownHandler);
-          this.shutdownHandler = null;
-        }
-        // Stop file watcher and EventServer
-        clearInterval(heartbeatInterval);
+        this.shutdownCoordinator?.dispose();
+        this.shutdownCoordinator = null;
+        this.stopStatusHeartbeat?.();
+        this.stopStatusHeartbeat = null;
         if (this.cronScheduleInterval !== null) {
           clearInterval(this.cronScheduleInterval);
           this.cronScheduleInterval = null;
@@ -529,128 +513,21 @@ export class DaemonRunner {
   }
 
   private async initializeRuntimeFoundation(): Promise<void> {
-    await Promise.all([
-      this.approvalStore?.ensureReady(),
-      this.outboxStore?.ensureReady(),
-      this.runtimeHealthStore?.ensureReady(),
-    ]);
-
-    await this.saveRuntimeHealthSnapshot("foundation_only", {
-      gateway: "degraded",
-      queue: "degraded",
-      leases: "ok",
-      approval: "ok",
-      outbox: "ok",
-      supervisor: "degraded",
-    });
-
-    this.logger.info("Runtime journal foundation initialized", {
-      runtime_root: this.runtimeRoot,
-      queue_path: this.runtimeRoot ? path.join(this.runtimeRoot, "queue.json") : undefined,
-    });
+    await this.runtimeOwnership.initializeFoundation();
   }
 
   private async saveRuntimeHealthSnapshot(
     phase: string,
-    components: {
-      gateway: "ok" | "degraded";
-      queue: "ok" | "degraded";
-      leases: "ok" | "degraded";
-      approval: "ok" | "degraded";
-      outbox: "ok" | "degraded";
-      supervisor: "ok" | "degraded";
-    }
+    components: RuntimeHealthComponents
   ): Promise<void> {
-    this.runtimeHealthPhase = phase;
-    this.runtimeHealthComponents = components;
-    const status = Object.values(components).every((value) => value === "ok") ? "ok" : "degraded";
-    await this.runtimeHealthStore?.saveSnapshot({
-      status,
-      leader: this.leaderOwnerToken !== null,
-      checked_at: Date.now(),
-      components,
-      details: {
-        pid: process.pid,
-        runtime_journal_v2: true,
-        runtime_root: this.runtimeRoot,
-        phase,
-      },
-    });
+    await this.runtimeOwnership.saveRuntimeHealthSnapshot(phase, components);
   }
 
   private async acquireRuntimeLeadership(): Promise<void> {
-    if (!this.leaderLockManager) {
-      return;
-    }
-
-    const acquired = await this.leaderLockManager.acquire({
-      leaseMs: RUNTIME_LEADER_LEASE_MS,
-    });
-    if (!acquired) {
-      const current = await this.leaderLockManager.read();
-      throw new Error(
-        `Runtime daemon leader already active (PID ${current?.pid ?? "unknown"})`
-      );
-    }
-
-    this.leaderOwnerToken = acquired.owner_token;
-    await this.writeRuntimeHeartbeat();
-    this.leaderHeartbeatTimer = setInterval(() => {
-      void this.renewRuntimeLeadership().catch((err) => {
-        this.logger.error("Failed to renew runtime leader lock", {
-          error: err instanceof Error ? err.message : String(err),
-        });
-        this.failRuntimeLeadership(
-          err instanceof Error ? err.message : String(err)
-        );
-      });
-    }, RUNTIME_LEADER_HEARTBEAT_MS);
-    this.leaderHeartbeatTimer.unref?.();
-  }
-
-  private async renewRuntimeLeadership(): Promise<void> {
-    if (!this.leaderLockManager || !this.leaderOwnerToken) {
-      return;
-    }
-
-    const renewed = await this.leaderLockManager.renew(this.leaderOwnerToken, {
-      leaseMs: RUNTIME_LEADER_LEASE_MS,
-    });
-    if (!renewed) {
-      this.failRuntimeLeadership("Runtime leader lock was lost");
-      return;
-    }
-
-    await this.writeRuntimeHeartbeat();
-  }
-
-  private async writeRuntimeHeartbeat(): Promise<void> {
-    if (!this.runtimeHealthStore) {
-      return;
-    }
-
-    const components =
-      this.runtimeHealthComponents ??
-      {
-        gateway: "degraded" as const,
-        queue: "degraded" as const,
-        leases: "degraded" as const,
-        approval: "degraded" as const,
-        outbox: "degraded" as const,
-        supervisor: "degraded" as const,
-      };
-    const status = Object.values(components).every((value) => value === "ok") ? "ok" : "degraded";
-    await this.runtimeHealthStore.saveDaemonHealth({
-      status,
-      leader: this.leaderOwnerToken !== null,
-      checked_at: Date.now(),
-      details: {
-        pid: process.pid,
-        runtime_journal_v2: true,
-        runtime_root: this.runtimeRoot,
-        phase: this.runtimeHealthPhase,
-      },
-    });
+    await this.runtimeOwnership.acquireLeadership(
+      RUNTIME_LEADER_LEASE_MS,
+      RUNTIME_LEADER_HEARTBEAT_MS
+    );
   }
 
   private failRuntimeLeadership(reason: string): void {
@@ -671,15 +548,7 @@ export class DaemonRunner {
   }
 
   private async releaseStartupOwnership(): Promise<void> {
-    if (this.leaderHeartbeatTimer !== null) {
-      clearInterval(this.leaderHeartbeatTimer);
-      this.leaderHeartbeatTimer = null;
-    }
-    const ownerToken = this.leaderOwnerToken;
-    this.leaderOwnerToken = null;
-    if (ownerToken) {
-      await this.leaderLockManager?.release(ownerToken);
-    }
+    await this.runtimeOwnership.releaseLeadership();
   }
 
   /** Expose approvalFn for callers (e.g. cmdStart) to wire into TaskLifecycle */
@@ -981,26 +850,8 @@ export class DaemonRunner {
       }
     }
     await this.saveDaemonState();
-    if (this.leaderHeartbeatTimer !== null) {
-      clearInterval(this.leaderHeartbeatTimer);
-      this.leaderHeartbeatTimer = null;
-    }
-    const ownerToken = this.leaderOwnerToken;
-    this.leaderOwnerToken = null;
-    if (ownerToken) {
-      await this.leaderLockManager?.release(ownerToken);
-    }
-    await this.runtimeHealthStore?.saveDaemonHealth({
-      status: wasCrashed ? "failed" : "degraded",
-      leader: false,
-      checked_at: Date.now(),
-      details: {
-        pid: process.pid,
-        runtime_journal_v2: true,
-        runtime_root: this.runtimeRoot,
-        phase: this.runtimeHealthPhase,
-      },
-    });
+    await this.runtimeOwnership.releaseLeadership();
+    await this.runtimeOwnership.saveFinalHealth(wasCrashed ? "failed" : "degraded");
 
     // Write clean shutdown marker (async, atomic)
     const markerPath = path.join(this.baseDir, "shutdown-state.json");
@@ -1023,6 +874,20 @@ export class DaemonRunner {
       loop_count: this.state.loop_count,
       crash_count: this.state.crash_count,
     });
+  }
+
+  private beginGracefulShutdown(): void {
+    if (this.shuttingDown) {
+      return;
+    }
+
+    this.shuttingDown = true;
+    this.logger.info("Shutting down gracefully...");
+    this.running = false;
+    this.state.status = "stopping";
+    this.state.interrupted_goals = [...this.state.active_goals];
+    this.shutdownResolve?.();
+    this.sleepAbortController?.abort();
   }
 
   // ─── Private: Cron Scheduler ───

--- a/src/runtime/daemon-runtime-ownership.ts
+++ b/src/runtime/daemon-runtime-ownership.ts
@@ -1,0 +1,171 @@
+import * as path from "node:path";
+import type { Logger } from "./logger.js";
+import type { ApprovalStore, OutboxStore, RuntimeHealthStore } from "./store/index.js";
+import type { LeaderLockManager } from "./leader-lock-manager.js";
+
+export type RuntimeHealthComponents = Record<
+  "gateway" | "queue" | "leases" | "approval" | "outbox" | "supervisor",
+  "ok" | "degraded"
+>;
+
+interface RuntimeOwnershipDeps {
+  runtimeRoot: string | null;
+  logger: Logger;
+  approvalStore: ApprovalStore | null;
+  outboxStore: OutboxStore | null;
+  runtimeHealthStore: RuntimeHealthStore | null;
+  leaderLockManager: LeaderLockManager | null;
+  onLeadershipLost: (reason: string) => void;
+}
+
+export class RuntimeOwnershipCoordinator {
+  private leaderOwnerToken: string | null = null;
+  private leaderHeartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private runtimeHealthPhase = "disabled";
+  private runtimeHealthComponents: RuntimeHealthComponents | null = null;
+
+  constructor(private readonly deps: RuntimeOwnershipDeps) {}
+
+  async initializeFoundation(): Promise<void> {
+    await Promise.all([
+      this.deps.approvalStore?.ensureReady(),
+      this.deps.outboxStore?.ensureReady(),
+      this.deps.runtimeHealthStore?.ensureReady(),
+    ]);
+
+    await this.saveRuntimeHealthSnapshot("foundation_only", {
+      gateway: "degraded",
+      queue: "degraded",
+      leases: "ok",
+      approval: "ok",
+      outbox: "ok",
+      supervisor: "degraded",
+    });
+
+    this.deps.logger.info("Runtime journal foundation initialized", {
+      runtime_root: this.deps.runtimeRoot,
+      queue_path: this.deps.runtimeRoot ? path.join(this.deps.runtimeRoot, "queue.json") : undefined,
+    });
+  }
+
+  async saveRuntimeHealthSnapshot(
+    phase: string,
+    components: RuntimeHealthComponents
+  ): Promise<void> {
+    this.runtimeHealthPhase = phase;
+    this.runtimeHealthComponents = components;
+    const status = Object.values(components).every((value) => value === "ok") ? "ok" : "degraded";
+    await this.deps.runtimeHealthStore?.saveSnapshot({
+      status,
+      leader: this.leaderOwnerToken !== null,
+      checked_at: Date.now(),
+      components,
+      details: {
+        pid: process.pid,
+        runtime_journal_v2: true,
+        runtime_root: this.deps.runtimeRoot,
+        phase,
+      },
+    });
+  }
+
+  async acquireLeadership(leaseMs: number, heartbeatMs: number): Promise<void> {
+    if (!this.deps.leaderLockManager) {
+      return;
+    }
+
+    const acquired = await this.deps.leaderLockManager.acquire({ leaseMs });
+    if (!acquired) {
+      const current = await this.deps.leaderLockManager.read();
+      throw new Error(
+        `Runtime daemon leader already active (PID ${current?.pid ?? "unknown"})`
+      );
+    }
+
+    this.leaderOwnerToken = acquired.owner_token;
+    await this.writeRuntimeHeartbeat();
+    this.leaderHeartbeatTimer = setInterval(() => {
+      void this.renewLeadership(leaseMs).catch((err) => {
+        this.deps.logger.error("Failed to renew runtime leader lock", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        this.deps.onLeadershipLost(
+          err instanceof Error ? err.message : String(err)
+        );
+      });
+    }, heartbeatMs);
+    this.leaderHeartbeatTimer.unref?.();
+  }
+
+  async releaseLeadership(): Promise<void> {
+    if (this.leaderHeartbeatTimer !== null) {
+      clearInterval(this.leaderHeartbeatTimer);
+      this.leaderHeartbeatTimer = null;
+    }
+
+    const ownerToken = this.leaderOwnerToken;
+    this.leaderOwnerToken = null;
+    if (ownerToken) {
+      await this.deps.leaderLockManager?.release(ownerToken);
+    }
+  }
+
+  async saveFinalHealth(status: "failed" | "degraded"): Promise<void> {
+    await this.deps.runtimeHealthStore?.saveDaemonHealth({
+      status,
+      leader: false,
+      checked_at: Date.now(),
+      details: {
+        pid: process.pid,
+        runtime_journal_v2: true,
+        runtime_root: this.deps.runtimeRoot,
+        phase: this.runtimeHealthPhase,
+      },
+    });
+  }
+
+  private async renewLeadership(leaseMs: number): Promise<void> {
+    if (!this.deps.leaderLockManager || !this.leaderOwnerToken) {
+      return;
+    }
+
+    const renewed = await this.deps.leaderLockManager.renew(this.leaderOwnerToken, {
+      leaseMs,
+    });
+    if (!renewed) {
+      this.deps.onLeadershipLost("Runtime leader lock was lost");
+      return;
+    }
+
+    await this.writeRuntimeHeartbeat();
+  }
+
+  private async writeRuntimeHeartbeat(): Promise<void> {
+    if (!this.deps.runtimeHealthStore) {
+      return;
+    }
+
+    const components =
+      this.runtimeHealthComponents ??
+      {
+        gateway: "degraded" as const,
+        queue: "degraded" as const,
+        leases: "degraded" as const,
+        approval: "degraded" as const,
+        outbox: "degraded" as const,
+        supervisor: "degraded" as const,
+      };
+    const status = Object.values(components).every((value) => value === "ok") ? "ok" : "degraded";
+    await this.deps.runtimeHealthStore.saveDaemonHealth({
+      status,
+      leader: this.leaderOwnerToken !== null,
+      checked_at: Date.now(),
+      details: {
+        pid: process.pid,
+        runtime_journal_v2: true,
+        runtime_root: this.deps.runtimeRoot,
+        phase: this.runtimeHealthPhase,
+      },
+    });
+  }
+}

--- a/src/runtime/event-server-snapshot-reader.ts
+++ b/src/runtime/event-server-snapshot-reader.ts
@@ -1,0 +1,111 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import type { ApprovalRequiredEvent } from "./approval-broker.js";
+import type { OutboxStore } from "./store/index.js";
+
+type ActiveWorkersProvider = () =>
+  | Array<Record<string, unknown>>
+  | Promise<Array<Record<string, unknown>>>;
+
+export interface EventServerSnapshotData {
+  daemon: Record<string, unknown> | null;
+  goals: Array<{ id: string; title: string; status: string; loop_status: string }>;
+  approvals: ApprovalRequiredEvent[];
+  active_workers: Array<Record<string, unknown>>;
+  last_outbox_seq: number;
+}
+
+export class EventServerSnapshotReader {
+  constructor(private readonly eventsDir: string) {}
+
+  async buildSnapshot(
+    approvalEvents: ApprovalRequiredEvent[],
+    outboxStore?: OutboxStore,
+    activeWorkersProvider?: ActiveWorkersProvider
+  ): Promise<EventServerSnapshotData> {
+    const [daemon, goals, latestOutbox, activeWorkers] = await Promise.all([
+      this.readDaemonState(),
+      this.readGoalSummaries(),
+      outboxStore?.loadLatest() ?? Promise.resolve(null),
+      activeWorkersProvider?.() ?? Promise.resolve([]),
+    ]);
+
+    return {
+      daemon,
+      goals,
+      approvals: approvalEvents,
+      active_workers: activeWorkers,
+      last_outbox_seq: latestOutbox?.seq ?? 0,
+    };
+  }
+
+  async readDaemonStateRaw(): Promise<string | null> {
+    const statePath = path.join(this.eventsDir.replace("/events", ""), "daemon-state.json");
+    try {
+      return await fsp.readFile(statePath, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  async readDaemonState(): Promise<Record<string, unknown> | null> {
+    const raw = await this.readDaemonStateRaw();
+    if (raw === null) return null;
+    try {
+      return JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  async readGoalSummaries(): Promise<Array<{ id: string; title: string; status: string; loop_status: string }>> {
+    const goalsDir = path.join(path.dirname(this.eventsDir), "goals");
+    let entries: string[];
+    try {
+      entries = await fsp.readdir(goalsDir);
+    } catch {
+      return [];
+    }
+
+    const goals: Array<{ id: string; title: string; status: string; loop_status: string }> = [];
+    for (const entry of entries) {
+      const goalFile = path.join(goalsDir, entry, "goal.json");
+      try {
+        const content = await fsp.readFile(goalFile, "utf-8");
+        const raw = JSON.parse(content) as Record<string, unknown>;
+        goals.push({
+          id: String(raw["id"] ?? entry),
+          title: String(raw["title"] ?? ""),
+          status: String(raw["status"] ?? "active"),
+          loop_status: String(raw["loop_status"] ?? "idle"),
+        });
+      } catch {
+        // Skip unreadable entries.
+      }
+    }
+    return goals;
+  }
+
+  async readGoalDetail(goalId: string): Promise<Record<string, unknown> | null> {
+    const goalFile = path.join(path.dirname(this.eventsDir), "goals", goalId, "goal.json");
+    let goalRaw: Record<string, unknown>;
+    try {
+      const content = await fsp.readFile(goalFile, "utf-8");
+      goalRaw = JSON.parse(content) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+
+    const gapFile = path.join(path.dirname(this.eventsDir), "goals", goalId, "gap-history.json");
+    let currentGap: unknown = null;
+    try {
+      const gapContent = await fsp.readFile(gapFile, "utf-8");
+      const gapHistory = JSON.parse(gapContent) as unknown[];
+      currentGap = gapHistory.at(-1) ?? null;
+    } catch {
+      // Gap file may not exist.
+    }
+
+    return { ...goalRaw, current_gap: currentGap };
+  }
+}

--- a/src/runtime/event-server-sse.ts
+++ b/src/runtime/event-server-sse.ts
@@ -1,0 +1,181 @@
+import * as http from "node:http";
+import type { ApprovalBroker } from "./approval-broker.js";
+import type { Logger } from "./logger.js";
+import type { OutboxRecord, OutboxStore } from "./store/index.js";
+
+export class EventServerSseManager {
+  private readonly sseClients = new Set<http.ServerResponse>();
+  private eventIdCounter = 0;
+  private broadcastChain: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly logger?: Logger,
+    private approvalBroker?: ApprovalBroker,
+    private outboxStore?: OutboxStore
+  ) {}
+
+  setApprovalBroker(broker: ApprovalBroker): void {
+    this.approvalBroker = broker;
+  }
+
+  setOutboxStore(store: OutboxStore): void {
+    this.outboxStore = store;
+  }
+
+  closeAllClients(): void {
+    for (const client of this.sseClients) {
+      try {
+        client.end();
+      } catch {
+        // ignore
+      }
+    }
+    this.sseClients.clear();
+  }
+
+  async broadcast(eventType: string, data: unknown): Promise<void> {
+    await this.enqueueBroadcast(async () => {
+      let outboxRecord: OutboxRecord | null = null;
+      if (this.outboxStore) {
+        outboxRecord = await this.outboxStore.append(this.toOutboxInput(eventType, data));
+      }
+
+      const id = outboxRecord ? String(outboxRecord.seq) : undefined;
+      for (const client of this.sseClients) {
+        try {
+          this.writeSseEvent(client, eventType, data, id);
+        } catch {
+          this.sseClients.delete(client);
+        }
+      }
+    }).catch((err) => {
+      this.logger?.error(`EventServer: broadcast failed for ${eventType}: ${String(err)}`);
+    });
+  }
+
+  async handleStream(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    requestUrl: URL
+  ): Promise<void> {
+    const afterSeq = this.resolveReplayCursor(
+      requestUrl.searchParams.get("after"),
+      req.headers["last-event-id"]
+    );
+
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "Access-Control-Allow-Origin": "*",
+    });
+    res.write(`event: connected\ndata: ${JSON.stringify({ timestamp: new Date().toISOString() })}\n\n`);
+
+    await this.enqueueBroadcast(async () => {
+      const pendingApprovals = this.approvalBroker?.getPendingApprovalEvents() ?? [];
+      const pendingApprovalIds = new Set(pendingApprovals.map((pending) => pending.requestId));
+      const replayedApprovals = await this.replayOutbox(res, afterSeq, pendingApprovalIds);
+      for (const pending of pendingApprovals) {
+        if (replayedApprovals.has(pending.requestId)) continue;
+        this.writeSseEvent(res, "approval_required", pending);
+      }
+      this.sseClients.add(res);
+    }).catch((err) => {
+      this.logger?.error(`EventServer: stream replay failed: ${String(err)}`);
+      try {
+        res.end();
+      } catch {
+        // ignore
+      }
+    });
+
+    req.on("close", () => {
+      this.sseClients.delete(res);
+    });
+    const keepAlive = setInterval(() => {
+      try {
+        res.write(": keepalive\n\n");
+      } catch {
+        clearInterval(keepAlive);
+        this.sseClients.delete(res);
+      }
+    }, 30_000);
+    req.on("close", () => clearInterval(keepAlive));
+  }
+
+  private resolveReplayCursor(
+    queryAfter: string | null,
+    lastEventIdHeader: string | string[] | undefined
+  ): number {
+    const headerValue = Array.isArray(lastEventIdHeader) ? lastEventIdHeader[0] : lastEventIdHeader;
+    return Math.max(this.parseReplayCursorValue(queryAfter), this.parseReplayCursorValue(headerValue));
+  }
+
+  private parseReplayCursorValue(value: string | null | undefined): number {
+    if (!value) return 0;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  }
+
+  private async replayOutbox(
+    res: http.ServerResponse,
+    afterSeq: number,
+    pendingApprovalIds: ReadonlySet<string>
+  ): Promise<Set<string>> {
+    const replayedApprovals = new Set<string>();
+    if (!this.outboxStore) return replayedApprovals;
+
+    const records = await this.outboxStore.list(afterSeq);
+    for (const record of records) {
+      if (record.event_type === "approval_required" && isRecord(record.payload)) {
+        const requestId = record.payload["requestId"];
+        if (typeof requestId === "string") {
+          if (pendingApprovalIds.has(requestId)) {
+            continue;
+          }
+          replayedApprovals.add(requestId);
+        }
+      }
+      this.writeSseEvent(res, record.event_type, record.payload, String(record.seq));
+    }
+    return replayedApprovals;
+  }
+
+  private toOutboxInput(eventType: string, data: unknown): Omit<OutboxRecord, "seq"> {
+    const record: Omit<OutboxRecord, "seq"> = {
+      event_type: eventType,
+      created_at: Date.now(),
+      payload: data,
+    };
+
+    if (isRecord(data)) {
+      const goalId = data["goalId"] ?? data["goal_id"];
+      const correlationId =
+        data["correlationId"] ?? data["correlation_id"] ?? data["requestId"] ?? data["request_id"];
+      if (typeof goalId === "string") record.goal_id = goalId;
+      if (typeof correlationId === "string") record.correlation_id = correlationId;
+    }
+
+    return record;
+  }
+
+  private enqueueBroadcast<T>(operation: () => Promise<T>): Promise<T> {
+    const run = this.broadcastChain.then(operation, operation);
+    this.broadcastChain = run.then(() => undefined, () => undefined);
+    return run;
+  }
+
+  private writeSseEvent(
+    res: http.ServerResponse,
+    eventType: string,
+    data: unknown,
+    id?: string
+  ): void {
+    const eventId = id ?? String(++this.eventIdCounter);
+    res.write(`id: ${eventId}\nevent: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/runtime/event-server.ts
+++ b/src/runtime/event-server.ts
@@ -14,6 +14,8 @@ import { findAvailablePort, DEFAULT_PORT, MAX_PORT_ATTEMPTS } from "./port-utils
 import { createEnvelope, type Envelope } from "./types/envelope.js";
 import type { ApprovalBroker, ApprovalRequiredEvent } from "./approval-broker.js";
 import type { OutboxStore, OutboxRecord } from "./store/index.js";
+import { EventServerSnapshotReader } from "./event-server-snapshot-reader.js";
+import { EventServerSseManager } from "./event-server-sse.js";
 
 export interface EventServerConfig {
   host?: string; // default: "127.0.0.1" (localhost only!)
@@ -48,15 +50,14 @@ export class EventServer {
   private readonly logger?: Logger;
   private readonly stateManager?: StateManager;
   private readonly triggerMapper?: TriggerMapper;
+  private readonly snapshotReader: EventServerSnapshotReader;
+  private readonly sseManager: EventServerSseManager;
   private triggerMappingsCache: TriggerMappingsConfig | null = null;
-  private sseClients: Set<http.ServerResponse> = new Set();
-  private eventIdCounter = 0;
   private approvalQueue: Map<string, { resolve: (approved: boolean) => void; timer: ReturnType<typeof setTimeout> }> = new Map();
   private approvalBroker?: ApprovalBroker;
   private outboxStore?: OutboxStore;
   private envelopeHook?: (eventData: Record<string, unknown>) => void | Promise<void>;
   private commandEnvelopeHook?: (envelope: Envelope) => void | Promise<void>;
-  private broadcastChain: Promise<void> = Promise.resolve();
   private activeWorkersProvider?: ActiveWorkersProvider;
 
   constructor(driveSystem: DriveSystem, config?: EventServerConfig, logger?: Logger) {
@@ -70,6 +71,8 @@ export class EventServer {
     this.triggerMapper = config?.triggerMapper;
     this.approvalBroker = config?.approvalBroker;
     this.outboxStore = config?.outboxStore;
+    this.snapshotReader = new EventServerSnapshotReader(this.eventsDir);
+    this.sseManager = new EventServerSseManager(this.logger, this.approvalBroker, this.outboxStore);
   }
 
   /** Start HTTP server, auto-retrying on EADDRINUSE up to MAX_PORT_ATTEMPTS times */
@@ -120,11 +123,7 @@ export class EventServer {
   async stop(): Promise<void> {
     this.stopFileWatcher();
     await this.approvalBroker?.stop();
-    // Close all SSE connections
-    for (const client of this.sseClients) {
-      try { client.end(); } catch { /* ignore */ }
-    }
-    this.sseClients.clear();
+    this.sseManager.closeAllClients();
     return new Promise((resolve) => {
       if (!this.server) {
         resolve();
@@ -237,23 +236,7 @@ export class EventServer {
 
   /** Broadcast an SSE event to all connected clients */
   async broadcast(eventType: string, data: unknown): Promise<void> {
-    await this.enqueueBroadcast(async () => {
-      let outboxRecord: OutboxRecord | null = null;
-      if (this.outboxStore) {
-        outboxRecord = await this.outboxStore.append(this.toOutboxInput(eventType, data));
-      }
-
-      const id = outboxRecord ? String(outboxRecord.seq) : undefined;
-      for (const client of this.sseClients) {
-        try {
-          this.writeSseEvent(client, eventType, data, id);
-        } catch {
-          this.sseClients.delete(client);
-        }
-      }
-    }).catch((err) => {
-      this.logger?.error(`EventServer: broadcast failed for ${eventType}: ${String(err)}`);
-    });
+    await this.sseManager.broadcast(eventType, data);
   }
 
   /** Request human approval and wait for response (5 min timeout) */
@@ -300,10 +283,12 @@ export class EventServer {
 
   setApprovalBroker(broker: ApprovalBroker): void {
     this.approvalBroker = broker;
+    this.sseManager.setApprovalBroker(broker);
   }
 
   setOutboxStore(store: OutboxStore): void {
     this.outboxStore = store;
+    this.sseManager.setOutboxStore(store);
   }
 
   setActiveWorkersProvider(provider: ActiveWorkersProvider): void {
@@ -360,12 +345,11 @@ export class EventServer {
     // GET /daemon/status
     if (req.method === "GET" && urlPath === "/daemon/status") {
       void (async () => {
-        const statePath = path.join(this.eventsDir.replace("/events", ""), "daemon-state.json");
-        try {
-          const raw = await fsp.readFile(statePath, "utf-8");
+        const raw = await this.snapshotReader.readDaemonStateRaw();
+        if (raw !== null) {
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(raw);
-        } catch {
+        } else {
           res.writeHead(404, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "daemon state not found" }));
         }
@@ -625,7 +609,7 @@ export class EventServer {
 
   private async handleGetGoals(res: http.ServerResponse): Promise<void> {
     try {
-      const goals = await this.readGoalSummaries();
+      const goals = await this.snapshotReader.readGoalSummaries();
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(goals));
     } catch (err) {
@@ -636,29 +620,14 @@ export class EventServer {
 
   private async handleGetGoalById(res: http.ServerResponse, goalId: string): Promise<void> {
     try {
-      const goalFile = path.join(path.dirname(this.eventsDir), "goals", goalId, "goal.json");
-      let goalRaw: Record<string, unknown>;
-      try {
-        const content = await fsp.readFile(goalFile, "utf-8");
-        goalRaw = JSON.parse(content) as Record<string, unknown>;
-      } catch {
+      const goal = await this.snapshotReader.readGoalDetail(goalId);
+      if (goal === null) {
         res.writeHead(404, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Goal not found" }));
         return;
       }
-
-      const gapFile = path.join(path.dirname(this.eventsDir), "goals", goalId, "gap-history.json");
-      let currentGap: unknown = null;
-      try {
-        const gapContent = await fsp.readFile(gapFile, "utf-8");
-        const gapHistory = JSON.parse(gapContent) as unknown[];
-        currentGap = gapHistory.at(-1) ?? null;
-      } catch {
-        // Gap file may not exist
-      }
-
       res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ...goalRaw, current_gap: currentGap }));
+      res.end(JSON.stringify(goal));
     } catch (err) {
       res.writeHead(500, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Internal error", details: String(err) }));
@@ -703,49 +672,7 @@ export class EventServer {
     res: http.ServerResponse,
     requestUrl: URL
   ): Promise<void> {
-    const afterSeq = this.resolveReplayCursor(
-      requestUrl.searchParams.get("after"),
-      req.headers["last-event-id"]
-    );
-
-    res.writeHead(200, {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-      "Access-Control-Allow-Origin": "*",
-    });
-    res.write(`event: connected\ndata: ${JSON.stringify({ timestamp: new Date().toISOString() })}\n\n`);
-
-    await this.enqueueBroadcast(async () => {
-      const pendingApprovals = this.approvalBroker?.getPendingApprovalEvents() ?? [];
-      const pendingApprovalIds = new Set(pendingApprovals.map((pending) => pending.requestId));
-      const replayedApprovals = await this.replayOutbox(res, afterSeq, pendingApprovalIds);
-      for (const pending of pendingApprovals) {
-        if (replayedApprovals.has(pending.requestId)) continue;
-        this.writeSseEvent(res, "approval_required", pending);
-      }
-      this.sseClients.add(res);
-    }).catch((err) => {
-      this.logger?.error(`EventServer: stream replay failed: ${String(err)}`);
-      try {
-        res.end();
-      } catch {
-        // ignore
-      }
-    });
-
-    req.on("close", () => {
-      this.sseClients.delete(res);
-    });
-    const keepAlive = setInterval(() => {
-      try {
-        res.write(": keepalive\n\n");
-      } catch {
-        clearInterval(keepAlive);
-        this.sseClients.delete(res);
-      }
-    }, 30_000);
-    req.on("close", () => clearInterval(keepAlive));
+    await this.sseManager.handleStream(req, res, requestUrl);
   }
 
   private async dispatchCommandEnvelope(input: {
@@ -770,134 +697,12 @@ export class EventServer {
   }
 
   private async buildSnapshot(): Promise<EventServerSnapshot> {
-    const [daemon, goals, latestOutbox, activeWorkers] = await Promise.all([
-      this.readDaemonState(),
-      this.readGoalSummaries(),
-      this.outboxStore?.loadLatest() ?? Promise.resolve(null),
-      this.activeWorkersProvider?.() ?? Promise.resolve([]),
-    ]);
-
-    return {
-      daemon,
-      goals,
-      approvals: this.approvalBroker?.getPendingApprovalEvents() ?? [],
-      active_workers: activeWorkers,
-      last_outbox_seq: latestOutbox?.seq ?? 0,
-    };
+    return this.snapshotReader.buildSnapshot(
+      this.approvalBroker?.getPendingApprovalEvents() ?? [],
+      this.outboxStore,
+      this.activeWorkersProvider
+    );
   }
-
-  private async readDaemonState(): Promise<Record<string, unknown> | null> {
-    const statePath = path.join(this.eventsDir.replace("/events", ""), "daemon-state.json");
-    try {
-      const raw = await fsp.readFile(statePath, "utf-8");
-      return JSON.parse(raw) as Record<string, unknown>;
-    } catch {
-      return null;
-    }
-  }
-
-  private async readGoalSummaries(): Promise<Array<{ id: string; title: string; status: string; loop_status: string }>> {
-    const goalsDir = path.join(path.dirname(this.eventsDir), "goals");
-    let entries: string[];
-    try {
-      entries = await fsp.readdir(goalsDir);
-    } catch {
-      return [];
-    }
-
-    const goals: Array<{ id: string; title: string; status: string; loop_status: string }> = [];
-    for (const entry of entries) {
-      const goalFile = path.join(goalsDir, entry, "goal.json");
-      try {
-        const content = await fsp.readFile(goalFile, "utf-8");
-        const raw = JSON.parse(content) as Record<string, unknown>;
-        goals.push({
-          id: String(raw["id"] ?? entry),
-          title: String(raw["title"] ?? ""),
-          status: String(raw["status"] ?? "active"),
-          loop_status: String(raw["loop_status"] ?? "idle"),
-        });
-      } catch {
-        // Skip unreadable entries
-      }
-    }
-    return goals;
-  }
-
-  private resolveReplayCursor(
-    queryAfter: string | null,
-    lastEventIdHeader: string | string[] | undefined
-  ): number {
-    const headerValue = Array.isArray(lastEventIdHeader) ? lastEventIdHeader[0] : lastEventIdHeader;
-    return Math.max(this.parseReplayCursorValue(queryAfter), this.parseReplayCursorValue(headerValue));
-  }
-
-  private parseReplayCursorValue(value: string | null | undefined): number {
-    if (!value) return 0;
-    const parsed = Number.parseInt(value, 10);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-  }
-
-  private async replayOutbox(
-    res: http.ServerResponse,
-    afterSeq: number,
-    pendingApprovalIds: ReadonlySet<string>
-  ): Promise<Set<string>> {
-    const replayedApprovals = new Set<string>();
-    if (!this.outboxStore) return replayedApprovals;
-
-    const records = await this.outboxStore.list(afterSeq);
-    for (const record of records) {
-      if (record.event_type === "approval_required" && isRecord(record.payload)) {
-        const requestId = record.payload["requestId"];
-        if (typeof requestId === "string") {
-          if (pendingApprovalIds.has(requestId)) {
-            continue;
-          }
-          replayedApprovals.add(requestId);
-        }
-      }
-      this.writeSseEvent(res, record.event_type, record.payload, String(record.seq));
-    }
-    return replayedApprovals;
-  }
-
-  private toOutboxInput(eventType: string, data: unknown): Omit<OutboxRecord, "seq"> {
-    const record: Omit<OutboxRecord, "seq"> = {
-      event_type: eventType,
-      created_at: Date.now(),
-      payload: data,
-    };
-
-    if (isRecord(data)) {
-      const goalId = data["goalId"] ?? data["goal_id"];
-      const correlationId = data["correlationId"] ?? data["correlation_id"] ?? data["requestId"] ?? data["request_id"];
-      if (typeof goalId === "string") record.goal_id = goalId;
-      if (typeof correlationId === "string") record.correlation_id = correlationId;
-    }
-
-    return record;
-  }
-
-  private enqueueBroadcast<T>(operation: () => Promise<T>): Promise<T> {
-    const run = this.broadcastChain.then(operation, operation);
-    this.broadcastChain = run.then(() => undefined, () => undefined);
-    return run;
-  }
-
-  private writeSseEvent(
-    res: http.ServerResponse,
-    eventType: string,
-    data: unknown,
-    id?: string
-  ): void {
-    const eventId = id ?? String(++this.eventIdCounter);
-    res.write(`id: ${eventId}\nevent: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`);
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
 }
 
 /** Read the full request body as a string (max 1 MB). */


### PR DESCRIPTION
## Summary
- extract goal-scoped write orchestration and WAL recovery out of `StateManager`
- extract runtime ownership and lifecycle coordination out of `DaemonRunner`
- extract snapshot reading and SSE handling out of `EventServer`
- tighten `ContextAssembler` type boundaries and remove broad `any` plumbing
- advance issue #616, #617, and #618 in the same refactor batch

## Testing
- `npm run typecheck`
- `npm exec vitest run src/base/state/__tests__/state-manager-wal.test.ts src/base/state/__tests__/state-manager.test.ts src/runtime/__tests__/daemon-runner.test.ts src/runtime/__tests__/daemon-runner-shutdown.test.ts src/runtime/__tests__/daemon-runner-gateway.test.ts src/runtime/__tests__/event-server.test.ts src/runtime/__tests__/event-file-watcher.test.ts src/runtime/__tests__/event-server-approval.test.ts src/prompt/__tests__/context-assembler.test.ts src/prompt/__tests__/gateway-integration.test.ts src/prompt/__tests__/gateway.test.ts`
