### PR TITLE
[codex] Harden external access surfaces

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - v*
-  workflow_dispatch:
 
 jobs:
   build-and-publish:
@@ -28,8 +27,17 @@ jobs:
 
       - run: npx vitest run
 
+      - name: Verify release tag matches package version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Tag version $TAG_VERSION does not match package version $PACKAGE_VERSION"
+            exit 1
+          fi
+
       - name: Publish to npm
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
@@ -77,6 +77,23 @@ describe("config — loadConfig", () => {
     expect(cfg.allowed_user_ids).toEqual([]);
   });
 
+  it("defaults allow_all to false", () => {
+    writeTmpConfig(tmpDir, { bot_token: "tok", chat_id: 1 });
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.allow_all).toBe(false);
+  });
+
+  it("accepts explicit allow_all when set to true", () => {
+    writeTmpConfig(tmpDir, { bot_token: "tok", chat_id: 1, allow_all: true });
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.allow_all).toBe(true);
+  });
+
+  it("throws when allow_all is not a boolean", () => {
+    writeTmpConfig(tmpDir, { bot_token: "tok", chat_id: 1, allow_all: "yes" });
+    expect(() => loadConfig(tmpDir)).toThrow("allow_all");
+  });
+
   it("throws when config.json does not exist", () => {
     expect(() => loadConfig(tmpDir)).toThrow("telegram-bot: failed to read config.json");
   });
