### PR TITLE
[codex] Harden state transaction boundaries

### DIFF
--- a/src/base/state/__tests__/state-lock.test.ts
+++ b/src/base/state/__tests__/state-lock.test.ts
@@ -15,7 +15,7 @@ describe("state-lock", () => {
   it("basic acquire and release round-trip", async () => {
     tmpDir = makeTempDir();
     await acquireLock("goal-1", tmpDir);
-    const lockDir = path.join(tmpDir, "goals", "goal-1", ".lock");
+    const lockDir = path.join(tmpDir, "locks", "goals", "goal-1.lock");
     expect(fs.existsSync(lockDir)).toBe(true);
     await releaseLock("goal-1", tmpDir);
     expect(fs.existsSync(lockDir)).toBe(false);
@@ -24,10 +24,26 @@ describe("state-lock", () => {
   it("pid file is written with current process pid", async () => {
     tmpDir = makeTempDir();
     await acquireLock("goal-pid", tmpDir);
-    const pidFile = path.join(tmpDir, "goals", "goal-pid", ".lock", "pid");
+    const pidFile = path.join(tmpDir, "locks", "goals", "goal-pid.lock", "pid");
     const written = await fsp.readFile(pidFile, "utf-8");
     expect(parseInt(written.trim(), 10)).toBe(process.pid);
     await releaseLock("goal-pid", tmpDir);
+  });
+
+  it("also acquires the legacy goal-dir lock when the goal directory exists", async () => {
+    tmpDir = makeTempDir();
+    await fsp.mkdir(path.join(tmpDir, "goals", "goal-legacy"), { recursive: true });
+
+    await acquireLock("goal-legacy", tmpDir);
+
+    const stableLockDir = path.join(tmpDir, "locks", "goals", "goal-legacy.lock");
+    const legacyLockDir = path.join(tmpDir, "goals", "goal-legacy", ".lock");
+    expect(fs.existsSync(stableLockDir)).toBe(true);
+    expect(fs.existsSync(legacyLockDir)).toBe(true);
+
+    await releaseLock("goal-legacy", tmpDir);
+    expect(fs.existsSync(stableLockDir)).toBe(false);
+    expect(fs.existsSync(legacyLockDir)).toBe(false);
   });
 
   it("release on non-existent lock is a no-op (does not throw)", async () => {
@@ -47,7 +63,7 @@ describe("state-lock", () => {
   it("stale lock (dead PID) is cleared and re-acquired", async () => {
     tmpDir = makeTempDir();
     // Write a fake lock with a PID that cannot be alive (PID 0 is always invalid for kill)
-    const lockDir = path.join(tmpDir, "goals", "goal-stale", ".lock");
+    const lockDir = path.join(tmpDir, "locks", "goals", "goal-stale.lock");
     await fsp.mkdir(lockDir, { recursive: true });
     await fsp.writeFile(path.join(lockDir, "pid"), "999999999", "utf-8");
 

--- a/src/base/state/__tests__/state-manager-wal.test.ts
+++ b/src/base/state/__tests__/state-manager-wal.test.ts
@@ -7,6 +7,7 @@ import { appendWALRecord } from "../state-wal.js";
 import { listSnapshots } from "../state-snapshot.js";
 import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { makeGoal } from "../../../../tests/helpers/fixtures.js";
+import type { ObservationLogEntry } from "../../types/state.js";
 
 describe("StateManager WAL integration", () => {
   let tmpDir: string;
@@ -70,6 +71,82 @@ describe("StateManager WAL integration", () => {
     const loaded = await sm.loadGoal(goalId);
     expect(loaded).not.toBeNull();
     expect(loaded!.id).toBe(goalId);
+  });
+
+  it("crash recovery replays combined observation + goal intent", async () => {
+    const goalId = "g-observation-apply";
+    const goalDir = path.join(tmpDir, "goals", goalId);
+    fs.mkdirSync(goalDir, { recursive: true });
+
+    const goal = makeGoal({
+      id: goalId,
+      dimensions: [
+        {
+          name: "dim-a",
+          label: "Dimension A",
+          current_value: 1,
+          threshold: { type: "min", value: 1 },
+          confidence: 0.9,
+          observation_method: {
+            type: "mechanical",
+            source: "test",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "mechanical",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+
+    const entry: ObservationLogEntry = {
+      observation_id: "obs-apply",
+      timestamp: new Date().toISOString(),
+      trigger: "periodic",
+      goal_id: goalId,
+      dimension_name: "dim-a",
+      layer: "mechanical",
+      method: {
+        type: "mechanical",
+        source: "test",
+        schedule: null,
+        endpoint: null,
+        confidence_tier: "mechanical",
+      },
+      raw_result: 2,
+      extracted_value: 2,
+      confidence: 0.9,
+      notes: null,
+    };
+
+    await appendWALRecord(goalId, tmpDir, {
+      op: "append_observation_and_save_goal",
+      data: {
+        observationLog: {
+          goal_id: goalId,
+          entries: [entry],
+        },
+        goal,
+      },
+      ts: new Date().toISOString(),
+    });
+
+    const sm = new StateManager(tmpDir, undefined, { walEnabled: true });
+    await sm.init();
+
+    const loadedGoal = await sm.loadGoal(goalId);
+    expect(loadedGoal).not.toBeNull();
+    expect(loadedGoal!.dimensions[0]!.current_value).toBe(1);
+
+    const loadedLog = await sm.loadObservationLog(goalId);
+    expect(loadedLog).not.toBeNull();
+    expect(loadedLog!.entries).toHaveLength(1);
+    expect(loadedLog!.entries[0]!.observation_id).toBe("obs-apply");
   });
 
   it("snapshot is created every 50 writes", async () => {

--- a/src/base/state/__tests__/state-manager.test.ts
+++ b/src/base/state/__tests__/state-manager.test.ts
@@ -428,6 +428,70 @@ describe("StateManager", async () => {
       expect(loaded!.entries[1].observation_id).toBe("obs-b");
     });
 
+    it("serializes concurrent appendObservation calls without losing entries", async () => {
+      await manager.saveGoal(makeGoal({ id: "append-obs-concurrent" }));
+
+      let releaseFence: () => void = () => {
+        throw new Error("releaseFence was not initialized");
+      };
+      let resolveFirstFence: () => void = () => {};
+      const firstEnteredFence = new Promise<void>((resolve) => {
+        resolveFirstFence = resolve;
+      });
+      let fenceCalls = 0;
+      manager.setWriteFence("append-obs-concurrent", async () => {
+        fenceCalls += 1;
+        if (fenceCalls === 1) {
+          resolveFirstFence();
+          await new Promise<void>((resolve) => {
+            releaseFence = resolve;
+          });
+        }
+      });
+
+      const entry1: ObservationLogEntry = {
+        observation_id: "obs-concurrent-a",
+        timestamp: new Date().toISOString(),
+        trigger: "periodic",
+        goal_id: "append-obs-concurrent",
+        dimension_name: "dim1",
+        layer: "mechanical",
+        method: {
+          type: "api_query",
+          source: "api",
+          schedule: null,
+          endpoint: null,
+          confidence_tier: "mechanical",
+        },
+        raw_result: 10,
+        extracted_value: 10,
+        confidence: 0.9,
+        notes: null,
+      };
+
+      const entry2: ObservationLogEntry = {
+        ...entry1,
+        observation_id: "obs-concurrent-b",
+        extracted_value: 20,
+      };
+
+      const first = manager.appendObservation("append-obs-concurrent", entry1);
+      await firstEnteredFence;
+      const second = manager.appendObservation("append-obs-concurrent", entry2);
+
+      expect(fenceCalls).toBe(1);
+      releaseFence();
+
+      await Promise.all([first, second]);
+
+      const loaded = await manager.loadObservationLog("append-obs-concurrent");
+      expect(loaded!.entries).toHaveLength(2);
+      expect(loaded!.entries.map((entry) => entry.observation_id)).toEqual([
+        "obs-concurrent-a",
+        "obs-concurrent-b",
+      ]);
+    }, 30_000);
+
     it("rejects appendObservation when entry goal_id does not match", async () => {
       await manager.saveGoal(makeGoal({ id: "append-obs-mismatch" }));
 
@@ -506,6 +570,54 @@ describe("StateManager", async () => {
       expect(loaded[0].gap_vector[0].normalized_weighted_gap).toBe(0.8);
       expect(loaded[1].gap_vector[0].normalized_weighted_gap).toBe(0.6);
     });
+
+    it("serializes concurrent appendGapHistoryEntry calls without losing entries", async () => {
+      await manager.saveGoal(makeGoal({ id: "gap-append-concurrent" }));
+
+      let releaseFence: () => void = () => {
+        throw new Error("releaseFence was not initialized");
+      };
+      let resolveFirstFence: () => void = () => {};
+      const firstEnteredFence = new Promise<void>((resolve) => {
+        resolveFirstFence = resolve;
+      });
+      let fenceCalls = 0;
+      manager.setWriteFence("gap-append-concurrent", async () => {
+        fenceCalls += 1;
+        if (fenceCalls === 1) {
+          resolveFirstFence();
+          await new Promise<void>((resolve) => {
+            releaseFence = resolve;
+          });
+        }
+      });
+
+      const entry1: GapHistoryEntry = {
+        iteration: 1,
+        timestamp: new Date().toISOString(),
+        gap_vector: [{ dimension_name: "d", normalized_weighted_gap: 0.8 }],
+        confidence_vector: [{ dimension_name: "d", confidence: 0.5 }],
+      };
+
+      const entry2: GapHistoryEntry = {
+        iteration: 2,
+        timestamp: new Date().toISOString(),
+        gap_vector: [{ dimension_name: "d", normalized_weighted_gap: 0.6 }],
+        confidence_vector: [{ dimension_name: "d", confidence: 0.7 }],
+      };
+
+      const first = manager.appendGapHistoryEntry("gap-append-concurrent", entry1);
+      await firstEnteredFence;
+      const second = manager.appendGapHistoryEntry("gap-append-concurrent", entry2);
+
+      expect(fenceCalls).toBe(1);
+      releaseFence();
+
+      await Promise.all([first, second]);
+
+      const loaded = await manager.loadGapHistory("gap-append-concurrent");
+      expect(loaded.map((entry) => entry.iteration)).toEqual([1, 2]);
+    }, 30_000);
 
     it("returns empty array for non-existent gap history", async () => {
       expect(await manager.loadGapHistory("nonexistent")).toEqual([]);
@@ -898,6 +1010,43 @@ describe("StateManager", async () => {
       // Reports moved
       expect(fs.existsSync(path.join(archiveBase, "reports", "report.json"))).toBe(true);
       expect(fs.existsSync(reportsDir)).toBe(false);
+    });
+
+    it("serializes concurrent archiveGoal calls on the same goal", async () => {
+      const goalId = "archive-locked";
+      await manager.saveGoal(makeGoal({ id: goalId }));
+
+      let releaseFence: () => void = () => {
+        throw new Error("releaseFence was not initialized");
+      };
+      let resolveFirstFence: () => void = () => {};
+      const firstEnteredFence = new Promise<void>((resolve) => {
+        resolveFirstFence = resolve;
+      });
+      let fenceCalls = 0;
+      manager.setWriteFence(goalId, async () => {
+        fenceCalls += 1;
+        if (fenceCalls === 1) {
+          resolveFirstFence();
+          await new Promise<void>((resolve) => {
+            releaseFence = resolve;
+          });
+        }
+      });
+
+      const first = manager.archiveGoal(goalId);
+      await firstEnteredFence;
+      const second = manager.archiveGoal(goalId);
+
+      expect(fenceCalls).toBe(1);
+      releaseFence();
+
+      await expect(first).resolves.toBe(true);
+      await expect(second).resolves.toBe(false);
+
+      const archiveBase = path.join(tmpDir, "archive", goalId);
+      expect(fs.existsSync(path.join(archiveBase, "goal", "goal.json"))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, "goals", goalId))).toBe(false);
     });
 
     it("returns false for non-existent goal", async () => {

--- a/src/base/state/state-lock.ts
+++ b/src/base/state/state-lock.ts
@@ -3,7 +3,9 @@ import * as path from "node:path";
 
 /**
  * Per-goal advisory locking using lockfiles.
- * Lock path: <baseDir>/goals/<goalId>/.lock/
+ * Lock path: <baseDir>/locks/goals/<goalId>.lock/
+ * Transition compatibility: also acquire <baseDir>/goals/<goalId>/.lock
+ * when the legacy goal directory already exists.
  * Uses mkdir as atomic primitive (POSIX: EEXIST = lock held).
  */
 
@@ -14,11 +16,25 @@ export interface LockOptions {
 }
 
 function lockPath(goalId: string, baseDir: string): string {
+  return path.join(baseDir, "locks", "goals", `${goalId}.lock`);
+}
+
+function legacyLockPath(goalId: string, baseDir: string): string {
   return path.join(baseDir, "goals", goalId, ".lock");
 }
 
 function pidFilePath(lockDir: string): string {
   return path.join(lockDir, "pid");
+}
+
+async function pathExists(dir: string): Promise<boolean> {
+  try {
+    await fsp.access(dir);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
+  }
 }
 
 async function isProcessAlive(pid: number): Promise<boolean> {
@@ -69,20 +85,19 @@ async function clearStaleLock(lockDir: string): Promise<void> {
   }
 }
 
-/** Acquire an advisory lock for the given goalId. Throws if timeout exceeded. */
-export async function acquireLock(
-  goalId: string,
-  baseDir: string,
-  opts?: LockOptions
+async function acquireLockDir(
+  lockDir: string,
+  label: string,
+  opts?: LockOptions,
+  createParent = true
 ): Promise<void> {
   const maxRetries = opts?.maxRetries ?? 5;
   const initialDelayMs = opts?.initialDelayMs ?? 50;
   const maxTotalMs = opts?.maxTotalMs ?? 500;
 
-  const lockDir = lockPath(goalId, baseDir);
-
-  // Ensure parent dir exists
-  await fsp.mkdir(path.dirname(lockDir), { recursive: true });
+  if (createParent) {
+    await fsp.mkdir(path.dirname(lockDir), { recursive: true });
+  }
 
   const start = Date.now();
   let delay = initialDelayMs;
@@ -93,23 +108,56 @@ export async function acquireLock(
     }
 
     if (Date.now() - start >= maxTotalMs) {
-      throw new Error(`acquireLock: timeout exceeded for goal "${goalId}" after ${maxTotalMs}ms`);
+      throw new Error(`acquireLock: timeout exceeded for "${label}" after ${maxTotalMs}ms`);
     }
 
     await new Promise((resolve) => setTimeout(resolve, delay));
     delay = Math.min(delay * 2, maxTotalMs);
   }
 
-  throw new Error(`acquireLock: max retries exceeded for goal "${goalId}"`);
+  throw new Error(`acquireLock: max retries exceeded for "${label}"`);
 }
 
-/** Release the advisory lock for the given goalId. No-op if lock does not exist. */
-export async function releaseLock(goalId: string, baseDir: string): Promise<void> {
-  const lockDir = lockPath(goalId, baseDir);
+async function releaseLockDir(lockDir: string): Promise<void> {
   try {
     await fsp.rm(lockDir, { recursive: true, force: true });
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
     throw err;
   }
+}
+
+async function shouldAcquireLegacyLock(goalId: string, baseDir: string): Promise<boolean> {
+  return pathExists(path.join(baseDir, "goals", goalId));
+}
+
+/** Acquire an advisory lock for the given goalId. Throws if timeout exceeded. */
+export async function acquireLock(
+  goalId: string,
+  baseDir: string,
+  opts?: LockOptions
+): Promise<void> {
+  const legacyLockDir = legacyLockPath(goalId, baseDir);
+  const needsLegacyLock = await shouldAcquireLegacyLock(goalId, baseDir);
+  if (needsLegacyLock) {
+    try {
+      await acquireLockDir(legacyLockDir, `${goalId} legacy`, opts, false);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    }
+  }
+
+  const stableLockDir = lockPath(goalId, baseDir);
+  try {
+    await acquireLockDir(stableLockDir, goalId, opts);
+  } catch (err) {
+    if (needsLegacyLock) await releaseLockDir(legacyLockDir);
+    throw err;
+  }
+}
+
+/** Release the advisory lock for the given goalId. No-op if lock does not exist. */
+export async function releaseLock(goalId: string, baseDir: string): Promise<void> {
+  await releaseLockDir(lockPath(goalId, baseDir));
+  await releaseLockDir(legacyLockPath(goalId, baseDir));
 }

--- a/src/base/state/state-manager-goal-write.ts
+++ b/src/base/state/state-manager-goal-write.ts
@@ -57,18 +57,67 @@ export class GoalWriteCoordinator {
     data: unknown,
     writeFn: () => Promise<void>,
   ): Promise<void> {
-    if (!this.walEnabled) {
-      await this.assertWriteFence(goalId, op, data);
-      await writeFn();
-      return;
-    }
-
     await acquireLock(goalId, this.baseDir);
     try {
       await this.assertWriteFence(goalId, op, data);
+      if (!this.walEnabled) {
+        await writeFn();
+        return;
+      }
       const ts = new Date().toISOString();
       await appendWALRecord(goalId, this.baseDir, { op, data, ts });
       await writeFn();
+      await appendWALRecord(goalId, this.baseDir, {
+        op: "commit",
+        ref_ts: ts,
+        ts: new Date().toISOString(),
+      });
+      this.writeCount.set(goalId, (this.writeCount.get(goalId) || 0) + 1);
+      const count = this.writeCount.get(goalId)!;
+      if (count % 50 === 0) {
+        const fullGoal = await this.loadGoal(goalId);
+        if (fullGoal !== null) await writeSnapshot(goalId, this.baseDir, fullGoal);
+      }
+      if (count % 100 === 0) await compactWAL(goalId, this.baseDir);
+    } finally {
+      await releaseLock(goalId, this.baseDir);
+    }
+  }
+
+  /** Wrap a goal-scoped operation with lock + fence only (no WAL). */
+  async protectedOperation(
+    goalId: string,
+    op: string,
+    data: unknown,
+    run: () => Promise<void>,
+  ): Promise<void> {
+    await acquireLock(goalId, this.baseDir);
+    try {
+      await this.assertWriteFence(goalId, op, data);
+      await run();
+    } finally {
+      await releaseLock(goalId, this.baseDir);
+    }
+  }
+
+  /** Wrap a locked read-modify-write cycle with lock + WAL + snapshot cycle. */
+  async protectedReadModifyWrite<TData>(
+    goalId: string,
+    op: string,
+    buildData: () => Promise<TData>,
+    writeFn: (data: TData) => Promise<void>,
+  ): Promise<void> {
+    await acquireLock(goalId, this.baseDir);
+    try {
+      const data = await buildData();
+      await this.assertWriteFence(goalId, op, data);
+      if (!this.walEnabled) {
+        await writeFn(data);
+        return;
+      }
+      const ts = new Date().toISOString();
+      await appendWALRecord(goalId, this.baseDir, { op, data, ts });
+      await writeFn(data);
       await appendWALRecord(goalId, this.baseDir, {
         op: "commit",
         ref_ts: ts,

--- a/src/base/state/state-manager-wal.ts
+++ b/src/base/state/state-manager-wal.ts
@@ -68,6 +68,18 @@ export async function replayStateManagerIntent(
       }
       break;
     }
+    case "append_observation_and_save_goal": {
+      const goal = data?.goal as Record<string, unknown> | undefined;
+      const observationLog = data?.observationLog;
+      const goalId = goal?.id as string | undefined;
+      if (goalId && observationLog && goal) {
+        const dir = path.join(baseDir, "goals", goalId);
+        await fsp.mkdir(dir, { recursive: true });
+        await atomicWrite(path.join(dir, "observations.json"), observationLog);
+        await atomicWrite(path.join(dir, "goal.json"), goal);
+      }
+      break;
+    }
     case "save_gap_history":
     case "append_gap_entry": {
       const goalId = data?.goalId as string;

--- a/src/base/state/state-manager.ts
+++ b/src/base/state/state-manager.ts
@@ -207,14 +207,6 @@ export class StateManager {
     }
   }
 
-  private async buildAppendedObservationLog(goalId: string, entry: ObservationLogEntry): Promise<ObservationLog> {
-    const log = (await this.loadObservationLog(goalId)) ?? { goal_id: goalId, entries: [] };
-    return {
-      ...log,
-      entries: this.capHistoryEntries([...log.entries, entry]),
-    };
-  }
-
   private async writeObservationLog(
     goalId: string,
     op: string,
@@ -291,73 +283,78 @@ export class StateManager {
    */
   async archiveGoal(goalId: string, _visited = new Set<string>()): Promise<boolean> {
     if (!this.markGoalVisited(goalId, _visited)) return false;
+    let archived = false;
+    await this.goalWriteCoordinator.protectedOperation(goalId, "archive_goal", { goalId }, async () => {
+      const location = await this.resolveGoalLocation(goalId, false);
+      if (location === null) return;
 
-    const location = await this.resolveGoalLocation(goalId, false);
-    if (location === null) return false;
+      // Recursively archive children first (depth-first)
+      await this.visitChildGoals(goalId, location, _visited, (childId, visited) => this.archiveGoal(childId, visited));
 
-    // Recursively archive children first (depth-first)
-    await this.visitChildGoals(goalId, location, _visited, (childId, visited) => this.archiveGoal(childId, visited));
+      const archiveBase = path.join(this.baseDir, "archive", goalId);
+      await fsp.mkdir(archiveBase, { recursive: true });
 
-    const archiveBase = path.join(this.baseDir, "archive", goalId);
-    await fsp.mkdir(archiveBase, { recursive: true });
+      // Move goals/<goalId>/ → archive/<goalId>/goal/
+      const archiveGoalDir = path.join(archiveBase, "goal");
+      await fsp.cp(location.dir, archiveGoalDir, {
+        recursive: true,
+        filter: (source) => path.basename(source) !== ".lock",
+      });
 
-    // Move goals/<goalId>/ → archive/<goalId>/goal/
-    const archiveGoalDir = path.join(archiveBase, "goal");
-    await fsp.cp(location.dir, archiveGoalDir, { recursive: true });
-    await fsp.rm(location.dir, { recursive: true, force: true });
-
-    // Update status to "archived" in the archived goal.json (Bug 5)
-    // Use direct JSON merge instead of GoalSchema.parse() to avoid silent failure
-    // when unrelated fields fail Zod validation, which would leave status as "active".
-    const archivedGoalJsonPath = path.join(archiveGoalDir, "goal.json");
-    try {
-      const archivedRaw = await this.atomicRead<unknown>(archivedGoalJsonPath);
-      if (archivedRaw !== null && typeof archivedRaw === "object") {
-        await this.atomicWrite(archivedGoalJsonPath, { ...(archivedRaw as Record<string, unknown>), status: "archived" });
-      } else {
-        this.logger?.warn(`[StateManager] Could not update status to "archived" for "${goalId}": goal.json missing or not an object`);
+      // Update status to "archived" in the archived goal.json (Bug 5)
+      // Use direct JSON merge instead of GoalSchema.parse() to avoid silent failure
+      // when unrelated fields fail Zod validation, which would leave status as "active".
+      const archivedGoalJsonPath = path.join(archiveGoalDir, "goal.json");
+      try {
+        const archivedRaw = await this.atomicRead<unknown>(archivedGoalJsonPath);
+        if (archivedRaw !== null && typeof archivedRaw === "object") {
+          await this.atomicWrite(archivedGoalJsonPath, { ...(archivedRaw as Record<string, unknown>), status: "archived" });
+        } else {
+          this.logger?.warn(`[StateManager] Could not update status to "archived" for "${goalId}": goal.json missing or not an object`);
+        }
+      } catch (err) {
+        this.logger?.warn(`[StateManager] Could not update status to "archived" for "${goalId}": ${String(err)}`);
       }
-    } catch (err) {
-      this.logger?.warn(`[StateManager] Could not update status to "archived" for "${goalId}": ${String(err)}`);
-    }
 
-    // Move tasks/<goalId>/ → archive/<goalId>/tasks/ (if exists)
-    const tasksDir = path.join(this.baseDir, "tasks", goalId);
-    try {
-      await fsp.access(tasksDir);
-      const archiveTasksDir = path.join(archiveBase, "tasks");
-      await fsp.cp(tasksDir, archiveTasksDir, { recursive: true });
-      await fsp.rm(tasksDir, { recursive: true, force: true });
-    } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
+      // Move tasks/<goalId>/ → archive/<goalId>/tasks/ (if exists)
+      const tasksDir = path.join(this.baseDir, "tasks", goalId);
+      try {
+        await fsp.access(tasksDir);
+        const archiveTasksDir = path.join(archiveBase, "tasks");
+        await fsp.cp(tasksDir, archiveTasksDir, { recursive: true });
+        await fsp.rm(tasksDir, { recursive: true, force: true });
+      } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
 
-    // Move strategies/<goalId>/ → archive/<goalId>/strategies/ (if exists)
-    const strategiesDir = path.join(this.baseDir, "strategies", goalId);
-    try {
-      await fsp.access(strategiesDir);
-      const archiveStrategiesDir = path.join(archiveBase, "strategies");
-      await fsp.cp(strategiesDir, archiveStrategiesDir, { recursive: true });
-      await fsp.rm(strategiesDir, { recursive: true, force: true });
-    } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
+      // Move strategies/<goalId>/ → archive/<goalId>/strategies/ (if exists)
+      const strategiesDir = path.join(this.baseDir, "strategies", goalId);
+      try {
+        await fsp.access(strategiesDir);
+        const archiveStrategiesDir = path.join(archiveBase, "strategies");
+        await fsp.cp(strategiesDir, archiveStrategiesDir, { recursive: true });
+        await fsp.rm(strategiesDir, { recursive: true, force: true });
+      } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
 
-    // Move stalls/<goalId>.json → archive/<goalId>/stalls.json (if exists)
-    const stallsFile = path.join(this.baseDir, "stalls", `${goalId}.json`);
-    try {
-      await fsp.access(stallsFile);
-      const archiveStallsFile = path.join(archiveBase, "stalls.json");
-      await fsp.cp(stallsFile, archiveStallsFile);
-      await fsp.rm(stallsFile, { force: true });
-    } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
+      // Move stalls/<goalId>.json → archive/<goalId>/stalls.json (if exists)
+      const stallsFile = path.join(this.baseDir, "stalls", `${goalId}.json`);
+      try {
+        await fsp.access(stallsFile);
+        const archiveStallsFile = path.join(archiveBase, "stalls.json");
+        await fsp.cp(stallsFile, archiveStallsFile);
+        await fsp.rm(stallsFile, { force: true });
+      } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
 
-    // Move reports/<goalId>/ → archive/<goalId>/reports/ (if exists)
-    const reportsDir = path.join(this.baseDir, "reports", goalId);
-    try {
-      await fsp.access(reportsDir);
-      const archiveReportsDir = path.join(archiveBase, "reports");
-      await fsp.cp(reportsDir, archiveReportsDir, { recursive: true });
-      await fsp.rm(reportsDir, { recursive: true, force: true });
-    } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
-
-    return true;
+      // Move reports/<goalId>/ → archive/<goalId>/reports/ (if exists)
+      const reportsDir = path.join(this.baseDir, "reports", goalId);
+      try {
+        await fsp.access(reportsDir);
+        const archiveReportsDir = path.join(archiveBase, "reports");
+        await fsp.cp(reportsDir, archiveReportsDir, { recursive: true });
+        await fsp.rm(reportsDir, { recursive: true, force: true });
+      } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
+      await fsp.rm(location.dir, { recursive: true, force: true });
+      archived = true;
+    });
+    return archived;
   }
 
   /**
@@ -437,8 +434,21 @@ export class StateManager {
   async appendObservation(goalId: string, entry: ObservationLogEntry): Promise<void> {
     const parsed = ObservationLogEntrySchema.parse(entry);
     this.assertObservationGoalId(goalId, parsed);
-    const log = await this.buildAppendedObservationLog(goalId, parsed);
-    await this.writeObservationLog(goalId, "append_observation", log, false);
+    await this.goalWriteCoordinator.protectedReadModifyWrite(
+      goalId,
+      "append_observation",
+      async () => {
+        const log = (await this.loadObservationLog(goalId)) ?? { goal_id: goalId, entries: [] };
+        return {
+          ...log,
+          entries: this.capHistoryEntries([...log.entries, parsed]),
+        };
+      },
+      async (log) => {
+        const dir = await this.goalDir(goalId);
+        await this.atomicWrite(path.join(dir, "observations.json"), log);
+      }
+    );
   }
 
   // ─── Gap History ───
@@ -462,9 +472,59 @@ export class StateManager {
 
   async appendGapHistoryEntry(goalId: string, entry: GapHistoryEntry): Promise<void> {
     const parsed = GapHistoryEntrySchema.parse(entry);
-    const history = await this.loadGapHistory(goalId);
-    const trimmed = this.capHistoryEntries([...history, parsed]);
-    await this.writeGapHistory(goalId, "append_gap_entry", trimmed, false);
+    await this.goalWriteCoordinator.protectedReadModifyWrite(
+      goalId,
+      "append_gap_entry",
+      async () => {
+        const history = await this.loadGapHistory(goalId);
+        return {
+          goalId,
+          entries: this.capHistoryEntries([...history, parsed]),
+        };
+      },
+      async (payload) => {
+        const dir = await this.goalDir(goalId);
+        await this.atomicWrite(path.join(dir, "gap-history.json"), payload.entries);
+      }
+    );
+  }
+
+  async appendObservationAndSaveGoal(
+    goalId: string,
+    entry: ObservationLogEntry,
+    updateGoal: (goal: Goal) => Goal
+  ): Promise<void> {
+    const parsed = ObservationLogEntrySchema.parse(entry);
+    this.assertObservationGoalId(goalId, parsed);
+
+    await this.goalWriteCoordinator.protectedReadModifyWrite(
+      goalId,
+      "append_observation_and_save_goal",
+      async () => {
+        const goal = await this.loadGoal(goalId);
+        if (goal === null) {
+          throw new StateError(`appendObservationAndSaveGoal: goal "${goalId}" not found`);
+        }
+
+        const observationLog = (await this.loadObservationLog(goalId)) ?? { goal_id: goalId, entries: [] };
+        const updatedGoal = GoalSchema.parse(updateGoal(goal));
+        if (updatedGoal.id !== goalId) {
+          throw new StateError(`appendObservationAndSaveGoal: update changed goal id from "${goalId}" to "${updatedGoal.id}"`);
+        }
+        return {
+          observationLog: {
+            ...observationLog,
+            entries: this.capHistoryEntries([...observationLog.entries, parsed]),
+          },
+          goal: updatedGoal,
+        };
+      },
+      async (data) => {
+        const dir = await this.goalDir(goalId);
+        await this.atomicWrite(path.join(dir, "observations.json"), data.observationLog);
+        await this.atomicWrite(path.join(dir, "goal.json"), data.goal);
+      }
+    );
   }
 
   /**

--- a/src/platform/observation/__tests__/observation-crossvalidation-override.test.ts
+++ b/src/platform/observation/__tests__/observation-crossvalidation-override.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import { ObservationEngine } from "../observation-engine.js";
 import { StateManager } from "../../../base/state/state-manager.js";
 import type { ObservationMethod } from "../../../base/types/core.js";
+import type { ObservationLogEntry } from "../../../base/types/state.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import type { IDataSourceAdapter } from "../data-source-adapter.js";
 import type { DataSourceConfig } from "../../../base/types/data-source.js";
@@ -425,5 +426,121 @@ describe("observation-apply value bounds validation", () => {
 
     // Value should be clamped to 20 (2x threshold value of 10)
     expect(dim!.current_value).toBe(20);
+  });
+
+  it("serializes concurrent applyObservation calls without dropping goal updates", async () => {
+    const goal = makeGoal({
+      id: "goal-apply-concurrent",
+      dimensions: [
+        {
+          name: "dim-a",
+          label: "Dimension A",
+          current_value: 0,
+          threshold: { type: "min", value: 10 },
+          confidence: 0.90,
+          observation_method: {
+            type: "llm_review",
+            source: "llm",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "independent_review",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+        {
+          name: "dim-b",
+          label: "Dimension B",
+          current_value: 0,
+          threshold: { type: "min", value: 10 },
+          confidence: 0.90,
+          observation_method: {
+            type: "llm_review",
+            source: "llm",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "independent_review",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await stateManager.saveGoal(goal);
+
+    let releaseFence: () => void = () => {
+      throw new Error("releaseFence was not initialized");
+    };
+    let resolveFirstFence: () => void = () => {};
+    const firstEnteredFence = new Promise<void>((resolve) => {
+      resolveFirstFence = resolve;
+    });
+    let fenceCalls = 0;
+    stateManager.setWriteFence("goal-apply-concurrent", async () => {
+      fenceCalls += 1;
+      if (fenceCalls === 1) {
+        resolveFirstFence();
+        await new Promise<void>((resolve) => {
+          releaseFence = resolve;
+        });
+      }
+    });
+
+    const entryA: ObservationLogEntry = {
+      observation_id: "obs-apply-a",
+      timestamp: new Date().toISOString(),
+      trigger: "periodic",
+      goal_id: "goal-apply-concurrent",
+      dimension_name: "dim-a",
+      layer: "independent_review",
+      method: defaultMethod,
+      raw_result: 3,
+      extracted_value: 3,
+      confidence: 0.9,
+      notes: null,
+    };
+
+    const entryB: ObservationLogEntry = {
+      observation_id: "obs-apply-b",
+      timestamp: new Date().toISOString(),
+      trigger: "periodic",
+      goal_id: "goal-apply-concurrent",
+      dimension_name: "dim-b",
+      layer: "independent_review",
+      method: defaultMethod,
+      raw_result: 4,
+      extracted_value: 4,
+      confidence: 0.9,
+      notes: null,
+    };
+
+    const first = applyObservation("goal-apply-concurrent", entryA, stateManager, {});
+    await firstEnteredFence;
+    const second = applyObservation("goal-apply-concurrent", entryB, stateManager, {});
+
+    expect(fenceCalls).toBe(1);
+    releaseFence();
+
+    await Promise.all([first, second]);
+
+    const updated = await stateManager.loadGoal("goal-apply-concurrent");
+    const dimA = updated!.dimensions.find((dim) => dim.name === "dim-a");
+    const dimB = updated!.dimensions.find((dim) => dim.name === "dim-b");
+    expect(dimA!.current_value).toBe(3);
+    expect(dimB!.current_value).toBe(4);
+
+    const log = await stateManager.loadObservationLog("goal-apply-concurrent");
+    expect(log!.entries.map((entry) => entry.observation_id)).toEqual([
+      "obs-apply-a",
+      "obs-apply-b",
+    ]);
   });
 });

--- a/src/platform/observation/observation-apply.ts
+++ b/src/platform/observation/observation-apply.ts
@@ -22,124 +22,115 @@ export async function applyObservation(
   stateManager: StateManager,
   options: ObservationEngineOptions
 ): Promise<void> {
-  const goal = await stateManager.loadGoal(goalId);
-  if (goal === null) {
-    throw new Error(`applyObservation: goal "${goalId}" not found`);
-  }
+  await stateManager.appendObservationAndSaveGoal(goalId, entry, (goal) => {
+    const safeName = normalizeDimensionName(entry.dimension_name);
+    let dimIndex = goal.dimensions.findIndex((d) => d.name === safeName);
+    // Fallback: try exact name if normalization changed it and didn't match
+    if (dimIndex === -1 && safeName !== entry.dimension_name) {
+      dimIndex = goal.dimensions.findIndex((d) => d.name === entry.dimension_name);
+    }
+    if (dimIndex === -1) {
+      throw new Error(
+        `applyObservation: dimension "${entry.dimension_name}" not found in goal "${goalId}"`
+      );
+    }
 
-  const safeName = normalizeDimensionName(entry.dimension_name);
-  let dimIndex = goal.dimensions.findIndex((d) => d.name === safeName);
-  // Fallback: try exact name if normalization changed it and didn't match
-  if (dimIndex === -1 && safeName !== entry.dimension_name) {
-    dimIndex = goal.dimensions.findIndex((d) => d.name === entry.dimension_name);
-  }
-  if (dimIndex === -1) {
-    throw new Error(
-      `applyObservation: dimension "${entry.dimension_name}" not found in goal "${goalId}"`
-    );
-  }
+    const dim = goal.dimensions[dimIndex]!;
 
-  const dim = goal.dimensions[dimIndex]!;
-
-  // ─── Value bounds validation ───
-  // Clamp numeric observation values to reasonable bounds based on threshold type.
-  // This prevents LLM hallucinations (e.g., reporting 1.0 for a normalized dimension
-  // when the actual value is 0) from persisting unchecked.
-  let effectiveValue = entry.extracted_value;
-  if (typeof effectiveValue === "number") {
-    const thresholdType = dim.threshold.type;
-    if (thresholdType === "present" || thresholdType === "match") {
-      // present/match dimensions use 0-1 normalized values
-      if (effectiveValue < 0 || effectiveValue > 1) {
-        const clamped = Math.max(0, Math.min(1, effectiveValue));
-        // Log is intentionally omitted here — callers handle warnings
-        effectiveValue = clamped;
-      }
-    } else if (thresholdType === "min" && "value" in dim.threshold) {
-      // min thresholds: value should not exceed 2x the target (sanity bound)
-      const maxBound = (dim.threshold as { value: number }).value * 2;
-      if (maxBound > 0 && effectiveValue > maxBound) {
-        effectiveValue = maxBound;
-      }
-      if (effectiveValue < 0) {
-        effectiveValue = 0;
-      }
-    } else if (thresholdType === "max" && "value" in dim.threshold) {
-      // max thresholds: value should not be negative
-      if (effectiveValue < 0) {
-        effectiveValue = 0;
+    // ─── Value bounds validation ───
+    // Clamp numeric observation values to reasonable bounds based on threshold type.
+    // This prevents LLM hallucinations (e.g., reporting 1.0 for a normalized dimension
+    // when the actual value is 0) from persisting unchecked.
+    let effectiveValue = entry.extracted_value;
+    if (typeof effectiveValue === "number") {
+      const thresholdType = dim.threshold.type;
+      if (thresholdType === "present" || thresholdType === "match") {
+        // present/match dimensions use 0-1 normalized values
+        if (effectiveValue < 0 || effectiveValue > 1) {
+          const clamped = Math.max(0, Math.min(1, effectiveValue));
+          // Log is intentionally omitted here — callers handle warnings
+          effectiveValue = clamped;
+        }
+      } else if (thresholdType === "min" && "value" in dim.threshold) {
+        // min thresholds: value should not exceed 2x the target (sanity bound)
+        const maxBound = (dim.threshold as { value: number }).value * 2;
+        if (maxBound > 0 && effectiveValue > maxBound) {
+          effectiveValue = maxBound;
+        }
+        if (effectiveValue < 0) {
+          effectiveValue = 0;
+        }
+      } else if (thresholdType === "max" && "value" in dim.threshold) {
+        // max thresholds: value should not be negative
+        if (effectiveValue < 0) {
+          effectiveValue = 0;
+        }
       }
     }
-  }
 
-  // Monotonic floor for min thresholds: never decrease an observed value below the
-  // current floor. This prevents noise from hiding real progress on "higher is better"
-  // dimensions. Max thresholds are NOT clamped — regressions (e.g. bug count going up)
-  // must remain visible.
-  if (typeof effectiveValue === 'number' && typeof dim.current_value === 'number') {
-    // NOTE: range thresholds intentionally not clamped — progress direction is ambiguous.
-    // Assumes earlier observations are reliable; no mechanism to override a false-high floor.
-    if (
-      dim.threshold.type === 'min' &&
-      effectiveValue < dim.current_value &&
-      entry.confidence < (dim.confidence ?? 1)
-    ) {
-      effectiveValue = dim.current_value;
+    // Monotonic floor for min thresholds: never decrease an observed value below the
+    // current floor. This prevents noise from hiding real progress on "higher is better"
+    // dimensions. Max thresholds are NOT clamped — regressions (e.g. bug count going up)
+    // must remain visible.
+    if (typeof effectiveValue === "number" && typeof dim.current_value === "number") {
+      // NOTE: range thresholds intentionally not clamped — progress direction is ambiguous.
+      // Assumes earlier observations are reliable; no mechanism to override a false-high floor.
+      if (
+        dim.threshold.type === "min" &&
+        effectiveValue < dim.current_value &&
+        entry.confidence < (dim.confidence ?? 1)
+      ) {
+        effectiveValue = dim.current_value;
+      }
     }
-  }
 
-  // Determine if the incoming observation should update the dimension's confidence.
-  // Only allow confidence updates from an equal or higher-priority layer.
-  // This prevents a low-layer self_report from downgrading confidence that was
-  // established by a mechanical or independent_review observation.
-  const existingTier = (dim.last_observed_layer ?? "self_report") as ObservationLayer;
-  const existingPriority = LAYER_PRIORITY[existingTier] ?? 0;
-  const incomingPriority = LAYER_PRIORITY[entry.layer] ?? 0;
-  // Allow update when the incoming layer has equal or higher priority.
-  // Same-layer updates are accepted regardless of confidence direction
-  // ONLY when there has been a prior real observation (last_observed_layer is set),
-  // so that repeated LLM observations can reflect new (lower) confidence values
-  // rather than freezing at the first observation (#315).
-  // When last_observed_layer is null (initial seed confidence, never observed),
-  // the same-priority guard still applies so the seed is not prematurely overwritten
-  // by a low-confidence incoming entry.
-  const hasBeenObserved = dim.last_observed_layer !== null && dim.last_observed_layer !== undefined;
-  const shouldUpdateConfidence =
-    incomingPriority > existingPriority ||
-    (incomingPriority === existingPriority && (hasBeenObserved || entry.confidence >= (dim.confidence ?? 0)));
+    // Determine if the incoming observation should update the dimension's confidence.
+    // Only allow confidence updates from an equal or higher-priority layer.
+    // This prevents a low-layer self_report from downgrading confidence that was
+    // established by a mechanical or independent_review observation.
+    const existingTier = (dim.last_observed_layer ?? "self_report") as ObservationLayer;
+    const existingPriority = LAYER_PRIORITY[existingTier] ?? 0;
+    const incomingPriority = LAYER_PRIORITY[entry.layer] ?? 0;
+    // Allow update when the incoming layer has equal or higher priority.
+    // Same-layer updates are accepted regardless of confidence direction
+    // ONLY when there has been a prior real observation (last_observed_layer is set),
+    // so that repeated LLM observations can reflect new (lower) confidence values
+    // rather than freezing at the first observation (#315).
+    // When last_observed_layer is null (initial seed confidence, never observed),
+    // the same-priority guard still applies so the seed is not prematurely overwritten
+    // by a low-confidence incoming entry.
+    const hasBeenObserved = dim.last_observed_layer !== null && dim.last_observed_layer !== undefined;
+    const shouldUpdateConfidence =
+      incomingPriority > existingPriority ||
+      (incomingPriority === existingPriority && (hasBeenObserved || entry.confidence >= (dim.confidence ?? 0)));
 
-  // Update dimension values
-  const updatedDim = {
-    ...dim,
-    current_value: effectiveValue,
-    confidence: shouldUpdateConfidence ? entry.confidence : dim.confidence,
-    last_observed_layer: shouldUpdateConfidence ? entry.layer : dim.last_observed_layer,
-    last_updated: entry.timestamp,
-    history: [
-      ...dim.history,
-      {
-        value: entry.extracted_value,
-        timestamp: entry.timestamp,
-        confidence: entry.confidence,
-        source_observation_id: entry.observation_id,
-      },
-    ],
-  };
+    // Update dimension values
+    const updatedDim = {
+      ...dim,
+      current_value: effectiveValue,
+      confidence: shouldUpdateConfidence ? entry.confidence : dim.confidence,
+      last_observed_layer: shouldUpdateConfidence ? entry.layer : dim.last_observed_layer,
+      last_updated: entry.timestamp,
+      history: [
+        ...dim.history,
+        {
+          value: entry.extracted_value,
+          timestamp: entry.timestamp,
+          confidence: entry.confidence,
+          source_observation_id: entry.observation_id,
+        },
+      ],
+    };
 
-  const updatedDimensions = [...goal.dimensions];
-  updatedDimensions[dimIndex] = updatedDim;
+    const updatedDimensions = [...goal.dimensions];
+    updatedDimensions[dimIndex] = updatedDim;
 
-  const updatedGoal = {
-    ...goal,
-    dimensions: updatedDimensions,
-    updated_at: new Date().toISOString(),
-  };
-
-  // Persist observation entry
-  await stateManager.appendObservation(goalId, entry);
-
-  // Persist updated goal
-  await stateManager.saveGoal(updatedGoal);
+    return {
+      ...goal,
+      dimensions: updatedDimensions,
+      updated_at: new Date().toISOString(),
+    };
+  });
 
   // Index dimension name for semantic search (fire-and-forget, non-blocking)
   if (options.vectorIndex) {


### PR DESCRIPTION
## Summary

- Move StateManager append read-modify-write paths under per-goal lock + WAL
- Add a combined observation-log + goal update boundary for `applyObservation`
- Lock `archiveGoal` work and keep compatibility with legacy goal-directory locks during the stable lock migration
- Add WAL replay and concurrency tests for the new transaction boundaries

## Why

The transaction-boundary review found lost-update risks in append paths and a split persistence boundary between observation logs and `goal.json`. It also identified archive concurrency risk and a lock-path migration concern for mixed-version processes.

## Validation

- `npm test -- src/base/state src/platform/observation`
- `npm run typecheck`
