### PR TITLE
feat(agent-loop): add first-class default profiles and review surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ default for most users is `agent_loop` with OpenAI or Anthropic.
   verify, or stop
 - `AgentLoop` handles bounded tool-using work for task execution, chat, and
   selected runtime phases
+- Centralized AgentLoop profiles keep task execution isolated by default,
+  narrow chat permissions, and run `/review` through a dedicated read-only
+  review posture
 - Dream-backed playbooks can feed verified workflow hints into later task
   generation without auto-writing executable skills
 - State, reports, schedules, and local memory live under `~/.pulseed/`

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,8 +59,10 @@ export type { ProviderConfig, ValidationResult } from "./base/llm/provider-confi
 export { TaskLifecycle } from "./orchestrator/execution/task/task-lifecycle.js";
 export {
   ChatAgentLoopRunner,
+  ReviewAgentLoopRunner,
   TaskAgentLoopRunner,
   createNativeChatAgentLoopRunner,
+  createNativeReviewAgentLoopRunner,
   createNativeTaskAgentLoopRunner,
   shouldUseNativeTaskAgentLoop,
 } from "./orchestrator/execution/agent-loop/index.js";

--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -73,6 +73,8 @@ describe("ChatRunner policy commands", () => {
     expect(result.success).toBe(true);
     expect(result.output).toContain("sandbox_mode: workspace_write");
     expect(result.output).toContain("network_access: off");
+    expect(result.output).toContain("profile_id: chat");
+    expect(result.output).toContain("resolved_posture: sandbox=workspace_write approval=on_request network=off");
   });
 
   it("/permissions updates sandbox and network settings for the session", async () => {
@@ -85,6 +87,8 @@ describe("ChatRunner policy commands", () => {
     expect(result.output).toContain("sandbox_mode: read_only");
     expect(result.output).toContain("network_access: on");
     expect(result.output).toContain("approval_policy: never");
+    expect(result.output).toContain("profile_id: chat");
+    expect(result.output).toContain("resolved_posture: sandbox=read_only approval=never network=on");
   });
 
   it("/review returns diff summary and execution policy", async () => {
@@ -96,6 +100,9 @@ describe("ChatRunner policy commands", () => {
     expect(result.success).toBe(true);
     expect(result.output).toContain("Review summary");
     expect(result.output).toContain("Execution policy");
+    expect(result.output).toContain("Review profile");
+    expect(result.output).toContain("profile_id: review");
+    expect(result.output).toContain("resolved_posture: sandbox=workspace_write approval=on_request network=off");
   });
 
   it("/fork creates a new session id", async () => {

--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -74,7 +74,7 @@ describe("ChatRunner policy commands", () => {
     expect(result.output).toContain("sandbox_mode: workspace_write");
     expect(result.output).toContain("network_access: off");
     expect(result.output).toContain("profile_id: chat");
-    expect(result.output).toContain("resolved_posture: sandbox=workspace_write approval=on_request network=off");
+    expect(result.output).toContain("resolved_posture: sandbox=workspace_write approval=on_request network=off reasoning=low");
   });
 
   it("/permissions updates sandbox and network settings for the session", async () => {
@@ -88,7 +88,7 @@ describe("ChatRunner policy commands", () => {
     expect(result.output).toContain("network_access: on");
     expect(result.output).toContain("approval_policy: never");
     expect(result.output).toContain("profile_id: chat");
-    expect(result.output).toContain("resolved_posture: sandbox=read_only approval=never network=on");
+    expect(result.output).toContain("resolved_posture: sandbox=read_only approval=never network=on reasoning=low");
   });
 
   it("/review returns diff summary and execution policy", async () => {
@@ -102,8 +102,7 @@ describe("ChatRunner policy commands", () => {
     expect(result.output).toContain("Execution policy");
     expect(result.output).toContain("Review profile");
     expect(result.output).toContain("profile_id: review");
-    expect(result.output).toContain("resolved_posture:");
-    expect(result.output).toContain("sandbox=read_only approval=never network=off");
+    expect(result.output).toContain("resolved_posture: sandbox=read_only approval=never network=off reasoning=medium");
   });
 
   it("/review routes through the native review runner with review posture", async () => {

--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -102,7 +102,34 @@ describe("ChatRunner policy commands", () => {
     expect(result.output).toContain("Execution policy");
     expect(result.output).toContain("Review profile");
     expect(result.output).toContain("profile_id: review");
-    expect(result.output).toContain("resolved_posture: sandbox=workspace_write approval=on_request network=off");
+    expect(result.output).toContain("resolved_posture:");
+    expect(result.output).toContain("sandbox=read_only approval=never network=off");
+  });
+
+  it("/review routes through the native review runner with review posture", async () => {
+    const reviewAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "native review output",
+        review: null,
+      }),
+    };
+    const runner = new ChatRunner(makeDeps({ reviewAgentLoopRunner }));
+    runner.startSession("/repo");
+
+    const result = await runner.execute("/review", "/repo");
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("native review output");
+    expect(reviewAgentLoopRunner.execute).toHaveBeenCalledOnce();
+    const input = vi.mocked(reviewAgentLoopRunner.execute).mock.calls[0][0] as {
+      executionPolicy?: { sandboxMode: string; approvalPolicy: string; networkAccess: boolean };
+    };
+    expect(input.executionPolicy).toMatchObject({
+      sandboxMode: "read_only",
+      approvalPolicy: "never",
+      networkAccess: false,
+    });
   });
 
   it("/fork creates a new session id", async () => {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -49,7 +49,11 @@ import type {
   RuntimeControlReplyTarget,
 } from "../../runtime/store/runtime-operation-schemas.js";
 import {
-  resolveExecutionPolicy,
+  formatAgentLoopResolvedProfileSummary,
+  resolveAgentLoopDefaultProfile,
+  summarizeAgentLoopResolvedProfile,
+} from "../../orchestrator/execution/agent-loop/agent-loop-default-profile.js";
+import {
   summarizeExecutionPolicy,
   withExecutionPolicyOverrides,
   type ExecutionPolicy,
@@ -735,7 +739,11 @@ export class ChatRunner {
     if (!args) {
       return {
         success: true,
-        output: summarizeExecutionPolicy(policy),
+        output: this.formatExecutionPolicyOutput(
+          summarizeExecutionPolicy(policy),
+          "Profile",
+          await this.getAgentLoopProfileSummary("chat", policy),
+        ),
         elapsed_ms: Date.now() - start,
       };
     }
@@ -779,7 +787,11 @@ export class ChatRunner {
     this.sessionExecutionPolicy = nextPolicy;
     return {
       success: true,
-      output: summarizeExecutionPolicy(nextPolicy),
+      output: this.formatExecutionPolicyOutput(
+        summarizeExecutionPolicy(nextPolicy),
+        "Profile",
+        await this.getAgentLoopProfileSummary("chat", nextPolicy),
+      ),
       elapsed_ms: Date.now() - start,
     };
   }
@@ -794,6 +806,9 @@ export class ChatRunner {
       "",
       "Execution policy",
       summarizeExecutionPolicy(policy),
+      "",
+      "Review profile",
+      await this.getAgentLoopProfileSummary("review"),
     ].join("\n");
     return { success: true, output, elapsed_ms: Date.now() - start };
   }
@@ -1984,12 +1999,37 @@ export class ChatRunner {
   /** Build a ToolCallContext from ChatRunnerDeps for tool dispatch. */
   private async getSessionExecutionPolicy(): Promise<ExecutionPolicy> {
     if (this.sessionExecutionPolicy) return this.sessionExecutionPolicy;
+    this.sessionExecutionPolicy = (await this.getAgentLoopDefaultProfile("chat")).executionPolicy!;
+    return this.sessionExecutionPolicy;
+  }
+
+  private async getAgentLoopDefaultProfile(
+    surface: "chat" | "review",
+  ): Promise<ReturnType<typeof resolveAgentLoopDefaultProfile>> {
     const config = await loadProviderConfig({ saveMigration: false });
-    this.sessionExecutionPolicy = resolveExecutionPolicy({
+    return resolveAgentLoopDefaultProfile({
+      surface,
       workspaceRoot: this.sessionCwd ?? process.cwd(),
       security: config.agent_loop?.security,
     });
-    return this.sessionExecutionPolicy;
+  }
+
+  private async getAgentLoopProfileSummary(
+    surface: "chat" | "review",
+    executionPolicy?: ExecutionPolicy,
+  ): Promise<string> {
+    const profile = await this.getAgentLoopDefaultProfile(surface);
+    return formatAgentLoopResolvedProfileSummary(
+      summarizeAgentLoopResolvedProfile(profile, executionPolicy),
+    );
+  }
+
+  private formatExecutionPolicyOutput(
+    policySummary: string,
+    profileHeading: string,
+    profileSummary: string,
+  ): string {
+    return [policySummary, "", profileHeading, profileSummary].join("\n");
   }
 
   private async buildToolCallContext(): Promise<ToolCallContext> {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -33,6 +33,7 @@ import type { DaemonClient } from "../../runtime/daemon/client.js";
 import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
 import type { ActivityKind, ChatEvent, ChatEventContext } from "./chat-events.js";
 import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
+import type { ReviewAgentLoopRunner } from "../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
 import type {
   AgentLoopEvent,
   AgentLoopEventSink,
@@ -99,6 +100,8 @@ export interface ChatRunnerDeps {
   onEvent?: (event: ChatEvent) => void;
   /** Optional: native agentloop runner for chat turns. */
   chatAgentLoopRunner?: ChatAgentLoopRunner;
+  /** Optional: native agentloop runner for review turns. */
+  reviewAgentLoopRunner?: Pick<ReviewAgentLoopRunner, "execute">;
   /** Optional: first-class runtime control service for natural-language restart/update requests. */
   runtimeControlService?: Pick<RuntimeControlService, "request">;
   /** Optional: approval handler scoped to runtime-control operations only. */
@@ -799,16 +802,27 @@ export class ChatRunner {
   private async handleReview(start: number): Promise<ChatRunResult> {
     const cwd = this.sessionCwd ?? process.cwd();
     const diffStat = await checkGitChanges(cwd);
-    const policy = await this.getSessionExecutionPolicy();
+    const reviewProfile = await this.getAgentLoopDefaultProfile("review");
+    const reviewPolicy = reviewProfile.executionPolicy ?? await this.getSessionExecutionPolicy();
+    if (this.deps.reviewAgentLoopRunner) {
+      const review = await this.deps.reviewAgentLoopRunner.execute({
+        cwd,
+        diffStat,
+        executionPolicy: reviewPolicy,
+      });
+      return { success: review.success, output: review.output, elapsed_ms: Date.now() - start };
+    }
     const output = [
       "Review summary",
       diffStat ? diffStat : "No uncommitted changes detected.",
       "",
       "Execution policy",
-      summarizeExecutionPolicy(policy),
+      summarizeExecutionPolicy(reviewPolicy),
       "",
       "Review profile",
-      await this.getAgentLoopProfileSummary("review"),
+      formatAgentLoopResolvedProfileSummary(
+        summarizeAgentLoopResolvedProfile(reviewProfile, reviewPolicy),
+      ),
     ].join("\n");
     return { success: true, output, elapsed_ms: Date.now() - start };
   }
@@ -1999,7 +2013,11 @@ export class ChatRunner {
   /** Build a ToolCallContext from ChatRunnerDeps for tool dispatch. */
   private async getSessionExecutionPolicy(): Promise<ExecutionPolicy> {
     if (this.sessionExecutionPolicy) return this.sessionExecutionPolicy;
-    this.sessionExecutionPolicy = (await this.getAgentLoopDefaultProfile("chat")).executionPolicy!;
+    const profile = await this.getAgentLoopDefaultProfile("chat");
+    if (!profile.executionPolicy) {
+      throw new Error("Chat profile did not resolve an execution policy.");
+    }
+    this.sessionExecutionPolicy = profile.executionPolicy;
     return this.sessionExecutionPolicy;
   }
 

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -25,6 +25,7 @@ import {
 } from "../../tools/index.js";
 import {
   createNativeChatAgentLoopRunner,
+  createNativeReviewAgentLoopRunner,
   shouldUseNativeTaskAgentLoop,
 } from "../../orchestrator/execution/agent-loop/index.js";
 import {
@@ -389,6 +390,15 @@ async function createGlobalCrossPlatformChatSessionManager(): Promise<CrossPlatf
         traceBaseDir: stateManager.getBaseDir(),
       })
     : undefined;
+  const reviewAgentLoopRunner = shouldUseNativeTaskAgentLoop(providerConfig, llmClient)
+    ? createNativeReviewAgentLoopRunner({
+        llmClient,
+        providerConfig,
+        toolRegistry,
+        toolExecutor,
+        traceBaseDir: stateManager.getBaseDir(),
+      })
+    : undefined;
 
   return new CrossPlatformChatSessionManager({
     stateManager,
@@ -397,6 +407,7 @@ async function createGlobalCrossPlatformChatSessionManager(): Promise<CrossPlatf
     registry: toolRegistry,
     toolExecutor,
     chatAgentLoopRunner,
+    reviewAgentLoopRunner,
     runtimeControlService: new RuntimeControlService({
       runtimeRoot: path.join(stateManager.getBaseDir(), "runtime"),
       executor: createDaemonRuntimeControlExecutor({

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -142,6 +142,7 @@ async function buildDeps() {
   const { buildCliDataSourceRegistry } = await import("../cli/data-source-bootstrap.js");
   const {
     createNativeChatAgentLoopRunner,
+    createNativeReviewAgentLoopRunner,
     createNativeTaskAgentLoopRunner,
     shouldUseNativeTaskAgentLoop,
   } = await import("../../orchestrator/execution/agent-loop/index.js");
@@ -445,6 +446,16 @@ async function buildDeps() {
           traceBaseDir: stateManager.getBaseDir(),
         })
       : undefined;
+    const reviewAgentLoopRunner = shouldUseNativeTaskAgentLoop(providerConfig, llmClient)
+      ? createNativeReviewAgentLoopRunner({
+          llmClient,
+          providerConfig,
+          toolRegistry,
+          toolExecutor,
+          cwd: process.cwd(),
+          traceBaseDir: stateManager.getBaseDir(),
+        })
+      : undefined;
     chatRunner = new ChatRunner({
       stateManager,
       adapter,
@@ -453,6 +464,7 @@ async function buildDeps() {
       registry: toolRegistry,
       toolExecutor,
       chatAgentLoopRunner,
+      reviewAgentLoopRunner,
       approvalFn: chatToolApprovalFn,
     });
   } catch (err) {
@@ -638,13 +650,23 @@ async function startTUIDaemonMode(): Promise<void> {
     try {
       const { ChatRunner } = await import("../../interface/chat/chat-runner.js");
       const { buildLLMClient, buildAdapterRegistry } = await import("../../base/llm/provider-factory.js");
-      const { createNativeChatAgentLoopRunner, shouldUseNativeTaskAgentLoop } = await import("../../orchestrator/execution/agent-loop/index.js");
+      const { createNativeChatAgentLoopRunner, createNativeReviewAgentLoopRunner, shouldUseNativeTaskAgentLoop } = await import("../../orchestrator/execution/agent-loop/index.js");
       const llmClient = await buildLLMClient();
       const adapterRegistry = await buildAdapterRegistry(llmClient);
       const adapterType = providerConfig.adapter ?? "claude_code_cli";
       const adapter = adapterRegistry.getAdapter(adapterType);
       const chatAgentLoopRunner = shouldUseNativeTaskAgentLoop(providerConfig, llmClient)
         ? createNativeChatAgentLoopRunner({
+            llmClient,
+            providerConfig,
+            toolRegistry,
+            toolExecutor,
+            cwd: process.cwd(),
+            traceBaseDir: stateManager.getBaseDir(),
+          })
+        : undefined;
+      const reviewAgentLoopRunner = shouldUseNativeTaskAgentLoop(providerConfig, llmClient)
+        ? createNativeReviewAgentLoopRunner({
             llmClient,
             providerConfig,
             toolRegistry,
@@ -661,6 +683,7 @@ async function startTUIDaemonMode(): Promise<void> {
         registry: toolRegistry,
         toolExecutor,
         chatAgentLoopRunner,
+        reviewAgentLoopRunner,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/orchestrator/execution/adapter-layer.ts
+++ b/src/orchestrator/execution/adapter-layer.ts
@@ -7,6 +7,7 @@
 
 import { AdapterError } from "../../base/utils/errors.js";
 import type { VerificationFileDiff } from "../../base/types/task.js";
+import type { AgentLoopReasoningEffort } from "./agent-loop/agent-loop-model.js";
 
 // ─── Types ───
 
@@ -41,6 +42,11 @@ export interface AgentLoopExecutionInfo {
   isolatedWorkspace?: boolean;
   workspaceCleanupStatus?: "not_requested" | "cleaned_up" | "kept";
   workspaceCleanupReason?: string;
+  profileName?: string;
+  reasoningEffort?: AgentLoopReasoningEffort;
+  sandboxMode?: string;
+  approvalPolicy?: string;
+  networkAccess?: boolean;
 }
 
 export interface AgentResult {

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-default-profile.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-default-profile.test.ts
@@ -4,7 +4,12 @@ import {
   resolveAgentLoopDefaultProfile,
   summarizeAgentLoopResolvedProfile,
 } from "../agent-loop-default-profile.js";
+import { createAgentLoopSession } from "../agent-loop-session.js";
+import { ToolRegistryAgentLoopToolRouter } from "../agent-loop-tool-router.js";
 import { StaticCorePhasePolicyRegistry } from "../../../loop/core-loop/phase-policy.js";
+import { ToolRegistry } from "../../../../tools/registry.js";
+import { ReadPulseedFileTool } from "../../../../tools/fs/ReadPulseedFileTool/ReadPulseedFileTool.js";
+import { TestRunnerTool } from "../../../../tools/system/TestRunnerTool/TestRunnerTool.js";
 
 describe("resolveAgentLoopDefaultProfile", () => {
   it("preserves current task defaults", () => {
@@ -42,8 +47,8 @@ describe("resolveAgentLoopDefaultProfile", () => {
       workspaceRoot: "/repo",
       budget: { maxModelTurns: 4 },
       toolPolicy: {
-        allowedTools: ["read_pulseed_file"],
-        requiredTools: ["read_pulseed_file"],
+        allowedTools: ["read-pulseed-file"],
+        requiredTools: ["read-pulseed-file"],
       },
     });
 
@@ -52,8 +57,8 @@ describe("resolveAgentLoopDefaultProfile", () => {
     expect(profile.budget.maxToolCalls).toBe(40);
     expect(profile.reasoningEffort).toBe("low");
     expect(profile.toolPolicy).toEqual({
-      allowedTools: ["read_pulseed_file"],
-      requiredTools: ["read_pulseed_file"],
+      allowedTools: ["read-pulseed-file"],
+      requiredTools: ["read-pulseed-file"],
     });
   });
 
@@ -66,7 +71,7 @@ describe("resolveAgentLoopDefaultProfile", () => {
     expect(profile.name).toBe("core_phase:observe_evidence");
     expect(profile.budget.maxModelTurns).toBe(6);
     expect(profile.toolPolicy.allowedTools).toEqual([
-      "read_pulseed_file",
+      "read-pulseed-file",
       "glob",
       "grep",
       "git_log",
@@ -95,7 +100,7 @@ describe("resolveAgentLoopDefaultProfile", () => {
     });
 
     expect(profile.toolPolicy.allowedTools).toContain("git_diff");
-    expect(profile.toolPolicy.allowedTools).toContain("test_runner");
+    expect(profile.toolPolicy.allowedTools).toContain("test-runner");
     expect(profile.executionPolicy).toMatchObject({
       sandboxMode: "read_only",
       approvalPolicy: "never",
@@ -108,6 +113,63 @@ describe("resolveAgentLoopDefaultProfile", () => {
       "profile_id: review",
       "resolved_posture: sandbox=read_only approval=never network=off reasoning=medium",
     ].join("\n"));
+  });
+
+  it("keeps real registry tool names visible through the router", () => {
+    const registry = new ToolRegistry();
+    registry.register(new ReadPulseedFileTool());
+    registry.register(new TestRunnerTool());
+    const router = new ToolRegistryAgentLoopToolRouter(registry);
+    const profile = resolveAgentLoopDefaultProfile({
+      surface: "review",
+      workspaceRoot: "/repo",
+    });
+
+    const visible = router.modelVisibleTools({
+      session: createAgentLoopSession({
+        sessionId: "session-1",
+        traceId: "trace-1",
+        stateStore: { load: async () => null, save: async () => undefined },
+      }),
+      turnId: "turn-1",
+      goalId: "review",
+      profileName: profile.name,
+      cwd: "/repo",
+      model: { providerId: "openai", modelId: "gpt-5.4-mini" },
+      modelInfo: {
+        ref: { providerId: "openai", modelId: "gpt-5.4-mini" },
+        displayName: "openai/gpt-5.4-mini",
+        capabilities: {
+          toolCalling: true,
+          parallelToolCalls: true,
+          streaming: false,
+          structuredOutput: true,
+          reasoning: true,
+          attachments: false,
+          interleavedThinking: false,
+          inputModalities: ["text"],
+          outputModalities: ["text"],
+        },
+      },
+      reasoningEffort: profile.reasoningEffort,
+      messages: [],
+      outputSchema: { parse: (value: unknown) => value } as never,
+      budget: profile.budget,
+      toolPolicy: profile.toolPolicy,
+      toolCallContext: {
+        cwd: "/repo",
+        goalId: "review",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+      executionPolicy: profile.executionPolicy,
+    });
+
+    expect(visible.map((tool) => tool.function.name)).toEqual([
+      "read-pulseed-file",
+      "test-runner",
+    ]);
   });
 });
 

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-default-profile.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-default-profile.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatAgentLoopResolvedProfileSummary,
+  resolveAgentLoopDefaultProfile,
+  summarizeAgentLoopResolvedProfile,
+} from "../agent-loop-default-profile.js";
+import { StaticCorePhasePolicyRegistry } from "../../../loop/core-loop/phase-policy.js";
+
+describe("resolveAgentLoopDefaultProfile", () => {
+  it("preserves current task defaults", () => {
+    const profile = resolveAgentLoopDefaultProfile({
+      surface: "task",
+      workspaceRoot: "/repo",
+      security: {
+        sandbox_mode: "workspace_write",
+        approval_policy: "on_request",
+        network_access: false,
+        trust_project_instructions: true,
+      },
+    });
+
+    expect(profile.name).toBe("task");
+    expect(profile.budget.maxModelTurns).toBe(12);
+    expect(profile.budget.compactionMaxMessages).toBe(8);
+    expect(profile.toolPolicy).toEqual({});
+    expect(profile.executionPolicy).toMatchObject({
+      sandboxMode: "workspace_write",
+      approvalPolicy: "on_request",
+      networkAccess: false,
+      trustProjectInstructions: true,
+    });
+  });
+
+  it("merges chat overrides on top of the current defaults", () => {
+    const profile = resolveAgentLoopDefaultProfile({
+      surface: "chat",
+      workspaceRoot: "/repo",
+      budget: { maxModelTurns: 4 },
+      toolPolicy: {
+        allowedTools: ["read_pulseed_file"],
+        requiredTools: ["read_pulseed_file"],
+      },
+    });
+
+    expect(profile.name).toBe("chat");
+    expect(profile.budget.maxModelTurns).toBe(4);
+    expect(profile.budget.maxToolCalls).toBe(40);
+    expect(profile.toolPolicy).toEqual({
+      allowedTools: ["read_pulseed_file"],
+      requiredTools: ["read_pulseed_file"],
+    });
+  });
+
+  it("preserves current core phase defaults", () => {
+    const profile = resolveAgentLoopDefaultProfile({
+      surface: "core_phase",
+      phase: "observe_evidence",
+    });
+
+    expect(profile.name).toBe("core_phase:observe_evidence");
+    expect(profile.budget.maxModelTurns).toBe(6);
+    expect(profile.toolPolicy.allowedTools).toEqual([
+      "read_pulseed_file",
+      "glob",
+      "grep",
+      "git_log",
+      "shell_command",
+      "soil_query",
+      "tool_search",
+    ]);
+    expect(profile.corePhase).toEqual({
+      enabled: true,
+      maxInvocationsPerIteration: 1,
+      failPolicy: "fallback_deterministic",
+    });
+  });
+
+  it("summarizes review posture without changing defaults", () => {
+    const profile = resolveAgentLoopDefaultProfile({
+      surface: "review",
+      workspaceRoot: "/repo",
+      security: {
+        sandbox_mode: "workspace_write",
+        approval_policy: "on_request",
+        network_access: false,
+        trust_project_instructions: true,
+      },
+    });
+
+    expect(
+      formatAgentLoopResolvedProfileSummary(summarizeAgentLoopResolvedProfile(profile)),
+    ).toBe([
+      "profile_id: review",
+      "resolved_posture: sandbox=workspace_write approval=on_request network=off",
+    ].join("\n"));
+  });
+});
+
+describe("StaticCorePhasePolicyRegistry", () => {
+  it("resolves defaults through the shared profile resolver", () => {
+    const registry = new StaticCorePhasePolicyRegistry();
+    const policy = registry.get("knowledge_refresh");
+
+    expect(policy.enabled).toBe(true);
+    expect(policy.requiredTools).toEqual(["soil_query"]);
+    expect(policy.allowedTools).toContain("knowledge_query");
+    expect(policy.budget.maxWallClockMs).toBe(90_000);
+    expect(policy.failPolicy).toBe("return_low_confidence");
+  });
+});

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-default-profile.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-default-profile.test.ts
@@ -75,7 +75,7 @@ describe("resolveAgentLoopDefaultProfile", () => {
     });
   });
 
-  it("summarizes review posture without changing defaults", () => {
+  it("resolves review posture to a dedicated read-only profile", () => {
     const profile = resolveAgentLoopDefaultProfile({
       surface: "review",
       workspaceRoot: "/repo",
@@ -87,11 +87,19 @@ describe("resolveAgentLoopDefaultProfile", () => {
       },
     });
 
+    expect(profile.toolPolicy.allowedTools).toContain("git_diff");
+    expect(profile.toolPolicy.allowedTools).toContain("test_runner");
+    expect(profile.executionPolicy).toMatchObject({
+      sandboxMode: "read_only",
+      approvalPolicy: "never",
+      networkAccess: false,
+      trustProjectInstructions: true,
+    });
     expect(
       formatAgentLoopResolvedProfileSummary(summarizeAgentLoopResolvedProfile(profile)),
     ).toBe([
       "profile_id: review",
-      "resolved_posture: sandbox=workspace_write approval=on_request network=off",
+      "resolved_posture: sandbox=read_only approval=never network=off",
     ].join("\n"));
   });
 });

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-default-profile.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-default-profile.test.ts
@@ -23,11 +23,16 @@ describe("resolveAgentLoopDefaultProfile", () => {
     expect(profile.budget.maxModelTurns).toBe(12);
     expect(profile.budget.compactionMaxMessages).toBe(8);
     expect(profile.toolPolicy).toEqual({});
+    expect(profile.reasoningEffort).toBe("medium");
     expect(profile.executionPolicy).toMatchObject({
       sandboxMode: "workspace_write",
-      approvalPolicy: "on_request",
+      approvalPolicy: "never",
       networkAccess: false,
       trustProjectInstructions: true,
+    });
+    expect(profile.worktreePolicy).toEqual({
+      enabled: true,
+      cleanupPolicy: "on_success",
     });
   });
 
@@ -45,6 +50,7 @@ describe("resolveAgentLoopDefaultProfile", () => {
     expect(profile.name).toBe("chat");
     expect(profile.budget.maxModelTurns).toBe(4);
     expect(profile.budget.maxToolCalls).toBe(40);
+    expect(profile.reasoningEffort).toBe("low");
     expect(profile.toolPolicy).toEqual({
       allowedTools: ["read_pulseed_file"],
       requiredTools: ["read_pulseed_file"],
@@ -73,6 +79,7 @@ describe("resolveAgentLoopDefaultProfile", () => {
       maxInvocationsPerIteration: 1,
       failPolicy: "fallback_deterministic",
     });
+    expect(profile.reasoningEffort).toBe("low");
   });
 
   it("resolves review posture to a dedicated read-only profile", () => {
@@ -99,7 +106,7 @@ describe("resolveAgentLoopDefaultProfile", () => {
       formatAgentLoopResolvedProfileSummary(summarizeAgentLoopResolvedProfile(profile)),
     ).toBe([
       "profile_id: review",
-      "resolved_posture: sandbox=read_only approval=never network=off",
+      "resolved_posture: sandbox=read_only approval=never network=off reasoning=medium",
     ].join("\n"));
   });
 });

--- a/src/orchestrator/execution/agent-loop/__tests__/review-agent-loop-runner.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/review-agent-loop-runner.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import { ReviewAgentLoopRunner } from "../review-agent-loop-runner.js";
+import type { AgentLoopResult } from "../agent-loop-result.js";
+import type { ReviewAgentLoopOutput } from "../review-agent-loop-runner.js";
+
+describe("ReviewAgentLoopRunner", () => {
+  it("runs with review posture and formats the returned review", async () => {
+    const run = vi.fn(async (turn: {
+      toolPolicy: { allowedTools?: readonly string[] };
+      profileName?: string;
+      reasoningEffort?: string;
+      executionPolicy?: { sandboxMode: string; approvalPolicy: string; networkAccess: boolean };
+      messages: Array<{ role: string; content: string }>;
+    }): Promise<AgentLoopResult<ReviewAgentLoopOutput>> => ({
+      success: true,
+      output: {
+        status: "needs_attention",
+        summary: "Two issues found",
+        findings: ["Missing regression test"],
+        suggestedChecks: ["Run targeted unit tests"],
+        evidence: ["git diff shows new behavior without coverage"],
+      },
+      finalText: "",
+      stopReason: "completed",
+      elapsedMs: 1,
+      modelTurns: 1,
+      toolCalls: 0,
+      compactions: 0,
+      changedFiles: [],
+      commandResults: [],
+      traceId: "trace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    }));
+    const runner = new ReviewAgentLoopRunner({
+      boundedRunner: { run } as never,
+      modelClient: {
+        getModelInfo: vi.fn().mockResolvedValue({
+          ref: { providerId: "openai", modelId: "gpt-5.4-mini" },
+          displayName: "openai/gpt-5.4-mini",
+          capabilities: {
+            toolCalling: true,
+            parallelToolCalls: true,
+            streaming: false,
+            structuredOutput: true,
+            reasoning: true,
+            attachments: false,
+            interleavedThinking: false,
+            inputModalities: ["text"],
+            outputModalities: ["text"],
+          },
+        }),
+      } as never,
+      modelRegistry: {
+        defaultModel: vi.fn().mockResolvedValue({ providerId: "openai", modelId: "gpt-5.4-mini" }),
+      } as never,
+      defaultToolPolicy: {
+        allowedTools: ["git_diff", "grep", "test-runner"],
+      },
+      defaultReasoningEffort: "medium",
+      defaultExecutionPolicy: {
+        sandboxMode: "read_only",
+        approvalPolicy: "never",
+        networkAccess: false,
+        workspaceRoot: "/repo",
+        protectedPaths: [],
+        trustProjectInstructions: true,
+      },
+      profile: {
+        name: "review",
+        budget: {
+          maxModelTurns: 6,
+          maxToolCalls: 10,
+          maxWallClockMs: 60_000,
+          maxConsecutiveToolErrors: 2,
+          maxRepeatedToolCalls: 2,
+          maxSchemaRepairAttempts: 1,
+          maxCompletionValidationAttempts: 1,
+          maxCompactions: 1,
+          compactionMaxMessages: 6,
+        },
+        toolPolicy: { allowedTools: ["git_diff", "grep", "test-runner"] },
+        executionPolicy: {
+          sandboxMode: "read_only",
+          approvalPolicy: "never",
+          networkAccess: false,
+          workspaceRoot: "/repo",
+          protectedPaths: [],
+          trustProjectInstructions: true,
+        },
+      },
+    });
+
+    const result = await runner.execute({
+      cwd: "/repo",
+      diffStat: " src/file.ts | 2 +-",
+      executionPolicy: {
+        sandboxMode: "read_only",
+        approvalPolicy: "never",
+        networkAccess: false,
+        workspaceRoot: "/repo",
+        protectedPaths: [],
+        trustProjectInstructions: true,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("status: needs_attention");
+    expect(result.output).toContain("findings:");
+    expect(result.output).toContain("Missing regression test");
+    const turn = run.mock.calls[0]?.[0] as {
+      toolPolicy: { allowedTools?: readonly string[] };
+      profileName?: string;
+      reasoningEffort?: string;
+      executionPolicy?: { sandboxMode: string; approvalPolicy: string; networkAccess: boolean };
+      messages: Array<{ role: string; content: string }>;
+    };
+    expect(turn.toolPolicy.allowedTools).toEqual(["git_diff", "grep", "test-runner"]);
+    expect(turn.messages[0]?.content).toContain("review agentloop");
+    expect(turn.messages[1]?.content).toContain("sandbox_mode: read_only");
+    expect(turn.profileName).toBe("review");
+    expect(turn.reasoningEffort).toBe("medium");
+    expect(turn.executionPolicy).toMatchObject({
+      sandboxMode: "read_only",
+      approvalPolicy: "never",
+      networkAccess: false,
+    });
+  });
+});

--- a/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
@@ -103,7 +103,7 @@ const DEFAULT_CORE_PHASE_BUDGET: Partial<Record<CorePhaseKind, Partial<AgentLoop
 };
 
 const CHAT_ALLOWED_TOOLS = [
-  "read_pulseed_file",
+  "read-pulseed-file",
   "glob",
   "grep",
   "list_dir",
@@ -114,7 +114,7 @@ const CHAT_ALLOWED_TOOLS = [
   "file_edit",
   "file_write",
   "json_query",
-  "test_runner",
+  "test-runner",
   "task_get",
   "goal_state",
   "progress_history",
@@ -127,13 +127,13 @@ const CHAT_ALLOWED_TOOLS = [
 ] as const;
 
 const REVIEW_ALLOWED_TOOLS = [
-  "read_pulseed_file",
+  "read-pulseed-file",
   "glob",
   "grep",
   "git_diff",
   "git_log",
   "shell_command",
-  "test_runner",
+  "test-runner",
   "task_get",
   "goal_state",
   "progress_history",
@@ -149,7 +149,7 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
     budget: DEFAULT_CORE_PHASE_BUDGET.observe_evidence ?? {},
     toolPolicy: {
       allowedTools: [
-        "read_pulseed_file",
+        "read-pulseed-file",
         "glob",
         "grep",
         "git_log",
@@ -168,7 +168,7 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
       allowedTools: [
         "soil_query",
         "knowledge_query",
-        "read_pulseed_file",
+        "read-pulseed-file",
         "grep",
       ],
       requiredTools: ["soil_query"],
@@ -181,7 +181,7 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
     budget: DEFAULT_CORE_PHASE_BUDGET.stall_investigation ?? {},
     toolPolicy: {
       allowedTools: [
-        "read_pulseed_file",
+        "read-pulseed-file",
         "glob",
         "grep",
         "git_log",
@@ -212,12 +212,12 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
     budget: DEFAULT_CORE_PHASE_BUDGET.verification_evidence ?? {},
     toolPolicy: {
       allowedTools: [
-        "read_pulseed_file",
+        "read-pulseed-file",
         "glob",
         "grep",
         "git_diff",
         "git_log",
-        "test_runner",
+        "test-runner",
         "shell_command",
       ],
     },

--- a/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
@@ -1,0 +1,237 @@
+import type { AgentLoopBudget } from "./agent-loop-budget.js";
+import type { CorePhaseKind } from "./core-phase-runner.js";
+import type { AgentLoopSecurityConfig, ExecutionPolicy } from "./execution-policy.js";
+import { resolveExecutionPolicy } from "./execution-policy.js";
+import type { AgentLoopReasoningEffort } from "./agent-loop-model.js";
+import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
+import { withDefaultBudget } from "./agent-loop-turn-context.js";
+import type { AgentLoopWorktreePolicy } from "./task-agent-loop-worktree.js";
+
+export type AgentLoopDefaultProfileName =
+  | "task"
+  | "chat"
+  | "review"
+  | `core_phase:${CorePhaseKind}`;
+
+export interface AgentLoopResolvedProfile {
+  name: AgentLoopDefaultProfileName;
+  budget: AgentLoopBudget;
+  toolPolicy: AgentLoopToolPolicy;
+  executionPolicy?: ExecutionPolicy;
+  reasoningEffort?: AgentLoopReasoningEffort;
+  worktreePolicy?: AgentLoopWorktreePolicy;
+  corePhase?: {
+    enabled: boolean;
+    maxInvocationsPerIteration: number;
+    failPolicy: "return_low_confidence" | "fallback_deterministic" | "fail_cycle";
+  };
+}
+
+export interface AgentLoopResolvedProfileSummary {
+  profileId: AgentLoopDefaultProfileName;
+  resolvedPosture: string;
+}
+
+interface CorePhaseProfileDefaults {
+  enabled: boolean;
+  maxInvocationsPerIteration: number;
+  budget: Partial<AgentLoopBudget>;
+  toolPolicy: AgentLoopToolPolicy;
+  failPolicy: "return_low_confidence" | "fallback_deterministic" | "fail_cycle";
+}
+
+const DEFAULT_SURFACE_PROFILE = {
+  budget: {} as Partial<AgentLoopBudget>,
+  toolPolicy: {} as AgentLoopToolPolicy,
+};
+
+const DEFAULT_CORE_PHASE_BUDGET: Partial<AgentLoopBudget> = {
+  maxModelTurns: 6,
+  maxToolCalls: 12,
+  maxWallClockMs: 90_000,
+  maxConsecutiveToolErrors: 2,
+  maxRepeatedToolCalls: 2,
+  maxSchemaRepairAttempts: 1,
+  maxCompletionValidationAttempts: 1,
+  maxCompactions: 1,
+  compactionMaxMessages: 6,
+};
+
+const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefaults> = {
+  observe_evidence: {
+    enabled: true,
+    maxInvocationsPerIteration: 1,
+    budget: DEFAULT_CORE_PHASE_BUDGET,
+    toolPolicy: {
+      allowedTools: [
+        "read_pulseed_file",
+        "glob",
+        "grep",
+        "git_log",
+        "shell_command",
+        "soil_query",
+        "tool_search",
+      ],
+    },
+    failPolicy: "fallback_deterministic",
+  },
+  knowledge_refresh: {
+    enabled: true,
+    maxInvocationsPerIteration: 1,
+    budget: DEFAULT_CORE_PHASE_BUDGET,
+    toolPolicy: {
+      allowedTools: [
+        "soil_query",
+        "knowledge_query",
+        "memory_recall",
+        "glob",
+        "grep",
+        "read_pulseed_file",
+      ],
+      requiredTools: ["soil_query"],
+    },
+    failPolicy: "return_low_confidence",
+  },
+  stall_investigation: {
+    enabled: true,
+    maxInvocationsPerIteration: 1,
+    budget: DEFAULT_CORE_PHASE_BUDGET,
+    toolPolicy: {
+      allowedTools: [
+        "progress_history",
+        "session_history",
+        "git_log",
+        "shell_command",
+        "soil_query",
+        "task_get",
+      ],
+    },
+    failPolicy: "return_low_confidence",
+  },
+  replanning_options: {
+    enabled: false,
+    maxInvocationsPerIteration: 1,
+    budget: DEFAULT_CORE_PHASE_BUDGET,
+    toolPolicy: {
+      allowedTools: [
+        "task_get",
+        "goal_state",
+        "soil_query",
+        "read_plan",
+        "session_history",
+        "memory_recall",
+      ],
+    },
+    failPolicy: "fallback_deterministic",
+  },
+  verification_evidence: {
+    enabled: true,
+    maxInvocationsPerIteration: 1,
+    budget: DEFAULT_CORE_PHASE_BUDGET,
+    toolPolicy: {
+      allowedTools: [
+        "test_runner",
+        "shell_command",
+        "git_diff",
+        "read_pulseed_file",
+        "grep",
+        "soil_query",
+      ],
+    },
+    failPolicy: "fallback_deterministic",
+  },
+};
+
+interface SurfaceProfileInput {
+  surface: "task" | "chat" | "review";
+  workspaceRoot: string;
+  security?: AgentLoopSecurityConfig;
+  budget?: Partial<AgentLoopBudget>;
+  toolPolicy?: AgentLoopToolPolicy;
+}
+
+interface CorePhaseProfileInput {
+  surface: "core_phase";
+  phase: CorePhaseKind;
+  workspaceRoot?: string;
+  security?: AgentLoopSecurityConfig;
+  budget?: Partial<AgentLoopBudget>;
+  toolPolicy?: AgentLoopToolPolicy;
+  enabled?: boolean;
+  maxInvocationsPerIteration?: number;
+  failPolicy?: "return_low_confidence" | "fallback_deterministic" | "fail_cycle";
+}
+
+export function resolveAgentLoopDefaultProfile(
+  input: SurfaceProfileInput | CorePhaseProfileInput,
+): AgentLoopResolvedProfile {
+  if (input.surface === "core_phase") {
+    const defaults = CORE_PHASE_PROFILE_DEFAULTS[input.phase];
+    return {
+      name: `core_phase:${input.phase}`,
+      budget: withDefaultBudget({ ...defaults.budget, ...input.budget }),
+      toolPolicy: mergeToolPolicy(defaults.toolPolicy, input.toolPolicy),
+      ...(input.workspaceRoot
+        ? {
+            executionPolicy: resolveExecutionPolicy({
+              workspaceRoot: input.workspaceRoot,
+              security: input.security,
+            }),
+          }
+        : {}),
+      corePhase: {
+        enabled: input.enabled ?? defaults.enabled,
+        maxInvocationsPerIteration: input.maxInvocationsPerIteration ?? defaults.maxInvocationsPerIteration,
+        failPolicy: input.failPolicy ?? defaults.failPolicy,
+      },
+    };
+  }
+
+  return {
+    name: input.surface,
+    budget: withDefaultBudget({ ...DEFAULT_SURFACE_PROFILE.budget, ...input.budget }),
+    toolPolicy: mergeToolPolicy(DEFAULT_SURFACE_PROFILE.toolPolicy, input.toolPolicy),
+    executionPolicy: resolveExecutionPolicy({
+      workspaceRoot: input.workspaceRoot,
+      security: input.security,
+    }),
+  };
+}
+
+export function summarizeAgentLoopResolvedProfile(
+  profile: Pick<AgentLoopResolvedProfile, "name" | "executionPolicy">,
+  executionPolicy = profile.executionPolicy,
+): AgentLoopResolvedProfileSummary {
+  return {
+    profileId: profile.name,
+    resolvedPosture: executionPolicy
+      ? `sandbox=${executionPolicy.sandboxMode} approval=${executionPolicy.approvalPolicy} network=${executionPolicy.networkAccess ? "on" : "off"}`
+      : "no_execution_policy",
+  };
+}
+
+export function formatAgentLoopResolvedProfileSummary(
+  summary: AgentLoopResolvedProfileSummary,
+): string {
+  return [
+    `profile_id: ${summary.profileId}`,
+    `resolved_posture: ${summary.resolvedPosture}`,
+  ].join("\n");
+}
+
+function mergeToolPolicy(
+  base: AgentLoopToolPolicy,
+  override?: AgentLoopToolPolicy,
+): AgentLoopToolPolicy {
+  const allowedTools = override?.allowedTools ?? base.allowedTools;
+  const requiredTools = override?.requiredTools ?? base.requiredTools;
+  const deniedTools = override?.deniedTools ?? base.deniedTools;
+  const includeDeferred = override?.includeDeferred ?? base.includeDeferred;
+
+  return {
+    ...(allowedTools ? { allowedTools: [...allowedTools] } : {}),
+    ...(requiredTools ? { requiredTools: [...requiredTools] } : {}),
+    ...(deniedTools ? { deniedTools: [...deniedTools] } : {}),
+    ...(includeDeferred !== undefined ? { includeDeferred } : {}),
+  };
+}

--- a/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
@@ -1,7 +1,7 @@
 import type { AgentLoopBudget } from "./agent-loop-budget.js";
 import type { CorePhaseKind } from "./core-phase-runner.js";
 import type { AgentLoopSecurityConfig, ExecutionPolicy } from "./execution-policy.js";
-import { resolveExecutionPolicy } from "./execution-policy.js";
+import { resolveExecutionPolicy, withExecutionPolicyOverrides } from "./execution-policy.js";
 import type { AgentLoopReasoningEffort } from "./agent-loop-model.js";
 import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
 import { withDefaultBudget } from "./agent-loop-turn-context.js";
@@ -40,6 +40,28 @@ interface CorePhaseProfileDefaults {
   failPolicy: "return_low_confidence" | "fallback_deterministic" | "fail_cycle";
 }
 
+interface SurfaceProfileInput {
+  surface: "task" | "chat" | "review";
+  workspaceRoot: string;
+  security?: AgentLoopSecurityConfig;
+  budget?: Partial<AgentLoopBudget>;
+  toolPolicy?: AgentLoopToolPolicy;
+  worktreePolicy?: AgentLoopWorktreePolicy;
+  reasoningEffort?: AgentLoopReasoningEffort;
+}
+
+interface CorePhaseProfileInput {
+  surface: "core_phase";
+  phase: CorePhaseKind;
+  workspaceRoot?: string;
+  security?: AgentLoopSecurityConfig;
+  budget?: Partial<AgentLoopBudget>;
+  toolPolicy?: AgentLoopToolPolicy;
+  enabled?: boolean;
+  maxInvocationsPerIteration?: number;
+  failPolicy?: "return_low_confidence" | "fallback_deterministic" | "fail_cycle";
+}
+
 const DEFAULT_SURFACE_PROFILE = {
   budget: {} as Partial<AgentLoopBudget>,
   toolPolicy: {} as AgentLoopToolPolicy,
@@ -57,6 +79,52 @@ const DEFAULT_CORE_PHASE_BUDGET: Partial<AgentLoopBudget> = {
   compactionMaxMessages: 6,
 };
 
+const CHAT_ALLOWED_TOOLS = [
+  "read",
+  "read-pulseed-file",
+  "glob",
+  "grep",
+  "git_diff",
+  "git_log",
+  "shell_command",
+  "test-runner",
+  "tool_search",
+  "read-plan",
+  "session_history",
+  "progress_history",
+  "task_get",
+  "goal_state",
+  "soil_query",
+  "knowledge_query",
+  "memory_recall",
+  "web_search",
+  "http_fetch",
+  "github_read",
+  "mcp_list_tools",
+  "mcp_call_tool",
+  "desktop_list_apps",
+  "desktop_get_app_state",
+  "browser_get_state",
+  "browser_run_workflow",
+] as const;
+
+const REVIEW_ALLOWED_TOOLS = [
+  "read",
+  "read-pulseed-file",
+  "glob",
+  "grep",
+  "git_diff",
+  "git_log",
+  "shell_command",
+  "test-runner",
+  "task_get",
+  "goal_state",
+  "progress_history",
+  "session_history",
+  "soil_query",
+  "knowledge_query",
+] as const;
+
 const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefaults> = {
   observe_evidence: {
     enabled: true,
@@ -64,7 +132,8 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
     budget: DEFAULT_CORE_PHASE_BUDGET,
     toolPolicy: {
       allowedTools: [
-        "read_pulseed_file",
+        "read",
+        "read-pulseed-file",
         "glob",
         "grep",
         "git_log",
@@ -86,7 +155,8 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
         "memory_recall",
         "glob",
         "grep",
-        "read_pulseed_file",
+        "read",
+        "read-pulseed-file",
       ],
       requiredTools: ["soil_query"],
     },
@@ -117,7 +187,7 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
         "task_get",
         "goal_state",
         "soil_query",
-        "read_plan",
+        "read-plan",
         "session_history",
         "memory_recall",
       ],
@@ -130,10 +200,11 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
     budget: DEFAULT_CORE_PHASE_BUDGET,
     toolPolicy: {
       allowedTools: [
-        "test_runner",
+        "test-runner",
         "shell_command",
         "git_diff",
-        "read_pulseed_file",
+        "read",
+        "read-pulseed-file",
         "grep",
         "soil_query",
       ],
@@ -141,26 +212,6 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
     failPolicy: "fallback_deterministic",
   },
 };
-
-interface SurfaceProfileInput {
-  surface: "task" | "chat" | "review";
-  workspaceRoot: string;
-  security?: AgentLoopSecurityConfig;
-  budget?: Partial<AgentLoopBudget>;
-  toolPolicy?: AgentLoopToolPolicy;
-}
-
-interface CorePhaseProfileInput {
-  surface: "core_phase";
-  phase: CorePhaseKind;
-  workspaceRoot?: string;
-  security?: AgentLoopSecurityConfig;
-  budget?: Partial<AgentLoopBudget>;
-  toolPolicy?: AgentLoopToolPolicy;
-  enabled?: boolean;
-  maxInvocationsPerIteration?: number;
-  failPolicy?: "return_low_confidence" | "fallback_deterministic" | "fail_cycle";
-}
 
 export function resolveAgentLoopDefaultProfile(
   input: SurfaceProfileInput | CorePhaseProfileInput,
@@ -171,6 +222,7 @@ export function resolveAgentLoopDefaultProfile(
       name: `core_phase:${input.phase}`,
       budget: withDefaultBudget({ ...defaults.budget, ...input.budget }),
       toolPolicy: mergeToolPolicy(defaults.toolPolicy, input.toolPolicy),
+      reasoningEffort: "low",
       ...(input.workspaceRoot
         ? {
             executionPolicy: resolveExecutionPolicy({
@@ -187,25 +239,79 @@ export function resolveAgentLoopDefaultProfile(
     };
   }
 
+  const executionPolicy = resolveExecutionPolicy({
+    workspaceRoot: input.workspaceRoot,
+    security: input.security,
+  });
+
+  if (input.surface === "review") {
+    return {
+      name: "review",
+      budget: withDefaultBudget({
+        ...DEFAULT_SURFACE_PROFILE.budget,
+        maxModelTurns: 6,
+        maxToolCalls: 10,
+        ...input.budget,
+      }),
+      toolPolicy: mergeToolPolicy(
+        {
+          allowedTools: REVIEW_ALLOWED_TOOLS,
+        },
+        input.toolPolicy,
+      ),
+      executionPolicy: withExecutionPolicyOverrides(executionPolicy, {
+        sandboxMode: "read_only",
+        approvalPolicy: "never",
+      }),
+      reasoningEffort: input.reasoningEffort ?? "medium",
+    };
+  }
+
+  if (input.surface === "chat") {
+    return {
+      name: "chat",
+      budget: withDefaultBudget({ ...DEFAULT_SURFACE_PROFILE.budget, ...input.budget }),
+      toolPolicy: mergeToolPolicy(
+        {
+          allowedTools: CHAT_ALLOWED_TOOLS,
+        },
+        input.toolPolicy,
+      ),
+      executionPolicy,
+      reasoningEffort: input.reasoningEffort ?? "low",
+    };
+  }
+
   return {
     name: input.surface,
     budget: withDefaultBudget({ ...DEFAULT_SURFACE_PROFILE.budget, ...input.budget }),
     toolPolicy: mergeToolPolicy(DEFAULT_SURFACE_PROFILE.toolPolicy, input.toolPolicy),
-    executionPolicy: resolveExecutionPolicy({
-      workspaceRoot: input.workspaceRoot,
-      security: input.security,
+    executionPolicy: withExecutionPolicyOverrides(executionPolicy, {
+      approvalPolicy: "never",
     }),
+    worktreePolicy: {
+      enabled: true,
+      cleanupPolicy: "on_success",
+      ...input.worktreePolicy,
+    },
+    reasoningEffort: input.reasoningEffort ?? "medium",
   };
 }
 
 export function summarizeAgentLoopResolvedProfile(
-  profile: Pick<AgentLoopResolvedProfile, "name" | "executionPolicy">,
+  profile: Pick<AgentLoopResolvedProfile, "name" | "executionPolicy" | "reasoningEffort" | "worktreePolicy">,
   executionPolicy = profile.executionPolicy,
 ): AgentLoopResolvedProfileSummary {
   return {
     profileId: profile.name,
     resolvedPosture: executionPolicy
-      ? `sandbox=${executionPolicy.sandboxMode} approval=${executionPolicy.approvalPolicy} network=${executionPolicy.networkAccess ? "on" : "off"}`
+      ? [
+          `sandbox=${executionPolicy.sandboxMode}`,
+          `approval=${executionPolicy.approvalPolicy}`,
+          `network=${executionPolicy.networkAccess ? "on" : "off"}`,
+          `worktree=${profile.worktreePolicy?.enabled ? "isolated" : "shared"}`,
+          `reasoning=${profile.reasoningEffort ?? "default"}`,
+        ].join(" ")
       : "no_execution_policy",
   };
 }

--- a/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
@@ -53,8 +53,6 @@ interface SurfaceProfileInput {
 interface CorePhaseProfileInput {
   surface: "core_phase";
   phase: CorePhaseKind;
-  workspaceRoot?: string;
-  security?: AgentLoopSecurityConfig;
   budget?: Partial<AgentLoopBudget>;
   toolPolicy?: AgentLoopToolPolicy;
   enabled?: boolean;
@@ -62,61 +60,80 @@ interface CorePhaseProfileInput {
   failPolicy?: "return_low_confidence" | "fallback_deterministic" | "fail_cycle";
 }
 
-const DEFAULT_SURFACE_PROFILE = {
-  budget: {} as Partial<AgentLoopBudget>,
-  toolPolicy: {} as AgentLoopToolPolicy,
-};
+export type ResolveAgentLoopDefaultProfileInput =
+  | SurfaceProfileInput
+  | CorePhaseProfileInput;
 
-const DEFAULT_CORE_PHASE_BUDGET: Partial<AgentLoopBudget> = {
-  maxModelTurns: 6,
-  maxToolCalls: 12,
-  maxWallClockMs: 90_000,
-  maxConsecutiveToolErrors: 2,
-  maxRepeatedToolCalls: 2,
-  maxSchemaRepairAttempts: 1,
-  maxCompletionValidationAttempts: 1,
-  maxCompactions: 1,
-  compactionMaxMessages: 6,
+const DEFAULT_SURFACE_PROFILE = {
+  budget: withDefaultBudget(),
+  toolPolicy: {},
+} as const;
+
+const DEFAULT_CORE_PHASE_BUDGET: Partial<Record<CorePhaseKind, Partial<AgentLoopBudget>>> = {
+  observe_evidence: {
+    maxModelTurns: 6,
+    maxToolCalls: 8,
+    maxWallClockMs: 90_000,
+    compactionMaxMessages: 6,
+  },
+  knowledge_refresh: {
+    maxModelTurns: 6,
+    maxToolCalls: 8,
+    maxWallClockMs: 90_000,
+    compactionMaxMessages: 6,
+  },
+  stall_investigation: {
+    maxModelTurns: 4,
+    maxToolCalls: 5,
+    maxWallClockMs: 60_000,
+    compactionMaxMessages: 6,
+  },
+  replanning_options: {
+    maxModelTurns: 4,
+    maxToolCalls: 4,
+    maxWallClockMs: 60_000,
+    compactionMaxMessages: 6,
+  },
+  verification_evidence: {
+    maxModelTurns: 6,
+    maxToolCalls: 8,
+    maxWallClockMs: 90_000,
+    compactionMaxMessages: 6,
+  },
 };
 
 const CHAT_ALLOWED_TOOLS = [
-  "read",
-  "read-pulseed-file",
+  "read_pulseed_file",
   "glob",
   "grep",
+  "list_dir",
   "git_diff",
   "git_log",
   "shell_command",
-  "test-runner",
-  "tool_search",
-  "read-plan",
-  "session_history",
-  "progress_history",
+  "apply_patch",
+  "file_edit",
+  "file_write",
+  "json_query",
+  "test_runner",
   "task_get",
   "goal_state",
+  "progress_history",
+  "session_history",
+  "tool_search",
+  "update_plan",
   "soil_query",
   "knowledge_query",
   "memory_recall",
-  "web_search",
-  "http_fetch",
-  "github_read",
-  "mcp_list_tools",
-  "mcp_call_tool",
-  "desktop_list_apps",
-  "desktop_get_app_state",
-  "browser_get_state",
-  "browser_run_workflow",
 ] as const;
 
 const REVIEW_ALLOWED_TOOLS = [
-  "read",
-  "read-pulseed-file",
+  "read_pulseed_file",
   "glob",
   "grep",
   "git_diff",
   "git_log",
   "shell_command",
-  "test-runner",
+  "test_runner",
   "task_get",
   "goal_state",
   "progress_history",
@@ -129,11 +146,10 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
   observe_evidence: {
     enabled: true,
     maxInvocationsPerIteration: 1,
-    budget: DEFAULT_CORE_PHASE_BUDGET,
+    budget: DEFAULT_CORE_PHASE_BUDGET.observe_evidence ?? {},
     toolPolicy: {
       allowedTools: [
-        "read",
-        "read-pulseed-file",
+        "read_pulseed_file",
         "glob",
         "grep",
         "git_log",
@@ -147,16 +163,13 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
   knowledge_refresh: {
     enabled: true,
     maxInvocationsPerIteration: 1,
-    budget: DEFAULT_CORE_PHASE_BUDGET,
+    budget: DEFAULT_CORE_PHASE_BUDGET.knowledge_refresh ?? {},
     toolPolicy: {
       allowedTools: [
         "soil_query",
         "knowledge_query",
-        "memory_recall",
-        "glob",
+        "read_pulseed_file",
         "grep",
-        "read",
-        "read-pulseed-file",
       ],
       requiredTools: ["soil_query"],
     },
@@ -165,31 +178,30 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
   stall_investigation: {
     enabled: true,
     maxInvocationsPerIteration: 1,
-    budget: DEFAULT_CORE_PHASE_BUDGET,
+    budget: DEFAULT_CORE_PHASE_BUDGET.stall_investigation ?? {},
     toolPolicy: {
       allowedTools: [
-        "progress_history",
-        "session_history",
+        "read_pulseed_file",
+        "glob",
+        "grep",
         "git_log",
         "shell_command",
-        "soil_query",
-        "task_get",
+        "progress_history",
+        "tool_search",
       ],
     },
     failPolicy: "return_low_confidence",
   },
   replanning_options: {
-    enabled: false,
+    enabled: true,
     maxInvocationsPerIteration: 1,
-    budget: DEFAULT_CORE_PHASE_BUDGET,
+    budget: DEFAULT_CORE_PHASE_BUDGET.replanning_options ?? {},
     toolPolicy: {
       allowedTools: [
         "task_get",
         "goal_state",
+        "progress_history",
         "soil_query",
-        "read-plan",
-        "session_history",
-        "memory_recall",
       ],
     },
     failPolicy: "fallback_deterministic",
@@ -197,24 +209,24 @@ const CORE_PHASE_PROFILE_DEFAULTS: Record<CorePhaseKind, CorePhaseProfileDefault
   verification_evidence: {
     enabled: true,
     maxInvocationsPerIteration: 1,
-    budget: DEFAULT_CORE_PHASE_BUDGET,
+    budget: DEFAULT_CORE_PHASE_BUDGET.verification_evidence ?? {},
     toolPolicy: {
       allowedTools: [
-        "test-runner",
-        "shell_command",
-        "git_diff",
-        "read",
-        "read-pulseed-file",
+        "read_pulseed_file",
+        "glob",
         "grep",
-        "soil_query",
+        "git_diff",
+        "git_log",
+        "test_runner",
+        "shell_command",
       ],
     },
-    failPolicy: "fallback_deterministic",
+    failPolicy: "return_low_confidence",
   },
 };
 
 export function resolveAgentLoopDefaultProfile(
-  input: SurfaceProfileInput | CorePhaseProfileInput,
+  input: ResolveAgentLoopDefaultProfileInput,
 ): AgentLoopResolvedProfile {
   if (input.surface === "core_phase") {
     const defaults = CORE_PHASE_PROFILE_DEFAULTS[input.phase];
@@ -223,14 +235,6 @@ export function resolveAgentLoopDefaultProfile(
       budget: withDefaultBudget({ ...defaults.budget, ...input.budget }),
       toolPolicy: mergeToolPolicy(defaults.toolPolicy, input.toolPolicy),
       reasoningEffort: "low",
-      ...(input.workspaceRoot
-        ? {
-            executionPolicy: resolveExecutionPolicy({
-              workspaceRoot: input.workspaceRoot,
-              security: input.security,
-            }),
-          }
-        : {}),
       corePhase: {
         enabled: input.enabled ?? defaults.enabled,
         maxInvocationsPerIteration: input.maxInvocationsPerIteration ?? defaults.maxInvocationsPerIteration,
@@ -273,6 +277,7 @@ export function resolveAgentLoopDefaultProfile(
       budget: withDefaultBudget({ ...DEFAULT_SURFACE_PROFILE.budget, ...input.budget }),
       toolPolicy: mergeToolPolicy(
         {
+          ...DEFAULT_SURFACE_PROFILE.toolPolicy,
           allowedTools: CHAT_ALLOWED_TOOLS,
         },
         input.toolPolicy,
@@ -283,36 +288,45 @@ export function resolveAgentLoopDefaultProfile(
   }
 
   return {
-    name: input.surface,
+    name: "task",
     budget: withDefaultBudget({ ...DEFAULT_SURFACE_PROFILE.budget, ...input.budget }),
     toolPolicy: mergeToolPolicy(DEFAULT_SURFACE_PROFILE.toolPolicy, input.toolPolicy),
     executionPolicy: withExecutionPolicyOverrides(executionPolicy, {
       approvalPolicy: "never",
     }),
-    worktreePolicy: {
-      enabled: true,
-      cleanupPolicy: "on_success",
-      ...input.worktreePolicy,
-    },
+    worktreePolicy: mergeWorktreePolicy(
+      { enabled: true, cleanupPolicy: "on_success" },
+      input.worktreePolicy,
+    ),
     reasoningEffort: input.reasoningEffort ?? "medium",
   };
 }
 
 export function summarizeAgentLoopResolvedProfile(
-  profile: Pick<AgentLoopResolvedProfile, "name" | "executionPolicy" | "reasoningEffort" | "worktreePolicy">,
+  profile: Pick<
+    AgentLoopResolvedProfile,
+    "name" | "executionPolicy" | "reasoningEffort" | "worktreePolicy"
+  >,
   executionPolicy = profile.executionPolicy,
 ): AgentLoopResolvedProfileSummary {
+  const posture = executionPolicy
+    ? [
+        `sandbox=${executionPolicy.sandboxMode}`,
+        `approval=${executionPolicy.approvalPolicy}`,
+        `network=${executionPolicy.networkAccess ? "on" : "off"}`,
+      ]
+    : ["execution=unset"];
+
+  if (profile.worktreePolicy) {
+    posture.push(`worktree=${profile.worktreePolicy.enabled ? "on" : "off"}`);
+  }
+  if (profile.reasoningEffort) {
+    posture.push(`reasoning=${profile.reasoningEffort}`);
+  }
+
   return {
     profileId: profile.name,
-    resolvedPosture: executionPolicy
-      ? [
-          `sandbox=${executionPolicy.sandboxMode}`,
-          `approval=${executionPolicy.approvalPolicy}`,
-          `network=${executionPolicy.networkAccess ? "on" : "off"}`,
-          `worktree=${profile.worktreePolicy?.enabled ? "isolated" : "shared"}`,
-          `reasoning=${profile.reasoningEffort ?? "default"}`,
-        ].join(" ")
-      : "no_execution_policy",
+    resolvedPosture: posture.join(" "),
   };
 }
 
@@ -326,18 +340,22 @@ export function formatAgentLoopResolvedProfileSummary(
 }
 
 function mergeToolPolicy(
-  base: AgentLoopToolPolicy,
+  base: AgentLoopToolPolicy | undefined,
   override?: AgentLoopToolPolicy,
 ): AgentLoopToolPolicy {
-  const allowedTools = override?.allowedTools ?? base.allowedTools;
-  const requiredTools = override?.requiredTools ?? base.requiredTools;
-  const deniedTools = override?.deniedTools ?? base.deniedTools;
-  const includeDeferred = override?.includeDeferred ?? base.includeDeferred;
-
   return {
-    ...(allowedTools ? { allowedTools: [...allowedTools] } : {}),
-    ...(requiredTools ? { requiredTools: [...requiredTools] } : {}),
-    ...(deniedTools ? { deniedTools: [...deniedTools] } : {}),
-    ...(includeDeferred !== undefined ? { includeDeferred } : {}),
+    ...(base ?? {}),
+    ...(override ?? {}),
+  };
+}
+
+function mergeWorktreePolicy(
+  base: AgentLoopWorktreePolicy | undefined,
+  override: AgentLoopWorktreePolicy | undefined,
+): AgentLoopWorktreePolicy | undefined {
+  if (!base && !override) return undefined;
+  return {
+    ...(base ?? {}),
+    ...(override ?? {}),
   };
 }

--- a/src/orchestrator/execution/agent-loop/agent-loop-model.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model.ts
@@ -31,6 +31,7 @@ export interface AgentLoopModelInfo {
 
 export type AgentLoopMessageRole = "system" | "user" | "assistant" | "tool";
 export type AgentLoopMessagePhase = "commentary" | "final_answer";
+export type AgentLoopReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
 
 export interface AgentLoopMessage {
   role: AgentLoopMessageRole;
@@ -53,6 +54,7 @@ export interface AgentLoopModelRequest {
   tools: ToolDefinition[];
   system?: string;
   maxOutputTokens?: number;
+  reasoningEffort?: AgentLoopReasoningEffort;
 }
 
 export interface AgentLoopAssistantOutput {

--- a/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
@@ -1,14 +1,16 @@
 import type { SubagentRole } from "./execution-policy.js";
 
 export function buildAgentLoopBaseInstructions(options?: {
-  mode?: "task" | "chat";
+  mode?: "task" | "chat" | "review";
   extraRules?: string[];
   role?: SubagentRole;
 }): string {
   const mode = options?.mode ?? "task";
   const header = mode === "task"
     ? "You are PulSeed's task agentloop."
-    : "You are PulSeed's user-facing agentloop.";
+    : mode === "review"
+      ? "You are PulSeed's review agentloop."
+      : "You are PulSeed's user-facing agentloop.";
 
   const rules = [
     header,

--- a/src/orchestrator/execution/agent-loop/agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-result.ts
@@ -1,3 +1,5 @@
+import type { AgentLoopReasoningEffort } from "./agent-loop-model.js";
+import type { ExecutionPolicy } from "./execution-policy.js";
 import type { AgentLoopStopReason } from "./agent-loop-budget.js";
 
 export type AgentLoopCommandResultCategory = "verification" | "observation" | "other";
@@ -38,6 +40,9 @@ export interface AgentLoopResult<TOutput> {
   traceId: string;
   sessionId: string;
   turnId: string;
+  profileName?: string;
+  reasoningEffort?: AgentLoopReasoningEffort;
+  executionPolicy?: ExecutionPolicy;
 }
 
 export interface AgentLoopCompletionValidationResult {

--- a/src/orchestrator/execution/agent-loop/agent-loop-session-factory.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-session-factory.ts
@@ -7,7 +7,7 @@ import { JsonAgentLoopSessionStateStore } from "./agent-loop-session-state.js";
 
 export interface PersistentAgentLoopSessionFactoryOptions {
   traceBaseDir: string;
-  kind: "task" | "chat";
+  kind: "task" | "chat" | "review";
 }
 
 export interface PersistentAgentLoopSessionInput {

--- a/src/orchestrator/execution/agent-loop/agent-loop-turn-context.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-turn-context.ts
@@ -2,10 +2,16 @@ import type { z } from "zod";
 import type { ToolCallContext } from "../../../tools/types.js";
 import type { AgentLoopBudget } from "./agent-loop-budget.js";
 import { defaultAgentLoopBudget } from "./agent-loop-budget.js";
-import type { AgentLoopModelInfo, AgentLoopMessage, AgentLoopModelRef } from "./agent-loop-model.js";
+import type {
+  AgentLoopModelInfo,
+  AgentLoopMessage,
+  AgentLoopModelRef,
+  AgentLoopReasoningEffort,
+} from "./agent-loop-model.js";
 import type { AgentLoopCommandResult, AgentLoopCompletionValidationResult } from "./agent-loop-result.js";
 import type { AgentLoopSession } from "./agent-loop-session.js";
 import type { AgentLoopSessionState } from "./agent-loop-session-state.js";
+import type { ExecutionPolicy } from "./execution-policy.js";
 
 export interface AgentLoopToolPolicy {
   allowedTools?: readonly string[];
@@ -19,14 +25,17 @@ export interface AgentLoopTurnContext<TOutput> {
   turnId: string;
   goalId: string;
   taskId?: string;
+  profileName?: string;
   cwd: string;
   model: AgentLoopModelRef;
   modelInfo: AgentLoopModelInfo;
+  reasoningEffort?: AgentLoopReasoningEffort;
   messages: AgentLoopMessage[];
   outputSchema: z.ZodType<TOutput, z.ZodTypeDef, unknown>;
   budget: AgentLoopBudget;
   toolPolicy: AgentLoopToolPolicy;
   toolCallContext: ToolCallContext;
+  executionPolicy?: ExecutionPolicy;
   completionValidator?: (input: {
     output: TOutput;
     changedFiles: string[];

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -380,6 +380,9 @@ export class BoundedAgentLoopRunner {
       traceId: turn.session.traceId,
       sessionId: turn.session.sessionId,
       turnId: turn.turnId,
+      ...(turn.profileName ? { profileName: turn.profileName } : {}),
+      ...(turn.reasoningEffort ? { reasoningEffort: turn.reasoningEffort } : {}),
+      ...(turn.executionPolicy ? { executionPolicy: turn.executionPolicy } : {}),
     };
   }
 
@@ -502,6 +505,7 @@ export class BoundedAgentLoopRunner {
         model: turn.model,
         messages,
         tools,
+        reasoningEffort: turn.reasoningEffort,
       });
     }
 
@@ -509,6 +513,7 @@ export class BoundedAgentLoopRunner {
       model: turn.model,
       messages,
       tools,
+      reasoningEffort: turn.reasoningEffort,
     });
     return {
       assistant: response.content || response.toolCalls.length > 0 ? [{

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import type { AgentResult } from "../adapter-layer.js";
 import type { AgentLoopBudget } from "./agent-loop-budget.js";
-import type { AgentLoopModelClient, AgentLoopModelRef, AgentLoopModelRegistry } from "./agent-loop-model.js";
+import type {
+  AgentLoopModelClient,
+  AgentLoopModelRef,
+  AgentLoopModelRegistry,
+  AgentLoopReasoningEffort,
+} from "./agent-loop-model.js";
 import { createAgentLoopSession, type AgentLoopSession } from "./agent-loop-session.js";
 import type { AgentLoopEventSink } from "./agent-loop-events.js";
 import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
@@ -11,7 +16,7 @@ import type { BoundedAgentLoopRunner } from "./bounded-agent-loop-runner.js";
 import type { AgentLoopSessionState } from "./agent-loop-session-state.js";
 import { buildAgentLoopBaseInstructions } from "./agent-loop-prompts.js";
 import type { ApprovalRequest, ToolCallContext } from "../../../tools/types.js";
-import type { SubagentRole } from "./execution-policy.js";
+import type { ExecutionPolicy, SubagentRole } from "./execution-policy.js";
 
 export const ChatAgentLoopOutputSchema = z.object({
   status: z.enum(["done", "blocked", "failed"]).default("done"),
@@ -30,6 +35,9 @@ export interface ChatAgentLoopRunnerDeps {
   defaultBudget?: Partial<AgentLoopBudget>;
   defaultToolPolicy?: AgentLoopToolPolicy;
   defaultToolCallContext?: Partial<ToolCallContext>;
+  defaultReasoningEffort?: AgentLoopReasoningEffort;
+  defaultProfileName?: string;
+  defaultExecutionPolicy?: ExecutionPolicy;
   createSession?: (input: {
     goalId?: string;
     eventSink?: AgentLoopEventSink;
@@ -82,6 +90,8 @@ export class ChatAgentLoopRunner {
       cwd,
       model,
       modelInfo,
+      ...(this.deps.defaultProfileName ? { profileName: this.deps.defaultProfileName } : {}),
+      ...(this.deps.defaultReasoningEffort ? { reasoningEffort: this.deps.defaultReasoningEffort } : {}),
       messages: input.resumeOnly
         ? []
         : [
@@ -106,6 +116,7 @@ export class ChatAgentLoopRunner {
       budget: withDefaultBudget({ ...this.deps.defaultBudget, ...input.budget }),
       toolPolicy: { ...this.deps.defaultToolPolicy, ...input.toolPolicy },
       ...(input.resumeState ? { resumeState: input.resumeState } : {}),
+      ...(this.deps.defaultExecutionPolicy ? { executionPolicy: this.deps.defaultExecutionPolicy } : {}),
       toolCallContext: {
         cwd,
         goalId: input.goalId ?? "chat",
@@ -154,9 +165,18 @@ export class ChatAgentLoopRunner {
         modelTurns: result.modelTurns,
         toolCalls: result.toolCalls,
         compactions: result.compactions,
+        ...(result.profileName ? { profileName: result.profileName } : {}),
+        ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),
         completionEvidence: result.output?.evidence ?? [],
         verificationHints: result.output?.blockers ?? [],
         filesChangedPaths: result.changedFiles,
+        ...(result.executionPolicy
+          ? {
+              sandboxMode: result.executionPolicy.sandboxMode,
+              approvalPolicy: result.executionPolicy.approvalPolicy,
+              networkAccess: result.executionPolicy.networkAccess,
+            }
+          : {}),
       },
     };
   }

--- a/src/orchestrator/execution/agent-loop/index.ts
+++ b/src/orchestrator/execution/agent-loop/index.ts
@@ -2,6 +2,7 @@ export * from "./agent-loop-budget.js";
 export * from "./agent-loop-command-classifier.js";
 export * from "./agent-loop-compactor.js";
 export * from "./agent-loop-context-assembler.js";
+export * from "./agent-loop-default-profile.js";
 export * from "./agent-loop-dogfood-benchmark.js";
 export * from "./agent-loop-evaluator.js";
 export * from "./agent-loop-events.js";

--- a/src/orchestrator/execution/agent-loop/index.ts
+++ b/src/orchestrator/execution/agent-loop/index.ts
@@ -29,6 +29,7 @@ export * from "./core-phase-runner.js";
 export * from "./openai-responses-agent-loop-model-client.js";
 export * from "./agent-loop-prompts.js";
 export * from "./prompted-tool-protocol.js";
+export * from "./review-agent-loop-runner.js";
 export * from "./task-agent-loop-context.js";
 export * from "./task-agent-loop-factory.js";
 export * from "./task-agent-loop-result.js";

--- a/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
@@ -61,6 +61,7 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
       input: this.toInputItems(input.messages),
       tools: input.tools.map((tool) => this.toFunctionTool(tool)),
       max_output_tokens: input.maxOutputTokens,
+      ...(input.reasoningEffort ? { reasoning: { effort: input.reasoningEffort } } : {}),
     }) as Response;
 
     const assistant: AgentLoopAssistantOutput[] = [];

--- a/src/orchestrator/execution/agent-loop/review-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/review-agent-loop-runner.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import type { AgentLoopBudget } from "./agent-loop-budget.js";
+import type { AgentLoopResolvedProfile } from "./agent-loop-default-profile.js";
+import {
+  formatAgentLoopResolvedProfileSummary,
+  summarizeAgentLoopResolvedProfile,
+} from "./agent-loop-default-profile.js";
+import type {
+  AgentLoopModelClient,
+  AgentLoopModelRef,
+  AgentLoopModelRegistry,
+  AgentLoopReasoningEffort,
+} from "./agent-loop-model.js";
+import { createAgentLoopSession, type AgentLoopSession } from "./agent-loop-session.js";
+import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
+import { withDefaultBudget } from "./agent-loop-turn-context.js";
+import type { BoundedAgentLoopRunner } from "./bounded-agent-loop-runner.js";
+import { buildAgentLoopBaseInstructions } from "./agent-loop-prompts.js";
+import { summarizeExecutionPolicy, type ExecutionPolicy } from "./execution-policy.js";
+import type { ToolCallContext } from "../../../tools/types.js";
+
+export const ReviewAgentLoopOutputSchema = z.object({
+  status: z.enum(["clean", "needs_attention", "blocked"]).default("clean"),
+  summary: z.string(),
+  findings: z.array(z.string()).default([]),
+  suggestedChecks: z.array(z.string()).default([]),
+  evidence: z.array(z.string()).default([]),
+});
+
+export type ReviewAgentLoopOutput = z.infer<typeof ReviewAgentLoopOutputSchema>;
+
+export interface ReviewAgentLoopRunnerDeps {
+  boundedRunner: BoundedAgentLoopRunner;
+  modelClient: AgentLoopModelClient;
+  modelRegistry: AgentLoopModelRegistry;
+  defaultModel?: AgentLoopModelRef;
+  cwd?: string;
+  defaultBudget?: Partial<AgentLoopBudget>;
+  defaultToolPolicy?: AgentLoopToolPolicy;
+  defaultToolCallContext?: Partial<ToolCallContext>;
+  defaultReasoningEffort?: AgentLoopReasoningEffort;
+  defaultExecutionPolicy?: ExecutionPolicy;
+  profile?: AgentLoopResolvedProfile;
+  createSession?: () => AgentLoopSession;
+}
+
+export interface ReviewAgentLoopInput {
+  cwd?: string;
+  diffStat?: string | null;
+  executionPolicy: ExecutionPolicy;
+  model?: AgentLoopModelRef;
+}
+
+export interface ReviewAgentLoopResult {
+  success: boolean;
+  output: string;
+  review: ReviewAgentLoopOutput | null;
+}
+
+export class ReviewAgentLoopRunner {
+  constructor(private readonly deps: ReviewAgentLoopRunnerDeps) {}
+
+  async execute(input: ReviewAgentLoopInput): Promise<ReviewAgentLoopResult> {
+    const cwd = input.cwd ?? this.deps.cwd ?? process.cwd();
+    const model = input.model ?? this.deps.defaultModel ?? await this.deps.modelRegistry.defaultModel();
+    const modelInfo = await this.deps.modelClient.getModelInfo(model);
+    const session = this.deps.createSession?.() ?? createAgentLoopSession();
+    const result = await this.deps.boundedRunner.run({
+      session,
+      turnId: randomUUID(),
+      goalId: "review",
+      profileName: this.deps.profile?.name ?? "review",
+      cwd,
+      model,
+      modelInfo,
+      reasoningEffort: this.deps.defaultReasoningEffort ?? this.deps.profile?.reasoningEffort,
+      messages: [
+        {
+          role: "system",
+          content: buildAgentLoopBaseInstructions({
+            mode: "review",
+            role: "reviewer",
+            extraRules: [
+              "Review the current workspace diff and supporting evidence without making edits.",
+              "Report only material defects, regressions, or missing verification.",
+              "If the diff is clean, say so directly.",
+            ],
+          }),
+        },
+        {
+          role: "user",
+          content: [
+            "Review the current workspace state.",
+            input.diffStat?.trim()
+              ? `Git diff stat:\n${input.diffStat.trim()}`
+              : "Git diff stat:\nNo uncommitted changes detected.",
+            "Resolved runtime posture:",
+            summarizeExecutionPolicy(input.executionPolicy),
+            "Return schema-valid review findings only.",
+          ].join("\n\n"),
+        },
+      ],
+      outputSchema: ReviewAgentLoopOutputSchema,
+      budget: withDefaultBudget(this.deps.defaultBudget),
+      toolPolicy: { ...this.deps.defaultToolPolicy },
+      executionPolicy: this.deps.defaultExecutionPolicy ?? input.executionPolicy,
+      toolCallContext: {
+        cwd,
+        goalId: "review",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+        ...this.deps.defaultToolCallContext,
+      },
+    });
+
+    const review = result.output;
+    const finalReview = review ?? {
+      status: "blocked" as const,
+      summary: result.finalText || result.stopReason,
+      findings: [],
+      suggestedChecks: [],
+      evidence: [],
+    };
+
+    return {
+      success: result.success && review !== null,
+      output: formatReviewOutput(finalReview, this.deps.profile, input.executionPolicy),
+      review,
+    };
+  }
+}
+
+function formatReviewOutput(
+  review: ReviewAgentLoopOutput,
+  profile: AgentLoopResolvedProfile | undefined,
+  executionPolicy: ExecutionPolicy,
+): string {
+  const lines = [
+    "Review summary",
+    review.summary,
+    "",
+    "Execution policy",
+    summarizeExecutionPolicy(executionPolicy),
+    "",
+    "Review profile",
+    formatAgentLoopResolvedProfileSummary(
+      summarizeAgentLoopResolvedProfile(profile ?? { name: "review", executionPolicy }, executionPolicy),
+    ),
+    "",
+    `status: ${review.status}`,
+  ];
+
+  if (review.findings.length > 0) {
+    lines.push("", "findings:");
+    for (const finding of review.findings) {
+      lines.push(`- ${finding}`);
+    }
+  }
+
+  if (review.suggestedChecks.length > 0) {
+    lines.push("", "suggested checks:");
+    for (const check of review.suggestedChecks) {
+      lines.push(`- ${check}`);
+    }
+  }
+
+  if (review.evidence.length > 0) {
+    lines.push("", "evidence:");
+    for (const item of review.evidence) {
+      lines.push(`- ${item}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-context.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-context.ts
@@ -3,7 +3,11 @@ import { cwd as processCwd } from "node:process";
 import type { Task } from "../../../base/types/task.js";
 import type { ToolCallContext } from "../../../tools/types.js";
 import type { AgentLoopBudget } from "./agent-loop-budget.js";
-import type { AgentLoopModelInfo, AgentLoopModelRef } from "./agent-loop-model.js";
+import type {
+  AgentLoopModelInfo,
+  AgentLoopModelRef,
+  AgentLoopReasoningEffort,
+} from "./agent-loop-model.js";
 import type { AgentLoopCompletionValidationResult } from "./agent-loop-result.js";
 import type { AgentLoopSession } from "./agent-loop-session.js";
 import type { AgentLoopSessionState } from "./agent-loop-session-state.js";
@@ -12,7 +16,7 @@ import { withDefaultBudget } from "./agent-loop-turn-context.js";
 import { TaskAgentLoopOutputSchema, type TaskAgentLoopOutput } from "./task-agent-loop-result.js";
 import { buildAgentLoopBaseInstructions } from "./agent-loop-prompts.js";
 import { isTaskRelevantVerificationCommand } from "./task-agent-loop-verification.js";
-import type { SubagentRole } from "./execution-policy.js";
+import type { ExecutionPolicy, SubagentRole } from "./execution-policy.js";
 
 export interface TaskAgentLoopContextInput {
   task: Task;
@@ -27,6 +31,9 @@ export interface TaskAgentLoopContextInput {
   budget?: Partial<AgentLoopBudget>;
   toolPolicy?: AgentLoopToolPolicy;
   toolCallContext?: Partial<ToolCallContext>;
+  profileName?: string;
+  reasoningEffort?: AgentLoopReasoningEffort;
+  executionPolicy?: ExecutionPolicy;
   resumeState?: AgentLoopSessionState;
   abortSignal?: AbortSignal;
   role?: SubagentRole;
@@ -50,9 +57,11 @@ export function buildTaskAgentLoopTurnContext(
     turnId: randomUUID(),
     goalId: input.task.goal_id,
     taskId: input.task.id,
+    ...(input.profileName ? { profileName: input.profileName } : {}),
     cwd,
     model: input.model,
     modelInfo: input.modelInfo,
+    ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
     messages: [
       {
         role: "system",
@@ -71,6 +80,7 @@ export function buildTaskAgentLoopTurnContext(
     outputSchema: TaskAgentLoopOutputSchema,
     budget: withDefaultBudget(input.budget),
     toolPolicy: input.toolPolicy ?? {},
+    ...(input.executionPolicy ? { executionPolicy: input.executionPolicy } : {}),
     completionValidator: ({ output, changedFiles, commandResults }): AgentLoopCompletionValidationResult => {
       if (output.status !== "done") return { ok: true, reasons: [] };
 

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
@@ -55,6 +55,7 @@ export function createNativeTaskAgentLoopRunner(
     security: deps.providerConfig.agent_loop?.security,
     budget: deps.defaultBudget,
     toolPolicy: deps.defaultToolPolicy,
+    worktreePolicy: deps.defaultWorktreePolicy ?? deps.providerConfig.agent_loop?.worktree,
   });
 
   return new TaskAgentLoopRunner({
@@ -65,7 +66,10 @@ export function createNativeTaskAgentLoopRunner(
     defaultBudget: profile.budget,
     defaultToolPolicy: profile.toolPolicy,
     defaultToolCallContext: profile.executionPolicy ? { executionPolicy: profile.executionPolicy } : undefined,
-    defaultWorktreePolicy: deps.defaultWorktreePolicy,
+    defaultWorktreePolicy: profile.worktreePolicy ?? deps.defaultWorktreePolicy,
+    defaultReasoningEffort: profile.reasoningEffort,
+    defaultProfileName: profile.name,
+    defaultExecutionPolicy: profile.executionPolicy,
     soilPrefetch: deps.soilPrefetch,
     cwd: deps.cwd,
     createSession: deps.traceBaseDir
@@ -97,6 +101,9 @@ export function createNativeChatAgentLoopRunner(
     defaultBudget: profile.budget,
     defaultToolPolicy: profile.toolPolicy,
     defaultToolCallContext: profile.executionPolicy ? { executionPolicy: profile.executionPolicy } : undefined,
+    defaultReasoningEffort: profile.reasoningEffort,
+    defaultProfileName: profile.name,
+    defaultExecutionPolicy: profile.executionPolicy,
     cwd: deps.cwd,
     createSession: deps.traceBaseDir
       ? createPersistentAgentLoopSessionFactory({ traceBaseDir: deps.traceBaseDir, kind: "chat" })

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
@@ -19,9 +19,9 @@ import { TaskAgentLoopRunner } from "./task-agent-loop-runner.js";
 import type { AgentLoopBudget } from "./agent-loop-budget.js";
 import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
 import type { SoilPrefetchQuery, SoilPrefetchResult } from "./agent-loop-context-assembler.js";
+import { resolveAgentLoopDefaultProfile } from "./agent-loop-default-profile.js";
 import { createPersistentAgentLoopSessionFactory } from "./agent-loop-session-factory.js";
 import type { AgentLoopWorktreePolicy } from "./task-agent-loop-worktree.js";
-import { resolveExecutionPolicy } from "./execution-policy.js";
 
 export interface NativeTaskAgentLoopRuntimeDeps {
   llmClient: ILLMClient;
@@ -48,9 +48,12 @@ export function createNativeTaskAgentLoopRunner(
   deps: NativeTaskAgentLoopRuntimeDeps,
 ): TaskAgentLoopRunner {
   const runtime = createNativeAgentLoopRuntime(deps);
-  const executionPolicy = resolveExecutionPolicy({
+  const profile = resolveAgentLoopDefaultProfile({
+    surface: "task",
     workspaceRoot: deps.cwd ?? process.cwd(),
     security: deps.providerConfig.agent_loop?.security,
+    budget: deps.defaultBudget,
+    toolPolicy: deps.defaultToolPolicy,
   });
 
   return new TaskAgentLoopRunner({
@@ -58,9 +61,9 @@ export function createNativeTaskAgentLoopRunner(
     modelClient: runtime.modelClient,
     modelRegistry: runtime.modelRegistry,
     defaultModel: runtime.modelInfo.ref,
-    defaultBudget: deps.defaultBudget,
-    defaultToolPolicy: deps.defaultToolPolicy,
-    defaultToolCallContext: { executionPolicy },
+    defaultBudget: profile.budget,
+    defaultToolPolicy: profile.toolPolicy,
+    defaultToolCallContext: profile.executionPolicy ? { executionPolicy: profile.executionPolicy } : undefined,
     defaultWorktreePolicy: deps.defaultWorktreePolicy,
     soilPrefetch: deps.soilPrefetch,
     cwd: deps.cwd,
@@ -77,9 +80,12 @@ export function createNativeChatAgentLoopRunner(
   deps: NativeTaskAgentLoopRuntimeDeps,
 ): ChatAgentLoopRunner {
   const runtime = createNativeAgentLoopRuntime(deps);
-  const executionPolicy = resolveExecutionPolicy({
+  const profile = resolveAgentLoopDefaultProfile({
+    surface: "chat",
     workspaceRoot: deps.cwd ?? process.cwd(),
     security: deps.providerConfig.agent_loop?.security,
+    budget: deps.defaultBudget,
+    toolPolicy: deps.defaultToolPolicy,
   });
 
   return new ChatAgentLoopRunner({
@@ -87,9 +93,9 @@ export function createNativeChatAgentLoopRunner(
     modelClient: runtime.modelClient,
     modelRegistry: runtime.modelRegistry,
     defaultModel: runtime.modelInfo.ref,
-    defaultBudget: deps.defaultBudget,
-    defaultToolPolicy: deps.defaultToolPolicy,
-    defaultToolCallContext: { executionPolicy },
+    defaultBudget: profile.budget,
+    defaultToolPolicy: profile.toolPolicy,
+    defaultToolCallContext: profile.executionPolicy ? { executionPolicy: profile.executionPolicy } : undefined,
     cwd: deps.cwd,
     createSession: deps.traceBaseDir
       ? createPersistentAgentLoopSessionFactory({ traceBaseDir: deps.traceBaseDir, kind: "chat" })

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
@@ -15,6 +15,7 @@ import {
 import { ToolExecutorAgentLoopToolRuntime } from "./agent-loop-tool-runtime.js";
 import { ToolRegistryAgentLoopToolRouter } from "./agent-loop-tool-router.js";
 import { ChatAgentLoopRunner } from "./chat-agent-loop-runner.js";
+import { ReviewAgentLoopRunner } from "./review-agent-loop-runner.js";
 import { TaskAgentLoopRunner } from "./task-agent-loop-runner.js";
 import type { AgentLoopBudget } from "./agent-loop-budget.js";
 import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
@@ -99,6 +100,34 @@ export function createNativeChatAgentLoopRunner(
     cwd: deps.cwd,
     createSession: deps.traceBaseDir
       ? createPersistentAgentLoopSessionFactory({ traceBaseDir: deps.traceBaseDir, kind: "chat" })
+      : undefined,
+  });
+}
+
+export function createNativeReviewAgentLoopRunner(
+  deps: NativeTaskAgentLoopRuntimeDeps,
+): ReviewAgentLoopRunner {
+  const runtime = createNativeAgentLoopRuntime(deps);
+  const profile = resolveAgentLoopDefaultProfile({
+    surface: "review",
+    workspaceRoot: deps.cwd ?? process.cwd(),
+    security: deps.providerConfig.agent_loop?.security,
+  });
+
+  return new ReviewAgentLoopRunner({
+    boundedRunner: runtime.boundedRunner,
+    modelClient: runtime.modelClient,
+    modelRegistry: runtime.modelRegistry,
+    defaultModel: runtime.modelInfo.ref,
+    defaultBudget: profile.budget,
+    defaultToolPolicy: profile.toolPolicy,
+    defaultToolCallContext: profile.executionPolicy ? { executionPolicy: profile.executionPolicy } : undefined,
+    defaultReasoningEffort: profile.reasoningEffort,
+    defaultExecutionPolicy: profile.executionPolicy,
+    profile,
+    cwd: deps.cwd,
+    createSession: deps.traceBaseDir
+      ? createPersistentAgentLoopSessionFactory({ traceBaseDir: deps.traceBaseDir, kind: "review" })
       : undefined,
   });
 }

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
@@ -49,6 +49,8 @@ export function taskAgentLoopResultToAgentResult(
       modelTurns: result.modelTurns,
       toolCalls: result.toolCalls,
       compactions: result.compactions,
+      ...(result.profileName ? { profileName: result.profileName } : {}),
+      ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),
       completionEvidence: [
         ...(result.output?.completionEvidence ?? []),
         ...runtimeVerificationCommands.filter((command) => command.success).map((command) => `verified command: ${command.command}`),
@@ -65,6 +67,13 @@ export function taskAgentLoopResultToAgentResult(
             isolatedWorkspace: result.workspace.isolated,
             workspaceCleanupStatus: result.workspace.cleanupStatus,
             workspaceCleanupReason: result.workspace.cleanupReason,
+          }
+        : {}),
+      ...(result.executionPolicy
+        ? {
+            sandboxMode: result.executionPolicy.sandboxMode,
+            approvalPolicy: result.executionPolicy.approvalPolicy,
+            networkAccess: result.executionPolicy.networkAccess,
           }
         : {}),
     },

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-runner.ts
@@ -1,7 +1,12 @@
 import type { Task } from "../../../base/types/task.js";
 import type { AgentResult } from "../adapter-layer.js";
 import type { AgentLoopBudget } from "./agent-loop-budget.js";
-import type { AgentLoopModelClient, AgentLoopModelRef, AgentLoopModelRegistry } from "./agent-loop-model.js";
+import type {
+  AgentLoopModelClient,
+  AgentLoopModelRef,
+  AgentLoopModelRegistry,
+  AgentLoopReasoningEffort,
+} from "./agent-loop-model.js";
 import { BoundedAgentLoopRunner } from "./bounded-agent-loop-runner.js";
 import { createAgentLoopSession, type AgentLoopSession } from "./agent-loop-session.js";
 import type { AgentLoopResult } from "./agent-loop-result.js";
@@ -19,7 +24,7 @@ import {
   type AgentLoopWorktreePolicy,
 } from "./task-agent-loop-worktree.js";
 import type { ToolCallContext } from "../../../tools/types.js";
-import type { SubagentRole } from "./execution-policy.js";
+import type { ExecutionPolicy, SubagentRole } from "./execution-policy.js";
 
 export interface TaskAgentLoopRunnerDeps {
   boundedRunner: BoundedAgentLoopRunner;
@@ -30,6 +35,9 @@ export interface TaskAgentLoopRunnerDeps {
   defaultToolPolicy?: AgentLoopToolPolicy;
   defaultToolCallContext?: Partial<ToolCallContext>;
   defaultWorktreePolicy?: AgentLoopWorktreePolicy;
+  defaultReasoningEffort?: AgentLoopReasoningEffort;
+  defaultProfileName?: string;
+  defaultExecutionPolicy?: ExecutionPolicy;
   contextAssembler?: AgentLoopContextAssembler;
   soilPrefetch?: (query: SoilPrefetchQuery) => Promise<SoilPrefetchResult | null>;
   cwd?: string;
@@ -85,6 +93,9 @@ export class TaskAgentLoopRunner {
       budget: { ...this.deps.defaultBudget, ...input.budget },
       toolPolicy: { ...this.deps.defaultToolPolicy, ...input.toolPolicy },
       toolCallContext: this.deps.defaultToolCallContext,
+      ...(this.deps.defaultProfileName ? { profileName: this.deps.defaultProfileName } : {}),
+      ...(this.deps.defaultReasoningEffort ? { reasoningEffort: this.deps.defaultReasoningEffort } : {}),
+      ...(this.deps.defaultExecutionPolicy ? { executionPolicy: this.deps.defaultExecutionPolicy } : {}),
       ...(input.resumeState ? { resumeState: input.resumeState } : {}),
       abortSignal: input.abortSignal,
       role: input.role,

--- a/src/orchestrator/loop/core-loop/phase-policy.ts
+++ b/src/orchestrator/loop/core-loop/phase-policy.ts
@@ -1,3 +1,4 @@
+import { resolveAgentLoopDefaultProfile } from "../../execution/agent-loop/agent-loop-default-profile.js";
 import type { CorePhaseKind } from "../../execution/agent-loop/core-phase-runner.js";
 import type { AgentLoopBudget } from "../../execution/agent-loop/agent-loop-budget.js";
 
@@ -14,93 +15,43 @@ export interface CorePhasePolicyRegistry {
   get(phase: CorePhaseKind): CorePhasePolicy;
 }
 
-const DEFAULT_POLICY: CorePhasePolicy = {
-  enabled: false,
-  maxInvocationsPerIteration: 1,
-  budget: {
-    maxModelTurns: 6,
-    maxToolCalls: 12,
-    maxWallClockMs: 90_000,
-    maxConsecutiveToolErrors: 2,
-    maxRepeatedToolCalls: 2,
-    maxSchemaRepairAttempts: 1,
-    maxCompletionValidationAttempts: 1,
-    maxCompactions: 1,
-    compactionMaxMessages: 6,
-  },
-  allowedTools: [],
-  requiredTools: [],
-  failPolicy: "fallback_deterministic",
-};
+const CORE_PHASE_KINDS: readonly CorePhaseKind[] = [
+  "observe_evidence",
+  "knowledge_refresh",
+  "stall_investigation",
+  "replanning_options",
+  "verification_evidence",
+] as const;
 
-export const defaultCorePhasePolicies: Record<CorePhaseKind, CorePhasePolicy> = {
-  observe_evidence: {
-    ...DEFAULT_POLICY,
-    enabled: true,
-    allowedTools: [
-      "read_pulseed_file",
-      "glob",
-      "grep",
-      "git_log",
-      "shell_command",
-      "soil_query",
-      "tool_search",
-    ],
-  },
-  knowledge_refresh: {
-    ...DEFAULT_POLICY,
-    enabled: true,
-    allowedTools: [
-      "soil_query",
-      "knowledge_query",
-      "memory_recall",
-      "glob",
-      "grep",
-      "read_pulseed_file",
-    ],
-    requiredTools: ["soil_query"],
-    failPolicy: "return_low_confidence",
-  },
-  stall_investigation: {
-    ...DEFAULT_POLICY,
-    enabled: true,
-    allowedTools: [
-      "progress_history",
-      "session_history",
-      "git_log",
-      "shell_command",
-      "soil_query",
-      "task_get",
-    ],
-    failPolicy: "return_low_confidence",
-  },
-  replanning_options: {
-    ...DEFAULT_POLICY,
-    enabled: false,
-    allowedTools: [
-      "task_get",
-      "goal_state",
-      "soil_query",
-      "read_plan",
-      "session_history",
-      "memory_recall",
-    ],
-    failPolicy: "fallback_deterministic",
-  },
-  verification_evidence: {
-    ...DEFAULT_POLICY,
-    enabled: true,
-    allowedTools: [
-      "test_runner",
-      "shell_command",
-      "git_diff",
-      "read_pulseed_file",
-      "grep",
-      "soil_query",
-    ],
-    failPolicy: "fallback_deterministic",
-  },
-};
+function toCorePhasePolicy(phase: CorePhaseKind, override?: CorePhasePolicy): CorePhasePolicy {
+  const resolved = resolveAgentLoopDefaultProfile({
+    surface: "core_phase",
+    phase,
+    ...(override?.budget ? { budget: override.budget } : {}),
+    toolPolicy: {
+      ...(override?.allowedTools ? { allowedTools: override.allowedTools } : {}),
+      ...(override?.requiredTools ? { requiredTools: override.requiredTools } : {}),
+    },
+    ...(override?.enabled !== undefined ? { enabled: override.enabled } : {}),
+    ...(override?.maxInvocationsPerIteration !== undefined
+      ? { maxInvocationsPerIteration: override.maxInvocationsPerIteration }
+      : {}),
+    ...(override?.failPolicy ? { failPolicy: override.failPolicy } : {}),
+  });
+
+  return {
+    enabled: resolved.corePhase?.enabled ?? false,
+    maxInvocationsPerIteration: resolved.corePhase?.maxInvocationsPerIteration ?? 1,
+    budget: resolved.budget,
+    allowedTools: resolved.toolPolicy.allowedTools ?? [],
+    requiredTools: resolved.toolPolicy.requiredTools ?? [],
+    failPolicy: resolved.corePhase?.failPolicy ?? "fallback_deterministic",
+  };
+}
+
+export const defaultCorePhasePolicies: Record<CorePhaseKind, CorePhasePolicy> = Object.fromEntries(
+  CORE_PHASE_KINDS.map((phase) => [phase, toCorePhasePolicy(phase)]),
+) as Record<CorePhaseKind, CorePhasePolicy>;
 
 export class StaticCorePhasePolicyRegistry implements CorePhasePolicyRegistry {
   constructor(
@@ -108,6 +59,6 @@ export class StaticCorePhasePolicyRegistry implements CorePhasePolicyRegistry {
   ) {}
 
   get(phase: CorePhaseKind): CorePhasePolicy {
-    return this.policies[phase] ?? DEFAULT_POLICY;
+    return toCorePhasePolicy(phase, this.policies[phase]);
   }
 }


### PR DESCRIPTION
## Summary
- add first-class AgentLoop default profiles for task, chat, review, and core phases
- wire resolved profile posture through native task/chat/review entrypoints and runtime metadata
- add a native review surface plus targeted verification for profile posture, reasoning defaults, and worktree defaults

## Verification
- npm run typecheck -- --pretty false
- npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-default-profile.test.ts src/orchestrator/execution/agent-loop/__tests__/review-agent-loop-runner.test.ts src/orchestrator/execution/agent-loop/__tests__/openai-responses-agent-loop-model-client.test.ts src/interface/chat/__tests__/chat-runner-policy.test.ts src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-worktree.test.ts