### PR TITLE
Require explicit selectedRoute for executeIngressMessage and align ingress routing

### DIFF
--- a/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
@@ -19,6 +19,16 @@ const mockGetGlobalCrossPlatformChatSessionManager = vi.hoisted(() => vi.fn().mo
 const mockShouldUseNativeTaskAgentLoop = vi.hoisted(() => vi.fn().mockReturnValue(false));
 const mockCreateNativeChatAgentLoopRunner = vi.hoisted(() => vi.fn());
 const mockResolveChannelRoute = vi.hoisted(() => vi.fn().mockReturnValue({ metadata: {} }));
+const mockSelectRoute = vi.hoisted(() => vi.fn().mockReturnValue({
+  lane: "fast",
+  kind: "tool_loop",
+  reason: "tool_loop_available",
+  replyTargetPolicy: "turn_reply_target",
+  eventProjectionPolicy: "turn_only",
+  concurrencyPolicy: "session_serial",
+  daemonChatPolicy: "compatibility_only",
+}));
+const mockCreateIngressRouter = vi.hoisted(() => vi.fn().mockReturnValue({ selectRoute: mockSelectRoute }));
 
 vi.mock("pulseed", () => {
   class FakeStateManager {
@@ -96,6 +106,7 @@ vi.mock("pulseed", () => {
     shouldUseNativeTaskAgentLoop: mockShouldUseNativeTaskAgentLoop,
     createNativeChatAgentLoopRunner: mockCreateNativeChatAgentLoopRunner,
     resolveChannelRoute: mockResolveChannelRoute,
+    createIngressRouter: mockCreateIngressRouter,
   };
 });
 
@@ -117,6 +128,17 @@ describe("TelegramChatRunnerProcessor", () => {
     mockCreateNativeChatAgentLoopRunner.mockReset();
     mockResolveChannelRoute.mockReset();
     mockResolveChannelRoute.mockReturnValue({ metadata: {} });
+    mockSelectRoute.mockClear();
+    mockSelectRoute.mockReturnValue({
+      lane: "fast",
+      kind: "tool_loop",
+      reason: "tool_loop_available",
+      replyTargetPolicy: "turn_reply_target",
+      eventProjectionPolicy: "turn_only",
+      concurrencyPolicy: "session_serial",
+      daemonChatPolicy: "compatibility_only",
+    });
+    mockCreateIngressRouter.mockClear();
   });
 
   it("reuses one ChatRunner per chatId", async () => {
@@ -151,11 +173,73 @@ describe("TelegramChatRunnerProcessor", () => {
       "/workspace",
       expect.any(Number),
       expect.objectContaining({
-        kind: "adapter",
-        reason: "adapter_fallback",
+        kind: "tool_loop",
+        reason: "tool_loop_available",
+      })
+    );
+    expect(mockSelectRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "first",
+        channel: "plugin_gateway",
+        platform: "telegram",
+      }),
+      expect.objectContaining({
+        hasLightweightLlm: true,
+        hasAgentLoop: false,
+        hasToolLoop: true,
       })
     );
     cwdSpy.mockRestore();
+  });
+
+  it("preserves fallback route selection for direct-answer and runtime-control lanes", async () => {
+    const directRoute = {
+      lane: "fast",
+      kind: "direct_answer",
+      reason: "simple_question",
+      modelTier: "light",
+      maxTokens: 256,
+      replyTargetPolicy: "turn_reply_target",
+      eventProjectionPolicy: "turn_only",
+      concurrencyPolicy: "session_serial",
+      daemonChatPolicy: "compatibility_only",
+    };
+    const runtimeRoute = {
+      lane: "durable",
+      kind: "runtime_control",
+      reason: "runtime_control_intent",
+      intent: { kind: "restart_daemon", reason: "PulSeed を再起動して" },
+      replyTargetPolicy: "turn_reply_target",
+      eventProjectionPolicy: "latest_active_reply_target",
+      concurrencyPolicy: "session_serial",
+      daemonChatPolicy: "compatibility_only",
+    };
+    mockSelectRoute
+      .mockReturnValueOnce(directRoute)
+      .mockReturnValueOnce(runtimeRoute);
+    const processor = new TelegramChatRunnerProcessor("/tmp/plugins/telegram-bot", "/workspace", undefined, [777]);
+
+    await expect(processor.processMessage("What is PulSeed?", 101, vi.fn())).resolves.toBe("runner-output");
+    await expect(processor.processMessage("PulSeed を再起動して", 101, vi.fn(), 777)).resolves.toBe("runner-output");
+
+    expect(mockCreatedRunners[0]!.executeIngressMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "What is PulSeed?" }),
+      "/workspace",
+      expect.any(Number),
+      directRoute
+    );
+    expect(mockCreatedRunners[0]!.executeIngressMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: "PulSeed を再起動して",
+        runtimeControl: expect.objectContaining({
+          allowed: true,
+          approvalMode: "interactive",
+        }),
+      }),
+      "/workspace",
+      expect.any(Number),
+      runtimeRoute
+    );
   });
 
   it("returns a plain error string when bootstrap fails", async () => {

--- a/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
+++ b/plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts
@@ -148,7 +148,12 @@ describe("TelegramChatRunnerProcessor", () => {
         platform: "telegram",
         conversation_id: "101",
       }),
-      "/workspace"
+      "/workspace",
+      expect.any(Number),
+      expect.objectContaining({
+        kind: "adapter",
+        reason: "adapter_fallback",
+      })
     );
     cwdSpy.mockRestore();
   });

