### PR TITLE
[codex] Speed up slow export and Codex E2E tests

### DIFF
--- a/src/__tests__/index-exports.test.ts
+++ b/src/__tests__/index-exports.test.ts
@@ -1,24 +1,46 @@
 import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const INDEX_PATH = path.join(path.dirname(fileURLToPath(import.meta.url)), "../index.ts");
+
+function loadValueExports(): Map<string, string> {
+  const sourceText = fs.readFileSync(INDEX_PATH, "utf-8");
+  const exports = new Map<string, string>();
+  const exportDeclarationPattern = /export\s*{\s*([^}]+?)\s*}\s*from\s*"([^"]+)";/gs;
+
+  for (const match of sourceText.matchAll(exportDeclarationPattern)) {
+    const [, specifierList, moduleSpecifier] = match;
+    for (const rawSpecifier of specifierList!.split(",")) {
+      const specifier = rawSpecifier.trim();
+      if (specifier.length === 0 || specifier.startsWith("type ")) {
+        continue;
+      }
+      const exportedName = specifier.includes(" as ") ? specifier.split(" as ").at(-1)! : specifier;
+      exports.set(exportedName.trim(), moduleSpecifier!);
+    }
+  }
+
+  return exports;
+}
 
 describe("src/index.ts exports", () => {
-  it("re-exports core symbols from their source modules", async () => {
-    const barrel = await import("../index.js");
-    const llmModule = await import("../base/llm/llm-client.js");
-    const ethicsModule = await import("../platform/traits/ethics-gate.js");
-    const stateModule = await import("../base/state/state-manager.js");
+  it("declares core value re-exports from their source modules", () => {
+    const exports = loadValueExports();
 
-    expect(barrel.LLMClient).toBe(llmModule.LLMClient);
-    expect(barrel.MockLLMClient).toBe(llmModule.MockLLMClient);
-    expect(barrel.extractJSON).toBe(llmModule.extractJSON);
-    expect(barrel.EthicsGate).toBe(ethicsModule.EthicsGate);
-    expect(barrel.StateManager).toBe(stateModule.StateManager);
-  }, 60_000);
+    expect(exports.get("LLMClient")).toBe("./base/llm/llm-client.js");
+    expect(exports.get("MockLLMClient")).toBe("./base/llm/llm-client.js");
+    expect(exports.get("extractJSON")).toBe("./base/llm/llm-client.js");
+    expect(exports.get("EthicsGate")).toBe("./platform/traits/ethics-gate.js");
+    expect(exports.get("StateManager")).toBe("./base/state/state-manager.js");
+  });
 
-  it("re-exports selected utility functions as callable values", async () => {
-    const barrel = await import("../index.js");
+  it("declares selected utility functions as value exports", () => {
+    const exports = loadValueExports();
 
-    expect(typeof barrel.calculateDimensionGap).toBe("function");
-    expect(typeof barrel.scoreAllDimensions).toBe("function");
-    expect(typeof barrel.buildLLMClient).toBe("function");
-  }, 60_000);
+    expect(exports.get("calculateDimensionGap")).toBe("./platform/drive/gap-calculator.js");
+    expect(exports.get("scoreAllDimensions")).toBe("./platform/drive/drive-scorer.js");
+    expect(exports.get("buildLLMClient")).toBe("./base/llm/provider-factory.js");
+  });
 });

--- a/tests/e2e/codex-cli-e2e.test.ts
+++ b/tests/e2e/codex-cli-e2e.test.ts
@@ -4,10 +4,11 @@
  * These tests spawn the real `codex` binary and are skipped when the CLI is not
  * installed. Run them intentionally with:
  *
- *   npx vitest run tests/e2e/codex-cli-e2e.test.ts
+ *   PULSEED_RUN_CODEX_E2E=1 npx vitest run tests/e2e/codex-cli-e2e.test.ts
  *
- * The suite auto-skips when `codex` is not found on PATH (or at the known
- * absolute path). Keep tasks minimal to conserve ChatGPT Plus quota.
+ * The suite auto-skips unless PULSEED_RUN_CODEX_E2E=1 is set and `codex` is
+ * found on PATH (or at the known absolute path). Keep tasks minimal to
+ * conserve ChatGPT Plus quota.
  *
  * Requirements:
  *   - codex CLI installed (v0.114.0+)
@@ -55,7 +56,8 @@ function findCodexBin(): string | null {
 }
 
 const CODEX_BIN = findCodexBin();
-const CODEX_AVAILABLE = CODEX_BIN !== null;
+const CODEX_E2E_ENABLED = process.env["PULSEED_RUN_CODEX_E2E"] === "1";
+const CODEX_AVAILABLE = CODEX_E2E_ENABLED && CODEX_BIN !== null;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- replace the src/index.ts barrel runtime import test with a lightweight export declaration check
- require PULSEED_RUN_CODEX_E2E=1 before running the real Codex CLI E2E suite, so normal full test runs do not invoke the local codex binary or consume quota

## Measurements
- index-exports targeted run: 3.42s before -> 171ms after
- codex-cli-e2e normal targeted run: 24.1s in previous full profile -> 186ms skipped by default
- in the follow-up full JSON profile, index-exports was 5ms and codex-cli-e2e was 0ms

## Validation
- npx vitest run src/__tests__/index-exports.test.ts --reporter=verbose
- npx vitest run tests/e2e/codex-cli-e2e.test.ts --reporter=verbose
- npm run typecheck
- npm run lint:boundaries
- npx vitest run --reporter=json --outputFile=/tmp/pulseed-vitest-results-after-speedup.json