@@ -311,14 +328,17 @@ describe("TelegramNotifier", () => {
 describe("PollingLoop", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let api: TelegramAPI;
+  let tmpDir: string;
 
   beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tg-loop-"));
     fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
     api = new TelegramAPI("tok");
   });
 
   afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -332,8 +352,14 @@ describe("PollingLoop", () => {
     } as unknown as Response;
   }
 
+  function loadLoopConfig(data: Record<string, unknown>): void {
+    writeTmpConfig(tmpDir, data);
+    loadConfig(tmpDir);
+  }
+
   it("processes messages from allowed users", async () => {
     const onMessage = vi.fn().mockResolvedValue(undefined);
+    loadLoopConfig({ bot_token: "tok", chat_id: 200, allowed_user_ids: [111] });
 
     // First call returns one message; second call blocks until stop()
     let stopLoop!: () => void;
@@ -345,7 +371,7 @@ describe("PollingLoop", () => {
       ]))
       .mockReturnValueOnce(blocker);
 
-    const loop = new PollingLoop(api, onMessage, [111]);
+    const loop = new PollingLoop(api, onMessage, [111], { allowedChatId: 200 });
     loop.start();
 
     // Let the first iteration run
@@ -360,6 +386,7 @@ describe("PollingLoop", () => {
 
   it("rejects messages from non-allowed users", async () => {
     const onMessage = vi.fn().mockResolvedValue(undefined);
+    loadLoopConfig({ bot_token: "tok", chat_id: 200, allowed_user_ids: [111] });
 
     let stopLoop!: () => void;
     const blocker = new Promise<Response>((resolve) => { stopLoop = () => resolve(updatesResponse([])); });
@@ -370,7 +397,7 @@ describe("PollingLoop", () => {
       ]))
       .mockReturnValueOnce(blocker);
 
-    const loop = new PollingLoop(api, onMessage, [111]); // 999 not in list
+    const loop = new PollingLoop(api, onMessage, [111], { allowedChatId: 200 }); // 999 not in list
     loop.start();
 
     await new Promise((r) => setImmediate(r));
@@ -382,8 +409,9 @@ describe("PollingLoop", () => {
     stopLoop();
   });
 
-  it("allows all users when allowed_user_ids is empty", async () => {
+  it("rejects messages when allowed_user_ids is empty and allow_all is false", async () => {
     const onMessage = vi.fn().mockResolvedValue(undefined);
+    loadLoopConfig({ bot_token: "tok", chat_id: 300, allowed_user_ids: [] });
 
     let stopLoop!: () => void;
     const blocker = new Promise<Response>((resolve) => { stopLoop = () => resolve(updatesResponse([])); });
@@ -394,7 +422,32 @@ describe("PollingLoop", () => {
       ]))
       .mockReturnValueOnce(blocker);
 
-    const loop = new PollingLoop(api, onMessage, []); // empty = allow all
+    const loop = new PollingLoop(api, onMessage, [], { allowedChatId: 300 });
+    loop.start();
+
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onMessage).not.toHaveBeenCalled();
+
+    loop.stop();
+    stopLoop();
+  });
+
+  it("allows all users when allow_all is true but still requires the configured chat_id", async () => {
+    const onMessage = vi.fn().mockResolvedValue(undefined);
+    loadLoopConfig({ bot_token: "tok", chat_id: 300, allowed_user_ids: [], allow_all: true });
+
+    let stopLoop!: () => void;
+    const blocker = new Promise<Response>((resolve) => { stopLoop = () => resolve(updatesResponse([])); });
+
+    fetchMock
+      .mockResolvedValueOnce(updatesResponse([
+        { update_id: 1, message: { message_id: 1, from: { id: 777 }, chat: { id: 300 }, text: "hi" } },
+      ]))
+      .mockReturnValueOnce(blocker);
+
+    const loop = new PollingLoop(api, onMessage, [], { allowedChatId: 300, allowAll: true });
     loop.start();
 
     await new Promise((r) => setImmediate(r));
@@ -406,15 +459,41 @@ describe("PollingLoop", () => {
     stopLoop();
   });
 
+  it("rejects messages from the wrong chat even when the user is allowed", async () => {
+    const onMessage = vi.fn().mockResolvedValue(undefined);
+    loadLoopConfig({ bot_token: "tok", chat_id: 300, allowed_user_ids: [777] });
+
+    let stopLoop!: () => void;
+    const blocker = new Promise<Response>((resolve) => { stopLoop = () => resolve(updatesResponse([])); });
+
+    fetchMock
+      .mockResolvedValueOnce(updatesResponse([
+        { update_id: 1, message: { message_id: 1, from: { id: 777 }, chat: { id: 999 }, text: "hi" } },
+      ]))
+      .mockReturnValueOnce(blocker);
+
+    const loop = new PollingLoop(api, onMessage, [777], { allowedChatId: 300 });
+    loop.start();
+
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onMessage).not.toHaveBeenCalled();
+
+    loop.stop();
+    stopLoop();
+  });
+
   it("stop() halts the loop — running becomes false", async () => {
     const onMessage = vi.fn().mockResolvedValue(undefined);
+    loadLoopConfig({ bot_token: "tok", chat_id: 300, allowed_user_ids: [] });
 
     let stopLoop!: () => void;
     const blocker = new Promise<Response>((resolve) => { stopLoop = () => resolve(updatesResponse([])); });
 
     fetchMock.mockReturnValueOnce(blocker);
 
-    const loop = new PollingLoop(api, onMessage, []);
+    const loop = new PollingLoop(api, onMessage, [], { allowedChatId: 300 });
     loop.start();
 
     loop.stop(); // stop before first fetch resolves
@@ -429,6 +508,7 @@ describe("PollingLoop", () => {
   it("handles getUpdates errors without crashing (backoff)", async () => {
     const onMessage = vi.fn().mockResolvedValue(undefined);
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    loadLoopConfig({ bot_token: "tok", chat_id: 300, allowed_user_ids: [] });
 
     let stopLoop!: () => void;
     const blocker = new Promise<Response>((resolve) => { stopLoop = () => resolve(updatesResponse([])); });
@@ -437,7 +517,7 @@ describe("PollingLoop", () => {
       .mockRejectedValueOnce(new Error("network timeout"))
       .mockReturnValueOnce(blocker);
 
-    const loop = new PollingLoop(api, onMessage, []);
+    const loop = new PollingLoop(api, onMessage, [], { allowedChatId: 300 });
     loop.start();
 
     await new Promise((r) => setImmediate(r));

--- a/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
@@ -36,6 +36,16 @@ vi.mock("pulseed", () => {
   return {
     StateManager: FakeStateManager,
     ChatRunner: FakeChatRunner,
+    TrustManager: class {
+      constructor(_stateManager: unknown) {}
+    },
+    ToolExecutor: class {
+      constructor(_deps: unknown) {}
+    },
+    ToolPermissionManager: class {
+      constructor(_deps: unknown) {}
+    },
+    ConcurrencyController: class {},
     buildLLMClient: mockBuildLLMClient,
     buildAdapterRegistry: mockBuildAdapterRegistry,
     loadProviderConfig: mockLoadProviderConfig,

--- a/plugins/telegram-bot/src/config.ts
+++ b/plugins/telegram-bot/src/config.ts
@@ -7,6 +7,7 @@ export interface TelegramConfig {
   bot_token: string;
   chat_id: number;
   allowed_user_ids: number[];
+  allow_all: boolean;
   polling_timeout: number;
 }
 
@@ -46,6 +47,11 @@ function validateConfig(raw: unknown): TelegramConfig {
     throw new Error("telegram-bot: allowed_user_ids must be an array of integers");
   }
 
+  const allowAll = cfg["allow_all"] ?? false;
+  if (typeof allowAll !== "boolean") {
+    throw new Error("telegram-bot: allow_all must be a boolean");
+  }
+
   const pollingTimeout = cfg["polling_timeout"] ?? 30;
   if (typeof pollingTimeout !== "number" || !Number.isInteger(pollingTimeout)) {
     throw new Error("telegram-bot: polling_timeout must be an integer");
@@ -55,6 +61,7 @@ function validateConfig(raw: unknown): TelegramConfig {
     bot_token: cfg["bot_token"] as string,
     chat_id: cfg["chat_id"] as number,
     allowed_user_ids: allowedUserIds as number[],
+    allow_all: allowAll,
     polling_timeout: Math.min(Math.max(pollingTimeout as number, 1), 60),
   };
 }

--- a/plugins/telegram-bot/src/index.ts
+++ b/plugins/telegram-bot/src/index.ts
@@ -49,7 +49,8 @@ export class TelegramBotPlugin {
       async (text, fromUserId, chatId) => {
         await bridge.handleMessage(text, fromUserId, chatId);
       },
-      config.allowed_user_ids
+      config.allowed_user_ids,
+      { allowedChatId: config.chat_id, allowAll: config.allow_all }
     );
   }
 

--- a/plugins/telegram-bot/src/polling-loop.ts
+++ b/plugins/telegram-bot/src/polling-loop.ts
@@ -3,6 +3,10 @@ import type { TelegramAPI } from "./telegram-api.js";
 // ─── Types ───
 
 type OnMessageFn = (text: string, fromUserId: number, chatId: number) => Promise<void>;
+interface PollingLoopOptions {
+  allowedChatId: number;
+  allowAll?: boolean;
+}
 
 // ─── Backoff config ───
 
@@ -14,15 +18,19 @@ export class PollingLoop {
   private readonly api: TelegramAPI;
   private readonly onMessage: OnMessageFn;
   private readonly allowedUserIds: number[];
+  private readonly allowedChatId: number;
+  private readonly allowAll: boolean;
 
   private running = false;
   private offset = 0;
   private abortController: AbortController | null = null;
 
-  constructor(api: TelegramAPI, onMessage: OnMessageFn, allowedUserIds: number[]) {
+  constructor(api: TelegramAPI, onMessage: OnMessageFn, allowedUserIds: number[], options: PollingLoopOptions) {
     this.api = api;
     this.onMessage = onMessage;
     this.allowedUserIds = allowedUserIds;
+    this.allowedChatId = options.allowedChatId;
+    this.allowAll = options.allowAll ?? false;
   }
 
   start(): void {
@@ -52,12 +60,17 @@ export class PollingLoop {
           const msg = update.message;
           if (!msg?.text) continue;
 
-          const fromId = msg.from.id;
-          if (this.allowedUserIds.length > 0 && !this.allowedUserIds.includes(fromId)) {
+          const fromId = msg.from?.id;
+          const chatId = msg.chat?.id;
+          if (typeof fromId !== "number" || !Number.isInteger(fromId)) continue;
+          if (typeof chatId !== "number" || !Number.isInteger(chatId)) continue;
+          if (chatId !== this.allowedChatId) continue;
+
+          if (!this.allowAll && !this.allowedUserIds.includes(fromId)) {
             continue;
           }
 
-          await this.onMessage(msg.text, fromId, msg.chat.id);
+          await this.onMessage(msg.text, fromId, chatId);
         }
       } catch (err) {
         if (!this.running) break;

--- a/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
+++ b/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
@@ -6,6 +6,9 @@ import {
   buildLLMClient,
   loadProviderConfig,
   ToolRegistry,
+  ToolExecutor,
+  ToolPermissionManager,
+  ConcurrencyController,
   createBuiltinTools,
   type ChatEventHandler,
   type IAdapter,
@@ -13,12 +16,14 @@ import {
   type ChatRunnerLike,
   type ProviderConfig,
 } from "pulseed";
+import { TrustManager } from "pulseed";
 
 interface BootstrapResult {
   stateManager: StateManager;
   llmClient: ILLMClient;
   adapter: IAdapter;
   registry: ToolRegistry;
+  toolExecutor: ToolExecutor;
   providerConfig: ProviderConfig;
 }
 
@@ -60,6 +65,7 @@ export class TelegramChatRunnerProcessor {
       adapter: bootstrap.adapter,
       llmClient: bootstrap.llmClient,
       registry: bootstrap.registry,
+      toolExecutor: bootstrap.toolExecutor,
     });
     runner.startSession(this.workspaceRoot);
     this.sessions.set(chatId, runner);
@@ -85,15 +91,25 @@ export class TelegramChatRunnerProcessor {
     const registry = await buildAdapterRegistry(llmClient, providerConfig);
     const adapter = registry.getAdapter(providerConfig.adapter);
     const toolRegistry = new ToolRegistry();
-    for (const tool of createBuiltinTools({ stateManager })) {
+    const trustManager = new TrustManager(stateManager);
+    for (const tool of createBuiltinTools({ stateManager, trustManager, registry: toolRegistry })) {
       toolRegistry.register(tool);
     }
+    const permissionManager = new ToolPermissionManager({
+      trustManager,
+    });
+    const toolExecutor = new ToolExecutor({
+      registry: toolRegistry,
+      permissionManager,
+      concurrency: new ConcurrencyController(),
+    });
 
     return {
       stateManager,
       llmClient,
       adapter,
       registry: toolRegistry,
+      toolExecutor,
       providerConfig,
     };
   }

--- a/src/__tests__/index-exports.test.ts
+++ b/src/__tests__/index-exports.test.ts
@@ -12,7 +12,7 @@ describe("src/index.ts exports", () => {
     expect(barrel.extractJSON).toBe(llmModule.extractJSON);
     expect(barrel.EthicsGate).toBe(ethicsModule.EthicsGate);
     expect(barrel.StateManager).toBe(stateModule.StateManager);
-  });
+  }, 15_000);
 
   it("re-exports selected utility functions as callable values", async () => {
     const barrel = await import("../index.js");
@@ -20,5 +20,5 @@ describe("src/index.ts exports", () => {
     expect(typeof barrel.calculateDimensionGap).toBe("function");
     expect(typeof barrel.scoreAllDimensions).toBe("function");
     expect(typeof barrel.buildLLMClient).toBe("function");
-  });
+  }, 15_000);
 });

--- a/src/interface/chat/__tests__/chat-runner-tools.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-tools.test.ts
@@ -5,6 +5,7 @@ import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient, LLMResponse } from "../../../base/llm/llm-client.js";
 import type { ToolRegistry } from "../../../tools/registry.js";
+import type { ToolExecutor } from "../../../tools/executor.js";
 import type { ITool, ToolResult, ToolCallContext } from "../../../tools/types.js";
 import { z } from "zod";
 
@@ -98,6 +99,14 @@ function makeMockRegistry(tool: ITool): ToolRegistry {
   } as unknown as ToolRegistry;
 }
 
+function makeMockExecutor(
+  executeImpl: (toolName: string, input: unknown, context: ToolCallContext) => Promise<ToolResult>
+): ToolExecutor {
+  return {
+    execute: vi.fn().mockImplementation(executeImpl),
+  } as unknown as ToolExecutor;
+}
+
 function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
   return {
     stateManager: makeMockStateManager(),
@@ -131,6 +140,49 @@ describe("ChatRunner — tool status callbacks", () => {
 
       expect(onToolStart).toHaveBeenCalledOnce();
       expect(onToolStart).toHaveBeenCalledWith(toolName, toolArgs);
+    });
+
+    it("routes tool calls through ToolExecutor when available", async () => {
+      const onToolStart = vi.fn();
+      const onToolEnd = vi.fn();
+      const tool = makeMockTool(toolName, async () => {
+        throw new Error("raw tool.call should not run");
+      });
+      const executor = makeMockExecutor(async (executedName, input, context) => {
+        expect(executedName).toBe(toolName);
+        expect(input).toEqual(toolArgs);
+        const approved = await context.approvalFn({
+          toolName: executedName,
+          input,
+          reason: "approval required",
+          permissionLevel: "write_local",
+          isDestructive: false,
+          reversibility: "unknown",
+        });
+        expect(approved).toBe(false);
+        return {
+          success: false,
+          data: null,
+          summary: "User denied approval",
+          durationMs: 5,
+        };
+      });
+      const deps = makeDeps({
+        llmClient: makeLLMClientWithToolCall(toolName, toolArgs),
+        registry: makeMockRegistry(tool),
+        onToolStart,
+        onToolEnd,
+        toolExecutor: executor,
+      });
+      const runner = new ChatRunner(deps);
+
+      const result = await runner.execute("test", "/repo");
+
+      expect((executor.execute as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+      expect(tool.call).not.toHaveBeenCalled();
+      expect(onToolStart).toHaveBeenCalledOnce();
+      expect(onToolEnd).toHaveBeenCalledOnce();
+      expect(result.output).toBe("Tool executed, here is the result.");
     });
 
     it("is called before tool.call() executes", async () => {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -661,61 +661,75 @@ export class ChatRunner {
         ...this.eventBase(eventContext),
       });
 
-      // Gate: check permissions before execution
-      const permResult = await tool.checkPermissions(parsed.data, context);
-      if (permResult.status === "denied") {
-        this.emitEvent({
-          type: "tool_end",
-          toolCallId,
-          toolName: name,
-          success: false,
-          summary: permResult.reason,
-          durationMs: Date.now() - startTime,
-          ...this.eventBase(eventContext),
-        });
-        return `Tool ${name} denied: ${permResult.reason}`;
-      }
-      if (permResult.status === "needs_approval") {
+      let result: { success: boolean; summary: string; data?: unknown; error?: string };
+      if (this.deps.toolExecutor) {
         this.emitEvent({
           type: "tool_update",
           toolCallId,
           toolName: name,
-          status: "awaiting_approval",
-          message: permResult.reason,
+          status: "running",
+          message: "running",
           ...this.eventBase(eventContext),
         });
-        const approved = await context.approvalFn({
-          toolName: name,
-          input: parsed.data,
-          reason: permResult.reason,
-          permissionLevel: tool.metadata.permissionLevel,
-          isDestructive: tool.metadata.isDestructive,
-          reversibility: "unknown",
-        });
-        if (!approved) {
+        this.deps.onToolStart?.(name, args);
+        result = await this.deps.toolExecutor.execute(name, parsed.data, context);
+      } else {
+        // Gate: check permissions before execution
+        const permResult = await tool.checkPermissions(parsed.data, context);
+        if (permResult.status === "denied") {
           this.emitEvent({
             type: "tool_end",
             toolCallId,
             toolName: name,
             success: false,
-            summary: `Not approved: ${permResult.reason}`,
+            summary: permResult.reason,
             durationMs: Date.now() - startTime,
             ...this.eventBase(eventContext),
           });
-          return `Tool ${name} not approved: ${permResult.reason}`;
+          return `Tool ${name} denied: ${permResult.reason}`;
         }
+        if (permResult.status === "needs_approval") {
+          this.emitEvent({
+            type: "tool_update",
+            toolCallId,
+            toolName: name,
+            status: "awaiting_approval",
+            message: permResult.reason,
+            ...this.eventBase(eventContext),
+          });
+          const approved = await context.approvalFn({
+            toolName: name,
+            input: parsed.data,
+            reason: permResult.reason,
+            permissionLevel: tool.metadata.permissionLevel,
+            isDestructive: tool.metadata.isDestructive,
+            reversibility: "unknown",
+          });
+          if (!approved) {
+            this.emitEvent({
+              type: "tool_end",
+              toolCallId,
+              toolName: name,
+              success: false,
+              summary: `Not approved: ${permResult.reason}`,
+              durationMs: Date.now() - startTime,
+              ...this.eventBase(eventContext),
+            });
+            return `Tool ${name} not approved: ${permResult.reason}`;
+          }
+        }
+        this.emitEvent({
+          type: "tool_update",
+          toolCallId,
+          toolName: name,
+          status: "running",
+          message: "running",
+          ...this.eventBase(eventContext),
+        });
+        this.deps.onToolStart?.(name, args);
+        result = await tool.call(parsed.data, context);
       }
 
-      this.emitEvent({
-        type: "tool_update",
-        toolCallId,
-        toolName: name,
-        status: "running",
-        message: "running",
-        ...this.eventBase(eventContext),
-      });
-      this.deps.onToolStart?.(name, args);
-      const result = await tool.call(parsed.data, context);
       const durationMs = Date.now() - startTime;
       this.deps.onToolEnd?.(name, { success: result.success, summary: result.summary || '...', durationMs });
       this.emitEvent({

--- a/src/interface/chat/event-subscriber.ts
+++ b/src/interface/chat/event-subscriber.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { readDaemonAuthToken } from "../../runtime/daemon/client.js";
 
 export interface TendNotification {
   type: "progress" | "stall" | "complete" | "error" | "approval";
@@ -39,7 +40,8 @@ export class EventSubscriber extends EventEmitter {
   constructor(
     private baseUrl: string,
     private goalId: string,
-    private verbosity: NotificationVerbosity = "normal"
+    private verbosity: NotificationVerbosity = "normal",
+    private authToken: string | null = readDaemonAuthToken()
   ) {
     super();
   }
@@ -60,7 +62,11 @@ export class EventSubscriber extends EventEmitter {
       }
 
       const res = await fetch(`${this.baseUrl}/stream?after=${this.lastOutboxSeq}`, {
-        headers: { Accept: "text/event-stream", "Cache-Control": "no-cache" },
+        headers: {
+          Accept: "text/event-stream",
+          "Cache-Control": "no-cache",
+          ...this.authHeaders(),
+        },
         signal: this.abortController!.signal,
       });
 
@@ -273,7 +279,7 @@ export class EventSubscriber extends EventEmitter {
   private async bootstrapSnapshot(): Promise<void> {
     try {
       const res = await fetch(`${this.baseUrl}/snapshot`, {
-        headers: { Accept: "application/json" },
+        headers: { Accept: "application/json", ...this.authHeaders() },
         signal: this.abortController!.signal,
       });
       if (!res.ok) {
@@ -295,5 +301,9 @@ export class EventSubscriber extends EventEmitter {
     } catch {
       // Snapshot bootstrap is best-effort.
     }
+  }
+
+  private authHeaders(): Record<string, string> {
+    return this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {};
   }
 }

--- a/src/interface/cli/commands/chat.ts
+++ b/src/interface/cli/commands/chat.ts
@@ -21,9 +21,10 @@ import { EscalationHandler } from "../../chat/escalation.js";
 import { DaemonClient, isDaemonRunning } from "../../../runtime/daemon/client.js";
 import { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import { TrustManager } from "../../../platform/traits/trust-manager.js";
-import { ToolRegistry } from "../../../tools/registry.js";
+import { ToolRegistry, ToolExecutor, ToolPermissionManager, ConcurrencyController } from "../../../tools/index.js";
 import { createBuiltinTools } from "../../../tools/builtin/index.js";
 import { applyChatEventToMessages } from "../../chat/chat-event-state.js";
+import { isSafeBashCommand } from "../../tui/bash-mode.js";
 
 const logger = getCliLogger();
 
@@ -198,6 +199,25 @@ export async function cmdChat(
     })) {
       registry.register(tool);
     }
+    const permissionManager = new ToolPermissionManager({
+      trustManager,
+      allowRules: [
+        {
+          toolName: "shell",
+          inputMatcher: (input) =>
+            typeof input === "object" &&
+            input !== null &&
+            typeof (input as Record<string, unknown>)["command"] === "string" &&
+            isSafeBashCommand((input as Record<string, unknown>)["command"] as string),
+          reason: "safe shell command",
+        },
+      ],
+    });
+    const toolExecutor = new ToolExecutor({
+      registry,
+      permissionManager,
+      concurrency: new ConcurrencyController(),
+    });
 
     // Build escalation + tend deps (optional — /track and /tend work only when LLM is available)
     let escalationHandler: EscalationHandler | undefined;
@@ -219,7 +239,15 @@ export async function cmdChat(
     try {
       const daemonInfo = await isDaemonRunning(pulseedDir);
       if (daemonInfo.running) {
-        daemonClient = new DaemonClient({ host: "127.0.0.1", port: daemonInfo.port });
+        if (daemonInfo.authToken) {
+          process.env["PULSEED_DAEMON_TOKEN"] = daemonInfo.authToken;
+        }
+        daemonClient = new DaemonClient({
+          host: "127.0.0.1",
+          port: daemonInfo.port,
+          authToken: daemonInfo.authToken,
+          baseDir: pulseedDir,
+        });
         daemonBaseUrl = `http://127.0.0.1:${daemonInfo.port}`;
       }
     } catch {
@@ -236,6 +264,7 @@ export async function cmdChat(
       daemonClient,
       daemonBaseUrl,
       registry,
+      toolExecutor,
       approvalFn: promptChatApproval,
     });
 

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -32,7 +32,7 @@ import { getProviderRuntimeFingerprint } from "../../../base/llm/provider-config
 import { buildDeps } from "../setup.js";
 import { formatOperationError } from "../utils.js";
 import { getCliLogger } from "../cli-logger.js";
-import { getPulseedDirPath, getLogsDir } from "../../../base/utils/paths.js";
+import { getPulseedDirPath, getLogsDir, getEventsDir } from "../../../base/utils/paths.js";
 import { summarizeTaskOutcomeLedgers } from "../../../orchestrator/execution/task/task-outcome-ledger.js";
 import type { SupervisorState } from "../../../runtime/executor/index.js";
 
@@ -266,7 +266,7 @@ export async function cmdStart(
   // Create EventServer for event-driven wake-ups and SSE clients.
   const eventServer = new EventServer(
     deps.driveSystem,
-    { port: resolvedDaemonConfig.event_server_port },
+    { port: resolvedDaemonConfig.event_server_port, eventsDir: getEventsDir(daemonBaseDir) },
     logger
   );
   notificationDispatcher.setRealtimeSink(async (report) => {

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -56,13 +56,13 @@ async function startDaemonDetached(baseDir: string): Promise<void> {
   child.unref();
 }
 
-async function waitForDaemon(baseDir: string, timeoutMs: number): Promise<number> {
+async function waitForDaemon(baseDir: string, timeoutMs: number): Promise<{ port: number; authToken?: string | null }> {
   const { isDaemonRunning } = await import("../../runtime/daemon/client.js");
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    const { running, port } = await isDaemonRunning(baseDir);
-    if (running) return port;
+    const { running, port, authToken } = await isDaemonRunning(baseDir);
+    if (running) return { port, authToken };
     await new Promise((r) => setTimeout(r, 500));
   }
   throw new Error("Daemon failed to start within timeout");
@@ -426,14 +426,14 @@ async function startTUIDaemonMode(): Promise<void> {
   let daemonClient: InstanceType<typeof DaemonClient>;
 
   try {
-    const { running, port } = await isDaemonRunning(baseDir);
+    const { running, port, authToken } = await isDaemonRunning(baseDir);
 
     if (running) {
-      daemonClient = new DaemonClient({ host: "127.0.0.1", port });
+      daemonClient = new DaemonClient({ host: "127.0.0.1", port, authToken, baseDir });
     } else {
       await startDaemonDetached(baseDir);
-      const readyPort = await waitForDaemon(baseDir, 10_000);
-      daemonClient = new DaemonClient({ host: "127.0.0.1", port: readyPort });
+      const ready = await waitForDaemon(baseDir, 10_000);
+      daemonClient = new DaemonClient({ host: "127.0.0.1", port: ready.port, authToken: ready.authToken, baseDir });
     }
 
     daemonClient.connect();

--- a/src/runtime/__tests__/daemon-client.test.ts
+++ b/src/runtime/__tests__/daemon-client.test.ts
@@ -67,6 +67,7 @@ describe("DaemonClient snapshot + replay", () => {
       port: server.getPort(),
       reconnectInterval: 50,
       maxReconnectAttempts: 2,
+      authToken: server.getAuthToken(),
     });
 
     try {
@@ -97,6 +98,7 @@ describe("DaemonClient snapshot + replay", () => {
       port: server.getPort(),
       reconnectInterval: 50,
       maxReconnectAttempts: 2,
+      authToken: server.getAuthToken(),
     });
 
     try {

--- a/src/runtime/__tests__/daemon-runner-approval.test.ts
+++ b/src/runtime/__tests__/daemon-runner-approval.test.ts
@@ -68,7 +68,8 @@ function request(
   port: number,
   method: string,
   urlPath: string,
-  body?: unknown
+  body: unknown,
+  authToken: string
 ): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const data = body === undefined ? "" : JSON.stringify(body);
@@ -80,6 +81,7 @@ function request(
         method,
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${authToken}`,
           ...(data ? { "Content-Length": Buffer.byteLength(data) } : {}),
         },
       },
@@ -102,7 +104,7 @@ function request(
   });
 }
 
-function waitForSseEvent(port: number, eventType: string): Promise<unknown> {
+function waitForSseEvent(port: number, eventType: string, authToken: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let settled = false;
     const req = http.get(
@@ -110,7 +112,7 @@ function waitForSseEvent(port: number, eventType: string): Promise<unknown> {
         hostname: "127.0.0.1",
         port,
         path: "/stream",
-        headers: { Accept: "text/event-stream" },
+        headers: { Accept: "text/event-stream", Authorization: `Bearer ${authToken}` },
       },
       (res) => {
         let buffer = "";
@@ -245,7 +247,8 @@ describe("DaemonRunner durable approval restart", () => {
       poll();
     });
 
-    const restored = await waitForSseEvent(port, "approval_required");
+    const authToken = (daemon as any)?.eventServer?.getAuthToken?.() as string;
+    const restored = await waitForSseEvent(port, "approval_required", authToken);
     expect(restored).toEqual(
       expect.objectContaining({
         requestId: approvalId,
@@ -257,7 +260,7 @@ describe("DaemonRunner durable approval restart", () => {
     const approveResult = await request(port, "POST", "/goals/goal-1/approve", {
       requestId: approvalId,
       approved: true,
-    });
+    }, authToken);
     expect(approveResult.status).toBe(200);
 
     const resolvedPath = paths.approvalResolvedPath(approvalId);

--- a/src/runtime/__tests__/event-server-approval.test.ts
+++ b/src/runtime/__tests__/event-server-approval.test.ts
@@ -19,7 +19,8 @@ function request(
   port: number,
   method: string,
   urlPath: string,
-  body?: unknown
+  body: unknown,
+  authToken: string
 ): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const data = body === undefined ? "" : JSON.stringify(body);
@@ -31,6 +32,7 @@ function request(
         method,
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${authToken}`,
           ...(data ? { "Content-Length": Buffer.byteLength(data) } : {}),
         },
       },
@@ -53,7 +55,7 @@ function request(
   });
 }
 
-function waitForSseEvent(port: number, eventType: string): Promise<unknown> {
+function waitForSseEvent(port: number, eventType: string, authToken: string): Promise<unknown> {
   return new Promise((resolve, reject) => {
     let settled = false;
     const req = http.get(
@@ -61,7 +63,7 @@ function waitForSseEvent(port: number, eventType: string): Promise<unknown> {
         hostname: "127.0.0.1",
         port,
         path: "/stream",
-        headers: { Accept: "text/event-stream" },
+        headers: { Accept: "text/event-stream", Authorization: `Bearer ${authToken}` },
       },
       (res) => {
         let buffer = "";
@@ -161,7 +163,7 @@ describe("EventServer durable approval integration", () => {
       const result = await request(server.getPort(), "POST", "/goals/goal-1/approve", {
         requestId: "approval-http",
         approved: true,
-      });
+      }, server.getAuthToken());
 
       expect(result.status).toBe(200);
       await expect(approval).resolves.toBe(true);
@@ -206,7 +208,7 @@ describe("EventServer durable approval integration", () => {
 
     try {
       await server.start();
-      const event = await waitForSseEvent(server.getPort(), "approval_required");
+      const event = await waitForSseEvent(server.getPort(), "approval_required", server.getAuthToken());
       expect(event).toEqual({
         requestId: "approval-sse",
         goalId: "goal-sse",

--- a/src/runtime/__tests__/event-server.test.ts
+++ b/src/runtime/__tests__/event-server.test.ts
@@ -22,14 +22,15 @@ const createMockDriveSystem = (tmpDir: string) => ({
 async function startWithRetry(
   driveSystem: ReturnType<typeof createMockDriveSystem>
 ): Promise<{ server: EventServer; port: number }> {
-  const s = new EventServer(driveSystem as never, { port: 0 });
+  const s = new EventServer(driveSystem as never, { port: 0, eventsDir: path.join(tmpDir, "events") });
   await s.start();
   return { server: s, port: s.getPort() };
 }
 
 function postEvent(
   port: number,
-  body: unknown
+  body: unknown,
+  authToken: string | null | undefined = server?.getAuthToken()
 ): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const data = JSON.stringify(body);
@@ -42,6 +43,7 @@ function postEvent(
         headers: {
           "Content-Type": "application/json",
           "Content-Length": Buffer.byteLength(data),
+          ...authHeaders(authToken),
         },
       },
       (res) => {
@@ -60,12 +62,16 @@ function makeRequest(
   port: number,
   method: string,
   urlPath: string,
-  body?: unknown
+  body?: unknown,
+  authToken: string | null | undefined = server?.getAuthToken(),
+  extraHeaders: http.OutgoingHttpHeaders = {}
 ): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const data = body !== undefined ? JSON.stringify(body) : "";
     const headers: http.OutgoingHttpHeaders = {
       "Content-Type": "application/json",
+      ...authHeaders(authToken),
+      ...extraHeaders,
     };
     if (data.length > 0) {
       headers["Content-Length"] = Buffer.byteLength(data);
@@ -94,7 +100,8 @@ function collectSseEvents(
   port: number,
   urlPath: string,
   eventType: string,
-  expectedCount: number
+  expectedCount: number,
+  authToken: string | null | undefined = server?.getAuthToken()
 ): Promise<unknown[]> {
   return new Promise((resolve, reject) => {
     const received: unknown[] = [];
@@ -104,7 +111,7 @@ function collectSseEvents(
         hostname: "127.0.0.1",
         port,
         path: urlPath,
-        headers: { Accept: "text/event-stream" },
+        headers: { Accept: "text/event-stream", ...authHeaders(authToken) },
       },
       (res) => {
         let buffer = "";
@@ -158,6 +165,10 @@ function collectSseEvents(
   });
 }
 
+function authHeaders(authToken: string | null | undefined): http.OutgoingHttpHeaders {
+  return authToken ? { Authorization: `Bearer ${authToken}` } : {};
+}
+
 const validEvent: PulSeedEvent = {
   type: "external",
   source: "test-source",
@@ -175,7 +186,7 @@ let port: number;
 beforeEach(async () => {
   tmpDir = makeTempDir();
   mockDriveSystem = createMockDriveSystem(tmpDir);
-  server = new EventServer(mockDriveSystem as never, { port: 0 });
+  server = new EventServer(mockDriveSystem as never, { port: 0, eventsDir: path.join(tmpDir, "events") });
   // port will be set after start() for tests that need it; for tests that
   // call start() themselves they must read server.getPort() afterward.
   port = 0;
@@ -222,7 +233,7 @@ describe("start / stop", () => {
     await server.start();
     await server.stop();
 
-    const server2 = new EventServer(mockDriveSystem as never, { port: 0 });
+    const server2 = new EventServer(mockDriveSystem as never, { port: 0, eventsDir: path.join(tmpDir, "events") });
     await server2.start();
     expect(server2.isRunning()).toBe(true);
     await server2.stop();
@@ -352,6 +363,7 @@ describe("POST /events — invalid data", () => {
             headers: {
               "Content-Type": "application/json",
               "Content-Length": Buffer.byteLength(data),
+              Authorization: `Bearer ${server.getAuthToken()}`,
             },
           },
           (res) => {
@@ -443,6 +455,88 @@ describe("routing — wrong method or path", () => {
     await makeRequest(port, "GET", "/events");
     await makeRequest(port, "POST", "/wrong", validEvent);
     expect(mockDriveSystem.writeEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("daemon HTTP auth guard", () => {
+  beforeEach(async () => {
+    await server.start();
+    port = server.getPort();
+  });
+
+  it("writes a per-daemon token file next to the events directory", () => {
+    const tokenPath = path.join(tmpDir, "daemon-token.json");
+    const tokenFile = JSON.parse(fs.readFileSync(tokenPath, "utf-8")) as {
+      token?: string;
+      port?: number;
+    };
+
+    expect(tokenFile.token).toBe(server.getAuthToken());
+    expect(tokenFile.port).toBe(port);
+  });
+
+  it("keeps /health available without auth", async () => {
+    const result = await makeRequest(port, "GET", "/health", undefined, null);
+    expect(result.status).toBe(200);
+  });
+
+  it("rejects state-changing POST requests without a bearer token", async () => {
+    const result = await postEvent(port, validEvent, null);
+    expect(result.status).toBe(401);
+    expect(mockDriveSystem.writeEvent).not.toHaveBeenCalled();
+  });
+
+  it("rejects browser cross-site requests even with a valid bearer token", async () => {
+    const result = await makeRequest(
+      port,
+      "POST",
+      "/goals/g-1/start",
+      {},
+      server.getAuthToken(),
+      {
+        Origin: "https://attacker.example",
+        "Sec-Fetch-Site": "cross-site",
+      }
+    );
+
+    expect(result.status).toBe(403);
+  });
+
+  it("rejects non-JSON POST requests", async () => {
+    const result = await makeRequest(
+      port,
+      "POST",
+      "/goals/g-1/start",
+      {},
+      server.getAuthToken(),
+      { "Content-Type": "text/plain" }
+    );
+
+    expect(result.status).toBe(415);
+  });
+
+  it("rejects unauthenticated SSE and does not emit wildcard CORS", async () => {
+    const result = await new Promise<{ status: number; cors: string | undefined }>((resolve, reject) => {
+      const req = http.get(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/stream",
+          headers: { Accept: "text/event-stream" },
+        },
+        (res) => {
+          res.resume();
+          res.on("end", () => resolve({
+            status: res.statusCode ?? 0,
+            cors: res.headers["access-control-allow-origin"] as string | undefined,
+          }));
+        }
+      );
+      req.on("error", reject);
+    });
+
+    expect(result.status).toBe(401);
+    expect(result.cors).toBeUndefined();
   });
 });
 

--- a/src/runtime/__tests__/trigger-api.test.ts
+++ b/src/runtime/__tests__/trigger-api.test.ts
@@ -24,11 +24,15 @@ function makeRequest(
   port: number,
   method: string,
   urlPath: string,
-  body?: unknown
+  body?: unknown,
+  authToken: string | null | undefined = server?.getAuthToken()
 ): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const data = body !== undefined ? JSON.stringify(body) : "";
-    const headers: http.OutgoingHttpHeaders = { "Content-Type": "application/json" };
+    const headers: http.OutgoingHttpHeaders = {
+      "Content-Type": "application/json",
+      ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}),
+    };
     if (data.length > 0) headers["Content-Length"] = Buffer.byteLength(data);
     const req = http.request(
       { hostname: "127.0.0.1", port, path: urlPath, method, headers },

--- a/src/runtime/daemon/client.ts
+++ b/src/runtime/daemon/client.ts
@@ -4,6 +4,9 @@
 // Receives events via SSE, sends commands via REST.
 
 import http from "node:http";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { DEFAULT_PORT } from "../port-utils.js";
 
 export interface DaemonClientConfig {
@@ -11,6 +14,8 @@ export interface DaemonClientConfig {
   port: number;
   reconnectInterval?: number; // ms, default 3000
   maxReconnectAttempts?: number; // default 10
+  authToken?: string | null;
+  baseDir?: string;
 }
 
 export interface DaemonEvent {
@@ -43,8 +48,49 @@ export interface DaemonHealthProbeResult {
 
 type EventHandler = (data: unknown) => void;
 
+const DAEMON_TOKEN_FILENAME = "daemon-token.json";
+const DAEMON_TOKEN_ENV = "PULSEED_DAEMON_TOKEN";
+
+export interface DaemonAuthToken {
+  token: string;
+  host?: string;
+  port?: number;
+  pid?: number;
+  created_at?: string;
+}
+
+export function getDaemonTokenPath(baseDir?: string): string {
+  return path.join(baseDir ?? process.env["PULSEED_HOME"] ?? path.join(os.homedir(), ".pulseed"), DAEMON_TOKEN_FILENAME);
+}
+
+export function readDaemonAuthToken(baseDir?: string, expectedPort?: number): string | null {
+  const envToken = process.env[DAEMON_TOKEN_ENV];
+  if (envToken && envToken.trim() !== "") {
+    return envToken.trim();
+  }
+
+  try {
+    const raw = fs.readFileSync(getDaemonTokenPath(baseDir), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<DaemonAuthToken>;
+    if (expectedPort !== undefined && parsed.port !== undefined && parsed.port !== expectedPort) {
+      return null;
+    }
+    return typeof parsed.token === "string" && parsed.token.length > 0 ? parsed.token : null;
+  } catch {
+    return null;
+  }
+}
+
+interface ResolvedDaemonClientConfig {
+  host: string;
+  port: number;
+  reconnectInterval: number;
+  maxReconnectAttempts: number;
+  authToken: string | null;
+}
+
 export class DaemonClient {
-  private config: Required<DaemonClientConfig>;
+  private config: ResolvedDaemonClientConfig;
   private handlers: Map<string, Set<EventHandler>> = new Map();
   private sseRequest: http.ClientRequest | null = null;
   private reconnectAttempts = 0;
@@ -61,6 +107,7 @@ export class DaemonClient {
       port: config.port,
       reconnectInterval: config.reconnectInterval ?? 3000,
       maxReconnectAttempts: config.maxReconnectAttempts ?? 10,
+      authToken: config.authToken ?? readDaemonAuthToken(config.baseDir, config.port),
     };
   }
 
@@ -82,6 +129,7 @@ export class DaemonClient {
     const headers: Record<string, string> = {
       Accept: "text/event-stream",
       "Cache-Control": "no-cache",
+      ...this.authHeaders(),
     };
     if (this.lastEventId) {
       headers["Last-Event-ID"] = this.lastEventId;
@@ -290,7 +338,12 @@ export class DaemonClient {
   private get(path: string): Promise<unknown> {
     return new Promise((resolve, reject) => {
       const req = http.get(
-        { hostname: this.config.host, port: this.config.port, path },
+        {
+          hostname: this.config.host,
+          port: this.config.port,
+          path,
+          headers: this.authHeaders(),
+        },
         (res) => {
           let body = "";
           res.setEncoding("utf-8");
@@ -336,6 +389,7 @@ export class DaemonClient {
           headers: {
             "Content-Type": "application/json",
             "Content-Length": Buffer.byteLength(body),
+            ...this.authHeaders(),
           },
         },
         (res) => {
@@ -355,6 +409,10 @@ export class DaemonClient {
       req.write(body);
       req.end();
     });
+  }
+
+  private authHeaders(): Record<string, string> {
+    return this.config.authToken ? { Authorization: `Bearer ${this.config.authToken}` } : {};
   }
 }
 
@@ -385,7 +443,7 @@ export async function probeDaemonHealth(config: Pick<DaemonClientConfig, "host" 
   }
 }
 
-export async function isDaemonRunning(baseDir: string): Promise<{ running: boolean; port: number }> {
+export async function isDaemonRunning(baseDir: string): Promise<{ running: boolean; port: number; authToken?: string | null }> {
   const fs = await import("node:fs/promises");
   const path = await import("node:path");
   // DEFAULT_PORT imported from port-utils
@@ -417,9 +475,13 @@ export async function isDaemonRunning(baseDir: string): Promise<{ running: boole
       // Use default port
     }
 
+    const authToken = readDaemonAuthToken(baseDir, port);
+
     // Verify EventServer is actually responding
     const probe = await probeDaemonHealth({ host: "127.0.0.1", port });
-    return { running: probe.ok, port };
+    return authToken
+      ? { running: probe.ok, port, authToken }
+      : { running: probe.ok, port };
   } catch {
     return { running: false, port: DEFAULT_PORT };
   }

--- a/src/runtime/event/server-sse.ts
+++ b/src/runtime/event/server-sse.ts
@@ -67,7 +67,6 @@ export class EventServerSseManager {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
       Connection: "keep-alive",
-      "Access-Control-Allow-Origin": "*",
     });
     res.write(`event: connected\ndata: ${JSON.stringify({ timestamp: new Date().toISOString() })}\n\n`);
 

--- a/src/runtime/event/server.ts
+++ b/src/runtime/event/server.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import * as http from "node:http";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import type { DriveSystem } from "../../platform/drive/drive-system.js";
 import { PulSeedEventSchema } from "../../base/types/drive.js";
 import { TriggerEventSchema, TriggerMappingsConfigSchema } from "../../base/types/trigger.js";
@@ -39,6 +40,8 @@ type ActiveWorkersProvider = () =>
   | Array<Record<string, unknown>>
   | Promise<Array<Record<string, unknown>>>;
 
+const DAEMON_TOKEN_FILENAME = "daemon-token.json";
+
 export class EventServer {
   private server: http.Server | null = null;
   private driveSystem: DriveSystem;
@@ -56,6 +59,7 @@ export class EventServer {
   private approvalQueue: Map<string, { resolve: (approved: boolean) => void; timer: ReturnType<typeof setTimeout> }> = new Map();
   private approvalBroker?: ApprovalBroker;
   private outboxStore?: OutboxStore;
+  private readonly authToken: string;
   private envelopeHook?: (eventData: Record<string, unknown>) => void | Promise<void>;
   private commandEnvelopeHook?: (envelope: Envelope) => void | Promise<void>;
   private activeWorkersProvider?: ActiveWorkersProvider;
@@ -71,6 +75,7 @@ export class EventServer {
     this.triggerMapper = config?.triggerMapper;
     this.approvalBroker = config?.approvalBroker;
     this.outboxStore = config?.outboxStore;
+    this.authToken = randomBytes(32).toString("base64url");
     this.snapshotReader = new EventServerSnapshotReader(this.eventsDir);
     this.sseManager = new EventServerSseManager(this.logger, this.approvalBroker, this.outboxStore);
   }
@@ -89,13 +94,15 @@ export class EventServer {
       this.server = http.createServer((req, res) => this.handleRequest(req, res));
       const server = this.server;
       server.listen(startPort, this.host, () => {
-        // Capture the actual bound port (important for port 0 and auto-retry cases)
-        const addr = server.address();
-        if (addr && typeof addr === "object") {
-          this.port = addr.port;
-        }
-        this.logger?.info(`EventServer listening on ${this.host}:${this.port}`);
-        resolve();
+        void (async () => {
+          try {
+            await this.finishServerStartup(server);
+            this.logger?.info(`EventServer listening on ${this.host}:${this.port}`);
+            resolve();
+          } catch (err) {
+            server.close(() => reject(err));
+          }
+        })();
       });
       this.server.on("error", (err: NodeJS.ErrnoException) => {
         // EADDRINUSE should not reach here since findAvailablePort pre-checks,
@@ -104,12 +111,15 @@ export class EventServer {
           const fallbackStart = startPort + MAX_PORT_ATTEMPTS;
           findAvailablePort(fallbackStart).then((fallback) => {
             server.listen(fallback, this.host, () => {
-              const addr = server.address();
-              if (addr && typeof addr === "object") {
-                this.port = addr.port;
-              }
-              this.logger?.info(`EventServer listening on ${this.host}:${this.port} (fallback)`);
-              resolve();
+              void (async () => {
+                try {
+                  await this.finishServerStartup(server);
+                  this.logger?.info(`EventServer listening on ${this.host}:${this.port} (fallback)`);
+                  resolve();
+                } catch (err) {
+                  server.close(() => reject(err));
+                }
+              })();
             });
           }).catch(reject);
         } else {
@@ -126,10 +136,13 @@ export class EventServer {
     this.sseManager.closeAllClients();
     return new Promise((resolve) => {
       if (!this.server) {
-        resolve();
+        void this.removeAuthTokenFile().finally(() => resolve());
         return;
       }
-      this.server.close(() => resolve());
+      this.server.close(() => {
+        this.server = null;
+        void this.removeAuthTokenFile().finally(() => resolve());
+      });
     });
   }
 
@@ -303,6 +316,10 @@ export class EventServer {
     if (req.method === "GET" && urlPath === "/health") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ status: "ok", uptime: process.uptime() }));
+      return;
+    }
+
+    if (!this.authorizeRequest(req, res)) {
       return;
     }
 
@@ -656,6 +673,10 @@ export class EventServer {
     return this.eventsDir;
   }
 
+  getAuthToken(): string {
+    return this.authToken;
+  }
+
   private async handleGetSnapshot(res: http.ServerResponse): Promise<void> {
     try {
       const snapshot = await this.buildSnapshot();
@@ -702,6 +723,139 @@ export class EventServer {
       this.outboxStore,
       this.activeWorkersProvider
     );
+  }
+
+  private async finishServerStartup(server: http.Server): Promise<void> {
+    const addr = server.address();
+    if (addr && typeof addr === "object") {
+      this.port = addr.port;
+    }
+    await this.persistAuthToken();
+  }
+
+  private getAuthTokenPath(): string {
+    return path.join(path.dirname(this.eventsDir), DAEMON_TOKEN_FILENAME);
+  }
+
+  private async persistAuthToken(): Promise<void> {
+    const tokenPath = this.getAuthTokenPath();
+    await fsp.mkdir(path.dirname(tokenPath), { recursive: true });
+    const payload = {
+      token: this.authToken,
+      host: this.host,
+      port: this.port,
+      pid: process.pid,
+      created_at: new Date().toISOString(),
+    };
+    await fsp.writeFile(tokenPath, JSON.stringify(payload, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    await fsp.chmod(tokenPath, 0o600).catch(() => undefined);
+  }
+
+  private async removeAuthTokenFile(): Promise<void> {
+    const tokenPath = this.getAuthTokenPath();
+    try {
+      const raw = await fsp.readFile(tokenPath, "utf-8");
+      const parsed = JSON.parse(raw) as { token?: unknown };
+      if (parsed.token !== this.authToken) return;
+      await fsp.unlink(tokenPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        this.logger?.warn(`EventServer: failed to remove auth token file: ${String(err)}`);
+      }
+    }
+  }
+
+  private authorizeRequest(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+    if (!this.isAllowedHost(req.headers.host)) {
+      this.writeJsonError(res, 403, "Forbidden host");
+      return false;
+    }
+
+    if (!this.isAllowedOrigin(req.headers.origin)) {
+      this.writeJsonError(res, 403, "Forbidden origin");
+      return false;
+    }
+
+    const fetchSite = this.singleHeader(req.headers["sec-fetch-site"])?.toLowerCase();
+    if (fetchSite && fetchSite !== "same-origin" && fetchSite !== "none") {
+      this.writeJsonError(res, 403, "Forbidden browser request");
+      return false;
+    }
+
+    if (!this.hasValidAuth(req.headers.authorization)) {
+      this.writeJsonError(res, 401, "Unauthorized");
+      return false;
+    }
+
+    if (req.method === "POST" && !this.hasJsonContentType(req.headers["content-type"])) {
+      this.writeJsonError(res, 415, "Content-Type must be application/json");
+      return false;
+    }
+
+    return true;
+  }
+
+  private hasValidAuth(header: string | string[] | undefined): boolean {
+    const value = this.singleHeader(header);
+    if (!value?.startsWith("Bearer ")) return false;
+    const candidate = value.slice("Bearer ".length).trim();
+    const expected = Buffer.from(this.authToken);
+    const actual = Buffer.from(candidate);
+    return actual.length === expected.length && timingSafeEqual(actual, expected);
+  }
+
+  private hasJsonContentType(header: string | string[] | undefined): boolean {
+    const value = this.singleHeader(header);
+    return value?.split(";")[0]?.trim().toLowerCase() === "application/json";
+  }
+
+  private isAllowedHost(hostHeader: string | undefined): boolean {
+    if (!hostHeader) return false;
+    const hostname = this.parseHostname(hostHeader);
+    if (!hostname) return false;
+    return this.isAllowedHostname(hostname);
+  }
+
+  private isAllowedOrigin(originHeader: string | string[] | undefined): boolean {
+    const origin = this.singleHeader(originHeader);
+    if (!origin) return true;
+    try {
+      const parsed = new URL(origin);
+      if (parsed.protocol !== "http:") return false;
+      if (!this.isAllowedHostname(parsed.hostname)) return false;
+      const originPort = parsed.port ? Number.parseInt(parsed.port, 10) : 80;
+      return originPort === this.port;
+    } catch {
+      return false;
+    }
+  }
+
+  private isAllowedHostname(hostname: string): boolean {
+    const normalized = hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+    return normalized === this.host.toLowerCase()
+      || normalized === "127.0.0.1"
+      || normalized === "localhost"
+      || normalized === "::1";
+  }
+
+  private parseHostname(hostHeader: string): string | null {
+    try {
+      return new URL(`http://${hostHeader}`).hostname;
+    } catch {
+      return null;
+    }
+  }
+
+  private singleHeader(header: string | string[] | undefined): string | undefined {
+    return Array.isArray(header) ? header[0] : header;
+  }
+
+  private writeJsonError(res: http.ServerResponse, status: number, error: string): void {
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error }));
   }
 }
 

--- a/src/tools/fs/FileValidationTool/FileValidationTool.ts
+++ b/src/tools/fs/FileValidationTool/FileValidationTool.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 
 const BLOCKED_PATTERNS = [".env", "credentials", "secret", ".ssh/", "id_rsa", "node_modules"];
 
@@ -8,7 +8,8 @@ export function validateFilePath(
 ): { valid: boolean; resolved: string; error?: string } {
   const resolvedCwd = resolve(cwd);
   const resolved = resolve(cwd, filePath);
-  if (!resolved.startsWith(resolvedCwd)) {
+  const pathFromCwd = relative(resolvedCwd, resolved);
+  if (pathFromCwd.startsWith("..") || isAbsolute(pathFromCwd)) {
     return { valid: false, resolved, error: "Path traversal outside working directory" };
   }
   const lower = resolved.toLowerCase();

--- a/src/tools/fs/FileValidationTool/__tests__/FileValidationTool.test.ts
+++ b/src/tools/fs/FileValidationTool/__tests__/FileValidationTool.test.ts
@@ -16,6 +16,12 @@ describe("validateFilePath", () => {
     expect(result.error).toContain("Path traversal");
   });
 
+  it("rejects sibling prefix escapes", () => {
+    const result = validateFilePath("../test-evil/output/file.txt", "/tmp/test");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Path traversal");
+  });
+
   it("rejects .env paths", () => {
     const result = validateFilePath(".env", cwd);
     expect(result.valid).toBe(false);

--- a/src/tools/fs/GlobTool/GlobTool.ts
+++ b/src/tools/fs/GlobTool/GlobTool.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata, ToolDescriptionContext } from "../../types.js";
 import { glob } from "glob";
+import { isAbsolute } from "node:path";
+import { validateFilePath } from "../FileValidationTool/FileValidationTool.js";
 import { DESCRIPTION_PREFIX, DESCRIPTION_SUFFIX } from "./prompt.js";
 import { TAGS, PERMISSION_LEVEL, MAX_OUTPUT_CHARS, READ_ONLY } from "./constants.js";
 
@@ -55,7 +57,16 @@ export class GlobTool implements ITool<GlobInput, string[]> {
     }
   }
 
-  async checkPermissions(_input: GlobInput, _context?: ToolCallContext): Promise<PermissionCheckResult> {
+  async checkPermissions(input: GlobInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
+    if (isAbsolute(input.pattern) || input.pattern.split(/[\\/]+/).includes("..")) {
+      return { status: "needs_approval", reason: `Glob pattern may access outside the working directory: ${input.pattern}` };
+    }
+    if (context) {
+      const validation = validateFilePath(input.path ?? ".", context.cwd);
+      if (!validation.valid) {
+        return { status: "needs_approval", reason: `Globbing outside the working directory: ${validation.resolved}` };
+      }
+    }
     return { status: "allowed" };
   }
 

--- a/src/tools/fs/GlobTool/__tests__/GlobTool.test.ts
+++ b/src/tools/fs/GlobTool/__tests__/GlobTool.test.ts
@@ -79,6 +79,16 @@ describe("GlobTool", () => {
     expect(result.status).toBe("allowed");
   });
 
+  it("checkPermissions requires approval for traversal patterns", async () => {
+    const result = await tool.checkPermissions({ pattern: "../*.ts", limit: 500 }, makeContext(tmpDir));
+    expect(result.status).toBe("needs_approval");
+  });
+
+  it("checkPermissions requires approval for paths outside cwd", async () => {
+    const result = await tool.checkPermissions({ pattern: "*.ts", path: "../outside", limit: 500 }, makeContext(tmpDir));
+    expect(result.status).toBe("needs_approval");
+  });
+
   it("isConcurrencySafe returns true", () => {
     expect(tool.isConcurrencySafe({ pattern: "**/*.ts", limit: 500 })).toBe(true);
   });

--- a/src/tools/fs/GrepTool/GrepTool.ts
+++ b/src/tools/fs/GrepTool/GrepTool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata } from "../../types.js";
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
+import { validateFilePath } from "../FileValidationTool/FileValidationTool.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, PERMISSION_LEVEL, MAX_OUTPUT_CHARS, READ_ONLY } from "./constants.js";
 
@@ -84,7 +85,13 @@ export class GrepTool implements ITool<GrepInput, string> {
     }
   }
 
-  async checkPermissions(_input: GrepInput, _context?: ToolCallContext): Promise<PermissionCheckResult> {
+  async checkPermissions(input: GrepInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
+    if (context) {
+      const validation = validateFilePath(input.path ?? ".", context.cwd);
+      if (!validation.valid) {
+        return { status: "needs_approval", reason: `Searching outside the working directory: ${validation.resolved}` };
+      }
+    }
     return { status: "allowed" };
   }
 

--- a/src/tools/fs/GrepTool/__tests__/GrepTool.test.ts
+++ b/src/tools/fs/GrepTool/__tests__/GrepTool.test.ts
@@ -147,6 +147,14 @@ describe("GrepTool", () => {
     expect(result.status).toBe("allowed");
   });
 
+  it("checkPermissions requires approval for paths outside cwd", async () => {
+    const result = await tool.checkPermissions(
+      { pattern: "test", path: "../outside", outputMode: "files_with_matches", limit: 250, caseInsensitive: false },
+      makeContext(tmpDir)
+    );
+    expect(result.status).toBe("needs_approval");
+  });
+
   it("isConcurrencySafe returns true", () => {
     expect(tool.isConcurrencySafe({ pattern: "test", outputMode: "files_with_matches", limit: 250, caseInsensitive: false })).toBe(true);
   });

--- a/src/tools/fs/JsonQueryTool/JsonQueryTool.ts
+++ b/src/tools/fs/JsonQueryTool/JsonQueryTool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata } from "../../types.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { validateFilePath } from "../FileValidationTool/FileValidationTool.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, CATEGORY as _CATEGORY, MAX_OUTPUT_CHARS, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
 
@@ -37,7 +38,13 @@ export class JsonQueryTool implements ITool<JsonQueryInput, unknown> {
     }
   }
 
-  async checkPermissions(_input: JsonQueryInput, _context?: ToolCallContext): Promise<PermissionCheckResult> {
+  async checkPermissions(input: JsonQueryInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
+    if (context) {
+      const validation = validateFilePath(input.file_path, context.cwd);
+      if (!validation.valid) {
+        return { status: "needs_approval", reason: `Reading JSON outside the working directory: ${validation.resolved}` };
+      }
+    }
     return { status: "allowed" };
   }
 

--- a/src/tools/fs/JsonQueryTool/__tests__/JsonQueryTool.test.ts
+++ b/src/tools/fs/JsonQueryTool/__tests__/JsonQueryTool.test.ts
@@ -54,6 +54,14 @@ describe("JsonQueryTool", () => {
       const result = await tool.checkPermissions({ file_path: "any.json", query: "name" });
       expect(result.status).toBe("allowed");
     });
+
+    it("requires approval for files outside cwd", async () => {
+      const result = await tool.checkPermissions(
+        { file_path: "../outside.json", query: "name" },
+        makeContext(tmpDir)
+      );
+      expect(result.status).toBe("needs_approval");
+    });
   });
 
   describe("isConcurrencySafe", () => {

--- a/src/tools/fs/ListDirTool/ListDirTool.ts
+++ b/src/tools/fs/ListDirTool/ListDirTool.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import * as path from "node:path";
 import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata, ToolDescriptionContext } from "../../types.js";
+import { validateFilePath } from "../FileValidationTool/FileValidationTool.js";
 import { DESCRIPTION_TEMPLATE } from "./prompt.js";
 import { TAGS, CATEGORY as _CATEGORY, MAX_OUTPUT_CHARS, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
 
@@ -40,16 +41,17 @@ export class ListDirTool implements ITool<ListDirInput, DirEntry[]> {
     return DESCRIPTION_TEMPLATE(cwd);
   }
 
-  async call(input: ListDirInput, _context: ToolCallContext): Promise<ToolResult> {
+  async call(input: ListDirInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
+    const dirPath = path.isAbsolute(input.path) ? input.path : path.resolve(context.cwd, input.path);
     try {
-      const entries = await listDir(input.path, input.recursive, input.maxDepth, input.includeHidden, 0);
+      const entries = await listDir(dirPath, input.recursive, input.maxDepth, input.includeHidden, 0);
       return {
         success: true,
         data: entries,
-        summary: `Listed ${entries.length} entries in ${input.path}`,
+        summary: `Listed ${entries.length} entries in ${dirPath}`,
         durationMs: Date.now() - startTime,
-        artifacts: [input.path],
+        artifacts: [dirPath],
       };
     } catch (err) {
       return {
@@ -62,7 +64,13 @@ export class ListDirTool implements ITool<ListDirInput, DirEntry[]> {
     }
   }
 
-  async checkPermissions(_input: ListDirInput, _context?: ToolCallContext): Promise<PermissionCheckResult> {
+  async checkPermissions(input: ListDirInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
+    if (context) {
+      const validation = validateFilePath(input.path, context.cwd);
+      if (!validation.valid) {
+        return { status: "needs_approval", reason: `Listing outside the working directory: ${validation.resolved}` };
+      }
+    }
     return { status: "allowed" };
   }
 

--- a/src/tools/fs/ListDirTool/__tests__/ListDirTool.test.ts
+++ b/src/tools/fs/ListDirTool/__tests__/ListDirTool.test.ts
@@ -64,9 +64,14 @@ describe("ListDirTool", () => {
   });
 
   describe("checkPermissions", () => {
-    it("always returns allowed", async () => {
-      const result = await tool.checkPermissions({ path: tmpDir, recursive: false, maxDepth: 2, includeHidden: false }, makeContext());
+    it("returns allowed for paths inside cwd", async () => {
+      const result = await tool.checkPermissions({ path: tmpDir, recursive: false, maxDepth: 2, includeHidden: false }, makeContext(tmpDir));
       expect(result.status).toBe("allowed");
+    });
+
+    it("requires approval for paths outside cwd", async () => {
+      const result = await tool.checkPermissions({ path: "../outside", recursive: false, maxDepth: 2, includeHidden: false }, makeContext(tmpDir));
+      expect(result.status).toBe("needs_approval");
     });
   });
 

--- a/src/tools/fs/ReadTool/ReadTool.ts
+++ b/src/tools/fs/ReadTool/ReadTool.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata } from "../../types.js";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { validateFilePath } from "../FileValidationTool/FileValidationTool.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, PERMISSION_LEVEL, MAX_OUTPUT_CHARS, READ_ONLY } from "./constants.js";
 
@@ -61,11 +62,17 @@ export class ReadTool implements ITool<ReadInput, string> {
     }
   }
 
-  async checkPermissions(input: ReadInput): Promise<PermissionCheckResult> {
+  async checkPermissions(input: ReadInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
     const basename = path.basename(input.file_path);
     const sensitivePatterns = [".env", "credentials", "secret", "private_key"];
     if (sensitivePatterns.some((p) => basename.toLowerCase().includes(p))) {
       return { status: "needs_approval", reason: `Reading potentially sensitive file: ${basename}` };
+    }
+    if (context) {
+      const validation = validateFilePath(input.file_path, context.cwd);
+      if (!validation.valid) {
+        return { status: "needs_approval", reason: `Reading outside the working directory: ${validation.resolved}` };
+      }
     }
     return { status: "allowed" };
   }

--- a/src/tools/fs/ReadTool/__tests__/ReadTool.test.ts
+++ b/src/tools/fs/ReadTool/__tests__/ReadTool.test.ts
@@ -100,6 +100,14 @@ describe("ReadTool", () => {
     expect(result.status).toBe("allowed");
   });
 
+  it("checkPermissions requires approval for files outside cwd", async () => {
+    const result = await tool.checkPermissions(
+      { file_path: "../outside.txt", limit: 2000 },
+      makeContext(tmpDir)
+    );
+    expect(result.status).toBe("needs_approval");
+  });
+
   it("isConcurrencySafe returns true", () => {
     expect(tool.isConcurrencySafe({ file_path: testFile, limit: 2000 })).toBe(true);
   });

--- a/src/tools/network/HttpFetchTool/HttpFetchTool.ts
+++ b/src/tools/network/HttpFetchTool/HttpFetchTool.ts
@@ -1,3 +1,7 @@
+import { lookup } from "node:dns/promises";
+import * as http from "node:http";
+import * as https from "node:https";
+import { isIP } from "node:net";
 import { z } from "zod";
 import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata } from "../../types.js";
 import { DESCRIPTION } from "./prompt.js";
@@ -13,6 +17,220 @@ export const HttpFetchInputSchema = z.object({
 export type HttpFetchInput = z.infer<typeof HttpFetchInputSchema>;
 export interface HttpFetchOutput { statusCode: number; headers: Record<string, string>; body: string; ok: boolean; }
 
+const MAX_REDIRECTS = 5;
+
+export interface ValidatedDestination {
+  address: string;
+  family: 4 | 6;
+}
+
+export interface HttpFetchTransportRequest {
+  url: URL;
+  method: "GET" | "HEAD";
+  headers?: Record<string, string>;
+  timeoutMs: number;
+  maxResponseBytes: number;
+  destination: ValidatedDestination;
+}
+
+export type HttpFetchTransport = (request: HttpFetchTransportRequest) => Promise<HttpFetchOutput>;
+
+function parseIPv4(address: string): number[] | null {
+  const parts = address.split(".");
+  if (parts.length !== 4) return null;
+  const octets = parts.map((part) => Number.parseInt(part, 10));
+  if (octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) return null;
+  return octets;
+}
+
+function formatIPv4(octets: number[]): string {
+  return octets.join(".");
+}
+
+function parseIPv6Bytes(address: string): number[] | null {
+  const withoutZone = address.toLowerCase().split("%")[0]!;
+  const pieces = withoutZone.split("::");
+  if (pieces.length > 2) return null;
+
+  const parsePart = (part: string): number[] | null => {
+    if (part === "") return [];
+    const hextets: number[] = [];
+    for (const segment of part.split(":")) {
+      if (segment.includes(".")) {
+        const octets = parseIPv4(segment);
+        if (!octets) return null;
+        hextets.push((octets[0]! << 8) | octets[1]!, (octets[2]! << 8) | octets[3]!);
+        continue;
+      }
+      if (!/^[0-9a-f]{1,4}$/.test(segment)) return null;
+      hextets.push(Number.parseInt(segment, 16));
+    }
+    return hextets;
+  };
+
+  const head = parsePart(pieces[0]!);
+  const tail = pieces.length === 2 ? parsePart(pieces[1]!) : [];
+  if (!head || !tail) return null;
+  const zeroCount = pieces.length === 2 ? 8 - head.length - tail.length : 0;
+  if (zeroCount < 0) return null;
+  const hextets = pieces.length === 2 ? [...head, ...Array.from({ length: zeroCount }, () => 0), ...tail] : head;
+  if (hextets.length !== 8 || hextets.some((hextet) => hextet < 0 || hextet > 0xffff)) return null;
+
+  return hextets.flatMap((hextet) => [(hextet >> 8) & 0xff, hextet & 0xff]);
+}
+
+function ipv4FromBytes(bytes: number[], offset: number): string {
+  return formatIPv4(bytes.slice(offset, offset + 4));
+}
+
+function isZeroSlice(bytes: number[], start: number, end: number): boolean {
+  return bytes.slice(start, end).every((byte) => byte === 0);
+}
+
+function isBlockedAddress(address: string): boolean {
+  const normalizedAddress = address.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+  const family = isIP(normalizedAddress);
+  if (family === 4) {
+    const octets = parseIPv4(normalizedAddress);
+    if (!octets) return false;
+    const [a, b, c] = octets;
+    if (a === 0 || a === 10 || a === 127) return true;
+    if (a === 100 && b >= 64 && b <= 127) return true;
+    if (a === 169 && b === 254) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 0) return true;
+    if (a === 192 && b === 88 && c === 99) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 198 && (b === 18 || b === 19)) return true;
+    if (a === 198 && b === 51 && c === 100) return true;
+    if (a === 203 && b === 0 && c === 113) return true;
+    if (a >= 224) return true;
+    return false;
+  }
+  if (family === 6) {
+    const bytes = parseIPv6Bytes(normalizedAddress);
+    if (!bytes) return false;
+    if (bytes.every((byte) => byte === 0)) return true; // ::/128
+    if (isZeroSlice(bytes, 0, 15) && bytes[15] === 1) return true; // ::1/128
+    if (isZeroSlice(bytes, 0, 10) && bytes[10] === 0xff && bytes[11] === 0xff) {
+      return isBlockedAddress(ipv4FromBytes(bytes, 12)); // ::ffff:0:0/96
+    }
+    if (bytes[0] === 0x00 && bytes[1] === 0x64 && bytes[2] === 0xff && bytes[3] === 0x9b && isZeroSlice(bytes, 4, 12)) {
+      return isBlockedAddress(ipv4FromBytes(bytes, 12)); // 64:ff9b::/96 NAT64
+    }
+    if (bytes[0] === 0x20 && bytes[1] === 0x02) {
+      return isBlockedAddress(ipv4FromBytes(bytes, 2)); // 2002::/16 6to4
+    }
+    if ((bytes[0]! & 0xfe) === 0xfc) return true; // fc00::/7
+    if (bytes[0] === 0xfe && (bytes[1]! & 0xc0) === 0x80) return true; // fe80::/10
+    if (bytes[0] === 0xfe && (bytes[1]! & 0xc0) === 0xc0) return true; // fec0::/10
+    if (bytes[0] === 0xff) return true; // ff00::/8
+    if (bytes[0] === 0x20 && bytes[1] === 0x01 && bytes[2] === 0x0d && bytes[3] === 0xb8) return true; // 2001:db8::/32
+    return false;
+  }
+  return false;
+}
+
+async function resolveHostAddresses(hostname: string): Promise<string[]> {
+  const normalizedHostname = hostname.replace(/^\[/, "").replace(/\]$/, "");
+  if (isIP(normalizedHostname)) return [normalizedHostname];
+  const records = await lookup(normalizedHostname, { all: true, verbatim: true });
+  return records.map((record) => record.address);
+}
+
+async function validateDestination(url: URL): Promise<ValidatedDestination> {
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Unsupported URL protocol: ${url.protocol}`);
+  }
+  const addresses = await resolveHostAddresses(url.hostname);
+  if (addresses.length === 0) {
+    throw new Error(`Unable to resolve host: ${url.toString()}`);
+  }
+  if (addresses.some((address) => isBlockedAddress(address))) {
+    throw new Error(`Fetching from internal or private address: ${url.toString()}`);
+  }
+  const address = addresses[0]!;
+  const family = isIP(address);
+  if (family !== 4 && family !== 6) {
+    throw new Error(`Unable to resolve host: ${url.toString()}`);
+  }
+  return { address, family };
+}
+
+function isRedirect(statusCode: number): boolean {
+  return statusCode === 301 || statusCode === 302 || statusCode === 303 || statusCode === 307 || statusCode === 308;
+}
+
+function normalizeHeaders(headers: http.IncomingHttpHeaders): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) continue;
+    normalized[key.toLowerCase()] = Array.isArray(value) ? value.join(", ") : String(value);
+  }
+  return normalized;
+}
+
+export function defaultHttpFetchTransport(request: HttpFetchTransportRequest): Promise<HttpFetchOutput> {
+  return new Promise((resolve, reject) => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), request.timeoutMs);
+    const client = request.url.protocol === "https:" ? https : http;
+    const req = client.request(
+      {
+        protocol: request.url.protocol,
+        hostname: request.url.hostname,
+        port: request.url.port,
+        path: `${request.url.pathname}${request.url.search}`,
+        method: request.method,
+        headers: request.headers,
+        signal: controller.signal,
+        family: request.destination.family,
+        lookup: (_hostname, options, callback) => {
+          const cb = callback as (...args: unknown[]) => void;
+          if (typeof options === "object" && options !== null && "all" in options && options.all === true) {
+            cb(null, [{ address: request.destination.address, family: request.destination.family }]);
+            return;
+          }
+          cb(null, request.destination.address, request.destination.family);
+        },
+      },
+      (res) => {
+        res.setEncoding("utf-8");
+        const headers = normalizeHeaders(res.headers);
+        let body = "";
+        let truncated = false;
+        res.on("data", (chunk: string) => {
+          if (request.method === "HEAD" || truncated) return;
+          const remaining = request.maxResponseBytes - body.length;
+          if (remaining <= 0) {
+            truncated = true;
+            return;
+          }
+          body += chunk.slice(0, remaining);
+          if (chunk.length > remaining) truncated = true;
+        });
+        res.on("end", () => {
+          clearTimeout(timeout);
+          const outputBody = truncated ? `${body}\n[truncated]` : body;
+          const statusCode = res.statusCode ?? 0;
+          resolve({
+            statusCode,
+            headers,
+            body: outputBody,
+            ok: statusCode >= 200 && statusCode < 300,
+          });
+        });
+      },
+    );
+
+    req.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+    req.end();
+  });
+}
+
 export class HttpFetchTool implements ITool<HttpFetchInput, HttpFetchOutput> {
   readonly metadata: ToolMetadata = {
     name: "http_fetch", aliases: ["fetch", "curl", "http"],
@@ -22,24 +240,42 @@ export class HttpFetchTool implements ITool<HttpFetchInput, HttpFetchOutput> {
   };
   readonly inputSchema = HttpFetchInputSchema;
 
+  constructor(private readonly transport: HttpFetchTransport = defaultHttpFetchTransport) {}
+
   description(): string {
     return DESCRIPTION;
   }
 
   async call(input: HttpFetchInput, _context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
+    let currentUrl = new URL(input.url);
     try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), input.timeoutMs);
-      const response = await fetch(input.url, { method: input.method, headers: input.headers, signal: controller.signal });
-      clearTimeout(timeout);
-      const body = input.method === "HEAD" ? "" : await response.text();
-      const truncatedBody = body.length > input.maxResponseBytes ? body.slice(0, input.maxResponseBytes) + "\n[truncated]" : body;
-      const output: HttpFetchOutput = { statusCode: response.status, headers: Object.fromEntries(response.headers.entries()), body: truncatedBody, ok: response.ok };
+      let response: HttpFetchOutput | null = null;
+      for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
+        const destination = await validateDestination(currentUrl);
+        response = await this.transport({
+          url: currentUrl,
+          method: input.method,
+          headers: input.headers,
+          timeoutMs: input.timeoutMs,
+          maxResponseBytes: input.maxResponseBytes,
+          destination,
+        });
+        const location = response.headers["location"];
+        if (!isRedirect(response.statusCode) || !location) break;
+        if (redirects === MAX_REDIRECTS) {
+          throw new Error(`Too many redirects fetching ${input.url}`);
+        }
+        currentUrl = new URL(location, currentUrl);
+      }
+
+      if (!response) {
+        throw new Error(`HTTP fetch failed: ${input.url}`);
+      }
       return {
-        success: response.ok, data: output,
-        summary: `${input.method} ${input.url} -> ${response.status} (${truncatedBody.length} bytes)`,
-        error: response.ok ? undefined : `HTTP ${response.status}: ${truncatedBody.slice(0, 200)}`,
+        success: response.ok, data: response,
+        summary: `${input.method} ${input.url} -> ${response.statusCode} (${response.body.length} bytes)`,
+        error: response.ok ? undefined : `HTTP ${response.statusCode}: ${response.body.slice(0, 200)}`,
         durationMs: Date.now() - startTime,
       };
     } catch (err) {
@@ -53,8 +289,11 @@ export class HttpFetchTool implements ITool<HttpFetchInput, HttpFetchOutput> {
 
   async checkPermissions(input: HttpFetchInput): Promise<PermissionCheckResult> {
     const url = new URL(input.url);
-    const isInternal = ["localhost", "127.0.0.1", "::1", "0.0.0.0"].includes(url.hostname) || url.hostname.startsWith("192.168.") || url.hostname.startsWith("10.");
-    if (isInternal) return { status: "needs_approval", reason: `Fetching from internal address: ${input.url}` };
+    try {
+      await validateDestination(url);
+    } catch (err) {
+      return { status: "needs_approval", reason: (err as Error).message };
+    }
     return { status: "allowed" };
   }
 

--- a/src/tools/network/HttpFetchTool/__tests__/HttpFetchTool.test.ts
+++ b/src/tools/network/HttpFetchTool/__tests__/HttpFetchTool.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { HttpFetchTool } from "../HttpFetchTool.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as http from "node:http";
+import { defaultHttpFetchTransport, HttpFetchTool } from "../HttpFetchTool.js";
 import type { ToolCallContext } from "../../../types.js";
+
+const lookupMock = vi.hoisted(() => vi.fn());
+vi.mock("node:dns/promises", () => ({ lookup: lookupMock }));
 
 const makeContext = (): ToolCallContext => ({
   cwd: "/tmp",
@@ -30,16 +34,22 @@ describe("HttpFetchTool", () => {
   });
 
   describe("checkPermissions", () => {
+    beforeEach(() => {
+      lookupMock.mockReset();
+    });
+
     it("allows public URL", async () => {
+      lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
       const result = await tool.checkPermissions({ url: "https://example.com", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
       expect(result.status).toBe("allowed");
     });
 
     it("needs_approval for localhost", async () => {
+      lookupMock.mockResolvedValue([{ address: "127.0.0.1", family: 4 }]);
       const result = await tool.checkPermissions({ url: "http://localhost:3000/api", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
       expect(result.status).toBe("needs_approval");
       if (result.status === "needs_approval") {
-        expect(result.reason).toContain("internal address");
+        expect(result.reason).toContain("internal or private address");
       }
     });
 
@@ -57,6 +67,68 @@ describe("HttpFetchTool", () => {
       const result = await tool.checkPermissions({ url: "http://10.0.0.1", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
       expect(result.status).toBe("needs_approval");
     });
+
+    it("needs_approval for 172.16.x.x", async () => {
+      const result = await tool.checkPermissions({ url: "http://172.16.0.1", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
+      expect(result.status).toBe("needs_approval");
+    });
+
+    it("needs_approval for link-local IPv4", async () => {
+      const result = await tool.checkPermissions({ url: "http://169.254.169.254/latest/meta-data", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
+      expect(result.status).toBe("needs_approval");
+    });
+
+    it("needs_approval for encoded loopback IPv4 variants", async () => {
+      await expect(tool.checkPermissions({ url: "http://2130706433", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 })).resolves.toMatchObject({ status: "needs_approval" });
+      await expect(tool.checkPermissions({ url: "http://0x7f000001", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 })).resolves.toMatchObject({ status: "needs_approval" });
+      await expect(tool.checkPermissions({ url: "http://0177.0.0.1", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 })).resolves.toMatchObject({ status: "needs_approval" });
+    });
+
+    it("needs_approval for documentation and reserved IPv4 ranges", async () => {
+      await expect(tool.checkPermissions({ url: "http://203.0.113.10", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 })).resolves.toMatchObject({ status: "needs_approval" });
+      await expect(tool.checkPermissions({ url: "http://198.51.100.10", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 })).resolves.toMatchObject({ status: "needs_approval" });
+      await expect(tool.checkPermissions({ url: "http://192.0.2.10", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 })).resolves.toMatchObject({ status: "needs_approval" });
+    });
+
+    it("needs_approval for IPv6 loopback", async () => {
+      const result = await tool.checkPermissions({ url: "http://[::1]:8080", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
+      expect(result.status).toBe("needs_approval");
+    });
+
+    it("needs_approval for IPv6 private and documentation ranges", async () => {
+      await expect(tool.checkPermissions({ url: "http://[fc00::1]", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 })).resolves.toMatchObject({ status: "needs_approval" });
+      await expect(tool.checkPermissions({ url: "http://[fe80::1]", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 })).resolves.toMatchObject({ status: "needs_approval" });
+      await expect(tool.checkPermissions({ url: "http://[2001:db8::1]", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 })).resolves.toMatchObject({ status: "needs_approval" });
+    });
+
+    it("needs_approval when DNS resolves to IPv4-mapped IPv6 private address", async () => {
+      lookupMock.mockResolvedValue([{ address: "::ffff:7f00:1", family: 6 }]);
+      const result = await tool.checkPermissions({ url: "https://mapped.example.test", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
+      expect(result.status).toBe("needs_approval");
+    });
+
+    it("needs_approval for literal IPv4-mapped IPv6 private address", async () => {
+      const result = await tool.checkPermissions({ url: "http://[::ffff:7f00:1]", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
+      expect(result.status).toBe("needs_approval");
+    });
+
+    it("needs_approval when DNS resolves to NAT64 private address", async () => {
+      lookupMock.mockResolvedValue([{ address: "64:ff9b::a9fe:a9fe", family: 6 }]);
+      const result = await tool.checkPermissions({ url: "https://nat64.example.test", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
+      expect(result.status).toBe("needs_approval");
+    });
+
+    it("needs_approval when DNS resolves to private address", async () => {
+      lookupMock.mockResolvedValue([{ address: "10.1.2.3", family: 4 }]);
+      const result = await tool.checkPermissions({ url: "https://internal.example.test", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
+      expect(result.status).toBe("needs_approval");
+    });
+
+    it("needs_approval when DNS lookup fails", async () => {
+      lookupMock.mockRejectedValue(new Error("ENOTFOUND"));
+      const result = await tool.checkPermissions({ url: "https://unresolvable.example.test", method: "GET", timeoutMs: 30_000, maxResponseBytes: 1_048_576 });
+      expect(result.status).toBe("needs_approval");
+    });
   });
 
   describe("isConcurrencySafe", () => {
@@ -67,95 +139,164 @@ describe("HttpFetchTool", () => {
 
   describe("call", () => {
     beforeEach(() => {
-      vi.stubGlobal("fetch", vi.fn());
-    });
-
-    afterEach(() => {
-      vi.unstubAllGlobals();
+      lookupMock.mockReset();
+      lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
     });
 
     it("returns success on 200 response", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({
+      const mockTransport = vi.fn().mockResolvedValue({
         ok: true,
-        status: 200,
-        headers: { entries: () => [["content-type", "application/json"]] },
-        text: async () => '{"result": "ok"}',
+        statusCode: 200,
+        headers: { "content-type": "application/json" },
+        body: '{"result": "ok"}',
       });
-      vi.stubGlobal("fetch", mockFetch);
+      const fetchTool = new HttpFetchTool(mockTransport);
 
-      const result = await tool.call({ url: "https://api.example.com/data", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
+      const result = await fetchTool.call({ url: "https://api.example.com/data", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
       expect(result.success).toBe(true);
       expect((result.data as { statusCode: number }).statusCode).toBe(200);
       expect((result.data as { ok: boolean }).ok).toBe(true);
       expect(result.summary).toContain("200");
+      expect(mockTransport).toHaveBeenCalledTimes(1);
     });
 
     it("returns failure on 404 response", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({
+      const mockTransport = vi.fn().mockResolvedValue({
         ok: false,
-        status: 404,
-        headers: { entries: () => [] },
-        text: async () => "Not Found",
+        statusCode: 404,
+        headers: {},
+        body: "Not Found",
       });
-      vi.stubGlobal("fetch", mockFetch);
+      const fetchTool = new HttpFetchTool(mockTransport);
 
-      const result = await tool.call({ url: "https://api.example.com/missing", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
+      const result = await fetchTool.call({ url: "https://api.example.com/missing", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
       expect(result.success).toBe(false);
       expect((result.data as { statusCode: number }).statusCode).toBe(404);
       expect(result.error).toContain("404");
     });
 
     it("returns failure on network error", async () => {
-      const mockFetch = vi.fn().mockRejectedValue(new Error("Network failure"));
-      vi.stubGlobal("fetch", mockFetch);
+      const mockTransport = vi.fn().mockRejectedValue(new Error("Network failure"));
+      const fetchTool = new HttpFetchTool(mockTransport);
 
-      const result = await tool.call({ url: "https://api.example.com/data", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
+      const result = await fetchTool.call({ url: "https://api.example.com/data", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
       expect(result.success).toBe(false);
       expect(result.error).toContain("Network failure");
       expect((result.data as { statusCode: number }).statusCode).toBe(0);
     });
 
     it("returns empty body for HEAD request", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({
+      const mockTransport = vi.fn().mockResolvedValue({
         ok: true,
-        status: 200,
-        headers: { entries: () => [] },
-        text: async () => "should not be called",
+        statusCode: 200,
+        headers: {},
+        body: "",
       });
-      vi.stubGlobal("fetch", mockFetch);
+      const fetchTool = new HttpFetchTool(mockTransport);
 
-      const result = await tool.call({ url: "https://api.example.com/data", method: "HEAD", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
+      const result = await fetchTool.call({ url: "https://api.example.com/data", method: "HEAD", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
       expect(result.success).toBe(true);
       expect((result.data as { body: string }).body).toBe("");
+      expect(mockTransport).toHaveBeenCalledWith(expect.objectContaining({ method: "HEAD" }));
     });
 
     it("truncates large responses", async () => {
-      const largeBody = "x".repeat(2000);
-      const mockFetch = vi.fn().mockResolvedValue({
+      const mockTransport = vi.fn().mockResolvedValue({
         ok: true,
-        status: 200,
-        headers: { entries: () => [] },
-        text: async () => largeBody,
+        statusCode: 200,
+        headers: {},
+        body: `${"x".repeat(100)}\n[truncated]`,
       });
-      vi.stubGlobal("fetch", mockFetch);
+      const fetchTool = new HttpFetchTool(mockTransport);
 
-      const result = await tool.call({ url: "https://api.example.com/data", method: "GET", timeoutMs: 5_000, maxResponseBytes: 100 }, makeContext());
+      const result = await fetchTool.call({ url: "https://api.example.com/data", method: "GET", timeoutMs: 5_000, maxResponseBytes: 100 }, makeContext());
       expect(result.success).toBe(true);
       expect((result.data as { body: string }).body).toContain("[truncated]");
-      expect((result.data as { body: string }).body.length).toBeLessThan(largeBody.length);
+      expect(mockTransport).toHaveBeenCalledWith(expect.objectContaining({ maxResponseBytes: 100 }));
     });
 
     it("tracks durationMs", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({
+      const mockTransport = vi.fn().mockResolvedValue({
         ok: true,
-        status: 200,
-        headers: { entries: () => [] },
-        text: async () => "ok",
+        statusCode: 200,
+        headers: {},
+        body: "ok",
       });
-      vi.stubGlobal("fetch", mockFetch);
+      const fetchTool = new HttpFetchTool(mockTransport);
 
-      const result = await tool.call({ url: "https://api.example.com", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
+      const result = await fetchTool.call({ url: "https://api.example.com", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
       expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("follows redirects only after validating the next destination", async () => {
+      lookupMock
+        .mockResolvedValueOnce([{ address: "93.184.216.34", family: 4 }])
+        .mockResolvedValueOnce([{ address: "93.184.216.35", family: 4 }]);
+      const mockTransport = vi.fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          statusCode: 302,
+          headers: { location: "https://cdn.example.com/data" },
+          body: "",
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          statusCode: 200,
+          headers: {},
+          body: "ok",
+        });
+      const fetchTool = new HttpFetchTool(mockTransport);
+
+      const result = await fetchTool.call({ url: "https://api.example.com/data", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
+
+      expect(result.success).toBe(true);
+      expect(mockTransport).toHaveBeenCalledTimes(2);
+      expect(mockTransport).toHaveBeenNthCalledWith(2, expect.objectContaining({ url: new URL("https://cdn.example.com/data") }));
+    });
+
+    it("blocks redirects to internal addresses", async () => {
+      const mockTransport = vi.fn().mockResolvedValueOnce({
+        ok: false,
+        statusCode: 302,
+        headers: { location: "http://169.254.169.254/latest/meta-data" },
+        body: "",
+      });
+      const fetchTool = new HttpFetchTool(mockTransport);
+
+      const result = await fetchTool.call({ url: "https://api.example.com/data", method: "GET", timeoutMs: 5_000, maxResponseBytes: 1_048_576 }, makeContext());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("internal or private address");
+      expect(mockTransport).toHaveBeenCalledTimes(1);
+    });
+
+    it("pins the default transport request to the validated address", async () => {
+      const server = http.createServer((req, res) => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end(`host=${req.headers.host ?? ""}`);
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("test server did not bind to a TCP port");
+        }
+
+        const result = await defaultHttpFetchTransport({
+          url: new URL(`http://example.test:${address.port}/data`),
+          method: "GET",
+          timeoutMs: 5_000,
+          maxResponseBytes: 1_048_576,
+          destination: { address: "127.0.0.1", family: 4 },
+        });
+
+        expect(result.statusCode).toBe(200);
+        expect(result.body).toContain(`host=example.test:${address.port}`);
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((err) => err ? reject(err) : resolve());
+        });
+      }
     });
   });
 

--- a/tests/e2e/milestone4-daemon.test.ts
+++ b/tests/e2e/milestone4-daemon.test.ts
@@ -410,7 +410,11 @@ describe("Milestone 4 — Group 2: Event-Driven Integration", () => {
 
     // Use a dynamic port to avoid collisions
     const port = 41800 + Math.floor(Math.random() * 100);
-    const eventServer = new EventServer(driveSystem, { host: "127.0.0.1", port });
+    const eventServer = new EventServer(driveSystem, {
+      host: "127.0.0.1",
+      port,
+      eventsDir: path.join(tempDir, "events"),
+    });
 
     expect(eventServer.isRunning()).toBe(false);
 
@@ -429,7 +433,10 @@ describe("Milestone 4 — Group 2: Event-Driven Integration", () => {
 
     const response = await fetch(`http://127.0.0.1:${port}/events`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${eventServer.getAuthToken()}`,
+      },
       body: JSON.stringify(event),
     });
 

--- a/tests/e2e/phase-b-integration.test.ts
+++ b/tests/e2e/phase-b-integration.test.ts
@@ -29,6 +29,8 @@ import { makeTempDir, cleanupTempDir } from "../helpers/temp-dir.js";
 
 // ─── Shared helpers ───
 
+const eventServerAuthTokens = new Map<number, string>();
+
 function writeHooksJson(dir: string, hooks: HookConfig[]): void {
   fs.writeFileSync(path.join(dir, "hooks.json"), JSON.stringify({ hooks }), "utf-8");
 }
@@ -51,11 +53,16 @@ function makeHttpRequest(
   port: number,
   method: string,
   urlPath: string,
-  body?: unknown
+  body?: unknown,
+  authToken?: string
 ): Promise<{ status: number; body: string }> {
   return new Promise((resolve, reject) => {
     const data = body !== undefined ? JSON.stringify(body) : "";
-    const headers: http.OutgoingHttpHeaders = { "Content-Type": "application/json" };
+    const resolvedAuthToken = authToken ?? eventServerAuthTokens.get(port);
+    const headers: http.OutgoingHttpHeaders = {
+      "Content-Type": "application/json",
+      ...(resolvedAuthToken ? { Authorization: `Bearer ${resolvedAuthToken}` } : {}),
+    };
     if (data.length > 0) headers["Content-Length"] = Buffer.byteLength(data);
     const req = http.request(
       { hostname: "127.0.0.1", port, path: urlPath, method, headers },
@@ -69,6 +76,10 @@ function makeHttpRequest(
     if (data.length > 0) req.write(data);
     req.end();
   });
+}
+
+function rememberEventServerAuth(server: EventServer): void {
+  eventServerAuthTokens.set(server.getPort(), server.getAuthToken());
 }
 
 function makeMockMCPConnection(overrides: Partial<IMCPConnection> = {}): IMCPConnection {
@@ -350,6 +361,7 @@ describe("Phase B — Remote Trigger API: POST trigger creates event", () => {
     });
     await server.start();
     port = server.getPort();
+    rememberEventServerAuth(server);
   });
 
   afterEach(async () => {
@@ -478,6 +490,7 @@ describe("Phase B — Remote Trigger API: GET /goals returns goal states", () =>
     });
     await server.start();
     port = server.getPort();
+    rememberEventServerAuth(server);
   });
 
   afterEach(async () => {
@@ -723,6 +736,7 @@ describe("Phase B — Hook + Trigger integration: trigger fires → hook interce
     });
     await server.start();
     port = server.getPort();
+    rememberEventServerAuth(server);
   });
 
   afterEach(async () => {
@@ -846,6 +860,7 @@ describe("Phase B — EventServer lifecycle: start → requests → graceful shu
     });
     await server.start();
     const port = server.getPort();
+    rememberEventServerAuth(server);
 
     expect(server.isRunning()).toBe(true);
 
@@ -880,6 +895,7 @@ describe("Phase B — EventServer lifecycle: start → requests → graceful shu
     });
     await server.start();
     const port = server.getPort();
+    rememberEventServerAuth(server);
 
     const res = await makeHttpRequest(port, "GET", "/unknown/path");
     expect(res.status).toBe(404);
@@ -897,6 +913,7 @@ describe("Phase B — EventServer lifecycle: start → requests → graceful shu
     });
     await server.start();
     const port = server.getPort();
+    rememberEventServerAuth(server);
 
     // Fire 5 concurrent health checks
     const requests = Array.from({ length: 5 }, () =>
@@ -932,6 +949,7 @@ describe("Phase B — EventServer lifecycle: start → requests → graceful shu
     });
     await server.start();
     const port = server.getPort();
+    rememberEventServerAuth(server);
 
     const res = await makeHttpRequest(port, "POST", "/events", {
       type: "external",
@@ -959,6 +977,7 @@ describe("Phase B — EventServer lifecycle: start → requests → graceful shu
     });
     await server.start();
     const port = server.getPort();
+    rememberEventServerAuth(server);
 
     const res = await makeHttpRequest(port, "POST", "/events", {
       bad_field: "not a valid event",


### PR DESCRIPTION
## Summary
- default-deny Telegram bot access unless allow_all is explicitly configured, while still checking the configured chat id
- route ChatRunner tool execution through ToolExecutor and harden filesystem/network tool boundaries
- add daemon API bearer auth, browser-origin checks, and SSE auth handling
- restrict npm publish to version tags and update vulnerable dependency resolutions

## Validation
- npm run typecheck
- npm test
- npx vitest run tests/e2e/phase-b-integration.test.ts tests/e2e/milestone4-daemon.test.ts
- npm audit --json
- git diff --check