### PR TITLE
[codex] fix chat wiring regressions

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -576,7 +576,7 @@ describe("ChatRunner", () => {
         await stateManager.init();
         await stateManager.writeRaw("chat/sessions/saved-session.json", {
           id: "saved-session",
-          cwd: "/repo",
+          cwd: "/loaded-repo",
           createdAt: "2026-01-01T00:00:00.000Z",
           updatedAt: "2026-01-01T00:00:01.000Z",
           title: "Work Session",
@@ -589,7 +589,7 @@ describe("ChatRunner", () => {
           traceId: "trace-1",
           turnId: "turn-1",
           goalId: "chat",
-          cwd: "/repo",
+          cwd: "/loaded-repo",
           modelRef: "openai/gpt-5.4-mini",
           messages: [{ role: "assistant", content: "continuing..." }],
           modelTurns: 1,
@@ -622,10 +622,12 @@ describe("ChatRunner", () => {
         expect(result.output).toBe("Resumed selected session");
         expect(runner.getSessionId()).toBe("saved-session");
         const input = (chatAgentLoopRunner.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+          cwd?: string;
           resumeOnly?: boolean;
           resumeState?: { sessionId: string };
           resumeStatePath?: string;
         };
+        expect(input.cwd).toBe("/loaded-repo");
         expect(input.resumeOnly).toBe(true);
         expect(input.resumeState?.sessionId).toBe("saved-session");
         expect(input.resumeStatePath).toBe("chat/agentloop/saved-session.state.json");
@@ -1127,7 +1129,7 @@ describe("ChatRunner", () => {
       const adapter = makeMockAdapter();
       const runner = new ChatRunner(makeDeps({ adapter }));
 
-      const result = await runner.execute("PulSeed 自身を更新して", "/repo");
+      const result = await runner.execute("PulSeed を再起動して", "/repo");
 
       expect(result.success).toBe(false);
       expect(result.output).toContain("Runtime control is not available");

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -248,4 +248,51 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(adapter.execute).toHaveBeenCalledTimes(2);
     expect(maxConcurrentCalls).toBe(1);
   });
+
+  it("passes gateway-routed goal_id into ChatRunner agent-loop execution", async () => {
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "Agent loop response",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 42,
+        stopped_reason: "completed",
+      }),
+    };
+    const adapter = makeMockAdapter();
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager: makeMockStateManager(),
+      adapter,
+      chatAgentLoopRunner: chatAgentLoopRunner as never,
+    }));
+
+    const result = await manager.processIncomingMessage({
+      text: "implement this",
+      platform: "slack",
+      conversation_id: "C_GENERAL",
+      sender_id: "U123",
+      goal_id: "goal-routed",
+      metadata: { goal_id: "goal-metadata-only" },
+      cwd: "/repo",
+    });
+    await manager.processIncomingMessage({
+      text: "implement next thing",
+      platform: "slack",
+      conversation_id: "C_GENERAL",
+      sender_id: "U123",
+      goal_id: "goal-next",
+      cwd: "/repo",
+    });
+
+    expect(result).toBe("Agent loop response");
+    expect(adapter.execute).not.toHaveBeenCalled();
+    expect(chatAgentLoopRunner.execute).toHaveBeenCalledTimes(2);
+    expect(chatAgentLoopRunner.execute).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      goalId: "goal-routed",
+    }));
+    expect(chatAgentLoopRunner.execute).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      goalId: "goal-next",
+    }));
+  });
 });

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -62,6 +62,7 @@ import {
   buildStandaloneIngressMessage,
   createIngressRouter,
   type ChatIngressMessage,
+  type IngressReplyTarget,
   type SelectedChatRoute,
 } from "./ingress-router.js";
 
