### PR TITLE
[codex] refactor adapters github issue datasource

### DIFF
--- a/src/adapters/__tests__/github-issue-datasource.test.ts
+++ b/src/adapters/__tests__/github-issue-datasource.test.ts
@@ -91,6 +91,9 @@ describe("GitHubIssueDataSourceAdapter.query", () => {
 
     expect(result.value).toBe(3);
     expect(typeof result.timestamp).toBe("string");
+    expect(result.raw).toHaveLength(3);
+    expect(result.source_id).toBe("github-issues");
+    expect(result.error).toBeUndefined();
   });
 
   it("closed_issue_count returns the count of closed issues", async () => {
@@ -117,6 +120,12 @@ describe("GitHubIssueDataSourceAdapter.query", () => {
 
     // 3 / (2 + 3) = 0.6
     expect(result.value).toBeCloseTo(0.6, 5);
+    expect(result.metadata).toEqual({
+      open_count: 2,
+      closed_count: 3,
+      total_count: 5,
+      completion_ratio: 0.6,
+    });
   });
 
   it("total_issue_count returns open + closed", async () => {
@@ -157,6 +166,8 @@ describe("GitHubIssueDataSourceAdapter.query", () => {
 
     expect(result.value).toBeNull();
     expect(result.error).toContain("gh: authentication required");
+    expect(result.raw).toEqual([]);
+    expect(result.source_id).toBe("github-issues");
   });
 });
 
@@ -273,6 +284,24 @@ describe("GitHubIssueDataSourceAdapter.healthCheck edge cases", () => {
     expect(child.kill).toHaveBeenCalledWith("SIGTERM");
     expect(result).toBe(false);
   });
+
+  it("ignores duplicate healthCheck process events after resolving", async () => {
+    const adapter = new GitHubIssueDataSourceAdapter(makeConfig());
+    const child = makeFakeChild();
+
+    const healthPromise = adapter.healthCheck();
+    child.emit("error", new Error("spawn gh ENOENT"));
+    child.emit("close", 0);
+    const result = await healthPromise;
+
+    expect(result).toBe(false);
+
+    const nextChild = makeFakeChild();
+    const nextHealthPromise = adapter.healthCheck();
+    nextChild.emit("close", 0);
+    nextChild.emit("error", new Error("late error"));
+    await expect(nextHealthPromise).resolves.toBe(true);
+  });
 });
 
 // ─── query edge cases ───
@@ -310,6 +339,39 @@ describe("GitHubIssueDataSourceAdapter.query edge cases", () => {
     expect(result.value).toBe(0);
   });
 
+  it("treats null stdout as an empty issue list", async () => {
+    const child = makeFakeChild();
+    const queryPromise = adapter.query(makeQuery({ dimension_name: "open_issue_count" }));
+    child.stdout.emit("data", Buffer.from("null"));
+    child.emit("close", 0);
+    const result = await queryPromise;
+
+    expect(result.value).toBe(0);
+    expect(result.raw).toEqual([]);
+  });
+
+  it("treats non-array JSON stdout as an empty issue list", async () => {
+    const child = makeFakeChild();
+    const queryPromise = adapter.query(makeQuery({ dimension_name: "open_issue_count" }));
+    child.stdout.emit("data", Buffer.from(JSON.stringify({ total_count: 3 })));
+    child.emit("close", 0);
+    const result = await queryPromise;
+
+    expect(result.value).toBe(0);
+    expect(result.raw).toEqual([]);
+  });
+
+  it("uses the exit-code fallback when gh exits non-zero without stderr", async () => {
+    const child = makeFakeChild();
+    const queryPromise = adapter.query(makeQuery({ dimension_name: "open_issue_count" }));
+    child.emit("close", 2);
+    const result = await queryPromise;
+
+    expect(result.value).toBeNull();
+    expect(result.error).toBe("gh issue list exited with code 2");
+    expect(result.raw).toEqual([]);
+  });
+
   it("completion_ratio is 0 when there are no issues at all", async () => {
     const openChild = makeFakeChild();
     const closedChild = makeFakeChild();
@@ -320,6 +382,31 @@ describe("GitHubIssueDataSourceAdapter.query edge cases", () => {
     const result = await queryPromise;
 
     expect(result.value).toBe(0);
+  });
+
+  it("returns the open-query error when aggregate metrics cannot load open issues", async () => {
+    const openChild = makeFakeChild();
+    const queryPromise = adapter.query(makeQuery({ dimension_name: "completion_ratio" }));
+    rejectChild(openChild, "open query failed", 1);
+    const result = await queryPromise;
+
+    expect(result.value).toBeNull();
+    expect(result.error).toBe("open query failed");
+    expect(result.raw).toEqual([]);
+  });
+
+  it("returns the closed-query error when aggregate metrics cannot load closed issues", async () => {
+    const openChild = makeFakeChild();
+    const closedChild = makeFakeChild();
+
+    const queryPromise = adapter.query(makeQuery({ dimension_name: "completion_ratio" }));
+    resolveChild(openChild, [{ number: 1 }]);
+    rejectChild(closedChild, "closed query failed", 1);
+    const result = await queryPromise;
+
+    expect(result.value).toBeNull();
+    expect(result.error).toBe("closed query failed");
+    expect(result.raw).toEqual([]);
   });
 
   it("uses custom _label from dimension_mapping", async () => {
@@ -360,6 +447,22 @@ describe("GitHubIssueDataSourceAdapter.query edge cases", () => {
     const listCall = spawnCalls[0];
     const args: string[] = listCall[1] as string[];
     expect(args.join(" ")).toContain("fallback-org/fallback-repo");
+  });
+
+  it("omits --repo when neither connection.repo nor connection.url is configured", async () => {
+    const config = makeConfig({
+      connection: {},
+    });
+    const noRepoAdapter = new GitHubIssueDataSourceAdapter(config);
+    const child = makeFakeChild();
+
+    const queryPromise = noRepoAdapter.query(makeQuery({ dimension_name: "open_issue_count" }));
+    resolveChild(child, [{ number: 1 }]);
+    await queryPromise;
+
+    const listCall = mockSpawn.mock.calls[0];
+    const args: string[] = listCall[1] as string[];
+    expect(args).not.toContain("--repo");
   });
 
   it("dimension_mapping redirect resolves a mapped dimension name", async () => {

--- a/src/adapters/datasources/github-issue-datasource.ts
+++ b/src/adapters/datasources/github-issue-datasource.ts
@@ -37,6 +37,10 @@ interface GhIssue {
   createdAt?: string;
 }
 
+type QueryPlan =
+  | { kind: "single"; state: "open" | "closed" }
+  | { kind: "aggregate"; dimension: "total_issue_count" | "completion_ratio" };
+
 // ─── Adapter ───
 
 export class GitHubIssueDataSourceAdapter implements IDataSourceAdapter {
@@ -63,119 +67,29 @@ export class GitHubIssueDataSourceAdapter implements IDataSourceAdapter {
   }
 
   query(params: DataSourceQuery): Promise<GhDataSourceResult> {
-    const config = this.config;
-    const repo = this.resolveRepo(config);
-    const label = this.resolveLabel(config);
-    const timeoutMs = params.timeout_ms ?? 10_000;
-    const sourceId = this.sourceId;
+    const { repo, label, timeoutMs, resolvedDimension, sourceId } = this.resolveQueryContext(params);
 
-    // Check dimension_mapping for redirect
-    const dimMapping: Record<string, string> = config.dimension_mapping ?? {};
-    const dimension = params.expression ?? params.dimension_name;
-    const resolvedDimension = dimMapping[dimension] ?? dimension;
-
-    // Unknown dimension — return immediately without spawning
-    const knownDimensions = new Set([
-      "open_issue_count",
-      "closed_issue_count",
-      "total_issue_count",
-      "completion_ratio",
-    ]);
-
-    if (!knownDimensions.has(resolvedDimension)) {
-      return Promise.resolve({
-        value: null,
-        raw: [],
-        timestamp: new Date().toISOString(),
-        source_id: sourceId,
-      });
+    const queryPlan = this.resolveQueryPlan(resolvedDimension);
+    if (queryPlan === null) {
+      return Promise.resolve(this.buildUnknownDimensionResult(sourceId));
     }
 
-    // ── Dimensions that require only open issues ──────────────────────────
-    if (resolvedDimension === "open_issue_count") {
-      return this.queryOneState("open", repo, label, timeoutMs, (openIssues, err) => {
-        if (err !== null) {
-          return {
-            value: null,
-            raw: [],
-            timestamp: new Date().toISOString(),
-            source_id: sourceId,
-            error: err,
-          };
-        }
-        return {
-          value: openIssues.length,
-          raw: openIssues,
-          timestamp: new Date().toISOString(),
-          source_id: sourceId,
-        };
-      });
+    if (queryPlan.kind === "single") {
+      return this.queryOneState(
+        queryPlan.state,
+        repo,
+        label,
+        timeoutMs,
+        this.createSingleStateResultBuilder(sourceId)
+      );
     }
 
-    if (resolvedDimension === "closed_issue_count") {
-      return this.queryOneState("closed", repo, label, timeoutMs, (closedIssues, err) => {
-        if (err !== null) {
-          return {
-            value: null,
-            raw: [],
-            timestamp: new Date().toISOString(),
-            source_id: sourceId,
-            error: err,
-          };
-        }
-        return {
-          value: closedIssues.length,
-          raw: closedIssues,
-          timestamp: new Date().toISOString(),
-          source_id: sourceId,
-        };
-      });
-    }
-
-    // ── Dimensions that require both open and closed issues ───────────────
-    // (completion_ratio, total_issue_count)
-    return this.queryBothStates(repo, label, timeoutMs, (openIssues, closedIssues, err) => {
-      if (err !== null) {
-        return {
-          value: null,
-          raw: [],
-          timestamp: new Date().toISOString(),
-          source_id: sourceId,
-          error: err,
-        };
-      }
-
-      const openCount = openIssues.length;
-      const closedCount = closedIssues.length;
-      const totalCount = openCount + closedCount;
-      const completionRatio = totalCount === 0 ? 0 : closedCount / totalCount;
-      const allIssues = [...openIssues, ...closedIssues];
-
-      let value: number;
-      switch (resolvedDimension) {
-        case "total_issue_count":
-          value = totalCount;
-          break;
-        case "completion_ratio":
-          value = completionRatio;
-          break;
-        default:
-          value = 0;
-      }
-
-      return {
-        value,
-        raw: allIssues,
-        timestamp: new Date().toISOString(),
-        source_id: sourceId,
-        metadata: {
-          open_count: openCount,
-          closed_count: closedCount,
-          total_count: totalCount,
-          completion_ratio: completionRatio,
-        },
-      };
-    });
+    return this.queryBothStates(
+      repo,
+      label,
+      timeoutMs,
+      this.createAggregateResultBuilder(sourceId, queryPlan.dimension)
+    );
   }
 
   getSupportedDimensions(): string[] {
@@ -238,6 +152,45 @@ export class GitHubIssueDataSourceAdapter implements IDataSourceAdapter {
     return mapping["_label"] ?? "pulseed";
   }
 
+  private resolveQueryContext(params: DataSourceQuery): {
+    repo: string | undefined;
+    label: string | undefined;
+    timeoutMs: number;
+    resolvedDimension: string;
+    sourceId: string;
+  } {
+    const config = this.config;
+    const repo = this.resolveRepo(config);
+    const label = this.resolveLabel(config);
+    const timeoutMs = params.timeout_ms ?? 10_000;
+    const sourceId = this.sourceId;
+    const dimMapping: Record<string, string> = config.dimension_mapping ?? {};
+    const dimension = params.expression ?? params.dimension_name;
+    const resolvedDimension = dimMapping[dimension] ?? dimension;
+
+    return {
+      repo,
+      label,
+      timeoutMs,
+      resolvedDimension,
+      sourceId,
+    };
+  }
+
+  private resolveQueryPlan(resolvedDimension: string): QueryPlan | null {
+    switch (resolvedDimension) {
+      case "open_issue_count":
+        return { kind: "single", state: "open" };
+      case "closed_issue_count":
+        return { kind: "single", state: "closed" };
+      case "total_issue_count":
+      case "completion_ratio":
+        return { kind: "aggregate", dimension: resolvedDimension };
+      default:
+        return null;
+    }
+  }
+
   /**
    * Spawn `gh issue list` for a single state and call back with results.
    * Uses a callback so the result can be returned synchronously inside
@@ -251,42 +204,8 @@ export class GitHubIssueDataSourceAdapter implements IDataSourceAdapter {
     cb: (issues: GhIssue[], err: string | null) => GhDataSourceResult
   ): Promise<GhDataSourceResult> {
     return new Promise<GhDataSourceResult>((resolve) => {
-      let stdout = "";
-      let stderr = "";
-      let timedOut = false;
-
-      const args = this.buildListArgs(state, repo, label);
-      const child = spawn(this.ghPath, args, { stdio: ["ignore", "pipe", "pipe"] });
-
-      const timeoutHandle = setTimeout(() => {
-        timedOut = true;
-        child.kill("SIGTERM");
-      }, timeoutMs);
-
-      child.stdout.on("data", (chunk: Buffer) => {
-        stdout += chunk.toString("utf8");
-      });
-
-      child.stderr.on("data", (chunk: Buffer) => {
-        stderr += chunk.toString("utf8");
-      });
-
-      child.on("error", (err: Error) => {
-        clearTimeout(timeoutHandle);
-        resolve(cb([], err.message));
-      });
-
-      child.on("close", (code: number | null) => {
-        clearTimeout(timeoutHandle);
-        if (timedOut) {
-          resolve(cb([], `gh issue list timed out after ${timeoutMs}ms`));
-          return;
-        }
-        if (code !== 0) {
-          resolve(cb([], stderr.trim() || `gh issue list exited with code ${code}`));
-          return;
-        }
-        resolve(cb(this.parseIssueList(stdout), null));
+      this.spawnList(state, repo, label, timeoutMs, (issues, err) => {
+        resolve(cb(issues, err));
       });
     });
   }
@@ -337,12 +256,10 @@ export class GitHubIssueDataSourceAdapter implements IDataSourceAdapter {
     timeoutMs: number,
     cb: (issues: GhIssue[], err: string | null) => void
   ): void {
+    const child = this.createListProcess(state, repo, label);
     let stdout = "";
     let stderr = "";
     let timedOut = false;
-
-    const args = this.buildListArgs(state, repo, label);
-    const child = spawn(this.ghPath, args, { stdio: ["ignore", "pipe", "pipe"] });
 
     const timeoutHandle = setTimeout(() => {
       timedOut = true;
@@ -374,6 +291,130 @@ export class GitHubIssueDataSourceAdapter implements IDataSourceAdapter {
       }
       cb(this.parseIssueList(stdout), null);
     });
+  }
+
+  private createListProcess(
+    state: "open" | "closed",
+    repo: string | undefined,
+    label: string | undefined
+  ) {
+    const args = this.buildListArgs(state, repo, label);
+    return spawn(this.ghPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+  }
+
+  private buildCountResult(sourceId: string, issues: GhIssue[]): GhDataSourceResult {
+    return this.buildMetricResult(sourceId, issues.length, issues);
+  }
+
+  private createSingleStateResultBuilder(
+    sourceId: string
+  ): (issues: GhIssue[], err: string | null) => GhDataSourceResult {
+    return (issues, err) => this.buildSingleStateResult(sourceId, issues, err);
+  }
+
+  private createAggregateResultBuilder(
+    sourceId: string,
+    dimension: "total_issue_count" | "completion_ratio"
+  ): (openIssues: GhIssue[], closedIssues: GhIssue[], err: string | null) => GhDataSourceResult {
+    return (openIssues, closedIssues, err) =>
+      this.buildAggregateResult(sourceId, dimension, openIssues, closedIssues, err);
+  }
+
+  private buildSingleStateResult(
+    sourceId: string,
+    issues: GhIssue[],
+    err: string | null
+  ): GhDataSourceResult {
+    return err !== null ? this.buildErrorResult(sourceId, err) : this.buildCountResult(sourceId, issues);
+  }
+
+  private buildAggregateResult(
+    sourceId: string,
+    dimension: "total_issue_count" | "completion_ratio",
+    openIssues: GhIssue[],
+    closedIssues: GhIssue[],
+    err: string | null
+  ): GhDataSourceResult {
+    if (err !== null) {
+      return this.buildErrorResult(sourceId, err);
+    }
+
+    const aggregate = this.buildAggregateMetrics(openIssues, closedIssues);
+    const value = dimension === "total_issue_count" ? aggregate.totalCount : aggregate.completionRatio;
+
+    return {
+      ...this.buildMetricResult(sourceId, value, aggregate.allIssues),
+      metadata: this.buildCompletionMetadata(
+        aggregate.openCount,
+        aggregate.closedCount,
+        aggregate.totalCount,
+        aggregate.completionRatio
+      ),
+    };
+  }
+
+  private buildErrorResult(sourceId: string, error: string): GhDataSourceResult {
+    return {
+      value: null,
+      raw: [],
+      timestamp: new Date().toISOString(),
+      source_id: sourceId,
+      error,
+    };
+  }
+
+  private buildMetricResult(sourceId: string, value: number, raw: GhIssue[]): GhDataSourceResult {
+    return {
+      value,
+      raw,
+      timestamp: new Date().toISOString(),
+      source_id: sourceId,
+    };
+  }
+
+  private buildUnknownDimensionResult(sourceId: string): GhDataSourceResult {
+    return {
+      value: null,
+      raw: [],
+      timestamp: new Date().toISOString(),
+      source_id: sourceId,
+    };
+  }
+
+  private buildCompletionMetadata(
+    openCount: number,
+    closedCount: number,
+    totalCount: number,
+    completionRatio: number
+  ): NonNullable<GhDataSourceResult["metadata"]> {
+    return {
+      open_count: openCount,
+      closed_count: closedCount,
+      total_count: totalCount,
+      completion_ratio: completionRatio,
+    };
+  }
+
+  private buildAggregateMetrics(openIssues: GhIssue[], closedIssues: GhIssue[]): {
+    openCount: number;
+    closedCount: number;
+    totalCount: number;
+    completionRatio: number;
+    allIssues: GhIssue[];
+  } {
+    const openCount = openIssues.length;
+    const closedCount = closedIssues.length;
+    const totalCount = openCount + closedCount;
+    const completionRatio = totalCount === 0 ? 0 : closedCount / totalCount;
+    const allIssues = [...openIssues, ...closedIssues];
+
+    return {
+      openCount,
+      closedCount,
+      totalCount,
+      completionRatio,
+      allIssues,
+    };
   }
 
   private buildListArgs(


### PR DESCRIPTION
## Summary
- Refactor GitHubIssueDataSourceAdapter query dispatch into small helpers for context resolution, dimension planning, result building, and aggregate metrics.
- Centralize gh issue list spawning through createListProcess/spawnList while preserving timeout, stderr, exit-code, and parse fallback behavior.
- Expand github-issue-datasource coverage for result shape, aggregate failure paths, parse edge cases, repo fallback, and healthCheck duplicate event guards.

## Validation
- npm test -- src/adapters
- npm run typecheck
- npm run lint:boundaries

## Notes
- No dependency, public API, DB schema, or log contract changes.
- p95 latency and DB query count were not separately benchmarked; this adapter uses gh CLI spawn calls and does not issue DB queries.