### PR TITLE
[codex] Add structured TUI diff rendering for verification results

### DIFF
--- a/src/interface/tui/__tests__/diff-view.test.ts
+++ b/src/interface/tui/__tests__/diff-view.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { diffLineColor } from "../diff-view.js";
+import { theme } from "../theme.js";
+
+describe("diffLineColor", () => {
+  it("colors added lines as success", () => {
+    expect(diffLineColor("+added line")).toBe(theme.success);
+  });
+
+  it("colors removed lines as error", () => {
+    expect(diffLineColor("-removed line")).toBe(theme.error);
+  });
+
+  it("colors hunk headers as info", () => {
+    expect(diffLineColor("@@ -1 +1 @@")).toBe(theme.info);
+  });
+
+  it("colors file headers distinctly from content changes", () => {
+    expect(diffLineColor("+++ b/src/example.ts")).toBe(theme.warning);
+    expect(diffLineColor("--- a/src/example.ts")).toBe(theme.warning);
+  });
+});

--- a/src/interface/tui/__tests__/report-view.test.ts
+++ b/src/interface/tui/__tests__/report-view.test.ts
@@ -1,0 +1,77 @@
+import React from "react";
+import { Writable } from "node:stream";
+import { render } from "ink";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ReportView } from "../report-view.js";
+import { ReportSchema } from "../../../base/types/report.js";
+
+vi.mock("ink", async () => {
+  const actual = await vi.importActual<typeof import("ink")>("ink");
+  return {
+    ...actual,
+    useInput: vi.fn(),
+    useStdout: () => ({ stdout: { columns: 80, rows: 24 } }),
+  };
+});
+
+describe("ReportView", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders structured verification diffs from report metadata", () => {
+    const report = ReportSchema.parse({
+      id: "report-1",
+      report_type: "execution_summary",
+      goal_id: "goal-1",
+      title: "Execution Summary - Loop 1",
+      content: "## Execution Summary\n\nTask completed.",
+      verbosity: "standard",
+      generated_at: new Date("2026-04-18T00:00:00.000Z").toISOString(),
+      delivered_at: null,
+      read: false,
+      metadata: {
+        task_verification_diffs: [
+          {
+            path: "src/example.ts",
+            patch: [
+              "diff --git a/src/example.ts b/src/example.ts",
+              "@@ -1 +1 @@",
+              "-before",
+              "+after",
+            ].join("\n"),
+          },
+        ],
+      },
+    });
+
+    let output = "";
+    const stdout = new Writable({
+      write(chunk, _encoding, callback) {
+        output += chunk.toString();
+        callback();
+      },
+    }) as Writable & { columns: number; rows: number };
+    stdout.columns = 80;
+    stdout.rows = 24;
+
+    const screen = render(
+      React.createElement(ReportView, {
+        report,
+        onDismiss: () => {},
+      }),
+      {
+        patchConsole: false,
+        stdout,
+        stderr: process.stderr,
+      },
+    );
+
+    expect(output).toContain("File Diff");
+    expect(output).toContain("src/example.ts");
+    expect(output).toContain("-before");
+    expect(output).toContain("+after");
+
+    screen.unmount();
+  });
+});

--- a/src/interface/tui/diff-view.tsx
+++ b/src/interface/tui/diff-view.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Text } from "ink";
+import { theme } from "./theme.js";
+
+export function diffLineColor(line: string): string | undefined {
+  if (line.startsWith("+") && !line.startsWith("+++")) return theme.success;
+  if (line.startsWith("-") && !line.startsWith("---")) return theme.error;
+  if (line.startsWith("@@")) return theme.info;
+  if (
+    line.startsWith("diff --git") ||
+    line.startsWith("index ") ||
+    line.startsWith("---") ||
+    line.startsWith("+++")
+  ) {
+    return theme.warning;
+  }
+  return undefined;
+}
+
+export function DiffLine({ line }: { line: string }) {
+  const color = diffLineColor(line);
+  return <Text {...(color ? { color } : {})}>{line}</Text>;
+}

--- a/src/interface/tui/report-view.tsx
+++ b/src/interface/tui/report-view.tsx
@@ -8,8 +8,10 @@
 import React, { useState } from "react";
 import { Box, Text, useInput, useStdout } from "ink";
 import { renderMarkdownLines } from "./markdown-renderer.js";
+import type { MarkdownLine } from "./markdown-renderer.js";
 import type { Report } from "../../base/types/report.js";
 import { reportColor } from "./theme.js";