--- a/plugins/telegram-bot/src/pulseed.ts
+++ b/plugins/telegram-bot/src/pulseed.ts
@@ -22,6 +22,7 @@ export {
   PluginLoader,
   NotifierRegistry,
   resolveChannelRoute,
+  createIngressRouter,
 } from "../../../src/index.js";
 
 export type {

--- a/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
+++ b/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
@@ -154,7 +154,15 @@ export class TelegramChatRunnerProcessor {
         metadata: {
           chat_id: chatId,
         },
-      }, this.workspaceRoot);
+      }, this.workspaceRoot, 120_000, {
+        lane: "fast",
+        kind: "adapter",
+        reason: "adapter_fallback",
+        replyTargetPolicy: "turn_reply_target",
+        eventProjectionPolicy: "turn_only",
+        concurrencyPolicy: "session_serial",
+        daemonChatPolicy: "compatibility_only",
+      });
       return result.output;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
+++ b/plugins/telegram-bot/src/telegram-chat-runner-processor.ts
@@ -28,6 +28,7 @@ import {
   createNativeChatAgentLoopRunner,
   shouldUseNativeTaskAgentLoop,
   resolveChannelRoute,
+  createIngressRouter,
 } from "pulseed";
 import { TrustManager } from "pulseed";
 
@@ -123,8 +124,9 @@ export class TelegramChatRunnerProcessor {
 
     try {
       const runner = await this.getRunner(chatId);
+      const bootstrap = await this.bootstrap();
       runner.onEvent = emit;
-      const result = await runner.executeIngressMessage({
+      const ingress = {
         text,
         channel: "plugin_gateway",
         platform: "telegram",
@@ -154,15 +156,14 @@ export class TelegramChatRunnerProcessor {
         metadata: {
           chat_id: chatId,
         },
-      }, this.workspaceRoot, 120_000, {
-        lane: "fast",
-        kind: "adapter",
-        reason: "adapter_fallback",
-        replyTargetPolicy: "turn_reply_target",
-        eventProjectionPolicy: "turn_only",
-        concurrencyPolicy: "session_serial",
-        daemonChatPolicy: "compatibility_only",
+      } as const;
+      const selectedRoute = createIngressRouter().selectRoute(ingress, {
+        hasLightweightLlm: bootstrap.llmClient !== undefined,
+        hasAgentLoop: bootstrap.chatAgentLoopRunner !== undefined,
+        hasToolLoop: bootstrap.llmClient !== undefined,
+        hasRuntimeControlService: false,
       });
+      const result = await runner.executeIngressMessage(ingress, this.workspaceRoot, 120_000, selectedRoute);
       return result.output;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,21 @@ export type {
   CrossPlatformChatSessionInfo,
   CrossPlatformIncomingChatMessage,
 } from "./interface/chat/cross-platform-session.js";
+export {
+  buildStandaloneIngressMessage,
+  createIngressRouter,
+  describeSelectedRoute,
+  normalizeLegacyIngressInput,
+  selectLegacyChatRoute,
+} from "./interface/chat/ingress-router.js";
+export type {
+  ChatIngressChannel,
+  ChatIngressReplyTarget,
+  ChatSelectedRoute,
+  IngressMessage,
+  IngressRuntimeControl,
+  SelectedChatRoute,
+} from "./interface/chat/ingress-router.js";
 export type {
   ChatEvent,
   ChatEventHandler,

--- a/src/interface/chat/__tests__/chat-grounding.test.ts
+++ b/src/interface/chat/__tests__/chat-grounding.test.ts
@@ -32,7 +32,7 @@ vi.mock("../../../adapters/spawn-helper.js", () => ({
 }));
 
 // ─── Module imports (after mocks) ───
-import { buildChatGroundingBundle, buildSystemPrompt } from "../grounding.js";
+import { buildChatAgentLoopSystemPrompt, buildChatGroundingBundle, buildSystemPrompt } from "../grounding.js";
 import { ClaudeAPIAdapter } from "../../../adapters/agents/claude-api.js";
 import { ClaudeCodeCLIAdapter } from "../../../adapters/agents/claude-code-cli.js";
 import { OpenAICodexCLIAdapter } from "../../../adapters/agents/openai-codex.js";
@@ -259,6 +259,49 @@ describe("buildSystemPrompt (grounding.ts)", () => {
     const bundle = await buildChatGroundingBundle({ stateManager: sm, workspaceRoot: "/repo", userMessage: "Ship feature X" });
 
     expect(bundle.dynamicSections.some((section) => section.key === "goal_state" && section.content.includes("Ship feature X"))).toBe(true);
+  });
+
+  it("builds agentloop-oriented chat grounding with workspace facts in the prompt", async () => {
+    const sm = makeMockStateManager(
+      ["goal-1"],
+      {
+        "goal-1": { title: "Ship feature X", status: "active", loop_status: "running" },
+      }
+    );
+
+    const prompt = await buildChatAgentLoopSystemPrompt({
+      stateManager: sm,
+      workspaceRoot: "/repo",
+      userMessage: "Ship feature X",
+      workspaceContext: "Working directory: /repo",
+    });
+
+    expect(prompt).toContain("## Workspace Facts");
+    expect(prompt).toContain("Workspace root: /repo");
+    expect(prompt).toContain("Working directory: /repo");
+    expect(prompt).toContain("## Provider");
+    expect(prompt).toContain("## Installed Plugins");
+  });
+
+  it("keeps nested workspace instructions when chat grounding runs below the git root", async () => {
+    const repoRoot = path.join(tmpDir, "repo");
+    const nestedWorkspace = path.join(repoRoot, "packages", "app");
+    await fsp.mkdir(path.join(repoRoot, ".git"), { recursive: true });
+    await fsp.mkdir(nestedWorkspace, { recursive: true });
+    await fsp.writeFile(path.join(repoRoot, "AGENTS.md"), "Root instructions", "utf-8");
+    await fsp.writeFile(path.join(nestedWorkspace, "AGENTS.md"), "Nested instructions", "utf-8");
+
+    const sm = makeMockStateManager();
+    const prompt = await buildChatAgentLoopSystemPrompt({
+      stateManager: sm,
+      workspaceRoot: nestedWorkspace,
+      userMessage: "Inspect the package",
+      workspaceContext: `Working directory: ${nestedWorkspace}`,
+    });
+
+    expect(prompt).toContain("Root instructions");
+    expect(prompt).toContain("Nested instructions");
+    expect(prompt).toContain(`Workspace root: ${nestedWorkspace}`);
   });
 });
 

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -15,7 +15,7 @@ import { RuntimeOperationStore } from "../../../runtime/store/runtime-operation-
 import type { Goal } from "../../../base/types/goal.js";
 import type { Task } from "../../../base/types/task.js";
 import type { ChatEvent } from "../chat-events.js";
-
+import { selectLegacyChatRoute } from "../ingress-router.js";
 // Mock context-provider so tests don't walk the real filesystem
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -1710,12 +1710,89 @@ describe("ChatRunner", () => {
           approvalMode: "interactive",
         },
         metadata: {},
-      }, "/repo");
+      }, "/repo", 120_000, selectLegacyChatRoute("What is this lane?", {
+        hasLightweightLlm: true,
+        hasAgentLoop: false,
+        hasToolLoop: false,
+        hasRuntimeControlService: false,
+      }));
 
       expect(result.success).toBe(true);
       expect(result.output).toBe("TUI answer");
       expect(result.diagnostics?.reason).toBe("simple_question");
       expect(adapter.execute).not.toHaveBeenCalled();
+    });
+
+    it("requires selectedRoute when executeIngressMessage is called directly", async () => {
+      const runner = new ChatRunner(makeDeps({}));
+
+      await expect(
+        runner.executeIngressMessage({
+          text: "PulSeed を再起動して",
+          channel: "tui",
+          platform: "local_tui",
+          actor: {
+            surface: "tui",
+            platform: "local_tui",
+          },
+          replyTarget: {
+            surface: "tui",
+            platform: "local_tui",
+            metadata: {},
+          },
+          runtimeControl: {
+            allowed: false,
+            approvalMode: "disallowed",
+          },
+          metadata: {},
+        }, "/repo")
+      ).rejects.toThrow("executeIngressMessage requires selectedRoute");
+    });
+
+    it("supports routed ingress execution with explicit route", async () => {
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "Agentloop from explicit route",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
+        }),
+      } as unknown as ChatAgentLoopRunner;
+      const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner }));
+
+      const result = await runner.executeIngressMessage({
+        text: "PulSeed を再起動して",
+        channel: "tui",
+        platform: "local_tui",
+        actor: {
+          surface: "tui",
+          platform: "local_tui",
+        },
+        replyTarget: {
+          surface: "tui",
+          platform: "local_tui",
+          metadata: {},
+        },
+        runtimeControl: {
+          allowed: false,
+          approvalMode: "disallowed",
+        },
+        metadata: {},
+      }, "/repo", 120_000, {
+        lane: "fast",
+        kind: "agent_loop",
+        reason: "agent_loop_available",
+        replyTargetPolicy: "turn_reply_target",
+        eventProjectionPolicy: "turn_only",
+        concurrencyPolicy: "session_serial",
+        daemonChatPolicy: "compatibility_only",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe("Agentloop from explicit route");
+      expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
     });
 
     it("does not route repository confirmation questions through the direct path", async () => {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1727,7 +1727,7 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({}));
 
       await expect(
-        runner.executeIngressMessage({
+        (runner.executeIngressMessage as any)({
           text: "PulSeed を再起動して",
           channel: "tui",
           platform: "local_tui",

--- a/src/interface/chat/__tests__/chat-schedule-integration.test.ts
+++ b/src/interface/chat/__tests__/chat-schedule-integration.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../../platform/observation/context-provider.js", () => ({
 
 vi.mock("../grounding.js", () => ({
   buildStaticSystemPrompt: () => "",
+  buildChatAgentLoopSystemPrompt: async () => "",
   buildDynamicContextPrompt: async () => "",
   createChatGroundingGateway: () => ({
     build: async () => ({

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -21,7 +21,7 @@ import {
 } from "./chat-session-store.js";
 import { buildChatContext, resolveGitRoot } from "../../platform/observation/context-provider.js";
 import type { EscalationHandler } from "./escalation.js";
-import { buildStaticSystemPrompt, createChatGroundingGateway } from "./grounding.js";
+import { buildChatAgentLoopSystemPrompt, buildStaticSystemPrompt, createChatGroundingGateway } from "./grounding.js";
 import type { GroundingGateway } from "../../grounding/gateway.js";
 import { verifyChatAction } from "./chat-verifier.js";
 import type { ApprovalLevel } from "./mutation-tool-defs.js";
@@ -300,13 +300,27 @@ export class ChatRunner {
     ingress: ChatIngressMessage,
     cwd: string,
     timeoutMs = DEFAULT_TIMEOUT_MS,
-    selectedRoute?: SelectedChatRoute
+    selectedRoute: SelectedChatRoute
   ): Promise<ChatRunResult> {
+    if (!selectedRoute) {
+      throw new Error(
+        "executeIngressMessage requires selectedRoute; use CrossPlatformChatSessionManager for ingress route selection."
+      );
+    }
+
     const runtimeControlContext = this.buildRuntimeControlContextFromIngress(ingress);
-    return this.execute(ingress.text, cwd, timeoutMs, {
-      selectedRoute: selectedRoute ?? standaloneIngressRouter.selectRoute(ingress, this.getRouteCapabilities()),
-      runtimeControlContext,
-    });
+    return this.execute(ingress.text, cwd, timeoutMs, { selectedRoute, runtimeControlContext });
+  }
+
+  private resolveRouteFromIngress(ingress: ChatIngressMessage): SelectedChatRoute {
+    return standaloneIngressRouter.selectRoute(ingress, this.getRouteCapabilities());
+  }
+
+  private resolveRouteFromInput(
+    input: string,
+    runtimeControlContext: RuntimeControlChatContext | null
+  ): SelectedChatRoute {
+    return this.resolveRouteFromIngress(this.buildStandaloneIngressMessage(input, runtimeControlContext));
   }
 
   private getRouteCapabilities(): {
@@ -1518,10 +1532,7 @@ export class ChatRunner {
 
     const selectedRoute = resumeOnly
       ? null
-      : (options.selectedRoute ?? standaloneIngressRouter.selectRoute(
-        this.buildStandaloneIngressMessage(input, runtimeControlContext),
-        this.getRouteCapabilities()
-      ));
+      : (options.selectedRoute ?? this.resolveRouteFromInput(input, runtimeControlContext));
     const directPrompt = historyBlock ? `${historyBlock}${input}` : input;
 
     const start = Date.now();
@@ -1612,20 +1623,37 @@ export class ChatRunner {
       }
     }
 
+    const usesNativeAgentLoop = resumeOnly || selectedRoute?.kind === "agent_loop";
+    const groundingWorkspaceContext = !resumeOnly && usesNativeAgentLoop
+      ? await buildChatContext(input, cwd)
+      : undefined;
+
     let systemPrompt = this.cachedStaticSystemPrompt ?? "";
     if (!resumeOnly) {
       try {
         this.emitActivity("lifecycle", "Preparing context...", eventContext, "lifecycle:context");
-        const groundingBundle = await this.groundingGateway.build({
-          surface: "chat",
-          purpose: "general_turn",
-          workspaceRoot: cwd,
-          goalId: this.deps.goalId,
-          userMessage: input,
-          query: input,
-          trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
-        });
-        systemPrompt = String(groundingBundle.render("prompt"));
+        if (usesNativeAgentLoop) {
+          systemPrompt = await buildChatAgentLoopSystemPrompt({
+            stateManager: this.deps.stateManager,
+            pluginLoader: this.deps.pluginLoader,
+            workspaceRoot: cwd,
+            goalId: this.deps.goalId,
+            userMessage: input,
+            trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
+            workspaceContext: groundingWorkspaceContext,
+          });
+        } else {
+          const groundingBundle = await this.groundingGateway.build({
+            surface: "chat",
+            purpose: "general_turn",
+            workspaceRoot: cwd,
+            goalId: this.deps.goalId,
+            userMessage: input,
+            query: input,
+            trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
+          });
+          systemPrompt = String(groundingBundle.render("prompt"));
+        }
       } catch {
         systemPrompt = this.cachedStaticSystemPrompt ?? "";
       }
@@ -1638,7 +1666,7 @@ export class ChatRunner {
       .join("\n\n")
       .trim();
 
-    const context = resumeOnly ? "" : await buildChatContext(input, gitRoot);
+    const context = resumeOnly || usesNativeAgentLoop ? "" : await buildChatContext(input, gitRoot);
     const basePrompt = resumeOnly ? "" : (context ? `${context}\n\n${input}` : input);
     const prompt = historyBlock ? `${historyBlock}${basePrompt}` : basePrompt;
 

--- a/src/interface/chat/grounding.ts
+++ b/src/interface/chat/grounding.ts
@@ -19,6 +19,11 @@ export interface GroundingOptions {
   workspaceContext?: string;
 }
 
+interface ChatGroundingRequestOverrides extends Partial<GroundingRequest> {
+  surface?: GroundingRequest["surface"];
+  purpose?: GroundingRequest["purpose"];
+}
+
 function createChatGateway(options: Pick<GroundingOptions, "stateManager" | "pluginLoader">): GroundingGateway {
   return createGroundingGateway({
     stateManager: options.stateManager,
@@ -51,11 +56,11 @@ const CHAT_DYNAMIC_CONTEXT_INCLUDE: Partial<GroundingRequest["include"]> = {
 
 function buildChatGroundingRequest(
   options: GroundingOptions,
-  overrides: Partial<GroundingRequest> = {},
+  overrides: ChatGroundingRequestOverrides = {},
 ): GroundingRequest {
   return {
-    surface: "chat",
-    purpose: "general_turn",
+    surface: overrides.surface ?? "chat",
+    purpose: overrides.purpose ?? "general_turn",
     homeDir: options.homeDir,
     workspaceRoot: options.workspaceRoot,
     goalId: options.goalId,
@@ -95,9 +100,25 @@ function renderLegacyDynamicPrompt(sections: readonly GroundingSection[]): strin
 
 export async function buildChatGroundingBundle(
   options: GroundingOptions,
-  overrides: Partial<GroundingRequest> = {},
+  overrides: ChatGroundingRequestOverrides = {},
 ): Promise<GroundingBundle> {
   return await createChatGateway(options).build(buildChatGroundingRequest(options, overrides));
+}
+
+export async function buildChatAgentLoopSystemPrompt(options: GroundingOptions): Promise<string> {
+  const bundle = await buildChatGroundingBundle(options, {
+    surface: "agent_loop",
+    purpose: "task_execution",
+    include: {
+      progress_history: false,
+      session_history: false,
+      task_state: false,
+      trust_state: true,
+      provider_state: true,
+      plugins: true,
+    },
+  });
+  return String(bundle.render("prompt"));
 }
 
 export function buildStaticSystemPrompt(): string {

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -3,7 +3,7 @@ import { render } from "ink";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DaemonClient } from "../../../runtime/daemon/client.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
-import type { ChatRunner } from "../../chat/chat-runner.js";
+import type { TuiChatSurface } from "../chat-surface.js";
 import { App, formatDaemonConnectionState } from "../app.js";
 
 const testState = vi.hoisted(() => ({
@@ -120,7 +120,7 @@ describe("standalone slash command routing", () => {
 
     const screen = render(React.createElement(App, {
       stateManager: stateManager as unknown as StateManager,
-      chatRunner: chatRunner as unknown as ChatRunner,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
       intentRecognizer: intentRecognizer as any,
       actionHandler: actionHandler as any,
       noFlicker: false,
@@ -164,7 +164,7 @@ describe("daemon-mode chat routing", () => {
     const screen = render(React.createElement(App, {
       daemonClient: daemonClient as unknown as DaemonClient,
       stateManager: stateManager as unknown as StateManager,
-      chatRunner: chatRunner as unknown as ChatRunner,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
       noFlicker: false,
       controlStream: process.stdout,
       cwd: "~/workspace",
@@ -183,14 +183,8 @@ describe("daemon-mode chat routing", () => {
 
     await testState.lastChatProps!.onSubmit("free form question");
 
-    expect(chatRunner.executeIngressMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        text: "free form question",
-        channel: "tui",
-        platform: "local_tui",
-      }),
-      process.cwd()
-    );
+    expect(chatRunner.execute).toHaveBeenCalledWith("free form question", process.cwd());
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
     expect(daemonClient.chat).not.toHaveBeenCalled();
 
     screen.unmount();
@@ -204,7 +198,7 @@ describe("daemon-mode chat routing", () => {
     const screen = render(React.createElement(App, {
       daemonClient: daemonClient as unknown as DaemonClient,
       stateManager: stateManager as unknown as StateManager,
-      chatRunner: chatRunner as unknown as ChatRunner,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
       noFlicker: false,
       controlStream: process.stdout,
       cwd: "~/workspace",
@@ -245,7 +239,7 @@ describe("daemon-mode chat routing", () => {
     const screen = render(React.createElement(App, {
       daemonClient: daemonClient as unknown as DaemonClient,
       stateManager: stateManager as unknown as StateManager,
-      chatRunner: chatRunner as unknown as ChatRunner,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
       noFlicker: false,
       controlStream: process.stdout,
       cwd: "~/workspace",

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -494,27 +494,7 @@ export function App({
               }].slice(-MAX_MESSAGES));
             }
           } else if (freeformRoute === "chat_runner" && chatRunner) {
-            await chatRunner.executeIngressMessage({
-              text: input,
-              channel: "tui",
-              platform: "local_tui",
-              actor: {
-                surface: "tui",
-                platform: "local_tui",
-              },
-              replyTarget: {
-                surface: "tui",
-                platform: "local_tui",
-                metadata: {},
-              },
-              runtimeControl: {
-                allowed: true,
-                approvalMode: "interactive",
-              },
-              metadata: {},
-              ingress_id: randomUUID(),
-              received_at: new Date().toISOString(),
-            }, process.cwd());
+            await chatRunner.execute(input, process.cwd());
           } else {
             setMessages((prev) => [...prev, {
               id: randomUUID(), role: "pulseed" as const,


### PR DESCRIPTION
## Summary
- Make ChatRunner.executeIngressMessage require explicit SelectedChatRoute and throw when omitted.
- Keep route resolution only at ingress/session layer (cross-platform session and gateway-managed paths).
- Add explicit adapter route for telegram fallback processing.
- Update agent-loop grounding to use dedicated agent-loop system prompt path.
- Update tests for required-route enforcement and added grounding behavior.

## Validation
- npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-grounding.test.ts src/interface/chat/__tests__/chat-schedule-integration.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/ingress-router.test.ts src/interface/tui/__tests__/chat-surface.test.ts plugins/telegram-bot/__tests__/telegram-chat-runner-processor.test.ts