### PR TITLE
[codex] improve setup wizard UX and migration import

### DIFF
--- a/src/interface/cli/__tests__/cli-daemon-start.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-start.test.ts
@@ -246,6 +246,7 @@ describe("cmdStart", () => {
     expect(daemonRunnerArgs[0]).toEqual(
       expect.objectContaining({
         eventServer: eventServerInstances[0],
+        gateway: expect.any(Object),
         reportingEngine: expect.any(Object),
       })
     );

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -11,6 +11,7 @@ const cancelMock = vi.fn();
 const logWarnMock = vi.fn();
 const logInfoMock = vi.fn();
 const logErrorMock = vi.fn();
+const logSuccessMock = vi.fn();
 
 vi.mock("@clack/prompts", () => ({
   confirm: confirmMock,
@@ -24,6 +25,7 @@ vi.mock("@clack/prompts", () => ({
     warn: logWarnMock,
     info: logInfoMock,
     error: logErrorMock,
+    success: logSuccessMock,
   },
   isCancel: vi.fn(() => false),
 }));
@@ -41,6 +43,7 @@ describe("setup notification step", () => {
     logWarnMock.mockReset();
     logInfoMock.mockReset();
     logErrorMock.mockReset();
+    logSuccessMock.mockReset();
   });
 
   afterEach(() => {
@@ -49,8 +52,11 @@ describe("setup notification step", () => {
     vi.doUnmock("../commands/setup/steps-provider.js");
     vi.doUnmock("../commands/setup/steps-adapter.js");
     vi.doUnmock("../commands/setup/steps-runtime.js");
+    vi.doUnmock("../commands/setup/steps-notification.js");
     vi.doUnmock("../../../base/llm/provider-config.js");
     vi.doUnmock("../../../base/config/identity-loader.js");
+    vi.doUnmock("../../../runtime/daemon/client.js");
+    vi.doUnmock("node:child_process");
     vi.doUnmock("node:fs");
   });
 
@@ -115,6 +121,26 @@ describe("setup notification step", () => {
     );
   });
 
+  it("preselects custom model when modifying an unknown current model", async () => {
+    selectMock.mockResolvedValueOnce("__custom__");
+    textMock.mockResolvedValueOnce("my-custom-model");
+
+    const { stepModel } = await import("../commands/setup/steps-provider.js");
+    const result = await stepModel("openai", "my-custom-model");
+
+    expect(result).toBe("my-custom-model");
+    expect(selectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValue: "__custom__",
+      })
+    );
+    expect(textMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialValue: "my-custom-model",
+      })
+    );
+  });
+
   it("writes notification.json only after final confirmation", async () => {
     vi.doMock("../commands/setup/steps-identity.js", () => ({
       getBanner: () => "banner",
@@ -139,6 +165,13 @@ describe("setup notification step", () => {
       writeUserMd: vi.fn(),
     }));
     vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4-mini": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
       saveProviderConfig: vi.fn(async () => {}),
       validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
     }));
@@ -159,6 +192,11 @@ describe("setup notification step", () => {
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(true);
     textMock.mockResolvedValueOnce("https://example.com/webhook");
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
 
     const { runSetupWizard } = await import("../commands/setup-wizard.js");
     const code = await runSetupWizard();
@@ -174,6 +212,332 @@ describe("setup notification step", () => {
       "utf-8"
     );
     expect(mkdirSyncMock).toHaveBeenCalledWith("/tmp/pulseed-test", { recursive: true });
+  });
+
+  it("can go back to a previous setup section before saving", async () => {
+    const stepUserNameMock = vi.fn()
+      .mockResolvedValueOnce("User 1")
+      .mockResolvedValueOnce("User 2");
+    const stepSeedyNameMock = vi.fn()
+      .mockResolvedValueOnce("Seedy 1")
+      .mockResolvedValueOnce("Seedy 2");
+    const stepProviderMock = vi.fn(async () => "openai");
+    const saveProviderConfigMock = vi.fn(async () => {});
+    const writeUserMdMock = vi.fn();
+    const writeSeedMdMock = vi.fn();
+
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(async () => "reset"),
+      stepUserName: stepUserNameMock,
+      stepSeedyName: stepSeedyNameMock,
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: stepProviderMock,
+      stepModel: vi.fn(async () => "gpt-5.4-mini"),
+      stepApiKey: vi.fn(async () => "sk-test"),
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: vi.fn(async () => "openai_codex_cli"),
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: false, port: 41700 })),
+      writeSeedMd: writeSeedMdMock,
+      writeRootMd: vi.fn(),
+      writeUserMd: writeUserMdMock,
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4-mini": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      saveProviderConfig: saveProviderConfigMock,
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("back")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(stepUserNameMock).toHaveBeenCalledTimes(2);
+    expect(stepProviderMock).toHaveBeenCalledTimes(2);
+    expect(writeUserMdMock).toHaveBeenCalledWith("/tmp/pulseed-test", "User 2");
+    expect(writeSeedMdMock).toHaveBeenCalledWith("/tmp/pulseed-test", "Seedy 2");
+    expect(saveProviderConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("can go back from runtime settings to provider settings", async () => {
+    const stepProviderMock = vi.fn(async () => "openai");
+    const stepDaemonMock = vi.fn(async () => ({ start: false, port: 41700 }));
+    const saveProviderConfigMock = vi.fn(async () => {});
+
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(async () => "reset"),
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: vi.fn(async () => "Seedy"),
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: stepProviderMock,
+      stepModel: vi.fn(async () => "gpt-5.4-mini"),
+      stepApiKey: vi.fn(async () => "sk-test"),
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: vi.fn(async () => "openai_codex_cli"),
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: stepDaemonMock,
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4-mini": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      saveProviderConfig: saveProviderConfigMock,
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("back")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(stepProviderMock).toHaveBeenCalledTimes(2);
+    expect(stepDaemonMock).toHaveBeenCalledTimes(2);
+    expect(saveProviderConfigMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates only provider settings when modifying an existing config", async () => {
+    const stepUserNameMock = vi.fn(async () => "User");
+    const stepSeedyNameMock = vi.fn(async () => "Seedy");
+    const stepDaemonMock = vi.fn(async () => ({ start: false, port: 41700 }));
+    const stepNotificationMock = vi.fn(async () => null);
+    const saveProviderConfigMock = vi.fn(async () => {});
+
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(async () => "modify"),
+      stepUserName: stepUserNameMock,
+      stepSeedyName: stepSeedyNameMock,
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: vi.fn(async () => "openai"),
+      stepModel: vi.fn(async () => "gpt-5.4-mini"),
+      stepApiKey: vi.fn(async () => "sk-existing"),
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: vi.fn(async () => "agent_loop"),
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: stepDaemonMock,
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: stepNotificationMock,
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4-mini": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(async () => ({
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        adapter: "openai_codex_cli",
+        api_key: "sk-existing",
+        codex_cli_path: "/usr/local/bin/codex",
+      })),
+      saveProviderConfig: saveProviderConfigMock,
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock.mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(stepUserNameMock).not.toHaveBeenCalled();
+    expect(stepSeedyNameMock).not.toHaveBeenCalled();
+    expect(stepDaemonMock).not.toHaveBeenCalled();
+    expect(stepNotificationMock).not.toHaveBeenCalled();
+    expect(saveProviderConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        adapter: "agent_loop",
+        api_key: "sk-existing",
+        codex_cli_path: "/usr/local/bin/codex",
+      })
+    );
+  });
+
+  it("starts daemon and gateway after saving daemon config", async () => {
+    const spawnChild = {
+      pid: 12345,
+      unref: vi.fn(),
+      once: vi.fn(),
+    };
+    spawnChild.once.mockImplementation((event: string, callback: () => void) => {
+      if (event === "spawn") queueMicrotask(callback);
+      return spawnChild;
+    });
+    const spawnMock = vi.fn(() => spawnChild);
+    const isDaemonRunningMock = vi.fn(async () => ({ running: true, port: 41701 }));
+
+    vi.doMock("node:child_process", () => ({
+      spawn: spawnMock,
+    }));
+    vi.doMock("../../../runtime/daemon/client.js", () => ({
+      isDaemonRunning: isDaemonRunningMock,
+    }));
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(async () => "reset"),
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: vi.fn(async () => "Seedy"),
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: vi.fn(async () => "openai"),
+      stepModel: vi.fn(async () => "gpt-5.4-mini"),
+      stepApiKey: vi.fn(async () => "sk-test"),
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: vi.fn(async () => "openai_codex_cli"),
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: true, port: 41701 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4-mini": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      saveProviderConfig: vi.fn(async () => {}),
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    const writeFileSyncMock = vi.fn();
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: writeFileSyncMock,
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(writeFileSyncMock).toHaveBeenCalledWith(
+      "/tmp/pulseed-test/daemon.json",
+      expect.stringContaining("\"event_server_port\": 41701"),
+      "utf-8"
+    );
+    expect(spawnMock).toHaveBeenCalledWith(
+      process.execPath,
+      [expect.any(String), "daemon", "start", "--detach"],
+      expect.objectContaining({
+        detached: true,
+        stdio: "ignore",
+        env: expect.objectContaining({ PULSEED_HOME: "/tmp/pulseed-test" }),
+      })
+    );
+    expect(spawnChild.unref).toHaveBeenCalled();
+    expect(isDaemonRunningMock).toHaveBeenCalledWith("/tmp/pulseed-test");
+    expect(logSuccessMock).toHaveBeenCalledWith(
+      "Daemon and gateway started (PID: 12345) on port 41701."
+    );
   });
 
   it("warns when notification config write fails", async () => {
@@ -200,6 +564,13 @@ describe("setup notification step", () => {
       writeUserMd: vi.fn(),
     }));
     vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4-mini": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
       saveProviderConfig: vi.fn(async () => {}),
       validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
     }));
