### PR TITLE
Reduce repeated daemon cycle schedule lookups

### DIFF
--- a/src/platform/drive/__tests__/drive-system.test.ts
+++ b/src/platform/drive/__tests__/drive-system.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
@@ -161,6 +161,26 @@ describe("DriveSystem", () => {
       const goalId = "nonexistent-goal";
       // No goal stored, no schedule => schedule is due => true
       expect(await driveSystem.shouldActivate(goalId)).toBe(true);
+    });
+
+    it("builds an activation snapshot with a single schedule read", async () => {
+      const goalId = randomUUID();
+      const goal = makeGoal({ id: goalId, status: "active" });
+      await stateManager.saveGoal(goal);
+
+      const futureTime = new Date(Date.now() + 10 * 60 * 60 * 1000).toISOString();
+      const schedule = driveSystem.createDefaultSchedule(goalId, 10);
+      await driveSystem.updateSchedule(goalId, { ...schedule, next_check_at: futureTime });
+
+      const getScheduleSpy = vi.spyOn(driveSystem, "getSchedule");
+
+      const snapshot = await driveSystem.getGoalActivationSnapshot(goalId);
+
+      expect(snapshot.goalId).toBe(goalId);
+      expect(snapshot.shouldActivate).toBe(false);
+      expect(snapshot.schedule?.goal_id).toBe(goalId);
+      expect(getScheduleSpy).toHaveBeenCalledTimes(1);
+      expect(getScheduleSpy).toHaveBeenCalledWith(goalId);
     });
   });
 

--- a/src/platform/drive/drive-system.ts
+++ b/src/platform/drive/drive-system.ts
@@ -8,6 +8,12 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import type { Logger } from "../../runtime/logger.js";
 import { writeJsonFileAtomic } from "../../base/utils/json-io.js";
 
+export interface GoalActivationSnapshot {
+  goalId: string;
+  shouldActivate: boolean;
+  schedule: GoalSchedule | null;
+}
+
 /**
  * DriveSystem handles lightweight activation checks (no LLM calls), event queue
  * processing, and goal schedule management.
@@ -56,6 +62,53 @@ export class DriveSystem {
 
   // ─── Activation Check ───
 
+  private isTerminalGoalStatus(status: string | null | undefined): boolean {
+    return status === "completed"
+      || status === "cancelled"
+      || status === "archived"
+      || status === "abandoned";
+  }
+
+  private isScheduleDueForSnapshot(schedule: GoalSchedule | null): boolean {
+    if (schedule === null) {
+      return true;
+    }
+    return new Date(schedule.next_check_at).getTime() <= Date.now();
+  }
+
+  async getGoalActivationSnapshot(goalId: string): Promise<GoalActivationSnapshot> {
+    const goal = await this.stateManager.loadGoal(goalId);
+    const schedule = await this.getSchedule(goalId);
+
+    if (this.isTerminalGoalStatus(goal?.status)) {
+      return {
+        goalId,
+        shouldActivate: false,
+        schedule,
+      };
+    }
+
+    const events = await this.readEventQueue();
+    if (events.length > 0) {
+      const hasGoalEvent = events.some(
+        (e) => e.data["goal_id"] === goalId || e.data["target_goal_id"] === goalId
+      );
+      if (hasGoalEvent) {
+        return {
+          goalId,
+          shouldActivate: true,
+          schedule,
+        };
+      }
+    }
+
+    return {
+      goalId,
+      shouldActivate: this.isScheduleDueForSnapshot(schedule),
+      schedule,
+    };
+  }
+
   /**
    * Lightweight check (no LLM). Returns true if any condition is met:
    * 1. Event queue has unprocessed events for this goal
@@ -63,36 +116,7 @@ export class DriveSystem {
    * 3. Goal is not in a terminal status ("completed", "cancelled", "archived")
    */
   async shouldActivate(goalId: string): Promise<boolean> {
-    // Check goal status — terminal statuses suppress activation
-    const goal = await this.stateManager.loadGoal(goalId);
-    if (goal !== null) {
-      if (
-        goal.status === "completed" ||
-        goal.status === "cancelled" ||
-        goal.status === "archived" ||
-        goal.status === "abandoned"
-      ) {
-        return false;
-      }
-    }
-
-    // Check event queue for events targeting this goal
-    const events = await this.readEventQueue();
-    if (events.length > 0) {
-      const hasGoalEvent = events.some(
-        (e) => e.data["goal_id"] === goalId || e.data["target_goal_id"] === goalId
-      );
-      if (hasGoalEvent) {
-        return true;
-      }
-    }
-
-    // Check if schedule is due
-    if (await this.isScheduleDue(goalId)) {
-      return true;
-    }
-
-    return false;
+    return (await this.getGoalActivationSnapshot(goalId)).shouldActivate;
   }
 
   // ─── Event Queue ───

