### PR TITLE
refactor: break plugin-loader chat session cycle

### DIFF
--- a/src/interface/chat/cross-platform-session-global.ts
+++ b/src/interface/chat/cross-platform-session-global.ts
@@ -1,0 +1,27 @@
+export type GlobalCrossPlatformChatSessionManagerGetter = () => Promise<unknown>;
+
+interface PulseedRuntimeGlobal {
+  __pulseedGetGlobalCrossPlatformChatSessionManager?: GlobalCrossPlatformChatSessionManagerGetter;
+}
+
+let registeredGetter: GlobalCrossPlatformChatSessionManagerGetter | undefined;
+
+export function registerGlobalCrossPlatformChatSessionManager(
+  getter: GlobalCrossPlatformChatSessionManagerGetter,
+): void {
+  registeredGetter = getter;
+}
+
+export function exposeRegisteredCrossPlatformChatSessionManager(): void {
+  const runtimeGlobal = globalThis as typeof globalThis & PulseedRuntimeGlobal;
+  if (registeredGetter) {
+    runtimeGlobal.__pulseedGetGlobalCrossPlatformChatSessionManager = registeredGetter;
+    return;
+  }
+  delete runtimeGlobal.__pulseedGetGlobalCrossPlatformChatSessionManager;
+}
+
+export function clearRegisteredCrossPlatformChatSessionManager(): void {
+  registeredGetter = undefined;
+  delete (globalThis as typeof globalThis & PulseedRuntimeGlobal).__pulseedGetGlobalCrossPlatformChatSessionManager;
+}

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -32,6 +32,7 @@ import {
   RuntimeControlService,
   createDaemonRuntimeControlExecutor,
 } from "../../runtime/control/index.js";
