### PR TITLE
[codex] Add chat activity progress events

### DIFF
--- a/plugins/discord-bot/__tests__/webhook-server.test.ts
+++ b/plugins/discord-bot/__tests__/webhook-server.test.ts
@@ -82,4 +82,40 @@ describe("DiscordWebhookServer", () => {
       );
     });
   });
+
+  it("sends only tool activity as Discord follow-up progress", async () => {
+    const fetchChatReply = vi.fn().mockImplementation(async (input) => {
+      await input.onEvent?.({ type: "activity", kind: "lifecycle", message: "Received. Starting work..." });
+      await input.onEvent?.({ type: "activity", kind: "commentary", message: "Thinking about it" });
+      await input.onEvent?.({ type: "activity", kind: "tool", message: "Running tool: grep - ChatEvent" });
+      return "final reply";
+    });
+    const server = new DiscordWebhookServer(config, api as DiscordAPI, fetchChatReply);
+    const { res, done } = createMockServerResponse();
+
+    await server.handleRequest(
+      createJsonPostRequest({
+        id: "interaction-3",
+        type: 2,
+        token: "token-3",
+        application_id: "app-1",
+        channel_id: "channel-1",
+        member: { user: { id: "user-2" } },
+        data: { name: "pulseed", options: [{ name: "message", value: "check events" }] },
+      }),
+      res
+    );
+    await done;
+
+    await vi.waitFor(() => {
+      expect(api.sendInteractionFollowUp).toHaveBeenCalledTimes(2);
+    });
+    expect(api.sendInteractionFollowUp).toHaveBeenNthCalledWith(
+      1,
+      "app-1",
+      "token-3",
+      "Running tool: grep - ChatEvent"
+    );
+    expect(api.sendInteractionFollowUp).toHaveBeenNthCalledWith(2, "app-1", "token-3", "final reply");
+  });
 });

