### PR TITLE
[codex] Ground PulSeed self identity in runtime files

### DIFF
--- a/docs/design/core/self-knowledge.md
+++ b/docs/design/core/self-knowledge.md
@@ -6,7 +6,7 @@
 
 PulSeed has a chat interface. Users naturally ask questions about PulSeed itself -- "What goals do you have?", "What's your trust score?", "What model are you using?" PulSeed should answer these questions accurately, drawing from its actual runtime state rather than hallucinating.
 
-The current grounding mechanism (`src/chat/grounding.ts`) injects a minimal summary (goal titles, provider name, plugin names) into every system prompt. This covers the basics but falls short in two ways:
+The current grounding mechanism (`src/interface/chat/grounding.ts`) injects a minimal summary (goal titles, provider name, plugin names) into every system prompt. This covers the basics but falls short in two ways:
 
 - **Shallow**: It provides names and summaries, not details. "What's the gap score on goal X?" cannot be answered from a title alone.
 - **Static**: Injecting everything "just in case" wastes tokens on every turn, even when the user is asking about something unrelated.
@@ -85,7 +85,7 @@ Returns the current trust state and its governing rules.
 | delta_failure | -10 per failed verification |
 | high_trust_threshold | +20 (above this, some approvals are skipped) |
 | ethics_gate_level | Current ethics gate level (e.g., L1) |
-| execution_boundary | "PulSeed orchestrates goal pursuit. It perceives the world directly through read-only tools (Glob, Grep, Read, Shell, HttpFetch, JsonQuery) and delegates all mutations and complex multi-step work to agents." |
+| execution_boundary | "PulSeed orchestrates goal pursuit. It uses available tools directly for safe local work and delegates when specialization, parallelism, or context isolation helps." |
 
 **Data source**: TrustManager + static definitions
 
@@ -127,7 +127,7 @@ Returns a static description of PulSeed's architecture and capabilities.
 **Content** (hardcoded string):
 - Layer structure (Layer 0-15) with module names
 - Module responsibilities summary
-- Execution boundary: "PulSeed orchestrates goal pursuit. It perceives the world directly through read-only tools (Glob, Grep, Read, Shell, HttpFetch, JsonQuery) and delegates all mutations and complex multi-step work to agents."
+- Execution boundary: "PulSeed orchestrates goal pursuit. It uses available tools directly for safe local work and delegates when specialization, parallelism, or context isolation helps."
 - Runtime shape: CoreLoop for long-lived control plus AgentLoop for bounded tool-using execution- 4-element model: Goal -> Current State -> Gap -> Constraints
 
 **Data source**: Hardcoded text

