### PR TITLE
[codex] Refactor runtime daemon runner and event server orchestration

### DIFF
--- a/src/runtime/daemon/runner-commands.ts
+++ b/src/runtime/daemon/runner-commands.ts
@@ -1,0 +1,292 @@
+import { resolveScheduleEntry } from "../schedule/entry-resolver.js";
+import { RuntimeOperationStore, type RuntimeControlOperationKind } from "../store/index.js";
+import type { Logger } from "../logger.js";
+import type { EventServer } from "../event/server.js";
+import type { ScheduleEngine } from "../schedule/engine.js";
+import type { StateManager } from "../../base/state/state-manager.js";
+import type { DaemonState } from "../../base/types/daemon.js";
+import type { Envelope } from "../types/envelope.js";
+import type { ApprovalBroker } from "../approval-broker.js";
+import type { LoopSupervisor } from "../executor/index.js";
+import type { JournalBackedQueue, JournalBackedQueueAcceptResult } from "../queue/journal-backed-queue.js";
+import { writeChatMessageEvent } from "./maintenance.js";
+import { runCommandWithHealth as runCommandWithHealthFn } from "./runner-errors.js";
+
+export interface DaemonRunnerCommandContext {
+  runtimeRoot?: string;
+  logger: Logger;
+  scheduleEngine?: ScheduleEngine;
+  stateManager: StateManager;
+  state: DaemonState;
+  currentGoalIds: string[];
+  supervisor?: LoopSupervisor;
+  approvalBroker?: ApprovalBroker;
+  eventServer?: EventServer;
+  journalQueue?: JournalBackedQueue;
+  saveDaemonState(): Promise<void>;
+  refreshOperationalState(): void;
+  abortSleep(): void;
+  beginGracefulShutdown(): void;
+  broadcastGoalUpdated(goalId: string, fallbackStatus?: string): Promise<void>;
+  broadcastChatResponse(goalId: string, message: string): Promise<void>;
+  runtimeOwnership: {
+    observeTaskExecution(
+      status: "ok" | "degraded" | "failed",
+      reason?: string,
+    ): Promise<void>;
+    observeCommandAcceptance(
+      status: "accepted" | "rejected" | "failed",
+      reason?: string,
+    ): Promise<void>;
+  };
+  driveSystem: {
+    writeEvent(event: unknown): Promise<void>;
+  };
+}
+
+export function acceptRuntimeEnvelope(
+  context: Pick<DaemonRunnerCommandContext, "journalQueue" | "logger" | "runtimeRoot">,
+  envelope: Envelope,
+): boolean {
+  if (!context.journalQueue) return true;
+
+  const result: JournalBackedQueueAcceptResult = context.journalQueue.accept(envelope);
+  if (result.accepted) {
+    return true;
+  }
+
+  context.logger.info("Runtime journal skipped envelope", {
+    id: envelope.id,
+    name: envelope.name,
+    type: envelope.type,
+    duplicate: result.duplicate,
+    runtime_root: context.runtimeRoot,
+  });
+  return false;
+}
+
+export async function handleInboundEnvelope(
+  context: Pick<DaemonRunnerCommandContext, "journalQueue" | "logger" | "runtimeRoot">,
+  envelope: Envelope,
+): Promise<void> {
+  if (!acceptRuntimeEnvelope(context, envelope)) {
+    return;
+  }
+}
+
+export async function handleGoalStartCommand(
+  context: Pick<
+    DaemonRunnerCommandContext,
+    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state"
+  >,
+  goalId: string,
+): Promise<void> {
+  if (!context.currentGoalIds.includes(goalId)) {
+    context.currentGoalIds.push(goalId);
+  }
+  context.refreshOperationalState();
+  await context.saveDaemonState();
+  context.supervisor?.activateGoal(goalId);
+  context.abortSleep();
+  await context.broadcastGoalUpdated(goalId, "active");
+}
+
+export async function handleGoalStopCommand(
+  context: Pick<
+    DaemonRunnerCommandContext,
+    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state"
+  >,
+  goalId: string,
+): Promise<void> {
+  context.currentGoalIds.splice(0, context.currentGoalIds.length, ...context.currentGoalIds.filter((id) => id !== goalId));
+  context.refreshOperationalState();
+  if (context.state.interrupted_goals) {
+    context.state.interrupted_goals = context.state.interrupted_goals.filter((id) => id !== goalId);
+  }
+  await context.saveDaemonState();
+  context.supervisor?.deactivateGoal(goalId);
+  context.abortSleep();
+  await context.broadcastGoalUpdated(goalId, "stopped");
+}
+
+export async function handleRuntimeControlCommand(
+  context: Pick<DaemonRunnerCommandContext, "runtimeRoot" | "logger" | "beginGracefulShutdown">,
+  operationId: string,
+  kind: RuntimeControlOperationKind,
+): Promise<void> {
+  const operationStore = new RuntimeOperationStore(context.runtimeRoot ?? undefined);
+  const operation = await operationStore.load(operationId);
+  if (!operation) {
+    context.logger.warn("Runtime control operation not found", { operation_id: operationId, kind });
+    return;
+  }
+
+  if (kind !== "restart_daemon" && kind !== "restart_gateway") {
+    const now = new Date().toISOString();
+    await operationStore.save({
+      ...operation,
+      state: "failed",
+      updated_at: now,
+      completed_at: now,
+      result: {
+        ok: false,
+        message: `Runtime control operation ${kind} is not implemented yet.`,
+      },
+    });
+    return;
+  }
+
+  const now = new Date().toISOString();
+  await operationStore.save({
+    ...operation,
+    state: "restarting",
+    started_at: operation.started_at ?? now,
+    updated_at: now,
+    result: {
+      ok: true,
+      message:
+        kind === "restart_gateway"
+          ? "gateway restart is being handled by a daemon restart because the gateway runs in-process."
+          : "daemon restart was accepted by the runtime command dispatcher.",
+    },
+  });
+
+  context.logger.info("Runtime control requested daemon restart", { operation_id: operationId, kind });
+  setTimeout(() => {
+    context.beginGracefulShutdown();
+  }, 25).unref?.();
+}
+
+export async function handleScheduleRunNowCommand(
+  context: Pick<DaemonRunnerCommandContext, "scheduleEngine" | "logger">,
+  scheduleId: string,
+  allowEscalation: boolean,
+): Promise<void> {
+  if (!context.scheduleEngine) {
+    throw new Error("ScheduleEngine is not configured");
+  }
+
+  await context.scheduleEngine.loadEntries();
+  const entry = resolveScheduleEntry(context.scheduleEngine.getEntries(), scheduleId);
+  if (!entry) {
+    throw new Error(`Schedule not found: ${scheduleId}`);
+  }
+
+  const run = await context.scheduleEngine.runEntryNow(entry.id, {
+    allowEscalation,
+    preserveEnabled: true,
+  });
+  if (!run) {
+    throw new Error(`Schedule not found: ${scheduleId}`);
+  }
+
+  context.logger.info("Schedule run-now completed", {
+    schedule_id: entry.id,
+    schedule_name: entry.name,
+    status: run.result.status,
+    reason: run.reason,
+    allow_escalation: allowEscalation,
+  });
+}
+
+export async function handleGoalCompletion(
+  context: Pick<
+    DaemonRunnerCommandContext,
+    "state" | "saveDaemonState" | "runtimeOwnership" | "eventServer" | "stateManager" | "broadcastGoalUpdated"
+  > & { currentLoopIndex: number; setCurrentLoopIndex(index: number): void },
+  goalId: string,
+  result: { status: string; totalIterations: number },
+): Promise<void> {
+  context.state.loop_count++;
+  context.setCurrentLoopIndex(context.state.loop_count);
+  context.state.last_loop_at = new Date().toISOString();
+  await context.saveDaemonState();
+  await context.runtimeOwnership.observeTaskExecution(
+    result.status === "error"
+      ? "failed"
+      : result.status === "stalled"
+        ? "degraded"
+        : "ok",
+    result.status === "error"
+      ? `goal ${goalId} execution failed`
+      : result.status === "stalled"
+        ? `goal ${goalId} stalled`
+        : undefined,
+  );
+
+  if (context.eventServer) {
+    const goal = await context.stateManager.loadGoal(goalId).catch(() => null);
+    void context.eventServer.broadcast?.("iteration_complete", {
+      goalId,
+      loopCount: context.state.loop_count,
+      status: goal?.status ?? result.status,
+      iterations: result.totalIterations,
+    });
+    void context.eventServer.broadcast?.("daemon_status", {
+      status: context.state.status,
+      activeGoals: context.state.active_goals,
+      loopCount: context.state.loop_count,
+      lastLoopAt: context.state.last_loop_at,
+    });
+  }
+  await context.broadcastGoalUpdated(goalId, result.status);
+}
+
+export async function handleChatMessageCommand(
+  context: Pick<DaemonRunnerCommandContext, "driveSystem" | "broadcastChatResponse" | "abortSleep">,
+  goalId: string,
+  message: string,
+): Promise<void> {
+  await writeChatMessageEvent(context.driveSystem as never, goalId, message);
+  await context.broadcastChatResponse(goalId, message);
+  context.abortSleep();
+}
+
+export async function runCommandWithHealth<T>(
+  context: Pick<DaemonRunnerCommandContext, "runtimeOwnership">,
+  commandName: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return runCommandWithHealthFn(
+    commandName,
+    fn,
+    (status, reason) => context.runtimeOwnership.observeCommandAcceptance(status as "accepted" | "rejected" | "failed", reason),
+  );
+}
+
+export async function handleApprovalResponseCommand(
+  context: Pick<DaemonRunnerCommandContext, "approvalBroker" | "eventServer">,
+  goalId: string | undefined,
+  requestId: string,
+  approved: boolean,
+): Promise<void> {
+  if (context.approvalBroker) {
+    await context.approvalBroker.resolveApproval(requestId, approved, "dispatcher");
+    return;
+  }
+  if (goalId && context.eventServer) {
+    await context.eventServer.resolveApproval(requestId, approved);
+  }
+}
+
+export async function handleCronTaskDue(
+  context: Pick<DaemonRunnerCommandContext, "logger"> & {
+    cronScheduler?: {
+      markFired(taskId: string): Promise<void>;
+    };
+  },
+  taskId: string,
+): Promise<void> {
+  if (!context.cronScheduler) {
+    return;
+  }
+  try {
+    await context.cronScheduler.markFired(taskId);
+    context.logger.info(`Cron task fired: ${taskId}`);
+  } catch (err) {
+    context.logger.warn(`Cron task ${taskId} failed`, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    await context.cronScheduler.markFired(taskId);
+  }
+}

--- a/src/runtime/daemon/runner-goal-cycle.ts
+++ b/src/runtime/daemon/runner-goal-cycle.ts
@@ -1,0 +1,104 @@
+import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
+import type { GoalCycleScheduleSnapshotEntry } from "./maintenance.js";
+
+const MAX_IDLE_SLEEP_MS = 5_000;
+
+export type GoalCycleRunnerContext = any;
+
+export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): Promise<void> {
+  while (context.running && !context.shuttingDown) {
+    try {
+      const goalIds = [...context.currentGoalIds];
+      context.refreshOperationalState();
+      const cycleSnapshot = await context.collectGoalCycleSnapshot(goalIds);
+      const activeGoals = await context.determineActiveGoals(goalIds, cycleSnapshot);
+      await context.maybeRefreshProviderRuntime(activeGoals.length);
+
+      if (activeGoals.length === 0) {
+        context.logger.info("No goals need activation this cycle", { checked: goalIds.length });
+      }
+
+      for (const goalId of activeGoals) {
+        if (!context.running) break;
+
+        context.logger.info(`Running loop for goal: ${goalId}`);
+
+        try {
+          const iterationsPerCycle = context.config.iterations_per_cycle ?? 1;
+          const result: LoopResult = await context.coreLoop.run(goalId, { maxIterations: iterationsPerCycle });
+          context.state.loop_count++;
+          context.currentLoopIndex = context.state.loop_count;
+          context.state.last_loop_at = new Date().toISOString();
+          context.logger.info(`Loop completed for goal: ${goalId}`, {
+            status: result.finalStatus,
+            iterations: result.totalIterations,
+          });
+          if (context.eventServer) {
+            const goal = await context.stateManager.loadGoal(goalId).catch(() => null);
+            void context.eventServer.broadcast?.("iteration_complete", {
+              goalId,
+              loopCount: context.state.loop_count,
+              status: goal?.status ?? "unknown",
+            });
+          }
+          await context.broadcastGoalUpdated(goalId, result.finalStatus);
+        } catch (err) {
+          context.handleLoopError(goalId, err);
+        }
+
+        if (!context.running) break;
+      }
+
+      context.refreshOperationalState();
+      await context.saveDaemonState();
+      if (context.eventServer) {
+        void context.eventServer.broadcast?.("daemon_status", {
+          status: context.state.status,
+          activeGoals: context.state.active_goals,
+          loopCount: context.state.loop_count,
+          lastLoopAt: context.state.last_loop_at,
+        });
+      }
+
+      await context.processCronTasks();
+      await context.processScheduleEntries();
+
+      if (context.state.loop_count > 0 && context.state.loop_count % 100 === 0) {
+        await context.expireCronTasks();
+      }
+
+      if (context.running) {
+        await context.proactiveTick();
+      }
+
+      if (context.running) {
+        await context.runRuntimeStoreMaintenance();
+      }
+
+      if (activeGoals.length > 0) {
+        context.consecutiveIdleCycles = 0;
+      } else {
+        context.consecutiveIdleCycles++;
+      }
+
+      if (context.running) {
+        const baseIntervalMs = context.getNextInterval(goalIds);
+        const maxGapScore = await context.getMaxGapScore(goalIds, cycleSnapshot);
+        const intervalMs = context.calculateAdaptiveInterval(
+          baseIntervalMs,
+          activeGoals.length,
+          maxGapScore,
+          context.consecutiveIdleCycles,
+        );
+        const sleepIntervalMs =
+          activeGoals.length === 0 ? Math.min(intervalMs, MAX_IDLE_SLEEP_MS) : intervalMs;
+        context.logger.info(`Sleeping for ${sleepIntervalMs}ms until next check`);
+        await context.sleep(sleepIntervalMs);
+      }
+    } catch (err) {
+      await context.handleCriticalError(err);
+    }
+  }
+
+  await context.cleanup();
+}

