### PR TITLE
Fix setup import and harden release packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,6 @@ jobs:
 
       - run: npm install -g npm@11
       - run: npm ci
-      - run: npm run build
-      - run: npm test
 
       - name: Verify release tag matches package version
         run: |
@@ -36,4 +34,6 @@ jobs:
             exit 1
           fi
 
+      - run: npm run verify:release
+      - run: git diff --exit-code
       - run: npm publish --provenance --access public

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ memory/
 docs/archive/
 scripts/*
 !scripts/check-docs.mjs
+!scripts/clean-dist.mjs
 !scripts/release.mjs
 
 # Non-public: stale, will revisit later

--- a/README.md
+++ b/README.md
@@ -6,10 +6,14 @@
 
 Goal-driven orchestration for long-running work.
 
-[![Website](https://img.shields.io/badge/Website-pulseed.dev-blue)](https://pulseed.dev)
-[![CI](https://github.com/my-name-is-yu/PulSeed/actions/workflows/ci.yml/badge.svg)](https://github.com/my-name-is-yu/PulSeed/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/pulseed.svg)](https://www.npmjs.com/package/pulseed)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Website](https://img.shields.io/badge/Website-pulseed.dev-blue?style=flat-square)](https://pulseed.dev)
+[![CI](https://img.shields.io/github/actions/workflow/status/my-name-is-yu/PulSeed/ci.yml?branch=main&label=CI&style=flat-square)](https://github.com/my-name-is-yu/PulSeed/actions/workflows/ci.yml)
+[![Publish](https://img.shields.io/github/actions/workflow/status/my-name-is-yu/PulSeed/publish.yml?label=Publish&style=flat-square)](https://github.com/my-name-is-yu/PulSeed/actions/workflows/publish.yml)
+[![npm version](https://img.shields.io/npm/v/pulseed.svg?style=flat-square)](https://www.npmjs.com/package/pulseed)
+[![npm downloads](https://img.shields.io/npm/dm/pulseed.svg?style=flat-square)](https://www.npmjs.com/package/pulseed)
+[![Node.js >=20](https://img.shields.io/badge/node-%3E%3D20-339933?style=flat-square&logo=node.js&logoColor=white)](https://nodejs.org/)
+[![Security Policy](https://img.shields.io/badge/security-policy-brightgreen.svg?style=flat-square)](SECURITY.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 
 </div>
 
@@ -44,8 +48,10 @@ PulSeed uses two layers:
 State, reports, schedules, and local memory live under `~/.pulseed/`.
 
 Security boundary: PulSeed uses approval gates and verification around delegated work.
-Supported CLI adapters can be wrapped with a configured terminal backend such as Docker,
-but high-risk or untrusted goals should still run inside an environment you control. See [Security](SECURITY.md).
+Native `agent_loop` task execution can use isolated git worktrees, and supported
+CLI adapters can be wrapped with a Docker terminal backend. These reduce blast
+radius, but local backends and plugins still run with the user's privileges. See
+[Security](SECURITY.md).
 
 ## Main Command
 
@@ -73,9 +79,10 @@ Run releases from a clean, up-to-date `main` branch:
 npm run release -- 0.4.9
 ```
 
-The script updates the package version, runs docs/build/test checks, pushes `main`,
-then pushes the matching `v*` tag. The tag push triggers GitHub Actions to publish
-to npm through Trusted Publishing.
+The script updates the package version, runs release verification including
+docs, typecheck, boundary lint, full tests, production audit, and an npm pack
+dry run, pushes `main`, then pushes the matching `v*` tag. The tag push triggers
+GitHub Actions to publish to npm through Trusted Publishing.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,7 +52,14 @@ PulSeed is a local-first orchestrator. Its trust boundaries are as follows:
 PulSeed calls external LLM APIs (OpenAI, Anthropic) for goal decomposition, observation, and task generation. API keys are read from environment variables or `~/.pulseed/provider.json`. All LLM responses are treated as untrusted input: they pass through a Zod schema validation and sanitization pipeline before any data is acted upon. Errors in this pipeline are always logged — they are never silently swallowed.
 
 ### Agent Execution
-PulSeed delegates tasks to AI agents (e.g., Claude Code CLI, OpenAI Codex CLI) by spawning subprocesses. These agents can execute shell commands and file operations on the user's machine. PulSeed provides a configurable terminal backend for supported CLI adapters, including a Docker wrapper, but the default backend is still the local process backend. The EthicsGate (L1) provides a software-level safety check — evaluating proposed actions against mechanical rules and, for ambiguous cases, an LLM judgment — but this is not a substitute for using a container, VM, or host-level sandbox for untrusted work.
+PulSeed has two task execution families:
+
+- Native `agent_loop` execution runs PulSeed's bounded tool-using runtime. When `agent_loop.worktree.enabled` is configured, task execution happens in a detached git worktree and can preserve or clean up that worktree according to the configured policy.
+- Supported CLI adapters such as Claude Code CLI and OpenAI Codex CLI spawn subprocesses. They can run through the local process backend or through the configured Docker terminal backend. The Docker backend mounts the task cwd into the container and defaults container networking to `none`.
+
+Git worktrees isolate repository changes from the primary checkout, but they are not an OS privilege boundary. The local process backend runs with the user's OS privileges. Docker provides a stronger process and network boundary for supported CLI adapters, but its protection depends on the Docker image, volume configuration, and host Docker setup.
+
+The EthicsGate (L1) provides a software-level safety check — evaluating proposed actions against mechanical rules and, for ambiguous cases, an LLM judgment — but this is not a substitute for a host-level sandbox when running untrusted work.
 
 Irreversible actions (file deletion, external API mutations, state modifications) always require explicit human approval, regardless of trust score or confidence level. PulSeed never executes these directly; it delegates and verifies.
 
@@ -76,7 +83,11 @@ API keys for LLM providers may be stored in `~/.pulseed/provider.json` or passed
 - Rotate keys regularly
 
 ### Agent Execution Sandbox Limitations
-The EthicsGate performs rule-based and LLM-based checks on proposed agent actions before execution. It operates entirely in software and cannot guarantee prevention against a sufficiently crafted prompt or a compromised LLM response. Users running PulSeed against untrusted goals, in shared environments, or automating high-risk tasks should consider running it inside a container or VM for additional isolation.
+The EthicsGate performs rule-based and LLM-based checks on proposed agent actions before execution. It operates entirely in software and cannot guarantee prevention against a sufficiently crafted prompt or a compromised LLM response.
+
+Worktree isolation helps keep native `agent_loop` file changes out of the primary checkout, but a process running in that worktree still has the privileges granted to the PulSeed process and its tools. Docker terminal backends give supported CLI adapters a configurable process and network boundary, but only for those subprocess-backed adapters.
+
+Users running PulSeed against untrusted goals, in shared environments, or automating high-risk tasks should use Docker-backed CLI adapters, run PulSeed itself inside a container, or use a VM for additional isolation.
 
 ### LLM Prompt Injection
 PulSeed passes user-supplied goal descriptions and observed state into LLM prompts. A maliciously crafted goal string could attempt to manipulate LLM output (prompt injection). All LLM responses are validated through a schema pipeline, which reduces the blast radius, but does not eliminate the risk entirely. Review goals before executing the core loop.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,7 +79,11 @@ Optional `terminal_backend` shape for CLI adapters:
 }
 ```
 
-When omitted, PulSeed uses the local process backend. The Docker backend wraps supported CLI adapters in `docker run`, mounts the task cwd at the configured workdir, and defaults network access to `none`.
+When omitted, supported CLI execution adapters use the local process backend.
+The Docker backend wraps those CLI adapters in `docker run`, mounts the task cwd
+at the configured workdir, and defaults network access to `none`. This backend
+applies to CLI adapters such as `openai_codex_cli` and `claude_code_cli`; native
+`agent_loop` isolation is configured separately through `agent_loop.worktree`.
 
 ## 4. Environment variables
 
@@ -135,6 +139,8 @@ Operational meaning:
 
 - when enabled, task execution can run in a separate worktree instead of mutating the primary workspace directly
 - when `keep_for_debug` is true, PulSeed leaves the worktree behind for inspection
+- worktree isolation separates filesystem changes from the primary checkout, but it is not an OS-level sandbox
+- for untrusted goals that need process or network isolation, use a Docker terminal backend for supported CLI adapters or run PulSeed inside a container or VM
 
 ## 7. Local state layout
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -30,9 +30,12 @@ For broader navigation, see [Architecture Map](architecture-map.md).
 
 ## Safety Boundary
 
-PulSeed has software-level approval and verification gates, but it does not provide
-OS-level sandboxing for delegated agent subprocesses. For high-risk or untrusted
-goals, use an external container or VM boundary. See [Security](../SECURITY.md).
+PulSeed has software-level approval and verification gates. Native `agent_loop`
+task execution can use git worktree isolation, and supported CLI adapters can be
+wrapped with a Docker terminal backend. These boundaries are configurable and do
+not cover every execution path: local backends and plugins still run with the
+user's privileges. For high-risk or untrusted goals, use Docker, a containerized
+PulSeed process, or a VM boundary. See [Security](../SECURITY.md).
 
 ## Source of truth
 

--- a/package.json
+++ b/package.json
@@ -45,8 +45,12 @@
     "LICENSE"
   ],
   "scripts": {
+    "clean": "node scripts/clean-dist.mjs",
     "build": "tsc -p tsconfig.build.json",
     "check:docs": "node scripts/check-docs.mjs",
+    "audit:prod": "npm audit --omit=dev --audit-level=high",
+    "prepack": "npm run clean && npm run build",
+    "pack:dry-run": "npm pack --dry-run",
     "release": "node scripts/release.mjs",
     "test": "vitest run --exclude tests/e2e",
     "test:all": "vitest run",
@@ -56,6 +60,7 @@
     "test:changed": "vitest run --changed",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
+    "verify:release": "npm run check:docs && npm run typecheck && npm run lint:boundaries && npm run test:all && npm audit --omit=dev --audit-level=high && npm pack --dry-run",
     "tui": "node dist/interface/tui/entry.js",
     "test:remote": "bash scripts/test-remote.sh",
     "test:remote:coverage": "bash scripts/test-remote.sh --coverage",

--- a/scripts/clean-dist.mjs
+++ b/scripts/clean-dist.mjs
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { rmSync } from "node:fs";
+import { resolve } from "node:path";
+
+const distPath = resolve(process.cwd(), "dist");
+rmSync(distPath, { recursive: true, force: true });
+console.error(`Removed ${distPath}`);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -38,9 +38,8 @@ if (remoteTagExists(tagName)) {
 
 run('npm', ['version', version, '--no-git-tag-version']);
 run('git', ['add', 'package.json', 'package-lock.json']);
-run('npm', ['run', 'check:docs']);
-run('npm', ['run', 'build']);
-run('npm', ['test']);
+run('npm', ['run', 'verify:release']);
+run('git', ['diff', '--exit-code']);
 run('git', ['add', 'package.json', 'package-lock.json']);
 run('git', ['commit', '-m', `Release ${version}`]);
 run('git', ['push', 'origin', 'main']);

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -51,7 +51,14 @@ export async function readCodexOAuthToken(): Promise<string | undefined> {
  * Ollama models are dynamic and not listed here.
  */
 export const MODEL_REGISTRY: Record<string, { provider: string; adapters: string[] }> = {
+  "gpt-5.4": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
+  "gpt-5.2-codex": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
+  "gpt-5.1-codex-max": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
   "gpt-5.4-mini": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
+  "gpt-5.3-codex": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
+  "gpt-5.3-codex-spark": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
+  "gpt-5.2": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
+  "gpt-5.1-codex-mini": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
   "gpt-4.1": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
   "gpt-4o-mini": { provider: "openai", adapters: ["openai_api", "agent_loop"] },
   "o3-mini": { provider: "openai", adapters: ["openai_api", "agent_loop"] },

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -124,12 +124,12 @@ describe("setup notification step", () => {
     );
   });
 
