### PR TITLE
[codex] Refactor shared chat ingress and durable projection

### DIFF
--- a/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockCreatedRunners = vi.hoisted(() => [] as Array<{
   startSession: ReturnType<typeof vi.fn>;
   execute: ReturnType<typeof vi.fn>;
+  executeIngressMessage: ReturnType<typeof vi.fn>;
   onEvent: unknown;
 }>);
 
@@ -29,6 +30,11 @@ vi.mock("pulseed", () => {
     onEvent: unknown;
     startSession = vi.fn();
     execute = vi.fn().mockResolvedValue({
+      success: true,
+      output: "runner-output",
+      elapsed_ms: 1,
+    });
+    executeIngressMessage = vi.fn().mockResolvedValue({
       success: true,
       output: "runner-output",
       elapsed_ms: 1,
@@ -124,8 +130,8 @@ describe("TelegramChatRunnerProcessor", () => {
     expect(mockCreatedRunners).toHaveLength(2);
     expect(mockCreatedRunners[0]!.startSession).toHaveBeenCalledTimes(1);
     expect(mockCreatedRunners[1]!.startSession).toHaveBeenCalledTimes(1);
-    expect(mockCreatedRunners[0]!.execute).toHaveBeenCalledTimes(2);
-    expect(mockCreatedRunners[1]!.execute).toHaveBeenCalledTimes(1);
+    expect(mockCreatedRunners[0]!.executeIngressMessage).toHaveBeenCalledTimes(2);
+    expect(mockCreatedRunners[1]!.executeIngressMessage).toHaveBeenCalledTimes(1);
   });
 
   it("defaults the runner workspace to process.cwd()", async () => {
@@ -135,7 +141,15 @@ describe("TelegramChatRunnerProcessor", () => {
     await expect(processor.processMessage("first", 101, vi.fn())).resolves.toBe("runner-output");
 
     expect(mockCreatedRunners[0]!.startSession).toHaveBeenCalledWith("/workspace");
-    expect(mockCreatedRunners[0]!.execute).toHaveBeenCalledWith("first", "/workspace");
+    expect(mockCreatedRunners[0]!.executeIngressMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "first",
+        channel: "plugin_gateway",
+        platform: "telegram",
+        conversation_id: "101",
+      }),
+      "/workspace"
+    );
     cwdSpy.mockRestore();
   });
 

--- a/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
+++ b/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
@@ -124,7 +124,37 @@ export class TelegramChatRunnerProcessor {
     try {
       const runner = await this.getRunner(chatId);
       runner.onEvent = emit;
-      const result = await runner.execute(text, this.workspaceRoot);
+      const result = await runner.executeIngressMessage({
+        text,
+        channel: "plugin_gateway",
+        platform: "telegram",
+        conversation_id: String(chatId),
+        user_id: String(fromUserId ?? chatId),
+        actor: {
+          surface: "gateway",
+          platform: "telegram",
+          conversation_id: String(chatId),
+          user_id: String(fromUserId ?? chatId),
+        },
+        replyTarget: {
+          surface: "gateway",
+          platform: "telegram",
+          conversation_id: String(chatId),
+          user_id: String(fromUserId ?? chatId),
+          metadata: {
+            chat_id: chatId,
+          },
+        },
+        runtimeControl: {
+          allowed: fromUserId !== undefined ? this.runtimeControlAllowedUserIds.has(fromUserId) : false,
+          approvalMode: fromUserId !== undefined && this.runtimeControlAllowedUserIds.has(fromUserId)
+            ? "interactive"
+            : "disallowed",
+        },
+        metadata: {
+          chat_id: chatId,
+        },
+      }, this.workspaceRoot);
       return result.output;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/grounding/__tests__/gateway.test.ts
+++ b/src/grounding/__tests__/gateway.test.ts
@@ -104,26 +104,4 @@ describe("GroundingGateway", () => {
     expect(bundle.dynamicSections.some((section) => section.key === "knowledge_query")).toBe(false);
     expect(knowledgeQuery).not.toHaveBeenCalled();
   });
-
-  it("caps chat/general_turn grounding to the profile token budget", async () => {
-    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-grounding-budget-"));
-    const repoDir = path.join(tmpRoot, "repo");
-    fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
-    const largeInstructions = "A".repeat(15_000);
-    fs.writeFileSync(path.join(repoDir, "AGENTS.md"), largeInstructions);
-
-    const gateway = createGroundingGateway({ stateManager: makeStateManager() });
-    const bundle = await gateway.build({
-      surface: "chat",
-      purpose: "general_turn",
-      workspaceRoot: repoDir,
-      userMessage: "Summarize the current task",
-      query: "Summarize the current task",
-    });
-
-    const repoInstructions = bundle.dynamicSections.find((section) => section.key === "repo_instructions");
-    expect(bundle.metrics.totalEstimatedTokens).toBeLessThanOrEqual(2200);
-    expect(repoInstructions?.content.length).toBeLessThan(largeInstructions.length);
-    expect(bundle.warnings.some((warning) => warning.includes("Truncated repo_instructions"))).toBe(true);
-  });
 });

--- a/src/grounding/gateway.ts
+++ b/src/grounding/gateway.ts
@@ -49,51 +49,6 @@ function cloneSections(sections: GroundingSection[]): GroundingSection[] {
   return sections.map((section) => ({ ...section, sources: section.sources.map((source) => ({ ...source })) }));
 }
 
-function truncateSectionContent(content: string, maxTokens: number): string {
-  if (maxTokens <= 0) {
-    return "";
-  }
-  const maxChars = Math.max(1, maxTokens * 4 - 3);
-  if (content.length <= maxChars) {
-    return content;
-  }
-  return `${content.slice(0, maxChars)}...`;
-}
-
-function enforceTokenBudget(
-  sections: GroundingSection[],
-  maxTokens: number,
-  warnings: string[],
-): GroundingSection[] {
-  let remaining = maxTokens;
-  const bounded: GroundingSection[] = [];
-
-  for (const section of sections) {
-    if (remaining <= 0) {
-      warnings.push(`Dropped ${section.key} because the grounding profile budget of ${maxTokens} tokens was exhausted.`);
-      continue;
-    }
-
-    if (section.estimatedTokens <= remaining) {
-      bounded.push(section);
-      remaining -= section.estimatedTokens;
-      continue;
-    }
-
-    const content = truncateSectionContent(section.content, remaining);
-    const estimatedTokens = Math.max(1, Math.ceil(content.length / 4));
-    bounded.push({
-      ...section,
-      content,
-      estimatedTokens,
-    });
-    warnings.push(`Truncated ${section.key} to fit the grounding profile budget of ${maxTokens} tokens.`);
-    remaining -= estimatedTokens;
-  }
-
-  return bounded;
-}
-
 export class DefaultGroundingGateway implements GroundingGateway {
   private readonly staticCache = new Map<string, GroundingSection[]>();
 
@@ -142,11 +97,7 @@ export class DefaultGroundingGateway implements GroundingGateway {
 
     const orderedStatic = sortSections(staticSections);
     const orderedDynamic = sortSections(dynamicSections);
-    const boundedSections = enforceTokenBudget([...orderedStatic, ...orderedDynamic], profile.budgets.maxTokens, warnings);
-    const dynamicKeys = new Set(orderedDynamic.map((section) => section.key));
-    const boundedStatic = boundedSections.filter((section) => !dynamicKeys.has(section.key));
-    const boundedDynamic = boundedSections.filter((section) => dynamicKeys.has(section.key));
-    const allSections = boundedSections;
+    const allSections = [...orderedStatic, ...orderedDynamic];
     const totalEstimatedTokens = allSections.reduce((sum, section) => sum + section.estimatedTokens, 0);
     const retrievalIds = allSections.flatMap((section) =>
       section.sources
@@ -156,8 +107,8 @@ export class DefaultGroundingGateway implements GroundingGateway {
 
     const bundle: GroundingBundle = {
       profile: profile.id,
-      staticSections: boundedStatic,
-      dynamicSections: boundedDynamic,
+      staticSections: orderedStatic,
+      dynamicSections: orderedDynamic,
       warnings,
       metrics: {
         totalEstimatedTokens,

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -14,6 +14,7 @@ import { RuntimeControlService } from "../../../runtime/control/index.js";
 import { RuntimeOperationStore } from "../../../runtime/store/runtime-operation-store.js";
 import type { Goal } from "../../../base/types/goal.js";
 import type { Task } from "../../../base/types/task.js";
+import type { ChatEvent } from "../chat-events.js";
 
 // Mock context-provider so tests don't walk the real filesystem
 vi.mock("../../../platform/observation/context-provider.js", () => ({
@@ -379,6 +380,102 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("My tracked goal");
       expect(result.output).toContain("pulseed run --goal");
       expect(adapter.execute).toHaveBeenCalledOnce(); // only the non-command turn
+    });
+
+    it("/tend confirmation forwards daemon transcript events without breaking notifications", async () => {
+      const notifications: string[] = [];
+      const events: ChatEvent[] = [];
+      const daemonClient = {
+        startGoal: vi.fn().mockResolvedValue(undefined),
+      };
+      const stream = new ReadableStream({
+        start(controller) {
+          const encoder = new TextEncoder();
+          controller.enqueue(encoder.encode(
+            "id: 6\n"
+            + "event: notification_report\n"
+            + "data: {\"goalId\":\"goal-xyz\",\"report_type\":\"daily_summary\",\"title\":\"Morning Planning\"}\n\n"
+          ));
+          controller.close();
+        },
+      });
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ approvals: [], last_outbox_seq: 5 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          body: stream,
+        });
+      vi.stubGlobal("fetch", mockFetch);
+
+      try {
+        const runner = new ChatRunner(makeDeps({
+          daemonClient: daemonClient as never,
+          daemonBaseUrl: "http://localhost:9000",
+          onNotification: (message) => { notifications.push(message); },
+          onEvent: (event) => { events.push(event); },
+        }));
+        (runner as any).pendingTend = { goalId: "goal-xyz" };
+
+        const result = await runner.execute("y", "/repo");
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(result.success).toBe(true);
+        expect(daemonClient.startGoal).toHaveBeenCalledWith("goal-xyz");
+        expect((mockFetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(2);
+        expect((mockFetch as ReturnType<typeof vi.fn>).mock.invocationCallOrder[1]).toBeLessThan(
+          (daemonClient.startGoal as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]
+        );
+        expect(notifications.some((message) => message.includes("Morning Planning"))).toBe(true);
+        expect(events.some((event) => (
+          event.type === "activity"
+          && event.message.includes("Morning Planning")
+          && event.transient === false
+        ))).toBe(true);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+
+    it("/tend confirmation fails when durable subscription cannot be armed", async () => {
+      const daemonClient = {
+        startGoal: vi.fn().mockResolvedValue(undefined),
+      };
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ approvals: [], last_outbox_seq: 0 }),
+        })
+        .mockRejectedValueOnce(new Error("stream unavailable"))
+        .mockRejectedValueOnce(new Error("stream unavailable"));
+      vi.stubGlobal("fetch", mockFetch);
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(((fn: (...args: any[]) => void) => {
+        fn();
+        return 0 as any;
+      }) as typeof setTimeout);
+
+      try {
+        const runner = new ChatRunner(makeDeps({
+          daemonClient: daemonClient as never,
+          daemonBaseUrl: "http://localhost:9000",
+        }));
+        (runner as any).pendingTend = { goalId: "goal-xyz" };
+
+        const result = await runner.execute("y", "/repo");
+
+        expect(result.success).toBe(false);
+        expect(result.output).toContain("Daemon event stream unavailable");
+        expect(result.output).toContain("Goal was not started");
+        expect(daemonClient.startGoal).not.toHaveBeenCalled();
+      } finally {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+      }
     });
 
     it("/exit returns exit message without calling adapter", async () => {
@@ -1581,6 +1678,44 @@ describe("ChatRunner", () => {
         modelTier: "light",
         maxTokens: 256,
       });
+    });
+
+    it("supports routed ingress execution for TUI callers", async () => {
+      const adapter = makeMockAdapter();
+      const llmClient = {
+        sendMessage: vi.fn().mockResolvedValue({
+          content: "TUI answer",
+          usage: { input_tokens: 2, output_tokens: 3 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn(),
+      };
+
+      const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never }));
+      const result = await runner.executeIngressMessage({
+        text: "What is this lane?",
+        channel: "tui",
+        platform: "local_tui",
+        actor: {
+          surface: "tui",
+          platform: "local_tui",
+        },
+        replyTarget: {
+          surface: "tui",
+          platform: "local_tui",
+          metadata: {},
+        },
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+        metadata: {},
+      }, "/repo");
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe("TUI answer");
+      expect(result.diagnostics?.reason).toBe("simple_question");
+      expect(adapter.execute).not.toHaveBeenCalled();
     });
 
     it("does not route repository confirmation questions through the direct path", async () => {

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -87,8 +87,16 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(info?.conversation_id).toBe("conv-1");
     expect(info?.cwd).toBe("/repo");
     expect(info?.metadata).toMatchObject({
+      channel: "plugin_gateway",
       platform: "discord",
       conversation_id: "thread-9",
+      user_id: "user-a",
+    });
+    expect(info?.active_reply_target).toMatchObject({
+      surface: "gateway",
+      platform: "discord",
+      conversation_id: "thread-9",
+      identity_key: "user-123",
       user_id: "user-a",
     });
 
@@ -189,5 +197,55 @@ describe("CrossPlatformChatSessionManager", () => {
         }),
       })
     );
+
+    const info = manager.getSessionInfo({ identity_key: "owner" });
+    expect(info?.active_reply_target).toMatchObject({
+      surface: "gateway",
+      platform: "telegram",
+      conversation_id: "telegram-chat-1",
+      identity_key: "owner",
+      user_id: "user-1",
+    });
+  });
+
+  it("serializes concurrent turns for the same shared session across channels", async () => {
+    let activeCalls = 0;
+    let maxConcurrentCalls = 0;
+    const adapter = {
+      adapterType: "mock",
+      execute: vi.fn().mockImplementation(async () => {
+        activeCalls += 1;
+        maxConcurrentCalls = Math.max(maxConcurrentCalls, activeCalls);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        activeCalls -= 1;
+        return CANNED_RESULT;
+      }),
+    } as unknown as IAdapter;
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager: makeMockStateManager(),
+      adapter,
+    }));
+
+    await Promise.all([
+      manager.processIncomingMessage({
+        text: "turn one",
+        identity_key: "shared-user",
+        platform: "discord",
+        conversation_id: "discord-1",
+        sender_id: "u-1",
+        cwd: "/repo",
+      }),
+      manager.processIncomingMessage({
+        text: "turn two",
+        identity_key: "shared-user",
+        platform: "telegram",
+        conversation_id: "telegram-2",
+        sender_id: "u-1",
+        cwd: "/repo",
+      }),
+    ]);
+
+    expect(adapter.execute).toHaveBeenCalledTimes(2);
+    expect(maxConcurrentCalls).toBe(1);
   });
 });

--- a/src/interface/chat/__tests__/event-subscriber.test.ts
+++ b/src/interface/chat/__tests__/event-subscriber.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventSubscriber } from "../event-subscriber.js";
 import type { TendNotification, NotificationVerbosity } from "../event-subscriber.js";
+import type { ChatEvent } from "../chat-events.js";
 
 // ─── Helpers ───
 
@@ -191,7 +192,12 @@ describe("EventSubscriber", () => {
 
   describe("subscribe / unsubscribe", () => {
     it("bootstraps snapshot then connects to /stream with after cursor", async () => {
-      const stream = new ReadableStream({
+      const firstStream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+      const retryStream = new ReadableStream({
         start(controller) {
           controller.close();
         },
@@ -206,7 +212,12 @@ describe("EventSubscriber", () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          body: stream,
+          body: firstStream,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          body: retryStream,
         });
 
       vi.stubGlobal("fetch", mockFetch);
@@ -242,6 +253,66 @@ describe("EventSubscriber", () => {
 
       expect(abortMock).toHaveBeenCalledOnce();
       expect((sub as any).abortController).toBeNull();
+    });
+
+    it("subscribeReady resolves after a retry without waiting for the full stream lifecycle", async () => {
+      const stream = new ReadableStream({
+        start() {
+          // Keep the stream open; subscribeReady should still resolve once connected.
+        },
+      });
+
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ approvals: [], last_outbox_seq: 0 }),
+        })
+        .mockRejectedValueOnce(new Error("temporary failure"))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          body: stream,
+        });
+
+      vi.stubGlobal("fetch", mockFetch);
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(((fn: (...args: any[]) => void) => {
+        fn();
+        return 0 as any;
+      }) as typeof setTimeout);
+
+      try {
+        const sub = new EventSubscriber("http://localhost:9000", "goal-xyz", "quiet");
+        await expect(sub.subscribeReady()).resolves.toBeUndefined();
+      } finally {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+      }
+    });
+
+    it("subscribeReady rejects when both initial connect attempts fail", async () => {
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ approvals: [], last_outbox_seq: 0 }),
+        })
+        .mockRejectedValueOnce(new Error("temporary failure"))
+        .mockRejectedValueOnce(new Error("still failing"));
+
+      vi.stubGlobal("fetch", mockFetch);
+      vi.spyOn(globalThis, "setTimeout").mockImplementation(((fn: (...args: any[]) => void) => {
+        fn();
+        return 0 as any;
+      }) as typeof setTimeout);
+
+      try {
+        const sub = new EventSubscriber("http://localhost:9000", "goal-xyz", "quiet");
+        await expect(sub.subscribeReady()).rejects.toThrow("still failing");
+      } finally {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+      }
     });
   });
 
