### PR TITLE
[codex] Add Codex-like agentloop safety policy

### DIFF
--- a/src/adapters/__tests__/openai-codex-adapter.test.ts
+++ b/src/adapters/__tests__/openai-codex-adapter.test.ts
@@ -79,7 +79,7 @@ describe("OpenAICodexCLIAdapter", () => {
       const [cliPath, spawnArgs, opts] = mockSpawn.mock.calls[0] as [string, string[], { cwd: string }];
       expect(cliPath).toBe("codex");
       // Prompt must NOT appear in spawn args (would expose it in `ps aux`)
-      expect(spawnArgs).toEqual(["exec", "-s", "danger-full-access", "--skip-git-repo-check"]);
+      expect(spawnArgs).toEqual(["exec", "-s", "workspace-write", "--skip-git-repo-check"]);
       expect(spawnArgs).not.toContain("run tests");
       expect(opts.cwd).toBe(".");
       // Prompt is delivered via stdin instead
@@ -154,7 +154,7 @@ describe("OpenAICodexCLIAdapter", () => {
 
       const [, spawnArgs] = mockSpawn.mock.calls[0] as [string, string[]];
       expect(spawnArgs).not.toContain("--skip-git-repo-check");
-      expect(spawnArgs).toEqual(["exec", "-s", "danger-full-access"]);
+      expect(spawnArgs).toEqual(["exec", "-s", "workspace-write"]);
     });
 
     it("wraps codex execution with docker terminal backend when configured", async () => {

--- a/src/adapters/agents/openai-codex.ts
+++ b/src/adapters/agents/openai-codex.ts
@@ -3,7 +3,7 @@
 // IAdapter implementation that spawns the `codex` CLI process.
 // The task prompt is written to stdin (not passed as a CLI arg) to avoid
 // exposing sensitive content in `ps aux` output.
-// Uses -s danger-full-access by default for non-interactive execution.
+// Uses -s workspace-write by default for non-interactive execution.
 //
 // Usage: echo "PROMPT" | codex exec [-s danger-full-access] [-m <model>]
 //
@@ -24,8 +24,8 @@ export interface OpenAICodexCLIAdapterConfig {
   /** The executable name / path for the codex CLI. Default: "codex" */
   cliPath?: string;
   /**
-   * Sandbox policy passed via -s flag. Default: "danger-full-access" for
-   * non-interactive execution. Use "workspace-write" for a safer sandbox.
+   * Sandbox policy passed via -s flag. Default: "workspace-write" for
+   * non-interactive execution. Use "danger-full-access" only as an explicit opt-in.
    * Set to null to omit the flag entirely.
    */
   sandboxPolicy?: string | null;
@@ -54,7 +54,7 @@ export class OpenAICodexCLIAdapter implements IAdapter {
   constructor(config: OpenAICodexCLIAdapterConfig = {}, logger?: Logger) {
     this.cliPath = config.cliPath ?? "codex";
     this.sandboxPolicy =
-      config.sandboxPolicy !== undefined ? config.sandboxPolicy : "danger-full-access";
+      config.sandboxPolicy !== undefined ? config.sandboxPolicy : "workspace-write";
     this.model = config.model;
     this.repoPath = config.repoPath?.trim() || ".";
     this.skipGitRepoCheck = config.skipGitRepoCheck ?? true;

--- a/src/base/llm/__tests__/codex-llm-client.test.ts
+++ b/src/base/llm/__tests__/codex-llm-client.test.ts
@@ -111,7 +111,7 @@ describe("CodexLLMClient", () => {
   // ─── spawn arguments ───
 
   describe("sendMessage: spawn args", () => {
-    it("spawns with exec -s danger-full-access --skip-git-repo-check -o <path> - (stdin mode) and cwd set", async () => {
+    it("spawns with exec -s workspace-write --skip-git-repo-check -o <path> - (stdin mode) and cwd set", async () => {
       const client = new CodexLLMClient();
       const child = makeFakeChild();
 
@@ -125,7 +125,7 @@ describe("CodexLLMClient", () => {
       expect(spawnArgs).not.toContain("--ephemeral");
       expect(spawnArgs).not.toContain("--full-auto");
       expect(spawnArgs).toContain("-s");
-      expect(spawnArgs).toContain("danger-full-access");
+      expect(spawnArgs).toContain("workspace-write");
       expect(spawnArgs).toContain("--skip-git-repo-check");
       // --path is not supported by codex-cli 0.114.0+; cwd is used instead
       expect(spawnArgs).not.toContain("--path");

--- a/src/base/llm/codex-llm-client.ts
+++ b/src/base/llm/codex-llm-client.ts
@@ -53,6 +53,10 @@ export interface CodexLLMClientConfig {
   repoPath?: string;
   /** Timeout per call in milliseconds. Default: 120000 (2 minutes) */
   timeoutMs?: number;
+  /** Sandbox passed to codex exec. Default: workspace-write. */
+  sandboxPolicy?: string;
+  /** Pass --skip-git-repo-check. Default: true. */
+  skipGitRepoCheck?: boolean;
 }
 
 /**
@@ -71,6 +75,8 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
   private readonly model: string | undefined;
   private readonly repoPath: string;
   private readonly timeoutMs: number;
+  private readonly sandboxPolicy: string;
+  private readonly skipGitRepoCheck: boolean;
 
   constructor(config: CodexLLMClientConfig = {}) {
     super();
@@ -79,6 +85,8 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
     this.lightModel = config.lightModel;
     this.repoPath = config.repoPath?.trim() || ".";
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.sandboxPolicy = config.sandboxPolicy ?? "workspace-write";
+    this.skipGitRepoCheck = config.skipGitRepoCheck ?? true;
   }
 
   /**
@@ -122,7 +130,7 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
   supportsToolCalling(): boolean { return false; }
 
   /**
-   * Spawn `codex exec -s danger-full-access [-o <tmpfile>] [--model <model>] "PROMPT"`
+   * Spawn `codex exec -s <sandbox> [-o <tmpfile>] [--model <model>] "PROMPT"`
    * and return the response content read from the temp output file.
    */
   private async _spawnCodex(prompt: string, model?: string): Promise<string> {
@@ -132,17 +140,20 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
 
     return new Promise((resolve, reject) => {
 
-      // Build spawn args: exec -s danger-full-access -o <tmpfile> [--model <model>] -
+      // Build spawn args: exec -s <sandbox> -o <tmpfile> [--model <model>] -
       // Prompt is sent via stdin (using "-" as positional arg) to avoid arg length limits.
       // --path is not supported by codex-cli 0.114.0+; use cwd instead (see src/adapters/openai-codex.ts)
       const spawnArgs: string[] = [
         "exec",
         "-s",
-        "danger-full-access",
-        "--skip-git-repo-check",
+        this.sandboxPolicy,
         "-o",
         tmpFile,
       ];
+
+      if (this.skipGitRepoCheck) {
+        spawnArgs.splice(3, 0, "--skip-git-repo-check");
+      }
 
       if (model) {
         spawnArgs.push("--model", model);

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -10,6 +10,7 @@ import * as os from "node:os";
 import { createHash } from "node:crypto";
 import { getPulseedDirPath } from "../utils/paths.js";
 import { writeJsonFileAtomic } from "../utils/json-io.js";
+import type { AgentLoopSecurityConfig } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 
 // ─── OAuth Token Helpers ───
 
@@ -125,6 +126,7 @@ export interface ProviderConfig {
 
   /** Native agentloop runtime settings */
   agent_loop?: {
+    security?: AgentLoopSecurityConfig;
     worktree?: {
       enabled?: boolean;
       base_dir?: string;
@@ -159,6 +161,14 @@ const DEFAULT_PROVIDER_CONFIG: ProviderConfig = {
   provider: "openai",
   model: "gpt-5.4-mini",
   adapter: "openai_codex_cli",
+  agent_loop: {
+    security: {
+      sandbox_mode: "workspace_write",
+      approval_policy: "on_request",
+      network_access: false,
+      trust_project_instructions: true,
+    },
+  },
 };
 
 // Track whether we've already warned about provider config issues in this process

--- a/src/base/llm/provider-factory.ts
+++ b/src/base/llm/provider-factory.ts
@@ -18,6 +18,7 @@ import { NativeAgentLoopAdapter } from "../../adapters/agents/native-agent-loop.
 import { GitHubIssueAdapter } from "../../adapters/github-issue.js";
 import { A2AAdapter } from "../../adapters/agents/a2a-adapter.js";
 import type { ProviderConfig } from "./provider-config.js";
+import { resolveExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 
 type OpenClawACPAdapterCtor = new (config: {
   cliPath?: string;
@@ -72,10 +73,15 @@ export async function buildLLMClient(): Promise<ILLMClient> {
       // CodexLLMClient shells out to the codex CLI which handles auth internally,
       // so no api_key check is needed here.
       if (config.adapter === "openai_codex_cli") {
+        const executionPolicy = resolveExecutionPolicy({
+          workspaceRoot: process.cwd(),
+          security: config.agent_loop?.security,
+        });
         return new CodexLLMClient({
           cliPath: config.codex_cli_path,
           model: config.model,
           lightModel: config.light_model,
+          sandboxPolicy: executionPolicy.sandboxMode === "danger_full_access" ? "danger-full-access" : executionPolicy.sandboxMode.replace("_", "-"),
         });
       }
       // Otherwise use OpenAILLMClient
@@ -141,6 +147,15 @@ export async function buildAdapterRegistry(
   registry.register(new OpenAICodexCLIAdapter({
     cliPath: config.codex_cli_path,
     model: config.model,
+    sandboxPolicy: resolveExecutionPolicy({
+      workspaceRoot: process.cwd(),
+      security: config.agent_loop?.security,
+    }).sandboxMode === "danger_full_access"
+      ? "danger-full-access"
+      : resolveExecutionPolicy({
+          workspaceRoot: process.cwd(),
+          security: config.agent_loop?.security,
+        }).sandboxMode.replace("_", "-"),
     terminalBackend: config.terminal_backend,
   }));
   registry.register(new NativeAgentLoopAdapter());

--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatRunner } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { StateManager } from "../../../base/state/state-manager.js";
+import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
+import type { ChatAgentLoopRunner } from "../../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
+
+vi.mock("../../../platform/observation/context-provider.js", () => ({
+  resolveGitRoot: (cwd: string) => cwd,
+  buildChatContext: (_task: string, cwd: string) => Promise.resolve(`Working directory: ${cwd}`),
+}));
+
+vi.mock("../../../base/llm/provider-config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../base/llm/provider-config.js")>();
+  return {
+    ...actual,
+    loadProviderConfig: vi.fn().mockResolvedValue({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      adapter: "openai_codex_cli",
+      agent_loop: {
+        security: {
+          sandbox_mode: "workspace_write",
+          approval_policy: "on_request",
+          network_access: false,
+          trust_project_instructions: true,
+        },
+      },
+    }),
+  };
+});
+
+function makeMockStateManager(): StateManager {
+  return {
+    writeRaw: vi.fn().mockResolvedValue(undefined),
+    readRaw: vi.fn().mockResolvedValue(null),
+  } as unknown as StateManager;
+}
+
+function makeMockAdapter(): IAdapter {
+  return {
+    adapterType: "mock",
+    execute: vi.fn().mockResolvedValue({
+      success: true,
+      output: "adapter output",
+      error: null,
+      exit_code: 0,
+      elapsed_ms: 10,
+      stopped_reason: "completed",
+    }),
+  } as unknown as IAdapter;
+}
+
+function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
+  return {
+    stateManager: makeMockStateManager(),
+    adapter: makeMockAdapter(),
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ChatRunner policy commands", () => {
+  it("/permissions shows the current execution policy", async () => {
+    const runner = new ChatRunner(makeDeps());
+    runner.startSession("/repo");
+
+    const result = await runner.execute("/permissions", "/repo");
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("sandbox_mode: workspace_write");
+    expect(result.output).toContain("network_access: off");
+  });
+
+  it("/permissions updates sandbox and network settings for the session", async () => {
+    const runner = new ChatRunner(makeDeps());
+    runner.startSession("/repo");
+
+    const result = await runner.execute("/permissions read-only network on approval never", "/repo");
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("sandbox_mode: read_only");
+    expect(result.output).toContain("network_access: on");
+    expect(result.output).toContain("approval_policy: never");
+  });
+
+  it("/review returns diff summary and execution policy", async () => {
+    const runner = new ChatRunner(makeDeps());
+    runner.startSession("/repo");
+
+    const result = await runner.execute("/review", "/repo");
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Review summary");
+    expect(result.output).toContain("Execution policy");
+  });
+
+  it("/fork creates a new session id", async () => {
+    const runner = new ChatRunner(makeDeps());
+    runner.startSession("/repo");
+    const before = runner.getSessionId();
+
+    const result = await runner.execute("/fork Branch copy", "/repo");
+    const after = runner.getSessionId();
+
+    expect(result.success).toBe(true);
+    expect(after).not.toBe(before);
+    expect(result.output).toContain("Forked chat session");
+  });
+
+  it("/undo removes the latest turn from chat history", async () => {
+    const runner = new ChatRunner(makeDeps());
+    runner.startSession("/repo");
+
+    await runner.execute("Do something", "/repo");
+    expect(runner.getCurrentSessionMessages().length).toBe(2);
+
+    const result = await runner.execute("/undo", "/repo");
+
+    expect(result.success).toBe(true);
+    expect(runner.getCurrentSessionMessages().length).toBe(0);
+    expect(result.output).toContain("File changes were not reverted");
+  });
+
+  it("/permissions updates the execution policy used by native agentloop", async () => {
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "agentloop output",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 10,
+        stopped_reason: "completed",
+      }),
+    } as unknown as ChatAgentLoopRunner;
+    const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner }));
+    runner.startSession("/repo");
+
+    await runner.execute("/permissions read-only network on", "/repo");
+    const result = await runner.execute("Run with agentloop", "/repo");
+
+    expect(result.success).toBe(true);
+    expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
+    const input = vi.mocked(chatAgentLoopRunner.execute).mock.calls[0][0] as {
+      toolCallContext?: { executionPolicy?: { sandboxMode: string; networkAccess: boolean } };
+    };
+    expect(input.toolCallContext?.executionPolicy?.sandboxMode).toBe("read_only");
+    expect(input.toolCallContext?.executionPolicy?.networkAccess).toBe(true);
+  });
+});

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -117,6 +117,25 @@ export class ChatHistory {
     return { before, after: this.session.messages.length };
   }
 
+  async removeLastTurn(): Promise<number> {
+    if (this.session.messages.length === 0) return 0;
+
+    let removed = 0;
+    while (this.session.messages.length > 0) {
+      const message = this.session.messages.pop();
+      if (!message) break;
+      removed += 1;
+      if (message.role === "user") break;
+    }
+
+    this.session.messages = this.session.messages.map((message, index) => ({
+      ...message,
+      turnIndex: index,
+    }));
+    await this.persist();
+    return removed;
+  }
+
   getMessages(): ChatMessage[] {
     return [...this.session.messages];
   }

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -51,6 +51,12 @@ import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
 } from "../../runtime/store/runtime-operation-schemas.js";
+import {
+  resolveExecutionPolicy,
+  summarizeExecutionPolicy,
+  withExecutionPolicyOverrides,
+  type ExecutionPolicy,
+} from "../../orchestrator/execution/agent-loop/execution-policy.js";
 
 // ─── Types ───
 
@@ -171,10 +177,16 @@ Goals and tasks
 Configuration
   /config               Show provider configuration with secrets masked
   /model                Show the active provider/model/adapter
+  /permissions [args]   Show or update session execution policy
   /plugins              List installed plugins when plugin metadata is available
 
+Review and branching
+  /review               Show current diff summary and verification context
+  /fork [title]         Fork the current chat session into a new session
+  /undo                 Remove the latest chat turn from session history
+
 Deferred
-  /retry, /undo, and /usage are intentionally not supported yet.`;
+  /retry and /usage are intentionally not supported yet.`;
 
 // ─── Helpers ───
 
@@ -245,6 +257,7 @@ export class ChatRunner {
   onEvent: ((event: ChatEvent) => void) | undefined = undefined;
   private nativeAgentLoopStatePath: string | null = null;
   private runtimeControlContext: RuntimeControlChatContext | null = null;
+  private sessionExecutionPolicy: ExecutionPolicy | null = null;
 
   constructor(deps: ChatRunnerDeps) {
     this.deps = deps;
@@ -263,6 +276,7 @@ export class ChatRunner {
     this.sessionActive = true;
     this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
     this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
+    this.sessionExecutionPolicy = null;
   }
 
   startSessionFromLoadedSession(session: LoadedChatSession): void {
@@ -272,6 +286,7 @@ export class ChatRunner {
     this.sessionActive = true;
     this.nativeAgentLoopStatePath = session.agentLoopStatePath ?? `chat/agentloop/${session.id}.state.json`;
     this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
+    this.sessionExecutionPolicy = null;
   }
 
   getSessionId(): string | null {
@@ -761,8 +776,20 @@ export class ChatRunner {
     if (cmd === "/model") {
       return this.handleModel(start);
     }
+    if (cmd === "/permissions") {
+      return this.handlePermissions(trimmed.slice("/permissions".length).trim(), start);
+    }
     if (cmd === "/plugins") {
       return this.handlePlugins(start);
+    }
+    if (cmd === "/review") {
+      return this.handleReview(start);
+    }
+    if (cmd === "/fork") {
+      return this.handleFork(trimmed.slice("/fork".length).trim(), start);
+    }
+    if (cmd === "/undo") {
+      return this.handleUndo(start);
     }
     if (cmd === "/exit") {
       return { success: true, output: "Exiting chat mode.", elapsed_ms: Date.now() - start };
@@ -817,6 +844,120 @@ export class ChatRunner {
         elapsed_ms: Date.now() - start,
       };
     }
+  }
+
+  private async handlePermissions(args: string, start: number): Promise<ChatRunResult> {
+    const policy = await this.getSessionExecutionPolicy();
+    if (!args) {
+      return {
+        success: true,
+        output: summarizeExecutionPolicy(policy),
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    const tokens = args.toLowerCase().split(/\s+/).filter(Boolean);
+    let nextPolicy = policy;
+    for (let index = 0; index < tokens.length; index++) {
+      const token = tokens[index];
+      if (token === "read-only" || token === "readonly" || token === "read_only") {
+        nextPolicy = withExecutionPolicyOverrides(nextPolicy, { sandboxMode: "read_only" });
+        continue;
+      }
+      if (token === "workspace-write" || token === "workspace_write") {
+        nextPolicy = withExecutionPolicyOverrides(nextPolicy, { sandboxMode: "workspace_write" });
+        continue;
+      }
+      if (token === "full-access" || token === "danger-full-access" || token === "danger_full_access") {
+        nextPolicy = withExecutionPolicyOverrides(nextPolicy, { sandboxMode: "danger_full_access" });
+        continue;
+      }
+      if (token === "network" && tokens[index + 1]) {
+        nextPolicy = withExecutionPolicyOverrides(nextPolicy, { networkAccess: tokens[index + 1] === "on" });
+        index += 1;
+        continue;
+      }
+      if (token === "approval" && tokens[index + 1]) {
+        const approvalPolicy = tokens[index + 1];
+        if (approvalPolicy === "never" || approvalPolicy === "on_request" || approvalPolicy === "untrusted") {
+          nextPolicy = withExecutionPolicyOverrides(nextPolicy, { approvalPolicy });
+          index += 1;
+          continue;
+        }
+      }
+      return {
+        success: false,
+        output: "Usage: /permissions [read-only|workspace-write|full-access] [network on|off] [approval on_request|never|untrusted]",
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    this.sessionExecutionPolicy = nextPolicy;
+    return {
+      success: true,
+      output: summarizeExecutionPolicy(nextPolicy),
+      elapsed_ms: Date.now() - start,
+    };
+  }
+
+  private async handleReview(start: number): Promise<ChatRunResult> {
+    const cwd = this.sessionCwd ?? process.cwd();
+    const diffStat = await checkGitChanges(cwd);
+    const policy = await this.getSessionExecutionPolicy();
+    const output = [
+      "Review summary",
+      diffStat ? diffStat : "No uncommitted changes detected.",
+      "",
+      "Execution policy",
+      summarizeExecutionPolicy(policy),
+    ].join("\n");
+    return { success: true, output, elapsed_ms: Date.now() - start };
+  }
+
+  private async handleFork(title: string, start: number): Promise<ChatRunResult> {
+    const cwd = this.sessionCwd ?? process.cwd();
+    const sessionId = crypto.randomUUID();
+    const baseSession = this.history?.getSessionData() ?? {
+      id: sessionId,
+      cwd,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      messages: [],
+    };
+    const now = new Date().toISOString();
+    const forkedSession: ChatSession = {
+      ...baseSession,
+      id: sessionId,
+      createdAt: now,
+      updatedAt: now,
+      title: title || (baseSession.title ? `${baseSession.title} (fork)` : "Forked session"),
+    };
+    this.history = ChatHistory.fromSession(this.deps.stateManager, forkedSession);
+    this.sessionCwd = cwd;
+    this.sessionActive = true;
+    this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
+    this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
+    await this.history.persist();
+    return {
+      success: true,
+      output: `Forked chat session as ${sessionId}.`,
+      elapsed_ms: Date.now() - start,
+    };
+  }
+
+  private async handleUndo(start: number): Promise<ChatRunResult> {
+    if (!this.history) {
+      return { success: false, output: "No active chat session to undo.", elapsed_ms: Date.now() - start };
+    }
+    const removed = await this.history.removeLastTurn();
+    if (removed === 0) {
+      return { success: false, output: "No chat turn to undo.", elapsed_ms: Date.now() - start };
+    }
+    return {
+      success: true,
+      output: `Removed ${removed} message(s) from chat history. File changes were not reverted.`,
+      elapsed_ms: Date.now() - start,
+    };
   }
 
   private async handleTend(args: string, start: number): Promise<ChatRunResult> {
@@ -1227,6 +1368,9 @@ export class ChatRunner {
             }
             return false;
           },
+          toolCallContext: {
+            executionPolicy: await this.getSessionExecutionPolicy(),
+          },
           ...(this.nativeAgentLoopStatePath ? { resumeStatePath: this.nativeAgentLoopStatePath } : {}),
           ...(resumeState ? { resumeState } : {}),
           ...(resumeOnly ? { resumeOnly: true } : {}),
@@ -1433,7 +1577,7 @@ export class ChatRunner {
   ): Promise<string> {
     const llmClient = this.deps.llmClient!;
     const messages: LLMMessage[] = [{ role: "user", content: prompt }];
-    const toolCallContext = this.buildToolCallContext();
+    const toolCallContext = await this.buildToolCallContext();
 
     for (let loop = 0; loop < MAX_TOOL_LOOPS; loop++) {
       // Recompute tools each iteration so newly activated deferred tools are included
@@ -1954,7 +2098,18 @@ export class ChatRunner {
   }
 
   /** Build a ToolCallContext from ChatRunnerDeps for tool dispatch. */
-  private buildToolCallContext(): ToolCallContext {
+  private async getSessionExecutionPolicy(): Promise<ExecutionPolicy> {
+    if (this.sessionExecutionPolicy) return this.sessionExecutionPolicy;
+    const config = await loadProviderConfig({ saveMigration: false });
+    this.sessionExecutionPolicy = resolveExecutionPolicy({
+      workspaceRoot: this.sessionCwd ?? process.cwd(),
+      security: config.agent_loop?.security,
+    });
+    return this.sessionExecutionPolicy;
+  }
+
+  private async buildToolCallContext(): Promise<ToolCallContext> {
+    const executionPolicy = await this.getSessionExecutionPolicy();
     return {
       cwd: this.sessionCwd ?? process.cwd(),
       goalId: this.deps.goalId ?? "",
@@ -1966,6 +2121,7 @@ export class ChatRunner {
         }
         return false;
       },
+      executionPolicy,
     };
   }
 }

--- a/src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts
+++ b/src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentResult, IAdapter } from "../adapter-layer.js";
+import { executeTask, type TaskExecutorDeps } from "../task/task-executor.js";
+import type { Task } from "../../../base/types/task.js";
+import type { SessionManager } from "../session-manager.js";
+
+vi.mock("../../../base/llm/provider-config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../base/llm/provider-config.js")>();
+  return {
+    ...actual,
+    loadProviderConfig: vi.fn().mockResolvedValue({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      adapter: "openai_codex_cli",
+      agent_loop: {
+        security: {
+          protected_paths: ["build"],
+        },
+      },
+    }),
+  };
+});
+
+function makeTask(): Task {
+  return {
+    id: "task-1",
+    goal_id: "goal-1",
+    strategy_id: null,
+    target_dimensions: ["quality"],
+    primary_dimension: "quality",
+    work_description: "work",
+    rationale: "why",
+    approach: "how",
+    success_criteria: [{ description: "done", verification_method: "review", is_blocking: true }],
+    scope_boundary: { in_scope: ["src"], out_of_scope: [], blast_radius: "low" },
+    constraints: [],
+    plateau_until: null,
+    estimated_duration: null,
+    consecutive_failure_count: 0,
+    reversibility: "reversible",
+    task_category: "normal",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: new Date().toISOString(),
+  };
+}
+
+describe("executeTask protected paths", () => {
+  let stateManager: TaskExecutorDeps["stateManager"];
+  let sessionManager: SessionManager;
+  let adapter: IAdapter;
+  let execFileSyncFn: TaskExecutorDeps["execFileSyncFn"];
+
+  beforeEach(() => {
+    stateManager = {
+      loadGoal: vi.fn().mockResolvedValue({ constraints: ["workspace_path:/repo"] }),
+      readRaw: vi.fn().mockResolvedValue(null),
+      writeRaw: vi.fn().mockResolvedValue(undefined),
+    } as unknown as TaskExecutorDeps["stateManager"];
+    sessionManager = {
+      createSession: vi.fn().mockResolvedValue({ id: "session-1" }),
+      buildTaskExecutionContext: vi.fn().mockReturnValue([]),
+      endSession: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SessionManager;
+    adapter = {
+      adapterType: "mock",
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "done",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 1,
+        stopped_reason: "completed",
+      } as AgentResult),
+    } as unknown as IAdapter;
+    execFileSyncFn = vi.fn().mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "diff") return "build/output.txt";
+      if (args[0] === "ls-files") return "";
+      return "";
+    });
+  });
+
+  it("fails successful task results when configured protected paths are modified", async () => {
+    const result = await executeTask(
+      {
+        stateManager,
+        sessionManager,
+        execFileSyncFn,
+      },
+      makeTask(),
+      adapter,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("build/output.txt");
+  });
+});

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-context-assembler.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-context-assembler.test.ts
@@ -1,0 +1,103 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentLoopContextAssembler, loadProjectInstructionBlocks } from "../agent-loop-context-assembler.js";
+import type { Task } from "../../../../base/types/task.js";
+
+function makeTask(): Task {
+  return {
+    id: "task-1",
+    goal_id: "goal-1",
+    strategy_id: null,
+    target_dimensions: ["quality"],
+    primary_dimension: "quality",
+    work_description: "Implement the change",
+    rationale: "Needed",
+    approach: "Do it safely",
+    success_criteria: [{ description: "done", verification_method: "review", is_blocking: true }],
+    scope_boundary: { in_scope: ["src"], out_of_scope: [], blast_radius: "low" },
+    constraints: [],
+    plateau_until: null,
+    estimated_duration: null,
+    consecutive_failure_count: 0,
+    reversibility: "reversible",
+    task_category: "normal",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: new Date().toISOString(),
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("loadProjectInstructionBlocks", () => {
+  it("loads home and project AGENTS files including overrides", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-agents-"));
+    const homeDir = path.join(tmpRoot, "home");
+    const repoDir = path.join(tmpRoot, "repo");
+    const nestedDir = path.join(repoDir, "packages", "app");
+    fs.mkdirSync(path.join(homeDir, ".pulseed"), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.mkdirSync(nestedDir, { recursive: true });
+
+    fs.writeFileSync(path.join(homeDir, ".pulseed", "AGENTS.md"), "Home instruction");
+    fs.writeFileSync(path.join(homeDir, ".pulseed", "AGENTS.override.md"), "Home override");
+    fs.writeFileSync(path.join(repoDir, "AGENTS.md"), "Repo instruction");
+    fs.writeFileSync(path.join(nestedDir, "AGENTS.override.md"), "Nested override");
+    vi.stubEnv("HOME", homeDir);
+
+    const blocks = await loadProjectInstructionBlocks(nestedDir, 10_000);
+    const sources = blocks.map((block) => block.source);
+
+    expect(sources.some((source) => source.endsWith(".pulseed/AGENTS.md"))).toBe(true);
+    expect(sources.some((source) => source.endsWith(".pulseed/AGENTS.override.md"))).toBe(true);
+    expect(sources.some((source) => source.endsWith("/repo/AGENTS.md"))).toBe(true);
+    expect(sources.some((source) => source.endsWith("/packages/app/AGENTS.override.md"))).toBe(true);
+  });
+
+  it("skips project instructions when trust_project_instructions is off", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-agents-"));
+    const homeDir = path.join(tmpRoot, "home");
+    const repoDir = path.join(tmpRoot, "repo");
+    fs.mkdirSync(path.join(homeDir, ".pulseed"), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+
+    fs.writeFileSync(path.join(homeDir, ".pulseed", "AGENTS.md"), "Home instruction");
+    fs.writeFileSync(path.join(repoDir, "AGENTS.md"), "Repo instruction");
+    vi.stubEnv("HOME", homeDir);
+
+    const blocks = await loadProjectInstructionBlocks(repoDir, 10_000, { trustProjectInstructions: false });
+
+    expect(blocks.some((block) => block.content.includes("Home instruction"))).toBe(true);
+    expect(blocks.some((block) => block.content.includes("Repo instruction"))).toBe(false);
+  });
+});
+
+describe("AgentLoopContextAssembler", () => {
+  it("injects layered AGENTS context into the task prompt", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-agents-"));
+    const homeDir = path.join(tmpRoot, "home");
+    const repoDir = path.join(tmpRoot, "repo");
+    fs.mkdirSync(path.join(homeDir, ".pulseed"), { recursive: true });
+    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+    fs.writeFileSync(path.join(homeDir, ".pulseed", "AGENTS.md"), "Home instruction");
+    fs.writeFileSync(path.join(repoDir, "AGENTS.md"), "Repo instruction");
+    vi.stubEnv("HOME", homeDir);
+
+    const assembler = new AgentLoopContextAssembler();
+    const assembled = await assembler.assembleTask({
+      task: makeTask(),
+      cwd: repoDir,
+      maxProjectDocChars: 10_000,
+    });
+
+    expect(assembled.userPrompt).toContain("Home instruction");
+    expect(assembled.userPrompt).toContain("Repo instruction");
+  });
+});

--- a/src/orchestrator/execution/agent-loop/agent-loop-context-assembler.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-context-assembler.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { homedir } from "node:os";
 import type { Task } from "../../../base/types/task.js";
 
 export interface AgentLoopContextBlock {
@@ -30,6 +31,7 @@ export interface TaskAgentLoopAssemblyInput {
   knowledgeContext?: string;
   soilPrefetch?: (query: SoilPrefetchQuery) => Promise<SoilPrefetchResult | null>;
   maxProjectDocChars?: number;
+  trustProjectInstructions?: boolean;
 }
 
 export interface TaskAgentLoopAssembly {
@@ -43,7 +45,9 @@ export class AgentLoopContextAssembler {
   async assembleTask(input: TaskAgentLoopAssemblyInput): Promise<TaskAgentLoopAssembly> {
     const cwd = resolve(input.cwd ?? process.cwd());
     const blocks: AgentLoopContextBlock[] = [];
-    const projectDocs = await loadProjectInstructionBlocks(cwd, input.maxProjectDocChars ?? 20_000);
+    const projectDocs = await loadProjectInstructionBlocks(cwd, input.maxProjectDocChars ?? 20_000, {
+      trustProjectInstructions: input.trustProjectInstructions ?? true,
+    });
     blocks.push(...projectDocs);
 
     if (input.workspaceContext?.trim()) {
@@ -109,7 +113,11 @@ export class AgentLoopContextAssembler {
   }
 }
 
-export async function loadProjectInstructionBlocks(cwd: string, maxChars: number): Promise<AgentLoopContextBlock[]> {
+export async function loadProjectInstructionBlocks(
+  cwd: string,
+  maxChars: number,
+  options: { trustProjectInstructions?: boolean } = {},
+): Promise<AgentLoopContextBlock[]> {
   const root = findProjectRoot(cwd);
   const dirs: string[] = [];
   let cursor = resolve(cwd);
@@ -123,8 +131,11 @@ export async function loadProjectInstructionBlocks(cwd: string, maxChars: number
 
   const blocks: AgentLoopContextBlock[] = [];
   let remaining = maxChars;
-  for (const dir of dirs.reverse()) {
-    const filePath = join(dir, "AGENTS.md");
+  const homeCandidates = [
+    join(homedir(), ".pulseed", "AGENTS.md"),
+    join(homedir(), ".pulseed", "AGENTS.override.md"),
+  ];
+  for (const filePath of homeCandidates) {
     if (!existsSync(filePath) || remaining <= 0) continue;
     const content = (await readFile(filePath, "utf-8")).slice(0, remaining);
     remaining -= content.length;
@@ -132,8 +143,27 @@ export async function loadProjectInstructionBlocks(cwd: string, maxChars: number
       id: `project-doc:${filePath}`,
       source: filePath,
       content,
-      priority: 5,
+      priority: filePath.endsWith("override.md") ? 1 : 2,
     });
+  }
+
+  if (options.trustProjectInstructions === false) {
+    return blocks;
+  }
+
+  for (const dir of dirs.reverse()) {
+    const candidates = [join(dir, "AGENTS.md"), join(dir, "AGENTS.override.md")];
+    for (const filePath of candidates) {
+      if (!existsSync(filePath) || remaining <= 0) continue;
+      const content = (await readFile(filePath, "utf-8")).slice(0, remaining);
+      remaining -= content.length;
+      blocks.push({
+        id: `project-doc:${filePath}`,
+        source: filePath,
+        content,
+        priority: filePath.endsWith("override.md") ? 3 : 5,
+      });
+    }
   }
   return blocks;
 }

--- a/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
@@ -1,6 +1,9 @@
+import type { SubagentRole } from "./execution-policy.js";
+
 export function buildAgentLoopBaseInstructions(options?: {
   mode?: "task" | "chat";
   extraRules?: string[];
+  role?: SubagentRole;
 }): string {
   const mode = options?.mode ?? "task";
   const header = mode === "task"
@@ -15,8 +18,22 @@ export function buildAgentLoopBaseInstructions(options?: {
     "Keep changes scoped to the requested task. Avoid unrelated edits and avoid fixing unrelated failures.",
     "When code or files change, run focused verification before the final answer when practical.",
     "Preserve and follow AGENTS.md and project instructions from the workspace context.",
+    buildSubagentRoleInstructions(options?.role ?? "default"),
     ...(options?.extraRules ?? []),
   ];
 
   return rules.join("\n");
+}
+
+export function buildSubagentRoleInstructions(role: SubagentRole): string {
+  switch (role) {
+    case "explorer":
+      return "Role: explorer. Prefer read-only inspection and evidence gathering over editing.";
+    case "worker":
+      return "Role: worker. Own the assigned implementation slice and verify the modified path.";
+    case "reviewer":
+      return "Role: reviewer. Do not author changes. Focus on material defects and missing verification.";
+    default:
+      return "Role: default. Use the narrowest tool set needed to complete the request.";
+  }
 }

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -10,7 +10,8 @@ import { withDefaultBudget } from "./agent-loop-turn-context.js";
 import type { BoundedAgentLoopRunner } from "./bounded-agent-loop-runner.js";
 import type { AgentLoopSessionState } from "./agent-loop-session-state.js";
 import { buildAgentLoopBaseInstructions } from "./agent-loop-prompts.js";
-import type { ApprovalRequest } from "../../../tools/types.js";
+import type { ApprovalRequest, ToolCallContext } from "../../../tools/types.js";
+import type { SubagentRole } from "./execution-policy.js";
 
 export const ChatAgentLoopOutputSchema = z.object({
   status: z.enum(["done", "blocked", "failed"]).default("done"),
@@ -28,6 +29,7 @@ export interface ChatAgentLoopRunnerDeps {
   cwd?: string;
   defaultBudget?: Partial<AgentLoopBudget>;
   defaultToolPolicy?: AgentLoopToolPolicy;
+  defaultToolCallContext?: Partial<ToolCallContext>;
   createSession?: (input: {
     goalId?: string;
     eventSink?: AgentLoopEventSink;
@@ -48,9 +50,11 @@ export interface ChatAgentLoopInput {
   budget?: Partial<AgentLoopBudget>;
   toolPolicy?: AgentLoopToolPolicy;
   approvalFn?: (request: ApprovalRequest) => Promise<boolean>;
+  toolCallContext?: Partial<ToolCallContext>;
   resumeState?: AgentLoopSessionState;
   resumeStatePath?: string;
   resumeOnly?: boolean;
+  role?: SubagentRole;
 }
 
 export class ChatAgentLoopRunner {
@@ -90,6 +94,7 @@ export class ChatAgentLoopRunner {
                     "Use tools to answer the user and operate CoreLoop only through tools.",
                     "Do not call CoreLoop internals directly.",
                   ],
+                  role: input.role,
                 }),
                 input.systemPrompt?.trim() ? input.systemPrompt.trim() : "",
               ].join("\n"),
@@ -123,6 +128,9 @@ export class ChatAgentLoopRunner {
             isDestructive: request.isDestructive,
           });
         },
+        ...this.deps.defaultToolCallContext,
+        ...input.toolCallContext,
+        agentRole: input.role,
       },
     });
 

--- a/src/orchestrator/execution/agent-loop/execution-policy.ts
+++ b/src/orchestrator/execution/agent-loop/execution-policy.ts
@@ -1,0 +1,75 @@
+import { resolve } from "node:path";
+
+export type AgentLoopSandboxMode = "read_only" | "workspace_write" | "danger_full_access";
+export type AgentLoopApprovalPolicy = "on_request" | "never" | "untrusted";
+export type SubagentRole = "default" | "explorer" | "worker" | "reviewer";
+
+export interface AgentLoopSecurityConfig {
+  sandbox_mode?: AgentLoopSandboxMode;
+  approval_policy?: AgentLoopApprovalPolicy;
+  network_access?: boolean;
+  protected_paths?: string[];
+  trust_project_instructions?: boolean;
+}
+
+export interface ExecutionPolicy {
+  sandboxMode: AgentLoopSandboxMode;
+  approvalPolicy: AgentLoopApprovalPolicy;
+  networkAccess: boolean;
+  workspaceRoot: string;
+  protectedPaths: string[];
+  trustProjectInstructions: boolean;
+}
+
+export function defaultExecutionPolicy(workspaceRoot: string): ExecutionPolicy {
+  return {
+    sandboxMode: "workspace_write",
+    approvalPolicy: "on_request",
+    networkAccess: false,
+    workspaceRoot: resolve(workspaceRoot),
+    protectedPaths: [],
+    trustProjectInstructions: true,
+  };
+}
+
+export function resolveExecutionPolicy(input: {
+  workspaceRoot: string;
+  security?: AgentLoopSecurityConfig;
+}): ExecutionPolicy {
+  const base = defaultExecutionPolicy(input.workspaceRoot);
+  const security = input.security;
+  if (!security) return base;
+
+  return {
+    sandboxMode: security.sandbox_mode ?? base.sandboxMode,
+    approvalPolicy: security.approval_policy ?? base.approvalPolicy,
+    networkAccess: security.network_access ?? base.networkAccess,
+    workspaceRoot: base.workspaceRoot,
+    protectedPaths: [...(security.protected_paths ?? [])],
+    trustProjectInstructions: security.trust_project_instructions ?? base.trustProjectInstructions,
+  };
+}
+
+export function summarizeExecutionPolicy(policy: ExecutionPolicy): string {
+  const lines = [
+    `sandbox_mode: ${policy.sandboxMode}`,
+    `approval_policy: ${policy.approvalPolicy}`,
+    `network_access: ${policy.networkAccess ? "on" : "off"}`,
+    `workspace_root: ${policy.workspaceRoot}`,
+    `trust_project_instructions: ${policy.trustProjectInstructions ? "on" : "off"}`,
+  ];
+  if (policy.protectedPaths.length > 0) {
+    lines.push(`protected_paths: ${policy.protectedPaths.join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+export function withExecutionPolicyOverrides(
+  policy: ExecutionPolicy,
+  overrides: Partial<Pick<ExecutionPolicy, "sandboxMode" | "approvalPolicy" | "networkAccess" | "trustProjectInstructions">>,
+): ExecutionPolicy {
+  return {
+    ...policy,
+    ...overrides,
+  };
+}

--- a/src/orchestrator/execution/agent-loop/index.ts
+++ b/src/orchestrator/execution/agent-loop/index.ts
@@ -6,6 +6,7 @@ export * from "./agent-loop-dogfood-benchmark.js";
 export * from "./agent-loop-evaluator.js";
 export * from "./agent-loop-events.js";
 export * from "./agent-loop-history.js";
+export * from "./execution-policy.js";
 export * from "./agent-loop-model.js";
 export * from "./agent-loop-model-client.js";
 export * from "./agent-loop-model-client-factory.js";

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-context.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-context.ts
@@ -12,6 +12,7 @@ import { withDefaultBudget } from "./agent-loop-turn-context.js";
 import { TaskAgentLoopOutputSchema, type TaskAgentLoopOutput } from "./task-agent-loop-result.js";
 import { buildAgentLoopBaseInstructions } from "./agent-loop-prompts.js";
 import { isTaskRelevantVerificationCommand } from "./task-agent-loop-verification.js";
+import type { SubagentRole } from "./execution-policy.js";
 
 export interface TaskAgentLoopContextInput {
   task: Task;
@@ -28,6 +29,7 @@ export interface TaskAgentLoopContextInput {
   toolCallContext?: Partial<ToolCallContext>;
   resumeState?: AgentLoopSessionState;
   abortSignal?: AbortSignal;
+  role?: SubagentRole;
 }
 
 export function buildTaskAgentLoopTurnContext(
@@ -61,6 +63,7 @@ export function buildTaskAgentLoopTurnContext(
             "If files changed or you claim files changed, run at least one focused verification command through tools before the final answer.",
             "Do not return status=done while blockers remain.",
           ],
+          role: input.role,
         }),
       },
       { role: "user", content: userPrompt },
@@ -104,6 +107,7 @@ export function buildTaskAgentLoopTurnContext(
       trustBalance: 0,
       preApproved: true,
       approvalFn: async () => false,
+      agentRole: input.role,
       ...input.toolCallContext,
     },
     ...(input.resumeState ? { resumeState: input.resumeState } : {}),

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
@@ -21,6 +21,7 @@ import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
 import type { SoilPrefetchQuery, SoilPrefetchResult } from "./agent-loop-context-assembler.js";
 import { createPersistentAgentLoopSessionFactory } from "./agent-loop-session-factory.js";
 import type { AgentLoopWorktreePolicy } from "./task-agent-loop-worktree.js";
+import { resolveExecutionPolicy } from "./execution-policy.js";
 
 export interface NativeTaskAgentLoopRuntimeDeps {
   llmClient: ILLMClient;
@@ -47,6 +48,10 @@ export function createNativeTaskAgentLoopRunner(
   deps: NativeTaskAgentLoopRuntimeDeps,
 ): TaskAgentLoopRunner {
   const runtime = createNativeAgentLoopRuntime(deps);
+  const executionPolicy = resolveExecutionPolicy({
+    workspaceRoot: deps.cwd ?? process.cwd(),
+    security: deps.providerConfig.agent_loop?.security,
+  });
 
   return new TaskAgentLoopRunner({
     boundedRunner: runtime.boundedRunner,
@@ -55,6 +60,7 @@ export function createNativeTaskAgentLoopRunner(
     defaultModel: runtime.modelInfo.ref,
     defaultBudget: deps.defaultBudget,
     defaultToolPolicy: deps.defaultToolPolicy,
+    defaultToolCallContext: { executionPolicy },
     defaultWorktreePolicy: deps.defaultWorktreePolicy,
     soilPrefetch: deps.soilPrefetch,
     cwd: deps.cwd,
@@ -71,6 +77,10 @@ export function createNativeChatAgentLoopRunner(
   deps: NativeTaskAgentLoopRuntimeDeps,
 ): ChatAgentLoopRunner {
   const runtime = createNativeAgentLoopRuntime(deps);
+  const executionPolicy = resolveExecutionPolicy({
+    workspaceRoot: deps.cwd ?? process.cwd(),
+    security: deps.providerConfig.agent_loop?.security,
+  });
 
   return new ChatAgentLoopRunner({
     boundedRunner: runtime.boundedRunner,
@@ -79,6 +89,7 @@ export function createNativeChatAgentLoopRunner(
     defaultModel: runtime.modelInfo.ref,
     defaultBudget: deps.defaultBudget,
     defaultToolPolicy: deps.defaultToolPolicy,
+    defaultToolCallContext: { executionPolicy },
     cwd: deps.cwd,
     createSession: deps.traceBaseDir
       ? createPersistentAgentLoopSessionFactory({ traceBaseDir: deps.traceBaseDir, kind: "chat" })

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-runner.ts
@@ -18,6 +18,8 @@ import {
   prepareTaskAgentLoopWorkspace,
   type AgentLoopWorktreePolicy,
 } from "./task-agent-loop-worktree.js";
+import type { ToolCallContext } from "../../../tools/types.js";
+import type { SubagentRole } from "./execution-policy.js";
 
 export interface TaskAgentLoopRunnerDeps {
   boundedRunner: BoundedAgentLoopRunner;
@@ -26,6 +28,7 @@ export interface TaskAgentLoopRunnerDeps {
   defaultModel?: AgentLoopModelRef;
   defaultBudget?: Partial<AgentLoopBudget>;
   defaultToolPolicy?: AgentLoopToolPolicy;
+  defaultToolCallContext?: Partial<ToolCallContext>;
   defaultWorktreePolicy?: AgentLoopWorktreePolicy;
   contextAssembler?: AgentLoopContextAssembler;
   soilPrefetch?: (query: SoilPrefetchQuery) => Promise<SoilPrefetchResult | null>;
@@ -44,6 +47,7 @@ export interface TaskAgentLoopRunInput {
   worktreePolicy?: AgentLoopWorktreePolicy;
   resumeState?: AgentLoopSessionState;
   abortSignal?: AbortSignal;
+  role?: SubagentRole;
 }
 
 export class TaskAgentLoopRunner {
@@ -66,6 +70,7 @@ export class TaskAgentLoopRunner {
       knowledgeContext: input.knowledgeContext,
       cwd: workspace.executionCwd,
       soilPrefetch: this.deps.soilPrefetch,
+      trustProjectInstructions: this.deps.defaultToolCallContext?.executionPolicy?.trustProjectInstructions,
     });
     const turn = buildTaskAgentLoopTurnContext({
       task: input.task,
@@ -79,8 +84,10 @@ export class TaskAgentLoopRunner {
       userPrompt: assembled.userPrompt,
       budget: { ...this.deps.defaultBudget, ...input.budget },
       toolPolicy: { ...this.deps.defaultToolPolicy, ...input.toolPolicy },
+      toolCallContext: this.deps.defaultToolCallContext,
       ...(input.resumeState ? { resumeState: input.resumeState } : {}),
       abortSignal: input.abortSignal,
+      role: input.role,
     });
     try {
       const result = await this.deps.boundedRunner.run(turn);

--- a/src/orchestrator/execution/task/task-executor.ts
+++ b/src/orchestrator/execution/task/task-executor.ts
@@ -6,6 +6,8 @@ import type { Task } from "../../../base/types/task.js";
 import { TaskSchema } from "../../../base/types/task.js";
 import type { Strategy } from "../../../base/types/strategy.js";
 import { appendTaskOutcomeEvent } from "./task-outcome-ledger.js";
+import { validateProtectedPath } from "../../../tools/fs/FileValidationTool/protected-path-policy.js";
+import { loadProviderConfig } from "../../../base/llm/provider-config.js";
 const DEBUG = process.env.PULSEED_DEBUG === "true";
 
 // ─── Deps interface ───
@@ -207,26 +209,18 @@ export async function executeTask(
       }
 
       if (changedFiles.length > 0) {
-        const protectedPatterns = [
-          /vitest\.config/,
-          /jest\.config/,
-          /tsconfig/,
-          /package\.json$/,
-          /package-lock\.json$/,
-          /\.config\.(ts|js|mjs)$/,
-        ];
-
-        const protectedChanges = changedFiles.filter((f) =>
-          protectedPatterns.some((p) => p.test(f))
+        const providerConfig = await loadProviderConfig({ saveMigration: false });
+        const protectedPaths = providerConfig.agent_loop?.security?.protected_paths;
+        const protectedChanges = changedFiles.filter((changedFile) =>
+          !validateProtectedPath(changedFile, { cwd: gitCwd, workspaceRoot: gitCwd, protectedPaths }).valid
         );
 
         if (protectedChanges.length > 0) {
-          execFileSyncFn("git", ["checkout", "--", ...protectedChanges], {
-            cwd: gitCwd,
-            encoding: "utf-8",
-          });
+          result.success = false;
+          result.error = `Protected files were modified: ${protectedChanges.join(", ")}`;
           result.output = (result.output || "") +
-            `\n[Scope Check] Reverted ${protectedChanges.length} protected file(s): ${protectedChanges.join(", ")}`;
+            `\n[Scope Check] Protected files were modified: ${protectedChanges.join(", ")}`;
+          result.stopped_reason = "error";
         }
       }
     } catch {

--- a/src/tools/__tests__/permission.test.ts
+++ b/src/tools/__tests__/permission.test.ts
@@ -43,6 +43,77 @@ function makeContext(overrides: Partial<ToolCallContext> = {}): ToolCallContext 
 // --- Tests ---
 
 describe("ToolPermissionManager", () => {
+  describe("execution policy", () => {
+    it("read_only sandbox blocks write tools", async () => {
+      const manager = new ToolPermissionManager({});
+      const tool = makeTool({ permissionLevel: "write_local", isReadOnly: false });
+      const result = await manager.check(tool, {}, makeContext({
+        executionPolicy: {
+          sandboxMode: "read_only",
+          approvalPolicy: "on_request",
+          networkAccess: false,
+          workspaceRoot: "/tmp",
+          protectedPaths: [],
+          trustProjectInstructions: true,
+        },
+      }));
+      expect(result.status).toBe("denied");
+    });
+
+    it("network-off policy blocks remote writes", async () => {
+      const manager = new ToolPermissionManager({});
+      const tool = makeTool({ permissionLevel: "write_remote", isReadOnly: false });
+      const result = await manager.check(tool, {}, makeContext({
+        executionPolicy: {
+          sandboxMode: "workspace_write",
+          approvalPolicy: "on_request",
+          networkAccess: false,
+          workspaceRoot: "/tmp",
+          protectedPaths: [],
+          trustProjectInstructions: true,
+        },
+      }));
+      expect(result.status).toBe("denied");
+    });
+
+    it("network-off policy blocks read-only network tools", async () => {
+      const manager = new ToolPermissionManager({});
+      const tool = makeTool({
+        permissionLevel: "read_only",
+        isReadOnly: true,
+        requiresNetwork: true,
+        tags: ["network"],
+      });
+      const result = await manager.check(tool, {}, makeContext({
+        executionPolicy: {
+          sandboxMode: "workspace_write",
+          approvalPolicy: "on_request",
+          networkAccess: false,
+          workspaceRoot: "/tmp",
+          protectedPaths: [],
+          trustProjectInstructions: true,
+        },
+      }));
+      expect(result.status).toBe("denied");
+    });
+
+    it("read_only policy still allows safe shell reads", async () => {
+      const manager = new ToolPermissionManager({});
+      const tool = makeTool({ name: "shell", permissionLevel: "read_metrics", isReadOnly: false });
+      const result = await manager.check(tool, { command: "git status" }, makeContext({
+        executionPolicy: {
+          sandboxMode: "read_only",
+          approvalPolicy: "on_request",
+          networkAccess: false,
+          workspaceRoot: "/tmp",
+          protectedPaths: [],
+          trustProjectInstructions: true,
+        },
+      }));
+      expect(result.status).toBe("allowed");
+    });
+  });
+
   describe("Layer 1: deny-list", () => {
     it("blocks tool matching deny rule by name", async () => {
       const manager = new ToolPermissionManager({

--- a/src/tools/execution/SpawnSessionTool/SpawnSessionTool.ts
+++ b/src/tools/execution/SpawnSessionTool/SpawnSessionTool.ts
@@ -7,12 +7,31 @@ import { DESCRIPTION } from "./prompt.js";
 import { TAGS, CATEGORY as _CATEGORY, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
 
 export const SpawnSessionInputSchema = z.object({
-  session_type: z.enum(["task_execution", "observation", "task_review", "goal_review", "chat_execution"]),
+  session_type: z.enum(["task_execution", "observation", "task_review", "goal_review", "chat_execution"]).optional(),
+  role: z.enum(["default", "explorer", "worker", "reviewer"]).optional(),
   goal_id: z.string().min(1, "goal_id is required"),
   task_id: z.string().optional(),
   context_budget: z.number().int().positive().optional(),
+}).superRefine((value, ctx) => {
+  if (!value.session_type && !value.role) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["session_type"],
+      message: "session_type or role is required",
+    });
+  }
 });
 export type SpawnSessionInput = z.infer<typeof SpawnSessionInputSchema>;
+
+export function resolveSpawnSessionType(input: Pick<SpawnSessionInput, "session_type" | "role">): SessionType {
+  if (input.session_type) return input.session_type;
+  switch (input.role) {
+    case "explorer": return "observation";
+    case "reviewer": return "task_review";
+    case "worker": return "task_execution";
+    default: return "chat_execution";
+  }
+}
 
 export class SpawnSessionTool implements ITool<SpawnSessionInput, unknown> {
   readonly metadata: ToolMetadata = {
@@ -39,15 +58,20 @@ export class SpawnSessionTool implements ITool<SpawnSessionInput, unknown> {
     const startTime = Date.now();
     try {
       const session = await this.sessionManager.createSession(
-        input.session_type as SessionType,
+        resolveSpawnSessionType(input),
         input.goal_id,
         input.task_id ?? null,
         input.context_budget ?? DEFAULT_CONTEXT_BUDGET,
       );
       return {
         success: true,
-        data: { sessionId: session.id, session_type: session.session_type, goal_id: session.goal_id },
-        summary: `Session ${session.id} created (type=${session.session_type})`,
+        data: {
+          sessionId: session.id,
+          session_type: session.session_type,
+          goal_id: session.goal_id,
+          role: input.role ?? "default",
+        },
+        summary: `Session ${session.id} created (type=${session.session_type}, role=${input.role ?? "default"})`,
         durationMs: Date.now() - startTime,
       };
     } catch (err) {

--- a/src/tools/execution/SpawnSessionTool/__tests__/SpawnSessionTool.test.ts
+++ b/src/tools/execution/SpawnSessionTool/__tests__/SpawnSessionTool.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { SpawnSessionTool } from "../SpawnSessionTool.js";
+import { SpawnSessionTool, resolveSpawnSessionType } from "../SpawnSessionTool.js";
 import type { ToolCallContext } from "../../../types.js";
 import type { SessionManager } from "../../../../orchestrator/execution/session-manager.js";
+import { DEFAULT_CONTEXT_BUDGET } from "../../../../orchestrator/execution/session-manager.js";
 
 function makeContext(): ToolCallContext {
   return {
@@ -82,6 +83,24 @@ describe("SpawnSessionTool", () => {
     expect(sessionManager.createSession).toHaveBeenCalledWith("observation", "goal-1", "task-x", 2048);
   });
 
+  it("maps explorer role to observation session", async () => {
+    expect(resolveSpawnSessionType({ role: "explorer" } as any)).toBe("observation");
+    expect(resolveSpawnSessionType({ role: "worker" } as any)).toBe("task_execution");
+    expect(resolveSpawnSessionType({ role: "reviewer" } as any)).toBe("task_review");
+  });
+
+  it("creates a role-based session when role is provided without session_type", async () => {
+    vi.mocked(sessionManager.createSession).mockResolvedValue({ ...mockSession, session_type: "task_review" } as any);
+
+    const result = await tool.call(
+      { role: "reviewer", goal_id: "goal-1" } as any,
+      makeContext(),
+    );
+
+    expect(sessionManager.createSession).toHaveBeenCalledWith("task_review", "goal-1", null, DEFAULT_CONTEXT_BUDGET);
+    expect(result.summary).toContain("role=reviewer");
+  });
+
   it("handles sessionManager error gracefully", async () => {
     vi.mocked(sessionManager.createSession).mockRejectedValue(new Error("disk full"));
 
@@ -100,6 +119,11 @@ describe("SpawnSessionTool", () => {
 
   it("rejects invalid session_type", () => {
     const parsed = tool.inputSchema.safeParse({ session_type: "invalid_type", goal_id: "goal-1" });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("rejects missing both session_type and role", () => {
+    const parsed = tool.inputSchema.safeParse({ goal_id: "goal-1" });
     expect(parsed.success).toBe(false);
   });
 });

--- a/src/tools/fs/FileEditTool/FileEditTool.ts
+++ b/src/tools/fs/FileEditTool/FileEditTool.ts
@@ -50,7 +50,7 @@ export class FileEditTool implements ITool<FileEditInput, FileEditOutput> {
 
   async call(input: FileEditInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
-    const validation = validateFilePath(input.path, context.cwd);
+    const validation = validateFilePath(input.path, context.cwd, context.executionPolicy?.protectedPaths);
     if (!validation.valid) {
       return {
         success: false,

--- a/src/tools/fs/FileValidationTool/FileValidationTool.ts
+++ b/src/tools/fs/FileValidationTool/FileValidationTool.ts
@@ -1,22 +1,9 @@
-import { isAbsolute, relative, resolve } from "node:path";
-
-const BLOCKED_PATTERNS = [".env", "credentials", "secret", ".ssh/", "id_rsa", "node_modules"];
+import { validateProtectedPath } from "./protected-path-policy.js";
 
 export function validateFilePath(
   filePath: string,
   cwd: string,
+  protectedPaths?: string[],
 ): { valid: boolean; resolved: string; error?: string } {
-  const resolvedCwd = resolve(cwd);
-  const resolved = resolve(cwd, filePath);
-  const pathFromCwd = relative(resolvedCwd, resolved);
-  if (pathFromCwd.startsWith("..") || isAbsolute(pathFromCwd)) {
-    return { valid: false, resolved, error: "Path traversal outside working directory" };
-  }
-  const lower = resolved.toLowerCase();
-  for (const p of BLOCKED_PATTERNS) {
-    if (lower.includes(p)) {
-      return { valid: false, resolved, error: `Blocked: path contains sensitive pattern "${p}"` };
-    }
-  }
-  return { valid: true, resolved };
+  return validateProtectedPath(filePath, { cwd, workspaceRoot: cwd, protectedPaths });
 }

--- a/src/tools/fs/FileValidationTool/__tests__/FileValidationTool.test.ts
+++ b/src/tools/fs/FileValidationTool/__tests__/FileValidationTool.test.ts
@@ -45,4 +45,10 @@ describe("validateFilePath", () => {
     expect(result.valid).toBe(false);
     expect(result.error).toContain("node_modules");
   });
+
+  it("rejects custom protected paths from execution policy", () => {
+    const result = validateFilePath("build/output.txt", cwd, ["build"]);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("build");
+  });
 });

--- a/src/tools/fs/FileValidationTool/protected-path-policy.ts
+++ b/src/tools/fs/FileValidationTool/protected-path-policy.ts
@@ -1,0 +1,80 @@
+import { realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+const DEFAULT_PROTECTED_PATH_PATTERNS = [
+  ".git",
+  ".codex",
+  ".agents",
+  ".pulseed",
+  "AGENTS.md",
+  "AGENTS.override.md",
+  ".env",
+  ".env.local",
+  ".env.production",
+  "credentials",
+  "secret",
+  ".ssh",
+  "id_rsa",
+  "node_modules",
+];
+
+export interface ProtectedPathPolicyInput {
+  cwd: string;
+  workspaceRoot?: string;
+  protectedPaths?: string[];
+}
+
+export interface ProtectedPathValidationResult {
+  valid: boolean;
+  resolved: string;
+  error?: string;
+}
+
+export function validateProtectedPath(
+  filePath: string,
+  input: ProtectedPathPolicyInput,
+): ProtectedPathValidationResult {
+  const workspaceRoot = canonicalPath(input.workspaceRoot ?? input.cwd);
+  const resolved = canonicalPath(resolve(input.cwd, filePath));
+  const pathFromWorkspace = relative(workspaceRoot, resolved);
+
+  if (pathFromWorkspace.startsWith("..") || isAbsolute(pathFromWorkspace)) {
+    return { valid: false, resolved, error: "Path traversal outside workspace root" };
+  }
+
+  const protectedPatterns = [
+    ...DEFAULT_PROTECTED_PATH_PATTERNS,
+    ...(input.protectedPaths ?? []),
+  ];
+  const normalized = normalizeForMatch(pathFromWorkspace === "" ? "." : pathFromWorkspace);
+  for (const pattern of protectedPatterns) {
+    const protectedPattern = normalizeForMatch(pattern);
+    const isBroadToken = !protectedPattern.includes("/") && !protectedPattern.startsWith(".");
+    if (
+      normalized === protectedPattern
+      || normalized.startsWith(`${protectedPattern}/`)
+      || normalized.includes(`/${protectedPattern}/`)
+      || (isBroadToken && normalized.includes(protectedPattern))
+    ) {
+      return {
+        valid: false,
+        resolved,
+        error: `Blocked: path targets protected area "${pattern}"`,
+      };
+    }
+  }
+
+  return { valid: true, resolved };
+}
+
+function canonicalPath(value: string): string {
+  try {
+    return realpathSync(value);
+  } catch {
+    return resolve(value);
+  }
+}
+
+function normalizeForMatch(value: string): string {
+  return value.split(sep).join("/").replace(/^\.\/+/, "").toLowerCase();
+}

--- a/src/tools/fs/FileWriteTool/FileWriteTool.ts
+++ b/src/tools/fs/FileWriteTool/FileWriteTool.ts
@@ -39,7 +39,7 @@ export class FileWriteTool implements ITool<FileWriteInput, FileWriteOutput> {
 
   async call(input: FileWriteInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
-    const validation = validateFilePath(input.path, context.cwd);
+    const validation = validateFilePath(input.path, context.cwd, context.executionPolicy?.protectedPaths);
     if (!validation.valid) {
       return {
         success: false,

--- a/src/tools/fs/GlobTool/GlobTool.ts
+++ b/src/tools/fs/GlobTool/GlobTool.ts
@@ -62,7 +62,7 @@ export class GlobTool implements ITool<GlobInput, string[]> {
       return { status: "needs_approval", reason: `Glob pattern may access outside the working directory: ${input.pattern}` };
     }
     if (context) {
-      const validation = validateFilePath(input.path ?? ".", context.cwd);
+      const validation = validateFilePath(input.path ?? ".", context.cwd, context.executionPolicy?.protectedPaths);
       if (!validation.valid) {
         return { status: "needs_approval", reason: `Globbing outside the working directory: ${validation.resolved}` };
       }

--- a/src/tools/fs/GrepTool/GrepTool.ts
+++ b/src/tools/fs/GrepTool/GrepTool.ts
@@ -87,7 +87,7 @@ export class GrepTool implements ITool<GrepInput, string> {
 
   async checkPermissions(input: GrepInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
     if (context) {
-      const validation = validateFilePath(input.path ?? ".", context.cwd);
+      const validation = validateFilePath(input.path ?? ".", context.cwd, context.executionPolicy?.protectedPaths);
       if (!validation.valid) {
         return { status: "needs_approval", reason: `Searching outside the working directory: ${validation.resolved}` };
       }

--- a/src/tools/fs/JsonQueryTool/JsonQueryTool.ts
+++ b/src/tools/fs/JsonQueryTool/JsonQueryTool.ts
@@ -40,7 +40,7 @@ export class JsonQueryTool implements ITool<JsonQueryInput, unknown> {
 
   async checkPermissions(input: JsonQueryInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
     if (context) {
-      const validation = validateFilePath(input.file_path, context.cwd);
+      const validation = validateFilePath(input.file_path, context.cwd, context.executionPolicy?.protectedPaths);
       if (!validation.valid) {
         return { status: "needs_approval", reason: `Reading JSON outside the working directory: ${validation.resolved}` };
       }

--- a/src/tools/fs/ListDirTool/ListDirTool.ts
+++ b/src/tools/fs/ListDirTool/ListDirTool.ts
@@ -66,7 +66,7 @@ export class ListDirTool implements ITool<ListDirInput, DirEntry[]> {
 
   async checkPermissions(input: ListDirInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
     if (context) {
-      const validation = validateFilePath(input.path, context.cwd);
+      const validation = validateFilePath(input.path, context.cwd, context.executionPolicy?.protectedPaths);
       if (!validation.valid) {
         return { status: "needs_approval", reason: `Listing outside the working directory: ${validation.resolved}` };
       }

--- a/src/tools/fs/ReadTool/ReadTool.ts
+++ b/src/tools/fs/ReadTool/ReadTool.ts
@@ -69,7 +69,7 @@ export class ReadTool implements ITool<ReadInput, string> {
       return { status: "needs_approval", reason: `Reading potentially sensitive file: ${basename}` };
     }
     if (context) {
-      const validation = validateFilePath(input.file_path, context.cwd);
+      const validation = validateFilePath(input.file_path, context.cwd, context.executionPolicy?.protectedPaths);
       if (!validation.valid) {
         return { status: "needs_approval", reason: `Reading outside the working directory: ${validation.resolved}` };
       }

--- a/src/tools/network/HttpFetchTool/HttpFetchTool.ts
+++ b/src/tools/network/HttpFetchTool/HttpFetchTool.ts
@@ -236,7 +236,7 @@ export class HttpFetchTool implements ITool<HttpFetchInput, HttpFetchOutput> {
     name: "http_fetch", aliases: ["fetch", "curl", "http"],
     permissionLevel: PERMISSION_LEVEL, isReadOnly: true, isDestructive: false,
     shouldDefer: true, alwaysLoad: false, maxConcurrency: 5,
-    maxOutputChars: MAX_OUTPUT_CHARS, tags: [...TAGS],
+    maxOutputChars: MAX_OUTPUT_CHARS, tags: [...TAGS], requiresNetwork: true,
   };
   readonly inputSchema = HttpFetchInputSchema;
 

--- a/src/tools/network/WebSearchTool/WebSearchTool.ts
+++ b/src/tools/network/WebSearchTool/WebSearchTool.ts
@@ -70,6 +70,7 @@ export class WebSearchTool implements ITool<WebSearchInput, SearchResult[]> {
     maxConcurrency: 3,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    requiresNetwork: true,
   };
 
   readonly inputSchema = WebSearchInputSchema;

--- a/src/tools/permission.ts
+++ b/src/tools/permission.ts
@@ -4,6 +4,7 @@ import type {
   PermissionCheckResult,
   ToolPermissionLevel,
 } from "./types.js";
+import { assessShellCommand } from "./system/ShellTool/command-policy.js";
 
 /**
  * 3-layer permission model for tool invocations.
@@ -30,6 +31,9 @@ export class ToolPermissionManager {
     input: unknown,
     context: ToolCallContext,
   ): Promise<PermissionCheckResult> {
+    const policyResult = this.checkExecutionPolicy(tool, input, context);
+    if (policyResult) return policyResult;
+
     // --- Layer 1: Registry Deny-List ---
     for (const rule of this.denyList) {
       if (this.ruleMatches(rule, tool, input, context)) {
@@ -120,6 +124,40 @@ export class ToolPermissionManager {
     if (rule.inputMatcher && !rule.inputMatcher(input)) return false;
     if (rule.goalId && rule.goalId !== context.goalId) return false;
     return true;
+  }
+
+  private checkExecutionPolicy(
+    tool: ITool,
+    input: unknown,
+    context: ToolCallContext,
+  ): PermissionCheckResult | null {
+    const policy = context.executionPolicy;
+    if (!policy) return null;
+
+    if (tool.metadata.name === "shell" && typeof input === "object" && input !== null) {
+      const command = (input as { command?: unknown }).command;
+      if (typeof command === "string") {
+        const assessment = assessShellCommand(command, policy, context.trusted === true);
+        if (assessment.status === "allowed") return { status: "allowed" };
+        if (assessment.status === "needs_approval") {
+          return { status: "needs_approval", reason: assessment.reason ?? "Shell command requires approval" };
+        }
+        return { status: "denied", reason: assessment.reason ?? "Shell command denied by execution policy" };
+      }
+    }
+
+    if (policy.sandboxMode === "read_only" && !tool.metadata.isReadOnly) {
+      return { status: "denied", reason: "Read-only sandbox blocks mutating tools" };
+    }
+    if (!policy.networkAccess && (tool.metadata.permissionLevel === "write_remote" || tool.metadata.requiresNetwork || tool.metadata.tags.includes("network"))) {
+      return { status: "denied", reason: "Network access is disabled for this session" };
+    }
+    if (tool.metadata.permissionLevel === "write_local" || tool.metadata.permissionLevel === "execute" || tool.metadata.permissionLevel === "write_remote") {
+      if (policy.approvalPolicy !== "never") {
+        return { status: "needs_approval", reason: `Execution policy requires approval for ${tool.metadata.permissionLevel} tools` };
+      }
+    }
+    return null;
   }
 }
 

--- a/src/tools/permission.ts
+++ b/src/tools/permission.ts
@@ -149,7 +149,7 @@ export class ToolPermissionManager {
     if (policy.sandboxMode === "read_only" && !tool.metadata.isReadOnly) {
       return { status: "denied", reason: "Read-only sandbox blocks mutating tools" };
     }
-    if (!policy.networkAccess && (tool.metadata.permissionLevel === "write_remote" || tool.metadata.requiresNetwork || tool.metadata.tags.includes("network"))) {
+    if (!policy.networkAccess && (tool.metadata.permissionLevel === "write_remote" || tool.metadata.requiresNetwork === true || tool.metadata.tags.includes("network"))) {
       return { status: "denied", reason: "Network access is disabled for this session" };
     }
     if (tool.metadata.permissionLevel === "write_local" || tool.metadata.permissionLevel === "execute" || tool.metadata.permissionLevel === "write_remote") {

--- a/src/tools/system/ShellTool/ShellTool.ts
+++ b/src/tools/system/ShellTool/ShellTool.ts
@@ -3,6 +3,7 @@ import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMet
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, MAX_OUTPUT_CHARS, PERMISSION_LEVEL } from "./constants.js";
+import { assessShellCommand } from "./command-policy.js";
 
 export const ShellInputSchema = z.object({
   command: z.string().min(1),
@@ -54,51 +55,12 @@ export class ShellTool implements ITool<ShellInput, ShellOutput> {
   }
 
   async checkPermissions(input: ShellInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
-    const cmd = input.command.trim();
-    const SAFE_PATTERNS = [
-      /^(cat|head|tail|wc|ls|pwd|echo|date|hostname|which|type|file)/,
-      /^git\s+(status|log|diff|show|branch|rev-parse|rev-list|describe|tag\s+-l)/,
-      /^npm\s+(ls|list|view|info|outdated|audit)/,
-      /^npx\s+vitest\s+(run|list|--reporter)/,
-      /^npx\s+tsc\s+--noEmit/,
-      /^rg\s/, /^find\s/, /^du\s/, /^df\s/, /^tree\s/,
-    ];
-    const DENY_PATTERNS = [
-      /rm\s/, /mv\s/, /cp\s/, /mkdir\s/, /touch\s/, /chmod\s/, /chown\s/,
-      /git\s+(push|commit|merge|rebase|reset|checkout|clean|stash)/,
-      /npm\s+(install|uninstall|publish|run|exec)/,
-      /curl\s.*(-X\s*(POST|PUT|DELETE|PATCH)|-d\s)/,
-      /wget\s/, /sudo\s/, /mkfs/, /dd\s+if=/, /shutdown/, /reboot/,
-    ];
-    const segments = cmd.split(/\s*(?:&&|\|\||;)\s*/);
-    // Injection patterns always checked regardless of trust level
-    const INJECTION_PATTERNS = [/>/, /\|.*(tee|dd|rm|mv)/];
-    for (const segment of segments) {
-      const trimmed = segment.trim();
-      if (!trimmed) continue;
-      if (INJECTION_PATTERNS.some(p => p.test(trimmed))) {
-        return { status: "denied", reason: `Denied command segment (injection risk): ${trimmed}` };
-      }
+    const assessment = assessShellCommand(input.command, context?.executionPolicy, context?.trusted === true);
+    if (assessment.status === "allowed") return { status: "allowed" };
+    if (assessment.status === "needs_approval") {
+      return { status: "needs_approval", reason: assessment.reason ?? "Shell command requires approval" };
     }
-    // trusted: skip DENY_PATTERNS and SAFE_PATTERNS; only injection checks above apply
-    if (context?.trusted) {
-      return { status: "allowed" };
-    }
-    for (const segment of segments) {
-      const trimmed = segment.trim();
-      if (!trimmed) continue;
-      if (DENY_PATTERNS.some(p => p.test(trimmed))) {
-        return { status: "denied", reason: `Denied command segment: ${trimmed}` };
-      }
-    }
-    for (const segment of segments) {
-      const trimmed = segment.trim();
-      if (!trimmed) continue;
-      if (!SAFE_PATTERNS.some(p => p.test(trimmed))) {
-        return { status: "needs_approval", reason: `Unknown command segment requires approval: ${trimmed}` };
-      }
-    }
-    return { status: "allowed" };
+    return { status: "denied", reason: assessment.reason ?? "Shell command denied by policy" };
   }
 
   isConcurrencySafe(input: ShellInput): boolean {

--- a/src/tools/system/ShellTool/command-policy.ts
+++ b/src/tools/system/ShellTool/command-policy.ts
@@ -1,0 +1,148 @@
+import type { ExecutionPolicy } from "../../../orchestrator/execution/agent-loop/execution-policy.js";
+
+export interface ShellCommandAssessment {
+  status: "allowed" | "needs_approval" | "denied";
+  reason?: string;
+  capabilities: {
+    readOnly: boolean;
+    localWrite: boolean;
+    network: boolean;
+    destructive: boolean;
+    protectedTarget: boolean;
+  };
+}
+
+const SAFE_PATTERNS = [
+  /^(cat|head|tail|wc|ls|pwd|echo|date|hostname|which|type|file)\b/,
+  /^git\s+(status|log|diff|show|branch|rev-parse|rev-list|describe|tag\s+-l)\b/,
+  /^npm\s+(ls|list|view|info|outdated|audit)\b/,
+  /^npx\s+vitest\s+(run|list|--reporter)\b/,
+  /^npx\s+tsc\s+--noemit\b/i,
+  /^rg\b/, /^find\b/, /^du\b/, /^df\b/, /^tree\b/,
+];
+
+const LOCAL_WRITE_PATTERNS = [
+  /\brm\b/, /\bmv\b/, /\bcp\b/, /\bmkdir\b/, /\btouch\b/, /\bchmod\b/, /\bchown\b/,
+  /\bsed\s+-i\b/, /\bperl\s+-i\b/, /\btee\b/, />/, /\bapply_patch\b/,
+  /\bgit\s+(apply|checkout|restore)\b/,
+  /\bnpm\s+(install|uninstall|run|exec)\b/,
+];
+
+const NETWORK_PATTERNS = [
+  /\bcurl\b/, /\bwget\b/, /\bssh\b/, /\bscp\b/, /\brsync\b/, /\bpip\s+install\b/,
+  /\bnpm\s+(install|publish)\b/, /\bgit\s+(fetch|pull|push|clone)\b/,
+];
+
+const DESTRUCTIVE_PATTERNS = [
+  /\brm\b/, /\bmkfs\b/, /\bdd\s+if=/, /\bshutdown\b/, /\breboot\b/,
+  /\bgit\s+(push|commit|merge|rebase|reset|clean|stash)\b/,
+  /\bsudo\b/,
+];
+
+const BLOCKED_PATTERNS = [
+  /\brm\b/, /\bmv\b/, /\bcp\b/, /\bmkdir\b/, /\btouch\b/, /\bchmod\b/, /\bchown\b/,
+  /\bgit\s+(push|commit|merge|rebase|reset|checkout|clean|stash)\b/,
+  /\bnpm\s+(install|uninstall|publish|run|exec)\b/,
+  /\bcurl\b/, /\bwget\b/, /\bsudo\b/, /\bmkfs\b/, /\bdd\s+if=/, /\bshutdown\b/, /\breboot\b/,
+];
+
+const INJECTION_PATTERNS = [/>/, /\$\(/, /`/, /\|.*(tee|dd|rm|mv)\b/];
+const PROTECTED_TARGET_PATTERNS = [
+  /\.git\b/i,
+  /\.codex\b/i,
+  /\.agents\b/i,
+  /\.pulseed\b/i,
+  /\bagents\.md\b/i,
+  /\.env(\.[a-z0-9_-]+)?\b/i,
+  /\bnode_modules\b/i,
+  /\bpackage\.json\b/i,
+  /\btsconfig(\.[^/\s]+)?\.json\b/i,
+];
+
+export function assessShellCommand(
+  command: string,
+  policy?: ExecutionPolicy,
+  trusted = false,
+): ShellCommandAssessment {
+  const trimmed = command.trim();
+  const segments = trimmed.split(/\s*(?:&&|\|\||;)\s*/).map((segment) => segment.trim()).filter(Boolean);
+  const capabilities = {
+    readOnly: true,
+    localWrite: false,
+    network: false,
+    destructive: false,
+    protectedTarget: false,
+  };
+
+  for (const segment of segments) {
+    if (INJECTION_PATTERNS.some((pattern) => pattern.test(segment))) {
+      return {
+        status: "denied",
+        reason: `Denied command segment (injection risk): ${segment}`,
+        capabilities,
+      };
+    }
+
+    const isSafe = SAFE_PATTERNS.some((pattern) => pattern.test(segment));
+    const writes = LOCAL_WRITE_PATTERNS.some((pattern) => pattern.test(segment));
+    const network = NETWORK_PATTERNS.some((pattern) => pattern.test(segment));
+    const destructive = DESTRUCTIVE_PATTERNS.some((pattern) => pattern.test(segment));
+    const protectedTarget = PROTECTED_TARGET_PATTERNS.some((pattern) => pattern.test(segment));
+
+    if (!isSafe) capabilities.readOnly = false;
+    if (writes) capabilities.localWrite = true;
+    if (network) capabilities.network = true;
+    if (destructive) capabilities.destructive = true;
+    if (protectedTarget) capabilities.protectedTarget = true;
+  }
+
+  if (trusted && !capabilities.protectedTarget) {
+    return { status: "allowed", capabilities };
+  }
+
+  if (segments.some((segment) => INJECTION_PATTERNS.some((pattern) => pattern.test(segment)))) {
+    return {
+      status: "denied",
+      reason: `Denied command segment (injection risk): ${segments.find((segment) => INJECTION_PATTERNS.some((pattern) => pattern.test(segment)))}`,
+      capabilities,
+    };
+  }
+  if (segments.some((segment) => BLOCKED_PATTERNS.some((pattern) => pattern.test(segment)))) {
+    return { status: "denied", reason: `Denied command segment: ${segments.find((segment) => BLOCKED_PATTERNS.some((pattern) => pattern.test(segment)))}`, capabilities };
+  }
+  if (capabilities.destructive) {
+    return { status: "denied", reason: "Denied command segment: destructive shell command", capabilities };
+  }
+  if (capabilities.protectedTarget && capabilities.localWrite) {
+    return { status: "denied", reason: "Shell command targets a protected path", capabilities };
+  }
+  if (capabilities.network && policy && !policy.networkAccess) {
+    return { status: "denied", reason: "Network access is disabled for this session", capabilities };
+  }
+  if (!capabilities.localWrite && !capabilities.network && capabilities.readOnly) {
+    return { status: "allowed", capabilities };
+  }
+
+  if (policy?.sandboxMode === "read_only") {
+    return { status: "denied", reason: "Read-only sandbox blocks mutating shell commands", capabilities };
+  }
+
+  if (!policy) {
+    return {
+      status: capabilities.localWrite || capabilities.network || !capabilities.readOnly ? "needs_approval" : "allowed",
+      reason: capabilities.localWrite || capabilities.network || !capabilities.readOnly ? "Unknown command segment requires approval" : undefined,
+      capabilities,
+    };
+  }
+
+  const needsApproval = policy.approvalPolicy !== "never";
+  if (capabilities.localWrite || capabilities.network) {
+    return {
+      status: needsApproval ? "needs_approval" : "allowed",
+      reason: needsApproval ? "Shell command requires approval under current execution policy" : undefined,
+      capabilities,
+    };
+  }
+
+  return { status: "allowed", capabilities };
+}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { ExecutionPolicy, SubagentRole } from "../orchestrator/execution/agent-loop/execution-policy.js";
 
 // --- Tool Result ---
 
@@ -72,6 +73,8 @@ export const ToolMetadataSchema = z.object({
    * Used by the context-filtered tier of the registry.
    */
   tags: z.array(z.string()).default([]),
+  /** Whether this tool requires network access even if it is otherwise read-only. */
+  requiresNetwork: z.boolean().default(false),
 });
 
 export type ToolMetadata = z.infer<typeof ToolMetadataSchema>;
@@ -150,6 +153,10 @@ export interface ToolCallContext {
   onApprovalRequested?: (request: ApprovalRequest & { callId?: string }) => Promise<void> | void;
   /** When true, bypass DENY_PATTERNS in ShellTool (internal use only) */
   trusted?: boolean;
+  /** Shared execution policy for chat/agent-loop sessions. */
+  executionPolicy?: ExecutionPolicy;
+  /** Optional subagent role for delegated runs. */
+  agentRole?: SubagentRole;
   /** Abort signal for cancellation */
   abortSignal?: AbortSignal;
   /** Timeout in milliseconds (per-tool-call) */

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -74,7 +74,7 @@ export const ToolMetadataSchema = z.object({
    */
   tags: z.array(z.string()).default([]),
   /** Whether this tool requires network access even if it is otherwise read-only. */
-  requiresNetwork: z.boolean().default(false),
+  requiresNetwork: z.boolean().optional(),
 });
 
 export type ToolMetadata = z.infer<typeof ToolMetadataSchema>;


### PR DESCRIPTION
## Summary

Adds Codex-like safety and orchestration behavior to PulSeed's native `agent_loop` path.

- Introduces a shared execution policy with sandbox mode, approval policy, network access, protected paths, and project-instruction trust settings.
- Changes Codex CLI defaults from `danger-full-access` to `workspace-write` unless explicitly configured otherwise.
- Centralizes shell command assessment and protected path validation.
- Wires `/permissions`, `/review`, `/fork`, and `/undo` into chat mode.
- Extends AGENTS loading to include home-level instructions, overrides, and trust gating.
- Adds subagent roles for explorer, worker, reviewer, and default sessions.
- Ensures `network_access=false` blocks read-only network tools such as `http_fetch` and `web_search`.

## Why

`agent_loop` is intended to behave more like Codex during general chat task execution. The previous implementation had unsafe defaults, ad hoc shell permission logic, shallow AGENTS handling, and no first-class way to expose session policy or subagent roles.

## Validation

Ran in an isolated worktree created from `origin/main`:

```bash
npx vitest run \
  src/base/llm/__tests__/provider-factory.test.ts \
  src/base/llm/__tests__/provider-config.test.ts \
  src/interface/chat/__tests__/chat-runner.test.ts \
  src/interface/chat/__tests__/chat-runner-permissions.test.ts \
  src/interface/chat/__tests__/chat-runner-policy.test.ts \
  src/tools/__tests__/permission.test.ts \
  src/tools/system/ShellTool/__tests__/ShellTool.test.ts \
  src/tools/fs/FileValidationTool/__tests__/FileValidationTool.test.ts \
  src/tools/execution/SpawnSessionTool/__tests__/SpawnSessionTool.test.ts \
  src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts \
  src/orchestrator/execution/agent-loop/__tests__/agent-loop-context-assembler.test.ts \
  src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts \
  src/adapters/__tests__/openai-codex-adapter.test.ts \
  src/base/llm/__tests__/codex-llm-client.test.ts
```

Result: 14 test files passed, 242 tests passed.

## Notes

The PR branch was built in a separate worktree from `origin/main` so the unrelated TUI changes currently present in the original local checkout are not included.
