### PR TITLE
Core gateway channels and setup flow

### DIFF
--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -116,6 +116,14 @@ export interface ProviderConfig {
     }>;
   };
 
+  /** Optional local-only OpenClaw ACP adapter configuration */
+  openclaw?: {
+    cli_path?: string;
+    profile?: string;
+    model?: string;
+    work_dir?: string;
+  };
+
   /** Native agentloop runtime settings */
   agent_loop?: {
     security?: AgentLoopSecurityConfig;
@@ -502,6 +510,7 @@ async function resolveProviderConfig(
   if (fileConfig.terminal_backend !== undefined) config.terminal_backend = fileConfig.terminal_backend;
   if (fileConfig.a2a !== undefined) config.a2a = fileConfig.a2a;
   if (lightModel !== undefined) config.light_model = lightModel;
+  if (fileConfig.openclaw !== undefined) config.openclaw = fileConfig.openclaw;
   if (fileConfig.agent_loop !== undefined) config.agent_loop = fileConfig.agent_loop;
   return config;
 }
@@ -591,6 +600,7 @@ export async function getProviderRuntimeFingerprint(): Promise<string> {
       ? createHash("sha256").update(config.api_key).digest("hex")
       : null,
     a2a: config.a2a ?? null,
+    openclaw: config.openclaw ?? null,
     agent_loop: config.agent_loop ?? null,
   };
 

--- a/src/base/utils/paths.ts
+++ b/src/base/utils/paths.ts
@@ -30,6 +30,22 @@ export function getPluginsDir(base?: string): string {
   return path.join(base ?? getPulseedDirPath(), "plugins");
 }
 
+export function getPromotedPluginsDir(base?: string): string {
+  return path.join(base ?? getPulseedDirPath(), "plugins-promoted-to-core");
+}
+
+export function getGatewayDir(base?: string): string {
+  return path.join(base ?? getPulseedDirPath(), "gateway");
+}
+
+export function getGatewayChannelsDir(base?: string): string {
+  return path.join(getGatewayDir(base), "channels");
+}
+
+export function getGatewayChannelDir(channelName: string, base?: string): string {
+  return path.join(getGatewayChannelsDir(base), channelName);
+}
+
 export function getSkillsDir(base?: string): string {
   return path.join(base ?? getPulseedDirPath(), "skills");
 }

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
 import type { NotificationConfig } from "../../../runtime/types/notification.js";
 import type { SetupImportSelection } from "../commands/setup/import/types.js";
 
 const confirmMock = vi.fn();
 const textMock = vi.fn();
 const selectMock = vi.fn();
+const multiselectMock = vi.fn();
 const noteMock = vi.fn();
 const introMock = vi.fn();
 const outroMock = vi.fn();
@@ -22,6 +26,7 @@ vi.mock("@clack/prompts", () => ({
   confirm: confirmMock,
   text: textMock,
   select: selectMock,
+  multiselect: multiselectMock,
   note: noteMock,
   intro: introMock,
   outro: outroMock,
@@ -42,9 +47,11 @@ vi.mock("../../../base/config/global-config.js", () => ({
 describe("setup notification step", () => {
   beforeEach(() => {
     vi.resetModules();
+    delete process.env["PULSEED_HOME"];
     confirmMock.mockReset();
     textMock.mockReset();
     selectMock.mockReset();
+    multiselectMock.mockReset();
     noteMock.mockReset();
     introMock.mockReset();
     outroMock.mockReset();
@@ -54,15 +61,19 @@ describe("setup notification step", () => {
     logErrorMock.mockReset();
     logSuccessMock.mockReset();
     updateGlobalConfigMock.mockReset();
+    multiselectMock.mockResolvedValue([]);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env["PULSEED_HOME"];
     vi.doUnmock("../commands/setup/steps-identity.js");
     vi.doUnmock("../commands/setup/steps-provider.js");
     vi.doUnmock("../commands/setup/steps-adapter.js");
     vi.doUnmock("../commands/setup/steps-runtime.js");
     vi.doUnmock("../commands/setup/steps-notification.js");
+    vi.doUnmock("../commands/setup/steps-gateway.js");
     vi.doUnmock("../../../base/llm/provider-config.js");
     vi.doUnmock("../../../base/config/global-config.js");
     vi.doUnmock("../../../base/config/identity-loader.js");
@@ -281,6 +292,93 @@ describe("setup notification step", () => {
       "utf-8"
     );
     expect(mkdirSyncMock).toHaveBeenCalledWith("/tmp/pulseed-test", { recursive: true });
+  });
+
+  it("writes selected gateway channel config during full setup", async () => {
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-setup-gateway-test-"));
+    process.env["PULSEED_HOME"] = tmpDir;
+
+    vi.doMock("../commands/setup/steps-identity.js", () => ({
+      getBanner: () => "banner",
+      stepExistingConfig: vi.fn(async () => "reset"),
+      stepUserName: vi.fn(async () => "User"),
+      stepSeedyName: vi.fn(async () => "Seedy"),
+    }));
+    vi.doMock("../commands/setup/steps-provider.js", () => ({
+      stepRootPreset: vi.fn(async () => "default"),
+      stepProvider: vi.fn(async () => "openai"),
+      stepModel: vi.fn(async () => "gpt-5.4-mini"),
+      stepApiKey: vi.fn(async () => "sk-test"),
+      stepOpenAIAuthMethod: vi.fn(async () => "api_key"),
+    }));
+    vi.doMock("../commands/setup/steps-runtime.js", () => ({
+      ensurePulseedDir: vi.fn(() => tmpDir),
+      stepDaemon: vi.fn(async () => ({ start: false, port: 41700 })),
+      writeSeedMd: vi.fn(),
+      writeRootMd: vi.fn(),
+      writeUserMd: vi.fn(),
+    }));
+    vi.doMock("../commands/setup/steps-notification.js", () => ({
+      stepNotification: vi.fn(async () => null),
+    }));
+    vi.doMock("../../../base/llm/provider-config.js", () => ({
+      MODEL_REGISTRY: {
+        "gpt-5.4-mini": {
+          provider: "openai",
+          adapters: ["openai_codex_cli", "openai_api", "agent_loop"],
+        },
+      },
+      loadProviderConfig: vi.fn(),
+      saveProviderConfig: vi.fn(async () => {}),
+      validateProviderConfig: vi.fn(() => ({ valid: true, errors: [] })),
+    }));
+    vi.doMock("../../../base/config/identity-loader.js", () => ({
+      clearIdentityCache: vi.fn(),
+    }));
+    vi.doMock("node:fs", () => ({
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn(),
+      existsSync: vi.fn(() => false),
+      readFileSync: vi.fn(),
+    }));
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        result: { id: 42, first_name: "PulSeed", username: "pulseed_bot" },
+      }),
+    }));
+
+    confirmMock.mockResolvedValueOnce(true);
+    multiselectMock.mockResolvedValueOnce(["telegram-bot"]);
+    textMock
+      .mockResolvedValueOnce("test-token")
+      .mockResolvedValueOnce("777,888")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("personal");
+    selectMock
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("continue")
+      .mockResolvedValueOnce("save");
+
+    const { runSetupWizard } = await import("../commands/setup-wizard.js");
+    const code = await runSetupWizard();
+
+    expect(code).toBe(0);
+    const telegramConfig = JSON.parse(
+      await fsp.readFile(path.join(tmpDir, "gateway", "channels", "telegram-bot", "config.json"), "utf-8")
+    ) as Record<string, unknown>;
+    expect(telegramConfig).toMatchObject({
+      bot_token: "test-token",
+      allowed_user_ids: [777, 888],
+      runtime_control_allowed_user_ids: [777, 888],
+      allow_all: false,
+      identity_key: "personal",
+    });
+
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+    delete process.env["PULSEED_HOME"];
   });
 
   it("can go back to a previous setup section before saving", async () => {
@@ -773,7 +871,7 @@ describe("setup notification step", () => {
     );
   });
 
-  it("uses imported provider settings without re-asking execution prompts after importing from Hermes", async () => {
+  it("uses imported provider settings without re-asking execution prompts after importing from OpenClaw", async () => {
     const stepExistingConfigMock = vi.fn(async () => "keep");
     const stepSeedyNameMock = vi.fn(async () => "Imported Seedy");
     const stepProviderMock = vi.fn(async (initial?: string) => initial ?? "openai");
@@ -784,17 +882,17 @@ describe("setup notification step", () => {
     const saveProviderConfigMock = vi.fn(async () => {});
     const applySetupImportSelectionMock = vi.fn(async () => ({
       created_at: "2026-04-13T00:00:00.000Z",
-      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes" }],
+      sources: [{ id: "openclaw", label: "OpenClaw", rootDir: "/tmp/openclaw" }],
       items: [],
     }));
 
     const importSelection: SetupImportSelection = {
-      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: "/tmp/hermes", items: [] }],
+      sources: [{ id: "openclaw", label: "OpenClaw", rootDir: "/tmp/openclaw", items: [] }],
       items: [
         {
-          id: "hermes:provider:config.json",
-          source: "hermes",
-          sourceLabel: "Hermes Agent",
+          id: "openclaw:provider:config.json",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
           kind: "provider",
           label: "anthropic / claude-sonnet-4-6 / agent_loop",
           decision: "import",

--- a/src/interface/cli/__tests__/gateway-setup.test.ts
+++ b/src/interface/cli/__tests__/gateway-setup.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const multiselectMock = vi.fn();
+const textMock = vi.fn();
+const confirmMock = vi.fn();
+const noteMock = vi.fn();
+const introMock = vi.fn();
+const outroMock = vi.fn();
+const cancelMock = vi.fn();
+const logInfoMock = vi.fn();
+const logSuccessMock = vi.fn();
+const logWarnMock = vi.fn();
+
+const isDaemonRunningMock = vi.fn(async () => ({ running: false, port: 41700 }));
+
+vi.mock("@clack/prompts", () => ({
+  multiselect: multiselectMock,
+  text: textMock,
+  confirm: confirmMock,
+  note: noteMock,
+  intro: introMock,
+  outro: outroMock,
+  cancel: cancelMock,
+  log: {
+    info: logInfoMock,
+    success: logSuccessMock,
+    warn: logWarnMock,
+  },
+  isCancel: vi.fn(() => false),
+}));
+
+vi.mock("../../../runtime/daemon/client.js", () => ({
+  isDaemonRunning: isDaemonRunningMock,
+}));
+
+vi.mock("../../../runtime/pid-manager.js", () => ({
+  PIDManager: vi.fn().mockImplementation(() => ({
+    stopRuntime: vi.fn(async () => ({ stopped: true })),
+  })),
+}));
+
+describe("cmdGatewaySetup", () => {
+  let tmpDir: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-gateway-setup-test-"));
+    process.env["PULSEED_HOME"] = tmpDir;
+    multiselectMock.mockReset();
+    textMock.mockReset();
+    confirmMock.mockReset();
+    noteMock.mockReset();
+    introMock.mockReset();
+    outroMock.mockReset();
+    cancelMock.mockReset();
+    logInfoMock.mockReset();
+    logSuccessMock.mockReset();
+    logWarnMock.mockReset();
+    isDaemonRunningMock.mockClear();
+    fetchMock = vi.fn().mockResolvedValue({
+      json: vi.fn().mockResolvedValue({
+        ok: true,
+        result: { id: 42, first_name: "PulSeed", username: "pulseed_bot" },
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env["PULSEED_HOME"];
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes selected Telegram and Signal core gateway configs", async () => {
+    multiselectMock.mockResolvedValue(["telegram-bot", "signal-bridge"]);
+    textMock
+      .mockResolvedValueOnce("test-token")
+      .mockResolvedValueOnce("777,888")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("personal")
+      .mockResolvedValueOnce("http://127.0.0.1:8080")
+      .mockResolvedValueOnce("+15550001111")
+      .mockResolvedValueOnce("+15550001111")
+      .mockResolvedValueOnce("+15550002222,+15550003333")
+      .mockResolvedValueOnce("")
+      .mockResolvedValueOnce("personal")
+      .mockResolvedValueOnce("5000")
+      .mockResolvedValueOnce("2000");
+
+    const { cmdGatewaySetup } = await import("../commands/gateway.js");
+    const code = await cmdGatewaySetup([]);
+
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledWith("https://api.telegram.org/bottest-token/getMe");
+
+    const telegramConfig = JSON.parse(
+      await fsp.readFile(path.join(tmpDir, "gateway", "channels", "telegram-bot", "config.json"), "utf-8")
+    ) as Record<string, unknown>;
+    expect(telegramConfig).toMatchObject({
+      bot_token: "test-token",
+      allowed_user_ids: [777, 888],
+      runtime_control_allowed_user_ids: [777, 888],
+      allow_all: false,
+      polling_timeout: 30,
+      identity_key: "personal",
+    });
+    expect(telegramConfig.chat_id).toBeUndefined();
+
+    const signalConfig = JSON.parse(
+      await fsp.readFile(path.join(tmpDir, "gateway", "channels", "signal-bridge", "config.json"), "utf-8")
+    ) as Record<string, unknown>;
+    expect(signalConfig).toMatchObject({
+      bridge_url: "http://127.0.0.1:8080",
+      account: "+15550001111",
+      recipient_id: "+15550001111",
+      allowed_sender_ids: ["+15550002222", "+15550003333"],
+      runtime_control_allowed_sender_ids: ["+15550002222", "+15550003333"],
+      allowed_conversation_ids: [],
+      identity_key: "personal",
+      poll_interval_ms: 5000,
+      receive_timeout_ms: 2000,
+    });
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "Gateway configs were saved. Run `pulseed setup` or `pulseed daemon start` when you are ready."
+    );
+  }, 15000);
+
+  it("exits cleanly when no platform is selected", async () => {
+    multiselectMock.mockResolvedValue([]);
+
+    const { cmdGatewaySetup } = await import("../commands/gateway.js");
+    const code = await cmdGatewaySetup([]);
+
+    expect(code).toBe(0);
+    expect(textMock).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tmpDir, "gateway", "channels"))).toBe(false);
+    expect(outroMock).toHaveBeenCalledWith("No gateway changes made.");
+  }, 15000);
+});

--- a/src/interface/cli/__tests__/setup-import.test.ts
+++ b/src/interface/cli/__tests__/setup-import.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  delete process.env["PULSEED_IMPORT_OPENCLAW_HOME"];
   delete process.env["PULSEED_IMPORT_HERMES_HOME"];
   vi.doUnmock("@clack/prompts");
   vi.doUnmock("../commands/setup/import/discovery.js");
@@ -25,30 +26,37 @@ async function writeJson(filePath: string, value: unknown): Promise<void> {
 }
 
 describe("setup import discovery", () => {
-  it("detects Hermes provider, skills, MCP servers, and plugins", async () => {
-    const hermesHome = path.join(tmpDir, "hermes");
-    process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
+  it("detects OpenClaw provider, skills, MCP servers, and plugins", async () => {
+    const openclawHome = path.join(tmpDir, "openclaw");
+    process.env["PULSEED_IMPORT_OPENCLAW_HOME"] = openclawHome;
 
-    await writeJson(path.join(hermesHome, "settings.json"), {
-      provider: "openai",
-      model: "gpt-5.4-mini",
+    await writeJson(path.join(openclawHome, "config.json"), {
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
       adapter: "agent_loop",
       apiKey: "sk-imported",
       baseUrl: "https://example.test",
     });
-    await fsp.mkdir(path.join(hermesHome, "skills", "review"), { recursive: true });
-    await fsp.writeFile(path.join(hermesHome, "skills", "review", "SKILL.md"), "# Review\n", "utf-8");
-    await writeJson(path.join(hermesHome, "mcp.json"), {
+    await fsp.mkdir(path.join(openclawHome, "skills", "review"), { recursive: true });
+    await fsp.writeFile(path.join(openclawHome, "skills", "review", "SKILL.md"), "# Review\n", "utf-8");
+    await writeJson(path.join(openclawHome, "mcp.json"), {
       mcpServers: {
         filesystem: {
           command: "node",
           args: ["server.js"],
           env: { ROOT: "/tmp" },
+          tool_mappings: [
+            {
+              tool_name: "read_file",
+              dimension_pattern: "filesystem_*",
+              args_template: { path: "$path" },
+            },
+          ],
         },
       },
     });
-    await fsp.mkdir(path.join(hermesHome, "plugins", "notifier"), { recursive: true });
-    await writeJson(path.join(hermesHome, "plugins", "notifier", "plugin.json"), {
+    await fsp.mkdir(path.join(openclawHome, "plugins", "notifier"), { recursive: true });
+    await writeJson(path.join(openclawHome, "plugins", "notifier", "plugin.json"), {
       name: "notifier",
       version: "1.0.0",
       type: "notifier",
@@ -61,40 +69,112 @@ describe("setup import discovery", () => {
         shell: false,
       },
     });
-    await fsp.writeFile(path.join(hermesHome, "USER.md"), "# About You\n\nName: Imported User\n", "utf-8");
+    await fsp.writeFile(path.join(openclawHome, "USER.md"), "# About You\n\nName: Imported User\n", "utf-8");
 
     const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
     const sources = detectSetupImportSources();
-    const hermes = sources.find((source) => source.id === "hermes");
+    const openclaw = sources.find((source) => source.id === "openclaw");
 
-    expect(hermes).toBeDefined();
-    expect(hermes?.items.map((item) => item.kind).sort()).toEqual([
+    expect(openclaw).toBeDefined();
+    expect(openclaw?.items.map((item) => item.kind).sort()).toEqual([
       "mcp",
       "plugin",
       "provider",
       "skill",
       "user",
     ]);
-    expect(hermes?.items.find((item) => item.kind === "provider")?.providerSettings).toMatchObject({
-      provider: "openai",
-      model: "gpt-5.4-mini",
+    expect(openclaw?.items.find((item) => item.kind === "provider")?.providerSettings).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
       adapter: "agent_loop",
       apiKey: "sk-imported",
       baseUrl: "https://example.test",
     });
-    expect(hermes?.items.find((item) => item.kind === "mcp")?.mcpServer).toMatchObject({
-      id: "hermes-filesystem",
+    expect(openclaw?.items.find((item) => item.kind === "mcp")?.mcpServer).toMatchObject({
+      id: "openclaw-filesystem",
       enabled: false,
+      transport: "stdio",
       command: "node",
-      args: ["server.js"],
+      tool_mappings: [
+        {
+          tool_name: "read_file",
+          dimension_pattern: "filesystem_*",
+          args_template: { path: "$path" },
+        },
+      ],
     });
-    expect(hermes?.items.find((item) => item.kind === "plugin")?.pluginCompatibility?.status).toBe("convertible");
-    expect(hermes?.items.find((item) => item.kind === "user")?.userSettings).toEqual({
+    expect(openclaw?.items.find((item) => item.kind === "plugin")?.decision).toBe("copy_disabled");
+    expect(openclaw?.items.find((item) => item.kind === "plugin")?.pluginCompatibility?.status).toBe("convertible");
+    expect(openclaw?.items.find((item) => item.kind === "user")?.userSettings).toEqual({
       content: "# About You\n\nName: Imported User\n",
     });
   });
 
-  it("imports provider API keys from the workspace env file selected by Hermes config", async () => {
+  it("detects OpenClaw migration-style YAML, env secrets, workspace skills, and nested MCP servers", async () => {
+    const openclawHome = path.join(tmpDir, "openclaw");
+    process.env["PULSEED_IMPORT_OPENCLAW_HOME"] = openclawHome;
+
+    await fsp.mkdir(openclawHome, { recursive: true });
+    await fsp.writeFile(
+      path.join(openclawHome, ".env"),
+      [
+        "OPENAI_API_KEY=sk-env-openai",
+        "TELEGRAM_BOT_TOKEN=123456:telegram-token",
+      ].join("\n"),
+      "utf-8"
+    );
+    await fsp.writeFile(
+      path.join(openclawHome, "config.yaml"),
+      [
+        "agents:",
+        "  defaults:",
+        "    model: gpt-5.4-mini",
+        "models:",
+        "  providers:",
+        "    openai:",
+        "      apiKey:",
+        "        source: env",
+        "        id: OPENAI_API_KEY",
+        "      baseUrl: https://api.openai.com/v1",
+        "channels:",
+        "  telegram:",
+        "    botToken: ${TELEGRAM_BOT_TOKEN}",
+        "mcp:",
+        "  servers:",
+        "    filesystem:",
+        "      command: node",
+        "      args:",
+        "        - server.js",
+      ].join("\n"),
+      "utf-8"
+    );
+    await fsp.mkdir(path.join(openclawHome, "workspace-main", "skills", "review"), { recursive: true });
+    await fsp.writeFile(path.join(openclawHome, "workspace-main", "skills", "review", "SKILL.md"), "# Review\n", "utf-8");
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const openclaw = sources.find((source) => source.id === "openclaw");
+    const provider = openclaw?.items.find((item) => item.kind === "provider");
+    const skill = openclaw?.items.find((item) => item.kind === "skill");
+    const mcp = openclaw?.items.find((item) => item.kind === "mcp");
+
+    expect(provider?.providerSettings).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      apiKey: "sk-env-openai",
+      baseUrl: "https://api.openai.com/v1",
+    });
+    expect(provider?.providerSettings?.apiKey).not.toBe("123456:telegram-token");
+    expect(skill?.label).toBe("review");
+    expect(mcp?.mcpServer).toMatchObject({
+      id: "openclaw-filesystem",
+      command: "node",
+      args: ["server.js"],
+      enabled: false,
+    });
+  });
+
+  it("imports provider API keys from the workspace env file selected by the config", async () => {
     const hermesHome = path.join(tmpDir, "hermes");
     process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
 
@@ -126,6 +206,165 @@ describe("setup import discovery", () => {
       apiKey: "sk-workspace-openai",
     });
   });
+
+  it("does not pull an api key from an unrelated Hermes workspace", async () => {
+    const hermesHome = path.join(tmpDir, "hermes");
+    process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
+
+    await fsp.mkdir(path.join(hermesHome, "workspace-main"), { recursive: true });
+    await fsp.mkdir(path.join(hermesHome, "workspace-secondary"), { recursive: true });
+    await fsp.writeFile(
+      path.join(hermesHome, "workspace-main", ".env"),
+      "OPENAI_API_KEY=sk-workspace-main\n",
+      "utf-8"
+    );
+    await fsp.writeFile(
+      path.join(hermesHome, "workspace-secondary", ".env"),
+      "OPENAI_API_KEY=sk-workspace-secondary\n",
+      "utf-8"
+    );
+    await writeJson(path.join(hermesHome, "settings.json"), {
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "agent_loop",
+      workspace: "workspace-main",
+      openai: {
+        apiKey: "OPENAI_API_KEY",
+      },
+    });
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const hermes = sources.find((source) => source.id === "hermes");
+    const provider = hermes?.items.find((item) => item.kind === "provider");
+
+    expect(provider?.providerSettings).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "agent_loop",
+      apiKey: "sk-workspace-main",
+    });
+    expect(provider?.providerSettings?.apiKey).not.toBe("sk-workspace-secondary");
+  });
+
+  it("prefers the actual provider object over unrelated sibling model values", async () => {
+    const hermesHome = path.join(tmpDir, "hermes");
+    process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
+
+    await writeJson(path.join(hermesHome, "settings.json"), {
+      agents: {
+        defaults: {
+          model: "gpt-4o-mini-tts",
+        },
+      },
+      provider: {
+        provider: "openai",
+        model: "gpt-5.4",
+        adapter: "openai_codex_cli",
+        apiKey: "OPENAI_API_KEY",
+      },
+    });
+    await fsp.writeFile(path.join(hermesHome, ".env"), "OPENAI_API_KEY=sk-hermes-openai\n", "utf-8");
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const hermes = sources.find((source) => source.id === "hermes");
+    const provider = hermes?.items.find((item) => item.kind === "provider");
+
+    expect(provider?.providerSettings).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "openai_codex_cli",
+      apiKey: "sk-hermes-openai",
+    });
+  });
+
+  it("detects USER.md from Hermes for identity import", async () => {
+    const hermesHome = path.join(tmpDir, "hermes");
+    process.env["PULSEED_IMPORT_HERMES_HOME"] = hermesHome;
+
+    await writeJson(path.join(hermesHome, "settings.json"), {
+      provider: "openai",
+      model: "gpt-5.4",
+      adapter: "openai_codex_cli",
+    });
+    await fsp.writeFile(
+      path.join(hermesHome, "USER.md"),
+      "# About You\n\nName: Imported User\nPrefers concise updates.\n",
+      "utf-8"
+    );
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const hermes = sources.find((source) => source.id === "hermes");
+    const user = hermes?.items.find((item) => item.kind === "user");
+
+    expect(user?.userSettings).toEqual({
+      content: "# About You\n\nName: Imported User\nPrefers concise updates.\n",
+    });
+  });
+
+  it("classifies imported plugin manifests by compatibility and permission summary", async () => {
+    const openclawHome = path.join(tmpDir, "openclaw");
+    process.env["PULSEED_IMPORT_OPENCLAW_HOME"] = openclawHome;
+
+    await fsp.mkdir(path.join(openclawHome, "plugins", "convertible"), { recursive: true });
+    await writeJson(path.join(openclawHome, "plugins", "convertible", "plugin.json"), {
+      name: "convertible",
+      version: "1.0.0",
+      type: "notifier",
+      capabilities: ["notify"],
+      description: "convertible plugin",
+      permissions: {
+        network: false,
+        file_read: false,
+        file_write: false,
+        shell: false,
+      },
+    });
+    await fsp.mkdir(path.join(openclawHome, "plugins", "quarantined"), { recursive: true });
+    await writeJson(path.join(openclawHome, "plugins", "quarantined", "plugin.json"), {
+      name: "quarantined",
+      version: "1.0.0",
+      type: "notifier",
+      capabilities: ["notify"],
+      description: "quarantined plugin",
+      permissions: {
+        network: true,
+        file_read: false,
+        file_write: false,
+        shell: false,
+      },
+    });
+    await fsp.mkdir(path.join(openclawHome, "plugins", "incompatible"), { recursive: true });
+    await writeJson(path.join(openclawHome, "plugins", "incompatible", "plugin.json"), {
+      name: "Bad Name",
+      version: "1.0",
+      type: "custom",
+      capabilities: [],
+      description: "",
+    });
+
+    const { detectSetupImportSources } = await import("../commands/setup/import/discovery.js");
+    const sources = detectSetupImportSources();
+    const openclaw = sources.find((source) => source.id === "openclaw");
+    const pluginItems = openclaw?.items.filter((item) => item.kind === "plugin") ?? [];
+
+    expect(pluginItems.map((item) => item.label).sort()).toEqual([
+      "convertible",
+      "incompatible",
+      "quarantined",
+    ]);
+    expect(pluginItems.find((item) => item.label === "convertible")?.pluginCompatibility?.status).toBe("convertible");
+    expect(pluginItems.find((item) => item.label === "quarantined")?.pluginCompatibility?.status).toBe("quarantined");
+    expect(pluginItems.find((item) => item.label === "incompatible")?.pluginCompatibility?.status).toBe("incompatible");
+    expect(pluginItems.find((item) => item.label === "quarantined")?.pluginCompatibility?.permissions).toMatchObject({
+      network: true,
+      file_read: false,
+      file_write: false,
+      shell: false,
+    });
+  });
 });
 
 describe("setup import apply", () => {
@@ -153,7 +392,7 @@ describe("setup import apply", () => {
     await writeJson(path.join(baseDir, "mcp-servers.json"), {
       servers: [
         {
-          id: "hermes-filesystem",
+          id: "openclaw-filesystem",
           name: "existing",
           transport: "stdio",
           command: "node",
@@ -164,12 +403,12 @@ describe("setup import apply", () => {
     });
 
     const selection: SetupImportSelection = {
-      sources: [{ id: "hermes", label: "Hermes Agent", rootDir: sourceRoot, items: [] }],
+      sources: [{ id: "openclaw", label: "OpenClaw", rootDir: sourceRoot, items: [] }],
       items: [
         {
-          id: "hermes:skill:review",
-          source: "hermes",
-          sourceLabel: "Hermes Agent",
+          id: "openclaw:skill:review",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
           kind: "skill",
           label: "review",
           sourcePath: skillDir,
@@ -177,16 +416,16 @@ describe("setup import apply", () => {
           reason: "SKILL.md found",
         },
         {
-          id: "hermes:plugin:notifier",
-          source: "hermes",
-          sourceLabel: "Hermes Agent",
+          id: "openclaw:plugin:notifier",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
           kind: "plugin",
           label: "notifier",
           sourcePath: pluginDir,
           decision: "copy_disabled",
           reason: "quarantine",
           pluginCompatibility: {
-            source: "hermes",
+            source: "openclaw",
             status: "quarantined",
             issues: ["requested permissions: network"],
             permissions: {
@@ -207,15 +446,15 @@ describe("setup import apply", () => {
           } satisfies ForeignPluginCompatibilityReport,
         },
         {
-          id: "hermes:mcp:filesystem",
-          source: "hermes",
-          sourceLabel: "Hermes Agent",
+          id: "openclaw:mcp:filesystem",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
           kind: "mcp",
           label: "filesystem",
           decision: "copy_disabled",
           reason: "disabled until reviewed",
           mcpServer: {
-            id: "hermes-filesystem",
+            id: "openclaw-filesystem",
             name: "filesystem",
             transport: "stdio",
             command: "node",
@@ -224,38 +463,63 @@ describe("setup import apply", () => {
             enabled: false,
           },
         },
+        {
+          id: "openclaw:telegram:config.json",
+          source: "openclaw",
+          sourceLabel: "OpenClaw",
+          kind: "telegram",
+          label: "bot token / 2 allowed user(s)",
+          decision: "import",
+          reason: "Telegram bot and allowed-user defaults",
+          telegramSettings: {
+            botToken: "123456:token",
+            allowedUserIds: [111, 222],
+          },
+        },
       ],
     };
 
     const { applySetupImportSelection } = await import("../commands/setup/import/apply.js");
     const report = await applySetupImportSelection(baseDir, selection);
 
-    expect(fs.existsSync(path.join(baseDir, "skills", "imported", "hermes", "review", "SKILL.md"))).toBe(true);
-    expect(fs.existsSync(path.join(baseDir, "plugins-imported-disabled", "hermes", "notifier", "plugin.json"))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, "skills", "imported", "openclaw", "review", "SKILL.md"))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, "plugins-imported-disabled", "openclaw", "notifier", "plugin.json"))).toBe(true);
 
     const mcp = JSON.parse(
       await fsp.readFile(path.join(baseDir, "mcp-servers.json"), "utf-8")
     ) as { servers: Array<{ id: string; enabled: boolean }> };
     expect(mcp.servers).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: "hermes-filesystem", enabled: true }),
-        expect.objectContaining({ id: "hermes-filesystem-2", enabled: false }),
+        expect.objectContaining({ id: "openclaw-filesystem", enabled: true }),
+        expect.objectContaining({ id: "openclaw-filesystem-2", enabled: false }),
       ])
     );
-    expect(report.items.filter((item) => item.status === "applied")).toHaveLength(3);
+    expect(report.items.filter((item) => item.status === "applied")).toHaveLength(4);
     expect(report.items.find((item) => item.kind === "plugin")?.pluginCompatibility?.status).toBe("quarantined");
-    const reportRoots = await fsp.readdir(path.join(baseDir, "imports", "hermes"));
+    const telegramConfig = JSON.parse(
+      await fsp.readFile(path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"), "utf-8")
+    ) as Record<string, unknown>;
+    expect(telegramConfig).toMatchObject({
+      bot_token: "123456:token",
+      allowed_user_ids: [111, 222],
+      runtime_control_allowed_user_ids: [111, 222],
+      allow_all: false,
+      polling_timeout: 30,
+    });
+
+    const reportRoots = await fsp.readdir(path.join(baseDir, "imports", "openclaw"));
     expect(reportRoots).toHaveLength(1);
-    expect(fs.existsSync(path.join(baseDir, "imports", "hermes", reportRoots[0]!, "report.json"))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, "imports", "openclaw", reportRoots[0]!, "report.json"))).toBe(true);
   });
 });
 
 describe("setup import flow", () => {
   it("does not prompt when no import sources are detected", async () => {
     vi.resetModules();
-    const selectMock = vi.fn();
+    const confirmMock = vi.fn();
     vi.doMock("@clack/prompts", () => ({
-      select: selectMock,
+      confirm: confirmMock,
+      select: vi.fn(),
       note: vi.fn(),
       multiselect: vi.fn(),
       log: { info: vi.fn() },
@@ -267,13 +531,14 @@ describe("setup import flow", () => {
 
     const { stepSetupImport } = await import("../commands/setup/import/flow.js");
     await expect(stepSetupImport()).resolves.toBeUndefined();
-    expect(selectMock).not.toHaveBeenCalled();
+    expect(confirmMock).not.toHaveBeenCalled();
   });
 
-  it("imports all items from the detected Hermes source without a second item-selection prompt", async () => {
+  it("asks which source to import from when Hermes and OpenClaw are both detected", async () => {
     vi.resetModules();
-    const selectMock = vi.fn().mockResolvedValueOnce("hermes");
-    const multiselectMock = vi.fn();
+    const confirmMock = vi.fn(async () => true);
+    const selectMock = vi.fn().mockResolvedValueOnce("openclaw");
+    const logInfoMock = vi.fn();
     const sources: SetupImportSource[] = [
       {
         id: "hermes",
@@ -292,23 +557,121 @@ describe("setup import flow", () => {
               provider: "openai",
               model: "gpt-5.4-mini",
               adapter: "agent_loop",
+              apiKey: "sk-hermes",
             },
           },
+        ],
+      },
+      {
+        id: "openclaw",
+        label: "OpenClaw",
+        rootDir: "/tmp/openclaw",
+        items: [
           {
-            id: "hermes-skill",
-            source: "hermes",
-            sourceLabel: "Hermes Agent",
-            kind: "skill",
-            label: "review",
+            id: "openclaw-provider",
+            source: "openclaw",
+            sourceLabel: "OpenClaw",
+            kind: "provider",
+            label: "anthropic / claude-sonnet-4-6 / agent_loop",
             decision: "import",
-            reason: "SKILL.md found",
-            sourcePath: "/tmp/hermes/skills/review",
+            reason: "provider defaults",
+            providerSettings: {
+              provider: "anthropic",
+              model: "claude-sonnet-4-6",
+              adapter: "agent_loop",
+              apiKey: "sk-openclaw",
+            },
           },
         ],
       },
     ];
 
     vi.doMock("@clack/prompts", () => ({
+      confirm: confirmMock,
+      select: selectMock,
+      note: vi.fn(),
+      multiselect: vi.fn(),
+      log: { info: logInfoMock },
+      isCancel: vi.fn(() => false),
+    }));
+    vi.doMock("../commands/setup/import/discovery.js", () => ({
+      detectSetupImportSources: () => sources,
+    }));
+
+    const { stepSetupImport } = await import("../commands/setup/import/flow.js");
+    const selection = await stepSetupImport();
+
+    expect(selection?.providerSettings).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      adapter: "agent_loop",
+      apiKey: "sk-openclaw",
+    });
+    expect(selection?.sources.map((source) => source.id)).toEqual(["openclaw"]);
+    expect(selection?.items.find((item) => item.id === "hermes-provider")).toBeUndefined();
+    expect(selection?.items.find((item) => item.id === "openclaw-provider")?.decision).toBe("import");
+    expect(selectMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        message: "Found existing settings!",
+        options: expect.arrayContaining([
+          expect.objectContaining({ label: "Migrate Hermes Agent settings" }),
+          expect.objectContaining({ label: "Migrate OpenClaw settings" }),
+          expect.objectContaining({ label: "Do not migrate" }),
+        ]),
+      })
+    );
+    const firstPrompt = selectMock.mock.calls[0]?.[0] as { options: Array<{ label: string }> };
+    expect(firstPrompt.options.map((option) => option.label)).toEqual([
+      "Migrate OpenClaw settings",
+      "Migrate Hermes Agent settings",
+      "Do not migrate",
+    ]);
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(confirmMock).not.toHaveBeenCalled();
+  });
+
+  it("imports all items from the selected source without a second item-selection prompt", async () => {
+    vi.resetModules();
+    const confirmMock = vi.fn(async () => true);
+    const selectMock = vi.fn().mockResolvedValueOnce("openclaw");
+    const multiselectMock = vi.fn(async () => ["openclaw-skill"]);
+    const sources: SetupImportSource[] = [
+      {
+        id: "openclaw",
+        label: "OpenClaw",
+        rootDir: "/tmp/openclaw",
+        items: [
+          {
+            id: "openclaw-provider",
+            source: "openclaw",
+            sourceLabel: "OpenClaw",
+            kind: "provider",
+            label: "openai / gpt-5.4-mini / agent_loop",
+            decision: "import",
+            reason: "provider defaults",
+            providerSettings: {
+              provider: "openai",
+              model: "gpt-5.4-mini",
+              adapter: "agent_loop",
+            },
+          },
+          {
+            id: "openclaw-skill",
+            source: "openclaw",
+            sourceLabel: "OpenClaw",
+            kind: "skill",
+            label: "review",
+            decision: "import",
+            reason: "SKILL.md found",
+            sourcePath: "/tmp/openclaw/skills/review",
+          },
+        ],
+      },
+    ];
+
+    vi.doMock("@clack/prompts", () => ({
+      confirm: confirmMock,
       select: selectMock,
       note: vi.fn(),
       multiselect: multiselectMock,
@@ -327,10 +690,10 @@ describe("setup import flow", () => {
       model: "gpt-5.4-mini",
       adapter: "agent_loop",
     });
-    expect(selection?.sources.map((source) => source.id)).toEqual(["hermes"]);
-    expect(selection?.items.find((item) => item.id === "hermes-provider")?.decision).toBe("import");
-    expect(selection?.items.find((item) => item.id === "hermes-skill")?.decision).toBe("import");
+    expect(selection?.items.find((item) => item.id === "openclaw-provider")?.decision).toBe("import");
+    expect(selection?.items.find((item) => item.id === "openclaw-skill")?.decision).toBe("import");
     expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(confirmMock).not.toHaveBeenCalled();
     expect(multiselectMock).not.toHaveBeenCalled();
   });
 });

--- a/src/interface/cli/__tests__/telegram-setup.test.ts
+++ b/src/interface/cli/__tests__/telegram-setup.test.ts
@@ -55,11 +55,12 @@ describe("cmdTelegramSetup", () => {
     expect(fetchMock).toHaveBeenCalledWith("https://api.telegram.org/bottest-token/getMe");
     expect(readlineState.close).toHaveBeenCalledTimes(1);
 
-    const configPath = path.join(tmpDir, "plugins", "telegram-bot", "config.json");
+    const configPath = path.join(tmpDir, "gateway", "channels", "telegram-bot", "config.json");
     const config = JSON.parse(await fsp.readFile(configPath, "utf-8")) as Record<string, unknown>;
     expect(config).toMatchObject({
       bot_token: "test-token",
       allowed_user_ids: [777, 888],
+      allow_all: false,
       polling_timeout: 30,
       identity_key: "personal",
     });

--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -40,6 +40,7 @@ import { cmdDoctor } from "./commands/doctor.js";
 import { cmdLogs } from "./commands/logs.js";
 import { cmdInstall, cmdUninstall } from "./commands/install.js";
 import { cmdNotify } from "./commands/notify.js";
+import { cmdGateway } from "./commands/gateway.js";
 import { cmdTelegramSetup } from "./commands/telegram.js";
 import { cmdSchedule } from "./commands/schedule.js";
 import { cmdSkills } from "./commands/skills.js";
@@ -537,6 +538,10 @@ export async function dispatchCommand(
 
   if (subcommand === "notify") {
     return await cmdNotify(argv.slice(1));
+  }
+
+  if (subcommand === "gateway") {
+    return await cmdGateway(argv.slice(1));
   }
 
   if (subcommand === "telegram") {

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -15,7 +15,11 @@ import { Logger } from "../../../runtime/logger.js";
 import { DaemonRunner } from "../../../runtime/daemon/runner.js";
 import { PIDManager } from "../../../runtime/pid-manager.js";
 import { EventServer } from "../../../runtime/event/server.js";
-import { IngressGateway, SlackChannelAdapter } from "../../../runtime/gateway/index.js";
+import {
+  IngressGateway,
+  SlackChannelAdapter,
+  loadBuiltinGatewayIntegrations,
+} from "../../../runtime/gateway/index.js";
 import { CronScheduler } from "../../../runtime/cron-scheduler.js";
 import { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import { RuntimeWatchdog } from "../../../runtime/watchdog.js";
@@ -322,6 +326,13 @@ export async function cmdStart(
     logger
   );
   const gateway = new IngressGateway(logger);
+  const builtinGatewayIntegrations = await loadBuiltinGatewayIntegrations(daemonBaseDir, logger);
+  for (const adapter of builtinGatewayIntegrations.adapters) {
+    gateway.registerAdapter(adapter);
+  }
+  for (const { name, notifier } of builtinGatewayIntegrations.notifiers) {
+    notifierRegistry.register(name, notifier);
+  }
   const slackGatewayConfig = resolvedDaemonConfig.gateway.slack;
   if (slackGatewayConfig.enabled) {
     if (!slackGatewayConfig.signing_secret) {

--- a/src/interface/cli/commands/gateway.ts
+++ b/src/interface/cli/commands/gateway.ts
@@ -1,0 +1,129 @@
+import * as p from "@clack/prompts";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawn } from "node:child_process";
+import { getPulseedDirPath } from "../../../base/utils/paths.js";
+import { isDaemonRunning } from "../../../runtime/daemon/client.js";
+import { PIDManager } from "../../../runtime/pid-manager.js";
+import {
+  saveGatewayChannels,
+  stepGatewayChannels,
+} from "./setup/steps-gateway.js";
+import { guardCancel } from "./setup/utils.js";
+
+export async function cmdGateway(argv: string[]): Promise<number> {
+  const subcommand = argv[0];
+  if (subcommand === "setup") {
+    return cmdGatewaySetup(argv.slice(1));
+  }
+
+  console.error(`Unknown gateway subcommand: "${subcommand ?? ""}"`);
+  console.error("Available: gateway setup");
+  return 1;
+}
+
+export async function cmdGatewaySetup(_argv: string[]): Promise<number> {
+  const baseDir = getPulseedDirPath();
+  p.intro("PulSeed Gateway Setup");
+
+  const setup = await stepGatewayChannels(baseDir);
+  if (!setup) {
+    p.outro("No gateway changes made.");
+    return 0;
+  }
+
+  const savedPaths = await saveGatewayChannels(baseDir, setup);
+  p.note(setup.selectedChannels.join(", "), "Updated channels");
+  if (savedPaths.length > 0) {
+    p.log.info(`Saved ${savedPaths.length} gateway config file${savedPaths.length === 1 ? "" : "s"}.`);
+  }
+
+  await maybeRestartDaemonForGatewayChanges(baseDir);
+  p.outro("Gateway setup complete.");
+  return 0;
+}
+
+async function maybeRestartDaemonForGatewayChanges(baseDir: string): Promise<void> {
+  const daemonConfigPath = path.join(baseDir, "daemon.json");
+  const { running } = await isDaemonRunning(baseDir);
+  if (running) {
+    const restart = guardCancel(
+      await p.confirm({
+        message: "Restart the daemon now to apply gateway changes?",
+        initialValue: true,
+      })
+    );
+    if (!restart) return;
+    await restartDaemon(baseDir);
+    return;
+  }
+
+  if (!fs.existsSync(daemonConfigPath)) {
+    p.log.info("Gateway configs were saved. Run `pulseed setup` or `pulseed daemon start` when you are ready.");
+    return;
+  }
+
+  const start = guardCancel(
+    await p.confirm({
+      message: "Start the daemon now so the gateway comes online?",
+      initialValue: true,
+    })
+  );
+  if (!start) return;
+  await startDaemon(baseDir);
+}
+
+async function restartDaemon(baseDir: string): Promise<void> {
+  const pidManager = new PIDManager(baseDir);
+  const stopResult = await pidManager.stopRuntime({ timeoutMs: 10_000 });
+  if (!stopResult.stopped) {
+    p.log.warn("Could not stop the existing daemon cleanly. Continuing with a fresh start attempt.");
+  }
+  await startDaemon(baseDir);
+}
+
+async function startDaemon(baseDir: string): Promise<void> {
+  p.log.info("Starting daemon and gateway...");
+  const pid = await startDaemonDetached(baseDir);
+  try {
+    await waitForDaemonReady(baseDir);
+    p.log.success(`Daemon and gateway started${pid ? ` (PID: ${pid})` : ""}.`);
+  } catch (err) {
+    p.log.warn(
+      `Gateway config saved, but daemon/gateway did not become ready: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+
+async function startDaemonDetached(baseDir: string): Promise<number | undefined> {
+  const scriptPath = process.argv[1];
+  if (!scriptPath) {
+    throw new Error("Could not determine CLI entrypoint for daemon start.");
+  }
+
+  const child = spawn(process.execPath, [scriptPath, "daemon", "start", "--detach"], {
+    detached: true,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      PULSEED_HOME: baseDir,
+    },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("spawn", resolve);
+  });
+  child.unref();
+  return child.pid;
+}
+
+async function waitForDaemonReady(baseDir: string, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { running } = await isDaemonRunning(baseDir);
+    if (running) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Daemon did not respond within ${timeoutMs}ms.`);
+}

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -2,6 +2,7 @@ import * as p from "@clack/prompts";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { spawn } from "node:child_process";
+import { getPulseedDirPath } from "../../../base/utils/paths.js";
 import {
   loadProviderConfig,
   saveProviderConfig,
@@ -18,6 +19,12 @@ import type { Provider } from "./setup-shared.js";
 import { getBanner, stepExistingConfig, stepUserName, stepSeedyName } from "./setup/steps-identity.js";
 import { stepRootPreset, stepProvider, stepModel, stepApiKey, runCodexOAuthLogin, stepOpenAIAuthMethod } from "./setup/steps-provider.js";
 import { stepNotification } from "./setup/steps-notification.js";
+import {
+  formatGatewaySetupSummary,
+  saveGatewayChannels,
+  stepGatewayChannels,
+  type GatewaySetupResult,
+} from "./setup/steps-gateway.js";
 import { stepDaemon, ensurePulseedDir, writeSeedMd, writeRootMd, writeUserMd } from "./setup/steps-runtime.js";
 import { guardCancel } from "./setup/utils.js";
 import { applySetupImportSelection } from "./setup/import/apply.js";
@@ -36,11 +43,12 @@ type SetupAnswers = {
   startDaemon: boolean;
   daemonPort: number;
   notificationConfig: Awaited<ReturnType<typeof stepNotification>>;
+  gatewaySetup: GatewaySetupResult | null;
 };
 
 type IdentityAnswers = Pick<SetupAnswers, "userName" | "agentName" | "rootPreset">;
 type ExecutionAnswers = Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">;
-type RuntimeAnswers = Pick<SetupAnswers, "startDaemon" | "daemonPort" | "notificationConfig">;
+type RuntimeAnswers = Pick<SetupAnswers, "startDaemon" | "daemonPort" | "notificationConfig" | "gatewaySetup">;
 type FullSetupSection = "identity" | "execution" | "runtime" | "review";
 type IdentityConfigOptions = {
   skipRootPreset?: boolean;
@@ -63,6 +71,7 @@ function formatSummary(answers: SetupAnswers): string {
     formatAuthSummary(answers),
     formatCredentialSummary(answers),
     `Daemon:    ${answers.startDaemon ? `configured (port ${answers.daemonPort})` : "not configured"}`,
+    `Gateway:   ${formatGatewaySetupSummary(answers.gatewaySetup)}`,
     `Notify:    ${notificationChannels}`,
   ].join("\n");
 }
@@ -153,6 +162,7 @@ function buildProviderConfig(
 
   if (base?.provider && base.provider !== execution.provider) {
     delete config.base_url;
+    delete config.openclaw;
   }
 
   return config;
@@ -355,9 +365,11 @@ async function stepIdentityConfig(
 
 async function stepRuntimeConfig(): Promise<RuntimeAnswers> {
   const daemonConfig = await stepDaemon();
+  const gatewaySetup = await stepGatewayChannels(getPulseedDirPath());
   return {
     startDaemon: daemonConfig.start,
     daemonPort: daemonConfig.port,
+    gatewaySetup,
     notificationConfig: await stepNotification(),
   };
 }
@@ -577,6 +589,7 @@ export async function runSetupWizard(): Promise<number> {
     startDaemon: false,
     daemonPort: 0,
     notificationConfig: null,
+    gatewaySetup: null,
   };
   const skipImportedExecution =
     Boolean(importSelection) && (await importedExecutionIsComplete(answers, importedProviderPatch));
@@ -714,6 +727,14 @@ export async function runSetupWizard(): Promise<number> {
       fs.writeFileSync(notifPath, JSON.stringify(finalAnswers.notificationConfig, null, 2));
     } catch (err) {
       p.log.warn(`Setup saved, but could not save notification config: ${err}`);
+    }
+  }
+
+  if (finalAnswers.gatewaySetup) {
+    try {
+      await saveGatewayChannels(dir, finalAnswers.gatewaySetup);
+    } catch (err) {
+      p.log.warn(`Setup saved, but could not save gateway channel config: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
 

--- a/src/interface/cli/commands/setup/import/apply.ts
+++ b/src/interface/cli/commands/setup/import/apply.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import * as fsp from "node:fs/promises";
 import { readJsonFileOrNull, writeJsonFileAtomic } from "../../../../../base/utils/json-io.js";
 import type { MCPServerConfig, MCPServersConfig } from "../../../../../base/types/mcp.js";
+import { getGatewayChannelDir } from "../../../../../base/utils/paths.js";
 import { copyDirectoryNoSymlinks, safeImportName, uniqueImportPath } from "./fs-utils.js";
 import type {
   SetupImportAppliedItem,
@@ -10,7 +11,7 @@ import type {
   SetupImportSelection,
 } from "./types.js";
 
-interface TelegramPluginConfig {
+interface TelegramGatewayConfig {
   bot_token?: string;
   chat_id?: number;
   allowed_user_ids?: number[];
@@ -117,41 +118,12 @@ function reportItem(item: SetupImportItem, status: SetupImportAppliedItem["statu
   };
 }
 
-async function copyTelegramPluginYaml(pluginDir: string): Promise<void> {
-  const destYaml = path.join(pluginDir, "plugin.yaml");
-  const minimal = [
-    "name: telegram-bot",
-    "version: 1.0.0",
-    "type: notifier",
-    "capabilities:",
-    "  - telegram_notification",
-    "  - bidirectional_chat",
-    "description: \"Telegram bot plugin for PulSeed\"",
-    "config_schema:",
-    "  bot_token:",
-    "    type: string",
-    "    required: true",
-    "  chat_id:",
-    "    type: number",
-    "    required: false",
-    "entry_point: \"dist/index.js\"",
-    "permissions:",
-    "  network: true",
-  ].join("\n") + "\n";
-  await fsp.mkdir(pluginDir, { recursive: true });
-  try {
-    await fsp.access(destYaml);
-  } catch {
-    await fsp.writeFile(destYaml, minimal, "utf-8");
-  }
-}
-
 async function applyTelegramConfig(baseDir: string, items: SetupImportItem[]): Promise<string | undefined> {
   const selected = items.filter((item) => item.kind === "telegram" && item.telegramSettings);
   if (selected.length === 0) return undefined;
-  const pluginDir = path.join(baseDir, "plugins", "telegram-bot");
-  const configPath = path.join(pluginDir, "config.json");
-  const current = await readJsonFileOrNull<TelegramPluginConfig>(configPath);
+  const channelDir = getGatewayChannelDir("telegram-bot", baseDir);
+  const configPath = path.join(channelDir, "config.json");
+  const current = await readJsonFileOrNull<TelegramGatewayConfig>(configPath);
   const allowed = new Set<number>(current?.allowed_user_ids ?? []);
   const runtimeAllowed = new Set<number>(current?.runtime_control_allowed_user_ids ?? []);
   let botToken = current?.bot_token;
@@ -164,7 +136,7 @@ async function applyTelegramConfig(baseDir: string, items: SetupImportItem[]): P
     }
   }
 
-  const config: TelegramPluginConfig = {
+  const config: TelegramGatewayConfig = {
     ...(current ?? {}),
     ...(botToken ? { bot_token: botToken } : {}),
     allowed_user_ids: [...allowed],
@@ -172,8 +144,8 @@ async function applyTelegramConfig(baseDir: string, items: SetupImportItem[]): P
     allow_all: current?.allow_all ?? false,
     polling_timeout: current?.polling_timeout ?? 30,
   };
+  await fsp.mkdir(channelDir, { recursive: true });
   await writeJsonFileAtomic(configPath, config);
-  await copyTelegramPluginYaml(pluginDir);
   return configPath;
 }
 
@@ -191,7 +163,7 @@ export async function applySetupImportSelection(
       } else if (item.kind === "user") {
         applied.push(reportItem(item, "applied", "USER.md seeded into setup identity"));
       } else if (item.kind === "telegram") {
-        applied.push(reportItem(item, "applied", "telegram settings seeded into plugin config"));
+        applied.push(reportItem(item, "applied", "telegram settings seeded into gateway channel config"));
       } else if (item.kind === "skill" || item.kind === "plugin") {
         applied.push(await applyFileItem(baseDir, item));
       }

--- a/src/interface/cli/commands/setup/import/constants.ts
+++ b/src/interface/cli/commands/setup/import/constants.ts
@@ -2,6 +2,7 @@ import type { SetupImportSourceId } from "./types.js";
 
 export const SOURCE_LABELS: Record<SetupImportSourceId, string> = {
   hermes: "Hermes Agent",
+  openclaw: "OpenClaw",
 };
 
 export const CONFIG_FILENAMES = [
@@ -11,6 +12,8 @@ export const CONFIG_FILENAMES = [
   "config.yml",
   "settings.json",
   "agent.json",
+  "openclaw.json",
+  "openclaw.config.json",
   "clawdbot.json",
   "moltbot.json",
   "hermes.config.json",

--- a/src/interface/cli/commands/setup/import/discovery.ts
+++ b/src/interface/cli/commands/setup/import/discovery.ts
@@ -37,7 +37,7 @@ function workspaceRoots(rootDir: string): string[] {
   ]);
 }
 
-function findSkillDirs(_source: SetupImportSourceId, rootDir: string): string[] {
+function findSkillDirs(source: SetupImportSourceId, rootDir: string): string[] {
   const roots = unique([
     path.join(rootDir, "skills"),
     path.join(rootDir, "agent", "skills"),
@@ -71,16 +71,28 @@ function findPluginDirs(rootDir: string): string[] {
   return unique(candidates);
 }
 
-function sourceRoots(_source: SetupImportSourceId): string[] {
+function sourceRoots(source: SetupImportSourceId): string[] {
   const home = os.homedir();
-  return unique([
-    process.env["PULSEED_IMPORT_HERMES_HOME"] ?? "",
-    process.env["PULSEED_HERMES_HOME"] ?? "",
-    process.env["HERMES_HOME"] ?? "",
-    path.join(home, ".hermes"),
-    path.join(home, ".hermes-agent"),
-    path.join(home, "Library", "Application Support", "Hermes Agent"),
-  ].filter(Boolean));
+  if (source === "hermes") {
+    return unique([
+      process.env["PULSEED_IMPORT_HERMES_HOME"] ?? "",
+      process.env["PULSEED_HERMES_HOME"] ?? "",
+      process.env["HERMES_HOME"] ?? "",
+      path.join(home, ".hermes"),
+      path.join(home, ".hermes-agent"),
+      path.join(home, "Library", "Application Support", "Hermes Agent"),
+    ].filter(Boolean));
+  }
+    return unique([
+      process.env["PULSEED_IMPORT_OPENCLAW_HOME"] ?? "",
+      process.env["PULSEED_OPENCLAW_HOME"] ?? "",
+      process.env["OPENCLAW_HOME"] ?? "",
+      path.join(home, ".openclaw"),
+      path.join(home, ".clawdbot"),
+      path.join(home, ".moltbot"),
+      path.join(home, ".config", "openclaw"),
+      path.join(home, "Library", "Application Support", "OpenClaw"),
+    ].filter(Boolean));
 }
 
 function providerItems(source: SetupImportSourceId, rootDir: string): SetupImportItem[] {
@@ -247,7 +259,7 @@ function detectSource(source: SetupImportSourceId): SetupImportSource | undefine
 }
 
 export function detectSetupImportSources(): SetupImportSource[] {
-  return (["hermes"] as const).flatMap((source) => {
+  return (["hermes", "openclaw"] as const).flatMap((source) => {
     const detected = detectSource(source);
     return detected ? [detected] : [];
   });

--- a/src/interface/cli/commands/setup/import/flow.ts
+++ b/src/interface/cli/commands/setup/import/flow.ts
@@ -91,6 +91,7 @@ function defaultProviderConfigFromImport(
     ...(settings.apiKey ? { api_key: settings.apiKey } : {}),
     ...(settings.baseUrl ? { base_url: settings.baseUrl } : {}),
     ...(settings.codexCliPath ? { codex_cli_path: settings.codexCliPath } : {}),
+    ...(settings.openclaw ? { openclaw: settings.openclaw } : {}),
   };
 }
 
@@ -104,7 +105,10 @@ export async function stepSetupImport(): Promise<SetupImportSelection | undefine
   const detectedSources = detectSetupImportSources();
   if (detectedSources.length === 0) return undefined;
 
-  const choiceSources = [...detectedSources];
+  const choiceSources = [...detectedSources].sort((a, b) => {
+    const order: Record<SetupImportSource["id"], number> = { openclaw: 0, hermes: 1 };
+    return order[a.id] - order[b.id];
+  });
 
   p.note(sourceSummary(detectedSources), "Existing agent configs found");
   const sourceChoice = guardCancel(
@@ -113,7 +117,9 @@ export async function stepSetupImport(): Promise<SetupImportSelection | undefine
       options: [
         ...choiceSources.map((source) => ({
           value: source.id,
-          label: "Migrate Hermes Agent settings",
+          label: source.id === "hermes"
+            ? "Migrate Hermes Agent settings"
+            : "Migrate OpenClaw settings",
           hint: source.rootDir,
         })),
         {

--- a/src/interface/cli/commands/setup/import/types.ts
+++ b/src/interface/cli/commands/setup/import/types.ts
@@ -2,7 +2,7 @@ import type { ProviderConfig } from "../../../../../base/llm/provider-config.js"
 import type { MCPServerConfig } from "../../../../../base/types/mcp.js";
 import type { ForeignPluginCompatibilityReport } from "../../../../../runtime/foreign-plugins/types.js";
 
-export type SetupImportSourceId = "hermes";
+export type SetupImportSourceId = "hermes" | "openclaw";
 
 export type SetupImportItemKind = "provider" | "user" | "skill" | "mcp" | "plugin" | "telegram";
 
@@ -15,6 +15,7 @@ export interface SetupImportProviderSettings {
   apiKey?: string;
   baseUrl?: string;
   codexCliPath?: string;
+  openclaw?: ProviderConfig["openclaw"];
 }
 
 export interface SetupImportTelegramSettings {

--- a/src/interface/cli/commands/setup/steps-gateway.ts
+++ b/src/interface/cli/commands/setup/steps-gateway.ts
@@ -1,0 +1,448 @@
+import * as p from "@clack/prompts";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../../../../base/utils/json-io.js";
+import { getGatewayChannelDir } from "../../../../base/utils/paths.js";
+import {
+  BUILTIN_GATEWAY_CHANNEL_NAMES,
+  type BuiltinGatewayChannelName,
+} from "../../../../runtime/gateway/builtin-channel-names.js";
+import type { TelegramGatewayConfig } from "../../../../runtime/gateway/telegram-gateway-adapter.js";
+import type { DiscordGatewayConfig } from "../../../../runtime/gateway/discord-gateway-adapter.js";
+import type { WhatsAppGatewayConfig } from "../../../../runtime/gateway/whatsapp-gateway-adapter.js";
+import type { SignalGatewayConfig } from "../../../../runtime/gateway/signal-gateway-adapter.js";
+import { guardCancel } from "./utils.js";
+
+interface TelegramVerifyResponse {
+  ok: boolean;
+  result?: {
+    id: number;
+    username?: string;
+    first_name: string;
+  };
+}
+
+export interface GatewayChannelConfigs {
+  "telegram-bot"?: TelegramGatewayConfig;
+  "discord-bot"?: DiscordGatewayConfig;
+  "whatsapp-webhook"?: WhatsAppGatewayConfig;
+  "signal-bridge"?: SignalGatewayConfig;
+}
+
+export interface GatewaySetupResult {
+  selectedChannels: BuiltinGatewayChannelName[];
+  channelConfigs: GatewayChannelConfigs;
+}
+
+export async function stepGatewayChannels(baseDir: string): Promise<GatewaySetupResult | null> {
+  const existingSummary = await summarizeExistingGatewayChannels(baseDir);
+  p.note(formatExistingGatewaySummary(existingSummary), "Configured messaging channels");
+
+  const selectedChannels = guardCancel(
+    await p.multiselect<BuiltinGatewayChannelName>({
+      message: "Which messaging platforms should PulSeed configure now?",
+      required: false,
+      options: BUILTIN_GATEWAY_CHANNEL_NAMES.map((channelName) => ({
+        value: channelName,
+        label: gatewayChannelLabel(channelName),
+        hint: existingSummary[channelName],
+      })),
+    })
+  );
+
+  if (selectedChannels.length === 0) {
+    return null;
+  }
+
+  const channelConfigs: GatewayChannelConfigs = {};
+
+  for (const channelName of selectedChannels) {
+    switch (channelName) {
+      case "telegram-bot":
+        channelConfigs["telegram-bot"] = await promptTelegramChannelConfig(baseDir);
+        break;
+      case "discord-bot":
+        channelConfigs["discord-bot"] = await promptDiscordChannelConfig(baseDir);
+        break;
+      case "whatsapp-webhook":
+        channelConfigs["whatsapp-webhook"] = await promptWhatsAppChannelConfig(baseDir);
+        break;
+      case "signal-bridge":
+        channelConfigs["signal-bridge"] = await promptSignalChannelConfig(baseDir);
+        break;
+    }
+  }
+
+  return { selectedChannels, channelConfigs };
+}
+
+export async function saveGatewayChannels(baseDir: string, setup: GatewaySetupResult): Promise<string[]> {
+  const savedPaths: string[] = [];
+
+  for (const channelName of setup.selectedChannels) {
+    const config = setup.channelConfigs[channelName];
+    if (!config) continue;
+    const configPath = path.join(getGatewayChannelDir(channelName, baseDir), "config.json");
+    await fs.mkdir(path.dirname(configPath), { recursive: true });
+    await writeJsonFileAtomic(configPath, config);
+    savedPaths.push(configPath);
+  }
+
+  return savedPaths;
+}
+
+export function formatGatewaySetupSummary(setup: GatewaySetupResult | null | undefined): string {
+  if (!setup || setup.selectedChannels.length === 0) {
+    return "none";
+  }
+  return setup.selectedChannels.map(gatewayChannelLabel).join(", ");
+}
+
+async function summarizeExistingGatewayChannels(baseDir: string): Promise<Record<BuiltinGatewayChannelName, string>> {
+  const entries = await Promise.all(
+    BUILTIN_GATEWAY_CHANNEL_NAMES.map(async (channelName) => {
+      const config = await readJsonFileOrNull<Record<string, unknown>>(path.join(getGatewayChannelDir(channelName, baseDir), "config.json"));
+      const summary = config ? summarizeChannelConfig(channelName, config) : "not configured";
+      return [channelName, summary] as const;
+    })
+  );
+  return Object.fromEntries(entries) as Record<BuiltinGatewayChannelName, string>;
+}
+
+function gatewayChannelLabel(channelName: BuiltinGatewayChannelName): string {
+  switch (channelName) {
+    case "telegram-bot":
+      return "Telegram";
+    case "discord-bot":
+      return "Discord";
+    case "whatsapp-webhook":
+      return "WhatsApp";
+    case "signal-bridge":
+      return "Signal";
+  }
+}
+
+function formatExistingGatewaySummary(summary: Record<BuiltinGatewayChannelName, string>): string {
+  return BUILTIN_GATEWAY_CHANNEL_NAMES
+    .map((channelName) => `${gatewayChannelLabel(channelName)}: ${summary[channelName]}`)
+    .join("\n");
+}
+
+function summarizeChannelConfig(channelName: BuiltinGatewayChannelName, config: Record<string, unknown>): string {
+  switch (channelName) {
+    case "telegram-bot":
+      return typeof config["bot_token"] === "string"
+        ? `configured (${typeof config["chat_id"] === "number" ? "home chat set" : "/sethome later"})`
+        : "not configured";
+    case "discord-bot":
+      return typeof config["application_id"] === "string"
+        ? `configured (${String(config["host"] ?? "127.0.0.1")}:${String(config["port"] ?? 8787)})`
+        : "not configured";
+    case "whatsapp-webhook":
+      return typeof config["phone_number_id"] === "string"
+        ? `configured (${String(config["host"] ?? "127.0.0.1")}:${String(config["port"] ?? 8788)}${String(config["path"] ?? "/webhook")})`
+        : "not configured";
+    case "signal-bridge":
+      return typeof config["bridge_url"] === "string"
+        ? `configured (${String(config["bridge_url"])})`
+        : "not configured";
+  }
+}
+
+async function promptTelegramChannelConfig(baseDir: string): Promise<TelegramGatewayConfig> {
+  p.note(
+    [
+      "Hermes-style Telegram onboarding:",
+      "1. Enter a bot token from @BotFather",
+      "2. Optionally restrict by Telegram user ID",
+      "3. Optionally defer the home chat and use /sethome later",
+    ].join("\n"),
+    "Telegram"
+  );
+
+  const configPath = path.join(getGatewayChannelDir("telegram-bot", baseDir), "config.json");
+  const current = await readJsonFileOrNull<TelegramGatewayConfig>(configPath);
+  const token = await promptTelegramBotToken(current?.bot_token);
+  const allowedUserIds = parseIntegerList(
+    guardCancel(
+      await p.text({
+        message: "Allowed Telegram user IDs (comma-separated, blank = allow all)",
+        placeholder: "123456789,987654321",
+        initialValue: current?.allowed_user_ids.join(",") ?? "",
+      })
+    )
+  );
+  const chatIdInput = guardCancel(
+    await p.text({
+      message: "Home chat ID (optional, blank = use /sethome later)",
+      placeholder: "-1001234567890",
+      initialValue: current?.chat_id !== undefined ? String(current.chat_id) : "",
+      validate: (value) => {
+        if (value === undefined) return "Chat ID is required.";
+        if (value.trim().length === 0) return undefined;
+        return Number.isInteger(Number(value)) ? undefined : "Chat ID must be an integer.";
+      },
+    })
+  );
+  const identityKey = guardCancel(
+    await p.text({
+      message: "Identity key (optional, same key shares a session across platforms)",
+      placeholder: "personal",
+      initialValue: current?.identity_key ?? "",
+    })
+  ).trim();
+
+  return {
+    bot_token: token,
+    ...(chatIdInput.trim().length > 0 ? { chat_id: Number(chatIdInput) } : {}),
+    allowed_user_ids: allowedUserIds,
+    denied_user_ids: current?.denied_user_ids ?? [],
+    allowed_chat_ids: current?.allowed_chat_ids ?? [],
+    denied_chat_ids: current?.denied_chat_ids ?? [],
+    runtime_control_allowed_user_ids: allowedUserIds,
+    chat_goal_map: current?.chat_goal_map ?? {},
+    user_goal_map: current?.user_goal_map ?? {},
+    default_goal_id: current?.default_goal_id,
+    allow_all: allowedUserIds.length === 0,
+    polling_timeout: current?.polling_timeout ?? 30,
+    ...(identityKey ? { identity_key: identityKey } : {}),
+  };
+}
+
+async function promptDiscordChannelConfig(baseDir: string): Promise<DiscordGatewayConfig> {
+  p.note(
+    [
+      "Hermes-style Discord flow, adapted to PulSeed's current adapter:",
+      "1. Create a Discord application and bot",
+      "2. Enable Message Content + Server Members intents",
+      "3. Point Discord interactions at the configured host/port through a tunnel or reverse proxy",
+    ].join("\n"),
+    "Discord"
+  );
+
+  const configPath = path.join(getGatewayChannelDir("discord-bot", baseDir), "config.json");
+  const current = await readJsonFileOrNull<DiscordGatewayConfig>(configPath);
+  const applicationId = await promptRequiredText("Discord application ID", current?.application_id);
+  const botToken = await promptRequiredText("Discord bot token", current?.bot_token);
+  const channelId = await promptRequiredText("Home channel ID for notifications", current?.channel_id);
+  const publicKeyHex = guardCancel(
+    await p.text({
+      message: "Discord public key (optional, recommended for request verification)",
+      placeholder: "hex string",
+      initialValue: current?.public_key_hex ?? "",
+    })
+  ).trim();
+  const allowedSenderIds = parseStringList(
+    guardCancel(
+      await p.text({
+        message: "Allowed Discord user IDs (comma-separated, blank = allow all)",
+        placeholder: "123456789012345678",
+        initialValue: current?.allowed_sender_ids.join(",") ?? "",
+      })
+    )
+  );
+  const identityKey = await promptRequiredText("Identity key", current?.identity_key ?? "personal");
+  const commandName = await promptRequiredText("Slash command name", current?.command_name ?? "pulseed");
+  const host = await promptRequiredText("Webhook bind host", current?.host ?? "127.0.0.1");
+  const port = await promptInteger("Webhook bind port", current?.port ?? 8787, 1024, 65535);
+  const ephemeral = guardCancel(
+    await p.confirm({
+      message: "Use ephemeral slash-command replies?",
+      initialValue: current?.ephemeral ?? false,
+    })
+  );
+
+  return {
+    application_id: applicationId,
+    ...(publicKeyHex ? { public_key_hex: publicKeyHex } : {}),
+    bot_token: botToken,
+    channel_id: channelId,
+    identity_key: identityKey,
+    allowed_sender_ids: allowedSenderIds,
+    denied_sender_ids: current?.denied_sender_ids ?? [],
+    allowed_conversation_ids: current?.allowed_conversation_ids ?? [],
+    denied_conversation_ids: current?.denied_conversation_ids ?? [],
+    runtime_control_allowed_sender_ids: allowedSenderIds,
+    conversation_goal_map: current?.conversation_goal_map ?? {},
+    sender_goal_map: current?.sender_goal_map ?? {},
+    default_goal_id: current?.default_goal_id,
+    command_name: commandName,
+    host,
+    port,
+    ephemeral,
+  };
+}
+
+async function promptWhatsAppChannelConfig(baseDir: string): Promise<WhatsAppGatewayConfig> {
+  p.note(
+    [
+      "PulSeed currently uses WhatsApp Cloud API webhook setup.",
+      "This differs from Hermes's Baileys bridge, but the setup flow stays centralized in one wizard.",
+    ].join("\n"),
+    "WhatsApp"
+  );
+
+  const configPath = path.join(getGatewayChannelDir("whatsapp-webhook", baseDir), "config.json");
+  const current = await readJsonFileOrNull<WhatsAppGatewayConfig>(configPath);
+  const phoneNumberId = await promptRequiredText("WhatsApp phone number ID", current?.phone_number_id);
+  const accessToken = await promptRequiredText("WhatsApp access token", current?.access_token);
+  const verifyToken = await promptRequiredText("WhatsApp verify token", current?.verify_token);
+  const recipientId = await promptRequiredText("Default recipient ID for notifications", current?.recipient_id);
+  const appSecret = guardCancel(
+    await p.text({
+      message: "Meta app secret (optional, enables webhook signature verification)",
+      initialValue: current?.app_secret ?? "",
+    })
+  ).trim();
+  const allowedSenderIds = parseStringList(
+    guardCancel(
+      await p.text({
+        message: "Allowed WhatsApp sender IDs (comma-separated, blank = allow all)",
+        placeholder: "15551234567",
+        initialValue: current?.allowed_sender_ids.join(",") ?? "",
+      })
+    )
+  );
+  const identityKey = await promptRequiredText("Identity key", current?.identity_key ?? "personal");
+  const host = await promptRequiredText("Webhook bind host", current?.host ?? "127.0.0.1");
+  const port = await promptInteger("Webhook bind port", current?.port ?? 8788, 1024, 65535);
+  const webhookPath = await promptRequiredText("Webhook path", current?.path ?? "/webhook");
+
+  return {
+    phone_number_id: phoneNumberId,
+    access_token: accessToken,
+    verify_token: verifyToken,
+    recipient_id: recipientId,
+    identity_key: identityKey,
+    allowed_sender_ids: allowedSenderIds,
+    denied_sender_ids: current?.denied_sender_ids ?? [],
+    runtime_control_allowed_sender_ids: allowedSenderIds,
+    sender_goal_map: current?.sender_goal_map ?? {},
+    default_goal_id: current?.default_goal_id,
+    host,
+    port,
+    path: webhookPath,
+    ...(appSecret ? { app_secret: appSecret } : {}),
+  };
+}
+
+async function promptSignalChannelConfig(baseDir: string): Promise<SignalGatewayConfig> {
+  p.note(
+    [
+      "Hermes-style Signal usage usually starts with a linked device and a local signal-cli daemon.",
+      "PulSeed expects a running bridge endpoint and will poll it for messages.",
+    ].join("\n"),
+    "Signal"
+  );
+
+  const configPath = path.join(getGatewayChannelDir("signal-bridge", baseDir), "config.json");
+  const current = await readJsonFileOrNull<SignalGatewayConfig>(configPath);
+  const bridgeUrl = await promptRequiredText("Signal bridge URL", current?.bridge_url ?? "http://127.0.0.1:8080");
+  const account = await promptRequiredText("Signal account number", current?.account);
+  const recipientId = await promptRequiredText("Default recipient ID", current?.recipient_id ?? account);
+  const allowedSenderIds = parseStringList(
+    guardCancel(
+      await p.text({
+        message: "Allowed Signal sender IDs (comma-separated, blank = allow all)",
+        placeholder: "+15551234567",
+        initialValue: current?.allowed_sender_ids.join(",") ?? "",
+      })
+    )
+  );
+  const allowedConversationIds = parseStringList(
+    guardCancel(
+      await p.text({
+        message: "Allowed Signal conversation IDs (optional)",
+        placeholder: "group-id-1,group-id-2",
+        initialValue: current?.allowed_conversation_ids.join(",") ?? "",
+      })
+    )
+  );
+  const identityKey = await promptRequiredText("Identity key", current?.identity_key ?? "personal");
+  const pollInterval = await promptInteger("Poll interval (ms)", current?.poll_interval_ms ?? 5000, 1000, 60000);
+  const receiveTimeout = await promptInteger("Receive timeout (ms)", current?.receive_timeout_ms ?? 2000, 250, 60000);
+
+  return {
+    bridge_url: bridgeUrl,
+    account,
+    recipient_id: recipientId,
+    identity_key: identityKey,
+    allowed_sender_ids: allowedSenderIds,
+    denied_sender_ids: current?.denied_sender_ids ?? [],
+    allowed_conversation_ids: allowedConversationIds,
+    denied_conversation_ids: current?.denied_conversation_ids ?? [],
+    runtime_control_allowed_sender_ids: allowedSenderIds,
+    conversation_goal_map: current?.conversation_goal_map ?? {},
+    sender_goal_map: current?.sender_goal_map ?? {},
+    default_goal_id: current?.default_goal_id,
+    poll_interval_ms: pollInterval,
+    receive_timeout_ms: receiveTimeout,
+  };
+}
+
+async function promptTelegramBotToken(initialToken?: string): Promise<string> {
+  for (;;) {
+    const token = guardCancel(
+      await p.text({
+        message: "Telegram bot token",
+        placeholder: "1234567890:AA...",
+        initialValue: initialToken,
+        validate: (value) => value !== undefined && value.trim().length > 0 ? undefined : "Bot token is required.",
+      })
+    ).trim();
+    try {
+      const response = await fetch(`https://api.telegram.org/bot${token}/getMe`);
+      const payload = (await response.json()) as TelegramVerifyResponse;
+      if (payload.ok && payload.result) {
+        const displayName = payload.result.username ?? payload.result.first_name;
+        p.log.success(`Verified Telegram bot @${displayName}`);
+        return token;
+      }
+    } catch {
+      // continue to retry
+    }
+    p.log.warn("Telegram token verification failed. Check the token and try again.");
+  }
+}
+
+async function promptRequiredText(message: string, initialValue?: string): Promise<string> {
+  return guardCancel(
+    await p.text({
+      message,
+      initialValue,
+      validate: (value) => value !== undefined && value.trim().length > 0 ? undefined : "This value is required.",
+    })
+  ).trim();
+}
+
+async function promptInteger(message: string, initialValue: number, min: number, max: number): Promise<number> {
+  const value = guardCancel(
+    await p.text({
+      message,
+      initialValue: String(initialValue),
+      validate: (raw) => {
+        const parsed = Number(raw);
+        if (!Number.isInteger(parsed)) return "Enter a whole number.";
+        if (parsed < min || parsed > max) return `Enter a value between ${min} and ${max}.`;
+        return undefined;
+      },
+    })
+  );
+  return Number(value);
+}
+
+function parseStringList(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function parseIntegerList(value: string): number[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .map((item) => Number(item))
+    .filter((item) => Number.isInteger(item));
+}

--- a/src/interface/cli/commands/telegram.ts
+++ b/src/interface/cli/commands/telegram.ts
@@ -1,19 +1,17 @@
-// ─── pulseed telegram setup — Telegram Bot plugin configuration wizard ───
+// ─── pulseed telegram setup — Telegram Bot gateway configuration wizard ───
 //
-// Guides the user through configuring the Telegram Bot plugin:
+// Guides the user through configuring the Telegram Bot gateway channel:
 //   1. Bot token (from @BotFather) — verified via getMe API
 //   2. allowed_user_ids (optional, comma-separated)
 //   3. home chat_id (optional) — can be set later by sending /sethome
 //   4. identity_key (optional) — share one PulSeed session across chat platforms
 //
-// Writes config to ~/.pulseed/plugins/telegram-bot/config.json
-// Copies plugin.yaml from the repo if available.
+// Writes config to ~/.pulseed/gateway/channels/telegram-bot/config.json
 
 import * as readline from "node:readline";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
-import { getPulseedDirPath } from "../../../base/utils/paths.js";
+import { getGatewayChannelDir } from "../../../base/utils/paths.js";
 
 // ─── Readline helpers ───
 
@@ -57,46 +55,14 @@ async function verifyBotToken(token: string): Promise<TelegramUser | null> {
   }
 }
 
-// ─── Plugin directory helpers ───
+// ─── Gateway channel directory helpers ───
 
-function getPluginDir(): string {
-  return path.join(getPulseedDirPath(), "plugins", "telegram-bot");
+function getChannelDir(): string {
+  return getGatewayChannelDir("telegram-bot");
 }
 
-async function ensurePluginDir(pluginDir: string): Promise<void> {
-  await fsp.mkdir(pluginDir, { recursive: true });
-}
-
-async function copyPluginYaml(pluginDir: string): Promise<void> {
-  // Resolve repo root relative to this compiled file (dist/cli/commands/telegram.js → project root)
-  const thisFile = fileURLToPath(import.meta.url);
-  const repoRoot = path.resolve(path.dirname(thisFile), "..", "..", "..", "..");
-  const repoYaml = path.join(repoRoot, "plugins", "telegram-bot", "plugin.yaml");
-
-  const destYaml = path.join(pluginDir, "plugin.yaml");
-
-  // Skip if already exists
-  try {
-    await fsp.access(destYaml);
-    return;
-  } catch {
-    // does not exist yet — proceed
-  }
-
-  try {
-    await fsp.copyFile(repoYaml, destYaml);
-  } catch {
-    // Write a minimal plugin.yaml as fallback
-    const minimal = [
-      "name: telegram-bot",
-      "version: 1.0.0",
-      'description: "Telegram Bot notifier plugin for PulSeed"',
-      "main: src/index.js",
-      "type: notifier",
-      "notifier_id: telegram",
-    ].join("\n") + "\n";
-    await fsp.writeFile(destYaml, minimal, "utf8");
-  }
+async function ensureChannelDir(channelDir: string): Promise<void> {
+  await fsp.mkdir(channelDir, { recursive: true });
 }
 
 // ─── Public entry point ───
@@ -145,7 +111,7 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
 
     // Step 3: home chat_id (optional)
     console.log("\nStep 3: Home chat (optional)");
-    console.log("  Leave empty now, then send /sethome to the bot from Telegram after the plugin is running.");
+    console.log("  Leave empty now, then send /sethome to the bot from Telegram after the daemon is running.");
     console.log("  Notifications will use that chat.\n");
 
     const chatIdStr = await ask(rl, "Home chat_id (number) or press Enter to set later with /sethome: ");
@@ -168,21 +134,20 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
     const identityKey = await ask(rl, "Identity key (e.g. personal) or press Enter to skip: ");
 
     // Step 5: Write config
-    const pluginDir = getPluginDir();
-    await ensurePluginDir(pluginDir);
+    const channelDir = getChannelDir();
+    await ensureChannelDir(channelDir);
 
     const config = {
       bot_token: token,
       allowed_user_ids: allowedUserIds,
+      allow_all: allowedUserIds.length === 0,
       polling_timeout: 30,
       ...(chatId !== undefined ? { chat_id: chatId } : {}),
       ...(identityKey ? { identity_key: identityKey } : {}),
     };
 
-    const configPath = path.join(pluginDir, "config.json");
+    const configPath = path.join(channelDir, "config.json");
     await fsp.writeFile(configPath, JSON.stringify(config, null, 2), "utf8");
-
-    await copyPluginYaml(pluginDir);
 
     // Summary
     console.log("\nTelegram Bot setup complete!");
@@ -199,7 +164,7 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
     } else {
       console.log("  Identity key: (not set)");
     }
-    console.log("\nRun 'pulseed plugin install' to activate the plugin.");
+    console.log("\nThe daemon will pick this up automatically as a built-in gateway channel.");
 
     return 0;
   } finally {

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -80,7 +80,8 @@ Usage:
   pulseed notify list                  List configured notification channels
   pulseed notify remove <index>        Remove a notification channel
   pulseed setup                        Interactive setup wizard (first-time configuration)
-  pulseed telegram setup               Configure Telegram Bot notification plugin
+  pulseed gateway setup                Configure messaging gateway channels
+  pulseed telegram setup               Configure the Telegram gateway channel
   pulseed provider show                Show current provider config
   pulseed provider set                 Set LLM provider and/or default adapter
 

--- a/src/runtime/foreign-plugins/types.ts
+++ b/src/runtime/foreign-plugins/types.ts
@@ -1,4 +1,4 @@
-export type ForeignPluginSource = "hermes";
+export type ForeignPluginSource = "hermes" | "openclaw";
 
 export type ForeignPluginCompatibilityStatus = "convertible" | "quarantined" | "incompatible";
 

--- a/src/runtime/gateway/__tests__/builtin-channel-integrations.test.ts
+++ b/src/runtime/gateway/__tests__/builtin-channel-integrations.test.ts
@@ -1,0 +1,125 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  BUILTIN_GATEWAY_CHANNEL_NAMES,
+  ensureBuiltinGatewayChannelLocations,
+  loadBuiltinGatewayIntegrations,
+} from "../builtin-channel-integrations.js";
+
+const tempDirs: string[] = [];
+
+describe("loadBuiltinGatewayIntegrations", () => {
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  it("loads built-in adapters and notifiers from legacy plugin config locations", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "pulseed-gateway-core-"));
+    tempDirs.push(baseDir);
+
+    await writePluginConfig(baseDir, "telegram-bot", {
+      bot_token: "token",
+      allowed_user_ids: [1],
+      denied_user_ids: [],
+      allowed_chat_ids: [],
+      denied_chat_ids: [],
+      runtime_control_allowed_user_ids: [],
+      chat_goal_map: {},
+      user_goal_map: {},
+      allow_all: true,
+      polling_timeout: 30,
+    });
+    await writePluginConfig(baseDir, "discord-bot", {
+      application_id: "app",
+      bot_token: "token",
+      channel_id: "channel",
+      identity_key: "identity",
+      allowed_sender_ids: [],
+      denied_sender_ids: [],
+      allowed_conversation_ids: [],
+      denied_conversation_ids: [],
+      runtime_control_allowed_sender_ids: [],
+      conversation_goal_map: {},
+      sender_goal_map: {},
+      command_name: "pulseed",
+      host: "127.0.0.1",
+      port: 8787,
+      ephemeral: false,
+    });
+
+    const loaded = await loadBuiltinGatewayIntegrations(baseDir);
+
+    expect(loaded.adapters.map((adapter) => adapter.name).sort()).toEqual(["discord", "telegram"]);
+    expect(loaded.notifiers.map((entry) => entry.name).sort()).toEqual(["discord-bot", "telegram-bot"]);
+    expect(
+      JSON.parse(
+        await fs.readFile(
+          path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"),
+          "utf-8"
+        )
+      )
+    ).toMatchObject({ bot_token: "token" });
+    expect(
+      await pathExists(path.join(baseDir, "plugins-promoted-to-core", "telegram-bot"))
+    ).toBe(true);
+    expect(await pathExists(path.join(baseDir, "plugins", "telegram-bot"))).toBe(false);
+  });
+
+  it("prefers canonical gateway channel config when present", async () => {
+    const baseDir = await fs.mkdtemp(path.join(os.tmpdir(), "pulseed-gateway-core-"));
+    tempDirs.push(baseDir);
+
+    await fs.mkdir(path.join(baseDir, "gateway", "channels", "signal-bridge"), { recursive: true });
+    await fs.writeFile(
+      path.join(baseDir, "gateway", "channels", "signal-bridge", "config.json"),
+      JSON.stringify({
+        bridge_url: "http://localhost:8080",
+        account: "+10000000000",
+        recipient_id: "+10000000001",
+        identity_key: "me",
+        allowed_sender_ids: [],
+        denied_sender_ids: [],
+        allowed_conversation_ids: [],
+        denied_conversation_ids: [],
+        runtime_control_allowed_sender_ids: [],
+        conversation_goal_map: {},
+        sender_goal_map: {},
+        poll_interval_ms: 5000,
+        receive_timeout_ms: 2000,
+      }, null, 2),
+      "utf-8"
+    );
+    await writePluginConfig(baseDir, "signal-bridge", { bridge_url: "legacy" });
+
+    const locations = await ensureBuiltinGatewayChannelLocations(baseDir);
+
+    expect(locations.find((entry) => entry.channelName === "signal-bridge")?.source).toBe("core");
+    expect(await pathExists(path.join(baseDir, "plugins", "signal-bridge", "config.json"))).toBe(true);
+  });
+
+  it("keeps the canonical channel name list", () => {
+    expect(BUILTIN_GATEWAY_CHANNEL_NAMES).toEqual([
+      "telegram-bot",
+      "whatsapp-webhook",
+      "signal-bridge",
+      "discord-bot",
+    ]);
+  });
+});
+
+async function writePluginConfig(baseDir: string, pluginName: string, config: Record<string, unknown>): Promise<void> {
+  const pluginDir = path.join(baseDir, "plugins", pluginName);
+  await fs.mkdir(pluginDir, { recursive: true });
+  await fs.writeFile(path.join(pluginDir, "config.json"), JSON.stringify(config, null, 2), "utf-8");
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/runtime/gateway/builtin-channel-integrations.ts
+++ b/src/runtime/gateway/builtin-channel-integrations.ts
@@ -1,0 +1,175 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import {
+  getGatewayChannelDir,
+  getGatewayChannelsDir,
+  getPluginsDir,
+  getPromotedPluginsDir,
+} from "../../base/utils/paths.js";
+import type { Logger } from "../logger.js";
+import type { INotifier } from "../../base/types/plugin.js";
+import type { ChannelAdapter } from "./channel-adapter.js";
+import { BUILTIN_GATEWAY_CHANNEL_NAMES } from "./builtin-channel-names.js";
+import { DiscordGatewayAdapter } from "./discord-gateway-adapter.js";
+import { SignalGatewayAdapter } from "./signal-gateway-adapter.js";
+import { TelegramGatewayAdapter } from "./telegram-gateway-adapter.js";
+import { WhatsAppGatewayAdapter } from "./whatsapp-gateway-adapter.js";
+
+export interface BuiltinGatewayIntegrations {
+  adapters: ChannelAdapter[];
+  notifiers: Array<{ name: string; notifier: INotifier }>;
+}
+
+export { BUILTIN_GATEWAY_CHANNEL_NAMES } from "./builtin-channel-names.js";
+
+export interface BuiltinGatewayChannelLocation {
+  channelName: string;
+  channelDir: string;
+  configPath: string;
+  source: "core" | "legacy-plugin";
+}
+
+export async function loadBuiltinGatewayIntegrations(
+  baseDir: string,
+  logger?: Logger
+): Promise<BuiltinGatewayIntegrations> {
+  const adapters: ChannelAdapter[] = [];
+  const notifiers: Array<{ name: string; notifier: INotifier }> = [];
+  const locations = await ensureBuiltinGatewayChannelLocations(baseDir, logger);
+
+  for (const location of locations) {
+    try {
+      switch (location.channelName) {
+        case "telegram-bot": {
+          const adapter = TelegramGatewayAdapter.fromConfigDir(location.channelDir);
+          adapters.push(adapter);
+          notifiers.push({ name: "telegram-bot", notifier: adapter.getNotifier() });
+          break;
+        }
+        case "whatsapp-webhook": {
+          const adapter = WhatsAppGatewayAdapter.fromConfigDir(location.channelDir);
+          adapters.push(adapter);
+          notifiers.push({ name: "whatsapp-webhook", notifier: adapter.getNotifier() });
+          break;
+        }
+        case "signal-bridge": {
+          const adapter = SignalGatewayAdapter.fromConfigDir(location.channelDir);
+          adapters.push(adapter);
+          notifiers.push({ name: "signal-bridge", notifier: adapter.getNotifier() });
+          break;
+        }
+        case "discord-bot": {
+          const adapter = DiscordGatewayAdapter.fromConfigDir(location.channelDir);
+          adapters.push(adapter);
+          notifiers.push({ name: "discord-bot", notifier: adapter.getNotifier() });
+          break;
+        }
+      }
+    } catch (err) {
+      logger?.warn(
+        `[daemon] built-in ${location.channelName} gateway disabled: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+
+  return { adapters, notifiers };
+}
+
+export async function ensureBuiltinGatewayChannelLocations(
+  baseDir: string,
+  logger?: Logger
+): Promise<BuiltinGatewayChannelLocation[]> {
+  await fs.mkdir(getGatewayChannelsDir(baseDir), { recursive: true });
+  const locations: BuiltinGatewayChannelLocation[] = [];
+
+  for (const channelName of BUILTIN_GATEWAY_CHANNEL_NAMES) {
+    const location = await ensureBuiltinGatewayChannelLocation(baseDir, channelName, logger);
+    if (location) {
+      locations.push(location);
+    }
+  }
+
+  return locations;
+}
+
+export async function ensureBuiltinGatewayChannelLocation(
+  baseDir: string,
+  channelName: string,
+  logger?: Logger
+): Promise<BuiltinGatewayChannelLocation | null> {
+  const channelDir = getGatewayChannelDir(channelName, baseDir);
+  const configPath = path.join(channelDir, "config.json");
+  if (await pathExists(configPath)) {
+    return {
+      channelName,
+      channelDir,
+      configPath,
+      source: "core",
+    };
+  }
+
+  const migrated = await migrateLegacyPluginChannel(baseDir, channelName, logger);
+  if (migrated) {
+    return migrated;
+  }
+
+  return null;
+}
+
+async function migrateLegacyPluginChannel(
+  baseDir: string,
+  channelName: string,
+  logger?: Logger
+): Promise<BuiltinGatewayChannelLocation | null> {
+  const legacyDir = path.join(getPluginsDir(baseDir), channelName);
+  const legacyConfigPath = path.join(legacyDir, "config.json");
+  if (!(await pathExists(legacyConfigPath))) {
+    return null;
+  }
+
+  const channelDir = getGatewayChannelDir(channelName, baseDir);
+  const configPath = path.join(channelDir, "config.json");
+  await fs.mkdir(channelDir, { recursive: true });
+  await fs.copyFile(legacyConfigPath, configPath);
+  await retireLegacyPluginDirectory(baseDir, channelName, legacyDir);
+  logger?.info(`[daemon] promoted legacy ${channelName} plugin config into gateway core`, {
+    legacy_dir: legacyDir,
+    channel_dir: channelDir,
+  });
+
+  return {
+    channelName,
+    channelDir,
+    configPath,
+    source: "legacy-plugin",
+  };
+}
+
+async function retireLegacyPluginDirectory(baseDir: string, channelName: string, legacyDir: string): Promise<void> {
+  const archiveRoot = getPromotedPluginsDir(baseDir);
+  await fs.mkdir(archiveRoot, { recursive: true });
+  const targetDir = await nextAvailablePromotedDir(path.join(archiveRoot, channelName));
+  await fs.rename(legacyDir, targetDir);
+}
+
+async function nextAvailablePromotedDir(basePath: string): Promise<string> {
+  if (!(await pathExists(basePath))) {
+    return basePath;
+  }
+  for (let index = 2; index < 1000; index += 1) {
+    const candidate = `${basePath}-${index}`;
+    if (!(await pathExists(candidate))) {
+      return candidate;
+    }
+  }
+  throw new Error(`Unable to find archive slot for promoted plugin: ${basePath}`);
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/runtime/gateway/builtin-channel-names.ts
+++ b/src/runtime/gateway/builtin-channel-names.ts
@@ -1,0 +1,8 @@
+export const BUILTIN_GATEWAY_CHANNEL_NAMES = [
+  "telegram-bot",
+  "whatsapp-webhook",
+  "signal-bridge",
+  "discord-bot",
+] as const;
+
+export type BuiltinGatewayChannelName = typeof BUILTIN_GATEWAY_CHANNEL_NAMES[number];

--- a/src/runtime/gateway/chat-session-dispatch.ts
+++ b/src/runtime/gateway/chat-session-dispatch.ts
@@ -1,0 +1,53 @@
+import type { ChatEventHandler } from "../../interface/chat/chat-events.js";
+import { getGlobalCrossPlatformChatSessionManager } from "../../interface/chat/cross-platform-session.js";
+
+export interface GatewayChatDispatchInput {
+  text: string;
+  platform: string;
+  identity_key?: string;
+  conversation_id: string;
+  sender_id: string;
+  message_id?: string;
+  cwd?: string;
+  metadata?: Record<string, unknown>;
+  onEvent?: ChatEventHandler;
+}
+
+export async function dispatchGatewayChatInput(
+  input: GatewayChatDispatchInput
+): Promise<string | null> {
+  try {
+    const manager = await getGlobalCrossPlatformChatSessionManager();
+    const result = await manager.processIncomingMessage({
+      text: input.text,
+      platform: input.platform,
+      identity_key: input.identity_key,
+      conversation_id: input.conversation_id,
+      sender_id: input.sender_id,
+      message_id: input.message_id,
+      cwd: input.cwd,
+      metadata: input.metadata,
+      onEvent: input.onEvent,
+    });
+    return normalizeManagerResult(result);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeManagerResult(result: unknown): string | null {
+  if (typeof result === "string") {
+    const trimmed = result.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof result === "object" && result !== null) {
+    const record = result as Record<string, unknown>;
+    for (const key of ["text", "message"] as const) {
+      const value = record[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        return value;
+      }
+    }
+  }
+  return null;
+}

--- a/src/runtime/gateway/core-channel-notification.ts
+++ b/src/runtime/gateway/core-channel-notification.ts
@@ -1,0 +1,46 @@
+import type { NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
+
+export const CORE_GATEWAY_SUPPORTED_EVENTS: NotificationEventType[] = [
+  "goal_progress",
+  "goal_complete",
+  "task_blocked",
+  "approval_needed",
+  "stall_detected",
+  "trust_change",
+  "schedule_change_detected",
+  "schedule_heartbeat_failure",
+  "schedule_escalation",
+  "schedule_report_ready",
+];
+
+export function supportsCoreGatewayNotification(eventType: NotificationEventType): boolean {
+  return CORE_GATEWAY_SUPPORTED_EVENTS.includes(eventType);
+}
+
+export function formatPlaintextNotification(event: NotificationEvent): string {
+  const detailKeys = Object.keys(event.details);
+  const detailSuffix = detailKeys.length > 0 ? ` | details: ${detailKeys.join(",")}` : "";
+  const content = typeof event.details["content"] === "string" ? `\n\n${event.details["content"]}` : "";
+  return `[${event.severity}] ${event.summary} (goal ${event.goal_id})${detailSuffix}${content}`;
+}
+
+export function formatTelegramNotification(event: NotificationEvent): string {
+  const severityIcon = event.severity === "critical"
+    ? "[CRITICAL]"
+    : event.severity === "warning"
+      ? "[WARN]"
+      : "[INFO]";
+  const lines: string[] = [
+    `${severityIcon} *${event.type}*`,
+    `Goal: ${event.goal_id}`,
+    event.summary,
+  ];
+  if (Object.keys(event.details).length > 0) {
+    lines.push(
+      Object.entries(event.details)
+        .map(([key, value]) => `  ${key}: ${JSON.stringify(value)}`)
+        .join("\n")
+    );
+  }
+  return lines.join("\n");
+}

--- a/src/runtime/gateway/discord-gateway-adapter.ts
+++ b/src/runtime/gateway/discord-gateway-adapter.ts
@@ -1,0 +1,455 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as http from "node:http";
+import { createHash, webcrypto } from "node:crypto";
+import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
+import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
+import { formatPlaintextNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
+import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
+import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
+
+const MAX_DISCORD_ACTIVITY_MESSAGES = 8;
+const MAX_DISCORD_ACTIVITY_CHARS = 300;
+
+interface DiscordInteractionOption {
+  name: string;
+  value?: unknown;
+}
+
+interface DiscordInteractionPayload {
+  id?: string;
+  type?: number;
+  token?: string;
+  application_id?: string;
+  channel_id?: string;
+  guild_id?: string;
+  member?: {
+    user?: {
+      id?: string;
+    };
+  };
+  user?: {
+    id?: string;
+  };
+  data?: {
+    name?: string;
+    options?: DiscordInteractionOption[];
+  };
+}
+
+interface ActivityChatEvent {
+  type: "activity";
+  kind: "lifecycle" | "commentary" | "tool" | "plugin" | "skill";
+  message: string;
+}
+
+export interface DiscordGatewayConfig {
+  application_id: string;
+  public_key_hex?: string;
+  bot_token: string;
+  channel_id: string;
+  identity_key: string;
+  allowed_sender_ids: string[];
+  denied_sender_ids: string[];
+  allowed_conversation_ids: string[];
+  denied_conversation_ids: string[];
+  runtime_control_allowed_sender_ids: string[];
+  conversation_goal_map: Record<string, string>;
+  sender_goal_map: Record<string, string>;
+  default_goal_id?: string;
+  command_name: string;
+  host: string;
+  port: number;
+  ephemeral: boolean;
+}
+
+export class DiscordGatewayNotifier implements INotifier {
+  readonly name = "discord-bot";
+
+  constructor(
+    private readonly api: DiscordAPI,
+    private readonly config: DiscordGatewayConfig
+  ) {}
+
+  supports(eventType: NotificationEventType): boolean {
+    return supportsCoreGatewayNotification(eventType);
+  }
+
+  async notify(event: NotificationEvent): Promise<void> {
+    await this.api.sendChannelMessage(this.config.channel_id, formatPlaintextNotification(event));
+  }
+}
+
+export class DiscordGatewayAdapter implements ChannelAdapter {
+  readonly name = "discord";
+
+  private handler: EnvelopeHandler | null = null;
+  private server: http.Server | null = null;
+  private readonly api: DiscordAPI;
+  private readonly notifier: DiscordGatewayNotifier;
+
+  constructor(private readonly config: DiscordGatewayConfig) {
+    this.api = new DiscordAPI(config.bot_token);
+    this.notifier = new DiscordGatewayNotifier(this.api, config);
+  }
+
+  static fromConfigDir(configDir: string): DiscordGatewayAdapter {
+    return new DiscordGatewayAdapter(loadDiscordGatewayConfig(configDir));
+  }
+
+  getNotifier(): INotifier {
+    return this.notifier;
+  }
+
+  onEnvelope(handler: EnvelopeHandler): void {
+    this.handler = handler;
+  }
+
+  async start(): Promise<void> {
+    if (this.server !== null) return;
+    this.server = http.createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+    await new Promise<void>((resolve) => {
+      this.server!.listen(this.config.port, this.config.host, resolve);
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.server === null) return;
+    await new Promise<void>((resolve) => {
+      this.server!.close(() => resolve());
+    });
+    this.server = null;
+  }
+
+  private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    if (req.method !== "POST") {
+      this.respondJson(res, 405, { error: "method_not_allowed" });
+      return;
+    }
+
+    const body = await this.readBody(req);
+    if (body === null) {
+      this.respondJson(res, 400, { error: "invalid_body" });
+      return;
+    }
+
+    if (!(await this.verifyRequest(req, body))) {
+      this.respondJson(res, 401, { error: "invalid_signature" });
+      return;
+    }
+
+    let payload: DiscordInteractionPayload;
+    try {
+      payload = JSON.parse(body) as DiscordInteractionPayload;
+    } catch {
+      this.respondJson(res, 400, { error: "invalid_json" });
+      return;
+    }
+
+    if (payload.type === 1) {
+      this.respondJson(res, 200, { type: 1 });
+      return;
+    }
+
+    if (
+      payload.type !== 2 ||
+      payload.token === undefined ||
+      payload.application_id === undefined ||
+      payload.data?.name !== this.config.command_name
+    ) {
+      this.respondJson(res, 400, { error: "unsupported_interaction" });
+      return;
+    }
+
+    const text = this.extractCommandText(payload);
+    if (text === null) {
+      this.respondJson(res, 400, { error: "missing_message_text" });
+      return;
+    }
+
+    const senderId = payload.member?.user?.id ?? payload.user?.id ?? "discord-user";
+    const conversationId = payload.channel_id ?? payload.guild_id ?? payload.id ?? senderId;
+    const channelContext = {
+      platform: "discord",
+      senderId,
+      conversationId,
+      channelId: payload.channel_id,
+    };
+    const access = evaluateChannelAccess(
+      {
+        allowedSenderIds: this.config.allowed_sender_ids,
+        deniedSenderIds: this.config.denied_sender_ids,
+        allowedConversationIds: this.config.allowed_conversation_ids,
+        deniedConversationIds: this.config.denied_conversation_ids,
+        runtimeControlAllowedSenderIds: this.config.runtime_control_allowed_sender_ids,
+      },
+      channelContext
+    );
+    if (!access.allowed) {
+      this.respondJson(res, 403, { error: access.reason ?? "forbidden" });
+      return;
+    }
+
+    const route = resolveChannelRoute(
+      {
+        identityKey: this.config.identity_key,
+        conversationGoalMap: this.config.conversation_goal_map,
+        senderGoalMap: this.config.sender_goal_map,
+        defaultGoalId: this.config.default_goal_id,
+      },
+      channelContext
+    );
+
+    void this.processIncomingMessage(payload, {
+      text,
+      platform: "discord",
+      identity_key: route.identityKey ?? this.config.identity_key,
+      conversation_id: conversationId,
+      sender_id: senderId,
+      message_id: payload.id,
+      metadata: {
+        ...route.metadata,
+        interaction_type: payload.type,
+        command_name: payload.data?.name,
+        channel_id: payload.channel_id,
+        guild_id: payload.guild_id,
+        ...(route.goalId ? { goal_id: route.goalId } : {}),
+        ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+      },
+    }).catch(() => undefined);
+
+    this.respondJson(res, 200, {
+      type: 5,
+      data: this.config.ephemeral ? { flags: 64 } : undefined,
+    });
+  }
+
+  private async processIncomingMessage(
+    payload: DiscordInteractionPayload,
+    input: Parameters<typeof dispatchGatewayChatInput>[0]
+  ): Promise<void> {
+    let sentActivityCount = 0;
+    let lastActivity = "";
+    const reply = await dispatchGatewayChatInput({
+      ...input,
+      onEvent: async (event: unknown) => {
+        if (
+          !isActivityChatEvent(event) ||
+          (event.kind !== "tool" && event.kind !== "plugin" && event.kind !== "skill") ||
+          payload.application_id === undefined ||
+          payload.token === undefined ||
+          sentActivityCount >= MAX_DISCORD_ACTIVITY_MESSAGES
+        ) {
+          return;
+        }
+        const content = truncateDiscordActivity(event.message);
+        if (content === lastActivity) return;
+        lastActivity = content;
+        sentActivityCount++;
+        await this.api.sendInteractionFollowUp(payload.application_id, payload.token, content);
+      },
+    });
+    const content = reply ?? "Received.";
+
+    if (payload.application_id !== undefined && payload.token !== undefined) {
+      await this.api.sendInteractionFollowUp(payload.application_id, payload.token, content);
+    }
+  }
+
+  private extractCommandText(payload: DiscordInteractionPayload): string | null {
+    for (const option of payload.data?.options ?? []) {
+      if (
+        (option.name === "message" || option.name === "text" || option.name === "content") &&
+        typeof option.value === "string" &&
+        option.value.trim().length > 0
+      ) {
+        return option.value;
+      }
+    }
+    return null;
+  }
+
+  private async verifyRequest(req: http.IncomingMessage, body: string): Promise<boolean> {
+    if (!this.config.public_key_hex) {
+      return true;
+    }
+    const signature = req.headers["x-signature-ed25519"];
+    const timestamp = req.headers["x-signature-timestamp"];
+    if (typeof signature !== "string" || typeof timestamp !== "string") {
+      return false;
+    }
+
+    const publicKeyBytes = Uint8Array.from(Buffer.from(this.config.public_key_hex, "hex"));
+    let key: Awaited<ReturnType<typeof webcrypto.subtle.importKey>>;
+    try {
+      key = await webcrypto.subtle.importKey("raw", publicKeyBytes, { name: "Ed25519" }, false, ["verify"]);
+    } catch {
+      return false;
+    }
+
+    const signedMessage = new TextEncoder().encode(`${timestamp}${body}`);
+    const signatureBytes = Uint8Array.from(Buffer.from(signature, "hex"));
+    return webcrypto.subtle.verify("Ed25519", key, signatureBytes, signedMessage);
+  }
+
+  private async readBody(req: http.IncomingMessage): Promise<string | null> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    return Buffer.concat(chunks).toString("utf-8");
+  }
+
+  private respondJson(res: http.ServerResponse, statusCode: number, payload: unknown): void {
+    res.statusCode = statusCode;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(payload));
+  }
+}
+
+class DiscordAPI {
+  constructor(
+    private readonly botToken: string,
+    private readonly fetchImpl: typeof fetch = fetch
+  ) {}
+
+  async sendChannelMessage(channelId: string, content: string): Promise<void> {
+    const response = await this.fetchImpl(`https://discord.com/api/v10/channels/${channelId}/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bot ${this.botToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        content,
+        allowed_mentions: { parse: [] as string[] },
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`discord-bot: channel send failed with ${response.status}`);
+    }
+  }
+
+  async sendInteractionFollowUp(applicationId: string, interactionToken: string, content: string): Promise<void> {
+    const response = await this.fetchImpl(`https://discord.com/api/v10/webhooks/${applicationId}/${interactionToken}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        content,
+        allowed_mentions: { parse: [] as string[] },
+      }),
+    });
+    if (!response.ok) {
+      throw new Error(`discord-bot: follow-up send failed with ${response.status}`);
+    }
+  }
+}
+
+function loadDiscordGatewayConfig(pluginDir: string): DiscordGatewayConfig {
+  const configPath = path.join(pluginDir, "config.json");
+  const raw = JSON.parse(fs.readFileSync(configPath, "utf-8")) as Record<string, unknown>;
+  const commandName = raw["command_name"] ?? "pulseed";
+  const host = raw["host"] ?? "127.0.0.1";
+  const port = raw["port"] ?? 8787;
+  const ephemeral = raw["ephemeral"] ?? false;
+  const runtimeControlAllowedSenderIds = raw["runtime_control_allowed_sender_ids"] ?? [];
+  const allowedSenderIds = raw["allowed_sender_ids"] ?? raw["allow_from"] ?? [];
+  const deniedSenderIds = raw["denied_sender_ids"] ?? raw["deny_from"] ?? [];
+  const allowedConversationIds = raw["allowed_conversation_ids"] ?? [];
+  const deniedConversationIds = raw["denied_conversation_ids"] ?? [];
+  const conversationGoalMap = raw["conversation_goal_map"] ?? raw["goal_routes"] ?? {};
+  const senderGoalMap = raw["sender_goal_map"] ?? {};
+
+  assertNonEmptyString(raw["application_id"], "discord-bot: application_id must be a non-empty string");
+  assertNonEmptyString(raw["bot_token"], "discord-bot: bot_token must be a non-empty string");
+  assertNonEmptyString(raw["channel_id"], "discord-bot: channel_id must be a non-empty string");
+  assertNonEmptyString(raw["identity_key"], "discord-bot: identity_key must be a non-empty string");
+  assertNonEmptyString(commandName, "discord-bot: command_name must be a non-empty string");
+  assertNonEmptyString(host, "discord-bot: host must be a non-empty string");
+  assertInteger(port, "discord-bot: port must be an integer");
+  assertBoolean(ephemeral, "discord-bot: ephemeral must be a boolean");
+  assertStringArray(runtimeControlAllowedSenderIds, "discord-bot: runtime_control_allowed_sender_ids must be an array of non-empty strings");
+  assertStringArray(allowedSenderIds, "discord-bot: allowed_sender_ids must be an array of non-empty strings");
+  assertStringArray(deniedSenderIds, "discord-bot: denied_sender_ids must be an array of non-empty strings");
+  assertStringArray(allowedConversationIds, "discord-bot: allowed_conversation_ids must be an array of non-empty strings");
+  assertStringArray(deniedConversationIds, "discord-bot: denied_conversation_ids must be an array of non-empty strings");
+  assertGoalMap(conversationGoalMap, "discord-bot: conversation_goal_map must map IDs to goal IDs");
+  assertGoalMap(senderGoalMap, "discord-bot: sender_goal_map must map IDs to goal IDs");
+  if (raw["default_goal_id"] !== undefined) {
+    assertNonEmptyString(raw["default_goal_id"], "discord-bot: default_goal_id must be a non-empty string when set");
+  }
+  if (raw["public_key_hex"] !== undefined && typeof raw["public_key_hex"] !== "string") {
+    throw new Error("discord-bot: public_key_hex must be a string when set");
+  }
+
+  return {
+    application_id: raw["application_id"] as string,
+    public_key_hex: raw["public_key_hex"] as string | undefined,
+    bot_token: raw["bot_token"] as string,
+    channel_id: raw["channel_id"] as string,
+    identity_key: raw["identity_key"] as string,
+    allowed_sender_ids: allowedSenderIds as string[],
+    denied_sender_ids: deniedSenderIds as string[],
+    allowed_conversation_ids: allowedConversationIds as string[],
+    denied_conversation_ids: deniedConversationIds as string[],
+    runtime_control_allowed_sender_ids: runtimeControlAllowedSenderIds as string[],
+    conversation_goal_map: conversationGoalMap as Record<string, string>,
+    sender_goal_map: senderGoalMap as Record<string, string>,
+    default_goal_id: raw["default_goal_id"] as string | undefined,
+    command_name: commandName as string,
+    host: host as string,
+    port: port as number,
+    ephemeral: ephemeral as boolean,
+  };
+}
+
+function isActivityChatEvent(event: unknown): event is ActivityChatEvent {
+  return typeof event === "object" && event !== null &&
+    (event as Record<string, unknown>)["type"] === "activity" &&
+    typeof (event as Record<string, unknown>)["message"] === "string";
+}
+
+function truncateDiscordActivity(message: string): string {
+  const trimmed = message.trim();
+  if (trimmed.length <= MAX_DISCORD_ACTIVITY_CHARS) return trimmed;
+  return `${trimmed.slice(0, MAX_DISCORD_ACTIVITY_CHARS - 1)}...`;
+}
+
+function assertNonEmptyString(value: unknown, message: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(message);
+  }
+}
+
+function assertInteger(value: unknown, message: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(message);
+  }
+}
+
+function assertBoolean(value: unknown, message: string): asserts value is boolean {
+  if (typeof value !== "boolean") {
+    throw new Error(message);
+  }
+}
+
+function assertStringArray(value: unknown, message: string): asserts value is string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string" && item.length > 0)) {
+    throw new Error(message);
+  }
+}
+
+function assertGoalMap(value: unknown, message: string): asserts value is Record<string, string> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !Object.values(value).every((goalId) => typeof goalId === "string" && goalId.length > 0)
+  ) {
+    throw new Error(message);
+  }
+}

--- a/src/runtime/gateway/index.ts
+++ b/src/runtime/gateway/index.ts
@@ -1,4 +1,12 @@
 export { IngressGateway } from "./ingress-gateway.js";
+export { BUILTIN_GATEWAY_CHANNEL_NAMES, type BuiltinGatewayChannelName } from "./builtin-channel-names.js";
+export {
+  ensureBuiltinGatewayChannelLocation,
+  ensureBuiltinGatewayChannelLocations,
+  loadBuiltinGatewayIntegrations,
+  type BuiltinGatewayIntegrations,
+  type BuiltinGatewayChannelLocation,
+} from "./builtin-channel-integrations.js";
 export { HttpChannelAdapter } from "./http-channel-adapter.js";
 export { SlackChannelAdapter } from "./slack-channel-adapter.js";
 export type { ChannelAdapter, EnvelopeHandler, ReplyChannel } from "./channel-adapter.js";

--- a/src/runtime/gateway/signal-gateway-adapter.ts
+++ b/src/runtime/gateway/signal-gateway-adapter.ts
@@ -1,0 +1,335 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
+import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
+import { formatPlaintextNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
+import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
+import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
+
+export interface SignalGatewayConfig {
+  bridge_url: string;
+  account: string;
+  recipient_id: string;
+  identity_key: string;
+  allowed_sender_ids: string[];
+  denied_sender_ids: string[];
+  allowed_conversation_ids: string[];
+  denied_conversation_ids: string[];
+  runtime_control_allowed_sender_ids: string[];
+  conversation_goal_map: Record<string, string>;
+  sender_goal_map: Record<string, string>;
+  default_goal_id?: string;
+  poll_interval_ms: number;
+  receive_timeout_ms: number;
+}
+
+interface SignalReceivedMessage {
+  id?: string;
+  sender?: string;
+  sender_number?: string;
+  source?: string;
+  message?: string;
+  body?: string;
+  timestamp?: number;
+  conversationId?: string;
+  groupId?: string;
+}
+
+export class SignalGatewayNotifier implements INotifier {
+  readonly name = "signal-bridge";
+
+  constructor(
+    private readonly client: SignalBridgeClient,
+    private readonly config: SignalGatewayConfig
+  ) {}
+
+  supports(eventType: NotificationEventType): boolean {
+    return supportsCoreGatewayNotification(eventType);
+  }
+
+  async notify(event: NotificationEvent): Promise<void> {
+    await this.client.sendTextMessage({
+      recipient: this.config.recipient_id,
+      body: formatPlaintextNotification(event),
+    });
+  }
+}
+
+export class SignalGatewayAdapter implements ChannelAdapter {
+  readonly name = "signal";
+
+  private handler: EnvelopeHandler | null = null;
+  private readonly client: SignalBridgeClient;
+  private readonly notifier: SignalGatewayNotifier;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly seenMessageIds = new Set<string>();
+
+  constructor(private readonly config: SignalGatewayConfig) {
+    this.client = new SignalBridgeClient(config.bridge_url, config.account);
+    this.notifier = new SignalGatewayNotifier(this.client, config);
+  }
+
+  static fromConfigDir(configDir: string): SignalGatewayAdapter {
+    return new SignalGatewayAdapter(loadSignalGatewayConfig(configDir));
+  }
+
+  getNotifier(): INotifier {
+    return this.notifier;
+  }
+
+  onEnvelope(handler: EnvelopeHandler): void {
+    this.handler = handler;
+  }
+
+  async start(): Promise<void> {
+    if (this.timer !== null) return;
+    void this.pollOnce().catch(() => undefined);
+    this.timer = setInterval(() => {
+      void this.pollOnce().catch(() => undefined);
+    }, this.config.poll_interval_ms);
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private async pollOnce(): Promise<void> {
+    const messages = await this.client.receiveMessages(this.config.receive_timeout_ms);
+    for (const message of messages) {
+      const normalized = this.normalizeMessage(message);
+      if (normalized === null || this.seenMessageIds.has(normalized.messageId)) {
+        continue;
+      }
+      this.seenMessageIds.add(normalized.messageId);
+      const channelContext = {
+        platform: "signal",
+        senderId: normalized.senderId,
+        conversationId: normalized.conversationId,
+      };
+      const access = evaluateChannelAccess(
+        {
+          allowedSenderIds: this.config.allowed_sender_ids,
+          deniedSenderIds: this.config.denied_sender_ids,
+          allowedConversationIds: this.config.allowed_conversation_ids,
+          deniedConversationIds: this.config.denied_conversation_ids,
+          runtimeControlAllowedSenderIds: this.config.runtime_control_allowed_sender_ids,
+        },
+        channelContext
+      );
+      if (!access.allowed) continue;
+      const route = resolveChannelRoute(
+        {
+          identityKey: this.config.identity_key,
+          conversationGoalMap: this.config.conversation_goal_map,
+          senderGoalMap: this.config.sender_goal_map,
+          defaultGoalId: this.config.default_goal_id,
+        },
+        channelContext
+      );
+      const reply = await dispatchGatewayChatInput({
+        text: normalized.text,
+        platform: "signal",
+        identity_key: route.identityKey ?? this.config.identity_key,
+        conversation_id: normalized.conversationId,
+        sender_id: normalized.senderId,
+        message_id: normalized.messageId,
+        metadata: {
+          ...route.metadata,
+          ...normalized.metadata,
+          ...(route.goalId ? { goal_id: route.goalId } : {}),
+          ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+        },
+      });
+
+      if (reply !== null) {
+        await this.client.sendTextMessage({
+          recipient: normalized.senderId,
+          body: reply,
+        });
+      }
+    }
+  }
+
+  private normalizeMessage(message: SignalReceivedMessage): {
+    messageId: string;
+    conversationId: string;
+    senderId: string;
+    text: string;
+    metadata: Record<string, unknown>;
+  } | null {
+    const text = typeof message.message === "string"
+      ? message.message
+      : typeof message.body === "string"
+        ? message.body
+        : null;
+    const senderId = message.sender ?? message.sender_number ?? message.source ?? null;
+    if (text === null || senderId === null) {
+      return null;
+    }
+    const messageId = message.id ?? `${senderId}:${message.timestamp ?? Date.now()}:${text}`;
+    const conversationId = message.groupId ?? message.conversationId ?? senderId;
+    return {
+      messageId,
+      conversationId,
+      senderId,
+      text,
+      metadata: {
+        source: message.source,
+        timestamp: message.timestamp,
+        group_id: message.groupId,
+      },
+    };
+  }
+}
+
+class SignalBridgeClient {
+  constructor(
+    private readonly bridgeUrl: string,
+    private readonly account: string,
+    private readonly fetchImpl: typeof fetch = fetch
+  ) {}
+
+  async sendTextMessage(message: { recipient: string; body: string }): Promise<void> {
+    const response = await this.fetchImpl(`${this.bridgeUrl}/v2/send`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        message: message.body,
+        recipients: [message.recipient],
+        number: this.account,
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "(unreadable)");
+      throw new Error(`signal-bridge: send failed with ${response.status}: ${body}`);
+    }
+  }
+
+  async receiveMessages(timeoutMs: number): Promise<SignalReceivedMessage[]> {
+    const endpoints = [
+      `${this.bridgeUrl}/v1/receive/${encodeURIComponent(this.account)}?timeout=${timeoutMs}`,
+      `${this.bridgeUrl}/v2/receive/${encodeURIComponent(this.account)}?timeout=${timeoutMs}`,
+      `${this.bridgeUrl}/v1/receive`,
+    ];
+    for (const endpoint of endpoints) {
+      const response = await this.fetchImpl(endpoint, {
+        method: endpoint.endsWith("/v1/receive") ? "POST" : "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: endpoint.endsWith("/v1/receive")
+          ? JSON.stringify({ number: this.account, timeout: timeoutMs })
+          : undefined,
+      });
+      if (!response.ok) {
+        continue;
+      }
+      const payload = (await response.json().catch(() => null)) as unknown;
+      const messages = normalizeReceiveResponse(payload);
+      if (messages !== null) {
+        return messages;
+      }
+    }
+    return [];
+  }
+}
+
+function normalizeReceiveResponse(payload: unknown): SignalReceivedMessage[] | null {
+  if (Array.isArray(payload)) {
+    return payload as SignalReceivedMessage[];
+  }
+  if (typeof payload === "object" && payload !== null) {
+    const record = payload as Record<string, unknown>;
+    if (Array.isArray(record["messages"])) {
+      return record["messages"] as SignalReceivedMessage[];
+    }
+    if (Array.isArray(record["data"])) {
+      return record["data"] as SignalReceivedMessage[];
+    }
+    if (typeof record["message"] === "string" || typeof record["sender"] === "string") {
+      return [record as SignalReceivedMessage];
+    }
+  }
+  return null;
+}
+
+function loadSignalGatewayConfig(pluginDir: string): SignalGatewayConfig {
+  const raw = JSON.parse(fs.readFileSync(path.join(pluginDir, "config.json"), "utf-8")) as Record<string, unknown>;
+  const pollInterval = raw["poll_interval_ms"] ?? 5000;
+  const receiveTimeout = raw["receive_timeout_ms"] ?? 2000;
+  const runtimeControlAllowedSenderIds = raw["runtime_control_allowed_sender_ids"] ?? [];
+  const allowedSenderIds = raw["allowed_sender_ids"] ?? raw["allow_from"] ?? [];
+  const deniedSenderIds = raw["denied_sender_ids"] ?? raw["deny_from"] ?? [];
+  const allowedConversationIds = raw["allowed_conversation_ids"] ?? [];
+  const deniedConversationIds = raw["denied_conversation_ids"] ?? [];
+  const conversationGoalMap = raw["conversation_goal_map"] ?? raw["goal_routes"] ?? {};
+  const senderGoalMap = raw["sender_goal_map"] ?? {};
+
+  assertNonEmptyString(raw["bridge_url"], "signal-bridge: bridge_url must be a non-empty string");
+  assertNonEmptyString(raw["account"], "signal-bridge: account must be a non-empty string");
+  assertNonEmptyString(raw["recipient_id"], "signal-bridge: recipient_id must be a non-empty string");
+  assertNonEmptyString(raw["identity_key"], "signal-bridge: identity_key must be a non-empty string");
+  assertInteger(pollInterval, "signal-bridge: poll_interval_ms must be an integer");
+  assertInteger(receiveTimeout, "signal-bridge: receive_timeout_ms must be an integer");
+  assertStringArray(runtimeControlAllowedSenderIds, "signal-bridge: runtime_control_allowed_sender_ids must be an array of non-empty strings");
+  assertStringArray(allowedSenderIds, "signal-bridge: allowed_sender_ids must be an array of non-empty strings");
+  assertStringArray(deniedSenderIds, "signal-bridge: denied_sender_ids must be an array of non-empty strings");
+  assertStringArray(allowedConversationIds, "signal-bridge: allowed_conversation_ids must be an array of non-empty strings");
+  assertStringArray(deniedConversationIds, "signal-bridge: denied_conversation_ids must be an array of non-empty strings");
+  assertGoalMap(conversationGoalMap, "signal-bridge: conversation_goal_map must map IDs to goal IDs");
+  assertGoalMap(senderGoalMap, "signal-bridge: sender_goal_map must map IDs to goal IDs");
+  if (raw["default_goal_id"] !== undefined) {
+    assertNonEmptyString(raw["default_goal_id"], "signal-bridge: default_goal_id must be a non-empty string when set");
+  }
+
+  return {
+    bridge_url: raw["bridge_url"] as string,
+    account: raw["account"] as string,
+    recipient_id: raw["recipient_id"] as string,
+    identity_key: raw["identity_key"] as string,
+    allowed_sender_ids: allowedSenderIds as string[],
+    denied_sender_ids: deniedSenderIds as string[],
+    allowed_conversation_ids: allowedConversationIds as string[],
+    denied_conversation_ids: deniedConversationIds as string[],
+    runtime_control_allowed_sender_ids: runtimeControlAllowedSenderIds as string[],
+    conversation_goal_map: conversationGoalMap as Record<string, string>,
+    sender_goal_map: senderGoalMap as Record<string, string>,
+    default_goal_id: raw["default_goal_id"] as string | undefined,
+    poll_interval_ms: Math.max(1000, pollInterval as number),
+    receive_timeout_ms: Math.max(250, receiveTimeout as number),
+  };
+}
+
+function assertNonEmptyString(value: unknown, message: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(message);
+  }
+}
+
+function assertInteger(value: unknown, message: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(message);
+  }
+}
+
+function assertStringArray(value: unknown, message: string): asserts value is string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string" && item.length > 0)) {
+    throw new Error(message);
+  }
+}
+
+function assertGoalMap(value: unknown, message: string): asserts value is Record<string, string> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !Object.values(value).every((goalId) => typeof goalId === "string" && goalId.length > 0)
+  ) {
+    throw new Error(message);
+  }
+}

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -1,0 +1,491 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
+import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
+import { formatTelegramNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
+import { writeJsonFileAtomic } from "../../base/utils/json-io.js";
+import type { ChatEvent, ChatEventHandler } from "../../interface/chat/chat-events.js";
+import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
+import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
+
+const BACKOFF_STEPS_MS = [5_000, 10_000, 20_000, 40_000, 60_000];
+
+export interface TelegramGatewayConfig {
+  bot_token: string;
+  chat_id?: number;
+  allowed_user_ids: number[];
+  denied_user_ids: number[];
+  allowed_chat_ids: number[];
+  denied_chat_ids: number[];
+  runtime_control_allowed_user_ids: number[];
+  chat_goal_map: Record<string, string>;
+  user_goal_map: Record<string, string>;
+  default_goal_id?: string;
+  allow_all: boolean;
+  polling_timeout: number;
+  identity_key?: string;
+}
+
+export class TelegramGatewayNotifier implements INotifier {
+  readonly name = "telegram-bot";
+
+  constructor(
+    private readonly api: TelegramAPI,
+    private readonly homeChatStore: TelegramHomeChatStore
+  ) {}
+
+  supports(eventType: NotificationEventType): boolean {
+    return supportsCoreGatewayNotification(eventType);
+  }
+
+  async notify(event: NotificationEvent): Promise<void> {
+    const chatId = this.homeChatStore.get();
+    if (chatId === undefined) {
+      throw new Error("telegram-bot: no home chat configured. Send /sethome from the target Telegram chat.");
+    }
+    await this.api.sendMessage(chatId, formatTelegramNotification(event));
+  }
+}
+
+export class TelegramGatewayAdapter implements ChannelAdapter {
+  readonly name = "telegram";
+
+  private handler: EnvelopeHandler | null = null;
+  private readonly api: TelegramAPI;
+  private readonly config: TelegramGatewayConfig;
+  private readonly homeChatStore: TelegramHomeChatStore;
+  private readonly notifier: TelegramGatewayNotifier;
+  private running = false;
+  private offset = 0;
+
+  constructor(pluginDir: string, config: TelegramGatewayConfig) {
+    this.config = config;
+    this.api = new TelegramAPI(config.bot_token);
+    this.homeChatStore = new TelegramHomeChatStore(pluginDir, config.chat_id);
+    this.notifier = new TelegramGatewayNotifier(this.api, this.homeChatStore);
+  }
+
+  static fromConfigDir(configDir: string): TelegramGatewayAdapter {
+    return new TelegramGatewayAdapter(configDir, loadTelegramGatewayConfig(configDir));
+  }
+
+  getNotifier(): INotifier {
+    return this.notifier;
+  }
+
+  onEnvelope(handler: EnvelopeHandler): void {
+    this.handler = handler;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    await this.api.getMe();
+    this.running = true;
+    void this.loop().catch(() => undefined);
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+  }
+
+  private async loop(): Promise<void> {
+    let backoffIndex = 0;
+    while (this.running) {
+      try {
+        const updates = await this.api.getUpdates(this.offset, this.config.polling_timeout);
+        backoffIndex = 0;
+        for (const update of updates) {
+          this.offset = update.update_id + 1;
+          const msg = update.message;
+          if (!msg?.text) continue;
+          const fromId = msg.from?.id;
+          const chatId = msg.chat?.id;
+          if (!Number.isInteger(fromId) || !Number.isInteger(chatId)) continue;
+          if (this.config.denied_user_ids.includes(fromId)) continue;
+          if (this.config.denied_chat_ids.includes(chatId)) continue;
+          if (this.config.allowed_chat_ids.length > 0 && !this.config.allowed_chat_ids.includes(chatId)) continue;
+          if (!this.config.allow_all && !this.config.allowed_user_ids.includes(fromId)) continue;
+          await this.processMessage(msg.text, fromId, chatId);
+        }
+      } catch (err) {
+        if (!this.running) break;
+        const delay = BACKOFF_STEPS_MS[Math.min(backoffIndex, BACKOFF_STEPS_MS.length - 1)];
+        backoffIndex++;
+        await sleep(delay);
+      }
+    }
+  }
+
+  private async processMessage(text: string, fromUserId: number, chatId: number): Promise<void> {
+    const normalized = text.trim().toLowerCase();
+    if (normalized === "/sethome" || normalized.startsWith("/sethome@")) {
+      await this.homeChatStore.set(chatId);
+      await this.api.sendPlainMessage(chatId, "This chat is now the home channel for PulSeed notifications.");
+      return;
+    }
+
+    const eventAdapter = new TelegramChatEventAdapter(this.api, chatId);
+    const route = resolveChannelRoute(
+      {
+        identityKey: this.config.identity_key,
+        conversationGoalMap: this.config.chat_goal_map,
+        senderGoalMap: this.config.user_goal_map,
+        defaultGoalId: this.config.default_goal_id,
+      },
+      {
+        platform: "telegram",
+        senderId: String(fromUserId),
+        conversationId: String(chatId),
+        channelId: String(chatId),
+      }
+    );
+    const access = evaluateChannelAccess(
+      {
+        allowedSenderIds: this.config.allow_all ? undefined : this.config.allowed_user_ids.map(String),
+        deniedSenderIds: this.config.denied_user_ids.map(String),
+        allowedConversationIds: this.config.allowed_chat_ids.map(String),
+        deniedConversationIds: this.config.denied_chat_ids.map(String),
+        runtimeControlAllowedSenderIds: this.config.runtime_control_allowed_user_ids.map(String),
+      },
+      {
+        platform: "telegram",
+        senderId: String(fromUserId),
+        conversationId: String(chatId),
+        channelId: String(chatId),
+      }
+    );
+    if (!access.allowed) {
+      return;
+    }
+
+    const reply = await dispatchGatewayChatInput({
+      text,
+      platform: "telegram",
+      identity_key: route.identityKey ?? this.config.identity_key,
+      conversation_id: String(chatId),
+      sender_id: String(fromUserId),
+      cwd: process.cwd(),
+      onEvent: (event) => eventAdapter.handle(event),
+      metadata: {
+        ...route.metadata,
+        chat_id: chatId,
+        ...(route.goalId ? { goal_id: route.goalId } : {}),
+        ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+      },
+    });
+
+    if (!eventAdapter.renderedAssistantOutput) {
+      await eventAdapter.sendFinalFallback(reply ?? "Received.");
+    }
+  }
+}
+
+interface TelegramMessage {
+  message_id: number;
+  from: { id: number };
+  chat: { id: number };
+  text?: string;
+}
+
+interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+}
+
+interface SendMessageResult {
+  message_id: number;
+}
+
+class TelegramAPI {
+  private readonly baseUrl: string;
+
+  constructor(botToken: string) {
+    this.baseUrl = `https://api.telegram.org/bot${botToken}`;
+  }
+
+  async getMe(): Promise<unknown> {
+    return this.call("getMe");
+  }
+
+  async getUpdates(offset: number, timeout: number): Promise<TelegramUpdate[]> {
+    return this.call("getUpdates", {
+      offset,
+      timeout,
+      allowed_updates: ["message"],
+    });
+  }
+
+  async sendMessage(chatId: number, text: string): Promise<void> {
+    await this.sendMessageInternal(chatId, text, "Markdown");
+  }
+
+  async sendPlainMessage(chatId: number, text: string): Promise<number> {
+    return this.sendMessageInternal(chatId, text, null);
+  }
+
+  async editMessageText(chatId: number, messageId: number, text: string): Promise<void> {
+    const chunks = splitMessage(text, 4096);
+    if (chunks.length === 0) return;
+    await this.call("editMessageText", {
+      chat_id: chatId,
+      message_id: messageId,
+      text: chunks[0],
+    });
+    for (const chunk of chunks.slice(1)) {
+      await this.call("sendMessage", {
+        chat_id: chatId,
+        text: chunk,
+      });
+    }
+  }
+
+  private async sendMessageInternal(chatId: number, text: string, parseMode: "Markdown" | null): Promise<number> {
+    const chunks = splitMessage(text, 4096);
+    let firstMessageId = -1;
+    for (const [index, chunk] of chunks.entries()) {
+      const result = await this.call<SendMessageResult>("sendMessage", {
+        chat_id: chatId,
+        text: chunk,
+        ...(parseMode ? { parse_mode: parseMode } : {}),
+      });
+      if (index === 0) {
+        firstMessageId = result.message_id;
+      }
+    }
+    return firstMessageId;
+  }
+
+  private async call<T>(method: string, params?: Record<string, unknown>): Promise<T> {
+    const response = await fetch(`${this.baseUrl}/${method}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: params !== undefined ? JSON.stringify(params) : undefined,
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "(unreadable)");
+      throw new Error(`telegram-api: ${method} returned ${response.status}: ${body}`);
+    }
+    const json = (await response.json()) as { ok: boolean; result: T; description?: string };
+    if (!json.ok) {
+      throw new Error(`telegram-api: ${method} error: ${json.description ?? "unknown"}`);
+    }
+    return json.result;
+  }
+}
+
+class TelegramHomeChatStore {
+  private readonly configPath: string;
+  private chatId: number | undefined;
+
+  constructor(pluginDir: string, initialChatId?: number) {
+    this.configPath = path.join(pluginDir, "config.json");
+    this.chatId = initialChatId;
+  }
+
+  get(): number | undefined {
+    return this.chatId;
+  }
+
+  async set(chatId: number): Promise<void> {
+    this.chatId = chatId;
+    let current: Record<string, unknown> = {};
+    try {
+      current = JSON.parse(fs.readFileSync(this.configPath, "utf-8")) as Record<string, unknown>;
+    } catch {
+      current = {};
+    }
+    current["chat_id"] = chatId;
+    await writeJsonFileAtomic(this.configPath, current);
+  }
+}
+
+class TelegramChatEventAdapter {
+  private assistantMessage: { messageId: number; text: string } | null = null;
+  private readonly toolMessages = new Map<string, { messageId: number; text: string }>();
+  private readonly activityMessages = new Map<string, { messageId: number; text: string }>();
+  private hasAssistantOutput = false;
+
+  constructor(
+    private readonly api: TelegramAPI,
+    private readonly chatId: number
+  ) {}
+
+  get renderedAssistantOutput(): boolean {
+    return this.hasAssistantOutput;
+  }
+
+  async handle(event: ChatEvent): Promise<void> {
+    switch (event.type) {
+      case "lifecycle_start":
+        this.assistantMessage = null;
+        this.toolMessages.clear();
+        this.activityMessages.clear();
+        this.hasAssistantOutput = false;
+        return;
+      case "assistant_delta":
+      case "assistant_final":
+        await this.upsertAssistantMessage(event.text);
+        return;
+      case "activity":
+        if (event.kind === "plugin" || event.kind === "skill") {
+          await this.upsertActivityMessage(event.sourceId ?? event.kind, `[${event.kind}] ${event.message}`);
+        }
+        return;
+      case "tool_start":
+        await this.upsertToolMessage(event.toolCallId, `[tool] ${event.toolName} started`);
+        return;
+      case "tool_update":
+        await this.upsertToolMessage(event.toolCallId, `[tool] ${event.toolName} ${event.status}: ${event.message}`);
+        return;
+      case "tool_end":
+        await this.upsertToolMessage(
+          event.toolCallId,
+          `[tool] ${event.toolName} ${event.success ? "done" : "failed"}: ${event.summary}`
+        );
+        return;
+      case "lifecycle_error":
+        await this.sendFinalFallback(event.partialText ? `${event.partialText}\n\n[interrupted: ${event.error}]` : `Error: ${event.error}`);
+        return;
+      case "lifecycle_end":
+        return;
+    }
+  }
+
+  async sendFinalFallback(text: string): Promise<void> {
+    if (!text.trim()) return;
+    await this.upsertAssistantMessage(text);
+  }
+
+  private async upsertAssistantMessage(text: string): Promise<void> {
+    if (!this.assistantMessage) {
+      const messageId = await this.api.sendPlainMessage(this.chatId, text);
+      this.assistantMessage = { messageId, text };
+      this.hasAssistantOutput = true;
+      return;
+    }
+    await this.api.editMessageText(this.chatId, this.assistantMessage.messageId, text);
+    this.assistantMessage.text = text;
+    this.hasAssistantOutput = true;
+  }
+
+  private async upsertToolMessage(toolCallId: string, text: string): Promise<void> {
+    const existing = this.toolMessages.get(toolCallId);
+    if (!existing) {
+      const messageId = await this.api.sendPlainMessage(this.chatId, text);
+      this.toolMessages.set(toolCallId, { messageId, text });
+      return;
+    }
+    await this.api.editMessageText(this.chatId, existing.messageId, text);
+    existing.text = text;
+  }
+
+  private async upsertActivityMessage(activityId: string, text: string): Promise<void> {
+    const existing = this.activityMessages.get(activityId);
+    if (!existing) {
+      const messageId = await this.api.sendPlainMessage(this.chatId, text);
+      this.activityMessages.set(activityId, { messageId, text });
+      return;
+    }
+    await this.api.editMessageText(this.chatId, existing.messageId, text);
+    existing.text = text;
+  }
+}
+
+function loadTelegramGatewayConfig(pluginDir: string): TelegramGatewayConfig {
+  const raw = JSON.parse(fs.readFileSync(path.join(pluginDir, "config.json"), "utf-8")) as Record<string, unknown>;
+  const allowedUserIds = raw["allowed_user_ids"] ?? [];
+  const deniedUserIds = raw["denied_user_ids"] ?? raw["deny_from"] ?? [];
+  const allowedChatIds = raw["allowed_chat_ids"] ?? [];
+  const deniedChatIds = raw["denied_chat_ids"] ?? [];
+  const runtimeControlAllowedUserIds = raw["runtime_control_allowed_user_ids"] ?? [];
+  const allowAll = raw["allow_all"] ?? false;
+  const pollingTimeout = raw["polling_timeout"] ?? 30;
+  const chatGoalMap = raw["chat_goal_map"] ?? raw["goal_routes"] ?? {};
+  const userGoalMap = raw["user_goal_map"] ?? {};
+
+  assertNonEmptyString(raw["bot_token"], "telegram-bot: bot_token must be a non-empty string");
+  if (raw["chat_id"] !== undefined) {
+    assertInteger(raw["chat_id"], "telegram-bot: chat_id must be an integer when set");
+  }
+  assertIntegerArray(allowedUserIds, "telegram-bot: allowed_user_ids must be an array of integers");
+  assertIntegerArray(deniedUserIds, "telegram-bot: denied_user_ids must be an array of integers");
+  assertIntegerArray(allowedChatIds, "telegram-bot: allowed_chat_ids must be an array of integers");
+  assertIntegerArray(deniedChatIds, "telegram-bot: denied_chat_ids must be an array of integers");
+  assertIntegerArray(runtimeControlAllowedUserIds, "telegram-bot: runtime_control_allowed_user_ids must be an array of integers");
+  if (typeof allowAll !== "boolean") {
+    throw new Error("telegram-bot: allow_all must be a boolean");
+  }
+  assertInteger(pollingTimeout, "telegram-bot: polling_timeout must be an integer");
+  if (raw["identity_key"] !== undefined) {
+    assertNonEmptyString(raw["identity_key"], "telegram-bot: identity_key must be a non-empty string when set");
+  }
+  assertGoalMap(chatGoalMap, "telegram-bot: chat_goal_map must map IDs to goal IDs");
+  assertGoalMap(userGoalMap, "telegram-bot: user_goal_map must map IDs to goal IDs");
+  if (raw["default_goal_id"] !== undefined) {
+    assertNonEmptyString(raw["default_goal_id"], "telegram-bot: default_goal_id must be a non-empty string when set");
+  }
+
+  return {
+    bot_token: raw["bot_token"] as string,
+    chat_id: raw["chat_id"] as number | undefined,
+    allowed_user_ids: allowedUserIds as number[],
+    denied_user_ids: deniedUserIds as number[],
+    allowed_chat_ids: allowedChatIds as number[],
+    denied_chat_ids: deniedChatIds as number[],
+    runtime_control_allowed_user_ids: runtimeControlAllowedUserIds as number[],
+    chat_goal_map: chatGoalMap as Record<string, string>,
+    user_goal_map: userGoalMap as Record<string, string>,
+    default_goal_id: raw["default_goal_id"] as string | undefined,
+    allow_all: allowAll as boolean,
+    polling_timeout: Math.min(Math.max(pollingTimeout as number, 1), 60),
+    identity_key: raw["identity_key"] as string | undefined,
+  };
+}
+
+function splitMessage(text: string, maxLen: number): string[] {
+  if (text.length <= maxLen) return [text];
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > maxLen) {
+    const slice = remaining.slice(0, maxLen);
+    const lastNewline = slice.lastIndexOf("\n");
+    const splitAt = lastNewline > 0 ? lastNewline + 1 : maxLen;
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+  if (remaining.length > 0) chunks.push(remaining);
+  return chunks;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function assertNonEmptyString(value: unknown, message: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(message);
+  }
+}
+
+function assertInteger(value: unknown, message: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(message);
+  }
+}
+
+function assertIntegerArray(value: unknown, message: string): asserts value is number[] {
+  if (!Array.isArray(value) || !value.every((item) => Number.isInteger(item))) {
+    throw new Error(message);
+  }
+}
+
+function assertGoalMap(value: unknown, message: string): asserts value is Record<string, string> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !Object.values(value).every((goalId) => typeof goalId === "string" && goalId.length > 0)
+  ) {
+    throw new Error(message);
+  }
+}

--- a/src/runtime/gateway/whatsapp-gateway-adapter.ts
+++ b/src/runtime/gateway/whatsapp-gateway-adapter.ts
@@ -1,0 +1,365 @@
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as path from "node:path";
+import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
+import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
+import { formatPlaintextNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
+import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
+import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
+
+interface WhatsAppWebhookPayload {
+  entry?: Array<{
+    changes?: Array<{
+      value?: {
+        messages?: Array<{
+          id?: string;
+          from?: string;
+          timestamp?: string;
+          type?: string;
+          text?: { body?: string };
+        }>;
+      };
+    }>;
+  }>;
+}
+
+export interface WhatsAppGatewayConfig {
+  phone_number_id: string;
+  access_token: string;
+  verify_token: string;
+  recipient_id: string;
+  identity_key: string;
+  allowed_sender_ids: string[];
+  denied_sender_ids: string[];
+  runtime_control_allowed_sender_ids: string[];
+  sender_goal_map: Record<string, string>;
+  default_goal_id?: string;
+  host: string;
+  port: number;
+  path: string;
+  app_secret?: string;
+}
+
+export class WhatsAppGatewayNotifier implements INotifier {
+  readonly name = "whatsapp-webhook";
+
+  constructor(
+    private readonly client: WhatsAppCloudClient,
+    private readonly config: WhatsAppGatewayConfig
+  ) {}
+
+  supports(eventType: NotificationEventType): boolean {
+    return supportsCoreGatewayNotification(eventType);
+  }
+
+  async notify(event: NotificationEvent): Promise<void> {
+    await this.client.sendTextMessage({
+      to: this.config.recipient_id,
+      body: formatPlaintextNotification(event),
+    });
+  }
+}
+
+export class WhatsAppGatewayAdapter implements ChannelAdapter {
+  readonly name = "whatsapp";
+
+  private handler: EnvelopeHandler | null = null;
+  private server: http.Server | null = null;
+  private readonly client: WhatsAppCloudClient;
+  private readonly notifier: WhatsAppGatewayNotifier;
+
+  constructor(private readonly config: WhatsAppGatewayConfig) {
+    this.client = new WhatsAppCloudClient(config.phone_number_id, config.access_token);
+    this.notifier = new WhatsAppGatewayNotifier(this.client, config);
+  }
+
+  static fromConfigDir(configDir: string): WhatsAppGatewayAdapter {
+    return new WhatsAppGatewayAdapter(loadWhatsAppGatewayConfig(configDir));
+  }
+
+  getNotifier(): INotifier {
+    return this.notifier;
+  }
+
+  onEnvelope(handler: EnvelopeHandler): void {
+    this.handler = handler;
+  }
+
+  async start(): Promise<void> {
+    if (this.server !== null) return;
+    this.server = http.createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+    await new Promise<void>((resolve) => {
+      this.server!.listen(this.config.port, this.config.host, resolve);
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (this.server === null) return;
+    await new Promise<void>((resolve) => {
+      this.server!.close(() => resolve());
+    });
+    this.server = null;
+  }
+
+  private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? this.config.host}`);
+    if (req.method === "GET" && url.pathname === this.config.path) {
+      this.handleVerification(res, url);
+      return;
+    }
+    if (req.method !== "POST" || url.pathname !== this.config.path) {
+      this.respondJson(res, 404, { error: "not_found" });
+      return;
+    }
+
+    const body = await this.readBody(req);
+    if (body === null) {
+      this.respondJson(res, 400, { error: "invalid_body" });
+      return;
+    }
+    if (!(await this.verifySignature(req, body))) {
+      this.respondJson(res, 401, { error: "invalid_signature" });
+      return;
+    }
+
+    let payload: WhatsAppWebhookPayload;
+    try {
+      payload = JSON.parse(body) as WhatsAppWebhookPayload;
+    } catch {
+      this.respondJson(res, 400, { error: "invalid_json" });
+      return;
+    }
+
+    for (const message of this.extractMessages(payload)) {
+      void this.processMessage(message).catch(() => undefined);
+    }
+
+    this.respondJson(res, 200, { ok: true });
+  }
+
+  private handleVerification(res: http.ServerResponse, url: URL): void {
+    const mode = url.searchParams.get("hub.mode");
+    const token = url.searchParams.get("hub.verify_token");
+    const challenge = url.searchParams.get("hub.challenge");
+    if (mode === "subscribe" && token === this.config.verify_token && challenge !== null) {
+      res.statusCode = 200;
+      res.end(challenge);
+      return;
+    }
+    this.respondJson(res, 403, { error: "verification_failed" });
+  }
+
+  private async processMessage(message: {
+    id?: string;
+    from?: string;
+    timestamp?: string;
+    text?: { body?: string };
+    type?: string;
+  }): Promise<void> {
+    if (message.from === undefined || message.text?.body === undefined || message.text.body.trim().length === 0) {
+      return;
+    }
+    const channelContext = {
+      platform: "whatsapp",
+      senderId: message.from,
+      conversationId: message.from,
+    };
+    const access = evaluateChannelAccess(
+      {
+        allowedSenderIds: this.config.allowed_sender_ids,
+        deniedSenderIds: this.config.denied_sender_ids,
+        runtimeControlAllowedSenderIds: this.config.runtime_control_allowed_sender_ids,
+      },
+      channelContext
+    );
+    if (!access.allowed) return;
+
+    const route = resolveChannelRoute(
+      {
+        identityKey: this.config.identity_key,
+        senderGoalMap: this.config.sender_goal_map,
+        defaultGoalId: this.config.default_goal_id,
+      },
+      channelContext
+    );
+    const reply = await dispatchGatewayChatInput({
+      text: message.text.body,
+      platform: "whatsapp",
+      identity_key: route.identityKey ?? this.config.identity_key,
+      conversation_id: message.from,
+      sender_id: message.from,
+      message_id: message.id,
+      metadata: {
+        ...route.metadata,
+        message_type: message.type,
+        timestamp: message.timestamp,
+        ...(route.goalId ? { goal_id: route.goalId } : {}),
+        ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+      },
+    });
+
+    await this.client.sendTextMessage({
+      to: message.from,
+      body: reply ?? "Received.",
+    });
+  }
+
+  private extractMessages(payload: WhatsAppWebhookPayload): Array<{
+    id?: string;
+    from?: string;
+    timestamp?: string;
+    type?: string;
+    text?: { body?: string };
+  }> {
+    const messages: Array<{
+      id?: string;
+      from?: string;
+      timestamp?: string;
+      type?: string;
+      text?: { body?: string };
+    }> = [];
+    for (const entry of payload.entry ?? []) {
+      for (const change of entry.changes ?? []) {
+        for (const message of change.value?.messages ?? []) {
+          messages.push(message);
+        }
+      }
+    }
+    return messages;
+  }
+
+  private async verifySignature(req: http.IncomingMessage, body: string): Promise<boolean> {
+    if (!this.config.app_secret) {
+      return true;
+    }
+    const header = req.headers["x-hub-signature-256"];
+    if (typeof header !== "string" || !header.startsWith("sha256=")) {
+      return false;
+    }
+    const expected = crypto.createHmac("sha256", this.config.app_secret).update(body).digest("hex");
+    const actual = header.slice("sha256=".length);
+    if (expected.length !== actual.length) return false;
+    return crypto.timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(actual, "hex"));
+  }
+
+  private async readBody(req: http.IncomingMessage): Promise<string | null> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    return Buffer.concat(chunks).toString("utf-8");
+  }
+
+  private respondJson(res: http.ServerResponse, statusCode: number, payload: unknown): void {
+    res.statusCode = statusCode;
+    res.setHeader("Content-Type", "application/json");
+    res.end(JSON.stringify(payload));
+  }
+}
+
+class WhatsAppCloudClient {
+  constructor(
+    private readonly phoneNumberId: string,
+    private readonly accessToken: string,
+    private readonly fetchImpl: typeof fetch = fetch
+  ) {}
+
+  async sendTextMessage(message: { to: string; body: string }): Promise<void> {
+    const response = await this.fetchImpl(`https://graph.facebook.com/v20.0/${this.phoneNumberId}/messages`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        messaging_product: "whatsapp",
+        to: message.to,
+        type: "text",
+        text: { body: message.body },
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "(unreadable)");
+      throw new Error(`whatsapp-webhook: send failed with ${response.status}: ${body}`);
+    }
+  }
+}
+
+function loadWhatsAppGatewayConfig(pluginDir: string): WhatsAppGatewayConfig {
+  const raw = JSON.parse(fs.readFileSync(path.join(pluginDir, "config.json"), "utf-8")) as Record<string, unknown>;
+  const host = raw["host"] ?? "127.0.0.1";
+  const port = raw["port"] ?? 8788;
+  const pathValue = raw["path"] ?? "/webhook";
+  const runtimeControlAllowedSenderIds = raw["runtime_control_allowed_sender_ids"] ?? [];
+  const allowedSenderIds = raw["allowed_sender_ids"] ?? raw["allow_from"] ?? [];
+  const deniedSenderIds = raw["denied_sender_ids"] ?? raw["deny_from"] ?? [];
+  const senderGoalMap = raw["sender_goal_map"] ?? raw["goal_routes"] ?? {};
+
+  assertNonEmptyString(raw["phone_number_id"], "whatsapp-webhook: phone_number_id must be a non-empty string");
+  assertNonEmptyString(raw["access_token"], "whatsapp-webhook: access_token must be a non-empty string");
+  assertNonEmptyString(raw["verify_token"], "whatsapp-webhook: verify_token must be a non-empty string");
+  assertNonEmptyString(raw["recipient_id"], "whatsapp-webhook: recipient_id must be a non-empty string");
+  assertNonEmptyString(raw["identity_key"], "whatsapp-webhook: identity_key must be a non-empty string");
+  assertNonEmptyString(host, "whatsapp-webhook: host must be a non-empty string");
+  assertInteger(port, "whatsapp-webhook: port must be an integer");
+  assertNonEmptyString(pathValue, "whatsapp-webhook: path must be a non-empty string");
+  if (raw["app_secret"] !== undefined && typeof raw["app_secret"] !== "string") {
+    throw new Error("whatsapp-webhook: app_secret must be a string when set");
+  }
+  assertStringArray(runtimeControlAllowedSenderIds, "whatsapp-webhook: runtime_control_allowed_sender_ids must be an array of non-empty strings");
+  assertStringArray(allowedSenderIds, "whatsapp-webhook: allowed_sender_ids must be an array of non-empty strings");
+  assertStringArray(deniedSenderIds, "whatsapp-webhook: denied_sender_ids must be an array of non-empty strings");
+  assertGoalMap(senderGoalMap, "whatsapp-webhook: sender_goal_map must map IDs to goal IDs");
+  if (raw["default_goal_id"] !== undefined) {
+    assertNonEmptyString(raw["default_goal_id"], "whatsapp-webhook: default_goal_id must be a non-empty string when set");
+  }
+
+  return {
+    phone_number_id: raw["phone_number_id"] as string,
+    access_token: raw["access_token"] as string,
+    verify_token: raw["verify_token"] as string,
+    recipient_id: raw["recipient_id"] as string,
+    identity_key: raw["identity_key"] as string,
+    allowed_sender_ids: allowedSenderIds as string[],
+    denied_sender_ids: deniedSenderIds as string[],
+    runtime_control_allowed_sender_ids: runtimeControlAllowedSenderIds as string[],
+    sender_goal_map: senderGoalMap as Record<string, string>,
+    default_goal_id: raw["default_goal_id"] as string | undefined,
+    host: host as string,
+    port: port as number,
+    path: pathValue as string,
+    app_secret: raw["app_secret"] as string | undefined,
+  };
+}
+
+function assertNonEmptyString(value: unknown, message: string): asserts value is string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(message);
+  }
+}
+
+function assertInteger(value: unknown, message: string): asserts value is number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(message);
+  }
+}
+
+function assertStringArray(value: unknown, message: string): asserts value is string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "string" && item.length > 0)) {
+    throw new Error(message);
+  }
+}
+
+function assertGoalMap(value: unknown, message: string): asserts value is Record<string, string> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !Object.values(value).every((goalId) => typeof goalId === "string" && goalId.length > 0)
+  ) {
+    throw new Error(message);
+  }
+}


### PR DESCRIPTION
## Summary
- move Telegram, Discord, WhatsApp, and Signal into gateway core with canonical channel config paths
- add a dedicated `pulseed gateway setup` wizard and reuse the same flow inside `pulseed setup`
- keep a compatibility migration path from legacy plugin channel configs into core-owned gateway channels

## Verification
- `npm run typecheck`
- `npx vitest run src/interface/cli/__tests__/gateway-setup.test.ts src/interface/cli/__tests__/telegram-setup.test.ts src/interface/cli/__tests__/setup-import.test.ts src/interface/cli/__tests__/cli-setup-notification.test.ts src/runtime/gateway/__tests__/builtin-channel-integrations.test.ts src/interface/cli/__tests__/cli-daemon-start.test.ts`
