### PR TITLE
[codex] Wire workspace and learning runtime deps

### DIFF
--- a/src/interface/cli/__tests__/cli-daemon-start.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-start.test.ts
@@ -228,6 +228,8 @@ describe("cmdStart", () => {
         warn: expect.any(Function),
         error: expect.any(Function),
       }),
+      undefined,
+      undefined,
     );
 
     expect(scheduleEngineArgs).toHaveLength(1);
@@ -249,6 +251,31 @@ describe("cmdStart", () => {
     );
     expect(daemonStartMock).toHaveBeenCalledWith(["goal-1"]);
     expect(watchdogStartMock).not.toHaveBeenCalled();
+  });
+
+  it("passes explicit daemon workspace into buildDeps and DaemonRunner", async () => {
+    process.env.PULSEED_WATCHDOG_CHILD = "1";
+
+    await cmdStart(
+      { getBaseDir: vi.fn().mockReturnValue("/tmp/pulseed-daemon-start-base") } as never,
+      {} as never,
+      ["--workspace", "/tmp/pulseed-workspace"]
+    );
+
+    expect(buildDepsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      expect.any(Function),
+      expect.any(Object),
+      undefined,
+      "/tmp/pulseed-workspace",
+    );
+    expect(daemonRunnerArgs[0]).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({ workspace_path: "/tmp/pulseed-workspace" }),
+      })
+    );
   });
 
   it("launches RuntimeWatchdog on the top-level daemon start path", async () => {

--- a/src/interface/cli/__tests__/cli-install.test.ts
+++ b/src/interface/cli/__tests__/cli-install.test.ts
@@ -195,6 +195,21 @@ describe("buildPlist", () => {
     expect(xml).toContain("<string>5000</string>");
   });
 
+  it("includes --workspace when workspace is provided", () => {
+    const xml = buildPlist({
+      nodePath: "/usr/local/bin/node",
+      cliRunnerPath: "/app/dist/cli/cli-runner.js",
+      goalIds: ["g1"],
+      stdoutLog: "/logs/out.log",
+      stderrLog: "/logs/err.log",
+      workingDir: "/work/project",
+      workspace: "/work/project",
+    });
+
+    expect(xml).toContain("<string>--workspace</string>");
+    expect(xml).toContain("<string>/work/project</string>");
+  });
+
   it("escapes special XML characters in paths", () => {
     const xml = buildPlist({
       nodePath: "/usr/local/bin/node",
@@ -291,6 +306,26 @@ describe("cmdInstall", () => {
     );
     expect(execFileNoThrow).toHaveBeenCalledWith("launchctl", ["load", PLIST_PATH]);
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining(PLIST_PATH));
+    logSpy.mockRestore();
+  });
+
+  it("writes explicit workspace into launchd arguments and WorkingDirectory", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const code = await cmdInstall(["--goal", "goal-1", "--workspace", "/tmp/pulseed-workspace"]);
+
+    expect(code).toBe(0);
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      PLIST_PATH,
+      expect.stringContaining("<string>--workspace</string>"),
+      "utf8"
+    );
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      PLIST_PATH,
+      expect.stringContaining("<string>/tmp/pulseed-workspace</string>"),
+      "utf8"
+    );
     logSpy.mockRestore();
   });
 

--- a/src/interface/cli/__tests__/cli-setup-tools.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-tools.test.ts
@@ -49,6 +49,8 @@ describe("CLI buildDeps tool wiring", () => {
   it("wires ToolExecutor into CLI runtime and executes a read-only tool", async () => {
     const stateManager = new StateManager(tempDir);
     const characterConfigManager = new CharacterConfigManager(stateManager);
+    const workspaceDir = fs.mkdtempSync(path.join(tempDir, "workspace-"));
+    fs.writeFileSync(path.join(workspaceDir, "package.json"), "{}\n", "utf-8");
     const deps = await buildDeps(
       stateManager,
       characterConfigManager,
@@ -56,7 +58,7 @@ describe("CLI buildDeps tool wiring", () => {
       undefined,
       undefined,
       undefined,
-      process.cwd(),
+      workspaceDir,
     );
 
     expect(deps.toolRegistry.get("glob")).toBeDefined();
@@ -65,14 +67,18 @@ describe("CLI buildDeps tool wiring", () => {
     const coreLoopDeps = (deps.coreLoop as unknown as { deps: Record<string, unknown> }).deps;
     expect(coreLoopDeps["toolExecutor"]).toBe(deps.toolExecutor);
     expect(coreLoopDeps["toolRegistry"]).toBe(deps.toolRegistry);
+    expect(coreLoopDeps["learningPipeline"]).toBe(deps.learningPipeline);
     expect((coreLoopDeps["observationEngine"] as { toolExecutor?: unknown }).toolExecutor).toBe(deps.toolExecutor);
     expect((coreLoopDeps["taskLifecycle"] as { toolExecutor?: unknown }).toolExecutor).toBe(deps.toolExecutor);
+    expect((coreLoopDeps["taskLifecycle"] as { knowledgeTransfer?: unknown }).knowledgeTransfer).toBe(deps.knowledgeTransfer);
+    expect((coreLoopDeps["taskLifecycle"] as { revertCwd?: unknown }).revertCwd).toBe(workspaceDir);
+    expect((coreLoopDeps["taskLifecycle"] as { healthCheckCwd?: unknown }).healthCheckCwd).toBe(workspaceDir);
 
     const result = await deps.toolExecutor.execute(
       "glob",
       { pattern: "package.json", path: "." },
       {
-        cwd: process.cwd(),
+        cwd: workspaceDir,
         goalId: "cli-setup-tools",
         trustBalance: 100,
         preApproved: true,

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -67,7 +67,7 @@ export async function cmdStart(
   characterConfigManager: CharacterConfigManager,
   args: string[]
 ): Promise<void> {
-  let values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string };
+  let values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; workspace?: string };
   try {
     ({ values } = parseArgs({
       args,
@@ -78,9 +78,10 @@ export async function cmdStart(
         detach: { type: "boolean", short: "d" },
         "check-interval-ms": { type: "string" },
         "iterations-per-cycle": { type: "string" },
+        workspace: { type: "string" },
       },
       strict: false,
-    }) as { values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string } });
+    }) as { values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; workspace?: string } });
   } catch (err) {
     getCliLogger().error(formatOperationError("parse start command arguments", err));
     values = {};
@@ -136,6 +137,10 @@ export async function cmdStart(
     }
     daemonConfig = daemonConfig ?? {};
     daemonConfig.iterations_per_cycle = parsed;
+  }
+  if (values.workspace) {
+    daemonConfig = daemonConfig ?? {};
+    daemonConfig.workspace_path = path.resolve(values.workspace);
   }
 
   const resolvedDaemonConfig = DaemonConfigSchema.parse(daemonConfig ?? {});
@@ -246,6 +251,8 @@ export async function cmdStart(
     undefined,
     approvalBridge,
     logger,
+    undefined,
+    resolvedDaemonConfig.workspace_path,
   );
 
   // Load notifier plugins and wire NotificationDispatcher
@@ -301,6 +308,8 @@ export async function cmdStart(
       undefined,
       approvalBridge,
       logger,
+      undefined,
+      resolvedDaemonConfig.workspace_path,
     );
     freshDeps.reportingEngine.setNotificationDispatcher(notificationDispatcher);
 

--- a/src/interface/cli/commands/install.ts
+++ b/src/interface/cli/commands/install.ts
@@ -28,6 +28,7 @@ export function buildPlist(opts: {
   stdoutLog: string;
   stderrLog: string;
   workingDir: string;
+  workspace?: string;
   envPath?: string;
   pulseedHome?: string;
 }): string {
@@ -40,6 +41,9 @@ export function buildPlist(opts: {
   }
   if (opts.intervalMs !== undefined) {
     programArgs.push("--check-interval-ms", String(opts.intervalMs));
+  }
+  if (opts.workspace) {
+    programArgs.push("--workspace", opts.workspace);
   }
 
   const argEntries = programArgs
@@ -103,7 +107,7 @@ export async function cmdInstall(args: string[]): Promise<number> {
     return 1;
   }
 
-  let values: { goal?: string[]; config?: string; interval?: string };
+  let values: { goal?: string[]; config?: string; interval?: string; workspace?: string };
   try {
     ({ values } = parseArgs({
       args,
@@ -111,9 +115,10 @@ export async function cmdInstall(args: string[]): Promise<number> {
         goal: { type: "string", multiple: true },
         config: { type: "string" },
         interval: { type: "string" },
+        workspace: { type: "string" },
       },
       strict: false,
-    }) as { values: { goal?: string[]; config?: string; interval?: string } });
+    }) as { values: { goal?: string[]; config?: string; interval?: string; workspace?: string } });
   } catch {
     console.error("Failed to parse arguments");
     return 1;
@@ -139,7 +144,7 @@ export async function cmdInstall(args: string[]): Promise<number> {
   const logsDir = path.join(home, ".pulseed", "logs");
   const stdoutLog = path.join(logsDir, "launchd-stdout.log");
   const stderrLog = path.join(logsDir, "launchd-stderr.log");
-  const workingDir = process.cwd();
+  const workingDir = path.resolve(values.workspace ?? process.cwd());
 
   const plistContent = buildPlist({
     nodePath,
@@ -150,6 +155,7 @@ export async function cmdInstall(args: string[]): Promise<number> {
     stdoutLog,
     stderrLog,
     workingDir,
+    workspace: workingDir,
     envPath: process.env["PATH"],
     pulseedHome: process.env["PULSEED_HOME"],
   });

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -42,6 +42,8 @@ import { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js"
 import { VectorIndex } from "../../platform/knowledge/vector-index.js";
 import { OpenAIEmbeddingClient, MockEmbeddingClient } from "../../platform/knowledge/embedding-client.js";
 import type { IEmbeddingClient } from "../../platform/knowledge/embedding-client.js";
+import { LearningPipeline } from "../../platform/knowledge/learning/learning-pipeline.js";
+import { KnowledgeTransfer } from "../../platform/knowledge/transfer/knowledge-transfer.js";
 import { CharacterConfigManager } from "../../platform/traits/character-config.js";
 import * as GapCalculator from "../../platform/drive/gap-calculator.js";
 import * as DriveScorer from "../../platform/drive/drive-scorer.js";
@@ -56,7 +58,10 @@ import { formatOperationError } from "./utils.js";
 import { ToolRegistry, ToolExecutor, ToolPermissionManager, ConcurrencyController, createBuiltinTools } from "../../tools/index.js";
 import { isSafeBashCommand } from "../tui/bash-mode.js";
 
-export function createCliDataSourceAdapter(cfg: DataSourceConfig): IDataSourceAdapter | null {
+export function createCliDataSourceAdapter(
+  cfg: DataSourceConfig,
+  workspacePath = process.cwd(),
+): IDataSourceAdapter | null {
   if (cfg.type === "file") {
     return new FileDataSourceAdapter(cfg);
   }
@@ -76,7 +81,7 @@ export function createCliDataSourceAdapter(cfg: DataSourceConfig): IDataSourceAd
     const adapter = new ShellDataSourceAdapter(
       cfg.id,
       (cfg.connection.commands ?? {}) as Record<string, import("../../adapters/datasources/shell-datasource.js").ShellCommandSpec>,
-      cfg.connection?.path ?? process.cwd()
+      cfg.connection?.path ?? workspacePath
     );
     if (cfg.scope_goal_id) {
       (adapter.config as Record<string, unknown>).scope_goal_id = cfg.scope_goal_id;
@@ -96,6 +101,7 @@ export async function buildDeps(
   onProgress?: (event: ProgressEvent) => void,
   workspacePath?: string,
 ) {
+  const resolvedWorkspacePath = workspacePath ?? process.cwd();
   const characterConfig = await characterConfigManager.load();
   const llmClient = await buildLLMClient();
   const trustManager = new TrustManager(stateManager);
@@ -142,7 +148,7 @@ export async function buildDeps(
       const files = (await fsp.readdir(dsDir)).filter(f => f.endsWith('.json'));
       for (const file of files) {
         const cfg = await readJsonFile<DataSourceConfig>(path.join(dsDir, file));
-        const adapter = createCliDataSourceAdapter(cfg);
+        const adapter = createCliDataSourceAdapter(cfg, resolvedWorkspacePath);
         if (adapter) {
           dataSources.push(adapter);
         } else {
@@ -155,7 +161,7 @@ export async function buildDeps(
   }
 
   const contextProvider = createWorkspaceContextProvider(
-    { workDir: workspacePath ?? process.cwd() },
+    { workDir: resolvedWorkspacePath },
     async (goalId: string) => {
       try {
         const goal = await stateManager.loadGoal(goalId);
@@ -265,6 +271,22 @@ export async function buildDeps(
     vectorIndex,
     embeddingClient,
   );
+  const learningPipeline = new LearningPipeline(
+    llmClient,
+    vectorIndex ?? null,
+    stateManager,
+  );
+  const knowledgeTransfer = new KnowledgeTransfer({
+    llmClient,
+    knowledgeManager,
+    vectorIndex: vectorIndex ?? null,
+    learningPipeline,
+    ethicsGate,
+    stateManager,
+  });
+  learningPipeline.setKnowledgeTransfer(knowledgeTransfer);
+  reportingEngine.setKnowledgeTransfer(knowledgeTransfer);
+
   registerBuiltinTools({
     adapterRegistry,
     knowledgeManager,
@@ -285,8 +307,11 @@ export async function buildDeps(
       hookManager,
       adapterRegistry,
       knowledgeManager,
+      knowledgeTransfer,
       memoryLifecycle: memoryLifecycleManager,
       toolExecutor,
+      revertCwd: resolvedWorkspacePath,
+      healthCheckCwd: resolvedWorkspacePath,
     },
   });
 
@@ -344,6 +369,7 @@ export async function buildDeps(
     memoryLifecycleManager,
     driveScoreAdapter,
     knowledgeManager,
+    learningPipeline,
     hookManager,
     logger,
     contextProvider,
@@ -376,6 +402,8 @@ export async function buildDeps(
     hookManager,
     memoryLifecycleManager,
     knowledgeManager,
+    learningPipeline,
+    knowledgeTransfer,
     toolExecutor,
     toolRegistry,
   };

--- a/src/orchestrator/execution/__tests__/task-lifecycle-healthcheck.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-healthcheck.test.ts
@@ -518,6 +518,7 @@ describe("TaskLifecycle — post-execution health check", () => {
 
   it("runPostExecutionHealthCheck uses ToolExecutor.execute(shell) when provided", async () => {
     const executeCalls: Array<{ toolName: string; input: unknown }> = [];
+    const cwd = "/tmp/pulseed-health-workspace";
     const mockExecutor: ToolExecutor = {
       execute: vi.fn().mockImplementation((toolName: string, input: unknown) => {
         executeCalls.push({ toolName, input });
@@ -534,6 +535,7 @@ describe("TaskLifecycle — post-execution health check", () => {
     const result = await runPostExecutionHealthCheck(
       async () => { throw new Error("should not be called"); },
       mockExecutor,
+      cwd,
     );
 
     expect(result.healthy).toBe(true);
@@ -544,6 +546,7 @@ describe("TaskLifecycle — post-execution health check", () => {
     // trusted=true is set in context (checked via the execute mock receiving it)
     const firstCtx = (mockExecutor.execute as ReturnType<typeof vi.fn>).mock.calls[0]![2];
     expect(firstCtx.trusted).toBe(true);
+    expect(firstCtx.cwd).toBe(cwd);
   });
 
   // ─────────────────────────────────────────────

--- a/src/orchestrator/execution/task/task-health-check.ts
+++ b/src/orchestrator/execution/task/task-health-check.ts
@@ -14,9 +14,9 @@ export type ShellCommandFn = (
   options: { timeout: number; cwd: string }
 ) => Promise<{ success: boolean; stdout: string; stderr: string }>;
 
-function makeHealthCheckContext(): ToolCallContext {
+function makeHealthCheckContext(cwd: string): ToolCallContext {
   return {
-    cwd: process.cwd(),
+    cwd,
     goalId: "health-check",
     trustBalance: 100,
     preApproved: true,
@@ -29,9 +29,10 @@ async function runCommandViaToolExecutor(
   toolExecutor: ToolExecutor,
   argv: string[],
   timeoutMs: number,
+  cwd: string,
 ): Promise<{ success: boolean; stdout: string; stderr: string }> {
   const command = argv.join(" ");
-  const ctx = makeHealthCheckContext();
+  const ctx = makeHealthCheckContext(cwd);
   const result = await toolExecutor.execute(
     "shell",
     { command, timeoutMs },
@@ -62,17 +63,18 @@ async function runCommandViaToolExecutor(
 export async function runPostExecutionHealthCheck(
   runShellCommandFn: ShellCommandFn,
   toolExecutor?: ToolExecutor,
+  cwd = process.cwd(),
 ): Promise<{ healthy: boolean; output: string }> {
   const runCmd = toolExecutor
     ? (argv: string[], opts: { timeout: number; cwd: string }) =>
-        runCommandViaToolExecutor(toolExecutor, argv, opts.timeout)
+        runCommandViaToolExecutor(toolExecutor, argv, opts.timeout, opts.cwd)
     : runShellCommandFn;
 
   // Run build check
   try {
     const buildResult = await runCmd(["npm", "run", "build"], {
       timeout: 60000,
-      cwd: process.cwd(),
+      cwd,
     });
     if (!buildResult.success) {
       return {
@@ -88,7 +90,7 @@ export async function runPostExecutionHealthCheck(
   try {
     const testResult = await runCmd(
       ["npx", "vitest", "run", "--reporter=dot"],
-      { timeout: 120000, cwd: process.cwd() }
+      { timeout: 120000, cwd }
     );
     if (!testResult.success) {
       return {

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -113,6 +113,8 @@ export interface TaskLifecycleOptions {
   toolExecutor?: ToolExecutor;
   /** Optional explicit workspace root for git-based revert operations. */
   revertCwd?: string;
+  /** Optional explicit workspace root for post-execution health checks. */
+  healthCheckCwd?: string;
 }
 
 export interface TaskLifecycleDeps extends TaskLifecycleCoreDeps {
@@ -147,6 +149,7 @@ export class TaskLifecycle {
   private readonly hookManager?: HookManager;
   private readonly toolExecutor?: ToolExecutor;
   private readonly revertCwd?: string;
+  private readonly healthCheckCwd?: string;
   private onTaskComplete?: (strategyId: string) => void;
 
   constructor(deps: TaskLifecycleDeps);
@@ -202,6 +205,7 @@ export class TaskLifecycle {
     this.hookManager = resolvedOptions?.hookManager;
     this.toolExecutor = resolvedOptions?.toolExecutor;
     this.revertCwd = resolvedOptions?.revertCwd;
+    this.healthCheckCwd = resolvedOptions?.healthCheckCwd;
   }
 
   /** Register a callback invoked when a task completes successfully (used by PortfolioManager). */
@@ -641,6 +645,7 @@ export class TaskLifecycle {
     return _runPostExecutionHealthCheck(
       this.runShellCommand.bind(this),
       this.toolExecutor,
+      this.healthCheckCwd,
     );
   }
 

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -76,6 +76,11 @@ import {
 import type { GoalCycleScheduleSnapshotEntry } from "./maintenance.js";
 const RUNTIME_JOURNAL_MAX_ATTEMPTS = 1_000;
 
+function resolveResidentWorkspaceDir(configuredPath?: string): string {
+  const trimmed = configuredPath?.trim();
+  return trimmed ? path.resolve(trimmed) : process.cwd();
+}
+
 function gatherResidentWorkspaceContext(workspaceDir: string, seedDescription?: string): string {
   const parts: string[] = [`Workspace: ${workspaceDir}`];
   const seed = seedDescription?.trim();
@@ -1219,7 +1224,7 @@ export class DaemonRunner {
       typeof details?.["title"] === "string" ? details["title"].trim() : "";
 
     try {
-      const workspaceDir = process.cwd();
+      const workspaceDir = resolveResidentWorkspaceDir(this.config.workspace_path);
       const workspaceContext = gatherResidentWorkspaceContext(workspaceDir, hintedDescription);
       const existingTitles = await this.loadExistingGoalTitles();
       const suggestions = await this.goalNegotiator.suggestGoals(workspaceContext, {

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -10,6 +10,7 @@ export const DaemonConfigSchema = z.object({
   pid_file: z.string().default("pulseed.pid"),
   log_dir: z.string().default("logs"),
   runtime_root: z.string().optional(),
+  workspace_path: z.string().optional(),
   log_rotation: z.object({
     max_size_mb: z.number().positive().default(10),
     max_files: z.number().int().positive().default(5),


### PR DESCRIPTION
## Summary
- wire `LearningPipeline` and `KnowledgeTransfer` into CLI production `buildDeps`, CoreLoop, TaskLifecycle, and ReportingEngine
- propagate explicit workspace roots through daemon config/start/install, shell datasources, resident discovery, revert, and health-check paths
- add regression coverage for daemon workspace flags, launchd plist args, LearningPipeline wiring, and ToolExecutor health-check cwd
- re-triage stale daemon reliability issues: closed #598/#599/#600/#601/#605/#606; left #597/#604 open with comments

Closes #630
Closes #632

## Validation
- `npm run typecheck`
- `npx vitest run src/interface/cli/__tests__/cli-setup-tools.test.ts src/interface/cli/__tests__/cli-install.test.ts src/interface/cli/__tests__/cli-daemon-start.test.ts src/orchestrator/execution/__tests__/task-lifecycle-healthcheck.test.ts`
- `npm run build`
- `npm test`
- `npm run lint:boundaries`