+import { DiffLine } from "./diff-view.js";
 
 function reportIcon(reportType: Report["report_type"]): string {
   switch (reportType) {
@@ -43,6 +45,39 @@ export interface ReportViewProps {
   onDismiss: () => void;
 }
 
+type ReportViewLine =
+  | { kind: "markdown"; line: MarkdownLine }
+  | { kind: "diff"; text: string };
+
+function buildReportViewLines(report: Report): ReportViewLine[] {
+  const lines: ReportViewLine[] = renderMarkdownLines(report.content).map((line) => ({
+    kind: "markdown",
+    line,
+  }));
+  const fileDiffs = report.metadata?.task_verification_diffs ?? [];
+  if (fileDiffs.length === 0) {
+    return lines;
+  }
+
+  const lastLine = lines[lines.length - 1];
+  if (lastLine && lastLine.kind === "markdown" && lastLine.line.text !== "") {
+    lines.push({ kind: "markdown", line: { text: "" } });
+  }
+
+  lines.push({ kind: "markdown", line: { text: "File Diff", bold: true } });
+  lines.push({ kind: "markdown", line: { text: "" } });
+
+  for (const fileDiff of fileDiffs) {
+    lines.push({ kind: "markdown", line: { text: fileDiff.path, bold: true } });
+    for (const diffLine of fileDiff.patch.split("\n")) {
+      lines.push({ kind: "diff", text: diffLine });
+    }
+    lines.push({ kind: "markdown", line: { text: "" } });
+  }
+
+  return lines;
+}
+
 export function ReportView({ report, onDismiss }: ReportViewProps) {
   const { stdout } = useStdout();
   const termRows = stdout?.rows ?? 24;
@@ -50,7 +85,7 @@ export function ReportView({ report, onDismiss }: ReportViewProps) {
 
   const color = reportColor(report.report_type);
   const icon = reportIcon(report.report_type);
-  const mdLines = renderMarkdownLines(report.content);
+  const reportLines = buildReportViewLines(report);
 
   const generatedAt = report.generated_at
     ? new Date(report.generated_at).toLocaleString("en-US", {
@@ -64,10 +99,10 @@ export function ReportView({ report, onDismiss }: ReportViewProps) {
 
   // Reserve rows: 1 header box border top + 1 header row + 1 goal row + 1 separator + 2 border bottom/footer + 1 footer hint
   const reservedRows = 7;
-  const visibleLines = Math.max(1, termRows - reservedRows);
-  const maxScroll = Math.max(0, mdLines.length - visibleLines);
+  const visibleLineCount = Math.max(1, termRows - reservedRows);
+  const maxScroll = Math.max(0, reportLines.length - visibleLineCount);
   const clampedOffset = Math.min(scrollOffset, maxScroll);
-  const visibleMdLines = mdLines.slice(clampedOffset, clampedOffset + visibleLines);
+  const visibleReportLines = reportLines.slice(clampedOffset, clampedOffset + visibleLineCount);
 
   useInput((input, key) => {
     if (input === "q" || key.escape) {
@@ -105,7 +140,12 @@ export function ReportView({ report, onDismiss }: ReportViewProps) {
       <Text dimColor>{"─".repeat(40)}</Text>
 
       <Box flexDirection="column">
-        {visibleMdLines.map((line, i) => {
+        {visibleReportLines.map((entry, i) => {
+          if (entry.kind === "diff") {
+            return <DiffLine key={i} line={entry.text} />;
+          }
+
+          const { line } = entry;
           if (line.text === "") {
             return <Text key={i}> </Text>;
           }

--- a/src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import { z } from "zod";
 import { StateManager } from "../../../base/state/state-manager.js";
@@ -14,6 +14,7 @@ import type {
   LLMRequestOptions,
   LLMResponse,
 } from "../../../base/llm/llm-client.js";
+import type { ToolExecutor } from "../../../tools/executor.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 
@@ -133,6 +134,7 @@ describe("TaskLifecycle", async () => {
       logger?: import("../../../runtime/logger.js").Logger;
       adapterRegistry?: import("../task/task-lifecycle.js").AdapterRegistry;
       execFileSyncFn?: (cmd: string, args: string[], opts: { cwd: string; encoding: "utf-8" }) => string;
+      toolExecutor?: ToolExecutor;
     }
   ): TaskLifecycle {
     strategyManager = new StrategyManager(stateManager, llmClient);
@@ -242,6 +244,90 @@ describe("TaskLifecycle", async () => {
       const verification = await lifecycle.verifyTask(task, result);
       expect(verification.verdict).toBe("pass");
       expect(verification.confidence).toBeGreaterThanOrEqual(0.8);
+    });
+
+    it("uses execution-provided diffs as the source of truth", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const execute = vi.fn();
+      const lifecycle = createLifecycle(llm, {
+        toolExecutor: { execute } as unknown as ToolExecutor,
+      });
+      const task = makeTask();
+      const result = makeExecutionResult({
+        filesChangedPaths: ["src/example.ts"],
+        fileDiffs: [{
+          path: "src/example.ts",
+          patch: [
+            "diff --git a/src/example.ts b/src/example.ts",
+            "@@ -1 +1 @@",
+            "-before",
+            "+after",
+          ].join("\n"),
+        }],
+      });
+
+      const verification = await lifecycle.verifyTask(task, result);
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(verification.file_diffs).toEqual([
+        expect.objectContaining({
+          path: "src/example.ts",
+          patch: expect.stringContaining("+after"),
+        }),
+      ]);
+    });
+
+    it("falls back to synthetic diff output for newly created files", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const execute = vi.fn()
+        .mockResolvedValueOnce({
+          success: true,
+          data: "",
+          summary: "No changes found",
+          durationMs: 1,
+        })
+        .mockResolvedValueOnce({
+          success: false,
+          data: {
+            stdout: [
+              "diff --git a/src/new-file.ts b/src/new-file.ts",
+              "new file mode 100644",
+              "--- /dev/null",
+              "+++ b/src/new-file.ts",
+              "@@ -0,0 +1 @@",
+              "+export const created = true;",
+            ].join("\n"),
+            stderr: "",
+            exitCode: 1,
+          },
+          summary: "Command failed (exit 1)",
+          error: "",
+          durationMs: 1,
+        });
+      const lifecycle = createLifecycle(llm, {
+        toolExecutor: { execute } as unknown as ToolExecutor,
+      });
+      const task = makeTask();
+      const result = makeExecutionResult({
+        filesChangedPaths: ["src/new-file.ts"],
+      });
+
+      const verification = await lifecycle.verifyTask(task, result);
+
+      expect(execute).toHaveBeenNthCalledWith(
+        2,
+        "shell_command",
+        expect.objectContaining({
+          command: expect.stringContaining("git diff --no-index -- /dev/null"),
+        }),
+        expect.objectContaining({ goalId: task.goal_id })
+      );
+      expect(verification.file_diffs).toEqual([
+        expect.objectContaining({
+          path: "src/new-file.ts",
+          patch: expect.stringContaining("new file mode 100644"),
+        }),
+      ]);
     });
 
     it("uses the preferred execution adapter for mechanical verification", async () => {
@@ -649,6 +735,36 @@ describe("TaskLifecycle", async () => {
         completion_evidence: ["updated handler", "added regression test"],
         verification_hints: ["run targeted vitest"],
       });
+    });
+
+    it("collects git diff entries into the verification result when toolExecutor is available", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const toolExecutor = {
+        execute: async (toolName: string, input: unknown) => {
+          if (toolName !== "git_diff") throw new Error("unexpected tool");
+          const path = (input as { path?: string }).path;
+          return {
+            success: true,
+            data: `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n@@ -1 +1 @@\n-old\n+new`,
+            summary: "diff ok",
+            durationMs: 1,
+          };
+        },
+      } as unknown as ToolExecutor;
+      const lifecycle = createLifecycle(llm, { toolExecutor });
+      const task = makeTask();
+      const result = makeExecutionResult({
+        filesChangedPaths: ["src/example.ts"],
+      });
+
+      const verification = await lifecycle.verifyTask(task, result);
+
+      expect(verification.file_diffs).toEqual([
+        expect.objectContaining({
+          path: "src/example.ts",
+        }),
+      ]);
+      expect(verification.file_diffs[0]?.patch).toContain("+new");
     });
 
     it("truncates very long output in L2 review prompt", async () => {

--- a/src/orchestrator/execution/adapter-layer.ts
+++ b/src/orchestrator/execution/adapter-layer.ts
@@ -6,6 +6,7 @@
 // concrete agent implementations (Claude Code CLI, Claude API, etc.).
 
 import { AdapterError } from "../../base/utils/errors.js";
+import type { VerificationFileDiff } from "../../base/types/task.js";
 
 // ─── Types ───
 
@@ -61,6 +62,10 @@ export interface AgentResult {
    * true = files were changed; false = adapter reported success but no files changed.
    */
   filesChanged?: boolean;
+  /** Relative file paths changed during execution, when available. */
+  filesChangedPaths?: string[];
+  /** Unified diffs captured immediately after execution, when available. */
+  fileDiffs?: VerificationFileDiff[];
   /** Native agentloop execution metadata when the task ran through the in-process loop. */
   agentLoop?: AgentLoopExecutionInfo;
 }

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
@@ -40,6 +40,7 @@ export function taskAgentLoopResultToAgentResult(
       result.stopReason === "timeout" ? "timeout" :
       done ? "completed" : "error",
     filesChanged: result.changedFiles.length > 0 || (result.output ? result.output.filesChanged.length > 0 : result.filesChanged),
+    filesChangedPaths: [...new Set([...(result.output?.filesChanged ?? []), ...result.changedFiles])],
     agentLoop: {
       traceId: result.traceId,
       sessionId: result.sessionId,

--- a/src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts
+++ b/src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { captureExecutionDiffArtifacts, type ExecFileSyncFn } from "../task-diff-capture.js";
+
+function makeExecFileSync(outputs: Record<string, string>, thrownOutputs: Record<string, string> = {}): ExecFileSyncFn {
+  return ((cmd, args) => {
+    const key = `${cmd} ${args.join(" ")}`;
+    if (key in thrownOutputs) {
+      const error = new Error("command failed") as Error & { stdout?: string };
+      error.stdout = thrownOutputs[key];
+      throw error;
+    }
+    return outputs[key] ?? "";
+  }) as ExecFileSyncFn;
+}
+
+describe("captureExecutionDiffArtifacts", () => {
+  it("collects tracked file diffs and changed paths", () => {
+    const execFileSyncFn = makeExecFileSync({
+      "git diff --name-only": "src/example.ts\n",
+      "git ls-files --others --exclude-standard": "",
+      "git diff -- src/example.ts": "diff --git a/src/example.ts b/src/example.ts\n@@ -1 +1 @@\n-old\n+new\n",
+    });
+
+    const result = captureExecutionDiffArtifacts(execFileSyncFn, "/repo");
+
+    expect(result.changedPaths).toEqual(["src/example.ts"]);
+    expect(result.fileDiffs).toEqual([
+      expect.objectContaining({
+        path: "src/example.ts",
+        patch: expect.stringContaining("+new"),
+      }),
+    ]);
+  });
+
+  it("captures untracked file diffs from git diff --no-index output", () => {
+    const execFileSyncFn = makeExecFileSync(
+      {
+        "git diff --name-only": "",
+        "git ls-files --others --exclude-standard": "src/new-file.ts\n",
+        "git diff -- src/new-file.ts": "",
+      },
+      {
+        "git diff --no-index -- /dev/null src/new-file.ts": [
+          "diff --git a/src/new-file.ts b/src/new-file.ts",
+          "new file mode 100644",
+          "--- /dev/null",
+          "+++ b/src/new-file.ts",
+          "@@ -0,0 +1 @@",
+          "+export const created = true;",
+          "",
+        ].join("\n"),
+      },
+    );
+
+    const result = captureExecutionDiffArtifacts(execFileSyncFn, "/repo");
+
+    expect(result.changedPaths).toEqual(["src/new-file.ts"]);
+    expect(result.fileDiffs).toEqual([
+      expect.objectContaining({
+        path: "src/new-file.ts",
+        patch: expect.stringContaining("new file mode 100644"),
+      }),
+    ]);
+  });
+});

--- a/src/orchestrator/execution/task/task-diff-capture.ts
+++ b/src/orchestrator/execution/task/task-diff-capture.ts
@@ -1,0 +1,78 @@
+import type { VerificationFileDiff } from "../../../base/types/task.js";
+
+export type ExecFileSyncFn = (
+  cmd: string,
+  args: string[],
+  opts: { cwd: string; encoding: "utf-8" }
+) => string;
+
+export interface ExecutionDiffArtifacts {
+  changedPaths: string[];
+  fileDiffs: VerificationFileDiff[];
+}
+
+function uniqueNonEmpty(values: string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))];
+}
+
+function readStdoutFromExecError(error: unknown): string {
+  if (
+    error &&
+    typeof error === "object" &&
+    "stdout" in error &&
+    typeof (error as { stdout?: unknown }).stdout === "string"
+  ) {
+    return (error as { stdout: string }).stdout;
+  }
+
+  if (
+    error &&
+    typeof error === "object" &&
+    "stdout" in error &&
+    Buffer.isBuffer((error as { stdout?: unknown }).stdout)
+  ) {
+    return ((error as { stdout: Buffer }).stdout).toString("utf-8");
+  }
+
+  return "";
+}
+
+function runGitRead(
+  execFileSyncFn: ExecFileSyncFn,
+  cwd: string,
+  args: string[],
+): string {
+  try {
+    return execFileSyncFn("git", args, { cwd, encoding: "utf-8" });
+  } catch (error) {
+    return readStdoutFromExecError(error);
+  }
+}
+
+export function captureExecutionDiffArtifacts(
+  execFileSyncFn: ExecFileSyncFn,
+  cwd: string,
+): ExecutionDiffArtifacts {
+  const trackedPaths = runGitRead(execFileSyncFn, cwd, ["diff", "--name-only"])
+    .split("\n");
+  const untrackedPaths = runGitRead(execFileSyncFn, cwd, ["ls-files", "--others", "--exclude-standard"])
+    .split("\n");
+  const changedPaths = uniqueNonEmpty([...trackedPaths, ...untrackedPaths]);
+  const untrackedSet = new Set(uniqueNonEmpty(untrackedPaths));
+
+  const fileDiffs = changedPaths.flatMap((path) => {
+    const trackedPatch = runGitRead(execFileSyncFn, cwd, ["diff", "--", path]).trim();
+    if (trackedPatch.length > 0) {
+      return [{ path, patch: trackedPatch }];
+    }
+
+    if (!untrackedSet.has(path)) {
+      return [];
+    }
+
+    const untrackedPatch = runGitRead(execFileSyncFn, cwd, ["diff", "--no-index", "--", "/dev/null", path]).trim();
+    return untrackedPatch.length > 0 ? [{ path, patch: untrackedPatch }] : [];
+  });
+
+  return { changedPaths, fileDiffs };
+}

--- a/src/orchestrator/execution/task/task-execution-helpers.ts
+++ b/src/orchestrator/execution/task/task-execution-helpers.ts
@@ -6,6 +6,7 @@ import type { ToolExecutor } from "../../../tools/executor.js";
 import { executeTask as executeTaskDirect } from "./task-executor.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { SessionManager } from "../session-manager.js";
+import { captureExecutionDiffArtifacts } from "./task-diff-capture.js";
 
 interface ExecuteTaskWithGuardsParams {
   task: Task;
@@ -80,7 +81,15 @@ export async function executeTaskWithGuards(
         toolCtx
       );
       if (toolResult.success && toolResult.data != null) {
-        return toolResult.data as AgentResult;
+        const result = toolResult.data as AgentResult;
+        const goal = await stateManager.loadGoal(task.goal_id).catch(() => null);
+        const workspaceCwd = goal?.constraints.find((constraint) => constraint.startsWith("workspace_path:"))
+          ?.slice("workspace_path:".length);
+        const diffArtifacts = captureExecutionDiffArtifacts(execFileSyncFn, workspaceCwd ?? process.cwd());
+        result.filesChangedPaths = diffArtifacts.changedPaths;
+        result.fileDiffs = diffArtifacts.fileDiffs;
+        result.filesChanged = diffArtifacts.changedPaths.length > 0;
+        return result;
       }
       logger?.warn?.(`[TaskLifecycle] run-adapter tool failed, falling back to direct call: ${toolResult.error ?? "unknown"}`);
     } catch (err) {

--- a/src/orchestrator/execution/task/task-executor.ts
+++ b/src/orchestrator/execution/task/task-executor.ts
@@ -8,6 +8,7 @@ import type { Strategy } from "../../../base/types/strategy.js";
 import { appendTaskOutcomeEvent } from "./task-outcome-ledger.js";
 import { validateProtectedPath } from "../../../tools/fs/FileValidationTool/protected-path-policy.js";
 import { loadProviderConfig } from "../../../base/llm/provider-config.js";
+import { captureExecutionDiffArtifacts } from "./task-diff-capture.js";
 const DEBUG = process.env.PULSEED_DEBUG === "true";
 
 // ─── Deps interface ───
@@ -177,26 +178,10 @@ export async function executeTask(
   if (result.success) {
     try {
       const gitCwd = workspaceCwd ?? process.cwd();
-      const diffOutput = execFileSyncFn("git", ["diff", "--name-only"], {
-        cwd: gitCwd,
-        encoding: "utf-8",
-      }).trim();
-
-      // Also detect new (untracked) files — git diff alone misses them
-      let untrackedOutput = "";
-      try {
-        untrackedOutput = execFileSyncFn("git", ["ls-files", "--others", "--exclude-standard"], {
-          cwd: gitCwd,
-          encoding: "utf-8",
-        }).trim();
-      } catch {
-        // git ls-files failure is non-fatal
-      }
-
-      const changedFiles = [
-        ...(diffOutput ? diffOutput.split("\n") : []),
-        ...(untrackedOutput ? untrackedOutput.split("\n") : []),
-      ];
+      const diffArtifacts = captureExecutionDiffArtifacts(execFileSyncFn, gitCwd);
+      const changedFiles = diffArtifacts.changedPaths;
+      result.filesChangedPaths = changedFiles;
+      result.fileDiffs = diffArtifacts.fileDiffs;
       result.filesChanged = changedFiles.length > 0;
       if (!result.filesChanged) {
         logger?.warn(

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -56,6 +56,7 @@ import type { MemoryLifecycleManager } from "../../../platform/knowledge/memory/
 import { buildEnrichedKnowledgeContext } from "./task-context-enricher.js";
 import { persistTaskCycleSideEffects } from "./task-side-effects.js";
 import { finalizeSuccessfulExecution } from "./task-post-execution.js";
+import { captureExecutionDiffArtifacts } from "./task-diff-capture.js";
 import { GuardrailRunner } from "../../../platform/traits/guardrail-runner.js";
 import type { HookManager } from "../../../runtime/hook-manager.js";
 import type { ToolExecutor } from "../../../tools/executor.js";
@@ -407,6 +408,15 @@ export class TaskLifecycle {
         knowledgeContext,
       });
       result = taskAgentLoopResultToAgentResult(agentLoopResult);
+      if (agentLoopResult.workspace?.executionCwd) {
+        const diffArtifacts = captureExecutionDiffArtifacts(
+          this.execFileSyncFn,
+          agentLoopResult.workspace.executionCwd,
+        );
+        result.filesChangedPaths = diffArtifacts.changedPaths;
+        result.fileDiffs = diffArtifacts.fileDiffs;
+        result.filesChanged = diffArtifacts.changedPaths.length > 0;
+      }
     } catch (err) {
       result = {
         success: false,

--- a/src/orchestrator/execution/task/task-verifier.ts
+++ b/src/orchestrator/execution/task/task-verifier.ts
@@ -18,7 +18,7 @@
 
 import { StateManager } from "../../../base/state/state-manager.js";
 import { VerificationResultSchema } from "../../../base/types/task.js";
-import type { Task, VerificationResult } from "../../../base/types/task.js";
+import type { Task, VerificationResult, VerificationFileDiff } from "../../../base/types/task.js";
 import type { AgentResult } from "../adapter-layer.js";
 import { wrapXmlTag, formatKnowledge } from "../../../prompt/formatters.js";
 import { analyzeImpact } from "../impact-analyzer.js";
@@ -70,6 +70,113 @@ function formatSelfReportEvidence(executorReport: import("./task-verifier-types.
   ].filter((segment) => segment.length > 0);
 
   return segments.join("\n");
+}
+
+function quoteShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+async function collectVerificationDiffs(
+  deps: VerifierDeps,
+  task: Task,
+  executionResult: AgentResult,
+): Promise<VerificationFileDiff[]> {
+  if (executionResult.fileDiffs && executionResult.fileDiffs.length > 0) {
+    return executionResult.fileDiffs;
+  }
+
+  if (!deps.toolExecutor) return [];
+
+  const cwd =
+    executionResult.agentLoop?.requestedCwd ??
+    executionResult.agentLoop?.executionCwd ??
+    task.constraints.find((constraint) => constraint.startsWith("workspace_path:"))?.slice("workspace_path:".length) ??
+    process.cwd();
+
+  const changedPaths = [
+    ...(executionResult.filesChangedPaths ?? []),
+    ...(executionResult.agentLoop?.filesChangedPaths ?? []),
+  ].filter((path, index, all) => path.length > 0 && all.indexOf(path) === index);
+
+  const toolContext = {
+    cwd,
+    goalId: task.goal_id,
+    trustBalance: 0,
+    preApproved: true,
+    approvalFn: async () => true,
+  };
+
+  const collectForPath = async (path: string): Promise<VerificationFileDiff | null> => {
+    try {
+      const result = await deps.toolExecutor!.execute(
+        "git_diff",
+        { target: "unstaged", path, maxLines: 160 },
+        toolContext
+      );
+      if (result.success && typeof result.data === "string" && result.data.trim()) {
+        return { path, patch: result.data };
+      }
+    } catch {
+      // Fall through to untracked-file fallback.
+    }
+
+    try {
+      const quotedPath = quoteShellArg(path);
+      const fallback = await deps.toolExecutor!.execute(
+        "shell_command",
+        {
+          command: `test -f ${quotedPath} && git diff --no-index -- /dev/null ${quotedPath} || true`,
+          cwd,
+          timeoutMs: 30_000,
+          description: `Render diff for new file ${path}`,
+        },
+        toolContext
+      );
+      const shellOutput =
+        fallback.data &&
+        typeof fallback.data === "object" &&
+        "stdout" in fallback.data &&
+        typeof fallback.data.stdout === "string"
+          ? fallback.data.stdout
+          : "";
+      if (shellOutput.trim()) {
+        return { path, patch: shellOutput };
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
+  };
+
+  if (changedPaths.length > 0) {
+    const diffs = await Promise.all(changedPaths.slice(0, 5).map((path) => collectForPath(path)));
+    return diffs.filter((diff): diff is VerificationFileDiff => diff !== null);
+  }
+
+  try {
+    const result = await deps.toolExecutor.execute(
+      "git_diff",
+      { target: "unstaged", maxLines: 240 },
+      toolContext
+    );
+    if (!result.success || typeof result.data !== "string" || !result.data.trim()) return [];
+
+    return result.data
+      .split(/^diff --git /m)
+      .filter(Boolean)
+      .slice(0, 5)
+      .map((section) => {
+        const patch = `diff --git ${section}`;
+        const match = patch.match(/^diff --git a\/(.+?) b\/(.+)$/m);
+        return {
+          path: match?.[2] ?? match?.[1] ?? "unknown",
+          patch,
+        };
+      });
+  } catch {
+    return [];
+  }
 }
 
 // ─── verifyTask ───
@@ -312,6 +419,7 @@ export async function verifyTask(
     confidence,
     evidence,
     dimension_updates,
+    file_diffs: await collectVerificationDiffs(deps, task, executionResult),
     timestamp: now,
   });
 

--- a/src/orchestrator/execution/types/task.ts
+++ b/src/orchestrator/execution/types/task.ts
@@ -25,6 +25,12 @@ export const ScopeBoundarySchema = z.object({
 });
 export type ScopeBoundary = z.infer<typeof ScopeBoundarySchema>;
 
+export const VerificationFileDiffSchema = z.object({
+  path: z.string(),
+  patch: z.string(),
+});
+export type VerificationFileDiff = z.infer<typeof VerificationFileDiffSchema>;
+
 // --- Task ---
 
 export const TaskSchema = z.object({
@@ -96,6 +102,7 @@ export const VerificationResultSchema = z.object({
   confidence: z.number().min(0).max(1),
   evidence: z.array(EvidenceSchema),
   dimension_updates: z.array(DimensionUpdateSchema),
+  file_diffs: z.array(VerificationFileDiffSchema).optional(),
   timestamp: z.string(),
 });
 export type VerificationResult = z.infer<typeof VerificationResultSchema>;

--- a/src/orchestrator/loop/core-loop/contracts.ts
+++ b/src/orchestrator/loop/core-loop/contracts.ts
@@ -27,6 +27,7 @@ import type { GoalRefiner } from "../../goal/goal-refiner.js";
 import type { Goal } from "../../../base/types/goal.js";
 import type { GapVector } from "../../../base/types/gap.js";
 import type { DriveContext, DriveScore } from "../../../base/types/drive.js";
+import type { VerificationFileDiff } from "../../../base/types/task.js";
 import type { ToolExecutor } from "../../../tools/executor.js";
 import type { ToolRegistry } from "../../../tools/registry.js";
 import type { CorePhaseRunner } from "../../execution/agent-loop/core-phase-runner.js";
@@ -72,7 +73,12 @@ export interface ExecutionSummaryParams {
   loopIndex: number;
   observation: { dimensionName: string; progress: number; confidence: number }[];
   gapAggregate: number;
-  taskResult: { taskId: string; action: string; dimension: string } | null;
+  taskResult: {
+    taskId: string;
+    action: string;
+    dimension: string;
+    verificationDiffs?: VerificationFileDiff[];
+  } | null;
   stallDetected: boolean;
   pivotOccurred: boolean;
   elapsedMs: number;

--- a/src/orchestrator/loop/loop-report-helper.ts
+++ b/src/orchestrator/loop/loop-report-helper.ts
@@ -45,6 +45,7 @@ export async function generateLoopReport(
             taskId: iterationResult.taskResult.task.id,
             action: iterationResult.taskResult.action,
             dimension: iterationResult.taskResult.task.primary_dimension,
+            verificationDiffs: iterationResult.taskResult.verificationResult.file_diffs,
           }
         : null;
 

--- a/src/reporting/__tests__/reporting-engine.test.ts
+++ b/src/reporting/__tests__/reporting-engine.test.ts
@@ -85,6 +85,33 @@ describe("generateExecutionSummary", () => {
     expect(report.content).toContain("code_quality");
   });
 
+  it("stores verification diffs in structured metadata", () => {
+    const report = engine.generateExecutionSummary(makeBaseParams({
+      taskResult: {
+        taskId: "task-xyz",
+        action: "fix-lint",
+        dimension: "code_quality",
+        verificationDiffs: [{
+          path: "src/example.ts",
+          patch: [
+            "diff --git a/src/example.ts b/src/example.ts",
+            "@@ -1 +1 @@",
+            "-before",
+            "+after",
+          ].join("\n"),
+        }],
+      },
+    }));
+
+    expect(report.metadata?.task_verification_diffs).toEqual([
+      expect.objectContaining({
+        path: "src/example.ts",
+        patch: expect.stringContaining("+after"),
+      }),
+    ]);
+    expect(report.content).not.toContain("```diff");
+  });
+
   it("shows 'No task executed' when taskResult is null", () => {
     const report = engine.generateExecutionSummary(makeBaseParams({ taskResult: null }));
     expect(report.content).toContain("No task executed");

--- a/src/reporting/reporting-engine.ts
+++ b/src/reporting/reporting-engine.ts
@@ -88,6 +88,7 @@ export class ReportingEngine {
         elapsed_ms: elapsedMs,
         task_id: taskResult?.taskId ?? null,
         task_action: taskResult?.action ?? null,
+        task_verification_diffs: taskResult?.verificationDiffs,
       },
     });
 

--- a/src/reporting/reporting-types.ts
+++ b/src/reporting/reporting-types.ts
@@ -1,9 +1,16 @@
+import type { VerificationFileDiff } from "../base/types/task.js";
+
 export type ExecutionSummaryParams = {
   goalId: string;
   loopIndex: number;
   observation: { dimensionName: string; progress: number; confidence: number }[];
   gapAggregate: number;
-  taskResult: { taskId: string; action: string; dimension: string } | null;
+  taskResult: {
+    taskId: string;
+    action: string;
+    dimension: string;
+    verificationDiffs?: VerificationFileDiff[];
+  } | null;
   stallDetected: boolean;
   pivotOccurred: boolean;
   elapsedMs: number;

--- a/src/reporting/types/report.ts
+++ b/src/reporting/types/report.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { ReportTypeEnum, VerbosityLevelEnum } from "../../base/types/core.js";
+import { VerificationFileDiffSchema } from "../../base/types/task.js";
 
 // --- Report ---
 
@@ -23,6 +24,7 @@ export const ReportSchema = z.object({
       elapsed_ms: z.number().optional(),
       task_id: z.string().nullable().optional(),
       task_action: z.string().nullable().optional(),
+      task_verification_diffs: z.array(VerificationFileDiffSchema).optional(),
       loops_run: z.number().optional(),
       stall_count: z.number().optional(),
       pivot_count: z.number().optional(),
@@ -34,4 +36,3 @@ export const ReportSchema = z.object({
     .optional(),
 });
 export type Report = z.infer<typeof ReportSchema>;
-


### PR DESCRIPTION
## Summary
- add structured verification diff capture at execution time and carry it through `VerificationResult`
- store execution summary diffs in report metadata instead of embedding diff markdown in report content
- add TUI diff rendering plus focused tests for diff capture, reporting metadata, and report rendering

## Why
Issue #105 asked for visible file diffs in the TUI after agent-driven edits. The previous direction of reconstructing diffs during verification and re-parsing markdown in the TUI would have become brittle over time.

## User Impact
Users can now inspect file diffs directly in the TUI execution summary with colored `+` and `-` lines.

## Root Cause
The system had no structured path for file diff artifacts from execution to verification and display, so the TUI had nothing reliable to render.

## Validation
- `npx vitest run src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts -t "(uses execution-provided diffs as the source of truth|falls back to synthetic diff output for newly created files)"`
- `npx vitest run src/reporting/__tests__/reporting-engine.test.ts -t "stores verification diffs in structured metadata"`
- `npx vitest run src/interface/tui/__tests__/diff-view.test.ts src/interface/tui/__tests__/report-view.test.ts`
