### PR TITLE
[codex] Fix WaitStrategy lifecycle wiring

### DIFF
--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -21,7 +21,7 @@ import type { StallReport } from "../../../base/types/stall.js";
 import type { DriveScore } from "../../../base/types/drive.js";
 import { saveDreamConfig } from "../../../platform/dream/dream-config.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
-import { makeGoal } from "../../../../tests/helpers/fixtures.js";
+import { makeDimension, makeGoal } from "../../../../tests/helpers/fixtures.js";
 
 function makeGapVector(goalId = "goal-1"): GapVector {
   return {
@@ -931,6 +931,40 @@ describe("CoreLoop", async () => {
 
       expect(portfolioManager.handleWaitStrategyExpiry).toHaveBeenCalledWith("goal-1", waitStrategy.id);
       expect(portfolioManager.rebalance).toHaveBeenCalledWith("goal-1", waitTrigger);
+    });
+
+    it("uses WaitStrategy.wait_until to suppress stall checks for its primary dimension", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal({
+        dimensions: [makeDimension({ name: "dim1" })],
+      }));
+
+      const waitUntil = new Date(Date.now() + 100_000).toISOString();
+      const waitStrategy = {
+        id: "wait-strategy-1",
+        state: "active",
+        goal_id: "goal-1",
+        primary_dimension: "dim1",
+        wait_until: waitUntil,
+      };
+      mocks.strategyManager.getPortfolio.mockReturnValue({
+        goal_id: "goal-1",
+        strategies: [waitStrategy],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+      mocks.stallDetector.isSuppressed.mockReturnValue(true);
+
+      const portfolioManager = createMockPortfolioManager();
+      portfolioManager.isWaitStrategy.mockReturnValue(true);
+
+      const depsWithPM = { ...deps, portfolioManager: portfolioManager as any };
+      const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(mocks.stallDetector.isSuppressed).toHaveBeenCalledWith(waitUntil);
+      expect(mocks.stallDetector.checkDimensionStall).not.toHaveBeenCalled();
+      expect(result.waitSuppressed).toBe(true);
     });
 
     it("portfolio rebalance errors are non-fatal", async () => {

--- a/src/orchestrator/loop/core-loop/preparation.ts
+++ b/src/orchestrator/loop/core-loop/preparation.ts
@@ -22,11 +22,7 @@ export interface PhaseCtx {
   config: ResolvedLoopConfig;
   logger: Logger | undefined;
   toolExecutor?: ToolExecutor;
-  /**
-   * Optional TimeHorizonEngine for canAffordWait gate in rebalancePortfolio (Gap 1).
-   * When present, WaitStrategy processing is skipped if the engine reports the goal
-   * cannot afford to wait given the remaining time budget.
-   */
+  /** Optional TimeHorizonEngine for adaptive pacing and wait activation budget checks. */
   timeHorizonEngine?: import("../../../platform/time/time-horizon-engine.js").ITimeHorizonEngine;
 }
 

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -151,7 +151,8 @@ export async function detectStallsAndRebalance(
       }
     }
 
-    // Gap 3: isSuppressed wiring — suppression is per-dimension only.
+    // Suppression uses WaitStrategy.wait_until as the authoritative source of truth.
+    // task.plateau_until is a task-local mirror for consumers that do not load portfolios.
     // Collect suppressed dimensions from all active WaitStrategies; skip those dims in stall loop.
     const suppressedDimensions = new Set<string>();
     if (ctx.deps.portfolioManager) {
@@ -432,48 +433,6 @@ async function rebalancePortfolio(
     if (portfolio) {
       for (const strategy of portfolio.strategies) {
         if (ctx.deps.portfolioManager.isWaitStrategy(strategy)) {
-          // Gap 1: canAffordWait gate — if TimeHorizonEngine is available, check whether
-          // the goal can afford the wait before processing WaitStrategy expiry.
-          if (ctx.timeHorizonEngine) {
-            try {
-              const ws = strategy as Record<string, unknown>;
-              const waitUntil = typeof ws["wait_until"] === "string" ? ws["wait_until"] as string : null;
-              const startedAt = typeof ws["started_at"] === "string" ? ws["started_at"] as string : (goal.created_at ?? new Date().toISOString());
-              // Remaining wait time (not total): use now as reference so nearly-expired waits pass
-              const waitHours = waitUntil
-                ? Math.max(0, (new Date(waitUntil).getTime() - Date.now()) / 3_600_000)
-                : 0;
-              const currentGap = result?.gapAggregate ?? 1;
-              const initialGap = typeof ws["gap_snapshot_at_start"] === "number" ? ws["gap_snapshot_at_start"] as number : currentGap;
-              // Compute an approximate velocity from gap progress and elapsed time.
-              // Fallback to a small positive value (0.01/h) when elapsed is too short to measure.
-              const elapsedHours = waitUntil
-                ? Math.max(0, (Date.now() - new Date(startedAt).getTime()) / 3_600_000)
-                : 0;
-              const gapDelta = initialGap - currentGap;
-              const velocity = elapsedHours > 0.001 && gapDelta > 0
-                ? gapDelta / elapsedHours
-                : 0.01; // conservative positive fallback; replace with real velocity when available
-              const budget = ctx.timeHorizonEngine.getTimeBudget(
-                goal.deadline ?? null,
-                startedAt,
-                currentGap,
-                initialGap,
-                velocity
-              );
-              if (!budget.canAffordWait(waitHours)) {
-                ctx.logger?.info("CoreLoop: canAffordWait=false, skipping WaitStrategy processing", {
-                  goalId,
-                  strategyId: strategy.id,
-                  waitHours,
-                });
-                continue;
-              }
-            } catch {
-              // Non-fatal: if canAffordWait check fails, proceed normally
-            }
-          }
-
           const waitTrigger = await ctx.deps.portfolioManager.handleWaitStrategyExpiry(
             goalId,
             strategy.id

--- a/src/orchestrator/strategy/__tests__/portfolio-manager.test.ts
+++ b/src/orchestrator/strategy/__tests__/portfolio-manager.test.ts
@@ -759,7 +759,7 @@ describe("PortfolioManager", () => {
       expect(result).toBeNull();
     });
 
-    it("returns null when expired and gap improved", async () => {
+    it("completes the WaitStrategy when expired and gap improved", async () => {
       const wait = makeWaitStrategy({
         id: "ws1",
         state: "active",
@@ -774,9 +774,35 @@ describe("PortfolioManager", () => {
 
       const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
       expect(result).toBeNull();
+      expect(mockStrategyManager.updateState).toHaveBeenCalledWith("ws1", "completed");
     });
 
-    it("returns rebalance trigger when expired and gap worsened", async () => {
+    it("activates fallback and terminates the WaitStrategy when expired with unchanged gap", async () => {
+      const fallback = makeStrategy({
+        id: "fallback-1",
+        state: "candidate",
+        allocation: 0,
+      });
+      const wait = makeWaitStrategy({
+        id: "ws1",
+        state: "active",
+        wait_until: new Date(Date.now() - 100_000).toISOString(),
+        gap_snapshot_at_start: 0.5,
+        primary_dimension: "quality",
+        fallback_strategy_id: fallback.id,
+      });
+      const portfolio = makePortfolio([wait, fallback]);
+      (mockStrategyManager.getPortfolio as ReturnType<typeof vi.fn>).mockReturnValue(portfolio);
+      (mockStateManager.readRaw as ReturnType<typeof vi.fn>).mockResolvedValue({ quality: 0.5 });
+
+      const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
+
+      expect(result).toBeNull();
+      expect(mockStrategyManager.updateState).toHaveBeenNthCalledWith(1, "fallback-1", "active");
+      expect(mockStrategyManager.updateState).toHaveBeenNthCalledWith(2, "ws1", "terminated");
+    });
+
+    it("terminates and returns rebalance trigger when expired and gap worsened", async () => {
       const wait = makeWaitStrategy({
         id: "ws1",
         state: "active",
@@ -793,6 +819,7 @@ describe("PortfolioManager", () => {
       expect(result).not.toBeNull();
       expect(result!.type).toBe("stall_detected");
       expect(result!.strategy_id).toBe("ws1");
+      expect(mockStrategyManager.updateState).toHaveBeenCalledWith("ws1", "terminated");
     });
 
     it("returns null for non-existent strategy", async () => {

--- a/src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts
@@ -163,6 +163,56 @@ describe("Phase 2 methods", () => {
         "not in candidate state"
       );
     });
+
+    it("blocks WaitStrategy activation when the wait budget cannot afford it", async () => {
+      const mock = createMockLLMClient([]);
+      const manager = new StrategyManager(stateManager, mock);
+      const wait = await manager.createWaitStrategy("goal-1", {
+        hypothesis: "Wait for external signal",
+        wait_reason: "Awaiting external signal",
+        wait_until: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+        measurement_plan: "Check signal after wait",
+        fallback_strategy_id: null,
+        target_dimensions: ["quality"],
+        primary_dimension: "quality",
+      });
+
+      await expect(
+        manager.activateMultiple("goal-1", [wait.id], {
+          getCurrentGap: async () => 0.42,
+          canAffordWait: async () => false,
+        })
+      ).rejects.toThrow("cannot be activated because the goal cannot afford waiting");
+
+      const portfolio = await manager.getPortfolio("goal-1");
+      const stored = portfolio!.strategies.find((s) => s.id === wait.id);
+      expect(stored!.state).toBe("candidate");
+      expect(stored!.gap_snapshot_at_start).toBeNull();
+    });
+
+    it("captures a WaitStrategy baseline when activation succeeds", async () => {
+      const mock = createMockLLMClient([]);
+      const manager = new StrategyManager(stateManager, mock);
+      const wait = await manager.createWaitStrategy("goal-1", {
+        hypothesis: "Wait for external signal",
+        wait_reason: "Awaiting external signal",
+        wait_until: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+        measurement_plan: "Check signal after wait",
+        fallback_strategy_id: null,
+        target_dimensions: ["quality"],
+        primary_dimension: "quality",
+      });
+
+      const activated = await manager.activateMultiple("goal-1", [wait.id], {
+        getCurrentGap: async () => 0.42,
+        canAffordWait: async ({ currentGap, initialGap }) => currentGap === 0.42 && initialGap === 0.42,
+      });
+
+      expect(activated[0]!.gap_snapshot_at_start).toBe(0.42);
+      const portfolio = await manager.getPortfolio("goal-1");
+      const stored = portfolio!.strategies.find((s) => s.id === wait.id);
+      expect(stored!.gap_snapshot_at_start).toBe(0.42);
+    });
   });
 
   describe("terminateStrategy", () => {

--- a/src/orchestrator/strategy/portfolio-manager.ts
+++ b/src/orchestrator/strategy/portfolio-manager.ts
@@ -2,6 +2,7 @@ import { StrategyManager } from "./strategy-manager.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { StrategySchema, parseStrategy } from "../../base/types/strategy.js";
 import type { Strategy, Portfolio } from "../../base/types/strategy.js";
+import type { StrategyState } from "../../base/types/core.js";
 import { PortfolioConfigSchema } from "../../base/types/portfolio.js";
 import type {
   PortfolioConfig,
@@ -371,9 +372,9 @@ export class PortfolioManager {
    * Handle expiry of a WaitStrategy.
    *
    * When wait_until has passed:
-   * - Gap improved: return null (let the wait strategy continue its evaluation)
-   * - Gap unchanged: activate fallback strategy if one exists
-   * - Gap worsened: return rebalance trigger
+   * - Gap improved: complete the WaitStrategy
+   * - Gap unchanged: activate fallback strategy if one exists, otherwise trigger rebalance
+   * - Gap worsened: terminate the WaitStrategy and trigger rebalance
    */
   async handleWaitStrategyExpiry(
     goalId: string,
@@ -391,7 +392,7 @@ export class PortfolioManager {
       strategy,
       (s) => this.isWaitStrategy(s),
       (gId, dim) => this.getCurrentGapForDimension(gId, dim),
-      (sId, state) => this.strategyManager.updateState(sId, state as "active"),
+      (sId, state) => this.strategyManager.updateState(sId, state as StrategyState),
       async (gId) => (await this.strategyManager.getPortfolio(gId))?.strategies ?? []
     );
   }

--- a/src/orchestrator/strategy/portfolio-rebalance.ts
+++ b/src/orchestrator/strategy/portfolio-rebalance.ts
@@ -274,9 +274,9 @@ export function adjustAllocations(
  * Handle expiry of a WaitStrategy.
  *
  * When wait_until has passed:
- * - Gap improved: return null
- * - Gap unchanged: activate fallback strategy if one exists
- * - Gap worsened: return rebalance trigger
+ * - Gap improved: complete the WaitStrategy
+ * - Gap unchanged: activate fallback strategy if one exists, otherwise trigger rebalance
+ * - Gap worsened: terminate the WaitStrategy and trigger rebalance
  *
  * @param isWaitStrategy - predicate to detect WaitStrategy instances
  * @param getGap - get current gap for a dimension of a goal
@@ -300,15 +300,14 @@ export async function handleWaitStrategyExpiry(
 
   if (now < waitUntil) return null;
 
-  const startGap = strategy.gap_snapshot_at_start;
-  if (startGap === null) return null;
-
   const currentGap = await getGap(goalId, strategy.primary_dimension);
   if (currentGap === null) return null;
 
+  const startGap = strategy.gap_snapshot_at_start ?? currentGap;
   const gapDelta = currentGap - startGap;
 
   if (gapDelta < 0) {
+    await updateState(strategyId, "completed");
     return null;
   }
 
@@ -320,11 +319,19 @@ export async function handleWaitStrategyExpiry(
       );
       if (fallback && fallback.state === "candidate") {
         await updateState(fallback.id, "active");
+        await updateState(strategyId, "terminated");
+        return null;
       }
     }
-    return null;
+    await updateState(strategyId, "terminated");
+    return {
+      type: "stall_detected",
+      strategy_id: strategyId,
+      details: `WaitStrategy expired with no gap improvement: ${startGap.toFixed(3)} → ${currentGap.toFixed(3)}`,
+    };
   }
 
+  await updateState(strategyId, "terminated");
   return {
     type: "stall_detected",
     strategy_id: strategyId,

--- a/src/orchestrator/strategy/strategy-manager.ts
+++ b/src/orchestrator/strategy/strategy-manager.ts
@@ -6,9 +6,24 @@ import { isWaitStrategy } from "./portfolio-allocation.js";
 import type { Strategy } from "../../base/types/strategy.js";
 import { redistributeAllocation } from "./strategy-helpers.js";
 import { StrategyManagerBase } from "./strategy-manager-base.js";
+import { getCurrentGapForDimension } from "./portfolio-rebalance.js";
 
 export { VALID_TRANSITIONS, StrategyArraySchema, buildGenerationPrompt, redistributeAllocation, detectStrategyGap } from "./strategy-helpers.js";
 export { StrategyManagerBase } from "./strategy-manager-base.js";
+
+export interface WaitStrategyActivationContext {
+  getCurrentGap?: (
+    goalId: string,
+    dimension: string
+  ) => number | null | Promise<number | null>;
+  canAffordWait?: (input: {
+    strategy: Strategy;
+    waitHours: number;
+    currentGap: number;
+    initialGap: number;
+    startedAt: string;
+  }) => boolean | Promise<boolean>;
+}
 
 /**
  * StrategyManager manages strategy lifecycle for a goal:
@@ -32,7 +47,11 @@ export class StrategyManager extends StrategyManagerBase {
    * Allocates resources equally, respecting min=0.1 and max=0.7 per strategy.
    * Single strategy receives allocation=1.0.
    */
-  async activateMultiple(goalId: string, strategyIds: string[]): Promise<Strategy[]> {
+  async activateMultiple(
+    goalId: string,
+    strategyIds: string[],
+    activationContext?: WaitStrategyActivationContext
+  ): Promise<Strategy[]> {
     if (strategyIds.length === 0) {
       throw new Error(`activateMultiple: strategyIds must not be empty`);
     }
@@ -53,6 +72,8 @@ export class StrategyManager extends StrategyManagerBase {
       alloc = Math.min(Math.max(raw, MIN), MAX);
     }
 
+    const waitBaselines = new Map<string, number>();
+
     // Validate all strategies before mutating to avoid partial state
     for (const id of strategyIds) {
       const s = portfolio.strategies.find((s) => s.id === id);
@@ -66,6 +87,38 @@ export class StrategyManager extends StrategyManagerBase {
           `activateMultiple: strategy "${s.id}" is not in candidate state (current: ${s.state})`
         );
       }
+
+      if (isWaitStrategy(s)) {
+        const currentGap =
+          await activationContext?.getCurrentGap?.(goalId, s.primary_dimension) ??
+          await getCurrentGapForDimension(
+            goalId,
+            s.primary_dimension,
+            (gapPath) => this.stateManager.readRaw(gapPath)
+          );
+        const baseline = s.gap_snapshot_at_start ?? currentGap ?? 1.0;
+        const waitHours = Math.max(
+          0,
+          (new Date(s.wait_until).getTime() - new Date(now).getTime()) / 3_600_000
+        );
+
+        if (activationContext?.canAffordWait) {
+          const canAfford = await activationContext.canAffordWait({
+            strategy: s,
+            waitHours,
+            currentGap: currentGap ?? baseline,
+            initialGap: baseline,
+            startedAt: now,
+          });
+          if (!canAfford) {
+            throw new Error(
+              `activateMultiple: WaitStrategy "${s.id}" cannot be activated because the goal cannot afford waiting`
+            );
+          }
+        }
+
+        waitBaselines.set(s.id, baseline);
+      }
     }
 
     const activated: Strategy[] = [];
@@ -78,7 +131,7 @@ export class StrategyManager extends StrategyManagerBase {
         state: "active",
         started_at: now,
         allocation: alloc,
-        gap_snapshot_at_start: s.gap_snapshot_at_start,
+        gap_snapshot_at_start: waitBaselines.get(s.id) ?? s.gap_snapshot_at_start,
       });
       activated.push(updated);
       return updated;


### PR DESCRIPTION
## Summary
- gate WaitStrategy activation through an optional wait budget context before adopting the wait
- capture a usable gap baseline at activation and keep wait_until as the suppression source of truth
- resolve expired WaitStrategies into completed/terminated states across success, fallback, and rebalance paths
- add regression coverage for activation, suppression, expiry success, fallback, and failure

Closes #594

## Validation
- npm run typecheck
- npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts src/orchestrator/strategy/__tests__/portfolio-manager.test.ts src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
- npm run build
- npm test
- npm run lint:boundaries