@@ -307,6 +378,33 @@ describe("EventSubscriber", () => {
       expect(received[0].message).toContain("Approve daily brief dispatch");
     });
 
+    it("projects loop_error events into notifications and chat events", () => {
+      const sub = makeSubscriber("goal-abc", "normal");
+      const notifications: TendNotification[] = [];
+      const chatEvents: ChatEvent[] = [];
+      sub.on("notification", (n: TendNotification) => notifications.push(n));
+      sub.on("chat_event", (event: ChatEvent) => chatEvents.push(event));
+
+      const raw = `id: 11\nevent: loop_error\ndata: {"goalId":"goal-abc","message":"boom","status":"error"}`;
+      (sub as any).parseSSEMessage(raw);
+
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]).toMatchObject({
+        type: "error",
+        goalId: "goal-abc",
+      });
+      expect(notifications[0].message).toContain("boom");
+      expect(chatEvents).toHaveLength(1);
+      expect(chatEvents[0]).toMatchObject({
+        type: "activity",
+        kind: "commentary",
+      });
+      if (chatEvents[0].type === "activity") {
+        expect(chatEvents[0].message).toContain("boom");
+        expect(chatEvents[0].sourceId).toBe("daemon:goal-abc:loop_error:error");
+      }
+    });
+
     it("ignores events for other goals when goalId is present", () => {
       const sub = makeSubscriber("goal-abc", "normal");
       const received: TendNotification[] = [];
@@ -317,6 +415,96 @@ describe("EventSubscriber", () => {
 
       expect(received).toHaveLength(0);
       expect((sub as any).lastOutboxSeq).toBe(7);
+    });
+
+    it("emits transcript-compatible chat events for durable progress", () => {
+      const sub = makeSubscriber("goal-abc", "normal");
+      const received: ChatEvent[] = [];
+      sub.on("chat_event", (event: ChatEvent) => received.push(event));
+
+      const raw = `id: 9\nevent: progress\ndata: {"phase":"Observing...","gap":0.5,"iteration":1,"maxIterations":5}`;
+      (sub as any).parseSSEMessage(raw);
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toMatchObject({
+        type: "activity",
+        kind: "commentary",
+      });
+      if (received[0].type === "activity") {
+        expect(received[0].message).toContain("[1/5]");
+        expect(received[0].message).toContain("gap: 0.50");
+        expect(received[0].message).not.toContain("0.50→0.50");
+        expect(received[0].sourceId).toBe("daemon:goal-abc:progress");
+      }
+    });
+
+    it("emits assistant_final chat events for chat_response", () => {
+      const sub = makeSubscriber("goal-abc", "normal");
+      const received: ChatEvent[] = [];
+      sub.on("chat_event", (event: ChatEvent) => received.push(event));
+
+      const raw = `id: 10\nevent: chat_response\ndata: {"goalId":"goal-abc","message":"queued","status":"queued"}`;
+      (sub as any).parseSSEMessage(raw);
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toMatchObject({
+        type: "assistant_final",
+        text: "queued",
+        persisted: false,
+      });
+    });
+
+    it("projects snapshot approvals into chat events during bootstrap", async () => {
+      const firstStream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+      const retryStream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            approvals: [{
+              goalId: "goal-xyz",
+              requestId: "approval-123",
+              task: { description: "Approve daily brief dispatch" },
+            }],
+            last_outbox_seq: 5,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          body: firstStream,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          body: retryStream,
+        });
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const sub = new EventSubscriber("http://localhost:9000", "goal-xyz", "normal");
+      const received: ChatEvent[] = [];
+      sub.on("chat_event", (event: ChatEvent) => received.push(event));
+
+      await sub.subscribe();
+
+      expect(received.some((event) => (
+        event.type === "activity"
+        && event.message.includes("Approve daily brief dispatch")
+        && event.sourceId === "daemon:goal-xyz:approval_required:approval-123"
+      ))).toBe(true);
+
+      vi.unstubAllGlobals();
     });
   });
 

--- a/src/interface/chat/__tests__/ingress-router.test.ts
+++ b/src/interface/chat/__tests__/ingress-router.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { IngressRouter, buildStandaloneIngressMessage } from "../ingress-router.js";
+
+describe("IngressRouter", () => {
+  const router = new IngressRouter();
+
+  it("selects direct answers for simple questions regardless of ingress channel", () => {
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: "What is a lightweight direct-answer route?",
+        channel: "plugin_gateway",
+        platform: "discord",
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      }),
+      {
+        hasLightweightLlm: true,
+        hasAgentLoop: false,
+        hasToolLoop: true,
+      }
+    );
+
+    expect(route.kind).toBe("direct_answer");
+    expect(route.lane).toBe("fast");
+    expect(route.replyTargetPolicy).toBe("turn_reply_target");
+    expect(route.daemonChatPolicy).toBe("compatibility_only");
+  });
+
+  it("keeps repository-inspection questions off the direct-answer route", () => {
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: "What files changed?",
+      }),
+      {
+        hasLightweightLlm: true,
+        hasAgentLoop: false,
+        hasToolLoop: true,
+      }
+    );
+
+    expect(route.kind).toBe("tool_loop");
+  });
+
+  it("routes explicit runtime-control requests to the durable lane when allowed", () => {
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: "PulSeed を再起動して",
+        channel: "plugin_gateway",
+        platform: "telegram",
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      }),
+      {
+        hasLightweightLlm: true,
+        hasAgentLoop: true,
+        hasToolLoop: true,
+      }
+    );
+
+    expect(route.kind).toBe("runtime_control");
+    expect(route.lane).toBe("durable");
+    expect(route.eventProjectionPolicy).toBe("latest_active_reply_target");
+  });
+
+  it("does not route runtime-control text to the durable lane when ingress policy disallows it", () => {
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: "PulSeed を再起動して",
+        channel: "plugin_gateway",
+        platform: "telegram",
+        runtimeControl: {
+          allowed: false,
+          approvalMode: "disallowed",
+        },
+      }),
+      {
+        hasLightweightLlm: true,
+        hasAgentLoop: true,
+        hasToolLoop: true,
+      }
+    );
+
+    expect(route.kind).toBe("agent_loop");
+    expect(route.lane).toBe("fast");
+  });
+});

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -47,7 +47,6 @@ import {
   buildPromptedToolProtocolSystemPrompt,
   extractPromptedToolCalls,
 } from "../../orchestrator/execution/agent-loop/prompted-tool-protocol.js";
