### PR TITLE
[codex] Fix setup import parity with Hermes

### DIFF
--- a/src/base/llm/__tests__/provider-config.test.ts
+++ b/src/base/llm/__tests__/provider-config.test.ts
@@ -369,11 +369,25 @@ describe("loadProviderConfig", () => {
     expect(config.provider).toBe("anthropic");
   });
 
-  it("PULSEED_MODEL env var overrides file model", async () => {
+  it("PULSEED_MODEL env var is used when provider.json omits model", async () => {
     process.env["PULSEED_MODEL"] = "my-custom-model";
     process.env["OPENAI_API_KEY"] = "sk-test";
     const config = await loadProviderConfig();
     expect(config.model).toBe("my-custom-model");
+  });
+
+  it("keeps provider.json model authoritative over PULSEED_MODEL", async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "openai_codex_cli",
+    }));
+    process.env["PULSEED_MODEL"] = "gpt-4o-mini-tts";
+
+    const config = await loadProviderConfig();
+
+    expect(config.model).toBe("gpt-5.4");
   });
 
   it("auto-migrates legacy config format", async () => {
@@ -408,16 +422,20 @@ describe("loadProviderConfig", () => {
     expect(config.api_key).toBe("sk-test");
   });
 
-  it("auto-corrects gpt-4o-mini to gpt-5.4-mini when adapter is openai_codex_cli", async () => {
-    process.env["OPENAI_MODEL"] = "gpt-4o-mini";
-    process.env["OPENAI_API_KEY"] = "sk-test";
+  it("keeps explicit file models even when adapter compatibility is mismatched", async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      provider: "openai",
+      model: "gpt-4o-mini",
+      adapter: "openai_codex_cli",
+    }));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const config = await loadProviderConfig();
 
-    expect(config.model).toBe("gpt-5.4-mini");
+    expect(config.model).toBe("gpt-4o-mini");
     expect(config.adapter).toBe("openai_codex_cli");
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('not compatible with adapter "openai_codex_cli"'));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Keeping provider.json model"));
     warnSpy.mockRestore();
   });
 

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -302,29 +302,32 @@ function resolveAdapter(
   return fileAdapter ?? "openai_codex_cli";
 }
 
