### PR TITLE
refactor: reuse grounding prompt rendering helpers

### DIFF
--- a/src/grounding/__tests__/prompt-renderer.test.ts
+++ b/src/grounding/__tests__/prompt-renderer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { GroundingSection } from "../contracts.js";
+import { pickGroundingSections, renderPromptSections } from "../renderers/prompt-renderer.js";
+
+const SECTIONS: GroundingSection[] = [
+  {
+    key: "identity",
+    title: "Identity",
+    priority: 10,
+    estimatedTokens: 10,
+    content: "You are Seedy.",
+    sources: [],
+  },
+  {
+    key: "execution_policy",
+    title: "Execution Policy",
+    priority: 20,
+    estimatedTokens: 10,
+    content: "## Execution Bias\n- Do the next safe thing.",
+    sources: [],
+  },
+  {
+    key: "approval_policy",
+    title: "Safety And Approval",
+    priority: 30,
+    estimatedTokens: 10,
+    content: "- Ask before destructive changes.",
+    sources: [],
+  },
+];
+
+describe("prompt-renderer", () => {
+  it("picks only the requested section keys", () => {
+    const picked = pickGroundingSections(SECTIONS, ["identity", "approval_policy"]);
+
+    expect(picked.map((section) => section.key)).toEqual(["identity", "approval_policy"]);
+  });
+
+  it("can omit headings for embedded multi-section content while preserving order", () => {
+    const rendered = renderPromptSections(SECTIONS, {
+      omitHeadingKeys: ["execution_policy"],
+      preserveOrder: true,
+    });
+
+    expect(rendered).toContain("## Identity");
+    expect(rendered).toContain("## Execution Bias");
+    expect(rendered).not.toContain("## Execution Policy");
+    expect(rendered).toContain("## Safety And Approval");
+  });
+});

--- a/src/grounding/renderers/prompt-renderer.ts
+++ b/src/grounding/renderers/prompt-renderer.ts
@@ -1,13 +1,39 @@
-import type { GroundingBundle, GroundingSection } from "../contracts.js";
+import type { GroundingBundle, GroundingSection, GroundingSectionKey } from "../contracts.js";
+import { sortSections } from "../providers/helpers.js";
 
