### PR TITLE
Wire CLI ToolExecutor into production runtime

### DIFF
--- a/src/interface/cli/__tests__/cli-setup-tools.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-tools.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+vi.mock("../../../base/llm/provider-factory.js", () => ({
+  buildLLMClient: vi.fn().mockResolvedValue({
+    sendMessage: vi.fn().mockResolvedValue({ content: "mock" }),
+    parseJSON: vi.fn().mockResolvedValue({}),
+  }),
+  buildAdapterRegistry: vi.fn().mockResolvedValue({
+    register: vi.fn(),
+    getAdapter: vi.fn(),
+    getAdapterCapabilities: vi.fn().mockReturnValue([]),
+  }),
+}));
+
+import { StateManager } from "../../../base/state/state-manager.js";
+import { CharacterConfigManager } from "../../../platform/traits/character-config.js";
+import { buildDeps } from "../setup.js";
+
+describe("CLI buildDeps tool wiring", () => {
+  let tempDir: string;
+  let originalPulseedHome: string | undefined;
+  let originalOpenAIKey: string | undefined;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-cli-setup-"));
+    originalPulseedHome = process.env["PULSEED_HOME"];
+    originalOpenAIKey = process.env["OPENAI_API_KEY"];
+    process.env["PULSEED_HOME"] = tempDir;
+    delete process.env["OPENAI_API_KEY"];
+  });
+
+  afterEach(() => {
+    if (originalPulseedHome === undefined) {
+      delete process.env["PULSEED_HOME"];
+    } else {
+      process.env["PULSEED_HOME"] = originalPulseedHome;
+    }
+    if (originalOpenAIKey === undefined) {
+      delete process.env["OPENAI_API_KEY"];
+    } else {
+      process.env["OPENAI_API_KEY"] = originalOpenAIKey;
+    }
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("wires ToolExecutor into CLI runtime and executes a read-only tool", async () => {
+    const stateManager = new StateManager(tempDir);
+    const characterConfigManager = new CharacterConfigManager(stateManager);
+    const deps = await buildDeps(
+      stateManager,
+      characterConfigManager,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      process.cwd(),
+    );
+
+    expect(deps.toolRegistry.get("glob")).toBeDefined();
+    expect(deps.toolRegistry.get("observe-goal")).toBeDefined();
+
+    const coreLoopDeps = (deps.coreLoop as unknown as { deps: Record<string, unknown> }).deps;
+    expect(coreLoopDeps["toolExecutor"]).toBe(deps.toolExecutor);
+    expect(coreLoopDeps["toolRegistry"]).toBe(deps.toolRegistry);
+    expect((coreLoopDeps["observationEngine"] as { toolExecutor?: unknown }).toolExecutor).toBe(deps.toolExecutor);
+    expect((coreLoopDeps["taskLifecycle"] as { toolExecutor?: unknown }).toolExecutor).toBe(deps.toolExecutor);
+
+    const result = await deps.toolExecutor.execute(
+      "glob",
+      { pattern: "package.json", path: "." },
+      {
+        cwd: process.cwd(),
+        goalId: "cli-setup-tools",
+        trustBalance: 100,
+        preApproved: true,
+        trusted: true,
+        approvalFn: async () => true,
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.artifacts?.some((artifact) => artifact.endsWith("package.json"))).toBe(true);
+  });
+});

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -31,6 +31,7 @@ import { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
 import { TaskLifecycle } from "../../orchestrator/execution/task/task-lifecycle.js";
 import { ReportingEngine } from "../../reporting/reporting-engine.js";
 import { CoreLoop } from "../../orchestrator/loop/core-loop.js";
+import { ScheduleEngine } from "../../runtime/schedule/engine.js";
 import { TreeLoopOrchestrator } from "../../orchestrator/goal/tree-loop-orchestrator.js";
 import { GoalTreeManager } from "../../orchestrator/goal/goal-tree-manager.js";
 import { StateAggregator } from "../../orchestrator/goal/state-aggregator.js";
@@ -52,6 +53,8 @@ import { TimeHorizonEngine } from "../../platform/time/time-horizon-engine.js";
 import { HookManager } from "../../runtime/hook-manager.js";
 import { getCliLogger } from "./cli-logger.js";
 import { formatOperationError } from "./utils.js";
+import { ToolRegistry, ToolExecutor, ToolPermissionManager, ConcurrencyController, createBuiltinTools } from "../../tools/index.js";
+import { isSafeBashCommand } from "../tui/bash-mode.js";
 
 export function createCliDataSourceAdapter(cfg: DataSourceConfig): IDataSourceAdapter | null {
   if (cfg.type === "file") {
@@ -97,6 +100,37 @@ export async function buildDeps(
   const llmClient = await buildLLMClient();
   const trustManager = new TrustManager(stateManager);
   const driveSystem = new DriveSystem(stateManager);
+  const adapterRegistry = await buildAdapterRegistry(llmClient);
+  const scheduleEngine = new ScheduleEngine({ baseDir: stateManager.getBaseDir() });
+  await scheduleEngine.loadEntries();
+  const toolRegistry = new ToolRegistry();
+  const registerBuiltinTools = (deps?: Parameters<typeof createBuiltinTools>[0]) => {
+    for (const tool of createBuiltinTools(deps)) {
+      if (!toolRegistry.get(tool.metadata.name)) {
+        toolRegistry.register(tool);
+      }
+    }
+  };
+  registerBuiltinTools({ stateManager, trustManager, registry: toolRegistry, scheduleEngine });
+  const permissionManager = new ToolPermissionManager({
+    trustManager,
+    allowRules: [
+      {
+        toolName: "shell",
+        inputMatcher: (input) =>
+          typeof input === "object" &&
+          input !== null &&
+          typeof (input as Record<string, unknown>)["command"] === "string" &&
+          isSafeBashCommand((input as Record<string, unknown>)["command"] as string),
+        reason: "safe shell command",
+      },
+    ],
+  });
+  const toolExecutor = new ToolExecutor({
+    registry: toolRegistry,
+    permissionManager,
+    concurrency: new ConcurrencyController(),
+  });
 
   // Read datasource configs from ~/.pulseed/datasources/
   const dsDir = getDatasourcesDir();
@@ -157,6 +191,7 @@ export async function buildDeps(
   const observationPreChecker = new DimensionPreChecker({
     min_observation_interval_sec: 60,
     strategies: ["age", "git_diff"],
+    toolExecutor,
   });
   const observationEngine = new ObservationEngine(
     stateManager,
@@ -166,7 +201,8 @@ export async function buildDeps(
     {},
     logger,
     observationPreChecker,
-    hookManager
+    hookManager,
+    toolExecutor
   );
   const progressPredictor = new ProgressPredictor();
   const stallDetector = new StallDetector(stateManager, characterConfig, progressPredictor);
@@ -177,7 +213,7 @@ export async function buildDeps(
   const goalDependencyGraph = new GoalDependencyGraph(stateManager, llmClient, undefined, logger);
   const sessionManager = new SessionManager(stateManager, goalDependencyGraph);
   const strategyManager = new StrategyManager(stateManager, llmClient);
-  const adapterRegistry = await buildAdapterRegistry(llmClient);
+  strategyManager.setToolExecutor?.(toolExecutor);
 
   const reportingEngine = new ReportingEngine(stateManager, undefined, characterConfig);
 
@@ -229,6 +265,12 @@ export async function buildDeps(
     vectorIndex,
     embeddingClient,
   );
+  registerBuiltinTools({
+    adapterRegistry,
+    knowledgeManager,
+    observationEngine,
+    sessionManager,
+  });
 
   const taskLifecycle = new TaskLifecycle({
     stateManager,
@@ -244,6 +286,7 @@ export async function buildDeps(
       adapterRegistry,
       knowledgeManager,
       memoryLifecycle: memoryLifecycleManager,
+      toolExecutor,
     },
   });
 
@@ -306,6 +349,8 @@ export async function buildDeps(
     contextProvider,
     onProgress,
     goalRefiner,
+    toolExecutor,
+    toolRegistry,
   }, config);
 
   coreLoop.setTimeHorizonEngine(new TimeHorizonEngine());
@@ -331,5 +376,7 @@ export async function buildDeps(
     hookManager,
     memoryLifecycleManager,
     knowledgeManager,
+    toolExecutor,
+    toolRegistry,
   };
 }

--- a/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import {
   type CoreLoopDeps,
   type GapCalculatorModule,
@@ -252,6 +253,36 @@ afterEach(() => {
 // ─── Tests ───
 
 describe("detectStallsAndRebalance — reRefineLeaf on observation-failure stall", () => {
+  it("uses the goal workspace_path for tool-based stall evidence", async () => {
+    const deps = createBaseDeps(tmpDir);
+    const workspacePath = path.join(tmpDir, "workspace");
+    fs.mkdirSync(workspacePath, { recursive: true });
+    const goal = makeGoal({
+      id: "goal-1",
+      constraints: [`workspace_path:${workspacePath}`],
+    });
+    await deps.stateManager.saveGoal(goal);
+    await deps.stateManager.saveGapHistory("goal-1", []);
+
+    const execute = vi.fn().mockResolvedValue({
+      success: true,
+      data: "",
+      summary: "no changes",
+      durationMs: 0,
+    });
+    const ctx = buildPhaseCtx(deps, { maxIterations: 10, adapterType: "openai_codex_cli" });
+    ctx.toolExecutor = { execute } as never;
+    const result = makeIterationResult();
+
+    await detectStallsAndRebalance(ctx, "goal-1", goal, result);
+
+    expect(execute).toHaveBeenCalledWith(
+      "git-diff",
+      { target: "unstaged", path: workspacePath },
+      expect.objectContaining({ cwd: workspacePath, goalId: "goal-1" }),
+    );
+  });
+
   it("calls reRefineLeaf() when stall suggested_cause is information_deficit and goalRefiner is present", async () => {
     const deps = createBaseDeps(tmpDir);
 

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -30,6 +30,12 @@ import type { CapabilityAcquisitionOutcome } from "./capability.js";
 
 // ─── Phase 5 ───
 
+function resolveGoalWorkspacePath(goal: Goal): string | undefined {
+  const constraint = goal.constraints.find((entry) => entry.startsWith("workspace_path:"));
+  const workspacePath = constraint?.slice("workspace_path:".length).trim();
+  return workspacePath || undefined;
+}
+
 /** Completion check + milestone deadline check.
  * Sets result.error on fatal failure, sets result.completionJudgment. */
 export async function checkCompletionAndMilestones(
@@ -127,14 +133,15 @@ export async function detectStallsAndRebalance(
     // Gather tool-based workspace evidence for stall detection (Phase 6)
     if (ctx.toolExecutor) {
       try {
+        const workspacePath = resolveGoalWorkspacePath(goal);
         const toolContext = {
-          cwd: process.cwd(),
+          cwd: workspacePath ?? process.cwd(),
           goalId,
           trustBalance: 0,
           preApproved: true,
           approvalFn: async () => false,
         };
-        const evidence = await gatherStallEvidence(ctx.toolExecutor, toolContext);
+        const evidence = await gatherStallEvidence(ctx.toolExecutor, toolContext, workspacePath);
         result.toolStallEvidence = evidence;
         if (!evidence.hasWorkspaceChanges) {
           ctx.logger?.info("CoreLoop: stall evidence — no workspace changes detected", { goalId, toolErrors: evidence.toolErrors });

--- a/src/runtime/__tests__/watchdog.test.ts
+++ b/src/runtime/__tests__/watchdog.test.ts
@@ -212,76 +212,74 @@ describe("RuntimeWatchdog", () => {
   });
 
   it("restarts the child when the live daemon health probe fails repeatedly", async () => {
-    tmpDir = makeTempDir();
-    const runtimeRoot = path.join(tmpDir, "runtime");
-    const pidManager = new PIDManager(tmpDir);
-    const healthStore = new RuntimeHealthStore(runtimeRoot);
-    const leaderLockManager = new LeaderLockManager(runtimeRoot, 60);
-    await healthStore.ensureReady();
+    vi.useFakeTimers();
+    try {
+      tmpDir = makeTempDir();
+      const runtimeRoot = path.join(tmpDir, "runtime");
+      const pidManager = new PIDManager(tmpDir);
+      const healthStore = new RuntimeHealthStore(runtimeRoot);
+      const leaderLockManager = new LeaderLockManager(runtimeRoot, 60);
+      await healthStore.ensureReady();
 
-    const children: FakeChildProcess[] = [];
-    const healthProbe = vi.fn()
-      .mockResolvedValueOnce({ ok: false, detail: "ECONNREFUSED" })
-      .mockResolvedValueOnce({ ok: false, detail: "ECONNREFUSED" })
-      .mockResolvedValue({ ok: true });
-    const watchdog = new RuntimeWatchdog({
-      pidManager,
-      healthStore,
-      leaderLockManager,
-      logger: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      startChild: () => {
-        const child = new FakeChildProcess(30_000 + children.length);
-        children.push(child);
-        return child;
-      },
-      healthProbe,
-      healthProbeFailureThreshold: 2,
-      pollIntervalMs: 20,
-      heartbeatTimeoutMs: 200,
-      startupGraceMs: 40,
-      restartBackoffMs: 10,
-      maxRestartBackoffMs: 20,
-      childShutdownGraceMs: 10,
-    });
+      const children: FakeChildProcess[] = [];
+      const healthProbe = vi.fn().mockResolvedValue({ ok: false, detail: "ECONNREFUSED" });
+      const watchdog = new RuntimeWatchdog({
+        pidManager,
+        healthStore,
+        leaderLockManager,
+        logger: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        startChild: () => {
+          const child = new FakeChildProcess(30_000 + children.length);
+          children.push(child);
+          return child;
+        },
+        healthProbe,
+        healthProbeFailureThreshold: 2,
+        pollIntervalMs: 20,
+        heartbeatTimeoutMs: 200,
+        startupGraceMs: 40,
+        restartBackoffMs: 10,
+        maxRestartBackoffMs: 20,
+        childShutdownGraceMs: 10,
+      });
 
-    const startPromise = watchdog.start();
+      const startPromise = watchdog.start();
 
-    await waitFor(() => children.length === 1);
-    await writeLeaderRecord(runtimeRoot, children[0]!.pid, Date.now() + 500);
-    await healthStore.saveDaemonHealth({
-      status: "ok",
-      leader: true,
-      checked_at: Date.now(),
-      kpi: {
-        process_alive: { status: "ok", checked_at: Date.now(), last_ok_at: Date.now() },
-        command_acceptance: { status: "ok", checked_at: Date.now(), last_ok_at: Date.now() },
-        task_execution: { status: "ok", checked_at: Date.now(), last_ok_at: Date.now() },
-      },
-      details: { pid: children[0]!.pid },
-    });
+      await vi.waitFor(() => {
+        expect(children.length).toBe(1);
+      });
+      await writeLeaderRecord(runtimeRoot, children[0]!.pid, Date.now() + 500);
+      await healthStore.saveDaemonHealth({
+        status: "ok",
+        leader: true,
+        checked_at: Date.now(),
+        kpi: {
+          process_alive: { status: "ok", checked_at: Date.now(), last_ok_at: Date.now() },
+          command_acceptance: { status: "ok", checked_at: Date.now(), last_ok_at: Date.now() },
+          task_execution: { status: "ok", checked_at: Date.now(), last_ok_at: Date.now() },
+        },
+        details: { pid: children[0]!.pid },
+      });
 
-    await waitFor(() => children.length === 2, 2_000, 20);
-    expect(children[0]!.kills).toContain("SIGTERM");
-    expect(healthProbe).toHaveBeenCalledTimes(2);
+      await vi.advanceTimersByTimeAsync(120);
+      await vi.waitFor(() => {
+        expect(children.length).toBe(2);
+      });
+      watchdog.stop();
+      for (const child of children) {
+        child.kill("SIGTERM");
+      }
+      await vi.runOnlyPendingTimersAsync();
+      await startPromise;
 
-    await writeLeaderRecord(runtimeRoot, children[1]!.pid, Date.now() + 500);
-    await healthStore.saveDaemonHealth({
-      status: "ok",
-      leader: true,
-      checked_at: Date.now(),
-      kpi: {
-        process_alive: { status: "ok", checked_at: Date.now(), last_ok_at: Date.now() },
-        command_acceptance: { status: "ok", checked_at: Date.now(), last_ok_at: Date.now() },
-        task_execution: { status: "ok", checked_at: Date.now(), last_ok_at: Date.now() },
-      },
-      details: { pid: children[1]!.pid },
-    });
-
-    watchdog.stop();
-    await startPromise;
-  });
+      expect(children[0]!.kills).toContain("SIGTERM");
+      expect(healthProbe.mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 15_000);
 });

--- a/src/tools/query/GoalStateTool/GoalStateTool.ts
+++ b/src/tools/query/GoalStateTool/GoalStateTool.ts
@@ -13,7 +13,7 @@ export type GoalStateInput = z.infer<typeof GoalStateInputSchema>;
 export class GoalStateTool implements ITool<GoalStateInput, unknown> {
   readonly metadata: ToolMetadata = {
     name: "goal_state",
-    aliases: ["get_goal_state", "observe_goal"],
+    aliases: ["get_goal_state", "read_goal_state"],
     permissionLevel: PERMISSION_LEVEL,
     isReadOnly: true,
     isDestructive: false,


### PR DESCRIPTION
## Summary\n- build ToolRegistry/ToolExecutor in CLI buildDeps and inject them into ObservationEngine, TaskLifecycle, CoreLoop, and StrategyManager\n- register observation-backed tools on the production CLI registry and resolve the observe_goal alias conflict\n- use goal workspace_path for tool-based stall evidence instead of ambient cwd\n\n## Issue handling\n- Closes #631\n- Part of #630\n- Re-triaged and closed stale daemon/queue issues #628, #629, #602, #603, and #607 after isolated daemon smoke checks and current-code inspection\n\n## Verification\n- npm run typecheck\n- npm run build\n- npm test\n- isolated daemon smoke: start --detach with zero goals, status idle, stop, start again, status idle, stop\n