### PR TITLE
Wire schedule runtime integrations

### DIFF
--- a/examples/plugins/jira-datasource/__tests__/jira-datasource-plugin.test.ts
+++ b/examples/plugins/jira-datasource/__tests__/jira-datasource-plugin.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { JiraDataSourceAdapter } from "../src/index.js";
-import type { DataSourceConfig } from "../../../../src/types/data-source.js";
+import type { DataSourceConfig } from "pulseed";
 
 // ─── Helpers ───
 

--- a/examples/plugins/jira-datasource/src/index.ts
+++ b/examples/plugins/jira-datasource/src/index.ts
@@ -9,8 +9,8 @@ import type {
   DataSourceConfig,
   DataSourceQuery,
   DataSourceResult,
-} from "../../../../src/types/data-source.js";
-import type { IDataSourceAdapter } from "../../../../src/observation/data-source-adapter.js";
+  IDataSourceAdapter,
+} from "pulseed";
 
 // ─── Adapter ───
 

--- a/examples/plugins/mysql-datasource/__tests__/mysql-datasource-plugin.test.ts
+++ b/examples/plugins/mysql-datasource/__tests__/mysql-datasource-plugin.test.ts
@@ -27,7 +27,7 @@ vi.mock("mysql2/promise", () => ({
 // ─── Import after mock ───
 
 import { MysqlDataSourceAdapter } from "../src/index.js";
-import type { DataSourceConfig } from "../../../../src/types/data-source.js";
+import type { DataSourceConfig } from "pulseed";
 
 // ─── Helpers ───
 

--- a/examples/plugins/mysql-datasource/src/index.ts
+++ b/examples/plugins/mysql-datasource/src/index.ts
@@ -8,8 +8,8 @@ import type {
   DataSourceConfig,
   DataSourceQuery,
   DataSourceResult,
-} from "../../../../src/types/data-source.js";
-import type { IDataSourceAdapter } from "../../../../src/observation/data-source-adapter.js";
+  IDataSourceAdapter,
+} from "pulseed";
 
 type MySQLPool = mysql.Pool;
 

--- a/examples/plugins/pagerduty-notifier/__tests__/pagerduty-notifier-plugin.test.ts
+++ b/examples/plugins/pagerduty-notifier/__tests__/pagerduty-notifier-plugin.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { PagerDutyNotifier } from "../src/index.js";
-import type { NotificationEvent } from "../../../../src/types/plugin.js";
+import type { NotificationEvent } from "pulseed";
 
 // ─── Helpers ───
 

--- a/examples/plugins/pagerduty-notifier/src/index.ts
+++ b/examples/plugins/pagerduty-notifier/src/index.ts
@@ -7,7 +7,7 @@ import type {
   INotifier,
   NotificationEvent,
   NotificationEventType,
-} from "../../../../src/types/plugin.js";
+} from "pulseed";
 
 // ─── Supported events (must match plugin.yaml) ───
 

--- a/examples/plugins/postgres-datasource/__tests__/postgres-datasource-plugin.test.ts
+++ b/examples/plugins/postgres-datasource/__tests__/postgres-datasource-plugin.test.ts
@@ -27,7 +27,7 @@ vi.mock("pg", () => ({
 // ─── Import after mock ───
 
 import { PostgresDataSourceAdapter } from "../src/index.js";
-import type { DataSourceConfig } from "../../../../src/types/data-source.js";
+import type { DataSourceConfig } from "pulseed";
 
 // ─── Helpers ───
 

--- a/examples/plugins/postgres-datasource/src/index.ts
+++ b/examples/plugins/postgres-datasource/src/index.ts
@@ -8,8 +8,8 @@ import type {
   DataSourceConfig,
   DataSourceQuery,
   DataSourceResult,
-} from "../../../../src/types/data-source.js";
-import type { IDataSourceAdapter } from "../../../../src/observation/data-source-adapter.js";
+  IDataSourceAdapter,
+} from "pulseed";
 
 const { Pool } = pg;
 type PgPool = InstanceType<typeof Pool>;

--- a/examples/plugins/sqlite-datasource/__tests__/sqlite-datasource-plugin.test.ts
+++ b/examples/plugins/sqlite-datasource/__tests__/sqlite-datasource-plugin.test.ts
@@ -27,7 +27,7 @@ vi.mock("better-sqlite3", () => ({
 // ─── Import after mock ───
 
 import { SqliteDataSourceAdapter } from "../src/index.js";
-import type { DataSourceConfig } from "../../../../src/types/data-source.js";
+import type { DataSourceConfig } from "pulseed";
 
 // ─── Helpers ───
 

--- a/examples/plugins/sqlite-datasource/src/index.ts
+++ b/examples/plugins/sqlite-datasource/src/index.ts
@@ -8,8 +8,8 @@ import type {
   DataSourceConfig,
   DataSourceQuery,
   DataSourceResult,
-} from "../../../../src/types/data-source.js";
-import type { IDataSourceAdapter } from "../../../../src/observation/data-source-adapter.js";
+  IDataSourceAdapter,
+} from "pulseed";
 
 // ─── Security ───
 

--- a/examples/plugins/sse-datasource/__tests__/sse-datasource-plugin.test.ts
+++ b/examples/plugins/sse-datasource/__tests__/sse-datasource-plugin.test.ts
@@ -89,7 +89,7 @@ vi.mock("eventsource", () => ({
 // ─── Import after mock ───
 
 import { SseDataSourceAdapter } from "../src/index.js";
-import type { DataSourceConfig } from "../../../../src/types/data-source.js";
+import type { DataSourceConfig } from "pulseed";
 
 // ─── Helpers ───
 

--- a/examples/plugins/sse-datasource/src/index.ts
+++ b/examples/plugins/sse-datasource/src/index.ts
@@ -9,8 +9,8 @@ import type {
   DataSourceConfig,
   DataSourceQuery,
   DataSourceResult,
-} from "../../../../src/types/data-source.js";
-import type { IDataSourceAdapter } from "../../../../src/observation/data-source-adapter.js";
+  IDataSourceAdapter,
+} from "pulseed";
 
 // ─── Adapter ───
 

--- a/examples/plugins/websocket-datasource/__tests__/websocket-datasource-plugin.test.ts
+++ b/examples/plugins/websocket-datasource/__tests__/websocket-datasource-plugin.test.ts
@@ -55,7 +55,7 @@ vi.mock("ws", () => ({
 // ─── Import after mock ───
 
 import { WebSocketDataSourceAdapter } from "../src/index.js";
-import type { DataSourceConfig } from "../../../../src/types/data-source.js";
+import type { DataSourceConfig } from "pulseed";
 
 // ─── Helpers ───
 

--- a/examples/plugins/websocket-datasource/src/index.ts
+++ b/examples/plugins/websocket-datasource/src/index.ts
@@ -9,8 +9,8 @@ import type {
   DataSourceConfig,
   DataSourceQuery,
   DataSourceResult,
-} from "../../../../src/types/data-source.js";
-import type { IDataSourceAdapter } from "../../../../src/observation/data-source-adapter.js";
+  IDataSourceAdapter,
+} from "pulseed";
 
 // ─── Types ───
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,13 @@
         "cron-parser": "^5.5.0",
         "glob": "^13.0.0",
         "ink": "^6.8.0",
-        "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
         "js-yaml": "^4.1.1",
         "nodemailer": "^8.0.2",
         "openai": "^6.27.0",
         "react": "^19.2.4",
-        "zod": "^3.22.0"
+        "zod": "^3.22.0",
+        "zod-to-json-schema": "^3.25.2"
       },
       "bin": {
         "pulseed": "dist/interface/cli/cli-runner.js"
@@ -1636,18 +1636,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cli-truncate": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
@@ -3077,22 +3065,6 @@
         "react-devtools-core": {
           "optional": true
         }
-      }
-    },
-    "node_modules/ink-spinner": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ink-spinner/-/ink-spinner-5.0.0.tgz",
-      "integrity": "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==",
-      "license": "MIT",
-      "dependencies": {
-        "cli-spinners": "^2.7.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "peerDependencies": {
-        "ink": ">=4.0.0",
-        "react": ">=18.0.0"
       }
     },
     "node_modules/ink-text-input": {

--- a/package.json
+++ b/package.json
@@ -72,13 +72,13 @@
     "cron-parser": "^5.5.0",
     "glob": "^13.0.0",
     "ink": "^6.8.0",
-    "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",
     "js-yaml": "^4.1.1",
     "nodemailer": "^8.0.2",
     "openai": "^6.27.0",
     "react": "^19.2.4",
-    "zod": "^3.22.0"
+    "zod": "^3.22.0",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",

--- a/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
@@ -13,6 +13,7 @@ const mockBuildAdapterRegistry = vi.hoisted(() => vi.fn().mockResolvedValue({
   getAdapter: vi.fn().mockReturnValue({ adapterType: "openai_api" }),
 }));
 const mockCreateBuiltinTools = vi.hoisted(() => vi.fn().mockReturnValue([]));
+const mockBuildCliDataSourceRegistry = vi.hoisted(() => vi.fn().mockResolvedValue({ getAllSources: vi.fn().mockReturnValue([]) }));
 const mockGetGlobalCrossPlatformChatSessionManager = vi.hoisted(() => vi.fn().mockResolvedValue(null));
 const mockShouldUseNativeTaskAgentLoop = vi.hoisted(() => vi.fn().mockReturnValue(false));
 const mockCreateNativeChatAgentLoopRunner = vi.hoisted(() => vi.fn());
@@ -20,6 +21,7 @@ const mockCreateNativeChatAgentLoopRunner = vi.hoisted(() => vi.fn());
 vi.mock("pulseed", () => {
   class FakeStateManager {
     init = mockInit;
+    getBaseDir = vi.fn().mockReturnValue("/tmp/pulseed");
   }
 
   class FakeChatRunner {
@@ -55,6 +57,33 @@ vi.mock("pulseed", () => {
     ToolRegistry: class {
       register = vi.fn();
     },
+    buildCliDataSourceRegistry: mockBuildCliDataSourceRegistry,
+    ObservationEngine: class {
+      getDataSources = vi.fn().mockReturnValue([]);
+      addDataSource = vi.fn();
+      constructor(_stateManager: unknown, _dataSources: unknown, _llmClient: unknown) {}
+    },
+    KnowledgeManager: class {
+      constructor(_stateManager: unknown, _llmClient: unknown) {}
+    },
+    GoalDependencyGraph: class {
+      init = vi.fn().mockResolvedValue(undefined);
+      constructor(_stateManager: unknown, _llmClient: unknown) {}
+    },
+    SessionManager: class {
+      constructor(_stateManager: unknown, _goalDependencyGraph: unknown) {}
+    },
+    ScheduleEngine: class {
+      loadEntries = vi.fn().mockResolvedValue(undefined);
+      syncExternalSources = vi.fn().mockResolvedValue(undefined);
+      constructor(_deps: unknown) {}
+    },
+    PluginLoader: class {
+      loadAll = vi.fn().mockResolvedValue([]);
+      getScheduleSources = vi.fn().mockReturnValue([]);
+      constructor(..._args: unknown[]) {}
+    },
+    NotifierRegistry: class {},
     createBuiltinTools: mockCreateBuiltinTools,
     getGlobalCrossPlatformChatSessionManager: mockGetGlobalCrossPlatformChatSessionManager,
     shouldUseNativeTaskAgentLoop: mockShouldUseNativeTaskAgentLoop,
@@ -72,6 +101,7 @@ describe("TelegramChatRunnerProcessor", () => {
     mockBuildLLMClient.mockClear();
     mockBuildAdapterRegistry.mockClear();
     mockCreateBuiltinTools.mockClear();
+    mockBuildCliDataSourceRegistry.mockClear();
     mockGetGlobalCrossPlatformChatSessionManager.mockReset();
     mockGetGlobalCrossPlatformChatSessionManager.mockResolvedValue(null);
     mockShouldUseNativeTaskAgentLoop.mockReset();

--- a/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
+++ b/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
@@ -11,6 +11,14 @@ import {
   ConcurrencyController,
   createBuiltinTools,
   getGlobalCrossPlatformChatSessionManager,
+  buildCliDataSourceRegistry,
+  ObservationEngine,
+  KnowledgeManager,
+  GoalDependencyGraph,
+  SessionManager,
+  ScheduleEngine,
+  PluginLoader,
+  NotifierRegistry,
   type ChatEventHandler,
   type IAdapter,
   type ILLMClient,
@@ -156,7 +164,46 @@ export class TelegramChatRunnerProcessor {
     const adapter = registry.getAdapter(providerConfig.adapter);
     const toolRegistry = new ToolRegistry();
     const trustManager = new TrustManager(stateManager);
-    for (const tool of createBuiltinTools({ stateManager, trustManager, registry: toolRegistry })) {
+    const dataSourceRegistry = await buildCliDataSourceRegistry(this.workspaceRoot);
+    const observationEngine = new ObservationEngine(stateManager, dataSourceRegistry.getAllSources(), llmClient);
+    const knowledgeManager = new KnowledgeManager(stateManager, llmClient);
+    const goalDependencyGraph = new GoalDependencyGraph(stateManager, llmClient);
+    await goalDependencyGraph.init();
+    const sessionManager = new SessionManager(stateManager, goalDependencyGraph);
+    const scheduleEngine = new ScheduleEngine({
+      baseDir: stateManager.getBaseDir(),
+      dataSourceRegistry,
+      llmClient,
+      stateManager,
+      knowledgeManager,
+    });
+    await scheduleEngine.loadEntries();
+    const pluginLoader = new PluginLoader(
+      registry,
+      dataSourceRegistry,
+      new NotifierRegistry(),
+      undefined,
+      undefined,
+      (dataSource) => {
+        if (!observationEngine.getDataSources().some((source) => source.sourceId === dataSource.sourceId)) {
+          observationEngine.addDataSource(dataSource);
+        }
+      }
+    );
+    await pluginLoader.loadAll().catch(() => []);
+    await scheduleEngine.syncExternalSources(pluginLoader.getScheduleSources()).catch(() => undefined);
+
+    for (const tool of createBuiltinTools({
+      stateManager,
+      trustManager,
+      registry: toolRegistry,
+      adapterRegistry: registry,
+      knowledgeManager,
+      observationEngine,
+      sessionManager,
+      scheduleEngine,
+      pluginLoader,
+    })) {
       toolRegistry.register(tool);
     }
     const permissionManager = new ToolPermissionManager({

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,9 @@ export type { EmbeddingConfig, EmbeddingEntry, VectorSearchResult } from "./base
 // --- Data source ---
 export { DataSourceRegistry, FileDataSourceAdapter, HttpApiDataSourceAdapter, getNestedValue } from "./platform/observation/data-source-adapter.js";
 export type { IDataSourceAdapter } from "./platform/observation/data-source-adapter.js";
+export { createCliDataSourceAdapter, buildCliDataSourceRegistry } from "./interface/cli/data-source-bootstrap.js";
+export { ScheduleEngine } from "./runtime/schedule/engine.js";
+export type { RunScheduleNowOptions, RunScheduleNowResult } from "./runtime/schedule/engine.js";
 
 // --- Stage 14 modules ---
 export { GoalTreeManager } from "./orchestrator/goal/goal-tree-manager.js";

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -8,6 +8,14 @@ import { StateManager } from "../../base/state/state-manager.js";
 import { buildAdapterRegistry, buildLLMClient } from "../../base/llm/provider-factory.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
 import { TrustManager } from "../../platform/traits/trust-manager.js";
+import { ObservationEngine } from "../../platform/observation/observation-engine.js";
+import { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
+import { GoalDependencyGraph } from "../../orchestrator/goal/goal-dependency-graph.js";
+import { SessionManager } from "../../orchestrator/execution/session-manager.js";
+import { ScheduleEngine } from "../../runtime/schedule/engine.js";
+import { PluginLoader } from "../../runtime/plugin-loader.js";
+import { NotifierRegistry } from "../../runtime/notifier-registry.js";
+import { buildCliDataSourceRegistry } from "../cli/data-source-bootstrap.js";
 import {
   ConcurrencyController,
   createBuiltinTools,
@@ -319,7 +327,50 @@ async function createGlobalCrossPlatformChatSessionManager(): Promise<CrossPlatf
   const adapter = adapterRegistry.getAdapter(providerConfig.adapter);
   const toolRegistry = new ToolRegistry();
   const trustManager = new TrustManager(stateManager);
-  for (const tool of createBuiltinTools({ stateManager, trustManager, registry: toolRegistry })) {
+  const dataSourceRegistry = await buildCliDataSourceRegistry();
+  const observationEngine = new ObservationEngine(
+    stateManager,
+    dataSourceRegistry.getAllSources(),
+    llmClient,
+  );
+  const knowledgeManager = new KnowledgeManager(stateManager, llmClient);
+  const goalDependencyGraph = new GoalDependencyGraph(stateManager, llmClient);
+  await goalDependencyGraph.init();
+  const sessionManager = new SessionManager(stateManager, goalDependencyGraph);
+  const scheduleEngine = new ScheduleEngine({
+    baseDir: stateManager.getBaseDir(),
+    dataSourceRegistry,
+    llmClient,
+    stateManager,
+    knowledgeManager,
+  });
+  await scheduleEngine.loadEntries();
+  const pluginLoader = new PluginLoader(
+    adapterRegistry,
+    dataSourceRegistry,
+    new NotifierRegistry(),
+    undefined,
+    undefined,
+    (dataSource) => {
+      if (!observationEngine.getDataSources().some((source) => source.sourceId === dataSource.sourceId)) {
+        observationEngine.addDataSource(dataSource);
+      }
+    }
+  );
+  await pluginLoader.loadAll().catch(() => []);
+  await scheduleEngine.syncExternalSources(pluginLoader.getScheduleSources()).catch(() => undefined);
+
+  for (const tool of createBuiltinTools({
+    stateManager,
+    trustManager,
+    registry: toolRegistry,
+    adapterRegistry,
+    knowledgeManager,
+    observationEngine,
+    sessionManager,
+    scheduleEngine,
+    pluginLoader,
+  })) {
     toolRegistry.register(tool);
   }
 

--- a/src/interface/cli/__tests__/cli-daemon-start.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-start.test.ts
@@ -8,6 +8,7 @@ const {
   watchdogStartMock,
   scheduleLoadEntriesMock,
   scheduleEnsureSoilPublishScheduleMock,
+  scheduleSyncExternalSourcesMock,
   pluginLoadAllMock,
   setRealtimeSinkMock,
   eventServerBroadcastMock,
@@ -23,6 +24,7 @@ const {
   watchdogStartMock: vi.fn().mockResolvedValue(undefined),
   scheduleLoadEntriesMock: vi.fn().mockResolvedValue(undefined),
   scheduleEnsureSoilPublishScheduleMock: vi.fn().mockResolvedValue(null),
+  scheduleSyncExternalSourcesMock: vi.fn().mockResolvedValue({ added: 0, updated: 0, disabled: 0, skipped: 0, errors: [] }),
   pluginLoadAllMock: vi.fn().mockResolvedValue(undefined),
   setRealtimeSinkMock: vi.fn(),
   eventServerBroadcastMock: vi.fn(),
@@ -112,6 +114,7 @@ vi.mock("../../../runtime/schedule/engine.js", () => ({
     scheduleEngineArgs.push(args);
     return {
       loadEntries: scheduleLoadEntriesMock,
+      syncExternalSources: scheduleSyncExternalSourcesMock,
       ensureSoilPublishSchedule: scheduleEnsureSoilPublishScheduleMock,
     };
   }),
@@ -121,6 +124,7 @@ vi.mock("../../../runtime/plugin-loader.js", () => ({
   PluginLoader: vi.fn().mockImplementation(function () {
     return {
       loadAll: pluginLoadAllMock,
+      getScheduleSources: vi.fn().mockReturnValue([]),
     };
   }),
 }));
@@ -163,6 +167,7 @@ describe("cmdStart", () => {
     watchdogStartMock.mockClear();
     scheduleLoadEntriesMock.mockClear();
     scheduleEnsureSoilPublishScheduleMock.mockClear();
+    scheduleSyncExternalSourcesMock.mockClear();
     pluginLoadAllMock.mockClear();
     setRealtimeSinkMock.mockClear();
     eventServerBroadcastMock.mockClear();
@@ -187,6 +192,12 @@ describe("cmdStart", () => {
       hookManager: { id: "hook-manager" },
       memoryLifecycleManager: { id: "memory" },
       knowledgeManager: { id: "knowledge" },
+      adapterRegistry: { id: "adapter-registry" },
+      dataSourceRegistry: { id: "data-source-registry" },
+      observationEngine: {
+        getDataSources: vi.fn().mockReturnValue([]),
+        addDataSource: vi.fn(),
+      },
     });
   });
 

--- a/src/interface/cli/__tests__/schedule-command.test.ts
+++ b/src/interface/cli/__tests__/schedule-command.test.ts
@@ -98,6 +98,61 @@ describe("cmdSchedule", () => {
     }
   });
 
+  it("prints schedule token cost from history", async () => {
+    const tempDir = makeTempDir("schedule-command-cost-");
+    try {
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+      const entry = await engine.addEntry({
+        name: "Daily digest",
+        layer: "cron",
+        trigger: { type: "interval", seconds: 3600 },
+        metadata: {
+          source: "manual",
+          dependency_hints: [],
+        },
+        cron: {
+          job_kind: "prompt",
+          prompt_template: "Summarize work",
+          context_sources: [],
+          output_format: "notification",
+          max_tokens: 500,
+        },
+      });
+      const now = new Date().toISOString();
+      await fs.writeFile(
+        path.join(tempDir, "schedule-history.json"),
+        JSON.stringify([
+          {
+            id: "11111111-1111-4111-8111-111111111111",
+            entry_id: entry.id,
+            entry_name: entry.name,
+            layer: entry.layer,
+            reason: "manual_run",
+            attempt: 0,
+            scheduled_for: now,
+            started_at: now,
+            finished_at: now,
+            retry_at: null,
+            status: "ok",
+            duration_ms: 10,
+            fired_at: now,
+            tokens_used: 42,
+            escalated_to: null,
+          },
+        ]),
+        "utf8",
+      );
+
+      await cmdSchedule(makeStateManager(tempDir), ["cost", "--period", "7d"]);
+
+      expect(logSpy.mock.calls.flat().join("\n")).toContain("tokens:     42");
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  });
+
   it("pauses, resumes, and edits a schedule entry", async () => {
     const tempDir = makeTempDir("schedule-command-lifecycle-");
     try {

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -16,7 +16,7 @@ import { Logger } from "../../../runtime/logger.js";
 import { DaemonRunner } from "../../../runtime/daemon/runner.js";
 import { PIDManager } from "../../../runtime/pid-manager.js";
 import { EventServer } from "../../../runtime/event/server.js";
-import { IngressGateway } from "../../../runtime/gateway/index.js";
+import { IngressGateway, SlackChannelAdapter } from "../../../runtime/gateway/index.js";
 import { CronScheduler } from "../../../runtime/cron-scheduler.js";
 import { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import { RuntimeWatchdog } from "../../../runtime/watchdog.js";
@@ -28,8 +28,6 @@ import { PluginLoader } from "../../../runtime/plugin-loader.js";
 import { NotifierRegistry } from "../../../runtime/notifier-registry.js";
 import { NotificationDispatcher } from "../../../runtime/notification-dispatcher.js";
 import { getNotificationConfigPath, loadNotificationConfig } from "../../../runtime/notification-routing.js";
-import { AdapterRegistry } from "../../../orchestrator/execution/adapter-layer.js";
-import { DataSourceRegistry } from "../../../platform/observation/data-source-adapter.js";
 import { getProviderRuntimeFingerprint } from "../../../base/llm/provider-config.js";
 import { buildDeps } from "../setup.js";
 import { formatOperationError } from "../utils.js";
@@ -37,6 +35,7 @@ import { getCliLogger } from "../cli-logger.js";
 import { getPulseedDirPath, getLogsDir, getEventsDir } from "../../../base/utils/paths.js";
 import { summarizeTaskOutcomeLedgers } from "../../../orchestrator/execution/task/task-outcome-ledger.js";
 import type { SupervisorState } from "../../../runtime/executor/index.js";
+import { createBuiltinTools } from "../../../tools/index.js";
 
 const WATCHDOG_CHILD_ENV = "PULSEED_WATCHDOG_CHILD";
 
@@ -286,17 +285,41 @@ export async function cmdStart(
     resolvedDaemonConfig.workspace_path,
   );
 
-  // Load notifier plugins and wire NotificationDispatcher
+  // Load plugins into the same registries used by the resident runtime.
   const notifierRegistry = new NotifierRegistry();
   const pluginsDir = path.join(os.homedir(), ".pulseed", "plugins");
-  const adapterRegistry = new AdapterRegistry();
-  const dataSourceRegistry = new DataSourceRegistry();
-  const pluginLoader = new PluginLoader(adapterRegistry, dataSourceRegistry, notifierRegistry, pluginsDir);
-  try {
-    await pluginLoader.loadAll();
-  } catch (err) {
-    getCliLogger().warn(`[daemon] Plugin loading failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
-  }
+
+  const loadPluginsIntoDeps = async (runtimeDeps: Awaited<ReturnType<typeof buildDeps>>): Promise<PluginLoader> => {
+    const pluginLoader = new PluginLoader(
+      runtimeDeps.adapterRegistry,
+      runtimeDeps.dataSourceRegistry,
+      notifierRegistry,
+      pluginsDir,
+      logger,
+      (adapter) => {
+        if (!runtimeDeps.observationEngine.getDataSources().some((source) => source.sourceId === adapter.sourceId)) {
+          runtimeDeps.observationEngine.addDataSource(adapter);
+        }
+      }
+    );
+    try {
+      await pluginLoader.loadAll();
+    } catch (err) {
+      getCliLogger().warn(`[daemon] Plugin loading failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    if (runtimeDeps.toolRegistry) {
+      for (const tool of createBuiltinTools({ pluginLoader, registry: runtimeDeps.toolRegistry })) {
+        if (!runtimeDeps.toolRegistry.get(tool.metadata.name)) {
+          runtimeDeps.toolRegistry.register(tool);
+        }
+      }
+    }
+
+    return pluginLoader;
+  };
+
+  const pluginLoader = await loadPluginsIntoDeps(deps);
   const daemonBaseDir = deps.stateManager.getBaseDir();
   const notificationConfig = await loadNotificationConfig(getNotificationConfigPath(daemonBaseDir));
   const notificationDispatcher = new NotificationDispatcher(notificationConfig, notifierRegistry);
@@ -309,6 +332,19 @@ export async function cmdStart(
     logger
   );
   const gateway = new IngressGateway(logger);
+  const slackGatewayConfig = resolvedDaemonConfig.gateway.slack;
+  if (slackGatewayConfig.enabled) {
+    if (!slackGatewayConfig.signing_secret) {
+      getCliLogger().warn("[daemon] gateway.slack.enabled is true but signing_secret is missing; Slack gateway disabled.");
+    } else {
+      const slackAdapter = new SlackChannelAdapter({
+        signingSecret: slackGatewayConfig.signing_secret,
+        channelGoalMap: slackGatewayConfig.channel_goal_map,
+      });
+      eventServer.setSlackChannelAdapter(slackAdapter, slackGatewayConfig.path);
+      gateway.registerAdapter(slackAdapter);
+    }
+  }
   notificationDispatcher.setRealtimeSink(async (report) => {
     eventServer.broadcast("notification_report", report);
   });
@@ -320,7 +356,7 @@ export async function cmdStart(
   const scheduleEngine = new ScheduleEngine({
     baseDir: daemonBaseDir,
     logger,
-    dataSourceRegistry,
+    dataSourceRegistry: deps.dataSourceRegistry,
     llmClient: deps.llmClient,
     coreLoop: deps.coreLoop,
     stateManager: deps.stateManager,
@@ -331,6 +367,7 @@ export async function cmdStart(
     knowledgeManager: deps.knowledgeManager,
   });
   await scheduleEngine.loadEntries();
+  await scheduleEngine.syncExternalSources(pluginLoader.getScheduleSources());
   await scheduleEngine.ensureSoilPublishSchedule();
 
   const refreshResidentDeps = async () => {
@@ -348,7 +385,7 @@ export async function cmdStart(
     const freshScheduleEngine = new ScheduleEngine({
       baseDir: daemonBaseDir,
       logger,
-      dataSourceRegistry,
+      dataSourceRegistry: freshDeps.dataSourceRegistry,
       llmClient: freshDeps.llmClient,
       coreLoop: freshDeps.coreLoop,
       stateManager: freshDeps.stateManager,
@@ -359,6 +396,8 @@ export async function cmdStart(
       knowledgeManager: freshDeps.knowledgeManager,
     });
     await freshScheduleEngine.loadEntries();
+    const freshPluginLoader = await loadPluginsIntoDeps(freshDeps);
+    await freshScheduleEngine.syncExternalSources(freshPluginLoader.getScheduleSources());
     await freshScheduleEngine.ensureSoilPublishSchedule();
 
     return {

--- a/src/interface/cli/commands/schedule.ts
+++ b/src/interface/cli/commands/schedule.ts
@@ -10,6 +10,7 @@ import {
 import { DreamScheduleSuggestionStore } from "../../../platform/dream/dream-schedule-suggestions.js";
 import type { ScheduleTriggerInput } from "../../../runtime/types/schedule.js";
 import { scheduleEdit } from "./schedule/edit.js";
+import { scheduleCost } from "./schedule/cost.js";
 import { scheduleHistory } from "./schedule/history.js";
 import { scheduleRunNow } from "./schedule/run-now.js";
 import { getScheduleOrPrintError } from "./schedule/shared.js";
@@ -46,6 +47,8 @@ export async function cmdSchedule(
       return await scheduleRunNow(stateManager, characterConfigManager, engine, argv.slice(1));
     case "history":
       return await scheduleHistory(engine, argv.slice(1));
+    case "cost":
+      return await scheduleCost(engine, argv.slice(1));
     case "remove":
       return await scheduleRemove(engine, argv.slice(1));
     case "presets":
@@ -53,7 +56,7 @@ export async function cmdSchedule(
     case "suggestions":
       return await scheduleSuggestions(baseDir, engine, argv.slice(1));
     default:
-      console.log("Usage: pulseed schedule <list|show|add|edit|pause|resume|run|history|remove|presets|suggestions>");
+      console.log("Usage: pulseed schedule <list|show|add|edit|pause|resume|run|history|cost|remove|presets|suggestions>");
       console.log("  list                              List all schedule entries");
       console.log("  show <id>                         Show one schedule entry as JSON");
       console.log("  add                               Add a heartbeat entry or preset");
@@ -62,6 +65,7 @@ export async function cmdSchedule(
       console.log("  resume <id>                       Re-enable a paused schedule entry");
       console.log("  run <id>                          Run a schedule entry immediately");
       console.log("  history <id> [--limit <n>]        Show recent execution history");
+      console.log("  cost [--period <7d|24h|2w>]       Show schedule token usage for a period");
       console.log("  remove <id>                       Remove a schedule entry");
       console.log("  presets                           List reusable schedule presets");
       console.log("  suggestions <list|apply|reject|dismiss>  Review dream-generated suggestions");

--- a/src/interface/cli/commands/schedule/cost.ts
+++ b/src/interface/cli/commands/schedule/cost.ts
@@ -1,0 +1,92 @@
+import { parseArgs } from "node:util";
+import type { ScheduleEngine } from "../../../../runtime/schedule/engine.js";
+
+function parsePeriodMs(period: string): number {
+  const match = /^(\d+)([dhw])$/.exec(period.trim());
+  if (!match) {
+    throw new Error("period must look like 7d, 24h, or 2w");
+  }
+  const value = Number(match[1]);
+  const unit = match[2];
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("period value must be positive");
+  }
+  if (unit === "h") return value * 60 * 60 * 1000;
+  if (unit === "w") return value * 7 * 24 * 60 * 60 * 1000;
+  return value * 24 * 60 * 60 * 1000;
+}
+
+export async function scheduleCost(engine: ScheduleEngine, argv: string[]): Promise<void> {
+  let parsed: ReturnType<typeof parseArgs>;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      allowPositionals: true,
+      options: {
+        period: { type: "string", default: "7d" },
+      },
+      strict: false,
+    });
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    return;
+  }
+
+  let periodMs: number;
+  const period = String(parsed.values.period ?? "7d");
+  try {
+    periodMs = parsePeriodMs(period);
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    return;
+  }
+
+  const sinceMs = Date.now() - periodMs;
+  const history = (await engine.getRecentHistory(5000))
+    .filter((record) => new Date(record.finished_at).getTime() >= sinceMs);
+  const entries = engine.getEntries();
+  const byEntry = new Map<string, { name: string; layer: string; executions: number; tokens: number }>();
+
+  for (const entry of entries) {
+    byEntry.set(entry.id, {
+      name: entry.name,
+      layer: entry.layer,
+      executions: 0,
+      tokens: 0,
+    });
+  }
+
+  for (const record of history) {
+    const current = byEntry.get(record.entry_id) ?? {
+      name: record.entry_name,
+      layer: record.layer ?? "unknown",
+      executions: 0,
+      tokens: 0,
+    };
+    current.executions += 1;
+    current.tokens += record.tokens_used ?? 0;
+    byEntry.set(record.entry_id, current);
+  }
+
+  const rows = Array.from(byEntry.entries())
+    .map(([entryId, row]) => ({ entryId, ...row }))
+    .filter((row) => row.executions > 0 || row.tokens > 0)
+    .sort((left, right) => right.tokens - left.tokens || left.name.localeCompare(right.name));
+  const totalTokens = rows.reduce((sum, row) => sum + row.tokens, 0);
+  const totalExecutions = rows.reduce((sum, row) => sum + row.executions, 0);
+
+  console.log(`Schedule cost summary (${period})`);
+  console.log(`  executions: ${totalExecutions}`);
+  console.log(`  tokens:     ${totalTokens}`);
+
+  if (rows.length === 0) {
+    console.log("  no schedule executions in this period");
+    return;
+  }
+
+  for (const row of rows) {
+    console.log(
+      `  ${row.entryId.slice(0, 8)}  [${row.layer}] ${row.name}  executions=${row.executions}  tokens=${row.tokens}`
+    );
+  }
+}

--- a/src/interface/cli/data-source-bootstrap.ts
+++ b/src/interface/cli/data-source-bootstrap.ts
@@ -1,0 +1,90 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { GitHubIssueDataSourceAdapter } from "../../adapters/datasources/github-issue-datasource.js";
+import { FileExistenceDataSourceAdapter } from "../../adapters/datasources/file-existence-datasource.js";
+import { ShellDataSourceAdapter } from "../../adapters/datasources/shell-datasource.js";
+import type { DataSourceConfig } from "../../base/types/data-source.js";
+import { readJsonFile } from "../../base/utils/json-io.js";
+import { getDatasourcesDir } from "../../base/utils/paths.js";
+import type { IDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
+import {
+  DataSourceRegistry,
+  FileDataSourceAdapter,
+  HttpApiDataSourceAdapter,
+  PostgresDataSourceAdapter,
+} from "../../platform/observation/data-source-adapter.js";
+
+interface DataSourceBootstrapLogger {
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+const consoleLogger: DataSourceBootstrapLogger = {
+  warn: (message) => console.warn(message),
+  error: (message) => console.error(message),
+};
+
+export function createCliDataSourceAdapter(
+  cfg: DataSourceConfig,
+  workspacePath = process.cwd(),
+): IDataSourceAdapter | null {
+  if (cfg.type === "file") {
+    return new FileDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "http_api") {
+    return new HttpApiDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "database") {
+    return new PostgresDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "github_issue") {
+    return new GitHubIssueDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "file_existence") {
+    return new FileExistenceDataSourceAdapter(cfg);
+  }
+  if (cfg.type === "shell") {
+    const adapter = new ShellDataSourceAdapter(
+      cfg.id,
+      (cfg.connection.commands ?? {}) as Record<string, import("../../adapters/datasources/shell-datasource.js").ShellCommandSpec>,
+      cfg.connection?.path ?? workspacePath
+    );
+    if (cfg.scope_goal_id) {
+      (adapter.config as Record<string, unknown>).scope_goal_id = cfg.scope_goal_id;
+    }
+    return adapter;
+  }
+
+  return null;
+}
+
+export async function buildCliDataSourceRegistry(
+  workspacePath = process.cwd(),
+  logger: DataSourceBootstrapLogger = consoleLogger,
+): Promise<DataSourceRegistry> {
+  const registry = new DataSourceRegistry();
+  const dsDir = getDatasourcesDir();
+
+  try {
+    let dsExists = false;
+    try { await fsp.access(dsDir); dsExists = true; } catch { /* not found */ }
+    if (!dsExists) {
+      return registry;
+    }
+
+    const files = (await fsp.readdir(dsDir)).filter(f => f.endsWith(".json"));
+    for (const file of files) {
+      const cfg = await readJsonFile<DataSourceConfig>(path.join(dsDir, file));
+      const adapter = createCliDataSourceAdapter(cfg, workspacePath);
+      if (adapter) {
+        registry.register(adapter);
+      } else {
+        logger.warn(`[pulseed] Unsupported built-in datasource type "${cfg.type}" in ${file}; skipping`);
+      }
+    }
+  } catch (err) {
+    logger.error(`[pulseed] Failed to load datasource configurations from "${dsDir}": ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  return registry;
+}

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -2,18 +2,11 @@
 //
 // buildDeps() wires all PulSeed dependencies for CLI subcommands.
 
-import * as fsp from "node:fs/promises";
 import * as path from "node:path";
-import { getPulseedDirPath, getDatasourcesDir } from "../../base/utils/paths.js";
-import { readJsonFile } from "../../base/utils/json-io.js";
+import * as fsp from "node:fs/promises";
+import { getPulseedDirPath } from "../../base/utils/paths.js";
 
 import { StateManager } from "../../base/state/state-manager.js";
-import type { DataSourceConfig } from "../../base/types/data-source.js";
-import type { IDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
-import { FileDataSourceAdapter, HttpApiDataSourceAdapter, PostgresDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
-import { GitHubIssueDataSourceAdapter } from "../../adapters/datasources/github-issue-datasource.js";
-import { FileExistenceDataSourceAdapter } from "../../adapters/datasources/file-existence-datasource.js";
-import { ShellDataSourceAdapter } from "../../adapters/datasources/shell-datasource.js";
 import { createWorkspaceContextProvider } from "../../platform/observation/workspace-context.js";
 import { buildLLMClient, buildAdapterRegistry } from "../../base/llm/provider-factory.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
@@ -66,40 +59,8 @@ import {
   type SoilPrefetchQuery,
   type SoilPrefetchResult,
 } from "../../orchestrator/execution/agent-loop/index.js";
-
-export function createCliDataSourceAdapter(
-  cfg: DataSourceConfig,
-  workspacePath = process.cwd(),
-): IDataSourceAdapter | null {
-  if (cfg.type === "file") {
-    return new FileDataSourceAdapter(cfg);
-  }
-  if (cfg.type === "http_api") {
-    return new HttpApiDataSourceAdapter(cfg);
-  }
-  if (cfg.type === "database") {
-    return new PostgresDataSourceAdapter(cfg);
-  }
-  if (cfg.type === "github_issue") {
-    return new GitHubIssueDataSourceAdapter(cfg);
-  }
-  if (cfg.type === "file_existence") {
-    return new FileExistenceDataSourceAdapter(cfg);
-  }
-  if (cfg.type === "shell") {
-    const adapter = new ShellDataSourceAdapter(
-      cfg.id,
-      (cfg.connection.commands ?? {}) as Record<string, import("../../adapters/datasources/shell-datasource.js").ShellCommandSpec>,
-      cfg.connection?.path ?? workspacePath
-    );
-    if (cfg.scope_goal_id) {
-      (adapter.config as Record<string, unknown>).scope_goal_id = cfg.scope_goal_id;
-    }
-    return adapter;
-  }
-
-  return null;
-}
+import { buildCliDataSourceRegistry } from "./data-source-bootstrap.js";
+export { createCliDataSourceAdapter } from "./data-source-bootstrap.js";
 
 export async function buildDeps(
   stateManager: StateManager,
@@ -116,8 +77,6 @@ export async function buildDeps(
   const trustManager = new TrustManager(stateManager);
   const driveSystem = new DriveSystem(stateManager);
   const adapterRegistry = await buildAdapterRegistry(llmClient);
-  const scheduleEngine = new ScheduleEngine({ baseDir: stateManager.getBaseDir() });
-  await scheduleEngine.loadEntries();
   const toolRegistry = new ToolRegistry();
   const registerBuiltinTools = (deps?: Parameters<typeof createBuiltinTools>[0]) => {
     for (const tool of createBuiltinTools(deps)) {
@@ -127,12 +86,17 @@ export async function buildDeps(
         toolRegistry.register(tool);
         continue;
       }
+      if (existing && tool.metadata.name.startsWith("schedule_") && deps?.scheduleEngine) {
+        toolRegistry.unregister(tool.metadata.name);
+        toolRegistry.register(tool);
+        continue;
+      }
       if (!existing) {
         toolRegistry.register(tool);
       }
     }
   };
-  registerBuiltinTools({ stateManager, trustManager, registry: toolRegistry, scheduleEngine });
+  registerBuiltinTools({ stateManager, trustManager, registry: toolRegistry });
   const permissionManager = new ToolPermissionManager({
     trustManager,
     allowRules: [
@@ -153,27 +117,8 @@ export async function buildDeps(
     concurrency: new ConcurrencyController(),
   });
 
-  // Read datasource configs from ~/.pulseed/datasources/
-  const dsDir = getDatasourcesDir();
-  const dataSources: IDataSourceAdapter[] = [];
-  try {
-    let dsExists = false;
-    try { await fsp.access(dsDir); dsExists = true; } catch { /* not found */ }
-    if (dsExists) {
-      const files = (await fsp.readdir(dsDir)).filter(f => f.endsWith('.json'));
-      for (const file of files) {
-        const cfg = await readJsonFile<DataSourceConfig>(path.join(dsDir, file));
-        const adapter = createCliDataSourceAdapter(cfg, resolvedWorkspacePath);
-        if (adapter) {
-          dataSources.push(adapter);
-        } else {
-          getCliLogger().warn(`[pulseed] Unsupported built-in datasource type "${cfg.type}" in ${file}; skipping`);
-        }
-      }
-    }
-  } catch (err) {
-    getCliLogger().error(formatOperationError(`load datasource configurations from "${dsDir}"`, err));
-  }
+  const dataSourceRegistry = await buildCliDataSourceRegistry(resolvedWorkspacePath, getCliLogger());
+  const dataSources = dataSourceRegistry.getAllSources();
 
   const contextProvider = createWorkspaceContextProvider(
     { workDir: resolvedWorkspacePath },
@@ -445,6 +390,21 @@ export async function buildDeps(
 
   coreLoop.setTimeHorizonEngine(new TimeHorizonEngine());
 
+  const scheduleEngine = new ScheduleEngine({
+    baseDir: stateManager.getBaseDir(),
+    logger,
+    dataSourceRegistry,
+    llmClient,
+    coreLoop,
+    stateManager,
+    reportingEngine,
+    hookManager,
+    memoryLifecycle: memoryLifecycleManager,
+    knowledgeManager,
+  });
+  await scheduleEngine.loadEntries();
+  registerBuiltinTools({ stateManager, trustManager, registry: toolRegistry, scheduleEngine });
+
   const curiosityEngine = new CuriosityEngine({
     stateManager,
     llmClient,
@@ -463,7 +423,11 @@ export async function buildDeps(
     stateManager,
     driveSystem,
     llmClient,
-    dataSourceRegistry: new Map(dataSources.map((adapter) => [adapter.sourceId, adapter])),
+    adapterRegistry,
+    dataSourceRegistry,
+    observationEngine,
+    scheduleEngine,
+    trustManager,
     hookManager,
     memoryLifecycleManager,
     knowledgeManager,

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -92,9 +92,11 @@ async function buildDeps() {
   const { TreeLoopOrchestrator } = await import("../../orchestrator/goal/tree-loop-orchestrator.js");
   const { ScheduleEngine } = await import("../../runtime/schedule/engine.js");
   const { MemoryLifecycleManager, DriveScoreAdapter } = await import("../../platform/knowledge/memory/memory-lifecycle.js");
+  const { KnowledgeManager } = await import("../../platform/knowledge/knowledge-manager.js");
   const { CharacterConfigManager } = await import("../../platform/traits/character-config.js");
   const { ChatRunner } = await import("../../interface/chat/chat-runner.js");
   const { ToolRegistry, ToolExecutor, ToolPermissionManager, ConcurrencyController, createBuiltinTools } = await import("../../tools/index.js");
+  const { buildCliDataSourceRegistry } = await import("../cli/data-source-bootstrap.js");
   const {
     createNativeChatAgentLoopRunner,
     createNativeTaskAgentLoopRunner,
@@ -112,11 +114,15 @@ async function buildDeps() {
   const providerConfig = await loadProviderConfig();
   const trustManager = new TrustManager(stateManager);
   const driveSystem = new DriveSystem(stateManager);
-  const scheduleEngine = new ScheduleEngine({ baseDir: stateManager.getBaseDir() });
-  await scheduleEngine.loadEntries();
+  const dataSourceRegistry = await buildCliDataSourceRegistry(process.cwd(), getCliLogger());
   const toolRegistry = new ToolRegistry();
-  for (const tool of createBuiltinTools({ stateManager, trustManager, registry: toolRegistry, scheduleEngine })) {
-    toolRegistry.register(tool);
+  const registerToolIfMissing = (tool: ReturnType<typeof createBuiltinTools>[number]) => {
+    if (!toolRegistry.get(tool.metadata.name)) {
+      toolRegistry.register(tool);
+    }
+  };
+  for (const tool of createBuiltinTools({ stateManager, trustManager, registry: toolRegistry })) {
+    registerToolIfMissing(tool);
   }
 
   const contextProvider = createWorkspaceContextProvider(
@@ -149,7 +155,7 @@ async function buildDeps() {
     }
   );
 
-  const observationEngine = new ObservationEngine(stateManager, [], llmClient, contextProvider);
+  const observationEngine = new ObservationEngine(stateManager, dataSourceRegistry.getAllSources(), llmClient, contextProvider);
   const progressPredictor = new ProgressPredictor();
   const stallDetector = new StallDetector(stateManager, characterConfig, progressPredictor);
   const satisficingJudge = new SatisficingJudge(stateManager);
@@ -255,6 +261,7 @@ async function buildDeps() {
     memoryLifecycleManager = undefined;
     driveScoreAdapter = undefined;
   }
+  const knowledgeManager = new KnowledgeManager(stateManager, llmClient);
 
   const soilPrefetch = memoryLifecycleManager
     ? async (query: { query: string; rootDir: string; limit: number }) => {
@@ -337,6 +344,30 @@ async function buildDeps() {
     driveScoreAdapter,
     contextProvider,
   });
+
+  const scheduleEngine = new ScheduleEngine({
+    baseDir: stateManager.getBaseDir(),
+    dataSourceRegistry,
+    llmClient,
+    coreLoop,
+    stateManager,
+    reportingEngine,
+    memoryLifecycle: memoryLifecycleManager,
+    knowledgeManager,
+  });
+  await scheduleEngine.loadEntries();
+  for (const tool of createBuiltinTools({
+    stateManager,
+    trustManager,
+    registry: toolRegistry,
+    scheduleEngine,
+    adapterRegistry,
+    sessionManager,
+    observationEngine,
+    knowledgeManager,
+  })) {
+    registerToolIfMissing(tool);
+  }
 
   const goalNegotiator = new GoalNegotiator(
     stateManager,
@@ -502,10 +533,15 @@ async function startTUIDaemonMode(): Promise<void> {
   const stateManager = new StateManager(baseDir);
   await stateManager.init();
   const { TrustManager } = await import("../../platform/traits/trust-manager.js");
+  const { ScheduleEngine } = await import("../../runtime/schedule/engine.js");
+  const { buildCliDataSourceRegistry } = await import("../cli/data-source-bootstrap.js");
   const { ToolRegistry, ToolExecutor, ToolPermissionManager, ConcurrencyController, createBuiltinTools } = await import("../../tools/index.js");
   const trustManager = new TrustManager(stateManager);
   const toolRegistry = new ToolRegistry();
-  for (const tool of createBuiltinTools({ stateManager, trustManager })) {
+  const dataSourceRegistry = await buildCliDataSourceRegistry(process.cwd(), getCliLogger());
+  const scheduleEngine = new ScheduleEngine({ baseDir, dataSourceRegistry });
+  await scheduleEngine.loadEntries();
+  for (const tool of createBuiltinTools({ stateManager, trustManager, registry: toolRegistry, scheduleEngine })) {
     toolRegistry.register(tool);
   }
   const permissionManager = new ToolPermissionManager({

--- a/src/platform/observation/data-source-adapter.ts
+++ b/src/platform/observation/data-source-adapter.ts
@@ -441,6 +441,10 @@ export class DataSourceRegistry {
     return Array.from(this.sources.keys()).sort();
   }
 
+  getAllSources(): IDataSourceAdapter[] {
+    return Array.from(this.sources.values());
+  }
+
   remove(id: string): void {
     if (!this.sources.has(id)) {
       throw new Error(

--- a/src/runtime/event/server.ts
+++ b/src/runtime/event/server.ts
@@ -18,6 +18,7 @@ import type { OutboxStore, OutboxRecord } from "../store/index.js";
 import { RuntimeControlOperationKindSchema } from "../store/index.js";
 import { EventServerSnapshotReader } from "./server-snapshot-reader.js";
 import { EventServerSseManager } from "./server-sse.js";
+import type { SlackChannelAdapter } from "../gateway/slack-channel-adapter.js";
 
 export interface EventServerConfig {
   host?: string; // default: "127.0.0.1" (localhost only!)
@@ -73,6 +74,8 @@ export class EventServer {
   private envelopeHook?: (eventData: Record<string, unknown>) => void | Promise<void>;
   private commandEnvelopeHook?: (envelope: Envelope) => void | Promise<void>;
   private activeWorkersProvider?: ActiveWorkersProvider;
+  private slackChannelAdapter?: SlackChannelAdapter;
+  private slackEventsPath = "/slack/events";
 
   constructor(driveSystem: DriveSystem, config?: EventServerConfig, logger?: Logger) {
     this.driveSystem = driveSystem;
@@ -406,6 +409,11 @@ export class EventServer {
     this.activeWorkersProvider = provider;
   }
 
+  setSlackChannelAdapter(adapter: SlackChannelAdapter, eventsPath = "/slack/events"): void {
+    this.slackChannelAdapter = adapter;
+    this.slackEventsPath = eventsPath.startsWith("/") ? eventsPath : `/${eventsPath}`;
+  }
+
   private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
     const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
     const urlPath = requestUrl.pathname;
@@ -414,6 +422,11 @@ export class EventServer {
     if (req.method === "GET" && urlPath === "/health") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ status: "ok", uptime: process.uptime() }));
+      return;
+    }
+
+    if (req.method === "POST" && this.slackChannelAdapter && urlPath === this.slackEventsPath) {
+      void this.handlePostSlackEvents(req, res);
       return;
     }
 
@@ -888,6 +901,32 @@ export class EventServer {
     } catch (err) {
       res.writeHead(400, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ ok: false, error: "Invalid schedule run request", details: String(err) }));
+    }
+  }
+
+  private async handlePostSlackEvents(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    if (!this.slackChannelAdapter) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Slack adapter is not configured" }));
+      return;
+    }
+
+    try {
+      const body = await readBody(req);
+      const headers = Object.fromEntries(
+        Object.entries(req.headers)
+          .filter((entry): entry is [string, string | string[]] => entry[1] !== undefined)
+          .map(([key, value]) => [key.toLowerCase(), Array.isArray(value) ? value.join(",") : value])
+      );
+      const response = this.slackChannelAdapter.handleRequest(body, headers);
+      res.writeHead(response.status, { "Content-Type": "application/json" });
+      res.end(response.body);
+    } catch (err) {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "Invalid Slack event request", details: String(err) }));
     }
   }
 

--- a/src/runtime/plugin-loader.ts
+++ b/src/runtime/plugin-loader.ts
@@ -45,7 +45,8 @@ export class PluginLoader {
     dataSourceRegistry: DataSourceRegistry,
     notifierRegistry: NotifierRegistry,
     pluginsDir?: string,
-    logger?: Logger
+    logger?: Logger,
+    private readonly onDataSourceRegistered?: (adapter: IDataSourceAdapter) => void
   ) {
     this.adapterRegistry = adapterRegistry;
     this.dataSourceRegistry = dataSourceRegistry;
@@ -277,6 +278,7 @@ export class PluginLoader {
         break;
       case "data_source":
         this.dataSourceRegistry.register(impl as IDataSourceAdapter);
+        this.onDataSourceRegistered?.(impl as IDataSourceAdapter);
         break;
       case "notifier":
         this.notifierRegistry.register(manifest.name, impl as INotifier);

--- a/src/runtime/schedule/__tests__/external-source-sync.test.ts
+++ b/src/runtime/schedule/__tests__/external-source-sync.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { ScheduleEngine } from "../engine.js";
+import type { IScheduleSource } from "../source.js";
+
+function makeSource(entries: Awaited<ReturnType<IScheduleSource["fetchEntries"]>>): IScheduleSource {
+  return {
+    id: "calendar",
+    name: "Calendar",
+    async healthCheck() {
+      return { healthy: true };
+    },
+    async fetchEntries() {
+      return entries;
+    },
+  };
+}
+
+describe("ScheduleEngine external source sync", () => {
+  it("adds and disables entries from schedule source plugins", async () => {
+    const tempDir = makeTempDir("schedule-source-sync-");
+    try {
+      const engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+
+      const first = await engine.syncExternalSources([
+        makeSource([
+          {
+            external_id: "standup",
+            source_id: "calendar",
+            name: "Calendar standup",
+            layer: "cron",
+            trigger: { type: "interval", seconds: 3600 },
+            enabled: true,
+            cron: {
+              job_kind: "prompt",
+              prompt_template: "Summarize standup notes",
+              context_sources: [],
+              output_format: "notification",
+              max_tokens: 100,
+            },
+            metadata: {},
+            synced_at: "2026-04-14T00:00:00.000Z",
+          },
+        ]),
+      ]);
+
+      expect(first).toMatchObject({ added: 1, updated: 0, disabled: 0, skipped: 0 });
+      expect(engine.getEntries()[0]).toMatchObject({
+        name: "Calendar standup",
+        metadata: {
+          source: "external",
+          external_source_id: "calendar",
+          external_id: "standup",
+        },
+      });
+
+      const second = await engine.syncExternalSources([makeSource([])]);
+
+      expect(second.disabled).toBe(1);
+      expect(engine.getEntries()[0]?.enabled).toBe(false);
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  });
+
+  it("does not disable existing entries when a source cannot be reconciled", async () => {
+    const tempDir = makeTempDir("schedule-source-sync-");
+    try {
+      const engine = new ScheduleEngine({ baseDir: tempDir });
+      await engine.loadEntries();
+
+      await engine.syncExternalSources([
+        makeSource([
+          {
+            external_id: "standup",
+            source_id: "calendar",
+            name: "Calendar standup",
+            layer: "cron",
+            trigger: { type: "interval", seconds: 3600 },
+            enabled: true,
+            cron: {
+              job_kind: "prompt",
+              prompt_template: "Summarize standup notes",
+              context_sources: [],
+              output_format: "notification",
+              max_tokens: 100,
+            },
+            metadata: {},
+            synced_at: "2026-04-14T00:00:00.000Z",
+          },
+        ]),
+      ]);
+
+      const failed = await engine.syncExternalSources([
+        {
+          id: "calendar",
+          name: "Calendar",
+          async healthCheck() {
+            return { healthy: false, error: "temporarily unavailable" };
+          },
+          async fetchEntries() {
+            throw new Error("should not fetch unhealthy source");
+          },
+        },
+      ]);
+
+      expect(failed.disabled).toBe(0);
+      expect(failed.errors[0]).toMatchObject({
+        source_id: "calendar",
+        message: "temporarily unavailable",
+      });
+      expect(engine.getEntries()[0]?.enabled).toBe(true);
+    } finally {
+      cleanupTempDir(tempDir);
+    }
+  });
+});

--- a/src/runtime/schedule/engine.ts
+++ b/src/runtime/schedule/engine.ts
@@ -22,6 +22,12 @@ import {
   type ScheduleResult,
   type ScheduleTriggerInput,
 } from "../types/schedule.js";
+import {
+  CronConfigSchema,
+  GoalTriggerConfigSchema,
+  HeartbeatConfigSchema,
+  ProbeConfigSchema,
+} from "../types/schedule.js";
 import { executeCron, executeGoalTrigger, executeProbe } from "./engine-layers.js";
 import {
   ScheduleHistoryStore,
@@ -37,6 +43,7 @@ import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manage
 import { projectSchedulesToSoil, rebuildSoilIndex } from "../../platform/soil/index.js";
 import { hasConfiguredSoilPublishProvider } from "../../platform/soil/publish/index.js";
 import { buildSchedulePresetEntry } from "./presets.js";
+import { ExternalScheduleEntrySchema, type ExternalScheduleEntry, type IScheduleSource } from "./source.js";
 
 const SCHEDULES_FILE = "schedules.json";
 const DEFAULT_RETRY_POLICY: ScheduleRetryPolicy = {
@@ -186,6 +193,142 @@ export class ScheduleEngine {
 
   getEntries(): ScheduleEntry[] {
     return this.entries;
+  }
+
+  getBaseDir(): string {
+    return this.baseDir;
+  }
+
+  async syncExternalSources(sources: IScheduleSource[]): Promise<{
+    added: number;
+    updated: number;
+    disabled: number;
+    skipped: number;
+    errors: Array<{ source_id: string; message: string }>;
+  }> {
+    const seenKeys = new Set<string>();
+    const reconciledSourceIds = new Set<string>();
+    const errors: Array<{ source_id: string; message: string }> = [];
+    let added = 0;
+    let updated = 0;
+    let skipped = 0;
+
+    for (const source of sources) {
+      try {
+        const health = await source.healthCheck();
+        if (!health.healthy) {
+          errors.push({ source_id: source.id, message: health.error ?? "source is unhealthy" });
+          continue;
+        }
+
+        const rawEntries = await source.fetchEntries();
+        const sourceIdsFromFetchedEntries = new Set<string>([source.id]);
+        let sourceHadEntryErrors = false;
+
+        for (const raw of rawEntries) {
+          const parsed = ExternalScheduleEntrySchema.safeParse(raw);
+          if (!parsed.success) {
+            sourceHadEntryErrors = true;
+            skipped++;
+            errors.push({ source_id: source.id, message: parsed.error.message });
+            continue;
+          }
+
+          const external = parsed.data;
+          sourceIdsFromFetchedEntries.add(external.source_id);
+          const entryInput = this.buildExternalScheduleEntryInput(external);
+          if (!entryInput) {
+            sourceHadEntryErrors = true;
+            skipped++;
+            errors.push({ source_id: external.source_id, message: `missing ${external.layer} config for ${external.external_id}` });
+            continue;
+          }
+
+          const key = this.externalEntryKey(external.source_id, external.external_id);
+          seenKeys.add(key);
+          const existingIndex = this.entries.findIndex((entry) =>
+            entry.metadata?.source === "external" &&
+            entry.metadata.external_source_id === external.source_id &&
+            entry.metadata.external_id === external.external_id
+          );
+
+          if (existingIndex === -1) {
+            this.entries.push(ScheduleEntrySchema.parse({
+              ...entryInput,
+              id: randomUUID(),
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+              last_fired_at: null,
+              next_fire_at: this.computeNextFireAt(entryInput.trigger),
+              consecutive_failures: 0,
+              last_escalation_at: null,
+              baseline_results: [],
+              total_executions: 0,
+              total_tokens_used: 0,
+            }));
+            added++;
+            continue;
+          }
+
+          const existing = this.entries[existingIndex]!;
+          const candidate = ScheduleEntrySchema.parse({
+            ...existing,
+            ...entryInput,
+            id: existing.id,
+            created_at: existing.created_at,
+            updated_at: existing.updated_at,
+            next_fire_at: JSON.stringify(existing.trigger) === JSON.stringify(entryInput.trigger)
+              ? existing.next_fire_at
+              : this.computeNextFireAt(entryInput.trigger),
+          });
+          if (JSON.stringify(existing) !== JSON.stringify(candidate)) {
+            this.entries[existingIndex] = ScheduleEntrySchema.parse({
+              ...candidate,
+              updated_at: new Date().toISOString(),
+            });
+            updated++;
+          }
+        }
+
+        if (!sourceHadEntryErrors) {
+          for (const sourceId of sourceIdsFromFetchedEntries) {
+            reconciledSourceIds.add(sourceId);
+          }
+        }
+      } catch (error) {
+        errors.push({ source_id: source.id, message: error instanceof Error ? error.message : String(error) });
+      }
+    }
+
+    let disabled = 0;
+    this.entries = this.entries.map((entry) => {
+      if (
+        entry.metadata?.source !== "external" ||
+        !entry.enabled ||
+        !entry.metadata.external_source_id ||
+        !reconciledSourceIds.has(entry.metadata.external_source_id)
+      ) {
+        return entry;
+      }
+
+      const key = this.externalEntryKey(entry.metadata.external_source_id, entry.metadata.external_id ?? "");
+      if (seenKeys.has(key)) {
+        return entry;
+      }
+
+      disabled++;
+      return ScheduleEntrySchema.parse({
+        ...entry,
+        enabled: false,
+        updated_at: new Date().toISOString(),
+      });
+    });
+
+    if (added > 0 || updated > 0 || disabled > 0) {
+      await this.saveEntries();
+    }
+
+    return { added, updated, disabled, skipped, errors };
   }
 
   // ─── Entry management ───
@@ -518,6 +661,60 @@ export class ScheduleEngine {
       knowledgeManager: this.knowledgeManager,
       logger: this.logger,
     };
+  }
+
+  private externalEntryKey(sourceId: string, externalId: string): string {
+    return `${sourceId}:${externalId}`;
+  }
+
+  private buildExternalScheduleEntryInput(external: ExternalScheduleEntry): Omit<
+    ScheduleEntryInput,
+    | "id"
+    | "created_at"
+    | "updated_at"
+    | "last_fired_at"
+    | "next_fire_at"
+    | "consecutive_failures"
+    | "last_escalation_at"
+    | "baseline_results"
+    | "total_executions"
+    | "total_tokens_used"
+    | "max_tokens_per_day"
+    | "tokens_used_today"
+    | "budget_reset_at"
+    | "escalation_timestamps"
+  > | null {
+    const base = {
+      name: external.name,
+      layer: external.layer,
+      trigger: external.trigger.type === "cron"
+        ? { type: "cron" as const, expression: external.trigger.expression!, timezone: "UTC" }
+        : { type: "interval" as const, seconds: external.trigger.seconds!, jitter_factor: 0 },
+      enabled: external.enabled,
+      metadata: {
+        source: "external" as const,
+        external_source_id: external.source_id,
+        external_id: external.external_id,
+        dependency_hints: [],
+        note: typeof external.metadata["note"] === "string" ? external.metadata["note"] : undefined,
+      },
+    };
+
+    if (external.layer === "heartbeat") {
+      const parsed = HeartbeatConfigSchema.safeParse(external.heartbeat ?? external.metadata["heartbeat"]);
+      return parsed.success ? { ...base, heartbeat: parsed.data } : null;
+    }
+    if (external.layer === "probe") {
+      const parsed = ProbeConfigSchema.safeParse(external.probe ?? external.metadata["probe"]);
+      return parsed.success ? { ...base, probe: parsed.data } : null;
+    }
+    if (external.layer === "cron") {
+      const parsed = CronConfigSchema.safeParse(external.cron ?? external.metadata["cron"]);
+      return parsed.success ? { ...base, cron: parsed.data } : null;
+    }
+
+    const parsed = GoalTriggerConfigSchema.safeParse(external.goal_trigger ?? external.metadata["goal_trigger"]);
+    return parsed.success ? { ...base, goal_trigger: parsed.data } : null;
   }
 
   private async executeEntry(entry: ScheduleEntry): Promise<ScheduleResult> {

--- a/src/runtime/schedule/source.ts
+++ b/src/runtime/schedule/source.ts
@@ -14,6 +14,11 @@ export const ExternalScheduleEntrySchema = z.object({
     (t) => (t.type === 'cron' ? !!t.expression : !!t.seconds),
     { message: 'cron trigger requires expression, interval trigger requires seconds' }
   ),
+  enabled: z.boolean().default(true),
+  heartbeat: z.unknown().optional(),
+  probe: z.unknown().optional(),
+  cron: z.unknown().optional(),
+  goal_trigger: z.unknown().optional(),
   metadata: z.record(z.unknown()).default({}), // source-specific data
   synced_at: z.string().datetime(),
 });

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -25,6 +25,14 @@ export const DaemonConfigSchema = z.object({
   iterations_per_cycle: z.number().int().positive().default(10), // max CoreLoop iterations per daemon cycle
   max_concurrent_goals: z.number().int().positive().default(4), // max goals the supervisor may execute at once
   event_server_port: z.number().int().nonnegative().default(41700), // EventServer HTTP port (0 = OS-assigned, safe for tests)
+  gateway: z.object({
+    slack: z.object({
+      enabled: z.boolean().default(false),
+      signing_secret: z.string().optional(),
+      path: z.string().default("/slack/events"),
+      channel_goal_map: z.record(z.string()).default({}),
+    }).default({}),
+  }).default({}),
   proactive_mode: z.boolean().default(false),
   proactive_interval_ms: z.number().default(3_600_000), // 1 hour minimum between proactive ticks
   goal_review_interval_ms: z.number().int().nonnegative().default(7 * 24 * 60 * 60 * 1000), // weekly goal review cadence

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -64,9 +64,11 @@ export const GoalTriggerConfigSchema = z.object({
 export type GoalTriggerConfig = z.infer<typeof GoalTriggerConfigSchema>;
 
 export const ScheduleEntryMetadataSchema = z.object({
-  source: z.enum(["manual", "preset", "dream"]).default("manual"),
+  source: z.enum(["manual", "preset", "dream", "external"]).default("manual"),
   preset_key: z.string().optional(),
   dream_suggestion_id: z.string().optional(),
+  external_source_id: z.string().optional(),
+  external_id: z.string().optional(),
   dependency_hints: z.array(z.string()).default([]),
   note: z.string().optional(),
 });

--- a/src/tools/schedule/RunScheduleTool/RunScheduleTool.ts
+++ b/src/tools/schedule/RunScheduleTool/RunScheduleTool.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../types.js";
 import type { ScheduleEngine, RunScheduleNowResult } from "../../../runtime/schedule/engine.js";
 import type { ScheduleEntry } from "../../../runtime/types/schedule.js";
+import { DaemonClient, isDaemonRunning } from "../../../runtime/daemon/client.js";
 import { resolveScheduleEntry } from "../../../runtime/schedule/entry-resolver.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
@@ -60,6 +61,42 @@ export class RunScheduleTool implements ITool<RunScheduleInput, RunScheduleOutpu
           error: `Schedule not found: ${input.schedule_id}`,
           durationMs: Date.now() - startTime,
         };
+      }
+
+      const getBaseDir = this.scheduleEngine.getBaseDir;
+      if (typeof getBaseDir === "function") {
+        const baseDir = getBaseDir.call(this.scheduleEngine);
+        const daemon = await isDaemonRunning(baseDir);
+        if (daemon.running) {
+          const client = new DaemonClient({
+            host: "127.0.0.1",
+            port: daemon.port,
+            authToken: daemon.authToken,
+            baseDir,
+          });
+          await client.runScheduleNow(existingEntry.id, {
+            allowEscalation: input.allow_escalation,
+          });
+          return {
+            success: true,
+            data: {
+              entry: existingEntry,
+              reason: "manual_run",
+              result: {
+                entry_id: existingEntry.id,
+                status: "ok",
+                duration_ms: Date.now() - startTime,
+                fired_at: new Date().toISOString(),
+                layer: existingEntry.layer,
+                tokens_used: 0,
+                escalated_to: null,
+                output_summary: "Requested daemon-resident schedule run",
+              },
+            },
+            summary: `Requested daemon schedule run: ${existingEntry.name}`,
+            durationMs: Date.now() - startTime,
+          };
+        }
       }
 
       const run = await this.scheduleEngine.runEntryNow(existingEntry.id, {


### PR DESCRIPTION
## Summary
- Share CLI datasource bootstrap across CLI/TUI/chat/Telegram and wire plugin datasources into the resident observation runtime
- Sync external schedule sources into ScheduleEngine and route run_schedule through the daemon when available
- Add schedule cost CLI, Slack gateway event wiring, dependency cleanup, and tests for schedule sync/cost/runtime wiring

## Verification
- npm run typecheck
- npm run lint:boundaries
- npm run check:docs
- npm test
- npm run build
- npx vitest run src/runtime/schedule/__tests__/external-source-sync.test.ts
- npx --yes knip --reporter compact --no-progress (still reports pre-existing unused files/exports and example plugin package deps; targeted ink-spinner/zod-to-json-schema issues are resolved)