### PR TITLE
[codex] add PulSeed chat input routing

### DIFF
--- a/plugins/discord-bot/README.md
+++ b/plugins/discord-bot/README.md
@@ -1,0 +1,39 @@
+# Discord Bot Plugin
+
+Discord interaction webhook integration for PulSeed.
+
+Inbound chat arrives through the Discord Interactions endpoint. Outbound
+messages use the Discord REST API so the plugin can send normal channel
+messages as well as reply to slash-command traffic.
+
+## Requirements
+
+- A Discord application with interactions enabled
+- A slash command named `pulseed` or a custom `command_name`
+- A bot token with permission to post in the configured channel
+- A public key for interaction verification
+
+## Configuration
+
+Create `config.json` in the plugin directory:
+
+```json
+{
+  "application_id": "123456789012345678",
+  "public_key_hex": "deadbeef...",
+  "bot_token": "Bot ...",
+  "channel_id": "123456789012345678",
+  "identity_key": "discord:team-a",
+  "command_name": "pulseed",
+  "host": "127.0.0.1",
+  "port": 8787
+}
+```
+
+## Notes
+
+- The shared cross-platform session manager receives `identity_key` inside the
+  inbound payload so the same conversation can continue across channels.
+- If `public_key_hex` is omitted, the webhook still works for local testing but
+  request verification is skipped.
+- Voice memo transcription is not implemented.

--- a/plugins/discord-bot/__tests__/config.test.ts
+++ b/plugins/discord-bot/__tests__/config.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadConfig } from "../src/config.js";
+
+describe("discord-bot config loader", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "discord-cfg-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it("loads the required config fields", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        application_id: "app-1",
+        bot_token: "bot-1",
+        channel_id: "chan-1",
+        identity_key: "discord:alpha",
+      }),
+      "utf-8"
+    );
+
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.application_id).toBe("app-1");
+    expect(cfg.command_name).toBe("pulseed");
+    expect(cfg.port).toBe(8787);
+    expect(cfg.ephemeral).toBe(false);
+  });
+
+  it("requires identity_key", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        application_id: "app-1",
+        bot_token: "bot-1",
+        channel_id: "chan-1",
+      }),
+      "utf-8"
+    );
+
+    expect(() => loadConfig(tmpDir)).toThrow("identity_key");
+  });
+});

--- a/plugins/discord-bot/__tests__/discord-api.test.ts
+++ b/plugins/discord-bot/__tests__/discord-api.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+import { DiscordAPI } from "../src/discord-api.js";
+
+describe("DiscordAPI", () => {
+  it("sends channel messages with the bot token", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+    const api = new DiscordAPI("bot-token", fetchMock as typeof fetch);
+
+    await api.sendChannelMessage("channel-1", "hello");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/channels/channel-1/messages");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bot bot-token");
+  });
+});

--- a/plugins/discord-bot/__tests__/discord-bot-plugin.test.ts
+++ b/plugins/discord-bot/__tests__/discord-bot-plugin.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDispatchChatInput = vi.hoisted(() => vi.fn());
+const mockServerStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockSendChannelMessage = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockSendFollowUp = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("pulseed", () => ({
+  getGlobalCrossPlatformChatSessionManager: vi.fn().mockResolvedValue({
+    processIncomingMessage: mockDispatchChatInput,
+  }),
+}));
+
+vi.mock("../src/discord-api.js", () => ({
+  DiscordAPI: class {
+    sendChannelMessage = mockSendChannelMessage;
+    sendInteractionFollowUp = mockSendFollowUp;
+  },
+}));
+
+vi.mock("../src/webhook-server.js", () => ({
+  DiscordWebhookServer: class {
+    start = mockServerStart;
+    stop = vi.fn().mockResolvedValue(undefined);
+    constructor(_config: unknown, _api: unknown) {}
+  },
+}));
+
+import { DiscordBotPlugin } from "../src/index.js";
+
+describe("DiscordBotPlugin", () => {
+  beforeEach(() => {
+    mockDispatchChatInput.mockReset();
+    mockServerStart.mockClear();
+    mockSendChannelMessage.mockClear();
+    mockSendFollowUp.mockClear();
+  });
+
+  it("passes identity_key into the shared manager payload", async () => {
+    mockDispatchChatInput.mockResolvedValue("reply text");
+    const plugin = new DiscordBotPlugin("/tmp/discord-plugin");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 204,
+    } as Response);
+
+    vi.spyOn(
+      await import("../src/config.js"),
+      "loadConfig"
+    ).mockReturnValue({
+      application_id: "app-1",
+      bot_token: "bot-1",
+      channel_id: "channel-1",
+      identity_key: "discord:alpha",
+      command_name: "pulseed",
+      host: "127.0.0.1",
+      port: 8787,
+      ephemeral: false,
+    });
+
+    await plugin.init();
+
+    expect(mockServerStart).toHaveBeenCalledTimes(1);
+    await plugin.notify({
+      type: "goal_complete",
+      goal_id: "goal-1",
+      timestamp: "2026-04-11T00:00:00.000Z",
+      summary: "Goal reached",
+      details: {},
+      severity: "info",
+    });
+
+    expect(mockSendChannelMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/discord-bot/__tests__/shared-manager.test.ts
+++ b/plugins/discord-bot/__tests__/shared-manager.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dispatchChatInput } from "../src/shared-manager.js";
+
+interface PulseedRuntimeGlobal {
+  __pulseedGetGlobalCrossPlatformChatSessionManager?: () => Promise<Record<string, unknown> | null>;
+}
+
+describe("discord-bot shared manager bridge", () => {
+  afterEach(() => {
+    delete (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+      .__pulseedGetGlobalCrossPlatformChatSessionManager;
+  });
+
+  it("dispatches through the PulSeed runtime manager injected by PluginLoader", async () => {
+    const processIncomingMessage = vi.fn().mockResolvedValue({ text: "discord reply" });
+    (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+      .__pulseedGetGlobalCrossPlatformChatSessionManager = vi.fn().mockResolvedValue({
+        processIncomingMessage,
+      });
+
+    const input = {
+      platform: "discord" as const,
+      identity_key: "person-a",
+      conversation_id: "channel-1",
+      sender_id: "user-1",
+      text: "hello",
+      metadata: {},
+    };
+
+    await expect(dispatchChatInput(input)).resolves.toBe("discord reply");
+    expect(processIncomingMessage).toHaveBeenCalledWith(input);
+  });
+});

--- a/plugins/discord-bot/package.json
+++ b/plugins/discord-bot/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@pulseed/discord-bot",
+  "version": "1.0.0",
+  "description": "Discord interaction webhook plugin for PulSeed — bidirectional chat",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "pulseed",
+    "plugin",
+    "discord",
+    "webhook",
+    "chat"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "pulseed": ">=0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/plugins/discord-bot/plugin.yaml
+++ b/plugins/discord-bot/plugin.yaml
@@ -1,0 +1,63 @@
+name: discord-bot
+version: "1.0.0"
+type: notifier
+capabilities:
+  - discord_notification
+  - bidirectional_chat
+supported_events:
+  - goal_complete
+  - approval_needed
+  - stall_detected
+  - task_blocked
+  - goal_progress
+  - trust_change
+  - schedule_change_detected
+  - schedule_heartbeat_failure
+  - schedule_escalation
+  - schedule_report_ready
+description: "Discord interaction webhook plugin for PulSeed — bidirectional chat"
+config_schema:
+  application_id:
+    type: string
+    required: true
+    description: "Discord application id used for interaction follow-ups"
+  public_key_hex:
+    type: string
+    required: false
+    description: "Discord interaction public key in hex form"
+  bot_token:
+    type: string
+    required: true
+    description: "Discord bot token used for outbound notifications"
+  channel_id:
+    type: string
+    required: true
+    description: "Channel id that receives outbound messages"
+  identity_key:
+    type: string
+    required: true
+    description: "Cross-platform identity key passed to the shared session manager"
+  command_name:
+    type: string
+    required: false
+    default: pulseed
+    description: "Slash command name that triggers chat handoff"
+  ephemeral:
+    type: boolean
+    required: false
+    default: false
+    description: "Whether slash-command acknowledgements are visible only to the caller"
+  port:
+    type: number
+    required: false
+    default: 8787
+    description: "Local webhook port"
+  host:
+    type: string
+    required: false
+    default: 127.0.0.1
+    description: "Local webhook host"
+entry_point: "dist/index.js"
+min_pulseed_version: "0.1.0"
+permissions:
+  network: true

--- a/plugins/discord-bot/src/config.ts
+++ b/plugins/discord-bot/src/config.ts
@@ -1,0 +1,80 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface DiscordBotConfig {
+  application_id: string;
+  public_key_hex?: string;
+  bot_token: string;
+  channel_id: string;
+  identity_key: string;
+  command_name: string;
+  host: string;
+  port: number;
+  ephemeral: boolean;
+}
+
+export function loadConfig(pluginDir: string): DiscordBotConfig {
+  const configPath = path.join(pluginDir, "config.json");
+  let raw: unknown;
+
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`discord-bot: failed to read config.json — ${msg}`);
+  }
+
+  return validateConfig(raw);
+}
+
+function validateConfig(raw: unknown): DiscordBotConfig {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("discord-bot: config must be a JSON object");
+  }
+
+  const cfg = raw as Record<string, unknown>;
+  const commandName = cfg["command_name"] ?? "pulseed";
+  const host = cfg["host"] ?? "127.0.0.1";
+  const port = cfg["port"] ?? 8787;
+  const ephemeral = cfg["ephemeral"] ?? false;
+
+  if (typeof cfg["application_id"] !== "string" || cfg["application_id"].length === 0) {
+    throw new Error("discord-bot: application_id must be a non-empty string");
+  }
+  if (typeof cfg["bot_token"] !== "string" || cfg["bot_token"].length === 0) {
+    throw new Error("discord-bot: bot_token must be a non-empty string");
+  }
+  if (typeof cfg["channel_id"] !== "string" || cfg["channel_id"].length === 0) {
+    throw new Error("discord-bot: channel_id must be a non-empty string");
+  }
+  if (typeof cfg["identity_key"] !== "string" || cfg["identity_key"].length === 0) {
+    throw new Error("discord-bot: identity_key must be a non-empty string");
+  }
+  if (typeof commandName !== "string" || commandName.length === 0) {
+    throw new Error("discord-bot: command_name must be a non-empty string");
+  }
+  if (typeof host !== "string" || host.length === 0) {
+    throw new Error("discord-bot: host must be a non-empty string");
+  }
+  if (typeof port !== "number" || !Number.isInteger(port)) {
+    throw new Error("discord-bot: port must be an integer");
+  }
+  if (typeof ephemeral !== "boolean") {
+    throw new Error("discord-bot: ephemeral must be a boolean");
+  }
+  if (cfg["public_key_hex"] !== undefined && typeof cfg["public_key_hex"] !== "string") {
+    throw new Error("discord-bot: public_key_hex must be a string when set");
+  }
+
+  return {
+    application_id: cfg["application_id"] as string,
+    public_key_hex: cfg["public_key_hex"] as string | undefined,
+    bot_token: cfg["bot_token"] as string,
+    channel_id: cfg["channel_id"] as string,
+    identity_key: cfg["identity_key"] as string,
+    command_name: commandName,
+    host,
+    port,
+    ephemeral,
+  };
+}

--- a/plugins/discord-bot/src/discord-api.ts
+++ b/plugins/discord-bot/src/discord-api.ts
@@ -1,0 +1,55 @@
+export interface DiscordOutboundMessage {
+  content: string;
+  allowed_mentions?: {
+    parse: string[];
+  };
+}
+
+export class DiscordAPI {
+  constructor(
+    private readonly botToken: string,
+    private readonly fetchImpl: typeof fetch = fetch
+  ) {}
+
+  async sendChannelMessage(channelId: string, content: string): Promise<void> {
+    const response = await this.fetchImpl(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bot ${this.botToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        content,
+        allowed_mentions: { parse: [] },
+      } satisfies DiscordOutboundMessage),
+    });
+
+    if (!response.ok) {
+      throw new Error(`discord-bot: channel send failed with ${response.status}`);
+    }
+  }
+
+  async sendInteractionFollowUp(
+    applicationId: string,
+    interactionToken: string,
+    content: string
+  ): Promise<void> {
+    const response = await this.fetchImpl(
+      `https://discord.com/api/v10/webhooks/${applicationId}/${interactionToken}`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          content,
+          allowed_mentions: { parse: [] },
+        } satisfies DiscordOutboundMessage),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`discord-bot: follow-up send failed with ${response.status}`);
+    }
+  }
+}

--- a/plugins/discord-bot/src/index.ts
+++ b/plugins/discord-bot/src/index.ts
@@ -1,0 +1,59 @@
+import type { INotifier, NotificationEvent, NotificationEventType } from "./types.js";
+import { loadConfig, type DiscordBotConfig } from "./config.js";
+import { DiscordAPI } from "./discord-api.js";
+import { DiscordWebhookServer } from "./webhook-server.js";
+
+const SUPPORTED_EVENTS: NotificationEventType[] = [
+  "goal_progress",
+  "goal_complete",
+  "task_blocked",
+  "approval_needed",
+  "stall_detected",
+  "trust_change",
+  "schedule_change_detected",
+  "schedule_heartbeat_failure",
+  "schedule_escalation",
+  "schedule_report_ready",
+];
+
+function formatNotification(event: NotificationEvent): string {
+  const detailKeys = Object.keys(event.details);
+  const detailSuffix = detailKeys.length > 0 ? ` | details: ${detailKeys.join(",")}` : "";
+  const content = typeof event.details["content"] === "string" ? `\n\n${event.details["content"]}` : "";
+  return `[${event.severity}] ${event.summary} (goal ${event.goal_id})${detailSuffix}${content}`;
+}
+
+export class DiscordBotPlugin implements INotifier {
+  readonly name = "discord-bot";
+
+  private config: DiscordBotConfig | null = null;
+  private api: DiscordAPI | null = null;
+  private server: DiscordWebhookServer | null = null;
+
+  constructor(private readonly pluginDir: string) {}
+
+  async init(): Promise<void> {
+    this.config = loadConfig(this.pluginDir);
+    this.api = new DiscordAPI(this.config.bot_token);
+    this.server = new DiscordWebhookServer(this.config, this.api);
+    await this.server.start();
+  }
+
+  supports(eventType: NotificationEventType): boolean {
+    return SUPPORTED_EVENTS.includes(eventType);
+  }
+
+  async notify(event: NotificationEvent): Promise<void> {
+    if (this.config === null || this.api === null) {
+      throw new Error("discord-bot: plugin not initialized");
+    }
+    await this.api.sendChannelMessage(this.config.channel_id, formatNotification(event));
+  }
+
+  async stop(): Promise<void> {
+    await this.server?.stop();
+    this.server = null;
+  }
+}
+
+export default DiscordBotPlugin;

