### PR TITLE
[codex] Add Soil display builtin integration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,7 @@ Common directories:
 - `memory/`
 - `chat/`
 - `plugins/`
+- `plugins-imported-disabled/`
 
 Depending on the features in use, you may also see:
 
@@ -163,6 +164,12 @@ Depending on the features in use, you may also see:
 - runtime health snapshots
 - Soil projections and indexes
 - schedule suggestions and approval state
+
+`plugins/` contains installed PulSeed-native plugins. Foreign plugins imported
+from Hermes Agent or OpenClaw are copied to `plugins-imported-disabled/` with a
+compatibility report and are not loaded until reviewed. Builtin integrations
+such as `soil-display`, `mcp-bridge`, and `foreign-plugin-bridge` ship with the
+runtime and are reported separately from installed plugins.
 
 ## 8. Skills
 

--- a/docs/design/infrastructure/plugin-architecture.md
+++ b/docs/design/infrastructure/plugin-architecture.md
@@ -41,6 +41,37 @@ What belongs in PulSeed's core should be minimal. Use the following criteria:
 
 This principle keeps the PulSeed core small and delegates service-specific logic to plugins.
 
+### Builtin Integrations
+
+PulSeed also has builtin integrations. They are plugin-like capabilities that
+ship with the runtime and are registered from code, not dynamically imported
+from `~/.pulseed/plugins`. They are used for standard bridges that many users
+need and that must share PulSeed's trust boundary.
+
+Current builtin integrations:
+
+| ID | Role |
+|---|---|
+| `soil-display` | Materializes typed Soil records/pages into publishable Markdown for Obsidian, Notion, and other display sinks |
+| `mcp-bridge` | Imports MCP server configuration while keeping imported servers disabled until reviewed |
+| `foreign-plugin-bridge` | Classifies Hermes/OpenClaw plugin manifests before quarantine copy |
+
+Builtin integrations are reported separately from installed plugins. They may
+prepare or bridge data for tools, but they are not user-installed code and are
+not loaded through `PluginLoader`.
+
+### Foreign Plugin Import Boundary
+
+Hermes Agent and OpenClaw plugins can be discovered during setup import, but
+they are not enabled automatically. PulSeed copies them to
+`plugins-imported-disabled/<source>/...`, records a compatibility report, and
+requires review before conversion into a PulSeed-native plugin or bridge.
+
+MCP servers and skills are easier to import because they have narrower
+contracts. MCP servers are merged disabled, and skills are copied as local
+skill documents. Arbitrary foreign plugin code remains quarantined until its
+manifest, permissions, and execution model are compatible with PulSeed.
+
 ---
 
 ## §2 Plugin Types

--- a/docs/design/knowledge/soil-system.md
+++ b/docs/design/knowledge/soil-system.md
@@ -33,6 +33,12 @@ Legacy `.index/soil.db` remains the old `file-json-v1` Markdown snapshot and is
 kept as a fallback path. The new SQLite retrieval store uses `.index/soil.sqlite`
 so the two formats do not conflict.
 
+Display integrations use the Markdown projection contract. Obsidian and Notion
+do not read `soil_records` directly; the builtin `soil-display` integration
+first materializes typed `soil_pages` into the Markdown tree and fallback
+projects active typed records that do not yet have a page. Snapshot consumers
+then read the publishable Markdown tree.
+
 ---
 
 ## 2. Record Model