--- a/src/base/config/__tests__/identity-loader.test.ts
+++ b/src/base/config/__tests__/identity-loader.test.ts
@@ -24,6 +24,9 @@ const {
   clearIdentityCache,
   getAgentName,
   getInternalIdentityPrefix,
+  getRuntimeIdentitySlotContent,
+  getSelfIdentityResponse,
+  getSelfIdentityResponseForBaseDir,
   getUserFacingIdentity,
   DEFAULT_SEED,
   DEFAULT_ROOT,
@@ -180,7 +183,7 @@ describe("getInternalIdentityPrefix()", () => {
 
   it("returns expected default prefix", () => {
     const result = getInternalIdentityPrefix("morning planner");
-    expect(result).toBe("You are Seedy, PulSeed's morning planner. Seedy runs PulSeed, an AI agent orchestration system.");
+    expect(result).toBe("You are Seedy, PulSeed's morning planner. Seedy is the configured agent identity running PulSeed, an AI agent orchestration system.");
   });
 
   it("uses custom agent name when SEED.md sets one", () => {
@@ -189,6 +192,54 @@ Content here.`);
     clearIdentityCache();
     const result = getInternalIdentityPrefix("planner");
     expect(result).toContain("Pebble");
+  });
+});
+
+describe("runtime identity slot", () => {
+  beforeEach(() => {
+    clearIdentityCache();
+    mockReadFileSync.mockReset();
+    mockExistsSync.mockReset();
+  });
+
+  it("states that runtime identity files own self-identity", () => {
+    noFiles();
+    const result = getRuntimeIdentitySlotContent();
+    expect(result).toContain("SEED.md, ROOT.md, and USER.md");
+    expect(result).toContain("Active agent name: Seedy");
+    expect(result).toContain("configured agent running PulSeed");
+    expect(result).toContain("Do not identify as Codex, Claude, ChatGPT");
+  });
+
+  it("answers self-identity from the configured SEED.md agent name", () => {
+    withFile("SEED.md", "# Sprout\n\nCustom identity.");
+    const result = getSelfIdentityResponse();
+    expect(result).toContain("Sprout");
+    expect(result).toContain("SEED.md/ROOT.md/USER.md");
+    expect(result).toContain("runtime identity");
+    expect(result).not.toContain("私はCodex");
+    expect(result).not.toContain("私はClaude");
+    expect(result).not.toContain("私はChatGPT");
+  });
+
+  it("answers English self-identity questions from the same runtime slot", () => {
+    withFile("SEED.md", "# Sprout\n\nCustom identity.");
+    const result = getSelfIdentityResponse("en");
+    expect(result).toContain("I am Sprout");
+    expect(result).toContain("SEED.md/ROOT.md/USER.md");
+    expect(result).toContain("runtime identity");
+    expect(result).not.toContain("I am Codex");
+    expect(result).not.toContain("I am Claude");
+    expect(result).not.toContain("I am ChatGPT");
+  });
+
+  it("can answer self-identity from an explicit runtime base dir without using global cache", () => {
+    noFiles();
+    loadIdentity();
+    const result = getSelfIdentityResponseForBaseDir("/isolated/runtime-home", "en");
+
+    expect(result).toContain("I am Seedy");
+    expect(mockReadFileSync).toHaveBeenCalledWith("/isolated/runtime-home/SEED.md", "utf-8");
   });
 });
 
@@ -204,6 +255,7 @@ describe("getUserFacingIdentity()", () => {
     const result = getUserFacingIdentity();
     expect(result).toContain(DEFAULT_SEED);
     expect(result).toContain(DEFAULT_ROOT);
+    expect(result).toContain("Runtime Identity Slot");
   });
 
   it("includes user content when USER.md has real content", () => {

--- a/src/base/config/identity-loader.ts
+++ b/src/base/config/identity-loader.ts
@@ -14,6 +14,8 @@ export interface Identity {
   user: string;
 }
 
+export type SelfIdentityLanguage = "ja" | "en";
+
 export const DEFAULT_SEED = `# Seedy
 
 I'm Seedy — a small seed with big ambitions.
@@ -70,15 +72,18 @@ function parseAgentName(seedContent: string): string {
   return match?.[1]?.trim() ?? "Seedy";
 }
 
-export function loadIdentity(): Identity {
-  if (_cache) return _cache;
-
-  const base = getPulseedDirPath();
+export function loadIdentityFromBaseDir(base: string): Identity {
   const seed = readFileSafe(path.join(base, "SEED.md"), DEFAULT_SEED);
   const root = readFileSafe(path.join(base, "ROOT.md"), DEFAULT_ROOT);
   const user = readFileSafe(path.join(base, "USER.md"), DEFAULT_USER);
 
-  _cache = { name: parseAgentName(seed), seed, root, user };
+  return { name: parseAgentName(seed), seed, root, user };
+}
+
+export function loadIdentity(): Identity {
+  if (_cache) return _cache;
+
+  _cache = loadIdentityFromBaseDir(getPulseedDirPath());
   return _cache;
 }
 
@@ -91,7 +96,27 @@ export function getAgentName(): string {
 }
 
 function getCoreIdentity(name: string): string {
-  return `${name} runs PulSeed, an AI agent orchestration system.`;
+  return `${name} is the configured agent identity running PulSeed, an AI agent orchestration system.`;
+}
+
+export function getRuntimeIdentitySlotContent(identity: Identity = loadIdentity()): string {
+  const { name } = identity;
+  return [
+    "Runtime Identity Slot",
+    "- PulSeed owns self-identity through the runtime identity files: SEED.md, ROOT.md, and USER.md.",
+    "- SEED.md is the canonical local setup file for the active agent name; its first Markdown heading is the name.",
+    `- Active agent name: ${name}.`,
+    `- When asked who you are or what your name is, answer as ${name}, the configured agent running PulSeed.`,
+    "- Do not identify as Codex, Claude, ChatGPT, OpenAI, Anthropic, or any provider/model unless explicitly discussing the backend provider.",
+  ].join("\n");
+}
+
+export function getSelfIdentityResponse(language: SelfIdentityLanguage = "ja", identity: Identity = loadIdentity()): string {
+  const { name } = identity;
+  if (language === "en") {
+    return `I am ${name}, the configured agent identity running PulSeed. My self-identity is owned by the PulSeed runtime SEED.md/ROOT.md/USER.md files, so I follow that runtime identity rather than a provider or model name.`;
+  }
+  return `私は${name}です。PulSeedを動かす設定済みエージェントとして応答しています。自己認識はPulSeed runtimeのSEED.md/ROOT.md/USER.mdで管理され、プロバイダーやモデル名ではなく、このruntime identityに従います。`;
 }
 
 export function getInternalIdentityPrefix(role: string): string {
@@ -105,10 +130,18 @@ function isUserContentMeaningful(user: string): boolean {
 }
 
 export function getUserFacingIdentity(): string {
-  const { name, seed, root, user } = loadIdentity();
-  const parts = [getCoreIdentity(name), seed.trim(), root.trim()];
+  return getUserFacingIdentityForIdentity(loadIdentity());
+}
+
+export function getUserFacingIdentityForIdentity(identity: Identity): string {
+  const { name, seed, root, user } = identity;
+  const parts = [getCoreIdentity(name), getRuntimeIdentitySlotContent(identity), seed.trim(), root.trim()];
   if (isUserContentMeaningful(user)) {
     parts.push(user.trim());
   }
   return parts.join("\n\n---\n\n");
+}
+
+export function getSelfIdentityResponseForBaseDir(baseDir: string, language: SelfIdentityLanguage = "ja"): string {
+  return getSelfIdentityResponse(language, loadIdentityFromBaseDir(baseDir));
 }

--- a/src/grounding/__tests__/gateway.test.ts
+++ b/src/grounding/__tests__/gateway.test.ts
@@ -104,4 +104,38 @@ describe("GroundingGateway", () => {
     expect(bundle.dynamicSections.some((section) => section.key === "knowledge_query")).toBe(false);
     expect(knowledgeQuery).not.toHaveBeenCalled();
   });
+
+  it("does not reuse cached identity sections across runtime homes", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-grounding-identity-"));
+    const homeA = path.join(tmpRoot, "a");
+    const homeB = path.join(tmpRoot, "b");
+    fs.mkdirSync(homeA, { recursive: true });
+    fs.mkdirSync(homeB, { recursive: true });
+    fs.writeFileSync(path.join(homeA, "SEED.md"), "# SeedA\n\nA identity.", "utf-8");
+    fs.writeFileSync(path.join(homeB, "SEED.md"), "# SeedB\n\nB identity.", "utf-8");
+
+    try {
+      const gateway = createGroundingGateway({ stateManager: makeStateManager() });
+      const first = await gateway.build({
+        surface: "chat",
+        purpose: "general_turn",
+        homeDir: homeA,
+      });
+      const second = await gateway.build({
+        surface: "chat",
+        purpose: "general_turn",
+        homeDir: homeB,
+      });
+
+      const firstIdentity = first.staticSections.find((section) => section.key === "identity")?.content ?? "";
+      const secondIdentity = second.staticSections.find((section) => section.key === "identity")?.content ?? "";
+      expect(firstIdentity).toContain("SeedA");
+      expect(firstIdentity).not.toContain("SeedB");
+      expect(secondIdentity).toContain("SeedB");
+      expect(secondIdentity).not.toContain("SeedA");
+      expect(second.metrics.cacheHits).toBe(0);
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/grounding/gateway.ts
+++ b/src/grounding/gateway.ts
@@ -21,7 +21,7 @@ import { knowledgeQueryProvider } from "./providers/knowledge-provider.js";
 import { lessonsProvider } from "./providers/lessons-provider.js";
 import { repoInstructionsProvider } from "./providers/agents-provider.js";
 import { workspaceFactsProvider } from "./providers/workspace-facts-provider.js";
-import { sortSections } from "./providers/helpers.js";
+import { resolveStateManagerBaseDir, sortSections } from "./providers/helpers.js";
 
 const PROVIDERS: GroundingProvider[] = [
   identityProvider,
@@ -63,6 +63,7 @@ export class DefaultGroundingGateway implements GroundingGateway {
 
     const staticCacheKey = JSON.stringify({
       profile: profile.id,
+      identityBaseDir: request.homeDir ?? resolveStateManagerBaseDir(this.deps.stateManager) ?? null,
       include: {
         identity: profile.include.identity,
         execution_policy: profile.include.execution_policy,

--- a/src/grounding/providers/static-policy-provider.ts
+++ b/src/grounding/providers/static-policy-provider.ts
@@ -1,19 +1,27 @@
-import { getAgentName, getUserFacingIdentity, loadIdentity } from "../../base/config/identity-loader.js";
+import {
+  getAgentName,
+  getUserFacingIdentityForIdentity,
+  loadIdentity,
+  loadIdentityFromBaseDir,
+} from "../../base/config/identity-loader.js";
 import type { GroundingProvider } from "../contracts.js";
-import { makeSection, makeSource } from "./helpers.js";
+import { makeSection, makeSource, resolveStateManagerBaseDir } from "./helpers.js";
 
-export function buildIdentitySectionContent(): string {
-  const { name } = loadIdentity();
+export function buildIdentitySectionContent(baseDir?: string): string {
+  const identity = baseDir ? loadIdentityFromBaseDir(baseDir) : loadIdentity();
+  const { name } = identity;
 
   return [
     `You are ${name}.`,
-    "You run PulSeed, an AI goal pursuit orchestration system.",
+    "You are the configured agent identity running PulSeed, an AI goal pursuit orchestration system.",
+    "PulSeed runtime identity files (SEED.md, ROOT.md, USER.md) own self-identity; persona text and provider/model identity must not override that runtime slot.",
+    `When asked who you are or what your name is, answer as ${name}, the configured agent running PulSeed, not as Codex, Claude, ChatGPT, OpenAI, Anthropic, or another provider/model.`,
     "Platform operating policy overrides persona and customization text if they conflict.",
     "",
     "Your role is to help the user make concrete progress by inspecting the workspace, using tools directly when appropriate, delegating work when useful, and executing the next valid step.",
     "",
     "### Persona And Customization",
-    getUserFacingIdentity().trim(),
+    getUserFacingIdentityForIdentity(identity).trim(),
   ].join("\n");
 }
 
@@ -60,8 +68,9 @@ export function buildApprovalPolicySectionContent(): string {
 export const identityProvider: GroundingProvider = {
   key: "identity",
   kind: "static",
-  async build() {
-    return makeSection("identity", buildIdentitySectionContent(), [
+  async build(context) {
+    const baseDir = context.request.homeDir ?? resolveStateManagerBaseDir(context.deps.stateManager);
+    return makeSection("identity", buildIdentitySectionContent(baseDir), [
       makeSource("identity", "identity-loader", { type: "derived", trusted: true, accepted: true }),
     ]);
   },

--- a/src/interface/chat/__tests__/chat-grounding.test.ts
+++ b/src/interface/chat/__tests__/chat-grounding.test.ts
@@ -43,6 +43,7 @@ import type { StateManager } from "../../../base/state/state-manager.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import { spawnWithTimeout } from "../../../adapters/spawn-helper.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
+import { writeSeedMd } from "../../cli/commands/setup/steps-runtime.js";
 
 // ─── Shared helpers ───
 
@@ -110,7 +111,32 @@ describe("buildSystemPrompt (grounding.ts)", () => {
     const prompt = await buildSystemPrompt({ stateManager: sm, homeDir: tmpDir });
 
     expect(prompt).toContain("Seedy");
-    expect(prompt).toContain("You run PulSeed");
+    expect(prompt).toContain("configured agent identity running PulSeed");
+    expect(prompt).toContain("SEED.md, ROOT.md, USER.md");
+  });
+
+  it("grounds self-description in runtime identity files instead of provider identity", async () => {
+    await fsp.writeFile(path.join(tmpDir, "SEED.md"), "# Sprout\n\nCustom identity.", "utf-8");
+    clearIdentityCache();
+    const sm = makeMockStateManager();
+    const prompt = await buildSystemPrompt({ stateManager: sm, homeDir: tmpDir });
+
+    expect(prompt).toContain("When asked who you are or what your name is, answer as Sprout");
+    expect(prompt).toContain("PulSeed runtime identity files (SEED.md, ROOT.md, USER.md) own self-identity");
+    expect(prompt).toContain("not as Codex, Claude, ChatGPT");
+  });
+
+  it("grounds setup-chosen agent name written to SEED.md", async () => {
+    writeSeedMd(tmpDir, "Sprout");
+    clearIdentityCache();
+    const sm = makeMockStateManager();
+    const prompt = await buildSystemPrompt({ stateManager: sm, homeDir: tmpDir });
+
+    expect(prompt).toContain("Active agent name: Sprout");
+    expect(prompt).toContain("When asked who you are or what your name is, answer as Sprout");
+    expect(prompt).toContain("I'm Sprout");
+    expect(prompt).not.toContain("Active agent name: Seedy");
+    expect(prompt).not.toContain("I'm Seedy");
   });
 
   it("includes fixed policy sections", async () => {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -16,6 +16,7 @@ import { RuntimeOperationStore } from "../../../runtime/store/runtime-operation-
 import type { Goal } from "../../../base/types/goal.js";
 import type { Task } from "../../../base/types/task.js";
 import type { ChatEvent } from "../chat-events.js";
+import { clearIdentityCache } from "../../../base/config/identity-loader.js";
 // Mock context-provider so tests don't walk the real filesystem
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -1712,6 +1713,199 @@ describe("ChatRunner", () => {
         modelTier: "light",
         maxTokens: 256,
       });
+    });
+
+    it("answers Japanese self-identity questions from PulSeed identity without calling the model", async () => {
+      const pulseedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-identity-"));
+      const previousHome = process.env["PULSEED_HOME"];
+      process.env["PULSEED_HOME"] = pulseedHome;
+      clearIdentityCache();
+      const adapter = makeMockAdapter();
+      const llmClient = {
+        sendMessage: vi.fn().mockResolvedValue({
+          content: "Codex",
+          usage: { input_tokens: 2, output_tokens: 3 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn(),
+      };
+
+      try {
+        const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never }));
+        const result = await runner.execute("あなたは誰？", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("Seedy");
+        expect(result.output).toContain("PulSeed");
+        expect(result.output).not.toContain("Codex");
+        expect(llmClient.sendMessage).not.toHaveBeenCalled();
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        if (previousHome === undefined) {
+          delete process.env["PULSEED_HOME"];
+        } else {
+          process.env["PULSEED_HOME"] = previousHome;
+        }
+        clearIdentityCache();
+        fs.rmSync(pulseedHome, { recursive: true, force: true });
+      }
+    });
+
+    it("answers Japanese name questions from custom SEED.md identity without saying Codex", async () => {
+      const pulseedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-identity-"));
+      const previousHome = process.env["PULSEED_HOME"];
+      process.env["PULSEED_HOME"] = pulseedHome;
+      clearIdentityCache();
+      fs.writeFileSync(path.join(pulseedHome, "SEED.md"), "# Sprout\n\nCustom identity.\n", "utf-8");
+      const adapter = makeMockAdapter();
+      const llmClient = {
+        sendMessage: vi.fn().mockResolvedValue({
+          content: "Codex",
+          usage: { input_tokens: 2, output_tokens: 3 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn(),
+      };
+
+      try {
+        const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never }));
+        const result = await runner.execute("名前は何？", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("Sprout");
+        expect(result.output).toContain("PulSeed");
+        expect(result.output).not.toContain("Codex");
+        expect(llmClient.sendMessage).not.toHaveBeenCalled();
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        if (previousHome === undefined) {
+          delete process.env["PULSEED_HOME"];
+        } else {
+          process.env["PULSEED_HOME"] = previousHome;
+        }
+        clearIdentityCache();
+        fs.rmSync(pulseedHome, { recursive: true, force: true });
+      }
+    });
+
+    it("answers English name questions from custom SEED.md identity without saying ChatGPT", async () => {
+      const pulseedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-identity-"));
+      const previousHome = process.env["PULSEED_HOME"];
+      process.env["PULSEED_HOME"] = pulseedHome;
+      clearIdentityCache();
+      fs.writeFileSync(path.join(pulseedHome, "SEED.md"), "# Sprout\n\nCustom identity.\n", "utf-8");
+      const adapter = makeMockAdapter();
+      const llmClient = {
+        sendMessage: vi.fn().mockResolvedValue({
+          content: "ChatGPT",
+          usage: { input_tokens: 2, output_tokens: 3 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn(),
+      };
+
+      try {
+        const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never }));
+        const result = await runner.execute("What is your name?", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("I am Sprout");
+        expect(result.output).toContain("PulSeed");
+        expect(result.output).not.toContain("ChatGPT");
+        expect(llmClient.sendMessage).not.toHaveBeenCalled();
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        if (previousHome === undefined) {
+          delete process.env["PULSEED_HOME"];
+        } else {
+          process.env["PULSEED_HOME"] = previousHome;
+        }
+        clearIdentityCache();
+        fs.rmSync(pulseedHome, { recursive: true, force: true });
+      }
+    });
+
+    it("resolves self-identity from the ChatRunner stateManager base dir", async () => {
+      const pulseedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-identity-"));
+      const previousHome = process.env["PULSEED_HOME"];
+      delete process.env["PULSEED_HOME"];
+      clearIdentityCache();
+      fs.writeFileSync(path.join(pulseedHome, "SEED.md"), "# BaseDirSeed\n\nCustom identity.\n", "utf-8");
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => pulseedHome,
+      } as unknown as StateManager;
+      const adapter = makeMockAdapter();
+      const llmClient = {
+        sendMessage: vi.fn().mockResolvedValue({
+          content: "Codex",
+          usage: { input_tokens: 2, output_tokens: 3 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn(),
+      };
+
+      try {
+        const runner = new ChatRunner(makeDeps({ adapter, stateManager, llmClient: llmClient as never }));
+        const result = await runner.execute("あなたは誰？", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("BaseDirSeed");
+        expect(result.output).toContain("PulSeed");
+        expect(result.output).not.toContain("Codex");
+        expect(llmClient.sendMessage).not.toHaveBeenCalled();
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        if (previousHome === undefined) {
+          delete process.env["PULSEED_HOME"];
+        } else {
+          process.env["PULSEED_HOME"] = previousHome;
+        }
+        clearIdentityCache();
+        fs.rmSync(pulseedHome, { recursive: true, force: true });
+      }
+    });
+
+    it("builds direct-answer static grounding from the ChatRunner stateManager base dir", async () => {
+      const pulseedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-identity-"));
+      const previousHome = process.env["PULSEED_HOME"];
+      delete process.env["PULSEED_HOME"];
+      clearIdentityCache();
+      fs.writeFileSync(path.join(pulseedHome, "SEED.md"), "# StaticPromptSeed\n\nCustom identity.\n", "utf-8");
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => pulseedHome,
+      } as unknown as StateManager;
+      const adapter = makeMockAdapter();
+      const llmClient = {
+        sendMessage: vi.fn().mockResolvedValue({
+          content: "Plain answer",
+          usage: { input_tokens: 2, output_tokens: 3 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn(),
+      };
+
+      try {
+        const runner = new ChatRunner(makeDeps({ adapter, stateManager, llmClient: llmClient as never }));
+        const result = await runner.execute("What is this lane?", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toBe("Plain answer");
+        expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+        const options = llmClient.sendMessage.mock.calls[0]?.[1] as { system?: string } | undefined;
+        expect(options?.system).toContain("StaticPromptSeed");
+        expect(options?.system).toContain("configured agent identity running PulSeed");
+        expect(adapter.execute).not.toHaveBeenCalled();
+      } finally {
+        if (previousHome === undefined) {
+          delete process.env["PULSEED_HOME"];
+        } else {
+          process.env["PULSEED_HOME"] = previousHome;
+        }
+        clearIdentityCache();
+        fs.rmSync(pulseedHome, { recursive: true, force: true });
+      }
     });
 
     it("routes natural TUI ingress through the production selector", async () => {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -10,6 +10,7 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import type { IAdapter, AgentTask } from "../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { getPulseedDirPath } from "../../base/utils/paths.js";
+import { getSelfIdentityResponseForBaseDir } from "../../base/config/identity-loader.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
 import { TaskSchema, type Task } from "../../base/types/task.js";
 import type { Goal } from "../../base/types/goal.js";
@@ -223,6 +224,22 @@ function previewActivityText(value: string, maxChars = ACTIVITY_PREVIEW_CHARS): 
 function formatToolActivity(action: "Running" | "Finished" | "Failed", toolName: string, detail?: string): string {
   const preview = detail ? previewActivityText(detail) : "";
   return preview ? `${action} tool: ${toolName} - ${preview}` : `${action} tool: ${toolName}`;
+}
+
+function resolveSelfIdentityResponse(input: string, baseDir: string): string | null {
+  const normalized = input.trim().toLowerCase().replace(/\s+/g, "");
+  if (!normalized) return null;
+
+  const isEnglishIdentityQuestion = /^(whoareyou|whatisyourname|what'syourname)[?]?$/.test(normalized);
+  const isIdentityQuestion = [
+    /^(あなた|君|きみ|お前|おまえ)(は|って)?(誰|だれ|何者|なにもの)(ですか|なの|です)?[？?]?$/,
+    /^(あなた|君|きみ|お前|おまえ)の名前(は|って)?(何|なに)(ですか|なの|です)?[？?]?$/,
+    /^名前(は|って)?(何|なに)(ですか|なの|です)?[？?]?$/,
+  ].some((pattern) => pattern.test(normalized));
+
+  if (!isIdentityQuestion && !isEnglishIdentityQuestion) return null;
+
+  return getSelfIdentityResponseForBaseDir(baseDir, isEnglishIdentityQuestion ? "en" : "ja");
 }
 
 // ─── ChatRunner ───
@@ -1531,7 +1548,7 @@ export class ChatRunner {
     // Build static grounding once per session; dynamic context is rebuilt each turn.
     if (this.cachedStaticSystemPrompt === null) {
       try {
-        this.cachedStaticSystemPrompt = buildStaticSystemPrompt();
+        this.cachedStaticSystemPrompt = buildStaticSystemPrompt(this.providerConfigBaseDir());
       } catch {
         this.cachedStaticSystemPrompt = "";
       }
@@ -1564,6 +1581,25 @@ export class ChatRunner {
     const start = Date.now();
     const assistantBuffer: AssistantBuffer = { text: "" };
     const turnUsage = this.zeroUsageCounter();
+    const identityResponse = resumeOnly ? null : resolveSelfIdentityResponse(input, this.providerConfigBaseDir());
+
+    if (identityResponse !== null) {
+      const elapsed_ms = Date.now() - start;
+      await history.appendAssistantMessage(identityResponse);
+      this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
+      this.emitEvent({
+        type: "assistant_final",
+        text: identityResponse,
+        persisted: true,
+        ...this.eventBase(eventContext),
+      });
+      this.emitLifecycleEndEvent("completed", elapsed_ms, eventContext, true);
+      return {
+        success: true,
+        output: identityResponse,
+        elapsed_ms,
+      };
+    }
 
     if (selectedRoute?.kind === "runtime_control") {
       const runtimeControlResult = await this.executeRuntimeControlRoute(

--- a/src/interface/chat/grounding.ts
+++ b/src/interface/chat/grounding.ts
@@ -121,9 +121,9 @@ export async function buildChatAgentLoopSystemPrompt(options: GroundingOptions):
   return String(bundle.render("prompt"));
 }
 
-export function buildStaticSystemPrompt(): string {
+export function buildStaticSystemPrompt(baseDir?: string): string {
   return [
-    `## Identity\n${buildIdentitySectionContent()}`,
+    `## Identity\n${buildIdentitySectionContent(baseDir)}`,
     buildExecutionPolicySectionContent(),
     `## Safety And Approval\n${buildApprovalPolicySectionContent()}`,
   ].join("\n\n").trim();

--- a/src/interface/cli/commands/setup/__tests__/steps-runtime.test.ts
+++ b/src/interface/cli/commands/setup/__tests__/steps-runtime.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  getRuntimeIdentitySlotContent,
+  getSelfIdentityResponseForBaseDir,
+  loadIdentityFromBaseDir,
+} from "../../../../../base/config/identity-loader.js";
+import { renderSeedMd, writeSeedMd } from "../steps-runtime.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-setup-identity-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("setup runtime identity files", () => {
+  it("renders the setup agent name into SEED.md heading and body", () => {
+    const rendered = renderSeedMd("Sprout");
+
+    expect(rendered).toContain("# Sprout");
+    expect(rendered).toContain("I'm Sprout");
+    expect(rendered).not.toContain("# Seedy");
+    expect(rendered).not.toContain("I'm Seedy");
+  });
+
+  it("uses setup-created SEED.md as the local self-grounding source", () => {
+    const dir = makeTempDir();
+    writeSeedMd(dir, "Sprout");
+
+    const identity = loadIdentityFromBaseDir(dir);
+    const slot = getRuntimeIdentitySlotContent(identity);
+    const response = getSelfIdentityResponseForBaseDir(dir);
+
+    expect(identity.name).toBe("Sprout");
+    expect(identity.seed).toContain("I'm Sprout");
+    expect(slot).toContain("SEED.md is the canonical local setup file");
+    expect(slot).toContain("Active agent name: Sprout");
+    expect(response).toContain("私はSproutです");
+  });
+});

--- a/src/interface/cli/commands/setup/steps-identity.ts
+++ b/src/interface/cli/commands/setup/steps-identity.ts
@@ -80,6 +80,10 @@ export async function stepSeedyName(initialName?: string): Promise<string> {
       placeholder: "Seedy",
       initialValue: initialName,
       defaultValue: "Seedy",
+      validate: (v) => {
+        if (!v || !v.trim()) return "Agent name cannot be empty.";
+        return undefined;
+      },
     })
   );
   return name;

--- a/src/interface/cli/commands/setup/steps-runtime.ts
+++ b/src/interface/cli/commands/setup/steps-runtime.ts
@@ -155,9 +155,20 @@ export function ensurePulseedDir(): string {
   return dir;
 }
 
+export function normalizeSetupAgentName(agentName: string): string {
+  const normalized = agentName.replace(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : "Seedy";
+}
+
+export function renderSeedMd(agentName: string): string {
+  const normalizedName = normalizeSetupAgentName(agentName);
+  return DEFAULT_SEED
+    .replace(/^#\s+.+$/m, () => `# ${normalizedName}`)
+    .replace(/\bI'm Seedy\b/g, () => `I'm ${normalizedName}`);
+}
+
 export function writeSeedMd(dir: string, agentName: string): void {
-  const content = DEFAULT_SEED.replace(/^#\s+.+$/m, `# ${agentName}`);
-  fs.writeFileSync(path.join(dir, "SEED.md"), content, "utf-8");
+  fs.writeFileSync(path.join(dir, "SEED.md"), renderSeedMd(agentName), "utf-8");
 }
 
 export function writeRootMd(dir: string, presetKey: RootPresetKey): void {

--- a/src/tools/query/ArchitectureTool/ArchitectureTool.ts
+++ b/src/tools/query/ArchitectureTool/ArchitectureTool.ts
@@ -88,7 +88,7 @@ export class ArchitectureTool implements ITool<ArchitectureToolInput, unknown> {
       core_concept: {
         model: "4-element: Goal (with thresholds) -> Current State (observation + confidence) -> Gap -> Constraints",
         core_loop: "observe -> gap -> score -> task -> execute -> verify (NEVER STOP)",
-        execution_boundary: "PulSeed always delegates. Direct actions: LLM calls (thinking) + state read/write only.",
+        execution_boundary: "PulSeed uses available tools directly for safe local work and delegates when specialization, parallelism, or context isolation helps.",
       },
       layers: LAYERS,
       modules: MODULE_DESCRIPTIONS,

--- a/src/tools/query/ArchitectureTool/__tests__/ArchitectureTool.test.ts
+++ b/src/tools/query/ArchitectureTool/__tests__/ArchitectureTool.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { ArchitectureTool } from "../ArchitectureTool.js";
+
+describe("ArchitectureTool", () => {
+  it("describes direct tool use without stale delegate-only wording", async () => {
+    const tool = new ArchitectureTool();
+    const result = await tool.call({}, {
+      cwd: "/repo",
+      goalId: "goal-1",
+      trustBalance: 0,
+      preApproved: false,
+      approvalFn: async () => false,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      core_concept: {
+        execution_boundary: expect.stringContaining("uses available tools directly"),
+      },
+    });
+    expect(JSON.stringify(result.data)).not.toContain("PulSeed always delegates");
+    expect(JSON.stringify(result.data)).not.toContain("state read/write only");
+  });
+});


### PR DESCRIPTION
## Summary
- make PulSeed self-identity answers come from runtime identity files (`SEED.md`, `ROOT.md`, `USER.md`) instead of provider/Codex identity
- pass runtime home/baseDir into static grounding and cache identity sections per runtime home
- update ArchitectureTool/docs wording so self-knowledge no longer claims PulSeed only delegates

## Root cause
Self-identity questions could fall through to the model/provider prompt path, where Codex/provider identity won over PulSeed runtime identity. Static grounding also had baseDir/cache paths that could reuse the wrong runtime identity across homes.

## Validation
- `npx vitest run --config vitest.unit.config.ts src/grounding/__tests__/gateway.test.ts src/base/config/__tests__/identity-loader.test.ts src/interface/chat/__tests__/chat-grounding.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/tools/query/ArchitectureTool/__tests__/ArchitectureTool.test.ts`
- `npm run typecheck`
- `git diff --check`