### PR TITLE
Fix no-flicker TUI regressions and streamline installer onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ scripts/*
 !scripts/check-docs.mjs
 !scripts/check-subpackages.mjs
 !scripts/clean-dist.mjs
+!scripts/install.sh
+!scripts/install.ps1
 !scripts/release.mjs
 !scripts/run-tui-test.mjs
 !scripts/test-changed.mjs

--- a/README.md
+++ b/README.md
@@ -46,18 +46,27 @@ menu of subcommands.
 
 ## Start Here
 
-PulSeed supports Node.js 22 and 24. The default install path below uses Node.js 24 via nvm.
+PulSeed supports Node.js 22 or 24.
+
+Quick install (macOS / Linux):
 
 ```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-nvm install 24
-nvm use 24
-nvm alias default 24
-npm install -g pulseed
+curl -fsSL https://raw.githubusercontent.com/my-name-is-yu/PulSeed/main/scripts/install.sh | bash
+```
+
+Quick install (Windows / PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/my-name-is-yu/PulSeed/main/scripts/install.ps1 | iex
+```
+
+Then start PulSeed:
+
+```bash
 pulseed
 ```
+
+For pinned-tag installs, fallback npm installs, and installer flags, see [Getting Started](docs/getting-started.md).
 
 Then describe the goal in natural language:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,16 +4,64 @@ This is the shortest path from install to a first goal run.
 
 ## 1. Install
 
-PulSeed supports Node.js 22 and 24. The default install path below uses Node.js 24 via nvm.
+PulSeed supports Node.js 22 or 24.
+
+macOS / Linux:
 
 ```bash
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | bash
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-nvm install 24
-nvm use 24
-nvm alias default 24
+curl -fsSL https://raw.githubusercontent.com/my-name-is-yu/PulSeed/main/scripts/install.sh | bash
+```
+
+Windows (PowerShell):
+
+```powershell
+irm https://raw.githubusercontent.com/my-name-is-yu/PulSeed/main/scripts/install.ps1 | iex
+```
+
+On Windows, the installer attempts Node.js bootstrap via `winget` when Node.js/npm are missing.
+
+Reproducible alternative (pin to a release tag):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/my-name-is-yu/PulSeed/refs/tags/<tag>/scripts/install.sh | bash
+```
+
+```powershell
+irm https://raw.githubusercontent.com/my-name-is-yu/PulSeed/refs/tags/<tag>/scripts/install.ps1 | iex
+```
+
+Fallback:
+
+```bash
 npm install -g pulseed
+```
+
+If global npm install fails with `EACCES`/`EPERM`, use a user-local npm path:
+
+```bash
+mkdir -p ~/.npm-global
+npm config set prefix ~/.npm-global
+export PATH="$HOME/.npm-global/bin:$PATH"
+npm install -g pulseed
+```
+
+```powershell
+$prefix = "$HOME\.npm-global"
+npm config set prefix $prefix
+$env:Path = "$prefix;$env:Path"
+[Environment]::SetEnvironmentVariable("Path", "$prefix;" + [Environment]::GetEnvironmentVariable("Path", "User"), "User")
+npm install -g pulseed
+```
+
+Optional installer flags (for example, fixed version or dry run):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/my-name-is-yu/PulSeed/main/scripts/install.sh | bash -s -- --version x.y.z --dry-run
+```
+
+```powershell
+$installer = irm https://raw.githubusercontent.com/my-name-is-yu/PulSeed/main/scripts/install.ps1
+& ([ScriptBlock]::Create($installer)) -Version x.y.z -DryRun
 ```
 
 ## 2. Start PulSeed

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,370 @@
+param(
+  [string]$Version = "latest",
+  [switch]$Setup,
+  [switch]$NoSetup,
+  [switch]$DryRun
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$NpmUserPrefix = Join-Path $HOME ".npm-global"
+
+function Write-Log {
+  param([string]$Message)
+  Write-Host $Message
+}
+
+function Write-WarnLog {
+  param([string]$Message)
+  Write-Warning $Message
+}
+
+function Fail {
+  param([string]$Message)
+  throw "Error: $Message"
+}
+
+function Write-CommandOutput {
+  param($Output)
+  if ($null -eq $Output) {
+    return
+  }
+  $Output | ForEach-Object {
+    if ($null -ne $_ -and $_.ToString().Length -gt 0) {
+      Write-Host $_
+    }
+  }
+}
+
+function Invoke-CommandStep {
+  param(
+    [string]$CommandName,
+    [string[]]$Arguments
+  )
+
+  if ($DryRun) {
+    Write-Log ("[dry-run] {0} {1}" -f $CommandName, ($Arguments -join " "))
+    return [pscustomobject]@{
+      ExitCode = 0
+      Output   = @()
+    }
+  }
+
+  $output = & $CommandName @Arguments 2>&1
+  $exitCode = $LASTEXITCODE
+  return [pscustomobject]@{
+    ExitCode = $exitCode
+    Output   = $output
+  }
+}
+
+function Ensure-Command {
+  param(
+    [string]$Name,
+    [string]$Hint
+  )
+
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    Fail $Hint
+  }
+}
+
+function Refresh-ProcessPathFromSystem {
+  $machinePath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  $parts = @()
+  if (-not [string]::IsNullOrWhiteSpace($machinePath)) {
+    $parts += $machinePath
+  }
+  if (-not [string]::IsNullOrWhiteSpace($userPath)) {
+    $parts += $userPath
+  }
+  if ($parts.Count -gt 0) {
+    $env:Path = ($parts -join ";")
+  }
+}
+
+function Get-NodeMajor {
+  $raw = (node --version).Trim()
+  if ($raw -match "^v(\d+)") {
+    return [int]$matches[1]
+  }
+  Fail "Unable to parse Node.js version from '$raw'."
+}
+
+function Split-PathList {
+  param([string]$Value)
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return @()
+  }
+  return $Value -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+}
+
+function Path-EntryExists {
+  param(
+    [string[]]$Entries,
+    [string]$Candidate
+  )
+
+  $normalizedCandidate = $Candidate.TrimEnd("\").ToLowerInvariant()
+  foreach ($entry in $Entries) {
+    if ($entry.TrimEnd("\").ToLowerInvariant() -eq $normalizedCandidate) {
+      return $true
+    }
+  }
+  return $false
+}
+
+function Ensure-PathEntry {
+  param([string]$PathEntry)
+
+  if ([string]::IsNullOrWhiteSpace($PathEntry)) {
+    return
+  }
+
+  $resolved = [System.IO.Path]::GetFullPath($PathEntry)
+
+  $processEntries = Split-PathList $env:Path
+  if (-not (Path-EntryExists -Entries $processEntries -Candidate $resolved)) {
+    $env:Path = "{0};{1}" -f $resolved, $env:Path
+    Write-Log "Added $resolved to PATH in current shell"
+  } else {
+    Write-Log "PATH already contains $resolved"
+  }
+
+  $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+  $userEntries = Split-PathList $userPath
+  if (Path-EntryExists -Entries $userEntries -Candidate $resolved) {
+    Write-Log "PATH already persisted in user environment"
+    return
+  }
+
+  if ($DryRun) {
+    Write-Log "[dry-run] Persist $resolved in user PATH"
+    return
+  }
+
+  $newUserPath = if ([string]::IsNullOrWhiteSpace($userPath)) {
+    $resolved
+  } else {
+    "{0};{1}" -f $resolved, $userPath
+  }
+  [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+  Write-Log "Persisted $resolved in user PATH"
+}
+
+function Try-BootstrapNodeWithWinget {
+  if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+    Write-WarnLog "winget was not found. Cannot auto-install Node.js."
+    return $false
+  }
+
+  Write-Log "Attempting to install Node.js LTS via winget..."
+  $args = @(
+    "install",
+    "--id", "OpenJS.NodeJS.LTS",
+    "-e",
+    "--accept-package-agreements",
+    "--accept-source-agreements"
+  )
+
+  $result = Invoke-CommandStep -CommandName "winget" -Arguments $args
+  if ($result.ExitCode -ne 0) {
+    $text = ($result.Output | Out-String).Trim()
+    Write-WarnLog "winget Node.js install failed: $text"
+    return $false
+  }
+
+  Write-CommandOutput -Output $result.Output
+  if (-not $DryRun) {
+    Refresh-ProcessPathFromSystem
+  }
+  return $true
+}
+
+function Ensure-SupportedNode {
+  $hasNode = [bool](Get-Command node -ErrorAction SilentlyContinue)
+  $hasNpm = [bool](Get-Command npm -ErrorAction SilentlyContinue)
+  $needsBootstrap = $false
+
+  if (-not $hasNode -or -not $hasNpm) {
+    Write-WarnLog "Node.js/npm not found. Attempting bootstrap via winget."
+    $needsBootstrap = $true
+  } else {
+    $major = Get-NodeMajor
+    if ($major -ne 22 -and $major -ne 24) {
+      Write-WarnLog ("Detected unsupported Node.js {0}. Attempting bootstrap via winget." -f (node --version))
+      $needsBootstrap = $true
+    }
+  }
+
+  if ($needsBootstrap) {
+    [void](Try-BootstrapNodeWithWinget)
+  }
+
+  if ($DryRun -and (-not (Get-Command node -ErrorAction SilentlyContinue) -or -not (Get-Command npm -ErrorAction SilentlyContinue))) {
+    Write-Log "Dry run: skipping strict Node.js/npm availability check."
+    return
+  }
+
+  Ensure-Command -Name "node" -Hint "Node.js 22 or 24 is required. Install from https://nodejs.org/ and retry."
+  Ensure-Command -Name "npm" -Hint "npm is required. Install Node.js 22 or 24 (includes npm) and retry."
+
+  $currentMajor = Get-NodeMajor
+  if ($currentMajor -ne 22 -and $currentMajor -ne 24) {
+    Fail ("Detected Node.js {0}. PulSeed supports Node.js 22 or 24." -f (node --version))
+  }
+  Write-Log ("Detected Node.js {0}" -f (node --version))
+}
+
+function Is-PermissionInstallError {
+  param([string]$Message)
+  if ([string]::IsNullOrWhiteSpace($Message)) {
+    return $false
+  }
+  return $Message -match "EACCES|EPERM|permission denied"
+}
+
+function Configure-NpmUserPrefix {
+  Write-Log "Configuring npm user prefix at $NpmUserPrefix"
+  if ($DryRun) {
+    Write-Log "[dry-run] New-Item -ItemType Directory -Force -Path $NpmUserPrefix"
+  } else {
+    New-Item -ItemType Directory -Force -Path $NpmUserPrefix | Out-Null
+  }
+
+  $setPrefix = Invoke-CommandStep -CommandName "npm" -Arguments @("config", "set", "prefix", $NpmUserPrefix)
+  if ($setPrefix.ExitCode -ne 0) {
+    $text = ($setPrefix.Output | Out-String).Trim()
+    Fail "Failed to set npm prefix: $text"
+  }
+
+  Ensure-PathEntry -PathEntry $NpmUserPrefix
+  $binDir = Join-Path $NpmUserPrefix "bin"
+  if (Test-Path $binDir) {
+    Ensure-PathEntry -PathEntry $binDir
+  }
+}
+
+function Install-PackageGlobal {
+  param([string]$PackageSpec)
+
+  Write-Log "Installing $PackageSpec globally with npm..."
+  $result = Invoke-CommandStep -CommandName "npm" -Arguments @("install", "-g", $PackageSpec)
+  if ($result.ExitCode -eq 0) {
+    Write-CommandOutput -Output $result.Output
+    return
+  }
+
+  $outputText = ($result.Output | Out-String).Trim()
+  if (-not (Is-PermissionInstallError -Message $outputText)) {
+    Fail "Global npm install failed: $outputText"
+  }
+
+  Write-WarnLog "Global npm install failed due to permissions. Retrying with user prefix."
+  Configure-NpmUserPrefix
+  $retry = Invoke-CommandStep -CommandName "npm" -Arguments @("install", "-g", $PackageSpec)
+  if ($retry.ExitCode -ne 0) {
+    $retryText = ($retry.Output | Out-String).Trim()
+    Fail "Global npm install failed after user-prefix fallback: $retryText"
+  }
+  Write-CommandOutput -Output $retry.Output
+}
+
+function Get-NpmPathCandidates {
+  $candidates = New-Object System.Collections.Generic.List[string]
+
+  $prefixResult = Invoke-CommandStep -CommandName "npm" -Arguments @("config", "get", "prefix")
+  if ($prefixResult.ExitCode -eq 0 -and $null -ne $prefixResult.Output) {
+    $prefix = ($prefixResult.Output | Select-Object -Last 1).ToString().Trim()
+    if (-not [string]::IsNullOrWhiteSpace($prefix) -and $prefix -ne "undefined") {
+      $candidates.Add($prefix)
+      $candidates.Add((Join-Path $prefix "bin"))
+    }
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($env:APPDATA)) {
+    $candidates.Add((Join-Path $env:APPDATA "npm"))
+  }
+
+  return $candidates | Select-Object -Unique
+}
+
+function Ensure-PulseedOnPath {
+  if ($DryRun) {
+    Write-Log "Dry run: skipping pulseed PATH checks."
+    return
+  }
+
+  if (Get-Command pulseed -ErrorAction SilentlyContinue) {
+    return
+  }
+
+  foreach ($candidate in Get-NpmPathCandidates) {
+    if ([string]::IsNullOrWhiteSpace($candidate)) {
+      continue
+    }
+    Ensure-PathEntry -PathEntry $candidate
+    if (Get-Command pulseed -ErrorAction SilentlyContinue) {
+      return
+    }
+  }
+
+  Fail "Install completed but 'pulseed' is still not on PATH."
+}
+
+function Verify-Install {
+  if ($DryRun) {
+    Write-Log "Dry run: skipping post-install verification."
+    return
+  }
+
+  $versionResult = Invoke-CommandStep -CommandName "pulseed" -Arguments @("--version")
+  if ($versionResult.ExitCode -ne 0) {
+    $text = ($versionResult.Output | Out-String).Trim()
+    Fail "'pulseed --version' failed after install: $text"
+  }
+  $versionText = ($versionResult.Output | Out-String).Trim()
+  Write-Log "pulseed --version: $versionText"
+
+  Write-Log "Running 'pulseed doctor' (best-effort)..."
+  $doctorResult = Invoke-CommandStep -CommandName "pulseed" -Arguments @("doctor")
+  if ($doctorResult.ExitCode -eq 0) {
+    Write-Log "pulseed doctor: OK"
+  } else {
+    Write-WarnLog "pulseed doctor reported issues. Continuing installer completion."
+  }
+  Write-CommandOutput -Output $doctorResult.Output
+}
+
+if ($Setup -and $NoSetup) {
+  Fail "Use either --setup or --no-setup, not both."
+}
+
+Ensure-SupportedNode
+
+$packageSpec = if ($Version -eq "latest") { "pulseed" } else { "pulseed@$Version" }
+Install-PackageGlobal -PackageSpec $packageSpec
+Ensure-PulseedOnPath
+Verify-Install
+
+$shouldRunSetup = if ($Setup) {
+  $true
+} elseif ($NoSetup) {
+  $false
+} else {
+  [Environment]::UserInteractive
+}
+
+if ($shouldRunSetup) {
+  Write-Log "Running: pulseed setup"
+  $setupResult = Invoke-CommandStep -CommandName "pulseed" -Arguments @("setup")
+  if ($setupResult.ExitCode -ne 0) {
+    $setupText = ($setupResult.Output | Out-String).Trim()
+    Fail "pulseed setup failed: $setupText"
+  }
+  Write-CommandOutput -Output $setupResult.Output
+} else {
+  Write-Log "Skipping setup. Run 'pulseed setup' later if needed."
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+DRY_RUN=0
+REQUESTED_VERSION="latest"
+SETUP_MODE="auto"
+NPM_USER_PREFIX="$HOME/.npm-global"
+NVM_INSTALL_URL="https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh"
+
+usage() {
+  cat <<EOF
+Install PulSeed globally via npm.
+
+Usage:
+  $SCRIPT_NAME [options]
+
+Options:
+  --version <version>  Install a specific pulseed version (default: latest)
+  --setup              Run 'pulseed setup' after install
+  --no-setup           Skip setup after install
+  --dry-run            Print planned actions without executing them
+  -h, --help           Show this help message
+EOF
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+warn() {
+  printf 'Warning: %s\n' "$*" >&2
+}
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '[dry-run] %s\n' "$*"
+    return 0
+  fi
+  "$@"
+}
+
+is_interactive() {
+  [ -t 0 ] && [ -t 1 ]
+}
+
+detect_os() {
+  local uname_out
+  uname_out="$(uname -s 2>/dev/null || true)"
+  case "$uname_out" in
+    Darwin) echo "darwin" ;;
+    Linux) echo "linux" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+is_wsl() {
+  [ -r /proc/version ] && grep -qi 'microsoft' /proc/version
+}
+
+require_command() {
+  local cmd="$1"
+  local hint="$2"
+  command -v "$cmd" >/dev/null 2>&1 || die "$hint"
+}
+
+node_major_version() {
+  node -p "process.versions.node.split('.')[0]"
+}
+
+path_contains() {
+  local dir="$1"
+  case ":$PATH:" in
+    *":$dir:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+to_home_expr() {
+  local dir="$1"
+  if [ "$dir" = "$HOME" ]; then
+    printf '%s\n' '$HOME'
+    return 0
+  fi
+  case "$dir" in
+    "$HOME"/*)
+      printf '$HOME/%s\n' "${dir#"$HOME"/}"
+      ;;
+    *)
+      printf '%s\n' "$dir"
+      ;;
+  esac
+}
+
+append_line_if_missing() {
+  local file="$1"
+  local line="$2"
+  if [ ! -f "$file" ]; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+      log "[dry-run] Create $file"
+    else
+      touch "$file"
+      log "Created $file"
+    fi
+  fi
+  if grep -Fqx "$line" "$file"; then
+    log "PATH already persisted in $file"
+    return 0
+  fi
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "[dry-run] Append to $file: $line"
+    return 0
+  fi
+  printf '\n%s\n' "$line" >>"$file"
+  log "Updated $file for PATH persistence"
+}
+
+persist_path_for_future_shells() {
+  local dir="$1"
+  local home_expr
+  home_expr="$(to_home_expr "$dir")"
+  local export_line="export PATH=\"$home_expr:\$PATH\""
+
+  append_line_if_missing "$HOME/.zshrc" "$export_line"
+  append_line_if_missing "$HOME/.bashrc" "$export_line"
+  append_line_if_missing "$HOME/.profile" "$export_line"
+}
+
+ensure_path_now_and_persistent() {
+  local dir="$1"
+  if [ -z "$dir" ]; then
+    return 0
+  fi
+  if path_contains "$dir"; then
+    log "PATH already contains $dir"
+  else
+    export PATH="$dir:$PATH"
+    log "Added $dir to PATH in current shell"
+  fi
+  persist_path_for_future_shells "$dir"
+}
+
+npm_global_bin_dir() {
+  local prefix
+  prefix="$(npm config get prefix 2>/dev/null || true)"
+  if [ -z "$prefix" ] || [ "$prefix" = "undefined" ] || [ "$prefix" = "null" ]; then
+    return 1
+  fi
+  printf '%s\n' "$prefix/bin"
+}
+
+is_permission_error() {
+  local message
+  message="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  case "$message" in
+    *eacces*|*eperm*|*"permission denied"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+bootstrap_node_with_nvm() {
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+    require_command "curl" "curl is required to bootstrap Node.js via nvm."
+    log "Installing nvm into $NVM_DIR (profile files will not be modified)..."
+    if [ "$DRY_RUN" -eq 1 ]; then
+      log "[dry-run] curl -fsSL $NVM_INSTALL_URL | PROFILE=/dev/null bash"
+    else
+      curl -fsSL "$NVM_INSTALL_URL" | PROFILE=/dev/null bash
+    fi
+  else
+    log "Found existing nvm at $NVM_DIR"
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "Dry run: skipping nvm source/install/use steps."
+    return 0
+  fi
+
+  [ -s "$NVM_DIR/nvm.sh" ] || die "nvm installation did not produce $NVM_DIR/nvm.sh"
+  # shellcheck disable=SC1090
+  . "$NVM_DIR/nvm.sh"
+  log "Installing and using Node.js 24 via nvm for this installer run..."
+  nvm install 24 >/dev/null
+  nvm use 24 >/dev/null
+}
+
+ensure_supported_node() {
+  local need_bootstrap=0
+
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    warn "Node.js/npm not found. Bootstrapping Node.js 24 with nvm."
+    need_bootstrap=1
+  else
+    local current_major
+    current_major="$(node_major_version)"
+    if [ "$current_major" -ne 22 ] && [ "$current_major" -ne 24 ]; then
+      warn "Detected unsupported Node.js $(node -v). Bootstrapping Node.js 24 with nvm."
+      need_bootstrap=1
+    fi
+  fi
+
+  if [ "$need_bootstrap" -eq 1 ]; then
+    bootstrap_node_with_nvm
+  fi
+
+  if [ "$DRY_RUN" -eq 1 ] && (! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1); then
+    log "Dry run: skipping strict Node.js/npm availability check."
+    return 0
+  fi
+
+  require_command "node" "Node.js 22 or 24 is required. Install from https://nodejs.org/ and retry."
+  require_command "npm" "npm is required. Install Node.js 22 or 24 (includes npm) and retry."
+
+  local node_major
+  node_major="$(node_major_version)"
+  if [ "$node_major" -ne 22 ] && [ "$node_major" -ne 24 ]; then
+    die "Detected Node.js $(node -v). PulSeed supports Node.js 22 or 24."
+  fi
+  log "Detected Node.js $(node -v)"
+}
+
+configure_npm_user_prefix() {
+  local bin_dir="$NPM_USER_PREFIX/bin"
+  log "Configuring npm user prefix at $NPM_USER_PREFIX"
+  run mkdir -p "$bin_dir"
+  run npm config set prefix "$NPM_USER_PREFIX"
+  ensure_path_now_and_persistent "$bin_dir"
+}
+
+install_package_with_npm() {
+  local package_spec="$1"
+  log "Installing $package_spec globally with npm..."
+
+  if [ "$DRY_RUN" -eq 1 ]; then
+    run npm install -g "$package_spec"
+    return 0
+  fi
+
+  local output
+  if output="$(npm install -g "$package_spec" 2>&1)"; then
+    [ -n "$output" ] && printf '%s\n' "$output"
+    return 0
+  fi
+
+  printf '%s\n' "$output" >&2
+  if ! is_permission_error "$output"; then
+    die "Global npm install failed."
+  fi
+
+  warn "Global npm install failed due to permissions. Retrying with user prefix."
+  configure_npm_user_prefix
+  run npm install -g "$package_spec"
+}
+
+ensure_pulseed_on_path() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "Dry run: skipping pulseed PATH checks."
+    return 0
+  fi
+
+  if command -v pulseed >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local npm_bin
+  npm_bin="$(npm_global_bin_dir || true)"
+  if [ -n "$npm_bin" ]; then
+    warn "'pulseed' not found on PATH. Attempting to add npm global bin: $npm_bin"
+    ensure_path_now_and_persistent "$npm_bin"
+  fi
+
+  command -v pulseed >/dev/null 2>&1 || die "Install completed but 'pulseed' is still not on PATH."
+}
+
+verify_installation() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    log "Dry run: skipping post-install verification."
+    return 0
+  fi
+
+  local pulseed_version
+  pulseed_version="$(pulseed --version 2>&1)" || die "'pulseed --version' failed after install."
+  log "pulseed --version: $pulseed_version"
+
+  log "Running 'pulseed doctor' (best-effort)..."
+  local doctor_output
+  if doctor_output="$(pulseed doctor 2>&1)"; then
+    log "pulseed doctor: OK"
+    [ -n "$doctor_output" ] && printf '%s\n' "$doctor_output"
+  else
+    warn "pulseed doctor reported issues. Continuing installer completion."
+    [ -n "$doctor_output" ] && printf '%s\n' "$doctor_output"
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ "${2:-}" ] || die "--version requires a value"
+      REQUESTED_VERSION="$2"
+      shift 2
+      ;;
+    --setup)
+      SETUP_MODE="yes"
+      shift
+      ;;
+    --no-setup)
+      SETUP_MODE="no"
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown option: $1 (use --help)"
+      ;;
+  esac
+done
+
+OS_NAME="$(detect_os)"
+if [ "$OS_NAME" = "unknown" ]; then
+  die "Unsupported OS. This installer currently supports macOS (darwin) and Linux."
+fi
+log "Detected OS: $OS_NAME"
+if [ "$OS_NAME" = "linux" ] && is_wsl; then
+  warn "WSL detected. PulSeed works in WSL, but ensure Node/npm are installed inside your WSL distro."
+fi
+
+ensure_supported_node
+
+PACKAGE_SPEC="pulseed"
+if [ "$REQUESTED_VERSION" != "latest" ]; then
+  PACKAGE_SPEC="pulseed@$REQUESTED_VERSION"
+fi
+
+install_package_with_npm "$PACKAGE_SPEC"
+ensure_pulseed_on_path
+verify_installation
+
+SHOULD_RUN_SETUP=0
+case "$SETUP_MODE" in
+  yes) SHOULD_RUN_SETUP=1 ;;
+  no) SHOULD_RUN_SETUP=0 ;;
+  auto)
+    if is_interactive; then
+      SHOULD_RUN_SETUP=1
+    fi
+    ;;
+  *)
+    die "Invalid setup mode: $SETUP_MODE"
+    ;;
+esac
+
+if [ "$SHOULD_RUN_SETUP" -eq 1 ]; then
+  log "Running: pulseed setup"
+  run pulseed setup
+else
+  log "Skipping setup. Run 'pulseed setup' later if needed."
+fi

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -98,6 +98,54 @@ describe("formatDaemonConnectionState", () => {
   });
 });
 
+describe("standalone slash command routing", () => {
+  beforeEach(() => {
+    testState.lastChatProps = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes /permissions to ChatRunner instead of standalone intent handlers", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const intentRecognizer = {
+      recognize: vi.fn(async () => ({ intent: "unknown", raw: "/permissions" })),
+    };
+    const actionHandler = {
+      handle: vi.fn(async () => ({ messages: ["unexpected"] })),
+    };
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as ChatRunner,
+      intentRecognizer: intentRecognizer as any,
+      actionHandler: actionHandler as any,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("/permissions workspace-write");
+
+    expect(chatRunner.execute).toHaveBeenCalledWith("/permissions workspace-write", process.cwd());
+    expect(intentRecognizer.recognize).not.toHaveBeenCalled();
+    expect(actionHandler.handle).not.toHaveBeenCalled();
+
+    screen.unmount();
+  });
+});
+
 describe("daemon-mode chat routing", () => {
   beforeEach(() => {
     testState.lastChatProps = null;
@@ -177,6 +225,37 @@ describe("daemon-mode chat routing", () => {
 
     expect(daemonClient.chat).toHaveBeenCalledWith("goal-123", "question for the active goal");
     expect(chatRunner.execute).not.toHaveBeenCalled();
+
+    screen.unmount();
+  });
+
+  it("routes /permissions to ChatRunner in daemon mode", async () => {
+    const daemonClient = createDaemonClientMock();
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+
+    const screen = render(React.createElement(App, {
+      daemonClient: daemonClient as unknown as DaemonClient,
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as ChatRunner,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("/permissions read-only");
+
+    expect(chatRunner.execute).toHaveBeenCalledWith("/permissions read-only", process.cwd());
+    expect(daemonClient.chat).not.toHaveBeenCalled();
 
     screen.unmount();
   });

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import React from "react";
+import { Text } from "ink";
 import {
   buildChatViewport,
   estimateComposerHeight,
@@ -7,8 +9,13 @@ import {
   getMatchingSuggestions,
   parseMouseEvent,
   getScrollRequest,
+  normalizeComposerInput,
   stripMouseEscapeSequences,
 } from "../chat.js";
+import {
+  formatProcessingLabel,
+  renderProcessingRow,
+} from "../fullscreen-chat.js";
 import { estimateMarkdownHeight, estimateWrappedLineCount, wrapTextToRows } from "../markdown-renderer.js";
 import { extractBashCommand, isBashModeInput, isSafeBashCommand, createShellApprovalTask, formatShellOutput } from "../bash-mode.js";
 import {
@@ -18,11 +25,14 @@ import {
   buildCursorEscapeFromCaretMarker,
   buildCursorEscapeFromInputMarker,
 } from "../cursor-tracker.js";
+import { CheckerboardSpinner } from "../checkerboard-spinner.js";
+import { ShimmerText } from "../shimmer-text.js";
 
 describe("getMatchingSuggestions", () => {
   it("hides suggestions for an exact slash command so enter can submit", () => {
     expect(getMatchingSuggestions("/help", [])).toEqual([]);
     expect(getMatchingSuggestions("/config", [])).toEqual([]);
+    expect(getMatchingSuggestions("/permissions", [])).toEqual([]);
   });
 
   it("keeps suggestions for partial slash commands", () => {
@@ -230,6 +240,12 @@ describe("chat scroll keys", () => {
   it("strips sgr mouse sequences from input text", () => {
     expect(stripMouseEscapeSequences("hello\u001b[<64;40;12Mworld")).toBe("helloworld");
   });
+
+  it("normalizes Shift+Enter escape sequences into newlines", () => {
+    expect(normalizeComposerInput("[27;2;13~")).toBe("\n");
+    expect(normalizeComposerInput("\u001b[27;2;13~")).toBe("\n");
+    expect(normalizeComposerInput("left[27;2;13~right")).toBe("left\nright");
+  });
 });
 
 describe("cursor tracker", () => {
@@ -266,5 +282,29 @@ describe("cursor tracker", () => {
     ].join("\n");
 
     expect(buildCursorEscapeFromInputMarker(frame, 3)).toBe("\u001b[2;8H\u001b[?25h");
+  });
+});
+
+describe("fullscreen processing row", () => {
+  it("builds animated spinner + shimmer row while processing", () => {
+    const row = renderProcessingRow(
+      true,
+      "Thinking",
+      40,
+    ) as React.ReactElement<{ children?: React.ReactNode }>;
+    const children = React.Children.toArray(
+      row.props.children,
+    ) as React.ReactElement<{ children?: React.ReactNode }>[];
+
+    expect(row.type).toBe(React.Fragment);
+    expect(children[0]?.type).toBe(CheckerboardSpinner);
+    expect(children[1]?.type).toBe(Text);
+    expect(children[2]?.type).toBe(ShimmerText);
+    expect(children[2]?.props.children).toBe("Thinking...");
+  });
+
+  it("formats processing label to available width budget", () => {
+    expect(formatProcessingLabel("Thinking", 8)).toBe("Thin");
+    expect(formatProcessingLabel("Working", 4)).toBe("W");
   });
 });

--- a/src/interface/tui/__tests__/frame-writer.test.ts
+++ b/src/interface/tui/__tests__/frame-writer.test.ts
@@ -42,7 +42,7 @@ describe("frame-writer", () => {
 
     expect(stream.write).toHaveBeenCalledTimes(1);
     const output = (stream.write as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(output).toBe(BSU + CURSOR_HOME + "hello" + "[24;1H" + ESU + "[24;1H");
+    expect(output).toBe(BSU + CURSOR_HOME + "hello" + "[24;1H" + ESU);
   });
 
   it("updates only changed rows after the first frame", () => {
@@ -53,9 +53,7 @@ describe("frame-writer", () => {
     fw.write("alpha\nBETA\ngamma");
 
     const output = (stream.write as ReturnType<typeof vi.fn>).mock.calls[1][0];
-    expect(output).toBe(
-      BSU + cursorTo(2) + ERASE_LINE + "BETA" + "[24;1H" + ESU + "[24;1H",
-    );
+    expect(output).toBe(BSU + cursorTo(2) + ERASE_LINE + "BETA" + "[24;1H" + ESU);
   });
 
   it("erases trailing rows when the next frame has fewer lines", () => {
@@ -66,7 +64,7 @@ describe("frame-writer", () => {
     fw.write("alpha\nbeta");
 
     const output = (stream.write as ReturnType<typeof vi.fn>).mock.calls[1][0];
-    expect(output).toBe(BSU + cursorTo(3) + ERASE_LINE + "[24;1H" + ESU + "[24;1H");
+    expect(output).toBe(BSU + cursorTo(3) + ERASE_LINE + "[24;1H" + ESU);
   });
 
   it("skips writing when frame and cursor are unchanged", () => {
@@ -87,7 +85,7 @@ describe("frame-writer", () => {
     fw.write("hello", "\u001b[3;6H\u001b[?25h");
 
     const output = (stream.write as ReturnType<typeof vi.fn>).mock.calls[1][0];
-    expect(output).toBe(BSU + "\u001b[3;6H\u001b[?25h" + ESU + "\u001b[3;6H\u001b[?25h");
+    expect(output).toBe(BSU + "\u001b[3;6H\u001b[?25h" + ESU);
   });
 
   it("includes ERASE_SCREEN after requestErase()", () => {
@@ -98,7 +96,7 @@ describe("frame-writer", () => {
     fw.write("content");
 
     const output = (stream.write as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(output).toBe(BSU + ERASE_SCREEN + CURSOR_HOME + "content" + "[24;1H" + ESU + "[24;1H");
+    expect(output).toBe(BSU + ERASE_SCREEN + CURSOR_HOME + "content" + "[24;1H" + ESU);
   });
 
   it("clears needsErase after one write", () => {
@@ -157,7 +155,7 @@ describe("frame-writer", () => {
     fw.write("hello", "\u001b[3;5H\u001b[?25h");
 
     const output = (stream.write as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(output).toBe(BSU + CURSOR_HOME + "hello" + "\u001b[3;5H\u001b[?25h" + ESU + "\u001b[3;5H\u001b[?25h");
+    expect(output).toBe(BSU + CURSOR_HOME + "hello" + "\u001b[3;5H\u001b[?25h" + ESU);
   });
 
   it("rewrites protected rows without erase-line and strips the marker", () => {
@@ -171,7 +169,21 @@ describe("frame-writer", () => {
     const second = (stream.write as ReturnType<typeof vi.fn>).mock.calls[1][0];
     expect(first).not.toContain(PROTECTED_ROW_MARKER);
     expect(second).toBe(
-      BSU + cursorTo(2) + "input two" + "\u001b[24;1H" + ESU + "\u001b[24;1H",
+      BSU + cursorTo(2) + "input two" + "\u001b[24;1H" + ESU,
+    );
+    expect(second).not.toContain(ERASE_LINE);
+  });
+
+  it("pads protected rows with spaces when the next content is shorter", () => {
+    const stream = createMockStream(24);
+    const fw = createFrameWriter(stream);
+
+    fw.write(`alpha\n${PROTECTED_ROW_MARKER}input content`);
+    fw.write(`alpha\n${PROTECTED_ROW_MARKER}input`);
+
+    const second = (stream.write as ReturnType<typeof vi.fn>).mock.calls[1][0];
+    expect(second).toBe(
+      BSU + cursorTo(2) + "input" + " ".repeat(" content".length) + "\u001b[24;1H" + ESU,
     );
     expect(second).not.toContain(ERASE_LINE);
   });

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -340,6 +340,8 @@ export function App({
       try {
         // Local-only commands — no LLM round-trip needed
         const trimmedInput = input.trim().toLowerCase();
+        const isPermissionsCommand =
+          trimmedInput === "/permissions" || trimmedInput.startsWith("/permissions ");
         const bashCommand = extractBashCommand(input);
         if (bashCommand !== null) {
           if (!bashCommand) {
@@ -379,6 +381,11 @@ export function App({
             timestamp: new Date(),
             messageType: result.success ? ("info" as const) : ("error" as const),
           }].slice(-MAX_MESSAGES));
+          return;
+        }
+
+        if (isPermissionsCommand && !isDaemonMode && chatRunner) {
+          await chatRunner.execute(input, process.cwd());
           return;
         }
 
@@ -434,6 +441,11 @@ export function App({
           const trimmed = input.trim().toLowerCase();
           if (trimmed === "/help" || trimmed === "/?") {
             setShowHelp(true);
+          } else if (
+            (trimmed === "/permissions" || trimmed.startsWith("/permissions ")) &&
+            chatRunner
+          ) {
+            await chatRunner.execute(input, process.cwd());
           } else if (trimmed === "/settings" || trimmed === "/config") {
             setShowSettings(true);
           } else if (trimmed === "/dashboard" || trimmed === "/d") {

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -18,7 +18,10 @@ import { isBashModeInput } from "./bash-mode.js";
 import { isRenderableFrameChunk } from "./render-output.js";
 import { estimateWrappedLineCount } from "./markdown-renderer.js";
 import { buildChatViewport } from "./chat/viewport.js";
-import { getScrollRequest, stripMouseEscapeSequences } from "./chat/scroll.js";
+import {
+  getScrollRequest,
+  normalizeComposerInput,
+} from "./chat/scroll.js";
 import { getMatchingSuggestions, type Suggestion } from "./chat/suggestions.js";
 import type { ChatMessage } from "./chat/types.js";
 import { getTrustedTuiControlStream } from "./terminal-output.js";
@@ -51,7 +54,12 @@ const SCROLL_INDICATOR_ROWS = 2;
 const INPUT_BOX_HORIZONTAL_CHROME = 4;
 const SUGGESTION_HINT = " arrows to navigate, tab/enter to select, esc to dismiss";
 export { buildChatViewport } from "./chat/viewport.js";
-export { getScrollRequest, parseMouseEvent, stripMouseEscapeSequences } from "./chat/scroll.js";
+export {
+  getScrollRequest,
+  normalizeComposerInput,
+  parseMouseEvent,
+  stripMouseEscapeSequences,
+} from "./chat/scroll.js";
 export { getMatchingSuggestions } from "./chat/suggestions.js";
 
 export function getInputPromptLabel(bashMode: boolean): string {
@@ -589,7 +597,7 @@ export function Chat({
               value={input}
               onChange={(val) => {
                 justSelected.current = false;
-                setInput(stripMouseEscapeSequences(val));
+                setInput(normalizeComposerInput(val));
               }}
               onSubmit={handleSubmit}
               placeholder={getInputPlaceholder(bashMode)}

--- a/src/interface/tui/chat/scroll.ts
+++ b/src/interface/tui/chat/scroll.ts
@@ -2,6 +2,7 @@ import type { ScrollRequest } from "./types.js";
 
 const SGR_MOUSE_SEQUENCE = /(?:\u001b)?\[<(\d+);(\d+);(\d+)([mM])/;
 const SGR_MOUSE_SEQUENCE_GLOBAL = /(?:\u001b)?\[<(\d+);(\d+);(\d+)([mM])/g;
+const SHIFT_ENTER_SEQUENCE_GLOBAL = /(?:\u001b)?\[27;2;13~/g;
 
 type ScrollKey = {
   upArrow?: boolean;
@@ -118,4 +119,8 @@ export function getScrollRequest(
 
 export function stripMouseEscapeSequences(input: string): string {
   return input.replace(SGR_MOUSE_SEQUENCE_GLOBAL, "");
+}
+
+export function normalizeComposerInput(input: string): string {
+  return stripMouseEscapeSequences(input).replace(SHIFT_ENTER_SEQUENCE_GLOBAL, "\n");
 }

--- a/src/interface/tui/chat/suggestions.ts
+++ b/src/interface/tui/chat/suggestions.ts
@@ -56,6 +56,12 @@ const COMMANDS: Suggestion[] = [
     description: "View and toggle config",
     type: "command",
   },
+  {
+    name: "/permissions",
+    aliases: [],
+    description: "Show or update execution policy",
+    type: "command",
+  },
 ];
 
 const GOAL_ARG_COMMANDS = ["/run ", "/start "];

--- a/src/interface/tui/flicker/frame-writer.ts
+++ b/src/interface/tui/flicker/frame-writer.ts
@@ -54,8 +54,7 @@ export function createFrameWriter(stream: NodeJS.WriteStream): FrameWriter {
     const prefix = syncSupported ? BSU : "";
     const suffix = syncSupported ? ESU : "";
     const erase = needsErase ? ERASE_SCREEN : "";
-    const trailingCursor = syncSupported ? finalCursor : "";
-    return prefix + erase + CURSOR_HOME + joinFrame(lines) + finalCursor + suffix + trailingCursor;
+    return prefix + erase + CURSOR_HOME + joinFrame(lines) + finalCursor + suffix;
   }
 
   function splitFrame(frame: string): ParsedLine[] {
@@ -70,7 +69,6 @@ export function createFrameWriter(stream: NodeJS.WriteStream): FrameWriter {
   function buildDiffFrame(nextLines: ParsedLine[], finalCursor: string): string {
     const prefix = syncSupported ? BSU : "";
     const suffix = syncSupported ? ESU : "";
-    const trailingCursor = syncSupported ? finalCursor : "";
     const previousLines = lastLines ?? [];
     const maxLines = Math.max(previousLines.length, nextLines.length);
     let output = "";
@@ -91,6 +89,9 @@ export function createFrameWriter(stream: NodeJS.WriteStream): FrameWriter {
         if (nextText.length > 0) {
           output += nextText;
         }
+        if (previousText.length > nextText.length) {
+          output += " ".repeat(previousText.length - nextText.length);
+        }
         continue;
       }
 
@@ -104,7 +105,7 @@ export function createFrameWriter(stream: NodeJS.WriteStream): FrameWriter {
       return "";
     }
 
-    return prefix + output + finalCursor + suffix + trailingCursor;
+    return prefix + output + finalCursor + suffix;
   }
 
   return {

--- a/src/interface/tui/fullscreen-chat.tsx
+++ b/src/interface/tui/fullscreen-chat.tsx
@@ -3,6 +3,8 @@ import { Box, Text, useInput } from "ink";
 import { getClipboardContent } from "./clipboard.js";
 import { logTuiDebug } from "./debug-log.js";
 import { theme } from "./theme.js";
+import { CheckerboardSpinner } from "./checkerboard-spinner.js";
+import { ShimmerText } from "./shimmer-text.js";
 import { pickSpinnerVerb } from "./spinner-verbs.js";
 import {
   buildHiddenCursorEscapeFromPosition,
@@ -15,8 +17,8 @@ import { isBashModeInput } from "./bash-mode.js";
 import { buildChatViewport } from "./chat/viewport.js";
 import {
   getScrollRequest,
+  normalizeComposerInput,
   parseMouseEvent,
-  stripMouseEscapeSequences,
 } from "./chat/scroll.js";
 import { getMatchingSuggestions, type Suggestion } from "./chat/suggestions.js";
 import type { ChatMessage, ChatDisplayRow } from "./chat/types.js";
@@ -55,6 +57,7 @@ type RenderLine = {
   key: string;
   text?: string;
   segments?: RenderSegment[];
+  processing?: boolean;
   color?: string;
   backgroundColor?: string;
   bold?: boolean;
@@ -125,6 +128,28 @@ function padToWidth(text: string, width: number): string {
   const trimmed = trimToWidth(text, width);
   const padding = Math.max(0, width - stringWidth(trimmed));
   return trimmed + " ".repeat(padding);
+}
+
+export function formatProcessingLabel(spinnerVerb: string, availableCols: number): string {
+  return trimToWidth(`${spinnerVerb}...`, Math.max(1, availableCols - 4));
+}
+
+export function renderProcessingRow(
+  isProcessing: boolean,
+  spinnerVerb: string,
+  availableCols: number,
+): React.ReactNode {
+  if (!isProcessing) {
+    return <Text>{padToWidth("", availableCols)}</Text>;
+  }
+
+  return (
+    <>
+      <CheckerboardSpinner />
+      <Text> </Text>
+      <ShimmerText>{formatProcessingLabel(spinnerVerb, availableCols)}</ShimmerText>
+    </>
+  );
 }
 
 function getPreviousOffset(text: string, offset: number): number {
@@ -1047,7 +1072,7 @@ export function FullscreenChat({
     }
 
     if (inputChar && !key.ctrl && !key.meta) {
-      const clean = stripMouseEscapeSequences(inputChar);
+      const clean = normalizeComposerInput(inputChar);
       if (clean.length === 0) return;
       insertText(clean);
     }
@@ -1082,8 +1107,7 @@ export function FullscreenChat({
 
   lines.push({
     key: "processing",
-    text: padToWidth(isProcessing ? `⠋ ${spinnerVerb}...` : "", availableCols),
-    dim: !isProcessing,
+    processing: true,
   });
   lines.push({
     key: "indicator-bottom",
@@ -1108,7 +1132,9 @@ export function FullscreenChat({
     <Box flexDirection="column" flexGrow={1} overflow="hidden">
       {visibleLines.map((line) => (
         <Box key={line.key} height={1} overflow="hidden">
-          {line.segments ? (
+          {line.processing ? (
+            renderProcessingRow(isProcessing, spinnerVerb, availableCols)
+          ) : line.segments ? (
             line.segments.map((segment, index) => (
               <Text
                 key={`${line.key}-${index}`}

--- a/src/interface/tui/help-overlay.tsx
+++ b/src/interface/tui/help-overlay.tsx
@@ -77,6 +77,10 @@ export function HelpOverlay({ onDismiss }: HelpOverlayProps) {
             <Text>View and toggle config</Text>
           </Box>
           <Box>
+            <Box width={20}><Text color={theme.command} bold>/permissions</Text></Box>
+            <Text>Show or update execution policy</Text>
+          </Box>
+          <Box>
             <Box width={20}><Text dimColor>{"<anything else>"}</Text></Box>
             <Text>Chat with PulSeed</Text>
           </Box>


### PR DESCRIPTION
## Summary
- fix no-flicker/fullscreen TUI regressions: animated spinner + shimmer styling, Shift+Enter normalization, /permissions routing, and cursor/frame-writer behavior
- add cross-platform one-command installers (`scripts/install.sh`, `scripts/install.ps1`) with Node 22/24 gating, npm permission fallback, PATH persistence, and post-install verification
- simplify README install section and move detailed install/fallback guidance to Getting Started

## Validation
- `bash -n scripts/install.sh`
- `bash scripts/install.sh --dry-run --no-setup`
- `npm run check:docs`
- `npm run -s typecheck`
- `npx vitest run src/interface/tui/__tests__/app.test.ts src/interface/tui/__tests__/chat.test.ts src/interface/tui/__tests__/frame-writer.test.ts`
