### PR TITLE
Strengthen chat session resume and history

### DIFF
--- a/docs/design/execution/chat-mode.md
+++ b/docs/design/execution/chat-mode.md
@@ -172,12 +172,19 @@ Handles `/track`, which promotes the session to Tier 2.
 
 The command passes conversation history to the LLM as the primary source for goal generation. The user's own words become the goal description — no separate re-statement required.
 
-### 5.4 CLI Entry Point (`src/cli/commands/chat.ts`)
+### 5.4 CLI Entry Point (`src/interface/cli/commands/chat.ts`)
 
-Parses `pulseed chat [task]` and delegates to ChatRunner.
+Parses the chat command surface and dispatches to the appropriate flow.
 
-- If `task` argument is present: non-interactive, single turn
-- If `task` is absent: open interactive REPL backed by the TUI chat component (`src/interface/tui/chat.tsx`)- Flags: `--adapter <name>`, `--resume [id]` (Phase 2), `--timeout <ms>`
+- `pulseed chat [task]` starts a single-turn execution
+- `pulseed chat --continue` / `pulseed chat -c [id-or-title]` reopens the latest session or a selected session
+- `pulseed chat --resume <id-or-title>` targets a specific session selector
+- `pulseed chat --sessions` lists the session catalog
+- `pulseed chat --history <id-or-title>` prints a stored history view
+- `pulseed chat --title <title>` renames the selected/current session
+- `pulseed chat --cleanup-sessions [--dry-run]` cleans up stale sessions from the chat session store
+
+The session catalog lives in `src/interface/chat/chat-session-store.ts` and keeps chat history separate from unrelated memory search internals.
 
 ### 5.5 Context Provider Extension (`src/observation/context-provider.ts`)
 
@@ -280,13 +287,22 @@ The compaction is invisible to the user during normal flow. It is logged at debu
 
 ### Session Persistence and Resume (from OpenClaw + Codex CLI)
 
-Chat sessions are written to disk after every turn. If the process crashes or the user closes the terminal, the session can be resumed.
+Chat sessions are written to disk after every turn. If the process crashes or the user closes the terminal, the session can be resumed through the chat session catalog.
 
 Storage path: `~/.pulseed/chat/sessions/<id>.json`
 
-Resume: `pulseed chat --resume` loads the most recent session for the current git root. `pulseed chat --resume <id>` loads a specific session.
+Resume contract:
 
-Auto-expiry: sessions not accessed in 7 days (configurable via `chat_session_ttl_days`) are deleted on the next `pulseed chat` invocation. This is a simple mtime check on the session file.
+- `pulseed chat --continue` loads the most recent session for the current git root
+- `pulseed chat --continue <id-or-title>` uses the provided selector
+- `pulseed chat --resume <id-or-title>` loads a specific session selector
+
+Cleanup contract:
+
+- `pulseed chat --cleanup-sessions` scans `~/.pulseed/chat/sessions/` and removes eligible sessions
+- `--dry-run` previews deletions without removing files
+- sessions not accessed in 7 days are eligible for cleanup on the next cleanup pass
+- the active session is protected when cleanup runs from inside chat
 
 ### Timeout and Output Caps (from Codex CLI)
 
@@ -348,14 +364,15 @@ Verify: `/track` creates a Goal and starts CoreLoop; GoalRefiner determines tree
 
 ### Phase 2 — Session Persistence and Resume
 
-Deliverable: sessions survive process exit; `--resume` reloads them.
+Deliverable: sessions survive process exit; the CLI contract above resolves against a session catalog.
 
 Files:
-- `src/chat/chat-history.ts` — add `persist()`, `load()`, auto-expiry
-- `src/cli/commands/chat.ts` — add `--resume [id]` flag handling
-- `src/chat/chat-runner.ts` — add compaction logic
+- `src/interface/cli/commands/chat.ts` — parse `--continue`, `--resume`, `--sessions`, `--history`, `--title`, and `--cleanup-sessions`
+- `src/interface/chat/chat-history.ts` — persist updated metadata and restore loaded sessions
+- `src/interface/chat/chat-session-store.ts` — list, load, resolve selectors, rename, and cleanup chat sessions
+- `src/interface/chat/chat-runner.ts` — slash-command session list/history/title/cleanup and selected native agentloop resume
 
-Verify: kill process mid-session, resume, conversation history intact.
+Verify: kill process mid-session, resume, conversation history intact, cleanup respects dry-run.
 
 ### Phase 3 — Auto-escalation Proposals
 

--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -31,7 +31,8 @@ Main exported surfaces include:
 ### Chat entry
 
 - `src/interface/chat/chat-runner.ts`
-- `src/interface/cli/commands/chat.ts`
+- `src/interface/chat/chat-session-store.ts`
+- `src/interface/cli/commands/chat.ts` — chat command parsing, session-control flags, and REPL entrypoint
 
 ## 2. Directory guide
 
@@ -219,6 +220,7 @@ Start with:
 
 - `src/interface/chat/chat-runner.ts`
 - `src/interface/chat/chat-history.ts`
+- `src/interface/chat/chat-session-store.ts`
 - `src/interface/chat/cross-platform-session.ts`
 - `src/interface/cli/commands/chat.ts`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,13 @@ export type { CoreLoopDeps, LoopConfig, LoopResult } from "./orchestrator/loop/c
 export { CLIRunner } from "./interface/cli/cli-runner.js";
 export { ChatRunner } from "./interface/chat/chat-runner.js";
 export type { ChatRunnerDeps, ChatRunResult } from "./interface/chat/chat-runner.js";
+export { ChatSessionCatalog, ChatSessionSelectorError } from "./interface/chat/chat-session-store.js";
+export type {
+  ChatSessionCatalogEntry,
+  LoadedChatSession,
+  ChatSessionCleanupOptions,
+  ChatSessionCleanupReport,
+} from "./interface/chat/chat-session-store.js";
 export { CrossPlatformChatSessionManager, getGlobalCrossPlatformChatSessionManager } from "./interface/chat/cross-platform-session.js";
 export type {
   CrossPlatformChatSessionOptions,

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ChatRunner } from "../chat-runner.js";
 import type { ChatRunnerDeps } from "../chat-runner.js";