@@ -139,6 +140,7 @@ export interface RuntimeControlChatContext {
 export interface ChatRunnerExecutionOptions {
   selectedRoute?: SelectedChatRoute;
   runtimeControlContext?: RuntimeControlChatContext | null;
+  goalId?: string;
 }
 
 interface AssistantBuffer {
@@ -309,7 +311,11 @@ export class ChatRunner {
     }
 
     const runtimeControlContext = this.buildRuntimeControlContextFromIngress(ingress);
-    return this.execute(ingress.text, cwd, timeoutMs, { selectedRoute, runtimeControlContext });
+    return this.execute(ingress.text, cwd, timeoutMs, {
+      selectedRoute,
+      runtimeControlContext,
+      goalId: ingress.goal_id,
+    });
   }
 
   private resolveRouteFromIngress(ingress: ChatIngressMessage): SelectedChatRoute {
@@ -351,6 +357,24 @@ export class ChatRunner {
     const runtimeApprovalFn = runtimeControlContext?.approvalFn
       ?? this.deps.runtimeControlApprovalFn
       ?? this.deps.approvalFn;
+    const replyTarget = runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget;
+    const replyTargetInput: Partial<IngressReplyTarget> | undefined = replyTarget
+      ? {
+          ...(replyTarget.surface ? { surface: replyTarget.surface } : {}),
+          channel,
+          ...(replyTarget.platform ? { platform: replyTarget.platform } : {}),
+          ...(replyTarget.conversation_id ? { conversation_id: replyTarget.conversation_id } : {}),
+          ...(replyTarget.message_id ? { message_id: replyTarget.message_id } : {}),
+          ...(replyTarget.response_channel ? { response_channel: replyTarget.response_channel } : {}),
+          ...(replyTarget.outbox_topic ? { outbox_topic: replyTarget.outbox_topic } : {}),
+          ...(replyTarget.identity_key ? { identity_key: replyTarget.identity_key } : {}),
+          ...(replyTarget.user_id ? { user_id: replyTarget.user_id } : {}),
+          ...(replyTarget.deliveryMode === "reply" || replyTarget.deliveryMode === "notify" || replyTarget.deliveryMode === "thread_reply"
+            ? { deliveryMode: replyTarget.deliveryMode }
+            : {}),
+          ...(replyTarget.metadata ? { metadata: replyTarget.metadata } : {}),
+        }
+      : undefined;
     return buildStandaloneIngressMessage({
       text: input,
       channel,
@@ -359,7 +383,7 @@ export class ChatRunner {
       conversation_id: runtimeControlContext?.replyTarget?.conversation_id ?? this.deps.runtimeReplyTarget?.conversation_id,
       user_id: runtimeControlContext?.replyTarget?.user_id ?? this.deps.runtimeReplyTarget?.user_id,
       actor: runtimeControlContext?.actor ?? this.deps.runtimeControlActor,
-      replyTarget: runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget,
+      replyTarget: replyTargetInput,
       runtimeControl: {
         allowed: true,
         approvalMode: "interactive",
@@ -1411,6 +1435,7 @@ export class ChatRunner {
     const resumeCommand = this.parseResumeCommand(input);
     const resumeOnly = resumeCommand !== null;
     const runtimeControlContext = options.runtimeControlContext ?? this.runtimeControlContext;
+    const executionGoalId = options.goalId ?? this.deps.goalId;
 
     // Intercept commands before any adapter call
     const commandResult = resumeOnly ? null : await this.handleCommand(input);
@@ -1486,6 +1511,7 @@ export class ChatRunner {
       this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
       this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
     }
+    const executionCwd = this.sessionCwd ?? cwd;
     const gitRoot = this.sessionCwd ?? resolveGitRoot(cwd);
 
     // history is always assigned by this point (either by startSession or the block above)
@@ -1543,7 +1569,7 @@ export class ChatRunner {
       const runtimeControlResult = await this.executeRuntimeControlRoute(
         selectedRoute,
         runtimeControlContext,
-        cwd,
+        executionCwd,
         start
       );
       if (runtimeControlResult.success) {
@@ -1625,7 +1651,7 @@ export class ChatRunner {
 
     const usesNativeAgentLoop = resumeOnly || selectedRoute?.kind === "agent_loop";
     const groundingWorkspaceContext = !resumeOnly && usesNativeAgentLoop
-      ? await buildChatContext(input, cwd)
+      ? await buildChatContext(input, executionCwd)
       : undefined;
 
     let systemPrompt = this.cachedStaticSystemPrompt ?? "";
@@ -1636,8 +1662,8 @@ export class ChatRunner {
           systemPrompt = await buildChatAgentLoopSystemPrompt({
             stateManager: this.deps.stateManager,
             pluginLoader: this.deps.pluginLoader,
-            workspaceRoot: cwd,
-            goalId: this.deps.goalId,
+            workspaceRoot: executionCwd,
+            goalId: executionGoalId,
             userMessage: input,
             trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
             workspaceContext: groundingWorkspaceContext,
@@ -1646,8 +1672,8 @@ export class ChatRunner {
           const groundingBundle = await this.groundingGateway.build({
             surface: "chat",
             purpose: "general_turn",
-            workspaceRoot: cwd,
-            goalId: this.deps.goalId,
+            workspaceRoot: executionCwd,
+            goalId: executionGoalId,
             userMessage: input,
             query: input,
             trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
@@ -1710,8 +1736,8 @@ export class ChatRunner {
         this.emitActivity("lifecycle", "Calling model...", eventContext, "lifecycle:model");
         const result = await chatAgentLoopRunner!.execute({
           message: basePrompt,
-          cwd,
-          goalId: this.deps.goalId,
+          cwd: executionCwd,
+          goalId: executionGoalId,
           history: priorTurns.map((m: { role: string; content: string }) => ({
             role: m.role === "assistant" ? "assistant" : "user",
             content: m.content,
@@ -1777,7 +1803,13 @@ export class ChatRunner {
     // Prefer the local LLM/tool loop over the external adapter fallback whenever a client is available.
     if (selectedRoute?.kind === "tool_loop") {
       try {
-        const toolResult = await this.executeWithTools(prompt, eventContext, assistantBuffer, systemPrompt || undefined);
+        const toolResult = await this.executeWithTools(
+          prompt,
+          eventContext,
+          assistantBuffer,
+          systemPrompt || undefined,
+          executionGoalId
+        );
         const elapsed_ms = Date.now() - start;
         if (this.hasUsage(toolResult.usage)) {
           history.recordUsage("execution", toolResult.usage);
@@ -1947,11 +1979,12 @@ export class ChatRunner {
     prompt: string,
     eventContext: ChatEventContext,
     assistantBuffer: AssistantBuffer,
-    systemPrompt?: string
+    systemPrompt?: string,
+    goalId?: string
   ): Promise<{ output: string; usage: ChatUsageCounter }> {
     const llmClient = this.deps.llmClient!;
     const messages: LLMMessage[] = [{ role: "user", content: prompt }];
-    const toolCallContext = await this.buildToolCallContext();
+    const toolCallContext = await this.buildToolCallContext(goalId);
     const usage = this.zeroUsageCounter();
 
     for (let loop = 0; loop < MAX_TOOL_LOOPS; loop++) {
@@ -2490,11 +2523,11 @@ export class ChatRunner {
     return this.sessionExecutionPolicy;
   }
 
-  private async buildToolCallContext(): Promise<ToolCallContext> {
+  private async buildToolCallContext(goalId = this.deps.goalId): Promise<ToolCallContext> {
     const executionPolicy = await this.getSessionExecutionPolicy();
     return {
       cwd: this.sessionCwd ?? process.cwd(),
-      goalId: this.deps.goalId ?? "",
+      goalId: goalId ?? "",
       trustBalance: 0,
       preApproved: false,
       approvalFn: async (req) => {

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -62,6 +62,8 @@ export interface CrossPlatformChatSessionOptions {
   channel?: ChatIngressChannel;
   /** Optional per-turn message id from the transport. */
   message_id?: string;
+  /** Optional goal selected by gateway routing for this turn. */
+  goal_id?: string;
   /** Explicit typed actor override for routing/runtime control. */
   actor?: Partial<RuntimeControlActor>;
   /** Explicit reply target override for outbound routing. */
@@ -89,6 +91,7 @@ export interface CrossPlatformIncomingChatMessage {
   user_id?: string;
   user_name?: string;
   message_id?: string;
+  goal_id?: string;
   cwd?: string;
   timeoutMs?: number;
   actor?: Partial<RuntimeControlActor>;
@@ -315,6 +318,7 @@ export class CrossPlatformChatSessionManager {
       user_id: options.user_id,
       user_name: options.user_name,
       message_id: options.message_id,
+      goal_id: options.goal_id,
       channel: options.channel ?? (options.platform ? "plugin_gateway" : "cli"),
       actor: options.actor,
       replyTarget: options.replyTarget,
@@ -364,8 +368,15 @@ export class CrossPlatformChatSessionManager {
     input: CrossPlatformIncomingChatMessage | (CrossPlatformChatSessionOptions & { text: string })
   ): CrossPlatformIngressMessage {
     const channel = resolveChannel(input);
-    const metadata = {
+    const metadataGoalId = typeof input.metadata?.["goal_id"] === "string"
+      ? input.metadata["goal_id"].trim()
+      : typeof input.metadata?.["routed_goal_id"] === "string"
+        ? input.metadata["routed_goal_id"].trim()
+        : "";
+    const goalId = normalizeIdentity(input.goal_id ?? metadataGoalId) ?? undefined;
+    const metadata: Record<string, unknown> = {
       ...(input.metadata ?? {}),
+      ...(goalId ? { goal_id: goalId } : {}),
       ...("sender_id" in input && input.sender_id ? { sender_id: input.sender_id } : {}),
       ...(input.message_id ? { message_id: input.message_id } : {}),
     };
@@ -383,6 +394,7 @@ export class CrossPlatformChatSessionManager {
       ...(identityKey ? { identity_key: identityKey } : {}),
       ...(conversationId ? { conversation_id: conversationId } : {}),
       ...(messageId ? { message_id: messageId } : {}),
+      ...(goalId ? { goal_id: goalId } : {}),
       ...(userId ? { user_id: userId } : {}),
       text: input.text,
       actor: normalizeActor(channel, {

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -35,6 +35,7 @@ export interface ChatIngressMessage {
   identity_key?: string;
   conversation_id?: string;
   message_id?: string;
+  goal_id?: string;
   user_id?: string;
   user_name?: string;
   text: string;
@@ -228,6 +229,7 @@ export interface NormalizeLegacyIngressInput {
   user_name?: string;
   sender_id?: string;
   message_id?: string;
+  goal_id?: string;
   cwd?: string;
   timeoutMs?: number;
   metadata?: Record<string, unknown>;
@@ -244,8 +246,17 @@ export function normalizeLegacyIngressInput(input: NormalizeLegacyIngressInput):
   const identityKey = normalizeIdentity(input.identity_key);
   const conversationId = normalizeIdentity(input.conversation_id);
   const userId = normalizeIdentity(input.user_id ?? input.sender_id);
+  const metadataGoalId = typeof input.metadata?.["goal_id"] === "string"
+    ? input.metadata["goal_id"].trim()
+    : typeof input.metadata?.["routed_goal_id"] === "string"
+      ? input.metadata["routed_goal_id"].trim()
+      : "";
+  const goalId = normalizeIdentity(input.goal_id ?? metadataGoalId);
   const actorSurface = inferActorSurface(channel);
-  const metadata = { ...(input.metadata ?? {}) };
+  const metadata: Record<string, unknown> = {
+    ...(input.metadata ?? {}),
+    ...(goalId ? { goal_id: goalId } : {}),
+  };
   const preapproved = input.runtimeControl?.approvalMode === "preapproved"
     || input.runtimeControl?.approval_mode === "preapproved"
     || metadata["runtime_control_approved"] === true;
@@ -282,6 +293,7 @@ export function normalizeLegacyIngressInput(input: NormalizeLegacyIngressInput):
     ...(identityKey ? { identity_key: identityKey } : {}),
     ...(conversationId ? { conversation_id: conversationId } : {}),
     ...(input.message_id ? { message_id: input.message_id } : {}),
+    ...(goalId ? { goal_id: goalId } : {}),
     ...(userId ? { user_id: userId } : {}),
     ...(input.user_name ? { user_name: input.user_name } : {}),
     text: input.text,

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -340,6 +340,7 @@ export async function cmdStart(
     } else {
       const slackAdapter = new SlackChannelAdapter({
         signingSecret: slackGatewayConfig.signing_secret,
+        botToken: slackGatewayConfig.bot_token,
         channelGoalMap: slackGatewayConfig.channel_goal_map,
       });
       eventServer.setSlackChannelAdapter(slackAdapter, slackGatewayConfig.path);

--- a/src/interface/tui/__tests__/app-routing.test.ts
+++ b/src/interface/tui/__tests__/app-routing.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveDaemonGoalIdFromActiveGoals,
+  isChatRunnerOwnedSlashCommand,
+  resolveFreeformInputRoute,
+} from "../app.js";
+
+describe("TUI app routing helpers", () => {
+  it("keeps free-form input on ChatRunner when daemon has an active goal", () => {
+    expect(resolveFreeformInputRoute({
+      isDaemonMode: true,
+      daemonGoalId: "goal-1",
+      hasChatRunner: true,
+    })).toBe("chat_runner");
+  });
+
+  it("falls back to daemon goal chat only when ChatRunner is unavailable", () => {
+    expect(resolveFreeformInputRoute({
+      isDaemonMode: true,
+      daemonGoalId: "goal-1",
+      hasChatRunner: false,
+    })).toBe("daemon_goal_chat");
+  });
+
+  it("recognizes ChatRunner-owned slash commands from the TUI surface", () => {
+    expect(isChatRunnerOwnedSlashCommand("/resume Work Session")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/sessions")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/history saved")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/compact")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/tend")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/permissions read-only")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/start goal-1")).toBe(false);
+  });
+
+  it("derives and clears displayed daemon goal from activeGoals", () => {
+    expect(deriveDaemonGoalIdFromActiveGoals("goal-2", ["goal-1", "goal-2"])).toBe("goal-2");
+    expect(deriveDaemonGoalIdFromActiveGoals("stale-goal", ["goal-1"])).toBe("goal-1");
+    expect(deriveDaemonGoalIdFromActiveGoals("stale-goal", [])).toBeNull();
+  });
+});

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -139,7 +139,7 @@ describe("standalone slash command routing", () => {
 
     await testState.lastChatProps!.onSubmit("/permissions workspace-write");
 
-    expect(chatRunner.execute).toHaveBeenCalledWith("/permissions workspace-write", process.cwd());
+    expect(chatRunner.execute).toHaveBeenCalledWith("/permissions workspace-write", "~/workspace");
     expect(intentRecognizer.recognize).not.toHaveBeenCalled();
     expect(actionHandler.handle).not.toHaveBeenCalled();
 
@@ -178,19 +178,19 @@ describe("daemon-mode chat routing", () => {
 
     await flush();
 
-    expect(chatRunner.startSession).toHaveBeenCalledWith(process.cwd());
+    expect(chatRunner.startSession).toHaveBeenCalledWith("~/workspace");
     expect(testState.lastChatProps).not.toBeNull();
 
     await testState.lastChatProps!.onSubmit("free form question");
 
-    expect(chatRunner.execute).toHaveBeenCalledWith("free form question", process.cwd());
+    expect(chatRunner.execute).toHaveBeenCalledWith("free form question", "~/workspace");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
     expect(daemonClient.chat).not.toHaveBeenCalled();
 
     screen.unmount();
   });
 
-  it("routes free-form text to daemon chat once an active goal is present", async () => {
+  it("keeps free-form text on ChatRunner even when a daemon goal is active", async () => {
     const daemonClient = createDaemonClientMock();
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
@@ -225,7 +225,8 @@ describe("daemon-mode chat routing", () => {
 
     await testState.lastChatProps!.onSubmit("question for the active goal");
 
-    expect(daemonClient.chat).toHaveBeenCalledWith("goal-123", "question for the active goal");
+    expect(chatRunner.execute).toHaveBeenCalledWith("question for the active goal", "~/workspace");
+    expect(daemonClient.chat).not.toHaveBeenCalled();
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
 
     screen.unmount();
@@ -256,7 +257,7 @@ describe("daemon-mode chat routing", () => {
 
     await testState.lastChatProps!.onSubmit("/permissions read-only");
 
-    expect(chatRunner.execute).toHaveBeenCalledWith("/permissions read-only", process.cwd());
+    expect(chatRunner.execute).toHaveBeenCalledWith("/permissions read-only", "~/workspace");
     expect(daemonClient.chat).not.toHaveBeenCalled();
 
     screen.unmount();

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -66,13 +66,35 @@ export function resolveFreeformInputRoute({
   daemonGoalId: string | null;
   hasChatRunner: boolean;
 }): FreeformInputRoute {
-  if (isDaemonMode && daemonGoalId) {
-    return "daemon_goal_chat";
-  }
   if (hasChatRunner) {
     return "chat_runner";
   }
+  if (isDaemonMode && daemonGoalId) {
+    return "daemon_goal_chat";
+  }
   return "unavailable";
+}
+
+const CHAT_RUNNER_OWNED_COMMANDS = new Set([
+  "/resume",
+  "/sessions",
+  "/history",
+  "/compact",
+  "/tend",
+  "/permissions",
+]);
+
+export function isChatRunnerOwnedSlashCommand(input: string): boolean {
+  const command = input.trim().toLowerCase().split(/\s+/)[0] ?? "";
+  return CHAT_RUNNER_OWNED_COMMANDS.has(command);
+}
+
+export function deriveDaemonGoalIdFromActiveGoals(
+  currentGoalId: string | null,
+  activeGoals: string[],
+): string | null {
+  if (activeGoals.length === 0) return null;
+  return currentGoalId && activeGoals.includes(currentGoalId) ? currentGoalId : activeGoals[0]!;
 }
 
 interface AppProps {
@@ -189,11 +211,34 @@ export function App({
       setDaemonLoopState((prev) => ({
         ...prev,
         running: (d.running as boolean) ?? prev.running,
-        goalId: (d.goalId as string | null) ?? prev.goalId,
+        goalId: Object.hasOwn(d, "goalId") ? (d.goalId as string | null) : prev.goalId,
         iteration: (d.iteration as number) ?? prev.iteration,
         status: (d.status as string) ?? prev.status,
         trustScore: (d.trustScore as number) ?? prev.trustScore,
       }));
+    };
+
+    const onDaemonStatus = (data: unknown) => {
+      const d = data as Record<string, unknown>;
+      const activeGoals = Array.isArray(d.activeGoals)
+        ? d.activeGoals.filter((goalId): goalId is string => typeof goalId === "string" && goalId.length > 0)
+        : null;
+      setDaemonLoopState((prev) => {
+        const nextGoalId = activeGoals
+          ? deriveDaemonGoalIdFromActiveGoals(prev.goalId, activeGoals)
+          : prev.goalId;
+        return {
+          ...prev,
+          goalId: nextGoalId,
+          running: activeGoals ? activeGoals.length > 0 : prev.running,
+          status: typeof d.status === "string"
+            ? d.status
+            : activeGoals && activeGoals.length === 0
+              ? "idle"
+              : prev.status,
+          iteration: typeof d.loopCount === "number" ? d.loopCount : prev.iteration,
+        };
+      });
     };
 
     const onApproval = (data: unknown) => {
@@ -214,12 +259,14 @@ export function App({
     daemonClient.on("_connected", onConnected);
     daemonClient.on("_disconnected", onDisconnected);
     daemonClient.on("loop_update", onLoopUpdate);
+    daemonClient.on("daemon_status", onDaemonStatus);
     daemonClient.on("approval_required", onApproval);
 
     return () => {
       daemonClient.off("_connected", onConnected);
       daemonClient.off("_disconnected", onDisconnected);
       daemonClient.off("loop_update", onLoopUpdate);
+      daemonClient.off("daemon_status", onDaemonStatus);
       daemonClient.off("approval_required", onApproval);
     };
   }, [isDaemonMode, daemonClient]);
@@ -260,12 +307,12 @@ export function App({
   // Start ChatRunner session on mount (standalone mode)
   useEffect(() => {
     if (chatRunner) {
-      chatRunner.startSession(process.cwd());
+      chatRunner.startSession(cwd ?? process.cwd());
       chatRunner.onEvent = (event) => {
         setMessages((prev) => applyChatEventToMessages(prev, event, MAX_MESSAGES) as ChatMessage[]);
       };
     }
-  }, [chatRunner]);
+  }, [chatRunner, cwd]);
 
   // Pre-load active/waiting goal names for fuzzy completion in Chat
   useEffect(() => {
@@ -340,8 +387,6 @@ export function App({
       try {
         // Local-only commands — no LLM round-trip needed
         const trimmedInput = input.trim().toLowerCase();
-        const isPermissionsCommand =
-          trimmedInput === "/permissions" || trimmedInput.startsWith("/permissions ");
         const bashCommand = extractBashCommand(input);
         if (bashCommand !== null) {
           if (!bashCommand) {
@@ -384,8 +429,8 @@ export function App({
           return;
         }
 
-        if (isPermissionsCommand && !isDaemonMode && chatRunner) {
-          await chatRunner.execute(input, process.cwd());
+        if (chatRunner && isChatRunnerOwnedSlashCommand(input)) {
+          await chatRunner.execute(input, cwd ?? process.cwd());
           return;
         }
 
@@ -441,11 +486,6 @@ export function App({
           const trimmed = input.trim().toLowerCase();
           if (trimmed === "/help" || trimmed === "/?") {
             setShowHelp(true);
-          } else if (
-            (trimmed === "/permissions" || trimmed.startsWith("/permissions ")) &&
-            chatRunner
-          ) {
-            await chatRunner.execute(input, process.cwd());
           } else if (trimmed === "/settings" || trimmed === "/config") {
             setShowSettings(true);
           } else if (trimmed === "/dashboard" || trimmed === "/d") {
@@ -494,7 +534,7 @@ export function App({
               }].slice(-MAX_MESSAGES));
             }
           } else if (freeformRoute === "chat_runner" && chatRunner) {
-            await chatRunner.execute(input, process.cwd());
+            await chatRunner.execute(input, cwd ?? process.cwd());
           } else {
             setMessages((prev) => [...prev, {
               id: randomUUID(), role: "pulseed" as const,
@@ -521,7 +561,7 @@ export function App({
         setIsProcessing(false);
       }
     },
-    [intentRecognizer, actionHandler, chatRunner, daemonClient, isDaemonMode, daemonLoopState.goalId, startLoop, stopLoop, isProcessing]
+    [intentRecognizer, actionHandler, chatRunner, daemonClient, isDaemonMode, daemonLoopState.goalId, startLoop, stopLoop, isProcessing, cwd]
   );
 
   // goalCount: 1 when there is an active goal in the loop, 0 otherwise

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-session-factory.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-session-factory.test.ts
@@ -32,6 +32,39 @@ describe("createPersistentAgentLoopSessionFactory", () => {
     expect(content).toContain("\"type\":\"started\"");
     expect(content).toContain(session.traceId);
   });
+
+  it("resolves relative resume state paths under the configured base directory", async () => {
+    const baseDir = makeTempDir();
+    const createSession = createPersistentAgentLoopSessionFactory({
+      traceBaseDir: baseDir,
+      kind: "chat",
+    });
+    const session = createSession({ resumeStatePath: "chat/agentloop/session-1.state.json" });
+
+    await session.stateStore.save({
+      sessionId: session.sessionId,
+      traceId: session.traceId,
+      turnId: "turn-1",
+      goalId: "chat",
+      cwd: baseDir,
+      modelRef: "openai/gpt-test",
+      messages: [{ role: "user", content: "continue" }],
+      modelTurns: 1,
+      toolCalls: 0,
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+      compactions: 0,
+      completionValidationAttempts: 0,
+      calledTools: [],
+      lastToolLoopSignature: null,
+      repeatedToolLoopCount: 0,
+      finalText: "",
+      status: "running",
+      updatedAt: new Date().toISOString(),
+    });
+
+    const statePath = path.join(baseDir, "chat", "agentloop", "session-1.state.json");
+    await expect(fs.readFile(statePath, "utf-8")).resolves.toContain(session.sessionId);
+  });
 });
 
 describe("JsonAgentLoopSessionStateStore", () => {

--- a/src/orchestrator/execution/agent-loop/agent-loop-session-factory.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-session-factory.ts
@@ -33,7 +33,8 @@ export function createPersistentAgentLoopSessionFactory(
       `${timestamp}-${sessionId}.jsonl`,
     );
     const statePath = input.resumeStatePath
-      ?? tracePath.replace(/\.jsonl$/, ".state.json");
+      ? path.resolve(options.traceBaseDir, input.resumeStatePath)
+      : tracePath.replace(/\.jsonl$/, ".state.json");
     const traceStore = new JsonlAgentLoopTraceStore(tracePath);
     const stateStore = new JsonAgentLoopSessionStateStore(statePath);
 

--- a/src/runtime/__tests__/runtime-control-result-routing.test.ts
+++ b/src/runtime/__tests__/runtime-control-result-routing.test.ts
@@ -1,0 +1,153 @@
+import * as path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { cleanupTempDir, makeTempDir } from "../../../tests/helpers/temp-dir.js";
+import { reconcileRuntimeControlOperationsAfterStartup } from "../daemon/runner-startup.js";
+import { OutboxStore } from "../store/outbox-store.js";
+import { RuntimeOperationStore } from "../store/runtime-operation-store.js";
+import type { RuntimeControlOperation } from "../store/runtime-operation-schemas.js";
+
+function makeRestartingOperation(
+  overrides: Partial<RuntimeControlOperation> = {}
+): RuntimeControlOperation {
+  return {
+    operation_id: "op-restart-1",
+    kind: "restart_daemon",
+    state: "restarting",
+    requested_at: "2026-04-13T00:00:00.000Z",
+    updated_at: "2026-04-13T00:00:00.000Z",
+    requested_by: {
+      surface: "gateway",
+      platform: "slack",
+      conversation_id: "thread-1",
+      identity_key: "owner",
+      user_id: "owner-user",
+    },
+    reply_target: {
+      surface: "gateway",
+      channel: "plugin_gateway",
+      platform: "slack",
+      conversation_id: "thread-1",
+      message_id: "msg-1",
+      identity_key: "owner",
+      user_id: "owner-user",
+      deliveryMode: "thread_reply",
+      metadata: {
+        response_url: "https://example.test/response",
+      },
+    },
+    reason: "PulSeed を再起動して",
+    started_at: "2026-04-13T00:00:01.000Z",
+    expected_health: {
+      daemon_ping: true,
+      gateway_acceptance: true,
+    },
+    result: {
+      ok: true,
+      message: "daemon restart was accepted by the runtime command dispatcher.",
+    },
+    ...overrides,
+  };
+}
+
+describe("runtime-control restart result routing", () => {
+  it("publishes verified restart results to the durable reply target events", async () => {
+    const tmpDir = makeTempDir("pulseed-runtime-control-result-routing-");
+    try {
+      const runtimeRoot = path.join(tmpDir, "runtime");
+      const operationStore = new RuntimeOperationStore(runtimeRoot);
+      await operationStore.save(makeRestartingOperation());
+
+      await reconcileRuntimeControlOperationsAfterStartup(
+        runtimeRoot,
+        { status: "idle" },
+        { info: vi.fn() },
+      );
+
+      expect(await operationStore.listPending()).toHaveLength(0);
+      const completed = await operationStore.listCompleted();
+      expect(completed).toHaveLength(1);
+      expect(completed[0]).toMatchObject({
+        operation_id: "op-restart-1",
+        state: "verified",
+        reply_target: {
+          channel: "plugin_gateway",
+          message_id: "msg-1",
+          deliveryMode: "thread_reply",
+          metadata: {
+            response_url: "https://example.test/response",
+          },
+        },
+      });
+
+      const outbox = await new OutboxStore(runtimeRoot).list();
+      expect(outbox).toHaveLength(2);
+      expect(outbox[0]).toMatchObject({
+        event_type: "runtime_control_result",
+        correlation_id: "op-restart-1",
+        payload: {
+          operation_id: "op-restart-1",
+          state: "verified",
+          ok: true,
+          reply_target: {
+            conversation_id: "thread-1",
+            message_id: "msg-1",
+          },
+        },
+      });
+      expect(outbox[1]).toMatchObject({
+        event_type: "chat_response",
+        correlation_id: "op-restart-1",
+        payload: {
+          goalId: "runtime_control:op-restart-1",
+          goal_id: "runtime_control:op-restart-1",
+          status: "verified",
+          reply_target: {
+            conversation_id: "thread-1",
+            message_id: "msg-1",
+          },
+          runtime_control: {
+            operation_id: "op-restart-1",
+          },
+        },
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("uses the live event publisher when startup has an event server", async () => {
+    const tmpDir = makeTempDir("pulseed-runtime-control-result-publisher-");
+    try {
+      const runtimeRoot = path.join(tmpDir, "runtime");
+      const operationStore = new RuntimeOperationStore(runtimeRoot);
+      await operationStore.save(makeRestartingOperation({ operation_id: "op-restart-2" }));
+      const published: Array<{ eventType: string; data: unknown }> = [];
+
+      await reconcileRuntimeControlOperationsAfterStartup(
+        runtimeRoot,
+        { status: "running" },
+        { info: vi.fn() },
+        {
+          broadcast: (eventType, data) => {
+            published.push({ eventType, data });
+          },
+        },
+      );
+
+      expect(published.map((entry) => entry.eventType)).toEqual([
+        "runtime_control_result",
+        "chat_response",
+      ]);
+      expect(published[1]?.data).toMatchObject({
+        goalId: "runtime_control:op-restart-2",
+        message: "PulSeed daemon の再起動を確認しました。",
+        reply_target: {
+          channel: "plugin_gateway",
+          message_id: "msg-1",
+        },
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+});

--- a/src/runtime/control/__tests__/runtime-control-intent.test.ts
+++ b/src/runtime/control/__tests__/runtime-control-intent.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { recognizeRuntimeControlIntent } from "../runtime-control-intent.js";
+
+describe("recognizeRuntimeControlIntent", () => {
+  it("recognizes only runtime operations supported by the production executor", () => {
+    expect(recognizeRuntimeControlIntent("gateway を再起動して")).toMatchObject({
+      kind: "restart_gateway",
+    });
+    expect(recognizeRuntimeControlIntent("PulSeed を再起動して")).toMatchObject({
+      kind: "restart_daemon",
+    });
+
+    expect(recognizeRuntimeControlIntent("runtime 設定を再読み込みして")).toBeNull();
+    expect(recognizeRuntimeControlIntent("PulSeed 自身を更新して")).toBeNull();
+  });
+});

--- a/src/runtime/control/__tests__/runtime-control-service.test.ts
+++ b/src/runtime/control/__tests__/runtime-control-service.test.ts
@@ -5,7 +5,7 @@ import { RuntimeOperationStore } from "../../store/runtime-operation-store.js";
 import { RuntimeControlService } from "../runtime-control-service.js";
 
 describe("RuntimeControlService", () => {
-  it("executes approval-free runtime operations through the configured executor", async () => {
+  it("executes approved restart operations through the configured executor", async () => {
     const tmpDir = makeTempDir("pulseed-runtime-control-service-");
     try {
       const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
@@ -17,8 +17,9 @@ describe("RuntimeControlService", () => {
       const service = new RuntimeControlService({ operationStore, executor });
 
       const result = await service.request({
-        intent: { kind: "reload_config", reason: "runtime 設定を再読み込みして" },
+        intent: { kind: "restart_gateway", reason: "gateway を再起動して" },
         cwd: "/repo",
+        approvalFn: vi.fn().mockResolvedValue(true),
       });
 
       expect(result).toMatchObject({
@@ -31,13 +32,38 @@ describe("RuntimeControlService", () => {
       const pending = await operationStore.listPending();
       expect(pending).toHaveLength(1);
       expect(pending[0]).toMatchObject({
-        kind: "reload_config",
+        kind: "restart_gateway",
         state: "acknowledged",
         expected_health: {
-          daemon_ping: false,
-          gateway_acceptance: false,
+          daemon_ping: true,
+          gateway_acceptance: true,
         },
       });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("rejects unsupported operation kinds before claiming executor support", async () => {
+    const tmpDir = makeTempDir("pulseed-runtime-control-service-unsupported-");
+    try {
+      const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+      const executor = vi.fn();
+      const service = new RuntimeControlService({ operationStore, executor });
+
+      const result = await service.request({
+        intent: { kind: "reload_config", reason: "runtime 設定を再読み込みして" },
+        cwd: "/repo",
+      });
+
+      expect(result).toMatchObject({
+        success: false,
+        state: "failed",
+        message: expect.stringContaining("not supported"),
+      });
+      expect(executor).not.toHaveBeenCalled();
+      expect(await operationStore.listPending()).toHaveLength(0);
+      expect(await operationStore.listCompleted()).toHaveLength(0);
     } finally {
       cleanupTempDir(tmpDir);
     }

--- a/src/runtime/control/index.ts
+++ b/src/runtime/control/index.ts
@@ -2,6 +2,10 @@ export { recognizeRuntimeControlIntent } from "./runtime-control-intent.js";
 export type { RuntimeControlIntent } from "./runtime-control-intent.js";
 export { RuntimeControlService } from "./runtime-control-service.js";
 export { createDaemonRuntimeControlExecutor } from "./daemon-runtime-control-executor.js";
+export {
+  publishRuntimeControlResult,
+  toRuntimeControlResultPayload,
+} from "./runtime-control-result-routing.js";
 export type {
   DaemonRuntimeControlExecutorOptions,
   DaemonRuntimeControlRequestBody,

--- a/src/runtime/control/runtime-control-intent.ts
+++ b/src/runtime/control/runtime-control-intent.ts
@@ -6,8 +6,6 @@ export interface RuntimeControlIntent {
 }
 
 const RESTART_TERMS = [/再起動/, /リスタート/i, /\brestart\b/i];
-const UPDATE_TERMS = [/更新/, /最新版/, /\bupdate\b/i, /\bupgrade\b/i];
-const RELOAD_TERMS = [/読み直/, /再読/, /\breload\b/i];
 const RUNTIME_TERMS = [/pulseed/i, /daemon/i, /gateway/i, /runtime/i, /自身/, /自分/];
 const EXPLANATION_TERMS = [/設計/, /説明/, /教えて/, /どう/, /\bexplain\b/i, /\bhow\b/i, /\bwhy\b/i];
 
@@ -20,14 +18,6 @@ export function recognizeRuntimeControlIntent(input: string): RuntimeControlInte
   if (!trimmed) return null;
   if (anyMatch(trimmed, EXPLANATION_TERMS)) return null;
   if (!anyMatch(trimmed, RUNTIME_TERMS)) return null;
-
-  if (anyMatch(trimmed, UPDATE_TERMS)) {
-    return { kind: "self_update", reason: trimmed };
-  }
-
-  if (anyMatch(trimmed, RELOAD_TERMS) && /config|設定|env/i.test(trimmed)) {
-    return { kind: "reload_config", reason: trimmed };
-  }
 
   if (anyMatch(trimmed, RESTART_TERMS)) {
     if (/gateway/i.test(trimmed)) {

--- a/src/runtime/control/runtime-control-result-routing.ts
+++ b/src/runtime/control/runtime-control-result-routing.ts
@@ -1,0 +1,81 @@
+import { OutboxStore } from "../store/outbox-store.js";
+import type { RuntimeControlOperation } from "../store/runtime-operation-schemas.js";
+
+export interface RuntimeControlResultEventPublisher {
+  broadcast(eventType: string, data: unknown): Promise<void> | void;
+}
+
+export interface PublishRuntimeControlResultOptions {
+  operation: RuntimeControlOperation;
+  publisher?: RuntimeControlResultEventPublisher;
+  outboxStore?: OutboxStore;
+  runtimeRoot?: string | null;
+  now?: () => number;
+}
+
+export interface RuntimeControlResultPayload {
+  operationId: string;
+  operation_id: string;
+  kind: RuntimeControlOperation["kind"];
+  state: RuntimeControlOperation["state"];
+  ok: boolean;
+  message: string;
+  daemon_status?: string;
+  health_error?: string;
+  requested_by: RuntimeControlOperation["requested_by"];
+  reply_target: RuntimeControlOperation["reply_target"];
+  completed_at?: string;
+}
+
+export async function publishRuntimeControlResult(
+  options: PublishRuntimeControlResultOptions
+): Promise<void> {
+  const payload = toRuntimeControlResultPayload(options.operation);
+  const chatResponse = {
+    goalId: `runtime_control:${payload.operation_id}`,
+    goal_id: `runtime_control:${payload.operation_id}`,
+    message: payload.message,
+    status: payload.ok ? "verified" : "failed",
+    reply_target: payload.reply_target,
+    runtime_control: payload,
+  };
+
+  if (options.publisher) {
+    await options.publisher.broadcast("runtime_control_result", payload);
+    await options.publisher.broadcast("chat_response", chatResponse);
+    return;
+  }
+
+  const outboxStore = options.outboxStore ?? new OutboxStore(options.runtimeRoot ?? undefined);
+  const createdAt = options.now?.() ?? Date.now();
+  await outboxStore.append({
+    event_type: "runtime_control_result",
+    correlation_id: payload.operation_id,
+    created_at: createdAt,
+    payload,
+  });
+  await outboxStore.append({
+    event_type: "chat_response",
+    correlation_id: payload.operation_id,
+    created_at: options.now?.() ?? Date.now(),
+    payload: chatResponse,
+  });
+}
+
+export function toRuntimeControlResultPayload(
+  operation: RuntimeControlOperation
+): RuntimeControlResultPayload {
+  return {
+    operationId: operation.operation_id,
+    operation_id: operation.operation_id,
+    kind: operation.kind,
+    state: operation.state,
+    ok: operation.result?.ok ?? false,
+    message: operation.result?.message ?? "Runtime control operation completed.",
+    daemon_status: operation.result?.daemon_status,
+    health_error: operation.result?.health_error,
+    requested_by: operation.requested_by,
+    reply_target: operation.reply_target,
+    completed_at: operation.completed_at,
+  };
+}

--- a/src/runtime/control/runtime-control-service.ts
+++ b/src/runtime/control/runtime-control-service.ts
@@ -58,6 +58,14 @@ export class RuntimeControlService {
   }
 
   async request(request: RuntimeControlRequest): Promise<RuntimeControlResult> {
+    if (!isExecutableRuntimeControlKind(request.intent.kind)) {
+      return {
+        success: false,
+        message: `Runtime control operation ${request.intent.kind} is not supported by the production executor.`,
+        state: "failed",
+      };
+    }
+
     const initial = await this.createInitialOperation(request);
     const approved = await this.approveIfRequired(initial, request.approvalFn);
     if (!approved.ok) return approved.result;
@@ -75,7 +83,7 @@ export class RuntimeControlService {
       requested_at: requestedAt,
       updated_at: requestedAt,
       requested_by: request.requestedBy ?? { surface: "chat" },
-      reply_target: request.replyTarget ?? { surface: "chat" },
+      reply_target: normalizeReplyTarget(request.replyTarget ?? { surface: "chat" }),
       reason: request.intent.reason,
       expected_health: expectedHealthFor(request.intent.kind),
     };
@@ -200,14 +208,42 @@ export class RuntimeControlService {
   }
 }
 
+export function isExecutableRuntimeControlKind(
+  kind: RuntimeControlOperationKind
+): kind is Extract<RuntimeControlOperationKind, "restart_daemon" | "restart_gateway"> {
+  return kind === "restart_daemon" || kind === "restart_gateway";
+}
+
 function requiresApproval(kind: RuntimeControlOperationKind): boolean {
-  return kind === "restart_daemon" || kind === "restart_gateway" || kind === "self_update";
+  return isExecutableRuntimeControlKind(kind);
+}
+
+function normalizeReplyTarget(target: RuntimeControlReplyTarget): RuntimeControlReplyTarget {
+  return {
+    ...target,
+    channel: target.channel ?? defaultChannelForSurface(target.surface),
+  };
+}
+
+function defaultChannelForSurface(
+  surface: RuntimeControlReplyTarget["surface"]
+): RuntimeControlReplyTarget["channel"] {
+  switch (surface) {
+    case "gateway":
+      return "plugin_gateway";
+    case "cli":
+    case "tui":
+      return surface;
+    case "chat":
+    case undefined:
+      return undefined;
+  }
 }
 
 function expectedHealthFor(kind: RuntimeControlOperationKind): { daemon_ping: boolean; gateway_acceptance: boolean } {
   return {
-    daemon_ping: kind !== "reload_config",
-    gateway_acceptance: kind === "restart_gateway" || kind === "restart_daemon" || kind === "self_update",
+    daemon_ping: isExecutableRuntimeControlKind(kind),
+    gateway_acceptance: isExecutableRuntimeControlKind(kind),
   };
 }
 

--- a/src/runtime/daemon/runner-startup.ts
+++ b/src/runtime/daemon/runner-startup.ts
@@ -4,6 +4,10 @@ import { IngressGateway, HttpChannelAdapter } from "../gateway/index.js";
 import type { LoopSupervisor, SupervisorState } from "../executor/index.js";
 import { PulSeedEventSchema } from "../../base/types/drive.js";
 import { RuntimeOperationStore, type RuntimeControlOperationKind } from "../store/index.js";
+import {
+  publishRuntimeControlResult,
+  type RuntimeControlResultEventPublisher,
+} from "../control/runtime-control-result-routing.js";
 import { ProcessShutdownCoordinator, startDaemonStatusHeartbeat, type ProcessSignalTarget } from "./runner-lifecycle.js";
 import { handleCriticalDaemonError, handleDaemonLoopError } from "./runner-errors.js";
 import type { Envelope } from "../types/envelope.js";
@@ -322,6 +326,7 @@ export async function reconcileRuntimeControlOperationsAfterStartup(
   runtimeRoot: string | null,
   state: { status: string },
   logger: { info(message: string, meta?: Record<string, unknown>): void },
+  publisher?: RuntimeControlResultEventPublisher,
 ): Promise<void> {
   const operationStore = new RuntimeOperationStore(runtimeRoot ?? undefined);
   const pending = await operationStore.listPending();
@@ -333,7 +338,7 @@ export async function reconcileRuntimeControlOperationsAfterStartup(
     ) {
       continue;
     }
-    await operationStore.save({
+    const verified = await operationStore.save({
       ...operation,
       state: "verified",
       updated_at: now,
@@ -342,10 +347,15 @@ export async function reconcileRuntimeControlOperationsAfterStartup(
         ok: true,
         message:
           operation.kind === "restart_gateway"
-            ? "gateway restart verified after daemon startup."
-            : "daemon restart verified after startup.",
+            ? "gateway の再起動を確認しました。"
+            : "PulSeed daemon の再起動を確認しました。",
         daemon_status: state.status,
       },
+    });
+    await publishRuntimeControlResult({
+      operation: verified,
+      publisher,
+      runtimeRoot,
     });
     logger.info("Runtime control restart operation verified after startup", {
       operation_id: operation.operation_id,

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -499,7 +499,7 @@ export class DaemonRunner {
   }
 
   private async reconcileRuntimeControlOperationsAfterStartup(): Promise<void> {
-    await reconcileRuntimeControlOperationsAfterStartupFn(this.runtimeRoot, this.state, this.logger);
+    await reconcileRuntimeControlOperationsAfterStartupFn(this.runtimeRoot, this.state, this.logger, this.eventServer ?? undefined);
   }
 
   // ─── Private: Cleanup ───

--- a/src/runtime/gateway/__tests__/ingress-runtime-control-contract.test.ts
+++ b/src/runtime/gateway/__tests__/ingress-runtime-control-contract.test.ts
@@ -159,10 +159,15 @@ describe("IngressGateway runtime-control contract", () => {
         },
         reply_target: {
           surface: "gateway",
+          channel: "plugin_gateway",
           platform: "slack",
           conversation_id: "slack-thread-1",
+          message_id: "slack-msg-1",
           identity_key: "owner",
           user_id: "owner-user",
+          metadata: {
+            runtime_control_approved: true,
+          },
         },
       });
       expect(daemonRestart).toMatchObject({
@@ -176,10 +181,15 @@ describe("IngressGateway runtime-control contract", () => {
         },
         reply_target: {
           surface: "gateway",
+          channel: "plugin_gateway",
           platform: "telegram",
           conversation_id: "telegram-chat-1",
+          message_id: "telegram-msg-1",
           identity_key: "owner",
           user_id: "owner-user",
+          metadata: {
+            runtime_control_approved: true,
+          },
         },
       });
       expect(daemonRestart?.reply_target.platform).not.toBe(gatewayRestart?.reply_target.platform);

--- a/src/runtime/gateway/__tests__/slack-channel-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/slack-channel-adapter.test.ts
@@ -1,9 +1,14 @@
 import { createHmac } from "crypto";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { dispatchGatewayChatInput } from "../chat-session-dispatch.js";
 import {
   SlackChannelAdapter,
   type SlackChannelAdapterConfig,
 } from "../slack-channel-adapter.js";
+
+vi.mock("../chat-session-dispatch.js", () => ({
+  dispatchGatewayChatInput: vi.fn().mockResolvedValue("ok"),
+}));
 
 const SIGNING_SECRET = "test-signing-secret-abc123";
 
@@ -24,6 +29,14 @@ function makeAdapter(extra?: Partial<SlackChannelAdapterConfig>): SlackChannelAd
     ...extra,
   });
 }
+
+beforeEach(() => {
+  vi.mocked(dispatchGatewayChatInput).mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 // ---------------------------------------------------------------------------
 // Basic adapter properties
@@ -195,7 +208,7 @@ describe("SlackChannelAdapter — event_callback to Envelope", () => {
       type: "event_callback",
       team_id: "T_TEAM1",
       event_id: "Ev_001",
-      event: { type: "message", text: "hello", channel: "C_GENERAL" },
+      event: { type: "reaction_added", reaction: "eyes", channel: "C_GENERAL" },
     });
     adapter.handleRequest(body, buildHeaders(body));
 
@@ -203,7 +216,7 @@ describe("SlackChannelAdapter — event_callback to Envelope", () => {
     const envelope = handler.mock.calls[0][0];
     expect(envelope.type).toBe("event");
     expect(envelope.source).toBe("slack");
-    expect(envelope.name).toBe("message");
+    expect(envelope.name).toBe("reaction_added");
   });
 
   it("sets envelope.name from slack event type", () => {
@@ -215,12 +228,12 @@ describe("SlackChannelAdapter — event_callback to Envelope", () => {
       type: "event_callback",
       team_id: "T1",
       event_id: "E1",
-      event: { type: "app_mention", channel: "C1" },
+      event: { type: "reaction_added", channel: "C1" },
     });
     adapter.handleRequest(body, buildHeaders(body));
 
     const envelope = handler.mock.calls[0][0];
-    expect(envelope.name).toBe("app_mention");
+    expect(envelope.name).toBe("reaction_added");
   });
 
   it("sets payload to the Slack event object", () => {
@@ -228,7 +241,7 @@ describe("SlackChannelAdapter — event_callback to Envelope", () => {
     const handler = vi.fn();
     adapter.onEnvelope(handler);
 
-    const slackEvent = { type: "message", text: "ping", channel: "C_TEST", user: "U123" };
+    const slackEvent = { type: "reaction_added", reaction: "thumbsup", channel: "C_TEST", user: "U123" };
     const body = JSON.stringify({
       type: "event_callback",
       team_id: "T1",
@@ -250,7 +263,7 @@ describe("SlackChannelAdapter — event_callback to Envelope", () => {
       type: "event_callback",
       team_id: "T_META",
       event_id: "Ev_META",
-      event: { type: "message" },
+      event: { type: "reaction_added" },
     });
     adapter.handleRequest(body, buildHeaders(body));
 
@@ -269,12 +282,163 @@ describe("SlackChannelAdapter — event_callback to Envelope", () => {
       type: "event_callback",
       team_id: "T1",
       event_id: "Ev_DEDUP",
-      event: { type: "message" },
+      event: { type: "reaction_added" },
     });
     adapter.handleRequest(body, buildHeaders(body));
 
     const envelope = handler.mock.calls[0][0];
     expect(envelope.dedupe_key).toBe("Ev_DEDUP");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Chat dispatch
+// ---------------------------------------------------------------------------
+
+describe("SlackChannelAdapter — chat dispatch", () => {
+  it("dispatches Slack message text to the cross-platform chat path", () => {
+    const adapter = makeAdapter({
+      botToken: "xoxb-test-token",
+      channelGoalMap: { C_GENERAL: "goal-001" },
+      routing: { identityKey: "shared-slack-user" },
+    });
+    vi.mocked(dispatchGatewayChatInput).mockResolvedValueOnce(null);
+    const handler = vi.fn();
+    adapter.onEnvelope(handler);
+
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T_TEAM1",
+      event_id: "Ev_001",
+      event: {
+        type: "message",
+        text: "  hello from slack  ",
+        channel: "C_GENERAL",
+        user: "U123",
+        ts: "171234.567",
+      },
+    });
+    const res = adapter.handleRequest(body, buildHeaders(body));
+
+    expect(res.status).toBe(200);
+    expect(handler).not.toHaveBeenCalled();
+    expect(dispatchGatewayChatInput).toHaveBeenCalledWith(expect.objectContaining({
+      text: "hello from slack",
+      platform: "slack",
+      identity_key: "shared-slack-user",
+      conversation_id: "C_GENERAL",
+      sender_id: "U123",
+      message_id: "171234.567",
+      goal_id: "goal-001",
+      metadata: expect.objectContaining({
+        goal_id: "goal-001",
+        routed_goal_id: "goal-001",
+        slack_team_id: "T_TEAM1",
+        slack_event_id: "Ev_001",
+      }),
+    }));
+  });
+
+  it("dispatches app_mention text through the same chat path", () => {
+    const adapter = makeAdapter({ botToken: "xoxb-test-token" });
+    vi.mocked(dispatchGatewayChatInput).mockResolvedValueOnce(null);
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T1",
+      event_id: "E1",
+      event: { type: "app_mention", text: "<@BOT> help", channel: "C_HELP", user: "U_HELP" },
+    });
+
+    adapter.handleRequest(body, buildHeaders(body));
+
+    expect(dispatchGatewayChatInput).toHaveBeenCalledWith(expect.objectContaining({
+      text: "<@BOT> help",
+      platform: "slack",
+      conversation_id: "C_HELP",
+      sender_id: "U_HELP",
+      message_id: "E1",
+    }));
+  });
+
+  it("posts the chat reply back to Slack when a bot token is configured", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.mocked(dispatchGatewayChatInput).mockResolvedValueOnce("Slack reply text");
+    const adapter = makeAdapter({ botToken: "xoxb-test-token" });
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T1",
+      event_id: "E1",
+      event: { type: "message", text: "hello", channel: "C_HELP", user: "U_HELP", ts: "123.456" },
+    });
+
+    adapter.handleRequest(body, buildHeaders(body));
+
+    await vi.waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://slack.com/api/chat.postMessage",
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            Authorization: "Bearer xoxb-test-token",
+          }),
+          body: JSON.stringify({
+            channel: "C_HELP",
+            text: "Slack reply text",
+            thread_ts: "123.456",
+          }),
+        })
+      );
+    });
+  });
+
+  it("keeps signing-secret-only Slack text events on the envelope path", () => {
+    const adapter = makeAdapter();
+    const handler = vi.fn();
+    adapter.onEnvelope(handler);
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T1",
+      event_id: "E1",
+      event: { type: "message", text: "hello", channel: "C_HELP", user: "U_HELP", ts: "123.456" },
+    });
+
+    adapter.handleRequest(body, buildHeaders(body));
+
+    expect(dispatchGatewayChatInput).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][0]).toMatchObject({
+      type: "event",
+      source: "slack",
+      name: "message",
+    });
+  });
+
+  it("does not dispatch bot messages back into chat", () => {
+    const adapter = makeAdapter();
+    const handler = vi.fn();
+    adapter.onEnvelope(handler);
+    const body = JSON.stringify({
+      type: "event_callback",
+      team_id: "T1",
+      event_id: "E1",
+      event: {
+        type: "message",
+        subtype: "bot_message",
+        text: "bot echo",
+        channel: "C_HELP",
+        user: "U_BOT",
+        bot_id: "B1",
+      },
+    });
+
+    adapter.handleRequest(body, buildHeaders(body));
+
+    expect(dispatchGatewayChatInput).not.toHaveBeenCalled();
+    expect(handler).toHaveBeenCalledOnce();
   });
 });
 

--- a/src/runtime/gateway/chat-session-dispatch.ts
+++ b/src/runtime/gateway/chat-session-dispatch.ts
@@ -8,6 +8,7 @@ export interface GatewayChatDispatchInput {
   conversation_id: string;
   sender_id: string;
   message_id?: string;
+  goal_id?: string;
   cwd?: string;
   metadata?: Record<string, unknown>;
   onEvent?: ChatEventHandler;
@@ -25,6 +26,7 @@ export async function dispatchGatewayChatInput(
       conversation_id: input.conversation_id,
       sender_id: input.sender_id,
       message_id: input.message_id,
+      goal_id: input.goal_id,
       cwd: input.cwd,
       metadata: input.metadata,
       onEvent: input.onEvent,

--- a/src/runtime/gateway/discord-gateway-adapter.ts
+++ b/src/runtime/gateway/discord-gateway-adapter.ts
@@ -209,6 +209,7 @@ export class DiscordGatewayAdapter implements ChannelAdapter {
       conversation_id: conversationId,
       sender_id: senderId,
       message_id: payload.id,
+      goal_id: route.goalId,
       metadata: {
         ...route.metadata,
         interaction_type: payload.type,

--- a/src/runtime/gateway/signal-gateway-adapter.ts
+++ b/src/runtime/gateway/signal-gateway-adapter.ts
@@ -136,6 +136,7 @@ export class SignalGatewayAdapter implements ChannelAdapter {
         conversation_id: normalized.conversationId,
         sender_id: normalized.senderId,
         message_id: normalized.messageId,
+        goal_id: route.goalId,
         metadata: {
           ...route.metadata,
           ...normalized.metadata,

--- a/src/runtime/gateway/slack-channel-adapter.ts
+++ b/src/runtime/gateway/slack-channel-adapter.ts
@@ -7,9 +7,12 @@ import {
   type ChannelAccessPolicy,
   type ChannelRoutingPolicy,
 } from "./channel-policy.js";
+import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
 
 export interface SlackChannelAdapterConfig {
   signingSecret: string;
+  /** Optional bot token used to send chat replies back to Slack channels. */
+  botToken?: string;
   /** Optional: map Slack channel IDs to PulSeed goal IDs */
   channelGoalMap?: Record<string, string>;
   security?: ChannelAccessPolicy;
@@ -36,9 +39,11 @@ export class SlackChannelAdapter implements ChannelAdapter {
   readonly name = "slack";
   private handler: EnvelopeHandler | null = null;
   private readonly config: SlackChannelAdapterConfig;
+  private readonly api: SlackAPI | null;
 
   constructor(config: SlackChannelAdapterConfig) {
     this.config = config;
+    this.api = config.botToken ? new SlackAPI(config.botToken) : null;
   }
 
   onEnvelope(handler: EnvelopeHandler): void {
@@ -140,11 +145,6 @@ export class SlackChannelAdapter implements ChannelAdapter {
       return { status: 400, body: "missing event field" };
     }
 
-    if (!this.handler) {
-      console.warn("SlackChannelAdapter: no handler registered, dropping event");
-      return { status: 200, body: "ok" };
-    }
-
     const slackChannelId = slackEvent["channel"] as string | undefined;
     const userId = slackEvent["user"] as string | undefined;
     const context = {
@@ -169,6 +169,35 @@ export class SlackChannelAdapter implements ChannelAdapter {
     );
 
     const eventType = String(slackEvent["type"] ?? "slack_event");
+    const metadata = {
+      ...route.metadata,
+      slack_team_id: parsed["team_id"],
+      slack_event_id: parsed["event_id"],
+      ...(route.goalId ? { goal_id: route.goalId } : {}),
+      ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+    };
+
+    if (isSlackChatTextEvent(slackEvent, eventType) && this.api) {
+      void this.dispatchSlackChat({
+        text: slackEvent["text"].trim(),
+        channel: slackEvent["channel"],
+        user: slackEvent["user"],
+        messageId: typeof slackEvent["ts"] === "string"
+          ? slackEvent["ts"]
+          : parsed["event_id"] as string | undefined,
+        identityKey: route.identityKey,
+        goalId: route.goalId,
+        metadata,
+      }).catch((err: unknown) => {
+        console.warn("SlackChannelAdapter: chat dispatch failed", err);
+      });
+      return { status: 200, body: "ok" };
+    }
+
+    if (!this.handler) {
+      console.warn("SlackChannelAdapter: no handler registered, dropping event");
+      return { status: 200, body: "ok" };
+    }
 
     const envelope = createEnvelope({
       type: "event",
@@ -182,15 +211,96 @@ export class SlackChannelAdapter implements ChannelAdapter {
     });
 
     // Attach Slack-specific metadata via a plain property merge (envelope is a plain object)
-    (envelope as Record<string, unknown>)["metadata"] = {
-      ...route.metadata,
-      slack_team_id: parsed["team_id"],
-      slack_event_id: parsed["event_id"],
-      ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
-    };
+    (envelope as Record<string, unknown>)["metadata"] = metadata;
 
     this.handler(envelope);
 
     return { status: 200, body: "ok" };
   }
+
+  private async dispatchSlackChat(input: {
+    text: string;
+    channel: string;
+    user: string;
+    messageId?: string;
+    identityKey?: string;
+    goalId?: string;
+    metadata: Record<string, unknown>;
+  }): Promise<void> {
+    let sentAssistantOutput = false;
+    const sendReply = async (text: string): Promise<void> => {
+      const trimmed = text.trim();
+      if (!trimmed || sentAssistantOutput || !this.api) return;
+      sentAssistantOutput = true;
+      await this.api.postMessage(input.channel, trimmed, input.messageId);
+    };
+
+    const reply = await dispatchGatewayChatInput({
+      text: input.text,
+      platform: "slack",
+      identity_key: input.identityKey,
+      conversation_id: input.channel,
+      sender_id: input.user,
+      message_id: input.messageId,
+      goal_id: input.goalId,
+      cwd: process.cwd(),
+      onEvent: (event) => {
+        if (event.type === "assistant_final") {
+          void sendReply(event.text).catch((err: unknown) => {
+            console.warn("SlackChannelAdapter: failed to send assistant event", err);
+          });
+        }
+      },
+      metadata: input.metadata,
+    });
+    if (reply) {
+      await sendReply(reply);
+    }
+  }
+}
+
+class SlackAPI {
+  constructor(private readonly botToken: string) {}
+
+  async postMessage(channel: string, text: string, threadTs?: string): Promise<void> {
+    const response = await fetch("https://slack.com/api/chat.postMessage", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.botToken}`,
+        "Content-Type": "application/json; charset=utf-8",
+      },
+      body: JSON.stringify({
+        channel,
+        text,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+      }),
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => "(unreadable)");
+      throw new Error(`slack-api: chat.postMessage returned ${response.status}: ${body}`);
+    }
+    const json = await response.json().catch(() => ({})) as { ok?: boolean; error?: string };
+    if (json.ok === false) {
+      throw new Error(`slack-api: chat.postMessage failed: ${json.error ?? "unknown error"}`);
+    }
+  }
+}
+
+function isSlackChatTextEvent(
+  slackEvent: Record<string, unknown>,
+  eventType: string
+): slackEvent is Record<string, unknown> & { text: string; channel: string; user: string } {
+  if (eventType !== "message" && eventType !== "app_mention") {
+    return false;
+  }
+  if (typeof slackEvent["text"] !== "string" || slackEvent["text"].trim().length === 0) {
+    return false;
+  }
+  if (typeof slackEvent["channel"] !== "string" || slackEvent["channel"].trim().length === 0) {
+    return false;
+  }
+  if (typeof slackEvent["user"] !== "string" || slackEvent["user"].trim().length === 0) {
+    return false;
+  }
+  return typeof slackEvent["bot_id"] !== "string" && slackEvent["subtype"] !== "bot_message";
 }

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -164,6 +164,7 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
       identity_key: route.identityKey ?? this.config.identity_key,
       conversation_id: String(chatId),
       sender_id: String(fromUserId),
+      goal_id: route.goalId,
       cwd: process.cwd(),
       onEvent: (event) => eventAdapter.handle(event),
       metadata: {

--- a/src/runtime/gateway/whatsapp-gateway-adapter.ts
+++ b/src/runtime/gateway/whatsapp-gateway-adapter.ts
@@ -192,6 +192,7 @@ export class WhatsAppGatewayAdapter implements ChannelAdapter {
       conversation_id: message.from,
       sender_id: message.from,
       message_id: message.id,
+      goal_id: route.goalId,
       metadata: {
         ...route.metadata,
         message_type: message.type,

--- a/src/runtime/store/runtime-operation-schemas.ts
+++ b/src/runtime/store/runtime-operation-schemas.ts
@@ -31,12 +31,17 @@ export type RuntimeControlActor = z.infer<typeof RuntimeControlActorSchema>;
 
 export const RuntimeControlReplyTargetSchema = z.object({
   surface: z.enum(["chat", "gateway", "cli", "tui"]).optional(),
+  channel: z.enum(["tui", "plugin_gateway", "cli", "web"]).optional(),
   platform: z.string().optional(),
   conversation_id: z.string().optional(),
+  message_id: z.string().optional(),
   response_channel: z.string().optional(),
   outbox_topic: z.string().optional(),
   identity_key: z.string().optional(),
   user_id: z.string().optional(),
+  deliveryMode: z.enum(["reply", "notify", "thread_reply"]).optional(),
+  delivery_mode: z.enum(["reply", "notify", "thread_reply"]).optional(),
+  metadata: z.record(z.unknown()).optional(),
 });
 export type RuntimeControlReplyTarget = z.infer<typeof RuntimeControlReplyTargetSchema>;
 

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -29,6 +29,7 @@ export const DaemonConfigSchema = z.object({
     slack: z.object({
       enabled: z.boolean().default(false),
       signing_secret: z.string().optional(),
+      bot_token: z.string().optional(),
       path: z.string().default("/slack/events"),
       channel_goal_map: z.record(z.string()).default({}),
     }).default({}),


### PR DESCRIPTION
## Summary

- Route TUI free-form chat through ChatRunner/agentloop instead of stealing it into daemon goal chat when an active goal exists.
- Fix native agent-loop resume state path/cwd handling so session state is written and resumed from the same StateManager-backed location.
- Thread gateway-selected `goal_id` into chat execution, including Telegram/Discord/Signal/WhatsApp and Slack.
- Wire Slack text/app_mention events into chat with Slack replies when `bot_token` is configured, while preserving signing-secret-only envelope behavior.
- Persist richer runtime-control reply targets and publish scoped restart verification results through EventServer/SSE/outbox.
- Stop recognizing unsupported runtime-control operations (`self_update`, `reload_config`) as executable natural-language control intents.

## Root Cause

Several tests covered lower-level ingress/gateway/runtime-control objects but not the production caller path. The implementation still had stale or partial wiring across TUI, gateway dispatch, agent-loop state persistence, Slack ingress, and runtime-control result publishing.

## Validation

- `npm run typecheck`
- `npm run build`
- `npm run test:unit`
- `npm run test:smoke`
- `npm run test:integration`
- Focused wiring tests for TUI routing, agent-loop session state, cross-platform goal routing, Slack dispatch/reply behavior, runtime-control intent/result routing, and gateway runtime-control contracts.
- Fresh review agents reported no remaining material findings after the final Slack/result-routing fixes.
