### PR TITLE
Fix Codex chat timeout handling and trace stops

### DIFF
--- a/src/base/llm/__tests__/codex-llm-client.test.ts
+++ b/src/base/llm/__tests__/codex-llm-client.test.ts
@@ -293,11 +293,11 @@ describe("CodexLLMClient", () => {
   // ─── Error handling ───
 
   describe("sendMessage: spawn error", () => {
-    it("throws when spawn emits error event (single attempt, no retry delay)", async () => {
+    it("retries retryable spawn errors up to the configured attempt limit", async () => {
       // Use fake timers to skip retry delays
       vi.useFakeTimers();
 
-      const client = new CodexLLMClient({ cliPath: "codex" });
+      const client = new CodexLLMClient({ cliPath: "codex", retryAttempts: 3 });
 
       // Queue children for all 3 retry attempts
       const children: FakeChildProcess[] = [];
@@ -313,8 +313,10 @@ describe("CodexLLMClient", () => {
       children[0]!.emit("error", new Error("spawn ENOENT"));
       // Advance timers to trigger retry delays, emit error on subsequent children
       await vi.advanceTimersByTimeAsync(1001);
+      await vi.advanceTimersByTimeAsync(0);
       children[1]!.emit("error", new Error("spawn ENOENT"));
       await vi.advanceTimersByTimeAsync(2001);
+      await vi.advanceTimersByTimeAsync(0);
       children[2]!.emit("error", new Error("spawn ENOENT"));
       await vi.runAllTimersAsync();
 
@@ -325,25 +327,72 @@ describe("CodexLLMClient", () => {
       expect((err as Error).message).toContain("spawn ENOENT");
     });
 
-    it("throws when process exits with non-zero code (after retries)", async () => {
+    it("respects retryAttempts when configured lower than the default", async () => {
       vi.useFakeTimers();
 
-      const client = new CodexLLMClient();
+      const client = new CodexLLMClient({ retryAttempts: 1 });
+      const child = makeFakeChild();
+
+      const promise = client.sendMessage([{ role: "user", content: "hi" }]).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(0);
+      child.emit("error", new Error("spawn ENOENT"));
+      await vi.runAllTimersAsync();
+
+      vi.useRealTimers();
+
+      const err = await promise;
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("spawn ENOENT");
+    });
+
+    it("caps retryAttempts at five total attempts", async () => {
+      vi.useFakeTimers();
+
+      const client = new CodexLLMClient({ retryAttempts: 99 });
 
       const children: FakeChildProcess[] = [];
-      for (let i = 0; i < 3; i++) {
+      for (let i = 0; i < 5; i++) {
         children.push(makeFakeChild());
       }
 
       const promise = client.sendMessage([{ role: "user", content: "hi" }]).catch((e) => e);
 
+      await vi.advanceTimersByTimeAsync(0);
+      children[0]!.emit("error", new Error("spawn ENOENT"));
+      await vi.advanceTimersByTimeAsync(1001);
+      await vi.advanceTimersByTimeAsync(0);
+      children[1]!.emit("error", new Error("spawn ENOENT"));
+      await vi.advanceTimersByTimeAsync(2001);
+      await vi.advanceTimersByTimeAsync(0);
+      children[2]!.emit("error", new Error("spawn ENOENT"));
+      await vi.advanceTimersByTimeAsync(4001);
+      await vi.advanceTimersByTimeAsync(0);
+      children[3]!.emit("error", new Error("spawn ENOENT"));
+      await vi.advanceTimersByTimeAsync(8001);
+      await vi.advanceTimersByTimeAsync(0);
+      children[4]!.emit("error", new Error("spawn ENOENT"));
+      await vi.runAllTimersAsync();
+
+      vi.useRealTimers();
+
+      const err = await promise;
+      expect(mockSpawn).toHaveBeenCalledTimes(5);
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("spawn ENOENT");
+    });
+
+    it("does not retry non-timeout process exits", async () => {
+      vi.useFakeTimers();
+
+      const client = new CodexLLMClient({ retryAttempts: 3 });
+      const child = makeFakeChild();
+
+      const promise = client.sendMessage([{ role: "user", content: "hi" }]).catch((e) => e);
+
       // Flush microtasks so mkdtemp resolves and spawn is called before emitting close
       await vi.advanceTimersByTimeAsync(0);
-      children[0]!.emit("close", 1);
-      await vi.advanceTimersByTimeAsync(1001);
-      children[1]!.emit("close", 1);
-      await vi.advanceTimersByTimeAsync(2001);
-      children[2]!.emit("close", 1);
+      child.emit("close", 1);
       await vi.runAllTimersAsync();
 
       vi.useRealTimers();
@@ -351,30 +400,62 @@ describe("CodexLLMClient", () => {
       const err = await promise;
       expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toContain("exited with code 1");
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
     });
   });
 
   // ─── Timeout ───
 
   describe("sendMessage: timeout", () => {
-    it("rejects with timeout error when timeoutMs elapses", async () => {
-      const client = new CodexLLMClient({ timeoutMs: 50 });
+    it("rejects with total timeout error when timeoutMs elapses", async () => {
+      vi.useFakeTimers();
 
-      // Set up 3 fake children that emit "close" only AFTER timeout fires
-      for (let i = 0; i < 3; i++) {
-        const child = new FakeChildProcess();
-        mockSpawn.mockReturnValueOnce(child);
-        // When kill is called (by timeout), emit close
-        child.kill.mockImplementation(() => {
-          setTimeout(() => child.emit("close", null), 5);
-          return true;
-        });
-      }
+      const client = new CodexLLMClient({ timeoutMs: 50, idleTimeoutMs: 1000, retryAttempts: 3 });
 
-      const err = await client.sendMessage([{ role: "user", content: "hi" }]).catch((e) => e);
+      const child = new FakeChildProcess();
+      mockSpawn.mockReturnValueOnce(child);
+      child.kill.mockImplementation(() => {
+        setTimeout(() => child.emit("close", null), 5);
+        return true;
+      });
+
+      const promise = client.sendMessage([{ role: "user", content: "hi" }]).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(55);
+      const err = await promise;
+
+      vi.useRealTimers();
 
       expect(err).toBeInstanceOf(Error);
-      expect((err as Error).message).toContain("timed out");
+      expect((err as Error).message).toContain("request timed out");
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects with idle timeout error when no output is produced", async () => {
+      vi.useFakeTimers();
+
+      const client = new CodexLLMClient({ timeoutMs: 1000, idleTimeoutMs: 50 });
+      const child = new FakeChildProcess();
+      mockSpawn.mockReturnValueOnce(child);
+      child.kill.mockImplementation(() => {
+        setTimeout(() => child.emit("close", null), 5);
+        return true;
+      });
+
+      const promise = client.sendMessage([{ role: "user", content: "hi" }]).catch((e) => e);
+      await vi.advanceTimersByTimeAsync(0);
+      child.stderr.emit("data", Buffer.from("working\n"));
+      await vi.advanceTimersByTimeAsync(49);
+      expect(child.kill).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(2);
+      await vi.advanceTimersByTimeAsync(5);
+      const err = await promise;
+
+      vi.useRealTimers();
+
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("idle timed out");
     });
   });
 

--- a/src/base/llm/__tests__/provider-config.test.ts
+++ b/src/base/llm/__tests__/provider-config.test.ts
@@ -424,6 +424,24 @@ describe("loadProviderConfig", () => {
     expect(config.api_key).toBe("sk-test");
   });
 
+  it("loads Codex timeout and retry settings from flat config", async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      provider: "openai",
+      model: "gpt-5.4-mini",
+      adapter: "openai_codex_cli",
+      codex_timeout_ms: 180000,
+      codex_idle_timeout_ms: 30000,
+      codex_retry_attempts: 4,
+    }));
+
+    const config = await loadProviderConfig();
+
+    expect(config.codex_timeout_ms).toBe(180000);
+    expect(config.codex_idle_timeout_ms).toBe(30000);
+    expect(config.codex_retry_attempts).toBe(4);
+  });
+
   it("keeps explicit file models even when adapter compatibility is mismatched", async () => {
     mockAccess.mockResolvedValue(undefined);
     mockReadFile.mockResolvedValue(JSON.stringify({
@@ -511,11 +529,19 @@ describe("loadProviderConfig", () => {
       model: "gpt-5.4-mini",
       adapter: "openai_codex_cli",
       api_key: "sk-provider-file",
+      codex_timeout_ms: 180000,
+      codex_idle_timeout_ms: 30000,
+      codex_retry_attempts: 4,
     });
 
     expect(writeJsonFileAtomic).toHaveBeenCalledWith(
       expect.stringContaining("provider.json"),
-      expect.objectContaining({ api_key: "sk-provider-file" }),
+      expect.objectContaining({
+        api_key: "sk-provider-file",
+        codex_timeout_ms: 180000,
+        codex_idle_timeout_ms: 30000,
+        codex_retry_attempts: 4,
+      }),
       { mode: 0o600, directoryMode: 0o700 }
     );
   });

--- a/src/base/llm/__tests__/provider-factory.test.ts
+++ b/src/base/llm/__tests__/provider-factory.test.ts
@@ -49,6 +49,7 @@ vi.mock("../provider-config.js", () => ({
 import { buildLLMClient } from "../provider-factory.js";
 import { LLMClient } from "../llm-client.js";
 import { OpenAILLMClient } from "../openai-client.js";
+import { CodexLLMClient } from "../codex-llm-client.js";
 
 // ─── Tests ───
 
@@ -171,6 +172,32 @@ describe("buildLLMClient — early API key validation", () => {
       });
 
       await expect(buildLLMClient()).resolves.not.toThrow();
+    });
+
+    it("passes Codex timeout and retry config through to CodexLLMClient", async () => {
+      const MockedCodexLLMClient = vi.mocked(CodexLLMClient);
+      MockedCodexLLMClient.mockClear();
+
+      mockLoadProviderConfig.mockResolvedValue({
+        provider: "openai",
+        model: "gpt-5.4-mini",
+        adapter: "openai_codex_cli",
+        codex_cli_path: "/usr/local/bin/codex",
+        codex_timeout_ms: 180000,
+        codex_idle_timeout_ms: 30000,
+        codex_retry_attempts: 4,
+      });
+
+      await buildLLMClient();
+
+      expect(MockedCodexLLMClient).toHaveBeenCalledOnce();
+      expect(MockedCodexLLMClient).toHaveBeenCalledWith(expect.objectContaining({
+        cliPath: "/usr/local/bin/codex",
+        model: "gpt-5.4-mini",
+        timeoutMs: 180000,
+        idleTimeoutMs: 30000,
+        retryAttempts: 4,
+      }));
     });
 
     it("succeeds when api_key is present", async () => {

--- a/src/base/llm/codex-llm-client.ts
+++ b/src/base/llm/codex-llm-client.ts
@@ -2,7 +2,7 @@ import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawn } from "node:child_process";
-import { BaseLLMClient, MAX_RETRY_ATTEMPTS, RETRY_DELAYS_MS } from "./base-llm-client.js";
+import { BaseLLMClient } from "./base-llm-client.js";
 import {
   type ILLMClient,
   type LLMMessage,
@@ -14,7 +14,12 @@ import { LLMError } from "../utils/errors.js";
 
 // ─── Constants ───
 
-const DEFAULT_TIMEOUT_MS = 120_000; // 2 minutes per call
+const DEFAULT_TIMEOUT_MS = 300_000; // 5 minutes per call
+const DEFAULT_IDLE_TIMEOUT_MS = 0;
+const DEFAULT_RETRY_ATTEMPTS = 2;
+const MAX_RETRY_ATTEMPTS = 5;
+const RETRY_DELAYS_MS = [1000, 2000, 4000, 8000];
+const SIGKILL_DELAY_MS = 5000;
 
 /**
  * Build a single prompt string from messages and system prompt.
@@ -51,8 +56,12 @@ export interface CodexLLMClientConfig {
   lightModel?: string;
   /** Repository path passed to Codex for workspace-aware execution. Default: "." */
   repoPath?: string;
-  /** Timeout per call in milliseconds. Default: 120000 (2 minutes) */
+  /** Total request timeout per call in milliseconds. Default: 300000 (5 minutes) */
   timeoutMs?: number;
+  /** Idle timeout after Codex emits output and then goes quiet. Disabled by default. */
+  idleTimeoutMs?: number;
+  /** Total retry attempts including the initial call. Default: 2, capped at 5. */
+  retryAttempts?: number;
   /** Sandbox passed to codex exec. Default: workspace-write. */
   sandboxPolicy?: string;
   /** Pass --skip-git-repo-check. Default: true. */
@@ -74,7 +83,9 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
   private readonly cliPath: string;
   private readonly model: string | undefined;
   private readonly repoPath: string;
-  private readonly timeoutMs: number;
+  private readonly totalTimeoutMs: number;
+  private readonly idleTimeoutMs: number;
+  private readonly retryAttempts: number;
   private readonly sandboxPolicy: string;
   private readonly skipGitRepoCheck: boolean;
 
@@ -84,7 +95,14 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
     this.model = config.model;
     this.lightModel = config.lightModel;
     this.repoPath = config.repoPath?.trim() || ".";
-    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.totalTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.idleTimeoutMs = typeof config.idleTimeoutMs === "number" && Number.isFinite(config.idleTimeoutMs)
+      ? Math.max(0, Math.trunc(config.idleTimeoutMs))
+      : DEFAULT_IDLE_TIMEOUT_MS;
+    const requestedRetryAttempts = typeof config.retryAttempts === "number" && Number.isFinite(config.retryAttempts)
+      ? Math.trunc(config.retryAttempts)
+      : DEFAULT_RETRY_ATTEMPTS;
+    this.retryAttempts = Math.max(1, Math.min(requestedRetryAttempts, MAX_RETRY_ATTEMPTS));
     this.sandboxPolicy = config.sandboxPolicy ?? "workspace-write";
     this.skipGitRepoCheck = config.skipGitRepoCheck ?? true;
   }
@@ -104,7 +122,7 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
 
     let lastError: unknown;
 
-    for (let attempt = 0; attempt < MAX_RETRY_ATTEMPTS; attempt++) {
+    for (let attempt = 0; attempt < this.retryAttempts; attempt++) {
       try {
         const content = await this._spawnCodex(prompt, model);
         return {
@@ -117,8 +135,11 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
         };
       } catch (err) {
         lastError = err;
-        if (attempt < MAX_RETRY_ATTEMPTS - 1) {
-          await sleep(RETRY_DELAYS_MS[attempt] ?? 1000);
+        if (!isRetryableCodexError(err)) {
+          break;
+        }
+        if (attempt < this.retryAttempts - 1) {
+          await sleep(RETRY_DELAYS_MS[attempt] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1]!);
         }
       }
     }
@@ -168,21 +189,51 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
       });
 
       let timedOut = false;
+      let timeoutReason: "total" | "idle" | undefined;
+      let totalTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      let idleTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      let sigkillHandle: ReturnType<typeof setTimeout> | undefined;
       let stderrData = "";
-      child.stderr.on("data", (chunk: Buffer) => { stderrData += chunk.toString(); });
-
-      // Timeout: send SIGTERM, then SIGKILL after 5s
-      const timeoutHandle = setTimeout(() => {
+      const clearTimers = (): void => {
+        if (totalTimeoutHandle) clearTimeout(totalTimeoutHandle);
+        if (idleTimeoutHandle) clearTimeout(idleTimeoutHandle);
+        if (sigkillHandle) clearTimeout(sigkillHandle);
+      };
+      const cleanupTmp = (): void => {
+        clearTimers();
+        void _cleanupTmp(tmpDir, tmpFile).catch((cleanupErr) => {
+          console.debug("CodexLLMClient: _cleanupTmp failed (non-critical)", String(cleanupErr));
+        });
+      };
+      const triggerTimeout = (reason: "total" | "idle"): void => {
+        if (timedOut) return;
         timedOut = true;
+        timeoutReason = reason;
         child.kill("SIGTERM");
-        setTimeout(() => {
+        sigkillHandle = setTimeout(() => {
           try {
             child.kill("SIGKILL");
           } catch {
             // process already exited
           }
-        }, 5000);
-      }, this.timeoutMs);
+        }, SIGKILL_DELAY_MS);
+      };
+      const armIdleTimeout = (): void => {
+        if (this.idleTimeoutMs <= 0) return;
+        if (idleTimeoutHandle) clearTimeout(idleTimeoutHandle);
+        idleTimeoutHandle = setTimeout(() => triggerTimeout("idle"), this.idleTimeoutMs);
+      };
+      const markActivity = (): void => {
+        armIdleTimeout();
+      };
+
+      totalTimeoutHandle = setTimeout(() => triggerTimeout("total"), this.totalTimeoutMs);
+
+      child.stdout?.on("data", markActivity);
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderrData += chunk.toString();
+        markActivity();
+      });
 
       // Suppress EPIPE errors on stdin
       child.stdin.on("error", (err: NodeJS.ErrnoException) => {
@@ -194,32 +245,26 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
       child.stdin.end();
 
       child.on("error", (err: Error) => {
-        clearTimeout(timeoutHandle);
-        _cleanupTmp(tmpDir, tmpFile).catch((cleanupErr) => {
-          console.debug("CodexLLMClient: _cleanupTmp failed (non-critical)", String(cleanupErr));
-        });
+        cleanupTmp();
         reject(new LLMError(`CodexLLMClient: spawn error — ${err.message}`));
       });
 
       child.on("close", (code: number | null) => {
-        clearTimeout(timeoutHandle);
+        clearTimers();
 
         if (timedOut) {
-          _cleanupTmp(tmpDir, tmpFile).catch((cleanupErr) => {
-            console.debug("CodexLLMClient: _cleanupTmp failed (non-critical)", String(cleanupErr));
-          });
+          cleanupTmp();
+          const timeoutLabel = timeoutReason === "idle" ? "idle timed out" : "request timed out";
           reject(
             new LLMError(
-              `CodexLLMClient: timed out after ${this.timeoutMs}ms`
+              `CodexLLMClient: ${timeoutLabel} after ${timeoutReason === "idle" ? this.idleTimeoutMs : this.totalTimeoutMs}ms`
             )
           );
           return;
         }
 
         if (code !== 0) {
-          _cleanupTmp(tmpDir, tmpFile).catch((cleanupErr) => {
-            console.debug("CodexLLMClient: _cleanupTmp failed (non-critical)", String(cleanupErr));
-          });
+          cleanupTmp();
           const detail = stderrData.trim() ? ` — ${stderrData.trim().slice(0, 500)}` : "";
           reject(
             new LLMError(
@@ -232,15 +277,11 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
         // Read response from temp file
         fsp.readFile(tmpFile, "utf-8")
           .then((raw) => {
-            _cleanupTmp(tmpDir, tmpFile).catch((cleanupErr) => {
-              console.debug("CodexLLMClient: _cleanupTmp failed (non-critical)", String(cleanupErr));
-            });
+            cleanupTmp();
             resolve(raw.trim());
           })
           .catch((readErr) => {
-            _cleanupTmp(tmpDir, tmpFile).catch((cleanupErr) => {
-              console.debug("CodexLLMClient: _cleanupTmp failed (non-critical)", String(cleanupErr));
-            });
+            cleanupTmp();
             reject(
               new LLMError(
                 `CodexLLMClient: failed to read output file — ${String(readErr)}`
@@ -250,6 +291,11 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
       });
     });
   }
+}
+
+function isRetryableCodexError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.includes("CodexLLMClient: spawn error");
 }
 
 // ─── Helpers ───

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -92,6 +92,15 @@ export interface ProviderConfig {
   /** CLI path for openai_codex_cli adapter */
   codex_cli_path?: string;
 
+  /** Total Codex request timeout in milliseconds. */
+  codex_timeout_ms?: number;
+
+  /** Codex idle timeout in milliseconds. Disabled when omitted. */
+  codex_idle_timeout_ms?: number;
+
+  /** Maximum Codex retry attempts. */
+  codex_retry_attempts?: number;
+
   /** Optional terminal backend for CLI execution adapters. */
   terminal_backend?: {
     type: "local" | "docker";
@@ -507,6 +516,9 @@ async function resolveProviderConfig(
   if (apiKey !== undefined) config.api_key = apiKey;
   if (baseUrl !== undefined) config.base_url = baseUrl;
   if (fileConfig.codex_cli_path !== undefined) config.codex_cli_path = fileConfig.codex_cli_path;
+  if (fileConfig.codex_timeout_ms !== undefined) config.codex_timeout_ms = fileConfig.codex_timeout_ms;
+  if (fileConfig.codex_idle_timeout_ms !== undefined) config.codex_idle_timeout_ms = fileConfig.codex_idle_timeout_ms;
+  if (fileConfig.codex_retry_attempts !== undefined) config.codex_retry_attempts = fileConfig.codex_retry_attempts;
   if (fileConfig.terminal_backend !== undefined) config.terminal_backend = fileConfig.terminal_backend;
   if (fileConfig.a2a !== undefined) config.a2a = fileConfig.a2a;
   if (lightModel !== undefined) config.light_model = lightModel;
@@ -533,6 +545,9 @@ function providerFileOnlyConfig(fileConfig: Partial<ProviderConfig>): ProviderCo
   if (fileConfig.api_key !== undefined) fileOnly.api_key = fileConfig.api_key;
   if (fileConfig.base_url !== undefined) fileOnly.base_url = fileConfig.base_url;
   if (fileConfig.codex_cli_path !== undefined) fileOnly.codex_cli_path = fileConfig.codex_cli_path;
+  if (fileConfig.codex_timeout_ms !== undefined) fileOnly.codex_timeout_ms = fileConfig.codex_timeout_ms;
+  if (fileConfig.codex_idle_timeout_ms !== undefined) fileOnly.codex_idle_timeout_ms = fileConfig.codex_idle_timeout_ms;
+  if (fileConfig.codex_retry_attempts !== undefined) fileOnly.codex_retry_attempts = fileConfig.codex_retry_attempts;
   if (fileConfig.terminal_backend !== undefined) fileOnly.terminal_backend = fileConfig.terminal_backend;
   if (fileConfig.a2a !== undefined) fileOnly.a2a = fileConfig.a2a;
   if (fileConfig.agent_loop !== undefined) fileOnly.agent_loop = fileConfig.agent_loop;
@@ -595,6 +610,9 @@ export async function getProviderRuntimeFingerprint(): Promise<string> {
     light_model: config.light_model ?? null,
     base_url: config.base_url ?? null,
     codex_cli_path: config.codex_cli_path ?? null,
+    codex_timeout_ms: config.codex_timeout_ms ?? null,
+    codex_idle_timeout_ms: config.codex_idle_timeout_ms ?? null,
+    codex_retry_attempts: config.codex_retry_attempts ?? null,
     terminal_backend: config.terminal_backend ?? null,
     api_key_hash: config.api_key
       ? createHash("sha256").update(config.api_key).digest("hex")

--- a/src/base/llm/provider-factory.ts
+++ b/src/base/llm/provider-factory.ts
@@ -49,6 +49,9 @@ export async function buildLLMClient(): Promise<ILLMClient> {
           cliPath: config.codex_cli_path,
           model: config.model,
           lightModel: config.light_model,
+          timeoutMs: config.codex_timeout_ms,
+          idleTimeoutMs: config.codex_idle_timeout_ms,
+          retryAttempts: config.codex_retry_attempts,
           sandboxPolicy: executionPolicy.sandboxMode === "danger_full_access" ? "danger-full-access" : executionPolicy.sandboxMode.replace("_", "-"),
         });
       }

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1505,6 +1505,29 @@ describe("ChatRunner", () => {
       expect(result.diagnostics).toBeUndefined();
     });
 
+    it("surfaces native agentloop failures through the chat path", async () => {
+      const adapter = makeMockAdapter();
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockResolvedValue({
+          success: false,
+          output: "Agent loop stopped: model request timed out. Narrow broad repo-wide searches or increase `codex_timeout_ms` if this workload is expected.",
+          error: "LLM timeout while waiting for the provider response",
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "timeout",
+        }),
+      } as unknown as ChatAgentLoopRunner;
+
+      const runner = new ChatRunner(makeDeps({ adapter, chatAgentLoopRunner }));
+      const result = await runner.execute("Please inspect the repo and report the issue.", "/repo");
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("timed out");
+      expect(result.output).toContain("codex_timeout_ms");
+      expect(result.output).not.toContain("[interrupted:");
+      expect(adapter.execute).not.toHaveBeenCalled();
+    });
+
     it("passes compacted chat summary to native chat agentloop", async () => {
       const adapter = makeMockAdapter();
       const chatAgentLoopRunner = {

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -17,6 +17,7 @@ import type { Task } from "../../../../base/types/task.js";
 import { makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
 import {
   BoundedAgentLoopRunner,
+  buildAgentLoopBaseInstructions,
   ILLMClientAgentLoopModelClient,
   InMemoryAgentLoopTraceStore,
   StaticAgentLoopModelRegistry,
@@ -271,6 +272,12 @@ describe("agentloop phase 0", () => {
     expect(modelClient).toBeInstanceOf(ILLMClientAgentLoopModelClient);
   });
 
+  it("adds a targeted-inspection guardrail to the chat base instructions", () => {
+    const prompt = buildAgentLoopBaseInstructions({ mode: "chat" });
+    expect(prompt).toContain("Start with targeted inspection first");
+    expect(prompt).toContain("avoid repo-wide glob or grep sweeps");
+  });
+
   it("parses explicit prompted tool-call JSON and preserves unknown tools for runtime feedback", () => {
     let id = 0;
     const calls = extractPromptedToolCalls({
@@ -493,6 +500,7 @@ describe("agentloop phase 1", () => {
     expect(llmCalls[0]?.options?.tools).toBeUndefined();
     expect(llmCalls[0]?.options?.system).toContain("You do not have native function/tool calling");
     expect(llmCalls[0]?.options?.system).toContain("Available tools:");
+    expect(llmCalls[0]?.options?.system).toContain("avoid repo-wide glob or grep sweeps");
     expect(llmCalls[1]?.messages.some((message) => message.role === "user" && message.content.startsWith("Tool result"))).toBe(true);
   });
 
@@ -571,6 +579,53 @@ describe("agentloop phase 1", () => {
 
     expect(result.success).toBe(false);
     expect(result.stopReason).toBe("stalled_tool_loop");
+  });
+
+  it("records a stopped trace with timeout details when the model call throws", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(): Promise<AgentLoopModelResponse> {
+        throw new Error("LLM timeout while waiting for the provider response");
+      },
+    };
+    const { router, runtime } = makeToolRuntime();
+    const runner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+    const session = createAgentLoopSession();
+
+    const result = await runner.run({
+      session,
+      turnId: "turn-timeout",
+      goalId: "goal-1",
+      cwd: process.cwd(),
+      model: modelInfo.ref,
+      modelInfo,
+      messages: [{ role: "user", content: "do it" }],
+      outputSchema: z.object({ status: z.literal("done"), finalAnswer: z.string() }),
+      budget: withDefaultBudget({ maxModelTurns: 4 }),
+      toolPolicy: {},
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.stopReason).toBe("timeout");
+    expect(result.finalText).toContain("timed out");
+    const events = await session.traceStore.list(session.traceId);
+    const stopped = events.at(-1);
+    expect(stopped).toMatchObject({
+      type: "stopped",
+      reason: "timeout",
+    });
+    expect(stopped).toHaveProperty("reasonDetail");
+    expect((stopped as { reasonDetail?: string }).reasonDetail).toContain("LLM timeout while waiting");
   });
 });
 

--- a/src/orchestrator/execution/agent-loop/agent-loop-events.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-events.ts
@@ -115,6 +115,7 @@ export interface AgentLoopFinalEvent extends AgentLoopBaseEvent {
 export interface AgentLoopStoppedEvent extends AgentLoopBaseEvent {
   type: "stopped";
   reason: string;
+  reasonDetail?: string;
 }
 
 export interface AgentLoopEventSink {

--- a/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
@@ -27,6 +27,7 @@ export interface AgentLoopSessionState {
   finalText: string;
   status: "running" | "completed" | "failed";
   stopReason?: AgentLoopStopReason;
+  stopDetail?: string;
   updatedAt: string;
 }
 
@@ -113,6 +114,7 @@ export function normalizeAgentLoopSessionState(value: unknown): AgentLoopSession
     finalText: typeof value["finalText"] === "string" ? value["finalText"] : "",
     status: statusField(value, "status"),
     ...(typeof value["stopReason"] === "string" ? { stopReason: value["stopReason"] as AgentLoopStopReason } : {}),
+    ...(typeof value["stopDetail"] === "string" ? { stopDetail: value["stopDetail"] } : {}),
     updatedAt: typeof value["updatedAt"] === "string" ? value["updatedAt"] : new Date(0).toISOString(),
   };
 }

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -63,27 +63,29 @@ export class BoundedAgentLoopRunner {
     }
 
     let messages: AgentLoopMessage[] = resumed?.messages ? [...resumed.messages] : [...turn.messages];
-    const preTurnCompaction = await this.compactIfNeeded(turn, messages, "pre_turn", "context_limit", undefined, compactions);
-    if (preTurnCompaction.error) {
-      return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, [], commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
-    }
-    messages = preTurnCompaction.messages;
-    compactions += preTurnCompaction.compacted ? 1 : 0;
-    await this.saveState(turn, messages, modelTurns, toolCalls, usage, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
 
-    while (true) {
-      if (Date.now() - startedAt > turn.budget.maxWallClockMs) {
-        return this.stop(turn, "timeout", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+    try {
+      const preTurnCompaction = await this.compactIfNeeded(turn, messages, "pre_turn", "context_limit", undefined, compactions);
+      if (preTurnCompaction.error) {
+        return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, [], commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
-      if (modelTurns >= turn.budget.maxModelTurns) {
-        return this.stop(turn, "max_model_turns", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
-      }
-      if (toolCalls >= turn.budget.maxToolCalls) {
-        return this.stop(turn, "max_tool_calls", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
-      }
-      if (turn.abortSignal?.aborted) {
-        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
-      }
+      messages = preTurnCompaction.messages;
+      compactions += preTurnCompaction.compacted ? 1 : 0;
+      await this.saveState(turn, messages, modelTurns, toolCalls, usage, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+
+      while (true) {
+        if (Date.now() - startedAt > turn.budget.maxWallClockMs) {
+          return this.stop(turn, "timeout", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        }
+        if (modelTurns >= turn.budget.maxModelTurns) {
+          return this.stop(turn, "max_model_turns", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        }
+        if (toolCalls >= turn.budget.maxToolCalls) {
+          return this.stop(turn, "max_tool_calls", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        }
+        if (turn.abortSignal?.aborted) {
+          return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, usage, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        }
 
       const tools = this.deps.toolRouter.modelVisibleTools(turn as AgentLoopTurnContext<unknown>);
       if (modelTurns === 0) {
@@ -314,7 +316,31 @@ export class BoundedAgentLoopRunner {
       }
       messages = compacted.messages;
       compactions += compacted.compacted ? 1 : 0;
-      await this.saveState(turn, messages, modelTurns, toolCalls, usage, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+        await this.saveState(turn, messages, modelTurns, toolCalls, usage, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+      }
+    } catch (err) {
+      const failure = this.classifyRunFailure(err);
+      const changedFiles = await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot);
+      return this.stop(
+        turn,
+        failure.reason,
+        startedAt,
+        modelTurns,
+        toolCalls,
+        usage,
+        failure.message,
+        null,
+        false,
+        compactions,
+        changedFiles,
+        commandResults,
+        messages,
+        calledTools,
+        lastToolLoopSignature,
+        repeatedToolLoopCount,
+        completionValidationAttempts,
+        failure.detail,
+      );
     }
   }
 
@@ -353,6 +379,7 @@ export class BoundedAgentLoopRunner {
     lastToolLoopSignature?: string | null,
     repeatedToolLoopCount?: number,
     completionValidationAttempts?: number,
+    reasonDetail?: string,
   ): Promise<AgentLoopResult<TOutput>> {
     await this.saveState(
       turn,
@@ -368,12 +395,14 @@ export class BoundedAgentLoopRunner {
       finalText,
       success ? "completed" : "failed",
       reason,
+      reasonDetail,
     );
 
     await this.record(turn, {
       type: "stopped",
       ...this.baseEvent(turn),
       reason,
+      ...(reasonDetail ? { reasonDetail } : {}),
     });
 
     return {
@@ -423,6 +452,28 @@ export class BoundedAgentLoopRunner {
   private async record<TOutput>(turn: AgentLoopTurnContext<TOutput>, event: Parameters<typeof turn.session.traceStore.append>[0]): Promise<void> {
     await turn.session.traceStore.append(event);
     await turn.session.eventSink.emit(event);
+  }
+
+  private classifyRunFailure(error: unknown): { reason: AgentLoopStopReason; detail: string; message: string } {
+    const detail = error instanceof Error
+      ? [error.name !== "Error" ? error.name : null, error.message]
+        .filter((part): part is string => typeof part === "string" && part.length > 0)
+        .join(": ")
+      : String(error);
+    const lowered = detail.toLowerCase();
+    const isTimeout = lowered.includes("timeout") || lowered.includes("timed out") || lowered.includes("aborterror") || lowered.includes("aborted");
+    if (isTimeout) {
+      return {
+        reason: "timeout",
+        detail,
+        message: "Agent loop stopped: model request timed out. Narrow broad repo-wide searches or increase `codex_timeout_ms` if this workload is expected.",
+      };
+    }
+    return {
+      reason: "fatal_error",
+      detail,
+      message: `Agent loop stopped: model request failed. ${detail ? `Detail: ${detail}. ` : ""}Retry the turn or inspect the provider connection.`,
+    };
   }
 
   private preview(value: string): string {
@@ -572,6 +623,7 @@ export class BoundedAgentLoopRunner {
     finalText: string,
     status: AgentLoopSessionState["status"],
     stopReason?: AgentLoopStopReason,
+    stopDetail?: string,
   ): Promise<void> {
     const state: AgentLoopSessionState = {
       sessionId: turn.session.sessionId,
@@ -593,6 +645,7 @@ export class BoundedAgentLoopRunner {
       finalText,
       status,
       ...(stopReason ? { stopReason } : {}),
+      ...(stopDetail ? { stopDetail } : {}),
       updatedAt: new Date().toISOString(),
     };
     await turn.session.stateStore.save(state);

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -116,106 +116,137 @@ export class ChatAgentLoopRunner {
       ...(input.eventSink ? { eventSink: input.eventSink } : {}),
       ...(input.resumeState ? { sessionId: input.resumeState.sessionId, traceId: input.resumeState.traceId } : {}),
     });
-    const result = await this.deps.boundedRunner.run({
-      session,
-      turnId,
-      goalId: input.goalId ?? "chat",
-      cwd,
-      model,
-      modelInfo,
-      ...(this.deps.defaultProfileName ? { profileName: this.deps.defaultProfileName } : {}),
-      ...(this.deps.defaultReasoningEffort ? { reasoningEffort: this.deps.defaultReasoningEffort } : {}),
-      loadPersistedState: input.resumeOnly || input.resumeState !== undefined,
-      messages: input.resumeOnly
-        ? []
-        : [
-            {
-              role: "system",
-              content: [
-                buildAgentLoopBaseInstructions({
-                  mode: "chat",
-                  extraRules: [
-                    "Use tools to answer the user and operate CoreLoop only through tools.",
-                    "Do not call CoreLoop internals directly.",
-                  ],
-                  role: input.role,
-                }),
-                input.systemPrompt?.trim() ? input.systemPrompt.trim() : "",
-              ].join("\n"),
-            },
-            ...(input.history ?? []).map((m) => ({ role: m.role, content: m.content })),
-            { role: "user" as const, content: input.message },
-          ],
-      outputSchema: ChatAgentLoopOutputSchema,
-      budget: withDefaultBudget({ ...this.deps.defaultBudget, ...input.budget }),
-      toolPolicy: { ...this.deps.defaultToolPolicy, ...input.toolPolicy },
-      ...(input.resumeState ? { resumeState: input.resumeState } : {}),
-      ...(this.deps.defaultExecutionPolicy ? { executionPolicy: this.deps.defaultExecutionPolicy } : {}),
-      toolCallContext: {
-        cwd,
+    try {
+      const result = await this.deps.boundedRunner.run({
+        session,
+        turnId,
         goalId: input.goalId ?? "chat",
-        trustBalance: 0,
-        preApproved: true,
-        approvalFn: input.approvalFn ?? (async () => false),
-        onApprovalRequested: async (request) => {
-          await input.eventSink?.emit({
-            type: "approval_request",
-            eventId: randomUUID(),
-            sessionId: session.sessionId,
-            traceId: session.traceId,
-            turnId,
-            goalId: input.goalId ?? "chat",
-            createdAt: new Date().toISOString(),
-            callId: request.callId ?? `approval:${turnId}`,
-            toolName: request.toolName,
-            reason: request.reason,
-            permissionLevel: request.permissionLevel,
-            isDestructive: request.isDestructive,
-          });
+        cwd,
+        model,
+        modelInfo,
+        ...(this.deps.defaultProfileName ? { profileName: this.deps.defaultProfileName } : {}),
+        ...(this.deps.defaultReasoningEffort ? { reasoningEffort: this.deps.defaultReasoningEffort } : {}),
+        loadPersistedState: input.resumeOnly || input.resumeState !== undefined,
+        messages: input.resumeOnly
+          ? []
+          : [
+              {
+                role: "system",
+                content: [
+                  buildAgentLoopBaseInstructions({
+                    mode: "chat",
+                    extraRules: [
+                      "Use tools to answer the user and operate CoreLoop only through tools.",
+                      "Do not call CoreLoop internals directly.",
+                    ],
+                    role: input.role,
+                  }),
+                  input.systemPrompt?.trim() ? input.systemPrompt.trim() : "",
+                ].join("\n"),
+              },
+              ...(input.history ?? []).map((m) => ({ role: m.role, content: m.content })),
+              { role: "user" as const, content: input.message },
+            ],
+        outputSchema: ChatAgentLoopOutputSchema,
+        budget: withDefaultBudget({ ...this.deps.defaultBudget, ...input.budget }),
+        toolPolicy: { ...this.deps.defaultToolPolicy, ...input.toolPolicy },
+        ...(input.resumeState ? { resumeState: input.resumeState } : {}),
+        ...(this.deps.defaultExecutionPolicy ? { executionPolicy: this.deps.defaultExecutionPolicy } : {}),
+        toolCallContext: {
+          cwd,
+          goalId: input.goalId ?? "chat",
+          trustBalance: 0,
+          preApproved: true,
+          approvalFn: input.approvalFn ?? (async () => false),
+          onApprovalRequested: async (request) => {
+            await input.eventSink?.emit({
+              type: "approval_request",
+              eventId: randomUUID(),
+              sessionId: session.sessionId,
+              traceId: session.traceId,
+              turnId,
+              goalId: input.goalId ?? "chat",
+              createdAt: new Date().toISOString(),
+              callId: request.callId ?? `approval:${turnId}`,
+              toolName: request.toolName,
+              reason: request.reason,
+              permissionLevel: request.permissionLevel,
+              isDestructive: request.isDestructive,
+            });
+          },
+          ...this.deps.defaultToolCallContext,
+          ...input.toolCallContext,
+          agentRole: input.role,
         },
-        ...this.deps.defaultToolCallContext,
-        ...input.toolCallContext,
-        agentRole: input.role,
-      },
-    });
+      });
 
-    const success = result.success && result.output?.status === "done";
-    const hadApprovalDeniedError = result.commandResults.some((entry) =>
-      /approval denied|user denied approval|requires approval/i.test(entry.outputSummary),
-    );
-    const fallbackOutput = success
-      ? this.buildSuccessfulOutput(result.finalText, result.output)
-      : this.buildFailureOutput(result.stopReason, hadApprovalDeniedError, result.finalText, result.output, result.output?.blockers);
-    return {
-      success,
-      output: fallbackOutput,
-      error: success ? null : result.output?.blockers.join("; ") || result.stopReason,
-      exit_code: null,
-      elapsed_ms: Date.now() - started,
-      stopped_reason: success ? "completed" : result.stopReason === "timeout" ? "timeout" : "error",
-      agentLoop: {
-        traceId: result.traceId,
-        sessionId: result.sessionId,
-        turnId: result.turnId,
-        stopReason: result.stopReason,
-        modelTurns: result.modelTurns,
-        toolCalls: result.toolCalls,
-        usage: result.usage,
-        compactions: result.compactions,
-        ...(result.profileName ? { profileName: result.profileName } : {}),
-        ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),
-        completionEvidence: result.output?.evidence ?? [],
-        verificationHints: result.output?.blockers ?? [],
-        filesChangedPaths: result.changedFiles,
-        ...(result.executionPolicy
-          ? {
-              sandboxMode: result.executionPolicy.sandboxMode,
-              approvalPolicy: result.executionPolicy.approvalPolicy,
-              networkAccess: result.executionPolicy.networkAccess,
-            }
-          : {}),
-      },
-    };
+      const success = result.success && result.output?.status === "done";
+      const hadApprovalDeniedError = result.commandResults.some((entry) =>
+        /approval denied|user denied approval|requires approval/i.test(entry.outputSummary),
+      );
+      const fallbackOutput = success
+        ? this.buildSuccessfulOutput(result.finalText, result.output)
+        : this.buildFailureOutput(result.stopReason, hadApprovalDeniedError, result.finalText, result.output, result.output?.blockers);
+      return {
+        success,
+        output: fallbackOutput,
+        error: success ? null : result.output?.blockers.join("; ") || result.stopReason,
+        exit_code: null,
+        elapsed_ms: Date.now() - started,
+        stopped_reason: success ? "completed" : result.stopReason === "timeout" ? "timeout" : "error",
+        agentLoop: {
+          traceId: result.traceId,
+          sessionId: result.sessionId,
+          turnId: result.turnId,
+          stopReason: result.stopReason,
+          modelTurns: result.modelTurns,
+          toolCalls: result.toolCalls,
+          usage: result.usage,
+          compactions: result.compactions,
+          ...(result.profileName ? { profileName: result.profileName } : {}),
+          ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),
+          completionEvidence: result.output?.evidence ?? [],
+          verificationHints: result.output?.blockers ?? [],
+          filesChangedPaths: result.changedFiles,
+          ...(result.executionPolicy
+            ? {
+                sandboxMode: result.executionPolicy.sandboxMode,
+                approvalPolicy: result.executionPolicy.approvalPolicy,
+                networkAccess: result.executionPolicy.networkAccess,
+              }
+            : {}),
+        },
+      };
+    } catch (err) {
+      const detail = err instanceof Error
+        ? [err.name !== "Error" ? err.name : null, err.message].filter((part): part is string => typeof part === "string" && part.length > 0).join(": ")
+        : String(err);
+      const lowered = detail.toLowerCase();
+      const isTimeout = lowered.includes("timeout") || lowered.includes("timed out") || lowered.includes("aborterror") || lowered.includes("aborted");
+      const output = isTimeout
+        ? "Agent loop stopped: model request timed out. Narrow broad repo-wide searches or increase `codex_timeout_ms` if this workload is expected."
+        : `Agent loop stopped: model request failed. ${detail ? `Detail: ${detail}. ` : ""}Retry the turn or inspect the provider connection.`;
+      return {
+        success: false,
+        output,
+        error: detail || output,
+        exit_code: null,
+        elapsed_ms: Date.now() - started,
+        stopped_reason: isTimeout ? "timeout" : "error",
+        agentLoop: {
+          traceId: session.traceId,
+          sessionId: session.sessionId,
+          turnId,
+          stopReason: isTimeout ? "timeout" : "fatal_error",
+          modelTurns: 0,
+          toolCalls: 0,
+          compactions: 0,
+          completionEvidence: [],
+          verificationHints: [],
+          filesChangedPaths: [],
+        },
+      };
+    }
   }
 
   private buildSuccessfulOutput(finalText: string, output?: ChatAgentLoopOutput | null): string {

--- a/src/orchestrator/execution/agent-loop/prompted-tool-protocol.ts
+++ b/src/orchestrator/execution/agent-loop/prompted-tool-protocol.ts
@@ -26,6 +26,7 @@ export function buildPromptedToolProtocolSystemPrompt(input: {
     "If you need to call tools, return exactly one JSON object and nothing else.",
     'For one tool, use { "tool": "<name>", "input": { ... } } or { "tool_call": { "name": "<name>", "input": { ... } } }.',
     'For multiple tools, use { "tool_calls": [{ "name": "<name>", "input": { ... } }] }.',
+    "When you need repository context, inspect the narrowest likely files first; avoid repo-wide glob or grep sweeps unless they are truly necessary.",
     "Only use tool names listed below.",
     "Available tools:",
     toolDefinitions,


### PR DESCRIPTION
## Summary
- make Codex CLI timeout/retry behavior configurable and raise the default request timeout for medium chat tasks
- always emit a final native agent-loop stopped event with reason details when model calls throw
- nudge the agent-loop toward targeted inspection before repo-wide glob/grep sweeps and add regressions for timeout propagation/chat failures

## Testing
- npm test -- --run src/base/llm/__tests__/codex-llm-client.test.ts src/base/llm/__tests__/provider-config.test.ts src/base/llm/__tests__/provider-factory.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/interface/chat/__tests__/chat-runner.test.ts
- npm test -- --run src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts