### PR TITLE
[codex] Make agent loop always on

### DIFF
--- a/src/base/llm/codex-llm-client.ts
+++ b/src/base/llm/codex-llm-client.ts
@@ -118,7 +118,7 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
     throw lastError;
   }
 
-  /** CodexLLMClient does not support function/tool calling. */
+  /** CodexLLMClient does not support native provider function/tool calling. */
   supportsToolCalling(): boolean { return false; }
 
   /**

--- a/src/base/llm/llm-client.ts
+++ b/src/base/llm/llm-client.ts
@@ -75,10 +75,11 @@ export interface ILLMClient {
   parseJSON<T>(content: string, schema: ZodSchema<T>): T;
   parseJSON<T>(content: string, schema: ZodSchema<T>, options: ParseJSONOptions): Promise<T>;
   /**
-   * Whether this client supports function/tool calling in sendMessage().
+   * Whether this client supports native provider function/tool calling in sendMessage().
+   * This does not decide whether PulSeed can run an agent loop; non-native clients
+   * can still use the prompted JSON/text tool protocol.
    * CLI-wrapping clients (e.g., CodexLLMClient) that cannot handle tool
    * definitions should override this to return false.
-   * When absent or returning true, the chat runner routes through executeWithTools.
    */
   supportsToolCalling?(): boolean;
 }

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import { z } from "zod";
 import { ChatRunner } from "../chat-runner.js";
 import type { ChatRunnerDeps } from "../chat-runner.js";
 import { StateManager } from "../../../base/state/state-manager.js";
@@ -800,7 +801,7 @@ describe("ChatRunner", () => {
     });
   });
 