--- a/plugins/discord-bot/src/shared-manager.ts
+++ b/plugins/discord-bot/src/shared-manager.ts
@@ -1,0 +1,77 @@
+export interface ChatContinuationInput {
+  platform: "discord";
+  identity_key: string;
+  conversation_id: string;
+  sender_id: string;
+  message_id?: string;
+  text: string;
+  metadata: Record<string, unknown>;
+}
+
+type SessionManagerMethod = (input: ChatContinuationInput) => Promise<unknown> | unknown;
+type SessionManagerProvider = () => Promise<Record<string, unknown> | null> | Record<string, unknown> | null;
+
+interface PulseedRuntimeGlobal {
+  __pulseedGetGlobalCrossPlatformChatSessionManager?: SessionManagerProvider;
+}
+
+export async function getGlobalCrossPlatformChatSessionManager(): Promise<Record<string, unknown> | null> {
+  const getter = (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+    .__pulseedGetGlobalCrossPlatformChatSessionManager;
+  if (typeof getter !== "function") {
+    return null;
+  }
+
+  try {
+    return await getter();
+  } catch {
+    return null;
+  }
+}
+
+export async function dispatchChatInput(input: ChatContinuationInput): Promise<string | null> {
+  const manager = await getGlobalCrossPlatformChatSessionManager();
+  if (manager === null) {
+    return null;
+  }
+
+  const methodNames = [
+    "processIncomingMessage",
+    "handleIncomingMessage",
+    "continueConversation",
+    "resumeConversation",
+    "routeIncomingMessage",
+    "processMessage",
+    "handleMessage",
+  ] as const;
+
+  for (const methodName of methodNames) {
+    const method = manager[methodName];
+    if (typeof method !== "function") {
+      continue;
+    }
+
+    const result = await (method as SessionManagerMethod).call(manager, input);
+    return normalizeManagerResult(result);
+  }
+
+  return null;
+}
+
+function normalizeManagerResult(result: unknown): string | null {
+  if (typeof result === "string" && result.trim().length > 0) {
+    return result;
+  }
+  if (typeof result === "object" && result !== null) {
+    const record = result as Record<string, unknown>;
+    const text = record["text"];
+    if (typeof text === "string" && text.trim().length > 0) {
+      return text;
+    }
+    const message = record["message"];
+    if (typeof message === "string" && message.trim().length > 0) {
+      return message;
+    }
+  }
+  return null;
+}

--- a/plugins/discord-bot/src/types.ts
+++ b/plugins/discord-bot/src/types.ts
@@ -1,0 +1,26 @@
+export type NotificationEventType =
+  | "goal_progress"
+  | "goal_complete"
+  | "task_blocked"
+  | "approval_needed"
+  | "stall_detected"
+  | "trust_change"
+  | "schedule_change_detected"
+  | "schedule_heartbeat_failure"
+  | "schedule_escalation"
+  | "schedule_report_ready";
+
+export interface NotificationEvent {
+  type: NotificationEventType;
+  goal_id: string;
+  timestamp: string;
+  summary: string;
+  details: Record<string, unknown>;
+  severity: "info" | "warning" | "critical";
+}
+
+export interface INotifier {
+  name: string;
+  notify(event: NotificationEvent): Promise<void>;
+  supports(eventType: NotificationEventType): boolean;
+}

--- a/plugins/discord-bot/src/webhook-server.ts
+++ b/plugins/discord-bot/src/webhook-server.ts
@@ -1,0 +1,208 @@
+import * as http from "node:http";
+import { createHash, webcrypto } from "node:crypto";
+import { DiscordAPI } from "./discord-api.js";
+import { dispatchChatInput, type ChatContinuationInput } from "./shared-manager.js";
+import type { DiscordBotConfig } from "./config.js";
+
+interface DiscordInteractionOption {
+  name: string;
+  value?: unknown;
+}
+
+interface DiscordInteractionPayload {
+  id?: string;
+  type?: number;
+  token?: string;
+  application_id?: string;
+  channel_id?: string;
+  guild_id?: string;
+  member?: {
+    user?: {
+      id?: string;
+      username?: string;
+    };
+  };
+  user?: {
+    id?: string;
+    username?: string;
+  };
+  data?: {
+    name?: string;
+    options?: DiscordInteractionOption[];
+  };
+}
+
+export class DiscordWebhookServer {
+  private server: http.Server | null = null;
+
+  constructor(
+    private readonly config: DiscordBotConfig,
+    private readonly api: DiscordAPI,
+    private readonly fetchChatReply: typeof dispatchChatInput = dispatchChatInput
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.server !== null) {
+      return;
+    }
+
+    this.server = http.createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+
+    await new Promise<void>((resolve) => {
+      this.server!.listen(this.config.port, this.config.host, resolve);
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.server === null) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      this.server!.close(() => resolve());
+    });
+    this.server = null;
+  }
+
+  async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    if (req.method !== "POST") {
+      this.respondJson(res, 405, { error: "method_not_allowed" });
+      return;
+    }
+
+    const body = await this.readBody(req);
+    if (body === null) {
+      this.respondJson(res, 400, { error: "invalid_body" });
+      return;
+    }
+
+    if (!(await this.verifyRequest(req, body))) {
+      this.respondJson(res, 401, { error: "invalid_signature" });
+      return;
+    }
+
+    let payload: DiscordInteractionPayload;
+    try {
+      payload = JSON.parse(body) as DiscordInteractionPayload;
+    } catch {
+      this.respondJson(res, 400, { error: "invalid_json" });
+      return;
+    }
+
+    if (payload.type === 1) {
+      this.respondJson(res, 200, { type: 1 });
+      return;
+    }
+
+    if (
+      payload.type !== 2 ||
+      payload.token === undefined ||
+      payload.application_id === undefined ||
+      payload.data?.name !== this.config.command_name
+    ) {
+      this.respondJson(res, 400, { error: "unsupported_interaction" });
+      return;
+    }
+
+    const text = this.extractCommandText(payload);
+    if (text === null) {
+      this.respondJson(res, 400, { error: "missing_message_text" });
+      return;
+    }
+
+    const senderId = payload.member?.user?.id ?? payload.user?.id ?? "discord-user";
+    const conversationId = payload.channel_id ?? payload.guild_id ?? payload.id ?? senderId;
+    const input: ChatContinuationInput = {
+      platform: "discord",
+      identity_key: this.config.identity_key,
+      conversation_id: conversationId,
+      sender_id: senderId,
+      message_id: payload.id,
+      text,
+      metadata: {
+        interaction_type: payload.type,
+        command_name: payload.data?.name,
+        channel_id: payload.channel_id,
+        guild_id: payload.guild_id,
+      },
+    };
+
+    void this.processIncomingMessage(payload, input).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[discord-bot] failed to process interaction: ${msg}`);
+    });
+    this.respondJson(res, 200, { type: 5, data: this.config.ephemeral ? { flags: 64 } : undefined });
+  }
+
+  private async processIncomingMessage(
+    payload: DiscordInteractionPayload,
+    input: ChatContinuationInput
+  ): Promise<void> {
+    const reply = await this.fetchChatReply(input);
+    const content = reply ?? "Received.";
+
+    if (payload.application_id !== undefined && payload.token !== undefined) {
+      await this.api.sendInteractionFollowUp(payload.application_id, payload.token, content);
+    }
+  }
+
+  private extractCommandText(payload: DiscordInteractionPayload): string | null {
+    const options = payload.data?.options ?? [];
+    for (const option of options) {
+      if (option.name === "message" || option.name === "text" || option.name === "content") {
+        if (typeof option.value === "string" && option.value.trim().length > 0) {
+          return option.value;
+        }
+      }
+    }
+    return null;
+  }
+
+  private async verifyRequest(req: http.IncomingMessage, body: string): Promise<boolean> {
+    if (this.config.public_key_hex === undefined || this.config.public_key_hex.length === 0) {
+      return true;
+    }
+
+    const signature = req.headers["x-signature-ed25519"];
+    const timestamp = req.headers["x-signature-timestamp"];
+    if (typeof signature !== "string" || typeof timestamp !== "string") {
+      return false;
+    }
+
+    const publicKeyBytes = Uint8Array.from(Buffer.from(this.config.public_key_hex, "hex"));
+    let key: CryptoKey;
+    try {
+      key = await webcrypto.subtle.importKey("raw", publicKeyBytes, { name: "Ed25519" }, false, ["verify"]);
+    } catch {
+      return false;
+    }
+
+    const messageBytes = new TextEncoder().encode(timestamp + body);
+    try {
+      return await webcrypto.subtle.verify(
+        { name: "Ed25519" },
+        key,
+        Buffer.from(signature, "hex"),
+        messageBytes
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  private async readBody(req: http.IncomingMessage): Promise<string | null> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    return Buffer.concat(chunks).toString("utf-8");
+  }
+
+  private respondJson(res: http.ServerResponse, statusCode: number, payload: unknown): void {
+    res.statusCode = statusCode;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(payload));
+  }
+}

--- a/plugins/discord-bot/tsconfig.json
+++ b/plugins/discord-bot/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/discord-bot/vitest.config.ts
+++ b/plugins/discord-bot/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/plugins/signal-bridge/README.md
+++ b/plugins/signal-bridge/README.md
@@ -1,0 +1,31 @@
+# Signal Bridge Plugin
+
+Signal integration for PulSeed using a `signal-cli` REST bridge.
+
+This plugin polls the bridge for inbound messages and sends outbound replies
+through the same bridge. That keeps the integration dependency-free while still
+matching the real deployment boundary for Signal.
+
+## Requirements
+
+- A running `signal-cli` REST bridge
+- A registered Signal account for the bridge
+
+## Configuration
+
+```json
+{
+  "bridge_url": "http://127.0.0.1:7583",
+  "account": "+15551234567",
+  "recipient_id": "+15557654321",
+  "identity_key": "signal:ops",
+  "poll_interval_ms": 5000,
+  "receive_timeout_ms": 2000
+}
+```
+
+## Notes
+
+- The bridge API can vary slightly by deployment. The client uses a small set
+  of compatible receive endpoints and falls back between them.
+- Voice memo transcription is not implemented.

--- a/plugins/signal-bridge/__tests__/config.test.ts
+++ b/plugins/signal-bridge/__tests__/config.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadConfig } from "../src/config.js";
+
+describe("signal-bridge config loader", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "signal-cfg-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it("loads the required config fields", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        bridge_url: "http://127.0.0.1:7583",
+        account: "+15551234567",
+        recipient_id: "+15557654321",
+        identity_key: "signal:alpha",
+      }),
+      "utf-8"
+    );
+
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.poll_interval_ms).toBe(5000);
+    expect(cfg.receive_timeout_ms).toBe(2000);
+  });
+
+  it("requires account", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        bridge_url: "http://127.0.0.1:7583",
+        recipient_id: "+15557654321",
+        identity_key: "signal:alpha",
+      }),
+      "utf-8"
+    );
+
+    expect(() => loadConfig(tmpDir)).toThrow("account");
+  });
+});

--- a/plugins/signal-bridge/__tests__/shared-manager.test.ts
+++ b/plugins/signal-bridge/__tests__/shared-manager.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dispatchChatInput } from "../src/shared-manager.js";
+
+interface PulseedRuntimeGlobal {
+  __pulseedGetGlobalCrossPlatformChatSessionManager?: () => Promise<Record<string, unknown> | null>;
+}
+
+describe("signal-bridge shared manager bridge", () => {
+  afterEach(() => {
+    delete (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+      .__pulseedGetGlobalCrossPlatformChatSessionManager;
+  });
+
+  it("dispatches through the PulSeed runtime manager injected by PluginLoader", async () => {
+    const processIncomingMessage = vi.fn().mockResolvedValue("signal reply");
+    (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+      .__pulseedGetGlobalCrossPlatformChatSessionManager = vi.fn().mockResolvedValue({
+        processIncomingMessage,
+      });
+
+    const input = {
+      platform: "signal" as const,
+      identity_key: "person-a",
+      conversation_id: "+15551234567",
+      sender_id: "+15551234567",
+      text: "hello",
+      metadata: {},
+    };
+
+    await expect(dispatchChatInput(input)).resolves.toBe("signal reply");
+    expect(processIncomingMessage).toHaveBeenCalledWith(input);
+  });
+});

--- a/plugins/signal-bridge/__tests__/signal-client.test.ts
+++ b/plugins/signal-bridge/__tests__/signal-client.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { SignalBridgeClient } from "../src/signal-client.js";
+
+describe("SignalBridgeClient", () => {
+  it("posts outbound messages to the bridge", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const client = new SignalBridgeClient("http://127.0.0.1:7583", "+15551234567", fetchMock as typeof fetch);
+
+    await client.sendTextMessage({ recipient: "+15557654321", body: "hello" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/v2/send");
+    const body = JSON.parse(init.body as string) as { number: string; recipients: string[] };
+    expect(body.number).toBe("+15551234567");
+    expect(body.recipients).toEqual(["+15557654321"]);
+  });
+});

--- a/plugins/signal-bridge/__tests__/signal-poller.test.ts
+++ b/plugins/signal-bridge/__tests__/signal-poller.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SignalBridgeClient } from "../src/signal-client.js";
+import { SignalBridgePoller } from "../src/poller.js";
+
+describe("SignalBridgePoller", () => {
+  const fetchMock = vi.fn();
+  const client = new SignalBridgeClient("http://127.0.0.1:7583", "+15551234567", fetchMock as typeof fetch);
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("passes identity_key to the shared manager and replies", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            id: "msg-1",
+            sender: "+15557654321",
+            message: "hello",
+            timestamp: 1,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+
+    const replyHandler = vi.fn().mockResolvedValue("reply text");
+    const poller = new SignalBridgePoller(
+      {
+        bridge_url: "http://127.0.0.1:7583",
+        account: "+15551234567",
+        recipient_id: "+15557654321",
+        identity_key: "signal:alpha",
+        poll_interval_ms: 5000,
+        receive_timeout_ms: 2000,
+      },
+      client,
+      replyHandler
+    );
+
+    await poller.pollOnce();
+
+    expect(replyHandler).toHaveBeenCalledTimes(1);
+    expect(replyHandler.mock.calls[0]?.[0]).toMatchObject({
+      identity_key: "signal:alpha",
+      sender_id: "+15557654321",
+      text: "hello",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/signal-bridge/package.json
+++ b/plugins/signal-bridge/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@pulseed/signal-bridge",
+  "version": "1.0.0",
+  "description": "signal-cli REST bridge plugin for PulSeed — bidirectional chat",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "pulseed",
+    "plugin",
+    "signal",
+    "bridge",
+    "chat"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "pulseed": ">=0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/plugins/signal-bridge/plugin.yaml
+++ b/plugins/signal-bridge/plugin.yaml
@@ -1,0 +1,49 @@
+name: signal-bridge
+version: "1.0.0"
+type: notifier
+capabilities:
+  - signal_notification
+  - bidirectional_chat
+supported_events:
+  - goal_progress
+  - goal_complete
+  - task_blocked
+  - approval_needed
+  - stall_detected
+  - trust_change
+  - schedule_change_detected
+  - schedule_heartbeat_failure
+  - schedule_escalation
+  - schedule_report_ready
+description: "signal-cli REST bridge plugin for PulSeed — bidirectional chat"
+config_schema:
+  bridge_url:
+    type: string
+    required: true
+    description: "signal-cli REST bridge base URL"
+  account:
+    type: string
+    required: true
+    description: "Signal account/number used for send and receive"
+  recipient_id:
+    type: string
+    required: true
+    description: "Default recipient used for outbound notifications"
+  identity_key:
+    type: string
+    required: true
+    description: "Cross-platform identity key passed to the shared session manager"
+  poll_interval_ms:
+    type: number
+    required: false
+    default: 5000
+    description: "Polling interval for inbound messages"
+  receive_timeout_ms:
+    type: number
+    required: false
+    default: 2000
+    description: "Bridge receive timeout"
+entry_point: "dist/index.js"
+min_pulseed_version: "0.1.0"
+permissions:
+  network: true

--- a/plugins/signal-bridge/src/config.ts
+++ b/plugins/signal-bridge/src/config.ts
@@ -1,0 +1,63 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface SignalBridgeConfig {
+  bridge_url: string;
+  account: string;
+  recipient_id: string;
+  identity_key: string;
+  poll_interval_ms: number;
+  receive_timeout_ms: number;
+}
+
+export function loadConfig(pluginDir: string): SignalBridgeConfig {
+  const configPath = path.join(pluginDir, "config.json");
+  let raw: unknown;
+
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`signal-bridge: failed to read config.json — ${msg}`);
+  }
+
+  return validateConfig(raw);
+}
+
+function validateConfig(raw: unknown): SignalBridgeConfig {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("signal-bridge: config must be a JSON object");
+  }
+
+  const cfg = raw as Record<string, unknown>;
+  const pollInterval = cfg["poll_interval_ms"] ?? 5000;
+  const receiveTimeout = cfg["receive_timeout_ms"] ?? 2000;
+
+  if (typeof cfg["bridge_url"] !== "string" || cfg["bridge_url"].length === 0) {
+    throw new Error("signal-bridge: bridge_url must be a non-empty string");
+  }
+  if (typeof cfg["account"] !== "string" || cfg["account"].length === 0) {
+    throw new Error("signal-bridge: account must be a non-empty string");
+  }
+  if (typeof cfg["recipient_id"] !== "string" || cfg["recipient_id"].length === 0) {
+    throw new Error("signal-bridge: recipient_id must be a non-empty string");
+  }
+  if (typeof cfg["identity_key"] !== "string" || cfg["identity_key"].length === 0) {
+    throw new Error("signal-bridge: identity_key must be a non-empty string");
+  }
+  if (typeof pollInterval !== "number" || !Number.isInteger(pollInterval)) {
+    throw new Error("signal-bridge: poll_interval_ms must be an integer");
+  }
+  if (typeof receiveTimeout !== "number" || !Number.isInteger(receiveTimeout)) {
+    throw new Error("signal-bridge: receive_timeout_ms must be an integer");
+  }
+
+  return {
+    bridge_url: cfg["bridge_url"] as string,
+    account: cfg["account"] as string,
+    recipient_id: cfg["recipient_id"] as string,
+    identity_key: cfg["identity_key"] as string,
+    poll_interval_ms: Math.max(1000, pollInterval),
+    receive_timeout_ms: Math.max(250, receiveTimeout),
+  };
+}

--- a/plugins/signal-bridge/src/index.ts
+++ b/plugins/signal-bridge/src/index.ts
@@ -1,0 +1,63 @@
+import type { INotifier, NotificationEvent, NotificationEventType } from "./types.js";
+import { loadConfig, type SignalBridgeConfig } from "./config.js";
+import { SignalBridgeClient } from "./signal-client.js";
+import { SignalBridgePoller } from "./poller.js";
+
+const SUPPORTED_EVENTS: NotificationEventType[] = [
+  "goal_progress",
+  "goal_complete",
+  "task_blocked",
+  "approval_needed",
+  "stall_detected",
+  "trust_change",
+  "schedule_change_detected",
+  "schedule_heartbeat_failure",
+  "schedule_escalation",
+  "schedule_report_ready",
+];
+
+function formatNotification(event: NotificationEvent): string {
+  const detailKeys = Object.keys(event.details);
+  const detailSuffix = detailKeys.length > 0 ? ` | details: ${detailKeys.join(",")}` : "";
+  const content = typeof event.details["content"] === "string" ? `\n\n${event.details["content"]}` : "";
+  return `[${event.severity}] ${event.summary} (goal ${event.goal_id})${detailSuffix}${content}`;
+}
+
+export class SignalBridgePlugin implements INotifier {
+  readonly name = "signal-bridge";
+
+  private config: SignalBridgeConfig | null = null;
+  private client: SignalBridgeClient | null = null;
+  private poller: SignalBridgePoller | null = null;
+
+  constructor(private readonly pluginDir: string) {}
+
+  async init(): Promise<void> {
+    this.config = loadConfig(this.pluginDir);
+    this.client = new SignalBridgeClient(this.config.bridge_url, this.config.account);
+    this.poller = new SignalBridgePoller(this.config, this.client);
+    this.poller.start();
+  }
+
+  supports(eventType: NotificationEventType): boolean {
+    return SUPPORTED_EVENTS.includes(eventType);
+  }
+
+  async notify(event: NotificationEvent): Promise<void> {
+    if (this.config === null || this.client === null) {
+      throw new Error("signal-bridge: plugin not initialized");
+    }
+
+    await this.client.sendTextMessage({
+      recipient: this.config.recipient_id,
+      body: formatNotification(event),
+    });
+  }
+
+  stop(): void {
+    this.poller?.stop();
+    this.poller = null;
+  }
+}
+
+export default SignalBridgePlugin;

--- a/plugins/signal-bridge/src/poller.ts
+++ b/plugins/signal-bridge/src/poller.ts
@@ -1,0 +1,102 @@
+import { SignalBridgeClient, type SignalReceivedMessage } from "./signal-client.js";
+import { dispatchChatInput, type ChatContinuationInput } from "./shared-manager.js";
+import type { SignalBridgeConfig } from "./config.js";
+
+export class SignalBridgePoller {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly seenMessageIds = new Set<string>();
+
+  constructor(
+    private readonly config: SignalBridgeConfig,
+    private readonly client: SignalBridgeClient,
+    private readonly fetchChatReply: typeof dispatchChatInput = dispatchChatInput
+  ) {}
+
+  start(): void {
+    if (this.timer !== null) {
+      return;
+    }
+
+    void this.pollOnce().catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[signal-bridge] poll failed: ${msg}`);
+    });
+    this.timer = setInterval(() => {
+      void this.pollOnce().catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[signal-bridge] poll failed: ${msg}`);
+      });
+    }, this.config.poll_interval_ms);
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async pollOnce(): Promise<void> {
+    const messages = await this.client.receiveMessages(this.config.receive_timeout_ms);
+    for (const message of messages) {
+      const normalized = this.normalizeMessage(message);
+      if (normalized === null) {
+        continue;
+      }
+
+      if (this.seenMessageIds.has(normalized.messageId)) {
+        continue;
+      }
+      this.seenMessageIds.add(normalized.messageId);
+
+      const reply = await this.fetchChatReply({
+        platform: "signal",
+        identity_key: this.config.identity_key,
+        conversation_id: normalized.conversationId,
+        sender_id: normalized.senderId,
+        message_id: normalized.messageId,
+        text: normalized.text,
+        metadata: normalized.metadata,
+      });
+
+      if (reply !== null) {
+        await this.client.sendTextMessage({
+          recipient: normalized.senderId,
+          body: reply,
+        });
+      }
+    }
+  }
+
+  private normalizeMessage(message: SignalReceivedMessage): {
+    messageId: string;
+    conversationId: string;
+    senderId: string;
+    text: string;
+    metadata: Record<string, unknown>;
+  } | null {
+    const text = typeof message.message === "string"
+      ? message.message
+      : typeof message.body === "string"
+        ? message.body
+        : null;
+    const senderId = message.sender ?? message.sender_number ?? message.source ?? null;
+    if (text === null || senderId === null) {
+      return null;
+    }
+
+    const messageId = message.id ?? `${senderId}:${message.timestamp ?? Date.now()}:${text}`;
+    const conversationId = message.groupId ?? message.conversationId ?? senderId;
+    return {
+      messageId,
+      conversationId,
+      senderId,
+      text,
+      metadata: {
+        source: message.source,
+        timestamp: message.timestamp,
+        group_id: message.groupId,
+      },
+    };
+  }
+}

--- a/plugins/signal-bridge/src/shared-manager.ts
+++ b/plugins/signal-bridge/src/shared-manager.ts
@@ -1,0 +1,77 @@
+export interface ChatContinuationInput {
+  platform: "signal";
+  identity_key: string;
+  conversation_id: string;
+  sender_id: string;
+  message_id?: string;
+  text: string;
+  metadata: Record<string, unknown>;
+}
+
+type SessionManagerMethod = (input: ChatContinuationInput) => Promise<unknown> | unknown;
+type SessionManagerProvider = () => Promise<Record<string, unknown> | null> | Record<string, unknown> | null;
+
+interface PulseedRuntimeGlobal {
+  __pulseedGetGlobalCrossPlatformChatSessionManager?: SessionManagerProvider;
+}
+
+export async function getGlobalCrossPlatformChatSessionManager(): Promise<Record<string, unknown> | null> {
+  const getter = (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+    .__pulseedGetGlobalCrossPlatformChatSessionManager;
+  if (typeof getter !== "function") {
+    return null;
+  }
+
+  try {
+    return await getter();
+  } catch {
+    return null;
+  }
+}
+
+export async function dispatchChatInput(input: ChatContinuationInput): Promise<string | null> {
+  const manager = await getGlobalCrossPlatformChatSessionManager();
+  if (manager === null) {
+    return null;
+  }
+
+  const methodNames = [
+    "processIncomingMessage",
+    "handleIncomingMessage",
+    "continueConversation",
+    "resumeConversation",
+    "routeIncomingMessage",
+    "processMessage",
+    "handleMessage",
+  ] as const;
+
+  for (const methodName of methodNames) {
+    const method = manager[methodName];
+    if (typeof method !== "function") {
+      continue;
+    }
+
+    const result = await (method as SessionManagerMethod).call(manager, input);
+    return normalizeManagerResult(result);
+  }
+
+  return null;
+}
+
+function normalizeManagerResult(result: unknown): string | null {
+  if (typeof result === "string" && result.trim().length > 0) {
+    return result;
+  }
+  if (typeof result === "object" && result !== null) {
+    const record = result as Record<string, unknown>;
+    const text = record["text"];
+    if (typeof text === "string" && text.trim().length > 0) {
+      return text;
+    }
+    const message = record["message"];
+    if (typeof message === "string" && message.trim().length > 0) {
+      return message;
+    }
+  }
+  return null;
+}

--- a/plugins/signal-bridge/src/signal-client.ts
+++ b/plugins/signal-bridge/src/signal-client.ts
@@ -1,0 +1,95 @@
+export interface SignalOutboundMessage {
+  recipient: string;
+  body: string;
+}
+
+export interface SignalReceivedMessage {
+  id?: string;
+  sender?: string;
+  sender_number?: string;
+  source?: string;
+  message?: string;
+  body?: string;
+  timestamp?: number;
+  conversationId?: string;
+  groupId?: string;
+}
+
+export class SignalBridgeClient {
+  constructor(
+    private readonly bridgeUrl: string,
+    private readonly account: string,
+    private readonly fetchImpl: typeof fetch = fetch
+  ) {}
+
+  async sendTextMessage(message: SignalOutboundMessage): Promise<void> {
+    const response = await this.fetchImpl(`${this.bridgeUrl}/v2/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: message.body,
+        recipients: [message.recipient],
+        number: this.account,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "(unreadable)");
+      throw new Error(`signal-bridge: send failed with ${response.status}: ${body}`);
+    }
+  }
+
+  async receiveMessages(timeoutMs: number): Promise<SignalReceivedMessage[]> {
+    const endpoints = [
+      `${this.bridgeUrl}/v1/receive/${encodeURIComponent(this.account)}?timeout=${timeoutMs}`,
+      `${this.bridgeUrl}/v2/receive/${encodeURIComponent(this.account)}?timeout=${timeoutMs}`,
+      `${this.bridgeUrl}/v1/receive`,
+    ];
+
+    for (const endpoint of endpoints) {
+      const response = await this.fetchImpl(endpoint, {
+        method: endpoint.endsWith("/v1/receive") ? "POST" : "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: endpoint.endsWith("/v1/receive")
+          ? JSON.stringify({ number: this.account, timeout: timeoutMs })
+          : undefined,
+      });
+
+      if (!response.ok) {
+        continue;
+      }
+
+      const payload = (await response.json().catch(() => null)) as unknown;
+      const messages = normalizeReceiveResponse(payload);
+      if (messages !== null) {
+        return messages;
+      }
+    }
+
+    return [];
+  }
+}
+
+function normalizeReceiveResponse(payload: unknown): SignalReceivedMessage[] | null {
+  if (Array.isArray(payload)) {
+    return payload as SignalReceivedMessage[];
+  }
+  if (typeof payload === "object" && payload !== null) {
+    const record = payload as Record<string, unknown>;
+    const messages = record["messages"];
+    if (Array.isArray(messages)) {
+      return messages as SignalReceivedMessage[];
+    }
+    if (Array.isArray(record["data"])) {
+      return record["data"] as SignalReceivedMessage[];
+    }
+    if (typeof record["message"] === "string" || typeof record["sender"] === "string") {
+      return [record as SignalReceivedMessage];
+    }
+  }
+  return null;
+}

