### PR TITLE
feat(chat): optimize medium-task chat output

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -34,8 +34,8 @@ describe("applyChatEventToMessages", () => {
     });
   });
 
-  it("does not add separate chat rows for raw tool events", () => {
-    const messages = applyChatEventToMessages([], {
+  it("keeps tool progress visible as one updatable row per tool call", () => {
+    const started = applyChatEventToMessages([], {
       type: "tool_start",
       runId: "run-1",
       turnId: "turn-1",
@@ -45,7 +45,44 @@ describe("applyChatEventToMessages", () => {
       args: { pattern: "ChatEvent" },
     }, 20);
 
-    expect(messages).toEqual([]);
+    const running = applyChatEventToMessages(started, {
+      type: "tool_update",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      toolCallId: "tool-1",
+      toolName: "grep",
+      status: "running",
+      message: "started",
+    }, 20);
+
+    expect(running).toHaveLength(1);
+    expect(running[0]!).toMatchObject({
+      id: "tool:turn-1:tool-1",
+      role: "pulseed",
+      text: "Running tool: grep",
+      messageType: "info",
+      transient: true,
+    });
+
+    const finished = applyChatEventToMessages(running, {
+      type: "tool_end",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:02.000Z",
+      toolCallId: "tool-1",
+      toolName: "grep",
+      success: true,
+      summary: "2 matches",
+      durationMs: 50,
+    }, 20);
+
+    expect(finished).toHaveLength(1);
+    expect(finished[0]!).toMatchObject({
+      id: "tool:turn-1:tool-1",
+      text: "Finished tool: grep - 2 matches",
+      messageType: "success",
+    });
   });
 
   it("removes transient activity when assistant final arrives", () => {
@@ -121,6 +158,71 @@ describe("applyChatEventToMessages", () => {
     }, 20);
 
     expect(afterEnd).toEqual([]);
+  });
+
+  it("removes transient tool progress on lifecycle end", () => {
+    const withToolProgress = applyChatEventToMessages([], {
+      type: "tool_update",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      toolCallId: "tool-1",
+      toolName: "grep",
+      status: "running",
+      message: "Reading files",
+    }, 20);
+
+    const afterEnd = applyChatEventToMessages(withToolProgress, {
+      type: "lifecycle_end",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      status: "completed",
+      elapsedMs: 1000,
+      persisted: true,
+    }, 20);
+
+    expect(afterEnd).toEqual([]);
+  });
+
+  it("keeps other in-flight tool rows when one tool finishes", () => {
+    const withFirstTool = applyChatEventToMessages([], {
+      type: "tool_update",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      toolCallId: "tool-1",
+      toolName: "grep",
+      status: "running",
+      message: "Reading files",
+    }, 20);
+
+    const withSecondTool = applyChatEventToMessages(withFirstTool, {
+      type: "tool_update",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      toolCallId: "tool-2",
+      toolName: "glob",
+      status: "running",
+      message: "Finding files",
+    }, 20);
+
+    const afterFirstEnd = applyChatEventToMessages(withSecondTool, {
+      type: "tool_end",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:02.000Z",
+      toolCallId: "tool-1",
+      toolName: "grep",
+      success: true,
+      summary: "2 matches",
+      durationMs: 50,
+    }, 20);
+
+    expect(afterFirstEnd).toHaveLength(2);
+    expect(afterFirstEnd.some((message) => message.id === "tool:turn-1:tool-1" && message.text.includes("Finished tool: grep"))).toBe(true);
+    expect(afterFirstEnd.some((message) => message.id === "tool:turn-1:tool-2" && message.text.includes("glob: Finding files"))).toBe(true);
   });
 
   it("keeps non-transient activity rows after turn-ending events", () => {

--- a/src/interface/chat/__tests__/chat-grounding.test.ts
+++ b/src/interface/chat/__tests__/chat-grounding.test.ts
@@ -127,6 +127,14 @@ describe("buildSystemPrompt (grounding.ts)", () => {
     expect(prompt.length).toBeGreaterThan(0);
   });
 
+  it("biases final answers toward concise structured markdown", async () => {
+    const sm = makeMockStateManager();
+    const prompt = await buildSystemPrompt({ stateManager: sm, homeDir: tmpDir });
+
+    expect(prompt).toContain("concise structured markdown");
+    expect(prompt).toContain("short headings and bullets");
+  });
+
   it("aligns default identity text with direct tool execution", async () => {
     const sm = makeMockStateManager();
     const prompt = await buildSystemPrompt({ stateManager: sm, homeDir: tmpDir });

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -1,4 +1,9 @@
-import type { ChatEvent } from "./chat-events.js";
+import type {
+  ChatEvent,
+  ToolEndEvent,
+  ToolStartEvent,
+  ToolUpdateEvent,
+} from "./chat-events.js";
 
 export interface StreamChatMessage {
   id: string;
@@ -28,7 +33,56 @@ function removeTransientActivityForTurn(
   turnId: string
 ): StreamChatMessage[] {
   const transientActivityId = `activity:${turnId}`;
-  return messages.filter((message) => !(message.id === transientActivityId && message.transient));
+  const transientToolPrefix = `tool:${turnId}:`;
+  return messages.filter((message) => {
+    if (!message.transient) {
+      return true;
+    }
+    return !(
+      message.id === transientActivityId ||
+      message.id.startsWith(transientToolPrefix)
+    );
+  });
+}
+
+function buildToolMessage(
+  event: ToolStartEvent | ToolUpdateEvent | ToolEndEvent,
+): StreamChatMessage {
+  const id = `tool:${event.turnId}:${event.toolCallId}`;
+  if (event.type === "tool_start") {
+    return {
+      id,
+      role: "pulseed",
+      text: `Running tool: ${event.toolName}`,
+      timestamp: new Date(event.createdAt),
+      messageType: "info",
+      transient: true,
+    };
+  }
+
+  if (event.type === "tool_update") {
+    const transient = event.status !== "result";
+    const messageType = event.status === "awaiting_approval" ? "warning" : "info";
+    const text = event.status === "running" && event.message === "started"
+      ? `Running tool: ${event.toolName}`
+      : `${event.toolName}: ${event.message}`;
+    return {
+      id,
+      role: "pulseed",
+      text,
+      timestamp: new Date(event.createdAt),
+      messageType,
+      transient,
+    };
+  }
+
+  return {
+    id,
+    role: "pulseed",
+    text: `${event.success ? "Finished" : "Failed"} tool: ${event.toolName}${event.summary ? ` - ${event.summary}` : ""}`,
+    timestamp: new Date(event.createdAt),
+    messageType: event.success ? "success" : "error",
+  };
 }
 
 export function applyChatEventToMessages(
@@ -70,6 +124,10 @@ export function applyChatEventToMessages(
     }, maxMessages);
   }
 
+  if (event.type === "tool_start" || event.type === "tool_update" || event.type === "tool_end") {
+    return upsertMessage(messages, buildToolMessage(event), maxMessages);
+  }
+
   if (event.type === "lifecycle_error") {
     const next = removeTransientActivityForTurn(messages, event.turnId);
     const messageId = event.partialText ? event.turnId : `error:${event.runId}`;
@@ -87,18 +145,6 @@ export function applyChatEventToMessages(
 
   if (event.type === "lifecycle_end") {
     return removeTransientActivityForTurn(messages, event.turnId);
-  }
-
-  if (event.type === "tool_start") {
-    return messages;
-  }
-
-  if (event.type === "tool_update") {
-    return messages;
-  }
-
-  if (event.type === "tool_end") {
-    return messages;
   }
 
   return messages;

--- a/src/interface/chat/grounding.ts
+++ b/src/interface/chat/grounding.ts
@@ -83,6 +83,7 @@ function buildExecutionBiasSection(): string {
     "- Prefer direct local tool use for routine reads, edits, diffs, and verification.",
     "- Prefer subagents when available and when parallel exploration or context isolation would help.",
     "- Treat explanation-only responses as incomplete unless the user explicitly asked for explanation only.",
+    "- For final user-facing answers, prefer concise structured markdown with short headings and bullets instead of long prose.",
   ].join("\n");
 }
 
@@ -104,6 +105,8 @@ function buildCommunicationPolicySection(): string {
     "- Do not give long preambles before routine tool calls.",
     "- Prefer action first, then concise reporting.",
     "- Progress updates should be brief and relevant.",
+    "- Prefer short markdown paragraphs or flat bullets instead of one long block of prose.",
+    "- Keep diagnostics and raw internal metadata out of normal user-facing answers unless the user asks for them.",
     "- Do not narrate internal process details at length unless they matter to the user's decision.",
   ].join("\n");
 }

--- a/src/interface/chat/grounding.ts
+++ b/src/interface/chat/grounding.ts
@@ -105,7 +105,7 @@ function buildCommunicationPolicySection(): string {
     "- Do not give long preambles before routine tool calls.",
     "- Prefer action first, then concise reporting.",
     "- Progress updates should be brief and relevant.",
-    "- Prefer short markdown paragraphs or flat bullets instead of one long block of prose.",
+    "- Prefer concise structured markdown with short headings and bullets instead of one long block of prose.",
     "- Keep diagnostics and raw internal metadata out of normal user-facing answers unless the user asks for them.",
     "- Do not narrate internal process details at length unless they matter to the user's decision.",
   ].join("\n");

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -12,7 +12,13 @@ import {
   stripMouseEscapeSequences,
 } from "../chat.js";
 import { renderProcessingRow } from "../fullscreen-chat.js";
-import { estimateMarkdownHeight, estimateWrappedLineCount, wrapTextToRows } from "../markdown-renderer.js";
+import {
+  estimateMarkdownHeight,
+  estimateWrappedLineCount,
+  renderMarkdownLines,
+  splitMarkdownLineToRows,
+  wrapTextToRows,
+} from "../markdown-renderer.js";
 import { extractBashCommand, isBashModeInput, isSafeBashCommand, createShellApprovalTask, formatShellOutput } from "../bash-mode.js";
 import {
   CARET_MARKER,
@@ -108,6 +114,21 @@ describe("markdown sizing helpers", () => {
 });
 
 describe("chat viewport", () => {
+  it("preserves inline markdown segments through viewport rows", () => {
+    const rows = buildChatViewport([
+      {
+        id: "m1",
+        role: "pulseed" as const,
+        text: "Hello **world**",
+        timestamp: new Date(),
+      },
+    ], 80, 8, 0).rows;
+
+    const messageRow = rows.find((row) => row.kind === "pulseed");
+    expect(messageRow?.segments).toBeDefined();
+    expect(messageRow?.segments?.some((segment) => segment.bold === true)).toBe(true);
+  });
+
   it("keeps earlier rows available when scrolling back", () => {
     const messages = [
       {
@@ -137,6 +158,26 @@ describe("chat viewport", () => {
     const scrolled = buildChatViewport(messages, 40, 8, 3);
     expect(scrolled.hiddenAboveRows).toBe(0);
     expect(scrolled.rows.some((row) => row.text.trim() === "line 1")).toBe(true);
+  });
+});
+
+describe("markdown row wrapping", () => {
+  it("keeps inline segments attached when a styled line wraps", () => {
+    const rows = splitMarkdownLineToRows({
+      text: "hello **world**",
+      segments: [
+        { text: "hello " },
+        { text: "world", bold: true },
+      ],
+    }, 6);
+
+    expect(rows.some((row) => row.segments?.some((segment) => segment.bold === true))).toBe(true);
+  });
+
+  it("renders local markdown links as repo-relative paths", () => {
+    const [line] = renderMarkdownLines("[runner](/Users/yuyoshimuta/Documents/dev/SeedPulse-output-opt/src/interface/chat/chat-runner.ts:12)");
+
+    expect(line?.text).toContain("src/interface/chat/chat-runner.ts:12");
   });
 });
 

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -179,6 +179,12 @@ describe("markdown row wrapping", () => {
 
     expect(line?.text).toContain("src/interface/chat/chat-runner.ts:12");
   });
+
+  it("renders local markdown links with parentheses and titles as paths", () => {
+    const [line] = renderMarkdownLines("[spec](/Users/yuyoshimuta/Documents/dev/SeedPulse-output-opt/docs/Design (draft).md:8 \"draft\")");
+
+    expect(line?.text).toContain("docs/Design (draft).md:8");
+  });
 });
 
 describe("composer sizing", () => {

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -523,22 +523,47 @@ export function Chat({
               );
             }
 
+            if (row.kind === "user") {
+              return (
+                <Box key={row.key} paddingX={row.paddingX ?? 0}>
+                  <Text
+                    color={row.color}
+                    backgroundColor={row.backgroundColor}
+                    bold={row.bold}
+                    dimColor={row.dim}
+                    italic={row.italic}
+                  >
+                    {row.text}
+                  </Text>
+                </Box>
+              );
+            }
+
+            if (row.segments && row.segments.length > 0) {
+              return (
+                <Box key={row.key} marginLeft={row.marginLeft ?? 0}>
+                  {row.segments.map((segment, index) => (
+                    <Text
+                      key={`${row.key}-${index}`}
+                      color={segment.color ?? (segment.code ? theme.codeInline : row.color)}
+                      backgroundColor={row.backgroundColor}
+                      bold={segment.bold ?? row.bold}
+                      dimColor={row.dim}
+                      italic={segment.italic ?? row.italic}
+                    >
+                      {segment.text}
+                    </Text>
+                  ))}
+                </Box>
+              );
+            }
+
             const text = row.text;
             const textProps: Record<string, unknown> = {};
             if (row.color) textProps.color = row.color;
             if (row.bold) textProps.bold = true;
             if (row.dim) textProps.dimColor = true;
             if (row.italic) textProps.italic = true;
-
-            if (row.kind === "user") {
-              return (
-                <Box key={row.key} paddingX={row.paddingX ?? 0}>
-                  <Text {...textProps} backgroundColor={row.backgroundColor}>
-                    {text}
-                  </Text>
-                </Box>
-              );
-            }
 
             return (
               <Box key={row.key} marginLeft={row.marginLeft ?? 0}>

--- a/src/interface/tui/chat/types.ts
+++ b/src/interface/tui/chat/types.ts
@@ -1,3 +1,5 @@
+import type { MarkdownSegment } from "../markdown-renderer.js";
+
 export interface ChatMessage {
   id: string;
   role: "user" | "pulseed";
@@ -10,6 +12,7 @@ export interface ChatDisplayRow {
   key: string;
   kind: "user" | "pulseed" | "spacer";
   text: string;
+  segments?: MarkdownSegment[];
   color?: string;
   backgroundColor?: string;
   bold?: boolean;

--- a/src/interface/tui/chat/viewport.ts
+++ b/src/interface/tui/chat/viewport.ts
@@ -45,6 +45,7 @@ function buildMessageRows(msg: ChatMessage, width: number): ChatDisplayRow[] {
         key: `${msg.id}:pulseed:${lineIndex}:${rowIndex}`,
         kind: "pulseed",
         text: wrappedLine.text,
+        segments: wrappedLine.segments,
         color: typeColor,
         bold: wrappedLine.bold,
         dim: wrappedLine.dim,

--- a/src/interface/tui/fullscreen-chat.tsx
+++ b/src/interface/tui/fullscreen-chat.tsx
@@ -52,6 +52,7 @@ type RenderSegment = {
   backgroundColor?: string;
   bold?: boolean;
   dim?: boolean;
+  italic?: boolean;
 };
 
 type RenderLine = {
@@ -66,6 +67,7 @@ type RenderLine = {
   backgroundColor?: string;
   bold?: boolean;
   dim?: boolean;
+  italic?: boolean;
   protected?: boolean;
 };
 
@@ -575,6 +577,29 @@ function buildComposerLines(args: {
 function renderMessageRow(row: ChatDisplayRow, cols: number): RenderLine {
   if (row.kind === "spacer") {
     return { key: row.key, text: " ".repeat(cols) };
+  }
+
+  if (row.segments && row.segments.length > 0) {
+    const segments: RenderSegment[] = [];
+    for (const segment of row.segments) {
+      segments.push({
+        text: segment.text,
+        color: segment.color ?? (segment.code ? theme.codeInline : row.color),
+        backgroundColor: row.backgroundColor,
+        bold: segment.bold ?? row.bold,
+        dim: row.dim,
+        italic: segment.italic ?? row.italic,
+      });
+    }
+
+    return {
+      key: row.key,
+      segments,
+      color: row.color,
+      backgroundColor: row.backgroundColor,
+      bold: row.bold,
+      dim: row.dim,
+    };
   }
 
   return {
@@ -1161,6 +1186,7 @@ export function FullscreenChat({
                 backgroundColor={segment.backgroundColor ?? line.backgroundColor}
                 bold={segment.bold ?? line.bold}
                 dimColor={segment.dim ?? line.dim}
+                italic={segment.italic ?? line.italic}
               >
                 {index === 0 && line.protected
                   ? `${PROTECTED_ROW_MARKER}${segment.text}`

--- a/src/interface/tui/markdown-renderer.ts
+++ b/src/interface/tui/markdown-renderer.ts
@@ -342,7 +342,7 @@ function prependText(prefix: string, segs: MarkdownSegment[]): MarkdownSegment[]
 export function parseInlineSegments(text: string): MarkdownSegment[] {
   const segments: MarkdownSegment[] = [];
   // Pattern: bold+italic (***), bold (**/__), italic (*/_), code (`), link ([text](url))
-  const pattern = /(\*{3}.+?\*{3}|\*{2}.+?\*{2}|_{2}.+?_{2}|\*.+?\*|_.+?_|`[^`]+`|\[.+?\]\(.+?\))/g;
+  const pattern = /(\*{3}.+?\*{3}|\*{2}.+?\*{2}|_{2}.+?_{2}|\*.+?\*|_.+?_|`[^`]+`|\[[^\]]+\]\((?:[^()]|\([^)]*\))+(?:\s+"[^"]*")?\))/g;
   let lastIndex = 0;
   let m: RegExpExecArray | null;
 
@@ -365,7 +365,7 @@ export function parseInlineSegments(text: string): MarkdownSegment[] {
                (raw.startsWith('_') && raw.endsWith('_'))) {
       segments.push({ text: raw.slice(1, -1), italic: true });
     } else if (raw.startsWith('[')) {
-      const linkMatch = raw.match(/^\[(.+?)\]\((.+?)\)$/);
+      const linkMatch = raw.match(/^\[(.+?)\]\(((?:[^()]|\([^)]*\))+?)(?:\s+"[^"]*")?\)$/);
       const label = linkMatch?.[1] ?? raw;
       const destination = linkMatch?.[2] ?? "";
       segments.push({

--- a/src/interface/tui/markdown-renderer.ts
+++ b/src/interface/tui/markdown-renderer.ts
@@ -8,6 +8,8 @@
 // Instead, we do lightweight manual conversion that produces clean text
 // which Ink can properly measure and render.
 
+import * as os from "node:os";
+import * as path from "node:path";
 import { theme } from "./theme.js";
 
 export interface MarkdownSegment {
@@ -96,15 +98,119 @@ export function estimateWrappedLineCount(text: string, width: number): number {
 
 /**
  * Expand a rendered markdown line into terminal rows at the given width.
- * Line-level style is preserved, but inline segment styling is flattened on wrapped rows.
+ * Inline segment styling is preserved on wrapped rows.
  */
 export function splitMarkdownLineToRows(line: MarkdownLine, width: number): MarkdownLine[] {
-  return wrapTextToRows(line.text, width).map((text) => ({
-    text,
-    bold: line.bold,
-    dim: line.dim,
-    italic: line.italic,
-  }));
+  if (!line.segments || line.segments.length === 0) {
+    return wrapTextToRows(line.text, width).map((text) => ({
+      text,
+      bold: line.bold,
+      dim: line.dim,
+      italic: line.italic,
+    }));
+  }
+
+  const safeWidth = Math.max(1, Math.floor(width));
+  const rows: MarkdownLine[] = [];
+  let currentSegments: MarkdownSegment[] = [];
+  let currentText = "";
+  let currentWidth = 0;
+
+  const pushRow = (): void => {
+    rows.push({
+      text: currentText,
+      bold: line.bold,
+      dim: line.dim,
+      italic: line.italic,
+      segments: currentSegments.length > 0 ? currentSegments : undefined,
+      language: line.language,
+    });
+    currentSegments = [];
+    currentText = "";
+    currentWidth = 0;
+  };
+
+  const appendPiece = (piece: string, segment: MarkdownSegment): void => {
+    if (!piece) return;
+    const last = currentSegments[currentSegments.length - 1];
+    if (
+      last &&
+      last.bold === segment.bold &&
+      last.code === segment.code &&
+      last.italic === segment.italic &&
+      last.color === segment.color
+    ) {
+      last.text += piece;
+      currentText += piece;
+      return;
+    }
+
+    const nextSegment: MarkdownSegment = { ...segment, text: piece };
+    currentSegments.push(nextSegment);
+    currentText += piece;
+  };
+
+  const piecesFor = (text: string): string[] => {
+    if (text === "") {
+      return [""];
+    }
+    return WORD_SEGMENTER
+      ? Array.from(WORD_SEGMENTER.segment(text), (segment) => segment.segment)
+      : text.match(/\S+\s*|\s+/g) ?? [text];
+  };
+
+  for (const segment of line.segments) {
+    const pieces = piecesFor(segment.text);
+    for (const piece of pieces) {
+      if (!piece) continue;
+
+      if (piece.length > safeWidth) {
+        if (currentWidth > 0) {
+          pushRow();
+        }
+        for (let index = 0; index < piece.length; index += safeWidth) {
+          rows.push({
+            text: piece.slice(index, index + safeWidth),
+            bold: line.bold,
+            dim: line.dim,
+            italic: line.italic,
+            segments: [{ ...segment, text: piece.slice(index, index + safeWidth) }],
+            language: line.language,
+          });
+        }
+        continue;
+      }
+
+      if (currentWidth + piece.length > safeWidth && currentWidth > 0) {
+        pushRow();
+      }
+
+      const rowPiece = currentWidth === 0 ? piece : piece.trimStart();
+      if (!rowPiece) {
+        continue;
+      }
+
+      appendPiece(rowPiece, segment);
+      currentWidth += rowPiece.length;
+
+      if (currentWidth >= safeWidth) {
+        pushRow();
+      }
+    }
+  }
+
+  if (currentWidth > 0 || rows.length === 0) {
+    rows.push({
+      text: currentText,
+      bold: line.bold,
+      dim: line.dim,
+      italic: line.italic,
+      segments: currentSegments.length > 0 ? currentSegments : undefined,
+      language: line.language,
+    });
+  }
+
+  return rows;
 }
 
 /**
@@ -259,9 +365,13 @@ export function parseInlineSegments(text: string): MarkdownSegment[] {
                (raw.startsWith('_') && raw.endsWith('_'))) {
       segments.push({ text: raw.slice(1, -1), italic: true });
     } else if (raw.startsWith('[')) {
-      // Link: [text](url) -> just show text
-      const linkMatch = raw.match(/^\[(.+?)\]/);
-      segments.push({ text: linkMatch ? linkMatch[1] : raw });
+      const linkMatch = raw.match(/^\[(.+?)\]\((.+?)\)$/);
+      const label = linkMatch?.[1] ?? raw;
+      const destination = linkMatch?.[2] ?? "";
+      segments.push({
+        text: renderMarkdownLinkText(label, destination),
+        color: theme.info,
+      });
     } else {
       segments.push({ text: raw });
     }
@@ -275,6 +385,42 @@ export function parseInlineSegments(text: string): MarkdownSegment[] {
   }
 
   return segments.length > 0 ? segments : [{ text }];
+}
+
+function renderMarkdownLinkText(label: string, destination: string): string {
+  if (!destination || !isLocalPathLikeLink(destination)) {
+    return label;
+  }
+
+  return shortenLocalPath(destination.replace(/^file:\/\//, ""));
+}
+
+function isLocalPathLikeLink(destination: string): boolean {
+  return destination.startsWith("/")
+    || destination.startsWith("./")
+    || destination.startsWith("../")
+    || destination.startsWith("~/")
+    || destination.startsWith("file://");
+}
+
+function shortenLocalPath(destination: string): string {
+  if (destination.startsWith("~/")) {
+    return destination;
+  }
+
+  const homeDir = os.homedir();
+  if (destination.startsWith(homeDir)) {
+    return `~/${destination.slice(homeDir.length + 1)}`;
+  }
+
+  if (path.isAbsolute(destination)) {
+    const relative = path.relative(process.cwd(), destination);
+    if (relative && !relative.startsWith("..")) {
+      return relative;
+    }
+  }
+
+  return destination;
 }
 
 // ─── Code Syntax Highlighting ───

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
@@ -521,7 +521,7 @@ describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () =>
 
     expect(result.success).toBe(true);
     expect(result.output).toContain("Goal is running");
-    expect(result.output).toContain("Evidence:");
+    expect(result.output).toContain("### Evidence");
     expect(modelClient.calls[1].messages.some((m) => m.role === "tool" && m.toolName === "core_goal_status")).toBe(true);
   });
 
@@ -569,7 +569,7 @@ describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () =>
 
     expect(result.success).toBe(true);
     expect(result.output).toContain("approved path");
-    expect(result.output).toContain("Evidence:");
+    expect(result.output).toContain("### Evidence");
     expect(events.some((event) => event.type === "approval_request" && event.toolName === "approval_tool")).toBe(true);
     expect(modelClient.calls[1].messages.some((m) => m.role === "tool" && m.toolName === "approval_tool")).toBe(true);
   });
@@ -693,10 +693,52 @@ describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () =>
     const result = await chat.execute({ message: "何ができるの？" });
 
     expect(result.success).toBe(true);
-    expect(result.output).toContain("この環境でできること");
-    expect(result.output).toContain("Capabilities:");
+    expect(result.output.startsWith("この環境でできること")).toBe(true);
+    expect(result.output).toContain("### Capabilities");
     expect(result.output).toContain("- コードを読む");
-    expect(result.output).toContain("Next step:");
+    expect(result.output).toContain("### Next step");
+    expect(result.output).toContain("- 必要なら実装方針を作成する");
+  });
+
+  it("renders nested finalAnswer summaries and recommended steps in a compact order", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: {
+            summary: "Telegram 連携は既存機能を有効化すれば使えます。",
+            sections: [
+              {
+                title: "Recommended steps",
+                bullets: ["BotFather で bot を作成する", "通知先チャットで /sethome を送る"],
+              },
+            ],
+            evidence: ["telegram-bot plugin が存在する", "config は ~/.pulseed 配下に保存される"],
+            nextAction: "必要ならセットアップ手順を実行します。",
+          },
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const registry = new ToolRegistry();
+    const { router, runtime } = makeRuntime(registry);
+    const registryModel = new StaticAgentLoopModelRegistry([modelInfo]);
+    const chat = new ChatAgentLoopRunner({
+      boundedRunner: new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime }),
+      modelClient,
+      modelRegistry: registryModel,
+      defaultModel: modelInfo.ref,
+    });
+
+    const result = await chat.execute({ message: "telegramから操作できるようにしたい" });
+
+    expect(result.success).toBe(true);
+    expect(result.output.startsWith("Telegram 連携は既存機能を有効化すれば使えます。")).toBe(true);
+    expect(result.output).toContain("### Recommended steps");
+    expect(result.output).toContain("### Evidence");
+    expect(result.output).toContain("### Next steps");
   });
 
   it("returns a clear approval-policy message instead of leaking raw tool commentary", async () => {

--- a/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { ChatAgentLoopRunner } from "../chat-agent-loop-runner.js";
+import { buildAgentLoopBaseInstructions } from "../agent-loop-prompts.js";
+import type {
+  AgentLoopModelClient,
+  AgentLoopModelInfo,
+  AgentLoopModelRegistry,
+  AgentLoopModelRef,
+} from "../agent-loop-model.js";
+import type { BoundedAgentLoopRunner } from "../bounded-agent-loop-runner.js";
+import { defaultAgentLoopCapabilities } from "../index.js";
+
+function makeModelRef(): AgentLoopModelRef {
+  return { providerId: "test", modelId: "model" };
+}
+
+function makeModelInfo(): AgentLoopModelInfo {
+  return {
+    ref: makeModelRef(),
+    displayName: "test/model",
+    capabilities: { ...defaultAgentLoopCapabilities },
+  };
+}
+
+function makeRunner(returnOutput: unknown) {
+  const modelInfo = makeModelInfo();
+  const boundedRunner = {
+    run: vi.fn().mockResolvedValue({
+      success: true,
+      output: returnOutput,
+      finalText: JSON.stringify(returnOutput),
+      stopReason: "completed",
+      traceId: "trace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+      modelTurns: 1,
+      toolCalls: 0,
+      usage: undefined,
+      compactions: 0,
+      changedFiles: [],
+      commandResults: [],
+    }),
+  } as unknown as BoundedAgentLoopRunner;
+  const modelClient = {
+    getModelInfo: vi.fn().mockResolvedValue(modelInfo),
+  } as unknown as AgentLoopModelClient;
+  const modelRegistry = {
+    defaultModel: vi.fn().mockResolvedValue(modelInfo.ref),
+  } as unknown as AgentLoopModelRegistry;
+
+  return {
+    runner: new ChatAgentLoopRunner({ boundedRunner, modelClient, modelRegistry }),
+    boundedRunner,
+  };
+}
+
+describe("chat agentloop final-answer contract", () => {
+  it("renders the structured finalAnswer object as concise markdown", async () => {
+    const { runner, boundedRunner } = makeRunner({
+      status: "done",
+      message: "Updated the contract slice.",
+      evidence: ["Verified the new JSON contract.", "Kept the legacy fields working."],
+      blockers: [],
+      finalAnswer: {
+        summary: "Updated the contract slice.",
+        sections: [
+          { title: "What changed", bullets: ["Added a nested finalAnswer object.", "Kept flat output fields for compatibility."] },
+        ],
+        evidence: ["Verified the new JSON contract."],
+        blockers: [],
+        nextActions: ["Ship the change behind the current chat output path."],
+      },
+    });
+
+    const result = await runner.execute({ message: "test" });
+
+    expect(boundedRunner.run).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+    expect(result.output.startsWith("Updated the contract slice.")).toBe(true);
+    expect(result.output).toContain("### What changed");
+    expect(result.output).toContain("### Evidence");
+    expect(result.output).toContain("### Next steps");
+  });
+
+  it("keeps legacy flat outputs working", async () => {
+    const { runner } = makeRunner({
+      status: "done",
+      message: "Legacy summary",
+      evidence: ["legacy evidence"],
+      blockers: ["legacy blocker"],
+    });
+
+    const result = await runner.execute({ message: "test" });
+
+    expect(result.success).toBe(true);
+    expect(result.output.startsWith("Legacy summary")).toBe(true);
+    expect(result.output).toContain("### Evidence");
+    expect(result.output).toContain("### Blockers");
+  });
+
+  it("biases chat mode prompts toward concise structured markdown", () => {
+    const chatPrompt = buildAgentLoopBaseInstructions({ mode: "chat" });
+    const taskPrompt = buildAgentLoopBaseInstructions({ mode: "task" });
+
+    expect(chatPrompt).toContain("finalAnswer");
+    expect(chatPrompt).toContain("concise structured markdown");
+    expect(chatPrompt).toContain("short headings and bullets");
+    expect(taskPrompt).not.toContain("concise structured markdown");
+  });
+});

--- a/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
@@ -17,9 +17,16 @@ export function buildAgentLoopBaseInstructions(options?: {
     "Keep going until the request is completely resolved before ending the turn.",
     "Only finish when you are confident the task itself is solved. Do not decide goal completion, global priority, stall, or replan.",
     "Use available tools to inspect, edit, and verify. Prefer apply_patch for patch edits instead of shell-based file rewrites.",
+    "Start with targeted inspection first; avoid repo-wide glob or grep sweeps unless the task truly needs broad discovery.",
     "Keep changes scoped to the requested task. Avoid unrelated edits and avoid fixing unrelated failures.",
     "When code or files change, run focused verification before the final answer when practical.",
     "Preserve and follow AGENTS.md and project instructions from the workspace context.",
+    ...(mode === "chat"
+      ? [
+          "For the final answer, use concise structured markdown with short headings and bullets instead of long unbroken prose.",
+          "Keep the summary tight and put supporting evidence, blockers, and next steps in separate short sections when relevant.",
+        ]
+      : []),
     buildSubagentRoleInstructions(options?.role ?? "default"),
     ...(options?.extraRules ?? []),
   ];

--- a/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
@@ -23,6 +23,7 @@ export function buildAgentLoopBaseInstructions(options?: {
     "Preserve and follow AGENTS.md and project instructions from the workspace context.",
     ...(mode === "chat"
       ? [
+          "When returning structured output, keep the main response in finalAnswer with a short summary, optional sections, evidence, blockers, and next steps; keep compatibility fields brief.",
           "For the final answer, use concise structured markdown with short headings and bullets instead of long unbroken prose.",
           "Keep the summary tight and put supporting evidence, blockers, and next steps in separate short sections when relevant.",
         ]

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -18,11 +18,44 @@ import { buildAgentLoopBaseInstructions } from "./agent-loop-prompts.js";
 import type { ApprovalRequest, ToolCallContext } from "../../../tools/types.js";
 import type { ExecutionPolicy, SubagentRole } from "./execution-policy.js";
 
-export const ChatAgentLoopOutputSchema = z.object({
-  status: z.enum(["done", "blocked", "failed"]).default("done"),
-  message: z.string(),
+const ChatAgentLoopFinalAnswerSectionSchema = z.object({
+  title: z.string(),
+  bullets: z.array(z.string()).default([]),
+});
+
+const ChatAgentLoopFinalAnswerSchema = z.object({
+  summary: z.string().default(""),
+  sections: z.array(ChatAgentLoopFinalAnswerSectionSchema).default([]),
   evidence: z.array(z.string()).default([]),
   blockers: z.array(z.string()).default([]),
+  nextActions: z.array(z.string()).default([]),
+  nextAction: z.string().optional(),
+}).passthrough();
+
+const ChatAgentLoopOutputBaseSchema = z.object({
+  status: z.enum(["done", "blocked", "failed"]).default("done"),
+  message: z.string().default(""),
+  evidence: z.array(z.string()).default([]),
+  blockers: z.array(z.string()).default([]),
+  finalAnswer: ChatAgentLoopFinalAnswerSchema.optional(),
+}).passthrough();
+
+export const ChatAgentLoopOutputSchema = ChatAgentLoopOutputBaseSchema.transform((value) => {
+  const finalAnswer = value.finalAnswer ?? {
+    summary: value.message,
+    sections: [],
+    evidence: value.evidence,
+    blockers: value.blockers,
+    nextActions: [],
+  };
+
+  return {
+    ...value,
+    message: value.message.trim() || finalAnswer.summary.trim(),
+    evidence: value.evidence.length > 0 ? value.evidence : finalAnswer.evidence,
+    blockers: value.blockers.length > 0 ? value.blockers : finalAnswer.blockers,
+    finalAnswer,
+  };
 });
 export type ChatAgentLoopOutput = z.infer<typeof ChatAgentLoopOutputSchema>;
 
@@ -151,8 +184,8 @@ export class ChatAgentLoopRunner {
       /approval denied|user denied approval|requires approval/i.test(entry.outputSummary),
     );
     const fallbackOutput = success
-      ? this.buildSuccessfulOutput(result.finalText, result.output?.message)
-      : this.buildFailureOutput(result.stopReason, hadApprovalDeniedError, result.finalText, result.output?.blockers);
+      ? this.buildSuccessfulOutput(result.finalText, result.output)
+      : this.buildFailureOutput(result.stopReason, hadApprovalDeniedError, result.finalText, result.output, result.output?.blockers);
     return {
       success,
       output: fallbackOutput,
@@ -185,10 +218,12 @@ export class ChatAgentLoopRunner {
     };
   }
 
-  private buildSuccessfulOutput(finalText: string, fallbackMessage?: string): string {
+  private buildSuccessfulOutput(finalText: string, output?: ChatAgentLoopOutput | null): string {
+    const formattedOutput = this.formatChatOutput(output);
+    if (formattedOutput) return formattedOutput;
     const formatted = this.formatStructuredFinalText(finalText);
     if (formatted) return formatted;
-    if (fallbackMessage && fallbackMessage.trim().length > 0) return fallbackMessage.trim();
+    if (output?.message && output.message.trim().length > 0) return output.message.trim();
     if (finalText && finalText.trim().length > 0) return finalText.trim();
     return "(no response)";
   }
@@ -197,6 +232,7 @@ export class ChatAgentLoopRunner {
     stopReason: string,
     hadApprovalDeniedError: boolean,
     finalText: string,
+    output?: ChatAgentLoopOutput | null,
     blockers?: string[],
   ): string {
     if (
@@ -218,11 +254,98 @@ export class ChatAgentLoopRunner {
       return "I stopped because the tool loop repeated without making progress.";
     }
 
+    const formattedOutput = this.formatChatOutput(output);
+    if (formattedOutput) return formattedOutput;
     const formatted = this.formatStructuredFinalText(finalText);
     if (formatted) return formatted;
     if (blockers && blockers.length > 0) return blockers.join("; ");
     if (finalText && !/^Calling\s+/i.test(finalText.trim())) return finalText.trim();
     return `Interrupted: ${stopReason}`;
+  }
+
+  private formatChatOutput(output?: ChatAgentLoopOutput | null): string | null {
+    if (!output) return null;
+
+    const finalAnswer = output.finalAnswer;
+    const summary = finalAnswer?.summary.trim() || output.message.trim();
+    const sections: string[] = [];
+    const handledKeys = new Set<string>(["status", "message", "evidence", "blockers", "finalAnswer"]);
+
+    if (summary.length > 0) {
+      sections.push(summary);
+    }
+
+    for (const section of finalAnswer?.sections ?? []) {
+      const bullets = section.bullets.map((item) => item.trim()).filter((item) => item.length > 0);
+      if (bullets.length === 0) continue;
+      sections.push(`### ${section.title.trim()}\n${bullets.map((bullet) => `- ${bullet}`).join("\n")}`);
+    }
+
+    const evidence = [...new Set([
+      ...(finalAnswer?.evidence ?? []),
+      ...output.evidence,
+    ].map((item) => item.trim()).filter((item) => item.length > 0))];
+    if (evidence.length > 0) {
+      sections.push(`### Evidence\n${evidence.map((item) => `- ${item}`).join("\n")}`);
+    }
+
+    const blockers = [...new Set([
+      ...(finalAnswer?.blockers ?? []),
+      ...output.blockers,
+    ].map((item) => item.trim()).filter((item) => item.length > 0))];
+    if (blockers.length > 0) {
+      sections.push(`### Blockers\n${blockers.map((item) => `- ${item}`).join("\n")}`);
+    }
+
+    const nextActions = [
+      ...(finalAnswer?.nextActions ?? []),
+      ...(typeof finalAnswer?.nextAction === "string" ? [finalAnswer.nextAction] : []),
+    ].map((item) => item.trim()).filter((item) => item.length > 0);
+    if (nextActions.length > 0) {
+      sections.push(`### Next steps\n${nextActions.map((item) => `- ${item}`).join("\n")}`);
+    }
+
+    for (const [key, fieldValue] of Object.entries(output)) {
+      if (handledKeys.has(key) || !Array.isArray(fieldValue)) continue;
+      const lines = fieldValue.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+      if (lines.length === 0) continue;
+      sections.push(`### ${this.humanizeFieldLabel(this.normalizeOutputFieldLabel(key))}\n${lines.map((line) => `- ${line}`).join("\n")}`);
+    }
+
+    for (const [key, fieldValue] of Object.entries(output)) {
+      if (handledKeys.has(key) || typeof fieldValue !== "string") continue;
+      const value = fieldValue.trim();
+      if (!value) continue;
+      if (key === "nextAction" || key === "next_action" || key === "nextStep" || key === "next_step") {
+        sections.push(`### Next step\n- ${value}`);
+      }
+    }
+
+    const rendered = sections.join("\n\n").trim();
+    return rendered.length > 0 ? rendered : null;
+  }
+
+  private humanizeFieldLabel(key: string): string {
+    return key
+      .split(/[_\s-]+/g)
+      .filter(Boolean)
+      .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+      .join(" ");
+  }
+
+  private normalizeOutputFieldLabel(key: string): string {
+    switch (key) {
+      case "steps":
+        return "recommended_steps";
+      case "files":
+      case "relevantFiles":
+        return "relevant_files";
+      case "nextActions":
+      case "next_actions":
+        return "next_steps";
+      default:
+        return key;
+    }
   }
 
   private formatStructuredFinalText(finalText: string): string | null {
@@ -239,48 +362,8 @@ export class ChatAgentLoopRunner {
       return null;
     }
 
-    const value = parsed as Record<string, unknown>;
-    const message = typeof value.message === "string" ? value.message.trim() : "";
-    const sections: string[] = [];
-    const handledKeys = new Set<string>(["status", "message", "evidence", "blockers"]);
-
-    const appendStringArray = (title: string, key: string) => {
-      const array = value[key];
-      if (!Array.isArray(array)) return;
-      const lines = array.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
-      if (lines.length === 0) return;
-      handledKeys.add(key);
-      sections.push(`${title}:\n${lines.map((line) => `- ${line}`).join("\n")}`);
-    };
-
-    appendStringArray("Details", "details");
-    appendStringArray("Capabilities", "capabilities");
-    appendStringArray("Evidence", "evidence");
-    appendStringArray("Blockers", "blockers");
-    appendStringArray("Examples", "examples");
-    appendStringArray("Telegram examples", "telegram_examples");
-    appendStringArray("Next actions", "next_actions");
-
-    for (const [key, fieldValue] of Object.entries(value)) {
-      if (handledKeys.has(key) || !Array.isArray(fieldValue)) continue;
-      const lines = fieldValue.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
-      if (lines.length === 0) continue;
-      sections.push(`${this.humanizeFieldLabel(key)}:\n${lines.map((line) => `- ${line}`).join("\n")}`);
-    }
-
-    if (typeof value.next_step === "string" && value.next_step.trim().length > 0) {
-      sections.push(`Next step: ${value.next_step.trim()}`);
-    }
-
-    if (!message && sections.length === 0) return raw;
-    return [message, ...sections].filter((section) => section.length > 0).join("\n\n");
-  }
-
-  private humanizeFieldLabel(key: string): string {
-    return key
-      .split(/[_\s-]+/g)
-      .filter(Boolean)
-      .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
-      .join(" ");
+    const parsedOutput = ChatAgentLoopOutputSchema.safeParse(parsed);
+    if (!parsedOutput.success) return null;
+    return this.formatChatOutput(parsedOutput.data);
   }
 }


### PR DESCRIPTION
## Summary
- structure native chat agent-loop final answers for medium tasks with a concise markdown contract while keeping legacy compatibility
- preserve markdown segments through the TUI/chat rendering pipeline and improve local link readability
- surface compact tool/progress rows from existing chat events and lock the prompt/grounding/tests around the new output shape

## Testing
- ./node_modules/.bin/vitest run src/interface/tui/__tests__/chat.test.ts src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-grounding.test.ts src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
