### PR TITLE
Add schedule lifecycle controls

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,13 @@ Common scriptable commands:
 | `pulseed start --goal <id>` | Start the daemon |
 | `pulseed stop` | Stop the daemon |
 | `pulseed cron --goal <id>` | Print a cron entry |
+| `pulseed schedule list` | List schedule entries |
+| `pulseed schedule show <id>` | Inspect one schedule entry |
+| `pulseed schedule edit <id>` | Edit a schedule entry's name, trigger, enabled state, or layer config |
+| `pulseed schedule pause <id>` | Pause a schedule without deleting it |
+| `pulseed schedule resume <id>` | Resume a paused schedule |
+| `pulseed schedule run <id>` | Run a schedule entry immediately for validation |
+| `pulseed schedule history <id>` | Show recent schedule execution history |
 
 ## 10. Practical guidance
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,7 +170,7 @@ Common scriptable commands:
 | `pulseed schedule edit <id>` | Edit a schedule entry's name, trigger, enabled state, or layer config |
 | `pulseed schedule pause <id>` | Pause a schedule without deleting it |
 | `pulseed schedule resume <id>` | Resume a paused schedule |
-| `pulseed schedule run <id>` | Run a schedule entry immediately for validation |
+| `pulseed schedule run <id>` | Run a schedule entry immediately, using the resident daemon when it is running |
 | `pulseed schedule history <id>` | Show recent schedule execution history |
 
 ## 10. Practical guidance

--- a/docs/design/infrastructure/schedule-engine.md
+++ b/docs/design/infrastructure/schedule-engine.md
@@ -754,6 +754,9 @@ pulseed schedule resume <id>
 # Run immediately for validation
 pulseed schedule run <id>
 
+# If the daemon is resident, this queues the run into that daemon instead of
+# executing the schedule in a short-lived CLI process.
+
 # Remove
 pulseed schedule remove <id>
 

--- a/docs/design/infrastructure/schedule-engine.md
+++ b/docs/design/infrastructure/schedule-engine.md
@@ -738,12 +738,21 @@ Schedule entries are persisted to `~/.pulseed/schedules.json`. This file is mana
 # List all schedule entries
 pulseed schedule list
 
-# Add a new entry (interactive or from JSON)
-pulseed schedule add --name "morning-briefing" --layer cron --cron "0 8 * * *"
+# Show one entry
+pulseed schedule show <id>
 
-# Enable/disable
-pulseed schedule enable <id>
-pulseed schedule disable <id>
+# Add a preset-backed cron entry
+pulseed schedule add --preset daily_brief --name "morning-briefing" --cron "0 8 * * *"
+
+# Edit fields without deleting and recreating
+pulseed schedule edit <id> --name "morning-briefing" --cron "0 9 * * *" --timezone Asia/Tokyo
+
+# Pause/resume
+pulseed schedule pause <id>
+pulseed schedule resume <id>
+
+# Run immediately for validation
+pulseed schedule run <id>
 
 # Remove
 pulseed schedule remove <id>

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -40,6 +40,26 @@ It keeps the runtime alive for long-running goal work and recovery.
 The normal user-facing path is to ask PulSeed to keep a goal moving in the background.
 Scriptable daemon and cron subcommands remain lower-level controls.
 
