### PR TITLE
[codex] Improve TUI input box rendering

### DIFF
--- a/src/base/config/__tests__/global-config.test.ts
+++ b/src/base/config/__tests__/global-config.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const originalPulseedHome = process.env["PULSEED_HOME"];
+
+async function withTempPulseedHome<T>(run: (dir: string) => Promise<T>): Promise<T> {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pulseed-config-"));
+  process.env["PULSEED_HOME"] = tmpDir;
+  try {
+    return await run(tmpDir);
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+afterEach(() => {
+  if (originalPulseedHome === undefined) {
+    delete process.env["PULSEED_HOME"];
+  } else {
+    process.env["PULSEED_HOME"] = originalPulseedHome;
+  }
+});
+
+describe("loadGlobalConfig", () => {
+  it("defaults no_flicker to true when config file is absent", async () => {
+    await withTempPulseedHome(async () => {
+      const { loadGlobalConfig } = await import("../global-config.js");
+      await expect(loadGlobalConfig()).resolves.toMatchObject({
+        daemon_mode: false,
+        no_flicker: true,
+      });
+    });
+  });
+
+  it("preserves an explicit false no_flicker setting from config.json", async () => {
+    await withTempPulseedHome(async (tmpDir) => {
+      await fs.writeFile(
+        path.join(tmpDir, "config.json"),
+        JSON.stringify({ no_flicker: false }, null, 2),
+        "utf8",
+      );
+
+      const { loadGlobalConfig } = await import("../global-config.js");
+      await expect(loadGlobalConfig()).resolves.toMatchObject({
+        daemon_mode: false,
+        no_flicker: false,
+      });
+    });
+  });
+});

--- a/src/base/config/global-config.ts
+++ b/src/base/config/global-config.ts
@@ -8,14 +8,14 @@ import { z } from "zod";
 
 const GlobalConfigSchema = z.object({
   daemon_mode: z.boolean().default(false),
-  no_flicker: z.boolean().default(false),
+  no_flicker: z.boolean().default(true),
 });
 
 export type GlobalConfig = z.infer<typeof GlobalConfigSchema>;
 
 const DEFAULT_CONFIG: GlobalConfig = {
   daemon_mode: false,
-  no_flicker: false,
+  no_flicker: true,
 };
 
 function getConfigPath(): string {

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -149,6 +149,6 @@ describe("cursor tracker", () => {
       "└──────────────────┘",
     ].join("\n");
 
-    expect(buildCursorEscape(frame, "abc")).toBe("\u001b[2;8H\u001b[?25h");
+    expect(buildCursorEscape(frame, "abc")).toBe("\u001b[2;8H");
   });
 });

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildChatViewport, getMatchingSuggestions, getScrollRequest, stripMouseEscapeSequences } from "../chat.js";
+import { buildChatViewport, getInputPromptLabel, getMatchingSuggestions, getScrollRequest, stripMouseEscapeSequences } from "../chat.js";
 import { estimateMarkdownHeight, estimateWrappedLineCount, wrapTextToRows } from "../markdown-renderer.js";
 import { extractBashCommand, isBashModeInput, isSafeBashCommand, createShellApprovalTask, formatShellOutput } from "../bash-mode.js";
 import { INPUT_MARKER, buildCursorEscape } from "../cursor-tracker.js";
@@ -145,10 +145,15 @@ describe("cursor tracker", () => {
   it("positions the caret from the marker column inside a bordered input box", () => {
     const frame = [
       "┌──────────────────┐",
-      `│ \u001b[31m${INPUT_MARKER} \u001b[0mhello │`,
+      `│ \u001b[31m${INPUT_MARKER}! \u001b[0mhello │`,
       "└──────────────────┘",
     ].join("\n");
 
     expect(buildCursorEscape(frame, "abc")).toBe("\u001b[2;8H");
+  });
+
+  it("keeps the bash prompt label separate from the internal marker", () => {
+    expect(getInputPromptLabel(true)).toBe("!");
+    expect(getInputPromptLabel(false)).toBe("◉");
   });
 });

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { buildChatViewport, getMatchingSuggestions, getScrollRequest, stripMouseEscapeSequences } from "../chat.js";
 import { estimateMarkdownHeight, estimateWrappedLineCount, wrapTextToRows } from "../markdown-renderer.js";
 import { extractBashCommand, isBashModeInput, isSafeBashCommand, createShellApprovalTask, formatShellOutput } from "../bash-mode.js";
