### PR TITLE
Make archiveGoal crash-resilient

### DIFF
--- a/src/base/state/__tests__/state-manager.test.ts
+++ b/src/base/state/__tests__/state-manager.test.ts
@@ -1296,6 +1296,27 @@ describe("StateManager", async () => {
       expect(loaded!.title).toBe("Archived Goal");
     });
 
+    it("loadGoal prefers a committed archive over stale active state", async () => {
+      const goalId = "committed-archive-wins";
+      const activeGoal = makeGoal({ id: goalId, title: "Active Goal" });
+      const archivedGoal = makeGoal({ id: goalId, title: "Archived Goal", status: "archived" });
+
+      await manager.saveGoal(activeGoal);
+
+      const archiveBase = path.join(tmpDir, "archive", goalId);
+      fs.mkdirSync(path.join(archiveBase, "goal"), { recursive: true });
+      fs.writeFileSync(path.join(archiveBase, "goal", "goal.json"), JSON.stringify(archivedGoal));
+      fs.writeFileSync(path.join(archiveBase, ".archive-complete.json"), JSON.stringify({
+        goalId,
+        completed_at: new Date().toISOString(),
+      }));
+
+      const loaded = await manager.loadGoal(goalId);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.title).toBe("Archived Goal");
+      expect(loaded!.status).toBe("archived");
+    });
+
     it("loadGoal returns null for a goal that was never saved nor archived", async () => {
       expect(await manager.loadGoal("never-existed")).toBeNull();
     });