--- a/plugins/discord-bot/src/shared-manager.ts
+++ b/plugins/discord-bot/src/shared-manager.ts
@@ -1,3 +1,5 @@
+export type ChatEventHandler = (event: unknown) => Promise<void> | void;
+
 export interface ChatContinuationInput {
   platform: "discord";
   identity_key: string;
@@ -6,6 +8,7 @@ export interface ChatContinuationInput {
   message_id?: string;
   text: string;
   metadata: Record<string, unknown>;
+  onEvent?: ChatEventHandler;
 }
 
 type SessionManagerMethod = (input: ChatContinuationInput) => Promise<unknown> | unknown;

--- a/plugins/discord-bot/src/webhook-server.ts
+++ b/plugins/discord-bot/src/webhook-server.ts
@@ -4,6 +4,9 @@ import { DiscordAPI } from "./discord-api.js";
 import { dispatchChatInput, type ChatContinuationInput } from "./shared-manager.js";
 import type { DiscordBotConfig } from "./config.js";
 
+const MAX_DISCORD_ACTIVITY_MESSAGES = 8;
+const MAX_DISCORD_ACTIVITY_CHARS = 300;
+
 interface DiscordInteractionOption {
   name: string;
   value?: unknown;
@@ -30,6 +33,12 @@ interface DiscordInteractionPayload {
     name?: string;
     options?: DiscordInteractionOption[];
   };
+}
+
+interface ActivityChatEvent {
+  type: "activity";
+  kind: "lifecycle" | "commentary" | "tool" | "plugin" | "skill";
+  message: string;
 }
 
 export class DiscordWebhookServer {
@@ -143,7 +152,27 @@ export class DiscordWebhookServer {
     payload: DiscordInteractionPayload,
     input: ChatContinuationInput
   ): Promise<void> {
-    const reply = await this.fetchChatReply(input);
+    let sentActivityCount = 0;
+    let lastActivity = "";
+    const reply = await this.fetchChatReply({
+      ...input,
+      onEvent: async (event: unknown) => {
+        if (
+          !isActivityChatEvent(event) ||
+          (event.kind !== "tool" && event.kind !== "plugin" && event.kind !== "skill") ||
+          payload.application_id === undefined ||
+          payload.token === undefined ||
+          sentActivityCount >= MAX_DISCORD_ACTIVITY_MESSAGES
+        ) {
+          return;
+        }
+        const content = truncateDiscordActivity(event.message);
+        if (content === lastActivity) return;
+        lastActivity = content;
+        sentActivityCount++;
+        await this.api.sendInteractionFollowUp(payload.application_id, payload.token, content);
+      },
+    });
     const content = reply ?? "Received.";
 
     if (payload.application_id !== undefined && payload.token !== undefined) {
@@ -208,4 +237,18 @@ export class DiscordWebhookServer {
     res.setHeader("Content-Type", "application/json");
     res.end(JSON.stringify(payload));
   }
+}
+
+function truncateDiscordActivity(message: string): string {
+  const normalized = message.replace(/\s+/g, " ").trim();
+  if (normalized.length <= MAX_DISCORD_ACTIVITY_CHARS) return normalized;
+  return `${normalized.slice(0, MAX_DISCORD_ACTIVITY_CHARS)}...`;
+}
+
+function isActivityChatEvent(event: unknown): event is ActivityChatEvent {
+  return typeof event === "object"
+    && event !== null
+    && (event as Record<string, unknown>)["type"] === "activity"
+    && typeof (event as Record<string, unknown>)["kind"] === "string"
+    && typeof (event as Record<string, unknown>)["message"] === "string";
 }

--- a/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
@@ -755,6 +755,38 @@ describe("TelegramChatEventAdapter", () => {
     expect(editMessageText.mock.calls[0]![2]).toContain("done");
   });
 
+  it("renders plugin activity but ignores lifecycle activity", async () => {
+    const sendPlainMessage = vi.fn().mockResolvedValue(13);
+    const editMessageText = vi.fn().mockResolvedValue(undefined);
+    const api = {
+      sendPlainMessage,
+      editMessageText,
+    } as unknown as TelegramAPI;
+
+    const adapter = new TelegramChatEventAdapter(api, 777);
+
+    await adapter.handle({
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      kind: "lifecycle",
+      message: "Received. Starting work...",
+    });
+    await adapter.handle({
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      kind: "plugin",
+      message: "Plugin completed",
+      sourceId: "plugin-1",
+    });
+
+    expect(sendPlainMessage).toHaveBeenCalledOnce();
+    expect(sendPlainMessage).toHaveBeenCalledWith(777, "[plugin] Plugin completed");
+  });
+
   it("edits the assistant message to show lifecycle_error partial text", async () => {
     const sendPlainMessage = vi.fn().mockResolvedValue(12);
     const editMessageText = vi.fn().mockResolvedValue(undefined);

--- a/plugins/telegram-bot/src/telegram-chat-event-adapter.ts
+++ b/plugins/telegram-bot/src/telegram-chat-event-adapter.ts
@@ -15,6 +15,7 @@ export class TelegramChatEventAdapter {
   private readonly chatId: number;
   private assistantMessage: RenderedMessage | null = null;
   private readonly toolMessages = new Map<string, RenderedMessage>();
+  private readonly activityMessages = new Map<string, RenderedMessage>();
   private hasAssistantOutput = false;
 
   constructor(api: TelegramAPI, chatId: number) {
@@ -31,6 +32,7 @@ export class TelegramChatEventAdapter {
       case "lifecycle_start":
         this.assistantMessage = null;
         this.toolMessages.clear();
+        this.activityMessages.clear();
         this.hasAssistantOutput = false;
         return;
 
@@ -40,6 +42,12 @@ export class TelegramChatEventAdapter {
 
       case "assistant_final":
         await this.upsertAssistantMessage(event.text);
+        return;
+
+      case "activity":
+        if (event.kind === "plugin" || event.kind === "skill") {
+          await this.upsertActivityMessage(event.sourceId ?? event.kind, `[${event.kind}] ${event.message}`);
+        }
         return;
 
       case "tool_start":
@@ -104,6 +112,18 @@ export class TelegramChatEventAdapter {
     if (!existing) {
       const messageId = await this.api.sendPlainMessage(this.chatId, text);
       this.toolMessages.set(toolCallId, { messageId, text });
+      return;
+    }
+
+    await this.api.editMessageText(this.chatId, existing.messageId, text);
+    existing.text = text;
+  }
+
+  private async upsertActivityMessage(activityId: string, text: string): Promise<void> {
+    const existing = this.activityMessages.get(activityId);
+    if (!existing) {
+      const messageId = await this.api.sendPlainMessage(this.chatId, text);
+      this.activityMessages.set(activityId, { messageId, text });
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,6 +86,8 @@ export type {
   LifecycleStartEvent,
   AssistantDeltaEvent,
   AssistantFinalEvent,
+  ActivityEvent,
+  ActivityKind,
   ToolStartEvent,
   ToolUpdateEvent,
   ToolEndEvent,

--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { applyChatEventToMessages } from "../chat-event-state.js";
+
+describe("applyChatEventToMessages", () => {
+  it("keeps activity as one updatable row per turn", () => {
+    const first = applyChatEventToMessages([], {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      kind: "lifecycle",
+      message: "Received. Starting work...",
+      sourceId: "lifecycle:start",
+      transient: true,
+    }, 20);
+
+    const second = applyChatEventToMessages(first, {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      kind: "tool",
+      message: "Running tool: grep - ChatEvent",
+      sourceId: "tool-1",
+      transient: true,
+    }, 20);
+
+    expect(second).toHaveLength(1);
+    expect(second[0]!).toMatchObject({
+      id: "activity:turn-1",
+      role: "pulseed",
+      text: "Running tool: grep - ChatEvent",
+      messageType: "info",
+    });
+  });
+
+  it("does not add separate chat rows for raw tool events", () => {
+    const messages = applyChatEventToMessages([], {
+      type: "tool_start",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      toolCallId: "tool-1",
+      toolName: "grep",
+      args: { pattern: "ChatEvent" },
+    }, 20);
+
+    expect(messages).toEqual([]);
+  });
+});

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -78,6 +78,22 @@ describe("ChatRunner", () => {
       expect(result.elapsed_ms).toBeGreaterThanOrEqual(0);
     });
 
+    it("emits lifecycle activity before adapter execution", async () => {
+      const adapter = makeMockAdapter();
+      const events: string[] = [];
+      const runner = new ChatRunner(makeDeps({
+        adapter,
+        onEvent: (event) => {
+          if (event.type === "activity") events.push(`${event.kind}:${event.message}`);
+        },
+      }));
+
+      await runner.execute("Do something", "/repo");
+
+      expect(events[0]).toBe("lifecycle:Preparing context...");
+      expect(events).toContain("lifecycle:Calling adapter...");
+    });
+
     it("propagates adapter failure to ChatRunResult", async () => {
       const failResult: AgentResult = { ...CANNED_RESULT, success: false, output: "Agent failed", error: "boom", exit_code: 1 };
       const runner = new ChatRunner(makeDeps({ adapter: makeMockAdapter(failResult) }));

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -22,10 +22,6 @@ function upsertMessage(
   return [...next, nextMessage].slice(-maxMessages);
 }
 
-function toolMessageType(success: boolean): StreamChatMessage["messageType"] {
-  return success ? "info" : "error";
-}
-
 export function applyChatEventToMessages(
   messages: StreamChatMessage[],
   event: ChatEvent,
@@ -53,6 +49,16 @@ export function applyChatEventToMessages(
     }, maxMessages);
   }
 
+  if (event.type === "activity") {
+    return upsertMessage(messages, {
+      id: `activity:${event.turnId}`,
+      role: "pulseed",
+      text: event.message,
+      timestamp,
+      messageType: "info",
+    }, maxMessages);
+  }
+
   if (event.type === "lifecycle_error") {
     const messageId = event.partialText ? event.turnId : `error:${event.runId}`;
     const text = event.partialText
@@ -68,33 +74,15 @@ export function applyChatEventToMessages(
   }
 
   if (event.type === "tool_start") {
-    return upsertMessage(messages, {
-      id: `tool:${event.toolCallId}`,
-      role: "pulseed",
-      text: `[tool:${event.toolName}] started`,
-      timestamp,
-      messageType: "info",
-    }, maxMessages);
+    return messages;
   }
 
   if (event.type === "tool_update") {
-    return upsertMessage(messages, {
-      id: `tool:${event.toolCallId}`,
-      role: "pulseed",
-      text: `[tool:${event.toolName}] ${event.status}: ${event.message}`,
-      timestamp,
-      messageType: event.status === "awaiting_approval" ? "warning" : "info",
-    }, maxMessages);
+    return messages;
   }
 
   if (event.type === "tool_end") {
-    return upsertMessage(messages, {
-      id: `tool:${event.toolCallId}`,
-      role: "pulseed",
-      text: `[tool:${event.toolName}] ${event.success ? "done" : "failed"}: ${event.summary}`,
-      timestamp,
-      messageType: toolMessageType(event.success),
-    }, maxMessages);
+    return messages;
   }
 
   return messages;

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -21,6 +21,16 @@ export interface AssistantFinalEvent extends ChatEventBase {
   persisted: boolean;
 }
 
+export type ActivityKind = "lifecycle" | "commentary" | "tool" | "plugin" | "skill";
+
+export interface ActivityEvent extends ChatEventBase {
+  type: "activity";
+  kind: ActivityKind;
+  message: string;
+  sourceId?: string;
+  transient?: boolean;
+}
+
 export interface ToolStartEvent extends ChatEventBase {
   type: "tool_start";
   toolCallId: string;
@@ -63,6 +73,7 @@ export type ChatEvent =
   | LifecycleStartEvent
   | AssistantDeltaEvent
   | AssistantFinalEvent
+  | ActivityEvent
   | ToolStartEvent
   | ToolUpdateEvent
   | ToolEndEvent

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -23,7 +23,7 @@ import type { TendDeps } from "./tend-command.js";
 import { EventSubscriber } from "./event-subscriber.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
 import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
-import type { ChatEvent, ChatEventContext } from "./chat-events.js";
+import type { ActivityKind, ChatEvent, ChatEventContext } from "./chat-events.js";
 import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
 import type {
   AgentLoopEvent,
@@ -105,6 +105,7 @@ interface AssistantBuffer {
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
 const MAX_TOOL_LOOPS = 5;
+const ACTIVITY_PREVIEW_CHARS = 40;
 
 // ─── Command help text ───
 
@@ -124,6 +125,16 @@ function checkGitChanges(cwd: string): Promise<string | null> {
       resolve(err ? null : (stdout + stderr).trim());
     });
   });
+}
+
+function previewActivityText(value: string, maxChars = ACTIVITY_PREVIEW_CHARS): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > maxChars ? `${normalized.slice(0, maxChars)}...` : normalized;
+}
+
+function formatToolActivity(action: "Running" | "Finished" | "Failed", toolName: string, detail?: string): string {
+  const preview = detail ? previewActivityText(detail) : "";
+  return preview ? `${action} tool: ${toolName} - ${preview}` : `${action} tool: ${toolName}`;
 }
 
 // ─── ChatRunner ───
@@ -440,15 +451,16 @@ export class ChatRunner {
     // history is always assigned by this point (either by startSession or the block above)
     const history = this.history!;
 
-    // Persist-before-execute: user message written to disk first
-    if (!resumeOnly) {
-      await history.appendUserMessage(input);
-    }
     this.emitEvent({
       type: "lifecycle_start",
       input,
       ...this.eventBase(eventContext),
     });
+
+    // Persist-before-execute: user message written to disk before model or adapter execution.
+    if (!resumeOnly) {
+      await history.appendUserMessage(input);
+    }
 
     // Build static grounding once per session; dynamic context is rebuilt each turn.
     if (this.cachedStaticSystemPrompt === null) {
@@ -461,6 +473,7 @@ export class ChatRunner {
 
     let dynamicSystemPrompt = "";
     try {
+      this.emitActivity("lifecycle", "Preparing context...", eventContext, "lifecycle:context");
       dynamicSystemPrompt = await buildDynamicContextPrompt({ stateManager: this.deps.stateManager });
     } catch {
       dynamicSystemPrompt = "";
@@ -525,6 +538,7 @@ export class ChatRunner {
             elapsed_ms,
           };
         }
+        this.emitActivity("lifecycle", "Calling model...", eventContext, "lifecycle:model");
         const result = await this.deps.chatAgentLoopRunner.execute({
           message: basePrompt,
           cwd,
@@ -551,6 +565,7 @@ export class ChatRunner {
         }
         if (result.success) {
           await history.appendAssistantMessage(result.output);
+          this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
           this.emitEvent({
             type: "assistant_final",
             text: result.output,
@@ -588,6 +603,7 @@ export class ChatRunner {
         const toolResult = await this.executeWithTools(prompt, eventContext, assistantBuffer, systemPrompt || undefined);
         const elapsed_ms = Date.now() - start;
         await history.appendAssistantMessage(toolResult);
+        this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
         this.emitEvent({
           type: "assistant_final",
           text: toolResult,
@@ -618,6 +634,7 @@ export class ChatRunner {
       ...(systemPrompt ? { system_prompt: systemPrompt } : {}),
     };
     const resolvedTimeoutMs = task.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+    this.emitActivity("lifecycle", "Calling adapter...", eventContext, "lifecycle:adapter");
     const adapterPromise = this.deps.adapter.execute(task);
     const timeoutPromise = new Promise<never>((_, reject) =>
       setTimeout(() => reject(new Error(`Chat adapter timed out after ${resolvedTimeoutMs}ms`)), resolvedTimeoutMs)
@@ -637,6 +654,7 @@ export class ChatRunner {
     if (gitChanges !== null && gitChanges !== "") {
       let retries = 0;
       const VERIFY_TIMEOUT_MS = 30_000;
+      this.emitActivity("lifecycle", "Checking result...", eventContext, "lifecycle:checking");
       let verification = await Promise.race([
         verifyChatAction(gitRoot, this.deps.toolExecutor),
         new Promise<{ passed: true }>((resolve) =>
@@ -669,6 +687,7 @@ export class ChatRunner {
 
     if (result.success) {
       await history.appendAssistantMessage(result.output);
+      this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
       this.emitEvent({
         type: "assistant_final",
         text: result.output,
@@ -751,6 +770,7 @@ export class ChatRunner {
         : [];
       let response: LLMResponse;
       try {
+        this.emitActivity("lifecycle", "Calling model...", eventContext, "lifecycle:model");
         response = await this.sendLLMMessage(llmClient, messages, {
           tools,
           ...(systemPrompt ? { system: systemPrompt } : {}),
@@ -820,6 +840,8 @@ export class ChatRunner {
     return {
       emit: async (event: AgentLoopEvent) => {
         if (event.type === "tool_call_started") {
+          const detail = event.inputPreview ? previewActivityText(event.inputPreview) : undefined;
+          this.emitActivity("tool", formatToolActivity("Running", event.toolName, detail), eventContext, event.callId);
           this.emitEvent({
             type: "tool_start",
             toolCallId: event.callId,
@@ -839,6 +861,12 @@ export class ChatRunner {
         }
 
         if (event.type === "tool_call_finished") {
+          this.emitActivity(
+            "tool",
+            formatToolActivity(event.success ? "Finished" : "Failed", event.toolName, event.outputPreview),
+            eventContext,
+            event.callId
+          );
           this.emitEvent({
             type: "tool_end",
             toolCallId: event.callId,
@@ -852,11 +880,12 @@ export class ChatRunner {
         }
 
         if (event.type === "assistant_message" && event.phase === "commentary" && event.contentPreview) {
-          this.pushAssistantDelta(event.contentPreview, { text: "" }, eventContext);
+          this.emitActivity("commentary", previewActivityText(event.contentPreview, 120), eventContext, `commentary:${event.eventId}`);
           return;
         }
 
         if (event.type === "plan_update") {
+          this.emitActivity("tool", `Updated plan: ${previewActivityText(event.summary)}`, eventContext, `plan:${event.turnId}`);
           this.emitEvent({
             type: "tool_update",
             toolCallId: `plan:${event.turnId}:${event.createdAt}`,
@@ -869,6 +898,7 @@ export class ChatRunner {
         }
 
         if (event.type === "approval_request") {
+          this.emitActivity("tool", formatToolActivity("Running", event.toolName, `awaiting approval: ${event.reason}`), eventContext, event.callId);
           this.emitEvent({
             type: "tool_update",
             toolCallId: event.callId,
@@ -881,6 +911,7 @@ export class ChatRunner {
         }
 
         if (event.type === "approval") {
+          this.emitActivity("tool", formatToolActivity("Finished", event.toolName, `approval ${event.status}: ${event.reason}`), eventContext);
           this.emitEvent({
             type: "tool_update",
             toolCallId: `approval:${event.turnId}:${event.createdAt}`,
@@ -969,16 +1000,19 @@ export class ChatRunner {
     eventContext: ChatEventContext,
   ): Promise<string> {
     if (!this.deps.registry) {
+      this.emitActivity("tool", formatToolActivity("Failed", name, "No tool registry configured"), eventContext, toolCallId);
       return JSON.stringify({ error: `No tool registry configured` });
     }
     const tool = this.deps.registry.get(name);
     if (!tool) {
+      this.emitActivity("tool", formatToolActivity("Failed", name, `Unknown tool: ${name}`), eventContext, toolCallId);
       return JSON.stringify({ error: `Unknown tool: ${name}` });
     }
     const startTime = Date.now();
     try {
       const parsed = tool.inputSchema.safeParse(args);
       if (!parsed.success) {
+        this.emitActivity("tool", formatToolActivity("Failed", name, `Invalid input: ${parsed.error.message}`), eventContext, toolCallId);
         this.emitEvent({
           type: "tool_end",
           toolCallId,
@@ -998,6 +1032,7 @@ export class ChatRunner {
         args,
         ...this.eventBase(eventContext),
       });
+      this.emitActivity("tool", formatToolActivity("Running", name, JSON.stringify(args)), eventContext, toolCallId);
 
       let result: { success: boolean; summary: string; data?: unknown; error?: string };
       if (this.deps.toolExecutor) {
@@ -1027,6 +1062,7 @@ export class ChatRunner {
           return `Tool ${name} denied: ${permResult.reason}`;
         }
         if (permResult.status === "needs_approval") {
+          this.emitActivity("tool", formatToolActivity("Running", name, `awaiting approval: ${permResult.reason}`), eventContext, toolCallId);
           this.emitEvent({
             type: "tool_update",
             toolCallId,
@@ -1070,6 +1106,12 @@ export class ChatRunner {
 
       const durationMs = Date.now() - startTime;
       this.deps.onToolEnd?.(name, { success: result.success, summary: result.summary || '...', durationMs });
+      this.emitActivity(
+        "tool",
+        formatToolActivity(result.success ? "Finished" : "Failed", name, result.summary || "..."),
+        eventContext,
+        toolCallId
+      );
       this.emitEvent({
         type: "tool_update",
         toolCallId,
@@ -1093,6 +1135,7 @@ export class ChatRunner {
       const message = err instanceof Error ? err.message : String(err);
       const durationMs = Date.now() - startTime;
       this.deps.onToolEnd?.(name, { success: false, summary: message, durationMs });
+      this.emitActivity("tool", formatToolActivity("Failed", name, message), eventContext, toolCallId);
       this.emitEvent({
         type: "tool_end",
         toolCallId,
@@ -1148,6 +1191,23 @@ export class ChatRunner {
   private emitEvent(event: ChatEvent): void {
     const handler = this.onEvent ?? this.deps.onEvent;
     handler?.(event);
+  }
+
+  private emitActivity(
+    kind: ActivityKind,
+    message: string,
+    eventContext: ChatEventContext,
+    sourceId?: string
+  ): void {
+    if (!message.trim()) return;
+    this.emitEvent({
+      type: "activity",
+      kind,
+      message,
+      ...(sourceId ? { sourceId } : {}),
+      transient: true,
+      ...this.eventBase(eventContext),
+    });
   }
 
   private pushAssistantDelta(


### PR DESCRIPTION
## Summary

- Add a channel-agnostic chat `activity` event for progress updates separate from final assistant deltas.
- Render the latest activity as a single updatable TUI/CLI chat row while keeping the spinner behavior intact.
- Filter external channel progress so Telegram and Discord avoid lifecycle chatter and only surface tool/plugin/skill progress.

## Validation

- `npm run typecheck`
- `npm --prefix plugins/discord-bot run build`
- `npm --prefix plugins/telegram-bot run build`
- `npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts plugins/discord-bot/__tests__/webhook-server.test.ts`
- Mac mini smoke validation over `ssh mini`: typecheck, plugin TypeScript builds, related tests, full build, and a mock ChatRunner activity timing probe.
