### PR TITLE
[codex] improve setup migration and telegram onboarding

### DIFF
--- a/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts
@@ -60,9 +60,10 @@ describe("config — loadConfig", () => {
     expect(() => loadConfig(tmpDir)).toThrow("bot_token");
   });
 
-  it("throws when chat_id is missing", () => {
+  it("allows chat_id to be omitted before /sethome", () => {
     writeTmpConfig(tmpDir, { bot_token: "tok" });
-    expect(() => loadConfig(tmpDir)).toThrow("chat_id");
+    const cfg = loadConfig(tmpDir);
+    expect(cfg.chat_id).toBeUndefined();
   });
 
   it("defaults polling_timeout to 30", () => {
@@ -353,6 +354,11 @@ describe("TelegramNotifier", () => {
     sendMessageMock.mockRejectedValue(new Error("network error"));
     await expect(notifier.notify(makeEvent())).rejects.toThrow("network error");
   });
+
+  it("throws a setup hint when no home chat is configured", async () => {
+    notifier = new TelegramNotifier(mockApi, () => undefined);
+    await expect(notifier.notify(makeEvent())).rejects.toThrow("/sethome");
+  });
 });
 
 // ─── polling-loop.ts ───
@@ -520,6 +526,31 @@ describe("PollingLoop", () => {
     stopLoop();
   });
 
+  it("allows configured users from any chat when chat_id is not set", async () => {
+    const onMessage = vi.fn().mockResolvedValue(undefined);
+    loadLoopConfig({ bot_token: "tok", allowed_user_ids: [777] });
+
+    let stopLoop!: () => void;
+    const blocker = new Promise<Response>((resolve) => { stopLoop = () => resolve(updatesResponse([])); });
+
+    fetchMock
+      .mockResolvedValueOnce(updatesResponse([
+        { update_id: 1, message: { message_id: 1, from: { id: 777 }, chat: { id: 999 }, text: "hi" } },
+      ]))
+      .mockReturnValueOnce(blocker);
+
+    const loop = new PollingLoop(api, onMessage, [777], {});
+    loop.start();
+
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onMessage).toHaveBeenCalledWith("hi", 777, 999);
+
+    loop.stop();
+    stopLoop();
+  });
+
   it("stop() halts the loop — running becomes false", async () => {
     const onMessage = vi.fn().mockResolvedValue(undefined);
     loadLoopConfig({ bot_token: "tok", chat_id: 300, allowed_user_ids: [] });
@@ -667,6 +698,23 @@ describe("ChatBridge", () => {
     expect(first).not.toHaveBeenCalled();
     expect(second).toHaveBeenCalledOnce();
     expect(sendFinalFallback).toHaveBeenCalledWith("second");
+  });
+
+  it("handles /sethome before the normal message processor", async () => {
+    const processor = vi.fn().mockResolvedValue("should not run");
+    const onSetHome = vi.fn().mockReturnValue("home set");
+    const sendFinalFallback = vi.fn().mockResolvedValue(undefined);
+    const bridge = new ChatBridge(
+      processor,
+      () => ({ handle: vi.fn(), sendFinalFallback, renderedAssistantOutput: false } as unknown as TelegramChatEventAdapter),
+      onSetHome
+    );
+
+    await bridge.handleMessage("/sethome", 777, 999);
+
+    expect(onSetHome).toHaveBeenCalledWith(999);
+    expect(processor).not.toHaveBeenCalled();
+    expect(sendFinalFallback).toHaveBeenCalledWith("home set");
   });
 });
 
@@ -850,6 +898,12 @@ describe("TelegramBotPlugin", () => {
     await expect(plugin.init()).resolves.not.toThrow();
   });
 
+  it("init() succeeds before chat_id is configured", async () => {
+    writeTmpConfig(tmpDir, { bot_token: "tok123", allowed_user_ids: [42] });
+    const plugin = new TelegramBotPlugin(tmpDir);
+    await expect(plugin.init()).resolves.not.toThrow();
+  });
+
   it("getNotifier() returns TelegramNotifier after init", async () => {
     writeTmpConfig(tmpDir, { bot_token: "tok123", chat_id: 42 });
     const plugin = new TelegramBotPlugin(tmpDir);
@@ -893,5 +947,17 @@ describe("TelegramBotPlugin", () => {
 
     const bridge = (plugin as unknown as { bridge?: ChatBridge }).bridge;
     expect(bridge).toBeDefined();
+  });
+
+  it("/sethome persists the notification chat_id", async () => {
+    writeTmpConfig(tmpDir, { bot_token: "tok123", allowed_user_ids: [42] });
+    const plugin = new TelegramBotPlugin(tmpDir);
+    await plugin.init();
+
+    const bridge = (plugin as unknown as { bridge?: ChatBridge }).bridge;
+    await bridge!.handleMessage("/sethome", 42, 987);
+
+    const config = JSON.parse(fs.readFileSync(path.join(tmpDir, "config.json"), "utf-8")) as Record<string, unknown>;
+    expect(config["chat_id"]).toBe(987);
   });
 });

--- a/plugins/telegram-bot/plugin.yaml
+++ b/plugins/telegram-bot/plugin.yaml
@@ -19,8 +19,8 @@ config_schema:
     description: "Telegram Bot API token from @BotFather"
   chat_id:
     type: number
-    required: true
-    description: "Telegram chat ID to send notifications to"
+    required: false
+    description: "Optional Telegram home chat ID for notifications. If omitted, send /sethome to the bot from the target chat."
   allowed_user_ids:
     type: array
     required: false

--- a/plugins/telegram-bot/src/chat-bridge.ts
+++ b/plugins/telegram-bot/src/chat-bridge.ts
@@ -13,16 +13,21 @@ type ProcessMessageFn = (
   fromUserId?: number
 ) => Promise<string | void> | string | void;
 
+type HomeCommandFn = (chatId: number) => Promise<string | void> | string | void;
+
 export class ChatBridge {
   private processMessage: ProcessMessageFn;
   private readonly apiFactory: (chatId: number) => TelegramChatEventAdapter;
+  private readonly onSetHome?: HomeCommandFn;
 
   constructor(
     processMessage: ProcessMessageFn,
-    apiFactory: (chatId: number) => TelegramChatEventAdapter
+    apiFactory: (chatId: number) => TelegramChatEventAdapter,
+    onSetHome?: HomeCommandFn
   ) {
     this.processMessage = processMessage;
     this.apiFactory = apiFactory;
+    this.onSetHome = onSetHome;
   }
 
   setProcessMessage(processMessage: ProcessMessageFn): void {
@@ -31,6 +36,13 @@ export class ChatBridge {
 
   async handleMessage(text: string, fromUserId: number, chatId: number): Promise<void> {
     const adapter = this.apiFactory(chatId);
+    const normalized = text.trim().toLowerCase();
+    if ((normalized === "/sethome" || normalized.startsWith("/sethome@")) && this.onSetHome) {
+      const response = await this.onSetHome(chatId);
+      await adapter.sendFinalFallback(typeof response === "string" && response.trim() ? response : "This chat is now the home channel for PulSeed notifications.");
+      return;
+    }
+
     let eventQueue = Promise.resolve();
     const emit: ChatEventHandler = (event) => {
       const next = eventQueue.then(() => adapter.handle(event)).catch((err) => {

--- a/plugins/telegram-bot/src/config.ts
+++ b/plugins/telegram-bot/src/config.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 
 export interface TelegramConfig {
   bot_token: string;
-  chat_id: number;
+  chat_id?: number;
   allowed_user_ids: number[];
   runtime_control_allowed_user_ids: number[];
   allow_all: boolean;
@@ -40,8 +40,8 @@ function validateConfig(raw: unknown): TelegramConfig {
   if (typeof cfg["bot_token"] !== "string" || cfg["bot_token"].length === 0) {
     throw new Error("telegram-bot: bot_token must be a non-empty string");
   }
-  if (typeof cfg["chat_id"] !== "number" || !Number.isInteger(cfg["chat_id"])) {
-    throw new Error("telegram-bot: chat_id must be an integer");
+  if (cfg["chat_id"] !== undefined && (typeof cfg["chat_id"] !== "number" || !Number.isInteger(cfg["chat_id"]))) {
+    throw new Error("telegram-bot: chat_id must be an integer when set");
   }
 
   const allowedUserIds = cfg["allowed_user_ids"] ?? [];
@@ -72,7 +72,7 @@ function validateConfig(raw: unknown): TelegramConfig {
 
   return {
     bot_token: cfg["bot_token"] as string,
-    chat_id: cfg["chat_id"] as number,
+    chat_id: cfg["chat_id"] as number | undefined,
     allowed_user_ids: allowedUserIds as number[],
     runtime_control_allowed_user_ids: runtimeControlAllowedUserIds as number[],
     allow_all: allowAll,

--- a/plugins/telegram-bot/src/home-chat-store.ts
+++ b/plugins/telegram-bot/src/home-chat-store.ts
@@ -1,0 +1,30 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export class HomeChatStore {
+  private readonly configPath: string;
+  private chatId: number | undefined;
+
+  constructor(pluginDir: string, initialChatId?: number) {
+    this.configPath = path.join(pluginDir, "config.json");
+    this.chatId = initialChatId;
+  }
+
+  get(): number | undefined {
+    return this.chatId;
+  }
+
+  set(chatId: number): void {
+    this.chatId = chatId;
+
+    let current: Record<string, unknown> = {};
+    try {
+      current = JSON.parse(fs.readFileSync(this.configPath, "utf-8")) as Record<string, unknown>;
+    } catch {
+      current = {};
+    }
+
+    current["chat_id"] = chatId;
+    fs.writeFileSync(this.configPath, JSON.stringify(current, null, 2), "utf-8");
+  }
+}

--- a/plugins/telegram-bot/src/index.ts
+++ b/plugins/telegram-bot/src/index.ts
@@ -5,6 +5,7 @@ import { PollingLoop } from "./polling-loop.js";
 import { ChatBridge } from "./chat-bridge.js";
 import { TelegramChatEventAdapter } from "./telegram-chat-event-adapter.js";
 import { TelegramChatRunnerProcessor, type ProcessMessageFn } from "./telegram-chat-runner-processor.js";
+import { HomeChatStore } from "./home-chat-store.js";
 import type { ChatEventHandler } from "pulseed";
 
 type LegacyProcessMessageFn = (text: string, emit: ChatEventHandler) => Promise<string | void> | string | void;
@@ -27,12 +28,13 @@ export class TelegramBotPlugin {
     const config = loadConfig(this.pluginDir);
 
     this.api = new TelegramAPI(config.bot_token);
+    const homeChatStore = new HomeChatStore(this.pluginDir, config.chat_id);
 
     // Verify credentials
     const botInfo = await this.api.getMe();
     console.log(`[telegram-bot] connected as @${botInfo.username} (id: ${botInfo.id})`);
 
-    this.notifier = new TelegramNotifier(this.api, config.chat_id);
+    this.notifier = new TelegramNotifier(this.api, () => homeChatStore.get());
 
     this.processor = new TelegramChatRunnerProcessor(
       this.pluginDir,
@@ -44,7 +46,11 @@ export class TelegramBotPlugin {
     this.bridge = new ChatBridge(
       (text, chatId, emit, fromUserId) =>
         this.processor!.processMessage(text, chatId, emit, fromUserId),
-      (chatId) => new TelegramChatEventAdapter(this.api!, chatId)
+      (chatId) => new TelegramChatEventAdapter(this.api!, chatId),
+      (chatId) => {
+        homeChatStore.set(chatId);
+        return "This chat is now the home channel for PulSeed notifications.";
+      }
     );
 
     const api = this.api;

--- a/plugins/telegram-bot/src/notifier.ts
+++ b/plugins/telegram-bot/src/notifier.ts
@@ -15,11 +15,11 @@ export class TelegramNotifier implements INotifier {
   readonly name = "telegram-bot";
 
   private readonly api: TelegramAPI;
-  private readonly chatId: number;
+  private readonly resolveChatId: () => number | undefined;
 
-  constructor(api: TelegramAPI, chatId: number) {
+  constructor(api: TelegramAPI, chatId: number | (() => number | undefined)) {
     this.api = api;
-    this.chatId = chatId;
+    this.resolveChatId = typeof chatId === "function" ? chatId : () => chatId;
   }
 
   supports(_eventType: string): boolean {
@@ -27,7 +27,11 @@ export class TelegramNotifier implements INotifier {
   }
 
   async notify(event: NotificationEvent): Promise<void> {
+    const chatId = this.resolveChatId();
+    if (chatId === undefined) {
+      throw new Error("telegram-bot: no home chat configured. Send /sethome to the bot from the target Telegram chat.");
+    }
     const text = formatNotification(event);
-    await this.api.sendMessage(this.chatId, text);
+    await this.api.sendMessage(chatId, text);
   }
 }

--- a/plugins/telegram-bot/src/polling-loop.ts
+++ b/plugins/telegram-bot/src/polling-loop.ts
@@ -4,7 +4,7 @@ import type { TelegramAPI } from "./telegram-api.js";
 
 type OnMessageFn = (text: string, fromUserId: number, chatId: number) => Promise<void>;
 interface PollingLoopOptions {
-  allowedChatId: number;
+  allowedChatId?: number;
   allowAll?: boolean;
 }
 
@@ -18,7 +18,7 @@ export class PollingLoop {
   private readonly api: TelegramAPI;
   private readonly onMessage: OnMessageFn;
   private readonly allowedUserIds: number[];
-  private readonly allowedChatId: number;
+  private readonly allowedChatId: number | undefined;
   private readonly allowAll: boolean;
 
   private running = false;
@@ -64,7 +64,7 @@ export class PollingLoop {
           const chatId = msg.chat?.id;
           if (typeof fromId !== "number" || !Number.isInteger(fromId)) continue;
           if (typeof chatId !== "number" || !Number.isInteger(chatId)) continue;
-          if (chatId !== this.allowedChatId) continue;
+          if (this.allowedChatId !== undefined && chatId !== this.allowedChatId) continue;
 
           if (!this.allowAll && !this.allowedUserIds.includes(fromId)) {
             continue;

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -129,6 +129,7 @@ interface LegacyProviderConfig {
 // ─── Constants ───
 
 const PROVIDER_CONFIG_PATH = path.join(getPulseedDirPath(), "provider.json");
+const PROVIDER_ENV_PATH = path.join(getPulseedDirPath(), ".env");
 
 const DEFAULT_PROVIDER_CONFIG: ProviderConfig = {
   provider: "openai",
@@ -303,29 +304,53 @@ function resolveModel(
 
 function resolveApiKey(
   fileKey: string | undefined,
-  provider: ProviderConfig["provider"]
+  provider: ProviderConfig["provider"],
+  envFile: Record<string, string>
 ): string | undefined {
   if (provider === "anthropic") {
-    return process.env["ANTHROPIC_API_KEY"] ?? fileKey;
+    return process.env["ANTHROPIC_API_KEY"] ?? envFile["ANTHROPIC_API_KEY"] ?? fileKey;
   }
   // openai (and codex) both use OPENAI_API_KEY
   if (provider === "openai") {
-    return process.env["OPENAI_API_KEY"] ?? fileKey;
+    return process.env["OPENAI_API_KEY"] ?? envFile["OPENAI_API_KEY"] ?? fileKey;
   }
   return fileKey;
 }
 
 function resolveBaseUrl(
   fileUrl: string | undefined,
-  provider: ProviderConfig["provider"]
+  provider: ProviderConfig["provider"],
+  envFile: Record<string, string>
 ): string | undefined {
   if (provider === "ollama") {
-    return process.env["OLLAMA_BASE_URL"] ?? fileUrl;
+    return process.env["OLLAMA_BASE_URL"] ?? envFile["OLLAMA_BASE_URL"] ?? fileUrl;
   }
   if (provider === "openai") {
-    return process.env["OPENAI_BASE_URL"] ?? fileUrl;
+    return process.env["OPENAI_BASE_URL"] ?? envFile["OPENAI_BASE_URL"] ?? fileUrl;
   }
   return fileUrl;
+}
+
+function parseEnvFile(raw: string): Record<string, string> {
+  const entries = raw
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) return [];
+      const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(trimmed);
+      if (!match) return [];
+      const value = match[2]!.trim().replace(/^['"]|['"]$/g, "");
+      return [[match[1]!, value] as const];
+    });
+  return Object.fromEntries(entries);
+}
+
+async function readProviderEnvFile(): Promise<Record<string, string>> {
+  try {
+    return parseEnvFile(await fsp.readFile(PROVIDER_ENV_PATH, "utf-8"));
+  } catch {
+    return {};
+  }
 }
 
 // ─── Public API ───
@@ -343,6 +368,7 @@ function resolveBaseUrl(
 export async function loadProviderConfig(): Promise<ProviderConfig> {
   let fileConfig: Partial<ProviderConfig> = {};
   let needsMigrationSave = false;
+  const envFile = await readProviderEnvFile();
 
   try {
     await fsp.access(PROVIDER_CONFIG_PATH);
@@ -377,14 +403,14 @@ export async function loadProviderConfig(): Promise<ProviderConfig> {
     model = fallback;
   }
 
-  let api_key = resolveApiKey(fileConfig.api_key, provider);
+  let api_key = resolveApiKey(fileConfig.api_key, provider, envFile);
 
   // Fallback: read OAuth token from ~/.codex/auth.json when no API key is configured
   if (!api_key && provider === "openai" && adapter === "openai_codex_cli") {
     api_key = await readCodexOAuthToken();
   }
 
-  const base_url = resolveBaseUrl(fileConfig.base_url, provider);
+  const base_url = resolveBaseUrl(fileConfig.base_url, provider, envFile);
 
   const config: ProviderConfig = { provider, model, adapter };
   if (api_key !== undefined) config.api_key = api_key;

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -439,10 +439,10 @@ describe("setup notification step", () => {
         provider: "openai",
         model: "gpt-5.4-mini",
         adapter: "agent_loop",
-        api_key: "sk-existing",
         codex_cli_path: "/usr/local/bin/codex",
       })
     );
+    expect((saveProviderConfigMock.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty("api_key");
   });
 
   it("starts daemon and gateway after saving daemon config", async () => {
@@ -658,15 +658,15 @@ describe("setup notification step", () => {
     expect(stepProviderMock).toHaveBeenCalledWith("anthropic");
     expect(stepModelMock).toHaveBeenCalledWith("anthropic", "claude-sonnet-4-6");
     expect(stepAdapterMock).toHaveBeenCalledWith("claude-sonnet-4-6", "anthropic", "agent_loop");
-    expect(stepApiKeyMock).toHaveBeenCalledWith("anthropic", expect.any(Object), "sk-imported");
+    expect(stepApiKeyMock).toHaveBeenCalledWith("anthropic", expect.any(Object), "sk-imported", "agent_loop");
     expect(saveProviderConfigMock).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "anthropic",
         model: "claude-sonnet-4-6",
         adapter: "agent_loop",
-        api_key: "sk-imported",
       })
     );
+    expect((saveProviderConfigMock.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty("api_key");
     expect(applySetupImportSelectionMock).toHaveBeenCalledWith("/tmp/pulseed-test", importSelection);
   });
 
@@ -708,8 +708,10 @@ describe("setup notification step", () => {
       clearIdentityCache: vi.fn(),
     }));
     const mkdirSyncMock = vi.fn();
-    const writeFileSyncMock = vi.fn(() => {
-      throw new Error("disk full");
+    const writeFileSyncMock = vi.fn((filePath: string) => {
+      if (filePath.endsWith("notification.json")) {
+        throw new Error("disk full");
+      }
     });
     vi.doMock("node:fs", () => ({
       mkdirSync: mkdirSyncMock,

--- a/src/interface/cli/__tests__/setup-import.test.ts
+++ b/src/interface/cli/__tests__/setup-import.test.ts
@@ -65,23 +65,23 @@ describe("setup import discovery", () => {
 
     const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
     const sources = detectSetupImportSources();
+    const openclaw = sources.find((source) => source.id === "openclaw");
 
-    expect(sources).toHaveLength(1);
-    expect(sources[0]?.id).toBe("openclaw");
-    expect(sources[0]?.items.map((item) => item.kind).sort()).toEqual([
+    expect(openclaw).toBeDefined();
+    expect(openclaw?.items.map((item) => item.kind).sort()).toEqual([
       "mcp",
       "plugin",
       "provider",
       "skill",
     ]);
-    expect(sources[0]?.items.find((item) => item.kind === "provider")?.providerSettings).toMatchObject({
+    expect(openclaw?.items.find((item) => item.kind === "provider")?.providerSettings).toMatchObject({
       provider: "anthropic",
       model: "claude-sonnet-4-6",
       adapter: "agent_loop",
       apiKey: "sk-imported",
       baseUrl: "https://example.test",
     });
-    expect(sources[0]?.items.find((item) => item.kind === "mcp")?.mcpServer).toMatchObject({
+    expect(openclaw?.items.find((item) => item.kind === "mcp")?.mcpServer).toMatchObject({
       id: "openclaw-filesystem",
       enabled: false,
       transport: "stdio",
@@ -94,7 +94,71 @@ describe("setup import discovery", () => {
         },
       ],
     });
-    expect(sources[0]?.items.find((item) => item.kind === "plugin")?.decision).toBe("copy_disabled");
+    expect(openclaw?.items.find((item) => item.kind === "plugin")?.decision).toBe("copy_disabled");
+  });
+
+  it("detects OpenClaw migration-style YAML, env secrets, workspace skills, and nested MCP servers", async () => {
+    const openclawHome = path.join(tmpDir, "openclaw");
+    process.env["PULSEED_IMPORT_OPENCLAW_HOME"] = openclawHome;
+
+    await fsp.mkdir(openclawHome, { recursive: true });
+    await fsp.writeFile(
+      path.join(openclawHome, ".env"),
+      [
+        "OPENAI_API_KEY=sk-env-openai",
+        "TELEGRAM_BOT_TOKEN=123456:telegram-token",
+      ].join("\n"),
+      "utf-8"
+    );
+    await fsp.writeFile(
+      path.join(openclawHome, "config.yaml"),
+      [
+        "agents:",
+        "  defaults:",
+        "    model: gpt-5.4-mini",
+        "models:",
+        "  providers:",
+        "    openai:",
+        "      apiKey:",
+        "        source: env",
+        "        id: OPENAI_API_KEY",
+        "      baseUrl: https://api.openai.com/v1",
+        "channels:",
+        "  telegram:",
+        "    botToken: ${TELEGRAM_BOT_TOKEN}",
+        "mcp:",
+        "  servers:",
+        "    filesystem:",
+        "      command: node",
+        "      args:",
+        "        - server.js",
+      ].join("\n"),
+      "utf-8"
+    );
+    await fsp.mkdir(path.join(openclawHome, "workspace-main", "skills", "review"), { recursive: true });
+    await fsp.writeFile(path.join(openclawHome, "workspace-main", "skills", "review", "SKILL.md"), "# Review\n", "utf-8");
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const openclaw = sources.find((source) => source.id === "openclaw");
+    const provider = openclaw?.items.find((item) => item.kind === "provider");
+    const skill = openclaw?.items.find((item) => item.kind === "skill");
+    const mcp = openclaw?.items.find((item) => item.kind === "mcp");
+
+    expect(provider?.providerSettings).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      apiKey: "sk-env-openai",
+      baseUrl: "https://api.openai.com/v1",
+    });
+    expect(provider?.providerSettings?.apiKey).not.toBe("123456:telegram-token");
+    expect(skill?.label).toBe("review");
+    expect(mcp?.mcpServer).toMatchObject({
+      id: "openclaw-filesystem",
+      command: "node",
+      args: ["server.js"],
+      enabled: false,
+    });
   });
 });
 
@@ -168,6 +232,19 @@ describe("setup import apply", () => {
             enabled: false,
           },
         },
+        {
+          id: "openclaw:telegram:config.json",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
+          kind: "telegram",
+          label: "bot token / 2 allowed user(s)",
+          decision: "import",
+          reason: "Telegram bot and allowed-user defaults",
+          telegramSettings: {
+            botToken: "123456:token",
+            allowedUserIds: [111, 222],
+          },
+        },
       ],
     };
 
@@ -186,7 +263,17 @@ describe("setup import apply", () => {
         expect.objectContaining({ id: "openclaw-filesystem-2", enabled: false }),
       ])
     );
-    expect(report.items.filter((item) => item.status === "applied")).toHaveLength(3);
+    expect(report.items.filter((item) => item.status === "applied")).toHaveLength(4);
+    const telegramConfig = JSON.parse(
+      await fsp.readFile(path.join(baseDir, "plugins", "telegram-bot", "config.json"), "utf-8")
+    ) as Record<string, unknown>;
+    expect(telegramConfig).toMatchObject({
+      bot_token: "123456:token",
+      allowed_user_ids: [111, 222],
+      runtime_control_allowed_user_ids: [111, 222],
+      allow_all: false,
+      polling_timeout: 30,
+    });
 
     const reportRoots = await fsp.readdir(path.join(baseDir, "imports", "openclaw"));
     expect(reportRoots).toHaveLength(1);
@@ -215,12 +302,12 @@ describe("setup import flow", () => {
     expect(confirmMock).not.toHaveBeenCalled();
   });
 
-  it("asks which provider defaults to use when multiple provider configs are selected", async () => {
+  it("asks which source to import from when Hermes and OpenClaw are both detected", async () => {
     vi.resetModules();
     const confirmMock = vi.fn(async () => true);
     const selectMock = vi.fn()
-      .mockResolvedValueOnce("recommended")
-      .mockResolvedValueOnce("openclaw-provider");
+      .mockResolvedValueOnce("openclaw")
+      .mockResolvedValueOnce("recommended");
     const logInfoMock = vi.fn();
     const sources: SetupImportSource[] = [
       {
@@ -290,12 +377,13 @@ describe("setup import flow", () => {
       adapter: "agent_loop",
       apiKey: "sk-openclaw",
     });
-    expect(selection?.items.find((item) => item.id === "hermes-provider")?.decision).toBe("skip");
+    expect(selection?.sources.map((source) => source.id)).toEqual(["openclaw"]);
+    expect(selection?.items.find((item) => item.id === "hermes-provider")).toBeUndefined();
     expect(selection?.items.find((item) => item.id === "openclaw-provider")?.decision).toBe("import");
     expect(selectMock).toHaveBeenNthCalledWith(
-      2,
+      1,
       expect.objectContaining({
-        message: expect.stringContaining("Which provider settings"),
+        message: expect.stringContaining("Which existing agent"),
       })
     );
   });

--- a/src/interface/cli/__tests__/telegram-setup.test.ts
+++ b/src/interface/cli/__tests__/telegram-setup.test.ts
@@ -46,7 +46,7 @@ describe("cmdTelegramSetup", () => {
   });
 
   it("writes optional identity_key for cross-platform continuation", async () => {
-    readlineState.answers = ["test-token", "123456", "777,888", "personal"];
+    readlineState.answers = ["test-token", "777,888", "", "personal"];
     const { cmdTelegramSetup } = await import("../commands/telegram.js");
 
     const result = await cmdTelegramSetup([]);
@@ -59,10 +59,10 @@ describe("cmdTelegramSetup", () => {
     const config = JSON.parse(await fsp.readFile(configPath, "utf-8")) as Record<string, unknown>;
     expect(config).toMatchObject({
       bot_token: "test-token",
-      chat_id: 123456,
       allowed_user_ids: [777, 888],
       polling_timeout: 30,
       identity_key: "personal",
     });
+    expect(config.chat_id).toBeUndefined();
   });
 });

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -112,7 +112,9 @@ async function stepExecutionConfig(
 
   const detectedKeys = detectApiKeys();
   const apiKey =
-    current?.provider === provider ? await stepApiKey(provider, detectedKeys, current.apiKey) : await stepApiKey(provider, detectedKeys);
+    current?.provider === provider
+      ? await stepApiKey(provider, detectedKeys, current.apiKey, adapter)
+      : await stepApiKey(provider, detectedKeys, undefined, adapter);
   return { provider, model, adapter, apiKey };
 }
 
@@ -165,8 +167,44 @@ async function validateAndSaveProviderConfig(config: ProviderConfig): Promise<nu
     return 1;
   }
 
-  await saveProviderConfig(config);
+  const fileConfig: ProviderConfig = { ...config };
+  const apiKey = fileConfig.api_key;
+  delete fileConfig.api_key;
+  await saveProviderConfig(fileConfig);
+  if (apiKey) {
+    saveProviderApiKeyToEnv(config.provider, apiKey);
+  }
   return undefined;
+}
+
+function saveProviderApiKeyToEnv(provider: ProviderConfig["provider"], apiKey: string): void {
+  const envKey = provider === "openai"
+    ? "OPENAI_API_KEY"
+    : provider === "anthropic"
+      ? "ANTHROPIC_API_KEY"
+      : undefined;
+  if (!envKey) return;
+
+  const dir = ensurePulseedDir();
+  const envPath = path.join(dir, ".env");
+  let lines: string[] = [];
+  try {
+    lines = fs.readFileSync(envPath, "utf-8").split(/\r?\n/);
+  } catch {
+    lines = [];
+  }
+
+  const replacement = `${envKey}=${apiKey}`;
+  let replaced = false;
+  lines = lines.map((line) => {
+    if (line.startsWith(`${envKey}=`)) {
+      replaced = true;
+      return replacement;
+    }
+    return line;
+  }).filter((line, index, all) => line || index < all.length - 1);
+  if (!replaced) lines.push(replacement);
+  fs.writeFileSync(envPath, `${lines.join("\n")}\n`, "utf-8");
 }
 
 async function startDaemonDetached(baseDir: string): Promise<number | undefined> {

--- a/src/interface/cli/commands/setup/import/apply.ts
+++ b/src/interface/cli/commands/setup/import/apply.ts
@@ -1,4 +1,5 @@
 import * as path from "node:path";
+import * as fsp from "node:fs/promises";
 import { readJsonFileOrNull, writeJsonFileAtomic } from "../../../../../base/utils/json-io.js";
 import type { MCPServerConfig, MCPServersConfig } from "../../../../../base/types/mcp.js";
 import { copyDirectoryNoSymlinks, safeImportName, uniqueImportPath } from "./fs-utils.js";
@@ -8,6 +9,16 @@ import type {
   SetupImportReport,
   SetupImportSelection,
 } from "./types.js";
+
+interface TelegramPluginConfig {
+  bot_token?: string;
+  chat_id?: number;
+  allowed_user_ids?: number[];
+  runtime_control_allowed_user_ids?: number[];
+  allow_all?: boolean;
+  polling_timeout?: number;
+  identity_key?: string;
+}
 
 function nextMcpId(existing: Set<string>, requested: string): string {
   const base = safeImportName(requested);
@@ -102,6 +113,66 @@ function reportItem(item: SetupImportItem, status: SetupImportAppliedItem["statu
   };
 }
 
+async function copyTelegramPluginYaml(pluginDir: string): Promise<void> {
+  const destYaml = path.join(pluginDir, "plugin.yaml");
+  const minimal = [
+    "name: telegram-bot",
+    "version: 1.0.0",
+    "type: notifier",
+    "capabilities:",
+    "  - telegram_notification",
+    "  - bidirectional_chat",
+    "description: \"Telegram bot plugin for PulSeed\"",
+    "config_schema:",
+    "  bot_token:",
+    "    type: string",
+    "    required: true",
+    "  chat_id:",
+    "    type: number",
+    "    required: false",
+    "entry_point: \"dist/index.js\"",
+    "permissions:",
+    "  network: true",
+  ].join("\n") + "\n";
+  await fsp.mkdir(pluginDir, { recursive: true });
+  try {
+    await fsp.access(destYaml);
+  } catch {
+    await fsp.writeFile(destYaml, minimal, "utf-8");
+  }
+}
+
+async function applyTelegramConfig(baseDir: string, items: SetupImportItem[]): Promise<string | undefined> {
+  const selected = items.filter((item) => item.kind === "telegram" && item.telegramSettings);
+  if (selected.length === 0) return undefined;
+  const pluginDir = path.join(baseDir, "plugins", "telegram-bot");
+  const configPath = path.join(pluginDir, "config.json");
+  const current = await readJsonFileOrNull<TelegramPluginConfig>(configPath);
+  const allowed = new Set<number>(current?.allowed_user_ids ?? []);
+  const runtimeAllowed = new Set<number>(current?.runtime_control_allowed_user_ids ?? []);
+  let botToken = current?.bot_token;
+
+  for (const item of selected) {
+    if (item.telegramSettings?.botToken) botToken = item.telegramSettings.botToken;
+    for (const id of item.telegramSettings?.allowedUserIds ?? []) {
+      allowed.add(id);
+      runtimeAllowed.add(id);
+    }
+  }
+
+  const config: TelegramPluginConfig = {
+    ...(current ?? {}),
+    ...(botToken ? { bot_token: botToken } : {}),
+    allowed_user_ids: [...allowed],
+    runtime_control_allowed_user_ids: [...runtimeAllowed],
+    allow_all: current?.allow_all ?? false,
+    polling_timeout: current?.polling_timeout ?? 30,
+  };
+  await writeJsonFileAtomic(configPath, config);
+  await copyTelegramPluginYaml(pluginDir);
+  return configPath;
+}
+
 export async function applySetupImportSelection(
   baseDir: string,
   selection: SetupImportSelection
@@ -113,11 +184,34 @@ export async function applySetupImportSelection(
     try {
       if (item.kind === "provider") {
         applied.push(reportItem(item, "applied", "provider settings seeded into setup answers"));
+      } else if (item.kind === "telegram") {
+        applied.push(reportItem(item, "applied", "telegram settings seeded into plugin config"));
       } else if (item.kind === "skill" || item.kind === "plugin") {
         applied.push(await applyFileItem(baseDir, item));
       }
     } catch (err) {
       applied.push(reportItem(item, "failed", err instanceof Error ? err.message : String(err)));
+    }
+  }
+
+  try {
+    const targetPath = await applyTelegramConfig(baseDir, selectedItems);
+    if (targetPath) {
+      for (const item of selectedItems.filter((candidate) => candidate.kind === "telegram")) {
+        const existing = applied.find((appliedItem) => appliedItem.id === item.id);
+        if (existing) existing.targetPath = targetPath;
+      }
+    }
+  } catch (err) {
+    for (const item of selectedItems.filter((candidate) => candidate.kind === "telegram")) {
+      const existing = applied.find((appliedItem) => appliedItem.id === item.id);
+      const reason = err instanceof Error ? err.message : String(err);
+      if (existing) {
+        existing.status = "failed";
+        existing.reason = reason;
+      } else {
+        applied.push(reportItem(item, "failed", reason));
+      }
     }
   }
 

--- a/src/interface/cli/commands/setup/import/constants.ts
+++ b/src/interface/cli/commands/setup/import/constants.ts
@@ -8,9 +8,14 @@ export const SOURCE_LABELS: Record<SetupImportSourceId, string> = {
 export const CONFIG_FILENAMES = [
   "provider.json",
   "config.json",
+  "config.yaml",
+  "config.yml",
   "settings.json",
   "agent.json",
+  "openclaw.json",
   "openclaw.config.json",
+  "clawdbot.json",
+  "moltbot.json",
   "hermes.config.json",
 ] as const;
 

--- a/src/interface/cli/commands/setup/import/discovery.ts
+++ b/src/interface/cli/commands/setup/import/discovery.ts
@@ -4,11 +4,14 @@ import { CONFIG_FILENAMES, MCP_FILENAMES, SOURCE_LABELS } from "./constants.js";
 import {
   listImmediateDirs,
   pathExists,
+  readEnvFile,
   readJson,
+  safeImportName,
   unique,
 } from "./fs-utils.js";
 import { extractMcpServers } from "./mcp.js";
 import { buildProviderItem, extractProviderSettings } from "./provider.js";
+import { buildTelegramItem, extractTelegramSettings, telegramCredentialItems } from "./telegram.js";
 import type {
   SetupImportItem,
   SetupImportSource,
@@ -22,11 +25,24 @@ function candidateFiles(rootDir: string, filenames: readonly string[]): string[]
   ]).filter(pathExists);
 }
 
-function findSkillDirs(rootDir: string): string[] {
+function workspaceRoots(rootDir: string): string[] {
+  return unique([
+    path.join(rootDir, "workspace"),
+    path.join(rootDir, "workspace.default"),
+    path.join(rootDir, "workspace-main"),
+    ...listImmediateDirs(rootDir).filter((dir) => path.basename(dir).startsWith("workspace-")),
+  ]);
+}
+
+function findSkillDirs(source: SetupImportSourceId, rootDir: string): string[] {
   const roots = unique([
     path.join(rootDir, "skills"),
     path.join(rootDir, "agent", "skills"),
     path.join(rootDir, "agents", "skills"),
+    ...workspaceRoots(rootDir).flatMap((workspaceRoot) => [
+      path.join(workspaceRoot, "skills"),
+      path.join(workspaceRoot, ".agents", "skills"),
+    ]),
   ]);
   const candidates: string[] = [];
   for (const skillRoot of roots) {
@@ -64,28 +80,46 @@ function sourceRoots(source: SetupImportSourceId): string[] {
       path.join(home, "Library", "Application Support", "Hermes Agent"),
     ].filter(Boolean));
   }
-  return unique([
-    process.env["PULSEED_IMPORT_OPENCLAW_HOME"] ?? "",
-    process.env["PULSEED_OPENCLAW_HOME"] ?? "",
-    process.env["OPENCLAW_HOME"] ?? "",
-    path.join(home, ".openclaw"),
-    path.join(home, ".config", "openclaw"),
-    path.join(home, "Library", "Application Support", "OpenClaw"),
-  ].filter(Boolean));
+    return unique([
+      process.env["PULSEED_IMPORT_OPENCLAW_HOME"] ?? "",
+      process.env["PULSEED_OPENCLAW_HOME"] ?? "",
+      process.env["OPENCLAW_HOME"] ?? "",
+      path.join(home, ".openclaw"),
+      path.join(home, ".clawdbot"),
+      path.join(home, ".moltbot"),
+      path.join(home, ".config", "openclaw"),
+      path.join(home, "Library", "Application Support", "OpenClaw"),
+    ].filter(Boolean));
 }
 
 function providerItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
+  const env = {
+    ...readEnvFile(path.join(rootDir, ".env")),
+    ...readEnvFile(path.join(rootDir, "config", ".env")),
+  };
   return candidateFiles(rootDir, CONFIG_FILENAMES).flatMap((configPath) => {
-    const settings = extractProviderSettings(readJson(configPath), source);
+    const settings = extractProviderSettings(readJson(configPath), source, { env });
     return settings ? [buildProviderItem(source, configPath, settings)] : [];
   });
 }
 
+function telegramItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
+  const env = {
+    ...readEnvFile(path.join(rootDir, ".env")),
+    ...readEnvFile(path.join(rootDir, "config", ".env")),
+  };
+  const configItems = candidateFiles(rootDir, CONFIG_FILENAMES).flatMap((configPath) => {
+    const settings = extractTelegramSettings(readJson(configPath), env);
+    return settings ? [buildTelegramItem(source, configPath, settings)] : [];
+  });
+  return [...configItems, ...telegramCredentialItems(source, rootDir)];
+}
+
 function skillItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
-  return findSkillDirs(rootDir).map((skillDir) => {
+  return findSkillDirs(source, rootDir).map((skillDir) => {
     const name = path.basename(skillDir);
     return {
-      id: `${source}:skill:${name}`,
+      id: `${source}:skill:${safeImportName(skillDir)}`,
       source,
       sourceLabel: SOURCE_LABELS[source],
       kind: "skill",
@@ -98,7 +132,7 @@ function skillItems(source: SetupImportSourceId, rootDir: string): SetupImportIt
 }
 
 function mcpItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
-  return candidateFiles(rootDir, MCP_FILENAMES).flatMap((mcpPath) =>
+  return candidateFiles(rootDir, [...MCP_FILENAMES, ...CONFIG_FILENAMES]).flatMap((mcpPath) =>
     extractMcpServers(readJson(mcpPath), source).map((server) => ({
       id: `${source}:mcp:${server.id}`,
       source,
@@ -134,6 +168,7 @@ function detectSource(source: SetupImportSourceId): SetupImportSource | undefine
     if (!pathExists(rootDir)) continue;
     const items = [
       ...providerItems(source, rootDir),
+      ...telegramItems(source, rootDir),
       ...skillItems(source, rootDir),
       ...mcpItems(source, rootDir),
       ...pluginItems(source, rootDir),

--- a/src/interface/cli/commands/setup/import/flow.ts
+++ b/src/interface/cli/commands/setup/import/flow.ts
@@ -40,6 +40,11 @@ function itemPreview(item: SetupImportItem): string {
   const decision = item.decision === "copy_disabled" ? "copy disabled" : item.decision;
   const details = item.kind === "provider"
     ? providerPreview(item.providerSettings)
+    : item.kind === "telegram"
+      ? [
+          item.telegramSettings?.botToken ? `bot_token=${maskKey(item.telegramSettings.botToken)}` : undefined,
+          item.telegramSettings?.allowedUserIds?.length ? `allowed_users=${item.telegramSettings.allowedUserIds.length}` : undefined,
+        ].filter(Boolean).join(", ")
     : item.reason;
   return `[${item.sourceLabel}] ${item.kind}: ${item.label}\n  ${decision}${details ? ` - ${details}` : ""}`;
 }
@@ -82,10 +87,10 @@ export function providerConfigPatchFromImport(
 }
 
 export async function stepSetupImport(): Promise<SetupImportSelection | undefined> {
-  const sources = detectSetupImportSources();
-  if (sources.length === 0) return undefined;
+  const detectedSources = detectSetupImportSources();
+  if (detectedSources.length === 0) return undefined;
 
-  p.note(sourceSummary(sources), "Existing agent configs found");
+  p.note(sourceSummary(detectedSources), "Existing agent configs found");
   const wantsImport = guardCancel(
     await p.confirm({
       message: "Import settings from Hermes Agent / OpenClaw into PulSeed?",
@@ -93,6 +98,23 @@ export async function stepSetupImport(): Promise<SetupImportSelection | undefine
     })
   );
   if (!wantsImport) return undefined;
+
+  let sources = detectedSources;
+  if (detectedSources.length > 1) {
+    const sourceChoice = guardCancel(
+      await p.select({
+        message: "Which existing agent should PulSeed import from?",
+        options: detectedSources.map((source) => ({
+          value: source.id,
+          label: source.label,
+          hint: source.rootDir,
+        })),
+        initialValue: detectedSources.find((source) => source.id === "hermes")?.id ?? detectedSources[0]?.id,
+      })
+    );
+    sources = detectedSources.filter((source) => source.id === sourceChoice);
+  }
+
 
   p.note(preview(sources), "Import preview");
   const mode = guardCancel(

--- a/src/interface/cli/commands/setup/import/fs-utils.ts
+++ b/src/interface/cli/commands/setup/import/fs-utils.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
+import { load as parseYaml } from "js-yaml";
 
 export function unique<T>(values: T[]): T[] {
   return [...new Set(values)];
@@ -26,9 +27,32 @@ export async function pathExistsAsync(filePath: string): Promise<boolean> {
 
 export function readJson(filePath: string): unknown | undefined {
   try {
-    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
+    const raw = fs.readFileSync(filePath, "utf-8");
+    if (filePath.endsWith(".yaml") || filePath.endsWith(".yml")) {
+      return parseYaml(raw) as unknown;
+    }
+    return JSON.parse(raw) as unknown;
   } catch {
     return undefined;
+  }
+}
+
+export function readEnvFile(filePath: string): Record<string, string> {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const entries = raw
+      .split(/\r?\n/)
+      .flatMap((line) => {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) return [];
+        const match = /^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(trimmed);
+        if (!match) return [];
+        const value = match[2]!.trim().replace(/^['"]|['"]$/g, "");
+        return [[match[1]!, value] as const];
+      });
+    return Object.fromEntries(entries);
+  } catch {
+    return {};
   }
 }
 

--- a/src/interface/cli/commands/setup/import/mcp.ts
+++ b/src/interface/cli/commands/setup/import/mcp.ts
@@ -67,6 +67,8 @@ export function extractMcpServers(raw: unknown, source: SetupImportSourceId): MC
     ? raw["mcpServers"]
     : isRecord(raw["mcp_servers"])
       ? raw["mcp_servers"]
+      : isRecord(raw["mcp"]) && isRecord(raw["mcp"]["servers"])
+        ? raw["mcp"]["servers"]
       : raw;
 
   return Object.entries(mapValue).flatMap(([id, value]) => {

--- a/src/interface/cli/commands/setup/import/provider.ts
+++ b/src/interface/cli/commands/setup/import/provider.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import type { ProviderConfig } from "../../../../../base/llm/provider-config.js";
+import { MODEL_REGISTRY } from "../../../../../base/llm/provider-config.js";
 import { PROVIDERS, getAdaptersForModel } from "../../setup-shared.js";
 import type { Provider } from "../../setup-shared.js";
 import { SOURCE_LABELS } from "./constants.js";
@@ -21,9 +22,14 @@ const PROVIDER_KEYS = [
 
 const MODEL_KEYS = ["model", "default_model", "defaultModel", "modelName"];
 const ADAPTER_KEYS = ["adapter", "default_adapter", "defaultAdapter", "backend", "terminalBackend"];
-const API_KEY_KEYS = ["api_key", "apiKey", "key", "token", "authToken"];
+const API_KEY_KEYS = ["api_key", "apiKey", "openai_api_key", "anthropic_api_key", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"];
 const BASE_URL_KEYS = ["base_url", "baseUrl", "baseURL", "endpoint", "api_base"];
 const CLI_PATH_KEYS = ["codex_cli_path", "codexCliPath", "cli_path", "cliPath"];
+const PROVIDER_ENV_KEYS: Record<Provider, string[]> = {
+  openai: ["OPENAI_API_KEY"],
+  anthropic: ["ANTHROPIC_API_KEY"],
+  ollama: [],
+};
 
 function normalizeProvider(value: string | undefined): Provider | undefined {
   const normalized = value?.toLowerCase().trim();
@@ -38,6 +44,26 @@ function normalizeProvider(value: string | undefined): Provider | undefined {
     return "ollama";
   }
   return PROVIDERS.includes(normalized as Provider) ? (normalized as Provider) : undefined;
+}
+
+function providerFromModel(model: string | undefined): Provider | undefined {
+  if (!model) return undefined;
+  const registered = MODEL_REGISTRY[model]?.provider;
+  if (registered && PROVIDERS.includes(registered as Provider)) return registered as Provider;
+  const lower = model.toLowerCase();
+  if (lower.startsWith("gpt-") || lower.startsWith("o3") || lower.startsWith("o4")) return "openai";
+  if (lower.startsWith("claude-")) return "anthropic";
+  return undefined;
+}
+
+function providerFromKnownMap(records: Record<string, unknown>[]): Provider | undefined {
+  for (const record of records) {
+    const providers = nestedRecord(record, "providers");
+    if (!providers) continue;
+    const keys = Object.keys(providers).map(normalizeProvider).filter(Boolean) as Provider[];
+    if (keys.length === 1) return keys[0];
+  }
+  return undefined;
 }
 
 function normalizeAdapter(
@@ -88,6 +114,65 @@ function providerSection(
   return undefined;
 }
 
+function stringFromSecretRef(value: unknown, env: Record<string, string>): string | undefined {
+  if (typeof value === "string" && value.trim()) {
+    const match = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/.exec(value.trim());
+    if (match) return env[match[1]!];
+    return value.trim();
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (record["source"] === "env" && typeof record["id"] === "string") {
+    return env[record["id"]];
+  }
+  return undefined;
+}
+
+function firstSecretString(
+  records: Record<string, unknown>[],
+  keys: string[],
+  env: Record<string, string>
+): string | undefined {
+  for (const record of records) {
+    for (const key of keys) {
+      const value = stringFromSecretRef(record[key], env);
+      if (value) return value;
+    }
+  }
+  return undefined;
+}
+
+function envFromConfig(records: Record<string, unknown>[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const record of records) {
+    const env = nestedRecord(record, "env");
+    const vars = env ? nestedRecord(env, "vars") : undefined;
+    for (const source of [env, vars]) {
+      if (!source) continue;
+      for (const [key, value] of Object.entries(source)) {
+        if (typeof value === "string") result[key] = value;
+      }
+    }
+  }
+  return result;
+}
+
+function providerApiKey(
+  provider: Provider | undefined,
+  records: Record<string, unknown>[],
+  env: Record<string, string>
+): string | undefined {
+  if (!provider) return undefined;
+  const section = providerSection(records, provider);
+  const sectionKey = section ? firstSecretString([section], API_KEY_KEYS, env) : undefined;
+  if (sectionKey) return sectionKey;
+  for (const key of PROVIDER_ENV_KEYS[provider]) {
+    if (env[key]) return env[key];
+  }
+  const root = records[0];
+  return root ? firstSecretString([root], API_KEY_KEYS, env) : undefined;
+}
+
 function openclawSettings(
   records: Record<string, unknown>[],
   model: string | undefined
@@ -106,17 +191,23 @@ function openclawSettings(
 
 export function extractProviderSettings(
   raw: unknown,
-  source: SetupImportSourceId
+  source: SetupImportSourceId,
+  context: { env?: Record<string, string> } = {}
 ): SetupImportProviderSettings | undefined {
   const records = collectRecords(raw);
   if (records.length === 0) return undefined;
 
-  const provider = normalizeProvider(firstString(records, PROVIDER_KEYS));
+  const env = { ...envFromConfig(records), ...(context.env ?? {}) };
+  const initialModel = firstString(records, MODEL_KEYS);
+  const provider =
+    normalizeProvider(firstString(records, PROVIDER_KEYS)) ??
+    providerFromModel(initialModel) ??
+    providerFromKnownMap(records);
   const section = providerSection(records, provider);
   const searchable = section ? [section, ...records] : records;
-  const model = firstString(searchable, MODEL_KEYS);
+  const model = firstString(searchable, MODEL_KEYS) ?? initialModel;
   const adapter = normalizeAdapter(firstString(searchable, ADAPTER_KEYS), provider, model);
-  const apiKey = firstString(searchable, API_KEY_KEYS);
+  const apiKey = providerApiKey(provider, searchable, env);
   const baseUrl = firstString(searchable, BASE_URL_KEYS);
   const codexCliPath = firstString(searchable, CLI_PATH_KEYS);
   const openclaw = source === "openclaw" ? openclawSettings(searchable, model) : undefined;

--- a/src/interface/cli/commands/setup/import/telegram.ts
+++ b/src/interface/cli/commands/setup/import/telegram.ts
@@ -1,0 +1,118 @@
+import * as path from "node:path";
+import { SOURCE_LABELS } from "./constants.js";
+import { pathExists, readJson, safeImportName } from "./fs-utils.js";
+import { collectRecords, isRecord, nestedRecord, stringValue } from "./parse.js";
+import type { SetupImportItem, SetupImportSourceId, SetupImportTelegramSettings } from "./types.js";
+
+function secretString(value: unknown, env: Record<string, string>): string | undefined {
+  if (typeof value === "string" && value.trim()) {
+    const match = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/.exec(value.trim());
+    if (match) return env[match[1]!];
+    return value.trim();
+  }
+  if (!isRecord(value)) return undefined;
+  if (value["source"] === "env" && typeof value["id"] === "string") {
+    return env[value["id"]];
+  }
+  return undefined;
+}
+
+function numberArray(value: unknown): number[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const numbers = value.flatMap((item) => {
+    if (typeof item === "number" && Number.isInteger(item)) return [item];
+    if (typeof item === "string") {
+      const parsed = parseInt(item, 10);
+      return Number.isInteger(parsed) ? [parsed] : [];
+    }
+    return [];
+  });
+  return numbers.length > 0 ? numbers : undefined;
+}
+
+function findTelegramRecord(records: Record<string, unknown>[]): Record<string, unknown> | undefined {
+  for (const record of records) {
+    const channels = nestedRecord(record, "channels");
+    const telegram = channels ? nestedRecord(channels, "telegram") : undefined;
+    if (telegram) return telegram;
+
+    const messaging = nestedRecord(record, "messaging");
+    const messagingTelegram = messaging ? nestedRecord(messaging, "telegram") : undefined;
+    if (messagingTelegram) return messagingTelegram;
+  }
+  return undefined;
+}
+
+function findDefaultAccount(record: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  const accounts = record ? nestedRecord(record, "accounts") : undefined;
+  return accounts ? nestedRecord(accounts, "default") : undefined;
+}
+
+export function extractTelegramSettings(
+  raw: unknown,
+  env: Record<string, string>
+): SetupImportTelegramSettings | undefined {
+  const records = collectRecords(raw);
+  if (records.length === 0) return undefined;
+  const telegram = findTelegramRecord(records);
+  const account = findDefaultAccount(telegram);
+  const searchable = [account, telegram].filter((item): item is Record<string, unknown> => Boolean(item));
+  const botToken = searchable
+    .map((record) => secretString(record["botToken"] ?? record["bot_token"] ?? record["token"], env))
+    .find(Boolean);
+  const allowedUserIds = searchable
+    .map((record) => numberArray(record["allowFrom"] ?? record["allowedUserIds"] ?? record["allowed_user_ids"]))
+    .find(Boolean);
+  if (!botToken && !allowedUserIds) return undefined;
+  return {
+    ...(botToken ? { botToken } : {}),
+    ...(allowedUserIds ? { allowedUserIds } : {}),
+  };
+}
+
+export function telegramCredentialItems(
+  source: SetupImportSourceId,
+  rootDir: string
+): SetupImportItem[] {
+  const credentialPaths = [
+    path.join(rootDir, "credentials", "telegram-default-allowFrom.json"),
+  ].filter(pathExists);
+  return credentialPaths.flatMap((credentialPath) => {
+    const raw = readJson(credentialPath);
+    const allowedUserIds = isRecord(raw) ? numberArray(raw["allowFrom"] ?? raw["allowed_user_ids"]) : numberArray(raw);
+    if (!allowedUserIds) return [];
+    return [{
+      id: `${source}:telegram:${safeImportName(path.basename(credentialPath))}`,
+      source,
+      sourceLabel: SOURCE_LABELS[source],
+      kind: "telegram" as const,
+      label: "telegram allowed users",
+      sourcePath: credentialPath,
+      decision: "import" as const,
+      reason: "Telegram allowed user IDs",
+      telegramSettings: { allowedUserIds },
+    }];
+  });
+}
+
+export function buildTelegramItem(
+  source: SetupImportSourceId,
+  configPath: string,
+  settings: SetupImportTelegramSettings
+): SetupImportItem {
+  const label = [
+    settings.botToken ? "bot token" : undefined,
+    settings.allowedUserIds?.length ? `${settings.allowedUserIds.length} allowed user(s)` : undefined,
+  ].filter(Boolean).join(" / ");
+  return {
+    id: `${source}:telegram:${path.basename(configPath)}`,
+    source,
+    sourceLabel: SOURCE_LABELS[source],
+    kind: "telegram",
+    label: label || "telegram settings",
+    sourcePath: configPath,
+    decision: "import",
+    reason: "Telegram bot and allowed-user defaults",
+    telegramSettings: settings,
+  };
+}

--- a/src/interface/cli/commands/setup/import/types.ts
+++ b/src/interface/cli/commands/setup/import/types.ts
@@ -3,7 +3,7 @@ import type { MCPServerConfig } from "../../../../../base/types/mcp.js";
 
 export type SetupImportSourceId = "hermes" | "openclaw";
 
-export type SetupImportItemKind = "provider" | "skill" | "mcp" | "plugin";
+export type SetupImportItemKind = "provider" | "skill" | "mcp" | "plugin" | "telegram";
 
 export type SetupImportDecision = "import" | "copy_disabled" | "skip";
 
@@ -17,6 +17,11 @@ export interface SetupImportProviderSettings {
   openclaw?: ProviderConfig["openclaw"];
 }
 
+export interface SetupImportTelegramSettings {
+  botToken?: string;
+  allowedUserIds?: number[];
+}
+
 export interface SetupImportItem {
   id: string;
   source: SetupImportSourceId;
@@ -27,6 +32,7 @@ export interface SetupImportItem {
   decision: SetupImportDecision;
   reason: string;
   providerSettings?: SetupImportProviderSettings;
+  telegramSettings?: SetupImportTelegramSettings;
   mcpServer?: MCPServerConfig;
 }
 

--- a/src/interface/cli/commands/setup/steps-provider.ts
+++ b/src/interface/cli/commands/setup/steps-provider.ts
@@ -146,20 +146,71 @@ export async function runCodexOAuthLogin(): Promise<string | undefined> {
   return undefined;
 }
 
+function isLikelyCodexOAuthToken(value: string | undefined): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  return trimmed.startsWith("eyJ") && trimmed.split(".").length >= 3;
+}
+
+function requiresOpenAIApiKey(provider: Provider, adapter?: string): boolean {
+  return provider === "openai" && adapter !== "openai_codex_cli";
+}
+
 export async function stepApiKey(
   provider: Provider,
   detectedKeys: Record<string, boolean>,
-  existingApiKey?: string
+  existingApiKey?: string,
+  adapter?: string
 ): Promise<string | undefined> {
   const envKeyName = ENV_KEY_NAMES[provider];
   if (!envKeyName) return undefined;
 
-  if (detectedKeys[provider]) {
-    p.log.info(`Using ${envKeyName} from environment.`);
-    return process.env[envKeyName];
+  if (provider === "openai" && adapter === "openai_codex_cli") {
+    const existingToken = await readCodexOAuthToken();
+    if (existingToken) {
+      p.log.info("Using existing Codex CLI OAuth login. No OpenAI API key will be saved.");
+      return undefined;
+    }
+
+    const authChoice = guardCancel(
+      await p.select({
+        message: "Codex CLI authentication:",
+        options: [
+          {
+            value: "login" as const,
+            label: "Login with OAuth (opens browser via Codex CLI)",
+            hint: "recommended for OpenAI Codex CLI adapter",
+          },
+          {
+            value: "skip" as const,
+            label: "Skip for now",
+            hint: "run `codex login` before using this adapter",
+          },
+        ],
+        initialValue: "login" as const,
+      })
+    );
+
+    if (authChoice === "login") {
+      await runCodexOAuthLogin();
+    }
+    return undefined;
   }
 
-  if (existingApiKey) {
+  if (detectedKeys[provider]) {
+    const envValue = process.env[envKeyName];
+    if (requiresOpenAIApiKey(provider, adapter) && isLikelyCodexOAuthToken(envValue)) {
+      p.log.warn(`${envKeyName} appears to contain a Codex OAuth token, not an OpenAI API key.`);
+    } else {
+      p.log.info(`Using ${envKeyName} from environment.`);
+      return envValue;
+    }
+  }
+
+  const canKeepExisting =
+    existingApiKey && !(requiresOpenAIApiKey(provider, adapter) && isLikelyCodexOAuthToken(existingApiKey));
+
+  if (canKeepExisting) {
     const keyChoice = guardCancel(
       await p.select({
         message: `${envKeyName} is already configured. What should setup do?`,
@@ -178,53 +229,20 @@ export async function stepApiKey(
       })
     );
     if (keyChoice === "keep") return existingApiKey;
-  }
-
-  if (provider === "openai") {
-    const existingToken = await readCodexOAuthToken();
-
-    type OAuthMethod = "login" | "oauth" | "manual";
-    const oauthOptions: p.Option<OAuthMethod>[] = [
-      {
-        value: "login" as const,
-        label: "Login with OAuth (opens browser via Codex CLI)",
-        hint: "runs npx @openai/codex login",
-      },
-    ];
-
-    if (existingToken) {
-      oauthOptions.push({
-        value: "oauth" as const,
-        label: "Use existing OAuth token",
-        hint: "from previous Codex CLI login",
-      });
-    }
-
-    oauthOptions.push({
-      value: "manual" as const,
-      label: "Enter API key manually",
-    });
-
-    const authMethod = guardCancel(
-      await p.select({
-        message: "Select authentication method:",
-        options: oauthOptions,
-      })
-    ) as OAuthMethod;
-
-    if (authMethod === "login") {
-      const token = await runCodexOAuthLogin();
-      if (token) return token;
-      p.log.info("Falling back to manual API key entry.");
-    } else if (authMethod === "oauth" && existingToken) {
-      return existingToken;
-    }
+  } else if (existingApiKey && requiresOpenAIApiKey(provider, adapter)) {
+    p.log.warn("Existing OpenAI auth looks like a Codex OAuth token and cannot be used for the OpenAI API adapter.");
   }
 
   const key = guardCancel(
     await p.password({
       message: `Enter ${envKeyName}:`,
-      validate: (value) => (!value ? "API key is required" : undefined),
+      validate: (value) => {
+        if (!value) return "API key is required";
+        if (requiresOpenAIApiKey(provider, adapter) && isLikelyCodexOAuthToken(value)) {
+          return "Codex OAuth tokens cannot call OpenAI API endpoints. Enter an OpenAI API key instead.";
+        }
+        return undefined;
+      },
     })
   );
   if (!key) {

--- a/src/interface/cli/commands/telegram.ts
+++ b/src/interface/cli/commands/telegram.ts
@@ -2,8 +2,8 @@
 //
 // Guides the user through configuring the Telegram Bot plugin:
 //   1. Bot token (from @BotFather) — verified via getMe API
-//   2. chat_id (number) — instruct user to message the bot and use getUpdates
-//   3. allowed_user_ids (optional, comma-separated)
+//   2. allowed_user_ids (optional, comma-separated)
+//   3. home chat_id (optional) — can be set later by sending /sethome
 //   4. identity_key (optional) — share one PulSeed session across chat platforms
 //
 // Writes config to ~/.pulseed/plugins/telegram-bot/config.json
@@ -126,25 +126,11 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
     }
     console.log(` OK (@${botInfo.username ?? botInfo.first_name})\n`);
 
-    // Step 2: chat_id
-    console.log("Step 2: Chat ID");
-    console.log("  To find your chat_id:");
-    console.log("    1. Send any message to your bot in Telegram.");
-    console.log(`    2. Open: https://api.telegram.org/bot${token}/getUpdates`);
-    console.log('    3. Copy the numeric "id" from result[0].message.chat.id');
-    console.log("    Alternatively, forward a message to @userinfobot.\n");
-
-    const chatIdStr = await ask(rl, "Enter chat_id (number): ");
-    const chatId = parseInt(chatIdStr, 10);
-    if (isNaN(chatId)) {
-      console.error("Error: chat_id must be a number.");
-      return 1;
-    }
-
-    // Step 3: allowed_user_ids (optional)
-    console.log("\nStep 3: Allowed user IDs (optional)");
+    // Step 2: allowed_user_ids (optional)
+    console.log("\nStep 2: Allowed user IDs (recommended)");
     console.log("  Comma-separated Telegram user IDs that may send commands to the bot.");
-    console.log("  Leave empty to allow all users.\n");
+    console.log("  Hermes-style setup uses user IDs for access control instead of requiring chat_id up front.");
+    console.log("  Message @userinfobot if you need your numeric user ID.\n");
 
     const allowedStr = await ask(rl, "Allowed user IDs (e.g. 123456,789012) or press Enter to skip: ");
     const allowedUserIds: number[] = [];
@@ -155,6 +141,22 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
           allowedUserIds.push(n);
         }
       }
+    }
+
+    // Step 3: home chat_id (optional)
+    console.log("\nStep 3: Home chat (optional)");
+    console.log("  Leave empty now, then send /sethome to the bot from Telegram after the plugin is running.");
+    console.log("  Notifications will use that chat.\n");
+
+    const chatIdStr = await ask(rl, "Home chat_id (number) or press Enter to set later with /sethome: ");
+    let chatId: number | undefined;
+    if (chatIdStr) {
+      const parsed = parseInt(chatIdStr, 10);
+      if (isNaN(parsed)) {
+        console.error("Error: chat_id must be a number when provided.");
+        return 1;
+      }
+      chatId = parsed;
     }
 
     // Step 4: identity_key (optional)
@@ -171,9 +173,9 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
 
     const config = {
       bot_token: token,
-      chat_id: chatId,
       allowed_user_ids: allowedUserIds,
       polling_timeout: 30,
+      ...(chatId !== undefined ? { chat_id: chatId } : {}),
       ...(identityKey ? { identity_key: identityKey } : {}),
     };
 
@@ -186,7 +188,7 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
     console.log("\nTelegram Bot setup complete!");
     console.log(`  Config: ${configPath}`);
     console.log(`  Bot:    @${botInfo.username ?? botInfo.first_name}`);
-    console.log(`  Chat:   ${chatId}`);
+    console.log(`  Home:   ${chatId !== undefined ? chatId : "(send /sethome to set later)"}`);
     if (allowedUserIds.length > 0) {
       console.log(`  Allowed users: ${allowedUserIds.join(", ")}`);
     } else {


### PR DESCRIPTION
## Summary

- Move setup-managed provider API keys out of `provider.json` and into `~/.pulseed/.env`, while keeping env/config fallback compatibility.
- Harden Hermes/OpenClaw migration so PulSeed handles YAML configs, env/SecretRef resolution, workspace skills, nested MCP config, Telegram settings, and source selection when both agents are detected.
- Reduce Telegram onboarding friction by making `chat_id` optional, supporting `/sethome`, and importing Telegram bot/allowed-user defaults into the PulSeed Telegram plugin config.

## Why

Hermes has a lower-friction setup flow than OpenClaw largely because it avoids asking for brittle values like Telegram `chat_id` up front and separates secrets from ordinary config. PulSeed setup was still mixing those concerns, and migration could confuse provider API keys with messaging tokens.

## Validation

- `npm test -- --run src/interface/cli/__tests__/setup-import.test.ts src/interface/cli/__tests__/cli-setup-notification.test.ts src/interface/cli/__tests__/telegram-setup.test.ts plugins/telegram-bot/__tests__/telegram-bot-plugin.test.ts`
- `npm run typecheck`
- `npm run build`
- Repeated the same targeted test/typecheck/build flow on the Mac mini test host via `ssh mini` using a temporary synced checkout.
