### PR TITLE
[codex] add agent workflow tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "test": "vitest run --exclude tests/e2e",
     "test:all": "vitest run",
     "test:e2e": "vitest run tests/e2e",
+    "test:dogfood": "vitest run src/orchestrator/execution/agent-loop/__tests__/agent-loop-dogfood-benchmark.test.ts",
+    "dogfood:agentloop:real": "npm run build && node dist/orchestrator/execution/agent-loop/agent-loop-real-dogfood.js",
     "test:changed": "vitest run --changed",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/src/adapters/__tests__/a2a-client.test.ts
+++ b/src/adapters/__tests__/a2a-client.test.ts
@@ -61,7 +61,7 @@ describe("A2AClient", () => {
     client = new A2AClient({
       baseUrl: "https://agent.example.com",
       pollIntervalMs: 10,
-      maxWaitMs: 100,
+      maxWaitMs: 1_000,
     });
   });
 
@@ -201,9 +201,14 @@ describe("A2AClient", () => {
       mockFetch.mockImplementation(() =>
         Promise.resolve(jsonRpcOk(a2aTask("working")))
       );
+      const shortClient = new A2AClient({
+        baseUrl: "https://agent.example.com",
+        pollIntervalMs: 10,
+        maxWaitMs: 100,
+      });
 
       await expect(
-        client.waitForCompletion("task-1")
+        shortClient.waitForCompletion("task-1")
       ).rejects.toThrow(/did not complete within 100ms/);
     });
 
@@ -211,9 +216,14 @@ describe("A2AClient", () => {
       mockFetch.mockImplementation(() =>
         Promise.resolve(jsonRpcOk(a2aTask("working")))
       );
+      const shortClient = new A2AClient({
+        baseUrl: "https://agent.example.com",
+        pollIntervalMs: 10,
+        maxWaitMs: 100,
+      });
 
       try {
-        await client.waitForCompletion("task-1");
+        await shortClient.waitForCompletion("task-1");
       } catch {
         // expected
       }

--- a/src/base/state/__tests__/state-manager.test.ts
+++ b/src/base/state/__tests__/state-manager.test.ts
@@ -256,16 +256,20 @@ describe("StateManager", async () => {
         notes: null,
       };
 
-      // Append 510 entries
-      for (let i = 0; i < 510; i++) {
-        await manager.appendObservation("cap-obs", { ...baseEntry, observation_id: `obs-${i}` });
-      }
+      await manager.saveObservationLog({
+        goal_id: "cap-obs",
+        entries: Array.from({ length: 510 }, (_, i) => ({
+          ...baseEntry,
+          observation_id: `obs-${i}`,
+        })),
+      });
+      await manager.appendObservation("cap-obs", { ...baseEntry, observation_id: "obs-510" });
 
       const loaded = await manager.loadObservationLog("cap-obs");
       expect(loaded!.entries).toHaveLength(500);
-      // Should keep the last 500 (obs-10 through obs-509)
-      expect(loaded!.entries[0].observation_id).toBe("obs-10");
-      expect(loaded!.entries[499].observation_id).toBe("obs-509");
+      // Should keep the last 500 (obs-11 through obs-510)
+      expect(loaded!.entries[0].observation_id).toBe("obs-11");
+      expect(loaded!.entries[499].observation_id).toBe("obs-510");
     }, 30_000);
 
     it("appendGapHistoryEntry caps entries at 500", async () => {
@@ -278,16 +282,17 @@ describe("StateManager", async () => {
         confidence_vector: [{ dimension_name: "d", confidence: 0.9 }],
       };
 
-      // Append 510 entries
-      for (let i = 0; i < 510; i++) {
-        await manager.appendGapHistoryEntry("cap-gap", { ...baseEntry, iteration: i });
-      }
+      await manager.saveGapHistory(
+        "cap-gap",
+        Array.from({ length: 510 }, (_, i) => ({ ...baseEntry, iteration: i })),
+      );
+      await manager.appendGapHistoryEntry("cap-gap", { ...baseEntry, iteration: 510 });
 
       const loaded = await manager.loadGapHistory("cap-gap");
       expect(loaded).toHaveLength(500);
-      // Should keep the last 500 (iteration 10 through 509)
-      expect(loaded[0].iteration).toBe(10);
-      expect(loaded[499].iteration).toBe(509);
+      // Should keep the last 500 (iteration 11 through 510)
+      expect(loaded[0].iteration).toBe(11);
+      expect(loaded[499].iteration).toBe(510);
     }, 30_000);
   });
 
@@ -1080,21 +1085,26 @@ describe("StateManager", async () => {
         notes: null,
       };
 
-      // Append 510 entries
-      for (let i = 0; i < 510; i++) {
-        await manager.appendObservation("cap-test", {
+      await manager.saveObservationLog({
+        goal_id: "cap-test",
+        entries: Array.from({ length: 510 }, (_, i) => ({
           ...baseEntry,
           observation_id: `obs-${i}`,
           extracted_value: i,
-        });
-      }
+        })),
+      });
+      await manager.appendObservation("cap-test", {
+        ...baseEntry,
+        observation_id: "obs-510",
+        extracted_value: 510,
+      });
 
       const loaded = await manager.loadObservationLog("cap-test");
       expect(loaded).not.toBeNull();
       expect(loaded!.entries.length).toBe(500);
-      // Should have the last 500 entries (obs-10 through obs-509)
-      expect(loaded!.entries[0].observation_id).toBe("obs-10");
-      expect(loaded!.entries[499].observation_id).toBe("obs-509");
+      // Should have the last 500 entries (obs-11 through obs-510)
+      expect(loaded!.entries[0].observation_id).toBe("obs-11");
+      expect(loaded!.entries[499].observation_id).toBe("obs-510");
     }, 30_000);
 
     it("listGoalIds propagates non-ENOENT errors", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,6 +214,15 @@ export { GitDiffTool } from "./tools/system/GitDiffTool/GitDiffTool.js";
 export { EnvTool } from "./tools/system/EnvTool/EnvTool.js";
 export { SleepTool } from "./tools/system/SleepTool/SleepTool.js";
 export { ProcessStatusTool } from "./tools/system/ProcessStatusTool/ProcessStatusTool.js";
+export {
+  ProcessSessionManager,
+  ProcessSessionStartTool,
+  ProcessSessionReadTool,
+  ProcessSessionWriteTool,
+  ProcessSessionStopTool,
+  ProcessSessionListTool,
+  defaultProcessSessionManager,
+} from "./tools/system/ProcessSessionTool/ProcessSessionTool.js";
 export { TestRunnerTool } from "./tools/system/TestRunnerTool/TestRunnerTool.js";
 export { ListDirTool } from "./tools/fs/ListDirTool/ListDirTool.js";
 export { FileWriteTool } from "./tools/fs/FileWriteTool/FileWriteTool.js";
@@ -226,5 +235,7 @@ export { KnowledgeQueryTool } from "./tools/query/KnowledgeQueryTool/KnowledgeQu
 export { ProgressHistoryTool } from "./tools/query/ProgressHistoryTool/ProgressHistoryTool.js";
 export { WebSearchTool, createWebSearchClient } from "./tools/network/WebSearchTool/WebSearchTool.js";
 export type { ISearchClient, SearchResult } from "./tools/network/WebSearchTool/WebSearchTool.js";
+export { GitHubReadTool, GitHubPrCreateTool } from "./tools/network/GitHubCliTool/GitHubCliTool.js";
+export { McpListToolsTool, McpCallToolTool } from "./tools/network/McpStdioTool/McpStdioTool.js";
 export { ToolSearchTool } from "./tools/query/ToolSearchTool/ToolSearchTool.js";
 export type { BuiltinToolDeps } from "./tools/builtin/index.js";

--- a/src/interface/cli/__tests__/cli-doctor.test.ts
+++ b/src/interface/cli/__tests__/cli-doctor.test.ts
@@ -28,6 +28,7 @@ import {
   checkBuild,
   checkDaemon,
   checkNotifications,
+  checkNativeTaskAgentLoopTools,
   cmdDoctor,
 } from "../commands/doctor.js";
 
@@ -616,6 +617,17 @@ describe("checkNotifications", () => {
   });
 });
 