+import { registerGlobalCrossPlatformChatSessionManager } from "./cross-platform-session-global.js";
 
 export interface CrossPlatformChatSessionOptions {
   /**
@@ -416,3 +417,5 @@ async function createGlobalCrossPlatformChatSessionManager(): Promise<CrossPlatf
     }),
   });
 }
+
+registerGlobalCrossPlatformChatSessionManager(getGlobalCrossPlatformChatSessionManager);

--- a/src/runtime/__tests__/plugin-loader.test.ts
+++ b/src/runtime/__tests__/plugin-loader.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as path from "node:path";
 import { PluginLoader, parseSemver, compareSemver, satisfiesRange } from "../plugin-loader.js";
 import { NotifierRegistry } from "../notifier-registry.js";
+import {
+  clearRegisteredCrossPlatformChatSessionManager,
+  registerGlobalCrossPlatformChatSessionManager,
+} from "../../interface/chat/cross-platform-session-global.js";
 import { PluginManifestSchema, PluginStateSchema } from "../../base/types/plugin.js";
 import type { INotifier, NotificationEvent, NotificationEventType, PluginManifest } from "../../base/types/plugin.js";
 import type { AdapterRegistry, IAdapter, AgentTask, AgentResult } from "../../orchestrator/execution/adapter-layer.js";
@@ -25,6 +29,10 @@ function makeDataSourceRegistry(): DataSourceRegistry {
     list: vi.fn().mockReturnValue([]),
   } as unknown as DataSourceRegistry;
 }
+
+afterEach(() => {
+  clearRegisteredCrossPlatformChatSessionManager();
+});
 
 function makeNotifierRegistry(): NotifierRegistry {
   return new NotifierRegistry();
@@ -574,5 +582,51 @@ describe("PluginLoader.getPluginState and updatePluginState", () => {
   it("updatePluginState does nothing for unknown plugin", async () => {
     // Should not throw
     await expect(loader.updatePluginState("ghost-plugin", { trust_score: 10 })).resolves.toBeUndefined();
+  });
+});
+
+describe("PluginLoader cross-platform session exposure", () => {
+  let tmpDir: string;
+  let loader: PluginLoader;
+
+  beforeEach(() => {
+    tmpDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "pulseed-plugin-global-test-"));
+    loader = new PluginLoader(
+      makeAdapterRegistry(),
+      makeDataSourceRegistry(),
+      makeNotifierRegistry(),
+      tmpDir
+    );
+  });
+
+  afterEach(() => {
+    fsSync.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it("exposes the registered cross-platform session getter before plugin import", async () => {
+    const pluginDir = path.join(tmpDir, "global-aware-plugin");
+    fsSync.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
+    fsSync.writeFileSync(path.join(pluginDir, "plugin.json"), JSON.stringify(makeValidManifest({
+      name: "global-aware-plugin",
+      entry_point: "dist/index.js",
+    })));
+    fsSync.writeFileSync(
+      path.join(pluginDir, "dist", "index.js"),
+      [
+        "export default {",
+        "  name: 'global-aware-plugin',",
+        "  notify: async () => {},",
+        "  supports: () => true,",
+        "};",
+      ].join("\n"),
+    );
+
+    const getter = vi.fn().mockResolvedValue({ manager: true });
+    registerGlobalCrossPlatformChatSessionManager(getter);
+
+    await expect(loader.loadOne(pluginDir)).resolves.toMatchObject({ status: "loaded" });
+    expect((globalThis as typeof globalThis & {
+      __pulseedGetGlobalCrossPlatformChatSessionManager?: typeof getter;
+    }).__pulseedGetGlobalCrossPlatformChatSessionManager).toBe(getter);
   });
 });

--- a/src/runtime/plugin-loader.ts
+++ b/src/runtime/plugin-loader.ts
@@ -5,7 +5,7 @@ import { getPluginsDir } from "../base/utils/paths.js";
 import { getPulseedVersion as getPackageVersion } from "../base/utils/pulseed-meta.js";
 import { writeJsonFileAtomic } from "../base/utils/json-io.js";
 import { ValidationError } from "../base/utils/errors.js";
-import { getGlobalCrossPlatformChatSessionManager } from "../interface/chat/cross-platform-session.js";
+import { exposeRegisteredCrossPlatformChatSessionManager } from "../interface/chat/cross-platform-session-global.js";
 import type { Logger } from "./logger.js";
 import {
   PluginManifestSchema,
@@ -102,7 +102,7 @@ export class PluginLoader {
     }
 
     // 2. Dynamically import the entry point
-    exposeCrossPlatformChatSessionManager();
+    exposeRegisteredCrossPlatformChatSessionManager();
     const entryPath = path.resolve(pluginDir, manifest.entry_point);
     if (!entryPath.startsWith(pluginDir + path.sep) && entryPath !== pluginDir) {
       throw new ValidationError(`Plugin entry point escapes plugin directory: ${manifest.entry_point}`);
@@ -400,15 +400,6 @@ export class PluginLoader {
 }
 
 // ─── Module-level helpers ───
-
-interface PulseedRuntimeGlobal {
-  __pulseedGetGlobalCrossPlatformChatSessionManager?: typeof getGlobalCrossPlatformChatSessionManager;
-}
-
-function exposeCrossPlatformChatSessionManager(): void {
-  (globalThis as typeof globalThis & PulseedRuntimeGlobal)
-    .__pulseedGetGlobalCrossPlatformChatSessionManager = getGlobalCrossPlatformChatSessionManager;
-}
 
 // ─── PulSeed version (read once from package.json) ───
 


### PR DESCRIPTION
## Summary
- remove the direct `plugin-loader -> cross-platform-session` import edge
- register the global cross-platform chat session getter through a tiny neutral module
- add a plugin-loader test that verifies the registered getter is exposed before plugin import

## Verification
- `npm run typecheck`
- `./node_modules/.bin/vitest run src/runtime/__tests__/plugin-loader.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts`
- `npx --yes madge --circular --extensions ts,tsx src/runtime/plugin-loader.ts src/interface/chat/cross-platform-session.ts src/platform/traits/trust-manager.ts`
- `./node_modules/.bin/eslint src/runtime/plugin-loader.ts src/interface/chat/cross-platform-session.ts src/interface/chat/cross-platform-session-global.ts src/runtime/__tests__/plugin-loader.test.ts`

## Result
- the plugin-loader / cross-platform-session cycle is removed
- remaining cycles from this slice: `base/state/state-manager-goal-write.ts > base/state/state-manager.ts`, `runtime/daemon/client.ts > runtime/control/index.ts > runtime/control/daemon-runtime-control-executor.ts`