--- a/plugins/signal-bridge/src/types.ts
+++ b/plugins/signal-bridge/src/types.ts
@@ -1,0 +1,26 @@
+export type NotificationEventType =
+  | "goal_progress"
+  | "goal_complete"
+  | "task_blocked"
+  | "approval_needed"
+  | "stall_detected"
+  | "trust_change"
+  | "schedule_change_detected"
+  | "schedule_heartbeat_failure"
+  | "schedule_escalation"
+  | "schedule_report_ready";
+
+export interface NotificationEvent {
+  type: NotificationEventType;
+  goal_id: string;
+  timestamp: string;
+  summary: string;
+  details: Record<string, unknown>;
+  severity: "info" | "warning" | "critical";
+}
+
+export interface INotifier {
+  name: string;
+  notify(event: NotificationEvent): Promise<void>;
+  supports(eventType: NotificationEventType): boolean;
+}

--- a/plugins/signal-bridge/tsconfig.json
+++ b/plugins/signal-bridge/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/signal-bridge/vitest.config.ts
+++ b/plugins/signal-bridge/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
@@ -89,9 +89,20 @@ describe("config — loadConfig", () => {
     expect(cfg.allow_all).toBe(true);
   });
 
+  it("accepts optional identity_key for cross-platform continuation", () => {
+    writeTmpConfig(tmpDir, { bot_token: "tok", chat_id: 1, identity_key: "personal" });
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.identity_key).toBe("personal");
+  });
+
   it("throws when allow_all is not a boolean", () => {
     writeTmpConfig(tmpDir, { bot_token: "tok", chat_id: 1, allow_all: "yes" });
     expect(() => loadConfig(tmpDir)).toThrow("allow_all");
+  });
+
+  it("throws when identity_key is empty", () => {
+    writeTmpConfig(tmpDir, { bot_token: "tok", chat_id: 1, identity_key: "" });
+    expect(() => loadConfig(tmpDir)).toThrow("identity_key");
   });
 
   it("throws when config.json does not exist", () => {

--- a/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
@@ -13,6 +13,7 @@ const mockBuildAdapterRegistry = vi.hoisted(() => vi.fn().mockResolvedValue({
   getAdapter: vi.fn().mockReturnValue({ adapterType: "openai_api" }),
 }));
 const mockCreateBuiltinTools = vi.hoisted(() => vi.fn().mockReturnValue([]));
+const mockGetGlobalCrossPlatformChatSessionManager = vi.hoisted(() => vi.fn().mockResolvedValue(null));
 
 vi.mock("pulseed", () => {
   class FakeStateManager {
@@ -53,6 +54,7 @@ vi.mock("pulseed", () => {
       register = vi.fn();
     },
     createBuiltinTools: mockCreateBuiltinTools,
+    getGlobalCrossPlatformChatSessionManager: mockGetGlobalCrossPlatformChatSessionManager,
   };
 });
 
@@ -66,6 +68,8 @@ describe("TelegramChatRunnerProcessor", () => {
     mockBuildLLMClient.mockClear();
     mockBuildAdapterRegistry.mockClear();
     mockCreateBuiltinTools.mockClear();
+    mockGetGlobalCrossPlatformChatSessionManager.mockReset();
+    mockGetGlobalCrossPlatformChatSessionManager.mockResolvedValue(null);
   });
 
   it("reuses one ChatRunner per chatId", async () => {
@@ -99,6 +103,27 @@ describe("TelegramChatRunnerProcessor", () => {
     const processor = new TelegramChatRunnerProcessor("/tmp/plugins/telegram-bot");
 
     await expect(processor.processMessage("hello", 101, vi.fn())).resolves.toBe("Error: missing provider config");
+    expect(mockCreatedRunners).toHaveLength(0);
+  });
+
+  it("uses the shared cross-platform manager when available", async () => {
+    const processIncomingMessage = vi.fn().mockResolvedValue("shared-output");
+    mockGetGlobalCrossPlatformChatSessionManager.mockResolvedValue({ processIncomingMessage });
+    const emit = vi.fn();
+    const processor = new TelegramChatRunnerProcessor("/tmp/plugins/telegram-bot", "/workspace", "shared-human");
+
+    await expect(processor.processMessage("hello", 101, emit)).resolves.toBe("shared-output");
+
+    expect(processIncomingMessage).toHaveBeenCalledWith({
+      text: "hello",
+      platform: "telegram",
+      identity_key: "shared-human",
+      conversation_id: "101",
+      sender_id: "101",
+      cwd: "/workspace",
+      onEvent: emit,
+      metadata: { chat_id: 101 },
+    });
     expect(mockCreatedRunners).toHaveLength(0);
   });
 });

--- a/plugins/telegram-bot/plugin.yaml
+++ b/plugins/telegram-bot/plugin.yaml
@@ -25,6 +25,10 @@ config_schema:
     type: array
     required: false
     description: "Telegram user IDs allowed to send commands (empty = all)"
+  identity_key:
+    type: string
+    required: false
+    description: "Optional cross-platform identity key shared with Discord, WhatsApp, and Signal plugins"
   polling_timeout:
     type: number
     default: 30

--- a/plugins/telegram-bot/src/config.ts
+++ b/plugins/telegram-bot/src/config.ts
@@ -9,6 +9,7 @@ export interface TelegramConfig {
   allowed_user_ids: number[];
   allow_all: boolean;
   polling_timeout: number;
+  identity_key?: string;
 }
 
 // ─── Config loader + validator ───
@@ -56,6 +57,9 @@ function validateConfig(raw: unknown): TelegramConfig {
   if (typeof pollingTimeout !== "number" || !Number.isInteger(pollingTimeout)) {
     throw new Error("telegram-bot: polling_timeout must be an integer");
   }
+  if (cfg["identity_key"] !== undefined && (typeof cfg["identity_key"] !== "string" || cfg["identity_key"].trim().length === 0)) {
+    throw new Error("telegram-bot: identity_key must be a non-empty string when set");
+  }
 
   return {
     bot_token: cfg["bot_token"] as string,
@@ -63,5 +67,6 @@ function validateConfig(raw: unknown): TelegramConfig {
     allowed_user_ids: allowedUserIds as number[],
     allow_all: allowAll,
     polling_timeout: Math.min(Math.max(pollingTimeout as number, 1), 60),
+    identity_key: cfg["identity_key"] as string | undefined,
   };
 }

--- a/plugins/telegram-bot/src/index.ts
+++ b/plugins/telegram-bot/src/index.ts
@@ -34,7 +34,7 @@ export class TelegramBotPlugin {
 
     this.notifier = new TelegramNotifier(this.api, config.chat_id);
 
-    this.processor = new TelegramChatRunnerProcessor(this.pluginDir);
+    this.processor = new TelegramChatRunnerProcessor(this.pluginDir, process.cwd(), config.identity_key);
 
     this.bridge = new ChatBridge(
       (text, chatId, emit) => this.processor!.processMessage(text, chatId, emit),

--- a/plugins/telegram-bot/src/pulseed.ts
+++ b/plugins/telegram-bot/src/pulseed.ts
@@ -6,6 +6,11 @@ export {
   ToolRegistry,
   createBuiltinTools,
   ChatRunner,
+  getGlobalCrossPlatformChatSessionManager,
+  ToolExecutor,
+  ToolPermissionManager,
+  ConcurrencyController,
+  TrustManager,
 } from "../../../src/index.js";
 
 export type {

--- a/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
+++ b/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
@@ -10,6 +10,7 @@ import {
   ToolPermissionManager,
   ConcurrencyController,
   createBuiltinTools,
+  getGlobalCrossPlatformChatSessionManager,
   type ChatEventHandler,
   type IAdapter,
   type ILLMClient,
@@ -35,14 +36,30 @@ function formatError(message: string): string {
 
 export class TelegramChatRunnerProcessor {
   private readonly workspaceRoot: string;
+  private readonly identityKey: string | undefined;
   private bootstrapPromise: Promise<BootstrapResult> | null = null;
   private readonly sessions = new Map<number, ChatRunnerLike>();
 
-  constructor(_pluginDir: string, workspaceRoot = process.cwd()) {
+  constructor(_pluginDir: string, workspaceRoot = process.cwd(), identityKey?: string) {
     this.workspaceRoot = workspaceRoot;
+    this.identityKey = identityKey;
   }
 
   async processMessage(text: string, chatId: number, emit: ChatEventHandler): Promise<string> {
+    const shared = await this.getSharedManager();
+    if (shared !== null) {
+      return shared.processIncomingMessage({
+        text,
+        platform: "telegram",
+        identity_key: this.identityKey,
+        conversation_id: String(chatId),
+        sender_id: String(chatId),
+        cwd: this.workspaceRoot,
+        onEvent: emit,
+        metadata: { chat_id: chatId },
+      });
+    }
+
     try {
       const runner = await this.getRunner(chatId);
       runner.onEvent = emit;
@@ -52,6 +69,26 @@ export class TelegramChatRunnerProcessor {
       const message = err instanceof Error ? err.message : String(err);
       console.warn(`[telegram-bot] chat runner unavailable for chat ${chatId}: ${message}`);
       return formatError(message);
+    }
+  }
+
+  private async getSharedManager(): Promise<{
+    processIncomingMessage(input: {
+      text: string;
+      platform: string;
+      identity_key?: string;
+      conversation_id: string;
+      sender_id: string;
+      cwd: string;
+      onEvent: ChatEventHandler;
+      metadata: Record<string, unknown>;
+    }): Promise<string>;
+  } | null> {
+    try {
+      const manager = await getGlobalCrossPlatformChatSessionManager();
+      return typeof manager.processIncomingMessage === "function" ? manager : null;
+    } catch {
+      return null;
     }
   }
 

--- a/plugins/whatsapp-webhook/README.md
+++ b/plugins/whatsapp-webhook/README.md
@@ -1,0 +1,34 @@
+# WhatsApp Webhook Plugin
+
+WhatsApp Cloud API webhook integration for PulSeed.
+
+Inbound messages arrive through the Meta webhook and are handed to the shared
+cross-platform session manager with the configured `identity_key`. Outbound
+notifications are delivered through the same Cloud API client.
+
+## Requirements
+
+- A WhatsApp Business account connected to the Cloud API
+- A verified webhook endpoint
+- A phone number id and access token
+
+## Configuration
+
+```json
+{
+  "phone_number_id": "1234567890",
+  "access_token": "EAAG...",
+  "verify_token": "shared-secret",
+  "recipient_id": "15551234567",
+  "identity_key": "whatsapp:family",
+  "host": "127.0.0.1",
+  "port": 8788,
+  "path": "/webhook"
+}
+```
+
+## Notes
+
+- `app_secret` is optional. When present, the webhook verifies
+  `X-Hub-Signature-256` before accepting POST requests.
+- Voice memo transcription is not implemented.

--- a/plugins/whatsapp-webhook/__tests__/config.test.ts
+++ b/plugins/whatsapp-webhook/__tests__/config.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadConfig } from "../src/config.js";
+
+describe("whatsapp-webhook config loader", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "whatsapp-cfg-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it("loads the required config fields", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        phone_number_id: "phone-1",
+        access_token: "token-1",
+        verify_token: "verify-1",
+        recipient_id: "15551234567",
+        identity_key: "whatsapp:alpha",
+      }),
+      "utf-8"
+    );
+
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.path).toBe("/webhook");
+    expect(cfg.port).toBe(8788);
+  });
+
+  it("requires verify_token", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        phone_number_id: "phone-1",
+        access_token: "token-1",
+        recipient_id: "15551234567",
+        identity_key: "whatsapp:alpha",
+      }),
+      "utf-8"
+    );
+
+    expect(() => loadConfig(tmpDir)).toThrow("verify_token");
+  });
+});

