### PR TITLE
[codex] Implement Soil viewer publish integrations

### DIFF
--- a/src/interface/cli/__tests__/cli-daemon-start.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-start.test.ts
@@ -7,6 +7,7 @@ const {
   daemonStartMock,
   watchdogStartMock,
   scheduleLoadEntriesMock,
+  scheduleEnsureSoilPublishScheduleMock,
   pluginLoadAllMock,
   setRealtimeSinkMock,
   eventServerBroadcastMock,
@@ -19,6 +20,7 @@ const {
   daemonStartMock: vi.fn().mockResolvedValue(undefined),
   watchdogStartMock: vi.fn().mockResolvedValue(undefined),
   scheduleLoadEntriesMock: vi.fn().mockResolvedValue(undefined),
+  scheduleEnsureSoilPublishScheduleMock: vi.fn().mockResolvedValue(null),
   pluginLoadAllMock: vi.fn().mockResolvedValue(undefined),
   setRealtimeSinkMock: vi.fn(),
   eventServerBroadcastMock: vi.fn(),
@@ -98,6 +100,7 @@ vi.mock("../../../runtime/schedule/engine.js", () => ({
     scheduleEngineArgs.push(args);
     return {
       loadEntries: scheduleLoadEntriesMock,
+      ensureSoilPublishSchedule: scheduleEnsureSoilPublishScheduleMock,
     };
   }),
 }));
@@ -146,6 +149,7 @@ describe("cmdStart", () => {
     daemonStartMock.mockClear();
     watchdogStartMock.mockClear();
     scheduleLoadEntriesMock.mockClear();
+    scheduleEnsureSoilPublishScheduleMock.mockClear();
     pluginLoadAllMock.mockClear();
     setRealtimeSinkMock.mockClear();
     eventServerBroadcastMock.mockClear();

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -291,6 +291,7 @@ export async function cmdStart(
     knowledgeManager: deps.knowledgeManager,
   });
   await scheduleEngine.loadEntries();
+  await scheduleEngine.ensureSoilPublishSchedule();
 
   const refreshResidentDeps = async () => {
     const freshDeps = await buildDeps(
@@ -316,6 +317,7 @@ export async function cmdStart(
       knowledgeManager: freshDeps.knowledgeManager,
     });
     await freshScheduleEngine.loadEntries();
+    await freshScheduleEngine.ensureSoilPublishSchedule();
 
     return {
       coreLoop: freshDeps.coreLoop,

--- a/src/platform/soil/__tests__/soil-index.test.ts
+++ b/src/platform/soil/__tests__/soil-index.test.ts
@@ -174,4 +174,23 @@ describe("Soil index snapshot", () => {
       cleanupTempDir(rootDir);
     }
   });
+
+  it("reports missing required Soil entry pages", async () => {
+    const rootDir = makeTempDir("soil-required-pages-");
+    try {
+      const report = await SoilDoctor.create({ rootDir }).inspect();
+      expect(report.findings).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          code: "missing-required-page",
+          relativePath: "index.md",
+        }),
+        expect.objectContaining({
+          code: "missing-required-page",
+          relativePath: "schedule/active.md",
+        }),
+      ]));
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
 });