+## Schedule Operations
+
+PulSeed schedules are managed by the ScheduleEngine, which supports heartbeat,
+probe, cron, and goal-trigger entries. The scriptable lifecycle commands are:
+
+```bash
+pulseed schedule list
+pulseed schedule show <id>
+pulseed schedule add --preset daily_brief
+pulseed schedule edit <id> --name "Morning brief" --cron "0 9 * * *" --timezone Asia/Tokyo
+pulseed schedule pause <id>
+pulseed schedule resume <id>
+pulseed schedule run <id>
+pulseed schedule history <id> --limit 10
+pulseed schedule remove <id>
+```
+
+`run` executes an entry immediately and records it as manual history. It does
+not resume a paused schedule unless `resume` is used separately.
+
 ## What runtime does not explain
 
 This page does not restate the loop model, verification model, or completion model in full.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -57,8 +57,10 @@ pulseed schedule history <id> --limit 10
 pulseed schedule remove <id>
 ```
 
-`run` executes an entry immediately and records it as manual history. It does
-not resume a paused schedule unless `resume` is used separately.
+`run` executes an entry immediately and records it as manual history. When the
+daemon is running, the request is accepted by the daemon and runs inside the
+resident ScheduleEngine; otherwise the CLI falls back to a local validation run.
+It does not resume a paused schedule unless `resume` is used separately.
 
 ## What runtime does not explain
 

--- a/src/interface/chat/__tests__/chat-schedule-integration.test.ts
+++ b/src/interface/chat/__tests__/chat-schedule-integration.test.ts
@@ -80,6 +80,7 @@ function makeScheduleEngine(entries: ReturnType<typeof makeScheduleEntry>[] = []
     addEntry: vi.fn().mockResolvedValue(makeScheduleEntry()),
     updateEntry: vi.fn().mockResolvedValue(null),
     removeEntry: vi.fn().mockResolvedValue(false),
+    runEntryNow: vi.fn().mockResolvedValue(null),
   } as unknown as ScheduleEngine;
 }
 
@@ -137,6 +138,7 @@ describe("ChatRunner schedule integration", () => {
     expect(parsed.seenTools).toContain("list_schedules");
     expect(registry.get("create_schedule")).toBeDefined();
     expect(registry.get("list_schedules")).toBeDefined();
+    expect(registry.get("run_schedule")).toBeDefined();
   });
 
   it("runs list_schedules through the chat tool execution path", async () => {
@@ -234,6 +236,70 @@ describe("ChatRunner schedule integration", () => {
       "Creating a persistent schedule changes background automation and requires approval",
     );
     expect(vi.mocked(scheduleEngine.addEntry)).toHaveBeenCalledOnce();
+  });
+
+  it("routes run_schedule through approvalFn before executing", async () => {
+    const entry = makeScheduleEntry();
+    const scheduleEngine = makeScheduleEngine([entry]);
+    vi.mocked(scheduleEngine.runEntryNow).mockResolvedValue({
+      entry,
+      reason: "manual_run",
+      result: {
+        entry_id: entry.id,
+        status: "ok",
+        duration_ms: 2,
+        fired_at: "2026-04-08T00:00:00.000Z",
+        layer: "cron",
+        tokens_used: 0,
+        escalated_to: null,
+        output_summary: "done",
+      },
+    });
+    const registry = buildRegistry(scheduleEngine);
+    const approvalFn = vi.fn().mockResolvedValue(true);
+    const llmClient = {
+      supportsToolCalling: () => true,
+      sendMessage: vi.fn()
+        .mockResolvedValueOnce({
+          content: "",
+          tool_calls: [
+            {
+              id: "tool-call-1",
+              function: {
+                name: "run_schedule",
+                arguments: JSON.stringify({
+                  schedule_id: entry.id.slice(0, 8),
+                }),
+              },
+            },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "tool_use",
+        })
+        .mockResolvedValueOnce({
+          content: "Ran schedule",
+          tool_calls: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "completed",
+        }),
+    };
+
+    const runner = new ChatRunner(makeDeps({
+      registry,
+      llmClient: llmClient as never,
+      approvalFn,
+    }));
+
+    await runner.execute("run the daily digest schedule now", "/tmp");
+
+    expect(approvalFn).toHaveBeenCalledOnce();
+    expect(approvalFn).toHaveBeenCalledWith(
+      "Running a persistent schedule may execute background automation and requires approval",
+    );
+    expect(vi.mocked(scheduleEngine.runEntryNow)).toHaveBeenCalledWith(
+      entry.id,
+      { allowEscalation: false, preserveEnabled: true },
+    );
   });
 
   it("supports preset-based schedule creation through the chat tool path", async () => {

--- a/src/interface/cli/__tests__/schedule-command.test.ts
+++ b/src/interface/cli/__tests__/schedule-command.test.ts
@@ -97,4 +97,100 @@ describe("cmdSchedule", () => {
       cleanupTempDir(tempDir);
     }
   });
+
+  it("pauses, resumes, and edits a schedule entry", async () => {
+    const tempDir = makeTempDir("schedule-command-lifecycle-");
+    try {
+      vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await cmdSchedule(makeStateManager(tempDir), [
+        "add",
+        "--name",
+        "custom-check",
+        "--type",
+        "custom",
+        "--command",
+        "echo ok",
+        "--interval",
+        "60",
+      ]);
+
+      let engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      const id = engine.getEntries()[0]!.id;
+
+      await cmdSchedule(makeStateManager(tempDir), ["pause", id.slice(0, 8)]);
+      engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      expect(engine.getEntries()[0]!.enabled).toBe(false);
+
+      await cmdSchedule(makeStateManager(tempDir), ["resume", id.slice(0, 8)]);
+      engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      expect(engine.getEntries()[0]!.enabled).toBe(true);
+
+      await cmdSchedule(makeStateManager(tempDir), [
+        "edit",
+        id.slice(0, 8),
+        "--name",
+        "renamed-check",
+        "--cron",
+        "0 9 * * *",
+        "--timezone",
+        "Asia/Tokyo",
+        "--disabled",
+      ]);
+
+      engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      expect(engine.getEntries()[0]).toEqual(expect.objectContaining({
+        name: "renamed-check",
+        enabled: false,
+        trigger: { type: "cron", expression: "0 9 * * *", timezone: "Asia/Tokyo" },
+      }));
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  });
+
+  it("runs a paused schedule entry immediately without resuming it and exposes history", async () => {
+    const tempDir = makeTempDir("schedule-command-run-now-");
+    try {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await cmdSchedule(makeStateManager(tempDir), [
+        "add",
+        "--name",
+        "manual-run-check",
+        "--type",
+        "custom",
+        "--command",
+        "echo ok",
+        "--interval",
+        "60",
+      ]);
+
+      let engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      const id = engine.getEntries()[0]!.id;
+
+      await cmdSchedule(makeStateManager(tempDir), ["pause", id]);
+      await cmdSchedule(makeStateManager(tempDir), ["run", id]);
+
+      engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      expect(engine.getEntries()[0]!.enabled).toBe(false);
+      expect(engine.getEntries()[0]!.total_executions).toBe(1);
+
+      const history = await engine.getRecentHistory(10, id);
+      expect(history).toHaveLength(1);
+      expect(history[0]!.reason).toBe("manual_run");
+      expect(history[0]!.status).toBe("ok");
+
+      await cmdSchedule(makeStateManager(tempDir), ["history", id, "--limit", "1"]);
+      expect(logSpy.mock.calls.some((call) => String(call[0]).includes("manual_run"))).toBe(true);
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  });
 });

--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -325,7 +325,7 @@ export async function dispatchCommand(
   }
 
   if (subcommand === "schedule") {
-    await cmdSchedule(stateManager, argv.slice(1));
+    await cmdSchedule(stateManager, argv.slice(1), characterConfigManager);
     return 0;
   }
 

--- a/src/interface/cli/cli-runner.ts
+++ b/src/interface/cli/cli-runner.ts
@@ -14,6 +14,10 @@
 //   pulseed start --goal <id>          Start daemon mode for one or more goals
 //   pulseed stop                       Stop the running daemon
 //   pulseed cron --goal <id>           Print crontab entry for a goal
+//   pulseed schedule list              List schedule entries
+//   pulseed schedule pause <id>        Pause a schedule entry
+//   pulseed schedule resume <id>       Resume a paused schedule entry
+//   pulseed schedule run <id>          Run a schedule entry immediately
 //   pulseed cleanup                    Archive all completed goals and remove stale data
 //   pulseed improve [path]             Analyze, suggest goals, and run improvement loop
 //   pulseed suggest "<context>"        Suggest improvement goals for a project

--- a/src/interface/cli/commands/schedule.ts
+++ b/src/interface/cli/commands/schedule.ts
@@ -1,6 +1,7 @@
 import { parseArgs } from "node:util";
 import { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
+import type { CharacterConfigManager } from "../../../platform/traits/character-config.js";
 import {
   buildSchedulePresetEntry,
   listSchedulePresetDefinitions,
@@ -8,10 +9,15 @@ import {
 } from "../../../runtime/schedule/presets.js";
 import { DreamScheduleSuggestionStore } from "../../../platform/dream/dream-schedule-suggestions.js";
 import type { ScheduleTriggerInput } from "../../../runtime/types/schedule.js";
+import { scheduleEdit } from "./schedule/edit.js";
+import { scheduleHistory } from "./schedule/history.js";
+import { scheduleRunNow } from "./schedule/run-now.js";
+import { getScheduleOrPrintError } from "./schedule/shared.js";
 
 export async function cmdSchedule(
   stateManager: StateManager,
   argv: string[],
+  characterConfigManager?: CharacterConfigManager,
 ): Promise<void> {
   const subcommand = argv[0];
   const baseDir = stateManager.getBaseDir();
@@ -21,8 +27,25 @@ export async function cmdSchedule(
   switch (subcommand) {
     case "list":
       return await scheduleList(engine);
+    case "show":
+    case "get":
+      return scheduleShow(engine, argv.slice(1));
     case "add":
       return await scheduleAdd(engine, argv.slice(1));
+    case "edit":
+    case "update":
+      return await scheduleEdit(engine, argv.slice(1));
+    case "pause":
+    case "disable":
+      return await scheduleSetEnabled(engine, argv.slice(1), false);
+    case "resume":
+    case "enable":
+      return await scheduleSetEnabled(engine, argv.slice(1), true);
+    case "run":
+    case "run-now":
+      return await scheduleRunNow(stateManager, characterConfigManager, engine, argv.slice(1));
+    case "history":
+      return await scheduleHistory(engine, argv.slice(1));
     case "remove":
       return await scheduleRemove(engine, argv.slice(1));
     case "presets":
@@ -30,9 +53,15 @@ export async function cmdSchedule(
     case "suggestions":
       return await scheduleSuggestions(baseDir, engine, argv.slice(1));
     default:
-      console.log("Usage: pulseed schedule <list|add|remove|presets|suggestions>");
+      console.log("Usage: pulseed schedule <list|show|add|edit|pause|resume|run|history|remove|presets|suggestions>");
       console.log("  list                              List all schedule entries");
+      console.log("  show <id>                         Show one schedule entry as JSON");
       console.log("  add                               Add a heartbeat entry or preset");
+      console.log("  edit <id>                         Edit name, trigger, enabled state, or layer config");
+      console.log("  pause <id>                        Disable a schedule entry without deleting it");
+      console.log("  resume <id>                       Re-enable a paused schedule entry");
+      console.log("  run <id>                          Run a schedule entry immediately");
+      console.log("  history <id> [--limit <n>]        Show recent execution history");
       console.log("  remove <id>                       Remove a schedule entry");
       console.log("  presets                           List reusable schedule presets");
       console.log("  suggestions <list|apply|reject|dismiss>  Review dream-generated suggestions");
@@ -58,6 +87,23 @@ async function scheduleList(engine: ScheduleEngine): Promise<void> {
       `  ${entry.id.slice(0, 8)}  [${entry.layer}] ${entry.name}  (${schedule})  ${status}  source: ${source}  last: ${lastFired}`
     );
   }
+}
+
+function scheduleShow(engine: ScheduleEngine, argv: string[]): void {
+  const entry = getScheduleOrPrintError(engine, argv[0]);
+  if (!entry) return;
+  console.log(JSON.stringify(entry, null, 2));
+}
+
+async function scheduleSetEnabled(engine: ScheduleEngine, argv: string[], enabled: boolean): Promise<void> {
+  const entry = getScheduleOrPrintError(engine, argv[0]);
+  if (!entry) return;
+  const updated = await engine.updateEntry(entry.id, { enabled });
+  if (!updated) {
+    console.error(`No schedule entry found matching: ${argv[0]}`);
+    return;
+  }
+  console.log(`${enabled ? "Resumed" : "Paused"} schedule entry: ${updated.id} (${updated.name})`);
 }
 
 function resolveOptionalTrigger(values: { cron?: string; interval?: string }): ScheduleTriggerInput | undefined {
@@ -95,6 +141,11 @@ function buildPresetInput(values: Record<string, unknown>): SchedulePresetInput 
           : typeof values["context-source"] === "string"
             ? [values["context-source"] as string]
             : [],
+      };
+    case "soil_publish":
+      return {
+        ...common,
+        preset: "soil_publish",
       };
     case "goal_probe":
       if (typeof values["data-source-id"] !== "string" || values["data-source-id"].length === 0) {
@@ -201,17 +252,8 @@ async function scheduleAdd(engine: ScheduleEngine, argv: string[]): Promise<void
 }
 
 async function scheduleRemove(engine: ScheduleEngine, argv: string[]): Promise<void> {
-  const id = argv[0];
-  if (!id) {
-    console.error("Error: schedule entry ID is required");
-    return;
-  }
-  const entries = engine.getEntries();
-  const match = entries.find((entry) => entry.id === id || entry.id.startsWith(id));
-  if (!match) {
-    console.error(`No schedule entry found matching: ${id}`);
-    return;
-  }
+  const match = getScheduleOrPrintError(engine, argv[0]);
+  if (!match) return;
   await engine.removeEntry(match.id);
   console.log(`Removed schedule entry: ${match.id} (${match.name})`);
 }

--- a/src/interface/cli/commands/schedule/__tests__/edit.test.ts
+++ b/src/interface/cli/commands/schedule/__tests__/edit.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { buildScheduleEditPatch } from "../edit.js";
+
+describe("buildScheduleEditPatch", () => {
+  it("builds name, enabled, and cron trigger updates", () => {
+    const patch = buildScheduleEditPatch({
+      name: "Morning brief",
+      enabled: true,
+      cron: "0 9 * * *",
+      timezone: "Asia/Tokyo",
+    });
+
+    expect(patch).toEqual({
+      name: "Morning brief",
+      enabled: true,
+      trigger: { type: "cron", expression: "0 9 * * *", timezone: "Asia/Tokyo" },
+    });
+  });
+
+  it("parses layer config and retry policy JSON", () => {
+    const patch = buildScheduleEditPatch({
+      "heartbeat-json": JSON.stringify({
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 5,
+        timeout_ms: 1000,
+      }),
+      "retry-policy-json": JSON.stringify({
+        enabled: true,
+        initial_delay_ms: 1000,
+        max_delay_ms: 5000,
+        multiplier: 2,
+        jitter_factor: 0,
+        max_attempts: 2,
+        max_retry_window_ms: 10000,
+        retryable_failure_kinds: ["transient"],
+      }),
+    });
+
+    expect(patch.heartbeat).toEqual({
+      check_type: "custom",
+      check_config: { command: "echo ok" },
+      failure_threshold: 5,
+      timeout_ms: 1000,
+    });
+    expect(patch.retry_policy).toEqual(expect.objectContaining({
+      initial_delay_ms: 1000,
+      max_attempts: 2,
+    }));
+  });
+
+  it("rejects conflicting enabled flags", () => {
+    expect(() => buildScheduleEditPatch({ enabled: true, disabled: true })).toThrow(
+      "Use only one of --enabled or --disabled",
+    );
+  });
+
+  it("rejects conflicting trigger flags", () => {
+    expect(() => buildScheduleEditPatch({ cron: "0 9 * * *", interval: "60" })).toThrow(
+      "Use only one of --cron or --interval",
+    );
+  });
+
+  it("rejects invalid JSON config", () => {
+    expect(() => buildScheduleEditPatch({ "cron-json": "{bad" })).toThrow("--cron-json is not valid JSON");
+  });
+});

--- a/src/interface/cli/commands/schedule/edit.ts
+++ b/src/interface/cli/commands/schedule/edit.ts
@@ -1,0 +1,93 @@
+import { parseArgs } from "node:util";
+import type { ScheduleEntryUpdateInput, ScheduleEngine } from "../../../../runtime/schedule/engine.js";
+import {
+  CronConfigSchema,
+  EscalationConfigSchema,
+  GoalTriggerConfigSchema,
+  HeartbeatConfigSchema,
+  ProbeConfigSchema,
+  ScheduleRetryPolicySchema,
+} from "../../../../runtime/types/schedule.js";
+import { getScheduleOrPrintError, parseJsonConfig, resolveTriggerPatch } from "./shared.js";
+
+export async function scheduleEdit(engine: ScheduleEngine, argv: string[]): Promise<void> {
+  let parsed: ReturnType<typeof parseArgs>;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      allowPositionals: true,
+      options: {
+        name: { type: "string" },
+        cron: { type: "string" },
+        interval: { type: "string" },
+        timezone: { type: "string" },
+        enabled: { type: "boolean" },
+        disabled: { type: "boolean" },
+        "heartbeat-json": { type: "string" },
+        "probe-json": { type: "string" },
+        "cron-json": { type: "string" },
+        "goal-trigger-json": { type: "string" },
+        "escalation-json": { type: "string" },
+        "clear-escalation": { type: "boolean" },
+        "retry-policy-json": { type: "string" },
+      },
+      strict: false,
+    });
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    return;
+  }
+
+  const id = parsed.positionals[0];
+  const entry = getScheduleOrPrintError(engine, id);
+  if (!entry) return;
+
+  try {
+    const patch = buildScheduleEditPatch(parsed.values as Record<string, unknown>);
+    const updated = await engine.updateEntry(entry.id, patch);
+    if (!updated) {
+      console.error(`No schedule entry found matching: ${id}`);
+      return;
+    }
+    console.log(`Updated schedule entry: ${updated.id} (${updated.name})`);
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+  }
+}
+
+export function buildScheduleEditPatch(values: Record<string, unknown>): ScheduleEntryUpdateInput {
+  if (values.enabled === true && values.disabled === true) {
+    throw new Error("Use only one of --enabled or --disabled");
+  }
+  if (values["escalation-json"] !== undefined && values["clear-escalation"] === true) {
+    throw new Error("Use only one of --escalation-json or --clear-escalation");
+  }
+
+  const patch: ScheduleEntryUpdateInput = {};
+  if (typeof values.name === "string") patch.name = values.name;
+  if (values.enabled === true) patch.enabled = true;
+  if (values.disabled === true) patch.enabled = false;
+
+  const trigger = resolveTriggerPatch({
+    cron: typeof values.cron === "string" ? values.cron : undefined,
+    interval: typeof values.interval === "string" ? values.interval : undefined,
+    timezone: typeof values.timezone === "string" ? values.timezone : undefined,
+  });
+  if (trigger) patch.trigger = trigger;
+
+  const heartbeat = parseJsonConfig(values["heartbeat-json"], HeartbeatConfigSchema, "--heartbeat-json");
+  if (heartbeat) patch.heartbeat = heartbeat;
+  const probe = parseJsonConfig(values["probe-json"], ProbeConfigSchema, "--probe-json");
+  if (probe) patch.probe = probe;
+  const cron = parseJsonConfig(values["cron-json"], CronConfigSchema, "--cron-json");
+  if (cron) patch.cron = cron;
+  const goalTrigger = parseJsonConfig(values["goal-trigger-json"], GoalTriggerConfigSchema, "--goal-trigger-json");
+  if (goalTrigger) patch.goal_trigger = goalTrigger;
+  const escalation = parseJsonConfig(values["escalation-json"], EscalationConfigSchema, "--escalation-json");
+  if (escalation) patch.escalation = escalation;
+  if (values["clear-escalation"] === true) patch.escalation = null;
+  const retryPolicy = parseJsonConfig(values["retry-policy-json"], ScheduleRetryPolicySchema, "--retry-policy-json");
+  if (retryPolicy) patch.retry_policy = retryPolicy;
+
+  return patch;
+}

--- a/src/interface/cli/commands/schedule/history.ts
+++ b/src/interface/cli/commands/schedule/history.ts
@@ -1,0 +1,41 @@
+import { parseArgs } from "node:util";
+import type { ScheduleEngine } from "../../../../runtime/schedule/engine.js";
+import { getScheduleOrPrintError, parsePositiveInteger } from "./shared.js";
+
+export async function scheduleHistory(engine: ScheduleEngine, argv: string[]): Promise<void> {
+  let parsed: ReturnType<typeof parseArgs>;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      allowPositionals: true,
+      options: {
+        limit: { type: "string", default: "10" },
+      },
+      strict: false,
+    });
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    return;
+  }
+
+  const entry = getScheduleOrPrintError(engine, parsed.positionals[0]);
+  if (!entry) return;
+
+  try {
+    const limit = parsePositiveInteger(String(parsed.values.limit ?? "10"), "--limit");
+    const records = await engine.getRecentHistory(limit, entry.id);
+    if (records.length === 0) {
+      console.log(`No schedule history for ${entry.id} (${entry.name}).`);
+      return;
+    }
+    for (const record of records) {
+      const error = record.error_message ? ` error=${record.error_message}` : "";
+      const output = record.output_summary ? ` output=${record.output_summary}` : "";
+      console.log(
+        `  ${record.fired_at}  ${record.reason}  ${record.status}  attempt=${record.attempt}${error}${output}`
+      );
+    }
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+  }
+}

--- a/src/interface/cli/commands/schedule/run-now.ts
+++ b/src/interface/cli/commands/schedule/run-now.ts
@@ -1,0 +1,103 @@
+import { parseArgs } from "node:util";
+import type { StateManager } from "../../../../base/state/state-manager.js";
+import type { CharacterConfigManager } from "../../../../platform/traits/character-config.js";
+import { ScheduleEngine } from "../../../../runtime/schedule/engine.js";
+import type { ScheduleEntry } from "../../../../runtime/types/schedule.js";
+import { buildDeps } from "../../setup.js";
+import { getCliLogger } from "../../cli-logger.js";
+import { getScheduleOrPrintError } from "./shared.js";
+
+async function buildScheduleRunEngine(
+  stateManager: StateManager,
+  characterConfigManager: CharacterConfigManager | undefined,
+  entry: ScheduleEntry,
+  allowEscalation: boolean,
+): Promise<ScheduleEngine> {
+  const canRunWithLocalDeps =
+    !allowEscalation &&
+    (entry.layer === "heartbeat" ||
+      (entry.layer === "cron" && entry.cron?.job_kind === "soil_publish"));
+
+  if (!characterConfigManager || canRunWithLocalDeps) {
+    const engine = new ScheduleEngine({ baseDir: stateManager.getBaseDir() });
+    await engine.loadEntries();
+    return engine;
+  }
+
+  const deps = await buildDeps(
+    stateManager,
+    characterConfigManager,
+    undefined,
+    undefined,
+    getCliLogger(),
+  );
+  const engine = new ScheduleEngine({
+    baseDir: stateManager.getBaseDir(),
+    logger: getCliLogger(),
+    dataSourceRegistry: deps.dataSourceRegistry,
+    llmClient: deps.llmClient,
+    coreLoop: deps.coreLoop,
+    stateManager: deps.stateManager,
+    reportingEngine: deps.reportingEngine,
+    hookManager: deps.hookManager,
+    memoryLifecycle: deps.memoryLifecycleManager,
+    knowledgeManager: deps.knowledgeManager,
+  });
+  await engine.loadEntries();
+  return engine;
+}
+
+export async function scheduleRunNow(
+  stateManager: StateManager,
+  characterConfigManager: CharacterConfigManager | undefined,
+  fallbackEngine: ScheduleEngine,
+  argv: string[],
+): Promise<void> {
+  let parsed: ReturnType<typeof parseArgs>;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      allowPositionals: true,
+      options: {
+        "with-escalation": { type: "boolean" },
+      },
+      strict: false,
+    });
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    return;
+  }
+
+  const id = parsed.positionals[0];
+  const preflightEntry = getScheduleOrPrintError(fallbackEngine, id);
+  if (!preflightEntry) return;
+
+  try {
+    const allowEscalation = parsed.values["with-escalation"] === true;
+    const runEngine = await buildScheduleRunEngine(
+      stateManager,
+      characterConfigManager,
+      preflightEntry,
+      allowEscalation,
+    );
+    const entry = getScheduleOrPrintError(runEngine, preflightEntry.id);
+    if (!entry) return;
+
+    const result = await runEngine.runEntryNow(entry.id, {
+      allowEscalation,
+      preserveEnabled: true,
+    });
+    if (!result) {
+      console.error(`No schedule entry found matching: ${id}`);
+      return;
+    }
+
+    const summary = result.result.output_summary ? `: ${result.result.output_summary}` : "";
+    console.log(`Ran schedule entry: ${entry.id} (${entry.name}) -> ${result.result.status}${summary}`);
+    if (result.result.error_message) {
+      console.error(`Error: ${result.result.error_message}`);
+    }
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+  }
+}

--- a/src/interface/cli/commands/schedule/run-now.ts
+++ b/src/interface/cli/commands/schedule/run-now.ts
@@ -1,6 +1,7 @@
 import { parseArgs } from "node:util";
 import type { StateManager } from "../../../../base/state/state-manager.js";
 import type { CharacterConfigManager } from "../../../../platform/traits/character-config.js";
+import { DaemonClient, isDaemonRunning } from "../../../../runtime/daemon/client.js";
 import { ScheduleEngine } from "../../../../runtime/schedule/engine.js";
 import type { ScheduleEntry } from "../../../../runtime/types/schedule.js";
 import { buildDeps } from "../../setup.js";
@@ -47,6 +48,27 @@ async function buildScheduleRunEngine(
   return engine;
 }
 
+async function requestDaemonRunNow(
+  stateManager: StateManager,
+  entry: ScheduleEntry,
+  allowEscalation: boolean,
+): Promise<boolean> {
+  const daemon = await isDaemonRunning(stateManager.getBaseDir());
+  if (!daemon.running) {
+    return false;
+  }
+
+  const client = new DaemonClient({
+    host: "127.0.0.1",
+    port: daemon.port,
+    authToken: daemon.authToken,
+    baseDir: stateManager.getBaseDir(),
+  });
+  await client.runScheduleNow(entry.id, { allowEscalation });
+  console.log(`Requested daemon schedule run: ${entry.id} (${entry.name})`);
+  return true;
+}
+
 export async function scheduleRunNow(
   stateManager: StateManager,
   characterConfigManager: CharacterConfigManager | undefined,
@@ -74,6 +96,9 @@ export async function scheduleRunNow(
 
   try {
     const allowEscalation = parsed.values["with-escalation"] === true;
+    const daemonAccepted = await requestDaemonRunNow(stateManager, preflightEntry, allowEscalation);
+    if (daemonAccepted) return;
+
     const runEngine = await buildScheduleRunEngine(
       stateManager,
       characterConfigManager,

--- a/src/interface/cli/commands/schedule/shared.ts
+++ b/src/interface/cli/commands/schedule/shared.ts
@@ -1,0 +1,74 @@
+import type { z } from "zod";
+import type { ScheduleEngine } from "../../../../runtime/schedule/engine.js";
+import { resolveScheduleEntry } from "../../../../runtime/schedule/entry-resolver.js";
+import type { ScheduleEntry, ScheduleTriggerInput } from "../../../../runtime/types/schedule.js";
+
+export function getScheduleOrPrintError(engine: ScheduleEngine, id: string | undefined): ScheduleEntry | null {
+  if (!id) {
+    console.error("Error: schedule entry ID is required");
+    return null;
+  }
+  try {
+    const match = resolveScheduleEntry(engine.getEntries(), id);
+    if (!match) {
+      console.error(`No schedule entry found matching: ${id}`);
+      return null;
+    }
+    return match;
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+export function parsePositiveInteger(value: string | undefined, label: string): number {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    throw new Error(`${label} must be a positive integer`);
+  }
+  return parsed;
+}
+
+export function parseJsonConfig<T>(
+  raw: unknown,
+  parser: Pick<z.ZodType<T>, "parse">,
+  label: string,
+): T | undefined {
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw new Error(`${label} must be a non-empty JSON string`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`${label} is not valid JSON: ${(err as Error).message}`);
+  }
+  try {
+    return parser.parse(parsed);
+  } catch (err) {
+    throw new Error(`${label} failed schema validation: ${(err as Error).message}`);
+  }
+}
+
+export function resolveTriggerPatch(values: {
+  cron?: string;
+  interval?: string;
+  timezone?: string;
+}): ScheduleTriggerInput | undefined {
+  if (values.cron && values.interval) {
+    throw new Error("Use only one of --cron or --interval");
+  }
+  if (values.cron) {
+    return { type: "cron", expression: values.cron, timezone: values.timezone ?? "UTC" };
+  }
+  if (values.interval) {
+    return { type: "interval", seconds: parsePositiveInteger(values.interval, "--interval"), jitter_factor: 0 };
+  }
+  if (values.timezone) {
+    throw new Error("--timezone can only be used with --cron");
+  }
+  return undefined;
+}

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -463,6 +463,7 @@ export async function buildDeps(
     stateManager,
     driveSystem,
     llmClient,
+    dataSourceRegistry: new Map(dataSources.map((adapter) => [adapter.sourceId, adapter])),
     hookManager,
     memoryLifecycleManager,
     knowledgeManager,

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -49,6 +49,11 @@ Usage:
   pulseed daemon status                Show running daemon status
   pulseed daemon ping                  Check daemon responsiveness
   pulseed cron --goal <id>             Print crontab entry for a goal
+  pulseed schedule list                List schedule entries
+  pulseed schedule edit <id>           Edit a schedule entry
+  pulseed schedule pause <id>          Pause a schedule without deleting it
+  pulseed schedule resume <id>         Resume a paused schedule
+  pulseed schedule run <id>            Run a schedule entry immediately
   pulseed config show                  Show current configuration
   pulseed config set <key> <value>     Set a configuration value
   pulseed config get <key>             Get a configuration value

--- a/src/runtime/__tests__/daemon-client.test.ts
+++ b/src/runtime/__tests__/daemon-client.test.ts
@@ -160,6 +160,36 @@ describe("DaemonClient snapshot + replay", () => {
       },
     });
   });
+
+  it("sends schedule run-now requests as daemon command envelopes", async () => {
+    const envelopes: unknown[] = [];
+    server.setCommandEnvelopeHook((envelope) => {
+      envelopes.push(envelope);
+    });
+    await server.start();
+
+    const client = new DaemonClient({
+      host: "127.0.0.1",
+      port: server.getPort(),
+      authToken: server.getAuthToken(),
+    });
+
+    await expect(client.runScheduleNow("sched-1", {
+      allowEscalation: true,
+    })).resolves.toEqual({ ok: true, scheduleId: "sched-1" });
+
+    expect(envelopes).toHaveLength(1);
+    expect(envelopes[0]).toMatchObject({
+      type: "command",
+      name: "schedule_run_now",
+      source: "http",
+      priority: "high",
+      payload: {
+        scheduleId: "sched-1",
+        allowEscalation: true,
+      },
+    });
+  });
 });
 
 describe("isDaemonRunning", () => {

--- a/src/runtime/__tests__/daemon-runner-bus.test.ts
+++ b/src/runtime/__tests__/daemon-runner-bus.test.ts
@@ -264,6 +264,75 @@ describe("DaemonRunner durable runtime wiring", () => {
     );
   });
 
+  it("dispatches schedule_run_now commands through the daemon ScheduleEngine", async () => {
+    const mockEventServer = {
+      setEnvelopeHook: vi.fn(),
+      setCommandEnvelopeHook: vi.fn(),
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      startFileWatcher: vi.fn(),
+      stopFileWatcher: vi.fn(),
+      getPort: vi.fn().mockReturnValue(41700),
+      setActiveWorkersProvider: vi.fn(),
+    };
+
+    let capturedCommandHook:
+      | ((envelope: import("../types/envelope.js").Envelope) => void | Promise<void>)
+      | undefined;
+    mockEventServer.setCommandEnvelopeHook.mockImplementation(
+      (hook: (envelope: import("../types/envelope.js").Envelope) => void | Promise<void>) => {
+        capturedCommandHook = hook;
+      }
+    );
+
+    const entry = {
+      id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      name: "Daily digest",
+    };
+    const mockScheduleEngine = {
+      loadEntries: vi.fn().mockResolvedValue([entry]),
+      getEntries: vi.fn().mockReturnValue([entry]),
+      runEntryNow: vi.fn().mockResolvedValue({
+        entry,
+        reason: "manual_run",
+        result: {
+          status: "ok",
+        },
+      }),
+    };
+    const deps = makeDeps(tmpDir, {
+      eventServer: mockEventServer as any,
+      scheduleEngine: mockScheduleEngine as any,
+      config: { check_interval_ms: 50 },
+    });
+
+    const daemon = new DaemonRunner(deps);
+    currentDaemon = daemon;
+    currentStartPromise = daemon.start([]);
+
+    await waitFor(() => capturedCommandHook !== undefined);
+
+    await capturedCommandHook?.(
+      createEnvelope({
+        type: "command",
+        name: "schedule_run_now",
+        source: "http",
+        payload: {
+          scheduleId: "aaaaaaaa",
+          allowEscalation: true,
+        },
+      })
+    );
+
+    await waitFor(() => mockScheduleEngine.runEntryNow.mock.calls.length > 0);
+
+    expect(mockScheduleEngine.loadEntries).toHaveBeenCalled();
+    expect(mockScheduleEngine.runEntryNow).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      { allowEscalation: true, preserveEnabled: true }
+    );
+  });
+
   it("dispatches durable chat_message commands into DriveSystem events", async () => {
     const mockEventServer = {
       setEnvelopeHook: vi.fn(),

--- a/src/runtime/__tests__/event-server.test.ts
+++ b/src/runtime/__tests__/event-server.test.ts
@@ -598,6 +598,30 @@ describe("goal action commands", () => {
     );
   });
 
+  it("sends schedule run-now requests through the command hook as command envelopes", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    server.setCommandEnvelopeHook((envelope) => {
+      seen.push(envelope as unknown as Record<string, unknown>);
+    });
+
+    const result = await makeRequest(port, "POST", "/schedules/sched-1/run", {
+      allowEscalation: true,
+    });
+
+    expect(result.status).toBe(200);
+    expect(JSON.parse(result.body)).toEqual({ ok: true, scheduleId: "sched-1" });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual(
+      expect.objectContaining({
+        type: "command",
+        name: "schedule_run_now",
+        source: "http",
+        priority: "high",
+        payload: { scheduleId: "sched-1", allowEscalation: true },
+      })
+    );
+  });
+
   it("rejects approval responses for unknown requests before command accept", async () => {
     const hook = vi.fn();
     server.setCommandEnvelopeHook(hook);

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -252,6 +252,34 @@ describe("ScheduleEngine", () => {
     expect(updated!.next_fire_at).not.toBe("2026-04-07T00:00:00.000Z");
   });
 
+  it("runEntryNow executes immediately without resuming a paused entry", async () => {
+    const entry = await engine.addEntry({
+      name: "manual-run-check",
+      layer: "heartbeat",
+      trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+      enabled: false,
+      heartbeat: {
+        check_type: "custom",
+        check_config: { command: "echo ok" },
+        failure_threshold: 3,
+        timeout_ms: 5000,
+      },
+    });
+
+    const run = await engine.runEntryNow(entry.id);
+
+    expect(run?.result.status).toBe("ok");
+    const updated = engine.getEntries()[0]!;
+    expect(updated.enabled).toBe(false);
+    expect(updated.total_executions).toBe(1);
+    expect(updated.last_fired_at).not.toBeNull();
+
+    const history = await engine.getRecentHistory(10, entry.id);
+    expect(history).toHaveLength(1);
+    expect(history[0]!.reason).toBe("manual_run");
+    expect(history[0]!.status).toBe("ok");
+  });
+
   it("updateEntry rejects layer config updates that do not match the entry layer", async () => {
     const entry = await engine.addEntry({
       name: "layer-mismatch-check",

--- a/src/runtime/command-dispatcher.ts
+++ b/src/runtime/command-dispatcher.ts
@@ -28,6 +28,11 @@ export interface CommandDispatcherDeps {
     kind: RuntimeControlOperationKind,
     envelope: Envelope
   ) => Promise<void> | void;
+  onScheduleRunNow?: (
+    scheduleId: string,
+    allowEscalation: boolean,
+    envelope: Envelope
+  ) => Promise<void> | void;
 }
 
 export interface CommandDispatcherConfig {
@@ -155,6 +160,15 @@ export class CommandDispatcher {
           throw new Error("runtime_control command is missing operationId");
         }
         await this.deps.onRuntimeControl?.(operationId, kind, envelope);
+        return;
+      }
+      case "schedule_run_now": {
+        const scheduleId = this.readStringField(envelope.payload, "scheduleId");
+        const allowEscalation = this.readBooleanField(envelope.payload, "allowEscalation") ?? false;
+        if (!scheduleId) {
+          throw new Error("schedule_run_now command is missing scheduleId");
+        }
+        await this.deps.onScheduleRunNow?.(scheduleId, allowEscalation, envelope);
         return;
       }
       default:

--- a/src/runtime/daemon/client.ts
+++ b/src/runtime/daemon/client.ts
@@ -47,6 +47,11 @@ export interface DaemonHealthProbeResult {
   error?: string;
 }
 
+export interface DaemonScheduleRunNowResponse {
+  ok: boolean;
+  scheduleId: string;
+}
+
 type EventHandler = (data: unknown) => void;
 
 const DAEMON_TOKEN_FILENAME = "daemon-token.json";
@@ -308,6 +313,16 @@ export class DaemonClient {
 
   async requestRuntimeControl(input: DaemonRuntimeControlRequestBody): Promise<{ ok: boolean }> {
     return this.post("/daemon/runtime-control", input);
+  }
+
+  async runScheduleNow(
+    scheduleId: string,
+    input: { allowEscalation?: boolean } = {}
+  ): Promise<DaemonScheduleRunNowResponse> {
+    return this.post(
+      `/schedules/${encodeURIComponent(scheduleId)}/run`,
+      { allowEscalation: input.allowEscalation === true }
+    ) as Promise<DaemonScheduleRunNowResponse>;
   }
 
   async getStatus(): Promise<unknown> {

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -18,6 +18,7 @@ import { DaemonConfigSchema, DaemonStateSchema, ResidentActivitySchema } from ".
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { CronScheduler } from "../cron-scheduler.js";
 import { ScheduleEngine } from "../schedule/engine.js";
+import { resolveScheduleEntry } from "../schedule/entry-resolver.js";
 import type { MemoryLifecycleManager } from "../../platform/knowledge/memory/memory-lifecycle.js";
 import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
 import { lintAgentMemory } from "../../platform/knowledge/knowledge-manager-lint.js";
@@ -596,6 +597,11 @@ export class DaemonRunner {
           this.runCommandWithHealth("approval_response", () => this.handleApprovalResponseCommand(goalId, requestId, approved)),
         onRuntimeControl: async (operationId, kind) =>
           this.runCommandWithHealth("runtime_control", () => this.handleRuntimeControlCommand(operationId, kind)),
+        onScheduleRunNow: async (scheduleId, allowEscalation) =>
+          this.runCommandWithHealth(
+            "schedule_run_now",
+            () => this.handleScheduleRunNowCommand(scheduleId, allowEscalation)
+          ),
       });
     }
 
@@ -1219,6 +1225,37 @@ export class DaemonRunner {
     setTimeout(() => {
       this.beginGracefulShutdown();
     }, 25).unref?.();
+  }
+
+  private async handleScheduleRunNowCommand(
+    scheduleId: string,
+    allowEscalation: boolean
+  ): Promise<void> {
+    if (!this.scheduleEngine) {
+      throw new Error("ScheduleEngine is not configured");
+    }
+
+    await this.scheduleEngine.loadEntries();
+    const entry = resolveScheduleEntry(this.scheduleEngine.getEntries(), scheduleId);
+    if (!entry) {
+      throw new Error(`Schedule not found: ${scheduleId}`);
+    }
+
+    const run = await this.scheduleEngine.runEntryNow(entry.id, {
+      allowEscalation,
+      preserveEnabled: true,
+    });
+    if (!run) {
+      throw new Error(`Schedule not found: ${scheduleId}`);
+    }
+
+    this.logger.info("Schedule run-now completed", {
+      schedule_id: entry.id,
+      schedule_name: entry.name,
+      status: run.result.status,
+      reason: run.reason,
+      allow_escalation: allowEscalation,
+    });
   }
 
   private async handleGoalCompletion(goalId: string, result: { status: string; totalIterations: number }): Promise<void> {

--- a/src/runtime/event/server.ts
+++ b/src/runtime/event/server.ts
@@ -477,6 +477,12 @@ export class EventServer {
       return;
     }
 
+    const scheduleRunMatch = /^\/schedules\/([^/]+)\/run$/.exec(urlPath);
+    if (req.method === "POST" && scheduleRunMatch) {
+      void this.handlePostScheduleRunNow(req, res, scheduleRunMatch[1]!);
+      return;
+    }
+
     // POST /goals/:id/start|stop|approve|chat
     const goalActionMatch = /^\/goals\/([^/]+)\/([^/]+)$/.exec(urlPath);
     if (req.method === "POST" && goalActionMatch) {
@@ -852,6 +858,36 @@ export class EventServer {
     } catch (err) {
       res.writeHead(400, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: false, error: "Invalid runtime control request", details: String(err) }));
+    }
+  }
+
+  private async handlePostScheduleRunNow(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    rawScheduleId: string
+  ): Promise<void> {
+    const scheduleId = decodeURIComponent(rawScheduleId).trim();
+    if (!scheduleId) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "scheduleId is required" }));
+      return;
+    }
+
+    try {
+      const body = await readBody(req);
+      const parsed = body.trim() ? JSON.parse(body) as Record<string, unknown> : {};
+      const allowEscalation = parsed["allowEscalation"] === true;
+      await this.dispatchCommandEnvelope({
+        name: "schedule_run_now",
+        priority: "high",
+        payload: { scheduleId, allowEscalation },
+      });
+      await this.broadcast("schedule_run_requested", { scheduleId, allowEscalation });
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: true, scheduleId }));
+    } catch (err) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Invalid schedule run request", details: String(err) }));
     }
   }
 

--- a/src/runtime/schedule/__tests__/entry-resolver.test.ts
+++ b/src/runtime/schedule/__tests__/entry-resolver.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { resolveScheduleEntry, ScheduleEntryResolutionError } from "../entry-resolver.js";
+import { ScheduleEntrySchema } from "../../types/schedule.js";
+
+function makeEntry(id: string) {
+  return ScheduleEntrySchema.parse({
+    id,
+    name: `schedule-${id.slice(0, 4)}`,
+    layer: "heartbeat",
+    trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+    enabled: true,
+    heartbeat: {
+      check_type: "custom",
+      check_config: { command: "echo ok" },
+      failure_threshold: 3,
+      timeout_ms: 5000,
+    },
+    baseline_results: [],
+    created_at: "2026-04-08T00:00:00.000Z",
+    updated_at: "2026-04-08T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-04-08T00:01:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+  });
+}
+
+describe("resolveScheduleEntry", () => {
+  it("prefers exact id matches over prefix matches", () => {
+    const exact = makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+    const longerPrefix = makeEntry("aaaaaaaa-bbbb-4aaa-8aaa-aaaaaaaaaaaa");
+
+    expect(resolveScheduleEntry([longerPrefix, exact], exact.id)).toBe(exact);
+  });
+
+  it("resolves unique prefixes", () => {
+    const entry = makeEntry("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb");
+
+    expect(resolveScheduleEntry([entry], "bbbbbbbb")).toBe(entry);
+  });
+
+  it("returns null for missing ids", () => {
+    const entry = makeEntry("cccccccc-cccc-4ccc-8ccc-cccccccccccc");
+
+    expect(resolveScheduleEntry([entry], "missing")).toBeNull();
+  });
+
+  it("throws a typed error for ambiguous prefixes", () => {
+    const first = makeEntry("dddd0000-0000-4000-8000-000000000000");
+    const second = makeEntry("dddd1111-1111-4111-8111-111111111111");
+
+    expect(() => resolveScheduleEntry([first, second], "dddd")).toThrow(ScheduleEntryResolutionError);
+    expect(() => resolveScheduleEntry([first, second], "dddd")).toThrow("ambiguous");
+  });
+});

--- a/src/runtime/schedule/engine.ts
+++ b/src/runtime/schedule/engine.ts
@@ -56,6 +56,17 @@ interface DueEntryDescriptor {
   scheduledFor: string | null;
 }
 
+export interface RunScheduleNowOptions {
+  preserveEnabled?: boolean;
+  allowEscalation?: boolean;
+}
+
+export interface RunScheduleNowResult {
+  entry: ScheduleEntry | null;
+  result: ScheduleResult;
+  reason: ScheduleRunReason;
+}
+
 interface ScheduleEngineDeps {
   baseDir: string;
   logger?: {
@@ -316,6 +327,65 @@ export class ScheduleEngine {
     return filtered.slice(-limit);
   }
 
+  async runEntryNow(
+    entryId: string,
+    options: RunScheduleNowOptions = {}
+  ): Promise<RunScheduleNowResult | null> {
+    const entry = this.entries.find((candidate) => candidate.id === entryId);
+    if (!entry) {
+      return null;
+    }
+
+    const scheduledFor = new Date().toISOString();
+    const immediateEntry = {
+      ...entry,
+      enabled: true,
+      next_fire_at: scheduledFor,
+    };
+    const executedResult = await this.executeEntry(immediateEntry);
+    const applied = await this.applyExecutionOutcome(
+      entry.id,
+      executedResult,
+      "manual_run",
+      scheduledFor,
+      { preserveEnabled: options.preserveEnabled ?? true }
+    );
+
+    let finalResult = executedResult;
+    if (options.allowEscalation && applied?.entry) {
+      const escalationResult = await this.checkEscalation(applied.entry, executedResult);
+      if (escalationResult !== null) {
+        finalResult = escalationResult;
+      }
+    }
+
+    if (applied) {
+      await this.saveEntries();
+      await this.recordHistory({
+        entry_id: applied.entry?.id ?? entry.id,
+        entry_name: applied.entry?.name ?? entry.name,
+        layer: entry.layer,
+        result: {
+          ...finalResult,
+          failure_kind: applied.failureKind,
+        },
+        reason: "manual_run",
+        attempt: applied.attempt,
+        scheduled_for: scheduledFor,
+        started_at: applied.startedAt,
+        finished_at: applied.finishedAt,
+        retry_at: applied.retryAt,
+        failure_kind: applied.failureKind,
+      });
+    }
+
+    return {
+      entry: applied?.entry ?? null,
+      result: finalResult,
+      reason: "manual_run",
+    };
+  }
+
   private async getDueEntryDescriptors(): Promise<DueEntryDescriptor[]> {
     const now = Date.now();
     return this.entries.flatMap((entry) => {
@@ -539,7 +609,8 @@ export class ScheduleEngine {
     entryId: string,
     result: ScheduleResult,
     _reason: ScheduleRunReason,
-    scheduledFor: string | null
+    scheduledFor: string | null,
+    options: { preserveEnabled?: boolean } = {}
   ): Promise<{
     entry: ScheduleEntry | null;
     attempt: number;
@@ -583,7 +654,7 @@ export class ScheduleEngine {
 
     this.entries[idx] = {
       ...entry,
-      enabled: true,
+      enabled: options.preserveEnabled ? entry.enabled : true,
       last_fired_at: result.fired_at,
       next_fire_at: this.computeNextFireAt(entry.trigger),
       updated_at: new Date().toISOString(),

--- a/src/runtime/schedule/entry-resolver.ts
+++ b/src/runtime/schedule/entry-resolver.ts
@@ -1,0 +1,25 @@
+import type { ScheduleEntry } from "../types/schedule.js";
+
+export class ScheduleEntryResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ScheduleEntryResolutionError";
+  }
+}
+
+export function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
+  const exact = entries.find((entry) => entry.id === scheduleId);
+  if (exact) {
+    return exact;
+  }
+
+  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
+  if (matches.length === 1) {
+    return matches[0]!;
+  }
+  if (matches.length > 1) {
+    throw new ScheduleEntryResolutionError(`Schedule ID prefix is ambiguous: ${scheduleId}`);
+  }
+
+  return null;
+}

--- a/src/runtime/schedule/history.ts
+++ b/src/runtime/schedule/history.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 const HISTORY_FILE = "schedule-history.json";
 const DEFAULT_MAX_RECENT = 500;
 
-export const ScheduleRunReasonSchema = z.enum(["cadence", "retry", "escalation_target"]);
+export const ScheduleRunReasonSchema = z.enum(["cadence", "retry", "escalation_target", "manual_run"]);
 export type ScheduleRunReason = z.infer<typeof ScheduleRunReasonSchema>;
 
 export const ScheduleRunHistoryRecordSchema = ScheduleResultSchema.extend({

--- a/src/tools/builtin/index.ts
+++ b/src/tools/builtin/index.ts
@@ -80,6 +80,7 @@ export { ListSchedulesTool } from "../schedule/ListSchedulesTool/ListSchedulesTo
 export { PauseScheduleTool } from "../schedule/PauseScheduleTool/PauseScheduleTool.js";
 export { RemoveScheduleTool } from "../schedule/RemoveScheduleTool/RemoveScheduleTool.js";
 export { ResumeScheduleTool } from "../schedule/ResumeScheduleTool/ResumeScheduleTool.js";
+export { RunScheduleTool } from "../schedule/RunScheduleTool/RunScheduleTool.js";
 export { UpdateScheduleTool } from "../schedule/UpdateScheduleTool/UpdateScheduleTool.js";
 
 import { GlobTool } from "../fs/GlobTool/GlobTool.js";
@@ -161,6 +162,7 @@ import { ListSchedulesTool } from "../schedule/ListSchedulesTool/ListSchedulesTo
 import { PauseScheduleTool } from "../schedule/PauseScheduleTool/PauseScheduleTool.js";
 import { RemoveScheduleTool } from "../schedule/RemoveScheduleTool/RemoveScheduleTool.js";
 import { ResumeScheduleTool } from "../schedule/ResumeScheduleTool/ResumeScheduleTool.js";
+import { RunScheduleTool } from "../schedule/RunScheduleTool/RunScheduleTool.js";
 import { UpdateScheduleTool } from "../schedule/UpdateScheduleTool/UpdateScheduleTool.js";
 import type { AdapterRegistry } from "../../orchestrator/execution/adapter-layer.js";
 import type { SessionManager } from "../../orchestrator/execution/session-manager.js";
@@ -317,6 +319,7 @@ export function createBuiltinTools(deps?: BuiltinToolDeps): ITool[] {
       new RemoveScheduleTool(deps.scheduleEngine),
       new PauseScheduleTool(deps.scheduleEngine),
       new ResumeScheduleTool(deps.scheduleEngine),
+      new RunScheduleTool(deps.scheduleEngine),
     );
   }
 

--- a/src/tools/schedule/GetScheduleTool/GetScheduleTool.ts
+++ b/src/tools/schedule/GetScheduleTool/GetScheduleTool.ts
@@ -7,8 +7,8 @@ import type {
   ToolMetadata,
   ToolResult,
 } from "../../types.js";
-import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
 import type { ScheduleEngine } from "../../../runtime/schedule/engine.js";
+import { resolveScheduleEntry } from "../../../runtime/schedule/entry-resolver.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, PERMISSION_LEVEL, MAX_OUTPUT_CHARS } from "./constants.js";
 
@@ -16,23 +16,6 @@ export const GetScheduleInputSchema = z.object({
   schedule_id: z.string().min(1),
 });
 export type GetScheduleInput = z.infer<typeof GetScheduleInputSchema>;
-
-function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
-  const exact = entries.find((entry) => entry.id === scheduleId);
-  if (exact) {
-    return exact;
-  }
-
-  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
-  if (matches.length === 1) {
-    return matches[0]!;
-  }
-  if (matches.length > 1) {
-    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
-  }
-
-  return null;
-}
 
 export class GetScheduleTool implements ITool<GetScheduleInput, unknown> {
   readonly metadata: ToolMetadata = {

--- a/src/tools/schedule/PauseScheduleTool/PauseScheduleTool.ts
+++ b/src/tools/schedule/PauseScheduleTool/PauseScheduleTool.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../types.js";
 import type { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import { resolveScheduleEntry } from "../../../runtime/schedule/entry-resolver.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
 
@@ -19,23 +20,6 @@ export type PauseScheduleInput = z.infer<typeof PauseScheduleInputSchema>;
 
 export interface PauseScheduleOutput {
   entry: ScheduleEntry;
-}
-
-function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
-  const exact = entries.find((entry) => entry.id === scheduleId);
-  if (exact) {
-    return exact;
-  }
-
-  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
-  if (matches.length === 1) {
-    return matches[0]!;
-  }
-  if (matches.length > 1) {
-    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
-  }
-
-  return null;
 }
 
 export class PauseScheduleTool implements ITool<PauseScheduleInput, PauseScheduleOutput> {

--- a/src/tools/schedule/RemoveScheduleTool/RemoveScheduleTool.ts
+++ b/src/tools/schedule/RemoveScheduleTool/RemoveScheduleTool.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../types.js";
 import type { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import { resolveScheduleEntry } from "../../../runtime/schedule/entry-resolver.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
 
@@ -23,23 +24,6 @@ export interface RemoveScheduleOutput {
     id: string;
     name: string;
   };
-}
-
-function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
-  const exact = entries.find((entry) => entry.id === scheduleId);
-  if (exact) {
-    return exact;
-  }
-
-  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
-  if (matches.length === 1) {
-    return matches[0]!;
-  }
-  if (matches.length > 1) {
-    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
-  }
-
-  return null;
 }
 
 export class RemoveScheduleTool implements ITool<RemoveScheduleInput, RemoveScheduleOutput> {

--- a/src/tools/schedule/ResumeScheduleTool/ResumeScheduleTool.ts
+++ b/src/tools/schedule/ResumeScheduleTool/ResumeScheduleTool.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../types.js";
 import type { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import { resolveScheduleEntry } from "../../../runtime/schedule/entry-resolver.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
 
@@ -19,23 +20,6 @@ export type ResumeScheduleInput = z.infer<typeof ResumeScheduleInputSchema>;
 
 export interface ResumeScheduleOutput {
   entry: ScheduleEntry;
-}
-
-function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
-  const exact = entries.find((entry) => entry.id === scheduleId);
-  if (exact) {
-    return exact;
-  }
-
-  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
-  if (matches.length === 1) {
-    return matches[0]!;
-  }
-  if (matches.length > 1) {
-    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
-  }
-
-  return null;
 }
 
 export class ResumeScheduleTool implements ITool<ResumeScheduleInput, ResumeScheduleOutput> {

--- a/src/tools/schedule/RunScheduleTool/RunScheduleTool.ts
+++ b/src/tools/schedule/RunScheduleTool/RunScheduleTool.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import type { ScheduleEngine, RunScheduleNowResult } from "../../../runtime/schedule/engine.js";
+import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import { resolveScheduleEntry } from "../../../runtime/schedule/entry-resolver.js";
+import { DESCRIPTION } from "./prompt.js";
+import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
+
+export const RunScheduleInputSchema = z.object({
+  schedule_id: z.string().min(1),
+  allow_escalation: z.boolean().default(false),
+});
+export type RunScheduleInput = z.infer<typeof RunScheduleInputSchema>;
+
+export interface RunScheduleOutput {
+  entry: ScheduleEntry | null;
+  result: RunScheduleNowResult["result"];
+  reason: RunScheduleNowResult["reason"];
+}
+
+export class RunScheduleTool implements ITool<RunScheduleInput, RunScheduleOutput> {
+  readonly metadata: ToolMetadata = {
+    name: "run_schedule",
+    aliases: ["run_schedule_now"],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 4000,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = RunScheduleInputSchema;
+
+  constructor(private readonly scheduleEngine: ScheduleEngine) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: RunScheduleInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+
+    try {
+      const existingEntry = resolveScheduleEntry(this.scheduleEngine.getEntries(), input.schedule_id);
+      if (!existingEntry) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      const run = await this.scheduleEngine.runEntryNow(existingEntry.id, {
+        allowEscalation: input.allow_escalation,
+        preserveEnabled: true,
+      });
+      if (!run) {
+        return {
+          success: false,
+          data: null,
+          summary: `Schedule not found: ${input.schedule_id}`,
+          error: `Schedule not found: ${input.schedule_id}`,
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      const summary = run.result.output_summary ? `: ${run.result.output_summary}` : "";
+      return {
+        success: true,
+        data: {
+          entry: run.entry,
+          result: run.result,
+          reason: run.reason,
+        },
+        summary: `Ran schedule: ${existingEntry.name} -> ${run.result.status}${summary}`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: null,
+        summary: `RunScheduleTool failed: ${(err as Error).message}`,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(
+    _input: RunScheduleInput,
+    context: ToolCallContext,
+  ): Promise<PermissionCheckResult> {
+    if (context.preApproved) return { status: "allowed" };
+    return {
+      status: "needs_approval",
+      reason: "Running a persistent schedule may execute background automation and requires approval",
+    };
+  }
+
+  isConcurrencySafe(_input: RunScheduleInput): boolean {
+    return false;
+  }
+}

--- a/src/tools/schedule/RunScheduleTool/constants.ts
+++ b/src/tools/schedule/RunScheduleTool/constants.ts
@@ -1,0 +1,4 @@
+export const TAGS = ["schedule", "mutation", "automation", "execution"] as const;
+export const CATEGORY = "schedule";
+export const READ_ONLY = false;
+export const PERMISSION_LEVEL = "write_local" as const;

--- a/src/tools/schedule/RunScheduleTool/prompt.ts
+++ b/src/tools/schedule/RunScheduleTool/prompt.ts
@@ -1,0 +1,1 @@
+export const DESCRIPTION = "Run a PulSeed schedule entry immediately for validation or one-off execution.";

--- a/src/tools/schedule/UpdateScheduleTool/UpdateScheduleTool.ts
+++ b/src/tools/schedule/UpdateScheduleTool/UpdateScheduleTool.ts
@@ -11,6 +11,7 @@ import {
   ScheduleEngine,
   type ScheduleEntryUpdateInput,
 } from "../../../runtime/schedule/engine.js";
+import { resolveScheduleEntry } from "../../../runtime/schedule/entry-resolver.js";
 import {
   CronConfigSchema,
   EscalationConfigSchema,
@@ -58,23 +59,6 @@ export type UpdateScheduleInput = z.infer<typeof UpdateScheduleInputSchema>;
 
 export interface UpdateScheduleOutput {
   entry: ScheduleEntry;
-}
-
-function resolveScheduleEntry(entries: ScheduleEntry[], scheduleId: string): ScheduleEntry | null {
-  const exact = entries.find((entry) => entry.id === scheduleId);
-  if (exact) {
-    return exact;
-  }
-
-  const matches = entries.filter((entry) => entry.id.startsWith(scheduleId));
-  if (matches.length === 1) {
-    return matches[0]!;
-  }
-  if (matches.length > 1) {
-    throw new Error(`Schedule ID prefix is ambiguous: ${scheduleId}`);
-  }
-
-  return null;
 }
 
 export class UpdateScheduleTool implements ITool<UpdateScheduleInput, UpdateScheduleOutput> {

--- a/src/tools/schedule/__tests__/run-schedule.test.ts
+++ b/src/tools/schedule/__tests__/run-schedule.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  RunScheduleInputSchema,
+  RunScheduleTool,
+  type RunScheduleOutput,
+} from "../RunScheduleTool/RunScheduleTool.js";
+import type { ToolCallContext } from "../../types.js";
+import type { ScheduleEngine } from "../../../runtime/schedule-engine.js";
+import type { ScheduleEntry, ScheduleResult } from "../../../runtime/types/schedule.js";
+
+function makeContext(overrides: Partial<ToolCallContext> = {}): ToolCallContext {
+  return {
+    cwd: "/tmp",
+    goalId: "test-goal",
+    trustBalance: 50,
+    preApproved: false,
+    approvalFn: async () => false,
+    ...overrides,
+  };
+}
+
+function makeEntry(
+  id: string,
+  overrides: Partial<ScheduleEntry> = {},
+): ScheduleEntry {
+  return {
+    id,
+    name: `Schedule ${id}`,
+    layer: "heartbeat",
+    trigger: { type: "interval", seconds: 60, jitter_factor: 0 },
+    enabled: true,
+    heartbeat: {
+      check_type: "http",
+      check_config: { url: "https://example.com/health" },
+      failure_threshold: 3,
+      timeout_ms: 5000,
+    },
+    probe: undefined,
+    cron: undefined,
+    goal_trigger: undefined,
+    escalation: undefined,
+    baseline_results: [],
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    last_fired_at: null,
+    next_fire_at: "2026-01-01T00:01:00.000Z",
+    consecutive_failures: 0,
+    last_escalation_at: null,
+    escalation_timestamps: [],
+    total_executions: 0,
+    total_tokens_used: 0,
+    max_tokens_per_day: 100000,
+    tokens_used_today: 0,
+    budget_reset_at: null,
+    ...overrides,
+  };
+}
+
+function makeResult(
+  entryId: string,
+  overrides: Partial<ScheduleResult> = {},
+): ScheduleResult {
+  return {
+    entry_id: entryId,
+    status: "ok",
+    duration_ms: 3,
+    fired_at: "2026-01-01T00:00:00.000Z",
+    layer: "heartbeat",
+    tokens_used: 0,
+    escalated_to: null,
+    ...overrides,
+  };
+}
+
+describe("RunScheduleTool", () => {
+  let scheduleEngine: ScheduleEngine;
+  let tool: RunScheduleTool;
+
+  beforeEach(() => {
+    scheduleEngine = {
+      getEntries: vi.fn().mockReturnValue([]),
+      runEntryNow: vi.fn(),
+    } as unknown as ScheduleEngine;
+    tool = new RunScheduleTool(scheduleEngine);
+  });
+
+  it("has correct metadata", () => {
+    expect(tool.metadata.name).toBe("run_schedule");
+    expect(tool.metadata.permissionLevel).toBe("write_local");
+    expect(tool.metadata.isDestructive).toBe(false);
+    expect(tool.metadata.tags).toContain("execution");
+  });
+
+  it("description returns non-empty string", () => {
+    expect(tool.description()).toContain("Run");
+  });
+
+  it("checkPermissions returns needs_approval when not pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      RunScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+      makeContext(),
+    );
+
+    expect(result.status).toBe("needs_approval");
+  });
+
+  it("checkPermissions returns allowed when pre-approved", async () => {
+    const result = await tool.checkPermissions(
+      RunScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.status).toBe("allowed");
+  });
+
+  it("isConcurrencySafe returns false", () => {
+    expect(
+      tool.isConcurrencySafe(
+        RunScheduleInputSchema.parse({
+          schedule_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("resolves a unique prefix and runs the canonical schedule id", async () => {
+    const entry = makeEntry("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", {
+      name: "Heartbeat watch",
+    });
+    const result = makeResult(entry.id, { output_summary: "healthy" });
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+      entry,
+    ]);
+    vi.mocked(scheduleEngine.runEntryNow).mockResolvedValue({
+      entry,
+      result,
+      reason: "manual_run",
+    });
+    const approvalFn = vi.fn().mockResolvedValue(false);
+
+    const toolResult = await tool.call(
+      RunScheduleInputSchema.parse({
+        schedule_id: "aaaaaaaa",
+        allow_escalation: true,
+      }),
+      makeContext({ approvalFn }),
+    );
+
+    expect(approvalFn).not.toHaveBeenCalled();
+    expect(scheduleEngine.runEntryNow).toHaveBeenCalledTimes(1);
+    expect(scheduleEngine.runEntryNow).toHaveBeenCalledWith(
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      { allowEscalation: true, preserveEnabled: true },
+    );
+    expect(toolResult.success).toBe(true);
+    expect((toolResult.data as RunScheduleOutput).result).toEqual(result);
+    expect(toolResult.summary).toContain("healthy");
+  });
+
+  it("returns failure when the schedule id prefix is ambiguous", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("eeee0000-0000-4000-8000-000000000000"),
+      makeEntry("eeee1111-1111-4111-8111-111111111111"),
+    ]);
+
+    const result = await tool.call(
+      RunScheduleInputSchema.parse({
+        schedule_id: "eeee",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("ambiguous");
+    expect(scheduleEngine.runEntryNow).not.toHaveBeenCalled();
+  });
+
+  it("returns failure when the schedule is missing", async () => {
+    vi.mocked(scheduleEngine.getEntries).mockReturnValue([
+      makeEntry("dddddddd-dddd-4ddd-8ddd-dddddddddddd"),
+    ]);
+
+    const result = await tool.call(
+      RunScheduleInputSchema.parse({
+        schedule_id: "missing",
+      }),
+      makeContext({ preApproved: true }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing");
+    expect(scheduleEngine.runEntryNow).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `pulseed schedule show/edit/pause/resume/run/history` lifecycle commands
- Add `ScheduleEngine.runEntryNow()` with `manual_run` history while preserving paused state
- Extract shared schedule ID resolution and split CLI schedule lifecycle helpers for clearer responsibilities
- Document the lifecycle surface and add focused tests for resolver/edit/manual-run behavior

Closes #673

## Verification
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run check:docs`
- `npm test`
- targeted coverage run for schedule CLI helpers and resolver

## Notes
- `pulseed schedule run` executes in the CLI process with the appropriate ScheduleEngine dependencies. A daemon RPC endpoint for run-now remains a future extension if resident daemon context becomes required.