### PR TITLE
[codex] Remove unused GoalRefiner negotiator dependency

### DIFF
--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -404,7 +404,6 @@ export async function buildDeps(
     stateManager,
     llmClient,
     observationEngine,
-    goalNegotiator,
     goalTreeManager,
     ethicsGate,
   );

--- a/src/orchestrator/goal/__tests__/goal-refiner.refine.test.ts
+++ b/src/orchestrator/goal/__tests__/goal-refiner.refine.test.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import { GoalRefiner } from "../goal-refiner.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { ObservationEngine } from "../../../platform/observation/observation-engine.js";
-import type { GoalNegotiator } from "../goal-negotiator.js";
 import type { GoalTreeManager } from "../goal-tree-manager.js";
 import type { EthicsGate } from "../../../platform/traits/ethics-gate.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
@@ -111,10 +110,6 @@ function makeObservationEngine(): ObservationEngine {
   } as unknown as ObservationEngine;
 }
 
-function makeNegotiator(): GoalNegotiator {
-  return {} as unknown as GoalNegotiator;
-}
-
 function makeTreeManager(): GoalTreeManager {
   return {
     decomposeGoal: vi.fn(async (_goalId: string) => ({
@@ -169,7 +164,6 @@ describe("GoalRefiner.refine()", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       makeTreeManager(),
       makeEthicsGate()
     );
@@ -263,7 +257,6 @@ describe("GoalRefiner.refine()", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       treeManager,
       makeEthicsGate()
     );
@@ -330,7 +323,6 @@ describe("GoalRefiner.refine()", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       treeManager,
       makeEthicsGate()
     );

--- a/src/orchestrator/goal/__tests__/goal-refiner.test.ts
+++ b/src/orchestrator/goal/__tests__/goal-refiner.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GoalRefiner } from "../goal-refiner.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { ObservationEngine } from "../../../platform/observation/observation-engine.js";
-import type { GoalNegotiator } from "../goal-negotiator.js";
 import type { GoalTreeManager } from "../goal-tree-manager.js";
 import type { EthicsGate } from "../../../platform/traits/ethics-gate.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
@@ -56,10 +55,6 @@ function makeObservationEngine(): ObservationEngine {
       { sourceId: "shell", config: { name: "shell" } },
     ]),
   } as unknown as ObservationEngine;
-}
-
-function makeNegotiator(): GoalNegotiator {
-  return {} as unknown as GoalNegotiator;
 }
 
 function makeTreeManager(childGoals: ReturnType<typeof makeGoal>[] = []): GoalTreeManager {
@@ -201,7 +196,6 @@ describe("GoalRefiner", () => {
         stateManager,
         llmClient,
         makeObservationEngine(),
-        makeNegotiator(),
         makeTreeManager(),
         makeEthicsGate()
       );
@@ -306,7 +300,6 @@ describe("GoalRefiner", () => {
         stateManager,
         llmClient,
         makeObservationEngine(),
-        makeNegotiator(),
         treeManager,
         makeEthicsGate()
       );
@@ -385,7 +378,6 @@ describe("GoalRefiner", () => {
         stateManager,
         llmClient,
         makeObservationEngine(),
-        makeNegotiator(),
         treeManager,
         makeEthicsGate()
       );
@@ -458,7 +450,6 @@ describe("GoalRefiner", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       treeManager,
       makeEthicsGate()
     );
@@ -509,7 +500,6 @@ describe("GoalRefiner", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       treeManager,
       makeEthicsGate()
     );
@@ -569,7 +559,6 @@ describe("GoalRefiner", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       treeManager,
       makeEthicsGate()
     );
@@ -610,7 +599,6 @@ describe("GoalRefiner", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       makeTreeManager(),
       makeEthicsGate()
     );
@@ -643,7 +631,6 @@ describe("GoalRefiner", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       makeTreeManager(),
       makeEthicsGate()
     );

--- a/src/orchestrator/goal/__tests__/refine.test.ts
+++ b/src/orchestrator/goal/__tests__/refine.test.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import { GoalRefiner } from "../goal-refiner.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { ObservationEngine } from "../../../platform/observation/observation-engine.js";
-import type { GoalNegotiator } from "../goal-negotiator.js";
 import type { GoalTreeManager } from "../goal-tree-manager.js";
 import type { EthicsGate } from "../../../platform/traits/ethics-gate.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
@@ -118,10 +117,6 @@ function makeObservationEngine(): ObservationEngine {
   } as unknown as ObservationEngine;
 }
 
-function makeNegotiator(): GoalNegotiator {
-  return {} as unknown as GoalNegotiator;
-}
-
 function makeTreeManager(): GoalTreeManager {
   return {
     decomposeGoal: vi.fn(async (_goalId: string) => ({
@@ -182,7 +177,6 @@ describe("refine()", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       makeTreeManager(),
       makeEthicsGate()
     );
@@ -284,7 +278,6 @@ describe("refine()", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       treeManager,
       makeEthicsGate()
     );
@@ -352,7 +345,6 @@ describe("refine()", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       treeManager,
       makeEthicsGate()
     );
@@ -368,7 +360,6 @@ describe("refine()", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       makeTreeManager(),
       makeEthicsGate()
     );
@@ -411,7 +402,6 @@ describe("refine()", () => {
       stateManager,
       llmClient,
       makeObservationEngine(),
-      makeNegotiator(),
       treeManager,
       makeEthicsGate()
     );

--- a/src/orchestrator/goal/goal-refiner.ts
+++ b/src/orchestrator/goal/goal-refiner.ts
@@ -1,8 +1,8 @@
 /**
  * goal-refiner.ts — GoalRefiner class.
  *
- * Unified entry point that composes GoalNegotiator (feasibility) and
- * GoalTreeManager (decomposition) without replacing them.
+ * Unified entry point that composes feasibility checks and GoalTreeManager
+ * decomposition without replacing them.
  *
  * See docs/design/goal-refinement-pipeline.md §3 for the full algorithm.
  */
@@ -10,7 +10,6 @@
 import type { StateManager } from "../../base/state/state-manager.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import type { ObservationEngine } from "../../platform/observation/observation-engine.js";
-import type { GoalNegotiator } from "./goal-negotiator.js";
 import type { GoalTreeManager } from "./goal-tree-manager.js";
 import type { EthicsGate } from "../../platform/traits/ethics-gate.js";
 import { GoalSchema } from "../../base/types/goal.js";
@@ -136,7 +135,6 @@ export class GoalRefiner {
     private readonly stateManager: StateManager,
     private readonly llmClient: ILLMClient,
     private readonly observationEngine: ObservationEngine,
-    private readonly negotiator: GoalNegotiator,
     private readonly treeManager: GoalTreeManager,
     private readonly ethicsGate: EthicsGate,
   ) {}


### PR DESCRIPTION
## Summary
- remove the unused GoalNegotiator constructor dependency from GoalRefiner
- update CLI dependency wiring and refiner tests for the narrower constructor
- keep GoalNegotiator.negotiate, GoalTreeManager.decomposeGoal, and goal add --no-refine behavior unchanged

## Validation
- npm run typecheck
- npx vitest run src/orchestrator/goal/__tests__/goal-refiner.refine.test.ts src/orchestrator/goal/__tests__/goal-refiner.test.ts src/orchestrator/goal/__tests__/refine.test.ts src/orchestrator/goal/__tests__/goal-cli-refine.test.ts src/interface/cli/__tests__/cli-runner.test.ts src/interface/cli/__tests__/goal-dispatch-infer.test.ts src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts