### PR TITLE
refactor(agent-loop): resolve native defaults via provider config

### DIFF
--- a/src/base/llm/__tests__/provider-config.test.ts
+++ b/src/base/llm/__tests__/provider-config.test.ts
@@ -3,6 +3,7 @@ import {
   migrateProviderConfig,
   validateProviderConfig,
   MODEL_REGISTRY,
+  resolveProviderNativeAgentLoopDefaults,
 } from "../provider-config.js";
 
 // ─── Migration Tests ───
@@ -268,6 +269,51 @@ describe("validateProviderConfig", () => {
   });
 });
 
+describe("resolveProviderNativeAgentLoopDefaults", () => {
+  it("returns explicit native defaults when agent_loop config is absent", () => {
+    expect(resolveProviderNativeAgentLoopDefaults()).toMatchObject({
+      security: {
+        sandbox_mode: "workspace_write",
+        approval_policy: "on_request",
+        network_access: false,
+        trust_project_instructions: true,
+      },
+      worktreePolicy: {
+        enabled: true,
+        cleanupPolicy: "on_success",
+      },
+    });
+  });
+
+  it("merges configured security and worktree overrides over defaults", () => {
+    expect(resolveProviderNativeAgentLoopDefaults({
+      agent_loop: {
+        security: {
+          network_access: true,
+          protected_paths: ["/tmp/secrets"],
+        },
+        worktree: {
+          cleanup_policy: "always",
+          base_dir: "/tmp/worktrees",
+        },
+      },
+    })).toMatchObject({
+      security: {
+        sandbox_mode: "workspace_write",
+        approval_policy: "on_request",
+        network_access: true,
+        trust_project_instructions: true,
+        protected_paths: ["/tmp/secrets"],
+      },
+      worktreePolicy: {
+        enabled: true,
+        cleanupPolicy: "always",
+        baseDir: "/tmp/worktrees",
+      },
+    });
+  });
+});
+
 // ─── MODEL_REGISTRY Tests ───
 
 describe("MODEL_REGISTRY", () => {
@@ -350,10 +396,20 @@ describe("loadProviderConfig", () => {
 
   it("returns defaults when no file exists and no env vars", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const config = await loadProviderConfig();
+    const config = await loadProviderConfig({ baseDir: "/tmp/provider-config-defaults", saveMigration: false });
     expect(config.provider).toBe("openai");
     expect(config.model).toBe("gpt-5.4-mini");
     expect(config.adapter).toBe("openai_codex_cli");
+    expect(config.agent_loop?.security).toEqual({
+      sandbox_mode: "workspace_write",
+      approval_policy: "on_request",
+      network_access: false,
+      trust_project_instructions: true,
+    });
+    expect(config.agent_loop?.worktree).toEqual({
+      enabled: true,
+      cleanup_policy: "on_success",
+    });
     warnSpy.mockRestore();
   });
 

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -11,6 +11,7 @@ import { createHash } from "node:crypto";
 import { getPulseedDirPath } from "../utils/paths.js";
 import { writeJsonFileAtomic } from "../utils/json-io.js";
 import type { AgentLoopSecurityConfig } from "../../orchestrator/execution/agent-loop/execution-policy.js";
+import type { AgentLoopWorktreePolicy } from "../../orchestrator/execution/agent-loop/task-agent-loop-worktree.js";
 
 // ─── OAuth Token Helpers ───
 
@@ -145,6 +146,13 @@ export interface ProviderConfig {
   };
 }
 
+export type ProviderNativeAgentLoopConfig = NonNullable<ProviderConfig["agent_loop"]>;
+
+export interface ResolvedProviderNativeAgentLoopDefaults {
+  security?: AgentLoopSecurityConfig;
+  worktreePolicy?: AgentLoopWorktreePolicy;
+}
+
 /** Old nested provider config format (for migration) */
 interface LegacyProviderConfig {
   llm_provider: "anthropic" | "openai" | "ollama" | "codex";
@@ -176,6 +184,10 @@ const DEFAULT_PROVIDER_CONFIG: ProviderConfig = {
       approval_policy: "on_request",
       network_access: false,
       trust_project_instructions: true,
+    },
+    worktree: {
+      enabled: true,
+      cleanup_policy: "on_success",
     },
   },
 };
@@ -523,8 +535,24 @@ async function resolveProviderConfig(
   if (fileConfig.a2a !== undefined) config.a2a = fileConfig.a2a;
   if (lightModel !== undefined) config.light_model = lightModel;
   if (fileConfig.openclaw !== undefined) config.openclaw = fileConfig.openclaw;
-  if (fileConfig.agent_loop !== undefined) config.agent_loop = fileConfig.agent_loop;
+  config.agent_loop = resolveProviderNativeAgentLoopConfigShape(fileConfig);
   return config;
+}
+
+export function resolveProviderNativeAgentLoopDefaults(
+  providerConfig: Pick<ProviderConfig, "agent_loop"> | Partial<ProviderConfig> = {},
+): ResolvedProviderNativeAgentLoopDefaults {
+  const resolved = resolveProviderNativeAgentLoopConfigShape(providerConfig);
+  return {
+    security: resolved.security,
+    worktreePolicy: resolveProviderNativeAgentLoopWorktreePolicy(resolved.worktree),
+  };
+}
+
+export function resolveProviderNativeAgentLoopConfig(
+  providerConfig: Pick<ProviderConfig, "agent_loop"> | Partial<ProviderConfig> = {},
+): ProviderNativeAgentLoopConfig {
+  return resolveProviderNativeAgentLoopConfigShape(providerConfig);
 }
 
 function warnOnceForInvalidProviderConfig(config: ProviderConfig): void {
@@ -638,3 +666,34 @@ export async function saveProviderConfig(config: ProviderConfig): Promise<void> 
 
 // Re-export default for tests that need it
 export { DEFAULT_PROVIDER_CONFIG };
+
+function resolveProviderNativeAgentLoopConfigShape(
+  providerConfig: Pick<ProviderConfig, "agent_loop"> | Partial<ProviderConfig> = {},
+): ProviderNativeAgentLoopConfig {
+  const defaults = DEFAULT_PROVIDER_CONFIG.agent_loop;
+  const configured = providerConfig.agent_loop;
+  return {
+    security: mergeAgentLoopConfig(defaults?.security, configured?.security),
+    worktree: mergeAgentLoopConfig(defaults?.worktree, configured?.worktree),
+  };
+}
+
+function resolveProviderNativeAgentLoopWorktreePolicy(
+  worktree: ProviderNativeAgentLoopConfig["worktree"] | undefined,
+): AgentLoopWorktreePolicy | undefined {
+  if (!worktree) return undefined;
+  return {
+    enabled: worktree.enabled,
+    baseDir: worktree.base_dir,
+    keepForDebug: worktree.keep_for_debug,
+    cleanupPolicy: worktree.cleanup_policy,
+  };
+}
+
+function mergeAgentLoopConfig<T extends object>(defaults: T | undefined, configured: T | undefined): T | undefined {
+  if (!defaults && !configured) return undefined;
+  return {
+    ...(defaults ?? {}),
+    ...(configured ?? {}),
+  } as T;
+}

--- a/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-factory.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-factory.test.ts
@@ -5,9 +5,10 @@ import { ToolRegistry } from "../../../../tools/registry.js";
 import { ToolExecutor } from "../../../../tools/executor.js";
 import { ToolPermissionManager } from "../../../../tools/permission.js";
 import { ConcurrencyController } from "../../../../tools/concurrency.js";
-import { resolveAgentLoopDefaultProfile } from "../agent-loop-default-profile.js";
+import { resolveAgentLoopDefaultProfileFromProviderConfig } from "../agent-loop-default-profile.js";
 import {
   createNativeChatAgentLoopRunner,
+  createNativeReviewAgentLoopRunner,
   createNativeTaskAgentLoopRunner,
 } from "../task-agent-loop-factory.js";
 
@@ -25,9 +26,19 @@ function makeProviderConfig(): ProviderConfig {
       },
       worktree: {
         enabled: true,
-        cleanupPolicy: "always",
+        base_dir: "/tmp/provider-worktrees",
+        keep_for_debug: true,
+        cleanup_policy: "always",
       },
     },
+  } as ProviderConfig;
+}
+
+function makeProviderConfigWithoutAgentLoop(): ProviderConfig {
+  return {
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    adapter: "openai_codex_cli",
   } as ProviderConfig;
 }
 