@@ -222,6 +593,11 @@ describe("setup notification step", () => {
       .mockResolvedValueOnce(true)
       .mockResolvedValueOnce(true);
     textMock.mockResolvedValueOnce("https://example.com/webhook");
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
 
     const { runSetupWizard } = await import("../commands/setup-wizard.js");
     const code = await runSetupWizard();

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NotificationConfig } from "../../../runtime/types/notification.js";
+import type { SetupImportSelection } from "../commands/setup/import/types.js";
 
 const confirmMock = vi.fn();
 const textMock = vi.fn();
@@ -58,6 +59,8 @@ describe("setup notification step", () => {
     vi.doUnmock("../../../runtime/daemon/client.js");
     vi.doUnmock("node:child_process");
     vi.doUnmock("node:fs");
+    vi.doUnmock("../commands/setup/import/flow.js");
+    vi.doUnmock("../commands/setup/import/apply.js");
   });
 
   it("returns null when notifications are skipped", async () => {
@@ -538,6 +541,133 @@ describe("setup notification step", () => {
     expect(logSuccessMock).toHaveBeenCalledWith(
       "Daemon and gateway started (PID: 12345) on port 41701."
     );
+  });
+
+  it("still asks for Seedy name after importing from OpenClaw", async () => {
+    const stepExistingConfigMock = vi.fn(async () => "keep");
+    const stepSeedyNameMock = vi.fn(async () => "Imported Seedy");
+    const stepProviderMock = vi.fn(async (initial?: string) => initial ?? "openai");
+    const stepModelMock = vi.fn(async (_provider: string, initial?: string) => initial ?? "gpt-5.4-mini");
+    const stepApiKeyMock = vi.fn(async (_provider: string, _detected: Record<string, boolean>, initial?: string) => initial ?? "sk-test");
+    const stepAdapterMock = vi.fn(async (_model: string, _provider: string, initial?: string) => initial ?? "agent_loop");
+    const saveProviderConfigMock = vi.fn(async () => {});
+    const applySetupImportSelectionMock = vi.fn(async () => ({
+      created_at: "2026-04-13T00:00:00.000Z",
+      sources: [{ id: "openclaw", label: "OpenClaw", rootDir: "/tmp/openclaw" }],
+      items: [],
+    }));
+
+    const importSelection: SetupImportSelection = {
+      sources: [{ id: "openclaw", label: "OpenClaw", rootDir: "/tmp/openclaw", items: [] }],
+      items: [
+        {
+          id: "openclaw:provider:config.json",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
+          kind: "provider",
+          label: "anthropic / claude-sonnet-4-6 / agent_loop",
+          decision: "import",
+          reason: "provider defaults",
+          providerSettings: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            adapter: "agent_loop",
+            apiKey: "sk-imported",
+          },
+        },
+      ],
+      providerSettings: {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        adapter: "agent_loop",
+        apiKey: "sk-imported",
+      },
+    };
+
+    vi.doMock("../commands/setup/import/flow.js", () => ({
+      stepSetupImport: vi.fn(async () => importSelection),
+      providerConfigPatchFromImport: vi.fn((settings: NonNullable<SetupImportSelection["providerSettings"]>) => ({
+        provider: settings.provider,
+        model: settings.model,
+        adapter: settings.adapter,
+        api_key: settings.apiKey,
+      })),
+    }));
+    vi.doMock("../commands/setup/import/apply.js", () => ({
+      applySetupImportSelection: applySetupImportSelectionMock,
+    }));
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: stepExistingConfigMock,
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: stepSeedyNameMock,
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: stepProviderMock,
+      stepModel: stepModelMock,
+      stepApiKey: stepApiKeyMock,
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: stepAdapterMock,
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: false, port: 41700 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "claude-sonnet-4-6": {
+          provider: "anthropic",
+          adapters: ["claude_code_cli", "claude_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      saveProviderConfig: saveProviderConfigMock,
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(stepExistingConfigMock).not.toHaveBeenCalled();
+    expect(stepSeedyNameMock).toHaveBeenCalledTimes(1);
+    expect(stepProviderMock).toHaveBeenCalledWith("anthropic");
+    expect(stepModelMock).toHaveBeenCalledWith("anthropic", "claude-sonnet-4-6");
+    expect(stepAdapterMock).toHaveBeenCalledWith("claude-sonnet-4-6", "anthropic", "agent_loop");
+    expect(stepApiKeyMock).toHaveBeenCalledWith("anthropic", expect.any(Object), "sk-imported");
+    expect(saveProviderConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        adapter: "agent_loop",
+        api_key: "sk-imported",
+      })
+    );
+    expect(applySetupImportSelectionMock).toHaveBeenCalledWith("/tmp/pulseed-test", importSelection);
   });
 
   it("warns when notification config write fails", async () => {

--- a/src/interface/cli/__tests__/setup-import.test.ts
+++ b/src/interface/cli/__tests__/setup-import.test.ts
@@ -195,6 +195,26 @@ describe("setup import apply", () => {
 });
 
 describe("setup import flow", () => {
+  it("does not prompt when no import sources are detected", async () => {
+    vi.resetModules();
+    const confirmMock = vi.fn();
+    vi.doMock("@clack/prompts", () => ({
+      confirm: confirmMock,
+      select: vi.fn(),
+      note: vi.fn(),
+      multiselect: vi.fn(),
+      log: { info: vi.fn() },
+      isCancel: vi.fn(() => false),
+    }));
+    vi.doMock("../commands/setup/import/discovery.js", () => ({
+      detectSetupImportSources: () => [],
+    }));
+
+    const { stepSetupImport } = await import("../commands/setup/import/flow.js");
+    await expect(stepSetupImport()).resolves.toBeUndefined();
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
   it("asks which provider defaults to use when multiple provider configs are selected", async () => {
     vi.resetModules();
     const confirmMock = vi.fn(async () => true);
@@ -276,6 +296,70 @@ describe("setup import flow", () => {
       2,
       expect.objectContaining({
         message: expect.stringContaining("Which provider settings"),
+      })
+    );
+  });
+
+  it("respects manual item selection and does not seed skipped provider defaults", async () => {
+    vi.resetModules();
+    const confirmMock = vi.fn(async () => true);
+    const selectMock = vi.fn(async () => "choose");
+    const multiselectMock = vi.fn(async () => ["openclaw-skill"]);
+    const sources: SetupImportSource[] = [
+      {
+        id: "openclaw",
+        label: "OpenClaw",
+        rootDir: "/tmp/openclaw",
+        items: [
+          {
+            id: "openclaw-provider",
+            source: "openclaw",
+            sourceLabel: "OpenClaw",
+            kind: "provider",
+            label: "openai / gpt-5.4-mini / agent_loop",
+            decision: "import",
+            reason: "provider defaults",
+            providerSettings: {
+              provider: "openai",
+              model: "gpt-5.4-mini",
+              adapter: "agent_loop",
+            },
+          },
+          {
+            id: "openclaw-skill",
+            source: "openclaw",
+            sourceLabel: "OpenClaw",
+            kind: "skill",
+            label: "review",
+            decision: "import",
+            reason: "SKILL.md found",
+            sourcePath: "/tmp/openclaw/skills/review",
+          },
+        ],
+      },
+    ];
+
+    vi.doMock("@clack/prompts", () => ({
+      confirm: confirmMock,
+      select: selectMock,
+      note: vi.fn(),
+      multiselect: multiselectMock,
+      log: { info: vi.fn() },
+      isCancel: vi.fn(() => false),
+    }));
+    vi.doMock("../commands/setup/import/discovery.js", () => ({
+      detectSetupImportSources: () => sources,
+    }));
+
+    const { stepSetupImport } = await import("../commands/setup/import/flow.js");
+    const selection = await stepSetupImport();
+
+    expect(selection?.providerSettings).toBeUndefined();
+    expect(selection?.items.find((item) => item.id === "openclaw-provider")?.decision).toBe("skip");
+    expect(selection?.items.find((item) => item.id === "openclaw-skill")?.decision).toBe("import");
+    expect(multiselectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Select items to import:",
       })
     );
   });

--- a/src/interface/cli/__tests__/setup-import.test.ts
+++ b/src/interface/cli/__tests__/setup-import.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { SetupImportSelection, SetupImportSource } from "../commands/setup/import/types.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-setup-import-test-"));
+});
+
+afterEach(async () => {
+  delete process.env["PULSEED_IMPORT_OPENCLAW_HOME"];
+  delete process.env["PULSEED_IMPORT_HERMES_HOME"];
+  vi.doUnmock("@clack/prompts");
+  vi.doUnmock("../commands/setup/import/discovery.js");
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await fsp.mkdir(path.dirname(filePath), { recursive: true });
+  await fsp.writeFile(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+describe("setup import discovery", () => {
+  it("detects OpenClaw provider, skills, MCP servers, and plugins", async () => {
+    const openclawHome = path.join(tmpDir, "openclaw");
+    process.env["PULSEED_IMPORT_OPENCLAW_HOME"] = openclawHome;
+
+    await writeJson(path.join(openclawHome, "config.json"), {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      adapter: "agent_loop",
+      apiKey: "sk-imported",
+      baseUrl: "https://example.test",
+    });
+    await fsp.mkdir(path.join(openclawHome, "skills", "review"), { recursive: true });
+    await fsp.writeFile(path.join(openclawHome, "skills", "review", "SKILL.md"), "# Review\n", "utf-8");
+    await writeJson(path.join(openclawHome, "mcp.json"), {
+      mcpServers: {
+        filesystem: {
+          command: "node",
+          args: ["server.js"],
+          env: { ROOT: "/tmp" },
+          tool_mappings: [
+            {
+              tool_name: "read_file",
+              dimension_pattern: "filesystem_*",
+              args_template: { path: "$path" },
+            },
+          ],
+        },
+      },
+    });
+    await fsp.mkdir(path.join(openclawHome, "plugins", "notifier"), { recursive: true });
+    await writeJson(path.join(openclawHome, "plugins", "notifier", "plugin.json"), {
+      name: "notifier",
+      version: "1.0.0",
+      type: "notifier",
+      capabilities: ["notify"],
+      description: "test",
+    });
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0]?.id).toBe("openclaw");
+    expect(sources[0]?.items.map((item) => item.kind).sort()).toEqual([
+      "mcp",
+      "plugin",
+      "provider",
+      "skill",
+    ]);
+    expect(sources[0]?.items.find((item) => item.kind === "provider")?.providerSettings).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      adapter: "agent_loop",
+      apiKey: "sk-imported",
+      baseUrl: "https://example.test",
+    });
+    expect(sources[0]?.items.find((item) => item.kind === "mcp")?.mcpServer).toMatchObject({
+      id: "openclaw-filesystem",
+      enabled: false,
+      transport: "stdio",
+      command: "node",
+      tool_mappings: [
+        {
+          tool_name: "read_file",
+          dimension_pattern: "filesystem_*",
+          args_template: { path: "$path" },
+        },
+      ],
+    });
+    expect(sources[0]?.items.find((item) => item.kind === "plugin")?.decision).toBe("copy_disabled");
+  });
+});
+
+describe("setup import apply", () => {
+  it("copies skills and quarantined plugins, merges disabled MCP servers, and writes a report", async () => {
+    const sourceRoot = path.join(tmpDir, "source");
+    const baseDir = path.join(tmpDir, "pulseed");
+    const skillDir = path.join(sourceRoot, "skills", "review");
+    const pluginDir = path.join(sourceRoot, "plugins", "notifier");
+    await fsp.mkdir(skillDir, { recursive: true });
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "# Review\n", "utf-8");
+    await fsp.mkdir(pluginDir, { recursive: true });
+    await writeJson(path.join(pluginDir, "plugin.json"), {
+      name: "notifier",
+      version: "1.0.0",
+      type: "notifier",
+      capabilities: ["notify"],
+      description: "test",
+    });
+    await writeJson(path.join(baseDir, "mcp-servers.json"), {
+      servers: [
+        {
+          id: "openclaw-filesystem",
+          name: "existing",
+          transport: "stdio",
+          command: "node",
+          tool_mappings: [],
+          enabled: true,
+        },
+      ],
+    });
+
+    const selection: SetupImportSelection = {
+      sources: [{ id: "openclaw", label: "OpenClaw", rootDir: sourceRoot, items: [] }],
+      items: [
+        {
+          id: "openclaw:skill:review",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
+          kind: "skill",
+          label: "review",
+          sourcePath: skillDir,
+          decision: "import",
+          reason: "SKILL.md found",
+        },
+        {
+          id: "openclaw:plugin:notifier",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
+          kind: "plugin",
+          label: "notifier",
+          sourcePath: pluginDir,
+          decision: "copy_disabled",
+          reason: "quarantine",
+        },
+        {
+          id: "openclaw:mcp:filesystem",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
+          kind: "mcp",
+          label: "filesystem",
+          decision: "copy_disabled",
+          reason: "disabled until reviewed",
+          mcpServer: {
+            id: "openclaw-filesystem",
+            name: "filesystem",
+            transport: "stdio",
+            command: "node",
+            args: ["server.js"],
+            tool_mappings: [],
+            enabled: false,
+          },
+        },
+      ],
+    };
+
+    const { applySetupImportSelection } = await import("../commands/setup/import/apply.js");
+    const report = await applySetupImportSelection(baseDir, selection);
+
+    expect(fs.existsSync(path.join(baseDir, "skills", "imported", "openclaw", "review", "SKILL.md"))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, "plugins-imported-disabled", "openclaw", "notifier", "plugin.json"))).toBe(true);
+
+    const mcp = JSON.parse(
+      await fsp.readFile(path.join(baseDir, "mcp-servers.json"), "utf-8")
+    ) as { servers: Array<{ id: string; enabled: boolean }> };
+    expect(mcp.servers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "openclaw-filesystem", enabled: true }),
+        expect.objectContaining({ id: "openclaw-filesystem-2", enabled: false }),
+      ])
+    );
+    expect(report.items.filter((item) => item.status === "applied")).toHaveLength(3);
+
+    const reportRoots = await fsp.readdir(path.join(baseDir, "imports", "openclaw"));
+    expect(reportRoots).toHaveLength(1);
+    expect(fs.existsSync(path.join(baseDir, "imports", "openclaw", reportRoots[0]!, "report.json"))).toBe(true);
+  });
+});
+
+describe("setup import flow", () => {
+  it("asks which provider defaults to use when multiple provider configs are selected", async () => {
+    vi.resetModules();
+    const confirmMock = vi.fn(async () => true);
+    const selectMock = vi.fn()
+      .mockResolvedValueOnce("recommended")
+      .mockResolvedValueOnce("openclaw-provider");
+    const logInfoMock = vi.fn();
+    const sources: SetupImportSource[] = [
+      {
+        id: "hermes",
+        label: "Hermes Agent",
+        rootDir: "/tmp/hermes",
+        items: [
+          {
+            id: "hermes-provider",
+            source: "hermes",
+            sourceLabel: "Hermes Agent",
+            kind: "provider",
+            label: "openai / gpt-5.4-mini / agent_loop",
+            decision: "import",
+            reason: "provider defaults",
+            providerSettings: {
+              provider: "openai",
+              model: "gpt-5.4-mini",
+              adapter: "agent_loop",
+              apiKey: "sk-hermes",
+            },
+          },
+        ],
+      },
+      {
+        id: "openclaw",
+        label: "OpenClaw",
+        rootDir: "/tmp/openclaw",
+        items: [
+          {
+            id: "openclaw-provider",
+            source: "openclaw",
+            sourceLabel: "OpenClaw",
+            kind: "provider",
+            label: "anthropic / claude-sonnet-4-6 / agent_loop",
+            decision: "import",
+            reason: "provider defaults",
+            providerSettings: {
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+              adapter: "agent_loop",
+              apiKey: "sk-openclaw",
+            },
+          },
+        ],
+      },
+    ];
+
+    vi.doMock("@clack/prompts", () => ({
+      confirm: confirmMock,
+      select: selectMock,
+      note: vi.fn(),
+      multiselect: vi.fn(),
+      log: { info: logInfoMock },
+      isCancel: vi.fn(() => false),
+    }));
+    vi.doMock("../commands/setup/import/discovery.js", () => ({
+      detectSetupImportSources: () => sources,
+    }));
+
+    const { stepSetupImport } = await import("../commands/setup/import/flow.js");
+    const selection = await stepSetupImport();
+
+    expect(selection?.providerSettings).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      adapter: "agent_loop",
+      apiKey: "sk-openclaw",
+    });
+    expect(selection?.items.find((item) => item.id === "hermes-provider")?.decision).toBe("skip");
+    expect(selection?.items.find((item) => item.id === "openclaw-provider")?.decision).toBe("import");
+    expect(selectMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: expect.stringContaining("Which provider settings"),
+      })
+    );
+  });
+});

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -16,6 +16,7 @@ import { Logger } from "../../../runtime/logger.js";
 import { DaemonRunner } from "../../../runtime/daemon/runner.js";
 import { PIDManager } from "../../../runtime/pid-manager.js";
 import { EventServer } from "../../../runtime/event/server.js";