--- a/plugins/whatsapp-webhook/__tests__/shared-manager.test.ts
+++ b/plugins/whatsapp-webhook/__tests__/shared-manager.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { dispatchChatInput } from "../src/shared-manager.js";
+
+interface PulseedRuntimeGlobal {
+  __pulseedGetGlobalCrossPlatformChatSessionManager?: () => Promise<Record<string, unknown> | null>;
+}
+
+describe("whatsapp-webhook shared manager bridge", () => {
+  afterEach(() => {
+    delete (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+      .__pulseedGetGlobalCrossPlatformChatSessionManager;
+  });
+
+  it("dispatches through the PulSeed runtime manager injected by PluginLoader", async () => {
+    const processIncomingMessage = vi.fn().mockResolvedValue({ message: "whatsapp reply" });
+    (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+      .__pulseedGetGlobalCrossPlatformChatSessionManager = vi.fn().mockResolvedValue({
+        processIncomingMessage,
+      });
+
+    const input = {
+      platform: "whatsapp" as const,
+      identity_key: "person-a",
+      conversation_id: "15551234567",
+      sender_id: "15551234567",
+      text: "hello",
+      metadata: {},
+    };
+
+    await expect(dispatchChatInput(input)).resolves.toBe("whatsapp reply");
+    expect(processIncomingMessage).toHaveBeenCalledWith(input);
+  });
+});

--- a/plugins/whatsapp-webhook/__tests__/whatsapp-client.test.ts
+++ b/plugins/whatsapp-webhook/__tests__/whatsapp-client.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { WhatsAppCloudClient } from "../src/whatsapp-client.js";
+
+describe("WhatsAppCloudClient", () => {
+  it("posts text messages to the Cloud API", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    const client = new WhatsAppCloudClient("phone-1", "token-1", fetchMock as typeof fetch);
+
+    await client.sendTextMessage({ to: "15551234567", body: "hello" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/phone-1/messages");
+    const body = JSON.parse(init.body as string) as { messaging_product: string; to: string };
+    expect(body.messaging_product).toBe("whatsapp");
+    expect(body.to).toBe("15551234567");
+  });
+});

--- a/plugins/whatsapp-webhook/__tests__/whatsapp-webhook-plugin.test.ts
+++ b/plugins/whatsapp-webhook/__tests__/whatsapp-webhook-plugin.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDispatchChatInput = vi.hoisted(() => vi.fn());
+const mockServerStart = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const mockSendTextMessage = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+
+vi.mock("pulseed", () => ({
+  getGlobalCrossPlatformChatSessionManager: vi.fn().mockResolvedValue({
+    processIncomingMessage: mockDispatchChatInput,
+  }),
+}));
+
+vi.mock("../src/whatsapp-client.js", () => ({
+  WhatsAppCloudClient: class {
+    sendTextMessage = mockSendTextMessage;
+  },
+}));
+
+vi.mock("../src/webhook-server.js", () => ({
+  WhatsAppWebhookServer: class {
+    start = mockServerStart;
+    stop = vi.fn().mockResolvedValue(undefined);
+    constructor(_config: unknown, _client: unknown) {}
+  },
+}));
+
+import { WhatsAppWebhookPlugin } from "../src/index.js";
+
+describe("WhatsAppWebhookPlugin", () => {
+  beforeEach(() => {
+    mockDispatchChatInput.mockReset();
+    mockServerStart.mockClear();
+    mockSendTextMessage.mockClear();
+  });
+
+  it("sends notifications through the Cloud API client", async () => {
+    vi.spyOn(await import("../src/config.js"), "loadConfig").mockReturnValue({
+      phone_number_id: "phone-1",
+      access_token: "token-1",
+      verify_token: "verify-1",
+      recipient_id: "15551234567",
+      identity_key: "whatsapp:alpha",
+      host: "127.0.0.1",
+      port: 8788,
+      path: "/webhook",
+      app_secret: undefined,
+    });
+
+    const plugin = new WhatsAppWebhookPlugin("/tmp/whatsapp-plugin");
+    await plugin.init();
+    await plugin.notify({
+      type: "goal_complete",
+      goal_id: "goal-1",
+      timestamp: "2026-04-11T00:00:00.000Z",
+      summary: "Goal reached",
+      details: {},
+      severity: "info",
+    });
+
+    expect(mockServerStart).toHaveBeenCalledTimes(1);
+    expect(mockSendTextMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/whatsapp-webhook/package.json
+++ b/plugins/whatsapp-webhook/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@pulseed/whatsapp-webhook",
+  "version": "1.0.0",
+  "description": "WhatsApp Cloud API webhook plugin for PulSeed — bidirectional chat",
+  "type": "module",
+  "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "pulseed",
+    "plugin",
+    "whatsapp",
+    "webhook",
+    "chat"
+  ],
+  "license": "MIT",
+  "peerDependencies": {
+    "pulseed": ">=0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/plugins/whatsapp-webhook/plugin.yaml
+++ b/plugins/whatsapp-webhook/plugin.yaml
@@ -1,0 +1,62 @@
+name: whatsapp-webhook
+version: "1.0.0"
+type: notifier
+capabilities:
+  - whatsapp_notification
+  - bidirectional_chat
+supported_events:
+  - goal_complete
+  - approval_needed
+  - stall_detected
+  - task_blocked
+  - goal_progress
+  - trust_change
+  - schedule_change_detected
+  - schedule_heartbeat_failure
+  - schedule_escalation
+  - schedule_report_ready
+description: "WhatsApp Cloud API webhook plugin for PulSeed — bidirectional chat"
+config_schema:
+  phone_number_id:
+    type: string
+    required: true
+    description: "WhatsApp Cloud API phone number id"
+  access_token:
+    type: string
+    required: true
+    description: "WhatsApp Cloud API access token"
+  verify_token:
+    type: string
+    required: true
+    description: "Webhook verify token configured in Meta"
+  recipient_id:
+    type: string
+    required: true
+    description: "Default recipient used for outbound notifications"
+  identity_key:
+    type: string
+    required: true
+    description: "Cross-platform identity key passed to the shared session manager"
+  host:
+    type: string
+    required: false
+    default: 127.0.0.1
+    description: "Webhook host"
+  port:
+    type: number
+    required: false
+    default: 8788
+    description: "Webhook port"
+  path:
+    type: string
+    required: false
+    default: /webhook
+    description: "Webhook path"
+  app_secret:
+    type: string
+    required: false
+    description: "Optional Meta app secret for X-Hub-Signature-256 verification"
+entry_point: "dist/index.js"
+min_pulseed_version: "0.1.0"
+permissions:
+  network: true

--- a/plugins/whatsapp-webhook/src/config.ts
+++ b/plugins/whatsapp-webhook/src/config.ts
@@ -1,0 +1,79 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface WhatsAppWebhookConfig {
+  phone_number_id: string;
+  access_token: string;
+  verify_token: string;
+  recipient_id: string;
+  identity_key: string;
+  host: string;
+  port: number;
+  path: string;
+  app_secret?: string;
+}
+
+export function loadConfig(pluginDir: string): WhatsAppWebhookConfig {
+  const configPath = path.join(pluginDir, "config.json");
+  let raw: unknown;
+
+  try {
+    raw = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`whatsapp-webhook: failed to read config.json — ${msg}`);
+  }
+
+  return validateConfig(raw);
+}
+
+function validateConfig(raw: unknown): WhatsAppWebhookConfig {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("whatsapp-webhook: config must be a JSON object");
+  }
+
+  const cfg = raw as Record<string, unknown>;
+  const host = cfg["host"] ?? "127.0.0.1";
+  const port = cfg["port"] ?? 8788;
+  const pathValue = cfg["path"] ?? "/webhook";
+
+  if (typeof cfg["phone_number_id"] !== "string" || cfg["phone_number_id"].length === 0) {
+    throw new Error("whatsapp-webhook: phone_number_id must be a non-empty string");
+  }
+  if (typeof cfg["access_token"] !== "string" || cfg["access_token"].length === 0) {
+    throw new Error("whatsapp-webhook: access_token must be a non-empty string");
+  }
+  if (typeof cfg["verify_token"] !== "string" || cfg["verify_token"].length === 0) {
+    throw new Error("whatsapp-webhook: verify_token must be a non-empty string");
+  }
+  if (typeof cfg["recipient_id"] !== "string" || cfg["recipient_id"].length === 0) {
+    throw new Error("whatsapp-webhook: recipient_id must be a non-empty string");
+  }
+  if (typeof cfg["identity_key"] !== "string" || cfg["identity_key"].length === 0) {
+    throw new Error("whatsapp-webhook: identity_key must be a non-empty string");
+  }
+  if (typeof host !== "string" || host.length === 0) {
+    throw new Error("whatsapp-webhook: host must be a non-empty string");
+  }
+  if (typeof port !== "number" || !Number.isInteger(port)) {
+    throw new Error("whatsapp-webhook: port must be an integer");
+  }
+  if (typeof pathValue !== "string" || pathValue.length === 0) {
+    throw new Error("whatsapp-webhook: path must be a non-empty string");
+  }
+  if (cfg["app_secret"] !== undefined && typeof cfg["app_secret"] !== "string") {
+    throw new Error("whatsapp-webhook: app_secret must be a string when set");
+  }
+
+  return {
+    phone_number_id: cfg["phone_number_id"] as string,
+    access_token: cfg["access_token"] as string,
+    verify_token: cfg["verify_token"] as string,
+    recipient_id: cfg["recipient_id"] as string,
+    identity_key: cfg["identity_key"] as string,
+    host,
+    port,
+    path: pathValue,
+    app_secret: cfg["app_secret"] as string | undefined,
+  };
+}

--- a/plugins/whatsapp-webhook/src/index.ts
+++ b/plugins/whatsapp-webhook/src/index.ts
@@ -1,0 +1,63 @@
+import type { INotifier, NotificationEvent, NotificationEventType } from "./types.js";
+import { loadConfig, type WhatsAppWebhookConfig } from "./config.js";
+import { WhatsAppCloudClient } from "./whatsapp-client.js";
+import { WhatsAppWebhookServer } from "./webhook-server.js";
+
+const SUPPORTED_EVENTS: NotificationEventType[] = [
+  "goal_progress",
+  "goal_complete",
+  "task_blocked",
+  "approval_needed",
+  "stall_detected",
+  "trust_change",
+  "schedule_change_detected",
+  "schedule_heartbeat_failure",
+  "schedule_escalation",
+  "schedule_report_ready",
+];
+
+function formatNotification(event: NotificationEvent): string {
+  const detailKeys = Object.keys(event.details);
+  const detailSuffix = detailKeys.length > 0 ? ` | details: ${detailKeys.join(",")}` : "";
+  const content = typeof event.details["content"] === "string" ? `\n\n${event.details["content"]}` : "";
+  return `[${event.severity}] ${event.summary} (goal ${event.goal_id})${detailSuffix}${content}`;
+}
+
+export class WhatsAppWebhookPlugin implements INotifier {
+  readonly name = "whatsapp-webhook";
+
+  private config: WhatsAppWebhookConfig | null = null;
+  private client: WhatsAppCloudClient | null = null;
+  private server: WhatsAppWebhookServer | null = null;
+
+  constructor(private readonly pluginDir: string) {}
+
+  async init(): Promise<void> {
+    this.config = loadConfig(this.pluginDir);
+    this.client = new WhatsAppCloudClient(this.config.phone_number_id, this.config.access_token);
+    this.server = new WhatsAppWebhookServer(this.config, this.client);
+    await this.server.start();
+  }
+
+  supports(eventType: NotificationEventType): boolean {
+    return SUPPORTED_EVENTS.includes(eventType);
+  }
+
+  async notify(event: NotificationEvent): Promise<void> {
+    if (this.config === null || this.client === null) {
+      throw new Error("whatsapp-webhook: plugin not initialized");
+    }
+
+    await this.client.sendTextMessage({
+      to: this.config.recipient_id,
+      body: formatNotification(event),
+    });
+  }
+
+  async stop(): Promise<void> {
+    await this.server?.stop();
+    this.server = null;
+  }
+}
+
+export default WhatsAppWebhookPlugin;

--- a/plugins/whatsapp-webhook/src/shared-manager.ts
+++ b/plugins/whatsapp-webhook/src/shared-manager.ts
@@ -1,0 +1,77 @@
+export interface ChatContinuationInput {
+  platform: "whatsapp";
+  identity_key: string;
+  conversation_id: string;
+  sender_id: string;
+  message_id?: string;
+  text: string;
+  metadata: Record<string, unknown>;
+}
+
+type SessionManagerMethod = (input: ChatContinuationInput) => Promise<unknown> | unknown;
+type SessionManagerProvider = () => Promise<Record<string, unknown> | null> | Record<string, unknown> | null;
+
+interface PulseedRuntimeGlobal {
+  __pulseedGetGlobalCrossPlatformChatSessionManager?: SessionManagerProvider;
+}
+
+export async function getGlobalCrossPlatformChatSessionManager(): Promise<Record<string, unknown> | null> {
+  const getter = (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+    .__pulseedGetGlobalCrossPlatformChatSessionManager;
+  if (typeof getter !== "function") {
+    return null;
+  }
+
+  try {
+    return await getter();
+  } catch {
+    return null;
+  }
+}
+
+export async function dispatchChatInput(input: ChatContinuationInput): Promise<string | null> {
+  const manager = await getGlobalCrossPlatformChatSessionManager();
+  if (manager === null) {
+    return null;
+  }
+
+  const methodNames = [
+    "processIncomingMessage",
+    "handleIncomingMessage",
+    "continueConversation",
+    "resumeConversation",
+    "routeIncomingMessage",
+    "processMessage",
+    "handleMessage",
+  ] as const;
+
+  for (const methodName of methodNames) {
+    const method = manager[methodName];
+    if (typeof method !== "function") {
+      continue;
+    }
+
+    const result = await (method as SessionManagerMethod).call(manager, input);
+    return normalizeManagerResult(result);
+  }
+
+  return null;
+}
+
+function normalizeManagerResult(result: unknown): string | null {
+  if (typeof result === "string" && result.trim().length > 0) {
+    return result;
+  }
+  if (typeof result === "object" && result !== null) {
+    const record = result as Record<string, unknown>;
+    const text = record["text"];
+    if (typeof text === "string" && text.trim().length > 0) {
+      return text;
+    }
+    const message = record["message"];
+    if (typeof message === "string" && message.trim().length > 0) {
+      return message;
+    }
+  }
+  return null;
+}

--- a/plugins/whatsapp-webhook/src/types.ts
+++ b/plugins/whatsapp-webhook/src/types.ts
@@ -1,0 +1,26 @@
+export type NotificationEventType =
+  | "goal_progress"
+  | "goal_complete"
+  | "task_blocked"
+  | "approval_needed"
+  | "stall_detected"
+  | "trust_change"
+  | "schedule_change_detected"
+  | "schedule_heartbeat_failure"
+  | "schedule_escalation"
+  | "schedule_report_ready";
+
+export interface NotificationEvent {
+  type: NotificationEventType;
+  goal_id: string;
+  timestamp: string;
+  summary: string;
+  details: Record<string, unknown>;
+  severity: "info" | "warning" | "critical";
+}
+
+export interface INotifier {
+  name: string;
+  notify(event: NotificationEvent): Promise<void>;
+  supports(eventType: NotificationEventType): boolean;
+}

--- a/plugins/whatsapp-webhook/src/webhook-server.ts
+++ b/plugins/whatsapp-webhook/src/webhook-server.ts
@@ -1,0 +1,206 @@
+import * as crypto from "node:crypto";
+import * as http from "node:http";
+import { WhatsAppCloudClient } from "./whatsapp-client.js";
+import { dispatchChatInput, type ChatContinuationInput } from "./shared-manager.js";
+import type { WhatsAppWebhookConfig } from "./config.js";
+
+interface WhatsAppWebhookPayload {
+  entry?: Array<{
+    changes?: Array<{
+      value?: {
+        messages?: Array<{
+          id?: string;
+          from?: string;
+          timestamp?: string;
+          type?: string;
+          text?: { body?: string };
+        }>;
+      };
+    }>;
+  }>;
+}
+
+export class WhatsAppWebhookServer {
+  private server: http.Server | null = null;
+
+  constructor(
+    private readonly config: WhatsAppWebhookConfig,
+    private readonly client: WhatsAppCloudClient,
+    private readonly fetchChatReply: typeof dispatchChatInput = dispatchChatInput
+  ) {}
+
+  async start(): Promise<void> {
+    if (this.server !== null) {
+      return;
+    }
+
+    this.server = http.createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+
+    await new Promise<void>((resolve) => {
+      this.server!.listen(this.config.port, this.config.host, resolve);
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.server === null) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      this.server!.close(() => resolve());
+    });
+    this.server = null;
+  }
+
+  async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? this.config.host}`);
+
+    if (req.method === "GET" && url.pathname === this.config.path) {
+      this.handleVerification(req, res, url);
+      return;
+    }
+
+    if (req.method !== "POST" || url.pathname !== this.config.path) {
+      this.respondJson(res, 404, { error: "not_found" });
+      return;
+    }
+
+    const body = await this.readBody(req);
+    if (body === null) {
+      this.respondJson(res, 400, { error: "invalid_body" });
+      return;
+    }
+
+    if (!(await this.verifySignature(req, body))) {
+      this.respondJson(res, 401, { error: "invalid_signature" });
+      return;
+    }
+
+    let payload: WhatsAppWebhookPayload;
+    try {
+      payload = JSON.parse(body) as WhatsAppWebhookPayload;
+    } catch {
+      this.respondJson(res, 400, { error: "invalid_json" });
+      return;
+    }
+
+    const messages = this.extractMessages(payload);
+    for (const message of messages) {
+      void this.processMessage(message).catch((err) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[whatsapp-webhook] failed to process message: ${msg}`);
+      });
+    }
+
+    this.respondJson(res, 200, { ok: true });
+  }
+
+  private handleVerification(req: http.IncomingMessage, res: http.ServerResponse, url: URL): void {
+    const mode = url.searchParams.get("hub.mode");
+    const token = url.searchParams.get("hub.verify_token");
+    const challenge = url.searchParams.get("hub.challenge");
+
+    if (mode === "subscribe" && token === this.config.verify_token && challenge !== null) {
+      res.statusCode = 200;
+      res.end(challenge);
+      return;
+    }
+
+    this.respondJson(res, 403, { error: "verification_failed" });
+  }
+
+  private async processMessage(message: {
+    id?: string;
+    from?: string;
+    timestamp?: string;
+    text?: { body?: string };
+    type?: string;
+  }): Promise<void> {
+    if (message.from === undefined || message.text?.body === undefined || message.text.body.trim().length === 0) {
+      return;
+    }
+
+    const input: ChatContinuationInput = {
+      platform: "whatsapp",
+      identity_key: this.config.identity_key,
+      conversation_id: message.from,
+      sender_id: message.from,
+      message_id: message.id,
+      text: message.text.body,
+      metadata: {
+        message_type: message.type,
+        timestamp: message.timestamp,
+      },
+    };
+
+    const reply = await this.fetchChatReply(input);
+    const content = reply ?? "Received.";
+    await this.client.sendTextMessage({
+      to: message.from,
+      body: content,
+    });
+  }
+
+  private extractMessages(payload: WhatsAppWebhookPayload): Array<{
+    id?: string;
+    from?: string;
+    timestamp?: string;
+    type?: string;
+    text?: { body?: string };
+  }> {
+    const messages: Array<{
+      id?: string;
+      from?: string;
+      timestamp?: string;
+      type?: string;
+      text?: { body?: string };
+    }> = [];
+
+    for (const entry of payload.entry ?? []) {
+      for (const change of entry.changes ?? []) {
+        for (const message of change.value?.messages ?? []) {
+          messages.push(message);
+        }
+      }
+    }
+
+    return messages;
+  }
+
+  private async verifySignature(req: http.IncomingMessage, body: string): Promise<boolean> {
+    if (this.config.app_secret === undefined || this.config.app_secret.length === 0) {
+      return true;
+    }
+
+    const header = req.headers["x-hub-signature-256"];
+    if (typeof header !== "string" || !header.startsWith("sha256=")) {
+      return false;
+    }
+
+    const expected = crypto
+      .createHmac("sha256", this.config.app_secret)
+      .update(body)
+      .digest("hex");
+    const actual = header.slice("sha256=".length);
+    if (expected.length !== actual.length) {
+      return false;
+    }
+    return crypto.timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(actual, "hex"));
+  }
+
+  private async readBody(req: http.IncomingMessage): Promise<string | null> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    return Buffer.concat(chunks).toString("utf-8");
+  }
+
+  private respondJson(res: http.ServerResponse, statusCode: number, payload: unknown): void {
+    res.statusCode = statusCode;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(payload));
+  }
+}