--- a/src/runtime/daemon/runner-resident.ts
+++ b/src/runtime/daemon/runner-resident.ts
@@ -1,0 +1,658 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawnSync } from "node:child_process";
+import type { Goal } from "../../base/types/goal.js";
+import type { DaemonConfig, DaemonState, ResidentActivity } from "../../base/types/daemon.js";
+import { ResidentActivitySchema } from "../../base/types/daemon.js";
+import type { StateManager } from "../../base/state/state-manager.js";
+import { PulSeedEventSchema } from "../../base/types/drive.js";
+import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
+import type { CuriosityEngine } from "../../platform/traits/curiosity-engine.js";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+import type { MemoryLifecycleManager } from "../../platform/knowledge/memory/memory-lifecycle.js";
+import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
+import { lintAgentMemory } from "../../platform/knowledge/knowledge-manager-lint.js";
+import { DreamAnalyzer } from "../../platform/dream/dream-analyzer.js";
+import { DreamConsolidator, type DreamLegacyConsolidationReport } from "../../platform/dream/dream-consolidator.js";
+import { DreamScheduleSuggestionStore } from "../../platform/dream/dream-schedule-suggestions.js";
+import { createRuntimeDreamSoilSyncService } from "../../platform/dream/dream-soil-sync.js";
+import type { DreamReport, DreamRunReport, DreamTier } from "../../platform/dream/dream-types.js";
+import { runDreamConsolidation } from "../../reflection/dream-consolidation.js";
+import type { Logger } from "../logger.js";
+import type { LoopSupervisor } from "../executor/index.js";
+import type { ScheduleEngine } from "../schedule/engine.js";
+import { runProactiveMaintenance } from "./maintenance.js";
+
+export function resolveResidentWorkspaceDir(configuredPath?: string): string {
+  const trimmed = configuredPath?.trim();
+  return trimmed ? path.resolve(trimmed) : process.cwd();
+}
+
+export function gatherResidentWorkspaceContext(workspaceDir: string, seedDescription?: string): string {
+  const parts: string[] = [`Workspace: ${workspaceDir}`];
+  const seed = seedDescription?.trim();
+  if (seed) {
+    parts.push(`Resident trigger hint: ${seed}`);
+  }
+
+  try {
+    const pkgPath = path.join(workspaceDir, "package.json");
+    const pkgRaw = fs.readFileSync(pkgPath, "utf-8");
+    const pkg = JSON.parse(pkgRaw) as Record<string, unknown>;
+    const name = typeof pkg.name === "string" ? pkg.name : "";
+    const description = typeof pkg.description === "string" ? pkg.description : "";
+    const scripts = pkg.scripts && typeof pkg.scripts === "object"
+      ? Object.keys(pkg.scripts as Record<string, unknown>).join(", ")
+      : "";
+    const prefix = name ? `Node.js project '${name}'` : "Node.js project";
+    const descPart = description ? `. ${description}` : "";
+    const scriptsPart = scripts ? `. Scripts: ${scripts}` : "";
+    parts.push(`${prefix}${descPart}${scriptsPart}`);
+  } catch {
+    // No package metadata available.
+  }
+
+  try {
+    const entries = fs.readdirSync(workspaceDir);
+    const dirs = entries.filter((entry) => {
+      try {
+        return fs.statSync(path.join(workspaceDir, entry)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+    const files = entries.filter((entry) => {
+      try {
+        return fs.statSync(path.join(workspaceDir, entry)).isFile();
+      } catch {
+        return false;
+      }
+    });
+    const visibleEntries = [
+      dirs.slice(0, 10).map((entry) => `${entry}/`).join(", "),
+      files.slice(0, 5).join(", "),
+    ].filter(Boolean).join(", ");
+    if (visibleEntries) {
+      parts.push(`Files: ${visibleEntries}`);
+    }
+  } catch {
+    // Workspace listing is best-effort.
+  }
+
+  const gitResult = spawnSync("git", ["log", "--oneline", "-5", "--format=%s"], {
+    cwd: workspaceDir,
+    encoding: "utf-8",
+  });
+  if (gitResult.status === 0 && gitResult.stdout.trim().length > 0) {
+    parts.push(`Recent changes: ${gitResult.stdout.trim().split("\n").join("; ")}`);
+  }
+
+  return parts.join(". ");
+}
+
+export interface DaemonRunnerResidentContext {
+  baseDir: string;
+  config: DaemonConfig;
+  state: DaemonState;
+  currentGoalIds: string[];
+  stateManager: StateManager;
+  driveSystem: { writeEvent(event: unknown): Promise<void> };
+  logger: Logger;
+  goalNegotiator?: GoalNegotiator;
+  curiosityEngine?: CuriosityEngine;
+  llmClient?: ILLMClient;
+  memoryLifecycle?: MemoryLifecycleManager;
+  knowledgeManager?: KnowledgeManager;
+  scheduleEngine?: ScheduleEngine;
+  supervisor?: LoopSupervisor;
+  saveDaemonState(): Promise<void>;
+  refreshOperationalState(): void;
+  abortSleep(): void;
+}
+
+export async function loadExistingGoalTitles(
+  context: Pick<DaemonRunnerResidentContext, "stateManager">,
+): Promise<string[]> {
+  const goalIds = await context.stateManager.listGoalIds().catch(() => []);
+  const titles: string[] = [];
+  for (const goalId of goalIds) {
+    const goal = await context.stateManager.loadGoal(goalId).catch(() => null);
+    if (goal?.title) {
+      titles.push(goal.title);
+    }
+  }
+  return titles;
+}
+
+export async function loadKnownGoals(
+  context: Pick<DaemonRunnerResidentContext, "stateManager">,
+): Promise<Goal[]> {
+  const goalIds = await context.stateManager.listGoalIds().catch(() => []);
+  const goals: Goal[] = [];
+  for (const goalId of goalIds) {
+    const goal = await context.stateManager.loadGoal(goalId).catch(() => null);
+    if (goal) {
+      goals.push(goal);
+    }
+  }
+  return goals;
+}
+
+export async function persistResidentActivity(
+  context: Pick<DaemonRunnerResidentContext, "state" | "saveDaemonState">,
+  activity: Omit<ResidentActivity, "recorded_at"> & { recorded_at?: string },
+): Promise<void> {
+  const residentActivity = ResidentActivitySchema.parse({
+    ...activity,
+    recorded_at: activity.recorded_at ?? new Date().toISOString(),
+  });
+  context.state.last_resident_at = residentActivity.recorded_at;
+  context.state.resident_activity = residentActivity;
+  await context.saveDaemonState();
+}
+
+export async function triggerResidentGoalDiscovery(
+  context: Pick<
+    DaemonRunnerResidentContext,
+    "goalNegotiator" | "currentGoalIds" | "config" | "supervisor" | "refreshOperationalState" | "abortSleep" | "logger"
+  > &
+    Pick<DaemonRunnerResidentContext, "saveDaemonState" | "state" | "stateManager">,
+  details?: Record<string, unknown>,
+): Promise<void> {
+  if (!context.goalNegotiator) {
+    await persistResidentActivity(context, {
+      kind: "skipped",
+      trigger: "proactive_tick",
+      summary: "Resident discovery skipped because goal negotiation is unavailable.",
+    });
+    return;
+  }
+
+  if (context.currentGoalIds.length > 0) {
+    await persistResidentActivity(context, {
+      kind: "skipped",
+      trigger: "proactive_tick",
+      summary: "Resident discovery skipped because active goals are already running.",
+    });
+    return;
+  }
+
+  const hintedDescription =
+    typeof details?.["description"] === "string" ? details["description"].trim() : "";
+  const hintedTitle =
+    typeof details?.["title"] === "string" ? details["title"].trim() : "";
+
+  try {
+    const workspaceDir = resolveResidentWorkspaceDir(context.config.workspace_path);
+    const workspaceContext = gatherResidentWorkspaceContext(workspaceDir, hintedDescription);
+    const existingTitles = await loadExistingGoalTitles(context);
+    const suggestions = await context.goalNegotiator.suggestGoals(workspaceContext, {
+      maxSuggestions: 1,
+      existingGoals: existingTitles,
+      repoPath: workspaceDir,
+    });
+    const suggestion = suggestions[0];
+    const suggestionTitle = suggestion?.title ?? hintedTitle;
+    const negotiationDescription = suggestion?.description ?? hintedDescription;
+
+    if (!negotiationDescription) {
+      await persistResidentActivity(context, {
+        kind: "suggestion",
+        trigger: "proactive_tick",
+        summary: "Resident discovery ran but found no actionable goal to negotiate.",
+        suggestion_title: suggestionTitle || undefined,
+      });
+      return;
+    }
+
+    const { goal } = await context.goalNegotiator.negotiate(negotiationDescription, {
+      workspaceContext,
+      timeoutMs: 30_000,
+    });
+    if (!context.currentGoalIds.includes(goal.id)) {
+      context.currentGoalIds.push(goal.id);
+    }
+    context.refreshOperationalState();
+    await persistResidentActivity(context, {
+      kind: "negotiation",
+      trigger: "proactive_tick",
+      summary: `Resident discovery negotiated a new goal: ${suggestionTitle || goal.title}`,
+      suggestion_title: suggestionTitle || goal.title,
+      goal_id: goal.id,
+    });
+    context.supervisor?.activateGoal(goal.id);
+    context.abortSleep();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    context.logger.warn("Resident discovery failed", { error: message });
+    await persistResidentActivity(context, {
+      kind: "error",
+      trigger: "proactive_tick",
+      summary: `Resident discovery failed: ${message}`,
+    });
+  }
+}
+
+export async function runResidentCuriosityCycle(
+  context: Pick<
+    DaemonRunnerResidentContext,
+    "curiosityEngine" | "stateManager" | "saveDaemonState" | "state" | "logger"
+  >,
+  options?: {
+    activityTrigger?: ResidentActivity["trigger"];
+    focus?: string;
+    reviewLabel?: string;
+    skipWhenNoTriggers?: boolean;
+  },
+): Promise<boolean> {
+  if (!context.curiosityEngine) {
+    if (options?.skipWhenNoTriggers) {
+      return false;
+    }
+    await persistResidentActivity(context, {
+      kind: "skipped",
+      trigger: options?.activityTrigger ?? "proactive_tick",
+      summary: "Resident investigation skipped because curiosity wiring is unavailable.",
+    });
+    return true;
+  }
+
+  try {
+    const goals = await loadKnownGoals(context);
+    const triggers = await context.curiosityEngine.evaluateTriggers(goals);
+    const focus = options?.focus?.trim() ?? "";
+
+    if (triggers.length === 0) {
+      if (options?.skipWhenNoTriggers) {
+        return false;
+      }
+      await persistResidentActivity(context, {
+        kind: "curiosity",
+        trigger: options?.activityTrigger ?? "proactive_tick",
+        summary: options?.reviewLabel
+          ? `Resident ${options.reviewLabel} ran and found no curiosity triggers.`
+          : `Resident investigation ran${focus ? ` for ${focus}` : ""} and found nothing actionable.`,
+      });
+      return true;
+    }
+
+    const proposals = await context.curiosityEngine.generateProposals(triggers, goals);
+    if (proposals.length === 0) {
+      await persistResidentActivity(context, {
+        kind: "curiosity",
+        trigger: options?.activityTrigger ?? "proactive_tick",
+        summary: options?.reviewLabel
+          ? `Resident ${options.reviewLabel} ran but produced no curiosity proposals.`
+          : `Resident investigation ran${focus ? ` for ${focus}` : ""} but produced no curiosity proposals.`,
+      });
+      return true;
+    }
+
+    const proposal = proposals[0]!;
+    await persistResidentActivity(context, {
+      kind: "curiosity",
+      trigger: options?.activityTrigger ?? "proactive_tick",
+      summary: options?.reviewLabel
+        ? `Resident ${options.reviewLabel} created ${proposals.length} curiosity proposal(s); next focus: ${proposal.proposed_goal.description}`
+        : `Resident investigation created ${proposals.length} curiosity proposal(s); next focus: ${proposal.proposed_goal.description}`,
+      suggestion_title: proposal.proposed_goal.description,
+    });
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    context.logger.warn("Resident investigation failed", { error: message });
+    await persistResidentActivity(context, {
+      kind: "error",
+      trigger: options?.activityTrigger ?? "proactive_tick",
+      summary: `Resident investigation failed: ${message}`,
+    });
+    return true;
+  }
+}
+
+export async function triggerResidentInvestigation(
+  context: Pick<DaemonRunnerResidentContext, "curiosityEngine" | "stateManager" | "saveDaemonState" | "state" | "logger">,
+  details?: Record<string, unknown>,
+): Promise<void> {
+  const focus = typeof details?.["what"] === "string" ? details["what"].trim() : "";
+  await runResidentCuriosityCycle(context, {
+    activityTrigger: "proactive_tick",
+    focus,
+    skipWhenNoTriggers: false,
+  });
+}
+
+export async function runScheduledGoalReview(
+  context: Pick<DaemonRunnerResidentContext, "curiosityEngine" | "stateManager" | "saveDaemonState" | "state" | "logger" | "config">,
+  lastGoalReviewAt: number,
+  setLastGoalReviewAt: (value: number) => void,
+): Promise<boolean> {
+  if (!context.curiosityEngine || !context.config.proactive_mode) {
+    return false;
+  }
+  const now = Date.now();
+  if (now - lastGoalReviewAt < context.config.goal_review_interval_ms) {
+    return false;
+  }
+  setLastGoalReviewAt(now);
+  return runResidentCuriosityCycle(context, {
+    activityTrigger: "schedule",
+    reviewLabel: "goal review",
+    skipWhenNoTriggers: false,
+  });
+}
+
+export async function tryApplyPendingDreamSuggestion(
+  context: Pick<DaemonRunnerResidentContext, "baseDir" | "scheduleEngine">,
+): Promise<{
+  suggestion: { id: string; name?: string; reason?: string };
+  entry: { id: string };
+  duplicate: boolean;
+} | null> {
+  const dreamStore = new DreamScheduleSuggestionStore(context.baseDir);
+  const pendingSuggestion = (await dreamStore.list()).find((suggestion) => suggestion.status === "pending");
+  if (!pendingSuggestion || !context.scheduleEngine) {
+    return null;
+  }
+
+  return dreamStore.applySuggestion(pendingSuggestion.id, context.scheduleEngine);
+}
+
+export async function runDreamAnalysis(
+  context: Pick<DaemonRunnerResidentContext, "baseDir" | "llmClient" | "logger">,
+  tier: DreamTier,
+): Promise<DreamRunReport> {
+  const analyzer = new DreamAnalyzer({
+    baseDir: context.baseDir,
+    llmClient: context.llmClient,
+    logger: context.logger,
+  });
+  return analyzer.run({ tier });
+}
+
+export async function runPlatformDreamConsolidation(
+  context: Pick<
+    DaemonRunnerResidentContext,
+    "baseDir" | "logger" | "knowledgeManager" | "llmClient" | "memoryLifecycle" | "stateManager"
+  >,
+  tier: DreamTier,
+): Promise<DreamReport | null> {
+  try {
+    const knowledgeManager = context.knowledgeManager;
+    const llmClient = context.llmClient;
+    const consolidator = new DreamConsolidator({
+      baseDir: context.baseDir,
+      logger: context.logger,
+      syncService: createRuntimeDreamSoilSyncService(),
+      memoryQualityService: knowledgeManager && llmClient
+        ? {
+            run: async (input) => {
+              const result = await lintAgentMemory({
+                km: knowledgeManager,
+                llmCall: async (prompt) => {
+                  const response = await llmClient.sendMessage(
+                    [{ role: "user", content: prompt }],
+                    { max_tokens: 2000, model_tier: "light" },
+                  );
+                  return response.content;
+                },
+                autoRepair: input.autoRepair,
+                minAutoRepairConfidence: input.minAutoRepairConfidence,
+              });
+              return {
+                findings: result.findings.length,
+                contradictionsFound: result.findings.filter((finding) => finding.type === "contradiction").length,
+                stalenessFound: result.findings.filter((finding) => finding.type === "staleness").length,
+                redundancyFound: result.findings.filter((finding) => finding.type === "redundancy").length,
+                repairsApplied: result.repairs_applied,
+                entriesFlagged: result.entries_flagged,
+              };
+            },
+          }
+        : undefined,
+      legacyConsolidationService: tier === "deep"
+        ? {
+            run: () => runDreamConsolidation({
+              stateManager: context.stateManager,
+              memoryLifecycle: context.memoryLifecycle,
+              knowledgeManager: context.knowledgeManager,
+              baseDir: context.baseDir,
+            }),
+          }
+        : undefined,
+    });
+    return await consolidator.run({ tier });
+  } catch (error) {
+    context.logger.warn("Platform Dream consolidation failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+export function legacyReportFromPlatformDream(report: DreamReport | null): DreamLegacyConsolidationReport | null {
+  const category = report?.categories.find((result) => result.category === "legacyReflectionCompatibility");
+  if (!category || category.status !== "completed") {
+    return null;
+  }
+  const legacy = report?.operational?.legacy_reflection;
+  return legacy
+    ? {
+        goals_consolidated: legacy.goals_consolidated,
+        entries_compressed: legacy.entries_compressed,
+        stale_entries_found: legacy.stale_entries_found,
+        revalidation_tasks_created: legacy.revalidation_tasks_created,
+      }
+    : null;
+}
+
+export async function triggerResidentDreamMaintenance(
+  context: Pick<
+    DaemonRunnerResidentContext,
+    "baseDir" | "scheduleEngine" | "saveDaemonState" | "state" | "logger" | "knowledgeManager" | "llmClient" | "memoryLifecycle" | "stateManager"
+  >,
+  details?: Record<string, unknown>,
+  tier: DreamTier = "deep",
+): Promise<void> {
+  try {
+    const appliedBeforeAnalysis = await tryApplyPendingDreamSuggestion(context);
+    if (appliedBeforeAnalysis) {
+      await persistResidentActivity(context, {
+        kind: "dream",
+        trigger: "proactive_tick",
+        summary: appliedBeforeAnalysis.duplicate
+          ? `Resident dream linked pending suggestion "${appliedBeforeAnalysis.suggestion.name ?? appliedBeforeAnalysis.suggestion.id}" to existing schedule ${appliedBeforeAnalysis.entry.id}.`
+          : `Resident dream applied pending suggestion "${appliedBeforeAnalysis.suggestion.name ?? appliedBeforeAnalysis.suggestion.id}" into schedule ${appliedBeforeAnalysis.entry.id}.`,
+        suggestion_title: appliedBeforeAnalysis.suggestion.name ?? appliedBeforeAnalysis.suggestion.reason,
+      });
+      return;
+    }
+
+    const analysisReport = await runDreamAnalysis(context, tier);
+    const appliedAfterAnalysis = tier === "deep" ? await tryApplyPendingDreamSuggestion(context) : null;
+    const platformReport = await runPlatformDreamConsolidation(context, tier);
+    const consolidationReport = tier === "deep"
+      ? legacyReportFromPlatformDream(platformReport) ?? await runDreamConsolidation({
+          stateManager: context.stateManager,
+          memoryLifecycle: context.memoryLifecycle,
+          knowledgeManager: context.knowledgeManager,
+          baseDir: context.baseDir,
+        })
+      : null;
+    const requestedGoalId =
+      typeof details?.["goal_id"] === "string" ? details["goal_id"].trim() : "";
+    const goalHint = requestedGoalId ? ` for ${requestedGoalId}` : "";
+
+    await persistResidentActivity(context, {
+      kind: "dream",
+      trigger: "proactive_tick",
+      summary: tier === "light"
+        ? `Resident dream light analysis ran${goalHint}; processed ${analysisReport.goalsProcessed.length} goals, persisted ${analysisReport.patternsPersisted} patterns, and generated ${analysisReport.scheduleSuggestions} schedule suggestion(s).`
+        : `Resident dream deep analysis ran${goalHint}; processed ${analysisReport.goalsProcessed.length} goals, persisted ${analysisReport.patternsPersisted} patterns, generated ${analysisReport.scheduleSuggestions} schedule suggestion(s), compressed ${consolidationReport?.entries_compressed ?? 0} entries, and created ${consolidationReport?.revalidation_tasks_created ?? 0} revalidation tasks${appliedAfterAnalysis ? ` while applying "${appliedAfterAnalysis.suggestion.name ?? appliedAfterAnalysis.suggestion.id}"` : ""}.`,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    context.logger.warn("Resident dream maintenance failed", { error: message });
+    await persistResidentActivity(context, {
+      kind: "error",
+      trigger: "proactive_tick",
+      summary: `Resident dream maintenance failed: ${message}`,
+    });
+  }
+}
+
+export async function triggerResidentPreemptiveCheck(
+  context: Pick<
+    DaemonRunnerResidentContext,
+    "stateManager" | "driveSystem" | "currentGoalIds" | "refreshOperationalState" | "supervisor" | "abortSleep" | "saveDaemonState" | "state" | "logger"
+  >,
+  details?: Record<string, unknown>,
+): Promise<void> {
+  const goalId =
+    typeof details?.["goal_id"] === "string" ? details["goal_id"].trim() : "";
+
+  if (!goalId) {
+    await persistResidentActivity(context, {
+      kind: "skipped",
+      trigger: "proactive_tick",
+      summary: "Resident preemptive check skipped because no goal_id was provided.",
+    });
+    return;
+  }
+
+  try {
+    const goal = await context.stateManager.loadGoal(goalId).catch(() => null);
+    if (!goal) {
+      await persistResidentActivity(context, {
+        kind: "skipped",
+        trigger: "proactive_tick",
+        summary: `Resident preemptive check skipped because goal "${goalId}" was not found.`,
+        goal_id: goalId,
+      });
+      return;
+    }
+
+    await context.driveSystem.writeEvent(
+      PulSeedEventSchema.parse({
+        type: "external",
+        source: "resident-proactive",
+        timestamp: new Date().toISOString(),
+        data: {
+          event_type: "preemptive_check",
+          goal_id: goalId,
+          requested_by: "resident-daemon",
+        },
+      }),
+    );
+    if (!context.currentGoalIds.includes(goalId)) {
+      context.currentGoalIds.push(goalId);
+    }
+    context.refreshOperationalState();
+    context.supervisor?.activateGoal(goalId);
+    context.abortSleep();
+    await persistResidentActivity(context, {
+      kind: "observation",
+      trigger: "proactive_tick",
+      summary: `Resident preemptive check queued an observation wake-up for goal "${goalId}".`,
+      goal_id: goalId,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    context.logger.warn("Resident preemptive check failed", { error: message, goal_id: goalId });
+    await persistResidentActivity(context, {
+      kind: "error",
+      trigger: "proactive_tick",
+      summary: `Resident preemptive check failed: ${message}`,
+      goal_id: goalId || undefined,
+    });
+  }
+}
+
+export async function triggerIdleResidentMaintenance(
+  context: Pick<
+    DaemonRunnerResidentContext,
+    "currentGoalIds" | "baseDir" | "memoryLifecycle" | "knowledgeManager" | "llmClient" | "saveDaemonState" | "state" | "logger" | "scheduleEngine" | "stateManager"
+  >,
+): Promise<void> {
+  if (context.currentGoalIds.length > 0) {
+    return;
+  }
+
+  const dreamSuggestionPath = path.join(context.baseDir, "dream", "schedule-suggestions.json");
+  const hasDreamSuggestionFile = fs.existsSync(dreamSuggestionPath);
+  if (!hasDreamSuggestionFile && !context.memoryLifecycle && !context.knowledgeManager && !context.llmClient) {
+    return;
+  }
+
+  await triggerResidentDreamMaintenance(context, undefined, "light");
+}
+
+export async function proactiveTick(
+  context: Pick<
+    DaemonRunnerResidentContext,
+    "config" | "llmClient" | "state" | "logger" | "saveDaemonState" | "curiosityEngine" | "stateManager" | "goalNegotiator" | "currentGoalIds" | "supervisor" | "refreshOperationalState" | "abortSleep" | "baseDir" | "scheduleEngine" | "knowledgeManager" | "memoryLifecycle" | "driveSystem"
+  >,
+  lastProactiveTickAt: number,
+  setLastProactiveTickAt: (value: number) => void,
+  lastGoalReviewAt: number,
+  setLastGoalReviewAt: (value: number) => void,
+): Promise<void> {
+  if (!context.config.proactive_mode) {
+    return;
+  }
+
+  if (await runScheduledGoalReview(context, lastGoalReviewAt, setLastGoalReviewAt)) {
+    return;
+  }
+
+  const curiosityTriggered = await runResidentCuriosityCycle(context, {
+    activityTrigger: "proactive_tick",
+    skipWhenNoTriggers: true,
+  });
+  if (curiosityTriggered) {
+    return;
+  }
+
+  const result = await runProactiveMaintenance({
+    config: context.config,
+    llmClient: context.llmClient,
+    state: context.state,
+    lastProactiveTickAt,
+    logger: context.logger,
+  });
+  setLastProactiveTickAt(result.lastProactiveTickAt);
+  if (!result.decision) {
+    return;
+  }
+
+  if (result.decision.action === "sleep") {
+    await persistResidentActivity(context, {
+      kind: "sleep",
+      trigger: "proactive_tick",
+      summary: "Resident proactive tick stayed idle.",
+    });
+    await triggerIdleResidentMaintenance(context);
+    return;
+  }
+
+  if (result.decision.action === "suggest_goal") {
+    await triggerResidentGoalDiscovery(context, result.decision.details);
+    return;
+  }
+
+  if (result.decision.action === "investigate") {
+    await triggerResidentInvestigation(context, result.decision.details);
+    return;
+  }
+
+  if (result.decision.action === "preemptive_check") {
+    await triggerResidentPreemptiveCheck(context, result.decision.details);
+    return;
+  }
+
+  await persistResidentActivity(context, {
+    kind: "skipped",
+    trigger: "proactive_tick",
+    summary: `Resident proactive tick requested ${result.decision.action}, but no resident executor is wired for it yet.`,
+  });
+}

--- a/src/runtime/daemon/runner-startup.ts
+++ b/src/runtime/daemon/runner-startup.ts
@@ -1,0 +1,412 @@
+import * as path from "node:path";
+import { EventServer } from "../event/server.js";
+import { IngressGateway, HttpChannelAdapter } from "../gateway/index.js";
+import type { LoopSupervisor } from "../executor/index.js";
+import { PulSeedEventSchema } from "../../base/types/drive.js";
+import { RuntimeOperationStore, type RuntimeControlOperationKind } from "../store/index.js";
+import { ProcessShutdownCoordinator, startDaemonStatusHeartbeat, type ProcessSignalTarget } from "./runner-lifecycle.js";
+import { handleCriticalDaemonError, handleDaemonLoopError } from "./runner-errors.js";
+import type { Envelope } from "../types/envelope.js";
+import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
+import type { CoreLoop } from "../../orchestrator/loop/core-loop.js";
+import { CommandDispatcher } from "../command-dispatcher.js";
+import { EventDispatcher } from "../event/dispatcher.js";
+
+const RUNTIME_LEADER_LEASE_MS = 30_000;
+const RUNTIME_LEADER_HEARTBEAT_MS = 10_000;
+
+export type StartupRunnerContext = any;
+
+export async function startDaemonRunner(
+  context: StartupRunnerContext,
+  goalIds: string[],
+): Promise<void> {
+  let startupReady = false;
+  try {
+    await context.initializeRuntimeFoundation();
+    await context.acquireRuntimeLeadership();
+
+    if (!context.eventServer) {
+      const esPort = context.config.event_server_port ?? 41700;
+      context.eventServer = new EventServer(context.driveSystem, {
+        port: esPort,
+        stateManager: context.stateManager,
+        outboxStore: context.outboxStore ?? undefined,
+      }, context.logger);
+    }
+    if (context.outboxStore) {
+      context.eventServer.setOutboxStore?.(context.outboxStore);
+    }
+    context.eventServer.setActiveWorkersProvider?.(() => {
+      const workers = context.supervisor?.getState().workers ?? [];
+      return workers
+        .filter((worker: any) => worker.goalId !== null)
+        .map((worker: any) => ({
+          worker_id: worker.workerId,
+          goal_id: worker.goalId,
+          started_at: worker.startedAt,
+          iterations: worker.iterations,
+        }));
+    });
+    if (context.approvalBroker) {
+      context.approvalBroker.setBroadcast((eventType: string, data: unknown) => {
+        void context.eventServer?.broadcast?.(eventType, data);
+      });
+      context.eventServer.setApprovalBroker?.(context.approvalBroker);
+    }
+
+    context.eventServer.setCommandEnvelopeHook?.(
+      async (envelope: Envelope) => context.handleInboundEnvelope(envelope),
+    );
+
+    if (context.gateway) {
+      const httpAdapter = new HttpChannelAdapter(context.eventServer);
+      context.gateway.registerAdapter(httpAdapter);
+      context.gateway.onEnvelope(async (envelope: Envelope) => context.handleInboundEnvelope(envelope));
+      await context.gateway.start();
+      context.logger.info("Gateway started with HTTP adapter", { port: context.eventServer.getPort() });
+    } else {
+      await context.eventServer.start();
+      context.eventServer.startFileWatcher();
+      context.logger.info("EventServer started", { port: context.eventServer.getPort() });
+    }
+
+    if (!context.approvalFn && context.eventServer) {
+      const es = context.eventServer;
+      context.approvalFn = async (task: Record<string, unknown>): Promise<boolean> => {
+        const goalId = String(task["goal_id"] ?? "unknown");
+        const description = String(task["description"] ?? "");
+        const action = String(task["action"] ?? "");
+        const taskId = String(task["id"] ?? "");
+
+        if (context.reportingEngine) {
+          try {
+            await context.reportingEngine.generateNotification("approval_required", {
+              goalId,
+              message: description || action || taskId || "Task approval required",
+              details: [`task_id: ${taskId || "(none)"}`, `action: ${action || "(none)"}`].join("\n"),
+            });
+          } catch (err) {
+            context.logger.warn("Approval notification dispatch failed", {
+              goalId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+        }
+
+        return es.requestApproval(goalId, {
+          id: taskId,
+          description,
+          action,
+        });
+      };
+    }
+
+    context.stopStatusHeartbeat = startDaemonStatusHeartbeat({
+      eventServer: context.eventServer,
+      getSnapshot: () => ({
+        status: context.state.status,
+        activeGoals: context.state.active_goals,
+        loopCount: context.state.loop_count,
+        startedAt: context.state.started_at,
+      }),
+    });
+
+    context.driveSystem.startWatcher((event: unknown) => context.onEventReceived(event));
+
+    context.shuttingDown = false;
+    const shutdownTimeout = context.config.crash_recovery.graceful_shutdown_timeout_ms ?? 30_000;
+    context.shutdownCoordinator = new ProcessShutdownCoordinator({
+      logger: context.logger,
+      gracefulShutdownTimeoutMs: shutdownTimeout,
+      onShutdown: () => context.beginGracefulShutdown(),
+      onForceStop: () => {
+        context.running = false;
+      },
+      signalTarget: context.deps.shutdownSignalTarget,
+    });
+    context.shutdownCoordinator.activate();
+
+    const restoredGoalIds = await context.restoreState(goalIds);
+    const reconciledGoalIds = await context.reconcileInterruptedExecutions();
+    const mergedGoalIds = Array.from(new Set([...restoredGoalIds, ...reconciledGoalIds]));
+
+    context.running = true;
+    context.currentGoalIds = mergedGoalIds;
+    context.currentLoopIndex = 0;
+    context.state = {
+      pid: process.pid,
+      started_at: new Date().toISOString(),
+      last_loop_at: null,
+      loop_count: 0,
+      active_goals: mergedGoalIds,
+      status: mergedGoalIds.length === 0 ? "idle" : "running",
+      crash_count: 0,
+      last_error: null,
+      last_resident_at: null,
+      resident_activity: null,
+    } as typeof context.state;
+    (context as StartupRunnerContext & { providerRuntimeFingerprint: string | null }).providerRuntimeFingerprint =
+      await context.captureProviderRuntimeFingerprint();
+    await context.saveDaemonState();
+
+    await context.writeShutdownMarker({
+      goal_ids: mergedGoalIds,
+      loop_index: 0,
+      timestamp: new Date().toISOString(),
+      reason: "startup",
+      state: "running",
+    });
+
+    context.logger.info("Daemon started", {
+      pid: process.pid,
+      goals: mergedGoalIds,
+      check_interval_ms: context.config.check_interval_ms,
+    });
+
+    const sweepResult = context.queueClaimSweeper?.sweep();
+    if (sweepResult && (sweepResult.reclaimed > 0 || sweepResult.deadlettered > 0)) {
+      context.logger.info("Recovered stale runtime claims on startup", {
+        reclaimed: sweepResult.reclaimed,
+        deadlettered: sweepResult.deadlettered,
+        expiredClaimTokens: sweepResult.expiredClaimTokens,
+      });
+    }
+    context.queueClaimSweeper?.start();
+
+    if (!context.supervisor) {
+      const factory = context.deps.coreLoopFactory ?? (() => context.coreLoop);
+      context.supervisor = new (await import("../executor/index.js")).LoopSupervisor(
+        {
+          coreLoopFactory: factory,
+          journalQueue: context.journalQueue!,
+          goalLeaseManager: context.goalLeaseManager!,
+          driveSystem: context.driveSystem,
+          stateManager: context.stateManager,
+          logger: context.logger,
+          onGoalComplete: async (goalId, result) => context.handleGoalCompletion(goalId, result),
+          onEscalation: (goalId, crashCount, lastError) => {
+            context.logger.error(`Goal ${goalId} suspended after ${crashCount} crashes: ${lastError}`);
+          },
+        },
+        {
+          concurrency: context.config.max_concurrent_goals,
+          iterationsPerCycle: context.config.iterations_per_cycle,
+          stateFilePath: path.join(context.runtimeRoot!, "supervisor-state.json"),
+        }
+      );
+    }
+    if (!context.eventDispatcher) {
+      context.eventDispatcher = new EventDispatcher({
+        journalQueue: context.journalQueue!,
+        logger: context.logger,
+        onGoalActivate: async (goalId) => context.handleGoalStartCommand(goalId),
+        onExternalEvent: async (event: unknown) => context.driveSystem.writeEvent(PulSeedEventSchema.parse(event)),
+        onCronTaskDue: async (task) => context.handleCronTaskDue(task.id),
+      });
+    }
+    if (!context.commandDispatcher) {
+      context.commandDispatcher = new CommandDispatcher({
+        journalQueue: context.journalQueue!,
+        logger: context.logger,
+        onGoalStart: async (goalId) =>
+          context.runCommandWithHealth("goal_start", () => context.handleGoalStartCommand(goalId)),
+        onGoalStop: async (goalId) =>
+          context.runCommandWithHealth("goal_stop", () => context.handleGoalStopCommand(goalId)),
+        onChatMessage: async (goalId, message) =>
+          context.runCommandWithHealth("chat_message", () => context.handleChatMessageCommand(goalId, message)),
+        onApprovalResponse: async (goalId, requestId, approved) =>
+          context.runCommandWithHealth("approval_response", () =>
+            context.handleApprovalResponseCommand(goalId, requestId, approved)),
+        onRuntimeControl: async (operationId, kind) =>
+          context.runCommandWithHealth("runtime_control", () => context.handleRuntimeControlCommand(operationId, kind)),
+        onScheduleRunNow: async (scheduleId, allowEscalation) =>
+          context.runCommandWithHealth("schedule_run_now", () =>
+            context.handleScheduleRunNowCommand(scheduleId, allowEscalation)),
+      });
+    }
+
+    await context.saveRuntimeHealthSnapshot(
+      context.supervisor ? "execution_ownership_durable" : "foundation_only",
+      {
+        gateway: context.gateway || context.eventServer ? "ok" : "degraded",
+        queue: "ok",
+        leases: "ok",
+        approval: "ok",
+        outbox: "ok",
+        supervisor: context.supervisor ? "ok" : "degraded",
+      }
+    );
+    context.startStartupRuntimeStoreMaintenance();
+
+    startupReady = true;
+    let cleanupHandled = false;
+    try {
+      await context.eventDispatcher?.start();
+      await context.commandDispatcher?.start();
+      if (context.supervisor) {
+        await context.supervisor.start(mergedGoalIds);
+        const maintenanceIntervalMs = context.config.check_interval_ms;
+        await context.runSupervisorMaintenanceCycle();
+        await context.reconcileRuntimeControlOperationsAfterStartup();
+        context.cronScheduleInterval = setInterval(async () => {
+          if (context.shuttingDown) return;
+          await context.runSupervisorMaintenanceCycle();
+        }, maintenanceIntervalMs);
+
+        await new Promise<void>((resolve) => {
+          context.shutdownResolve = resolve;
+          if (!context.running) resolve();
+        });
+      } else {
+        await context.reconcileRuntimeControlOperationsAfterStartup();
+        await context.runLoop();
+        cleanupHandled = true;
+      }
+    } finally {
+      context.queueClaimSweeper?.stop();
+      context.shutdownCoordinator?.dispose();
+      context.shutdownCoordinator = null;
+      context.stopStatusHeartbeat?.();
+      context.stopStatusHeartbeat = null;
+      if (context.cronScheduleInterval !== null) {
+        clearInterval(context.cronScheduleInterval);
+        context.cronScheduleInterval = null;
+      }
+      await context.supervisor?.shutdown();
+      await context.eventDispatcher?.shutdown();
+      await context.commandDispatcher?.shutdown();
+      context.driveSystem.stopWatcher();
+      if (context.gateway) {
+        await context.gateway.stop();
+        context.logger.info("Gateway stopped");
+      } else if (context.eventServer) {
+        context.eventServer.stopFileWatcher();
+        await context.eventServer.stop();
+        context.logger.info("EventServer stopped");
+      }
+      if (!cleanupHandled) {
+        await context.cleanup();
+      }
+    }
+  } catch (err) {
+    if (!startupReady) {
+      try {
+        await context.drainStartupRuntimeStoreMaintenance();
+      } finally {
+        await context.releaseStartupOwnership();
+      }
+    }
+    throw err;
+  }
+}
+
+export async function reconcileRuntimeControlOperationsAfterStartup(
+  runtimeRoot: string | null,
+  state: { status: string },
+  logger: { info(message: string, meta?: Record<string, unknown>): void },
+): Promise<void> {
+  const operationStore = new RuntimeOperationStore(runtimeRoot ?? undefined);
+  const pending = await operationStore.listPending();
+  const now = new Date().toISOString();
+  for (const operation of pending) {
+    if (
+      operation.state !== "restarting" ||
+      (operation.kind !== "restart_daemon" && operation.kind !== "restart_gateway")
+    ) {
+      continue;
+    }
+    await operationStore.save({
+      ...operation,
+      state: "verified",
+      updated_at: now,
+      completed_at: now,
+      result: {
+        ok: true,
+        message:
+          operation.kind === "restart_gateway"
+            ? "gateway restart verified after daemon startup."
+            : "daemon restart verified after startup.",
+        daemon_status: state.status,
+      },
+    });
+    logger.info("Runtime control restart operation verified after startup", {
+      operation_id: operation.operation_id,
+      kind: operation.kind,
+    });
+  }
+}
+
+export function failRuntimeLeadership(
+  context: Pick<
+    StartupRunnerContext,
+    "state" | "logger" | "running" | "shuttingDown" | "shutdownResolve" | "sleepAbortController" | "saveDaemonState"
+  > & { currentGoalIds?: string[] },
+  reason: string,
+): void {
+  if (context.state.status === "crashed") {
+    return;
+  }
+
+  context.logger.error("Lost runtime leadership; stopping daemon", { error: reason });
+  context.state.status = "crashed";
+  context.state.last_error = reason;
+  context.state.interrupted_goals = [...context.state.active_goals];
+  context.running = false;
+  context.shuttingDown = true;
+  context.shutdownResolve?.();
+  context.sleepAbortController?.abort();
+  void context.saveDaemonState();
+}
+
+export function handleLoopError(
+  context: Pick<StartupRunnerContext, "state" | "config" | "logger" | "runtimeOwnership"> & { running: boolean },
+  goalId: string,
+  err: unknown,
+): boolean {
+  const { shouldStop } = handleDaemonLoopError({
+    goalId,
+    error: err,
+    state: context.state,
+    maxRetries: context.config.crash_recovery.max_retries,
+    logger: context.logger,
+    observeTaskExecution: (status, reason) => context.runtimeOwnership.observeTaskExecution(status, reason),
+  });
+  if (shouldStop) {
+    context.running = false;
+  }
+  return shouldStop;
+}
+
+export async function handleCriticalError(
+  context: Pick<StartupRunnerContext, "state" | "logger" | "runtimeOwnership" | "saveDaemonState"> & { running: boolean },
+  err: unknown,
+): Promise<void> {
+  await handleCriticalDaemonError({
+    error: err,
+    state: context.state,
+    logger: context.logger,
+    observeTaskExecution: (status, reason) => context.runtimeOwnership.observeTaskExecution(status, reason),
+    saveDaemonState: () => context.saveDaemonState(),
+  });
+  context.running = false;
+}
+
+export function beginGracefulShutdown(
+  context: Pick<
+    StartupRunnerContext,
+    "shuttingDown" | "logger" | "running" | "state" | "shutdownResolve" | "sleepAbortController"
+  >,
+): void {
+  if (context.shuttingDown) {
+    return;
+  }
+
+  context.shuttingDown = true;
+  context.logger.info("Shutting down gracefully...");
+  context.running = false;
+  context.state.status = "stopping";
+  context.state.interrupted_goals = [...context.state.active_goals];
+  context.shutdownResolve?.();
+  context.sleepAbortController?.abort();
+}

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -1,6 +1,4 @@
-import * as fs from "node:fs";
 import * as path from "node:path";
-import { spawnSync } from "node:child_process";
 import { CoreLoop } from "../../orchestrator/loop/core-loop.js";
 import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
 import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
@@ -30,8 +28,7 @@ import type { DreamReport, DreamRunReport, DreamTier } from "../../platform/drea
 import { runDreamConsolidation } from "../../reflection/dream-consolidation.js";
 import { generateCronEntry } from "./signals.js";
 import { rotateDaemonLog, calculateAdaptiveInterval as calcAdaptiveInterval } from "./health.js";
-import { IngressGateway, HttpChannelAdapter } from "../gateway/index.js";
-import { PulSeedEventSchema } from "../../base/types/drive.js";
+import { IngressGateway } from "../gateway/index.js";
 import type { Envelope } from "../types/envelope.js";
 import { LoopSupervisor } from "../executor/index.js";
 import {
@@ -56,11 +53,8 @@ import {
 import {
   type ProcessSignalTarget,
   ProcessShutdownCoordinator,
-  startDaemonStatusHeartbeat,
 } from "./runner-lifecycle.js";
 import {
-  handleCriticalDaemonError,
-  handleDaemonLoopError,
   runCommandWithHealth as runCommandWithHealthFn,
 } from "./runner-errors.js";
 import { reconcileInterruptedExecutions as reconcileInterruptedExecutionsFn } from "./runner-recovery.js";
@@ -82,87 +76,56 @@ import {
   runProactiveMaintenance,
   runSupervisorMaintenanceCycleForDaemon,
   saveDaemonStateFile,
-  writeChatMessageEvent,
   writeShutdownMarkerFile,
 } from "./index.js";
 import type { GoalCycleScheduleSnapshotEntry } from "./maintenance.js";
+import {
+  acceptRuntimeEnvelope as acceptRuntimeEnvelopeFn,
+  handleApprovalResponseCommand as handleApprovalResponseCommandFn,
+  handleChatMessageCommand as handleChatMessageCommandFn,
+  handleCronTaskDue as handleCronTaskDueFn,
+  handleGoalStartCommand as handleGoalStartCommandFn,
+  handleGoalStopCommand as handleGoalStopCommandFn,
+  handleInboundEnvelope as handleInboundEnvelopeFn,
+  handleRuntimeControlCommand as handleRuntimeControlCommandFn,
+  handleScheduleRunNowCommand as handleScheduleRunNowCommandFn,
+} from "./runner-commands.js";
+import { runDaemonGoalCycleLoop } from "./runner-goal-cycle.js";
+import {
+  beginGracefulShutdown as beginGracefulShutdownFn,
+  failRuntimeLeadership as failRuntimeLeadershipFn,
+  handleCriticalError as handleCriticalErrorFn,
+  handleLoopError as handleLoopErrorFn,
+  reconcileRuntimeControlOperationsAfterStartup as reconcileRuntimeControlOperationsAfterStartupFn,
+  startDaemonRunner,
+} from "./runner-startup.js";
+import {
+  gatherResidentWorkspaceContext,
+  legacyReportFromPlatformDream as legacyReportFromPlatformDreamFn,
+  loadExistingGoalTitles as loadExistingGoalTitlesFn,
+  loadKnownGoals as loadKnownGoalsFn,
+  persistResidentActivity as persistResidentActivityFn,
+  proactiveTick as proactiveTickFn,
+  resolveResidentWorkspaceDir,
+  runDreamAnalysis as runDreamAnalysisFn,
+  runPlatformDreamConsolidation as runPlatformDreamConsolidationFn,
+  runResidentCuriosityCycle as runResidentCuriosityCycleFn,
+  runScheduledGoalReview as runScheduledGoalReviewFn,
+  triggerIdleResidentMaintenance as triggerIdleResidentMaintenanceFn,
+  triggerResidentDreamMaintenance as triggerResidentDreamMaintenanceFn,
+  triggerResidentGoalDiscovery as triggerResidentGoalDiscoveryFn,
+  triggerResidentInvestigation as triggerResidentInvestigationFn,
+  triggerResidentPreemptiveCheck as triggerResidentPreemptiveCheckFn,
+  tryApplyPendingDreamSuggestion as tryApplyPendingDreamSuggestionFn,
+} from "./runner-resident.js";
 const RUNTIME_JOURNAL_MAX_ATTEMPTS = 1_000;
-
-function resolveResidentWorkspaceDir(configuredPath?: string): string {
-  const trimmed = configuredPath?.trim();
-  return trimmed ? path.resolve(trimmed) : process.cwd();
-}
-
-function gatherResidentWorkspaceContext(workspaceDir: string, seedDescription?: string): string {
-  const parts: string[] = [`Workspace: ${workspaceDir}`];
-  const seed = seedDescription?.trim();
-  if (seed) {
-    parts.push(`Resident trigger hint: ${seed}`);
-  }
-
-  try {
-    const pkgPath = path.join(workspaceDir, "package.json");
-    const pkgRaw = fs.readFileSync(pkgPath, "utf-8");
-    const pkg = JSON.parse(pkgRaw) as Record<string, unknown>;
-    const name = typeof pkg.name === "string" ? pkg.name : "";
-    const description = typeof pkg.description === "string" ? pkg.description : "";
-    const scripts = pkg.scripts && typeof pkg.scripts === "object"
-      ? Object.keys(pkg.scripts as Record<string, unknown>).join(", ")
-      : "";
-    const prefix = name ? `Node.js project '${name}'` : "Node.js project";
-    const descPart = description ? `. ${description}` : "";
-    const scriptsPart = scripts ? `. Scripts: ${scripts}` : "";
-    parts.push(`${prefix}${descPart}${scriptsPart}`);
-  } catch {
-    // No package metadata available.
-  }
-
-  try {
-    const entries = fs.readdirSync(workspaceDir);
-    const dirs = entries.filter((entry) => {
-      try {
-        return fs.statSync(path.join(workspaceDir, entry)).isDirectory();
-      } catch {
-        return false;
-      }
-    });
-    const files = entries.filter((entry) => {
-      try {
-        return fs.statSync(path.join(workspaceDir, entry)).isFile();
-      } catch {
-        return false;
-      }
-    });
-    const visibleEntries = [
-      dirs.slice(0, 10).map((entry) => `${entry}/`).join(", "),
-      files.slice(0, 5).join(", "),
-    ].filter(Boolean).join(", ");
-    if (visibleEntries) {
-      parts.push(`Files: ${visibleEntries}`);
-    }
-  } catch {
-    // Workspace listing is best-effort.
-  }
-
-  const gitResult = spawnSync("git", ["log", "--oneline", "-5", "--format=%s"], {
-    cwd: workspaceDir,
-    encoding: "utf-8",
-  });
-  if (gitResult.status === 0 && gitResult.stdout.trim().length > 0) {
-    parts.push(`Recent changes: ${gitResult.stdout.trim().split("\n").join("; ")}`);
-  }
-
-  return parts.join(". ");
-}
+const RUNTIME_LEADER_LEASE_MS = 30_000;
+const RUNTIME_LEADER_HEARTBEAT_MS = 10_000;
 
 // Re-exports for callers that imported these from daemon-runner
 export { generateCronEntry } from "./signals.js";
 export { rotateDaemonLog, calculateAdaptiveInterval } from "./health.js";
 export type { ShutdownMarker } from "./index.js";
-
-const RUNTIME_LEADER_LEASE_MS = 30_000;
-const RUNTIME_LEADER_HEARTBEAT_MS = 10_000;
-const MAX_IDLE_SLEEP_MS = 5_000;
 
 // ─── DaemonRunner ───
 //
@@ -388,309 +351,9 @@ export class DaemonRunner {
    * Throws if daemon is already running.
    */
   async start(goalIds: string[]): Promise<void> {
-    let startupReady = false;
-    try {
-      // 2. Rotate log if needed, then check for crash recovery marker
-      await this.rotateLog();
-      await this.checkCrashRecovery();
-      await this.initializeRuntimeFoundation();
-      await this.acquireRuntimeLeadership();
-
-      // 2c. Start EventServer (always-on) and file watcher
-      if (!this.eventServer) {
-        const esPort = this.config.event_server_port ?? 41700;
-        this.eventServer = new EventServer(this.driveSystem, {
-          port: esPort,
-          stateManager: this.stateManager,
-          outboxStore: this.outboxStore ?? undefined,
-        }, this.logger);
-      }
-      if (this.outboxStore) {
-        this.eventServer.setOutboxStore?.(this.outboxStore);
-      }
-      this.eventServer.setActiveWorkersProvider?.(() => {
-        const workers = this.supervisor?.getState().workers ?? [];
-        return workers
-          .filter((worker) => worker.goalId !== null)
-          .map((worker) => ({
-            worker_id: worker.workerId,
-            goal_id: worker.goalId,
-            started_at: worker.startedAt,
-            iterations: worker.iterations,
-          }));
-      });
-      if (this.approvalBroker) {
-        this.approvalBroker.setBroadcast((eventType, data) => {
-          void this.eventServer?.broadcast?.(eventType, data);
-        });
-        this.eventServer.setApprovalBroker?.(this.approvalBroker);
-      }
-
-      this.eventServer.setCommandEnvelopeHook?.(async (envelope: Envelope) => this.handleInboundEnvelope(envelope));
-
-      if (this.gateway) {
-        // Phase A: Route through Gateway → Envelope → writeEvent
-        const httpAdapter = new HttpChannelAdapter(this.eventServer);
-        this.gateway.registerAdapter(httpAdapter);
-        this.gateway.onEnvelope(async (envelope: Envelope) => this.handleInboundEnvelope(envelope));
-        // Wire onHighPriority to abort sleep — done via the abortSleep() public method.
-        // Callers who construct buses should pass: onHighPriority: () => daemon.abortSleep()
-        // The daemon provides abortSleep() below for this purpose.
-        await this.gateway.start();
-        this.logger.info("Gateway started with HTTP adapter", { port: this.eventServer.getPort() });
-      } else {
-        await this.eventServer.start();
-        this.eventServer.startFileWatcher();
-        this.logger.info("EventServer started", { port: this.eventServer.getPort() });
-      }
-
-      // Wire approval bridge if not already provided
-      if (!this.approvalFn && this.eventServer) {
-        const es = this.eventServer;
-        this.approvalFn = async (task: Record<string, unknown>): Promise<boolean> => {
-          const goalId = String(task["goal_id"] ?? "unknown");
-          const description = String(task["description"] ?? "");
-          const action = String(task["action"] ?? "");
-          const taskId = String(task["id"] ?? "");
-
-          if (this.reportingEngine) {
-            try {
-              await this.reportingEngine.generateNotification("approval_required", {
-                goalId,
-                message: description || action || taskId || "Task approval required",
-                details: [`task_id: ${taskId || "(none)"}`, `action: ${action || "(none)"}`].join("\n"),
-              });
-            } catch (err) {
-              this.logger.warn("Approval notification dispatch failed", {
-                goalId,
-                error: err instanceof Error ? err.message : String(err),
-              });
-            }
-          }
-
-          return es.requestApproval(
-            goalId,
-            {
-              id: taskId,
-              description,
-              action,
-            }
-          );
-        };
-      }
-
-      this.stopStatusHeartbeat = startDaemonStatusHeartbeat({
-        eventServer: this.eventServer,
-        getSnapshot: () => ({
-          status: this.state.status,
-          activeGoals: this.state.active_goals,
-          loopCount: this.state.loop_count,
-          startedAt: this.state.started_at,
-        }),
-      });
-
-      this.driveSystem.startWatcher((event) => this.onEventReceived(event));
-
-      this.shuttingDown = false;
-      const shutdownTimeout = this.config.crash_recovery.graceful_shutdown_timeout_ms ?? 30_000;
-      this.shutdownCoordinator = new ProcessShutdownCoordinator({
-        logger: this.logger,
-        gracefulShutdownTimeoutMs: shutdownTimeout,
-        onShutdown: () => this.beginGracefulShutdown(),
-        onForceStop: () => {
-          this.running = false;
-        },
-        signalTarget: this.deps.shutdownSignalTarget,
-      });
-      this.shutdownCoordinator.activate();
-
-      // 4. Restore state from previous interrupted run
-      const restoredGoalIds = await this.restoreState(goalIds);
-      const reconciledGoalIds = await this.reconcileInterruptedExecutions();
-      const mergedGoalIds = Array.from(new Set([...restoredGoalIds, ...reconciledGoalIds]));
-
-      // 5. Save initial daemon state
-      this.running = true;
-      this.currentGoalIds = mergedGoalIds;
-      this.currentLoopIndex = 0;
-      this.state = DaemonStateSchema.parse({
-        pid: process.pid,
-        started_at: new Date().toISOString(),
-        last_loop_at: null,
-        loop_count: 0,
-        active_goals: mergedGoalIds,
-        status: mergedGoalIds.length === 0 ? "idle" : "running",
-        crash_count: 0,
-        last_error: null,
-        last_resident_at: null,
-        resident_activity: null,
-      });
-      this.providerRuntimeFingerprint = await this.captureProviderRuntimeFingerprint();
-      await this.saveDaemonState();
-
-      // 5b. Write "running" shutdown marker (crash detection on next startup)
-      await this.writeShutdownMarker({
-        goal_ids: mergedGoalIds,
-        loop_index: 0,
-        timestamp: new Date().toISOString(),
-        reason: "startup",
-        state: "running",
-      });
-
-      // 6. Log start
-      this.logger.info("Daemon started", {
-        pid: process.pid,
-        goals: mergedGoalIds,
-        check_interval_ms: this.config.check_interval_ms,
-      });
-
-      const sweepResult = this.queueClaimSweeper?.sweep();
-      if (sweepResult && (sweepResult.reclaimed > 0 || sweepResult.deadlettered > 0)) {
-        this.logger.info("Recovered stale runtime claims on startup", {
-          reclaimed: sweepResult.reclaimed,
-          deadlettered: sweepResult.deadlettered,
-          expiredClaimTokens: sweepResult.expiredClaimTokens,
-        });
-      }
-      this.queueClaimSweeper?.start();
-
-    // 7. Create supervisor if not already provided.
-    if (!this.supervisor) {
-      const factory = this.deps.coreLoopFactory ?? (() => this.coreLoop);
-      this.supervisor = new LoopSupervisor(
-        {
-          coreLoopFactory: factory,
-          journalQueue: this.journalQueue!,
-          goalLeaseManager: this.goalLeaseManager!,
-          driveSystem: this.driveSystem,
-          stateManager: this.stateManager,
-          logger: this.logger,
-          onGoalComplete: async (goalId, result) => this.handleGoalCompletion(goalId, result),
-          onEscalation: (goalId, crashCount, lastError) => {
-            this.logger.error(`Goal ${goalId} suspended after ${crashCount} crashes: ${lastError}`);
-          },
-        },
-        {
-          concurrency: this.config.max_concurrent_goals,
-          iterationsPerCycle: this.config.iterations_per_cycle,
-          stateFilePath: path.join(this.runtimeRoot!, "supervisor-state.json"),
-        }
-      );
-    }
-    if (!this.eventDispatcher) {
-      this.eventDispatcher = new EventDispatcher({
-        journalQueue: this.journalQueue!,
-        logger: this.logger,
-        onGoalActivate: async (goalId) => this.handleGoalStartCommand(goalId),
-        onExternalEvent: async (event) =>
-          this.driveSystem.writeEvent(PulSeedEventSchema.parse(event)),
-        onCronTaskDue: async (task) => this.handleCronTaskDue(task.id),
-      });
-    }
-    if (!this.commandDispatcher) {
-      this.commandDispatcher = new CommandDispatcher({
-        journalQueue: this.journalQueue!,
-        logger: this.logger,
-        onGoalStart: async (goalId) =>
-          this.runCommandWithHealth("goal_start", () => this.handleGoalStartCommand(goalId)),
-        onGoalStop: async (goalId) =>
-          this.runCommandWithHealth("goal_stop", () => this.handleGoalStopCommand(goalId)),
-        onChatMessage: async (goalId, message) =>
-          this.runCommandWithHealth("chat_message", () => this.handleChatMessageCommand(goalId, message)),
-        onApprovalResponse: async (goalId, requestId, approved) =>
-          this.runCommandWithHealth("approval_response", () => this.handleApprovalResponseCommand(goalId, requestId, approved)),
-        onRuntimeControl: async (operationId, kind) =>
-          this.runCommandWithHealth("runtime_control", () => this.handleRuntimeControlCommand(operationId, kind)),
-        onScheduleRunNow: async (scheduleId, allowEscalation) =>
-          this.runCommandWithHealth(
-            "schedule_run_now",
-            () => this.handleScheduleRunNowCommand(scheduleId, allowEscalation)
-          ),
-      });
-    }
-
-    await this.saveRuntimeHealthSnapshot(
-      this.supervisor
-        ? "execution_ownership_durable"
-        : "foundation_only",
-      {
-        gateway: this.gateway || this.eventServer ? "ok" : "degraded",
-        queue: "ok",
-        leases: "ok",
-        approval: "ok",
-        outbox: "ok",
-        supervisor: this.supervisor ? "ok" : "degraded",
-      }
-    );
-    this.startStartupRuntimeStoreMaintenance();
-
-    // 8. Run main loop — supervisor mode when supervisor is injected via deps,
-    //    fallback to sequential runLoop otherwise.
-      startupReady = true;
-      let cleanupHandled = false;
-      try {
-        await this.eventDispatcher?.start();
-        await this.commandDispatcher?.start();
-        if (this.supervisor) {
-          // Supervisor handles goal execution; cron/schedule must also run in this mode.
-          await this.supervisor.start(mergedGoalIds);
-
-          const maintenanceIntervalMs = this.config.check_interval_ms;
-          await this.runSupervisorMaintenanceCycle();
-          await this.reconcileRuntimeControlOperationsAfterStartup();
-          this.cronScheduleInterval = setInterval(async () => {
-            if (this.shuttingDown) return;
-            await this.runSupervisorMaintenanceCycle();
-          }, maintenanceIntervalMs);
-
-          // Block until stop() is called.
-          await new Promise<void>((resolve) => {
-            this.shutdownResolve = resolve;
-            // If already stopped before we get here, resolve immediately.
-            if (!this.running) resolve();
-          });
-        } else {
-          // Fallback: sequential mode
-          await this.reconcileRuntimeControlOperationsAfterStartup();
-          await this.runLoop();
-          cleanupHandled = true;
-        }
-      } finally {
-        this.queueClaimSweeper?.stop();
-        this.shutdownCoordinator?.dispose();
-        this.shutdownCoordinator = null;
-        this.stopStatusHeartbeat?.();
-        this.stopStatusHeartbeat = null;
-        if (this.cronScheduleInterval !== null) {
-          clearInterval(this.cronScheduleInterval);
-          this.cronScheduleInterval = null;
-        }
-        await this.supervisor?.shutdown();
-        await this.eventDispatcher?.shutdown();
-        await this.commandDispatcher?.shutdown();
-        this.driveSystem.stopWatcher();
-        if (this.gateway) {
-          await this.gateway.stop();
-          this.logger.info("Gateway stopped");
-        } else if (this.eventServer) {
-          this.eventServer.stopFileWatcher();
-          await this.eventServer.stop();
-          this.logger.info("EventServer stopped");
-        }
-        if (!cleanupHandled) {
-          await this.cleanup();
-        }
-      }
-    } catch (err) {
-      if (!startupReady) {
-        try {
-          await this.drainStartupRuntimeStoreMaintenance();
-        } finally {
-          await this.releaseStartupOwnership();
-        }
-      }
-      throw err;
-    }
+    await this.rotateLog();
+    await this.checkCrashRecovery();
+    await startDaemonRunner(this as never, goalIds);
   }
 
   private async initializeRuntimeFoundation(): Promise<void> {
@@ -712,21 +375,7 @@ export class DaemonRunner {
   }
 
   private failRuntimeLeadership(reason: string): void {
-    if (this.state.status === "crashed") {
-      return;
-    }
-
-    this.logger.error("Lost runtime leadership; stopping daemon", {
-      error: reason,
-    });
-    this.state.status = "crashed";
-    this.state.last_error = reason;
-    this.state.interrupted_goals = [...this.state.active_goals];
-    this.running = false;
-    this.shuttingDown = true;
-    this.shutdownResolve?.();
-    this.sleepAbortController?.abort();
-    void this.saveDaemonState();
+    failRuntimeLeadershipFn(this as never, reason);
   }
 
   private async releaseStartupOwnership(): Promise<void> {
@@ -767,116 +416,7 @@ export class DaemonRunner {
    * Main daemon loop. Runs until this.running is false or a critical error occurs.
    */
   private async runLoop(): Promise<void> {
-    while (this.running && !this.shuttingDown) {
-      try {
-        const goalIds = [...this.currentGoalIds];
-        this.refreshOperationalState();
-        const cycleSnapshot = await this.collectGoalCycleSnapshot(goalIds);
-        // 1. Determine which goals need activation
-        const activeGoals = await this.determineActiveGoals(goalIds, cycleSnapshot);
-        await this.maybeRefreshProviderRuntime(activeGoals.length);
-
-        if (activeGoals.length === 0) {
-          this.logger.info("No goals need activation this cycle", {
-            checked: goalIds.length,
-          });
-        }
-
-        // 2. Execute loop for each active goal
-        for (const goalId of activeGoals) {
-          if (!this.running) break;
-
-          this.logger.info(`Running loop for goal: ${goalId}`);
-
-          try {
-            const iterationsPerCycle = this.config.iterations_per_cycle ?? 1;
-            const result: LoopResult = await this.coreLoop.run(goalId, { maxIterations: iterationsPerCycle });
-            this.state.loop_count++;
-            this.currentLoopIndex = this.state.loop_count;
-            this.state.last_loop_at = new Date().toISOString();
-            this.logger.info(`Loop completed for goal: ${goalId}`, {
-              status: result.finalStatus,
-              iterations: result.totalIterations,
-            });
-            if (this.eventServer) {
-              const goal = await this.stateManager.loadGoal(goalId).catch(() => null);
-              void this.eventServer.broadcast?.("iteration_complete", {
-                goalId,
-                loopCount: this.state.loop_count,
-                status: goal?.status ?? "unknown",
-              });
-            }
-            await this.broadcastGoalUpdated(goalId, result.finalStatus);
-          } catch (err) {
-            this.handleLoopError(goalId, err);
-          }
-
-          // Bail out of goal iteration if crash limit exceeded
-          if (!this.running) break;
-        }
-
-        // 3. Save state
-        this.refreshOperationalState();
-        await this.saveDaemonState();
-        if (this.eventServer) {
-          void this.eventServer.broadcast?.("daemon_status", {
-            status: this.state.status,
-            activeGoals: this.state.active_goals,
-            loopCount: this.state.loop_count,
-            lastLoopAt: this.state.last_loop_at,
-          });
-        }
-
-        // 3b. Process due cron-scheduled tasks
-        await this.processCronTasks();
-
-        // 3b2. Process schedule engine entries
-        await this.processScheduleEntries();
-
-        // 3c. Expire old cron tasks periodically (every 100 cycles)
-        if (this.state.loop_count > 0 && this.state.loop_count % 100 === 0) {
-          await this.expireCronTasks();
-        }
-
-        // 4. Proactive tick: fire every cycle (not only when idle) so long-running goals
-        // do not block proactive actions indefinitely.
-        if (this.running) {
-          await this.proactiveTick();
-        }
-
-        if (this.running) {
-          await this.runRuntimeStoreMaintenance();
-        }
-
-        // 5. Track idle cycles for adaptive sleep
-        if (activeGoals.length > 0) {
-          this.consecutiveIdleCycles = 0;
-        } else {
-          this.consecutiveIdleCycles++;
-        }
-
-        // 6. Wait for next check interval
-        if (this.running) {
-          const baseIntervalMs = this.getNextInterval(goalIds);
-          const maxGapScore = await this.getMaxGapScore(goalIds, cycleSnapshot);
-          const intervalMs = this.calculateAdaptiveInterval(
-            baseIntervalMs,
-            activeGoals.length,
-            maxGapScore,
-            this.consecutiveIdleCycles
-          );
-          const sleepIntervalMs =
-            activeGoals.length === 0 ? Math.min(intervalMs, MAX_IDLE_SLEEP_MS) : intervalMs;
-          this.logger.info(`Sleeping for ${sleepIntervalMs}ms until next check`);
-          await this.sleep(sleepIntervalMs);
-        }
-      } catch (err) {
-        await this.handleCriticalError(err);
-      }
-    }
-
-    // Cleanup after loop exits
-    await this.cleanup();
+    await runDaemonGoalCycleLoop(this as never);
   }
 
   // ─── Private: Goal Activation ───
@@ -916,18 +456,7 @@ export class DaemonRunner {
    * Increments crash_count and stops daemon if max_retries exceeded.
    */
   private handleLoopError(goalId: string, err: unknown): void {
-    const { shouldStop } = handleDaemonLoopError({
-      goalId,
-      error: err,
-      state: this.state,
-      maxRetries: this.config.crash_recovery.max_retries,
-      logger: this.logger,
-      observeTaskExecution: (status, reason) =>
-        this.runtimeOwnership.observeTaskExecution(status, reason),
-    });
-    if (shouldStop) {
-      this.running = false;
-    }
+    handleLoopErrorFn(this as never, goalId, err);
   }
 
   /**
@@ -935,15 +464,7 @@ export class DaemonRunner {
    * Marks state as crashed and stops the loop.
    */
   private async handleCriticalError(err: unknown): Promise<void> {
-    await handleCriticalDaemonError({
-      error: err,
-      state: this.state,
-      logger: this.logger,
-      observeTaskExecution: (status, reason) =>
-        this.runtimeOwnership.observeTaskExecution(status, reason),
-      saveDaemonState: () => this.saveDaemonState(),
-    });
-    this.running = false;
+    await handleCriticalErrorFn(this as never, err);
   }
 
   // ─── Private: State Persistence ───
@@ -973,35 +494,7 @@ export class DaemonRunner {
   }
 
   private async reconcileRuntimeControlOperationsAfterStartup(): Promise<void> {
-    const operationStore = new RuntimeOperationStore(this.runtimeRoot ?? undefined);
-    const pending = await operationStore.listPending();
-    const now = new Date().toISOString();
-    for (const operation of pending) {
-      if (
-        operation.state !== "restarting" ||
-        (operation.kind !== "restart_daemon" && operation.kind !== "restart_gateway")
-      ) {
-        continue;
-      }
-      await operationStore.save({
-        ...operation,
-        state: "verified",
-        updated_at: now,
-        completed_at: now,
-        result: {
-          ok: true,
-          message:
-            operation.kind === "restart_gateway"
-              ? "gateway restart verified after daemon startup."
-              : "daemon restart verified after startup.",
-          daemon_status: this.state.status,
-        },
-      });
-      this.logger.info("Runtime control restart operation verified after startup", {
-        operation_id: operation.operation_id,
-        kind: operation.kind,
-      });
-    }
+    await reconcileRuntimeControlOperationsAfterStartupFn(this.runtimeRoot, this.state, this.logger);
   }
 
   // ─── Private: Cleanup ───
@@ -1033,17 +526,7 @@ export class DaemonRunner {
   }
 
   private beginGracefulShutdown(): void {
-    if (this.shuttingDown) {
-      return;
-    }
-
-    this.shuttingDown = true;
-    this.logger.info("Shutting down gracefully...");
-    this.running = false;
-    this.state.status = "stopping";
-    this.state.interrupted_goals = [...this.state.active_goals];
-    this.shutdownResolve?.();
-    this.sleepAbortController?.abort();
+    beginGracefulShutdownFn(this as never);
   }
 
   // ─── Private: Cron Scheduler ───
@@ -1138,128 +621,33 @@ export class DaemonRunner {
   }
 
   private acceptRuntimeEnvelope(envelope: Envelope): boolean {
-    if (!this.journalQueue) return true;
-
-    const result: JournalBackedQueueAcceptResult = this.journalQueue.accept(envelope);
-    if (result.accepted) {
-      return true;
-    }
-
-    this.logger.info("Runtime journal skipped envelope", {
-      id: envelope.id,
-      name: envelope.name,
-      type: envelope.type,
-      duplicate: result.duplicate,
-      runtime_root: this.runtimeRoot,
-    });
-    return false;
+    return acceptRuntimeEnvelopeFn(this as never, envelope);
   }
 
   private async handleInboundEnvelope(envelope: Envelope): Promise<void> {
-    if (!this.acceptRuntimeEnvelope(envelope)) {
-      return;
-    }
+    await handleInboundEnvelopeFn(this as never, envelope);
   }
 
   private async handleGoalStartCommand(goalId: string): Promise<void> {
-    if (!this.currentGoalIds.includes(goalId)) {
-      this.currentGoalIds.push(goalId);
-    }
-    this.refreshOperationalState();
-    await this.saveDaemonState();
-    this.supervisor?.activateGoal(goalId);
-    this.abortSleep();
-    await this.broadcastGoalUpdated(goalId, "active");
+    await handleGoalStartCommandFn(this as never, goalId);
   }
 
   private async handleGoalStopCommand(goalId: string): Promise<void> {
-    this.currentGoalIds = this.currentGoalIds.filter((id) => id !== goalId);
-    this.refreshOperationalState();
-    if (this.state.interrupted_goals) {
-      this.state.interrupted_goals = this.state.interrupted_goals.filter((id) => id !== goalId);
-    }
-    await this.saveDaemonState();
-    this.supervisor?.deactivateGoal(goalId);
-    this.abortSleep();
-    await this.broadcastGoalUpdated(goalId, "stopped");
+    await handleGoalStopCommandFn(this as never, goalId);
   }
 
   private async handleRuntimeControlCommand(
     operationId: string,
     kind: RuntimeControlOperationKind
   ): Promise<void> {
-    const operationStore = new RuntimeOperationStore(this.runtimeRoot ?? undefined);
-    const operation = await operationStore.load(operationId);
-    if (!operation) {
-      this.logger.warn("Runtime control operation not found", { operation_id: operationId, kind });
-      return;
-    }
-
-    if (kind !== "restart_daemon" && kind !== "restart_gateway") {
-      const now = new Date().toISOString();
-      await operationStore.save({
-        ...operation,
-        state: "failed",
-        updated_at: now,
-        completed_at: now,
-        result: {
-          ok: false,
-          message: `Runtime control operation ${kind} is not implemented yet.`,
-        },
-      });
-      return;
-    }
-
-    const now = new Date().toISOString();
-    await operationStore.save({
-      ...operation,
-      state: "restarting",
-      started_at: operation.started_at ?? now,
-      updated_at: now,
-      result: {
-        ok: true,
-        message:
-          kind === "restart_gateway"
-            ? "gateway restart is being handled by a daemon restart because the gateway runs in-process."
-            : "daemon restart was accepted by the runtime command dispatcher.",
-      },
-    });
-
-    this.logger.info("Runtime control requested daemon restart", { operation_id: operationId, kind });
-    setTimeout(() => {
-      this.beginGracefulShutdown();
-    }, 25).unref?.();
+    await handleRuntimeControlCommandFn(this as never, operationId, kind);
   }
 
   private async handleScheduleRunNowCommand(
     scheduleId: string,
     allowEscalation: boolean
   ): Promise<void> {
-    if (!this.scheduleEngine) {
-      throw new Error("ScheduleEngine is not configured");
-    }
-
-    await this.scheduleEngine.loadEntries();
-    const entry = resolveScheduleEntry(this.scheduleEngine.getEntries(), scheduleId);
-    if (!entry) {
-      throw new Error(`Schedule not found: ${scheduleId}`);
-    }
-
-    const run = await this.scheduleEngine.runEntryNow(entry.id, {
-      allowEscalation,
-      preserveEnabled: true,
-    });
-    if (!run) {
-      throw new Error(`Schedule not found: ${scheduleId}`);
-    }
-
-    this.logger.info("Schedule run-now completed", {
-      schedule_id: entry.id,
-      schedule_name: entry.name,
-      status: run.result.status,
-      reason: run.reason,
-      allow_escalation: allowEscalation,
-    });
+    await handleScheduleRunNowCommandFn(this as never, scheduleId, allowEscalation);
   }
 
   private async handleGoalCompletion(goalId: string, result: { status: string; totalIterations: number }): Promise<void> {
@@ -1299,114 +687,21 @@ export class DaemonRunner {
   }
 
   private async loadExistingGoalTitles(): Promise<string[]> {
-    const goalIds = await this.stateManager.listGoalIds().catch(() => []);
-    const titles: string[] = [];
-    for (const goalId of goalIds) {
-      const goal = await this.stateManager.loadGoal(goalId).catch(() => null);
-      if (goal?.title) {
-        titles.push(goal.title);
-      }
-    }
-    return titles;
+    return loadExistingGoalTitlesFn(this as never);
   }
 
   private async loadKnownGoals(): Promise<Goal[]> {
-    const goalIds = await this.stateManager.listGoalIds().catch(() => []);
-    const goals: Goal[] = [];
-    for (const goalId of goalIds) {
-      const goal = await this.stateManager.loadGoal(goalId).catch(() => null);
-      if (goal) {
-        goals.push(goal);
-      }
-    }
-    return goals;
+    return loadKnownGoalsFn(this as never);
   }
 
   private async persistResidentActivity(
     activity: Omit<ResidentActivity, "recorded_at"> & { recorded_at?: string }
   ): Promise<void> {
-    const residentActivity = ResidentActivitySchema.parse({
-      ...activity,
-      recorded_at: activity.recorded_at ?? new Date().toISOString(),
-    });
-    this.state.last_resident_at = residentActivity.recorded_at;
-    this.state.resident_activity = residentActivity;
-    await this.saveDaemonState();
+    await persistResidentActivityFn(this as never, activity);
   }
 
   private async triggerResidentGoalDiscovery(details?: Record<string, unknown>): Promise<void> {
-    if (!this.goalNegotiator) {
-      await this.persistResidentActivity({
-        kind: "skipped",
-        trigger: "proactive_tick",
-        summary: "Resident discovery skipped because goal negotiation is unavailable.",
-      });
-      return;
-    }
-
-    if (this.currentGoalIds.length > 0) {
-      await this.persistResidentActivity({
-        kind: "skipped",
-        trigger: "proactive_tick",
-        summary: "Resident discovery skipped because active goals are already running.",
-      });
-      return;
-    }
-
-    const hintedDescription =
-      typeof details?.["description"] === "string" ? details["description"].trim() : "";
-    const hintedTitle =
-      typeof details?.["title"] === "string" ? details["title"].trim() : "";
-
-    try {
-      const workspaceDir = resolveResidentWorkspaceDir(this.config.workspace_path);
-      const workspaceContext = gatherResidentWorkspaceContext(workspaceDir, hintedDescription);
-      const existingTitles = await this.loadExistingGoalTitles();
-      const suggestions = await this.goalNegotiator.suggestGoals(workspaceContext, {
-        maxSuggestions: 1,
-        existingGoals: existingTitles,
-        repoPath: workspaceDir,
-      });
-      const suggestion = suggestions[0];
-      const suggestionTitle = suggestion?.title ?? hintedTitle;
-      const negotiationDescription = suggestion?.description ?? hintedDescription;
-
-      if (!negotiationDescription) {
-        await this.persistResidentActivity({
-          kind: "suggestion",
-          trigger: "proactive_tick",
-          summary: "Resident discovery ran but found no actionable goal to negotiate.",
-          suggestion_title: suggestionTitle || undefined,
-        });
-        return;
-      }
-
-      const { goal } = await this.goalNegotiator.negotiate(negotiationDescription, {
-        workspaceContext,
-        timeoutMs: 30_000,
-      });
-      if (!this.currentGoalIds.includes(goal.id)) {
-        this.currentGoalIds.push(goal.id);
-      }
-      this.refreshOperationalState();
-      await this.persistResidentActivity({
-        kind: "negotiation",
-        trigger: "proactive_tick",
-        summary: `Resident discovery negotiated a new goal: ${suggestionTitle || goal.title}`,
-        suggestion_title: suggestionTitle || goal.title,
-        goal_id: goal.id,
-      });
-      this.supervisor?.activateGoal(goal.id);
-      this.abortSleep();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.warn("Resident discovery failed", { error: message });
-      await this.persistResidentActivity({
-        kind: "error",
-        trigger: "proactive_tick",
-        summary: `Resident discovery failed: ${message}`,
-      });
-    }
+    await triggerResidentGoalDiscoveryFn(this as never, details);
   }
 
   private async runResidentCuriosityCycle(options?: {
@@ -1415,94 +710,21 @@ export class DaemonRunner {
     reviewLabel?: string;
     skipWhenNoTriggers?: boolean;
   }): Promise<boolean> {
-    if (!this.curiosityEngine) {
-      if (options?.skipWhenNoTriggers) {
-        return false;
-      }
-      await this.persistResidentActivity({
-        kind: "skipped",
-        trigger: options?.activityTrigger ?? "proactive_tick",
-        summary: "Resident investigation skipped because curiosity wiring is unavailable.",
-      });
-      return true;
-    }
-
-    try {
-      const goals = await this.loadKnownGoals();
-      const triggers = await this.curiosityEngine.evaluateTriggers(goals);
-      const focus = options?.focus?.trim() ?? "";
-
-      if (triggers.length === 0) {
-        if (options?.skipWhenNoTriggers) {
-          return false;
-        }
-        await this.persistResidentActivity({
-          kind: "curiosity",
-          trigger: options?.activityTrigger ?? "proactive_tick",
-          summary: options?.reviewLabel
-            ? `Resident ${options.reviewLabel} ran and found no curiosity triggers.`
-            : `Resident investigation ran${focus ? ` for ${focus}` : ""} and found nothing actionable.`,
-        });
-        return true;
-      }
-
-      const proposals = await this.curiosityEngine.generateProposals(triggers, goals);
-      if (proposals.length === 0) {
-        await this.persistResidentActivity({
-          kind: "curiosity",
-          trigger: options?.activityTrigger ?? "proactive_tick",
-          summary: options?.reviewLabel
-            ? `Resident ${options.reviewLabel} ran but produced no curiosity proposals.`
-            : `Resident investigation ran${focus ? ` for ${focus}` : ""} but produced no curiosity proposals.`,
-        });
-        return true;
-      }
-
-      const proposal = proposals[0]!;
-      await this.persistResidentActivity({
-        kind: "curiosity",
-        trigger: options?.activityTrigger ?? "proactive_tick",
-        summary: options?.reviewLabel
-          ? `Resident ${options.reviewLabel} created ${proposals.length} curiosity proposal(s); next focus: ${proposal.proposed_goal.description}`
-          : `Resident investigation created ${proposals.length} curiosity proposal(s); next focus: ${proposal.proposed_goal.description}`,
-        suggestion_title: proposal.proposed_goal.description,
-      });
-      return true;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.warn("Resident investigation failed", { error: message });
-      await this.persistResidentActivity({
-        kind: "error",
-        trigger: options?.activityTrigger ?? "proactive_tick",
-        summary: `Resident investigation failed: ${message}`,
-      });
-      return true;
-    }
+    return runResidentCuriosityCycleFn(this as never, options);
   }
 
   private async triggerResidentInvestigation(details?: Record<string, unknown>): Promise<void> {
-    const focus = typeof details?.["what"] === "string" ? details["what"].trim() : "";
-    await this.runResidentCuriosityCycle({
-      activityTrigger: "proactive_tick",
-      focus,
-      skipWhenNoTriggers: false,
-    });
+    await triggerResidentInvestigationFn(this as never, details);
   }
 
   private async runScheduledGoalReview(): Promise<boolean> {
-    if (!this.curiosityEngine || !this.config.proactive_mode) {
-      return false;
-    }
-    const now = Date.now();
-    if (now - this.lastGoalReviewAt < this.config.goal_review_interval_ms) {
-      return false;
-    }
-    this.lastGoalReviewAt = now;
-    return this.runResidentCuriosityCycle({
-      activityTrigger: "schedule",
-      reviewLabel: "goal review",
-      skipWhenNoTriggers: false,
-    });
+    return runScheduledGoalReviewFn(
+      this as never,
+      this.lastGoalReviewAt,
+      (value: number) => {
+        this.lastGoalReviewAt = value;
+      },
+    );
   }
 
   private async tryApplyPendingDreamSuggestion(): Promise<{
@@ -1510,215 +732,31 @@ export class DaemonRunner {
     entry: { id: string };
     duplicate: boolean;
   } | null> {
-    const dreamStore = new DreamScheduleSuggestionStore(this.baseDir);
-    const pendingSuggestion = (await dreamStore.list()).find((suggestion) => suggestion.status === "pending");
-    if (!pendingSuggestion || !this.scheduleEngine) {
-      return null;
-    }
-
-    return dreamStore.applySuggestion(pendingSuggestion.id, this.scheduleEngine);
+    return tryApplyPendingDreamSuggestionFn(this as never);
   }
 
   private async runDreamAnalysis(tier: DreamTier): Promise<DreamRunReport> {
-    const analyzer = new DreamAnalyzer({
-      baseDir: this.baseDir,
-      llmClient: this.llmClient,
-      logger: this.logger,
-    });
-    return analyzer.run({ tier });
+    return runDreamAnalysisFn(this as never, tier);
   }
 
   private async runPlatformDreamConsolidation(tier: DreamTier): Promise<DreamReport | null> {
-    try {
-      const knowledgeManager = this.knowledgeManager;
-      const llmClient = this.llmClient;
-      const consolidator = new DreamConsolidator({
-        baseDir: this.baseDir,
-        logger: this.logger,
-        syncService: createRuntimeDreamSoilSyncService(),
-        memoryQualityService: knowledgeManager && llmClient
-          ? {
-              run: async (input) => {
-                const result = await lintAgentMemory({
-                  km: knowledgeManager,
-                  llmCall: async (prompt) => {
-                    const response = await llmClient.sendMessage(
-                      [{ role: "user", content: prompt }],
-                      { max_tokens: 2000, model_tier: "light" }
-                    );
-                    return response.content;
-                  },
-                  autoRepair: input.autoRepair,
-                  minAutoRepairConfidence: input.minAutoRepairConfidence,
-                });
-                return {
-                  findings: result.findings.length,
-                  contradictionsFound: result.findings.filter((finding) => finding.type === "contradiction").length,
-                  stalenessFound: result.findings.filter((finding) => finding.type === "staleness").length,
-                  redundancyFound: result.findings.filter((finding) => finding.type === "redundancy").length,
-                  repairsApplied: result.repairs_applied,
-                  entriesFlagged: result.entries_flagged,
-                };
-              },
-            }
-          : undefined,
-        legacyConsolidationService: tier === "deep"
-          ? {
-              run: () => runDreamConsolidation({
-                stateManager: this.stateManager,
-                memoryLifecycle: this.memoryLifecycle,
-                knowledgeManager: this.knowledgeManager,
-                baseDir: this.baseDir,
-              }),
-            }
-          : undefined,
-      });
-      return await consolidator.run({ tier });
-    } catch (error) {
-      this.logger.warn("Platform Dream consolidation failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return null;
-    }
+    return runPlatformDreamConsolidationFn(this as never, tier);
   }
 
   private legacyReportFromPlatformDream(report: DreamReport | null): DreamLegacyConsolidationReport | null {
-    const category = report?.categories.find((result) => result.category === "legacyReflectionCompatibility");
-    if (!category || category.status !== "completed") {
-      return null;
-    }
-    const legacy = report?.operational?.legacy_reflection;
-    return legacy
-      ? {
-          goals_consolidated: legacy.goals_consolidated,
-          entries_compressed: legacy.entries_compressed,
-          stale_entries_found: legacy.stale_entries_found,
-          revalidation_tasks_created: legacy.revalidation_tasks_created,
-        }
-      : null;
+    return legacyReportFromPlatformDreamFn(report);
   }
 
   private async triggerResidentDreamMaintenance(details?: Record<string, unknown>, tier: DreamTier = "deep"): Promise<void> {
-    try {
-      const appliedBeforeAnalysis = await this.tryApplyPendingDreamSuggestion();
-      if (appliedBeforeAnalysis) {
-        await this.persistResidentActivity({
-          kind: "dream",
-          trigger: "proactive_tick",
-          summary: appliedBeforeAnalysis.duplicate
-            ? `Resident dream linked pending suggestion "${appliedBeforeAnalysis.suggestion.name ?? appliedBeforeAnalysis.suggestion.id}" to existing schedule ${appliedBeforeAnalysis.entry.id}.`
-            : `Resident dream applied pending suggestion "${appliedBeforeAnalysis.suggestion.name ?? appliedBeforeAnalysis.suggestion.id}" into schedule ${appliedBeforeAnalysis.entry.id}.`,
-          suggestion_title: appliedBeforeAnalysis.suggestion.name ?? appliedBeforeAnalysis.suggestion.reason,
-        });
-        return;
-      }
-
-      const analysisReport = await this.runDreamAnalysis(tier);
-      const appliedAfterAnalysis = tier === "deep" ? await this.tryApplyPendingDreamSuggestion() : null;
-      const platformReport = await this.runPlatformDreamConsolidation(tier);
-      const consolidationReport = tier === "deep"
-        ? this.legacyReportFromPlatformDream(platformReport) ?? await runDreamConsolidation({
-            stateManager: this.stateManager,
-            memoryLifecycle: this.memoryLifecycle,
-            knowledgeManager: this.knowledgeManager,
-            baseDir: this.baseDir,
-          })
-        : null;
-      const requestedGoalId =
-        typeof details?.["goal_id"] === "string" ? details["goal_id"].trim() : "";
-      const goalHint = requestedGoalId ? ` for ${requestedGoalId}` : "";
-
-      await this.persistResidentActivity({
-        kind: "dream",
-        trigger: "proactive_tick",
-        summary: tier === "light"
-          ? `Resident dream light analysis ran${goalHint}; processed ${analysisReport.goalsProcessed.length} goals, persisted ${analysisReport.patternsPersisted} patterns, and generated ${analysisReport.scheduleSuggestions} schedule suggestion(s).`
-          : `Resident dream deep analysis ran${goalHint}; processed ${analysisReport.goalsProcessed.length} goals, persisted ${analysisReport.patternsPersisted} patterns, generated ${analysisReport.scheduleSuggestions} schedule suggestion(s), compressed ${consolidationReport?.entries_compressed ?? 0} entries, and created ${consolidationReport?.revalidation_tasks_created ?? 0} revalidation tasks${appliedAfterAnalysis ? ` while applying "${appliedAfterAnalysis.suggestion.name ?? appliedAfterAnalysis.suggestion.id}"` : ""}.`,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.warn("Resident dream maintenance failed", { error: message });
-      await this.persistResidentActivity({
-        kind: "error",
-        trigger: "proactive_tick",
-        summary: `Resident dream maintenance failed: ${message}`,
-      });
-    }
+    await triggerResidentDreamMaintenanceFn(this as never, details, tier);
   }
 
   private async triggerResidentPreemptiveCheck(details?: Record<string, unknown>): Promise<void> {
-    const goalId =
-      typeof details?.["goal_id"] === "string" ? details["goal_id"].trim() : "";
-
-    if (!goalId) {
-      await this.persistResidentActivity({
-        kind: "skipped",
-        trigger: "proactive_tick",
-        summary: "Resident preemptive check skipped because no goal_id was provided.",
-      });
-      return;
-    }
-
-    try {
-      const goal = await this.stateManager.loadGoal(goalId).catch(() => null);
-      if (!goal) {
-        await this.persistResidentActivity({
-          kind: "skipped",
-          trigger: "proactive_tick",
-          summary: `Resident preemptive check skipped because goal "${goalId}" was not found.`,
-          goal_id: goalId,
-        });
-        return;
-      }
-
-      await this.driveSystem.writeEvent(
-        PulSeedEventSchema.parse({
-          type: "external",
-          source: "resident-proactive",
-          timestamp: new Date().toISOString(),
-          data: {
-            event_type: "preemptive_check",
-            goal_id: goalId,
-            requested_by: "resident-daemon",
-          },
-        }),
-      );
-      if (!this.currentGoalIds.includes(goalId)) {
-        this.currentGoalIds.push(goalId);
-      }
-      this.refreshOperationalState();
-      this.supervisor?.activateGoal(goalId);
-      this.abortSleep();
-      await this.persistResidentActivity({
-        kind: "observation",
-        trigger: "proactive_tick",
-        summary: `Resident preemptive check queued an observation wake-up for goal "${goalId}".`,
-        goal_id: goalId,
-      });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      this.logger.warn("Resident preemptive check failed", { error: message, goal_id: goalId });
-      await this.persistResidentActivity({
-        kind: "error",
-        trigger: "proactive_tick",
-        summary: `Resident preemptive check failed: ${message}`,
-        goal_id: goalId || undefined,
-      });
-    }
+    await triggerResidentPreemptiveCheckFn(this as never, details);
   }
 
   private async triggerIdleResidentMaintenance(): Promise<void> {
-    if (this.currentGoalIds.length > 0) {
-      return;
-    }
-
-    const dreamSuggestionPath = path.join(this.baseDir, "dream", "schedule-suggestions.json");
-    const hasDreamSuggestionFile = fs.existsSync(dreamSuggestionPath);
-    if (!hasDreamSuggestionFile && !this.memoryLifecycle && !this.knowledgeManager && !this.llmClient) {
-      return;
-    }
-
-    await this.triggerResidentDreamMaintenance(undefined, "light");
+    await triggerIdleResidentMaintenanceFn(this as never);
   }
 
   private async runSupervisorMaintenanceCycle(): Promise<void> {
@@ -1784,9 +822,7 @@ export class DaemonRunner {
   }
 
   private async handleChatMessageCommand(goalId: string, message: string): Promise<void> {
-    await writeChatMessageEvent(this.driveSystem, goalId, message);
-    await this.broadcastChatResponse(goalId, message);
-    this.abortSleep();
+    await handleChatMessageCommandFn(this as never, goalId, message);
   }
 
   private async runCommandWithHealth<T>(commandName: string, fn: () => Promise<T>): Promise<T> {
@@ -1802,28 +838,11 @@ export class DaemonRunner {
     requestId: string,
     approved: boolean
   ): Promise<void> {
-    if (this.approvalBroker) {
-      await this.approvalBroker.resolveApproval(requestId, approved, "dispatcher");
-      return;
-    }
-    if (goalId && this.eventServer) {
-      await this.eventServer.resolveApproval(requestId, approved);
-    }
+    await handleApprovalResponseCommandFn(this as never, goalId, requestId, approved);
   }
 
   private async handleCronTaskDue(taskId: string): Promise<void> {
-    if (!this.cronScheduler) {
-      return;
-    }
-    try {
-      await this.cronScheduler.markFired(taskId);
-      this.logger.info(`Cron task fired: ${taskId}`);
-    } catch (err) {
-      this.logger.warn(`Cron task ${taskId} failed`, {
-        error: err instanceof Error ? err.message : String(err),
-      });
-      await this.cronScheduler.markFired(taskId);
-    }
+    await handleCronTaskDueFn(this as never, taskId);
   }
 
   private async runRuntimeStoreMaintenance(force = false): Promise<void> {
@@ -1885,64 +904,17 @@ export class DaemonRunner {
    * Errors are caught and logged — they never affect the daemon loop.
    */
   private async proactiveTick(): Promise<void> {
-    if (!this.config.proactive_mode) {
-      return;
-    }
-
-    if (await this.runScheduledGoalReview()) {
-      return;
-    }
-
-    const curiosityTriggered = await this.runResidentCuriosityCycle({
-      activityTrigger: "proactive_tick",
-      skipWhenNoTriggers: true,
-    });
-    if (curiosityTriggered) {
-      return;
-    }
-
-    const result = await runProactiveMaintenance({
-      config: this.config,
-      llmClient: this.llmClient,
-      state: this.state,
-      lastProactiveTickAt: this.lastProactiveTickAt,
-      logger: this.logger,
-    });
-    this.lastProactiveTickAt = result.lastProactiveTickAt;
-    if (!result.decision) {
-      return;
-    }
-
-    if (result.decision.action === "sleep") {
-      await this.persistResidentActivity({
-        kind: "sleep",
-        trigger: "proactive_tick",
-        summary: "Resident proactive tick stayed idle.",
-      });
-      await this.triggerIdleResidentMaintenance();
-      return;
-    }
-
-    if (result.decision.action === "suggest_goal") {
-      await this.triggerResidentGoalDiscovery(result.decision.details);
-      return;
-    }
-
-    if (result.decision.action === "investigate") {
-      await this.triggerResidentInvestigation(result.decision.details);
-      return;
-    }
-
-    if (result.decision.action === "preemptive_check") {
-      await this.triggerResidentPreemptiveCheck(result.decision.details);
-      return;
-    }
-
-    await this.persistResidentActivity({
-      kind: "skipped",
-      trigger: "proactive_tick",
-      summary: `Resident proactive tick requested ${result.decision.action}, but no resident executor is wired for it yet.`,
-    });
+    await proactiveTickFn(
+      this as never,
+      this.lastProactiveTickAt,
+      (value: number) => {
+        this.lastProactiveTickAt = value;
+      },
+      this.lastGoalReviewAt,
+      (value: number) => {
+        this.lastGoalReviewAt = value;
+      },
+    );
   }
 
   // ─── Private: Adaptive Sleep ───

--- a/src/runtime/event/server-auth.ts
+++ b/src/runtime/event/server-auth.ts
@@ -1,0 +1,143 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import * as http from "node:http";
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { Logger } from "../logger.js";
+import { writeJsonError } from "./server-http.js";
+
+const DAEMON_TOKEN_FILENAME = "daemon-token.json";
+
+export class EventServerAuth {
+  private readonly authToken = randomBytes(32).toString("base64url");
+
+  constructor(
+    private readonly host: string,
+    private readonly eventsDir: string,
+    private readonly getPort: () => number,
+    private readonly logger?: Logger
+  ) {}
+
+  getToken(): string {
+    return this.authToken;
+  }
+
+  async persistAuthToken(): Promise<void> {
+    const tokenPath = this.getAuthTokenPath();
+    await fsp.mkdir(path.dirname(tokenPath), { recursive: true });
+    const payload = {
+      token: this.authToken,
+      host: this.host,
+      port: this.getPort(),
+      pid: process.pid,
+      created_at: new Date().toISOString(),
+    };
+    await fsp.writeFile(tokenPath, JSON.stringify(payload, null, 2), {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+    await fsp.chmod(tokenPath, 0o600).catch(() => undefined);
+  }
+
+  async removeAuthTokenFile(): Promise<void> {
+    const tokenPath = this.getAuthTokenPath();
+    try {
+      const raw = await fsp.readFile(tokenPath, "utf-8");
+      const parsed = JSON.parse(raw) as { token?: unknown };
+      if (parsed.token !== this.authToken) return;
+      await fsp.unlink(tokenPath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        this.logger?.warn(`EventServer: failed to remove auth token file: ${String(err)}`);
+      }
+    }
+  }
+
+  authorizeRequest(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+    if (!this.isAllowedHost(req.headers.host)) {
+      writeJsonError(res, 403, "Forbidden host");
+      return false;
+    }
+
+    if (!this.isAllowedOrigin(req.headers.origin)) {
+      writeJsonError(res, 403, "Forbidden origin");
+      return false;
+    }
+
+    const fetchSite = this.singleHeader(req.headers["sec-fetch-site"])?.toLowerCase();
+    if (fetchSite && fetchSite !== "same-origin" && fetchSite !== "none") {
+      writeJsonError(res, 403, "Forbidden browser request");
+      return false;
+    }
+
+    if (!this.hasValidAuth(req.headers.authorization)) {
+      writeJsonError(res, 401, "Unauthorized");
+      return false;
+    }
+
+    if (req.method === "POST" && !this.hasJsonContentType(req.headers["content-type"])) {
+      writeJsonError(res, 415, "Content-Type must be application/json");
+      return false;
+    }
+
+    return true;
+  }
+
+  private getAuthTokenPath(): string {
+    return path.join(path.dirname(this.eventsDir), DAEMON_TOKEN_FILENAME);
+  }
+
+  private hasValidAuth(header: string | string[] | undefined): boolean {
+    const value = this.singleHeader(header);
+    if (!value?.startsWith("Bearer ")) return false;
+    const candidate = value.slice("Bearer ".length).trim();
+    const expected = Buffer.from(this.authToken);
+    const actual = Buffer.from(candidate);
+    return actual.length === expected.length && timingSafeEqual(actual, expected);
+  }
+
+  private hasJsonContentType(header: string | string[] | undefined): boolean {
+    const value = this.singleHeader(header);
+    return value?.split(";")[0]?.trim().toLowerCase() === "application/json";
+  }
+
+  private isAllowedHost(hostHeader: string | undefined): boolean {
+    if (!hostHeader) return false;
+    const hostname = this.parseHostname(hostHeader);
+    if (!hostname) return false;
+    return this.isAllowedHostname(hostname);
+  }
+
+  private isAllowedOrigin(originHeader: string | string[] | undefined): boolean {
+    const origin = this.singleHeader(originHeader);
+    if (!origin) return true;
+    try {
+      const parsed = new URL(origin);
+      if (parsed.protocol !== "http:") return false;
+      if (!this.isAllowedHostname(parsed.hostname)) return false;
+      const originPort = parsed.port ? Number.parseInt(parsed.port, 10) : 80;
+      return originPort === this.getPort();
+    } catch {
+      return false;
+    }
+  }
+
+  private isAllowedHostname(hostname: string): boolean {
+    const normalized = hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
+    return normalized === this.host.toLowerCase()
+      || normalized === "127.0.0.1"
+      || normalized === "localhost"
+      || normalized === "::1";
+  }
+
+  private parseHostname(hostHeader: string): string | null {
+    try {
+      return new URL(`http://${hostHeader}`).hostname;
+    } catch {
+      return null;
+    }
+  }
+
+  private singleHeader(header: string | string[] | undefined): string | undefined {
+    return Array.isArray(header) ? header[0] : header;
+  }
+}

--- a/src/runtime/event/server-command-handler.ts
+++ b/src/runtime/event/server-command-handler.ts
@@ -1,0 +1,218 @@
+import type * as http from "node:http";
+import { createEnvelope, type Envelope } from "../types/envelope.js";
+import type { ApprovalBroker } from "../approval-broker.js";
+import type { SlackChannelAdapter } from "../gateway/slack-channel-adapter.js";
+import { RuntimeControlOperationKindSchema } from "../store/index.js";
+import { readBody, writeJson, writeJsonError } from "./server-http.js";
+
+export class EventServerCommandHandler {
+  constructor(
+    private readonly broadcast: (eventType: string, data: unknown) => Promise<void>,
+    private readonly getCommandEnvelopeHook: () => ((envelope: Envelope) => void | Promise<void>) | undefined,
+    private readonly hasPendingApprovalRequest: (requestId: string) => boolean,
+    private readonly resolveApproval: (requestId: string, approved: boolean) => Promise<boolean>,
+    private readonly getApprovalBroker: () => ApprovalBroker | undefined,
+    private readonly getSlackChannelAdapter: () => SlackChannelAdapter | undefined
+  ) {}
+
+  async handleGoalAction(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    goalId: string,
+    action: string
+  ): Promise<void> {
+    if (action === "start") {
+      try {
+        await this.dispatchCommandEnvelope({
+          name: "goal_start",
+          goalId,
+          payload: { goalId },
+        });
+        await this.broadcast("goal_start_requested", { goalId });
+        writeJson(res, 200, { ok: true, goalId });
+      } catch (err) {
+        writeJsonError(res, 500, "Command accept failed", err);
+      }
+      return;
+    }
+
+    if (action === "stop") {
+      try {
+        await this.dispatchCommandEnvelope({
+          name: "goal_stop",
+          goalId,
+          payload: { goalId },
+        });
+        await this.broadcast("goal_stop_requested", { goalId });
+        writeJson(res, 200, { ok: true, goalId });
+      } catch (err) {
+        writeJsonError(res, 500, "Command accept failed", err);
+      }
+      return;
+    }
+
+    if (action === "approve") {
+      try {
+        const body = await readBody(req);
+        const { requestId, approved } = JSON.parse(body) as { requestId: string; approved: boolean };
+        if (!this.getApprovalBroker() && !this.hasPendingApprovalRequest(requestId)) {
+          writeJson(res, 404, { ok: false });
+          return;
+        }
+        await this.dispatchCommandEnvelope({
+          name: "approval_response",
+          goalId,
+          priority: "high",
+          dedupeKey: `approval_response:${requestId}`,
+          payload: { goalId, requestId, approved },
+      });
+        const resolved = await this.resolveApproval(requestId, approved);
+        writeJson(res, resolved ? 200 : 404, { ok: resolved });
+      } catch (err) {
+        if (err instanceof Error && err.message === "Payload too large") {
+          writeJsonError(res, 413, "Payload too large");
+          return;
+        }
+        writeJsonError(res, 400, "Invalid approval response", err);
+      }
+      return;
+    }
+
+    if (action === "chat") {
+      try {
+        const body = await readBody(req);
+        const { message } = JSON.parse(body) as { message: string };
+        await this.dispatchCommandEnvelope({
+          name: "chat_message",
+          goalId,
+          payload: { goalId, message },
+        });
+        await this.broadcast("chat_message_received", { goalId, message });
+        writeJson(res, 200, { ok: true });
+      } catch (err) {
+        if (err instanceof Error && err.message === "Payload too large") {
+          writeJsonError(res, 413, "Payload too large");
+          return;
+        }
+        writeJsonError(res, 400, "Invalid chat message", err);
+      }
+      return;
+    }
+
+    writeJsonError(res, 404, "Not found");
+  }
+
+  async handlePostDaemonRuntimeControl(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    try {
+      const body = await readBody(req);
+      const parsed = JSON.parse(body) as Record<string, unknown>;
+      const operationId = typeof parsed["operationId"] === "string" ? parsed["operationId"] : "";
+      const reason = typeof parsed["reason"] === "string" ? parsed["reason"] : "";
+      const kind = RuntimeControlOperationKindSchema.parse(parsed["kind"]);
+      if (!operationId) {
+        writeJson(res, 400, { ok: false, error: "operationId is required" });
+        return;
+      }
+
+      await this.dispatchCommandEnvelope({
+        name: "runtime_control",
+        priority: "critical",
+        dedupeKey: `runtime_control:${operationId}`,
+        payload: { operationId, kind, reason },
+      });
+      await this.broadcast("runtime_control_requested", { operationId, kind });
+      writeJson(res, 200, { ok: true, operationId });
+    } catch (err) {
+      if (err instanceof Error && err.message === "Payload too large") {
+        writeJson(res, 413, { ok: false, error: "Payload too large" });
+        return;
+      }
+      writeJson(res, 400, { ok: false, error: "Invalid runtime control request", details: String(err) });
+    }
+  }
+
+  async handlePostScheduleRunNow(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    rawScheduleId: string
+  ): Promise<void> {
+    const scheduleId = decodeURIComponent(rawScheduleId).trim();
+    if (!scheduleId) {
+      writeJson(res, 400, { ok: false, error: "scheduleId is required" });
+      return;
+    }
+
+    try {
+      const body = await readBody(req);
+      const parsed = body.trim() ? JSON.parse(body) as Record<string, unknown> : {};
+      const allowEscalation = parsed["allowEscalation"] === true;
+      await this.dispatchCommandEnvelope({
+        name: "schedule_run_now",
+        priority: "high",
+        payload: { scheduleId, allowEscalation },
+      });
+      await this.broadcast("schedule_run_requested", { scheduleId, allowEscalation });
+      writeJson(res, 200, { ok: true, scheduleId });
+    } catch (err) {
+      if (err instanceof Error && err.message === "Payload too large") {
+        writeJson(res, 413, { ok: false, error: "Payload too large" });
+        return;
+      }
+      writeJson(res, 400, { ok: false, error: "Invalid schedule run request", details: String(err) });
+    }
+  }
+
+  async handlePostSlackEvents(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    const slackChannelAdapter = this.getSlackChannelAdapter();
+    if (!slackChannelAdapter) {
+      writeJson(res, 404, { ok: false, error: "Slack adapter is not configured" });
+      return;
+    }
+
+    try {
+      const body = await readBody(req);
+      const headers = Object.fromEntries(
+        Object.entries(req.headers)
+          .filter((entry): entry is [string, string | string[]] => entry[1] !== undefined)
+          .map(([key, value]) => [key.toLowerCase(), Array.isArray(value) ? value.join(",") : value])
+      );
+      const response = slackChannelAdapter.handleRequest(body, headers);
+      res.writeHead(response.status, { "Content-Type": "application/json" });
+      res.end(response.body);
+    } catch (err) {
+      if (err instanceof Error && err.message === "Payload too large") {
+        writeJson(res, 413, { ok: false, error: "Payload too large" });
+        return;
+      }
+      writeJson(res, 400, { ok: false, error: "Invalid Slack event request", details: String(err) });
+    }
+  }
+
+  private async dispatchCommandEnvelope(input: {
+    name: string;
+    goalId?: string;
+    payload: Record<string, unknown>;
+    priority?: Envelope["priority"];
+    dedupeKey?: string;
+  }): Promise<void> {
+    const commandEnvelopeHook = this.getCommandEnvelopeHook();
+    if (!commandEnvelopeHook) return;
+    await commandEnvelopeHook(
+      createEnvelope({
+        type: "command",
+        name: input.name,
+        source: "http",
+        goal_id: input.goalId,
+        priority: input.priority,
+        dedupe_key: input.dedupeKey,
+        payload: input.payload,
+      })
+    );
+  }
+}

--- a/src/runtime/event/server-file-ingestion.ts
+++ b/src/runtime/event/server-file-ingestion.ts
@@ -1,0 +1,186 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { PulSeedEventSchema } from "../../base/types/drive.js";
+import type { Logger } from "../logger.js";
+
+export class EventServerFileIngestion {
+  private fileWatcher: fs.FSWatcher | null = null;
+  private readonly processingFiles = new Set<string>();
+  private readonly eventFileAttempts = new Map<string, number>();
+  private readonly eventFileRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private fileWatcherGeneration = 0;
+
+  constructor(
+    private readonly eventsDir: string,
+    private readonly logger: Logger | undefined,
+    private readonly eventFileMaxAttempts: number,
+    private readonly eventFileRetryDelayMs: number,
+    private readonly dispatchEvent: (eventData: Record<string, unknown>) => Promise<void>
+  ) {}
+
+  start(): void {
+    if (this.fileWatcher) return;
+
+    fs.mkdirSync(this.eventsDir, { recursive: true });
+    const generation = ++this.fileWatcherGeneration;
+    void this.rescanEventFiles(generation);
+
+    this.fileWatcher = fs.watch(this.eventsDir, (eventType, filename) => {
+      if (generation !== this.fileWatcherGeneration) return;
+      if ((eventType !== "rename" && eventType !== "change") || !filename) return;
+      this.queueEventFile(String(filename), 0, generation);
+    });
+  }
+
+  stop(): void {
+    this.fileWatcherGeneration += 1;
+    if (this.fileWatcher) {
+      this.fileWatcher.close();
+      this.fileWatcher = null;
+    }
+    for (const timer of this.eventFileRetryTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.eventFileRetryTimers.clear();
+  }
+
+  isWatching(): boolean {
+    return this.fileWatcher !== null;
+  }
+
+  private async processEventFile(filePath: string, filename: string): Promise<void> {
+    let stat;
+    try {
+      let lastErr: unknown;
+      for (let attempt = 0; attempt < 3; attempt++) {
+        try {
+          stat = await fsp.stat(filePath);
+          break;
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code !== "ENOENT") throw err;
+          lastErr = err;
+          await new Promise((r) => setTimeout(r, 20));
+        }
+      }
+      if (!stat) {
+        void lastErr;
+        return;
+      }
+    } catch {
+      return;
+    }
+    if (!stat.isFile()) return;
+
+    const content = await fsp.readFile(filePath, "utf-8");
+    const raw = JSON.parse(content) as unknown;
+    const event = PulSeedEventSchema.parse(raw);
+
+    await this.dispatchEvent(event as Record<string, unknown>);
+
+    const processedDir = path.join(this.eventsDir, "processed");
+    await fsp.mkdir(processedDir, { recursive: true });
+    await fsp.rename(filePath, path.join(processedDir, filename));
+    this.eventFileAttempts.delete(filename);
+  }
+
+  private async rescanEventFiles(generation: number): Promise<void> {
+    let entries: string[];
+    try {
+      entries = await fsp.readdir(this.eventsDir);
+    } catch {
+      return;
+    }
+    if (generation !== this.fileWatcherGeneration) return;
+    for (const entry of entries) {
+      this.queueEventFile(entry, 0, generation);
+    }
+  }
+
+  private queueEventFile(filename: string, delayMs = 0, generation = this.fileWatcherGeneration): void {
+    if (generation !== this.fileWatcherGeneration) return;
+    if (!this.shouldProcessEventFilename(filename)) return;
+    if (this.eventFileRetryTimers.has(filename)) return;
+    if (delayMs <= 0 && this.processingFiles.has(filename)) return;
+
+    const run = (): void => {
+      if (generation !== this.fileWatcherGeneration) {
+        this.eventFileRetryTimers.delete(filename);
+        return;
+      }
+      this.eventFileRetryTimers.delete(filename);
+      if (this.processingFiles.has(filename)) return;
+      this.processingFiles.add(filename);
+      const filePath = path.join(this.eventsDir, filename);
+      void (async () => {
+        try {
+          await this.processEventFile(filePath, filename);
+        } catch (err) {
+          await this.handleEventFileFailure(filePath, filename, err);
+        } finally {
+          this.processingFiles.delete(filename);
+        }
+      })();
+    };
+
+    if (delayMs <= 0) {
+      run();
+      return;
+    }
+
+    const timer = setTimeout(run, delayMs);
+    timer.unref?.();
+    this.eventFileRetryTimers.set(filename, timer);
+  }
+
+  private shouldProcessEventFilename(filename: string): boolean {
+    if (path.basename(filename) !== filename) return false;
+    if (!filename.endsWith(".json") || filename.endsWith(".tmp")) return false;
+    return filename !== "daemon-token.json";
+  }
+
+  private async handleEventFileFailure(
+    filePath: string,
+    filename: string,
+    err: unknown
+  ): Promise<void> {
+    const attempt = (this.eventFileAttempts.get(filename) ?? 0) + 1;
+    this.eventFileAttempts.set(filename, attempt);
+    const message = err instanceof Error ? err.message : String(err);
+
+    if (attempt < this.eventFileMaxAttempts) {
+      this.logger?.warn(
+        `EventServer: failed to process event file "${filename}", retrying (${attempt}/${this.eventFileMaxAttempts}): ${message}`
+      );
+      this.queueEventFile(filename, this.eventFileRetryDelayMs);
+      return;
+    }
+
+    this.logger?.error(
+      `EventServer: failed to process event file "${filename}" after ${attempt} attempts; moving to failed/: ${message}`
+    );
+    this.eventFileAttempts.delete(filename);
+    await this.moveFailedEventFile(filePath, filename);
+  }
+
+  private async moveFailedEventFile(filePath: string, filename: string): Promise<void> {
+    try {
+      const failedDir = path.join(this.eventsDir, "failed");
+      await fsp.mkdir(failedDir, { recursive: true });
+      let dstPath = path.join(failedDir, filename);
+      try {
+        await fsp.access(dstPath);
+        const parsed = path.parse(filename);
+        dstPath = path.join(failedDir, `${parsed.name}-${Date.now()}${parsed.ext}`);
+      } catch {
+        // Destination is free.
+      }
+      await fsp.rename(filePath, dstPath);
+    } catch (moveErr) {
+      this.logger?.error(
+        `EventServer: failed to quarantine event file "${filename}": ${String(moveErr)}`
+      );
+    }
+  }
+}

--- a/src/runtime/event/server-http.ts
+++ b/src/runtime/event/server-http.ts
@@ -1,0 +1,43 @@
+import type * as http from "node:http";
+
+const MAX_BODY_SIZE = 1_048_576;
+
+export function writeJson(
+  res: http.ServerResponse,
+  status: number,
+  body: unknown
+): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+export function writeJsonError(
+  res: http.ServerResponse,
+  status: number,
+  error: string,
+  details?: unknown
+): void {
+  writeJson(res, status, details === undefined ? { error } : { error, details: String(details) });
+}
+
+export function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let body = "";
+    let bytes = 0;
+    req.on("data", (chunk: Buffer) => {
+      bytes += chunk.length;
+      if (bytes > MAX_BODY_SIZE) {
+        reject(new Error("Payload too large"));
+        req.destroy();
+        return;
+      }
+      body += chunk;
+    });
+    req.on("end", () => resolve(body));
+    req.on("error", reject);
+  });
+}
+
+export function readJsonBody<T>(req: http.IncomingMessage): Promise<T> {
+  return readBody(req).then((body) => JSON.parse(body) as T);
+}

--- a/src/runtime/event/server-router.ts
+++ b/src/runtime/event/server-router.ts
@@ -1,0 +1,120 @@
+import type * as http from "node:http";
+import { writeJson, writeJsonError } from "./server-http.js";
+
+interface EventServerRouterDeps {
+  slackEventsPath: string;
+  isSlackConfigured: () => boolean;
+  authorizeRequest: (req: http.IncomingMessage, res: http.ServerResponse) => boolean;
+  handlePostSlackEvents: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>;
+  handlePostEvents: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>;
+  handlePostTriggers: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>;
+  handleGetGoals: (res: http.ServerResponse) => Promise<void>;
+  handleGetSnapshot: (res: http.ServerResponse) => Promise<void>;
+  handleGetGoalById: (res: http.ServerResponse, goalId: string) => Promise<void>;
+  handleStream: (req: http.IncomingMessage, res: http.ServerResponse, requestUrl: URL) => Promise<void>;
+  readDaemonStateRaw: () => Promise<string | null>;
+  handlePostDaemonRuntimeControl: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>;
+  handlePostScheduleRunNow: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    scheduleId: string
+  ) => Promise<void>;
+  handleGoalAction: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    goalId: string,
+    action: string
+  ) => Promise<void>;
+}
+
+export class EventServerRouter {
+  constructor(private readonly deps: EventServerRouterDeps) {}
+
+  setSlackEventsPath(slackEventsPath: string): void {
+    this.deps.slackEventsPath = slackEventsPath;
+  }
+
+  route(req: http.IncomingMessage, res: http.ServerResponse): void {
+    const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+    const urlPath = requestUrl.pathname;
+
+    if (req.method === "GET" && urlPath === "/health") {
+      writeJson(res, 200, { status: "ok", uptime: process.uptime() });
+      return;
+    }
+
+    if (req.method === "POST" && this.deps.isSlackConfigured() && urlPath === this.deps.slackEventsPath) {
+      void this.deps.handlePostSlackEvents(req, res);
+      return;
+    }
+
+    if (!this.deps.authorizeRequest(req, res)) {
+      return;
+    }
+
+    if (req.method === "POST" && urlPath === "/events") {
+      void this.deps.handlePostEvents(req, res);
+      return;
+    }
+
+    if (req.method === "POST" && urlPath === "/triggers") {
+      void this.deps.handlePostTriggers(req, res);
+      return;
+    }
+
+    if (req.method === "GET" && urlPath === "/goals") {
+      void this.deps.handleGetGoals(res);
+      return;
+    }
+
+    if (req.method === "GET" && urlPath === "/snapshot") {
+      void this.deps.handleGetSnapshot(res);
+      return;
+    }
+
+    const goalsMatch = /^\/goals\/([^/]+)$/.exec(urlPath);
+    if (req.method === "GET" && goalsMatch) {
+      void this.deps.handleGetGoalById(res, goalsMatch[1]!);
+      return;
+    }
+
+    if (req.method === "GET" && urlPath === "/stream") {
+      void this.deps.handleStream(req, res, requestUrl);
+      return;
+    }
+
+    if (req.method === "GET" && urlPath === "/daemon/status") {
+      void this.handleGetDaemonStatus(res);
+      return;
+    }
+
+    if (req.method === "POST" && urlPath === "/daemon/runtime-control") {
+      void this.deps.handlePostDaemonRuntimeControl(req, res);
+      return;
+    }
+
+    const scheduleRunMatch = /^\/schedules\/([^/]+)\/run$/.exec(urlPath);
+    if (req.method === "POST" && scheduleRunMatch) {
+      void this.deps.handlePostScheduleRunNow(req, res, scheduleRunMatch[1]!);
+      return;
+    }
+
+    const goalActionMatch = /^\/goals\/([^/]+)\/([^/]+)$/.exec(urlPath);
+    if (req.method === "POST" && goalActionMatch) {
+      void this.deps.handleGoalAction(req, res, goalActionMatch[1]!, goalActionMatch[2]!);
+      return;
+    }
+
+    writeJsonError(res, 404, "Not found");
+  }
+
+  private async handleGetDaemonStatus(res: http.ServerResponse): Promise<void> {
+    const raw = await this.deps.readDaemonStateRaw();
+    if (raw !== null) {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(raw);
+      return;
+    }
+    writeJsonError(res, 404, "daemon state not found");
+  }
+}

--- a/src/runtime/event/server-trigger-handler.ts
+++ b/src/runtime/event/server-trigger-handler.ts
@@ -1,0 +1,138 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import type * as http from "node:http";
+import { PulSeedEventSchema } from "../../base/types/drive.js";
+import { TriggerEventSchema, TriggerMappingsConfigSchema } from "../../base/types/trigger.js";
+import type { TriggerMappingsConfig } from "../../base/types/trigger.js";
+import type { Logger } from "../logger.js";
+import type { TriggerMapper } from "../trigger-mapper.js";
+import { readJsonBody, writeJsonError, writeJson } from "./server-http.js";
+
+type TriggerInput = { source: string; event_type: string; data: Record<string, unknown>; goal_id?: string };
+
+export class EventServerTriggerHandler {
+  private triggerMappingsCache: TriggerMappingsConfig | null = null;
+
+  constructor(
+    private readonly eventsDir: string,
+    private readonly logger: Logger | undefined,
+    private readonly triggerMapper: TriggerMapper | undefined,
+    private readonly dispatchEvent: (eventData: Record<string, unknown>) => Promise<void>
+  ) {}
+
+  invalidateCache(): void {
+    this.triggerMappingsCache = null;
+  }
+
+  async handlePostTriggers(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    try {
+      const data = await readJsonBody<unknown>(req);
+      const trigger = TriggerEventSchema.parse(data);
+
+      let action: string;
+      let goalId: string | undefined | null;
+
+      if (this.triggerMapper) {
+        const resolved = await this.triggerMapper.resolve(trigger, []);
+        if (resolved.action === "none") {
+          writeJson(res, 200, { status: "no_mapping" });
+          return;
+        }
+        action = resolved.action;
+        goalId = resolved.goal_id ?? undefined;
+      } else {
+        const mappingsConfig = await this.loadTriggerMappings();
+        const mapping = mappingsConfig.mappings.find(
+          (m) => m.source === trigger.source && m.event_type === trigger.event_type
+        );
+
+        goalId = mapping?.goal_id ?? trigger.goal_id;
+
+        if (!mapping) {
+          if (!trigger.goal_id) {
+            writeJson(res, 200, { status: "no_mapping" });
+            return;
+          }
+          action = "observe";
+        } else {
+          action = mapping.action;
+        }
+      }
+
+      await this.executeTriggerAction(action, trigger, goalId ?? undefined);
+      writeJson(res, 200, { status: "ok", action, goal_id: goalId ?? null });
+    } catch (err) {
+      if (err instanceof Error && err.message === "Payload too large") {
+        writeJsonError(res, 413, "Payload too large");
+        return;
+      }
+      writeJsonError(res, 400, "Invalid trigger", err);
+    }
+  }
+
+  private async executeTriggerAction(
+    action: string,
+    trigger: TriggerInput,
+    goalId?: string
+  ): Promise<void> {
+    if (action === "observe") {
+      const event = PulSeedEventSchema.parse({
+        type: "external",
+        source: trigger.source,
+        timestamp: new Date().toISOString(),
+        data: { ...trigger.data, event_type: trigger.event_type, goal_id: goalId },
+      });
+      try {
+        await this.dispatchEvent(event as Record<string, unknown>);
+      } catch (err) {
+        this.logger?.error(`EventServer: trigger observe failed: ${String(err)}`);
+        throw err;
+      }
+      return;
+    }
+
+    if (action === "create_task") {
+      const filename = `trigger_${Date.now()}_${Math.random().toString(36).slice(2)}.json`;
+      const filePath = path.join(this.eventsDir, filename);
+      const payload = {
+        type: "external",
+        source: trigger.source,
+        timestamp: new Date().toISOString(),
+        data: { ...trigger.data, event_type: trigger.event_type, action: "create_task", goal_id: goalId },
+      };
+      await fsp.writeFile(filePath, JSON.stringify(payload), "utf-8");
+      return;
+    }
+
+    if (action === "notify") {
+      this.logger?.warn(
+        `EventServer: trigger notify — source=${trigger.source} event_type=${trigger.event_type} goal_id=${goalId ?? "none"}`
+      );
+      return;
+    }
+
+    if (action === "wake") {
+      this.logger?.warn(
+        `EventServer: trigger wake — source=${trigger.source} event_type=${trigger.event_type}`
+      );
+    }
+  }
+
+  private async loadTriggerMappings(): Promise<TriggerMappingsConfig> {
+    if (this.triggerMappingsCache !== null) return this.triggerMappingsCache;
+
+    const mappingsPath = path.join(this.eventsDir, "..", "trigger-mappings.json");
+    try {
+      const content = await fsp.readFile(mappingsPath, "utf-8");
+      const raw = JSON.parse(content) as unknown;
+      this.triggerMappingsCache = TriggerMappingsConfigSchema.parse(raw);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT") {
+        this.logger?.warn(`EventServer: failed to load trigger-mappings.json: ${String(err)}`);
+      }
+      this.triggerMappingsCache = { mappings: [] };
+    }
+    return this.triggerMappingsCache;
+  }
+}

--- a/src/runtime/event/server-types.ts
+++ b/src/runtime/event/server-types.ts
@@ -1,0 +1,28 @@
+import type { StateManager } from "../../base/state/state-manager.js";
+import type { TriggerMapper } from "../trigger-mapper.js";
+import type { ApprovalBroker, ApprovalRequiredEvent } from "../approval-broker.js";
+import type { OutboxStore } from "../store/index.js";
+
+export interface EventServerConfig {
+  host?: string;
+  port?: number;
+  eventsDir?: string;
+  stateManager?: StateManager;
+  triggerMapper?: TriggerMapper;
+  approvalBroker?: ApprovalBroker;
+  outboxStore?: OutboxStore;
+  eventFileMaxAttempts?: number;
+  eventFileRetryDelayMs?: number;
+}
+
+export interface EventServerSnapshot {
+  daemon: Record<string, unknown> | null;
+  goals: Array<{ id: string; title: string; status: string; loop_status: string }>;
+  approvals: ApprovalRequiredEvent[];
+  active_workers: Array<Record<string, unknown>>;
+  last_outbox_seq: number;
+}
+
+export type ActiveWorkersProvider = () =>
+  | Array<Record<string, unknown>>
+  | Promise<Array<Record<string, unknown>>>;

--- a/src/runtime/event/server.ts
+++ b/src/runtime/event/server.ts
@@ -1,110 +1,120 @@
-import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
-import * as path from "node:path";
 import * as http from "node:http";
-import { randomBytes, timingSafeEqual } from "node:crypto";
 import type { DriveSystem } from "../../platform/drive/drive-system.js";
 import { PulSeedEventSchema } from "../../base/types/drive.js";
-import { TriggerEventSchema, TriggerMappingsConfigSchema } from "../../base/types/trigger.js";
-import type { TriggerMappingsConfig } from "../../base/types/trigger.js";
 import { getEventsDir } from "../../base/utils/paths.js";
 import type { Logger } from "../logger.js";
-import type { StateManager } from "../../base/state/state-manager.js";
-import type { TriggerMapper } from "../trigger-mapper.js";
 import { DEFAULT_PORT } from "../port-utils.js";
-import { createEnvelope, type Envelope } from "../types/envelope.js";
-import type { ApprovalBroker, ApprovalRequiredEvent } from "../approval-broker.js";
-import type { OutboxStore, OutboxRecord } from "../store/index.js";
-import { RuntimeControlOperationKindSchema } from "../store/index.js";
+import type { ApprovalBroker } from "../approval-broker.js";
+import type { OutboxStore } from "../store/index.js";
+import type { Envelope } from "../types/envelope.js";
+import type { SlackChannelAdapter } from "../gateway/slack-channel-adapter.js";
+import { EventServerAuth } from "./server-auth.js";
+import { EventServerCommandHandler } from "./server-command-handler.js";
+import { EventServerFileIngestion } from "./server-file-ingestion.js";
+import { readJsonBody, writeJson, writeJsonError } from "./server-http.js";
+import { EventServerRouter } from "./server-router.js";
 import { EventServerSnapshotReader } from "./server-snapshot-reader.js";
 import { EventServerSseManager } from "./server-sse.js";
-import type { SlackChannelAdapter } from "../gateway/slack-channel-adapter.js";
+import { EventServerTriggerHandler } from "./server-trigger-handler.js";
+import type {
+  ActiveWorkersProvider,
+  EventServerConfig,
+  EventServerSnapshot,
+} from "./server-types.js";
 
-export interface EventServerConfig {
-  host?: string; // default: "127.0.0.1" (localhost only!)
-  port?: number; // default: 41700
-  eventsDir?: string; // default: ~/.pulseed/events/
-  stateManager?: StateManager;
-  triggerMapper?: TriggerMapper;
-  approvalBroker?: ApprovalBroker;
-  outboxStore?: OutboxStore;
-  eventFileMaxAttempts?: number;
-  eventFileRetryDelayMs?: number;
-}
-
-export interface EventServerSnapshot {
-  daemon: Record<string, unknown> | null;
-  goals: Array<{ id: string; title: string; status: string; loop_status: string }>;
-  approvals: ApprovalRequiredEvent[];
-  active_workers: Array<Record<string, unknown>>;
-  last_outbox_seq: number;
-}
-
-type ActiveWorkersProvider = () =>
-  | Array<Record<string, unknown>>
-  | Promise<Array<Record<string, unknown>>>;
-
-const DAEMON_TOKEN_FILENAME = "daemon-token.json";
 const DEFAULT_EVENT_FILE_MAX_ATTEMPTS = 3;
 const DEFAULT_EVENT_FILE_RETRY_DELAY_MS = 250;
 
+export type { EventServerConfig, EventServerSnapshot } from "./server-types.js";
+
 export class EventServer {
   private server: http.Server | null = null;
-  private driveSystem: DriveSystem;
-  private host: string;
+  private readonly host: string;
   private port: number;
-  private eventsDir: string;
-  private fileWatcher: fs.FSWatcher | null = null;
-  private readonly processingFiles = new Set<string>();
+  private readonly eventsDir: string;
   private readonly logger?: Logger;
-  private readonly stateManager?: StateManager;
-  private readonly triggerMapper?: TriggerMapper;
-  private readonly snapshotReader: EventServerSnapshotReader;
-  private readonly sseManager: EventServerSseManager;
-  private triggerMappingsCache: TriggerMappingsConfig | null = null;
-  private approvalQueue: Map<string, { resolve: (approved: boolean) => void; timer: ReturnType<typeof setTimeout> }> = new Map();
   private approvalBroker?: ApprovalBroker;
   private outboxStore?: OutboxStore;
-  private readonly eventFileMaxAttempts: number;
-  private readonly eventFileRetryDelayMs: number;
-  private readonly eventFileAttempts = new Map<string, number>();
-  private readonly eventFileRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  private fileWatcherGeneration = 0;
-  private readonly authToken: string;
+  private readonly snapshotReader: EventServerSnapshotReader;
+  private readonly sseManager: EventServerSseManager;
+  private readonly auth: EventServerAuth;
+  private readonly fileIngestion: EventServerFileIngestion;
+  private readonly triggerHandler: EventServerTriggerHandler;
+  private readonly commandHandler: EventServerCommandHandler;
+  private readonly router: EventServerRouter;
+  private readonly approvalQueue = new Map<
+    string,
+    { resolve: (approved: boolean) => void; timer: ReturnType<typeof setTimeout> }
+  >();
   private envelopeHook?: (eventData: Record<string, unknown>) => void | Promise<void>;
   private commandEnvelopeHook?: (envelope: Envelope) => void | Promise<void>;
   private activeWorkersProvider?: ActiveWorkersProvider;
   private slackChannelAdapter?: SlackChannelAdapter;
   private slackEventsPath = "/slack/events";
 
-  constructor(driveSystem: DriveSystem, config?: EventServerConfig, logger?: Logger) {
-    this.driveSystem = driveSystem;
+  constructor(
+    private readonly driveSystem: DriveSystem,
+    private readonly config?: EventServerConfig,
+    logger?: Logger,
+  ) {
     this.host = config?.host ?? "127.0.0.1";
     this.port = config?.port ?? DEFAULT_PORT;
-    // Default events directory: ~/.pulseed/events/
     this.eventsDir = config?.eventsDir ?? getEventsDir();
     this.logger = logger;
-    this.stateManager = config?.stateManager;
-    this.triggerMapper = config?.triggerMapper;
     this.approvalBroker = config?.approvalBroker;
     this.outboxStore = config?.outboxStore;
-    this.eventFileMaxAttempts = Math.max(1, config?.eventFileMaxAttempts ?? DEFAULT_EVENT_FILE_MAX_ATTEMPTS);
-    this.eventFileRetryDelayMs = Math.max(0, config?.eventFileRetryDelayMs ?? DEFAULT_EVENT_FILE_RETRY_DELAY_MS);
-    this.authToken = randomBytes(32).toString("base64url");
     this.snapshotReader = new EventServerSnapshotReader(this.eventsDir);
     this.sseManager = new EventServerSseManager(this.logger, this.approvalBroker, this.outboxStore);
+    this.auth = new EventServerAuth(this.host, this.eventsDir, () => this.port, this.logger);
+    this.fileIngestion = new EventServerFileIngestion(
+      this.eventsDir,
+      this.logger,
+      Math.max(1, config?.eventFileMaxAttempts ?? DEFAULT_EVENT_FILE_MAX_ATTEMPTS),
+      Math.max(0, config?.eventFileRetryDelayMs ?? DEFAULT_EVENT_FILE_RETRY_DELAY_MS),
+      async (eventData) => this.dispatchEvent(eventData),
+    );
+    this.triggerHandler = new EventServerTriggerHandler(
+      this.eventsDir,
+      this.logger,
+      config?.triggerMapper,
+      async (eventData) => this.dispatchEvent(eventData),
+    );
+    this.commandHandler = new EventServerCommandHandler(
+      async (eventType, data) => this.broadcast(eventType, data),
+      () => this.commandEnvelopeHook,
+      (requestId) => this.approvalQueue.has(requestId),
+      async (requestId, approved) => this.resolveApproval(requestId, approved),
+      () => this.approvalBroker,
+      () => this.slackChannelAdapter,
+    );
+    this.router = new EventServerRouter({
+      slackEventsPath: this.slackEventsPath,
+      isSlackConfigured: () => this.slackChannelAdapter !== undefined,
+      authorizeRequest: (req, res) => this.auth.authorizeRequest(req, res),
+      handlePostSlackEvents: async (req, res) => this.commandHandler.handlePostSlackEvents(req, res),
+      handlePostEvents: async (req, res) => this.handlePostEvents(req, res),
+      handlePostTriggers: async (req, res) => this.triggerHandler.handlePostTriggers(req, res),
+      handleGetGoals: async (res) => this.handleGetGoals(res),
+      handleGetSnapshot: async (res) => this.handleGetSnapshot(res),
+      handleGetGoalById: async (res, goalId) => this.handleGetGoalById(res, goalId),
+      handleStream: async (req, res, requestUrl) => this.sseManager.handleStream(req, res, requestUrl),
+      readDaemonStateRaw: async () => this.snapshotReader.readDaemonStateRaw(),
+      handlePostDaemonRuntimeControl: async (req, res) => this.commandHandler.handlePostDaemonRuntimeControl(req, res),
+      handlePostScheduleRunNow: async (req, res, scheduleId) =>
+        this.commandHandler.handlePostScheduleRunNow(req, res, scheduleId),
+      handleGoalAction: async (req, res, goalId, action) =>
+        this.commandHandler.handleGoalAction(req, res, goalId, action),
+    });
   }
 
-  /** Start HTTP server. Port 0 keeps OS-assigned behavior for tests. */
   async start(): Promise<void> {
-    if (this.server) {
-      return; // Already running
-    }
+    if (this.server) return;
     await fsp.mkdir(this.eventsDir, { recursive: true });
     await this.approvalBroker?.start();
     const startPort = this.port;
     return new Promise((resolve, reject) => {
-      this.server = http.createServer((req, res) => this.handleRequest(req, res));
+      this.server = http.createServer((req, res) => this.router.route(req, res));
       const server = this.server;
       server.listen(startPort, this.host, () => {
         void (async () => {
@@ -124,216 +134,34 @@ export class EventServer {
     });
   }
 
-  /** Stop HTTP server */
   async stop(): Promise<void> {
     this.stopFileWatcher();
     await this.approvalBroker?.stop();
     this.sseManager.closeAllClients();
     return new Promise((resolve) => {
       if (!this.server) {
-        void this.removeAuthTokenFile().finally(() => resolve());
+        void this.auth.removeAuthTokenFile().finally(() => resolve());
         return;
       }
       this.server.close(() => {
         this.server = null;
-        void this.removeAuthTokenFile().finally(() => resolve());
+        void this.auth.removeAuthTokenFile().finally(() => resolve());
       });
     });
   }
 
-  /**
-   * Start watching the events directory for new `.json` files.
-   * When a file appears:
-   *   1. Read and parse it
-   *   2. Validate via PulSeedEventSchema
-   *   3. Dispatch to DriveSystem (writeEvent)
-   *   4. Move to events/processed/ subdirectory
-   *   5. Log errors for malformed files but don't crash
-   *
-   * Creates the events directory if it doesn't exist.
-   */
   startFileWatcher(): void {
-    if (this.fileWatcher) return; // already watching
-
-    fs.mkdirSync(this.eventsDir, { recursive: true });
-    const generation = ++this.fileWatcherGeneration;
-    void this.rescanEventFiles(generation);
-
-    this.fileWatcher = fs.watch(this.eventsDir, (eventType, filename) => {
-      if (generation !== this.fileWatcherGeneration) return;
-      if ((eventType !== "rename" && eventType !== "change") || !filename) return;
-      this.queueEventFile(String(filename), 0, generation);
-    });
+    this.fileIngestion.start();
   }
 
-  /** Stop the file watcher and clean up the handle. */
   stopFileWatcher(): void {
-    this.fileWatcherGeneration += 1;
-    if (this.fileWatcher) {
-      this.fileWatcher.close();
-      this.fileWatcher = null;
-    }
-    for (const timer of this.eventFileRetryTimers.values()) {
-      clearTimeout(timer);
-    }
-    this.eventFileRetryTimers.clear();
+    this.fileIngestion.stop();
   }
 
-  /**
-   * Read, validate, dispatch, and move a single event file.
-   * Errors are logged but never propagated (caller must not crash).
-   */
-  private async processEventFile(filePath: string, filename: string): Promise<void> {
-    let stat;
-    try {
-      // Retry on ENOENT: on macOS, fs.watch fires 'rename' before the file
-      // is visible to fsp.stat, so retry up to 3 times with 20ms delay.
-      let lastErr: unknown;
-      for (let attempt = 0; attempt < 3; attempt++) {
-        try {
-          stat = await fsp.stat(filePath);
-          break;
-        } catch (err) {
-          const code = (err as NodeJS.ErrnoException).code;
-          if (code !== "ENOENT") throw err;
-          lastErr = err;
-          await new Promise((r) => setTimeout(r, 20));
-        }
-      }
-      if (!stat) {
-        // File never appeared — already removed
-        void lastErr; // suppress unused warning
-        return;
-      }
-    } catch {
-      return; // non-ENOENT error — file already removed or inaccessible
-    }
-    if (!stat.isFile()) return;
-
-    const content = await fsp.readFile(filePath, "utf-8");
-    const raw = JSON.parse(content) as unknown;
-    const event = PulSeedEventSchema.parse(raw);
-
-    // Dispatch through Gateway Envelope path or direct
-    if (this.envelopeHook) {
-      await this.envelopeHook(event as unknown as Record<string, unknown>);
-    } else {
-      await this.driveSystem.writeEvent(event);
-    }
-
-    // Move to processed/
-    const processedDir = path.join(this.eventsDir, "processed");
-    await fsp.mkdir(processedDir, { recursive: true });
-    const dstPath = path.join(processedDir, filename);
-    await fsp.rename(filePath, dstPath);
-    this.eventFileAttempts.delete(filename);
-  }
-
-  private async rescanEventFiles(generation: number): Promise<void> {
-    let entries: string[];
-    try {
-      entries = await fsp.readdir(this.eventsDir);
-    } catch {
-      return;
-    }
-    if (generation !== this.fileWatcherGeneration) return;
-    for (const entry of entries) {
-      this.queueEventFile(entry, 0, generation);
-    }
-  }
-
-  private queueEventFile(filename: string, delayMs = 0, generation = this.fileWatcherGeneration): void {
-    if (generation !== this.fileWatcherGeneration) return;
-    if (!this.shouldProcessEventFilename(filename)) return;
-    if (this.eventFileRetryTimers.has(filename)) return;
-    if (delayMs <= 0 && this.processingFiles.has(filename)) return;
-
-    const run = (): void => {
-      if (generation !== this.fileWatcherGeneration) {
-        this.eventFileRetryTimers.delete(filename);
-        return;
-      }
-      this.eventFileRetryTimers.delete(filename);
-      if (this.processingFiles.has(filename)) return;
-      this.processingFiles.add(filename);
-      const filePath = path.join(this.eventsDir, filename);
-      void (async () => {
-        try {
-          await this.processEventFile(filePath, filename);
-        } catch (err) {
-          await this.handleEventFileFailure(filePath, filename, err);
-        } finally {
-          this.processingFiles.delete(filename);
-        }
-      })();
-    };
-
-    if (delayMs <= 0) {
-      run();
-      return;
-    }
-
-    const timer = setTimeout(run, delayMs);
-    timer.unref?.();
-    this.eventFileRetryTimers.set(filename, timer);
-  }
-
-  private shouldProcessEventFilename(filename: string): boolean {
-    if (path.basename(filename) !== filename) return false;
-    if (!filename.endsWith(".json") || filename.endsWith(".tmp")) return false;
-    return filename !== "daemon-token.json";
-  }
-
-  private async handleEventFileFailure(
-    filePath: string,
-    filename: string,
-    err: unknown
-  ): Promise<void> {
-    const attempt = (this.eventFileAttempts.get(filename) ?? 0) + 1;
-    this.eventFileAttempts.set(filename, attempt);
-    const message = err instanceof Error ? err.message : String(err);
-
-    if (attempt < this.eventFileMaxAttempts) {
-      this.logger?.warn(
-        `EventServer: failed to process event file "${filename}", retrying (${attempt}/${this.eventFileMaxAttempts}): ${message}`
-      );
-      this.queueEventFile(filename, this.eventFileRetryDelayMs);
-      return;
-    }
-
-    this.logger?.error(
-      `EventServer: failed to process event file "${filename}" after ${attempt} attempts; moving to failed/: ${message}`
-    );
-    this.eventFileAttempts.delete(filename);
-    await this.moveFailedEventFile(filePath, filename);
-  }
-
-  private async moveFailedEventFile(filePath: string, filename: string): Promise<void> {
-    try {
-      const failedDir = path.join(this.eventsDir, "failed");
-      await fsp.mkdir(failedDir, { recursive: true });
-      let dstPath = path.join(failedDir, filename);
-      try {
-        await fsp.access(dstPath);
-        const parsed = path.parse(filename);
-        dstPath = path.join(failedDir, `${parsed.name}-${Date.now()}${parsed.ext}`);
-      } catch {
-        // Destination is free.
-      }
-      await fsp.rename(filePath, dstPath);
-    } catch (moveErr) {
-      this.logger?.error(
-        `EventServer: failed to quarantine event file "${filename}": ${String(moveErr)}`
-      );
-    }
-  }
-
-  /** Broadcast an SSE event to all connected clients */
   async broadcast(eventType: string, data: unknown): Promise<void> {
     await this.sseManager.broadcast(eventType, data);
   }
 
-  /** Request human approval and wait for response (5 min timeout) */
   async requestApproval(goalId: string, task: { id: string; description: string; action: string }): Promise<boolean> {
     if (this.approvalBroker) {
       return this.approvalBroker.requestApproval(goalId, task);
@@ -350,7 +178,6 @@ export class EventServer {
     });
   }
 
-  /** Resolve a pending approval request */
   async resolveApproval(requestId: string, approved: boolean): Promise<boolean> {
     if (this.approvalBroker) {
       return this.approvalBroker.resolveApproval(requestId, approved, "http");
@@ -364,13 +191,10 @@ export class EventServer {
     return true;
   }
 
-  /** Handle incoming HTTP request */
-  /** Set a hook to intercept incoming events as Envelopes (used by HttpChannelAdapter). */
   setEnvelopeHook(hook: (eventData: Record<string, unknown>) => void | Promise<void>): void {
     this.envelopeHook = hook;
   }
 
-  /** Set a hook to intercept command-style HTTP actions as Envelopes. */
   setCommandEnvelopeHook(hook: (envelope: Envelope) => void | Promise<void>): void {
     this.commandEnvelopeHook = hook;
   }
@@ -392,338 +216,54 @@ export class EventServer {
   setSlackChannelAdapter(adapter: SlackChannelAdapter, eventsPath = "/slack/events"): void {
     this.slackChannelAdapter = adapter;
     this.slackEventsPath = eventsPath.startsWith("/") ? eventsPath : `/${eventsPath}`;
+    this.router.setSlackEventsPath(this.slackEventsPath);
   }
 
-  private handleRequest(req: http.IncomingMessage, res: http.ServerResponse): void {
-    const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
-    const urlPath = requestUrl.pathname;
-
-    // GET /health
-    if (req.method === "GET" && urlPath === "/health") {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "ok", uptime: process.uptime() }));
-      return;
-    }
-
-    if (req.method === "POST" && this.slackChannelAdapter && urlPath === this.slackEventsPath) {
-      void this.handlePostSlackEvents(req, res);
-      return;
-    }
-
-    if (!this.authorizeRequest(req, res)) {
-      return;
-    }
-
-    // POST /events
-    if (req.method === "POST" && urlPath === "/events") {
-      this.handlePostEvents(req, res);
-      return;
-    }
-
-    // POST /triggers
-    if (req.method === "POST" && urlPath === "/triggers") {
-      this.handlePostTriggers(req, res);
-      return;
-    }
-
-    // GET /goals
-    if (req.method === "GET" && urlPath === "/goals") {
-      void this.handleGetGoals(res);
-      return;
-    }
-
-    if (req.method === "GET" && urlPath === "/snapshot") {
-      void this.handleGetSnapshot(res);
-      return;
-    }
-
-    // GET /goals/:id
-    const goalsMatch = /^\/goals\/([^/]+)$/.exec(urlPath);
-    if (req.method === "GET" && goalsMatch) {
-      void this.handleGetGoalById(res, goalsMatch[1]!);
-      return;
-    }
-
-    // GET /stream — SSE event stream
-    if (req.method === "GET" && urlPath === "/stream") {
-      void this.handleStream(req, res, requestUrl);
-      return;
-    }
-
-    // GET /daemon/status
-    if (req.method === "GET" && urlPath === "/daemon/status") {
-      void (async () => {
-        const raw = await this.snapshotReader.readDaemonStateRaw();
-        if (raw !== null) {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(raw);
-        } else {
-          res.writeHead(404, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "daemon state not found" }));
-        }
-      })();
-      return;
-    }
-
-    if (req.method === "POST" && urlPath === "/daemon/runtime-control") {
-      void this.handlePostDaemonRuntimeControl(req, res);
-      return;
-    }
-
-    const scheduleRunMatch = /^\/schedules\/([^/]+)\/run$/.exec(urlPath);
-    if (req.method === "POST" && scheduleRunMatch) {
-      void this.handlePostScheduleRunNow(req, res, scheduleRunMatch[1]!);
-      return;
-    }
-
-    // POST /goals/:id/start|stop|approve|chat
-    const goalActionMatch = /^\/goals\/([^/]+)\/([^/]+)$/.exec(urlPath);
-    if (req.method === "POST" && goalActionMatch) {
-      const goalId = goalActionMatch[1]!;
-      const action = goalActionMatch[2]!;
-      void (async () => {
-        if (action === "start") {
-          try {
-            await this.dispatchCommandEnvelope({
-              name: "goal_start",
-              goalId,
-              payload: { goalId },
-            });
-            await this.broadcast("goal_start_requested", { goalId });
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ ok: true, goalId }));
-          } catch (err) {
-            res.writeHead(500, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: "Command accept failed", details: String(err) }));
-          }
-        } else if (action === "stop") {
-          try {
-            await this.dispatchCommandEnvelope({
-              name: "goal_stop",
-              goalId,
-              payload: { goalId },
-            });
-            await this.broadcast("goal_stop_requested", { goalId });
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ ok: true, goalId }));
-          } catch (err) {
-            res.writeHead(500, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: "Command accept failed", details: String(err) }));
-          }
-        } else if (action === "approve") {
-          try {
-            const body = await readBody(req);
-            const { requestId, approved } = JSON.parse(body) as { requestId: string; approved: boolean };
-            if (!this.approvalBroker && !this.approvalQueue.has(requestId)) {
-              res.writeHead(404, { "Content-Type": "application/json" });
-              res.end(JSON.stringify({ ok: false }));
-              return;
-            }
-            await this.dispatchCommandEnvelope({
-              name: "approval_response",
-              goalId,
-              priority: "high",
-              dedupeKey: `approval_response:${requestId}`,
-              payload: { goalId, requestId, approved },
-            });
-            const resolved = await this.resolveApproval(requestId, approved);
-            res.writeHead(resolved ? 200 : 404, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ ok: resolved }));
-          } catch (err) {
-            res.writeHead(400, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: "Invalid approval response", details: String(err) }));
-          }
-        } else if (action === "chat") {
-          try {
-            const body = await readBody(req);
-            const { message } = JSON.parse(body) as { message: string };
-            await this.dispatchCommandEnvelope({
-              name: "chat_message",
-              goalId,
-              payload: { goalId, message },
-            });
-            await this.broadcast("chat_message_received", { goalId, message });
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ ok: true }));
-          } catch (err) {
-            res.writeHead(400, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: "Invalid chat message", details: String(err) }));
-          }
-        } else {
-          res.writeHead(404, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "Not found" }));
-        }
-      })();
-      return;
-    }
-
-    res.writeHead(404, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "Not found" }));
-  }
-
-  private handlePostEvents(req: http.IncomingMessage, res: http.ServerResponse): void {
-    const MAX_BODY_SIZE = 1_048_576; // 1 MB
-    let body = "";
-    let bytesReceived = 0;
-    req.on("data", (chunk: Buffer) => {
-      bytesReceived += chunk.length;
-      if (bytesReceived > MAX_BODY_SIZE) {
-        res.writeHead(413, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Payload too large" }));
-        req.destroy();
-        return;
-      }
-      body += chunk;
-    });
-    req.on("end", () => {
-      void (async () => {
-        try {
-          const data = JSON.parse(body) as unknown;
-          const event = PulSeedEventSchema.parse(data);
-          if (this.envelopeHook) {
-            // Route through Gateway Envelope path and wait for durable accept.
-            await this.envelopeHook(event as unknown as Record<string, unknown>);
-          } else {
-            await this.driveSystem.writeEvent(event);
-          }
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ status: "accepted", event_type: event.type }));
-        } catch (err) {
-          res.writeHead(400, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "Invalid event", details: String(err) }));
-        }
-      })();
-    });
-  }
-
-  private handlePostTriggers(req: http.IncomingMessage, res: http.ServerResponse): void {
-    const MAX_BODY_SIZE = 1_048_576;
-    let body = "";
-    let bytesReceived = 0;
-    req.on("data", (chunk: Buffer) => {
-      bytesReceived += chunk.length;
-      if (bytesReceived > MAX_BODY_SIZE) {
-        res.writeHead(413, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Payload too large" }));
-        req.destroy();
-        return;
-      }
-      body += chunk;
-    });
-    req.on("end", () => {
-      void (async () => {
-        try {
-          const data = JSON.parse(body) as unknown;
-          const trigger = TriggerEventSchema.parse(data);
-
-          let action: string;
-          let goalId: string | undefined | null;
-
-          if (this.triggerMapper) {
-            const resolved = await this.triggerMapper.resolve(trigger, []);
-            if (resolved.action === "none") {
-              res.writeHead(200, { "Content-Type": "application/json" });
-              res.end(JSON.stringify({ status: "no_mapping" }));
-              return;
-            }
-            action = resolved.action;
-            goalId = resolved.goal_id ?? undefined;
-          } else {
-            const mappingsConfig = await this.loadTriggerMappings();
-            const mapping = mappingsConfig.mappings.find(
-              (m) => m.source === trigger.source && m.event_type === trigger.event_type
-            );
-
-            goalId = mapping?.goal_id ?? trigger.goal_id;
-
-            if (!mapping) {
-              if (!trigger.goal_id) {
-                res.writeHead(200, { "Content-Type": "application/json" });
-                res.end(JSON.stringify({ status: "no_mapping" }));
-                return;
-              }
-              action = "observe";
-            } else {
-              action = mapping.action;
-            }
-          }
-
-          await this.executeTriggerAction(action, trigger, goalId ?? undefined);
-
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ status: "ok", action, goal_id: goalId ?? null }));
-        } catch (err) {
-          res.writeHead(400, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "Invalid trigger", details: String(err) }));
-        }
-      })();
-    });
-  }
-
-  private async executeTriggerAction(
-    action: string,
-    trigger: { source: string; event_type: string; data: Record<string, unknown>; goal_id?: string },
-    goalId?: string
-  ): Promise<void> {
-    if (action === "observe") {
-      const event = PulSeedEventSchema.parse({
-        type: "external",
-        source: trigger.source,
-        timestamp: new Date().toISOString(),
-        data: { ...trigger.data, event_type: trigger.event_type, goal_id: goalId },
-      });
-      try {
-        if (this.envelopeHook) {
-          await this.envelopeHook(event as unknown as Record<string, unknown>);
-        } else {
-          await this.driveSystem.writeEvent(event);
-        }
-      } catch (err) {
-        this.logger?.error(`EventServer: trigger observe failed: ${String(err)}`);
-        throw err;
-      }
-    } else if (action === "create_task") {
-      const filename = `trigger_${Date.now()}_${Math.random().toString(36).slice(2)}.json`;
-      const filePath = path.join(this.eventsDir, filename);
-      const payload = {
-        type: "external",
-        source: trigger.source,
-        timestamp: new Date().toISOString(),
-        data: { ...trigger.data, event_type: trigger.event_type, action: "create_task", goal_id: goalId },
-      };
-      await fsp.writeFile(filePath, JSON.stringify(payload), "utf-8");
-    } else if (action === "notify") {
-      this.logger?.warn(
-        `EventServer: trigger notify — source=${trigger.source} event_type=${trigger.event_type} goal_id=${goalId ?? "none"}`
-      );
-    } else if (action === "wake") {
-      this.logger?.warn(
-        `EventServer: trigger wake — source=${trigger.source} event_type=${trigger.event_type}`
-      );
-    }
-  }
-
-  private async loadTriggerMappings(): Promise<TriggerMappingsConfig> {
-    if (this.triggerMappingsCache !== null) return this.triggerMappingsCache;
-
-    const mappingsPath = path.join(this.eventsDir, "..", "trigger-mappings.json");
-    try {
-      const content = await fsp.readFile(mappingsPath, "utf-8");
-      const raw = JSON.parse(content) as unknown;
-      this.triggerMappingsCache = TriggerMappingsConfigSchema.parse(raw);
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== "ENOENT") {
-        this.logger?.warn(`EventServer: failed to load trigger-mappings.json: ${String(err)}`);
-      }
-      this.triggerMappingsCache = { mappings: [] };
-    }
-    return this.triggerMappingsCache;
-  }
-
-  /** Invalidate the trigger mappings cache (for testing or hot-reload). */
   invalidateTriggerMappingsCache(): void {
-    this.triggerMappingsCache = null;
+    this.triggerHandler.invalidateCache();
+  }
+
+  isRunning(): boolean {
+    return this.server !== null && this.server.listening;
+  }
+
+  isWatching(): boolean {
+    return this.fileIngestion.isWatching();
+  }
+
+  getPort(): number {
+    return this.port;
+  }
+
+  getHost(): string {
+    return this.host;
+  }
+
+  getEventsDir(): string {
+    return this.eventsDir;
+  }
+
+  getAuthToken(): string {
+    return this.auth.getToken();
+  }
+
+  private async dispatchEvent(eventData: Record<string, unknown>): Promise<void> {
+    if (this.envelopeHook) {
+      await this.envelopeHook(eventData);
+      return;
+    }
+    await this.driveSystem.writeEvent(eventData as never);
+  }
+
+  private async handlePostEvents(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    try {
+      const data = await readJsonBody<unknown>(req);
+      const event = PulSeedEventSchema.parse(data);
+      await this.dispatchEvent(event as unknown as Record<string, unknown>);
+      writeJson(res, 200, { status: "accepted", event_type: event.type });
+    } catch (err) {
+      writeJsonError(res, 400, "Invalid event", err);
+    }
   }
 
   private async handleGetGoals(res: http.ServerResponse): Promise<void> {
@@ -753,35 +293,13 @@ export class EventServer {
     }
   }
 