-function renderSection(section: GroundingSection): string {
-  return `## ${section.title}\n${section.content}`.trim();
+export interface PromptSectionRenderOptions {
+  omitHeadingKeys?: readonly GroundingSectionKey[];
+  titleOverrides?: Partial<Record<GroundingSectionKey, string>>;
+  preserveOrder?: boolean;
+}
+
+function renderSection(section: GroundingSection, options: PromptSectionRenderOptions): string {
+  if (options.omitHeadingKeys?.includes(section.key)) {
+    return section.content.trim();
+  }
+  const title = options.titleOverrides?.[section.key] ?? section.title;
+  return `## ${title}\n${section.content}`.trim();
+}
+
+export function pickGroundingSections<T extends GroundingSection>(
+  sections: readonly T[],
+  keys: readonly GroundingSectionKey[],
+): T[] {
+  const wanted = new Set(keys);
+  return sections.filter((section) => wanted.has(section.key));
+}
+
+export function renderPromptSections(
+  sections: readonly GroundingSection[],
+  options: PromptSectionRenderOptions = {},
+): string {
+  const ordered = options.preserveOrder ? [...sections] : sortSections([...sections]);
+  return ordered
+    .map((section) => renderSection(section, options))
+    .join("\n\n")
+    .trim();
 }
 
 export function renderPromptBundle(bundle: GroundingBundle): string {
-  return [...bundle.staticSections, ...bundle.dynamicSections]
-    .sort((a, b) => a.priority - b.priority)
-    .map(renderSection)
-    .join("\n\n")
-    .trim();
+  return renderPromptSections([...bundle.staticSections, ...bundle.dynamicSections]);
 }

--- a/src/interface/chat/grounding.ts
+++ b/src/interface/chat/grounding.ts
@@ -1,6 +1,7 @@
 import type { StateManager } from "../../base/state/state-manager.js";
 import { createGroundingGateway, type GroundingGateway } from "../../grounding/gateway.js";
-import type { GroundingBundle } from "../../grounding/contracts.js";
+import type { GroundingBundle, GroundingRequest, GroundingSection, GroundingSectionKey } from "../../grounding/contracts.js";
+import { pickGroundingSections, renderPromptSections } from "../../grounding/renderers/prompt-renderer.js";
 import {
   buildApprovalPolicySectionContent,
   buildExecutionPolicySectionContent,
@@ -27,20 +28,55 @@ function createChatGateway(options: Pick<GroundingOptions, "stateManager" | "plu
 
 export { createChatGateway as createChatGroundingGateway };
 
-function renderLegacyStaticPrompt(bundle: GroundingBundle): string {
-  return bundle.staticSections.map((section) => {
-    if (section.key === "execution_policy") {
-      return section.content.trim();
-    }
-    if (section.key === "approval_policy") {
-      return `## Safety And Approval\n${section.content}`.trim();
-    }
-    return `## ${section.title}\n${section.content}`.trim();
-  }).join("\n\n").trim();
+const CHAT_STATIC_SECTION_KEYS: readonly GroundingSectionKey[] = [
+  "identity",
+  "execution_policy",
+  "approval_policy",
+];
+
+const CHAT_DYNAMIC_SECTION_KEYS: readonly GroundingSectionKey[] = [
+  "goal_state",
+  "plugins",
+  "provider_state",
+];
+
+const CHAT_DYNAMIC_CONTEXT_INCLUDE: Partial<GroundingRequest["include"]> = {
+  identity: false,
+  execution_policy: false,
+  approval_policy: false,
+  trust_state: false,
+  repo_instructions: false,
+  soil_knowledge: false,
+};
+
+function buildChatGroundingRequest(
+  options: GroundingOptions,
+  overrides: Partial<GroundingRequest> = {},
+): GroundingRequest {
+  return {
+    surface: "chat",
+    purpose: "general_turn",
+    homeDir: options.homeDir,
+    workspaceRoot: options.workspaceRoot,
+    goalId: options.goalId,
+    userMessage: options.userMessage,
+    query: options.userMessage,
+    trustProjectInstructions: options.trustProjectInstructions,
+    workspaceContext: options.workspaceContext,
+    ...overrides,
+    ...(overrides.include ? { include: overrides.include } : {}),
+  };
 }
 
-function renderLegacyDynamicPrompt(bundle: GroundingBundle): string {
-  const byKey = new Map(bundle.dynamicSections.map((section) => [section.key, section]));
+function renderLegacyStaticPrompt(sections: readonly GroundingSection[]): string {
+  return renderPromptSections(sections, {
+    omitHeadingKeys: ["execution_policy"],
+    preserveOrder: true,
+  });
+}
+
+function renderLegacyDynamicPrompt(sections: readonly GroundingSection[]): string {
+  const byKey = new Map(sections.map((section) => [section.key, section]));
   const goalState = byKey.get("goal_state")?.content ?? "No goals configured yet.";
   const plugins = byKey.get("plugins")?.content?.replace(/^Installed:\s*/, "") ?? "none";
   const provider = byKey.get("provider_state")?.content ?? "not configured";
@@ -57,18 +93,11 @@ function renderLegacyDynamicPrompt(bundle: GroundingBundle): string {
   ].join("\n").trim();
 }
 
-export async function buildChatGroundingBundle(options: GroundingOptions): Promise<GroundingBundle> {
-  return await createChatGateway(options).build({
-    surface: "chat",
-    purpose: "general_turn",
-    homeDir: options.homeDir,
-    workspaceRoot: options.workspaceRoot,
-    goalId: options.goalId,
-    userMessage: options.userMessage,
-    query: options.userMessage,
-    trustProjectInstructions: options.trustProjectInstructions,
-    workspaceContext: options.workspaceContext,
-  });
+export async function buildChatGroundingBundle(
+  options: GroundingOptions,
+  overrides: Partial<GroundingRequest> = {},
+): Promise<GroundingBundle> {
+  return await createChatGateway(options).build(buildChatGroundingRequest(options, overrides));
 }
 
 export function buildStaticSystemPrompt(): string {
@@ -80,33 +109,16 @@ export function buildStaticSystemPrompt(): string {
 }
 
 export async function buildDynamicContextPrompt(options: GroundingOptions): Promise<string> {
-  const bundle = await createChatGateway(options).build({
-    surface: "chat",
-    purpose: "general_turn",
-    homeDir: options.homeDir,
-    goalId: options.goalId,
-    include: {
-      identity: false,
-      execution_policy: false,
-      approval_policy: false,
-      trust_state: false,
-      repo_instructions: false,
-      soil_knowledge: false,
-    },
-  });
-  return renderLegacyDynamicPrompt(bundle);
+  const bundle = await buildChatGroundingBundle(options, { include: CHAT_DYNAMIC_CONTEXT_INCLUDE });
+  return renderLegacyDynamicPrompt(pickGroundingSections(bundle.dynamicSections, CHAT_DYNAMIC_SECTION_KEYS));
 }
 
 export async function buildSystemPrompt(options: GroundingOptions): Promise<string> {
   const bundle = await buildChatGroundingBundle(options);
-  const staticSections = bundle.staticSections.filter((section) =>
-    section.key === "identity" || section.key === "execution_policy" || section.key === "approval_policy"
-  );
-  const dynamicSections = bundle.dynamicSections.filter((section) =>
-    section.key === "goal_state" || section.key === "plugins" || section.key === "provider_state"
-  );
+  const staticSections = pickGroundingSections(bundle.staticSections, CHAT_STATIC_SECTION_KEYS);
+  const dynamicSections = pickGroundingSections(bundle.dynamicSections, CHAT_DYNAMIC_SECTION_KEYS);
   return [
-    renderLegacyStaticPrompt({ ...bundle, staticSections, dynamicSections: [] }),
-    renderLegacyDynamicPrompt({ ...bundle, staticSections: [], dynamicSections }),
+    renderLegacyStaticPrompt(staticSections),
+    renderLegacyDynamicPrompt(dynamicSections),
   ].join("\n\n").trim();
 }

--- a/src/orchestrator/execution/agent-loop/agent-loop-context-assembler.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-context-assembler.ts
@@ -3,6 +3,7 @@ import type { Task } from "../../../base/types/task.js";
 import { createGroundingGateway, type GroundingGateway } from "../../../grounding/gateway.js";
 import { discoverAgentInstructionCandidates } from "../../../grounding/providers/agents-provider.js";
 import type { GroundingSection } from "../../../grounding/contracts.js";
+import { renderPromptSections } from "../../../grounding/renderers/prompt-renderer.js";
 
 export interface AgentLoopContextBlock {
   id: string;
@@ -50,13 +51,6 @@ function sectionToBlock(section: GroundingSection): AgentLoopContextBlock {
     content: section.content,
     priority: section.priority,
   };
-}
-
-function renderStaticSections(sections: GroundingSection[]): string {
-  return sections
-    .map((section) => `## ${section.title}\n${section.content}`.trim())
-    .join("\n\n")
-    .trim();
 }
 
 export class AgentLoopContextAssembler {
@@ -126,7 +120,7 @@ export class AgentLoopContextAssembler {
 
     return {
       cwd,
-      systemPrompt: renderStaticSections(bundle.staticSections),
+      systemPrompt: renderPromptSections(bundle.staticSections, { preserveOrder: true }),
       userPrompt,
       contextBlocks: blocks,
     };


### PR DESCRIPTION
## Summary
- reuse grounding prompt section rendering across chat and agent-loop
- centralize chat grounding request/section selection helpers
- add focused tests for prompt section selection and rendering behavior

## Verification
- `npm run typecheck`
- `npm run lint:boundaries`
- `./node_modules/.bin/vitest run src/grounding/__tests__/gateway.test.ts src/grounding/__tests__/prompt-renderer.test.ts src/interface/chat/__tests__/chat-grounding.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-context-assembler.test.ts`
