### PR TITLE
Improve imported setup defaults and auth detection

### DIFF
--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -586,6 +586,7 @@ describe("setup notification step", () => {
     const stepModelMock = vi.fn(async (_provider: string, initial?: string) => initial ?? "gpt-5.4-mini");
     const stepApiKeyMock = vi.fn(async (_provider: string, _detected: Record<string, boolean>, initial?: string) => initial ?? "sk-test");
     const stepAdapterMock = vi.fn(async (_model: string, _provider: string, initial?: string) => initial ?? "agent_loop");
+    const stepRootPresetMock = vi.fn(async () => "default");
     const saveProviderConfigMock = vi.fn(async () => {});
     const applySetupImportSelectionMock = vi.fn(async () => ({
       created_at: "2026-04-13T00:00:00.000Z",
@@ -639,7 +640,7 @@ describe("setup notification step", () => {
       stepSeedyName: stepSeedyNameMock,
     }));
     vi.doMock("../commands/setup/steps-provider.js", () => ({
-      stepRootPreset: vi.fn(async () => "default"),
+      stepRootPreset: stepRootPresetMock,
       stepProvider: stepProviderMock,
       stepModel: stepModelMock,
       stepApiKey: stepApiKeyMock,
@@ -691,6 +692,7 @@ describe("setup notification step", () => {
     expect(code).toBe(0);
     expect(stepExistingConfigMock).not.toHaveBeenCalled();
     expect(stepSeedyNameMock).toHaveBeenCalledTimes(1);
+    expect(stepRootPresetMock).not.toHaveBeenCalled();
     expect(stepProviderMock).not.toHaveBeenCalled();
     expect(stepModelMock).not.toHaveBeenCalled();
     expect(stepAdapterMock).not.toHaveBeenCalled();

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -644,6 +644,7 @@ describe("setup notification step", () => {
       stepProvider: stepProviderMock,
       stepModel: stepModelMock,
       stepApiKey: stepApiKeyMock,
+      runCodexOAuthLogin: vi.fn(),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
       stepAdapter: stepAdapterMock,
@@ -714,6 +715,246 @@ describe("setup notification step", () => {
     );
     expect((saveProviderConfigMock.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty("api_key");
     expect(applySetupImportSelectionMock).toHaveBeenCalledWith("/tmp/pulseed-test", importSelection);
+  });
+
+  it("skips execution prompts for imported Codex OAuth setups when a usable login already exists", async () => {
+    const stepExistingConfigMock = vi.fn(async () => "keep");
+    const stepSeedyNameMock = vi.fn(async () => "Imported Seedy");
+    const stepProviderMock = vi.fn(async (initial?: string) => initial ?? "openai");
+    const stepModelMock = vi.fn(async (_provider: string, initial?: string) => initial ?? "gpt-5.4");
+    const stepApiKeyMock = vi.fn(async (_provider: string, _detected: Record<string, boolean>, initial?: string) => initial ?? "sk-test");
+    const stepAdapterMock = vi.fn(async (_model: string, _provider: string, initial?: string) => initial ?? "openai_codex_cli");
+    const stepRootPresetMock = vi.fn(async () => "default");
+    const saveProviderConfigMock = vi.fn(async () => {});
+    const readCodexOAuthTokenMock = vi.fn(async () => "eyJ.has.usable.oauth");
+    const applySetupImportSelectionMock = vi.fn(async () => ({
+      created_at: "2026-04-13T00:00:00.000Z",
+      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes" }],
+      items: [],
+    }));
+
+    const importSelection: SetupImportSelection = {
+      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes", items: [] }],
+      items: [
+        {
+          id: "hermes:provider:settings.json",
+          source: "hermes",
+          sourceLabel: "Hermes Agent",
+          kind: "provider",
+          label: "openai / gpt-5.4 / openai_codex_cli",
+          decision: "import",
+          reason: "provider defaults",
+          providerSettings: {
+            provider: "openai",
+            model: "gpt-5.4",
+            adapter: "openai_codex_cli",
+          },
+        },
+      ],
+      providerSettings: {
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "openai_codex_cli",
+      },
+    };
+
+    vi.doMock("../commands/setup/import/flow.js", () => ({
+      stepSetupImport: vi.fn(async () => importSelection),
+      providerConfigPatchFromImport: vi.fn((settings: NonNullable<SetupImportSelection["providerSettings"]>) => ({
+        provider: settings.provider,
+        model: settings.model,
+        adapter: settings.adapter,
+        api_key: settings.apiKey,
+      })),
+    }));
+    vi.doMock("../commands/setup/import/apply.js", () => ({
+      applySetupImportSelection: applySetupImportSelectionMock,
+    }));
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: stepExistingConfigMock,
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: stepSeedyNameMock,
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: stepRootPresetMock,
+      stepProvider: stepProviderMock,
+      stepModel: stepModelMock,
+      stepApiKey: stepApiKeyMock,
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: stepAdapterMock,
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: false, port: 41700 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      readCodexOAuthToken: readCodexOAuthTokenMock,
+      saveProviderConfig: saveProviderConfigMock,
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(readCodexOAuthTokenMock).toHaveBeenCalledTimes(1);
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("Provider settings were imported completely and applied as defaults."),
+      "Imported setup defaults"
+    );
+    expect(stepExistingConfigMock).not.toHaveBeenCalled();
+    expect(stepSeedyNameMock).toHaveBeenCalledTimes(1);
+    expect(stepRootPresetMock).not.toHaveBeenCalled();
+    expect(stepProviderMock).not.toHaveBeenCalled();
+    expect(stepModelMock).not.toHaveBeenCalled();
+    expect(stepAdapterMock).not.toHaveBeenCalled();
+    expect(stepApiKeyMock).not.toHaveBeenCalled();
+    expect(saveProviderConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "openai_codex_cli",
+      })
+    );
+    expect((saveProviderConfigMock.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty("api_key");
+    expect(applySetupImportSelectionMock).toHaveBeenCalledWith("/tmp/pulseed-test", importSelection);
+  });
+
+  it("falls back to execution auth handling when imported Codex OAuth setups have no usable login", async () => {
+    const stepProviderMock = vi.fn(async () => "openai");
+    const stepModelMock = vi.fn(async () => "gpt-5.4");
+    const stepApiKeyMock = vi.fn(async () => undefined);
+    const stepAdapterMock = vi.fn(async () => "openai_codex_cli");
+    const saveProviderConfigMock = vi.fn(async () => {});
+    const readCodexOAuthTokenMock = vi.fn(async () => undefined);
+
+    const importSelection: SetupImportSelection = {
+      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes", items: [] }],
+      items: [],
+      providerSettings: {
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "openai_codex_cli",
+      },
+    };
+
+    vi.doMock("../commands/setup/import/flow.js", () => ({
+      stepSetupImport: vi.fn(async () => importSelection),
+      providerConfigPatchFromImport: vi.fn((settings: NonNullable<SetupImportSelection["providerSettings"]>) => ({
+        provider: settings.provider,
+        model: settings.model,
+        adapter: settings.adapter,
+        api_key: settings.apiKey,
+      })),
+    }));
+    vi.doMock("../commands/setup/import/apply.js", () => ({
+      applySetupImportSelection: vi.fn(async () => ({
+        created_at: "2026-04-13T00:00:00.000Z",
+        sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes" }],
+        items: [],
+      })),
+    }));
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(),
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: vi.fn(async () => "Seedy"),
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: stepProviderMock,
+      stepModel: stepModelMock,
+      stepApiKey: stepApiKeyMock,
+      runCodexOAuthLogin: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: stepAdapterMock,
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: false, port: 41700 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      readCodexOAuthToken: readCodexOAuthTokenMock,
+      saveProviderConfig: saveProviderConfigMock,
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(readCodexOAuthTokenMock).toHaveBeenCalledTimes(1);
+    expect(stepProviderMock).not.toHaveBeenCalled();
+    expect(stepModelMock).not.toHaveBeenCalled();
+    expect(stepAdapterMock).not.toHaveBeenCalled();
+    expect(stepApiKeyMock).toHaveBeenCalledTimes(1);
+    expect(saveProviderConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "openai_codex_cli",
+      })
+    );
   });
 
   it("explains missing imported OpenAI API key and can switch to Codex CLI", async () => {

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -690,6 +690,11 @@ describe("setup notification step", () => {
     const code = await runSetupWizard();
 
     expect(code).toBe(0);
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("API Key:   found in imported settings"),
+      "Imported setup defaults"
+    );
+    expect(logInfoMock).toHaveBeenCalledWith("Provider settings were imported, so provider questions are skipped.");
     expect(stepExistingConfigMock).not.toHaveBeenCalled();
     expect(stepSeedyNameMock).toHaveBeenCalledTimes(1);
     expect(stepRootPresetMock).not.toHaveBeenCalled();
@@ -706,6 +711,232 @@ describe("setup notification step", () => {
     );
     expect((saveProviderConfigMock.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty("api_key");
     expect(applySetupImportSelectionMock).toHaveBeenCalledWith("/tmp/pulseed-test", importSelection);
+  });
+
+  it("explains missing imported OpenAI API key and can switch to Codex CLI", async () => {
+    const stepProviderMock = vi.fn(async () => "openai");
+    const stepModelMock = vi.fn(async () => "gpt-5.4");
+    const stepApiKeyMock = vi.fn(async () => "sk-test");
+    const stepAdapterMock = vi.fn(async () => "agent_loop");
+    const saveProviderConfigMock = vi.fn(async () => {});
+
+    const importSelection: SetupImportSelection = {
+      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes", items: [] }],
+      items: [],
+      providerSettings: {
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "agent_loop",
+      },
+    };
+
+    vi.doMock("../commands/setup/import/flow.js", () => ({
+      stepSetupImport: vi.fn(async () => importSelection),
+      providerConfigPatchFromImport: vi.fn((settings: NonNullable<SetupImportSelection["providerSettings"]>) => ({
+        provider: settings.provider,
+        model: settings.model,
+        adapter: settings.adapter,
+        api_key: settings.apiKey,
+      })),
+    }));
+    vi.doMock("../commands/setup/import/apply.js", () => ({
+      applySetupImportSelection: vi.fn(async () => ({
+        created_at: "2026-04-13T00:00:00.000Z",
+        sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes" }],
+        items: [],
+      })),
+    }));
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(),
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: vi.fn(async () => "Seedy"),
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: stepProviderMock,
+      stepModel: stepModelMock,
+      stepApiKey: stepApiKeyMock,
+      runCodexOAuthLogin: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: stepAdapterMock,
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: false, port: 41700 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      saveProviderConfig: saveProviderConfigMock,
+      validateProviderConfig: vi.fn((config: { api_key?: string; adapter: string }) => ({
+        valid: config.adapter === "openai_codex_cli" || Boolean(config.api_key),
+        errors: config.adapter === "openai_codex_cli" || config.api_key ? [] : ["API key required"],
+      })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    delete process.env["OPENAI_API_KEY"];
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("skip")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("OpenAI API key was not found in the imported settings."),
+      "OpenAI authentication needed"
+    );
+    expect(stepProviderMock).not.toHaveBeenCalled();
+    expect(stepModelMock).not.toHaveBeenCalled();
+    expect(stepAdapterMock).not.toHaveBeenCalled();
+    expect(stepApiKeyMock).not.toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "Skipping OpenAI API key. PulSeed will use OpenAI Codex CLI; run `codex login` before using it."
+    );
+    expect(saveProviderConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "openai_codex_cli",
+      })
+    );
+  });
+
+  it("does not treat imported Codex OAuth tokens as complete OpenAI API keys", async () => {
+    const stepApiKeyMock = vi.fn(async () => "sk-test");
+    const runCodexOAuthLoginMock = vi.fn(async () => "eyJ.new.token");
+    const saveProviderConfigMock = vi.fn(async () => {});
+
+    const importSelection: SetupImportSelection = {
+      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes", items: [] }],
+      items: [],
+      providerSettings: {
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "agent_loop",
+        apiKey: "eyJ.imported.oauth",
+      },
+    };
+
+    vi.doMock("../commands/setup/import/flow.js", () => ({
+      stepSetupImport: vi.fn(async () => importSelection),
+      providerConfigPatchFromImport: vi.fn((settings: NonNullable<SetupImportSelection["providerSettings"]>) => ({
+        provider: settings.provider,
+        model: settings.model,
+        adapter: settings.adapter,
+        api_key: settings.apiKey,
+      })),
+    }));
+    vi.doMock("../commands/setup/import/apply.js", () => ({
+      applySetupImportSelection: vi.fn(async () => ({
+        created_at: "2026-04-13T00:00:00.000Z",
+        sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes" }],
+        items: [],
+      })),
+    }));
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(),
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: vi.fn(async () => "Seedy"),
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: vi.fn(),
+      stepModel: vi.fn(),
+      stepApiKey: stepApiKeyMock,
+      runCodexOAuthLogin: runCodexOAuthLoginMock,
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: false, port: 41700 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      saveProviderConfig: saveProviderConfigMock,
+      validateProviderConfig: vi.fn((config: { api_key?: string; adapter: string }) => ({
+        valid: config.adapter === "openai_codex_cli" || Boolean(config.api_key),
+        errors: config.adapter === "openai_codex_cli" || config.api_key ? [] : ["API key required"],
+      })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    delete process.env["OPENAI_API_KEY"];
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("oauth")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("looks like a Codex OAuth token"),
+      "OpenAI authentication needed"
+    );
+    expect(runCodexOAuthLoginMock).toHaveBeenCalledTimes(1);
+    expect(stepApiKeyMock).not.toHaveBeenCalled();
+    expect(saveProviderConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "openai_codex_cli",
+      })
+    );
   });
 
   it("warns when notification config write fails", async () => {

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -694,7 +694,10 @@ describe("setup notification step", () => {
       expect.stringContaining("API Key:   found in imported settings"),
       "Imported setup defaults"
     );
-    expect(logInfoMock).toHaveBeenCalledWith("Provider settings were imported, so provider questions are skipped.");
+    expect(noteMock).toHaveBeenCalledWith(
+      expect.stringContaining("Provider settings were imported completely and applied as defaults."),
+      "Imported setup defaults"
+    );
     expect(stepExistingConfigMock).not.toHaveBeenCalled();
     expect(stepSeedyNameMock).toHaveBeenCalledTimes(1);
     expect(stepRootPresetMock).not.toHaveBeenCalled();

--- a/src/interface/cli/__tests__/setup-import.test.ts
+++ b/src/interface/cli/__tests__/setup-import.test.ts
@@ -161,7 +161,7 @@ describe("setup import discovery", () => {
     });
   });
 
-  it("imports provider API keys from workspace env files", async () => {
+  it("imports provider API keys from the workspace env file selected by the config", async () => {
     const hermesHome = path.join(tmpDir, "hermes");
     process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
 
@@ -175,6 +175,7 @@ describe("setup import discovery", () => {
       provider: "openai",
       model: "gpt-5.4",
       adapter: "agent_loop",
+      workspace: "workspace-main",
       openai: {
         apiKey: "OPENAI_API_KEY",
       },
@@ -191,6 +192,46 @@ describe("setup import discovery", () => {
       adapter: "agent_loop",
       apiKey: "sk-workspace-openai",
     });
+  });
+
+  it("does not pull an api key from an unrelated Hermes workspace", async () => {
+    const hermesHome = path.join(tmpDir, "hermes");
+    process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
+
+    await fsp.mkdir(path.join(hermesHome, "workspace-main"), { recursive: true });
+    await fsp.mkdir(path.join(hermesHome, "workspace-secondary"), { recursive: true });
+    await fsp.writeFile(
+      path.join(hermesHome, "workspace-main", ".env"),
+      "OPENAI_API_KEY=sk-workspace-main\n",
+      "utf-8"
+    );
+    await fsp.writeFile(
+      path.join(hermesHome, "workspace-secondary", ".env"),
+      "OPENAI_API_KEY=sk-workspace-secondary\n",
+      "utf-8"
+    );
+    await writeJson(path.join(hermesHome, "settings.json"), {
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "agent_loop",
+      workspace: "workspace-main",
+      openai: {
+        apiKey: "OPENAI_API_KEY",
+      },
+    });
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const hermes = sources.find((source) => source.id === "hermes");
+    const provider = hermes?.items.find((item) => item.kind === "provider");
+
+    expect(provider?.providerSettings).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "agent_loop",
+      apiKey: "sk-workspace-main",
+    });
+    expect(provider?.providerSettings?.apiKey).not.toBe("sk-workspace-secondary");
   });
 });
 

--- a/src/interface/cli/__tests__/setup-import.test.ts
+++ b/src/interface/cli/__tests__/setup-import.test.ts
@@ -160,6 +160,38 @@ describe("setup import discovery", () => {
       enabled: false,
     });
   });
+
+  it("imports provider API keys from workspace env files", async () => {
+    const hermesHome = path.join(tmpDir, "hermes");
+    process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
+
+    await fsp.mkdir(path.join(hermesHome, "workspace-main"), { recursive: true });
+    await fsp.writeFile(
+      path.join(hermesHome, "workspace-main", ".env"),
+      "OPENAI_API_KEY=sk-workspace-openai\n",
+      "utf-8"
+    );
+    await writeJson(path.join(hermesHome, "settings.json"), {
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "agent_loop",
+      openai: {
+        apiKey: "OPENAI_API_KEY",
+      },
+    });
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const hermes = sources.find((source) => source.id === "hermes");
+    const provider = hermes?.items.find((item) => item.kind === "provider");
+
+    expect(provider?.providerSettings).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "agent_loop",
+      apiKey: "sk-workspace-openai",
+    });
+  });
 });
 
 describe("setup import apply", () => {

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -39,6 +39,9 @@ type IdentityAnswers = Pick<SetupAnswers, "userName" | "agentName" | "rootPreset
 type ExecutionAnswers = Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">;
 type RuntimeAnswers = Pick<SetupAnswers, "startDaemon" | "daemonPort" | "notificationConfig">;
 type FullSetupSection = "identity" | "execution" | "runtime" | "review";
+type IdentityConfigOptions = {
+  skipRootPreset?: boolean;
+};
 
 function formatSummary(answers: SetupAnswers): string {
   const notificationChannels = answers.notificationConfig
@@ -149,11 +152,16 @@ async function stepExecutionConfig(
   return { provider, model, adapter, apiKey };
 }
 
-async function stepIdentityConfig(current?: Partial<IdentityAnswers>): Promise<IdentityAnswers> {
+async function stepIdentityConfig(
+  current?: Partial<IdentityAnswers>,
+  options: IdentityConfigOptions = {}
+): Promise<IdentityAnswers> {
   return {
     userName: await stepUserName(current?.userName),
     agentName: await stepSeedyName(current?.agentName),
-    rootPreset: await stepRootPreset(current?.rootPreset),
+    rootPreset: options.skipRootPreset
+      ? current?.rootPreset ?? "default"
+      : await stepRootPreset(current?.rootPreset),
   };
 }
 
@@ -371,7 +379,12 @@ export async function runSetupWizard(): Promise<number> {
 
   while (!finalAnswers) {
     if (section === "identity") {
-      Object.assign(answers, await stepIdentityConfig(answers.userName ? answers : undefined));
+      Object.assign(
+        answers,
+        await stepIdentityConfig(answers.userName ? answers : undefined, {
+          skipRootPreset: Boolean(importSelection),
+        })
+      );
       const next = await stepSectionNavigation("Identity settings complete.");
       if (next === "cancel") {
         p.cancel("Setup cancelled.");

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../base/llm/provider-config.js";
 import type { ProviderConfig } from "../../../base/llm/provider-config.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
+import { readCodexOAuthToken } from "../../../base/llm/provider-config.js";
 import { isDaemonRunning } from "../../../runtime/daemon/client.js";
 import { ROOT_PRESETS } from "./presets/root-presets.js";
 import { MODEL_REGISTRY, detectApiKeys, getAdaptersForModel, maskKey } from "./setup-shared.js";
@@ -148,18 +149,16 @@ function canUseImportedApiKey(provider: Provider, adapter: string, apiKey: strin
   return !(provider === "openai" && adapter !== "openai_codex_cli" && isLikelyCodexOAuthToken(apiKey));
 }
 
-function importedExecutionIsComplete(
+async function importedExecutionIsComplete(
   execution: Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">,
   base?: Partial<ProviderConfig>
-): boolean {
+): Promise<boolean> {
   if (!execution.provider || !execution.model || !execution.adapter) return false;
   if (!canUseImportedModel(execution.provider, execution.model)) return false;
   if (!getAdaptersForModel(execution.model, execution.provider).includes(execution.adapter)) return false;
-  if (
-    execution.provider === "openai" &&
-    execution.adapter === "openai_codex_cli"
-  ) {
-    return false;
+  if (execution.provider === "openai" && execution.adapter === "openai_codex_cli") {
+    const token = await readCodexOAuthToken();
+    if (!token) return false;
   }
   if (execution.provider === "openai" && execution.adapter !== "openai_codex_cli") {
     if (!execution.apiKey) return false;
@@ -521,8 +520,8 @@ export async function runSetupWizard(): Promise<number> {
     daemonPort: 0,
     notificationConfig: null,
   };
-  const skipImportedExecution = Boolean(importSelection) &&
-    importedExecutionIsComplete(answers, importedProviderPatch);
+  const skipImportedExecution =
+    Boolean(importSelection) && (await importedExecutionIsComplete(answers, importedProviderPatch));
   let section: FullSetupSection = "identity";
   let finalAnswers: SetupAnswers | undefined;
 

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -14,13 +14,14 @@ import { ROOT_PRESETS } from "./presets/root-presets.js";
 import { MODEL_REGISTRY, detectApiKeys, getAdaptersForModel, maskKey } from "./setup-shared.js";
 import type { Provider } from "./setup-shared.js";
 import { getBanner, stepExistingConfig, stepUserName, stepSeedyName } from "./setup/steps-identity.js";
-import { stepRootPreset, stepProvider, stepModel, stepApiKey } from "./setup/steps-provider.js";
+import { stepRootPreset, stepProvider, stepModel, stepApiKey, runCodexOAuthLogin } from "./setup/steps-provider.js";
 import { stepAdapter } from "./setup/steps-adapter.js";
 import { stepNotification } from "./setup/steps-notification.js";
 import { stepDaemon, ensurePulseedDir, writeSeedMd, writeRootMd, writeUserMd } from "./setup/steps-runtime.js";
 import { guardCancel } from "./setup/utils.js";
 import { applySetupImportSelection } from "./setup/import/apply.js";
 import { providerConfigPatchFromImport, stepSetupImport } from "./setup/import/flow.js";
+import type { SetupImportSelection } from "./setup/import/types.js";
 
 type SetupAnswers = {
   userName: string;
@@ -74,6 +75,37 @@ function formatExecutionSummary(
   ].join("\n");
 }
 
+function formatImportSetupSummary(
+  selection: SetupImportSelection,
+  providerPatch: Partial<ProviderConfig> | undefined
+): string {
+  const sourceNames = selection.sources.map((source) => source.label).join(", ");
+  if (!providerPatch?.provider) {
+    return [
+      `Source:    ${sourceNames}`,
+      "Provider:  not found",
+      "Style:     Default",
+      "Next:      PulSeed will ask for provider settings.",
+    ].join("\n");
+  }
+
+  const apiKeyStatus =
+    providerPatch.api_key
+      ? "found in imported settings"
+      : providerPatch.provider === "ollama" || providerPatch.adapter === "openai_codex_cli"
+        ? "not required for this adapter"
+        : "not found";
+
+  return [
+    `Source:    ${sourceNames}`,
+    `Provider:  ${providerPatch.provider}`,
+    `Model:     ${providerPatch.model ?? "not found"}`,
+    `Adapter:   ${providerPatch.adapter ?? "not found"}`,
+    `API Key:   ${apiKeyStatus}`,
+    "Style:     Default",
+  ].join("\n");
+}
+
 function buildProviderConfig(
   execution: Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">,
   base?: Partial<ProviderConfig>
@@ -116,6 +148,101 @@ function canUseImportedApiKey(provider: Provider, adapter: string, apiKey: strin
   return !(provider === "openai" && adapter !== "openai_codex_cli" && isLikelyCodexOAuthToken(apiKey));
 }
 
+function importedExecutionIsComplete(
+  execution: Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">,
+  base?: Partial<ProviderConfig>
+): boolean {
+  if (!execution.provider || !execution.model || !execution.adapter) return false;
+  if (!canUseImportedModel(execution.provider, execution.model)) return false;
+  if (!getAdaptersForModel(execution.model, execution.provider).includes(execution.adapter)) return false;
+  if (
+    execution.provider === "openai" &&
+    execution.adapter === "openai_codex_cli"
+  ) {
+    return false;
+  }
+  if (execution.provider === "openai" && execution.adapter !== "openai_codex_cli") {
+    if (!execution.apiKey) return false;
+    if (!canUseImportedApiKey(execution.provider, execution.adapter, execution.apiKey)) return false;
+  }
+  return validateProviderConfig(buildProviderConfig(execution, base)).valid;
+}
+
+async function stepMissingOpenAiAuth(
+  model: string,
+  adapter: string,
+  adaptersForModel: string[],
+  importedApiKey: string | undefined
+): Promise<{ adapter: string; apiKey?: string }> {
+  const details = [
+    "OpenAI API key was not found in the imported settings.",
+    `${adapter} uses the OpenAI API directly, so PulSeed needs an API key unless you switch to Codex CLI OAuth.`,
+  ];
+  if (importedApiKey && isLikelyCodexOAuthToken(importedApiKey)) {
+    details.push("The imported auth value looks like a Codex OAuth token, not an OpenAI API key.");
+  }
+  p.note(details.join("\n"), "OpenAI authentication needed");
+
+  const canUseCodexCli = adaptersForModel.includes("openai_codex_cli");
+  const authChoice = guardCancel(
+    await p.select({
+      message: "How should PulSeed handle OpenAI authentication?",
+      options: [
+        { value: "enter" as const, label: "Enter OpenAI API key" },
+        ...(canUseCodexCli
+          ? [
+              {
+                value: "oauth" as const,
+                label: "Use Codex CLI OAuth instead",
+                hint: `switch adapter for ${model} to OpenAI Codex CLI`,
+              },
+              {
+                value: "skip" as const,
+                label: "Skip for now",
+                hint: "use OpenAI Codex CLI and run codex login later",
+              },
+            ]
+          : []),
+      ],
+      initialValue: "enter" as const,
+    })
+  );
+
+  if (authChoice === "oauth") {
+    const token = await runCodexOAuthLogin();
+    if (token) return { adapter: "openai_codex_cli" };
+
+    p.log.warn("Codex OAuth login did not produce a usable token.");
+    const fallback = guardCancel(
+      await p.select({
+        message: "Codex CLI authentication is not ready. How should setup continue?",
+        options: [
+          { value: "enter" as const, label: "Enter OpenAI API key instead" },
+          {
+            value: "skip" as const,
+            label: "Skip for now",
+            hint: "use OpenAI Codex CLI and run codex login later",
+          },
+        ],
+        initialValue: "enter" as const,
+      })
+    );
+    if (fallback === "skip") {
+      p.log.warn("Skipping Codex OAuth login. Run `codex login` before using OpenAI Codex CLI.");
+      return { adapter: "openai_codex_cli" };
+    }
+    const apiKey = await stepApiKey("openai", detectApiKeys(), undefined, adapter);
+    return { adapter, apiKey };
+  }
+  if (authChoice === "skip") {
+    p.log.warn("Skipping OpenAI API key. PulSeed will use OpenAI Codex CLI; run `codex login` before using it.");
+    return { adapter: "openai_codex_cli" };
+  }
+
+  const apiKey = await stepApiKey("openai", detectApiKeys(), undefined, adapter);
+  return { adapter, apiKey };
+}
+
 async function stepExecutionConfig(
   current?: ExecutionAnswers,
   mode: "interactive" | "imported" = "interactive"
@@ -143,8 +270,25 @@ async function stepExecutionConfig(
   if (!adapter) return { provider, model, adapter, apiKey: current?.apiKey };
 
   const detectedKeys = detectApiKeys();
+  const openAiEnvKey = process.env["OPENAI_API_KEY"];
+  const hasUsableOpenAiEnvKey = Boolean(openAiEnvKey) && !isLikelyCodexOAuthToken(openAiEnvKey);
+  const validImportedApiKey =
+    mode === "imported" &&
+    adapter !== "openai_codex_cli" &&
+    canUseImportedApiKey(provider, adapter, current?.apiKey);
+  if (
+    mode === "imported" &&
+    provider === "openai" &&
+    adapter !== "openai_codex_cli" &&
+    !hasUsableOpenAiEnvKey &&
+    !validImportedApiKey
+  ) {
+    const auth = await stepMissingOpenAiAuth(model, adapter, adaptersForModel, current?.apiKey);
+    return { provider, model, adapter: auth.adapter, apiKey: auth.apiKey };
+  }
+
   const apiKey =
-    mode === "imported" && canUseImportedApiKey(provider, adapter, current?.apiKey)
+    validImportedApiKey
       ? current.apiKey
       : current?.provider === provider
         ? await stepApiKey(provider, detectedKeys, current.apiKey, adapter)
@@ -313,6 +457,9 @@ export async function runSetupWizard(): Promise<number> {
   const importSelection = await stepSetupImport();
   const importedProviderPatch = providerConfigPatchFromImport(importSelection?.providerSettings);
   let executionMode: "interactive" | "imported" = importedProviderPatch?.provider ? "imported" : "interactive";
+  if (importSelection) {
+    p.note(formatImportSetupSummary(importSelection, importedProviderPatch), "Imported setup defaults");
+  }
 
   if (!importSelection) {
     const existingChoice = await stepExistingConfig();
@@ -374,6 +521,8 @@ export async function runSetupWizard(): Promise<number> {
     daemonPort: 0,
     notificationConfig: null,
   };
+  const skipImportedExecution = Boolean(importSelection) &&
+    importedExecutionIsComplete(answers, importedProviderPatch);
   let section: FullSetupSection = "identity";
   let finalAnswers: SetupAnswers | undefined;
 
@@ -391,7 +540,13 @@ export async function runSetupWizard(): Promise<number> {
         return 0;
       }
       if (next === "continue") {
-        section = "execution";
+        if (skipImportedExecution) {
+          p.log.info("Provider settings were imported, so provider questions are skipped.");
+          executionMode = "interactive";
+          section = "runtime";
+        } else {
+          section = "execution";
+        }
       }
       continue;
     }

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -541,7 +541,7 @@ export async function runSetupWizard(): Promise<number> {
       }
       if (next === "continue") {
         if (skipImportedExecution) {
-          p.log.info("Provider settings were imported, so provider questions are skipped.");
+          p.note("Provider settings were imported completely and applied as defaults.", "Imported setup defaults");
           executionMode = "interactive";
           section = "runtime";
         } else {

--- a/src/interface/cli/commands/setup/import/discovery.ts
+++ b/src/interface/cli/commands/setup/import/discovery.ts
@@ -95,7 +95,14 @@ function sourceRoots(source: SetupImportSourceId): string[] {
 function providerItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
   const env = {
     ...readEnvFile(path.join(rootDir, ".env")),
+    ...readEnvFile(path.join(rootDir, ".env.local")),
     ...readEnvFile(path.join(rootDir, "config", ".env")),
+    ...readEnvFile(path.join(rootDir, "config", ".env.local")),
+    ...workspaceRoots(rootDir).reduce<Record<string, string>>((acc, workspaceRoot) => ({
+      ...acc,
+      ...readEnvFile(path.join(workspaceRoot, ".env")),
+      ...readEnvFile(path.join(workspaceRoot, ".env.local")),
+    }), {}),
   };
   return candidateFiles(rootDir, CONFIG_FILENAMES).flatMap((configPath) => {
     const settings = extractProviderSettings(readJson(configPath), source, { env });

--- a/src/interface/cli/commands/setup/import/discovery.ts
+++ b/src/interface/cli/commands/setup/import/discovery.ts
@@ -10,6 +10,7 @@ import {
   unique,
 } from "./fs-utils.js";
 import { extractMcpServers } from "./mcp.js";
+import { collectRecords, firstString, nestedRecord } from "./parse.js";
 import { buildProviderItem, extractProviderSettings } from "./provider.js";
 import { buildTelegramItem, extractTelegramSettings, telegramCredentialItems } from "./telegram.js";
 import type {
@@ -93,19 +94,39 @@ function sourceRoots(source: SetupImportSourceId): string[] {
 }
 
 function providerItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
-  const env = {
+  const baseEnv = {
     ...readEnvFile(path.join(rootDir, ".env")),
     ...readEnvFile(path.join(rootDir, ".env.local")),
     ...readEnvFile(path.join(rootDir, "config", ".env")),
     ...readEnvFile(path.join(rootDir, "config", ".env.local")),
-    ...workspaceRoots(rootDir).reduce<Record<string, string>>((acc, workspaceRoot) => ({
-      ...acc,
-      ...readEnvFile(path.join(workspaceRoot, ".env")),
-      ...readEnvFile(path.join(workspaceRoot, ".env.local")),
-    }), {}),
   };
   return candidateFiles(rootDir, CONFIG_FILENAMES).flatMap((configPath) => {
-    const settings = extractProviderSettings(readJson(configPath), source, { env });
+    const raw = readJson(configPath);
+    const records = collectRecords(raw);
+    const workspaceHint = records
+      .map((record) => {
+        const direct =
+          firstString([record], ["work_dir", "workDir", "workspacePath"]) ??
+          firstString([record], ["workspace"]);
+        if (direct) return direct;
+        const workspace = nestedRecord(record, "workspace");
+        if (!workspace) return undefined;
+        return firstString([workspace], ["path", "dir", "root", "work_dir", "workDir", "workspacePath", "name"]);
+      })
+      .find(Boolean);
+
+    const env = { ...baseEnv };
+    if (workspaceHint) {
+      const workspaceRoot = path.isAbsolute(workspaceHint)
+        ? workspaceHint
+        : path.join(rootDir, workspaceHint);
+      if (pathExists(workspaceRoot)) {
+        Object.assign(env, readEnvFile(path.join(workspaceRoot, ".env")));
+        Object.assign(env, readEnvFile(path.join(workspaceRoot, ".env.local")));
+      }
+    }
+
+    const settings = extractProviderSettings(raw, source, { env });
     return settings ? [buildProviderItem(source, configPath, settings)] : [];
   });
 }

--- a/src/interface/cli/commands/setup/import/provider.ts
+++ b/src/interface/cli/commands/setup/import/provider.ts
@@ -23,6 +23,17 @@ const PROVIDER_KEYS = [
 const MODEL_KEYS = ["model", "default_model", "defaultModel", "modelName"];
 const ADAPTER_KEYS = ["adapter", "default_adapter", "defaultAdapter", "backend", "terminalBackend"];
 const API_KEY_KEYS = ["api_key", "apiKey", "openai_api_key", "anthropic_api_key", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"];
+const SECTION_API_KEY_KEYS = [
+  ...API_KEY_KEYS,
+  "key",
+  "token",
+  "auth_token",
+  "authToken",
+  "access_token",
+  "accessToken",
+  "secret_key",
+  "secretKey",
+];
 const BASE_URL_KEYS = ["base_url", "baseUrl", "baseURL", "endpoint", "api_base"];
 const CLI_PATH_KEYS = ["codex_cli_path", "codexCliPath", "cli_path", "cliPath"];
 const PROVIDER_ENV_KEYS: Record<Provider, string[]> = {
@@ -116,9 +127,11 @@ function providerSection(
 
 function stringFromSecretRef(value: unknown, env: Record<string, string>): string | undefined {
   if (typeof value === "string" && value.trim()) {
-    const match = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/.exec(value.trim());
+    const trimmed = value.trim();
+    const match = /^\$\{([A-Za-z_][A-Za-z0-9_]*)\}$/.exec(trimmed);
     if (match) return env[match[1]!];
-    return value.trim();
+    if (/^[A-Z_][A-Z0-9_]*$/.test(trimmed)) return env[trimmed];
+    return trimmed;
   }
   if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
   const record = value as Record<string, unknown>;
@@ -164,7 +177,7 @@ function providerApiKey(
 ): string | undefined {
   if (!provider) return undefined;
   const section = providerSection(records, provider);
-  const sectionKey = section ? firstSecretString([section], API_KEY_KEYS, env) : undefined;
+  const sectionKey = section ? firstSecretString([section], SECTION_API_KEY_KEYS, env) : undefined;
   if (sectionKey) return sectionKey;
   for (const key of PROVIDER_ENV_KEYS[provider]) {
     if (env[key]) return env[key];

--- a/src/interface/cli/commands/setup/steps-provider.ts
+++ b/src/interface/cli/commands/setup/steps-provider.ts
@@ -191,8 +191,29 @@ export async function stepApiKey(
       })
     );
 
-    if (authChoice === "login") {
-      await runCodexOAuthLogin();
+    let nextAuthChoice = authChoice;
+    while (nextAuthChoice === "login") {
+      const token = await runCodexOAuthLogin();
+      if (token) return undefined;
+
+      p.log.warn("Codex OAuth login did not produce a usable token.");
+      nextAuthChoice = guardCancel(
+        await p.select({
+          message: "Codex CLI authentication is not ready. What should setup do?",
+          options: [
+            {
+              value: "login" as const,
+              label: "Try OAuth login again",
+            },
+            {
+              value: "skip" as const,
+              label: "Skip for now",
+              hint: "run `codex login` before using this adapter",
+            },
+          ],
+          initialValue: "login" as const,
+        })
+      );
     }
     return undefined;
   }


### PR DESCRIPTION
## Summary
- skip the communication-style/root preset prompt during imported setup and keep the default preset
- import provider API keys from root/config/workspace env files, including .env.local
- resolve provider-section env var name references such as apiKey: OPENAI_API_KEY without treating the env var name itself as the secret

## Tests
- npx vitest run src/interface/cli/__tests__/setup-import.test.ts src/interface/cli/__tests__/cli-setup-notification.test.ts
- npm run typecheck