--- a/src/platform/soil/__tests__/soil-open.test.ts
+++ b/src/platform/soil/__tests__/soil-open.test.ts
@@ -1,0 +1,49 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { buildSoilOpenCommand, openSoil, resolveSoilOpenPath } from "../open.js";
+
+describe("Soil open bridge", () => {
+  it("resolves known Soil targets without creating root active.md", () => {
+    const rootDir = makeTempDir("soil-open-");
+    try {
+      expect(resolveSoilOpenPath({ rootDir, target: "root" }).path).toBe(rootDir);
+      expect(resolveSoilOpenPath({ rootDir, target: "status" }).path).toBe(path.join(rootDir, "status.md"));
+      expect(resolveSoilOpenPath({ rootDir, target: "schedule_active" }).path).toBe(path.join(rootDir, "schedule", "active.md"));
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("builds vscode argv and uses the injected runner", async () => {
+    const rootDir = makeTempDir("soil-open-runner-");
+    try {
+      const command = buildSoilOpenCommand({ rootDir, viewer: "vscode", target: "schedule_active" });
+      expect(command.command).toBe("code");
+      expect(command.args).toEqual([path.join(rootDir, "schedule", "active.md")]);
+
+      const calls: Array<{ command: string; args: string[] }> = [];
+      const result = await openSoil(
+        { rootDir, viewer: "vscode", target: "status" },
+        async (command, args) => {
+          calls.push({ command, args });
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }
+      );
+      expect(result.exitCode).toBe(0);
+      expect(calls).toEqual([{ command: "code", args: [path.join(rootDir, "status.md")] }]);
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("rejects path targets outside the Soil root", () => {
+    const rootDir = makeTempDir("soil-open-escape-");
+    try {
+      expect(() => resolveSoilOpenPath({ rootDir, target: "path", targetPath: path.join(rootDir, "..", "outside.md") }))
+        .toThrow(/escapes the root/);
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+});

--- a/src/platform/soil/__tests__/soil-projections.test.ts
+++ b/src/platform/soil/__tests__/soil-projections.test.ts
@@ -43,7 +43,7 @@ describe("Soil projections", () => {
     }
   });
 
-  it("projects current schedules into soil/schedule/current.md", async () => {
+  it("projects current and active schedules into soil/schedule markdown", async () => {
     const baseDir = makeTempDir("soil-schedule-projection-");
     try {
       const entry = ScheduleEntrySchema.parse({
@@ -83,6 +83,13 @@ describe("Soil projections", () => {
       expect(page?.frontmatter.summary).toBe("1/1 schedules enabled");
       expect(page?.body).toContain("Daily brief");
       expect(page?.body).toContain("cron 0 9 * * * (Asia/Tokyo)");
+
+      const activePage = await readSoilMarkdownFile(path.join(baseDir, "soil", "schedule", "active.md"));
+      expect(activePage?.frontmatter.soil_id).toBe("schedule/active");
+      expect(activePage?.frontmatter.summary).toBe("1 active schedules");
+      expect(activePage?.body).toContain("Daily brief");
+      expect(activePage?.body).toContain("2026-04-12T09:00:00.000Z");
+      expect(activePage?.body).toContain("reflection:morning_planning");
     } finally {
       cleanupTempDir(baseDir);
     }

--- a/src/platform/soil/__tests__/soil-publish.test.ts
+++ b/src/platform/soil/__tests__/soil-publish.test.ts
@@ -1,0 +1,199 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { writeJsonFileAtomic } from "../../../base/utils/json-io.js";
+import {
+  collectSoilSnapshotFiles,
+  filterAppleNotesSnapshotFiles,
+  loadSoilPublishState,
+  publishSoilSnapshots,
+  type NotionPublishClient,
+} from "../publish/index.js";
+
+async function writeSoilFixture(rootDir: string): Promise<void> {
+  await fsp.mkdir(path.join(rootDir, "schedule"), { recursive: true });
+  await fsp.mkdir(path.join(rootDir, "knowledge"), { recursive: true });
+  await fsp.mkdir(path.join(rootDir, ".index"), { recursive: true });
+  await fsp.mkdir(path.join(rootDir, ".publish"), { recursive: true });
+  await fsp.writeFile(path.join(rootDir, "status.md"), "# Status\n", "utf-8");
+  await fsp.writeFile(path.join(rootDir, "schedule", "active.md"), "# Active\n", "utf-8");
+  await fsp.writeFile(path.join(rootDir, "knowledge", "index.md"), "# Knowledge\n", "utf-8");
+  await fsp.writeFile(path.join(rootDir, ".index", "hidden.md"), "# Hidden\n", "utf-8");
+  await fsp.writeFile(path.join(rootDir, ".publish", "hidden.md"), "# Hidden\n", "utf-8");
+}
+
+describe("Soil snapshot publish", () => {
+  it("collects the Soil markdown tree while excluding hidden directories", async () => {
+    const rootDir = makeTempDir("soil-publish-collect-");
+    try {
+      await writeSoilFixture(rootDir);
+      const files = await collectSoilSnapshotFiles(rootDir);
+      expect(files.map((file) => file.relativePath)).toEqual([
+        "knowledge/index.md",
+        "schedule/active.md",
+        "status.md",
+      ]);
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("publishes Notion snapshots for the full visible Soil tree and skips unchanged hashes", async () => {
+    const rootDir = makeTempDir("soil-publish-notion-");
+    try {
+      await writeSoilFixture(rootDir);
+      await writeJsonFileAtomic(path.join(rootDir, "publish.json"), {
+        notion: { enabled: true, token: "secret", parentPageId: "parent", titlePrefix: "Soil" },
+      });
+
+      const created: string[] = [];
+      const replaced: string[] = [];
+      const client: NotionPublishClient = {
+        createPage: vi.fn(async ({ title }) => {
+          created.push(title);
+          return `page-${created.length}`;
+        }),
+        replacePageMarkdown: vi.fn(async ({ pageId }) => {
+          replaced.push(pageId);
+        }),
+      };
+
+      const first = await publishSoilSnapshots({ rootDir, provider: "notion", notionClient: client });
+      expect(first.providers[0]?.pages.map((page) => page.relativePath).sort()).toEqual([
+        "knowledge/index.md",
+        "schedule/active.md",
+        "status.md",
+      ]);
+      expect(first.providers[0]?.pages.every((page) => page.status === "published")).toBe(true);
+      expect(created).toHaveLength(3);
+      expect(replaced).toHaveLength(3);
+
+      const second = await publishSoilSnapshots({ rootDir, provider: "notion", notionClient: client });
+      expect(second.providers[0]?.pages.every((page) => page.status === "skipped")).toBe(true);
+      expect(created).toHaveLength(3);
+      expect(replaced).toHaveLength(3);
+
+      const state = await loadSoilPublishState(rootDir);
+      expect(Object.keys(state.notion.pages).sort()).toEqual([
+        "knowledge/index.md",
+        "schedule/active.md",
+        "status.md",
+      ]);
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("archives Notion pages that no longer exist in the Soil tree", async () => {
+    const rootDir = makeTempDir("soil-publish-notion-stale-");
+    try {
+      await writeSoilFixture(rootDir);
+      await writeJsonFileAtomic(path.join(rootDir, "publish.json"), {
+        notion: { enabled: true, token: "secret", parentPageId: "parent", titlePrefix: "Soil" },
+      });
+      await writeJsonFileAtomic(path.join(rootDir, ".publish", "state.json"), {
+        version: "soil-publish-state-v1",
+        notion: {
+          pages: {
+            "status.md": {
+              notion_page_id: "page-status",
+              source_hash: "old-status",
+              published_at: "2026-04-11T00:00:00.000Z",
+            },
+            "old.md": {
+              notion_page_id: "page-old",
+              source_hash: "old",
+              published_at: "2026-04-11T00:00:00.000Z",
+            },
+          },
+        },
+        apple_notes: { pages: {} },
+      });
+
+      const archived: string[] = [];
+      const client: NotionPublishClient = {
+        createPage: vi.fn(async () => "page-new"),
+        replacePageMarkdown: vi.fn(async () => undefined),
+        archivePage: vi.fn(async ({ pageId }) => {
+          archived.push(pageId);
+        }),
+      };
+
+      const result = await publishSoilSnapshots({ rootDir, provider: "notion", notionClient: client });
+      expect(result.providers[0]?.pages).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          provider: "notion",
+          relativePath: "old.md",
+          status: "archived",
+          destinationId: "page-old",
+        }),
+      ]));
+      expect(archived).toEqual(["page-old"]);
+      const state = await loadSoilPublishState(rootDir);
+      expect(state.notion.pages["old.md"]).toBeUndefined();
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("limits Apple Notes snapshots to status and active schedule pages", async () => {
+    const rootDir = makeTempDir("soil-publish-apple-");
+    try {
+      await writeSoilFixture(rootDir);
+      const files = filterAppleNotesSnapshotFiles(await collectSoilSnapshotFiles(rootDir));
+      expect(files.map((file) => file.relativePath)).toEqual(["schedule/active.md", "status.md"]);
+
+      await writeJsonFileAtomic(path.join(rootDir, "publish.json"), {
+        apple_notes: { enabled: true, shortcutName: "Publish Soil Page", folderName: "PulSeed" },
+      });
+      const result = await publishSoilSnapshots({
+        rootDir,
+        provider: "apple_notes",
+        dryRun: true,
+        appleNotesPlatform: "darwin",
+      });
+      expect(result.providers[0]?.pages).toEqual(expect.arrayContaining([
+        expect.objectContaining({ provider: "apple_notes", relativePath: "status.md", status: "dry_run" }),
+        expect.objectContaining({ provider: "apple_notes", relativePath: "schedule/active.md", status: "dry_run" }),
+      ]));
+      expect(result.providers[0]?.pages).toHaveLength(2);
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("runs Apple Notes shortcuts with file input only", async () => {
+    const rootDir = makeTempDir("soil-publish-apple-runner-");
+    try {
+      await writeSoilFixture(rootDir);
+      await writeJsonFileAtomic(path.join(rootDir, "publish.json"), {
+        apple_notes: { enabled: true, shortcutName: "Publish Soil Page", folderName: "PulSeed" },
+      });
+      const calls: Array<{ command: string; args: string[] }> = [];
+      const result = await publishSoilSnapshots({
+        rootDir,
+        provider: "apple_notes",
+        appleNotesPlatform: "darwin",
+        appleNotesRunner: async (command, args) => {
+          calls.push({ command, args });
+          return { stdout: "", stderr: "", exitCode: 0 };
+        },
+      });
+
+      expect(result.providers[0]?.pages.every((page) => page.status === "published")).toBe(true);
+      expect(calls).toEqual([
+        {
+          command: "shortcuts",
+          args: ["run", "Publish Soil Page", "--input-path", path.join(rootDir, "schedule", "active.md")],
+        },
+        {
+          command: "shortcuts",
+          args: ["run", "Publish Soil Page", "--input-path", path.join(rootDir, "status.md")],
+        },
+      ]);
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+});

--- a/src/platform/soil/doctor.ts
+++ b/src/platform/soil/doctor.ts
@@ -23,6 +23,7 @@ export interface SoilDoctorFinding {
     | "checksum-mismatch"
     | "watermark-mismatch"
     | "missing-index"
+    | "missing-required-page"
     | "index-page-count-mismatch"
     | "index-checksum-mismatch";
   severity: "error" | "warn";
@@ -221,6 +222,8 @@ export class SoilDoctor {
       }
     }
 
+    findings.push(...(await this.checkRequiredPages(pages)));
+
     return {
       rootDir: this.config.rootDir,
       totalPages: pages.length,
@@ -232,6 +235,35 @@ export class SoilDoctor {
     const pages: ScannedPage[] = [];
     await this.walk(this.config.rootDir, pages);
     return pages;
+  }
+
+  private async checkRequiredPages(pages: ScannedPage[]): Promise<SoilDoctorFinding[]> {
+    const findings: SoilDoctorFinding[] = [];
+    const existing = new Set(pages.map((page) => page.relativePath));
+    const requiredPages = [
+      { relativePath: "index.md", severity: "error" as const, message: "Required Soil entry page is missing: index.md" },
+      {
+        relativePath: "schedule/active.md",
+        severity: "warn" as const,
+        message: "Required active schedule page is missing: schedule/active.md",
+      },
+    ];
+
+    for (const page of requiredPages) {
+      if (existing.has(page.relativePath)) {
+        continue;
+      }
+      const absolutePath = path.join(this.config.rootDir, page.relativePath);
+      findings.push({
+        code: "missing-required-page",
+        severity: page.severity,
+        relativePath: page.relativePath,
+        absolutePath,
+        message: page.message,
+      });
+    }
+
+    return findings;
   }
 
   private async walk(dir: string, pages: ScannedPage[]): Promise<void> {

--- a/src/platform/soil/index.ts
+++ b/src/platform/soil/index.ts
@@ -12,3 +12,5 @@ export * from "./projections.js";
 export * from "./content-projections.js";
 export * from "./runtime-rebuild.js";
 export * from "./importer.js";
+export * from "./open.js";
+export * from "./publish/index.js";

--- a/src/platform/soil/open.ts
+++ b/src/platform/soil/open.ts
@@ -1,0 +1,118 @@
+import * as path from "node:path";
+import { execFileNoThrow, type ExecFileResult } from "../../base/utils/execFileNoThrow.js";
+import { createSoilConfig, type SoilConfigInput } from "./config.js";
+import { resolveSoilPageFilePath } from "./paths.js";
+
+export type SoilOpenViewer = "default" | "finder" | "vscode" | "obsidian" | "logseq";
+export type SoilOpenTarget =
+  | "root"
+  | "schedule_active"
+  | "status"
+  | "report"
+  | "schedule"
+  | "memory"
+  | "knowledge"
+  | "path";
+
+export interface SoilOpenInput extends SoilConfigInput {
+  viewer?: SoilOpenViewer;
+  target?: SoilOpenTarget;
+  targetPath?: string;
+}
+
+export interface SoilOpenCommand {
+  command: string;
+  args: string[];
+  path: string;
+  viewer: SoilOpenViewer;
+  target: SoilOpenTarget;
+}
+
+export type SoilOpenRunner = (command: string, args: string[], options?: { timeoutMs?: number }) => Promise<ExecFileResult>;
+
+export interface SoilOpenResult extends SoilOpenCommand {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function isInside(rootDir: string, candidate: string): boolean {
+  const root = path.resolve(rootDir);
+  const resolved = path.resolve(candidate);
+  const prefix = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  return resolved === root || resolved.startsWith(prefix);
+}
+
+export function resolveSoilOpenPath(input: SoilOpenInput): { rootDir: string; target: SoilOpenTarget; path: string } {
+  const config = createSoilConfig(input);
+  const target = input.target ?? "root";
+  if (target === "path") {
+    if (!input.targetPath) {
+      throw new Error("targetPath is required when target is path");
+    }
+    const candidate = path.isAbsolute(input.targetPath)
+      ? path.resolve(input.targetPath)
+      : resolveSoilPageFilePath(config.rootDir, input.targetPath);
+    if (!isInside(config.rootDir, candidate)) {
+      throw new Error(`Soil open target escapes the root: ${input.targetPath}`);
+    }
+    return { rootDir: config.rootDir, target, path: candidate };
+  }
+
+  const relativeByTarget: Record<Exclude<SoilOpenTarget, "root" | "path">, string> = {
+    schedule_active: path.join("schedule", "active.md"),
+    status: "status.md",
+    report: "report",
+    schedule: "schedule",
+    memory: "memory",
+    knowledge: "knowledge",
+  };
+  const targetPath = target === "root" ? config.rootDir : path.join(config.rootDir, relativeByTarget[target]);
+  return { rootDir: config.rootDir, target, path: targetPath };
+}
+
+function platformOpenCommand(targetPathOrUrl: string): { command: string; args: string[] } {
+  if (process.platform === "darwin") {
+    return { command: "open", args: [targetPathOrUrl] };
+  }
+  if (process.platform === "win32") {
+    return { command: "cmd", args: ["/c", "start", "", targetPathOrUrl] };
+  }
+  return { command: "xdg-open", args: [targetPathOrUrl] };
+}
+
+export function buildSoilOpenCommand(input: SoilOpenInput): SoilOpenCommand {
+  const resolved = resolveSoilOpenPath(input);
+  const viewer = input.viewer ?? "default";
+
+  if (viewer === "vscode") {
+    return { command: "code", args: [resolved.path], path: resolved.path, viewer, target: resolved.target };
+  }
+  if (viewer === "obsidian") {
+    const url = `obsidian://open?path=${encodeURIComponent(resolved.path)}`;
+    const command = platformOpenCommand(url);
+    return { ...command, path: resolved.path, viewer, target: resolved.target };
+  }
+  if (viewer === "logseq") {
+    const url = `logseq://graph/${encodeURIComponent(resolved.rootDir)}?page=${encodeURIComponent(resolved.path)}`;
+    const command = platformOpenCommand(url);
+    return { ...command, path: resolved.path, viewer, target: resolved.target };
+  }
+
+  const command = platformOpenCommand(resolved.path);
+  if (viewer === "finder" && process.platform === "darwin") {
+    return { command: "open", args: ["-R", resolved.path], path: resolved.path, viewer, target: resolved.target };
+  }
+  return { ...command, path: resolved.path, viewer, target: resolved.target };
+}
+
+export async function openSoil(input: SoilOpenInput, runner: SoilOpenRunner = execFileNoThrow): Promise<SoilOpenResult> {
+  const command = buildSoilOpenCommand(input);
+  const result = await runner(command.command, command.args, { timeoutMs: 10_000 });
+  return {
+    ...command,
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}

--- a/src/platform/soil/projections.ts
+++ b/src/platform/soil/projections.ts
@@ -197,6 +197,75 @@ function scheduleBody(entries: ScheduleEntry[]): string {
   return lines.join("\n");
 }
 
+function schedulePurpose(entry: ScheduleEntry): string {
+  if (entry.cron) {
+    if (entry.cron.job_kind === "reflection") {
+      return entry.cron.reflection_kind ? `reflection:${entry.cron.reflection_kind}` : "reflection";
+    }
+    if (entry.cron.job_kind === "soil_publish") {
+      return "soil snapshot publish";
+    }
+    return summaryFromText(entry.cron.prompt_template, 120);
+  }
+  if (entry.probe) {
+    return `probe ${entry.probe.data_source_id}${entry.probe.probe_dimension ? `/${entry.probe.probe_dimension}` : ""}`;
+  }
+  if (entry.heartbeat) {
+    return `heartbeat ${entry.heartbeat.check_type}`;
+  }
+  if (entry.goal_trigger) {
+    return `goal trigger ${entry.goal_trigger.goal_id}`;
+  }
+  return entry.metadata?.note ?? "none";
+}
+
+function scheduleOutputHint(entry: ScheduleEntry): string {
+  if (entry.cron) {
+    return [
+      entry.cron.output_format,
+      entry.cron.report_type ? `report:${entry.cron.report_type}` : undefined,
+    ].filter(Boolean).join(" / ");
+  }
+  if (entry.probe) {
+    return entry.probe.llm_on_change ? "probe change + optional LLM note" : "probe change";
+  }
+  if (entry.heartbeat) {
+    return "health status";
+  }
+  if (entry.goal_trigger) {
+    return `run goal ${entry.goal_trigger.goal_id}`;
+  }
+  return "none";
+}
+
+function activeScheduleBody(entries: ScheduleEntry[]): string {
+  const active = [...entries]
+    .filter((entry) => entry.enabled)
+    .sort((left, right) => left.next_fire_at.localeCompare(right.next_fire_at));
+  const lines = [
+    "# Active schedules",
+    "",
+    `Active: ${active.length}`,
+    `Total: ${entries.length}`,
+    "",
+    "| Name | Layer | Trigger | Next fire | Purpose | Output hint | Last fired |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+  ];
+
+  for (const entry of active) {
+    lines.push(
+      `| ${entry.name} | ${entry.layer} | ${scheduleTriggerSummary(entry)} | ${entry.next_fire_at} | ${schedulePurpose(entry)} | ${scheduleOutputHint(entry)} | ${entry.last_fired_at ?? ""} |`
+    );
+  }
+
+  if (active.length === 0) {
+    lines.push("| none | | | | | | |");
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
 export async function projectSchedulesToSoil(input: ProjectSchedulesToSoilInput): Promise<void> {
   const generatedAt = nowIso(input.clock);
   const sourcePath = path.join(input.baseDir, "schedules.json");
@@ -211,7 +280,7 @@ export async function projectSchedulesToSoil(input: ProjectSchedulesToSoilInput)
     .sort()
     .at(0) ?? generatedAt;
 
-  const frontmatter = baseFrontmatter({
+  const currentFrontmatter = baseFrontmatter({
     soilId: "schedule/current",
     title: "Current schedules",
     kind: "schedule",
@@ -225,9 +294,28 @@ export async function projectSchedulesToSoil(input: ProjectSchedulesToSoilInput)
     domain: "schedule",
     renderedFrom: "schedule-engine",
   });
+  const activeFrontmatter = baseFrontmatter({
+    soilId: "schedule/active",
+    title: "Active schedules",
+    kind: "schedule",
+    route: "schedule",
+    createdAt,
+    updatedAt,
+    generatedAt,
+    sourcePath,
+    sourceHash,
+    summary: `${enabledCount} active schedules`,
+    domain: "schedule",
+    renderedFrom: "schedule-engine",
+  });
+  const compiler = SoilCompiler.create({ rootDir: soilRootFromBaseDir(input) }, { clock: input.clock });
 
-  await SoilCompiler.create({ rootDir: soilRootFromBaseDir(input) }, { clock: input.clock }).write({
-    frontmatter,
+  await compiler.write({
+    frontmatter: currentFrontmatter,
     body: scheduleBody(input.entries),
+  });
+  await compiler.write({
+    frontmatter: activeFrontmatter,
+    body: activeScheduleBody(input.entries),
   });
 }

--- a/src/platform/soil/publish/apple-notes.ts
+++ b/src/platform/soil/publish/apple-notes.ts
@@ -1,0 +1,70 @@
+import { execFileNoThrow, type ExecFileResult } from "../../../base/utils/execFileNoThrow.js";
+import type { SoilPublishConfig, SoilPublishPageResult, SoilPublishState, SoilSnapshotFile } from "./types.js";
+
+export type AppleNotesRunner = (command: string, args: string[], options?: { timeoutMs?: number }) => Promise<ExecFileResult>;
+
+export async function publishAppleNotesSnapshot(input: {
+  config: SoilPublishConfig;
+  files: SoilSnapshotFile[];
+  state: SoilPublishState;
+  dryRun?: boolean;
+  runner?: AppleNotesRunner;
+  platform?: NodeJS.Platform;
+  clock?: () => Date;
+}): Promise<SoilPublishPageResult[]> {
+  const config = input.config.apple_notes;
+  if (!config?.enabled) {
+    return [{ provider: "apple_notes", relativePath: "", status: "skipped", message: "Apple Notes publish is disabled" }];
+  }
+  if ((input.platform ?? process.platform) !== "darwin") {
+    return [{ provider: "apple_notes", relativePath: "", status: "skipped", message: "Apple Notes publish requires macOS" }];
+  }
+  if (!config.shortcutName) {
+    return [{ provider: "apple_notes", relativePath: "", status: "skipped", message: "Apple Notes shortcutName is required" }];
+  }
+
+  const runner = input.runner ?? execFileNoThrow;
+  const results: SoilPublishPageResult[] = [];
+  for (const file of input.files) {
+    const existing = input.state.apple_notes.pages[file.relativePath];
+    if (existing?.source_hash === file.sourceHash) {
+      results.push({
+        provider: "apple_notes",
+        relativePath: file.relativePath,
+        status: "skipped",
+        sourceHash: file.sourceHash,
+        message: "source hash unchanged",
+      });
+      continue;
+    }
+    if (input.dryRun) {
+      results.push({ provider: "apple_notes", relativePath: file.relativePath, status: "dry_run", sourceHash: file.sourceHash });
+      continue;
+    }
+
+    const args = ["run", config.shortcutName, "--input-path", file.absolutePath];
+    const result = await runner("shortcuts", args, { timeoutMs: 30_000 });
+    if (result.exitCode === 0) {
+      input.state.apple_notes.pages[file.relativePath] = {
+        source_hash: file.sourceHash,
+        published_at: (input.clock?.() ?? new Date()).toISOString(),
+      };
+      results.push({
+        provider: "apple_notes",
+        relativePath: file.relativePath,
+        status: "published",
+        sourceHash: file.sourceHash,
+        destinationId: config.folderName,
+      });
+    } else {
+      results.push({
+        provider: "apple_notes",
+        relativePath: file.relativePath,
+        status: "error",
+        sourceHash: file.sourceHash,
+        message: result.stderr || `shortcuts exited with ${result.exitCode}`,
+      });
+    }
+  }
+  return results;
+}

--- a/src/platform/soil/publish/config.ts
+++ b/src/platform/soil/publish/config.ts
@@ -1,0 +1,75 @@
+import * as path from "node:path";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../../../base/utils/json-io.js";
+import { createSoilConfig, type SoilConfigInput } from "../config.js";
+import {
+  SoilPublishConfigSchema,
+  SoilPublishStateSchema,
+  type SoilPublishConfig,
+  type SoilPublishState,
+} from "./types.js";
+
+export interface SoilPublishConfigInput extends SoilConfigInput {
+  baseDir?: string;
+}
+
+export function resolveSoilPublishRoot(input: SoilPublishConfigInput = {}): string {
+  if (input.rootDir) {
+    return createSoilConfig({ rootDir: input.rootDir }).rootDir;
+  }
+  if (input.baseDir) {
+    return path.join(input.baseDir, "soil");
+  }
+  return createSoilConfig({}).rootDir;
+}
+
+export function getSoilPublishConfigPath(rootDir: string): string {
+  return path.join(rootDir, "publish.json");
+}
+
+export function getSoilPublishStatePath(rootDir: string): string {
+  return path.join(rootDir, ".publish", "state.json");
+}
+
+export async function loadSoilPublishConfig(input: SoilPublishConfigInput = {}): Promise<SoilPublishConfig> {
+  const rootDir = resolveSoilPublishRoot(input);
+  const raw = await readJsonFileOrNull(getSoilPublishConfigPath(rootDir));
+  const parsed = SoilPublishConfigSchema.safeParse(raw ?? {});
+  const config = parsed.success ? parsed.data : SoilPublishConfigSchema.parse({});
+  if (process.env.NOTION_TOKEN) {
+    return SoilPublishConfigSchema.parse({
+      ...config,
+      notion: {
+        enabled: config.notion?.enabled ?? false,
+        titlePrefix: config.notion?.titlePrefix ?? "Soil",
+        parentPageId: config.notion?.parentPageId,
+        token: process.env.NOTION_TOKEN,
+      },
+    });
+  }
+  return config;
+}
+
+export async function loadSoilPublishState(rootDir: string): Promise<SoilPublishState> {
+  const raw = await readJsonFileOrNull(getSoilPublishStatePath(rootDir));
+  const parsed = SoilPublishStateSchema.safeParse(raw ?? {});
+  return parsed.success ? parsed.data : SoilPublishStateSchema.parse({});
+}
+
+export async function saveSoilPublishState(rootDir: string, state: SoilPublishState): Promise<void> {
+  await writeJsonFileAtomic(getSoilPublishStatePath(rootDir), SoilPublishStateSchema.parse(state));
+}
+
+export function configuredSoilPublishProviders(config: SoilPublishConfig): Array<"notion" | "apple_notes"> {
+  const providers: Array<"notion" | "apple_notes"> = [];
+  if (config.notion?.enabled && config.notion.token && config.notion.parentPageId) {
+    providers.push("notion");
+  }
+  if (config.apple_notes?.enabled && config.apple_notes.shortcutName && process.platform === "darwin") {
+    providers.push("apple_notes");
+  }
+  return providers;
+}
+
+export async function hasConfiguredSoilPublishProvider(input: SoilPublishConfigInput = {}): Promise<boolean> {
+  return configuredSoilPublishProviders(await loadSoilPublishConfig(input)).length > 0;
+}

--- a/src/platform/soil/publish/index.ts
+++ b/src/platform/soil/publish/index.ts
@@ -1,0 +1,6 @@
+export * from "./types.js";
+export * from "./config.js";
+export * from "./snapshot.js";
+export * from "./notion.js";
+export * from "./apple-notes.js";
+export * from "./publisher.js";

--- a/src/platform/soil/publish/notion.ts
+++ b/src/platform/soil/publish/notion.ts
@@ -1,0 +1,234 @@
+import type { SoilPublishConfig, SoilPublishPageResult, SoilPublishState, SoilSnapshotFile } from "./types.js";
+
+export interface NotionPublishClient {
+  createPage(input: { parentPageId: string; title: string }): Promise<string>;
+  replacePageMarkdown(input: { pageId: string; title: string; markdown: string }): Promise<void>;
+  archivePage?(input: { pageId: string; relativePath: string }): Promise<void>;
+}
+
+interface NotionFetchResponse {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+type NotionFetch = (url: string, init: RequestInit) => Promise<NotionFetchResponse>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+async function readNotionJson(response: NotionFetchResponse): Promise<Record<string, unknown>> {
+  const body = await response.json().catch(async () => ({ message: await response.text().catch(() => "") }));
+  return asRecord(body);
+}
+
+function textBlocks(markdown: string): Array<Record<string, unknown>> {
+  const chunks: string[] = [];
+  for (let index = 0; index < markdown.length; index += 1800) {
+    chunks.push(markdown.slice(index, index + 1800));
+  }
+  return chunks.map((chunk) => ({
+    object: "block",
+    type: "code",
+    code: {
+      language: "markdown",
+      rich_text: [{ type: "text", text: { content: chunk } }],
+    },
+  }));
+}
+
+function chunkBlocks(blocks: Array<Record<string, unknown>>, size: number): Array<Array<Record<string, unknown>>> {
+  const chunks: Array<Array<Record<string, unknown>>> = [];
+  for (let index = 0; index < blocks.length; index += size) {
+    chunks.push(blocks.slice(index, index + size));
+  }
+  return chunks;
+}
+
+export class FetchNotionPublishClient implements NotionPublishClient {
+  private readonly fetchFn: NotionFetch;
+
+  constructor(private readonly token: string, fetchFn?: NotionFetch) {
+    this.fetchFn = fetchFn ?? (globalThis.fetch as unknown as NotionFetch);
+  }
+
+  private async request(path: string, init: RequestInit = {}): Promise<Record<string, unknown>> {
+    const response = await this.fetchFn(`https://api.notion.com/v1${path}`, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        "Notion-Version": "2022-06-28",
+        "Content-Type": "application/json",
+        ...(init.headers ?? {}),
+      },
+    });
+    const body = await readNotionJson(response);
+    if (!response.ok) {
+      throw new Error(`Notion API ${response.status}: ${String(body["message"] ?? "request failed")}`);
+    }
+    return body;
+  }
+
+  async createPage(input: { parentPageId: string; title: string }): Promise<string> {
+    const body = await this.request("/pages", {
+      method: "POST",
+      body: JSON.stringify({
+        parent: { page_id: input.parentPageId },
+        properties: {
+          title: {
+            title: [{ type: "text", text: { content: input.title } }],
+          },
+        },
+      }),
+    });
+    const id = body["id"];
+    if (typeof id !== "string") {
+      throw new Error("Notion create page response did not include an id");
+    }
+    return id;
+  }
+
+  async replacePageMarkdown(input: { pageId: string; title: string; markdown: string }): Promise<void> {
+    let cursor: string | undefined;
+    do {
+      const suffix = cursor ? `&start_cursor=${encodeURIComponent(cursor)}` : "";
+      const children = await this.request(`/blocks/${input.pageId}/children?page_size=100${suffix}`, { method: "GET" });
+      for (const child of Array.isArray(children["results"]) ? children["results"] : []) {
+        const record = asRecord(child);
+        if (typeof record["id"] === "string") {
+          await this.request(`/blocks/${record["id"]}`, { method: "DELETE" });
+        }
+      }
+      cursor = children["has_more"] === true && typeof children["next_cursor"] === "string"
+        ? children["next_cursor"]
+        : undefined;
+    } while (cursor);
+
+    const blocks = [
+      {
+        object: "block",
+        type: "heading_2",
+        heading_2: { rich_text: [{ type: "text", text: { content: input.title } }] },
+      },
+      ...textBlocks(input.markdown || "\n"),
+    ];
+    for (const children of chunkBlocks(blocks, 90)) {
+      await this.request(`/blocks/${input.pageId}/children`, {
+        method: "PATCH",
+        body: JSON.stringify({ children }),
+      });
+    }
+  }
+
+  async archivePage(input: { pageId: string }): Promise<void> {
+    await this.request(`/pages/${input.pageId}`, {
+      method: "PATCH",
+      body: JSON.stringify({ archived: true }),
+    });
+  }
+}
+
+export async function publishNotionSnapshot(input: {
+  config: SoilPublishConfig;
+  files: SoilSnapshotFile[];
+  state: SoilPublishState;
+  dryRun?: boolean;
+  client?: NotionPublishClient;
+  clock?: () => Date;
+}): Promise<SoilPublishPageResult[]> {
+  const config = input.config.notion;
+  if (!config?.enabled) {
+    return [{ provider: "notion", relativePath: "", status: "skipped", message: "Notion publish is disabled" }];
+  }
+  if (!config.token || !config.parentPageId) {
+    return [{ provider: "notion", relativePath: "", status: "skipped", message: "Notion token and parentPageId are required" }];
+  }
+
+  const client = input.client ?? new FetchNotionPublishClient(config.token);
+  const results: SoilPublishPageResult[] = [];
+  const currentPaths = new Set(input.files.map((file) => file.relativePath));
+  for (const file of input.files) {
+    const existing = input.state.notion.pages[file.relativePath];
+    if (existing?.source_hash === file.sourceHash && existing.notion_page_id) {
+      results.push({
+        provider: "notion",
+        relativePath: file.relativePath,
+        status: "skipped",
+        sourceHash: file.sourceHash,
+        destinationId: existing.notion_page_id,
+        message: "source hash unchanged",
+      });
+      continue;
+    }
+    if (input.dryRun) {
+      results.push({ provider: "notion", relativePath: file.relativePath, status: "dry_run", sourceHash: file.sourceHash });
+      continue;
+    }
+
+    try {
+      const title = `${config.titlePrefix ?? "Soil"} / ${file.relativePath}`;
+      const pageId = existing?.notion_page_id ?? await client.createPage({ parentPageId: config.parentPageId, title });
+      await client.replacePageMarkdown({ pageId, title, markdown: file.content });
+      input.state.notion.pages[file.relativePath] = {
+        notion_page_id: pageId,
+        source_hash: file.sourceHash,
+        published_at: (input.clock?.() ?? new Date()).toISOString(),
+      };
+      results.push({
+        provider: "notion",
+        relativePath: file.relativePath,
+        status: "published",
+        sourceHash: file.sourceHash,
+        destinationId: pageId,
+      });
+    } catch (error) {
+      results.push({
+        provider: "notion",
+        relativePath: file.relativePath,
+        status: "error",
+        sourceHash: file.sourceHash,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  for (const [relativePath, existing] of Object.entries(input.state.notion.pages)) {
+    if (currentPaths.has(relativePath)) {
+      continue;
+    }
+    if (input.dryRun) {
+      results.push({
+        provider: "notion",
+        relativePath,
+        status: "dry_run",
+        destinationId: existing.notion_page_id,
+        message: "stale Notion page would be archived",
+      });
+      continue;
+    }
+    try {
+      if (typeof client.archivePage === "function") {
+        await client.archivePage({ pageId: existing.notion_page_id, relativePath });
+      }
+      delete input.state.notion.pages[relativePath];
+      results.push({
+        provider: "notion",
+        relativePath,
+        status: "archived",
+        destinationId: existing.notion_page_id,
+        message: "Soil page no longer exists",
+      });
+    } catch (error) {
+      results.push({
+        provider: "notion",
+        relativePath,
+        status: "error",
+        destinationId: existing.notion_page_id,
+        message: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return results;
+}

--- a/src/platform/soil/publish/publisher.ts
+++ b/src/platform/soil/publish/publisher.ts
@@ -1,0 +1,79 @@
+import {
+  getSoilPublishStatePath,
+  loadSoilPublishConfig,
+  loadSoilPublishState,
+  resolveSoilPublishRoot,
+  saveSoilPublishState,
+  type SoilPublishConfigInput,
+} from "./config.js";
+import { publishAppleNotesSnapshot, type AppleNotesRunner } from "./apple-notes.js";
+import { publishNotionSnapshot, type NotionPublishClient } from "./notion.js";
+import { collectSoilSnapshotFiles, filterAppleNotesSnapshotFiles } from "./snapshot.js";
+import {
+  SoilPublishProviderSchema,
+  type SoilPublishProvider,
+  type SoilPublishProviderResult,
+  type SoilPublishResult,
+} from "./types.js";
+
+function providerStatus(pages: Array<{ status: string }>): SoilPublishProviderResult["status"] {
+  if (pages.length === 0 || pages.every((page) => page.status === "skipped")) {
+    return "skipped";
+  }
+  if (pages.some((page) => page.status === "error")) {
+    return "error";
+  }
+  return "ok";
+}
+
+export async function publishSoilSnapshots(input: SoilPublishConfigInput & {
+  provider?: SoilPublishProvider;
+  dryRun?: boolean;
+  notionClient?: NotionPublishClient;
+  appleNotesRunner?: AppleNotesRunner;
+  appleNotesPlatform?: NodeJS.Platform;
+  clock?: () => Date;
+} = {}): Promise<SoilPublishResult> {
+  const provider = SoilPublishProviderSchema.parse(input.provider ?? "all");
+  const rootDir = resolveSoilPublishRoot(input);
+  const config = await loadSoilPublishConfig({ rootDir });
+  const state = await loadSoilPublishState(rootDir);
+  const files = await collectSoilSnapshotFiles(rootDir);
+  const providers: SoilPublishProviderResult[] = [];
+
+  if (provider === "all" || provider === "notion") {
+    const pages = await publishNotionSnapshot({
+      config,
+      files,
+      state,
+      dryRun: input.dryRun,
+      client: input.notionClient,
+      clock: input.clock,
+    });
+    providers.push({ provider: "notion", status: providerStatus(pages), pages });
+  }
+
+  if (provider === "all" || provider === "apple_notes") {
+    const pages = await publishAppleNotesSnapshot({
+      config,
+      files: filterAppleNotesSnapshotFiles(files),
+      state,
+      dryRun: input.dryRun,
+      runner: input.appleNotesRunner,
+      platform: input.appleNotesPlatform,
+      clock: input.clock,
+    });
+    providers.push({ provider: "apple_notes", status: providerStatus(pages), pages });
+  }
+
+  if (!input.dryRun) {
+    await saveSoilPublishState(rootDir, state);
+  }
+
+  return {
+    rootDir,
+    dryRun: input.dryRun ?? false,
+    providers,
+    statePath: getSoilPublishStatePath(rootDir),
+  };
+}

--- a/src/platform/soil/publish/snapshot.ts
+++ b/src/platform/soil/publish/snapshot.ts
@@ -1,0 +1,45 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { computeSoilChecksum } from "../checksum.js";
+import type { SoilSnapshotFile } from "./types.js";
+
+const HIDDEN_DIRS = new Set([".index", ".publish", ".stale"]);
+
+function toPosix(value: string): string {
+  return value.split(path.sep).join("/");
+}
+
+async function walk(rootDir: string, dir: string, files: SoilSnapshotFile[]): Promise<void> {
+  const entries = await fsp.readdir(dir, { withFileTypes: true }).catch(() => []);
+  for (const entry of entries) {
+    if (entry.name.startsWith(".") || HIDDEN_DIRS.has(entry.name)) {
+      continue;
+    }
+    const absolutePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await walk(rootDir, absolutePath, files);
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".md")) {
+      continue;
+    }
+    const content = await fsp.readFile(absolutePath, "utf-8");
+    files.push({
+      relativePath: toPosix(path.relative(rootDir, absolutePath)),
+      absolutePath,
+      content,
+      sourceHash: computeSoilChecksum(content),
+    });
+  }
+}
+
+export async function collectSoilSnapshotFiles(rootDir: string): Promise<SoilSnapshotFile[]> {
+  const files: SoilSnapshotFile[] = [];
+  await walk(rootDir, rootDir, files);
+  return files.sort((left, right) => left.relativePath.localeCompare(right.relativePath));
+}
+
+export function filterAppleNotesSnapshotFiles(files: SoilSnapshotFile[]): SoilSnapshotFile[] {
+  const allowed = new Set(["status.md", "schedule/active.md"]);
+  return files.filter((file) => allowed.has(file.relativePath));
+}

--- a/src/platform/soil/publish/types.ts
+++ b/src/platform/soil/publish/types.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+export const SoilPublishProviderSchema = z.enum(["notion", "apple_notes", "all"]);
+export type SoilPublishProvider = z.infer<typeof SoilPublishProviderSchema>;
+
+export const SoilPublishConfigSchema = z.object({
+  notion: z.object({
+    enabled: z.boolean().default(false),
+    token: z.string().min(1).optional(),
+    parentPageId: z.string().min(1).optional(),
+    titlePrefix: z.string().default("Soil"),
+  }).optional(),
+  apple_notes: z.object({
+    enabled: z.boolean().default(false),
+    shortcutName: z.string().min(1).optional(),
+    folderName: z.string().min(1).optional(),
+  }).optional(),
+});
+export type SoilPublishConfig = z.infer<typeof SoilPublishConfigSchema>;
+
+export const SoilPublishStateSchema = z.object({
+  version: z.literal("soil-publish-state-v1").default("soil-publish-state-v1"),
+  notion: z.object({
+    pages: z.record(z.object({
+      notion_page_id: z.string(),
+      source_hash: z.string(),
+      published_at: z.string(),
+    })).default({}),
+  }).default({ pages: {} }),
+  apple_notes: z.object({
+    pages: z.record(z.object({
+      source_hash: z.string(),
+      published_at: z.string(),
+    })).default({}),
+  }).default({ pages: {} }),
+});
+export type SoilPublishState = z.infer<typeof SoilPublishStateSchema>;
+
+export interface SoilSnapshotFile {
+  relativePath: string;
+  absolutePath: string;
+  content: string;
+  sourceHash: string;
+}
+
+export interface SoilPublishPageResult {
+  provider: Exclude<SoilPublishProvider, "all">;
+  relativePath: string;
+  status: "published" | "archived" | "skipped" | "dry_run" | "error";
+  sourceHash?: string;
+  destinationId?: string;
+  message?: string;
+}
+
+export interface SoilPublishProviderResult {
+  provider: Exclude<SoilPublishProvider, "all">;
+  status: "ok" | "skipped" | "error";
+  pages: SoilPublishPageResult[];
+  message?: string;
+}
+
+export interface SoilPublishResult {
+  rootDir: string;
+  dryRun: boolean;
+  providers: SoilPublishProviderResult[];
+  statePath: string;
+}

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -1830,6 +1830,44 @@ describe("Cron execution (Phase 3)", () => {
     expect(memoryLifecycle.compressToLongTerm).toHaveBeenCalled();
     expect(fs.existsSync(path.join(tempDir, "reflections"))).toBe(true);
   });
+
+  it("executeCron runs soil_publish jobs without an LLM", async () => {
+    const eng = new ScheduleEngine({ baseDir: tempDir });
+    const entry = await eng.addEntry(makeCronEntry({
+      cron: {
+        job_kind: "soil_publish",
+        prompt_template: "Publish Soil snapshots",
+        context_sources: [],
+        output_format: "report",
+        report_type: "soil_publish",
+        max_tokens: 0,
+      },
+    }));
+
+    const result = await (eng as any).executeCron(entry);
+
+    expect(result.status).toBe("ok");
+    expect(result.output_summary).toContain("Soil publish completed");
+  });
+
+  it("ensures one 24h soil_publish schedule only when publish is configured", async () => {
+    const eng = new ScheduleEngine({ baseDir: tempDir });
+    await eng.loadEntries();
+    expect(await eng.ensureSoilPublishSchedule()).toBeNull();
+
+    fs.mkdirSync(path.join(tempDir, "soil"), { recursive: true });
+    fs.writeFileSync(path.join(tempDir, "soil", "publish.json"), JSON.stringify({
+      notion: { enabled: true, token: "secret", parentPageId: "parent" },
+    }), "utf-8");
+
+    const first = await eng.ensureSoilPublishSchedule();
+    const second = await eng.ensureSoilPublishSchedule();
+
+    expect(first?.cron?.job_kind).toBe("soil_publish");
+    expect(first?.trigger).toEqual({ type: "interval", seconds: 86400, jitter_factor: 0 });
+    expect(second?.id).toBe(first?.id);
+    expect(eng.getEntries().filter((entry) => entry.cron?.job_kind === "soil_publish")).toHaveLength(1);
+  });
 });
 
 // ─── Phase 3: GoalTrigger execution ───

--- a/src/runtime/__tests__/schedule-presets.test.ts
+++ b/src/runtime/__tests__/schedule-presets.test.ts
@@ -12,6 +12,7 @@ describe("schedule-presets", () => {
       "daily_brief",
       "weekly_review",
       "dream_consolidation",
+      "soil_publish",
       "goal_probe",
     ]);
   });
@@ -61,6 +62,27 @@ describe("schedule-presets", () => {
           threshold_value: 0.8,
           baseline_window: 7,
         }),
+      }),
+    }));
+  });
+
+  it("builds the soil publish preset as a 24h cron entry", () => {
+    const entry = buildSchedulePresetEntry(SchedulePresetInputSchema.parse({
+      preset: "soil_publish",
+    }));
+
+    expect(entry).toEqual(expect.objectContaining({
+      name: "Soil snapshot publish",
+      layer: "cron",
+      trigger: { type: "interval", seconds: 86400, jitter_factor: 0 },
+      metadata: expect.objectContaining({
+        source: "preset",
+        preset_key: "soil_publish",
+      }),
+      cron: expect.objectContaining({
+        job_kind: "soil_publish",
+        report_type: "soil_publish",
+        max_tokens: 0,
       }),
     }));
   });

--- a/src/runtime/schedule/engine-layers.ts
+++ b/src/runtime/schedule/engine-layers.ts
@@ -24,6 +24,7 @@ import {
   runWeeklyReview,
 } from "../../reflection/index.js";
 import { DreamAnalyzer } from "../../platform/dream/dream-analyzer.js";
+import { publishSoilSnapshots } from "../../platform/soil/index.js";
 
 interface LayerDeps {
   baseDir?: string;
@@ -237,6 +238,33 @@ export async function executeCron(entry: ScheduleEntry, deps: LayerDeps): Promis
         });
       }
       return executeReflectionCron(entry, deps, firedAt, start, cfg.reflection_kind);
+    }
+
+    if (cfg.job_kind === "soil_publish") {
+      if (!deps.baseDir) {
+        return ScheduleResultSchema.parse({
+          entry_id: entry.id,
+          status: "error",
+          duration_ms: 0,
+          error_message: "Soil publish cron requires baseDir",
+          fired_at: firedAt,
+          failure_kind: "permanent",
+        });
+      }
+      const result = await publishSoilSnapshots({ baseDir: deps.baseDir, provider: "all" });
+      const pageResults = result.providers.flatMap((provider) => provider.pages);
+      const errors = pageResults.filter((page) => page.status === "error");
+      const published = pageResults.filter((page) => page.status === "published");
+      const skipped = pageResults.filter((page) => page.status === "skipped");
+      return ScheduleResultSchema.parse({
+        entry_id: entry.id,
+        status: errors.length > 0 ? "error" : "ok",
+        duration_ms: Date.now() - start,
+        error_message: errors.length > 0 ? `${errors.length} Soil publish page(s) failed` : undefined,
+        fired_at: firedAt,
+        failure_kind: errors.length > 0 ? "transient" : undefined,
+        output_summary: `Soil publish completed: ${published.length} published, ${skipped.length} skipped, ${errors.length} errors`,
+      });
     }
 
     // Gather context from data sources

--- a/src/runtime/schedule/engine.ts
+++ b/src/runtime/schedule/engine.ts
@@ -35,6 +35,8 @@ import type { HookManager } from "../hook-manager.js";
 import type { MemoryLifecycleManager } from "../../platform/knowledge/memory/memory-lifecycle.js";
 import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
 import { projectSchedulesToSoil, rebuildSoilIndex } from "../../platform/soil/index.js";
+import { hasConfiguredSoilPublishProvider } from "../../platform/soil/publish/index.js";
+import { buildSchedulePresetEntry } from "./presets.js";
 
 const SCHEDULES_FILE = "schedules.json";
 const DEFAULT_RETRY_POLICY: ScheduleRetryPolicy = {
@@ -143,6 +145,21 @@ export class ScheduleEngine {
   async saveEntries(): Promise<void> {
     await writeJsonFileAtomic(this.schedulesPath, this.entries);
     await this.projectCurrentSchedulesToSoil();
+  }
+
+  async ensureSoilPublishSchedule(): Promise<ScheduleEntry | null> {
+    const configured = await hasConfiguredSoilPublishProvider({ baseDir: this.baseDir });
+    if (!configured) {
+      return null;
+    }
+    const existing = this.entries.find((entry) =>
+      entry.layer === "cron" &&
+      (entry.cron?.job_kind === "soil_publish" || entry.metadata?.preset_key === "soil_publish")
+    );
+    if (existing) {
+      return existing;
+    }
+    return this.addEntry(buildSchedulePresetEntry({ preset: "soil_publish" }));
   }
 
   private async projectCurrentSchedulesToSoil(): Promise<void> {

--- a/src/runtime/schedule/presets.ts
+++ b/src/runtime/schedule/presets.ts
@@ -46,6 +46,10 @@ export const DreamConsolidationPresetInputSchema = SchedulePresetBaseSchema.exte
   context_sources: z.array(z.string()).default([]),
 });
 
+export const SoilPublishPresetInputSchema = SchedulePresetBaseSchema.extend({
+  preset: z.literal("soil_publish"),
+});
+
 export const GoalProbePresetInputSchema = SchedulePresetBaseSchema.extend({
   preset: z.literal("goal_probe"),
   data_source_id: z.string().min(1),
@@ -62,6 +66,7 @@ export const SchedulePresetInputSchema = z.discriminatedUnion("preset", [
   DailyBriefPresetInputSchema,
   WeeklyReviewPresetInputSchema,
   DreamConsolidationPresetInputSchema,
+  SoilPublishPresetInputSchema,
   GoalProbePresetInputSchema,
 ]);
 
@@ -98,6 +103,13 @@ const PRESET_DEFINITIONS: Record<SchedulePresetKey, SchedulePresetDefinition> = 
     description: "Runs overnight consolidation for memory and stale knowledge cleanup.",
     defaultTrigger: { type: "cron", expression: "0 2 * * *", timezone: "UTC" },
     dependencyHints: ["memory_lifecycle", "knowledge_manager"],
+  },
+  soil_publish: {
+    key: "soil_publish",
+    title: "Soil snapshot publish",
+    description: "Publishes configured read-only Soil snapshots to external viewers.",
+    defaultTrigger: { type: "interval", seconds: 24 * 60 * 60, jitter_factor: 0 },
+    dependencyHints: ["soil_publish_config"],
   },
   goal_probe: {
     key: "goal_probe",
@@ -190,6 +202,19 @@ export function buildSchedulePresetEntry(input: SchedulePresetInput): CreateSche
           output_format: "report",
           report_type: "dream_consolidation",
           max_tokens: 1200,
+        },
+      };
+    case "soil_publish":
+      return {
+        ...base,
+        layer: "cron",
+        cron: {
+          job_kind: "soil_publish",
+          prompt_template: "Publish configured Soil snapshots.",
+          context_sources: [],
+          output_format: "report",
+          report_type: "soil_publish",
+          max_tokens: 0,
         },
       };
     case "goal_probe":

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -36,7 +36,7 @@ export const ReflectionJobKindSchema = z.enum([
 export type ReflectionJobKind = z.infer<typeof ReflectionJobKindSchema>;
 
 export const CronConfigSchema = z.object({
-  job_kind: z.enum(["prompt", "reflection"]).default("prompt"),
+  job_kind: z.enum(["prompt", "reflection", "soil_publish"]).default("prompt"),
   reflection_kind: ReflectionJobKindSchema.optional(),
   prompt_template: z.string(),
   context_sources: z.array(z.string()).default([]),

--- a/src/tools/builtin/index.ts
+++ b/src/tools/builtin/index.ts
@@ -21,6 +21,8 @@ export { ArchitectureTool } from "../query/ArchitectureTool/ArchitectureTool.js"
 export { SoilQueryTool } from "../query/SoilQueryTool/SoilQueryTool.js";
 export { SoilDoctorTool } from "../execution/SoilDoctorTool/SoilDoctorTool.js";
 export { SoilImportTool } from "../execution/SoilImportTool/SoilImportTool.js";
+export { SoilOpenTool } from "../execution/SoilOpenTool/SoilOpenTool.js";
+export { SoilPublishTool } from "../execution/SoilPublishTool/SoilPublishTool.js";
 export { SoilRebuildTool } from "../execution/SoilRebuildTool/SoilRebuildTool.js";
 export { WebSearchTool, createWebSearchClient } from "../network/WebSearchTool/WebSearchTool.js";
 export type { ISearchClient, SearchResult } from "../network/WebSearchTool/WebSearchTool.js";
@@ -87,6 +89,8 @@ import { ArchitectureTool } from "../query/ArchitectureTool/ArchitectureTool.js"
 import { SoilQueryTool } from "../query/SoilQueryTool/SoilQueryTool.js";
 import { SoilDoctorTool } from "../execution/SoilDoctorTool/SoilDoctorTool.js";
 import { SoilImportTool } from "../execution/SoilImportTool/SoilImportTool.js";
+import { SoilOpenTool } from "../execution/SoilOpenTool/SoilOpenTool.js";
+import { SoilPublishTool } from "../execution/SoilPublishTool/SoilPublishTool.js";
 import { SoilRebuildTool } from "../execution/SoilRebuildTool/SoilRebuildTool.js";
 import { WebSearchTool, createWebSearchClient } from "../network/WebSearchTool/WebSearchTool.js";
 import { ToolSearchTool } from "../query/ToolSearchTool/ToolSearchTool.js";
@@ -187,7 +191,15 @@ export function createBuiltinTools(deps?: BuiltinToolDeps): ITool[] {
     tools.push(new MemoryRecallTool(deps.knowledgeManager));
   }
 
-  tools.push(new ConfigTool(), new ArchitectureTool(), new SoilQueryTool(), new SoilDoctorTool(), new SoilImportTool());
+  tools.push(
+    new ConfigTool(),
+    new ArchitectureTool(),
+    new SoilQueryTool(),
+    new SoilDoctorTool(),
+    new SoilImportTool(),
+    new SoilOpenTool(),
+    new SoilPublishTool(),
+  );
 
   if (deps?.pluginLoader) {
     tools.push(new PluginStateTool(deps.pluginLoader));

--- a/src/tools/execution/SoilDoctorTool/__tests__/SoilDoctorTool.test.ts
+++ b/src/tools/execution/SoilDoctorTool/__tests__/SoilDoctorTool.test.ts
@@ -93,14 +93,15 @@ describe("SoilDoctorTool", () => {
 
   describe("call", () => {
     it("returns an empty report for a clean soil root", async () => {
-      await seedPage();
+      await seedPage({ soil_id: "index", kind: "index", route: "index", title: "Soil" });
+      await seedPage({ soil_id: "schedule/active", kind: "schedule", route: "schedule", title: "Active schedules" });
       await rebuildSoilIndex({ rootDir });
 
       const result = await tool.call({ rootDir }, makeContext());
 
       expect(result.success).toBe(true);
       const data = result.data as { report: { findingCount: number; errorCount: number; warnCount: number; totalPages: number }; findings: unknown[] };
-      expect(data.report.totalPages).toBe(1);
+      expect(data.report.totalPages).toBe(2);
       expect(data.report.findingCount).toBe(0);
       expect(data.report.errorCount).toBe(0);
       expect(data.report.warnCount).toBe(0);

--- a/src/tools/execution/SoilOpenTool/SoilOpenTool.ts
+++ b/src/tools/execution/SoilOpenTool/SoilOpenTool.ts
@@ -1,0 +1,76 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import { openSoil, type SoilOpenRunner } from "../../../platform/soil/index.js";
+import { ALIASES, MAX_OUTPUT_CHARS, PERMISSION_LEVEL, TAGS, TOOL_NAME } from "./constants.js";
+import { DESCRIPTION } from "./prompt.js";
+
+export const SoilOpenInputSchema = z.object({
+  rootDir: z.string().min(1).optional(),
+  viewer: z.enum(["default", "finder", "vscode", "obsidian", "logseq"]).default("default"),
+  target: z.enum(["root", "schedule_active", "status", "report", "schedule", "memory", "knowledge", "path"]).default("root"),
+  targetPath: z.string().min(1).optional(),
+});
+export type SoilOpenInput = z.infer<typeof SoilOpenInputSchema>;
+
+export class SoilOpenTool implements ITool<SoilOpenInput> {
+  readonly metadata: ToolMetadata = {
+    name: TOOL_NAME,
+    aliases: [...ALIASES],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: MAX_OUTPUT_CHARS,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = SoilOpenInputSchema;
+
+  constructor(private readonly runner?: SoilOpenRunner) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: SoilOpenInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    try {
+      const parsed = this.inputSchema.parse(input);
+      const result = await openSoil(parsed, this.runner);
+      return {
+        success: result.exitCode === 0,
+        data: result,
+        summary: result.exitCode === 0
+          ? `Opened Soil ${result.target} with ${result.viewer}: ${result.path}`
+          : `Soil open failed: ${result.stderr || `exit ${result.exitCode}`}`,
+        error: result.exitCode === 0 ? undefined : result.stderr || `exit ${result.exitCode}`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `Soil open failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(_input: SoilOpenInput, _context: ToolCallContext): Promise<PermissionCheckResult> {
+    return { status: "needs_approval", reason: "Opening Soil launches a local viewer application" };
+  }
+
+  isConcurrencySafe(_input?: SoilOpenInput): boolean {
+    return true;
+  }
+}

--- a/src/tools/execution/SoilOpenTool/__tests__/SoilOpenTool.test.ts
+++ b/src/tools/execution/SoilOpenTool/__tests__/SoilOpenTool.test.ts
@@ -1,0 +1,31 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
+import type { ToolCallContext } from "../../../types.js";
+import { SoilOpenTool } from "../SoilOpenTool.js";
+
+const makeContext = (): ToolCallContext => ({
+  cwd: "/tmp",
+  goalId: "goal-1",
+  trustBalance: 50,
+  preApproved: false,
+  approvalFn: async () => false,
+});
+
+describe("SoilOpenTool", () => {
+  it("opens Soil through an injected runner", async () => {
+    const rootDir = makeTempDir("soil-open-tool-");
+    try {
+      const calls: Array<{ command: string; args: string[] }> = [];
+      const tool = new SoilOpenTool(async (command, args) => {
+        calls.push({ command, args });
+        return { stdout: "", stderr: "", exitCode: 0 };
+      });
+      const result = await tool.call({ rootDir, viewer: "vscode", target: "schedule_active" }, makeContext());
+      expect(result.success).toBe(true);
+      expect(calls).toEqual([{ command: "code", args: [path.join(rootDir, "schedule", "active.md")] }]);
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+});

--- a/src/tools/execution/SoilOpenTool/constants.ts
+++ b/src/tools/execution/SoilOpenTool/constants.ts
@@ -1,0 +1,5 @@
+export const TAGS = ["soil", "open", "viewer"] as const;
+export const MAX_OUTPUT_CHARS = 4000;
+export const PERMISSION_LEVEL = "execute" as const;
+export const TOOL_NAME = "soil_open";
+export const ALIASES = ["open_soil", "soil_view"] as const;

--- a/src/tools/execution/SoilOpenTool/prompt.ts
+++ b/src/tools/execution/SoilOpenTool/prompt.ts
@@ -1,0 +1,2 @@
+export const DESCRIPTION =
+  "Open the local Soil Markdown tree or a Soil page in a local viewer such as Finder, VS Code, Obsidian, or Logseq.";

--- a/src/tools/execution/SoilPublishTool/SoilPublishTool.ts
+++ b/src/tools/execution/SoilPublishTool/SoilPublishTool.ts
@@ -1,0 +1,90 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import {
+  publishSoilSnapshots,
+  type AppleNotesRunner,
+  type NotionPublishClient,
+} from "../../../platform/soil/index.js";
+import { ALIASES, MAX_OUTPUT_CHARS, PERMISSION_LEVEL, TAGS, TOOL_NAME } from "./constants.js";
+import { DESCRIPTION } from "./prompt.js";
+
+export const SoilPublishInputSchema = z.object({
+  provider: z.enum(["notion", "apple_notes", "all"]).default("all"),
+  dryRun: z.boolean().default(false),
+  baseDir: z.string().min(1).optional(),
+  rootDir: z.string().min(1).optional(),
+});
+export type SoilPublishInput = z.infer<typeof SoilPublishInputSchema>;
+
+export class SoilPublishTool implements ITool<SoilPublishInput> {
+  readonly metadata: ToolMetadata = {
+    name: TOOL_NAME,
+    aliases: [...ALIASES],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: MAX_OUTPUT_CHARS,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = SoilPublishInputSchema;
+
+  constructor(private readonly deps: {
+    notionClient?: NotionPublishClient;
+    appleNotesRunner?: AppleNotesRunner;
+  } = {}) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: SoilPublishInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    try {
+      const parsed = this.inputSchema.parse(input);
+      const result = await publishSoilSnapshots({
+        ...parsed,
+        notionClient: this.deps.notionClient,
+        appleNotesRunner: this.deps.appleNotesRunner,
+      });
+      const pageCount = result.providers.reduce((sum, provider) => sum + provider.pages.length, 0);
+      const errors = result.providers.reduce((sum, provider) => sum + provider.pages.filter((page) => page.status === "error").length, 0);
+      return {
+        success: errors === 0,
+        data: result,
+        summary: `Soil publish ${result.dryRun ? "dry run " : ""}completed for ${result.providers.length} provider(s), ${pageCount} page result(s), ${errors} error(s)`,
+        error: errors === 0 ? undefined : `${errors} publish page result(s) failed`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `Soil publish failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(input: SoilPublishInput, _context: ToolCallContext): Promise<PermissionCheckResult> {
+    if (input.dryRun) {
+      return { status: "allowed" };
+    }
+    return { status: "needs_approval", reason: "Soil publish writes to configured external destinations" };
+  }
+
+  isConcurrencySafe(_input?: SoilPublishInput): boolean {
+    return false;
+  }
+}

--- a/src/tools/execution/SoilPublishTool/__tests__/SoilPublishTool.test.ts
+++ b/src/tools/execution/SoilPublishTool/__tests__/SoilPublishTool.test.ts
@@ -1,0 +1,40 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { cleanupTempDir, makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
+import { writeJsonFileAtomic } from "../../../../base/utils/json-io.js";
+import type { NotionPublishClient } from "../../../../platform/soil/index.js";
+import type { ToolCallContext } from "../../../types.js";
+import { SoilPublishTool } from "../SoilPublishTool.js";
+
+const makeContext = (): ToolCallContext => ({
+  cwd: "/tmp",
+  goalId: "goal-1",
+  trustBalance: 50,
+  preApproved: false,
+  approvalFn: async () => false,
+});
+
+describe("SoilPublishTool", () => {
+  it("runs a dry-run publish without writing to remote clients", async () => {
+    const rootDir = makeTempDir("soil-publish-tool-");
+    try {
+      await fsp.writeFile(path.join(rootDir, "status.md"), "# Status\n", "utf-8");
+      await writeJsonFileAtomic(path.join(rootDir, "publish.json"), {
+        notion: { enabled: true, token: "secret", parentPageId: "parent" },
+      });
+      const client: NotionPublishClient = {
+        createPage: vi.fn(async () => "page"),
+        replacePageMarkdown: vi.fn(async () => undefined),
+      };
+      const tool = new SoilPublishTool({ notionClient: client });
+      const result = await tool.call({ rootDir, provider: "notion", dryRun: true }, makeContext());
+      expect(result.success).toBe(true);
+      expect(client.createPage).not.toHaveBeenCalled();
+      expect(client.replacePageMarkdown).not.toHaveBeenCalled();
+      expect(result.summary).toContain("dry run");
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+});

--- a/src/tools/execution/SoilPublishTool/constants.ts
+++ b/src/tools/execution/SoilPublishTool/constants.ts
@@ -1,0 +1,5 @@
+export const TAGS = ["soil", "publish", "snapshot"] as const;
+export const MAX_OUTPUT_CHARS = 12000;
+export const PERMISSION_LEVEL = "write_remote" as const;
+export const TOOL_NAME = "soil_publish";
+export const ALIASES = ["publish_soil_snapshot", "soil_snapshot_publish"] as const;

--- a/src/tools/execution/SoilPublishTool/prompt.ts
+++ b/src/tools/execution/SoilPublishTool/prompt.ts
@@ -1,0 +1,2 @@
+export const DESCRIPTION =
+  "Publish read-only Soil snapshots to configured external viewers. Notion mirrors the Soil Markdown tree; Apple Notes publishes status.md and schedule/active.md only.";


### PR DESCRIPTION
## Summary
- add Soil local viewer open bridge and `soil_open` tool
- add Soil snapshot publish support with Notion full-tree read-copy mirror and Apple Notes status/schedule-only publish
- add `soil_publish` schedule preset, cron execution path, daemon ensure hook, and required Soil page doctor checks

## Validation
- `npx tsc --noEmit --pretty false`
- `npm run lint:boundaries`
- `git diff --check`
- `npm test`

## Notes
- Notion uses `~/.pulseed/soil/publish.json` plus `NOTION_TOKEN` when present.
- Apple Notes remains macOS best-effort through Shortcuts and only publishes `soil/status.md` and `soil/schedule/active.md`.
