### PR TITLE
Add runtime session registry CLI queries

### DIFF
--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -1,0 +1,210 @@
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StateManager } from "../../../base/state/state-manager.js";
+import { CharacterConfigManager } from "../../../platform/traits/character-config.js";
+import { dispatchCommand } from "../cli-command-registry.js";
+import { CLIRunner } from "../cli-runner.js";
+import type { CoreLoop } from "../../../orchestrator/loop/core-loop.js";
+import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
+
+describe("runtime registry CLI commands", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+  let characterConfigManager: CharacterConfigManager;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-runtime-cli-"));
+    stateManager = new StateManager(tmpDir, undefined, { walEnabled: false });
+    await stateManager.init();
+    characterConfigManager = new CharacterConfigManager(stateManager);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function runCLI(...args: string[]): Promise<number> {
+    return dispatchCommand(args, false, stateManager, characterConfigManager, { value: null as CoreLoop | null });
+  }
+
+  it("lists runtime sessions from real StateManager registry files", async () => {
+    await writeConversationWithRunningAgent();
+    await stateManager.writeRaw("supervisor-state.json", {
+      workers: [
+        {
+          workerId: "worker-1",
+          goalId: "goal-runtime",
+          startedAt: Date.parse("2026-04-25T00:00:00.000Z"),
+        },
+      ],
+      updatedAt: Date.parse("2026-04-25T00:30:00.000Z"),
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("runtime", "sessions", "--active");
+    const output = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(code).toBe(0);
+    expect(output).toContain("Runtime sessions:");
+    expect(output).toContain("session:agent:agent-session-a");
+    expect(output).toContain("session:coreloop:worker-1");
+    expect(output).not.toContain("session:conversation:chat-a");
+  });
+
+  it("reads runtime sessions through CLIRunner baseDir routing", async () => {
+    await writeConversationWithRunningAgent();
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await new CLIRunner(tmpDir).run(["runtime", "sessions", "--json"]);
+    const output = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(output) as {
+      sessions: Array<{ id: string; parent_session_id: string | null }>;
+    };
+
+    expect(code).toBe(0);
+    expect(parsed.sessions).toContainEqual(expect.objectContaining({
+      id: "session:conversation:chat-a",
+    }));
+    expect(parsed.sessions).toContainEqual(expect.objectContaining({
+      id: "session:agent:agent-session-a",
+      parent_session_id: "session:conversation:chat-a",
+    }));
+  });
+
+  it("prints JSON list output with generated_at and warnings envelope", async () => {
+    await writeConversationWithRunningAgent();
+    await fsp.mkdir(path.join(tmpDir, "runtime", "process-sessions"), { recursive: true });
+    await fsp.writeFile(path.join(tmpDir, "runtime", "process-sessions", "bad.json"), "{not-json", "utf-8");
+    await stateManager.writeRaw("runtime/process-sessions/proc-failed.json", makeProcessSnapshot({
+      session_id: "proc-failed",
+      running: false,
+      exitCode: 1,
+      exitedAt: "2026-04-25T01:00:00.000Z",
+    }));
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("runtime", "runs", "--json", "--attention");
+    const output = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(output) as {
+      schema_version: string;
+      generated_at: string;
+      warnings: Array<{ code: string }>;
+      background_runs: Array<{ id: string; status: string }>;
+    };
+
+    expect(code).toBe(0);
+    expect(parsed.schema_version).toBe("runtime-session-registry-v1");
+    expect(parsed.generated_at).toEqual(expect.any(String));
+    expect(parsed.warnings).toContainEqual(expect.objectContaining({ code: "source_parse_failed" }));
+    expect(parsed.background_runs).toEqual([
+      expect.objectContaining({
+        id: "run:process:proc-failed",
+        status: "failed",
+      }),
+    ]);
+  });
+
+  it("shows one runtime session as JSON", async () => {
+    await writeConversationWithRunningAgent();
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("runtime", "session", "session:agent:agent-session-a", "--json");
+    const output = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(output) as { id: string; kind: string; status: string };
+
+    expect(code).toBe(0);
+    expect(parsed).toMatchObject({
+      id: "session:agent:agent-session-a",
+      kind: "agent",
+      status: "active",
+    });
+  });
+
+  it("shows one runtime run as JSON", async () => {
+    await stateManager.writeRaw("runtime/process-sessions/proc-ok.json", makeProcessSnapshot({
+      session_id: "proc-ok",
+      running: false,
+      exitCode: 0,
+      exitedAt: "2026-04-25T01:00:00.000Z",
+    }));
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("runtime", "run", "run:process:proc-ok", "--json");
+    const output = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(output) as { id: string; kind: string; status: string };
+
+    expect(code).toBe(0);
+    expect(parsed).toMatchObject({
+      id: "run:process:proc-ok",
+      kind: "process_run",
+      status: "succeeded",
+    });
+  });
+
+  it("returns 1 and writes console.error for missing detail records", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const code = await runCLI("runtime", "run", "run:process:missing", "--json");
+    const errors = errorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(code).toBe(1);
+    expect(errors).toContain("Runtime run not found: run:process:missing");
+  });
+
+  async function writeConversationWithRunningAgent(): Promise<void> {
+    await stateManager.writeRaw("chat/sessions/chat-a.json", {
+      id: "chat-a",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:10:00.000Z",
+      title: "Runtime registry",
+      messages: [],
+      agentLoopStatePath: "chat/agentloop/agent-a.state.json",
+      agentLoopStatus: "running",
+      agentLoopResumable: true,
+      agentLoopUpdatedAt: "2026-04-25T00:11:00.000Z",
+    });
+    await stateManager.writeRaw("chat/agentloop/agent-a.state.json", {
+      sessionId: "agent-session-a",
+      traceId: "trace-a",
+      turnId: "turn-a",
+      goalId: "goal-a",
+      cwd: "/repo",
+      modelRef: "native:test",
+      messages: [],
+      modelTurns: 1,
+      toolCalls: 0,
+      compactions: 0,
+      completionValidationAttempts: 0,
+      calledTools: [],
+      lastToolLoopSignature: null,
+      repeatedToolLoopCount: 0,
+      finalText: "",
+      status: "running",
+      updatedAt: "2026-04-25T00:12:00.000Z",
+    });
+  }
+});
+
+function makeProcessSnapshot(overrides: Partial<ProcessSessionSnapshot> = {}): ProcessSessionSnapshot {
+  return {
+    session_id: overrides.session_id ?? "proc-1",
+    label: overrides.label ?? "training",
+    command: overrides.command ?? "node",
+    args: overrides.args ?? ["train.js"],
+    cwd: overrides.cwd ?? "/repo",
+    pid: overrides.pid ?? 12345,
+    running: overrides.running ?? true,
+    exitCode: overrides.exitCode ?? null,
+    signal: overrides.signal ?? null,
+    startedAt: overrides.startedAt ?? "2026-04-25T00:00:00.000Z",
+    ...(overrides.exitedAt ? { exitedAt: overrides.exitedAt } : {}),
+    bufferedChars: overrides.bufferedChars ?? 0,
+    metadataRelativePath: overrides.metadataRelativePath ?? `runtime/process-sessions/${overrides.session_id ?? "proc-1"}.json`,
+    artifactRefs: overrides.artifactRefs ?? [],
+  };
+}