-import type { StateManager } from "../../../base/state/state-manager.js";
+import { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adapter-layer.js";
 import type { EscalationHandler, EscalationResult } from "../escalation.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
@@ -272,6 +272,96 @@ describe("ChatRunner", () => {
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
       expect(writeRawMock).toHaveBeenCalledTimes(1);
       expect(stateManager.readRaw).toHaveBeenCalledTimes(1);
+    });
+
+    it("/resume <selector> loads the selected session before resuming native agentloop state", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-resume-selector-"));
+      try {
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("chat/sessions/saved-session.json", {
+          id: "saved-session",
+          cwd: "/repo",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:01.000Z",
+          title: "Work Session",
+          messages: [
+            { role: "user", content: "continue this", timestamp: "2026-01-01T00:00:00.000Z", turnIndex: 0 },
+          ],
+        });
+        await stateManager.writeRaw("chat/agentloop/saved-session.state.json", {
+          sessionId: "saved-session",
+          traceId: "trace-1",
+          turnId: "turn-1",
+          goalId: "chat",
+          cwd: "/repo",
+          modelRef: "openai/gpt-5.4-mini",
+          messages: [{ role: "assistant", content: "continuing..." }],
+          modelTurns: 1,
+          toolCalls: 0,
+          compactions: 0,
+          completionValidationAttempts: 0,
+          calledTools: [],
+          lastToolLoopSignature: null,
+          repeatedToolLoopCount: 0,
+          finalText: "continuing...",
+          status: "failed",
+          stopReason: "timeout",
+          updatedAt: "2026-01-01T00:00:02.000Z",
+        });
+        const chatAgentLoopRunner = {
+          execute: vi.fn().mockResolvedValue({
+            success: true,
+            output: "Resumed selected session",
+            error: null,
+            exit_code: null,
+            elapsed_ms: 30,
+            stopped_reason: "completed",
+          }),
+        } as unknown as ChatAgentLoopRunner;
+        const runner = new ChatRunner(makeDeps({ stateManager, chatAgentLoopRunner }));
+
+        const result = await runner.execute("/resume Work Session", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toBe("Resumed selected session");
+        expect(runner.getSessionId()).toBe("saved-session");
+        const input = (chatAgentLoopRunner.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+          resumeOnly?: boolean;
+          resumeState?: { sessionId: string };
+          resumeStatePath?: string;
+        };
+        expect(input.resumeOnly).toBe(true);
+        expect(input.resumeState?.sessionId).toBe("saved-session");
+        expect(input.resumeStatePath).toBe("chat/agentloop/saved-session.state.json");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/sessions lists prior chat sessions", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-sessions-"));
+      try {
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("chat/sessions/prior-session.json", {
+          id: "prior-session",
+          cwd: "/repo",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:01.000Z",
+          title: "Prior",
+          messages: [],
+        });
+        const runner = new ChatRunner(makeDeps({ stateManager }));
+
+        const result = await runner.execute("/sessions", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("prior-session");
+        expect(result.output).toContain("Prior");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/src/interface/chat/__tests__/chat-session-store.test.ts
+++ b/src/interface/chat/__tests__/chat-session-store.test.ts
@@ -1,0 +1,408 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { StateManager } from "../../../base/state/state-manager.js";
+import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
+import {
+  ChatSessionCatalog,
+  type ChatSessionCatalogEntry,
+} from "../chat-session-store.js";
+import type { AgentLoopSessionState } from "../../../orchestrator/execution/agent-loop/agent-loop-session-state.js";
+
+function makeSession(overrides: Partial<Record<string, unknown>> & {
+  id: string;
+  cwd: string;
+  createdAt: string;
+  updatedAt?: string;
+  title?: string;
+  messages?: Array<Record<string, unknown>>;
+}): Record<string, unknown> {
+  return {
+    id: overrides.id,
+    cwd: overrides.cwd,
+    createdAt: overrides.createdAt,
+    ...(overrides.updatedAt ? { updatedAt: overrides.updatedAt } : {}),
+    ...(overrides.title ? { title: overrides.title } : {}),
+    messages: overrides.messages ?? [],
+  };
+}
+
+function makeAgentLoopState(overrides: Partial<AgentLoopSessionState> & {
+  sessionId: string;
+  traceId: string;
+  turnId: string;
+  goalId: string;
+  cwd: string;
+  modelRef: string;
+}): AgentLoopSessionState {
+  return {
+    sessionId: overrides.sessionId,
+    traceId: overrides.traceId,
+    turnId: overrides.turnId,
+    goalId: overrides.goalId,
+    cwd: overrides.cwd,
+    modelRef: overrides.modelRef,
+    messages: overrides.messages ?? [
+      {
+        role: "system",
+        content: "resume me",
+      },
+    ],
+    modelTurns: overrides.modelTurns ?? 1,
+    toolCalls: overrides.toolCalls ?? 0,
+    compactions: overrides.compactions ?? 0,
+    completionValidationAttempts: overrides.completionValidationAttempts ?? 0,
+    calledTools: overrides.calledTools ?? [],
+    lastToolLoopSignature: overrides.lastToolLoopSignature ?? null,
+    repeatedToolLoopCount: overrides.repeatedToolLoopCount ?? 0,
+    finalText: overrides.finalText ?? "",
+    status: overrides.status ?? "running",
+    ...(overrides.stopReason ? { stopReason: overrides.stopReason } : {}),
+    updatedAt: overrides.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+describe("ChatSessionCatalog", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+  let catalog: ChatSessionCatalog;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir();
+    stateManager = new StateManager(tmpDir);
+    await stateManager.init();
+    catalog = new ChatSessionCatalog(stateManager);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  it("loads legacy session files and backfills updatedAt", async () => {
+    await stateManager.writeRaw(
+      "chat/sessions/legacy-session.json",
+      makeSession({
+        id: "legacy-session",
+        cwd: "/repo",
+        createdAt: "2025-01-01T00:00:00.000Z",
+        messages: [
+          { role: "user", content: "hello", timestamp: "2025-01-01T00:00:00.000Z", turnIndex: 0 },
+        ],
+      })
+    );
+
+    const loaded = await catalog.loadSession("legacy-session");
+    expect(loaded).not.toBeNull();
+    expect(loaded?.id).toBe("legacy-session");
+    expect(loaded?.updatedAt).toBe("2025-01-01T00:00:00.000Z");
+    expect(loaded?.title).toBeNull();
+    expect(loaded?.agentLoopStatus).toBe("missing");
+    expect(loaded?.agentLoopResumable).toBe(false);
+
+    const sessions = await catalog.listSessions();
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      id: "legacy-session",
+      cwd: "/repo",
+      title: null,
+      messageCount: 1,
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+      agentLoopStatus: "missing",
+      agentLoopResumable: false,
+    });
+  });
+
+  it("sorts by updatedAt desc and discovers resumable agentloop state", async () => {
+    await stateManager.writeRaw(
+      "chat/sessions/older.json",
+      makeSession({
+        id: "older",
+        cwd: "/repo",
+        createdAt: "2025-01-01T00:00:00.000Z",
+        updatedAt: "2025-01-01T01:00:00.000Z",
+        title: "Older",
+        messages: [
+          { role: "user", content: "old", timestamp: "2025-01-01T00:00:00.000Z", turnIndex: 0 },
+        ],
+      })
+    );
+
+    await stateManager.writeRaw(
+      "chat/sessions/newer.json",
+      makeSession({
+        id: "newer",
+        cwd: "/repo",
+        createdAt: "2025-01-02T00:00:00.000Z",
+        updatedAt: "2025-01-02T02:00:00.000Z",
+        title: "Latest",
+        messages: [
+          { role: "user", content: "new", timestamp: "2025-01-02T00:00:00.000Z", turnIndex: 0 },
+        ],
+      })
+    );
+
+    await stateManager.writeRaw(
+      "chat/agentloop/newer.state.json",
+      makeAgentLoopState({
+        sessionId: "newer",
+        traceId: "trace-1",
+        turnId: "turn-1",
+        goalId: "goal-1",
+        cwd: "/repo",
+        modelRef: "model",
+      })
+    );
+
+    const sessions = await catalog.listSessions();
+    expect(sessions.map((session: ChatSessionCatalogEntry) => session.id)).toEqual(["newer", "older"]);
+    expect(sessions[0]).toMatchObject({
+      id: "newer",
+      title: "Latest",
+      agentLoopStatePath: path.join("chat", "agentloop", "newer.state.json"),
+      agentLoopStatus: "running",
+      agentLoopResumable: true,
+    });
+  });
+
+  it("resolves selectors by id prefix and unique title with clear errors", async () => {
+    await stateManager.writeRaw(
+      "chat/sessions/alpha-001.json",
+      makeSession({
+        id: "alpha-001",
+        cwd: "/repo",
+        createdAt: "2025-01-01T00:00:00.000Z",
+        title: "Alpha Run",
+        messages: [],
+      })
+    );
+    await stateManager.writeRaw(
+      "chat/sessions/alpha-002.json",
+      makeSession({
+        id: "alpha-002",
+        cwd: "/repo",
+        createdAt: "2025-01-01T00:00:01.000Z",
+        title: "Alpha Two",
+        messages: [],
+      })
+    );
+    await stateManager.writeRaw(
+      "chat/sessions/beta-003.json",
+      makeSession({
+        id: "beta-003",
+        cwd: "/repo",
+        createdAt: "2025-01-01T00:00:02.000Z",
+        title: "Unique Title",
+        messages: [],
+      })
+    );
+    await stateManager.writeRaw(
+      "chat/sessions/beta-004.json",
+      makeSession({
+        id: "beta-004",
+        cwd: "/repo",
+        createdAt: "2025-01-01T00:00:03.000Z",
+        title: "Unique Title",
+        messages: [],
+      })
+    );
+
+    const resolvedByPrefix = await catalog.resolveSelector("alpha-001");
+    expect(resolvedByPrefix.id).toBe("alpha-001");
+
+    const resolvedByTitle = await catalog.resolveSelector("Alpha Run");
+    expect(resolvedByTitle.id).toBe("alpha-001");
+
+    await expect(catalog.resolveSelector("beta-00")).rejects.toMatchObject({
+      kind: "ambiguous",
+      selector: "beta-00",
+    });
+
+    await expect(catalog.resolveSelector("Unique Title")).rejects.toMatchObject({
+      kind: "ambiguous",
+      selector: "Unique Title",
+    });
+
+    await expect(catalog.resolveSelector("missing")).rejects.toMatchObject({
+      kind: "not_found",
+      selector: "missing",
+    });
+  });
+
+  it("renames a session and bumps updatedAt", async () => {
+    await stateManager.writeRaw(
+      "chat/sessions/rename-me.json",
+      makeSession({
+        id: "rename-me",
+        cwd: "/repo",
+        createdAt: "2025-01-01T00:00:00.000Z",
+        updatedAt: "2025-01-01T01:00:00.000Z",
+        title: "Original",
+        messages: [],
+      })
+    );
+
+    const renamed = await catalog.renameSession("rename-me", "Renamed Session");
+    expect(renamed.title).toBe("Renamed Session");
+    expect(renamed.updatedAt).not.toBe("2025-01-01T01:00:00.000Z");
+
+    const loaded = await catalog.loadSession("rename-me");
+    expect(loaded?.title).toBe("Renamed Session");
+  });
+
+  it("lists by cwd and returns the latest matching session", async () => {
+    await stateManager.writeRaw(
+      "chat/sessions/repo-a-old.json",
+      makeSession({
+        id: "repo-a-old",
+        cwd: "/repo-a",
+        createdAt: "2025-01-01T00:00:00.000Z",
+        updatedAt: "2025-01-01T01:00:00.000Z",
+        messages: [],
+      })
+    );
+    await stateManager.writeRaw(
+      "chat/sessions/repo-a-new.json",
+      makeSession({
+        id: "repo-a-new",
+        cwd: "/repo-a",
+        createdAt: "2025-01-02T00:00:00.000Z",
+        updatedAt: "2025-01-02T01:00:00.000Z",
+        messages: [],
+      })
+    );
+    await stateManager.writeRaw(
+      "chat/sessions/repo-b-new.json",
+      makeSession({
+        id: "repo-b-new",
+        cwd: "/repo-b",
+        createdAt: "2025-01-03T00:00:00.000Z",
+        updatedAt: "2025-01-03T01:00:00.000Z",
+        messages: [],
+      })
+    );
+
+    const repoASessions = await catalog.listSessions({ cwd: "/repo-a" });
+    expect(repoASessions.map((session) => session.id)).toEqual(["repo-a-new", "repo-a-old"]);
+    await expect(catalog.latestSession({ cwd: "/repo-a" })).resolves.toMatchObject({ id: "repo-a-new" });
+  });
+
+  it("clears a session title when renamed to null", async () => {
+    await stateManager.writeRaw(
+      "chat/sessions/clear-title.json",
+      makeSession({
+        id: "clear-title",
+        cwd: "/repo",
+        createdAt: "2025-01-01T00:00:00.000Z",
+        title: "Original",
+        messages: [],
+      })
+    );
+
+    const renamed = await catalog.renameSession("clear-title", null);
+    expect(renamed.title).toBeNull();
+    const loaded = await catalog.loadSession("clear-title");
+    expect(loaded?.title).toBeNull();
+  });
+
+  it("uses agentloop updatedAt when deciding cleanup freshness", async () => {
+    await stateManager.writeRaw(
+      "chat/sessions/old-chat-fresh-agentloop.json",
+      makeSession({
+        id: "old-chat-fresh-agentloop",
+        cwd: "/repo",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T01:00:00.000Z",
+        messages: [],
+      })
+    );
+    await stateManager.writeRaw(
+      "chat/agentloop/old-chat-fresh-agentloop.state.json",
+      makeAgentLoopState({
+        sessionId: "old-chat-fresh-agentloop",
+        traceId: "trace-fresh",
+        turnId: "turn-fresh",
+        goalId: "goal-fresh",
+        cwd: "/repo",
+        modelRef: "model",
+        status: "failed",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      })
+    );
+
+    const dryRun = await catalog.cleanupSessions({
+      dryRun: true,
+      olderThanMs: 60 * 60 * 1000,
+      now: Date.parse("2026-01-01T00:30:00.000Z"),
+    });
+
+    expect(dryRun.removedSessionIds).not.toContain("old-chat-fresh-agentloop");
+    expect(dryRun.retainedSessionIds).toContain("old-chat-fresh-agentloop");
+  });
+
+  it("cleans up old sessions in dry-run and enforce modes while protecting the active session", async () => {
+    const oldSession = makeSession({
+      id: "old-session",
+      cwd: "/repo",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T01:00:00.000Z",
+      messages: [],
+    });
+    const activeSession = makeSession({
+      id: "active-session",
+      cwd: "/repo",
+      createdAt: "2024-01-02T00:00:00.000Z",
+      updatedAt: "2024-01-02T01:00:00.000Z",
+      messages: [],
+    });
+    const freshSession = makeSession({
+      id: "fresh-session",
+      cwd: "/repo",
+      createdAt: "2025-12-31T23:30:00.000Z",
+      updatedAt: "2025-12-31T23:50:00.000Z",
+      messages: [],
+    });
+
+    await stateManager.writeRaw("chat/sessions/old-session.json", oldSession);
+    await stateManager.writeRaw("chat/sessions/active-session.json", activeSession);
+    await stateManager.writeRaw("chat/sessions/fresh-session.json", freshSession);
+    await stateManager.writeRaw(
+      "chat/agentloop/old-session.state.json",
+      makeAgentLoopState({
+        sessionId: "old-session",
+        traceId: "trace-old",
+        turnId: "turn-old",
+        goalId: "goal-old",
+        cwd: "/repo",
+        modelRef: "model",
+        updatedAt: "2024-01-01T01:00:00.000Z",
+      })
+    );
+
+    const dryRun = await catalog.cleanupSessions({
+      dryRun: true,
+      activeSessionId: "active-session",
+      olderThanMs: 60 * 60 * 1000,
+      now: Date.parse("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(dryRun.removedSessionIds).toContain("old-session");
+    expect(dryRun.retainedSessionIds).toContain("active-session");
+    expect(fs.existsSync(path.join(tmpDir, "chat", "sessions", "old-session.json"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "chat", "agentloop", "old-session.state.json"))).toBe(true);
+
+    const enforced = await catalog.cleanupSessions({
+      dryRun: false,
+      activeSessionId: "active-session",
+      olderThanMs: 60 * 60 * 1000,
+      now: Date.parse("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(enforced.removedSessionIds).toContain("old-session");
+    expect(enforced.retainedSessionIds).toContain("active-session");
+    expect(fs.existsSync(path.join(tmpDir, "chat", "sessions", "old-session.json"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "chat", "agentloop", "old-session.state.json"))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "chat", "sessions", "active-session.json"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "chat", "sessions", "fresh-session.json"))).toBe(true);
+  });
+});

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -13,16 +13,31 @@ export const ChatMessageSchema = z.object({
   content: z.string(),
   timestamp: z.string(), // ISO 8601
   turnIndex: z.number().int().min(0),
-});
+}).passthrough();
 export type ChatMessage = z.infer<typeof ChatMessageSchema>;
+
+export const ChatSessionAgentLoopMetadataSchema = z.object({
+  statePath: z.string().nullable().optional(),
+  status: z.enum(["running", "completed", "failed"]).nullable().optional(),
+  resumable: z.boolean().nullable().optional(),
+  updatedAt: z.string().nullable().optional(),
+}).passthrough();
+export type ChatSessionAgentLoopMetadata = z.infer<typeof ChatSessionAgentLoopMetadataSchema>;
 
 export const ChatSessionSchema = z.object({
   id: z.string(),
   cwd: z.string(), // git root at session start
   createdAt: z.string(),
+  updatedAt: z.string().optional(),
+  title: z.string().trim().min(1).max(200).nullable().optional(),
   messages: z.array(ChatMessageSchema),
   compactionSummary: z.string().optional(),
-});
+  agentLoopStatePath: z.string().nullable().optional(),
+  agentLoopStatus: z.enum(["running", "completed", "failed"]).nullable().optional(),
+  agentLoopResumable: z.boolean().nullable().optional(),
+  agentLoopUpdatedAt: z.string().nullable().optional(),
+  agentLoop: ChatSessionAgentLoopMetadataSchema.optional(),
+}).passthrough();
 export type ChatSession = z.infer<typeof ChatSessionSchema>;
 
 // ─── ChatHistory ───
@@ -32,15 +47,31 @@ export class ChatHistory {
   private readonly sessionId: string;
   private readonly session: ChatSession;
 
-  constructor(stateManager: StateManager, sessionId: string, cwd: string) {
+  constructor(stateManager: StateManager, sessionId: string, cwd: string, existingSession?: ChatSession) {
     this.stateManager = stateManager;
     this.sessionId = sessionId;
-    this.session = {
-      id: sessionId,
-      cwd,
-      createdAt: new Date().toISOString(),
-      messages: [],
-    };
+    if (existingSession) {
+      this.session = {
+        ...existingSession,
+        id: existingSession.id,
+        cwd: existingSession.cwd,
+        updatedAt: existingSession.updatedAt ?? existingSession.createdAt,
+        messages: [...existingSession.messages],
+      };
+    } else {
+      const createdAt = new Date().toISOString();
+      this.session = {
+        id: sessionId,
+        cwd,
+        createdAt,
+        updatedAt: createdAt,
+        messages: [],
+      };
+    }
+  }
+
+  static fromSession(stateManager: StateManager, session: ChatSession): ChatHistory {
+    return new ChatHistory(stateManager, session.id, session.cwd, session);
   }
 
   /** Append a user message and persist to disk BEFORE adapter execution. */
@@ -83,7 +114,24 @@ export class ChatHistory {
     return this.sessionId;
   }
 
+  setTitle(title: string | null): void {
+    if (title && title.trim().length > 0) {
+      this.session.title = title.trim();
+    } else {
+      delete this.session.title;
+    }
+  }
+
+  setAgentLoopStatePath(statePath: string | null): void {
+    if (statePath) {
+      this.session.agentLoopStatePath = statePath;
+    } else {
+      delete this.session.agentLoopStatePath;
+    }
+  }
+
   async persist(): Promise<void> {
+    this.session.updatedAt = new Date().toISOString();
     await this.stateManager.writeRaw(
       `chat/sessions/${this.sessionId}.json`,
       this.session

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -7,7 +7,12 @@ import { execFile } from "node:child_process";
 import type { StateManager } from "../../base/state/state-manager.js";
 import type { IAdapter, AgentTask } from "../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
-import { ChatHistory } from "./chat-history.js";
+import { ChatHistory, type ChatSession } from "./chat-history.js";
+import {
+  ChatSessionCatalog,
+  ChatSessionSelectorError,
+  type LoadedChatSession,
+} from "./chat-session-store.js";
 import { buildChatContext, resolveGitRoot } from "../../platform/observation/context-provider.js";
 import type { EscalationHandler } from "./escalation.js";
 import { buildDynamicContextPrompt, buildStaticSystemPrompt } from "./grounding.js";
@@ -102,6 +107,10 @@ interface AssistantBuffer {
   text: string;
 }
 
+interface ResumeCommand {
+  selector?: string;
+}
+
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
 const MAX_TOOL_LOOPS = 5;
@@ -110,12 +119,16 @@ const ACTIVITY_PREVIEW_CHARS = 40;
 // ─── Command help text ───
 
 const COMMAND_HELP = `Available commands:
-  /help    Show this help message
-  /clear   Clear conversation history
-  /resume  Resume the last native agentloop turn when resumable state exists
-  /exit    Exit chat mode
-  /track   Promote session to Tier 2 goal pursuit (not yet implemented)
-  /tend    Generate a goal from chat history and start autonomous daemon execution`;
+  /help                 Show this help message
+  /clear                Clear conversation history
+  /sessions             List prior chat sessions
+  /history [id|title]   Show saved chat history
+  /title <title>        Rename the current session
+  /resume [id|title]    Resume native agentloop state for the current or selected session
+  /cleanup [--dry-run]  Clean up stale chat sessions
+  /exit                 Exit chat mode
+  /track                Promote session to Tier 2 goal pursuit (not yet implemented)
+  /tend                 Generate a goal from chat history and start autonomous daemon execution`;
 
 // ─── Helpers ───
 
@@ -178,10 +191,69 @@ export class ChatRunner {
     this.sessionCwd = gitRoot;
     this.sessionActive = true;
     this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
+    this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
+  }
+
+  startSessionFromLoadedSession(session: LoadedChatSession): void {
+    const chatSession = this.loadedSessionToChatSession(session);
+    this.history = ChatHistory.fromSession(this.deps.stateManager, chatSession);
+    this.sessionCwd = session.cwd;
+    this.sessionActive = true;
+    this.nativeAgentLoopStatePath = session.agentLoopStatePath ?? `chat/agentloop/${session.id}.state.json`;
+    this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
+  }
+
+  getSessionId(): string | null {
+    return this.history?.getSessionId() ?? null;
+  }
+
+  getCurrentSessionMessages(): ChatSession["messages"] {
+    return this.history?.getMessages() ?? [];
   }
 
   setRuntimeControlContext(context: RuntimeControlChatContext | null): void {
     this.runtimeControlContext = context;
+  }
+
+  private loadedSessionToChatSession(session: LoadedChatSession): ChatSession {
+    return {
+      id: session.id,
+      cwd: session.cwd,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+      messages: [...session.messages],
+      ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
+      ...(session.title ? { title: session.title } : {}),
+      ...(session.agentLoopStatePath ? { agentLoopStatePath: session.agentLoopStatePath } : {}),
+      ...(session.agentLoopStatus === "running" || session.agentLoopStatus === "completed" || session.agentLoopStatus === "failed"
+        ? { agentLoopStatus: session.agentLoopStatus }
+        : {}),
+      ...(session.agentLoopResumable ? { agentLoopResumable: true } : {}),
+      ...(session.agentLoopUpdatedAt ? { agentLoopUpdatedAt: session.agentLoopUpdatedAt } : {}),
+      ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
+    };
+  }
+
+  private formatSessionsList(entries: Array<{ id: string; title: string | null; cwd: string; updatedAt: string; messageCount: number; agentLoopResumable: boolean }>): string {
+    if (entries.length === 0) return "No chat sessions found.";
+    const lines = entries.map((entry) => {
+      const title = entry.title ? ` "${entry.title}"` : "";
+      const resumable = entry.agentLoopResumable ? " resumable" : "";
+      return `${entry.id}${title} - ${entry.messageCount} message(s), updated ${entry.updatedAt}, cwd ${entry.cwd}${resumable}`;
+    });
+    return `Chat sessions:\n${lines.join("\n")}`;
+  }
+
+  private formatHistory(session: LoadedChatSession): string {
+    const title = session.title ? ` "${session.title}"` : "";
+    if (session.messages.length === 0) {
+      return `Session ${session.id}${title} has no messages.`;
+    }
+    const lines = session.messages.map((message) => {
+      const role = message.role === "assistant" ? "Assistant" : "User";
+      return `${role}: ${message.content}`;
+    });
+    return `Session ${session.id}${title} (${session.cwd})\n${lines.join("\n")}`;
   }
 
   private async handleCommand(input: string): Promise<ChatRunResult | null> {
@@ -197,6 +269,52 @@ export class ChatRunner {
     if (cmd === "/clear") {
       this.history?.clear();
       return { success: true, output: "Conversation history cleared.", elapsed_ms: Date.now() - start };
+    }
+    if (cmd === "/sessions") {
+      const catalog = new ChatSessionCatalog(this.deps.stateManager);
+      const sessions = await catalog.listSessions();
+      return { success: true, output: this.formatSessionsList(sessions), elapsed_ms: Date.now() - start };
+    }
+    if (cmd === "/history") {
+      const catalog = new ChatSessionCatalog(this.deps.stateManager);
+      const selector = trimmed.slice("/history".length).trim();
+      const session = selector
+        ? await catalog.loadSessionBySelector(selector)
+        : this.history
+          ? await catalog.loadSession(this.history.getSessionId())
+          : null;
+      if (!session) {
+        return { success: false, output: "No chat session history found.", elapsed_ms: Date.now() - start };
+      }
+      return { success: true, output: this.formatHistory(session), elapsed_ms: Date.now() - start };
+    }
+    if (cmd === "/title") {
+      const title = trimmed.slice("/title".length).trim();
+      if (!title) {
+        return { success: false, output: "Usage: /title <title>", elapsed_ms: Date.now() - start };
+      }
+      if (!this.history) {
+        return { success: false, output: "No active chat session to rename.", elapsed_ms: Date.now() - start };
+      }
+      const catalog = new ChatSessionCatalog(this.deps.stateManager);
+      this.history.setTitle(title);
+      await this.history.persist();
+      await catalog.renameSession(this.history.getSessionId(), title);
+      return { success: true, output: `Renamed chat session to "${title}".`, elapsed_ms: Date.now() - start };
+    }
+    if (cmd === "/cleanup") {
+      const catalog = new ChatSessionCatalog(this.deps.stateManager);
+      const dryRun = trimmed.includes("--dry-run");
+      const report = await catalog.cleanupSessions({
+        dryRun,
+        activeSessionId: this.history?.getSessionId(),
+      });
+      const verb = dryRun ? "would remove" : "removed";
+      return {
+        success: true,
+        output: `Chat session cleanup ${verb} ${report.removedSessionIds.length} session(s).`,
+        elapsed_ms: Date.now() - start,
+      };
     }
     if (cmd === "/exit") {
       return { success: true, output: "Exiting chat mode.", elapsed_ms: Date.now() - start };
@@ -381,7 +499,8 @@ export class ChatRunner {
    */
   async execute(input: string, cwd: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<ChatRunResult> {
     const eventContext = this.createEventContext();
-    const resumeOnly = this.isResumeCommand(input);
+    const resumeCommand = this.parseResumeCommand(input);
+    const resumeOnly = resumeCommand !== null;
 
     // Intercept commands before any adapter call
     const commandResult = resumeOnly ? null : await this.handleCommand(input);
@@ -439,12 +558,44 @@ export class ChatRunner {
       return runtimeControlResult;
     }
 
+    if (resumeOnly && resumeCommand.selector) {
+      try {
+        const catalog = new ChatSessionCatalog(this.deps.stateManager);
+        const session = await catalog.loadSessionBySelector(resumeCommand.selector);
+        if (!session) {
+          const elapsed_ms = 0;
+          const output = `No chat session matched selector "${resumeCommand.selector}".`;
+          this.emitEvent({
+            type: "assistant_final",
+            text: output,
+            persisted: false,
+            ...this.eventBase(eventContext),
+          });
+          this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
+          return { success: false, output, elapsed_ms };
+        }
+        this.startSessionFromLoadedSession(session);
+      } catch (err) {
+        const elapsed_ms = 0;
+        const output = err instanceof ChatSessionSelectorError ? err.message : `Failed to load chat session: ${err instanceof Error ? err.message : String(err)}`;
+        this.emitEvent({
+          type: "assistant_final",
+          text: output,
+          persisted: false,
+          ...this.eventBase(eventContext),
+        });
+        this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
+        return { success: false, output, elapsed_ms };
+      }
+    }
+
     // Reuse session (interactive mode) or create a fresh one per call (1-shot mode)
     if (!this.sessionActive) {
       const gitRoot = resolveGitRoot(cwd);
       const sessionId = crypto.randomUUID();
       this.history = new ChatHistory(this.deps.stateManager, sessionId, gitRoot);
       this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
+      this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
     }
     const gitRoot = this.sessionCwd ?? resolveGitRoot(cwd);
 
@@ -961,8 +1112,12 @@ export class ChatRunner {
     return preview ? { preview } : {};
   }
 
-  private isResumeCommand(input: string): boolean {
-    return input.trim().toLowerCase() === "/resume";
+  private parseResumeCommand(input: string): ResumeCommand | null {
+    const trimmed = input.trim();
+    const match = /^\/resume(?:\s+(.+))?$/i.exec(trimmed);
+    if (!match) return null;
+    const selector = match[1]?.trim();
+    return selector ? { selector } : {};
   }
 
   private async loadResumableAgentLoopState(): Promise<AgentLoopSessionState | null> {

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -1,0 +1,507 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { type Dirent } from "node:fs";
+import { StateError } from "../../base/utils/errors.js";
+import type { StateManager } from "../../base/state/state-manager.js";
+import { ChatSessionSchema, type ChatSession } from "./chat-history.js";
+import { normalizeAgentLoopSessionState, type AgentLoopSessionState } from "../../orchestrator/execution/agent-loop/agent-loop-session-state.js";
+
+const CHAT_SESSION_DIR = path.join("chat", "sessions");
+const CHAT_AGENTLOOP_DIR = path.join("chat", "agentloop");
+const DEFAULT_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type ChatSessionAgentLoopStatus = "missing" | "running" | "completed" | "failed";
+
+export interface ChatSessionCatalogEntry {
+  id: string;
+  cwd: string;
+  title: string | null;
+  messageCount: number;
+  createdAt: string;
+  updatedAt: string;
+  agentLoopStatePath: string | null;
+  agentLoopStatus: ChatSessionAgentLoopStatus;
+  agentLoopResumable: boolean;
+}
+
+export interface LoadedChatSession {
+  id: string;
+  cwd: string;
+  createdAt: string;
+  updatedAt: string;
+  title: string | null;
+  messages: ChatSession["messages"];
+  compactionSummary?: string;
+  agentLoopStatePath: string | null;
+  agentLoopStatus: ChatSessionAgentLoopStatus;
+  agentLoopResumable: boolean;
+  agentLoopUpdatedAt?: string | null;
+  agentLoop?: ChatSession["agentLoop"];
+  [key: string]: unknown;
+}
+
+export interface ChatSessionCleanupOptions {
+  dryRun?: boolean;
+  activeSessionId?: string;
+  olderThanMs?: number;
+  now?: number;
+}
+
+export interface ChatSessionListOptions {
+  cwd?: string;
+}
+
+export interface ChatSessionCleanupReport {
+  dryRun: boolean;
+  olderThanMs: number;
+  activeSessionId: string | null;
+  totalSessions: number;
+  retainedSessionIds: string[];
+  removedSessionIds: string[];
+  removedAgentLoopStatePaths: string[];
+}
+
+export class ChatSessionSelectorError extends StateError {
+  constructor(
+    message: string,
+    public readonly selector: string,
+    public readonly kind: "not_found" | "ambiguous",
+    public readonly matches: string[] = [],
+  ) {
+    super(message);
+    this.name = "ChatSessionSelectorError";
+  }
+}
+
+interface SessionRecord {
+  session: LoadedChatSession;
+  filePath: string;
+  activityAtMs: number;
+  fileMtimeMs: number;
+}
+
+interface AgentLoopDiscovery {
+  statePath: string | null;
+  status: ChatSessionAgentLoopStatus;
+  resumable: boolean;
+  updatedAt: string | null;
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function normalizeTitle(value: unknown): string | null {
+  const title = optionalString(value);
+  return title ? title.trim() : null;
+}
+
+function parseTime(value: string | null | undefined): number {
+  if (!value) return Number.NEGATIVE_INFINITY;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
+function resolvePathWithinBaseDir(baseDir: string, candidate: string | null | undefined): { relative: string; absolute: string } | null {
+  const trimmed = candidate?.trim();
+  if (!trimmed) return null;
+
+  const absolute = path.isAbsolute(trimmed) ? path.resolve(trimmed) : path.resolve(baseDir, trimmed);
+  const root = path.resolve(baseDir);
+  const relative = path.relative(root, absolute);
+  if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+    return { absolute, relative: relative === "" ? "." : relative };
+  }
+  return null;
+}
+
+function sessionToAgentLoopStatePath(session: ChatSession, baseDir: string): string | null {
+  const topLevelPath = optionalString(session.agentLoopStatePath);
+  if (topLevelPath) {
+    const resolved = resolvePathWithinBaseDir(baseDir, topLevelPath);
+    if (resolved) return resolved.relative;
+  }
+
+  const nestedPath = optionalString(session.agentLoop?.statePath);
+  if (nestedPath) {
+    const resolved = resolvePathWithinBaseDir(baseDir, nestedPath);
+    if (resolved) return resolved.relative;
+  }
+
+  return path.join(CHAT_AGENTLOOP_DIR, `${session.id}.state.json`);
+}
+
+function extractSessionActivityAtMs(session: { createdAt: string; updatedAt?: string | null; agentLoopUpdatedAt?: string | null }, fileMtimeMs: number): number {
+  const metadataActivity = Math.max(parseTime(session.updatedAt), parseTime(session.createdAt), parseTime(session.agentLoopUpdatedAt));
+  return metadataActivity === Number.NEGATIVE_INFINITY ? fileMtimeMs : metadataActivity;
+}
+
+async function readFileMtimeMs(filePath: string, fallbackMs: number): Promise<number> {
+  try {
+    return (await fsp.stat(filePath)).mtimeMs;
+  } catch {
+    return fallbackMs;
+  }
+}
+
+function normalizeAgentLoopStatus(
+  session: ChatSession,
+  agentLoopState: AgentLoopSessionState | null,
+): AgentLoopDiscovery {
+  const metadataStatus = session.agentLoopStatus ?? session.agentLoop?.status ?? null;
+  const statePath = session.agentLoopStatePath ?? session.agentLoop?.statePath ?? null;
+  const resumableMetadata = session.agentLoopResumable ?? session.agentLoop?.resumable ?? null;
+
+  if (agentLoopState) {
+    const status = agentLoopState.status;
+    return {
+      statePath,
+      status,
+      resumable: status !== "completed",
+      updatedAt: agentLoopState.updatedAt,
+    };
+  }
+
+  if (metadataStatus) {
+    return {
+      statePath,
+      status: metadataStatus,
+      resumable: resumableMetadata ?? metadataStatus !== "completed",
+      updatedAt: session.agentLoopUpdatedAt ?? session.agentLoop?.updatedAt ?? null,
+    };
+  }
+
+  return {
+    statePath,
+    status: "missing",
+    resumable: resumableMetadata ?? false,
+    updatedAt: session.agentLoopUpdatedAt ?? session.agentLoop?.updatedAt ?? null,
+  };
+}
+
+async function loadAgentLoopState(
+  stateManager: StateManager,
+  baseDir: string,
+  session: ChatSession,
+): Promise<AgentLoopDiscovery> {
+  const statePaths: string[] = [];
+  const metadataPaths = [
+    optionalString(session.agentLoopStatePath),
+    optionalString(session.agentLoop?.statePath),
+  ];
+  for (const candidate of metadataPaths) {
+    const resolved = resolvePathWithinBaseDir(baseDir, candidate);
+    if (resolved && !statePaths.includes(resolved.relative)) statePaths.push(resolved.relative);
+  }
+
+  const discoveredPath = sessionToAgentLoopStatePath(session, baseDir);
+  if (discoveredPath && !statePaths.includes(discoveredPath)) statePaths.push(discoveredPath);
+
+  let loadedState: AgentLoopSessionState | null = null;
+  let loadedPath: string | null = null;
+  for (const relativePath of statePaths) {
+    const raw = await stateManager.readRaw(relativePath);
+    const normalized = normalizeAgentLoopSessionState(raw);
+    if (normalized) {
+      loadedState = normalized;
+      loadedPath = relativePath;
+      break;
+    }
+  }
+
+  const discovery = normalizeAgentLoopStatus(session, loadedState);
+  return {
+    statePath: loadedPath ?? discovery.statePath,
+    status: discovery.status,
+    resumable: loadedState ? loadedState.status !== "completed" : discovery.resumable,
+    updatedAt: loadedState?.updatedAt ?? discovery.updatedAt,
+  };
+}
+
+function normalizeSessionRecord(session: LoadedChatSession, filePath: string, fileMtimeMs: number, agentLoop: AgentLoopDiscovery): SessionRecord {
+  return {
+    session: {
+      ...session,
+      title: normalizeTitle(session.title),
+      agentLoopStatePath: agentLoop.statePath,
+      agentLoopStatus: agentLoop.status,
+      agentLoopResumable: agentLoop.resumable,
+      agentLoopUpdatedAt: agentLoop.updatedAt,
+    },
+    filePath,
+    activityAtMs: extractSessionActivityAtMs(session, fileMtimeMs),
+    fileMtimeMs,
+  };
+}
+
+async function readSessionRecordWithMetadata(
+  stateManager: StateManager,
+  baseDir: string,
+  sessionId: string,
+  fallbackFileMtimeMs: number = Date.now(),
+): Promise<SessionRecord | null> {
+  const relativePath = path.join(CHAT_SESSION_DIR, `${sessionId}.json`);
+  const raw = await stateManager.readRaw(relativePath);
+  if (raw === null) return null;
+
+  const parsed = ChatSessionSchema.safeParse(raw);
+  if (!parsed.success) {
+    const issues = parsed.error.issues.map((issue) => `${issue.path.join(".") || "<root>"}: ${issue.message}`).join("; ");
+    throw new ChatSessionSelectorError(
+      `Invalid chat session record for "${sessionId}" at ${relativePath}: ${issues}`,
+      sessionId,
+      "not_found",
+    );
+  }
+
+  const filePath = path.join(baseDir, relativePath);
+  const fileMtimeMs = await readFileMtimeMs(filePath, fallbackFileMtimeMs);
+  const discovery = await loadAgentLoopState(stateManager, baseDir, parsed.data);
+  const session: LoadedChatSession = {
+    id: parsed.data.id,
+    cwd: parsed.data.cwd,
+    createdAt: parsed.data.createdAt,
+    updatedAt: parsed.data.updatedAt ?? parsed.data.createdAt,
+    title: normalizeTitle(parsed.data.title),
+    messages: [...parsed.data.messages],
+    ...(parsed.data.compactionSummary ? { compactionSummary: parsed.data.compactionSummary } : {}),
+    agentLoopStatePath: discovery.statePath,
+    agentLoopStatus: discovery.status,
+    agentLoopResumable: discovery.resumable,
+    agentLoopUpdatedAt: discovery.updatedAt,
+    ...(parsed.data.agentLoop ? { agentLoop: parsed.data.agentLoop } : {}),
+  };
+
+  return normalizeSessionRecord(session, filePath, fileMtimeMs, discovery);
+}
+
+function buildCatalogEntry(record: SessionRecord): ChatSessionCatalogEntry {
+  const { session } = record;
+  return {
+    id: session.id,
+    cwd: session.cwd,
+    title: session.title,
+    messageCount: session.messages.length,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    agentLoopStatePath: session.agentLoopStatePath,
+    agentLoopStatus: session.agentLoopStatus,
+    agentLoopResumable: session.agentLoopResumable,
+  };
+}
+
+function toPersistedSession(session: LoadedChatSession): ChatSession {
+  return {
+    id: session.id,
+    cwd: session.cwd,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    messages: [...session.messages],
+    ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
+    ...(session.title !== null ? { title: session.title } : {}),
+    ...(session.agentLoopStatePath !== null ? { agentLoopStatePath: session.agentLoopStatePath } : {}),
+    ...(session.agentLoopStatus === "running" || session.agentLoopStatus === "completed" || session.agentLoopStatus === "failed"
+      ? { agentLoopStatus: session.agentLoopStatus }
+      : {}),
+    ...(session.agentLoopResumable ? { agentLoopResumable: true } : {}),
+    ...(session.agentLoopUpdatedAt !== null && session.agentLoopUpdatedAt !== undefined
+      ? { agentLoopUpdatedAt: session.agentLoopUpdatedAt }
+      : {}),
+    ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
+  };
+}
+
+export class ChatSessionCatalog {
+  constructor(private readonly stateManager: StateManager) {}
+
+  private get baseDir(): string {
+    return this.stateManager.getBaseDir();
+  }
+
+  private sessionRelativePath(sessionId: string): string {
+    return path.join(CHAT_SESSION_DIR, `${sessionId}.json`);
+  }
+
+  private sessionAbsolutePath(sessionId: string): string {
+    return path.join(this.baseDir, this.sessionRelativePath(sessionId));
+  }
+
+  private async readSessionRecord(sessionId: string): Promise<LoadedChatSession | null> {
+    const record = await readSessionRecordWithMetadata(this.stateManager, this.baseDir, sessionId);
+    return record?.session ?? null;
+  }
+
+  private async listSessionRecords(): Promise<SessionRecord[]> {
+    const dir = path.join(this.baseDir, CHAT_SESSION_DIR);
+    let entries: Dirent[];
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw error;
+    }
+
+    const records: SessionRecord[] = [];
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+      const sessionId = entry.name.slice(0, -".json".length);
+      try {
+        const record = await readSessionRecordWithMetadata(this.stateManager, this.baseDir, sessionId);
+        if (record) records.push(record);
+      } catch {
+        continue;
+      }
+    }
+
+    records.sort((left, right) => {
+      if (right.activityAtMs !== left.activityAtMs) return right.activityAtMs - left.activityAtMs;
+      if (right.fileMtimeMs !== left.fileMtimeMs) return right.fileMtimeMs - left.fileMtimeMs;
+      return left.session.id.localeCompare(right.session.id);
+    });
+
+    return records;
+  }
+
+  async loadSession(sessionId: string): Promise<LoadedChatSession | null> {
+    return this.readSessionRecord(sessionId);
+  }
+
+  async listSessions(options: ChatSessionListOptions = {}): Promise<ChatSessionCatalogEntry[]> {
+    const records = await this.listSessionRecords();
+    const cwd = options.cwd?.trim();
+    const catalogEntries = records.map(buildCatalogEntry);
+    return cwd ? catalogEntries.filter((entry) => entry.cwd === cwd) : catalogEntries;
+  }
+
+  async latestSession(options: ChatSessionListOptions = {}): Promise<ChatSessionCatalogEntry | null> {
+    const sessions = await this.listSessions(options);
+    return sessions[0] ?? null;
+  }
+
+  async resolveSelector(selector: string): Promise<ChatSessionCatalogEntry> {
+    const normalizedSelector = selector.trim();
+    if (!normalizedSelector) {
+      throw new ChatSessionSelectorError("Chat session selector cannot be empty.", selector, "not_found");
+    }
+
+    const sessions = await this.listSessions();
+
+    const exactId = sessions.find((session) => session.id === normalizedSelector);
+    if (exactId) return exactId;
+
+    const exactTitleMatches = sessions.filter((session) => session.title === normalizedSelector);
+    if (exactTitleMatches.length === 1) return exactTitleMatches[0];
+    if (exactTitleMatches.length > 1) {
+      throw new ChatSessionSelectorError(
+        `Ambiguous chat session title "${normalizedSelector}" matches ${exactTitleMatches.length} sessions.`,
+        selector,
+        "ambiguous",
+        exactTitleMatches.map((session) => session.id),
+      );
+    }
+
+    const prefixMatches = sessions.filter((session) => session.id.startsWith(normalizedSelector));
+    if (prefixMatches.length === 1) return prefixMatches[0];
+    if (prefixMatches.length > 1) {
+      throw new ChatSessionSelectorError(
+        `Ambiguous chat session id prefix "${normalizedSelector}" matches ${prefixMatches.length} sessions.`,
+        selector,
+        "ambiguous",
+        prefixMatches.map((session) => session.id),
+      );
+    }
+
+    throw new ChatSessionSelectorError(
+      `No chat session matched selector "${normalizedSelector}".`,
+      selector,
+      "not_found",
+    );
+  }
+
+  async loadSessionBySelector(selector: string): Promise<LoadedChatSession | null> {
+    const resolved = await this.resolveSelector(selector);
+    return this.loadSession(resolved.id);
+  }
+
+  async renameSession(selector: string, title: string | null): Promise<LoadedChatSession> {
+    const resolved = await this.resolveSelector(selector);
+    const session = await this.loadSession(resolved.id);
+    if (!session) {
+      throw new ChatSessionSelectorError(
+        `Chat session "${resolved.id}" disappeared before it could be renamed.`,
+        selector,
+        "not_found",
+      );
+    }
+
+    const normalizedTitle = normalizeTitle(title);
+    const updatedAt = new Date().toISOString();
+    const persisted = toPersistedSession(session);
+    const { title: _existingTitle, ...withoutTitle } = persisted;
+    const updated: ChatSession = {
+      ...(normalizedTitle !== null ? persisted : withoutTitle),
+      ...(normalizedTitle !== null ? { title: normalizedTitle } : {}),
+      updatedAt,
+    };
+    await this.stateManager.writeRaw(this.sessionRelativePath(session.id), updated);
+    return {
+      id: session.id,
+      cwd: session.cwd,
+      createdAt: session.createdAt,
+      updatedAt,
+      title: normalizedTitle,
+      messages: [...session.messages],
+      ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
+      agentLoopStatePath: session.agentLoopStatePath,
+      agentLoopStatus: session.agentLoopStatus,
+      agentLoopResumable: session.agentLoopResumable,
+      ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
+    };
+  }
+
+  async cleanupSessions(options: ChatSessionCleanupOptions = {}): Promise<ChatSessionCleanupReport> {
+    const dryRun = options.dryRun ?? true;
+    const activeSessionId = options.activeSessionId?.trim() || null;
+    const olderThanMs = options.olderThanMs ?? DEFAULT_SESSION_TTL_MS;
+    const now = options.now ?? Date.now();
+    const threshold = now - olderThanMs;
+    const sessions = await this.listSessionRecords();
+    const retainedSessionIds: string[] = [];
+    const removedSessionIds: string[] = [];
+    const removedAgentLoopStatePaths: string[] = [];
+
+    for (const record of sessions) {
+      const protectedSession = activeSessionId !== null && record.session.id === activeSessionId;
+      const isOld = record.activityAtMs < threshold;
+      if (!protectedSession && isOld) {
+        removedSessionIds.push(record.session.id);
+        const statePath = record.session.agentLoopStatePath ?? path.join(CHAT_AGENTLOOP_DIR, `${record.session.id}.state.json`);
+        if (statePath) removedAgentLoopStatePaths.push(statePath);
+        continue;
+      }
+      retainedSessionIds.push(record.session.id);
+    }
+
+    if (!dryRun) {
+      for (const sessionId of removedSessionIds) {
+        await fsp.rm(this.sessionAbsolutePath(sessionId), { force: true });
+      }
+
+      for (const relativeStatePath of removedAgentLoopStatePaths) {
+        const resolved = resolvePathWithinBaseDir(this.baseDir, relativeStatePath);
+        if (!resolved) continue;
+        await fsp.rm(resolved.absolute, { force: true });
+      }
+    }
+
+    return {
+      dryRun,
+      olderThanMs,
+      activeSessionId,
+      totalSessions: sessions.length,
+      retainedSessionIds,
+      removedSessionIds,
+      removedAgentLoopStatePaths: [...new Set(removedAgentLoopStatePaths)],
+    };
+  }
+}

--- a/src/interface/cli/__tests__/chat-command.test.ts
+++ b/src/interface/cli/__tests__/chat-command.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StateManager } from "../../../base/state/state-manager.js";
+import { ChatSessionCatalog } from "../../chat/chat-session-store.js";
+import {
+  chatMessagesFromSession,
+  parseChatCommandRequest,
+  printChatCommandUsage,
+  resolveSessionForIntent,
+  runCatalogOnlyIntent,
+} from "../commands/chat-session-cli.js";
+import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+
+async function makeStateManager(): Promise<{ stateManager: StateManager; tmpDir: string }> {
+  const tmpDir = makeTempDir();
+  const stateManager = new StateManager(tmpDir);
+  await stateManager.init();
+  return { stateManager, tmpDir };
+}
+
+async function seedChatSession(stateManager: StateManager, id: string, title: string, cwd = "/repo"): Promise<void> {
+  await stateManager.writeRaw(`chat/sessions/${id}.json`, {
+    id,
+    cwd,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:01.000Z",
+    title,
+    messages: [
+      { role: "user", content: "hello", timestamp: "2026-01-01T00:00:00.000Z", turnIndex: 0 },
+      { role: "assistant", content: "hi", timestamp: "2026-01-01T00:00:01.000Z", turnIndex: 1 },
+    ],
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseChatCommandRequest", () => {
+  it("parses continue without a selector", () => {
+    const request = parseChatCommandRequest(["--continue"]);
+    expect(request.intent).toEqual(expect.objectContaining({
+      action: "continue",
+      selector: undefined,
+    }));
+  });
+
+  it("parses continue with an optional selector", () => {
+    const request = parseChatCommandRequest(["--continue", "nightly-session"]);
+    expect(request.intent).toEqual(expect.objectContaining({
+      action: "continue",
+      selector: "nightly-session",
+    }));
+  });
+
+  it("parses resume with a selector and title", () => {
+    const request = parseChatCommandRequest(["--resume", "session-123", "--title", "warm start"]);
+    expect(request.intent).toEqual(expect.objectContaining({
+      action: "resume",
+      selector: "session-123",
+      title: "warm start",
+    }));
+  });
+
+  it("parses short resume with a selector", () => {
+    const request = parseChatCommandRequest(["-r", "session-123"]);
+    expect(request.intent).toEqual(expect.objectContaining({
+      action: "resume",
+      selector: "session-123",
+    }));
+  });
+
+  it("parses title rename with an optional selector", () => {
+    const request = parseChatCommandRequest(["--title", "warm start", "session-123"]);
+    expect(request.intent).toEqual(expect.objectContaining({
+      action: "rename",
+      selector: "session-123",
+      title: "warm start",
+    }));
+  });
+
+  it("cleanup enforces by default when dry-run is absent", () => {
+    const request = parseChatCommandRequest(["--cleanup-sessions"]);
+    expect(request.intent).toEqual(expect.objectContaining({
+      action: "cleanup",
+      dryRun: false,
+    }));
+  });
+
+  it("does not treat dry-run alone as cleanup", () => {
+    const request = parseChatCommandRequest(["--dry-run", "inspect state"]);
+    expect(request.intent).toBeNull();
+    expect(request.task).toBe("inspect state");
+  });
+
+  it("parses cleanup with dry run", () => {
+    const request = parseChatCommandRequest(["--cleanup-sessions", "--dry-run"]);
+    expect(request.intent).toEqual(expect.objectContaining({
+      action: "cleanup",
+      dryRun: true,
+    }));
+  });
+
+  it("treats a positional argument as a task when no session flags are present", () => {
+    const request = parseChatCommandRequest(["refactor the chat entrypoint"]);
+    expect(request.task).toBe("refactor the chat entrypoint");
+    expect(request.intent).toBeNull();
+  });
+});
+
+describe("printChatCommandUsage", () => {
+  it("documents the chat session control surface and storage contract", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    printChatCommandUsage();
+
+    expect(logSpy).toHaveBeenCalled();
+    const printed = logSpy.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(printed).toContain("--continue");
+    expect(printed).toContain("--resume");
+    expect(printed).toContain("~/.pulseed/chat/sessions/<id>.json");
+    expect(printed).toContain("--cleanup-sessions");
+  });
+});
+
+describe("chat session CLI helpers", () => {
+  it("lists sessions and prints history", async () => {
+    const { stateManager, tmpDir } = await makeStateManager();
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      await seedChatSession(stateManager, "session-1", "First");
+
+      await expect(runCatalogOnlyIntent(stateManager, { action: "list" }, "/repo")).resolves.toBe(0);
+      expect(writeSpy.mock.calls.map((call) => String(call[0])).join("")).toContain("session-1");
+
+      writeSpy.mockClear();
+      await expect(runCatalogOnlyIntent(stateManager, { action: "history", selector: "First" }, "/repo")).resolves.toBe(0);
+      const historyOutput = writeSpy.mock.calls.map((call) => String(call[0])).join("");
+      expect(historyOutput).toContain("User: hello");
+      expect(historyOutput).toContain("Assistant: hi");
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("renames and cleanup sessions through catalog-only intents", async () => {
+    const { stateManager, tmpDir } = await makeStateManager();
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      await seedChatSession(stateManager, "session-1", "First", tmpDir);
+
+      await expect(runCatalogOnlyIntent(stateManager, { action: "rename", selector: "session-1", title: "Renamed" }, tmpDir)).resolves.toBe(0);
+      await expect(new ChatSessionCatalog(stateManager).loadSession("session-1")).resolves.toMatchObject({ title: "Renamed" });
+
+      await expect(runCatalogOnlyIntent(stateManager, { action: "cleanup", dryRun: true }, tmpDir)).resolves.toBe(0);
+      expect(writeSpy.mock.calls.map((call) => String(call[0])).join("")).toContain("would remove");
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("resolves resume intent and applies title rename before opening", async () => {
+    const { stateManager, tmpDir } = await makeStateManager();
+    try {
+      await seedChatSession(stateManager, "session-1", "First", tmpDir);
+
+      const resolved = await resolveSessionForIntent(
+        new ChatSessionCatalog(stateManager),
+        { action: "resume", selector: "session-1", title: "Warm Start" },
+        tmpDir,
+      );
+
+      expect(resolved).toMatchObject({ id: "session-1", title: "Warm Start" });
+      const messages = chatMessagesFromSession(resolved!);
+      expect(messages.map((message) => message.text)).toEqual([
+        "Resumed chat session session-1 \"Warm Start\".",
+        "hello",
+        "hi",
+      ]);
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+});

--- a/src/interface/cli/commands/chat-session-cli.ts
+++ b/src/interface/cli/commands/chat-session-cli.ts
@@ -1,0 +1,320 @@
+// ─── Chat session CLI helpers ───
+
+import { randomUUID } from "node:crypto";
+import { parseArgs } from "node:util";
+
+import { StateManager } from "../../../base/state/state-manager.js";
+import { resolveGitRoot } from "../../../platform/observation/context-provider.js";
+import {
+  ChatSessionCatalog,
+  ChatSessionSelectorError,
+  type ChatSessionCatalogEntry,
+  type LoadedChatSession,
+} from "../../chat/chat-session-store.js";
+import type { ChatMessage } from "../../tui/chat.js";
+import { getCliLogger } from "../cli-logger.js";
+
+const logger = getCliLogger();
+const CHAT_SESSION_STORAGE_PATH = "~/.pulseed/chat/sessions/<id>.json";
+const CHAT_SESSION_STORAGE_DIR = "~/.pulseed/chat/sessions/";
+const CHAT_SESSION_CLEANUP_NOTE = "Sessions not accessed in 7 days are eligible for cleanup.";
+const DEFAULT_CHAT_SESSION_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+type ChatSessionAction =
+  | "list"
+  | "history"
+  | "resume"
+  | "continue"
+  | "rename"
+  | "cleanup";
+
+export interface ChatSessionIntent {
+  action: ChatSessionAction;
+  selector?: string;
+  title?: string;
+  dryRun?: boolean;
+}
+
+export interface ChatCommandRequest {
+  adapter?: string;
+  timeoutMs: number;
+  task?: string;
+  intent: ChatSessionIntent | null;
+}
+
+interface ParsedChatCommandValues {
+  adapter?: string;
+  timeout?: string;
+  continue?: boolean;
+  resume?: string;
+  sessions?: boolean;
+  history?: string;
+  title?: string;
+  "cleanup-sessions"?: boolean;
+  "dry-run"?: boolean;
+}
+
+function parseTimeout(timeout: string | undefined): number {
+  if (timeout === undefined) {
+    return 120_000;
+  }
+
+  const parsed = Number.parseInt(timeout, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    throw new Error(`Invalid --timeout value: "${timeout}"`);
+  }
+
+  return parsed;
+}
+
+function buildIntent(values: ParsedChatCommandValues, positionals: string[]): ChatSessionIntent | null {
+  if (values["cleanup-sessions"]) {
+    return {
+      action: "cleanup",
+      dryRun: Boolean(values["dry-run"]),
+    };
+  }
+  if (values.sessions) {
+    return { action: "list" };
+  }
+  if (values.history !== undefined) {
+    return {
+      action: "history",
+      selector: values.history,
+      title: values.title,
+    };
+  }
+  if (values.resume !== undefined) {
+    return {
+      action: "resume",
+      selector: values.resume,
+      title: values.title,
+    };
+  }
+  if (values.continue) {
+    return {
+      action: "continue",
+      selector: positionals[0],
+      title: values.title,
+    };
+  }
+  if (values.title !== undefined) {
+    return {
+      action: "rename",
+      selector: positionals[0],
+      title: values.title,
+    };
+  }
+  return null;
+}
+
+export function printChatCommandUsage(): void {
+  const usage = `
+pulseed chat — interactive chat and session controls
+
+Usage:
+  pulseed chat [task]
+  pulseed chat --continue [id-or-title]
+  pulseed chat -c [id-or-title]
+  pulseed chat --resume <id-or-title>
+  pulseed chat --sessions
+  pulseed chat --history <id-or-title>
+  pulseed chat --title <title>
+  pulseed chat --cleanup-sessions [--dry-run]
+
+Options:
+  --adapter <type>        Adapter: claude_api | claude_code_cli | github_issue
+  --timeout <ms>          Override command timeout (default: 120000)
+  --continue, -c          Continue the latest chat session, or the one selected by the optional positional argument
+  --resume <selector>     Resume a session by ID or title
+  --sessions              List chat sessions
+  --history <selector>    Show the history for a session
+  --title <title>         Rename the selected or current session
+  --cleanup-sessions      Clean up stale chat sessions in ${CHAT_SESSION_STORAGE_DIR}
+  --dry-run               Preview cleanup without deleting anything
+
+Persistence contract:
+  Sessions are stored under ${CHAT_SESSION_STORAGE_PATH}
+  ${CHAT_SESSION_CLEANUP_NOTE}
+`.trim();
+
+  console.log(usage);
+}
+
+export function parseChatCommandRequest(argv: string[]): ChatCommandRequest {
+  const parsed = parseArgs({
+    args: argv,
+    options: {
+      adapter: { type: "string" },
+      timeout: { type: "string" },
+      continue: { type: "boolean", short: "c" },
+      resume: { type: "string", short: "r" },
+      sessions: { type: "boolean" },
+      history: { type: "string" },
+      title: { type: "string" },
+      "cleanup-sessions": { type: "boolean" },
+      "dry-run": { type: "boolean" },
+    },
+    allowPositionals: true,
+    strict: false,
+  }) as { values: ParsedChatCommandValues; positionals: string[] };
+  const { values, positionals } = parsed;
+  const intent = buildIntent(values, positionals);
+
+  return {
+    adapter: values.adapter,
+    timeoutMs: parseTimeout(values.timeout),
+    ...(intent ? { intent } : { task: positionals[0], intent: null }),
+  };
+}
+
+function formatCatalogEntry(entry: ChatSessionCatalogEntry): string {
+  const title = entry.title ? ` "${entry.title}"` : "";
+  const resumable = entry.agentLoopResumable ? " resumable" : "";
+  return `${entry.id}${title} - ${entry.messageCount} message(s), updated ${entry.updatedAt}, cwd ${entry.cwd}${resumable}`;
+}
+
+function formatSessionHistory(session: LoadedChatSession): string {
+  const title = session.title ? ` "${session.title}"` : "";
+  if (session.messages.length === 0) {
+    return `Session ${session.id}${title} has no messages.`;
+  }
+  const transcript = session.messages.map((message) => {
+    const role = message.role === "assistant" ? "Assistant" : "User";
+    return `${role}: ${message.content}`;
+  });
+  return `Session ${session.id}${title} (${session.cwd})\n${transcript.join("\n")}`;
+}
+
+async function resolveCatalogEntry(
+  catalog: ChatSessionCatalog,
+  selector: string | undefined,
+  cwd: string,
+): Promise<ChatSessionCatalogEntry | null> {
+  if (selector) {
+    return await catalog.resolveSelector(selector);
+  }
+  return await catalog.latestSession({ cwd: resolveGitRoot(cwd) });
+}
+
+export async function resolveSessionForIntent(
+  catalog: ChatSessionCatalog,
+  intent: ChatSessionIntent,
+  cwd: string,
+): Promise<LoadedChatSession | null> {
+  if (intent.action !== "continue" && intent.action !== "resume") return null;
+  const entry = await resolveCatalogEntry(catalog, intent.selector, cwd);
+  if (!entry) {
+    throw new Error(`No chat session found for ${resolveGitRoot(cwd)}.`);
+  }
+  if (intent.title) {
+    return await catalog.renameSession(entry.id, intent.title);
+  }
+  const session = await catalog.loadSession(entry.id);
+  if (!session) {
+    throw new Error(`Chat session "${entry.id}" disappeared before it could be resumed.`);
+  }
+  return session;
+}
+
+export function chatMessagesFromSession(session: LoadedChatSession): ChatMessage[] {
+  const title = session.title ? ` "${session.title}"` : "";
+  const messages: ChatMessage[] = [
+    {
+      id: randomUUID(),
+      role: "pulseed",
+      text: `Resumed chat session ${session.id}${title}.`,
+      timestamp: new Date(),
+      messageType: "info",
+    },
+  ];
+  for (const message of session.messages) {
+    messages.push({
+      id: randomUUID(),
+      role: message.role === "assistant" ? "pulseed" : "user",
+      text: message.content,
+      timestamp: Number.isNaN(Date.parse(message.timestamp)) ? new Date() : new Date(message.timestamp),
+    });
+  }
+  return messages;
+}
+
+async function runListIntent(catalog: ChatSessionCatalog): Promise<number> {
+  const sessions = await catalog.listSessions();
+  process.stdout.write(sessions.length === 0 ? "No chat sessions found.\n" : `Chat sessions:\n${sessions.map(formatCatalogEntry).join("\n")}\n`);
+  return 0;
+}
+
+async function runHistoryIntent(catalog: ChatSessionCatalog, intent: ChatSessionIntent): Promise<number> {
+  if (!intent.selector) {
+    logger.error("Error: --history requires a session ID or title.");
+    return 1;
+  }
+  const session = await catalog.loadSessionBySelector(intent.selector);
+  if (!session) {
+    logger.error(`No chat session matched selector "${intent.selector}".`);
+    return 1;
+  }
+  process.stdout.write(formatSessionHistory(session) + "\n");
+  return 0;
+}
+
+async function runRenameIntent(catalog: ChatSessionCatalog, intent: ChatSessionIntent, cwd: string): Promise<number> {
+  if (!intent.title) {
+    logger.error("Error: --title requires a non-empty title.");
+    return 1;
+  }
+  const entry = await resolveCatalogEntry(catalog, intent.selector, cwd);
+  if (!entry) {
+    logger.error(`No chat session found for ${resolveGitRoot(cwd)}.`);
+    return 1;
+  }
+  const renamed = await catalog.renameSession(entry.id, intent.title);
+  process.stdout.write(`Renamed chat session ${renamed.id} to "${renamed.title}".\n`);
+  return 0;
+}
+
+async function runCleanupIntent(catalog: ChatSessionCatalog, intent: ChatSessionIntent): Promise<number> {
+  const report = await catalog.cleanupSessions({
+    dryRun: Boolean(intent.dryRun),
+    olderThanMs: DEFAULT_CHAT_SESSION_TTL_MS,
+  });
+  const verb = report.dryRun ? "would remove" : "removed";
+  process.stdout.write(`Chat session cleanup ${verb} ${report.removedSessionIds.length} session(s).\n`);
+  if (report.removedSessionIds.length > 0) {
+    process.stdout.write(report.removedSessionIds.join("\n") + "\n");
+  }
+  return 0;
+}
+
+export async function runCatalogOnlyIntent(
+  stateManager: StateManager,
+  intent: ChatSessionIntent,
+  cwd: string,
+): Promise<number> {
+  const catalog = new ChatSessionCatalog(stateManager);
+  try {
+    switch (intent.action) {
+      case "list":
+        return await runListIntent(catalog);
+      case "history":
+        return await runHistoryIntent(catalog, intent);
+      case "rename":
+        return await runRenameIntent(catalog, intent, cwd);
+      case "cleanup":
+        return await runCleanupIntent(catalog, intent);
+      case "continue":
+      case "resume":
+        return 0;
+    }
+  } catch (err) {
+    if (err instanceof ChatSessionSelectorError) {
+      logger.error(err.message);
+      if (err.matches.length > 0) {
+        logger.error(`Matches: ${err.matches.join(", ")}`);
+      }
+      return 1;
+    }
+    throw err;
+  }
+}

--- a/src/interface/cli/commands/chat.ts
+++ b/src/interface/cli/commands/chat.ts
@@ -2,7 +2,6 @@
 
 import React, { useState, useCallback, useEffect } from "react";
 import { render, useApp } from "ink";
-import { parseArgs } from "node:util";
 import { randomUUID } from "node:crypto";
 import { createInterface } from "node:readline";
 import * as path from "node:path";
@@ -14,6 +13,7 @@ import { loadProviderConfig } from "../../../base/llm/provider-config.js";
 import { formatOperationError } from "../utils.js";
 import { getCliLogger } from "../cli-logger.js";
 import type { ChatRunner } from "../../chat/chat-runner.js";
+import { ChatSessionCatalog, ChatSessionSelectorError, type LoadedChatSession } from "../../chat/chat-session-store.js";
 import { Chat, type ChatMessage } from "../../tui/chat.js";
 import { EthicsGate } from "../../../platform/traits/ethics-gate.js";
 import { ObservationEngine } from "../../../platform/observation/observation-engine.js";
@@ -34,8 +34,18 @@ import {
   RuntimeControlService,
   createDaemonRuntimeControlExecutor,
 } from "../../../runtime/control/index.js";
+import {
+  chatMessagesFromSession,
+  parseChatCommandRequest,
+  printChatCommandUsage,
+  resolveSessionForIntent,
+  runCatalogOnlyIntent,
+  type ChatCommandRequest,
+} from "./chat-session-cli.js";
 
 const logger = getCliLogger();
+
+export { parseChatCommandRequest, printChatCommandUsage } from "./chat-session-cli.js";
 
 async function promptChatApproval(reason: string): Promise<boolean> {
   if (!process.stdin.isTTY) return false;
@@ -66,11 +76,12 @@ interface ChatAppProps {
   chatRunner: ChatRunner;
   cwd: string;
   timeoutMs: number;
+  initialMessages?: ChatMessage[];
 }
 
-function ChatApp({ chatRunner, cwd, timeoutMs }: ChatAppProps) {
+function ChatApp({ chatRunner, cwd, timeoutMs, initialMessages }: ChatAppProps) {
   const { exit } = useApp();
-  const [messages, setMessages] = useState<ChatMessage[]>([
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages ?? [
     {
       id: randomUUID(),
       role: "pulseed",
@@ -98,7 +109,9 @@ function ChatApp({ chatRunner, cwd, timeoutMs }: ChatAppProps) {
   );
 
   useEffect(() => {
-    chatRunner.startSession(cwd);
+    if (chatRunner.getSessionId() === null) {
+      chatRunner.startSession(cwd);
+    }
     // Wire notification callback so /tend daemon events appear in chat
     chatRunner.onNotification = pushNotification;
     chatRunner.onEvent = (event) => {
@@ -147,174 +160,259 @@ function ChatApp({ chatRunner, cwd, timeoutMs }: ChatAppProps) {
 
 // ─── Command handler ───
 
+type ChatProviderConfig = Awaited<ReturnType<typeof loadProviderConfig>>;
+type ChatLLMClient = Awaited<ReturnType<typeof buildLLMClient>>;
+
+const SESSION_RESOLVE_FAILED = Symbol("session-resolve-failed");
+
+function isCatalogOnlyIntent(request: ChatCommandRequest): boolean {
+  return request.intent !== null && request.intent.action !== "continue" && request.intent.action !== "resume";
+}
+
+async function resolveAdapterType(requestedAdapter: string | undefined): Promise<string> {
+  if (requestedAdapter) {
+    return requestedAdapter;
+  }
+  try {
+    const providerConfig = await loadProviderConfig();
+    return providerConfig.adapter;
+  } catch {
+    return "claude_code_cli";
+  }
+}
+
+async function buildChatToolRuntime(
+  stateManager: StateManager,
+  llmClient: ChatLLMClient,
+  effectiveProviderConfig: ChatProviderConfig,
+  pulseedDir: string,
+) {
+  const trustManager = new TrustManager(stateManager);
+  const scheduleEngine = new ScheduleEngine({ baseDir: pulseedDir });
+  await scheduleEngine.loadEntries();
+
+  const registry = new ToolRegistry();
+  for (const tool of createBuiltinTools({
+    stateManager,
+    trustManager,
+    registry,
+    scheduleEngine,
+  })) {
+    registry.register(tool);
+  }
+
+  const permissionManager = new ToolPermissionManager({
+    trustManager,
+    allowRules: [
+      {
+        toolName: "shell",
+        inputMatcher: (input) =>
+          typeof input === "object" &&
+          input !== null &&
+          typeof (input as Record<string, unknown>)["command"] === "string" &&
+          isSafeBashCommand((input as Record<string, unknown>)["command"] as string),
+        reason: "safe shell command",
+      },
+    ],
+  });
+  const toolExecutor = new ToolExecutor({
+    registry,
+    permissionManager,
+    concurrency: new ConcurrencyController(),
+  });
+  const chatAgentLoopRunner = shouldUseNativeTaskAgentLoop(effectiveProviderConfig, llmClient)
+    ? createNativeChatAgentLoopRunner({
+        llmClient,
+        providerConfig: effectiveProviderConfig,
+        toolRegistry: registry,
+        toolExecutor,
+        cwd: process.cwd(),
+        traceBaseDir: stateManager.getBaseDir(),
+      })
+    : undefined;
+
+  return { registry, toolExecutor, chatAgentLoopRunner };
+}
+
+async function buildEscalationDeps(stateManager: StateManager, llmClient: ChatLLMClient): Promise<{
+  escalationHandler?: EscalationHandler;
+  goalNegotiatorForTend?: GoalNegotiator;
+}> {
+  try {
+    const ethicsGate = new EthicsGate(stateManager, llmClient);
+    const observationEngine = new ObservationEngine(stateManager, [], llmClient);
+    const goalNegotiator = new GoalNegotiator(stateManager, llmClient, ethicsGate, observationEngine);
+    return {
+      escalationHandler: new EscalationHandler({ stateManager, llmClient, goalNegotiator }),
+      goalNegotiatorForTend: goalNegotiator,
+    };
+  } catch {
+    logger.warn("Escalation handler could not be initialized — /track and /tend will be unavailable");
+    return {};
+  }
+}
+
+async function buildDaemonDeps(pulseedDir: string): Promise<{
+  daemonClient?: DaemonClient;
+  daemonBaseUrl?: string;
+}> {
+  try {
+    const daemonInfo = await isDaemonRunning(pulseedDir);
+    if (!daemonInfo.running) {
+      return {};
+    }
+    if (daemonInfo.authToken) {
+      process.env["PULSEED_DAEMON_TOKEN"] = daemonInfo.authToken;
+    }
+    return {
+      daemonClient: new DaemonClient({
+        host: "127.0.0.1",
+        port: daemonInfo.port,
+        authToken: daemonInfo.authToken,
+        baseDir: pulseedDir,
+      }),
+      daemonBaseUrl: `http://127.0.0.1:${daemonInfo.port}`,
+    };
+  } catch {
+    return {};
+  }
+}
+
+async function createChatRunnerForCommand(stateManager: StateManager, request: ChatCommandRequest): Promise<ChatRunner> {
+  const adapterType = await resolveAdapterType(request.adapter);
+  await ensureProviderConfig();
+
+  const llmClient = await buildLLMClient();
+  const providerConfig = await loadProviderConfig();
+  const effectiveProviderConfig = {
+    ...providerConfig,
+    adapter: adapterType as typeof providerConfig.adapter,
+  };
+  const adapterRegistry = await buildAdapterRegistry(llmClient, effectiveProviderConfig);
+  const adapter = adapterRegistry.getAdapter(adapterType);
+  const pulseedDir = stateManager.getBaseDir();
+  const { registry, toolExecutor, chatAgentLoopRunner } = await buildChatToolRuntime(
+    stateManager,
+    llmClient,
+    effectiveProviderConfig,
+    pulseedDir,
+  );
+  const { escalationHandler, goalNegotiatorForTend } = await buildEscalationDeps(stateManager, llmClient);
+  const { daemonClient, daemonBaseUrl } = await buildDaemonDeps(pulseedDir);
+  const { ChatRunner } = await import("../../chat/chat-runner.js");
+
+  return new ChatRunner({
+    adapter,
+    stateManager,
+    llmClient,
+    escalationHandler,
+    goalNegotiator: goalNegotiatorForTend,
+    daemonClient,
+    daemonBaseUrl,
+    registry,
+    toolExecutor,
+    chatAgentLoopRunner,
+    approvalFn: promptChatApproval,
+    runtimeControlService: new RuntimeControlService({
+      runtimeRoot: path.join(stateManager.getBaseDir(), "runtime"),
+      executor: createDaemonRuntimeControlExecutor({
+        baseDir: stateManager.getBaseDir(),
+      }),
+    }),
+    runtimeReplyTarget: { surface: "cli" },
+  });
+}
+
+async function startRequestedSession(
+  chatRunner: ChatRunner,
+  stateManager: StateManager,
+  request: ChatCommandRequest,
+): Promise<LoadedChatSession | null | typeof SESSION_RESOLVE_FAILED> {
+  if (!request.intent) {
+    return null;
+  }
+  try {
+    const resumedSession = await resolveSessionForIntent(
+      new ChatSessionCatalog(stateManager),
+      request.intent,
+      process.cwd(),
+    );
+    if (resumedSession) {
+      chatRunner.startSessionFromLoadedSession(resumedSession);
+    }
+    return resumedSession;
+  } catch (err) {
+    if (err instanceof ChatSessionSelectorError) {
+      logger.error(err.message);
+      if (err.matches.length > 0) {
+        logger.error(`Matches: ${err.matches.join(", ")}`);
+      }
+      return SESSION_RESOLVE_FAILED;
+    }
+    throw err;
+  }
+}
+
+async function runChatRequest(
+  chatRunner: ChatRunner,
+  request: ChatCommandRequest,
+  resumedSession: LoadedChatSession | null,
+): Promise<number> {
+  if (request.task) {
+    const result = await chatRunner.execute(request.task, process.cwd(), request.timeoutMs);
+    if (result.output) {
+      process.stdout.write(result.output + "\n");
+    }
+    return result.success ? 0 : 1;
+  }
+
+  const { waitUntilExit } = render(
+    React.createElement(ChatApp, {
+      chatRunner,
+      cwd: process.cwd(),
+      timeoutMs: request.timeoutMs,
+      initialMessages: resumedSession ? chatMessagesFromSession(resumedSession) : undefined,
+    })
+  );
+  await waitUntilExit();
+  return 0;
+}
+
+async function runCatalogIntentWithErrorHandling(stateManager: StateManager, request: ChatCommandRequest): Promise<number> {
+  try {
+    return await runCatalogOnlyIntent(stateManager, request.intent!, process.cwd());
+  } catch (err) {
+    logger.error(formatOperationError("execute chat command", err));
+    return 1;
+  }
+}
+
 export async function cmdChat(
   stateManager: StateManager,
   argv: string[]
 ): Promise<number> {
-  let values: { adapter?: string; timeout?: string };
-  let positionals: string[];
+  if (argv.includes("--help") || argv.includes("-h")) {
+    printChatCommandUsage();
+    return 0;
+  }
+
+  let request: ChatCommandRequest;
   try {
-    const parsed = parseArgs({
-      args: argv,
-      options: {
-        adapter: { type: "string" },
-        timeout: { type: "string" },
-      },
-      allowPositionals: true,
-      strict: false,
-    }) as { values: { adapter?: string; timeout?: string }; positionals: string[] };
-    values = parsed.values;
-    positionals = parsed.positionals;
+    request = parseChatCommandRequest(argv);
   } catch (err) {
     logger.error(formatOperationError("parse chat command arguments", err));
     return 1;
   }
 
-  const task = positionals[0];
-
-  try {
-    await ensureProviderConfig();
-  } catch (err) {
-    logger.error(err instanceof Error ? err.message : String(err));
-    return 1;
-  }
-
-  const timeoutMs = values.timeout !== undefined ? parseInt(values.timeout, 10) : 120_000;
-
-  let adapterType = values.adapter;
-  if (!adapterType) {
-    try {
-      const providerConfig = await loadProviderConfig();
-      adapterType = providerConfig.adapter;
-    } catch {
-      adapterType = "claude_code_cli";
-    }
+  if (isCatalogOnlyIntent(request)) {
+    return await runCatalogIntentWithErrorHandling(stateManager, request);
   }
 
   try {
-    const llmClient = await buildLLMClient();
-    const providerConfig = await loadProviderConfig();
-    const effectiveProviderConfig = {
-      ...providerConfig,
-      adapter: adapterType as typeof providerConfig.adapter,
-    };
-    const adapterRegistry = await buildAdapterRegistry(llmClient, effectiveProviderConfig);
-    const adapter = adapterRegistry.getAdapter(adapterType);
-    const pulseedDir = stateManager.getBaseDir();
-    const trustManager = new TrustManager(stateManager);
-    const scheduleEngine = new ScheduleEngine({ baseDir: pulseedDir });
-    await scheduleEngine.loadEntries();
-    const registry = new ToolRegistry();
-    for (const tool of createBuiltinTools({
-      stateManager,
-      trustManager,
-      registry,
-      scheduleEngine,
-    })) {
-      registry.register(tool);
-    }
-    const permissionManager = new ToolPermissionManager({
-      trustManager,
-      allowRules: [
-        {
-          toolName: "shell",
-          inputMatcher: (input) =>
-            typeof input === "object" &&
-            input !== null &&
-            typeof (input as Record<string, unknown>)["command"] === "string" &&
-            isSafeBashCommand((input as Record<string, unknown>)["command"] as string),
-          reason: "safe shell command",
-        },
-      ],
-    });
-    const toolExecutor = new ToolExecutor({
-      registry,
-      permissionManager,
-      concurrency: new ConcurrencyController(),
-    });
-    const chatAgentLoopRunner = shouldUseNativeTaskAgentLoop(effectiveProviderConfig, llmClient)
-      ? createNativeChatAgentLoopRunner({
-          llmClient,
-          providerConfig: effectiveProviderConfig,
-          toolRegistry: registry,
-          toolExecutor,
-          cwd: process.cwd(),
-          traceBaseDir: stateManager.getBaseDir(),
-        })
-      : undefined;
-
-    // Build escalation + tend deps (optional — /track and /tend work only when LLM is available)
-    let escalationHandler: EscalationHandler | undefined;
-    let goalNegotiatorForTend: GoalNegotiator | undefined;
-    try {
-      const ethicsGate = new EthicsGate(stateManager, llmClient);
-      const observationEngine = new ObservationEngine(stateManager, [], llmClient);
-      const goalNegotiator = new GoalNegotiator(stateManager, llmClient, ethicsGate, observationEngine);
-      escalationHandler = new EscalationHandler({ stateManager, llmClient, goalNegotiator });
-      goalNegotiatorForTend = goalNegotiator;
-    } catch {
-      // Non-fatal: /track and /tend will show "not available" if deps fail to init
-      logger.warn("Escalation handler could not be initialized — /track and /tend will be unavailable");
-    }
-
-    // Build daemon client for /tend (optional — degrades gracefully if daemon not running)
-    let daemonClient: DaemonClient | undefined;
-    let daemonBaseUrl: string | undefined;
-    try {
-      const daemonInfo = await isDaemonRunning(pulseedDir);
-      if (daemonInfo.running) {
-        if (daemonInfo.authToken) {
-          process.env["PULSEED_DAEMON_TOKEN"] = daemonInfo.authToken;
-        }
-        daemonClient = new DaemonClient({
-          host: "127.0.0.1",
-          port: daemonInfo.port,
-          authToken: daemonInfo.authToken,
-          baseDir: pulseedDir,
-        });
-        daemonBaseUrl = `http://127.0.0.1:${daemonInfo.port}`;
-      }
-    } catch {
-      // Non-fatal: /tend will show "daemon not available" message
-    }
-
-    const { ChatRunner } = await import("../../chat/chat-runner.js");
-    const chatRunner = new ChatRunner({
-      adapter,
-      stateManager,
-      llmClient,
-      escalationHandler,
-      goalNegotiator: goalNegotiatorForTend,
-      daemonClient,
-      daemonBaseUrl,
-      registry,
-      toolExecutor,
-      chatAgentLoopRunner,
-      approvalFn: promptChatApproval,
-      runtimeControlService: new RuntimeControlService({
-        runtimeRoot: path.join(stateManager.getBaseDir(), "runtime"),
-        executor: createDaemonRuntimeControlExecutor({
-          baseDir: stateManager.getBaseDir(),
-        }),
-      }),
-      runtimeReplyTarget: { surface: "cli" },
-    });
-
-    // Non-interactive: single turn
-    if (task) {
-      const result = await chatRunner.execute(task, process.cwd(), timeoutMs);
-      if (result.output) {
-        process.stdout.write(result.output + "\n");
-      }
-      return result.success ? 0 : 1;
-    }
-
-    // Interactive REPL
-    const { waitUntilExit } = render(
-      React.createElement(ChatApp, { chatRunner, cwd: process.cwd(), timeoutMs })
-    );
-    await waitUntilExit();
-    return 0;
+    const chatRunner = await createChatRunnerForCommand(stateManager, request);
+    const resumedSession = await startRequestedSession(chatRunner, stateManager, request);
+    if (resumedSession === SESSION_RESOLVE_FAILED) return 1;
+    return await runChatRequest(chatRunner, request, resumedSession);
   } catch (err) {
     logger.error(formatOperationError("execute chat command", err));
     return 1;


### PR DESCRIPTION
## Summary
- add a durable chat session catalog for listing, loading, selector resolution, titles, agentloop freshness, and cleanup
- wire ChatRunner slash commands and CLI flags for sessions, history, title, cleanup, continue, and resume-by-selector
- update docs/exports and add focused session catalog, runner, and CLI parser tests

Closes #671.

## Verification
- npm exec tsc --noEmit
- npm exec vitest run src/interface/chat/__tests__/chat-history.test.ts src/interface/chat/__tests__/chat-session-store.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/interface/cli/__tests__/chat-command.test.ts
- npm run check:docs
- npm test