-  /** Check if server is running */
-  isRunning(): boolean {
-    return this.server !== null && this.server.listening;
-  }
-
-  /** Check if file watcher is active (internal use) */
-  isWatching(): boolean {
-    return this.fileWatcher !== null;
-  }
-
-  getPort(): number {
-    return this.port;
-  }
-
-  getHost(): string {
-    return this.host;
-  }
-
-  getEventsDir(): string {
-    return this.eventsDir;
-  }
-
-  getAuthToken(): string {
-    return this.authToken;
-  }
-
   private async handleGetSnapshot(res: http.ServerResponse): Promise<void> {
     try {
-      const snapshot = await this.buildSnapshot();
+      const snapshot = await this.snapshotReader.buildSnapshot(
+        this.approvalBroker?.getPendingApprovalEvents() ?? [],
+        this.outboxStore,
+        this.activeWorkersProvider,
+      );
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify(snapshot));
     } catch (err) {
@@ -790,280 +308,11 @@ export class EventServer {
     }
   }
 
-  private async handleStream(
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-    requestUrl: URL
-  ): Promise<void> {
-    await this.sseManager.handleStream(req, res, requestUrl);
-  }
-
-  private async dispatchCommandEnvelope(input: {
-    name: string;
-    goalId?: string;
-    payload: Record<string, unknown>;
-    priority?: Envelope["priority"];
-    dedupeKey?: string;
-  }): Promise<void> {
-    if (!this.commandEnvelopeHook) return;
-    await this.commandEnvelopeHook(
-      createEnvelope({
-        type: "command",
-        name: input.name,
-        source: "http",
-        goal_id: input.goalId,
-        priority: input.priority,
-        dedupe_key: input.dedupeKey,
-        payload: input.payload,
-      })
-    );
-  }
-
-  private async handlePostDaemonRuntimeControl(
-    req: http.IncomingMessage,
-    res: http.ServerResponse
-  ): Promise<void> {
-    try {
-      const body = await readBody(req);
-      const parsed = JSON.parse(body) as Record<string, unknown>;
-      const operationId = typeof parsed["operationId"] === "string" ? parsed["operationId"] : "";
-      const reason = typeof parsed["reason"] === "string" ? parsed["reason"] : "";
-      const kind = RuntimeControlOperationKindSchema.parse(parsed["kind"]);
-      if (!operationId) {
-        res.writeHead(400, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ ok: false, error: "operationId is required" }));
-        return;
-      }
-
-      await this.dispatchCommandEnvelope({
-        name: "runtime_control",
-        priority: "critical",
-        dedupeKey: `runtime_control:${operationId}`,
-        payload: {
-          operationId,
-          kind,
-          reason,
-        },
-      });
-      await this.broadcast("runtime_control_requested", { operationId, kind });
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: true, operationId }));
-    } catch (err) {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: false, error: "Invalid runtime control request", details: String(err) }));
-    }
-  }
-
-  private async handlePostScheduleRunNow(
-    req: http.IncomingMessage,
-    res: http.ServerResponse,
-    rawScheduleId: string
-  ): Promise<void> {
-    const scheduleId = decodeURIComponent(rawScheduleId).trim();
-    if (!scheduleId) {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: false, error: "scheduleId is required" }));
-      return;
-    }
-
-    try {
-      const body = await readBody(req);
-      const parsed = body.trim() ? JSON.parse(body) as Record<string, unknown> : {};
-      const allowEscalation = parsed["allowEscalation"] === true;
-      await this.dispatchCommandEnvelope({
-        name: "schedule_run_now",
-        priority: "high",
-        payload: { scheduleId, allowEscalation },
-      });
-      await this.broadcast("schedule_run_requested", { scheduleId, allowEscalation });
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: true, scheduleId }));
-    } catch (err) {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: false, error: "Invalid schedule run request", details: String(err) }));
-    }
-  }
-
-  private async handlePostSlackEvents(
-    req: http.IncomingMessage,
-    res: http.ServerResponse
-  ): Promise<void> {
-    if (!this.slackChannelAdapter) {
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: false, error: "Slack adapter is not configured" }));
-      return;
-    }
-
-    try {
-      const body = await readBody(req);
-      const headers = Object.fromEntries(
-        Object.entries(req.headers)
-          .filter((entry): entry is [string, string | string[]] => entry[1] !== undefined)
-          .map(([key, value]) => [key.toLowerCase(), Array.isArray(value) ? value.join(",") : value])
-      );
-      const response = this.slackChannelAdapter.handleRequest(body, headers);
-      res.writeHead(response.status, { "Content-Type": "application/json" });
-      res.end(response.body);
-    } catch (err) {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ ok: false, error: "Invalid Slack event request", details: String(err) }));
-    }
-  }
-
-  private async buildSnapshot(): Promise<EventServerSnapshot> {
-    return this.snapshotReader.buildSnapshot(
-      this.approvalBroker?.getPendingApprovalEvents() ?? [],
-      this.outboxStore,
-      this.activeWorkersProvider
-    );
-  }
-
   private async finishServerStartup(server: http.Server): Promise<void> {
     const addr = server.address();
     if (addr && typeof addr === "object") {
       this.port = addr.port;
     }
-    await this.persistAuthToken();
+    await this.auth.persistAuthToken();
   }
