### PR TITLE
[codex] Add wait observe runtime contract

### DIFF
--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -1025,10 +1025,19 @@ describe("CoreLoop", async () => {
         last_rebalanced_at: new Date().toISOString(),
       });
 
-      const waitTrigger = { type: "wait_expired" as const, details: "wait period elapsed" };
+      const waitTrigger = {
+        type: "stall_detected" as const,
+        strategy_id: waitStrategy.id,
+        details: "wait period elapsed",
+      };
       const portfolioManager = createMockPortfolioManager();
       portfolioManager.isWaitStrategy.mockReturnValue(true);
-      portfolioManager.handleWaitStrategyExpiry.mockReturnValue(waitTrigger);
+      portfolioManager.handleWaitStrategyExpiry.mockReturnValue({
+        status: "worsened",
+        goal_id: "goal-1",
+        strategy_id: waitStrategy.id,
+        rebalance_trigger: waitTrigger,
+      });
 
       const depsWithPM = { ...deps, portfolioManager: portfolioManager as any };
       const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
@@ -1036,6 +1045,39 @@ describe("CoreLoop", async () => {
 
       expect(portfolioManager.handleWaitStrategyExpiry).toHaveBeenCalledWith("goal-1", waitStrategy.id);
       expect(portfolioManager.rebalance).toHaveBeenCalledWith("goal-1", waitTrigger);
+    });
+
+    it("marks waitExpired when WaitStrategy expiry does not require rebalance", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal());
+
+      const waitStrategy = {
+        id: "wait-strategy-1",
+        state: "active",
+        goal_id: "goal-1",
+      };
+      mocks.strategyManager.getPortfolio.mockReturnValue({
+        goal_id: "goal-1",
+        strategies: [waitStrategy],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+
+      const portfolioManager = createMockPortfolioManager();
+      portfolioManager.isWaitStrategy.mockReturnValue(true);
+      portfolioManager.handleWaitStrategyExpiry.mockReturnValue({
+        status: "improved",
+        goal_id: "goal-1",
+        strategy_id: waitStrategy.id,
+      });
+
+      const depsWithPM = { ...deps, portfolioManager: portfolioManager as any };
+      const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(result.waitExpired).toBe(true);
+      expect(result.waitStrategyId).toBe(waitStrategy.id);
+      expect(portfolioManager.rebalance).not.toHaveBeenCalled();
     });
 
     it("uses WaitStrategy.wait_until to suppress stall checks for its primary dimension", async () => {

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -446,16 +446,17 @@ async function rebalancePortfolio(
     if (portfolio) {
       for (const strategy of portfolio.strategies) {
         if (ctx.deps.portfolioManager.isWaitStrategy(strategy)) {
-          const waitTrigger = await ctx.deps.portfolioManager.handleWaitStrategyExpiry(
+          const waitOutcome = await ctx.deps.portfolioManager.handleWaitStrategyExpiry(
             goalId,
             strategy.id
           );
+          const waitTrigger = waitOutcome?.rebalance_trigger ?? null;
+          if (waitOutcome && waitOutcome.status !== "not_due" && result) {
+            result.waitExpired = true;
+            result.waitStrategyId = strategy.id;
+          }
           if (waitTrigger) {
             await ctx.deps.portfolioManager.rebalance(goalId, waitTrigger);
-            if (result) {
-              result.waitExpired = true;
-              result.waitStrategyId = strategy.id;
-            }
           }
         }
       }

--- a/src/orchestrator/strategy/__tests__/parse-strategy.test.ts
+++ b/src/orchestrator/strategy/__tests__/parse-strategy.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
-import { parseStrategy, parseStrategies, PortfolioSchema, WaitStrategySchema, StrategySchema } from "../../../base/types/strategy.js";
+import {
+  parseStrategy,
+  parseStrategies,
+  normalizeWaitMetadata,
+  PortfolioSchema,
+  StrategySchema,
+  WaitMetadataSchema,
+  WaitStrategySchema,
+} from "../../../base/types/strategy.js";
 import { isWaitStrategy } from "../portfolio-allocation.js";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { StrategyManager } from "../strategy-manager.js";
@@ -178,6 +186,35 @@ describe("WaitStrategy persistence round-trip", () => {
     expect(loaded).toBeDefined();
     expect(isWaitStrategy(loaded as Record<string, unknown>)).toBe(true);
     expect((loaded as Record<string, unknown>)["wait_until"]).toBe("2026-04-14T00:00:00.000Z");
+
+    const metadata = WaitMetadataSchema.parse(
+      await stateManager.readRaw(`strategies/goal-1/wait-meta/${waitStrategy.id}.json`)
+    );
+    expect(metadata.wait_until).toBe("2026-04-14T00:00:00.000Z");
+    expect(metadata.conditions).toEqual([
+      { type: "time_until", until: "2026-04-14T00:00:00.000Z" },
+    ]);
+    expect(metadata.resume_plan).toEqual({ action: "complete_wait" });
+  });
+
+  it("normalizes legacy wait-meta sidecars into the durable wait metadata contract", async () => {
+    const waitStrategy = WaitStrategySchema.parse(makeWaitStrategyData({
+      wait_until: "2026-04-14T00:00:00.000Z",
+      fallback_strategy_id: "fallback-1",
+    }));
+
+    const metadata = normalizeWaitMetadata(waitStrategy, {
+      wait_until: "2026-04-14T00:00:00.000Z",
+    });
+
+    expect(metadata.schema_version).toBe(1);
+    expect(metadata.conditions).toEqual([
+      { type: "time_until", until: "2026-04-14T00:00:00.000Z" },
+    ]);
+    expect(metadata.resume_plan).toEqual({
+      action: "activate_fallback",
+      strategy_id: "fallback-1",
+    });
   });
 
   it("WaitStrategy fields preserved after updateState (terminated)", async () => {

--- a/src/orchestrator/strategy/__tests__/portfolio-manager.test.ts
+++ b/src/orchestrator/strategy/__tests__/portfolio-manager.test.ts
@@ -753,7 +753,7 @@ describe("PortfolioManager", () => {
   });
 
   describe("handleWaitStrategyExpiry", () => {
-    it("returns null when not expired", async () => {
+    it("returns not_due when not expired", async () => {
       const wait = makeWaitStrategy({
         id: "ws1",
         state: "active",
@@ -765,7 +765,31 @@ describe("PortfolioManager", () => {
       (mockStrategyManager.getPortfolio as ReturnType<typeof vi.fn>).mockReturnValue(portfolio);
 
       const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
-      expect(result).toBeNull();
+      expect(result).toMatchObject({ status: "not_due", strategy_id: "ws1" });
+    });
+
+    it("uses durable next_observe_at instead of expiring on stale wait_until", async () => {
+      const wait = makeWaitStrategy({
+        id: "ws1",
+        state: "active",
+        wait_until: new Date(Date.now() - 100_000).toISOString(),
+        gap_snapshot_at_start: 0.8,
+        primary_dimension: "quality",
+      });
+      const portfolio = makePortfolio([wait]);
+      (mockStrategyManager.getPortfolio as ReturnType<typeof vi.fn>).mockReturnValue(portfolio);
+      (mockStateManager.readRaw as ReturnType<typeof vi.fn>).mockResolvedValue({
+        schema_version: 1,
+        wait_until: wait.wait_until,
+        conditions: [{ type: "time_until", until: wait.wait_until }],
+        next_observe_at: new Date(Date.now() + 100_000).toISOString(),
+        resume_plan: { action: "complete_wait" },
+      });
+
+      const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
+
+      expect(result).toMatchObject({ status: "not_due", strategy_id: "ws1" });
+      expect(mockStrategyManager.updateState).not.toHaveBeenCalled();
     });
 
     it("completes the WaitStrategy when expired and gap improved", async () => {
@@ -782,7 +806,8 @@ describe("PortfolioManager", () => {
       (mockStateManager.readRaw as ReturnType<typeof vi.fn>).mockResolvedValue({ quality: 0.5 });
 
       const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
-      expect(result).toBeNull();
+      expect(result).toMatchObject({ status: "improved", strategy_id: "ws1" });
+      expect(result?.rebalance_trigger).toBeUndefined();
       expect(mockStrategyManager.updateState).toHaveBeenCalledWith("ws1", "completed");
     });
 
@@ -806,7 +831,8 @@ describe("PortfolioManager", () => {
 
       const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
 
-      expect(result).toBeNull();
+      expect(result).toMatchObject({ status: "fallback_activated", strategy_id: "ws1" });
+      expect(result?.rebalance_trigger).toBeUndefined();
       expect(mockStrategyManager.updateState).toHaveBeenNthCalledWith(1, "fallback-1", "active");
       expect(mockStrategyManager.updateState).toHaveBeenNthCalledWith(2, "ws1", "terminated");
     });
@@ -826,8 +852,9 @@ describe("PortfolioManager", () => {
 
       const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
       expect(result).not.toBeNull();
-      expect(result!.type).toBe("stall_detected");
-      expect(result!.strategy_id).toBe("ws1");
+      expect(result!.status).toBe("worsened");
+      expect(result!.rebalance_trigger?.type).toBe("stall_detected");
+      expect(result!.rebalance_trigger?.strategy_id).toBe("ws1");
       expect(mockStrategyManager.updateState).toHaveBeenCalledWith("ws1", "terminated");
     });
 

--- a/src/orchestrator/strategy/portfolio-manager.ts
+++ b/src/orchestrator/strategy/portfolio-manager.ts
@@ -1,7 +1,7 @@
 import { StrategyManager } from "./strategy-manager.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { StrategySchema, parseStrategy } from "../../base/types/strategy.js";
-import type { Strategy, Portfolio } from "../../base/types/strategy.js";
+import type { Strategy, Portfolio, WaitExpiryOutcome } from "../../base/types/strategy.js";
 import type { StrategyState } from "../../base/types/core.js";
 import { PortfolioConfigSchema } from "../../base/types/portfolio.js";
 import type {
@@ -382,7 +382,7 @@ export class PortfolioManager {
   async handleWaitStrategyExpiry(
     goalId: string,
     strategyId: string
-  ): Promise<RebalanceTrigger | null> {
+  ): Promise<WaitExpiryOutcome | null> {
     const portfolio = await this.strategyManager.getPortfolio(goalId);
     if (!portfolio) return null;
 
@@ -396,7 +396,8 @@ export class PortfolioManager {
       (s) => this.isWaitStrategy(s),
       (gId, dim) => this.getCurrentGapForDimension(gId, dim),
       (sId, state) => this.strategyManager.updateState(sId, state as StrategyState),
-      async (gId) => (await this.strategyManager.getPortfolio(gId))?.strategies ?? []
+      async (gId) => (await this.strategyManager.getPortfolio(gId))?.strategies ?? [],
+      (gId, sId) => this.stateManager.readRaw(`strategies/${gId}/wait-meta/${sId}.json`)
     );
   }
 

--- a/src/orchestrator/strategy/portfolio-rebalance.ts
+++ b/src/orchestrator/strategy/portfolio-rebalance.ts
@@ -15,7 +15,13 @@ import type {
   RebalanceTrigger,
   TaskSelectionResult,
 } from "../../base/types/portfolio.js";
-import type { Strategy, WaitStrategy } from "../../base/types/strategy.js";
+import {
+  normalizeWaitMetadata,
+  resolveWaitNextObserveAt,
+  type Strategy,
+  type WaitExpiryOutcome,
+  type WaitStrategy,
+} from "../../base/types/strategy.js";
 
 /**
  * Get the current gap value for a specific dimension of a goal.
@@ -290,25 +296,57 @@ export async function handleWaitStrategyExpiry(
   isWaitStrategy: (s: Strategy) => boolean,
   getGap: (goalId: string, dimension: string) => number | null | Promise<number | null>,
   updateState: (strategyId: string, state: string) => void | Promise<void>,
-  getPortfolioStrategies: (goalId: string) => Strategy[] | Promise<Strategy[]>
-): Promise<RebalanceTrigger | null> {
-  if (!isWaitStrategy(strategy)) return null;
+  getPortfolioStrategies: (goalId: string) => Strategy[] | Promise<Strategy[]>,
+  getWaitMetadata?: (goalId: string, strategyId: string) => unknown | null | Promise<unknown | null>
+): Promise<WaitExpiryOutcome> {
+  if (!isWaitStrategy(strategy)) {
+    return {
+      status: "unknown",
+      goal_id: goalId,
+      strategy_id: strategyId,
+      details: "Strategy is not a WaitStrategy",
+    };
+  }
 
   const waitStrategy = strategy as unknown as WaitStrategy;
-  const waitUntil = new Date(waitStrategy.wait_until).getTime();
+  const metadata = normalizeWaitMetadata(
+    waitStrategy,
+    await getWaitMetadata?.(goalId, strategyId)
+  );
+  const nextObserveAt = resolveWaitNextObserveAt(waitStrategy, metadata);
+  const waitUntil = nextObserveAt ? new Date(nextObserveAt).getTime() : new Date(waitStrategy.wait_until).getTime();
   const now = Date.now();
 
-  if (now < waitUntil) return null;
+  if (now < waitUntil) {
+    return {
+      status: "not_due",
+      goal_id: goalId,
+      strategy_id: strategyId,
+      details: `WaitStrategy is not due until ${nextObserveAt ?? waitStrategy.wait_until}`,
+    };
+  }
 
   const currentGap = await getGap(goalId, strategy.primary_dimension);
-  if (currentGap === null) return null;
+  if (currentGap === null) {
+    return {
+      status: "unknown",
+      goal_id: goalId,
+      strategy_id: strategyId,
+      details: `WaitStrategy expired but current gap is unavailable for ${strategy.primary_dimension}`,
+    };
+  }
 
   const startGap = strategy.gap_snapshot_at_start ?? currentGap;
   const gapDelta = currentGap - startGap;
 
   if (gapDelta < 0) {
     await updateState(strategyId, "completed");
-    return null;
+    return {
+      status: "improved",
+      goal_id: goalId,
+      strategy_id: strategyId,
+      details: `WaitStrategy expired with gap improvement: ${startGap.toFixed(3)} → ${currentGap.toFixed(3)}`,
+    };
   }
 
   if (gapDelta === 0) {
@@ -320,23 +358,48 @@ export async function handleWaitStrategyExpiry(
       if (fallback && fallback.state === "candidate") {
         await updateState(fallback.id, "active");
         await updateState(strategyId, "terminated");
-        return null;
+        return {
+          status: "fallback_activated",
+          goal_id: goalId,
+          strategy_id: strategyId,
+          details: `WaitStrategy expired unchanged; activated fallback strategy ${fallback.id}`,
+        };
       }
     }
     await updateState(strategyId, "terminated");
-    return {
+    const rebalanceTrigger: RebalanceTrigger = {
       type: "stall_detected",
       strategy_id: strategyId,
       details: `WaitStrategy expired with no gap improvement: ${startGap.toFixed(3)} → ${currentGap.toFixed(3)}`,
     };
+    return {
+      status: "unchanged",
+      goal_id: goalId,
+      strategy_id: strategyId,
+      details: rebalanceTrigger.details,
+      rebalance_trigger: rebalanceTrigger,
+    };
   }
 
   await updateState(strategyId, "terminated");
-  return {
+  const rebalanceTrigger: RebalanceTrigger = {
     type: "stall_detected",
     strategy_id: strategyId,
     details: `WaitStrategy expired with gap worsening: ${startGap.toFixed(3)} → ${currentGap.toFixed(3)}`,
   };
+  return {
+    status: "worsened",
+    goal_id: goalId,
+    strategy_id: strategyId,
+    details: rebalanceTrigger.details,
+    rebalance_trigger: rebalanceTrigger,
+  };
+}
+
+export function rebalanceTriggerFromWaitExpiryOutcome(
+  outcome: WaitExpiryOutcome | null | undefined
+): RebalanceTrigger | null {
+  return outcome?.rebalance_trigger ?? null;
 }
 
 /**

--- a/src/orchestrator/strategy/strategy-manager.ts
+++ b/src/orchestrator/strategy/strategy-manager.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
-import { StrategySchema, WaitStrategySchema, parseStrategy } from "../../base/types/strategy.js";
+import { StrategySchema, WaitStrategySchema, buildDefaultWaitMetadata, parseStrategy } from "../../base/types/strategy.js";
 import { isWaitStrategy } from "./portfolio-allocation.js";
 import type { Strategy } from "../../base/types/strategy.js";
 import { redistributeAllocation } from "./strategy-helpers.js";
@@ -311,10 +311,10 @@ export class StrategyManager extends StrategyManagerBase {
     portfolio.strategies.push(waitStrategy);
     await this.savePortfolio(goalId, portfolio);
 
-    // Persist wait-specific fields in a sidecar so activateMultiple can read wait_until
+    // Persist wait-specific fields in a sidecar so wait observation can survive schema changes.
     await this.stateManager.writeRaw(
       `strategies/${goalId}/wait-meta/${waitStrategy.id}.json`,
-      { wait_until: params.wait_until }
+      buildDefaultWaitMetadata(waitStrategy)
     );
 
     this.strategyIndex.set(waitStrategy.id, goalId);

--- a/src/orchestrator/strategy/types/strategy.ts
+++ b/src/orchestrator/strategy/types/strategy.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { StrategyStateEnum, DurationSchema } from "../../../base/types/core.js";
+import type { RebalanceTrigger } from "./portfolio.js";
 
 // --- Expected Effect ---
 
@@ -70,6 +71,158 @@ export const WaitStrategySchema = StrategySchema.extend({
   fallback_strategy_id: z.string().nullable(),
 });
 export type WaitStrategy = z.infer<typeof WaitStrategySchema>;
+
+export const TimeUntilWaitConditionSchema = z.object({
+  type: z.literal("time_until"),
+  until: z.string(),
+});
+
+export const FileExistsWaitConditionSchema = z.object({
+  type: z.literal("file_exists"),
+  path: z.string(),
+});
+
+export const FileMtimeChangedWaitConditionSchema = z.object({
+  type: z.literal("file_mtime_changed"),
+  path: z.string(),
+  previous_mtime_ms: z.number(),
+});
+
+export const ProcessSessionExitedWaitConditionSchema = z.object({
+  type: z.literal("process_session_exited"),
+  session_id: z.string(),
+});
+
+export const ArtifactJsonValueWaitConditionSchema = z.object({
+  type: z.literal("artifact_json_value"),
+  path: z.string(),
+  json_pointer: z.string(),
+  expected: z.unknown(),
+});
+
+export const MetricThresholdWaitConditionSchema = z.object({
+  type: z.literal("metric_threshold"),
+  metric: z.string(),
+  operator: z.enum(["lt", "lte", "eq", "gte", "gt"]),
+  value: z.number(),
+});
+
+export const WaitConditionSchema = z.discriminatedUnion("type", [
+  TimeUntilWaitConditionSchema,
+  FileExistsWaitConditionSchema,
+  FileMtimeChangedWaitConditionSchema,
+  ProcessSessionExitedWaitConditionSchema,
+  ArtifactJsonValueWaitConditionSchema,
+  MetricThresholdWaitConditionSchema,
+]);
+export type WaitCondition = z.infer<typeof WaitConditionSchema>;
+
+export const WaitObservationResultSchema = z.object({
+  status: z.enum(["pending", "satisfied", "stale", "failed", "expired"]),
+  evidence: z.record(z.string(), z.unknown()).default({}),
+  next_observe_at: z.string().nullable().default(null),
+  confidence: z.number().min(0).max(1).default(0),
+  resume_hint: z.string().nullable().default(null),
+});
+export type WaitObservationResult = z.infer<typeof WaitObservationResultSchema>;
+
+export const WaitResumePlanSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("continue_strategy") }),
+  z.object({ action: z.literal("activate_fallback"), strategy_id: z.string() }),
+  z.object({ action: z.literal("request_approval"), reason: z.string().nullable().default(null) }),
+  z.object({ action: z.literal("complete_wait") }),
+  z.object({ action: z.literal("generate_task"), prompt: z.string().nullable().default(null) }),
+]);
+export type WaitResumePlan = z.infer<typeof WaitResumePlanSchema>;
+
+export const WaitMetadataSchema = z.object({
+  schema_version: z.literal(1).default(1),
+  wait_until: z.string(),
+  conditions: z.array(WaitConditionSchema).default([]),
+  resume_plan: WaitResumePlanSchema.default({ action: "complete_wait" }),
+  process_refs: z.array(z.record(z.string(), z.unknown())).default([]),
+  artifact_refs: z.array(z.record(z.string(), z.unknown())).default([]),
+  approval_policy: z.record(z.string(), z.unknown()).nullable().default(null),
+  next_observe_at: z.string().nullable().default(null),
+  latest_observation: WaitObservationResultSchema.nullable().default(null),
+}).passthrough();
+export type WaitMetadata = z.infer<typeof WaitMetadataSchema>;
+
+export const WaitExpiryOutcomeStatusSchema = z.enum([
+  "not_due",
+  "improved",
+  "unchanged",
+  "worsened",
+  "unknown",
+  "fallback_activated",
+  "approval_required",
+]);
+export type WaitExpiryOutcomeStatus = z.infer<typeof WaitExpiryOutcomeStatusSchema>;
+
+export interface WaitExpiryOutcome {
+  status: WaitExpiryOutcomeStatus;
+  goal_id: string;
+  strategy_id: string;
+  details?: string;
+  rebalance_trigger?: RebalanceTrigger;
+}
+
+export function waitConditionFromWaitUntil(waitUntil: string): WaitCondition {
+  return { type: "time_until", until: waitUntil };
+}
+
+export function buildDefaultWaitMetadata(waitStrategy: WaitStrategy): WaitMetadata {
+  return WaitMetadataSchema.parse({
+    schema_version: 1,
+    wait_until: waitStrategy.wait_until,
+    conditions: [waitConditionFromWaitUntil(waitStrategy.wait_until)],
+    resume_plan: waitStrategy.fallback_strategy_id
+      ? { action: "activate_fallback", strategy_id: waitStrategy.fallback_strategy_id }
+      : { action: "complete_wait" },
+  });
+}
+
+export function normalizeWaitMetadata(waitStrategy: WaitStrategy, data: unknown): WaitMetadata {
+  const fallback = buildDefaultWaitMetadata(waitStrategy);
+  const raw = data && typeof data === "object" ? data as Record<string, unknown> : {};
+  return WaitMetadataSchema.parse({
+    ...raw,
+    schema_version: 1,
+    wait_until: typeof raw["wait_until"] === "string" ? raw["wait_until"] : fallback.wait_until,
+    conditions: Array.isArray(raw["conditions"]) && raw["conditions"].length > 0
+      ? raw["conditions"]
+      : fallback.conditions,
+    resume_plan: raw["resume_plan"] ?? fallback.resume_plan,
+  });
+}
+
+export function resolveWaitNextObserveAt(
+  waitStrategy: WaitStrategy,
+  metadata: WaitMetadata
+): string | null {
+  const explicitNextObserveAt = validWaitDateString(metadata.next_observe_at)
+    ?? validWaitDateString(metadata.latest_observation?.next_observe_at);
+  if (explicitNextObserveAt) return explicitNextObserveAt;
+
+  const candidates = [
+    ...metadata.conditions.map((condition) => waitConditionDeadline(condition)),
+    waitStrategy.wait_until,
+  ].filter((value): value is string => validWaitDateString(value) !== null);
+
+  if (candidates.length === 0) return null;
+  return candidates.sort((a, b) => Date.parse(a) - Date.parse(b))[0] ?? null;
+}
+
+function waitConditionDeadline(condition: WaitCondition): string | null {
+  if (condition.type === "time_until") return condition.until;
+  return null;
+}
+
+function validWaitDateString(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  if (!Number.isFinite(Date.parse(value))) return null;
+  return value;
+}
 
 // --- Parse Helpers ---
 

--- a/src/runtime/__tests__/runner-goal-cycle.test.ts
+++ b/src/runtime/__tests__/runner-goal-cycle.test.ts
@@ -177,4 +177,136 @@ describe("runDaemonGoalCycleLoop", () => {
     );
     expect(context.handleLoopError).toHaveBeenCalledWith("goal-1", expect.any(Error));
   });
+
+  it("clamps daemon sleep to the next wait observation deadline", async () => {
+    const run = vi.fn().mockResolvedValue(makeLoopResult());
+
+    let context: Record<string, unknown>;
+    context = {
+      running: true,
+      shuttingDown: false,
+      currentGoalIds: ["goal-1"],
+      config: { iterations_per_cycle: 1 },
+      state: {
+        loop_count: 0,
+        last_loop_at: null,
+        status: "running",
+        active_goals: ["goal-1"],
+      },
+      consecutiveIdleCycles: 0,
+      currentLoopIndex: 0,
+      coreLoop: { run },
+      eventServer: null,
+      stateManager: {
+        loadGoal: vi.fn().mockResolvedValue({ status: "active" }),
+      },
+      logger: { info: vi.fn() },
+      refreshOperationalState: vi.fn(),
+      collectGoalCycleSnapshot: vi.fn().mockResolvedValue([]),
+      determineActiveGoals: vi.fn().mockResolvedValue(["goal-1"]),
+      maybeRefreshProviderRuntime: vi.fn().mockResolvedValue(undefined),
+      broadcastGoalUpdated: vi.fn().mockResolvedValue(undefined),
+      handleLoopError: vi.fn(),
+      saveDaemonState: vi.fn().mockResolvedValue(undefined),
+      processCronTasks: vi.fn().mockResolvedValue(undefined),
+      processScheduleEntries: vi.fn().mockResolvedValue(undefined),
+      expireCronTasks: vi.fn().mockResolvedValue(undefined),
+      proactiveTick: vi.fn().mockResolvedValue(undefined),
+      runRuntimeStoreMaintenance: vi.fn().mockResolvedValue(undefined),
+      getNextInterval: vi.fn().mockReturnValue(300_000),
+      getMaxGapScore: vi.fn().mockResolvedValue(0.5),
+      calculateAdaptiveInterval: vi.fn().mockReturnValue(300_000),
+      resolveWaitDeadlines: vi.fn().mockResolvedValue({
+        next_observe_at: "2026-04-24T12:01:00.000Z",
+        waiting_goals: [],
+      }),
+      clampIntervalToWaitDeadline: vi.fn().mockReturnValue(60_000),
+      sleep: vi.fn().mockImplementation(async () => {
+        context.running = false;
+      }),
+      handleCriticalError: vi.fn(),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await runDaemonGoalCycleLoop(context);
+
+    expect(context.resolveWaitDeadlines).toHaveBeenCalledWith(["goal-1"]);
+    expect(context.clampIntervalToWaitDeadline).toHaveBeenCalledWith(
+      300_000,
+      expect.objectContaining({ next_observe_at: "2026-04-24T12:01:00.000Z" })
+    );
+    expect(context.sleep).toHaveBeenCalledWith(60_000);
+  });
+
+  it("runs a goal when its wait observation deadline is due even if drive schedule is idle", async () => {
+    const run = vi.fn().mockResolvedValue(makeLoopResult());
+
+    let context: Record<string, unknown>;
+    context = {
+      running: true,
+      shuttingDown: false,
+      currentGoalIds: ["goal-1"],
+      config: { iterations_per_cycle: 1 },
+      state: {
+        loop_count: 0,
+        last_loop_at: null,
+        status: "running",
+        active_goals: [],
+      },
+      consecutiveIdleCycles: 0,
+      currentLoopIndex: 0,
+      coreLoop: { run },
+      eventServer: null,
+      stateManager: {
+        loadGoal: vi.fn().mockResolvedValue({ status: "active" }),
+      },
+      logger: { info: vi.fn() },
+      refreshOperationalState: vi.fn(),
+      collectGoalCycleSnapshot: vi.fn().mockResolvedValue([]),
+      determineActiveGoals: vi.fn().mockResolvedValue([]),
+      maybeRefreshProviderRuntime: vi.fn().mockResolvedValue(undefined),
+      broadcastGoalUpdated: vi.fn().mockResolvedValue(undefined),
+      handleLoopError: vi.fn(),
+      saveDaemonState: vi.fn().mockResolvedValue(undefined),
+      processCronTasks: vi.fn().mockResolvedValue(undefined),
+      processScheduleEntries: vi.fn().mockResolvedValue(undefined),
+      expireCronTasks: vi.fn().mockResolvedValue(undefined),
+      proactiveTick: vi.fn().mockResolvedValue(undefined),
+      runRuntimeStoreMaintenance: vi.fn().mockResolvedValue(undefined),
+      getNextInterval: vi.fn().mockReturnValue(300_000),
+      getMaxGapScore: vi.fn().mockResolvedValue(0.5),
+      calculateAdaptiveInterval: vi.fn().mockReturnValue(300_000),
+      resolveWaitDeadlines: vi.fn().mockResolvedValue({
+        next_observe_at: "2026-04-24T12:00:00.000Z",
+        waiting_goals: [
+          {
+            goal_id: "goal-1",
+            strategy_id: "wait-1",
+            next_observe_at: "2026-04-24T12:00:00.000Z",
+            wait_until: "2026-04-24T12:00:00.000Z",
+            wait_reason: "deadline due",
+          },
+        ],
+      }),
+      clampIntervalToWaitDeadline: vi.fn().mockReturnValue(0),
+      sleep: vi.fn().mockImplementation(async () => {
+        context.running = false;
+      }),
+      handleCriticalError: vi.fn(),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    };
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-24T12:00:00.000Z"));
+    try {
+      await runDaemonGoalCycleLoop(context);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(context.determineActiveGoals).toHaveBeenCalledWith(["goal-1"], []);
+    expect(run).toHaveBeenCalledWith("goal-1", expect.any(Object));
+    expect(context.maybeRefreshProviderRuntime).toHaveBeenCalledWith(1);
+    expect(context.sleep).toHaveBeenCalledWith(0);
+  });
 });

--- a/src/runtime/__tests__/wait-deadline-resolver.test.ts
+++ b/src/runtime/__tests__/wait-deadline-resolver.test.ts
@@ -1,0 +1,121 @@
+import * as fs from "node:fs";
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { StateManager } from "../../base/state/state-manager.js";
+import { WaitDeadlineResolver, clampIntervalToNextWaitDeadline } from "../daemon/wait-deadline-resolver.js";
+import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
+
+let tempDir: string;
+let stateManager: StateManager;
+
+beforeEach(() => {
+  tempDir = makeTempDir("pulseed-wait-deadline-");
+  stateManager = new StateManager(tempDir);
+});
+
+afterEach(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+function makeActiveWaitStrategy(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "wait-1",
+    goal_id: "goal-1",
+    target_dimensions: ["quality"],
+    primary_dimension: "quality",
+    hypothesis: "Wait for external job completion",
+    expected_effect: [],
+    resource_estimate: {
+      sessions: 0,
+      duration: { value: 0, unit: "hours" },
+      llm_calls: null,
+    },
+    state: "active",
+    allocation: 1,
+    created_at: "2026-04-24T12:00:00.000Z",
+    started_at: "2026-04-24T12:00:00.000Z",
+    completed_at: null,
+    gap_snapshot_at_start: 0.5,
+    tasks_generated: [],
+    effectiveness_score: null,
+    consecutive_stall_count: 0,
+    wait_reason: "External job is still running",
+    wait_until: "2026-04-24T12:10:00.000Z",
+    measurement_plan: "Check the output file",
+    fallback_strategy_id: null,
+    ...overrides,
+  };
+}
+
+describe("WaitDeadlineResolver", () => {
+  it("resolves next_observe_at from durable wait metadata", async () => {
+    await stateManager.writeRaw("strategies/goal-1/portfolio.json", {
+      goal_id: "goal-1",
+      strategies: [makeActiveWaitStrategy()],
+      rebalance_interval: { value: 1, unit: "hours" },
+      last_rebalanced_at: "2026-04-24T12:00:00.000Z",
+    });
+    await stateManager.writeRaw("strategies/goal-1/wait-meta/wait-1.json", {
+      schema_version: 1,
+      wait_until: "2026-04-24T12:10:00.000Z",
+      conditions: [{ type: "time_until", until: "2026-04-24T12:03:00.000Z" }],
+      resume_plan: { action: "complete_wait" },
+    });
+
+    const resolution = await new WaitDeadlineResolver(stateManager).resolve(["goal-1"]);
+
+    expect(resolution.next_observe_at).toBe("2026-04-24T12:03:00.000Z");
+    expect(resolution.waiting_goals).toEqual([
+      expect.objectContaining({
+        goal_id: "goal-1",
+        strategy_id: "wait-1",
+        next_observe_at: "2026-04-24T12:03:00.000Z",
+      }),
+    ]);
+  });
+
+  it("falls back to wait_until when legacy wait metadata has no conditions", async () => {
+    await stateManager.writeRaw("strategies/goal-1/portfolio.json", {
+      goal_id: "goal-1",
+      strategies: [makeActiveWaitStrategy()],
+      rebalance_interval: { value: 1, unit: "hours" },
+      last_rebalanced_at: "2026-04-24T12:00:00.000Z",
+    });
+    await stateManager.writeRaw("strategies/goal-1/wait-meta/wait-1.json", {
+      wait_until: "2026-04-24T12:10:00.000Z",
+    });
+
+    const resolution = await new WaitDeadlineResolver(stateManager).resolve(["goal-1"]);
+
+    expect(resolution.next_observe_at).toBe("2026-04-24T12:10:00.000Z");
+  });
+
+  it("lets durable next_observe_at postpone an original wait_until after re-wait", async () => {
+    await stateManager.writeRaw("strategies/goal-1/portfolio.json", {
+      goal_id: "goal-1",
+      strategies: [makeActiveWaitStrategy()],
+      rebalance_interval: { value: 1, unit: "hours" },
+      last_rebalanced_at: "2026-04-24T12:00:00.000Z",
+    });
+    await stateManager.writeRaw("strategies/goal-1/wait-meta/wait-1.json", {
+      schema_version: 1,
+      wait_until: "2026-04-24T12:10:00.000Z",
+      conditions: [{ type: "time_until", until: "2026-04-24T12:10:00.000Z" }],
+      next_observe_at: "2026-04-24T12:30:00.000Z",
+      resume_plan: { action: "complete_wait" },
+    });
+
+    const resolution = await new WaitDeadlineResolver(stateManager).resolve(["goal-1"]);
+
+    expect(resolution.next_observe_at).toBe("2026-04-24T12:30:00.000Z");
+  });
+
+  it("clamps interval so daemon sleep cannot overshoot the next wait deadline", () => {
+    const clamped = clampIntervalToNextWaitDeadline(
+      300_000,
+      "2026-04-24T12:01:00.000Z",
+      Date.parse("2026-04-24T12:00:00.000Z")
+    );
+
+    expect(clamped).toBe(60_000);
+  });
+});

--- a/src/runtime/__tests__/wait-deadline-resolver.test.ts
+++ b/src/runtime/__tests__/wait-deadline-resolver.test.ts
@@ -89,6 +89,32 @@ describe("WaitDeadlineResolver", () => {
     expect(resolution.next_observe_at).toBe("2026-04-24T12:10:00.000Z");
   });
 
+  it("does not throw and falls back to wait_until when wait metadata is malformed", async () => {
+    await stateManager.writeRaw("strategies/goal-1/portfolio.json", {
+      goal_id: "goal-1",
+      strategies: [makeActiveWaitStrategy()],
+      rebalance_interval: { value: 1, unit: "hours" },
+      last_rebalanced_at: "2026-04-24T12:00:00.000Z",
+    });
+    await stateManager.writeRaw("strategies/goal-1/wait-meta/wait-1.json", {
+      schema_version: 1,
+      wait_until: "2026-04-24T12:10:00.000Z",
+      conditions: [{ type: "metric_threshold", metric: "quality", operator: "gte" }],
+      resume_plan: { action: "complete_wait" },
+    });
+
+    const resolution = await new WaitDeadlineResolver(stateManager).resolve(["goal-1"]);
+
+    expect(resolution.next_observe_at).toBe("2026-04-24T12:10:00.000Z");
+    expect(resolution.waiting_goals).toEqual([
+      expect.objectContaining({
+        goal_id: "goal-1",
+        strategy_id: "wait-1",
+        next_observe_at: "2026-04-24T12:10:00.000Z",
+      }),
+    ]);
+  });
+
   it("lets durable next_observe_at postpone an original wait_until after re-wait", async () => {
     await stateManager.writeRaw("strategies/goal-1/portfolio.json", {
       goal_id: "goal-1",

--- a/src/runtime/daemon/index.ts
+++ b/src/runtime/daemon/index.ts
@@ -4,6 +4,7 @@ export type { ShutdownMarker } from "./types.js";
 export * from "./runtime-ownership.js";
 export * from "./runner-lifecycle.js";
 export * from "./signals.js";
+export * from "./wait-deadline-resolver.js";
 export {
   checkCrashRecoveryMarker,
   cleanupDaemonRun,

--- a/src/runtime/daemon/runner-goal-cycle.ts
+++ b/src/runtime/daemon/runner-goal-cycle.ts
@@ -2,6 +2,7 @@ import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
 import type { ProgressEvent } from "../../orchestrator/loop/core-loop.js";
 import type { GoalCycleScheduleSnapshotEntry } from "./maintenance.js";
 import { errorMessage } from "./runner-errors.js";
+import { getDueWaitGoalIds } from "./wait-deadline-resolver.js";
 
 const MAX_IDLE_SLEEP_MS = 5_000;
 
@@ -35,7 +36,10 @@ export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): P
       const goalIds = [...context.currentGoalIds];
       context.refreshOperationalState();
       const cycleSnapshot = await context.collectGoalCycleSnapshot(goalIds);
-      const activeGoals = await context.determineActiveGoals(goalIds, cycleSnapshot);
+      const waitDeadlines = await context.resolveWaitDeadlines?.(goalIds);
+      const scheduledActiveGoals = await context.determineActiveGoals(goalIds, cycleSnapshot);
+      const dueWaitGoalIds = waitDeadlines ? getDueWaitGoalIds(waitDeadlines) : [];
+      const activeGoals = [...new Set([...scheduledActiveGoals, ...dueWaitGoalIds])];
       await context.maybeRefreshProviderRuntime(activeGoals.length);
 
       if (activeGoals.length === 0) {
@@ -127,8 +131,11 @@ export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): P
           maxGapScore,
           context.consecutiveIdleCycles,
         );
-        const sleepIntervalMs =
+        const idleAwareIntervalMs =
           activeGoals.length === 0 ? Math.min(intervalMs, MAX_IDLE_SLEEP_MS) : intervalMs;
+        const sleepIntervalMs = waitDeadlines
+          ? context.clampIntervalToWaitDeadline(idleAwareIntervalMs, waitDeadlines)
+          : idleAwareIntervalMs;
         context.logger.info(`Sleeping for ${sleepIntervalMs}ms until next check`);
         await context.sleep(sleepIntervalMs);
       }

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -91,6 +91,7 @@ import {
   handleScheduleRunNowCommand as handleScheduleRunNowCommandFn,
 } from "./runner-commands.js";
 import { runDaemonGoalCycleLoop } from "./runner-goal-cycle.js";
+import { WaitDeadlineResolver, type WaitDeadlineResolution } from "./wait-deadline-resolver.js";
 import {
   beginGracefulShutdown as beginGracefulShutdownFn,
   failRuntimeLeadership as failRuntimeLeadershipFn,
@@ -452,6 +453,17 @@ export class DaemonRunner {
    */
   private getNextInterval(goalIds: string[]): number {
     return getNextIntervalForGoals(this.config, goalIds);
+  }
+
+  private async resolveWaitDeadlines(goalIds: string[]): Promise<WaitDeadlineResolution> {
+    return new WaitDeadlineResolver(this.stateManager).resolve(goalIds);
+  }
+
+  private clampIntervalToWaitDeadline(
+    intervalMs: number,
+    resolution: WaitDeadlineResolution
+  ): number {
+    return new WaitDeadlineResolver(this.stateManager).clampInterval(intervalMs, resolution);
   }
 
   // ─── Private: Error Handling ───

--- a/src/runtime/daemon/wait-deadline-resolver.ts
+++ b/src/runtime/daemon/wait-deadline-resolver.ts
@@ -1,5 +1,6 @@
 import { PortfolioSchema } from "../../base/types/strategy.js";
 import {
+  buildDefaultWaitMetadata,
   normalizeWaitMetadata,
   resolveWaitNextObserveAt,
   type WaitMetadata,
@@ -43,7 +44,7 @@ export class WaitDeadlineResolver {
         const rawMetadata = await this.stateManager.readRaw(
           `strategies/${goalId}/wait-meta/${waitStrategy.id}.json`
         );
-        const metadata = normalizeWaitMetadata(waitStrategy, rawMetadata);
+        const metadata = normalizeWaitMetadataFailSoft(waitStrategy, rawMetadata);
         const nextObserveAt = resolveNextObserveAt(waitStrategy, metadata);
         if (!nextObserveAt) continue;
 
@@ -67,6 +68,17 @@ export class WaitDeadlineResolver {
 
   clampInterval(intervalMs: number, resolution: WaitDeadlineResolution, nowMs = Date.now()): number {
     return clampIntervalToNextWaitDeadline(intervalMs, resolution.next_observe_at, nowMs);
+  }
+}
+
+function normalizeWaitMetadataFailSoft(
+  waitStrategy: WaitStrategy,
+  data: unknown
+): WaitMetadata {
+  try {
+    return normalizeWaitMetadata(waitStrategy, data);
+  } catch {
+    return buildDefaultWaitMetadata(waitStrategy);
   }
 }
 

--- a/src/runtime/daemon/wait-deadline-resolver.ts
+++ b/src/runtime/daemon/wait-deadline-resolver.ts
@@ -1,0 +1,105 @@
+import { PortfolioSchema } from "../../base/types/strategy.js";
+import {
+  normalizeWaitMetadata,
+  resolveWaitNextObserveAt,
+  type WaitMetadata,
+  type WaitStrategy,
+} from "../../base/types/strategy.js";
+import { isWaitStrategy } from "../../orchestrator/strategy/portfolio-allocation.js";
+
+export interface WaitDeadlineResolution {
+  next_observe_at: string | null;
+  waiting_goals: Array<{
+    goal_id: string;
+    strategy_id: string;
+    next_observe_at: string;
+    wait_until: string;
+    wait_reason: string;
+  }>;
+}
+
+export interface WaitDeadlineResolverState {
+  readRaw(path: string): Promise<unknown | null>;
+}
+
+export class WaitDeadlineResolver {
+  constructor(private readonly stateManager: WaitDeadlineResolverState) {}
+
+  async resolve(goalIds: string[]): Promise<WaitDeadlineResolution> {
+    const waitingGoals: WaitDeadlineResolution["waiting_goals"] = [];
+
+    for (const goalId of goalIds) {
+      const rawPortfolio = await this.stateManager.readRaw(`strategies/${goalId}/portfolio.json`);
+      if (!rawPortfolio) continue;
+
+      const portfolio = PortfolioSchema.safeParse(rawPortfolio);
+      if (!portfolio.success) continue;
+
+      for (const strategy of portfolio.data.strategies) {
+        if (!isWaitStrategy(strategy as Record<string, unknown>)) continue;
+        if (strategy.state !== "active") continue;
+
+        const waitStrategy = strategy as WaitStrategy;
+        const rawMetadata = await this.stateManager.readRaw(
+          `strategies/${goalId}/wait-meta/${waitStrategy.id}.json`
+        );
+        const metadata = normalizeWaitMetadata(waitStrategy, rawMetadata);
+        const nextObserveAt = resolveNextObserveAt(waitStrategy, metadata);
+        if (!nextObserveAt) continue;
+
+        waitingGoals.push({
+          goal_id: goalId,
+          strategy_id: waitStrategy.id,
+          next_observe_at: nextObserveAt,
+          wait_until: waitStrategy.wait_until,
+          wait_reason: waitStrategy.wait_reason,
+        });
+      }
+    }
+
+    waitingGoals.sort((a, b) => Date.parse(a.next_observe_at) - Date.parse(b.next_observe_at));
+
+    return {
+      next_observe_at: waitingGoals[0]?.next_observe_at ?? null,
+      waiting_goals: waitingGoals,
+    };
+  }
+
+  clampInterval(intervalMs: number, resolution: WaitDeadlineResolution, nowMs = Date.now()): number {
+    return clampIntervalToNextWaitDeadline(intervalMs, resolution.next_observe_at, nowMs);
+  }
+}
+
+export function resolveNextObserveAt(
+  waitStrategy: WaitStrategy,
+  metadata: WaitMetadata
+): string | null {
+  return resolveWaitNextObserveAt(waitStrategy, metadata);
+}
+
+export function getDueWaitGoalIds(
+  resolution: WaitDeadlineResolution,
+  nowMs = Date.now()
+): string[] {
+  const dueGoalIds = new Set<string>();
+  for (const goal of resolution.waiting_goals) {
+    const observeAtMs = Date.parse(goal.next_observe_at);
+    if (!Number.isFinite(observeAtMs)) continue;
+    if (observeAtMs <= nowMs) {
+      dueGoalIds.add(goal.goal_id);
+    }
+  }
+  return [...dueGoalIds];
+}
+
+export function clampIntervalToNextWaitDeadline(
+  intervalMs: number,
+  nextObserveAt: string | null | undefined,
+  nowMs = Date.now()
+): number {
+  if (!nextObserveAt) return intervalMs;
+  const nextObserveMs = Date.parse(nextObserveAt);
+  if (!Number.isFinite(nextObserveMs)) return intervalMs;
+  const waitMs = Math.max(0, nextObserveMs - nowMs);
+  return Math.min(intervalMs, waitMs);
+}


### PR DESCRIPTION
## Summary

- Add first-class wait/observe/resume contracts for long-running runtime work.
- Persist wait metadata in a schema-versioned sidecar, including normalized `time_until` conditions and resume metadata.
- Return explicit `WaitExpiryOutcome` values while preserving rebalance behavior through `rebalance_trigger`.
- Add a daemon `WaitDeadlineResolver` so active wait strategies do not oversleep their next observation deadline.
- Wake due wait goals even when the normal drive schedule is idle, and honor durable `next_observe_at` for re-wait flows.

## Why

`WaitStrategy` previously behaved mostly as stall suppression plus a `wait_until` timestamp. That made long-running external waits hard to recover and easy to oversleep. This PR gives daemon/CoreLoop strategy handling a shared runtime contract for wait metadata and deadline resolution without introducing a dedicated observation ledger.

## Validation

- `pnpm exec vitest run src/orchestrator/strategy/__tests__/portfolio-manager.test.ts src/runtime/__tests__/wait-deadline-resolver.test.ts src/runtime/__tests__/runner-goal-cycle.test.ts src/orchestrator/loop/__tests__/core-loop-integrations.test.ts src/orchestrator/strategy/__tests__/parse-strategy.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `git diff --check`
- Independent review agent re-check: no material findings on wait deadline activation or `next_observe_at` handling.
