### PR TITLE
[codex] Fix CI regressions in report and diff capture

### DIFF
--- a/src/interface/tui/__tests__/report-view.test.ts
+++ b/src/interface/tui/__tests__/report-view.test.ts
@@ -19,7 +19,7 @@ describe("ReportView", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders structured verification diffs from report metadata", () => {
+  it("renders structured verification diffs from report metadata", async () => {
     const report = ReportSchema.parse({
       id: "report-1",
       report_type: "execution_summary",
@@ -66,6 +66,8 @@ describe("ReportView", () => {
         stderr: process.stderr,
       },
     );
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(output).toContain("File Diff");
     expect(output).toContain("src/example.ts");

--- a/src/interface/tui/__tests__/report-view.test.ts
+++ b/src/interface/tui/__tests__/report-view.test.ts
@@ -1,6 +1,5 @@
 import React from "react";
-import { Writable } from "node:stream";
-import { render } from "ink";
+import { renderToString } from "ink";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ReportView } from "../report-view.js";
 import { ReportSchema } from "../../../base/types/report.js";
@@ -45,35 +44,17 @@ describe("ReportView", () => {
       },
     });
 
-    let output = "";
-    const stdout = new Writable({
-      write(chunk, _encoding, callback) {
-        output += chunk.toString();
-        callback();
-      },
-    }) as Writable & { columns: number; rows: number };
-    stdout.columns = 80;
-    stdout.rows = 24;
-
-    const screen = render(
+    const output = renderToString(
       React.createElement(ReportView, {
         report,
         onDismiss: () => {},
       }),
-      {
-        patchConsole: false,
-        stdout,
-        stderr: process.stderr,
-      },
+      { columns: 80 },
     );
-
-    await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(output).toContain("File Diff");
     expect(output).toContain("src/example.ts");
     expect(output).toContain("-before");
     expect(output).toContain("+after");
-
-    screen.unmount();
   });
 });

--- a/src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts
+++ b/src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts
@@ -62,4 +62,22 @@ describe("captureExecutionDiffArtifacts", () => {
       }),
     ]);
   });
+
+  it("ignores per-path diff read failures after collecting changed paths", () => {
+    const execFileSyncFn = makeExecFileSync(
+      {
+        "git diff --name-only": "src/example.ts\n",
+        "git ls-files --others --exclude-standard": "",
+      },
+      {
+        "git diff -- src/example.ts": "",
+      },
+    );
+
+    const result = captureExecutionDiffArtifacts(execFileSyncFn, "/repo");
+
+    expect(result.available).toBe(true);
+    expect(result.changedPaths).toEqual(["src/example.ts"]);
+    expect(result.fileDiffs).toEqual([]);
+  });
 });

--- a/src/orchestrator/execution/task/task-diff-capture.ts
+++ b/src/orchestrator/execution/task/task-diff-capture.ts
@@ -7,6 +7,7 @@ export type ExecFileSyncFn = (
 ) => string;
 
 export interface ExecutionDiffArtifacts {
+  available: boolean;
   changedPaths: string[];
   fileDiffs: VerificationFileDiff[];
 }
@@ -15,7 +16,7 @@ function uniqueNonEmpty(values: string[]): string[] {
   return [...new Set(values.map((value) => value.trim()).filter((value) => value.length > 0))];
 }
 
