### PR TITLE
Fix chat agentloop to resume only on explicit resume

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
@@ -571,6 +571,98 @@ describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () =>
     expect(events.some((event) => event.type === "approval_request" && event.toolName === "approval_tool")).toBe(true);
     expect(modelClient.calls[1].messages.some((m) => m.role === "tool" && m.toolName === "approval_tool")).toBe(true);
   });
+
+  it("uses the latest chat input even when a state file path is reused", async () => {
+    const stateDir = makeTempDir();
+    const statePath = path.join(stateDir, "chat.state.json");
+    try {
+      const modelInfo = makeModelInfo();
+      const modelClient = new ScriptedModelClient(modelInfo, [
+        {
+          content: JSON.stringify({ status: "done", message: "first", evidence: [], blockers: [] }),
+          toolCalls: [],
+          stopReason: "end_turn",
+        },
+        {
+          content: JSON.stringify({ status: "done", message: "second", evidence: [], blockers: [] }),
+          toolCalls: [],
+          stopReason: "end_turn",
+        },
+      ]);
+      const registry = new ToolRegistry();
+      const { router, runtime } = makeRuntime(registry);
+      const registryModel = new StaticAgentLoopModelRegistry([modelInfo]);
+      const chat = new ChatAgentLoopRunner({
+        boundedRunner: new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime }),
+        modelClient,
+        modelRegistry: registryModel,
+        defaultModel: modelInfo.ref,
+        createSession: () =>
+          createAgentLoopSession({
+            sessionId: "chat-session",
+            traceId: "chat-trace",
+            stateStore: new JsonAgentLoopSessionStateStore(statePath),
+          }),
+      });
+
+      await chat.execute({ message: "first input" });
+      await chat.execute({ message: "second input" });
+
+      const firstLastUser = [...modelClient.calls[0].messages].reverse().find((message) => message.role === "user")?.content ?? "";
+      const secondLastUser = [...modelClient.calls[1].messages].reverse().find((message) => message.role === "user")?.content ?? "";
+      expect(firstLastUser).toContain("first input");
+      expect(secondLastUser).toContain("second input");
+      expect(secondLastUser).not.toContain("first input");
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it("loads persisted state for explicit resumeOnly chat turns", async () => {
+    const stateDir = makeTempDir();
+    const statePath = path.join(stateDir, "chat-resume.state.json");
+    try {
+      const modelInfo = makeModelInfo();
+      const modelClient = new ScriptedModelClient(modelInfo, [
+        {
+          content: JSON.stringify({ status: "done", message: "initial", evidence: [], blockers: [] }),
+          toolCalls: [],
+          stopReason: "end_turn",
+        },
+        {
+          content: JSON.stringify({ status: "done", message: "resumed", evidence: [], blockers: [] }),
+          toolCalls: [],
+          stopReason: "end_turn",
+        },
+      ]);
+      const registry = new ToolRegistry();
+      const { router, runtime } = makeRuntime(registry);
+      const registryModel = new StaticAgentLoopModelRegistry([modelInfo]);
+      const chat = new ChatAgentLoopRunner({
+        boundedRunner: new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime }),
+        modelClient,
+        modelRegistry: registryModel,
+        defaultModel: modelInfo.ref,
+        createSession: () =>
+          createAgentLoopSession({
+            sessionId: "resume-session",
+            traceId: "resume-trace",
+            stateStore: new JsonAgentLoopSessionStateStore(statePath),
+          }),
+      });
+
+      await chat.execute({ message: "persist this input" });
+      await chat.execute({ message: "fresh input should be ignored on resume", resumeOnly: true });
+
+      const secondUserMessages = modelClient.calls[1].messages
+        .filter((message) => message.role === "user")
+        .map((message) => message.content);
+      expect(secondUserMessages.some((content) => content.includes("persist this input"))).toBe(true);
+      expect(secondUserMessages.some((content) => content.includes("fresh input should be ignored on resume"))).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
 });
 
 function run(command: string, args: string[], cwd: string): Promise<void> {

--- a/src/orchestrator/execution/agent-loop/agent-loop-turn-context.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-turn-context.ts
@@ -45,6 +45,8 @@ export interface AgentLoopTurnContext<TOutput> {
     toolCalls: number;
   }) => AgentLoopCompletionValidationResult;
   resumeState?: AgentLoopSessionState;
+  /** When false, skip loading persisted state from session.stateStore for this run. */
+  loadPersistedState?: boolean;
   abortSignal?: AbortSignal;
 }
 

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -30,7 +30,8 @@ export class BoundedAgentLoopRunner {
 
   async run<TOutput>(turn: AgentLoopTurnContext<TOutput>): Promise<AgentLoopResult<TOutput>> {
     const startedAt = Date.now();
-    const resumed = turn.resumeState ?? await turn.session.stateStore.load();
+    const resumed = turn.resumeState
+      ?? (turn.loadPersistedState === false ? null : await turn.session.stateStore.load());
     let modelTurns = resumed?.modelTurns ?? 0;
     let toolCalls = resumed?.toolCalls ?? 0;
     const usage: AgentLoopTokenUsage = resumed?.usage

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -92,6 +92,7 @@ export class ChatAgentLoopRunner {
       modelInfo,
       ...(this.deps.defaultProfileName ? { profileName: this.deps.defaultProfileName } : {}),
       ...(this.deps.defaultReasoningEffort ? { reasoningEffort: this.deps.defaultReasoningEffort } : {}),
+      loadPersistedState: input.resumeOnly || input.resumeState !== undefined,
       messages: input.resumeOnly
         ? []
         : [


### PR DESCRIPTION
## Summary
- prevent chat turns from implicitly loading persisted agentloop state
- keep persisted-state loading enabled only for explicit resume paths (`resumeOnly` or explicit `resumeState`)
- add regression tests for both normal turn behavior and explicit resume behavior

## Why
Non-resume chat turns could replay stale persisted messages and ignore the latest user input, causing repeated replies.

## Validation
- npm run test -- src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts src/interface/chat/__tests__/chat-runner.test.ts
- npm run typecheck
