### PR TITLE
Fix TUI chat answer JSON rendering

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
@@ -98,6 +98,19 @@ describe("chat agentloop final-answer contract", () => {
     expect(result.output).toContain("### Blockers");
   });
 
+  it("unwraps answer-only structured chat output into plain assistant text", async () => {
+    const { runner } = makeRunner({
+      status: "done",
+      answer: "Codexです。あなたの端末上の作業環境でコード作業を進めます。",
+    });
+
+    const result = await runner.execute({ message: "あなたは誰？" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("Codexです。あなたの端末上の作業環境でコード作業を進めます。");
+    expect(result.output).not.toContain('"answer"');
+  });
+
   it("biases chat mode prompts toward concise structured markdown", () => {
     const chatPrompt = buildAgentLoopBaseInstructions({ mode: "chat" });
     const taskPrompt = buildAgentLoopBaseInstructions({ mode: "task" });

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -35,14 +35,16 @@ const ChatAgentLoopFinalAnswerSchema = z.object({
 const ChatAgentLoopOutputBaseSchema = z.object({
   status: z.enum(["done", "blocked", "failed"]).default("done"),
   message: z.string().default(""),
+  answer: z.string().optional(),
   evidence: z.array(z.string()).default([]),
   blockers: z.array(z.string()).default([]),
   finalAnswer: ChatAgentLoopFinalAnswerSchema.optional(),
 }).passthrough();
 
 export const ChatAgentLoopOutputSchema = ChatAgentLoopOutputBaseSchema.transform((value) => {
+  const summary = value.message.trim() || value.answer?.trim() || "";
   const finalAnswer = value.finalAnswer ?? {
-    summary: value.message,
+    summary,
     sections: [],
     evidence: value.evidence,
     blockers: value.blockers,
@@ -51,7 +53,7 @@ export const ChatAgentLoopOutputSchema = ChatAgentLoopOutputBaseSchema.transform
 
   return {
     ...value,
-    message: value.message.trim() || finalAnswer.summary.trim(),
+    message: value.message.trim() || value.answer?.trim() || finalAnswer.summary.trim(),
     evidence: value.evidence.length > 0 ? value.evidence : finalAnswer.evidence,
     blockers: value.blockers.length > 0 ? value.blockers : finalAnswer.blockers,
     finalAnswer,
@@ -255,6 +257,7 @@ export class ChatAgentLoopRunner {
     const formatted = this.formatStructuredFinalText(finalText);
     if (formatted) return formatted;
     if (output?.message && output.message.trim().length > 0) return output.message.trim();
+    if (output?.answer && output.answer.trim().length > 0) return output.answer.trim();
     if (finalText && finalText.trim().length > 0) return finalText.trim();
     return "(no response)";
   }
@@ -298,9 +301,11 @@ export class ChatAgentLoopRunner {
     if (!output) return null;
 
     const finalAnswer = output.finalAnswer;
-    const summary = finalAnswer?.summary.trim() || output.message.trim();
+    const outputEvidence = Array.isArray(output.evidence) ? output.evidence : [];
+    const outputBlockers = Array.isArray(output.blockers) ? output.blockers : [];
+    const summary = finalAnswer?.summary.trim() || output.message?.trim() || output.answer?.trim() || "";
     const sections: string[] = [];
-    const handledKeys = new Set<string>(["status", "message", "evidence", "blockers", "finalAnswer"]);
+    const handledKeys = new Set<string>(["status", "message", "answer", "evidence", "blockers", "finalAnswer"]);
 
     if (summary.length > 0) {
       sections.push(summary);
@@ -314,7 +319,7 @@ export class ChatAgentLoopRunner {
 
     const evidence = [...new Set([
       ...(finalAnswer?.evidence ?? []),
-      ...output.evidence,
+      ...outputEvidence,
     ].map((item) => item.trim()).filter((item) => item.length > 0))];
     if (evidence.length > 0) {
       sections.push(`### Evidence\n${evidence.map((item) => `- ${item}`).join("\n")}`);
@@ -322,7 +327,7 @@ export class ChatAgentLoopRunner {
 
     const blockers = [...new Set([
       ...(finalAnswer?.blockers ?? []),
-      ...output.blockers,
+      ...outputBlockers,
     ].map((item) => item.trim()).filter((item) => item.length > 0))];
     if (blockers.length > 0) {
       sections.push(`### Blockers\n${blockers.map((item) => `- ${item}`).join("\n")}`);


### PR DESCRIPTION
## Summary
- unwrap chat agent loop outputs that use an `answer` field instead of `message`
- make chat output formatting tolerate unnormalized answer-only objects
- add a regression for the TUI-visible answer-only JSON shape

## Tests
- npm test -- --run src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
- npm run typecheck -- --pretty false
- npm run test:changed