+import { INPUT_MARKER, buildCursorEscape } from "../cursor-tracker.js";
 
 describe("getMatchingSuggestions", () => {
   it("hides suggestions for an exact slash command so enter can submit", () => {
@@ -137,5 +138,17 @@ describe("chat scroll keys", () => {
 
   it("strips sgr mouse sequences from input text", () => {
     expect(stripMouseEscapeSequences("hello\u001b[<64;40;12Mworld")).toBe("helloworld");
+  });
+});
+
+describe("cursor tracker", () => {
+  it("positions the caret from the marker column inside a bordered input box", () => {
+    const frame = [
+      "┌──────────────────┐",
+      `│ \u001b[31m${INPUT_MARKER} \u001b[0mhello │`,
+      "└──────────────────┘",
+    ].join("\n");
+
+    expect(buildCursorEscape(frame, "abc")).toBe("\u001b[2;8H\u001b[?25h");
   });
 });

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -145,7 +145,7 @@ describe("cursor tracker", () => {
   it("positions the caret from the marker column inside a bordered input box", () => {
     const frame = [
       "┌──────────────────┐",
-      `│ \u001b[31m${INPUT_MARKER}! \u001b[0mhello │`,
+      `│ \u001b[31m! \u001b[0m${INPUT_MARKER}hello │`,
       "└──────────────────┘",
     ].join("\n");
 

--- a/src/interface/tui/__tests__/mouse-tracking.test.ts
+++ b/src/interface/tui/__tests__/mouse-tracking.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { attachMouseTracking } from "../flicker/MouseTracking.js";
+import { DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING } from "../flicker/dec.js";
+
+function createMockStream(): NodeJS.WriteStream & { _written: string[] } {
+  const written: string[] = [];
+  return {
+    write: vi.fn((chunk: string) => {
+      written.push(chunk);
+      return true;
+    }),
+    _written: written,
+  } as unknown as NodeJS.WriteStream & { _written: string[] };
+}
+
+describe("mouse tracking", () => {
+  it("enables mouse tracking on attach and disables it on cleanup", () => {
+    const stream = createMockStream();
+
+    const cleanup = attachMouseTracking(stream);
+
+    expect(stream.write).toHaveBeenCalledWith(ENABLE_MOUSE_TRACKING);
+    expect(stream._written).toContain(ENABLE_MOUSE_TRACKING);
+
+    cleanup();
+
+    expect(stream._written.at(-1)).toBe(DISABLE_MOUSE_TRACKING);
+  });
+});

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -38,10 +38,16 @@ interface ChatProps {
 }
 
 const SCROLL_LINE_STEP = 3;
+const DEFAULT_PROMPT = "◉";
+const BASH_PROMPT = "!";
 
 export { buildChatViewport } from "./chat/viewport.js";
 export { getScrollRequest, stripMouseEscapeSequences } from "./chat/scroll.js";
 export { getMatchingSuggestions } from "./chat/suggestions.js";
+
+export function getInputPromptLabel(bashMode: boolean): string {
+  return bashMode ? BASH_PROMPT : DEFAULT_PROMPT;
+}
 
 export function Chat({
   messages,
@@ -356,7 +362,8 @@ export function Chat({
             paddingX={1}
           >
             <Text color={bashMode ? theme.command : theme.userPrompt} bold>
-              {`${INPUT_MARKER} `}
+              {INPUT_MARKER}
+              {getInputPromptLabel(bashMode)}{" "}
             </Text>
             <TextInput
               value={input}

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -13,6 +13,7 @@ import { theme } from "./theme.js";
 import { pickSpinnerVerb } from "./spinner-verbs.js";
 import { ShimmerText } from "./shimmer-text.js";
 import { INPUT_MARKER, positionCursorInFrame, buildCursorEscape } from "./cursor-tracker.js";
+import { HIDE_CURSOR, SHOW_CURSOR } from "./flicker/dec.js";
 import { isBashModeInput } from "./bash-mode.js";
 import { isRenderableFrameChunk } from "./render-output.js";
 import { buildChatViewport } from "./chat/viewport.js";
@@ -246,13 +247,15 @@ export function Chat({
     };
   }, []);
 
-  // Hide cursor during AI processing
+  // Keep the terminal's real cursor hidden in standard mode.
   React.useEffect(() => {
-    if (isProcessing) {
-      const original = process.stdout.write.bind(process.stdout);
-      original("\x1b[?25l");
-    }
-  }, [isProcessing]);
+    if (noFlicker) return;
+    const original = process.stdout.write.bind(process.stdout);
+    original(HIDE_CURSOR);
+    return () => {
+      original(SHOW_CURSOR);
+    };
+  }, [noFlicker]);
 
   const handleSubmit = (value: string) => {
     if (hasMatches) return; // let useInput handle enter when suggestions are shown

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -362,9 +362,9 @@ export function Chat({
             paddingX={1}
           >
             <Text color={bashMode ? theme.command : theme.userPrompt} bold>
-              {INPUT_MARKER}
               {getInputPromptLabel(bashMode)}{" "}
             </Text>
+            <Text>{INPUT_MARKER}</Text>
             <TextInput
               value={input}
               onChange={(val) => {

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -12,7 +12,7 @@ import { getClipboardContent } from "./clipboard.js";
 import { theme } from "./theme.js";
 import { pickSpinnerVerb } from "./spinner-verbs.js";
 import { ShimmerText } from "./shimmer-text.js";
-import { positionCursorInFrame, buildCursorEscape } from "./cursor-tracker.js";
+import { INPUT_MARKER, positionCursorInFrame, buildCursorEscape } from "./cursor-tracker.js";
 import { isBashModeInput } from "./bash-mode.js";
 import { isRenderableFrameChunk } from "./render-output.js";
 import { buildChatViewport } from "./chat/viewport.js";
@@ -350,13 +350,10 @@ export function Chat({
           <Box
             borderStyle="single"
             borderColor={bashMode ? theme.command : theme.border}
-            borderBottom={false}
-            borderLeft={false}
-            borderRight={false}
-          />
-          <Box>
+            paddingX={1}
+          >
             <Text color={bashMode ? theme.command : theme.userPrompt} bold>
-              {"​◉ "}
+              {`${INPUT_MARKER} `}
             </Text>
             <TextInput
               value={input}
@@ -368,13 +365,6 @@ export function Chat({
               placeholder={bashMode ? "! for bash mode" : "/ for commands"}
             />
           </Box>
-          <Box
-            borderStyle="single"
-            borderColor={bashMode ? theme.command : theme.border}
-            borderTop={false}
-            borderLeft={false}
-            borderRight={false}
-          />
           {bashMode && <Text color={theme.command}>! for bash mode</Text>}
           {emptyHint && (
             <Text dimColor> Type a message or /help for commands</Text>

--- a/src/interface/tui/cursor-tracker.ts
+++ b/src/interface/tui/cursor-tracker.ts
@@ -3,11 +3,11 @@
  * Used for IME candidate window positioning — avoids fragile arithmetic.
  */
 
-// Unique marker: zero-width space + ◉ — won't appear in message history
-export const INPUT_MARKER = "\u200B\u25C9";
+// Unique invisible marker — won't appear in message history or the visible prompt.
+export const INPUT_MARKER = "\u200B\u2060";
 const ZERO_WIDTH_SPACE = "\u200B";
 const ESCAPE_SEQUENCE = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
-const PROMPT_WIDTH = 2; // "◉ " prefix
+const PROMPT_WIDTH = 2; // one prompt glyph + trailing space
 
 function displayWidth(text: string): number {
   let width = 0;
@@ -46,7 +46,7 @@ export function findCursorRow(frame: string): number | null {
 
 /**
  * Compute the cursor x-position from the marker column and input text.
- * Prompt "◉ " = 2 columns. CJK chars = 2 columns each.
+ * Prompt "x " = 2 columns. CJK chars = 2 columns each.
  */
 export function computeCursorX(frame: string, input: string): number | null {
   const position = findInputMarkerPosition(frame);

--- a/src/interface/tui/cursor-tracker.ts
+++ b/src/interface/tui/cursor-tracker.ts
@@ -72,8 +72,8 @@ export function positionCursorInFrame(
   const row = findCursorRow(frame);
   const x = computeCursorX(frame, inputText);
   if (row === null || x === null) return;
-  // ANSI CSI: move to row;col (1-indexed) and show cursor
-  write(`\x1b[${row + 1};${x + 1}H\x1b[?25h`);
+  // ANSI CSI: move to row;col (1-indexed)
+  write(`\x1b[${row + 1};${x + 1}H`);
 }
 
 /**
@@ -88,5 +88,5 @@ export function buildCursorEscape(
   const row = findCursorRow(frame);
   const x = computeCursorX(frame, inputText);
   if (row === null || x === null) return null;
-  return `[${row + 1};${x + 1}H[?25h`;
+  return `\x1b[${row + 1};${x + 1}H`;
 }

--- a/src/interface/tui/cursor-tracker.ts
+++ b/src/interface/tui/cursor-tracker.ts
@@ -4,28 +4,55 @@
  */
 
 // Unique marker: zero-width space + ◉ — won't appear in message history
-const INPUT_MARKER = "\u200B\u25C9";
+export const INPUT_MARKER = "\u200B\u25C9";
+const ZERO_WIDTH_SPACE = "\u200B";
+const ESCAPE_SEQUENCE = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
+const PROMPT_WIDTH = 2; // "◉ " prefix
 
-/**
- * Find the row index of the input prompt in a rendered frame.
- * Returns null if the marker is not found (e.g., overlay is showing).
- */
-export function findCursorRow(frame: string): number | null {
+function displayWidth(text: string): number {
+  let width = 0;
+  for (const segment of text
+    .replace(ESCAPE_SEQUENCE, "")
+    .split(ZERO_WIDTH_SPACE)
+    .join("")) {
+    const cp = segment.codePointAt(0) ?? 0;
+    width += cp > 0x2E7F ? 2 : 1;
+  }
+  return width;
+}
+
+function findInputMarkerPosition(frame: string): { row: number; col: number } | null {
   const lines = frame.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].includes(INPUT_MARKER)) {
-      return i;
+  for (let row = 0; row < lines.length; row++) {
+    const line = lines[row];
+    const markerIndex = line.indexOf(INPUT_MARKER);
+    if (markerIndex >= 0) {
+      return {
+        row,
+        col: displayWidth(line.slice(0, markerIndex)),
+      };
     }
   }
   return null;
 }
 
 /**
- * Compute the cursor x-position from input text.
+ * Find the row index of the input prompt in a rendered frame.
+ * Returns null if the marker is not found (e.g., overlay is showing).
+ */
+export function findCursorRow(frame: string): number | null {
+  return findInputMarkerPosition(frame)?.row ?? null;
+}
+
+/**
+ * Compute the cursor x-position from the marker column and input text.
  * Prompt "◉ " = 2 columns. CJK chars = 2 columns each.
  */
-export function computeCursorX(input: string): number {
-  let width = 2; // "◉ " prefix
+export function computeCursorX(frame: string, input: string): number | null {
+  const position = findInputMarkerPosition(frame);
+  if (!position) return null;
+
+  let width = position.col + PROMPT_WIDTH;
   for (const ch of input) {
     const cp = ch.codePointAt(0) ?? 0;
     width += cp > 0x2E7F ? 2 : 1;
@@ -43,8 +70,8 @@ export function positionCursorInFrame(
   write: (s: string) => boolean,
 ): void {
   const row = findCursorRow(frame);
-  if (row === null) return;
-  const x = computeCursorX(inputText);
+  const x = computeCursorX(frame, inputText);
+  if (row === null || x === null) return;
   // ANSI CSI: move to row;col (1-indexed) and show cursor
   write(`\x1b[${row + 1};${x + 1}H\x1b[?25h`);
 }
@@ -59,7 +86,7 @@ export function buildCursorEscape(
   inputText: string,
 ): string | null {
   const row = findCursorRow(frame);
-  if (row === null) return null;
-  const x = computeCursorX(inputText);
+  const x = computeCursorX(frame, inputText);
+  if (row === null || x === null) return null;
   return `[${row + 1};${x + 1}H[?25h`;
 }

--- a/src/interface/tui/cursor-tracker.ts
+++ b/src/interface/tui/cursor-tracker.ts
@@ -7,7 +7,6 @@
 export const INPUT_MARKER = "\u200B\u2060";
 const ZERO_WIDTH_SPACE = "\u200B";
 const ESCAPE_SEQUENCE = /\u001b\[[0-9;?]*[ -/]*[@-~]/g;
-const PROMPT_WIDTH = 2; // one prompt glyph + trailing space
 
 function displayWidth(text: string): number {
   let width = 0;
@@ -46,13 +45,13 @@ export function findCursorRow(frame: string): number | null {
 
 /**
  * Compute the cursor x-position from the marker column and input text.
- * Prompt "x " = 2 columns. CJK chars = 2 columns each.
+ * The marker is rendered at the input start column. CJK chars = 2 columns each.
  */
 export function computeCursorX(frame: string, input: string): number | null {
   const position = findInputMarkerPosition(frame);
   if (!position) return null;
 
-  let width = position.col + PROMPT_WIDTH;
+  let width = position.col;
   for (const ch of input) {
     const cp = ch.codePointAt(0) ?? 0;
     width += cp > 0x2E7F ? 2 : 1;

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -18,7 +18,7 @@ import { isSafeBashCommand } from "./bash-mode.js";
 import { getCliLogger } from "../cli/cli-logger.js";
 import { ensureProviderConfig } from "../cli/ensure-api-key.js";
 import type { Task } from "../../base/types/task.js";
-import { isNoFlickerEnabled, createFrameWriter, AlternateScreen, type FrameWriter } from "./flicker/index.js";
+import { isNoFlickerEnabled, createFrameWriter, AlternateScreen, MouseTracking, type FrameWriter } from "./flicker/index.js";
 import { isRenderableFrameChunk } from "./render-output.js";
 
 // ─── Breadcrumb helpers ───
@@ -494,9 +494,13 @@ async function startTUIStandaloneMode(): Promise<void> {
   });
 
   const { waitUntilExit } = render(
-    noFlicker
-      ? React.createElement(AlternateScreen, { enabled: true }, appElement)
-      : appElement,
+    React.createElement(
+      MouseTracking,
+      null,
+      noFlicker
+        ? React.createElement(AlternateScreen, { enabled: true }, appElement)
+        : appElement,
+    ),
     { exitOnCtrlC: false }
   );
 
@@ -615,9 +619,13 @@ async function startTUIDaemonMode(): Promise<void> {
   });
 
   const { waitUntilExit } = render(
-    noFlicker
-      ? React.createElement(AlternateScreen, { enabled: true }, appElement)
-      : appElement,
+    React.createElement(
+      MouseTracking,
+      null,
+      noFlicker
+        ? React.createElement(AlternateScreen, { enabled: true }, appElement)
+        : appElement,
+    ),
     { exitOnCtrlC: false }
   );
 

--- a/src/interface/tui/flicker/MouseTracking.tsx
+++ b/src/interface/tui/flicker/MouseTracking.tsx
@@ -1,0 +1,36 @@
+import React, { useInsertionEffect } from "react";
+import { DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING } from "./dec.js";
+
+type MouseTrackingStream = Pick<NodeJS.WriteStream, "write">;
+
+export function attachMouseTracking(stream: MouseTrackingStream): () => void {
+  stream.write(ENABLE_MOUSE_TRACKING);
+
+  const disable = () => {
+    stream.write(DISABLE_MOUSE_TRACKING);
+  };
+
+  process.once("exit", disable);
+
+  return () => {
+    process.off("exit", disable);
+    disable();
+  };
+}
+
+interface MouseTrackingProps {
+  children?: React.ReactNode;
+  enabled?: boolean;
+}
+
+export function MouseTracking({
+  children,
+  enabled = true,
+}: MouseTrackingProps): React.ReactNode {
+  useInsertionEffect(() => {
+    if (!enabled) return;
+    return attachMouseTracking(process.stdout);
+  }, [enabled]);
+
+  return React.createElement(React.Fragment, null, children);
+}

--- a/src/interface/tui/flicker/dec.ts
+++ b/src/interface/tui/flicker/dec.ts
@@ -25,6 +25,12 @@ export const HIDE_CURSOR = "[?25l";
 /** Show cursor */
 export const SHOW_CURSOR = "[?25h";
 
+/** Enable SGR mouse tracking */
+export const ENABLE_MOUSE_TRACKING = "[?1000h[?1006h";
+
+/** Disable SGR mouse tracking */
+export const DISABLE_MOUSE_TRACKING = "[?1006l[?1000l";
+
 /** Build a cursor-park sequence for the given terminal row */
 export function parkCursor(rows: number): string {
   return `[${rows};1H`;

--- a/src/interface/tui/flicker/index.ts
+++ b/src/interface/tui/flicker/index.ts
@@ -1,9 +1,10 @@
 import { loadGlobalConfig } from "../../../base/config/global-config.js";
 
-export { ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, BSU, ESU, CURSOR_HOME, ERASE_SCREEN, HIDE_CURSOR, SHOW_CURSOR, parkCursor } from "./dec.js";
+export { ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, BSU, ESU, CURSOR_HOME, ERASE_SCREEN, HIDE_CURSOR, SHOW_CURSOR, ENABLE_MOUSE_TRACKING, DISABLE_MOUSE_TRACKING, parkCursor } from "./dec.js";
 export { isSynchronizedOutputSupported, isTmuxCC } from "./terminal-detect.js";
 export { createFrameWriter, type FrameWriter } from "./frame-writer.js";
 export { AlternateScreen } from "./AlternateScreen.js";
+export { MouseTracking, attachMouseTracking } from "./MouseTracking.js";
 
 /**
  * Check if no-flicker mode is enabled.


### PR DESCRIPTION
## Summary
- render the TUI chat input as a single bordered Ink box instead of split top/bottom faux lines
- keep the existing prompt marker while making cursor placement follow the marker column inside the rendered frame
- add a regression test for cursor escape generation inside the bordered input box

## Why
The chat input was visually approximated with two separate border lines around a plain text input, which did not render like a native Ink input box. Once the input was wrapped in a real bordered container, cursor positioning also needed to stop assuming the prompt started at column 0.

## Impact
- input field now uses the TUI border rendering directly
- cursor tracking stays aligned even with borders and ANSI styling around the prompt marker
- bash mode color switching remains unchanged

## Validation
- npx vitest run src/interface/tui/__tests__/chat.test.ts
- npm run typecheck -- --pretty false
