### PR TITLE
Validate openai_api adapter API keys

### DIFF
--- a/src/base/llm/__tests__/provider-config.test.ts
+++ b/src/base/llm/__tests__/provider-config.test.ts
@@ -152,6 +152,19 @@ describe("validateProviderConfig", () => {
     expect(result.errors).toEqual([]);
   });
 
+  it("reports error when api_key is missing for openai_api adapter on ollama", () => {
+    const result = validateProviderConfig({
+      provider: "ollama",
+      model: "llama3",
+      adapter: "openai_api",
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual(
+      expect.stringContaining('API key required for adapter "openai_api"')
+    );
+  });
+
   it("reports error when model provider mismatches", () => {
     const result = validateProviderConfig({
       provider: "anthropic",
@@ -419,6 +432,21 @@ describe("loadProviderConfig", () => {
     process.env["OPENAI_API_KEY"] = "sk-env";
 
     const config = await loadProviderConfig();
+    expect(config.api_key).toBe("sk-env");
+  });
+
+  it("OPENAI_API_KEY env var satisfies openai_api adapter on ollama provider", async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      provider: "ollama",
+      model: "llama3",
+      adapter: "openai_api",
+    }));
+    process.env["OPENAI_API_KEY"] = "sk-env";
+
+    const config = await loadProviderConfig();
+    expect(config.provider).toBe("ollama");
+    expect(config.adapter).toBe("openai_api");
     expect(config.api_key).toBe("sk-env");
   });
 });

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -237,9 +237,15 @@ export function validateProviderConfig(config: ProviderConfig): ValidationResult
   }
 
   // Check required api_key
-  if (!config.api_key && config.adapter !== "openai_codex_cli" && (config.provider === "openai" || config.provider === "anthropic")) {
-    const envName = config.provider === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
-    errors.push(`API key required for provider "${config.provider}". Set ${envName} or add api_key to config.`);
+  const requiresOpenAiApiKey =
+    config.provider === "openai" && config.adapter !== "openai_codex_cli";
+  const requiresAnthropicApiKey = config.provider === "anthropic";
+  const requiresAdapterApiKey = config.adapter === "openai_api";
+  const requiresApiKey = requiresOpenAiApiKey || requiresAnthropicApiKey || requiresAdapterApiKey;
+  if (!config.api_key && requiresApiKey) {
+    const envName = requiresAdapterApiKey || requiresOpenAiApiKey ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
+    const providerLabel = requiresAdapterApiKey ? 'adapter "openai_api"' : `provider "${config.provider}"`;
+    errors.push(`API key required for ${providerLabel}. Set ${envName} or add api_key to config.`);
   }
 
   return { valid: errors.length === 0, errors };
@@ -305,8 +311,12 @@ function resolveModel(
 function resolveApiKey(
   fileKey: string | undefined,
   provider: ProviderConfig["provider"],
+  adapter: ProviderConfig["adapter"],
   envFile: Record<string, string>
 ): string | undefined {
+  if (adapter === "openai_api") {
+    return process.env["OPENAI_API_KEY"] ?? envFile["OPENAI_API_KEY"] ?? fileKey;
+  }
   if (provider === "anthropic") {
     return process.env["ANTHROPIC_API_KEY"] ?? envFile["ANTHROPIC_API_KEY"] ?? fileKey;
   }
@@ -403,7 +413,7 @@ export async function loadProviderConfig(): Promise<ProviderConfig> {
     model = fallback;
   }
 
-  let api_key = resolveApiKey(fileConfig.api_key, provider, envFile);
+  let api_key = resolveApiKey(fileConfig.api_key, provider, adapter, envFile);
 
   // Fallback: read OAuth token from ~/.codex/auth.json when no API key is configured
   if (!api_key && provider === "openai" && adapter === "openai_codex_cli") {


### PR DESCRIPTION
## Summary
- require api_key validation for adapter: openai_api regardless of provider
- resolve OPENAI_API_KEY for openai_api adapter even when provider is ollama
- preserve openai_codex_cli OAuth and native Ollama no-key behavior

## Tests
- npm test -- src/base/llm/__tests__/provider-config.test.ts
- npm run typecheck
- npm run lint:boundaries
- git diff --check

Closes #522