-import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
 import type { RuntimeControlService } from "../../runtime/control/index.js";
 import type {
   RuntimeControlActor,
@@ -59,6 +58,12 @@ import {
   withExecutionPolicyOverrides,
   type ExecutionPolicy,
 } from "../../orchestrator/execution/agent-loop/execution-policy.js";
+import {
+  buildStandaloneIngressMessage,
+  createIngressRouter,
+  type ChatIngressMessage,
+  type SelectedChatRoute,
+} from "./ingress-router.js";
 
 // ─── Types ───
 
@@ -131,6 +136,11 @@ export interface RuntimeControlChatContext {
   approvalFn?: (description: string) => Promise<boolean>;
 }
 
+export interface ChatRunnerExecutionOptions {
+  selectedRoute?: SelectedChatRoute;
+  runtimeControlContext?: RuntimeControlChatContext | null;
+}
+
 interface AssistantBuffer {
   text: string;
 }
@@ -153,7 +163,7 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
 const MAX_TOOL_LOOPS = 5;
 const ACTIVITY_PREVIEW_CHARS = 40;
-const DIRECT_ANSWER_MAX_TOKENS = 256;
+const standaloneIngressRouter = createIngressRouter();
 
 // ─── Command help text ───
 
@@ -211,31 +221,6 @@ function previewActivityText(value: string, maxChars = ACTIVITY_PREVIEW_CHARS): 
 function formatToolActivity(action: "Running" | "Finished" | "Failed", toolName: string, detail?: string): string {
   const preview = detail ? previewActivityText(detail) : "";
   return preview ? `${action} tool: ${toolName} - ${preview}` : `${action} tool: ${toolName}`;
-}
-
-function shouldUseDirectAnswerRoute(input: string): boolean {
-  const normalized = input.trim();
-  if (!normalized) return false;
-
-  const lowered = normalized.toLowerCase();
-  const questionSignals = [
-    /[?？]/,
-    /\b(what|why|how|when|where|who|which|is|are|can|could|would|should|tell me|explain|describe|help me understand)\b/,
-    /(教えて|説明して|教えてください|説明してください|どう思う|なんで|なぜ|どうして|いつ|どこ|だれ|誰|何|どれ|どっち)/,
-  ];
-  if (!questionSignals.some((pattern) => pattern.test(lowered))) {
-    return false;
-  }
-
-  const workSignals = [
-    /\b(fix|implement|change|changed|add|remove|delete|update|refactor|patch|debug|diagnose|investigate|review|write|create|build|run|execute|test|verify|confirm|check|inspect|search|open|read|edit|modify|commit|push|merge|release|deploy|start|stop|restart|resume|compare|convert|migrate|optimize|improve|configure|setup|set up)\b/,
-    /(修正|実装|変更|追加|削除|更新|リファクタ|デバッグ|調査|確認|レビュー|書いて|作って|作成|実行|走らせ|テスト|検証|調べて|開いて|読んで|編集|コミット|プッシュ|マージ|デプロイ|再起動|再開|設定)/,
-    /\b(git|repo|repository|branch|commit|diff|pull request|pr|issue|ticket|adapter|agentloop|tool|tools|code)\b|コード|src\//,
-    /\b(latest|most recent|current|today|now|recent|news|web|internet|api|docs|github|release|version)\b|最新|最新版|今日|現在|最近|今|外部|ネット/,
-    /\bwhat\s+(files?\s+)?changed\b|\bwhich\s+files?\s+(changed|were\s+(modified|edited))\b/,
-    /(\.(ts|tsx|js|jsx|json|md|yml|yaml|toml|py|go|rs|sh|sql)\b|\/[^/\s]+\.[A-Za-z0-9]+$)/,
-  ];
-  return !workSignals.some((pattern) => pattern.test(lowered));
 }
 
 // ─── ChatRunner ───
@@ -309,6 +294,80 @@ export class ChatRunner {
 
   setRuntimeControlContext(context: RuntimeControlChatContext | null): void {
     this.runtimeControlContext = context;
+  }
+
+  async executeIngressMessage(
+    ingress: ChatIngressMessage,
+    cwd: string,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    selectedRoute?: SelectedChatRoute
+  ): Promise<ChatRunResult> {
+    const runtimeControlContext = this.buildRuntimeControlContextFromIngress(ingress);
+    return this.execute(ingress.text, cwd, timeoutMs, {
+      selectedRoute: selectedRoute ?? standaloneIngressRouter.selectRoute(ingress, this.getRouteCapabilities()),
+      runtimeControlContext,
+    });
+  }
+
+  private getRouteCapabilities(): {
+    hasLightweightLlm: boolean;
+    hasAgentLoop: boolean;
+    hasToolLoop: boolean;
+    hasRuntimeControlService: boolean;
+  } {
+    return {
+      hasLightweightLlm: this.deps.llmClient !== undefined,
+      hasAgentLoop: this.deps.chatAgentLoopRunner !== undefined,
+      hasToolLoop: this.deps.llmClient !== undefined,
+      hasRuntimeControlService: this.deps.runtimeControlService !== undefined,
+    };
+  }
+
+  private buildStandaloneIngressMessage(
+    input: string,
+    runtimeControlContext: RuntimeControlChatContext | null
+  ): ChatIngressMessage {
+    const channel = runtimeControlContext?.replyTarget?.surface === "tui"
+      ? "tui"
+      : runtimeControlContext?.replyTarget?.surface === "cli"
+        ? "cli"
+        : runtimeControlContext?.replyTarget?.surface === "gateway"
+          ? "plugin_gateway"
+          : "cli";
+    const runtimeApprovalFn = runtimeControlContext?.approvalFn
+      ?? this.deps.runtimeControlApprovalFn
+      ?? this.deps.approvalFn;
+    return buildStandaloneIngressMessage({
+      text: input,
+      channel,
+      platform: runtimeControlContext?.replyTarget?.platform ?? this.deps.runtimeReplyTarget?.platform,
+      identity_key: runtimeControlContext?.replyTarget?.identity_key ?? this.deps.runtimeReplyTarget?.identity_key,
+      conversation_id: runtimeControlContext?.replyTarget?.conversation_id ?? this.deps.runtimeReplyTarget?.conversation_id,
+      user_id: runtimeControlContext?.replyTarget?.user_id ?? this.deps.runtimeReplyTarget?.user_id,
+      actor: runtimeControlContext?.actor ?? this.deps.runtimeControlActor,
+      replyTarget: runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget,
+      runtimeControl: {
+        allowed: true,
+        approvalMode: "interactive",
+      },
+    });
+  }
+
+  private buildRuntimeControlContextFromIngress(ingress: ChatIngressMessage): RuntimeControlChatContext | null {
+    if (!ingress.actor && !ingress.replyTarget) return null;
+    const interactiveApproval =
+      this.runtimeControlContext?.approvalFn
+      ?? this.deps.runtimeControlApprovalFn
+      ?? this.deps.approvalFn;
+    return {
+      actor: ingress.actor,
+      replyTarget: ingress.replyTarget,
+      approvalFn: ingress.runtimeControl.approvalMode === "preapproved"
+        ? async () => true
+        : ingress.runtimeControl.approvalMode === "interactive"
+          ? interactiveApproval
+          : undefined,
+    };
   }
 
   private loadedSessionToChatSession(session: LoadedChatSession): ChatSession {
@@ -1262,34 +1321,49 @@ export class ChatRunner {
       };
     }
 
+    const { goalId, maxIterations } = pending;
+    let subscriber: EventSubscriber | null = null;
+    if (this.deps.daemonBaseUrl && !this.activeSubscribers.has(goalId)) {
+      subscriber = new EventSubscriber(this.deps.daemonBaseUrl, goalId, "normal");
+      this.activeSubscribers.set(goalId, subscriber);
+
+      subscriber.on("notification", (notification: unknown) => {
+        const n = notification as { message: string };
+        this.deps.onNotification?.(n.message);
+        this.onNotification?.(n.message);
+      });
+
+      subscriber.on("chat_event", (event: ChatEvent) => {
+        this.emitEvent(event);
+      });
+
+      try {
+        await subscriber.subscribeReady();
+      } catch (err) {
+        subscriber.unsubscribe();
+        this.activeSubscribers.delete(goalId);
+        const msg = err instanceof Error ? err.message : String(err);
+        return {
+          success: false,
+          output: `Daemon event stream unavailable: ${msg}. Goal was not started.`,
+          elapsed_ms: Date.now() - start,
+        };
+      }
+    }
+
     try {
-      await this.deps.daemonClient.startGoal(pending.goalId);
+      await this.deps.daemonClient.startGoal(goalId);
     } catch (err) {
+      if (subscriber) {
+        subscriber.unsubscribe();
+        this.activeSubscribers.delete(goalId);
+      }
       const msg = err instanceof Error ? err.message : String(err);
       return {
         success: false,
         output: `Daemon unavailable: ${msg}. Start the daemon with 'pulseed daemon start' first.`,
         elapsed_ms: Date.now() - start,
       };
-    }
-
-    // Subscribe to EventServer progress notifications (non-blocking)
-    const { goalId, maxIterations } = pending;
-    if (this.deps.daemonBaseUrl && !this.activeSubscribers.has(goalId)) {
-      const subscriber = new EventSubscriber(this.deps.daemonBaseUrl, goalId, "normal");
-      this.activeSubscribers.set(goalId, subscriber);
-
-      subscriber.on("notification", (notification: unknown) => {
-        const n = notification as { message: string };
-        // Invoke both the deps callback (wired at construction) and the public
-        // onNotification property (wired post-construction, e.g. from React useEffect)
-        this.deps.onNotification?.(n.message);
-        this.onNotification?.(n.message);
-      });
-
-      subscriber.subscribe().catch(() => {
-        // Connection failures are handled inside EventSubscriber
-      });
     }
 
     const iterNote = maxIterations !== undefined ? ` (max ${maxIterations} iterations)` : "";
@@ -1313,10 +1387,16 @@ export class ChatRunner {
    *  6. Verify changes (git diff + tests); retry up to MAX_VERIFY_RETRIES if tests fail
    *  7. Persist assistant response only after the final assistant text is complete
    */
-  async execute(input: string, cwd: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<ChatRunResult> {
+  async execute(
+    input: string,
+    cwd: string,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    options: ChatRunnerExecutionOptions = {}
+  ): Promise<ChatRunResult> {
     const eventContext = this.createEventContext();
     const resumeCommand = this.parseResumeCommand(input);
     const resumeOnly = resumeCommand !== null;
+    const runtimeControlContext = options.runtimeControlContext ?? this.runtimeControlContext;
 
     // Intercept commands before any adapter call
     const commandResult = resumeOnly ? null : await this.handleCommand(input);
@@ -1351,27 +1431,6 @@ export class ChatRunner {
         false
       );
       return confirmationResult;
-    }
-
-    const runtimeControlResult = resumeOnly
-      ? null
-      : await this.handleRuntimeControlIntent(input, cwd, Date.now());
-    if (runtimeControlResult !== null) {
-      if (runtimeControlResult.output) {
-        this.emitEvent({
-          type: "assistant_final",
-          text: runtimeControlResult.output,
-          persisted: false,
-          ...this.eventBase(eventContext),
-        });
-      }
-      this.emitLifecycleEndEvent(
-        runtimeControlResult.success ? "completed" : "error",
-        runtimeControlResult.elapsed_ms,
-        eventContext,
-        false
-      );
-      return runtimeControlResult;
     }
 
     if (resumeOnly && resumeCommand.selector) {
@@ -1457,14 +1516,43 @@ export class ChatRunner {
       historyBlock = `${historySections.join("\n\n")}\n\nCurrent message:\n`;
     }
 
-    const directAnswerRoute = !resumeOnly && !this.deps.chatAgentLoopRunner && this.deps.llmClient !== undefined && shouldUseDirectAnswerRoute(input);
+    const selectedRoute = resumeOnly
+      ? null
+      : (options.selectedRoute ?? standaloneIngressRouter.selectRoute(
+        this.buildStandaloneIngressMessage(input, runtimeControlContext),
+        this.getRouteCapabilities()
+      ));
     const directPrompt = historyBlock ? `${historyBlock}${input}` : input;
 
     const start = Date.now();
     const assistantBuffer: AssistantBuffer = { text: "" };
     const turnUsage = this.zeroUsageCounter();
 
-    if (directAnswerRoute) {
+    if (selectedRoute?.kind === "runtime_control") {
+      const runtimeControlResult = await this.executeRuntimeControlRoute(
+        selectedRoute,
+        runtimeControlContext,
+        cwd,
+        start
+      );
+      if (runtimeControlResult.success) {
+        await history.appendAssistantMessage(runtimeControlResult.output);
+        this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
+        this.emitEvent({
+          type: "assistant_final",
+          text: runtimeControlResult.output,
+          persisted: true,
+          ...this.eventBase(eventContext),
+        });
+        this.emitLifecycleEndEvent("completed", runtimeControlResult.elapsed_ms, eventContext, true);
+      } else {
+        this.emitLifecycleErrorEvent(runtimeControlResult.output, assistantBuffer.text, eventContext);
+        this.emitLifecycleEndEvent("error", runtimeControlResult.elapsed_ms, eventContext, false);
+      }
+      return runtimeControlResult;
+    }
+
+    if (selectedRoute?.kind === "direct_answer") {
       try {
         this.emitActivity("lifecycle", "Calling model...", eventContext, "lifecycle:model");
         const directResponse = await this.sendLLMMessage(
@@ -1472,8 +1560,8 @@ export class ChatRunner {
           [{ role: "user", content: directPrompt }],
           {
             ...(this.cachedStaticSystemPrompt ? { system: this.cachedStaticSystemPrompt } : {}),
-            model_tier: "light",
-            max_tokens: DIRECT_ANSWER_MAX_TOKENS,
+            model_tier: selectedRoute.modelTier,
+            max_tokens: selectedRoute.maxTokens,
           },
           assistantBuffer,
           eventContext
@@ -1499,9 +1587,9 @@ export class ChatRunner {
           elapsed_ms,
           diagnostics: {
             route: "direct",
-            reason: "simple_question",
-            modelTier: "light",
-            maxTokens: DIRECT_ANSWER_MAX_TOKENS,
+            reason: selectedRoute.reason,
+            modelTier: selectedRoute.modelTier,
+            maxTokens: selectedRoute.maxTokens,
           },
         };
       } catch (err) {
@@ -1516,29 +1604,31 @@ export class ChatRunner {
           elapsed_ms: Date.now() - start,
           diagnostics: {
             route: "direct",
-            reason: "simple_question",
-            modelTier: "light",
-            maxTokens: DIRECT_ANSWER_MAX_TOKENS,
+            reason: selectedRoute.reason,
+            modelTier: selectedRoute.modelTier,
+            maxTokens: selectedRoute.maxTokens,
           },
         };
       }
     }
 
     let systemPrompt = this.cachedStaticSystemPrompt ?? "";
-    try {
-      this.emitActivity("lifecycle", "Preparing context...", eventContext, "lifecycle:context");
-      const groundingBundle = await this.groundingGateway.build({
-        surface: "chat",
-        purpose: "general_turn",
-        workspaceRoot: cwd,
-        goalId: this.deps.goalId,
-        userMessage: input,
-        query: input,
-        trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
-      });
-      systemPrompt = String(groundingBundle.render("prompt"));
-    } catch {
-      systemPrompt = this.cachedStaticSystemPrompt ?? "";
+    if (!resumeOnly) {
+      try {
+        this.emitActivity("lifecycle", "Preparing context...", eventContext, "lifecycle:context");
+        const groundingBundle = await this.groundingGateway.build({
+          surface: "chat",
+          purpose: "general_turn",
+          workspaceRoot: cwd,
+          goalId: this.deps.goalId,
+          userMessage: input,
+          query: input,
+          trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
+        });
+        systemPrompt = String(groundingBundle.render("prompt"));
+      } catch {
+        systemPrompt = this.cachedStaticSystemPrompt ?? "";
+      }
     }
     const agentLoopSystemPrompt = [
       systemPrompt,
@@ -1569,7 +1659,8 @@ export class ChatRunner {
       };
     }
 
-    if (this.deps.chatAgentLoopRunner) {
+    const chatAgentLoopRunner = this.deps.chatAgentLoopRunner;
+    if (resumeOnly || selectedRoute?.kind === "agent_loop") {
       try {
         const resumeState = resumeOnly ? await this.loadResumableAgentLoopState() : null;
         if (resumeOnly && !resumeState) {
@@ -1589,7 +1680,7 @@ export class ChatRunner {
           };
         }
         this.emitActivity("lifecycle", "Calling model...", eventContext, "lifecycle:model");
-        const result = await this.deps.chatAgentLoopRunner.execute({
+        const result = await chatAgentLoopRunner!.execute({
           message: basePrompt,
           cwd,
           goalId: this.deps.goalId,
@@ -1656,7 +1747,7 @@ export class ChatRunner {
     }
 
     // Prefer the local LLM/tool loop over the external adapter fallback whenever a client is available.
-    if (this.deps.llmClient) {
+    if (selectedRoute?.kind === "tool_loop") {
       try {
         const toolResult = await this.executeWithTools(prompt, eventContext, assistantBuffer, systemPrompt || undefined);
         const elapsed_ms = Date.now() - start;
@@ -1685,6 +1776,18 @@ export class ChatRunner {
           elapsed_ms: Date.now() - start,
         };
       }
+    }
+
+    if (!resumeOnly && selectedRoute && selectedRoute.kind !== "adapter") {
+      const elapsed_ms = Date.now() - start;
+      const output = `Unsupported chat route: ${selectedRoute.kind}`;
+      this.emitLifecycleErrorEvent(output, assistantBuffer.text, eventContext);
+      this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
+      return {
+        success: false,
+        output,
+        elapsed_ms,
+      };
     }
 
     const task: AgentTask = {
@@ -1769,14 +1872,12 @@ export class ChatRunner {
     };
   }
 
-  private async handleRuntimeControlIntent(
-    input: string,
+  private async executeRuntimeControlRoute(
+    route: Extract<SelectedChatRoute, { kind: "runtime_control" }>,
+    runtimeControlContext: RuntimeControlChatContext | null,
     cwd: string,
     start: number
-  ): Promise<ChatRunResult | null> {
-    const intent = recognizeRuntimeControlIntent(input);
-    if (intent === null) return null;
-
+  ): Promise<ChatRunResult> {
     if (!this.deps.runtimeControlService) {
       return {
         success: false,
@@ -1785,10 +1886,10 @@ export class ChatRunner {
       };
     }
 
-    const replyTarget = this.runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget;
-    const actor = this.runtimeControlContext?.actor ?? this.deps.runtimeControlActor;
+    const replyTarget = runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget;
+    const actor = runtimeControlContext?.actor ?? this.deps.runtimeControlActor;
     const result = await this.deps.runtimeControlService.request({
-      intent,
+      intent: route.intent,
       cwd,
       requestedBy: actor ?? {
         surface: replyTarget?.surface ?? "chat",
@@ -1798,7 +1899,7 @@ export class ChatRunner {
         user_id: replyTarget?.user_id,
       },
       replyTarget: replyTarget ?? { surface: "chat" },
-      approvalFn: this.runtimeControlContext?.approvalFn
+      approvalFn: runtimeControlContext?.approvalFn
         ?? this.deps.runtimeControlApprovalFn
         ?? this.deps.approvalFn,
     });

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -2,8 +2,15 @@ import { randomUUID } from "node:crypto";
 import * as path from "node:path";
 import { ChatRunner } from "./chat-runner.js";
 import type { ChatRunResult, ChatRunnerDeps } from "./chat-runner.js";
-import type { RuntimeControlChatContext } from "./chat-runner.js";
 import type { ChatEvent, ChatEventHandler } from "./chat-events.js";
+import {
+  createIngressRouter,
+  type ChatIngressChannel,
+  type ChatIngressMessage,
+  type ChatIngressReplyTarget,
+  type ChatIngressRuntimeControl,
+  type SelectedChatRoute,
+} from "./ingress-router.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { buildAdapterRegistry, buildLLMClient } from "../../base/llm/provider-factory.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
@@ -33,6 +40,7 @@ import {
   createDaemonRuntimeControlExecutor,
 } from "../../runtime/control/index.js";
 import { registerGlobalCrossPlatformChatSessionManager } from "./cross-platform-session-global.js";
+import type { RuntimeControlActor } from "../../runtime/store/runtime-operation-schemas.js";
 
 export interface CrossPlatformChatSessionOptions {
   /**
@@ -50,6 +58,16 @@ export interface CrossPlatformChatSessionOptions {
   user_id?: string;
   /** Human-readable user name. */
   user_name?: string;
+  /** Channel family for ingress normalization. */
+  channel?: ChatIngressChannel;
+  /** Optional per-turn message id from the transport. */
+  message_id?: string;
+  /** Explicit typed actor override for routing/runtime control. */
+  actor?: Partial<RuntimeControlActor>;
+  /** Explicit reply target override for outbound routing. */
+  replyTarget?: Partial<ChatIngressReplyTarget>;
+  /** Explicit runtime-control policy for the turn. */
+  runtimeControl?: Partial<ChatIngressRuntimeControl>;
   /** Workspace root or working directory used when the session is created. */
   cwd?: string;
   /** Per-turn timeout forwarded to ChatRunner. */
@@ -62,6 +80,7 @@ export interface CrossPlatformChatSessionOptions {
 
 export interface CrossPlatformIncomingChatMessage {
   text: string;
+  channel?: ChatIngressChannel;
   identity_key?: string;
   platform?: string;
   conversation_id?: string;
@@ -72,9 +91,14 @@ export interface CrossPlatformIncomingChatMessage {
   message_id?: string;
   cwd?: string;
   timeoutMs?: number;
+  actor?: Partial<RuntimeControlActor>;
+  replyTarget?: Partial<ChatIngressReplyTarget>;
+  runtimeControl?: Partial<ChatIngressRuntimeControl>;
   metadata?: Record<string, unknown>;
   onEvent?: ChatEventHandler;
 }
+
+export type CrossPlatformIngressMessage = ChatIngressMessage;
 
 export interface CrossPlatformChatSessionInfo {
   session_key: string;
@@ -87,6 +111,8 @@ export interface CrossPlatformChatSessionInfo {
   cwd: string;
   created_at: string;
   last_used_at: string;
+  last_message_id?: string;
+  active_reply_target?: ChatIngressReplyTarget;
   metadata: Record<string, unknown>;
 }
 
@@ -94,6 +120,7 @@ interface ManagedChatSession {
   runner: ChatRunner;
   info: CrossPlatformChatSessionInfo;
   queue: Promise<void>;
+  lastRoute?: SelectedChatRoute;
 }
 
 function normalizeIdentity(value: string | undefined): string | null {
@@ -106,19 +133,24 @@ function normalizePlatform(value: string | undefined): string | null {
   return trimmed ? trimmed.toLowerCase() : null;
 }
 
-function buildSessionKey(options: CrossPlatformChatSessionOptions): string {
-  const identityKey = normalizeIdentity(options.identity_key);
+function buildSessionKeyFromParts(params: {
+  identity_key?: string;
+  platform?: string;
+  conversation_id?: string;
+  user_id?: string;
+}): string {
+  const identityKey = normalizeIdentity(params.identity_key);
   if (identityKey) {
     return `identity:${identityKey}`;
   }
 
-  const platform = normalizePlatform(options.platform);
-  const conversationId = normalizeIdentity(options.conversation_id);
+  const platform = normalizePlatform(params.platform);
+  const conversationId = normalizeIdentity(params.conversation_id);
   if (platform && conversationId) {
     return `platform:${platform}:conversation:${conversationId}`;
   }
 
-  const userId = normalizeIdentity(options.user_id);
+  const userId = normalizeIdentity(params.user_id);
   if (platform && userId) {
     return `platform:${platform}:user:${userId}`;
   }
@@ -126,13 +158,26 @@ function buildSessionKey(options: CrossPlatformChatSessionOptions): string {
   return `ephemeral:${randomUUID()}`;
 }
 
+function buildSessionKey(options: CrossPlatformChatSessionOptions): string {
+  return buildSessionKeyFromParts(options);
+}
+
 function cloneMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> {
   return metadata ? { ...metadata } : {};
 }
 
-function buildSessionMetadata(options: CrossPlatformChatSessionOptions): Record<string, unknown> {
+function buildSessionMetadata(options: {
+  metadata?: Record<string, unknown>;
+  platform?: string;
+  conversation_id?: string;
+  conversation_name?: string;
+  user_id?: string;
+  user_name?: string;
+  channel?: ChatIngressChannel;
+}): Record<string, unknown> {
   return {
     ...(options.metadata ?? {}),
+    ...(options.channel ? { channel: options.channel } : {}),
     ...(options.platform ? { platform: options.platform } : {}),
     ...(options.conversation_id ? { conversation_id: options.conversation_id } : {}),
     ...(options.conversation_name ? { conversation_name: options.conversation_name } : {}),
@@ -141,32 +186,99 @@ function buildSessionMetadata(options: CrossPlatformChatSessionOptions): Record<
   };
 }
 
-function buildRuntimeControlChatContext(
-  options: CrossPlatformChatSessionOptions
-): RuntimeControlChatContext | null {
-  const platform = normalizePlatform(options.platform);
-  const conversationId = normalizeIdentity(options.conversation_id);
-  const identityKey = normalizeIdentity(options.identity_key);
-  const userId = normalizeIdentity(options.user_id);
-  if (!platform && !conversationId && !identityKey && !userId) return null;
-  const runtimeControlApproved = options.metadata?.["runtime_control_approved"] === true;
+function resolveChannel(
+  input: Pick<CrossPlatformIncomingChatMessage, "channel" | "platform"> | CrossPlatformChatSessionOptions
+): ChatIngressChannel {
+  if (input.channel) return input.channel;
+  return input.platform ? "plugin_gateway" : "cli";
+}
+
+function resolveActorSurface(channel: ChatIngressChannel): RuntimeControlActor["surface"] {
+  switch (channel) {
+    case "plugin_gateway":
+      return "gateway";
+    case "cli":
+      return "cli";
+    case "tui":
+      return "tui";
+    default:
+      return "chat";
+  }
+}
+
+function resolveRuntimeControl(
+  channel: ChatIngressChannel,
+  runtimeControl: Partial<ChatIngressRuntimeControl> | undefined,
+  metadata: Record<string, unknown> | undefined
+): ChatIngressRuntimeControl {
+  const approvalMode = runtimeControl?.approvalMode
+    ?? (metadata?.["runtime_control_approved"] === true
+      ? "preapproved"
+      : channel === "tui" || channel === "cli"
+        ? "interactive"
+        : "disallowed");
+  return {
+    allowed: runtimeControl?.allowed ?? approvalMode !== "disallowed",
+    approvalMode,
+  };
+}
+
+function normalizeReplyTarget(
+  channel: ChatIngressChannel,
+  input: {
+    platform?: string;
+    conversation_id?: string;
+    identity_key?: string;
+    user_id?: string;
+    message_id?: string;
+    replyTarget?: Partial<ChatIngressReplyTarget>;
+    metadata?: Record<string, unknown>;
+  }
+): ChatIngressReplyTarget {
+  const platform = normalizePlatform(input.replyTarget?.platform ?? input.platform) ?? undefined;
+  const conversationId = normalizeIdentity(input.replyTarget?.conversation_id ?? input.conversation_id) ?? undefined;
+  const identityKey = normalizeIdentity(input.replyTarget?.identity_key ?? input.identity_key) ?? undefined;
+  const userId = normalizeIdentity(input.replyTarget?.user_id ?? input.user_id) ?? undefined;
+  const messageId = normalizeIdentity(input.replyTarget?.message_id ?? input.message_id) ?? undefined;
 
   return {
-    actor: {
-      surface: platform ? "gateway" : "chat",
-      ...(platform ? { platform } : {}),
-      ...(conversationId ? { conversation_id: conversationId } : {}),
-      ...(identityKey ? { identity_key: identityKey } : {}),
-      ...(userId ? { user_id: userId } : {}),
+    surface: input.replyTarget?.surface ?? resolveActorSurface(channel),
+    ...(platform ? { platform } : {}),
+    ...(conversationId ? { conversation_id: conversationId } : {}),
+    ...(identityKey ? { identity_key: identityKey } : {}),
+    ...(userId ? { user_id: userId } : {}),
+    ...(messageId ? { message_id: messageId } : {}),
+    deliveryMode: input.replyTarget?.deliveryMode ?? "reply",
+    metadata: {
+      ...(input.metadata ?? {}),
+      ...(input.replyTarget?.metadata ?? {}),
     },
-    replyTarget: {
-      surface: platform ? "gateway" : "chat",
-      ...(platform ? { platform } : {}),
-      ...(conversationId ? { conversation_id: conversationId } : {}),
-      ...(identityKey ? { identity_key: identityKey } : {}),
-      ...(userId ? { user_id: userId } : {}),
-    },
-    ...(runtimeControlApproved ? { approvalFn: async () => true } : {}),
+    ...input.replyTarget,
+  };
+}
+
+function normalizeActor(
+  channel: ChatIngressChannel,
+  input: {
+    platform?: string;
+    conversation_id?: string;
+    identity_key?: string;
+    user_id?: string;
+    actor?: Partial<RuntimeControlActor>;
+  }
+): RuntimeControlActor {
+  const platform = normalizePlatform(input.actor?.platform ?? input.platform) ?? undefined;
+  const conversationId = normalizeIdentity(input.actor?.conversation_id ?? input.conversation_id) ?? undefined;
+  const identityKey = normalizeIdentity(input.actor?.identity_key ?? input.identity_key) ?? undefined;
+  const userId = normalizeIdentity(input.actor?.user_id ?? input.user_id) ?? undefined;
+
+  return {
+    surface: input.actor?.surface ?? resolveActorSurface(channel),
+    ...(platform ? { platform } : {}),
+    ...(conversationId ? { conversation_id: conversationId } : {}),
+    ...(identityKey ? { identity_key: identityKey } : {}),
+    ...(userId ? { user_id: userId } : {}),
+    ...input.actor,
   };
 }
 
@@ -184,6 +296,7 @@ function safeInvoke(handler: ChatEventHandler | undefined, event: ChatEvent): vo
 
 export class CrossPlatformChatSessionManager {
   private readonly sessions = new Map<string, ManagedChatSession>();
+  private readonly ingressRouter = createIngressRouter();
 
   constructor(private readonly deps: ChatRunnerDeps) {}
 
@@ -193,30 +306,46 @@ export class CrossPlatformChatSessionManager {
    * otherwise it creates an isolated one-shot session.
    */
   async execute(input: string, options: CrossPlatformChatSessionOptions = {}): Promise<ChatRunResult> {
-    const session = this.getOrCreateSession(options);
-    const queueEntry = session.queue.then(() => this.executeInSession(session, input, options));
+    const ingress = this.createIngressMessage({
+      text: input,
+      identity_key: options.identity_key,
+      platform: options.platform,
+      conversation_id: options.conversation_id,
+      conversation_name: options.conversation_name,
+      user_id: options.user_id,
+      user_name: options.user_name,
+      message_id: options.message_id,
+      channel: options.channel ?? (options.platform ? "plugin_gateway" : "cli"),
+      actor: options.actor,
+      replyTarget: options.replyTarget,
+      runtimeControl: options.runtimeControl ?? {
+        allowed: true,
+        approvalMode: "interactive",
+      },
+      cwd: options.cwd,
+      timeoutMs: options.timeoutMs,
+      metadata: options.metadata,
+      onEvent: options.onEvent,
+    });
+    const session = this.getOrCreateSession(ingress, options.cwd);
+    const queueEntry = session.queue.then(() => this.executeInSession(session, ingress, options));
     session.queue = queueEntry.then(() => undefined, () => undefined);
     return queueEntry;
   }
 
   async processIncomingMessage(input: CrossPlatformIncomingChatMessage): Promise<string> {
-    const result = await this.execute(input.text, {
-      identity_key: input.identity_key,
-      platform: input.platform,
-      conversation_id: input.conversation_id,
-      conversation_name: input.conversation_name,
-      user_id: input.user_id ?? input.sender_id,
-      user_name: input.user_name,
-      cwd: input.cwd,
-      timeoutMs: input.timeoutMs,
-      metadata: {
-        ...(input.metadata ?? {}),
-        ...(input.sender_id ? { sender_id: input.sender_id } : {}),
-        ...(input.message_id ? { message_id: input.message_id } : {}),
-      },
-      onEvent: input.onEvent,
-    });
+    const result = await this.executeIngress(this.createIngressMessage(input), input);
     return result.output;
+  }
+
+  async executeIngress(
+    ingress: CrossPlatformIngressMessage,
+    options: Pick<CrossPlatformIncomingChatMessage, "cwd" | "timeoutMs" | "onEvent" | "conversation_name" | "user_name"> = {}
+  ): Promise<ChatRunResult> {
+    const session = this.getOrCreateSession(ingress, options.cwd);
+    const queueEntry = session.queue.then(() => this.executeInSession(session, ingress, options));
+    session.queue = queueEntry.then(() => undefined, () => undefined);
+    return queueEntry;
   }
 
   handleIncomingMessage(input: CrossPlatformIncomingChatMessage): Promise<string> {
@@ -231,45 +360,104 @@ export class CrossPlatformChatSessionManager {
     return this.processIncomingMessage(input);
   }
 
+  private createIngressMessage(
+    input: CrossPlatformIncomingChatMessage | (CrossPlatformChatSessionOptions & { text: string })
+  ): CrossPlatformIngressMessage {
+    const channel = resolveChannel(input);
+    const metadata = {
+      ...(input.metadata ?? {}),
+      ...("sender_id" in input && input.sender_id ? { sender_id: input.sender_id } : {}),
+      ...(input.message_id ? { message_id: input.message_id } : {}),
+    };
+    const userId = normalizeIdentity(input.user_id ?? ("sender_id" in input ? input.sender_id : undefined)) ?? undefined;
+    const platform = normalizePlatform(input.platform) ?? undefined;
+    const identityKey = normalizeIdentity(input.identity_key) ?? undefined;
+    const conversationId = normalizeIdentity(input.conversation_id) ?? undefined;
+    const messageId = normalizeIdentity(input.message_id) ?? undefined;
+
+    return {
+      ingress_id: randomUUID(),
+      received_at: new Date().toISOString(),
+      channel,
+      ...(platform ? { platform } : {}),
+      ...(identityKey ? { identity_key: identityKey } : {}),
+      ...(conversationId ? { conversation_id: conversationId } : {}),
+      ...(messageId ? { message_id: messageId } : {}),
+      ...(userId ? { user_id: userId } : {}),
+      text: input.text,
+      actor: normalizeActor(channel, {
+        platform,
+        conversation_id: conversationId,
+        identity_key: identityKey,
+        user_id: userId,
+        actor: input.actor,
+      }),
+      runtimeControl: resolveRuntimeControl(channel, input.runtimeControl, metadata),
+      metadata,
+      replyTarget: normalizeReplyTarget(channel, {
+        platform,
+        conversation_id: conversationId,
+        identity_key: identityKey,
+        user_id: userId,
+        message_id: messageId,
+        replyTarget: input.replyTarget,
+        metadata,
+      }),
+    };
+  }
+
   /**
    * Returns the active session info if a matching session is already loaded.
    */
   getSessionInfo(options: CrossPlatformChatSessionOptions): CrossPlatformChatSessionInfo | null {
     const sessionKey = buildSessionKey(options);
     const session = this.sessions.get(sessionKey);
-    return session ? { ...session.info, metadata: cloneMetadata(session.info.metadata) } : null;
+    return session
+      ? {
+          ...session.info,
+          metadata: cloneMetadata(session.info.metadata),
+          active_reply_target: session.info.active_reply_target
+            ? {
+                ...session.info.active_reply_target,
+                metadata: cloneMetadata(session.info.active_reply_target.metadata),
+              }
+            : undefined,
+        }
+      : null;
   }
 
-  private getOrCreateSession(options: CrossPlatformChatSessionOptions): ManagedChatSession {
-    const sessionKey = buildSessionKey(options);
+  private getOrCreateSession(
+    ingress: Pick<ChatIngressMessage, "identity_key" | "platform" | "conversation_id" | "user_id">,
+    cwdOverride?: string
+  ): ManagedChatSession {
+    const sessionKey = buildSessionKeyFromParts(ingress);
     const existing = this.sessions.get(sessionKey);
     if (existing) {
       return existing;
     }
 
-    const cwd = options.cwd?.trim() || process.cwd();
+    const cwd = cwdOverride?.trim() || process.cwd();
     const runner = new ChatRunner(this.deps);
     runner.startSession(cwd);
 
     const now = new Date().toISOString();
     const info: CrossPlatformChatSessionInfo = {
       session_key: sessionKey,
-      identity_key: normalizeIdentity(options.identity_key) ?? undefined,
-      platform: options.platform?.trim() || undefined,
-      conversation_id: options.conversation_id?.trim() || undefined,
-      conversation_name: options.conversation_name?.trim() || undefined,
-      user_id: options.user_id?.trim() || undefined,
-      user_name: options.user_name?.trim() || undefined,
+      identity_key: normalizeIdentity(ingress.identity_key) ?? undefined,
+      platform: normalizePlatform(ingress.platform) ?? undefined,
+      conversation_id: normalizeIdentity(ingress.conversation_id) ?? undefined,
+      user_id: normalizeIdentity(ingress.user_id) ?? undefined,
       cwd,
       created_at: now,
       last_used_at: now,
-      metadata: cloneMetadata(buildSessionMetadata(options)),
+      metadata: {},
     };
 
     const created: ManagedChatSession = {
       runner,
       info,
       queue: Promise.resolve(),
+      lastRoute: undefined,
     };
     this.sessions.set(sessionKey, created);
     return created;
@@ -277,11 +465,35 @@ export class CrossPlatformChatSessionManager {
 
   private async executeInSession(
     session: ManagedChatSession,
-    input: string,
-    options: CrossPlatformChatSessionOptions
+    ingress: CrossPlatformIngressMessage,
+    options: Pick<CrossPlatformIncomingChatMessage, "timeoutMs" | "onEvent" | "conversation_name" | "user_name"> = {}
   ): Promise<ChatRunResult> {
     session.info.last_used_at = new Date().toISOString();
-    session.info.metadata = cloneMetadata(buildSessionMetadata(options));
+    session.info.conversation_name = options.conversation_name?.trim() || session.info.conversation_name;
+    session.info.user_id = session.info.user_id ?? (normalizeIdentity(ingress.user_id) ?? undefined);
+    session.info.user_name = options.user_name?.trim() || session.info.user_name;
+    session.info.last_message_id = normalizeIdentity(ingress.message_id) ?? session.info.last_message_id;
+    session.info.active_reply_target = {
+      ...ingress.replyTarget,
+      metadata: cloneMetadata(ingress.replyTarget.metadata),
+    };
+    session.info.metadata = cloneMetadata(buildSessionMetadata({
+      metadata: ingress.metadata,
+      channel: ingress.channel,
+      platform: ingress.platform,
+      conversation_id: ingress.conversation_id,
+      conversation_name: options.conversation_name,
+      user_id: ingress.user_id,
+      user_name: options.user_name,
+    }));
+
+    const selectedRoute = this.ingressRouter.selectRoute(ingress, {
+      hasLightweightLlm: this.deps.llmClient !== undefined,
+      hasAgentLoop: this.deps.chatAgentLoopRunner !== undefined,
+      hasToolLoop: this.deps.llmClient !== undefined,
+      hasRuntimeControlService: this.deps.runtimeControlService !== undefined,
+    });
+    session.lastRoute = selectedRoute;
 
     const previousOnEvent = session.runner.onEvent;
     if (options.onEvent) {
@@ -298,11 +510,14 @@ export class CrossPlatformChatSessionManager {
     }
 
     try {
-      session.runner.setRuntimeControlContext(buildRuntimeControlChatContext(options));
-      return await session.runner.execute(input, session.info.cwd, options.timeoutMs);
+      return await session.runner.executeIngressMessage(
+        ingress,
+        session.info.cwd,
+        options.timeoutMs,
+        selectedRoute
+      );
     } finally {
       session.runner.onEvent = previousOnEvent;
-      session.runner.setRuntimeControlContext(null);
     }
   }
 }

--- a/src/interface/chat/event-subscriber.ts
+++ b/src/interface/chat/event-subscriber.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import { readDaemonAuthToken } from "../../runtime/daemon/client.js";
+import type { ChatEvent } from "./chat-events.js";
 
 export interface TendNotification {
   type: "progress" | "stall" | "complete" | "error" | "approval";
@@ -31,11 +32,32 @@ interface RawNotificationReport {
   goal_id?: string | null;
 }
 
+interface RawChatResponseEvent {
+  goalId?: string;
+  goal_id?: string;
+  message?: string;
+  status?: string;
+}
+
+interface RawLoopErrorEvent {
+  goalId?: string;
+  goal_id?: string;
+  error?: string;
+  message?: string;
+  status?: string;
+  crashCount?: number;
+  crash_count?: number;
+  maxRetries?: number;
+  max_retries?: number;
+}
+
 export class EventSubscriber extends EventEmitter {
   private abortController: AbortController | null = null;
   private previousGap: number | undefined = undefined;
   private lastOutboxSeq = 0;
   private snapshotBootstrapped = false;
+  private streamLoopPromise: Promise<void> | null = null;
+  private localProjectionSeq = 0;
 
   constructor(
     private baseUrl: string,
@@ -53,7 +75,18 @@ export class EventSubscriber extends EventEmitter {
     await this.connect(false);
   }
 
-  private async connect(isRetry: boolean): Promise<void> {
+  /**
+   * Bootstrap snapshot state, open the SSE stream, then continue consuming it
+   * in the background. This is used when callers need the subscription to be
+   * live before triggering daemon work.
+   */
+  async subscribeReady(): Promise<void> {
+    this.abortController?.abort();
+    this.abortController = new AbortController();
+    await this.connect(false, true);
+  }
+
+  private async connect(isRetry: boolean, background = false): Promise<void> {
     if (this.abortController?.signal.aborted) return;
 
     try {
@@ -74,25 +107,13 @@ export class EventSubscriber extends EventEmitter {
         throw new Error(`SSE connect failed: HTTP ${res.status}`);
       }
 
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const parts = buffer.split("\n\n");
-        buffer = parts.pop() ?? "";
-        for (const part of parts) {
-          this.parseSSEMessage(part);
-        }
+      const loopPromise = this.consumeStream(res.body.getReader(), isRetry);
+      this.streamLoopPromise = loopPromise;
+      if (background) {
+        void loopPromise.catch(() => undefined);
+        return;
       }
-
-      // Stream ended — attempt reconnect once if not aborted
-      if (!this.abortController?.signal.aborted && !isRetry) {
-        await this.connect(true);
-      }
+      await loopPromise;
     } catch (err) {
       if ((err as { name?: string }).name === "AbortError") return;
       const notification: TendNotification = {
@@ -100,12 +121,13 @@ export class EventSubscriber extends EventEmitter {
         goalId: this.goalId,
         message: `⚠️ [tend] ${this.goalId}: Connection error — ${String(err)}`,
       };
-      this.emit("notification", notification);
+      this.emitProjectedEvent("connection_error", null, notification);
       // Retry once on error
       if (!isRetry && !this.abortController?.signal.aborted) {
         await new Promise((r) => setTimeout(r, 2000));
-        await this.connect(true);
+        return this.connect(true, background);
       }
+      throw err;
     }
   }
 
@@ -113,6 +135,29 @@ export class EventSubscriber extends EventEmitter {
   unsubscribe(): void {
     this.abortController?.abort();
     this.abortController = null;
+  }
+
+  private async consumeStream(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    isRetry: boolean
+  ): Promise<void> {
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split("\n\n");
+      buffer = parts.pop() ?? "";
+      for (const part of parts) {
+        this.parseSSEMessage(part);
+      }
+    }
+
+    if (!this.abortController?.signal.aborted && !isRetry) {
+      await this.connect(true, true);
+    }
   }
 
   private parseSSEMessage(raw: string): void {
@@ -147,10 +192,7 @@ export class EventSubscriber extends EventEmitter {
       return;
     }
 
-    const notification = this.formatNotification(eventType, parsed);
-    if (notification) {
-      this.emit("notification", notification);
-    }
+    this.emitProjectedEvent(eventType, parsed);
   }
 
   /** Format a raw SSE event into a TendNotification (returns null if verbosity filters it out) */
@@ -267,7 +309,61 @@ export class EventSubscriber extends EventEmitter {
       return { type: "complete", goalId: this.goalId, message: msg, gap };
     }
 
+    if (eventType === "loop_error") {
+      const ev = data as RawLoopErrorEvent;
+      const message = ev.error ?? ev.message ?? "Unknown daemon loop error";
+      const crashCount = typeof ev.crashCount === "number"
+        ? ev.crashCount
+        : typeof ev.crash_count === "number"
+          ? ev.crash_count
+          : undefined;
+      const maxRetries = typeof ev.maxRetries === "number"
+        ? ev.maxRetries
+        : typeof ev.max_retries === "number"
+          ? ev.max_retries
+          : undefined;
+      const retryNote = crashCount !== undefined && maxRetries !== undefined
+        ? ` (${crashCount}/${maxRetries})`
+        : "";
+      return {
+        type: "error",
+        goalId: this.goalId,
+        message: `⚠️ [tend] ${shortId}: Loop error${retryNote} — ${message}`,
+      };
+    }
+
     return null;
+  }
+
+  private formatChatEvent(
+    eventType: string,
+    data: unknown,
+    notification: TendNotification | null
+  ): ChatEvent | null {
+    if (eventType === "chat_response") {
+      const response = data as RawChatResponseEvent;
+      const text = typeof response.message === "string" ? response.message.trim() : "";
+      if (!text) return null;
+      return {
+        type: "assistant_final",
+        text,
+        persisted: false,
+        ...this.createChatEventBase(eventType, data),
+      };
+    }
+
+    if (!notification) {
+      return null;
+    }
+
+    return {
+      type: "activity",
+      kind: "commentary",
+      message: notification.message,
+      sourceId: this.createChatSourceId(eventType, data, notification),
+      transient: false,
+      ...this.createChatEventBase(eventType, data),
+    };
   }
 
   private matchesGoal(data: unknown): boolean {
@@ -293,14 +389,82 @@ export class EventSubscriber extends EventEmitter {
       this.lastOutboxSeq = Math.max(this.lastOutboxSeq, snapshot.last_outbox_seq ?? 0);
       for (const approval of snapshot.approvals ?? []) {
         if (!this.matchesGoal(approval)) continue;
-        const notification = this.formatNotification("approval_required", approval);
-        if (notification) {
-          this.emit("notification", notification);
-        }
+        this.emitProjectedEvent("approval_required", approval);
       }
     } catch {
       // Snapshot bootstrap is best-effort.
     }
+  }
+
+  private emitProjectedEvent(
+    eventType: string,
+    data: unknown,
+    notificationOverride: TendNotification | null = null
+  ): void {
+    const notification = notificationOverride ?? this.formatNotification(eventType, data);
+    if (notification) {
+      this.emit("notification", notification);
+    }
+
+    const chatEvent = this.formatChatEvent(eventType, data, notification);
+    if (chatEvent) {
+      this.emit("chat_event", chatEvent);
+    }
+  }
+
+  private createChatEventBase(eventType: string, data: unknown): {
+    runId: string;
+    turnId: string;
+    createdAt: string;
+  } {
+    const projectionId = this.createProjectionId(eventType, data);
+    return {
+      runId: `daemon:${this.goalId}`,
+      turnId: `daemon:${this.goalId}:${projectionId}`,
+      createdAt: new Date().toISOString(),
+    };
+  }
+
+  private createProjectionId(eventType: string, data: unknown): string {
+    const record = typeof data === "object" && data !== null
+      ? data as Record<string, unknown>
+      : null;
+    const requestId = record?.["requestId"];
+    if (typeof requestId === "string" && requestId) {
+      return `${eventType}:${requestId}`;
+    }
+
+    if (this.lastOutboxSeq > 0) {
+      return `${eventType}:${this.lastOutboxSeq}`;
+    }
+
+    this.localProjectionSeq += 1;
+    return `${eventType}:local:${this.localProjectionSeq}`;
+  }
+
+  private createChatSourceId(
+    eventType: string,
+    data: unknown,
+    notification: TendNotification
+  ): string {
+    const requestId = notification.requestId;
+    if (requestId) {
+      return `daemon:${this.goalId}:${eventType}:${requestId}`;
+    }
+
+    if (notification.reportType) {
+      return `daemon:${this.goalId}:${eventType}:${notification.reportType}`;
+    }
+
+    const record = typeof data === "object" && data !== null
+      ? data as Record<string, unknown>
+      : null;
+    const status = record?.["status"];
+    if (typeof status === "string" && status) {
+      return `daemon:${this.goalId}:${eventType}:${status}`;
+    }
+
+    return `daemon:${this.goalId}:${eventType}`;
   }
 
   private authHeaders(): Record<string, string> {

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -1,0 +1,322 @@
+import { randomUUID } from "node:crypto";
+import type { ChatEventHandler } from "./chat-events.js";
+import { recognizeRuntimeControlIntent, type RuntimeControlIntent } from "../../runtime/control/index.js";
+import type {
+  RuntimeControlActor,
+  RuntimeControlReplyTarget,
+} from "../../runtime/store/runtime-operation-schemas.js";
+
+export type IngressChannel = "tui" | "plugin_gateway" | "cli" | "web";
+export type IngressDeliveryMode = "reply" | "notify" | "thread_reply";
+export type IngressApprovalMode = "interactive" | "preapproved" | "disallowed";
+export type ReplyTargetPolicy = "turn_reply_target";
+export type EventProjectionPolicy = "turn_only" | "latest_active_reply_target";
+export type ConcurrencyPolicy = "session_serial";
+export type DaemonChatPolicy = "compatibility_only";
+
+export interface ChatIngressRuntimeControl {
+  allowed: boolean;
+  approvalMode: IngressApprovalMode;
+  approval_mode?: IngressApprovalMode;
+}
+
+export interface IngressReplyTarget extends RuntimeControlReplyTarget {
+  channel?: IngressChannel;
+  message_id?: string;
+  deliveryMode?: IngressDeliveryMode;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ChatIngressMessage {
+  ingress_id?: string;
+  received_at?: string;
+  channel: IngressChannel;
+  platform?: string;
+  identity_key?: string;
+  conversation_id?: string;
+  message_id?: string;
+  user_id?: string;
+  user_name?: string;
+  text: string;
+  actor: RuntimeControlActor;
+  runtimeControl: ChatIngressRuntimeControl;
+  deliveryMode?: IngressDeliveryMode;
+  metadata: Record<string, unknown>;
+  replyTarget: IngressReplyTarget;
+  cwd?: string;
+  timeoutMs?: number;
+  onEvent?: ChatEventHandler;
+}
+
+export type SelectedChatRoute =
+  | {
+      lane: "fast";
+      kind: "direct_answer";
+      reason: "simple_question";
+      modelTier: "light";
+      maxTokens: number;
+      replyTargetPolicy: ReplyTargetPolicy;
+      eventProjectionPolicy: EventProjectionPolicy;
+      concurrencyPolicy: ConcurrencyPolicy;
+      daemonChatPolicy: DaemonChatPolicy;
+    }
+  | {
+      lane: "fast";
+      kind: "agent_loop" | "tool_loop" | "adapter";
+      reason: "agent_loop_available" | "tool_loop_available" | "adapter_fallback";
+      replyTargetPolicy: ReplyTargetPolicy;
+      eventProjectionPolicy: EventProjectionPolicy;
+      concurrencyPolicy: ConcurrencyPolicy;
+      daemonChatPolicy: DaemonChatPolicy;
+    }
+  | {
+      lane: "durable";
+      kind: "runtime_control";
+      reason: "runtime_control_intent";
+      intent: RuntimeControlIntent;
+      replyTargetPolicy: ReplyTargetPolicy;
+      eventProjectionPolicy: EventProjectionPolicy;
+      concurrencyPolicy: ConcurrencyPolicy;
+      daemonChatPolicy: DaemonChatPolicy;
+    };
+
+export interface IngressRouterCapabilities {
+  hasLightweightLlm: boolean;
+  hasAgentLoop: boolean;
+  hasToolLoop: boolean;
+  hasRuntimeControlService?: boolean;
+}
+
+function shouldUseDirectAnswerRoute(input: string): boolean {
+  const normalized = input.trim();
+  if (!normalized) return false;
+
+  const lowered = normalized.toLowerCase();
+  const questionSignals = [
+    /[?？]/,
+    /\b(what|why|how|when|where|who|which|is|are|can|could|would|should|tell me|explain|describe|help me understand)\b/,
+    /(教えて|説明して|教えてください|説明してください|どう思う|なんで|なぜ|どうして|いつ|どこ|だれ|誰|何|どれ|どっち)/,
+  ];
+  if (!questionSignals.some((pattern) => pattern.test(lowered))) {
+    return false;
+  }
+
+  const workSignals = [
+    /\b(fix|implement|change|changed|add|remove|delete|update|refactor|patch|debug|diagnose|investigate|review|write|create|build|run|execute|test|verify|confirm|check|inspect|search|open|read|edit|modify|commit|push|merge|release|deploy|start|stop|restart|resume|compare|convert|migrate|optimize|improve|configure|setup|set up)\b/,
+    /(修正|実装|変更|追加|削除|更新|リファクタ|デバッグ|調査|確認|レビュー|書いて|作って|作成|実行|走らせ|テスト|検証|調べて|開いて|読んで|編集|コミット|プッシュ|マージ|デプロイ|再起動|再開|設定)/,
+    /\b(git|repo|repository|branch|commit|diff|pull request|pr|issue|ticket|adapter|agentloop|tool|tools|code)\b|コード|src\//,
+    /\b(latest|most recent|current|today|now|recent|news|web|internet|api|docs|github|release|version)\b|最新|最新版|今日|現在|最近|今|外部|ネット/,
+    /\bwhat\s+(files?\s+)?changed\b|\bwhich\s+files?\s+(changed|were\s+(modified|edited))\b/,
+    /(\.(ts|tsx|js|jsx|json|md|yml|yaml|toml|py|go|rs|sh|sql)\b|\/[^/\s]+\.[A-Za-z0-9]+$)/,
+  ];
+  return !workSignals.some((pattern) => pattern.test(lowered));
+}
+
+function selectRouteForText(
+  text: string,
+  runtimeControl: ChatIngressRuntimeControl,
+  deps: IngressRouterCapabilities
+): SelectedChatRoute {
+  const baseFastPolicy = {
+    replyTargetPolicy: "turn_reply_target" as const,
+    eventProjectionPolicy: "turn_only" as const,
+    concurrencyPolicy: "session_serial" as const,
+    daemonChatPolicy: "compatibility_only" as const,
+  };
+  const baseDurablePolicy = {
+    replyTargetPolicy: "turn_reply_target" as const,
+    eventProjectionPolicy: "latest_active_reply_target" as const,
+    concurrencyPolicy: "session_serial" as const,
+    daemonChatPolicy: "compatibility_only" as const,
+  };
+
+  if (runtimeControl.allowed && runtimeControl.approvalMode !== "disallowed") {
+    const intent = recognizeRuntimeControlIntent(text);
+    if (intent !== null) {
+      return {
+        lane: "durable",
+        kind: "runtime_control",
+        reason: "runtime_control_intent",
+        intent,
+        ...baseDurablePolicy,
+      };
+    }
+  }
+
+  if (!deps.hasAgentLoop && deps.hasLightweightLlm && shouldUseDirectAnswerRoute(text)) {
+    return {
+      lane: "fast",
+      kind: "direct_answer",
+      reason: "simple_question",
+      modelTier: "light",
+      maxTokens: 256,
+      ...baseFastPolicy,
+    };
+  }
+
+  if (deps.hasAgentLoop) {
+    return {
+      lane: "fast",
+      kind: "agent_loop",
+      reason: "agent_loop_available",
+      ...baseFastPolicy,
+    };
+  }
+
+  if (deps.hasToolLoop) {
+    return {
+      lane: "fast",
+      kind: "tool_loop",
+      reason: "tool_loop_available",
+      ...baseFastPolicy,
+    };
+  }
+
+  return {
+    lane: "fast",
+    kind: "adapter",
+    reason: "adapter_fallback",
+    ...baseFastPolicy,
+  };
+}
+
+export class IngressRouter {
+  selectRoute(message: ChatIngressMessage, capabilities: IngressRouterCapabilities): SelectedChatRoute {
+    return selectRouteForText(message.text, message.runtimeControl, capabilities);
+  }
+}
+
+export function selectLegacyChatRoute(
+  input: string,
+  deps: IngressRouterCapabilities
+): SelectedChatRoute {
+  return selectRouteForText(input, { allowed: true, approvalMode: "interactive" }, deps);
+}
+
+function normalizePlatform(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+function normalizeIdentity(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function inferActorSurface(channel: IngressChannel): RuntimeControlActor["surface"] {
+  switch (channel) {
+    case "plugin_gateway":
+      return "gateway";
+    case "tui":
+      return "tui";
+    case "cli":
+      return "cli";
+    case "web":
+      return "chat";
+  }
+}
+
+export interface NormalizeLegacyIngressInput {
+  text: string;
+  channel?: IngressChannel;
+  ingress_id?: string;
+  received_at?: string;
+  identity_key?: string;
+  platform?: string;
+  conversation_id?: string;
+  user_id?: string;
+  user_name?: string;
+  sender_id?: string;
+  message_id?: string;
+  cwd?: string;
+  timeoutMs?: number;
+  metadata?: Record<string, unknown>;
+  onEvent?: ChatEventHandler;
+  deliveryMode?: IngressDeliveryMode;
+  actor?: RuntimeControlActor;
+  replyTarget?: Partial<IngressReplyTarget>;
+  runtimeControl?: Partial<ChatIngressRuntimeControl>;
+}
+
+export function normalizeLegacyIngressInput(input: NormalizeLegacyIngressInput): ChatIngressMessage {
+  const channel = input.channel ?? (input.platform ? "plugin_gateway" : "cli");
+  const platform = normalizePlatform(input.platform ?? (channel === "tui" ? "local_tui" : undefined));
+  const identityKey = normalizeIdentity(input.identity_key);
+  const conversationId = normalizeIdentity(input.conversation_id);
+  const userId = normalizeIdentity(input.user_id ?? input.sender_id);
+  const actorSurface = inferActorSurface(channel);
+  const metadata = { ...(input.metadata ?? {}) };
+  const preapproved = input.runtimeControl?.approvalMode === "preapproved"
+    || input.runtimeControl?.approval_mode === "preapproved"
+    || metadata["runtime_control_approved"] === true;
+  const interactiveDefault = channel === "tui" || channel === "cli";
+  const allowed = input.runtimeControl?.allowed ?? (preapproved || interactiveDefault);
+  const approvalMode = input.runtimeControl?.approvalMode
+    ?? input.runtimeControl?.approval_mode
+    ?? (preapproved ? "preapproved" : interactiveDefault ? "interactive" : "disallowed");
+
+  const actor: RuntimeControlActor = input.actor ?? {
+    surface: actorSurface,
+    ...(platform ? { platform } : {}),
+    ...(conversationId ? { conversation_id: conversationId } : {}),
+    ...(identityKey ? { identity_key: identityKey } : {}),
+    ...(userId ? { user_id: userId } : {}),
+  };
+  const replyTarget: IngressReplyTarget = {
+    surface: actor.surface,
+    channel,
+    ...(platform ? { platform } : {}),
+    ...(conversationId ? { conversation_id: conversationId } : {}),
+    ...(identityKey ? { identity_key: identityKey } : {}),
+    ...(userId ? { user_id: userId } : {}),
+    ...(input.message_id ? { message_id: input.message_id } : {}),
+    metadata,
+    ...(input.replyTarget ?? {}),
+  };
+
+  return {
+    ingress_id: input.ingress_id ?? randomUUID(),
+    received_at: input.received_at ?? new Date().toISOString(),
+    channel,
+    ...(platform ? { platform } : {}),
+    ...(identityKey ? { identity_key: identityKey } : {}),
+    ...(conversationId ? { conversation_id: conversationId } : {}),
+    ...(input.message_id ? { message_id: input.message_id } : {}),
+    ...(userId ? { user_id: userId } : {}),
+    ...(input.user_name ? { user_name: input.user_name } : {}),
+    text: input.text,
+    actor,
+    runtimeControl: {
+      allowed,
+      approvalMode,
+      approval_mode: approvalMode,
+    },
+    ...(input.deliveryMode ? { deliveryMode: input.deliveryMode } : {}),
+    metadata,
+    replyTarget,
+    ...(input.cwd ? { cwd: input.cwd } : {}),
+    ...(input.timeoutMs !== undefined ? { timeoutMs: input.timeoutMs } : {}),
+    ...(input.onEvent ? { onEvent: input.onEvent } : {}),
+  };
+}
+
+export function buildStandaloneIngressMessage(input: NormalizeLegacyIngressInput): ChatIngressMessage {
+  return normalizeLegacyIngressInput(input);
+}
+
+export function createIngressRouter(): IngressRouter {
+  return new IngressRouter();
+}
+
+export function describeSelectedRoute(route: SelectedChatRoute): string {
+  if (route.kind === "direct_answer") {
+    return `${route.lane} ${route.kind} (${route.reason}, ${route.modelTier}, max ${route.maxTokens}, reply=${route.replyTargetPolicy}, events=${route.eventProjectionPolicy}, concurrency=${route.concurrencyPolicy}, daemon=${route.daemonChatPolicy})`;
+  }
+  return `${route.lane} ${route.kind} (${route.reason}, reply=${route.replyTargetPolicy}, events=${route.eventProjectionPolicy}, concurrency=${route.concurrencyPolicy}, daemon=${route.daemonChatPolicy})`;
+}
+
+export type IngressMessage = ChatIngressMessage;
+export type IngressRuntimeControl = ChatIngressRuntimeControl;
+export type ChatSelectedRoute = SelectedChatRoute;
+export type ChatIngressChannel = IngressChannel;
+export type ChatIngressReplyTarget = IngressReplyTarget;

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -78,6 +78,7 @@ function createChatRunnerMock() {
   return {
     startSession: vi.fn(),
     execute: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
+    executeIngressMessage: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
     onEvent: undefined,
   };
 }
@@ -182,7 +183,14 @@ describe("daemon-mode chat routing", () => {
 
     await testState.lastChatProps!.onSubmit("free form question");
 
-    expect(chatRunner.execute).toHaveBeenCalledWith("free form question", process.cwd());
+    expect(chatRunner.executeIngressMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "free form question",
+        channel: "tui",
+        platform: "local_tui",
+      }),
+      process.cwd()
+    );
     expect(daemonClient.chat).not.toHaveBeenCalled();
 
     screen.unmount();
@@ -224,7 +232,7 @@ describe("daemon-mode chat routing", () => {
     await testState.lastChatProps!.onSubmit("question for the active goal");
 
     expect(daemonClient.chat).toHaveBeenCalledWith("goal-123", "question for the active goal");
-    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
 
     screen.unmount();
   });

--- a/src/interface/tui/__tests__/chat-surface.test.ts
+++ b/src/interface/tui/__tests__/chat-surface.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import type { StateManager } from "../../../base/state/state-manager.js";
+import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adapter-layer.js";
+import type { ChatRunnerDeps } from "../../chat/chat-runner.js";
+import { SharedManagerTuiChatSurface } from "../chat-surface.js";
+
+vi.mock("../../../platform/observation/context-provider.js", () => ({
+  resolveGitRoot: (cwd: string) => cwd,
+  buildChatContext: (_task: string, cwd: string) => Promise.resolve(`Working directory: ${cwd}`),
+}));
+
+const CANNED_RESULT: AgentResult = {
+  success: true,
+  output: "Task completed successfully.",
+  error: null,
+  exit_code: 0,
+  elapsed_ms: 50,
+  stopped_reason: "completed",
+};
+
+function makeMockAdapter(result: AgentResult = CANNED_RESULT): IAdapter {
+  return {
+    adapterType: "mock",
+    execute: vi.fn().mockResolvedValue(result),
+  } as unknown as IAdapter;
+}
+
+function makeMockStateManager(): StateManager {
+  return {
+    writeRaw: vi.fn().mockResolvedValue(undefined),
+    readRaw: vi.fn().mockResolvedValue(null),
+  } as unknown as StateManager;
+}
+
+function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
+  return {
+    stateManager: makeMockStateManager(),
+    adapter: makeMockAdapter(),
+    ...overrides,
+  };
+}
+
+function getSessionPaths(stateManager: StateManager): string[] {
+  const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
+  return writeRawMock.mock.calls
+    .map((call: unknown[]) => call[0] as string)
+    .filter((path: string) => path.startsWith("chat/sessions/"));
+}
+
+describe("SharedManagerTuiChatSurface", () => {
+  it("keeps a stable TUI conversation id when executeIngressMessage omits one", async () => {
+    const stateManager = makeMockStateManager();
+    const surface = new SharedManagerTuiChatSurface(makeDeps({ stateManager }));
+    surface.startSession("/repo");
+
+    await surface.executeIngressMessage({
+      text: "first",
+      channel: "tui",
+      platform: "local_tui",
+      actor: { surface: "tui", platform: "local_tui" },
+      replyTarget: { surface: "tui", platform: "local_tui", metadata: {} },
+      runtimeControl: { allowed: true, approvalMode: "interactive" },
+      metadata: {},
+    }, "/repo");
+
+    await surface.executeIngressMessage({
+      text: "second",
+      channel: "tui",
+      platform: "local_tui",
+      actor: { surface: "tui", platform: "local_tui" },
+      replyTarget: { surface: "tui", platform: "local_tui", metadata: {} },
+      runtimeControl: { allowed: true, approvalMode: "interactive" },
+      metadata: {},
+    }, "/repo");
+
+    const sessionPaths = getSessionPaths(stateManager);
+    expect(new Set(sessionPaths).size).toBe(1);
+    expect(sessionPaths[0]).toMatch(/^chat\/sessions\/.+\.json$/);
+  });
+});

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -5,6 +5,7 @@ import {
   formatSuggestionLabel,
   getInputPromptLabel,
   getMatchingSuggestions,
+  normalizeTerminalInputChunk,
   parseMouseEvent,
   getScrollRequest,
   stripMouseEscapeSequences,
@@ -261,14 +262,21 @@ describe("chat scroll keys", () => {
     expect(stripMouseEscapeSequences("hello\u001b[<64;40;12Mworld")).toBe("helloworld");
   });
 
-  it("normalizes shift-enter escape variants into newlines", () => {
+  it("normalizes escape-prefixed shift-enter variants into newlines", () => {
     expect(stripMouseEscapeSequences("foo\u001b[27;2;13~bar")).toBe("foo\nbar");
-    expect(stripMouseEscapeSequences("foo[27;2;13~bar")).toBe("foo\nbar");
+    expect(stripMouseEscapeSequences("foo[27;2;13~bar")).toBe("foo[27;2;13~bar");
   });
 
-  it("strips bracketed-paste wrappers with and without esc prefix", () => {
+  it("strips escape-prefixed bracketed-paste wrappers", () => {
     expect(stripMouseEscapeSequences("\u001b[200~hello\nworld\u001b[201~")).toBe("hello\nworld");
-    expect(stripMouseEscapeSequences("[200~hello[201~")).toBe("hello");
+    expect(stripMouseEscapeSequences("[200~hello[201~")).toBe("[200~hello[201~");
+  });
+
+  it("normalizes raw terminal chunks without corrupting ordinary text", () => {
+    expect(normalizeTerminalInputChunk("[27;2;13~")).toBe("\n");
+    expect(normalizeTerminalInputChunk("[200~hello[201~")).toBe("hello");
+    expect(normalizeTerminalInputChunk("foo[27;2;13~bar")).toBe("foo[27;2;13~bar");
+    expect(normalizeTerminalInputChunk("notes [200~ literal")).toBe("notes [200~ literal");
   });
 });
 

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -31,7 +31,7 @@ import type { CoreLoop } from "../../orchestrator/loop/core-loop.js";
 import type { StateManager } from "../../base/state/state-manager.js";
 import type { TrustManager } from "../../platform/traits/trust-manager.js";
 import type { Task } from "../../base/types/task.js";
-import type { ChatRunner } from "../../interface/chat/chat-runner.js";
+import type { TuiChatSurface } from "./chat-surface.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
 import { ShellTool } from "../../tools/system/ShellTool/ShellTool.js";
 import { getPulseedVersion } from "../../base/utils/pulseed-meta.js";
@@ -83,7 +83,7 @@ interface AppProps {
   trustManager?: TrustManager;
   actionHandler?: ActionHandler;
   intentRecognizer?: IntentRecognizer;
-  chatRunner?: ChatRunner;
+  chatRunner?: TuiChatSurface;
   onApprovalReady?: (requestFn: (req: ApprovalRequest) => void) => void;
   // Shared
   stateManager: StateManager;
@@ -494,7 +494,27 @@ export function App({
               }].slice(-MAX_MESSAGES));
             }
           } else if (freeformRoute === "chat_runner" && chatRunner) {
-            await chatRunner.execute(input, process.cwd());
+            await chatRunner.executeIngressMessage({
+              text: input,
+              channel: "tui",
+              platform: "local_tui",
+              actor: {
+                surface: "tui",
+                platform: "local_tui",
+              },
+              replyTarget: {
+                surface: "tui",
+                platform: "local_tui",
+                metadata: {},
+              },
+              runtimeControl: {
+                allowed: true,
+                approvalMode: "interactive",
+              },
+              metadata: {},
+              ingress_id: randomUUID(),
+              received_at: new Date().toISOString(),
+            }, process.cwd());
           } else {
             setMessages((prev) => [...prev, {
               id: randomUUID(), role: "pulseed" as const,

--- a/src/interface/tui/chat-surface.ts
+++ b/src/interface/tui/chat-surface.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from "node:crypto";
+import type { ChatEventHandler } from "../chat/chat-events.js";
+import type { ChatRunResult, ChatRunnerDeps } from "../chat/chat-runner.js";
+import { CrossPlatformChatSessionManager } from "../chat/cross-platform-session.js";
+import type { CrossPlatformIngressMessage } from "../chat/cross-platform-session.js";
+
+export interface TuiChatSurface {
+  onEvent?: ChatEventHandler;
+  startSession(cwd: string): void;
+  execute(input: string, cwd: string): Promise<ChatRunResult>;
+  executeIngressMessage(ingress: CrossPlatformIngressMessage, cwd: string): Promise<ChatRunResult>;
+}
+
+export class SharedManagerTuiChatSurface implements TuiChatSurface {
+  onEvent: ChatEventHandler | undefined = undefined;
+
+  private readonly conversationId = randomUUID();
+  private sessionCwd: string | null = null;
+  private readonly manager: CrossPlatformChatSessionManager;
+
+  constructor(deps: ChatRunnerDeps) {
+    this.manager = new CrossPlatformChatSessionManager(deps);
+  }
+
+  startSession(cwd: string): void {
+    this.sessionCwd = cwd;
+  }
+
+  execute(input: string, cwd: string): Promise<ChatRunResult> {
+    const effectiveCwd = this.sessionCwd ?? cwd;
+    return this.manager.execute(input, {
+      channel: "tui",
+      platform: "local_tui",
+      conversation_id: this.conversationId,
+      cwd: effectiveCwd,
+      onEvent: this.onEvent,
+      runtimeControl: {
+        allowed: true,
+        approvalMode: "interactive",
+      },
+      replyTarget: {
+        surface: "tui",
+        channel: "tui",
+        platform: "local_tui",
+        conversation_id: this.conversationId,
+      },
+    });
+  }
+
+  executeIngressMessage(ingress: CrossPlatformIngressMessage, cwd: string): Promise<ChatRunResult> {
+    const effectiveCwd = this.sessionCwd ?? cwd;
+    return this.manager.executeIngress({
+      ...ingress,
+      channel: ingress.channel ?? "tui",
+      platform: ingress.platform ?? "local_tui",
+      conversation_id: ingress.conversation_id ?? this.conversationId,
+      replyTarget: {
+        ...ingress.replyTarget,
+        channel: ingress.replyTarget?.channel ?? "tui",
+        platform: ingress.replyTarget?.platform ?? ingress.platform ?? "local_tui",
+        conversation_id: ingress.replyTarget?.conversation_id ?? ingress.conversation_id ?? this.conversationId,
+      },
+      actor: {
+        ...ingress.actor,
+        surface: ingress.actor?.surface ?? "tui",
+        platform: ingress.actor?.platform ?? ingress.platform ?? "local_tui",
+        conversation_id: ingress.actor?.conversation_id ?? ingress.conversation_id ?? this.conversationId,
+      },
+    }, {
+      cwd: effectiveCwd,
+      onEvent: this.onEvent,
+    });
+  }
+}

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -51,7 +51,12 @@ const SCROLL_INDICATOR_ROWS = 2;
 const INPUT_BOX_HORIZONTAL_CHROME = 4;
 const SUGGESTION_HINT = " arrows to navigate, tab/enter to select, esc to dismiss";
 export { buildChatViewport } from "./chat/viewport.js";
-export { getScrollRequest, parseMouseEvent, stripMouseEscapeSequences } from "./chat/scroll.js";
+export {
+  getScrollRequest,
+  normalizeTerminalInputChunk,
+  parseMouseEvent,
+  stripMouseEscapeSequences,
+} from "./chat/scroll.js";
 export { getMatchingSuggestions } from "./chat/suggestions.js";
 
 export function getInputPromptLabel(bashMode: boolean): string {

--- a/src/interface/tui/chat/scroll.ts
+++ b/src/interface/tui/chat/scroll.ts
@@ -2,9 +2,11 @@ import type { ScrollRequest } from "./types.js";
 
 const SGR_MOUSE_SEQUENCE = /(?:\u001b)?\[<(\d+);(\d+);(\d+)([mM])/;
 const SGR_MOUSE_SEQUENCE_GLOBAL = /(?:\u001b)?\[<(\d+);(\d+);(\d+)([mM])/g;
-const SHIFT_ENTER_SEQUENCE_GLOBAL = /(?:\u001b)?\[27;2;13~/g;
-const BRACKETED_PASTE_START_SEQUENCE_GLOBAL = /(?:\u001b)?\[200~/g;
-const BRACKETED_PASTE_END_SEQUENCE_GLOBAL = /(?:\u001b)?\[201~/g;
+const ESC_SHIFT_ENTER_SEQUENCE_GLOBAL = /\u001b\[27;2;13~/g;
+const ESC_BRACKETED_PASTE_OPEN_GLOBAL = /\u001b\[200~/g;
+const ESC_BRACKETED_PASTE_CLOSE_GLOBAL = /\u001b\[201~/g;
+const RAW_SHIFT_ENTER_SEQUENCE = "[27;2;13~";
+const RAW_BRACKETED_PASTE_WRAPPER = /^\[200~([\s\S]*)\[201~$/;
 
 type ScrollKey = {
   upArrow?: boolean;
@@ -121,8 +123,21 @@ export function getScrollRequest(
 
 export function stripMouseEscapeSequences(input: string): string {
   return input
-    .replace(SGR_MOUSE_SEQUENCE_GLOBAL, "")
-    .replace(BRACKETED_PASTE_START_SEQUENCE_GLOBAL, "")
-    .replace(BRACKETED_PASTE_END_SEQUENCE_GLOBAL, "")
-    .replace(SHIFT_ENTER_SEQUENCE_GLOBAL, "\n");
+    .replace(ESC_SHIFT_ENTER_SEQUENCE_GLOBAL, "\n")
+    .replace(ESC_BRACKETED_PASTE_OPEN_GLOBAL, "")
+    .replace(ESC_BRACKETED_PASTE_CLOSE_GLOBAL, "")
+    .replace(SGR_MOUSE_SEQUENCE_GLOBAL, "");
+}
+
+export function normalizeTerminalInputChunk(input: string): string {
+  if (input === RAW_SHIFT_ENTER_SEQUENCE) {
+    return "\n";
+  }
+
+  const bracketedPasteMatch = RAW_BRACKETED_PASTE_WRAPPER.exec(input);
+  if (bracketedPasteMatch) {
+    return bracketedPasteMatch[1] ?? "";
+  }
+
+  return stripMouseEscapeSequences(input);
 }

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -14,7 +14,7 @@ import { StateManager } from "../../base/state/state-manager.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
 import { getPulseedDirPath } from "../../base/utils/paths.js";
 import { App, type ApprovalRequest } from "./app.js";
-import type { ChatRunner } from "../../interface/chat/chat-runner.js";
+import type { TuiChatSurface } from "./chat-surface.js";
 import { isSafeBashCommand } from "./bash-mode.js";
 import { getCliLogger } from "../cli/cli-logger.js";
 import { ensureProviderConfig } from "../cli/ensure-api-key.js";
@@ -137,7 +137,7 @@ async function buildDeps() {
   const { MemoryLifecycleManager, DriveScoreAdapter } = await import("../../platform/knowledge/memory/memory-lifecycle.js");
   const { KnowledgeManager } = await import("../../platform/knowledge/knowledge-manager.js");
   const { CharacterConfigManager } = await import("../../platform/traits/character-config.js");
-  const { ChatRunner } = await import("../../interface/chat/chat-runner.js");
+  const { SharedManagerTuiChatSurface } = await import("./chat-surface.js");
   const { ToolRegistry, ToolExecutor, ToolPermissionManager, ConcurrencyController, createBuiltinTools } = await import("../../tools/index.js");
   const { buildCliDataSourceRegistry } = await import("../cli/data-source-bootstrap.js");
   const {
@@ -433,7 +433,7 @@ async function buildDeps() {
     }
   };
 
-  let chatRunner: InstanceType<typeof ChatRunner> | undefined;
+  let chatRunner: TuiChatSurface | undefined;
   try {
     const adapterType = providerConfig.adapter ?? "claude_code_cli";
     const adapter = adapterRegistry.getAdapter(adapterType);
@@ -457,7 +457,7 @@ async function buildDeps() {
           traceBaseDir: stateManager.getBaseDir(),
         })
       : undefined;
-    chatRunner = new ChatRunner({
+    chatRunner = new SharedManagerTuiChatSurface({
       stateManager,
       adapter,
       llmClient,
@@ -612,7 +612,7 @@ async function startTUIDaemonMode(): Promise<void> {
 
     const stateManager = new StateManager(baseDir);
     await stateManager.init();
-    let chatRunner: ChatRunner | undefined;
+    let chatRunner: TuiChatSurface | undefined;
     const { TrustManager } = await import("../../platform/traits/trust-manager.js");
     const { ScheduleEngine } = await import("../../runtime/schedule/engine.js");
     const { buildCliDataSourceRegistry } = await import("../cli/data-source-bootstrap.js");
@@ -700,7 +700,7 @@ async function startTUIDaemonMode(): Promise<void> {
     const providerName = providerConfig.provider;
 
     try {
-      const { ChatRunner } = await import("../../interface/chat/chat-runner.js");
+      const { SharedManagerTuiChatSurface } = await import("./chat-surface.js");
       const { buildLLMClient, buildAdapterRegistry } = await import("../../base/llm/provider-factory.js");
       const {
         createNativeChatAgentLoopRunner,
@@ -731,7 +731,7 @@ async function startTUIDaemonMode(): Promise<void> {
             traceBaseDir: stateManager.getBaseDir(),
           })
         : undefined;
-      chatRunner = new ChatRunner({
+      chatRunner = new SharedManagerTuiChatSurface({
         stateManager,
         adapter,
         llmClient,

--- a/src/interface/tui/fullscreen-chat.tsx
+++ b/src/interface/tui/fullscreen-chat.tsx
@@ -15,8 +15,8 @@ import { isBashModeInput } from "./bash-mode.js";
 import { buildChatViewport } from "./chat/viewport.js";
 import {
   getScrollRequest,
+  normalizeTerminalInputChunk,
   parseMouseEvent,
-  stripMouseEscapeSequences,
 } from "./chat/scroll.js";
 import { getMatchingSuggestions, type Suggestion } from "./chat/suggestions.js";
 import type { ChatMessage, ChatDisplayRow } from "./chat/types.js";
@@ -1123,7 +1123,7 @@ export function FullscreenChat({
     }
 
     if (inputChar && !key.ctrl && !key.meta) {
-      const clean = stripMouseEscapeSequences(inputChar);
+      const clean = normalizeTerminalInputChunk(inputChar);
       if (clean.length === 0) return;
       insertText(clean);
     }

--- a/src/orchestrator/loop/__tests__/core-loop.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop.test.ts
@@ -199,6 +199,46 @@ describe("CoreLoop", () => {
     expect(mocks.stateManager.saveGoal).toHaveBeenCalledWith(expect.objectContaining({ status: "completed" }));
   });
 
+  it("applies maxIterations overrides to in-run progress metadata and restores config afterwards", async () => {
+    const { CoreLoop } = await import("../core-loop.js");
+    const onProgress = vi.fn();
+
+    const loop = new CoreLoop({
+      stateManager: mocks.stateManager as any,
+      observationEngine: {} as any,
+      gapCalculator: {} as any,
+      driveScorer: {} as any,
+      taskLifecycle: {} as any,
+      satisficingJudge: {} as any,
+      stallDetector: mocks.stallDetector as any,
+      strategyManager: mocks.strategyManager as any,
+      reportingEngine: mocks.reportingEngine as any,
+      driveSystem: {} as any,
+      adapterRegistry: { listAdapters: () => ["mock"] } as any,
+      learningPipeline: {} as any,
+      onProgress,
+      logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() } as any,
+    }, { maxIterations: 5 });
+
+    vi.spyOn(loop, "runOneIteration").mockImplementationOnce(async () => {
+      onProgress({
+        iteration: 1,
+        maxIterations: (loop as any).config.maxIterations,
+        phase: "Observing...",
+      });
+      return mocks.completedIteration as any;
+    });
+
+    await loop.run("goal-1", { maxIterations: 1 });
+
+    expect(onProgress).toHaveBeenCalledWith(expect.objectContaining({
+      iteration: 1,
+      maxIterations: 1,
+      phase: "Observing...",
+    }));
+    expect((loop as any).config.maxIterations).toBe(5);
+  });
+
   it("returns early from runOneIteration when the goal is already satisfied (gap=0 + SatisficingJudge)", async () => {
     const { CoreLoop } = await import("../core-loop.js");
     const calculateGapOrComplete = (await import("../core-loop/preparation.js")).calculateGapOrComplete as unknown as ReturnType<typeof vi.fn>;

--- a/src/orchestrator/loop/core-loop.ts
+++ b/src/orchestrator/loop/core-loop.ts
@@ -109,7 +109,21 @@ export class CoreLoop {
    * Run the full loop until completion or stop condition.
    * @param options.maxIterations - Override config.maxIterations for this run only (e.g. per-cycle budget from DaemonRunner).
    */
-  async run(goalId: string, options?: { maxIterations?: number }): Promise<LoopResult> {
+  async run(
+    goalId: string,
+    options?: { maxIterations?: number; onProgress?: CoreLoopDeps["onProgress"] }
+  ): Promise<LoopResult> {
+    const depsWithMutableProgress = this.deps as CoreLoopDeps;
+    const previousOnProgress = depsWithMutableProgress.onProgress;
+    const previousMaxIterations = this.config.maxIterations;
+    if (options?.onProgress) {
+      depsWithMutableProgress.onProgress = options.onProgress;
+    }
+    if (options?.maxIterations !== undefined) {
+      this.config.maxIterations = options.maxIterations;
+    }
+
+    try {
     const startedAt = new Date().toISOString();
     const dreamCollector = this.deps.hookManager?.getDreamCollector();
     const sessionId = dreamCollector?.buildSessionId(goalId, startedAt) ?? `${goalId}:${startedAt}`;
@@ -345,6 +359,10 @@ export class CoreLoop {
       completedAt,
       tokensUsed: totalTokens,
     };
+    } finally {
+      depsWithMutableProgress.onProgress = previousOnProgress;
+      this.config.maxIterations = previousMaxIterations;
+    }
   }
 
   /**

--- a/src/runtime/__tests__/runner-goal-cycle.test.ts
+++ b/src/runtime/__tests__/runner-goal-cycle.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from "vitest";
+import { runDaemonGoalCycleLoop } from "../daemon/runner-goal-cycle.js";
+import type { LoopResult, ProgressEvent } from "../../orchestrator/loop/core-loop.js";
+
+function makeLoopResult(overrides: Partial<LoopResult> = {}): LoopResult {
+  return {
+    goalId: "goal-1",
+    totalIterations: 1,
+    finalStatus: "completed",
+    iterations: [
+      {
+        loopIndex: 0,
+        goalId: "goal-1",
+        gapAggregate: 0.25,
+        driveScores: [],
+        taskResult: null,
+        stallDetected: false,
+        stallReport: null,
+        pivotOccurred: false,
+        completionJudgment: {
+          is_complete: true,
+          blocking_dimensions: [],
+          low_confidence_dimensions: [],
+          needs_verification_task: false,
+          checked_at: new Date().toISOString(),
+        },
+        elapsedMs: 10,
+        error: null,
+      },
+    ],
+    startedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("runDaemonGoalCycleLoop", () => {
+  it("broadcasts CoreLoop progress and loop_complete events through the daemon event server", async () => {
+    const broadcast = vi.fn();
+    const run = vi.fn().mockImplementation(
+      async (_goalId: string, options?: { maxIterations?: number; onProgress?: (event: ProgressEvent) => void }) => {
+        options?.onProgress?.({
+          iteration: 1,
+          maxIterations: 1,
+          phase: "Observing...",
+          gap: 0.5,
+        });
+        return makeLoopResult();
+      }
+    );
+
+    let context: Record<string, unknown>;
+    context = {
+      running: true,
+      shuttingDown: false,
+      currentGoalIds: ["goal-1"],
+      config: { iterations_per_cycle: 1 },
+      state: {
+        loop_count: 0,
+        last_loop_at: null,
+        status: "running",
+        active_goals: ["goal-1"],
+      },
+      consecutiveIdleCycles: 0,
+      currentLoopIndex: 0,
+      coreLoop: { run },
+      eventServer: { broadcast },
+      stateManager: {
+        loadGoal: vi.fn().mockResolvedValue({ status: "active" }),
+      },
+      logger: { info: vi.fn() },
+      refreshOperationalState: vi.fn(),
+      collectGoalCycleSnapshot: vi.fn().mockResolvedValue([]),
+      determineActiveGoals: vi.fn().mockResolvedValue(["goal-1"]),
+      maybeRefreshProviderRuntime: vi.fn().mockResolvedValue(undefined),
+      broadcastGoalUpdated: vi.fn().mockResolvedValue(undefined),
+      handleLoopError: vi.fn(),
+      saveDaemonState: vi.fn().mockResolvedValue(undefined),
+      processCronTasks: vi.fn().mockResolvedValue(undefined),
+      processScheduleEntries: vi.fn().mockResolvedValue(undefined),
+      expireCronTasks: vi.fn().mockResolvedValue(undefined),
+      proactiveTick: vi.fn().mockResolvedValue(undefined),
+      runRuntimeStoreMaintenance: vi.fn().mockResolvedValue(undefined),
+      getNextInterval: vi.fn().mockReturnValue(1),
+      getMaxGapScore: vi.fn().mockResolvedValue(0.5),
+      calculateAdaptiveInterval: vi.fn().mockReturnValue(1),
+      sleep: vi.fn().mockImplementation(async () => {
+        context.running = false;
+      }),
+      handleCriticalError: vi.fn(),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await runDaemonGoalCycleLoop(context);
+
+    expect(run).toHaveBeenCalledWith(
+      "goal-1",
+      expect.objectContaining({
+        maxIterations: 1,
+        onProgress: expect.any(Function),
+      })
+    );
+    expect(broadcast).toHaveBeenCalledWith(
+      "progress",
+      expect.objectContaining({
+        goalId: "goal-1",
+        phase: "Observing...",
+        gap: 0.5,
+      })
+    );
+    expect(broadcast).toHaveBeenCalledWith(
+      "loop_complete",
+      expect.objectContaining({
+        goalId: "goal-1",
+        iterations: 1,
+        gap: 0.25,
+        status: "completed",
+      })
+    );
+  });
+
+  it("broadcasts loop_error when the CoreLoop run fails", async () => {
+    const broadcast = vi.fn();
+    const run = vi.fn().mockRejectedValue(new Error("boom"));
+
+    let context: Record<string, unknown>;
+    context = {
+      running: true,
+      shuttingDown: false,
+      currentGoalIds: ["goal-1"],
+      config: { iterations_per_cycle: 1 },
+      state: {
+        loop_count: 0,
+        last_loop_at: null,
+        status: "running",
+        active_goals: ["goal-1"],
+      },
+      consecutiveIdleCycles: 0,
+      currentLoopIndex: 0,
+      coreLoop: { run },
+      eventServer: { broadcast },
+      stateManager: {
+        loadGoal: vi.fn().mockResolvedValue({ status: "active" }),
+      },
+      logger: { info: vi.fn() },
+      refreshOperationalState: vi.fn(),
+      collectGoalCycleSnapshot: vi.fn().mockResolvedValue([]),
+      determineActiveGoals: vi.fn().mockResolvedValue(["goal-1"]),
+      maybeRefreshProviderRuntime: vi.fn().mockResolvedValue(undefined),
+      broadcastGoalUpdated: vi.fn().mockResolvedValue(undefined),
+      handleLoopError: vi.fn(),
+      saveDaemonState: vi.fn().mockResolvedValue(undefined),
+      processCronTasks: vi.fn().mockResolvedValue(undefined),
+      processScheduleEntries: vi.fn().mockResolvedValue(undefined),
+      expireCronTasks: vi.fn().mockResolvedValue(undefined),
+      proactiveTick: vi.fn().mockResolvedValue(undefined),
+      runRuntimeStoreMaintenance: vi.fn().mockResolvedValue(undefined),
+      getNextInterval: vi.fn().mockReturnValue(1),
+      getMaxGapScore: vi.fn().mockResolvedValue(0.5),
+      calculateAdaptiveInterval: vi.fn().mockReturnValue(1),
+      sleep: vi.fn().mockImplementation(async () => {
+        context.running = false;
+      }),
+      handleCriticalError: vi.fn(),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await runDaemonGoalCycleLoop(context);
+
+    expect(broadcast).toHaveBeenCalledWith(
+      "loop_error",
+      expect.objectContaining({
+        goalId: "goal-1",
+        message: "boom",
+        status: "error",
+      })
+    );
+    expect(context.handleLoopError).toHaveBeenCalledWith("goal-1", expect.any(Error));
+  });
+});

--- a/src/runtime/daemon/runner-goal-cycle.ts
+++ b/src/runtime/daemon/runner-goal-cycle.ts
@@ -1,9 +1,33 @@
 import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
+import type { ProgressEvent } from "../../orchestrator/loop/core-loop.js";
 import type { GoalCycleScheduleSnapshotEntry } from "./maintenance.js";
+import { errorMessage } from "./runner-errors.js";
 
 const MAX_IDLE_SLEEP_MS = 5_000;
 
 export type GoalCycleRunnerContext = any;
+
+function buildLoopCompletePayload(goalId: string, result: LoopResult): Record<string, unknown> {
+  const lastIteration = result.iterations.at(-1);
+  return {
+    goalId,
+    iterations: result.totalIterations,
+    gap: lastIteration?.gapAggregate,
+    status: result.finalStatus,
+  };
+}
+
+function buildLoopErrorPayload(goalId: string, error: unknown, context: GoalCycleRunnerContext): Record<string, unknown> {
+  const message = errorMessage(error);
+  return {
+    goalId,
+    error: message,
+    message,
+    status: "error",
+    crashCount: context.state?.crash_count,
+    maxRetries: context.config?.crash_recovery?.max_retries,
+  };
+}
 
 export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): Promise<void> {
   while (context.running && !context.shuttingDown) {
@@ -25,7 +49,16 @@ export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): P
 
         try {
           const iterationsPerCycle = context.config.iterations_per_cycle ?? 1;
-          const result: LoopResult = await context.coreLoop.run(goalId, { maxIterations: iterationsPerCycle });
+          const result: LoopResult = await context.coreLoop.run(goalId, {
+            maxIterations: iterationsPerCycle,
+            onProgress: (event: ProgressEvent) => {
+              if (!context.eventServer) return;
+              void context.eventServer.broadcast?.("progress", {
+                goalId,
+                ...event,
+              });
+            },
+          });
           context.state.loop_count++;
           context.currentLoopIndex = context.state.loop_count;
           context.state.last_loop_at = new Date().toISOString();
@@ -40,9 +73,13 @@ export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): P
               loopCount: context.state.loop_count,
               status: goal?.status ?? "unknown",
             });
+            void context.eventServer.broadcast?.("loop_complete", buildLoopCompletePayload(goalId, result));
           }
           await context.broadcastGoalUpdated(goalId, result.finalStatus);
         } catch (err) {
+          if (context.eventServer) {
+            void context.eventServer.broadcast?.("loop_error", buildLoopErrorPayload(goalId, err, context));
+          }
           context.handleLoopError(goalId, err);
         }
 


### PR DESCRIPTION
## What changed

- introduced a shared grounding gateway and exported public knowledge interfaces to remove chat-specific grounding assembly from the execution path
- added channel-aware shared chat ingress with ingress routing, cross-platform session routing, and a shared TUI chat surface path
- completed durable daemon event projection into chat transcripts, including progress, completion, approval, and loop-error projection before `/tend` starts work
- split builtin tool exports/factory wiring and updated telegram/TUI/chat integration tests around the new execution surfaces

## Why

The previous chat path mixed ingress normalization, lane selection, grounding assembly, and daemon progress delivery inside ChatRunner. This made multi-channel input support fragile and left durable progress partially outside the transcript model.

## Impact

- chat and TUI now share the same ingress and routing contract
- daemon/CoreLoop progress and failures can surface back into the chat transcript consistently
- grounding and builtin tool plumbing are easier to reuse from non-chat surfaces

## Validation

- pnpm vitest run src/interface/chat/__tests__/event-subscriber.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/runtime/__tests__/runner-goal-cycle.test.ts
- pnpm vitest run src/orchestrator/loop/__tests__/core-loop.test.ts src/interface/chat/__tests__/event-subscriber.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/runtime/__tests__/runner-goal-cycle.test.ts
- pnpm exec tsc -p tsconfig.json --noEmit
