### PR TITLE
[codex] release 0.4.6

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,9 +1,7 @@
 name: Publish to npm
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_dispatch:
 
 jobs:
   build-and-publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.4.6] - 2026-04-13
+
+### Added
+- Added GitHub CLI-backed agent tools for PR, issue, Actions, and draft PR workflows (#655)
+- Added persistent process session tools for dev servers, watchers, and REPL-style agent workflows (#655)
+- Added MCP stdio bridge tools for listing and calling external MCP tools from the native tool registry (#655)
+- Added native AgentLoop dogfood benchmarking and a real-model dogfood runner for tool-using task execution (#655)
+
+### Changed
+- Switched npm publishing workflow to manual dispatch so release tags can be created without automatically publishing to npm
+- Expanded native AgentLoop tool profile and doctor coverage for GitHub, MCP, and process session tools (#655)
+- Bumped the package version to `0.4.6`
+
+### Fixed
+- Fixed OpenAI Responses AgentLoop replay and tool schema handling for native tool calls (#655)
+- Fixed GrepTool cwd handling, Codex-style apply_patch support, and verification command classification for grep (#655)
+- Hardened slow and flaky tests around memory lifecycle, daemon runner, schedules, process sessions, and A2A polling (#655)
+
 ## [0.4.5] - 2026-04-11
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pulseed",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pulseed",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulseed",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "AI agent orchestrator that gives existing agents the drive to persist — set a goal, and PulSeed observes, delegates, verifies, and loops until done.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump npm package metadata to 0.4.6
- add the 0.4.6 changelog entry for the agent workflow tool release
- make the npm publish workflow manual-only so creating v0.4.6 does not automatically publish to npm

## Validation
- npm run check:docs
- npm run build
- npm run typecheck
- npm test
- npm pack --dry-run --json

## Release note
npm publish is intentionally left for manual execution outside this PR.
