### PR TITLE
feat(chat): share grounding with native agentloop

### DIFF
--- a/src/interface/chat/__tests__/chat-grounding.test.ts
+++ b/src/interface/chat/__tests__/chat-grounding.test.ts
@@ -32,7 +32,7 @@ vi.mock("../../../adapters/spawn-helper.js", () => ({
 }));
 
 // ─── Module imports (after mocks) ───
-import { buildChatGroundingBundle, buildSystemPrompt } from "../grounding.js";
+import { buildChatAgentLoopSystemPrompt, buildChatGroundingBundle, buildSystemPrompt } from "../grounding.js";
 import { ClaudeAPIAdapter } from "../../../adapters/agents/claude-api.js";
 import { ClaudeCodeCLIAdapter } from "../../../adapters/agents/claude-code-cli.js";
 import { OpenAICodexCLIAdapter } from "../../../adapters/agents/openai-codex.js";
@@ -259,6 +259,49 @@ describe("buildSystemPrompt (grounding.ts)", () => {
     const bundle = await buildChatGroundingBundle({ stateManager: sm, workspaceRoot: "/repo", userMessage: "Ship feature X" });
 
     expect(bundle.dynamicSections.some((section) => section.key === "goal_state" && section.content.includes("Ship feature X"))).toBe(true);
+  });
+
+  it("builds agentloop-oriented chat grounding with workspace facts in the prompt", async () => {
+    const sm = makeMockStateManager(
+      ["goal-1"],
+      {
+        "goal-1": { title: "Ship feature X", status: "active", loop_status: "running" },
+      }
+    );
+
+    const prompt = await buildChatAgentLoopSystemPrompt({
+      stateManager: sm,
+      workspaceRoot: "/repo",
+      userMessage: "Ship feature X",
+      workspaceContext: "Working directory: /repo",
+    });
+
+    expect(prompt).toContain("## Workspace Facts");
+    expect(prompt).toContain("Workspace root: /repo");
+    expect(prompt).toContain("Working directory: /repo");
+    expect(prompt).toContain("## Provider");
+    expect(prompt).toContain("## Installed Plugins");
+  });
+
+  it("keeps nested workspace instructions when chat grounding runs below the git root", async () => {
+    const repoRoot = path.join(tmpDir, "repo");
+    const nestedWorkspace = path.join(repoRoot, "packages", "app");
+    await fsp.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fsp.mkdir(nestedWorkspace, { recursive: true });
+    await fsp.writeFile(path.join(repoRoot, "AGENTS.md"), "Root instructions", "utf-8");
+    await fsp.writeFile(path.join(nestedWorkspace, "AGENTS.md"), "Nested instructions", "utf-8");
+
+    const sm = makeMockStateManager();
+    const prompt = await buildChatAgentLoopSystemPrompt({
+      stateManager: sm,
+      workspaceRoot: nestedWorkspace,
+      userMessage: "Inspect the package",
+      workspaceContext: `Working directory: ${nestedWorkspace}`,
+    });
+
+    expect(prompt).toContain("Root instructions");
+    expect(prompt).toContain("Nested instructions");
+    expect(prompt).toContain(`Workspace root: ${nestedWorkspace}`);
   });
 });
 

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1602,6 +1602,38 @@ describe("ChatRunner", () => {
       expect(result.diagnostics).toBeUndefined();
     });
 