+describe("checkNativeTaskAgentLoopTools", () => {
+  it("passes when builtin tools cover the native task AgentLoop profile", () => {
+    const result = checkNativeTaskAgentLoopTools();
+
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("required");
+    expect(result.detail).toContain("recommended");
+    expect(result.detail).toContain("profile ready");
+  });
+});
+
 describe("cmdDoctor summary counts", () => {
   let tmpDir: string;
   let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -663,6 +675,7 @@ describe("cmdDoctor summary counts", () => {
 
     const allOutput = consoleSpy.mock.calls.map((c: unknown[]) => c[0] as string).join("\n");
     expect(allOutput).toMatch(/Summary: \d+ passed, \d+ failed, \d+ warnings/);
+    expect(allOutput).toContain("Native AgentLoop tools");
   });
 
   it("returns exit code 0 when all critical checks pass", async () => {

--- a/src/interface/cli/__tests__/cli-runner-integration.test.ts
+++ b/src/interface/cli/__tests__/cli-runner-integration.test.ts
@@ -15,6 +15,8 @@ import * as fs from "node:fs";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 
+vi.setConfig({ testTimeout: 20_000 });
+
 // ─── Module mocks ─────────────────────────────────────────────────────────────
 // Only mock modules that would make real network/process calls.
 
@@ -313,7 +315,7 @@ describe("run subcommand with real CoreLoop (max_iterations=1)", () => {
   });
 
   it("exits with code 1 when ANTHROPIC_API_KEY is missing", async () => {
-    delete process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = "";
     await stateManager.saveGoal(makeGoal({ id: "key-test-goal" }));
 
     const code = await runCLI(tmpDir, "run", "--goal", "key-test-goal");

--- a/src/interface/cli/commands/doctor.ts
+++ b/src/interface/cli/commands/doctor.ts
@@ -20,6 +20,9 @@ import {
 import { runRuntimeStoreMaintenanceCycle, type RuntimeMaintenanceLogger } from "../../../runtime/daemon/maintenance.js";
 import { DaemonStateSchema } from "../../../runtime/types/daemon.js";
 import { summarizeTaskOutcomeLedgers } from "../../../orchestrator/execution/task/task-outcome-ledger.js";
+import { assessTaskAgentLoopToolProfileFromTools, nativeTaskAgentLoopToolProfile } from "../../../orchestrator/execution/agent-loop/agent-loop-dogfood-benchmark.js";
+import { ToolRegistry } from "../../../tools/registry.js";
+import { createBuiltinTools } from "../../../tools/builtin/index.js";
 
 // ─── Types ───
 
@@ -354,6 +357,41 @@ export async function checkDiskUsage(baseDir?: string): Promise<CheckResult> {
   return { name: "Disk space", status: "warn", detail: `${displayDir} (could not determine size)` };
 }
 
+export function checkNativeTaskAgentLoopTools(): CheckResult {
+  const registry = new ToolRegistry();
+  const tools = createBuiltinTools({ registry });
+  for (const tool of tools) {
+    registry.register(tool);
+  }
+
+  const assessment = assessTaskAgentLoopToolProfileFromTools(registry.listAll());
+  const requiredTotal = nativeTaskAgentLoopToolProfile.requiredToolNames.length;
+  const recommendedTotal = nativeTaskAgentLoopToolProfile.recommendedToolNames.length;
+  const requiredAvailable = requiredTotal - assessment.missingRequiredToolNames.length;
+  const recommendedAvailable = recommendedTotal - assessment.missingRecommendedToolNames.length;
+  const coverage = `required ${requiredAvailable}/${requiredTotal}, recommended ${recommendedAvailable}/${recommendedTotal}`;
+
+  if (!assessment.ready) {
+    return {
+      name: "Native AgentLoop tools",
+      status: "fail",
+      detail: `${coverage}; missing required: ${assessment.missingRequiredToolNames.join(", ")}`,
+    };
+  }
+  if (assessment.missingRecommendedToolNames.length > 0) {
+    return {
+      name: "Native AgentLoop tools",
+      status: "warn",
+      detail: `${coverage}; missing recommended: ${assessment.missingRecommendedToolNames.join(", ")}`,
+    };
+  }
+  return {
+    name: "Native AgentLoop tools",
+    status: "pass",
+    detail: `${coverage}; ${assessment.profileName} profile ready`,
+  };
+}
+
 // ─── Output helpers ───
 
 function statusIcon(status: CheckStatus): string {
@@ -415,6 +453,7 @@ export async function cmdDoctor(_args: string[]): Promise<number> {
     checkGoals(baseDir),
     checkLogDirectory(baseDir),
     checkBuild(),
+    checkNativeTaskAgentLoopTools(),
     await checkDaemon(baseDir),
     checkNotifications(baseDir),
     await checkDiskUsage(baseDir),

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-command-classifier.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-command-classifier.test.ts
@@ -14,6 +14,10 @@ describe("classifyAgentLoopCommandResult", () => {
       category: "verification",
       evidenceEligible: true,
     });
+    expect(classifyAgentLoopCommandResult({ toolName: "grep", command: "grep marker README.md" })).toMatchObject({
+      category: "verification",
+      evidenceEligible: true,
+    });
   });
 
   it("does not treat generic observation commands as completion evidence", () => {

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-dogfood-benchmark.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-dogfood-benchmark.test.ts
@@ -1,0 +1,748 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { spawn } from "node:child_process";
+import type { AgentLoopResult } from "../agent-loop-result.js";
+import type { AgentLoopBudget } from "../agent-loop-budget.js";
+import {
+  assessTaskAgentLoopToolProfile,
+  assessTaskAgentLoopToolProfileFromTools,
+  nativeTaskAgentLoopToolProfile,
+  runTaskAgentLoopDogfoodBenchmark,
+  scoreTaskAgentLoopDogfoodResult,
+} from "../agent-loop-dogfood-benchmark.js";
+import type { TaskAgentLoopOutput } from "../task-agent-loop-result.js";
+import type {
+  AgentLoopModelClient,
+  AgentLoopModelInfo,
+  AgentLoopModelRequest,
+  AgentLoopModelResponse,
+} from "../agent-loop-model.js";
+import { defaultAgentLoopCapabilities } from "../agent-loop-model.js";
+import { StaticAgentLoopModelRegistry } from "../agent-loop-model-registry.js";
+import { TaskAgentLoopRunner } from "../task-agent-loop-runner.js";
+import { BoundedAgentLoopRunner } from "../bounded-agent-loop-runner.js";
+import { createAgentLoopSession, type AgentLoopSession } from "../agent-loop-session.js";
+import { ToolRegistryAgentLoopToolRouter } from "../agent-loop-tool-router.js";
+import { ToolExecutorAgentLoopToolRuntime } from "../agent-loop-tool-runtime.js";
+import { ToolRegistry } from "../../../../tools/registry.js";
+import { createBuiltinTools } from "../../../../tools/builtin/index.js";
+import { ToolExecutor } from "../../../../tools/executor.js";
+import { ToolPermissionManager } from "../../../../tools/permission.js";
+import { ConcurrencyController } from "../../../../tools/concurrency.js";
+import { ApplyPatchTool } from "../../../../tools/fs/ApplyPatchTool/ApplyPatchTool.js";
+import { ShellCommandTool } from "../../../../tools/system/ShellCommandTool/ShellCommandTool.js";
+import type { Task } from "../../../../base/types/task.js";
+import { makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  }
+});
+
+class ScriptedModelClient implements AgentLoopModelClient {
+  calls: AgentLoopModelRequest[] = [];
+  private index = 0;
+
+  constructor(
+    private readonly modelInfo: AgentLoopModelInfo,
+    private readonly responses: AgentLoopModelResponse[],
+  ) {}
+
+  async getModelInfo(): Promise<AgentLoopModelInfo> {
+    return this.modelInfo;
+  }
+
+  async createTurn(input: AgentLoopModelRequest): Promise<AgentLoopModelResponse> {
+    this.calls.push(input);
+    return this.responses[this.index++] ?? this.responses[this.responses.length - 1]!;
+  }
+}
+
+function makeResult(
+  overrides: Partial<AgentLoopResult<TaskAgentLoopOutput>> = {},
+): AgentLoopResult<TaskAgentLoopOutput> {
+  return {
+    success: true,
+    output: {
+      status: "done",
+      finalAnswer: "done",
+      summary: "changed code and verified it",
+      filesChanged: ["src/foo.ts"],
+      testsRun: [],
+      completionEvidence: [],
+      verificationHints: [],
+      blockers: [],
+    },
+    finalText: "{}",
+    stopReason: "completed",
+    elapsedMs: 100,
+    modelTurns: 2,
+    toolCalls: 3,
+    compactions: 0,
+    filesChanged: true,
+    changedFiles: ["src/foo.ts"],
+    commandResults: [{
+      toolName: "shell",
+      command: "npx vitest run src/foo.test.ts",
+      cwd: "/repo",
+      success: true,
+      category: "verification",
+      evidenceEligible: true,
+      relevantToTask: true,
+      outputSummary: "pass",
+      durationMs: 10,
+    }],
+    workspace: {
+      requestedCwd: "/repo",
+      executionCwd: "/repo-worktree",
+      isolated: true,
+      cleanupStatus: "kept",
+    },
+    traceId: "trace",
+    sessionId: "session",
+    turnId: "turn",
+    ...overrides,
+  };
+}
+
+describe("scoreTaskAgentLoopDogfoodResult", () => {
+  it("passes a completed task with changed files, verification evidence, and isolated workspace", () => {
+    const score = scoreTaskAgentLoopDogfoodResult(makeResult(), {
+      mutationExpected: true,
+      expectedChangedFiles: ["src/foo.ts"],
+      requireIsolatedWorkspace: true,
+      maxModelTurns: 5,
+      maxToolCalls: 10,
+    });
+
+    expect(score.passed).toBe(true);
+    expect(score.reasons).toEqual([]);
+    expect(score.signals.successfulVerificationCommands).toBe(1);
+    expect(score.signals.changedFiles).toEqual(["src/foo.ts"]);
+  });
+
+  it("fails when the task finishes without verification evidence", () => {
+    const score = scoreTaskAgentLoopDogfoodResult(makeResult({ commandResults: [] }), {
+      mutationExpected: true,
+    });
+
+    expect(score.passed).toBe(false);
+    expect(score.reasons).toContain("successful verification commands 0 < 1");
+  });
+
+  it("fails when failed verification commands are present", () => {
+    const score = scoreTaskAgentLoopDogfoodResult(makeResult({
+      commandResults: [{
+        toolName: "shell",
+        command: "npm test",
+        cwd: "/repo",
+        success: false,
+        category: "verification",
+        evidenceEligible: true,
+        relevantToTask: true,
+        outputSummary: "fail",
+        durationMs: 10,
+      }],
+    }));
+
+    expect(score.passed).toBe(false);
+    expect(score.reasons).toContain("successful verification commands 0 < 1");
+    expect(score.reasons.some((reason) => reason.includes("failed verification commands"))).toBe(true);
+  });
+});
+
+describe("assessTaskAgentLoopToolProfile", () => {
+  it("reports missing required tools separately from recommended tools", () => {
+    const assessment = assessTaskAgentLoopToolProfile([
+      "read",
+      "grep",
+      "glob",
+      "list_dir",
+      "apply_patch",
+      "shell_command",
+      "git_diff",
+      "file_edit",
+    ]);
+
+    expect(assessment.ready).toBe(true);
+    expect(assessment.missingRequiredToolNames).toEqual([]);
+    expect(assessment.missingRecommendedToolNames).toEqual(
+      nativeTaskAgentLoopToolProfile.recommendedToolNames.filter((name) => name !== "file_edit"),
+    );
+    expect(assessment.requiredCoverage).toBe(1);
+    expect(assessment.recommendedCoverage).toBe(1 / nativeTaskAgentLoopToolProfile.recommendedToolNames.length);
+  });
+
+  it("passes the native task profile with the CLI builtin tool registry", () => {
+    const registry = new ToolRegistry();
+    const tools = createBuiltinTools({ registry });
+    for (const tool of tools) {
+      registry.register(tool);
+    }
+
+    const assessment = assessTaskAgentLoopToolProfileFromTools(registry.listAll());
+
+    expect(assessment.ready).toBe(true);
+    expect(assessment.missingRequiredToolNames).toEqual([]);
+    expect(assessment.missingRecommendedToolNames).toEqual([]);
+  });
+});
+
+describe("runTaskAgentLoopDogfoodBenchmark", () => {
+  it("summarizes readiness across benchmark cases", async () => {
+    const summary = await runTaskAgentLoopDogfoodBenchmark([
+      {
+        name: "passing-case",
+        expectations: { mutationExpected: true, requireIsolatedWorkspace: true },
+        run: async () => makeResult(),
+      },
+      {
+        name: "missing-verification",
+        expectations: { mutationExpected: true },
+        run: async () => makeResult({ commandResults: [] }),
+      },
+    ]);
+
+    expect(summary.totalCases).toBe(2);
+    expect(summary.passedCases).toBe(1);
+    expect(summary.passRate).toBe(0.5);
+    expect(summary.ready).toBe(false);
+    expect(summary.reasons.some((reason) => reason.includes("missing-verification"))).toBe(true);
+  });
+
+  it("scores a deterministic native TaskAgentLoop run with worktree diff and verification evidence", async () => {
+    const repoDir = await createGitRepo();
+    const worktreeBaseDir = path.join(path.dirname(repoDir), `${path.basename(repoDir)}.worktrees`);
+    tempDirs.push(worktreeBaseDir);
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{
+          id: "call-1",
+          name: "apply_patch",
+          input: { patch: dogfoodPatch() },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{
+          id: "call-2",
+          name: "shell_command",
+          input: { command: "grep dogfood-ok dogfood.txt" },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "Created dogfood.txt and verified dogfood-ok.",
+          summary: "Added a dogfood marker file and verified it with grep.",
+          filesChanged: ["dogfood.txt"],
+          testsRun: [{ command: "grep dogfood-ok dogfood.txt", passed: true, outputSummary: "dogfood-ok" }],
+          completionEvidence: ["verified command: grep dogfood-ok dogfood.txt"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+
+    const runner = makeTaskRunner(modelInfo, modelClient, repoDir);
+    const summary = await runTaskAgentLoopDogfoodBenchmark([
+      {
+        name: "native-agentloop-worktree-edit",
+        expectations: {
+          mutationExpected: true,
+          expectedChangedFiles: ["dogfood.txt"],
+          requireIsolatedWorkspace: true,
+          maxModelTurns: 4,
+          maxToolCalls: 3,
+        },
+        run: () => runner.runTask({
+          task: makeTask(),
+          cwd: repoDir,
+          worktreePolicy: {
+            enabled: true,
+            baseDir: worktreeBaseDir,
+            cleanupPolicy: "always",
+          },
+        }),
+      },
+    ]);
+
+    expect(summary.ready).toBe(true);
+    expect(summary.passedCases).toBe(1);
+    expect(summary.results[0]!.score.signals.changedFiles).toEqual(["dogfood.txt"]);
+    expect(summary.results[0]!.score.signals.successfulVerificationCommands).toBe(1);
+    expect(summary.results[0]!.result.workspace?.isolated).toBe(true);
+    expect(fs.existsSync(path.join(repoDir, "dogfood.txt"))).toBe(false);
+  });
+
+  it("scores a read-only native TaskAgentLoop investigation without changed files", async () => {
+    const repoDir = await createGitRepo({ readme: "dogfood repo\nread-only-marker\n" });
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{
+          id: "call-1",
+          name: "shell_command",
+          input: { command: "grep read-only-marker README.md" },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "README.md contains read-only-marker.",
+          summary: "Confirmed the marker without editing files.",
+          filesChanged: [],
+          testsRun: [{ command: "grep read-only-marker README.md", passed: true, outputSummary: "read-only-marker" }],
+          completionEvidence: ["verified command: grep read-only-marker README.md"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+
+    const runner = makeTaskRunner(modelInfo, modelClient, repoDir);
+    const summary = await runTaskAgentLoopDogfoodBenchmark([
+      {
+        name: "native-agentloop-readonly-investigation",
+        expectations: {
+          mutationExpected: false,
+          maxModelTurns: 3,
+          maxToolCalls: 1,
+        },
+        run: () => runner.runTask({
+          task: makeTask({
+            work_description: "Verify README.md contains read-only-marker without changing files.",
+            approach: "Run a focused read-only command, then return final JSON.",
+            success_criteria: [{ description: "README.md contains read-only-marker", verification_method: "grep read-only-marker README.md", is_blocking: true }],
+          }),
+          cwd: repoDir,
+        }),
+      },
+    ]);
+
+    expect(summary.ready).toBe(true);
+    expect(summary.results[0]!.score.signals.changedFiles).toEqual([]);
+    expect(summary.results[0]!.score.signals.successfulVerificationCommands).toBe(1);
+    expect(fs.readFileSync(path.join(repoDir, "README.md"), "utf-8")).toContain("read-only-marker");
+  });
+
+  it("scores failed verification recovery before final completion", async () => {
+    const repoDir = await createGitRepo();
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{ id: "call-1", name: "apply_patch", input: { patch: dogfoodPatch("dogfood-bad") } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-2", name: "shell_command", input: { command: "grep dogfood-ok dogfood.txt" } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "Premature completion after failed verification.",
+          summary: "This should be rejected by completion validation.",
+          filesChanged: ["dogfood.txt"],
+          testsRun: [{ command: "grep dogfood-ok dogfood.txt", passed: false, outputSummary: "no match" }],
+          completionEvidence: ["claimed evidence"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-3", name: "apply_patch", input: { patch: dogfoodRepairPatch() } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-4", name: "shell_command", input: { command: "grep dogfood-ok dogfood.txt" } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "Fixed dogfood.txt and verified dogfood-ok.",
+          summary: "Recovered after failed verification.",
+          filesChanged: ["dogfood.txt"],
+          testsRun: [{ command: "grep dogfood-ok dogfood.txt", passed: true, outputSummary: "dogfood-ok" }],
+          completionEvidence: ["verified command: grep dogfood-ok dogfood.txt"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+
+    const runner = makeTaskRunner(modelInfo, modelClient, repoDir, {
+      defaultBudget: { maxModelTurns: 8, maxToolCalls: 6, maxCompletionValidationAttempts: 2 },
+    });
+    const summary = await runTaskAgentLoopDogfoodBenchmark([
+      {
+        name: "native-agentloop-verification-recovery",
+        expectations: {
+          mutationExpected: true,
+          expectedChangedFiles: ["dogfood.txt"],
+          allowFailedVerificationCommands: true,
+          minSuccessfulVerificationCommands: 1,
+          maxModelTurns: 6,
+          maxToolCalls: 4,
+        },
+        run: () => runner.runTask({
+          task: makeTask(),
+          cwd: repoDir,
+        }),
+      },
+    ]);
+
+    expect(summary.ready).toBe(true);
+    expect(summary.results[0]!.score.signals.failedVerificationCommands).toBe(1);
+    expect(summary.results[0]!.score.signals.successfulVerificationCommands).toBe(1);
+    expect(fs.readFileSync(path.join(repoDir, "dogfood.txt"), "utf-8")).toBe("dogfood-ok\n");
+  });
+
+  it("scores recovery across a denied command and failed verification before completion", async () => {
+    const repoDir = await createGitRepo();
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{ id: "call-1", name: "apply_patch", input: { patch: dogfoodPatch("dogfood-bad") } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-2", name: "shell_command", input: { command: "cat dogfood.txt" } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-3", name: "shell_command", input: { command: "grep dogfood-ok dogfood.txt" } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "Premature completion after one denied command and one failed grep.",
+          summary: "This should be rejected because the runtime verification failed.",
+          filesChanged: ["dogfood.txt"],
+          testsRun: [{ command: "grep dogfood-ok dogfood.txt", passed: false, outputSummary: "no match" }],
+          completionEvidence: [],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-4", name: "apply_patch", input: { patch: dogfoodRepairPatch() } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-5", name: "shell_command", input: { command: "grep dogfood-ok dogfood.txt" } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "Recovered from denied/failed verification and verified dogfood-ok.",
+          summary: "Fixed the file and verified it after the completion gate rejected premature success.",
+          filesChanged: ["dogfood.txt"],
+          testsRun: [{ command: "grep dogfood-ok dogfood.txt", passed: true, outputSummary: "dogfood-ok" }],
+          completionEvidence: ["verified command: grep dogfood-ok dogfood.txt"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+
+    const runner = makeTaskRunner(modelInfo, modelClient, repoDir, {
+      defaultBudget: {
+        maxModelTurns: 9,
+        maxToolCalls: 8,
+        maxConsecutiveToolErrors: 3,
+        maxCompletionValidationAttempts: 2,
+      },
+      denyShellCommand: (command) => command === "cat dogfood.txt",
+    });
+    const summary = await runTaskAgentLoopDogfoodBenchmark([
+      {
+        name: "native-agentloop-denied-command-recovery",
+        expectations: {
+          mutationExpected: true,
+          expectedChangedFiles: ["dogfood.txt"],
+          allowFailedVerificationCommands: true,
+          minSuccessfulVerificationCommands: 1,
+          maxModelTurns: 7,
+          maxToolCalls: 5,
+        },
+        run: () => runner.runTask({
+          task: makeTask(),
+          cwd: repoDir,
+        }),
+      },
+    ]);
+
+    expect(summary.ready).toBe(true);
+    expect(summary.results[0]!.score.signals.failedVerificationCommands).toBe(1);
+    expect(summary.results[0]!.score.signals.successfulVerificationCommands).toBe(1);
+    expect(summary.results[0]!.result.commandResults).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        command: "cat dogfood.txt",
+        success: false,
+        category: "observation",
+        evidenceEligible: false,
+      }),
+    ]));
+    expect(fs.readFileSync(path.join(repoDir, "dogfood.txt"), "utf-8")).toBe("dogfood-ok\n");
+  });
+
+  it("scores a resumed native TaskAgentLoop after a tool-call budget stop", async () => {
+    const repoDir = await createGitRepo();
+    const modelInfo = makeModelInfo();
+    const session = createAgentLoopSession();
+    const firstModelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{ id: "call-1", name: "apply_patch", input: { patch: resumePatch() } }],
+        stopReason: "tool_use",
+      },
+    ]);
+    const firstRunner = makeTaskRunner(modelInfo, firstModelClient, repoDir, {
+      createSession: () => session,
+      defaultBudget: { maxModelTurns: 4, maxToolCalls: 1 },
+    });
+
+    const task = makeTask({
+      id: "resume-task",
+      work_description: "Create resume.txt with resume-ok and verify it.",
+      approach: "Patch the file, resume after interruption, verify the file, then finish.",
+      success_criteria: [{ description: "resume.txt contains resume-ok", verification_method: "grep resume-ok resume.txt", is_blocking: true }],
+      scope_boundary: { in_scope: ["resume.txt"], out_of_scope: [], blast_radius: "low" },
+    });
+
+    const interrupted = await firstRunner.runTask({ task, cwd: repoDir });
+    expect(interrupted.success).toBe(false);
+    expect(interrupted.stopReason).toBe("max_tool_calls");
+
+    const secondModelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{ id: "call-2", name: "shell_command", input: { command: "grep resume-ok resume.txt" } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "Resumed and verified resume.txt.",
+          summary: "Completed after resuming from saved AgentLoop state.",
+          filesChanged: ["resume.txt"],
+          testsRun: [{ command: "grep resume-ok resume.txt", passed: true, outputSummary: "resume-ok" }],
+          completionEvidence: ["verified command: grep resume-ok resume.txt"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const secondRunner = makeTaskRunner(modelInfo, secondModelClient, repoDir, {
+      createSession: () => session,
+      defaultBudget: { maxModelTurns: 4, maxToolCalls: 4 },
+    });
+
+    const summary = await runTaskAgentLoopDogfoodBenchmark([
+      {
+        name: "native-agentloop-resume",
+        expectations: {
+          mutationExpected: true,
+          expectedChangedFiles: ["resume.txt"],
+          minSuccessfulVerificationCommands: 1,
+          maxModelTurns: 3,
+          maxToolCalls: 2,
+        },
+        run: () => secondRunner.runTask({ task, cwd: repoDir }),
+      },
+    ]);
+
+    expect(summary.ready).toBe(true);
+    expect(summary.results[0]!.score.signals.successfulVerificationCommands).toBe(1);
+    expect(fs.readFileSync(path.join(repoDir, "resume.txt"), "utf-8")).toBe("resume-ok\n");
+  });
+});
+
+function makeModelInfo(): AgentLoopModelInfo {
+  return {
+    ref: { providerId: "test", modelId: "dogfood" },
+    displayName: "test/dogfood",
+    capabilities: { ...defaultAgentLoopCapabilities },
+  };
+}
+
+function makeTaskRunner(
+  modelInfo: AgentLoopModelInfo,
+  modelClient: AgentLoopModelClient,
+  cwd: string,
+  options: {
+    createSession?: () => AgentLoopSession;
+    defaultBudget?: Partial<AgentLoopBudget>;
+    denyShellCommand?: (command: string) => boolean;
+  } = {},
+): TaskAgentLoopRunner {
+  const registry = new ToolRegistry();
+  registry.register(new ApplyPatchTool());
+  registry.register(new ShellCommandTool());
+  const router = new ToolRegistryAgentLoopToolRouter(registry);
+  const executor = new ToolExecutor({
+    registry,
+    permissionManager: new ToolPermissionManager({
+      denyRules: options.denyShellCommand
+        ? [{
+            toolName: "shell_command",
+            inputMatcher: (input) =>
+              input !== null
+              && typeof input === "object"
+              && typeof (input as Record<string, unknown>)["command"] === "string"
+              && options.denyShellCommand!((input as Record<string, string>)["command"]),
+            reason: "dogfood denied shell command",
+          }]
+        : [],
+      allowRules: [{ toolName: "shell_command", reason: "dogfood benchmark verification command" }],
+    }),
+    concurrency: new ConcurrencyController(),
+  });
+  const runtime = new ToolExecutorAgentLoopToolRuntime(executor, router);
+  const boundedRunner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+
+  return new TaskAgentLoopRunner({
+    boundedRunner,
+    modelClient,
+    modelRegistry: new StaticAgentLoopModelRegistry([modelInfo]),
+    defaultModel: modelInfo.ref,
+    defaultToolPolicy: {
+      allowedTools: ["apply_patch", "shell_command"],
+    },
+    defaultBudget: {
+      maxModelTurns: 5,
+      maxToolCalls: 5,
+      maxCompletionValidationAttempts: 1,
+      ...options.defaultBudget,
+    },
+    cwd,
+    ...(options.createSession ? { createSession: options.createSession } : {}),
+  });
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "dogfood-task",
+    goal_id: "dogfood-goal",
+    strategy_id: null,
+    target_dimensions: ["execution"],
+    primary_dimension: "execution",
+    work_description: "Create dogfood.txt with the text dogfood-ok and verify it.",
+    rationale: "Exercise native AgentLoop worktree diff and verification evidence.",
+    approach: "Patch the file, run a focused verification command, then return final JSON.",
+    success_criteria: [{ description: "dogfood.txt contains dogfood-ok", verification_method: "grep dogfood-ok dogfood.txt", is_blocking: true }],
+    scope_boundary: { in_scope: ["dogfood.txt"], out_of_scope: [], blast_radius: "low" },
+    constraints: [],
+    plateau_until: null,
+    estimated_duration: { value: 1, unit: "minutes" },
+    consecutive_failure_count: 0,
+    reversibility: "reversible",
+    task_category: "normal",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function dogfoodPatch(value = "dogfood-ok"): string {
+  return [
+    "diff --git a/dogfood.txt b/dogfood.txt",
+    "new file mode 100644",
+    "index 0000000..7b6b304",
+    "--- /dev/null",
+    "+++ b/dogfood.txt",
+    "@@ -0,0 +1 @@",
+    `+${value}`,
+    "",
+  ].join("\n");
+}
+
+function dogfoodRepairPatch(): string {
+  return [
+    "diff --git a/dogfood.txt b/dogfood.txt",
+    "index 7b6b304..3d7e4aa 100644",
+    "--- a/dogfood.txt",
+    "+++ b/dogfood.txt",
+    "@@ -1 +1 @@",
+    "-dogfood-bad",
+    "+dogfood-ok",
+    "",
+  ].join("\n");
+}
+
+function resumePatch(): string {
+  return [
+    "diff --git a/resume.txt b/resume.txt",
+    "new file mode 100644",
+    "index 0000000..7b6b304",
+    "--- /dev/null",
+    "+++ b/resume.txt",
+    "@@ -0,0 +1 @@",
+    "+resume-ok",
+    "",
+  ].join("\n");
+}
+
+async function createGitRepo(input: { readme?: string } = {}): Promise<string> {
+  const repoDir = makeTempDir();
+  tempDirs.push(repoDir);
+  await fsp.writeFile(path.join(repoDir, "README.md"), input.readme ?? "dogfood repo\n", "utf-8");
+  await run("git", ["init"], repoDir);
+  await run("git", ["config", "user.email", "test@example.com"], repoDir);
+  await run("git", ["config", "user.name", "Test"], repoDir);
+  await run("git", ["add", "README.md"], repoDir);
+  await run("git", ["commit", "-m", "init"], repoDir);
+  return repoDir;
+}
+
+function run(command: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, { cwd });
+    let stderr = "";
+    proc.stderr.setEncoding("utf-8");
+    proc.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    proc.on("close", (code) => code === 0 ? resolve() : reject(new Error(stderr || `${command} failed`)));
+  });
+}

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -108,6 +108,14 @@ class VerifyTool implements ITool<{ command: string; cwd?: string }> {
   }
 }
 
+class DeferredTool extends EchoTool {
+  readonly metadata = {
+    ...new EchoTool().metadata,
+    name: "deferred_echo",
+    shouldDefer: true,
+  };
+}
+
 class ScriptedModelClient implements AgentLoopModelClient {
   calls: AgentLoopModelRequest[] = [];
   private index = 0;
@@ -246,6 +254,36 @@ describe("agentloop phase 1", () => {
       },
       required: ["value"],
     });
+  });
+
+  it("exposes required deferred tools to the model without enabling all deferred tools", () => {
+    const registry = new ToolRegistry();
+    registry.register(new EchoTool());
+    registry.register(new DeferredTool());
+    const router = new ToolRegistryAgentLoopToolRouter(registry);
+
+    const tools = router.modelVisibleTools({
+      session: createAgentLoopSession(),
+      turnId: "turn-1",
+      goalId: "goal-1",
+      taskId: "task-1",
+      cwd: process.cwd(),
+      model: { providerId: "test", modelId: "model" },
+      modelInfo: makeModelInfo(),
+      messages: [{ role: "user", content: "schema" }],
+      outputSchema: z.object({ ok: z.boolean() }),
+      budget: withDefaultBudget({}),
+      toolPolicy: { requiredTools: ["deferred_echo"] },
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+    });
+
+    expect(tools.map((tool) => tool.function.name)).toEqual(["echo", "deferred_echo"]);
   });
 
   it("executes model-selected tools and returns schema-valid final output", async () => {

--- a/src/orchestrator/execution/agent-loop/__tests__/openai-responses-agent-loop-model-client.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/openai-responses-agent-loop-model-client.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  defaultAgentLoopCapabilities,
+  OpenAIResponsesAgentLoopModelClient,
+  StaticAgentLoopModelRegistry,
+} from "../index.js";
+
+describe("OpenAIResponsesAgentLoopModelClient", () => {
+  it("does not send internal message phase fields to the Responses API", async () => {
+    const registry = new StaticAgentLoopModelRegistry([{
+      ref: { providerId: "openai", modelId: "gpt-test" },
+      displayName: "openai/gpt-test",
+      capabilities: { ...defaultAgentLoopCapabilities },
+    }]);
+    const client = new OpenAIResponsesAgentLoopModelClient({ apiKey: "test-key" }, registry);
+    const create = vi.fn(async (input: unknown) => {
+      expect(JSON.stringify(input)).not.toContain("\"phase\"");
+      expect(JSON.stringify(input)).not.toContain("\"strict\":true");
+      const inputItems = (input as { input: Array<{ type: string; call_id?: string }> }).input;
+      expect(inputItems.some((item) => item.type === "function_call" && item.call_id === "call-1")).toBe(true);
+      expect(inputItems.some((item) => item.type === "function_call_output" && item.call_id === "call-1")).toBe(true);
+      expect(inputItems.findIndex((item) => item.type === "function_call")).toBeLessThan(
+        inputItems.findIndex((item) => item.type === "function_call_output"),
+      );
+      return {
+        id: "resp-1",
+        status: "completed",
+        output: [{
+          type: "message",
+          content: [{ type: "output_text", text: "{\"ok\":true}" }],
+        }],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      };
+    });
+    (client as unknown as { client: { responses: { create: typeof create } } }).client = {
+      responses: { create },
+    };
+
+    const protocol = await client.createTurnProtocol({
+      model: { providerId: "openai", modelId: "gpt-test" },
+      messages: [
+        { role: "system", content: "system" },
+        {
+          role: "assistant",
+          content: "Calling tool",
+          phase: "commentary",
+          toolCalls: [{ id: "call-1", name: "echo", input: { value: "hello" } }],
+        },
+        { role: "tool", toolCallId: "call-1", toolName: "echo", content: "tool output" },
+        { role: "assistant", content: "{\"ok\":true}", phase: "final_answer" },
+      ],
+      tools: [],
+    });
+
+    expect(protocol.responseCompleted).toBe(true);
+    expect(protocol.assistant[0]?.content).toBe("{\"ok\":true}");
+  });
+});

--- a/src/orchestrator/execution/agent-loop/agent-loop-command-classifier.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-command-classifier.ts
@@ -10,7 +10,7 @@ export function classifyAgentLoopCommandResult(input: {
   const toolName = input.toolName.trim();
   const command = input.command.trim();
 
-  if (toolName === "verify") {
+  if (toolName === "verify" || toolName === "grep") {
     return { category: "verification", evidenceEligible: true };
   }
 

--- a/src/orchestrator/execution/agent-loop/agent-loop-dogfood-benchmark.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-dogfood-benchmark.ts
@@ -1,0 +1,269 @@
+import type { AgentLoopResult } from "./agent-loop-result.js";
+import type { TaskAgentLoopOutput } from "./task-agent-loop-result.js";
+
+export interface TaskAgentLoopDogfoodExpectations {
+  mutationExpected?: boolean;
+  expectedChangedFiles?: string[];
+  minSuccessfulVerificationCommands?: number;
+  requireRelevantVerification?: boolean;
+  requireIsolatedWorkspace?: boolean;
+  allowFailedVerificationCommands?: boolean;
+  maxModelTurns?: number;
+  maxToolCalls?: number;
+  maxElapsedMs?: number;
+}
+
+export interface TaskAgentLoopDogfoodScore {
+  passed: boolean;
+  reasons: string[];
+  signals: {
+    completed: boolean;
+    doneStatus: boolean;
+    changedFiles: string[];
+    successfulVerificationCommands: number;
+    failedVerificationCommands: number;
+    isolatedWorkspace: boolean;
+    modelTurns: number;
+    toolCalls: number;
+    elapsedMs: number;
+  };
+}
+
+export interface TaskAgentLoopDogfoodCase {
+  name: string;
+  run: () => Promise<AgentLoopResult<TaskAgentLoopOutput>>;
+  expectations?: TaskAgentLoopDogfoodExpectations;
+}
+
+export interface TaskAgentLoopDogfoodCaseResult {
+  name: string;
+  result: AgentLoopResult<TaskAgentLoopOutput>;
+  score: TaskAgentLoopDogfoodScore;
+}
+
+export interface TaskAgentLoopDogfoodBenchmarkCriteria {
+  minPassRate: number;
+  requireEveryCasePassed: boolean;
+}
+
+export interface TaskAgentLoopDogfoodBenchmarkSummary {
+  totalCases: number;
+  passedCases: number;
+  passRate: number;
+  ready: boolean;
+  reasons: string[];
+  results: TaskAgentLoopDogfoodCaseResult[];
+}
+
+export interface TaskAgentLoopToolProfile {
+  name: string;
+  requiredToolNames: readonly string[];
+  recommendedToolNames: readonly string[];
+}
+
+export interface TaskAgentLoopToolProfileAssessment {
+  profileName: string;
+  ready: boolean;
+  availableToolNames: string[];
+  missingRequiredToolNames: string[];
+  missingRecommendedToolNames: string[];
+  requiredCoverage: number;
+  recommendedCoverage: number;
+}
+
+export const nativeTaskAgentLoopToolProfile: TaskAgentLoopToolProfile = {
+  name: "native-task-agentloop",
+  requiredToolNames: [
+    "read",
+    "grep",
+    "glob",
+    "list_dir",
+    "apply_patch",
+    "shell_command",
+    "git_diff",
+  ],
+  recommendedToolNames: [
+    "file_edit",
+    "file_write",
+    "test-runner",
+    "git_log",
+    "json_query",
+    "env_info",
+    "update_plan",
+    "tool_search",
+    "github_read",
+    "github_pr_create",
+    "process_session_start",
+    "process_session_read",
+    "process_session_write",
+    "process_session_stop",
+    "process_session_list",
+    "mcp_list_tools",
+    "mcp_call_tool",
+  ],
+};
+
+export const defaultTaskAgentLoopDogfoodExpectations: Required<Pick<
+  TaskAgentLoopDogfoodExpectations,
+  "minSuccessfulVerificationCommands" | "requireRelevantVerification" | "allowFailedVerificationCommands"
+>> = {
+  minSuccessfulVerificationCommands: 1,
+  requireRelevantVerification: true,
+  allowFailedVerificationCommands: false,
+};
+
+export const defaultTaskAgentLoopDogfoodBenchmarkCriteria: TaskAgentLoopDogfoodBenchmarkCriteria = {
+  minPassRate: 0.9,
+  requireEveryCasePassed: true,
+};
+
+export function scoreTaskAgentLoopDogfoodResult(
+  result: AgentLoopResult<TaskAgentLoopOutput>,
+  expectations: TaskAgentLoopDogfoodExpectations = {},
+): TaskAgentLoopDogfoodScore {
+  const resolved = { ...defaultTaskAgentLoopDogfoodExpectations, ...expectations };
+  const changedFiles = unique([
+    ...result.changedFiles,
+    ...(result.output?.filesChanged ?? []),
+  ]);
+  const relevantVerificationCommands = result.commandResults.filter((command) =>
+    command.evidenceEligible
+    && (!resolved.requireRelevantVerification || command.relevantToTask !== false)
+  );
+  const successfulVerificationCommands = relevantVerificationCommands.filter((command) => command.success);
+  const failedVerificationCommands = relevantVerificationCommands.filter((command) => !command.success);
+  const reasons: string[] = [];
+
+  if (!result.success) {
+    reasons.push(`result success was false (${result.stopReason})`);
+  }
+  if (result.stopReason !== "completed") {
+    reasons.push(`stopReason ${result.stopReason} was not completed`);
+  }
+  if (result.output?.status !== "done") {
+    reasons.push(`output status ${result.output?.status ?? "missing"} was not done`);
+  }
+  if (expectations.mutationExpected === true && changedFiles.length === 0) {
+    reasons.push("mutation was expected but no changed files were reported");
+  }
+  if (expectations.mutationExpected === false && changedFiles.length > 0) {
+    reasons.push(`no mutation was expected but changed files were reported: ${changedFiles.join(", ")}`);
+  }
+  for (const expectedPath of expectations.expectedChangedFiles ?? []) {
+    if (!changedFiles.includes(expectedPath)) {
+      reasons.push(`expected changed file was not reported: ${expectedPath}`);
+    }
+  }
+  if (successfulVerificationCommands.length < resolved.minSuccessfulVerificationCommands) {
+    reasons.push(
+      `successful verification commands ${successfulVerificationCommands.length} < ${resolved.minSuccessfulVerificationCommands}`,
+    );
+  }
+  if (!resolved.allowFailedVerificationCommands && failedVerificationCommands.length > 0) {
+    reasons.push(`failed verification commands were reported: ${failedVerificationCommands.map((command) => command.command).join(", ")}`);
+  }
+  if (expectations.requireIsolatedWorkspace === true && result.workspace?.isolated !== true) {
+    reasons.push("isolated worktree execution was required but not reported");
+  }
+  if (expectations.maxModelTurns !== undefined && result.modelTurns > expectations.maxModelTurns) {
+    reasons.push(`modelTurns ${result.modelTurns} > ${expectations.maxModelTurns}`);
+  }
+  if (expectations.maxToolCalls !== undefined && result.toolCalls > expectations.maxToolCalls) {
+    reasons.push(`toolCalls ${result.toolCalls} > ${expectations.maxToolCalls}`);
+  }
+  if (expectations.maxElapsedMs !== undefined && result.elapsedMs > expectations.maxElapsedMs) {
+    reasons.push(`elapsedMs ${result.elapsedMs} > ${expectations.maxElapsedMs}`);
+  }
+
+  return {
+    passed: reasons.length === 0,
+    reasons,
+    signals: {
+      completed: result.success && result.stopReason === "completed",
+      doneStatus: result.output?.status === "done",
+      changedFiles,
+      successfulVerificationCommands: successfulVerificationCommands.length,
+      failedVerificationCommands: failedVerificationCommands.length,
+      isolatedWorkspace: result.workspace?.isolated === true,
+      modelTurns: result.modelTurns,
+      toolCalls: result.toolCalls,
+      elapsedMs: result.elapsedMs,
+    },
+  };
+}
+
+export async function runTaskAgentLoopDogfoodBenchmark(
+  cases: readonly TaskAgentLoopDogfoodCase[],
+  criteria: Partial<TaskAgentLoopDogfoodBenchmarkCriteria> = {},
+): Promise<TaskAgentLoopDogfoodBenchmarkSummary> {
+  const resolvedCriteria = { ...defaultTaskAgentLoopDogfoodBenchmarkCriteria, ...criteria };
+  const results: TaskAgentLoopDogfoodCaseResult[] = [];
+
+  for (const benchmarkCase of cases) {
+    const result = await benchmarkCase.run();
+    results.push({
+      name: benchmarkCase.name,
+      result,
+      score: scoreTaskAgentLoopDogfoodResult(result, benchmarkCase.expectations),
+    });
+  }
+
+  const totalCases = results.length;
+  const passedCases = results.filter((entry) => entry.score.passed).length;
+  const passRate = totalCases === 0 ? 0 : passedCases / totalCases;
+  const reasons: string[] = [];
+
+  if (passRate < resolvedCriteria.minPassRate) {
+    reasons.push(`passRate ${passRate.toFixed(2)} < ${resolvedCriteria.minPassRate.toFixed(2)}`);
+  }
+  if (resolvedCriteria.requireEveryCasePassed) {
+    for (const result of results.filter((entry) => !entry.score.passed)) {
+      reasons.push(`${result.name}: ${result.score.reasons.join("; ")}`);
+    }
+  }
+
+  return {
+    totalCases,
+    passedCases,
+    passRate,
+    ready: reasons.length === 0,
+    reasons,
+    results,
+  };
+}
+
+export function assessTaskAgentLoopToolProfile(
+  availableToolNames: Iterable<string>,
+  profile: TaskAgentLoopToolProfile = nativeTaskAgentLoopToolProfile,
+): TaskAgentLoopToolProfileAssessment {
+  const available = unique([...availableToolNames]).sort();
+  const availableSet = new Set(available);
+  const missingRequiredToolNames = profile.requiredToolNames.filter((name) => !availableSet.has(name));
+  const missingRecommendedToolNames = profile.recommendedToolNames.filter((name) => !availableSet.has(name));
+
+  return {
+    profileName: profile.name,
+    ready: missingRequiredToolNames.length === 0,
+    availableToolNames: available,
+    missingRequiredToolNames,
+    missingRecommendedToolNames,
+    requiredCoverage: coverage(profile.requiredToolNames.length, missingRequiredToolNames.length),
+    recommendedCoverage: coverage(profile.recommendedToolNames.length, missingRecommendedToolNames.length),
+  };
+}
+
+export function assessTaskAgentLoopToolProfileFromTools(
+  tools: readonly { metadata: { name: string } }[],
+  profile: TaskAgentLoopToolProfile = nativeTaskAgentLoopToolProfile,
+): TaskAgentLoopToolProfileAssessment {
+  return assessTaskAgentLoopToolProfile(tools.map((tool) => tool.metadata.name), profile);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function coverage(total: number, missing: number): number {
+  if (total === 0) return 1;
+  return (total - missing) / total;
+}

--- a/src/orchestrator/execution/agent-loop/agent-loop-real-dogfood.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-real-dogfood.ts
@@ -1,0 +1,415 @@
+import { spawn } from "node:child_process";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
+import { buildLLMClient } from "../../../base/llm/provider-factory.js";
+import { loadProviderConfig, type ProviderConfig } from "../../../base/llm/provider-config.js";
+import { getPulseedDirPath } from "../../../base/utils/paths.js";
+import { writeJsonFileAtomic } from "../../../base/utils/json-io.js";
+import type { Task } from "../../../base/types/task.js";
+import { ToolRegistry } from "../../../tools/registry.js";
+import { createBuiltinTools } from "../../../tools/builtin/index.js";
+import { ToolPermissionManager } from "../../../tools/permission.js";
+import { ToolExecutor } from "../../../tools/executor.js";
+import { ConcurrencyController } from "../../../tools/concurrency.js";
+import { createNativeTaskAgentLoopRunner } from "./task-agent-loop-factory.js";
+import type { AgentLoopResult } from "./agent-loop-result.js";
+import type { TaskAgentLoopOutput } from "./task-agent-loop-result.js";
+import {
+  runTaskAgentLoopDogfoodBenchmark,
+  type TaskAgentLoopDogfoodBenchmarkSummary,
+  type TaskAgentLoopDogfoodCase,
+} from "./agent-loop-dogfood-benchmark.js";
+
+interface RealDogfoodCaseSpec {
+  name: string;
+  seed: (repoDir: string) => Promise<void>;
+  task: Task;
+  expectations: TaskAgentLoopDogfoodCase["expectations"];
+}
+
+interface RealDogfoodReport {
+  status: "passed" | "failed" | "skipped";
+  skippedReason?: string;
+  provider: Pick<ProviderConfig, "provider" | "model" | "adapter" | "base_url"> & { has_api_key: boolean };
+  outputDir: string;
+  traceBaseDir: string;
+  worktreeBaseDir: string;
+  startedAt: string;
+  completedAt: string;
+  summary?: TaskAgentLoopDogfoodBenchmarkSummary;
+  cases: Array<{ name: string; repoDir?: string }>;
+}
+
+interface RealDogfoodOptions {
+  outputDir?: string;
+  keepWorkspaces: boolean;
+  caseLimit?: number;
+  maxModelTurns?: number;
+  maxToolCalls?: number;
+  timeoutMs?: number;
+}
+
+const SAFE_AGENT_LOOP_TOOLS = [
+  "read",
+  "grep",
+  "glob",
+  "list_dir",
+  "apply_patch",
+  "file_write",
+  "file_edit",
+  "shell_command",
+  "git_diff",
+  "json_query",
+  "update_plan",
+  "tool_search",
+] as const;
+
+async function main(): Promise<number> {
+  const startedAt = new Date().toISOString();
+  const options = parseArgs(process.argv.slice(2));
+  const outputDir = path.resolve(
+    options.outputDir
+    ?? process.env["PULSEED_AGENTLOOP_DOGFOOD_DIR"]
+    ?? path.join(getPulseedDirPath(), "dogfood", "agentloop-real", timestampForPath(startedAt)),
+  );
+  const traceBaseDir = path.join(outputDir, "trace");
+  const worktreeBaseDir = path.join(outputDir, "worktrees");
+  const providerConfig = await loadProviderConfig();
+  const cases: Array<{ name: string; repoDir?: string }> = [];
+
+  await fsp.mkdir(outputDir, { recursive: true });
+
+  const skipReason = skipReasonForProvider(providerConfig);
+  if (skipReason) {
+    await writeReport(outputDir, {
+      status: "skipped",
+      skippedReason: skipReason,
+      provider: reportProvider(providerConfig),
+      outputDir,
+      traceBaseDir,
+      worktreeBaseDir,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      cases,
+    });
+    console.log(`AgentLoop real dogfood skipped: ${skipReason}`);
+    console.log(`Report: ${path.join(outputDir, "report.json")}`);
+    return 0;
+  }
+
+  const llmClient = await buildLLMClient();
+  const toolRegistry = new ToolRegistry();
+  for (const tool of createBuiltinTools({ registry: toolRegistry })) {
+    if (!toolRegistry.get(tool.metadata.name)) {
+      toolRegistry.register(tool);
+    }
+  }
+  const toolExecutor = new ToolExecutor({
+    registry: toolRegistry,
+    permissionManager: new ToolPermissionManager({
+      allowRules: [{
+        toolName: "shell_command",
+        inputMatcher: isAllowedDogfoodShellCommand,
+        reason: "AgentLoop real dogfood runs only focused local verification commands in temporary repos.",
+      }],
+    }),
+    concurrency: new ConcurrencyController(),
+  });
+  const runner = createNativeTaskAgentLoopRunner({
+    llmClient,
+    providerConfig,
+    toolRegistry,
+    toolExecutor,
+    traceBaseDir,
+    defaultBudget: {
+      maxModelTurns: options.maxModelTurns ?? 10,
+      maxToolCalls: options.maxToolCalls ?? 16,
+      maxWallClockMs: options.timeoutMs ?? 180_000,
+      maxCompletionValidationAttempts: 2,
+    },
+    defaultToolPolicy: {
+      allowedTools: SAFE_AGENT_LOOP_TOOLS,
+      includeDeferred: false,
+    },
+    defaultWorktreePolicy: {
+      enabled: true,
+      baseDir: worktreeBaseDir,
+      cleanupPolicy: options.keepWorkspaces ? "never" : "always",
+      keepForDebug: options.keepWorkspaces,
+    },
+  });
+
+  const specs = makeCaseSpecs().slice(0, options.caseLimit ?? 3);
+  const benchmarkCases: TaskAgentLoopDogfoodCase[] = [];
+  for (const spec of specs) {
+    const repoDir = await createGitRepo(spec.name);
+    await spec.seed(repoDir);
+    await run("git", ["add", "."], repoDir);
+    await run("git", ["commit", "-m", "seed"], repoDir);
+    cases.push({ name: spec.name, repoDir });
+    benchmarkCases.push({
+      name: spec.name,
+      expectations: spec.expectations,
+      run: () => runTaskSafely(spec.name, () => runner.runTask({
+          task: spec.task,
+          cwd: repoDir,
+          workspaceContext: "This is a temporary dogfood repository. Keep changes focused to the task. Use tools for file changes and verification.",
+        })),
+    });
+  }
+
+  const summary = await runTaskAgentLoopDogfoodBenchmark(benchmarkCases);
+  const status = summary.ready ? "passed" : "failed";
+  await writeReport(outputDir, {
+    status,
+    provider: reportProvider(providerConfig),
+    outputDir,
+    traceBaseDir,
+    worktreeBaseDir,
+    startedAt,
+    completedAt: new Date().toISOString(),
+    summary,
+    cases,
+  });
+
+  console.log(`AgentLoop real dogfood ${status}: ${summary.passedCases}/${summary.totalCases} passed (${(summary.passRate * 100).toFixed(1)}%)`);
+  if (summary.reasons.length > 0) {
+    console.log(`Reasons: ${summary.reasons.join(" | ")}`);
+  }
+  console.log(`Report: ${path.join(outputDir, "report.json")}`);
+  console.log(`Traces: ${path.join(traceBaseDir, "traces", "agentloop", "task")}`);
+  return summary.ready ? 0 : 1;
+}
+
+async function runTaskSafely(
+  name: string,
+  run: () => Promise<AgentLoopResult<TaskAgentLoopOutput>>,
+): Promise<AgentLoopResult<TaskAgentLoopOutput>> {
+  try {
+    return await run();
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    return {
+      success: false,
+      output: null,
+      finalText: `case ${name} threw: ${message}`,
+      stopReason: "fatal_error",
+      elapsedMs: 0,
+      modelTurns: 0,
+      toolCalls: 0,
+      compactions: 0,
+      filesChanged: false,
+      changedFiles: [],
+      commandResults: [],
+      traceId: "unavailable",
+      sessionId: "unavailable",
+      turnId: "unavailable",
+    };
+  }
+}
+
+function makeCaseSpecs(): RealDogfoodCaseSpec[] {
+  return [
+    {
+      name: "readonly-readme-marker",
+      seed: async (repoDir) => {
+        await fsp.writeFile(path.join(repoDir, "README.md"), "Dogfood fixture\nmarker: readonly-ok\n", "utf-8");
+      },
+      task: makeTask({
+        id: "dogfood-readonly",
+        work_description: "Verify README.md contains the exact marker readonly-ok without changing files.",
+        approach: "Inspect the file or run a focused grep command, then return the required final JSON.",
+        success_criteria: [{ description: "README.md contains readonly-ok", verification_method: "grep readonly-ok README.md", is_blocking: true }],
+        scope_boundary: { in_scope: ["README.md"], out_of_scope: ["all other files"], blast_radius: "low" },
+      }),
+      expectations: {
+        mutationExpected: false,
+        minSuccessfulVerificationCommands: 1,
+        requireIsolatedWorkspace: true,
+        maxModelTurns: 5,
+        maxToolCalls: 4,
+      },
+    },
+    {
+      name: "create-marker-file",
+      seed: async (repoDir) => {
+        await fsp.writeFile(path.join(repoDir, "README.md"), "Dogfood fixture\n", "utf-8");
+      },
+      task: makeTask({
+        id: "dogfood-create-file",
+        work_description: "Create result.txt containing exactly one line: real-dogfood-ok",
+        approach: "Use a file-editing tool, verify the marker with grep, then return the required final JSON.",
+        success_criteria: [{ description: "result.txt contains real-dogfood-ok", verification_method: "grep real-dogfood-ok result.txt", is_blocking: true }],
+        scope_boundary: { in_scope: ["result.txt"], out_of_scope: ["README.md"], blast_radius: "low" },
+      }),
+      expectations: {
+        mutationExpected: true,
+        expectedChangedFiles: ["result.txt"],
+        minSuccessfulVerificationCommands: 1,
+        requireIsolatedWorkspace: true,
+        maxModelTurns: 7,
+        maxToolCalls: 6,
+      },
+    },
+    {
+      name: "edit-existing-file",
+      seed: async (repoDir) => {
+        await fsp.writeFile(path.join(repoDir, "settings.txt"), "mode=dogfood\nenabled=false\n", "utf-8");
+      },
+      task: makeTask({
+        id: "dogfood-edit-existing",
+        work_description: "Change settings.txt so enabled=false becomes enabled=true. Leave the mode line unchanged.",
+        approach: "Use a file-editing tool, verify enabled=true with grep, then return the required final JSON.",
+        success_criteria: [{ description: "settings.txt contains enabled=true", verification_method: "grep enabled=true settings.txt", is_blocking: true }],
+        scope_boundary: { in_scope: ["settings.txt"], out_of_scope: ["all other files"], blast_radius: "low" },
+      }),
+      expectations: {
+        mutationExpected: true,
+        expectedChangedFiles: ["settings.txt"],
+        minSuccessfulVerificationCommands: 1,
+        requireIsolatedWorkspace: true,
+        maxModelTurns: 7,
+        maxToolCalls: 6,
+      },
+    },
+  ];
+}
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    id: "dogfood-task",
+    goal_id: "agentloop-real-dogfood",
+    strategy_id: null,
+    target_dimensions: ["execution"],
+    primary_dimension: "execution",
+    work_description: "Run a real AgentLoop dogfood task.",
+    rationale: "Measure native AgentLoop task execution with a real model.",
+    approach: "Use tools, verify the result, and return final JSON.",
+    success_criteria: [{ description: "task complete", verification_method: "grep", is_blocking: true }],
+    scope_boundary: { in_scope: [], out_of_scope: [], blast_radius: "low" },
+    constraints: [
+      "Use only the temporary repository.",
+      "Do not modify files outside the task scope.",
+      "Return final output as JSON matching the required schema.",
+    ],
+    plateau_until: null,
+    estimated_duration: { value: 5, unit: "minutes" },
+    consecutive_failure_count: 0,
+    reversibility: "reversible",
+    task_category: "normal",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function parseArgs(argv: string[]): RealDogfoodOptions {
+  const result: RealDogfoodOptions = { keepWorkspaces: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--output-dir" && argv[i + 1]) result.outputDir = argv[++i];
+    else if (arg === "--keep-workspaces") result.keepWorkspaces = true;
+    else if (arg === "--cases" && argv[i + 1]) result.caseLimit = parsePositiveInt(argv[++i]);
+    else if (arg === "--max-model-turns" && argv[i + 1]) result.maxModelTurns = parsePositiveInt(argv[++i]);
+    else if (arg === "--max-tool-calls" && argv[i + 1]) result.maxToolCalls = parsePositiveInt(argv[++i]);
+    else if (arg === "--timeout-ms" && argv[i + 1]) result.timeoutMs = parsePositiveInt(argv[++i]);
+  }
+  return result;
+}
+
+function parsePositiveInt(value: string): number | undefined {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function skipReasonForProvider(config: ProviderConfig): string | null {
+  if (config.adapter !== "agent_loop") {
+    return `provider adapter is ${config.adapter}; set PULSEED_ADAPTER=agent_loop or configure provider.json adapter=agent_loop`;
+  }
+  if ((config.provider === "openai" || config.provider === "anthropic") && !config.api_key) {
+    const envName = config.provider === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
+    return `${envName} is not configured`;
+  }
+  return null;
+}
+
+function reportProvider(config: ProviderConfig): RealDogfoodReport["provider"] {
+  return {
+    provider: config.provider,
+    model: config.model,
+    adapter: config.adapter,
+    ...(config.base_url ? { base_url: config.base_url } : {}),
+    has_api_key: Boolean(config.api_key),
+  };
+}
+
+function isAllowedDogfoodShellCommand(input: unknown): boolean {
+  if (input === null || typeof input !== "object") return false;
+  const command = (input as Record<string, unknown>)["command"];
+  if (typeof command !== "string") return false;
+  const trimmed = command.trim();
+  if (trimmed.includes(">")) return false;
+  return [
+    /^grep\s+[A-Za-z0-9_.=-]+\s+[A-Za-z0-9_.\/-]+$/,
+    /^grep\s+-n\s+'?\^[A-Za-z0-9_.=-]+='?\s+[A-Za-z0-9_.\/-]+$/,
+    /^grep\s+-n\s+'?\^[A-Za-z0-9_.=-]+='?\s+[A-Za-z0-9_.\/-]+\s+&&\s+grep\s+-n\s+'?\^[A-Za-z0-9_.=-]+='?\s+[A-Za-z0-9_.\/-]+$/,
+    /^test\s+-f\s+[A-Za-z0-9_.\/-]+$/,
+    /^git\s+(status|diff|show)\b/,
+    /^pwd$/,
+    /^ls(\s+[A-Za-z0-9_.\/-]+)?$/,
+    /^cat\s+[A-Za-z0-9_.\/-]+$/,
+    /^pwd\s+&&\s+printf\s+'---\\n'\s+&&\s+cat\s+[A-Za-z0-9_.\/-]+\s+&&\s+printf\s+'---\\n'\s+&&\s+wc\s+-l\s+<\s+[A-Za-z0-9_.\/-]+$/,
+  ].some((pattern) => pattern.test(trimmed));
+}
+
+async function createGitRepo(name: string): Promise<string> {
+  const repoDir = await fsp.mkdtemp(path.join(os.tmpdir(), `pulseed-agentloop-${name}-`));
+  await run("git", ["init"], repoDir);
+  await run("git", ["config", "user.email", "dogfood@example.com"], repoDir);
+  await run("git", ["config", "user.name", "AgentLoop Dogfood"], repoDir);
+  return repoDir;
+}
+
+function run(command: string, args: string[], cwd: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, { cwd });
+    let stderr = "";
+    proc.stderr.setEncoding("utf-8");
+    proc.stderr.on("data", (chunk: string) => { stderr += chunk; });
+    proc.on("close", (code) => code === 0 ? resolve() : reject(new Error(stderr || `${command} ${args.join(" ")} failed`)));
+  });
+}
+
+async function writeReport(outputDir: string, report: RealDogfoodReport): Promise<void> {
+  await writeJsonFileAtomic(path.join(outputDir, "report.json"), report);
+}
+
+function timestampForPath(value: string): string {
+  return value.replace(/[:.]/g, "-");
+}
+
+const isMain = (() => {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(process.argv[1]);
+  } catch {
+    return false;
+  }
+})();
+
+if (isMain) {
+  main().then(
+    (code) => { process.exitCode = code; },
+    (error: unknown) => {
+      console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+      process.exitCode = 1;
+    },
+  );
+}

--- a/src/orchestrator/execution/agent-loop/agent-loop-tool-router.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-tool-router.ts
@@ -17,7 +17,11 @@ export class ToolRegistryAgentLoopToolRouter implements AgentLoopToolRouter {
   modelVisibleTools(turn: AgentLoopTurnContext<unknown>): ToolDefinition[] {
     return this.registry.listAll()
       .filter((tool) => this.isToolAllowed(tool.metadata.name, turn))
-      .filter((tool) => turn.toolPolicy.includeDeferred || !tool.metadata.shouldDefer)
+      .filter((tool) =>
+        turn.toolPolicy.includeDeferred
+        || !tool.metadata.shouldDefer
+        || turn.toolPolicy.requiredTools?.includes(tool.metadata.name) === true
+      )
       .map((tool) => {
         const definition = toToolDefinition(tool);
         definition.function.description = tool.description({ cwd: turn.cwd, goalId: turn.goalId });

--- a/src/orchestrator/execution/agent-loop/agent-loop-tool-runtime.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-tool-runtime.ts
@@ -59,7 +59,7 @@ export class ToolExecutorAgentLoopToolRuntime implements AgentLoopToolRuntime {
         abortSignal: turn.abortSignal,
       });
       const disposition = this.resolveDisposition(result.error, turn.abortSignal?.aborted === true);
-      const command = this.extractCommand(call.input);
+      const command = this.extractCommand(call.name, call.input);
       const resolvedCwd = this.extractCwd(call.input) ?? turn.cwd;
       return {
         callId: call.id,
@@ -118,10 +118,19 @@ export class ToolExecutorAgentLoopToolRuntime implements AgentLoopToolRuntime {
     return "respond_to_model";
   }
 
-  private extractCommand(input: unknown): string | undefined {
-    return input && typeof input === "object" && typeof (input as Record<string, unknown>)["command"] === "string"
-      ? (input as Record<string, string>)["command"]
-      : undefined;
+  private extractCommand(toolName: string, input: unknown): string | undefined {
+    if (!input || typeof input !== "object") return undefined;
+    const obj = input as Record<string, unknown>;
+    if (typeof obj["command"] === "string") return obj["command"];
+    if (toolName === "grep" && typeof obj["pattern"] === "string") {
+      const target = typeof obj["glob"] === "string"
+        ? obj["glob"]
+        : typeof obj["path"] === "string"
+          ? obj["path"]
+          : ".";
+      return `grep ${obj["pattern"]} ${target}`;
+    }
+    return undefined;
   }
 
   private extractCwd(input: unknown): string | undefined {

--- a/src/orchestrator/execution/agent-loop/index.ts
+++ b/src/orchestrator/execution/agent-loop/index.ts
@@ -2,6 +2,7 @@ export * from "./agent-loop-budget.js";
 export * from "./agent-loop-command-classifier.js";
 export * from "./agent-loop-compactor.js";
 export * from "./agent-loop-context-assembler.js";
+export * from "./agent-loop-dogfood-benchmark.js";
 export * from "./agent-loop-evaluator.js";
 export * from "./agent-loop-events.js";
 export * from "./agent-loop-history.js";

--- a/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
@@ -119,7 +119,8 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
   }
 
   private toInputItems(messages: AgentLoopMessage[]): ResponseInput {
-    return messages.map((message) => {
+    const items: ResponseInputItem[] = [];
+    for (const message of messages) {
       if (message.role === "tool") {
         if (!message.toolCallId) {
           throw new Error("Agent loop tool messages require toolCallId for Responses API replay.");
@@ -129,17 +130,29 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
           call_id: message.toolCallId,
           output: message.content,
         };
-        return item;
+        items.push(item);
+        continue;
       }
 
-      const item: EasyInputMessage = {
-        type: "message",
-        role: message.role === "system" ? "developer" : message.role,
-        content: message.content,
-        phase: message.role === "assistant" ? message.phase ?? null : null,
-      };
-      return item;
-    });
+      if (message.content.trim()) {
+        const item: EasyInputMessage = {
+          type: "message",
+          role: message.role === "system" ? "developer" : message.role,
+          content: message.content,
+        };
+        items.push(item);
+      }
+
+      for (const toolCall of message.toolCalls ?? []) {
+        items.push({
+          type: "function_call",
+          call_id: toolCall.id,
+          name: toolCall.name,
+          arguments: this.stringifyArguments(toolCall.input),
+        });
+      }
+    }
+    return items;
   }
 
   private toFunctionTool(tool: ToolDefinition): FunctionTool {
@@ -148,7 +161,7 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
       name: tool.function.name,
       description: tool.function.description,
       parameters: tool.function.parameters,
-      strict: true,
+      strict: false,
     };
   }
 
@@ -158,6 +171,16 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
       return JSON.parse(value);
     } catch {
       return value;
+    }
+  }
+
+  private stringifyArguments(value: unknown): string {
+    if (typeof value === "string") return value;
+    if (value === undefined) return "{}";
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return "{}";
     }
   }
 }

--- a/src/platform/knowledge/__tests__/knowledge-manager-auto-consolidate.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-manager-auto-consolidate.test.ts
@@ -6,6 +6,8 @@ import { StateManager } from "../../../base/state/state-manager.js";
 import { KnowledgeManager } from "../knowledge-manager.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
 
+vi.setConfig({ testTimeout: 20_000 });
+
 // ─── Helpers ───
 
 function makeTempDir(): string {

--- a/src/platform/knowledge/__tests__/memory-lifecycle-phase2.test.ts
+++ b/src/platform/knowledge/__tests__/memory-lifecycle-phase2.test.ts
@@ -307,21 +307,20 @@ describe("onSatisficingJudgment", () => {
 
 describe("applyRetentionPolicy with drive-based delays", () => {
   it("skips compression when loop span < compressionDelay with high dissatisfaction", async () => {
-    // High dissatisfaction → delay = 200
+    // High dissatisfaction doubles retention: base 4 -> delay 8.
     const driveScorer = makeMockDriveScorer({ dim1: 0.9 });
     const mgr = new MemoryLifecycleManager(
       tmpDir,
       createMockLLMClient([]),
-      { default_retention_loops: 100 },
+      { default_retention_loops: 4 },
       undefined,
       undefined,
       driveScorer
     );
     await mgr.initializeDirectories();
 
-    // Record 150 entries (loop 0..149) — this would trigger without drive delay (>100),
-    // but with drive delay (>200) it should NOT trigger.
-    for (let i = 0; i < 150; i++) {
+    // Span 5 would trigger with base retention 4, but not with drive-delayed retention 8.
+    for (let i = 0; i <= 5; i++) {
       await mgr.recordToShortTerm("goal-a", "experience_log", { test: i }, {
         loopNumber: i,
         dimensions: ["dim1"],
@@ -329,7 +328,6 @@ describe("applyRetentionPolicy with drive-based delays", () => {
     }
 
     const results = await mgr.applyRetentionPolicy("goal-a");
-    // span = 149 - 0 = 149, effective limit = 200 → no compression
     expect(results).toHaveLength(0);
   });
 
@@ -338,11 +336,11 @@ describe("applyRetentionPolicy with drive-based delays", () => {
     const mgr = new MemoryLifecycleManager(
       tmpDir,
       createMockLLMClient(llmResponses),
-      { default_retention_loops: 50 }
+      { default_retention_loops: 4 }
     );
     await mgr.initializeDirectories();
 
-    for (let i = 0; i <= 50; i++) {
+    for (let i = 0; i <= 4; i++) {
       await mgr.recordToShortTerm("goal-a", "experience_log", { test: i }, {
         loopNumber: i,
       });

--- a/src/runtime/__tests__/daemon-runner.test.ts
+++ b/src/runtime/__tests__/daemon-runner.test.ts
@@ -18,6 +18,8 @@ import { runSupervisorMaintenanceCycleForDaemon } from "../daemon/maintenance.js
 import type { DaemonState } from "../../base/types/daemon.js";
 import { restoreInterruptedGoals } from "../daemon/persistence.js";
 
+vi.setConfig({ testTimeout: 20_000 });
+
 async function pollForFile(
   filePath: string,
   timeoutMs = 2_000,

--- a/src/runtime/__tests__/event-file-watcher.test.ts
+++ b/src/runtime/__tests__/event-file-watcher.test.ts
@@ -130,6 +130,7 @@ describe("file watcher — detects new JSON files", () => {
 
     await waitFor(() => mockDriveSystem.writeEvent.mock.calls.length > 0, 8000);
     expect(mockDriveSystem.writeEvent).toHaveBeenCalledOnce();
+    await waitFor(() => fs.existsSync(path.join(eventsDir, "processed", "existing.json")), 8000);
     expect(fs.existsSync(path.join(eventsDir, "processed", "existing.json"))).toBe(true);
   });
 

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -2599,7 +2599,7 @@ describe("GoalTrigger token tracking (Phase 4)", () => {
 // ─── Phase 4: IScheduleSource / PluginLoader integration ───
 
 describe("PluginLoader schedule_source interface validation (Phase 4)", () => {
-  it("PluginLoader validates schedule_source interface (fetchEntries, healthCheck)", async () => {
+  it("PluginLoader validates schedule_source interface (fetchEntries, healthCheck)", { timeout: 20_000 }, async () => {
     const { PluginLoader } = await import("../plugin-loader.js");
     const { NotifierRegistry } = await import("../notifier-registry.js");
 
@@ -2631,7 +2631,7 @@ describe("PluginLoader schedule_source interface validation (Phase 4)", () => {
     expect(() => loader.validateInterface("schedule_source", badImpl2)).toThrow(/healthCheck/);
   });
 
-  it("PluginLoader registers schedule_source and returns it from getScheduleSources", async () => {
+  it("PluginLoader registers schedule_source and returns it from getScheduleSources", { timeout: 20_000 }, async () => {
     const { PluginLoader } = await import("../plugin-loader.js");
     const { NotifierRegistry } = await import("../notifier-registry.js");
 

--- a/src/tools/builtin/index.ts
+++ b/src/tools/builtin/index.ts
@@ -28,10 +28,21 @@ export { SoilPublishTool } from "../execution/SoilPublishTool/SoilPublishTool.js
 export { SoilRebuildTool } from "../execution/SoilRebuildTool/SoilRebuildTool.js";
 export { WebSearchTool, createWebSearchClient } from "../network/WebSearchTool/WebSearchTool.js";
 export type { ISearchClient, SearchResult } from "../network/WebSearchTool/WebSearchTool.js";
+export { GitHubReadTool, GitHubPrCreateTool } from "../network/GitHubCliTool/GitHubCliTool.js";
+export { McpListToolsTool, McpCallToolTool } from "../network/McpStdioTool/McpStdioTool.js";
 export { ToolSearchTool } from "../query/ToolSearchTool/ToolSearchTool.js";
 export { EnvTool } from "../system/EnvTool/EnvTool.js";
 export { SleepTool } from "../system/SleepTool/SleepTool.js";
 export { GitDiffTool } from "../system/GitDiffTool/GitDiffTool.js";
+export {
+  ProcessSessionManager,
+  ProcessSessionStartTool,
+  ProcessSessionReadTool,
+  ProcessSessionWriteTool,
+  ProcessSessionStopTool,
+  ProcessSessionListTool,
+  defaultProcessSessionManager,
+} from "../system/ProcessSessionTool/ProcessSessionTool.js";
 export { FileWriteTool } from "../fs/FileWriteTool/FileWriteTool.js";
 export { FileEditTool } from "../fs/FileEditTool/FileEditTool.js";
 export { ApplyPatchTool } from "../fs/ApplyPatchTool/ApplyPatchTool.js";
@@ -100,10 +111,20 @@ import { SoilOpenTool } from "../execution/SoilOpenTool/SoilOpenTool.js";
 import { SoilPublishTool } from "../execution/SoilPublishTool/SoilPublishTool.js";
 import { SoilRebuildTool } from "../execution/SoilRebuildTool/SoilRebuildTool.js";
 import { WebSearchTool, createWebSearchClient } from "../network/WebSearchTool/WebSearchTool.js";
+import { GitHubReadTool, GitHubPrCreateTool } from "../network/GitHubCliTool/GitHubCliTool.js";
+import { McpListToolsTool, McpCallToolTool } from "../network/McpStdioTool/McpStdioTool.js";
 import { ToolSearchTool } from "../query/ToolSearchTool/ToolSearchTool.js";
 import { EnvTool } from "../system/EnvTool/EnvTool.js";
 import { SleepTool } from "../system/SleepTool/SleepTool.js";
 import { GitDiffTool } from "../system/GitDiffTool/GitDiffTool.js";
+import {
+  ProcessSessionStartTool,
+  ProcessSessionReadTool,
+  ProcessSessionWriteTool,
+  ProcessSessionStopTool,
+  ProcessSessionListTool,
+  defaultProcessSessionManager,
+} from "../system/ProcessSessionTool/ProcessSessionTool.js";
 import { FileWriteTool } from "../fs/FileWriteTool/FileWriteTool.js";
 import { FileEditTool } from "../fs/FileEditTool/FileEditTool.js";
 import { ApplyPatchTool } from "../fs/ApplyPatchTool/ApplyPatchTool.js";
@@ -177,12 +198,21 @@ export function createBuiltinTools(deps?: BuiltinToolDeps): ITool[] {
     new FileWriteTool(),
     new GitDiffTool(),
     new GitLogTool(),
+    new GitHubPrCreateTool(),
+    new GitHubReadTool(),
     new GlobTool(),
     new GrepTool(),
     new HttpFetchTool(),
     new JsonQueryTool(),
     new ListDirTool(),
     new ProcessStatusTool(),
+    new ProcessSessionListTool(defaultProcessSessionManager),
+    new ProcessSessionReadTool(defaultProcessSessionManager),
+    new ProcessSessionStartTool(defaultProcessSessionManager),
+    new ProcessSessionStopTool(defaultProcessSessionManager),
+    new ProcessSessionWriteTool(defaultProcessSessionManager),
+    new McpCallToolTool(),
+    new McpListToolsTool(),
     new ReadTool(),
     new ShellCommandTool(),
     new ShellTool(),

--- a/src/tools/fs/ApplyPatchTool/ApplyPatchTool.ts
+++ b/src/tools/fs/ApplyPatchTool/ApplyPatchTool.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
 import { z } from "zod";
 import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../types.js";
 
@@ -32,6 +34,9 @@ export class ApplyPatchTool implements ITool<ApplyPatchInput> {
   async call(input: ApplyPatchInput, context: ToolCallContext): Promise<ToolResult> {
     const started = Date.now();
     const cwd = input.cwd ?? context.cwd;
+    if (input.patch.trimStart().startsWith("*** Begin Patch")) {
+      return this.callCodexPatch(input, cwd, started);
+    }
     const args = input.checkOnly ? ["apply", "--check", "--whitespace=nowarn", "-"] : ["apply", "--whitespace=nowarn", "-"];
     const result = await runGitApply(args, input.patch, cwd);
     const changedPaths = extractPatchPaths(input.patch);
@@ -50,6 +55,51 @@ export class ApplyPatchTool implements ITool<ApplyPatchInput> {
       durationMs: Date.now() - started,
       artifacts: changedPaths,
     };
+  }
+
+  private async callCodexPatch(input: ApplyPatchInput, cwd: string, started: number): Promise<ToolResult> {
+    try {
+      const operations = parseCodexPatch(input.patch);
+      if (input.checkOnly) {
+        for (const operation of operations) {
+          await validateCodexPatchOperation(operation, cwd);
+        }
+      } else {
+        for (const operation of operations) {
+          await applyCodexPatchOperation(operation, cwd);
+        }
+      }
+      const changedPaths = operations.map((operation) => operation.filePath);
+      return {
+        success: true,
+        data: {
+          changedPaths,
+          stdout: "",
+          stderr: "",
+          checkOnly: input.checkOnly,
+          format: "codex",
+        },
+        summary: `${input.checkOnly ? "Patch check passed" : "Patch applied"}: ${changedPaths.join(", ") || "no paths detected"}`,
+        durationMs: Date.now() - started,
+        artifacts: changedPaths,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        data: {
+          changedPaths: [],
+          stdout: "",
+          stderr: message,
+          checkOnly: input.checkOnly,
+          format: "codex",
+        },
+        summary: `Patch failed: ${message}`,
+        error: message,
+        durationMs: Date.now() - started,
+        artifacts: [],
+      };
+    }
   }
 
   async checkPermissions(_input: ApplyPatchInput, _context: ToolCallContext): Promise<PermissionCheckResult> {
@@ -84,4 +134,122 @@ function extractPatchPaths(patch: string): string[] {
     }
   }
   return [...paths];
+}
+
+type CodexPatchOperation =
+  | { type: "add"; filePath: string; content: string }
+  | { type: "update"; filePath: string; hunks: Array<{ oldText: string; newText: string }> };
+
+function parseCodexPatch(patch: string): CodexPatchOperation[] {
+  const lines = patch.split("\n");
+  const operations: CodexPatchOperation[] = [];
+  let i = 0;
+  if (lines[i]?.trim() !== "*** Begin Patch") {
+    throw new Error("Codex patch must start with *** Begin Patch");
+  }
+  i++;
+
+  while (i < lines.length) {
+    const line = lines[i]?.trimEnd() ?? "";
+    if (line === "*** End Patch") break;
+    if (line.startsWith("*** Add File: ")) {
+      const filePath = line.slice("*** Add File: ".length).trim();
+      i++;
+      const contentLines: string[] = [];
+      while (i < lines.length && !lines[i]!.startsWith("*** ")) {
+        const contentLine = lines[i]!;
+        if (!contentLine.startsWith("+")) throw new Error(`Invalid add-file line for ${filePath}: ${contentLine}`);
+        contentLines.push(contentLine.slice(1));
+        i++;
+      }
+      operations.push({ type: "add", filePath, content: contentLines.join("\n") + "\n" });
+      continue;
+    }
+    if (line.startsWith("*** Update File: ")) {
+      const filePath = line.slice("*** Update File: ".length).trim();
+      i++;
+      const hunks: Array<{ oldText: string; newText: string }> = [];
+      let oldLines: string[] = [];
+      let newLines: string[] = [];
+      const flush = () => {
+        if (oldLines.length === 0 && newLines.length === 0) return;
+        hunks.push({ oldText: oldLines.join("\n") + "\n", newText: newLines.join("\n") + "\n" });
+        oldLines = [];
+        newLines = [];
+      };
+      while (i < lines.length && !lines[i]!.startsWith("*** ")) {
+        const hunkLine = lines[i]!;
+        if (hunkLine.startsWith("@@")) {
+          flush();
+        } else if (hunkLine.startsWith("-")) {
+          oldLines.push(hunkLine.slice(1));
+        } else if (hunkLine.startsWith("+")) {
+          newLines.push(hunkLine.slice(1));
+        } else if (hunkLine.startsWith(" ")) {
+          oldLines.push(hunkLine.slice(1));
+          newLines.push(hunkLine.slice(1));
+        } else if (hunkLine.trim() !== "") {
+          throw new Error(`Invalid update-file line for ${filePath}: ${hunkLine}`);
+        }
+        i++;
+      }
+      flush();
+      if (hunks.length === 0) throw new Error(`No update hunks found for ${filePath}`);
+      operations.push({ type: "update", filePath, hunks });
+      continue;
+    }
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+    throw new Error(`Unsupported Codex patch operation: ${line}`);
+  }
+
+  if (operations.length === 0) throw new Error("No patch operations found");
+  return operations;
+}
+
+async function validateCodexPatchOperation(operation: CodexPatchOperation, cwd: string): Promise<void> {
+  const target = resolveWorkspacePath(cwd, operation.filePath);
+  if (operation.type === "add") {
+    try {
+      await fsp.access(target);
+      throw new Error(`File already exists: ${operation.filePath}`);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+    return;
+  }
+  const current = await fsp.readFile(target, "utf-8");
+  for (const hunk of operation.hunks) {
+    if (!current.includes(hunk.oldText)) {
+      throw new Error(`Patch context not found in ${operation.filePath}: ${hunk.oldText.trim()}`);
+    }
+  }
+}
+
+async function applyCodexPatchOperation(operation: CodexPatchOperation, cwd: string): Promise<void> {
+  const target = resolveWorkspacePath(cwd, operation.filePath);
+  if (operation.type === "add") {
+    await fsp.mkdir(path.dirname(target), { recursive: true });
+    await fsp.writeFile(target, operation.content, "utf-8");
+    return;
+  }
+  let current = await fsp.readFile(target, "utf-8");
+  for (const hunk of operation.hunks) {
+    if (!current.includes(hunk.oldText)) {
+      throw new Error(`Patch context not found in ${operation.filePath}: ${hunk.oldText.trim()}`);
+    }
+    current = current.replace(hunk.oldText, hunk.newText);
+  }
+  await fsp.writeFile(target, current, "utf-8");
+}
+
+function resolveWorkspacePath(cwd: string, filePath: string): string {
+  const resolvedCwd = path.resolve(cwd);
+  const resolved = path.resolve(resolvedCwd, filePath);
+  if (resolved !== resolvedCwd && !resolved.startsWith(`${resolvedCwd}${path.sep}`)) {
+    throw new Error(`Patch path escapes workspace: ${filePath}`);
+  }
+  return resolved;
 }

--- a/src/tools/fs/ApplyPatchTool/__tests__/ApplyPatchTool.test.ts
+++ b/src/tools/fs/ApplyPatchTool/__tests__/ApplyPatchTool.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ApplyPatchTool } from "../ApplyPatchTool.js";
+import type { ToolCallContext } from "../../../types.js";
+
+function makeContext(cwd: string): ToolCallContext {
+  return {
+    cwd,
+    goalId: "goal-1",
+    trustBalance: 0,
+    preApproved: true,
+    approvalFn: async () => false,
+  };
+}
+
+describe("ApplyPatchTool", () => {
+  it("applies Codex add-file patches", async () => {
+    const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "apply-patch-add-"));
+    const tool = new ApplyPatchTool();
+
+    const result = await tool.call({
+      patch: [
+        "*** Begin Patch",
+        "*** Add File: result.txt",
+        "+real-dogfood-ok",
+        "*** End Patch",
+        "",
+      ].join("\n"),
+      checkOnly: false,
+    }, makeContext(cwd));
+
+    expect(result.success).toBe(true);
+    expect(await fsp.readFile(path.join(cwd, "result.txt"), "utf-8")).toBe("real-dogfood-ok\n");
+    await fsp.rm(cwd, { recursive: true, force: true });
+  });
+
+  it("applies Codex update-file patches", async () => {
+    const cwd = await fsp.mkdtemp(path.join(os.tmpdir(), "apply-patch-update-"));
+    await fsp.writeFile(path.join(cwd, "settings.txt"), "mode=dogfood\nenabled=false\n", "utf-8");
+    const tool = new ApplyPatchTool();
+
+    const result = await tool.call({
+      patch: [
+        "*** Begin Patch",
+        "*** Update File: settings.txt",
+        "@@",
+        "-enabled=false",
+        "+enabled=true",
+        "*** End Patch",
+        "",
+      ].join("\n"),
+      checkOnly: false,
+    }, makeContext(cwd));
+
+    expect(result.success).toBe(true);
+    expect(await fsp.readFile(path.join(cwd, "settings.txt"), "utf-8")).toBe("mode=dogfood\nenabled=true\n");
+    await fsp.rm(cwd, { recursive: true, force: true });
+  });
+});

--- a/src/tools/fs/GrepTool/GrepTool.ts
+++ b/src/tools/fs/GrepTool/GrepTool.ts
@@ -37,7 +37,7 @@ export class GrepTool implements ITool<GrepInput, string> {
 
   async call(input: GrepInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
-    const searchPath = input.path ?? context.cwd;
+    const searchPath = input.path ?? ".";
     try {
       const args: string[] = ["--no-heading"];
       if (input.caseInsensitive) args.push("-i");
@@ -57,7 +57,7 @@ export class GrepTool implements ITool<GrepInput, string> {
       args.push("--max-count", String(input.limit));
       args.push(input.pattern, searchPath);
 
-      const result = await execFileNoThrow("rg", args, { timeoutMs: 30_000 });
+      const result = await execFileNoThrow("rg", args, { cwd: context.cwd, timeoutMs: 30_000 });
       let output = result.stdout.trim();
       if (
         input.outputMode === "content" &&

--- a/src/tools/fs/GrepTool/__tests__/GrepTool.test.ts
+++ b/src/tools/fs/GrepTool/__tests__/GrepTool.test.ts
@@ -87,6 +87,15 @@ describe("GrepTool", () => {
     expect(output).toContain("foo");
   });
 
+  it.skipIf(!HAS_RG)("uses context cwd when path is relative", async () => {
+    const result = await tool.call(
+      { pattern: "foo", path: ".", glob: "alpha.ts", outputMode: "content", limit: 250, caseInsensitive: false },
+      makeContext(tmpDir)
+    );
+    expect(result.success).toBe(true);
+    expect(result.data).toContain("foo");
+  });
+
   it.skipIf(!HAS_RG)("count mode returns match counts per file", async () => {
     const result = await tool.call(
       { pattern: "hello", outputMode: "count", limit: 250, caseInsensitive: false },

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,4 +6,18 @@ export { ToolPermissionManager } from "./permission.js";
 export type { PermissionManagerDeps, PermissionRule } from "./permission.js";
 export { ConcurrencyController } from "./concurrency.js";
 export { createBuiltinTools } from "./builtin/index.js";
+export type { BuiltinToolDeps } from "./builtin/index.js";
+export {
+  GitHubReadTool,
+  GitHubPrCreateTool,
+  McpListToolsTool,
+  McpCallToolTool,
+  ProcessSessionManager,
+  ProcessSessionStartTool,
+  ProcessSessionReadTool,
+  ProcessSessionWriteTool,
+  ProcessSessionStopTool,
+  ProcessSessionListTool,
+  defaultProcessSessionManager,
+} from "./builtin/index.js";
 export * from "./types.js";

--- a/src/tools/network/GitHubCliTool/GitHubCliTool.ts
+++ b/src/tools/network/GitHubCliTool/GitHubCliTool.ts
@@ -1,0 +1,273 @@
+import { z } from "zod";
+import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../types.js";
+import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
+
+const MAX_OUTPUT_CHARS = 20_000;
+const SAFE_REPO_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+export const GitHubReadInputSchema = z.object({
+  action: z.enum([
+    "repo_view",
+    "pr_view",
+    "pr_checks",
+    "pr_diff",
+    "pr_comments",
+    "run_list",
+    "run_view",
+    "run_logs",
+    "issue_view",
+  ]),
+  repo: z.string().regex(SAFE_REPO_RE, "repo must be owner/name").optional(),
+  pr: z.number().int().positive().optional(),
+  issue: z.number().int().positive().optional(),
+  run_id: z.union([z.string().min(1), z.number().int().positive()]).optional(),
+  limit: z.number().int().min(1).max(100).default(20),
+  patch: z.boolean().default(true),
+  maxChars: z.number().int().min(100).max(100_000).default(MAX_OUTPUT_CHARS),
+  timeoutMs: z.number().int().min(1_000).max(120_000).default(30_000),
+});
+export type GitHubReadInput = z.infer<typeof GitHubReadInputSchema>;
+
+export const GitHubPrCreateInputSchema = z.object({
+  repo: z.string().regex(SAFE_REPO_RE, "repo must be owner/name").optional(),
+  title: z.string().min(1).max(300),
+  body: z.string().max(20_000).default(""),
+  base: z.string().min(1).max(200).optional(),
+  head: z.string().min(1).max(200).optional(),
+  draft: z.boolean().default(true),
+  fill: z.boolean().default(false),
+  timeoutMs: z.number().int().min(1_000).max(120_000).default(30_000),
+});
+export type GitHubPrCreateInput = z.infer<typeof GitHubPrCreateInputSchema>;
+
+export interface GitHubCliOutput {
+  command: string;
+  args: string[];
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+export class GitHubReadTool implements ITool<GitHubReadInput, GitHubCliOutput> {
+  readonly metadata: ToolMetadata = {
+    name: "github_read",
+    aliases: ["gh_read", "github_pr_read", "github_ci_read"],
+    permissionLevel: "read_only",
+    isReadOnly: true,
+    isDestructive: false,
+    shouldDefer: true,
+    alwaysLoad: false,
+    maxConcurrency: 3,
+    maxOutputChars: MAX_OUTPUT_CHARS,
+    tags: ["github", "pr", "ci", "network", "agentloop"],
+  };
+
+  readonly inputSchema = GitHubReadInputSchema;
+
+  description(): string {
+    return "Read GitHub repository, PR, issue, and Actions status through the gh CLI. Requires gh to be installed and authenticated.";
+  }
+
+  async call(input: GitHubReadInput, context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    const validationError = validateGitHubReadInput(input);
+    if (validationError) {
+      return failure(validationError, startTime);
+    }
+
+    const args = buildGitHubReadArgs(input);
+    const result = await execFileNoThrow("gh", args, { cwd: context.cwd, timeoutMs: input.timeoutMs });
+    const stdout = truncate(result.stdout, input.maxChars);
+    const stderr = truncate(result.stderr, input.maxChars);
+    const data: GitHubCliOutput = {
+      command: "gh",
+      args,
+      stdout,
+      stderr,
+      exitCode: result.exitCode,
+    };
+    const succeeded = result.exitCode === 0;
+
+    return {
+      success: succeeded,
+      data,
+      summary: succeeded
+        ? `gh ${args.slice(0, 3).join(" ")} succeeded${stdout ? `: ${stdout.slice(0, 200)}` : ""}`
+        : `gh ${args.slice(0, 3).join(" ")} failed: ${stderr.slice(0, 300)}`,
+      error: succeeded ? undefined : stderr.slice(0, 500),
+      durationMs: Date.now() - startTime,
+      artifacts: input.repo ? [`github:${input.repo}`] : undefined,
+    };
+  }
+
+  async checkPermissions(input: GitHubReadInput): Promise<PermissionCheckResult> {
+    const validationError = validateGitHubReadInput(input);
+    if (validationError) {
+      return { status: "denied", reason: validationError };
+    }
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(_input: GitHubReadInput): boolean {
+    return true;
+  }
+}
+
+export class GitHubPrCreateTool implements ITool<GitHubPrCreateInput, GitHubCliOutput> {
+  readonly metadata: ToolMetadata = {
+    name: "github_pr_create",
+    aliases: ["gh_pr_create", "create_github_pr"],
+    permissionLevel: "write_remote",
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: true,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: MAX_OUTPUT_CHARS,
+    tags: ["github", "pr", "network", "agentloop"],
+  };
+
+  readonly inputSchema = GitHubPrCreateInputSchema;
+
+  description(): string {
+    return "Create a GitHub pull request through the gh CLI. Defaults to draft PRs.";
+  }
+
+  async call(input: GitHubPrCreateInput, context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    const args = buildGitHubPrCreateArgs(input);
+    const result = await execFileNoThrow("gh", args, { cwd: context.cwd, timeoutMs: input.timeoutMs });
+    const stdout = truncate(result.stdout, MAX_OUTPUT_CHARS);
+    const stderr = truncate(result.stderr, MAX_OUTPUT_CHARS);
+    const data: GitHubCliOutput = {
+      command: "gh",
+      args,
+      stdout,
+      stderr,
+      exitCode: result.exitCode,
+    };
+    const succeeded = result.exitCode === 0;
+
+    return {
+      success: succeeded,
+      data,
+      summary: succeeded
+        ? `GitHub PR created${stdout ? `: ${stdout.slice(0, 200)}` : ""}`
+        : `GitHub PR creation failed: ${stderr.slice(0, 300)}`,
+      error: succeeded ? undefined : stderr.slice(0, 500),
+      durationMs: Date.now() - startTime,
+      artifacts: input.repo ? [`github:${input.repo}`] : undefined,
+    };
+  }
+
+  async checkPermissions(input: GitHubPrCreateInput): Promise<PermissionCheckResult> {
+    if (input.fill && input.body.trim().length > 0) {
+      return { status: "denied", reason: "Use either fill=true or an explicit body, not both." };
+    }
+    return { status: "needs_approval", reason: "Creating a GitHub pull request changes remote repository state." };
+  }
+
+  isConcurrencySafe(_input: GitHubPrCreateInput): boolean {
+    return false;
+  }
+}
+
+function validateGitHubReadInput(input: GitHubReadInput): string | null {
+  if ((input.action === "run_view" || input.action === "run_logs") && input.run_id === undefined) {
+    return `${input.action} requires run_id`;
+  }
+  if (input.action === "issue_view" && input.issue === undefined) {
+    return "issue_view requires issue";
+  }
+  return null;
+}
+
+function buildGitHubReadArgs(input: GitHubReadInput): string[] {
+  switch (input.action) {
+    case "repo_view": {
+      const args = ["repo", "view"];
+      if (input.repo) args.push(input.repo);
+      args.push("--json", "nameWithOwner,description,url,defaultBranchRef,isPrivate,viewerPermission");
+      return args;
+    }
+    case "pr_view": {
+      return withRepo([
+        "pr", "view", ...optionalNumber(input.pr),
+        "--json", "number,title,state,author,headRefName,baseRefName,url,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup",
+      ], input.repo);
+    }
+    case "pr_checks": {
+      return withRepo(["pr", "checks", ...optionalNumber(input.pr)], input.repo);
+    }
+    case "pr_diff": {
+      return withRepo(["pr", "diff", ...optionalNumber(input.pr), ...(input.patch ? ["--patch"] : [])], input.repo);
+    }
+    case "pr_comments": {
+      return withRepo([
+        "pr", "view", ...optionalNumber(input.pr),
+        "--comments",
+        "--json", "number,title,url,comments,reviews",
+      ], input.repo);
+    }
+    case "run_list": {
+      return withRepo([
+        "run", "list",
+        "--limit", String(input.limit),
+        "--json", "databaseId,displayTitle,status,conclusion,workflowName,headBranch,event,createdAt,url",
+      ], input.repo);
+    }
+    case "run_view": {
+      return withRepo([
+        "run", "view", String(input.run_id),
+        "--json", "databaseId,displayTitle,status,conclusion,workflowName,headBranch,headSha,event,createdAt,updatedAt,url",
+      ], input.repo);
+    }
+    case "run_logs": {
+      return withRepo(["run", "view", String(input.run_id), "--log-failed"], input.repo);
+    }
+    case "issue_view": {
+      return withRepo([
+        "issue", "view", String(input.issue),
+        "--comments",
+        "--json", "number,title,state,author,body,comments,url",
+      ], input.repo);
+    }
+  }
+}
+
+function buildGitHubPrCreateArgs(input: GitHubPrCreateInput): string[] {
+  const args = ["pr", "create", "--title", input.title];
+  if (input.fill) {
+    args.push("--fill");
+  } else {
+    args.push("--body", input.body);
+  }
+  if (input.base) args.push("--base", input.base);
+  if (input.head) args.push("--head", input.head);
+  if (input.draft) args.push("--draft");
+  return withRepo(args, input.repo);
+}
+
+function optionalNumber(value: number | undefined): string[] {
+  return value === undefined ? [] : [String(value)];
+}
+
+function withRepo(args: string[], repo: string | undefined): string[] {
+  if (!repo) return args;
+  return [...args, "--repo", repo];
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}\n[truncated ${value.length - maxChars} chars]`;
+}
+
+function failure(message: string, startTime: number): ToolResult {
+  return {
+    success: false,
+    data: null,
+    summary: message,
+    error: message,
+    durationMs: Date.now() - startTime,
+  };
+}

--- a/src/tools/network/GitHubCliTool/__tests__/GitHubCliTool.test.ts
+++ b/src/tools/network/GitHubCliTool/__tests__/GitHubCliTool.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { GitHubPrCreateInputSchema, GitHubPrCreateTool, GitHubReadInputSchema, GitHubReadTool } from "../GitHubCliTool.js";
+import type { ToolCallContext } from "../../../types.js";
+import * as execMod from "../../../../base/utils/execFileNoThrow.js";
+
+const makeContext = (cwd = "/tmp"): ToolCallContext => ({
+  goalId: "goal-1",
+  cwd,
+  trustBalance: 0,
+  preApproved: false,
+  approvalFn: async () => false,
+});
+
+describe("GitHubReadTool", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("builds gh pr view args with repo and JSON fields", async () => {
+    const tool = new GitHubReadTool();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValueOnce({
+      stdout: "{\"number\":12}",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const input = GitHubReadInputSchema.parse({ action: "pr_view", pr: 12, repo: "owner/repo" });
+    const result = await tool.call(input, makeContext("/repo"));
+
+    expect(result.success).toBe(true);
+    expect(execSpy).toHaveBeenCalledWith(
+      "gh",
+      expect.arrayContaining(["pr", "view", "12", "--repo", "owner/repo"]),
+      expect.objectContaining({ cwd: "/repo", timeoutMs: 30_000 }),
+    );
+  });
+
+  it("denies run log reads without run_id", async () => {
+    const tool = new GitHubReadTool();
+    const input = GitHubReadInputSchema.parse({ action: "run_logs" });
+    const permission = await tool.checkPermissions(input);
+    expect(permission.status).toBe("denied");
+  });
+});
+
+describe("GitHubPrCreateTool", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requires approval because it writes remote GitHub state", async () => {
+    const tool = new GitHubPrCreateTool();
+    const input = GitHubPrCreateInputSchema.parse({ title: "Add feature", body: "Body" });
+    const permission = await tool.checkPermissions(input);
+    expect(permission.status).toBe("needs_approval");
+  });
+
+  it("creates draft PRs by default through gh", async () => {
+    const tool = new GitHubPrCreateTool();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValueOnce({
+      stdout: "https://github.com/owner/repo/pull/1",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const input = GitHubPrCreateInputSchema.parse({
+      repo: "owner/repo",
+      title: "Add feature",
+      body: "Body",
+      base: "main",
+      head: "feature",
+    });
+    const result = await tool.call(input, makeContext("/repo"));
+
+    expect(result.success).toBe(true);
+    expect(execSpy).toHaveBeenCalledWith(
+      "gh",
+      [
+        "pr", "create",
+        "--title", "Add feature",
+        "--body", "Body",
+        "--base", "main",
+        "--head", "feature",
+        "--draft",
+        "--repo", "owner/repo",
+      ],
+      expect.objectContaining({ cwd: "/repo" }),
+    );
+  });
+
+  it("denies fill=true with explicit body", async () => {
+    const tool = new GitHubPrCreateTool();
+    const input = GitHubPrCreateInputSchema.parse({ title: "Add feature", body: "Body", fill: true });
+    const permission = await tool.checkPermissions(input);
+    expect(permission.status).toBe("denied");
+  });
+});

--- a/src/tools/network/McpStdioTool/McpStdioTool.ts
+++ b/src/tools/network/McpStdioTool/McpStdioTool.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport, getDefaultEnvironment } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../types.js";
+
+const MAX_OUTPUT_CHARS = 20_000;
+
+const McpServerProcessSchema = z.object({
+  command: z.string().min(1),
+  args: z.array(z.string()).default([]),
+  cwd: z.string().optional(),
+  env: z.record(z.string()).optional(),
+  timeoutMs: z.number().int().min(1_000).max(120_000).default(30_000),
+});
+
+export const McpListToolsInputSchema = McpServerProcessSchema;
+export type McpListToolsInput = z.infer<typeof McpListToolsInputSchema>;
+
+export const McpCallToolInputSchema = McpServerProcessSchema.extend({
+  tool_name: z.string().min(1),
+  arguments: z.record(z.unknown()).default({}),
+});
+export type McpCallToolInput = z.infer<typeof McpCallToolInputSchema>;
+
+export class McpListToolsTool implements ITool<McpListToolsInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "mcp_list_tools",
+    aliases: ["list_mcp_tools"],
+    permissionLevel: "read_metrics",
+    isReadOnly: true,
+    isDestructive: false,
+    shouldDefer: true,
+    alwaysLoad: false,
+    maxConcurrency: 2,
+    maxOutputChars: MAX_OUTPUT_CHARS,
+    tags: ["mcp", "tool", "external", "agentloop"],
+  };
+
+  readonly inputSchema = McpListToolsInputSchema;
+
+  description(): string {
+    return "Start an MCP stdio server process, list its tools, then close it.";
+  }
+
+  async call(input: McpListToolsInput, context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    try {
+      const data = await withMcpClient(input, context.cwd, async (client) => client.listTools({}, { timeout: input.timeoutMs }));
+      return {
+        success: true,
+        data,
+        summary: `Listed ${(data as { tools?: unknown[] }).tools?.length ?? 0} MCP tool(s)`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return failureResult(`MCP list tools failed: ${(err as Error).message}`, startTime);
+    }
+  }
+
+  async checkPermissions(_input: McpListToolsInput): Promise<PermissionCheckResult> {
+    return { status: "needs_approval", reason: "Listing MCP tools starts an external server process." };
+  }
+
+  isConcurrencySafe(_input: McpListToolsInput): boolean {
+    return true;
+  }
+}
+
+export class McpCallToolTool implements ITool<McpCallToolInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "mcp_call_tool",
+    aliases: ["call_mcp_tool"],
+    permissionLevel: "write_remote",
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: true,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: MAX_OUTPUT_CHARS,
+    tags: ["mcp", "tool", "external", "agentloop"],
+  };
+
+  readonly inputSchema = McpCallToolInputSchema;
+
+  description(): string {
+    return "Start an MCP stdio server process, call one tool, then close it. The called tool may have side effects.";
+  }
+
+  async call(input: McpCallToolInput, context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    try {
+      const data = await withMcpClient(input, context.cwd, async (client) =>
+        client.callTool({ name: input.tool_name, arguments: input.arguments }, undefined, { timeout: input.timeoutMs })
+      );
+      return {
+        success: true,
+        data,
+        summary: `MCP tool ${input.tool_name} completed`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return failureResult(`MCP tool ${input.tool_name} failed: ${(err as Error).message}`, startTime);
+    }
+  }
+
+  async checkPermissions(input: McpCallToolInput): Promise<PermissionCheckResult> {
+    return { status: "needs_approval", reason: `Calling MCP tool ${input.tool_name} can change external state.` };
+  }
+
+  isConcurrencySafe(_input: McpCallToolInput): boolean {
+    return false;
+  }
+}
+
+async function withMcpClient<T>(
+  input: McpListToolsInput,
+  defaultCwd: string,
+  fn: (client: Client) => Promise<T>,
+): Promise<T> {
+  const transport = new StdioClientTransport({
+    command: input.command,
+    args: input.args,
+    cwd: input.cwd ?? defaultCwd,
+    env: input.env ? { ...getDefaultEnvironment(), ...input.env } : undefined,
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "pulseed-mcp-bridge", version: "0.1.0" }, { capabilities: {} });
+  try {
+    await client.connect(transport, { timeout: input.timeoutMs });
+    return await fn(client);
+  } finally {
+    await transport.close().catch(() => undefined);
+  }
+}
+
+function failureResult(message: string, startTime: number): ToolResult {
+  return {
+    success: false,
+    data: null,
+    summary: message,
+    error: message,
+    durationMs: Date.now() - startTime,
+  };
+}

--- a/src/tools/network/McpStdioTool/__tests__/McpStdioTool.test.ts
+++ b/src/tools/network/McpStdioTool/__tests__/McpStdioTool.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { McpCallToolInputSchema, McpCallToolTool, McpListToolsInputSchema, McpListToolsTool } from "../McpStdioTool.js";
+
+describe("MCP stdio tools", () => {
+  it("requires approval before starting an MCP server for listing", async () => {
+    const tool = new McpListToolsTool();
+    const input = McpListToolsInputSchema.parse({ command: "node", args: ["server.js"] });
+    const permission = await tool.checkPermissions(input);
+    expect(permission.status).toBe("needs_approval");
+  });
+
+  it("requires approval before calling an MCP tool", async () => {
+    const tool = new McpCallToolTool();
+    const input = McpCallToolInputSchema.parse({
+      command: "node",
+      args: ["server.js"],
+      tool_name: "external_tool",
+      arguments: { value: 1 },
+    });
+    const permission = await tool.checkPermissions(input);
+    expect(permission.status).toBe("needs_approval");
+  });
+});

--- a/src/tools/system/ProcessSessionTool/ProcessSessionTool.ts
+++ b/src/tools/system/ProcessSessionTool/ProcessSessionTool.ts
@@ -1,0 +1,440 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../types.js";
+
+const MAX_BUFFER_CHARS = 1_000_000;
+const DEFAULT_MAX_READ_CHARS = 12_000;
+
+export const ProcessSessionStartInputSchema = z.object({
+  command: z.string().min(1),
+  args: z.array(z.string()).default([]),
+  cwd: z.string().optional(),
+  env: z.record(z.string()).optional(),
+  label: z.string().min(1).max(120).optional(),
+});
+export type ProcessSessionStartInput = z.infer<typeof ProcessSessionStartInputSchema>;
+
+export const ProcessSessionReadInputSchema = z.object({
+  session_id: z.string().min(1),
+  maxChars: z.number().int().min(1).max(100_000).default(DEFAULT_MAX_READ_CHARS),
+  waitMs: z.number().int().min(0).max(30_000).default(0),
+  consume: z.boolean().default(true),
+});
+export type ProcessSessionReadInput = z.infer<typeof ProcessSessionReadInputSchema>;
+
+export const ProcessSessionWriteInputSchema = z.object({
+  session_id: z.string().min(1),
+  input: z.string(),
+  appendNewline: z.boolean().default(true),
+});
+export type ProcessSessionWriteInput = z.infer<typeof ProcessSessionWriteInputSchema>;
+
+export const ProcessSessionStopInputSchema = z.object({
+  session_id: z.string().min(1),
+  signal: z.enum(["SIGTERM", "SIGINT", "SIGHUP", "SIGKILL"]).default("SIGTERM"),
+  waitMs: z.number().int().min(0).max(30_000).default(1_000),
+});
+export type ProcessSessionStopInput = z.infer<typeof ProcessSessionStopInputSchema>;
+
+export const ProcessSessionListInputSchema = z.object({
+  includeExited: z.boolean().default(true),
+});
+export type ProcessSessionListInput = z.infer<typeof ProcessSessionListInputSchema>;
+
+export interface ProcessSessionSnapshot {
+  session_id: string;
+  label?: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  pid?: number;
+  running: boolean;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  startedAt: string;
+  exitedAt?: string;
+  bufferedChars: number;
+}
+
+export interface ProcessSessionReadOutput extends ProcessSessionSnapshot {
+  output: string;
+  truncated: boolean;
+}
+
+interface ProcessSessionRecord {
+  id: string;
+  label?: string;
+  command: string;
+  args: string[];
+  cwd: string;
+  child: ChildProcessWithoutNullStreams;
+  startedAt: Date;
+  exitedAt?: Date;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  combined: string;
+  readOffset: number;
+}
+
+export class ProcessSessionManager {
+  private readonly sessions = new Map<string, ProcessSessionRecord>();
+
+  start(input: ProcessSessionStartInput, cwd: string): ProcessSessionSnapshot {
+    const id = randomUUID();
+    const resolvedCwd = input.cwd ?? cwd;
+    const child = spawn(input.command, input.args, {
+      cwd: resolvedCwd,
+      env: input.env ? { ...process.env, ...input.env } : process.env,
+      stdio: "pipe",
+    });
+    const record: ProcessSessionRecord = {
+      id,
+      label: input.label,
+      command: input.command,
+      args: input.args,
+      cwd: resolvedCwd,
+      child,
+      startedAt: new Date(),
+      exitCode: null,
+      signal: null,
+      combined: "",
+      readOffset: 0,
+    };
+
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => this.append(record, String(chunk)));
+    child.stderr.on("data", (chunk) => this.append(record, String(chunk)));
+    child.on("error", (err) => {
+      this.append(record, `[process error] ${err.message}\n`);
+    });
+    child.on("exit", (code, signal) => {
+      record.exitCode = code;
+      record.signal = signal;
+      record.exitedAt = new Date();
+      this.append(record, `[process exited code=${code ?? "null"} signal=${signal ?? "null"}]\n`);
+    });
+
+    this.sessions.set(id, record);
+    return this.snapshot(record);
+  }
+
+  async read(input: ProcessSessionReadInput): Promise<ProcessSessionReadOutput | null> {
+    const record = this.sessions.get(input.session_id);
+    if (!record) return null;
+    if (input.waitMs > 0) {
+      await delay(input.waitMs);
+    }
+    const unread = record.combined.slice(record.readOffset);
+    const truncated = unread.length > input.maxChars;
+    const output = truncated ? unread.slice(0, input.maxChars) : unread;
+    if (input.consume) {
+      record.readOffset += output.length;
+    }
+    return { ...this.snapshot(record), output, truncated };
+  }
+
+  write(input: ProcessSessionWriteInput): ProcessSessionSnapshot | null {
+    const record = this.sessions.get(input.session_id);
+    if (!record || record.child.killed || record.exitCode !== null) return null;
+    record.child.stdin.write(input.appendNewline ? `${input.input}\n` : input.input);
+    return this.snapshot(record);
+  }
+
+  async stop(input: ProcessSessionStopInput): Promise<ProcessSessionSnapshot | null> {
+    const record = this.sessions.get(input.session_id);
+    if (!record) return null;
+    if (record.exitCode === null && !record.child.killed) {
+      record.child.kill(input.signal);
+      if (input.waitMs > 0) {
+        await Promise.race([
+          onceExit(record),
+          delay(input.waitMs),
+        ]);
+      }
+    }
+    return this.snapshot(record);
+  }
+
+  list(includeExited: boolean): ProcessSessionSnapshot[] {
+    return [...this.sessions.values()]
+      .filter((record) => includeExited || record.exitCode === null)
+      .map((record) => this.snapshot(record));
+  }
+
+  async stopAll(): Promise<void> {
+    await Promise.all([...this.sessions.values()].map(async (record) => {
+      if (record.exitCode === null && !record.child.killed) {
+        record.child.kill("SIGTERM");
+        await Promise.race([onceExit(record), delay(500)]);
+      }
+    }));
+  }
+
+  private append(record: ProcessSessionRecord, chunk: string): void {
+    record.combined += chunk;
+    if (record.combined.length <= MAX_BUFFER_CHARS) return;
+    const overflow = record.combined.length - MAX_BUFFER_CHARS;
+    record.combined = record.combined.slice(overflow);
+    record.readOffset = Math.max(0, record.readOffset - overflow);
+  }
+
+  private snapshot(record: ProcessSessionRecord): ProcessSessionSnapshot {
+    return {
+      session_id: record.id,
+      label: record.label,
+      command: record.command,
+      args: record.args,
+      cwd: record.cwd,
+      pid: record.child.pid,
+      running: record.exitCode === null && !record.child.killed,
+      exitCode: record.exitCode,
+      signal: record.signal,
+      startedAt: record.startedAt.toISOString(),
+      exitedAt: record.exitedAt?.toISOString(),
+      bufferedChars: record.combined.length,
+    };
+  }
+}
+
+export const defaultProcessSessionManager = new ProcessSessionManager();
+
+abstract class ProcessSessionBaseTool<TInput, TOutput> implements ITool<TInput, TOutput> {
+  abstract readonly metadata: ToolMetadata;
+  abstract readonly inputSchema: z.ZodType<TInput, z.ZodTypeDef, unknown>;
+
+  constructor(protected readonly manager: ProcessSessionManager = defaultProcessSessionManager) {}
+
+  abstract description(): string;
+  abstract call(input: TInput, context: ToolCallContext): Promise<ToolResult>;
+  abstract checkPermissions(input: TInput, context: ToolCallContext): Promise<PermissionCheckResult>;
+  abstract isConcurrencySafe(input: TInput): boolean;
+}
+
+export class ProcessSessionStartTool extends ProcessSessionBaseTool<ProcessSessionStartInput, ProcessSessionSnapshot> {
+  readonly metadata: ToolMetadata = {
+    name: "process_session_start",
+    aliases: ["start_process_session", "start_session_process"],
+    permissionLevel: "execute",
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: true,
+    alwaysLoad: false,
+    maxConcurrency: 2,
+    maxOutputChars: DEFAULT_MAX_READ_CHARS,
+    tags: ["process", "session", "agentloop", "dev-server"],
+  };
+  readonly inputSchema = ProcessSessionStartInputSchema;
+
+  description(): string {
+    return "Start a persistent process session without a shell. Use for dev servers, watchers, and REPL-like commands.";
+  }
+
+  async call(input: ProcessSessionStartInput, context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    try {
+      const data = this.manager.start(input, context.cwd);
+      return {
+        success: true,
+        data,
+        summary: `Started process session ${data.session_id}${data.pid ? ` (pid ${data.pid})` : ""}: ${data.command} ${data.args.join(" ")}`.trim(),
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return failureResult(`Failed to start process session: ${(err as Error).message}`, startTime);
+    }
+  }
+
+  async checkPermissions(_input: ProcessSessionStartInput): Promise<PermissionCheckResult> {
+    return { status: "needs_approval", reason: "Starting a persistent process can execute arbitrary local code." };
+  }
+
+  isConcurrencySafe(_input: ProcessSessionStartInput): boolean {
+    return false;
+  }
+}
+
+export class ProcessSessionReadTool extends ProcessSessionBaseTool<ProcessSessionReadInput, ProcessSessionReadOutput> {
+  readonly metadata: ToolMetadata = {
+    name: "process_session_read",
+    aliases: ["read_process_session"],
+    permissionLevel: "read_metrics",
+    isReadOnly: true,
+    isDestructive: false,
+    shouldDefer: true,
+    alwaysLoad: false,
+    maxConcurrency: 5,
+    maxOutputChars: DEFAULT_MAX_READ_CHARS,
+    tags: ["process", "session", "agentloop", "dev-server"],
+  };
+  readonly inputSchema = ProcessSessionReadInputSchema;
+
+  description(): string {
+    return "Read buffered output from a persistent process session.";
+  }
+
+  async call(input: ProcessSessionReadInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    const data = await this.manager.read(input);
+    if (!data) {
+      return failureResult(`Process session not found: ${input.session_id}`, startTime);
+    }
+    return {
+      success: true,
+      data,
+      summary: `Read ${data.output.length} chars from process session ${input.session_id}${data.truncated ? " (truncated)" : ""}`,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  async checkPermissions(_input: ProcessSessionReadInput): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(_input: ProcessSessionReadInput): boolean {
+    return true;
+  }
+}
+
+export class ProcessSessionWriteTool extends ProcessSessionBaseTool<ProcessSessionWriteInput, ProcessSessionSnapshot> {
+  readonly metadata: ToolMetadata = {
+    name: "process_session_write",
+    aliases: ["write_process_session"],
+    permissionLevel: "execute",
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: true,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: DEFAULT_MAX_READ_CHARS,
+    tags: ["process", "session", "agentloop", "dev-server"],
+  };
+  readonly inputSchema = ProcessSessionWriteInputSchema;
+
+  description(): string {
+    return "Write stdin to a running persistent process session.";
+  }
+
+  async call(input: ProcessSessionWriteInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    const data = this.manager.write(input);
+    if (!data) {
+      return failureResult(`Process session not found or not running: ${input.session_id}`, startTime);
+    }
+    return {
+      success: true,
+      data,
+      summary: `Wrote stdin to process session ${input.session_id}`,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  async checkPermissions(_input: ProcessSessionWriteInput): Promise<PermissionCheckResult> {
+    return { status: "needs_approval", reason: "Writing stdin to a process can trigger local side effects." };
+  }
+
+  isConcurrencySafe(_input: ProcessSessionWriteInput): boolean {
+    return false;
+  }
+}
+
+export class ProcessSessionStopTool extends ProcessSessionBaseTool<ProcessSessionStopInput, ProcessSessionSnapshot> {
+  readonly metadata: ToolMetadata = {
+    name: "process_session_stop",
+    aliases: ["stop_process_session"],
+    permissionLevel: "execute",
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: true,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: DEFAULT_MAX_READ_CHARS,
+    tags: ["process", "session", "agentloop", "dev-server"],
+  };
+  readonly inputSchema = ProcessSessionStopInputSchema;
+
+  description(): string {
+    return "Stop a persistent process session.";
+  }
+
+  async call(input: ProcessSessionStopInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    const data = await this.manager.stop(input);
+    if (!data) {
+      return failureResult(`Process session not found: ${input.session_id}`, startTime);
+    }
+    return {
+      success: true,
+      data,
+      summary: `Stopped process session ${input.session_id}`,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  async checkPermissions(_input: ProcessSessionStopInput): Promise<PermissionCheckResult> {
+    return { status: "needs_approval", reason: "Stopping a process changes local runtime state." };
+  }
+
+  isConcurrencySafe(_input: ProcessSessionStopInput): boolean {
+    return false;
+  }
+}
+
+export class ProcessSessionListTool extends ProcessSessionBaseTool<ProcessSessionListInput, ProcessSessionSnapshot[]> {
+  readonly metadata: ToolMetadata = {
+    name: "process_session_list",
+    aliases: ["list_process_sessions"],
+    permissionLevel: "read_metrics",
+    isReadOnly: true,
+    isDestructive: false,
+    shouldDefer: true,
+    alwaysLoad: false,
+    maxConcurrency: 5,
+    maxOutputChars: DEFAULT_MAX_READ_CHARS,
+    tags: ["process", "session", "agentloop", "dev-server"],
+  };
+  readonly inputSchema = ProcessSessionListInputSchema;
+
+  description(): string {
+    return "List persistent process sessions started by this PulSeed process.";
+  }
+
+  async call(input: ProcessSessionListInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    const data = this.manager.list(input.includeExited);
+    return {
+      success: true,
+      data,
+      summary: `Found ${data.length} process session(s)`,
+      durationMs: Date.now() - startTime,
+    };
+  }
+
+  async checkPermissions(_input: ProcessSessionListInput): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(_input: ProcessSessionListInput): boolean {
+    return true;
+  }
+}
+
+function onceExit(record: ProcessSessionRecord): Promise<void> {
+  if (record.exitCode !== null) return Promise.resolve();
+  return new Promise((resolve) => record.child.once("exit", () => resolve()));
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function failureResult(message: string, startTime: number): ToolResult {
+  return {
+    success: false,
+    data: null,
+    summary: message,
+    error: message,
+    durationMs: Date.now() - startTime,
+  };
+}

--- a/src/tools/system/ProcessSessionTool/__tests__/ProcessSessionTool.test.ts
+++ b/src/tools/system/ProcessSessionTool/__tests__/ProcessSessionTool.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  ProcessSessionListTool,
+  ProcessSessionManager,
+  ProcessSessionReadTool,
+  ProcessSessionStartTool,
+  ProcessSessionStopTool,
+  ProcessSessionWriteTool,
+  type ProcessSessionSnapshot,
+  type ProcessSessionReadOutput,
+} from "../ProcessSessionTool.js";
+import type { ToolCallContext } from "../../../types.js";
+
+const makeContext = (cwd = process.cwd()): ToolCallContext => ({
+  goalId: "goal-1",
+  cwd,
+  trustBalance: 0,
+  preApproved: false,
+  approvalFn: async () => false,
+});
+
+async function readUntil(
+  readTool: ProcessSessionReadTool,
+  sessionId: string,
+  expected: string,
+): Promise<string> {
+  let output = "";
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const read = await readTool.call({
+      session_id: sessionId,
+      waitMs: 100,
+      maxChars: 1000,
+      consume: true,
+    }, makeContext());
+    output += (read.data as ProcessSessionReadOutput).output;
+    if (output.includes(expected)) return output;
+  }
+  return output;
+}
+
+describe("ProcessSessionTool", () => {
+  const manager = new ProcessSessionManager();
+  const startTool = new ProcessSessionStartTool(manager);
+  const readTool = new ProcessSessionReadTool(manager);
+  const writeTool = new ProcessSessionWriteTool(manager);
+  const stopTool = new ProcessSessionStopTool(manager);
+  const listTool = new ProcessSessionListTool(manager);
+
+  afterEach(async () => {
+    await manager.stopAll();
+  });
+
+  it("starts, reads, lists, and stops a persistent process", async () => {
+    const start = await startTool.call({
+      command: process.execPath,
+      args: ["-e", "console.log('ready'); setInterval(() => {}, 1000);"],
+      label: "test-node",
+    }, makeContext());
+    expect(start.success).toBe(true);
+    const started = start.data as ProcessSessionSnapshot;
+    expect(started.session_id).toBeTruthy();
+    expect(started.running).toBe(true);
+
+    const output = await readUntil(readTool, started.session_id, "ready");
+    expect(output).toContain("ready");
+
+    const list = await listTool.call({ includeExited: false }, makeContext());
+    expect((list.data as ProcessSessionSnapshot[]).map((session) => session.session_id)).toContain(started.session_id);
+
+    const stop = await stopTool.call({ session_id: started.session_id, signal: "SIGTERM", waitMs: 500 }, makeContext());
+    expect(stop.success).toBe(true);
+    expect((stop.data as ProcessSessionSnapshot).running).toBe(false);
+  });
+
+  it("writes stdin to a running session", async () => {
+    const start = await startTool.call({
+      command: process.execPath,
+      args: ["-e", "process.stdin.on('data', (chunk) => { console.log('echo:' + chunk.toString().trim()); });"],
+    }, makeContext());
+    const started = start.data as ProcessSessionSnapshot;
+
+    const write = await writeTool.call({ session_id: started.session_id, input: "hello", appendNewline: true }, makeContext());
+    expect(write.success).toBe(true);
+
+    const output = await readUntil(readTool, started.session_id, "echo:hello");
+    expect(output).toContain("echo:hello");
+  });
+
+  it("uses approval gates for process start/write/stop", async () => {
+    await expect(startTool.checkPermissions({
+      command: process.execPath,
+      args: [],
+    })).resolves.toMatchObject({ status: "needs_approval" });
+    await expect(writeTool.checkPermissions({
+      session_id: "session",
+      input: "x",
+      appendNewline: true,
+    })).resolves.toMatchObject({ status: "needs_approval" });
+    await expect(stopTool.checkPermissions({
+      session_id: "session",
+      signal: "SIGTERM",
+      waitMs: 1_000,
+    })).resolves.toMatchObject({ status: "needs_approval" });
+  });
+});

--- a/src/tools/system/SleepTool/__tests__/SleepTool.test.ts
+++ b/src/tools/system/SleepTool/__tests__/SleepTool.test.ts
@@ -24,7 +24,7 @@ describe("SleepTool", () => {
     expect(result.success).toBe(true);
     const data = result.data as { sleptMs: number };
     expect(data.sleptMs).toBeGreaterThanOrEqual(durationMs - 5); // timer precision tolerance
-    expect(data.sleptMs).toBeLessThan(durationMs + 50);
+    expect(data.sleptMs).toBeLessThan(durationMs + 250);
   });
 
   it("caps at max duration (300000ms)", () => {


### PR DESCRIPTION
## Summary
- Add GitHub CLI-backed tools for PR, issue, and Actions inspection plus draft PR creation
- Add persistent process session tools for dev servers/watchers/REPL-like workflows
- Add MCP stdio list/call bridge tools and wire the native AgentLoop tool profile/doctor coverage
- Harden native AgentLoop dogfood, OpenAI Responses replay, grep cwd handling, Codex patch support, and related flaky tests

## Validation
- npm run check:docs
- npm run build
- npm run typecheck
- npx vitest run
- focused tests for GitHub/MCP/process session and dogfood paths

## Notes
- Browser automation is intentionally not reimplemented here; external CLI integration remains the preferred path.