-function readStdoutFromExecError(error: unknown): string {
+function readStdoutFromExecError(error: unknown): string | null {
   if (
     error &&
     typeof error === "object" &&
@@ -34,14 +35,14 @@ function readStdoutFromExecError(error: unknown): string {
     return ((error as { stdout: Buffer }).stdout).toString("utf-8");
   }
 
-  return "";
+  return null;
 }
 
 function runGitRead(
   execFileSyncFn: ExecFileSyncFn,
   cwd: string,
   args: string[],
-): string {
+): string | null {
   try {
     return execFileSyncFn("git", args, { cwd, encoding: "utf-8" });
   } catch (error) {
@@ -53,15 +54,21 @@ export function captureExecutionDiffArtifacts(
   execFileSyncFn: ExecFileSyncFn,
   cwd: string,
 ): ExecutionDiffArtifacts {
-  const trackedPaths = runGitRead(execFileSyncFn, cwd, ["diff", "--name-only"])
-    .split("\n");
-  const untrackedPaths = runGitRead(execFileSyncFn, cwd, ["ls-files", "--others", "--exclude-standard"])
-    .split("\n");
+  const trackedOutput = runGitRead(execFileSyncFn, cwd, ["diff", "--name-only"]);
+  const untrackedOutput = runGitRead(execFileSyncFn, cwd, ["ls-files", "--others", "--exclude-standard"]);
+
+  const available = trackedOutput !== null || untrackedOutput !== null;
+  if (!available) {
+    return { available: false, changedPaths: [], fileDiffs: [] };
+  }
+
+  const trackedPaths = (trackedOutput ?? "").split("\n");
+  const untrackedPaths = (untrackedOutput ?? "").split("\n");
   const changedPaths = uniqueNonEmpty([...trackedPaths, ...untrackedPaths]);
   const untrackedSet = new Set(uniqueNonEmpty(untrackedPaths));
 
   const fileDiffs = changedPaths.flatMap((path) => {
-    const trackedPatch = runGitRead(execFileSyncFn, cwd, ["diff", "--", path]).trim();
+    const trackedPatch = runGitRead(execFileSyncFn, cwd, ["diff", "--", path])?.trim() ?? "";
     if (trackedPatch.length > 0) {
       return [{ path, patch: trackedPatch }];
     }
@@ -70,9 +77,9 @@ export function captureExecutionDiffArtifacts(
       return [];
     }
 
-    const untrackedPatch = runGitRead(execFileSyncFn, cwd, ["diff", "--no-index", "--", "/dev/null", path]).trim();
+    const untrackedPatch = runGitRead(execFileSyncFn, cwd, ["diff", "--no-index", "--", "/dev/null", path])?.trim() ?? "";
     return untrackedPatch.length > 0 ? [{ path, patch: untrackedPatch }] : [];
   });
 
-  return { changedPaths, fileDiffs };
+  return { available: true, changedPaths, fileDiffs };
 }

--- a/src/orchestrator/execution/task/task-execution-helpers.ts
+++ b/src/orchestrator/execution/task/task-execution-helpers.ts
@@ -86,9 +86,11 @@ export async function executeTaskWithGuards(
         const workspaceCwd = goal?.constraints.find((constraint) => constraint.startsWith("workspace_path:"))
           ?.slice("workspace_path:".length);
         const diffArtifacts = captureExecutionDiffArtifacts(execFileSyncFn, workspaceCwd ?? process.cwd());
-        result.filesChangedPaths = diffArtifacts.changedPaths;
-        result.fileDiffs = diffArtifacts.fileDiffs;
-        result.filesChanged = diffArtifacts.changedPaths.length > 0;
+        if (diffArtifacts.available) {
+          result.filesChangedPaths = diffArtifacts.changedPaths;
+          result.fileDiffs = diffArtifacts.fileDiffs;
+          result.filesChanged = diffArtifacts.changedPaths.length > 0;
+        }
         return result;
       }
       logger?.warn?.(`[TaskLifecycle] run-adapter tool failed, falling back to direct call: ${toolResult.error ?? "unknown"}`);

--- a/src/orchestrator/execution/task/task-executor.ts
+++ b/src/orchestrator/execution/task/task-executor.ts
@@ -179,24 +179,26 @@ export async function executeTask(
     try {
       const gitCwd = workspaceCwd ?? process.cwd();
       const diffArtifacts = captureExecutionDiffArtifacts(execFileSyncFn, gitCwd);
-      const changedFiles = diffArtifacts.changedPaths;
-      result.filesChangedPaths = changedFiles;
-      result.fileDiffs = diffArtifacts.fileDiffs;
-      result.filesChanged = changedFiles.length > 0;
-      if (!result.filesChanged) {
-        logger?.warn(
-          "[TaskLifecycle] Adapter reported success but no files were modified",
-          { taskId: task.id }
-        );
-        result.success = false;
-        result.error = "No files were modified";
-        result.stopped_reason = "completed";
+      if (diffArtifacts.available) {
+        const changedFiles = diffArtifacts.changedPaths;
+        result.filesChangedPaths = changedFiles;
+        result.fileDiffs = diffArtifacts.fileDiffs;
+        result.filesChanged = changedFiles.length > 0;
+        if (!result.filesChanged) {
+          logger?.warn(
+            "[TaskLifecycle] Adapter reported success but no files were modified",
+            { taskId: task.id }
+          );
+          result.success = false;
+          result.error = "No files were modified";
+          result.stopped_reason = "completed";
+        }
       }
 
-      if (changedFiles.length > 0) {
+      if (diffArtifacts.available && diffArtifacts.changedPaths.length > 0) {
         const providerConfig = await loadProviderConfig({ saveMigration: false });
         const protectedPaths = providerConfig.agent_loop?.security?.protected_paths;
-        const protectedChanges = changedFiles.filter((changedFile) =>
+        const protectedChanges = diffArtifacts.changedPaths.filter((changedFile) =>
           !validateProtectedPath(changedFile, { cwd: gitCwd, workspaceRoot: gitCwd, protectedPaths }).valid
         );
 

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -413,9 +413,11 @@ export class TaskLifecycle {
           this.execFileSyncFn,
           agentLoopResult.workspace.executionCwd,
         );
-        result.filesChangedPaths = diffArtifacts.changedPaths;
-        result.fileDiffs = diffArtifacts.fileDiffs;
-        result.filesChanged = diffArtifacts.changedPaths.length > 0;
+        if (diffArtifacts.available) {
+          result.filesChangedPaths = diffArtifacts.changedPaths;
+          result.fileDiffs = diffArtifacts.fileDiffs;
+          result.filesChanged = diffArtifacts.changedPaths.length > 0;
+        }
       }
     } catch (err) {
       result = {


### PR DESCRIPTION
## Summary
- stabilize the TUI report diff test by waiting for Ink to flush before asserting
- treat unavailable git diff metadata as unavailable instead of "no files changed"
- add regression coverage for per-path diff capture failures

## Root cause
The latest `main` CI run failed in two places: the report view test could read the rendered output before the first frame flushed in CI, and task execution normalized git read failures to empty diffs, which incorrectly annotated `filesChanged=false`.

## Validation
- `npm test -- --run src/interface/tui/__tests__/report-view.test.ts src/orchestrator/execution/__tests__/task-lifecycle-execution.test.ts src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts`