### PR TITLE
[codex] Make chat agent loop display-text first

### DIFF
--- a/src/orchestrator/execution/adapter-layer.ts
+++ b/src/orchestrator/execution/adapter-layer.ts
@@ -59,6 +59,8 @@ export interface AgentResult {
   success: boolean;
   /** stdout from CLI / LLM response text */
   output: string;
+  /** Parsed machine-readable result, when a caller explicitly requested structured output. */
+  structuredOutput?: unknown;
   /** stderr / error message, null on success */
   error: string | null;
   /** Process exit code for CLI adapters; null for API adapters */

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
@@ -487,6 +487,118 @@ describe("agentloop phase 6 CorePhaseRunner", () => {
 });
 
 describe("agentloop phase 7 ChatAgentLoopRunner and CoreLoopControlTools", () => {
+  it("accepts plain final markdown in default display text chat mode", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "Plain **Markdown** answer.",
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const registry = new ToolRegistry();
+    const { router, runtime } = makeRuntime(registry);
+    const registryModel = new StaticAgentLoopModelRegistry([modelInfo]);
+    const chat = new ChatAgentLoopRunner({
+      boundedRunner: new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime }),
+      modelClient,
+      modelRegistry: registryModel,
+      defaultModel: modelInfo.ref,
+    });
+
+    const result = await chat.execute({ message: "answer plainly" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("Plain **Markdown** answer.");
+    expect(result.structuredOutput).toBeUndefined();
+    expect(modelClient.calls).toHaveLength(1);
+  });
+
+  it("repairs empty final text before completing default display text chat mode", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "   ",
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+      {
+        content: "Recovered answer.",
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const registry = new ToolRegistry();
+    const { router, runtime } = makeRuntime(registry);
+    const registryModel = new StaticAgentLoopModelRegistry([modelInfo]);
+    const chat = new ChatAgentLoopRunner({
+      boundedRunner: new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime }),
+      modelClient,
+      modelRegistry: registryModel,
+      defaultModel: modelInfo.ref,
+    });
+
+    const result = await chat.execute({
+      message: "answer plainly",
+      budget: { maxSchemaRepairAttempts: 1 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("Recovered answer.");
+    expect(modelClient.calls).toHaveLength(2);
+    expect(modelClient.calls[1].messages.some((m) => m.content.includes("final answer was empty"))).toBe(true);
+  });
+
+  it("uses schema repair and structuredOutput only for explicit structured chat mode", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "Plain text is invalid for this structured turn.",
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          answer: "Structured answer.",
+          payload: { ok: true },
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const registry = new ToolRegistry();
+    const { router, runtime } = makeRuntime(registry);
+    const registryModel = new StaticAgentLoopModelRegistry([modelInfo]);
+    const chat = new ChatAgentLoopRunner({
+      boundedRunner: new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime }),
+      modelClient,
+      modelRegistry: registryModel,
+      defaultModel: modelInfo.ref,
+    });
+    const schema = z.object({
+      status: z.literal("done"),
+      answer: z.string(),
+      payload: z.object({ ok: z.boolean() }),
+    });
+
+    const result = await chat.execute({
+      message: "return structured data",
+      outputMode: { kind: "structured", schema },
+      budget: { maxSchemaRepairAttempts: 1 },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("Structured answer.");
+    expect(result.structuredOutput).toEqual({
+      status: "done",
+      answer: "Structured answer.",
+      payload: { ok: true },
+    });
+    expect(modelClient.calls).toHaveLength(2);
+    expect(modelClient.calls[1].messages.some((m) => m.content.includes("required JSON schema"))).toBe(true);
+  });
+
   it("lets chat use CoreLoop control only as tools", async () => {
     const modelInfo = makeModelInfo();
     const modelClient = new ScriptedModelClient(modelInfo, [

--- a/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
 import { ChatAgentLoopRunner } from "../chat-agent-loop-runner.js";
-import { buildAgentLoopBaseInstructions } from "../agent-loop-prompts.js";
+import { buildAgentLoopBaseInstructions, buildChatStructuredOutputInstructions } from "../agent-loop-prompts.js";
 import type {
   AgentLoopModelClient,
   AgentLoopModelInfo,
@@ -22,13 +23,13 @@ function makeModelInfo(): AgentLoopModelInfo {
   };
 }
 
-function makeRunner(returnOutput: unknown) {
+function makeRunner(returnOutput: unknown, finalText = JSON.stringify(returnOutput)) {
   const modelInfo = makeModelInfo();
   const boundedRunner = {
     run: vi.fn().mockResolvedValue({
       success: true,
       output: returnOutput,
-      finalText: JSON.stringify(returnOutput),
+      finalText,
       stopReason: "completed",
       traceId: "trace-1",
       sessionId: "session-1",
@@ -55,6 +56,46 @@ function makeRunner(returnOutput: unknown) {
 }
 
 describe("chat agentloop final-answer contract", () => {
+  it("defaults to display text mode and returns final markdown without structured output", async () => {
+    const { runner, boundedRunner } = makeRunner(null, "Plain **Markdown** answer.");
+
+    const result = await runner.execute({ message: "test" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("Plain **Markdown** answer.");
+    expect(result.structuredOutput).toBeUndefined();
+    expect(boundedRunner.run).toHaveBeenCalledWith(expect.objectContaining({
+      finalOutputMode: "display_text",
+    }));
+  });
+
+  it("keeps parsed structured output separate when structured mode is explicit", async () => {
+    const structured = {
+      status: "done",
+      answer: "Structured answer text.",
+      payload: { ok: true },
+    };
+    const schema = z.object({
+      status: z.literal("done"),
+      answer: z.string(),
+      payload: z.object({ ok: z.boolean() }),
+    });
+    const { runner, boundedRunner } = makeRunner(structured);
+
+    const result = await runner.execute({
+      message: "test",
+      outputMode: { kind: "structured", schema },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("Structured answer text.");
+    expect(result.structuredOutput).toEqual(structured);
+    expect(boundedRunner.run).toHaveBeenCalledWith(expect.objectContaining({
+      finalOutputMode: "schema",
+      outputSchema: schema,
+    }));
+  });
+
   it("renders the structured finalAnswer object as concise markdown", async () => {
     const { runner, boundedRunner } = makeRunner({
       status: "done",
@@ -111,13 +152,115 @@ describe("chat agentloop final-answer contract", () => {
     expect(result.output).not.toContain('"answer"');
   });
 
-  it("biases chat mode prompts toward concise structured markdown", () => {
+  it("unwraps JSON strings in message fields before display", async () => {
+    const { runner } = makeRunner({
+      status: "done",
+      message: JSON.stringify({ answer: "JSON文字列ではなく本文だけを表示します。" }),
+      evidence: [],
+      blockers: [],
+    });
+
+    const result = await runner.execute({ message: "test" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("JSON文字列ではなく本文だけを表示します。");
+    expect(result.output).not.toContain('"answer"');
+  });
+
+  it("unwraps finalAnswer.summary JSON strings before display", async () => {
+    const { runner } = makeRunner({
+      status: "done",
+      message: "",
+      evidence: [],
+      blockers: [],
+      finalAnswer: {
+        summary: JSON.stringify({ message: "summary の中身だけを表示します。" }),
+        sections: [],
+        evidence: [],
+        blockers: [],
+        nextActions: [],
+      },
+    });
+
+    const result = await runner.execute({ message: "test" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("summary の中身だけを表示します。");
+    expect(result.output).not.toContain('"message"');
+  });
+
+  it("unwraps finalText finalAnswer.summary objects before display", async () => {
+    const modelInfo = makeModelInfo();
+    const boundedRunner = {
+      run: vi.fn().mockResolvedValue({
+        success: true,
+        output: { status: "done", message: "", evidence: [], blockers: [] },
+        finalText: JSON.stringify({ finalAnswer: { summary: "finalText 由来の本文です。" } }),
+        stopReason: "completed",
+        traceId: "trace-1",
+        sessionId: "session-1",
+        turnId: "turn-1",
+        modelTurns: 1,
+        toolCalls: 0,
+        usage: undefined,
+        compactions: 0,
+        changedFiles: [],
+        commandResults: [],
+      }),
+    } as unknown as BoundedAgentLoopRunner;
+    const modelClient = {
+      getModelInfo: vi.fn().mockResolvedValue(modelInfo),
+    } as unknown as AgentLoopModelClient;
+    const modelRegistry = {
+      defaultModel: vi.fn().mockResolvedValue(modelInfo.ref),
+    } as unknown as AgentLoopModelRegistry;
+    const runner = new ChatAgentLoopRunner({ boundedRunner, modelClient, modelRegistry });
+
+    const result = await runner.execute({ message: "test" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("finalText 由来の本文です。");
+    expect(result.output).not.toContain("finalAnswer");
+  });
+
+  it("does not display unwrappable JSON objects as normal chat text", async () => {
+    const { runner } = makeRunner({
+      status: "done",
+      message: JSON.stringify({ detail: "internal shape" }),
+      evidence: [],
+      blockers: [],
+    });
+
+    const result = await runner.execute({ message: "test" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe("(no response)");
+    expect(result.output).not.toContain("internal shape");
+    expect(result.output).not.toContain("{");
+  });
+
+  it("keeps raw JSON final text in display mode when it is the answer body", async () => {
+    const finalText = JSON.stringify({ foo: "bar" });
+    const { runner } = makeRunner(null, finalText);
+
+    const result = await runner.execute({ message: "JSONで返して" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe(finalText);
+    expect(result.structuredOutput).toBeUndefined();
+  });
+
+  it("biases chat mode prompts toward display markdown by default", () => {
     const chatPrompt = buildAgentLoopBaseInstructions({ mode: "chat" });
     const taskPrompt = buildAgentLoopBaseInstructions({ mode: "task" });
+    const structuredPrompt = buildChatStructuredOutputInstructions();
 
-    expect(chatPrompt).toContain("finalAnswer");
-    expect(chatPrompt).toContain("concise structured markdown");
+    expect(chatPrompt).toContain("user-visible Markdown");
+    expect(chatPrompt).toContain("Do not wrap the final answer in JSON");
     expect(chatPrompt).toContain("short headings and bullets");
-    expect(taskPrompt).not.toContain("concise structured markdown");
+    expect(chatPrompt).not.toContain("finalAnswer");
+    expect(taskPrompt).not.toContain("Do not wrap the final answer in JSON");
+    expect(structuredPrompt).toContain("Return only JSON");
+    expect(structuredPrompt).toContain("requested schema");
   });
 });

--- a/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
@@ -23,9 +23,9 @@ export function buildAgentLoopBaseInstructions(options?: {
     "Preserve and follow AGENTS.md and project instructions from the workspace context.",
     ...(mode === "chat"
       ? [
-          "When returning structured output, keep the main response in finalAnswer with a short summary, optional sections, evidence, blockers, and next steps; keep compatibility fields brief.",
-          "For the final answer, use concise structured markdown with short headings and bullets instead of long unbroken prose.",
-          "Keep the summary tight and put supporting evidence, blockers, and next steps in separate short sections when relevant.",
+          "Write the final assistant answer as user-visible Markdown or plain text.",
+          "Do not wrap the final answer in JSON, schema fields, or code fences unless the user explicitly asks to see JSON.",
+          "The CLI/TUI renders Markdown directly, so use short headings and bullets when they improve readability.",
         ]
       : []),
     buildSubagentRoleInstructions(options?.role ?? "default"),
@@ -33,6 +33,14 @@ export function buildAgentLoopBaseInstructions(options?: {
   ];
 
   return rules.join("\n");
+}
+
+export function buildChatStructuredOutputInstructions(): string {
+  return [
+    "This turn explicitly requested structured output for automation.",
+    "Return only JSON that matches the requested schema.",
+    "Keep any user-visible prose in display fields such as message, answer, or finalAnswer.summary when the schema provides them.",
+  ].join("\n");
 }
 
 export function buildSubagentRoleInstructions(role: SubagentRole): string {

--- a/src/orchestrator/execution/agent-loop/agent-loop-turn-context.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-turn-context.ts
@@ -20,6 +20,8 @@ export interface AgentLoopToolPolicy {
   includeDeferred?: boolean;
 }
 
+export type AgentLoopFinalOutputMode = "schema" | "display_text";
+
 export interface AgentLoopTurnContext<TOutput> {
   session: AgentLoopSession;
   turnId: string;
@@ -32,6 +34,7 @@ export interface AgentLoopTurnContext<TOutput> {
   reasoningEffort?: AgentLoopReasoningEffort;
   messages: AgentLoopMessage[];
   outputSchema: z.ZodType<TOutput, z.ZodTypeDef, unknown>;
+  finalOutputMode?: AgentLoopFinalOutputMode;
   budget: AgentLoopBudget;
   toolPolicy: AgentLoopToolPolicy;
   toolCallContext: ToolCallContext;

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -143,6 +143,55 @@ export class BoundedAgentLoopRunner {
       }
 
       if (response.toolCalls.length === 0) {
+        if (turn.finalOutputMode === "display_text") {
+          if (response.content.trim().length === 0) {
+            schemaRepairAttempts++;
+            if (schemaRepairAttempts > turn.budget.maxSchemaRepairAttempts) {
+              return this.stop(turn, "schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+            }
+
+            messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
+            messages.push({
+              role: "user",
+              content: "Your final answer was empty. Return a user-visible Markdown or plain text answer for the user.",
+            });
+            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
+            if (compacted.error) {
+              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+            }
+            messages = compacted.messages;
+            compactions += compacted.compacted ? 1 : 0;
+            await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+            continue;
+          }
+
+          const missingRequiredTools = this.missingRequiredTools(turn, calledTools);
+          if (missingRequiredTools.length > 0) {
+            messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
+            messages.push({
+              role: "user",
+              content: `Before the final answer, call these required tool(s) at least once: ${missingRequiredTools.join(", ")}.`,
+            });
+            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
+            if (compacted.error) {
+              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+            }
+            messages = compacted.messages;
+            compactions += compacted.compacted ? 1 : 0;
+            await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+            continue;
+          }
+
+          const changedFiles = await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot);
+          await this.record(turn, {
+            type: "final",
+            ...this.baseEvent(turn),
+            success: true,
+            outputPreview: this.preview(response.content),
+          });
+          return this.stop(turn, "completed", startedAt, modelTurns, toolCalls, response.content, null, true, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+        }
+
         const parsed = this.parseFinal(response.content, turn.outputSchema);
         if (parsed.success) {
           const missingRequiredTools = this.missingRequiredTools(turn, calledTools);

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -14,9 +14,10 @@ import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
 import { withDefaultBudget } from "./agent-loop-turn-context.js";
 import type { BoundedAgentLoopRunner } from "./bounded-agent-loop-runner.js";
 import type { AgentLoopSessionState } from "./agent-loop-session-state.js";
-import { buildAgentLoopBaseInstructions } from "./agent-loop-prompts.js";
+import { buildAgentLoopBaseInstructions, buildChatStructuredOutputInstructions } from "./agent-loop-prompts.js";
 import type { ApprovalRequest, ToolCallContext } from "../../../tools/types.js";
 import type { ExecutionPolicy, SubagentRole } from "./execution-policy.js";
+import { normalizeAssistantDisplayText } from "./chat-display-output.js";
 
 const ChatAgentLoopFinalAnswerSectionSchema = z.object({
   title: z.string(),
@@ -61,6 +62,10 @@ export const ChatAgentLoopOutputSchema = ChatAgentLoopOutputBaseSchema.transform
 });
 export type ChatAgentLoopOutput = z.infer<typeof ChatAgentLoopOutputSchema>;
 
+export type ChatAgentLoopOutputMode =
+  | { kind: "display_text" }
+  | { kind: "structured"; schema?: z.ZodType<unknown, z.ZodTypeDef, unknown> };
+
 export interface ChatAgentLoopRunnerDeps {
   boundedRunner: BoundedAgentLoopRunner;
   modelClient: AgentLoopModelClient;
@@ -98,6 +103,7 @@ export interface ChatAgentLoopInput {
   resumeStatePath?: string;
   resumeOnly?: boolean;
   role?: SubagentRole;
+  outputMode?: ChatAgentLoopOutputMode;
 }
 
 export class ChatAgentLoopRunner {
@@ -109,6 +115,10 @@ export class ChatAgentLoopRunner {
     const modelInfo = await this.deps.modelClient.getModelInfo(model);
     const cwd = input.cwd ?? this.deps.cwd ?? process.cwd();
     const turnId = randomUUID();
+    const outputMode = input.outputMode ?? { kind: "display_text" as const };
+    const outputSchema: z.ZodType<unknown, z.ZodTypeDef, unknown> = outputMode.kind === "structured"
+      ? outputMode.schema ?? ChatAgentLoopOutputSchema
+      : ChatAgentLoopOutputSchema;
     const session = this.deps.createSession?.({
       goalId: input.goalId,
       eventSink: input.eventSink,
@@ -139,6 +149,7 @@ export class ChatAgentLoopRunner {
                     extraRules: [
                       "Use tools to answer the user and operate CoreLoop only through tools.",
                       "Do not call CoreLoop internals directly.",
+                      ...(outputMode.kind === "structured" ? [buildChatStructuredOutputInstructions()] : []),
                     ],
                     role: input.role,
                   }),
@@ -148,7 +159,8 @@ export class ChatAgentLoopRunner {
               ...(input.history ?? []).map((m) => ({ role: m.role, content: m.content })),
               { role: "user" as const, content: input.message },
             ],
-        outputSchema: ChatAgentLoopOutputSchema,
+        outputSchema,
+        finalOutputMode: outputMode.kind === "structured" ? "schema" : "display_text",
         budget: withDefaultBudget({ ...this.deps.defaultBudget, ...input.budget }),
         toolPolicy: { ...this.deps.defaultToolPolicy, ...input.toolPolicy },
         ...(input.resumeState ? { resumeState: input.resumeState } : {}),
@@ -182,17 +194,24 @@ export class ChatAgentLoopRunner {
         },
       });
 
-      const success = result.success && result.output?.status === "done";
+      const chatOutput = isRecord(result.output) ? result.output as ChatAgentLoopOutput : null;
+      const outputStatus = isRecord(result.output) && typeof result.output.status === "string"
+        ? result.output.status
+        : "done";
+      const success = outputMode.kind === "structured"
+        ? result.success && outputStatus === "done"
+        : result.success;
       const hadApprovalDeniedError = result.commandResults.some((entry) =>
         /approval denied|user denied approval|requires approval/i.test(entry.outputSummary),
       );
       const fallbackOutput = success
-        ? this.buildSuccessfulOutput(result.finalText, result.output)
-        : this.buildFailureOutput(result.stopReason, hadApprovalDeniedError, result.finalText, result.output, result.output?.blockers);
+        ? this.buildSuccessfulOutput(result.finalText, chatOutput)
+        : this.buildFailureOutput(result.stopReason, hadApprovalDeniedError, result.finalText, chatOutput, extractStringArray(result.output, "blockers"));
       return {
         success,
         output: fallbackOutput,
-        error: success ? null : result.output?.blockers.join("; ") || result.stopReason,
+        ...(outputMode.kind === "structured" && result.output !== null ? { structuredOutput: result.output } : {}),
+        error: success ? null : extractStringArray(result.output, "blockers").join("; ") || result.stopReason,
         exit_code: null,
         elapsed_ms: Date.now() - started,
         stopped_reason: success ? "completed" : result.stopReason === "timeout" ? "timeout" : "error",
@@ -207,8 +226,8 @@ export class ChatAgentLoopRunner {
           compactions: result.compactions,
           ...(result.profileName ? { profileName: result.profileName } : {}),
           ...(result.reasoningEffort ? { reasoningEffort: result.reasoningEffort } : {}),
-          completionEvidence: result.output?.evidence ?? [],
-          verificationHints: result.output?.blockers ?? [],
+          completionEvidence: extractStringArray(result.output, "evidence"),
+          verificationHints: extractStringArray(result.output, "blockers"),
           filesChangedPaths: result.changedFiles,
           ...(result.executionPolicy
             ? {
@@ -252,13 +271,8 @@ export class ChatAgentLoopRunner {
   }
 
   private buildSuccessfulOutput(finalText: string, output?: ChatAgentLoopOutput | null): string {
-    const formattedOutput = this.formatChatOutput(output);
-    if (formattedOutput) return formattedOutput;
-    const formatted = this.formatStructuredFinalText(finalText);
-    if (formatted) return formatted;
-    if (output?.message && output.message.trim().length > 0) return output.message.trim();
-    if (output?.answer && output.answer.trim().length > 0) return output.answer.trim();
-    if (finalText && finalText.trim().length > 0) return finalText.trim();
+    const displayText = normalizeAssistantDisplayText({ finalText, output });
+    if (displayText) return displayText;
     return "(no response)";
   }
 
@@ -288,118 +302,20 @@ export class ChatAgentLoopRunner {
       return "I stopped because the tool loop repeated without making progress.";
     }
 
-    const formattedOutput = this.formatChatOutput(output);
-    if (formattedOutput) return formattedOutput;
-    const formatted = this.formatStructuredFinalText(finalText);
-    if (formatted) return formatted;
+    const displayText = normalizeAssistantDisplayText({ finalText, output });
+    if (displayText) return displayText;
     if (blockers && blockers.length > 0) return blockers.join("; ");
-    if (finalText && !/^Calling\s+/i.test(finalText.trim())) return finalText.trim();
     return `Interrupted: ${stopReason}`;
   }
+}
 
-  private formatChatOutput(output?: ChatAgentLoopOutput | null): string | null {
-    if (!output) return null;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
 
-    const finalAnswer = output.finalAnswer;
-    const outputEvidence = Array.isArray(output.evidence) ? output.evidence : [];
-    const outputBlockers = Array.isArray(output.blockers) ? output.blockers : [];
-    const summary = finalAnswer?.summary.trim() || output.message?.trim() || output.answer?.trim() || "";
-    const sections: string[] = [];
-    const handledKeys = new Set<string>(["status", "message", "answer", "evidence", "blockers", "finalAnswer"]);
-
-    if (summary.length > 0) {
-      sections.push(summary);
-    }
-
-    for (const section of finalAnswer?.sections ?? []) {
-      const bullets = section.bullets.map((item) => item.trim()).filter((item) => item.length > 0);
-      if (bullets.length === 0) continue;
-      sections.push(`### ${section.title.trim()}\n${bullets.map((bullet) => `- ${bullet}`).join("\n")}`);
-    }
-
-    const evidence = [...new Set([
-      ...(finalAnswer?.evidence ?? []),
-      ...outputEvidence,
-    ].map((item) => item.trim()).filter((item) => item.length > 0))];
-    if (evidence.length > 0) {
-      sections.push(`### Evidence\n${evidence.map((item) => `- ${item}`).join("\n")}`);
-    }
-
-    const blockers = [...new Set([
-      ...(finalAnswer?.blockers ?? []),
-      ...outputBlockers,
-    ].map((item) => item.trim()).filter((item) => item.length > 0))];
-    if (blockers.length > 0) {
-      sections.push(`### Blockers\n${blockers.map((item) => `- ${item}`).join("\n")}`);
-    }
-
-    const nextActions = [
-      ...(finalAnswer?.nextActions ?? []),
-      ...(typeof finalAnswer?.nextAction === "string" ? [finalAnswer.nextAction] : []),
-    ].map((item) => item.trim()).filter((item) => item.length > 0);
-    if (nextActions.length > 0) {
-      sections.push(`### Next steps\n${nextActions.map((item) => `- ${item}`).join("\n")}`);
-    }
-
-    for (const [key, fieldValue] of Object.entries(output)) {
-      if (handledKeys.has(key) || !Array.isArray(fieldValue)) continue;
-      const lines = fieldValue.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
-      if (lines.length === 0) continue;
-      sections.push(`### ${this.humanizeFieldLabel(this.normalizeOutputFieldLabel(key))}\n${lines.map((line) => `- ${line}`).join("\n")}`);
-    }
-
-    for (const [key, fieldValue] of Object.entries(output)) {
-      if (handledKeys.has(key) || typeof fieldValue !== "string") continue;
-      const value = fieldValue.trim();
-      if (!value) continue;
-      if (key === "nextAction" || key === "next_action" || key === "nextStep" || key === "next_step") {
-        sections.push(`### Next step\n- ${value}`);
-      }
-    }
-
-    const rendered = sections.join("\n\n").trim();
-    return rendered.length > 0 ? rendered : null;
-  }
-
-  private humanizeFieldLabel(key: string): string {
-    return key
-      .split(/[_\s-]+/g)
-      .filter(Boolean)
-      .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
-      .join(" ");
-  }
-
-  private normalizeOutputFieldLabel(key: string): string {
-    switch (key) {
-      case "steps":
-        return "recommended_steps";
-      case "files":
-      case "relevantFiles":
-        return "relevant_files";
-      case "nextActions":
-      case "next_actions":
-        return "next_steps";
-      default:
-        return key;
-    }
-  }
-
-  private formatStructuredFinalText(finalText: string): string | null {
-    const raw = finalText?.trim();
-    if (!raw) return null;
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      return null;
-    }
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return null;
-    }
-
-    const parsedOutput = ChatAgentLoopOutputSchema.safeParse(parsed);
-    if (!parsedOutput.success) return null;
-    return this.formatChatOutput(parsedOutput.data);
-  }
+function extractStringArray(value: unknown, key: string): string[] {
+  if (!isRecord(value)) return [];
+  const field = value[key];
+  if (!Array.isArray(field)) return [];
+  return field.filter((item): item is string => typeof item === "string" && item.length > 0);
 }

--- a/src/orchestrator/execution/agent-loop/chat-display-output.ts
+++ b/src/orchestrator/execution/agent-loop/chat-display-output.ts
@@ -1,0 +1,190 @@
+export interface ChatDisplayFinalAnswerSection {
+  title?: string;
+  bullets?: unknown[];
+}
+
+export interface ChatDisplayFinalAnswer {
+  summary?: string;
+  sections?: ChatDisplayFinalAnswerSection[];
+  evidence?: unknown[];
+  blockers?: unknown[];
+  nextActions?: unknown[];
+  nextAction?: unknown;
+}
+
+export interface ChatDisplayOutput {
+  status?: unknown;
+  message?: unknown;
+  answer?: unknown;
+  evidence?: unknown;
+  blockers?: unknown;
+  finalAnswer?: ChatDisplayFinalAnswer | null;
+  [key: string]: unknown;
+}
+
+export interface NormalizeAssistantDisplayTextInput {
+  finalText?: string | null;
+  output?: ChatDisplayOutput | null;
+}
+
+export function normalizeAssistantDisplayText(input: NormalizeAssistantDisplayTextInput): string | null {
+  const formattedOutput = formatChatOutput(input.output);
+  if (formattedOutput) return formattedOutput;
+
+  const formattedFinalText = formatStructuredFinalText(input.finalText);
+  if (formattedFinalText) return formattedFinalText;
+
+  const raw = input.finalText?.trim();
+  if (!raw) return null;
+  if (isJsonObjectString(raw) && input.output !== null && input.output !== undefined) return null;
+  return raw;
+}
+
+function formatChatOutput(output?: ChatDisplayOutput | null): string | null {
+  if (!output) return null;
+
+  const finalAnswer = isRecord(output.finalAnswer) ? output.finalAnswer : null;
+  const outputEvidence = stringArray(output.evidence);
+  const outputBlockers = stringArray(output.blockers);
+  const summary = firstDisplayText([
+    finalAnswer ? displayTextFromValue(finalAnswer.summary) : null,
+    displayTextFromValue(output.message),
+    displayTextFromValue(output.answer),
+  ]);
+  const sections: string[] = [];
+  const handledKeys = new Set<string>(["status", "message", "answer", "evidence", "blockers", "finalAnswer"]);
+
+  if (summary) {
+    sections.push(summary);
+  }
+
+  for (const section of Array.isArray(finalAnswer?.sections) ? finalAnswer.sections : []) {
+    if (!isRecord(section)) continue;
+    const title = typeof section.title === "string" ? section.title.trim() : "";
+    const bullets = stringArray(section.bullets);
+    if (!title || bullets.length === 0) continue;
+    sections.push(`### ${title}\n${bullets.map((bullet) => `- ${bullet}`).join("\n")}`);
+  }
+
+  const evidence = uniqueStrings([
+    ...stringArray(finalAnswer?.evidence),
+    ...outputEvidence,
+  ]);
+  if (evidence.length > 0) {
+    sections.push(`### Evidence\n${evidence.map((item) => `- ${item}`).join("\n")}`);
+  }
+
+  const blockers = uniqueStrings([
+    ...stringArray(finalAnswer?.blockers),
+    ...outputBlockers,
+  ]);
+  if (blockers.length > 0) {
+    sections.push(`### Blockers\n${blockers.map((item) => `- ${item}`).join("\n")}`);
+  }
+
+  const nextActions = stringArray(finalAnswer?.nextActions);
+  const nextAction = displayTextFromValue(finalAnswer?.nextAction);
+  if (nextAction) nextActions.push(nextAction);
+  if (nextActions.length > 0) {
+    sections.push(`### Next steps\n${nextActions.map((item) => `- ${item}`).join("\n")}`);
+  }
+
+  for (const [key, fieldValue] of Object.entries(output)) {
+    if (handledKeys.has(key) || !Array.isArray(fieldValue)) continue;
+    const lines = stringArray(fieldValue);
+    if (lines.length === 0) continue;
+    sections.push(`### ${humanizeFieldLabel(normalizeOutputFieldLabel(key))}\n${lines.map((line) => `- ${line}`).join("\n")}`);
+  }
+
+  for (const [key, fieldValue] of Object.entries(output)) {
+    if (handledKeys.has(key) || typeof fieldValue !== "string") continue;
+    const value = displayTextFromValue(fieldValue);
+    if (!value) continue;
+    if (key === "nextAction" || key === "next_action" || key === "nextStep" || key === "next_step") {
+      sections.push(`### Next step\n- ${value}`);
+    }
+  }
+
+  const rendered = sections.join("\n\n").trim();
+  return rendered.length > 0 ? rendered : null;
+}
+
+function formatStructuredFinalText(finalText?: string | null): string | null {
+  const parsed = parseJsonObject(finalText);
+  if (!parsed) return null;
+  return formatChatOutput(parsed);
+}
+
+function displayTextFromValue(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const raw = value.trim();
+  if (!raw) return null;
+
+  const parsed = parseJsonObject(raw);
+  if (!parsed) return raw;
+
+  return firstDisplayText([
+    displayTextFromValue(parsed.message),
+    displayTextFromValue(parsed.answer),
+    isRecord(parsed.finalAnswer) ? displayTextFromValue(parsed.finalAnswer.summary) : null,
+  ]);
+}
+
+function firstDisplayText(values: Array<string | null>): string | null {
+  return values.find((value): value is string => typeof value === "string" && value.length > 0) ?? null;
+}
+
+function parseJsonObject(value?: string | null): Record<string, unknown> | null {
+  const raw = value?.trim();
+  if (!raw || !isJsonObjectString(raw)) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isJsonObjectString(value: string): boolean {
+  const raw = value.trim();
+  return raw.startsWith("{") && raw.endsWith("}");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => displayTextFromValue(item))
+    .filter((item): item is string => typeof item === "string" && item.length > 0);
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return [...new Set(values.map((item) => item.trim()).filter((item) => item.length > 0))];
+}
+
+function humanizeFieldLabel(key: string): string {
+  return key
+    .split(/[_\s-]+/g)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function normalizeOutputFieldLabel(key: string): string {
+  switch (key) {
+    case "steps":
+      return "recommended_steps";
+    case "files":
+    case "relevantFiles":
+      return "relevant_files";
+    case "nextActions":
+    case "next_actions":
+      return "next_steps";
+    default:
+      return key;
+  }
+}


### PR DESCRIPTION
## Summary
- make native chat agent loop default to display text/Markdown finals instead of schema-first JSON parsing
- keep structured chat output as explicit opt-in and expose parsed data through `structuredOutput` while preserving `output` as user-visible text
- extract chat display normalization and add regressions for JSON unwrap/fallback behavior

## Why
Normal Chat/TUI replies should render plain user-facing text. Schema-shaped output is still useful for automation, but it should not be the default display contract or leak raw `{ "answer" }` payloads into chat.

## Validation
- `npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts src/interface/chat/__tests__/chat-boundary-contract.test.ts src/interface/chat/__tests__/chat-runner.test.ts`
- `npm run typecheck`
- `git diff --check`