--- a/src/runtime/__tests__/daemon-runner.test.ts
+++ b/src/runtime/__tests__/daemon-runner.test.ts
@@ -6,6 +6,7 @@ import { PIDManager } from "../pid-manager.js";
 import { Logger } from "../logger.js";
 import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
 import type { DaemonDeps } from "../daemon-runner.js";
+import type { GoalActivationSnapshot } from "../../platform/drive/drive-system.js";
 import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
 import { JournalBackedQueue } from "../queue/journal-backed-queue.js";
 import { GoalLeaseManager } from "../goal-lease-manager.js";
@@ -87,6 +88,11 @@ function makeDeps(tmpDir: string, overrides: Partial<DaemonDeps> = {}): DaemonDe
   };
 
   const mockDriveSystem = {
+    getGoalActivationSnapshot: vi.fn(async (goalId: string): Promise<GoalActivationSnapshot> => ({
+      goalId,
+      shouldActivate: false,
+      schedule: null,
+    })),
     shouldActivate: vi.fn().mockReturnValue(false),
     getSchedule: vi.fn().mockResolvedValue(null),
     prioritizeGoals: vi.fn().mockImplementation((ids: string[]) => ids),
@@ -439,6 +445,73 @@ describe("DaemonRunner durable runtime", () => {
 
     await expect(daemon.start(["goal-1"])).rejects.toThrow();
     expect(fs.existsSync(path.join(tmpDir, "pulseed.pid"))).toBe(false);
+  });
+
+  it("reuses a cycle-local schedule snapshot for activation ordering and adaptive sleep", async () => {
+    const getGoalActivationSnapshot = vi.fn(async (goalId: string): Promise<GoalActivationSnapshot> => {
+      if (goalId === "goal-soon") {
+        return {
+          goalId,
+          shouldActivate: true,
+          schedule: {
+            goal_id: goalId,
+            next_check_at: new Date("2026-01-01T00:00:00.000Z").toISOString(),
+            check_interval_hours: 1,
+            last_triggered_at: null,
+            consecutive_actions: 0,
+            cooldown_until: null,
+            current_interval_hours: 1,
+            last_gap_score: 2,
+          } as GoalActivationSnapshot["schedule"],
+        };
+      }
+
+      return {
+        goalId,
+        shouldActivate: true,
+        schedule: {
+          goal_id: goalId,
+          next_check_at: new Date("2026-01-02T00:00:00.000Z").toISOString(),
+          check_interval_hours: 1,
+          last_triggered_at: null,
+          consecutive_actions: 0,
+          cooldown_until: null,
+          current_interval_hours: 1,
+          last_gap_score: 7,
+        } as GoalActivationSnapshot["schedule"],
+      };
+    });
+    const prioritizeGoals = vi.fn((goalIds: string[], scores: Map<string, number>) =>
+      [...goalIds].sort((left, right) => (scores.get(right) ?? 0) - (scores.get(left) ?? 0))
+    );
+    const deps = makeDeps(tmpDir, {
+      driveSystem: {
+        getGoalActivationSnapshot,
+        shouldActivate: vi.fn().mockResolvedValue(true),
+        getSchedule: vi.fn(() => {
+          throw new Error("getSchedule should not be called when cycle snapshots are provided");
+        }),
+        prioritizeGoals,
+        startWatcher: vi.fn(),
+        stopWatcher: vi.fn(),
+        writeEvent: vi.fn().mockResolvedValue(undefined),
+      } as unknown as DaemonDeps["driveSystem"],
+      config: {
+        check_interval_ms: 50,
+      },
+    });
+    const daemon = new DaemonRunner(deps);
+
+    const snapshot = await (daemon as any).collectGoalCycleSnapshot(["goal-later", "goal-soon"]);
+    const activeGoals = await (daemon as any).determineActiveGoals(["goal-later", "goal-soon"], snapshot);
+    const maxGapScore = await (daemon as any).getMaxGapScore(["goal-later", "goal-soon"], snapshot);
+
+    expect(activeGoals).toEqual(["goal-soon", "goal-later"]);
+    expect(maxGapScore).toBe(7);
+    expect(getGoalActivationSnapshot).toHaveBeenCalledTimes(2);
+    expect(getGoalActivationSnapshot).toHaveBeenNthCalledWith(1, "goal-later");
+    expect(getGoalActivationSnapshot).toHaveBeenNthCalledWith(2, "goal-soon");
+    expect(prioritizeGoals).toHaveBeenCalledTimes(1);
   });
 
   it("generates cron entries for daemon scheduling", () => {

--- a/src/runtime/daemon/index.ts
+++ b/src/runtime/daemon/index.ts
@@ -15,6 +15,7 @@ export {
   writeShutdownMarkerFile,
 } from "./persistence.js";
 export {
+  collectGoalCycleScheduleSnapshot,
   determineActiveGoalsForCycle,
   expireOldCronTasks,
   getMaxGapScoreForGoals,

--- a/src/runtime/daemon/maintenance.ts
+++ b/src/runtime/daemon/maintenance.ts
@@ -3,7 +3,7 @@ import { getInternalIdentityPrefix } from "../../base/config/identity-loader.js"
 import { PulSeedEventSchema } from "../../base/types/drive.js";
 import type { DaemonConfig, DaemonState } from "../../base/types/daemon.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
-import type { DriveSystem } from "../../platform/drive/drive-system.js";
+import type { DriveSystem, GoalActivationSnapshot } from "../../platform/drive/drive-system.js";
 import { createEnvelope } from "../types/envelope.js";
 import type { Envelope } from "../types/envelope.js";
 import type { CronScheduler } from "../cron-scheduler.js";
@@ -15,18 +15,38 @@ const ProactiveResponseSchema = z.object({
   details: z.record(z.string(), z.unknown()).optional(),
 });
 
+export type GoalCycleScheduleSnapshotEntry = GoalActivationSnapshot;
+
+export async function collectGoalCycleScheduleSnapshot(
+  driveSystem: DriveSystem,
+  goalIds: string[],
+): Promise<GoalCycleScheduleSnapshotEntry[]> {
+  const snapshot: GoalCycleScheduleSnapshotEntry[] = [];
+
+  for (const goalId of goalIds) {
+    snapshot.push(await driveSystem.getGoalActivationSnapshot(goalId));
+  }
+
+  return snapshot;
+}
+
 export async function determineActiveGoalsForCycle(
   driveSystem: DriveSystem,
   goalIds: string[],
+  snapshot: GoalCycleScheduleSnapshotEntry[] = [],
 ): Promise<string[]> {
   const eligibleIds: string[] = [];
   const scores = new Map<string, number>();
+  const snapshotByGoalId = new Map(snapshot.map((entry) => [entry.goalId, entry]));
 
   for (const goalId of goalIds) {
-    if (await driveSystem.shouldActivate(goalId)) {
+    const entry =
+      snapshotByGoalId.get(goalId)
+      ?? await driveSystem.getGoalActivationSnapshot(goalId);
+
+    if (entry.shouldActivate) {
       eligibleIds.push(goalId);
-      const schedule = await driveSystem.getSchedule(goalId);
-      const nextCheckAt = schedule ? new Date(schedule.next_check_at).getTime() : 0;
+      const nextCheckAt = entry.schedule ? new Date(entry.schedule.next_check_at).getTime() : 0;
       scores.set(goalId, -nextCheckAt);
     }
   }
@@ -202,11 +222,25 @@ export async function runProactiveMaintenance(params: {
 export async function getMaxGapScoreForGoals(
   driveSystem: DriveSystem,
   goalIds: string[],
+  snapshot: GoalCycleScheduleSnapshotEntry[] = [],
 ): Promise<number> {
+  const snapshotByGoalId = new Map(snapshot.map((entry) => [entry.goalId, entry]));
   let max = 0;
+
   for (const goalId of goalIds) {
+    const entry = snapshotByGoalId.get(goalId);
+
+    if (entry) {
+      const score = (entry.schedule as Record<string, unknown> | null)?.["last_gap_score"];
+      if (typeof score === "number" && score > max) {
+        max = score;
+      }
+      continue;
+    }
+
     try {
-      const schedule = await driveSystem.getSchedule(goalId);
+      const fallbackEntry = await driveSystem.getGoalActivationSnapshot(goalId);
+      const schedule = fallbackEntry.schedule;
       const score = (schedule as Record<string, unknown>)["last_gap_score"];
       if (typeof score === "number" && score > max) {
         max = score;
@@ -229,9 +263,14 @@ export async function runSupervisorMaintenanceCycleForDaemon(params: {
   eventServer?: { broadcast?(event: string, payload: Record<string, unknown>): void | Promise<void> };
   state: DaemonState;
 }): Promise<void> {
+  const snapshot = await collectGoalCycleScheduleSnapshot(
+    params.driveSystem,
+    [...params.currentGoalIds],
+  );
   const activeGoals = await determineActiveGoalsForCycle(
     params.driveSystem,
     [...params.currentGoalIds],
+    snapshot,
   );
   for (const goalId of activeGoals) {
     params.supervisor?.activateGoal(goalId);

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -38,6 +38,7 @@ import type { ShutdownMarker } from "./index.js";
 import {
   checkCrashRecoveryMarker,
   cleanupDaemonRun,
+  collectGoalCycleScheduleSnapshot,
   deleteShutdownMarkerFile,
   determineActiveGoalsForCycle,
   expireOldCronTasks,
@@ -53,6 +54,7 @@ import {
   writeChatMessageEvent,
   writeShutdownMarkerFile,
 } from "./index.js";
+import type { GoalCycleScheduleSnapshotEntry } from "./maintenance.js";
 
 // Re-exports for callers that imported these from daemon-runner
 export { generateCronEntry } from "./signals.js";
@@ -589,8 +591,9 @@ export class DaemonRunner {
     while (this.running && !this.shuttingDown) {
       try {
         const goalIds = [...this.currentGoalIds];
+        const cycleSnapshot = await this.collectGoalCycleSnapshot(goalIds);
         // 1. Determine which goals need activation
-        const activeGoals = await this.determineActiveGoals(goalIds);
+        const activeGoals = await this.determineActiveGoals(goalIds, cycleSnapshot);
 
         if (activeGoals.length === 0) {
           this.logger.info("No goals need activation this cycle", {
@@ -668,7 +671,7 @@ export class DaemonRunner {
         // 6. Wait for next check interval
         if (this.running) {
           const baseIntervalMs = this.getNextInterval(goalIds);
-          const maxGapScore = await this.getMaxGapScore(goalIds);
+          const maxGapScore = await this.getMaxGapScore(goalIds, cycleSnapshot);
           const intervalMs = this.calculateAdaptiveInterval(
             baseIntervalMs,
             activeGoals.length,
@@ -693,8 +696,15 @@ export class DaemonRunner {
    * Determine which goals should be activated this cycle.
    * Uses DriveSystem.shouldActivate() for each goal, then sorts by priority.
    */
-  private async determineActiveGoals(goalIds: string[]): Promise<string[]> {
-    return determineActiveGoalsForCycle(this.driveSystem, goalIds);
+  private async determineActiveGoals(
+    goalIds: string[],
+    snapshot: GoalCycleScheduleSnapshotEntry[]
+  ): Promise<string[]> {
+    return determineActiveGoalsForCycle(this.driveSystem, goalIds, snapshot);
+  }
+
+  private async collectGoalCycleSnapshot(goalIds: string[]): Promise<GoalCycleScheduleSnapshotEntry[]> {
+    return collectGoalCycleScheduleSnapshot(this.driveSystem, goalIds);
   }
 
   // ─── Private: Interval Calculation ───
@@ -1000,8 +1010,11 @@ export class DaemonRunner {
    * Get the highest gap score across all active goals.
    * Falls back to 0 if no gap data is available.
    */
-  private async getMaxGapScore(goalIds: string[]): Promise<number> {
-    return getMaxGapScoreForGoals(this.driveSystem, goalIds);
+  private async getMaxGapScore(
+    goalIds: string[],
+    snapshot: GoalCycleScheduleSnapshotEntry[]
+  ): Promise<number> {
+    return getMaxGapScoreForGoals(this.driveSystem, goalIds, snapshot);
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a cycle-local goal activation snapshot in DriveSystem
- reuse the snapshot for daemon goal ordering and adaptive sleep gap scoring
- add focused tests covering single schedule reads and snapshot reuse

Closes #620

## Verification
- pnpm vitest run src/platform/drive/__tests__/drive-system.test.ts src/runtime/__tests__/daemon-runner.test.ts
- pnpm tsc --noEmit