### PR TITLE
feat(runtime): durable usage telemetry and /usage command surfaces

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -37,12 +37,12 @@ Supported chat slash commands:
 - Session: `/help`, `/clear`, `/sessions`, `/history [id|title]`, `/title <title>`, `/resume [id|title]`, `/cleanup [--dry-run]`, `/compact`, `/exit`
 - Goals and tasks: `/status [goal-id]`, `/goals`, `/tasks [goal-id]`, `/task <task-id> [goal-id]`, `/track`, `/tend`
 - Configuration: `/config`, `/model`, `/plugins`
+- Usage: `/usage [session|goal <goal-id>|daemon <goal-id>|schedule [24h|7d|2w]]`
 
 `/compact` summarizes older chat turns into the saved session summary and keeps the latest user and assistant turns available for continuation.
 `/config` and `/model` are read-only and mask secrets.
 
-Deferred commands: `/retry`, `/undo`, and `/usage` are intentionally not supported yet.
-Replay and undo need clearer handling of tool side effects, and usage needs durable accounting before it can be reliable.
+Deferred command: `/retry` is intentionally not supported yet.
 
 ## Daemon operations
 

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -218,11 +218,104 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("Session");
       expect(result.output).toContain("Goals and tasks");
       expect(result.output).toContain("Configuration");
+      expect(result.output).toContain("/usage");
       expect(result.output).toContain("Deferred");
       expect(result.output).toContain("/status [goal-id]");
       expect(result.output).toContain("/compact");
       expect(result.output).not.toContain("/context");
       expect(adapter.execute).not.toHaveBeenCalled();
