### PR TITLE
[codex] Improve CLI usability papercuts

### DIFF
--- a/src/interface/cli/__tests__/cli-daemon-start.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-start.test.ts
@@ -16,6 +16,7 @@ const {
   daemonRunnerArgs,
   watchdogArgs,
   notificationDispatcherArgs,
+  cliLoggerMock,
 } = vi.hoisted(() => ({
   buildDepsMock: vi.fn(),
   daemonStartMock: vi.fn().mockResolvedValue(undefined),
@@ -30,6 +31,11 @@ const {
   daemonRunnerArgs: [] as unknown[],
   watchdogArgs: [] as unknown[],
   notificationDispatcherArgs: [] as unknown[],
+  cliLoggerMock: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
 }));
 
 vi.mock("node:os", async (importOriginal) => {
@@ -79,6 +85,10 @@ vi.mock("../../../runtime/logger.js", () => ({
       error: vi.fn(),
     };
   }),
+}));
+
+vi.mock("../cli-logger.js", () => ({
+  getCliLogger: vi.fn(() => cliLoggerMock),
 }));
 
 vi.mock("../../../runtime/event/server.js", () => ({
@@ -161,6 +171,9 @@ describe("cmdStart", () => {
     daemonRunnerArgs.length = 0;
     watchdogArgs.length = 0;
     notificationDispatcherArgs.length = 0;
+    cliLoggerMock.info.mockClear();
+    cliLoggerMock.warn.mockClear();
+    cliLoggerMock.error.mockClear();
     delete process.env.PULSEED_WATCHDOG_CHILD;
     fs.rmSync(mockedHome, { recursive: true, force: true });
     fs.rmSync("/tmp/pulseed-daemon-start-base", { recursive: true, force: true });
@@ -296,6 +309,22 @@ describe("cmdStart", () => {
         startChild: expect.any(Function),
       })
     );
+  });
+
+  it("warns and falls back to defaults when ~/.pulseed/daemon.json is invalid", async () => {
+    fs.mkdirSync(path.join(mockedHome, ".pulseed"), { recursive: true });
+    fs.writeFileSync(path.join(mockedHome, ".pulseed", "daemon.json"), "{not-json", "utf-8");
+
+    await cmdStart(
+      { getBaseDir: vi.fn().mockReturnValue("/tmp/pulseed-daemon-start-base") } as never,
+      {} as never,
+      ["--goal", "goal-1"]
+    );
+
+    expect(cliLoggerMock.warn).toHaveBeenCalledWith(
+      expect.stringContaining("Ignoring invalid daemon config at")
+    );
+    expect(watchdogStartMock).toHaveBeenCalledOnce();
   });
 
   it("allows idle watchdog startup with zero initial goals", async () => {

--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -164,6 +164,8 @@ vi.mock("../../../reporting/reporting-engine.js", async (importOriginal) => {
 
 import { CLIRunner } from "../cli-runner.js";
 import { StateManager } from "../../../base/state/state-manager.js";
+import { ApprovalStore } from "../../../runtime/store/approval-store.js";
+import { ApprovalRecordSchema } from "../../../runtime/store/runtime-schemas.js";
 import { CoreLoop } from "../../../orchestrator/loop/core-loop.js";
 import { GoalNegotiator, EthicsRejectedError } from "../../../orchestrator/goal/goal-negotiator.js";
 import { GoalRefiner } from "../../../orchestrator/goal/goal-refiner.js";
@@ -203,6 +205,21 @@ function makeNegotiationResult(goal: Goal) {
       renegotiation_trigger: null,
     },
   };
+}
+
+function makeApproval(overrides: Record<string, unknown> = {}) {
+  return ApprovalRecordSchema.parse({
+    approval_id: "approval-1",
+    goal_id: "goal-1",
+    request_envelope_id: "msg-1",
+    correlation_id: "corr-1",
+    state: "pending",
+    created_at: 1,
+    expires_at: 2,
+    payload: { prompt: "approve?" },
+    response_channel: "chat",
+    ...overrides,
+  });
 }
 
 // No argv wrapper needed — run() accepts pure subcommand args directly.
@@ -266,6 +283,49 @@ describe("CLIRunner construction", () => {
   });
 });
 
+// ─── Goal argument errors ────────────────────────────────────────────────────
+
+describe("CLIRunner goal argument errors", () => {
+  it("names pulseed run and shows usage when --goal is missing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCLI("run");
+
+    expect(code).toBe(1);
+    const output = errorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("Error: --goal <id> is required for pulseed run.");
+    expect(output).toContain("Usage: pulseed run --goal <id>");
+
+    errorSpy.mockRestore();
+  });
+
+  it("names pulseed status and shows usage when --goal is missing", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCLI("status");
+
+    expect(code).toBe(1);
+    const output = errorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("Error: --goal <id> is required for pulseed status.");
+    expect(output).toContain("Usage: pulseed status --goal <id>");
+
+    errorSpy.mockRestore();
+  });
+
+  it("names pulseed run and shows usage when multiple goals are provided", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCLI("run", "--goal", "goal-a", "--goal", "goal-b");
+
+    expect(code).toBe(1);
+    const output = errorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("Error: only one --goal is supported per pulseed run.");
+    expect(output).toContain("Usage: pulseed run --goal <id>");
+
+    errorSpy.mockRestore();
+  });
+});
+
 // ─── Unknown subcommand ───────────────────────────────────────────────────────
 
 describe("unknown subcommand", async () => {
@@ -307,9 +367,10 @@ describe("unknown subcommand", async () => {
   it("exits with code 0 for --help", async () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const code = await runCLI("--help");
-    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
     expect(code).toBe(0);
     expect(output).toContain("pulseed daemon ping");
+    expect(output).toContain("pulseed approval list");
     consoleSpy.mockRestore();
   });
 
@@ -328,6 +389,115 @@ describe("unknown subcommand", async () => {
     const code = await runCLI("daemon", "ping");
 
     expect(code).toBe(0);
+  });
+});
+
+// ─── `approval list` subcommand ──────────────────────────────────────────────
+
+describe("approval list subcommand", async () => {
+  it("lists pending approvals from runtime storage", async () => {
+    const approvalStore = new ApprovalStore(path.join(tmpDir, "runtime"));
+    await approvalStore.ensureReady();
+    await approvalStore.savePending(
+      makeApproval({
+        approval_id: "approval-pending",
+        goal_id: "goal-pending",
+        expires_at: Date.now() + 3_600_000,
+      })
+    );
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("approval", "list");
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(code).toBe(0);
+    expect(output).toContain("approval-pe...");
+    expect(output).toContain("goal-pending");
+    expect(output).toContain("pending");
+    consoleSpy.mockRestore();
+  });
+
+  it("lists resolved approvals when --resolved is set", async () => {
+    const approvalStore = new ApprovalStore(path.join(tmpDir, "runtime"));
+    await approvalStore.ensureReady();
+    await approvalStore.saveResolved(
+      makeApproval({
+        approval_id: "approval-resolved",
+        goal_id: "goal-resolved",
+        state: "approved",
+        resolved_at: Date.now(),
+        response_channel: "daemon",
+      })
+    );
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("approval", "list", "--resolved");
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(code).toBe(0);
+    expect(output).toContain("approval-re...");
+    expect(output).toContain("goal-resolved");
+    expect(output).toContain("approved");
+    consoleSpy.mockRestore();
+  });
+
+  it("skips malformed approval files without crashing", async () => {
+    const approvalStore = new ApprovalStore(path.join(tmpDir, "runtime"));
+    await approvalStore.ensureReady();
+    await fs.promises.writeFile(
+      path.join(tmpDir, "runtime", "approvals", "pending", "bad.json"),
+      "{not-json",
+      "utf-8"
+    );
+    await approvalStore.savePending(
+      makeApproval({
+        approval_id: "approval-valid",
+        goal_id: "goal-valid",
+        created_at: 10,
+        expires_at: Date.now() + 3_600_000,
+      })
+    );
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const code = await runCLI("approval", "list");
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    const warnings = warnSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(code).toBe(0);
+    expect(output).toContain("approval-valid");
+    expect(output).toContain("goal-valid");
+    expect(output).not.toContain("bad.json");
+    expect(warnings).toContain("Skipped 1 invalid pending approval record(s).");
+    warnSpy.mockRestore();
+    consoleSpy.mockRestore();
+  });
+
+  it("normalizes long and odd approval fields for table output", async () => {
+    const approvalStore = new ApprovalStore(path.join(tmpDir, "runtime"));
+    await approvalStore.ensureReady();
+    await approvalStore.savePending(
+      makeApproval({
+        approval_id: "approval-with-a-very-long-id-and-newline\nsuffix",
+        goal_id: undefined,
+        created_at: 20,
+        expires_at: Date.now() + 3_600_000,
+        response_channel: "chat\nwith\todd whitespace and a very long channel name",
+      })
+    );
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("approval", "list");
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(code).toBe(0);
+    expect(output).toContain("approval-wi...");
+    expect(output).toContain("pending");
+    expect(output).toContain(" - ");
+    expect(output).toContain("chat with odd whitesp...");
+    expect(output).not.toContain("approval-with-a-very-long-id-and-newline\nsuffix");
+    expect(output).not.toContain("chat\nwith");
+    consoleSpy.mockRestore();
   });
 });
 

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -734,7 +734,7 @@ describe("setup notification step", () => {
 
     expect(code).toBe(0);
     expect(logWarnMock).toHaveBeenCalledWith(
-      expect.stringContaining("Could not save notification config: Error: disk full")
+      expect.stringContaining("Setup saved, but could not save notification config: Error: disk full")
     );
   });
 });