+import { IngressGateway } from "../../../runtime/gateway/index.js";
 import { CronScheduler } from "../../../runtime/cron-scheduler.js";
 import { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import { RuntimeWatchdog } from "../../../runtime/watchdog.js";
@@ -277,6 +278,7 @@ export async function cmdStart(
     { port: resolvedDaemonConfig.event_server_port, eventsDir: getEventsDir(daemonBaseDir) },
     logger
   );
+  const gateway = new IngressGateway(logger);
   notificationDispatcher.setRealtimeSink(async (report) => {
     eventServer.broadcast("notification_report", report);
   });
@@ -352,6 +354,7 @@ export async function cmdStart(
     reportingEngine: deps.reportingEngine,
     config: resolvedDaemonConfig,
     eventServer,
+    gateway,
     llmClient: deps.llmClient,
     cronScheduler,
     scheduleEngine,

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -19,6 +19,8 @@ import { stepAdapter } from "./setup/steps-adapter.js";
 import { stepNotification } from "./setup/steps-notification.js";
 import { stepDaemon, ensurePulseedDir, writeSeedMd, writeRootMd, writeUserMd } from "./setup/steps-runtime.js";
 import { guardCancel } from "./setup/utils.js";
+import { applySetupImportSelection } from "./setup/import/apply.js";
+import { providerConfigPatchFromImport, stepSetupImport } from "./setup/import/flow.js";
 
 type SetupAnswers = {
   userName: string;
@@ -71,7 +73,7 @@ function formatExecutionSummary(
 
 function buildProviderConfig(
   execution: Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">,
-  base?: ProviderConfig
+  base?: Partial<ProviderConfig>
 ): ProviderConfig {
   const config: ProviderConfig = {
     ...(base ?? {}),
@@ -88,6 +90,7 @@ function buildProviderConfig(
 
   if (base?.provider && base.provider !== execution.provider) {
     delete config.base_url;
+    delete config.openclaw;
   }
 
   return config;
@@ -230,60 +233,65 @@ export async function runSetupWizard(): Promise<number> {
     return 0;
   }
 
-  const existingChoice = await stepExistingConfig();
-  if (existingChoice === "keep") {
-    p.outro("Keeping existing configuration.");
-    return 0;
-  }
+  const importSelection = await stepSetupImport();
+  const importedProviderPatch = providerConfigPatchFromImport(importSelection?.providerSettings);
 
-  if (existingChoice === "modify") {
-    const existingConfig = await loadProviderConfig();
-    let execution = await stepExecutionConfig({
-      provider: existingConfig.provider,
-      model: existingConfig.model,
-      adapter: existingConfig.adapter,
-      apiKey: existingConfig.api_key,
-    });
-    if (!execution.adapter) return 1;
-
-    for (;;) {
-      p.note(formatExecutionSummary(execution), "Review provider settings");
-
-      const action = guardCancel(
-        await p.select({
-          message: "Save these provider settings?",
-          options: [
-            { value: "save" as const, label: "Save provider settings" },
-            { value: "edit" as const, label: "Edit provider, model, adapter" },
-            { value: "cancel" as const, label: "Cancel setup" },
-          ],
-          initialValue: "save" as const,
-        })
-      );
-
-      if (action === "save") break;
-      if (action === "cancel") {
-        p.cancel("Setup cancelled.");
-        return 0;
-      }
-      execution = await stepExecutionConfig(execution);
-      if (!execution.adapter) return 1;
+  if (!importSelection) {
+    const existingChoice = await stepExistingConfig();
+    if (existingChoice === "keep") {
+      p.outro("Keeping existing configuration.");
+      return 0;
     }
 
-    const saveResult = await validateAndSaveProviderConfig(buildProviderConfig(execution, existingConfig));
-    if (saveResult !== undefined) return saveResult;
-    p.outro("Provider settings updated.");
-    return 0;
+    if (existingChoice === "modify") {
+      const existingConfig = await loadProviderConfig();
+      let execution = await stepExecutionConfig({
+        provider: existingConfig.provider,
+        model: existingConfig.model,
+        adapter: existingConfig.adapter,
+        apiKey: existingConfig.api_key,
+      });
+      if (!execution.adapter) return 1;
+
+      for (;;) {
+        p.note(formatExecutionSummary(execution), "Review provider settings");
+
+        const action = guardCancel(
+          await p.select({
+            message: "Save these provider settings?",
+            options: [
+              { value: "save" as const, label: "Save provider settings" },
+              { value: "edit" as const, label: "Edit provider, model, adapter" },
+              { value: "cancel" as const, label: "Cancel setup" },
+            ],
+            initialValue: "save" as const,
+          })
+        );
+
+        if (action === "save") break;
+        if (action === "cancel") {
+          p.cancel("Setup cancelled.");
+          return 0;
+        }
+        execution = await stepExecutionConfig(execution);
+        if (!execution.adapter) return 1;
+      }
+
+      const saveResult = await validateAndSaveProviderConfig(buildProviderConfig(execution, existingConfig));
+      if (saveResult !== undefined) return saveResult;
+      p.outro("Provider settings updated.");
+      return 0;
+    }
   }
 
   let answers: SetupAnswers = {
     userName: "",
     agentName: "Seedy",
     rootPreset: "default",
-    provider: "openai",
-    model: "",
-    adapter: "",
-    apiKey: undefined,
+    provider: importedProviderPatch?.provider ?? "openai",
+    model: importedProviderPatch?.model ?? "",
+    adapter: importedProviderPatch?.adapter ?? "",
+    apiKey: importedProviderPatch?.api_key,
     startDaemon: false,
     daemonPort: 0,
     notificationConfig: null,
@@ -306,7 +314,7 @@ export async function runSetupWizard(): Promise<number> {
     }
 
     if (section === "execution") {
-      Object.assign(answers, await stepExecutionConfig(answers.adapter ? answers : undefined));
+      Object.assign(answers, await stepExecutionConfig(importSelection || answers.adapter ? answers : undefined));
       if (!answers.adapter) return 1;
       const next = await stepSectionNavigation(
         "Provider settings complete.",
@@ -376,7 +384,7 @@ export async function runSetupWizard(): Promise<number> {
 
   const dir = ensurePulseedDir();
 
-  const saveResult = await validateAndSaveProviderConfig(buildProviderConfig(finalAnswers));
+  const saveResult = await validateAndSaveProviderConfig(buildProviderConfig(finalAnswers, importedProviderPatch));
   if (saveResult !== undefined) return saveResult;
   writeSeedMd(dir, finalAnswers.agentName);
   writeRootMd(dir, finalAnswers.rootPreset);
@@ -405,6 +413,20 @@ export async function runSetupWizard(): Promise<number> {
       fs.writeFileSync(notifPath, JSON.stringify(finalAnswers.notificationConfig, null, 2));
     } catch (err) {
       p.log.warn(`Could not save notification config: ${err}`);
+    }
+  }
+
+  if (importSelection) {
+    try {
+      const report = await applySetupImportSelection(dir, importSelection);
+      const appliedCount = report.items.filter((item) => item.status === "applied").length;
+      const failedCount = report.items.filter((item) => item.status === "failed").length;
+      p.log.info(
+        `Imported ${appliedCount} item${appliedCount === 1 ? "" : "s"}` +
+          (failedCount > 0 ? ` (${failedCount} failed; see import report).` : ".")
+      );
+    } catch (err) {
+      p.log.warn(`Configuration saved, but import side effects failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -1,20 +1,216 @@
 import * as p from "@clack/prompts";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { spawn } from "node:child_process";
 import {
+  loadProviderConfig,
   saveProviderConfig,
   validateProviderConfig,
 } from "../../../base/llm/provider-config.js";
 import type { ProviderConfig } from "../../../base/llm/provider-config.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
+import { isDaemonRunning } from "../../../runtime/daemon/client.js";
 import { ROOT_PRESETS } from "./presets/root-presets.js";
-import { detectApiKeys, maskKey } from "./setup-shared.js";
+import { detectApiKeys, getAdaptersForModel, maskKey } from "./setup-shared.js";
+import type { Provider } from "./setup-shared.js";
 import { getBanner, stepExistingConfig, stepUserName, stepSeedyName } from "./setup/steps-identity.js";
 import { stepRootPreset, stepProvider, stepModel, stepApiKey } from "./setup/steps-provider.js";
 import { stepAdapter } from "./setup/steps-adapter.js";
 import { stepNotification } from "./setup/steps-notification.js";
 import { stepDaemon, ensurePulseedDir, writeSeedMd, writeRootMd, writeUserMd } from "./setup/steps-runtime.js";
 import { guardCancel } from "./setup/utils.js";
+
+type SetupAnswers = {
+  userName: string;
+  agentName: string;
+  rootPreset: keyof typeof ROOT_PRESETS;
+  provider: Provider;
+  model: string;
+  adapter: string;
+  apiKey?: string;
+  startDaemon: boolean;
+  daemonPort: number;
+  notificationConfig: Awaited<ReturnType<typeof stepNotification>>;
+};
+
+type IdentityAnswers = Pick<SetupAnswers, "userName" | "agentName" | "rootPreset">;
+type ExecutionAnswers = Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">;
+type RuntimeAnswers = Pick<SetupAnswers, "startDaemon" | "daemonPort" | "notificationConfig">;
+type FullSetupSection = "identity" | "execution" | "runtime" | "review";
+
+function formatSummary(answers: SetupAnswers): string {
+  const notificationChannels = answers.notificationConfig
+    ? answers.notificationConfig.channels.length === 0
+      ? "console only"
+      : answers.notificationConfig.channels.map((channel) => channel.type).join(", ")
+    : "no";
+
+  return [
+    `User:      ${answers.userName}`,
+    `Agent:     ${answers.agentName}`,
+    `Style:     ${ROOT_PRESETS[answers.rootPreset].name}`,
+    `Provider:  ${answers.provider}`,
+    `Model:     ${answers.model}`,
+    `Adapter:   ${answers.adapter}`,
+    `API Key:   ${maskKey(answers.apiKey)}`,
+    `Daemon:    ${answers.startDaemon ? `yes (port ${answers.daemonPort})` : "no"}`,
+    `Notify:    ${notificationChannels}`,
+  ].join("\n");
+}
+
+function formatExecutionSummary(
+  execution: Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">
+): string {
+  return [
+    `Provider:  ${execution.provider}`,
+    `Model:     ${execution.model}`,
+    `Adapter:   ${execution.adapter}`,
+    `API Key:   ${maskKey(execution.apiKey)}`,
+  ].join("\n");
+}
+
+function buildProviderConfig(
+  execution: Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">,
+  base?: ProviderConfig
+): ProviderConfig {
+  const config: ProviderConfig = {
+    ...(base ?? {}),
+    provider: execution.provider,
+    model: execution.model,
+    adapter: execution.adapter as ProviderConfig["adapter"],
+  };
+
+  if (execution.apiKey) {
+    config.api_key = execution.apiKey;
+  } else {
+    delete config.api_key;
+  }
+
+  if (base?.provider && base.provider !== execution.provider) {
+    delete config.base_url;
+  }
+
+  return config;
+}
+
+async function stepExecutionConfig(
+  current?: ExecutionAnswers
+): Promise<ExecutionAnswers> {
+  const provider = await stepProvider(current?.provider);
+  const initialModel = current?.provider === provider ? current.model : undefined;
+  const model = await stepModel(provider, initialModel);
+  const adaptersForModel = getAdaptersForModel(model, provider);
+  const initialAdapter =
+    current?.provider === provider && adaptersForModel.includes(current.adapter)
+      ? current.adapter
+      : undefined;
+  const adapter = await stepAdapter(model, provider, initialAdapter);
+  if (!adapter) return { provider, model, adapter, apiKey: current?.apiKey };
+
+  const detectedKeys = detectApiKeys();
+  const apiKey =
+    current?.provider === provider ? await stepApiKey(provider, detectedKeys, current.apiKey) : await stepApiKey(provider, detectedKeys);
+  return { provider, model, adapter, apiKey };
+}
+
+async function stepIdentityConfig(current?: Partial<IdentityAnswers>): Promise<IdentityAnswers> {
+  return {
+    userName: await stepUserName(current?.userName),
+    agentName: await stepSeedyName(current?.agentName),
+    rootPreset: await stepRootPreset(current?.rootPreset),
+  };
+}
+
+async function stepRuntimeConfig(): Promise<RuntimeAnswers> {
+  const daemonConfig = await stepDaemon();
+  return {
+    startDaemon: daemonConfig.start,
+    daemonPort: daemonConfig.port,
+    notificationConfig: await stepNotification(),
+  };
+}
+
+async function stepSectionNavigation(
+  message: string,
+  backLabel?: string
+): Promise<"continue" | "back" | "edit" | "cancel"> {
+  const options: p.Option<"continue" | "back" | "edit" | "cancel">[] = [
+    { value: "continue", label: "Continue" },
+    { value: "edit", label: "Edit this section" },
+  ];
+
+  if (backLabel) {
+    options.push({ value: "back", label: backLabel });
+  }
+  options.push({ value: "cancel", label: "Cancel setup" });
+
+  return guardCancel(
+    await p.select({
+      message,
+      options,
+      initialValue: "continue" as const,
+    })
+  );
+}
+
+async function validateAndSaveProviderConfig(config: ProviderConfig): Promise<number | undefined> {
+  const validation = validateProviderConfig(config);
+  if (!validation.valid) {
+    for (const err of validation.errors) {
+      p.log.error(err);
+    }
+    return 1;
+  }
+
+  await saveProviderConfig(config);
+  return undefined;
+}
+
+async function startDaemonDetached(baseDir: string): Promise<number | undefined> {
+  const scriptPath = process.argv[1];
+  if (!scriptPath) {
+    throw new Error("Could not determine CLI entrypoint for daemon start.");
+  }
+
+  const child = spawn(process.execPath, [scriptPath, "daemon", "start", "--detach"], {
+    detached: true,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      PULSEED_HOME: baseDir,
+    },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("spawn", resolve);
+  });
+  child.unref();
+  return child.pid;
+}
+
+async function waitForDaemonReady(
+  baseDir: string,
+  expectedPort: number,
+  timeoutMs = 10_000
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const { running, port } = await isDaemonRunning(baseDir);
+    if (running && port === expectedPort) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  throw new Error(`Daemon did not respond on port ${expectedPort} within ${timeoutMs}ms.`);
+}
+
+async function startDaemonAfterSetup(baseDir: string, port: number): Promise<void> {
+  p.log.info(`Starting daemon and gateway on port ${port}...`);
+  const pid = await startDaemonDetached(baseDir);
+  await waitForDaemonReady(baseDir, port);
+  p.log.success(`Daemon and gateway started${pid ? ` (PID: ${pid})` : ""} on port ${port}.`);
+}
 
 export async function runSetupWizard(): Promise<number> {
   console.log(getBanner());
@@ -40,93 +236,187 @@ export async function runSetupWizard(): Promise<number> {
     return 0;
   }
 
-  const userName = await stepUserName();
-  const agentName = await stepSeedyName();
-  const rootPreset = await stepRootPreset();
-  const provider = await stepProvider();
-  const model = await stepModel(provider);
-  const adapter = await stepAdapter(model, provider);
-  if (!adapter) return 1;
+  if (existingChoice === "modify") {
+    const existingConfig = await loadProviderConfig();
+    let execution = await stepExecutionConfig({
+      provider: existingConfig.provider,
+      model: existingConfig.model,
+      adapter: existingConfig.adapter,
+      apiKey: existingConfig.api_key,
+    });
+    if (!execution.adapter) return 1;
 
-  const detectedKeys = detectApiKeys();
-  const apiKey = await stepApiKey(provider, detectedKeys);
+    for (;;) {
+      p.note(formatExecutionSummary(execution), "Review provider settings");
 
-  const { start: startDaemon, port: daemonPort } = await stepDaemon();
-  const notificationConfig = await stepNotification();
+      const action = guardCancel(
+        await p.select({
+          message: "Save these provider settings?",
+          options: [
+            { value: "save" as const, label: "Save provider settings" },
+            { value: "edit" as const, label: "Edit provider, model, adapter" },
+            { value: "cancel" as const, label: "Cancel setup" },
+          ],
+          initialValue: "save" as const,
+        })
+      );
 
-  const summaryLines = [
-    `User:      ${userName}`,
-    `Agent:     ${agentName}`,
-    `Style:     ${ROOT_PRESETS[rootPreset].name}`,
-    `Provider:  ${provider}`,
-    `Model:     ${model}`,
-    `Adapter:   ${adapter}`,
-    `API Key:   ${maskKey(apiKey)}`,
-    `Daemon:    ${startDaemon ? `yes (port ${daemonPort})` : "no"}`,
-    `Notify:    ${notificationConfig ? "yes" : "no"}`,
-  ];
-  if (notificationConfig) {
-    const channels =
-      notificationConfig.channels.length === 0
-        ? "console only"
-        : notificationConfig.channels.map((channel) => channel.type).join(", ");
-    summaryLines.push(`Notify:    ${channels}`);
-  }
-  p.note(summaryLines.join("\n"), "Configuration Summary");
+      if (action === "save") break;
+      if (action === "cancel") {
+        p.cancel("Setup cancelled.");
+        return 0;
+      }
+      execution = await stepExecutionConfig(execution);
+      if (!execution.adapter) return 1;
+    }
 
-  const confirmed = guardCancel(
-    await p.confirm({ message: "Save this configuration?", initialValue: true })
-  );
-  if (!confirmed) {
-    p.cancel("Setup cancelled.");
+    const saveResult = await validateAndSaveProviderConfig(buildProviderConfig(execution, existingConfig));
+    if (saveResult !== undefined) return saveResult;
+    p.outro("Provider settings updated.");
     return 0;
+  }
+
+  let answers: SetupAnswers = {
+    userName: "",
+    agentName: "Seedy",
+    rootPreset: "default",
+    provider: "openai",
+    model: "",
+    adapter: "",
+    apiKey: undefined,
+    startDaemon: false,
+    daemonPort: 0,
+    notificationConfig: null,
+  };
+  let section: FullSetupSection = "identity";
+  let finalAnswers: SetupAnswers | undefined;
+
+  while (!finalAnswers) {
+    if (section === "identity") {
+      Object.assign(answers, await stepIdentityConfig(answers.userName ? answers : undefined));
+      const next = await stepSectionNavigation("Identity settings complete.");
+      if (next === "cancel") {
+        p.cancel("Setup cancelled.");
+        return 0;
+      }
+      if (next === "continue") {
+        section = "execution";
+      }
+      continue;
+    }
+
+    if (section === "execution") {
+      Object.assign(answers, await stepExecutionConfig(answers.adapter ? answers : undefined));
+      if (!answers.adapter) return 1;
+      const next = await stepSectionNavigation(
+        "Provider settings complete.",
+        "Back to identity settings"
+      );
+      if (next === "cancel") {
+        p.cancel("Setup cancelled.");
+        return 0;
+      }
+      if (next === "back") {
+        section = "identity";
+      } else if (next === "continue") {
+        section = "runtime";
+      }
+      continue;
+    }
+
+    if (section === "runtime") {
+      Object.assign(answers, await stepRuntimeConfig());
+      const next = await stepSectionNavigation(
+        "Daemon and notification settings complete.",
+        "Back to provider settings"
+      );
+      if (next === "cancel") {
+        p.cancel("Setup cancelled.");
+        return 0;
+      }
+      if (next === "back") {
+        section = "execution";
+      } else if (next === "continue") {
+        section = "review";
+      }
+      continue;
+    }
+
+    if (section === "review") {
+      p.note(formatSummary(answers), "Review configuration");
+
+      const action = guardCancel(
+        await p.select({
+          message: "Save this configuration?",
+          options: [
+            { value: "save" as const, label: "Save configuration", hint: "write files and finish" },
+            { value: "edit-execution" as const, label: "Edit provider, model, adapter" },
+            { value: "edit-identity" as const, label: "Edit user, agent, style" },
+            { value: "edit-runtime" as const, label: "Edit daemon and notifications" },
+            { value: "cancel" as const, label: "Cancel setup" },
+          ],
+          initialValue: "save" as const,
+        })
+      );
+
+      if (action === "save") {
+        finalAnswers = answers;
+      } else if (action === "cancel") {
+        p.cancel("Setup cancelled.");
+        return 0;
+      } else if (action === "edit-execution") {
+        section = "execution";
+      } else if (action === "edit-identity") {
+        section = "identity";
+      } else if (action === "edit-runtime") {
+        section = "runtime";
+      }
+    }
   }
 
   const dir = ensurePulseedDir();
 
-  const config: ProviderConfig = {
-    provider,
-    model,
-    adapter: adapter as ProviderConfig["adapter"],
-  };
-  if (apiKey) config.api_key = apiKey;
-
-  const validation = validateProviderConfig(config);
-  if (!validation.valid) {
-    for (const err of validation.errors) {
-      p.log.error(err);
-    }
-    return 1;
-  }
-
-  await saveProviderConfig(config);
-  writeSeedMd(dir, agentName);
-  writeRootMd(dir, rootPreset);
-  writeUserMd(dir, userName);
+  const saveResult = await validateAndSaveProviderConfig(buildProviderConfig(finalAnswers));
+  if (saveResult !== undefined) return saveResult;
+  writeSeedMd(dir, finalAnswers.agentName);
+  writeRootMd(dir, finalAnswers.rootPreset);
+  writeUserMd(dir, finalAnswers.userName);
   clearIdentityCache();
 
-  if (startDaemon) {
+  if (finalAnswers.startDaemon) {
     const daemonConfigPath = path.join(dir, "daemon.json");
     try {
       let existing: Record<string, unknown> = {};
       if (fs.existsSync(daemonConfigPath)) {
         existing = JSON.parse(fs.readFileSync(daemonConfigPath, "utf-8")) as Record<string, unknown>;
       }
-      existing["event_server_port"] = daemonPort;
+      existing["event_server_port"] = finalAnswers.daemonPort;
       fs.writeFileSync(daemonConfigPath, JSON.stringify(existing, null, 2), "utf-8");
     } catch {
       p.log.warn("Could not save daemon port to daemon.json");
     }
-    p.log.info("Daemon port " + daemonPort + " saved. Run pulseed to start.");
+    p.log.info("Daemon port " + finalAnswers.daemonPort + " saved.");
   }
 
-  if (notificationConfig) {
+  if (finalAnswers.notificationConfig) {
     const notifPath = path.join(dir, "notification.json");
     try {
       fs.mkdirSync(dir, { recursive: true });
-      fs.writeFileSync(notifPath, JSON.stringify(notificationConfig, null, 2));
+      fs.writeFileSync(notifPath, JSON.stringify(finalAnswers.notificationConfig, null, 2));
     } catch (err) {
       p.log.warn(`Could not save notification config: ${err}`);
+    }
+  }
+
+  if (finalAnswers.startDaemon) {
+    try {
+      await startDaemonAfterSetup(dir, finalAnswers.daemonPort);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      p.log.warn(
+        `Configuration saved, but daemon/gateway did not start: ${message}. ` +
+          "Run `pulseed daemon start --detach` to try again."
+      );
     }
   }
 

--- a/src/interface/cli/commands/setup/import/apply.ts
+++ b/src/interface/cli/commands/setup/import/apply.ts
@@ -1,0 +1,211 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../../../../../base/utils/json-io.js";
+import type { MCPServerConfig, MCPServersConfig } from "../../../../../base/types/mcp.js";
+import type {
+  SetupImportAppliedItem,
+  SetupImportItem,
+  SetupImportReport,
+  SetupImportSelection,
+} from "./types.js";
+
+function safeName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "imported";
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fsp.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function uniquePath(parentDir: string, name: string): Promise<string> {
+  const baseName = safeName(name);
+  let candidate = path.join(parentDir, baseName);
+  let suffix = 2;
+  while (await pathExists(candidate)) {
+    candidate = path.join(parentDir, `${baseName}-${suffix}`);
+    suffix += 1;
+  }
+  return candidate;
+}
+
+async function copyDirectoryNoSymlinks(sourceDir: string, targetDir: string): Promise<void> {
+  const stat = await fsp.lstat(sourceDir);
+  if (stat.isSymbolicLink()) {
+    throw new Error("refusing to copy symlink");
+  }
+  if (!stat.isDirectory()) {
+    throw new Error("source is not a directory");
+  }
+
+  await fsp.mkdir(targetDir, { recursive: true });
+  const entries = await fsp.readdir(sourceDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+    const entryStat = await fsp.lstat(sourcePath);
+    if (entryStat.isSymbolicLink()) continue;
+    if (entryStat.isDirectory()) {
+      await copyDirectoryNoSymlinks(sourcePath, targetPath);
+    } else if (entryStat.isFile()) {
+      await fsp.copyFile(sourcePath, targetPath);
+    }
+  }
+}
+
+function nextMcpId(existing: Set<string>, requested: string): string {
+  const base = safeName(requested);
+  if (!existing.has(base)) return base;
+  let suffix = 2;
+  for (;;) {
+    const candidate = `${base}-${suffix}`;
+    if (!existing.has(candidate)) return candidate;
+    suffix += 1;
+  }
+}
+
+async function mergeMcpServers(baseDir: string, servers: MCPServerConfig[]): Promise<string | undefined> {
+  if (servers.length === 0) return undefined;
+  const configPath = path.join(baseDir, "mcp-servers.json");
+  const current = await readJsonFileOrNull<MCPServersConfig>(configPath);
+  const existingServers = Array.isArray(current?.servers) ? current.servers : [];
+  const existingIds = new Set(existingServers.map((server) => server.id));
+  const imported = servers.map((server) => {
+    const id = nextMcpId(existingIds, server.id);
+    existingIds.add(id);
+    return { ...server, id, enabled: false };
+  });
+
+  await writeJsonFileAtomic(configPath, { servers: [...existingServers, ...imported] });
+  return configPath;
+}
+
+async function applyFileItem(baseDir: string, item: SetupImportItem): Promise<SetupImportAppliedItem> {
+  if (!item.sourcePath) {
+    return {
+      id: item.id,
+      source: item.source,
+      kind: item.kind,
+      label: item.label,
+      decision: item.decision,
+      status: "skipped",
+      reason: "no source path",
+    };
+  }
+
+  if (item.kind === "skill") {
+    const parentDir = path.join(baseDir, "skills", "imported", item.source);
+    const targetPath = await uniquePath(parentDir, item.label);
+    await copyDirectoryNoSymlinks(item.sourcePath, targetPath);
+    return {
+      id: item.id,
+      source: item.source,
+      kind: item.kind,
+      label: item.label,
+      decision: item.decision,
+      status: "applied",
+      targetPath,
+    };
+  }
+
+  if (item.kind === "plugin") {
+    const parentDir = path.join(baseDir, "plugins-imported-disabled", item.source);
+    const targetPath = await uniquePath(parentDir, item.label);
+    await copyDirectoryNoSymlinks(item.sourcePath, targetPath);
+    return {
+      id: item.id,
+      source: item.source,
+      kind: item.kind,
+      label: item.label,
+      decision: item.decision,
+      status: "applied",
+      targetPath,
+    };
+  }
+
+  return {
+    id: item.id,
+    source: item.source,
+    kind: item.kind,
+    label: item.label,
+    decision: item.decision,
+    status: "skipped",
+    reason: "not a file copy item",
+  };
+}
+
+function reportItem(item: SetupImportItem, status: SetupImportAppliedItem["status"], reason?: string): SetupImportAppliedItem {
+  return {
+    id: item.id,
+    source: item.source,
+    kind: item.kind,
+    label: item.label,
+    decision: item.decision,
+    status,
+    ...(reason ? { reason } : {}),
+  };
+}
+
+export async function applySetupImportSelection(
+  baseDir: string,
+  selection: SetupImportSelection
+): Promise<SetupImportReport> {
+  const applied: SetupImportAppliedItem[] = [];
+  const selectedItems = selection.items.filter((item) => item.decision !== "skip");
+
+  for (const item of selectedItems) {
+    try {
+      if (item.kind === "provider") {
+        applied.push(reportItem(item, "applied", "provider settings seeded into setup answers"));
+      } else if (item.kind === "skill" || item.kind === "plugin") {
+        applied.push(await applyFileItem(baseDir, item));
+      }
+    } catch (err) {
+      applied.push(reportItem(item, "failed", err instanceof Error ? err.message : String(err)));
+    }
+  }
+
+  const mcpItems = selectedItems.filter((item) => item.kind === "mcp" && item.mcpServer);
+  try {
+    const targetPath = await mergeMcpServers(
+      baseDir,
+      mcpItems.map((item) => item.mcpServer as MCPServerConfig)
+    );
+    for (const item of mcpItems) {
+      applied.push({
+        id: item.id,
+        source: item.source,
+        kind: item.kind,
+        label: item.label,
+        decision: item.decision,
+        status: targetPath ? "applied" : "skipped",
+        ...(targetPath ? { targetPath } : { reason: "no MCP server config" }),
+      });
+    }
+  } catch (err) {
+    for (const item of mcpItems) {
+      applied.push(reportItem(item, "failed", err instanceof Error ? err.message : String(err)));
+    }
+  }
+
+  const createdAt = new Date().toISOString();
+  const report: SetupImportReport = {
+    created_at: createdAt,
+    sources: selection.sources.map(({ id, label, rootDir }) => ({ id, label, rootDir })),
+    items: applied,
+  };
+
+  const reportName = createdAt.replace(/[:.]/g, "-");
+  const sourceName = selection.sources.map((source) => source.id).join("-") || "import";
+  const reportPath = path.join(baseDir, "imports", sourceName, reportName, "report.json");
+  await writeJsonFileAtomic(reportPath, report);
+
+  return report;
+}

--- a/src/interface/cli/commands/setup/import/apply.ts
+++ b/src/interface/cli/commands/setup/import/apply.ts
@@ -1,7 +1,7 @@
-import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { readJsonFileOrNull, writeJsonFileAtomic } from "../../../../../base/utils/json-io.js";
 import type { MCPServerConfig, MCPServersConfig } from "../../../../../base/types/mcp.js";
+import { copyDirectoryNoSymlinks, safeImportName, uniqueImportPath } from "./fs-utils.js";
 import type {
   SetupImportAppliedItem,
   SetupImportItem,
@@ -9,59 +9,8 @@ import type {
   SetupImportSelection,
 } from "./types.js";
 
-function safeName(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "") || "imported";
-}
-
-async function pathExists(filePath: string): Promise<boolean> {
-  try {
-    await fsp.access(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-async function uniquePath(parentDir: string, name: string): Promise<string> {
-  const baseName = safeName(name);
-  let candidate = path.join(parentDir, baseName);
-  let suffix = 2;
-  while (await pathExists(candidate)) {
-    candidate = path.join(parentDir, `${baseName}-${suffix}`);
-    suffix += 1;
-  }
-  return candidate;
-}
-
-async function copyDirectoryNoSymlinks(sourceDir: string, targetDir: string): Promise<void> {
-  const stat = await fsp.lstat(sourceDir);
-  if (stat.isSymbolicLink()) {
-    throw new Error("refusing to copy symlink");
-  }
-  if (!stat.isDirectory()) {
-    throw new Error("source is not a directory");
-  }
-
-  await fsp.mkdir(targetDir, { recursive: true });
-  const entries = await fsp.readdir(sourceDir, { withFileTypes: true });
-  for (const entry of entries) {
-    const sourcePath = path.join(sourceDir, entry.name);
-    const targetPath = path.join(targetDir, entry.name);
-    const entryStat = await fsp.lstat(sourcePath);
-    if (entryStat.isSymbolicLink()) continue;
-    if (entryStat.isDirectory()) {
-      await copyDirectoryNoSymlinks(sourcePath, targetPath);
-    } else if (entryStat.isFile()) {
-      await fsp.copyFile(sourcePath, targetPath);
-    }
-  }
-}
-
 function nextMcpId(existing: Set<string>, requested: string): string {
-  const base = safeName(requested);
+  const base = safeImportName(requested);
   if (!existing.has(base)) return base;
   let suffix = 2;
   for (;;) {
@@ -76,7 +25,7 @@ async function mergeMcpServers(baseDir: string, servers: MCPServerConfig[]): Pro
   const configPath = path.join(baseDir, "mcp-servers.json");
   const current = await readJsonFileOrNull<MCPServersConfig>(configPath);
   const existingServers = Array.isArray(current?.servers) ? current.servers : [];
-  const existingIds = new Set(existingServers.map((server) => server.id));
+  const existingIds = new Set<string>(existingServers.map((server) => server.id));
   const imported = servers.map((server) => {
     const id = nextMcpId(existingIds, server.id);
     existingIds.add(id);
@@ -102,7 +51,7 @@ async function applyFileItem(baseDir: string, item: SetupImportItem): Promise<Se
 
   if (item.kind === "skill") {
     const parentDir = path.join(baseDir, "skills", "imported", item.source);
-    const targetPath = await uniquePath(parentDir, item.label);
+    const targetPath = await uniqueImportPath(parentDir, item.label);
     await copyDirectoryNoSymlinks(item.sourcePath, targetPath);
     return {
       id: item.id,
@@ -117,7 +66,7 @@ async function applyFileItem(baseDir: string, item: SetupImportItem): Promise<Se
 
   if (item.kind === "plugin") {
     const parentDir = path.join(baseDir, "plugins-imported-disabled", item.source);
-    const targetPath = await uniquePath(parentDir, item.label);
+    const targetPath = await uniqueImportPath(parentDir, item.label);
     await copyDirectoryNoSymlinks(item.sourcePath, targetPath);
     return {
       id: item.id,

--- a/src/interface/cli/commands/setup/import/constants.ts
+++ b/src/interface/cli/commands/setup/import/constants.ts
@@ -1,0 +1,22 @@
+import type { SetupImportSourceId } from "./types.js";
+
+export const SOURCE_LABELS: Record<SetupImportSourceId, string> = {
+  hermes: "Hermes Agent",
+  openclaw: "OpenClaw",
+};
+
+export const CONFIG_FILENAMES = [
+  "provider.json",
+  "config.json",
+  "settings.json",
+  "agent.json",
+  "openclaw.config.json",
+  "hermes.config.json",
+] as const;
+
+export const MCP_FILENAMES = [
+  "mcp-servers.json",
+  "mcp.json",
+  "mcpServers.json",
+  "servers.json",
+] as const;

--- a/src/interface/cli/commands/setup/import/discovery.ts
+++ b/src/interface/cli/commands/setup/import/discovery.ts
@@ -1,0 +1,466 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ProviderConfig } from "../../../../../base/llm/provider-config.js";
+import type { MCPServerConfig } from "../../../../../base/types/mcp.js";
+import { PROVIDERS, getAdaptersForModel } from "../../setup-shared.js";
+import type { Provider } from "../../setup-shared.js";
+import type {
+  SetupImportItem,
+  SetupImportProviderSettings,
+  SetupImportSource,
+  SetupImportSourceId,
+} from "./types.js";
+
+const SOURCE_LABELS: Record<SetupImportSourceId, string> = {
+  hermes: "Hermes Agent",
+  openclaw: "OpenClaw",
+};
+
+const CONFIG_FILENAMES = [
+  "provider.json",
+  "config.json",
+  "settings.json",
+  "agent.json",
+  "openclaw.config.json",
+  "hermes.config.json",
+];
+
+const MCP_FILENAMES = [
+  "mcp-servers.json",
+  "mcp.json",
+  "mcpServers.json",
+  "servers.json",
+];
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function pathExists(filePath: string): boolean {
+  try {
+    fs.accessSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readJson(filePath: string): unknown | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value.filter((item): item is string => typeof item === "string");
+  return values.length === value.length ? values : undefined;
+}
+
+function nestedRecord(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function collectRecords(value: unknown, maxDepth = 3): Record<string, unknown>[] {
+  if (!isRecord(value) || maxDepth < 0) return [];
+  const records: Record<string, unknown>[] = [value];
+  if (maxDepth === 0) return records;
+  for (const child of Object.values(value)) {
+    if (isRecord(child)) {
+      records.push(...collectRecords(child, maxDepth - 1));
+    }
+  }
+  return records;
+}
+
+function firstString(records: Record<string, unknown>[], keys: string[]): string | undefined {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = stringValue(record[key]);
+      if (value) return value;
+    }
+  }
+  return undefined;
+}
+
+function normalizeProvider(value: string | undefined): Provider | undefined {
+  const normalized = value?.toLowerCase().trim();
+  if (!normalized) return undefined;
+  if (normalized === "codex" || normalized === "openai_codex" || normalized.includes("openai")) {
+    return "openai";
+  }
+  if (normalized === "claude" || normalized.includes("anthropic")) {
+    return "anthropic";
+  }
+  if (normalized.includes("ollama")) {
+    return "ollama";
+  }
+  return PROVIDERS.includes(normalized as Provider) ? (normalized as Provider) : undefined;
+}
+
+function normalizeAdapter(
+  value: string | undefined,
+  provider: ProviderConfig["provider"] | undefined,
+  model: string | undefined
+): ProviderConfig["adapter"] | undefined {
+  const normalized = value?.toLowerCase().trim();
+  const knownAdapters: ProviderConfig["adapter"][] = [
+    "claude_code_cli",
+    "claude_api",
+    "openai_codex_cli",
+    "openai_api",
+    "agent_loop",
+  ];
+  if (knownAdapters.includes(normalized as ProviderConfig["adapter"])) {
+    return normalized as ProviderConfig["adapter"];
+  }
+  if (normalized?.includes("codex")) return "openai_codex_cli";
+  if (normalized?.includes("claude") && normalized.includes("code")) return "claude_code_cli";
+  if (normalized?.includes("claude") || normalized?.includes("anthropic")) return "claude_api";
+  if (normalized?.includes("openai")) return "openai_api";
+  if (normalized?.includes("agent")) return "agent_loop";
+  if (provider && model) {
+    const adapters = getAdaptersForModel(model, provider);
+    return adapters[0] as ProviderConfig["adapter"] | undefined;
+  }
+  return undefined;
+}
+
+function providerSection(records: Record<string, unknown>[], provider: ProviderConfig["provider"] | undefined): Record<string, unknown> | undefined {
+  if (!provider) return undefined;
+  for (const record of records) {
+    const direct = nestedRecord(record, provider);
+    if (direct) return direct;
+    if (provider === "anthropic") {
+      const claude = nestedRecord(record, "claude");
+      if (claude) return claude;
+    }
+    if (provider === "openai") {
+      const codex = nestedRecord(record, "codex");
+      if (codex) return codex;
+    }
+  }
+  return undefined;
+}
+
+function extractProviderSettings(raw: unknown, source: SetupImportSourceId): SetupImportProviderSettings | undefined {
+  const records = collectRecords(raw);
+  if (records.length === 0) return undefined;
+
+  const provider = normalizeProvider(
+    firstString(records, [
+      "provider",
+      "llm_provider",
+      "llmProvider",
+      "model_provider",
+      "modelProvider",
+      "defaultProvider",
+    ])
+  );
+  const section = providerSection(records, provider);
+  const searchable = section ? [section, ...records] : records;
+  const model = firstString(searchable, ["model", "default_model", "defaultModel", "modelName"]);
+  const adapter = normalizeAdapter(
+    firstString(searchable, ["adapter", "default_adapter", "defaultAdapter", "backend", "terminalBackend"]),
+    provider,
+    model
+  );
+  const apiKey = firstString(searchable, ["api_key", "apiKey", "key", "token", "authToken"]);
+  const baseUrl = firstString(searchable, ["base_url", "baseUrl", "baseURL", "endpoint", "api_base"]);
+  const codexCliPath = firstString(searchable, ["codex_cli_path", "codexCliPath", "cli_path", "cliPath"]);
+  const openclawCliPath = source === "openclaw"
+    ? firstString(searchable, ["openclaw_cli_path", "openclawCliPath", "cli_path", "cliPath"])
+    : undefined;
+  const openclawProfile = source === "openclaw"
+    ? firstString(searchable, ["profile", "openclawProfile"])
+    : undefined;
+  const workDir = source === "openclaw"
+    ? firstString(searchable, ["work_dir", "workDir", "workspace", "workspacePath"])
+    : undefined;
+
+  const settings: SetupImportProviderSettings = {};
+  if (provider) settings.provider = provider;
+  if (model) settings.model = model;
+  if (adapter) settings.adapter = adapter;
+  if (apiKey) settings.apiKey = apiKey;
+  if (baseUrl) settings.baseUrl = baseUrl;
+  if (codexCliPath) settings.codexCliPath = codexCliPath;
+  if (source === "openclaw" && (openclawCliPath || openclawProfile || model || workDir)) {
+    settings.openclaw = {
+      ...(openclawCliPath ? { cli_path: openclawCliPath } : {}),
+      ...(openclawProfile ? { profile: openclawProfile } : {}),
+      ...(model ? { model } : {}),
+      ...(workDir ? { work_dir: workDir } : {}),
+    };
+  }
+
+  return Object.keys(settings).length > 0 ? settings : undefined;
+}
+
+function buildProviderItem(
+  source: SetupImportSourceId,
+  configPath: string,
+  settings: SetupImportProviderSettings
+): SetupImportItem {
+  const parts = [
+    settings.provider,
+    settings.model,
+    settings.adapter,
+  ].filter(Boolean);
+  return {
+    id: `${source}:provider:${path.basename(configPath)}`,
+    source,
+    sourceLabel: SOURCE_LABELS[source],
+    kind: "provider",
+    label: parts.length > 0 ? parts.join(" / ") : path.basename(configPath),
+    sourcePath: configPath,
+    decision: "import",
+    reason: "provider, model, adapter, and auth defaults",
+    providerSettings: settings,
+  };
+}
+
+function safeEntryName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "imported";
+}
+
+function listImmediateDirs(parentDir: string): string[] {
+  try {
+    return fs.readdirSync(parentDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(parentDir, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+function findSkillDirs(rootDir: string): string[] {
+  const roots = unique([
+    path.join(rootDir, "skills"),
+    path.join(rootDir, "agent", "skills"),
+    path.join(rootDir, "agents", "skills"),
+  ]);
+  const candidates: string[] = [];
+  for (const skillRoot of roots) {
+    for (const dir of listImmediateDirs(skillRoot)) {
+      if (pathExists(path.join(dir, "SKILL.md"))) candidates.push(dir);
+      for (const nested of listImmediateDirs(dir)) {
+        if (pathExists(path.join(nested, "SKILL.md"))) candidates.push(nested);
+      }
+    }
+  }
+  return unique(candidates);
+}
+
+function findPluginDirs(rootDir: string): string[] {
+  const roots = unique([
+    path.join(rootDir, "plugins"),
+    path.join(rootDir, "extensions"),
+  ]);
+  const candidates: string[] = [];
+  for (const pluginRoot of roots) {
+    for (const dir of listImmediateDirs(pluginRoot)) {
+      if (pathExists(path.join(dir, "plugin.yaml")) || pathExists(path.join(dir, "plugin.json"))) {
+        candidates.push(dir);
+      }
+    }
+  }
+  return unique(candidates);
+}
+
+function candidateConfigFiles(rootDir: string): string[] {
+  return unique([
+    ...CONFIG_FILENAMES.map((name) => path.join(rootDir, name)),
+    ...CONFIG_FILENAMES.map((name) => path.join(rootDir, "config", name)),
+  ]).filter(pathExists);
+}
+
+function candidateMcpFiles(rootDir: string): string[] {
+  return unique([
+    ...MCP_FILENAMES.map((name) => path.join(rootDir, name)),
+    ...MCP_FILENAMES.map((name) => path.join(rootDir, "config", name)),
+  ]).filter(pathExists);
+}
+
+function normalizeMcpServer(
+  id: string,
+  raw: Record<string, unknown>,
+  source: SetupImportSourceId
+): MCPServerConfig | undefined {
+  const command = stringValue(raw["command"]);
+  const args = stringArray(raw["args"]) ?? [];
+  const env = isRecord(raw["env"])
+    ? Object.fromEntries(
+        Object.entries(raw["env"]).filter(([, value]) => typeof value === "string")
+      ) as Record<string, string>
+    : undefined;
+  const url = stringValue(raw["url"]);
+  const transport = stringValue(raw["transport"]);
+  const resolvedTransport = transport === "sse" || url ? "sse" : "stdio";
+
+  if (resolvedTransport === "stdio" && !command) return undefined;
+  if (resolvedTransport === "sse" && !url) return undefined;
+
+  return {
+    id: safeEntryName(`${source}-${id}`),
+    name: stringValue(raw["name"]) ?? id,
+    transport: resolvedTransport,
+    ...(command ? { command } : {}),
+    ...(args.length > 0 ? { args } : {}),
+    ...(env && Object.keys(env).length > 0 ? { env } : {}),
+    ...(url ? { url } : {}),
+    tool_mappings: normalizeToolMappings(raw["tool_mappings"]),
+    enabled: false,
+  };
+}
+
+function normalizeToolMappings(value: unknown): MCPServerConfig["tool_mappings"] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const toolName = stringValue(item["tool_name"]);
+    const dimensionPattern = stringValue(item["dimension_pattern"]);
+    if (!toolName || !dimensionPattern) return [];
+    const argsTemplate = isRecord(item["args_template"]) ? item["args_template"] : undefined;
+    return [{
+      tool_name: toolName,
+      dimension_pattern: dimensionPattern,
+      ...(argsTemplate ? { args_template: argsTemplate } : {}),
+    }];
+  });
+}
+
+function extractMcpServers(raw: unknown, source: SetupImportSourceId): MCPServerConfig[] {
+  if (!isRecord(raw)) return [];
+  const serversValue = raw["servers"];
+  if (Array.isArray(serversValue)) {
+    return serversValue.flatMap((item, index) => {
+      if (!isRecord(item)) return [];
+      const id = stringValue(item["id"]) ?? stringValue(item["name"]) ?? `server-${index + 1}`;
+      const normalized = normalizeMcpServer(id, item, source);
+      return normalized ? [normalized] : [];
+    });
+  }
+
+  const mapValue = isRecord(raw["mcpServers"])
+    ? raw["mcpServers"]
+    : isRecord(raw["mcp_servers"])
+      ? raw["mcp_servers"]
+      : raw;
+
+  return Object.entries(mapValue).flatMap(([id, value]) => {
+    if (!isRecord(value)) return [];
+    const normalized = normalizeMcpServer(id, value, source);
+    return normalized ? [normalized] : [];
+  });
+}
+
+function sourceRoots(source: SetupImportSourceId): string[] {
+  const home = os.homedir();
+  if (source === "hermes") {
+    return unique([
+      process.env["PULSEED_IMPORT_HERMES_HOME"] ?? "",
+      process.env["PULSEED_HERMES_HOME"] ?? "",
+      process.env["HERMES_HOME"] ?? "",
+      path.join(home, ".hermes"),
+      path.join(home, ".hermes-agent"),
+      path.join(home, "Library", "Application Support", "Hermes Agent"),
+    ].filter(Boolean));
+  }
+  return unique([
+    process.env["PULSEED_IMPORT_OPENCLAW_HOME"] ?? "",
+    process.env["PULSEED_OPENCLAW_HOME"] ?? "",
+    process.env["OPENCLAW_HOME"] ?? "",
+    path.join(home, ".openclaw"),
+    path.join(home, ".config", "openclaw"),
+    path.join(home, "Library", "Application Support", "OpenClaw"),
+  ].filter(Boolean));
+}
+
+function detectSource(source: SetupImportSourceId): SetupImportSource | undefined {
+  for (const rootDir of sourceRoots(source)) {
+    if (!pathExists(rootDir)) continue;
+    const items: SetupImportItem[] = [];
+
+    for (const configPath of candidateConfigFiles(rootDir)) {
+      const settings = extractProviderSettings(readJson(configPath), source);
+      if (settings) items.push(buildProviderItem(source, configPath, settings));
+    }
+
+    for (const skillDir of findSkillDirs(rootDir)) {
+      const name = path.basename(skillDir);
+      items.push({
+        id: `${source}:skill:${name}`,
+        source,
+        sourceLabel: SOURCE_LABELS[source],
+        kind: "skill",
+        label: name,
+        sourcePath: skillDir,
+        decision: "import",
+        reason: "SKILL.md found",
+      });
+    }
+
+    for (const mcpPath of candidateMcpFiles(rootDir)) {
+      for (const server of extractMcpServers(readJson(mcpPath), source)) {
+        items.push({
+          id: `${source}:mcp:${server.id}`,
+          source,
+          sourceLabel: SOURCE_LABELS[source],
+          kind: "mcp",
+          label: server.name,
+          sourcePath: mcpPath,
+          decision: "copy_disabled",
+          reason: "MCP servers are imported disabled until reviewed",
+          mcpServer: server,
+        });
+      }
+    }
+
+    for (const pluginDir of findPluginDirs(rootDir)) {
+      const name = path.basename(pluginDir);
+      items.push({
+        id: `${source}:plugin:${name}`,
+        source,
+        sourceLabel: SOURCE_LABELS[source],
+        kind: "plugin",
+        label: name,
+        sourcePath: pluginDir,
+        decision: "copy_disabled",
+        reason: "plugins are quarantined until PulSeed compatibility is reviewed",
+      });
+    }
+
+    if (items.length > 0) {
+      return {
+        id: source,
+        label: SOURCE_LABELS[source],
+        rootDir,
+        items,
+      };
+    }
+  }
+  return undefined;
+}
+
+export function detectSetupImportSources(): SetupImportSource[] {
+  return (["hermes", "openclaw"] as const).flatMap((source) => {
+    const detected = detectSource(source);
+    return detected ? [detected] : [];
+  });
+}

--- a/src/interface/cli/commands/setup/import/discovery.ts
+++ b/src/interface/cli/commands/setup/import/discovery.ts
@@ -1,252 +1,25 @@
-import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { ProviderConfig } from "../../../../../base/llm/provider-config.js";
-import type { MCPServerConfig } from "../../../../../base/types/mcp.js";
-import { PROVIDERS, getAdaptersForModel } from "../../setup-shared.js";
-import type { Provider } from "../../setup-shared.js";
+import { CONFIG_FILENAMES, MCP_FILENAMES, SOURCE_LABELS } from "./constants.js";
+import {
+  listImmediateDirs,
+  pathExists,
+  readJson,
+  unique,
+} from "./fs-utils.js";
+import { extractMcpServers } from "./mcp.js";
+import { buildProviderItem, extractProviderSettings } from "./provider.js";
 import type {
   SetupImportItem,
-  SetupImportProviderSettings,
   SetupImportSource,
   SetupImportSourceId,
 } from "./types.js";
 
-const SOURCE_LABELS: Record<SetupImportSourceId, string> = {
-  hermes: "Hermes Agent",
-  openclaw: "OpenClaw",
-};
-
-const CONFIG_FILENAMES = [
-  "provider.json",
-  "config.json",
-  "settings.json",
-  "agent.json",
-  "openclaw.config.json",
-  "hermes.config.json",
-];
-
-const MCP_FILENAMES = [
-  "mcp-servers.json",
-  "mcp.json",
-  "mcpServers.json",
-  "servers.json",
-];
-
-function unique(values: string[]): string[] {
-  return [...new Set(values)];
-}
-
-function pathExists(filePath: string): boolean {
-  try {
-    fs.accessSync(filePath);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function readJson(filePath: string): unknown | undefined {
-  try {
-    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
-  } catch {
-    return undefined;
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-function stringArray(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const values = value.filter((item): item is string => typeof item === "string");
-  return values.length === value.length ? values : undefined;
-}
-
-function nestedRecord(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
-  const value = record[key];
-  return isRecord(value) ? value : undefined;
-}
-
-function collectRecords(value: unknown, maxDepth = 3): Record<string, unknown>[] {
-  if (!isRecord(value) || maxDepth < 0) return [];
-  const records: Record<string, unknown>[] = [value];
-  if (maxDepth === 0) return records;
-  for (const child of Object.values(value)) {
-    if (isRecord(child)) {
-      records.push(...collectRecords(child, maxDepth - 1));
-    }
-  }
-  return records;
-}
-
-function firstString(records: Record<string, unknown>[], keys: string[]): string | undefined {
-  for (const record of records) {
-    for (const key of keys) {
-      const value = stringValue(record[key]);
-      if (value) return value;
-    }
-  }
-  return undefined;
-}
-
-function normalizeProvider(value: string | undefined): Provider | undefined {
-  const normalized = value?.toLowerCase().trim();
-  if (!normalized) return undefined;
-  if (normalized === "codex" || normalized === "openai_codex" || normalized.includes("openai")) {
-    return "openai";
-  }
-  if (normalized === "claude" || normalized.includes("anthropic")) {
-    return "anthropic";
-  }
-  if (normalized.includes("ollama")) {
-    return "ollama";
-  }
-  return PROVIDERS.includes(normalized as Provider) ? (normalized as Provider) : undefined;
-}
-
-function normalizeAdapter(
-  value: string | undefined,
-  provider: ProviderConfig["provider"] | undefined,
-  model: string | undefined
-): ProviderConfig["adapter"] | undefined {
-  const normalized = value?.toLowerCase().trim();
-  const knownAdapters: ProviderConfig["adapter"][] = [
-    "claude_code_cli",
-    "claude_api",
-    "openai_codex_cli",
-    "openai_api",
-    "agent_loop",
-  ];
-  if (knownAdapters.includes(normalized as ProviderConfig["adapter"])) {
-    return normalized as ProviderConfig["adapter"];
-  }
-  if (normalized?.includes("codex")) return "openai_codex_cli";
-  if (normalized?.includes("claude") && normalized.includes("code")) return "claude_code_cli";
-  if (normalized?.includes("claude") || normalized?.includes("anthropic")) return "claude_api";
-  if (normalized?.includes("openai")) return "openai_api";
-  if (normalized?.includes("agent")) return "agent_loop";
-  if (provider && model) {
-    const adapters = getAdaptersForModel(model, provider);
-    return adapters[0] as ProviderConfig["adapter"] | undefined;
-  }
-  return undefined;
-}
-
-function providerSection(records: Record<string, unknown>[], provider: ProviderConfig["provider"] | undefined): Record<string, unknown> | undefined {
-  if (!provider) return undefined;
-  for (const record of records) {
-    const direct = nestedRecord(record, provider);
-    if (direct) return direct;
-    if (provider === "anthropic") {
-      const claude = nestedRecord(record, "claude");
-      if (claude) return claude;
-    }
-    if (provider === "openai") {
-      const codex = nestedRecord(record, "codex");
-      if (codex) return codex;
-    }
-  }
-  return undefined;
-}
-
-function extractProviderSettings(raw: unknown, source: SetupImportSourceId): SetupImportProviderSettings | undefined {
-  const records = collectRecords(raw);
-  if (records.length === 0) return undefined;
-
-  const provider = normalizeProvider(
-    firstString(records, [
-      "provider",
-      "llm_provider",
-      "llmProvider",
-      "model_provider",
-      "modelProvider",
-      "defaultProvider",
-    ])
-  );
-  const section = providerSection(records, provider);
-  const searchable = section ? [section, ...records] : records;
-  const model = firstString(searchable, ["model", "default_model", "defaultModel", "modelName"]);
-  const adapter = normalizeAdapter(
-    firstString(searchable, ["adapter", "default_adapter", "defaultAdapter", "backend", "terminalBackend"]),
-    provider,
-    model
-  );
-  const apiKey = firstString(searchable, ["api_key", "apiKey", "key", "token", "authToken"]);
-  const baseUrl = firstString(searchable, ["base_url", "baseUrl", "baseURL", "endpoint", "api_base"]);
-  const codexCliPath = firstString(searchable, ["codex_cli_path", "codexCliPath", "cli_path", "cliPath"]);
-  const openclawCliPath = source === "openclaw"
-    ? firstString(searchable, ["openclaw_cli_path", "openclawCliPath", "cli_path", "cliPath"])
-    : undefined;
-  const openclawProfile = source === "openclaw"
-    ? firstString(searchable, ["profile", "openclawProfile"])
-    : undefined;
-  const workDir = source === "openclaw"
-    ? firstString(searchable, ["work_dir", "workDir", "workspace", "workspacePath"])
-    : undefined;
-
-  const settings: SetupImportProviderSettings = {};
-  if (provider) settings.provider = provider;
-  if (model) settings.model = model;
-  if (adapter) settings.adapter = adapter;
-  if (apiKey) settings.apiKey = apiKey;
-  if (baseUrl) settings.baseUrl = baseUrl;
-  if (codexCliPath) settings.codexCliPath = codexCliPath;
-  if (source === "openclaw" && (openclawCliPath || openclawProfile || model || workDir)) {
-    settings.openclaw = {
-      ...(openclawCliPath ? { cli_path: openclawCliPath } : {}),
-      ...(openclawProfile ? { profile: openclawProfile } : {}),
-      ...(model ? { model } : {}),
-      ...(workDir ? { work_dir: workDir } : {}),
-    };
-  }
-
-  return Object.keys(settings).length > 0 ? settings : undefined;
-}
-
-function buildProviderItem(
-  source: SetupImportSourceId,
-  configPath: string,
-  settings: SetupImportProviderSettings
-): SetupImportItem {
-  const parts = [
-    settings.provider,
-    settings.model,
-    settings.adapter,
-  ].filter(Boolean);
-  return {
-    id: `${source}:provider:${path.basename(configPath)}`,
-    source,
-    sourceLabel: SOURCE_LABELS[source],
-    kind: "provider",
-    label: parts.length > 0 ? parts.join(" / ") : path.basename(configPath),
-    sourcePath: configPath,
-    decision: "import",
-    reason: "provider, model, adapter, and auth defaults",
-    providerSettings: settings,
-  };
-}
-
-function safeEntryName(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "") || "imported";
-}
-
-function listImmediateDirs(parentDir: string): string[] {
-  try {
-    return fs.readdirSync(parentDir, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => path.join(parentDir, entry.name));
-  } catch {
-    return [];
-  }
+function candidateFiles(rootDir: string, filenames: readonly string[]): string[] {
+  return unique([
+    ...filenames.map((name) => path.join(rootDir, name)),
+    ...filenames.map((name) => path.join(rootDir, "config", name)),
+  ]).filter(pathExists);
 }
 
 function findSkillDirs(rootDir: string): string[] {
@@ -268,12 +41,8 @@ function findSkillDirs(rootDir: string): string[] {
 }
 
 function findPluginDirs(rootDir: string): string[] {
-  const roots = unique([
-    path.join(rootDir, "plugins"),
-    path.join(rootDir, "extensions"),
-  ]);
   const candidates: string[] = [];
-  for (const pluginRoot of roots) {
+  for (const pluginRoot of [path.join(rootDir, "plugins"), path.join(rootDir, "extensions")]) {
     for (const dir of listImmediateDirs(pluginRoot)) {
       if (pathExists(path.join(dir, "plugin.yaml")) || pathExists(path.join(dir, "plugin.json"))) {
         candidates.push(dir);
@@ -281,93 +50,6 @@ function findPluginDirs(rootDir: string): string[] {
     }
   }
   return unique(candidates);
-}
-
-function candidateConfigFiles(rootDir: string): string[] {
-  return unique([
-    ...CONFIG_FILENAMES.map((name) => path.join(rootDir, name)),
-    ...CONFIG_FILENAMES.map((name) => path.join(rootDir, "config", name)),
-  ]).filter(pathExists);
-}
-
-function candidateMcpFiles(rootDir: string): string[] {
-  return unique([
-    ...MCP_FILENAMES.map((name) => path.join(rootDir, name)),
-    ...MCP_FILENAMES.map((name) => path.join(rootDir, "config", name)),
-  ]).filter(pathExists);
-}
-
-function normalizeMcpServer(
-  id: string,
-  raw: Record<string, unknown>,
-  source: SetupImportSourceId
-): MCPServerConfig | undefined {
-  const command = stringValue(raw["command"]);
-  const args = stringArray(raw["args"]) ?? [];
-  const env = isRecord(raw["env"])
-    ? Object.fromEntries(
-        Object.entries(raw["env"]).filter(([, value]) => typeof value === "string")
-      ) as Record<string, string>
-    : undefined;
-  const url = stringValue(raw["url"]);
-  const transport = stringValue(raw["transport"]);
-  const resolvedTransport = transport === "sse" || url ? "sse" : "stdio";
-
-  if (resolvedTransport === "stdio" && !command) return undefined;
-  if (resolvedTransport === "sse" && !url) return undefined;
-
-  return {
-    id: safeEntryName(`${source}-${id}`),
-    name: stringValue(raw["name"]) ?? id,
-    transport: resolvedTransport,
-    ...(command ? { command } : {}),
-    ...(args.length > 0 ? { args } : {}),
-    ...(env && Object.keys(env).length > 0 ? { env } : {}),
-    ...(url ? { url } : {}),
-    tool_mappings: normalizeToolMappings(raw["tool_mappings"]),
-    enabled: false,
-  };
-}
-
-function normalizeToolMappings(value: unknown): MCPServerConfig["tool_mappings"] {
-  if (!Array.isArray(value)) return [];
-  return value.flatMap((item) => {
-    if (!isRecord(item)) return [];
-    const toolName = stringValue(item["tool_name"]);
-    const dimensionPattern = stringValue(item["dimension_pattern"]);
-    if (!toolName || !dimensionPattern) return [];
-    const argsTemplate = isRecord(item["args_template"]) ? item["args_template"] : undefined;
-    return [{
-      tool_name: toolName,
-      dimension_pattern: dimensionPattern,
-      ...(argsTemplate ? { args_template: argsTemplate } : {}),
-    }];
-  });
-}
-
-function extractMcpServers(raw: unknown, source: SetupImportSourceId): MCPServerConfig[] {
-  if (!isRecord(raw)) return [];
-  const serversValue = raw["servers"];
-  if (Array.isArray(serversValue)) {
-    return serversValue.flatMap((item, index) => {
-      if (!isRecord(item)) return [];
-      const id = stringValue(item["id"]) ?? stringValue(item["name"]) ?? `server-${index + 1}`;
-      const normalized = normalizeMcpServer(id, item, source);
-      return normalized ? [normalized] : [];
-    });
-  }
-
-  const mapValue = isRecord(raw["mcpServers"])
-    ? raw["mcpServers"]
-    : isRecord(raw["mcp_servers"])
-      ? raw["mcp_servers"]
-      : raw;
-
-  return Object.entries(mapValue).flatMap(([id, value]) => {
-    if (!isRecord(value)) return [];
-    const normalized = normalizeMcpServer(id, value, source);
-    return normalized ? [normalized] : [];
-  });
 }
 
 function sourceRoots(source: SetupImportSourceId): string[] {
@@ -392,60 +74,70 @@ function sourceRoots(source: SetupImportSourceId): string[] {
   ].filter(Boolean));
 }
 
+function providerItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
+  return candidateFiles(rootDir, CONFIG_FILENAMES).flatMap((configPath) => {
+    const settings = extractProviderSettings(readJson(configPath), source);
+    return settings ? [buildProviderItem(source, configPath, settings)] : [];
+  });
+}
+
+function skillItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
+  return findSkillDirs(rootDir).map((skillDir) => {
+    const name = path.basename(skillDir);
+    return {
+      id: `${source}:skill:${name}`,
+      source,
+      sourceLabel: SOURCE_LABELS[source],
+      kind: "skill",
+      label: name,
+      sourcePath: skillDir,
+      decision: "import",
+      reason: "SKILL.md found",
+    };
+  });
+}
+
+function mcpItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
+  return candidateFiles(rootDir, MCP_FILENAMES).flatMap((mcpPath) =>
+    extractMcpServers(readJson(mcpPath), source).map((server) => ({
+      id: `${source}:mcp:${server.id}`,
+      source,
+      sourceLabel: SOURCE_LABELS[source],
+      kind: "mcp",
+      label: server.name,
+      sourcePath: mcpPath,
+      decision: "copy_disabled",
+      reason: "MCP servers are imported disabled until reviewed",
+      mcpServer: server,
+    }))
+  );
+}
+
+function pluginItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
+  return findPluginDirs(rootDir).map((pluginDir) => {
+    const name = path.basename(pluginDir);
+    return {
+      id: `${source}:plugin:${name}`,
+      source,
+      sourceLabel: SOURCE_LABELS[source],
+      kind: "plugin",
+      label: name,
+      sourcePath: pluginDir,
+      decision: "copy_disabled",
+      reason: "plugins are quarantined until PulSeed compatibility is reviewed",
+    };
+  });
+}
+
 function detectSource(source: SetupImportSourceId): SetupImportSource | undefined {
   for (const rootDir of sourceRoots(source)) {
     if (!pathExists(rootDir)) continue;
-    const items: SetupImportItem[] = [];
-
-    for (const configPath of candidateConfigFiles(rootDir)) {
-      const settings = extractProviderSettings(readJson(configPath), source);
-      if (settings) items.push(buildProviderItem(source, configPath, settings));
-    }
-
-    for (const skillDir of findSkillDirs(rootDir)) {
-      const name = path.basename(skillDir);
-      items.push({
-        id: `${source}:skill:${name}`,
-        source,
-        sourceLabel: SOURCE_LABELS[source],
-        kind: "skill",
-        label: name,
-        sourcePath: skillDir,
-        decision: "import",
-        reason: "SKILL.md found",
-      });
-    }
-
-    for (const mcpPath of candidateMcpFiles(rootDir)) {
-      for (const server of extractMcpServers(readJson(mcpPath), source)) {
-        items.push({
-          id: `${source}:mcp:${server.id}`,
-          source,
-          sourceLabel: SOURCE_LABELS[source],
-          kind: "mcp",
-          label: server.name,
-          sourcePath: mcpPath,
-          decision: "copy_disabled",
-          reason: "MCP servers are imported disabled until reviewed",
-          mcpServer: server,
-        });
-      }
-    }
-
-    for (const pluginDir of findPluginDirs(rootDir)) {
-      const name = path.basename(pluginDir);
-      items.push({
-        id: `${source}:plugin:${name}`,
-        source,
-        sourceLabel: SOURCE_LABELS[source],
-        kind: "plugin",
-        label: name,
-        sourcePath: pluginDir,
-        decision: "copy_disabled",
-        reason: "plugins are quarantined until PulSeed compatibility is reviewed",
-      });
-    }
-
+    const items = [
+      ...providerItems(source, rootDir),
+      ...skillItems(source, rootDir),
+      ...mcpItems(source, rootDir),
+      ...pluginItems(source, rootDir),
+    ];
     if (items.length > 0) {
       return {
         id: source,

--- a/src/interface/cli/commands/setup/import/flow.ts
+++ b/src/interface/cli/commands/setup/import/flow.ts
@@ -1,0 +1,172 @@
+import * as p from "@clack/prompts";
+import type { ProviderConfig } from "../../../../../base/llm/provider-config.js";
+import { maskKey } from "../../setup-shared.js";
+import { guardCancel } from "../utils.js";
+import { detectSetupImportSources } from "./discovery.js";
+import type {
+  SetupImportItem,
+  SetupImportProviderSettings,
+  SetupImportSelection,
+  SetupImportSource,
+} from "./types.js";
+
+function sourceSummary(sources: SetupImportSource[]): string {
+  return sources
+    .map((source) => {
+      const counts = source.items.reduce<Record<string, number>>((acc, item) => {
+        acc[item.kind] = (acc[item.kind] ?? 0) + 1;
+        return acc;
+      }, {});
+      const suffix = Object.entries(counts)
+        .map(([kind, count]) => `${kind}: ${count}`)
+        .join(", ");
+      return `${source.label}\n  root: ${source.rootDir}\n  ${suffix}`;
+    })
+    .join("\n\n");
+}
+
+function providerPreview(settings: SetupImportProviderSettings | undefined): string | undefined {
+  if (!settings) return undefined;
+  return [
+    settings.provider ? `provider=${settings.provider}` : undefined,
+    settings.model ? `model=${settings.model}` : undefined,
+    settings.adapter ? `adapter=${settings.adapter}` : undefined,
+    settings.apiKey ? `api_key=${maskKey(settings.apiKey)}` : undefined,
+    settings.baseUrl ? `base_url=${settings.baseUrl}` : undefined,
+  ].filter(Boolean).join(", ");
+}
+
+function itemPreview(item: SetupImportItem): string {
+  const decision = item.decision === "copy_disabled" ? "copy disabled" : item.decision;
+  const details = item.kind === "provider"
+    ? providerPreview(item.providerSettings)
+    : item.reason;
+  return `[${item.sourceLabel}] ${item.kind}: ${item.label}\n  ${decision}${details ? ` - ${details}` : ""}`;
+}
+
+function preview(sources: SetupImportSource[]): string {
+  return sources
+    .flatMap((source) => source.items)
+    .map(itemPreview)
+    .join("\n\n");
+}
+
+function mergeProviderSettings(items: SetupImportItem[]): SetupImportProviderSettings | undefined {
+  return items.find((item) => item.decision !== "skip" && item.providerSettings)?.providerSettings;
+}
+
+function itemOptionLabel(item: SetupImportItem): string {
+  const decision = item.decision === "copy_disabled" ? "copy disabled" : item.decision;
+  return `${item.sourceLabel}: ${item.kind} / ${item.label} (${decision})`;
+}
+
+function defaultProviderConfigFromImport(
+  settings: SetupImportProviderSettings | undefined
+): Partial<ProviderConfig> | undefined {
+  if (!settings) return undefined;
+  return {
+    ...(settings.provider ? { provider: settings.provider } : {}),
+    ...(settings.model ? { model: settings.model } : {}),
+    ...(settings.adapter ? { adapter: settings.adapter } : {}),
+    ...(settings.apiKey ? { api_key: settings.apiKey } : {}),
+    ...(settings.baseUrl ? { base_url: settings.baseUrl } : {}),
+    ...(settings.codexCliPath ? { codex_cli_path: settings.codexCliPath } : {}),
+    ...(settings.openclaw ? { openclaw: settings.openclaw } : {}),
+  };
+}
+
+export function providerConfigPatchFromImport(
+  settings: SetupImportProviderSettings | undefined
+): Partial<ProviderConfig> | undefined {
+  return defaultProviderConfigFromImport(settings);
+}
+
+export async function stepSetupImport(): Promise<SetupImportSelection | undefined> {
+  const sources = detectSetupImportSources();
+  if (sources.length === 0) return undefined;
+
+  p.note(sourceSummary(sources), "Existing agent configs found");
+  const wantsImport = guardCancel(
+    await p.confirm({
+      message: "Import settings from Hermes Agent / OpenClaw into PulSeed?",
+      initialValue: true,
+    })
+  );
+  if (!wantsImport) return undefined;
+
+  p.note(preview(sources), "Import preview");
+  const mode = guardCancel(
+    await p.select({
+      message: "How should PulSeed import these settings?",
+      options: [
+        {
+          value: "recommended" as const,
+          label: "Import recommended items",
+          hint: "provider and skills import; MCP/plugins are copied disabled",
+        },
+        {
+          value: "choose" as const,
+          label: "Choose items",
+        },
+        {
+          value: "skip" as const,
+          label: "Skip import",
+        },
+      ],
+      initialValue: "recommended" as const,
+    })
+  );
+
+  if (mode === "skip") return undefined;
+
+  const allItems = sources.flatMap((source) => source.items);
+  let items = allItems;
+  if (mode === "choose") {
+    const selectedIds = new Set(
+      guardCancel(
+        await p.multiselect({
+          message: "Select items to import:",
+          options: allItems.map((item) => ({
+            value: item.id,
+            label: itemOptionLabel(item),
+            hint: item.reason,
+          })),
+          initialValues: allItems.map((item) => item.id),
+        })
+      )
+    );
+    items = allItems.map((item) =>
+      selectedIds.has(item.id) ? item : { ...item, decision: "skip" as const }
+    );
+  }
+
+  const selectedItems = items.filter((item) => item.decision !== "skip");
+  const providerItems = selectedItems.filter((item) => item.providerSettings);
+  if (providerItems.length > 1) {
+    const providerChoice = guardCancel(
+      await p.select({
+        message: "Which provider settings should PulSeed use as setup defaults?",
+        options: providerItems.map((item) => ({
+          value: item.id,
+          label: `${item.sourceLabel}: ${item.label}`,
+          hint: providerPreview(item.providerSettings),
+        })),
+        initialValue: providerItems[0]?.id,
+      })
+    );
+    items = items.map((item) =>
+      item.providerSettings && item.id !== providerChoice
+        ? { ...item, decision: "skip" as const }
+        : item
+    );
+  }
+
+  const providerSettings = mergeProviderSettings(items);
+  if (providerSettings) {
+    p.log.info("Imported provider settings will be used as defaults. Seedy naming will still be asked.");
+  } else {
+    p.log.info("Import selected. Seedy naming will still be asked.");
+  }
+
+  return { sources, items, providerSettings };
+}

--- a/src/interface/cli/commands/setup/import/fs-utils.ts
+++ b/src/interface/cli/commands/setup/import/fs-utils.ts
@@ -1,0 +1,85 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+
+export function unique<T>(values: T[]): T[] {
+  return [...new Set(values)];
+}
+
+export function pathExists(filePath: string): boolean {
+  try {
+    fs.accessSync(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function pathExistsAsync(filePath: string): Promise<boolean> {
+  try {
+    await fsp.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readJson(filePath: string): unknown | undefined {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+export function listImmediateDirs(parentDir: string): string[] {
+  try {
+    return fs.readdirSync(parentDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(parentDir, entry.name));
+  } catch {
+    return [];
+  }
+}
+
+export function safeImportName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "") || "imported";
+}
+
+export async function uniqueImportPath(parentDir: string, name: string): Promise<string> {
+  const baseName = safeImportName(name);
+  let candidate = path.join(parentDir, baseName);
+  let suffix = 2;
+  while (await pathExistsAsync(candidate)) {
+    candidate = path.join(parentDir, `${baseName}-${suffix}`);
+    suffix += 1;
+  }
+  return candidate;
+}
+
+export async function copyDirectoryNoSymlinks(sourceDir: string, targetDir: string): Promise<void> {
+  const stat = await fsp.lstat(sourceDir);
+  if (stat.isSymbolicLink()) {
+    throw new Error("refusing to copy symlink");
+  }
+  if (!stat.isDirectory()) {
+    throw new Error("source is not a directory");
+  }
+
+  await fsp.mkdir(targetDir, { recursive: true });
+  const entries = await fsp.readdir(sourceDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const sourcePath = path.join(sourceDir, entry.name);
+    const targetPath = path.join(targetDir, entry.name);
+    const entryStat = await fsp.lstat(sourcePath);
+    if (entryStat.isSymbolicLink()) continue;
+    if (entryStat.isDirectory()) {
+      await copyDirectoryNoSymlinks(sourcePath, targetPath);
+    } else if (entryStat.isFile()) {
+      await fsp.copyFile(sourcePath, targetPath);
+    }
+  }
+}

--- a/src/interface/cli/commands/setup/import/mcp.ts
+++ b/src/interface/cli/commands/setup/import/mcp.ts
@@ -1,0 +1,77 @@
+import type { MCPServerConfig } from "../../../../../base/types/mcp.js";
+import { safeImportName } from "./fs-utils.js";
+import { isRecord, stringArray, stringValue } from "./parse.js";
+import type { SetupImportSourceId } from "./types.js";
+
+function normalizeToolMappings(value: unknown): MCPServerConfig["tool_mappings"] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!isRecord(item)) return [];
+    const toolName = stringValue(item["tool_name"]);
+    const dimensionPattern = stringValue(item["dimension_pattern"]);
+    if (!toolName || !dimensionPattern) return [];
+    const argsTemplate = isRecord(item["args_template"]) ? item["args_template"] : undefined;
+    return [{
+      tool_name: toolName,
+      dimension_pattern: dimensionPattern,
+      ...(argsTemplate ? { args_template: argsTemplate } : {}),
+    }];
+  });
+}
+
+function normalizeMcpServer(
+  id: string,
+  raw: Record<string, unknown>,
+  source: SetupImportSourceId
+): MCPServerConfig | undefined {
+  const command = stringValue(raw["command"]);
+  const args = stringArray(raw["args"]) ?? [];
+  const env = isRecord(raw["env"])
+    ? Object.fromEntries(
+        Object.entries(raw["env"]).filter(([, value]) => typeof value === "string")
+      ) as Record<string, string>
+    : undefined;
+  const url = stringValue(raw["url"]);
+  const transport = stringValue(raw["transport"]);
+  const resolvedTransport = transport === "sse" || url ? "sse" : "stdio";
+
+  if (resolvedTransport === "stdio" && !command) return undefined;
+  if (resolvedTransport === "sse" && !url) return undefined;
+
+  return {
+    id: safeImportName(`${source}-${id}`),
+    name: stringValue(raw["name"]) ?? id,
+    transport: resolvedTransport,
+    ...(command ? { command } : {}),
+    ...(args.length > 0 ? { args } : {}),
+    ...(env && Object.keys(env).length > 0 ? { env } : {}),
+    ...(url ? { url } : {}),
+    tool_mappings: normalizeToolMappings(raw["tool_mappings"]),
+    enabled: false,
+  };
+}
+
+export function extractMcpServers(raw: unknown, source: SetupImportSourceId): MCPServerConfig[] {
+  if (!isRecord(raw)) return [];
+  const serversValue = raw["servers"];
+  if (Array.isArray(serversValue)) {
+    return serversValue.flatMap((item, index) => {
+      if (!isRecord(item)) return [];
+      const id = stringValue(item["id"]) ?? stringValue(item["name"]) ?? `server-${index + 1}`;
+      const normalized = normalizeMcpServer(id, item, source);
+      return normalized ? [normalized] : [];
+    });
+  }
+
+  const mapValue = isRecord(raw["mcpServers"])
+    ? raw["mcpServers"]
+    : isRecord(raw["mcp_servers"])
+      ? raw["mcp_servers"]
+      : raw;
+
+  return Object.entries(mapValue).flatMap(([id, value]) => {
+    if (!isRecord(value)) return [];
+    const normalized = normalizeMcpServer(id, value, source);
+    return normalized ? [normalized] : [];
+  });
+}

--- a/src/interface/cli/commands/setup/import/parse.ts
+++ b/src/interface/cli/commands/setup/import/parse.ts
@@ -1,0 +1,46 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const values = value.filter((item): item is string => typeof item === "string");
+  return values.length === value.length ? values : undefined;
+}
+
+export function nestedRecord(
+  record: Record<string, unknown>,
+  key: string
+): Record<string, unknown> | undefined {
+  const value = record[key];
+  return isRecord(value) ? value : undefined;
+}
+
+export function collectRecords(value: unknown, maxDepth = 3): Record<string, unknown>[] {
+  if (!isRecord(value) || maxDepth < 0) return [];
+  const records: Record<string, unknown>[] = [value];
+  if (maxDepth === 0) return records;
+  for (const child of Object.values(value)) {
+    if (isRecord(child)) {
+      records.push(...collectRecords(child, maxDepth - 1));
+    }
+  }
+  return records;
+}
+
+export function firstString(
+  records: Record<string, unknown>[],
+  keys: string[]
+): string | undefined {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = stringValue(record[key]);
+      if (value) return value;
+    }
+  }
+  return undefined;
+}

--- a/src/interface/cli/commands/setup/import/provider.ts
+++ b/src/interface/cli/commands/setup/import/provider.ts
@@ -1,0 +1,157 @@
+import * as path from "node:path";
+import type { ProviderConfig } from "../../../../../base/llm/provider-config.js";
+import { PROVIDERS, getAdaptersForModel } from "../../setup-shared.js";
+import type { Provider } from "../../setup-shared.js";
+import { SOURCE_LABELS } from "./constants.js";
+import { collectRecords, firstString, nestedRecord } from "./parse.js";
+import type {
+  SetupImportItem,
+  SetupImportProviderSettings,
+  SetupImportSourceId,
+} from "./types.js";
+
+const PROVIDER_KEYS = [
+  "provider",
+  "llm_provider",
+  "llmProvider",
+  "model_provider",
+  "modelProvider",
+  "defaultProvider",
+];
+
+const MODEL_KEYS = ["model", "default_model", "defaultModel", "modelName"];
+const ADAPTER_KEYS = ["adapter", "default_adapter", "defaultAdapter", "backend", "terminalBackend"];
+const API_KEY_KEYS = ["api_key", "apiKey", "key", "token", "authToken"];
+const BASE_URL_KEYS = ["base_url", "baseUrl", "baseURL", "endpoint", "api_base"];
+const CLI_PATH_KEYS = ["codex_cli_path", "codexCliPath", "cli_path", "cliPath"];
+
+function normalizeProvider(value: string | undefined): Provider | undefined {
+  const normalized = value?.toLowerCase().trim();
+  if (!normalized) return undefined;
+  if (normalized === "codex" || normalized === "openai_codex" || normalized.includes("openai")) {
+    return "openai";
+  }
+  if (normalized === "claude" || normalized.includes("anthropic")) {
+    return "anthropic";
+  }
+  if (normalized.includes("ollama")) {
+    return "ollama";
+  }
+  return PROVIDERS.includes(normalized as Provider) ? (normalized as Provider) : undefined;
+}
+
+function normalizeAdapter(
+  value: string | undefined,
+  provider: ProviderConfig["provider"] | undefined,
+  model: string | undefined
+): ProviderConfig["adapter"] | undefined {
+  const normalized = value?.toLowerCase().trim();
+  const knownAdapters: ProviderConfig["adapter"][] = [
+    "claude_code_cli",
+    "claude_api",
+    "openai_codex_cli",
+    "openai_api",
+    "agent_loop",
+  ];
+  if (knownAdapters.includes(normalized as ProviderConfig["adapter"])) {
+    return normalized as ProviderConfig["adapter"];
+  }
+  if (normalized?.includes("codex")) return "openai_codex_cli";
+  if (normalized?.includes("claude") && normalized.includes("code")) return "claude_code_cli";
+  if (normalized?.includes("claude") || normalized?.includes("anthropic")) return "claude_api";
+  if (normalized?.includes("openai")) return "openai_api";
+  if (normalized?.includes("agent")) return "agent_loop";
+  if (provider && model) {
+    const adapters = getAdaptersForModel(model, provider);
+    return adapters[0] as ProviderConfig["adapter"] | undefined;
+  }
+  return undefined;
+}
+
+function providerSection(
+  records: Record<string, unknown>[],
+  provider: ProviderConfig["provider"] | undefined
+): Record<string, unknown> | undefined {
+  if (!provider) return undefined;
+  for (const record of records) {
+    const direct = nestedRecord(record, provider);
+    if (direct) return direct;
+    if (provider === "anthropic") {
+      const claude = nestedRecord(record, "claude");
+      if (claude) return claude;
+    }
+    if (provider === "openai") {
+      const codex = nestedRecord(record, "codex");
+      if (codex) return codex;
+    }
+  }
+  return undefined;
+}
+
+function openclawSettings(
+  records: Record<string, unknown>[],
+  model: string | undefined
+): ProviderConfig["openclaw"] | undefined {
+  const cliPath = firstString(records, ["openclaw_cli_path", "openclawCliPath", "cli_path", "cliPath"]);
+  const profile = firstString(records, ["profile", "openclawProfile"]);
+  const workDir = firstString(records, ["work_dir", "workDir", "workspace", "workspacePath"]);
+  if (!cliPath && !profile && !model && !workDir) return undefined;
+  return {
+    ...(cliPath ? { cli_path: cliPath } : {}),
+    ...(profile ? { profile } : {}),
+    ...(model ? { model } : {}),
+    ...(workDir ? { work_dir: workDir } : {}),
+  };
+}
+
+export function extractProviderSettings(
+  raw: unknown,
+  source: SetupImportSourceId
+): SetupImportProviderSettings | undefined {
+  const records = collectRecords(raw);
+  if (records.length === 0) return undefined;
+
+  const provider = normalizeProvider(firstString(records, PROVIDER_KEYS));
+  const section = providerSection(records, provider);
+  const searchable = section ? [section, ...records] : records;
+  const model = firstString(searchable, MODEL_KEYS);
+  const adapter = normalizeAdapter(firstString(searchable, ADAPTER_KEYS), provider, model);
+  const apiKey = firstString(searchable, API_KEY_KEYS);
+  const baseUrl = firstString(searchable, BASE_URL_KEYS);
+  const codexCliPath = firstString(searchable, CLI_PATH_KEYS);
+  const openclaw = source === "openclaw" ? openclawSettings(searchable, model) : undefined;
+
+  const settings: SetupImportProviderSettings = {};
+  if (provider) settings.provider = provider;
+  if (model) settings.model = model;
+  if (adapter) settings.adapter = adapter;
+  if (apiKey) settings.apiKey = apiKey;
+  if (baseUrl) settings.baseUrl = baseUrl;
+  if (codexCliPath) settings.codexCliPath = codexCliPath;
+  if (openclaw) settings.openclaw = openclaw;
+
+  return Object.keys(settings).length > 0 ? settings : undefined;
+}
+
+export function buildProviderItem(
+  source: SetupImportSourceId,
+  configPath: string,
+  settings: SetupImportProviderSettings
+): SetupImportItem {
+  const labelParts = [
+    settings.provider,
+    settings.model,
+    settings.adapter,
+  ].filter(Boolean);
+  return {
+    id: `${source}:provider:${path.basename(configPath)}`,
+    source,
+    sourceLabel: SOURCE_LABELS[source],
+    kind: "provider",
+    label: labelParts.length > 0 ? labelParts.join(" / ") : path.basename(configPath),
+    sourcePath: configPath,
+    decision: "import",
+    reason: "provider, model, adapter, and auth defaults",
+    providerSettings: settings,
+  };
+}

--- a/src/interface/cli/commands/setup/import/types.ts
+++ b/src/interface/cli/commands/setup/import/types.ts
@@ -1,0 +1,61 @@
+import type { ProviderConfig } from "../../../../../base/llm/provider-config.js";
+import type { MCPServerConfig } from "../../../../../base/types/mcp.js";
+
+export type SetupImportSourceId = "hermes" | "openclaw";
+
+export type SetupImportItemKind = "provider" | "skill" | "mcp" | "plugin";
+
+export type SetupImportDecision = "import" | "copy_disabled" | "skip";
+
+export interface SetupImportProviderSettings {
+  provider?: ProviderConfig["provider"];
+  model?: string;
+  adapter?: ProviderConfig["adapter"];
+  apiKey?: string;
+  baseUrl?: string;
+  codexCliPath?: string;
+  openclaw?: ProviderConfig["openclaw"];
+}
+
+export interface SetupImportItem {
+  id: string;
+  source: SetupImportSourceId;
+  sourceLabel: string;
+  kind: SetupImportItemKind;
+  label: string;
+  sourcePath?: string;
+  decision: SetupImportDecision;
+  reason: string;
+  providerSettings?: SetupImportProviderSettings;
+  mcpServer?: MCPServerConfig;
+}
+
+export interface SetupImportSource {
+  id: SetupImportSourceId;
+  label: string;
+  rootDir: string;
+  items: SetupImportItem[];
+}
+
+export interface SetupImportSelection {
+  sources: SetupImportSource[];
+  items: SetupImportItem[];
+  providerSettings?: SetupImportProviderSettings;
+}
+
+export interface SetupImportAppliedItem {
+  id: string;
+  source: SetupImportSourceId;
+  kind: SetupImportItemKind;
+  label: string;
+  decision: SetupImportDecision;
+  status: "applied" | "skipped" | "failed";
+  targetPath?: string;
+  reason?: string;
+}
+
+export interface SetupImportReport {
+  created_at: string;
+  sources: Array<Pick<SetupImportSource, "id" | "label" | "rootDir">>;
+  items: SetupImportAppliedItem[];
+}

--- a/src/interface/cli/commands/setup/steps-adapter.ts
+++ b/src/interface/cli/commands/setup/steps-adapter.ts
@@ -3,7 +3,27 @@ import { RECOMMENDED_ADAPTERS, getAdaptersForModel } from "../setup-shared.js";
 import type { Provider } from "../setup-shared.js";
 import { guardCancel } from "./utils.js";
 
-export async function stepAdapter(model: string, provider: Provider): Promise<string> {
+const ADAPTER_LABELS: Record<string, string> = {
+  agent_loop: "Native agent loop",
+  openai_codex_cli: "OpenAI Codex CLI",
+  openai_api: "OpenAI API",
+  claude_code_cli: "Claude Code CLI",
+  claude_api: "Anthropic API",
+};
+
+const ADAPTER_HINTS: Record<string, string> = {
+  agent_loop: "built-in task runner",
+  openai_codex_cli: "uses Codex CLI/OAuth",
+  openai_api: "direct API calls",
+  claude_code_cli: "uses Claude Code",
+  claude_api: "direct API calls",
+};
+
+export async function stepAdapter(
+  model: string,
+  provider: Provider,
+  initialAdapter?: string
+): Promise<string> {
   const adapters = getAdaptersForModel(model, provider);
   const recommendedAdapter = RECOMMENDED_ADAPTERS[provider];
 
@@ -14,16 +34,33 @@ export async function stepAdapter(model: string, provider: Provider): Promise<st
 
   if (adapters.length <= 1) {
     const adapter = adapters[0];
-    p.log.info(`Adapter: ${adapter} (auto-selected)`);
+    p.log.info(`Execution adapter: ${ADAPTER_LABELS[adapter] ?? adapter} (auto-selected)`);
     return adapter;
   }
 
   const options = adapters.map((adapter) => ({
     value: adapter,
-    label: adapter,
-    hint: adapter === recommendedAdapter ? "recommended" : undefined,
+    label: ADAPTER_LABELS[adapter] ?? adapter,
+    hint: [
+      adapter === recommendedAdapter ? "recommended" : undefined,
+      adapter === initialAdapter ? "current" : undefined,
+      ADAPTER_HINTS[adapter],
+    ].filter(Boolean).join(", ") || undefined,
   }));
 
-  const adapter = guardCancel(await p.select({ message: "Select execution adapter:", options }));
+  const initialValue =
+    initialAdapter && adapters.includes(initialAdapter)
+      ? initialAdapter
+      : adapters.includes(recommendedAdapter ?? "")
+        ? recommendedAdapter
+        : adapters[0];
+
+  const adapter = guardCancel(
+    await p.select({
+      message: `Select execution adapter for ${model}:`,
+      options,
+      initialValue,
+    })
+  );
   return adapter;
 }

--- a/src/interface/cli/commands/setup/steps-identity.ts
+++ b/src/interface/cli/commands/setup/steps-identity.ts
@@ -45,19 +45,24 @@ export async function stepExistingConfig(): Promise<"keep" | "modify" | "reset" 
       message: "What would you like to do?",
       options: [
         { value: "keep" as const, label: "Keep current config", hint: "exit wizard" },
-        { value: "modify" as const, label: "Modify", hint: "continue with current values as defaults" },
-        { value: "reset" as const, label: "Reset", hint: "start fresh" },
+        {
+          value: "modify" as const,
+          label: "Update provider settings",
+          hint: "reuse current provider/model/adapter as defaults",
+        },
+        { value: "reset" as const, label: "Run full setup again", hint: "recreate identity and optional settings" },
       ],
     })
   );
   return choice;
 }
 
-export async function stepUserName(): Promise<string> {
+export async function stepUserName(initialName?: string): Promise<string> {
   const name = guardCancel(
     await p.text({
       message: "What should I call you?",
       placeholder: "Your name",
+      initialValue: initialName,
       validate: (v) => {
         if (!v || !v.trim()) return "Name cannot be empty.";
         return undefined;
@@ -67,13 +72,14 @@ export async function stepUserName(): Promise<string> {
   return name;
 }
 
-export async function stepSeedyName(): Promise<string> {
+export async function stepSeedyName(initialName?: string): Promise<string> {
   p.note(SEEDY_PIXEL + "\n\n" + "Hi! I'm your new agent companion.", "Meet your agent");
 
   const name = guardCancel(
     await p.text({
       message: "What should your agent be called?",
       placeholder: "Seedy",
+      initialValue: initialName,
       defaultValue: "Seedy",
     })
   );

--- a/src/interface/cli/commands/setup/steps-provider.ts
+++ b/src/interface/cli/commands/setup/steps-provider.ts
@@ -14,7 +14,7 @@ import {
 import type { Provider } from "../setup-shared.js";
 import { guardCancel } from "./utils.js";
 
-export async function stepRootPreset(): Promise<RootPresetKey> {
+export async function stepRootPreset(initialPreset?: RootPresetKey): Promise<RootPresetKey> {
   const preset = guardCancel(
     await p.select({
       message: "Select a communication style for your agent:",
@@ -35,39 +35,73 @@ export async function stepRootPreset(): Promise<RootPresetKey> {
           hint: ROOT_PRESETS.caveman.description,
         },
       ],
+      initialValue: initialPreset,
     })
   );
   return preset;
 }
 
-export async function stepProvider(): Promise<Provider> {
+export async function stepProvider(initialProvider?: Provider): Promise<Provider> {
   const detectedKeys = detectApiKeys();
   const options = PROVIDERS.map((prov) => {
-    const detected = detectedKeys[prov] ? ` (${ENV_KEY_NAMES[prov]} detected)` : "";
-    return { value: prov, label: `${PROVIDER_LABELS[prov]}${detected}` };
+    const hints = [
+      detectedKeys[prov] ? `${ENV_KEY_NAMES[prov]} detected` : undefined,
+      prov === initialProvider ? "current" : undefined,
+    ].filter(Boolean);
+    return {
+      value: prov,
+      label: PROVIDER_LABELS[prov],
+      hint: hints.join(", ") || undefined,
+    };
   });
 
-  const provider = guardCancel(await p.select({ message: "Select LLM provider:", options }));
+  const provider = guardCancel(
+    await p.select({
+      message: "Select LLM provider:",
+      options,
+      initialValue: initialProvider,
+    })
+  );
   return provider;
 }
 
-export async function stepModel(provider: Provider): Promise<string> {
+export async function stepModel(provider: Provider, initialModel?: string): Promise<string> {
   const models = getModelsForProvider(provider);
   const recommended = RECOMMENDED_MODELS[provider];
 
   const options = models.map((model) => ({
     value: model,
     label: model,
-    hint: model === recommended ? "recommended" : undefined,
+    hint: [
+      model === recommended ? "recommended" : undefined,
+      model === initialModel ? "current" : undefined,
+    ].filter(Boolean).join(", ") || undefined,
   }));
-  options.push({ value: "__custom__", label: "Custom model name", hint: undefined });
+  options.push({
+    value: "__custom__",
+    label: "Custom model name",
+    hint: initialModel && !models.includes(initialModel) ? `current: ${initialModel}` : undefined,
+  });
 
-  const choice = guardCancel(await p.select({ message: "Select model:", options }));
+  const initialValue = initialModel
+    ? models.includes(initialModel)
+      ? initialModel
+      : "__custom__"
+    : undefined;
+
+  const choice = guardCancel(
+    await p.select({
+      message: "Select model:",
+      options,
+      initialValue,
+    })
+  );
 
   if (choice === "__custom__") {
     const custom = guardCancel(
       await p.text({
         message: "Enter model name:",
+        initialValue: initialModel && !models.includes(initialModel) ? initialModel : undefined,
         validate: (value) => {
           if (!value || !value.trim()) return "Model name cannot be empty.";
           return undefined;
@@ -114,7 +148,8 @@ export async function runCodexOAuthLogin(): Promise<string | undefined> {
 
 export async function stepApiKey(
   provider: Provider,
-  detectedKeys: Record<string, boolean>
+  detectedKeys: Record<string, boolean>,
+  existingApiKey?: string
 ): Promise<string | undefined> {
   const envKeyName = ENV_KEY_NAMES[provider];
   if (!envKeyName) return undefined;
@@ -122,6 +157,27 @@ export async function stepApiKey(
   if (detectedKeys[provider]) {
     p.log.info(`Using ${envKeyName} from environment.`);
     return process.env[envKeyName];
+  }
+
+  if (existingApiKey) {
+    const keyChoice = guardCancel(
+      await p.select({
+        message: `${envKeyName} is already configured. What should setup do?`,
+        options: [
+          {
+            value: "keep" as const,
+            label: `Keep existing key (${existingApiKey.slice(0, 4)}...${existingApiKey.slice(-4)})`,
+            hint: "use current config",
+          },
+          {
+            value: "replace" as const,
+            label: "Replace key",
+          },
+        ],
+        initialValue: "keep" as const,
+      })
+    );
+    if (keyChoice === "keep") return existingApiKey;
   }
 
   if (provider === "openai") {

--- a/src/interface/cli/commands/setup/steps-runtime.ts
+++ b/src/interface/cli/commands/setup/steps-runtime.ts
@@ -1,7 +1,6 @@
 import * as p from "@clack/prompts";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { homedir } from "node:os";
 import { getPulseedDirPath } from "../../../../base/utils/paths.js";
 import { DEFAULT_SEED, DEFAULT_USER } from "../../../../base/config/identity-loader.js";
 import { findAvailablePort, isPortAvailable, DEFAULT_PORT, getProcessOnPort } from "../../../../runtime/port-utils.js";
@@ -13,7 +12,7 @@ import type { RootPresetKey } from "../presets/root-presets.js";
 import { guardCancel } from "./utils.js";
 
 export async function stepDaemon(): Promise<{ start: boolean; port: number }> {
-  const baseDir = path.join(homedir(), ".pulseed");
+  const baseDir = getPulseedDirPath();
 
   const { running: alreadyRunning, port: currentPort } = await isDaemonRunning(baseDir);
 


### PR DESCRIPTION
## Summary

- Reworks setup wizard into section-based navigation so users can revisit identity, provider/model/adapter, and runtime settings before saving.
- Starts daemon/gateway after final setup save when requested, with detached spawn, PULSEED_HOME propagation, readiness wait, and active IngressGateway wiring.
- Adds Hermes Agent / OpenClaw import detection at setup start, with preview/confirmation before applying imported settings.
- Imports provider defaults, copies skills, merges MCP servers disabled-by-default, quarantines plugins outside the runtime loader path, and writes import reports.
- Keeps Seedy naming mandatory even when importing from Hermes Agent / OpenClaw.
- Refactors setup import internals by separating discovery orchestration from provider parsing, MCP parsing, constants, and filesystem helpers.

## Refactor Notes

- Split mechanical responsibility extraction and test coverage into separate commits:
  - `bee64c09 refactor setup import responsibilities`
  - `930d69ca cover setup import flow branches`
- Reduced `discovery.ts` from 466 lines to 158 lines.
- Removed duplicated safe-name/path-copy logic from `apply.ts` and moved it into shared import filesystem helpers.
- Preserved behavior: import UX, disabled MCP import, plugin quarantine path, Seedy naming requirement, and import report writes are unchanged.

## Validation

- npm test
- npm run typecheck -- --pretty false
- npx eslint -c eslint.config.mjs src/interface/cli/commands/setup/import/*.ts src/interface/cli/commands/setup-wizard.ts src/interface/cli/__tests__/setup-import.test.ts src/interface/cli/__tests__/cli-setup-notification.test.ts
- npx vitest run src/interface/cli/__tests__/setup-import.test.ts src/interface/cli/__tests__/cli-setup-notification.test.ts src/interface/cli/__tests__/cli-setup.test.ts
- npx vitest run src/interface/cli/__tests__/setup-import.test.ts --coverage --coverage.include='src/interface/cli/commands/setup/import/**/*.ts' --coverage.exclude='src/interface/cli/commands/setup/import/types.ts' --coverage.reporter=text
- git diff --check