-  it("preselects custom model when modifying an unknown current model", async () => {
+  it("preselects custom model for non-OpenAI providers when modifying an unknown current model", async () => {
     selectMock.mockResolvedValueOnce("__custom__");
     textMock.mockResolvedValueOnce("my-custom-model");
 
     const { stepModel } = await import("../commands/setup/steps-provider.js");
-    const result = await stepModel("openai", "my-custom-model");
+    const result = await stepModel("anthropic", "my-custom-model");
 
     expect(result).toBe("my-custom-model");
     expect(selectMock).toHaveBeenCalledWith(
@@ -142,6 +142,42 @@ describe("setup notification step", () => {
         initialValue: "my-custom-model",
       })
     );
+  });
+
+  it("shows the OpenAI model list without recommended hints", async () => {
+    selectMock.mockResolvedValueOnce("gpt-5.4");
+
+    const { stepModel } = await import("../commands/setup/steps-provider.js");
+    const result = await stepModel("openai");
+
+    expect(result).toBe("gpt-5.4");
+    const prompt = selectMock.mock.calls[0]?.[0] as {
+      options: Array<{ label: string; value: string; hint?: string }>;
+    };
+    expect(prompt.options.map((option) => option.label)).toEqual([
+      "GPT-5.4",
+      "GPT-5.2-Codex",
+      "GPT-5.1-Codex-Max",
+      "GPT-5.4-Mini",
+      "GPT-5.3-Codex",
+      "GPT-5.3-Codex-Spark",
+      "GPT-5.2",
+      "GPT-5.1-Codex-Mini",
+    ]);
+    expect(prompt.options.every((option) => option.hint !== "recommended")).toBe(true);
+  });
+
+  it("does not show recommended hints for execution adapters", async () => {
+    selectMock.mockResolvedValueOnce("agent_loop");
+
+    const { stepAdapter } = await import("../commands/setup/steps-adapter.js");
+    const result = await stepAdapter("gpt-5.4", "openai");
+
+    expect(result).toBe("agent_loop");
+    const prompt = selectMock.mock.calls[0]?.[0] as {
+      options: Array<{ hint?: string }>;
+    };
+    expect(prompt.options.some((option) => option.hint?.includes("recommended"))).toBe(false);
   });
 
   it("writes notification.json only after final confirmation", async () => {
@@ -543,7 +579,7 @@ describe("setup notification step", () => {
     );
   });
 
-  it("still asks for Seedy name after importing from OpenClaw", async () => {
+  it("uses imported provider settings without re-asking execution prompts after importing from OpenClaw", async () => {
     const stepExistingConfigMock = vi.fn(async () => "keep");
     const stepSeedyNameMock = vi.fn(async () => "Imported Seedy");
     const stepProviderMock = vi.fn(async (initial?: string) => initial ?? "openai");
@@ -655,10 +691,10 @@ describe("setup notification step", () => {
     expect(code).toBe(0);
     expect(stepExistingConfigMock).not.toHaveBeenCalled();
     expect(stepSeedyNameMock).toHaveBeenCalledTimes(1);
-    expect(stepProviderMock).toHaveBeenCalledWith("anthropic");
-    expect(stepModelMock).toHaveBeenCalledWith("anthropic", "claude-sonnet-4-6");
-    expect(stepAdapterMock).toHaveBeenCalledWith("claude-sonnet-4-6", "anthropic", "agent_loop");
-    expect(stepApiKeyMock).toHaveBeenCalledWith("anthropic", expect.any(Object), "sk-imported", "agent_loop");
+    expect(stepProviderMock).not.toHaveBeenCalled();
+    expect(stepModelMock).not.toHaveBeenCalled();
+    expect(stepAdapterMock).not.toHaveBeenCalled();
+    expect(stepApiKeyMock).not.toHaveBeenCalled();
     expect(saveProviderConfigMock).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: "anthropic",

--- a/src/interface/cli/__tests__/setup-import.test.ts
+++ b/src/interface/cli/__tests__/setup-import.test.ts
@@ -305,9 +305,7 @@ describe("setup import flow", () => {
   it("asks which source to import from when Hermes and OpenClaw are both detected", async () => {
     vi.resetModules();
     const confirmMock = vi.fn(async () => true);
-    const selectMock = vi.fn()
-      .mockResolvedValueOnce("openclaw")
-      .mockResolvedValueOnce("recommended");
+    const selectMock = vi.fn().mockResolvedValueOnce("openclaw");
     const logInfoMock = vi.fn();
     const sources: SetupImportSource[] = [
       {
@@ -383,15 +381,28 @@ describe("setup import flow", () => {
     expect(selectMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
-        message: expect.stringContaining("Which existing agent"),
+        message: "Found existing settings!",
+        options: expect.arrayContaining([
+          expect.objectContaining({ label: "Migrate Hermes Agent settings" }),
+          expect.objectContaining({ label: "Migrate OpenClaw settings" }),
+          expect.objectContaining({ label: "Do not migrate" }),
+        ]),
       })
     );
+    const firstPrompt = selectMock.mock.calls[0]?.[0] as { options: Array<{ label: string }> };
+    expect(firstPrompt.options.map((option) => option.label)).toEqual([
+      "Migrate OpenClaw settings",
+      "Migrate Hermes Agent settings",
+      "Do not migrate",
+    ]);
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(confirmMock).not.toHaveBeenCalled();
   });
 
-  it("respects manual item selection and does not seed skipped provider defaults", async () => {
+  it("imports all items from the selected source without a second item-selection prompt", async () => {
     vi.resetModules();
     const confirmMock = vi.fn(async () => true);
-    const selectMock = vi.fn(async () => "choose");
+    const selectMock = vi.fn().mockResolvedValueOnce("openclaw");
     const multiselectMock = vi.fn(async () => ["openclaw-skill"]);
     const sources: SetupImportSource[] = [
       {
@@ -442,13 +453,15 @@ describe("setup import flow", () => {
     const { stepSetupImport } = await import("../commands/setup/import/flow.js");
     const selection = await stepSetupImport();
 
-    expect(selection?.providerSettings).toBeUndefined();
-    expect(selection?.items.find((item) => item.id === "openclaw-provider")?.decision).toBe("skip");
+    expect(selection?.providerSettings).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      adapter: "agent_loop",
+    });
+    expect(selection?.items.find((item) => item.id === "openclaw-provider")?.decision).toBe("import");
     expect(selection?.items.find((item) => item.id === "openclaw-skill")?.decision).toBe("import");
-    expect(multiselectMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "Select items to import:",
-      })
-    );
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(multiselectMock).not.toHaveBeenCalled();
   });
 });

--- a/src/interface/cli/__tests__/setup-shared.test.ts
+++ b/src/interface/cli/__tests__/setup-shared.test.ts
@@ -57,12 +57,19 @@ describe("detectApiKeys", () => {
 // ─── getModelsForProvider ───
 
 describe("getModelsForProvider", () => {
-  it("returns openai models for openai provider", () => {
+  it("returns openai models for openai provider in the expected order", () => {
     const models = getModelsForProvider("openai");
     expect(models.length).toBeGreaterThan(0);
-    // All returned models should be from openai provider
-    expect(models).toContain("gpt-5.4-mini");
-    expect(models).toContain("gpt-4.1");
+    expect(models).toEqual([
+      "gpt-5.4",
+      "gpt-5.2-codex",
+      "gpt-5.1-codex-max",
+      "gpt-5.4-mini",
+      "gpt-5.3-codex",
+      "gpt-5.3-codex-spark",
+      "gpt-5.2",
+      "gpt-5.1-codex-mini",
+    ]);
   });
 
   it("returns anthropic models for anthropic provider", () => {

--- a/src/interface/cli/commands/setup-shared.ts
+++ b/src/interface/cli/commands/setup-shared.ts
@@ -27,6 +27,28 @@ export const RECOMMENDED_MODELS: Record<string, string> = {
   ollama: "qwen3:4b",
 };
 
+const OPENAI_MODEL_ORDER = [
+  "gpt-5.4",
+  "gpt-5.2-codex",
+  "gpt-5.1-codex-max",
+  "gpt-5.4-mini",
+  "gpt-5.3-codex",
+  "gpt-5.3-codex-spark",
+  "gpt-5.2",
+  "gpt-5.1-codex-mini",
+] as const;
+
+const OPENAI_MODEL_LABELS: Record<string, string> = {
+  "gpt-5.4": "GPT-5.4",
+  "gpt-5.2-codex": "GPT-5.2-Codex",
+  "gpt-5.1-codex-max": "GPT-5.1-Codex-Max",
+  "gpt-5.4-mini": "GPT-5.4-Mini",
+  "gpt-5.3-codex": "GPT-5.3-Codex",
+  "gpt-5.3-codex-spark": "GPT-5.3-Codex-Spark",
+  "gpt-5.2": "GPT-5.2",
+  "gpt-5.1-codex-mini": "GPT-5.1-Codex-Mini",
+};
+
 export const RECOMMENDED_ADAPTERS: Partial<Record<Provider, string>> = {
   openai: "agent_loop",
   anthropic: "agent_loop",
@@ -49,9 +71,20 @@ export function detectApiKeys(): Record<string, boolean> {
  * Returns all model names in MODEL_REGISTRY that belong to the given provider.
  */
 export function getModelsForProvider(provider: string): string[] {
+  if (provider === "openai") {
+    return [...OPENAI_MODEL_ORDER].filter((model) => {
+      const entry = MODEL_REGISTRY[model];
+      return !entry || entry.provider === provider;
+    });
+  }
+
   return Object.entries(MODEL_REGISTRY)
     .filter(([, info]) => info.provider === provider)
     .map(([name]) => name);
+}
+
+export function getModelLabel(model: string): string {
+  return OPENAI_MODEL_LABELS[model] ?? model;
 }
 
 /**

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -11,7 +11,7 @@ import type { ProviderConfig } from "../../../base/llm/provider-config.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
 import { isDaemonRunning } from "../../../runtime/daemon/client.js";
 import { ROOT_PRESETS } from "./presets/root-presets.js";
-import { detectApiKeys, getAdaptersForModel, maskKey } from "./setup-shared.js";
+import { MODEL_REGISTRY, detectApiKeys, getAdaptersForModel, maskKey } from "./setup-shared.js";
 import type { Provider } from "./setup-shared.js";
 import { getBanner, stepExistingConfig, stepUserName, stepSeedyName } from "./setup/steps-identity.js";
 import { stepRootPreset, stepProvider, stepModel, stepApiKey } from "./setup/steps-provider.js";
@@ -96,25 +96,56 @@ function buildProviderConfig(
   return config;
 }
 
+function canUseImportedModel(provider: Provider, model: string | undefined): model is string {
+  if (!model) return false;
+  const registryEntry = MODEL_REGISTRY[model];
+  return !registryEntry || registryEntry.provider === provider;
+}
+
+function isLikelyCodexOAuthToken(value: string | undefined): boolean {
+  if (!value) return false;
+  const trimmed = value.trim();
+  return trimmed.startsWith("eyJ") && trimmed.split(".").length >= 3;
+}
+
+function canUseImportedApiKey(provider: Provider, adapter: string, apiKey: string | undefined): apiKey is string {
+  if (!apiKey) return false;
+  return !(provider === "openai" && adapter !== "openai_codex_cli" && isLikelyCodexOAuthToken(apiKey));
+}
+
 async function stepExecutionConfig(
-  current?: ExecutionAnswers
+  current?: ExecutionAnswers,
+  mode: "interactive" | "imported" = "interactive"
 ): Promise<ExecutionAnswers> {
-  const provider = await stepProvider(current?.provider);
-  const initialModel = current?.provider === provider ? current.model : undefined;
-  const model = await stepModel(provider, initialModel);
+  const provider = mode === "imported" && current?.provider ? current.provider : await stepProvider(current?.provider);
+  const importedModel = mode === "imported" && canUseImportedModel(provider, current?.model);
+  const model =
+    importedModel
+      ? current.model
+      : await stepModel(
+          provider,
+          mode === "interactive" && current?.provider === provider ? current.model : undefined
+        );
   const adaptersForModel = getAdaptersForModel(model, provider);
-  const initialAdapter =
-    current?.provider === provider && adaptersForModel.includes(current.adapter)
+  const adapter =
+    mode === "imported" && current?.adapter && adaptersForModel.includes(current.adapter)
       ? current.adapter
-      : undefined;
-  const adapter = await stepAdapter(model, provider, initialAdapter);
+      : await stepAdapter(
+          model,
+          provider,
+          mode === "interactive" && current?.provider === provider && adaptersForModel.includes(current.adapter)
+            ? current.adapter
+            : undefined
+        );
   if (!adapter) return { provider, model, adapter, apiKey: current?.apiKey };
 
   const detectedKeys = detectApiKeys();
   const apiKey =
-    current?.provider === provider
-      ? await stepApiKey(provider, detectedKeys, current.apiKey, adapter)
-      : await stepApiKey(provider, detectedKeys, undefined, adapter);
+    mode === "imported" && canUseImportedApiKey(provider, adapter, current?.apiKey)
+      ? current.apiKey
+      : current?.provider === provider
+        ? await stepApiKey(provider, detectedKeys, current.apiKey, adapter)
+        : await stepApiKey(provider, detectedKeys, undefined, adapter);
   return { provider, model, adapter, apiKey };
 }
 
@@ -273,6 +304,7 @@ export async function runSetupWizard(): Promise<number> {
 
   const importSelection = await stepSetupImport();
   const importedProviderPatch = providerConfigPatchFromImport(importSelection?.providerSettings);
+  let executionMode: "interactive" | "imported" = importedProviderPatch?.provider ? "imported" : "interactive";
 
   if (!importSelection) {
     const existingChoice = await stepExistingConfig();
@@ -311,7 +343,7 @@ export async function runSetupWizard(): Promise<number> {
           p.cancel("Setup cancelled.");
           return 0;
         }
-        execution = await stepExecutionConfig(execution);
+        execution = await stepExecutionConfig(execution, "interactive");
         if (!execution.adapter) return 1;
       }
 
@@ -352,7 +384,8 @@ export async function runSetupWizard(): Promise<number> {
     }
 
     if (section === "execution") {
-      Object.assign(answers, await stepExecutionConfig(importSelection || answers.adapter ? answers : undefined));
+      Object.assign(answers, await stepExecutionConfig(answers, executionMode));
+      executionMode = "interactive";
       if (!answers.adapter) return 1;
       const next = await stepSectionNavigation(
         "Provider settings complete.",

--- a/src/interface/cli/commands/setup/import/flow.ts
+++ b/src/interface/cli/commands/setup/import/flow.ts
@@ -60,11 +60,6 @@ function mergeProviderSettings(items: SetupImportItem[]): SetupImportProviderSet
   return items.find((item) => item.decision !== "skip" && item.providerSettings)?.providerSettings;
 }
 
-function itemOptionLabel(item: SetupImportItem): string {
-  const decision = item.decision === "copy_disabled" ? "copy disabled" : item.decision;
-  return `${item.sourceLabel}: ${item.kind} / ${item.label} (${decision})`;
-}
-
 function defaultProviderConfigFromImport(
   settings: SetupImportProviderSettings | undefined
 ): Partial<ProviderConfig> | undefined {
@@ -90,77 +85,39 @@ export async function stepSetupImport(): Promise<SetupImportSelection | undefine
   const detectedSources = detectSetupImportSources();
   if (detectedSources.length === 0) return undefined;
 
-  p.note(sourceSummary(detectedSources), "Existing agent configs found");
-  const wantsImport = guardCancel(
-    await p.confirm({
-      message: "Import settings from Hermes Agent / OpenClaw into PulSeed?",
-      initialValue: true,
-    })
-  );
-  if (!wantsImport) return undefined;
+  const choiceSources = [...detectedSources].sort((a, b) => {
+    const order: Record<SetupImportSource["id"], number> = { openclaw: 0, hermes: 1 };
+    return order[a.id] - order[b.id];
+  });
 
-  let sources = detectedSources;
-  if (detectedSources.length > 1) {
-    const sourceChoice = guardCancel(
-      await p.select({
-        message: "Which existing agent should PulSeed import from?",
-        options: detectedSources.map((source) => ({
+  p.note(sourceSummary(detectedSources), "Existing agent configs found");
+  const sourceChoice = guardCancel(
+    await p.select({
+      message: "Found existing settings!",
+      options: [
+        ...choiceSources.map((source) => ({
           value: source.id,
-          label: source.label,
+          label: source.id === "hermes"
+            ? "Migrate Hermes Agent settings"
+            : "Migrate OpenClaw settings",
           hint: source.rootDir,
         })),
-        initialValue: detectedSources.find((source) => source.id === "hermes")?.id ?? detectedSources[0]?.id,
-      })
-    );
-    sources = detectedSources.filter((source) => source.id === sourceChoice);
-  }
-
-
-  p.note(preview(sources), "Import preview");
-  const mode = guardCancel(
-    await p.select({
-      message: "How should PulSeed import these settings?",
-      options: [
-        {
-          value: "recommended" as const,
-          label: "Import recommended items",
-          hint: "provider and skills import; MCP/plugins are copied disabled",
-        },
-        {
-          value: "choose" as const,
-          label: "Choose items",
-        },
         {
           value: "skip" as const,
-          label: "Skip import",
+          label: "Do not migrate",
         },
       ],
-      initialValue: "recommended" as const,
+      initialValue: choiceSources[0]?.id,
     })
   );
+  if (sourceChoice === "skip") return undefined;
 
-  if (mode === "skip") return undefined;
+  const sources = detectedSources.filter((source) => source.id === sourceChoice);
+  if (sources.length === 0) return undefined;
 
   const allItems = sources.flatMap((source) => source.items);
   let items = allItems;
-  if (mode === "choose") {
-    const selectedIds = new Set(
-      guardCancel(
-        await p.multiselect({
-          message: "Select items to import:",
-          options: allItems.map((item) => ({
-            value: item.id,
-            label: itemOptionLabel(item),
-            hint: item.reason,
-          })),
-          initialValues: allItems.map((item) => item.id),
-        })
-      )
-    );
-    items = allItems.map((item) =>
-      selectedIds.has(item.id) ? item : { ...item, decision: "skip" as const }
-    );
-  }
+  p.note(preview(sources), "Import preview");
 
   const selectedItems = items.filter((item) => item.decision !== "skip");
   const providerItems = selectedItems.filter((item) => item.providerSettings);

--- a/src/interface/cli/commands/setup/steps-adapter.ts
+++ b/src/interface/cli/commands/setup/steps-adapter.ts
@@ -42,7 +42,6 @@ export async function stepAdapter(
     value: adapter,
     label: ADAPTER_LABELS[adapter] ?? adapter,
     hint: [
-      adapter === recommendedAdapter ? "recommended" : undefined,
       adapter === initialAdapter ? "current" : undefined,
       ADAPTER_HINTS[adapter],
     ].filter(Boolean).join(", ") || undefined,

--- a/src/interface/cli/commands/setup/steps-provider.ts
+++ b/src/interface/cli/commands/setup/steps-provider.ts
@@ -7,8 +7,8 @@ import {
   PROVIDERS,
   PROVIDER_LABELS,
   ENV_KEY_NAMES,
-  RECOMMENDED_MODELS,
   detectApiKeys,
+  getModelLabel,
   getModelsForProvider,
 } from "../setup-shared.js";
 import type { Provider } from "../setup-shared.js";
@@ -67,26 +67,26 @@ export async function stepProvider(initialProvider?: Provider): Promise<Provider
 
 export async function stepModel(provider: Provider, initialModel?: string): Promise<string> {
   const models = getModelsForProvider(provider);
-  const recommended = RECOMMENDED_MODELS[provider];
 
   const options = models.map((model) => ({
     value: model,
-    label: model,
-    hint: [
-      model === recommended ? "recommended" : undefined,
-      model === initialModel ? "current" : undefined,
-    ].filter(Boolean).join(", ") || undefined,
+    label: getModelLabel(model),
+    hint: model === initialModel ? "current" : undefined,
   }));
-  options.push({
-    value: "__custom__",
-    label: "Custom model name",
-    hint: initialModel && !models.includes(initialModel) ? `current: ${initialModel}` : undefined,
-  });
+  if (provider !== "openai") {
+    options.push({
+      value: "__custom__",
+      label: "Custom model name",
+      hint: initialModel && !models.includes(initialModel) ? `current: ${initialModel}` : undefined,
+    });
+  }
 
   const initialValue = initialModel
     ? models.includes(initialModel)
       ? initialModel
-      : "__custom__"
+      : provider !== "openai"
+        ? "__custom__"
+        : undefined
     : undefined;
 
   const choice = guardCancel(
@@ -179,7 +179,7 @@ export async function stepApiKey(
           {
             value: "login" as const,
             label: "Login with OAuth (opens browser via Codex CLI)",
-            hint: "recommended for OpenAI Codex CLI adapter",
+            hint: "uses Codex CLI OAuth",
           },
           {
             value: "skip" as const,

--- a/src/orchestrator/execution/task/task-prompt-builder.ts
+++ b/src/orchestrator/execution/task/task-prompt-builder.ts
@@ -256,9 +256,9 @@ Gap Analysis:
 - work_description: issue title (line 1) + issue body
 - Generate specific, actionable issues only\n`;
   } else if (adapterType === "openai_codex_cli" || adapterType === "claude_code_cli") {
-    adapterSection = `\nExecution context: CLI code agent in sandbox.
+    adapterSection = `\nExecution context: CLI code agent.
 You MUST produce implementation tasks that modify or create files.
-The executing agent will run in a code sandbox with full file access.
+The executing agent's filesystem and network boundary depends on the configured terminal backend.
 Tasks should involve writing code, fixing bugs, adding tests, or editing configuration — NOT analysis or planning.
 For operational KPI dimensions such as reliability, recovery, latency, uptime, or daemon stability, do not generate a test-only/regression-only task unless the goal explicitly asks for tests; prefer the smallest runtime/config/code change that directly moves the KPI, with tests only as supporting validation.
 Constraints:

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,5 +3,12 @@
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["node_modules", "dist", "tests", "src/**/__tests__/**"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests",
+    "src/**/__tests__/**",
+    "src/adapters/agents/openclaw-acp.ts",
+    "src/adapters/datasources/openclaw-datasource.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- replace the setup import flow with a single English source-choice prompt for OpenClaw, Hermes Agent, or no migration
- seed imported provider/model/adapter/API key values without re-asking, and update the OpenAI model picker to the fixed model list
- add flat-square README badges for publish status, npm downloads, Node.js support, and the security policy
- align sandbox/security docs with current worktree and Docker terminal-backend behavior
- harden release verification so local releases and publish CI run docs, typecheck, boundary lint, full tests, production audit, and npm pack dry-run

## Tests
- npm run check:docs
- npm pack --dry-run --json
- npm run verify:release (passed locally before final packaging-script recheck: 490 passed / 5 skipped, 7660 passed / 7 skipped; audit reported only moderate vulnerabilities under audit-level high)