@@ -58,11 +69,10 @@ describe("createNative*AgentLoopRunner", () => {
     });
 
     const deps = (runner as unknown as { deps: Record<string, unknown> }).deps;
-    const profile = resolveAgentLoopDefaultProfile({
+    const profile = resolveAgentLoopDefaultProfileFromProviderConfig({
       surface: "task",
       workspaceRoot: "/repo",
-      security: providerConfig.agent_loop?.security,
-      worktreePolicy: providerConfig.agent_loop?.worktree,
+      providerConfig,
     });
 
     expect(deps.defaultBudget).toEqual(profile.budget);
@@ -71,6 +81,48 @@ describe("createNative*AgentLoopRunner", () => {
     expect(deps.defaultProfileName).toBe(profile.name);
     expect(deps.defaultExecutionPolicy).toEqual(profile.executionPolicy);
     expect(deps.defaultWorktreePolicy).toEqual(profile.worktreePolicy);
+    expect(profile.worktreePolicy).toEqual({
+      enabled: true,
+      baseDir: "/tmp/provider-worktrees",
+      keepForDebug: true,
+      cleanupPolicy: "always",
+    });
+  });
+
+  it("restores fallback task defaults when provider config omits agent_loop settings", () => {
+    const providerConfig = makeProviderConfigWithoutAgentLoop();
+    const registry = new ToolRegistry();
+    const runner = createNativeTaskAgentLoopRunner({
+      llmClient: makeLlmClient(),
+      providerConfig,
+      toolRegistry: registry,
+      toolExecutor: makeToolExecutor(registry),
+      cwd: "/repo",
+    });
+
+    const deps = (runner as unknown as { deps: Record<string, unknown> }).deps;
+    const profile = resolveAgentLoopDefaultProfileFromProviderConfig({
+      surface: "task",
+      workspaceRoot: "/repo",
+      providerConfig,
+    });
+
+    expect(deps.defaultBudget).toEqual(profile.budget);
+    expect(deps.defaultToolPolicy).toEqual(profile.toolPolicy);
+    expect(deps.defaultReasoningEffort).toBe(profile.reasoningEffort);
+    expect(deps.defaultProfileName).toBe(profile.name);
+    expect(deps.defaultExecutionPolicy).toEqual(profile.executionPolicy);
+    expect(deps.defaultWorktreePolicy).toEqual(profile.worktreePolicy);
+    expect(profile.executionPolicy).toMatchObject({
+      sandboxMode: "workspace_write",
+      approvalPolicy: "never",
+      networkAccess: false,
+      trustProjectInstructions: true,
+    });
+    expect(profile.worktreePolicy).toEqual({
+      enabled: true,
+      cleanupPolicy: "on_success",
+    });
   });
 
   it("keeps chat profile defaults for budget, reasoning, and execution policy", () => {
@@ -85,16 +137,40 @@ describe("createNative*AgentLoopRunner", () => {
     });
 
     const deps = (runner as unknown as { deps: Record<string, unknown> }).deps;
-    const profile = resolveAgentLoopDefaultProfile({
+    const profile = resolveAgentLoopDefaultProfileFromProviderConfig({
       surface: "chat",
       workspaceRoot: "/repo",
-      security: providerConfig.agent_loop?.security,
+      providerConfig,
     });
 
     expect(deps.defaultBudget).toEqual(profile.budget);
     expect(deps.defaultToolPolicy).toEqual(profile.toolPolicy);
     expect(deps.defaultReasoningEffort).toBe(profile.reasoningEffort);
     expect(deps.defaultProfileName).toBe(profile.name);
+    expect(deps.defaultExecutionPolicy).toEqual(profile.executionPolicy);
+  });
+
+  it("keeps review profile defaults for budget, tools, and execution posture", () => {
+    const providerConfig = makeProviderConfig();
+    const registry = new ToolRegistry();
+    const runner = createNativeReviewAgentLoopRunner({
+      llmClient: makeLlmClient(),
+      providerConfig,
+      toolRegistry: registry,
+      toolExecutor: makeToolExecutor(registry),
+      cwd: "/repo",
+    });
+
+    const deps = (runner as unknown as { deps: Record<string, unknown> }).deps;
+    const profile = resolveAgentLoopDefaultProfileFromProviderConfig({
+      surface: "review",
+      workspaceRoot: "/repo",
+      providerConfig,
+    });
+
+    expect(deps.defaultBudget).toEqual(profile.budget);
+    expect(deps.defaultToolPolicy).toEqual(profile.toolPolicy);
+    expect(deps.defaultReasoningEffort).toBe(profile.reasoningEffort);
     expect(deps.defaultExecutionPolicy).toEqual(profile.executionPolicy);
   });
 });

--- a/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
@@ -6,6 +6,8 @@ import type { AgentLoopReasoningEffort } from "./agent-loop-model.js";
 import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
 import { withDefaultBudget } from "./agent-loop-turn-context.js";
 import type { AgentLoopWorktreePolicy } from "./task-agent-loop-worktree.js";
+import type { ProviderConfig } from "../../../base/llm/provider-config.js";
+import { resolveProviderNativeAgentLoopDefaults } from "../../../base/llm/provider-config.js";
 
 export type AgentLoopDefaultProfileName =
   | "task"
@@ -63,6 +65,16 @@ interface CorePhaseProfileInput {
 export type ResolveAgentLoopDefaultProfileInput =
   | SurfaceProfileInput
   | CorePhaseProfileInput;
+
+export interface ResolveAgentLoopDefaultProfileFromProviderConfigInput {
+  surface: "task" | "chat" | "review";
+  workspaceRoot: string;
+  providerConfig?: Pick<ProviderConfig, "agent_loop">;
+  budget?: Partial<AgentLoopBudget>;
+  toolPolicy?: AgentLoopToolPolicy;
+  worktreePolicy?: AgentLoopWorktreePolicy;
+  reasoningEffort?: AgentLoopReasoningEffort;
+}
 
 const DEFAULT_SURFACE_PROFILE = {
   budget: withDefaultBudget(),
@@ -300,6 +312,21 @@ export function resolveAgentLoopDefaultProfile(
     ),
     reasoningEffort: input.reasoningEffort ?? "medium",
   };
+}
+
+export function resolveAgentLoopDefaultProfileFromProviderConfig(
+  input: ResolveAgentLoopDefaultProfileFromProviderConfigInput,
+): AgentLoopResolvedProfile {
+  const providerDefaults = resolveProviderNativeAgentLoopDefaults(input.providerConfig);
+  return resolveAgentLoopDefaultProfile({
+    surface: input.surface,
+    workspaceRoot: input.workspaceRoot,
+    security: providerDefaults.security,
+    budget: input.budget,
+    toolPolicy: input.toolPolicy,
+    worktreePolicy: mergeWorktreePolicy(providerDefaults.worktreePolicy, input.worktreePolicy),
+    reasoningEffort: input.reasoningEffort,
+  });
 }
 
 export function summarizeAgentLoopResolvedProfile(

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-factory.ts
@@ -21,7 +21,7 @@ import { ReviewAgentLoopRunner } from "./review-agent-loop-runner.js";
 import { TaskAgentLoopRunner } from "./task-agent-loop-runner.js";
 import type { AgentLoopBudget } from "./agent-loop-budget.js";
 import { AgentLoopContextAssembler } from "./agent-loop-context-assembler.js";
-import { resolveAgentLoopDefaultProfile } from "./agent-loop-default-profile.js";
+import { resolveAgentLoopDefaultProfileFromProviderConfig } from "./agent-loop-default-profile.js";
 import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
 import type { SoilPrefetchQuery, SoilPrefetchResult } from "./agent-loop-context-assembler.js";
 import { createPersistentAgentLoopSessionFactory } from "./agent-loop-session-factory.js";
@@ -53,13 +53,13 @@ export function createNativeTaskAgentLoopRunner(
   deps: NativeTaskAgentLoopRuntimeDeps,
 ): TaskAgentLoopRunner {
   const runtime = createNativeAgentLoopRuntime(deps);
-  const profile = resolveAgentLoopDefaultProfile({
+  const profile = resolveAgentLoopDefaultProfileFromProviderConfig({
     surface: "task",
     workspaceRoot: deps.cwd ?? process.cwd(),
-    security: deps.providerConfig.agent_loop?.security,
+    providerConfig: deps.providerConfig,
     budget: deps.defaultBudget,
     toolPolicy: deps.defaultToolPolicy,
-    worktreePolicy: deps.defaultWorktreePolicy ?? deps.providerConfig.agent_loop?.worktree,
+    worktreePolicy: deps.defaultWorktreePolicy,
   });
 
   return new TaskAgentLoopRunner({
@@ -92,10 +92,10 @@ export function createNativeChatAgentLoopRunner(
   deps: NativeTaskAgentLoopRuntimeDeps,
 ): ChatAgentLoopRunner {
   const runtime = createNativeAgentLoopRuntime(deps);
-  const profile = resolveAgentLoopDefaultProfile({
+  const profile = resolveAgentLoopDefaultProfileFromProviderConfig({
     surface: "chat",
     workspaceRoot: deps.cwd ?? process.cwd(),
-    security: deps.providerConfig.agent_loop?.security,
+    providerConfig: deps.providerConfig,
     budget: deps.defaultBudget,
     toolPolicy: deps.defaultToolPolicy,
   });
@@ -122,10 +122,10 @@ export function createNativeReviewAgentLoopRunner(
   deps: NativeTaskAgentLoopRuntimeDeps,
 ): ReviewAgentLoopRunner {
   const runtime = createNativeAgentLoopRuntime(deps);
-  const profile = resolveAgentLoopDefaultProfile({
+  const profile = resolveAgentLoopDefaultProfileFromProviderConfig({
     surface: "review",
     workspaceRoot: deps.cwd ?? process.cwd(),
-    security: deps.providerConfig.agent_loop?.security,
+    providerConfig: deps.providerConfig,
     budget: deps.defaultBudget,
     toolPolicy: deps.defaultToolPolicy,
   });


### PR DESCRIPTION
## Summary
- route native task/chat/review AgentLoop defaults through one provider-config-backed resolver path
- normalize `agent_loop.worktree` defaults and snake_case config mapping in provider config resolution
- add focused tests for missing `agent_loop` config and task/chat/review default posture

## Validation
- independent sub-agent review: LGTM
- `npx vitest run src/base/llm/__tests__/provider-config.test.ts src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-factory.test.ts`
