### PR TITLE
[codex] refresh current runtime docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![npm version](https://img.shields.io/npm/v/pulseed.svg)](https://www.npmjs.com/package/pulseed)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Set a goal. Seedy takes it from there — observing, planning, delegating to AI agents, and tracking progress until it's done.
+Set a goal. Seedy takes it from there with a long-lived `CoreLoop` for goal control and a bounded `AgentLoop` for tool-using task execution.
 
 <br/>
 </div>
@@ -49,7 +49,7 @@ pulseed run
 pulseed status
 ```
 
-Seedy assesses feasibility, breaks the goal down, delegates tasks to agents, and tracks progress automatically.
+Seedy assesses feasibility, breaks the goal down, runs the core loop, and uses bounded agent execution where it needs tool-driven work.
 
 > **Using OpenClaw?** Install the official plugin for seamless integration — see [`@pulseed/openclaw-plugin`](openclaw-plugin/README.md).
 
@@ -65,6 +65,7 @@ More examples in [docs/usecase.md](docs/usecase.md).
 
 ## Features
 
+- **Dual-loop runtime** — `CoreLoop` for long-lived control, `AgentLoop` for bounded execution
 - **Goal-driven orchestration** — Set a destination, not step-by-step instructions
 - **Agent-agnostic** — Swap agents without changing goals
 - **Satisficing** — Knows when "good enough" is enough
@@ -74,7 +75,7 @@ More examples in [docs/usecase.md](docs/usecase.md).
 - **Goal trees** — Decompose large goals into sub-goals, each tracked independently
 - **TUI dashboard** — Real-time terminal UI with progress, logs, and approval flow
 
-Deep dive: [Architecture Map](docs/architecture-map.md) | [How it works](docs/mechanism.md)
+Deep dive: [Architecture Map](docs/architecture-map.md) | [How it works](docs/mechanism.md) | [Current Design Baseline](docs/design/current-baseline.md)
 
 ## Adapters
 
@@ -104,8 +105,8 @@ Custom adapters: [Plugin Development Guide](docs/design/infrastructure/plugin-de
 import { CoreLoop, StateManager } from "pulseed";
 
 const stateManager = new StateManager("~/.pulseed");
-const loop = new CoreLoop({ stateManager, /* ...adapters */ });
-await loop.runOnce();
+const loop = new CoreLoop({ stateManager, /* ...deps */ });
+await loop.run("goal_abc123", { maxIterations: 1 });
 ```
 
 **CLI reference:** See [docs/getting-started.md](docs/getting-started.md) for the full command list.

--- a/docs/architecture-map.md
+++ b/docs/architecture-map.md
@@ -1,5 +1,7 @@
 # PulSeed -- Architecture Map
 
+Implementation-facing baseline: [docs/design/current-baseline.md](design/current-baseline.md)
+
 ---
 
 ## 1. In a Nutshell
@@ -100,7 +102,7 @@ PulSeed is a **task discovery engine**. It takes on the user's long-term goals (
 │  │  Persistence (JSON)                                             │  │
 │  └──────────────────────────────────────────────────────────────┘     │
 │                                                                       │
-│  ┌─────────── TUI Layer (src/tui/) ───────────────────────────────┐   │
+│  ┌─────────── TUI Layer (src/interface/tui/) ─────────────────────┐   │
 │  │  App │ Dashboard │ Chat │ ApprovalOverlay │ HelpOverlay │       │   │
 │  │  ReportView │ IntentRecognizer                                  │   │
 │  └──────────────────────────────────────────────────────────────┘     │

--- a/docs/codex-testing-guide.md
+++ b/docs/codex-testing-guide.md
@@ -86,7 +86,7 @@ source .env  # or: set -a; source .env; set +a
 
 ```bash
 # Run the built binary directly
-node dist/cli-runner.js <subcommand>
+node dist/interface/cli/cli-runner.js <subcommand>
 
 # Or via npx
 npx pulseed <subcommand>
@@ -101,7 +101,7 @@ npx pulseed <subcommand>
 ```bash
 PULSEED_LLM_PROVIDER=openai \
 OPENAI_API_KEY=sk-... \
-node dist/cli-runner.js status
+node dist/interface/cli/cli-runner.js status
 ```
 
 If the command starts without errors and displays the goal list (even if empty), the connection is working.
@@ -111,14 +111,14 @@ If the command starts without errors and displays the goal list (even if empty),
 ```bash
 PULSEED_LLM_PROVIDER=openai \
 OPENAI_API_KEY=sk-... \
-node dist/cli-runner.js goal add "Create a file hello.txt and write 'Hello, PulSeed!' in it"
+node dist/interface/cli/cli-runner.js goal add "Create a file hello.txt and write 'Hello, PulSeed!' in it"
 ```
 
 GoalNegotiator will call the LLM to evaluate the goal's dimensions, thresholds, and feasibility.
 Confirm registration:
 
 ```bash
-node dist/cli-runner.js goal list
+node dist/interface/cli/cli-runner.js goal list
 ```
 
 ### Step 3: Run One Core Loop Cycle
@@ -126,7 +126,7 @@ node dist/cli-runner.js goal list
 ```bash
 PULSEED_LLM_PROVIDER=openai \
 OPENAI_API_KEY=sk-... \
-node dist/cli-runner.js run
+node dist/interface/cli/cli-runner.js run
 ```
 
 This executes one full cycle: observe → gap → score → task → verify.
@@ -155,7 +155,7 @@ Run:
 ```bash
 PULSEED_LLM_PROVIDER=openai \
 OPENAI_API_KEY=sk-... \
-node dist/cli-runner.js run
+node dist/interface/cli/cli-runner.js run
 ```
 
 The Codex adapter internally executes:
@@ -173,19 +173,19 @@ To specify `--model`, pass it to the `OpenAICodexCLIAdapter` constructor (requir
 ### A. Simple File Creation Task (easy to run with Codex)
 
 ```bash
-node dist/cli-runner.js goal add "Create hello.txt in the current directory and write 'Hello from PulSeed!'"
+node dist/interface/cli/cli-runner.js goal add "Create hello.txt in the current directory and write 'Hello from PulSeed!'"
 ```
 
 ### B. Run Tests Task
 
 ```bash
-node dist/cli-runner.js goal add "Run npx vitest run and confirm all tests pass"
+node dist/interface/cli/cli-runner.js goal add "Run npx vitest run and confirm all tests pass"
 ```
 
 ### C. Documentation Generation Task
 
 ```bash
-node dist/cli-runner.js goal add "Create README.md and describe the project in 3 lines"
+node dist/interface/cli/cli-runner.js goal add "Create README.md and describe the project in 3 lines"
 ```
 
 ---

--- a/docs/design/cc-inspired-improvements.md
+++ b/docs/design/cc-inspired-improvements.md
@@ -22,7 +22,7 @@ Claude Code's KAIROS subsystem is a proactive "assistant mode" that transforms a
 - `sleep_progress` is ephemeral (not sent to API) to avoid context pollution
 
 **What PulSeed should do:**
-- PulSeed already has CoreLoop's observe→gap→score→task→execute→verify cycle
+- PulSeed already has a structured `CoreLoop` plus a bounded `AgentLoop` for tool-using execution
 - **Add idle-tick injection** between CoreLoop cycles: when no active tasks exist, inject a `<tick>` to the LLM asking "given current goals and state, what should I proactively work on?"
 - This bridges the gap between PulSeed's structured loop and CC's freeform initiative
 - Implement `SleepScheduler` — adaptive sleep duration based on:
@@ -173,7 +173,7 @@ Claude Code's KAIROS subsystem is a proactive "assistant mode" that transforms a
 
 | Capability | Claude Code | PulSeed | Comparison |
 |-----------|-------------|---------|------------|
-| Core loop | Reactive (user→response) + KAIROS tick | Observe→gap→score→task→execute→verify | **PulSeed stronger** — structured, goal-driven |
+| Core loop | Reactive (user→response) + KAIROS tick | CoreLoop + AgentLoop + bounded core phases | **PulSeed stronger** — structured, goal-driven |
 | Multi-agent | Coordinator/Swarm/Fork patterns | AdapterLayer + multi-strategy portfolio | **Comparable** — different abstraction level |
 | Session persistence | `~/.claude/sessions/` | `~/.pulseed/` state files | **Comparable** |
 | Knowledge/Memory | Auto-memory + MEMORY.md + dream | KnowledgeManager + VectorIndex + hierarchical memory | **PulSeed stronger** — semantic, hierarchical |

--- a/docs/design/core/self-knowledge.md
+++ b/docs/design/core/self-knowledge.md
@@ -128,7 +128,7 @@ Returns a static description of PulSeed's architecture and capabilities.
 - Layer structure (Layer 0-15) with module names
 - Module responsibilities summary
 - Execution boundary: "PulSeed orchestrates goal pursuit. It perceives the world directly through read-only tools (Glob, Grep, Read, Shell, HttpFetch, JsonQuery) and delegates all mutations and complex multi-step work to agents."
-- Core loop: observe -> gap -> score -> task -> execute -> verify (NEVER STOP)
+- Runtime shape: CoreLoop (long-lived control) + AgentLoop (bounded execution with tool choice)
 - 4-element model: Goal -> Current State -> Gap -> Constraints
 
 **Data source**: Hardcoded text

--- a/docs/design/current-baseline.md
+++ b/docs/design/current-baseline.md
@@ -1,0 +1,139 @@
+# Current Design Baseline
+
+Implementation-facing baseline for the current PulSeed runtime.
+
+Use this document as the starting point when changing code. Public docs explain the system at a higher level; subsystem design docs often include proposals, alternatives, or historical notes. This file is the shortest path to "what shape the code is in now."
+
+## 1. Documentation Boundary
+
+- Public docs in `docs/` explain current behavior for users and contributors.
+- This file explains the current implementation baseline for engineers.
+- Detailed files in `docs/design/` should be read as subsystem notes. Some are current, some are mixed current-plus-proposal, and some are future design only.
+
+If a design note conflicts with code, prefer the code and update the design note.
+
+## 2. Runtime Shape
+
+PulSeed currently has two loops:
+
+1. `CoreLoop`
+   Long-lived control loop for goal progress, prioritization, stall handling, and re-planning.
+2. `AgentLoop`
+   Bounded execution loop where the model chooses tools, reads tool results, and decides the next action until it can produce a final answer or termination signal.
+
+The intended relationship is:
+
+- `CoreLoop` decides what kind of work is needed next.
+- `CoreLoop` may execute deterministic phases directly.
+- `CoreLoop` may also invoke bounded agentic phases that behave like `AgentLoop`.
+- Chat/TUI/Telegram style task execution is driven by `AgentLoop`.
+
+This is the baseline to preserve when implementing further core-loop integration.
+
+## 3. Current Execution Boundary
+
+The current runtime boundary is:
+
+- PulSeed can directly read and inspect through tools.
+- PulSeed can directly query memory and Soil.
+- Bounded `AgentLoop` runs are used for short-to-medium execution.
+- Long-lived autonomous control remains in `CoreLoop`.
+
+Read-only and query-style operations live well inside PulSeed. Mutations, multi-step execution, and user-facing task completion flow through `AgentLoop`, task lifecycle orchestration, or adapters depending on the surface.
+
+## 4. Current Code Map
+
+### Foundation
+
+- `src/base/`
+  Shared types, LLM client foundation, state management, config, utilities.
+
+### Orchestration
+
+- `src/orchestrator/loop/`
+  Core loop control and iteration helpers.
+- `src/orchestrator/execution/`
+  Task lifecycle, adapter layer, session management, parallel execution, verification.
+- `src/orchestrator/goal/`
+  Goal negotiation, refinement, goal tree management, tree loop orchestration.
+- `src/orchestrator/strategy/`
+  Strategy and portfolio management.
+- `src/orchestrator/knowledge/`
+  Knowledge management and transfer orchestration.
+
+### Platform services
+
+- `src/platform/observation/`
+  Observation engine and observation-related helpers.
+- `src/platform/soil/`
+  Soil generation, publishing, and retrieval support.
+- `src/platform/drive/`
+  Gap, drive, stall, and satisficing primitives.
+- `src/platform/runtime/`, `src/runtime/`
+  Daemon, queue, schedule, gateway, and process runtime support.
+
+### Interfaces
+
+- `src/interface/chat/`
+  Chat runner, tend command, chat verification, self-knowledge tools.
+- `src/interface/cli/`
+  CLI entrypoints and commands.
+- `src/interface/tui/`
+  TUI application and chat surface.
+
+### Tools
+
+- `src/tools/`
+  Built-in tools used by bounded execution loops.
+- Important families:
+  - `src/tools/query/` for state, history, Soil, and knowledge queries
+  - `src/tools/fs/` for file inspection and controlled edits
+  - `src/tools/system/` for shell, sleep, test, and process tools
+  - `src/tools/mutation/` and `src/tools/schedule/` for controlled state changes
+
+## 5. Soil in the Current Baseline
+
+Soil is part of the current baseline, not an optional future idea.
+
+- Soil storage and publishing live under `src/platform/soil/`.
+- Tool access is exposed through `src/tools/query/SoilQueryTool/` and related execution tools.
+- The design direction is that both `AgentLoop` and bounded core-loop phases can use Soil as a first-class context source.
+
+When making loop changes, preserve this assumption.
+
+## 6. Current Entry Points
+
+- CLI runner: `src/interface/cli/cli-runner.ts`
+- Chat command: `src/interface/cli/commands/chat.ts`
+- Chat runtime: `src/interface/chat/chat-runner.ts`
+- TUI chat: `src/interface/tui/chat.tsx`
+- Core loop implementation: `src/orchestrator/loop/`
+
+## 7. How To Read `docs/design`
+
+Read in this order:
+
+1. This file
+2. `docs/architecture-map.md`
+3. `docs/runtime.md`
+4. `docs/module-map.md`
+5. Subsystem design notes that match the area you are changing
+
+Recommended subsystem notes for current runtime work:
+
+- `docs/design/execution/task-lifecycle.md`
+- `docs/design/execution/chat-mode.md`
+- `docs/design/goal/goal-tree.md`
+- `docs/design/knowledge/soil-system.md`
+- `docs/design/infrastructure/schedule-engine.md`
+- `docs/design/core/tool-system.md`
+
+Treat the following categories carefully:
+
+- Comparative or inspiration docs: useful for rationale, not source of truth
+- Large future architecture proposals: useful for direction, not current behavior
+- Historical documents that still mention old paths or old single-loop framing
+
+## 8. Change Rule
+
+When implementation changes the runtime shape, update this file first or in the same change.

--- a/docs/design/execution/chat-mode.md
+++ b/docs/design/execution/chat-mode.md
@@ -174,7 +174,7 @@ The command passes conversation history to the LLM as the primary source for goa
 Parses `pulseed chat [task]` and delegates to ChatRunner.
 
 - If `task` argument is present: non-interactive, single turn
-- If `task` is absent: open interactive REPL backed by TUI chat component (`src/tui/chat.tsx` — no changes needed)
+- If `task` is absent: open interactive REPL backed by TUI chat component (`src/interface/tui/chat.tsx` — no changes needed)
 - Flags: `--adapter <name>`, `--resume [id]` (Phase 2), `--timeout <ms>`
 
 ### 5.5 Context Provider Extension (`src/observation/context-provider.ts`)
@@ -330,7 +330,7 @@ No escalation, no persistence, no TUI. Verify: single-turn execution returns out
 Deliverable: `pulseed chat` opens an interactive loop.
 
 Files:
-- `src/cli/commands/chat.ts` — add interactive path, integrate `src/tui/chat.tsx`
+- `src/interface/cli/commands/chat.ts` — add interactive path, integrate `src/interface/tui/chat.tsx`
 - Built-in commands: `/help`, `/clear`, `/exit`
 
 No escalation yet. Verify: multi-turn conversation with history accumulation.

--- a/docs/design/execution/multi-agent-delegation.md
+++ b/docs/design/execution/multi-agent-delegation.md
@@ -212,12 +212,12 @@ The `confidence` label uses the same criteria as the observation engine (`>=0.50
 ### Phase 1 (MVP): Sequential pipeline + domain-specific observation + persistence + idempotency
 
 **New files:**
-- `src/types/pipeline.ts` — TaskDomain, TaskRole, PipelineStage, TaskPipeline, StageResult, PipelineState, ImpactAnalysis (~100 lines)
-- `src/execution/pipeline-executor.ts` — sequential stage execution + error escalation + persistence + idempotency check (~200 lines)
+- `src/base/types/pipeline.ts` — TaskDomain, TaskRole, PipelineStage, TaskPipeline, StageResult, PipelineState, ImpactAnalysis (~100 lines)
+- `src/orchestrator/execution/pipeline-executor.ts` — sequential stage execution + error escalation + persistence + idempotency check (~200 lines)
 
 **Modified files:**
-- `src/observation/observation-engine.ts` — add `domain: TaskDomain` parameter to `observeForTask()`, domain-specific collection strategies
-- `src/execution/task-lifecycle.ts` — add `runPipelineTaskCycle()` alongside `runTaskCycle()`. Existing `runTaskCycle()` is unchanged.
+- `src/platform/observation/observation-engine.ts` — add `domain: TaskDomain` parameter to `observeForTask()`, domain-specific collection strategies
+- `src/orchestrator/execution/task/task-lifecycle.ts` — add `runPipelineTaskCycle()` alongside `runTaskCycle()`. Existing `runTaskCycle()` is unchanged.
 
 **Tests:** `tests/execution/pipeline-executor.test.ts`
 
@@ -237,26 +237,26 @@ Flow of `runPipelineTaskCycle()`:
 ### Phase 2: Task decomposition + parallel execution + Plan Gate + strategy feedback
 
 **New files:**
-- `src/types/task-group.ts` — TaskGroup schema (~30 lines)
-- `src/execution/parallel-executor.ts` — `Promise.all` + file ownership check (~150 lines)
+- `src/base/types/task-group.ts` — TaskGroup schema (~30 lines)
+- `src/orchestrator/execution/parallel-executor.ts` — `Promise.all` + file ownership check (~150 lines)
 
 **Modified files:**
-- `src/execution/task-generation.ts` — TaskGroup + plan generation. LLM evaluates task complexity and decides between single task vs TaskGroup.
-- `src/core-loop.ts` — `runOneIteration()` detects TaskGroup and hands it to `ParallelExecutor`
-- `src/execution/pipeline-executor.ts` — Plan Approval Gate + three-strike escalation + `strategy_id` feedback
+- `src/orchestrator/execution/task/task-generation.ts` — TaskGroup + plan generation. LLM evaluates task complexity and decides between single task vs TaskGroup.
+- `src/orchestrator/loop/core-loop.ts` — `runOneIteration()` detects TaskGroup and hands it to `ParallelExecutor`
+- `src/orchestrator/execution/pipeline-executor.ts` — Plan Approval Gate + three-strike escalation + `strategy_id` feedback
 
 **Tests:** `tests/execution/parallel-executor.test.ts`
 
 ### Phase 3: Auto pipeline + side-effect detection + contradiction detection + fault tolerance
 
 **New files:**
-- `src/execution/result-reconciler.ts` — contradiction detection in parallel results (~120 lines)
+- `src/orchestrator/execution/result-reconciler.ts` — contradiction detection in parallel results (~120 lines)
 
 **Modified files:**
-- `src/execution/task-verifier.ts` — `ImpactAnalysis` generation + sycophancy mitigation (uses a different model instance)
-- `src/execution/task-generation.ts` — auto-configure pipeline based on task size evaluation
-- `src/execution/adapter-layer.ts` — capability matching + circuit breaker
-- `src/execution/parallel-executor.ts` — concurrency semaphore
+- `src/orchestrator/execution/task/task-verifier.ts` — `ImpactAnalysis` generation + sycophancy mitigation (uses a different model instance)
+- `src/orchestrator/execution/task/task-generation.ts` — auto-configure pipeline based on task size evaluation
+- `src/orchestrator/execution/adapter-layer.ts` — capability matching + circuit breaker
+- `src/orchestrator/execution/parallel-executor.ts` — concurrency semaphore
 
 **Tests:** `tests/execution/result-reconciler.test.ts`
 
@@ -265,20 +265,21 @@ Flow of `runPipelineTaskCycle()`:
 ## 6. File Structure
 
 ```
-src/types/
+src/base/types/
   pipeline.ts                    <- new (~100 lines)
   task-group.ts                  <- new (~30 lines)
 
-src/execution/
+src/orchestrator/execution/
   pipeline-executor.ts           <- new (~200 lines)
   parallel-executor.ts           <- new (~150 lines)
   result-reconciler.ts           <- new (~120 lines)
-  task-lifecycle.ts              <- modified (add runPipelineTaskCycle)
-  task-generation.ts             <- modified (pipeline generation + TaskGroup decomposition)
-  task-verifier.ts               <- modified (ImpactAnalysis + sycophancy mitigation, Phase 3)
+  task/
+    task-lifecycle.ts            <- modified (add runPipelineTaskCycle)
+    task-generation.ts           <- modified (pipeline generation + TaskGroup decomposition)
+    task-verifier.ts             <- modified (ImpactAnalysis + sycophancy mitigation, Phase 3)
   adapter-layer.ts               <- modified (capability matching + circuit breaker, Phase 3)
 
-src/observation/
+src/platform/observation/
   observation-engine.ts          <- modified (domain-specific observeForTask)
 
 tests/execution/

--- a/docs/design/goal/goal-refinement-pipeline.md
+++ b/docs/design/goal/goal-refinement-pipeline.md
@@ -129,9 +129,9 @@ The prompt includes available data sources from ObservationEngine so the LLM can
 ### 3.4 Where It Lives
 
 ```
-src/goal/goal-refiner.ts          # NEW — GoalRefiner class
-src/goal/refiner-prompts.ts       # NEW — leaf test prompt builder
-src/types/goal-refiner.ts         # NEW — RefineConfig, LeafTestResult, RefineResult schemas
+src/orchestrator/goal/goal-refiner.ts          # NEW — GoalRefiner class
+src/orchestrator/goal/refiner-prompts.ts       # NEW — leaf test prompt builder
+src/base/types/goal-refiner.ts                 # NEW — RefineConfig, LeafTestResult, RefineResult schemas
 ```
 
 **GoalRefiner** composes:
@@ -174,11 +174,11 @@ class GoalRefiner {
 
 Each step is independently testable and deployable. No breaking changes until step 4.
 
-1. **Add types** — `src/types/goal-refiner.ts` with `RefineConfig`, `LeafTestResult`, `RefineResult` Zod schemas. No behavior change.
+1. **Add types** — `src/base/types/goal-refiner.ts` with `RefineConfig`, `LeafTestResult`, `RefineResult` Zod schemas. No behavior change.
 
-2. **Add leaf test** — `src/goal/refiner-prompts.ts` with `buildLeafTestPrompt()`. Unit-testable with mock LLM. No integration yet.
+2. **Add leaf test** — `src/orchestrator/goal/refiner-prompts.ts` with `buildLeafTestPrompt()`. Unit-testable with mock LLM. No integration yet.
 
-3. **Add GoalRefiner** — `src/goal/goal-refiner.ts` implementing `refine()`. Calls GoalNegotiator and GoalTreeManager internally. Integration tests against mock LLM. Old paths still work.
+3. **Add GoalRefiner** — `src/orchestrator/goal/goal-refiner.ts` implementing `refine()`. Calls GoalNegotiator and GoalTreeManager internally. Integration tests against mock LLM.
 
 4. **Wire CLI** — `goal add` calls `refine()` by default. `--negotiate` and `--tree` flags become aliases / deprecated. `--no-refine` skips refinement entirely.
 

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -2,6 +2,24 @@
 
 Overview of PulSeed's design documentation, organized by subsystem.
 
+## Read This First
+
+Start here when you need the current implementation-facing design:
+
+- [Current Design Baseline](current-baseline.md)
+- [Architecture Map](../architecture-map.md)
+- [Runtime](../runtime.md)
+- [Module Map](../module-map.md)
+
+These four documents should answer "how the system is shaped now." The rest of `docs/design/` is primarily subsystem detail, rationale, and future design work.
+
+## How To Read These Docs
+
+- Public docs in `docs/` are the user/contributor-facing explanation of the current system.
+- `current-baseline.md` is the engineering baseline for current implementation.
+- The subsystem docs below may mix current behavior, near-term design, and future proposals.
+- If a design note conflicts with code, prefer the code and update the design note.
+
 ## Core — Loop and State Management
 
 | Document | Description |

--- a/docs/design/infrastructure/llm-fault-tolerance.md
+++ b/docs/design/infrastructure/llm-fault-tolerance.md
@@ -75,7 +75,7 @@ Allowed change magnitude: max(±0.3 absolute, ±30% of current value)
 If the proposed change exceeds the range: clamp to the limit and emit a warning log
 ```
 
-**Implementation location**: Add a `clampDimensionUpdate()` helper function inside the `dimension_updates` application loop near L316 in `src/execution/task-verifier.ts`
+**Implementation location**: Add a `clampDimensionUpdate()` helper function inside the `dimension_updates` application loop in `src/orchestrator/execution/task/task-verifier.ts`
 
 ```typescript
 function clampDimensionUpdate(current: number, proposed: number): number {
@@ -146,7 +146,7 @@ Contradiction condition: curr_gap > prev_gap + 0.05 AND verdict == "pass"
   → WARN log: `WARN: progress-verdict contradiction: gap increased (${prev_gap}→${curr_gap}) but verdict was pass. Overriding to partial.`
 ```
 
-**Implementation location**: Inside `handleVerdict()` in `src/execution/task-verifier.ts`, before the trust update
+**Implementation location**: Inside `handleVerdict()` in `src/orchestrator/execution/task/task-verifier.ts`, before the trust update
 
 **Behavior when guard fires**:
 - Rewrites `verdict` to `partial` (prevents `recordSuccess` from being triggered by a `pass`)
@@ -171,7 +171,7 @@ Against the N most recent tasks (N=10):
 Future: replace with semantic embedding similarity (once VectorIndex is available)
 ```
 
-**Implementation location**: In `src/execution/task-generation.ts`, after task generation and before returning to `TaskLifecycle`
+**Implementation location**: In `src/orchestrator/execution/task/task-generation.ts`, after task generation and before returning to `TaskLifecycle`
 
 **Behavior when guard fires**:
 - Returns `null` instead of a task (treated as generation failure)
@@ -258,9 +258,9 @@ task.intended_direction is assigned by task-generation.ts (not yet implemented �
 **Current limitation**: The `task.intended_direction` field does not exist in the current task schema. Enabling this guard requires a schema addition.
 
 **Implementation locations**:
-- Add `intended_direction?: "increase" | "decrease" | "neutral"` to `src/types/tasks.ts`
-- Add assignment instructions to the prompt in `src/execution/task-generation.ts`
-- Add the check inside the application loop near L316 in `src/execution/task-verifier.ts`
+- Add `intended_direction?: "increase" | "decrease" | "neutral"` to `src/base/types/tasks.ts`
+- Add assignment instructions to the prompt in `src/orchestrator/execution/task/task-generation.ts`
+- Add the check inside the application loop in `src/orchestrator/execution/task/task-verifier.ts`
 
 **Behavior when guard fires**:
 - Ignores `dimension_updates` (does not change any values)
@@ -285,7 +285,7 @@ const CompletionJudgerResponseSchema = z.object({
 });
 ```
 
-**Implementation location**: Inside the `completion_judger` function at L613–653 in `src/execution/task-verifier.ts`, switching to `llmClient.parseJSON()`
+**Implementation location**: Inside the `completion_judger` function in `src/orchestrator/execution/task/task-verifier.ts`, switching to `llmClient.parseJSON()`
 
 **Behavior when guard fires**:
 - On parse failure, retain the existing `{passed: false, confidence: 0.3}` fallback
@@ -316,8 +316,8 @@ On task verification failure (verdict = "fail" or "partial"):
 ```
 
 **Implementation locations**:
-- Save failure reason: write `last_failure_context` to `StateManager` inside `handleVerdict()` in `src/execution/task-verifier.ts`
-- Prompt injection: read `last_failure_context` and inject it during prompt construction in `src/execution/task-generation.ts`
+- Save failure reason: write `last_failure_context` to `StateManager` inside `handleVerdict()` in `src/orchestrator/execution/task/task-verifier.ts`
+- Prompt injection: read `last_failure_context` and inject it during prompt construction in `src/orchestrator/execution/task/task-generation.ts`
 
 **Behavior when guard fires**: Normal operation (this is information injection, not a guard). Skipped if no failure context exists.
 

--- a/docs/design/infrastructure/plugin-architecture.md
+++ b/docs/design/infrastructure/plugin-architecture.md
@@ -14,7 +14,7 @@
 
 In Claude Code and OpenClaw, plugins are "tools the user explicitly calls." The user runs a command and the tool responds. The user is the active agent.
 
-PulSeed plugins are different. PulSeed's core loop (observe → gap → score → task → execute → verify) runs autonomously without user instructions. Therefore, plugins must also be things **PulSeed autonomously selects and integrates into the core loop**. Not requiring user instructions like "please call this plugin" is the starting point of PulSeed's plugin design.
+PulSeed plugins are different. PulSeed's runtime is driven by an autonomous `CoreLoop` and bounded `AgentLoop` executions, not only by direct user instructions. Therefore, plugins must also be things **PulSeed autonomously selects and integrates into the runtime**. Not requiring user instructions like "please call this plugin" is the starting point of PulSeed's plugin design.
 
 ```
 Claude Code / OpenClaw:

--- a/docs/design/infrastructure/token-optimization.md
+++ b/docs/design/infrastructure/token-optimization.md
@@ -217,8 +217,8 @@ After 5 consecutive skips, the full loop runs regardless of state diff. This int
 
 **Files to change:**
 - `src/loop/state-diff.ts` -- NEW file, implements `StateDiffCalculator`
-- `src/core-loop.ts` -- add diff check after observation phase, before gap calculation
-- `src/types/loop.ts` -- add `IterationSnapshot` and `StateDiffThresholds` schemas
+- `src/orchestrator/loop/core-loop.ts` -- add diff check after observation phase, before gap calculation
+- `src/base/types/loop.ts` -- add `IterationSnapshot` and `StateDiffThresholds` schemas
 
 **Integration point in `runOneIteration`:**
 
@@ -349,12 +349,12 @@ This is optional (phase 2). The default static classification is sufficient for 
 ### Implementation
 
 **Files to change:**
-- `src/llm/provider-config.ts` -- add `light_model` field to provider config schema
-- `src/llm/base-llm-client.ts` -- add model selection logic based on `model_tier`
-- `src/types/llm.ts` -- add `ModelTier` type and `model_tier` to `LLMRequestOptions`
-- `src/observation/observation-llm.ts` -- pass `model_tier: 'light'`
-- `src/execution/task-generation.ts` -- pass `model_tier: 'main'` (default, explicit)
-- `src/execution/task-verifier.ts` -- pass `model_tier: 'light'` for L2, `model_tier: 'main'` for re-review
+- `src/base/llm/provider-config.ts` -- add `light_model` field to provider config schema
+- `src/base/llm/base-llm-client.ts` -- add model selection logic based on `model_tier`
+- `src/base/types/llm.ts` -- add `ModelTier` type and `model_tier` to `LLMRequestOptions`
+- `src/platform/observation/observation-llm.ts` -- pass `model_tier: 'light'`
+- `src/orchestrator/execution/task/task-generation.ts` -- pass `model_tier: 'main'` (default, explicit)
+- `src/orchestrator/execution/task/task-verifier.ts` -- pass `model_tier: 'light'` for L2, `model_tier: 'main'` for re-review
 
 ### Expected savings
 

--- a/docs/design/infrastructure/web-ui.md
+++ b/docs/design/infrastructure/web-ui.md
@@ -8,7 +8,7 @@
 
 ## 1. Overview
 
-- The TUI (`src/tui/`) is designed for a single terminal. The Web UI enables browser access and multi-screen display.
+- The TUI (`src/interface/tui/`) is designed for a single terminal. The Web UI enables browser access and multi-screen display.
 - The TUI is kept. The Web UI shares the same data layer as the TUI (StateManager, CoreLoop, etc.) and operates concurrently.
 
 **In scope**: 4 Web UI screens, REST API layer, SSE real-time updates
@@ -97,7 +97,7 @@ Common layout: left sidebar (nav, 120px fixed) + main area
 
 **Top — Goal list table**: Goal name (link), Gap % (progress bar, background `#1a1a1a`), Trust score (number + color: red <0, gray 0-20, green >20), strategy status badge, last updated
 
-**Middle — Active sessions**: Adapter name + role + stage (observe→gap→score→task→execute→verify), elapsed time
+**Middle — Active sessions**: Adapter name + runtime type (`core_loop` / `agent_loop`) + phase or step label, elapsed time
 
 **Bottom — Decision timeline (last 10 items)**: Timestamp + goal name + decision type (PIVOT/REFINE/ESCALATE) + one-line summary
 

--- a/docs/design/knowledge/hypothesis-verification.md
+++ b/docs/design/knowledge/hypothesis-verification.md
@@ -18,7 +18,7 @@
 
 ### PulSeedtion for Applying This to PulSeed
 
-PulSeed's core loop (observe → gap → score → task → execute → verify) is structurally sound, but has the following issues:
+PulSeed's current `CoreLoop` plus bounded `AgentLoop` execution model is structurally sound, but has the following issues:
 
 1. **No defined action after stall detection** — Even when StallDetector determines "it has stalled," CoreLoop has only limited branching
 2. **Zero meta-knowledge for strategy decisions** — There is no record of which strategies were effective for similar goals in the past, and no way to look that up

--- a/docs/design/knowledge/memory-lifecycle.md
+++ b/docs/design/knowledge/memory-lifecycle.md
@@ -15,7 +15,7 @@ Under long-term operation, PulSeed continuously accumulates the following data:
 
 | Data type | Source | Growth rate |
 |-----------|--------|------------|
-| Experience log | Each step of the core loop (observe→gap→score→task→execute→verify) | 1 entry per loop |
+| Experience log | Each CoreLoop iteration plus bounded AgentLoop execution summaries | 1 entry per loop / run |
 | Observation history | ObservationEngine periodic and event-driven observations | dimensions × observation frequency |
 | Knowledge base | Results of KnowledgeManager research tasks | Multiple entries per research task |
 | Strategy history | Strategy execution results from StrategyManager/PortfolioManager | 1 entry per strategy change |
@@ -114,7 +114,7 @@ Long-term Memory
 
 ### 3.1 Experience Log
 
-Records of the result of each step of the core loop (observe→gap→score→task→execute→verify). The data source for the learning pipeline in `mechanism.md` §4.
+Records of CoreLoop iteration results and bounded AgentLoop execution outcomes. The data source for the learning pipeline in `mechanism.md` §4.
 
 | Layer | What is retained | Format |
 |-------|----------------|--------|

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -34,7 +34,7 @@ git clone https://github.com/my-name-is-yu/PulSeed.git
 cd PulSeed
 npm install
 npm run build
-node dist/cli-runner.js --help
+node dist/interface/cli/cli-runner.js --help
 ```
 
 ---
@@ -169,18 +169,20 @@ pulseed report --goal <goal-id>
 
 ## 5. What Happens Next
 
-Each time you call `pulseed run`, PulSeed executes one full iteration of its core loop:
+`pulseed run` starts PulSeed's core loop for the selected goal and keeps iterating until completion, stall, explicit stop, or the active iteration budget is exhausted:
 
-```
-Observe → Gap → Score → Task → Execute → Verify
-```
+The current runtime combines:
 
-1. **Observe** — collects evidence from mechanical checks, an independent LLM review, and the executor's self-report
-2. **Gap** — quantifies how far each dimension is from its threshold
-3. **Score** — ranks gaps by dissatisfaction, deadline urgency, and opportunity
-4. **Task** — generates a concrete, verifiable task targeting the largest gap
-5. **Execute** — delegates the task to the selected adapter (Codex CLI, Claude Code, GitHub Issues, etc.)
-6. **Verify** — runs 3-layer verification; self-report alone caps progress at 70%
+- **CoreLoop** — long-lived control for observation, prioritization, completion checks, stall handling, and re-planning
+- **AgentLoop** — bounded execution where the model chooses tools, reads results, and works toward a final answer or task outcome
+
+The exact step shape varies by goal and execution path, but the common flow is:
+
+1. **Observe and refresh evidence**
+2. **Calculate gaps and priorities**
+3. **Choose the next task or bounded execution step**
+4. **Execute with adapters or tools**
+5. **Verify outcomes and update persisted state**
 
 State is written to `~/.pulseed/` after every loop, so you can stop and resume at any time. Running `pulseed run` again picks up exactly where the last run left off.
 

--- a/docs/local-llm-testing-guide.md
+++ b/docs/local-llm-testing-guide.md
@@ -60,49 +60,49 @@ Use `npx pulseed` or run directly:
 ```bash
 npx pulseed <subcommand>
 # or
-node dist/cli-runner.js <subcommand>
+node dist/interface/cli/cli-runner.js <subcommand>
 ```
 
 ### Help
 
 ```bash
-node dist/cli-runner.js --help
+node dist/interface/cli/cli-runner.js --help
 ```
 
 ### Add a Goal
 
 ```bash
-node dist/cli-runner.js goal add "Create a readme for PulSeed"
+node dist/interface/cli/cli-runner.js goal add "Create a readme for PulSeed"
 ```
 
 ### List Goals
 
 ```bash
-node dist/cli-runner.js goal list
+node dist/interface/cli/cli-runner.js goal list
 ```
 
 ### Run the Core Loop
 
 ```bash
-node dist/cli-runner.js run
+node dist/interface/cli/cli-runner.js run
 ```
 
 ### Check Status
 
 ```bash
-node dist/cli-runner.js status
+node dist/interface/cli/cli-runner.js status
 ```
 
 ### Report
 
 ```bash
-node dist/cli-runner.js report
+node dist/interface/cli/cli-runner.js report
 ```
 
 ### TUI (Interactive UI)
 
 ```bash
-node dist/cli-runner.js tui
+node dist/interface/cli/cli-runner.js tui
 ```
 
 TUI controls:
@@ -113,7 +113,7 @@ TUI controls:
 > **TUI notes**:
 > - Display may be garbled over SSH + tmux due to insufficient terminal width → use `Ctrl-b z` to zoom the pane and gain more width
 > - Chat is command-based, not free-form input
-> - If frozen, press `Ctrl-C` or run `pkill -f "node dist/cli-runner.js"` from another terminal pane
+> - If frozen, press `Ctrl-C` or run `pkill -f "node dist/interface/cli/cli-runner.js"` from another terminal pane
 
 ## 4. Connecting to Ollama from Another Machine
 
@@ -129,7 +129,7 @@ curl http://<older-mac-ip>:11434/v1/models
 # Run PulSeed from your development machine
 PULSEED_LLM_PROVIDER=ollama \
 OLLAMA_BASE_URL=http://<older-mac-ip>:11434 \
-node dist/cli-runner.js run
+node dist/interface/cli/cli-runner.js run
 ```
 
 ## 5. Test Scenarios
@@ -138,25 +138,25 @@ node dist/cli-runner.js run
 
 ```bash
 # 1. Add a goal
-node dist/cli-runner.js goal add "A simple goal for testing"
+node dist/interface/cli/cli-runner.js goal add "A simple goal for testing"
 
 # 2. Confirm registration with goal list
-node dist/cli-runner.js goal list
+node dist/interface/cli/cli-runner.js goal list
 
 # 3. Run the core loop
-node dist/cli-runner.js run
+node dist/interface/cli/cli-runner.js run
 
 # 4. Check status
-node dist/cli-runner.js status
+node dist/interface/cli/cli-runner.js status
 
 # 5. Generate a report
-node dist/cli-runner.js report
+node dist/interface/cli/cli-runner.js report
 ```
 
 ### B. TUI Operation Check
 
 ```bash
-node dist/cli-runner.js tui
+node dist/interface/cli/cli-runner.js tui
 # → Run /help to see available commands
 # → Try adding and running a goal
 # → Press Ctrl-C to exit
@@ -167,17 +167,17 @@ node dist/cli-runner.js tui
 ```bash
 # Run PulSeed while Ollama is stopped → verify retry and error output
 # (stop ollama in another terminal first, then run)
-node dist/cli-runner.js run
+node dist/interface/cli/cli-runner.js run
 ```
 
 ## 6. Known Issues
 
 | Issue | Cause | Workaround |
 |-------|-------|------------|
-| ~~`npx pulseed` produces no output~~ | ~~Fixed~~ Updated to use `import.meta.url` + `realpathSync` check | Both `npx pulseed` and `node dist/cli-runner.js` work |
+| ~~`npx pulseed` produces no output~~ | ~~Fixed~~ Updated to use `import.meta.url` + `realpathSync` check | Both `npx pulseed` and `node dist/interface/cli/cli-runner.js` work |
 | TUI display garbled | Insufficient terminal width over SSH + tmux | Zoom the pane with `Ctrl-b z` |
 | TUI chat says "I didn't understand" | Chat is command-based (free-form input not supported) | Check available commands with `/help` |
-| TUI frozen | Ink rendering issue | `Ctrl-C` or `pkill -f "node dist/cli-runner.js"` |
+| TUI frozen | Ink rendering issue | `Ctrl-C` or `pkill -f "node dist/interface/cli/cli-runner.js"` |
 | `ANTHROPIC_API_KEY` required | Hard-coded check at TUI startup | Set `ANTHROPIC_API_KEY=dummy` |
 
 ## 7. Resetting State

--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -1,7 +1,11 @@
 # Module Boundary Map
 
+Implementation-facing baseline: [docs/design/current-baseline.md](design/current-baseline.md)
+
 > This document is a guide for Claude Code to immediately determine "which files to touch."
 > Use it to quickly identify target files based on the type of change needed.
+>
+> Note: the detailed tables below predate parts of the current `src/base` / `src/orchestrator` / `src/platform` / `src/interface` split. Use `docs/design/current-baseline.md` and the live code layout as the source of truth when a path here disagrees with the repository.
 
 ## Quick Reference: Change Type → Target Files
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,5 +1,7 @@
 # PulSeed --- Runtime Infrastructure
 
+Implementation-facing baseline: [docs/design/current-baseline.md](design/current-baseline.md)
+
 > The foundational design for "running" the task discovery engine (mechanism.md).
 > While mechanism.md defines "what PulSeed thinks about," this document defines "how PulSeed runs."
 
@@ -117,7 +119,7 @@ In MVP, "scheduling" is the user's (or system cron's) responsibility. PulSeed do
 
 **`pulseed tui`** launches an Ink-based terminal UI, allowing interactive control of the core loop while viewing a dashboard.
 
-- Entry point is `src/tui/entry.ts` (`startTUI()`)
+- Entry point is `src/interface/tui/entry.ts` (`startTUI()`)
 - Dependencies chain: `entry.ts` → `App` (`app.tsx`) → `useLoop` hook (`use-loop.ts`) → `CoreLoop`
 - Loop startup, stop, and configuration changes are all managed internally by the `useLoop` hook, tied to the React component lifecycle
 - The core loop itself requires no changes. TUI uses the same `CoreLoop` instance as the CLI

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,238 +1,45 @@
 # Implementation Status
 
-Current repository state as of 2026-03-20.
+Current repository snapshot as of 2026-04-12.
 
-- Implementation scope: source modules for Stage 1-14 and Milestone 1-18 are present in `src/` and `web/`; Phase 3 refactoring complete; OSS optimization #112-#146 all 35 items complete
-- Source inventory: 184 `.ts` / `.tsx` implementation files under `src/`
-- Test inventory: 179 test files
-- Current test result: 4061 tests passing (excludes e2e tests)
+This document now tracks the current runtime shape and the codebase surfaces that are actively in use. Older stage-by-stage implementation history has been retained in `docs/archive/`.
 
-## Stage 1 (complete)
-- Implementation modules: `src/state-manager.ts`, `src/gap-calculator.ts`, core schemas in `src/types/` (`goal.ts`, `state.ts`, `task.ts`, `report.ts`, `drive.ts`, `trust.ts`, `stall.ts`, `strategy.ts`, `negotiation.ts`, `gap.ts`, `core.ts`)
-- Dedicated validation: 2 test files, 108 explicit `it()` / `test()` blocks
-- Status: complete, all tests passing
+## Current Baseline
 
-## Stage 2 (complete)
-- Implementation modules: `src/drive-system.ts`, `src/trust-manager.ts`, `src/observation-engine.ts`, `src/drive-scorer.ts`, `src/satisficing-judge.ts`, `src/stall-detector.ts`
-- Dedicated validation: 8 test files, 398 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+- Runtime model: `CoreLoop` for long-lived control, `AgentLoop` for bounded execution
+- Primary code split: `src/base/`, `src/orchestrator/`, `src/platform/`, `src/interface/`, `src/tools/`, `src/runtime/`
+- Current implementation-facing design reference: [docs/design/current-baseline.md](design/current-baseline.md)
 
-## Stage 3 (complete)
-- Implementation modules: `src/llm-client.ts`, `src/ethics-gate.ts`, `src/session-manager.ts`, `src/strategy-manager.ts`, `src/goal-negotiator.ts`
-- Dedicated validation: 6 test files, 397 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+## What Exists Now
 
-## Stage 4 (complete)
-- Implementation modules: `src/adapter-layer.ts`, `src/adapters/claude-code-cli.ts`, `src/adapters/claude-api.ts`, `src/task-lifecycle.ts`
-- Dedicated validation: 2 test files, 204 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+- Goal orchestration and tree handling under `src/orchestrator/goal/`
+- Core loop control under `src/orchestrator/loop/`
+- Task lifecycle, verification, sessions, and adapter layer under `src/orchestrator/execution/`
+- Observation, drive, Soil, memory, runtime, and traits support under `src/platform/`
+- CLI, chat, TUI, and MCP surfaces under `src/interface/`
+- Built-in tool surfaces under `src/tools/`
 
-## Stage 5 (complete)
-- Implementation modules: `src/reporting-engine.ts`, `src/core-loop.ts`
-- Dedicated validation: 4 test files, 205 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+## User-Facing Surfaces
 
-## Stage 6 (complete)
-- Implementation modules: `src/cli-runner.ts`, `src/index.ts`
-- Dedicated validation: 2 test files, 74 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+- CLI entrypoint: `dist/interface/cli/cli-runner.js`
+- Chat runtime: `src/interface/chat/`
+- TUI runtime: `src/interface/tui/`
+- Long-lived runtime and scheduling: `src/runtime/`
 
-## Stage 7 (complete)
-- Implementation modules: TUI layer in `src/tui/` (`actions.ts`, `app.tsx`, `approval-overlay.tsx`, `chat.tsx`, `dashboard.tsx`, `entry.ts`, `help-overlay.tsx`, `intent-recognizer.ts`, `markdown-renderer.ts`, `report-view.tsx`, `use-loop.ts`)
-- Dedicated validation: 3 test files, 70 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+## Documentation Status
 
-## Stage 8 (complete)
-- Implementation modules: `src/knowledge-manager.ts`, `src/capability-detector.ts`, `src/types/knowledge.ts`, `src/types/capability.ts`
-- Dedicated validation: 2 test files, 133 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+- Public docs in `docs/` describe the current runtime and usage model
+- `docs/design/current-baseline.md` is the implementation-facing source of truth for runtime shape
+- Some detailed design docs still include proposal or historical material; when they conflict with code, prefer code and update the docs
+- Historical implementation progress is archived under `docs/archive/`
 
-## Stage 9 (complete)
-- Implementation modules: `src/portfolio-manager.ts`, `src/types/portfolio.ts`
-- Dedicated validation: 1 test file, 40 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+## Validation
 
-## Stage 10 (complete)
-- Implementation modules: `src/daemon-runner.ts`, `src/pid-manager.ts`, `src/logger.ts`, `src/event-server.ts`, `src/notification-dispatcher.ts`, `src/memory-lifecycle.ts`, `src/types/daemon.ts`, `src/types/notification.ts`, `src/types/memory-lifecycle.ts`
-- Dedicated validation: 6 test files, 197 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+Recommended validation for current changes:
 
-## Stage 11 (complete)
-- Implementation modules: `src/types/ethics.ts`, `src/types/character.ts`, `src/types/curiosity.ts`, `src/character-config.ts`, `src/curiosity-engine.ts`
-- Dedicated validation: 3 test files, 155 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
+```bash
+npm run build
+npm test
+```
 
-## Stage 12 (complete)
-- Implementation modules: `src/types/embedding.ts`, `src/embedding-client.ts`, `src/vector-index.ts`, `src/knowledge-graph.ts`, `src/goal-dependency-graph.ts`, plus Stage 12-related type support in `src/types/dependency.ts`, `src/types/satisficing.ts`, `src/types/learning.ts`, `src/types/cross-portfolio.ts`, `src/types/goal-tree.ts`
-- Dedicated validation: 7 test files, 204 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
-
-## Stage 13 (complete)
-- Implementation modules: `src/capability-detector.ts`, `src/types/capability.ts`, `src/data-source-adapter.ts`, `src/types/data-source.ts`, `src/adapters/file-existence-datasource.ts`, `src/adapters/github-issue.ts`, and `src/adapters/github-issue-datasource.ts`
-- Stage integration points: `src/task-lifecycle.ts`, `src/observation-engine.ts`, `src/core-loop.ts`, `src/cli-runner.ts`, and `src/index.ts`; design reference remains in `docs/design/data-source.md`
-- Dedicated validation: 10 test files, 276 explicit `it()` / `test()` blocks
-- Dedicated tests: `tests/capability-detector.test.ts`, `tests/data-source-adapter.test.ts`, `tests/file-existence-datasource.test.ts`, `tests/github-issue-adapter.test.ts`, `tests/github-issue-datasource.test.ts`, `tests/data-source-hotplug.test.ts`, `tests/cli-runner-datasource-auto.test.ts`, `tests/cli-capability.test.ts`, `tests/core-loop-capability.test.ts`, `tests/observation-engine.test.ts`
-- Status: complete; all planned Stage 13 components are implemented, including the capability-detection flow, data-source registry/adapter integration, CLI auto-wiring, and observation-engine hooks, and they are covered by the dedicated tests listed here
-
-## Stage 14 (complete)
-- Implementation modules: `src/goal-tree-manager.ts`, `src/state-aggregator.ts`, `src/tree-loop-orchestrator.ts`, `src/cross-goal-portfolio.ts`, `src/strategy-template-registry.ts`, `src/learning-pipeline.ts`, `src/knowledge-transfer.ts`, plus Stage 14-adjacent provider/integration modules in `src/adapters/openai-codex.ts`, `src/codex-llm-client.ts`, `src/openai-client.ts`, `src/ollama-client.ts`, `src/provider-config.ts`, `src/provider-factory.ts`, `src/context-providers/workspace-context.ts`
-- Dedicated validation: 24 test files, 824 explicit `it()` / `test()` blocks
-- Status: implementation present and stage-specific tests passed in the latest suite run
-
-## Milestone 1: Observation Enhancement (LLM-powered observation, complete)
-- Implementation modules: `src/observation-engine.ts`, `src/context-providers/workspace-context.ts`, `src/adapters/file-existence-datasource.ts`
-- Dedicated validation: 3 test files, 35 explicit `it()` / `test()` blocks
-- Status: fully implemented; Milestone 1 remains complete and milestone-specific tests passed in the latest suite run
-
-## Milestone 2: Mid-scale Dogfooding Validation
-- Implementation modules: `src/observation-engine.ts`, `src/core-loop.ts`, `src/reporting-engine.ts`, `src/cli-runner.ts`, `src/adapters/file-existence-datasource.ts`
-- Dedicated validation: 3 test files, 13 explicit `it()` / `test()` blocks
-- Dedicated tests: `tests/e2e/milestone2-d1-readme.test.ts`, `tests/e2e/milestone2-d2-e2e-loop.test.ts`, `tests/e2e/milestone2-d3-npm-publish.test.ts`
-- Status: implementation present and milestone-specific tests passed in the latest suite run
-
-## Milestone 3: npm publish & Packaging
-- Implementation modules: `src/cli-runner.ts`, `src/index.ts`, published package surface in `package.json`
-- Dedicated validation: 3 test files, 79 explicit `it()` / `test()` blocks
-- Primary validation sources: package-facing CLI tests plus `tests/e2e/milestone2-d3-npm-publish.test.ts`
-- Status: implementation present and milestone-specific tests passed in the latest suite run
-
-## Milestone 4: Persistent Runtime Phase 2
-- Implementation modules: `src/daemon-runner.ts`, `src/pid-manager.ts`, `src/logger.ts`, `src/event-server.ts`, `src/notification-dispatcher.ts`, `src/memory-lifecycle.ts`, `src/drive-system.ts`
-- Dedicated validation: 7 test files, 206 explicit `it()` / `test()` blocks
-- Status: implementation present and milestone-specific tests passed in the latest suite run
-
-## Milestone 5: Semantic Embedding Phase 2
-- Implementation modules: `src/embedding-client.ts`, `src/vector-index.ts`, `src/knowledge-graph.ts`, `src/knowledge-manager.ts`, `src/goal-dependency-graph.ts`, `src/session-manager.ts`, `src/memory-lifecycle.ts`, `src/curiosity-engine.ts`
-- Dedicated validation: 8 test files, 211 explicit `it()` / `test()` blocks
-- Status: implementation present and milestone-specific tests passed in the latest suite run
-
-## Milestone 6: Autonomous Capability Acquisition Phase 2
-- Implementation modules: `src/capability-detector.ts`, `src/data-source-adapter.ts`, `src/adapters/file-existence-datasource.ts`, `src/adapters/github-issue.ts`, `src/adapters/github-issue-datasource.ts`, `src/core-loop.ts`, `src/cli-runner.ts`
-- Dedicated validation: 10 test files, 235 explicit `it()` / `test()` blocks
-- Status: implementation present and milestone-specific tests passed in the latest suite run
-
-## Milestone 7: Recursive Goal Tree & Cross-goal Portfolio Phase 2
-- Implementation modules: `src/goal-tree-manager.ts`, `src/state-aggregator.ts`, `src/tree-loop-orchestrator.ts`, `src/cross-goal-portfolio.ts`, `src/strategy-template-registry.ts`, `src/learning-pipeline.ts`, `src/knowledge-transfer.ts`
-- Dedicated validation: 14 test files, 671 explicit `it()` / `test()` blocks
-- Dedicated E2E validation: `tests/e2e/milestone7-goal-tree.test.ts`
-- Status: implementation present and milestone-specific tests passed in the latest suite run
-
-## Phase 3: Development Infrastructure (complete)
-
-Phase 3 is not about adding new features — it focuses on improving codebase quality and maintainability across three pillars. See `docs/design/phase3-plan.md`.
-
-### Pillar 1: Large File Splitting (complete)
-- Phase 2: Split 4 files into 18 files (`cross-goal-portfolio.ts`, `capability-detector.ts`, `memory-lifecycle.ts`, `learning-pipeline.ts` — each decomposed into responsibility-specific submodules)
-- Unified entry points (original filenames) now handle orchestration only, delegating implementation to submodules
-- Module boundary map (`docs/module-map.md`) updated to cover all modules
-
-### Pillar 2: Subdirectory Organization (complete)
-- Reorganized 48 files directly under `src/` into 9 subfolders (`src/goal/`, `src/drive/`, `src/execution/`, `src/observation/`, `src/llm/`, `src/strategy/`, `src/knowledge/`, `src/traits/`, `src/runtime/`)
-- Bulk-updated all existing tests and import paths
-
-### Pillar 3: Test Efficiency (complete)
-- Established shared mock factories and test helpers
-- Removed test duplication and improved coverage
-
----
-
-## Milestone 8: Safety Hardening + npm Publish (complete)
-- EthicsGate Layer 1 (blocking `destructive_action` and `credential_access` categories)
-- TaskLifecycle L1 mechanical verification implemented
-- CLI flags validation, `package.json` cleanup
-- Status: complete
-
-## Milestone 9: Observation Accuracy Enhancement (complete)
-- `src/adapters/shell-datasource.ts` — ShellDataSourceAdapter (uses `execFile`, secure)
-- `src/observation/observation-engine.ts` extended — `normalizeDimensionName()`, `crossValidate()`, `ObservationEngineOptions`
-- LLM prompts converted to English + 3-example few-shot calibration
-- Status: complete
-
-## Milestone 10: Automatic Goal Generation (complete)
-- `src/goal/goal-negotiator.ts` extended — `suggestGoals()`, `filterSuggestions()`
-- `src/cli-runner.ts` extended — `pulseed suggest`, `pulseed improve [path]` commands
-- Status: complete
-
-## Milestone 11: Autonomous Strategy Selection + Execution Quality (complete)
-- `src/observation/context-provider.ts` new — `buildWorkspaceContext()`
-- `src/execution/task-health-check.ts` extended — `runPostExecutionHealthCheck()`
-- `src/knowledge/memory-lifecycle.ts` extended — DriveScoreAdapter fully wired
-- `src/drive/satisficing-judge.ts` extended — condition 3 `resource_undershoot` implemented
-- Status: complete
-
-## Milestone 12: Plugin Architecture (complete)
-
-**Theme**: Keep the core thin while separating extensions as plugins. Service-specific dependencies (e.g., Slack) are provided as plugins rather than bundled into the core.
-
-### Implementation Modules
-- `src/types/plugin.ts` — plugin manifest, INotifier interface, NotificationEvent type definitions (Zod schemas)
-- `src/runtime/plugin-loader.ts` — dynamic plugin loading from `~/.pulseed/plugins/`, manifest validation, auto-registration into AdapterRegistry/DataSourceRegistry/NotifierRegistry
-- `src/runtime/notifier-registry.ts` — CRUD management of INotifier plugins with eventType-based routing
-- `src/runtime/notification-dispatcher.ts` extended — routing integration with NotifierRegistry
-- `src/runtime/daemon-runner.ts` extended — graceful SIGTERM/SIGINT shutdown, crash recovery, log rotation
-- `src/runtime/event-server.ts` extended — real-time file watcher for `~/.pulseed/events/` (fs.watch)
-- `plugins/slack-notifier/` — sample plugin (Slack Webhook implementation, `plugin.yaml` + `src/index.ts`)
-
-### Test Validation
-- Dedicated validation: 4 test files, 74 explicit `it()` / `test()` blocks
-- Dedicated tests: `tests/plugin-loader.test.ts`, `tests/notifier-registry.test.ts`, `tests/plugin-slack-notifier.test.ts`, `tests/notification-dispatcher-plugin.test.ts`
-- Status: complete; all planned M12 components implemented and tests passing
-
----
-
-## Milestone 13: Autonomous Plugin Selection + Semantic Knowledge Sharing (complete)
-- Status: complete (see roadmap.md for detail)
-
-## Milestone 14: Hypothesis Verification Mechanism (PIVOT/REFINE + Learning Loop) (complete)
-- Status: complete (see roadmap.md for detail)
-
-## Milestone 15: Multi-agent Delegation (complete)
-- Status: complete (see roadmap.md for detail)
-
-## Milestone 16: Advanced Long-term Memory & Knowledge Sharing (complete)
-
-**Theme**: Bring cross-goal knowledge transfer to a production-ready level
-
-### Implementation Modules
-- `src/types/cross-portfolio.ts` — TransferCandidate/DecisionRecord schema extensions
-- `src/types/knowledge.ts` — DecisionRecord `what_worked`/`what_failed`/`suggested_next`
-- `src/types/checkpoint.ts` — CheckpointSchema (new)
-- `src/knowledge/transfer-trust.ts` — transfer trust score learning (new)
-- `src/knowledge/knowledge-transfer.ts` — Phase 2 auto-apply + incremental meta-patterns
-- `src/knowledge/knowledge-search.ts` — `searchMetadata` added
-- `src/knowledge/vector-index.ts` — `searchMetadata` added
-- `src/knowledge/learning-pipeline.ts` — KnowledgeTransfer trigger integration
-- `src/execution/context-budget.ts` — dynamic budget allocation (new)
-- `src/execution/checkpoint-manager.ts` — checkpoint management (new)
-- `src/execution/session-manager.ts` — checkpoint delegation + budget integration
-- `src/execution/task-lifecycle.ts` — automatic checkpoint saving + real-time transfer
-- `src/reporting-engine.ts` — transfer impact reporting
-- `src/state-manager.ts` — `checkpoints/` directory added
-
-### Test Validation
-- New tests: tests/transfer-trust.test.ts, tests/knowledge-transfer-auto-apply.test.ts, tests/context-budget.test.ts, tests/checkpoint-manager.test.ts, tests/knowledge-transfer-incremental.test.ts, tests/m16-integration.test.ts
-- Status: complete; all M16 components implemented and tests passing
-
----
-
-## Milestone 17: External Integration Plugin Expansion (complete)
-
-**Theme**: Reference implementations for data source and notification plugins, plus a developer guide
-
-### Implementation Modules
-- `examples/plugins/jira-datasource/` — Jira REST API IDataSourceAdapter (fetch only, no external dependencies)
-- `examples/plugins/pagerduty-notifier/` — PagerDuty Events API v2 INotifier (fetch only, no external dependencies)
-- `docs/design/plugin-development-guide.md` — plugin development guide (data_source/notifier types, all plugin.yaml fields, testing approach, npm publish steps, existing plugin catalog)
-
-### Test Validation
-- `tests/jira-datasource-plugin.test.ts` — 19 tests (connect/query/healthCheck/disconnect)
-- `tests/pagerduty-notifier-plugin.test.ts` — 24 tests (INotifier compliance, supports, notify request content)
-- Status: complete; all 43 tests passing
-
----
-
-## Notes
-- Counts above are based on the current checked-in `src/` and `tests/` directories.
-- Source inventory includes both `.ts` and `.tsx` files under `src/`.
-- The latest `vitest run` executes 3504 tests (excluding e2e suite); the runner count is authoritative for the top-level inventory.
-- "Dedicated validation" counts are based on explicit `it()` / `test()` blocks in the test files mapped to each stage or milestone; they are not additive across the whole document because some areas intentionally overlap.
+CI remains the authoritative integration check for pull requests.


### PR DESCRIPTION
## Summary
- add a current implementation baseline doc for the dual-loop runtime
- refresh public docs to match current CLI paths and runtime behavior
- replace the stale status doc with a current snapshot and point detailed history to archive

## Why
The top-level docs and design docs had drifted from the current `CoreLoop + AgentLoop` runtime and current source layout. That made implementation work harder than it needed to be and left several public entrypoints pointing at old paths.

## Impact
- engineers now have a single implementation-facing baseline in `docs/design/current-baseline.md`
- public docs point to current CLI and TUI entrypoints
- `docs/status.md` now describes the current runtime instead of an old milestone ledger

## Validation
- `npm run build`
- `npm test` (full suite passed on rerun; one initial run hit flaky `watchdog` timeouts, then passed cleanly)
