### PR TITLE
Stabilize resident daemon runtime

### DIFF
--- a/src/base/llm/__tests__/provider-oauth.test.ts
+++ b/src/base/llm/__tests__/provider-oauth.test.ts
@@ -1,7 +1,12 @@
 import * as path from "node:path";
 import * as os from "node:os";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { isJwtExpired, readCodexOAuthToken, loadProviderConfig } from "../provider-config.js";
+import {
+  getProviderRuntimeFingerprint,
+  isJwtExpired,
+  loadProviderConfig,
+  readCodexOAuthToken,
+} from "../provider-config.js";
 
 // ─── isJwtExpired ───
 
@@ -133,6 +138,43 @@ describe("loadProviderConfig OAuth fallback", () => {
 
     const config = await loadProviderConfig();
     expect(config.api_key).toBe(validToken);
+
+    accessSpy.mockRestore();
+  });
+
+  it("changes fingerprint when the resolved OAuth token changes without exposing the raw token", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const tokenA = makeJwt({ exp: futureExp, sub: "user-a" });
+    const tokenB = makeJwt({ exp: futureExp, sub: "user-b" });
+    const providerJsonPath = path.join(os.homedir(), ".pulseed", "provider.json");
+    const authJsonPath = path.join(os.homedir(), ".codex", "auth.json");
+    const providerJson = JSON.stringify({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      adapter: "openai_codex_cli",
+    });
+
+    let authReadCount = 0;
+    mockReadFile.mockImplementation(async (filePath: unknown) => {
+      if (filePath === providerJsonPath) return providerJson;
+      if (filePath === authJsonPath) {
+        authReadCount += 1;
+        return JSON.stringify({
+          tokens: { access_token: authReadCount === 1 ? tokenA : tokenB },
+        });
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const fspModule = await import("node:fs/promises");
+    const accessSpy = vi.spyOn(fspModule, "access").mockResolvedValue(undefined);
+
+    const fingerprintA = await getProviderRuntimeFingerprint();
+    const fingerprintB = await getProviderRuntimeFingerprint();
+
+    expect(fingerprintA).not.toContain(tokenA);
+    expect(fingerprintB).not.toContain(tokenB);
+    expect(fingerprintA).not.toBe(fingerprintB);
 
     accessSpy.mockRestore();
   });

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -7,6 +7,7 @@
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
+import { createHash } from "node:crypto";
 import { getPulseedDirPath } from "../utils/paths.js";
 import { writeJsonFileAtomic } from "../utils/json-io.js";
 
@@ -410,6 +411,25 @@ export async function loadProviderConfig(): Promise<ProviderConfig> {
   }
 
   return config;
+}
+
+export async function getProviderRuntimeFingerprint(): Promise<string> {
+  const config = await loadProviderConfig();
+  const fingerprintSource = {
+    provider: config.provider,
+    model: config.model,
+    adapter: config.adapter,
+    light_model: config.light_model ?? null,
+    base_url: config.base_url ?? null,
+    codex_cli_path: config.codex_cli_path ?? null,
+    api_key_hash: config.api_key
+      ? createHash("sha256").update(config.api_key).digest("hex")
+      : null,
+    a2a: config.a2a ?? null,
+    openclaw: config.openclaw ?? null,
+  };
+
+  return JSON.stringify(fingerprintSource);
 }
 
 /**

--- a/src/interface/cli/__tests__/cli-daemon-start.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-start.test.ts
@@ -227,4 +227,15 @@ describe("cmdStart", () => {
       })
     );
   });
+
+  it("allows idle watchdog startup with zero initial goals", async () => {
+    await cmdStart(
+      { getBaseDir: vi.fn().mockReturnValue("/tmp/pulseed-daemon-start-base") } as never,
+      {} as never,
+      []
+    );
+
+    expect(watchdogStartMock).toHaveBeenCalledOnce();
+    expect(daemonStartMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/interface/cli/__tests__/cli-daemon-status.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-status.test.ts
@@ -18,6 +18,29 @@ vi.mock("../../../base/utils/paths.js", async (importOriginal) => {
 
 import { getPulseedDirPath } from "../../../base/utils/paths.js";
 import { cmdDaemonStatus } from "../commands/daemon.js";
+import { PIDManager } from "../../../runtime/pid-manager.js";
+
+function mockPidInspectRunning(runtimePid: number, ownerPid = runtimePid) {
+  return vi.spyOn(PIDManager.prototype, "inspect").mockResolvedValue({
+    info: {
+      pid: runtimePid,
+      runtime_pid: runtimePid,
+      owner_pid: ownerPid,
+      watchdog_pid: ownerPid !== runtimePid ? ownerPid : undefined,
+      started_at: new Date().toISOString(),
+      runtime_started_at: new Date().toISOString(),
+      owner_started_at: new Date().toISOString(),
+      watchdog_started_at: ownerPid !== runtimePid ? new Date().toISOString() : undefined,
+    },
+    running: true,
+    runtimePid,
+    ownerPid,
+    alivePids: ownerPid === runtimePid ? [runtimePid] : [runtimePid, ownerPid],
+    stalePids: [],
+    verifiedPids: ownerPid === runtimePid ? [runtimePid] : [runtimePid, ownerPid],
+    unverifiedLegacyPids: [],
+  });
+}
 
 describe("cmdDaemonStatus", () => {
   let tmpDir: string;
@@ -31,6 +54,7 @@ describe("cmdDaemonStatus", () => {
 
   afterEach(() => {
     consoleSpy.mockRestore();
+    vi.restoreAllMocks();
     cleanupTempDir(tmpDir);
   });
 
@@ -86,8 +110,10 @@ describe("cmdDaemonStatus", () => {
         started_at: new Date().toISOString(),
       })
     );
+    const inspectSpy = mockPidInspectRunning(process.pid);
 
     await cmdDaemonStatus([]);
+    inspectSpy.mockRestore();
 
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     expect(output).toContain(`running (PID: ${process.pid})`);
@@ -120,13 +146,67 @@ describe("cmdDaemonStatus", () => {
         started_at: new Date().toISOString(),
       })
     );
+    const inspectSpy = mockPidInspectRunning(runtimePid, watchdogPid);
 
     await cmdDaemonStatus([]);
+    inspectSpy.mockRestore();
 
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     expect(output).toContain(`idle (PID: ${runtimePid})`);
     expect(output).toContain(`Watchdog PID:    ${watchdogPid}`);
     expect(output).toContain("Active goals:    (none)");
+  });
+
+  it("shows restarting status when the watchdog is alive but the runtime child is dead", async () => {
+    const runtimePid = 999999999;
+    const watchdogPid = process.pid;
+    const state = {
+      pid: runtimePid,
+      started_at: new Date(Date.now() - 30_000).toISOString(),
+      last_loop_at: null,
+      loop_count: 0,
+      active_goals: [],
+      status: "running",
+      crash_count: 0,
+      last_error: null,
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+    fs.writeFileSync(
+      path.join(tmpDir, "pulseed.pid"),
+      JSON.stringify({
+        pid: runtimePid,
+        runtime_pid: runtimePid,
+        owner_pid: watchdogPid,
+        watchdog_pid: watchdogPid,
+        started_at: new Date().toISOString(),
+      })
+    );
+    const inspectSpy = vi.spyOn(PIDManager.prototype, "inspect").mockResolvedValue({
+      info: {
+        pid: runtimePid,
+        runtime_pid: runtimePid,
+        owner_pid: watchdogPid,
+        watchdog_pid: watchdogPid,
+        started_at: new Date().toISOString(),
+        runtime_started_at: new Date().toISOString(),
+        owner_started_at: new Date().toISOString(),
+        watchdog_started_at: new Date().toISOString(),
+      },
+      running: true,
+      runtimePid,
+      ownerPid: watchdogPid,
+      alivePids: [watchdogPid],
+      stalePids: [runtimePid],
+      verifiedPids: [watchdogPid],
+      unverifiedLegacyPids: [],
+    });
+
+    await cmdDaemonStatus([]);
+    inspectSpy.mockRestore();
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain(`restarting (PID: ${runtimePid})`);
+    expect(output).toContain(`Watchdog PID:    ${watchdogPid}`);
   });
 
   it("shows resident activity when the daemon has autonomous work history", async () => {
@@ -159,8 +239,10 @@ describe("cmdDaemonStatus", () => {
         started_at: new Date().toISOString(),
       })
     );
+    const inspectSpy = mockPidInspectRunning(process.pid);
 
     await cmdDaemonStatus([]);
+    inspectSpy.mockRestore();
 
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     expect(output).toContain("Resident:        negotiation");
@@ -196,8 +278,10 @@ describe("cmdDaemonStatus", () => {
         started_at: new Date().toISOString(),
       })
     );
+    const inspectSpy = mockPidInspectRunning(process.pid);
 
     await cmdDaemonStatus([]);
+    inspectSpy.mockRestore();
 
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     expect(output).toContain("Resident:        dream");

--- a/src/interface/cli/__tests__/cli-daemon-status.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-status.test.ts
@@ -77,6 +77,15 @@ describe("cmdDaemonStatus", () => {
       last_error: null,
     };
     fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+    fs.writeFileSync(
+      path.join(tmpDir, "pulseed.pid"),
+      JSON.stringify({
+        pid: process.pid,
+        runtime_pid: process.pid,
+        owner_pid: process.pid,
+        started_at: new Date().toISOString(),
+      })
+    );
 
     await cmdDaemonStatus([]);
 
@@ -85,6 +94,115 @@ describe("cmdDaemonStatus", () => {
     expect(output).toContain("Uptime:");
     expect(output).toContain("10 cycles completed");
     expect(output).toContain("0/3 retries used");
+  });
+
+  it("shows idle status and watchdog PID when the daemon is running without goals", async () => {
+    const runtimePid = process.pid;
+    const watchdogPid = 424242;
+    const state = {
+      pid: runtimePid,
+      started_at: new Date(Date.now() - 30_000).toISOString(),
+      last_loop_at: null,
+      loop_count: 0,
+      active_goals: [],
+      status: "idle",
+      crash_count: 0,
+      last_error: null,
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+    fs.writeFileSync(
+      path.join(tmpDir, "pulseed.pid"),
+      JSON.stringify({
+        pid: runtimePid,
+        runtime_pid: runtimePid,
+        owner_pid: watchdogPid,
+        watchdog_pid: watchdogPid,
+        started_at: new Date().toISOString(),
+      })
+    );
+
+    await cmdDaemonStatus([]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain(`idle (PID: ${runtimePid})`);
+    expect(output).toContain(`Watchdog PID:    ${watchdogPid}`);
+    expect(output).toContain("Active goals:    (none)");
+  });
+
+  it("shows resident activity when the daemon has autonomous work history", async () => {
+    const state = {
+      pid: process.pid,
+      started_at: new Date(Date.now() - 60_000).toISOString(),
+      last_loop_at: null,
+      loop_count: 1,
+      active_goals: ["resident-goal"],
+      status: "running",
+      crash_count: 0,
+      last_error: null,
+      last_resident_at: new Date(Date.now() - 5_000).toISOString(),
+      resident_activity: {
+        kind: "negotiation",
+        trigger: "proactive_tick",
+        summary: "Resident discovery negotiated a new goal: Add resident daemon coverage",
+        recorded_at: new Date(Date.now() - 5_000).toISOString(),
+        suggestion_title: "Add resident daemon coverage",
+        goal_id: "resident-goal",
+      },
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+    fs.writeFileSync(
+      path.join(tmpDir, "pulseed.pid"),
+      JSON.stringify({
+        pid: process.pid,
+        runtime_pid: process.pid,
+        owner_pid: process.pid,
+        started_at: new Date().toISOString(),
+      })
+    );
+
+    await cmdDaemonStatus([]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Resident:        negotiation");
+    expect(output).toContain("Resident note:   Resident discovery negotiated a new goal");
+    expect(output).toContain("Resident goal:   resident-goal");
+  });
+
+  it("shows dream resident activity without requiring a goal id", async () => {
+    const state = {
+      pid: process.pid,
+      started_at: new Date(Date.now() - 60_000).toISOString(),
+      last_loop_at: null,
+      loop_count: 1,
+      active_goals: [],
+      status: "idle",
+      crash_count: 0,
+      last_error: null,
+      last_resident_at: new Date(Date.now() - 5_000).toISOString(),
+      resident_activity: {
+        kind: "dream",
+        trigger: "proactive_tick",
+        summary: "Resident dream applied pending suggestion \"Dream resident schedule\" into schedule schedule-entry-1.",
+        recorded_at: new Date(Date.now() - 5_000).toISOString(),
+      },
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+    fs.writeFileSync(
+      path.join(tmpDir, "pulseed.pid"),
+      JSON.stringify({
+        pid: process.pid,
+        runtime_pid: process.pid,
+        owner_pid: process.pid,
+        started_at: new Date().toISOString(),
+      })
+    );
+
+    await cmdDaemonStatus([]);
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Resident:        dream");
+    expect(output).toContain("Resident note:   Resident dream applied pending suggestion");
+    expect(output).not.toContain("Resident goal:");
   });
 
   it("shows last_error when present", async () => {

--- a/src/interface/cli/__tests__/cli-doctor.test.ts
+++ b/src/interface/cli/__tests__/cli-doctor.test.ts
@@ -251,31 +251,62 @@ describe("checkDaemon", () => {
     cleanupTempDir(tmpDir);
   });
 
-  it("passes with clean state when no PID file exists", () => {
-    const result = checkDaemon(tmpDir);
+  it("passes with clean state when no PID file exists", async () => {
+    const result = await checkDaemon(tmpDir);
     expect(result.status).toBe("pass");
-    expect(result.detail).toContain("not running");
+    expect(result.detail).toContain("stopped");
   });
 
-  it("warns when PID file references a non-running process", () => {
+  it("warns when PID file references a non-running process", async () => {
     fs.writeFileSync(path.join(tmpDir, "pulseed.pid"), "999999999");
-    const result = checkDaemon(tmpDir);
+    const result = await checkDaemon(tmpDir);
     expect(result.status).toBe("warn");
     expect(result.detail).toContain("stale PID");
   });
 
-  it("passes when PID file references a running process (current process)", () => {
+  it("passes when PID file references a running process (current process)", async () => {
     fs.writeFileSync(path.join(tmpDir, "pulseed.pid"), String(process.pid));
-    const result = checkDaemon(tmpDir);
+    const result = await checkDaemon(tmpDir);
     expect(result.status).toBe("pass");
     expect(result.detail).toContain("running");
   });
 
-  it("passes when PID file is JSON format and references running process", () => {
+  it("passes when PID file is JSON format and references running process", async () => {
     fs.writeFileSync(path.join(tmpDir, "pulseed.pid"), JSON.stringify({ pid: process.pid }));
-    const result = checkDaemon(tmpDir);
+    const result = await checkDaemon(tmpDir);
     expect(result.status).toBe("pass");
     expect(result.detail).toContain("running");
+  });
+
+  it("reports idle daemon mode distinctly", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "pulseed.pid"),
+      JSON.stringify({
+        pid: process.pid,
+        runtime_pid: process.pid,
+        owner_pid: 424242,
+        watchdog_pid: 424242,
+        started_at: new Date().toISOString(),
+      })
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon-state.json"),
+      JSON.stringify({
+        pid: process.pid,
+        started_at: new Date().toISOString(),
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: [],
+        status: "idle",
+        crash_count: 0,
+        last_error: null,
+      })
+    );
+
+    const result = await checkDaemon(tmpDir);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("idle daemon running");
+    expect(result.detail).toContain(`PID: ${process.pid}`);
   });
 });
 
@@ -386,5 +417,22 @@ describe("cmdDoctor summary counts", () => {
     expect(allOutput).toContain("Summary:");
     // Exit code depends on build check — just ensure it's 0 or 1 (a number).
     expect([0, 1]).toContain(exitCode);
+  });
+
+  it("runs runtime store repair when requested", async () => {
+    const origHome = process.env["PULSEED_HOME"];
+    process.env["PULSEED_HOME"] = tmpDir;
+
+    const exitCode = await cmdDoctor(["--repair"]);
+
+    if (origHome !== undefined) {
+      process.env["PULSEED_HOME"] = origHome;
+    } else {
+      delete process.env["PULSEED_HOME"];
+    }
+
+    expect([0, 1]).toContain(exitCode);
+    const allOutput = consoleSpy.mock.calls.map((c: unknown[]) => c[0] as string).join("\n");
+    expect(allOutput).toContain("Repair:");
   });
 });

--- a/src/interface/cli/__tests__/cli-doctor.test.ts
+++ b/src/interface/cli/__tests__/cli-doctor.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { PIDManager } from "../../../runtime/pid-manager.js";
 
 // ─── cmdDoctor tests ───
 //
@@ -266,16 +267,107 @@ describe("checkDaemon", () => {
 
   it("passes when PID file references a running process (current process)", async () => {
     fs.writeFileSync(path.join(tmpDir, "pulseed.pid"), String(process.pid));
+    const inspectSpy = vi.spyOn(PIDManager.prototype, "inspect").mockResolvedValue({
+      info: {
+        pid: process.pid,
+        started_at: new Date().toISOString(),
+        owner_pid: process.pid,
+        runtime_pid: process.pid,
+      },
+      running: true,
+      runtimePid: process.pid,
+      ownerPid: process.pid,
+      alivePids: [process.pid],
+      stalePids: [],
+      verifiedPids: [process.pid],
+      unverifiedLegacyPids: [],
+    });
     const result = await checkDaemon(tmpDir);
+    inspectSpy.mockRestore();
     expect(result.status).toBe("pass");
     expect(result.detail).toContain("running");
   });
 
   it("passes when PID file is JSON format and references running process", async () => {
     fs.writeFileSync(path.join(tmpDir, "pulseed.pid"), JSON.stringify({ pid: process.pid }));
+    const inspectSpy = vi.spyOn(PIDManager.prototype, "inspect").mockResolvedValue({
+      info: {
+        pid: process.pid,
+        started_at: new Date().toISOString(),
+        owner_pid: process.pid,
+        runtime_pid: process.pid,
+      },
+      running: true,
+      runtimePid: process.pid,
+      ownerPid: process.pid,
+      alivePids: [process.pid],
+      stalePids: [],
+      verifiedPids: [process.pid],
+      unverifiedLegacyPids: [],
+    });
     const result = await checkDaemon(tmpDir);
+    inspectSpy.mockRestore();
     expect(result.status).toBe("pass");
     expect(result.detail).toContain("running");
+  });
+
+  it("fails when the watchdog is alive but the runtime child is dead", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "pulseed.pid"),
+      JSON.stringify({
+        pid: 999999999,
+        runtime_pid: 999999999,
+        owner_pid: process.pid,
+        watchdog_pid: process.pid,
+        started_at: new Date().toISOString(),
+      })
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon-state.json"),
+      JSON.stringify({
+        pid: 999999999,
+        started_at: new Date().toISOString(),
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: [],
+        status: "running",
+        crash_count: 0,
+        last_error: null,
+      })
+    );
+
+    const result = await checkDaemon(tmpDir);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("restarting");
+  });
+
+  it("fails when daemon-state.json reports crashed", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "pulseed.pid"),
+      JSON.stringify({
+        pid: process.pid,
+        runtime_pid: process.pid,
+        owner_pid: process.pid,
+        started_at: new Date().toISOString(),
+      })
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon-state.json"),
+      JSON.stringify({
+        pid: process.pid,
+        started_at: new Date().toISOString(),
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: [],
+        status: "crashed",
+        crash_count: 1,
+        last_error: "boom",
+      })
+    );
+
+    const result = await checkDaemon(tmpDir);
+    expect(result.status).toBe("fail");
+    expect(result.detail).toContain("crashed");
   });
 
   it("reports idle daemon mode distinctly", async () => {
@@ -302,8 +394,25 @@ describe("checkDaemon", () => {
         last_error: null,
       })
     );
+    const inspectSpy = vi.spyOn(PIDManager.prototype, "inspect").mockResolvedValue({
+      info: {
+        pid: process.pid,
+        started_at: new Date().toISOString(),
+        owner_pid: 424242,
+        watchdog_pid: 424242,
+        runtime_pid: process.pid,
+      },
+      running: true,
+      runtimePid: process.pid,
+      ownerPid: 424242,
+      alivePids: [process.pid, 424242],
+      stalePids: [],
+      verifiedPids: [process.pid, 424242],
+      unverifiedLegacyPids: [],
+    });
 
     const result = await checkDaemon(tmpDir);
+    inspectSpy.mockRestore();
     expect(result.status).toBe("pass");
     expect(result.detail).toContain("idle daemon running");
     expect(result.detail).toContain(`PID: ${process.pid}`);

--- a/src/interface/cli/__tests__/cli-install.test.ts
+++ b/src/interface/cli/__tests__/cli-install.test.ts
@@ -46,6 +46,20 @@ describe("buildPlist", () => {
     expect(xml).toContain("<string>--goal</string>");
   });
 
+  it("supports idle mode with no goal arguments", () => {
+    const xml = buildPlist({
+      nodePath: "/usr/local/bin/node",
+      cliRunnerPath: "/app/dist/cli/cli-runner.js",
+      goalIds: [],
+      stdoutLog: "/logs/out.log",
+      stderrLog: "/logs/err.log",
+      workingDir: "/home/user",
+    });
+
+    expect(xml).toContain("<string>start</string>");
+    expect(xml).not.toContain("<string>--goal</string>");
+  });
+
   it("includes the correct node path and cli-runner path", () => {
     const xml = buildPlist({
       nodePath: "/usr/local/bin/node",
@@ -243,15 +257,19 @@ describe("cmdInstall", () => {
     errSpy.mockRestore();
   });
 
-  it("returns 1 when no --goal is provided", async () => {
+  it("supports idle install with no initial goals", async () => {
     Object.defineProperty(process, "platform", { value: "darwin", writable: true });
-    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
     const code = await cmdInstall([]);
 
-    expect(code).toBe(1);
-    expect(errSpy).toHaveBeenCalledWith("Error: at least one --goal is required");
-    errSpy.mockRestore();
+    expect(code).toBe(0);
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      PLIST_PATH,
+      expect.not.stringContaining("<string>--goal</string>"),
+      "utf8"
+    );
+    logSpy.mockRestore();
   });
 
   it("writes the plist file and calls launchctl load on success", async () => {

--- a/src/interface/cli/__tests__/cli-install.test.ts
+++ b/src/interface/cli/__tests__/cli-install.test.ts
@@ -269,6 +269,11 @@ describe("cmdInstall", () => {
       expect.not.stringContaining("<string>--goal</string>"),
       "utf8"
     );
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      PLIST_PATH,
+      expect.stringContaining(`<string>${process.cwd()}</string>`),
+      "utf8"
+    );
     logSpy.mockRestore();
   });
 

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -318,16 +318,30 @@ function formatRelativeTime(isoDate: string): string {
   return `${Math.floor(ms / 86400000)}d ago`;
 }
 
+function isPidAlive(pidStatus: Awaited<ReturnType<PIDManager["inspect"]>>, pid?: number | null): boolean {
+  return typeof pid === "number" && pidStatus.alivePids.includes(pid);
+}
+
 export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   const baseDir = getPulseedDirPath();
   const statePath = path.join(baseDir, "daemon-state.json");
   const pidManager = new PIDManager(baseDir);
   const pidStatus = await pidManager.inspect();
+  const runtimePid = pidStatus.runtimePid ?? pidStatus.info?.pid ?? null;
+  const watchdogPid = pidStatus.info?.watchdog_pid ?? pidStatus.ownerPid ?? null;
+  const runtimeAlive = isPidAlive(pidStatus, runtimePid);
+  const watchdogAlive = isPidAlive(pidStatus, watchdogPid);
 
   const raw = await readJsonFileOrNull(statePath);
   if (raw === null) {
-    if (!pidStatus.running) {
+    if (!runtimeAlive && !watchdogAlive) {
       console.log("No daemon state found");
+      return;
+    }
+    if (!runtimeAlive && watchdogAlive) {
+      console.log(
+        `Daemon watchdog is running, but runtime child is restarting (PID: ${runtimePid ?? "unknown"})`
+      );
       return;
     }
     console.log("Daemon process is running, but daemon-state.json is missing");
@@ -340,9 +354,8 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   }
   const data: DaemonState = parsed.data;
 
-  const alive = pidStatus.running;
-  const runtimePid = pidStatus.runtimePid ?? data.pid;
-  const watchdogPid = pidStatus.info?.watchdog_pid ?? pidStatus.ownerPid;
+  const resolvedRuntimePid = runtimePid ?? data.pid;
+  const resolvedRuntimeAlive = isPidAlive(pidStatus, resolvedRuntimePid);
 
   // Load daemon config for config section display
   const configPath = path.join(baseDir, "daemon.json");
@@ -354,8 +367,14 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   const cfg = configParsed?.success ? configParsed.data : DaemonConfigSchema.parse({});
 
   const status =
-    !alive
-      ? "stopped"
+    !resolvedRuntimeAlive
+      ? watchdogAlive
+        ? "restarting"
+        : data.status === "crashed"
+          ? "crashed"
+          : data.status === "stopping"
+            ? "stopping"
+            : "stopped"
       : data.status === "crashed" || data.status === "stopping"
         ? data.status
         : data.status === "idle"
@@ -364,15 +383,15 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   const lines: string[] = [
     "PulSeed Daemon Status",
     "\u2500".repeat(21),
-    `Status:          ${status} (PID: ${runtimePid})`,
+    `Status:          ${status} (PID: ${resolvedRuntimePid})`,
   ];
 
-  if (watchdogPid && watchdogPid !== runtimePid) {
-    lines.push(`Watchdog PID:    ${watchdogPid}`);
+  if (watchdogPid && watchdogPid !== resolvedRuntimePid) {
+    lines.push(`Watchdog PID:    ${watchdogPid}${watchdogAlive ? "" : " (missing)"}`);
   }
 
   if (data.started_at) {
-    if (alive) {
+    if (resolvedRuntimeAlive) {
       lines.push(`Uptime:          ${formatUptime(data.started_at)}`);
     }
     lines.push(`Started:         ${data.started_at}`);

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -25,6 +25,7 @@ import { NotifierRegistry } from "../../../runtime/notifier-registry.js";
 import { NotificationDispatcher } from "../../../runtime/notification-dispatcher.js";
 import { AdapterRegistry } from "../../../orchestrator/execution/adapter-layer.js";
 import { DataSourceRegistry } from "../../../platform/observation/data-source-adapter.js";
+import { getProviderRuntimeFingerprint } from "../../../base/llm/provider-config.js";
 import { buildDeps } from "../setup.js";
 import { formatOperationError } from "../utils.js";
 import { getCliLogger } from "../cli-logger.js";
@@ -39,6 +40,10 @@ function resolveDaemonRuntimeRoot(baseDir: string, configuredRoot?: string): str
   return path.isAbsolute(configuredRoot)
     ? configuredRoot
     : path.resolve(baseDir, configuredRoot);
+}
+
+function formatGoalMode(goalIds: string[]): string {
+  return goalIds.length > 0 ? goalIds.join(", ") : "(idle mode)";
 }
 
 export async function cmdStart(
@@ -66,11 +71,6 @@ export async function cmdStart(
   }
 
   const goalIds = (values.goal as string[]) || [];
-
-  if (goalIds.length === 0) {
-    getCliLogger().error("Error: at least one --goal is required for daemon mode");
-    process.exit(1);
-  }
 
   // Gap 1: Load DaemonConfig from --config path (if provided)
   let daemonConfig: Partial<DaemonConfig> | undefined;
@@ -187,7 +187,7 @@ export async function cmdStart(
     process.on("SIGTERM", shutdown);
     process.on("SIGINT", shutdown);
     try {
-      logger.info(`Starting runtime watchdog for goals: ${goalIds.join(", ")}`);
+      logger.info(`Starting runtime watchdog for goals: ${formatGoalMode(goalIds)}`);
       await watchdog.start();
     } finally {
       process.removeListener("SIGTERM", shutdown);
@@ -243,8 +243,41 @@ export async function cmdStart(
   });
   await scheduleEngine.loadEntries();
 
+  const refreshResidentDeps = async () => {
+    const freshDeps = await buildDeps(stateManager, characterConfigManager);
+    freshDeps.reportingEngine.setNotificationDispatcher(notificationDispatcher);
+
+    const freshScheduleEngine = new ScheduleEngine({
+      baseDir: daemonBaseDir,
+      logger,
+      dataSourceRegistry,
+      llmClient: freshDeps.llmClient,
+      coreLoop: freshDeps.coreLoop,
+      stateManager: freshDeps.stateManager,
+      notificationDispatcher,
+      reportingEngine: freshDeps.reportingEngine,
+      hookManager: freshDeps.hookManager,
+      memoryLifecycle: freshDeps.memoryLifecycleManager,
+      knowledgeManager: freshDeps.knowledgeManager,
+    });
+    await freshScheduleEngine.loadEntries();
+
+    return {
+      coreLoop: freshDeps.coreLoop,
+      curiosityEngine: freshDeps.curiosityEngine,
+      goalNegotiator: freshDeps.goalNegotiator,
+      llmClient: freshDeps.llmClient,
+      reportingEngine: freshDeps.reportingEngine,
+      scheduleEngine: freshScheduleEngine,
+      memoryLifecycle: freshDeps.memoryLifecycleManager,
+      knowledgeManager: freshDeps.knowledgeManager,
+    };
+  };
+
   const daemon = new DaemonRunner({
     coreLoop: deps.coreLoop,
+    curiosityEngine: deps.curiosityEngine,
+    goalNegotiator: deps.goalNegotiator,
     driveSystem: deps.driveSystem,
     stateManager: deps.stateManager,
     pidManager,
@@ -255,9 +288,13 @@ export async function cmdStart(
     llmClient: deps.llmClient,
     cronScheduler,
     scheduleEngine,
+    memoryLifecycle: deps.memoryLifecycleManager,
+    knowledgeManager: deps.knowledgeManager,
+    getProviderRuntimeFingerprint,
+    refreshResidentDeps,
   });
 
-  logger.info(`Starting PulSeed daemon for goals: ${goalIds.join(", ")}`);
+  logger.info(`Starting PulSeed daemon for goals: ${formatGoalMode(goalIds)}`);
   await daemon.start(goalIds);
 }
 
@@ -284,10 +321,16 @@ function formatRelativeTime(isoDate: string): string {
 export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   const baseDir = getPulseedDirPath();
   const statePath = path.join(baseDir, "daemon-state.json");
+  const pidManager = new PIDManager(baseDir);
+  const pidStatus = await pidManager.inspect();
 
   const raw = await readJsonFileOrNull(statePath);
   if (raw === null) {
-    console.log("No daemon state found");
+    if (!pidStatus.running) {
+      console.log("No daemon state found");
+      return;
+    }
+    console.log("Daemon process is running, but daemon-state.json is missing");
     return;
   }
   const parsed = DaemonStateSchema.safeParse(raw);
@@ -297,14 +340,9 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   }
   const data: DaemonState = parsed.data;
 
-  // Check if the PID is actually running
-  let alive = false;
-  try {
-    process.kill(data.pid, 0);
-    alive = true;
-  } catch {
-    alive = false;
-  }
+  const alive = pidStatus.running;
+  const runtimePid = pidStatus.runtimePid ?? data.pid;
+  const watchdogPid = pidStatus.info?.watchdog_pid ?? pidStatus.ownerPid;
 
   // Load daemon config for config section display
   const configPath = path.join(baseDir, "daemon.json");
@@ -315,12 +353,23 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   const configParsed = configRaw !== null ? DaemonConfigSchema.safeParse(configRaw) : null;
   const cfg = configParsed?.success ? configParsed.data : DaemonConfigSchema.parse({});
 
-  const status = alive ? "running" : "stopped";
+  const status =
+    !alive
+      ? "stopped"
+      : data.status === "crashed" || data.status === "stopping"
+        ? data.status
+        : data.status === "idle"
+          ? "idle"
+          : "running";
   const lines: string[] = [
     "PulSeed Daemon Status",
     "\u2500".repeat(21),
-    `Status:          ${status} (PID: ${data.pid})`,
+    `Status:          ${status} (PID: ${runtimePid})`,
   ];
+
+  if (watchdogPid && watchdogPid !== runtimePid) {
+    lines.push(`Watchdog PID:    ${watchdogPid}`);
+  }
 
   if (data.started_at) {
     if (alive) {
@@ -337,6 +386,14 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   }
 
   lines.push(`Active goals:    ${data.active_goals.join(", ") || "(none)"}`);
+  if (data.resident_activity) {
+    const residentAgo = formatRelativeTime(data.resident_activity.recorded_at);
+    lines.push(`Resident:        ${data.resident_activity.kind} (${residentAgo})`);
+    lines.push(`Resident note:   ${data.resident_activity.summary}`);
+    if (data.resident_activity.goal_id) {
+      lines.push(`Resident goal:   ${data.resident_activity.goal_id}`);
+    }
+  }
 
   // Config section
   const intervalMin = Math.round(cfg.check_interval_ms / 60000);
@@ -364,30 +421,22 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
 
 export async function cmdStop(_args: string[]): Promise<void> {
   const pidManager = new PIDManager(getPulseedDirPath());
-
-  if (!(await pidManager.isRunning())) {
+  const stopResult = await pidManager.stopRuntime();
+  if (!stopResult.info || stopResult.sentSignalsTo.length === 0) {
     console.log("No running daemon found");
     return;
   }
-
-  const info = await pidManager.readPID();
-  if (info) {
-    console.log(`Stopping daemon (PID: ${info.pid})...`);
-    try {
-      process.kill(info.pid, "SIGTERM");
-      console.log("Stop signal sent");
-    } catch (err) {
-      // ESRCH means the process no longer exists (died between isRunning check and kill)
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ESRCH") {
-        await pidManager.cleanup();
-        console.log("No running daemon found");
-      } else {
-        getCliLogger().error(formatOperationError(`stop daemon process ${info.pid}`, err));
-        await pidManager.cleanup();
-      }
-    }
+  const displayPid = stopResult.runtimePid ?? stopResult.ownerPid ?? stopResult.info.pid;
+  console.log(`Stopping daemon (PID: ${displayPid})...`);
+  if (!stopResult.stopped) {
+    console.log(`Daemon still running (PIDs: ${stopResult.alivePids.join(", ")})`);
+    return;
   }
+  if (stopResult.forced) {
+    console.log("Daemon stopped after forcing remaining runtime processes");
+    return;
+  }
+  console.log("Daemon stopped");
 }
 
 export async function cmdCron(args: string[]): Promise<void> {

--- a/src/interface/cli/commands/doctor.ts
+++ b/src/interface/cli/commands/doctor.ts
@@ -164,28 +164,54 @@ export async function checkDaemon(baseDir?: string): Promise<CheckResult> {
     return { name: "Daemon", status: "warn", detail: "PID file exists but is unreadable" };
   }
 
-  if (!pidStatus.running) {
-    const runtimePid = pidInfo?.runtime_pid ?? pidInfo?.pid;
+  const runtimePid = pidStatus.runtimePid ?? pidInfo?.runtime_pid ?? pidInfo?.pid ?? null;
+  const watchdogPid = pidInfo?.watchdog_pid ?? pidStatus.ownerPid ?? null;
+  const runtimeAlive = typeof runtimePid === "number" && pidStatus.alivePids.includes(runtimePid);
+  const watchdogAlive = typeof watchdogPid === "number" && pidStatus.alivePids.includes(watchdogPid);
+  const runtimeState = daemonState?.success ? daemonState.data.status : null;
+
+  if (runtimeState === "crashed" || runtimeState === "stopping") {
+    return {
+      name: "Daemon",
+      status: "fail",
+      detail:
+        runtimeState === "crashed"
+          ? "daemon state reports crashed"
+          : "daemon state reports stopping",
+    };
+  }
+
+  if (!runtimeAlive) {
+    if (watchdogAlive) {
+      return {
+        name: "Daemon",
+        status: "fail",
+        detail: runtimePid !== null
+          ? `daemon restarting (runtime PID: ${runtimePid}, watchdog PID: ${watchdogPid})`
+          : `daemon restarting (watchdog PID: ${watchdogPid})`,
+      };
+    }
     return {
       name: "Daemon",
       status: pidFileExists ? "warn" : "pass",
-      detail: runtimePid
+      detail: runtimePid !== null
         ? `stale PID file (PID: ${runtimePid} not running)`
         : "stopped (clean state)",
     };
   }
 
-  const runtimePid = pidStatus.runtimePid ?? pidInfo?.pid ?? "unknown";
-  const watchdogPid = pidInfo?.watchdog_pid ?? pidStatus.ownerPid;
-  const runtimeState = daemonState?.success ? daemonState.data.status : null;
+  if (watchdogPid && watchdogPid !== runtimePid && !watchdogAlive) {
+    return {
+      name: "Daemon",
+      status: "warn",
+      detail: `running (PID: ${runtimePid}), watchdog PID: ${watchdogPid} missing`,
+    };
+  }
+
   const detailPrefix =
     runtimeState === "idle"
       ? `idle daemon running (PID: ${runtimePid})`
-      : runtimeState === "stopping"
-        ? `daemon stopping (PID: ${runtimePid})`
-        : runtimeState === "crashed"
-          ? `daemon running with crash state (PID: ${runtimePid})`
-          : `running (PID: ${runtimePid})`;
+      : `running (PID: ${runtimePid})`;
   const detail =
     watchdogPid && watchdogPid !== runtimePid
       ? `${detailPrefix}, watchdog PID: ${watchdogPid}`

--- a/src/interface/cli/commands/doctor.ts
+++ b/src/interface/cli/commands/doctor.ts
@@ -5,6 +5,11 @@ import * as path from "node:path";
 import { getPulseedDirPath, getLogsDir, getGoalsDir } from "../../../base/utils/paths.js";
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import { getCliRunnerBuildPath } from "../../../base/utils/pulseed-meta.js";
+import { readJsonFileOrNull } from "../../../base/utils/json-io.js";
+import { PIDManager } from "../../../runtime/pid-manager.js";
+import { ApprovalStore, OutboxStore, RuntimeHealthStore, createRuntimeStorePaths } from "../../../runtime/store/index.js";
+import { runRuntimeStoreMaintenanceCycle, type RuntimeMaintenanceLogger } from "../../../runtime/daemon/maintenance.js";
+import { DaemonStateSchema } from "../../../runtime/types/daemon.js";
 
 // ─── Types ───
 
@@ -140,35 +145,52 @@ export function checkBuild(buildPath = getCliRunnerBuildPath(import.meta.url)): 
   return { name: "Build", status: "fail", detail: `${displayPath} not found (run: npm run build)` };
 }
 
-export function checkDaemon(baseDir?: string): CheckResult {
+export async function checkDaemon(baseDir?: string): Promise<CheckResult> {
   const dir = baseDir ?? getPulseedDirPath();
-  const pidFile = path.join(dir, "pulseed.pid");
+  const pidManager = new PIDManager(dir);
+  const pidFileExists = fs.existsSync(pidManager.getPath());
+  const pidStatus = await pidManager.inspect();
+  const daemonStateRaw = await readJsonFileOrNull(path.join(dir, "daemon-state.json"));
+  const daemonState = daemonStateRaw !== null
+    ? DaemonStateSchema.safeParse(daemonStateRaw)
+    : null;
 
-  if (!fs.existsSync(pidFile)) {
-    return { name: "Daemon", status: "pass", detail: "not running (clean state)" };
+  if (!pidFileExists && !pidStatus.running) {
+    return { name: "Daemon", status: "pass", detail: "stopped (clean state)" };
   }
 
-  let pid: number;
-  try {
-    const content = fs.readFileSync(pidFile, "utf-8").trim();
-    // PID files may contain JSON (e.g. {"pid": 1234}) or plain integers
-    if (content.startsWith("{")) {
-      const parsed = JSON.parse(content) as Record<string, unknown>;
-      pid = Number(parsed["pid"]);
-    } else {
-      pid = parseInt(content, 10);
-    }
-    if (isNaN(pid)) throw new Error("invalid pid");
-  } catch {
+  const pidInfo = pidStatus.info ?? await pidManager.readPID();
+  if (pidInfo === null && pidFileExists) {
     return { name: "Daemon", status: "warn", detail: "PID file exists but is unreadable" };
   }
 
-  try {
-    process.kill(pid, 0);
-    return { name: "Daemon", status: "pass", detail: `running (PID: ${pid})` };
-  } catch {
-    return { name: "Daemon", status: "warn", detail: `stale PID file (PID: ${pid} not running)` };
+  if (!pidStatus.running) {
+    const runtimePid = pidInfo?.runtime_pid ?? pidInfo?.pid;
+    return {
+      name: "Daemon",
+      status: pidFileExists ? "warn" : "pass",
+      detail: runtimePid
+        ? `stale PID file (PID: ${runtimePid} not running)`
+        : "stopped (clean state)",
+    };
   }
+
+  const runtimePid = pidStatus.runtimePid ?? pidInfo?.pid ?? "unknown";
+  const watchdogPid = pidInfo?.watchdog_pid ?? pidStatus.ownerPid;
+  const runtimeState = daemonState?.success ? daemonState.data.status : null;
+  const detailPrefix =
+    runtimeState === "idle"
+      ? `idle daemon running (PID: ${runtimePid})`
+      : runtimeState === "stopping"
+        ? `daemon stopping (PID: ${runtimePid})`
+        : runtimeState === "crashed"
+          ? `daemon running with crash state (PID: ${runtimePid})`
+          : `running (PID: ${runtimePid})`;
+  const detail =
+    watchdogPid && watchdogPid !== runtimePid
+      ? `${detailPrefix}, watchdog PID: ${watchdogPid}`
+      : detailPrefix;
+  return { name: "Daemon", status: "pass", detail };
 }
 
 export function checkNotifications(baseDir?: string): CheckResult {
@@ -213,6 +235,38 @@ function formatRow(result: CheckResult): string {
 
 export async function cmdDoctor(_args: string[]): Promise<number> {
   const baseDir = getPulseedDirPath();
+  const repair = _args.includes("--repair");
+
+  if (repair) {
+    const runtimeRoot = path.join(baseDir, "runtime");
+    const runtimePaths = createRuntimeStorePaths(runtimeRoot);
+    const repairLogger: RuntimeMaintenanceLogger = {
+      debug: (message: string, context?: Record<string, unknown>) => {
+        console.log(`[repair][debug] ${message}${context ? ` ${JSON.stringify(context)}` : ""}`);
+      },
+      info: (message: string, context?: Record<string, unknown>) => {
+        console.log(`[repair][info] ${message}${context ? ` ${JSON.stringify(context)}` : ""}`);
+      },
+      warn: (message: string, context?: Record<string, unknown>) => {
+        console.log(`[repair][warn] ${message}${context ? ` ${JSON.stringify(context)}` : ""}`);
+      },
+      error: (message: string, context?: Record<string, unknown>) => {
+        console.log(`[repair][error] ${message}${context ? ` ${JSON.stringify(context)}` : ""}`);
+      },
+    };
+
+    const maintenanceReport = await runRuntimeStoreMaintenanceCycle({
+      runtimeRoot,
+      approvalStore: new ApprovalStore(runtimePaths),
+      outboxStore: new OutboxStore(runtimePaths),
+      runtimeHealthStore: new RuntimeHealthStore(runtimePaths),
+      logger: repairLogger,
+    });
+
+    console.log(
+      `Repair: approvals pruned=${maintenanceReport.approvals.prunedResolved}, outbox pruned=${maintenanceReport.outbox.pruned}, claims pruned=${maintenanceReport.claims.pruned}, health=${maintenanceReport.health.status ?? "unknown"}`
+    );
+  }
 
   const checks: CheckResult[] = [
     checkNodeVersion(),
@@ -222,7 +276,7 @@ export async function cmdDoctor(_args: string[]): Promise<number> {
     checkGoals(baseDir),
     checkLogDirectory(baseDir),
     checkBuild(),
-    checkDaemon(baseDir),
+    await checkDaemon(baseDir),
     checkNotifications(baseDir),
     await checkDiskUsage(baseDir),
   ];

--- a/src/interface/cli/commands/install.ts
+++ b/src/interface/cli/commands/install.ts
@@ -139,6 +139,7 @@ export async function cmdInstall(args: string[]): Promise<number> {
   const logsDir = path.join(home, ".pulseed", "logs");
   const stdoutLog = path.join(logsDir, "launchd-stdout.log");
   const stderrLog = path.join(logsDir, "launchd-stderr.log");
+  const workingDir = process.cwd();
 
   const plistContent = buildPlist({
     nodePath,
@@ -148,7 +149,7 @@ export async function cmdInstall(args: string[]): Promise<number> {
     intervalMs,
     stdoutLog,
     stderrLog,
-    workingDir: home,
+    workingDir,
     envPath: process.env["PATH"],
     pulseedHome: process.env["PULSEED_HOME"],
   });

--- a/src/interface/cli/commands/install.ts
+++ b/src/interface/cli/commands/install.ts
@@ -120,10 +120,6 @@ export async function cmdInstall(args: string[]): Promise<number> {
   }
 
   const goalIds = values.goal ?? [];
-  if (goalIds.length === 0) {
-    console.error("Error: at least one --goal is required");
-    return 1;
-  }
 
   const intervalMs =
     values.interval !== undefined ? parseInt(values.interval, 10) : undefined;

--- a/src/interface/cli/commands/setup/steps-runtime.ts
+++ b/src/interface/cli/commands/setup/steps-runtime.ts
@@ -59,17 +59,11 @@ export async function stepDaemon(): Promise<{ start: boolean; port: number }> {
     }
 
     const pidManager = new PIDManager(baseDir);
-    const pidInfo = await pidManager.readPID();
-    if (pidInfo !== null) {
-      try {
-        process.kill(pidInfo.pid, "SIGTERM");
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-        await pidManager.cleanup();
-        p.log.success("Daemon stopped.");
-      } catch {
-        p.log.warn("Could not stop daemon. It may have already exited.");
-        await pidManager.cleanup();
-      }
+    const stopResult = await pidManager.stopRuntime({ timeoutMs: 10_000 });
+    if (stopResult.stopped) {
+      p.log.success("Daemon stopped.");
+    } else {
+      p.log.warn("Could not stop daemon cleanly. Some runtime processes may still be alive.");
     }
   }
 

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -17,6 +17,7 @@ import { ShellDataSourceAdapter } from "../../adapters/datasources/shell-datasou
 import { createWorkspaceContextProvider } from "../../platform/observation/workspace-context.js";
 import { buildLLMClient, buildAdapterRegistry } from "../../base/llm/provider-factory.js";
 import { TrustManager } from "../../platform/traits/trust-manager.js";
+import { CuriosityEngine } from "../../platform/traits/curiosity-engine.js";
 import { DriveSystem } from "../../platform/drive/drive-system.js";
 import { ObservationEngine } from "../../platform/observation/observation-engine.js";
 import { StallDetector } from "../../platform/drive/stall-detector.js";
@@ -288,8 +289,18 @@ export async function buildDeps(
 
   coreLoop.setTimeHorizonEngine(new TimeHorizonEngine());
 
+  const curiosityEngine = new CuriosityEngine({
+    stateManager,
+    llmClient,
+    ethicsGate,
+    stallDetector,
+    driveSystem,
+    vectorIndex,
+  });
+
   return {
     coreLoop,
+    curiosityEngine,
     goalNegotiator,
     goalRefiner,
     reportingEngine,

--- a/src/runtime/__tests__/daemon-client.test.ts
+++ b/src/runtime/__tests__/daemon-client.test.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { DaemonClient } from "../daemon-client.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DaemonClient, isDaemonRunning } from "../daemon-client.js";
 import { EventServer } from "../event-server.js";
+import { DEFAULT_PORT } from "../port-utils.js";
 import { OutboxStore } from "../store/outbox-store.js";
 import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
 
@@ -86,5 +87,63 @@ describe("DaemonClient snapshot + replay", () => {
     } finally {
       client.disconnect();
     }
+  });
+
+  it("replays goal_updated and chat_response events through the SSE client", async () => {
+    await server.start();
+
+    const client = new DaemonClient({
+      host: "127.0.0.1",
+      port: server.getPort(),
+      reconnectInterval: 50,
+      maxReconnectAttempts: 2,
+    });
+
+    try {
+      client.connect();
+      await waitForEvent(client, "_connected");
+
+      const goalUpdated = waitForEvent(client, "goal_updated");
+      const chatResponse = waitForEvent(client, "chat_response");
+
+      await server.broadcast("goal_updated", { goalId: "goal-1", status: "completed" });
+      await server.broadcast("chat_response", { goalId: "goal-1", message: "queued", status: "queued" });
+
+      await expect(goalUpdated).resolves.toEqual({ goalId: "goal-1", status: "completed" });
+      await expect(chatResponse).resolves.toEqual({
+        goalId: "goal-1",
+        message: "queued",
+        status: "queued",
+      });
+    } finally {
+      client.disconnect();
+    }
+  });
+});
+
+describe("isDaemonRunning", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+    vi.restoreAllMocks();
+  });
+
+  it("treats idle daemon-state as running when the daemon health check passes", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon-state.json"),
+      JSON.stringify({ status: "idle", pid: process.pid }),
+      "utf-8"
+    );
+    vi.spyOn(DaemonClient.prototype, "healthCheck").mockResolvedValue(true);
+
+    await expect(isDaemonRunning(tmpDir)).resolves.toEqual({
+      running: true,
+      port: DEFAULT_PORT,
+    });
   });
 });

--- a/src/runtime/__tests__/daemon-maintenance.test.ts
+++ b/src/runtime/__tests__/daemon-maintenance.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
+import { ApprovalStore, OutboxStore, RuntimeHealthStore, createRuntimeStorePaths } from "../store/index.js";
+import { ApprovalRecordSchema, OutboxRecordSchema } from "../store/runtime-schemas.js";
+import { runRuntimeStoreMaintenanceCycle } from "../daemon/maintenance.js";
+
+describe("runRuntimeStoreMaintenanceCycle", () => {
+  let runtimeRoot: string;
+  let paths = createRuntimeStorePaths();
+  let approvalStore: ApprovalStore;
+  let outboxStore: OutboxStore;
+  let healthStore: RuntimeHealthStore;
+
+  beforeEach(() => {
+    runtimeRoot = makeTempDir("pulseed-runtime-maintenance-");
+    paths = createRuntimeStorePaths(runtimeRoot);
+    approvalStore = new ApprovalStore(paths);
+    outboxStore = new OutboxStore(paths);
+    healthStore = new RuntimeHealthStore(paths);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(runtimeRoot);
+  });
+
+  function logger() {
+    return {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  }
+
+  it("reconciles expired approvals, removes duplicate pending records, and prunes old resolved approvals", async () => {
+    const expiredPending = ApprovalRecordSchema.parse({
+      approval_id: "approval-expired",
+      goal_id: "goal-1",
+      request_envelope_id: "msg-1",
+      correlation_id: "corr-1",
+      state: "pending",
+      created_at: 1,
+      expires_at: 2,
+      payload: { note: "expired" },
+    });
+    const duplicatePending = ApprovalRecordSchema.parse({
+      approval_id: "approval-duplicate",
+      goal_id: "goal-2",
+      request_envelope_id: "msg-2",
+      correlation_id: "corr-2",
+      state: "pending",
+      created_at: 3,
+      expires_at: 10_000,
+      payload: { note: "duplicate" },
+    });
+    const oldResolved = ApprovalRecordSchema.parse({
+      approval_id: "approval-old",
+      goal_id: "goal-3",
+      request_envelope_id: "msg-3",
+      correlation_id: "corr-3",
+      state: "approved",
+      created_at: 4,
+      expires_at: 5,
+      resolved_at: 6,
+      payload: { note: "old" },
+    });
+
+    await approvalStore.savePending(expiredPending);
+    await approvalStore.savePending(duplicatePending);
+    await approvalStore.saveResolved({ ...duplicatePending, state: "approved", resolved_at: 9_900 });
+    await approvalStore.saveResolved(oldResolved);
+
+    const report = await runRuntimeStoreMaintenanceCycle({
+      runtimeRoot,
+      approvalStore,
+      outboxStore,
+      runtimeHealthStore: healthStore,
+      logger: logger(),
+      now: 10_000,
+      options: {
+        approvalRetentionMs: 500,
+      },
+    });
+
+    expect(report.approvals.removedPending).toBe(1);
+    expect(report.approvals.expiredPending).toBe(1);
+    expect(report.approvals.prunedResolved).toBe(1);
+    expect(await approvalStore.loadPending("approval-expired")).toBeNull();
+    expect(await approvalStore.loadResolved("approval-expired")).toMatchObject({ state: "expired" });
+    expect(await approvalStore.loadPending("approval-duplicate")).toBeNull();
+    expect(await approvalStore.loadResolved("approval-duplicate")).toMatchObject({ state: "approved" });
+    expect(await approvalStore.loadResolved("approval-old")).toBeNull();
+  });
+
+  it("prunes outbox history by age and count", async () => {
+    for (let seq = 1; seq <= 6; seq += 1) {
+      await outboxStore.save(OutboxRecordSchema.parse({
+        seq,
+        event_type: `event-${seq}`,
+        goal_id: "goal-1",
+        correlation_id: `corr-${seq}`,
+        created_at: seq,
+        payload: { seq },
+      }));
+    }
+
+    const report = await runRuntimeStoreMaintenanceCycle({
+      runtimeRoot,
+      approvalStore,
+      outboxStore,
+      runtimeHealthStore: healthStore,
+      logger: logger(),
+      now: 10_000,
+      options: {
+        outboxRetentionMs: 24 * 60 * 60 * 1000,
+        outboxMaxRecords: 3,
+      },
+    });
+
+    expect(report.outbox.pruned).toBe(3);
+    expect((await outboxStore.list()).map((record) => record.seq)).toEqual([4, 5, 6]);
+  });
+
+  it("repairs partial health snapshots into a loadable pair", async () => {
+    await healthStore.saveDaemonHealth({
+      status: "ok",
+      leader: true,
+      checked_at: 1,
+      details: { phase: "startup" },
+    });
+
+    const report = await runRuntimeStoreMaintenanceCycle({
+      runtimeRoot,
+      approvalStore,
+      outboxStore,
+      runtimeHealthStore: healthStore,
+      logger: logger(),
+      now: 10_000,
+    });
+
+    expect(report.health.repaired).toBe(true);
+    expect(await healthStore.loadSnapshot()).not.toBeNull();
+    expect(await healthStore.loadComponentsHealth()).not.toBeNull();
+  });
+
+  it("prunes stale claim artifacts from the runtime claims directory", async () => {
+    await fs.promises.mkdir(paths.claimsDir, { recursive: true });
+    const stalePath = path.join(paths.claimsDir, "stale-claim.json");
+    const freshPath = path.join(paths.claimsDir, "fresh-claim.json");
+    await fs.promises.writeFile(stalePath, "{}");
+    await fs.promises.writeFile(freshPath, "{}");
+    const staleTime = new Date("2020-01-01T00:00:00.000Z");
+    const freshTime = new Date("2026-04-10T00:00:00.000Z");
+    await fs.promises.utimes(stalePath, staleTime, staleTime);
+    await fs.promises.utimes(freshPath, freshTime, freshTime);
+
+    const report = await runRuntimeStoreMaintenanceCycle({
+      runtimeRoot,
+      approvalStore,
+      outboxStore,
+      runtimeHealthStore: healthStore,
+      logger: logger(),
+      now: new Date("2026-04-10T12:00:00.000Z").getTime(),
+      options: {
+        claimRetentionMs: 24 * 60 * 60 * 1000,
+      },
+    });
+
+    expect(report.claims.pruned).toBe(1);
+    expect(fs.existsSync(stalePath)).toBe(false);
+    expect(fs.existsSync(freshPath)).toBe(true);
+  });
+});

--- a/src/runtime/__tests__/daemon-runner.test.ts
+++ b/src/runtime/__tests__/daemon-runner.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { Goal } from "../../base/types/goal.js";
 import { DaemonRunner } from "../daemon-runner.js";
 import { PIDManager } from "../pid-manager.js";
 import { Logger } from "../logger.js";
@@ -106,6 +107,7 @@ function makeDeps(tmpDir: string, overrides: Partial<DaemonDeps> = {}): DaemonDe
   const mockStateManager = {
     getBaseDir: vi.fn().mockReturnValue(tmpDir),
     loadGoal: vi.fn().mockResolvedValue(null),
+    listGoalIds: vi.fn().mockResolvedValue([]),
   };
 
   const pidManager = new PIDManager(tmpDir);
@@ -205,6 +207,598 @@ describe("DaemonRunner durable runtime", () => {
     };
     expect(state.status).toBe("running");
     expect(state.active_goals).toEqual(["goal-a", "goal-b"]);
+
+    daemon.stop();
+    await startPromise;
+  });
+
+  it("starts in idle status when launched without initial goals", async () => {
+    const deps = makeDeps(tmpDir, { config: { check_interval_ms: 50 } });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start([]);
+    currentStartPromise = startPromise;
+
+    const state = await pollForFile(path.join(tmpDir, "daemon-state.json")) as {
+      status: string;
+      active_goals: string[];
+    };
+    expect(state.status).toBe("idle");
+    expect(state.active_goals).toEqual([]);
+
+    daemon.stop();
+    await startPromise;
+  });
+
+  it("refreshes resident deps when provider fingerprint changes while idle", async () => {
+    const refreshedCoreLoop = {
+      run: vi.fn().mockResolvedValue(makeLoopResult({ goalId: "goal-after-refresh" })),
+      stop: vi.fn(),
+    };
+    const getProviderRuntimeFingerprint = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce("fingerprint-a")
+      .mockResolvedValueOnce("fingerprint-b")
+      .mockResolvedValue("fingerprint-b");
+    const refreshResidentDeps = vi.fn().mockResolvedValue({
+      coreLoop: refreshedCoreLoop,
+      llmClient: {
+        sendMessage: vi.fn(),
+        parseJSON: vi.fn(),
+      },
+    });
+
+    const deps = makeDeps(tmpDir, {
+      config: { check_interval_ms: 20 },
+      getProviderRuntimeFingerprint,
+      refreshResidentDeps,
+    });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start([]);
+    currentStartPromise = startPromise;
+
+    await waitFor(() => refreshResidentDeps.mock.calls.length === 1, 2_000, 20);
+    expect(refreshResidentDeps).toHaveBeenCalledOnce();
+    await (daemon as unknown as { handleGoalStartCommand(goalId: string): Promise<void> })
+      .handleGoalStartCommand("goal-after-refresh");
+    await waitFor(
+      () => refreshedCoreLoop.run.mock.calls.some((call: unknown[]) => call[0] === "goal-after-refresh"),
+      2_000,
+      20
+    );
+
+    daemon.stop();
+    await startPromise;
+  });
+
+  it("does not refresh resident deps while a goal is actively running", async () => {
+    let releaseRun!: () => void;
+    const runPromise = new Promise<LoopResult>((resolve) => {
+      releaseRun = () => resolve(makeLoopResult({ goalId: "goal-active" }));
+    });
+
+    const deps = makeDeps(tmpDir, {
+      config: { check_interval_ms: 20 },
+      coreLoop: {
+        run: vi.fn().mockReturnValue(runPromise),
+        stop: vi.fn(),
+      } as unknown as DaemonDeps["coreLoop"],
+      driveSystem: {
+        getGoalActivationSnapshot: vi.fn(async (goalId: string): Promise<GoalActivationSnapshot> => ({
+          goalId,
+          shouldActivate: true,
+          schedule: null,
+        })),
+        shouldActivate: vi.fn().mockReturnValue(true),
+        getSchedule: vi.fn().mockResolvedValue(null),
+        prioritizeGoals: vi.fn().mockImplementation((ids: string[]) => ids),
+        startWatcher: vi.fn(),
+        stopWatcher: vi.fn(),
+        writeEvent: vi.fn().mockResolvedValue(undefined),
+      } as unknown as DaemonDeps["driveSystem"],
+      getProviderRuntimeFingerprint: vi
+        .fn<() => Promise<string>>()
+        .mockResolvedValueOnce("fingerprint-a")
+        .mockResolvedValueOnce("fingerprint-b")
+        .mockResolvedValue("fingerprint-b"),
+      refreshResidentDeps: vi.fn().mockResolvedValue({
+        coreLoop: {
+          run: vi.fn().mockResolvedValue(makeLoopResult({ goalId: "unused" })),
+          stop: vi.fn(),
+        },
+      }),
+    });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start(["goal-active"]);
+    currentStartPromise = startPromise;
+
+    const runMock = (deps.coreLoop as unknown as { run: ReturnType<typeof vi.fn> }).run;
+    await waitFor(() => runMock.mock.calls.length > 0, 2_000, 20);
+    vi.mocked(deps.refreshResidentDeps!).mockClear();
+
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(deps.refreshResidentDeps).not.toHaveBeenCalled();
+
+    daemon.stop();
+    releaseRun();
+    await startPromise;
+  });
+
+  it("negotiates a resident goal from idle proactive discovery and activates it", async () => {
+    const residentGoal = {
+      id: "resident-goal",
+      title: "Add resident daemon coverage",
+    } as Goal;
+    const goalNegotiator = {
+      suggestGoals: vi.fn().mockResolvedValue([
+        {
+          title: "Add resident daemon coverage",
+          description: "Add regression coverage for idle daemon resident discovery.",
+          rationale: "Resident mode should create work from idle.",
+          dimensions_hint: ["test_coverage"],
+        },
+      ]),
+      negotiate: vi.fn().mockResolvedValue({
+        goal: residentGoal,
+        response: {},
+        log: {},
+      }),
+    };
+    const llmClient = {
+      sendMessage: vi.fn().mockResolvedValue({
+        content: JSON.stringify({
+          action: "suggest_goal",
+          details: {
+            title: "Find one resident improvement",
+            description: "Look for a concrete always-on improvement in the current workspace.",
+          },
+        }),
+      }),
+      parseJSON: vi.fn((content: string) => JSON.parse(content)),
+    };
+
+    const deps = makeDeps(tmpDir, {
+      config: {
+        check_interval_ms: 50,
+        proactive_mode: true,
+        proactive_interval_ms: 0,
+      },
+      llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      goalNegotiator: goalNegotiator as unknown as DaemonDeps["goalNegotiator"],
+    });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start([]);
+    currentStartPromise = startPromise;
+
+    const state = await pollForJsonMatch<{
+      status: string;
+      active_goals: string[];
+      resident_activity: { kind: string; goal_id?: string; summary: string } | null;
+    }>(
+      path.join(tmpDir, "daemon-state.json"),
+      (value) =>
+        value.active_goals.includes("resident-goal")
+        && value.resident_activity?.kind === "negotiation"
+    );
+
+    expect(state.status).toBe("running");
+    expect(state.active_goals).toContain("resident-goal");
+    expect(state.resident_activity).toEqual(expect.objectContaining({
+      kind: "negotiation",
+      goal_id: "resident-goal",
+    }));
+
+    const runMock = (deps.coreLoop as unknown as { run: ReturnType<typeof vi.fn> }).run;
+    await waitFor(() => runMock.mock.calls.some((call: unknown[]) => call[0] === "resident-goal"));
+
+    expect(goalNegotiator.suggestGoals).toHaveBeenCalledOnce();
+    expect(goalNegotiator.negotiate).toHaveBeenCalledWith(
+      "Add regression coverage for idle daemon resident discovery.",
+      expect.objectContaining({
+        timeoutMs: 30_000,
+      })
+    );
+
+    daemon.stop();
+    await startPromise;
+  });
+
+  it("runs resident curiosity investigation from idle proactive ticks", async () => {
+    const curiosityEngine = {
+      evaluateTriggers: vi.fn().mockResolvedValue([
+        {
+          type: "periodic_exploration",
+          detected_at: new Date().toISOString(),
+          source_goal_id: null,
+          details: "Resident investigation found room for periodic exploration.",
+          severity: 0.3,
+        },
+      ]),
+      generateProposals: vi.fn().mockResolvedValue([
+        {
+          id: "curiosity-1",
+          trigger: {
+            type: "periodic_exploration",
+            detected_at: new Date().toISOString(),
+            source_goal_id: null,
+            details: "Resident investigation found room for periodic exploration.",
+            severity: 0.3,
+          },
+          proposed_goal: {
+            description: "Explore weak spots in idle daemon resident behavior.",
+            rationale: "Periodic exploration should turn idle time into useful investigation.",
+            suggested_dimensions: [
+              {
+                name: "resident_autonomy",
+                threshold_type: "min",
+                target: 0.7,
+              },
+            ],
+            scope_domain: "engineering",
+            detection_method: "periodic_review",
+          },
+          status: "pending",
+          created_at: new Date().toISOString(),
+          expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+          reviewed_at: null,
+          rejection_cooldown_until: null,
+          loop_count: 0,
+          goal_id: null,
+        },
+      ]),
+    };
+    const llmClient = {
+      sendMessage: vi.fn().mockResolvedValue({
+        content: JSON.stringify({
+          action: "investigate",
+          details: {
+            what: "idle daemon autonomy",
+            why: "Look for the next resident behavior to wire.",
+          },
+        }),
+      }),
+      parseJSON: vi.fn((content: string) => JSON.parse(content)),
+    };
+
+    const deps = makeDeps(tmpDir, {
+      config: {
+        check_interval_ms: 50,
+        proactive_mode: true,
+        proactive_interval_ms: 0,
+      },
+      llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      curiosityEngine: curiosityEngine as unknown as DaemonDeps["curiosityEngine"],
+    });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start([]);
+    currentStartPromise = startPromise;
+
+    const state = await pollForJsonMatch<{
+      status: string;
+      resident_activity: { kind: string; summary: string; suggestion_title?: string } | null;
+    }>(
+      path.join(tmpDir, "daemon-state.json"),
+      (value) => value.resident_activity?.kind === "curiosity"
+    );
+
+    expect(state.status).toBe("idle");
+    expect(state.resident_activity).toEqual(expect.objectContaining({
+      kind: "curiosity",
+      suggestion_title: "Explore weak spots in idle daemon resident behavior.",
+    }));
+    expect(curiosityEngine.evaluateTriggers).toHaveBeenCalledOnce();
+    expect(curiosityEngine.generateProposals).toHaveBeenCalledOnce();
+    expect(llmClient.sendMessage).not.toHaveBeenCalled();
+
+    daemon.stop();
+    await startPromise;
+  });
+
+  it("runs scheduled goal review before proactive LLM decisions", async () => {
+    const curiosityEngine = {
+      evaluateTriggers: vi.fn().mockResolvedValue([]),
+      generateProposals: vi.fn(),
+    };
+    const llmClient = {
+      sendMessage: vi.fn(),
+      parseJSON: vi.fn(),
+    };
+
+    const deps = makeDeps(tmpDir, {
+      config: {
+        check_interval_ms: 50,
+        proactive_mode: true,
+        proactive_interval_ms: 60_000,
+        goal_review_interval_ms: 0,
+      },
+      llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      curiosityEngine: curiosityEngine as unknown as DaemonDeps["curiosityEngine"],
+    });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start([]);
+    currentStartPromise = startPromise;
+
+    const state = await pollForJsonMatch<{
+      resident_activity: { kind: string; trigger: string; summary: string } | null;
+    }>(
+      path.join(tmpDir, "daemon-state.json"),
+      (value) => value.resident_activity?.trigger === "schedule"
+    );
+
+    expect(state.resident_activity).toEqual(expect.objectContaining({
+      kind: "curiosity",
+      trigger: "schedule",
+    }));
+    expect(state.resident_activity?.summary).toContain("goal review");
+    expect(curiosityEngine.evaluateTriggers).toHaveBeenCalledOnce();
+    expect(llmClient.sendMessage).not.toHaveBeenCalled();
+
+    daemon.stop();
+    await startPromise;
+  });
+
+  it("runs resident dream maintenance from idle proactive ticks", async () => {
+    const scheduleEngine = {
+      tick: vi.fn().mockResolvedValue([]),
+      getEntries: vi.fn().mockReturnValue([]),
+      addEntry: vi.fn().mockResolvedValue({
+        id: "schedule-entry-1",
+        name: "Dream resident schedule",
+      }),
+    };
+    const llmClient = {
+      sendMessage: vi.fn().mockResolvedValue({
+        content: JSON.stringify({
+          action: "sleep",
+        }),
+      }),
+      parseJSON: vi.fn((content: string) => JSON.parse(content)),
+    };
+
+    fs.mkdirSync(path.join(tmpDir, "dream"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "dream", "schedule-suggestions.json"),
+      JSON.stringify({
+        generated_at: new Date().toISOString(),
+        suggestions: [
+          {
+            id: "dream-1",
+            type: "cron",
+            name: "Dream resident schedule",
+            confidence: 0.9,
+            reason: "Follow up on resident daemon maintenance during idle time.",
+            proposal: "0 * * * *",
+            status: "pending",
+          },
+        ],
+      })
+    );
+
+    const deps = makeDeps(tmpDir, {
+      config: {
+        check_interval_ms: 50,
+        proactive_mode: true,
+        proactive_interval_ms: 0,
+      },
+      llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      scheduleEngine: scheduleEngine as unknown as DaemonDeps["scheduleEngine"],
+    });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start([]);
+    currentStartPromise = startPromise;
+
+    const state = await pollForJsonMatch<{
+      status: string;
+      resident_activity: { kind: string; summary: string } | null;
+    }>(
+      path.join(tmpDir, "daemon-state.json"),
+      (value) => value.resident_activity?.kind === "dream"
+    );
+
+    const suggestionFile = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "dream", "schedule-suggestions.json"), "utf-8")
+    ) as {
+      suggestions: Array<{ status: string; applied_entry_id?: string }>;
+    };
+
+    expect(state.status).toBe("idle");
+    expect(state.resident_activity?.summary).toContain("applied pending suggestion");
+    expect(scheduleEngine.addEntry).toHaveBeenCalledOnce();
+    expect(suggestionFile.suggestions[0]).toEqual(expect.objectContaining({
+      status: "applied",
+      applied_entry_id: "schedule-entry-1",
+    }));
+
+    daemon.stop();
+    await startPromise;
+  });
+
+  it("runs resident dream light analysis during idle sleep cycles", async () => {
+    const llmClient = {
+      sendMessage: vi.fn().mockResolvedValue({
+        content: JSON.stringify({
+          action: "sleep",
+        }),
+      }),
+      parseJSON: vi.fn((content: string) => JSON.parse(content)),
+    };
+
+    const deps = makeDeps(tmpDir, {
+      config: {
+        check_interval_ms: 50,
+        proactive_mode: true,
+        proactive_interval_ms: 0,
+      },
+      llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+    });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start([]);
+    currentStartPromise = startPromise;
+
+    const state = await pollForJsonMatch<{
+      resident_activity: { kind: string; summary: string } | null;
+    }>(
+      path.join(tmpDir, "daemon-state.json"),
+      (value) => value.resident_activity?.summary.includes("light analysis") ?? false
+    );
+
+    expect(state.resident_activity).toEqual(expect.objectContaining({
+      kind: "dream",
+    }));
+
+    daemon.stop();
+    await startPromise;
+  });
+
+  it("queues an observation wake-up for resident preemptive checks", async () => {
+    const llmClient = {
+      sendMessage: vi.fn().mockResolvedValue({
+        content: JSON.stringify({
+          action: "preemptive_check",
+          details: {
+            goal_id: "resident-goal",
+          },
+        }),
+      }),
+      parseJSON: vi.fn((content: string) => JSON.parse(content)),
+    };
+    const residentGoal = {
+      id: "resident-goal",
+      title: "Resident observation target",
+      description: "Target goal for preemptive observation.",
+      status: "active",
+      dimensions: [],
+      gap_aggregation: "max",
+      dimension_mapping: null,
+      constraints: [],
+      children_ids: [],
+      target_date: null,
+      origin: "manual",
+      pace_snapshot: null,
+      deadline: null,
+      confidence_flag: null,
+      user_override: false,
+      feasibility_note: null,
+      uncertainty_weight: 1,
+      decomposition_depth: 0,
+      specificity_score: null,
+      loop_status: "idle",
+      parent_id: null,
+      node_type: "goal",
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as Goal;
+
+    const stateManager = {
+      getBaseDir: vi.fn().mockReturnValue(tmpDir),
+      loadGoal: vi.fn(async (goalId: string) => (goalId === "resident-goal" ? residentGoal : null)),
+      listGoalIds: vi.fn().mockResolvedValue(["resident-goal"]),
+    };
+
+    const deps = makeDeps(tmpDir, {
+      config: {
+        check_interval_ms: 50,
+        proactive_mode: true,
+        proactive_interval_ms: 0,
+      },
+      llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      stateManager: stateManager as unknown as DaemonDeps["stateManager"],
+    });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start([]);
+    currentStartPromise = startPromise;
+
+    const state = await pollForJsonMatch<{
+      status: string;
+      active_goals: string[];
+      resident_activity: { kind: string; summary: string; goal_id?: string } | null;
+    }>(
+      path.join(tmpDir, "daemon-state.json"),
+      (value) => value.resident_activity?.kind === "observation",
+    );
+
+    expect(state.status).toBe("running");
+    expect(state.active_goals).toContain("resident-goal");
+    expect(state.resident_activity).toEqual(expect.objectContaining({
+      kind: "observation",
+      goal_id: "resident-goal",
+    }));
+    expect(
+      (deps.driveSystem as unknown as { writeEvent: ReturnType<typeof vi.fn> }).writeEvent
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "resident-proactive",
+        data: expect.objectContaining({
+          event_type: "preemptive_check",
+          goal_id: "resident-goal",
+        }),
+      }),
+    );
+
+    daemon.stop();
+    await startPromise;
+  });
+
+  it("degrades to resident error when dream suggestion storage is malformed", async () => {
+    const llmClient = {
+      sendMessage: vi.fn().mockResolvedValue({
+        content: JSON.stringify({
+          action: "sleep",
+        }),
+      }),
+      parseJSON: vi.fn((content: string) => JSON.parse(content)),
+    };
+
+    fs.mkdirSync(path.join(tmpDir, "dream"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "dream", "schedule-suggestions.json"),
+      JSON.stringify({ generated_at: 42, suggestions: {} }),
+      "utf-8",
+    );
+
+    const deps = makeDeps(tmpDir, {
+      config: {
+        check_interval_ms: 50,
+        proactive_mode: true,
+        proactive_interval_ms: 0,
+      },
+      llmClient: llmClient as unknown as DaemonDeps["llmClient"],
+      memoryLifecycle: {} as DaemonDeps["memoryLifecycle"],
+      knowledgeManager: {} as DaemonDeps["knowledgeManager"],
+    });
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+
+    const startPromise = daemon.start([]);
+    currentStartPromise = startPromise;
+
+    const state = await pollForJsonMatch<{
+      status: string;
+      resident_activity: { kind: string; summary: string } | null;
+    }>(
+      path.join(tmpDir, "daemon-state.json"),
+      (value) => value.resident_activity?.summary.includes("Resident dream maintenance failed") ?? false,
+    );
+
+    expect(state.status).toBe("idle");
+    expect(state.resident_activity?.summary).toContain("Resident dream maintenance failed");
 
     daemon.stop();
     await startPromise;
@@ -547,10 +1141,17 @@ describe("DaemonRunner durable runtime", () => {
       status: "running",
       crash_count: 0,
       last_error: null,
+      last_resident_at: null,
+      resident_activity: null,
     };
     const { filePath, saveDaemonState } = createPersistedStateFile(tmpDir, state);
     const saveSpy = vi.fn(saveDaemonState);
     const driveSystem = {
+      getGoalActivationSnapshot: vi.fn(async (goalId: string) => ({
+        goalId,
+        shouldActivate: false,
+        schedule: null,
+      })),
       shouldActivate: vi.fn().mockResolvedValue(false),
       getSchedule: vi.fn().mockResolvedValue(null),
       prioritizeGoals: vi.fn().mockImplementation((ids: string[]) => ids),
@@ -583,10 +1184,17 @@ describe("DaemonRunner durable runtime", () => {
       status: "running",
       crash_count: 0,
       last_error: null,
+      last_resident_at: null,
+      resident_activity: null,
     };
     const { filePath, saveDaemonState } = createPersistedStateFile(tmpDir, state);
     const saveSpy = vi.fn(saveDaemonState);
     const driveSystem = {
+      getGoalActivationSnapshot: vi.fn(async (goalId: string) => ({
+        goalId,
+        shouldActivate: true,
+        schedule: null,
+      })),
       shouldActivate: vi.fn().mockResolvedValue(true),
       getSchedule: vi.fn().mockResolvedValue(null),
       prioritizeGoals: vi.fn().mockImplementation((ids: string[]) => ids),

--- a/src/runtime/__tests__/pid-manager.test.ts
+++ b/src/runtime/__tests__/pid-manager.test.ts
@@ -16,6 +16,7 @@ describe("PIDManager", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
@@ -165,6 +166,15 @@ describe("PIDManager", () => {
       await pidManager.cleanup();
       expect(await pidManager.isRunning()).toBe(false);
     });
+
+    it("treats legacy numeric pidfiles as running when the process is still alive", async () => {
+      const legacyPidManager = new PIDManager(tmpDir, "legacy.pid", {
+        processCommandResolver: async (pid: number) =>
+          pid === process.pid ? "node dist/cli/cli-runner.js daemon start" : null,
+      });
+      fs.writeFileSync(legacyPidManager.getPath(), String(process.pid), "utf-8");
+      expect(await legacyPidManager.isRunning()).toBe(true);
+    });
   });
 
   // ─── cleanup ───
@@ -228,10 +238,6 @@ describe("PIDManager", () => {
   });
 
   describe("runtime tree ownership", () => {
-    afterEach(() => {
-      vi.restoreAllMocks();
-    });
-
     it("stores watchdog and runtime child ownership in the pid file", async () => {
       await pidManager.writePID({
         pid: 2202,
@@ -253,6 +259,15 @@ describe("PIDManager", () => {
 
     it("stopRuntime terminates the watchdog and runtime child together", async () => {
       const alive = new Set([4101, 4202]);
+      const matchingStartedAt = new Date("2026-04-10T00:00:00.000Z").toString();
+      const testPidManager = new PIDManager(tmpDir, "stable.pid", {
+        processStartedAtResolver: async (pid: number) => {
+          if (pid === 4101 || pid === 4202) {
+            return matchingStartedAt;
+          }
+          return null;
+        },
+      });
       const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
         if (signal === 0) {
           if (!alive.has(pid)) {
@@ -271,7 +286,7 @@ describe("PIDManager", () => {
         return true;
       }) as typeof process.kill);
 
-      await pidManager.writePID({
+      await testPidManager.writePID({
         pid: 4202,
         runtime_pid: 4202,
         owner_pid: 4101,
@@ -279,13 +294,115 @@ describe("PIDManager", () => {
         started_at: "2026-04-10T00:00:00.000Z",
       });
 
-      const result = await pidManager.stopRuntime({ timeoutMs: 50, pollIntervalMs: 1 });
+      const result = await testPidManager.stopRuntime({ timeoutMs: 50, pollIntervalMs: 1 });
 
       expect(killSpy).toHaveBeenCalledWith(4101, "SIGTERM");
       expect(killSpy).toHaveBeenCalledWith(4202, "SIGTERM");
       expect(result.stopped).toBe(true);
       expect(result.forced).toBe(false);
-      expect(fs.existsSync(pidManager.getPath())).toBe(false);
+      expect(fs.existsSync(testPidManager.getPath())).toBe(false);
+    });
+
+    it("treats a live recycled PID as stale when started_at does not match", async () => {
+      const recycledPid = 5101;
+      const pidfileStartedAt = "2026-04-10T00:00:00.000Z";
+      const recycledProcessStartedAt = new Date(Date.parse(pidfileStartedAt) + 60_000).toString();
+      const testPidManager = new PIDManager(tmpDir, "recycled.pid", {
+        processStartedAtResolver: async (pid: number) => {
+          if (pid === recycledPid) {
+            return recycledProcessStartedAt;
+          }
+          return null;
+        },
+      });
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+        if (signal === 0 && pid === recycledPid) {
+          return true;
+        }
+        return true;
+      }) as typeof process.kill);
+
+      fs.writeFileSync(
+        testPidManager.getPath(),
+        JSON.stringify({
+          pid: recycledPid,
+          started_at: pidfileStartedAt,
+        }),
+        "utf-8"
+      );
+
+      const status = await testPidManager.inspect();
+
+      expect(status.running).toBe(false);
+      expect(status.alivePids).toEqual([]);
+      expect(status.stalePids).toEqual([recycledPid]);
+      expect(fs.existsSync(testPidManager.getPath())).toBe(false);
+      expect(killSpy).toHaveBeenCalledWith(recycledPid, 0);
+
+      const stopResult = await testPidManager.stopRuntime({ timeoutMs: 10, pollIntervalMs: 1 });
+      expect(stopResult.stopped).toBe(false);
+      expect(stopResult.sentSignalsTo).toEqual([]);
+      expect(stopResult.alivePids).toEqual([]);
+    });
+
+    it("signals only verified alive PIDs during stopRuntime", async () => {
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+        if (signal === 0) return true;
+        return true;
+      }) as typeof process.kill);
+
+      const testPidManager = new PIDManager(tmpDir, "partial.pid", {
+        processStartedAtResolver: async (pid: number) => {
+          if (pid === 6101) {
+            return new Date("2026-04-10T00:00:00.000Z").toString();
+          }
+          if (pid === 6202) {
+            return new Date("2026-04-10T00:02:00.000Z").toString();
+          }
+          return null;
+        },
+      });
+
+      await testPidManager.writePID({
+        pid: 6202,
+        runtime_pid: 6202,
+        owner_pid: 6101,
+        watchdog_pid: 6101,
+        started_at: "2026-04-10T00:00:00.000Z",
+        owner_started_at: "2026-04-10T00:00:00.000Z",
+        watchdog_started_at: "2026-04-10T00:00:00.000Z",
+        runtime_started_at: "2026-04-10T00:00:00.000Z",
+      });
+
+      const result = await testPidManager.stopRuntime({ timeoutMs: 10, pollIntervalMs: 1 });
+
+      expect(result.sentSignalsTo).toEqual([6101]);
+      expect(killSpy).toHaveBeenCalledWith(6101, "SIGTERM");
+      expect(killSpy).not.toHaveBeenCalledWith(6202, "SIGTERM");
+    });
+
+    it("treats legacy numeric pidfiles as stale when the live process command does not match PulSeed", async () => {
+      const legacyPid = 7101;
+      const legacyPidManager = new PIDManager(tmpDir, "legacy-stale.pid", {
+        processCommandResolver: async (pid: number) =>
+          pid === legacyPid ? "python unrelated_script.py" : null,
+      });
+      vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+        if (signal === 0 && pid === legacyPid) {
+          return true;
+        }
+        return true;
+      }) as typeof process.kill);
+
+      fs.writeFileSync(legacyPidManager.getPath(), String(legacyPid), "utf-8");
+
+      const status = await legacyPidManager.inspect();
+
+      expect(status.running).toBe(false);
+      expect(status.alivePids).toEqual([]);
+      expect(status.unverifiedLegacyPids).toEqual([]);
+      expect(status.stalePids).toEqual([legacyPid]);
+      expect(fs.existsSync(legacyPidManager.getPath())).toBe(false);
     });
   });
 });

--- a/src/runtime/__tests__/pid-manager.test.ts
+++ b/src/runtime/__tests__/pid-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { PIDManager } from "../pid-manager.js";
@@ -75,9 +75,9 @@ describe("PIDManager", () => {
 
     it("should overwrite an existing PID file without error", async () => {
       await pidManager.writePID();
-      // Write a second time — should not throw
-      await expect(pidManager.writePID()).resolves.toBeUndefined();
+      const written = await pidManager.writePID();
       const info = await pidManager.readPID();
+      expect(written.pid).toBe(process.pid);
       expect(info!.pid).toBe(process.pid);
     });
   });
@@ -131,6 +131,8 @@ describe("PIDManager", () => {
       const result = await pidManager.readPID();
       expect(result!.pid).toBe(12345);
       expect(result!.started_at).toBe("2026-01-01T00:00:00.000Z");
+      expect(result!.runtime_pid).toBe(12345);
+      expect(result!.owner_pid).toBe(12345);
     });
   });
 
@@ -222,6 +224,68 @@ describe("PIDManager", () => {
       expect(await pidManager.isRunning()).toBe(true);
       await pidManager.cleanup();
       expect(await pidManager.isRunning()).toBe(false);
+    });
+  });
+
+  describe("runtime tree ownership", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("stores watchdog and runtime child ownership in the pid file", async () => {
+      await pidManager.writePID({
+        pid: 2202,
+        runtime_pid: 2202,
+        owner_pid: 1101,
+        watchdog_pid: 1101,
+        started_at: "2026-04-10T00:00:00.000Z",
+      });
+
+      const info = await pidManager.readPID();
+      expect(info).toMatchObject({
+        pid: 2202,
+        runtime_pid: 2202,
+        owner_pid: 1101,
+        watchdog_pid: 1101,
+        started_at: "2026-04-10T00:00:00.000Z",
+      });
+    });
+
+    it("stopRuntime terminates the watchdog and runtime child together", async () => {
+      const alive = new Set([4101, 4202]);
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: NodeJS.Signals | number) => {
+        if (signal === 0) {
+          if (!alive.has(pid)) {
+            const err = new Error("ESRCH") as NodeJS.ErrnoException;
+            err.code = "ESRCH";
+            throw err;
+          }
+          return true;
+        }
+
+        if (signal === "SIGTERM" || signal === "SIGKILL") {
+          alive.delete(pid);
+          return true;
+        }
+
+        return true;
+      }) as typeof process.kill);
+
+      await pidManager.writePID({
+        pid: 4202,
+        runtime_pid: 4202,
+        owner_pid: 4101,
+        watchdog_pid: 4101,
+        started_at: "2026-04-10T00:00:00.000Z",
+      });
+
+      const result = await pidManager.stopRuntime({ timeoutMs: 50, pollIntervalMs: 1 });
+
+      expect(killSpy).toHaveBeenCalledWith(4101, "SIGTERM");
+      expect(killSpy).toHaveBeenCalledWith(4202, "SIGTERM");
+      expect(result.stopped).toBe(true);
+      expect(result.forced).toBe(false);
+      expect(fs.existsSync(pidManager.getPath())).toBe(false);
     });
   });
 });

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -469,6 +469,97 @@ describe("Heartbeat execution", () => {
     expect(updated.consecutive_failures).toBe(0);
   });
 
+  it("schedules transient failures with retry/backoff and records durable history", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T00:00:00.000Z"));
+
+    const entry = await engine.addEntry({
+      name: "retry-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "exit 1" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+      retry_policy: {
+        enabled: true,
+        initial_delay_ms: 10_000,
+        max_delay_ms: 60_000,
+        multiplier: 2,
+        jitter_factor: 0,
+        max_attempts: 3,
+        max_retry_window_ms: 120_000,
+        retryable_failure_kinds: ["transient"],
+      },
+    });
+
+    const entries = engine.getEntries();
+    entries[0]!.next_fire_at = new Date("2026-04-07T23:59:00.000Z").toISOString();
+    await engine.saveEntries();
+    await engine.loadEntries();
+
+    const firstResults = await engine.tick();
+    expect(firstResults[0]!.status).toBe("down");
+
+    const updatedAfterFirst = engine.getEntries().find((e) => e.id === entry.id)!;
+    expect(updatedAfterFirst.retry_state).not.toBeNull();
+    expect(updatedAfterFirst.retry_state!.attempts).toBe(1);
+    expect(updatedAfterFirst.retry_state!.next_retry_at).toBe("2026-04-08T00:00:10.000Z");
+
+    const firstHistory = await engine.getRecentHistory(10, entry.id);
+    expect(firstHistory).toHaveLength(1);
+    expect(firstHistory[0]!.reason).toBe("cadence");
+    expect(firstHistory[0]!.failure_kind).toBe("transient");
+
+    vi.setSystemTime(new Date("2026-04-08T00:00:05.000Z"));
+    const pausedResults = await engine.tick();
+    expect(pausedResults).toHaveLength(0);
+
+    vi.setSystemTime(new Date("2026-04-08T00:00:10.000Z"));
+    const secondResults = await engine.tick();
+    expect(secondResults[0]!.status).toBe("down");
+
+    const updatedAfterSecond = engine.getEntries().find((e) => e.id === entry.id)!;
+    expect(updatedAfterSecond.retry_state).not.toBeNull();
+    expect(updatedAfterSecond.retry_state!.attempts).toBe(2);
+    expect(updatedAfterSecond.retry_state!.next_retry_at).toBe("2026-04-08T00:00:30.000Z");
+
+    const secondHistory = await engine.getRecentHistory(10, entry.id);
+    expect(secondHistory).toHaveLength(2);
+    expect(secondHistory.map((record) => record.reason)).toEqual(["cadence", "retry"]);
+
+    const engine2 = new ScheduleEngine({ baseDir: tempDir });
+    const persistedHistory = await engine2.getRecentHistory(10, entry.id);
+    expect(persistedHistory).toHaveLength(2);
+  });
+
+  it("does not create retry state for permanent cron failures", async () => {
+    const entry = await engine.addEntry({
+      name: "bad-cron",
+      layer: "cron",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+    });
+
+    const entries = engine.getEntries();
+    entries[0]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await engine.saveEntries();
+    await engine.loadEntries();
+
+    const results = await engine.tick();
+    expect(results[0]!.status).toBe("error");
+
+    const updated = engine.getEntries().find((candidate) => candidate.id === entry.id)!;
+    expect(updated.retry_state).toBeNull();
+
+    const history = await engine.getRecentHistory(10, entry.id);
+    expect(history).toHaveLength(1);
+    expect(history[0]!.failure_kind).toBe("permanent");
+  });
+
   it("tick routes cron entry without config to error (Phase 3)", async () => {
     const entry = await engine.addEntry({
       name: "cron-entry",
@@ -1076,6 +1167,98 @@ describe("Escalation", () => {
     const updatedTarget = eng.getEntries().find((e) => e.id === targetEntry.id)!;
     expect(updatedTarget.enabled).toBe(true);
   });
+
+  it("escalation executes target entry in the same tick", async () => {
+    const coreLoop = {
+      run: vi.fn().mockResolvedValue({ finalStatus: "completed", totalIterations: 1 }),
+    };
+    const eng = new ScheduleEngine({ baseDir: tempDir, coreLoop: coreLoop as any });
+
+    const targetEntry = await eng.addEntry({
+      name: "goal-trigger-target",
+      layer: "goal_trigger",
+      trigger: { type: "interval", seconds: 3600 },
+      enabled: false,
+      goal_trigger: {
+        goal_id: "goal-target",
+        max_iterations: 2,
+        skip_if_active: false,
+      },
+    });
+
+    const escalatingEntry = await eng.addEntry({
+      name: "escalating-entry",
+      layer: "probe",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      probe: {
+        data_source_id: "missing-source",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+      escalation: {
+        enabled: true,
+        circuit_breaker_threshold: 100,
+        cooldown_minutes: 0,
+        max_per_hour: 100,
+        target_entry_id: targetEntry.id,
+        target_layer: "goal_trigger",
+      },
+    });
+
+    const entries = eng.getEntries();
+    const idx = entries.findIndex((e) => e.id === escalatingEntry.id);
+    entries[idx]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    await eng.tick();
+
+    expect(coreLoop.run).toHaveBeenCalledWith("goal-target", { maxIterations: 2 });
+    const updatedTarget = eng.getEntries().find((e) => e.id === targetEntry.id)!;
+    expect(updatedTarget.last_fired_at).not.toBeNull();
+  });
+
+  it("escalation can run a direct goal target immediately", async () => {
+    const coreLoop = {
+      run: vi.fn().mockResolvedValue({ finalStatus: "completed", totalIterations: 1 }),
+    };
+    const eng = new ScheduleEngine({ baseDir: tempDir, coreLoop: coreLoop as any });
+
+    const escalatingEntry = await eng.addEntry({
+      name: "direct-goal-escalation",
+      layer: "probe",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      probe: {
+        data_source_id: "missing-source",
+        query_params: {},
+        change_detector: { mode: "diff", baseline_window: 5 },
+        llm_on_change: false,
+      },
+      escalation: {
+        enabled: true,
+        circuit_breaker_threshold: 100,
+        cooldown_minutes: 0,
+        max_per_hour: 100,
+        target_layer: "goal_trigger",
+        target_goal_id: "goal-direct",
+      },
+    });
+
+    const entries = eng.getEntries();
+    const idx = entries.findIndex((e) => e.id === escalatingEntry.id);
+    entries[idx]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+
+    expect(results[0]!.status).toBe("escalated");
+    expect(results[0]!.escalated_to).toBe("goal-direct");
+    expect(coreLoop.run).toHaveBeenCalledWith("goal-direct");
+  });
 });
 
 // ─── Additional Phase 2 tests ───
@@ -1164,7 +1347,7 @@ describe('Probe execution edge cases', () => {
     expect(result.error_message).toContain('No probe config');
   });
 
-  it('escalation sets target entry next_fire_at for immediate firing', async () => {
+  it('escalation executes the target entry immediately and advances its schedule', async () => {
     const eng = new ScheduleEngine({ baseDir: tempDir });
 
     const targetEntry = await eng.addEntry({
@@ -1207,13 +1390,51 @@ describe('Probe execution edge cases', () => {
     await eng.saveEntries();
     await eng.loadEntries();
 
-    const beforeTick = Date.now();
     await eng.tick();
 
     const updatedTarget = eng.getEntries().find((e) => e.id === targetEntry.id)!;
     expect(updatedTarget.enabled).toBe(true);
-    // next_fire_at should have been set to a time <= now (i.e., immediate firing)
-    expect(new Date(updatedTarget.next_fire_at).getTime()).toBeLessThanOrEqual(beforeTick + 5000);
+    expect(updatedTarget.last_fired_at).not.toBeNull();
+    expect(new Date(updatedTarget.next_fire_at).getTime()).toBeGreaterThan(Date.now() - 5000);
+  });
+
+  it("dispatches a heartbeat failure notification when the failure threshold is reached", async () => {
+    const notifications: Record<string, unknown>[] = [];
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      notificationDispatcher: {
+        dispatch: async (report) => { notifications.push(report); },
+      },
+    });
+
+    const entry = await eng.addEntry({
+      name: "heartbeat-failure",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60 },
+      enabled: true,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "exit 1" },
+        failure_threshold: 1,
+        timeout_ms: 1000,
+      },
+    });
+
+    const entries = eng.getEntries();
+    const idx = entries.findIndex((candidate) => candidate.id === entry.id);
+    entries[idx]!.next_fire_at = new Date(Date.now() - 1000).toISOString();
+    await eng.saveEntries();
+    await eng.loadEntries();
+
+    const results = await eng.tick();
+
+    expect(results[0]!.status).toBe("down");
+    expect(notifications).toEqual([
+      expect.objectContaining({
+        report_type: "schedule_heartbeat_failure",
+        entry_id: entry.id,
+      }),
+    ]);
   });
 });
 

--- a/src/runtime/__tests__/watchdog.test.ts
+++ b/src/runtime/__tests__/watchdog.test.ts
@@ -159,6 +159,10 @@ describe("RuntimeWatchdog", () => {
     const startPromise = watchdog.start();
 
     await waitFor(() => children.length === 1);
+    await waitFor(async () => {
+      const info = await pidManager.readPID();
+      return info?.pid === children[0]!.pid;
+    }, 2_000, 20);
     const firstInfo = await pidManager.readPID();
     expect(firstInfo).toMatchObject({
       pid: children[0]!.pid,

--- a/src/runtime/__tests__/watchdog.test.ts
+++ b/src/runtime/__tests__/watchdog.test.ts
@@ -26,13 +26,13 @@ class FakeChildProcess extends EventEmitter {
 }
 
 async function waitFor(
-  predicate: () => boolean,
+  predicate: () => boolean | Promise<boolean>,
   timeoutMs = 2_000,
   intervalMs = 20
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (predicate()) {
+    if (await predicate()) {
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
@@ -123,5 +123,72 @@ describe("RuntimeWatchdog", () => {
 
     expect(fs.existsSync(pidManager.getPath())).toBe(false);
     expect(children[1]!.kills).toContain("SIGTERM");
+  });
+
+  it("updates the pid file to the current runtime child across restarts", async () => {
+    tmpDir = makeTempDir();
+    const runtimeRoot = path.join(tmpDir, "runtime");
+    const pidManager = new PIDManager(tmpDir);
+    const healthStore = new RuntimeHealthStore(runtimeRoot);
+    const leaderLockManager = new LeaderLockManager(runtimeRoot, 60);
+    await healthStore.ensureReady();
+
+    const children: FakeChildProcess[] = [];
+    const watchdog = new RuntimeWatchdog({
+      pidManager,
+      healthStore,
+      leaderLockManager,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      startChild: () => {
+        const child = new FakeChildProcess(20_000 + children.length);
+        children.push(child);
+        return child;
+      },
+      pollIntervalMs: 20,
+      heartbeatTimeoutMs: 50,
+      startupGraceMs: 40,
+      restartBackoffMs: 10,
+      maxRestartBackoffMs: 20,
+      childShutdownGraceMs: 10,
+    });
+
+    const startPromise = watchdog.start();
+
+    await waitFor(() => children.length === 1);
+    const firstInfo = await pidManager.readPID();
+    expect(firstInfo).toMatchObject({
+      pid: children[0]!.pid,
+      runtime_pid: children[0]!.pid,
+      owner_pid: process.pid,
+      watchdog_pid: process.pid,
+    });
+
+    await writeLeaderRecord(runtimeRoot, children[0]!.pid, Date.now() + 100);
+    await healthStore.saveDaemonHealth({
+      status: "ok",
+      leader: true,
+      checked_at: Date.now(),
+      details: { pid: children[0]!.pid },
+    });
+
+    await waitFor(() => children.length === 2, 2_000, 20);
+    await waitFor(async () => {
+      const info = await pidManager.readPID();
+      return info?.pid === children[1]!.pid;
+    }, 2_000, 20);
+    const secondInfo = await pidManager.readPID();
+    expect(secondInfo).toMatchObject({
+      pid: children[1]!.pid,
+      runtime_pid: children[1]!.pid,
+      owner_pid: process.pid,
+      watchdog_pid: process.pid,
+    });
+
+    watchdog.stop();
+    await startPromise;
   });
 });

--- a/src/runtime/daemon/client.ts
+++ b/src/runtime/daemon/client.ts
@@ -351,7 +351,7 @@ export async function isDaemonRunning(baseDir: string): Promise<{ running: boole
     const raw = await fs.readFile(statePath, "utf-8");
     const state = JSON.parse(raw);
 
-    if (state.status !== "running" || !state.pid) {
+    if ((state.status !== "running" && state.status !== "idle") || !state.pid) {
       return { running: false, port: DEFAULT_PORT };
     }
 

--- a/src/runtime/daemon/index.ts
+++ b/src/runtime/daemon/index.ts
@@ -22,6 +22,7 @@ export {
   getNextIntervalForGoals,
   processCronTasksForDaemon,
   processScheduleEntriesForDaemon,
+  runRuntimeStoreMaintenanceCycle,
   runProactiveMaintenance,
   runSupervisorMaintenanceCycleForDaemon,
   writeChatMessageEvent,

--- a/src/runtime/daemon/maintenance.ts
+++ b/src/runtime/daemon/maintenance.ts
@@ -1,3 +1,5 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
 import { z } from "zod";
 import { getInternalIdentityPrefix } from "../../base/config/identity-loader.js";
 import { PulSeedEventSchema } from "../../base/types/drive.js";
@@ -9,11 +11,51 @@ import type { Envelope } from "../types/envelope.js";
 import type { CronScheduler } from "../cron-scheduler.js";
 import type { ScheduleEngine } from "../schedule/engine.js";
 import type { Logger } from "../logger.js";
+import { ApprovalStore, OutboxStore, RuntimeHealthStore, createRuntimeStorePaths } from "../store/index.js";
+
+export interface RuntimeMaintenanceLogger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  info(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+export interface RuntimeStoreMaintenanceOptions {
+  approvalRetentionMs?: number;
+  outboxRetentionMs?: number;
+  outboxMaxRecords?: number;
+  claimRetentionMs?: number;
+}
+
+export interface RuntimeStoreMaintenanceReport {
+  approvals: {
+    removedPending: number;
+    expiredPending: number;
+    prunedResolved: number;
+  };
+  outbox: {
+    pruned: number;
+    retained: number;
+  };
+  health: {
+    repaired: boolean;
+    status: string | null;
+  };
+  claims: {
+    pruned: number;
+  };
+}
 
 const ProactiveResponseSchema = z.object({
   action: z.enum(["suggest_goal", "investigate", "preemptive_check", "sleep"]),
   details: z.record(z.string(), z.unknown()).optional(),
 });
+export type ProactiveDecision = z.infer<typeof ProactiveResponseSchema>;
+
+export interface ProactiveMaintenanceResult {
+  lastProactiveTickAt: number;
+  decision: ProactiveDecision | null;
+}
 
 export type GoalCycleScheduleSnapshotEntry = GoalActivationSnapshot;
 
@@ -166,19 +208,124 @@ export async function expireOldCronTasks(
   }
 }
 
+async function pruneStaleFiles(
+  dirPath: string,
+  olderThanMs: number,
+  now: number,
+): Promise<number> {
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dirPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return 0;
+    }
+    throw err;
+  }
+
+  const threshold = now - olderThanMs;
+  let pruned = 0;
+
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry);
+    let stat: Awaited<ReturnType<typeof fsp.stat>>;
+    try {
+      stat = await fsp.stat(fullPath);
+    } catch {
+      continue;
+    }
+
+    if (!stat.isFile()) {
+      continue;
+    }
+    if (stat.mtimeMs >= threshold) {
+      continue;
+    }
+
+    try {
+      await fsp.unlink(fullPath);
+      pruned += 1;
+    } catch {
+      // Best-effort cleanup.
+    }
+  }
+
+  return pruned;
+}
+
+export async function runRuntimeStoreMaintenanceCycle(params: {
+  runtimeRoot: string;
+  approvalStore?: ApprovalStore;
+  outboxStore?: OutboxStore;
+  runtimeHealthStore?: RuntimeHealthStore;
+  logger: RuntimeMaintenanceLogger;
+  now?: number;
+  options?: RuntimeStoreMaintenanceOptions;
+}): Promise<RuntimeStoreMaintenanceReport> {
+  const now = params.now ?? Date.now();
+  const options = params.options ?? {};
+  const runtimePaths = createRuntimeStorePaths(params.runtimeRoot);
+  const approvalStore = params.approvalStore ?? new ApprovalStore(runtimePaths);
+  const outboxStore = params.outboxStore ?? new OutboxStore(runtimePaths);
+  const runtimeHealthStore =
+    params.runtimeHealthStore ?? new RuntimeHealthStore(runtimePaths);
+
+  const approvals = await approvalStore.reconcile(now);
+  const prunedResolved = await approvalStore.pruneResolved(
+    options.approvalRetentionMs ?? 30 * 24 * 60 * 60 * 1000,
+    now,
+  );
+  const outbox = await outboxStore.prune({
+    olderThanMs: options.outboxRetentionMs ?? 30 * 24 * 60 * 60 * 1000,
+    maxRecords: options.outboxMaxRecords ?? 5_000,
+    now,
+  });
+  const health = await runtimeHealthStore.reconcile(now);
+  const claims = await pruneStaleFiles(
+    runtimePaths.claimsDir,
+    options.claimRetentionMs ?? 7 * 24 * 60 * 60 * 1000,
+    now,
+  );
+
+  params.logger.info("Runtime store maintenance cycle completed", {
+    approvals_removed_pending: approvals.removedPending,
+    approvals_expired_pending: approvals.expiredPending,
+    approvals_pruned_resolved: prunedResolved,
+    outbox_pruned: outbox.pruned,
+    outbox_retained: outbox.retained,
+    claims_pruned: claims,
+    health_status: health.status,
+  });
+
+  return {
+    approvals: {
+      ...approvals,
+      prunedResolved,
+    },
+    outbox,
+    health: {
+      repaired: health.details?.["repaired"] === true,
+      status: health.status,
+    },
+    claims: {
+      pruned: claims,
+    },
+  };
+}
+
 export async function runProactiveMaintenance(params: {
   config: DaemonConfig;
   llmClient?: ILLMClient;
   state: DaemonState;
   lastProactiveTickAt: number;
   logger: Logger;
-}): Promise<number> {
+}): Promise<ProactiveMaintenanceResult> {
   const { config, llmClient, state, lastProactiveTickAt, logger } = params;
   if (!config.proactive_mode || !llmClient) {
-    return lastProactiveTickAt;
+    return { lastProactiveTickAt, decision: null };
   }
   if (Date.now() - lastProactiveTickAt < config.proactive_interval_ms) {
-    return lastProactiveTickAt;
+    return { lastProactiveTickAt, decision: null };
   }
 
   try {
@@ -201,7 +348,7 @@ export async function runProactiveMaintenance(params: {
         raw: response.content,
         error: parsed.error.message,
       });
-      return Date.now();
+      return { lastProactiveTickAt: Date.now(), decision: null };
     }
 
     const { action, details } = parsed.data;
@@ -210,13 +357,19 @@ export async function runProactiveMaintenance(params: {
     } else {
       logger.info(`Proactive tick: action=${action}`, { details });
     }
+    return {
+      lastProactiveTickAt: Date.now(),
+      decision: parsed.data,
+    };
   } catch (err) {
     logger.warn("Proactive tick: LLM error (ignored)", {
       error: err instanceof Error ? err.message : String(err),
     });
+    return {
+      lastProactiveTickAt: Date.now(),
+      decision: null,
+    };
   }
-
-  return Date.now();
 }
 
 export async function getMaxGapScoreForGoals(
@@ -259,6 +412,8 @@ function getPersistedDaemonStateSnapshot(state: DaemonState): string {
     loop_count: state.loop_count,
     last_loop_at: state.last_loop_at,
     interrupted_goals: state.interrupted_goals ? [...state.interrupted_goals] : undefined,
+    last_resident_at: state.last_resident_at,
+    resident_activity: state.resident_activity,
   });
 }
 
@@ -269,6 +424,7 @@ export async function runSupervisorMaintenanceCycleForDaemon(params: {
   processCronTasks: () => Promise<void>;
   processScheduleEntries: () => Promise<void>;
   proactiveTick: () => Promise<void>;
+  runRuntimeStoreMaintenance?: () => Promise<void>;
   saveDaemonState: () => Promise<void>;
   eventServer?: { broadcast?(event: string, payload: Record<string, unknown>): void | Promise<void> };
   state: DaemonState;
@@ -290,6 +446,7 @@ export async function runSupervisorMaintenanceCycleForDaemon(params: {
   await params.processCronTasks();
   await params.processScheduleEntries();
   await params.proactiveTick();
+  await params.runRuntimeStoreMaintenance?.();
   if (getPersistedDaemonStateSnapshot(params.state) !== stateBeforeMaintenance) {
     await params.saveDaemonState();
   }

--- a/src/runtime/daemon/runner-lifecycle.ts
+++ b/src/runtime/daemon/runner-lifecycle.ts
@@ -26,7 +26,10 @@ export function startDaemonStatusHeartbeat(
   const timer = setInterval(() => {
     const { eventServer } = options;
     const snapshot = options.getSnapshot();
-    if (!eventServer || snapshot.status !== "running") {
+    if (
+      !eventServer ||
+      (snapshot.status !== "running" && snapshot.status !== "idle")
+    ) {
       return;
     }
 

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -1,17 +1,29 @@
+import * as fs from "node:fs";
 import * as path from "node:path";
+import { spawnSync } from "node:child_process";
 import { CoreLoop } from "../../orchestrator/loop/core-loop.js";
 import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
+import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
+import type { Goal } from "../../base/types/goal.js";
 import { DriveSystem } from "../../platform/drive/drive-system.js";
 import { StateManager } from "../../base/state/state-manager.js";
+import { getProviderRuntimeFingerprint } from "../../base/llm/provider-config.js";
+import type { CuriosityEngine } from "../../platform/traits/curiosity-engine.js";
 import { PIDManager } from "../pid-manager.js";
 import { Logger } from "../logger.js";
 import { EventServer } from "../event/server.js";
 import type { PulSeedEvent } from "../../base/types/drive.js";
-import type { DaemonConfig, DaemonState } from "../../base/types/daemon.js";
-import { DaemonConfigSchema, DaemonStateSchema } from "../../base/types/daemon.js";
+import type { DaemonConfig, DaemonState, ResidentActivity } from "../../base/types/daemon.js";
+import { DaemonConfigSchema, DaemonStateSchema, ResidentActivitySchema } from "../../base/types/daemon.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { CronScheduler } from "../cron-scheduler.js";
 import { ScheduleEngine } from "../schedule/engine.js";
+import type { MemoryLifecycleManager } from "../../platform/knowledge/memory/memory-lifecycle.js";
+import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
+import { DreamAnalyzer } from "../../platform/dream/dream-analyzer.js";
+import { DreamScheduleSuggestionStore } from "../../platform/dream/dream-schedule-suggestions.js";
+import type { DreamRunReport, DreamTier } from "../../platform/dream/dream-types.js";
+import { runDreamConsolidation } from "../../reflection/dream-consolidation.js";
 import { generateCronEntry } from "./signals.js";
 import { rotateDaemonLog, calculateAdaptiveInterval as calcAdaptiveInterval } from "./health.js";
 import { IngressGateway, HttpChannelAdapter } from "../gateway/index.js";
@@ -46,6 +58,7 @@ import {
   getNextIntervalForGoals,
   processCronTasksForDaemon,
   processScheduleEntriesForDaemon,
+  runRuntimeStoreMaintenanceCycle,
   readShutdownMarkerFile,
   restoreInterruptedGoals,
   runProactiveMaintenance,
@@ -55,6 +68,68 @@ import {
   writeShutdownMarkerFile,
 } from "./index.js";
 import type { GoalCycleScheduleSnapshotEntry } from "./maintenance.js";
+
+function gatherResidentWorkspaceContext(workspaceDir: string, seedDescription?: string): string {
+  const parts: string[] = [`Workspace: ${workspaceDir}`];
+  const seed = seedDescription?.trim();
+  if (seed) {
+    parts.push(`Resident trigger hint: ${seed}`);
+  }
+
+  try {
+    const pkgPath = path.join(workspaceDir, "package.json");
+    const pkgRaw = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(pkgRaw) as Record<string, unknown>;
+    const name = typeof pkg.name === "string" ? pkg.name : "";
+    const description = typeof pkg.description === "string" ? pkg.description : "";
+    const scripts = pkg.scripts && typeof pkg.scripts === "object"
+      ? Object.keys(pkg.scripts as Record<string, unknown>).join(", ")
+      : "";
+    const prefix = name ? `Node.js project '${name}'` : "Node.js project";
+    const descPart = description ? `. ${description}` : "";
+    const scriptsPart = scripts ? `. Scripts: ${scripts}` : "";
+    parts.push(`${prefix}${descPart}${scriptsPart}`);
+  } catch {
+    // No package metadata available.
+  }
+
+  try {
+    const entries = fs.readdirSync(workspaceDir);
+    const dirs = entries.filter((entry) => {
+      try {
+        return fs.statSync(path.join(workspaceDir, entry)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+    const files = entries.filter((entry) => {
+      try {
+        return fs.statSync(path.join(workspaceDir, entry)).isFile();
+      } catch {
+        return false;
+      }
+    });
+    const visibleEntries = [
+      dirs.slice(0, 10).map((entry) => `${entry}/`).join(", "),
+      files.slice(0, 5).join(", "),
+    ].filter(Boolean).join(", ");
+    if (visibleEntries) {
+      parts.push(`Files: ${visibleEntries}`);
+    }
+  } catch {
+    // Workspace listing is best-effort.
+  }
+
+  const gitResult = spawnSync("git", ["log", "--oneline", "-5", "--format=%s"], {
+    cwd: workspaceDir,
+    encoding: "utf-8",
+  });
+  if (gitResult.status === 0 && gitResult.stdout.trim().length > 0) {
+    parts.push(`Recent changes: ${gitResult.stdout.trim().split("\n").join("; ")}`);
+  }
+
+  return parts.join(". ");
+}
 
 // Re-exports for callers that imported these from daemon-runner
 export { generateCronEntry } from "./signals.js";
@@ -81,6 +156,8 @@ const RUNTIME_LEADER_HEARTBEAT_MS = 10_000;
 
 export interface DaemonDeps {
   coreLoop: CoreLoop;
+  curiosityEngine?: CuriosityEngine;
+  goalNegotiator?: GoalNegotiator;
   driveSystem: DriveSystem;
   stateManager: StateManager;
   pidManager: PIDManager;
@@ -96,14 +173,34 @@ export interface DaemonDeps {
   llmClient?: ILLMClient;
   cronScheduler?: CronScheduler;
   scheduleEngine?: ScheduleEngine;
+  memoryLifecycle?: MemoryLifecycleManager;
+  knowledgeManager?: KnowledgeManager;
   gateway?: IngressGateway;
   supervisor?: LoopSupervisor;
+  getProviderRuntimeFingerprint?: () => Promise<string>;
+  refreshResidentDeps?: () => Promise<{
+    coreLoop: CoreLoop;
+    curiosityEngine?: CuriosityEngine;
+    goalNegotiator?: GoalNegotiator;
+    llmClient?: ILLMClient;
+    reportingEngine?: {
+      generateNotification(
+        type: "approval_required",
+        context: { goalId: string; message: string; details?: string }
+      ): Promise<unknown>;
+    };
+    scheduleEngine?: ScheduleEngine;
+    memoryLifecycle?: MemoryLifecycleManager;
+    knowledgeManager?: KnowledgeManager;
+  }>;
   /** Factory to create fresh CoreLoop instances for LoopSupervisor workers. */
   coreLoopFactory?: () => CoreLoop;
 }
 
 export class DaemonRunner {
   private coreLoop: CoreLoop;
+  private curiosityEngine: CuriosityEngine | undefined;
+  private goalNegotiator: GoalNegotiator | undefined;
   private driveSystem: DriveSystem;
   private stateManager: StateManager;
   private pidManager: PIDManager;
@@ -132,13 +229,17 @@ export class DaemonRunner {
     | undefined;
   private cronScheduler: CronScheduler | undefined;
   private scheduleEngine: ScheduleEngine | undefined;
+  private memoryLifecycle: MemoryLifecycleManager | undefined;
+  private knowledgeManager: KnowledgeManager | undefined;
   private consecutiveIdleCycles: number = 0;
   private gateway: IngressGateway | undefined;
   private supervisor: LoopSupervisor | null = null;
+  private lastGoalReviewAt: number = Date.now();
   private cronScheduleInterval: ReturnType<typeof setInterval> | null = null;
   private shutdownResolve: (() => void) | null = null;
   private shutdownCoordinator: ProcessShutdownCoordinator | null = null;
   private stopStatusHeartbeat: (() => void) | null = null;
+  private lastRuntimeStoreMaintenanceAt = 0;
   private readonly deps: DaemonDeps;
   private runtimeRoot: string | null = null;
   private approvalStore: ApprovalStore | null = null;
@@ -152,10 +253,15 @@ export class DaemonRunner {
   private commandDispatcher: CommandDispatcher | null = null;
   private eventDispatcher: EventDispatcher | null = null;
   private runtimeOwnership: RuntimeOwnershipCoordinator;
+  private readonly getProviderRuntimeFingerprintFn: () => Promise<string>;
+  private readonly refreshResidentDeps: DaemonDeps["refreshResidentDeps"];
+  private providerRuntimeFingerprint: string | null = null;
 
   constructor(deps: DaemonDeps) {
     this.deps = deps;
     this.coreLoop = deps.coreLoop;
+    this.curiosityEngine = deps.curiosityEngine;
+    this.goalNegotiator = deps.goalNegotiator;
     this.driveSystem = deps.driveSystem;
     this.stateManager = deps.stateManager;
     this.pidManager = deps.pidManager;
@@ -165,6 +271,8 @@ export class DaemonRunner {
     this.reportingEngine = deps.reportingEngine;
     this.cronScheduler = deps.cronScheduler;
     this.scheduleEngine = deps.scheduleEngine;
+    this.memoryLifecycle = deps.memoryLifecycle;
+    this.knowledgeManager = deps.knowledgeManager;
     this.gateway = deps.gateway;
     this.supervisor = deps.supervisor ?? null;
     this.lastProactiveTickAt = Date.now();
@@ -205,6 +313,9 @@ export class DaemonRunner {
       leaderLockManager: this.leaderLockManager,
       onLeadershipLost: (reason) => this.failRuntimeLeadership(reason),
     });
+    this.getProviderRuntimeFingerprintFn =
+      deps.getProviderRuntimeFingerprint ?? getProviderRuntimeFingerprint;
+    this.refreshResidentDeps = deps.refreshResidentDeps;
 
     // Initialize daemon state
     this.state = DaemonStateSchema.parse({
@@ -216,7 +327,17 @@ export class DaemonRunner {
       status: "stopped",
       crash_count: 0,
       last_error: null,
+      last_resident_at: null,
+      resident_activity: null,
     });
+  }
+
+  private refreshOperationalState(): void {
+    this.state.active_goals = [...this.currentGoalIds];
+    if (this.state.status === "crashed" || this.state.status === "stopping") {
+      return;
+    }
+    this.state.status = this.currentGoalIds.length === 0 ? "idle" : "running";
   }
 
   private resolveRuntimeRoot(): string {
@@ -243,6 +364,7 @@ export class DaemonRunner {
       await this.checkCrashRecovery();
       await this.initializeRuntimeFoundation();
       await this.acquireRuntimeLeadership();
+      await this.runRuntimeStoreMaintenance(true);
 
       // 2c. Start EventServer (always-on) and file watcher
       if (!this.eventServer) {
@@ -364,10 +486,13 @@ export class DaemonRunner {
         last_loop_at: null,
         loop_count: 0,
         active_goals: mergedGoalIds,
-        status: "running",
+        status: mergedGoalIds.length === 0 ? "idle" : "running",
         crash_count: 0,
         last_error: null,
+        last_resident_at: null,
+        resident_activity: null,
       });
+      this.providerRuntimeFingerprint = await this.captureProviderRuntimeFingerprint();
       await this.saveDaemonState();
 
       // 5b. Write "running" shutdown marker (crash detection on next startup)
@@ -591,9 +716,11 @@ export class DaemonRunner {
     while (this.running && !this.shuttingDown) {
       try {
         const goalIds = [...this.currentGoalIds];
+        this.refreshOperationalState();
         const cycleSnapshot = await this.collectGoalCycleSnapshot(goalIds);
         // 1. Determine which goals need activation
         const activeGoals = await this.determineActiveGoals(goalIds, cycleSnapshot);
+        await this.maybeRefreshProviderRuntime(activeGoals.length);
 
         if (activeGoals.length === 0) {
           this.logger.info("No goals need activation this cycle", {
@@ -625,6 +752,7 @@ export class DaemonRunner {
                 status: goal?.status ?? "unknown",
               });
             }
+            await this.broadcastGoalUpdated(goalId, result.finalStatus);
           } catch (err) {
             this.handleLoopError(goalId, err);
           }
@@ -634,6 +762,7 @@ export class DaemonRunner {
         }
 
         // 3. Save state
+        this.refreshOperationalState();
         await this.saveDaemonState();
         if (this.eventServer) {
           void this.eventServer.broadcast?.("daemon_status", {
@@ -659,6 +788,10 @@ export class DaemonRunner {
         // do not block proactive actions indefinitely.
         if (this.running) {
           await this.proactiveTick();
+        }
+
+        if (this.running) {
+          await this.runRuntimeStoreMaintenance();
         }
 
         // 5. Track idle cycles for adaptive sleep
@@ -831,6 +964,32 @@ export class DaemonRunner {
     });
   }
 
+  private async broadcastGoalUpdated(goalId: string, fallbackStatus?: string): Promise<void> {
+    if (!this.eventServer) {
+      return;
+    }
+
+    const goal = await this.stateManager.loadGoal(goalId).catch(() => null);
+    await this.eventServer.broadcast?.("goal_updated", {
+      goalId,
+      status: goal?.status ?? fallbackStatus ?? "unknown",
+      loopStatus: goal?.loop_status ?? null,
+      progress: null,
+    });
+  }
+
+  private async broadcastChatResponse(goalId: string, message: string): Promise<void> {
+    if (!this.eventServer) {
+      return;
+    }
+
+    await this.eventServer.broadcast?.("chat_response", {
+      goalId,
+      message,
+      status: "queued",
+    });
+  }
+
   /**
    * Expire old non-permanent cron tasks.
    */
@@ -899,21 +1058,23 @@ export class DaemonRunner {
     if (!this.currentGoalIds.includes(goalId)) {
       this.currentGoalIds.push(goalId);
     }
-    this.state.active_goals = [...this.currentGoalIds];
+    this.refreshOperationalState();
     await this.saveDaemonState();
     this.supervisor?.activateGoal(goalId);
     this.abortSleep();
+    await this.broadcastGoalUpdated(goalId, "active");
   }
 
   private async handleGoalStopCommand(goalId: string): Promise<void> {
     this.currentGoalIds = this.currentGoalIds.filter((id) => id !== goalId);
-    this.state.active_goals = [...this.currentGoalIds];
+    this.refreshOperationalState();
     if (this.state.interrupted_goals) {
       this.state.interrupted_goals = this.state.interrupted_goals.filter((id) => id !== goalId);
     }
     await this.saveDaemonState();
     this.supervisor?.deactivateGoal(goalId);
     this.abortSleep();
+    await this.broadcastGoalUpdated(goalId, "stopped");
   }
 
   private async handleGoalCompletion(goalId: string, result: { status: string; totalIterations: number }): Promise<void> {
@@ -937,9 +1098,366 @@ export class DaemonRunner {
         lastLoopAt: this.state.last_loop_at,
       });
     }
+    await this.broadcastGoalUpdated(goalId, result.status);
+  }
+
+  private async loadExistingGoalTitles(): Promise<string[]> {
+    const goalIds = await this.stateManager.listGoalIds().catch(() => []);
+    const titles: string[] = [];
+    for (const goalId of goalIds) {
+      const goal = await this.stateManager.loadGoal(goalId).catch(() => null);
+      if (goal?.title) {
+        titles.push(goal.title);
+      }
+    }
+    return titles;
+  }
+
+  private async loadKnownGoals(): Promise<Goal[]> {
+    const goalIds = await this.stateManager.listGoalIds().catch(() => []);
+    const goals: Goal[] = [];
+    for (const goalId of goalIds) {
+      const goal = await this.stateManager.loadGoal(goalId).catch(() => null);
+      if (goal) {
+        goals.push(goal);
+      }
+    }
+    return goals;
+  }
+
+  private async persistResidentActivity(
+    activity: Omit<ResidentActivity, "recorded_at"> & { recorded_at?: string }
+  ): Promise<void> {
+    const residentActivity = ResidentActivitySchema.parse({
+      ...activity,
+      recorded_at: activity.recorded_at ?? new Date().toISOString(),
+    });
+    this.state.last_resident_at = residentActivity.recorded_at;
+    this.state.resident_activity = residentActivity;
+    await this.saveDaemonState();
+  }
+
+  private async triggerResidentGoalDiscovery(details?: Record<string, unknown>): Promise<void> {
+    if (!this.goalNegotiator) {
+      await this.persistResidentActivity({
+        kind: "skipped",
+        trigger: "proactive_tick",
+        summary: "Resident discovery skipped because goal negotiation is unavailable.",
+      });
+      return;
+    }
+
+    if (this.currentGoalIds.length > 0) {
+      await this.persistResidentActivity({
+        kind: "skipped",
+        trigger: "proactive_tick",
+        summary: "Resident discovery skipped because active goals are already running.",
+      });
+      return;
+    }
+
+    const hintedDescription =
+      typeof details?.["description"] === "string" ? details["description"].trim() : "";
+    const hintedTitle =
+      typeof details?.["title"] === "string" ? details["title"].trim() : "";
+
+    try {
+      const workspaceDir = process.cwd();
+      const workspaceContext = gatherResidentWorkspaceContext(workspaceDir, hintedDescription);
+      const existingTitles = await this.loadExistingGoalTitles();
+      const suggestions = await this.goalNegotiator.suggestGoals(workspaceContext, {
+        maxSuggestions: 1,
+        existingGoals: existingTitles,
+        repoPath: workspaceDir,
+      });
+      const suggestion = suggestions[0];
+      const suggestionTitle = suggestion?.title ?? hintedTitle;
+      const negotiationDescription = suggestion?.description ?? hintedDescription;
+
+      if (!negotiationDescription) {
+        await this.persistResidentActivity({
+          kind: "suggestion",
+          trigger: "proactive_tick",
+          summary: "Resident discovery ran but found no actionable goal to negotiate.",
+          suggestion_title: suggestionTitle || undefined,
+        });
+        return;
+      }
+
+      const { goal } = await this.goalNegotiator.negotiate(negotiationDescription, {
+        workspaceContext,
+        timeoutMs: 30_000,
+      });
+      if (!this.currentGoalIds.includes(goal.id)) {
+        this.currentGoalIds.push(goal.id);
+      }
+      this.refreshOperationalState();
+      await this.persistResidentActivity({
+        kind: "negotiation",
+        trigger: "proactive_tick",
+        summary: `Resident discovery negotiated a new goal: ${suggestionTitle || goal.title}`,
+        suggestion_title: suggestionTitle || goal.title,
+        goal_id: goal.id,
+      });
+      this.supervisor?.activateGoal(goal.id);
+      this.abortSleep();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn("Resident discovery failed", { error: message });
+      await this.persistResidentActivity({
+        kind: "error",
+        trigger: "proactive_tick",
+        summary: `Resident discovery failed: ${message}`,
+      });
+    }
+  }
+
+  private async runResidentCuriosityCycle(options?: {
+    activityTrigger?: ResidentActivity["trigger"];
+    focus?: string;
+    reviewLabel?: string;
+    skipWhenNoTriggers?: boolean;
+  }): Promise<boolean> {
+    if (!this.curiosityEngine) {
+      if (options?.skipWhenNoTriggers) {
+        return false;
+      }
+      await this.persistResidentActivity({
+        kind: "skipped",
+        trigger: options?.activityTrigger ?? "proactive_tick",
+        summary: "Resident investigation skipped because curiosity wiring is unavailable.",
+      });
+      return true;
+    }
+
+    try {
+      const goals = await this.loadKnownGoals();
+      const triggers = await this.curiosityEngine.evaluateTriggers(goals);
+      const focus = options?.focus?.trim() ?? "";
+
+      if (triggers.length === 0) {
+        if (options?.skipWhenNoTriggers) {
+          return false;
+        }
+        await this.persistResidentActivity({
+          kind: "curiosity",
+          trigger: options?.activityTrigger ?? "proactive_tick",
+          summary: options?.reviewLabel
+            ? `Resident ${options.reviewLabel} ran and found no curiosity triggers.`
+            : `Resident investigation ran${focus ? ` for ${focus}` : ""} and found nothing actionable.`,
+        });
+        return true;
+      }
+
+      const proposals = await this.curiosityEngine.generateProposals(triggers, goals);
+      if (proposals.length === 0) {
+        await this.persistResidentActivity({
+          kind: "curiosity",
+          trigger: options?.activityTrigger ?? "proactive_tick",
+          summary: options?.reviewLabel
+            ? `Resident ${options.reviewLabel} ran but produced no curiosity proposals.`
+            : `Resident investigation ran${focus ? ` for ${focus}` : ""} but produced no curiosity proposals.`,
+        });
+        return true;
+      }
+
+      const proposal = proposals[0]!;
+      await this.persistResidentActivity({
+        kind: "curiosity",
+        trigger: options?.activityTrigger ?? "proactive_tick",
+        summary: options?.reviewLabel
+          ? `Resident ${options.reviewLabel} created ${proposals.length} curiosity proposal(s); next focus: ${proposal.proposed_goal.description}`
+          : `Resident investigation created ${proposals.length} curiosity proposal(s); next focus: ${proposal.proposed_goal.description}`,
+        suggestion_title: proposal.proposed_goal.description,
+      });
+      return true;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn("Resident investigation failed", { error: message });
+      await this.persistResidentActivity({
+        kind: "error",
+        trigger: options?.activityTrigger ?? "proactive_tick",
+        summary: `Resident investigation failed: ${message}`,
+      });
+      return true;
+    }
+  }
+
+  private async triggerResidentInvestigation(details?: Record<string, unknown>): Promise<void> {
+    const focus = typeof details?.["what"] === "string" ? details["what"].trim() : "";
+    await this.runResidentCuriosityCycle({
+      activityTrigger: "proactive_tick",
+      focus,
+      skipWhenNoTriggers: false,
+    });
+  }
+
+  private async runScheduledGoalReview(): Promise<boolean> {
+    if (!this.curiosityEngine || !this.config.proactive_mode) {
+      return false;
+    }
+    const now = Date.now();
+    if (now - this.lastGoalReviewAt < this.config.goal_review_interval_ms) {
+      return false;
+    }
+    this.lastGoalReviewAt = now;
+    return this.runResidentCuriosityCycle({
+      activityTrigger: "schedule",
+      reviewLabel: "goal review",
+      skipWhenNoTriggers: false,
+    });
+  }
+
+  private async tryApplyPendingDreamSuggestion(): Promise<{
+    suggestion: { id: string; name?: string; reason?: string };
+    entry: { id: string };
+    duplicate: boolean;
+  } | null> {
+    const dreamStore = new DreamScheduleSuggestionStore(this.baseDir);
+    const pendingSuggestion = (await dreamStore.list()).find((suggestion) => suggestion.status === "pending");
+    if (!pendingSuggestion || !this.scheduleEngine) {
+      return null;
+    }
+
+    return dreamStore.applySuggestion(pendingSuggestion.id, this.scheduleEngine);
+  }
+
+  private async runDreamAnalysis(tier: DreamTier): Promise<DreamRunReport> {
+    const analyzer = new DreamAnalyzer({
+      baseDir: this.baseDir,
+      llmClient: this.llmClient,
+      logger: this.logger,
+    });
+    return analyzer.run({ tier });
+  }
+
+  private async triggerResidentDreamMaintenance(details?: Record<string, unknown>, tier: DreamTier = "deep"): Promise<void> {
+    try {
+      const appliedBeforeAnalysis = await this.tryApplyPendingDreamSuggestion();
+      if (appliedBeforeAnalysis) {
+        await this.persistResidentActivity({
+          kind: "dream",
+          trigger: "proactive_tick",
+          summary: appliedBeforeAnalysis.duplicate
+            ? `Resident dream linked pending suggestion "${appliedBeforeAnalysis.suggestion.name ?? appliedBeforeAnalysis.suggestion.id}" to existing schedule ${appliedBeforeAnalysis.entry.id}.`
+            : `Resident dream applied pending suggestion "${appliedBeforeAnalysis.suggestion.name ?? appliedBeforeAnalysis.suggestion.id}" into schedule ${appliedBeforeAnalysis.entry.id}.`,
+          suggestion_title: appliedBeforeAnalysis.suggestion.name ?? appliedBeforeAnalysis.suggestion.reason,
+        });
+        return;
+      }
+
+      const analysisReport = await this.runDreamAnalysis(tier);
+      const appliedAfterAnalysis = tier === "deep" ? await this.tryApplyPendingDreamSuggestion() : null;
+      const consolidationReport = tier === "deep"
+        ? await runDreamConsolidation({
+          stateManager: this.stateManager,
+          memoryLifecycle: this.memoryLifecycle,
+          knowledgeManager: this.knowledgeManager,
+          baseDir: this.baseDir,
+        })
+        : null;
+      const requestedGoalId =
+        typeof details?.["goal_id"] === "string" ? details["goal_id"].trim() : "";
+      const goalHint = requestedGoalId ? ` for ${requestedGoalId}` : "";
+
+      await this.persistResidentActivity({
+        kind: "dream",
+        trigger: "proactive_tick",
+        summary: tier === "light"
+          ? `Resident dream light analysis ran${goalHint}; processed ${analysisReport.goalsProcessed.length} goals, persisted ${analysisReport.patternsPersisted} patterns, and generated ${analysisReport.scheduleSuggestions} schedule suggestion(s).`
+          : `Resident dream deep analysis ran${goalHint}; processed ${analysisReport.goalsProcessed.length} goals, persisted ${analysisReport.patternsPersisted} patterns, generated ${analysisReport.scheduleSuggestions} schedule suggestion(s), compressed ${consolidationReport?.entries_compressed ?? 0} entries, and created ${consolidationReport?.revalidation_tasks_created ?? 0} revalidation tasks${appliedAfterAnalysis ? ` while applying "${appliedAfterAnalysis.suggestion.name ?? appliedAfterAnalysis.suggestion.id}"` : ""}.`,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn("Resident dream maintenance failed", { error: message });
+      await this.persistResidentActivity({
+        kind: "error",
+        trigger: "proactive_tick",
+        summary: `Resident dream maintenance failed: ${message}`,
+      });
+    }
+  }
+
+  private async triggerResidentPreemptiveCheck(details?: Record<string, unknown>): Promise<void> {
+    const goalId =
+      typeof details?.["goal_id"] === "string" ? details["goal_id"].trim() : "";
+
+    if (!goalId) {
+      await this.persistResidentActivity({
+        kind: "skipped",
+        trigger: "proactive_tick",
+        summary: "Resident preemptive check skipped because no goal_id was provided.",
+      });
+      return;
+    }
+
+    try {
+      const goal = await this.stateManager.loadGoal(goalId).catch(() => null);
+      if (!goal) {
+        await this.persistResidentActivity({
+          kind: "skipped",
+          trigger: "proactive_tick",
+          summary: `Resident preemptive check skipped because goal "${goalId}" was not found.`,
+          goal_id: goalId,
+        });
+        return;
+      }
+
+      await this.driveSystem.writeEvent(
+        PulSeedEventSchema.parse({
+          type: "external",
+          source: "resident-proactive",
+          timestamp: new Date().toISOString(),
+          data: {
+            event_type: "preemptive_check",
+            goal_id: goalId,
+            requested_by: "resident-daemon",
+          },
+        }),
+      );
+      if (!this.currentGoalIds.includes(goalId)) {
+        this.currentGoalIds.push(goalId);
+      }
+      this.refreshOperationalState();
+      this.supervisor?.activateGoal(goalId);
+      this.abortSleep();
+      await this.persistResidentActivity({
+        kind: "observation",
+        trigger: "proactive_tick",
+        summary: `Resident preemptive check queued an observation wake-up for goal "${goalId}".`,
+        goal_id: goalId,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.logger.warn("Resident preemptive check failed", { error: message, goal_id: goalId });
+      await this.persistResidentActivity({
+        kind: "error",
+        trigger: "proactive_tick",
+        summary: `Resident preemptive check failed: ${message}`,
+        goal_id: goalId || undefined,
+      });
+    }
+  }
+
+  private async triggerIdleResidentMaintenance(): Promise<void> {
+    if (this.currentGoalIds.length > 0) {
+      return;
+    }
+
+    const dreamSuggestionPath = path.join(this.baseDir, "dream", "schedule-suggestions.json");
+    const hasDreamSuggestionFile = fs.existsSync(dreamSuggestionPath);
+    if (!hasDreamSuggestionFile && !this.memoryLifecycle && !this.knowledgeManager && !this.llmClient) {
+      return;
+    }
+
+    await this.triggerResidentDreamMaintenance(undefined, "light");
   }
 
   private async runSupervisorMaintenanceCycle(): Promise<void> {
+    this.refreshOperationalState();
+    await this.maybeRefreshProviderRuntime(
+      (this.supervisor?.getState().workers ?? []).filter((worker) => worker.goalId !== null).length
+    );
     await runSupervisorMaintenanceCycleForDaemon({
       currentGoalIds: this.currentGoalIds,
       driveSystem: this.driveSystem,
@@ -950,11 +1468,56 @@ export class DaemonRunner {
       saveDaemonState: () => this.saveDaemonState(),
       eventServer: this.eventServer,
       state: this.state,
+      runRuntimeStoreMaintenance: () => this.runRuntimeStoreMaintenance(),
     });
+  }
+
+  private async captureProviderRuntimeFingerprint(): Promise<string | null> {
+    try {
+      return await this.getProviderRuntimeFingerprintFn();
+    } catch (error) {
+      this.logger.warn("Failed to capture provider runtime fingerprint", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
+    }
+  }
+
+  private async maybeRefreshProviderRuntime(activeGoalCount: number): Promise<void> {
+    if (!this.refreshResidentDeps || activeGoalCount > 0) {
+      return;
+    }
+
+    const currentFingerprint = await this.captureProviderRuntimeFingerprint();
+    if (!currentFingerprint || currentFingerprint === this.providerRuntimeFingerprint) {
+      return;
+    }
+
+    try {
+      const freshDeps = await this.refreshResidentDeps();
+      this.coreLoop = freshDeps.coreLoop;
+      this.curiosityEngine = freshDeps.curiosityEngine;
+      this.goalNegotiator = freshDeps.goalNegotiator;
+      this.llmClient = freshDeps.llmClient;
+      this.reportingEngine = freshDeps.reportingEngine;
+      this.scheduleEngine = freshDeps.scheduleEngine;
+      this.memoryLifecycle = freshDeps.memoryLifecycle;
+      this.knowledgeManager = freshDeps.knowledgeManager;
+      this.supervisor?.replaceIdleWorkers(() => this.coreLoop);
+      this.providerRuntimeFingerprint = currentFingerprint;
+      this.logger.info("Refreshed resident daemon dependencies after provider drift", {
+        fingerprint_changed: true,
+      });
+    } catch (error) {
+      this.logger.warn("Failed to refresh resident daemon dependencies after provider drift", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   private async handleChatMessageCommand(goalId: string, message: string): Promise<void> {
     await writeChatMessageEvent(this.driveSystem, goalId, message);
+    await this.broadcastChatResponse(goalId, message);
     this.abortSleep();
   }
 
@@ -987,6 +1550,27 @@ export class DaemonRunner {
     }
   }
 
+  private async runRuntimeStoreMaintenance(force = false): Promise<void> {
+    if (!this.runtimeRoot) {
+      return;
+    }
+
+    const now = Date.now();
+    if (!force && now - this.lastRuntimeStoreMaintenanceAt < this.config.check_interval_ms) {
+      return;
+    }
+
+    this.lastRuntimeStoreMaintenanceAt = now;
+    await runRuntimeStoreMaintenanceCycle({
+      runtimeRoot: this.runtimeRoot,
+      approvalStore: this.approvalStore ?? undefined,
+      outboxStore: this.outboxStore ?? undefined,
+      runtimeHealthStore: this.runtimeHealthStore ?? undefined,
+      logger: this.logger,
+      now,
+    });
+  }
+
   // ─── Private: Proactive Tick ───
 
   /**
@@ -995,12 +1579,63 @@ export class DaemonRunner {
    * Errors are caught and logged — they never affect the daemon loop.
    */
   private async proactiveTick(): Promise<void> {
-    this.lastProactiveTickAt = await runProactiveMaintenance({
+    if (!this.config.proactive_mode) {
+      return;
+    }
+
+    if (await this.runScheduledGoalReview()) {
+      return;
+    }
+
+    const curiosityTriggered = await this.runResidentCuriosityCycle({
+      activityTrigger: "proactive_tick",
+      skipWhenNoTriggers: true,
+    });
+    if (curiosityTriggered) {
+      return;
+    }
+
+    const result = await runProactiveMaintenance({
       config: this.config,
       llmClient: this.llmClient,
       state: this.state,
       lastProactiveTickAt: this.lastProactiveTickAt,
       logger: this.logger,
+    });
+    this.lastProactiveTickAt = result.lastProactiveTickAt;
+    if (!result.decision) {
+      return;
+    }
+
+    if (result.decision.action === "sleep") {
+      await this.persistResidentActivity({
+        kind: "sleep",
+        trigger: "proactive_tick",
+        summary: "Resident proactive tick stayed idle.",
+      });
+      await this.triggerIdleResidentMaintenance();
+      return;
+    }
+
+    if (result.decision.action === "suggest_goal") {
+      await this.triggerResidentGoalDiscovery(result.decision.details);
+      return;
+    }
+
+    if (result.decision.action === "investigate") {
+      await this.triggerResidentInvestigation(result.decision.details);
+      return;
+    }
+
+    if (result.decision.action === "preemptive_check") {
+      await this.triggerResidentPreemptiveCheck(result.decision.details);
+      return;
+    }
+
+    await this.persistResidentActivity({
+      kind: "skipped",
+      trigger: "proactive_tick",
+      summary: `Resident proactive tick requested ${result.decision.action}, but no resident executor is wired for it yet.`,
     });
   }
 

--- a/src/runtime/daemon/runtime-ownership.ts
+++ b/src/runtime/daemon/runtime-ownership.ts
@@ -33,15 +33,6 @@ export class RuntimeOwnershipCoordinator {
       this.deps.runtimeHealthStore?.ensureReady(),
     ]);
 
-    await this.saveRuntimeHealthSnapshot("foundation_only", {
-      gateway: "degraded",
-      queue: "degraded",
-      leases: "ok",
-      approval: "ok",
-      outbox: "ok",
-      supervisor: "degraded",
-    });
-
     this.deps.logger.info("Runtime journal foundation initialized", {
       runtime_root: this.deps.runtimeRoot,
       queue_path: this.deps.runtimeRoot ? path.join(this.deps.runtimeRoot, "queue.json") : undefined,

--- a/src/runtime/executor/loop-supervisor.ts
+++ b/src/runtime/executor/loop-supervisor.ts
@@ -131,6 +131,18 @@ export class LoopSupervisor {
     };
   }
 
+  replaceIdleWorkers(coreLoopFactory: () => CoreLoop): void {
+    if (this.activeGoals.size > 0 || this.workers.some((worker) => !worker.isIdle())) {
+      return;
+    }
+
+    const workerCfg: GoalWorkerConfig = { iterationsPerCycle: this.config.iterationsPerCycle };
+    this.workers = [];
+    for (let i = 0; i < this.config.concurrency; i++) {
+      this.workers.push(new GoalWorker(coreLoopFactory(), workerCfg));
+    }
+  }
+
   activateGoal(goalId: string): void {
     this.stoppedGoals.delete(goalId);
     this.enqueueGoalActivation(goalId);

--- a/src/runtime/pid-manager.ts
+++ b/src/runtime/pid-manager.ts
@@ -1,19 +1,29 @@
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
+import { execFileSync } from "node:child_process";
 import { writeJsonFile } from "../base/utils/json-io.js";
 import { PIDInfoSchema, type PIDInfo } from "./types/daemon.js";
 
 const PID_EPOCH_ISO = "1970-01-01T00:00:00.000Z";
 const DEFAULT_STOP_TIMEOUT_MS = 35_000;
 const DEFAULT_STOP_POLL_INTERVAL_MS = 100;
+const PID_START_MATCH_TOLERANCE_MS = 30_000;
 
 export interface PIDWriteOptions {
   pid?: number;
   started_at?: string;
+  runtime_started_at?: string;
   owner_pid?: number;
+  owner_started_at?: string;
   watchdog_pid?: number;
+  watchdog_started_at?: string;
   runtime_pid?: number;
   version?: string;
+}
+
+export interface PIDManagerOptions {
+  processStartedAtResolver?: (pid: number) => Promise<string | null> | string | null;
+  processCommandResolver?: (pid: number) => Promise<string | null> | string | null;
 }
 
 export interface PIDRuntimeStatus {
@@ -23,6 +33,8 @@ export interface PIDRuntimeStatus {
   ownerPid: number | null;
   alivePids: number[];
   stalePids: number[];
+  verifiedPids: number[];
+  unverifiedLegacyPids: number[];
 }
 
 export interface StopRuntimeOptions {
@@ -56,21 +68,109 @@ function getOwnerPid(info: PIDInfo): number {
   return info.owner_pid ?? info.watchdog_pid ?? getRuntimePid(info);
 }
 
+async function readProcessStartedAt(pid: number): Promise<string | null> {
+  try {
+    const output = execFileSync(
+      "ps",
+      ["-p", String(pid), "-o", "lstart="],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          LC_ALL: "C",
+        },
+      }
+    );
+    const startedAt = String(output).trim();
+    if (startedAt === "") {
+      return null;
+    }
+    const parsed = new Date(startedAt);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+    return parsed.toISOString();
+  } catch {
+    return null;
+  }
+}
+
+async function readProcessCommand(pid: number): Promise<string | null> {
+  try {
+    const output = execFileSync(
+      "ps",
+      ["-p", String(pid), "-o", "command="],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          LC_ALL: "C",
+        },
+      }
+    );
+    const command = String(output).trim();
+    return command === "" ? null : command;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeStartedAt(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
 export class PIDManager {
   private pidPath: string;
+  private readonly processStartedAtResolver: (pid: number) => Promise<string | null>;
+  private readonly processCommandResolver: (pid: number) => Promise<string | null>;
 
-  constructor(baseDir: string, pidFile: string = "pulseed.pid") {
+  constructor(baseDir: string, pidFile: string = "pulseed.pid", options: PIDManagerOptions = {}) {
     this.pidPath = path.join(baseDir, pidFile);
+    this.processStartedAtResolver = async (pid: number) => {
+      if (options.processStartedAtResolver) {
+        return await options.processStartedAtResolver(pid);
+      }
+      return await readProcessStartedAt(pid);
+    };
+    this.processCommandResolver = async (pid: number) => {
+      if (options.processCommandResolver) {
+        return await options.processCommandResolver(pid);
+      }
+      return await readProcessCommand(pid);
+    };
   }
 
   /** Write PID ownership info to file (atomic write). */
   async writePID(options: PIDWriteOptions = {}): Promise<PIDInfo> {
     const runtimePid = options.runtime_pid ?? options.pid ?? process.pid;
+    const ownerPid = options.owner_pid ?? options.watchdog_pid ?? runtimePid;
+    const startedAt = options.started_at ?? new Date().toISOString();
+    const runtimeStartedAt =
+      options.runtime_started_at
+      ?? normalizeStartedAt(await this.processStartedAtResolver(runtimePid))
+      ?? startedAt;
+    const ownerStartedAt =
+      options.owner_started_at
+      ?? normalizeStartedAt(await this.processStartedAtResolver(ownerPid))
+      ?? startedAt;
+    const watchdogStartedAt =
+      options.watchdog_started_at
+      ?? (options.watchdog_pid ? ownerStartedAt : undefined);
     const info = PIDInfoSchema.parse({
       pid: options.pid ?? runtimePid,
-      started_at: options.started_at ?? new Date().toISOString(),
-      owner_pid: options.owner_pid ?? options.watchdog_pid ?? runtimePid,
+      started_at: startedAt,
+      runtime_started_at: runtimeStartedAt,
+      owner_pid: ownerPid,
+      owner_started_at: ownerStartedAt,
       watchdog_pid: options.watchdog_pid,
+      watchdog_started_at: watchdogStartedAt,
       runtime_pid: runtimePid,
       version: options.version,
     });
@@ -101,14 +201,44 @@ export class PIDManager {
         ownerPid: null,
         alivePids: [],
         stalePids: [],
+        verifiedPids: [],
+        unverifiedLegacyPids: [],
       };
     }
 
     const runtimePid = getRuntimePid(info);
     const ownerPid = getOwnerPid(info);
     const trackedPids = uniquePids([info.pid, runtimePid, ownerPid, info.watchdog_pid]);
-    const alivePids = trackedPids.filter((pid) => this.isPidAlive(pid));
-    const stalePids = trackedPids.filter((pid) => !alivePids.includes(pid));
+    const alivePids: number[] = [];
+    const stalePids: number[] = [];
+    const verifiedPids: number[] = [];
+    const unverifiedLegacyPids: number[] = [];
+    const expectedStartedAt = new Map<number, string>();
+    expectedStartedAt.set(info.pid, info.runtime_started_at ?? info.started_at);
+    expectedStartedAt.set(runtimePid, info.runtime_started_at ?? info.started_at);
+    if (typeof ownerPid === "number") {
+      expectedStartedAt.set(ownerPid, info.owner_started_at ?? info.started_at);
+    }
+    if (typeof info.watchdog_pid === "number") {
+      expectedStartedAt.set(
+        info.watchdog_pid,
+        info.watchdog_started_at ?? info.owner_started_at ?? info.started_at
+      );
+    }
+
+    for (const pid of trackedPids) {
+      const expected = expectedStartedAt.get(pid) ?? info.started_at;
+      const state = await this.getTrackedPidState(pid, expected);
+      if (state === "verified") {
+        alivePids.push(pid);
+        verifiedPids.push(pid);
+      } else if (state === "legacy_alive") {
+        alivePids.push(pid);
+        unverifiedLegacyPids.push(pid);
+      } else {
+        stalePids.push(pid);
+      }
+    }
 
     if (alivePids.length === 0) {
       await this.cleanup();
@@ -119,16 +249,20 @@ export class PIDManager {
         ownerPid,
         alivePids: [],
         stalePids,
+        verifiedPids,
+        unverifiedLegacyPids,
       };
     }
 
     return {
       info,
-      running: true,
+      running: alivePids.length > 0,
       runtimePid,
       ownerPid,
       alivePids,
       stalePids,
+      verifiedPids,
+      unverifiedLegacyPids,
     };
   }
 
@@ -147,21 +281,19 @@ export class PIDManager {
     const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_STOP_POLL_INTERVAL_MS;
     const initialStatus = await this.inspect();
 
-    if (!initialStatus.info || !initialStatus.running) {
+    if (!initialStatus.info || initialStatus.alivePids.length === 0) {
       return {
         info: initialStatus.info,
         runtimePid: initialStatus.runtimePid,
-        ownerPid: initialStatus.ownerPid,
-        sentSignalsTo: [],
-        forced: false,
-        stopped: false,
-        alivePids: initialStatus.alivePids,
+          ownerPid: initialStatus.ownerPid,
+          sentSignalsTo: [],
+          forced: false,
+          stopped: false,
+          alivePids: initialStatus.alivePids,
       };
     }
 
     const lifecyclePids = uniquePids([
-      initialStatus.ownerPid,
-      initialStatus.runtimePid,
       ...initialStatus.alivePids,
     ]);
     const sentSignalsTo: number[] = [];
@@ -274,18 +406,33 @@ export class PIDManager {
 
       const startedAt =
         typeof parsed["started_at"] === "string" ? parsed["started_at"] : PID_EPOCH_ISO;
+      const runtimeStartedAt =
+        typeof parsed["runtime_started_at"] === "string"
+          ? parsed["runtime_started_at"]
+          : startedAt;
       const ownerPid =
         typeof parsed["owner_pid"] === "number"
           ? parsed["owner_pid"]
           : typeof parsed["watchdog_pid"] === "number"
             ? parsed["watchdog_pid"]
             : pid;
+      const ownerStartedAt =
+        typeof parsed["owner_started_at"] === "string"
+          ? parsed["owner_started_at"]
+          : startedAt;
+      const watchdogStartedAt =
+        typeof parsed["watchdog_started_at"] === "string"
+          ? parsed["watchdog_started_at"]
+          : ownerStartedAt;
 
       return PIDInfoSchema.parse({
         ...parsed,
         pid,
         runtime_pid: typeof parsed["runtime_pid"] === "number" ? parsed["runtime_pid"] : pid,
+        runtime_started_at: runtimeStartedAt,
         owner_pid: ownerPid,
+        owner_started_at: ownerStartedAt,
+        watchdog_started_at: watchdogStartedAt,
         started_at: startedAt,
       });
     } catch {
@@ -300,6 +447,44 @@ export class PIDManager {
     } catch {
       return false;
     }
+  }
+
+  private async getTrackedPidState(
+    pid: number,
+    expectedStartedAt: string
+  ): Promise<"verified" | "legacy_alive" | "stale"> {
+    if (!this.isPidAlive(pid)) {
+      return "stale";
+    }
+
+    if (expectedStartedAt === PID_EPOCH_ISO) {
+      return await this.isLegacyPulseedProcess(pid) ? "legacy_alive" : "stale";
+    }
+
+    const actualStartedAt = await this.processStartedAtResolver(pid);
+    const normalizedActualStartedAt = normalizeStartedAt(actualStartedAt);
+    if (!normalizedActualStartedAt) {
+      return "stale";
+    }
+
+    const expectedMs = Date.parse(expectedStartedAt);
+    const actualMs = Date.parse(normalizedActualStartedAt);
+    if (!Number.isFinite(expectedMs) || !Number.isFinite(actualMs)) {
+      return "stale";
+    }
+
+    return Math.abs(actualMs - expectedMs) <= PID_START_MATCH_TOLERANCE_MS
+      ? "verified"
+      : "stale";
+  }
+
+  private async isLegacyPulseedProcess(pid: number): Promise<boolean> {
+    const command = await this.processCommandResolver(pid);
+    if (!command) {
+      return false;
+    }
+
+    return /pulseed|cli-runner\.js|daemon(?:\s|$)|watchdog/i.test(command);
   }
 
   private sendSignal(pid: number, signal: NodeJS.Signals): boolean {

--- a/src/runtime/pid-manager.ts
+++ b/src/runtime/pid-manager.ts
@@ -1,6 +1,60 @@
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { writeJsonFile } from "../base/utils/json-io.js";
+import { PIDInfoSchema, type PIDInfo } from "./types/daemon.js";
+
+const PID_EPOCH_ISO = "1970-01-01T00:00:00.000Z";
+const DEFAULT_STOP_TIMEOUT_MS = 35_000;
+const DEFAULT_STOP_POLL_INTERVAL_MS = 100;
+
+export interface PIDWriteOptions {
+  pid?: number;
+  started_at?: string;
+  owner_pid?: number;
+  watchdog_pid?: number;
+  runtime_pid?: number;
+  version?: string;
+}
+
+export interface PIDRuntimeStatus {
+  info: PIDInfo | null;
+  running: boolean;
+  runtimePid: number | null;
+  ownerPid: number | null;
+  alivePids: number[];
+  stalePids: number[];
+}
+
+export interface StopRuntimeOptions {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+export interface StopRuntimeResult {
+  info: PIDInfo | null;
+  runtimePid: number | null;
+  ownerPid: number | null;
+  sentSignalsTo: number[];
+  forced: boolean;
+  stopped: boolean;
+  alivePids: number[];
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function uniquePids(pids: Array<number | null | undefined>): number[] {
+  return [...new Set(pids.filter((pid): pid is number => typeof pid === "number" && pid > 0))];
+}
+
+function getRuntimePid(info: PIDInfo): number {
+  return info.runtime_pid ?? info.pid;
+}
+
+function getOwnerPid(info: PIDInfo): number {
+  return info.owner_pid ?? info.watchdog_pid ?? getRuntimePid(info);
+}
 
 export class PIDManager {
   private pidPath: string;
@@ -9,45 +63,171 @@ export class PIDManager {
     this.pidPath = path.join(baseDir, pidFile);
   }
 
-  /** Write current process PID to file (atomic write) */
-  async writePID(): Promise<void> {
-    const info = {
-      pid: process.pid,
-      started_at: new Date().toISOString(),
-    };
+  /** Write PID ownership info to file (atomic write). */
+  async writePID(options: PIDWriteOptions = {}): Promise<PIDInfo> {
+    const runtimePid = options.runtime_pid ?? options.pid ?? process.pid;
+    const info = PIDInfoSchema.parse({
+      pid: options.pid ?? runtimePid,
+      started_at: options.started_at ?? new Date().toISOString(),
+      owner_pid: options.owner_pid ?? options.watchdog_pid ?? runtimePid,
+      watchdog_pid: options.watchdog_pid,
+      runtime_pid: runtimePid,
+      version: options.version,
+    });
     const tmpPath = this.pidPath + ".tmp";
     await writeJsonFile(tmpPath, info);
     await fsp.rename(tmpPath, this.pidPath);
+    return info;
   }
 
-  /** Read PID from file. Returns null if file doesn't exist or is invalid */
-  async readPID(): Promise<{ pid: number; started_at: string } | null> {
+  /** Read PID ownership info. Returns null if the file does not exist or is invalid. */
+  async readPID(): Promise<PIDInfo | null> {
     try {
       const content = await fsp.readFile(this.pidPath, "utf-8");
-      const data = JSON.parse(content) as { pid: number; started_at: string };
-      if (typeof data.pid !== "number") return null;
-      return data;
+      return this.normalizePIDInfo(content);
     } catch {
       return null;
     }
   }
 
-  /** Check if a process with the stored PID is actually running */
-  async isRunning(): Promise<boolean> {
+  /** Inspect the pidfile and resolve the currently alive runtime tree processes. */
+  async inspect(): Promise<PIDRuntimeStatus> {
     const info = await this.readPID();
-    if (!info) return false;
-    try {
-      // signal 0 doesn't kill, just checks if process exists
-      process.kill(info.pid, 0);
-      return true;
-    } catch {
-      // Process doesn't exist - clean up stale PID file
-      await this.cleanup();
-      return false;
+    if (!info) {
+      return {
+        info: null,
+        running: false,
+        runtimePid: null,
+        ownerPid: null,
+        alivePids: [],
+        stalePids: [],
+      };
     }
+
+    const runtimePid = getRuntimePid(info);
+    const ownerPid = getOwnerPid(info);
+    const trackedPids = uniquePids([info.pid, runtimePid, ownerPid, info.watchdog_pid]);
+    const alivePids = trackedPids.filter((pid) => this.isPidAlive(pid));
+    const stalePids = trackedPids.filter((pid) => !alivePids.includes(pid));
+
+    if (alivePids.length === 0) {
+      await this.cleanup();
+      return {
+        info,
+        running: false,
+        runtimePid,
+        ownerPid,
+        alivePids: [],
+        stalePids,
+      };
+    }
+
+    return {
+      info,
+      running: true,
+      runtimePid,
+      ownerPid,
+      alivePids,
+      stalePids,
+    };
   }
 
-  /** Remove PID file */
+  /** Check whether any process recorded in the pidfile is still alive. */
+  async isRunning(): Promise<boolean> {
+    const status = await this.inspect();
+    return status.running;
+  }
+
+  /**
+   * Gracefully stop the tracked runtime tree.
+   * Sends SIGTERM to the owner/watchdog and runtime child, waits, then SIGKILLs survivors if needed.
+   */
+  async stopRuntime(options: StopRuntimeOptions = {}): Promise<StopRuntimeResult> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_STOP_TIMEOUT_MS;
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_STOP_POLL_INTERVAL_MS;
+    const initialStatus = await this.inspect();
+
+    if (!initialStatus.info || !initialStatus.running) {
+      return {
+        info: initialStatus.info,
+        runtimePid: initialStatus.runtimePid,
+        ownerPid: initialStatus.ownerPid,
+        sentSignalsTo: [],
+        forced: false,
+        stopped: false,
+        alivePids: initialStatus.alivePids,
+      };
+    }
+
+    const lifecyclePids = uniquePids([
+      initialStatus.ownerPid,
+      initialStatus.runtimePid,
+      ...initialStatus.alivePids,
+    ]);
+    const sentSignalsTo: number[] = [];
+
+    for (const pid of lifecyclePids) {
+      if (this.sendSignal(pid, "SIGTERM")) {
+        sentSignalsTo.push(pid);
+      }
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    let forced = false;
+
+    while (Date.now() < deadline) {
+      const status = await this.inspect();
+      if (!status.running) {
+        return {
+          info: initialStatus.info,
+          runtimePid: initialStatus.runtimePid,
+          ownerPid: initialStatus.ownerPid,
+          sentSignalsTo,
+          forced,
+          stopped: true,
+          alivePids: [],
+        };
+      }
+      await sleep(pollIntervalMs);
+    }
+
+    const beforeForce = await this.inspect();
+    for (const pid of beforeForce.alivePids) {
+      if (this.sendSignal(pid, "SIGKILL")) {
+        forced = true;
+      }
+    }
+
+    const forceDeadline = Date.now() + Math.max(1_000, pollIntervalMs * 10);
+    while (Date.now() < forceDeadline) {
+      const status = await this.inspect();
+      if (!status.running) {
+        return {
+          info: initialStatus.info,
+          runtimePid: initialStatus.runtimePid,
+          ownerPid: initialStatus.ownerPid,
+          sentSignalsTo,
+          forced,
+          stopped: true,
+          alivePids: [],
+        };
+      }
+      await sleep(pollIntervalMs);
+    }
+
+    const finalStatus = await this.inspect();
+    return {
+      info: initialStatus.info,
+      runtimePid: initialStatus.runtimePid,
+      ownerPid: initialStatus.ownerPid,
+      sentSignalsTo,
+      forced,
+      stopped: !finalStatus.running,
+      alivePids: finalStatus.alivePids,
+    };
+  }
+
+  /** Remove PID file. */
   async cleanup(): Promise<void> {
     try {
       await fsp.unlink(this.pidPath);
@@ -56,8 +236,78 @@ export class PIDManager {
     }
   }
 
-  /** Get the PID file path */
+  /** Get the PID file path. */
   getPath(): string {
     return this.pidPath;
+  }
+
+  private normalizePIDInfo(content: string): PIDInfo | null {
+    const trimmed = content.trim();
+    if (trimmed === "") {
+      return null;
+    }
+
+    if (!trimmed.startsWith("{")) {
+      const pid = parseInt(trimmed, 10);
+      if (!Number.isInteger(pid) || pid <= 0) {
+        return null;
+      }
+      return PIDInfoSchema.parse({
+        pid,
+        runtime_pid: pid,
+        owner_pid: pid,
+        started_at: PID_EPOCH_ISO,
+      });
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      const pid =
+        typeof parsed["runtime_pid"] === "number"
+          ? parsed["runtime_pid"]
+          : typeof parsed["pid"] === "number"
+            ? parsed["pid"]
+            : null;
+      if (pid === null || !Number.isInteger(pid) || pid <= 0) {
+        return null;
+      }
+
+      const startedAt =
+        typeof parsed["started_at"] === "string" ? parsed["started_at"] : PID_EPOCH_ISO;
+      const ownerPid =
+        typeof parsed["owner_pid"] === "number"
+          ? parsed["owner_pid"]
+          : typeof parsed["watchdog_pid"] === "number"
+            ? parsed["watchdog_pid"]
+            : pid;
+
+      return PIDInfoSchema.parse({
+        ...parsed,
+        pid,
+        runtime_pid: typeof parsed["runtime_pid"] === "number" ? parsed["runtime_pid"] : pid,
+        owner_pid: ownerPid,
+        started_at: startedAt,
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  private isPidAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private sendSignal(pid: number, signal: NodeJS.Signals): boolean {
+    try {
+      process.kill(pid, signal);
+      return true;
+    } catch {
+      return false;
+    }
   }
 }

--- a/src/runtime/schedule/engine-layers.ts
+++ b/src/runtime/schedule/engine-layers.ts
@@ -13,6 +13,7 @@ import type { DataSourceRegistry } from "../../platform/observation/data-source-
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import type { StateManager } from "../../base/state/state-manager.js";
 import type { HookManager } from "../hook-manager.js";
+import type { Logger } from "../logger.js";
 import type { MemoryLifecycleManager } from "../../platform/knowledge/memory/memory-lifecycle.js";
 import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
 import { detectChange } from "../change-detector.js";
@@ -22,6 +23,7 @@ import {
   runMorningPlanning,
   runWeeklyReview,
 } from "../../reflection/index.js";
+import { DreamAnalyzer } from "../../platform/dream/dream-analyzer.js";
 
 interface LayerDeps {
   baseDir?: string;
@@ -113,6 +115,7 @@ async function executeReflectionCron(
       duration_ms: 0,
       error_message: "Reflection cron requires baseDir and stateManager",
       fired_at: firedAt,
+      failure_kind: "permanent",
     });
   }
 
@@ -154,6 +157,14 @@ async function executeReflectionCron(
         }) as unknown as Record<string, unknown>;
         break;
       case "dream_consolidation":
+        {
+          const analyzer = new DreamAnalyzer({
+            baseDir: deps.baseDir,
+            llmClient: deps.llmClient,
+            logger: deps.logger as Logger,
+          });
+          await analyzer.runDeep();
+        }
         report = await runDreamConsolidation({
           stateManager: deps.stateManager,
           memoryLifecycle: deps.memoryLifecycle,
@@ -180,6 +191,7 @@ async function executeReflectionCron(
       duration_ms: Date.now() - start,
       error_message: msg,
       fired_at: firedAt,
+      failure_kind: "transient",
     });
   }
 }
@@ -196,6 +208,7 @@ export async function executeCron(entry: ScheduleEntry, deps: LayerDeps): Promis
       duration_ms: 0,
       error_message: "No cron config",
       fired_at: firedAt,
+      failure_kind: "permanent",
     });
   }
 
@@ -220,6 +233,7 @@ export async function executeCron(entry: ScheduleEntry, deps: LayerDeps): Promis
           duration_ms: 0,
           error_message: "Reflection cron is missing reflection_kind",
           fired_at: firedAt,
+          failure_kind: "permanent",
         });
       }
       return executeReflectionCron(entry, deps, firedAt, start, cfg.reflection_kind);
@@ -312,6 +326,7 @@ export async function executeCron(entry: ScheduleEntry, deps: LayerDeps): Promis
       duration_ms: Date.now() - start,
       error_message: msg,
       fired_at: firedAt,
+      failure_kind: "transient",
     });
   }
 }
@@ -328,6 +343,7 @@ export async function executeGoalTrigger(entry: ScheduleEntry, deps: LayerDeps):
       duration_ms: 0,
       error_message: "No goal_trigger config",
       fired_at: firedAt,
+      failure_kind: "permanent",
     });
   }
 
@@ -369,6 +385,7 @@ export async function executeGoalTrigger(entry: ScheduleEntry, deps: LayerDeps):
       duration_ms: 0,
       error_message: "No coreLoop provided",
       fired_at: firedAt,
+      failure_kind: "permanent",
     });
   }
 
@@ -384,6 +401,7 @@ export async function executeGoalTrigger(entry: ScheduleEntry, deps: LayerDeps):
       status: "ok",
       duration_ms: Date.now() - start,
       fired_at: firedAt,
+      goal_id: cfg.goal_id,
       tokens_used: tokensUsed,
     });
   } catch (err) {
@@ -395,6 +413,7 @@ export async function executeGoalTrigger(entry: ScheduleEntry, deps: LayerDeps):
       duration_ms: Date.now() - start,
       error_message: msg,
       fired_at: firedAt,
+      failure_kind: "transient",
     });
   }
 }
@@ -411,6 +430,7 @@ export async function executeProbe(entry: ScheduleEntry, deps: LayerDeps): Promi
       duration_ms: 0,
       error_message: "No probe config",
       fired_at: firedAt,
+      failure_kind: "permanent",
     });
   }
 
@@ -423,6 +443,7 @@ export async function executeProbe(entry: ScheduleEntry, deps: LayerDeps): Promi
       duration_ms: 0,
       error_message: `Data source not found: ${cfg.data_source_id}`,
       fired_at: firedAt,
+      failure_kind: "permanent",
     });
   }
 
@@ -509,6 +530,7 @@ export async function executeProbe(entry: ScheduleEntry, deps: LayerDeps): Promi
       duration_ms: Date.now() - start,
       error_message: msg,
       fired_at: firedAt,
+      failure_kind: "transient",
     });
   }
 }

--- a/src/runtime/schedule/engine.ts
+++ b/src/runtime/schedule/engine.ts
@@ -9,6 +9,7 @@ import {
   ScheduleEntrySchema,
   ScheduleEntryListSchema,
   ScheduleResultSchema,
+  type ScheduleFailureKind,
   type CronConfig,
   type EscalationConfig,
   type GoalTriggerConfig,
@@ -16,10 +17,17 @@ import {
   type ProbeConfig,
   type ScheduleEntry,
   type ScheduleEntryInput,
+  type ScheduleRetryPolicy,
+  type ScheduleRetryState,
   type ScheduleResult,
   type ScheduleTriggerInput,
 } from "../types/schedule.js";
 import { executeCron, executeGoalTrigger, executeProbe } from "./engine-layers.js";
+import {
+  ScheduleHistoryStore,
+  type ScheduleRunHistoryRecord,
+  type ScheduleRunReason,
+} from "./history.js";
 import type { IDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
 import type { DataSourceRegistry } from "../../platform/observation/data-source-adapter.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
@@ -28,6 +36,22 @@ import type { MemoryLifecycleManager } from "../../platform/knowledge/memory/mem
 import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
 
 const SCHEDULES_FILE = "schedules.json";
+const DEFAULT_RETRY_POLICY: ScheduleRetryPolicy = {
+  enabled: true,
+  initial_delay_ms: 30_000,
+  max_delay_ms: 15 * 60 * 1000,
+  multiplier: 2,
+  jitter_factor: 0.2,
+  max_attempts: 3,
+  max_retry_window_ms: 24 * 60 * 60 * 1000,
+  retryable_failure_kinds: ["transient"],
+};
+
+interface DueEntryDescriptor {
+  entry: ScheduleEntry;
+  reason: ScheduleRunReason;
+  scheduledFor: string | null;
+}
 
 interface ScheduleEngineDeps {
   baseDir: string;
@@ -66,6 +90,7 @@ export type ScheduleEntryUpdateInput = Partial<{
   cron: CronConfig;
   goal_trigger: GoalTriggerConfig;
   escalation: EscalationConfig | null;
+  retry_policy: ScheduleRetryPolicy;
 }>;
 
 export class ScheduleEngine {
@@ -82,6 +107,7 @@ export class ScheduleEngine {
   private hookManager?: HookManager;
   private memoryLifecycle?: MemoryLifecycleManager;
   private knowledgeManager?: KnowledgeManager;
+  private historyStore: ScheduleHistoryStore;
 
   constructor(deps: ScheduleEngineDeps) {
     this.baseDir = deps.baseDir;
@@ -96,6 +122,7 @@ export class ScheduleEngine {
     this.hookManager = deps.hookManager;
     this.memoryLifecycle = deps.memoryLifecycle;
     this.knowledgeManager = deps.knowledgeManager;
+    this.historyStore = new ScheduleHistoryStore(this.baseDir);
   }
 
   // ─── Persistence ───
@@ -182,7 +209,8 @@ export class ScheduleEngine {
       patch.probe !== undefined ||
       patch.cron !== undefined ||
       patch.goal_trigger !== undefined ||
-      patch.escalation !== undefined;
+      patch.escalation !== undefined ||
+      patch.retry_policy !== undefined;
 
     if (!hasUpdatableFields) {
       throw new Error("No updatable fields provided");
@@ -212,6 +240,7 @@ export class ScheduleEngine {
     if (patch.probe !== undefined) nextEntry.probe = patch.probe;
     if (patch.cron !== undefined) nextEntry.cron = patch.cron;
     if (patch.goal_trigger !== undefined) nextEntry.goal_trigger = patch.goal_trigger;
+    if (patch.retry_policy !== undefined) nextEntry.retry_policy = patch.retry_policy;
 
     if (patch.escalation !== undefined) {
       if (patch.escalation === null) {
@@ -223,6 +252,7 @@ export class ScheduleEngine {
 
     if (patch.trigger !== undefined || (current.enabled === false && patch.enabled === true)) {
       nextEntry.next_fire_at = this.computeNextFireAt(nextEntry.trigger);
+      nextEntry.retry_state = null;
     }
 
     nextEntry.updated_at = new Date().toISOString();
@@ -246,10 +276,33 @@ export class ScheduleEngine {
   // ─── Scheduling ───
 
   async getDueEntries(): Promise<ScheduleEntry[]> {
+    return (await this.getDueEntryDescriptors()).map((descriptor) => descriptor.entry);
+  }
+
+  async getRecentHistory(limit = 20, entryId?: string): Promise<ScheduleRunHistoryRecord[]> {
+    const history = await this.historyStore.load();
+    const filtered = entryId ? history.filter((record) => record.entry_id === entryId) : history;
+    return filtered.slice(-limit);
+  }
+
+  private async getDueEntryDescriptors(): Promise<DueEntryDescriptor[]> {
     const now = Date.now();
-    return this.entries.filter(
-      (e) => e.enabled && new Date(e.next_fire_at).getTime() <= now
-    );
+    return this.entries.flatMap((entry) => {
+      if (!entry.enabled) {
+        return [] as DueEntryDescriptor[];
+      }
+
+      const retryState = entry.retry_state ?? null;
+      if (retryState?.next_retry_at) {
+        return new Date(retryState.next_retry_at).getTime() <= now
+          ? ([{ entry, reason: "retry", scheduledFor: retryState.next_retry_at }] as DueEntryDescriptor[])
+          : ([] as DueEntryDescriptor[]);
+      }
+
+      return new Date(entry.next_fire_at).getTime() <= now
+        ? ([{ entry, reason: "cadence", scheduledFor: entry.next_fire_at }] as DueEntryDescriptor[])
+        : ([] as DueEntryDescriptor[]);
+    });
   }
 
   async tick(): Promise<ScheduleResult[]> {
@@ -266,82 +319,46 @@ export class ScheduleEngine {
       }
     }
 
-    const due = await this.getDueEntries();
+    const due = await this.getDueEntryDescriptors();
     const results: ScheduleResult[] = [];
 
-    for (const entry of due) {
-      let result: ScheduleResult;
+    for (const descriptor of due) {
+      const executedResult = await this.executeEntry(descriptor.entry);
+      const applied = await this.applyExecutionOutcome(
+        descriptor.entry.id,
+        executedResult,
+        descriptor.reason,
+        descriptor.scheduledFor
+      );
 
-      if (entry.layer === "heartbeat") {
-        result = await this.executeHeartbeat(entry);
-      } else if (entry.layer === "probe") {
-        result = await this.executeProbe(entry);
-      } else if (entry.layer === "cron") {
-        result = await this.executeCron(entry);
-      } else if (entry.layer === "goal_trigger") {
-        result = await this.executeGoalTrigger(entry);
-      } else {
-        result = ScheduleResultSchema.parse({
-          entry_id: entry.id,
-          status: "skipped",
-          duration_ms: 0,
-          fired_at: new Date().toISOString(),
-        });
-        this.logger.info(`Skipping unknown layer entry: ${entry.name} (layer=${entry.layer})`);
-      }
-
-      // Update entry state
-      const idx = this.entries.findIndex((e) => e.id === entry.id);
-      if (idx !== -1) {
-        const e = this.entries[idx];
-        const newFailures =
-          result.status === "error" || result.status === "down"
-            ? e.consecutive_failures + 1
-            : 0;
-
-        this.entries[idx] = {
-          ...e,
-          last_fired_at: result.fired_at,
-          next_fire_at: this.computeNextFireAt(e.trigger),
-          updated_at: new Date().toISOString(),
-          total_executions: e.total_executions + 1,
-          total_tokens_used: e.total_tokens_used + (result.tokens_used ?? 0),
-          tokens_used_today: (e.tokens_used_today ?? 0) + (result.tokens_used ?? 0),
-          consecutive_failures: newFailures,
-        };
-
-        // Circuit breaker: disable entry if threshold exceeded
-        if (
-          e.escalation?.circuit_breaker_threshold &&
-          newFailures >= e.escalation.circuit_breaker_threshold
-        ) {
-          this.entries[idx].enabled = false;
-          this.logger.warn(
-            `Entry "${e.name}" disabled by circuit breaker (${newFailures}/${e.escalation.circuit_breaker_threshold})`
-          );
-        }
-
-        // Heartbeat failure threshold warning
-        if (
-          result.status === "down" &&
-          e.heartbeat &&
-          newFailures >= e.heartbeat.failure_threshold
-        ) {
-          this.logger.warn(
-            `Entry "${e.name}" reached failure threshold (${newFailures}/${e.heartbeat.failure_threshold})`
-          );
-        }
-
-        // Escalation check
-        const escalationResult = await this.checkEscalation(this.entries[idx], result);
+      let finalResult = executedResult;
+      if (applied?.entry) {
+        const escalationResult = await this.checkEscalation(applied.entry, executedResult);
         if (escalationResult !== null) {
-          result = escalationResult;
-          results.push(result);
-          continue;
+          finalResult = escalationResult;
         }
       }
 
-      results.push(result);
+      if (applied) {
+        await this.recordHistory({
+          entry_id: applied.entry?.id ?? descriptor.entry.id,
+          entry_name: applied.entry?.name ?? descriptor.entry.name,
+          layer: descriptor.entry.layer,
+          result: {
+            ...finalResult,
+            failure_kind: applied.failureKind,
+          },
+          reason: descriptor.reason,
+          attempt: applied.attempt,
+          scheduled_for: descriptor.scheduledFor,
+          started_at: applied.startedAt,
+          finished_at: applied.finishedAt,
+          retry_at: applied.retryAt,
+          failure_kind: applied.failureKind,
+        });
+      }
+
+      results.push(finalResult);
     }
 
     if (results.length > 0) {
@@ -395,6 +412,303 @@ export class ScheduleEngine {
       knowledgeManager: this.knowledgeManager,
       logger: this.logger,
     };
+  }
+
+  private async executeEntry(entry: ScheduleEntry): Promise<ScheduleResult> {
+    if (entry.layer === "heartbeat") {
+      return this.executeHeartbeat(entry);
+    }
+    if (entry.layer === "probe") {
+      return this.executeProbe(entry);
+    }
+    if (entry.layer === "cron") {
+      return this.executeCron(entry);
+    }
+    if (entry.layer === "goal_trigger") {
+      return this.executeGoalTrigger(entry);
+    }
+
+    this.logger.info(`Skipping unknown layer entry: ${entry.name} (layer=${entry.layer})`);
+    return ScheduleResultSchema.parse({
+      entry_id: entry.id,
+      status: "skipped",
+      duration_ms: 0,
+      fired_at: new Date().toISOString(),
+    });
+  }
+
+  private normalizeRetryPolicy(entry: ScheduleEntry): ScheduleRetryPolicy {
+    return {
+      ...DEFAULT_RETRY_POLICY,
+      ...(entry.retry_policy ?? {}),
+    };
+  }
+
+  private classifyFailureKind(entry: ScheduleEntry, result: ScheduleResult): ScheduleFailureKind {
+    if (result.failure_kind) {
+      return result.failure_kind;
+    }
+
+    const message = `${result.error_message ?? ""}`.toLowerCase();
+    const permanentHints = [
+      "no cron config",
+      "no heartbeat config",
+      "no probe config",
+      "no coreloop",
+      "not found",
+      "missing",
+      "invalid",
+      "unsupported",
+      "cannot",
+      "schema",
+      "permission denied",
+    ];
+    if (permanentHints.some((hint) => message.includes(hint))) {
+      return "permanent";
+    }
+
+    const transientHints = [
+      "timeout",
+      "timed out",
+      "econnrefused",
+      "econnreset",
+      "etimedout",
+      "eai_again",
+      "enotfound",
+      "network",
+      "temporar",
+      "unavailable",
+      "rate limit",
+      "busy",
+      "abort",
+    ];
+    if (transientHints.some((hint) => message.includes(hint))) {
+      return "transient";
+    }
+
+    return entry.layer === "goal_trigger" ? "permanent" : "transient";
+  }
+
+  private computeRetryDelay(policy: ScheduleRetryPolicy, attempt: number): number {
+    const baseDelay = policy.initial_delay_ms * Math.pow(policy.multiplier, Math.max(0, attempt - 1));
+    const cappedDelay = Math.min(baseDelay, policy.max_delay_ms);
+    if (policy.jitter_factor <= 0) {
+      return cappedDelay;
+    }
+    const jitter = cappedDelay * policy.jitter_factor * (Math.random() * 2 - 1);
+    return Math.max(0, Math.round(cappedDelay + jitter));
+  }
+
+  private async applyExecutionOutcome(
+    entryId: string,
+    result: ScheduleResult,
+    _reason: ScheduleRunReason,
+    scheduledFor: string | null
+  ): Promise<{
+    entry: ScheduleEntry | null;
+    attempt: number;
+    startedAt: string;
+    finishedAt: string;
+    retryAt: string | null;
+    failureKind: ScheduleFailureKind;
+  } | null> {
+    const idx = this.entries.findIndex((candidate) => candidate.id === entryId);
+    if (idx === -1) {
+      return null;
+    }
+
+    const entry = this.entries[idx]!;
+    const startedAt = scheduledFor ?? result.fired_at;
+    const finishedAt = new Date().toISOString();
+    const failureKind = this.classifyFailureKind(entry, result);
+    const isFailure = result.status === "error" || result.status === "down";
+    const retryPolicy = this.normalizeRetryPolicy(entry);
+    const currentRetryState = entry.retry_state ?? null;
+    let retryAt: string | null = null;
+    let retryState: ScheduleRetryState | null = null;
+
+    if (isFailure && retryPolicy.enabled && retryPolicy.retryable_failure_kinds.includes(failureKind)) {
+      const attempts = (currentRetryState?.attempts ?? 0) + 1;
+      const firstFailureAt = currentRetryState?.first_failure_at ?? result.fired_at;
+      const windowElapsed = new Date(result.fired_at).getTime() - new Date(firstFailureAt).getTime();
+
+      if (attempts <= retryPolicy.max_attempts && windowElapsed <= retryPolicy.max_retry_window_ms) {
+        retryAt = new Date(Date.now() + this.computeRetryDelay(retryPolicy, attempts)).toISOString();
+        retryState = {
+          attempts,
+          next_retry_at: retryAt,
+          last_attempt_at: result.fired_at,
+          first_failure_at: firstFailureAt,
+          last_failure_kind: failureKind,
+          last_error_message: result.error_message ?? null,
+        };
+      }
+    }
+
+    this.entries[idx] = {
+      ...entry,
+      enabled: true,
+      last_fired_at: result.fired_at,
+      next_fire_at: this.computeNextFireAt(entry.trigger),
+      updated_at: new Date().toISOString(),
+      total_executions: entry.total_executions + 1,
+      total_tokens_used: entry.total_tokens_used + (result.tokens_used ?? 0),
+      tokens_used_today: (entry.tokens_used_today ?? 0) + (result.tokens_used ?? 0),
+      consecutive_failures: isFailure ? entry.consecutive_failures + 1 : 0,
+      retry_state: retryState,
+    };
+
+    const updated = this.entries[idx]!;
+
+    if (
+      updated.escalation?.circuit_breaker_threshold &&
+      updated.consecutive_failures >= updated.escalation.circuit_breaker_threshold
+    ) {
+      updated.enabled = false;
+      this.logger.warn(
+        `Entry "${updated.name}" disabled by circuit breaker (${updated.consecutive_failures}/${updated.escalation.circuit_breaker_threshold})`
+      );
+    }
+
+    if (
+      result.status === "down" &&
+      updated.heartbeat &&
+      updated.consecutive_failures >= updated.heartbeat.failure_threshold
+    ) {
+      this.logger.warn(
+        `Entry "${updated.name}" reached failure threshold (${updated.consecutive_failures}/${updated.heartbeat.failure_threshold})`
+      );
+      if (updated.consecutive_failures === updated.heartbeat.failure_threshold) {
+        await this.dispatchNotification({
+          report_type: "schedule_heartbeat_failure",
+          entry_id: updated.id,
+          entry_name: updated.name,
+          failure_threshold: updated.heartbeat.failure_threshold,
+          consecutive_failures: updated.consecutive_failures,
+          layer: updated.layer,
+        });
+      }
+    }
+
+    return {
+      entry: updated,
+      attempt: retryState?.attempts ?? 0,
+      startedAt,
+      finishedAt,
+      retryAt,
+      failureKind,
+    };
+  }
+
+  private async recordHistory(input: {
+    entry_id: string;
+    entry_name: string;
+    layer: ScheduleEntry["layer"];
+    result: ScheduleResult;
+    reason: ScheduleRunReason;
+    attempt: number;
+    scheduled_for: string | null;
+    started_at: string;
+    finished_at: string;
+    retry_at: string | null;
+    failure_kind: ScheduleFailureKind;
+  }): Promise<void> {
+    await this.historyStore.append({
+      entry_id: input.entry_id,
+      entry_name: input.entry_name,
+      layer: input.layer,
+      result: {
+        ...input.result,
+        failure_kind: input.failure_kind,
+      },
+      reason: input.reason,
+      attempt: input.attempt,
+      scheduled_for: input.scheduled_for,
+      started_at: input.started_at,
+      finished_at: input.finished_at,
+      retry_at: input.retry_at,
+      failure_kind: input.failure_kind,
+    });
+  }
+
+  private async executeEscalationTargetEntry(targetEntryId: string): Promise<ScheduleResult | null> {
+    const targetEntry = this.entries.find((candidate) => candidate.id === targetEntryId);
+    if (!targetEntry) {
+      this.logger.warn(`Escalation target entry not found: ${targetEntryId}`);
+      return null;
+    }
+
+    const immediateEntry = {
+      ...targetEntry,
+      enabled: true,
+      next_fire_at: new Date().toISOString(),
+    };
+    const result = await this.executeEntry(immediateEntry);
+    const applied = await this.applyExecutionOutcome(
+      targetEntryId,
+      result,
+      "escalation_target",
+      immediateEntry.next_fire_at
+    );
+    if (applied) {
+      await this.recordHistory({
+        entry_id: targetEntry.id,
+        entry_name: targetEntry.name,
+        layer: targetEntry.layer,
+        result: {
+          ...result,
+          failure_kind: applied.failureKind,
+        },
+        reason: "escalation_target",
+        attempt: applied.attempt,
+        scheduled_for: immediateEntry.next_fire_at,
+        started_at: applied.startedAt,
+        finished_at: applied.finishedAt,
+        retry_at: applied.retryAt,
+        failure_kind: applied.failureKind,
+      });
+    }
+    return result;
+  }
+
+  private async executeEscalationTargetGoal(goalId: string): Promise<ScheduleResult> {
+    const now = new Date().toISOString();
+    if (!this.coreLoop) {
+      return ScheduleResultSchema.parse({
+        entry_id: randomUUID(),
+        status: "error",
+        duration_ms: 0,
+        fired_at: now,
+        goal_id: goalId,
+        error_message: "No coreLoop provided for escalation target goal",
+        failure_kind: "permanent",
+      });
+    }
+
+    const startedAt = Date.now();
+    try {
+      const result = await this.coreLoop.run(goalId);
+      return ScheduleResultSchema.parse({
+        entry_id: randomUUID(),
+        status: "ok",
+        duration_ms: Date.now() - startedAt,
+        fired_at: now,
+        goal_id: goalId,
+        tokens_used: result?.tokensUsed ?? 0,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Escalation target goal "${goalId}" failed: ${message}`);
+      return ScheduleResultSchema.parse({
+        entry_id: randomUUID(),
+        status: "error",
+        duration_ms: Date.now() - startedAt,
+        fired_at: now,
+        goal_id: goalId,
+        error_message: message,
+        failure_kind: "transient",
+      });
+    }
   }
 
     // ─── Escalation logic ───
@@ -455,6 +769,7 @@ export class ScheduleEngine {
       entry_name: entry.name,
       target_layer: esc.target_layer,
       target_entry_id: esc.target_entry_id,
+      target_goal_id: esc.target_goal_id,
       consecutive_failures: entry.consecutive_failures,
     });
 
@@ -462,22 +777,19 @@ export class ScheduleEngine {
       `Escalating "${entry.name}" to ${esc.target_layer ?? "unknown"} (failures=${entry.consecutive_failures})`
     );
 
-    // Activate target entry if specified
+    // Execute target goal or target entry immediately so escalations take effect in the same tick.
+    if (esc.target_goal_id) {
+      await this.executeEscalationTargetGoal(esc.target_goal_id);
+    }
+
     if (esc.target_entry_id) {
-      const targetIdx = this.entries.findIndex((e) => e.id === esc.target_entry_id);
-      if (targetIdx !== -1) {
-        this.entries[targetIdx] = {
-          ...this.entries[targetIdx],
-          enabled: true,
-          next_fire_at: new Date().toISOString(), // fire immediately
-        };
-      }
+      await this.executeEscalationTargetEntry(esc.target_entry_id);
     }
 
     return ScheduleResultSchema.parse({
       ...result,
       status: "escalated",
-      escalated_to: esc.target_entry_id ?? esc.target_layer ?? null,
+      escalated_to: esc.target_goal_id ?? esc.target_entry_id ?? esc.target_layer ?? null,
     });
   }
 
@@ -506,6 +818,7 @@ export class ScheduleEngine {
         duration_ms: 0,
         error_message: "No heartbeat config",
         fired_at: firedAt,
+        failure_kind: "permanent",
       });
     }
 
@@ -550,6 +863,7 @@ export class ScheduleEngine {
         duration_ms: Date.now() - start,
         error_message: msg,
         fired_at: firedAt,
+        failure_kind: "transient",
       });
     }
   }

--- a/src/runtime/schedule/history.ts
+++ b/src/runtime/schedule/history.ts
@@ -1,0 +1,102 @@
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../../base/utils/json-io.js";
+import {
+  ScheduleResultSchema,
+  ScheduleLayerSchema,
+  type ScheduleFailureKind,
+  type ScheduleResult,
+} from "../types/schedule.js";
+import { z } from "zod";
+
+const HISTORY_FILE = "schedule-history.json";
+const DEFAULT_MAX_RECENT = 500;
+
+export const ScheduleRunReasonSchema = z.enum(["cadence", "retry", "escalation_target"]);
+export type ScheduleRunReason = z.infer<typeof ScheduleRunReasonSchema>;
+
+export const ScheduleRunHistoryRecordSchema = ScheduleResultSchema.extend({
+  id: z.string().uuid(),
+  entry_name: z.string(),
+  reason: ScheduleRunReasonSchema,
+  attempt: z.number().int().nonnegative().default(0),
+  scheduled_for: z.string().datetime().nullable().default(null),
+  started_at: z.string().datetime(),
+  finished_at: z.string().datetime(),
+  retry_at: z.string().datetime().nullable().default(null),
+});
+
+export type ScheduleRunHistoryRecord = z.infer<typeof ScheduleRunHistoryRecordSchema>;
+
+export interface ScheduleRunHistoryInput {
+  entry_id: string;
+  entry_name: string;
+  layer: z.infer<typeof ScheduleLayerSchema>;
+  result: ScheduleResult;
+  reason: ScheduleRunReason;
+  attempt?: number;
+  scheduled_for?: string | null;
+  started_at: string;
+  finished_at: string;
+  retry_at?: string | null;
+  failure_kind?: ScheduleFailureKind | null;
+}
+
+export class ScheduleHistoryStore {
+  private readonly historyPath: string;
+
+  constructor(
+    baseDir: string,
+    private readonly maxRecent = DEFAULT_MAX_RECENT
+  ) {
+    this.historyPath = path.join(baseDir, HISTORY_FILE);
+  }
+
+  async load(): Promise<ScheduleRunHistoryRecord[]> {
+    const raw = await readJsonFileOrNull(this.historyPath);
+    if (!Array.isArray(raw)) {
+      return [];
+    }
+
+    const parsed: ScheduleRunHistoryRecord[] = [];
+    for (const item of raw) {
+      const record = ScheduleRunHistoryRecordSchema.safeParse(item);
+      if (record.success) {
+        parsed.push(record.data);
+      }
+    }
+    return parsed;
+  }
+
+  async save(records: ScheduleRunHistoryRecord[]): Promise<void> {
+    const trimmed = records.slice(-this.maxRecent);
+    await writeJsonFileAtomic(this.historyPath, trimmed);
+  }
+
+  async append(input: ScheduleRunHistoryInput): Promise<ScheduleRunHistoryRecord> {
+    const existing = await this.load();
+    const parsed = ScheduleRunHistoryRecordSchema.parse({
+      ...input.result,
+      id: randomUUID(),
+      entry_id: input.entry_id,
+      entry_name: input.entry_name,
+      layer: input.layer,
+      reason: input.reason,
+      attempt: input.attempt ?? 0,
+      scheduled_for: input.scheduled_for ?? null,
+      started_at: input.started_at,
+      finished_at: input.finished_at,
+      retry_at: input.retry_at ?? null,
+      failure_kind: input.failure_kind ?? input.result.failure_kind,
+    });
+
+    existing.push(parsed);
+    await this.save(existing);
+    return parsed;
+  }
+
+  async recent(limit = 20): Promise<ScheduleRunHistoryRecord[]> {
+    const records = await this.load();
+    return records.slice(-limit);
+  }
+}

--- a/src/runtime/schedule/index.ts
+++ b/src/runtime/schedule/index.ts
@@ -1,4 +1,5 @@
 export * from "./engine.js";
 export * from "./engine-layers.js";
+export * from "./history.js";
 export * from "./presets.js";
 export * from "./source.js";

--- a/src/runtime/store/approval-store.ts
+++ b/src/runtime/store/approval-store.ts
@@ -103,6 +103,14 @@ export class ApprovalStore {
     return this.journal.list(this.paths.approvalsResolvedDir, ApprovalRecordSchema);
   }
 
+  async removePending(approvalId: string): Promise<void> {
+    await this.journal.remove(this.paths.approvalPendingPath(approvalId));
+  }
+
+  async removeResolved(approvalId: string): Promise<void> {
+    await this.journal.remove(this.paths.approvalResolvedPath(approvalId));
+  }
+
   async savePending(record: ApprovalRecord): Promise<ApprovalRecord> {
     const parsed = ApprovalRecordSchema.parse({ ...record, state: "pending" });
     return this.withApprovalLock(parsed.approval_id, async () => {
@@ -136,8 +144,58 @@ export class ApprovalStore {
         resolved_at: update.resolved_at ?? Date.now(),
       });
       await this.saveResolved(resolved);
-      await this.journal.remove(this.paths.approvalPendingPath(approvalId));
+      await this.removePending(approvalId);
       return resolved;
     });
+  }
+
+  async reconcile(now = Date.now()): Promise<{
+    removedPending: number;
+    expiredPending: number;
+  }> {
+    const pending = await this.journal.list(this.paths.approvalsPendingDir, ApprovalRecordSchema);
+    let removedPending = 0;
+    let expiredPending = 0;
+
+    for (const record of pending) {
+      const resolved = await this.loadResolved(record.approval_id);
+      if (resolved !== null) {
+        await this.removePending(record.approval_id);
+        removedPending += 1;
+        continue;
+      }
+
+      if (record.expires_at > now) {
+        continue;
+      }
+
+      await this.resolvePending(record.approval_id, {
+        state: "expired",
+        resolved_at: now,
+        response_channel: record.response_channel,
+        payload: record.payload,
+      });
+      expiredPending += 1;
+    }
+
+    return { removedPending, expiredPending };
+  }
+
+  async pruneResolved(olderThanMs: number, now = Date.now()): Promise<number> {
+    const threshold = now - olderThanMs;
+    const resolved = await this.listResolved();
+    let pruned = 0;
+
+    for (const record of resolved) {
+      const resolvedAt = record.resolved_at ?? record.created_at;
+      if (resolvedAt >= threshold) {
+        continue;
+      }
+
+      await this.removeResolved(record.approval_id);
+      pruned += 1;
+    }
+
+    return pruned;
   }
 }

--- a/src/runtime/store/health-store.ts
+++ b/src/runtime/store/health-store.ts
@@ -4,6 +4,7 @@ import {
   RuntimeDaemonHealthSchema,
   RuntimeHealthSnapshotSchema,
   summarizeRuntimeHealthStatus,
+  RuntimeHealthStatusSchema,
   type RuntimeComponentsHealth,
   type RuntimeDaemonHealth,
   type RuntimeHealthSnapshot,
@@ -79,6 +80,99 @@ export class RuntimeHealthStore {
       }),
     ]);
     return parsed;
+  }
+
+  async reconcile(now = Date.now()): Promise<RuntimeHealthSnapshot> {
+    const [daemon, components] = await Promise.all([
+      this.loadDaemonHealth(),
+      this.loadComponentsHealth(),
+    ]);
+
+    if (daemon !== null && components !== null) {
+      const snapshot = await this.loadSnapshot();
+      if (snapshot !== null) {
+        return snapshot;
+      }
+      return RuntimeHealthSnapshotSchema.parse({
+        status: daemon.status,
+        leader: daemon.leader,
+        checked_at: Math.max(daemon.checked_at, components.checked_at),
+        components: components.components,
+        details: daemon.details,
+      });
+    }
+
+    const degradedComponents: RuntimeComponentsHealth = {
+      checked_at: now,
+      components: {
+        gateway: "degraded",
+        queue: "degraded",
+        leases: "degraded",
+        approval: "degraded",
+        outbox: "degraded",
+        supervisor: "degraded",
+      },
+    };
+
+    if (daemon !== null && components === null) {
+      const degradedSnapshot = RuntimeHealthSnapshotSchema.parse({
+        status: "degraded",
+        leader: daemon.leader,
+        checked_at: now,
+        components: degradedComponents.components,
+        details: {
+          ...daemon.details,
+          repaired: true,
+          recovered_from: "missing_components_health",
+          previous_status: daemon.status,
+        },
+      });
+      await Promise.all([
+        this.saveComponentsHealth(degradedComponents),
+        this.saveDaemonHealth({
+          status: "degraded",
+          leader: daemon.leader,
+          checked_at: now,
+          details: degradedSnapshot.details,
+        }),
+      ]);
+      return degradedSnapshot;
+    }
+
+    if (daemon === null && components !== null) {
+      const status = summarizeRuntimeHealthStatus(components.components);
+      const repairedDaemon: RuntimeDaemonHealth = {
+        status,
+        leader: false,
+        checked_at: now,
+        details: {
+          repaired: true,
+          recovered_from: "missing_daemon_health",
+        },
+      };
+      await this.saveDaemonHealth(repairedDaemon);
+      return RuntimeHealthSnapshotSchema.parse({
+        status,
+        leader: repairedDaemon.leader,
+        checked_at: Math.max(now, components.checked_at),
+        components: components.components,
+        details: repairedDaemon.details,
+      });
+    }
+
+    const repairedSnapshot = RuntimeHealthSnapshotSchema.parse({
+      status: "degraded",
+      leader: false,
+      checked_at: now,
+      components: degradedComponents.components,
+      details: {
+        repaired: true,
+        recovered_from: "missing_health_snapshot",
+        previous_status: RuntimeHealthStatusSchema.parse("degraded"),
+      },
+    });
+    await this.saveSnapshot(repairedSnapshot);
+    return repairedSnapshot;
   }
 
   summarizeStatus(components: Record<string, RuntimeHealthSnapshot["status"]>): RuntimeHealthSnapshot["status"] {

--- a/src/runtime/store/outbox-store.ts
+++ b/src/runtime/store/outbox-store.ts
@@ -57,6 +57,10 @@ export class OutboxStore {
     return parsed;
   }
 
+  async remove(seq: number): Promise<void> {
+    await this.journal.remove(this.paths.outboxRecordPath(seq));
+  }
+
   private async acquireAppendLock(): Promise<AppendLock> {
     const lockPath = path.join(this.paths.outboxDir, ".append.lock");
     const staleAfterMs = 30_000;
@@ -104,5 +108,34 @@ export class OutboxStore {
     } finally {
       await lock.release();
     }
+  }
+
+  async prune(options: {
+    olderThanMs?: number;
+    maxRecords?: number;
+    now?: number;
+  } = {}): Promise<{ pruned: number; retained: number }> {
+    const now = options.now ?? Date.now();
+    const olderThanMs = options.olderThanMs ?? 30 * 24 * 60 * 60 * 1000;
+    const maxRecords = options.maxRecords ?? 5_000;
+    const threshold = now - olderThanMs;
+    const records = await this.list();
+    const protectedSeq = records.length > maxRecords
+      ? records[records.length - maxRecords]?.seq ?? null
+      : null;
+
+    let pruned = 0;
+    for (const record of records) {
+      const overAge = record.created_at < threshold;
+      const overCount = protectedSeq !== null && record.seq < protectedSeq;
+      if (!overAge && !overCount) {
+        continue;
+      }
+
+      await this.remove(record.seq);
+      pruned += 1;
+    }
+
+    return { pruned, retained: Math.max(records.length - pruned, 0) };
   }
 }

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -68,10 +68,13 @@ export const PIDInfoSchema = z.object({
   // Authoritative runtime PID. When a watchdog is present, this is the child daemon PID.
   pid: z.number().int().positive(),
   started_at: z.string().datetime().default(PID_EPOCH_ISO),
+  runtime_started_at: z.string().datetime().optional(),
   // Process that should receive lifecycle signals. When a watchdog is present, this is the parent PID.
   owner_pid: z.number().int().positive().optional(),
+  owner_started_at: z.string().datetime().optional(),
   // Explicit watchdog parent PID when running under the watchdog.
   watchdog_pid: z.number().int().positive().optional(),
+  watchdog_started_at: z.string().datetime().optional(),
   // Explicit daemon/runtime child PID when running under the watchdog.
   runtime_pid: z.number().int().positive().optional(),
   version: z.string().optional(),

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const PID_EPOCH_ISO = "1970-01-01T00:00:00.000Z";
+
 // Daemon configuration
 export const DaemonConfigSchema = z.object({
   // Deprecated compatibility flag. Durable runtime recovery is always enabled.
@@ -23,6 +25,7 @@ export const DaemonConfigSchema = z.object({
   event_server_port: z.number().int().nonnegative().default(41700), // EventServer HTTP port (0 = OS-assigned, safe for tests)
   proactive_mode: z.boolean().default(false),
   proactive_interval_ms: z.number().default(3_600_000), // 1 hour minimum between proactive ticks
+  goal_review_interval_ms: z.number().int().nonnegative().default(7 * 24 * 60 * 60 * 1000), // weekly goal review cadence
   adaptive_sleep: z.object({
     enabled: z.boolean().default(false),
     min_interval_ms: z.number().default(60_000),      // 1 minute minimum
@@ -34,6 +37,16 @@ export const DaemonConfigSchema = z.object({
 });
 export type DaemonConfig = z.infer<typeof DaemonConfigSchema>;
 
+export const ResidentActivitySchema = z.object({
+  kind: z.enum(["sleep", "suggestion", "negotiation", "curiosity", "dream", "observation", "skipped", "error"]),
+  trigger: z.enum(["proactive_tick", "schedule", "external"]).default("proactive_tick"),
+  summary: z.string(),
+  recorded_at: z.string().datetime(),
+  suggestion_title: z.string().optional(),
+  goal_id: z.string().optional(),
+});
+export type ResidentActivity = z.infer<typeof ResidentActivitySchema>;
+
 // Daemon runtime state
 export const DaemonStateSchema = z.object({
   pid: z.number().int().positive(),
@@ -41,17 +54,26 @@ export const DaemonStateSchema = z.object({
   last_loop_at: z.string().datetime().nullable(),
   loop_count: z.number().int().nonnegative(),
   active_goals: z.array(z.string()),
-  status: z.enum(["running", "stopping", "stopped", "crashed"]),
+  status: z.enum(["idle", "running", "stopping", "stopped", "crashed"]),
   crash_count: z.number().int().nonnegative().default(0),
   last_error: z.string().nullable().default(null),
   interrupted_goals: z.array(z.string()).optional(),
+  last_resident_at: z.string().datetime().nullable().default(null),
+  resident_activity: ResidentActivitySchema.nullable().default(null),
 });
 export type DaemonState = z.infer<typeof DaemonStateSchema>;
 
 // PID file info
 export const PIDInfoSchema = z.object({
+  // Authoritative runtime PID. When a watchdog is present, this is the child daemon PID.
   pid: z.number().int().positive(),
-  started_at: z.string().datetime(),
+  started_at: z.string().datetime().default(PID_EPOCH_ISO),
+  // Process that should receive lifecycle signals. When a watchdog is present, this is the parent PID.
+  owner_pid: z.number().int().positive().optional(),
+  // Explicit watchdog parent PID when running under the watchdog.
+  watchdog_pid: z.number().int().positive().optional(),
+  // Explicit daemon/runtime child PID when running under the watchdog.
+  runtime_pid: z.number().int().positive().optional(),
   version: z.string().optional(),
 });
 export type PIDInfo = z.infer<typeof PIDInfoSchema>;

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -73,10 +73,38 @@ export const ScheduleEntryMetadataSchema = z.object({
 
 export type ScheduleEntryMetadata = z.infer<typeof ScheduleEntryMetadataSchema>;
 
+export const ScheduleFailureKindSchema = z.enum(["transient", "permanent"]);
+export type ScheduleFailureKind = z.infer<typeof ScheduleFailureKindSchema>;
+
+export const ScheduleRetryPolicySchema = z.object({
+  enabled: z.boolean().default(true),
+  initial_delay_ms: z.number().int().min(0).default(30_000),
+  max_delay_ms: z.number().int().positive().default(15 * 60 * 1000),
+  multiplier: z.number().min(1).default(2),
+  jitter_factor: z.number().min(0).max(1).default(0.2),
+  max_attempts: z.number().int().min(1).default(3),
+  max_retry_window_ms: z.number().int().positive().default(24 * 60 * 60 * 1000),
+  retryable_failure_kinds: z.array(ScheduleFailureKindSchema).default(["transient"]),
+});
+
+export type ScheduleRetryPolicy = z.infer<typeof ScheduleRetryPolicySchema>;
+
+export const ScheduleRetryStateSchema = z.object({
+  attempts: z.number().int().nonnegative().default(0),
+  next_retry_at: z.string().datetime().nullable().default(null),
+  last_attempt_at: z.string().datetime().nullable().default(null),
+  first_failure_at: z.string().datetime().nullable().default(null),
+  last_failure_kind: ScheduleFailureKindSchema.nullable().default(null),
+  last_error_message: z.string().nullable().default(null),
+});
+
+export type ScheduleRetryState = z.infer<typeof ScheduleRetryStateSchema>;
+
 export const EscalationConfigSchema = z.object({
   enabled: z.boolean().default(false),
   target_layer: z.enum(["probe", "cron", "goal_trigger"]).optional(),
   target_entry_id: z.string().optional(),
+  target_goal_id: z.string().optional(),
   cooldown_minutes: z.number().default(15),
   max_per_hour: z.number().default(4),
   circuit_breaker_threshold: z.number().default(10),
@@ -102,6 +130,8 @@ export const ScheduleEntrySchema = z.object({
   heartbeat: HeartbeatConfigSchema.optional(),
   probe: ProbeConfigSchema.optional(),
   escalation: EscalationConfigSchema.optional(),
+  retry_policy: ScheduleRetryPolicySchema.optional(),
+  retry_state: ScheduleRetryStateSchema.nullable().optional(),
   baseline_results: z.array(z.unknown()).default([]),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
@@ -131,6 +161,8 @@ export const ScheduleResultSchema = z.object({
   error_message: z.string().optional(),
   fired_at: z.string().datetime(),
   layer: z.enum(["heartbeat", "probe", "cron", "goal_trigger"]).optional(),
+  goal_id: z.string().optional(),
+  failure_kind: ScheduleFailureKindSchema.optional(),
   tokens_used: z.number().default(0),
   escalated_to: z.string().nullable().default(null),
   output_summary: z.string().optional(),

--- a/src/runtime/watchdog.ts
+++ b/src/runtime/watchdog.ts
@@ -91,12 +91,23 @@ export class RuntimeWatchdog {
     this.stopping = false;
     let restartDelayMs = this.restartBackoffMs;
 
-    await this.pidManager.writePID();
+    await this.pidManager.writePID({
+      pid: process.pid,
+      owner_pid: process.pid,
+      watchdog_pid: process.pid,
+      runtime_pid: process.pid,
+    });
 
     try {
       while (!this.stopping) {
         const child = this.startChild();
         this.currentChild = child;
+        await this.pidManager.writePID({
+          pid: child.pid ?? process.pid,
+          owner_pid: process.pid,
+          watchdog_pid: process.pid,
+          runtime_pid: child.pid ?? process.pid,
+        });
         this.logger.info("Watchdog spawned daemon child", { pid: child.pid });
 
         const result = await this.monitorChild(child);


### PR DESCRIPTION
## Summary
- add runtime reconcile and retention/pruning for resident daemon state, plus `doctor --repair`
- add schedule retry/backoff classification and durable recent run history
- add idle-only provider/auth drift refresh for resident dependencies and tighten leader-owned maintenance ordering

## Verification
- npm run typecheck
- npm test -- src/runtime/__tests__/daemon-runner.test.ts src/runtime/__tests__/schedule-engine.test.ts src/runtime/__tests__/daemon-client.test.ts src/interface/cli/__tests__/cli-doctor.test.ts src/base/llm/__tests__/provider-oauth.test.ts src/runtime/__tests__/daemon-maintenance.test.ts