### PR TITLE
fix(tui): sanitize input escapes and clear stale chat activity

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -47,4 +47,105 @@ describe("applyChatEventToMessages", () => {
 
     expect(messages).toEqual([]);
   });
+
+  it("removes transient activity when assistant final arrives", () => {
+    const withActivity = applyChatEventToMessages([], {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      kind: "lifecycle",
+      message: "Working...",
+      transient: true,
+    }, 20);
+
+    const afterFinal = applyChatEventToMessages(withActivity, {
+      type: "assistant_final",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      text: "Done",
+      persisted: true,
+    }, 20);
+
+    expect(afterFinal).toHaveLength(1);
+    expect(afterFinal[0]!.id).toBe("turn-1");
+    expect(afterFinal[0]!.text).toBe("Done");
+  });
+
+  it("removes transient activity when lifecycle error arrives", () => {
+    const withActivity = applyChatEventToMessages([], {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      kind: "tool",
+      message: "Running tool...",
+      transient: true,
+    }, 20);
+
+    const afterError = applyChatEventToMessages(withActivity, {
+      type: "lifecycle_error",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      error: "boom",
+      partialText: "Partial",
+      persisted: false,
+    }, 20);
+
+    expect(afterError).toHaveLength(1);
+    expect(afterError[0]!.id).toBe("turn-1");
+    expect(afterError[0]!.messageType).toBe("error");
+  });
+
+  it("removes transient activity on lifecycle end", () => {
+    const withActivity = applyChatEventToMessages([], {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      kind: "commentary",
+      message: "Still working...",
+      transient: true,
+    }, 20);
+
+    const afterEnd = applyChatEventToMessages(withActivity, {
+      type: "lifecycle_end",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:02.000Z",
+      status: "completed",
+      elapsedMs: 2000,
+      persisted: true,
+    }, 20);
+
+    expect(afterEnd).toEqual([]);
+  });
+
+  it("keeps non-transient activity rows after turn-ending events", () => {
+    const withPersistentActivity = applyChatEventToMessages([], {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      kind: "commentary",
+      message: "Pinned note",
+      transient: false,
+    }, 20);
+
+    const afterEnd = applyChatEventToMessages(withPersistentActivity, {
+      type: "lifecycle_end",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      status: "completed",
+      elapsedMs: 1000,
+      persisted: true,
+    }, 20);
+
+    expect(afterEnd).toHaveLength(1);
+    expect(afterEnd[0]!.id).toBe("activity:turn-1");
+    expect(afterEnd[0]!.text).toBe("Pinned note");
+  });
 });

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -6,6 +6,7 @@ export interface StreamChatMessage {
   text: string;
   timestamp: Date;
   messageType?: "info" | "error" | "warning" | "success";
+  transient?: boolean;
 }
 
 function upsertMessage(
@@ -20,6 +21,14 @@ function upsertMessage(
     return next;
   }
   return [...next, nextMessage].slice(-maxMessages);
+}
+
+function removeTransientActivityForTurn(
+  messages: StreamChatMessage[],
+  turnId: string
+): StreamChatMessage[] {
+  const transientActivityId = `activity:${turnId}`;
+  return messages.filter((message) => !(message.id === transientActivityId && message.transient));
 }
 
 export function applyChatEventToMessages(
@@ -40,7 +49,8 @@ export function applyChatEventToMessages(
   }
 
   if (event.type === "assistant_final") {
-    return upsertMessage(messages, {
+    const next = removeTransientActivityForTurn(messages, event.turnId);
+    return upsertMessage(next, {
       id: event.turnId,
       role: "pulseed",
       text: event.text,
@@ -56,21 +66,27 @@ export function applyChatEventToMessages(
       text: event.message,
       timestamp,
       messageType: "info",
+      transient: event.transient === true,
     }, maxMessages);
   }
 
   if (event.type === "lifecycle_error") {
+    const next = removeTransientActivityForTurn(messages, event.turnId);
     const messageId = event.partialText ? event.turnId : `error:${event.runId}`;
     const text = event.partialText
       ? `${event.partialText}\n\n[interrupted: ${event.error}]`
       : `Error: ${event.error}`;
-    return upsertMessage(messages, {
+    return upsertMessage(next, {
       id: messageId,
       role: "pulseed",
       text,
       timestamp,
       messageType: "error",
     }, maxMessages);
+  }
+
+  if (event.type === "lifecycle_end") {
+    return removeTransientActivityForTurn(messages, event.turnId);
   }
 
   if (event.type === "tool_start") {

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, it } from "vitest";
-import React from "react";
-import { Text } from "ink";
 import {
   buildChatViewport,
   estimateComposerHeight,
@@ -9,13 +7,8 @@ import {
   getMatchingSuggestions,
   parseMouseEvent,
   getScrollRequest,
-  normalizeComposerInput,
   stripMouseEscapeSequences,
 } from "../chat.js";
-import {
-  formatProcessingLabel,
-  renderProcessingRow,
-} from "../fullscreen-chat.js";
 import { estimateMarkdownHeight, estimateWrappedLineCount, wrapTextToRows } from "../markdown-renderer.js";
 import { extractBashCommand, isBashModeInput, isSafeBashCommand, createShellApprovalTask, formatShellOutput } from "../bash-mode.js";
 import {
@@ -25,14 +18,11 @@ import {
   buildCursorEscapeFromCaretMarker,
   buildCursorEscapeFromInputMarker,
 } from "../cursor-tracker.js";
-import { CheckerboardSpinner } from "../checkerboard-spinner.js";
-import { ShimmerText } from "../shimmer-text.js";
 
 describe("getMatchingSuggestions", () => {
   it("hides suggestions for an exact slash command so enter can submit", () => {
     expect(getMatchingSuggestions("/help", [])).toEqual([]);
     expect(getMatchingSuggestions("/config", [])).toEqual([]);
-    expect(getMatchingSuggestions("/permissions", [])).toEqual([]);
   });
 
   it("keeps suggestions for partial slash commands", () => {
@@ -241,10 +231,14 @@ describe("chat scroll keys", () => {
     expect(stripMouseEscapeSequences("hello\u001b[<64;40;12Mworld")).toBe("helloworld");
   });
 
-  it("normalizes Shift+Enter escape sequences into newlines", () => {
-    expect(normalizeComposerInput("[27;2;13~")).toBe("\n");
-    expect(normalizeComposerInput("\u001b[27;2;13~")).toBe("\n");
-    expect(normalizeComposerInput("left[27;2;13~right")).toBe("left\nright");
+  it("normalizes shift-enter escape variants into newlines", () => {
+    expect(stripMouseEscapeSequences("foo\u001b[27;2;13~bar")).toBe("foo\nbar");
+    expect(stripMouseEscapeSequences("foo[27;2;13~bar")).toBe("foo\nbar");
+  });
+
+  it("strips bracketed-paste wrappers with and without esc prefix", () => {
+    expect(stripMouseEscapeSequences("\u001b[200~hello\nworld\u001b[201~")).toBe("hello\nworld");
+    expect(stripMouseEscapeSequences("[200~hello[201~")).toBe("hello");
   });
 });
 
@@ -282,29 +276,5 @@ describe("cursor tracker", () => {
     ].join("\n");
 
     expect(buildCursorEscapeFromInputMarker(frame, 3)).toBe("\u001b[2;8H\u001b[?25h");
-  });
-});
-
-describe("fullscreen processing row", () => {
-  it("builds animated spinner + shimmer row while processing", () => {
-    const row = renderProcessingRow(
-      true,
-      "Thinking",
-      40,
-    ) as React.ReactElement<{ children?: React.ReactNode }>;
-    const children = React.Children.toArray(
-      row.props.children,
-    ) as React.ReactElement<{ children?: React.ReactNode }>[];
-
-    expect(row.type).toBe(React.Fragment);
-    expect(children[0]?.type).toBe(CheckerboardSpinner);
-    expect(children[1]?.type).toBe(Text);
-    expect(children[2]?.type).toBe(ShimmerText);
-    expect(children[2]?.props.children).toBe("Thinking...");
-  });
-
-  it("formats processing label to available width budget", () => {
-    expect(formatProcessingLabel("Thinking", 8)).toBe("Thin");
-    expect(formatProcessingLabel("Working", 4)).toBe("W");
   });
 });

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -18,10 +18,7 @@ import { isBashModeInput } from "./bash-mode.js";
 import { isRenderableFrameChunk } from "./render-output.js";
 import { estimateWrappedLineCount } from "./markdown-renderer.js";
 import { buildChatViewport } from "./chat/viewport.js";
-import {
-  getScrollRequest,
-  normalizeComposerInput,
-} from "./chat/scroll.js";
+import { getScrollRequest, stripMouseEscapeSequences } from "./chat/scroll.js";
 import { getMatchingSuggestions, type Suggestion } from "./chat/suggestions.js";
 import type { ChatMessage } from "./chat/types.js";
 import { getTrustedTuiControlStream } from "./terminal-output.js";
@@ -54,12 +51,7 @@ const SCROLL_INDICATOR_ROWS = 2;
 const INPUT_BOX_HORIZONTAL_CHROME = 4;
 const SUGGESTION_HINT = " arrows to navigate, tab/enter to select, esc to dismiss";
 export { buildChatViewport } from "./chat/viewport.js";
-export {
-  getScrollRequest,
-  normalizeComposerInput,
-  parseMouseEvent,
-  stripMouseEscapeSequences,
-} from "./chat/scroll.js";
+export { getScrollRequest, parseMouseEvent, stripMouseEscapeSequences } from "./chat/scroll.js";
 export { getMatchingSuggestions } from "./chat/suggestions.js";
 
 export function getInputPromptLabel(bashMode: boolean): string {
@@ -597,7 +589,7 @@ export function Chat({
               value={input}
               onChange={(val) => {
                 justSelected.current = false;
-                setInput(normalizeComposerInput(val));
+                setInput(stripMouseEscapeSequences(val));
               }}
               onSubmit={handleSubmit}
               placeholder={getInputPlaceholder(bashMode)}

--- a/src/interface/tui/chat/scroll.ts
+++ b/src/interface/tui/chat/scroll.ts
@@ -3,6 +3,8 @@ import type { ScrollRequest } from "./types.js";
 const SGR_MOUSE_SEQUENCE = /(?:\u001b)?\[<(\d+);(\d+);(\d+)([mM])/;
 const SGR_MOUSE_SEQUENCE_GLOBAL = /(?:\u001b)?\[<(\d+);(\d+);(\d+)([mM])/g;
 const SHIFT_ENTER_SEQUENCE_GLOBAL = /(?:\u001b)?\[27;2;13~/g;
+const BRACKETED_PASTE_START_SEQUENCE_GLOBAL = /(?:\u001b)?\[200~/g;
+const BRACKETED_PASTE_END_SEQUENCE_GLOBAL = /(?:\u001b)?\[201~/g;
 
 type ScrollKey = {
   upArrow?: boolean;
@@ -118,9 +120,9 @@ export function getScrollRequest(
 }
 
 export function stripMouseEscapeSequences(input: string): string {
-  return input.replace(SGR_MOUSE_SEQUENCE_GLOBAL, "");
-}
-
-export function normalizeComposerInput(input: string): string {
-  return stripMouseEscapeSequences(input).replace(SHIFT_ENTER_SEQUENCE_GLOBAL, "\n");
+  return input
+    .replace(SGR_MOUSE_SEQUENCE_GLOBAL, "")
+    .replace(BRACKETED_PASTE_START_SEQUENCE_GLOBAL, "")
+    .replace(BRACKETED_PASTE_END_SEQUENCE_GLOBAL, "")
+    .replace(SHIFT_ENTER_SEQUENCE_GLOBAL, "\n");
 }

--- a/src/interface/tui/fullscreen-chat.tsx
+++ b/src/interface/tui/fullscreen-chat.tsx
@@ -3,8 +3,6 @@ import { Box, Text, useInput } from "ink";
 import { getClipboardContent } from "./clipboard.js";
 import { logTuiDebug } from "./debug-log.js";
 import { theme } from "./theme.js";
-import { CheckerboardSpinner } from "./checkerboard-spinner.js";
-import { ShimmerText } from "./shimmer-text.js";
 import { pickSpinnerVerb } from "./spinner-verbs.js";
 import {
   buildHiddenCursorEscapeFromPosition,
@@ -17,8 +15,8 @@ import { isBashModeInput } from "./bash-mode.js";
 import { buildChatViewport } from "./chat/viewport.js";
 import {
   getScrollRequest,
-  normalizeComposerInput,
   parseMouseEvent,
+  stripMouseEscapeSequences,
 } from "./chat/scroll.js";
 import { getMatchingSuggestions, type Suggestion } from "./chat/suggestions.js";
 import type { ChatMessage, ChatDisplayRow } from "./chat/types.js";
@@ -44,6 +42,8 @@ const INPUT_MARGIN = 4;
 const SELECTION_BACKGROUND = theme.text;
 const SELECTION_FOREGROUND = "#1F2329";
 const FAKE_CURSOR_GLYPH = "▌";
+const PROCESSING_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
+const PROCESSING_SPINNER_INTERVAL_MS = 80;
 
 type RenderSegment = {
   text: string;
@@ -57,7 +57,6 @@ type RenderLine = {
   key: string;
   text?: string;
   segments?: RenderSegment[];
-  processing?: boolean;
   color?: string;
   backgroundColor?: string;
   bold?: boolean;
@@ -128,28 +127,6 @@ function padToWidth(text: string, width: number): string {
   const trimmed = trimToWidth(text, width);
   const padding = Math.max(0, width - stringWidth(trimmed));
   return trimmed + " ".repeat(padding);
-}
-
-export function formatProcessingLabel(spinnerVerb: string, availableCols: number): string {
-  return trimToWidth(`${spinnerVerb}...`, Math.max(1, availableCols - 4));
-}
-
-export function renderProcessingRow(
-  isProcessing: boolean,
-  spinnerVerb: string,
-  availableCols: number,
-): React.ReactNode {
-  if (!isProcessing) {
-    return <Text>{padToWidth("", availableCols)}</Text>;
-  }
-
-  return (
-    <>
-      <CheckerboardSpinner />
-      <Text> </Text>
-      <ShimmerText>{formatProcessingLabel(spinnerVerb, availableCols)}</ShimmerText>
-    </>
-  );
 }
 
 function getPreviousOffset(text: string, offset: number): number {
@@ -666,6 +643,7 @@ export function FullscreenChat({
   const [scrollOffset, setScrollOffset] = React.useState(0);
   const [targetScrollOffset, setTargetScrollOffset] = React.useState(0);
   const [spinnerVerb, setSpinnerVerb] = React.useState(() => pickSpinnerVerb());
+  const [spinnerFrameIndex, setSpinnerFrameIndex] = React.useState(0);
 
   React.useEffect(() => {
     let lastClipboard = "";
@@ -698,6 +676,18 @@ export function FullscreenChat({
     const interval = setInterval(() => {
       setSpinnerVerb(pickSpinnerVerb());
     }, 5000);
+    return () => clearInterval(interval);
+  }, [isProcessing]);
+
+  React.useEffect(() => {
+    if (!isProcessing) {
+      setSpinnerFrameIndex(0);
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setSpinnerFrameIndex((prev) => (prev + 1) % PROCESSING_SPINNER_FRAMES.length);
+    }, PROCESSING_SPINNER_INTERVAL_MS);
     return () => clearInterval(interval);
   }, [isProcessing]);
 
@@ -964,7 +954,7 @@ export function FullscreenChat({
         clearSelection();
         return;
       }
-      setCursorOffset((prev) => Math.max(0, prev - 1));
+      setCursorOffset((prev) => getPreviousOffset(input, prev));
       return;
     }
     if (key.rightArrow) {
@@ -973,7 +963,7 @@ export function FullscreenChat({
         clearSelection();
         return;
       }
-      setCursorOffset((prev) => Math.min(input.length, prev + 1));
+      setCursorOffset((prev) => getNextOffset(input, prev));
       return;
     }
     if ((key.ctrl && inputChar === "a") || key.home) {
@@ -1072,7 +1062,7 @@ export function FullscreenChat({
     }
 
     if (inputChar && !key.ctrl && !key.meta) {
-      const clean = normalizeComposerInput(inputChar);
+      const clean = stripMouseEscapeSequences(inputChar);
       if (clean.length === 0) return;
       insertText(clean);
     }
@@ -1105,9 +1095,12 @@ export function FullscreenChat({
   }
   lines.push(...renderedRows);
 
+  const spinnerGlyph = PROCESSING_SPINNER_FRAMES[spinnerFrameIndex] ?? PROCESSING_SPINNER_FRAMES[0];
   lines.push({
     key: "processing",
-    processing: true,
+    text: padToWidth(isProcessing ? `${spinnerGlyph} ${spinnerVerb}...` : "", availableCols),
+    color: isProcessing ? theme.command : undefined,
+    dim: !isProcessing,
   });
   lines.push({
     key: "indicator-bottom",
@@ -1132,9 +1125,7 @@ export function FullscreenChat({
     <Box flexDirection="column" flexGrow={1} overflow="hidden">
       {visibleLines.map((line) => (
         <Box key={line.key} height={1} overflow="hidden">
-          {line.processing ? (
-            renderProcessingRow(isProcessing, spinnerVerb, availableCols)
-          ) : line.segments ? (
+          {line.segments ? (
             line.segments.map((segment, index) => (
               <Text
                 key={`${line.key}-${index}`}


### PR DESCRIPTION
## Summary
- sanitize composer input by stripping SGR mouse and bracketed-paste wrappers, and normalize Shift+Enter escape variants to newlines
- update no-flicker fullscreen chat processing row to use animated spinner frames with command color and surrogate-safe cursor movement
- clear transient activity rows on turn-ending events (assistant_final, lifecycle_error, lifecycle_end) to prevent delayed or stale output in chat

## Testing
- npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/chat.test.ts
- npx vitest run --config vitest.unit.config.ts src/interface/chat/__tests__/chat-event-state.test.ts
- npm run typecheck