### PR TITLE
fix(tui): restore stable no-flicker chat output and approval flow

### DIFF
--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import React from "react";
+import { Text } from "ink";
 import {
   buildChatViewport,
   estimateComposerHeight,
@@ -9,6 +11,7 @@ import {
   getScrollRequest,
   stripMouseEscapeSequences,
 } from "../chat.js";
+import { renderProcessingRow } from "../fullscreen-chat.js";
 import { estimateMarkdownHeight, estimateWrappedLineCount, wrapTextToRows } from "../markdown-renderer.js";
 import { extractBashCommand, isBashModeInput, isSafeBashCommand, createShellApprovalTask, formatShellOutput } from "../bash-mode.js";
 import {
@@ -18,6 +21,7 @@ import {
   buildCursorEscapeFromCaretMarker,
   buildCursorEscapeFromInputMarker,
 } from "../cursor-tracker.js";
+import { ShimmerText } from "../shimmer-text.js";
 
 describe("getMatchingSuggestions", () => {
   it("hides suggestions for an exact slash command so enter can submit", () => {
@@ -276,5 +280,26 @@ describe("cursor tracker", () => {
     ].join("\n");
 
     expect(buildCursorEscapeFromInputMarker(frame, 3)).toBe("\u001b[2;8H\u001b[?25h");
+  });
+});
+
+describe("fullscreen processing row", () => {
+  it("renders spinner + shimmer text while processing", () => {
+    const row = renderProcessingRow("⠋", "Thinking", 40) as React.ReactElement<{ children?: React.ReactNode; color?: string }>;
+    const children = React.Children.toArray(
+      row.props.children,
+    ) as React.ReactElement<{ children?: React.ReactNode; color?: string }>[];
+
+    expect(row.type).toBe(React.Fragment);
+    expect(children[0]?.type).toBe(Text);
+    expect(children[0]?.props.color).toBeDefined();
+    expect(children[2]?.type).toBe(ShimmerText);
+    expect(children[2]?.props.children).toBe("Thinking...");
+  });
+
+  it("renders an empty row when not processing", () => {
+    const row = renderProcessingRow("", "", 20) as React.ReactElement<{ children?: React.ReactNode }>;
+    expect(row.type).toBe(Text);
+    expect(row.props.children).toBeTypeOf("string");
   });
 });

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -641,6 +641,51 @@ async function startTUIDaemonMode(): Promise<void> {
       permissionManager,
       concurrency: new ConcurrencyController(),
     });
+    let requestApproval: ((req: ApprovalRequest) => void) | null = null;
+    const pendingApprovals: ApprovalRequest[] = [];
+    const enqueueApproval = (task: Task): Promise<boolean> => {
+      return new Promise((resolve) => {
+        const request = { task, resolve };
+        if (requestApproval) requestApproval(request);
+        else pendingApprovals.push(request);
+      });
+    };
+    const setRequestApproval = (fn: (req: ApprovalRequest) => void) => {
+      requestApproval = fn;
+      while (pendingApprovals.length > 0) {
+        requestApproval(pendingApprovals.shift()!);
+      }
+    };
+    const chatToolApprovalFn = async (description: string): Promise<boolean> => {
+      return enqueueApproval({
+        id: randomUUID(),
+        goal_id: "chat-tool-approval",
+        strategy_id: null,
+        target_dimensions: ["approval"],
+        primary_dimension: "approval",
+        work_description: description,
+        rationale: "Requested by chat tool execution",
+        approach: "Wait for explicit approval before continuing the chat tool call.",
+        success_criteria: [],
+        scope_boundary: {
+          in_scope: ["Approve or reject the pending chat tool action."],
+          out_of_scope: ["Execute any work beyond the requested chat tool action."],
+          blast_radius: "Limited to whether the pending chat tool call proceeds.",
+        },
+        constraints: [],
+        plateau_until: null,
+        estimated_duration: null,
+        consecutive_failure_count: 0,
+        reversibility: "unknown",
+        task_category: "normal",
+        status: "pending",
+        started_at: null,
+        completed_at: null,
+        timeout_at: null,
+        heartbeat_at: null,
+        created_at: new Date().toISOString(),
+      });
+    };
 
     const providerConfig = await loadProviderConfig();
     const cwd = getCwd();
@@ -684,6 +729,7 @@ async function startTUIDaemonMode(): Promise<void> {
         toolExecutor,
         chatAgentLoopRunner,
         reviewAgentLoopRunner,
+        approvalFn: chatToolApprovalFn,
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -712,6 +758,7 @@ async function startTUIDaemonMode(): Promise<void> {
       providerName,
       noFlicker,
       chatRunner,
+      onApprovalReady: setRequestApproval,
       controlStream: terminalStream,
     });
 

--- a/src/interface/tui/fullscreen-chat.tsx
+++ b/src/interface/tui/fullscreen-chat.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from "ink";
 import { getClipboardContent } from "./clipboard.js";
 import { logTuiDebug } from "./debug-log.js";
 import { theme } from "./theme.js";
+import { ShimmerText } from "./shimmer-text.js";
 import { pickSpinnerVerb } from "./spinner-verbs.js";
 import {
   buildHiddenCursorEscapeFromPosition,
@@ -57,6 +58,10 @@ type RenderLine = {
   key: string;
   text?: string;
   segments?: RenderSegment[];
+  processing?: {
+    glyph: string;
+    verb: string;
+  };
   color?: string;
   backgroundColor?: string;
   bold?: boolean;
@@ -127,6 +132,27 @@ function padToWidth(text: string, width: number): string {
   const trimmed = trimToWidth(text, width);
   const padding = Math.max(0, width - stringWidth(trimmed));
   return trimmed + " ".repeat(padding);
+}
+
+export function renderProcessingRow(glyph: string, verb: string, cols: number): React.ReactNode {
+  if (!verb) {
+    return <Text>{padToWidth("", cols)}</Text>;
+  }
+
+  const spinner = trimToWidth(glyph, Math.max(1, cols));
+  const remaining = Math.max(0, cols - stringWidth(spinner) - 1);
+  const label = trimToWidth(`${verb}...`, remaining);
+  const consumedWidth = stringWidth(spinner) + (remaining > 0 ? 1 + stringWidth(label) : 0);
+  const tailPadding = " ".repeat(Math.max(0, cols - consumedWidth));
+
+  return (
+    <>
+      <Text color={theme.command}>{spinner}</Text>
+      {remaining > 0 ? <Text> </Text> : null}
+      {remaining > 0 ? <ShimmerText>{label}</ShimmerText> : null}
+      {tailPadding.length > 0 ? <Text>{tailPadding}</Text> : null}
+    </>
+  );
 }
 
 function getPreviousOffset(text: string, offset: number): number {
@@ -1098,9 +1124,9 @@ export function FullscreenChat({
   const spinnerGlyph = PROCESSING_SPINNER_FRAMES[spinnerFrameIndex] ?? PROCESSING_SPINNER_FRAMES[0];
   lines.push({
     key: "processing",
-    text: padToWidth(isProcessing ? `${spinnerGlyph} ${spinnerVerb}...` : "", availableCols),
-    color: isProcessing ? theme.command : undefined,
-    dim: !isProcessing,
+    ...(isProcessing
+      ? { processing: { glyph: spinnerGlyph, verb: spinnerVerb } }
+      : { text: padToWidth("", availableCols), dim: true }),
   });
   lines.push({
     key: "indicator-bottom",
@@ -1125,7 +1151,9 @@ export function FullscreenChat({
     <Box flexDirection="column" flexGrow={1} overflow="hidden">
       {visibleLines.map((line) => (
         <Box key={line.key} height={1} overflow="hidden">
-          {line.segments ? (
+          {line.processing ? (
+            renderProcessingRow(line.processing.glyph, line.processing.verb, availableCols)
+          ) : line.segments ? (
             line.segments.map((segment, index) => (
               <Text
                 key={`${line.key}-${index}`}

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
@@ -520,7 +520,8 @@ describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () =>
     const result = await chat.execute({ message: "status?", goalId: "goal-1" });
 
     expect(result.success).toBe(true);
-    expect(result.output).toBe("Goal is running");
+    expect(result.output).toContain("Goal is running");
+    expect(result.output).toContain("Evidence:");
     expect(modelClient.calls[1].messages.some((m) => m.role === "tool" && m.toolName === "core_goal_status")).toBe(true);
   });
 
@@ -567,7 +568,8 @@ describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () =>
     });
 
     expect(result.success).toBe(true);
-    expect(result.output).toBe("approved path");
+    expect(result.output).toContain("approved path");
+    expect(result.output).toContain("Evidence:");
     expect(events.some((event) => event.type === "approval_request" && event.toolName === "approval_tool")).toBe(true);
     expect(modelClient.calls[1].messages.some((m) => m.role === "tool" && m.toolName === "approval_tool")).toBe(true);
   });
@@ -662,6 +664,81 @@ describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () =>
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     }
+  });
+
+  it("keeps structured details from final JSON instead of collapsing to a single message line", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: JSON.stringify({
+          status: "done",
+          message: "この環境でできること",
+          capabilities: ["コードを読む", "コードを修正する"],
+          next_step: "必要なら実装方針を作成する",
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const registry = new ToolRegistry();
+    const { router, runtime } = makeRuntime(registry);
+    const registryModel = new StaticAgentLoopModelRegistry([modelInfo]);
+    const chat = new ChatAgentLoopRunner({
+      boundedRunner: new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime }),
+      modelClient,
+      modelRegistry: registryModel,
+      defaultModel: modelInfo.ref,
+    });
+
+    const result = await chat.execute({ message: "何ができるの？" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("この環境でできること");
+    expect(result.output).toContain("Capabilities:");
+    expect(result.output).toContain("- コードを読む");
+    expect(result.output).toContain("Next step:");
+  });
+
+  it("returns a clear approval-policy message instead of leaking raw tool commentary", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{ id: "call-1", name: "approval_tool", input: { value: "a" } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-2", name: "approval_tool", input: { value: "b" } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-3", name: "approval_tool", input: { value: "c" } }],
+        stopReason: "tool_use",
+      },
+    ]);
+    const registry = new ToolRegistry();
+    registry.register(new ApprovalTool());
+    const { router, runtime } = makeRuntime(registry);
+    const registryModel = new StaticAgentLoopModelRegistry([modelInfo]);
+    const chat = new ChatAgentLoopRunner({
+      boundedRunner: new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime }),
+      modelClient,
+      modelRegistry: registryModel,
+      defaultModel: modelInfo.ref,
+      defaultToolPolicy: { allowedTools: ["approval_tool"] },
+    });
+
+    const result = await chat.execute({
+      message: "do work",
+      goalId: "goal-1",
+      approvalFn: async () => false,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("denied or failed");
+    expect(result.output).not.toContain("Calling approval_tool");
   });
 });
 

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -147,10 +147,12 @@ export class ChatAgentLoopRunner {
     });
 
     const success = result.success && result.output?.status === "done";
-    const fallbackOutput = result.output?.message
-      ?? result.finalText
-      ?? result.output?.blockers.join("; ")
-      ?? result.stopReason;
+    const hadApprovalDeniedError = result.commandResults.some((entry) =>
+      /approval denied|user denied approval|requires approval/i.test(entry.outputSummary),
+    );
+    const fallbackOutput = success
+      ? this.buildSuccessfulOutput(result.finalText, result.output?.message)
+      : this.buildFailureOutput(result.stopReason, hadApprovalDeniedError, result.finalText, result.output?.blockers);
     return {
       success,
       output: fallbackOutput,
@@ -181,5 +183,104 @@ export class ChatAgentLoopRunner {
           : {}),
       },
     };
+  }
+
+  private buildSuccessfulOutput(finalText: string, fallbackMessage?: string): string {
+    const formatted = this.formatStructuredFinalText(finalText);
+    if (formatted) return formatted;
+    if (fallbackMessage && fallbackMessage.trim().length > 0) return fallbackMessage.trim();
+    if (finalText && finalText.trim().length > 0) return finalText.trim();
+    return "(no response)";
+  }
+
+  private buildFailureOutput(
+    stopReason: string,
+    hadApprovalDeniedError: boolean,
+    finalText: string,
+    blockers?: string[],
+  ): string {
+    if (
+      stopReason === "consecutive_tool_errors"
+      && (hadApprovalDeniedError || /^Calling\s+/i.test(finalText.trim()))
+    ) {
+      return [
+        "I could not continue because repeated tool actions were denied or failed.",
+        "Approve the request or update session policy with `/permissions ...`, then retry.",
+      ].join("\n");
+    }
+    if (stopReason === "max_tool_calls") {
+      return "I reached the tool-call limit before completing this request. Please narrow the scope or continue in another turn.";
+    }
+    if (stopReason === "max_model_turns") {
+      return "I reached the model-turn limit before completing this request. Please continue in another turn.";
+    }
+    if (stopReason === "stalled_tool_loop") {
+      return "I stopped because the tool loop repeated without making progress.";
+    }
+
+    const formatted = this.formatStructuredFinalText(finalText);
+    if (formatted) return formatted;
+    if (blockers && blockers.length > 0) return blockers.join("; ");
+    if (finalText && !/^Calling\s+/i.test(finalText.trim())) return finalText.trim();
+    return `Interrupted: ${stopReason}`;
+  }
+
+  private formatStructuredFinalText(finalText: string): string | null {
+    const raw = finalText?.trim();
+    if (!raw) return null;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+
+    const value = parsed as Record<string, unknown>;
+    const message = typeof value.message === "string" ? value.message.trim() : "";
+    const sections: string[] = [];
+    const handledKeys = new Set<string>(["status", "message", "evidence", "blockers"]);
+
+    const appendStringArray = (title: string, key: string) => {
+      const array = value[key];
+      if (!Array.isArray(array)) return;
+      const lines = array.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+      if (lines.length === 0) return;
+      handledKeys.add(key);
+      sections.push(`${title}:\n${lines.map((line) => `- ${line}`).join("\n")}`);
+    };
+
+    appendStringArray("Details", "details");
+    appendStringArray("Capabilities", "capabilities");
+    appendStringArray("Evidence", "evidence");
+    appendStringArray("Blockers", "blockers");
+    appendStringArray("Examples", "examples");
+    appendStringArray("Telegram examples", "telegram_examples");
+    appendStringArray("Next actions", "next_actions");
+
+    for (const [key, fieldValue] of Object.entries(value)) {
+      if (handledKeys.has(key) || !Array.isArray(fieldValue)) continue;
+      const lines = fieldValue.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+      if (lines.length === 0) continue;
+      sections.push(`${this.humanizeFieldLabel(key)}:\n${lines.map((line) => `- ${line}`).join("\n")}`);
+    }
+
+    if (typeof value.next_step === "string" && value.next_step.trim().length > 0) {
+      sections.push(`Next step: ${value.next_step.trim()}`);
+    }
+
+    if (!message && sections.length === 0) return raw;
+    return [message, ...sections].filter((section) => section.length > 0).join("\n\n");
+  }
+
+  private humanizeFieldLabel(key: string): string {
+    return key
+      .split(/[_\s-]+/g)
+      .filter(Boolean)
+      .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+      .join(" ");
   }
 }


### PR DESCRIPTION
## Summary
- fix daemon-mode TUI chat approval wiring so chat agentloop tool calls can open approval overlay instead of hard-failing into consecutive tool errors
- restore no-flicker processing-row rendering with animated spinner + shimmer gradient text
- improve chat agentloop final output shaping to preserve structured long responses and return actionable failure text for approval/tool-loop stops
- add regression tests for the new chat output shaping and no-flicker processing row rendering

## Validation
- npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/chat.test.ts
- npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
- npm run typecheck