--- a/plugins/whatsapp-webhook/src/whatsapp-client.ts
+++ b/plugins/whatsapp-webhook/src/whatsapp-client.ts
@@ -1,0 +1,38 @@
+export interface WhatsAppMessage {
+  to: string;
+  body: string;
+}
+
+export class WhatsAppCloudClient {
+  constructor(
+    private readonly phoneNumberId: string,
+    private readonly accessToken: string,
+    private readonly fetchImpl: typeof fetch = fetch
+  ) {}
+
+  async sendTextMessage(message: WhatsAppMessage): Promise<void> {
+    const response = await this.fetchImpl(
+      `https://graph.facebook.com/v20.0/${this.phoneNumberId}/messages`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          messaging_product: "whatsapp",
+          to: message.to,
+          type: "text",
+          text: {
+            body: message.body,
+          },
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "(unreadable)");
+      throw new Error(`whatsapp-webhook: send failed with ${response.status}: ${body}`);
+    }
+  }
+}

--- a/plugins/whatsapp-webhook/tsconfig.json
+++ b/plugins/whatsapp-webhook/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "outDir": "dist",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/whatsapp-webhook/vitest.config.ts
+++ b/plugins/whatsapp-webhook/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,12 @@ export type { CoreLoopDeps, LoopConfig, LoopResult } from "./orchestrator/loop/c
 export { CLIRunner } from "./interface/cli/cli-runner.js";
 export { ChatRunner } from "./interface/chat/chat-runner.js";
 export type { ChatRunnerDeps, ChatRunResult } from "./interface/chat/chat-runner.js";