--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -18,6 +18,7 @@ import { dispatchGoalCommand } from "./commands/goal-dispatch.js";
 import { cmdPluginList, cmdPluginInstall, cmdPluginRemove, cmdPluginUpdate, cmdPluginSearch } from "./commands/plugin.js";
 import { cmdReport } from "./commands/report.js";
 import { cmdApprovalList } from "./commands/approval.js";
+import { cmdRuntime } from "./commands/runtime.js";
 import {
   cmdProvider,
   cmdConfigCharacter,
@@ -251,6 +252,10 @@ export async function dispatchCommand(
     logger.error(`Unknown approval subcommand: "${approvalSubcommand}"`);
     logger.error("Available: approval list");
     return 1;
+  }
+
+  if (subcommand === "runtime") {
+    return await cmdRuntime(stateManager, argv.slice(1));
   }
 
   if (subcommand === "log") {

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -1,0 +1,273 @@
+// ─── pulseed runtime commands (read-only) ───
+
+import { parseArgs } from "node:util";
+
+import { StateManager } from "../../../base/state/state-manager.js";
+import { createRuntimeSessionRegistry } from "../../../runtime/session-registry/index.js";
+import type {
+  BackgroundRun,
+  RuntimeSession,
+  RuntimeSessionRegistrySnapshot,
+  RuntimeSessionRegistryWarning,
+} from "../../../runtime/session-registry/types.js";
+import { getCliLogger } from "../cli-logger.js";
+import { formatOperationError } from "../utils.js";
+
+const ID_WIDTH = 34;
+const KIND_WIDTH = 12;
+const STATUS_WIDTH = 10;
+const UPDATED_WIDTH = 24;
+const WORKSPACE_WIDTH = 26;
+const TITLE_WIDTH = 32;
+
+type RuntimeListValues = {
+  json?: boolean;
+  active?: boolean;
+  attention?: boolean;
+};
+
+function formatCell(value: string | null | undefined, maxLen: number): string {
+  const normalized = (value ?? "-").replace(/\s+/g, " ").trim() || "-";
+  return normalized.length > maxLen ? `${normalized.slice(0, maxLen - 3)}...` : normalized;
+}
+
+function dateLabel(value: string | null | undefined): string {
+  return value ? formatCell(value, UPDATED_WIDTH) : "-";
+}
+
+function activeSession(session: RuntimeSession): boolean {
+  return session.status === "active";
+}
+
+function activeRun(run: BackgroundRun): boolean {
+  return run.status === "queued" || run.status === "running";
+}
+
+function attentionRun(run: BackgroundRun): boolean {
+  return run.status === "failed" || run.status === "timed_out" || run.status === "lost";
+}
+
+function filterSessions(snapshot: RuntimeSessionRegistrySnapshot, activeOnly: boolean): RuntimeSession[] {
+  return activeOnly ? snapshot.sessions.filter(activeSession) : snapshot.sessions;
+}
+
+function filterRuns(snapshot: RuntimeSessionRegistrySnapshot, activeOnly: boolean, attentionOnly: boolean): BackgroundRun[] {
+  return snapshot.background_runs.filter((run) => {
+    if (activeOnly && !activeRun(run)) return false;
+    if (attentionOnly && !attentionRun(run)) return false;
+    return true;
+  });
+}
+
+function printWarningsSummary(warnings: RuntimeSessionRegistryWarning[]): void {
+  if (warnings.length > 0) {
+    console.log(`Warnings: ${warnings.length}`);
+  }
+}
+
+function printSessionRows(sessions: RuntimeSession[], warnings: RuntimeSessionRegistryWarning[]): void {
+  if (sessions.length === 0) {
+    console.log("No runtime sessions found.");
+    printWarningsSummary(warnings);
+    return;
+  }
+
+  console.log("Runtime sessions:\n");
+  console.log(
+    `${"ID".padEnd(ID_WIDTH)} ${"KIND".padEnd(KIND_WIDTH)} ${"STATUS".padEnd(STATUS_WIDTH)} ${"UPDATED".padEnd(UPDATED_WIDTH)} ${"WORKSPACE".padEnd(WORKSPACE_WIDTH)} TITLE`
+  );
+  console.log("-".repeat(116));
+  for (const session of sessions) {
+    console.log(
+      `${formatCell(session.id, ID_WIDTH).padEnd(ID_WIDTH)} ${session.kind.padEnd(KIND_WIDTH)} ${session.status.padEnd(STATUS_WIDTH)} ${dateLabel(session.updated_at).padEnd(UPDATED_WIDTH)} ${formatCell(session.workspace, WORKSPACE_WIDTH).padEnd(WORKSPACE_WIDTH)} ${formatCell(session.title, TITLE_WIDTH)}`
+    );
+  }
+  console.log(`\nTotal: ${sessions.length} session(s)`);
+  printWarningsSummary(warnings);
+}
+
+function printRunRows(runs: BackgroundRun[], warnings: RuntimeSessionRegistryWarning[]): void {
+  if (runs.length === 0) {
+    console.log("No runtime runs found.");
+    printWarningsSummary(warnings);
+    return;
+  }
+
+  console.log("Runtime runs:\n");
+  console.log(
+    `${"ID".padEnd(ID_WIDTH)} ${"KIND".padEnd(KIND_WIDTH)} ${"STATUS".padEnd(STATUS_WIDTH)} ${"UPDATED".padEnd(UPDATED_WIDTH)} ${"WORKSPACE".padEnd(WORKSPACE_WIDTH)} TITLE`
+  );
+  console.log("-".repeat(116));
+  for (const run of runs) {
+    console.log(
+      `${formatCell(run.id, ID_WIDTH).padEnd(ID_WIDTH)} ${run.kind.padEnd(KIND_WIDTH)} ${run.status.padEnd(STATUS_WIDTH)} ${dateLabel(run.updated_at).padEnd(UPDATED_WIDTH)} ${formatCell(run.workspace, WORKSPACE_WIDTH).padEnd(WORKSPACE_WIDTH)} ${formatCell(run.title, TITLE_WIDTH)}`
+    );
+  }
+  console.log(`\nTotal: ${runs.length} run(s)`);
+  printWarningsSummary(warnings);
+}
+
+function refLabel(ref: { kind: string; id: string | null; relative_path: string | null; path: string | null } | null): string {
+  if (!ref) return "-";
+  const target = ref.relative_path ?? ref.path ?? ref.id ?? "-";
+  return `${ref.kind}:${target}`;
+}
+
+function printSessionDetail(session: RuntimeSession): void {
+  console.log(`Runtime session: ${session.id}`);
+  console.log(`  Kind:        ${session.kind}`);
+  console.log(`  Status:      ${session.status}`);
+  console.log(`  Parent:      ${session.parent_session_id ?? "-"}`);
+  console.log(`  Title:       ${session.title ?? "-"}`);
+  console.log(`  Workspace:   ${session.workspace ?? "-"}`);
+  console.log(`  Created:     ${session.created_at ?? "-"}`);
+  console.log(`  Updated:     ${session.updated_at ?? "-"}`);
+  console.log(`  Last event:  ${session.last_event_at ?? "-"}`);
+  console.log(`  Resumable:   ${session.resumable ? "yes" : "no"}`);
+  console.log(`  Attachable:  ${session.attachable ? "yes" : "no"}`);
+  console.log(`  Transcript:  ${refLabel(session.transcript_ref)}`);
+  console.log(`  State:       ${refLabel(session.state_ref)}`);
+  console.log(`  Reply:       ${session.reply_target ? session.reply_target.channel : "-"}`);
+  console.log(`  Sources:     ${session.source_refs.map(refLabel).join(", ") || "-"}`);
+}
+
+function printRunDetail(run: BackgroundRun): void {
+  console.log(`Runtime run: ${run.id}`);
+  console.log(`  Kind:        ${run.kind}`);
+  console.log(`  Status:      ${run.status}`);
+  console.log(`  Parent:      ${run.parent_session_id ?? "-"}`);
+  console.log(`  Child:       ${run.child_session_id ?? "-"}`);
+  console.log(`  Process:     ${run.process_session_id ?? "-"}`);
+  console.log(`  Notify:      ${run.notify_policy}`);
+  console.log(`  Title:       ${run.title ?? "-"}`);
+  console.log(`  Workspace:   ${run.workspace ?? "-"}`);
+  console.log(`  Created:     ${run.created_at ?? "-"}`);
+  console.log(`  Started:     ${run.started_at ?? "-"}`);
+  console.log(`  Updated:     ${run.updated_at ?? "-"}`);
+  console.log(`  Completed:   ${run.completed_at ?? "-"}`);
+  console.log(`  Summary:     ${run.summary ?? "-"}`);
+  console.log(`  Error:       ${run.error ?? "-"}`);
+  console.log(`  Artifacts:   ${run.artifacts.map((artifact) => artifact.label).join(", ") || "-"}`);
+  console.log(`  Sources:     ${run.source_refs.map(refLabel).join(", ") || "-"}`);
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function parseListArgs(args: string[], command: string): RuntimeListValues {
+  const logger = getCliLogger();
+  try {
+    const { values } = parseArgs({
+      args,
+      options: {
+        json: { type: "boolean" },
+        active: { type: "boolean" },
+        attention: { type: "boolean" },
+      },
+      strict: false,
+    }) as { values: RuntimeListValues };
+    return values;
+  } catch (err) {
+    logger.error(formatOperationError(`parse runtime ${command} arguments`, err));
+    return {};
+  }
+}
+
+function parseDetailArgs(args: string[], command: string): { id?: string; json?: boolean } {
+  const logger = getCliLogger();
+  try {
+    const { values, positionals } = parseArgs({
+      args,
+      options: {
+        json: { type: "boolean" },
+      },
+      allowPositionals: true,
+      strict: false,
+    }) as { values: { json?: boolean }; positionals: string[] };
+    return { id: positionals[0], json: values.json };
+  } catch (err) {
+    logger.error(formatOperationError(`parse runtime ${command} arguments`, err));
+    return {};
+  }
+}
+
+export async function cmdRuntime(stateManager: StateManager, args: string[]): Promise<number> {
+  const logger = getCliLogger();
+  const runtimeSubcommand = args[0];
+
+  if (!runtimeSubcommand) {
+    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>");
+    return 1;
+  }
+
+  const registry = createRuntimeSessionRegistry({ stateManager });
+
+  if (runtimeSubcommand === "sessions") {
+    const values = parseListArgs(args.slice(1), "sessions");
+    const snapshot = await registry.snapshot();
+    const sessions = filterSessions(snapshot, values.active === true);
+    if (values.json) {
+      printJson({
+        schema_version: snapshot.schema_version,
+        generated_at: snapshot.generated_at,
+        warnings: snapshot.warnings,
+        sessions,
+      });
+    } else {
+      printSessionRows(sessions, snapshot.warnings);
+    }
+    return 0;
+  }
+
+  if (runtimeSubcommand === "runs") {
+    const values = parseListArgs(args.slice(1), "runs");
+    const snapshot = await registry.snapshot();
+    const runs = filterRuns(snapshot, values.active === true, values.attention === true);
+    if (values.json) {
+      printJson({
+        schema_version: snapshot.schema_version,
+        generated_at: snapshot.generated_at,
+        warnings: snapshot.warnings,
+        background_runs: runs,
+      });
+    } else {
+      printRunRows(runs, snapshot.warnings);
+    }
+    return 0;
+  }
+
+  if (runtimeSubcommand === "session") {
+    const values = parseDetailArgs(args.slice(1), "session");
+    if (!values.id) {
+      logger.error("Error: session ID is required. Usage: pulseed runtime session <id> [--json]");
+      return 1;
+    }
+    const session = await registry.getSession(values.id);
+    if (!session) {
+      console.error(`Runtime session not found: ${values.id}`);
+      return 1;
+    }
+    values.json ? printJson(session) : printSessionDetail(session);
+    return 0;
+  }
+
+  if (runtimeSubcommand === "run") {
+    const values = parseDetailArgs(args.slice(1), "run");
+    if (!values.id) {
+      logger.error("Error: run ID is required. Usage: pulseed runtime run <id> [--json]");
+      return 1;
+    }
+    const run = await registry.getRun(values.id);
+    if (!run) {
+      console.error(`Runtime run not found: ${values.id}`);
+      return 1;
+    }
+    values.json ? printJson(run) : printRunDetail(run);
+    return 0;
+  }
+
+  logger.error(`Unknown runtime subcommand: "${runtimeSubcommand}"`);
+  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>");
+  return 1;
+}

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -43,6 +43,10 @@ Usage:
   pulseed report --goal <id>           Show latest report
   pulseed usage <scope>                Show usage totals for session, goal, daemon, or schedule
   pulseed approval list [--resolved]   List pending durable approvals
+  pulseed runtime sessions [--json] [--active]  List runtime sessions
+  pulseed runtime runs [--json] [--active] [--attention]  List background runs
+  pulseed runtime session <id> [--json]  Show one runtime session
+  pulseed runtime run <id> [--json]   Show one background run
   pulseed log --goal <id>              View observation and gap history log
   pulseed tui                          Launch the interactive TUI
   pulseed start --goal <id>            Start daemon mode for one or more goals


### PR DESCRIPTION
## Summary
- add read-only `pulseed runtime` CLI queries for sessions and background runs
- preserve registry JSON envelopes for list output and full item JSON for detail output
- cover dispatcher and `CLIRunner(baseDir)` routing with real StateManager fixtures

## Scope
- Phase 2 for #742 only
- no dashboard/TUI wiring
- no daemon HTTP calls or write behavior

## Test plan
- `npm test -- --run src/interface/cli/__tests__/runtime-command.test.ts`
- `npm run typecheck -- --pretty false`
- `npm run test:integration -- src/runtime/session-registry/__tests__/runtime-session-registry.test.ts`
- `npm run lint:boundaries -- --quiet src/interface/cli/commands/runtime.ts src/interface/cli/__tests__/runtime-command.test.ts`
- `git diff --check`
- `npm run test:changed`
