### PR TITLE
Refactor core-loop stall detection to index gap history

### DIFF
--- a/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
@@ -499,3 +499,173 @@ describe("detectStallsAndRebalance — global stall reRefineLeaf", () => {
     expect(mockRefiner.reRefineLeaf).not.toHaveBeenCalled();
   });
 });
+
+describe("detectStallsAndRebalance — gap history indexing reuse", () => {
+  it("reuses the same per-dimension history for dimension and global stall checks", async () => {
+    const deps = createBaseDeps(tmpDir);
+    const goal = makeGoal({
+      id: "goal-1",
+      dimensions: [
+        {
+          name: "dim1",
+          label: "Dim 1",
+          current_value: 0.2,
+          threshold: { type: "min", value: 1.0 },
+          confidence: 0.5,
+          observation_method: {
+            type: "manual",
+            source: "manual",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "self_report",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+        {
+          name: "dim2",
+          label: "Dim 2",
+          current_value: 0.4,
+          threshold: { type: "min", value: 1.0 },
+          confidence: 0.5,
+          observation_method: {
+            type: "manual",
+            source: "manual",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "self_report",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await deps.stateManager.saveGoal(goal);
+
+    await deps.stateManager.saveGapHistory("goal-1", [
+      {
+        iteration: 0,
+        timestamp: new Date().toISOString(),
+        gap_vector: [
+          { dimension_name: "dim1", normalized_weighted_gap: 0.8 },
+          { dimension_name: "dim2", normalized_weighted_gap: 0.4 },
+        ],
+        confidence_vector: [],
+      },
+      {
+        iteration: 1,
+        timestamp: new Date().toISOString(),
+        gap_vector: [
+          { dimension_name: "dim2", normalized_weighted_gap: 0.3 },
+        ],
+        confidence_vector: [],
+      },
+      {
+        iteration: 2,
+        timestamp: new Date().toISOString(),
+        gap_vector: [
+          { dimension_name: "dim1", normalized_weighted_gap: 0.6 },
+        ],
+        confidence_vector: [],
+      },
+    ]);
+
+    const dimensionHistories = new Map<string, Array<{ normalized_gap: number }>>();
+    (deps.stallDetector.checkDimensionStall as ReturnType<typeof vi.fn>).mockImplementation(
+      (_goalId: string, dimName: string, dimGapHistory: Array<{ normalized_gap: number }>) => {
+        dimensionHistories.set(dimName, dimGapHistory);
+        return null;
+      }
+    );
+
+    const globalHistories: Array<Map<string, Array<{ normalized_gap: number }>>> = [];
+    (deps.stallDetector.checkGlobalStall as ReturnType<typeof vi.fn>).mockImplementation(
+      (_goalId: string, allDimGaps: Map<string, Array<{ normalized_gap: number }>>) => {
+        globalHistories.push(allDimGaps);
+        return null;
+      }
+    );
+
+    const ctx = buildPhaseCtx(deps, { maxIterations: 10, adapterType: "openai_codex_cli" });
+    const result = makeIterationResult();
+
+    await detectStallsAndRebalance(ctx, "goal-1", goal, result);
+
+    expect(dimensionHistories.get("dim1")).toEqual([
+      { normalized_gap: 0.8 },
+      { normalized_gap: 0.6 },
+    ]);
+    expect(dimensionHistories.get("dim2")).toEqual([
+      { normalized_gap: 0.4 },
+      { normalized_gap: 0.3 },
+    ]);
+
+    const globalHistory = globalHistories[0];
+    expect(globalHistory).toBeDefined();
+    expect(globalHistory?.get("dim1")).toBe(dimensionHistories.get("dim1"));
+    expect(globalHistory?.get("dim2")).toBe(dimensionHistories.get("dim2"));
+  });
+
+  it("ignores stale dimensions that are no longer present on the goal", async () => {
+    const deps = createBaseDeps(tmpDir);
+    const goal = makeGoal({
+      id: "goal-1",
+      dimensions: [
+        {
+          name: "dim1",
+          label: "Dim 1",
+          current_value: 0.2,
+          threshold: { type: "min", value: 1.0 },
+          confidence: 0.5,
+          observation_method: {
+            type: "manual",
+            source: "manual",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "self_report",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await deps.stateManager.saveGoal(goal);
+
+    await deps.stateManager.saveGapHistory("goal-1", [
+      {
+        iteration: 0,
+        timestamp: new Date().toISOString(),
+        gap_vector: [
+          { dimension_name: "dim1", normalized_weighted_gap: 0.8 },
+          { dimension_name: "stale-dim", normalized_weighted_gap: 0.1 },
+        ],
+        confidence_vector: [],
+      },
+    ]);
+
+    (deps.stallDetector.checkDimensionStall as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const globalCheck = deps.stallDetector.checkGlobalStall as ReturnType<typeof vi.fn>;
+    globalCheck.mockReturnValue(null);
+
+    const ctx = buildPhaseCtx(deps, { maxIterations: 10, adapterType: "openai_codex_cli" });
+    const result = makeIterationResult();
+
+    await detectStallsAndRebalance(ctx, "goal-1", goal, result);
+
+    const globalHistory = globalCheck.mock.calls[0]?.[1] as Map<string, Array<{ normalized_gap: number }>>;
+    expect(globalHistory.has("dim1")).toBe(true);
+    expect(globalHistory.has("stale-dim")).toBe(false);
+  });
+});

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -122,6 +122,7 @@ export async function detectStallsAndRebalance(
 ): Promise<void> {
   try {
     const gapHistory = await ctx.deps.stateManager.loadGapHistory(goalId);
+    const gapHistoryByDimension = indexGapHistoryByDimension(goal, gapHistory);
 
     // Gather tool-based workspace evidence for stall detection (Phase 6)
     if (ctx.toolExecutor) {
@@ -176,14 +177,7 @@ export async function detectStallsAndRebalance(
     // Per-dimension stall check (skip dimensions suppressed by active WaitStrategies)
     for (const dim of goal.dimensions) {
       if (suppressedDimensions.has(dim.name)) continue;
-      const dimGapHistory = gapHistory
-        .filter((entry) =>
-          entry.gap_vector.some((g) => g.dimension_name === dim.name)
-        )
-        .map((entry) => {
-          const g = entry.gap_vector.find((g) => g.dimension_name === dim.name);
-          return { normalized_gap: g?.normalized_weighted_gap ?? 1 };
-        });
+      const dimGapHistory = gapHistoryByDimension.get(dim.name) ?? [];
 
       const stallReport = ctx.deps.stallDetector.checkDimensionStall(
         goalId,
@@ -215,7 +209,7 @@ export async function detectStallsAndRebalance(
 
     // Global stall check
     if (!result.stallDetected) {
-      await checkGlobalStall(ctx, goalId, goal, result, gapHistory);
+      await checkGlobalStall(ctx, goalId, goal, result, gapHistoryByDimension);
     }
 
     // Portfolio: check rebalance after stall detection
@@ -225,6 +219,35 @@ export async function detectStallsAndRebalance(
   } catch (err) {
     ctx.logger?.warn("CoreLoop: stall detection failed (non-fatal)", { error: err instanceof Error ? err.message : String(err) });
   }
+}
+
+function indexGapHistoryByDimension(
+  goal: Goal,
+  gapHistory: GapHistoryEntry[]
+): Map<string, Array<{ normalized_gap: number }>> {
+  const indexedHistory = new Map<string, Array<{ normalized_gap: number }>>();
+
+  for (const dim of goal.dimensions) {
+    indexedHistory.set(dim.name, []);
+  }
+
+  for (const entry of gapHistory) {
+    const seenDimensions = new Set<string>();
+    for (const gap of entry.gap_vector) {
+      if (seenDimensions.has(gap.dimension_name)) continue;
+      seenDimensions.add(gap.dimension_name);
+
+      const dimHistory = indexedHistory.get(gap.dimension_name);
+      if (!dimHistory) {
+        continue;
+      }
+
+      const normalizedGap = { normalized_gap: gap.normalized_weighted_gap ?? 1 };
+      dimHistory.push(normalizedGap);
+    }
+  }
+
+  return indexedHistory;
 }
 
 // ─── Shared stall-action helper ───
@@ -362,28 +385,15 @@ async function checkGlobalStall(
   goalId: string,
   goal: Goal,
   result: LoopIterationResult,
-  gapHistory: GapHistoryEntry[]
+  gapHistoryByDimension: Map<string, Array<{ normalized_gap: number }>>
 ): Promise<void> {
-  const allDimGaps = new Map<string, Array<{ normalized_gap: number }>>();
-  for (const dim of goal.dimensions) {
-    const dimGapHistory = gapHistory
-      .filter((entry) =>
-        entry.gap_vector.some((g) => g.dimension_name === dim.name)
-      )
-      .map((entry) => {
-        const g = entry.gap_vector.find((g) => g.dimension_name === dim.name);
-        return { normalized_gap: g?.normalized_weighted_gap ?? 1 };
-      });
-    allDimGaps.set(dim.name, dimGapHistory);
-  }
-
-  const globalStall = ctx.deps.stallDetector.checkGlobalStall(goalId, allDimGaps);
+  const globalStall = ctx.deps.stallDetector.checkGlobalStall(goalId, gapHistoryByDimension);
   if (!globalStall) return;
 
   result.stallDetected = true;
   result.stallReport = globalStall;
 
-  const firstDimHistory = allDimGaps.values().next().value ?? [];
+  const firstDimHistory = gapHistoryByDimension.get(goal.dimensions[0]?.name ?? "") ?? [];
   const firstDimName = goal.dimensions[0]?.name ?? "";
 
   // Pass escalationLevel=1 so that escalationLevel+1=2, preserving the original global PIVOT level


### PR DESCRIPTION
## Summary
- build a per-iteration gap-history index by dimension in task-cycle
- reuse the indexed histories for both dimension and global stall checks
- add focused regression tests for history reuse and stale-dimension exclusion

Closes #622

## Verification
- pnpm vitest run src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
- pnpm tsc --noEmit