### PR TITLE
[codex] Stabilize watchdog stale-heartbeat test on CI

### DIFF
--- a/src/runtime/__tests__/watchdog.test.ts
+++ b/src/runtime/__tests__/watchdog.test.ts
@@ -114,7 +114,7 @@ describe("RuntimeWatchdog", () => {
       },
       pollIntervalMs: 20,
       heartbeatTimeoutMs: 50,
-      startupGraceMs: 0,
+      startupGraceMs: 40,
       restartBackoffMs: 10,
       maxRestartBackoffMs: 20,
       childShutdownGraceMs: 10,
@@ -139,7 +139,7 @@ describe("RuntimeWatchdog", () => {
 
     expect(fs.existsSync(pidManager.getPath())).toBe(false);
     expect(children[1]!.kills).toContain("SIGTERM");
-  });
+  }, 20_000);
 
   it("updates the pid file to the current runtime child across restarts", async () => {
     tmpDir = makeTempDir();


### PR DESCRIPTION
## Summary
- restore a small startup grace window in the stale-heartbeat watchdog test
- give that test an explicit 20s timeout instead of relying on Vitest's 5s default

## Why
The merge-after CI failure on `main` was a separate flaky runtime test: `src/runtime/__tests__/watchdog.test.ts > restarts the child when the daemon heartbeat goes stale`. On slower CI runners, the second child could be polled before the test rewrote healthy leader/daemon state, and the spec could run past the default timeout.

## Validation
- `npx vitest run src/runtime/__tests__/watchdog.test.ts`
- repeated `npx vitest run src/runtime/__tests__/watchdog.test.ts` 10 times locally