--- a/src/interface/cli/__tests__/cli-setup.test.ts
+++ b/src/interface/cli/__tests__/cli-setup.test.ts
@@ -346,6 +346,27 @@ describe("ensureProviderConfig", () => {
     vi.mocked(tty.isatty).mockReset();
   });
 
+  it("does not fall through to defaults when provider.json is missing and interactive setup is required", async () => {
+    vi.mocked(tty.isatty).mockReturnValue(false);
+    const providerConfigMod = await import("../../../base/llm/provider-config.js");
+    const loadSpy = vi.spyOn(providerConfigMod, "loadProviderConfig").mockResolvedValue({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      adapter: "openai_codex_cli",
+      api_key: "sk-default",
+    });
+
+    const { ensureProviderConfig } = await import("../ensure-api-key.js");
+
+    await expect(
+      ensureProviderConfig({ requireInteractiveSetup: true })
+    ).rejects.toThrow(/no provider configuration found/i);
+    expect(loadSpy).not.toHaveBeenCalled();
+
+    loadSpy.mockRestore();
+    vi.mocked(tty.isatty).mockReset();
+  });
+
   it("falls back to loadProviderConfig when provider.json is invalid JSON and setup is not required", async () => {
     await writeConfig("{not-json");
 
@@ -388,6 +409,29 @@ describe("ensureProviderConfig", () => {
     await expect(
       ensureProviderConfig({ requireInteractiveSetup: true })
     ).rejects.toThrow(/invalid json/i);
+    loadSpy.mockRestore();
+    vi.mocked(tty.isatty).mockReset();
+  });
+
+  it("does not fall through to defaults when provider.json is invalid and interactive setup is required", async () => {
+    await writeConfig("{not-json");
+
+    vi.mocked(tty.isatty).mockReturnValue(false);
+    const providerConfigMod = await import("../../../base/llm/provider-config.js");
+    const loadSpy = vi.spyOn(providerConfigMod, "loadProviderConfig").mockResolvedValue({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      adapter: "openai_codex_cli",
+      api_key: "sk-default",
+    });
+
+    const { ensureProviderConfig } = await import("../ensure-api-key.js");
+
+    await expect(
+      ensureProviderConfig({ requireInteractiveSetup: true })
+    ).rejects.toThrow(/invalid json/i);
+    expect(loadSpy).not.toHaveBeenCalled();
+
     loadSpy.mockRestore();
     vi.mocked(tty.isatty).mockReset();
   });

--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -17,6 +17,7 @@ import { cmdStatus, cmdLog, cmdCleanup } from "./commands/goal.js";
 import { dispatchGoalCommand } from "./commands/goal-dispatch.js";
 import { cmdPluginList, cmdPluginInstall, cmdPluginRemove, cmdPluginUpdate, cmdPluginSearch } from "./commands/plugin.js";
 import { cmdReport } from "./commands/report.js";
+import { cmdApprovalList } from "./commands/approval.js";
 import {
   cmdProvider,
   cmdConfigCharacter,
@@ -46,6 +47,14 @@ import { printUsage, formatOperationError } from "./utils.js";
 import { ensureProviderConfig } from "./ensure-api-key.js";
 
 const logger = getCliLogger();
+
+function formatGoalRequiredError(command: string, usage: string): string {
+  return `Error: --goal <id> is required for pulseed ${command}.\nUsage: ${usage}`;
+}
+
+function formatMultiGoalError(command: string, usage: string): string {
+  return `Error: only one --goal is supported per pulseed ${command}. Run separately for each goal, or use --tree for tree traversal.\nUsage: ${usage}`;
+}
 
 /**
  * @description Dispatches a PulSeed CLI subcommand and returns an exit code.
@@ -95,11 +104,11 @@ export async function dispatchCommand(
 
     const goalIds = values.goal ?? [];
     if (goalIds.length === 0) {
-      logger.error("Error: --goal <id> is required for \.");
+      logger.error(formatGoalRequiredError("run", "pulseed run --goal <id> [--max-iterations <n>] [--adapter <type>] [--tree] [--workspace <path>] [--yes]"));
       return 1;
     }
     if (goalIds.length > 1) {
-      logger.error("Error: only one --goal is supported per \. Run separately for each goal, or use --tree for tree traversal.");
+      logger.error(formatMultiGoalError("run", "pulseed run --goal <id> [--max-iterations <n>] [--adapter <type>] [--tree] [--workspace <path>] [--yes]"));
       return 1;
     }
     const goalId = goalIds[0];
@@ -189,7 +198,7 @@ export async function dispatchCommand(
 
     const goalId = values.goal;
     if (!goalId || typeof goalId !== "string") {
-      logger.error("Error: --goal <id> is required for \.");
+      logger.error(formatGoalRequiredError("status", "pulseed status --goal <id>"));
       return 1;
     }
 
@@ -222,6 +231,23 @@ export async function dispatchCommand(
     }
 
     return cmdReport(stateManager, goalId);
+  }
+
+  if (subcommand === "approval") {
+    const approvalSubcommand = argv[1];
+
+    if (!approvalSubcommand) {
+      logger.error("Error: approval subcommand required. Available: approval list");
+      return 1;
+    }
+
+    if (approvalSubcommand === "list") {
+      return await cmdApprovalList(stateManager, argv.slice(2));
+    }
+
+    logger.error(`Unknown approval subcommand: "${approvalSubcommand}"`);
+    logger.error("Available: approval list");
+    return 1;
   }
 
   if (subcommand === "log") {

--- a/src/interface/cli/commands/approval.ts
+++ b/src/interface/cli/commands/approval.ts
@@ -1,0 +1,138 @@
+// ─── pulseed approval commands (read-only) ───
+
+import * as path from "node:path";
+import * as fsp from "node:fs/promises";
+import { parseArgs } from "node:util";
+
+import { StateManager } from "../../../base/state/state-manager.js";
+import { ApprovalStore } from "../../../runtime/store/approval-store.js";
+import { ApprovalRecordSchema, type ApprovalRecord } from "../../../runtime/store/runtime-schemas.js";
+import { createRuntimeStorePaths, type RuntimeStorePaths } from "../../../runtime/store/runtime-paths.js";
+import { getCliLogger } from "../cli-logger.js";
+import { formatOperationError } from "../utils.js";
+
+function createApprovalContext(stateManager: StateManager): {
+  approvalStore: ApprovalStore;
+  paths: RuntimeStorePaths;
+} {
+  const runtimeRoot = path.join(stateManager.getBaseDir(), "runtime");
+  const paths = createRuntimeStorePaths(runtimeRoot);
+  return { approvalStore: new ApprovalStore(paths), paths };
+}
+
+const ID_WIDTH = 14;
+const GOAL_WIDTH = 14;
+const STATE_WIDTH = 12;
+const DATE_WIDTH = 24;
+const CHANNEL_WIDTH = 24;
+
+function formatCell(value: string | undefined, maxLen: number): string {
+  const normalized = (value ?? "-").replace(/\s+/g, " ").trim() || "-";
+  return normalized.length > maxLen ? `${normalized.slice(0, maxLen - 3)}...` : normalized;
+}
+
+function dateLabel(value?: number): string {
+  return value === undefined ? "-" : new Date(value).toISOString();
+}
+
+async function countInvalidApprovalFiles(dirPath: string): Promise<number> {
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dirPath);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw err;
+  }
+
+  let invalid = 0;
+  for (const fileName of entries.filter((entry) => entry.endsWith(".json"))) {
+    try {
+      const raw = JSON.parse(await fsp.readFile(path.join(dirPath, fileName), "utf-8")) as unknown;
+      if (!ApprovalRecordSchema.safeParse(raw).success) {
+        invalid += 1;
+      }
+    } catch {
+      invalid += 1;
+    }
+  }
+  return invalid;
+}
+
+function printApprovalRows(records: ApprovalRecord[], showResolved: boolean): void {
+  if (showResolved) {
+    console.log(
+      `${"ID".padEnd(ID_WIDTH)} ${"GOAL".padEnd(GOAL_WIDTH)} ${"STATE".padEnd(STATE_WIDTH)} ${"CREATED".padEnd(DATE_WIDTH)} ${"RESOLVED".padEnd(DATE_WIDTH)} CHANNEL`
+    );
+    console.log("-".repeat(100));
+    for (const record of records) {
+      console.log(
+        `${formatCell(record.approval_id, ID_WIDTH).padEnd(ID_WIDTH)} ${formatCell(record.goal_id, GOAL_WIDTH).padEnd(GOAL_WIDTH)} ${record.state.padEnd(STATE_WIDTH)} ${dateLabel(record.created_at).padEnd(DATE_WIDTH)} ${dateLabel(record.resolved_at).padEnd(DATE_WIDTH)} ${formatCell(record.response_channel, CHANNEL_WIDTH)}`
+      );
+    }
+    return;
+  }
+
+  console.log(
+    `${"ID".padEnd(ID_WIDTH)} ${"GOAL".padEnd(GOAL_WIDTH)} ${"STATE".padEnd(STATE_WIDTH)} ${"CREATED".padEnd(DATE_WIDTH)} ${"EXPIRES".padEnd(DATE_WIDTH)} CHANNEL`
+  );
+  console.log("-".repeat(100));
+  for (const record of records) {
+    console.log(
+      `${formatCell(record.approval_id, ID_WIDTH).padEnd(ID_WIDTH)} ${formatCell(record.goal_id, GOAL_WIDTH).padEnd(GOAL_WIDTH)} ${record.state.padEnd(STATE_WIDTH)} ${dateLabel(record.created_at).padEnd(DATE_WIDTH)} ${dateLabel(record.expires_at).padEnd(DATE_WIDTH)} ${formatCell(record.response_channel, CHANNEL_WIDTH)}`
+    );
+  }
+}
+
+export async function cmdApprovalList(stateManager: StateManager, args: string[]): Promise<number> {
+  const logger = getCliLogger();
+  let values: { resolved?: boolean };
+
+  try {
+    ({ values } = parseArgs({
+      args,
+      options: {
+        resolved: { type: "boolean" },
+      },
+      strict: false,
+    }) as { values: { resolved?: boolean } });
+  } catch (err) {
+    logger.error(formatOperationError("parse approval list arguments", err));
+    values = {};
+  }
+
+  const showResolved = values.resolved === true;
+  const { approvalStore, paths } = createApprovalContext(stateManager);
+
+  let approvals: ApprovalRecord[];
+  let invalidCount = 0;
+  try {
+    approvals = showResolved ? await approvalStore.listResolved() : await approvalStore.listPending();
+    invalidCount = await countInvalidApprovalFiles(
+      showResolved ? paths.approvalsResolvedDir : paths.approvalsPendingDir
+    );
+  } catch (err) {
+    logger.error(formatOperationError("load approval records", err));
+    return 1;
+  }
+
+  if (invalidCount > 0) {
+    logger.warn(`Skipped ${invalidCount} invalid ${showResolved ? "resolved" : "pending"} approval record(s).`);
+  }
+
+  const label = showResolved ? "resolved" : "pending";
+  if (approvals.length === 0) {
+    console.log(`No ${label} approvals found.`);
+    return 0;
+  }
+
+  const sorted = [...approvals].sort((a, b) => {
+    if (a.created_at !== b.created_at) return b.created_at - a.created_at;
+    return a.approval_id.localeCompare(b.approval_id);
+  });
+
+  console.log(`${showResolved ? "Resolved" : "Pending"} approvals:\n`);
+  printApprovalRows(sorted, showResolved);
+  console.log(`\nTotal: ${sorted.length} approval(s)`);
+
+  return 0;
+}

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -56,11 +56,29 @@ function formatGoalMode(goalIds: string[]): string {
 async function loadDaemonConfig(baseDir: string): Promise<DaemonConfig> {
   const configPath = path.join(baseDir, "daemon.json");
   const legacyConfigPath = path.join(baseDir, "daemon-config.json");
-  const configRaw =
-    (await readJsonFileOrNull(configPath)) ??
-    (await readJsonFileOrNull(legacyConfigPath));
-  const configParsed = configRaw !== null ? DaemonConfigSchema.safeParse(configRaw) : null;
-  return configParsed?.success ? configParsed.data : DaemonConfigSchema.parse({});
+
+  function readDaemonConfigFile(filePath: string): DaemonConfig | null {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+
+    try {
+      const raw = JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
+      const configParsed = DaemonConfigSchema.safeParse(raw);
+      if (configParsed.success) {
+        return configParsed.data;
+      }
+      getCliLogger().warn(`Ignoring invalid daemon config at ${filePath}; using defaults.`);
+    } catch (err) {
+      getCliLogger().warn(
+        `Ignoring invalid daemon config at ${filePath}; using defaults. ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    return null;
+  }
+
+  return readDaemonConfigFile(configPath) ?? readDaemonConfigFile(legacyConfigPath) ?? DaemonConfigSchema.parse({});
 }
 
 export async function cmdStart(
@@ -115,8 +133,10 @@ export async function cmdStart(
       try {
         const raw = JSON.parse(fs.readFileSync(defaultDaemonConfigPath, 'utf-8'));
         daemonConfig = DaemonConfigSchema.parse(raw);
-      } catch {
-        // Ignore invalid daemon.json, use defaults
+      } catch (err) {
+        getCliLogger().warn(
+          `Ignoring invalid daemon config at ${defaultDaemonConfigPath}; using defaults. ${err instanceof Error ? err.message : String(err)}`
+        );
       }
     }
   }
@@ -747,7 +767,9 @@ export async function cmdCron(args: string[]): Promise<void> {
   const intervalMinutes = parseInt(values.interval as string, 10) || 60;
 
   if (goalIds.length === 0) {
-    getCliLogger().error("Error: at least one --goal is required");
+    getCliLogger().error(
+      "Error: at least one --goal is required for pulseed cron.\nUsage: pulseed cron --goal <id> [--goal <id> ...]"
+    );
     process.exit(1);
   }
 

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -401,7 +401,7 @@ export async function runSetupWizard(): Promise<number> {
       existing["event_server_port"] = finalAnswers.daemonPort;
       fs.writeFileSync(daemonConfigPath, JSON.stringify(existing, null, 2), "utf-8");
     } catch {
-      p.log.warn("Could not save daemon port to daemon.json");
+      p.log.warn("Setup saved, but could not save daemon port to daemon.json");
     }
     p.log.info("Daemon port " + finalAnswers.daemonPort + " saved. Start it later with pulseed daemon start or pulseed start --goal <goal-id>.");
   }
@@ -412,7 +412,7 @@ export async function runSetupWizard(): Promise<number> {
       fs.mkdirSync(dir, { recursive: true });
       fs.writeFileSync(notifPath, JSON.stringify(finalAnswers.notificationConfig, null, 2));
     } catch (err) {
-      p.log.warn(`Could not save notification config: ${err}`);
+      p.log.warn(`Setup saved, but could not save notification config: ${err}`);
     }
   }
 
@@ -426,7 +426,7 @@ export async function runSetupWizard(): Promise<number> {
           (failedCount > 0 ? ` (${failedCount} failed; see import report).` : ".")
       );
     } catch (err) {
-      p.log.warn(`Configuration saved, but import side effects failed: ${err instanceof Error ? err.message : String(err)}`);
+      p.log.warn(`Setup saved, but import side effects failed: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 
@@ -436,7 +436,7 @@ export async function runSetupWizard(): Promise<number> {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       p.log.warn(
-        `Configuration saved, but daemon/gateway did not start: ${message}. ` +
+        `Setup saved, but daemon/gateway did not start: ${message}. ` +
           "Run `pulseed daemon start --detach` to try again."
       );
     }

--- a/src/interface/cli/ensure-api-key.ts
+++ b/src/interface/cli/ensure-api-key.ts
@@ -68,7 +68,9 @@ export interface EnsureProviderConfigOptions {
  * the configured provider. Throws if a required key is missing.
  *
  * If no ~/.pulseed/provider.json exists and stdin is a TTY, automatically
- * runs the interactive setup wizard. If not a TTY, uses defaults silently.
+ * runs the interactive setup wizard. If requireInteractiveSetup is set, the
+ * helper throws for missing or invalid config on non-TTY input instead of
+ * falling through to defaults.
  *
  * Ollama provider is not checked here — it needs no API key.
  * OpenAI provider is validated by buildLLMClient() when the client is constructed.
@@ -84,22 +86,28 @@ export async function ensureProviderConfig(
   const configState = await inspectProviderConfig(configPath);
   const stdinIsTty = tty.isatty(0);
 
-  if (!configState.exists) {
-    if (stdinIsTty) {
-      await runSetupWizardOrThrow(
-        "No provider configuration found. Starting setup wizard...\n"
-      );
-    } else if (options.requireInteractiveSetup) {
-      throw new Error(formatMissingConfigError(configPath));
+  if (options.requireInteractiveSetup) {
+    if (!configState.exists) {
+      if (stdinIsTty) {
+        await runSetupWizardOrThrow(
+          "No provider configuration found. Starting setup wizard...\n"
+        );
+      } else {
+        throw new Error(formatMissingConfigError(configPath));
+      }
+    } else if (!configState.validJson) {
+      if (stdinIsTty) {
+        await runSetupWizardOrThrow(
+          "Provider configuration is invalid. Starting setup wizard...\n"
+        );
+      } else {
+        throw new Error(formatInvalidConfigError(configPath));
+      }
     }
-  } else if (!configState.validJson && options.requireInteractiveSetup) {
-    if (stdinIsTty) {
-      await runSetupWizardOrThrow(
-        "Provider configuration is invalid. Starting setup wizard...\n"
-      );
-    } else {
-      throw new Error(formatInvalidConfigError(configPath));
-    }
+  } else if (!configState.exists && stdinIsTty) {
+    await runSetupWizardOrThrow(
+      "No provider configuration found. Starting setup wizard...\n"
+    );
   }
 
   const config = await loadProviderConfig();

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -41,6 +41,7 @@ Usage:
   pulseed cleanup                      Archive all completed goals and remove stale data
   pulseed status --goal <id>           Show current status and progress
   pulseed report --goal <id>           Show latest report
+  pulseed approval list [--resolved]   List pending durable approvals
   pulseed log --goal <id>              View observation and gap history log
   pulseed tui                          Launch the interactive TUI
   pulseed start --goal <id>            Start daemon mode for one or more goals

--- a/tests/e2e/cli-binary-e2e.test.ts
+++ b/tests/e2e/cli-binary-e2e.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { promisify } from "node:util";
+import { makeTempDir } from "../helpers/temp-dir.js";
+
+const execFileAsync = promisify(execFile);
+const RUN_BINARY_E2E = process.env["PULSEED_RUN_BINARY_E2E"] === "1";
+const CLI_PATH = path.resolve(process.cwd(), "dist", "interface", "cli", "cli-runner.js");
+
+async function runBuiltCli(args: string[], pulseedHome: string): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  try {
+    const result = await execFileAsync(process.execPath, [CLI_PATH, ...args], {
+      env: {
+        ...process.env,
+        PULSEED_HOME: pulseedHome,
+        NO_COLOR: "1",
+      },
+      timeout: 10_000,
+    });
+    return { exitCode: 0, stdout: result.stdout, stderr: result.stderr };
+  } catch (err) {
+    const error = err as Error & {
+      code?: number;
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+    };
+    return {
+      exitCode: typeof error.code === "number" ? error.code : 1,
+      stdout: String(error.stdout ?? ""),
+      stderr: String(error.stderr ?? ""),
+    };
+  }
+}
+
+describe.skipIf(!RUN_BINARY_E2E)("built CLI binary", () => {
+  let tmpDir: string | null = null;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+      tmpDir = null;
+    }
+  });
+
+  it("prints actionable stderr for missing run goal", async () => {
+    expect(fs.existsSync(CLI_PATH), `Build first with \`npm run build\`; missing ${CLI_PATH}`).toBe(true);
+    tmpDir = makeTempDir("pulseed-cli-binary-");
+
+    const result = await runBuiltCli(["run"], tmpDir);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("Error: --goal <id> is required for pulseed run.");
+    expect(result.stderr).toContain("Usage: pulseed run --goal <id>");
+    expect(result.stderr).not.toContain("required for \\.");
+  });
+});


### PR DESCRIPTION
## Summary
- Improve CLI goal-argument errors so `run`, `status`, and `cron` name the command and print actionable usage.
- Add read-only `pulseed approval list [--resolved]` for durable approval records, with invalid-record warnings and safer table formatting for long or odd fields.
- Surface invalid daemon config and setup partial-failure warnings instead of silently falling back or hiding partial success.
- Add focused CLI tests plus an opt-in built-binary stderr e2e check.

## Validation
- `npx vitest run src/interface/cli/__tests__/cli-runner.test.ts src/interface/cli/__tests__/cli-daemon-start.test.ts src/interface/cli/__tests__/cli-setup.test.ts`
- `npm run typecheck`
- `npm run build`
- `PULSEED_RUN_BINARY_E2E=1 npx vitest run tests/e2e/cli-binary-e2e.test.ts`

## Notes
- The built CLI e2e is gated behind `PULSEED_RUN_BINARY_E2E=1` because it requires the build artifact under `dist/`.
