### PR TITLE
[codex] Implement wait observe phase 3 and 4

### DIFF
--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import {
   CoreLoop,
   type CoreLoopDeps,
@@ -34,6 +35,7 @@ import { SessionManager } from "../../execution/session-manager.js";
 import { TrustManager } from "../../../platform/traits/trust-manager.js";
 import { ReportingEngine as RealReportingEngine } from "../../../reporting/reporting-engine.js";
 import { CapabilityDetector } from "../../../platform/observation/capability-detector.js";
+import { ApprovalStore } from "../../../runtime/store/approval-store.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { makeDimension, makeGoal } from "../../../../tests/helpers/fixtures.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
@@ -1047,6 +1049,53 @@ describe("CoreLoop", async () => {
       expect(portfolioManager.rebalance).toHaveBeenCalledWith("goal-1", waitTrigger);
     });
 
+    it("continues to task generation when wait rebalance requests a new strategy generation", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal());
+
+      const waitStrategy = {
+        id: "wait-strategy-1",
+        state: "active",
+        goal_id: "goal-1",
+      };
+      mocks.strategyManager.getPortfolio.mockReturnValue({
+        goal_id: "goal-1",
+        strategies: [waitStrategy],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+
+      const waitTrigger = {
+        type: "stall_detected" as const,
+        strategy_id: waitStrategy.id,
+        details: "observation capability missing",
+      };
+      const portfolioManager = createMockPortfolioManager();
+      portfolioManager.isWaitStrategy.mockReturnValue(true);
+      portfolioManager.handleWaitStrategyExpiry.mockReturnValue({
+        status: "unknown",
+        goal_id: "goal-1",
+        strategy_id: waitStrategy.id,
+        rebalance_trigger: waitTrigger,
+      });
+      portfolioManager.rebalance.mockReturnValue({
+        triggered_by: "stall_detected",
+        adjustments: [],
+        terminated_strategies: [waitStrategy.id],
+        new_generation_needed: true,
+        timestamp: new Date().toISOString(),
+      });
+
+      const depsWithPM = { ...deps, portfolioManager: portfolioManager as any };
+      const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(result.waitExpired).toBe(true);
+      expect(result.waitObserveOnly).toBe(false);
+      expect(mocks.strategyManager.onStallDetected).toHaveBeenCalledWith("goal-1", 3, expect.any(String));
+      expect(mocks.taskLifecycle.runTaskCycle).toHaveBeenCalledOnce();
+    });
+
     it("marks waitExpired when WaitStrategy expiry does not require rebalance", async () => {
       const { deps, mocks } = createMockDeps(tmpDir);
       await mocks.stateManager.saveGoal(makeGoal());
@@ -1077,10 +1126,14 @@ describe("CoreLoop", async () => {
 
       expect(result.waitExpired).toBe(true);
       expect(result.waitStrategyId).toBe(waitStrategy.id);
+      expect(result.waitExpiryOutcome).toMatchObject({ status: "improved" });
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toBe("wait_observe_only");
+      expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
       expect(portfolioManager.rebalance).not.toHaveBeenCalled();
     });
 
-    it("uses WaitStrategy.wait_until to suppress stall checks for its primary dimension", async () => {
+    it("keeps a not-due WaitStrategy observe-only and does not generate a task", async () => {
       const { deps, mocks } = createMockDeps(tmpDir);
       await mocks.stateManager.saveGoal(makeGoal({
         dimensions: [makeDimension({ name: "dim1" })],
@@ -1104,14 +1157,213 @@ describe("CoreLoop", async () => {
 
       const portfolioManager = createMockPortfolioManager();
       portfolioManager.isWaitStrategy.mockReturnValue(true);
+      portfolioManager.handleWaitStrategyExpiry.mockReturnValue({
+        status: "not_due",
+        goal_id: "goal-1",
+        strategy_id: waitStrategy.id,
+      });
 
       const depsWithPM = { ...deps, portfolioManager: portfolioManager as any };
       const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
       const result = await loop.runOneIteration("goal-1", 0);
 
-      expect(mocks.stallDetector.isSuppressed).toHaveBeenCalledWith(waitUntil);
+      expect(result.waitSuppressed).toBe(true);
+      expect(result.waitStrategyId).toBe(waitStrategy.id);
+      expect(result.waitExpiryOutcome).toMatchObject({ status: "not_due" });
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toBe("wait_not_due");
+      expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
+    });
+
+    it("observes a due WaitStrategy even when an earlier active wait is not due", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal());
+
+      const notDueWait = {
+        id: "wait-not-due",
+        state: "active",
+        goal_id: "goal-1",
+      };
+      const dueWait = {
+        id: "wait-due",
+        state: "active",
+        goal_id: "goal-1",
+      };
+      mocks.strategyManager.getPortfolio.mockReturnValue({
+        goal_id: "goal-1",
+        strategies: [notDueWait, dueWait],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+
+      const waitTrigger = {
+        type: "stall_detected" as const,
+        strategy_id: dueWait.id,
+        details: "due wait worsened",
+      };
+      const portfolioManager = createMockPortfolioManager();
+      portfolioManager.isWaitStrategy.mockReturnValue(true);
+      portfolioManager.handleWaitStrategyExpiry
+        .mockReturnValueOnce({
+          status: "not_due",
+          goal_id: "goal-1",
+          strategy_id: notDueWait.id,
+        })
+        .mockReturnValueOnce({
+          status: "worsened",
+          goal_id: "goal-1",
+          strategy_id: dueWait.id,
+          rebalance_trigger: waitTrigger,
+        });
+
+      const depsWithPM = { ...deps, portfolioManager: portfolioManager as any };
+      const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(portfolioManager.handleWaitStrategyExpiry).toHaveBeenCalledTimes(2);
+      expect(result.waitExpired).toBe(true);
+      expect(result.waitStrategyId).toBe(dueWait.id);
+      expect(result.waitExpiryOutcome).toMatchObject({ status: "worsened" });
+      expect(portfolioManager.rebalance).toHaveBeenCalledWith("goal-1", waitTrigger);
+      expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
+    });
+
+    it("persists approval_required wait outcomes as pending runtime approvals", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal());
+
+      const waitStrategy = {
+        id: "wait-approval",
+        state: "active",
+        goal_id: "goal-1",
+      };
+      mocks.strategyManager.getPortfolio.mockReturnValue({
+        goal_id: "goal-1",
+        strategies: [waitStrategy],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+
+      const portfolioManager = createMockPortfolioManager();
+      portfolioManager.isWaitStrategy.mockReturnValue(true);
+      portfolioManager.handleWaitStrategyExpiry.mockReturnValue({
+        status: "approval_required",
+        goal_id: "goal-1",
+        strategy_id: waitStrategy.id,
+        details: "Approve external submission",
+      });
+
+      const depsWithPM = { ...deps, portfolioManager: portfolioManager as any };
+      const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      const approvalStore = new ApprovalStore(path.join(tmpDir, "runtime"));
+      const pending = await approvalStore.listPending();
+
+      expect(result.waitExpired).toBe(true);
+      expect(result.waitApprovalId).toBe(`wait-goal-1-${waitStrategy.id}`);
+      expect(pending).toHaveLength(1);
+      expect(pending[0]).toMatchObject({
+        approval_id: result.waitApprovalId,
+        goal_id: "goal-1",
+        state: "pending",
+      });
+      expect(pending[0]!.payload).toMatchObject({
+        task: {
+          id: `wait:${waitStrategy.id}`,
+          action: "wait_strategy_resume_approval",
+          description: "Approve external submission",
+        },
+        wait_strategy_id: waitStrategy.id,
+      });
+      expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
+    });
+
+    it("routes approval_required wait outcomes through the live approval broker when available", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal());
+
+      const waitStrategy = {
+        id: "wait-live-approval",
+        state: "active",
+        goal_id: "goal-1",
+      };
+      mocks.strategyManager.getPortfolio.mockReturnValue({
+        goal_id: "goal-1",
+        strategies: [waitStrategy],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+
+      const portfolioManager = createMockPortfolioManager();
+      portfolioManager.isWaitStrategy.mockReturnValue(true);
+      portfolioManager.handleWaitStrategyExpiry.mockReturnValue({
+        status: "approval_required",
+        goal_id: "goal-1",
+        strategy_id: waitStrategy.id,
+        details: "Approve external submission",
+      });
+      const waitApprovalBroker = {
+        requestApproval: vi.fn().mockResolvedValue(false),
+      };
+
+      const depsWithPM = { ...deps, portfolioManager: portfolioManager as any, waitApprovalBroker };
+      const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(result.waitApprovalId).toBe(`wait-goal-1-${waitStrategy.id}`);
+      expect(waitApprovalBroker.requestApproval).toHaveBeenCalledWith(
+        "goal-1",
+        {
+          id: `wait:${waitStrategy.id}`,
+          description: "Approve external submission",
+          action: "wait_strategy_resume_approval",
+        },
+        24 * 60 * 60 * 1000,
+        result.waitApprovalId
+      );
+      expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
+    });
+
+    it("handles active WaitStrategy before stall checks", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal({
+        dimensions: [makeDimension({ name: "dim1" })],
+      }));
+
+      const waitUntil = new Date(Date.now() + 100_000).toISOString();
+      const waitStrategy = {
+        id: "wait-strategy-1",
+        state: "active",
+        goal_id: "goal-1",
+        primary_dimension: "dim1",
+        wait_until: waitUntil,
+      };
+      mocks.strategyManager.getPortfolio.mockReturnValue({
+        goal_id: "goal-1",
+        strategies: [waitStrategy],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+      mocks.stallDetector.isSuppressed.mockReturnValue(true);
+
+      const portfolioManager = createMockPortfolioManager();
+      portfolioManager.isWaitStrategy.mockReturnValue(true);
+      portfolioManager.handleWaitStrategyExpiry.mockReturnValue({
+        status: "not_due",
+        goal_id: "goal-1",
+        strategy_id: waitStrategy.id,
+      });
+
+      const depsWithPM = { ...deps, portfolioManager: portfolioManager as any };
+      const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(portfolioManager.handleWaitStrategyExpiry).toHaveBeenCalledWith("goal-1", waitStrategy.id);
+      expect(mocks.stallDetector.isSuppressed).not.toHaveBeenCalled();
       expect(mocks.stallDetector.checkDimensionStall).not.toHaveBeenCalled();
       expect(result.waitSuppressed).toBe(true);
+      expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
     });
 
     it("portfolio rebalance errors are non-fatal", async () => {

--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -36,6 +36,7 @@ import { TrustManager } from "../../../platform/traits/trust-manager.js";
 import { ReportingEngine as RealReportingEngine } from "../../../reporting/reporting-engine.js";
 import { CapabilityDetector } from "../../../platform/observation/capability-detector.js";
 import { ApprovalStore } from "../../../runtime/store/approval-store.js";
+import { WaitDeadlineResolver, getDueWaitGoalIds } from "../../../runtime/daemon/wait-deadline-resolver.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { makeDimension, makeGoal } from "../../../../tests/helpers/fixtures.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
@@ -1232,16 +1233,46 @@ describe("CoreLoop", async () => {
       const { deps, mocks } = createMockDeps(tmpDir);
       await mocks.stateManager.saveGoal(makeGoal());
 
+      const overdueWaitUntil = new Date(Date.now() - 100_000).toISOString();
       const waitStrategy = {
         id: "wait-approval",
         state: "active",
         goal_id: "goal-1",
+        target_dimensions: ["dim1"],
+        primary_dimension: "dim1",
+        hypothesis: "Wait for external approval",
+        expected_effect: [],
+        resource_estimate: { sessions: 0, duration: { value: 0, unit: "hours" }, llm_calls: null },
+        allocation: 1,
+        created_at: new Date(Date.now() - 200_000).toISOString(),
+        started_at: new Date(Date.now() - 200_000).toISOString(),
+        completed_at: null,
+        gap_snapshot_at_start: 0.5,
+        tasks_generated: [],
+        effectiveness_score: null,
+        consecutive_stall_count: 0,
+        wait_reason: "Approval required",
+        wait_until: overdueWaitUntil,
+        measurement_plan: "Resume after approval",
+        fallback_strategy_id: null,
       };
       mocks.strategyManager.getPortfolio.mockReturnValue({
         goal_id: "goal-1",
         strategies: [waitStrategy],
         rebalance_interval: { value: 7, unit: "days" },
         last_rebalanced_at: new Date().toISOString(),
+      });
+      await mocks.stateManager.writeRaw("strategies/goal-1/portfolio.json", {
+        goal_id: "goal-1",
+        strategies: [waitStrategy],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+      await mocks.stateManager.writeRaw(`strategies/goal-1/wait-meta/${waitStrategy.id}.json`, {
+        schema_version: 1,
+        wait_until: overdueWaitUntil,
+        conditions: [{ type: "time_until", until: overdueWaitUntil }],
+        resume_plan: { action: "complete_wait" },
       });
 
       const portfolioManager = createMockPortfolioManager();
@@ -1259,6 +1290,8 @@ describe("CoreLoop", async () => {
 
       const approvalStore = new ApprovalStore(path.join(tmpDir, "runtime"));
       const pending = await approvalStore.listPending();
+      const metadata = await mocks.stateManager.readRaw(`strategies/goal-1/wait-meta/${waitStrategy.id}.json`) as Record<string, unknown>;
+      const resolution = await new WaitDeadlineResolver(mocks.stateManager).resolve(["goal-1"]);
 
       expect(result.waitExpired).toBe(true);
       expect(result.waitApprovalId).toBe(`wait-goal-1-${waitStrategy.id}`);
@@ -1276,6 +1309,19 @@ describe("CoreLoop", async () => {
         },
         wait_strategy_id: waitStrategy.id,
       });
+      expect(Date.parse(metadata["next_observe_at"] as string)).toBeGreaterThan(Date.now());
+      expect(metadata["approval_pending"]).toMatchObject({
+        approval_id: result.waitApprovalId,
+      });
+      expect(metadata["latest_observation"]).toMatchObject({
+        status: "pending",
+        evidence: {
+          approval_pending: true,
+          approval_id: result.waitApprovalId,
+        },
+        resume_hint: "waiting_for_approval",
+      });
+      expect(getDueWaitGoalIds(resolution)).toEqual([]);
       expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
     });
 

--- a/src/orchestrator/loop/__tests__/core-loop-types.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-types.test.ts
@@ -29,16 +29,29 @@ describe("LoopIterationResult — wait telemetry fields (Gap 6)", () => {
     expect(result.waitSuppressed).toBeUndefined();
     expect(result.waitExpired).toBeUndefined();
     expect(result.waitStrategyId).toBeUndefined();
+    expect(result.waitObserveOnly).toBeUndefined();
+    expect(result.waitExpiryOutcome).toBeUndefined();
+    expect(result.waitApprovalId).toBeUndefined();
   });
 
-  it("combines all three wait telemetry fields", () => {
+  it("combines wait telemetry fields", () => {
     const result: LoopIterationResult = makeEmptyIterationResult("goal-1", 1, {
       waitSuppressed: false,
       waitExpired: true,
       waitStrategyId: "ws-123",
+      waitObserveOnly: true,
+      waitExpiryOutcome: {
+        status: "improved",
+        goal_id: "goal-1",
+        strategy_id: "ws-123",
+      },
+      waitApprovalId: "wait-goal-1-ws-123",
     });
     expect(result.waitSuppressed).toBe(false);
     expect(result.waitExpired).toBe(true);
     expect(result.waitStrategyId).toBe("ws-123");
+    expect(result.waitObserveOnly).toBe(true);
+    expect(result.waitExpiryOutcome?.status).toBe("improved");
+    expect(result.waitApprovalId).toBe("wait-goal-1-ws-123");
   });
 });

--- a/src/orchestrator/loop/__tests__/core-loop.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop.test.ts
@@ -107,6 +107,11 @@ vi.mock("../core-loop/preparation.js", () => ({
 vi.mock("../core-loop/task-cycle.js", () => ({
   checkCompletionAndMilestones: vi.fn().mockResolvedValue(undefined),
   detectStallsAndRebalance: vi.fn().mockResolvedValue(undefined),
+  evaluateWaitStrategiesForObserveOnly: vi.fn().mockResolvedValue({
+    observeOnly: false,
+    newGenerationNeeded: false,
+    outcome: null,
+  }),
   checkDependencyBlock: vi.fn().mockReturnValue(false),
   runTaskCycleWithContext: vi.fn().mockResolvedValue(true),
 }));

--- a/src/orchestrator/loop/core-loop.ts
+++ b/src/orchestrator/loop/core-loop.ts
@@ -30,6 +30,7 @@ export type {
   DriveScorerModule,
   ExecutionSummaryParams,
   ReportingEngine,
+  WaitApprovalBroker,
   LoopConfig,
   ResolvedLoopConfig,
   CoreLoopDeps,
@@ -433,6 +434,10 @@ export class CoreLoop {
    */
   setTimeHorizonEngine(engine: ITimeHorizonEngine): void {
     this.timeHorizonEngine = engine;
+  }
+
+  setWaitApprovalBroker(broker: CoreLoopDeps["waitApprovalBroker"]): void {
+    (this.deps as CoreLoopDeps).waitApprovalBroker = broker;
   }
 
   /**

--- a/src/orchestrator/loop/core-loop/contracts.ts
+++ b/src/orchestrator/loop/core-loop/contracts.ts
@@ -89,6 +89,15 @@ export interface ReportingEngine {
   saveReport(report: unknown): void;
 }
 
+export interface WaitApprovalBroker {
+  requestApproval(
+    goalId: string,
+    task: { id: string; description: string; action: string },
+    timeoutMs?: number,
+    approvalId?: string
+  ): Promise<boolean>;
+}
+
 // ─── Config ───
 
 /**
@@ -258,6 +267,8 @@ export interface CoreLoopDeps extends ObservationDeps, TreeDeps, StallDeps, Task
   toolRegistry?: ToolRegistry;
   /** Optional bounded agentloop runner for core phases. */
   corePhaseRunner?: CorePhaseRunner;
+  /** Optional live approval broker for wait/resume approvals. */
+  waitApprovalBroker?: WaitApprovalBroker;
   /** Optional policy registry for core phase runtime. */
   corePhasePolicyRegistry?: CorePhasePolicyRegistry;
   /** Optional deterministic decision engine for iteration/run control. */

--- a/src/orchestrator/loop/core-loop/iteration-kernel.ts
+++ b/src/orchestrator/loop/core-loop/iteration-kernel.ts
@@ -15,6 +15,7 @@ import {
 import {
   checkCompletionAndMilestones,
   detectStallsAndRebalance,
+  evaluateWaitStrategiesForObserveOnly,
   checkDependencyBlock,
   runTaskCycleWithContext,
   type LoopCallbacks,
@@ -204,6 +205,20 @@ export class CoreIterationKernel {
         .map((g: any) => `${g.dimension_name}=${g.normalized_weighted_gap.toFixed(2)}`)
         .join(", ")}`
     );
+
+    const waitObservationDecision = await runPhase("wait-observation", () =>
+      evaluateWaitStrategiesForObserveOnly(ctx, goalId, goal, result)
+    );
+    if (waitObservationDecision.observeOnly) {
+      result.skipped = true;
+      result.skipReason =
+        waitObservationDecision.outcome?.status === "not_due"
+          ? "wait_not_due"
+          : "wait_observe_only";
+      await generateLoopReport(goalId, loopIndex, result, goal, this.deps.deps.reportingEngine, this.deps.logger);
+      result.elapsedMs = Date.now() - startTime;
+      return result;
+    }
 
     let driveScores: DriveScore[] = [];
     let highDissatisfactionDimensions: string[] = [];

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -34,6 +34,9 @@ import { buildWaitApprovalId } from "../../strategy/portfolio-rebalance.js";
 
 // ─── Phase 5 ───
 
+const WAIT_APPROVAL_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+const WAIT_APPROVAL_REMINDER_MS = 15 * 60 * 1000;
+
 function resolveGoalWorkspacePath(goal: Goal): string | undefined {
   const constraint = goal.constraints.find((entry) => entry.startsWith("workspace_path:"));
   const workspacePath = constraint?.slice("workspace_path:".length).trim();
@@ -543,7 +546,7 @@ export async function evaluateWaitStrategiesForObserveOnly(
       result.waitExpired = true;
 
       if (waitOutcome.status === "approval_required") {
-        result.waitApprovalId = await persistWaitApprovalPending(ctx, goalId, strategy.id, waitOutcome);
+        result.waitApprovalId = await persistWaitApprovalPending(ctx, goalId, strategy, waitOutcome);
       }
 
       const waitTrigger = waitOutcome.rebalance_trigger ?? null;
@@ -578,13 +581,16 @@ export async function evaluateWaitStrategiesForObserveOnly(
 async function persistWaitApprovalPending(
   ctx: PhaseCtx,
   goalId: string,
-  strategyId: string,
+  strategy: { id: string; wait_until?: unknown },
   outcome: WaitExpiryOutcome
 ): Promise<string | undefined> {
+  const strategyId = strategy.id;
   try {
     const now = Date.now();
     const approvalId = buildWaitApprovalId(goalId, strategyId);
-    const timeoutMs = 24 * 60 * 60 * 1000;
+    const timeoutMs = WAIT_APPROVAL_TIMEOUT_MS;
+    const nextObserveAt = new Date(now + WAIT_APPROVAL_REMINDER_MS).toISOString();
+    const expiresAt = new Date(now + timeoutMs).toISOString();
     const task = {
       id: `wait:${strategyId}`,
       description: outcome.details ?? "WaitStrategy requires approval before continuing",
@@ -599,6 +605,7 @@ async function persistWaitApprovalPending(
           error: err instanceof Error ? err.message : String(err),
         });
       });
+      await postponeWaitObservationForApproval(ctx, goalId, strategy, approvalId, nextObserveAt, expiresAt);
       return approvalId;
     }
 
@@ -622,6 +629,7 @@ async function persistWaitApprovalPending(
         wait_outcome: outcome,
       },
     });
+    await postponeWaitObservationForApproval(ctx, goalId, strategy, approvalId, nextObserveAt, expiresAt);
     return approvalId;
   } catch (err) {
     ctx.logger?.warn("CoreLoop: failed to persist wait approval request", {
@@ -630,6 +638,60 @@ async function persistWaitApprovalPending(
       error: err instanceof Error ? err.message : String(err),
     });
     return undefined;
+  }
+}
+
+async function postponeWaitObservationForApproval(
+  ctx: PhaseCtx,
+  goalId: string,
+  strategy: { id: string; wait_until?: unknown },
+  approvalId: string,
+  nextObserveAt: string,
+  expiresAt: string
+): Promise<void> {
+  try {
+    const path = `strategies/${goalId}/wait-meta/${strategy.id}.json`;
+    const raw = await ctx.deps.stateManager.readRaw(path);
+    const metadata = raw && typeof raw === "object" ? raw as Record<string, unknown> : {};
+    const waitUntil = typeof metadata["wait_until"] === "string"
+      ? metadata["wait_until"]
+      : typeof strategy.wait_until === "string"
+        ? strategy.wait_until
+        : nextObserveAt;
+    const conditions = Array.isArray(metadata["conditions"]) && metadata["conditions"].length > 0
+      ? metadata["conditions"]
+      : [{ type: "time_until", until: waitUntil }];
+
+    await ctx.deps.stateManager.writeRaw(path, {
+      ...metadata,
+      schema_version: 1,
+      wait_until: waitUntil,
+      conditions,
+      resume_plan: metadata["resume_plan"] ?? { action: "complete_wait" },
+      next_observe_at: nextObserveAt,
+      latest_observation: {
+        status: "pending",
+        evidence: {
+          approval_pending: true,
+          approval_id: approvalId,
+        },
+        next_observe_at: nextObserveAt,
+        confidence: 1,
+        resume_hint: "waiting_for_approval",
+      },
+      approval_pending: {
+        approval_id: approvalId,
+        requested_at: new Date().toISOString(),
+        next_reminder_at: nextObserveAt,
+        expires_at: expiresAt,
+      },
+    });
+  } catch (err) {
+    ctx.logger?.warn("CoreLoop: failed to postpone wait observation for approval", {
+      goalId,
+      strategyId: strategy.id,
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -8,6 +8,7 @@ import type { Goal } from "../../../base/types/goal.js";
 import type { GapVector, GapHistoryEntry } from "../../../base/types/gap.js";
 import type { StallReport } from "../../../base/types/stall.js";
 import type { DriveScore } from "../../../base/types/drive.js";
+import type { WaitExpiryOutcome } from "../../../base/types/strategy.js";
 import { KnowledgeGraph } from "../../../platform/knowledge/knowledge-graph.js";
 import { loadDreamActivationState, mergeUniqueKnowledgeEntries } from "../../../platform/dream/dream-activation.js";
 import {
@@ -28,6 +29,8 @@ import {
 } from "../../execution/context/context-builder.js";
 import type { CapabilityAcquisitionOutcome } from "./capability.js";
 import type { CoreLoopEvidenceLedger } from "./evidence-ledger.js";
+import { ApprovalStore } from "../../../runtime/store/approval-store.js";
+import { buildWaitApprovalId } from "../../strategy/portfolio-rebalance.js";
 
 // ─── Phase 5 ───
 
@@ -224,7 +227,7 @@ export async function detectStallsAndRebalance(
 
     // Portfolio: check rebalance after stall detection
     if (ctx.deps.portfolioManager) {
-      await rebalancePortfolio(ctx, goalId, goal, result);
+      await rebalancePortfolio(ctx, goalId, goal);
     }
   } catch (err) {
     ctx.logger?.warn("CoreLoop: stall detection failed (non-fatal)", { error: err instanceof Error ? err.message : String(err) });
@@ -421,12 +424,11 @@ async function checkGlobalStall(
   await applyStallAction(ctx, goalId, goal, firstDimHistory, globalStall, 1, firstDimName, result, "global ", stallActionHints);
 }
 
-/** Portfolio rebalance: check for rebalance triggers and handle wait strategy expiry. */
+/** Portfolio rebalance: check for normal rebalance triggers after stall detection. */
 async function rebalancePortfolio(
   ctx: PhaseCtx,
   goalId: string,
-  goal: Goal,
-  result?: LoopIterationResult
+  goal: Goal
 ): Promise<void> {
   if (!ctx.deps.portfolioManager) return;
   try {
@@ -439,30 +441,6 @@ async function rebalancePortfolio(
     }
   } catch {
     // Portfolio rebalance errors are non-fatal
-  }
-
-  try {
-    const portfolio = await ctx.deps.strategyManager.getPortfolio(goalId);
-    if (portfolio) {
-      for (const strategy of portfolio.strategies) {
-        if (ctx.deps.portfolioManager.isWaitStrategy(strategy)) {
-          const waitOutcome = await ctx.deps.portfolioManager.handleWaitStrategyExpiry(
-            goalId,
-            strategy.id
-          );
-          const waitTrigger = waitOutcome?.rebalance_trigger ?? null;
-          if (waitOutcome && waitOutcome.status !== "not_due" && result) {
-            result.waitExpired = true;
-            result.waitStrategyId = strategy.id;
-          }
-          if (waitTrigger) {
-            await ctx.deps.portfolioManager.rebalance(goalId, waitTrigger);
-          }
-        }
-      }
-    }
-  } catch {
-    // WaitStrategy expiry errors are non-fatal
   }
 }
 
@@ -505,6 +483,154 @@ export interface TaskGenerationHints {
 
 export interface StallActionHints {
   recommendedAction?: "continue" | "refine" | "pivot";
+}
+
+export interface WaitStrategyObservationDecision {
+  observeOnly: boolean;
+  newGenerationNeeded: boolean;
+  outcome: WaitExpiryOutcome | null;
+}
+
+interface PendingWaitOutcome {
+  strategyId: string;
+  outcome: WaitExpiryOutcome;
+}
+
+/**
+ * Evaluate active WaitStrategies before task generation. A due or pending wait
+ * is an observe-only iteration: the loop records status and returns without
+ * handing work to AgentLoop.
+ */
+export async function evaluateWaitStrategiesForObserveOnly(
+  ctx: PhaseCtx,
+  goalId: string,
+  goal: Goal,
+  result: LoopIterationResult
+): Promise<WaitStrategyObservationDecision> {
+  if (!ctx.deps.portfolioManager) {
+    return { observeOnly: false, newGenerationNeeded: false, outcome: null };
+  }
+
+  try {
+    const portfolio = await ctx.deps.strategyManager.getPortfolio(goalId);
+    if (!portfolio) {
+      return { observeOnly: false, newGenerationNeeded: false, outcome: null };
+    }
+
+    let firstNotDue: PendingWaitOutcome | null = null;
+
+    for (const strategy of portfolio.strategies) {
+      if (strategy.state !== "active" || !ctx.deps.portfolioManager.isWaitStrategy(strategy)) {
+        continue;
+      }
+
+      const waitOutcome = await ctx.deps.portfolioManager.handleWaitStrategyExpiry(
+        goalId,
+        strategy.id
+      );
+      if (!waitOutcome) {
+        continue;
+      }
+
+      if (waitOutcome.status === "not_due") {
+        firstNotDue ??= { strategyId: strategy.id, outcome: waitOutcome };
+        continue;
+      }
+
+      result.waitStrategyId = strategy.id;
+      result.waitExpiryOutcome = waitOutcome;
+      result.waitObserveOnly = true;
+      result.waitExpired = true;
+
+      if (waitOutcome.status === "approval_required") {
+        result.waitApprovalId = await persistWaitApprovalPending(ctx, goalId, strategy.id, waitOutcome);
+      }
+
+      const waitTrigger = waitOutcome.rebalance_trigger ?? null;
+      if (waitTrigger) {
+        const rebalanceResult = await ctx.deps.portfolioManager.rebalance(goalId, waitTrigger);
+        if (rebalanceResult.new_generation_needed) {
+          await ctx.deps.strategyManager.onStallDetected(goalId, 3, goal.origin ?? "general");
+          result.waitObserveOnly = false;
+          return { observeOnly: false, newGenerationNeeded: true, outcome: waitOutcome };
+        }
+      }
+      return { observeOnly: true, newGenerationNeeded: false, outcome: waitOutcome };
+    }
+
+    if (firstNotDue) {
+      result.waitStrategyId = firstNotDue.strategyId;
+      result.waitExpiryOutcome = firstNotDue.outcome;
+      result.waitObserveOnly = true;
+      result.waitSuppressed = true;
+      return { observeOnly: true, newGenerationNeeded: false, outcome: firstNotDue.outcome };
+    }
+  } catch (err) {
+    ctx.logger?.warn("CoreLoop: wait observation failed (non-fatal)", {
+      goalId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  return { observeOnly: false, newGenerationNeeded: false, outcome: null };
+}
+
+async function persistWaitApprovalPending(
+  ctx: PhaseCtx,
+  goalId: string,
+  strategyId: string,
+  outcome: WaitExpiryOutcome
+): Promise<string | undefined> {
+  try {
+    const now = Date.now();
+    const approvalId = buildWaitApprovalId(goalId, strategyId);
+    const timeoutMs = 24 * 60 * 60 * 1000;
+    const task = {
+      id: `wait:${strategyId}`,
+      description: outcome.details ?? "WaitStrategy requires approval before continuing",
+      action: "wait_strategy_resume_approval",
+    };
+
+    if (ctx.deps.waitApprovalBroker) {
+      void ctx.deps.waitApprovalBroker.requestApproval(goalId, task, timeoutMs, approvalId).catch((err) => {
+        ctx.logger?.warn("CoreLoop: wait approval broker request failed", {
+          goalId,
+          strategyId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+      return approvalId;
+    }
+
+    const baseDir = typeof ctx.deps.stateManager.getBaseDir === "function"
+      ? ctx.deps.stateManager.getBaseDir()
+      : null;
+    if (!baseDir) return undefined;
+
+    const approvalStore = new ApprovalStore(path.join(baseDir, "runtime"));
+    await approvalStore.savePending({
+      approval_id: approvalId,
+      goal_id: goalId,
+      request_envelope_id: approvalId,
+      correlation_id: approvalId,
+      state: "pending",
+      created_at: now,
+      expires_at: now + timeoutMs,
+      payload: {
+        task,
+        wait_strategy_id: strategyId,
+        wait_outcome: outcome,
+      },
+    });
+    return approvalId;
+  } catch (err) {
+    ctx.logger?.warn("CoreLoop: failed to persist wait approval request", {
+      goalId,
+      strategyId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
 }
 
 /** Collect context, run task cycle, handle capability acquisition,

--- a/src/orchestrator/loop/loop-result-types.ts
+++ b/src/orchestrator/loop/loop-result-types.ts
@@ -2,6 +2,7 @@ import type { DriveScore } from "../../base/types/drive.js";
 import type { CompletionJudgment } from "../../base/types/satisficing.js";
 import type { StallAnalysis, StallReport } from "../../base/types/stall.js";
 import type { TransferCandidate } from "../../base/types/cross-portfolio.js";
+import type { WaitExpiryOutcome } from "../../base/types/strategy.js";
 import type { TaskCycleResult } from "../execution/task/task-execution-types.js";
 import type { VerificationLayer1Result } from "./verification-layer1.js";
 import type { CorePhaseKind } from "../execution/agent-loop/core-phase-runner.js";
@@ -64,6 +65,12 @@ export interface LoopIterationResult {
   waitExpired?: boolean;
   /** Strategy ID of the active WaitStrategy, if any. */
   waitStrategyId?: string;
+  /** True when the iteration observed wait state and intentionally skipped task generation. */
+  waitObserveOnly?: boolean;
+  /** Full wait expiry decision used by CoreLoop and portfolio rebalance. */
+  waitExpiryOutcome?: WaitExpiryOutcome;
+  /** Durable approval request id created when wait resume requires approval. */
+  waitApprovalId?: string;
   /** Agentic core phase results collected during the iteration. */
   corePhaseResults?: CorePhaseIterationResult[];
   /** Deterministic scheduler directive for the next iteration of the same goal. */

--- a/src/orchestrator/strategy/__tests__/portfolio-manager.test.ts
+++ b/src/orchestrator/strategy/__tests__/portfolio-manager.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { PortfolioManager } from "../portfolio-manager.js";
 import type { Strategy, WaitStrategy, Portfolio } from "../../../base/types/strategy.js";
 import type { StrategyManager } from "../../strategy-manager.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { RebalanceTrigger } from "../../../base/types/portfolio.js";
+import { ApprovalStore } from "../../../runtime/store/approval-store.js";
+import { buildWaitApprovalId } from "../portfolio-rebalance.js";
+import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 
 // ─── Helpers ───
 
@@ -79,6 +84,7 @@ function createMockStateManager(): StateManager {
     readRaw: vi.fn().mockResolvedValue(null),
     writeRaw: vi.fn().mockResolvedValue(undefined),
     loadGoalState: vi.fn().mockReturnValue(null),
+    getBaseDir: vi.fn().mockReturnValue(""),
   } as unknown as StateManager;
 }
 
@@ -856,6 +862,140 @@ describe("PortfolioManager", () => {
       expect(result!.rebalance_trigger?.type).toBe("stall_detected");
       expect(result!.rebalance_trigger?.strategy_id).toBe("ws1");
       expect(mockStrategyManager.updateState).toHaveBeenCalledWith("ws1", "terminated");
+    });
+
+    it("returns unknown with a rebalance trigger when required observation capability is missing", async () => {
+      const wait = makeWaitStrategy({
+        id: "ws1",
+        state: "active",
+        wait_until: new Date(Date.now() - 100_000).toISOString(),
+        gap_snapshot_at_start: 0.5,
+        primary_dimension: "quality",
+      });
+      const portfolio = makePortfolio([wait]);
+      (mockStrategyManager.getPortfolio as ReturnType<typeof vi.fn>).mockReturnValue(portfolio);
+      (mockStateManager.readRaw as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+        if (path === "strategies/goal-1/wait-meta/ws1.json") {
+          return {
+            schema_version: 1,
+            wait_until: wait.wait_until,
+            conditions: [{ type: "time_until", until: wait.wait_until }],
+            resume_plan: { action: "complete_wait" },
+            required_capabilities: ["kaggle_leaderboard_read"],
+          };
+        }
+        if (path === "capability_registry.json") {
+          return {
+            capabilities: [],
+            last_checked: new Date().toISOString(),
+          };
+        }
+        return { quality: 0.5 };
+      });
+
+      const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
+
+      expect(result).toMatchObject({
+        status: "unknown",
+        strategy_id: "ws1",
+        rebalance_trigger: {
+          type: "stall_detected",
+          strategy_id: "ws1",
+        },
+      });
+      expect(result?.details).toContain("kaggle_leaderboard_read");
+      expect(mockStrategyManager.updateState).not.toHaveBeenCalled();
+    });
+
+    it("returns approval_required when wait metadata requires an unapproved capability", async () => {
+      const wait = makeWaitStrategy({
+        id: "ws1",
+        state: "active",
+        wait_until: new Date(Date.now() - 100_000).toISOString(),
+        gap_snapshot_at_start: 0.5,
+        primary_dimension: "quality",
+      });
+      const portfolio = makePortfolio([wait]);
+      (mockStrategyManager.getPortfolio as ReturnType<typeof vi.fn>).mockReturnValue(portfolio);
+      (mockStateManager.readRaw as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+        if (path === "strategies/goal-1/wait-meta/ws1.json") {
+          return {
+            schema_version: 1,
+            wait_until: wait.wait_until,
+            conditions: [{ type: "time_until", until: wait.wait_until }],
+            resume_plan: { action: "complete_wait" },
+            approval_policy: { required: true, capability: "kaggle_submit_approved" },
+          };
+        }
+        if (path === "capability_registry.json") {
+          return {
+            capabilities: [],
+            last_checked: new Date().toISOString(),
+          };
+        }
+        return { quality: 0.5 };
+      });
+
+      const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
+
+      expect(result).toMatchObject({ status: "approval_required", strategy_id: "ws1" });
+      expect(result?.details).toContain("kaggle_submit_approved");
+      expect(mockStrategyManager.updateState).not.toHaveBeenCalled();
+    });
+
+    it("continues expiry handling when a required wait approval is already approved", async () => {
+      const tmpDir = makeTempDir();
+      try {
+        const wait = makeWaitStrategy({
+          id: "ws1",
+          state: "active",
+          wait_until: new Date(Date.now() - 100_000).toISOString(),
+          gap_snapshot_at_start: 0.8,
+          primary_dimension: "quality",
+        });
+        const portfolio = makePortfolio([wait]);
+        const approvalId = buildWaitApprovalId("goal-1", wait.id);
+        const approvalStore = new ApprovalStore(path.join(tmpDir, "runtime"));
+        await approvalStore.saveResolved({
+          approval_id: approvalId,
+          goal_id: "goal-1",
+          request_envelope_id: approvalId,
+          correlation_id: approvalId,
+          state: "approved",
+          created_at: Date.now() - 10_000,
+          expires_at: Date.now() + 100_000,
+          resolved_at: Date.now(),
+          payload: { task: { id: `wait:${wait.id}`, description: "approved", action: "wait_strategy_resume_approval" } },
+        });
+
+        (mockStrategyManager.getPortfolio as ReturnType<typeof vi.fn>).mockReturnValue(portfolio);
+        (mockStateManager.getBaseDir as ReturnType<typeof vi.fn>).mockReturnValue(tmpDir);
+        (mockStateManager.readRaw as ReturnType<typeof vi.fn>).mockImplementation((rawPath: string) => {
+          if (rawPath === "strategies/goal-1/wait-meta/ws1.json") {
+            return {
+              schema_version: 1,
+              wait_until: wait.wait_until,
+              conditions: [{ type: "time_until", until: wait.wait_until }],
+              resume_plan: { action: "complete_wait" },
+              approval_policy: { required: true, capability: "kaggle_submit_approved" },
+            };
+          }
+          if (rawPath === "capability_registry.json") {
+            return {
+              capabilities: [],
+              last_checked: new Date().toISOString(),
+            };
+          }
+          return { quality: 0.4 };
+        });
+
+        const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1");
+
+        expect(result).toMatchObject({ status: "improved", strategy_id: "ws1" });
+        expect(mockStrategyManager.updateState).toHaveBeenCalledWith("ws1", "completed");
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+      }
     });
 
     it("returns null for non-existent strategy", async () => {

--- a/src/orchestrator/strategy/portfolio-manager.ts
+++ b/src/orchestrator/strategy/portfolio-manager.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { StrategyManager } from "./strategy-manager.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { StrategySchema, parseStrategy } from "../../base/types/strategy.js";
@@ -21,6 +22,7 @@ import {
   getCurrentGapForDimension as _getCurrentGapForDimension,
   calculateGapDeltaForStrategy as _calculateGapDeltaForStrategy,
 } from "./portfolio-rebalance.js";
+import { ApprovalStore } from "../../runtime/store/approval-store.js";
 import {
   isWaitStrategy,
   checkStrategyTermination,
@@ -397,7 +399,13 @@ export class PortfolioManager {
       (gId, dim) => this.getCurrentGapForDimension(gId, dim),
       (sId, state) => this.strategyManager.updateState(sId, state as StrategyState),
       async (gId) => (await this.strategyManager.getPortfolio(gId))?.strategies ?? [],
-      (gId, sId) => this.stateManager.readRaw(`strategies/${gId}/wait-meta/${sId}.json`)
+      (gId, sId) => this.stateManager.readRaw(`strategies/${gId}/wait-meta/${sId}.json`),
+      () => this.stateManager.readRaw("capability_registry.json"),
+      (approvalId) => {
+        const getBaseDir = this.stateManager.getBaseDir;
+        if (typeof getBaseDir !== "function") return null;
+        return new ApprovalStore(path.join(getBaseDir.call(this.stateManager), "runtime")).load(approvalId);
+      }
     );
   }
 

--- a/src/orchestrator/strategy/portfolio-rebalance.ts
+++ b/src/orchestrator/strategy/portfolio-rebalance.ts
@@ -19,9 +19,11 @@ import {
   normalizeWaitMetadata,
   resolveWaitNextObserveAt,
   type Strategy,
+  type WaitMetadata,
   type WaitExpiryOutcome,
   type WaitStrategy,
 } from "../../base/types/strategy.js";
+import { CapabilityRegistrySchema } from "../../base/types/capability.js";
 
 /**
  * Get the current gap value for a specific dimension of a goal.
@@ -297,7 +299,9 @@ export async function handleWaitStrategyExpiry(
   getGap: (goalId: string, dimension: string) => number | null | Promise<number | null>,
   updateState: (strategyId: string, state: string) => void | Promise<void>,
   getPortfolioStrategies: (goalId: string) => Strategy[] | Promise<Strategy[]>,
-  getWaitMetadata?: (goalId: string, strategyId: string) => unknown | null | Promise<unknown | null>
+  getWaitMetadata?: (goalId: string, strategyId: string) => unknown | null | Promise<unknown | null>,
+  getCapabilityRegistry?: () => unknown | null | Promise<unknown | null>,
+  getWaitApprovalRecord?: (approvalId: string) => unknown | null | Promise<unknown | null>
 ): Promise<WaitExpiryOutcome> {
   if (!isWaitStrategy(strategy)) {
     return {
@@ -323,6 +327,25 @@ export async function handleWaitStrategyExpiry(
       goal_id: goalId,
       strategy_id: strategyId,
       details: `WaitStrategy is not due until ${nextObserveAt ?? waitStrategy.wait_until}`,
+    };
+  }
+
+  const approvalOutcome = await approvalOutcomeFromWaitMetadata(goalId, strategyId, metadata, getCapabilityRegistry, getWaitApprovalRecord);
+  if (approvalOutcome) return approvalOutcome;
+
+  const missingCapabilities = await missingRequiredCapabilities(metadata, getCapabilityRegistry);
+  if (missingCapabilities.length > 0) {
+    const details = `WaitStrategy observation capability missing: ${missingCapabilities.join(", ")}`;
+    return {
+      status: "unknown",
+      goal_id: goalId,
+      strategy_id: strategyId,
+      details,
+      rebalance_trigger: {
+        type: "stall_detected",
+        strategy_id: strategyId,
+        details,
+      },
     };
   }
 
@@ -394,6 +417,105 @@ export async function handleWaitStrategyExpiry(
     details: rebalanceTrigger.details,
     rebalance_trigger: rebalanceTrigger,
   };
+}
+
+async function approvalOutcomeFromWaitMetadata(
+  goalId: string,
+  strategyId: string,
+  metadata: WaitMetadata,
+  getCapabilityRegistry?: () => unknown | null | Promise<unknown | null>,
+  getWaitApprovalRecord?: (approvalId: string) => unknown | null | Promise<unknown | null>
+): Promise<WaitExpiryOutcome | null> {
+  const resumePlan = metadata.resume_plan;
+  if (resumePlan.action === "request_approval") {
+    const existingApproval = await getApprovedWaitApproval(goalId, strategyId, getWaitApprovalRecord);
+    if (existingApproval) return null;
+    return {
+      status: "approval_required",
+      goal_id: goalId,
+      strategy_id: strategyId,
+      details: resumePlan.reason ?? "WaitStrategy requires approval before continuing",
+    };
+  }
+
+  const approvalPolicy = asRecord(metadata.approval_policy);
+  if (!approvalPolicy) return null;
+
+  const required = approvalPolicy["required"] === true || approvalPolicy["requires_approval"] === true;
+  if (!required) return null;
+
+  const existingApproval = await getApprovedWaitApproval(goalId, strategyId, getWaitApprovalRecord);
+  if (existingApproval) return null;
+
+  const capabilityName = typeof approvalPolicy["capability"] === "string"
+    ? approvalPolicy["capability"]
+    : typeof approvalPolicy["approved_capability"] === "string"
+      ? approvalPolicy["approved_capability"]
+      : null;
+  if (capabilityName && await hasAvailableCapability(capabilityName, getCapabilityRegistry)) {
+    return null;
+  }
+
+  return {
+    status: "approval_required",
+    goal_id: goalId,
+    strategy_id: strategyId,
+    details: capabilityName
+      ? `WaitStrategy requires approved capability: ${capabilityName}`
+      : "WaitStrategy requires approval before continuing",
+  };
+}
+
+async function getApprovedWaitApproval(
+  goalId: string,
+  strategyId: string,
+  getWaitApprovalRecord?: (approvalId: string) => unknown | null | Promise<unknown | null>
+): Promise<boolean> {
+  if (!getWaitApprovalRecord) return false;
+  const record = await getWaitApprovalRecord(buildWaitApprovalId(goalId, strategyId));
+  if (!record || typeof record !== "object") return false;
+  return (record as Record<string, unknown>)["state"] === "approved";
+}
+
+async function missingRequiredCapabilities(
+  metadata: WaitMetadata,
+  getCapabilityRegistry?: () => unknown | null | Promise<unknown | null>
+): Promise<string[]> {
+  const raw = (metadata as Record<string, unknown>)["required_capabilities"];
+  if (!Array.isArray(raw) || raw.length === 0) return [];
+
+  const missing: string[] = [];
+  for (const item of raw) {
+    const name = typeof item === "string"
+      ? item
+      : asRecord(item) && typeof asRecord(item)?.["name"] === "string"
+        ? asRecord(item)?.["name"] as string
+        : null;
+    if (!name) continue;
+    if (!await hasAvailableCapability(name, getCapabilityRegistry)) missing.push(name);
+  }
+  return missing;
+}
+
+async function hasAvailableCapability(
+  capabilityName: string,
+  getCapabilityRegistry?: () => unknown | null | Promise<unknown | null>
+): Promise<boolean> {
+  if (!getCapabilityRegistry) return false;
+  const raw = await getCapabilityRegistry();
+  const parsed = CapabilityRegistrySchema.safeParse(raw);
+  if (!parsed.success) return false;
+  return parsed.data.capabilities.some(
+    (capability) => capability.name === capabilityName && capability.status === "available"
+  );
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? value as Record<string, unknown> : null;
+}
+
+export function buildWaitApprovalId(goalId: string, strategyId: string): string {
+  return `wait-${encodeURIComponent(goalId)}-${encodeURIComponent(strategyId)}`;
 }
 
 export function rebalanceTriggerFromWaitExpiryOutcome(

--- a/src/runtime/__tests__/wait-deadline-resolver.test.ts
+++ b/src/runtime/__tests__/wait-deadline-resolver.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { StateManager } from "../../base/state/state-manager.js";
-import { WaitDeadlineResolver, clampIntervalToNextWaitDeadline } from "../daemon/wait-deadline-resolver.js";
+import { WaitDeadlineResolver, clampIntervalToNextWaitDeadline, getDueWaitGoalIds } from "../daemon/wait-deadline-resolver.js";
 import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
 
 let tempDir: string;
@@ -133,6 +133,40 @@ describe("WaitDeadlineResolver", () => {
     const resolution = await new WaitDeadlineResolver(stateManager).resolve(["goal-1"]);
 
     expect(resolution.next_observe_at).toBe("2026-04-24T12:30:00.000Z");
+  });
+
+  it("uses approval-pending next_observe_at instead of immediately redueing an expired wait", async () => {
+    await stateManager.writeRaw("strategies/goal-1/portfolio.json", {
+      goal_id: "goal-1",
+      strategies: [makeActiveWaitStrategy({ wait_until: "2026-04-24T12:00:00.000Z" })],
+      rebalance_interval: { value: 1, unit: "hours" },
+      last_rebalanced_at: "2026-04-24T12:00:00.000Z",
+    });
+    await stateManager.writeRaw("strategies/goal-1/wait-meta/wait-1.json", {
+      schema_version: 1,
+      wait_until: "2026-04-24T12:00:00.000Z",
+      conditions: [{ type: "time_until", until: "2026-04-24T12:00:00.000Z" }],
+      next_observe_at: "2026-04-24T12:15:00.000Z",
+      latest_observation: {
+        status: "pending",
+        evidence: { approval_pending: true, approval_id: "wait-goal-1-wait-1" },
+        next_observe_at: "2026-04-24T12:15:00.000Z",
+        confidence: 1,
+        resume_hint: "waiting_for_approval",
+      },
+      approval_pending: {
+        approval_id: "wait-goal-1-wait-1",
+        requested_at: "2026-04-24T12:00:00.000Z",
+        next_reminder_at: "2026-04-24T12:15:00.000Z",
+        expires_at: "2026-04-25T12:00:00.000Z",
+      },
+      resume_plan: { action: "complete_wait" },
+    });
+
+    const resolution = await new WaitDeadlineResolver(stateManager).resolve(["goal-1"]);
+
+    expect(resolution.next_observe_at).toBe("2026-04-24T12:15:00.000Z");
+    expect(getDueWaitGoalIds(resolution, Date.parse("2026-04-24T12:01:00.000Z"))).toEqual([]);
   });
 
   it("clamps interval so daemon sleep cannot overshoot the next wait deadline", () => {

--- a/src/runtime/approval-broker.ts
+++ b/src/runtime/approval-broker.ts
@@ -90,12 +90,12 @@ export class ApprovalBroker {
   async requestApproval(
     goalId: string,
     task: ApprovalTaskRequest,
-    timeoutMs = this.defaultTimeoutMs
+    timeoutMs = this.defaultTimeoutMs,
+    approvalId = this.createId()
   ): Promise<boolean> {
     await this.start();
 
     const createdAt = this.now();
-    const approvalId = this.createId();
     const record: ApprovalRecord = {
       approval_id: approvalId,
       goal_id: goalId,

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -291,6 +291,7 @@ export class DaemonRunner {
       store: this.approvalStore,
       logger: this.logger,
     });
+    this.coreLoop.setWaitApprovalBroker?.(this.approvalBroker);
     this.journalQueue = new JournalBackedQueue({
       journalPath: path.join(this.runtimeRoot, "queue.json"),
       maxAttempts: RUNTIME_JOURNAL_MAX_ATTEMPTS,
@@ -819,6 +820,7 @@ export class DaemonRunner {
     try {
       const freshDeps = await this.refreshResidentDeps();
       this.coreLoop = freshDeps.coreLoop;
+      this.coreLoop.setWaitApprovalBroker?.(this.approvalBroker ?? undefined);
       this.curiosityEngine = freshDeps.curiosityEngine;
       this.goalNegotiator = freshDeps.goalNegotiator;
       this.llmClient = freshDeps.llmClient;


### PR DESCRIPTION
## Summary
- add CoreLoop wait-observation handling so active WaitStrategies observe/expire before task generation
- connect WaitExpiryOutcome to rebalance, capability metadata, and approval-required handling
- route wait approvals through the live ApprovalBroker when available, with durable ApprovalStore fallback and deterministic IDs

## Validation
- npm run typecheck
- npm run test:changed
- npm run test:integration -- --run src/runtime/__tests__/approval-broker.test.ts
- final material-only review: no findings