### PR TITLE
[codex] Hide execution adapter from setup wizard

### DIFF
--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -190,6 +190,25 @@ describe("setup notification step", () => {
     expect(prompt.options.some((option) => option.hint?.includes("recommended"))).toBe(false);
   });
 
+  it("asks for OpenAI auth without listing agent loop as a setup choice", async () => {
+    selectMock.mockResolvedValueOnce("api_key");
+
+    const { stepOpenAIAuthMethod } = await import("../commands/setup/steps-provider.js");
+    const result = await stepOpenAIAuthMethod(undefined, { canUseCodexOAuth: true });
+
+    expect(result).toBe("api_key");
+    const prompt = selectMock.mock.calls[0]?.[0] as {
+      message: string;
+      options: Array<{ label: string; value: string }>;
+    };
+    expect(prompt.message).toBe("Select OpenAI authentication:");
+    expect(prompt.options.map((option) => option.label)).toEqual([
+      "Codex OAuth",
+      "OpenAI API key",
+    ]);
+    expect(prompt.options.map((option) => option.value)).not.toContain("agent_loop");
+  });
+
   it("writes notification.json only after final confirmation", async () => {
     vi.doMock("../commands/setup/steps-identity.js", () => ({
       getBanner: () => "banner",
@@ -202,6 +221,7 @@ describe("setup notification step", () => {
       stepProvider: vi.fn(async () => "openai"),
       stepModel: vi.fn(async () => "gpt-5.4-mini"),
       stepApiKey: vi.fn(async () => "sk-test"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
       stepAdapter: vi.fn(async () => "openai_codex_cli"),
@@ -286,6 +306,7 @@ describe("setup notification step", () => {
       stepProvider: stepProviderMock,
       stepModel: vi.fn(async () => "gpt-5.4-mini"),
       stepApiKey: vi.fn(async () => "sk-test"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
       stepAdapter: vi.fn(async () => "openai_codex_cli"),
@@ -357,6 +378,7 @@ describe("setup notification step", () => {
       stepProvider: stepProviderMock,
       stepModel: vi.fn(async () => "gpt-5.4-mini"),
       stepApiKey: vi.fn(async () => "sk-test"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
       stepAdapter: vi.fn(async () => "openai_codex_cli"),
@@ -428,6 +450,7 @@ describe("setup notification step", () => {
       stepProvider: vi.fn(async () => "openai"),
       stepModel: vi.fn(async () => "gpt-5.4-mini"),
       stepApiKey: vi.fn(async () => "sk-existing"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
       stepAdapter: vi.fn(async () => "agent_loop"),
@@ -491,6 +514,74 @@ describe("setup notification step", () => {
     expect((saveProviderConfigMock.mock.calls[0] as unknown[] | undefined)?.[0]).not.toHaveProperty("api_key");
   });
 
+  it("preserves existing OpenAI API transport when updating auth settings", async () => {
+    const saveProviderConfigMock = vi.fn(async () => {});
+
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(async () => "modify"),
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: vi.fn(async () => "Seedy"),
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: vi.fn(async () => "openai"),
+      stepModel: vi.fn(async () => "gpt-5.4-mini"),
+      stepApiKey: vi.fn(async () => "sk-existing"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => "/tmp/pulseed-test"),
+      stepDaemon: vi.fn(async () => ({ start: false, port: 41700 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4-mini": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(async () => ({
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        adapter: "openai_api",
+        api_key: "sk-existing",
+      })),
+      saveProviderConfig: saveProviderConfigMock,
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    selectMock.mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    expect(saveProviderConfigMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        adapter: "openai_api",
+      })
+    );
+  });
+
   it("starts daemon and gateway after saving daemon config", async () => {
     const spawnChild = {
       pid: 12345,
@@ -522,6 +613,7 @@ describe("setup notification step", () => {
       stepProvider: vi.fn(async () => "openai"),
       stepModel: vi.fn(async () => "gpt-5.4-mini"),
       stepApiKey: vi.fn(async () => "sk-test"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
       stepAdapter: vi.fn(async () => "openai_codex_cli"),
@@ -625,6 +717,7 @@ describe("setup notification step", () => {
       stepProvider: vi.fn(async () => "openai"),
       stepModel: vi.fn(async () => "gpt-5.4-mini"),
       stepApiKey: vi.fn(async () => "sk-test"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
       stepAdapter: vi.fn(async () => "openai_codex_cli"),
@@ -745,6 +838,7 @@ describe("setup notification step", () => {
       stepProvider: stepProviderMock,
       stepModel: stepModelMock,
       stepApiKey: stepApiKeyMock,
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
       runCodexOAuthLogin: vi.fn(),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
@@ -891,6 +985,7 @@ describe("setup notification step", () => {
       stepProvider: vi.fn(async () => "openai"),
       stepModel: vi.fn(async () => "gpt-5.4"),
       stepApiKey: vi.fn(async () => "sk-imported"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
       runCodexOAuthLogin: vi.fn(),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
@@ -1012,6 +1107,7 @@ describe("setup notification step", () => {
       stepProvider: stepProviderMock,
       stepModel: stepModelMock,
       stepApiKey: stepApiKeyMock,
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
       stepAdapter: stepAdapterMock,
@@ -1126,6 +1222,7 @@ describe("setup notification step", () => {
       stepProvider: stepProviderMock,
       stepModel: stepModelMock,
       stepApiKey: stepApiKeyMock,
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
       runCodexOAuthLogin: vi.fn(),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
@@ -1232,6 +1329,7 @@ describe("setup notification step", () => {
       stepProvider: stepProviderMock,
       stepModel: stepModelMock,
       stepApiKey: stepApiKeyMock,
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
       runCodexOAuthLogin: vi.fn(),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
@@ -1347,6 +1445,7 @@ describe("setup notification step", () => {
       stepProvider: vi.fn(),
       stepModel: vi.fn(),
       stepApiKey: stepApiKeyMock,
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
       runCodexOAuthLogin: runCodexOAuthLoginMock,
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
@@ -1426,6 +1525,7 @@ describe("setup notification step", () => {
       stepProvider: vi.fn(async () => "openai"),
       stepModel: vi.fn(async () => "gpt-5.4-mini"),
       stepApiKey: vi.fn(async () => "sk-test"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
     }));
     vi.doMock("../commands/setup/steps-adapter.js", () => ({
       stepAdapter: vi.fn(async () => "openai_codex_cli"),

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -16,8 +16,7 @@ import { ROOT_PRESETS } from "./presets/root-presets.js";
 import { MODEL_REGISTRY, detectApiKeys, getAdaptersForModel, maskKey } from "./setup-shared.js";
 import type { Provider } from "./setup-shared.js";
 import { getBanner, stepExistingConfig, stepUserName, stepSeedyName } from "./setup/steps-identity.js";
-import { stepRootPreset, stepProvider, stepModel, stepApiKey, runCodexOAuthLogin } from "./setup/steps-provider.js";
-import { stepAdapter } from "./setup/steps-adapter.js";
+import { stepRootPreset, stepProvider, stepModel, stepApiKey, runCodexOAuthLogin, stepOpenAIAuthMethod } from "./setup/steps-provider.js";
 import { stepNotification } from "./setup/steps-notification.js";
 import { stepDaemon, ensurePulseedDir, writeSeedMd, writeRootMd, writeUserMd } from "./setup/steps-runtime.js";
 import { guardCancel } from "./setup/utils.js";
@@ -61,8 +60,8 @@ function formatSummary(answers: SetupAnswers): string {
     `Style:     ${ROOT_PRESETS[answers.rootPreset].name}`,
     `Provider:  ${answers.provider}`,
     `Model:     ${answers.model}`,
-    `Adapter:   ${answers.adapter}`,
-    `API Key:   ${maskKey(answers.apiKey)}`,
+    formatAuthSummary(answers),
+    formatCredentialSummary(answers),
     `Daemon:    ${answers.startDaemon ? `configured (port ${answers.daemonPort})` : "not configured"}`,
     `Notify:    ${notificationChannels}`,
   ].join("\n");
@@ -74,9 +73,29 @@ function formatExecutionSummary(
   return [
     `Provider:  ${execution.provider}`,
     `Model:     ${execution.model}`,
-    `Adapter:   ${execution.adapter}`,
-    `API Key:   ${maskKey(execution.apiKey)}`,
+    formatAuthSummary(execution),
+    formatCredentialSummary(execution),
   ].join("\n");
+}
+
+function formatAuthSummary(execution: Pick<SetupAnswers, "provider" | "adapter">): string {
+  if (execution.provider === "openai") {
+    return `Auth:      ${execution.adapter === "openai_codex_cli" ? "Codex OAuth" : "OpenAI API key"}`;
+  }
+  if (execution.provider === "anthropic") {
+    return "Auth:      Anthropic API key";
+  }
+  return "Auth:      local Ollama";
+}
+
+function formatCredentialSummary(execution: Pick<SetupAnswers, "provider" | "adapter" | "apiKey">): string {
+  if (execution.provider === "openai" && execution.adapter === "openai_codex_cli") {
+    return "Credential: Codex OAuth login";
+  }
+  if (execution.provider === "ollama") {
+    return "Credential: local runtime";
+  }
+  return `API Key:   ${maskKey(execution.apiKey)}`;
 }
 
 function formatImportSetupSummary(
@@ -98,14 +117,17 @@ function formatImportSetupSummary(
     providerPatch.api_key
       ? "found in imported settings"
       : providerPatch.provider === "ollama" || providerPatch.adapter === "openai_codex_cli"
-        ? "not required for this adapter"
+        ? "not required for this auth method"
         : "not found";
 
   return [
     `Source:    ${sourceNames}`,
     `Provider:  ${providerPatch.provider}`,
     `Model:     ${providerPatch.model ?? "not found"}`,
-    `Adapter:   ${providerPatch.adapter ?? "not found"}`,
+    formatAuthSummary({
+      provider: providerPatch.provider,
+      adapter: providerPatch.adapter ?? "agent_loop",
+    }),
     `API Key:   ${apiKeyStatus}`,
     `User:      ${selection.userSettings ? "imported USER.md" : "PulSeed will ask"}`,
     "Style:     Default",
@@ -180,7 +202,7 @@ async function stepMissingOpenAiAuth(
 ): Promise<{ adapter: string; apiKey?: string }> {
   const details = [
     "OpenAI API key was not found in the imported settings.",
-    `${adapter} uses the OpenAI API directly, so PulSeed needs an API key unless you switch to Codex CLI OAuth.`,
+    "PulSeed needs an OpenAI API key unless you use Codex CLI OAuth.",
   ];
   if (importedApiKey && isLikelyCodexOAuthToken(importedApiKey)) {
     details.push("The imported auth value looks like a Codex OAuth token, not an OpenAI API key.");
@@ -198,7 +220,7 @@ async function stepMissingOpenAiAuth(
               {
                 value: "oauth" as const,
                 label: "Use Codex CLI OAuth instead",
-                hint: `switch adapter for ${model} to OpenAI Codex CLI`,
+                hint: `use Codex CLI authentication for ${model}`,
               },
               {
                 value: "skip" as const,
@@ -247,6 +269,12 @@ async function stepMissingOpenAiAuth(
   return { adapter, apiKey };
 }
 
+function defaultExecutionAdapter(provider: Provider, model: string): string {
+  const adapters = getAdaptersForModel(model, provider);
+  if (adapters.includes("agent_loop")) return "agent_loop";
+  return adapters[0] ?? "";
+}
+
 async function stepExecutionConfig(
   current?: ExecutionAnswers,
   mode: "interactive" | "imported" = "interactive"
@@ -261,17 +289,28 @@ async function stepExecutionConfig(
           mode === "interactive" && current?.provider === provider ? current.model : undefined
         );
   const adaptersForModel = getAdaptersForModel(model, provider);
-  const adapter =
-    mode === "imported" && current?.adapter && adaptersForModel.includes(current.adapter)
+  const compatibleCurrentAdapter =
+    current?.adapter && adaptersForModel.includes(current.adapter)
       ? current.adapter
-      : await stepAdapter(
-          model,
-          provider,
-          mode === "interactive" && current?.provider === provider && adaptersForModel.includes(current.adapter)
-            ? current.adapter
-            : undefined
-        );
+      : undefined;
+  let adapter = compatibleCurrentAdapter ?? defaultExecutionAdapter(provider, model);
   if (!adapter) return { provider, model, adapter, apiKey: current?.apiKey };
+
+  if (
+    provider === "openai" &&
+    !(mode === "imported" && compatibleCurrentAdapter)
+  ) {
+    const authMethod = await stepOpenAIAuthMethod(
+      compatibleCurrentAdapter === "openai_codex_cli" ? "codex_oauth" : "api_key",
+      { canUseCodexOAuth: adaptersForModel.includes("openai_codex_cli") }
+    );
+    adapter =
+      authMethod === "codex_oauth"
+        ? "openai_codex_cli"
+        : compatibleCurrentAdapter && compatibleCurrentAdapter !== "openai_codex_cli"
+          ? compatibleCurrentAdapter
+          : defaultExecutionAdapter(provider, model);
+  }
 
   const detectedKeys = detectApiKeys();
   const openAiEnvKey = process.env["OPENAI_API_KEY"];
@@ -492,7 +531,7 @@ export async function runSetupWizard(): Promise<number> {
             message: "Save these provider settings?",
             options: [
               { value: "save" as const, label: "Save provider settings" },
-              { value: "edit" as const, label: "Edit provider, model, adapter" },
+              { value: "edit" as const, label: "Edit provider, model, auth" },
               { value: "cancel" as const, label: "Cancel setup" },
             ],
             initialValue: "save" as const,
@@ -605,7 +644,7 @@ export async function runSetupWizard(): Promise<number> {
           message: "Save this configuration?",
           options: [
             { value: "save" as const, label: "Save configuration", hint: "write files and finish" },
-            { value: "edit-execution" as const, label: "Edit provider, model, adapter" },
+            { value: "edit-execution" as const, label: "Edit provider, model, auth" },
             { value: "edit-identity" as const, label: "Edit user, agent, style" },
             { value: "edit-runtime" as const, label: "Edit daemon and notifications" },
             { value: "cancel" as const, label: "Cancel setup" },

--- a/src/interface/cli/commands/setup.ts
+++ b/src/interface/cli/commands/setup.ts
@@ -154,8 +154,16 @@ async function runNonInteractive(argv: string[]): Promise<number> {
   console.log("Setup complete! Configuration saved to ~/.pulseed/provider.json");
   console.log(`  Provider: ${config.provider}`);
   console.log(`  Model:    ${config.model}`);
-  console.log(`  Adapter:  ${config.adapter}`);
+  console.log(`  Auth:     ${formatAuthForSetup(config)}`);
   return 0;
+}
+
+function formatAuthForSetup(config: Pick<ProviderConfig, "provider" | "adapter">): string {
+  if (config.provider === "openai") {
+    return config.adapter === "openai_codex_cli" ? "Codex OAuth" : "OpenAI API key";
+  }
+  if (config.provider === "anthropic") return "Anthropic API key";
+  return "local Ollama";
 }
 
 // ─── Help text ───
@@ -167,7 +175,6 @@ Interactive setup wizard for provider configuration.
 Options:
   --provider <name>   LLM provider (openai, anthropic, ollama)
   --model <name>      Model name (e.g., gpt-5.4-mini)
-  --adapter <name>    Execution adapter (agent_loop, openai_codex_cli, claude_code_cli, etc.)
   --agentloop-worktree <on|off>
                       Enable isolated git worktrees for native task agentloop
   --agentloop-worktree-base-dir <path>
@@ -177,6 +184,9 @@ Options:
   --agentloop-worktree-cleanup <on_success|always|never>
                       Cleanup policy for isolated worktrees
   --help, -h          Show this help
+
+Advanced compatibility:
+  --adapter <name>    Legacy provider transport field (agent_loop, openai_codex_cli, etc.)
 
 Note: Non-interactive mode only configures provider settings. Identity files
 (SEED.md, ROOT.md, USER.md) are only configured in interactive mode.

--- a/src/interface/cli/commands/setup/steps-identity.ts
+++ b/src/interface/cli/commands/setup/steps-identity.ts
@@ -34,7 +34,6 @@ export async function stepExistingConfig(): Promise<"keep" | "modify" | "reset" 
     [
       `Provider: ${current.provider}`,
       `Model:    ${current.model}`,
-      `Adapter:  ${current.adapter}`,
       `API Key:  ${maskKey(current.api_key)}`,
     ].join("\n"),
     "Existing configuration found"
@@ -48,7 +47,7 @@ export async function stepExistingConfig(): Promise<"keep" | "modify" | "reset" 
         {
           value: "modify" as const,
           label: "Update provider settings",
-          hint: "reuse current provider/model/adapter as defaults",
+          hint: "reuse current provider and model as defaults",
         },
         { value: "reset" as const, label: "Run full setup again", hint: "recreate identity and optional settings" },
       ],

--- a/src/interface/cli/commands/setup/steps-provider.ts
+++ b/src/interface/cli/commands/setup/steps-provider.ts
@@ -14,6 +14,8 @@ import {
 import type { Provider } from "../setup-shared.js";
 import { guardCancel } from "./utils.js";
 
+export type OpenAIAuthMethod = "codex_oauth" | "api_key";
+
 export async function stepRootPreset(initialPreset?: RootPresetKey): Promise<RootPresetKey> {
   const preset = guardCancel(
     await p.select({
@@ -144,6 +146,39 @@ export async function runCodexOAuthLogin(): Promise<string | undefined> {
 
   p.log.error("Codex CLI not found. Install with: npm install -g @openai/codex");
   return undefined;
+}
+
+export async function stepOpenAIAuthMethod(
+  initialMethod?: OpenAIAuthMethod,
+  options: { canUseCodexOAuth?: boolean } = {}
+): Promise<OpenAIAuthMethod> {
+  const canUseCodexOAuth = options.canUseCodexOAuth ?? true;
+  const choices = [
+    ...(canUseCodexOAuth
+      ? [
+          {
+            value: "codex_oauth" as const,
+            label: "Codex OAuth",
+            hint: "uses your Codex CLI login",
+          },
+        ]
+      : []),
+    {
+      value: "api_key" as const,
+      label: "OpenAI API key",
+      hint: "uses OpenAI API billing",
+    },
+  ];
+
+  return guardCancel(
+    await p.select({
+      message: "Select OpenAI authentication:",
+      options: choices,
+      initialValue: canUseCodexOAuth
+        ? initialMethod ?? "codex_oauth"
+        : "api_key",
+    })
+  );
 }
 
 function isLikelyCodexOAuthToken(value: string | undefined): boolean {


### PR DESCRIPTION
## Summary
- Replace setup wizard execution-adapter selection with OpenAI auth selection.
- Keep the legacy providerConfig.adapter field internally for compatibility.
- Remove adapter wording from normal setup summaries and keep --adapter as an advanced compatibility option.

## Validation
- npx vitest run src/interface/cli/__tests__/cli-setup-notification.test.ts src/interface/cli/__tests__/cli-setup.test.ts src/interface/cli/__tests__/setup-shared.test.ts
- npm run typecheck

## Notes
- Existing compatible OpenAI API transport values are preserved when updating auth settings.