### PR TITLE
[codex] harden resident agent reliability

### DIFF
--- a/src/interface/cli/__tests__/cli-doctor.test.ts
+++ b/src/interface/cli/__tests__/cli-doctor.test.ts
@@ -23,6 +23,9 @@ import {
   checkPulseedDir,
   checkProviderConfig,
   checkApiKey,
+  checkStateDirectoryPermissions,
+  checkProviderConfigPermissions,
+  checkPluginPermissionWarnings,
   checkGoals,
   checkLogDirectory,
   checkBuild,
@@ -139,6 +142,127 @@ describe("checkApiKey", () => {
     const result = checkApiKey(tmpDir);
     expect(result.status).toBe("pass");
     expect(result.detail).toContain("provider.json");
+  });
+});
+
+describe("checkStateDirectoryPermissions", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir("pulseed-doctor-state-perms-");
+  });
+
+  afterEach(() => {
+    fs.chmodSync(tmpDir, 0o700);
+    cleanupTempDir(tmpDir);
+  });
+
+  it("passes when the state directory is private", () => {
+    fs.chmodSync(tmpDir, 0o700);
+    const result = checkStateDirectoryPermissions(tmpDir);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("0700");
+  });
+
+  it("warns when the state directory is group/world accessible", () => {
+    fs.chmodSync(tmpDir, 0o755);
+    const result = checkStateDirectoryPermissions(tmpDir);
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("recommended 0700");
+  });
+});
+
+describe("checkProviderConfigPermissions", () => {
+  let tmpDir: string;
+  let providerPath: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir("pulseed-doctor-provider-perms-");
+    providerPath = path.join(tmpDir, "provider.json");
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(providerPath)) {
+      fs.chmodSync(providerPath, 0o600);
+    }
+    cleanupTempDir(tmpDir);
+  });
+
+  it("passes when provider.json stores no api_key", () => {
+    fs.writeFileSync(providerPath, JSON.stringify({ model: "gpt-4" }));
+    fs.chmodSync(providerPath, 0o644);
+    const result = checkProviderConfigPermissions(tmpDir);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("no api_key");
+  });
+
+  it("passes when provider.json stores api_key and is private", () => {
+    fs.writeFileSync(providerPath, JSON.stringify({ api_key: "sk-test" }));
+    fs.chmodSync(providerPath, 0o600);
+    const result = checkProviderConfigPermissions(tmpDir);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("0600");
+  });
+
+  it("warns when provider.json stores api_key and is group/world accessible", () => {
+    fs.writeFileSync(providerPath, JSON.stringify({ api_key: "sk-test" }));
+    fs.chmodSync(providerPath, 0o644);
+    const result = checkProviderConfigPermissions(tmpDir);
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("recommended 0600");
+  });
+});
+
+describe("checkPluginPermissionWarnings", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir("pulseed-doctor-plugin-perms-");
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  it("passes when no plugins are installed", () => {
+    const result = checkPluginPermissionWarnings(tmpDir);
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("no plugins");
+  });
+
+  it("warns when an installed plugin requests shell permission", () => {
+    const pluginDir = path.join(tmpDir, "plugins", "shell-runner");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginDir, "plugin.yaml"),
+      [
+        "name: shell-runner",
+        "version: 1.0.0",
+        "type: adapter",
+        "capabilities:",
+        "  - run_shell",
+        "description: Runs shell commands",
+        "config_schema: {}",
+        "dependencies: []",
+        "permissions:",
+        "  shell: true",
+        "",
+      ].join("\n")
+    );
+
+    const result = checkPluginPermissionWarnings(tmpDir);
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("shell-runner");
+  });
+
+  it("warns when a plugin manifest cannot be inspected", () => {
+    const pluginDir = path.join(tmpDir, "plugins", "broken");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, "plugin.yaml"), "{");
+
+    const result = checkPluginPermissionWarnings(tmpDir);
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("could not be inspected");
   });
 });
 

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -68,7 +68,7 @@ export async function cmdStart(
   characterConfigManager: CharacterConfigManager,
   args: string[]
 ): Promise<void> {
-  let values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; workspace?: string };
+  let values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; "max-concurrent-goals"?: string; workspace?: string };
   try {
     ({ values } = parseArgs({
       args,
@@ -79,10 +79,11 @@ export async function cmdStart(
         detach: { type: "boolean", short: "d" },
         "check-interval-ms": { type: "string" },
         "iterations-per-cycle": { type: "string" },
+        "max-concurrent-goals": { type: "string" },
         workspace: { type: "string" },
       },
       strict: false,
-    }) as { values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; workspace?: string } });
+    }) as { values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; "max-concurrent-goals"?: string; workspace?: string } });
   } catch (err) {
     getCliLogger().error(formatOperationError("parse start command arguments", err));
     values = {};
@@ -138,6 +139,15 @@ export async function cmdStart(
     }
     daemonConfig = daemonConfig ?? {};
     daemonConfig.iterations_per_cycle = parsed;
+  }
+  if (values["max-concurrent-goals"]) {
+    const parsed = parseInt(values["max-concurrent-goals"], 10);
+    if (isNaN(parsed) || parsed <= 0) {
+      getCliLogger().error("--max-concurrent-goals must be a positive integer");
+      process.exit(1);
+    }
+    daemonConfig = daemonConfig ?? {};
+    daemonConfig.max_concurrent_goals = parsed;
   }
   if (values.workspace) {
     daemonConfig = daemonConfig ?? {};
@@ -652,6 +662,7 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   lines.push("Config:");
   lines.push(`  Interval:      ${intervalMin}m (adaptive sleep: ${adaptiveSleep})`);
   lines.push(`  Iterations:    ${cfg.iterations_per_cycle} per cycle`);
+  lines.push(`  Concurrency:   ${cfg.max_concurrent_goals} goal${cfg.max_concurrent_goals === 1 ? "" : "s"}`);
   lines.push(`  Proactive:     ${proactive}`);
   lines.push("  Runtime:       durable auto-recovery");
   if (cfg.runtime_root) {

--- a/src/interface/cli/commands/doctor.ts
+++ b/src/interface/cli/commands/doctor.ts
@@ -2,11 +2,13 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { getPulseedDirPath, getLogsDir, getGoalsDir } from "../../../base/utils/paths.js";
+import yaml from "js-yaml";
+import { getPulseedDirPath, getLogsDir, getGoalsDir, getPluginsDir } from "../../../base/utils/paths.js";
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import { getCliRunnerBuildPath } from "../../../base/utils/pulseed-meta.js";
 import { readJsonFileOrNull } from "../../../base/utils/json-io.js";
 import { DaemonConfigSchema } from "../../../base/types/daemon.js";
+import { PluginManifestSchema } from "../../../base/types/plugin.js";
 import { PIDManager } from "../../../runtime/pid-manager.js";
 import { probeDaemonHealth } from "../../../runtime/daemon/client.js";
 import {
@@ -84,6 +86,19 @@ function formatLivePingDetail(latencyMs: number, error?: string): string {
   return error ? `live ping failed (${latency}; ${error})` : `live ping ok (${latency})`;
 }
 
+function formatOctalMode(mode: number): string {
+  return `0${(mode & 0o777).toString(8)}`;
+}
+
+function isGroupOrWorldAccessible(mode: number): boolean {
+  return (mode & 0o077) !== 0;
+}
+
+function formatNameList(names: string[], limit = 5): string {
+  const shown = names.slice(0, limit).join(", ");
+  return names.length > limit ? `${shown}, +${names.length - limit} more` : shown;
+}
+
 // ─── Individual checks ───
 
 export function checkNodeVersion(): CheckResult {
@@ -159,6 +174,137 @@ export function checkApiKey(baseDir?: string): CheckResult {
     status: "fail",
     detail: "ANTHROPIC_API_KEY / OPENAI_API_KEY not set (checked env + provider.json)",
   };
+}
+
+export function checkStateDirectoryPermissions(baseDir?: string): CheckResult {
+  const dir = baseDir ?? getPulseedDirPath();
+  const displayDir = dir.replace(process.env["HOME"] ?? "", "~");
+
+  if (!fs.existsSync(dir)) {
+    return { name: "State permissions", status: "warn", detail: `${displayDir} not found` };
+  }
+
+  try {
+    const mode = fs.statSync(dir).mode;
+    if (isGroupOrWorldAccessible(mode)) {
+      return {
+        name: "State permissions",
+        status: "warn",
+        detail: `${displayDir} is ${formatOctalMode(mode)}; recommended 0700`,
+      };
+    }
+    return { name: "State permissions", status: "pass", detail: `${displayDir} is ${formatOctalMode(mode)}` };
+  } catch {
+    return { name: "State permissions", status: "warn", detail: `${displayDir} could not be inspected` };
+  }
+}
+
+export function checkProviderConfigPermissions(baseDir?: string): CheckResult {
+  const dir = baseDir ?? getPulseedDirPath();
+  const configPath = path.join(dir, "provider.json");
+  const displayPath = configPath.replace(process.env["HOME"] ?? "", "~");
+
+  if (!fs.existsSync(configPath)) {
+    return { name: "Provider permissions", status: "warn", detail: `${displayPath} not found` };
+  }
+
+  let hasStoredApiKey = false;
+  try {
+    const content = fs.readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(content) as unknown;
+    hasStoredApiKey =
+      parsed !== null &&
+      typeof parsed === "object" &&
+      typeof (parsed as Record<string, unknown>)["api_key"] === "string" &&
+      ((parsed as Record<string, string>)["api_key"] ?? "").length > 0;
+  } catch {
+    return { name: "Provider permissions", status: "warn", detail: `${displayPath} could not be parsed` };
+  }
+
+  if (!hasStoredApiKey) {
+    return { name: "Provider permissions", status: "pass", detail: "no api_key stored in provider.json" };
+  }
+
+  try {
+    const mode = fs.statSync(configPath).mode;
+    if (isGroupOrWorldAccessible(mode)) {
+      return {
+        name: "Provider permissions",
+        status: "warn",
+        detail: `${displayPath} is ${formatOctalMode(mode)}; recommended 0600 because it stores api_key`,
+      };
+    }
+    return { name: "Provider permissions", status: "pass", detail: `${displayPath} is ${formatOctalMode(mode)}` };
+  } catch {
+    return { name: "Provider permissions", status: "warn", detail: `${displayPath} could not be inspected` };
+  }
+}
+
+export function checkPluginPermissionWarnings(baseDir?: string): CheckResult {
+  const pluginsDir = getPluginsDir(baseDir ?? getPulseedDirPath());
+
+  if (!fs.existsSync(pluginsDir)) {
+    return { name: "Plugin permissions", status: "pass", detail: "no plugins installed" };
+  }
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(pluginsDir, { withFileTypes: true });
+  } catch {
+    return { name: "Plugin permissions", status: "warn", detail: "could not read plugins directory" };
+  }
+
+  const shellPlugins: string[] = [];
+  let unreadableManifestCount = 0;
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const pluginDir = path.join(pluginsDir, entry.name);
+    const yamlPath = path.join(pluginDir, "plugin.yaml");
+    const jsonPath = path.join(pluginDir, "plugin.json");
+
+    let raw: unknown;
+    try {
+      if (fs.existsSync(yamlPath)) {
+        raw = yaml.load(fs.readFileSync(yamlPath, "utf-8"));
+      } else if (fs.existsSync(jsonPath)) {
+        raw = JSON.parse(fs.readFileSync(jsonPath, "utf-8"));
+      } else {
+        continue;
+      }
+    } catch {
+      unreadableManifestCount += 1;
+      continue;
+    }
+
+    const parsed = PluginManifestSchema.safeParse(raw);
+    if (!parsed.success) {
+      unreadableManifestCount += 1;
+      continue;
+    }
+    if (parsed.data.permissions.shell) {
+      shellPlugins.push(parsed.data.name);
+    }
+  }
+
+  if (shellPlugins.length > 0) {
+    return {
+      name: "Plugin permissions",
+      status: "warn",
+      detail: `${shellPlugins.length} plugin${shellPlugins.length === 1 ? "" : "s"} request shell permission: ${formatNameList(shellPlugins)}`,
+    };
+  }
+
+  if (unreadableManifestCount > 0) {
+    return {
+      name: "Plugin permissions",
+      status: "warn",
+      detail: `${unreadableManifestCount} plugin manifest${unreadableManifestCount === 1 ? "" : "s"} could not be inspected`,
+    };
+  }
+
+  return { name: "Plugin permissions", status: "pass", detail: "no shell-capable plugins found" };
 }
 
 export function checkGoals(baseDir?: string): CheckResult {
@@ -450,6 +596,9 @@ export async function cmdDoctor(_args: string[]): Promise<number> {
     checkPulseedDir(baseDir),
     checkProviderConfig(baseDir),
     checkApiKey(baseDir),
+    checkStateDirectoryPermissions(baseDir),
+    checkProviderConfigPermissions(baseDir),
+    checkPluginPermissionWarnings(baseDir),
     checkGoals(baseDir),
     checkLogDirectory(baseDir),
     checkBuild(),

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -55,7 +55,7 @@ function formatSummary(answers: SetupAnswers): string {
     `Model:     ${answers.model}`,
     `Adapter:   ${answers.adapter}`,
     `API Key:   ${maskKey(answers.apiKey)}`,
-    `Daemon:    ${answers.startDaemon ? `yes (port ${answers.daemonPort})` : "no"}`,
+    `Daemon:    ${answers.startDaemon ? `configured (port ${answers.daemonPort})` : "not configured"}`,
     `Notify:    ${notificationChannels}`,
   ].join("\n");
 }
@@ -403,7 +403,7 @@ export async function runSetupWizard(): Promise<number> {
     } catch {
       p.log.warn("Could not save daemon port to daemon.json");
     }
-    p.log.info("Daemon port " + finalAnswers.daemonPort + " saved.");
+    p.log.info("Daemon port " + finalAnswers.daemonPort + " saved. Start it later with pulseed daemon start or pulseed start --goal <goal-id>.");
   }
 
   if (finalAnswers.notificationConfig) {

--- a/src/interface/cli/commands/setup/steps-runtime.ts
+++ b/src/interface/cli/commands/setup/steps-runtime.ts
@@ -68,7 +68,7 @@ export async function stepDaemon(): Promise<{ start: boolean; port: number }> {
 
   const start = guardCancel(
     await p.confirm({
-      message: "Start PulSeed as a background daemon after setup?",
+      message: "Configure PulSeed background daemon settings for later use?",
       initialValue: false,
     })
   );

--- a/src/orchestrator/execution/__tests__/pipeline-executor.test.ts
+++ b/src/orchestrator/execution/__tests__/pipeline-executor.test.ts
@@ -189,6 +189,52 @@ describe("PipelineExecutor", () => {
     expect(executeMock).toHaveBeenCalledTimes(2);
   });
 
+  it("does not execute a stage when the adapter circuit is open", async () => {
+    for (let i = 0; i < 5; i++) {
+      registry.recordFailure("mock");
+    }
+
+    const executor = new PipelineExecutor(deps);
+    const result = await executor.run(
+      "task-open-circuit",
+      makeAgentTask(),
+      { stages: [{ role: "implementor" }], fail_fast: true },
+    );
+
+    expect(adapter.execute).not.toHaveBeenCalled();
+    expect(result.status).toBe("failed");
+    expect(result.final_verdict).toBe("fail");
+  });
+
+  it("records adapter failures when stage execution throws", async () => {
+    const throwingAdapter: IAdapter = {
+      adapterType: "mock",
+      execute: vi.fn(async () => {
+        throw new Error("boom");
+      }),
+    };
+    const reg = new AdapterRegistry();
+    reg.register(throwingAdapter);
+    const localDeps: PipelineExecutorDeps = {
+      stateManager: stateManager as unknown as PipelineExecutorDeps["stateManager"],
+      adapterRegistry: reg,
+    };
+
+    const executor = new PipelineExecutor(localDeps);
+    await executor.run(
+      "task-throw",
+      makeAgentTask(),
+      { stages: [{ role: "implementor" }], fail_fast: true },
+    );
+
+    expect(throwingAdapter.execute).toHaveBeenCalledOnce();
+    expect(reg.getCircuitState("mock")).toBe("closed");
+    for (let i = 0; i < 4; i++) {
+      reg.recordFailure("mock");
+    }
+    expect(reg.getCircuitState("mock")).toBe("open");
+  });
+
   // ─── 4. State persistence ───
 
   it("calls writeRaw after each stage completion", async () => {

--- a/src/orchestrator/execution/pipeline-executor.ts
+++ b/src/orchestrator/execution/pipeline-executor.ts
@@ -176,7 +176,11 @@ export class PipelineExecutor {
     let plan = "";
     try {
       const adapter = this.selectAdapter(stage);
-      const result = await adapter.execute(planTask);
+      const result = await this.executeAdapterWithCircuitBreaker(adapter, planTask);
+      if (!result.success) {
+        this.logger?.warn("[PipelineExecutor] Plan generation failed", { error: result.error ?? "unknown failure" });
+        return { approved: false, plan: "" };
+      }
       plan = result.output;
     } catch (err) {
       this.logger?.warn("[PipelineExecutor] Plan generation failed", { error: err instanceof Error ? err.message : String(err) });
@@ -243,12 +247,7 @@ export class PipelineExecutor {
         : { ...baseTask, prompt: `${baseTask.prompt}\n\nPREVIOUS ATTEMPT FAILED: ${lastError}\nPlease try again.` };
 
       let result: AgentResult;
-      try {
-        result = await currentAdapter.execute(retryTask);
-      } catch (err) {
-        lastError = err instanceof Error ? err.message : String(err);
-        result = { success: false, output: "", error: lastError, exit_code: null, elapsed_ms: 0, stopped_reason: "error" };
-      }
+      result = await this.executeAdapterWithCircuitBreaker(currentAdapter, retryTask);
 
       if (this.mapResultToVerdict(result) !== "fail") {
         return this.makeStageResult(stageIndex, stage, idempotencyKey, result.success, result.output);
@@ -262,6 +261,40 @@ export class PipelineExecutor {
   }
 
   // ─── Private helpers ───
+
+  private async executeAdapterWithCircuitBreaker(adapter: IAdapter, task: AgentTask): Promise<AgentResult> {
+    if (!this.adapterRegistry.isAvailable(adapter.adapterType)) {
+      return {
+        success: false,
+        output: "",
+        error: `Adapter circuit breaker is open for "${adapter.adapterType}"`,
+        exit_code: null,
+        elapsed_ms: 0,
+        stopped_reason: "error",
+      };
+    }
+
+    let result: AgentResult;
+    try {
+      result = await adapter.execute(task);
+    } catch (err) {
+      result = {
+        success: false,
+        output: "",
+        error: err instanceof Error ? err.message : String(err),
+        exit_code: null,
+        elapsed_ms: 0,
+        stopped_reason: "error",
+      };
+    }
+
+    if (result.success) {
+      this.adapterRegistry.recordSuccess(adapter.adapterType);
+    } else {
+      this.adapterRegistry.recordFailure(adapter.adapterType);
+    }
+    return result;
+  }
 
   private makeStageResult(
     stageIndex: number,

--- a/src/orchestrator/execution/task/task-execution-helpers.ts
+++ b/src/orchestrator/execution/task/task-execution-helpers.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "../../../runtime/logger.js";
 import type { Task } from "../../../base/types/task.js";
-import type { AgentResult, IAdapter } from "../adapter-layer.js";
+import type { AdapterRegistry, AgentResult, IAdapter } from "../adapter-layer.js";
 import type { GuardrailRunner } from "../../../platform/traits/guardrail-runner.js";
 import type { ToolExecutor } from "../../../tools/executor.js";
 import { executeTask as executeTaskDirect } from "./task-executor.js";
@@ -13,6 +13,7 @@ interface ExecuteTaskWithGuardsParams {
   workspaceContext?: string;
   guardrailRunner?: GuardrailRunner;
   toolExecutor?: ToolExecutor;
+  adapterRegistry?: AdapterRegistry;
   stateManager: StateManager;
   sessionManager: SessionManager;
   logger?: Logger;
@@ -28,6 +29,7 @@ export async function executeTaskWithGuards(
     workspaceContext,
     guardrailRunner,
     toolExecutor,
+    adapterRegistry,
     stateManager,
     sessionManager,
     logger,
@@ -97,6 +99,7 @@ export async function executeTaskWithGuards(
     adapter,
     workspaceContext
   );
+  recordAdapterCircuitOutcome(adapterRegistry, adapter.adapterType, result);
 
   if (guardrailRunner) {
     const afterResult = await guardrailRunner.run("after_tool", {
@@ -118,6 +121,19 @@ export async function executeTaskWithGuards(
   }
 
   return result;
+}
+
+function recordAdapterCircuitOutcome(
+  adapterRegistry: AdapterRegistry | undefined,
+  adapterType: string,
+  result: AgentResult
+): void {
+  if (!adapterRegistry) return;
+  if (result.stopped_reason === "error" || result.stopped_reason === "timeout") {
+    adapterRegistry.recordFailure(adapterType);
+    return;
+  }
+  adapterRegistry.recordSuccess(adapterType);
 }
 
 export async function verifyExecutionWithGitDiff(

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -14,7 +14,7 @@ import {
   selectTargetDimension as _selectTargetDimension,
   type DimensionSelectionOptions,
 } from "../context/dimension-selector.js";
-import type { Task, VerificationResult } from "../../../base/types/task.js";
+import { VerificationResultSchema, type Task, type VerificationResult } from "../../../base/types/task.js";
 import type { GapVector } from "../../../base/types/gap.js";
 import type { DriveContext } from "../../../base/types/drive.js";
 import type { Dimension } from "../../../base/types/goal.js";
@@ -583,6 +583,39 @@ export class TaskLifecycle {
       attempt: task.consecutive_failure_count + 1,
     });
 
+    if (this.adapterRegistry && !this.adapterRegistry.isAvailable(adapter.adapterType)) {
+      const reason = `Adapter circuit breaker is open for "${adapter.adapterType}"`;
+      const now = new Date().toISOString();
+      const blockedTask = {
+        ...task,
+        status: "error" as const,
+        completed_at: now,
+        execution_output: reason,
+      };
+      await this.stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, blockedTask);
+      await appendTaskOutcomeEvent(this.stateManager, {
+        task: blockedTask,
+        type: "failed",
+        attempt: task.consecutive_failure_count + 1,
+        reason,
+      });
+      this.logger?.warn(`[task] skipped: ${reason}`, { taskId: task.id });
+
+      return {
+        task: blockedTask,
+        verificationResult: VerificationResultSchema.parse({
+          task_id: task.id,
+          verdict: "fail",
+          confidence: 1,
+          evidence: [{ layer: "mechanical", description: reason, confidence: 1 }],
+          dimension_updates: [],
+          timestamp: now,
+        }),
+        action: "discard",
+        tokensUsed: taskCycleTokens,
+      };
+    }
+
     // 4. Execute task
     this.logger?.debug(`[DEBUG-TL] Executing task ${task.id} via adapter ${adapter.adapterType}`);
     void this.hookManager?.emit("PreExecute", { goal_id: goalId, data: { task_id: task.id } });
@@ -704,6 +737,7 @@ export class TaskLifecycle {
     return {
       guardrailRunner: this.guardrailRunner,
       toolExecutor: this.toolExecutor,
+      adapterRegistry: this.adapterRegistry,
       stateManager: this.stateManager,
       sessionManager: this.sessionManager,
       logger: this.logger,

--- a/src/platform/soil/__tests__/soil-platform.test.ts
+++ b/src/platform/soil/__tests__/soil-platform.test.ts
@@ -7,6 +7,7 @@ import { SoilCompiler } from "../compiler.js";
 import { SoilRetriever } from "../retriever.js";
 import { SoilDoctor } from "../doctor.js";
 import { readSoilMarkdownFile } from "../io.js";
+import { SqliteSoilRepository } from "../sqlite-repository.js";
 
 function fixedClock(): Date {
   return new Date("2026-04-11T10:00:00.000Z");
@@ -220,6 +221,62 @@ describe("Soil doctor", () => {
 
       expect(result.frontmatter.checksum).not.toBeUndefined();
     } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("warns when typed Soil records have not been projected to publishable pages", async () => {
+    const rootDir = makeTempDir("soil-doctor-typed-gap-");
+    const indexPath = path.join(rootDir, ".index", "custom-soil-store.db");
+    let repo: SqliteSoilRepository | null = null;
+    try {
+      repo = await SqliteSoilRepository.create({ rootDir, indexPath });
+      await repo.applyMutation({
+        records: [{
+          record_id: "rec-memory",
+          record_key: "memory.preference",
+          version: 1,
+          record_type: "preference",
+          soil_id: "memory/preferences/rec-memory",
+          title: "Preferred editor",
+          summary: "Use Obsidian as the memory viewer.",
+          canonical_text: "Use Obsidian as the memory viewer.",
+          goal_id: null,
+          task_id: null,
+          status: "active",
+          confidence: 0.9,
+          importance: 0.7,
+          source_reliability: null,
+          valid_from: null,
+          valid_to: null,
+          supersedes_record_id: null,
+          is_active: true,
+          source_type: "knowledge",
+          source_id: "memory-preference",
+          metadata_json: {},
+          created_at: "2026-04-11T09:00:00.000Z",
+          updated_at: "2026-04-11T09:00:00.000Z",
+        }],
+        chunks: [{
+          chunk_id: "chunk-memory",
+          record_id: "rec-memory",
+          soil_id: "memory/preferences/rec-memory",
+          chunk_index: 0,
+          chunk_kind: "paragraph",
+          heading_path_json: [],
+          chunk_text: "Use Obsidian as the memory viewer.",
+          token_count: 7,
+          checksum: "memory",
+          created_at: "2026-04-11T09:00:00.000Z",
+        }],
+      });
+      repo.close();
+      repo = null;
+
+      const report = await SoilDoctor.create({ rootDir, indexPath }).inspect();
+      expect(report.findings.some((finding) => finding.code === "typed-store-projection-gap")).toBe(true);
+    } finally {
+      repo?.close();
       cleanupTempDir(rootDir);
     }
   });

--- a/src/platform/soil/doctor.ts
+++ b/src/platform/soil/doctor.ts
@@ -1,7 +1,8 @@
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { createSoilConfig, type SoilConfig, type SoilConfigInput } from "./config.js";
+import Database from "better-sqlite3";
+import { createSoilConfig, getDefaultSoilSqliteIndexPath, type SoilConfig, type SoilConfigInput } from "./config.js";
 import { computeSoilChecksum } from "./checksum.js";
 import { parseSoilMarkdownLoose } from "./io.js";
 import { loadSoilIndexSnapshot } from "./index-store.js";
@@ -25,7 +26,9 @@ export interface SoilDoctorFinding {
     | "missing-index"
     | "missing-required-page"
     | "index-page-count-mismatch"
-    | "index-checksum-mismatch";
+    | "index-checksum-mismatch"
+    | "typed-store-projection-gap"
+    | "typed-store-unreadable";
   severity: "error" | "warn";
   soilId?: string;
   relativePath: string;
@@ -223,6 +226,7 @@ export class SoilDoctor {
     }
 
     findings.push(...(await this.checkRequiredPages(pages)));
+    findings.push(...(await this.checkTypedStoreProjectionGap(pages)));
 
     return {
       rootDir: this.config.rootDir,
@@ -264,6 +268,98 @@ export class SoilDoctor {
     }
 
     return findings;
+  }
+
+  private async checkTypedStoreProjectionGap(pages: ScannedPage[]): Promise<SoilDoctorFinding[]> {
+    const sqlitePath = await this.resolveTypedStoreSqlitePath();
+    if (sqlitePath === null) {
+      return [];
+    }
+
+    let db: Database.Database | null = null;
+    try {
+      db = new Database(sqlitePath, { readonly: true, fileMustExist: true });
+      const activeRecordCount = this.countSqliteRows(db, "soil_records", "is_active = 1");
+      const typedPageCount = this.countSqliteRows(db, "soil_pages");
+
+      if (activeRecordCount > 0 && typedPageCount === 0) {
+        return [{
+          code: "typed-store-projection-gap",
+          severity: "warn",
+          relativePath: path.relative(this.config.rootDir, sqlitePath) || sqlitePath,
+          absolutePath: sqlitePath,
+          message: "Typed Soil store has active records but no projected pages; Obsidian/Notion snapshot publish only sees Markdown pages",
+          details: {
+            active_record_count: activeRecordCount,
+            typed_page_count: typedPageCount,
+            markdown_page_count: pages.length,
+          },
+        }];
+      }
+
+      if (typedPageCount > pages.length) {
+        return [{
+          code: "typed-store-projection-gap",
+          severity: "warn",
+          relativePath: path.relative(this.config.rootDir, sqlitePath) || sqlitePath,
+          absolutePath: sqlitePath,
+          message: "Typed Soil store has more pages than the Markdown tree; Obsidian/Notion snapshot publish may miss typed-store-only pages",
+          details: {
+            active_record_count: activeRecordCount,
+            typed_page_count: typedPageCount,
+            markdown_page_count: pages.length,
+          },
+        }];
+      }
+
+      return [];
+    } catch (error) {
+      return [{
+        code: "typed-store-unreadable",
+        severity: "warn",
+        relativePath: path.relative(this.config.rootDir, sqlitePath) || sqlitePath,
+        absolutePath: sqlitePath,
+        message: "Typed Soil store could not be inspected",
+        details: { error: error instanceof Error ? error.message : String(error) },
+      }];
+    } finally {
+      db?.close();
+    }
+  }
+
+  private countSqliteRows(db: Database.Database, tableName: "soil_records" | "soil_pages", where?: string): number {
+    const row = db
+      .prepare(`SELECT COUNT(*) AS count FROM ${tableName}${where ? ` WHERE ${where}` : ""}`)
+      .get() as { count: number };
+    return row.count;
+  }
+
+  private async resolveTypedStoreSqlitePath(): Promise<string | null> {
+    const candidates = Array.from(new Set([
+      this.config.indexPath,
+      getDefaultSoilSqliteIndexPath(this.config.rootDir),
+    ]));
+
+    for (const candidate of candidates) {
+      if (await this.isSqliteDatabase(candidate)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  private async isSqliteDatabase(filePath: string): Promise<boolean> {
+    let handle: Awaited<ReturnType<typeof fsp.open>> | null = null;
+    try {
+      handle = await fsp.open(filePath, "r");
+      const buffer = Buffer.alloc(16);
+      const result = await handle.read(buffer, 0, buffer.length, 0);
+      return result.bytesRead === buffer.length && buffer.toString("utf-8") === "SQLite format 3\0";
+    } catch {
+      return false;
+    } finally {
+      await handle?.close();
+    }
   }
 
   private async walk(dir: string, pages: ScannedPage[]): Promise<void> {

--- a/src/platform/soil/health.ts
+++ b/src/platform/soil/health.ts
@@ -50,9 +50,11 @@ function doctorFindingCode(finding: SoilDoctorFinding): SoilMemoryLintFindingCod
     case "watermark-mismatch":
     case "index-checksum-mismatch":
     case "index-page-count-mismatch":
+    case "typed-store-projection-gap":
       return "stale_page";
     case "missing-index":
     case "unsafe-path":
+    case "typed-store-unreadable":
       return "schema_incompatible";
   }
 }

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -559,6 +559,7 @@ export class DaemonRunner {
           },
         },
         {
+          concurrency: this.config.max_concurrent_goals,
           iterationsPerCycle: this.config.iterations_per_cycle,
           stateFilePath: path.join(this.runtimeRoot!, "supervisor-state.json"),
         }

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -23,6 +23,7 @@ export const DaemonConfigSchema = z.object({
   }).default({}),
   goal_intervals: z.record(z.string(), z.number().int().positive()).optional(), // goal_id -> interval_ms override
   iterations_per_cycle: z.number().int().positive().default(10), // max CoreLoop iterations per daemon cycle
+  max_concurrent_goals: z.number().int().positive().default(4), // max goals the supervisor may execute at once
   event_server_port: z.number().int().nonnegative().default(41700), // EventServer HTTP port (0 = OS-assigned, safe for tests)
   proactive_mode: z.boolean().default(false),
   proactive_interval_ms: z.number().default(3_600_000), // 1 hour minimum between proactive ticks

--- a/src/tools/execution/RunAdapterTool/RunAdapterTool.ts
+++ b/src/tools/execution/RunAdapterTool/RunAdapterTool.ts
@@ -34,14 +34,30 @@ export class RunAdapterTool implements ITool<RunAdapterInput, unknown> {
 
   async call(input: RunAdapterInput, _context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
+    let shouldRecordAdapterFailure = false;
     try {
+      if (!this.adapterRegistry.isAvailable(input.adapter_id)) {
+        return {
+          success: false,
+          data: null,
+          summary: `Adapter ${input.adapter_id} skipped: circuit breaker is open`,
+          error: `Adapter circuit breaker is open for "${input.adapter_id}"`,
+          durationMs: Date.now() - startTime,
+        };
+      }
       const adapter = this.adapterRegistry.getAdapter(input.adapter_id);
+      shouldRecordAdapterFailure = true;
       const task: AgentTask = {
         prompt: input.task_description,
         timeout_ms: 60_000,
         adapter_type: input.adapter_id,
       };
       const result = await adapter.execute(task);
+      if (result.success) {
+        this.adapterRegistry.recordSuccess(input.adapter_id);
+      } else {
+        this.adapterRegistry.recordFailure(input.adapter_id);
+      }
       return {
         success: result.success,
         data: result,
@@ -52,6 +68,9 @@ export class RunAdapterTool implements ITool<RunAdapterInput, unknown> {
         durationMs: Date.now() - startTime,
       };
     } catch (err) {
+      if (shouldRecordAdapterFailure) {
+        this.adapterRegistry.recordFailure(input.adapter_id);
+      }
       return {
         success: false,
         data: null,

--- a/src/tools/execution/RunAdapterTool/__tests__/RunAdapterTool.test.ts
+++ b/src/tools/execution/RunAdapterTool/__tests__/RunAdapterTool.test.ts
@@ -29,6 +29,9 @@ describe("RunAdapterTool", () => {
   beforeEach(() => {
     registry = {
       getAdapter: vi.fn(),
+      isAvailable: vi.fn().mockReturnValue(true),
+      recordSuccess: vi.fn(),
+      recordFailure: vi.fn(),
     } as unknown as AdapterRegistry;
     tool = new RunAdapterTool(registry);
   });
@@ -67,6 +70,7 @@ describe("RunAdapterTool", () => {
     expect(result.success).toBe(true);
     expect(result.summary).toContain("claude");
     expect(mockAdapter.execute).toHaveBeenCalledOnce();
+    expect(registry.recordSuccess).toHaveBeenCalledWith("claude");
   });
 
   it("returns failure when adapter result is unsuccessful", async () => {
@@ -80,6 +84,35 @@ describe("RunAdapterTool", () => {
     );
     expect(result.success).toBe(false);
     expect(result.error).toContain("timeout");
+    expect(registry.recordFailure).toHaveBeenCalledWith("claude");
+  });
+
+  it("records failure when adapter execution throws", async () => {
+    const mockAdapter = { execute: vi.fn().mockRejectedValue(new Error("boom")) };
+    vi.mocked(registry.getAdapter).mockReturnValue(mockAdapter as any);
+
+    const result = await tool.call(
+      { adapter_id: "claude", task_description: "do x" },
+      makeContext(),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("boom");
+    expect(registry.recordFailure).toHaveBeenCalledWith("claude");
+  });
+
+  it("does not execute adapter when circuit breaker is open", async () => {
+    const mockAdapter = { execute: vi.fn().mockResolvedValue(mockResult) };
+    vi.mocked(registry.isAvailable).mockReturnValue(false);
+    vi.mocked(registry.getAdapter).mockReturnValue(mockAdapter as any);
+
+    const result = await tool.call(
+      { adapter_id: "claude", task_description: "do x" },
+      makeContext(),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("circuit breaker");
+    expect(mockAdapter.execute).not.toHaveBeenCalled();
+    expect(registry.getAdapter).not.toHaveBeenCalled();
   });
 
   it("handles registry error gracefully", async () => {

--- a/src/tools/execution/SoilDoctorTool/prompt.ts
+++ b/src/tools/execution/SoilDoctorTool/prompt.ts
@@ -1,2 +1,2 @@
 export const DESCRIPTION =
-  "Inspect Soil pages and report invalid frontmatter, checksum drift, duplicate soil IDs, watermark mismatches, and missing local source paths.";
+  "Inspect Soil pages and report invalid frontmatter, checksum drift, duplicate soil IDs, watermark mismatches, missing local source paths, and typed Soil store projection gaps.";


### PR DESCRIPTION
## Summary
- Add `pulseed doctor` checks for PulSeed state permissions, provider config permissions, and shell-capable plugin manifests.
- Wire existing adapter circuit breaker behavior into direct adapter execution, `run-adapter`, and pipeline execution without treating no-op task outcomes as adapter failures.
- Add daemon `max_concurrent_goals` config and CLI/status visibility so the supervisor has an explicit concurrency cap.
- Add Soil doctor warnings for typed Soil store records/pages that are not reflected in the Markdown publish surface.
- Clarify setup wizard daemon wording so setup stores daemon configuration rather than implying it starts the daemon.

## Related
- Created follow-up issue for typed Soil display integration updates: #660

## Validation
- `npm run typecheck`
- `npm test -- --run src/interface/cli/__tests__/cli-doctor.test.ts src/tools/execution/RunAdapterTool/__tests__/RunAdapterTool.test.ts src/platform/soil/__tests__/soil-platform.test.ts src/orchestrator/execution/__tests__/pipeline-executor.test.ts src/orchestrator/execution/__tests__/task-lifecycle-cycle-failure.test.ts src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts src/interface/cli/__tests__/cli-daemon-status.test.ts src/runtime/__tests__/loop-supervisor.test.ts`