+export { CrossPlatformChatSessionManager, getGlobalCrossPlatformChatSessionManager } from "./interface/chat/cross-platform-session.js";
+export type {
+  CrossPlatformChatSessionOptions,
+  CrossPlatformChatSessionInfo,
+  CrossPlatformIncomingChatMessage,
+} from "./interface/chat/cross-platform-session.js";
 export type {
   ChatEvent,
   ChatEventHandler,

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from "vitest";
+import { CrossPlatformChatSessionManager } from "../cross-platform-session.js";
+import type { CrossPlatformChatSessionOptions } from "../cross-platform-session.js";
+import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { StateManager } from "../../../base/state/state-manager.js";
+import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adapter-layer.js";
+
+vi.mock("../../../platform/observation/context-provider.js", () => ({
+  resolveGitRoot: (cwd: string) => cwd,
+  buildChatContext: (_task: string, cwd: string) => Promise.resolve(`Working directory: ${cwd}`),
+}));
+
+const CANNED_RESULT: AgentResult = {
+  success: true,
+  output: "Task completed successfully.",
+  error: null,
+  exit_code: 0,
+  elapsed_ms: 50,
+  stopped_reason: "completed",
+};
+
+function makeMockAdapter(result: AgentResult = CANNED_RESULT): IAdapter {
+  return {
+    adapterType: "mock",
+    execute: vi.fn().mockResolvedValue(result),
+  } as unknown as IAdapter;
+}
+
+function makeMockStateManager(): StateManager {
+  return {
+    writeRaw: vi.fn().mockResolvedValue(undefined),
+    readRaw: vi.fn().mockResolvedValue(null),
+  } as unknown as StateManager;
+}
+
+function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
+  return {
+    stateManager: makeMockStateManager(),
+    adapter: makeMockAdapter(),
+    ...overrides,
+  };
+}
+
+function getSessionPaths(stateManager: StateManager): string[] {
+  const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
+  return writeRawMock.mock.calls
+    .map((call: unknown[]) => call[0] as string)
+    .filter((path: string) => path.startsWith("chat/sessions/"));
+}
+
+describe("CrossPlatformChatSessionManager", () => {
+  it("reuses the same ChatRunner session for the same identity_key across platforms", async () => {
+    const stateManager = makeMockStateManager();
+    const manager = new CrossPlatformChatSessionManager(makeDeps({ stateManager }));
+    const events: string[] = [];
+
+    const first = await manager.execute("hello from slack", {
+      identity_key: "user-123",
+      platform: "slack",
+      conversation_id: "conv-1",
+      user_id: "user-a",
+      cwd: "/repo",
+      onEvent: (event) => {
+        events.push(event.type);
+      },
+    });
+
+    const second = await manager.execute("hello from discord", {
+      identity_key: "user-123",
+      platform: "discord",
+      conversation_id: "thread-9",
+      user_id: "user-a",
+      cwd: "/repo",
+    });
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(true);
+
+    const sessionPaths = getSessionPaths(stateManager);
+    expect(new Set(sessionPaths).size).toBe(1);
+    expect(sessionPaths[0]).toMatch(/^chat\/sessions\/.+\.json$/);
+
+    const info = manager.getSessionInfo({ identity_key: "user-123" } satisfies CrossPlatformChatSessionOptions);
+    expect(info).not.toBeNull();
+    expect(info?.identity_key).toBe("user-123");
+    expect(info?.platform).toBe("slack");
+    expect(info?.conversation_id).toBe("conv-1");
+    expect(info?.cwd).toBe("/repo");
+    expect(info?.metadata).toMatchObject({
+      platform: "discord",
+      conversation_id: "thread-9",
+      user_id: "user-a",
+    });
+
+    expect(events).toContain("lifecycle_start");
+    expect(events).toContain("assistant_final");
+  });
+
+  it("keeps sessions isolated when identity_key is omitted", async () => {
+    const stateManager = makeMockStateManager();
+    const manager = new CrossPlatformChatSessionManager(makeDeps({ stateManager }));
+
+    const sharedOptions: Omit<CrossPlatformChatSessionOptions, "identity_key" | "platform"> = {
+      conversation_id: "conv-1",
+      user_id: "user-a",
+      cwd: "/repo",
+    };
+
+    await manager.execute("hello from slack", {
+      ...sharedOptions,
+      platform: "slack",
+    });
+
+    await manager.execute("hello from discord", {
+      ...sharedOptions,
+      platform: "discord",
+    });
+
+    const sessionPaths = getSessionPaths(stateManager);
+    expect(new Set(sessionPaths).size).toBe(2);
+  });
+
+  it("streams ChatEvent updates through the per-turn callback", async () => {
+    const stateManager = makeMockStateManager();
+    const manager = new CrossPlatformChatSessionManager(makeDeps({ stateManager }));
+    const events: Array<{ type: string; text?: string }> = [];
+
+    const result = await manager.execute("stream this turn", {
+      identity_key: "stream-user",
+      platform: "web",
+      conversation_id: "web-1",
+      cwd: "/repo",
+      onEvent: (event) => {
+        events.push({ type: event.type, text: "text" in event ? event.text : undefined });
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(events.length).toBeGreaterThan(0);
+    expect(events.some((event) => event.type === "lifecycle_start")).toBe(true);
+    expect(events.some((event) => event.type === "assistant_delta")).toBe(true);
+    expect(events.some((event) => event.type === "assistant_final")).toBe(true);
+    expect(events.at(-1)?.type).toBe("lifecycle_end");
+  });
+});

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -1,0 +1,298 @@
+import { randomUUID } from "node:crypto";
+import { ChatRunner } from "./chat-runner.js";
+import type { ChatRunResult, ChatRunnerDeps } from "./chat-runner.js";
+import type { ChatEvent, ChatEventHandler } from "./chat-events.js";
+import { StateManager } from "../../base/state/state-manager.js";
+import { buildAdapterRegistry, buildLLMClient } from "../../base/llm/provider-factory.js";
+import { loadProviderConfig } from "../../base/llm/provider-config.js";
+import { TrustManager } from "../../platform/traits/trust-manager.js";
+import {
+  ConcurrencyController,
+  createBuiltinTools,
+  ToolExecutor,
+  ToolPermissionManager,
+  ToolRegistry,
+} from "../../tools/index.js";
+
+export interface CrossPlatformChatSessionOptions {
+  /**
+   * Stable cross-platform join key.
+   * When present, sessions with the same identity_key share one ChatRunner session.
+   */
+  identity_key?: string;
+  /** Platform or transport name, e.g. "slack", "discord", "web". */
+  platform?: string;
+  /** Conversation/thread identifier on the transport. */
+  conversation_id?: string;
+  /** Human-readable conversation title or thread name. */
+  conversation_name?: string;
+  /** User identifier on the transport. */
+  user_id?: string;
+  /** Human-readable user name. */
+  user_name?: string;
+  /** Workspace root or working directory used when the session is created. */
+  cwd?: string;
+  /** Per-turn timeout forwarded to ChatRunner. */
+  timeoutMs?: number;
+  /** Extra transport metadata for plugins to retain alongside the session. */
+  metadata?: Record<string, unknown>;
+  /** Optional streaming callback for ChatEvent updates. */
+  onEvent?: ChatEventHandler;
+}
+
+export interface CrossPlatformIncomingChatMessage {
+  text: string;
+  identity_key?: string;
+  platform?: string;
+  conversation_id?: string;
+  conversation_name?: string;
+  sender_id?: string;
+  user_id?: string;
+  user_name?: string;
+  message_id?: string;
+  cwd?: string;
+  timeoutMs?: number;
+  metadata?: Record<string, unknown>;
+  onEvent?: ChatEventHandler;
+}
+
+export interface CrossPlatformChatSessionInfo {
+  session_key: string;
+  identity_key?: string;
+  platform?: string;
+  conversation_id?: string;
+  conversation_name?: string;
+  user_id?: string;
+  user_name?: string;
+  cwd: string;
+  created_at: string;
+  last_used_at: string;
+  metadata: Record<string, unknown>;
+}
+
+interface ManagedChatSession {
+  runner: ChatRunner;
+  info: CrossPlatformChatSessionInfo;
+  queue: Promise<void>;
+}
+
+function normalizeIdentity(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizePlatform(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLowerCase() : null;
+}
+
+function buildSessionKey(options: CrossPlatformChatSessionOptions): string {
+  const identityKey = normalizeIdentity(options.identity_key);
+  if (identityKey) {
+    return `identity:${identityKey}`;
+  }
+
+  const platform = normalizePlatform(options.platform);
+  const conversationId = normalizeIdentity(options.conversation_id);
+  if (platform && conversationId) {
+    return `platform:${platform}:conversation:${conversationId}`;
+  }
+
+  const userId = normalizeIdentity(options.user_id);
+  if (platform && userId) {
+    return `platform:${platform}:user:${userId}`;
+  }
+
+  return `ephemeral:${randomUUID()}`;
+}
+
+function cloneMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> {
+  return metadata ? { ...metadata } : {};
+}
+
+function buildSessionMetadata(options: CrossPlatformChatSessionOptions): Record<string, unknown> {
+  return {
+    ...(options.metadata ?? {}),
+    ...(options.platform ? { platform: options.platform } : {}),
+    ...(options.conversation_id ? { conversation_id: options.conversation_id } : {}),
+    ...(options.conversation_name ? { conversation_name: options.conversation_name } : {}),
+    ...(options.user_id ? { user_id: options.user_id } : {}),
+    ...(options.user_name ? { user_name: options.user_name } : {}),
+  };
+}
+
+function safeInvoke(handler: ChatEventHandler | undefined, event: ChatEvent): void {
+  if (!handler) return;
+  try {
+    const result = handler(event);
+    if (result && typeof (result as Promise<void>).catch === "function") {
+      void (result as Promise<void>).catch(() => undefined);
+    }
+  } catch {
+    // Event streaming should not break chat delivery.
+  }
+}
+
+export class CrossPlatformChatSessionManager {
+  private readonly sessions = new Map<string, ManagedChatSession>();
+
+  constructor(private readonly deps: ChatRunnerDeps) {}
+
+  /**
+   * Execute a chat turn through a session keyed by identity_key.
+   * If identity_key is absent, the manager falls back to a deterministic platform-scoped key when possible,
+   * otherwise it creates an isolated one-shot session.
+   */
+  async execute(input: string, options: CrossPlatformChatSessionOptions = {}): Promise<ChatRunResult> {
+    const session = this.getOrCreateSession(options);
+    const queueEntry = session.queue.then(() => this.executeInSession(session, input, options));
+    session.queue = queueEntry.then(() => undefined, () => undefined);
+    return queueEntry;
+  }
+
+  async processIncomingMessage(input: CrossPlatformIncomingChatMessage): Promise<string> {
+    const result = await this.execute(input.text, {
+      identity_key: input.identity_key,
+      platform: input.platform,
+      conversation_id: input.conversation_id,
+      conversation_name: input.conversation_name,
+      user_id: input.user_id ?? input.sender_id,
+      user_name: input.user_name,
+      cwd: input.cwd,
+      timeoutMs: input.timeoutMs,
+      metadata: {
+        ...(input.metadata ?? {}),
+        ...(input.sender_id ? { sender_id: input.sender_id } : {}),
+        ...(input.message_id ? { message_id: input.message_id } : {}),
+      },
+      onEvent: input.onEvent,
+    });
+    return result.output;
+  }
+
+  handleIncomingMessage(input: CrossPlatformIncomingChatMessage): Promise<string> {
+    return this.processIncomingMessage(input);
+  }
+
+  continueConversation(input: CrossPlatformIncomingChatMessage): Promise<string> {
+    return this.processIncomingMessage(input);
+  }
+
+  processMessage(input: CrossPlatformIncomingChatMessage): Promise<string> {
+    return this.processIncomingMessage(input);
+  }
+
+  /**
+   * Returns the active session info if a matching session is already loaded.
+   */
+  getSessionInfo(options: CrossPlatformChatSessionOptions): CrossPlatformChatSessionInfo | null {
+    const sessionKey = buildSessionKey(options);
+    const session = this.sessions.get(sessionKey);
+    return session ? { ...session.info, metadata: cloneMetadata(session.info.metadata) } : null;
+  }
+
+  private getOrCreateSession(options: CrossPlatformChatSessionOptions): ManagedChatSession {
+    const sessionKey = buildSessionKey(options);
+    const existing = this.sessions.get(sessionKey);
+    if (existing) {
+      return existing;
+    }
+
+    const cwd = options.cwd?.trim() || process.cwd();
+    const runner = new ChatRunner(this.deps);
+    runner.startSession(cwd);
+
+    const now = new Date().toISOString();
+    const info: CrossPlatformChatSessionInfo = {
+      session_key: sessionKey,
+      identity_key: normalizeIdentity(options.identity_key) ?? undefined,
+      platform: options.platform?.trim() || undefined,
+      conversation_id: options.conversation_id?.trim() || undefined,
+      conversation_name: options.conversation_name?.trim() || undefined,
+      user_id: options.user_id?.trim() || undefined,
+      user_name: options.user_name?.trim() || undefined,
+      cwd,
+      created_at: now,
+      last_used_at: now,
+      metadata: cloneMetadata(buildSessionMetadata(options)),
+    };
+
+    const created: ManagedChatSession = {
+      runner,
+      info,
+      queue: Promise.resolve(),
+    };
+    this.sessions.set(sessionKey, created);
+    return created;
+  }
+
+  private async executeInSession(
+    session: ManagedChatSession,
+    input: string,
+    options: CrossPlatformChatSessionOptions
+  ): Promise<ChatRunResult> {
+    session.info.last_used_at = new Date().toISOString();
+    session.info.metadata = cloneMetadata(buildSessionMetadata(options));
+
+    const previousOnEvent = session.runner.onEvent;
+    if (options.onEvent) {
+      const handler = options.onEvent;
+      const upstream = this.deps.onEvent;
+      session.runner.onEvent = (event: ChatEvent) => {
+        safeInvoke(handler, event);
+        if (upstream && upstream !== handler) {
+          safeInvoke(upstream, event);
+        }
+      };
+    } else {
+      session.runner.onEvent = undefined;
+    }
+
+    try {
+      return await session.runner.execute(input, session.info.cwd, options.timeoutMs);
+    } finally {
+      session.runner.onEvent = previousOnEvent;
+    }
+  }
+}
+
+let globalManagerPromise: Promise<CrossPlatformChatSessionManager> | null = null;
+
+export function getGlobalCrossPlatformChatSessionManager(): Promise<CrossPlatformChatSessionManager> {
+  if (globalManagerPromise === null) {
+    globalManagerPromise = createGlobalCrossPlatformChatSessionManager().catch((err) => {
+      globalManagerPromise = null;
+      throw err;
+    });
+  }
+  return globalManagerPromise;
+}
+
+async function createGlobalCrossPlatformChatSessionManager(): Promise<CrossPlatformChatSessionManager> {
+  const providerConfig = await loadProviderConfig();
+  const stateManager = new StateManager();
+  await stateManager.init();
+
+  const llmClient = await buildLLMClient();
+  const adapterRegistry = await buildAdapterRegistry(llmClient, providerConfig);
+  const adapter = adapterRegistry.getAdapter(providerConfig.adapter);
+  const toolRegistry = new ToolRegistry();
+  const trustManager = new TrustManager(stateManager);
+  for (const tool of createBuiltinTools({ stateManager, trustManager, registry: toolRegistry })) {
+    toolRegistry.register(tool);
+  }
+
+  const toolExecutor = new ToolExecutor({
+    registry: toolRegistry,
+    permissionManager: new ToolPermissionManager({ trustManager }),
+    concurrency: new ConcurrencyController(),
+  });
+
+  return new CrossPlatformChatSessionManager({
+    stateManager,
+    adapter,
+    llmClient,
+    registry: toolRegistry,
+    toolExecutor,
+  });
+}

--- a/src/interface/cli/__tests__/cli-daemon-start.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-start.test.ts
@@ -15,6 +15,7 @@ const {
   scheduleEngineArgs,
   daemonRunnerArgs,
   watchdogArgs,
+  notificationDispatcherArgs,
 } = vi.hoisted(() => ({
   buildDepsMock: vi.fn(),
   daemonStartMock: vi.fn().mockResolvedValue(undefined),
@@ -28,6 +29,7 @@ const {
   scheduleEngineArgs: [] as unknown[],
   daemonRunnerArgs: [] as unknown[],
   watchdogArgs: [] as unknown[],
+  notificationDispatcherArgs: [] as unknown[],
 }));
 
 vi.mock("node:os", async (importOriginal) => {
@@ -120,7 +122,8 @@ vi.mock("../../../runtime/notifier-registry.js", () => ({
 }));
 
 vi.mock("../../../runtime/notification-dispatcher.js", () => ({
-  NotificationDispatcher: vi.fn().mockImplementation(function () {
+  NotificationDispatcher: vi.fn().mockImplementation(function (...args: unknown[]) {
+    notificationDispatcherArgs.push(args);
     return {
       setRealtimeSink: setRealtimeSinkMock,
     };
@@ -157,8 +160,10 @@ describe("cmdStart", () => {
     scheduleEngineArgs.length = 0;
     daemonRunnerArgs.length = 0;
     watchdogArgs.length = 0;
+    notificationDispatcherArgs.length = 0;
     delete process.env.PULSEED_WATCHDOG_CHILD;
     fs.rmSync(mockedHome, { recursive: true, force: true });
+    fs.rmSync("/tmp/pulseed-daemon-start-base", { recursive: true, force: true });
 
     buildDepsMock.mockResolvedValue({
       coreLoop: {},
@@ -174,11 +179,23 @@ describe("cmdStart", () => {
 
   afterEach(() => {
     fs.rmSync(mockedHome, { recursive: true, force: true });
+    fs.rmSync("/tmp/pulseed-daemon-start-base", { recursive: true, force: true });
     delete process.env.PULSEED_WATCHDOG_CHILD;
   });
 
   it("wires EventServer realtime sink and full ScheduleEngine deps in the watchdog child process", async () => {
     process.env.PULSEED_WATCHDOG_CHILD = "1";
+    fs.mkdirSync("/tmp/pulseed-daemon-start-base", { recursive: true });
+    fs.writeFileSync(
+      "/tmp/pulseed-daemon-start-base/notification.json",
+      JSON.stringify({
+        plugin_notifiers: {
+          mode: "only",
+          routes: [{ id: "discord-bot", enabled: true, report_types: ["weekly_report"] }],
+        },
+      }),
+      "utf-8"
+    );
 
     await cmdStart(
       { getBaseDir: vi.fn().mockReturnValue("/tmp/pulseed-daemon-start-base") } as never,
@@ -187,6 +204,15 @@ describe("cmdStart", () => {
     );
 
     expect(setRealtimeSinkMock).toHaveBeenCalledOnce();
+    expect(notificationDispatcherArgs[0]).toEqual([
+      expect.objectContaining({
+        plugin_notifiers: {
+          mode: "only",
+          routes: [{ id: "discord-bot", enabled: true, report_types: ["weekly_report"] }],
+        },
+      }),
+      expect.any(Object),
+    ]);
     const realtimeSink = setRealtimeSinkMock.mock.calls[0]?.[0] as ((report: unknown) => Promise<void>) | undefined;
     expect(realtimeSink).toBeTypeOf("function");
 

--- a/src/interface/cli/__tests__/cli-notify.test.ts
+++ b/src/interface/cli/__tests__/cli-notify.test.ts
@@ -172,6 +172,43 @@ describe("cmdNotify", () => {
     expect(consoleSpy).toHaveBeenCalledWith("No channels configured");
   });
 
+  it("route updates plugin notifier routing from natural language", async () => {
+    const code = await cmdNotify(["route", "緊急通知はWhatsAppだけに送って"]);
+
+    expect(code).toBe(0);
+
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "notification.json"), "utf-8")
+    );
+    expect(raw.plugin_notifiers).toEqual({
+      mode: "only",
+      routes: [
+        {
+          id: "whatsapp-webhook",
+          enabled: true,
+          report_types: ["urgent_alert", "approval_request"],
+        },
+      ],
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Plugin notification routing set to only")
+    );
+  });
+
+  it("route rejects invalid existing config without overwriting it", async () => {
+    const configPath = path.join(tmpDir, "notification.json");
+    const invalidJson = JSON.stringify({ channels: [{ type: "webhook", url: "not-a-url" }] });
+    fs.writeFileSync(configPath, invalidJson, "utf-8");
+
+    const code = await cmdNotify(["route", "Discordだけ"]);
+
+    expect(code).toBe(1);
+    expect(consoleErrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid notification config")
+    );
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(invalidJson);
+  });
+
   // ─── remove ───
 
   it("remove by index works", async () => {

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -80,6 +80,10 @@ describe("setup notification step", () => {
           format: "json",
         },
       ],
+      plugin_notifiers: {
+        mode: "all",
+        routes: [],
+      },
       do_not_disturb: {
         enabled: false,
         start_hour: 22,

--- a/src/interface/cli/__tests__/telegram-setup.test.ts
+++ b/src/interface/cli/__tests__/telegram-setup.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+
+const readlineState = vi.hoisted(() => ({
+  answers: [] as string[],
+  close: vi.fn(),
+}));
+
+vi.mock("node:readline", () => ({
+  createInterface: vi.fn(() => ({
+    question: vi.fn((_question: string, callback: (answer: string) => void) => {
+      callback(readlineState.answers.shift() ?? "");
+    }),
+    close: readlineState.close,
+  })),
+}));
+
+describe("cmdTelegramSetup", () => {
+  let tmpDir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-telegram-setup-test-"));
+    process.env["PULSEED_HOME"] = tmpDir;
+    fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        result: { id: 42, first_name: "PulSeed", username: "pulseed_bot" },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    readlineState.close.mockClear();
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    delete process.env["PULSEED_HOME"];
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes optional identity_key for cross-platform continuation", async () => {
+    readlineState.answers = ["test-token", "123456", "777,888", "personal"];
+    const { cmdTelegramSetup } = await import("../commands/telegram.js");
+
+    const result = await cmdTelegramSetup([]);
+
+    expect(result).toBe(0);
+    expect(fetchMock).toHaveBeenCalledWith("https://api.telegram.org/bottest-token/getMe");
+    expect(readlineState.close).toHaveBeenCalledTimes(1);
+
+    const configPath = path.join(tmpDir, "plugins", "telegram-bot", "config.json");
+    const config = JSON.parse(await fsp.readFile(configPath, "utf-8")) as Record<string, unknown>;
+    expect(config).toMatchObject({
+      bot_token: "test-token",
+      chat_id: 123456,
+      allowed_user_ids: [777, 888],
+      polling_timeout: 30,
+      identity_key: "personal",
+    });
+  });
+});

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -26,6 +26,7 @@ import { isDaemonRunning, probeDaemonHealth } from "../../../runtime/daemon/clie
 import { PluginLoader } from "../../../runtime/plugin-loader.js";
 import { NotifierRegistry } from "../../../runtime/notifier-registry.js";
 import { NotificationDispatcher } from "../../../runtime/notification-dispatcher.js";
+import { getNotificationConfigPath, loadNotificationConfig } from "../../../runtime/notification-routing.js";
 import { AdapterRegistry } from "../../../orchestrator/execution/adapter-layer.js";
 import { DataSourceRegistry } from "../../../platform/observation/data-source-adapter.js";
 import { getProviderRuntimeFingerprint } from "../../../base/llm/provider-config.js";
@@ -258,10 +259,10 @@ export async function cmdStart(
   } catch (err) {
     getCliLogger().warn(`[daemon] Plugin loading failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
   }
-  const notificationDispatcher = new NotificationDispatcher(undefined, notifierRegistry);
-  deps.reportingEngine.setNotificationDispatcher(notificationDispatcher);
-
   const daemonBaseDir = deps.stateManager.getBaseDir();
+  const notificationConfig = await loadNotificationConfig(getNotificationConfigPath(daemonBaseDir));
+  const notificationDispatcher = new NotificationDispatcher(notificationConfig, notifierRegistry);
+  deps.reportingEngine.setNotificationDispatcher(notificationDispatcher);
 
   // Create EventServer for event-driven wake-ups and SSE clients.
   const eventServer = new EventServer(

--- a/src/interface/cli/commands/notify.ts
+++ b/src/interface/cli/commands/notify.ts
@@ -1,31 +1,20 @@
 // ─── pulseed notify commands (add, list, remove, test) ───
 
 import { parseArgs } from "node:util";
-import * as path from "node:path";
-import { readJsonFileOrNull, writeJsonFileAtomic } from "../../../base/utils/json-io.js";
-import { NotificationConfigSchema } from "../../../base/types/notification.js";
 import type { NotificationConfig, NotificationChannel } from "../../../base/types/notification.js";
-import { getPulseedDirPath } from "../../../base/utils/paths.js";
-
-function getNotificationConfigPath(baseDir?: string): string {
-  return path.join(baseDir ?? getPulseedDirPath(), "notification.json");
-}
+import {
+  applyNaturalLanguageNotificationRouting,
+  getNotificationConfigPath,
+  loadNotificationConfig,
+  saveNotificationConfig,
+} from "../../../runtime/notification-routing.js";
 
 async function loadConfig(configPath: string): Promise<NotificationConfig> {
-  const raw = await readJsonFileOrNull(configPath);
-  if (raw === null) {
-    return NotificationConfigSchema.parse({});
-  }
-  const result = NotificationConfigSchema.safeParse(raw);
-  if (!result.success) {
-    console.error(`Warning: notification config has invalid format, resetting. (${result.error.message})`);
-    return NotificationConfigSchema.parse({});
-  }
-  return result.data;
+  return loadNotificationConfig(configPath);
 }
 
 async function saveConfig(configPath: string, config: NotificationConfig): Promise<void> {
-  await writeJsonFileAtomic(configPath, config);
+  await saveNotificationConfig(configPath, config);
 }
 
 function formatChannel(ch: NotificationChannel, index: number): string {
@@ -188,7 +177,7 @@ async function cmdNotifyAdd(args: string[], configPath: string): Promise<number>
 async function cmdNotifyList(configPath: string): Promise<number> {
   const config = await loadConfig(configPath);
 
-  if (config.channels.length === 0) {
+  if (config.channels.length === 0 && config.plugin_notifiers.routes.length === 0) {
     console.log("No channels configured");
     return 0;
   }
@@ -196,6 +185,13 @@ async function cmdNotifyList(configPath: string): Promise<number> {
   console.log("Notification Channels:");
   for (let i = 0; i < config.channels.length; i++) {
     console.log(formatChannel(config.channels[i]!, i));
+  }
+  console.log(`Plugin notifiers: ${config.plugin_notifiers.mode}`);
+  for (const route of config.plugin_notifiers.routes) {
+    const reports = route.report_types.length > 0
+      ? ` reports: ${route.report_types.join(", ")}`
+      : " reports: all";
+    console.log(`  ${route.id}: ${route.enabled ? "enabled" : "disabled"};${reports}`);
   }
   return 0;
 }
@@ -286,6 +282,24 @@ async function cmdNotifyTest(args: string[], configPath: string): Promise<number
   return 0;
 }
 
+async function cmdNotifyRoute(args: string[], configPath: string): Promise<number> {
+  const instruction = args.join(" ").trim();
+  if (!instruction) {
+    console.error("Usage: pulseed notify route <natural language instruction>");
+    return 1;
+  }
+
+  try {
+    const update = await applyNaturalLanguageNotificationRouting(instruction, configPath);
+    console.log(update.summary);
+    return 0;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Error: ${message}`);
+    return 1;
+  }
+}
+
 export async function cmdNotify(args: string[]): Promise<number> {
   const subcommand = args[0];
   const rest = args.slice(1);
@@ -304,15 +318,19 @@ export async function cmdNotify(args: string[]): Promise<number> {
     case "test":
       return cmdNotifyTest(rest, configPath);
 
+    case "route":
+      return cmdNotifyRoute(rest, configPath);
+
     default:
       console.error(
-        "Usage: pulseed notify <add|list|remove|test>\n" +
+        "Usage: pulseed notify <add|list|remove|test|route>\n" +
           "  add slack --webhook-url <url>\n" +
           "  add webhook --url <url> [--header 'Key: Value']\n" +
           "  add email --address <email> --smtp-host <host> [--smtp-port <port>]\n" +
           "  list\n" +
           "  remove <index>\n" +
-          "  test [index]"
+          "  test [index]\n" +
+          "  route <natural language instruction>"
       );
       return 1;
   }

--- a/src/interface/cli/commands/setup/steps-notification.ts
+++ b/src/interface/cli/commands/setup/steps-notification.ts
@@ -1,4 +1,5 @@
 import * as p from "@clack/prompts";
+import { NotificationConfigSchema } from "../../../../base/types/notification.js";
 import type { NotificationConfig } from "../../../../base/types/notification.js";
 import { guardCancel } from "./utils.js";
 
@@ -36,7 +37,7 @@ export async function stepNotification(): Promise<NotificationConfig | null> {
     })
   );
 
-  return {
+  return NotificationConfigSchema.parse({
     channels: [
       {
         type: "webhook",
@@ -65,5 +66,5 @@ export async function stepNotification(): Promise<NotificationConfig | null> {
       window_minutes: 30,
       digest_format: "compact",
     },
-  };
+  });
 }

--- a/src/interface/cli/commands/telegram.ts
+++ b/src/interface/cli/commands/telegram.ts
@@ -4,6 +4,7 @@
 //   1. Bot token (from @BotFather) — verified via getMe API
 //   2. chat_id (number) — instruct user to message the bot and use getUpdates
 //   3. allowed_user_ids (optional, comma-separated)
+//   4. identity_key (optional) — share one PulSeed session across chat platforms
 //
 // Writes config to ~/.pulseed/plugins/telegram-bot/config.json
 // Copies plugin.yaml from the repo if available.
@@ -156,7 +157,15 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
       }
     }
 
-    // Step 4: Write config
+    // Step 4: identity_key (optional)
+    console.log("\nStep 4: Cross-platform identity (optional)");
+    console.log("  Use the same key in Telegram, Discord, WhatsApp, and Signal configs");
+    console.log("  when they should continue the same PulSeed chat session.");
+    console.log("  Leave empty to keep this Telegram chat separate.\n");
+
+    const identityKey = await ask(rl, "Identity key (e.g. personal) or press Enter to skip: ");
+
+    // Step 5: Write config
     const pluginDir = getPluginDir();
     await ensurePluginDir(pluginDir);
 
@@ -165,6 +174,7 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
       chat_id: chatId,
       allowed_user_ids: allowedUserIds,
       polling_timeout: 30,
+      ...(identityKey ? { identity_key: identityKey } : {}),
     };
 
     const configPath = path.join(pluginDir, "config.json");
@@ -181,6 +191,11 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
       console.log(`  Allowed users: ${allowedUserIds.join(", ")}`);
     } else {
       console.log("  Allowed users: (all)");
+    }
+    if (identityKey) {
+      console.log(`  Identity key: ${identityKey}`);
+    } else {
+      console.log("  Identity key: (not set)");
     }
     console.log("\nRun 'pulseed plugin install' to activate the plugin.");
 

--- a/src/runtime/__tests__/notification-dispatcher-plugin.test.ts
+++ b/src/runtime/__tests__/notification-dispatcher-plugin.test.ts
@@ -152,6 +152,82 @@ describe("NotificationDispatcher — NotifierRegistry integration", () => {
     });
   });
 
+  it("routes daily and weekly reports through plugin notifiers", async () => {
+    const notifier = makeNotifier("report-target", ["goal_progress"]);
+    registry.register("report-target", notifier);
+
+    await dispatcher.dispatch(makeReport({ report_type: "weekly_report" }));
+
+    expect(notifier.notify).toHaveBeenCalledOnce();
+    const event = (notifier.notify as ReturnType<typeof vi.fn>).mock.calls[0][0] as NotificationEvent;
+    expect(event.type).toBe("goal_progress");
+    expect(event.details.report_type).toBe("weekly_report");
+  });
+
+  it("filters plugin notifier delivery through notification config", async () => {
+    dispatcher = new NotificationDispatcher(
+      {
+        plugin_notifiers: {
+          mode: "only",
+          routes: [{ id: "discord-bot", enabled: true, report_types: ["weekly_report"] }],
+        },
+      },
+      registry
+    );
+    const discord = makeNotifier("discord-bot", ["goal_progress"]);
+    const whatsapp = makeNotifier("whatsapp-webhook", ["goal_progress"]);
+    registry.register("discord-bot", discord);
+    registry.register("whatsapp-webhook", whatsapp);
+
+    await dispatcher.dispatch(makeReport({ report_type: "weekly_report" }));
+
+    expect(discord.notify).toHaveBeenCalledOnce();
+    expect(whatsapp.notify).not.toHaveBeenCalled();
+  });
+
+  it("applies DND suppression to plugin notifiers", async () => {
+    dispatcher = new NotificationDispatcher(
+      {
+        do_not_disturb: {
+          enabled: true,
+          start_hour: 0,
+          end_hour: 23,
+          exceptions: [],
+        },
+      },
+      registry
+    );
+    const notifier = makeNotifier("discord-bot", ["goal_complete"]);
+    registry.register("discord-bot", notifier);
+
+    await dispatcher.dispatch(makeReport({ report_type: "goal_completion" }));
+
+    expect(notifier.notify).not.toHaveBeenCalled();
+  });
+
+  it("applies cooldown suppression to plugin notifiers after a plugin delivery", async () => {
+    dispatcher = new NotificationDispatcher(
+      {
+        cooldown: {
+          goal_completion: 60,
+          urgent_alert: 0,
+          approval_request: 0,
+          stall_escalation: 60,
+          strategy_change: 30,
+          capability_escalation: 60,
+        },
+      },
+      registry
+    );
+    const notifier = makeNotifier("discord-bot", ["goal_complete"]);
+    registry.register("discord-bot", notifier);
+
+    await dispatcher.dispatch(makeReport({ report_type: "goal_completion" }));
+    await dispatcher.dispatch(makeReport({ report_type: "goal_completion", id: "r2" }));
+
+    expect(notifier.notify).toHaveBeenCalledOnce();
+  });
+
   it("one failing notifier does not prevent other notifiers from receiving event", async () => {
     const failing = makeNotifier("failing", ["goal_complete"], async () => {
       throw new Error("boom");

--- a/src/runtime/__tests__/notification-routing.test.ts
+++ b/src/runtime/__tests__/notification-routing.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { NotificationConfigSchema } from "../../base/types/notification.js";
+import {
+  applyNaturalLanguageNotificationRouting,
+  applyNaturalLanguageNotificationRoutingToConfig,
+} from "../notification-routing.js";
+
+describe("notification routing natural language updates", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("routes weekly reports only to Discord from a natural language instruction", () => {
+    const config = NotificationConfigSchema.parse({});
+
+    const update = applyNaturalLanguageNotificationRoutingToConfig(
+      config,
+      "週次レポートはDiscordだけに送って"
+    );
+
+    expect(update.config.plugin_notifiers.mode).toBe("only");
+    expect(update.config.plugin_notifiers.routes).toEqual([
+      {
+        id: "discord-bot",
+        enabled: true,
+        report_types: ["weekly_report"],
+      },
+    ]);
+  });
+
+  it("disables one notifier while leaving plugin routing in all mode", () => {
+    const config = NotificationConfigSchema.parse({});
+
+    const update = applyNaturalLanguageNotificationRoutingToConfig(
+      config,
+      "WhatsAppには通知を送らない"
+    );
+
+    expect(update.config.plugin_notifiers.mode).toBe("all");
+    expect(update.config.plugin_notifiers.routes).toEqual([
+      {
+        id: "whatsapp-webhook",
+        enabled: false,
+        report_types: [],
+      },
+    ]);
+  });
+
+  it("can disable all plugin notifier delivery", () => {
+    const config = NotificationConfigSchema.parse({});
+
+    const update = applyNaturalLanguageNotificationRoutingToConfig(
+      config,
+      "プラグイン通知は全部止めて"
+    );
+
+    expect(update.config.plugin_notifiers.mode).toBe("none");
+  });
+
+  it("does not overwrite an invalid notification config when applying a route", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-routing-invalid-"));
+    tmpDirs.push(tmpDir);
+    const configPath = path.join(tmpDir, "notification.json");
+    const invalidJson = JSON.stringify({ channels: [{ type: "webhook", url: "not-a-url" }] });
+    fs.writeFileSync(configPath, invalidJson, "utf-8");
+
+    await expect(
+      applyNaturalLanguageNotificationRouting("Discordだけ", configPath)
+    ).rejects.toThrow(/Invalid notification config/);
+
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(invalidJson);
+  });
+});

--- a/src/runtime/__tests__/plugin-loader.test.ts
+++ b/src/runtime/__tests__/plugin-loader.test.ts
@@ -307,6 +307,57 @@ describe("PluginLoader.validateInterface", () => {
   });
 });
 
+// ─── PluginLoader.preparePluginImplementation/initPluginIfNeeded ───
+
+describe("PluginLoader implementation preparation", () => {
+  let loader: PluginLoader;
+
+  beforeEach(() => {
+    loader = new PluginLoader(
+      makeAdapterRegistry(),
+      makeDataSourceRegistry(),
+      makeNotifierRegistry(),
+      "/tmp/plugins"
+    );
+  });
+
+  it("instantiates class default exports with the plugin directory and initializes them", async () => {
+    const init = vi.fn().mockResolvedValue(undefined);
+
+    class ClassNotifier implements INotifier {
+      readonly name = "class-notifier";
+
+      constructor(readonly pluginDir: string) {}
+
+      init = init;
+      notify = vi.fn().mockResolvedValue(undefined);
+      supports = vi.fn().mockReturnValue(true);
+    }
+
+    const impl = await loader.preparePluginImplementation(ClassNotifier, "/tmp/plugins/class-notifier");
+
+    expect(impl).toBeInstanceOf(ClassNotifier);
+    expect((impl as ClassNotifier).pluginDir).toBe("/tmp/plugins/class-notifier");
+    expect(() => loader.validateInterface("notifier", impl)).not.toThrow();
+
+    await loader.initPluginIfNeeded(impl);
+    expect(init).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses factory functions when the default export is not constructible", async () => {
+    const impl = makeNotifierImpl();
+    const factory = vi.fn(() => impl);
+
+    const prepared = await loader.preparePluginImplementation(
+      factory,
+      "/tmp/plugins/factory-notifier"
+    );
+
+    expect(prepared).toBe(impl);
+    expect(factory).toHaveBeenCalledWith("/tmp/plugins/factory-notifier");
+  });
+});
+
 // ─── PluginLoader.loadManifest ───
 
 describe("PluginLoader.loadManifest (mocked fs)", () => {

--- a/src/runtime/notification-dispatcher.ts
+++ b/src/runtime/notification-dispatcher.ts
@@ -32,6 +32,8 @@ function reportTypeToEventType(reportType: string): NotificationEventType | null
   switch (reportType) {
     case "goal_completion":
       return "goal_complete";
+    case "approval_request":
+      return "approval_needed";
     case "urgent_alert":
       return "approval_needed";
     case "stall_escalation":
@@ -41,6 +43,12 @@ function reportTypeToEventType(reportType: string): NotificationEventType | null
     case "capability_escalation":
       return "task_blocked";
     case "progress_update":
+      return "goal_progress";
+    case "daily_summary":
+      return "goal_progress";
+    case "weekly_report":
+      return "goal_progress";
+    case "execution_summary":
       return "goal_progress";
     case "schedule_change":
       return "schedule_change_detected";
@@ -171,11 +179,14 @@ export class NotificationDispatcher implements INotificationDispatcher {
    */
   private async dispatchToPluginNotifiers(report: Report): Promise<void> {
     if (!this.notifierRegistry) return;
+    if (this.isDND(report.report_type) || this.isCooldown(report.report_type)) return;
 
     const eventType = reportTypeToEventType(report.report_type);
     if (eventType === null) return;
 
-    const notifiers = this.notifierRegistry.findForEvent(eventType);
+    const notifiers = this.notifierRegistry
+      .findForEvent(eventType)
+      .filter((notifier) => this.pluginNotifierAcceptsReportType(notifier.name, report.report_type));
     if (notifiers.length === 0) return;
 
     const event: NotificationEvent = {
@@ -196,13 +207,19 @@ export class NotificationDispatcher implements INotificationDispatcher {
       notifiers.map((n) => n.notify(event))
     );
 
+    let delivered = false;
     for (let i = 0; i < settlements.length; i++) {
       const result = settlements[i];
       if (result.status === "rejected") {
         const notifierName = notifiers[i].name;
         const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
         this.logger?.error(`[NotificationDispatcher] plugin notifier "${notifierName}" failed: ${reason}`);
+      } else {
+        delivered = true;
       }
+    }
+    if (delivered) {
+      this.lastSent.set(report.report_type, Date.now());
     }
   }
 
@@ -276,6 +293,31 @@ export class NotificationDispatcher implements INotificationDispatcher {
   ): boolean {
     if (channel.report_types.length === 0) return true;
     return channel.report_types.includes(reportType);
+  }
+
+  /**
+   * Decide whether a registered INotifier should receive this report.
+   * mode=all keeps existing behavior unless a per-notifier route disables or narrows it.
+   * mode=only sends only to explicitly listed enabled routes.
+   * mode=none disables plugin notifier delivery while legacy channels still work.
+   */
+  private pluginNotifierAcceptsReportType(notifierName: string, reportType: string): boolean {
+    const routing = this.config.plugin_notifiers;
+    if (routing.mode === "none") {
+      return false;
+    }
+
+    const route = routing.routes.find((candidate) => candidate.id === notifierName);
+    if (routing.mode === "only" && route === undefined) {
+      return false;
+    }
+    if (route?.enabled === false) {
+      return false;
+    }
+    if (route && route.report_types.length > 0) {
+      return route.report_types.includes(reportType);
+    }
+    return true;
   }
 
   /** Dispatch to the correct sender based on channel type. */

--- a/src/runtime/notification-routing.ts
+++ b/src/runtime/notification-routing.ts
@@ -1,0 +1,198 @@
+import * as path from "node:path";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../base/utils/json-io.js";
+import { getPulseedDirPath } from "../base/utils/paths.js";
+import { NotificationConfigSchema } from "../base/types/notification.js";
+import type { NotificationConfig, PluginNotifierRoute } from "../base/types/notification.js";
+
+export interface NotificationRoutingUpdate {
+  config: NotificationConfig;
+  selected_notifiers: string[];
+  report_types: string[];
+  mode: "all" | "only" | "none";
+  summary: string;
+}
+
+interface NotifierAlias {
+  id: string;
+  labels: string[];
+}
+
+const NOTIFIER_ALIASES: NotifierAlias[] = [
+  { id: "discord-bot", labels: ["discord", "ディスコード"] },
+  { id: "whatsapp-webhook", labels: ["whatsapp", "what's app", "ワッツアップ", "ワッツアップ"] },
+  { id: "signal-bridge", labels: ["signal", "シグナル"] },
+  { id: "telegram-bot", labels: ["telegram", "テレグラム"] },
+  { id: "slack-notifier", labels: ["slack", "スラック"] },
+];
+
+const REPORT_TYPE_ALIASES: Array<{ reportTypes: string[]; labels: string[] }> = [
+  { reportTypes: ["urgent_alert", "approval_request"], labels: ["urgent", "緊急", "至急", "承認", "approval"] },
+  { reportTypes: ["stall_escalation"], labels: ["stall", "stuck", "停滞", "詰まり", "ブロック"] },
+  { reportTypes: ["goal_completion"], labels: ["complete", "completion", "完了", "達成"] },
+  { reportTypes: ["daily_summary"], labels: ["daily", "日次", "毎日", "朝", "夕方"] },
+  { reportTypes: ["weekly_report"], labels: ["weekly", "週次", "毎週"] },
+  { reportTypes: ["execution_summary"], labels: ["execution", "実行", "作業"] },
+  { reportTypes: ["strategy_change", "capability_escalation"], labels: ["strategy", "戦略", "方針", "capability", "能力"] },
+];
+
+export function getNotificationConfigPath(baseDir?: string): string {
+  return path.join(baseDir ?? getPulseedDirPath(), "notification.json");
+}
+
+export async function loadNotificationConfig(
+  configPath = getNotificationConfigPath(),
+  options: { invalid?: "default" | "throw" } = {}
+): Promise<NotificationConfig> {
+  const raw = await readJsonFileOrNull(configPath);
+  if (raw === null) {
+    return NotificationConfigSchema.parse({});
+  }
+  const result = NotificationConfigSchema.safeParse(raw);
+  if (!result.success) {
+    if (options.invalid === "throw") {
+      throw new Error(`Invalid notification config: ${result.error.message}`);
+    }
+    return NotificationConfigSchema.parse({});
+  }
+  return result.data;
+}
+
+export async function saveNotificationConfig(configPath: string, config: NotificationConfig): Promise<void> {
+  await writeJsonFileAtomic(configPath, config);
+}
+
+export async function applyNaturalLanguageNotificationRouting(
+  instruction: string,
+  configPath = getNotificationConfigPath()
+): Promise<NotificationRoutingUpdate> {
+  const config = await loadNotificationConfig(configPath, { invalid: "throw" });
+  const update = applyNaturalLanguageNotificationRoutingToConfig(config, instruction);
+  await saveNotificationConfig(configPath, update.config);
+  return update;
+}
+
+export function applyNaturalLanguageNotificationRoutingToConfig(
+  config: NotificationConfig,
+  instruction: string
+): NotificationRoutingUpdate {
+  const selected = detectNotifiers(instruction);
+  const reportTypes = detectReportTypes(instruction);
+  const mode = detectMode(instruction, selected.length);
+
+  const nextConfig = NotificationConfigSchema.parse(config);
+  const currentRoutes = nextConfig.plugin_notifiers.routes;
+
+  if (mode === "none") {
+    nextConfig.plugin_notifiers = {
+      mode: "none",
+      routes: currentRoutes,
+    };
+  } else {
+    nextConfig.plugin_notifiers = {
+      mode,
+      routes: mergeRoutes(currentRoutes, selected, reportTypes, !isDisableInstruction(instruction)),
+    };
+  }
+
+  return {
+    config: NotificationConfigSchema.parse(nextConfig),
+    selected_notifiers: selected,
+    report_types: reportTypes,
+    mode,
+    summary: buildSummary(mode, selected, reportTypes, instruction),
+  };
+}
+
+function mergeRoutes(
+  routes: PluginNotifierRoute[],
+  selected: string[],
+  reportTypes: string[],
+  enabled: boolean
+): PluginNotifierRoute[] {
+  const byId = new Map(routes.map((route) => [route.id, { ...route }]));
+  for (const id of selected) {
+    const existing = byId.get(id);
+    byId.set(id, {
+      id,
+      enabled,
+      report_types: reportTypes.length > 0 ? reportTypes : existing?.report_types ?? [],
+    });
+  }
+  return Array.from(byId.values());
+}
+
+function detectNotifiers(instruction: string): string[] {
+  const normalized = instruction.toLowerCase();
+  const selected: string[] = [];
+  for (const alias of NOTIFIER_ALIASES) {
+    if (alias.labels.some((label) => normalized.includes(label.toLowerCase()))) {
+      selected.push(alias.id);
+    }
+  }
+  return selected;
+}
+
+function detectReportTypes(instruction: string): string[] {
+  const normalized = instruction.toLowerCase();
+  const selected = new Set<string>();
+  for (const alias of REPORT_TYPE_ALIASES) {
+    if (alias.labels.some((label) => normalized.includes(label.toLowerCase()))) {
+      for (const reportType of alias.reportTypes) {
+        selected.add(reportType);
+      }
+    }
+  }
+  const hasGenericReport = ["report", "レポート", "報告"].some((label) => normalized.includes(label));
+  const hasSpecificReport = ["daily_summary", "weekly_report", "execution_summary"]
+    .some((reportType) => selected.has(reportType));
+  if (hasGenericReport && !hasSpecificReport) {
+    selected.add("daily_summary");
+    selected.add("weekly_report");
+    selected.add("execution_summary");
+  }
+  return Array.from(selected);
+}
+
+function detectMode(instruction: string, selectedCount: number): "all" | "only" | "none" {
+  if (isDisableInstruction(instruction) && selectedCount === 0) {
+    return "none";
+  }
+  const normalized = instruction.toLowerCase();
+  if (
+    normalized.includes("only") ||
+    normalized.includes("だけ") ||
+    normalized.includes("のみ") ||
+    normalized.includes("一本化")
+  ) {
+    return "only";
+  }
+  return "all";
+}
+
+function isDisableInstruction(instruction: string): boolean {
+  const normalized = instruction.toLowerCase();
+  return (
+    normalized.includes("disable") ||
+    normalized.includes("off") ||
+    normalized.includes("mute") ||
+    normalized.includes("stop") ||
+    normalized.includes("送らない") ||
+    normalized.includes("送信しない") ||
+    normalized.includes("止め") ||
+    normalized.includes("無効")
+  );
+}
+
+function buildSummary(
+  mode: "all" | "only" | "none",
+  selected: string[],
+  reportTypes: string[],
+  instruction: string
+): string {
+  if (mode === "none") {
+    return "Plugin notification delivery disabled from instruction: " + instruction;
+  }
+  const target = selected.length > 0 ? selected.join(", ") : "(no specific plugin notifier)";
+  const reportScope = reportTypes.length > 0 ? reportTypes.join(", ") : "all report types";
+  return `Plugin notification routing set to ${mode}: ${target} for ${reportScope}`;
+}

--- a/src/runtime/plugin-loader.ts
+++ b/src/runtime/plugin-loader.ts
@@ -5,6 +5,7 @@ import { getPluginsDir } from "../base/utils/paths.js";
 import { getPulseedVersion as getPackageVersion } from "../base/utils/pulseed-meta.js";
 import { writeJsonFileAtomic } from "../base/utils/json-io.js";
 import { ValidationError } from "../base/utils/errors.js";
+import { getGlobalCrossPlatformChatSessionManager } from "../interface/chat/cross-platform-session.js";
 import type { Logger } from "./logger.js";
 import {
   PluginManifestSchema,
@@ -100,6 +101,7 @@ export class PluginLoader {
     }
 
     // 2. Dynamically import the entry point
+    exposeCrossPlatformChatSessionManager();
     const entryPath = path.resolve(pluginDir, manifest.entry_point);
     if (!entryPath.startsWith(pluginDir + path.sep) && entryPath !== pluginDir) {
       throw new ValidationError(`Plugin entry point escapes plugin directory: ${manifest.entry_point}`);
@@ -114,7 +116,7 @@ export class PluginLoader {
       throw new Error(`Failed to import plugin entry point: ${entryPath} — ${msg}`);
     }
 
-    const impl = module.default;
+    const impl = await this.preparePluginImplementation(module.default, pluginDir);
     if (impl === undefined || impl === null) {
       throw new Error(
         `Plugin entry point has no default export: ${entryPath}`
@@ -123,11 +125,42 @@ export class PluginLoader {
 
     // 3. Validate interface compliance
     this.validateInterface(manifest.type, impl);
+    await this.initPluginIfNeeded(impl);
 
     // 4. Register in the appropriate registry
     await this.registerPlugin(manifest, impl, pluginDir);
 
     return this.buildSuccessState(manifest);
+  }
+
+  async preparePluginImplementation(impl: unknown, pluginDir: string): Promise<unknown> {
+    if (typeof impl !== "function") {
+      return impl;
+    }
+
+    try {
+      return new (impl as new (pluginDir: string) => unknown)(pluginDir);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!message.includes("not a constructor") && !message.includes("Class constructor")) {
+        throw err;
+      }
+      const result = (impl as (pluginDir: string) => unknown | Promise<unknown>)(pluginDir);
+      return await result;
+    }
+  }
+
+  async initPluginIfNeeded(impl: unknown): Promise<void> {
+    if (typeof impl !== "object" || impl === null || !("init" in impl)) {
+      return;
+    }
+
+    const init = (impl as { init?: unknown }).init;
+    if (typeof init !== "function") {
+      return;
+    }
+
+    await init.call(impl);
   }
 
   /**
@@ -365,6 +398,15 @@ export class PluginLoader {
 }
 
 // ─── Module-level helpers ───
+
+interface PulseedRuntimeGlobal {
+  __pulseedGetGlobalCrossPlatformChatSessionManager?: typeof getGlobalCrossPlatformChatSessionManager;
+}
+
+function exposeCrossPlatformChatSessionManager(): void {
+  (globalThis as typeof globalThis & PulseedRuntimeGlobal)
+    .__pulseedGetGlobalCrossPlatformChatSessionManager = getGlobalCrossPlatformChatSessionManager;
+}
 
 // ─── PulSeed version (read once from package.json) ───
 

--- a/src/runtime/types/notification.ts
+++ b/src/runtime/types/notification.ts
@@ -42,6 +42,19 @@ export const NotificationChannelSchema = z.discriminatedUnion("type", [
 ]);
 export type NotificationChannel = z.infer<typeof NotificationChannelSchema>;
 
+export const PluginNotifierRouteSchema = z.object({
+  id: z.string().min(1),
+  enabled: z.boolean().default(true),
+  report_types: z.array(z.string()).default([]),
+});
+export type PluginNotifierRoute = z.infer<typeof PluginNotifierRouteSchema>;
+
+export const PluginNotifierRoutingSchema = z.object({
+  mode: z.enum(["all", "only", "none"]).default("all"),
+  routes: z.array(PluginNotifierRouteSchema).default([]),
+}).default({});
+export type PluginNotifierRouting = z.infer<typeof PluginNotifierRoutingSchema>;
+
 // Do Not Disturb
 export const DoNotDisturbSchema = z.object({
   enabled: z.boolean().default(false),
@@ -82,6 +95,7 @@ export type NotificationBatching = z.infer<typeof NotificationBatchingSchema>;
 // Full notification config
 export const NotificationConfigSchema = z.object({
   channels: z.array(NotificationChannelSchema).default([]),
+  plugin_notifiers: PluginNotifierRoutingSchema,
   do_not_disturb: DoNotDisturbSchema.default({}),
   cooldown: NotificationCooldownSchema.default({}),
   goal_overrides: z.array(GoalReportingOverrideSchema).default([]),

--- a/src/tools/builtin/index.ts
+++ b/src/tools/builtin/index.ts
@@ -43,6 +43,7 @@ export { ArchiveGoalTool } from "../mutation/ArchiveGoalTool/ArchiveGoalTool.js"
 export { DeleteGoalTool } from "../mutation/DeleteGoalTool/DeleteGoalTool.js";
 export { TogglePluginTool } from "../mutation/TogglePluginTool/TogglePluginTool.js";
 export { UpdateConfigTool } from "../mutation/UpdateConfigTool/UpdateConfigTool.js";
+export { ConfigureNotificationRoutingTool } from "../mutation/ConfigureNotificationRoutingTool/ConfigureNotificationRoutingTool.js";
 export { ResetTrustTool } from "../mutation/ResetTrustTool/ResetTrustTool.js";
 export { RunAdapterTool } from "../execution/RunAdapterTool/RunAdapterTool.js";
 export { SpawnSessionTool } from "../execution/SpawnSessionTool/SpawnSessionTool.js";
@@ -109,6 +110,7 @@ import { ArchiveGoalTool } from "../mutation/ArchiveGoalTool/ArchiveGoalTool.js"
 import { DeleteGoalTool } from "../mutation/DeleteGoalTool/DeleteGoalTool.js";
 import { TogglePluginTool } from "../mutation/TogglePluginTool/TogglePluginTool.js";
 import { UpdateConfigTool } from "../mutation/UpdateConfigTool/UpdateConfigTool.js";
+import { ConfigureNotificationRoutingTool } from "../mutation/ConfigureNotificationRoutingTool/ConfigureNotificationRoutingTool.js";
 import { ResetTrustTool } from "../mutation/ResetTrustTool/ResetTrustTool.js";
 import { RunAdapterTool } from "../execution/RunAdapterTool/RunAdapterTool.js";
 import { SpawnSessionTool } from "../execution/SpawnSessionTool/SpawnSessionTool.js";
@@ -221,7 +223,7 @@ export function createBuiltinTools(deps?: BuiltinToolDeps): ITool[] {
     );
   }
 
-  tools.push(new TogglePluginTool(), new UpdateConfigTool());
+  tools.push(new TogglePluginTool(), new UpdateConfigTool(), new ConfigureNotificationRoutingTool());
 
   if (deps?.trustManager) {
     tools.push(new ResetTrustTool(deps.trustManager));

--- a/src/tools/mutation/ConfigureNotificationRoutingTool/ConfigureNotificationRoutingTool.ts
+++ b/src/tools/mutation/ConfigureNotificationRoutingTool/ConfigureNotificationRoutingTool.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata, ToolDescriptionContext } from "../../types.js";
+import { applyNaturalLanguageNotificationRouting } from "../../../runtime/notification-routing.js";
+import { DESCRIPTION } from "./prompt.js";
+import { TAGS, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
+
+export const ConfigureNotificationRoutingInputSchema = z.object({
+  instruction: z.string().min(1, "instruction is required"),
+});
+export type ConfigureNotificationRoutingInput = z.infer<typeof ConfigureNotificationRoutingInputSchema>;
+
+export class ConfigureNotificationRoutingTool implements ITool<ConfigureNotificationRoutingInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "configure_notification_routing",
+    aliases: ["route_notifications", "configure_reports"],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 4000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = ConfigureNotificationRoutingInputSchema;
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: ConfigureNotificationRoutingInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    try {
+      const update = await applyNaturalLanguageNotificationRouting(input.instruction);
+      return {
+        success: true,
+        data: update,
+        summary: update.summary,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        data: null,
+        summary: "ConfigureNotificationRoutingTool failed: " + message,
+        error: message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(_input: ConfigureNotificationRoutingInput, context: ToolCallContext): Promise<PermissionCheckResult> {
+    if (context.preApproved) return { status: "allowed" };
+    return {
+      status: "needs_approval",
+      reason: "Changing notification and report routing requires user confirmation",
+    };
+  }
+
+  isConcurrencySafe(_input?: ConfigureNotificationRoutingInput): boolean {
+    return false;
+  }
+}

--- a/src/tools/mutation/ConfigureNotificationRoutingTool/__tests__/ConfigureNotificationRoutingTool.test.ts
+++ b/src/tools/mutation/ConfigureNotificationRoutingTool/__tests__/ConfigureNotificationRoutingTool.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ConfigureNotificationRoutingTool } from "../ConfigureNotificationRoutingTool.js";
+import type { ToolCallContext } from "../../../types.js";
+
+vi.mock("../../../../base/utils/paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../base/utils/paths.js")>();
+  return {
+    ...actual,
+    getPulseedDirPath: vi.fn(() => "/tmp/pulseed-routing-tool-placeholder"),
+  };
+});
+
+import { getPulseedDirPath } from "../../../../base/utils/paths.js";
+
+function makeContext(): ToolCallContext {
+  return {
+    cwd: "/tmp",
+    goalId: "goal-1",
+    trustBalance: 50,
+    preApproved: true,
+    approvalFn: async () => true,
+  };
+}
+
+describe("ConfigureNotificationRoutingTool", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-routing-tool-"));
+    vi.mocked(getPulseedDirPath).mockReturnValue(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes plugin notifier routing from a natural language instruction", async () => {
+    const tool = new ConfigureNotificationRoutingTool();
+
+    const result = await tool.call(
+      { instruction: "週次レポートはDiscordだけに送って" },
+      makeContext()
+    );
+
+    expect(result.success).toBe(true);
+    const config = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "notification.json"), "utf-8")
+    ) as Record<string, unknown>;
+    expect(config["plugin_notifiers"]).toEqual({
+      mode: "only",
+      routes: [
+        {
+          id: "discord-bot",
+          enabled: true,
+          report_types: ["weekly_report"],
+        },
+      ],
+    });
+  });
+
+  it("requires approval when not pre-approved", async () => {
+    const tool = new ConfigureNotificationRoutingTool();
+
+    await expect(
+      tool.checkPermissions({ instruction: "Discordだけ" }, { ...makeContext(), preApproved: false })
+    ).resolves.toMatchObject({ status: "needs_approval" });
+  });
+});

--- a/src/tools/mutation/ConfigureNotificationRoutingTool/constants.ts
+++ b/src/tools/mutation/ConfigureNotificationRoutingTool/constants.ts
@@ -1,0 +1,4 @@
+export const TAGS = ["mutation", "config", "notification"] as const;
+export const CATEGORY = "mutation";
+export const READ_ONLY = false;
+export const PERMISSION_LEVEL = "write_local" as const;

--- a/src/tools/mutation/ConfigureNotificationRoutingTool/prompt.ts
+++ b/src/tools/mutation/ConfigureNotificationRoutingTool/prompt.ts
@@ -1,0 +1,4 @@
+export const DESCRIPTION = `Configure notification and report routing from a natural language instruction.
+Use this when the user says things like "weekly reports only to Discord",
+"send urgent alerts to WhatsApp", "stop plugin notifications", or
+"レポートはDiscordだけ、緊急通知はWhatsApp".`;


### PR DESCRIPTION
## Summary
- add PulSeed-native Discord, WhatsApp Cloud webhook, and Signal Bridge bidirectional input plugins, excluding voice memo transcription
- add a shared cross-platform chat session manager keyed by identity_key and wire Telegram into it
- add natural-language notification/report routing through `configure_notification_routing` and `pulseed notify route`
- load notification routing in the daemon and apply DND/cooldown to plugin notifiers

## Validation
- npm run build
- npm run typecheck
- npm test
- npm test --prefix plugins/discord-bot
- npm test --prefix plugins/whatsapp-webhook
- npm test --prefix plugins/signal-bridge
- npm run build --prefix plugins/discord-bot
- npm run build --prefix plugins/whatsapp-webhook
- npm run build --prefix plugins/signal-bridge

Note: full `npm test` emitted git pathspec warnings for newly added plugin files while they were untracked locally, but completed successfully.