### PR TITLE
[codex] Wire portfolio and runtime recovery gaps

### DIFF
--- a/src/interface/cli/__tests__/cli-setup-tools.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-tools.test.ts
@@ -68,6 +68,8 @@ describe("CLI buildDeps tool wiring", () => {
     expect(coreLoopDeps["toolExecutor"]).toBe(deps.toolExecutor);
     expect(coreLoopDeps["toolRegistry"]).toBe(deps.toolRegistry);
     expect(coreLoopDeps["learningPipeline"]).toBe(deps.learningPipeline);
+    expect(coreLoopDeps["portfolioManager"]).toBe(deps.portfolioManager);
+    expect(coreLoopDeps["crossGoalPortfolio"]).toBe(deps.crossGoalPortfolio);
     expect((coreLoopDeps["observationEngine"] as { toolExecutor?: unknown }).toolExecutor).toBe(deps.toolExecutor);
     expect((coreLoopDeps["taskLifecycle"] as { toolExecutor?: unknown }).toolExecutor).toBe(deps.toolExecutor);
     expect((coreLoopDeps["taskLifecycle"] as { knowledgeTransfer?: unknown }).knowledgeTransfer).toBe(deps.knowledgeTransfer);

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -27,6 +27,8 @@ import { SatisficingJudge } from "../../platform/drive/satisficing-judge.js";
 import { EthicsGate } from "../../platform/traits/ethics-gate.js";
 import { SessionManager } from "../../orchestrator/execution/session-manager.js";
 import { StrategyManager } from "../../orchestrator/strategy/strategy-manager.js";
+import { PortfolioManager } from "../../orchestrator/strategy/portfolio-manager.js";
+import { CrossGoalPortfolio } from "../../orchestrator/strategy/cross-goal-portfolio.js";
 import { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
 import { TaskLifecycle } from "../../orchestrator/execution/task/task-lifecycle.js";
 import { ReportingEngine } from "../../reporting/reporting-engine.js";
@@ -220,6 +222,7 @@ export async function buildDeps(
   const sessionManager = new SessionManager(stateManager, goalDependencyGraph);
   const strategyManager = new StrategyManager(stateManager, llmClient);
   strategyManager.setToolExecutor?.(toolExecutor);
+  const portfolioManager = new PortfolioManager(strategyManager, stateManager);
 
   const reportingEngine = new ReportingEngine(stateManager, undefined, characterConfig);
 
@@ -271,6 +274,14 @@ export async function buildDeps(
     vectorIndex,
     embeddingClient,
   );
+  const crossGoalPortfolio = vectorIndex
+    ? new CrossGoalPortfolio(
+        stateManager,
+        goalDependencyGraph,
+        vectorIndex,
+        embeddingClient,
+      )
+    : undefined;
   const learningPipeline = new LearningPipeline(
     llmClient,
     vectorIndex ?? null,
@@ -359,6 +370,7 @@ export async function buildDeps(
     satisficingJudge,
     stallDetector,
     strategyManager,
+    portfolioManager,
     reportingEngine,
     driveSystem,
     adapterRegistry,
@@ -366,6 +378,7 @@ export async function buildDeps(
     stateAggregator,
     treeLoopOrchestrator,
     goalDependencyGraph,
+    crossGoalPortfolio,
     memoryLifecycleManager,
     driveScoreAdapter,
     knowledgeManager,
@@ -402,6 +415,8 @@ export async function buildDeps(
     hookManager,
     memoryLifecycleManager,
     knowledgeManager,
+    portfolioManager,
+    crossGoalPortfolio,
     learningPipeline,
     knowledgeTransfer,
     toolExecutor,

--- a/src/runtime/__tests__/event-file-watcher.test.ts
+++ b/src/runtime/__tests__/event-file-watcher.test.ts
@@ -121,6 +121,18 @@ describe("events directory creation", () => {
 // ─── File watcher detects new JSON files ───
 
 describe("file watcher — detects new JSON files", () => {
+  it("rescans and processes existing JSON files when the watcher starts", { timeout: 10000 }, async () => {
+    const eventsDir = path.join(tmpDir, "events");
+    fs.mkdirSync(eventsDir, { recursive: true });
+    writeEventFile(eventsDir, "existing.json", validEvent);
+
+    server.startFileWatcher();
+
+    await waitFor(() => mockDriveSystem.writeEvent.mock.calls.length > 0, 8000);
+    expect(mockDriveSystem.writeEvent).toHaveBeenCalledOnce();
+    expect(fs.existsSync(path.join(eventsDir, "processed", "existing.json"))).toBe(true);
+  });
+
   it("calls driveSystem.writeEvent when a valid JSON file appears", { timeout: 10000 }, async () => {
     const eventsDir = path.join(tmpDir, "events");
     server.startFileWatcher();
@@ -225,6 +237,25 @@ describe("file watcher — processed files are moved to processed/", () => {
 // ─── Malformed files — graceful handling ───
 
 describe("file watcher — malformed files handled gracefully", () => {
+  it("retries dispatch failures and quarantines the event file", { timeout: 10000 }, async () => {
+    server.stopFileWatcher();
+    mockDriveSystem.writeEvent.mockRejectedValue(new Error("drive unavailable"));
+    server = new EventServer(mockDriveSystem as never, {
+      eventsDir: path.join(tmpDir, "events"),
+      eventFileMaxAttempts: 3,
+      eventFileRetryDelayMs: 20,
+    });
+    const eventsDir = path.join(tmpDir, "events");
+    server.startFileWatcher();
+    await waitForWatcherReady();
+
+    writeEventFile(eventsDir, "dispatch_failure.json", validEvent);
+
+    await waitFor(() => fs.existsSync(path.join(eventsDir, "failed", "dispatch_failure.json")), 8000);
+    expect(mockDriveSystem.writeEvent).toHaveBeenCalledTimes(3);
+    expect(fs.existsSync(path.join(eventsDir, "dispatch_failure.json"))).toBe(false);
+  });
+
   it("does not crash when a JSON file contains invalid JSON", async () => {
     const eventsDir = path.join(tmpDir, "events");
     server.startFileWatcher();

--- a/src/runtime/__tests__/watchdog.test.ts
+++ b/src/runtime/__tests__/watchdog.test.ts
@@ -282,4 +282,59 @@ describe("RuntimeWatchdog", () => {
       vi.useRealTimers();
     }
   }, 15_000);
+
+  it("opens the circuit breaker instead of restarting forever during a restart storm", async () => {
+    tmpDir = makeTempDir();
+    const runtimeRoot = path.join(tmpDir, "runtime");
+    const pidManager = new PIDManager(tmpDir);
+    const healthStore = new RuntimeHealthStore(runtimeRoot);
+    const leaderLockManager = new LeaderLockManager(runtimeRoot, 60);
+    await healthStore.ensureReady();
+
+    const children: FakeChildProcess[] = [];
+    const onCircuitOpen = vi.fn();
+    const logger = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const watchdog = new RuntimeWatchdog({
+      pidManager,
+      healthStore,
+      leaderLockManager,
+      logger,
+      startChild: () => {
+        const child = new FakeChildProcess(40_000 + children.length);
+        children.push(child);
+        queueMicrotask(() => child.emit("exit", 1, null));
+        return child;
+      },
+      pollIntervalMs: 20,
+      heartbeatTimeoutMs: 50,
+      startupGraceMs: 0,
+      restartBackoffMs: 1,
+      maxRestartBackoffMs: 1,
+      childShutdownGraceMs: 1,
+      restartStormWindowMs: 1_000,
+      maxUnhealthyRestartsInWindow: 2,
+      onCircuitOpen,
+    });
+
+    await watchdog.start();
+
+    expect(children).toHaveLength(2);
+    expect(onCircuitOpen).toHaveBeenCalledOnce();
+    expect(logger.error).toHaveBeenCalledWith(
+      "Watchdog circuit breaker opened after restart storm",
+      expect.objectContaining({ restartCount: 2 })
+    );
+    expect(await healthStore.loadDaemonHealth()).toEqual(
+      expect.objectContaining({
+        status: "failed",
+        leader: false,
+        details: expect.objectContaining({ circuit_reason: "watchdog_circuit_open" }),
+      })
+    );
+    expect(fs.existsSync(pidManager.getPath())).toBe(false);
+  });
 });

--- a/src/runtime/event/server.ts
+++ b/src/runtime/event/server.ts
@@ -26,6 +26,8 @@ export interface EventServerConfig {
   triggerMapper?: TriggerMapper;
   approvalBroker?: ApprovalBroker;
   outboxStore?: OutboxStore;
+  eventFileMaxAttempts?: number;
+  eventFileRetryDelayMs?: number;
 }
 
 export interface EventServerSnapshot {
@@ -41,6 +43,8 @@ type ActiveWorkersProvider = () =>
   | Promise<Array<Record<string, unknown>>>;
 
 const DAEMON_TOKEN_FILENAME = "daemon-token.json";
+const DEFAULT_EVENT_FILE_MAX_ATTEMPTS = 3;
+const DEFAULT_EVENT_FILE_RETRY_DELAY_MS = 250;
 
 export class EventServer {
   private server: http.Server | null = null;
@@ -59,6 +63,10 @@ export class EventServer {
   private approvalQueue: Map<string, { resolve: (approved: boolean) => void; timer: ReturnType<typeof setTimeout> }> = new Map();
   private approvalBroker?: ApprovalBroker;
   private outboxStore?: OutboxStore;
+  private readonly eventFileMaxAttempts: number;
+  private readonly eventFileRetryDelayMs: number;
+  private readonly eventFileAttempts = new Map<string, number>();
+  private readonly eventFileRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly authToken: string;
   private envelopeHook?: (eventData: Record<string, unknown>) => void | Promise<void>;
   private commandEnvelopeHook?: (envelope: Envelope) => void | Promise<void>;
@@ -75,6 +83,8 @@ export class EventServer {
     this.triggerMapper = config?.triggerMapper;
     this.approvalBroker = config?.approvalBroker;
     this.outboxStore = config?.outboxStore;
+    this.eventFileMaxAttempts = Math.max(1, config?.eventFileMaxAttempts ?? DEFAULT_EVENT_FILE_MAX_ATTEMPTS);
+    this.eventFileRetryDelayMs = Math.max(0, config?.eventFileRetryDelayMs ?? DEFAULT_EVENT_FILE_RETRY_DELAY_MS);
     this.authToken = randomBytes(32).toString("base64url");
     this.snapshotReader = new EventServerSnapshotReader(this.eventsDir);
     this.sseManager = new EventServerSseManager(this.logger, this.approvalBroker, this.outboxStore);
@@ -161,25 +171,11 @@ export class EventServer {
     if (this.fileWatcher) return; // already watching
 
     fs.mkdirSync(this.eventsDir, { recursive: true });
+    void this.rescanEventFiles();
 
     this.fileWatcher = fs.watch(this.eventsDir, (eventType, filename) => {
       if ((eventType !== "rename" && eventType !== "change") || !filename) return;
-      if (!filename.endsWith(".json") || filename.endsWith(".tmp")) return;
-
-      const filePath = path.join(this.eventsDir, filename);
-      if (this.processingFiles.has(filename)) return;
-      this.processingFiles.add(filename);
-      void (async () => {
-        try {
-          await this.processEventFile(filePath, filename);
-        } catch (err) {
-          this.logger?.error(
-            `EventServer: unhandled error processing event file "${filename}": ${String(err)}`
-          );
-        } finally {
-          this.processingFiles.delete(filename);
-        }
-      })();
+      this.queueEventFile(String(filename));
     });
   }
 
@@ -189,6 +185,10 @@ export class EventServer {
       this.fileWatcher.close();
       this.fileWatcher = null;
     }
+    for (const timer of this.eventFileRetryTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.eventFileRetryTimers.clear();
   }
 
   /**
@@ -196,54 +196,141 @@ export class EventServer {
    * Errors are logged but never propagated (caller must not crash).
    */
   private async processEventFile(filePath: string, filename: string): Promise<void> {
+    let stat;
     try {
-      let stat;
-      try {
-        // Retry on ENOENT: on macOS, fs.watch fires 'rename' before the file
-        // is visible to fsp.stat, so retry up to 3 times with 20ms delay.
-        let lastErr: unknown;
-        for (let attempt = 0; attempt < 3; attempt++) {
-          try {
-            stat = await fsp.stat(filePath);
-            break;
-          } catch (err) {
-            const code = (err as NodeJS.ErrnoException).code;
-            if (code !== "ENOENT") throw err;
-            lastErr = err;
-            await new Promise((r) => setTimeout(r, 20));
-          }
+      // Retry on ENOENT: on macOS, fs.watch fires 'rename' before the file
+      // is visible to fsp.stat, so retry up to 3 times with 20ms delay.
+      let lastErr: unknown;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          stat = await fsp.stat(filePath);
+          break;
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code !== "ENOENT") throw err;
+          lastErr = err;
+          await new Promise((r) => setTimeout(r, 20));
         }
-        if (!stat) {
-          // File never appeared — already removed
-          void lastErr; // suppress unused warning
-          return;
+      }
+      if (!stat) {
+        // File never appeared — already removed
+        void lastErr; // suppress unused warning
+        return;
+      }
+    } catch {
+      return; // non-ENOENT error — file already removed or inaccessible
+    }
+    if (!stat.isFile()) return;
+
+    const content = await fsp.readFile(filePath, "utf-8");
+    const raw = JSON.parse(content) as unknown;
+    const event = PulSeedEventSchema.parse(raw);
+
+    // Dispatch through Gateway Envelope path or direct
+    if (this.envelopeHook) {
+      await this.envelopeHook(event as unknown as Record<string, unknown>);
+    } else {
+      await this.driveSystem.writeEvent(event);
+    }
+
+    // Move to processed/
+    const processedDir = path.join(this.eventsDir, "processed");
+    await fsp.mkdir(processedDir, { recursive: true });
+    const dstPath = path.join(processedDir, filename);
+    await fsp.rename(filePath, dstPath);
+    this.eventFileAttempts.delete(filename);
+  }
+
+  private async rescanEventFiles(): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await fsp.readdir(this.eventsDir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      this.queueEventFile(entry);
+    }
+  }
+
+  private queueEventFile(filename: string, delayMs = 0): void {
+    if (!this.shouldProcessEventFilename(filename)) return;
+    if (this.eventFileRetryTimers.has(filename)) return;
+    if (delayMs <= 0 && this.processingFiles.has(filename)) return;
+
+    const run = (): void => {
+      this.eventFileRetryTimers.delete(filename);
+      if (this.processingFiles.has(filename)) return;
+      this.processingFiles.add(filename);
+      const filePath = path.join(this.eventsDir, filename);
+      void (async () => {
+        try {
+          await this.processEventFile(filePath, filename);
+        } catch (err) {
+          await this.handleEventFileFailure(filePath, filename, err);
+        } finally {
+          this.processingFiles.delete(filename);
         }
-      } catch {
-        return; // non-ENOENT error — file already removed or inaccessible
-      }
-      if (!stat.isFile()) return;
+      })();
+    };
 
-      const content = await fsp.readFile(filePath, "utf-8");
-      const raw = JSON.parse(content) as unknown;
-      const event = PulSeedEventSchema.parse(raw);
+    if (delayMs <= 0) {
+      run();
+      return;
+    }
 
-      // Dispatch through Gateway Envelope path or direct
-      if (this.envelopeHook) {
-        await this.envelopeHook(event as unknown as Record<string, unknown>);
-      } else {
-        await this.driveSystem.writeEvent(event);
-      }
+    const timer = setTimeout(run, delayMs);
+    timer.unref?.();
+    this.eventFileRetryTimers.set(filename, timer);
+  }
 
-      // Move to processed/
-      const processedDir = path.join(this.eventsDir, "processed");
-      await fsp.mkdir(processedDir, { recursive: true });
-      const dstPath = path.join(processedDir, filename);
-      await fsp.rename(filePath, dstPath);
-    } catch (err) {
-      this.logger?.error(
-        `EventServer: failed to process event file "${filename}": ${String(err)}`
+  private shouldProcessEventFilename(filename: string): boolean {
+    if (path.basename(filename) !== filename) return false;
+    if (!filename.endsWith(".json") || filename.endsWith(".tmp")) return false;
+    return filename !== "daemon-token.json";
+  }
+
+  private async handleEventFileFailure(
+    filePath: string,
+    filename: string,
+    err: unknown
+  ): Promise<void> {
+    const attempt = (this.eventFileAttempts.get(filename) ?? 0) + 1;
+    this.eventFileAttempts.set(filename, attempt);
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (attempt < this.eventFileMaxAttempts) {
+      this.logger?.warn(
+        `EventServer: failed to process event file "${filename}", retrying (${attempt}/${this.eventFileMaxAttempts}): ${message}`
       );
-      // Do not re-throw — watcher must keep running
+      this.queueEventFile(filename, this.eventFileRetryDelayMs);
+      return;
+    }
+
+    this.logger?.error(
+      `EventServer: failed to process event file "${filename}" after ${attempt} attempts; moving to failed/: ${message}`
+    );
+    this.eventFileAttempts.delete(filename);
+    await this.moveFailedEventFile(filePath, filename);
+  }
+
+  private async moveFailedEventFile(filePath: string, filename: string): Promise<void> {
+    try {
+      const failedDir = path.join(this.eventsDir, "failed");
+      await fsp.mkdir(failedDir, { recursive: true });
+      let dstPath = path.join(failedDir, filename);
+      try {
+        await fsp.access(dstPath);
+        const parsed = path.parse(filename);
+        dstPath = path.join(failedDir, `${parsed.name}-${Date.now()}${parsed.ext}`);
+      } catch {
+        // Destination is free.
+      }
+      await fsp.rename(filePath, dstPath);
+    } catch (moveErr) {
+      this.logger?.error(
+        `EventServer: failed to quarantine event file "${filename}": ${String(moveErr)}`
+      );
     }
   }
 

--- a/src/runtime/watchdog.ts
+++ b/src/runtime/watchdog.ts
@@ -27,6 +27,18 @@ export interface RuntimeWatchdogOptions {
   restartBackoffMs?: number;
   maxRestartBackoffMs?: number;
   childShutdownGraceMs?: number;
+  restartStormWindowMs?: number;
+  maxUnhealthyRestartsInWindow?: number;
+  onCircuitOpen?: (details: WatchdogCircuitOpenDetails) => Promise<void> | void;
+}
+
+export interface WatchdogCircuitOpenDetails extends Record<string, unknown> {
+  reason: ChildExitResult["reason"];
+  restartCount: number;
+  windowMs: number;
+  pid?: number;
+  code: number | null;
+  signal: NodeJS.Signals | null;
 }
 
 interface ChildExitResult {
@@ -42,6 +54,8 @@ const DEFAULT_STARTUP_GRACE_MS = 20_000;
 const DEFAULT_RESTART_BACKOFF_MS = 1_000;
 const DEFAULT_MAX_RESTART_BACKOFF_MS = 30_000;
 const DEFAULT_CHILD_SHUTDOWN_GRACE_MS = 5_000;
+const DEFAULT_RESTART_STORM_WINDOW_MS = 5 * 60_000;
+const DEFAULT_MAX_UNHEALTHY_RESTARTS_IN_WINDOW = 5;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -61,6 +75,9 @@ export class RuntimeWatchdog {
   private readonly restartBackoffMs: number;
   private readonly maxRestartBackoffMs: number;
   private readonly childShutdownGraceMs: number;
+  private readonly restartStormWindowMs: number;
+  private readonly maxUnhealthyRestartsInWindow: number;
+  private readonly onCircuitOpen?: (details: WatchdogCircuitOpenDetails) => Promise<void> | void;
   private currentChild: WatchdogChildProcess | null = null;
   private running = false;
   private stopping = false;
@@ -80,6 +97,12 @@ export class RuntimeWatchdog {
     this.maxRestartBackoffMs = options.maxRestartBackoffMs ?? DEFAULT_MAX_RESTART_BACKOFF_MS;
     this.childShutdownGraceMs =
       options.childShutdownGraceMs ?? DEFAULT_CHILD_SHUTDOWN_GRACE_MS;
+    this.restartStormWindowMs = Math.max(1, options.restartStormWindowMs ?? DEFAULT_RESTART_STORM_WINDOW_MS);
+    this.maxUnhealthyRestartsInWindow = Math.max(
+      1,
+      options.maxUnhealthyRestartsInWindow ?? DEFAULT_MAX_UNHEALTHY_RESTARTS_IN_WINDOW
+    );
+    this.onCircuitOpen = options.onCircuitOpen;
   }
 
   async start(): Promise<void> {
@@ -96,6 +119,7 @@ export class RuntimeWatchdog {
     this.running = true;
     this.stopping = false;
     let restartDelayMs = this.restartBackoffMs;
+    let unhealthyRestartTimestamps: number[] = [];
 
     await this.pidManager.writePID({
       pid: process.pid,
@@ -123,9 +147,21 @@ export class RuntimeWatchdog {
           break;
         }
 
-        restartDelayMs = result.healthy
-          ? this.restartBackoffMs
-          : Math.min(restartDelayMs * 2, this.maxRestartBackoffMs);
+        if (result.healthy) {
+          unhealthyRestartTimestamps = [];
+          restartDelayMs = this.restartBackoffMs;
+        } else {
+          const now = Date.now();
+          unhealthyRestartTimestamps = [
+            ...unhealthyRestartTimestamps.filter((timestamp) => now - timestamp <= this.restartStormWindowMs),
+            now,
+          ];
+          if (unhealthyRestartTimestamps.length >= this.maxUnhealthyRestartsInWindow) {
+            await this.tripCircuitBreaker(result, child, unhealthyRestartTimestamps.length);
+            break;
+          }
+          restartDelayMs = Math.min(restartDelayMs * 2, this.maxRestartBackoffMs);
+        }
 
         this.logger.warn("Watchdog restarting daemon child", {
           pid: child.pid,
@@ -141,6 +177,33 @@ export class RuntimeWatchdog {
       this.running = false;
       await this.pidManager.cleanup();
     }
+  }
+
+  private async tripCircuitBreaker(
+    result: ChildExitResult,
+    child: WatchdogChildProcess,
+    restartCount: number
+  ): Promise<void> {
+    this.stopping = true;
+    const details: WatchdogCircuitOpenDetails = {
+      reason: result.reason,
+      restartCount,
+      windowMs: this.restartStormWindowMs,
+      pid: child.pid,
+      code: result.code,
+      signal: result.signal,
+    };
+    this.logger.error("Watchdog circuit breaker opened after restart storm", details);
+    await this.healthStore.saveDaemonHealth({
+      status: "failed",
+      leader: false,
+      checked_at: Date.now(),
+      details: {
+        circuit_reason: "watchdog_circuit_open",
+        ...details,
+      },
+    });
+    await this.onCircuitOpen?.(details);
   }
 
   stop(): void {


### PR DESCRIPTION
## Summary
- wire production `buildDeps` with `PortfolioManager` and `CrossGoalPortfolio` so multi-goal runs use portfolio allocation instead of the equal-allocation fallback
- add EventServer file-ingress rescan, retry, and failed-file quarantine for watcher dispatch/parsing failures
- add a watchdog restart-storm circuit breaker with failed health persistence and an escalation callback hook

Closes #633
Closes #604
Closes #597

## Validation
- `npm run typecheck`
- `npx vitest run src/interface/cli/__tests__/cli-setup-tools.test.ts src/runtime/__tests__/event-file-watcher.test.ts src/runtime/__tests__/watchdog.test.ts`
- `npm run build`
- `npm run lint:boundaries`
- `npm test`
