### PR TITLE
fix(chat): avoid implicit agentloop state resume

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
@@ -574,7 +574,7 @@ describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () =>
     expect(modelClient.calls[1].messages.some((m) => m.role === "tool" && m.toolName === "approval_tool")).toBe(true);
   });
 
-  it("uses the latest chat input even when a state file path is reused", async () => {
+  it("uses the latest chat input even when a state file path is provided and reused", async () => {
     const stateDir = makeTempDir();
     const statePath = path.join(stateDir, "chat.state.json");
     try {
@@ -599,16 +599,16 @@ describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () =>
         modelClient,
         modelRegistry: registryModel,
         defaultModel: modelInfo.ref,
-        createSession: () =>
+        createSession: (input) =>
           createAgentLoopSession({
             sessionId: "chat-session",
             traceId: "chat-trace",
-            stateStore: new JsonAgentLoopSessionStateStore(statePath),
+            stateStore: new JsonAgentLoopSessionStateStore(input.resumeStatePath ?? statePath),
           }),
       });
 
-      await chat.execute({ message: "first input" });
-      await chat.execute({ message: "second input" });
+      await chat.execute({ message: "first input", resumeStatePath: statePath });
+      await chat.execute({ message: "second input", resumeStatePath: statePath });
 
       const firstLastUser = [...modelClient.calls[0].messages].reverse().find((message) => message.role === "user")?.content ?? "";
       const secondLastUser = [...modelClient.calls[1].messages].reverse().find((message) => message.role === "user")?.content ?? "";

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -150,7 +150,7 @@ export class ChatAgentLoopRunner {
         budget: withDefaultBudget({ ...this.deps.defaultBudget, ...input.budget }),
         toolPolicy: { ...this.deps.defaultToolPolicy, ...input.toolPolicy },
         ...(input.resumeState ? { resumeState: input.resumeState } : {}),
-        loadPersistedState: input.resumeOnly === true || input.resumeState !== undefined || input.resumeStatePath !== undefined,
+        loadPersistedState: input.resumeOnly === true || input.resumeState !== undefined,
         ...(this.deps.defaultExecutionPolicy ? { executionPolicy: this.deps.defaultExecutionPolicy } : {}),
         toolCallContext: {
           cwd,


### PR DESCRIPTION
## Summary
- stop treating resumeStatePath as an instruction to load persisted chat agent-loop state
- strengthen the regression test so repeated normal chat turns can reuse the same state file path without replaying the prior input

## Verification
- npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
- npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts
- npm run test:unit -- src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/ingress-router.test.ts src/interface/chat/__tests__/chat-event-state.test.ts src/interface/tui/__tests__/chat-surface.test.ts
- npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/tui/__tests__/chat-surface.test.ts
- npm run typecheck