+type ModelSource = "file" | "env" | "default";
+
 function resolveModel(
   fileModel: string | undefined,
   provider: ProviderConfig["provider"]
-): string {
-  const envModel = process.env["PULSEED_MODEL"];
-  if (envModel) return envModel;
+): { model: string; source: ModelSource } {
+  if (fileModel) {
+    return { model: fileModel, source: "file" };
+  }
 
-  // provider.json explicit value takes priority over generic env vars
-  if (fileModel) return fileModel;
+  const envModel = process.env["PULSEED_MODEL"];
+  if (envModel) return { model: envModel, source: "env" };
 
   // Provider-specific env vars apply only as fallback when model is not set in provider.json
   if (provider === "openai") {
     const m = process.env["OPENAI_MODEL"];
-    if (m) return m;
+    if (m) return { model: m, source: "env" };
   } else if (provider === "anthropic") {
     const m = process.env["ANTHROPIC_MODEL"];
-    if (m) return m;
+    if (m) return { model: m, source: "env" };
   } else if (provider === "ollama") {
     const m = process.env["OLLAMA_MODEL"];
-    if (m) return m;
+    if (m) return { model: m, source: "env" };
   }
 
-  return defaultModelForProvider(provider);
+  return { model: defaultModelForProvider(provider), source: "default" };
 }
 
 function resolveApiKey(
@@ -388,7 +391,7 @@ async function readProviderEnvFile(): Promise<Record<string, string>> {
  * Load provider configuration.
  *
  * Priority (highest to lowest):
- *   1. Environment variables (PULSEED_PROVIDER, PULSEED_ADAPTER, PULSEED_MODEL, etc.)
+ *   1. Environment variables for provider/adapter selection
  *   2. ~/.pulseed/provider.json
  *   3. Defaults (openai + gpt-5.4-mini + openai_codex_cli)
  *
@@ -419,17 +422,25 @@ export async function loadProviderConfig(): Promise<ProviderConfig> {
   }
 
   const provider = resolveProvider(fileConfig.provider);
-  let model = resolveModel(fileConfig.model, provider);
+  const resolvedModel = resolveModel(fileConfig.model, provider);
+  let model = resolvedModel.model;
   const adapter = resolveAdapter(fileConfig.adapter);
 
-  // Auto-correct model-adapter incompatibility (e.g. OPENAI_MODEL=gpt-4o-mini with openai_codex_cli)
+  // Only env/default-selected models are auto-corrected. Explicit provider.json
+  // models are preserved and surfaced as warnings instead of being replaced.
   const registryEntry = MODEL_REGISTRY[model];
   if (registryEntry && !registryEntry.adapters.includes(adapter)) {
-    const fallback = defaultModelForProvider(provider);
-    console.warn(
-      `[provider-config] Model "${model}" is not compatible with adapter "${adapter}". Falling back to "${fallback}".`
-    );
-    model = fallback;
+    if (resolvedModel.source === "file") {
+      console.warn(
+        `[provider-config] Model "${model}" is not compatible with adapter "${adapter}". Keeping provider.json model and relying on validation to surface the mismatch.`
+      );
+    } else {
+      const fallback = defaultModelForProvider(provider);
+      console.warn(
+        `[provider-config] Model "${model}" is not compatible with adapter "${adapter}". Falling back to "${fallback}".`
+      );
+      model = fallback;
+    }
   }
 
   let api_key = resolveApiKey(fileConfig.api_key, provider, adapter, envFile);

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -13,6 +13,10 @@ const logWarnMock = vi.fn();
 const logInfoMock = vi.fn();
 const logErrorMock = vi.fn();
 const logSuccessMock = vi.fn();
+const updateGlobalConfigMock = vi.fn(async () => ({
+  daemon_mode: true,
+  no_flicker: false,
+}));
 
 vi.mock("@clack/prompts", () => ({
   confirm: confirmMock,
@@ -31,6 +35,10 @@ vi.mock("@clack/prompts", () => ({
   isCancel: vi.fn(() => false),
 }));
 
+vi.mock("../../../base/config/global-config.js", () => ({
+  updateGlobalConfig: updateGlobalConfigMock,
+}));
+
 describe("setup notification step", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -45,6 +53,7 @@ describe("setup notification step", () => {
     logInfoMock.mockReset();
     logErrorMock.mockReset();
     logSuccessMock.mockReset();
+    updateGlobalConfigMock.mockReset();
   });
 
   afterEach(() => {
@@ -55,6 +64,7 @@ describe("setup notification step", () => {
     vi.doUnmock("../commands/setup/steps-runtime.js");
     vi.doUnmock("../commands/setup/steps-notification.js");
     vi.doUnmock("../../../base/llm/provider-config.js");
+    vi.doUnmock("../../../base/config/global-config.js");
     vi.doUnmock("../../../base/config/identity-loader.js");
     vi.doUnmock("../../../runtime/daemon/client.js");
     vi.doUnmock("node:child_process");
@@ -493,6 +503,7 @@ describe("setup notification step", () => {
     });
     const spawnMock = vi.fn(() => spawnChild);
     const isDaemonRunningMock = vi.fn(async () => ({ running: true, port: 41701 }));
+    const updateGlobalConfigMock = vi.fn(async () => ({ daemon_mode: true, no_flicker: false }));
 
     vi.doMock("node:child_process", () => ({
       spawn: spawnMock,
@@ -536,6 +547,9 @@ describe("setup notification step", () => {
       saveProviderConfig: vi.fn(async () => {}),
       validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
     }));
+    vi.doMock("../../../base/config/global-config.js", () => ({
+      updateGlobalConfig: updateGlobalConfigMock,
+    }));
     vi.doMock("../../../base/config/identity-loader.js", () => ({
       clearIdentityCache: vi.fn(),
     }));
@@ -563,6 +577,7 @@ describe("setup notification step", () => {
       expect.stringContaining("\"event_server_port\": 41701"),
       "utf-8"
     );
+    expect(updateGlobalConfigMock).toHaveBeenCalledWith({ daemon_mode: true });
     expect(spawnMock).toHaveBeenCalledWith(
       process.execPath,
       [expect.any(String), "daemon", "start", "--detach"],
@@ -576,6 +591,92 @@ describe("setup notification step", () => {
     expect(isDaemonRunningMock).toHaveBeenCalledWith("/tmp/pulseed-test");
     expect(logSuccessMock).toHaveBeenCalledWith(
       "Daemon and gateway started (PID: 12345) on port 41701."
+    );
+  });
+
+  it("does not enable daemon mode when daemon startup fails", async () => {
+    const startupError = new Error("spawn failed");
+    const spawnChild = {
+      pid: 12345,
+      unref: vi.fn(),
+      once: vi.fn(),
+    };
+    spawnChild.once.mockImplementation((event: string, callback: (error?: Error) => void) => {
+      if (event === "error") queueMicrotask(() => callback(startupError));
+      return spawnChild;
+    });
+    const spawnMock = vi.fn(() => spawnChild);
+    const updateGlobalConfigMock = vi.fn(async () => ({ daemon_mode: true, no_flicker: false }));
+
+    vi.doMock("node:child_process", () => ({
+      spawn: spawnMock,
+    }));
+    vi.doMock("../../../runtime/daemon/client.js", () => ({
+      isDaemonRunning: vi.fn(async () => ({ running: false, port: 41701 })),
+    }));
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(async () => "reset"),
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: vi.fn(async () => "Seedy"),
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: vi.fn(async () => "openai"),
+      stepModel: vi.fn(async () => "gpt-5.4-mini"),
+      stepApiKey: vi.fn(async () => "sk-test"),
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: vi.fn(async () => "openai_codex_cli"),
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: true, port: 41701 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4-mini": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      saveProviderConfig: vi.fn(async () => {}),
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/global-config.js", () => ({
+      updateGlobalConfig: updateGlobalConfigMock,
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(updateGlobalConfigMock).not.toHaveBeenCalled();
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("Setup saved, but daemon/gateway did not start: spawn failed.")
     );
   });
 
@@ -714,6 +815,136 @@ describe("setup notification step", () => {
       })
     );
     expect((saveProviderConfigMock.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty("api_key");
+    expect(applySetupImportSelectionMock).toHaveBeenCalledWith("/tmp/pulseed-test", importSelection);
+  });
+
+  it("uses imported USER.md and only asks for Seedy naming", async () => {
+    const stepUserNameMock = vi.fn(async () => "User");
+    const stepSeedyNameMock = vi.fn(async () => "Imported Seedy");
+    const writeUserMdMock = vi.fn();
+    const applySetupImportSelectionMock = vi.fn(async () => ({
+      created_at: "2026-04-13T00:00:00.000Z",
+      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes" }],
+      items: [],
+    }));
+
+    const importSelection: SetupImportSelection = {
+      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes", items: [] }],
+      items: [
+        {
+          id: "hermes:user:USER.md",
+          source: "hermes",
+          sourceLabel: "Hermes Agent",
+          kind: "user",
+          label: "USER.md",
+          decision: "import",
+          reason: "USER.md found",
+          userSettings: {
+            content: "# About You\n\nName: Imported User\nPrefers concise updates.\n",
+          },
+        },
+        {
+          id: "hermes:provider:settings.json",
+          source: "hermes",
+          sourceLabel: "Hermes Agent",
+          kind: "provider",
+          label: "openai / gpt-5.4 / openai_codex_cli",
+          decision: "import",
+          reason: "provider defaults",
+          providerSettings: {
+            provider: "openai",
+            model: "gpt-5.4",
+            adapter: "openai_codex_cli",
+          },
+        },
+      ],
+      providerSettings: {
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "openai_codex_cli",
+      },
+      userSettings: {
+        content: "# About You\n\nName: Imported User\nPrefers concise updates.\n",
+      },
+    };
+
+    vi.doMock("../commands/setup/import/flow.js", () => ({
+      stepSetupImport: vi.fn(async () => importSelection),
+      providerConfigPatchFromImport: vi.fn((settings: NonNullable<SetupImportSelection["providerSettings"]>) => ({
+        provider: settings.provider,
+        model: settings.model,
+        adapter: settings.adapter,
+        api_key: settings.apiKey,
+      })),
+    }));
+    vi.doMock("../commands/setup/import/apply.js", () => ({
+      applySetupImportSelection: applySetupImportSelectionMock,
+    }));
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(async () => "keep"),
+      stepUserName: stepUserNameMock,
+      stepSeedyName: stepSeedyNameMock,
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: vi.fn(async () => "openai"),
+      stepModel: vi.fn(async () => "gpt-5.4"),
+      stepApiKey: vi.fn(async () => "sk-imported"),
+      runCodexOAuthLogin: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-adapter.js", () => ({
+      stepAdapter: vi.fn(async () => "openai_codex_cli"),
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: false, port: 41700 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: writeUserMdMock,
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      readCodexOAuthToken: vi.fn(async () => "oauth-token"),
+      saveProviderConfig: vi.fn(async () => {}),
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(stepUserNameMock).not.toHaveBeenCalled();
+    expect(stepSeedyNameMock).toHaveBeenCalledTimes(1);
+    expect(writeUserMdMock).toHaveBeenCalledWith(
+      "/tmp/pulseed-test",
+      "Imported USER.md",
+      "# About You\n\nName: Imported User\nPrefers concise updates.\n"
+    );
     expect(applySetupImportSelectionMock).toHaveBeenCalledWith("/tmp/pulseed-test", importSelection);
   });
 

--- a/src/interface/cli/__tests__/setup-import.test.ts
+++ b/src/interface/cli/__tests__/setup-import.test.ts
@@ -62,6 +62,7 @@ describe("setup import discovery", () => {
       capabilities: ["notify"],
       description: "test",
     });
+    await fsp.writeFile(path.join(openclawHome, "USER.md"), "# About You\n\nName: Imported User\n", "utf-8");
 
     const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
     const sources = detectSetupImportSources();
@@ -73,6 +74,7 @@ describe("setup import discovery", () => {
       "plugin",
       "provider",
       "skill",
+      "user",
     ]);
     expect(openclaw?.items.find((item) => item.kind === "provider")?.providerSettings).toMatchObject({
       provider: "anthropic",
@@ -95,6 +97,9 @@ describe("setup import discovery", () => {
       ],
     });
     expect(openclaw?.items.find((item) => item.kind === "plugin")?.decision).toBe("copy_disabled");
+    expect(openclaw?.items.find((item) => item.kind === "user")?.userSettings).toEqual({
+      content: "# About You\n\nName: Imported User\n",
+    });
   });
 
   it("detects OpenClaw migration-style YAML, env secrets, workspace skills, and nested MCP servers", async () => {
@@ -232,6 +237,63 @@ describe("setup import discovery", () => {
       apiKey: "sk-workspace-main",
     });
     expect(provider?.providerSettings?.apiKey).not.toBe("sk-workspace-secondary");
+  });
+
+  it("prefers the actual provider object over unrelated sibling model values", async () => {
+    const hermesHome = path.join(tmpDir, "hermes");
+    process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
+
+    await writeJson(path.join(hermesHome, "settings.json"), {
+      agents: {
+        defaults: {
+          model: "gpt-4o-mini-tts",
+        },
+      },
+      provider: {
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "openai_codex_cli",
+        apiKey: "OPENAI_API_KEY",
+      },
+    });
+    await fsp.writeFile(path.join(hermesHome, ".env"), "OPENAI_API_KEY=sk-hermes-openai\n", "utf-8");
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const hermes = sources.find((source) => source.id === "hermes");
+    const provider = hermes?.items.find((item) => item.kind === "provider");
+
+    expect(provider?.providerSettings).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "openai_codex_cli",
+      apiKey: "sk-hermes-openai",
+    });
+  });
+
+  it("detects USER.md from Hermes for identity import", async () => {
+    const hermesHome = path.join(tmpDir, "hermes");
+    process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
+
+    await writeJson(path.join(hermesHome, "settings.json"), {
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "openai_codex_cli",
+    });
+    await fsp.writeFile(
+      path.join(hermesHome, "USER.md"),
+      "# About You\n\nName: Imported User\nPrefers concise updates.\n",
+      "utf-8"
+    );
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const hermes = sources.find((source) => source.id === "hermes");
+    const user = hermes?.items.find((item) => item.kind === "user");
+
+    expect(user?.userSettings).toEqual({
+      content: "# About You\n\nName: Imported User\nPrefers concise updates.\n",
+    });
   });
 });
 

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -9,6 +9,7 @@ import {
 } from "../../../base/llm/provider-config.js";
 import type { ProviderConfig } from "../../../base/llm/provider-config.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
+import { updateGlobalConfig } from "../../../base/config/global-config.js";
 import { readCodexOAuthToken } from "../../../base/llm/provider-config.js";
 import { isDaemonRunning } from "../../../runtime/daemon/client.js";
 import { ROOT_PRESETS } from "./presets/root-presets.js";
@@ -28,6 +29,7 @@ type SetupAnswers = {
   userName: string;
   agentName: string;
   rootPreset: keyof typeof ROOT_PRESETS;
+  importedUserContent?: string;
   provider: Provider;
   model: string;
   adapter: string;
@@ -43,6 +45,7 @@ type RuntimeAnswers = Pick<SetupAnswers, "startDaemon" | "daemonPort" | "notific
 type FullSetupSection = "identity" | "execution" | "runtime" | "review";
 type IdentityConfigOptions = {
   skipRootPreset?: boolean;
+  skipUserName?: boolean;
 };
 
 function formatSummary(answers: SetupAnswers): string {
@@ -53,7 +56,7 @@ function formatSummary(answers: SetupAnswers): string {
     : "no";
 
   return [
-    `User:      ${answers.userName}`,
+    `User:      ${answers.importedUserContent ? "imported USER.md" : answers.userName}`,
     `Agent:     ${answers.agentName}`,
     `Style:     ${ROOT_PRESETS[answers.rootPreset].name}`,
     `Provider:  ${answers.provider}`,
@@ -85,6 +88,7 @@ function formatImportSetupSummary(
     return [
       `Source:    ${sourceNames}`,
       "Provider:  not found",
+      `User:      ${selection.userSettings ? "imported USER.md" : "PulSeed will ask"}`,
       "Style:     Default",
       "Next:      PulSeed will ask for provider settings.",
     ].join("\n");
@@ -103,6 +107,7 @@ function formatImportSetupSummary(
     `Model:     ${providerPatch.model ?? "not found"}`,
     `Adapter:   ${providerPatch.adapter ?? "not found"}`,
     `API Key:   ${apiKeyStatus}`,
+    `User:      ${selection.userSettings ? "imported USER.md" : "PulSeed will ask"}`,
     "Style:     Default",
   ].join("\n");
 }
@@ -300,7 +305,9 @@ async function stepIdentityConfig(
   options: IdentityConfigOptions = {}
 ): Promise<IdentityAnswers> {
   return {
-    userName: await stepUserName(current?.userName),
+    userName: options.skipUserName
+      ? (current?.userName ?? "Imported USER.md")
+      : await stepUserName(current?.userName),
     agentName: await stepSeedyName(current?.agentName),
     rootPreset: options.skipRootPreset
       ? current?.rootPreset ?? "default"
@@ -509,9 +516,10 @@ export async function runSetupWizard(): Promise<number> {
   }
 
   let answers: SetupAnswers = {
-    userName: "",
+    userName: importSelection?.userSettings ? "Imported USER.md" : "",
     agentName: "Seedy",
     rootPreset: "default",
+    importedUserContent: importSelection?.userSettings?.content,
     provider: importedProviderPatch?.provider ?? "openai",
     model: importedProviderPatch?.model ?? "",
     adapter: importedProviderPatch?.adapter ?? "",
@@ -531,6 +539,7 @@ export async function runSetupWizard(): Promise<number> {
         answers,
         await stepIdentityConfig(answers.userName ? answers : undefined, {
           skipRootPreset: Boolean(importSelection),
+          skipUserName: Boolean(importSelection?.userSettings),
         })
       );
       const next = await stepSectionNavigation("Identity settings complete.");
@@ -626,7 +635,11 @@ export async function runSetupWizard(): Promise<number> {
   if (saveResult !== undefined) return saveResult;
   writeSeedMd(dir, finalAnswers.agentName);
   writeRootMd(dir, finalAnswers.rootPreset);
-  writeUserMd(dir, finalAnswers.userName);
+  if (finalAnswers.importedUserContent !== undefined) {
+    writeUserMd(dir, finalAnswers.userName, finalAnswers.importedUserContent);
+  } else {
+    writeUserMd(dir, finalAnswers.userName);
+  }
   clearIdentityCache();
 
   if (finalAnswers.startDaemon) {
@@ -671,6 +684,11 @@ export async function runSetupWizard(): Promise<number> {
   if (finalAnswers.startDaemon) {
     try {
       await startDaemonAfterSetup(dir, finalAnswers.daemonPort);
+      try {
+        await updateGlobalConfig({ daemon_mode: true });
+      } catch {
+        p.log.warn("Daemon started, but could not enable daemon mode in config.json");
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       p.log.warn(

--- a/src/interface/cli/commands/setup/import/apply.ts
+++ b/src/interface/cli/commands/setup/import/apply.ts
@@ -184,6 +184,8 @@ export async function applySetupImportSelection(
     try {
       if (item.kind === "provider") {
         applied.push(reportItem(item, "applied", "provider settings seeded into setup answers"));
+      } else if (item.kind === "user") {
+        applied.push(reportItem(item, "applied", "USER.md seeded into setup identity"));
       } else if (item.kind === "telegram") {
         applied.push(reportItem(item, "applied", "telegram settings seeded into plugin config"));
       } else if (item.kind === "skill" || item.kind === "plugin") {

--- a/src/interface/cli/commands/setup/import/discovery.ts
+++ b/src/interface/cli/commands/setup/import/discovery.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { CONFIG_FILENAMES, MCP_FILENAMES, SOURCE_LABELS } from "./constants.js";
@@ -131,6 +132,40 @@ function providerItems(source: SetupImportSourceId, rootDir: string): SetupImpor
   });
 }
 
+function userItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
+  const candidates = unique([
+    path.join(rootDir, "USER.md"),
+    path.join(rootDir, "user.md"),
+    ...workspaceRoots(rootDir).flatMap((workspaceRoot) => [
+      path.join(workspaceRoot, "USER.md"),
+      path.join(workspaceRoot, "user.md"),
+    ]),
+  ]).filter(pathExists);
+
+  const sourcePath = candidates.find((candidate) => {
+    try {
+      return fs.readFileSync(candidate, "utf-8").trim().length > 0;
+    } catch {
+      return false;
+    }
+  });
+  if (!sourcePath) return [];
+
+  return [{
+    id: `${source}:user:${safeImportName(sourcePath)}`,
+    source,
+    sourceLabel: SOURCE_LABELS[source],
+    kind: "user",
+    label: path.relative(rootDir, sourcePath) || "USER.md",
+    sourcePath,
+    decision: "import",
+    reason: "USER.md found",
+    userSettings: {
+      content: fs.readFileSync(sourcePath, "utf-8"),
+    },
+  }];
+}
+
 function telegramItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
   const env = {
     ...readEnvFile(path.join(rootDir, ".env")),
@@ -196,6 +231,7 @@ function detectSource(source: SetupImportSourceId): SetupImportSource | undefine
     if (!pathExists(rootDir)) continue;
     const items = [
       ...providerItems(source, rootDir),
+      ...userItems(source, rootDir),
       ...telegramItems(source, rootDir),
       ...skillItems(source, rootDir),
       ...mcpItems(source, rootDir),

--- a/src/interface/cli/commands/setup/import/flow.ts
+++ b/src/interface/cli/commands/setup/import/flow.ts
@@ -8,6 +8,7 @@ import type {
   SetupImportProviderSettings,
   SetupImportSelection,
   SetupImportSource,
+  SetupImportUserSettings,
 } from "./types.js";
 
 function sourceSummary(sources: SetupImportSource[]): string {
@@ -40,6 +41,8 @@ function itemPreview(item: SetupImportItem): string {
   const decision = item.decision === "copy_disabled" ? "copy disabled" : item.decision;
   const details = item.kind === "provider"
     ? providerPreview(item.providerSettings)
+    : item.kind === "user"
+      ? "will replace PulSeed USER.md"
     : item.kind === "telegram"
       ? [
           item.telegramSettings?.botToken ? `bot_token=${maskKey(item.telegramSettings.botToken)}` : undefined,
@@ -58,6 +61,10 @@ function preview(sources: SetupImportSource[]): string {
 
 function mergeProviderSettings(items: SetupImportItem[]): SetupImportProviderSettings | undefined {
   return items.find((item) => item.decision !== "skip" && item.providerSettings)?.providerSettings;
+}
+
+function mergeUserSettings(items: SetupImportItem[]): SetupImportUserSettings | undefined {
+  return items.find((item) => item.decision !== "skip" && item.userSettings)?.userSettings;
 }
 
 function defaultProviderConfigFromImport(
@@ -141,11 +148,18 @@ export async function stepSetupImport(): Promise<SetupImportSelection | undefine
   }
 
   const providerSettings = mergeProviderSettings(items);
+  const userSettings = mergeUserSettings(items);
   if (providerSettings) {
-    p.log.info("Imported provider settings will be used as defaults. Seedy naming will still be asked.");
+    p.log.info(
+      userSettings
+        ? "Imported provider settings and USER.md will be used as defaults. Setup will still ask for Seedy naming."
+        : "Imported provider settings will be used as defaults. Seedy naming will still be asked."
+    );
+  } else if (userSettings) {
+    p.log.info("Imported USER.md will be used as defaults. Setup will still ask for Seedy naming.");
   } else {
     p.log.info("Import selected. Seedy naming will still be asked.");
   }
 
-  return { sources, items, providerSettings };
+  return { sources, items, providerSettings, userSettings };
 }

--- a/src/interface/cli/commands/setup/import/provider.ts
+++ b/src/interface/cli/commands/setup/import/provider.ts
@@ -111,6 +111,8 @@ function providerSection(
 ): Record<string, unknown> | undefined {
   if (!provider) return undefined;
   for (const record of records) {
+    const generic = nestedRecord(record, "provider");
+    if (generic) return generic;
     const direct = nestedRecord(record, provider);
     if (direct) return direct;
     if (provider === "anthropic") {
@@ -210,15 +212,20 @@ export function extractProviderSettings(
   const records = collectRecords(raw);
   if (records.length === 0) return undefined;
 
+  const root = records[0]!;
   const env = { ...envFromConfig(records), ...(context.env ?? {}) };
-  const initialModel = firstString(records, MODEL_KEYS);
+  const rootModel = firstString([root], MODEL_KEYS);
+  const initialModel = rootModel ?? firstString(records, MODEL_KEYS);
   const provider =
     normalizeProvider(firstString(records, PROVIDER_KEYS)) ??
     providerFromModel(initialModel) ??
     providerFromKnownMap(records);
   const section = providerSection(records, provider);
-  const searchable = section ? [section, ...records] : records;
-  const model = firstString(searchable, MODEL_KEYS) ?? initialModel;
+  const model =
+    (section ? firstString([section], MODEL_KEYS) : undefined) ??
+    rootModel ??
+    initialModel;
+  const searchable = section ? [section, root] : [root];
   const adapter = normalizeAdapter(firstString(searchable, ADAPTER_KEYS), provider, model);
   const apiKey = providerApiKey(provider, searchable, env);
   const baseUrl = firstString(searchable, BASE_URL_KEYS);

--- a/src/interface/cli/commands/setup/import/types.ts
+++ b/src/interface/cli/commands/setup/import/types.ts
@@ -3,7 +3,7 @@ import type { MCPServerConfig } from "../../../../../base/types/mcp.js";
 
 export type SetupImportSourceId = "hermes" | "openclaw";
 
-export type SetupImportItemKind = "provider" | "skill" | "mcp" | "plugin" | "telegram";
+export type SetupImportItemKind = "provider" | "user" | "skill" | "mcp" | "plugin" | "telegram";
 
 export type SetupImportDecision = "import" | "copy_disabled" | "skip";
 
@@ -22,6 +22,10 @@ export interface SetupImportTelegramSettings {
   allowedUserIds?: number[];
 }
 
+export interface SetupImportUserSettings {
+  content: string;
+}
+
 export interface SetupImportItem {
   id: string;
   source: SetupImportSourceId;
@@ -32,6 +36,7 @@ export interface SetupImportItem {
   decision: SetupImportDecision;
   reason: string;
   providerSettings?: SetupImportProviderSettings;
+  userSettings?: SetupImportUserSettings;
   telegramSettings?: SetupImportTelegramSettings;
   mcpServer?: MCPServerConfig;
 }
@@ -47,6 +52,7 @@ export interface SetupImportSelection {
   sources: SetupImportSource[];
   items: SetupImportItem[];
   providerSettings?: SetupImportProviderSettings;
+  userSettings?: SetupImportUserSettings;
 }
 
 export interface SetupImportAppliedItem {

--- a/src/interface/cli/commands/setup/steps-runtime.ts
+++ b/src/interface/cli/commands/setup/steps-runtime.ts
@@ -164,7 +164,11 @@ export function writeRootMd(dir: string, presetKey: RootPresetKey): void {
   fs.writeFileSync(path.join(dir, "ROOT.md"), ROOT_PRESETS[presetKey].content, "utf-8");
 }
 
-export function writeUserMd(dir: string, userName: string): void {
+export function writeUserMd(dir: string, userName: string, importedContent?: string): void {
+  if (importedContent !== undefined) {
+    fs.writeFileSync(path.join(dir, "USER.md"), importedContent, "utf-8");
+    return;
+  }
   const content = DEFAULT_USER.replace(/^(#[^\n]*)\n/m, `$1\n\nName: ${userName}\n`);
   fs.writeFileSync(path.join(dir, "USER.md"), content, "utf-8");
 }

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatDaemonConnectionState } from "../app.js";
+
+describe("formatDaemonConnectionState", () => {
+  it("renders connected, connecting, and disconnected labels", () => {
+    expect(formatDaemonConnectionState("connected")).toBe("  [daemon connected]");
+    expect(formatDaemonConnectionState("connecting")).toBe("  [daemon connecting]");
+    expect(formatDaemonConnectionState("disconnected")).toBe("  [daemon disconnected]");
+  });
+
+  it("omits the badge when no daemon state is available", () => {
+    expect(formatDaemonConnectionState(undefined)).toBeUndefined();
+  });
+});

--- a/src/interface/tui/__tests__/entry.test.ts
+++ b/src/interface/tui/__tests__/entry.test.ts
@@ -1,0 +1,122 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PIDManager } from "../../../runtime/pid-manager.js";
+import * as daemonClient from "../../../runtime/daemon/client.js";
+import { resolveRunningDaemonConnection } from "../entry.js";
+
+describe("resolveRunningDaemonConnection", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-tui-entry-"));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("attaches to a live daemon process once health responds", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon.json"),
+      JSON.stringify({ event_server_port: 41888 }),
+      "utf-8"
+    );
+
+    vi.spyOn(PIDManager.prototype, "inspect").mockResolvedValue({
+      info: {
+        pid: 12345,
+        started_at: new Date().toISOString(),
+        runtime_started_at: new Date().toISOString(),
+        owner_pid: 12345,
+        owner_started_at: new Date().toISOString(),
+        runtime_pid: 12345,
+      },
+      running: true,
+      runtimePid: 12345,
+      ownerPid: 12345,
+      alivePids: [12345],
+      stalePids: [],
+      verifiedPids: [12345],
+      unverifiedLegacyPids: [],
+    });
+    const probeSpy = vi.spyOn(daemonClient, "probeDaemonHealth").mockResolvedValue({
+      ok: true,
+      port: 41888,
+      latency_ms: 1,
+      health: {
+        ok: true,
+        accepting_commands: true,
+        task_execution_ok: true,
+        runtime_kpi: null,
+      },
+    });
+    const runningSpy = vi.spyOn(daemonClient, "isDaemonRunning");
+
+    await expect(resolveRunningDaemonConnection(tmpDir)).resolves.toEqual({
+      port: 41888,
+      authToken: null,
+    });
+    expect(probeSpy).toHaveBeenCalledWith({ host: "127.0.0.1", port: 41888 });
+    expect(runningSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back when the pid is live but daemon health never comes up", async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon.json"),
+      JSON.stringify({ event_server_port: 41888 }),
+      "utf-8"
+    );
+
+    vi.spyOn(PIDManager.prototype, "inspect")
+      .mockResolvedValueOnce({
+        info: {
+          pid: 12345,
+          started_at: new Date().toISOString(),
+          runtime_started_at: new Date().toISOString(),
+          owner_pid: 12345,
+          owner_started_at: new Date().toISOString(),
+          runtime_pid: 12345,
+        },
+        running: true,
+        runtimePid: 12345,
+        ownerPid: 12345,
+        alivePids: [12345],
+        stalePids: [],
+        verifiedPids: [12345],
+        unverifiedLegacyPids: [],
+      })
+      .mockResolvedValueOnce({
+        info: {
+          pid: 12345,
+          started_at: new Date().toISOString(),
+          runtime_started_at: new Date().toISOString(),
+          owner_pid: 12345,
+          owner_started_at: new Date().toISOString(),
+          runtime_pid: 12345,
+        },
+        running: false,
+        runtimePid: null,
+        ownerPid: null,
+        alivePids: [],
+        stalePids: [12345],
+        verifiedPids: [],
+        unverifiedLegacyPids: [],
+      });
+    vi.spyOn(daemonClient, "probeDaemonHealth").mockResolvedValue({
+      ok: false,
+      port: 41888,
+      latency_ms: 1,
+      error: "connection refused",
+    });
+    const runningSpy = vi.spyOn(daemonClient, "isDaemonRunning").mockResolvedValue({
+      running: false,
+      port: 41888,
+    });
+
+    await expect(resolveRunningDaemonConnection(tmpDir)).resolves.toBeNull();
+    expect(runningSpy).toHaveBeenCalledWith(tmpDir);
+  });
+});

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -45,6 +45,13 @@ export interface ApprovalRequest {
   resolve: (approved: boolean) => void;
 }
 
+export type DaemonConnectionState = "connected" | "connecting" | "disconnected";
+
+export function formatDaemonConnectionState(state: DaemonConnectionState | undefined): string | undefined {
+  if (!state) return undefined;
+  return `  [daemon ${state}]`;
+}
+
 interface AppProps {
   // Daemon mode (thin client — events via SSE, commands via REST)
   daemonClient?: DaemonClient;
@@ -68,8 +75,8 @@ const StatusBar: React.FC<{
   trustScore: number;
   status: string;
   iteration: number;
-  daemonConnected?: boolean;
-}> = ({ goalCount, trustScore, status, iteration, daemonConnected }) => (
+  daemonConnectionState?: DaemonConnectionState;
+}> = ({ goalCount, trustScore, status, iteration, daemonConnectionState }) => (
   <Box
     borderStyle="single"
     borderColor={theme.border}
@@ -79,7 +86,7 @@ const StatusBar: React.FC<{
     <Text dimColor>
       Active: {goalCount}  Trust: {trustScore >= 0 ? "+" : ""}
       {trustScore}  Status: {statusLabel(status)}  Iter: {iteration}
-      {daemonConnected !== undefined && (daemonConnected ? "  [daemon]" : "  [disconnected]")}
+      {formatDaemonConnectionState(daemonConnectionState)}
     </Text>
     <Text dimColor>d:dashboard  ?:help  Ctrl-C× 2:quit</Text>
   </Box>
@@ -128,7 +135,11 @@ export function App({
     : null;
 
   const [daemonLoopState, setDaemonLoopState] = useState<LoopState>(IDLE_LOOP_STATE);
-  const [daemonConnected, setDaemonConnected] = useState(false);
+  const [daemonConnectionState, setDaemonConnectionState] = useState<DaemonConnectionState | undefined>(
+    isDaemonMode
+      ? (daemonClient?.isConnected() ? "connected" : "connecting")
+      : undefined
+  );
 
   const loopState = isDaemonMode ? daemonLoopState : (standaloneHook?.loopState ?? IDLE_LOOP_STATE);
   const startLoop = isDaemonMode
@@ -146,8 +157,8 @@ export function App({
   useEffect(() => {
     if (!isDaemonMode || !daemonClient) return;
 
-    const onConnected = () => setDaemonConnected(true);
-    const onDisconnected = () => setDaemonConnected(false);
+    const onConnected = () => setDaemonConnectionState("connected");
+    const onDisconnected = () => setDaemonConnectionState("disconnected");
 
     const onLoopUpdate = (data: unknown) => {
       const d = data as Record<string, unknown>;
@@ -499,7 +510,7 @@ export function App({
             <Text dimColor> v{PULSEED_VERSION}</Text>
           </Box>
           <Text dimColor>
-            daemon: {isDaemonMode ? "on" : "off"}{providerName ? ` · ${providerName}` : ""}
+            daemon: {isDaemonMode ? daemonConnectionState ?? "connecting" : "off"}{providerName ? ` · ${providerName}` : ""}
           </Text>
           {cwd && (
             <Text dimColor>{cwd}</Text>
@@ -553,7 +564,7 @@ export function App({
         trustScore={loopState.trustScore}
         status={loopState.status}
         iteration={loopState.iteration}
-        daemonConnected={isDaemonMode ? daemonConnected : undefined}
+        daemonConnectionState={daemonConnectionState}
       />
       {ctrlCPending && (
         <Box paddingX={1}>

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -9,6 +9,7 @@ import os from "os";
 import path from "path";
 import { execFileSync } from "child_process";
 import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
 
 import { StateManager } from "../../base/state/state-manager.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
@@ -20,8 +21,14 @@ import { ensureProviderConfig } from "../cli/ensure-api-key.js";
 import type { Task } from "../../base/types/task.js";
 import { isNoFlickerEnabled, createFrameWriter, AlternateScreen, type FrameWriter } from "./flicker/index.js";
 import { isRenderableFrameChunk } from "./render-output.js";
+import { PIDManager } from "../../runtime/pid-manager.js";
+import { probeDaemonHealth, readDaemonAuthToken } from "../../runtime/daemon/client.js";
+import { DEFAULT_PORT } from "../../runtime/port-utils.js";
 
 // ─── Breadcrumb helpers ───
+
+const EXISTING_DAEMON_HEALTH_TIMEOUT_MS = 10_000;
+const EXISTING_DAEMON_HEALTH_POLL_MS = 250;
 
 function getCwd(): string {
   const raw = process.cwd();
@@ -54,6 +61,47 @@ async function startDaemonDetached(baseDir: string): Promise<void> {
     env: { ...process.env, PULSEED_HOME: baseDir },
   });
   child.unref();
+}
+
+async function readDaemonPort(baseDir: string): Promise<number> {
+  try {
+    const configPath = path.join(baseDir, "daemon.json");
+    const raw = await fs.readFile(configPath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const port = parsed.event_server_port;
+    return typeof port === "number" && Number.isInteger(port) && port > 0 ? port : DEFAULT_PORT;
+  } catch {
+    return DEFAULT_PORT;
+  }
+}
+
+export async function resolveRunningDaemonConnection(
+  baseDir: string
+): Promise<{ port: number; authToken?: string | null } | null> {
+  const pidManager = new PIDManager(baseDir);
+  const status = await pidManager.inspect();
+  if (status.running) {
+    const port = await readDaemonPort(baseDir);
+    const authToken = readDaemonAuthToken(baseDir, port);
+    const deadline = Date.now() + EXISTING_DAEMON_HEALTH_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      const probe = await probeDaemonHealth({ host: "127.0.0.1", port });
+      if (probe.ok) {
+        return { port, authToken };
+      }
+      const refreshed = await pidManager.inspect();
+      if (!refreshed.running) break;
+      await new Promise((resolve) => setTimeout(resolve, EXISTING_DAEMON_HEALTH_POLL_MS));
+    }
+  }
+
+  const { isDaemonRunning } = await import("../../runtime/daemon/client.js");
+  const running = await isDaemonRunning(baseDir);
+  if (!running.running) return null;
+  return {
+    port: running.port,
+    authToken: running.authToken ?? readDaemonAuthToken(baseDir, running.port),
+  };
 }
 
 async function waitForDaemon(baseDir: string, timeoutMs: number): Promise<{ port: number; authToken?: string | null }> {
@@ -507,16 +555,16 @@ async function startTUIStandaloneMode(): Promise<void> {
 // ─── Daemon mode ───
 
 async function startTUIDaemonMode(): Promise<void> {
-  const { DaemonClient, isDaemonRunning } = await import("../../runtime/daemon/client.js");
+  const { DaemonClient } = await import("../../runtime/daemon/client.js");
   const baseDir = process.env.PULSEED_HOME ?? getPulseedDirPath();
 
   let daemonClient: InstanceType<typeof DaemonClient>;
 
   try {
-    const { running, port, authToken } = await isDaemonRunning(baseDir);
+    const existingConnection = await resolveRunningDaemonConnection(baseDir);
 
-    if (running) {
-      daemonClient = new DaemonClient({ host: "127.0.0.1", port, authToken, baseDir });
+    if (existingConnection) {
+      daemonClient = new DaemonClient({ host: "127.0.0.1", ...existingConnection, baseDir });
     } else {
       await startDaemonDetached(baseDir);
       const ready = await waitForDaemon(baseDir, 10_000);


### PR DESCRIPTION
## What changed

- fixes Hermes/OpenClaw setup import so imported provider settings keep the actual configured model instead of picking unrelated sibling values
- makes `provider.json` models authoritative over `PULSEED_MODEL` and other model env fallbacks
- imports `USER.md` during setup migration and uses it directly, while setup still asks only for the Seedy name
- persists `daemon_mode` only after daemon startup succeeds
- updates TUI daemon status to reflect connection state and avoids double-starting a daemon that is already booting

## Why

The setup flow was still short of Hermes parity in a few real cases:

- Hermes imports could land on `gpt-4o-mini-tts` instead of the intended `gpt-5.4`
- setup could start a daemon but leave TUI showing daemon mode as off
- imported setups did not bring over `USER.md`, so user identity still had to be rebuilt manually

## User impact

A Hermes/OpenClaw user can now run setup, keep the imported provider defaults, keep their imported `USER.md`, name Seedy, and land in a working daemon-backed setup that can immediately call the model.

## Validation

- `npx vitest run src/interface/cli/__tests__/setup-import.test.ts src/interface/cli/__tests__/cli-setup-notification.test.ts src/base/llm/__tests__/provider-config.test.ts src/interface/tui/__tests__/app.test.ts src/interface/tui/__tests__/entry.test.ts`
- `npm run typecheck`
- remote verification on `mini` with an isolated `HOME`:
  - fresh `pulseed setup` from Hermes-shaped config
  - asserted setup skipped the user-name prompt when imported `USER.md` existed
  - verified generated `provider.json` was `openai / gpt-5.4 / openai_codex_cli`
  - verified generated `config.json` had `daemon_mode: true`
  - verified imported `USER.md` was written as-is
  - verified `pulseed suggest ...` succeeded from the generated state