-
-  private getAuthTokenPath(): string {
-    return path.join(path.dirname(this.eventsDir), DAEMON_TOKEN_FILENAME);
-  }
-
-  private async persistAuthToken(): Promise<void> {
-    const tokenPath = this.getAuthTokenPath();
-    await fsp.mkdir(path.dirname(tokenPath), { recursive: true });
-    const payload = {
-      token: this.authToken,
-      host: this.host,
-      port: this.port,
-      pid: process.pid,
-      created_at: new Date().toISOString(),
-    };
-    await fsp.writeFile(tokenPath, JSON.stringify(payload, null, 2), {
-      encoding: "utf-8",
-      mode: 0o600,
-    });
-    await fsp.chmod(tokenPath, 0o600).catch(() => undefined);
-  }
-
-  private async removeAuthTokenFile(): Promise<void> {
-    const tokenPath = this.getAuthTokenPath();
-    try {
-      const raw = await fsp.readFile(tokenPath, "utf-8");
-      const parsed = JSON.parse(raw) as { token?: unknown };
-      if (parsed.token !== this.authToken) return;
-      await fsp.unlink(tokenPath);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        this.logger?.warn(`EventServer: failed to remove auth token file: ${String(err)}`);
-      }
-    }
-  }
-
-  private authorizeRequest(req: http.IncomingMessage, res: http.ServerResponse): boolean {
-    if (!this.isAllowedHost(req.headers.host)) {
-      this.writeJsonError(res, 403, "Forbidden host");
-      return false;
-    }
-
-    if (!this.isAllowedOrigin(req.headers.origin)) {
-      this.writeJsonError(res, 403, "Forbidden origin");
-      return false;
-    }
-
-    const fetchSite = this.singleHeader(req.headers["sec-fetch-site"])?.toLowerCase();
-    if (fetchSite && fetchSite !== "same-origin" && fetchSite !== "none") {
-      this.writeJsonError(res, 403, "Forbidden browser request");
-      return false;
-    }
-
-    if (!this.hasValidAuth(req.headers.authorization)) {
-      this.writeJsonError(res, 401, "Unauthorized");
-      return false;
-    }
-
-    if (req.method === "POST" && !this.hasJsonContentType(req.headers["content-type"])) {
-      this.writeJsonError(res, 415, "Content-Type must be application/json");
-      return false;
-    }
-
-    return true;
-  }
-
-  private hasValidAuth(header: string | string[] | undefined): boolean {
-    const value = this.singleHeader(header);
-    if (!value?.startsWith("Bearer ")) return false;
-    const candidate = value.slice("Bearer ".length).trim();
-    const expected = Buffer.from(this.authToken);
-    const actual = Buffer.from(candidate);
-    return actual.length === expected.length && timingSafeEqual(actual, expected);
-  }
-
-  private hasJsonContentType(header: string | string[] | undefined): boolean {
-    const value = this.singleHeader(header);
-    return value?.split(";")[0]?.trim().toLowerCase() === "application/json";
-  }
-
-  private isAllowedHost(hostHeader: string | undefined): boolean {
-    if (!hostHeader) return false;
-    const hostname = this.parseHostname(hostHeader);
-    if (!hostname) return false;
-    return this.isAllowedHostname(hostname);
-  }
-
-  private isAllowedOrigin(originHeader: string | string[] | undefined): boolean {
-    const origin = this.singleHeader(originHeader);
-    if (!origin) return true;
-    try {
-      const parsed = new URL(origin);
-      if (parsed.protocol !== "http:") return false;
-      if (!this.isAllowedHostname(parsed.hostname)) return false;
-      const originPort = parsed.port ? Number.parseInt(parsed.port, 10) : 80;
-      return originPort === this.port;
-    } catch {
-      return false;
-    }
-  }
-
-  private isAllowedHostname(hostname: string): boolean {
-    const normalized = hostname.toLowerCase().replace(/^\[/, "").replace(/\]$/, "");
-    return normalized === this.host.toLowerCase()
-      || normalized === "127.0.0.1"
-      || normalized === "localhost"
-      || normalized === "::1";
-  }
-
-  private parseHostname(hostHeader: string): string | null {
-    try {
-      return new URL(`http://${hostHeader}`).hostname;
-    } catch {
-      return null;
-    }
-  }
-
-  private singleHeader(header: string | string[] | undefined): string | undefined {
-    return Array.isArray(header) ? header[0] : header;
-  }
-
-  private writeJsonError(res: http.ServerResponse, status: number, error: string): void {
-    res.writeHead(status, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error }));
-  }
-}
-
-/** Read the full request body as a string (max 1 MB). */
-function readBody(req: http.IncomingMessage): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const MAX = 1_048_576;
-    let body = "";
-    let bytes = 0;
-    req.on("data", (chunk: Buffer) => {
-      bytes += chunk.length;
-      if (bytes > MAX) { reject(new Error("Payload too large")); req.destroy(); return; }
-      body += chunk;
-    });
-    req.on("end", () => resolve(body));
-    req.on("error", reject);
-  });
 }


### PR DESCRIPTION
## What changed
- split `DaemonRunner` into startup, goal-cycle, command, and resident/proactive helper modules while keeping the public surface stable
- split `EventServer` into auth, command handling, file ingestion, HTTP helpers, router, trigger handling, and shared internal types
- preserve existing runtime behavior while reducing the size and coupling of the two coordinator classes

## Why it changed
Both runtime entrypoints had grown into large orchestration files that mixed transport, lifecycle, and domain-specific flows. This made changes riskier and local reasoning slower.

## User impact
No intended user-facing behavior change. The runtime orchestration code is easier to follow, test, and change safely.

## Root cause
`DaemonRunner` and `EventServer` each accumulated multiple independent responsibilities in a single implementation file.

## Validation
- `npm run typecheck -- --pretty false`
- `npx vitest run src/runtime/__tests__/event-server.test.ts src/runtime/__tests__/event-file-watcher.test.ts src/runtime/__tests__/event-server-approval.test.ts src/runtime/__tests__/daemon-client.test.ts src/runtime/__tests__/trigger-api.test.ts`
- `npx vitest run src/runtime/__tests__/daemon-runner.test.ts src/runtime/__tests__/daemon-runner-bus.test.ts src/runtime/__tests__/daemon-runner-approval.test.ts src/runtime/__tests__/daemon-runner-gateway.test.ts src/runtime/__tests__/daemon-runner-shutdown.test.ts src/runtime/__tests__/daemon-maintenance.test.ts src/runtime/daemon/__tests__/runner-errors.test.ts src/runtime/daemon/__tests__/runner-recovery.test.ts`

Closes #616
Closes #617