+    });
+
+    it("/usage reports session totals and phase breakdown", async () => {
+      const stateManager = makeMockStateManager();
+      const llmClient = {
+        sendMessage: vi.fn().mockResolvedValue({
+          content: "Plain answer",
+          usage: { input_tokens: 2, output_tokens: 3 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn(),
+      } as unknown as ILLMClient;
+      const runner = new ChatRunner(makeDeps({ stateManager, llmClient }));
+      runner.startSession("/repo");
+
+      await runner.execute("What is 1+1?", "/repo");
+      const result = await runner.execute("/usage", "/repo");
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("Usage summary (session");
+      expect(result.output).toContain("Session total tokens:  5");
+      expect(result.output).toContain("execution: 5");
+    });
+
+    it("/usage goal <id> reads goal-level telemetry from task ledgers", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-usage-goal-"));
+      try {
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("tasks/goal-usage/ledger/task-1.json", {
+          task_id: "task-1",
+          goal_id: "goal-usage",
+          events: [{ type: "succeeded", ts: "2026-01-01T00:00:00.000Z", tokens_used: 123 }],
+          summary: {
+            latest_event_type: "succeeded",
+            tokens_used: 123,
+            latencies: {
+              created_to_acked_ms: null,
+              acked_to_started_ms: null,
+              started_to_completed_ms: null,
+              completed_to_verification_ms: null,
+              created_to_completed_ms: null,
+            },
+          },
+        });
+        const runner = new ChatRunner(makeDeps({ stateManager }));
+
+        const result = await runner.execute("/usage goal goal-usage", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("Usage summary (goal scope)");
+        expect(result.output).toContain("Goal: goal-usage");
+        expect(result.output).toContain("Total tokens: 123");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/usage schedule [period] aggregates schedule history tokens", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-usage-schedule-"));
+      try {
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("schedule-history.json", [
+          {
+            id: "record-1",
+            entry_id: "entry-1",
+            entry_name: "Daily brief",
+            layer: "cron",
+            status: "ok",
+            duration_ms: 1200,
+            fired_at: new Date().toISOString(),
+            reason: "manual_run",
+            attempt: 0,
+            scheduled_for: null,
+            started_at: new Date().toISOString(),
+            finished_at: new Date().toISOString(),
+            retry_at: null,
+            tokens_used: 88,
+          },
+        ]);
+        const runner = new ChatRunner(makeDeps({ stateManager }));
+
+        const result = await runner.execute("/usage schedule 24h", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("Usage summary (schedule, 24h)");
+        expect(result.output).toContain("Runs: 1");
+        expect(result.output).toContain("Total tokens: 88");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
     });
 
     it("/clear returns cleared message without calling adapter", async () => {

--- a/src/interface/chat/__tests__/chat-session-store.test.ts
+++ b/src/interface/chat/__tests__/chat-session-store.test.ts
@@ -50,6 +50,7 @@ function makeAgentLoopState(overrides: Partial<AgentLoopSessionState> & {
     ],
     modelTurns: overrides.modelTurns ?? 1,
     toolCalls: overrides.toolCalls ?? 0,
+    usage: overrides.usage ?? { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     compactions: overrides.compactions ?? 0,
     completionValidationAttempts: overrides.completionValidationAttempts ?? 0,
     calledTools: overrides.calledTools ?? [],

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -24,6 +24,24 @@ export const ChatSessionAgentLoopMetadataSchema = z.object({
 }).passthrough();
 export type ChatSessionAgentLoopMetadata = z.infer<typeof ChatSessionAgentLoopMetadataSchema>;
 
+export const ChatUsageCounterSchema = z.object({
+  inputTokens: z.number().int().nonnegative().default(0),
+  outputTokens: z.number().int().nonnegative().default(0),
+  totalTokens: z.number().int().nonnegative().default(0),
+}).passthrough();
+export type ChatUsageCounter = z.infer<typeof ChatUsageCounterSchema>;
+
+export const ChatSessionUsageSchema = z.object({
+  totals: ChatUsageCounterSchema.default({
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  }),
+  byPhase: z.record(ChatUsageCounterSchema).default({}),
+  updatedAt: z.string().optional(),
+}).passthrough();
+export type ChatSessionUsage = z.infer<typeof ChatSessionUsageSchema>;
+
 export const ChatSessionSchema = z.object({
   id: z.string(),
   cwd: z.string(), // git root at session start
@@ -37,6 +55,7 @@ export const ChatSessionSchema = z.object({
   agentLoopResumable: z.boolean().nullable().optional(),
   agentLoopUpdatedAt: z.string().nullable().optional(),
   agentLoop: ChatSessionAgentLoopMetadataSchema.optional(),
+  usage: ChatSessionUsageSchema.optional(),
 }).passthrough();
 export type ChatSession = z.infer<typeof ChatSessionSchema>;
 
@@ -57,6 +76,7 @@ export class ChatHistory {
         cwd: existingSession.cwd,
         updatedAt: existingSession.updatedAt ?? existingSession.createdAt,
         messages: [...existingSession.messages],
+        ...(existingSession.usage ? { usage: cloneUsage(existingSession.usage) } : {}),
       };
     } else {
       const createdAt = new Date().toISOString();
@@ -141,7 +161,11 @@ export class ChatHistory {
   }
 
   getSessionData(): ChatSession {
-    return { ...this.session, messages: [...this.session.messages] };
+    return {
+      ...this.session,
+      messages: [...this.session.messages],
+      ...(this.session.usage ? { usage: cloneUsage(this.session.usage) } : {}),
+    };
   }
 
   getSessionId(): string {
@@ -164,6 +188,24 @@ export class ChatHistory {
     }
   }
 
+  recordUsage(phase: string, usage: ChatUsageCounter): void {
+    const normalized = normalizeUsageCounter(usage);
+    const nextTotals = sumUsage(
+      this.session.usage?.totals,
+      normalized
+    );
+    const currentPhase = this.session.usage?.byPhase?.[phase];
+    const nextByPhase = {
+      ...(this.session.usage?.byPhase ?? {}),
+      [phase]: sumUsage(currentPhase, normalized),
+    };
+    this.session.usage = {
+      totals: nextTotals,
+      byPhase: nextByPhase,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
   async persist(): Promise<void> {
     this.session.updatedAt = new Date().toISOString();
     await this.stateManager.writeRaw(
@@ -171,4 +213,36 @@ export class ChatHistory {
       this.session
     );
   }
+}
+
+function normalizeUsageCounter(usage: ChatUsageCounter): ChatUsageCounter {
+  const inputTokens = Number.isFinite(usage.inputTokens) ? Math.max(0, Math.floor(usage.inputTokens)) : 0;
+  const outputTokens = Number.isFinite(usage.outputTokens) ? Math.max(0, Math.floor(usage.outputTokens)) : 0;
+  const totalTokens = Number.isFinite(usage.totalTokens)
+    ? Math.max(0, Math.floor(usage.totalTokens))
+    : inputTokens + outputTokens;
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens,
+  };
+}
+
+function sumUsage(base: ChatUsageCounter | undefined, delta: ChatUsageCounter): ChatUsageCounter {
+  const normalizedBase = normalizeUsageCounter(base ?? { inputTokens: 0, outputTokens: 0, totalTokens: 0 });
+  return {
+    inputTokens: normalizedBase.inputTokens + delta.inputTokens,
+    outputTokens: normalizedBase.outputTokens + delta.outputTokens,
+    totalTokens: normalizedBase.totalTokens + delta.totalTokens,
+  };
+}
+
+function cloneUsage(usage: ChatSessionUsage): ChatSessionUsage {
+  return {
+    totals: { ...usage.totals },
+    byPhase: Object.fromEntries(
+      Object.entries(usage.byPhase ?? {}).map(([phase, counter]) => [phase, { ...counter }])
+    ),
+    ...(usage.updatedAt ? { updatedAt: usage.updatedAt } : {}),
+  };
 }

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -4,13 +4,15 @@
 // Bypasses TaskLifecycle — calls adapter.execute() directly.
 
 import { execFile } from "node:child_process";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
 import type { StateManager } from "../../base/state/state-manager.js";
 import type { IAdapter, AgentTask } from "../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
 import type { Task } from "../../base/types/task.js";
 import type { Goal } from "../../base/types/goal.js";
-import { ChatHistory, type ChatSession } from "./chat-history.js";
+import { ChatHistory, type ChatSession, type ChatUsageCounter } from "./chat-history.js";
 import {
   ChatSessionCatalog,
   ChatSessionSelectorError,
@@ -174,6 +176,7 @@ Configuration
   /model                Show the active provider/model/adapter
   /permissions [args]   Show or update session execution policy
   /plugins              List installed plugins when plugin metadata is available
+  /usage [scope]        Show usage summary (session, goal <id>, daemon <goal-id>, schedule [7d|24h|2w])
 
 Review and branching
   /review               Show current diff summary and verification context
@@ -181,7 +184,7 @@ Review and branching
   /undo                 Remove the latest chat turn from session history
 
 Deferred
-  /retry and /usage are intentionally not supported yet.`;
+  /retry is intentionally not supported yet.`;
 
 // ─── Helpers ───
 
@@ -314,6 +317,7 @@ export class ChatRunner {
       ...(session.agentLoopResumable ? { agentLoopResumable: true } : {}),
       ...(session.agentLoopUpdatedAt ? { agentLoopUpdatedAt: session.agentLoopUpdatedAt } : {}),
       ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
+      ...(session.usage ? { usage: session.usage } : {}),
     };
   }
 
@@ -537,6 +541,213 @@ export class ChatRunner {
     }
   }
 
+  private zeroUsageCounter(): ChatUsageCounter {
+    return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  }
+
+  private normalizeUsageCounter(usage: ChatUsageCounter): ChatUsageCounter {
+    const inputTokens = Number.isFinite(usage.inputTokens) ? Math.max(0, Math.floor(usage.inputTokens)) : 0;
+    const outputTokens = Number.isFinite(usage.outputTokens) ? Math.max(0, Math.floor(usage.outputTokens)) : 0;
+    const totalTokens = Number.isFinite(usage.totalTokens)
+      ? Math.max(0, Math.floor(usage.totalTokens))
+      : inputTokens + outputTokens;
+    return {
+      inputTokens,
+      outputTokens,
+      totalTokens,
+    };
+  }
+
+  private usageFromLLMResponse(response: LLMResponse): ChatUsageCounter {
+    const inputTokens = response.usage?.input_tokens ?? 0;
+    const outputTokens = response.usage?.output_tokens ?? 0;
+    return {
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    };
+  }
+
+  private addUsageCounter(target: ChatUsageCounter, delta: ChatUsageCounter): void {
+    const normalizedDelta = this.normalizeUsageCounter(delta);
+    target.inputTokens += normalizedDelta.inputTokens;
+    target.outputTokens += normalizedDelta.outputTokens;
+    target.totalTokens += normalizedDelta.totalTokens;
+  }
+
+  private hasUsage(usage: ChatUsageCounter): boolean {
+    return usage.totalTokens > 0 || usage.inputTokens > 0 || usage.outputTokens > 0;
+  }
+
+  private formatUsageCounter(prefix: string, usage: ChatUsageCounter): string[] {
+    return [
+      `${prefix} input tokens:  ${usage.inputTokens}`,
+      `${prefix} output tokens: ${usage.outputTokens}`,
+      `${prefix} total tokens:  ${usage.totalTokens}`,
+    ];
+  }
+
+  private parseUsagePeriodMs(period: string): number {
+    const match = /^(\d+)([dhw])$/i.exec(period.trim());
+    if (!match) {
+      throw new Error("period must be one of 24h, 7d, 2w");
+    }
+    const value = Number(match[1]);
+    const unit = match[2]?.toLowerCase();
+    if (!Number.isFinite(value) || value <= 0) {
+      throw new Error("period value must be positive");
+    }
+    if (unit === "h") return value * 60 * 60 * 1000;
+    if (unit === "w") return value * 7 * 24 * 60 * 60 * 1000;
+    return value * 24 * 60 * 60 * 1000;
+  }
+
+  private async collectGoalUsage(goalId: string): Promise<{
+    goalId: string;
+    totalTokens: number;
+    taskCount: number;
+    terminalTaskCount: number;
+  }> {
+    const baseDir = this.deps.stateManager.getBaseDir();
+    const ledgerDir = path.join(baseDir, "tasks", goalId, "ledger");
+    let entries: string[] = [];
+    try {
+      entries = await fsp.readdir(ledgerDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+      return { goalId, totalTokens: 0, taskCount: 0, terminalTaskCount: 0 };
+    }
+
+    let totalTokens = 0;
+    let taskCount = 0;
+    let terminalTaskCount = 0;
+    for (const entry of entries) {
+      if (!entry.endsWith(".json")) continue;
+      taskCount += 1;
+      try {
+        const raw = await fsp.readFile(path.join(ledgerDir, entry), "utf-8");
+        const parsed = JSON.parse(raw) as {
+          summary?: { latest_event_type?: string; tokens_used?: number };
+        };
+        if (typeof parsed.summary?.tokens_used === "number") {
+          totalTokens += parsed.summary.tokens_used;
+        }
+        if (parsed.summary?.latest_event_type === "succeeded"
+          || parsed.summary?.latest_event_type === "failed"
+          || parsed.summary?.latest_event_type === "abandoned") {
+          terminalTaskCount += 1;
+        }
+      } catch {
+        // Ignore malformed records.
+      }
+    }
+
+    return { goalId, totalTokens, taskCount, terminalTaskCount };
+  }
+
+  private async collectScheduleUsage(period: string): Promise<{
+    period: string;
+    runs: number;
+    totalTokens: number;
+  }> {
+    const periodMs = this.parseUsagePeriodMs(period);
+    const since = Date.now() - periodMs;
+    const historyPath = path.join(this.deps.stateManager.getBaseDir(), "schedule-history.json");
+    let raw: unknown;
+    try {
+      raw = JSON.parse(await fsp.readFile(historyPath, "utf-8"));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return { period, runs: 0, totalTokens: 0 };
+      }
+      throw err;
+    }
+    if (!Array.isArray(raw)) {
+      return { period, runs: 0, totalTokens: 0 };
+    }
+    let runs = 0;
+    let totalTokens = 0;
+    for (const record of raw) {
+      if (!record || typeof record !== "object") continue;
+      const finishedAt = (record as Record<string, unknown>)["finished_at"];
+      const firedAt = typeof finishedAt === "string" ? Date.parse(finishedAt) : Number.NaN;
+      if (!Number.isFinite(firedAt) || firedAt < since) continue;
+      runs += 1;
+      const tokensUsed = (record as Record<string, unknown>)["tokens_used"];
+      if (typeof tokensUsed === "number" && Number.isFinite(tokensUsed)) {
+        totalTokens += tokensUsed;
+      }
+    }
+    return { period, runs, totalTokens };
+  }
+
+  private async handleUsage(args: string, start: number): Promise<ChatRunResult> {
+    const tokens = args.trim().split(/\s+/).filter(Boolean);
+    const scope = tokens[0]?.toLowerCase();
+
+    if (!scope || scope === "session") {
+      if (!this.history) {
+        return { success: false, output: "No active chat session. Start a session and run work before /usage.", elapsed_ms: Date.now() - start };
+      }
+      const session = this.history.getSessionData();
+      const totals = this.normalizeUsageCounter(session.usage?.totals ?? this.zeroUsageCounter());
+      const lines = [
+        `Usage summary (session ${session.id})`,
+        ...this.formatUsageCounter("Session", totals),
+      ];
+      const phaseEntries = Object.entries(session.usage?.byPhase ?? {})
+        .map(([phase, usage]) => ({ phase, usage: this.normalizeUsageCounter(usage as ChatUsageCounter) }))
+        .filter((entry) => this.hasUsage(entry.usage))
+        .sort((left, right) => right.usage.totalTokens - left.usage.totalTokens);
+      if (phaseEntries.length > 0) {
+        lines.push("");
+        lines.push("By phase:");
+        for (const entry of phaseEntries) {
+          lines.push(`- ${entry.phase}: ${entry.usage.totalTokens} (in=${entry.usage.inputTokens}, out=${entry.usage.outputTokens})`);
+        }
+      }
+      return { success: true, output: lines.join("\n"), elapsed_ms: Date.now() - start };
+    }
+
+    if (scope === "goal" || scope === "daemon") {
+      const goalId = tokens[1] ?? this.deps.goalId;
+      if (!goalId) {
+        return { success: false, output: "Usage: /usage goal <goal-id>", elapsed_ms: Date.now() - start };
+      }
+      const summary = await this.collectGoalUsage(goalId);
+      const lines = [
+        `Usage summary (${scope} scope)`,
+        `Goal: ${summary.goalId}`,
+        `Tasks observed: ${summary.taskCount}`,
+        `Terminal tasks: ${summary.terminalTaskCount}`,
+        `Total tokens: ${summary.totalTokens}`,
+      ];
+      return { success: true, output: lines.join("\n"), elapsed_ms: Date.now() - start };
+    }
+
+    if (scope === "schedule") {
+      const period = tokens[1] ?? "7d";
+      try {
+        const summary = await this.collectScheduleUsage(period);
+        const lines = [
+          `Usage summary (schedule, ${summary.period})`,
+          `Runs: ${summary.runs}`,
+          `Total tokens: ${summary.totalTokens}`,
+        ];
+        return { success: true, output: lines.join("\n"), elapsed_ms: Date.now() - start };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, output: `Usage: /usage schedule [24h|7d|2w]\nError: ${message}`, elapsed_ms: Date.now() - start };
+      }
+    }
+
+    return {
+      success: false,
+      output: "Usage: /usage [session|goal <goal-id>|daemon <goal-id>|schedule [24h|7d|2w]]",
+      elapsed_ms: Date.now() - start,
+    };
+  }
+
   private deterministicChatSummary(messages: ChatSession["messages"]): string {
     const lines = messages.map((message) => `${message.role}: ${message.content.replace(/\s+/g, " ").trim()}`);
     return lines.join("\n").slice(0, 4_000);
@@ -672,6 +883,9 @@ export class ChatRunner {
     }
     if (cmd === "/plugins") {
       return this.handlePlugins(start);
+    }
+    if (cmd === "/usage") {
+      return this.handleUsage(trimmed.slice("/usage".length).trim(), start);
     }
     if (cmd === "/review") {
       return this.handleReview(start);
@@ -1148,6 +1362,7 @@ export class ChatRunner {
 
     const start = Date.now();
     const assistantBuffer: AssistantBuffer = { text: "" };
+    const turnUsage = this.zeroUsageCounter();
 
     if (directAnswerRoute) {
       try {
@@ -1163,8 +1378,12 @@ export class ChatRunner {
           assistantBuffer,
           eventContext
         );
+        this.addUsageCounter(turnUsage, this.usageFromLLMResponse(directResponse));
         const elapsed_ms = Date.now() - start;
         const output = assistantBuffer.text || directResponse.content || "(no response)";
+        if (this.hasUsage(turnUsage)) {
+          history.recordUsage("execution", turnUsage);
+        }
         await history.appendAssistantMessage(output);
         this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
         this.emitEvent({
@@ -1290,6 +1509,10 @@ export class ChatRunner {
           ...(agentLoopSystemPrompt ? { systemPrompt: agentLoopSystemPrompt } : {}),
         });
         const elapsed_ms = Date.now() - start;
+        const agentLoopUsage = this.normalizeUsageCounter(result.agentLoop?.usage ?? this.zeroUsageCounter());
+        if (this.hasUsage(agentLoopUsage)) {
+          history.recordUsage("agentloop", agentLoopUsage);
+        }
         if (result.output) {
           this.pushAssistantDelta(result.output, assistantBuffer, eventContext);
         }
@@ -1304,6 +1527,9 @@ export class ChatRunner {
           });
           this.emitLifecycleEndEvent("completed", elapsed_ms, eventContext, true);
         } else {
+          if (this.hasUsage(agentLoopUsage)) {
+            await history.persist();
+          }
           this.emitLifecycleErrorEvent(result.output || result.error || "Unknown error", assistantBuffer.text, eventContext);
           this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
         }
@@ -1331,16 +1557,19 @@ export class ChatRunner {
       try {
         const toolResult = await this.executeWithTools(prompt, eventContext, assistantBuffer, systemPrompt || undefined);
         const elapsed_ms = Date.now() - start;
-        await history.appendAssistantMessage(toolResult);
+        if (this.hasUsage(toolResult.usage)) {
+          history.recordUsage("execution", toolResult.usage);
+        }
+        await history.appendAssistantMessage(toolResult.output);
         this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
         this.emitEvent({
           type: "assistant_final",
-          text: toolResult,
+          text: toolResult.output,
           persisted: true,
           ...this.eventBase(eventContext),
         });
         this.emitLifecycleEndEvent("completed", elapsed_ms, eventContext, true);
-        return { success: true, output: toolResult, elapsed_ms };
+        return { success: true, output: toolResult.output, elapsed_ms };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         this.emitLifecycleErrorEvent(message, assistantBuffer.text, eventContext);
@@ -1487,10 +1716,11 @@ export class ChatRunner {
     eventContext: ChatEventContext,
     assistantBuffer: AssistantBuffer,
     systemPrompt?: string
-  ): Promise<string> {
+  ): Promise<{ output: string; usage: ChatUsageCounter }> {
     const llmClient = this.deps.llmClient!;
     const messages: LLMMessage[] = [{ role: "user", content: prompt }];
     const toolCallContext = await this.buildToolCallContext();
+    const usage = this.zeroUsageCounter();
 
     for (let loop = 0; loop < MAX_TOOL_LOOPS; loop++) {
       // Recompute tools each iteration so newly activated deferred tools are included
@@ -1506,6 +1736,7 @@ export class ChatRunner {
             ? { tools, ...(systemPrompt ? { system: systemPrompt } : {}) }
             : { system: buildPromptedToolProtocolSystemPrompt({ systemPrompt, tools }) }),
         }, assistantBuffer, eventContext);
+        this.addUsageCounter(usage, this.usageFromLLMResponse(response));
       } catch (err) {
         console.error("[chat-runner] executeWithTools error:", err);
         const hint = err instanceof Error ? `: ${err.message}` : "";
@@ -1535,7 +1766,10 @@ export class ChatRunner {
 
       // No tool calls — return the text content
       if (toolCalls.length === 0) {
-        return assistantBuffer.text || response.content || "(no response)";
+        return {
+          output: assistantBuffer.text || response.content || "(no response)",
+          usage,
+        };
       }
 
       // Append assistant message, then process tool calls
@@ -1565,7 +1799,10 @@ export class ChatRunner {
 
     // Max loops reached — return last assistant content or fallback
     const lastAssistant = [...messages].reverse().find(m => m.role === "assistant");
-    return lastAssistant?.content || "I was unable to complete the request within the allowed tool call limit.";
+    return {
+      output: lastAssistant?.content || "I was unable to complete the request within the allowed tool call limit.",
+      usage,
+    };
   }
 
   /**
@@ -1726,10 +1963,19 @@ export class ChatRunner {
     const raw = await this.deps.stateManager.readRaw(this.nativeAgentLoopStatePath);
     if (!this.isAgentLoopSessionState(raw)) return null;
     if (raw.status === "completed") return null;
+    const usageCandidate = raw.usage as Record<string, unknown> | undefined;
+    const usage = usageCandidate
+      ? this.normalizeUsageCounter({
+          inputTokens: typeof usageCandidate.inputTokens === "number" ? usageCandidate.inputTokens : 0,
+          outputTokens: typeof usageCandidate.outputTokens === "number" ? usageCandidate.outputTokens : 0,
+          totalTokens: typeof usageCandidate.totalTokens === "number" ? usageCandidate.totalTokens : 0,
+        })
+      : this.zeroUsageCounter();
     return {
       ...raw,
       messages: [...raw.messages],
       calledTools: [...raw.calledTools],
+      usage,
     };
   }
 

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -37,6 +37,7 @@ export interface LoadedChatSession {
   agentLoopResumable: boolean;
   agentLoopUpdatedAt?: string | null;
   agentLoop?: ChatSession["agentLoop"];
+  usage?: ChatSession["usage"];
   [key: string]: unknown;
 }
 
@@ -270,6 +271,7 @@ async function readSessionRecordWithMetadata(
     agentLoopResumable: discovery.resumable,
     agentLoopUpdatedAt: discovery.updatedAt,
     ...(parsed.data.agentLoop ? { agentLoop: parsed.data.agentLoop } : {}),
+    ...(parsed.data.usage ? { usage: parsed.data.usage } : {}),
   };
 
   return normalizeSessionRecord(session, filePath, fileMtimeMs, discovery);
@@ -308,6 +310,7 @@ function toPersistedSession(session: LoadedChatSession): ChatSession {
       ? { agentLoopUpdatedAt: session.agentLoopUpdatedAt }
       : {}),
     ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
+    ...(session.usage ? { usage: session.usage } : {}),
   };
 }
 

--- a/src/interface/cli/__tests__/cli-usage.test.ts
+++ b/src/interface/cli/__tests__/cli-usage.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import { CLIRunner } from "../cli-runner.js";
+import { StateManager } from "../../../base/state/state-manager.js";
+import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+
+async function runCLI(tmpDir: string, ...args: string[]): Promise<number> {
+  const runner = new CLIRunner(tmpDir);
+  return runner.run(args);
+}
+
+describe("CLI usage command", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+  let origApiKey: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir("pulseed-cli-usage-");
+    stateManager = new StateManager(tmpDir);
+    await stateManager.init();
+    origApiKey = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = "test-api-key";
+    process.env.PULSEED_LLM_PROVIDER = "anthropic";
+  });
+
+  afterEach(() => {
+    if (origApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = origApiKey;
+    }
+    delete process.env.PULSEED_LLM_PROVIDER;
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    vi.restoreAllMocks();
+  });
+
+  it("reports session usage totals and phase breakdown", async () => {
+    await stateManager.writeRaw("chat/sessions/session-usage.json", {
+      id: "session-usage",
+      cwd: "/repo",
+      createdAt: new Date().toISOString(),
+      messages: [],
+      usage: {
+        totals: { inputTokens: 4, outputTokens: 5, totalTokens: 9 },
+        byPhase: {
+          execution: { inputTokens: 4, outputTokens: 5, totalTokens: 9 },
+        },
+      },
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const code = await runCLI(tmpDir, "usage", "session", "session-usage");
+
+    expect(code).toBe(0);
+    const output = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("Usage summary (session session-usage)");
+    expect(output).toContain("Session total tokens:  9");
+    expect(output).toContain("execution: 9");
+  });
+
+  it("reports goal usage totals from task ledgers and accepts daemon alias", async () => {
+    await stateManager.writeRaw("tasks/goal-usage/ledger/task-1.json", {
+      task_id: "task-1",
+      goal_id: "goal-usage",
+      events: [{ type: "succeeded", ts: "2026-01-01T00:00:00.000Z", tokens_used: 77 }],
+      summary: {
+        latest_event_type: "succeeded",
+        tokens_used: 77,
+        latencies: {
+          created_to_acked_ms: null,
+          acked_to_started_ms: null,
+          started_to_completed_ms: null,
+          completed_to_verification_ms: null,
+          created_to_completed_ms: null,
+        },
+      },
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const code = await runCLI(tmpDir, "usage", "daemon", "goal-usage");
+
+    expect(code).toBe(0);
+    const output = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("Usage summary (daemon scope)");
+    expect(output).toContain("Goal: goal-usage");
+    expect(output).toContain("Total tokens: 77");
+  });
+
+  it("reports schedule usage for a requested period", async () => {
+    await stateManager.writeRaw("schedule-history.json", [
+      {
+        id: "record-1",
+        entry_id: "entry-1",
+        entry_name: "Daily brief",
+        layer: "cron",
+        status: "ok",
+        duration_ms: 1200,
+        fired_at: new Date().toISOString(),
+        reason: "manual_run",
+        attempt: 0,
+        scheduled_for: null,
+        started_at: new Date().toISOString(),
+        finished_at: new Date().toISOString(),
+        retry_at: null,
+        tokens_used: 88,
+      },
+    ]);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const code = await runCLI(tmpDir, "usage", "schedule", "--period", "24h");
+
+    expect(code).toBe(0);
+    const output = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("Usage summary (schedule, 24h)");
+    expect(output).toContain("Runs: 1");
+    expect(output).toContain("Total tokens: 88");
+  });
+
+  it("returns 1 for an unknown usage scope", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCLI(tmpDir, "usage", "nonsense");
+
+    expect(code).toBe(1);
+    expect(errSpy.mock.calls.map((call) => call.join(" ")).join("\n")).toContain("Unknown usage scope.");
+    expect(logSpy.mock.calls.map((call) => call.join(" ")).join("\n")).toContain(
+      "Usage: pulseed usage <session|goal|daemon|schedule> [args]"
+    );
+  });
+
+  it("returns 1 when session scope is missing an id", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCLI(tmpDir, "usage", "session");
+
+    expect(code).toBe(1);
+    expect(errSpy.mock.calls.map((call) => call.join(" ")).join("\n")).toContain(
+      "Usage: pulseed usage session <session-id>"
+    );
+  });
+
+  it("returns 1 when schedule period is invalid", async () => {
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCLI(tmpDir, "usage", "schedule", "--period", "oops");
+
+    expect(code).toBe(1);
+    expect(errSpy.mock.calls.map((call) => call.join(" ")).join("\n")).toContain(
+      "Error: period must look like 7d, 24h, or 2w"
+    );
+  });
+});

--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -45,6 +45,7 @@ import { cmdTelegramSetup } from "./commands/telegram.js";
 import { cmdSchedule } from "./commands/schedule.js";
 import { cmdSkills } from "./commands/skills.js";
 import { cmdPlaybook } from "./commands/playbook.js";
+import { cmdUsage } from "./commands/usage.js";
 import { printUsage, formatOperationError } from "./utils.js";
 import { ensureProviderConfig } from "./ensure-api-key.js";
 
@@ -547,6 +548,10 @@ export async function dispatchCommand(
 
   if (subcommand === "playbook" || subcommand === "playbooks") {
     return await cmdPlaybook(argv.slice(1), stateManager);
+  }
+
+  if (subcommand === "usage") {
+    return await cmdUsage(stateManager, argv.slice(1));
   }
 
   if (subcommand === "telegram") {

--- a/src/interface/cli/commands/usage.ts
+++ b/src/interface/cli/commands/usage.ts
@@ -1,0 +1,266 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { parseArgs } from "node:util";
+import type { StateManager } from "../../../base/state/state-manager.js";
+
+interface UsageCounter {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+function zeroUsageCounter(): UsageCounter {
+  return { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+}
+
+function normalizeUsageCounter(raw: unknown): UsageCounter {
+  if (!raw || typeof raw !== "object") return zeroUsageCounter();
+  const value = raw as Record<string, unknown>;
+  const inputValue = Number(value.inputTokens);
+  const outputValue = Number(value.outputTokens);
+  const totalValue = Number(value.totalTokens);
+  const inputTokens = Number.isFinite(inputValue) ? Math.max(0, Math.floor(inputValue)) : 0;
+  const outputTokens = Number.isFinite(outputValue) ? Math.max(0, Math.floor(outputValue)) : 0;
+  const totalTokens = Number.isFinite(totalValue)
+    ? Math.max(0, Math.floor(totalValue))
+    : inputTokens + outputTokens;
+  return { inputTokens, outputTokens, totalTokens };
+}
+
+function parseUsagePeriodMs(period: string): number {
+  const match = /^(\d+)([dhw])$/i.exec(period.trim());
+  if (!match) {
+    throw new Error("period must look like 7d, 24h, or 2w");
+  }
+  const value = Number(match[1]);
+  const unit = match[2]?.toLowerCase();
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error("period value must be positive");
+  }
+  if (unit === "h") return value * 60 * 60 * 1000;
+  if (unit === "w") return value * 7 * 24 * 60 * 60 * 1000;
+  return value * 24 * 60 * 60 * 1000;
+}
+
+async function collectGoalUsage(stateManager: StateManager, goalId: string): Promise<{
+  goalId: string;
+  totalTokens: number;
+  taskCount: number;
+  terminalTaskCount: number;
+}> {
+  const ledgerDir = path.join(stateManager.getBaseDir(), "tasks", goalId, "ledger");
+  let entries: string[] = [];
+  try {
+    entries = await fsp.readdir(ledgerDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    return { goalId, totalTokens: 0, taskCount: 0, terminalTaskCount: 0 };
+  }
+
+  let totalTokens = 0;
+  let taskCount = 0;
+  let terminalTaskCount = 0;
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    taskCount += 1;
+    try {
+      const raw = await fsp.readFile(path.join(ledgerDir, entry), "utf-8");
+      const parsed = JSON.parse(raw) as {
+        summary?: { latest_event_type?: string; tokens_used?: number };
+      };
+      if (typeof parsed.summary?.tokens_used === "number") {
+        totalTokens += parsed.summary.tokens_used;
+      }
+      if (
+        parsed.summary?.latest_event_type === "succeeded"
+        || parsed.summary?.latest_event_type === "failed"
+        || parsed.summary?.latest_event_type === "abandoned"
+      ) {
+        terminalTaskCount += 1;
+      }
+    } catch {
+      // Ignore malformed ledger entries.
+    }
+  }
+
+  return { goalId, totalTokens, taskCount, terminalTaskCount };
+}
+
+async function collectScheduleUsage(stateManager: StateManager, period: string): Promise<{
+  period: string;
+  runs: number;
+  totalTokens: number;
+}> {
+  const periodMs = parseUsagePeriodMs(period);
+  const since = Date.now() - periodMs;
+  const historyPath = path.join(stateManager.getBaseDir(), "schedule-history.json");
+  let raw: unknown;
+  try {
+    raw = JSON.parse(await fsp.readFile(historyPath, "utf-8"));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { period, runs: 0, totalTokens: 0 };
+    }
+    throw err;
+  }
+  if (!Array.isArray(raw)) {
+    return { period, runs: 0, totalTokens: 0 };
+  }
+
+  let runs = 0;
+  let totalTokens = 0;
+  for (const record of raw) {
+    if (!record || typeof record !== "object") continue;
+    const finishedAt = (record as Record<string, unknown>)["finished_at"];
+    const firedAt = typeof finishedAt === "string" ? Date.parse(finishedAt) : Number.NaN;
+    if (!Number.isFinite(firedAt) || firedAt < since) continue;
+    runs += 1;
+    const tokensUsed = (record as Record<string, unknown>)["tokens_used"];
+    if (typeof tokensUsed === "number" && Number.isFinite(tokensUsed)) {
+      totalTokens += tokensUsed;
+    }
+  }
+
+  return { period, runs, totalTokens };
+}
+
+async function readSessionUsage(stateManager: StateManager, sessionId: string): Promise<{
+  sessionId: string;
+  totals: UsageCounter;
+  byPhase: Record<string, UsageCounter>;
+}> {
+  const raw = await stateManager.readRaw(`chat/sessions/${sessionId}.json`);
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`chat session not found: ${sessionId}`);
+  }
+  const session = raw as {
+    usage?: { totals?: unknown; byPhase?: Record<string, unknown> };
+  };
+  const byPhase = Object.fromEntries(
+    Object.entries(session.usage?.byPhase ?? {}).map(([phase, usage]) => [phase, normalizeUsageCounter(usage)])
+  );
+  return {
+    sessionId,
+    totals: normalizeUsageCounter(session.usage?.totals),
+    byPhase,
+  };
+}
+
+function printSessionSummary(summary: {
+  sessionId: string;
+  totals: UsageCounter;
+  byPhase: Record<string, UsageCounter>;
+}): void {
+  console.log(`Usage summary (session ${summary.sessionId})`);
+  console.log(`Session total tokens:  ${summary.totals.totalTokens}`);
+  console.log(`Session input tokens:  ${summary.totals.inputTokens}`);
+  console.log(`Session output tokens: ${summary.totals.outputTokens}`);
+  const phaseEntries = Object.entries(summary.byPhase)
+    .filter(([, usage]) => usage.totalTokens > 0)
+    .sort((left, right) => right[1].totalTokens - left[1].totalTokens);
+  if (phaseEntries.length === 0) return;
+  console.log("");
+  console.log("By phase:");
+  for (const [phase, usage] of phaseEntries) {
+    console.log(`- ${phase}: ${usage.totalTokens} (in=${usage.inputTokens}, out=${usage.outputTokens})`);
+  }
+}
+
+function printUsageHelp(): void {
+  console.log("Usage: pulseed usage <session|goal|daemon|schedule> [args]");
+  console.log("  session <id>                     Show usage for one chat session");
+  console.log("  goal <goal-id>                   Show usage from task ledgers for a goal");
+  console.log("  daemon <goal-id>                 Alias of goal scope for daemon-triggered runs");
+  console.log("  schedule [--period <7d|24h|2w>]  Show schedule token usage for a period");
+}
+
+export async function cmdUsage(stateManager: StateManager, argv: string[]): Promise<number> {
+  const scope = argv[0]?.toLowerCase();
+
+  if (!scope || scope === "help" || scope === "--help" || scope === "-h") {
+    printUsageHelp();
+    return 0;
+  }
+
+  if (scope === "session") {
+    let parsed: ReturnType<typeof parseArgs>;
+    try {
+      parsed = parseArgs({
+        args: argv.slice(1),
+        allowPositionals: true,
+        options: {
+          session: { type: "string" },
+        },
+        strict: false,
+      });
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      return 1;
+    }
+    const sessionId = String(parsed.values.session ?? parsed.positionals[0] ?? "");
+    if (!sessionId) {
+      console.error("Usage: pulseed usage session <session-id>");
+      return 1;
+    }
+    try {
+      const summary = await readSessionUsage(stateManager, sessionId);
+      printSessionSummary(summary);
+      return 0;
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      return 1;
+    }
+  }
+
+  if (scope === "goal" || scope === "daemon") {
+    const goalId = argv[1];
+    if (!goalId) {
+      console.error(`Usage: pulseed usage ${scope} <goal-id>`);
+      return 1;
+    }
+    try {
+      const summary = await collectGoalUsage(stateManager, goalId);
+      console.log(`Usage summary (${scope} scope)`);
+      console.log(`Goal: ${summary.goalId}`);
+      console.log(`Tasks observed: ${summary.taskCount}`);
+      console.log(`Terminal tasks: ${summary.terminalTaskCount}`);
+      console.log(`Total tokens: ${summary.totalTokens}`);
+      return 0;
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      return 1;
+    }
+  }
+
+  if (scope === "schedule") {
+    let parsed: ReturnType<typeof parseArgs>;
+    try {
+      parsed = parseArgs({
+        args: argv.slice(1),
+        allowPositionals: true,
+        options: {
+          period: { type: "string", default: "7d" },
+        },
+        strict: false,
+      });
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      return 1;
+    }
+    const period = String(parsed.values.period ?? parsed.positionals[0] ?? "7d");
+    try {
+      const summary = await collectScheduleUsage(stateManager, period);
+      console.log(`Usage summary (schedule, ${summary.period})`);
+      console.log(`Runs: ${summary.runs}`);
+      console.log(`Total tokens: ${summary.totalTokens}`);
+      return 0;
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      return 1;
+    }
+  }
+
+  console.error("Unknown usage scope.");
+  printUsageHelp();
+  return 1;
+}

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -41,6 +41,7 @@ Usage:
   pulseed cleanup                      Archive all completed goals and remove stale data
   pulseed status --goal <id>           Show current status and progress
   pulseed report --goal <id>           Show latest report
+  pulseed usage <scope>                Show usage totals for session, goal, daemon, or schedule
   pulseed approval list [--resolved]   List pending durable approvals
   pulseed log --goal <id>              View observation and gap history log
   pulseed tui                          Launch the interactive TUI

--- a/src/orchestrator/execution/__tests__/result-reconciler.test.ts
+++ b/src/orchestrator/execution/__tests__/result-reconciler.test.ts
@@ -40,6 +40,13 @@ function makeDeps(
           execute: vi.fn(async () => options.gatewayResponse) as unknown as NonNullable<
             ReconcilerDeps["gateway"]
           >["execute"],
+          executeWithUsage: vi.fn(async () => ({
+            data: options.gatewayResponse,
+            usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+            contextTokens: 0,
+          })) as unknown as NonNullable<
+            ReconcilerDeps["gateway"]
+          >["executeWithUsage"],
         } satisfies NonNullable<ReconcilerDeps["gateway"]>);
 
   return {

--- a/src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts
@@ -338,6 +338,7 @@ describe("TaskLifecycle — persistence", () => {
 
     expect(events.map((event) => event.type)).toEqual(["acked", "started", "succeeded"]);
     expect(summary.latest_event_type).toBe("succeeded");
+    expect(summary.tokens_used).toBeGreaterThan(0);
     expect((summary.latencies as Record<string, unknown>).created_to_acked_ms).not.toBeNull();
   });
 

--- a/src/orchestrator/execution/__tests__/task-lifecycle-usage-reporting.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-usage-reporting.test.ts
@@ -1,0 +1,523 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { StateManager } from "../../../base/state/state-manager.js";
+import { SessionManager } from "../session-manager.js";
+import { TrustManager } from "../../../platform/traits/trust-manager.js";
+import { StrategyManager } from "../../strategy/strategy-manager.js";
+import { StallDetector } from "../../../platform/drive/stall-detector.js";
+import { TaskLifecycle } from "../task/task-lifecycle.js";
+import { cmdUsage } from "../../../interface/cli/commands/usage.js";
+import type { IPromptGateway, PromptGatewayExecutionResult, PromptGatewayInput } from "../../../prompt/gateway.js";
+import type { ILLMClient } from "../../../base/llm/llm-client.js";
+import type { IAdapter } from "../adapter-layer.js";
+import type { TaskAgentLoopRunner } from "../agent-loop/task-agent-loop-runner.js";
+import type { AdapterRegistry } from "../task/task-lifecycle.js";
+import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { makeGoal } from "../../../../tests/helpers/fixtures.js";
+
+function makeGateway(): IPromptGateway {
+  let callIndex = 0;
+  return {
+    async execute<T>(_input: PromptGatewayInput<T>): Promise<T> {
+      throw new Error("execute() should not be used in this test");
+    },
+    async executeWithUsage<T>(_input: PromptGatewayInput<T>): Promise<PromptGatewayExecutionResult<T>> {
+      callIndex += 1;
+      if (callIndex === 1) {
+        return {
+          data: {
+            work_description: "Write regression coverage for usage reporting",
+            rationale: "Need a durable telemetry signal",
+            approach: "Add a focused end-to-end test",
+            success_criteria: [
+              {
+                description: "usage totals are reported",
+                verification_method: "review",
+                is_blocking: true,
+              },
+            ],
+            scope_boundary: {
+              in_scope: ["tests"],
+              out_of_scope: ["runtime redesign"],
+              blast_radius: "low",
+            },
+            constraints: [],
+            reversibility: "reversible",
+            estimated_duration: null,
+          } as T,
+          usage: { inputTokens: 30, outputTokens: 5, totalTokens: 35 },
+          contextTokens: 0,
+        };
+      }
+
+      return {
+        data: {
+          verdict: "pass",
+          reasoning: "usage was persisted and reported",
+          criteria_met: 1,
+          criteria_total: 1,
+        } as T,
+        usage: { inputTokens: 40, outputTokens: 2, totalTokens: 42 },
+        contextTokens: 0,
+      };
+    },
+  };
+}
+
+function makeNoopLLMClient(): ILLMClient {
+  return {
+    async sendMessage() {
+      throw new Error("llmClient should not be used when gateway is configured");
+    },
+    parseJSON() {
+      throw new Error("llmClient should not be used when gateway is configured");
+    },
+  } as unknown as ILLMClient;
+}
+
+function makeLifecycle(
+  tmpDir: string,
+  options?: {
+    gateway?: IPromptGateway;
+    agentLoopRunner?: TaskAgentLoopRunner;
+    adapterRegistry?: AdapterRegistry;
+  },
+): {
+  stateManager: StateManager;
+  lifecycle: TaskLifecycle;
+} {
+  const stateManager = new StateManager(tmpDir);
+  const llmClient = makeNoopLLMClient();
+  const sessionManager = new SessionManager(stateManager);
+  const trustManager = new TrustManager(stateManager);
+  const strategyManager = new StrategyManager(stateManager, llmClient);
+  const stallDetector = new StallDetector(stateManager);
+  const lifecycle = new TaskLifecycle(
+    stateManager,
+    llmClient,
+    sessionManager,
+    trustManager,
+    strategyManager,
+    stallDetector,
+    {
+      approvalFn: async () => true,
+      gateway: options?.gateway,
+      agentLoopRunner: options?.agentLoopRunner,
+      adapterRegistry: options?.adapterRegistry,
+      healthCheckEnabled: false,
+    }
+  );
+  return { stateManager, lifecycle };
+}
+
+describe("TaskLifecycle usage reporting", () => {
+  it("threads gateway generation and verifier usage into ledger summaries and CLI reporting", async () => {
+    const tmpDir = makeTempDir("pulseed-task-lifecycle-usage-");
+    const { stateManager, lifecycle } = makeLifecycle(tmpDir, { gateway: makeGateway() });
+    await stateManager.init();
+    await stateManager.saveGoal(makeGoal({ id: "goal-usage", title: "Close usage telemetry gaps" }));
+    const adapter: IAdapter = {
+      adapterType: "mock",
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "Implemented telemetry reporting",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 25,
+        stopped_reason: "completed",
+      }),
+    };
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      const result = await lifecycle.runTaskCycle(
+        "goal-usage",
+        {
+          goal_id: "goal-usage",
+          gaps: [{
+            dimension_name: "coverage",
+            raw_gap: 0.6,
+            normalized_gap: 0.6,
+            normalized_weighted_gap: 0.6,
+            confidence: 0.8,
+            uncertainty_weight: 1,
+          }],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          time_since_last_attempt: { coverage: 24 },
+          deadlines: { coverage: null },
+          opportunities: {},
+          pacing: {},
+        },
+        adapter,
+      );
+
+      expect(result.action).toBe("completed");
+      expect(result.tokensUsed).toBe(77);
+      expect(adapter.execute).toHaveBeenCalledTimes(1);
+
+      const ledgerDir = path.join(tmpDir, "tasks", "goal-usage", "ledger");
+      const ledgerFiles = fs.readdirSync(ledgerDir).filter((entry) => entry.endsWith(".json"));
+      expect(ledgerFiles).toHaveLength(1);
+      const ledgerRecord = JSON.parse(
+        fs.readFileSync(path.join(ledgerDir, ledgerFiles[0]!), "utf-8")
+      ) as { summary: { tokens_used: number } };
+      expect(ledgerRecord.summary.tokens_used).toBe(77);
+
+      await expect(cmdUsage(stateManager, ["goal", "goal-usage"])).resolves.toBe(0);
+      const output = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+      expect(output).toContain("Usage summary (goal scope)");
+      expect(output).toContain("Goal: goal-usage");
+      expect(output).toContain("Total tokens: 77");
+    } finally {
+      logSpy.mockRestore();
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it("includes native agent loop execution usage in task cycle totals", async () => {
+    const tmpDir = makeTempDir("pulseed-task-lifecycle-agentloop-usage-");
+    const agentLoopRunner = {
+      runTask: vi.fn(async () => ({
+        success: true,
+        output: {
+          status: "done" as const,
+          finalAnswer: "Implemented with native loop",
+          summary: "done",
+          filesChanged: ["src/example.ts"],
+          testsRun: [],
+          completionEvidence: ["implemented"],
+          verificationHints: [],
+          blockers: [],
+        },
+        finalText: "Implemented with native loop",
+        stopReason: "completed" as const,
+        elapsedMs: 123,
+        modelTurns: 2,
+        toolCalls: 3,
+        usage: { inputTokens: 7, outputTokens: 4, totalTokens: 11 },
+        compactions: 0,
+        changedFiles: ["src/example.ts"],
+        commandResults: [],
+        traceId: "trace-usage",
+        sessionId: "session-usage",
+        turnId: "turn-usage",
+      })),
+    } as unknown as TaskAgentLoopRunner;
+    const { stateManager, lifecycle } = makeLifecycle(tmpDir, {
+      gateway: makeGateway(),
+      agentLoopRunner,
+    });
+    await stateManager.init();
+    await stateManager.saveGoal(makeGoal({ id: "goal-native-usage", title: "Track native usage" }));
+
+    const adapter: IAdapter = {
+      adapterType: "mock",
+      execute: vi.fn(async () => {
+        throw new Error("adapter execute should not be called when native loop is enabled");
+      }),
+    };
+
+    try {
+      const result = await lifecycle.runTaskCycle(
+        "goal-native-usage",
+        {
+          goal_id: "goal-native-usage",
+          gaps: [{
+            dimension_name: "coverage",
+            raw_gap: 0.6,
+            normalized_gap: 0.6,
+            normalized_weighted_gap: 0.6,
+            confidence: 0.8,
+            uncertainty_weight: 1,
+          }],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          time_since_last_attempt: { coverage: 24 },
+          deadlines: { coverage: null },
+          opportunities: {},
+          pacing: {},
+        },
+        adapter,
+      );
+
+      expect(result.action).toBe("completed");
+      expect(result.tokensUsed).toBe(88);
+
+      const ledgerDir = path.join(tmpDir, "tasks", "goal-native-usage", "ledger");
+      const ledgerFiles = fs.readdirSync(ledgerDir).filter((entry) => entry.endsWith(".json"));
+      const ledgerRecord = JSON.parse(
+        fs.readFileSync(path.join(ledgerDir, ledgerFiles[0]!), "utf-8")
+      ) as { summary: { tokens_used: number } };
+      expect(ledgerRecord.summary.tokens_used).toBe(88);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it("preserves generation tokens when duplicate-pruned task creation returns null", async () => {
+    const tmpDir = makeTempDir("pulseed-task-lifecycle-duplicate-usage-");
+    const { stateManager, lifecycle } = makeLifecycle(tmpDir, {
+      adapterRegistry: {
+        isAvailable: () => false,
+      } as unknown as AdapterRegistry,
+    });
+    await stateManager.init();
+    await stateManager.saveGoal(makeGoal({ id: "goal-duplicate-usage", title: "Keep generation usage" }));
+    const adapter: IAdapter = {
+      adapterType: "mock",
+      execute: vi.fn(async () => ({
+        success: true,
+        output: "should not execute",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 1,
+        stopped_reason: "completed" as const,
+      })),
+    };
+    vi.spyOn(
+      lifecycle as unknown as {
+        _generateTaskWithTokens: typeof lifecycle["_generateTaskWithTokens"];
+      },
+      "_generateTaskWithTokens"
+    ).mockResolvedValue({ task: null, tokensUsed: 35, playbookIdsUsed: [] });
+
+    try {
+      const result = await lifecycle.runTaskCycle(
+        "goal-duplicate-usage",
+        {
+          goal_id: "goal-duplicate-usage",
+          gaps: [{
+            dimension_name: "coverage",
+            raw_gap: 0.6,
+            normalized_gap: 0.6,
+            normalized_weighted_gap: 0.6,
+            confidence: 0.8,
+            uncertainty_weight: 1,
+          }],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          time_since_last_attempt: { coverage: 24 },
+          deadlines: { coverage: null },
+          opportunities: {},
+          pacing: {},
+        },
+        adapter,
+      );
+
+      expect(result.action).toBe("discard");
+      expect(result.task.id).toBe("skipped");
+      expect(result.tokensUsed).toBe(35);
+      expect(adapter.execute).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it("persists generation tokens when pre-execution checks block the task", async () => {
+    const tmpDir = makeTempDir("pulseed-task-lifecycle-precheck-usage-");
+    const { stateManager, lifecycle } = makeLifecycle(tmpDir);
+    await stateManager.init();
+    await stateManager.saveGoal(makeGoal({ id: "goal-precheck-usage", title: "Keep precheck usage" }));
+    const adapter: IAdapter = {
+      adapterType: "mock",
+      execute: vi.fn(async () => ({
+        success: true,
+        output: "should not execute",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 1,
+        stopped_reason: "completed" as const,
+      })),
+    };
+    vi.spyOn(
+      lifecycle as unknown as {
+        _generateTaskWithTokens: typeof lifecycle["_generateTaskWithTokens"];
+      },
+      "_generateTaskWithTokens"
+    ).mockResolvedValue({
+      task: {
+        id: "task-precheck-usage",
+        goal_id: "goal-precheck-usage",
+        strategy_id: null,
+        target_dimensions: ["coverage"],
+        primary_dimension: "coverage",
+        work_description: "blocked before execution",
+        rationale: "test",
+        approach: "test",
+        success_criteria: [{
+          description: "n/a",
+          verification_method: "review",
+          is_blocking: true,
+        }],
+        scope_boundary: {
+          in_scope: ["tests"],
+          out_of_scope: [],
+          blast_radius: "low",
+        },
+        constraints: [],
+        plateau_until: null,
+        estimated_duration: null,
+        consecutive_failure_count: 0,
+        reversibility: "reversible",
+        task_category: "normal",
+        status: "pending",
+        started_at: null,
+        completed_at: null,
+        timeout_at: null,
+        heartbeat_at: null,
+        created_at: new Date().toISOString(),
+      },
+      tokensUsed: 35,
+      playbookIdsUsed: [],
+    });
+    vi.spyOn(
+      lifecycle as unknown as {
+        checkIrreversibleApproval: typeof lifecycle["checkIrreversibleApproval"];
+      },
+      "checkIrreversibleApproval"
+    ).mockResolvedValue(false);
+
+    try {
+      const result = await lifecycle.runTaskCycle(
+        "goal-precheck-usage",
+        {
+          goal_id: "goal-precheck-usage",
+          gaps: [{
+            dimension_name: "coverage",
+            raw_gap: 0.6,
+            normalized_gap: 0.6,
+            normalized_weighted_gap: 0.6,
+            confidence: 0.8,
+            uncertainty_weight: 1,
+          }],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          time_since_last_attempt: { coverage: 24 },
+          deadlines: { coverage: null },
+          opportunities: {},
+          pacing: {},
+        },
+        adapter,
+      );
+
+      expect(result.action).toBe("approval_denied");
+      expect(result.tokensUsed).toBe(35);
+      expect(adapter.execute).not.toHaveBeenCalled();
+      expect(result.verificationResult.evidence[0]?.description).toContain("Approval denied");
+
+      const ledgerRecord = JSON.parse(
+        fs.readFileSync(path.join(tmpDir, "tasks", "goal-precheck-usage", "ledger", "task-precheck-usage.json"), "utf-8")
+      ) as { summary: { tokens_used: number; latest_event_type: string | null } };
+      expect(ledgerRecord.summary.latest_event_type).toBe("abandoned");
+      expect(ledgerRecord.summary.tokens_used).toBe(35);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it("persists generation tokens when adapter circuit breaker blocks execution", async () => {
+    const tmpDir = makeTempDir("pulseed-task-lifecycle-circuit-usage-");
+    const { stateManager, lifecycle } = makeLifecycle(tmpDir);
+    await stateManager.init();
+    await stateManager.saveGoal(makeGoal({ id: "goal-circuit-usage", title: "Keep circuit-breaker usage" }));
+    const adapter: IAdapter = {
+      adapterType: "mock",
+      execute: vi.fn(async () => ({
+        success: true,
+        output: "should not execute",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 1,
+        stopped_reason: "completed" as const,
+      })),
+    };
+    vi.spyOn(
+      lifecycle as unknown as {
+        _generateTaskWithTokens: typeof lifecycle["_generateTaskWithTokens"];
+      },
+      "_generateTaskWithTokens"
+    ).mockResolvedValue({
+      task: {
+        id: "task-circuit-usage",
+        goal_id: "goal-circuit-usage",
+        strategy_id: null,
+        target_dimensions: ["coverage"],
+        primary_dimension: "coverage",
+        work_description: "blocked by circuit breaker",
+        rationale: "test",
+        approach: "test",
+        success_criteria: [{
+          description: "n/a",
+          verification_method: "review",
+          is_blocking: true,
+        }],
+        scope_boundary: {
+          in_scope: ["tests"],
+          out_of_scope: [],
+          blast_radius: "low",
+        },
+        constraints: [],
+        plateau_until: null,
+        estimated_duration: null,
+        consecutive_failure_count: 0,
+        reversibility: "reversible",
+        task_category: "normal",
+        status: "pending",
+        started_at: null,
+        completed_at: null,
+        timeout_at: null,
+        heartbeat_at: null,
+        created_at: new Date().toISOString(),
+      },
+      tokensUsed: 35,
+      playbookIdsUsed: [],
+    });
+    const adapterRegistry = {
+      isAvailable: vi.fn().mockReturnValue(false),
+    };
+    (lifecycle as unknown as { adapterRegistry: AdapterRegistry }).adapterRegistry = adapterRegistry as unknown as AdapterRegistry;
+    try {
+      const result = await lifecycle.runTaskCycle(
+        "goal-circuit-usage",
+        {
+          goal_id: "goal-circuit-usage",
+          gaps: [{
+            dimension_name: "coverage",
+            raw_gap: 0.6,
+            normalized_gap: 0.6,
+            normalized_weighted_gap: 0.6,
+            confidence: 0.8,
+            uncertainty_weight: 1,
+          }],
+          timestamp: new Date().toISOString(),
+        },
+        {
+          time_since_last_attempt: { coverage: 24 },
+          deadlines: { coverage: null },
+          opportunities: {},
+          pacing: {},
+        },
+        adapter,
+      );
+
+      expect(result.tokensUsed).toBe(35);
+      expect(adapter.execute).not.toHaveBeenCalled();
+      expect(adapterRegistry.isAvailable).toHaveBeenCalledWith("mock");
+      expect(result.verificationResult.evidence[0]?.description).toContain("Adapter circuit breaker is open");
+
+      const ledgerRecord = JSON.parse(
+        fs.readFileSync(path.join(tmpDir, "tasks", "goal-circuit-usage", "ledger", "task-circuit-usage.json"), "utf-8")
+      ) as { summary: { tokens_used: number; latest_event_type: string | null } };
+      expect(ledgerRecord.summary.latest_event_type).toBe("failed");
+      expect(ledgerRecord.summary.tokens_used).toBe(35);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+});

--- a/src/orchestrator/execution/__tests__/task-verifier-gateway-usage.test.ts
+++ b/src/orchestrator/execution/__tests__/task-verifier-gateway-usage.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { StateManager } from "../../../base/state/state-manager.js";
+import { SessionManager } from "../session-manager.js";
+import { runLLMReview } from "../task/task-verifier-llm.js";
+import type { VerifierDeps } from "../task/task-verifier-types.js";
+import type { Task } from "../../../base/types/task.js";
+import type { AgentResult } from "../adapter-layer.js";
+import type { IPromptGateway } from "../../../prompt/gateway.js";
+import type { PromptGatewayInput, PromptGatewayExecutionResult } from "../../../prompt/gateway.js";
+
+function makeTask(): Task {
+  return {
+    id: "task-gateway-usage",
+    goal_id: "goal-1",
+    strategy_id: null,
+    target_dimensions: ["coverage"],
+    primary_dimension: "coverage",
+    work_description: "write tests",
+    rationale: "increase coverage",
+    approach: "add unit tests",
+    success_criteria: [
+      {
+        description: "tests pass",
+        verification_method: "run tests",
+        is_blocking: true,
+      },
+    ],
+    scope_boundary: {
+      in_scope: ["tests/"],
+      out_of_scope: ["src/"],
+      blast_radius: "low",
+    },
+    constraints: [],
+    plateau_until: null,
+    estimated_duration: null,
+    consecutive_failure_count: 0,
+    reversibility: "reversible",
+    task_category: "normal",
+    status: "running",
+    started_at: new Date().toISOString(),
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: new Date().toISOString(),
+  };
+}
+
+function makeExecutionResult(): AgentResult {
+  return {
+    success: true,
+    output: "done",
+    error: null,
+    exit_code: 0,
+    elapsed_ms: 10,
+    stopped_reason: "completed",
+  };
+}
+
+describe("runLLMReview gateway usage telemetry", () => {
+  it("records gateway usage tokens and updates the verifier accumulator", async () => {
+    const tmpDir = makeTempDir("pulseed-task-verifier-gateway-usage-");
+    const stateManager = new StateManager(tmpDir);
+    const sessionManager = new SessionManager(stateManager);
+    const tokenAccumulator = { tokensUsed: 0 };
+    const gateway: IPromptGateway = {
+      async execute<T>(_input: PromptGatewayInput<T>): Promise<T> {
+        return {
+          verdict: "pass",
+          reasoning: "done",
+          criteria_met: 1,
+          criteria_total: 1,
+        } as T;
+      },
+      async executeWithUsage<T>(_input: PromptGatewayInput<T>): Promise<PromptGatewayExecutionResult<T>> {
+        return {
+          data: {
+            verdict: "pass",
+            reasoning: "done",
+            criteria_met: 1,
+            criteria_total: 1,
+          } as T,
+          usage: {
+            inputTokens: 30,
+            outputTokens: 12,
+            totalTokens: 42,
+          },
+          contextTokens: 77,
+        };
+      },
+    };
+    const deps = {
+      stateManager,
+      llmClient: {
+        async sendMessage() {
+          throw new Error("not used");
+        },
+        parseJSON() {
+          throw new Error("not used");
+        },
+      },
+      sessionManager,
+      trustManager: ({ getBalance: async () => ({ balance: 0 }) } as unknown as VerifierDeps["trustManager"]),
+      stallDetector: ({ detectStall: async () => null } as unknown as VerifierDeps["stallDetector"]),
+      gateway,
+      _tokenAccumulator: tokenAccumulator,
+    } as unknown as VerifierDeps;
+
+    try {
+      const review = await runLLMReview(
+        deps,
+        makeTask(),
+        makeExecutionResult(),
+      );
+
+      expect(review.passed).toBe(true);
+      expect(review.tokensUsed).toBe(42);
+      expect(tokenAccumulator.tokensUsed).toBe(42);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+});

--- a/src/orchestrator/execution/adapter-layer.ts
+++ b/src/orchestrator/execution/adapter-layer.ts
@@ -33,6 +33,11 @@ export interface AgentLoopExecutionInfo {
   stopReason: string;
   modelTurns: number;
   toolCalls: number;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
   compactions: number;
   completionEvidence?: string[];
   verificationHints?: string[];

--- a/src/orchestrator/execution/agent-loop/agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-result.ts
@@ -24,6 +24,12 @@ export interface AgentLoopWorkspaceInfo {
   cleanupReason?: string;
 }
 
+export interface AgentLoopTokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
 export interface AgentLoopResult<TOutput> {
   success: boolean;
   output: TOutput | null;
@@ -32,6 +38,7 @@ export interface AgentLoopResult<TOutput> {
   elapsedMs: number;
   modelTurns: number;
   toolCalls: number;
+  usage?: AgentLoopTokenUsage;
   compactions: number;
   filesChanged?: boolean;
   changedFiles: string[];

--- a/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
@@ -14,6 +14,11 @@ export interface AgentLoopSessionState {
   messages: AgentLoopMessage[];
   modelTurns: number;
   toolCalls: number;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
   compactions: number;
   completionValidationAttempts: number;
   calledTools: string[];
@@ -34,7 +39,14 @@ export class InMemoryAgentLoopSessionStateStore implements AgentLoopSessionState
   private state: AgentLoopSessionState | null = null;
 
   async load(): Promise<AgentLoopSessionState | null> {
-    return this.state ? { ...this.state, messages: [...this.state.messages], calledTools: [...this.state.calledTools] } : null;
+    return this.state
+      ? {
+          ...this.state,
+          messages: [...this.state.messages],
+          calledTools: [...this.state.calledTools],
+          ...(this.state.usage ? { usage: { ...this.state.usage } } : {}),
+        }
+      : null;
   }
 
   async save(state: AgentLoopSessionState): Promise<void> {
@@ -42,6 +54,7 @@ export class InMemoryAgentLoopSessionStateStore implements AgentLoopSessionState
       ...state,
       messages: [...state.messages],
       calledTools: [...state.calledTools],
+      ...(state.usage ? { usage: { ...state.usage } } : {}),
     };
   }
 }
@@ -91,6 +104,7 @@ export function normalizeAgentLoopSessionState(value: unknown): AgentLoopSession
     messages,
     modelTurns: nonNegativeNumberField(value, "modelTurns"),
     toolCalls: nonNegativeNumberField(value, "toolCalls"),
+    usage: usageField(value),
     compactions: nonNegativeNumberField(value, "compactions"),
     completionValidationAttempts: nonNegativeNumberField(value, "completionValidationAttempts"),
     calledTools: stringArrayField(value, "calledTools"),
@@ -138,6 +152,27 @@ function stringField(value: Record<string, unknown>, field: string): string | nu
 function nonNegativeNumberField(value: Record<string, unknown>, field: string): number {
   const raw = value[field];
   return typeof raw === "number" && Number.isFinite(raw) && raw >= 0 ? raw : 0;
+}
+
+function usageField(value: Record<string, unknown>): NonNullable<AgentLoopSessionState["usage"]> {
+  const raw = value["usage"];
+  if (isRecord(raw)) {
+    const inputTokens = nonNegativeNumberField(raw, "inputTokens");
+    const outputTokens = nonNegativeNumberField(raw, "outputTokens");
+    const totalTokensRaw = nonNegativeNumberField(raw, "totalTokens");
+    return {
+      inputTokens,
+      outputTokens,
+      totalTokens: totalTokensRaw > 0 ? totalTokensRaw : inputTokens + outputTokens,
+    };
+  }
+
+  // Legacy fallback for state files before usage tracking.
+  return {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
 }
 
 function stringArrayField(value: Record<string, unknown>, field: string): string[] {

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -3,7 +3,7 @@ import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import type { z } from "zod";
 import type { AgentLoopStopReason } from "./agent-loop-budget.js";
 import type { AgentLoopMessage, AgentLoopModelClient, AgentLoopModelTurnProtocol } from "./agent-loop-model.js";
-import type { AgentLoopCommandResult, AgentLoopResult } from "./agent-loop-result.js";
+import type { AgentLoopCommandResult, AgentLoopResult, AgentLoopTokenUsage } from "./agent-loop-result.js";
 import type { AgentLoopToolRuntime } from "./agent-loop-tool-runtime.js";
 import type { AgentLoopToolRouter } from "./agent-loop-tool-router.js";
 import type { AgentLoopTurnContext } from "./agent-loop-turn-context.js";
@@ -33,6 +33,9 @@ export class BoundedAgentLoopRunner {
     const resumed = turn.resumeState ?? await turn.session.stateStore.load();
     let modelTurns = resumed?.modelTurns ?? 0;
     let toolCalls = resumed?.toolCalls ?? 0;
+    const usage: AgentLoopTokenUsage = resumed?.usage
+      ? { ...resumed.usage }
+      : { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
     let consecutiveToolErrors = 0;
     let schemaRepairAttempts = 0;
     let completionValidationAttempts = resumed?.completionValidationAttempts ?? 0;
@@ -61,24 +64,24 @@ export class BoundedAgentLoopRunner {
     let messages: AgentLoopMessage[] = resumed?.messages ? [...resumed.messages] : [...turn.messages];
     const preTurnCompaction = await this.compactIfNeeded(turn, messages, "pre_turn", "context_limit", undefined, compactions);
     if (preTurnCompaction.error) {
-      return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, [], commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+      return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, [], commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
     }
     messages = preTurnCompaction.messages;
     compactions += preTurnCompaction.compacted ? 1 : 0;
-    await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+    await this.saveState(turn, messages, modelTurns, toolCalls, usage, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
 
     while (true) {
       if (Date.now() - startedAt > turn.budget.maxWallClockMs) {
-        return this.stop(turn, "timeout", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "timeout", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (modelTurns >= turn.budget.maxModelTurns) {
-        return this.stop(turn, "max_model_turns", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "max_model_turns", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (toolCalls >= turn.budget.maxToolCalls) {
-        return this.stop(turn, "max_tool_calls", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "max_tool_calls", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (turn.abortSignal?.aborted) {
-        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
 
       const tools = this.deps.toolRouter.modelVisibleTools(turn as AgentLoopTurnContext<unknown>);
@@ -100,8 +103,13 @@ export class BoundedAgentLoopRunner {
 
       const protocol = await this.createTurnProtocol(turn, messages, tools);
       if (!protocol.responseCompleted) {
-        return this.stop(turn, "protocol_incomplete", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "protocol_incomplete", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
+
+      const protocolUsage = this.normalizeUsage(protocol.usage);
+      usage.inputTokens += protocolUsage.inputTokens;
+      usage.outputTokens += protocolUsage.outputTokens;
+      usage.totalTokens += protocolUsage.totalTokens;
 
       const response = this.protocolToResponse(protocol);
       modelTurns++;
@@ -129,11 +137,11 @@ export class BoundedAgentLoopRunner {
             });
             const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
             }
             messages = compacted.messages;
             compactions += compacted.compacted ? 1 : 0;
-            await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+            await this.saveState(turn, messages, modelTurns, toolCalls, usage, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
             continue;
           }
 
@@ -149,7 +157,7 @@ export class BoundedAgentLoopRunner {
           if (completionValidation && !completionValidation.ok) {
             completionValidationAttempts++;
             if (completionValidationAttempts > turn.budget.maxCompletionValidationAttempts) {
-              return this.stop(turn, "completion_gate_failed", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+              return this.stop(turn, "completion_gate_failed", startedAt, modelTurns, toolCalls, usage, response.content, null, false, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
             }
 
             messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
@@ -159,11 +167,11 @@ export class BoundedAgentLoopRunner {
             });
             const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
             }
             messages = compacted.messages;
             compactions += compacted.compacted ? 1 : 0;
-            await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+            await this.saveState(turn, messages, modelTurns, toolCalls, usage, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
             continue;
           }
 
@@ -173,12 +181,12 @@ export class BoundedAgentLoopRunner {
             success: true,
             outputPreview: this.preview(response.content),
           });
-          return this.stop(turn, "completed", startedAt, modelTurns, toolCalls, response.content, parsed.output, true, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+          return this.stop(turn, "completed", startedAt, modelTurns, toolCalls, usage, response.content, parsed.output, true, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
         }
 
         schemaRepairAttempts++;
         if (schemaRepairAttempts > turn.budget.maxSchemaRepairAttempts) {
-          return this.stop(turn, "schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, "schema_error", startedAt, modelTurns, toolCalls, usage, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
 
         messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
@@ -188,11 +196,11 @@ export class BoundedAgentLoopRunner {
         });
         const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
         if (compacted.error) {
-          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         messages = compacted.messages;
         compactions += compacted.compacted ? 1 : 0;
-        await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+        await this.saveState(turn, messages, modelTurns, toolCalls, usage, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
         continue;
       }
 
@@ -213,7 +221,7 @@ export class BoundedAgentLoopRunner {
       }
 
       if (repeatedToolLoopCount > turn.budget.maxRepeatedToolCalls) {
-        return this.stop(turn, "stalled_tool_loop", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "stalled_tool_loop", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
 
       for (const call of response.toolCalls) {
@@ -289,23 +297,23 @@ export class BoundedAgentLoopRunner {
         }
 
         if (result.disposition === "fatal" || result.fatal) {
-          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         if (result.disposition === "cancelled") {
-          return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         if (consecutiveToolErrors >= turn.budget.maxConsecutiveToolErrors) {
-          return this.stop(turn, "consecutive_tool_errors", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, "consecutive_tool_errors", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
       }
 
       const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
       if (compacted.error) {
-        return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       messages = compacted.messages;
       compactions += compacted.compacted ? 1 : 0;
-      await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+      await this.saveState(turn, messages, modelTurns, toolCalls, usage, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
     }
   }
 
@@ -332,6 +340,7 @@ export class BoundedAgentLoopRunner {
     startedAt: number,
     modelTurns: number,
     toolCalls: number,
+    usage: AgentLoopTokenUsage,
     finalText: string,
     output: TOutput | null,
     success = false,
@@ -349,6 +358,7 @@ export class BoundedAgentLoopRunner {
       messages ?? turn.messages,
       modelTurns,
       toolCalls,
+      usage,
       compactions,
       completionValidationAttempts ?? 0,
       calledTools ?? new Set<string>(),
@@ -373,6 +383,7 @@ export class BoundedAgentLoopRunner {
       elapsedMs: Date.now() - startedAt,
       modelTurns,
       toolCalls,
+      usage,
       compactions,
       filesChanged: changedFiles.length > 0,
       changedFiles,
@@ -483,6 +494,18 @@ export class BoundedAgentLoopRunner {
     return response.usage.inputTokens + response.usage.outputTokens;
   }
 
+  private normalizeUsage(
+    usage: { inputTokens: number; outputTokens: number } | undefined
+  ): AgentLoopTokenUsage {
+    const inputTokens = usage?.inputTokens ?? 0;
+    const outputTokens = usage?.outputTokens ?? 0;
+    return {
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    };
+  }
+
   private estimateTokens(messages: AgentLoopMessage[]): number {
     const chars = messages.reduce((total, message) => total + message.content.length, 0);
     return Math.ceil(chars / 4);
@@ -539,6 +562,7 @@ export class BoundedAgentLoopRunner {
     messages: AgentLoopMessage[],
     modelTurns: number,
     toolCalls: number,
+    usage: AgentLoopTokenUsage,
     compactions: number,
     completionValidationAttempts: number,
     calledTools: Set<string>,
@@ -559,6 +583,7 @@ export class BoundedAgentLoopRunner {
       messages,
       modelTurns,
       toolCalls,
+      usage,
       compactions,
       completionValidationAttempts,
       calledTools: [...calledTools],

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -164,6 +164,7 @@ export class ChatAgentLoopRunner {
         stopReason: result.stopReason,
         modelTurns: result.modelTurns,
         toolCalls: result.toolCalls,
+        usage: result.usage,
         compactions: result.compactions,
         ...(result.profileName ? { profileName: result.profileName } : {}),
         ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
@@ -48,6 +48,7 @@ export function taskAgentLoopResultToAgentResult(
       stopReason: result.stopReason,
       modelTurns: result.modelTurns,
       toolCalls: result.toolCalls,
+      usage: result.usage,
       compactions: result.compactions,
       ...(result.profileName ? { profileName: result.profileName } : {}),
       ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),

--- a/src/orchestrator/execution/task/task-execution-types.ts
+++ b/src/orchestrator/execution/task/task-execution-types.ts
@@ -12,15 +12,15 @@ export interface TaskCycleResult {
   verificationResult: VerificationResult;
   action: "completed" | "keep" | "discard" | "escalate" | "approval_denied" | "capability_acquiring";
   acquisition_task?: CapabilityAcquisitionTask;
-  /** Total tokens consumed by LLM calls during this task cycle (generation + verification). */
+  /** Total tokens consumed during this task cycle (generation + native execution + verification). */
   tokensUsed?: number;
 }
 
 /**
  * Creates a synthetic TaskCycleResult for a skipped (duplicate-detected) task.
  */
-export function createSkippedTaskResult(goalId: string, targetDimension: string): TaskCycleResult {
+export function createSkippedTaskResult(goalId: string, targetDimension: string, tokensUsed = 0): TaskCycleResult {
   const skippedTask = TaskSchema.parse({ id: "skipped", goal_id: goalId, target_dimensions: [], primary_dimension: targetDimension, work_description: "skipped (duplicate)", rationale: "", approach: "", success_criteria: [], scope_boundary: { in_scope: [], out_of_scope: [], blast_radius: "" }, constraints: [], created_at: new Date().toISOString() });
   const skippedVerification = VerificationResultSchema.parse({ task_id: "skipped", verdict: "fail", confidence: 0, evidence: [], dimension_updates: [], timestamp: new Date().toISOString() });
-  return { task: skippedTask, verificationResult: skippedVerification, action: "discard" };
+  return { task: skippedTask, verificationResult: skippedVerification, action: "discard", tokensUsed };
 }

--- a/src/orchestrator/execution/task/task-generation.ts
+++ b/src/orchestrator/execution/task/task-generation.ts
@@ -346,14 +346,28 @@ export async function generateTask(
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       console.log(`  [LLM] Calling LLM for task generation (${targetDimension})...`);
-      generated = await deps.gateway.execute({
-        purpose: "task_generation",
-        goalId,
-        dimensionName: targetDimension,
-        additionalContext: { task_prompt: prompt },
-        responseSchema: LLMGeneratedTaskSchema as z.ZodSchema<ReturnType<typeof LLMGeneratedTaskSchema.parse>>,
-        maxTokens: maxGenerationTokens,
-      });
+      if (typeof deps.gateway.executeWithUsage === "function") {
+        const gatewayResult = await deps.gateway.executeWithUsage({
+          purpose: "task_generation",
+          goalId,
+          dimensionName: targetDimension,
+          additionalContext: { task_prompt: prompt },
+          responseSchema: LLMGeneratedTaskSchema as z.ZodSchema<ReturnType<typeof LLMGeneratedTaskSchema.parse>>,
+          maxTokens: maxGenerationTokens,
+        });
+        generated = gatewayResult.data;
+        generationTokens = gatewayResult.usage.totalTokens;
+      } else {
+        generated = await deps.gateway.execute({
+          purpose: "task_generation",
+          goalId,
+          dimensionName: targetDimension,
+          additionalContext: { task_prompt: prompt },
+          responseSchema: LLMGeneratedTaskSchema as z.ZodSchema<ReturnType<typeof LLMGeneratedTaskSchema.parse>>,
+          maxTokens: maxGenerationTokens,
+        });
+        generationTokens = 0;
+      }
       console.log(`  [LLM] Task generation complete (${targetDimension}).`);
     } catch (err) {
       deps.logger?.error(
@@ -362,8 +376,6 @@ export async function generateTask(
       );
       throw err;
     }
-    // PromptGateway does not expose usage data — tokens tracked as 0.
-    generationTokens = 0;
   } else {
     console.log(`  [LLM] Calling LLM for task generation (${targetDimension})...`);
     const response = await deps.llmClient.sendMessage(

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -62,6 +62,7 @@ import type { HookManager } from "../../../runtime/hook-manager.js";
 import type { ToolExecutor } from "../../../tools/executor.js";
 import type { TaskAgentLoopRunner } from "../agent-loop/task-agent-loop-runner.js";
 import { taskAgentLoopResultToAgentResult } from "../agent-loop/task-agent-loop-result.js";
+import type { IPromptGateway } from "../../../prompt/gateway.js";
 import {
   formatPlaybookHints,
   formatPatternHints,
@@ -84,7 +85,7 @@ export type {
 } from "./task-pipeline-types.js";
 import type { TaskCycleResult } from "./task-execution-types.js";
 import { createSkippedTaskResult } from "./task-execution-types.js";
-import { appendTaskOutcomeEvent } from "./task-outcome-ledger.js";
+import { appendTaskOutcomeEvent, setTaskOutcomeTokens } from "./task-outcome-ledger.js";
 
 export interface TaskLifecycleCoreDeps {
   stateManager: StateManager;
@@ -122,6 +123,8 @@ export interface TaskLifecycleOptions {
   toolExecutor?: ToolExecutor;
   /** Native task-level agentloop runner. When present, runTaskCycle executes tasks through this path. */
   agentLoopRunner?: TaskAgentLoopRunner;
+  /** Optional PromptGateway used for task generation and verifier review. */
+  gateway?: IPromptGateway;
   /** Optional explicit workspace root for git-based revert operations. */
   revertCwd?: string;
   /** Optional explicit workspace root for post-execution health checks. */
@@ -165,6 +168,7 @@ export class TaskLifecycle {
   private readonly hookManager?: HookManager;
   private readonly toolExecutor?: ToolExecutor;
   private readonly agentLoopRunner?: TaskAgentLoopRunner;
+  private readonly gateway?: IPromptGateway;
   private readonly revertCwd?: string;
   private readonly healthCheckCwd?: string;
   private onTaskComplete?: (strategyId: string) => void;
@@ -222,6 +226,7 @@ export class TaskLifecycle {
     this.hookManager = resolvedOptions?.hookManager;
     this.toolExecutor = resolvedOptions?.toolExecutor;
     this.agentLoopRunner = resolvedOptions?.agentLoopRunner;
+    this.gateway = resolvedOptions?.gateway;
     this.revertCwd = resolvedOptions?.revertCwd;
     this.healthCheckCwd = resolvedOptions?.healthCheckCwd;
   }
@@ -331,6 +336,7 @@ export class TaskLifecycle {
         logger: this.logger,
         knowledgeManager: this.knowledgeManager,
         memoryLifecycle: this.memoryLifecycle,
+        gateway: this.gateway,
       },
       goalId,
       targetDimension,
@@ -587,7 +593,7 @@ export class TaskLifecycle {
     const task = genResult.task;
     if (task === null) {
       this.logger?.warn("TaskLifecycle: task generation returned null (duplicate detected), skipping cycle");
-      return createSkippedTaskResult(goalId, targetDimension);
+      return createSkippedTaskResult(goalId, targetDimension, taskCycleTokens);
     }
     void this.hookManager?.emit("PostTaskCreate", { goal_id: goalId, data: { task_id: task.id } });
     this.logger?.info(`[task] created: ${task.work_description?.substring(0, 120)}`, { taskId: task.id });
@@ -613,7 +619,11 @@ export class TaskLifecycle {
         verificationResult: preCheckResult.verificationResult,
         reason: preCheckResult.verificationResult.evidence[0]?.description,
       });
-      return preCheckResult;
+      await setTaskOutcomeTokens(this.stateManager, task, taskCycleTokens);
+      return {
+        ...preCheckResult,
+        tokensUsed: taskCycleTokens,
+      };
     }
 
     await appendTaskOutcomeEvent(this.stateManager, {
@@ -638,6 +648,7 @@ export class TaskLifecycle {
         attempt: task.consecutive_failure_count + 1,
         reason,
       });
+      await setTaskOutcomeTokens(this.stateManager, blockedTask, taskCycleTokens);
       this.logger?.warn(`[task] skipped: ${reason}`, { taskId: task.id });
 
       return {
@@ -663,6 +674,10 @@ export class TaskLifecycle {
         ? this.executeTaskWithAgentLoop(task, workspaceContext, enrichedKnowledgeContext)
         : this.executeTask(task, adapter, workspaceContext)
     );
+    const nativeExecutionTokens = executionResult.agentLoop?.usage?.totalTokens;
+    if (typeof nativeExecutionTokens === "number" && Number.isFinite(nativeExecutionTokens)) {
+      taskCycleTokens += nativeExecutionTokens;
+    }
     void this.hookManager?.emit("PostExecute", { goal_id: goalId, data: { task_id: task.id, success: executionResult.success } });
     this.logger?.info(`[task] executed: ${executionResult.success ? 'success' : 'failed'}`, { taskId: task.id });
     this.logger?.debug(`[DEBUG-TL] Execution result: success=${executionResult.success}, stopped=${executionResult.stopped_reason}, error=${executionResult.error}, output=${executionResult.output?.substring(0, 200)}`);
@@ -709,6 +724,9 @@ export class TaskLifecycle {
         reusedPlaybookIds: playbookIdsUsed,
       })
     );
+    await runPhase("persist-usage-telemetry", async () => {
+      await setTaskOutcomeTokens(this.stateManager, verdictResult.task, taskCycleTokens);
+    });
 
     return {
       task: verdictResult.task,
@@ -766,6 +784,7 @@ export class TaskLifecycle {
       preferredAdapterType,
       logger: this.logger,
       onTaskComplete: this.onTaskComplete,
+      gateway: this.gateway,
       durationToMs: durationToMs,
       completionJudgerConfig: this.completionJudgerConfig,
       toolExecutor: this.toolExecutor,

--- a/src/orchestrator/execution/task/task-outcome-ledger.ts
+++ b/src/orchestrator/execution/task/task-outcome-ledger.ts
@@ -27,6 +27,7 @@ export interface TaskOutcomeEvent {
   verification_at: string | null;
   elapsed_ms: number | null;
   estimated_duration_ms: number | null;
+  tokens_used: number | null;
 }
 
 export interface TaskOutcomeSummary {
@@ -46,6 +47,7 @@ export interface TaskOutcomeSummary {
   last_failure_at: string | null;
   abandoned_at: string | null;
   estimated_duration_ms: number | null;
+  tokens_used: number;
   latencies: {
     created_to_acked_ms: number | null;
     acked_to_started_ms: number | null;
@@ -70,6 +72,7 @@ export interface TaskOutcomeAggregateSummary {
   failed: number;
   abandoned: number;
   retried: number;
+  total_tokens_used: number;
   success_rate: number | null;
   retry_rate: number | null;
   abandoned_rate: number | null;
@@ -88,6 +91,7 @@ interface AppendTaskOutcomeEventParams {
   stoppedReason?: string | null;
   verificationResult?: VerificationResult;
   elapsedMs?: number | null;
+  tokensUsed?: number | null;
 }
 
 const ledgerPath = (goalId: string, taskId: string): string => `tasks/${goalId}/ledger/${taskId}.json`;
@@ -140,6 +144,7 @@ function buildEvent(params: AppendTaskOutcomeEventParams): TaskOutcomeEvent {
     verification_at: params.verificationResult?.timestamp ?? null,
     elapsed_ms: params.elapsedMs ?? diffMs(params.task.started_at, params.task.completed_at),
     estimated_duration_ms: estimateDurationMs(params.task),
+    tokens_used: typeof params.tokensUsed === "number" ? params.tokensUsed : null,
   };
 }
 
@@ -165,6 +170,7 @@ function buildSummary(task: Task, events: TaskOutcomeEvent[]): TaskOutcomeSummar
     lastEvent?.verification_at ??
     findLastEvent(events, (event) => event.verification_at !== null)?.verification_at ??
     null;
+  const latestTokensUsed = findLastEvent(events, (event) => typeof event.tokens_used === "number")?.tokens_used ?? 0;
 
   return {
     task_id: task.id,
@@ -183,6 +189,7 @@ function buildSummary(task: Task, events: TaskOutcomeEvent[]): TaskOutcomeSummar
     last_failure_at: lastFailure?.ts ?? null,
     abandoned_at: lastAbandoned?.ts ?? null,
     estimated_duration_ms: estimateDurationMs(task),
+    tokens_used: latestTokensUsed,
     latencies: {
       created_to_acked_ms: diffMs(task.created_at ?? null, ackedAt),
       acked_to_started_ms: diffMs(ackedAt, task.started_at ?? null),
@@ -242,6 +249,31 @@ export async function syncTaskOutcomeSummary(
 ): Promise<TaskOutcomeLedgerRecord> {
   const existing = await readLedgerRecord(stateManager, task.goal_id, task.id);
   return writeLedgerRecord(stateManager, task, existing?.events ?? []);
+}
+
+export async function setTaskOutcomeTokens(
+  stateManager: StateManager,
+  task: Task,
+  tokensUsed: number
+): Promise<TaskOutcomeLedgerRecord | null> {
+  const existing = await readLedgerRecord(stateManager, task.goal_id, task.id);
+  if (!existing) return null;
+  const nextEvents = [...existing.events];
+  const lastIndex = nextEvents.length - 1;
+  if (lastIndex >= 0) {
+    const lastEvent = nextEvents[lastIndex]!;
+    nextEvents[lastIndex] = {
+      ...lastEvent,
+      tokens_used: tokensUsed,
+    };
+  } else {
+    nextEvents.push(buildEvent({
+      task,
+      type: inferMutationEvent(task) ?? "acked",
+      tokensUsed,
+    }));
+  }
+  return writeLedgerRecord(stateManager, task, nextEvents);
 }
 
 function inferMutationEvent(task: Task): TaskOutcomeEventType | null {
@@ -318,6 +350,7 @@ export async function summarizeTaskOutcomeLedgers(baseDir: string): Promise<Task
         failed: 0,
         abandoned: 0,
         retried: 0,
+        total_tokens_used: 0,
         success_rate: null,
         retry_rate: null,
         abandoned_rate: null,
@@ -348,6 +381,7 @@ export async function summarizeTaskOutcomeLedgers(baseDir: string): Promise<Task
   const failed = records.filter((record) => record.summary.latest_event_type === "failed").length;
   const abandoned = records.filter((record) => record.summary.latest_event_type === "abandoned").length;
   const retried = records.filter((record) => record.events.some((event) => event.type === "retried")).length;
+  const totalTokensUsed = records.reduce((sum, record) => sum + (record.summary.tokens_used ?? 0), 0);
   const inflightTasks = records.filter((record) => {
     const latestEvent = record.summary.latest_event_type;
     return latestEvent === "acked" || latestEvent === "started" || latestEvent === "retried";
@@ -362,6 +396,7 @@ export async function summarizeTaskOutcomeLedgers(baseDir: string): Promise<Task
     failed,
     abandoned,
     retried,
+    total_tokens_used: totalTokensUsed,
     success_rate: terminalTasks > 0 ? succeeded / terminalTasks : null,
     retry_rate: records.length > 0 ? retried / records.length : null,
     abandoned_rate: terminalTasks > 0 ? abandoned / terminalTasks : null,

--- a/src/orchestrator/execution/task/task-verifier-llm.ts
+++ b/src/orchestrator/execution/task/task-verifier-llm.ts
@@ -129,23 +129,46 @@ Return JSON:
   // Gateway path: route through PromptGateway when available
   if (deps.gateway) {
     let parsed: z.infer<typeof CompletionJudgerResponseSchema>;
+    let verifierTokens = 0;
     try {
-      parsed = await withRetry(
-        () => withTimeout(
-          deps.gateway!.execute({
-            purpose: "verification",
-            goalId: task.goal_id,
-            additionalContext: { review_prompt: prompt },
-            responseSchema: CompletionJudgerResponseSchema as z.ZodSchema<z.infer<typeof CompletionJudgerResponseSchema>>,
-            maxTokens: 1024,
-          }),
-          timeoutMs
-        ),
-        maxRetries,
-        retryBackoffMs,
-        deps.logger,
-        `completion_judger for task ${task.id}`
-      );
+      if (typeof deps.gateway.executeWithUsage === "function") {
+        const gatewayResult = await withRetry(
+          () => withTimeout(
+            deps.gateway!.executeWithUsage({
+              purpose: "verification",
+              goalId: task.goal_id,
+              additionalContext: { review_prompt: prompt },
+              responseSchema: CompletionJudgerResponseSchema as z.ZodSchema<z.infer<typeof CompletionJudgerResponseSchema>>,
+              maxTokens: 1024,
+            }),
+            timeoutMs
+          ),
+          maxRetries,
+          retryBackoffMs,
+          deps.logger,
+          `completion_judger for task ${task.id}`
+        );
+        parsed = gatewayResult.data;
+        verifierTokens = gatewayResult.usage.totalTokens;
+      } else {
+        parsed = await withRetry(
+          () => withTimeout(
+            deps.gateway!.execute({
+              purpose: "verification",
+              goalId: task.goal_id,
+              additionalContext: { review_prompt: prompt },
+              responseSchema: CompletionJudgerResponseSchema as z.ZodSchema<z.infer<typeof CompletionJudgerResponseSchema>>,
+              maxTokens: 1024,
+            }),
+            timeoutMs
+          ),
+          maxRetries,
+          retryBackoffMs,
+          deps.logger,
+          `completion_judger for task ${task.id}`
+        );
+        verifierTokens = 0;
+      }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       deps.logger?.error(`[completion_judger] All retries exhausted for task ${task.id}: ${msg}`);
@@ -166,7 +189,7 @@ Return JSON:
       confidence: verdictStr === "pass" ? 0.8 : verdictStr === "partial" ? 0.6 : 0.8,
       criteria_met: parsed.criteria_met,
       criteria_total: parsed.criteria_total,
-      tokensUsed: 0, // TODO: PromptGateway does not expose usage data
+      tokensUsed: verifierTokens,
     };
     if (deps._tokenAccumulator) deps._tokenAccumulator.tokensUsed += result.tokensUsed;
     await deps.sessionManager.endSession(reviewSession.id, `LLM review: ${verdictStr}`);

--- a/src/prompt/__tests__/gateway.test.ts
+++ b/src/prompt/__tests__/gateway.test.ts
@@ -220,6 +220,28 @@ describe("PromptGateway", () => {
     });
   });
 
+  describe("executeWithUsage()", () => {
+    it("returns parsed output with usage and context token metadata", async () => {
+      const assembler = makeMockAssembler({ totalTokensUsed: 77 });
+      const llmClient = makeMockLLMClient({ score: 0.91 });
+      const gateway = new PromptGateway(llmClient, assembler);
+
+      const result = await gateway.executeWithUsage({
+        purpose: "observation",
+        goalId: "goal-usage",
+        responseSchema: schema,
+      });
+
+      expect(result.data).toEqual({ score: 0.91 });
+      expect(result.usage).toEqual({
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 150,
+      });
+      expect(result.contextTokens).toBe(77);
+    });
+  });
+
   describe("error handling", () => {
     it("throws meaningful error when assembler.build fails", async () => {
       const assembler = new ContextAssembler({});

--- a/src/prompt/gateway.ts
+++ b/src/prompt/gateway.ts
@@ -22,8 +22,21 @@ export interface PromptGatewayInput<T> {
   temperature?: number;
 }
 
+export interface PromptGatewayUsage {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export interface PromptGatewayExecutionResult<T> {
+  data: T;
+  usage: PromptGatewayUsage;
+  contextTokens: number;
+}
+
 export interface IPromptGateway {
   execute<T>(input: PromptGatewayInput<T>): Promise<T>;
+  executeWithUsage<T>(input: PromptGatewayInput<T>): Promise<PromptGatewayExecutionResult<T>>;
 }
 
 // ─── Purpose → Role mapping ───────────────────────────────────────────────────
@@ -99,6 +112,11 @@ export class PromptGateway implements IPromptGateway {
   ) {}
 
   async execute<T>(input: PromptGatewayInput<T>): Promise<T> {
+    const result = await this.executeWithUsage(input);
+    return result.data;
+  }
+
+  async executeWithUsage<T>(input: PromptGatewayInput<T>): Promise<PromptGatewayExecutionResult<T>> {
     const config = PURPOSE_CONFIGS[input.purpose];
 
     let assembled;
@@ -138,13 +156,24 @@ ${baseSystemPrompt}`;
     }
 
     const parsed = this.llmClient.parseJSON(response.content, input.responseSchema);
+    const inputTokens = response.usage?.input_tokens ?? 0;
+    const outputTokens = response.usage?.output_tokens ?? 0;
+    const usage: PromptGatewayUsage = {
+      inputTokens,
+      outputTokens,
+      totalTokens: inputTokens + outputTokens,
+    };
 
     if (this.options?.logger) {
       this.options.logger(
-        `[PromptGateway] ${input.purpose} | tokens: ${response.usage.input_tokens}+${response.usage.output_tokens} | context: ${assembled.totalTokensUsed}`
+        `[PromptGateway] ${input.purpose} | tokens: ${usage.inputTokens}+${usage.outputTokens} | context: ${assembled.totalTokensUsed}`
       );
     }
 
-    return parsed;
+    return {
+      data: parsed,
+      usage,
+      contextTokens: assembled.totalTokensUsed,
+    };
   }
 }

--- a/src/prompt/index.ts
+++ b/src/prompt/index.ts
@@ -4,7 +4,12 @@
  */
 
 export { PromptGateway } from "./gateway.js";
-export type { IPromptGateway, PromptGatewayInput } from "./gateway.js";
+export type {
+  IPromptGateway,
+  PromptGatewayInput,
+  PromptGatewayUsage,
+  PromptGatewayExecutionResult,
+} from "./gateway.js";
 export { ContextAssembler } from "./context-assembler.js";
 export type { AssembledContext, ContextAssemblerDeps } from "./context-assembler.js";
 export type { ContextPurpose, ContextSlot, MemoryLayer } from "./slot-definitions.js";


### PR DESCRIPTION
## Summary
- add durable usage propagation from PromptGateway, AgentLoop, verifier, and task lifecycle into ledger/session state
- add `/usage` support in chat + TUI path and add new CLI `pulseed usage <session|goal|daemon|schedule>` surface
- persist task-cycle token totals (including early-exit branches) and expose goal/daemon/schedule/session usage aggregation
- update runtime docs and extend tests for gateway usage, lifecycle-to-reporting chain, and CLI usage behavior

## Validation
- pnpm vitest run src/interface/cli/__tests__/cli-usage.test.ts src/orchestrator/execution/__tests__/task-lifecycle-usage-reporting.test.ts src/orchestrator/execution/__tests__/task-verifier-gateway-usage.test.ts src/prompt/__tests__/gateway.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/orchestrator/execution/__tests__/result-reconciler.test.ts
- pnpm exec tsc --noEmit --pretty false

Closes #707
