### PR TITLE
[codex] Add runtime control recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ PulSeed uses two layers:
 
 State, reports, schedules, and local memory live under `~/.pulseed/`.
 
+Security boundary: PulSeed uses approval gates and verification around delegated work,
+but it does not provide OS-level sandboxing for agent subprocesses. For high-risk or
+untrusted goals, run PulSeed inside a container or VM. See [Security](SECURITY.md).
+
 ## Main Command
 
 ```bash

--- a/docs/status.md
+++ b/docs/status.md
@@ -28,6 +28,12 @@ For broader navigation, see [Architecture Map](architecture-map.md).
 - native AgentLoop quality and policy
 - design notes under `docs/design/`
 
+## Safety Boundary
+
+PulSeed has software-level approval and verification gates, but it does not provide
+OS-level sandboxing for delegated agent subprocesses. For high-risk or untrusted
+goals, use an external container or VM boundary. See [Security](../SECURITY.md).
+
 ## Source of truth
 
 When public docs disagree, prefer the more specific page:

--- a/plugins/discord-bot/README.md
+++ b/plugins/discord-bot/README.md
@@ -24,6 +24,7 @@ Create `config.json` in the plugin directory:
   "bot_token": "Bot ...",
   "channel_id": "123456789012345678",
   "identity_key": "discord:team-a",
+  "runtime_control_allowed_sender_ids": ["123456789012345678"],
   "command_name": "pulseed",
   "host": "127.0.0.1",
   "port": 8787
@@ -34,6 +35,9 @@ Create `config.json` in the plugin directory:
 
 - The shared cross-platform session manager receives `identity_key` inside the
   inbound payload so the same conversation can continue across channels.
+- `runtime_control_allowed_sender_ids` limits who can approve explicit PulSeed
+  runtime-control requests from Discord. Leave it empty to disable those
+  operations from Discord.
 - If `public_key_hex` is omitted, the webhook still works for local testing but
   request verification is skipped.
 - Voice memo transcription is not implemented.

--- a/plugins/discord-bot/__tests__/config.test.ts
+++ b/plugins/discord-bot/__tests__/config.test.ts
@@ -32,6 +32,40 @@ describe("discord-bot config loader", () => {
     expect(cfg.command_name).toBe("pulseed");
     expect(cfg.port).toBe(8787);
     expect(cfg.ephemeral).toBe(false);
+    expect(cfg.runtime_control_allowed_sender_ids).toEqual([]);
+  });
+
+  it("loads runtime control sender allowlist", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        application_id: "app-1",
+        bot_token: "bot-1",
+        channel_id: "chan-1",
+        identity_key: "discord:alpha",
+        runtime_control_allowed_sender_ids: ["user-1"],
+      }),
+      "utf-8"
+    );
+
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.runtime_control_allowed_sender_ids).toEqual(["user-1"]);
+  });
+
+  it("rejects invalid runtime control sender allowlist", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        application_id: "app-1",
+        bot_token: "bot-1",
+        channel_id: "chan-1",
+        identity_key: "discord:alpha",
+        runtime_control_allowed_sender_ids: [123],
+      }),
+      "utf-8"
+    );
+
+    expect(() => loadConfig(tmpDir)).toThrow("runtime_control_allowed_sender_ids");
   });
 
   it("requires identity_key", () => {

--- a/plugins/discord-bot/__tests__/discord-bot-plugin.test.ts
+++ b/plugins/discord-bot/__tests__/discord-bot-plugin.test.ts
@@ -53,6 +53,7 @@ describe("DiscordBotPlugin", () => {
       bot_token: "bot-1",
       channel_id: "channel-1",
       identity_key: "discord:alpha",
+      runtime_control_allowed_sender_ids: [],
       command_name: "pulseed",
       host: "127.0.0.1",
       port: 8787,

--- a/plugins/discord-bot/__tests__/webhook-server.test.ts
+++ b/plugins/discord-bot/__tests__/webhook-server.test.ts
@@ -1,0 +1,114 @@
+import type * as http from "node:http";
+import { PassThrough } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DiscordWebhookServer } from "../src/webhook-server.js";
+import type { DiscordBotConfig } from "../src/config.js";
+import type { DiscordAPI } from "../src/discord-api.js";
+
+function createRequest(body: unknown): http.IncomingMessage {
+  const req = new PassThrough() as unknown as http.IncomingMessage;
+  req.method = "POST";
+  req.url = "/";
+  req.headers = { host: "127.0.0.1" };
+  (req as unknown as PassThrough).end(JSON.stringify(body));
+  return req;
+}
+
+function createResponse(): { res: http.ServerResponse; done: Promise<void>; body: () => string } {
+  const chunks: string[] = [];
+  let resolve!: () => void;
+  const done = new Promise<void>((r) => {
+    resolve = r;
+  });
+  const res = {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn((chunk?: unknown) => {
+      if (chunk !== undefined) {
+        chunks.push(String(chunk));
+      }
+      resolve();
+    }),
+  } as unknown as http.ServerResponse;
+  return { res, done, body: () => chunks.join("") };
+}
+
+describe("DiscordWebhookServer", () => {
+  const config: DiscordBotConfig = {
+    application_id: "app-1",
+    bot_token: "Bot token",
+    channel_id: "channel-1",
+    identity_key: "discord:ops",
+    runtime_control_allowed_sender_ids: ["user-1"],
+    command_name: "pulseed",
+    host: "127.0.0.1",
+    port: 8787,
+    ephemeral: false,
+  };
+
+  let api: Pick<DiscordAPI, "sendInteractionFollowUp">;
+
+  beforeEach(() => {
+    api = {
+      sendInteractionFollowUp: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it("marks runtime control approved for configured Discord sender ids", async () => {
+    const fetchChatReply = vi.fn().mockResolvedValue("ok");
+    const server = new DiscordWebhookServer(config, api as DiscordAPI, fetchChatReply);
+    const { res, done } = createResponse();
+
+    await server.handleRequest(
+      createRequest({
+        id: "interaction-1",
+        type: 2,
+        token: "token-1",
+        application_id: "app-1",
+        channel_id: "channel-1",
+        member: { user: { id: "user-1" } },
+        data: { name: "pulseed", options: [{ name: "message", value: "PulSeed を再起動して" }] },
+      }),
+      res
+    );
+    await done;
+
+    await vi.waitFor(() => {
+      expect(fetchChatReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sender_id: "user-1",
+          metadata: expect.objectContaining({ runtime_control_approved: true }),
+        })
+      );
+    });
+  });
+
+  it("does not approve runtime control for unconfigured Discord sender ids", async () => {
+    const fetchChatReply = vi.fn().mockResolvedValue("ok");
+    const server = new DiscordWebhookServer(config, api as DiscordAPI, fetchChatReply);
+    const { res, done } = createResponse();
+
+    await server.handleRequest(
+      createRequest({
+        id: "interaction-2",
+        type: 2,
+        token: "token-2",
+        application_id: "app-1",
+        channel_id: "channel-1",
+        member: { user: { id: "user-2" } },
+        data: { name: "pulseed", options: [{ name: "message", value: "PulSeed を再起動して" }] },
+      }),
+      res
+    );
+    await done;
+
+    await vi.waitFor(() => {
+      expect(fetchChatReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sender_id: "user-2",
+          metadata: expect.not.objectContaining({ runtime_control_approved: true }),
+        })
+      );
+    });
+  });
+});

--- a/plugins/discord-bot/__tests__/webhook-server.test.ts
+++ b/plugins/discord-bot/__tests__/webhook-server.test.ts
@@ -1,37 +1,8 @@
-import type * as http from "node:http";
-import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DiscordWebhookServer } from "../src/webhook-server.js";
 import type { DiscordBotConfig } from "../src/config.js";
 import type { DiscordAPI } from "../src/discord-api.js";
-
-function createRequest(body: unknown): http.IncomingMessage {
-  const req = new PassThrough() as unknown as http.IncomingMessage;
-  req.method = "POST";
-  req.url = "/";
-  req.headers = { host: "127.0.0.1" };
-  (req as unknown as PassThrough).end(JSON.stringify(body));
-  return req;
-}
-
-function createResponse(): { res: http.ServerResponse; done: Promise<void>; body: () => string } {
-  const chunks: string[] = [];
-  let resolve!: () => void;
-  const done = new Promise<void>((r) => {
-    resolve = r;
-  });
-  const res = {
-    statusCode: 200,
-    setHeader: vi.fn(),
-    end: vi.fn((chunk?: unknown) => {
-      if (chunk !== undefined) {
-        chunks.push(String(chunk));
-      }
-      resolve();
-    }),
-  } as unknown as http.ServerResponse;
-  return { res, done, body: () => chunks.join("") };
-}
+import { createJsonPostRequest, createMockServerResponse } from "../../../tests/helpers/http-mocks.js";
 
 describe("DiscordWebhookServer", () => {
   const config: DiscordBotConfig = {
@@ -57,10 +28,10 @@ describe("DiscordWebhookServer", () => {
   it("marks runtime control approved for configured Discord sender ids", async () => {
     const fetchChatReply = vi.fn().mockResolvedValue("ok");
     const server = new DiscordWebhookServer(config, api as DiscordAPI, fetchChatReply);
-    const { res, done } = createResponse();
+    const { res, done } = createMockServerResponse();
 
     await server.handleRequest(
-      createRequest({
+      createJsonPostRequest({
         id: "interaction-1",
         type: 2,
         token: "token-1",
@@ -86,10 +57,10 @@ describe("DiscordWebhookServer", () => {
   it("does not approve runtime control for unconfigured Discord sender ids", async () => {
     const fetchChatReply = vi.fn().mockResolvedValue("ok");
     const server = new DiscordWebhookServer(config, api as DiscordAPI, fetchChatReply);
-    const { res, done } = createResponse();
+    const { res, done } = createMockServerResponse();
 
     await server.handleRequest(
-      createRequest({
+      createJsonPostRequest({
         id: "interaction-2",
         type: 2,
         token: "token-2",

--- a/plugins/discord-bot/plugin.yaml
+++ b/plugins/discord-bot/plugin.yaml
@@ -37,6 +37,10 @@ config_schema:
     type: string
     required: true
     description: "Cross-platform identity key passed to the shared session manager"
+  runtime_control_allowed_sender_ids:
+    type: array
+    required: false
+    description: "Discord user IDs allowed to approve explicit PulSeed runtime-control requests"
   command_name:
     type: string
     required: false

--- a/plugins/discord-bot/src/config.ts
+++ b/plugins/discord-bot/src/config.ts
@@ -7,6 +7,7 @@ export interface DiscordBotConfig {
   bot_token: string;
   channel_id: string;
   identity_key: string;
+  runtime_control_allowed_sender_ids: string[];
   command_name: string;
   host: string;
   port: number;
@@ -37,6 +38,7 @@ function validateConfig(raw: unknown): DiscordBotConfig {
   const host = cfg["host"] ?? "127.0.0.1";
   const port = cfg["port"] ?? 8787;
   const ephemeral = cfg["ephemeral"] ?? false;
+  const runtimeControlAllowedSenderIds = cfg["runtime_control_allowed_sender_ids"] ?? [];
 
   if (typeof cfg["application_id"] !== "string" || cfg["application_id"].length === 0) {
     throw new Error("discord-bot: application_id must be a non-empty string");
@@ -62,6 +64,12 @@ function validateConfig(raw: unknown): DiscordBotConfig {
   if (typeof ephemeral !== "boolean") {
     throw new Error("discord-bot: ephemeral must be a boolean");
   }
+  if (
+    !Array.isArray(runtimeControlAllowedSenderIds) ||
+    !runtimeControlAllowedSenderIds.every((id) => typeof id === "string" && id.length > 0)
+  ) {
+    throw new Error("discord-bot: runtime_control_allowed_sender_ids must be an array of non-empty strings");
+  }
   if (cfg["public_key_hex"] !== undefined && typeof cfg["public_key_hex"] !== "string") {
     throw new Error("discord-bot: public_key_hex must be a string when set");
   }
@@ -72,6 +80,7 @@ function validateConfig(raw: unknown): DiscordBotConfig {
     bot_token: cfg["bot_token"] as string,
     channel_id: cfg["channel_id"] as string,
     identity_key: cfg["identity_key"] as string,
+    runtime_control_allowed_sender_ids: runtimeControlAllowedSenderIds as string[],
     command_name: commandName,
     host,
     port,

--- a/plugins/discord-bot/src/webhook-server.ts
+++ b/plugins/discord-bot/src/webhook-server.ts
@@ -114,6 +114,8 @@ export class DiscordWebhookServer {
 
     const senderId = payload.member?.user?.id ?? payload.user?.id ?? "discord-user";
     const conversationId = payload.channel_id ?? payload.guild_id ?? payload.id ?? senderId;
+    const runtimeControlApproved =
+      this.config.runtime_control_allowed_sender_ids.includes(senderId);
     const input: ChatContinuationInput = {
       platform: "discord",
       identity_key: this.config.identity_key,
@@ -126,6 +128,7 @@ export class DiscordWebhookServer {
         command_name: payload.data?.name,
         channel_id: payload.channel_id,
         guild_id: payload.guild_id,
+        ...(runtimeControlApproved ? { runtime_control_approved: true } : {}),
       },
     };
 

--- a/plugins/signal-bridge/README.md
+++ b/plugins/signal-bridge/README.md
@@ -19,6 +19,7 @@ matching the real deployment boundary for Signal.
   "account": "+15551234567",
   "recipient_id": "+15557654321",
   "identity_key": "signal:ops",
+  "runtime_control_allowed_sender_ids": ["+15557654321"],
   "poll_interval_ms": 5000,
   "receive_timeout_ms": 2000
 }
@@ -28,4 +29,7 @@ matching the real deployment boundary for Signal.
 
 - The bridge API can vary slightly by deployment. The client uses a small set
   of compatible receive endpoints and falls back between them.
+- `runtime_control_allowed_sender_ids` limits who can approve explicit PulSeed
+  runtime-control requests from Signal. Leave it empty to disable those
+  operations from Signal.
 - Voice memo transcription is not implemented.

--- a/plugins/signal-bridge/__tests__/config.test.ts
+++ b/plugins/signal-bridge/__tests__/config.test.ts
@@ -30,6 +30,40 @@ describe("signal-bridge config loader", () => {
     const cfg = loadConfig(tmpDir);
     expect(cfg.poll_interval_ms).toBe(5000);
     expect(cfg.receive_timeout_ms).toBe(2000);
+    expect(cfg.runtime_control_allowed_sender_ids).toEqual([]);
+  });
+
+  it("loads runtime control sender allowlist", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        bridge_url: "http://127.0.0.1:7583",
+        account: "+15551234567",
+        recipient_id: "+15557654321",
+        identity_key: "signal:alpha",
+        runtime_control_allowed_sender_ids: ["+15557654321"],
+      }),
+      "utf-8"
+    );
+
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.runtime_control_allowed_sender_ids).toEqual(["+15557654321"]);
+  });
+
+  it("rejects invalid runtime control sender allowlist", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        bridge_url: "http://127.0.0.1:7583",
+        account: "+15551234567",
+        recipient_id: "+15557654321",
+        identity_key: "signal:alpha",
+        runtime_control_allowed_sender_ids: [123],
+      }),
+      "utf-8"
+    );
+
+    expect(() => loadConfig(tmpDir)).toThrow("runtime_control_allowed_sender_ids");
   });
 
   it("requires account", () => {

--- a/plugins/signal-bridge/__tests__/signal-poller.test.ts
+++ b/plugins/signal-bridge/__tests__/signal-poller.test.ts
@@ -32,6 +32,7 @@ describe("SignalBridgePoller", () => {
         account: "+15551234567",
         recipient_id: "+15557654321",
         identity_key: "signal:alpha",
+        runtime_control_allowed_sender_ids: [],
         poll_interval_ms: 5000,
         receive_timeout_ms: 2000,
       },
@@ -48,5 +49,45 @@ describe("SignalBridgePoller", () => {
       text: "hello",
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks runtime control approved for configured Signal sender ids", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            id: "msg-1",
+            sender: "+15557654321",
+            message: "PulSeed を再起動して",
+            timestamp: 1,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+
+    const replyHandler = vi.fn().mockResolvedValue("reply text");
+    const poller = new SignalBridgePoller(
+      {
+        bridge_url: "http://127.0.0.1:7583",
+        account: "+15551234567",
+        recipient_id: "+15557654321",
+        identity_key: "signal:alpha",
+        runtime_control_allowed_sender_ids: ["+15557654321"],
+        poll_interval_ms: 5000,
+        receive_timeout_ms: 2000,
+      },
+      client,
+      replyHandler
+    );
+
+    await poller.pollOnce();
+
+    expect(replyHandler.mock.calls[0]?.[0]).toMatchObject({
+      sender_id: "+15557654321",
+      metadata: {
+        runtime_control_approved: true,
+      },
+    });
   });
 });

--- a/plugins/signal-bridge/plugin.yaml
+++ b/plugins/signal-bridge/plugin.yaml
@@ -33,6 +33,10 @@ config_schema:
     type: string
     required: true
     description: "Cross-platform identity key passed to the shared session manager"
+  runtime_control_allowed_sender_ids:
+    type: array
+    required: false
+    description: "Signal sender IDs allowed to approve explicit PulSeed runtime-control requests"
   poll_interval_ms:
     type: number
     required: false

--- a/plugins/signal-bridge/src/config.ts
+++ b/plugins/signal-bridge/src/config.ts
@@ -6,6 +6,7 @@ export interface SignalBridgeConfig {
   account: string;
   recipient_id: string;
   identity_key: string;
+  runtime_control_allowed_sender_ids: string[];
   poll_interval_ms: number;
   receive_timeout_ms: number;
 }
@@ -32,6 +33,7 @@ function validateConfig(raw: unknown): SignalBridgeConfig {
   const cfg = raw as Record<string, unknown>;
   const pollInterval = cfg["poll_interval_ms"] ?? 5000;
   const receiveTimeout = cfg["receive_timeout_ms"] ?? 2000;
+  const runtimeControlAllowedSenderIds = cfg["runtime_control_allowed_sender_ids"] ?? [];
 
   if (typeof cfg["bridge_url"] !== "string" || cfg["bridge_url"].length === 0) {
     throw new Error("signal-bridge: bridge_url must be a non-empty string");
@@ -51,12 +53,19 @@ function validateConfig(raw: unknown): SignalBridgeConfig {
   if (typeof receiveTimeout !== "number" || !Number.isInteger(receiveTimeout)) {
     throw new Error("signal-bridge: receive_timeout_ms must be an integer");
   }
+  if (
+    !Array.isArray(runtimeControlAllowedSenderIds) ||
+    !runtimeControlAllowedSenderIds.every((id) => typeof id === "string" && id.length > 0)
+  ) {
+    throw new Error("signal-bridge: runtime_control_allowed_sender_ids must be an array of non-empty strings");
+  }
 
   return {
     bridge_url: cfg["bridge_url"] as string,
     account: cfg["account"] as string,
     recipient_id: cfg["recipient_id"] as string,
     identity_key: cfg["identity_key"] as string,
+    runtime_control_allowed_sender_ids: runtimeControlAllowedSenderIds as string[],
     poll_interval_ms: Math.max(1000, pollInterval),
     receive_timeout_ms: Math.max(250, receiveTimeout),
   };

--- a/plugins/signal-bridge/src/poller.ts
+++ b/plugins/signal-bridge/src/poller.ts
@@ -56,7 +56,12 @@ export class SignalBridgePoller {
         sender_id: normalized.senderId,
         message_id: normalized.messageId,
         text: normalized.text,
-        metadata: normalized.metadata,
+        metadata: {
+          ...normalized.metadata,
+          ...(this.config.runtime_control_allowed_sender_ids.includes(normalized.senderId)
+            ? { runtime_control_approved: true }
+            : {}),
+        },
       });
 
       if (reply !== null) {

--- a/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
@@ -77,6 +77,22 @@ describe("config — loadConfig", () => {
     expect(cfg.allowed_user_ids).toEqual([]);
   });
 
+  it("defaults runtime_control_allowed_user_ids to []", () => {
+    writeTmpConfig(tmpDir, { bot_token: "tok", chat_id: 1 });
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.runtime_control_allowed_user_ids).toEqual([]);
+  });
+
+  it("accepts runtime_control_allowed_user_ids", () => {
+    writeTmpConfig(tmpDir, {
+      bot_token: "tok",
+      chat_id: 1,
+      runtime_control_allowed_user_ids: [123, 456],
+    });
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.runtime_control_allowed_user_ids).toEqual([123, 456]);
+  });
+
   it("defaults allow_all to false", () => {
     writeTmpConfig(tmpDir, { bot_token: "tok", chat_id: 1 });
     const cfg = loadConfig(tmpDir);
@@ -98,6 +114,15 @@ describe("config — loadConfig", () => {
   it("throws when allow_all is not a boolean", () => {
     writeTmpConfig(tmpDir, { bot_token: "tok", chat_id: 1, allow_all: "yes" });
     expect(() => loadConfig(tmpDir)).toThrow("allow_all");
+  });
+
+  it("throws when runtime_control_allowed_user_ids is invalid", () => {
+    writeTmpConfig(tmpDir, {
+      bot_token: "tok",
+      chat_id: 1,
+      runtime_control_allowed_user_ids: ["123"],
+    });
+    expect(() => loadConfig(tmpDir)).toThrow("runtime_control_allowed_user_ids");
   });
 
   it("throws when identity_key is empty", () => {
@@ -561,6 +586,7 @@ describe("ChatBridge", () => {
     expect(processor.mock.calls[0]![0]).toBe("ping");
     expect(processor.mock.calls[0]![1]).toBe(100);
     expect(typeof processor.mock.calls[0]![2]).toBe("function");
+    expect(processor.mock.calls[0]![3]).toBe(1);
     expect(adapterFactory).toHaveBeenCalledWith(100);
     void sendPlainMessage;
   });
@@ -579,12 +605,16 @@ describe("ChatBridge", () => {
 
     await bridge.handleMessage("hello", 42, 999);
 
-    expect(processor).toHaveBeenCalledWith("hello", 999, expect.any(Function));
+    expect(processor).toHaveBeenCalledWith("hello", 999, expect.any(Function), 42);
     expect(sendFinalFallback).toHaveBeenCalledWith("ok");
   });
 
   it("does not send a fallback when assistant events already rendered output", async () => {
-    const processor = vi.fn().mockImplementation(async (_text: string, emit: (event: { type: string; runId: string; turnId: string; createdAt: string }) => Promise<void>) => {
+    const processor = vi.fn().mockImplementation(async (
+      _text: string,
+      _chatId: number,
+      emit: (event: { type: string; runId: string; turnId: string; createdAt: string }) => Promise<void>
+    ) => {
       await emit({
         type: "assistant_final",
         runId: "run-1",

--- a/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
@@ -133,4 +133,33 @@ describe("TelegramChatRunnerProcessor", () => {
     });
     expect(mockCreatedRunners).toHaveLength(0);
   });
+
+  it("marks runtime control approved only for configured Telegram user ids", async () => {
+    const processIncomingMessage = vi.fn().mockResolvedValue("shared-output");
+    mockGetGlobalCrossPlatformChatSessionManager.mockResolvedValue({ processIncomingMessage });
+    const processor = new TelegramChatRunnerProcessor(
+      "/tmp/plugins/telegram-bot",
+      "/workspace",
+      "shared-human",
+      [777]
+    );
+
+    await expect(processor.processMessage("PulSeed を再起動して", 101, vi.fn(), 777))
+      .resolves.toBe("shared-output");
+    await expect(processor.processMessage("PulSeed を再起動して", 101, vi.fn(), 888))
+      .resolves.toBe("shared-output");
+
+    expect(processIncomingMessage.mock.calls[0]?.[0]).toMatchObject({
+      metadata: {
+        chat_id: 101,
+        runtime_control_approved: true,
+      },
+    });
+    expect(processIncomingMessage.mock.calls[1]?.[0]).toMatchObject({
+      metadata: {
+        chat_id: 101,
+      },
+    });
+    expect(processIncomingMessage.mock.calls[1]?.[0].metadata.runtime_control_approved).toBeUndefined();
+  });
 });

--- a/plugins/telegram-bot/plugin.yaml
+++ b/plugins/telegram-bot/plugin.yaml
@@ -24,7 +24,15 @@ config_schema:
   allowed_user_ids:
     type: array
     required: false
-    description: "Telegram user IDs allowed to send commands (empty = all)"
+    description: "Telegram user IDs allowed to send chat commands when allow_all is false"
+  runtime_control_allowed_user_ids:
+    type: array
+    required: false
+    description: "Telegram user IDs allowed to approve explicit PulSeed runtime-control requests"
+  allow_all:
+    type: boolean
+    required: false
+    description: "Allow all Telegram users in the configured chat to send normal chat messages; runtime control still requires runtime_control_allowed_user_ids"
   identity_key:
     type: string
     required: false

--- a/plugins/telegram-bot/src/chat-bridge.ts
+++ b/plugins/telegram-bot/src/chat-bridge.ts
@@ -6,7 +6,12 @@ import { TelegramChatEventAdapter } from "./telegram-chat-event-adapter.js";
 // Thin adapter between the Telegram polling loop and the message processor.
 // Processors may emit chat events via the provided handler.
 
-type ProcessMessageFn = (text: string, chatId: number, emit: ChatEventHandler) => Promise<string | void> | string | void;
+type ProcessMessageFn = (
+  text: string,
+  chatId: number,
+  emit: ChatEventHandler,
+  fromUserId?: number
+) => Promise<string | void> | string | void;
 
 export class ChatBridge {
   private processMessage: ProcessMessageFn;
@@ -25,8 +30,6 @@ export class ChatBridge {
   }
 
   async handleMessage(text: string, fromUserId: number, chatId: number): Promise<void> {
-    // fromUserId and chatId are available for future routing/logging
-    void fromUserId;
     const adapter = this.apiFactory(chatId);
     let eventQueue = Promise.resolve();
     const emit: ChatEventHandler = (event) => {
@@ -41,7 +44,7 @@ export class ChatBridge {
     let response: string | void = undefined;
     let processError: unknown = null;
     try {
-      response = await this.processMessage(text, chatId, emit);
+      response = await this.processMessage(text, chatId, emit, fromUserId);
     } catch (err) {
       processError = err;
     }

--- a/plugins/telegram-bot/src/config.ts
+++ b/plugins/telegram-bot/src/config.ts
@@ -7,6 +7,7 @@ export interface TelegramConfig {
   bot_token: string;
   chat_id: number;
   allowed_user_ids: number[];
+  runtime_control_allowed_user_ids: number[];
   allow_all: boolean;
   polling_timeout: number;
   identity_key?: string;
@@ -48,6 +49,14 @@ function validateConfig(raw: unknown): TelegramConfig {
     throw new Error("telegram-bot: allowed_user_ids must be an array of integers");
   }
 
+  const runtimeControlAllowedUserIds = cfg["runtime_control_allowed_user_ids"] ?? [];
+  if (
+    !Array.isArray(runtimeControlAllowedUserIds) ||
+    !runtimeControlAllowedUserIds.every((id) => Number.isInteger(id))
+  ) {
+    throw new Error("telegram-bot: runtime_control_allowed_user_ids must be an array of integers");
+  }
+
   const allowAll = cfg["allow_all"] ?? false;
   if (typeof allowAll !== "boolean") {
     throw new Error("telegram-bot: allow_all must be a boolean");
@@ -65,6 +74,7 @@ function validateConfig(raw: unknown): TelegramConfig {
     bot_token: cfg["bot_token"] as string,
     chat_id: cfg["chat_id"] as number,
     allowed_user_ids: allowedUserIds as number[],
+    runtime_control_allowed_user_ids: runtimeControlAllowedUserIds as number[],
     allow_all: allowAll,
     polling_timeout: Math.min(Math.max(pollingTimeout as number, 1), 60),
     identity_key: cfg["identity_key"] as string | undefined,

--- a/plugins/telegram-bot/src/index.ts
+++ b/plugins/telegram-bot/src/index.ts
@@ -34,10 +34,16 @@ export class TelegramBotPlugin {
 
     this.notifier = new TelegramNotifier(this.api, config.chat_id);
 
-    this.processor = new TelegramChatRunnerProcessor(this.pluginDir, process.cwd(), config.identity_key);
+    this.processor = new TelegramChatRunnerProcessor(
+      this.pluginDir,
+      process.cwd(),
+      config.identity_key,
+      config.runtime_control_allowed_user_ids
+    );
 
     this.bridge = new ChatBridge(
-      (text, chatId, emit) => this.processor!.processMessage(text, chatId, emit),
+      (text, chatId, emit, fromUserId) =>
+        this.processor!.processMessage(text, chatId, emit, fromUserId),
       (chatId) => new TelegramChatEventAdapter(this.api!, chatId)
     );
 
@@ -62,9 +68,9 @@ export class TelegramBotPlugin {
     processMessage: ProcessMessageFn | LegacyProcessMessageFn
   ): void {
     if (!this.bridge) return;
-    this.bridge.setProcessMessage((text, chatId, emit) => {
+    this.bridge.setProcessMessage((text, chatId, emit, fromUserId) => {
       if (processMessage.length >= 3) {
-        return (processMessage as ProcessMessageFn)(text, chatId, emit);
+        return (processMessage as ProcessMessageFn)(text, chatId, emit, fromUserId);
       }
       return (processMessage as LegacyProcessMessageFn)(text, emit);
     });

--- a/plugins/telegram-bot/src/pulseed.ts
+++ b/plugins/telegram-bot/src/pulseed.ts
@@ -6,11 +6,13 @@ export {
   ToolRegistry,
   createBuiltinTools,
   ChatRunner,
+  createNativeChatAgentLoopRunner,
   getGlobalCrossPlatformChatSessionManager,
   ToolExecutor,
   ToolPermissionManager,
   ConcurrencyController,
   TrustManager,
+  shouldUseNativeTaskAgentLoop,
 } from "../../../src/index.js";
 
 export type {
@@ -20,6 +22,7 @@ export type {
   ChatEvent,
   ChatEventHandler,
   ChatRunResult,
+  ChatAgentLoopRunner,
 } from "../../../src/index.js";
 
 export type ChatRunnerLike =

--- a/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
+++ b/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
@@ -32,7 +32,12 @@ interface BootstrapResult {
   chatAgentLoopRunner?: ChatAgentLoopRunner;
 }
 
-type ProcessMessageFn = (text: string, chatId: number, emit: ChatEventHandler) => Promise<string | void> | string | void;
+export type ProcessMessageFn = (
+  text: string,
+  chatId: number,
+  emit: ChatEventHandler,
+  fromUserId?: number
+) => Promise<string | void> | string | void;
 
 function formatError(message: string): string {
   return `Error: ${message}`;
@@ -41,15 +46,27 @@ function formatError(message: string): string {
 export class TelegramChatRunnerProcessor {
   private readonly workspaceRoot: string;
   private readonly identityKey: string | undefined;
+  private readonly runtimeControlAllowedUserIds: Set<number>;
   private bootstrapPromise: Promise<BootstrapResult> | null = null;
   private readonly sessions = new Map<number, ChatRunnerLike>();
 
-  constructor(_pluginDir: string, workspaceRoot = process.cwd(), identityKey?: string) {
+  constructor(
+    _pluginDir: string,
+    workspaceRoot = process.cwd(),
+    identityKey?: string,
+    runtimeControlAllowedUserIds: number[] = []
+  ) {
     this.workspaceRoot = workspaceRoot;
     this.identityKey = identityKey;
+    this.runtimeControlAllowedUserIds = new Set(runtimeControlAllowedUserIds);
   }
 
-  async processMessage(text: string, chatId: number, emit: ChatEventHandler): Promise<string> {
+  async processMessage(
+    text: string,
+    chatId: number,
+    emit: ChatEventHandler,
+    fromUserId?: number
+  ): Promise<string> {
     const shared = await this.getSharedManager();
     if (shared !== null) {
       return shared.processIncomingMessage({
@@ -60,7 +77,12 @@ export class TelegramChatRunnerProcessor {
         sender_id: String(chatId),
         cwd: this.workspaceRoot,
         onEvent: emit,
-        metadata: { chat_id: chatId },
+        metadata: {
+          chat_id: chatId,
+          ...(fromUserId !== undefined && this.runtimeControlAllowedUserIds.has(fromUserId)
+            ? { runtime_control_approved: true }
+            : {}),
+        },
       });
     }
 

--- a/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
+++ b/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
@@ -189,5 +189,3 @@ export class TelegramChatRunnerProcessor {
     };
   }
 }
-
-export type { ProcessMessageFn };

--- a/plugins/whatsapp-webhook/README.md
+++ b/plugins/whatsapp-webhook/README.md
@@ -21,6 +21,7 @@ notifications are delivered through the same Cloud API client.
   "verify_token": "shared-secret",
   "recipient_id": "15551234567",
   "identity_key": "whatsapp:family",
+  "runtime_control_allowed_sender_ids": ["15551234567"],
   "host": "127.0.0.1",
   "port": 8788,
   "path": "/webhook"
@@ -31,4 +32,7 @@ notifications are delivered through the same Cloud API client.
 
 - `app_secret` is optional. When present, the webhook verifies
   `X-Hub-Signature-256` before accepting POST requests.
+- `runtime_control_allowed_sender_ids` limits who can approve explicit PulSeed
+  runtime-control requests from WhatsApp. Leave it empty to disable those
+  operations from WhatsApp.
 - Voice memo transcription is not implemented.

--- a/plugins/whatsapp-webhook/__tests__/config.test.ts
+++ b/plugins/whatsapp-webhook/__tests__/config.test.ts
@@ -31,6 +31,42 @@ describe("whatsapp-webhook config loader", () => {
     const cfg = loadConfig(tmpDir);
     expect(cfg.path).toBe("/webhook");
     expect(cfg.port).toBe(8788);
+    expect(cfg.runtime_control_allowed_sender_ids).toEqual([]);
+  });
+
+  it("loads runtime control sender allowlist", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        phone_number_id: "phone-1",
+        access_token: "token-1",
+        verify_token: "verify-1",
+        recipient_id: "15551234567",
+        identity_key: "whatsapp:alpha",
+        runtime_control_allowed_sender_ids: ["15557654321"],
+      }),
+      "utf-8"
+    );
+
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.runtime_control_allowed_sender_ids).toEqual(["15557654321"]);
+  });
+
+  it("rejects invalid runtime control sender allowlist", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "config.json"),
+      JSON.stringify({
+        phone_number_id: "phone-1",
+        access_token: "token-1",
+        verify_token: "verify-1",
+        recipient_id: "15551234567",
+        identity_key: "whatsapp:alpha",
+        runtime_control_allowed_sender_ids: [123],
+      }),
+      "utf-8"
+    );
+
+    expect(() => loadConfig(tmpDir)).toThrow("runtime_control_allowed_sender_ids");
   });
 
   it("requires verify_token", () => {

--- a/plugins/whatsapp-webhook/__tests__/webhook-server.test.ts
+++ b/plugins/whatsapp-webhook/__tests__/webhook-server.test.ts
@@ -1,0 +1,112 @@
+import type * as http from "node:http";
+import { PassThrough } from "node:stream";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WhatsAppWebhookConfig } from "../src/config.js";
+import type { WhatsAppCloudClient } from "../src/whatsapp-client.js";
+import { WhatsAppWebhookServer } from "../src/webhook-server.js";
+
+function createRequest(body: unknown): http.IncomingMessage {
+  const req = new PassThrough() as unknown as http.IncomingMessage;
+  req.method = "POST";
+  req.url = "/webhook";
+  req.headers = { host: "127.0.0.1" };
+  (req as unknown as PassThrough).end(JSON.stringify(body));
+  return req;
+}
+
+function createResponse(): { res: http.ServerResponse; done: Promise<void> } {
+  let resolve!: () => void;
+  const done = new Promise<void>((r) => {
+    resolve = r;
+  });
+  const res = {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn(() => {
+      resolve();
+    }),
+  } as unknown as http.ServerResponse;
+  return { res, done };
+}
+
+function createPayload(from: string): unknown {
+  return {
+    entry: [
+      {
+        changes: [
+          {
+            value: {
+              messages: [
+                {
+                  id: "msg-1",
+                  from,
+                  timestamp: "1",
+                  type: "text",
+                  text: { body: "PulSeed を再起動して" },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("WhatsAppWebhookServer", () => {
+  const config: WhatsAppWebhookConfig = {
+    phone_number_id: "phone-1",
+    access_token: "token-1",
+    verify_token: "verify-1",
+    recipient_id: "15551234567",
+    identity_key: "whatsapp:ops",
+    runtime_control_allowed_sender_ids: ["15551234567"],
+    host: "127.0.0.1",
+    port: 8788,
+    path: "/webhook",
+  };
+
+  let client: Pick<WhatsAppCloudClient, "sendTextMessage">;
+
+  beforeEach(() => {
+    client = {
+      sendTextMessage: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it("marks runtime control approved for configured WhatsApp sender ids", async () => {
+    const fetchChatReply = vi.fn().mockResolvedValue("ok");
+    const server = new WhatsAppWebhookServer(config, client as WhatsAppCloudClient, fetchChatReply);
+    const { res, done } = createResponse();
+
+    await server.handleRequest(createRequest(createPayload("15551234567")), res);
+    await done;
+
+    await vi.waitFor(() => {
+      expect(fetchChatReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sender_id: "15551234567",
+          metadata: expect.objectContaining({ runtime_control_approved: true }),
+        })
+      );
+    });
+  });
+
+  it("does not approve runtime control for unconfigured WhatsApp sender ids", async () => {
+    const fetchChatReply = vi.fn().mockResolvedValue("ok");
+    const server = new WhatsAppWebhookServer(config, client as WhatsAppCloudClient, fetchChatReply);
+    const { res, done } = createResponse();
+
+    await server.handleRequest(createRequest(createPayload("15550000000")), res);
+    await done;
+
+    await vi.waitFor(() => {
+      expect(fetchChatReply).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sender_id: "15550000000",
+          metadata: expect.not.objectContaining({ runtime_control_approved: true }),
+        })
+      );
+    });
+  });
+});

--- a/plugins/whatsapp-webhook/__tests__/webhook-server.test.ts
+++ b/plugins/whatsapp-webhook/__tests__/webhook-server.test.ts
@@ -1,33 +1,8 @@
-import type * as http from "node:http";
-import { PassThrough } from "node:stream";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WhatsAppWebhookConfig } from "../src/config.js";
 import type { WhatsAppCloudClient } from "../src/whatsapp-client.js";
 import { WhatsAppWebhookServer } from "../src/webhook-server.js";
-
-function createRequest(body: unknown): http.IncomingMessage {
-  const req = new PassThrough() as unknown as http.IncomingMessage;
-  req.method = "POST";
-  req.url = "/webhook";
-  req.headers = { host: "127.0.0.1" };
-  (req as unknown as PassThrough).end(JSON.stringify(body));
-  return req;
-}
-
-function createResponse(): { res: http.ServerResponse; done: Promise<void> } {
-  let resolve!: () => void;
-  const done = new Promise<void>((r) => {
-    resolve = r;
-  });
-  const res = {
-    statusCode: 200,
-    setHeader: vi.fn(),
-    end: vi.fn(() => {
-      resolve();
-    }),
-  } as unknown as http.ServerResponse;
-  return { res, done };
-}
+import { createJsonPostRequest, createMockServerResponse } from "../../../tests/helpers/http-mocks.js";
 
 function createPayload(from: string): unknown {
   return {
@@ -77,9 +52,9 @@ describe("WhatsAppWebhookServer", () => {
   it("marks runtime control approved for configured WhatsApp sender ids", async () => {
     const fetchChatReply = vi.fn().mockResolvedValue("ok");
     const server = new WhatsAppWebhookServer(config, client as WhatsAppCloudClient, fetchChatReply);
-    const { res, done } = createResponse();
+    const { res, done } = createMockServerResponse();
 
-    await server.handleRequest(createRequest(createPayload("15551234567")), res);
+    await server.handleRequest(createJsonPostRequest(createPayload("15551234567"), "/webhook"), res);
     await done;
 
     await vi.waitFor(() => {
@@ -95,9 +70,9 @@ describe("WhatsAppWebhookServer", () => {
   it("does not approve runtime control for unconfigured WhatsApp sender ids", async () => {
     const fetchChatReply = vi.fn().mockResolvedValue("ok");
     const server = new WhatsAppWebhookServer(config, client as WhatsAppCloudClient, fetchChatReply);
-    const { res, done } = createResponse();
+    const { res, done } = createMockServerResponse();
 
-    await server.handleRequest(createRequest(createPayload("15550000000")), res);
+    await server.handleRequest(createJsonPostRequest(createPayload("15550000000"), "/webhook"), res);
     await done;
 
     await vi.waitFor(() => {

--- a/plugins/whatsapp-webhook/__tests__/whatsapp-webhook-plugin.test.ts
+++ b/plugins/whatsapp-webhook/__tests__/whatsapp-webhook-plugin.test.ts
@@ -40,6 +40,7 @@ describe("WhatsAppWebhookPlugin", () => {
       verify_token: "verify-1",
       recipient_id: "15551234567",
       identity_key: "whatsapp:alpha",
+      runtime_control_allowed_sender_ids: [],
       host: "127.0.0.1",
       port: 8788,
       path: "/webhook",

--- a/plugins/whatsapp-webhook/plugin.yaml
+++ b/plugins/whatsapp-webhook/plugin.yaml
@@ -37,6 +37,10 @@ config_schema:
     type: string
     required: true
     description: "Cross-platform identity key passed to the shared session manager"
+  runtime_control_allowed_sender_ids:
+    type: array
+    required: false
+    description: "WhatsApp sender IDs allowed to approve explicit PulSeed runtime-control requests"
   host:
     type: string
     required: false

--- a/plugins/whatsapp-webhook/src/config.ts
+++ b/plugins/whatsapp-webhook/src/config.ts
@@ -7,6 +7,7 @@ export interface WhatsAppWebhookConfig {
   verify_token: string;
   recipient_id: string;
   identity_key: string;
+  runtime_control_allowed_sender_ids: string[];
   host: string;
   port: number;
   path: string;
@@ -36,6 +37,7 @@ function validateConfig(raw: unknown): WhatsAppWebhookConfig {
   const host = cfg["host"] ?? "127.0.0.1";
   const port = cfg["port"] ?? 8788;
   const pathValue = cfg["path"] ?? "/webhook";
+  const runtimeControlAllowedSenderIds = cfg["runtime_control_allowed_sender_ids"] ?? [];
 
   if (typeof cfg["phone_number_id"] !== "string" || cfg["phone_number_id"].length === 0) {
     throw new Error("whatsapp-webhook: phone_number_id must be a non-empty string");
@@ -64,6 +66,12 @@ function validateConfig(raw: unknown): WhatsAppWebhookConfig {
   if (cfg["app_secret"] !== undefined && typeof cfg["app_secret"] !== "string") {
     throw new Error("whatsapp-webhook: app_secret must be a string when set");
   }
+  if (
+    !Array.isArray(runtimeControlAllowedSenderIds) ||
+    !runtimeControlAllowedSenderIds.every((id) => typeof id === "string" && id.length > 0)
+  ) {
+    throw new Error("whatsapp-webhook: runtime_control_allowed_sender_ids must be an array of non-empty strings");
+  }
 
   return {
     phone_number_id: cfg["phone_number_id"] as string,
@@ -71,6 +79,7 @@ function validateConfig(raw: unknown): WhatsAppWebhookConfig {
     verify_token: cfg["verify_token"] as string,
     recipient_id: cfg["recipient_id"] as string,
     identity_key: cfg["identity_key"] as string,
+    runtime_control_allowed_sender_ids: runtimeControlAllowedSenderIds as string[],
     host,
     port,
     path: pathValue,

--- a/plugins/whatsapp-webhook/src/webhook-server.ts
+++ b/plugins/whatsapp-webhook/src/webhook-server.ts
@@ -122,6 +122,8 @@ export class WhatsAppWebhookServer {
       return;
     }
 
+    const runtimeControlApproved =
+      this.config.runtime_control_allowed_sender_ids.includes(message.from);
     const input: ChatContinuationInput = {
       platform: "whatsapp",
       identity_key: this.config.identity_key,
@@ -132,6 +134,7 @@ export class WhatsAppWebhookServer {
       metadata: {
         message_type: message.type,
         timestamp: message.timestamp,
+        ...(runtimeControlApproved ? { runtime_control_approved: true } : {}),
       },
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,33 @@ export { EventServer } from "./runtime/event-server.js";
 export type { EventServerConfig } from "./runtime/event-server.js";
 export { NotificationDispatcher } from "./runtime/notification-dispatcher.js";
 export type { INotificationDispatcher } from "./runtime/notification-dispatcher.js";
+export {
+  RuntimeControlService,
+  recognizeRuntimeControlIntent,
+} from "./runtime/control/index.js";
+export type {
+  RuntimeControlExecutor,
+  RuntimeControlExecutorResult,
+  RuntimeControlIntent,
+  RuntimeControlRequest,
+  RuntimeControlResult,
+  RuntimeControlServiceOptions,
+} from "./runtime/control/index.js";
+export { RuntimeOperationStore } from "./runtime/store/runtime-operation-store.js";
+export {
+  RuntimeControlActorSchema,
+  RuntimeControlOperationKindSchema,
+  RuntimeControlOperationSchema,
+  RuntimeControlOperationStateSchema,
+  RuntimeControlReplyTargetSchema,
+} from "./runtime/store/runtime-operation-schemas.js";
+export type {
+  RuntimeControlActor,
+  RuntimeControlOperation,
+  RuntimeControlOperationKind,
+  RuntimeControlOperationState,
+  RuntimeControlReplyTarget,
+} from "./runtime/store/runtime-operation-schemas.js";
 export { MemoryLifecycleManager } from "./platform/knowledge/memory/memory-lifecycle.js";
 export { CharacterConfigManager } from "./platform/traits/character-config.js";
 export { CharacterConfigSchema, DEFAULT_CHARACTER_CONFIG } from "./base/types/character.js";

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ChatRunner } from "../chat-runner.js";
 import type { ChatRunnerDeps } from "../chat-runner.js";
@@ -6,6 +9,8 @@ import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adap
 import type { EscalationHandler, EscalationResult } from "../escalation.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import type { ChatAgentLoopRunner } from "../../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
+import { RuntimeControlService } from "../../../runtime/control/index.js";
+import { RuntimeOperationStore } from "../../../runtime/store/runtime-operation-store.js";
 
 // Mock context-provider so tests don't walk the real filesystem
 vi.mock("../../../platform/observation/context-provider.js", () => ({
@@ -251,6 +256,227 @@ describe("ChatRunner", () => {
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
       expect(writeRawMock).toHaveBeenCalledTimes(1);
       expect(stateManager.readRaw).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("natural-language runtime control", () => {
+    it("handles daemon restart through durable runtime control without calling the adapter", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-runtime-control-chat-"));
+      try {
+        const adapter = makeMockAdapter();
+        const stateManager = makeMockStateManager();
+        const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+        const executor = vi.fn().mockResolvedValue({
+          ok: true,
+          message: "restart queued",
+          state: "acknowledged",
+        });
+        const runtimeControlService = new RuntimeControlService({
+          operationStore,
+          executor,
+        });
+        const approvalFn = vi.fn().mockResolvedValue(true);
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          stateManager,
+          approvalFn,
+          runtimeControlService,
+          runtimeReplyTarget: {
+            surface: "gateway",
+            platform: "telegram",
+            conversation_id: "chat-123",
+            identity_key: "owner",
+            user_id: "user-1",
+          },
+        }));
+
+        const result = await runner.execute("PulSeed を再起動して", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toBe("restart queued");
+        expect(adapter.execute).not.toHaveBeenCalled();
+        expect(approvalFn).toHaveBeenCalledWith(
+          expect.stringContaining("restart_daemon")
+        );
+        expect(executor).toHaveBeenCalledOnce();
+
+        const pending = await operationStore.listPending();
+        expect(pending).toHaveLength(1);
+        expect(pending[0]).toMatchObject({
+          kind: "restart_daemon",
+          state: "acknowledged",
+          reason: "PulSeed を再起動して",
+          requested_by: {
+            surface: "gateway",
+            platform: "telegram",
+            conversation_id: "chat-123",
+            identity_key: "owner",
+            user_id: "user-1",
+          },
+          reply_target: {
+            surface: "gateway",
+            platform: "telegram",
+            conversation_id: "chat-123",
+            identity_key: "owner",
+            user_id: "user-1",
+          },
+        });
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not route recognized runtime control text to the adapter when service is unavailable", async () => {
+      const adapter = makeMockAdapter();
+      const runner = new ChatRunner(makeDeps({ adapter }));
+
+      const result = await runner.execute("PulSeed 自身を更新して", "/repo");
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Runtime control is not available");
+      expect(adapter.execute).not.toHaveBeenCalled();
+    });
+
+    it("does not claim restart started when no runtime control executor is configured", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-runtime-control-no-executor-"));
+      try {
+        const adapter = makeMockAdapter();
+        const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+        const runtimeControlService = new RuntimeControlService({ operationStore });
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          approvalFn: vi.fn().mockResolvedValue(true),
+          runtimeControlService,
+          runtimeReplyTarget: { surface: "cli" },
+        }));
+
+        const result = await runner.execute("PulSeed を再起動して", "/repo");
+
+        expect(result.success).toBe(false);
+        expect(result.output).toContain("not configured");
+        expect(result.output).not.toContain("再起動を開始します");
+        expect(adapter.execute).not.toHaveBeenCalled();
+        expect(await operationStore.listPending()).toHaveLength(0);
+        const completed = await operationStore.listCompleted();
+        expect(completed).toHaveLength(1);
+        expect(completed[0]).toMatchObject({
+          kind: "restart_daemon",
+          state: "failed",
+        });
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("marks runtime control failed when the executor throws", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-runtime-control-executor-throws-"));
+      try {
+        const adapter = makeMockAdapter();
+        const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+        const runtimeControlService = new RuntimeControlService({
+          operationStore,
+          executor: vi.fn().mockRejectedValue(new Error("daemon auth failed")),
+        });
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          approvalFn: vi.fn().mockResolvedValue(true),
+          runtimeControlService,
+          runtimeReplyTarget: { surface: "cli" },
+        }));
+
+        const result = await runner.execute("PulSeed を再起動して", "/repo");
+
+        expect(result.success).toBe(false);
+        expect(result.output).toContain("daemon auth failed");
+        expect(adapter.execute).not.toHaveBeenCalled();
+        expect(await operationStore.listPending()).toHaveLength(0);
+        const completed = await operationStore.listCompleted();
+        expect(completed).toHaveLength(1);
+        expect(completed[0]).toMatchObject({
+          kind: "restart_daemon",
+          state: "failed",
+          result: {
+            ok: false,
+            message: "daemon auth failed",
+          },
+        });
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("marks runtime control failed when approval throws", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-runtime-control-approval-throws-"));
+      try {
+        const adapter = makeMockAdapter();
+        const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+        const executor = vi.fn().mockResolvedValue({ ok: true });
+        const runtimeControlService = new RuntimeControlService({
+          operationStore,
+          executor,
+        });
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          approvalFn: vi.fn().mockRejectedValue(new Error("approval store unavailable")),
+          runtimeControlService,
+          runtimeReplyTarget: { surface: "cli" },
+        }));
+
+        const result = await runner.execute("PulSeed を再起動して", "/repo");
+
+        expect(result.success).toBe(false);
+        expect(result.output).toContain("approval store unavailable");
+        expect(adapter.execute).not.toHaveBeenCalled();
+        expect(executor).not.toHaveBeenCalled();
+        expect(await operationStore.listPending()).toHaveLength(0);
+        const completed = await operationStore.listCompleted();
+        expect(completed).toHaveLength(1);
+        expect(completed[0]).toMatchObject({
+          kind: "restart_daemon",
+          state: "failed",
+          result: {
+            ok: false,
+            message: "approval store unavailable",
+          },
+        });
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("uses runtime-control approval without reusing general tool approval", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-runtime-control-scoped-approval-"));
+      try {
+        const adapter = makeMockAdapter();
+        const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+        const runtimeControlService = new RuntimeControlService({
+          operationStore,
+          executor: vi.fn().mockResolvedValue({
+            ok: true,
+            state: "restarting",
+            message: "restart requested",
+          }),
+        });
+        const approvalFn = vi.fn().mockResolvedValue(false);
+        const runtimeControlApprovalFn = vi.fn().mockResolvedValue(true);
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          approvalFn,
+          runtimeControlApprovalFn,
+          runtimeControlService,
+          runtimeReplyTarget: { surface: "gateway", platform: "telegram" },
+        }));
+
+        const result = await runner.execute("PulSeed を再起動して", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toBe("restart requested");
+        expect(runtimeControlApprovalFn).toHaveBeenCalledOnce();
+        expect(approvalFn).not.toHaveBeenCalled();
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -142,4 +142,52 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(events.some((event) => event.type === "assistant_final")).toBe(true);
     expect(events.at(-1)?.type).toBe("lifecycle_end");
   });
+
+  it("routes natural-language restart with the current platform reply target", async () => {
+    const stateManager = makeMockStateManager();
+    const adapter = makeMockAdapter();
+    const runtimeControlService = {
+      request: vi.fn().mockResolvedValue({
+        success: true,
+        message: "restart queued",
+        operationId: "op-1",
+        state: "acknowledged",
+      }),
+    };
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager,
+      adapter,
+      runtimeControlService,
+      approvalFn: vi.fn().mockResolvedValue(true),
+    }));
+
+    const result = await manager.execute("PulSeed を再起動して", {
+      identity_key: "owner",
+      platform: "telegram",
+      conversation_id: "telegram-chat-1",
+      user_id: "user-1",
+      cwd: "/repo",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("restart queued");
+    expect(adapter.execute).not.toHaveBeenCalled();
+    expect(runtimeControlService.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: expect.objectContaining({ kind: "restart_daemon" }),
+        replyTarget: expect.objectContaining({
+          surface: "gateway",
+          platform: "telegram",
+          conversation_id: "telegram-chat-1",
+          identity_key: "owner",
+          user_id: "user-1",
+        }),
+        requestedBy: expect.objectContaining({
+          surface: "gateway",
+          platform: "telegram",
+          conversation_id: "telegram-chat-1",
+        }),
+      })
+    );
+  });
 });

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -30,6 +30,12 @@ import type {
   AgentLoopEventSink,
 } from "../../orchestrator/execution/agent-loop/agent-loop-events.js";
 import type { AgentLoopSessionState } from "../../orchestrator/execution/agent-loop/agent-loop-session-state.js";
+import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
+import type { RuntimeControlService } from "../../runtime/control/index.js";
+import type {
+  RuntimeControlActor,
+  RuntimeControlReplyTarget,
+} from "../../runtime/store/runtime-operation-schemas.js";
 
 // ─── Types ───
 
@@ -70,12 +76,26 @@ export interface ChatRunnerDeps {
   onEvent?: (event: ChatEvent) => void;
   /** Optional: native agentloop runner for chat turns. */
   chatAgentLoopRunner?: ChatAgentLoopRunner;
+  /** Optional: first-class runtime control service for natural-language restart/update requests. */
+  runtimeControlService?: Pick<RuntimeControlService, "request">;
+  /** Optional: approval handler scoped to runtime-control operations only. */
+  runtimeControlApprovalFn?: (description: string) => Promise<boolean>;
+  /** Optional: durable reply target for post-restart reporting. */
+  runtimeReplyTarget?: RuntimeControlReplyTarget;
+  /** Optional: source metadata for runtime control operation records. */
+  runtimeControlActor?: RuntimeControlActor;
 }
 
 export interface ChatRunResult {
   success: boolean;
   output: string;
   elapsed_ms: number;
+}
+
+export interface RuntimeControlChatContext {
+  replyTarget?: RuntimeControlReplyTarget;
+  actor?: RuntimeControlActor;
+  approvalFn?: (description: string) => Promise<boolean>;
 }
 
 interface AssistantBuffer {
@@ -129,6 +149,7 @@ export class ChatRunner {
   onNotification: ((message: string) => void) | undefined = undefined;
   onEvent: ((event: ChatEvent) => void) | undefined = undefined;
   private nativeAgentLoopStatePath: string | null = null;
+  private runtimeControlContext: RuntimeControlChatContext | null = null;
 
   constructor(deps: ChatRunnerDeps) {
     this.deps = deps;
@@ -146,6 +167,10 @@ export class ChatRunner {
     this.sessionCwd = gitRoot;
     this.sessionActive = true;
     this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
+  }
+
+  setRuntimeControlContext(context: RuntimeControlChatContext | null): void {
+    this.runtimeControlContext = context;
   }
 
   private async handleCommand(input: string): Promise<ChatRunResult | null> {
@@ -380,6 +405,27 @@ export class ChatRunner {
         false
       );
       return confirmationResult;
+    }
+
+    const runtimeControlResult = resumeOnly
+      ? null
+      : await this.handleRuntimeControlIntent(input, cwd, Date.now());
+    if (runtimeControlResult !== null) {
+      if (runtimeControlResult.output) {
+        this.emitEvent({
+          type: "assistant_final",
+          text: runtimeControlResult.output,
+          persisted: false,
+          ...this.eventBase(eventContext),
+        });
+      }
+      this.emitLifecycleEndEvent(
+        runtimeControlResult.success ? "completed" : "error",
+        runtimeControlResult.elapsed_ms,
+        eventContext,
+        false
+      );
+      return runtimeControlResult;
     }
 
     // Reuse session (interactive mode) or create a fresh one per call (1-shot mode)
@@ -640,6 +686,47 @@ export class ChatRunner {
       success: result.success,
       output: result.output,
       elapsed_ms,
+    };
+  }
+
+  private async handleRuntimeControlIntent(
+    input: string,
+    cwd: string,
+    start: number
+  ): Promise<ChatRunResult | null> {
+    const intent = recognizeRuntimeControlIntent(input);
+    if (intent === null) return null;
+
+    if (!this.deps.runtimeControlService) {
+      return {
+        success: false,
+        output: "Runtime control is not available in this chat surface yet.",
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    const replyTarget = this.runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget;
+    const actor = this.runtimeControlContext?.actor ?? this.deps.runtimeControlActor;
+    const result = await this.deps.runtimeControlService.request({
+      intent,
+      cwd,
+      requestedBy: actor ?? {
+        surface: replyTarget?.surface ?? "chat",
+        platform: replyTarget?.platform,
+        conversation_id: replyTarget?.conversation_id,
+        identity_key: replyTarget?.identity_key,
+        user_id: replyTarget?.user_id,
+      },
+      replyTarget: replyTarget ?? { surface: "chat" },
+      approvalFn: this.runtimeControlContext?.approvalFn
+        ?? this.deps.runtimeControlApprovalFn
+        ?? this.deps.approvalFn,
+    });
+
+    return {
+      success: result.success,
+      output: result.message,
+      elapsed_ms: Date.now() - start,
     };
   }
 

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
+import * as path from "node:path";
 import { ChatRunner } from "./chat-runner.js";
 import type { ChatRunResult, ChatRunnerDeps } from "./chat-runner.js";
+import type { RuntimeControlChatContext } from "./chat-runner.js";
 import type { ChatEvent, ChatEventHandler } from "./chat-events.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { buildAdapterRegistry, buildLLMClient } from "../../base/llm/provider-factory.js";
@@ -17,6 +19,10 @@ import {
   createNativeChatAgentLoopRunner,
   shouldUseNativeTaskAgentLoop,
 } from "../../orchestrator/execution/agent-loop/index.js";
+import {
+  RuntimeControlService,
+  createDaemonRuntimeControlExecutor,
+} from "../../runtime/control/index.js";
 
 export interface CrossPlatformChatSessionOptions {
   /**
@@ -122,6 +128,35 @@ function buildSessionMetadata(options: CrossPlatformChatSessionOptions): Record<
     ...(options.conversation_name ? { conversation_name: options.conversation_name } : {}),
     ...(options.user_id ? { user_id: options.user_id } : {}),
     ...(options.user_name ? { user_name: options.user_name } : {}),
+  };
+}
+
+function buildRuntimeControlChatContext(
+  options: CrossPlatformChatSessionOptions
+): RuntimeControlChatContext | null {
+  const platform = normalizePlatform(options.platform);
+  const conversationId = normalizeIdentity(options.conversation_id);
+  const identityKey = normalizeIdentity(options.identity_key);
+  const userId = normalizeIdentity(options.user_id);
+  if (!platform && !conversationId && !identityKey && !userId) return null;
+  const runtimeControlApproved = options.metadata?.["runtime_control_approved"] === true;
+
+  return {
+    actor: {
+      surface: platform ? "gateway" : "chat",
+      ...(platform ? { platform } : {}),
+      ...(conversationId ? { conversation_id: conversationId } : {}),
+      ...(identityKey ? { identity_key: identityKey } : {}),
+      ...(userId ? { user_id: userId } : {}),
+    },
+    replyTarget: {
+      surface: platform ? "gateway" : "chat",
+      ...(platform ? { platform } : {}),
+      ...(conversationId ? { conversation_id: conversationId } : {}),
+      ...(identityKey ? { identity_key: identityKey } : {}),
+      ...(userId ? { user_id: userId } : {}),
+    },
+    ...(runtimeControlApproved ? { approvalFn: async () => true } : {}),
   };
 }
 
@@ -253,9 +288,11 @@ export class CrossPlatformChatSessionManager {
     }
 
     try {
+      session.runner.setRuntimeControlContext(buildRuntimeControlChatContext(options));
       return await session.runner.execute(input, session.info.cwd, options.timeoutMs);
     } finally {
       session.runner.onEvent = previousOnEvent;
+      session.runner.setRuntimeControlContext(null);
     }
   }
 }
@@ -309,5 +346,11 @@ async function createGlobalCrossPlatformChatSessionManager(): Promise<CrossPlatf
     registry: toolRegistry,
     toolExecutor,
     chatAgentLoopRunner,
+    runtimeControlService: new RuntimeControlService({
+      runtimeRoot: path.join(stateManager.getBaseDir(), "runtime"),
+      executor: createDaemonRuntimeControlExecutor({
+        baseDir: stateManager.getBaseDir(),
+      }),
+    }),
   });
 }

--- a/src/interface/cli/commands/chat.ts
+++ b/src/interface/cli/commands/chat.ts
@@ -5,6 +5,7 @@ import { render, useApp } from "ink";
 import { parseArgs } from "node:util";
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
+import * as path from "node:path";
 
 import { StateManager } from "../../../base/state/state-manager.js";
 import { ensureProviderConfig } from "../ensure-api-key.js";
@@ -29,6 +30,10 @@ import {
   createNativeChatAgentLoopRunner,
   shouldUseNativeTaskAgentLoop,
 } from "../../../orchestrator/execution/agent-loop/index.js";
+import {
+  RuntimeControlService,
+  createDaemonRuntimeControlExecutor,
+} from "../../../runtime/control/index.js";
 
 const logger = getCliLogger();
 
@@ -286,6 +291,13 @@ export async function cmdChat(
       toolExecutor,
       chatAgentLoopRunner,
       approvalFn: promptChatApproval,
+      runtimeControlService: new RuntimeControlService({
+        runtimeRoot: path.join(stateManager.getBaseDir(), "runtime"),
+        executor: createDaemonRuntimeControlExecutor({
+          baseDir: stateManager.getBaseDir(),
+        }),
+      }),
+      runtimeReplyTarget: { surface: "cli" },
     });
 
     // Non-interactive: single turn

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
@@ -21,6 +21,7 @@ import {
   ChatAgentLoopRunner,
   CorePhaseRunner,
   ExtractiveAgentLoopCompactor,
+  JsonAgentLoopSessionStateStore,
   NoopAgentLoopCompactor,
   StaticAgentLoopModelRegistry,
   ToolExecutorAgentLoopToolRuntime,
@@ -345,6 +346,102 @@ describe("agentloop phase 5 compaction", () => {
     expect(result.compactions).toBe(1);
     expect(modelClient.calls[1].messages.some((m) => m.role === "tool" && m.toolName === "update_plan")).toBe(true);
     expect(modelClient.calls[1].messages.some((m) => m.content.includes("Summary of earlier agentloop context"))).toBe(true);
+  });
+
+  it("resumes from persisted compacted state after an interrupted turn", async () => {
+    const statePath = path.join(makeTempDir(), "agentloop.state.json");
+    const modelInfo = makeModelInfo();
+    const registry = new ToolRegistry();
+    registry.register(new UpdatePlanTool());
+    const { router, runtime } = makeRuntime(registry);
+
+    const firstModelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{ id: "call-1", name: "update_plan", input: { steps: [{ step: "verify", status: "completed" }] } }],
+        stopReason: "tool_use",
+        usage: { inputTokens: 100, outputTokens: 100 },
+      },
+    ]);
+    const firstRunner = new BoundedAgentLoopRunner({
+      modelClient: firstModelClient,
+      toolRouter: router,
+      toolRuntime: runtime,
+      compactor: new ExtractiveAgentLoopCompactor(),
+    });
+
+    const first = await firstRunner.run({
+      session: createAgentLoopSession({
+        sessionId: "session-1",
+        traceId: "trace-1",
+        stateStore: new JsonAgentLoopSessionStateStore(statePath),
+      }),
+      turnId: "turn-1",
+      goalId: "goal-1",
+      cwd: process.cwd(),
+      model: modelInfo.ref,
+      modelInfo,
+      messages: [
+        { role: "system", content: "system" },
+        { role: "user", content: "one ".repeat(120) },
+        { role: "assistant", content: "two ".repeat(120) },
+        { role: "user", content: "three ".repeat(120) },
+        { role: "user", content: "continue after resume" },
+      ],
+      outputSchema: z.object({ status: z.literal("done"), message: z.string(), evidence: z.array(z.string()), blockers: z.array(z.string()) }),
+      budget: { ...defaultBudgetForTest(), maxToolCalls: 1, autoCompactTokenLimit: 50, compactionMaxMessages: 4 },
+      toolPolicy: {},
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+    });
+
+    expect(first.success).toBe(false);
+    expect(first.stopReason).toBe("max_tool_calls");
+    expect(first.compactions).toBeGreaterThanOrEqual(1);
+
+    const secondModelClient = new ScriptedModelClient(modelInfo, [
+      { content: JSON.stringify({ status: "done", message: "resumed", evidence: ["plan update"], blockers: [] }), toolCalls: [], stopReason: "end_turn" },
+    ]);
+    const secondRunner = new BoundedAgentLoopRunner({
+      modelClient: secondModelClient,
+      toolRouter: router,
+      toolRuntime: runtime,
+      compactor: new ExtractiveAgentLoopCompactor(),
+    });
+
+    const second = await secondRunner.run({
+      session: createAgentLoopSession({
+        sessionId: "session-1",
+        traceId: "trace-1",
+        stateStore: new JsonAgentLoopSessionStateStore(statePath),
+      }),
+      turnId: "turn-1",
+      goalId: "goal-1",
+      cwd: process.cwd(),
+      model: modelInfo.ref,
+      modelInfo,
+      messages: [{ role: "user", content: "fresh prompt should be replaced by persisted state" }],
+      outputSchema: z.object({ status: z.literal("done"), message: z.string(), evidence: z.array(z.string()), blockers: z.array(z.string()) }),
+      budget: { ...defaultBudgetForTest(), autoCompactTokenLimit: 50, compactionMaxMessages: 4 },
+      toolPolicy: {},
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+    });
+
+    expect(second.success).toBe(true);
+    expect(second.compactions).toBeGreaterThanOrEqual(first.compactions);
+    expect(secondModelClient.calls[0].messages.some((m) => m.content.includes("Summary of earlier agentloop context"))).toBe(true);
+    expect(secondModelClient.calls[0].messages.some((m) => m.role === "tool" && m.toolName === "update_plan")).toBe(true);
   });
 });
 

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-session-factory.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-session-factory.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
 import { createPersistentAgentLoopSessionFactory } from "../agent-loop-session-factory.js";
+import { JsonAgentLoopSessionStateStore } from "../agent-loop-session-state.js";
 
 describe("createPersistentAgentLoopSessionFactory", () => {
   it("persists trace events to jsonl files under the configured base directory", async () => {
@@ -30,5 +31,67 @@ describe("createPersistentAgentLoopSessionFactory", () => {
     const content = await fs.readFile(path.join(tracesDir, files[0]!), "utf-8");
     expect(content).toContain("\"type\":\"started\"");
     expect(content).toContain(session.traceId);
+  });
+});
+
+describe("JsonAgentLoopSessionStateStore", () => {
+  it("normalizes legacy state files that predate newer counters", async () => {
+    const baseDir = makeTempDir();
+    const statePath = path.join(baseDir, "legacy.state.json");
+    await fs.writeFile(statePath, JSON.stringify({
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "turn-1",
+      goalId: "goal-1",
+      cwd: baseDir,
+      modelRef: "openai/gpt-test",
+      messages: [
+        { role: "user", content: "continue" },
+        {
+          role: "assistant",
+          content: "Calling verify",
+          toolCalls: [{ id: "call-1", name: "verify", input: { command: "npm test" } }],
+        },
+      ],
+      modelTurns: 2,
+      toolCalls: 1,
+      compactions: 1,
+      status: "running",
+    }), "utf-8");
+
+    const state = await new JsonAgentLoopSessionStateStore(statePath).load();
+
+    expect(state).toMatchObject({
+      sessionId: "session-1",
+      traceId: "trace-1",
+      completionValidationAttempts: 0,
+      calledTools: [],
+      lastToolLoopSignature: null,
+      repeatedToolLoopCount: 0,
+      finalText: "",
+      status: "running",
+      updatedAt: "1970-01-01T00:00:00.000Z",
+    });
+    expect(state?.messages[1]?.toolCalls?.[0]).toMatchObject({
+      id: "call-1",
+      name: "verify",
+      input: { command: "npm test" },
+    });
+  });
+
+  it("returns null for corrupt or incompatible state files", async () => {
+    const baseDir = makeTempDir();
+    const corruptPath = path.join(baseDir, "corrupt.state.json");
+    const incompatiblePath = path.join(baseDir, "incompatible.state.json");
+    await fs.writeFile(corruptPath, "{", "utf-8");
+    await fs.writeFile(incompatiblePath, JSON.stringify({
+      sessionId: "session-1",
+      traceId: "trace-1",
+      goalId: "goal-1",
+      messages: [{ role: "user", content: "missing turnId/cwd/modelRef" }],
+    }), "utf-8");
+
+    await expect(new JsonAgentLoopSessionStateStore(corruptPath).load()).resolves.toBeNull();
+    await expect(new JsonAgentLoopSessionStateStore(incompatiblePath).load()).resolves.toBeNull();
   });
 });

--- a/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { AgentLoopStopReason } from "./agent-loop-budget.js";
-import type { AgentLoopMessage } from "./agent-loop-model.js";
+import type { AgentLoopMessage, AgentLoopMessagePhase, AgentLoopMessageRole, AgentLoopToolCall } from "./agent-loop-model.js";
 
 export interface AgentLoopSessionState {
   sessionId: string;
@@ -52,7 +52,7 @@ export class JsonAgentLoopSessionStateStore implements AgentLoopSessionStateStor
   async load(): Promise<AgentLoopSessionState | null> {
     try {
       const raw = await readFile(this.filePath, "utf-8");
-      return JSON.parse(raw) as AgentLoopSessionState;
+      return normalizeAgentLoopSessionState(JSON.parse(raw));
     } catch {
       return null;
     }
@@ -62,4 +62,100 @@ export class JsonAgentLoopSessionStateStore implements AgentLoopSessionStateStor
     await mkdir(dirname(this.filePath), { recursive: true });
     await writeFile(this.filePath, JSON.stringify(state, null, 2), "utf-8");
   }
+}
+
+export function normalizeAgentLoopSessionState(value: unknown): AgentLoopSessionState | null {
+  if (!isRecord(value)) return null;
+
+  const sessionId = stringField(value, "sessionId");
+  const traceId = stringField(value, "traceId");
+  const turnId = stringField(value, "turnId");
+  const goalId = stringField(value, "goalId");
+  const cwd = stringField(value, "cwd");
+  const modelRef = stringField(value, "modelRef");
+  if (!sessionId || !traceId || !turnId || !goalId || !cwd || !modelRef) return null;
+
+  const rawMessages = Array.isArray(value["messages"]) ? value["messages"] : null;
+  if (!rawMessages) return null;
+  const messages = rawMessages.map(normalizeMessage).filter((message): message is AgentLoopMessage => message !== null);
+  if (messages.length !== rawMessages.length) return null;
+
+  return {
+    sessionId,
+    traceId,
+    turnId,
+    goalId,
+    ...(typeof value["taskId"] === "string" ? { taskId: value["taskId"] } : {}),
+    cwd,
+    modelRef,
+    messages,
+    modelTurns: nonNegativeNumberField(value, "modelTurns"),
+    toolCalls: nonNegativeNumberField(value, "toolCalls"),
+    compactions: nonNegativeNumberField(value, "compactions"),
+    completionValidationAttempts: nonNegativeNumberField(value, "completionValidationAttempts"),
+    calledTools: stringArrayField(value, "calledTools"),
+    lastToolLoopSignature: typeof value["lastToolLoopSignature"] === "string" ? value["lastToolLoopSignature"] : null,
+    repeatedToolLoopCount: nonNegativeNumberField(value, "repeatedToolLoopCount"),
+    finalText: typeof value["finalText"] === "string" ? value["finalText"] : "",
+    status: statusField(value, "status"),
+    ...(typeof value["stopReason"] === "string" ? { stopReason: value["stopReason"] as AgentLoopStopReason } : {}),
+    updatedAt: typeof value["updatedAt"] === "string" ? value["updatedAt"] : new Date(0).toISOString(),
+  };
+}
+
+function normalizeMessage(value: unknown): AgentLoopMessage | null {
+  if (!isRecord(value)) return null;
+  const role = roleField(value, "role");
+  if (!role || typeof value["content"] !== "string") return null;
+  const phase = phaseField(value, "phase");
+
+  return {
+    role,
+    content: value["content"],
+    ...(phase ? { phase } : {}),
+    ...(typeof value["toolCallId"] === "string" ? { toolCallId: value["toolCallId"] } : {}),
+    ...(typeof value["toolName"] === "string" ? { toolName: value["toolName"] } : {}),
+    ...(Array.isArray(value["toolCalls"]) ? { toolCalls: value["toolCalls"].map(normalizeToolCall).filter((call): call is AgentLoopToolCall => call !== null) } : {}),
+  };
+}
+
+function normalizeToolCall(value: unknown): AgentLoopToolCall | null {
+  if (!isRecord(value)) return null;
+  const id = stringField(value, "id");
+  const name = stringField(value, "name");
+  if (!id || !name) return null;
+  return { id, name, input: value["input"] };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function stringField(value: Record<string, unknown>, field: string): string | null {
+  return typeof value[field] === "string" && value[field].trim().length > 0 ? value[field] : null;
+}
+
+function nonNegativeNumberField(value: Record<string, unknown>, field: string): number {
+  const raw = value[field];
+  return typeof raw === "number" && Number.isFinite(raw) && raw >= 0 ? raw : 0;
+}
+
+function stringArrayField(value: Record<string, unknown>, field: string): string[] {
+  const raw = value[field];
+  return Array.isArray(raw) ? raw.filter((item): item is string => typeof item === "string") : [];
+}
+
+function roleField(value: Record<string, unknown>, field: string): AgentLoopMessageRole | null {
+  const raw = value[field];
+  return raw === "system" || raw === "user" || raw === "assistant" || raw === "tool" ? raw : null;
+}
+
+function phaseField(value: Record<string, unknown>, field: string): AgentLoopMessagePhase | null {
+  const raw = value[field];
+  return raw === "commentary" || raw === "final_answer" ? raw : null;
+}
+
+function statusField(value: Record<string, unknown>, field: string): AgentLoopSessionState["status"] {
+  const raw = value[field];
+  return raw === "completed" || raw === "failed" ? raw : "running";
 }

--- a/src/platform/knowledge/__tests__/knowledge-transfer-incremental.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-transfer-incremental.test.ts
@@ -342,6 +342,55 @@ describe("M16.6: Incremental Meta-Pattern Update + Transfer Effect Report", () =
       expect(mockKT.updateMetaPatternsIncremental).toHaveBeenCalledOnce();
     });
 
+    it("goal completion persists learned feedback and triggers incremental meta-pattern update", async () => {
+      const tripletsResponse = JSON.stringify({
+        triplets: [
+          {
+            state_context: "Large task repeatedly stalled near verification",
+            action_taken: "Reduced scope to a single verifiable step",
+            outcome: "Task completed and verification evidence was collected",
+            gap_delta: -0.35,
+          },
+        ],
+      });
+      const patternsResponse = JSON.stringify({
+        patterns: [
+          {
+            description: "Reduce stalled tasks to a single verifiable step before retrying",
+            pattern_type: "scope_sizing",
+            action_group: "scope_reduction",
+            applicable_domains: ["agent_loop", "verification"],
+            occurrence_count: 3,
+            consistent_count: 3,
+            total_count: 3,
+            is_specific: true,
+          },
+        ],
+      });
+      const llmClient = createMockLLMClient([tripletsResponse, patternsResponse]);
+      const pipeline = new LearningPipeline(llmClient, null, stateManager);
+      const mockKT = { updateMetaPatternsIncremental: vi.fn().mockResolvedValue(1) };
+      pipeline.setKnowledgeTransfer(mockKT);
+      await stateManager.writeRaw("learning/goal_complete_logs.json", [
+        { loop: 1, action: "reduced scope", result: "verified" },
+      ]);
+
+      const learned = await pipeline.onGoalCompleted("goal_complete");
+
+      expect(learned).toHaveLength(1);
+      expect(mockKT.updateMetaPatternsIncremental).toHaveBeenCalledOnce();
+      await expect(pipeline.getPatterns("goal_complete")).resolves.toHaveLength(1);
+      const feedback = await pipeline.getFeedbackEntries("goal_complete");
+      expect(feedback).toHaveLength(1);
+      expect(feedback[0]).toMatchObject({
+        target_step: "task",
+        adjustment: "Reduce stalled tasks to a single verifiable step before retrying",
+      });
+      await expect(pipeline.applyFeedback("goal_complete", "task")).resolves.toEqual([
+        "Reduce stalled tasks to a single verifiable step before retrying",
+      ]);
+    });
+
     it("does not call updateMetaPatternsIncremental when analyzeLogs produces no patterns", async () => {
       const llmClient = createMockLLMClient([]);
       const pipeline = new LearningPipeline(llmClient, null, stateManager);

--- a/src/runtime/__tests__/daemon-client.test.ts
+++ b/src/runtime/__tests__/daemon-client.test.ts
@@ -1,7 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { DaemonClient, isDaemonRunning, probeDaemonHealth } from "../daemon-client.js";
+import {
+  DaemonClient,
+  isDaemonRunning,
+  probeDaemonHealth,
+  readDaemonAuthToken,
+} from "../daemon-client.js";
 import { EventServer } from "../event-server.js";
 import { DEFAULT_PORT } from "../port-utils.js";
 import { OutboxStore } from "../store/outbox-store.js";
@@ -121,6 +126,40 @@ describe("DaemonClient snapshot + replay", () => {
       client.disconnect();
     }
   });
+
+  it("sends runtime control requests as daemon command envelopes", async () => {
+    const envelopes: unknown[] = [];
+    server.setCommandEnvelopeHook((envelope) => {
+      envelopes.push(envelope);
+    });
+    await server.start();
+
+    const client = new DaemonClient({
+      host: "127.0.0.1",
+      port: server.getPort(),
+      authToken: server.getAuthToken(),
+    });
+
+    await expect(client.requestRuntimeControl({
+      operationId: "op-restart-1",
+      kind: "restart_daemon",
+      reason: "PulSeed を再起動して",
+    })).resolves.toEqual(expect.objectContaining({ ok: true }));
+
+    expect(envelopes).toHaveLength(1);
+    expect(envelopes[0]).toMatchObject({
+      type: "command",
+      name: "runtime_control",
+      source: "http",
+      priority: "critical",
+      dedupe_key: "runtime_control:op-restart-1",
+      payload: {
+        operationId: "op-restart-1",
+        kind: "restart_daemon",
+        reason: "PulSeed を再起動して",
+      },
+    });
+  });
 });
 
 describe("isDaemonRunning", () => {
@@ -132,6 +171,7 @@ describe("isDaemonRunning", () => {
 
   afterEach(() => {
     cleanupTempDir(tmpDir);
+    delete process.env["PULSEED_DAEMON_TOKEN"];
     vi.restoreAllMocks();
   });
 
@@ -147,6 +187,17 @@ describe("isDaemonRunning", () => {
       running: true,
       port: DEFAULT_PORT,
     });
+  });
+
+  it("prefers the daemon token file over stale process env tokens", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon-token.json"),
+      JSON.stringify({ token: "fresh-token", port: 41700 }),
+      "utf-8"
+    );
+    process.env["PULSEED_DAEMON_TOKEN"] = "stale-token";
+
+    expect(readDaemonAuthToken(tmpDir, 41700)).toBe("fresh-token");
   });
 });
 

--- a/src/runtime/command-dispatcher.ts
+++ b/src/runtime/command-dispatcher.ts
@@ -4,6 +4,8 @@ import {
 } from "./queue/journal-backed-queue.js";
 import type { Envelope } from "./types/envelope.js";
 import type { Logger } from "./logger.js";
+import { RuntimeControlOperationKindSchema } from "./store/index.js";
+import type { RuntimeControlOperationKind } from "./store/index.js";
 
 export interface CommandDispatcherDeps {
   journalQueue: JournalBackedQueue;
@@ -19,6 +21,11 @@ export interface CommandDispatcherDeps {
     goalId: string | undefined,
     requestId: string,
     approved: boolean,
+    envelope: Envelope
+  ) => Promise<void> | void;
+  onRuntimeControl?: (
+    operationId: string,
+    kind: RuntimeControlOperationKind,
     envelope: Envelope
   ) => Promise<void> | void;
 }
@@ -138,6 +145,16 @@ export class CommandDispatcher {
           throw new Error("approval_response command is missing requestId or approved");
         }
         await this.deps.onApprovalResponse?.(envelope.goal_id, requestId, approved, envelope);
+        return;
+      }
+      case "runtime_control": {
+        const operationId = this.readStringField(envelope.payload, "operationId");
+        const kindRaw = this.readStringField(envelope.payload, "kind");
+        const kind = RuntimeControlOperationKindSchema.parse(kindRaw);
+        if (!operationId) {
+          throw new Error("runtime_control command is missing operationId");
+        }
+        await this.deps.onRuntimeControl?.(operationId, kind, envelope);
         return;
       }
       default:

--- a/src/runtime/control/__tests__/daemon-runtime-control-executor.test.ts
+++ b/src/runtime/control/__tests__/daemon-runtime-control-executor.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { createDaemonRuntimeControlExecutor } from "../daemon-runtime-control-executor.js";
+import { DaemonClient, isDaemonRunning } from "../../daemon/client.js";
+import type { RuntimeControlOperation } from "../../store/index.js";
+
+const { requestRuntimeControlMock } = vi.hoisted(() => ({
+  requestRuntimeControlMock: vi.fn(),
+}));
+
+vi.mock("../../daemon/client.js", () => ({
+  DaemonClient: vi.fn().mockImplementation(function () {
+    return {
+      requestRuntimeControl: requestRuntimeControlMock,
+    };
+  }),
+  isDaemonRunning: vi.fn(),
+}));
+
+function makeOperation(kind: RuntimeControlOperation["kind"] = "restart_daemon"): RuntimeControlOperation {
+  return {
+    operation_id: "op-1",
+    kind,
+    state: "acknowledged",
+    requested_at: "2026-04-13T00:00:00.000Z",
+    updated_at: "2026-04-13T00:00:00.000Z",
+    requested_by: { surface: "cli" },
+    reply_target: { surface: "cli" },
+    reason: "PulSeed を再起動して",
+    expected_health: {
+      daemon_ping: true,
+      gateway_acceptance: true,
+    },
+  };
+}
+
+describe("createDaemonRuntimeControlExecutor", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requestRuntimeControlMock.mockResolvedValue({ ok: true });
+  });
+
+  it("submits daemon restart requests through the daemon HTTP command surface", async () => {
+    vi.mocked(isDaemonRunning).mockResolvedValue({
+      running: true,
+      port: 41700,
+      authToken: "token-1",
+    });
+
+    const executor = createDaemonRuntimeControlExecutor({ baseDir: "/tmp/pulseed" });
+    await expect(executor(makeOperation(), {
+      intent: { kind: "restart_daemon", reason: "PulSeed を再起動して" },
+      cwd: "/repo",
+    })).resolves.toMatchObject({
+      ok: true,
+      state: "running",
+    });
+
+    expect(DaemonClient).toHaveBeenCalledWith({
+      host: "127.0.0.1",
+      port: 41700,
+      authToken: "token-1",
+      baseDir: "/tmp/pulseed",
+    });
+    expect(requestRuntimeControlMock).toHaveBeenCalledWith({
+      operationId: "op-1",
+      kind: "restart_daemon",
+      reason: "PulSeed を再起動して",
+    });
+  });
+
+  it("fails without claiming restart when the daemon is not running", async () => {
+    vi.mocked(isDaemonRunning).mockResolvedValue({
+      running: false,
+      port: 41700,
+    });
+
+    const executor = createDaemonRuntimeControlExecutor({ baseDir: "/tmp/pulseed" });
+    await expect(executor(makeOperation(), {
+      intent: { kind: "restart_daemon", reason: "PulSeed を再起動して" },
+      cwd: "/repo",
+    })).resolves.toMatchObject({
+      ok: false,
+      state: "failed",
+      message: expect.stringContaining("not running"),
+    });
+
+    expect(requestRuntimeControlMock).not.toHaveBeenCalled();
+  });
+
+  it("does not route self-update through daemon restart", async () => {
+    const executor = createDaemonRuntimeControlExecutor({ baseDir: "/tmp/pulseed" });
+    await expect(executor(makeOperation("self_update"), {
+      intent: { kind: "self_update", reason: "PulSeed 自身を更新して" },
+      cwd: "/repo",
+    })).resolves.toMatchObject({
+      ok: false,
+      state: "failed",
+    });
+
+    expect(isDaemonRunning).not.toHaveBeenCalled();
+    expect(requestRuntimeControlMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/runtime/control/__tests__/runtime-control-service.test.ts
+++ b/src/runtime/control/__tests__/runtime-control-service.test.ts
@@ -1,0 +1,80 @@
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { RuntimeOperationStore } from "../../store/runtime-operation-store.js";
+import { RuntimeControlService } from "../runtime-control-service.js";
+
+describe("RuntimeControlService", () => {
+  it("executes approval-free runtime operations through the configured executor", async () => {
+    const tmpDir = makeTempDir("pulseed-runtime-control-service-");
+    try {
+      const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+      const executor = vi.fn().mockResolvedValue({
+        ok: true,
+        state: "acknowledged",
+        message: "reload queued",
+      });
+      const service = new RuntimeControlService({ operationStore, executor });
+
+      const result = await service.request({
+        intent: { kind: "reload_config", reason: "runtime 設定を再読み込みして" },
+        cwd: "/repo",
+      });
+
+      expect(result).toMatchObject({
+        success: true,
+        message: "reload queued",
+        state: "acknowledged",
+      });
+      expect(executor).toHaveBeenCalledOnce();
+      expect(await operationStore.listCompleted()).toHaveLength(0);
+      const pending = await operationStore.listPending();
+      expect(pending).toHaveLength(1);
+      expect(pending[0]).toMatchObject({
+        kind: "reload_config",
+        state: "acknowledged",
+        expected_health: {
+          daemon_ping: false,
+          gateway_acceptance: false,
+        },
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("records cancelled operations when required approval is rejected", async () => {
+    const tmpDir = makeTempDir("pulseed-runtime-control-service-rejected-");
+    try {
+      const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+      const executor = vi.fn();
+      const service = new RuntimeControlService({ operationStore, executor });
+
+      const result = await service.request({
+        intent: { kind: "restart_daemon", reason: "PulSeed を再起動して" },
+        cwd: "/repo",
+        approvalFn: vi.fn().mockResolvedValue(false),
+      });
+
+      expect(result).toMatchObject({
+        success: false,
+        message: "Runtime control operation was not approved.",
+        state: "cancelled",
+      });
+      expect(executor).not.toHaveBeenCalled();
+      expect(await operationStore.listPending()).toHaveLength(0);
+      const completed = await operationStore.listCompleted();
+      expect(completed).toHaveLength(1);
+      expect(completed[0]).toMatchObject({
+        kind: "restart_daemon",
+        state: "cancelled",
+        result: {
+          ok: false,
+          message: "Runtime control operation was not approved.",
+        },
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+});

--- a/src/runtime/control/daemon-runtime-control-executor.ts
+++ b/src/runtime/control/daemon-runtime-control-executor.ts
@@ -1,0 +1,70 @@
+import { DaemonClient, isDaemonRunning } from "../daemon/client.js";
+import type { RuntimeControlOperationKind } from "../store/runtime-operation-schemas.js";
+import type {
+  RuntimeControlExecutor,
+  RuntimeControlExecutorResult,
+} from "./runtime-control-service.js";
+
+export interface DaemonRuntimeControlExecutorOptions {
+  baseDir: string;
+  host?: string;
+}
+
+export interface DaemonRuntimeControlRequestBody {
+  operationId: string;
+  kind: RuntimeControlOperationKind;
+  reason: string;
+}
+
+export function createDaemonRuntimeControlExecutor(
+  options: DaemonRuntimeControlExecutorOptions
+): RuntimeControlExecutor {
+  return async (operation): Promise<RuntimeControlExecutorResult> => {
+    if (operation.kind !== "restart_daemon" && operation.kind !== "restart_gateway") {
+      return {
+        ok: false,
+        state: "failed",
+        message: `Runtime control operation ${operation.kind} is not implemented yet.`,
+      };
+    }
+
+    const daemonInfo = await isDaemonRunning(options.baseDir);
+    if (!daemonInfo.running) {
+      return {
+        ok: false,
+        state: "failed",
+        message: "PulSeed daemon is not running; restart was not requested.",
+      };
+    }
+
+    const client = new DaemonClient({
+      host: options.host ?? "127.0.0.1",
+      port: daemonInfo.port,
+      authToken: daemonInfo.authToken,
+      baseDir: options.baseDir,
+    });
+
+    const response = await client.requestRuntimeControl({
+      operationId: operation.operation_id,
+      kind: operation.kind,
+      reason: operation.reason,
+    });
+
+    if (!response.ok) {
+      return {
+        ok: false,
+        state: "failed",
+        message: "PulSeed daemon rejected the runtime control request.",
+      };
+    }
+
+    return {
+      ok: true,
+      state: "running",
+      message:
+        operation.kind === "restart_gateway"
+          ? "gateway の再起動要求を daemon に送信しました。daemon 全体の再起動として復帰を確認します。"
+          : "PulSeed daemon の再起動要求を送信しました。watchdog による復帰を確認します。",
+    };
+  };
+}

--- a/src/runtime/control/index.ts
+++ b/src/runtime/control/index.ts
@@ -1,0 +1,15 @@
+export { recognizeRuntimeControlIntent } from "./runtime-control-intent.js";
+export type { RuntimeControlIntent } from "./runtime-control-intent.js";
+export { RuntimeControlService } from "./runtime-control-service.js";
+export { createDaemonRuntimeControlExecutor } from "./daemon-runtime-control-executor.js";
+export type {
+  DaemonRuntimeControlExecutorOptions,
+  DaemonRuntimeControlRequestBody,
+} from "./daemon-runtime-control-executor.js";
+export type {
+  RuntimeControlExecutor,
+  RuntimeControlExecutorResult,
+  RuntimeControlRequest,
+  RuntimeControlResult,
+  RuntimeControlServiceOptions,
+} from "./runtime-control-service.js";

--- a/src/runtime/control/runtime-control-intent.ts
+++ b/src/runtime/control/runtime-control-intent.ts
@@ -1,0 +1,40 @@
+import type { RuntimeControlOperationKind } from "../store/runtime-operation-schemas.js";
+
+export interface RuntimeControlIntent {
+  kind: RuntimeControlOperationKind;
+  reason: string;
+}
+
+const RESTART_TERMS = [/再起動/, /リスタート/i, /\brestart\b/i];
+const UPDATE_TERMS = [/更新/, /最新版/, /\bupdate\b/i, /\bupgrade\b/i];
+const RELOAD_TERMS = [/読み直/, /再読/, /\breload\b/i];
+const RUNTIME_TERMS = [/pulseed/i, /daemon/i, /gateway/i, /runtime/i, /自身/, /自分/];
+const EXPLANATION_TERMS = [/設計/, /説明/, /教えて/, /どう/, /\bexplain\b/i, /\bhow\b/i, /\bwhy\b/i];
+
+function anyMatch(input: string, patterns: RegExp[]): boolean {
+  return patterns.some((pattern) => pattern.test(input));
+}
+
+export function recognizeRuntimeControlIntent(input: string): RuntimeControlIntent | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (anyMatch(trimmed, EXPLANATION_TERMS)) return null;
+  if (!anyMatch(trimmed, RUNTIME_TERMS)) return null;
+
+  if (anyMatch(trimmed, UPDATE_TERMS)) {
+    return { kind: "self_update", reason: trimmed };
+  }
+
+  if (anyMatch(trimmed, RELOAD_TERMS) && /config|設定|env/i.test(trimmed)) {
+    return { kind: "reload_config", reason: trimmed };
+  }
+
+  if (anyMatch(trimmed, RESTART_TERMS)) {
+    if (/gateway/i.test(trimmed)) {
+      return { kind: "restart_gateway", reason: trimmed };
+    }
+    return { kind: "restart_daemon", reason: trimmed };
+  }
+
+  return null;
+}

--- a/src/runtime/control/runtime-control-service.ts
+++ b/src/runtime/control/runtime-control-service.ts
@@ -1,0 +1,213 @@
+import { randomUUID } from "node:crypto";
+import { RuntimeOperationStore } from "../store/runtime-operation-store.js";
+import type {
+  RuntimeControlActor,
+  RuntimeControlOperation,
+  RuntimeControlOperationKind,
+  RuntimeControlOperationState,
+  RuntimeControlReplyTarget,
+} from "../store/runtime-operation-schemas.js";
+import type { RuntimeControlIntent } from "./runtime-control-intent.js";
+
+export interface RuntimeControlRequest {
+  intent: RuntimeControlIntent;
+  cwd: string;
+  requestedBy?: RuntimeControlActor;
+  replyTarget?: RuntimeControlReplyTarget;
+  approvalFn?: (reason: string) => Promise<boolean>;
+}
+
+export interface RuntimeControlResult {
+  success: boolean;
+  message: string;
+  operationId?: string;
+  state?: RuntimeControlOperationState;
+}
+
+export interface RuntimeControlExecutorResult {
+  ok: boolean;
+  message?: string;
+  state?: RuntimeControlOperationState;
+}
+
+export type RuntimeControlExecutor = (
+  operation: RuntimeControlOperation,
+  request: RuntimeControlRequest
+) => Promise<RuntimeControlExecutorResult>;
+
+export interface RuntimeControlServiceOptions {
+  operationStore?: RuntimeOperationStore;
+  runtimeRoot?: string;
+  executor?: RuntimeControlExecutor;
+  now?: () => Date;
+}
+
+export class RuntimeControlService {
+  private readonly operationStore: RuntimeOperationStore;
+  private readonly executor?: RuntimeControlExecutor;
+  private readonly now: () => Date;
+
+  constructor(options: RuntimeControlServiceOptions = {}) {
+    this.operationStore = options.operationStore ?? new RuntimeOperationStore(options.runtimeRoot);
+    this.executor = options.executor;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async request(request: RuntimeControlRequest): Promise<RuntimeControlResult> {
+    const requestedAt = this.nowIso();
+    const operation: RuntimeControlOperation = {
+      operation_id: randomUUID(),
+      kind: request.intent.kind,
+      state: "pending",
+      requested_at: requestedAt,
+      updated_at: requestedAt,
+      requested_by: request.requestedBy ?? { surface: "chat" },
+      reply_target: request.replyTarget ?? { surface: "chat" },
+      reason: request.intent.reason,
+      expected_health: expectedHealthFor(request.intent.kind),
+    };
+
+    await this.operationStore.save(operation);
+
+    if (requiresApproval(operation.kind)) {
+      if (!request.approvalFn) {
+        const failed = await this.update(operation, "failed", {
+          ok: false,
+          message: "Runtime control requires approval, but no approval handler is configured.",
+        });
+        return {
+          success: false,
+          message: failed.result?.message ?? "Runtime control requires approval.",
+          operationId: failed.operation_id,
+          state: failed.state,
+        };
+      }
+
+      let approved: boolean;
+      try {
+        approved = await request.approvalFn(approvalReason(operation.kind, operation.reason));
+      } catch (err) {
+        const failed = await this.update(operation, "failed", {
+          ok: false,
+          message: err instanceof Error ? err.message : String(err),
+        });
+        return {
+          success: false,
+          message: failed.result?.message ?? "Runtime control approval failed.",
+          operationId: failed.operation_id,
+          state: failed.state,
+        };
+      }
+
+      if (!approved) {
+        const cancelled = await this.update(operation, "cancelled", {
+          ok: false,
+          message: "Runtime control operation was not approved.",
+        });
+        return {
+          success: false,
+          message: cancelled.result?.message ?? "Runtime control operation was not approved.",
+          operationId: cancelled.operation_id,
+          state: cancelled.state,
+        };
+      }
+
+      operation.state = "approved";
+      operation.updated_at = this.nowIso();
+      await this.operationStore.save(operation);
+    }
+
+    const acknowledged = await this.update(operation, "acknowledged", {
+      ok: true,
+      message: ackMessage(operation.kind),
+    });
+
+    if (!this.executor) {
+      const failed = await this.update(acknowledged, "failed", {
+        ok: false,
+        message: "Runtime control executor is not configured; operation was recorded but not started.",
+      });
+      return {
+        success: false,
+        message: failed.result?.message ?? "Runtime control executor is not configured.",
+        operationId: failed.operation_id,
+        state: failed.state,
+      };
+    }
+
+    let executed: RuntimeControlExecutorResult;
+    try {
+      executed = await this.executor(acknowledged, request);
+    } catch (err) {
+      const failed = await this.update(acknowledged, "failed", {
+        ok: false,
+        message: err instanceof Error ? err.message : String(err),
+      });
+      return {
+        success: false,
+        message: failed.result?.message ?? "Runtime control executor failed.",
+        operationId: failed.operation_id,
+        state: failed.state,
+      };
+    }
+
+    const nextState = executed.state ?? (executed.ok ? "acknowledged" : "failed");
+    const saved = await this.update(acknowledged, nextState, {
+      ok: executed.ok,
+      message: executed.message ?? ackMessage(operation.kind),
+    });
+
+    return {
+      success: executed.ok,
+      message: saved.result?.message ?? ackMessage(operation.kind),
+      operationId: saved.operation_id,
+      state: saved.state,
+    };
+  }
+
+  private async update(
+    operation: RuntimeControlOperation,
+    state: RuntimeControlOperationState,
+    result: { ok: boolean; message: string }
+  ): Promise<RuntimeControlOperation> {
+    const updated: RuntimeControlOperation = {
+      ...operation,
+      state,
+      updated_at: this.nowIso(),
+      result,
+    };
+    return this.operationStore.save(updated);
+  }
+
+  private nowIso(): string {
+    return this.now().toISOString();
+  }
+}
+
+function requiresApproval(kind: RuntimeControlOperationKind): boolean {
+  return kind === "restart_daemon" || kind === "restart_gateway" || kind === "self_update";
+}
+
+function expectedHealthFor(kind: RuntimeControlOperationKind): { daemon_ping: boolean; gateway_acceptance: boolean } {
+  return {
+    daemon_ping: kind !== "reload_config",
+    gateway_acceptance: kind === "restart_gateway" || kind === "restart_daemon" || kind === "self_update",
+  };
+}
+
+function approvalReason(kind: RuntimeControlOperationKind, reason: string): string {
+  return `Runtime control ${kind}: ${reason}`;
+}
+
+function ackMessage(kind: RuntimeControlOperationKind): string {
+  switch (kind) {
+    case "restart_gateway":
+      return "gateway の再起動を開始します。復帰後にこの会話へ結果を返します。";
+    case "restart_daemon":
+      return "PulSeed daemon の再起動を開始します。復帰後にこの会話へ結果を返します。";
+    case "reload_config":
+      return "runtime 設定の再読み込みを開始します。";
+    case "self_update":
+      return "PulSeed 自身の更新準備を開始します。実行前に内容を確認します。";
+  }
+}

--- a/src/runtime/control/runtime-control-service.ts
+++ b/src/runtime/control/runtime-control-service.ts
@@ -42,6 +42,10 @@ export interface RuntimeControlServiceOptions {
   now?: () => Date;
 }
 
+type RuntimeControlStep =
+  | { ok: true; operation: RuntimeControlOperation }
+  | { ok: false; result: RuntimeControlResult };
+
 export class RuntimeControlService {
   private readonly operationStore: RuntimeOperationStore;
   private readonly executor?: RuntimeControlExecutor;
@@ -54,6 +58,15 @@ export class RuntimeControlService {
   }
 
   async request(request: RuntimeControlRequest): Promise<RuntimeControlResult> {
+    const initial = await this.createInitialOperation(request);
+    const approved = await this.approveIfRequired(initial, request.approvalFn);
+    if (!approved.ok) return approved.result;
+
+    const acknowledged = await this.acknowledge(approved.operation);
+    return this.executeAcknowledgedOperation(acknowledged, request);
+  }
+
+  private async createInitialOperation(request: RuntimeControlRequest): Promise<RuntimeControlOperation> {
     const requestedAt = this.nowIso();
     const operation: RuntimeControlOperation = {
       operation_id: randomUUID(),
@@ -67,101 +80,104 @@ export class RuntimeControlService {
       expected_health: expectedHealthFor(request.intent.kind),
     };
 
-    await this.operationStore.save(operation);
+    return this.operationStore.save(operation);
+  }
 
-    if (requiresApproval(operation.kind)) {
-      if (!request.approvalFn) {
-        const failed = await this.update(operation, "failed", {
-          ok: false,
-          message: "Runtime control requires approval, but no approval handler is configured.",
-        });
-        return {
-          success: false,
-          message: failed.result?.message ?? "Runtime control requires approval.",
-          operationId: failed.operation_id,
-          state: failed.state,
-        };
-      }
-
-      let approved: boolean;
-      try {
-        approved = await request.approvalFn(approvalReason(operation.kind, operation.reason));
-      } catch (err) {
-        const failed = await this.update(operation, "failed", {
-          ok: false,
-          message: err instanceof Error ? err.message : String(err),
-        });
-        return {
-          success: false,
-          message: failed.result?.message ?? "Runtime control approval failed.",
-          operationId: failed.operation_id,
-          state: failed.state,
-        };
-      }
-
-      if (!approved) {
-        const cancelled = await this.update(operation, "cancelled", {
-          ok: false,
-          message: "Runtime control operation was not approved.",
-        });
-        return {
-          success: false,
-          message: cancelled.result?.message ?? "Runtime control operation was not approved.",
-          operationId: cancelled.operation_id,
-          state: cancelled.state,
-        };
-      }
-
-      operation.state = "approved";
-      operation.updated_at = this.nowIso();
-      await this.operationStore.save(operation);
+  private async approveIfRequired(
+    operation: RuntimeControlOperation,
+    approvalFn: RuntimeControlRequest["approvalFn"]
+  ): Promise<RuntimeControlStep> {
+    if (!requiresApproval(operation.kind)) {
+      return { ok: true, operation };
     }
 
-    const acknowledged = await this.update(operation, "acknowledged", {
+    if (!approvalFn) {
+      return this.failStep(
+        operation,
+        "failed",
+        "Runtime control requires approval, but no approval handler is configured."
+      );
+    }
+
+    let approved: boolean;
+    try {
+      approved = await approvalFn(approvalReason(operation.kind, operation.reason));
+    } catch (err) {
+      return this.failStep(
+        operation,
+        "failed",
+        err instanceof Error ? err.message : String(err)
+      );
+    }
+
+    if (!approved) {
+      return this.failStep(operation, "cancelled", "Runtime control operation was not approved.");
+    }
+
+    const updated = await this.operationStore.save({
+      ...operation,
+      state: "approved",
+      updated_at: this.nowIso(),
+    });
+    return { ok: true, operation: updated };
+  }
+
+  private acknowledge(operation: RuntimeControlOperation): Promise<RuntimeControlOperation> {
+    return this.update(operation, "acknowledged", {
       ok: true,
       message: ackMessage(operation.kind),
     });
+  }
 
+  private async executeAcknowledgedOperation(
+    operation: RuntimeControlOperation,
+    request: RuntimeControlRequest
+  ): Promise<RuntimeControlResult> {
     if (!this.executor) {
-      const failed = await this.update(acknowledged, "failed", {
+      const failed = await this.update(operation, "failed", {
         ok: false,
         message: "Runtime control executor is not configured; operation was recorded but not started.",
       });
-      return {
-        success: false,
-        message: failed.result?.message ?? "Runtime control executor is not configured.",
-        operationId: failed.operation_id,
-        state: failed.state,
-      };
+      return this.toResult(failed);
     }
 
     let executed: RuntimeControlExecutorResult;
     try {
-      executed = await this.executor(acknowledged, request);
+      executed = await this.executor(operation, request);
     } catch (err) {
-      const failed = await this.update(acknowledged, "failed", {
+      const failed = await this.update(operation, "failed", {
         ok: false,
         message: err instanceof Error ? err.message : String(err),
       });
-      return {
-        success: false,
-        message: failed.result?.message ?? "Runtime control executor failed.",
-        operationId: failed.operation_id,
-        state: failed.state,
-      };
+      return this.toResult(failed);
     }
 
     const nextState = executed.state ?? (executed.ok ? "acknowledged" : "failed");
-    const saved = await this.update(acknowledged, nextState, {
+    const saved = await this.update(operation, nextState, {
       ok: executed.ok,
       message: executed.message ?? ackMessage(operation.kind),
     });
+    return this.toResult(saved);
+  }
 
+  private async failStep(
+    operation: RuntimeControlOperation,
+    state: Extract<RuntimeControlOperationState, "failed" | "cancelled">,
+    message: string
+  ): Promise<RuntimeControlStep> {
+    const saved = await this.update(operation, state, {
+      ok: false,
+      message,
+    });
+    return { ok: false, result: this.toResult(saved) };
+  }
+
+  private toResult(operation: RuntimeControlOperation): RuntimeControlResult {
     return {
-      success: executed.ok,
-      message: saved.result?.message ?? ackMessage(operation.kind),
-      operationId: saved.operation_id,
-      state: saved.state,
+      success: operation.result?.ok ?? false,
+      message: operation.result?.message ?? ackMessage(operation.kind),
+      operationId: operation.operation_id,
+      state: operation.state,
     };
   }
 

--- a/src/runtime/daemon/client.ts
+++ b/src/runtime/daemon/client.ts
@@ -8,6 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { DEFAULT_PORT } from "../port-utils.js";
+import type { DaemonRuntimeControlRequestBody } from "../control/index.js";
 
 export interface DaemonClientConfig {
   host: string;
@@ -64,11 +65,6 @@ export function getDaemonTokenPath(baseDir?: string): string {
 }
 
 export function readDaemonAuthToken(baseDir?: string, expectedPort?: number): string | null {
-  const envToken = process.env[DAEMON_TOKEN_ENV];
-  if (envToken && envToken.trim() !== "") {
-    return envToken.trim();
-  }
-
   try {
     const raw = fs.readFileSync(getDaemonTokenPath(baseDir), "utf-8");
     const parsed = JSON.parse(raw) as Partial<DaemonAuthToken>;
@@ -77,8 +73,15 @@ export function readDaemonAuthToken(baseDir?: string, expectedPort?: number): st
     }
     return typeof parsed.token === "string" && parsed.token.length > 0 ? parsed.token : null;
   } catch {
-    return null;
+    // Fall back to the environment below.
   }
+
+  const envToken = process.env[DAEMON_TOKEN_ENV];
+  if (envToken && envToken.trim() !== "") {
+    return envToken.trim();
+  }
+
+  return null;
 }
 
 interface ResolvedDaemonClientConfig {
@@ -301,6 +304,10 @@ export class DaemonClient {
 
   async chat(goalId: string, message: string): Promise<{ ok: boolean }> {
     return this.post(`/goals/${encodeURIComponent(goalId)}/chat`, { message });
+  }
+
+  async requestRuntimeControl(input: DaemonRuntimeControlRequestBody): Promise<{ ok: boolean }> {
+    return this.post("/daemon/runtime-control", input);
   }
 
   async getStatus(): Promise<unknown> {

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -33,7 +33,14 @@ import { IngressGateway, HttpChannelAdapter } from "../gateway/index.js";
 import { PulSeedEventSchema } from "../../base/types/drive.js";
 import type { Envelope } from "../types/envelope.js";
 import { LoopSupervisor } from "../executor/index.js";
-import { ApprovalStore, OutboxStore, RuntimeHealthStore, createRuntimeStorePaths } from "../store/index.js";
+import {
+  ApprovalStore,
+  OutboxStore,
+  RuntimeHealthStore,
+  RuntimeOperationStore,
+  createRuntimeStorePaths,
+} from "../store/index.js";
+import type { RuntimeControlOperationKind } from "../store/index.js";
 import { LeaderLockManager } from "../leader-lock-manager.js";
 import { GoalLeaseManager } from "../goal-lease-manager.js";
 import { JournalBackedQueue, type JournalBackedQueueAcceptResult } from "../queue/journal-backed-queue.js";
@@ -587,6 +594,8 @@ export class DaemonRunner {
           this.runCommandWithHealth("chat_message", () => this.handleChatMessageCommand(goalId, message)),
         onApprovalResponse: async (goalId, requestId, approved) =>
           this.runCommandWithHealth("approval_response", () => this.handleApprovalResponseCommand(goalId, requestId, approved)),
+        onRuntimeControl: async (operationId, kind) =>
+          this.runCommandWithHealth("runtime_control", () => this.handleRuntimeControlCommand(operationId, kind)),
       });
     }
 
@@ -618,6 +627,7 @@ export class DaemonRunner {
 
           const maintenanceIntervalMs = this.config.check_interval_ms;
           await this.runSupervisorMaintenanceCycle();
+          await this.reconcileRuntimeControlOperationsAfterStartup();
           this.cronScheduleInterval = setInterval(async () => {
             if (this.shuttingDown) return;
             await this.runSupervisorMaintenanceCycle();
@@ -631,6 +641,7 @@ export class DaemonRunner {
           });
         } else {
           // Fallback: sequential mode
+          await this.reconcileRuntimeControlOperationsAfterStartup();
           await this.runLoop();
           cleanupHandled = true;
         }
@@ -951,6 +962,38 @@ export class DaemonRunner {
     });
   }
 
+  private async reconcileRuntimeControlOperationsAfterStartup(): Promise<void> {
+    const operationStore = new RuntimeOperationStore(this.runtimeRoot ?? undefined);
+    const pending = await operationStore.listPending();
+    const now = new Date().toISOString();
+    for (const operation of pending) {
+      if (
+        operation.state !== "restarting" ||
+        (operation.kind !== "restart_daemon" && operation.kind !== "restart_gateway")
+      ) {
+        continue;
+      }
+      await operationStore.save({
+        ...operation,
+        state: "verified",
+        updated_at: now,
+        completed_at: now,
+        result: {
+          ok: true,
+          message:
+            operation.kind === "restart_gateway"
+              ? "gateway restart verified after daemon startup."
+              : "daemon restart verified after startup.",
+          daemon_status: this.state.status,
+        },
+      });
+      this.logger.info("Runtime control restart operation verified after startup", {
+        operation_id: operation.operation_id,
+        kind: operation.kind,
+      });
+    }
+  }
+
   // ─── Private: Cleanup ───
 
   /**
@@ -1129,6 +1172,53 @@ export class DaemonRunner {
     this.supervisor?.deactivateGoal(goalId);
     this.abortSleep();
     await this.broadcastGoalUpdated(goalId, "stopped");
+  }
+
+  private async handleRuntimeControlCommand(
+    operationId: string,
+    kind: RuntimeControlOperationKind
+  ): Promise<void> {
+    const operationStore = new RuntimeOperationStore(this.runtimeRoot ?? undefined);
+    const operation = await operationStore.load(operationId);
+    if (!operation) {
+      this.logger.warn("Runtime control operation not found", { operation_id: operationId, kind });
+      return;
+    }
+
+    if (kind !== "restart_daemon" && kind !== "restart_gateway") {
+      const now = new Date().toISOString();
+      await operationStore.save({
+        ...operation,
+        state: "failed",
+        updated_at: now,
+        completed_at: now,
+        result: {
+          ok: false,
+          message: `Runtime control operation ${kind} is not implemented yet.`,
+        },
+      });
+      return;
+    }
+
+    const now = new Date().toISOString();
+    await operationStore.save({
+      ...operation,
+      state: "restarting",
+      started_at: operation.started_at ?? now,
+      updated_at: now,
+      result: {
+        ok: true,
+        message:
+          kind === "restart_gateway"
+            ? "gateway restart is being handled by a daemon restart because the gateway runs in-process."
+            : "daemon restart was accepted by the runtime command dispatcher.",
+      },
+    });
+
+    this.logger.info("Runtime control requested daemon restart", { operation_id: operationId, kind });
+    setTimeout(() => {
+      this.beginGracefulShutdown();
+    }, 25).unref?.();
   }
 
   private async handleGoalCompletion(goalId: string, result: { status: string; totalIterations: number }): Promise<void> {

--- a/src/runtime/event/server.ts
+++ b/src/runtime/event/server.ts
@@ -15,6 +15,7 @@ import { findAvailablePort, DEFAULT_PORT, MAX_PORT_ATTEMPTS } from "../port-util
 import { createEnvelope, type Envelope } from "../types/envelope.js";
 import type { ApprovalBroker, ApprovalRequiredEvent } from "../approval-broker.js";
 import type { OutboxStore, OutboxRecord } from "../store/index.js";
+import { RuntimeControlOperationKindSchema } from "../store/index.js";
 import { EventServerSnapshotReader } from "./server-snapshot-reader.js";
 import { EventServerSseManager } from "./server-sse.js";
 
@@ -471,6 +472,11 @@ export class EventServer {
       return;
     }
 
+    if (req.method === "POST" && urlPath === "/daemon/runtime-control") {
+      void this.handlePostDaemonRuntimeControl(req, res);
+      return;
+    }
+
     // POST /goals/:id/start|stop|approve|chat
     const goalActionMatch = /^\/goals\/([^/]+)\/([^/]+)$/.exec(urlPath);
     if (req.method === "POST" && goalActionMatch) {
@@ -795,7 +801,7 @@ export class EventServer {
 
   private async dispatchCommandEnvelope(input: {
     name: string;
-    goalId: string;
+    goalId?: string;
     payload: Record<string, unknown>;
     priority?: Envelope["priority"];
     dedupeKey?: string;
@@ -812,6 +818,41 @@ export class EventServer {
         payload: input.payload,
       })
     );
+  }
+
+  private async handlePostDaemonRuntimeControl(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    try {
+      const body = await readBody(req);
+      const parsed = JSON.parse(body) as Record<string, unknown>;
+      const operationId = typeof parsed["operationId"] === "string" ? parsed["operationId"] : "";
+      const reason = typeof parsed["reason"] === "string" ? parsed["reason"] : "";
+      const kind = RuntimeControlOperationKindSchema.parse(parsed["kind"]);
+      if (!operationId) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "operationId is required" }));
+        return;
+      }
+
+      await this.dispatchCommandEnvelope({
+        name: "runtime_control",
+        priority: "critical",
+        dedupeKey: `runtime_control:${operationId}`,
+        payload: {
+          operationId,
+          kind,
+          reason,
+        },
+      });
+      await this.broadcast("runtime_control_requested", { operationId, kind });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, operationId }));
+    } catch (err) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Invalid runtime control request", details: String(err) }));
+    }
   }
 
   private async buildSnapshot(): Promise<EventServerSnapshot> {

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -57,7 +57,24 @@ export type {
   RuntimeHealthSnapshot,
 } from "./runtime-schemas.js";
 
+export {
+  RuntimeControlOperationKindSchema,
+  RuntimeControlOperationStateSchema,
+  RuntimeControlActorSchema,
+  RuntimeControlReplyTargetSchema,
+  RuntimeControlOperationSchema,
+  isTerminalRuntimeControlState,
+} from "./runtime-operation-schemas.js";
+export type {
+  RuntimeControlOperationKind,
+  RuntimeControlOperationState,
+  RuntimeControlActor,
+  RuntimeControlReplyTarget,
+  RuntimeControlOperation,
+} from "./runtime-operation-schemas.js";
+
 export { ApprovalStore } from "./approval-store.js";
 export type { ApprovalResolutionInput } from "./approval-store.js";
 export { OutboxStore } from "./outbox-store.js";
 export { RuntimeHealthStore } from "./health-store.js";
+export { RuntimeOperationStore } from "./runtime-operation-store.js";

--- a/src/runtime/store/runtime-operation-schemas.ts
+++ b/src/runtime/store/runtime-operation-schemas.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+
+export const RuntimeControlOperationKindSchema = z.enum([
+  "restart_daemon",
+  "restart_gateway",
+  "reload_config",
+  "self_update",
+]);
+export type RuntimeControlOperationKind = z.infer<typeof RuntimeControlOperationKindSchema>;
+
+export const RuntimeControlOperationStateSchema = z.enum([
+  "pending",
+  "acknowledged",
+  "approved",
+  "running",
+  "restarting",
+  "verified",
+  "failed",
+  "cancelled",
+]);
+export type RuntimeControlOperationState = z.infer<typeof RuntimeControlOperationStateSchema>;
+
+export const RuntimeControlActorSchema = z.object({
+  surface: z.enum(["chat", "gateway", "cli", "tui"]),
+  platform: z.string().optional(),
+  conversation_id: z.string().optional(),
+  identity_key: z.string().optional(),
+  user_id: z.string().optional(),
+});
+export type RuntimeControlActor = z.infer<typeof RuntimeControlActorSchema>;
+
+export const RuntimeControlReplyTargetSchema = z.object({
+  surface: z.enum(["chat", "gateway", "cli", "tui"]).optional(),
+  platform: z.string().optional(),
+  conversation_id: z.string().optional(),
+  response_channel: z.string().optional(),
+  outbox_topic: z.string().optional(),
+  identity_key: z.string().optional(),
+  user_id: z.string().optional(),
+});
+export type RuntimeControlReplyTarget = z.infer<typeof RuntimeControlReplyTargetSchema>;
+
+export const RuntimeControlOperationSchema = z.object({
+  operation_id: z.string().min(1),
+  kind: RuntimeControlOperationKindSchema,
+  state: RuntimeControlOperationStateSchema,
+  requested_at: z.string(),
+  updated_at: z.string(),
+  requested_by: RuntimeControlActorSchema,
+  reply_target: RuntimeControlReplyTargetSchema,
+  reason: z.string(),
+  started_at: z.string().optional(),
+  completed_at: z.string().optional(),
+  approval_id: z.string().optional(),
+  ack_outbox_seq: z.number().int().positive().optional(),
+  restart_marker_path: z.string().optional(),
+  expected_health: z.object({
+    daemon_ping: z.boolean(),
+    gateway_acceptance: z.boolean(),
+  }),
+  result: z.object({
+    ok: z.boolean(),
+    message: z.string(),
+    daemon_status: z.string().optional(),
+    health_error: z.string().optional(),
+  }).optional(),
+});
+export type RuntimeControlOperation = z.infer<typeof RuntimeControlOperationSchema>;
+
+export function isTerminalRuntimeControlState(state: RuntimeControlOperationState): boolean {
+  return state === "verified" || state === "failed" || state === "cancelled";
+}

--- a/src/runtime/store/runtime-operation-store.ts
+++ b/src/runtime/store/runtime-operation-store.ts
@@ -1,0 +1,73 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { RuntimeJournal } from "./runtime-journal.js";
+import {
+  RuntimeControlOperationSchema,
+  isTerminalRuntimeControlState,
+  type RuntimeControlOperation,
+} from "./runtime-operation-schemas.js";
+import { createRuntimeStorePaths, type RuntimeStorePaths } from "./runtime-paths.js";
+
+export class RuntimeOperationStore {
+  private readonly rootDir: string;
+  private readonly pendingDir: string;
+  private readonly completedDir: string;
+  private readonly journal: RuntimeJournal;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    const paths = typeof runtimeRootOrPaths === "string"
+      ? createRuntimeStorePaths(runtimeRootOrPaths)
+      : runtimeRootOrPaths ?? createRuntimeStorePaths();
+    this.rootDir = path.join(paths.rootDir, "operations");
+    this.pendingDir = path.join(this.rootDir, "pending");
+    this.completedDir = path.join(this.rootDir, "completed");
+    this.journal = new RuntimeJournal(paths);
+  }
+
+  async ensureReady(): Promise<void> {
+    await this.journal.ensureReady();
+    await Promise.all([
+      fsp.mkdir(this.rootDir, { recursive: true }),
+      fsp.mkdir(this.pendingDir, { recursive: true }),
+      fsp.mkdir(this.completedDir, { recursive: true }),
+    ]);
+  }
+
+  async load(operationId: string): Promise<RuntimeControlOperation | null> {
+    return (
+      await this.journal.load(this.pendingPath(operationId), RuntimeControlOperationSchema)
+    ) ?? (
+      await this.journal.load(this.completedPath(operationId), RuntimeControlOperationSchema)
+    );
+  }
+
+  async listPending(): Promise<RuntimeControlOperation[]> {
+    return this.journal.list(this.pendingDir, RuntimeControlOperationSchema);
+  }
+
+  async listCompleted(): Promise<RuntimeControlOperation[]> {
+    return this.journal.list(this.completedDir, RuntimeControlOperationSchema);
+  }
+
+  async save(operation: RuntimeControlOperation): Promise<RuntimeControlOperation> {
+    await this.ensureReady();
+    const parsed = RuntimeControlOperationSchema.parse(operation);
+    const targetPath = isTerminalRuntimeControlState(parsed.state)
+      ? this.completedPath(parsed.operation_id)
+      : this.pendingPath(parsed.operation_id);
+    const stalePath = isTerminalRuntimeControlState(parsed.state)
+      ? this.pendingPath(parsed.operation_id)
+      : this.completedPath(parsed.operation_id);
+    await this.journal.save(targetPath, RuntimeControlOperationSchema, parsed);
+    await this.journal.remove(stalePath);
+    return parsed;
+  }
+
+  private pendingPath(operationId: string): string {
+    return path.join(this.pendingDir, `${encodeURIComponent(operationId)}.json`);
+  }
+
+  private completedPath(operationId: string): string {
+    return path.join(this.completedDir, `${encodeURIComponent(operationId)}.json`);
+  }
+}

--- a/tests/helpers/http-mocks.ts
+++ b/tests/helpers/http-mocks.ts
@@ -1,0 +1,35 @@
+import type * as http from "node:http";
+import { PassThrough } from "node:stream";
+import { vi } from "vitest";
+
+export function createJsonPostRequest(body: unknown, url = "/"): http.IncomingMessage {
+  const req = new PassThrough() as unknown as http.IncomingMessage;
+  req.method = "POST";
+  req.url = url;
+  req.headers = { host: "127.0.0.1" };
+  (req as unknown as PassThrough).end(JSON.stringify(body));
+  return req;
+}
+
+export function createMockServerResponse(): {
+  res: http.ServerResponse;
+  done: Promise<void>;
+  body: () => string;
+} {
+  const chunks: string[] = [];
+  let resolve!: () => void;
+  const done = new Promise<void>((r) => {
+    resolve = r;
+  });
+  const res = {
+    statusCode: 200,
+    setHeader: vi.fn(),
+    end: vi.fn((chunk?: unknown) => {
+      if (chunk !== undefined) {
+        chunks.push(String(chunk));
+      }
+      resolve();
+    }),
+  } as unknown as http.ServerResponse;
+  return { res, done, body: () => chunks.join("") };
+}


### PR DESCRIPTION
## Summary
- Add runtime-control intent recognition, operation persistence, daemon command dispatch, and restart verification after watchdog recovery.
- Wire natural-language runtime-control requests through chat and cross-platform sessions with scoped approval metadata.
- Add per-channel runtime-control allowlists for Telegram, Discord, WhatsApp, and Signal, plus plugin docs and coverage.
- Harden long-context agent-loop resume by normalizing persisted session state and documenting the runtime safety boundary.

## Refactor follow-up
- Split `RuntimeControlService.request()` into explicit persistence, approval, ack, and executor side-effect steps while preserving operation state transitions.
- Extract duplicated webhook HTTP test mocks into `tests/helpers/http-mocks.ts`.
- Add direct `RuntimeControlService` tests for approval-free execution and rejected approval cancellation.
- Fix Telegram plugin facade exports so its package build covers the new processor type path.

## KPI notes
- Behavior: unchanged in runtime-control flow; existing full test suite passes.
- Complexity: simple cyclomatic scan on `runtime-control-service.ts` max function complexity dropped from 16 to 6.
- Coverage: targeted v8 coverage shows `runtime-control-service.ts` 100% lines, `daemon-runtime-control-executor.ts` 100% lines, `runtime-control-intent.ts` 95% lines.
- DB queries: no DB path; RuntimeOperationStore write/read count is unchanged for the refactored service paths.
- p95 latency: not benchmarked separately; refactor does not add runtime I/O or network calls.

## Validation
- `npx tsc --noEmit --pretty false`
- targeted `npx vitest run ...` for runtime-control and channel coverage
- targeted runtime-control v8 coverage run
- `npm test`
- `npm run build`
- `npm run check:docs`
- `npm run lint:boundaries`
- `git diff --check`
- `npm --prefix plugins/telegram-bot run build`
- `npm --prefix plugins/discord-bot run build`
- `npm --prefix plugins/whatsapp-webhook run build`
- `npm --prefix plugins/signal-bridge run build`
- Local isolated daemon restart smoke: request state `running`, final operation state `verified`
- Mac mini isolated daemon restart smoke on `ssh mini`: request state `running`, final operation state `verified`, port `41819`