--- a/src/base/state/__tests__/state-manager.test.ts
+++ b/src/base/state/__tests__/state-manager.test.ts
@@ -26,6 +26,7 @@ describe("StateManager", async () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
@@ -960,6 +961,12 @@ describe("StateManager", async () => {
   });
 
   describe("archiveGoal", async () => {
+    const createFreshManager = async () => {
+      const freshManager = new StateManager(tmpDir);
+      await freshManager.init();
+      return freshManager;
+    };
+
     it("archives a completed goal — moves all state files", async () => {
       const goalId = "archive-full";
       const goal = makeGoal({ id: goalId });
@@ -1012,6 +1019,186 @@ describe("StateManager", async () => {
       expect(fs.existsSync(reportsDir)).toBe(false);
     });
 
+    it("retries cleanly when the final rename fails before commit", async () => {
+      const goalId = "archive-retry-rename";
+      const goal = makeGoal({ id: goalId });
+      await manager.saveGoal(goal);
+
+      const tasksDir = path.join(tmpDir, "tasks", goalId);
+      fs.mkdirSync(tasksDir, { recursive: true });
+      fs.writeFileSync(path.join(tasksDir, "task.json"), JSON.stringify({ id: "t1" }));
+
+      const strategiesDir = path.join(tmpDir, "strategies", goalId);
+      fs.mkdirSync(strategiesDir, { recursive: true });
+      fs.writeFileSync(path.join(strategiesDir, "strategy.json"), JSON.stringify({ id: "s1" }));
+
+      const stallsDir = path.join(tmpDir, "stalls");
+      fs.mkdirSync(stallsDir, { recursive: true });
+      fs.writeFileSync(path.join(stallsDir, `${goalId}.json`), JSON.stringify({ stall: true }));
+
+      const reportsDir = path.join(tmpDir, "reports", goalId);
+      fs.mkdirSync(reportsDir, { recursive: true });
+      fs.writeFileSync(path.join(reportsDir, "report.json"), JSON.stringify({ report: 1 }));
+
+      const archiveBase = path.join(tmpDir, "archive", goalId);
+      const stagingBase = path.join(tmpDir, "archive", ".staging", goalId);
+      const commitArchiveGoal = manager as unknown as { commitArchiveGoal: (staging: string, archive: string) => Promise<void> };
+      const originalCommit = commitArchiveGoal.commitArchiveGoal.bind(manager);
+      commitArchiveGoal.commitArchiveGoal = async (staging, archive) => {
+        if (staging === stagingBase && archive === archiveBase) {
+          throw new Error("commit failed before final rename");
+        }
+        return originalCommit(staging, archive);
+      };
+
+      await expect(manager.archiveGoal(goalId)).rejects.toThrow("commit failed before final rename");
+
+      expect(fs.existsSync(archiveBase)).toBe(false);
+      expect(fs.existsSync(stagingBase)).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, "goals", goalId))).toBe(true);
+
+      commitArchiveGoal.commitArchiveGoal = originalCommit;
+
+      const retryManager = await createFreshManager();
+      await expect(retryManager.archiveGoal(goalId)).resolves.toBe(true);
+
+      expect(fs.existsSync(path.join(archiveBase, "goal", "goal.json"))).toBe(true);
+      expect(fs.existsSync(path.join(archiveBase, "tasks", "task.json"))).toBe(true);
+      expect(fs.existsSync(path.join(archiveBase, "strategies", "strategy.json"))).toBe(true);
+      expect(fs.existsSync(path.join(archiveBase, "stalls.json"))).toBe(true);
+      expect(fs.existsSync(path.join(archiveBase, "reports", "report.json"))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, "archive", ".staging", goalId))).toBe(false);
+      expect(fs.existsSync(path.join(tmpDir, "goals", goalId))).toBe(false);
+      expect(fs.existsSync(tasksDir)).toBe(false);
+      expect(fs.existsSync(strategiesDir)).toBe(false);
+      expect(fs.existsSync(path.join(stallsDir, `${goalId}.json`))).toBe(false);
+      expect(fs.existsSync(reportsDir)).toBe(false);
+      expect(await retryManager.loadGoal(goalId)).not.toBeNull();
+      expect((await retryManager.loadGoal(goalId))?.status).toBe("archived");
+    });
+
+    it("retries cleanly when active cleanup fails after commit", async () => {
+      const goalId = "archive-retry-cleanup";
+      const goal = makeGoal({ id: goalId });
+      await manager.saveGoal(goal);
+
+      const tasksDir = path.join(tmpDir, "tasks", goalId);
+      fs.mkdirSync(tasksDir, { recursive: true });
+      fs.writeFileSync(path.join(tasksDir, "task.json"), JSON.stringify({ id: "t1" }));
+
+      const archiveBase = path.join(tmpDir, "archive", goalId);
+      const stagingBase = path.join(tmpDir, "archive", ".staging", goalId);
+      const activeGoalDir = path.join(tmpDir, "goals", goalId);
+      const cleanupActiveGoalState = manager as unknown as { cleanupActiveGoalState: (goal: string) => Promise<void> };
+      const originalCleanup = cleanupActiveGoalState.cleanupActiveGoalState.bind(manager);
+      cleanupActiveGoalState.cleanupActiveGoalState = async (goal) => {
+        if (goal === goalId) {
+          throw new Error("cleanup failed after commit");
+        }
+        return originalCleanup(goal);
+      };
+
+      await expect(manager.archiveGoal(goalId)).rejects.toThrow("cleanup failed after commit");
+
+      expect(fs.existsSync(archiveBase)).toBe(true);
+      expect(fs.existsSync(path.join(archiveBase, "goal", "goal.json"))).toBe(true);
+      expect(fs.existsSync(stagingBase)).toBe(false);
+      expect(fs.existsSync(activeGoalDir)).toBe(true);
+      expect(fs.existsSync(tasksDir)).toBe(true);
+
+      cleanupActiveGoalState.cleanupActiveGoalState = originalCleanup;
+
+      const retryManager = await createFreshManager();
+      await expect(retryManager.archiveGoal(goalId)).resolves.toBe(true);
+
+      expect(fs.existsSync(path.join(archiveBase, "goal", "goal.json"))).toBe(true);
+      expect(fs.existsSync(stagingBase)).toBe(false);
+      expect(fs.existsSync(activeGoalDir)).toBe(false);
+      expect(fs.existsSync(tasksDir)).toBe(false);
+      expect(await retryManager.loadGoal(goalId)).not.toBeNull();
+      expect((await retryManager.loadGoal(goalId))?.status).toBe("archived");
+    });
+
+    it("does not rebuild a committed archive from partial active remnants", async () => {
+      const goalId = "archive-committed-source-of-truth";
+      const archiveBase = path.join(tmpDir, "archive", goalId);
+      fs.mkdirSync(path.join(archiveBase, "goal"), { recursive: true });
+      fs.mkdirSync(path.join(archiveBase, "tasks"), { recursive: true });
+      fs.writeFileSync(path.join(archiveBase, "goal", "goal.json"), JSON.stringify({ ...makeGoal({ id: goalId }), status: "archived" }));
+      fs.writeFileSync(path.join(archiveBase, "tasks", "task.json"), JSON.stringify({ id: "archived-task" }));
+      fs.writeFileSync(path.join(archiveBase, ".archive-complete.json"), JSON.stringify({ goalId, completed_at: new Date().toISOString() }));
+
+      await manager.saveGoal(makeGoal({ id: goalId, title: "leftover active goal" }));
+
+      expect(await manager.listArchivedGoals()).toContain(goalId);
+
+      const retryManager = await createFreshManager();
+      await expect(retryManager.archiveGoal(goalId)).resolves.toBe(true);
+
+      expect(fs.existsSync(path.join(archiveBase, "tasks", "task.json"))).toBe(true);
+      expect(JSON.parse(fs.readFileSync(path.join(archiveBase, "tasks", "task.json"), "utf-8"))).toEqual({ id: "archived-task" });
+      expect(fs.existsSync(path.join(tmpDir, "goals", goalId))).toBe(false);
+      expect(await retryManager.listArchivedGoals()).toContain(goalId);
+    });
+
+    it("rebuilds an incomplete visible archive from active state before cleanup", async () => {
+      const goalId = "archive-rebuild-visible-partial";
+      await manager.saveGoal(makeGoal({ id: goalId }));
+
+      const tasksDir = path.join(tmpDir, "tasks", goalId);
+      fs.mkdirSync(tasksDir, { recursive: true });
+      fs.writeFileSync(path.join(tasksDir, "task.json"), JSON.stringify({ id: "t1" }));
+
+      const archiveBase = path.join(tmpDir, "archive", goalId);
+      fs.mkdirSync(archiveBase, { recursive: true });
+      fs.writeFileSync(path.join(archiveBase, "partial.json"), JSON.stringify({ incomplete: true }));
+
+      expect(await manager.listArchivedGoals()).not.toContain(goalId);
+
+      const retryManager = await createFreshManager();
+      await expect(retryManager.archiveGoal(goalId)).resolves.toBe(true);
+
+      expect(fs.existsSync(path.join(archiveBase, "partial.json"))).toBe(false);
+      expect(fs.existsSync(path.join(archiveBase, "goal", "goal.json"))).toBe(true);
+      expect(fs.existsSync(path.join(archiveBase, "tasks", "task.json"))).toBe(true);
+      expect(fs.existsSync(path.join(tmpDir, "archive", ".staging", goalId))).toBe(false);
+      expect(fs.existsSync(path.join(tmpDir, "goals", goalId))).toBe(false);
+      expect(fs.existsSync(tasksDir)).toBe(false);
+      expect(await retryManager.listArchivedGoals()).toContain(goalId);
+    });
+
+    it("does not list committed archives until active remnants are cleaned up", async () => {
+      const goalId = "archive-remnants-hidden";
+      const archiveBase = path.join(tmpDir, "archive", goalId);
+      fs.mkdirSync(path.join(archiveBase, "goal"), { recursive: true });
+      fs.writeFileSync(path.join(archiveBase, "goal", "goal.json"), JSON.stringify({ ...makeGoal({ id: goalId }), status: "archived" }));
+
+      const tasksDir = path.join(tmpDir, "tasks", goalId);
+      fs.mkdirSync(tasksDir, { recursive: true });
+      fs.writeFileSync(path.join(tasksDir, "task.json"), JSON.stringify({ id: "t1" }));
+
+      expect(await manager.listArchivedGoals()).not.toContain(goalId);
+
+      const retryManager = await createFreshManager();
+      await expect(retryManager.archiveGoal(goalId)).resolves.toBe(true);
+
+      expect(fs.existsSync(path.join(archiveBase, "tasks", "task.json"))).toBe(true);
+      expect(fs.existsSync(tasksDir)).toBe(false);
+      expect(await retryManager.listArchivedGoals()).toContain(goalId);
+    });
+
+    it("finalizes an unmarked legacy archive when no active state remains", async () => {
+      const goalId = "archive-unmarked-legacy";
+      const archiveBase = path.join(tmpDir, "archive", goalId);
+      fs.mkdirSync(path.join(archiveBase, "goal"), { recursive: true });
+      fs.writeFileSync(path.join(archiveBase, "goal", "goal.json"), JSON.stringify({ ...makeGoal({ id: goalId }), status: "archived" }));
+
+      expect(await manager.listArchivedGoals()).not.toContain(goalId);
+      await expect(manager.archiveGoal(goalId)).resolves.toBe(true);
+      expect(fs.existsSync(path.join(archiveBase, ".archive-complete.json"))).toBe(true);
+      expect(await manager.listArchivedGoals()).toContain(goalId);
+    });
+
     it("serializes concurrent archiveGoal calls on the same goal", async () => {
       const goalId = "archive-locked";
       await manager.saveGoal(makeGoal({ id: goalId }));
@@ -1042,7 +1229,8 @@ describe("StateManager", async () => {
       releaseFence();
 
       await expect(first).resolves.toBe(true);
-      await expect(second).resolves.toBe(false);
+      await expect(second).resolves.toBe(true);
+      expect(fenceCalls).toBe(2);
 
       const archiveBase = path.join(tmpDir, "archive", goalId);
       expect(fs.existsSync(path.join(archiveBase, "goal", "goal.json"))).toBe(true);

--- a/src/base/state/state-manager.ts
+++ b/src/base/state/state-manager.ts
@@ -304,14 +304,26 @@ export class StateManager {
   }
 
   async loadGoal(goalId: string): Promise<Goal | null> {
+    const archiveBase = this.archiveGoalDir(goalId);
+    const archiveCompleteMarkerExists = await this.pathExists(this.archiveCompleteMarkerPath(archiveBase));
+    const archiveGoalPath = this.goalStorageLocation(goalId, "archive").goalJsonPath;
+    const archiveGoalExists = await this.pathExists(archiveGoalPath);
+
+    // Committed archive wins over stale active state after crash cleanup.
+    if (archiveCompleteMarkerExists && archiveGoalExists) {
+      const archiveRaw = await this.atomicRead<unknown>(archiveGoalPath);
+      if (archiveRaw !== null) return GoalSchema.parse(archiveRaw);
+    }
+
     // Primary path: active goals
     const filePath = path.join(this.baseDir, "goals", goalId, "goal.json");
     const raw = await this.atomicRead<unknown>(filePath);
     if (raw !== null) return GoalSchema.parse(raw);
 
     // Fallback: archived goals (archiveGoal() copies goal dir to archive/<goalId>/goal/)
-    const archivePath = path.join(this.baseDir, "archive", goalId, "goal", "goal.json");
-    const archiveRaw = await this.atomicRead<unknown>(archivePath);
+    if (!archiveGoalExists) return null;
+
+    const archiveRaw = await this.atomicRead<unknown>(archiveGoalPath);
     if (archiveRaw === null) return null;
     return GoalSchema.parse(archiveRaw);
   }

--- a/src/base/state/state-manager.ts
+++ b/src/base/state/state-manager.ts
@@ -148,6 +148,66 @@ export class StateManager {
     return { kind, dir, goalJsonPath: path.join(dir, "goal", "goal.json") };
   }
 
+  private archiveGoalDir(goalId: string): string {
+    return path.join(this.baseDir, "archive", goalId);
+  }
+
+  private archiveGoalStagingDir(goalId: string): string {
+    return path.join(this.baseDir, "archive", ".staging", goalId);
+  }
+
+  private archiveCompleteMarkerPath(archiveBase: string): string {
+    return path.join(archiveBase, ".archive-complete.json");
+  }
+
+  private async cleanupActiveGoalState(goalId: string): Promise<void> {
+    await fsp.rm(path.join(this.baseDir, "goals", goalId), { recursive: true, force: true });
+    await fsp.rm(path.join(this.baseDir, "tasks", goalId), { recursive: true, force: true });
+    await fsp.rm(path.join(this.baseDir, "strategies", goalId), { recursive: true, force: true });
+    await fsp.rm(path.join(this.baseDir, "stalls", `${goalId}.json`), { force: true });
+    await fsp.rm(path.join(this.baseDir, "reports", goalId), { recursive: true, force: true });
+  }
+
+  private async hasActiveGoalState(goalId: string): Promise<boolean> {
+    const activePaths = [
+      path.join(this.baseDir, "goals", goalId),
+      path.join(this.baseDir, "tasks", goalId),
+      path.join(this.baseDir, "strategies", goalId),
+      path.join(this.baseDir, "stalls", `${goalId}.json`),
+      path.join(this.baseDir, "reports", goalId),
+    ];
+    for (const activePath of activePaths) {
+      if (await this.pathExists(activePath)) return true;
+    }
+    return false;
+  }
+
+  private async copyActiveArchiveRemnants(goalId: string, archiveBase: string): Promise<void> {
+    const tasksDir = path.join(this.baseDir, "tasks", goalId);
+    if (await this.pathExists(tasksDir)) {
+      await fsp.cp(tasksDir, path.join(archiveBase, "tasks"), { recursive: true });
+    }
+
+    const strategiesDir = path.join(this.baseDir, "strategies", goalId);
+    if (await this.pathExists(strategiesDir)) {
+      await fsp.cp(strategiesDir, path.join(archiveBase, "strategies"), { recursive: true });
+    }
+
+    const stallsFile = path.join(this.baseDir, "stalls", `${goalId}.json`);
+    if (await this.pathExists(stallsFile)) {
+      await fsp.cp(stallsFile, path.join(archiveBase, "stalls.json"));
+    }
+
+    const reportsDir = path.join(this.baseDir, "reports", goalId);
+    if (await this.pathExists(reportsDir)) {
+      await fsp.cp(reportsDir, path.join(archiveBase, "reports"), { recursive: true });
+    }
+  }
+
+  private async commitArchiveGoal(stagingBase: string, archiveBase: string): Promise<void> {
+    await fsp.rename(stagingBase, archiveBase);
+  }
+
   private async resolveGoalLocation(goalId: string, includeArchive: boolean): Promise<GoalStorageLocation | null> {
     const activeLocation = this.goalStorageLocation(goalId, "active");
     if (await this.pathExists(activeLocation.dir)) return activeLocation;
@@ -285,17 +345,56 @@ export class StateManager {
     if (!this.markGoalVisited(goalId, _visited)) return false;
     let archived = false;
     await this.goalWriteCoordinator.protectedOperation(goalId, "archive_goal", { goalId }, async () => {
-      const location = await this.resolveGoalLocation(goalId, false);
-      if (location === null) return;
+      const archiveBase = this.archiveGoalDir(goalId);
+      const stagingBase = this.archiveGoalStagingDir(goalId);
+      const archiveLocation = this.goalStorageLocation(goalId, "archive");
+      const archiveExists = await this.pathExists(archiveBase);
+      const archiveCompleteMarkerExists = await this.pathExists(this.archiveCompleteMarkerPath(archiveBase));
+      const archiveGoalJsonExists = await this.pathExists(archiveLocation.goalJsonPath);
+      const activeLocation = await this.resolveGoalLocation(goalId, false);
+      const location = archiveCompleteMarkerExists
+        ? archiveLocation
+        : activeLocation ?? (archiveGoalJsonExists ? archiveLocation : null);
+      if (location === null) {
+        await fsp.rm(stagingBase, { recursive: true, force: true });
+        return;
+      }
 
       // Recursively archive children first (depth-first)
       await this.visitChildGoals(goalId, location, _visited, (childId, visited) => this.archiveGoal(childId, visited));
 
-      const archiveBase = path.join(this.baseDir, "archive", goalId);
-      await fsp.mkdir(archiveBase, { recursive: true });
+      if (archiveCompleteMarkerExists) {
+        await fsp.rm(stagingBase, { recursive: true, force: true });
+        await this.cleanupActiveGoalState(goalId);
+        archived = true;
+        return;
+      }
+
+      if (archiveExists && activeLocation === null) {
+        await fsp.rm(stagingBase, { recursive: true, force: true });
+        await this.copyActiveArchiveRemnants(goalId, archiveBase);
+        await this.atomicWrite(this.archiveCompleteMarkerPath(archiveBase), {
+          goalId,
+          completed_at: new Date().toISOString(),
+        });
+        await this.cleanupActiveGoalState(goalId);
+        archived = true;
+        return;
+      }
+
+      if (activeLocation === null) {
+        await fsp.rm(stagingBase, { recursive: true, force: true });
+        return;
+      }
+
+      await fsp.rm(stagingBase, { recursive: true, force: true });
+      await fsp.mkdir(path.dirname(stagingBase), { recursive: true });
+      if (archiveExists) {
+        await fsp.rm(archiveBase, { recursive: true, force: true });
+      }
 
       // Move goals/<goalId>/ → archive/<goalId>/goal/
-      const archiveGoalDir = path.join(archiveBase, "goal");
+      const archiveGoalDir = path.join(stagingBase, "goal");
       await fsp.cp(location.dir, archiveGoalDir, {
         recursive: true,
         filter: (source) => path.basename(source) !== ".lock",
@@ -320,38 +419,40 @@ export class StateManager {
       const tasksDir = path.join(this.baseDir, "tasks", goalId);
       try {
         await fsp.access(tasksDir);
-        const archiveTasksDir = path.join(archiveBase, "tasks");
+        const archiveTasksDir = path.join(stagingBase, "tasks");
         await fsp.cp(tasksDir, archiveTasksDir, { recursive: true });
-        await fsp.rm(tasksDir, { recursive: true, force: true });
       } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
 
       // Move strategies/<goalId>/ → archive/<goalId>/strategies/ (if exists)
       const strategiesDir = path.join(this.baseDir, "strategies", goalId);
       try {
         await fsp.access(strategiesDir);
-        const archiveStrategiesDir = path.join(archiveBase, "strategies");
+        const archiveStrategiesDir = path.join(stagingBase, "strategies");
         await fsp.cp(strategiesDir, archiveStrategiesDir, { recursive: true });
-        await fsp.rm(strategiesDir, { recursive: true, force: true });
       } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
 
       // Move stalls/<goalId>.json → archive/<goalId>/stalls.json (if exists)
       const stallsFile = path.join(this.baseDir, "stalls", `${goalId}.json`);
       try {
         await fsp.access(stallsFile);
-        const archiveStallsFile = path.join(archiveBase, "stalls.json");
+        const archiveStallsFile = path.join(stagingBase, "stalls.json");
         await fsp.cp(stallsFile, archiveStallsFile);
-        await fsp.rm(stallsFile, { force: true });
       } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
 
       // Move reports/<goalId>/ → archive/<goalId>/reports/ (if exists)
       const reportsDir = path.join(this.baseDir, "reports", goalId);
       try {
         await fsp.access(reportsDir);
-        const archiveReportsDir = path.join(archiveBase, "reports");
+        const archiveReportsDir = path.join(stagingBase, "reports");
         await fsp.cp(reportsDir, archiveReportsDir, { recursive: true });
-        await fsp.rm(reportsDir, { recursive: true, force: true });
       } catch (e: unknown) { if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e; }
-      await fsp.rm(location.dir, { recursive: true, force: true });
+
+      await this.atomicWrite(this.archiveCompleteMarkerPath(stagingBase), {
+        goalId,
+        completed_at: new Date().toISOString(),
+      });
+      await this.commitArchiveGoal(stagingBase, archiveBase);
+      await this.cleanupActiveGoalState(goalId);
       archived = true;
     });
     return archived;
@@ -364,7 +465,20 @@ export class StateManager {
     const archiveDir = path.join(this.baseDir, "archive");
     try {
       const entries = await fsp.readdir(archiveDir, { withFileTypes: true });
-      return entries.filter((d) => d.isDirectory()).map((d) => d.name);
+      const archived: string[] = [];
+      for (const entry of entries) {
+        if (!entry.isDirectory() || entry.name === ".staging") continue;
+        const archiveBase = this.archiveGoalDir(entry.name);
+        const hasCompleteMarker = await this.pathExists(this.archiveCompleteMarkerPath(archiveBase));
+        const hasGoalJson = await this.pathExists(this.goalStorageLocation(entry.name, "archive").goalJsonPath);
+        if (
+          hasGoalJson &&
+          hasCompleteMarker
+        ) {
+          archived.push(entry.name);
+        }
+      }
+      return archived;
     } catch (e: unknown) {
       if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
       return [];


### PR DESCRIPTION
## Summary
- stage archiveGoal output under archive/.staging/<goalId> and commit with a final rename
- add .archive-complete.json to distinguish committed archives from partial/legacy visible archives
- make retries cleanup committed archives, rebuild/finalize unmarked visible archives when possible, and preserve load/list compatibility

## Tests
- npm test -- src/base/state/__tests__/state-manager.test.ts
- npm run typecheck
- git diff --check

Closes #662