-  describe("supportsToolCalling routing", () => {
+  describe("agent loop and native tool protocol routing", () => {
     it("routes to chatAgentLoopRunner when configured", async () => {
       const seenEvents: string[] = [];
       const approvalFn = vi.fn().mockResolvedValue(true);
@@ -878,18 +879,21 @@ describe("ChatRunner", () => {
       expect(seenEvents).toContain("tool_update");
     });
 
-    it("routes simple questions directly through llmClient even when chatAgentLoopRunner is configured", async () => {
+    it("routes simple questions through chatAgentLoopRunner when configured", async () => {
       const adapter = makeMockAdapter();
       const chatAgentLoopRunner = {
-        execute: vi.fn().mockRejectedValue(new Error("chatAgentLoopRunner must not be called")),
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "Agentloop direct answer",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
+        }),
       } as unknown as ChatAgentLoopRunner;
       const llmClient = {
         supportsToolCalling: () => true,
-        sendMessage: vi.fn().mockResolvedValue({
-          content: "Direct answer",
-          usage: { input_tokens: 4, output_tokens: 6 },
-          stop_reason: "end_turn",
-        }),
+        sendMessage: vi.fn().mockRejectedValue(new Error("direct llm path must not be called")),
         parseJSON: vi.fn(),
       };
 
@@ -900,29 +904,12 @@ describe("ChatRunner", () => {
       }));
       const result = await runner.execute("What is a lightweight direct-answer route?", "/repo");
 
-      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
-      const [messages, options] = (llmClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0] as [
-        Array<{ role: string; content: string }>,
-        Record<string, unknown> | undefined,
-      ];
-      expect(messages).toHaveLength(1);
-      expect(messages[0].role).toBe("user");
-      expect(messages[0].content).toContain("What is a lightweight direct-answer route?");
-      expect(options).toMatchObject({
-        model_tier: "light",
-        max_tokens: 256,
-      });
-      expect(options?.tools).toBeUndefined();
-      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
+      expect(llmClient.sendMessage).not.toHaveBeenCalled();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
-      expect(result.output).toBe("Direct answer");
-      expect(result.diagnostics).toEqual({
-        route: "direct",
-        reason: "simple_question",
-        modelTier: "light",
-        maxTokens: 256,
-      });
+      expect(result.output).toBe("Agentloop direct answer");
+      expect(result.diagnostics).toBeUndefined();
     });
 
     it("keeps diagnostics out of the user-facing output", async () => {
@@ -1015,20 +1002,55 @@ describe("ChatRunner", () => {
       expect(result.diagnostics).toBeUndefined();
     });
 
-    it("routes to adapter.execute when supportsToolCalling() returns false", async () => {
+    it("keeps non-native-tool clients on the local LLM/tool loop instead of the adapter fallback", async () => {
       const adapter = makeMockAdapter();
+      const echoTool = {
+        metadata: {
+          name: "echo",
+          aliases: [],
+          permissionLevel: "read_only" as const,
+          isReadOnly: true,
+          isDestructive: false,
+          shouldDefer: false,
+          alwaysLoad: false,
+          maxConcurrency: 0,
+          maxOutputChars: 1000,
+          tags: ["test"],
+        },
+        inputSchema: z.object({ value: z.string() }),
+        description: () => "Echo a value.",
+        checkPermissions: vi.fn().mockResolvedValue({ status: "allowed" }),
+        call: vi.fn().mockResolvedValue({ success: true, summary: "echoed hello", data: { echoed: "hello" } }),
+        isConcurrencySafe: () => true,
+      };
+      const registry = {
+        listAll: () => [echoTool],
+        get: (name: string) => name === "echo" ? echoTool : undefined,
+      };
       const llmClient = {
         supportsToolCalling: () => false,
-        sendMessage: vi.fn().mockRejectedValue(new Error("sendMessage must not be called")),
+        sendMessage: vi.fn()
+          .mockResolvedValueOnce({
+            content: '{ "tool_calls": [{ "name": "echo", "input": { "value": "hello", }, }] }',
+            usage: { input_tokens: 5, output_tokens: 5 },
+            stop_reason: "end_turn",
+          })
+          .mockResolvedValueOnce({
+            content: "Prompted loop response",
+            usage: { input_tokens: 5, output_tokens: 5 },
+            stop_reason: "end_turn",
+          }),
         parseJSON: vi.fn(),
       };
 
-      const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never }));
+      const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never, registry: registry as never }));
       const result = await runner.execute("Do something", "/repo");
 
-      expect(adapter.execute).toHaveBeenCalledOnce();
-      expect(llmClient.sendMessage).not.toHaveBeenCalled();
+      expect(llmClient.sendMessage).toHaveBeenCalledTimes(2);
+      expect(echoTool.call).toHaveBeenCalledOnce();
+      expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
+      expect(result.output).toBe("Prompted loop response");
     });
 
     it("routes to executeWithTools (calls sendMessage) when supportsToolCalling is absent", async () => {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -22,7 +22,7 @@ import type { ToolRegistry } from "../../tools/registry.js";
 import { toToolDefinitionsFiltered } from "../../tools/tool-definition-adapter.js";
 import type { ToolCallContext } from "../../tools/types.js";
 import type { ToolExecutor } from "../../tools/executor.js";
-import type { LLMMessage, LLMRequestOptions, LLMResponse } from "../../base/llm/llm-client.js";
+import type { LLMMessage, LLMRequestOptions, LLMResponse, ToolCallResult } from "../../base/llm/llm-client.js";
 import { TendCommand } from "./tend-command.js";
 import type { TendDeps } from "./tend-command.js";
 import { EventSubscriber } from "./event-subscriber.js";
@@ -35,6 +35,10 @@ import type {
   AgentLoopEventSink,
 } from "../../orchestrator/execution/agent-loop/agent-loop-events.js";
 import type { AgentLoopSessionState } from "../../orchestrator/execution/agent-loop/agent-loop-session-state.js";
+import {
+  buildPromptedToolProtocolSystemPrompt,
+  extractPromptedToolCalls,
+} from "../../orchestrator/execution/agent-loop/prompted-tool-protocol.js";
 import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
 import type { RuntimeControlService } from "../../runtime/control/index.js";
 import type {
@@ -667,7 +671,7 @@ export class ChatRunner {
       historyBlock = `Previous conversation:\n${lines}\n\nCurrent message:\n`;
     }
 
-    const directAnswerRoute = !resumeOnly && this.deps.llmClient !== undefined && shouldUseDirectAnswerRoute(input);
+    const directAnswerRoute = !resumeOnly && !this.deps.chatAgentLoopRunner && this.deps.llmClient !== undefined && shouldUseDirectAnswerRoute(input);
     const directPrompt = historyBlock ? `${historyBlock}${input}` : input;
 
     const start = Date.now();
@@ -840,9 +844,8 @@ export class ChatRunner {
       }
     }
 
-    // Use llmClient with self-knowledge tools when available (function calling path)
-    // Skip executeWithTools for clients that don't support tool calling (e.g. CodexLLMClient)
-    if (this.deps.llmClient && this.deps.llmClient.supportsToolCalling?.() !== false) {
+    // Prefer the local LLM/tool loop over the external adapter fallback whenever a client is available.
+    if (this.deps.llmClient) {
       try {
         const toolResult = await this.executeWithTools(prompt, eventContext, assistantBuffer, systemPrompt || undefined);
         const elapsed_ms = Date.now() - start;
@@ -1012,12 +1015,14 @@ export class ChatRunner {
       const tools = this.deps.registry
         ? toToolDefinitionsFiltered(this.deps.registry.listAll(), { activatedTools: this.activatedTools })
         : [];
+      const supportsNativeToolCalling = llmClient.supportsToolCalling?.() !== false;
       let response: LLMResponse;
       try {
         this.emitActivity("lifecycle", "Calling model...", eventContext, "lifecycle:model");
         response = await this.sendLLMMessage(llmClient, messages, {
-          tools,
-          ...(systemPrompt ? { system: systemPrompt } : {}),
+          ...(supportsNativeToolCalling
+            ? { tools, ...(systemPrompt ? { system: systemPrompt } : {}) }
+            : { system: buildPromptedToolProtocolSystemPrompt({ systemPrompt, tools }) }),
         }, assistantBuffer, eventContext);
       } catch (err) {
         console.error("[chat-runner] executeWithTools error:", err);
@@ -1025,15 +1030,36 @@ export class ChatRunner {
         throw new Error(`Sorry, I encountered an error processing your request${hint}.`);
       }
 
+      const toolCalls = response.tool_calls?.length
+        ? response.tool_calls
+        : supportsNativeToolCalling
+          ? []
+          : extractPromptedToolCalls({
+              content: response.content,
+              tools,
+              createId: () => `prompted-${loop}-${crypto.randomUUID()}`,
+            }).map((call): ToolCallResult => ({
+              id: call.id,
+              type: "function",
+              function: {
+                name: call.name,
+                arguments: JSON.stringify(call.input ?? {}),
+              },
+            }));
+
+      if (!supportsNativeToolCalling && toolCalls.length > 0) {
+        assistantBuffer.text = "";
+      }
+
       // No tool calls — return the text content
-      if (!response.tool_calls || response.tool_calls.length === 0) {
+      if (toolCalls.length === 0) {
         return assistantBuffer.text || response.content || "(no response)";
       }
 
       // Append assistant message, then process tool calls
       messages.push({ role: "assistant", content: response.content || "" });
 
-      for (const tc of response.tool_calls) {
+      for (const tc of toolCalls) {
         let args: Record<string, unknown> = {};
         try {
           args = JSON.parse(tc.function.arguments || "{}") as Record<string, unknown>;

--- a/src/orchestrator/execution/__tests__/task-lifecycle-cycle.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-cycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import { z } from "zod";
 import { StateManager } from "../../../base/state/state-manager.js";
@@ -245,6 +245,7 @@ describe("TaskLifecycle", async () => {
       approvalFn?: (task: Task) => Promise<boolean>;
       logger?: import("../../../runtime/logger.js").Logger;
       adapterRegistry?: import("../task/task-lifecycle.js").AdapterRegistry;
+      agentLoopRunner?: import("../agent-loop/task-agent-loop-runner.js").TaskAgentLoopRunner;
       execFileSyncFn?: (cmd: string, args: string[], opts: { cwd: string; encoding: "utf-8" }) => string;
     }
   ): TaskLifecycle {
@@ -333,6 +334,61 @@ describe("TaskLifecycle", async () => {
       const result = await lifecycle.runTaskCycle("goal-1", gapVector, context, adapter);
 
       expect(result.action).toBe("approval_denied");
+    });
+
+    it("native agent loop runs even when the external adapter circuit breaker is closed", async () => {
+      const llm = createMockLLMClient([
+        VALID_TASK_RESPONSE,
+        LLM_REVIEW_PASS,
+      ]);
+      const adapterExecute = vi.fn(async () => {
+        throw new Error("adapter execute should not be called");
+      });
+      const adapter = {
+        adapterType: "external-cli",
+        execute: adapterExecute,
+      } as import("../task/task-lifecycle.js").IAdapter;
+      const agentLoopRunner = {
+        runTask: vi.fn(async () => ({
+          success: true,
+          output: {
+            status: "done" as const,
+            finalAnswer: "native agent loop completed",
+            summary: "done",
+            filesChanged: [],
+            testsRun: [],
+            completionEvidence: ["native loop evidence"],
+            verificationHints: [],
+            blockers: [],
+          },
+          finalText: "native agent loop completed",
+          stopReason: "completed" as const,
+          elapsedMs: 123,
+          modelTurns: 1,
+          toolCalls: 1,
+          compactions: 0,
+          changedFiles: [],
+          commandResults: [],
+          traceId: "trace-1",
+          sessionId: "session-1",
+          turnId: "turn-1",
+        })),
+      } as unknown as import("../agent-loop/task-agent-loop-runner.js").TaskAgentLoopRunner;
+      const lifecycle = createLifecycle(llm, {
+        approvalFn: async () => true,
+        adapterRegistry: {
+          isAvailable: () => false,
+        } as unknown as import("../task/task-lifecycle.js").AdapterRegistry,
+        agentLoopRunner,
+      });
+      const gapVector = makeGapVector("goal-1", [{ name: "coverage", gap: 0.5 }]);
+      const context = makeDriveContext(["coverage"]);
+
+      const result = await lifecycle.runTaskCycle("goal-1", gapVector, context, adapter);
+
+      expect(result.action).toBe("completed");
+      expect(agentLoopRunner.runTask).toHaveBeenCalledTimes(1);
+      expect(adapterExecute).not.toHaveBeenCalled();
     });
 
     it("execution fails -> verify -> handleFailure", async () => {

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -24,8 +24,11 @@ import {
   ToolExecutorAgentLoopToolRuntime,
   ToolRegistryAgentLoopToolRouter,
   createAgentLoopSession,
+  createProviderNativeAgentLoopModelClient,
   defaultAgentLoopCapabilities,
+  extractPromptedToolCalls,
   parseAgentLoopModelRef,
+  shouldUseNativeTaskAgentLoop,
   withDefaultBudget,
   type AgentLoopModelClient,
   type AgentLoopModelInfo,
@@ -202,6 +205,105 @@ function finalJson(status = "done") {
 }
 
 describe("agentloop phase 0", () => {
+  it("enables native task agentloop regardless of legacy adapter or native tool support", () => {
+    const parseJSON = <T,>(content: string, schema: z.ZodSchema<T>): T => schema.parse(JSON.parse(content));
+    const toolCallingClient: ILLMClient = {
+      async sendMessage(): Promise<LLMResponse> {
+        return { content: "{}", usage: { input_tokens: 0, output_tokens: 0 }, stop_reason: "end_turn" };
+      },
+      parseJSON,
+      supportsToolCalling: () => true,
+    };
+    const noToolCallingClient: ILLMClient = {
+      async sendMessage(): Promise<LLMResponse> {
+        return { content: "{}", usage: { input_tokens: 0, output_tokens: 0 }, stop_reason: "end_turn" };
+      },
+      parseJSON,
+      supportsToolCalling: () => false,
+    };
+
+    expect(shouldUseNativeTaskAgentLoop({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      adapter: "openai_api",
+    }, toolCallingClient)).toBe(true);
+    expect(shouldUseNativeTaskAgentLoop({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      adapter: "claude_code_cli",
+      api_key: "sk-ant-test",
+    }, toolCallingClient)).toBe(true);
+    expect(shouldUseNativeTaskAgentLoop({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      adapter: "openai_codex_cli",
+    }, noToolCallingClient)).toBe(true);
+    expect(shouldUseNativeTaskAgentLoop({
+      provider: "ollama",
+      model: "qwen3:4b",
+      adapter: "openai_api",
+    }, noToolCallingClient)).toBe(true);
+  });
+
+  it("keeps non-tool-calling clients on the prompted protocol even when provider config has an API key", () => {
+    const modelInfo = makeModelInfo({ ref: { providerId: "openai", modelId: "gpt-5.4-mini" } });
+    const noToolCallingClient: ILLMClient = {
+      async sendMessage(): Promise<LLMResponse> {
+        return { content: "{}", usage: { input_tokens: 0, output_tokens: 0 }, stop_reason: "end_turn" };
+      },
+      parseJSON<T>(content: string, schema: z.ZodSchema<T>): T {
+        return schema.parse(JSON.parse(content));
+      },
+      supportsToolCalling: () => false,
+    };
+
+    const modelClient = createProviderNativeAgentLoopModelClient({
+      providerConfig: {
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        adapter: "openai_codex_cli",
+        api_key: "codex-oauth-token",
+      },
+      llmClient: noToolCallingClient,
+      modelRegistry: new StaticAgentLoopModelRegistry([modelInfo]),
+    });
+
+    expect(modelClient).toBeInstanceOf(ILLMClientAgentLoopModelClient);
+  });
+
+  it("parses explicit prompted tool-call JSON and preserves unknown tools for runtime feedback", () => {
+    let id = 0;
+    const calls = extractPromptedToolCalls({
+      content: `\`\`\`json
+      {
+        "tool_calls": [
+          { "name": "echo", "arguments": "{ \\"value\\": \\"hello\\", }" },
+          { "name": "unknown_tool", "input": {} }
+        ],
+      }
+      \`\`\``,
+      tools: [{
+        type: "function",
+        function: {
+          name: "echo",
+          description: "Echo a value.",
+          parameters: { type: "object" },
+        },
+      }],
+      createId: () => `call-test-${++id}`,
+    });
+
+    expect(calls).toEqual([{
+      id: "call-test-1",
+      name: "echo",
+      input: { value: "hello" },
+    }, {
+      id: "call-test-2",
+      name: "unknown_tool",
+      input: {},
+    }]);
+  });
+
   it("stores trace events and parses provider/model refs", async () => {
     const ref = parseAgentLoopModelRef("openai/gpt-test");
     expect(ref).toEqual({ providerId: "openai", modelId: "gpt-test" });
@@ -331,6 +433,67 @@ describe("agentloop phase 1", () => {
     expect(assistantMessages).toHaveLength(2);
     expect(assistantMessages[0]).toMatchObject({ phase: "commentary" });
     expect(assistantMessages[1]).toMatchObject({ phase: "final_candidate" });
+  });
+
+  it("falls back to a text protocol when the LLM client cannot use native tools", async () => {
+    const modelInfo = makeModelInfo({ capabilities: { ...defaultAgentLoopCapabilities, toolCalling: false } });
+    const llmCalls: Array<{ messages: LLMMessage[]; options?: LLMRequestOptions }> = [];
+    let callIndex = 0;
+    const llmClient: ILLMClient = {
+      async sendMessage(messages: LLMMessage[], options?: LLMRequestOptions): Promise<LLMResponse> {
+        llmCalls.push({ messages, options });
+        callIndex++;
+        if (callIndex === 1) {
+          return {
+            content: '{ "tool_calls": [{ "name": "echo", "input": { "value": "hello", }, }, { "name": "echo", "input": { "value": "again" } }] }',
+            usage: { input_tokens: 1, output_tokens: 1 },
+            stop_reason: "end_turn",
+          };
+        }
+        return {
+          content: finalJson(),
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn",
+        };
+      },
+      parseJSON<T>(content: string, schema: z.ZodSchema<T>): T {
+        return schema.parse(JSON.parse(content));
+      },
+      supportsToolCalling: () => false,
+    };
+    const { router, runtime } = makeToolRuntime();
+    const modelClient = new ILLMClientAgentLoopModelClient(llmClient, new StaticAgentLoopModelRegistry([modelInfo]));
+    const runner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+
+    const result = await runner.run({
+      session: createAgentLoopSession(),
+      turnId: "turn-1",
+      goalId: "goal-1",
+      taskId: "task-1",
+      cwd: process.cwd(),
+      model: modelInfo.ref,
+      modelInfo,
+      messages: [{ role: "user", content: "do it" }],
+      outputSchema: z.object({ status: z.literal("done"), finalAnswer: z.string() }),
+      budget: withDefaultBudget({ maxModelTurns: 4 }),
+      toolPolicy: {},
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output?.finalAnswer).toBe("finished");
+    expect(result.toolCalls).toBe(2);
+    expect(llmCalls).toHaveLength(2);
+    expect(llmCalls[0]?.options?.tools).toBeUndefined();
+    expect(llmCalls[0]?.options?.system).toContain("You do not have native function/tool calling");
+    expect(llmCalls[0]?.options?.system).toContain("Available tools:");
+    expect(llmCalls[1]?.messages.some((message) => message.role === "user" && message.content.startsWith("Tool result"))).toBe(true);
   });
 
   it("stops after the schema repair budget is exhausted", async () => {

--- a/src/orchestrator/execution/agent-loop/agent-loop-budget.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-budget.ts
@@ -31,7 +31,6 @@ export type AgentLoopStopReason =
   | "consecutive_tool_errors"
   | "stalled_tool_loop"
   | "schema_error"
-  | "model_without_tool_calling"
   | "cancelled"
   | "protocol_incomplete"
   | "completion_gate_failed"

--- a/src/orchestrator/execution/agent-loop/agent-loop-model-client-factory.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model-client-factory.ts
@@ -10,6 +10,10 @@ export function createProviderNativeAgentLoopModelClient(input: {
   llmClient: ILLMClient;
   modelRegistry: AgentLoopModelRegistry;
 }): AgentLoopModelClient {
+  if (input.llmClient.supportsToolCalling?.() === false) {
+    return new ILLMClientAgentLoopModelClient(input.llmClient, input.modelRegistry);
+  }
+
   if (input.providerConfig.provider === "openai" && input.providerConfig.api_key) {
     return new OpenAIResponsesAgentLoopModelClient(
       {

--- a/src/orchestrator/execution/agent-loop/agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model-client.ts
@@ -15,6 +15,10 @@ import type {
   AgentLoopModelTurnProtocol,
   AgentLoopToolCall,
 } from "./agent-loop-model.js";
+import {
+  buildPromptedToolProtocolSystemPrompt,
+  extractPromptedToolCalls,
+} from "./prompted-tool-protocol.js";
 
 export class ILLMClientAgentLoopModelClient implements AgentLoopModelClient {
   constructor(
@@ -39,23 +43,31 @@ export class ILLMClientAgentLoopModelClient implements AgentLoopModelClient {
 
   async createTurnProtocol(input: AgentLoopModelRequest): Promise<AgentLoopModelTurnProtocol> {
     const messages = this.toLLMMessages(input.messages);
+    const supportsNativeToolCalling = this.llmClient.supportsToolCalling?.() !== false;
     const response = await this.llmClient.sendMessage(messages, {
       model: input.model.modelId,
-      system: input.system,
+      ...(supportsNativeToolCalling
+        ? { system: input.system }
+        : { system: buildPromptedToolProtocolSystemPrompt({ systemPrompt: input.system, tools: input.tools }) }),
       max_tokens: input.maxOutputTokens,
-      tools: input.tools,
+      ...(supportsNativeToolCalling ? { tools: input.tools } : {}),
     });
 
-    const toolCalls = response.tool_calls ?? [];
-    const assistant: AgentLoopAssistantOutput[] = response.content || toolCalls.length > 0
+    const toolCalls = supportsNativeToolCalling
+      ? (response.tool_calls ?? []).map((call) => this.toAgentLoopToolCall(call))
+      : extractPromptedToolCalls({ content: response.content, tools: input.tools });
+    const assistantContent = supportsNativeToolCalling
+      ? response.content
+      : (toolCalls.length > 0 ? `Calling ${toolCalls.map((call) => call.name).join(", ")}` : response.content);
+    const assistant: AgentLoopAssistantOutput[] = assistantContent
       ? [{
-          content: response.content || `Calling ${toolCalls.map((call) => call.function.name).join(", ")}`,
+          content: assistantContent,
           phase: toolCalls.length > 0 ? "commentary" : "final_answer",
         }]
       : [];
     return {
       assistant,
-      toolCalls: toolCalls.map((call) => this.toAgentLoopToolCall(call)),
+      toolCalls,
       stopReason: response.stop_reason,
       responseCompleted: true,
       usage: {
@@ -89,4 +101,5 @@ export class ILLMClientAgentLoopModelClient implements AgentLoopModelClient {
       input,
     };
   }
+
 }

--- a/src/orchestrator/execution/agent-loop/agent-loop-model.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model.ts
@@ -7,6 +7,7 @@ export interface AgentLoopModelRef {
 }
 
 export interface AgentLoopModelCapabilities {
+  /** Native provider function/tool calling support; prompted text protocols can still run the loop. */
   toolCalling: boolean;
   parallelToolCalls: boolean;
   streaming: boolean;

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -58,10 +58,6 @@ export class BoundedAgentLoopRunner {
       });
     }
 
-    if (!turn.modelInfo.capabilities.toolCalling) {
-      return this.stop(turn, "model_without_tool_calling", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, [], commandResults);
-    }
-
     let messages: AgentLoopMessage[] = resumed?.messages ? [...resumed.messages] : [...turn.messages];
     const preTurnCompaction = await this.compactIfNeeded(turn, messages, "pre_turn", "context_limit", undefined, compactions);
     if (preTurnCompaction.error) {

--- a/src/orchestrator/execution/agent-loop/index.ts
+++ b/src/orchestrator/execution/agent-loop/index.ts
@@ -26,6 +26,7 @@ export * from "./core-loop-control-tools.js";
 export * from "./core-phase-runner.js";
 export * from "./openai-responses-agent-loop-model-client.js";
 export * from "./agent-loop-prompts.js";
+export * from "./prompted-tool-protocol.js";
 export * from "./task-agent-loop-context.js";
 export * from "./task-agent-loop-factory.js";
 export * from "./task-agent-loop-result.js";

--- a/src/orchestrator/execution/agent-loop/prompted-tool-protocol.ts
+++ b/src/orchestrator/execution/agent-loop/prompted-tool-protocol.ts
@@ -1,0 +1,100 @@
+import { randomUUID } from "node:crypto";
+import type { ToolDefinition } from "../../../base/llm/llm-client.js";
+import { extractJSON } from "../../../base/llm/base-llm-client.js";
+import { sanitizeLLMJson } from "../../../base/llm/json-sanitizer.js";
+
+export interface PromptedToolCall {
+  id: string;
+  name: string;
+  input: unknown;
+}
+
+export function buildPromptedToolProtocolSystemPrompt(input: {
+  systemPrompt?: string;
+  tools: ToolDefinition[];
+}): string {
+  const toolDefinitions = input.tools.length > 0
+    ? input.tools.map((tool) => [
+        `- ${tool.function.name}: ${tool.function.description}`,
+        `  input schema: ${JSON.stringify(tool.function.parameters)}`,
+      ].join("\n")).join("\n")
+    : "- No tools are available.";
+
+  return [
+    input.systemPrompt?.trim() ?? "",
+    "You do not have native function/tool calling in this turn.",
+    "If you need to call tools, return exactly one JSON object and nothing else.",
+    'For one tool, use { "tool": "<name>", "input": { ... } } or { "tool_call": { "name": "<name>", "input": { ... } } }.',
+    'For multiple tools, use { "tool_calls": [{ "name": "<name>", "input": { ... } }] }.',
+    "Only use tool names listed below.",
+    "Available tools:",
+    toolDefinitions,
+  ].filter((part) => part.trim().length > 0).join("\n\n");
+}
+
+export function extractPromptedToolCalls(input: {
+  content: string;
+  tools: ToolDefinition[];
+  createId?: () => string;
+}): PromptedToolCall[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(sanitizeLLMJson(extractJSON(input.content))) as unknown;
+  } catch {
+    return [];
+  }
+
+  return normalizePromptedToolCalls(parsed, input.createId ?? randomUUID);
+}
+
+function normalizePromptedToolCalls(
+  value: unknown,
+  createId: () => string,
+): PromptedToolCall[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => normalizePromptedToolCall(item, createId, true));
+  }
+
+  if (!value || typeof value !== "object") return [];
+  const record = value as Record<string, unknown>;
+
+  if (Array.isArray(record["tool_calls"])) {
+    return record["tool_calls"].flatMap((item) => normalizePromptedToolCall(item, createId, true));
+  }
+
+  if (record["tool_call"] && typeof record["tool_call"] === "object") {
+    return normalizePromptedToolCall(record["tool_call"], createId, true);
+  }
+
+  return normalizePromptedToolCall(record, createId, false);
+}
+
+function normalizePromptedToolCall(
+  value: unknown,
+  createId: () => string,
+  allowNameField: boolean,
+): PromptedToolCall[] {
+  if (!value || typeof value !== "object") return [];
+  const record = value as Record<string, unknown>;
+  const name = typeof record["tool"] === "string"
+    ? record["tool"]
+    : allowNameField && typeof record["name"] === "string"
+      ? record["name"]
+      : null;
+  if (!name) return [];
+
+  return [{
+    id: createId(),
+    name,
+    input: normalizePromptedInput(record["input"] ?? record["arguments"] ?? {}),
+  }];
+}
+
+function normalizePromptedInput(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(sanitizeLLMJson(extractJSON(value))) as unknown;
+  } catch {
+    return value;
+  }
+}

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
@@ -36,10 +36,11 @@ export interface NativeTaskAgentLoopRuntimeDeps {
 }
 
 export function shouldUseNativeTaskAgentLoop(
-  providerConfig: ProviderConfig,
-  llmClient: ILLMClient,
+  _providerConfig: ProviderConfig,
+  _llmClient: ILLMClient,
 ): boolean {
-  return providerConfig.adapter === "agent_loop" && llmClient.supportsToolCalling?.() !== false;
+  // Agent loop eligibility is independent of provider/auth and native tool-call support.
+  return true;
 }
 
 export function createNativeTaskAgentLoopRunner(

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -583,7 +583,7 @@ export class TaskLifecycle {
       attempt: task.consecutive_failure_count + 1,
     });
 
-    if (this.adapterRegistry && !this.adapterRegistry.isAvailable(adapter.adapterType)) {
+    if (!this.agentLoopRunner && this.adapterRegistry && !this.adapterRegistry.isAvailable(adapter.adapterType)) {
       const reason = `Adapter circuit breaker is open for "${adapter.adapterType}"`;
       const now = new Date().toISOString();
       const blockedTask = {


### PR DESCRIPTION
## Summary
- make the native PulSeed agent loop always available independent of provider/auth/legacy adapter selection
- add a prompted JSON/text tool protocol for clients without native provider tool calling
- keep external adapter circuit breakers from blocking native agent-loop execution and prevent chat shortcuts from bypassing the loop

## Validation
- npm run typecheck
- npx vitest run src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/orchestrator/execution/__tests__/task-lifecycle-cycle.test.ts
- npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-runner-tools.test.ts src/interface/chat/__tests__/chat-runner-permissions.test.ts src/interface/chat/__tests__/tool-filtering.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/orchestrator/execution/agent-loop/__tests__ src/orchestrator/execution/__tests__/task-lifecycle-cycle.test.ts src/interface/cli/__tests__/cli-setup-notification.test.ts src/interface/cli/__tests__/cli-setup.test.ts src/interface/cli/__tests__/setup-shared.test.ts
