### PR TITLE
[codex] Collapse GitHub CI to two lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,23 @@ on:
     branches: [main]
 
 jobs:
-  unit:
+  ci:
+    name: ${{ matrix.name }} (${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22, 24]
+        include:
+          - name: unit
+            node-version: 22
+            run-docs: true
+            run-build: true
+            test-command: npm run test:unit
+          - name: integration
+            node-version: 24
+            run-docs: false
+            run-build: true
+            test-command: npm run test:integration
     steps:
       - uses: actions/checkout@v5
       - name: Use Node.js ${{ matrix.node-version }}
@@ -21,40 +32,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
-      - run: npm run check:docs
-      - run: npm run build
-      - run: npm run test:unit
-
-  smoke:
-    runs-on: ubuntu-latest
-    needs: unit
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [22, 24]
-    steps:
-      - uses: actions/checkout@v5
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-      - run: npm ci
-      - run: npm run test:smoke
-
-  integration:
-    runs-on: ubuntu-latest
-    needs: smoke
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [24]
-    steps:
-      - uses: actions/checkout@v5
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: "npm"
-      - run: npm ci
-      - run: npm run test:integration
+      - if: ${{ matrix.run-docs }}
+        run: npm run check:docs
+      - if: ${{ matrix.run-build }}
+        run: npm run build
+      - run: ${{ matrix.test-command }}


### PR DESCRIPTION
## Summary

- reduce GitHub CI to two lanes total: one Node 22 lane and one Node 24 lane
- keep docs/build/unit on Node 22 and build/integration on Node 24
- remove the separate smoke and extra matrix fan-out from the default GitHub workflow

## Validation

- npm run check:docs
- npm run build
- npm run test:unit
- npm run test:integration
