### PR TITLE
[codex] Tighten prompt and orchestration type boundaries

### DIFF
--- a/src/base/types/__tests__/goal-tree.test.ts
+++ b/src/base/types/__tests__/goal-tree.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   GoalDecompositionConfigSchema,
+  DecompositionChildSchema,
   DecompositionResultSchema,
   GoalTreeStateSchema,
   PruneReasonEnum,
@@ -8,6 +9,7 @@ import {
   AggregationDirectionEnum,
   StateAggregationRuleSchema,
 } from "../goal-tree.js";
+import { makeGoal } from "../../../../tests/helpers/fixtures.js";
 
 // ─── GoalDecompositionConfigSchema ───
 
@@ -83,15 +85,22 @@ describe("GoalDecompositionConfigSchema", () => {
 
 describe("DecompositionResultSchema", () => {
   it("parses valid input with all fields", () => {
+    const grandchild = makeGoal({ id: "grandchild-1", title: "Grandchild 1" });
+    const child = {
+      ...makeGoal({ id: "child-1", title: "Child 1" }),
+      children: [grandchild],
+    };
     const result = DecompositionResultSchema.parse({
       parent_id: "goal-1",
-      children: [{ id: "child-1" }, { id: "child-2" }],
+      children: [child, makeGoal({ id: "child-2", title: "Child 2" })],
       depth: 2,
       specificity_scores: { "child-1": 0.8, "child-2": 0.6 },
       reasoning: "Decomposed for clarity",
     });
     expect(result.parent_id).toBe("goal-1");
     expect(result.children).toHaveLength(2);
+    expect(result.children[0]?.children).toHaveLength(1);
+    expect(result.children[0]?.children?.[0]?.id).toBe("grandchild-1");
     expect(result.depth).toBe(2);
     expect(result.specificity_scores["child-1"]).toBe(0.8);
     expect(result.reasoning).toBe("Decomposed for clarity");
@@ -135,6 +144,20 @@ describe("DecompositionResultSchema", () => {
       reasoning: "bad",
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("DecompositionChildSchema", () => {
+  it("parses recursive child goals", () => {
+    const result = DecompositionChildSchema.parse({
+      ...makeGoal({ id: "child-root", title: "Child Root" }),
+      children: [
+        makeGoal({ id: "child-leaf", title: "Child Leaf" }),
+      ],
+    });
+    expect(result.id).toBe("child-root");
+    expect(result.children).toHaveLength(1);
+    expect(result.children?.[0]?.id).toBe("child-leaf");
   });
 });
 

--- a/src/orchestrator/goal/types/goal-tree.ts
+++ b/src/orchestrator/goal/types/goal-tree.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { SatisficingAggregationEnum } from "./goal.js";
+import { GoalSchema, SatisficingAggregationEnum } from "./goal.js";
 
 // --- Goal Decomposition Config ---
 
@@ -11,11 +11,31 @@ export const GoalDecompositionConfigSchema = z.object({
 });
 export type GoalDecompositionConfig = z.infer<typeof GoalDecompositionConfigSchema>;
 
+// --- Decomposition Child ---
+
+export interface DecompositionChildInput extends z.input<typeof GoalSchema> {
+  children?: DecompositionChildInput[];
+}
+
+export interface DecompositionChild extends z.infer<typeof GoalSchema> {
+  children?: DecompositionChild[];
+}
+
+export const DecompositionChildSchema: z.ZodType<
+  DecompositionChild,
+  z.ZodTypeDef,
+  DecompositionChildInput
+> = z.lazy(() =>
+  GoalSchema.extend({
+    children: z.array(DecompositionChildSchema).optional(),
+  })
+);
+
 // --- Decomposition Result ---
 
 export const DecompositionResultSchema = z.object({
   parent_id: z.string(),
-  children: z.array(z.any()),
+  children: z.array(DecompositionChildSchema),
   depth: z.number().int().min(0),
   specificity_scores: z.record(z.string(), z.number()),
   reasoning: z.string(),

--- a/src/orchestrator/strategy/strategy-manager-base.ts
+++ b/src/orchestrator/strategy/strategy-manager-base.ts
@@ -31,6 +31,7 @@ import {
   unwrapStrategyResponse,
 } from "./strategy-helpers.js";
 
+type RawStrategyCandidate = z.infer<typeof StrategyArraySchema>[number];
 
 export interface ExecutionFeedback {
   strategyId: string;
@@ -168,8 +169,7 @@ export class StrategyManagerBase {
       }
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let strategiesRaw: any[];
+    let strategiesRaw: RawStrategyCandidate[];
     if (this.promptGateway) {
       // Wrap the schema to unwrap any LLM wrapper object before array validation.
       const unwrappingSchema = z.unknown().transform(unwrapStrategyResponse).pipe(StrategyArraySchema);

--- a/src/prompt/__tests__/context-assembler.test.ts
+++ b/src/prompt/__tests__/context-assembler.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { ContextAssembler } from "../context-assembler.js";
-import type { ContextAssemblerDeps, ContextAssemblerGoalState } from "../context-assembler.js";
-
-type TestLesson = NonNullable<Awaited<ReturnType<NonNullable<ContextAssemblerDeps["memoryLifecycle"]>["selectForWorkingMemory"]>>["lessons"]>[number];
+import type {
+  ContextAssemblerDeps,
+  ContextAssemblerGoalState,
+  ContextAssemblerLessonEntry,
+} from "../context-assembler.js";
 
 const makeGoalState = (overrides: Partial<ContextAssemblerGoalState> = {}): ContextAssemblerGoalState & { id: string } => ({
   id: "goal-1",
@@ -228,7 +230,7 @@ describe("ContextAssembler", () => {
   });
 
   describe("context rot prevention — lesson stale filtering", () => {
-    const makeLesson = (overrides: Partial<TestLesson> = {}): TestLesson => ({
+    const makeLesson = (overrides: Partial<ContextAssemblerLessonEntry> = {}): ContextAssemblerLessonEntry => ({
       lesson: "Some lesson",
       relevance_tags: ["MEDIUM"],
       last_accessed: new Date().toISOString(),

--- a/src/prompt/__tests__/context-assembler.test.ts
+++ b/src/prompt/__tests__/context-assembler.test.ts
@@ -183,6 +183,30 @@ describe("ContextAssembler", () => {
       expect(result.contextBlock).toContain("How?");
     });
 
+    it("accepts richer vector search results and ignores extra metadata", async () => {
+      const vectorIndex: NonNullable<ContextAssemblerDeps["vectorIndex"]> = {
+        search: vi.fn().mockResolvedValue([
+          {
+            id: "knowledge-1",
+            text: "Vector knowledge entry",
+            similarity: 0.91,
+            metadata: { source: "semantic-index" },
+          },
+        ]),
+      };
+      const deps: ContextAssemblerDeps = {
+        stateManager: {
+          loadGoalState: vi.fn().mockResolvedValue(makeGoalState()),
+        },
+        vectorIndex,
+      };
+      const assembler = new ContextAssembler(deps);
+      const result = await assembler.build("task_generation", "goal-1");
+      expect(result.contextBlock).toContain("knowledge");
+      expect(result.contextBlock).toContain("Vector knowledge entry");
+      expect(vectorIndex.search).toHaveBeenCalledWith("goal-1", 5, 0.6);
+    });
+
     it("includes failure_context from additionalContext", async () => {
       const deps: ContextAssemblerDeps = {
         stateManager: {

--- a/src/prompt/context-assembler.ts
+++ b/src/prompt/context-assembler.ts
@@ -76,12 +76,12 @@ type GoalThreshold =
       value: string | number | boolean;
     };
 
-interface WorkingMemorySelection {
+export interface ContextAssemblerWorkingMemorySelection {
   shortTerm: unknown[];
-  lessons: LessonEntry[];
+  lessons: ContextAssemblerLessonEntry[];
 }
 
-interface LessonEntry {
+export interface ContextAssemblerLessonEntry {
   lesson?: string;
   content?: string;
   relevance_tags?: string[];
@@ -89,20 +89,20 @@ interface LessonEntry {
   access_count?: number;
 }
 
-interface KnowledgeEntry {
+export interface ContextAssemblerKnowledgeEntry {
   question?: string;
   answer?: string;
   content?: string;
   confidence?: number;
 }
 
-interface ReflectionEntry {
+export interface ContextAssemblerReflectionEntry {
   why_it_worked_or_failed?: string;
   what_to_do_differently?: string;
   what_was_attempted?: string;
 }
 
-interface StrategyTemplateEntry {
+export interface ContextAssemblerStrategyTemplateEntry {
   hypothesis_pattern: string;
   effectiveness_score: number;
   similarity?: number;
@@ -111,10 +111,16 @@ interface StrategyTemplateEntry {
   createdAt?: string;
 }
 
-interface TaskResultEntry {
+export interface ContextAssemblerTaskResultEntry {
   task_description: string;
   outcome: string;
   success: boolean;
+}
+
+interface ContextAssemblerVectorSearchResult {
+  id: string;
+  text: string;
+  similarity: number;
 }
 
 export interface ContextAssemblerDeps {
@@ -127,18 +133,18 @@ export interface ContextAssemblerDeps {
       dims: string[],
       tags: string[],
       max?: number
-    ): Promise<WorkingMemorySelection>;
+    ): Promise<ContextAssemblerWorkingMemorySelection>;
     selectForWorkingMemorySemantic?(
       goalId: string,
       query: string,
       dims: string[],
       tags: string[],
       max?: number
-    ): Promise<WorkingMemorySelection>;
+    ): Promise<ContextAssemblerWorkingMemorySelection>;
   };
   knowledgeManager?: {
-    getRelevantKnowledge?(goalId: string): Promise<KnowledgeEntry[]>;
-    loadKnowledge?(goalId: string, tags?: string[]): Promise<KnowledgeEntry[]>;
+    getRelevantKnowledge?(goalId: string): Promise<ContextAssemblerKnowledgeEntry[]>;
+    loadKnowledge?(goalId: string, tags?: string[]): Promise<ContextAssemblerKnowledgeEntry[]>;
   };
   contextProvider?: {
     buildWorkspaceContextItems?(
@@ -146,14 +152,14 @@ export interface ContextAssemblerDeps {
       dimensionName: string
     ): Promise<Array<{ label: string; content: string }>>;
   };
-  reflectionGetter?: (goalId: string, limit?: number) => Promise<ReflectionEntry[]>;
-  strategyTemplateSearch?: (query: string, topK?: number) => Promise<StrategyTemplateEntry[]>;
+  reflectionGetter?: (goalId: string, limit?: number) => Promise<ContextAssemblerReflectionEntry[]>;
+  strategyTemplateSearch?: (query: string, topK?: number) => Promise<ContextAssemblerStrategyTemplateEntry[]>;
   vectorIndex?: {
     search(
       query: string,
       topK?: number,
       threshold?: number
-    ): Promise<Array<{ id: string; text: string; similarity: number; metadata?: Record<string, unknown> }>>;
+    ): Promise<ContextAssemblerVectorSearchResult[]>;
   };
   budgetTokens?: number;
   budgetAllocator?: (totalBudget: number) => BudgetAllocation;
@@ -243,7 +249,9 @@ export class ContextAssembler {
 
     // Overrides are percentages; convert to absolute tokens
     const result = { ...base };
-    for (const [cat, pct] of Object.entries(overrides) as [keyof BudgetAllocation, number][]) {
+    for (const cat of Object.keys(overrides) as BudgetCategory[]) {
+      const pct = overrides[cat];
+      if (pct === undefined) continue;
       result[cat] = Math.floor(this.budget * (pct / 100));
     }
     return result;
@@ -382,7 +390,7 @@ export class ContextAssembler {
     const result = await this.deps.memoryLifecycle.selectForWorkingMemory(goalId, dims, []);
     if (!result?.lessons?.length) return "";
 
-    let lessons = result.lessons;
+    let lessons: ContextAssemblerLessonEntry[] = [...result.lessons];
 
     // Apply stale filtering only when we have more entries than needed
     const budgetedMax = 5; // default lesson slot max
@@ -416,7 +424,7 @@ export class ContextAssembler {
   private async buildKnowledge(goalId: string): Promise<string> {
     if (!this.deps.knowledgeManager && !this.deps.vectorIndex) return "";
 
-    let entries: KnowledgeEntry[] = [];
+    let entries: ContextAssemblerKnowledgeEntry[] = [];
 
     if (this.deps.knowledgeManager?.getRelevantKnowledge) {
       entries = await this.deps.knowledgeManager.getRelevantKnowledge(goalId);
@@ -435,7 +443,7 @@ export class ContextAssembler {
     if (!this.deps.strategyTemplateSearch) return "";
     const query = goalState?.active_strategy?.hypothesis ?? goalState?.title ?? "";
     if (!query) return "";
-    let templates = await this.deps.strategyTemplateSearch(query, 3);
+    let templates: ContextAssemblerStrategyTemplateEntry[] = [...await this.deps.strategyTemplateSearch(query, 3)];
     if (!templates?.length) return "";
 
     if (this.deps.vectorIndex) {
@@ -553,13 +561,13 @@ export class ContextAssembler {
   }
 }
 
-function isTaskResultEntryArray(value: unknown): value is TaskResultEntry[] {
+function isTaskResultEntryArray(value: unknown): value is ContextAssemblerTaskResultEntry[] {
   return Array.isArray(value) && value.every(isTaskResultEntry);
 }
 
-function isTaskResultEntry(value: unknown): value is TaskResultEntry {
+function isTaskResultEntry(value: unknown): value is ContextAssemblerTaskResultEntry {
   if (!value || typeof value !== "object") return false;
-  const candidate = value as Partial<TaskResultEntry>;
+  const candidate = value as Partial<ContextAssemblerTaskResultEntry>;
   return (
     typeof candidate.task_description === "string" &&
     typeof candidate.outcome === "string" &&

--- a/src/runtime/daemon/__tests__/runner-startup-active-workers.test.ts
+++ b/src/runtime/daemon/__tests__/runner-startup-active-workers.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as path from "node:path";
+import { EventServer } from "../../event-server.js";
+import { Logger } from "../../logger.js";
+import { beginGracefulShutdown, startDaemonRunner } from "../runner-startup.js";
+import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+
+vi.setConfig({ testTimeout: 20_000 });
+
+function makeRequest(
+  port: number,
+  urlPath: string,
+  authToken: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port,
+        path: urlPath,
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          resolve({ status: res.statusCode ?? 0, body });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000, intervalMs = 20): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+describe("runner startup active workers snapshot", () => {
+  let tmpDir: string;
+  let startupPromise: Promise<void> | null = null;
+  let releaseCoreLoop: (() => void) | null = null;
+  let shutdownContext: Record<string, unknown> | null = null;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    startupPromise = null;
+    releaseCoreLoop = null;
+    shutdownContext = null;
+  });
+
+  afterEach(async () => {
+    if (shutdownContext) {
+      beginGracefulShutdown(shutdownContext as never);
+    }
+    releaseCoreLoop?.();
+    await startupPromise?.catch(() => {});
+    startupPromise = null;
+    releaseCoreLoop = null;
+    shutdownContext = null;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("flattens live supervisor worker state into the snapshot payload", async () => {
+    const runtimeRoot = path.join(tmpDir, "runtime");
+    const eventsDir = path.join(runtimeRoot, "events");
+    const logger = new Logger({
+      dir: path.join(tmpDir, "logs"),
+      level: "error",
+      consoleOutput: false,
+    });
+    const eventServer = new EventServer(
+      {
+        writeEvent: vi.fn().mockResolvedValue(undefined),
+      } as never,
+      {
+        port: 0,
+        eventsDir,
+      },
+      logger,
+    );
+    const supervisor = {
+      start: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockReturnValue({
+        workers: [
+          {
+            workerId: "worker-1",
+            goalId: "goal-1",
+            startedAt: 111,
+            iterations: 7,
+          },
+          {
+            workerId: "worker-idle",
+            goalId: null,
+            startedAt: 222,
+            iterations: 3,
+          },
+        ],
+        crashCounts: {},
+        suspendedGoals: [],
+        updatedAt: 333,
+      }),
+    };
+
+    const context = {
+      config: {
+        event_server_port: 0,
+        check_interval_ms: 50,
+        max_concurrent_goals: 1,
+        iterations_per_cycle: 1,
+        crash_recovery: {
+          graceful_shutdown_timeout_ms: 1_000,
+        },
+      },
+      state: {
+        pid: process.pid,
+        started_at: new Date().toISOString(),
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: [],
+        status: "stopped",
+        crash_count: 0,
+        last_error: null,
+        last_resident_at: null,
+        resident_activity: null,
+      },
+      driveSystem: {
+        startWatcher: vi.fn(),
+        stopWatcher: vi.fn(),
+        writeEvent: vi.fn(),
+      },
+      deps: {
+        shutdownSignalTarget: undefined,
+      },
+      eventServer,
+      eventDispatcher: {
+        start: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      },
+      commandDispatcher: {
+        start: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      },
+      supervisor,
+      logger,
+      running: true,
+      shuttingDown: false,
+      initializeRuntimeFoundation: vi.fn().mockResolvedValue(undefined),
+      acquireRuntimeLeadership: vi.fn().mockResolvedValue(undefined),
+      saveRuntimeHealthSnapshot: vi.fn().mockResolvedValue(undefined),
+      startStartupRuntimeStoreMaintenance: vi.fn(),
+      stopStatusHeartbeat: null,
+      shutdownCoordinator: null,
+      queueClaimSweeper: null,
+      approvalBroker: null,
+      gateway: null,
+      approvalFn: undefined,
+      restoreState: vi.fn().mockImplementation(async (goalIds: string[]) => goalIds),
+      reconcileInterruptedExecutions: vi.fn().mockResolvedValue([]),
+      saveDaemonState: vi.fn().mockResolvedValue(undefined),
+      writeShutdownMarker: vi.fn().mockResolvedValue(undefined),
+      runSupervisorMaintenanceCycle: vi.fn().mockResolvedValue(undefined),
+      reconcileRuntimeControlOperationsAfterStartup: vi.fn().mockResolvedValue(undefined),
+      startStartupRuntimeStoreMaintenancePromise: null,
+      drainStartupRuntimeStoreMaintenance: vi.fn().mockResolvedValue(undefined),
+      releaseStartupOwnership: vi.fn().mockResolvedValue(undefined),
+      captureProviderRuntimeFingerprint: vi.fn().mockResolvedValue(null),
+      handleInboundEnvelope: vi.fn().mockResolvedValue(undefined),
+      onEventReceived: vi.fn(),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    };
+    shutdownContext = context;
+
+    startupPromise = startDaemonRunner(context as never, ["goal-1"]);
+
+    await waitFor(() => supervisor.start.mock.calls.length > 0);
+
+    const snapshotResponse = await makeRequest(eventServer.getPort(), "/snapshot", eventServer.getAuthToken());
+    expect(snapshotResponse.status).toBe(200);
+
+    const snapshot = JSON.parse(snapshotResponse.body) as { active_workers: unknown[] };
+    expect(snapshot.active_workers).toEqual([
+      {
+        worker_id: "worker-1",
+        goal_id: "goal-1",
+        started_at: 111,
+        iterations: 7,
+      },
+    ]);
+
+    beginGracefulShutdown(context as never);
+    await startupPromise;
+  });
+});

--- a/src/runtime/daemon/runner-startup.ts
+++ b/src/runtime/daemon/runner-startup.ts
@@ -1,7 +1,7 @@
 import * as path from "node:path";
 import { EventServer } from "../event/server.js";
 import { IngressGateway, HttpChannelAdapter } from "../gateway/index.js";
-import type { LoopSupervisor } from "../executor/index.js";
+import type { LoopSupervisor, SupervisorState } from "../executor/index.js";
 import { PulSeedEventSchema } from "../../base/types/drive.js";
 import { RuntimeOperationStore, type RuntimeControlOperationKind } from "../store/index.js";
 import { ProcessShutdownCoordinator, startDaemonStatusHeartbeat, type ProcessSignalTarget } from "./runner-lifecycle.js";
@@ -16,6 +16,30 @@ const RUNTIME_LEADER_LEASE_MS = 30_000;
 const RUNTIME_LEADER_HEARTBEAT_MS = 10_000;
 
 export type StartupRunnerContext = any;
+
+type SupervisorWorkerSnapshot = SupervisorState["workers"][number];
+
+type ActiveWorkerSnapshot = {
+  worker_id: string;
+  goal_id: string;
+  started_at: number;
+  iterations: number;
+};
+
+function isActiveWorkerSnapshot(
+  worker: SupervisorWorkerSnapshot,
+): worker is SupervisorWorkerSnapshot & { goalId: string } {
+  return worker.goalId !== null;
+}
+
+function flattenActiveWorkers(workers: ReadonlyArray<SupervisorWorkerSnapshot>): ActiveWorkerSnapshot[] {
+  return workers.filter(isActiveWorkerSnapshot).map((worker) => ({
+    worker_id: worker.workerId,
+    goal_id: worker.goalId,
+    started_at: worker.startedAt,
+    iterations: worker.iterations,
+  }));
+}
 
 export async function startDaemonRunner(
   context: StartupRunnerContext,
@@ -38,15 +62,8 @@ export async function startDaemonRunner(
       context.eventServer.setOutboxStore?.(context.outboxStore);
     }
     context.eventServer.setActiveWorkersProvider?.(() => {
-      const workers = context.supervisor?.getState().workers ?? [];
-      return workers
-        .filter((worker: any) => worker.goalId !== null)
-        .map((worker: any) => ({
-          worker_id: worker.workerId,
-          goal_id: worker.goalId,
-          started_at: worker.startedAt,
-          iterations: worker.iterations,
-        }));
+      const supervisorState = context.supervisor?.getState() as SupervisorState | undefined;
+      return flattenActiveWorkers(supervisorState?.workers ?? []);
     });
     if (context.approvalBroker) {
       context.approvalBroker.setBroadcast((eventType: string, data: unknown) => {


### PR DESCRIPTION
## What changed
- tightened `ContextAssembler` dependency boundaries with explicit local types for working-memory, knowledge, reflection, strategy-template, and task-result payloads
- added compatibility coverage for richer `vectorIndex.search` results so extra metadata fields remain accepted
- tightened orchestration type boundaries in strategy generation, goal decomposition, and daemon startup worker snapshots
- replaced `DecompositionResultSchema.children` broad `z.any()` with a recursive goal-shaped schema and added recursive schema tests
- added a focused runtime regression test that boots `startDaemonRunner`, hits the live `/snapshot` endpoint, and verifies the `active_workers` payload shape

## Why it changed
These paths still had broad `any` or similarly loose boundaries in places where structured payloads already existed. Tightening them improves refactor safety and catches shape drift earlier without changing runtime behavior.

## User impact
No intended product behavior change. This is a correctness and maintainability tightening pass around prompt assembly, orchestration contracts, and runtime snapshot reporting.

## Root cause
Several integration boundaries had grown around parsed LLM output or runtime snapshot assembly without carrying their actual schema/type contracts through the code.

## Validation
- `npm run typecheck -- --pretty false`
- `npx vitest run src/prompt/__tests__/context-assembler.test.ts src/prompt/__tests__/gateway.test.ts src/prompt/__tests__/gateway-integration.test.ts`
- `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts src/orchestrator/strategy/__tests__/strategy-required-tools.test.ts src/base/types/__tests__/goal-tree.test.ts src/orchestrator/goal/__tests__/goal-tree-manager.test.ts src/runtime/__tests__/daemon-runner.test.ts src/runtime/__tests__/daemon-maintenance.test.ts`
- `npx vitest run src/runtime/daemon/__tests__/runner-startup-active-workers.test.ts src/runtime/__tests__/daemon-runner.test.ts src/runtime/__tests__/daemon-maintenance.test.ts`

Closes #618