--- a/src/base/llm/__tests__/provider-config.test.ts
+++ b/src/base/llm/__tests__/provider-config.test.ts
@@ -319,7 +319,7 @@ describe("loadProviderConfig", () => {
   const envKeys = [
     "PULSEED_PROVIDER", "PULSEED_LLM_PROVIDER",
     "PULSEED_ADAPTER", "PULSEED_DEFAULT_ADAPTER",
-    "PULSEED_MODEL",
+    "PULSEED_MODEL", "PULSEED_LIGHT_MODEL",
     "OPENAI_API_KEY", "OPENAI_MODEL", "OPENAI_BASE_URL",
     "ANTHROPIC_API_KEY", "ANTHROPIC_MODEL",
     "OLLAMA_BASE_URL", "OLLAMA_MODEL",
@@ -466,5 +466,19 @@ describe("loadProviderConfig", () => {
     expect(config.provider).toBe("ollama");
     expect(config.adapter).toBe("openai_api");
     expect(config.api_key).toBe("sk-env");
+  });
+
+  it("PULSEED_LIGHT_MODEL env var overrides file light_model", async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      provider: "openai",
+      model: "gpt-5.4",
+      light_model: "gpt-file-light",
+      adapter: "openai_codex_cli",
+    }));
+    process.env["PULSEED_LIGHT_MODEL"] = "gpt-env-light";
+
+    const config = await loadProviderConfig();
+    expect(config.light_model).toBe("gpt-env-light");
   });
 });

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -147,8 +147,13 @@ interface LegacyProviderConfig {
 
 // ─── Constants ───
 
-const PROVIDER_CONFIG_PATH = path.join(getPulseedDirPath(), "provider.json");
-const PROVIDER_ENV_PATH = path.join(getPulseedDirPath(), ".env");
+function providerConfigPath(baseDir = getPulseedDirPath()): string {
+  return path.join(baseDir, "provider.json");
+}
+
+function providerEnvPath(baseDir = getPulseedDirPath()): string {
+  return path.join(baseDir, ".env");
+}
 
 const DEFAULT_PROVIDER_CONFIG: ProviderConfig = {
   provider: "openai",
@@ -363,6 +368,13 @@ function resolveBaseUrl(
   return fileUrl;
 }
 
+function resolveLightModel(
+  fileLightModel: string | undefined,
+  envFile: Record<string, string>
+): string | undefined {
+  return process.env["PULSEED_LIGHT_MODEL"] ?? envFile["PULSEED_LIGHT_MODEL"] ?? fileLightModel;
+}
+
 function parseEnvFile(raw: string): Record<string, string> {
   const entries = raw
     .split(/\r?\n/)
@@ -377,15 +389,139 @@ function parseEnvFile(raw: string): Record<string, string> {
   return Object.fromEntries(entries);
 }
 
-async function readProviderEnvFile(): Promise<Record<string, string>> {
+async function readProviderEnvFile(baseDir?: string): Promise<Record<string, string>> {
   try {
-    return parseEnvFile(await fsp.readFile(PROVIDER_ENV_PATH, "utf-8"));
+    return parseEnvFile(await fsp.readFile(providerEnvPath(baseDir), "utf-8"));
   } catch {
     return {};
   }
 }
 
 // ─── Public API ───
+
+export interface LoadProviderConfigOptions {
+  baseDir?: string;
+  saveMigration?: boolean;
+}
+
+interface LoadedProviderFileConfig {
+  fileConfig: Partial<ProviderConfig>;
+  needsMigrationSave: boolean;
+}
+
+async function loadProviderFileConfig(configPath: string): Promise<LoadedProviderFileConfig> {
+  try {
+    await fsp.access(configPath);
+  } catch {
+    return { fileConfig: {}, needsMigrationSave: false };
+  }
+
+  try {
+    const raw = await fsp.readFile(configPath, "utf-8");
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (isLegacyConfig(parsed)) {
+      return {
+        fileConfig: migrateProviderConfig(parsed as unknown as LegacyProviderConfig),
+        needsMigrationSave: true,
+      };
+    }
+    return { fileConfig: parsed as Partial<ProviderConfig>, needsMigrationSave: false };
+  } catch {
+    return { fileConfig: {}, needsMigrationSave: false };
+  }
+}
+
+function resolveCompatibleModel(
+  resolvedModel: { model: string; source: ModelSource },
+  provider: ProviderConfig["provider"],
+  adapter: ProviderConfig["adapter"]
+): string {
+  const registryEntry = MODEL_REGISTRY[resolvedModel.model];
+  if (!registryEntry || registryEntry.adapters.includes(adapter)) {
+    return resolvedModel.model;
+  }
+
+  if (resolvedModel.source === "file") {
+    console.warn(
+      `[provider-config] Model "${resolvedModel.model}" is not compatible with adapter "${adapter}". Keeping provider.json model and relying on validation to surface the mismatch.`
+    );
+    return resolvedModel.model;
+  }
+
+  const fallback = defaultModelForProvider(provider);
+  console.warn(
+    `[provider-config] Model "${resolvedModel.model}" is not compatible with adapter "${adapter}". Falling back to "${fallback}".`
+  );
+  return fallback;
+}
+
+async function resolveApiKeyWithFallback(
+  fileKey: string | undefined,
+  provider: ProviderConfig["provider"],
+  adapter: ProviderConfig["adapter"],
+  envFile: Record<string, string>
+): Promise<string | undefined> {
+  const apiKey = resolveApiKey(fileKey, provider, adapter, envFile);
+  if (apiKey || provider !== "openai" || adapter !== "openai_codex_cli") {
+    return apiKey;
+  }
+  return readCodexOAuthToken();
+}
+
+async function resolveProviderConfig(
+  fileConfig: Partial<ProviderConfig>,
+  envFile: Record<string, string>
+): Promise<ProviderConfig> {
+  const provider = resolveProvider(fileConfig.provider);
+  const adapter = resolveAdapter(fileConfig.adapter);
+  const model = resolveCompatibleModel(resolveModel(fileConfig.model, provider), provider, adapter);
+  const apiKey = await resolveApiKeyWithFallback(fileConfig.api_key, provider, adapter, envFile);
+  const baseUrl = resolveBaseUrl(fileConfig.base_url, provider, envFile);
+  const lightModel = resolveLightModel(fileConfig.light_model, envFile);
+
+  const config: ProviderConfig = { provider, model, adapter };
+  if (apiKey !== undefined) config.api_key = apiKey;
+  if (baseUrl !== undefined) config.base_url = baseUrl;
+  if (fileConfig.codex_cli_path !== undefined) config.codex_cli_path = fileConfig.codex_cli_path;
+  if (fileConfig.terminal_backend !== undefined) config.terminal_backend = fileConfig.terminal_backend;
+  if (fileConfig.a2a !== undefined) config.a2a = fileConfig.a2a;
+  if (lightModel !== undefined) config.light_model = lightModel;
+  if (fileConfig.openclaw !== undefined) config.openclaw = fileConfig.openclaw;
+  if (fileConfig.agent_loop !== undefined) config.agent_loop = fileConfig.agent_loop;
+  return config;
+}
+
+function warnOnceForInvalidProviderConfig(config: ProviderConfig): void {
+  const validation = validateProviderConfig(config);
+  if (validation.valid || _warnedOnce) return;
+  for (const err of validation.errors) {
+    console.warn(`[provider-config] Warning: ${err}`);
+  }
+  _warnedOnce = true;
+}
+
+function providerFileOnlyConfig(fileConfig: Partial<ProviderConfig>): ProviderConfig {
+  const fileOnly: ProviderConfig = {
+    provider: fileConfig.provider ?? "openai",
+    model: fileConfig.model ?? "gpt-5.4-mini",
+    adapter: fileConfig.adapter ?? "openai_codex_cli",
+  };
+  if (fileConfig.api_key !== undefined) fileOnly.api_key = fileConfig.api_key;
+  if (fileConfig.base_url !== undefined) fileOnly.base_url = fileConfig.base_url;
+  if (fileConfig.codex_cli_path !== undefined) fileOnly.codex_cli_path = fileConfig.codex_cli_path;
+  if (fileConfig.terminal_backend !== undefined) fileOnly.terminal_backend = fileConfig.terminal_backend;
+  if (fileConfig.a2a !== undefined) fileOnly.a2a = fileConfig.a2a;
+  if (fileConfig.agent_loop !== undefined) fileOnly.agent_loop = fileConfig.agent_loop;
+  return fileOnly;
+}
+
+async function saveMigratedProviderConfig(configPath: string, fileConfig: Partial<ProviderConfig>): Promise<void> {
+  try {
+    await writeJsonFileAtomic(configPath, providerFileOnlyConfig(fileConfig));
+  } catch {
+    // Best-effort — don't fail if we can't save
+  }
+}
 
 /**
  * Load provider configuration.
@@ -397,100 +533,15 @@ async function readProviderEnvFile(): Promise<Record<string, string>> {
  *
  * Auto-migrates old nested format to new flat format.
  */
-export async function loadProviderConfig(): Promise<ProviderConfig> {
-  let fileConfig: Partial<ProviderConfig> = {};
-  let needsMigrationSave = false;
-  const envFile = await readProviderEnvFile();
-
-  try {
-    await fsp.access(PROVIDER_CONFIG_PATH);
-    try {
-      const raw = await fsp.readFile(PROVIDER_CONFIG_PATH, "utf-8");
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-
-      if (isLegacyConfig(parsed)) {
-        fileConfig = migrateProviderConfig(parsed as unknown as LegacyProviderConfig);
-        needsMigrationSave = true;
-      } else {
-        fileConfig = parsed as Partial<ProviderConfig>;
-      }
-    } catch {
-      fileConfig = {};
-    }
-  } catch {
-    // File does not exist
+export async function loadProviderConfig(options: LoadProviderConfigOptions = {}): Promise<ProviderConfig> {
+  const envFile = await readProviderEnvFile(options.baseDir);
+  const configPath = providerConfigPath(options.baseDir);
+  const { fileConfig, needsMigrationSave } = await loadProviderFileConfig(configPath);
+  const config = await resolveProviderConfig(fileConfig, envFile);
+  warnOnceForInvalidProviderConfig(config);
+  if (needsMigrationSave && options.saveMigration !== false) {
+    await saveMigratedProviderConfig(configPath, fileConfig);
   }
-
-  const provider = resolveProvider(fileConfig.provider);
-  const resolvedModel = resolveModel(fileConfig.model, provider);
-  let model = resolvedModel.model;
-  const adapter = resolveAdapter(fileConfig.adapter);
-
-  // Only env/default-selected models are auto-corrected. Explicit provider.json
-  // models are preserved and surfaced as warnings instead of being replaced.
-  const registryEntry = MODEL_REGISTRY[model];
-  if (registryEntry && !registryEntry.adapters.includes(adapter)) {
-    if (resolvedModel.source === "file") {
-      console.warn(
-        `[provider-config] Model "${model}" is not compatible with adapter "${adapter}". Keeping provider.json model and relying on validation to surface the mismatch.`
-      );
-    } else {
-      const fallback = defaultModelForProvider(provider);
-      console.warn(
-        `[provider-config] Model "${model}" is not compatible with adapter "${adapter}". Falling back to "${fallback}".`
-      );
-      model = fallback;
-    }
-  }
-
-  let api_key = resolveApiKey(fileConfig.api_key, provider, adapter, envFile);
-
-  // Fallback: read OAuth token from ~/.codex/auth.json when no API key is configured
-  if (!api_key && provider === "openai" && adapter === "openai_codex_cli") {
-    api_key = await readCodexOAuthToken();
-  }
-
-  const base_url = resolveBaseUrl(fileConfig.base_url, provider, envFile);
-
-  const config: ProviderConfig = { provider, model, adapter };
-  if (api_key !== undefined) config.api_key = api_key;
-  if (base_url !== undefined) config.base_url = base_url;
-  if (fileConfig.codex_cli_path !== undefined) config.codex_cli_path = fileConfig.codex_cli_path;
-  if (fileConfig.terminal_backend !== undefined) config.terminal_backend = fileConfig.terminal_backend;
-  if (fileConfig.a2a !== undefined) config.a2a = fileConfig.a2a;
-  if (fileConfig.light_model !== undefined) config.light_model = fileConfig.light_model;
-  if (fileConfig.openclaw !== undefined) config.openclaw = fileConfig.openclaw;
-  if (fileConfig.agent_loop !== undefined) config.agent_loop = fileConfig.agent_loop;
-
-  // Validate and log warnings (only once per process)
-  const validation = validateProviderConfig(config);
-  if (!validation.valid && !_warnedOnce) {
-    for (const err of validation.errors) {
-      console.warn(`[provider-config] Warning: ${err}`);
-    }
-    _warnedOnce = true;
-  }
-
-  // Auto-save migrated config (save file-only values, not env-var-resolved ones)
-  if (needsMigrationSave) {
-    try {
-      const fileOnly: ProviderConfig = {
-        provider: fileConfig.provider ?? "openai",
-        model: fileConfig.model ?? "gpt-5.4-mini",
-        adapter: fileConfig.adapter ?? "openai_codex_cli",
-      };
-      if (fileConfig.api_key !== undefined) fileOnly.api_key = fileConfig.api_key;
-      if (fileConfig.base_url !== undefined) fileOnly.base_url = fileConfig.base_url;
-      if (fileConfig.codex_cli_path !== undefined) fileOnly.codex_cli_path = fileConfig.codex_cli_path;
-      if (fileConfig.terminal_backend !== undefined) fileOnly.terminal_backend = fileConfig.terminal_backend;
-      if (fileConfig.a2a !== undefined) fileOnly.a2a = fileConfig.a2a;
-      if (fileConfig.agent_loop !== undefined) fileOnly.agent_loop = fileConfig.agent_loop;
-      await saveProviderConfig(fileOnly);
-    } catch {
-      // Best-effort — don't fail if we can't save
-    }
-  }
-
   return config;
 }
 
@@ -520,7 +571,7 @@ export async function getProviderRuntimeFingerprint(): Promise<string> {
  * Creates the ~/.pulseed directory if it does not exist.
  */
 export async function saveProviderConfig(config: ProviderConfig): Promise<void> {
-  await writeJsonFileAtomic(PROVIDER_CONFIG_PATH, config);
+  await writeJsonFileAtomic(providerConfigPath(), config);
 }
 
 // Re-export default for tests that need it

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -496,6 +496,28 @@ describe("ChatRunner", () => {
       }
     });
 
+    it("/status <goal-id> reads archived goals without calling adapter", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-archived-status-"));
+      try {
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.saveGoal(makeGoal("goal-a"));
+        await stateManager.archiveGoal("goal-a");
+        const adapter = makeMockAdapter();
+        const runner = new ChatRunner(makeDeps({ stateManager, adapter }));
+
+        const result = await runner.execute("/status goal-a", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("Goal status: Goal goal-a");
+        expect(result.output).toContain("ID: goal-a");
+        expect(result.output).toContain("Status: archived");
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("/tasks and /task read task state without shelling out", async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-tasks-"));
       try {
@@ -518,6 +540,79 @@ describe("ChatRunner", () => {
         expect(adapter.execute).not.toHaveBeenCalled();
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/task <task-id> searches tasks under archived goals when no goal id is provided", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-archived-task-"));
+      try {
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.saveGoal(makeGoal("goal-a"));
+        await stateManager.writeRaw("tasks/goal-a/task-1.json", makeTask("task-1", "goal-a"));
+        await stateManager.archiveGoal("goal-a");
+        const adapter = makeMockAdapter();
+        const runner = new ChatRunner(makeDeps({ stateManager, adapter }));
+
+        const result = await runner.execute("/task task-1", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("Task: task-1");
+        expect(result.output).toContain("Goal: goal-a");
+        expect(result.output).toContain("Success criteria:");
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/task <task-id> searches recoverable archived goals without an archive marker", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-recoverable-archived-task-"));
+      try {
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        const archiveGoalDir = path.join(tmpDir, "archive", "goal-a", "goal");
+        const archiveTasksDir = path.join(tmpDir, "archive", "goal-a", "tasks");
+        fs.mkdirSync(archiveGoalDir, { recursive: true });
+        fs.mkdirSync(archiveTasksDir, { recursive: true });
+        fs.writeFileSync(path.join(archiveGoalDir, "goal.json"), JSON.stringify(makeGoal("goal-a", { status: "archived" })));
+        fs.writeFileSync(path.join(archiveTasksDir, "task-1.json"), JSON.stringify(makeTask("task-1", "goal-a")));
+        const adapter = makeMockAdapter();
+        const runner = new ChatRunner(makeDeps({ stateManager, adapter }));
+
+        const status = await runner.execute("/status goal-a", "/repo");
+        const task = await runner.execute("/task task-1", "/repo");
+
+        expect(status.success).toBe(true);
+        expect(status.output).toContain("Status: archived");
+        expect(task.success).toBe(true);
+        expect(task.output).toContain("Task: task-1");
+        expect(task.output).toContain("Goal: goal-a");
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/task with an explicit goal id cannot traverse outside the state directory", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-task-traversal-"));
+      const outsideDir = path.join(path.dirname(tmpDir), `${path.basename(tmpDir)}-outside`);
+      try {
+        fs.mkdirSync(outsideDir, { recursive: true });
+        fs.writeFileSync(path.join(outsideDir, "task-1.json"), JSON.stringify(makeTask("task-1", "outside-goal")));
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        const adapter = makeMockAdapter();
+        const runner = new ChatRunner(makeDeps({ stateManager, adapter }));
+
+        const result = await runner.execute(`/task task-1 ../../${path.basename(outsideDir)}`, "/repo");
+
+        expect(result.success).toBe(false);
+        expect(result.output).toContain("Task not found: task-1");
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        fs.rmSync(outsideDir, { recursive: true, force: true });
       }
     });
 
@@ -560,6 +655,58 @@ describe("ChatRunner", () => {
       expect(plugins.output).toContain("demo");
       expect(pluginLoader.loadAll).toHaveBeenCalledOnce();
       expect(adapter.execute).not.toHaveBeenCalled();
+    });
+
+    it("/config uses the shared provider resolver including .env values", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-config-env-"));
+      const oldEnv = {
+        PULSEED_PROVIDER: process.env["PULSEED_PROVIDER"],
+        PULSEED_LLM_PROVIDER: process.env["PULSEED_LLM_PROVIDER"],
+        PULSEED_MODEL: process.env["PULSEED_MODEL"],
+        PULSEED_LIGHT_MODEL: process.env["PULSEED_LIGHT_MODEL"],
+        PULSEED_ADAPTER: process.env["PULSEED_ADAPTER"],
+        PULSEED_DEFAULT_ADAPTER: process.env["PULSEED_DEFAULT_ADAPTER"],
+        OPENAI_API_KEY: process.env["OPENAI_API_KEY"],
+        OPENAI_BASE_URL: process.env["OPENAI_BASE_URL"],
+      };
+      try {
+        for (const key of Object.keys(oldEnv)) delete process.env[key];
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("provider.json", {
+          provider: "openai",
+          model: "gpt-5.4",
+          adapter: "openai_api",
+        });
+        fs.writeFileSync(
+          path.join(tmpDir, ".env"),
+          "OPENAI_API_KEY=sk-from-env\nOPENAI_BASE_URL=https://example.test/v1\nPULSEED_LIGHT_MODEL=gpt-env-light\n"
+        );
+        const adapter = makeMockAdapter();
+        const runner = new ChatRunner(makeDeps({ stateManager, adapter }));
+
+        const result = await runner.execute("/config", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("Provider configuration");
+        expect(result.output).toContain("provider: openai");
+        expect(result.output).toContain("model: gpt-5.4");
+        expect(result.output).toContain("light_model: gpt-env-light");
+        expect(result.output).toContain("adapter: openai_api");
+        expect(result.output).toContain("base_url: https://example.test/v1");
+        expect(result.output).toContain("has_api_key: true");
+        expect(result.output).not.toContain("sk-from-env");
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        for (const [key, value] of Object.entries(oldEnv)) {
+          if (value === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = value;
+          }
+        }
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
 
     it("/model reports migrated legacy provider config without saving it", async () => {

--- a/src/interface/chat/__tests__/self-knowledge-tools.test.ts
+++ b/src/interface/chat/__tests__/self-knowledge-tools.test.ts
@@ -212,19 +212,24 @@ describe("handleSelfKnowledgeToolCall — get_plugins", () => {
     const result = await handleSelfKnowledgeToolCall("get_plugins", {}, deps);
     const parsed = JSON.parse(result) as {
       plugins: Array<{ name: string; type: string; enabled: boolean }>;
+      builtin_integrations: Array<{ id: string; source: string }>;
     };
     expect(parsed.plugins).toHaveLength(2);
     expect(parsed.plugins[0].name).toBe("slack-notifier");
     expect(parsed.plugins[1].name).toBe("github-issues");
+    expect(parsed.builtin_integrations).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "soil-display", source: "builtin" }),
+    ]));
   });
 
   it("returns unavailable message when pluginLoader is absent", async () => {
     const deps = makeDeps({ pluginLoader: undefined });
     const result = await handleSelfKnowledgeToolCall("get_plugins", {}, deps);
-    const parsed = JSON.parse(result) as { message: string; plugins: unknown[] };
+    const parsed = JSON.parse(result) as { message: string; plugins: unknown[]; builtin_integrations: unknown[] };
     expect(parsed.message).toBeDefined();
     expect(parsed.message.toLowerCase()).toContain("not available");
     expect(parsed.plugins).toHaveLength(0);
+    expect(parsed.builtin_integrations.length).toBeGreaterThan(0);
   });
 
   it("fills defaults for missing type and enabled fields", async () => {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -10,7 +10,7 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import type { IAdapter, AgentTask } from "../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { getPulseedDirPath } from "../../base/utils/paths.js";
-import { migrateProviderConfig, type ProviderConfig } from "../../base/llm/provider-config.js";
+import { loadProviderConfig } from "../../base/llm/provider-config.js";
 import { TaskSchema, type Task } from "../../base/types/task.js";
 import type { Goal } from "../../base/types/goal.js";
 import { ChatHistory, type ChatSession } from "./chat-history.js";
@@ -127,6 +127,16 @@ interface AssistantBuffer {
 
 interface ResumeCommand {
   selector?: string;
+}
+
+interface ProviderConfigSummary {
+  provider: string;
+  model: string;
+  adapter: string;
+  light_model?: string;
+  base_url?: string;
+  codex_cli_path?: string;
+  has_api_key: boolean;
 }
 
 const DEFAULT_TIMEOUT_MS = 120_000;
@@ -323,6 +333,45 @@ export class ChatRunner {
     return goals.filter((goal): goal is Goal => goal !== null);
   }
 
+  private async listAllGoalIds(): Promise<string[]> {
+    const activeIds = await this.deps.stateManager.listGoalIds();
+    const archivedIds = await this.deps.stateManager.listArchivedGoals();
+    const recoverableArchivedIds = await this.listRecoverableArchivedGoalIds();
+    return [...new Set([...activeIds, ...archivedIds, ...recoverableArchivedIds])];
+  }
+
+  private resolveStatePath(baseDir: string, ...segments: string[]): string | null {
+    const base = path.resolve(baseDir);
+    const resolved = path.resolve(base, ...segments);
+    if (!resolved.startsWith(base + path.sep)) return null;
+    return resolved;
+  }
+
+  private async listRecoverableArchivedGoalIds(): Promise<string[]> {
+    const stateManager = this.deps.stateManager as StateManager & { getBaseDir?: () => string };
+    if (typeof stateManager.getBaseDir !== "function") return [];
+    const archiveDir = this.resolveStatePath(stateManager.getBaseDir(), "archive");
+    if (archiveDir === null) return [];
+    let entries: Array<{ name: string; isDirectory(): boolean }> = [];
+    try {
+      entries = await fsp.readdir(archiveDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+
+    const goalIds: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name === ".staging") continue;
+      try {
+        await fsp.access(path.join(archiveDir, entry.name, "goal", "goal.json"));
+        goalIds.push(entry.name);
+      } catch {
+        continue;
+      }
+    }
+    return goalIds;
+  }
+
   private activeGoals(goals: Goal[]): Goal[] {
     return goals.filter((goal) => goal.status === "active" || goal.status === "waiting" || goal.loop_status === "running");
   }
@@ -338,9 +387,8 @@ export class ChatRunner {
   }
 
   private async handleStatus(args: string, start: number): Promise<ChatRunResult> {
-    const goals = await this.loadGoals();
     if (args) {
-      const goal = goals.find((candidate) => candidate.id === args);
+      const goal = await this.deps.stateManager.loadGoal(args);
       if (!goal) {
         return { success: false, output: `Goal not found: ${args}`, elapsed_ms: Date.now() - start };
       }
@@ -359,6 +407,7 @@ export class ChatRunner {
       return { success: true, output: lines.join("\n"), elapsed_ms: Date.now() - start };
     }
 
+    const goals = await this.loadGoals();
     const active = this.activeGoals(goals);
     if (active.length === 0) {
       return { success: true, output: "No active goals found.", elapsed_ms: Date.now() - start };
@@ -382,10 +431,7 @@ export class ChatRunner {
     };
   }
 
-  private async readTasksForGoal(goalId: string): Promise<Task[]> {
-    const stateManager = this.deps.stateManager as StateManager & { getBaseDir?: () => string };
-    if (typeof stateManager.getBaseDir !== "function") return [];
-    const tasksDir = path.join(stateManager.getBaseDir(), "tasks", goalId);
+  private async readTasksFromDir(tasksDir: string): Promise<Task[]> {
     let entries: string[] = [];
     try {
       entries = await fsp.readdir(tasksDir);
@@ -396,11 +442,28 @@ export class ChatRunner {
     const tasks: Task[] = [];
     for (const entry of entries) {
       if (!entry.endsWith(".json") || entry === "task-history.json" || entry === "last-failure-context.json") continue;
-      const raw = await this.deps.stateManager.readRaw(`tasks/${goalId}/${entry}`);
+      let raw: unknown;
+      try {
+        raw = JSON.parse(await fsp.readFile(path.join(tasksDir, entry), "utf-8"));
+      } catch {
+        continue;
+      }
       const parsed = TaskSchema.safeParse(raw);
       if (parsed.success) tasks.push(parsed.data);
     }
     return tasks.sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+  }
+
+  private async readTasksForGoal(goalId: string): Promise<Task[]> {
+    const stateManager = this.deps.stateManager as StateManager & { getBaseDir?: () => string };
+    if (typeof stateManager.getBaseDir !== "function") return [];
+    const baseDir = stateManager.getBaseDir();
+    const activeTasksDir = this.resolveStatePath(baseDir, "tasks", goalId);
+    const archiveTasksDir = this.resolveStatePath(baseDir, "archive", goalId, "tasks");
+    if (activeTasksDir === null || archiveTasksDir === null) return [];
+    const activeTasks = await this.readTasksFromDir(activeTasksDir);
+    if (activeTasks.length > 0) return activeTasks;
+    return this.readTasksFromDir(archiveTasksDir);
   }
 
   private async resolveGoalForTasks(selector: string): Promise<{ goalId?: string; error?: string }> {
@@ -444,10 +507,15 @@ export class ChatRunner {
   }
 
   private async findTask(taskId: string, goalId?: string): Promise<{ task?: Task; matches: Array<{ goalId: string; task: Task }> }> {
-    const goalIds = goalId ? [goalId] : (await this.deps.stateManager.listGoalIds());
+    const goalIds = goalId ? [goalId] : await this.listAllGoalIds();
     const matches: Array<{ goalId: string; task: Task }> = [];
     for (const candidateGoalId of goalIds) {
-      let raw = await this.deps.stateManager.readRaw(`tasks/${candidateGoalId}/${taskId}.json`);
+      let raw: unknown | null = null;
+      try {
+        raw = await this.deps.stateManager.readRaw(`tasks/${candidateGoalId}/${taskId}.json`);
+      } catch {
+        raw = null;
+      }
       if (!raw) {
         const tasks = await this.readTasksForGoal(candidateGoalId);
         const matched = tasks.find((task) => task.id === taskId || task.id.startsWith(taskId));
@@ -501,43 +569,28 @@ export class ChatRunner {
     return { success: true, output: this.formatTask(found.task), elapsed_ms: Date.now() - start };
   }
 
-  private async readProviderConfigReadOnly(): Promise<Record<string, unknown>> {
+  private providerConfigBaseDir(): string {
     const stateManager = this.deps.stateManager as StateManager & { getBaseDir?: () => string };
-    const baseDir = typeof stateManager.getBaseDir === "function" ? stateManager.getBaseDir() : getPulseedDirPath();
-    const configPath = path.join(baseDir, "provider.json");
-    let fileConfig: Partial<ProviderConfig> = {};
-    try {
-      const raw = await fsp.readFile(configPath, "utf-8");
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      fileConfig = ("llm_provider" in parsed || "default_adapter" in parsed)
-        ? migrateProviderConfig(parsed as never)
-        : parsed as Partial<ProviderConfig>;
-    } catch {
-      fileConfig = {};
-    }
-    const envProvider = process.env["PULSEED_PROVIDER"] ?? process.env["PULSEED_LLM_PROVIDER"];
-    const provider = envProvider === "codex"
-      ? "openai"
-      : envProvider ?? fileConfig.provider ?? "openai";
-    const model = fileConfig.model
-      ?? process.env["PULSEED_MODEL"]
-      ?? (provider === "anthropic"
-        ? process.env["ANTHROPIC_MODEL"] ?? "claude-sonnet-4-6"
-        : provider === "ollama"
-          ? process.env["OLLAMA_MODEL"] ?? "qwen3:4b"
-          : process.env["OPENAI_MODEL"] ?? "gpt-5.4-mini");
+    return typeof stateManager.getBaseDir === "function" ? stateManager.getBaseDir() : getPulseedDirPath();
+  }
+
+  private async readProviderConfigSummary(): Promise<ProviderConfigSummary> {
+    const config = await loadProviderConfig({
+      baseDir: this.providerConfigBaseDir(),
+      saveMigration: false,
+    });
     return {
-      provider,
-      model,
-      adapter: process.env["PULSEED_ADAPTER"] ?? process.env["PULSEED_DEFAULT_ADAPTER"] ?? fileConfig.adapter ?? "openai_codex_cli",
-      light_model: process.env["PULSEED_LIGHT_MODEL"] ?? fileConfig.light_model,
-      base_url: process.env["OPENAI_BASE_URL"] ?? process.env["OLLAMA_BASE_URL"] ?? fileConfig.base_url,
-      codex_cli_path: fileConfig.codex_cli_path,
-      has_api_key: Boolean(process.env["OPENAI_API_KEY"] || process.env["ANTHROPIC_API_KEY"] || fileConfig.api_key),
+      provider: config.provider,
+      model: config.model,
+      adapter: config.adapter,
+      light_model: config.light_model,
+      base_url: config.base_url,
+      codex_cli_path: config.codex_cli_path,
+      has_api_key: Boolean(config.api_key),
     };
   }
 
-  private formatConfig(config: Record<string, unknown>): string {
+  private formatConfig(config: ProviderConfigSummary): string {
     return Object.entries(config)
       .filter(([, value]) => value !== undefined)
       .map(([key, value]) => `${key}: ${typeof value === "string" && /key|token|secret/i.test(key) ? "[masked]" : String(value)}`)
@@ -545,15 +598,15 @@ export class ChatRunner {
   }
 
   private async handleConfig(start: number): Promise<ChatRunResult> {
-    const config = await this.readProviderConfigReadOnly();
+    const config = await this.readProviderConfigSummary();
     return { success: true, output: `Provider configuration:\n${this.formatConfig(config)}`, elapsed_ms: Date.now() - start };
   }
 
   private async handleModel(start: number): Promise<ChatRunResult> {
-    const config = await this.readProviderConfigReadOnly();
+    const config = await this.readProviderConfigSummary();
     return {
       success: true,
-      output: `Model: ${String(config["model"])}\nProvider: ${String(config["provider"])}\nAdapter: ${String(config["adapter"])}`,
+      output: `Model: ${config.model}\nProvider: ${config.provider}\nAdapter: ${config.adapter}`,
       elapsed_ms: Date.now() - start,
     };
   }

--- a/src/interface/chat/self-knowledge-tools.ts
+++ b/src/interface/chat/self-knowledge-tools.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import type { StateManager } from "../../base/state/state-manager.js";
 import type { ToolDefinition } from "../../base/llm/llm-client.js";
 import { getAgentName } from "../../base/config/identity-loader.js";
+import { listBuiltinIntegrations } from "../../runtime/builtin-integrations.js";
 export type { ToolDefinition };
 
 // ─── Dependencies ───
@@ -10,7 +11,7 @@ export type { ToolDefinition };
 export interface SelfKnowledgeDeps {
   stateManager: StateManager;
   trustManager?: { getBalance(domain: string): Promise<{ balance: number }> };
-  pluginLoader?: { loadAll(): Promise<Array<{ name: string; type?: string; enabled?: boolean }>> };
+  pluginLoader?: { loadAll(): Promise<Array<{ name: string; type?: string; enabled?: boolean; status?: string; manifest?: { type?: string } }>> };
   homeDir: string;
 }
 
@@ -69,7 +70,7 @@ export function getSelfKnowledgeToolDefinitions(): ToolDefinition[] {
       function: {
         name: "get_plugins",
         description:
-          "Returns the list of installed plugins with name, type, and enabled status.",
+          "Returns installed plugins and builtin integrations with name, type, capabilities, and enabled status.",
         parameters: { type: "object", properties: {}, required: [] },
       },
     },
@@ -192,19 +193,28 @@ async function handleGetConfig(deps: SelfKnowledgeDeps): Promise<string> {
 }
 
 async function handleGetPlugins(deps: SelfKnowledgeDeps): Promise<string> {
+  const builtinIntegrations = listBuiltinIntegrations();
   if (!deps.pluginLoader) {
-    return JSON.stringify({ message: "Plugin information is not available.", plugins: [] });
+    return JSON.stringify({
+      message: "Plugin information is not available.",
+      plugins: [],
+      builtin_integrations: builtinIntegrations,
+    });
   }
   try {
     const pluginStates = await deps.pluginLoader.loadAll();
     const plugins = pluginStates.map((p) => ({
       name: p.name,
-      type: p.type ?? "unknown",
-      enabled: p.enabled ?? true,
+      type: p.type ?? p.manifest?.type ?? "unknown",
+      enabled: p.enabled ?? (p.status ? p.status === "loaded" : true),
     }));
-    return JSON.stringify({ plugins });
+    return JSON.stringify({ plugins, builtin_integrations: builtinIntegrations });
   } catch {
-    return JSON.stringify({ message: "Failed to load plugin information.", plugins: [] });
+    return JSON.stringify({
+      message: "Failed to load plugin information.",
+      plugins: [],
+      builtin_integrations: builtinIntegrations,
+    });
   }
 }
 

--- a/src/interface/cli/__tests__/setup-import.test.ts
+++ b/src/interface/cli/__tests__/setup-import.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { ForeignPluginCompatibilityReport } from "../../../runtime/foreign-plugins/types.js";
 import type { SetupImportSelection, SetupImportSource } from "../commands/setup/import/types.js";
 
 let tmpDir: string;
@@ -61,6 +62,12 @@ describe("setup import discovery", () => {
       type: "notifier",
       capabilities: ["notify"],
       description: "test",
+      permissions: {
+        network: false,
+        file_read: false,
+        file_write: false,
+        shell: false,
+      },
     });
     await fsp.writeFile(path.join(openclawHome, "USER.md"), "# About You\n\nName: Imported User\n", "utf-8");
 
@@ -97,6 +104,7 @@ describe("setup import discovery", () => {
       ],
     });
     expect(openclaw?.items.find((item) => item.kind === "plugin")?.decision).toBe("copy_disabled");
+    expect(openclaw?.items.find((item) => item.kind === "plugin")?.pluginCompatibility?.status).toBe("convertible");
     expect(openclaw?.items.find((item) => item.kind === "user")?.userSettings).toEqual({
       content: "# About You\n\nName: Imported User\n",
     });
@@ -295,6 +303,68 @@ describe("setup import discovery", () => {
       content: "# About You\n\nName: Imported User\nPrefers concise updates.\n",
     });
   });
+
+  it("classifies imported plugin manifests by compatibility and permission summary", async () => {
+    const openclawHome = path.join(tmpDir, "openclaw");
+    process.env["PULSEED_IMPORT_OPENCLAW_HOME"] = openclawHome;
+
+    await fsp.mkdir(path.join(openclawHome, "plugins", "convertible"), { recursive: true });
+    await writeJson(path.join(openclawHome, "plugins", "convertible", "plugin.json"), {
+      name: "convertible",
+      version: "1.0.0",
+      type: "notifier",
+      capabilities: ["notify"],
+      description: "convertible plugin",
+      permissions: {
+        network: false,
+        file_read: false,
+        file_write: false,
+        shell: false,
+      },
+    });
+    await fsp.mkdir(path.join(openclawHome, "plugins", "quarantined"), { recursive: true });
+    await writeJson(path.join(openclawHome, "plugins", "quarantined", "plugin.json"), {
+      name: "quarantined",
+      version: "1.0.0",
+      type: "notifier",
+      capabilities: ["notify"],
+      description: "quarantined plugin",
+      permissions: {
+        network: true,
+        file_read: false,
+        file_write: false,
+        shell: false,
+      },
+    });
+    await fsp.mkdir(path.join(openclawHome, "plugins", "incompatible"), { recursive: true });
+    await writeJson(path.join(openclawHome, "plugins", "incompatible", "plugin.json"), {
+      name: "Bad Name",
+      version: "1.0",
+      type: "custom",
+      capabilities: [],
+      description: "",
+    });
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const openclaw = sources.find((source) => source.id === "openclaw");
+    const pluginItems = openclaw?.items.filter((item) => item.kind === "plugin") ?? [];
+
+    expect(pluginItems.map((item) => item.label).sort()).toEqual([
+      "convertible",
+      "incompatible",
+      "quarantined",
+    ]);
+    expect(pluginItems.find((item) => item.label === "convertible")?.pluginCompatibility?.status).toBe("convertible");
+    expect(pluginItems.find((item) => item.label === "quarantined")?.pluginCompatibility?.status).toBe("quarantined");
+    expect(pluginItems.find((item) => item.label === "incompatible")?.pluginCompatibility?.status).toBe("incompatible");
+    expect(pluginItems.find((item) => item.label === "quarantined")?.pluginCompatibility?.permissions).toMatchObject({
+      network: true,
+      file_read: false,
+      file_write: false,
+      shell: false,
+    });
+  });
 });
 
 describe("setup import apply", () => {
@@ -312,6 +382,12 @@ describe("setup import apply", () => {
       type: "notifier",
       capabilities: ["notify"],
       description: "test",
+      permissions: {
+        network: true,
+        file_read: false,
+        file_write: false,
+        shell: false,
+      },
     });
     await writeJson(path.join(baseDir, "mcp-servers.json"), {
       servers: [
@@ -348,6 +424,26 @@ describe("setup import apply", () => {
           sourcePath: pluginDir,
           decision: "copy_disabled",
           reason: "quarantine",
+          pluginCompatibility: {
+            source: "openclaw",
+            status: "quarantined",
+            issues: ["requested permissions: network"],
+            permissions: {
+              network: true,
+              file_read: false,
+              file_write: false,
+              shell: false,
+            },
+            manifestPath: path.join(pluginDir, "plugin.json"),
+            manifest: {
+              name: "notifier",
+              version: "1.0.0",
+              type: "notifier",
+              capabilities: ["notify"],
+              description: "test",
+              entry_point: "dist/index.js",
+            },
+          } satisfies ForeignPluginCompatibilityReport,
         },
         {
           id: "openclaw:mcp:filesystem",
@@ -399,6 +495,7 @@ describe("setup import apply", () => {
       ])
     );
     expect(report.items.filter((item) => item.status === "applied")).toHaveLength(4);
+    expect(report.items.find((item) => item.kind === "plugin")?.pluginCompatibility?.status).toBe("quarantined");
     const telegramConfig = JSON.parse(
       await fsp.readFile(path.join(baseDir, "plugins", "telegram-bot", "config.json"), "utf-8")
     ) as Record<string, unknown>;

--- a/src/interface/cli/commands/setup/import/apply.ts
+++ b/src/interface/cli/commands/setup/import/apply.ts
@@ -57,6 +57,7 @@ async function applyFileItem(baseDir: string, item: SetupImportItem): Promise<Se
       decision: item.decision,
       status: "skipped",
       reason: "no source path",
+      ...(item.pluginCompatibility ? { pluginCompatibility: item.pluginCompatibility } : {}),
     };
   }
 
@@ -72,6 +73,7 @@ async function applyFileItem(baseDir: string, item: SetupImportItem): Promise<Se
       decision: item.decision,
       status: "applied",
       targetPath,
+      ...(item.pluginCompatibility ? { pluginCompatibility: item.pluginCompatibility } : {}),
     };
   }
 
@@ -87,6 +89,7 @@ async function applyFileItem(baseDir: string, item: SetupImportItem): Promise<Se
       decision: item.decision,
       status: "applied",
       targetPath,
+      ...(item.pluginCompatibility ? { pluginCompatibility: item.pluginCompatibility } : {}),
     };
   }
 
@@ -110,6 +113,7 @@ function reportItem(item: SetupImportItem, status: SetupImportAppliedItem["statu
     decision: item.decision,
     status,
     ...(reason ? { reason } : {}),
+    ...(item.pluginCompatibility ? { pluginCompatibility: item.pluginCompatibility } : {}),
   };
 }
 

--- a/src/interface/cli/commands/setup/import/discovery.ts
+++ b/src/interface/cli/commands/setup/import/discovery.ts
@@ -14,6 +14,7 @@ import { extractMcpServers } from "./mcp.js";
 import { collectRecords, firstString, nestedRecord } from "./parse.js";
 import { buildProviderItem, extractProviderSettings } from "./provider.js";
 import { buildTelegramItem, extractTelegramSettings, telegramCredentialItems } from "./telegram.js";
+import { analyzeForeignPluginDirectory } from "../../../../../runtime/foreign-plugins/compatibility.js";
 import type {
   SetupImportItem,
   SetupImportSource,
@@ -212,7 +213,14 @@ function mcpItems(source: SetupImportSourceId, rootDir: string): SetupImportItem
 
 function pluginItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
   return findPluginDirs(rootDir).map((pluginDir) => {
-    const name = path.basename(pluginDir);
+    const pluginCompatibility = analyzeForeignPluginDirectory(source, pluginDir);
+    const name = pluginCompatibility.manifest?.name ?? path.basename(pluginDir);
+    const reason =
+      pluginCompatibility.status === "convertible"
+        ? "plugin manifest is compatible and will be copied disabled until reviewed"
+        : pluginCompatibility.status === "quarantined"
+          ? `plugin is quarantined: ${pluginCompatibility.issues.join("; ")}`
+          : `plugin is incompatible: ${pluginCompatibility.issues.join("; ")}`;
     return {
       id: `${source}:plugin:${name}`,
       source,
@@ -221,7 +229,8 @@ function pluginItems(source: SetupImportSourceId, rootDir: string): SetupImportI
       label: name,
       sourcePath: pluginDir,
       decision: "copy_disabled",
-      reason: "plugins are quarantined until PulSeed compatibility is reviewed",
+      reason,
+      pluginCompatibility,
     };
   });
 }

--- a/src/interface/cli/commands/setup/import/flow.ts
+++ b/src/interface/cli/commands/setup/import/flow.ts
@@ -39,6 +39,17 @@ function providerPreview(settings: SetupImportProviderSettings | undefined): str
 
 function itemPreview(item: SetupImportItem): string {
   const decision = item.decision === "copy_disabled" ? "copy disabled" : item.decision;
+  const pluginCompatibility =
+    item.kind === "plugin" && item.pluginCompatibility
+      ? [
+          `compatibility=${item.pluginCompatibility.status}`,
+          `permissions=${
+            Object.entries(item.pluginCompatibility.permissions)
+              .flatMap(([key, value]) => (value ? [key] : []))
+              .join(", ") || "none"
+          }`,
+        ].join(", ")
+      : undefined;
   const details = item.kind === "provider"
     ? providerPreview(item.providerSettings)
     : item.kind === "user"
@@ -48,6 +59,8 @@ function itemPreview(item: SetupImportItem): string {
           item.telegramSettings?.botToken ? `bot_token=${maskKey(item.telegramSettings.botToken)}` : undefined,
           item.telegramSettings?.allowedUserIds?.length ? `allowed_users=${item.telegramSettings.allowedUserIds.length}` : undefined,
         ].filter(Boolean).join(", ")
+    : item.kind === "plugin"
+      ? pluginCompatibility
     : item.reason;
   return `[${item.sourceLabel}] ${item.kind}: ${item.label}\n  ${decision}${details ? ` - ${details}` : ""}`;
 }

--- a/src/interface/cli/commands/setup/import/types.ts
+++ b/src/interface/cli/commands/setup/import/types.ts
@@ -1,5 +1,6 @@
 import type { ProviderConfig } from "../../../../../base/llm/provider-config.js";
 import type { MCPServerConfig } from "../../../../../base/types/mcp.js";
+import type { ForeignPluginCompatibilityReport } from "../../../../../runtime/foreign-plugins/types.js";
 
 export type SetupImportSourceId = "hermes" | "openclaw";
 
@@ -39,6 +40,7 @@ export interface SetupImportItem {
   userSettings?: SetupImportUserSettings;
   telegramSettings?: SetupImportTelegramSettings;
   mcpServer?: MCPServerConfig;
+  pluginCompatibility?: ForeignPluginCompatibilityReport;
 }
 
 export interface SetupImportSource {
@@ -64,6 +66,7 @@ export interface SetupImportAppliedItem {
   status: "applied" | "skipped" | "failed";
   targetPath?: string;
   reason?: string;
+  pluginCompatibility?: ForeignPluginCompatibilityReport;
 }
 
 export interface SetupImportReport {

--- a/src/platform/soil/__tests__/soil-open.test.ts
+++ b/src/platform/soil/__tests__/soil-open.test.ts
@@ -1,7 +1,58 @@
+import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { SqliteSoilRepository } from "../sqlite-repository.js";
 import { buildSoilOpenCommand, openSoil, resolveSoilOpenPath } from "../open.js";
+
+async function seedTypedMemoryFixture(rootDir: string): Promise<string> {
+  const indexPath = path.join(rootDir, ".index", "typed-soil.db");
+  const repo = await SqliteSoilRepository.create({ rootDir, indexPath });
+  try {
+    await repo.applyMutation({
+      records: [{
+        record_id: "rec-memory",
+        record_key: "memory.preference",
+        version: 1,
+        record_type: "preference",
+        soil_id: "memory/preferences/rec-memory",
+        title: "Preferred editor",
+        summary: "Use Obsidian as the memory viewer.",
+        canonical_text: "Use Obsidian as the memory viewer.",
+        goal_id: null,
+        task_id: null,
+        status: "active",
+        confidence: 0.9,
+        importance: 0.7,
+        source_reliability: null,
+        valid_from: null,
+        valid_to: null,
+        supersedes_record_id: null,
+        is_active: true,
+        source_type: "knowledge",
+        source_id: "memory-preference",
+        metadata_json: {},
+        created_at: "2026-04-11T09:00:00.000Z",
+        updated_at: "2026-04-11T09:00:00.000Z",
+      }],
+      chunks: [{
+        chunk_id: "chunk-memory",
+        record_id: "rec-memory",
+        soil_id: "memory/preferences/rec-memory",
+        chunk_index: 0,
+        chunk_kind: "paragraph",
+        heading_path_json: [],
+        chunk_text: "Use Obsidian as the memory viewer.",
+        token_count: 7,
+        checksum: "memory",
+        created_at: "2026-04-11T09:00:00.000Z",
+      }],
+    });
+  } finally {
+    repo.close();
+  }
+  return indexPath;
+}
 
 describe("Soil open bridge", () => {
   it("resolves known Soil targets without creating root active.md", () => {
@@ -32,6 +83,26 @@ describe("Soil open bridge", () => {
       );
       expect(result.exitCode).toBe(0);
       expect(calls).toEqual([{ command: "code", args: [path.join(rootDir, "status.md")] }]);
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("materializes typed memory pages before opening Soil targets", async () => {
+    const rootDir = makeTempDir("soil-open-display-");
+    try {
+      const indexPath = await seedTypedMemoryFixture(rootDir);
+      const calls: Array<{ command: string; args: string[] }> = [];
+      const result = await openSoil(
+        { rootDir, indexPath, viewer: "vscode", target: "memory" },
+        async (command, args) => {
+          calls.push({ command, args });
+          return { stdout: "", stderr: "", exitCode: 0 };
+        }
+      );
+      expect(result.exitCode).toBe(0);
+      expect(calls).toEqual([{ command: "code", args: [path.join(rootDir, "memory")] }]);
+      await expect(fsp.access(path.join(rootDir, "memory", "preferences", "rec-memory.md"))).resolves.toBeUndefined();
     } finally {
       cleanupTempDir(rootDir);
     }

--- a/src/platform/soil/__tests__/soil-platform.test.ts
+++ b/src/platform/soil/__tests__/soil-platform.test.ts
@@ -8,6 +8,7 @@ import { SoilRetriever } from "../retriever.js";
 import { SoilDoctor } from "../doctor.js";
 import { readSoilMarkdownFile } from "../io.js";
 import { SqliteSoilRepository } from "../sqlite-repository.js";
+import { prepareSoilDisplaySnapshot } from "../display/index.js";
 
 function fixedClock(): Date {
   return new Date("2026-04-11T10:00:00.000Z");
@@ -275,6 +276,179 @@ describe("Soil doctor", () => {
 
       const report = await SoilDoctor.create({ rootDir, indexPath }).inspect();
       expect(report.findings.some((finding) => finding.code === "typed-store-projection-gap")).toBe(true);
+    } finally {
+      repo?.close();
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("clears the typed-store projection gap after preparing the display snapshot", async () => {
+    const rootDir = makeTempDir("soil-display-gap-");
+    const indexPath = path.join(rootDir, ".index", "custom-soil-store.db");
+    let repo: SqliteSoilRepository | null = null;
+    try {
+      await fsp.mkdir(path.join(rootDir, "schedule"), { recursive: true });
+      await fsp.writeFile(path.join(rootDir, "index.md"), "# Soil\n", "utf-8");
+      await fsp.writeFile(path.join(rootDir, "schedule", "active.md"), "# Active\n", "utf-8");
+
+      repo = await SqliteSoilRepository.create({ rootDir, indexPath });
+      await repo.applyMutation({
+        records: [{
+          record_id: "rec-memory",
+          record_key: "memory.preference",
+          version: 1,
+          record_type: "preference",
+          soil_id: "memory/preferences/rec-memory",
+          title: "Preferred editor",
+          summary: "Use Obsidian as the memory viewer.",
+          canonical_text: "Use Obsidian as the memory viewer.",
+          goal_id: null,
+          task_id: null,
+          status: "active",
+          confidence: 0.9,
+          importance: 0.7,
+          source_reliability: null,
+          valid_from: null,
+          valid_to: null,
+          supersedes_record_id: null,
+          is_active: true,
+          source_type: "knowledge",
+          source_id: "memory-preference",
+          metadata_json: {},
+          created_at: "2026-04-11T09:00:00.000Z",
+          updated_at: "2026-04-11T09:00:00.000Z",
+        }],
+        chunks: [{
+          chunk_id: "chunk-memory",
+          record_id: "rec-memory",
+          soil_id: "memory/preferences/rec-memory",
+          chunk_index: 0,
+          chunk_kind: "paragraph",
+          heading_path_json: [],
+          chunk_text: "Use Obsidian as the memory viewer.",
+          token_count: 7,
+          checksum: "memory",
+          created_at: "2026-04-11T09:00:00.000Z",
+        }],
+      });
+      repo.close();
+      repo = null;
+
+      const before = await SoilDoctor.create({ rootDir, indexPath }).inspect();
+      expect(before.findings.some((finding) => finding.code === "typed-store-projection-gap")).toBe(true);
+
+      await prepareSoilDisplaySnapshot({ rootDir, indexPath });
+
+      const after = await SoilDoctor.create({ rootDir, indexPath }).inspect();
+      expect(after.findings.some((finding) => finding.code === "typed-store-projection-gap")).toBe(false);
+      await expect(fsp.access(path.join(rootDir, "memory", "preferences", "rec-memory.md"))).resolves.toBeUndefined();
+    } finally {
+      repo?.close();
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("fallback-projects multiple active records that share one Soil page", async () => {
+    const rootDir = makeTempDir("soil-display-grouped-");
+    const indexPath = path.join(rootDir, ".index", "custom-soil-store.db");
+    let repo: SqliteSoilRepository | null = null;
+    try {
+      repo = await SqliteSoilRepository.create({ rootDir, indexPath });
+      await repo.applyMutation({
+        records: [
+          {
+            record_id: "rec-editor",
+            record_key: "memory.preference.editor",
+            version: 1,
+            record_type: "preference",
+            soil_id: "memory/preferences",
+            title: "Preferred editor",
+            summary: "Use Obsidian as the memory viewer.",
+            canonical_text: "Use Obsidian as the memory viewer.",
+            goal_id: null,
+            task_id: null,
+            status: "active",
+            confidence: 0.9,
+            importance: 0.7,
+            source_reliability: null,
+            valid_from: null,
+            valid_to: null,
+            supersedes_record_id: null,
+            is_active: true,
+            source_type: "knowledge",
+            source_id: "memory-preference-editor",
+            metadata_json: {},
+            created_at: "2026-04-11T09:00:00.000Z",
+            updated_at: "2026-04-11T09:00:00.000Z",
+          },
+          {
+            record_id: "rec-publish",
+            record_key: "memory.preference.publish",
+            version: 1,
+            record_type: "preference",
+            soil_id: "memory/preferences",
+            title: "Publish preference",
+            summary: "Publish memory through Soil display integrations.",
+            canonical_text: "Publish memory through Soil display integrations.",
+            goal_id: null,
+            task_id: null,
+            status: "active",
+            confidence: 0.8,
+            importance: 0.6,
+            source_reliability: null,
+            valid_from: null,
+            valid_to: null,
+            supersedes_record_id: null,
+            is_active: true,
+            source_type: "knowledge",
+            source_id: "memory-preference-publish",
+            metadata_json: {},
+            created_at: "2026-04-11T09:05:00.000Z",
+            updated_at: "2026-04-11T09:05:00.000Z",
+          },
+        ],
+        chunks: [
+          {
+            chunk_id: "chunk-editor",
+            record_id: "rec-editor",
+            soil_id: "memory/preferences",
+            chunk_index: 0,
+            chunk_kind: "paragraph",
+            heading_path_json: [],
+            chunk_text: "Use Obsidian as the memory viewer.",
+            token_count: 7,
+            checksum: "editor",
+            created_at: "2026-04-11T09:00:00.000Z",
+          },
+          {
+            chunk_id: "chunk-publish",
+            record_id: "rec-publish",
+            soil_id: "memory/preferences",
+            chunk_index: 0,
+            chunk_kind: "paragraph",
+            heading_path_json: [],
+            chunk_text: "Publish memory through Soil display integrations.",
+            token_count: 7,
+            checksum: "publish",
+            created_at: "2026-04-11T09:05:00.000Z",
+          },
+        ],
+      });
+      repo.close();
+      repo = null;
+
+      const result = await prepareSoilDisplaySnapshot({ rootDir, indexPath });
+
+      expect(result.fallbackPageCount).toBe(1);
+      expect(result.materializedPages).toEqual([
+        expect.objectContaining({
+          relativePath: "memory/preferences.md",
+          recordIds: ["rec-editor", "rec-publish"],
+        }),
+      ]);
+      const content = await fsp.readFile(path.join(rootDir, "memory", "preferences.md"), "utf-8");
+      expect(content).toContain("Preferred editor");
+      expect(content).toContain("Publish preference");
     } finally {
       repo?.close();
       cleanupTempDir(rootDir);

--- a/src/platform/soil/__tests__/soil-publish.test.ts
+++ b/src/platform/soil/__tests__/soil-publish.test.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { writeJsonFileAtomic } from "../../../base/utils/json-io.js";
+import { SqliteSoilRepository } from "../sqlite-repository.js";
 import {
   collectSoilSnapshotFiles,
   filterAppleNotesSnapshotFiles,
@@ -21,6 +22,55 @@ async function writeSoilFixture(rootDir: string): Promise<void> {
   await fsp.writeFile(path.join(rootDir, "knowledge", "index.md"), "# Knowledge\n", "utf-8");
   await fsp.writeFile(path.join(rootDir, ".index", "hidden.md"), "# Hidden\n", "utf-8");
   await fsp.writeFile(path.join(rootDir, ".publish", "hidden.md"), "# Hidden\n", "utf-8");
+}
+
+async function seedTypedMemoryFixture(rootDir: string): Promise<string> {
+  const indexPath = path.join(rootDir, ".index", "typed-soil.db");
+  const repo = await SqliteSoilRepository.create({ rootDir, indexPath });
+  try {
+    await repo.applyMutation({
+      records: [{
+        record_id: "rec-memory",
+        record_key: "memory.preference",
+        version: 1,
+        record_type: "preference",
+        soil_id: "memory/preferences/rec-memory",
+        title: "Preferred editor",
+        summary: "Use Obsidian as the memory viewer.",
+        canonical_text: "Use Obsidian as the memory viewer.",
+        goal_id: null,
+        task_id: null,
+        status: "active",
+        confidence: 0.9,
+        importance: 0.7,
+        source_reliability: null,
+        valid_from: null,
+        valid_to: null,
+        supersedes_record_id: null,
+        is_active: true,
+        source_type: "knowledge",
+        source_id: "memory-preference",
+        metadata_json: {},
+        created_at: "2026-04-11T09:00:00.000Z",
+        updated_at: "2026-04-11T09:00:00.000Z",
+      }],
+      chunks: [{
+        chunk_id: "chunk-memory",
+        record_id: "rec-memory",
+        soil_id: "memory/preferences/rec-memory",
+        chunk_index: 0,
+        chunk_kind: "paragraph",
+        heading_path_json: [],
+        chunk_text: "Use Obsidian as the memory viewer.",
+        token_count: 7,
+        checksum: "memory",
+        created_at: "2026-04-11T09:00:00.000Z",
+      }],
+    });
+  } finally {
+    repo.close();
+  }
+  return indexPath;
 }
 
 describe("Soil snapshot publish", () => {
@@ -80,6 +130,35 @@ describe("Soil snapshot publish", () => {
         "schedule/active.md",
         "status.md",
       ]);
+    } finally {
+      cleanupTempDir(rootDir);
+    }
+  });
+
+  it("includes typed-store-only memory pages after display preparation", async () => {
+    const rootDir = makeTempDir("soil-publish-display-");
+    try {
+      await writeSoilFixture(rootDir);
+      const indexPath = await seedTypedMemoryFixture(rootDir);
+      await writeJsonFileAtomic(path.join(rootDir, "publish.json"), {
+        notion: { enabled: true, token: "secret", parentPageId: "parent", titlePrefix: "Soil" },
+      });
+
+      const result = await publishSoilSnapshots({
+        rootDir,
+        indexPath,
+        provider: "notion",
+        dryRun: true,
+      });
+
+      expect(result.providers[0]?.pages).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          provider: "notion",
+          relativePath: "memory/preferences/rec-memory.md",
+          status: "dry_run",
+        }),
+      ]));
+      await expect(fsp.access(path.join(rootDir, "memory", "preferences", "rec-memory.md"))).resolves.toBeUndefined();
     } finally {
       cleanupTempDir(rootDir);
     }

--- a/src/platform/soil/display/index.ts
+++ b/src/platform/soil/display/index.ts
@@ -1,0 +1,3 @@
+export * from "./types.js";
+export * from "./registry.js";
+export * from "./materialize.js";

--- a/src/platform/soil/display/materialize.ts
+++ b/src/platform/soil/display/materialize.ts
@@ -1,0 +1,485 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import Database from "better-sqlite3";
+import { computeSoilChecksum } from "../checksum.js";
+import { createSoilConfig, getDefaultSoilSqliteIndexPath, type SoilConfig } from "../config.js";
+import { SoilChunkSchema, SoilPageSchema, SoilRecordSchema } from "../contracts.js";
+import { writeSoilMarkdownFile } from "../io.js";
+import { normalizeSoilRelativePath, resolveSoilPageFilePath } from "../paths.js";
+import { baseFrontmatter, nowIso, trimText } from "../projection-support.js";
+import { SoilPageFrontmatterSchema, type SoilKind, type SoilPageFrontmatter, type SoilRoute, type SoilStatus } from "../types.js";
+import type { SoilDisplayMaterializedPage, SoilDisplaySnapshotInput, SoilDisplaySnapshotResult } from "./types.js";
+
+interface SoilRecordRow {
+  record_id: string;
+  record_key: string;
+  version: number;
+  record_type: string;
+  soil_id: string;
+  title: string;
+  summary: string | null;
+  canonical_text: string;
+  goal_id: string | null;
+  task_id: string | null;
+  status: string;
+  confidence: number | null;
+  importance: number | null;
+  source_reliability: number | null;
+  valid_from: string | null;
+  valid_to: string | null;
+  supersedes_record_id: string | null;
+  is_active: number;
+  source_type: string;
+  source_id: string;
+  metadata_json: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface SoilPageRow {
+  page_id: string;
+  soil_id: string;
+  relative_path: string;
+  route: string;
+  kind: string;
+  status: string;
+  markdown: string;
+  checksum: string;
+  projected_at: string;
+}
+
+interface SoilChunkRow {
+  chunk_id: string;
+  record_id: string;
+  soil_id: string;
+  chunk_index: number;
+  chunk_kind: string;
+  heading_path_json: string;
+  chunk_text: string;
+  token_count: number;
+  checksum: string;
+  created_at: string;
+}
+
+interface SoilPageMemberRow {
+  page_id: string;
+  record_id: string;
+  ordinal: number;
+  role: string;
+  confidence: number | null;
+}
+
+type SoilRenderableRecord = {
+  title: string;
+  record_key: string;
+  record_type: string;
+  soil_id: string;
+  summary: string | null;
+  canonical_text: string;
+  status: string;
+  created_at: string;
+  updated_at: string;
+  confidence: number | null;
+  record_id: string;
+};
+type SoilParsedRecord = ReturnType<typeof toRecord>;
+type SoilParsedChunk = ReturnType<typeof toChunk>;
+
+function toRecord(row: SoilRecordRow) {
+  return SoilRecordSchema.parse({
+    ...row,
+    is_active: Boolean(row.is_active),
+    metadata_json: JSON.parse(row.metadata_json || "{}"),
+  });
+}
+
+function toPage(row: SoilPageRow) {
+  return SoilPageSchema.parse(row);
+}
+
+function toChunk(row: SoilChunkRow) {
+  return SoilChunkSchema.parse({
+    ...row,
+    heading_path_json: JSON.parse(row.heading_path_json || "[]"),
+  });
+}
+
+function isSqliteDatabase(filePath: string): Promise<boolean> {
+  return (async () => {
+    let handle: Awaited<ReturnType<typeof fsp.open>> | null = null;
+    try {
+      handle = await fsp.open(filePath, "r");
+      const buffer = Buffer.alloc(16);
+      const result = await handle.read(buffer, 0, buffer.length, 0);
+      return result.bytesRead === buffer.length && buffer.toString("utf-8") === "SQLite format 3\0";
+    } catch {
+      return false;
+    } finally {
+      await handle?.close();
+    }
+  })();
+}
+
+async function resolveTypedStoreSqlitePath(config: SoilConfig): Promise<string | null> {
+  const candidates = Array.from(new Set([config.indexPath, getDefaultSoilSqliteIndexPath(config.rootDir)]));
+  for (const candidate of candidates) {
+    if (await isSqliteDatabase(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function pageTitleFromRecord(record: SoilRenderableRecord | undefined, fallbackPath: string): string {
+  return record?.title ?? path.posix.basename(fallbackPath, ".md").replaceAll("-", " ");
+}
+
+function inferRouteAndKind(soilId: string): { route: SoilRoute; kind: SoilKind } {
+  const firstSegment = soilId.split("/")[0] ?? "memory";
+  const allowed = new Set<SoilRoute>([
+    "index",
+    "status",
+    "health",
+    "report",
+    "schedule",
+    "memory",
+    "knowledge",
+    "decision",
+    "identity",
+    "goal",
+    "task",
+    "timeline",
+    "operations",
+    "inbox",
+  ]);
+  if (allowed.has(firstSegment as SoilRoute)) {
+    return { route: firstSegment as SoilRoute, kind: firstSegment as SoilKind };
+  }
+  return { route: "memory", kind: "memory" };
+}
+
+function pageStatusFromRecordStatus(status: string): SoilStatus {
+  switch (status) {
+    case "draft":
+      return "draft";
+    case "candidate":
+      return "candidate";
+    case "stale":
+      return "stale";
+    case "superseded":
+    case "replaced":
+      return "superseded";
+    case "archived":
+      return "archived";
+    case "rejected":
+      return "rejected";
+    default:
+      return "confirmed";
+  }
+}
+
+function renderFallbackPageBody(record: SoilRenderableRecord, chunks: SoilParsedChunk[]): string {
+  const chunkSections =
+    chunks.length > 0
+      ? chunks.map((chunk) => [
+          `### ${chunk.chunk_id}`,
+          "",
+          `- Kind: ${chunk.chunk_kind}`,
+          `- Chunk index: ${chunk.chunk_index}`,
+          `- Heading path: ${chunk.heading_path_json.length > 0 ? chunk.heading_path_json.join(" / ") : "[]"}`,
+          `- Token count: ${chunk.token_count}`,
+          `- Checksum: ${chunk.checksum}`,
+          "",
+          chunk.chunk_text,
+          "",
+        ].join("\n"))
+      : ["No chunks."];
+
+  return [
+    `# ${record.title}`,
+    "",
+    `- Record key: ${record.record_key}`,
+    `- Record type: ${record.record_type}`,
+    `- Status: ${record.status}`,
+    `- Soil ID: ${record.soil_id}`,
+    `- Summary: ${record.summary ?? "none"}`,
+    `- Canonical text: ${trimText(record.canonical_text, 360)}`,
+    `- Created: ${record.created_at}`,
+    `- Updated: ${record.updated_at}`,
+    "",
+    "## Chunks",
+    "",
+    ...chunkSections,
+    "",
+  ].join("\n");
+}
+
+function renderGroupedFallbackPageBody(records: SoilParsedRecord[], chunksByRecordId: Map<string, SoilParsedChunk[]>): string {
+  const primary = records[0];
+  if (!primary) {
+    return "# Soil records\n\nNo records.\n";
+  }
+  if (records.length === 1) {
+    return renderFallbackPageBody(primary, chunksByRecordId.get(primary.record_id) ?? []);
+  }
+
+  return [
+    `# ${primary.title}`,
+    "",
+    `- Soil ID: ${primary.soil_id}`,
+    `- Records: ${records.length}`,
+    `- Updated: ${records.map((record) => record.updated_at).sort().at(-1) ?? primary.updated_at}`,
+    "",
+    "## Records",
+    "",
+    ...records.map((record) => {
+      const chunks = chunksByRecordId.get(record.record_id) ?? [];
+      return [
+        `### ${record.title}`,
+        "",
+        `- Record ID: ${record.record_id}`,
+        `- Record key: ${record.record_key}`,
+        `- Record type: ${record.record_type}`,
+        `- Status: ${record.status}`,
+        `- Summary: ${record.summary ?? "none"}`,
+        `- Canonical text: ${trimText(record.canonical_text, 360)}`,
+        "",
+        ...chunks.map((chunk) => [
+          `#### ${chunk.chunk_id}`,
+          "",
+          chunk.chunk_text,
+          "",
+        ].join("\n")),
+      ].join("\n");
+    }),
+    "",
+  ].join("\n");
+}
+
+function buildFrontmatter(input: {
+  soilId: string;
+  title: string;
+  kind: SoilKind;
+  route: SoilRoute;
+  status: SoilStatus;
+  createdAt: string;
+  updatedAt: string;
+  generatedAt: string;
+  summary?: string;
+}): SoilPageFrontmatter {
+  return SoilPageFrontmatterSchema.parse({
+    ...baseFrontmatter({
+      soilId: input.soilId,
+      title: input.title,
+      kind: input.kind,
+      route: input.route,
+      createdAt: input.createdAt,
+      updatedAt: input.updatedAt,
+      generatedAt: input.generatedAt,
+      sourceRefs: [],
+      sourceTruth: "soil",
+      renderedFrom: "soil-display-integration",
+      summary: input.summary,
+    }),
+    status: input.status,
+  });
+}
+
+async function writeMaterializedPage(filePath: string, frontmatter: SoilPageFrontmatter, body: string): Promise<void> {
+  await writeSoilMarkdownFile(filePath, frontmatter, body);
+}
+
+export async function prepareSoilDisplaySnapshot(input: SoilDisplaySnapshotInput = {}): Promise<SoilDisplaySnapshotResult> {
+  const config = createSoilConfig(input);
+  const sqlitePath = await resolveTypedStoreSqlitePath(config);
+  if (sqlitePath === null) {
+    return {
+      rootDir: config.rootDir,
+      indexPath: config.indexPath,
+      typedPageCount: 0,
+      fallbackPageCount: 0,
+      materializedPages: [],
+    };
+  }
+
+  const db = new Database(sqlitePath, { readonly: false, fileMustExist: true });
+  try {
+    const recordRows = db.prepare(`
+      SELECT *
+      FROM soil_records
+      ORDER BY record_key, version
+    `).all() as SoilRecordRow[];
+    const records = recordRows.map((row) => toRecord(row));
+    const recordsById = new Map(records.map((record) => [record.record_id, record]));
+    const activeRecords = records.filter((record) => record.is_active);
+
+    const pageRows = db.prepare(`
+      SELECT *
+      FROM soil_pages
+      ORDER BY relative_path
+    `).all() as SoilPageRow[];
+    const pages = pageRows.map((row) => toPage(row));
+    const pagesBySoilId = new Map(pages.map((page) => [page.soil_id, page]));
+
+    const pageIds = pages.map((page) => page.page_id);
+    const memberRows = pageIds.length > 0
+      ? db.prepare(`
+          SELECT *
+          FROM soil_page_members
+          WHERE page_id IN (${pageIds.map(() => "?").join(", ")})
+          ORDER BY page_id, ordinal
+        `).all(...pageIds) as SoilPageMemberRow[]
+      : [];
+    const membersByPageId = new Map<string, SoilPageMemberRow[]>();
+    for (const row of memberRows) {
+      const current = membersByPageId.get(row.page_id) ?? [];
+      current.push(row);
+      membersByPageId.set(row.page_id, current);
+    }
+
+    const chunkRows = db.prepare(`
+      SELECT *
+      FROM soil_chunks
+      ORDER BY record_id, chunk_index
+    `).all() as SoilChunkRow[];
+    const chunksByRecordId = new Map<string, SoilParsedChunk[]>();
+    for (const row of chunkRows) {
+      const current = chunksByRecordId.get(row.record_id) ?? [];
+      current.push(toChunk(row));
+      chunksByRecordId.set(row.record_id, current);
+    }
+
+    const materializedPages: SoilDisplayMaterializedPage[] = [];
+
+    for (const page of pages) {
+      const pageMembers = membersByPageId.get(page.page_id) ?? [];
+      const primaryMember = pageMembers[0];
+      const primaryRecord = primaryMember ? recordsById.get(primaryMember.record_id) : undefined;
+      const generatedAt = page.projected_at;
+      const frontmatter = buildFrontmatter({
+        soilId: page.soil_id,
+        title: pageTitleFromRecord(primaryRecord, page.relative_path),
+        kind: page.kind as SoilKind,
+        route: page.route as SoilRoute,
+        status: page.status as SoilStatus,
+        createdAt: primaryRecord?.created_at ?? generatedAt,
+        updatedAt: primaryRecord?.updated_at ?? generatedAt,
+        generatedAt,
+        summary: primaryRecord?.summary ?? undefined,
+      });
+      const body = page.markdown;
+      const checksum = computeSoilChecksum({ frontmatter, body });
+      const fileFrontmatter = SoilPageFrontmatterSchema.parse({ ...frontmatter, checksum });
+      const filePath = resolveSoilPageFilePath(config.rootDir, page.relative_path);
+      await writeMaterializedPage(filePath, fileFrontmatter, body);
+      materializedPages.push({
+        pageId: page.page_id,
+        soilId: page.soil_id,
+        relativePath: page.relative_path,
+        source: "typed_page",
+        recordIds: pageMembers.map((member) => member.record_id),
+        filePath,
+      });
+    }
+
+    const fallbackRecordsBySoilId = new Map<string, SoilParsedRecord[]>();
+    for (const record of activeRecords) {
+      if (pagesBySoilId.has(record.soil_id)) continue;
+      const current = fallbackRecordsBySoilId.get(record.soil_id) ?? [];
+      current.push(record);
+      fallbackRecordsBySoilId.set(record.soil_id, current);
+    }
+    const fallbackGroups = [...fallbackRecordsBySoilId.entries()];
+    if (fallbackGroups.length > 0) {
+      const insertPage = db.prepare(`
+        INSERT INTO soil_pages (
+          page_id, soil_id, relative_path, route, kind, status, markdown, checksum, projected_at
+        ) VALUES (
+          @page_id, @soil_id, @relative_path, @route, @kind, @status, @markdown, @checksum, @projected_at
+        )
+        ON CONFLICT(page_id) DO UPDATE SET
+          soil_id = excluded.soil_id,
+          relative_path = excluded.relative_path,
+          route = excluded.route,
+          kind = excluded.kind,
+          status = excluded.status,
+          markdown = excluded.markdown,
+          checksum = excluded.checksum,
+          projected_at = excluded.projected_at
+      `);
+      const deleteMembers = db.prepare("DELETE FROM soil_page_members WHERE page_id = ?");
+      const insertMember = db.prepare(`
+        INSERT INTO soil_page_members (page_id, record_id, ordinal, role, confidence)
+        VALUES (@page_id, @record_id, @ordinal, @role, @confidence)
+        ON CONFLICT(page_id, record_id, role) DO UPDATE SET
+          ordinal = excluded.ordinal,
+          confidence = excluded.confidence
+      `);
+      for (const [soilId, recordsForPage] of fallbackGroups) {
+        const record = recordsForPage[0];
+        if (!record) continue;
+        const { route, kind } = inferRouteAndKind(record.soil_id);
+        const updatedAt = recordsForPage.map((item) => item.updated_at).sort().at(-1) ?? record.updated_at;
+        const createdAt = recordsForPage.map((item) => item.created_at).sort().at(0) ?? record.created_at;
+        const generatedAt = updatedAt ?? createdAt ?? nowIso(input.clock);
+        const body = renderGroupedFallbackPageBody(recordsForPage, chunksByRecordId);
+        const frontmatter = buildFrontmatter({
+          soilId,
+          title: record.title,
+          kind,
+          route,
+          status: pageStatusFromRecordStatus(record.status),
+          createdAt: createdAt ?? generatedAt,
+          updatedAt: updatedAt ?? generatedAt,
+          generatedAt,
+          summary: record.summary ?? trimText(record.canonical_text, 180),
+        });
+        const checksum = computeSoilChecksum({ frontmatter, body });
+        const fileFrontmatter = SoilPageFrontmatterSchema.parse({ ...frontmatter, checksum });
+        const relativePath = normalizeSoilRelativePath(soilId);
+        const pageId = `display:${record.record_id}`;
+        insertPage.run({
+          page_id: pageId,
+          soil_id: soilId,
+          relative_path: relativePath,
+          route,
+          kind,
+          status: pageStatusFromRecordStatus(record.status),
+          markdown: body,
+          checksum,
+          projected_at: generatedAt,
+        });
+        deleteMembers.run(pageId);
+        recordsForPage.forEach((memberRecord, ordinal) => {
+          insertMember.run({
+            page_id: pageId,
+            record_id: memberRecord.record_id,
+            ordinal,
+            role: ordinal === 0 ? "primary" : "supporting",
+            confidence: memberRecord.confidence,
+          });
+        });
+        const filePath = resolveSoilPageFilePath(config.rootDir, soilId);
+        await writeMaterializedPage(filePath, fileFrontmatter, body);
+        materializedPages.push({
+          pageId,
+          soilId,
+          relativePath,
+          source: "fallback_record",
+          recordIds: recordsForPage.map((item) => item.record_id),
+          filePath,
+        });
+      }
+    }
+
+    return {
+      rootDir: config.rootDir,
+      indexPath: sqlitePath,
+      typedPageCount: pages.length,
+      fallbackPageCount: fallbackGroups.length,
+      materializedPages,
+    };
+  } finally {
+    db.close();
+  }
+}

--- a/src/platform/soil/display/registry.ts
+++ b/src/platform/soil/display/registry.ts
@@ -1,0 +1,22 @@
+import type { SoilDisplayIntegration } from "./types.js";
+import { prepareSoilDisplaySnapshot } from "./materialize.js";
+
+const BUILTIN_SOIL_DISPLAY_INTEGRATION: SoilDisplayIntegration = {
+  id: "soil-display",
+  title: "Soil display integration",
+  source: "builtin",
+  capabilities: [
+    "materialize_typed_pages",
+    "fallback_project_active_records",
+    "publishable_markdown_snapshot",
+  ],
+  prepare: prepareSoilDisplaySnapshot,
+};
+
+export function listBuiltinSoilDisplayIntegrations(): SoilDisplayIntegration[] {
+  return [BUILTIN_SOIL_DISPLAY_INTEGRATION];
+}
+
+export function getBuiltinSoilDisplayIntegration(id: string): SoilDisplayIntegration | null {
+  return listBuiltinSoilDisplayIntegrations().find((integration) => integration.id === id) ?? null;
+}

--- a/src/platform/soil/display/types.ts
+++ b/src/platform/soil/display/types.ts
@@ -1,0 +1,32 @@
+import type { SoilConfigInput } from "../config.js";
+
+export type SoilDisplayIntegrationSource = "builtin";
+
+export interface SoilDisplaySnapshotInput extends SoilConfigInput {
+  clock?: () => Date;
+}
+
+export interface SoilDisplayMaterializedPage {
+  pageId: string;
+  soilId: string;
+  relativePath: string;
+  source: "typed_page" | "fallback_record";
+  recordIds: string[];
+  filePath: string;
+}
+
+export interface SoilDisplaySnapshotResult {
+  rootDir: string;
+  indexPath: string;
+  typedPageCount: number;
+  fallbackPageCount: number;
+  materializedPages: SoilDisplayMaterializedPage[];
+}
+
+export interface SoilDisplayIntegration {
+  id: string;
+  title: string;
+  source: SoilDisplayIntegrationSource;
+  capabilities: string[];
+  prepare(input: SoilDisplaySnapshotInput): Promise<SoilDisplaySnapshotResult>;
+}

--- a/src/platform/soil/index.ts
+++ b/src/platform/soil/index.ts
@@ -13,6 +13,7 @@ export * from "./content-projections.js";
 export * from "./runtime-rebuild.js";
 export * from "./importer.js";
 export * from "./open.js";
+export * from "./display/index.js";
 export * from "./publish/index.js";
 export * from "./contracts.js";
 export * from "./ddl.js";

--- a/src/platform/soil/open.ts
+++ b/src/platform/soil/open.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import { execFileNoThrow, type ExecFileResult } from "../../base/utils/execFileNoThrow.js";
 import { createSoilConfig, type SoilConfigInput } from "./config.js";
 import { resolveSoilPageFilePath } from "./paths.js";
+import { prepareSoilDisplaySnapshot } from "./display/index.js";
 
 export type SoilOpenViewer = "default" | "finder" | "vscode" | "obsidian" | "logseq";
 export type SoilOpenTarget =
@@ -108,6 +109,7 @@ export function buildSoilOpenCommand(input: SoilOpenInput): SoilOpenCommand {
 
 export async function openSoil(input: SoilOpenInput, runner: SoilOpenRunner = execFileNoThrow): Promise<SoilOpenResult> {
   const command = buildSoilOpenCommand(input);
+  await prepareSoilDisplaySnapshot({ rootDir: input.rootDir, indexPath: input.indexPath });
   const result = await runner(command.command, command.args, { timeoutMs: 10_000 });
   return {
     ...command,

--- a/src/platform/soil/publish/publisher.ts
+++ b/src/platform/soil/publish/publisher.ts
@@ -9,6 +9,7 @@ import {
 import { publishAppleNotesSnapshot, type AppleNotesRunner } from "./apple-notes.js";
 import { publishNotionSnapshot, type NotionPublishClient } from "./notion.js";
 import { collectSoilSnapshotFiles, filterAppleNotesSnapshotFiles } from "./snapshot.js";
+import { prepareSoilDisplaySnapshot } from "../display/index.js";
 import {
   SoilPublishProviderSchema,
   type SoilPublishProvider,
@@ -38,6 +39,7 @@ export async function publishSoilSnapshots(input: SoilPublishConfigInput & {
   const rootDir = resolveSoilPublishRoot(input);
   const config = await loadSoilPublishConfig({ rootDir });
   const state = await loadSoilPublishState(rootDir);
+  await prepareSoilDisplaySnapshot({ rootDir, indexPath: input.indexPath, clock: input.clock });
   const files = await collectSoilSnapshotFiles(rootDir);
   const providers: SoilPublishProviderResult[] = [];
 

--- a/src/runtime/__tests__/builtin-integrations.test.ts
+++ b/src/runtime/__tests__/builtin-integrations.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { BUILTIN_INTEGRATIONS, listBuiltinIntegrations } from "../builtin-integrations.js";
+
+describe("builtin integrations", () => {
+  it("exposes the Soil, MCP, and foreign plugin builtin descriptors", () => {
+    expect(BUILTIN_INTEGRATIONS.map((integration) => integration.id)).toEqual([
+      "soil-display",
+      "mcp-bridge",
+      "foreign-plugin-bridge",
+    ]);
+    expect(listBuiltinIntegrations()).toEqual(BUILTIN_INTEGRATIONS);
+    expect(BUILTIN_INTEGRATIONS.every((integration) => integration.source === "builtin")).toBe(true);
+    expect(BUILTIN_INTEGRATIONS.every((integration) => integration.capabilities.length > 0)).toBe(true);
+  });
+});

--- a/src/runtime/__tests__/foreign-plugin-compatibility.test.ts
+++ b/src/runtime/__tests__/foreign-plugin-compatibility.test.ts
@@ -1,0 +1,88 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { analyzeForeignPluginDirectory, analyzeForeignPluginManifest } from "../foreign-plugins/compatibility.js";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "pulseed-foreign-plugin-test-"));
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+async function writeJson(filePath: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(value, null, 2), "utf-8");
+}
+
+describe("foreign plugin compatibility", () => {
+  it("classifies a safe manifest as convertible", async () => {
+    const pluginDir = path.join(tmpDir, "convertible");
+    await writeJson(path.join(pluginDir, "plugin.json"), {
+      name: "convertible",
+      version: "1.0.0",
+      type: "notifier",
+      capabilities: ["notify"],
+      description: "safe manifest",
+      permissions: {
+        network: false,
+        file_read: false,
+        file_write: false,
+        shell: false,
+      },
+    });
+
+    const report = analyzeForeignPluginDirectory("openclaw", pluginDir);
+    expect(report.status).toBe("convertible");
+    expect(report.permissions).toEqual({
+      network: false,
+      file_read: false,
+      file_write: false,
+      shell: false,
+    });
+    expect(report.manifest?.name).toBe("convertible");
+  });
+
+  it("classifies a manifest with elevated permissions as quarantined", () => {
+    const report = analyzeForeignPluginManifest("hermes", {
+      name: "riskier",
+      version: "1.0.0",
+      type: "notifier",
+      capabilities: ["notify"],
+      description: "needs review",
+      permissions: {
+        network: true,
+        file_read: false,
+        file_write: false,
+        shell: true,
+      },
+    });
+
+    expect(report.status).toBe("quarantined");
+    expect(report.permissions).toEqual({
+      network: true,
+      file_read: false,
+      file_write: false,
+      shell: true,
+    });
+    expect(report.issues[0]).toContain("network");
+    expect(report.manifest?.name).toBe("riskier");
+  });
+
+  it("classifies an invalid manifest as incompatible", () => {
+    const report = analyzeForeignPluginManifest("openclaw", {
+      name: "Bad Name",
+      version: "1.0",
+      type: "custom",
+      capabilities: [],
+      description: "",
+    });
+
+    expect(report.status).toBe("incompatible");
+    expect(report.issues.length).toBeGreaterThan(0);
+  });
+});

--- a/src/runtime/builtin-integrations.ts
+++ b/src/runtime/builtin-integrations.ts
@@ -1,0 +1,47 @@
+import type { BuiltinIntegrationDescriptor } from "./types/builtin-integration.js";
+
+export const BUILTIN_INTEGRATIONS: BuiltinIntegrationDescriptor[] = [
+  {
+    id: "soil-display",
+    kind: "display",
+    title: "Soil Display Bridge",
+    description: "Materializes typed Soil content into publishable Markdown snapshots.",
+    source: "builtin",
+    status: "available",
+    capabilities: [
+      "soil_projection_materialize",
+      "obsidian_markdown_bridge",
+      "notion_snapshot_publish",
+    ],
+  },
+  {
+    id: "mcp-bridge",
+    kind: "bridge",
+    title: "MCP Bridge",
+    description: "Imports MCP servers and keeps them disabled until reviewed.",
+    source: "builtin",
+    status: "available",
+    capabilities: [
+      "mcp_server_import",
+      "disabled_registration",
+      "stdio_transport_bridge",
+    ],
+  },
+  {
+    id: "foreign-plugin-bridge",
+    kind: "bridge",
+    title: "Foreign Plugin Bridge",
+    description: "Classifies Hermes and OpenClaw plugins before they are copied into quarantine.",
+    source: "builtin",
+    status: "available",
+    capabilities: [
+      "foreign_manifest_analysis",
+      "compatibility_report",
+      "quarantined_copy",
+    ],
+  },
+];
+
+export function listBuiltinIntegrations(): BuiltinIntegrationDescriptor[] {
+  return [...BUILTIN_INTEGRATIONS];
+}

--- a/src/runtime/foreign-plugins/compatibility.ts
+++ b/src/runtime/foreign-plugins/compatibility.ts
@@ -1,0 +1,207 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import yaml from "js-yaml";
+import type {
+  ForeignPluginCompatibilityReport,
+  ForeignPluginManifestSummary,
+  ForeignPluginPermissions,
+  ForeignPluginSource,
+} from "./types.js";
+
+const MANIFEST_FILENAMES = ["plugin.yaml", "plugin.json"] as const;
+const NAME_PATTERN = /^[a-z0-9-]+$/;
+const VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
+const SUPPORTED_TYPES = new Set(["adapter", "data_source", "notifier", "schedule_source"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function stringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const result = value.flatMap((item) => (typeof item === "string" && item.trim() ? [item.trim()] : []));
+  return result.length > 0 ? result : undefined;
+}
+
+function readManifest(filePath: string): unknown | undefined {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    if (filePath.endsWith(".yaml")) {
+      return yaml.load(raw) as unknown;
+    }
+    return JSON.parse(raw) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function findManifestPath(pluginDir: string): string | undefined {
+  for (const filename of MANIFEST_FILENAMES) {
+    const candidate = path.join(pluginDir, filename);
+    if (fs.existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function defaultPermissions(): ForeignPluginPermissions {
+  return {
+    network: false,
+    file_read: false,
+    file_write: false,
+    shell: false,
+  };
+}
+
+function normalizePermissions(raw: unknown): { permissions: ForeignPluginPermissions; issues: string[] } {
+  const permissions = defaultPermissions();
+  if (raw === undefined) return { permissions, issues: [] };
+  if (!isRecord(raw)) {
+    return { permissions, issues: ["permissions block must be an object"] };
+  }
+
+  const issues: string[] = [];
+  for (const key of Object.keys(permissions) as Array<keyof ForeignPluginPermissions>) {
+    const value = raw[key];
+    if (value === undefined) continue;
+    if (typeof value !== "boolean") {
+      issues.push(`permissions.${key} must be a boolean`);
+      continue;
+    }
+    permissions[key] = value;
+  }
+  return { permissions, issues };
+}
+
+function summarizeManifest(
+  raw: Record<string, unknown>,
+  pluginDir?: string
+): {
+  summary?: ForeignPluginManifestSummary;
+  issues: string[];
+  permissions: ForeignPluginPermissions;
+} {
+  const issues: string[] = [];
+  const name = stringValue(raw["name"]);
+  if (!name) issues.push("missing plugin name");
+  else if (!NAME_PATTERN.test(name)) issues.push("plugin name must use lowercase letters, digits, and hyphens");
+
+  const version = stringValue(raw["version"]);
+  if (!version) issues.push("missing plugin version");
+  else if (!VERSION_PATTERN.test(version)) issues.push("plugin version must use semver major.minor.patch");
+
+  const type = stringValue(raw["type"]);
+  if (!type) issues.push("missing plugin type");
+  else if (!SUPPORTED_TYPES.has(type)) issues.push(`unsupported plugin type: ${type}`);
+
+  const capabilities = stringArray(raw["capabilities"]);
+  if (!capabilities) issues.push("capabilities must be a non-empty array of strings");
+
+  const description = stringValue(raw["description"]);
+  if (!description) issues.push("missing plugin description");
+
+  const entryPoint = stringValue(raw["entry_point"]) ?? "dist/index.js";
+  if (pluginDir) {
+    const resolvedEntryPoint = path.resolve(pluginDir, entryPoint);
+    const boundary = pluginDir.endsWith(path.sep) ? pluginDir : `${pluginDir}${path.sep}`;
+    if (resolvedEntryPoint !== pluginDir && !resolvedEntryPoint.startsWith(boundary)) {
+      issues.push(`entry_point escapes plugin directory: ${entryPoint}`);
+    }
+  }
+
+  const { permissions, issues: permissionIssues } = normalizePermissions(raw["permissions"]);
+  issues.push(...permissionIssues);
+
+  if (issues.length > 0 || !name || !version || !type || !capabilities || !description) {
+    return { issues, permissions };
+  }
+
+  return {
+    summary: {
+      name,
+      version,
+      type,
+      capabilities,
+      description,
+      entry_point: entryPoint,
+    },
+    issues,
+    permissions,
+  };
+}
+
+export function analyzeForeignPluginManifest(
+  source: ForeignPluginSource,
+  raw: unknown,
+  context: { pluginDir?: string; manifestPath?: string } = {}
+): ForeignPluginCompatibilityReport {
+  const permissions = defaultPermissions();
+  if (!isRecord(raw)) {
+    return {
+      source,
+      status: "incompatible",
+      issues: ["manifest is not an object"],
+      permissions,
+      ...(context.manifestPath ? { manifestPath: context.manifestPath } : {}),
+    };
+  }
+
+  const { summary, issues, permissions: parsedPermissions } = summarizeManifest(raw, context.pluginDir);
+  if (issues.length > 0 || !summary) {
+    return {
+      source,
+      status: "incompatible",
+      issues: issues.length > 0 ? issues : ["manifest is incompatible"],
+      permissions: parsedPermissions,
+      ...(context.manifestPath ? { manifestPath: context.manifestPath } : {}),
+    };
+  }
+
+  const requestedPermissions = Object.entries(parsedPermissions)
+    .flatMap(([key, value]) => (value ? [key] : []));
+  const status = requestedPermissions.length > 0 ? "quarantined" : "convertible";
+  const compatibilityIssues =
+    status === "quarantined"
+      ? [`requested permissions: ${requestedPermissions.join(", ")}`]
+      : ["manifest is compatible and can be translated into a disabled PulSeed plugin"];
+
+  return {
+    source,
+    status,
+    issues: compatibilityIssues,
+    permissions: parsedPermissions,
+    manifest: summary,
+    ...(context.manifestPath ? { manifestPath: context.manifestPath } : {}),
+  };
+}
+
+export function analyzeForeignPluginDirectory(
+  source: ForeignPluginSource,
+  pluginDir: string
+): ForeignPluginCompatibilityReport {
+  const manifestPath = findManifestPath(pluginDir);
+  if (!manifestPath) {
+    return {
+      source,
+      status: "incompatible",
+      issues: ["plugin.yaml or plugin.json was not found"],
+      permissions: defaultPermissions(),
+    };
+  }
+
+  const raw = readManifest(manifestPath);
+  if (raw === undefined) {
+    return {
+      source,
+      status: "incompatible",
+      issues: [`failed to parse manifest: ${path.basename(manifestPath)}`],
+      permissions: defaultPermissions(),
+      manifestPath,
+    };
+  }
+
+  return analyzeForeignPluginManifest(source, raw, { pluginDir, manifestPath });
+}

--- a/src/runtime/foreign-plugins/index.ts
+++ b/src/runtime/foreign-plugins/index.ts
@@ -1,0 +1,11 @@
+export {
+  analyzeForeignPluginDirectory,
+  analyzeForeignPluginManifest,
+} from "./compatibility.js";
+export type {
+  ForeignPluginCompatibilityReport,
+  ForeignPluginCompatibilityStatus,
+  ForeignPluginManifestSummary,
+  ForeignPluginPermissions,
+  ForeignPluginSource,
+} from "./types.js";

--- a/src/runtime/foreign-plugins/types.ts
+++ b/src/runtime/foreign-plugins/types.ts
@@ -1,0 +1,28 @@
+export type ForeignPluginSource = "hermes" | "openclaw";
+
+export type ForeignPluginCompatibilityStatus = "convertible" | "quarantined" | "incompatible";
+
+export interface ForeignPluginPermissions {
+  network: boolean;
+  file_read: boolean;
+  file_write: boolean;
+  shell: boolean;
+}
+
+export interface ForeignPluginManifestSummary {
+  name: string;
+  version: string;
+  type: string;
+  capabilities: string[];
+  description: string;
+  entry_point: string;
+}
+
+export interface ForeignPluginCompatibilityReport {
+  source: ForeignPluginSource;
+  status: ForeignPluginCompatibilityStatus;
+  issues: string[];
+  permissions: ForeignPluginPermissions;
+  manifestPath?: string;
+  manifest?: ForeignPluginManifestSummary;
+}

--- a/src/runtime/types/builtin-integration.ts
+++ b/src/runtime/types/builtin-integration.ts
@@ -1,0 +1,15 @@
+export type BuiltinIntegrationId = "soil-display" | "mcp-bridge" | "foreign-plugin-bridge";
+
+export type BuiltinIntegrationKind = "display" | "bridge";
+
+export type BuiltinIntegrationStatus = "available" | "disabled";
+
+export interface BuiltinIntegrationDescriptor {
+  id: BuiltinIntegrationId;
+  kind: BuiltinIntegrationKind;
+  title: string;
+  description: string;
+  source: "builtin";
+  status: BuiltinIntegrationStatus;
+  capabilities: string[];
+}

--- a/src/tools/query/PluginStateTool/PluginStateTool.ts
+++ b/src/tools/query/PluginStateTool/PluginStateTool.ts
@@ -3,6 +3,7 @@ import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMet
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, PERMISSION_LEVEL, MAX_OUTPUT_CHARS } from "./constants.js";
 import type { PluginLoader } from "../../../runtime/plugin-loader.js";
+import { listBuiltinIntegrations } from "../../../runtime/builtin-integrations.js";
 
 export const PluginStateToolInputSchema = z.object({
   pluginId: z.string().optional(),
@@ -40,9 +41,19 @@ export class PluginStateTool implements ITool<PluginStateToolInput, unknown> {
         enabled: p.status === "loaded",
         status: p.status,
       }));
+      const builtinIntegrations = listBuiltinIntegrations();
 
       if (input.pluginId) {
         const match = plugins.find((p) => p.name === input.pluginId);
+        const builtinMatch = builtinIntegrations.find((integration) => integration.id === input.pluginId);
+        if (builtinMatch) {
+          return {
+            success: true,
+            data: builtinMatch,
+            summary: `Builtin integration ${builtinMatch.id}: kind=${builtinMatch.kind}, status=${builtinMatch.status}`,
+            durationMs: Date.now() - startTime,
+          };
+        }
         if (!match) {
           return {
             success: false,
@@ -62,8 +73,8 @@ export class PluginStateTool implements ITool<PluginStateToolInput, unknown> {
 
       return {
         success: true,
-        data: { plugins },
-        summary: `Found ${plugins.length} plugin(s)`,
+        data: { plugins, builtin_integrations: builtinIntegrations },
+        summary: `Found ${plugins.length} plugin(s) and ${builtinIntegrations.length} builtin integration(s)`,
         durationMs: Date.now() - startTime,
       };
     } catch (err) {


### PR DESCRIPTION
## Summary

- Add a builtin Soil display integration that materializes typed Soil pages and fallback-projects typed records into publishable Markdown.
- Run the display preparation before Soil publish/open paths so Notion and Obsidian see typed-store-only memory.
- Add builtin integration descriptors plus Hermes/OpenClaw foreign plugin compatibility reports while keeping imported plugins quarantined.
- Document the builtin integration, installed plugin, and foreign plugin import boundaries.

## Validation

- npm test -- src/platform/soil/__tests__/soil-publish.test.ts src/platform/soil/__tests__/soil-open.test.ts src/platform/soil/__tests__/soil-platform.test.ts src/runtime/__tests__/builtin-integrations.test.ts src/runtime/__tests__/foreign-plugin-compatibility.test.ts src/interface/cli/__tests__/setup-import.test.ts src/interface/chat/__tests__/self-knowledge-tools.test.ts
- npm run typecheck
- git diff --check