+    it("grounds native chat agentloop through systemPrompt instead of injecting workspace context into the message", async () => {
+      const adapter = makeMockAdapter();
+      const stateManager = {
+        ...makeMockStateManager(),
+        listGoalIds: vi.fn().mockResolvedValue([]),
+        loadGoal: vi.fn().mockResolvedValue(null),
+      } as unknown as StateManager;
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "Agentloop answer",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
+        }),
+      } as unknown as ChatAgentLoopRunner;
+
+      const runner = new ChatRunner(makeDeps({ adapter, stateManager, chatAgentLoopRunner }));
+      await runner.execute("Inspect the repo layout", "/repo");
+
+      const input = vi.mocked(chatAgentLoopRunner.execute).mock.calls[0]?.[0] as {
+        message: string;
+        systemPrompt?: string;
+      };
+      expect(input.message).toBe("Inspect the repo layout");
+      expect(input.message).not.toContain("Working directory: /repo");
+      expect(input.systemPrompt).toContain("## Workspace Facts");
+      expect(input.systemPrompt).toContain("Working directory: /repo");
+      expect(adapter.execute).not.toHaveBeenCalled();
+    });
+
     it("surfaces native agentloop failures through the chat path", async () => {
       const adapter = makeMockAdapter();
       const chatAgentLoopRunner = {

--- a/src/interface/chat/__tests__/chat-schedule-integration.test.ts
+++ b/src/interface/chat/__tests__/chat-schedule-integration.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../../platform/observation/context-provider.js", () => ({
 
 vi.mock("../grounding.js", () => ({
   buildStaticSystemPrompt: () => "",
+  buildChatAgentLoopSystemPrompt: async () => "",
   buildDynamicContextPrompt: async () => "",
   createChatGroundingGateway: () => ({
     build: async () => ({

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -21,7 +21,7 @@ import {
 } from "./chat-session-store.js";
 import { buildChatContext, resolveGitRoot } from "../../platform/observation/context-provider.js";
 import type { EscalationHandler } from "./escalation.js";
-import { buildStaticSystemPrompt, createChatGroundingGateway } from "./grounding.js";
+import { buildChatAgentLoopSystemPrompt, buildStaticSystemPrompt, createChatGroundingGateway } from "./grounding.js";
 import type { GroundingGateway } from "../../grounding/gateway.js";
 import { verifyChatAction } from "./chat-verifier.js";
 import type { ApprovalLevel } from "./mutation-tool-defs.js";
@@ -1612,20 +1612,37 @@ export class ChatRunner {
       }
     }
 
+    const usesNativeAgentLoop = resumeOnly || selectedRoute?.kind === "agent_loop";
+    const groundingWorkspaceContext = !resumeOnly && usesNativeAgentLoop
+      ? await buildChatContext(input, cwd)
+      : undefined;
+
     let systemPrompt = this.cachedStaticSystemPrompt ?? "";
     if (!resumeOnly) {
       try {
         this.emitActivity("lifecycle", "Preparing context...", eventContext, "lifecycle:context");
-        const groundingBundle = await this.groundingGateway.build({
-          surface: "chat",
-          purpose: "general_turn",
-          workspaceRoot: cwd,
-          goalId: this.deps.goalId,
-          userMessage: input,
-          query: input,
-          trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
-        });
-        systemPrompt = String(groundingBundle.render("prompt"));
+        if (usesNativeAgentLoop) {
+          systemPrompt = await buildChatAgentLoopSystemPrompt({
+            stateManager: this.deps.stateManager,
+            pluginLoader: this.deps.pluginLoader,
+            workspaceRoot: cwd,
+            goalId: this.deps.goalId,
+            userMessage: input,
+            trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
+            workspaceContext: groundingWorkspaceContext,
+          });
+        } else {
+          const groundingBundle = await this.groundingGateway.build({
+            surface: "chat",
+            purpose: "general_turn",
+            workspaceRoot: cwd,
+            goalId: this.deps.goalId,
+            userMessage: input,
+            query: input,
+            trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
+          });
+          systemPrompt = String(groundingBundle.render("prompt"));
+        }
       } catch {
         systemPrompt = this.cachedStaticSystemPrompt ?? "";
       }
@@ -1638,7 +1655,7 @@ export class ChatRunner {
       .join("\n\n")
       .trim();
 
-    const context = resumeOnly ? "" : await buildChatContext(input, gitRoot);
+    const context = resumeOnly || usesNativeAgentLoop ? "" : await buildChatContext(input, gitRoot);
     const basePrompt = resumeOnly ? "" : (context ? `${context}\n\n${input}` : input);
     const prompt = historyBlock ? `${historyBlock}${basePrompt}` : basePrompt;
 

--- a/src/interface/chat/grounding.ts
+++ b/src/interface/chat/grounding.ts
@@ -19,6 +19,11 @@ export interface GroundingOptions {
   workspaceContext?: string;
 }
 
+interface ChatGroundingRequestOverrides extends Partial<GroundingRequest> {
+  surface?: GroundingRequest["surface"];
+  purpose?: GroundingRequest["purpose"];
+}
+
 function createChatGateway(options: Pick<GroundingOptions, "stateManager" | "pluginLoader">): GroundingGateway {
   return createGroundingGateway({
     stateManager: options.stateManager,
@@ -51,11 +56,11 @@ const CHAT_DYNAMIC_CONTEXT_INCLUDE: Partial<GroundingRequest["include"]> = {
 
 function buildChatGroundingRequest(
   options: GroundingOptions,
-  overrides: Partial<GroundingRequest> = {},
+  overrides: ChatGroundingRequestOverrides = {},
 ): GroundingRequest {
   return {
-    surface: "chat",
-    purpose: "general_turn",
+    surface: overrides.surface ?? "chat",
+    purpose: overrides.purpose ?? "general_turn",
     homeDir: options.homeDir,
     workspaceRoot: options.workspaceRoot,
     goalId: options.goalId,
@@ -95,9 +100,25 @@ function renderLegacyDynamicPrompt(sections: readonly GroundingSection[]): strin
 
 export async function buildChatGroundingBundle(
   options: GroundingOptions,
-  overrides: Partial<GroundingRequest> = {},
+  overrides: ChatGroundingRequestOverrides = {},
 ): Promise<GroundingBundle> {
   return await createChatGateway(options).build(buildChatGroundingRequest(options, overrides));
+}
+
+export async function buildChatAgentLoopSystemPrompt(options: GroundingOptions): Promise<string> {
+  const bundle = await buildChatGroundingBundle(options, {
+    surface: "agent_loop",
+    purpose: "task_execution",
+    include: {
+      progress_history: false,
+      session_history: false,
+      task_state: false,
+      trust_state: true,
+      provider_state: true,
+      plugins: true,
+    },
+  });
+  return String(bundle.render("prompt"));
 }
 
 export function buildStaticSystemPrompt(): string {


### PR DESCRIPTION
## Summary
- move native chat agentloop grounding into the shared grounding/system prompt path
- keep non-agentloop chat behavior unchanged and avoid duplicating workspace context in the user message
- add regression coverage for workspace facts and nested `AGENTS.md` discovery

## Validation
- independent sub-agent review: LGTM
- `npx vitest run src/interface/chat/__tests__/chat-grounding.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-runner-policy.test.ts src/interface/chat/__tests__/chat-schedule-integration.test.ts`
