### PR TITLE
Connect chat sessions to runtime registry

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -17,6 +17,7 @@ import type { Goal } from "../../../base/types/goal.js";
 import type { Task } from "../../../base/types/task.js";
 import type { ChatEvent } from "../chat-events.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
+import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
 // Mock context-provider so tests don't walk the real filesystem
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -51,6 +52,51 @@ function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
     stateManager: makeMockStateManager(),
     adapter: makeMockAdapter(),
     ...overrides,
+  };
+}
+
+function makeAgentLoopState(overrides: Partial<{
+  sessionId: string;
+  status: "running" | "completed" | "failed";
+  updatedAt: string;
+}> = {}) {
+  return {
+    sessionId: overrides.sessionId ?? "agent-session-a",
+    traceId: "trace-a",
+    turnId: "turn-a",
+    goalId: "goal-a",
+    cwd: "/repo",
+    modelRef: "native:test",
+    messages: [],
+    modelTurns: 1,
+    toolCalls: 0,
+    compactions: 0,
+    completionValidationAttempts: 0,
+    calledTools: [],
+    lastToolLoopSignature: null,
+    repeatedToolLoopCount: 0,
+    finalText: "",
+    status: overrides.status ?? "running",
+    updatedAt: overrides.updatedAt ?? "2026-04-25T00:12:00.000Z",
+  };
+}
+
+function makeProcessSnapshot(overrides: Partial<ProcessSessionSnapshot> = {}): ProcessSessionSnapshot {
+  return {
+    session_id: overrides.session_id ?? "proc-1",
+    label: overrides.label ?? "training",
+    command: overrides.command ?? "node",
+    args: overrides.args ?? ["train.js"],
+    cwd: overrides.cwd ?? "/repo",
+    pid: overrides.pid ?? 12345,
+    running: overrides.running ?? true,
+    exitCode: overrides.exitCode ?? null,
+    signal: overrides.signal ?? null,
+    startedAt: overrides.startedAt ?? "2026-04-25T00:00:00.000Z",
+    ...(overrides.exitedAt ? { exitedAt: overrides.exitedAt } : {}),
+    bufferedChars: overrides.bufferedChars ?? 0,
+    metadataRelativePath: overrides.metadataRelativePath ?? `runtime/process-sessions/${overrides.session_id ?? "proc-1"}.json`,
+    artifactRefs: overrides.artifactRefs ?? [],
   };
 }
 
@@ -637,7 +683,99 @@ describe("ChatRunner", () => {
       }
     });
 
-    it("/sessions lists prior chat sessions", async () => {
+    it("/resume maps runtime conversation and agent ids to owning chat ids", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-resume-runtime-conversation-"));
+      try {
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("chat/sessions/chat-runtime.json", {
+          id: "chat-runtime",
+          cwd: "/loaded-repo",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:10:00.000Z",
+          title: "Runtime Chat",
+          messages: [],
+          agentLoopStatePath: "chat/agentloop/chat-runtime.state.json",
+          agentLoopStatus: "running",
+          agentLoopResumable: true,
+        });
+        await stateManager.writeRaw("chat/agentloop/chat-runtime.state.json", makeAgentLoopState({
+          sessionId: "agent-runtime",
+        }));
+        const chatAgentLoopRunner = {
+          execute: vi.fn().mockResolvedValue({
+            success: true,
+            output: "Resumed runtime conversation",
+            error: null,
+            exit_code: null,
+            elapsed_ms: 30,
+            stopped_reason: "completed",
+          }),
+        } as unknown as ChatAgentLoopRunner;
+        const runner = new ChatRunner(makeDeps({ stateManager, chatAgentLoopRunner }));
+
+        const conversation = await runner.execute("/resume session:conversation:chat-runtime", "/repo");
+        const agent = await runner.execute("/resume session:agent:agent-runtime", "/repo");
+
+        expect(conversation.success).toBe(true);
+        expect(conversation.output).toBe("Resumed runtime conversation");
+        expect(agent.success).toBe(true);
+        expect(agent.output).toBe("Resumed runtime conversation");
+        expect(runner.getSessionId()).toBe("chat-runtime");
+        expect(chatAgentLoopRunner.execute).toHaveBeenCalledTimes(2);
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/resume rejects non-chat runtime sessions and runs before native agentloop execution", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-resume-runtime-negative-"));
+      try {
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("supervisor-state.json", {
+          workers: [
+            {
+              workerId: "worker-1",
+              goalId: "goal-a",
+              startedAt: Date.parse("2026-04-25T00:00:00.000Z"),
+            },
+          ],
+          updatedAt: Date.parse("2026-04-25T00:30:00.000Z"),
+        });
+        await stateManager.writeRaw("runtime/process-sessions/proc-running.json", makeProcessSnapshot({
+          session_id: "proc-running",
+          pid: process.pid,
+          running: true,
+        }));
+        const chatAgentLoopRunner = {
+          execute: vi.fn().mockResolvedValue({
+            success: true,
+            output: "should not run",
+            error: null,
+            exit_code: null,
+            elapsed_ms: 30,
+            stopped_reason: "completed",
+          }),
+        } as unknown as ChatAgentLoopRunner;
+        const runner = new ChatRunner(makeDeps({ stateManager, chatAgentLoopRunner }));
+
+        const coreloop = await runner.execute("/resume session:coreloop:worker-1", "/repo");
+        const processRun = await runner.execute("/resume run:process:proc-running", "/repo");
+
+        expect(coreloop.success).toBe(false);
+        expect(coreloop.output).toContain("not chat-resumable");
+        expect(coreloop.output).toContain("pulseed runtime session session:coreloop:worker-1");
+        expect(processRun.success).toBe(false);
+        expect(processRun.output).toContain("not chat-resumable");
+        expect(processRun.output).toContain("pulseed runtime run run:process:proc-running");
+        expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/sessions lists chat sessions with registry runtime run summaries", async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-sessions-"));
       try {
         const stateManager = new StateManager(tmpDir);
@@ -649,14 +787,44 @@ describe("ChatRunner", () => {
           updatedAt: "2026-01-01T00:00:01.000Z",
           title: "Prior",
           messages: [],
+          agentLoopStatePath: "chat/agentloop/prior-session.state.json",
+          agentLoopStatus: "running",
+          agentLoopResumable: true,
+          agentLoopUpdatedAt: "2026-01-01T00:00:02.000Z",
         });
+        await stateManager.writeRaw("chat/agentloop/prior-session.state.json", makeAgentLoopState({
+          sessionId: "agent-prior",
+          updatedAt: "2026-01-01T00:00:02.000Z",
+        }));
+        await stateManager.writeRaw("supervisor-state.json", {
+          workers: [
+            {
+              workerId: "worker-1",
+              goalId: "goal-a",
+              startedAt: Date.parse("2026-04-25T00:00:00.000Z"),
+            },
+          ],
+          updatedAt: Date.parse("2026-04-25T00:30:00.000Z"),
+        });
+        await stateManager.writeRaw("runtime/process-sessions/proc-running.json", makeProcessSnapshot({
+          session_id: "proc-running",
+          pid: process.pid,
+          running: true,
+        }));
         const runner = new ChatRunner(makeDeps({ stateManager }));
 
         const result = await runner.execute("/sessions", "/repo");
 
         expect(result.success).toBe(true);
+        expect(result.output).toContain("Chat sessions:");
         expect(result.output).toContain("prior-session");
+        expect(result.output).toContain("runtime session:conversation:prior-session");
         expect(result.output).toContain("Prior");
+        expect(result.output).toContain("run:agent:agent-prior");
+        expect(result.output).toContain("session:coreloop:worker-1");
+        expect(result.output).toContain("run:coreloop:worker-1");
+        expect(result.output).toContain("run:process:proc-running");
+        expect(result.output).not.toContain("{");
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
@@ -668,6 +836,33 @@ describe("ChatRunner", () => {
         const stateManager = new StateManager(tmpDir);
         await stateManager.init();
         await stateManager.saveGoal(makeGoal("goal-a"));
+        await stateManager.writeRaw("chat/sessions/chat-runtime.json", {
+          id: "chat-runtime",
+          cwd: "/repo",
+          createdAt: "2026-04-25T00:00:00.000Z",
+          updatedAt: "2026-04-25T00:10:00.000Z",
+          title: "Runtime Chat",
+          messages: [],
+          agentLoopStatePath: "chat/agentloop/chat-runtime.state.json",
+          agentLoopStatus: "running",
+          agentLoopResumable: true,
+        });
+        await stateManager.writeRaw("chat/agentloop/chat-runtime.state.json", makeAgentLoopState({
+          sessionId: "agent-runtime",
+          updatedAt: "2026-04-25T00:12:00.000Z",
+        }));
+        await stateManager.writeRaw("runtime/process-sessions/proc-failed.json", makeProcessSnapshot({
+          session_id: "proc-failed",
+          running: false,
+          exitCode: 1,
+          exitedAt: "2026-04-25T01:00:00.000Z",
+        }));
+        await stateManager.writeRaw("runtime/process-sessions/proc-lost.json", makeProcessSnapshot({
+          session_id: "proc-lost",
+          running: false,
+          exitCode: null,
+          signal: null,
+        }));
         const adapter = makeMockAdapter();
         const runner = new ChatRunner(makeDeps({ stateManager, adapter }));
 
@@ -678,9 +873,16 @@ describe("ChatRunner", () => {
         expect(status.success).toBe(true);
         expect(status.output).toContain("Active goals");
         expect(status.output).toContain("goal-a");
+        expect(status.output).toContain("Active runtime sessions:");
+        expect(status.output).toContain("session:agent:agent-runtime");
+        expect(status.output).toContain("Background runs (queued/running/attention-needed):");
+        expect(status.output).toContain("run:agent:agent-runtime");
+        expect(status.output).toContain("run:process:proc-failed");
+        expect(status.output).toContain("run:process:proc-lost");
         expect(focused.success).toBe(true);
         expect(focused.output).toContain("Goal status: Goal goal-a");
         expect(focused.output).toContain("Dimensions:");
+        expect(focused.output).not.toContain("Active runtime sessions:");
         expect(goals.success).toBe(true);
         expect(goals.output).toContain("Goals:");
         expect(adapter.execute).not.toHaveBeenCalled();

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -66,6 +66,13 @@ import {
   type IngressReplyTarget,
   type SelectedChatRoute,
 } from "./ingress-router.js";
+import { createRuntimeSessionRegistry } from "../../runtime/session-registry/index.js";
+import type {
+  BackgroundRun,
+  RuntimeSession,
+  RuntimeSessionRegistrySnapshot,
+  RuntimeSessionRegistryWarning,
+} from "../../runtime/session-registry/types.js";
 
 // ─── Types ───
 
@@ -444,14 +451,106 @@ export class ChatRunner {
     };
   }
 
-  private formatSessionsList(entries: Array<{ id: string; title: string | null; cwd: string; updatedAt: string; messageCount: number; agentLoopResumable: boolean }>): string {
-    if (entries.length === 0) return "No chat sessions found.";
-    const lines = entries.map((entry) => {
-      const title = entry.title ? ` "${entry.title}"` : "";
-      const resumable = entry.agentLoopResumable ? " resumable" : "";
-      return `${entry.id}${title} - ${entry.messageCount} message(s), updated ${entry.updatedAt}, cwd ${entry.cwd}${resumable}`;
-    });
-    return `Chat sessions:\n${lines.join("\n")}`;
+  private formatRuntimeTimestamp(value: string | null | undefined): string {
+    return value ?? "unknown";
+  }
+
+  private formatRuntimeTitle(value: string | null | undefined): string {
+    return value ? ` "${value}"` : "";
+  }
+
+  private runtimeWarningLine(warnings: RuntimeSessionRegistryWarning[]): string | null {
+    return warnings.length > 0 ? `Warnings: ${warnings.length}` : null;
+  }
+
+  private activeRuntimeSession(session: RuntimeSession): boolean {
+    return session.status === "active";
+  }
+
+  private statusRuntimeRun(run: BackgroundRun): boolean {
+    return run.status === "queued"
+      || run.status === "running"
+      || run.status === "failed"
+      || run.status === "timed_out"
+      || run.status === "lost";
+  }
+
+  private compactRunLine(run: BackgroundRun): string {
+    const title = this.formatRuntimeTitle(run.title);
+    const updated = this.formatRuntimeTimestamp(run.updated_at ?? run.started_at ?? run.created_at);
+    const summary = run.summary ? ` - ${run.summary.replace(/\s+/g, " ").trim()}` : "";
+    const error = run.error ? ` - error: ${run.error.replace(/\s+/g, " ").trim()}` : "";
+    return `- ${run.id}${title} [${run.kind}, ${run.status}], updated ${updated}${summary}${error}`;
+  }
+
+  private compactSessionLine(session: RuntimeSession): string {
+    const displayId = session.kind === "conversation"
+      ? session.transcript_ref?.id ?? session.id.replace(/^session:conversation:/, "")
+      : session.id;
+    const title = this.formatRuntimeTitle(session.title);
+    const updated = this.formatRuntimeTimestamp(session.updated_at ?? session.last_event_at ?? session.created_at);
+    const workspace = session.workspace ? `, cwd ${session.workspace}` : "";
+    const resumable = session.resumable ? ", resumable" : "";
+    const attachable = session.attachable ? ", attachable" : "";
+    const runtimeId = displayId === session.id ? "" : `, runtime ${session.id}`;
+    return `- ${displayId}${title} [${session.kind}, ${session.status}], updated ${updated}${workspace}${resumable}${attachable}${runtimeId}`;
+  }
+
+  private formatRuntimeSessionsList(snapshot: RuntimeSessionRegistrySnapshot): string {
+    const chatSessions = snapshot.sessions.filter((session) => session.kind === "conversation");
+    const nonChatSessions = snapshot.sessions.filter((session) => session.kind !== "conversation");
+    const lines: string[] = ["Chat sessions:"];
+
+    if (chatSessions.length === 0) {
+      lines.push("No chat sessions found.");
+    } else {
+      for (const session of chatSessions) {
+        lines.push(this.compactSessionLine(session));
+        const runs = snapshot.background_runs.filter((run) => run.parent_session_id === session.id);
+        for (const run of runs) {
+          lines.push(`  ${this.compactRunLine(run)}`);
+        }
+      }
+    }
+
+    if (nonChatSessions.length > 0) {
+      lines.push("", "Other runtime sessions:");
+      lines.push(...nonChatSessions.map((session) => this.compactSessionLine(session)));
+    }
+
+    if (snapshot.background_runs.length > 0) {
+      lines.push("", "Background runs:");
+      lines.push(...snapshot.background_runs.map((run) => this.compactRunLine(run)));
+    }
+
+    const warningLine = this.runtimeWarningLine(snapshot.warnings);
+    if (warningLine) lines.push("", warningLine);
+    return lines.join("\n");
+  }
+
+  private formatRuntimeStatus(snapshot: RuntimeSessionRegistrySnapshot): string {
+    const activeSessions = snapshot.sessions.filter((session) => this.activeRuntimeSession(session));
+    const statusRuns = snapshot.background_runs.filter((run) => this.statusRuntimeRun(run));
+    const lines: string[] = [];
+
+    if (activeSessions.length > 0) {
+      lines.push("Active runtime sessions:");
+      lines.push(...activeSessions.map((session) => this.compactSessionLine(session)));
+    }
+
+    if (statusRuns.length > 0) {
+      if (lines.length > 0) lines.push("");
+      lines.push("Background runs (queued/running/attention-needed):");
+      lines.push(...statusRuns.map((run) => this.compactRunLine(run)));
+    }
+
+    const warningLine = this.runtimeWarningLine(snapshot.warnings);
+    if (warningLine) {
+      if (lines.length > 0) lines.push("");
+      lines.push(warningLine);
+    }
+
+    return lines.length > 0 ? lines.join("\n") : "No active runtime sessions or running/failed/lost background runs found.";
   }
 
   private formatHistory(session: LoadedChatSession): string {
@@ -546,14 +645,19 @@ export class ChatRunner {
       return { success: true, output: lines.join("\n"), elapsed_ms: Date.now() - start };
     }
 
-    const goals = await this.loadGoals();
+    const registry = createRuntimeSessionRegistry({ stateManager: this.deps.stateManager });
+    const [goals, runtimeSnapshot] = await Promise.all([
+      this.loadGoals(),
+      registry.snapshot(),
+    ]);
     const active = this.activeGoals(goals);
+    const runtimeStatus = this.formatRuntimeStatus(runtimeSnapshot);
     if (active.length === 0) {
-      return { success: true, output: "No active goals found.", elapsed_ms: Date.now() - start };
+      return { success: true, output: `No active goals found.\n\n${runtimeStatus}`, elapsed_ms: Date.now() - start };
     }
     return {
       success: true,
-      output: `Active goals:\n${active.map((goal) => this.formatGoalLine(goal)).join("\n")}`,
+      output: `Active goals:\n${active.map((goal) => this.formatGoalLine(goal)).join("\n")}\n\n${runtimeStatus}`,
       elapsed_ms: Date.now() - start,
     };
   }
@@ -1037,9 +1141,9 @@ export class ChatRunner {
       return { success: true, output: "Conversation history cleared.", elapsed_ms: Date.now() - start };
     }
     if (cmd === "/sessions") {
-      const catalog = new ChatSessionCatalog(this.deps.stateManager);
-      const sessions = await catalog.listSessions();
-      return { success: true, output: this.formatSessionsList(sessions), elapsed_ms: Date.now() - start };
+      const registry = createRuntimeSessionRegistry({ stateManager: this.deps.stateManager });
+      const snapshot = await registry.snapshot();
+      return { success: true, output: this.formatRuntimeSessionsList(snapshot), elapsed_ms: Date.now() - start };
     }
     if (cmd === "/history") {
       const catalog = new ChatSessionCatalog(this.deps.stateManager);
@@ -1491,11 +1595,24 @@ export class ChatRunner {
 
     if (resumeOnly && resumeCommand.selector) {
       try {
+        const selectorResolution = await this.resolveChatResumeSelector(resumeCommand.selector);
+        if (selectorResolution.nonResumableMessage) {
+          const elapsed_ms = 0;
+          const output = selectorResolution.nonResumableMessage;
+          this.emitEvent({
+            type: "assistant_final",
+            text: output,
+            persisted: false,
+            ...this.eventBase(eventContext),
+          });
+          this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
+          return { success: false, output, elapsed_ms };
+        }
         const catalog = new ChatSessionCatalog(this.deps.stateManager);
-        const session = await catalog.loadSessionBySelector(resumeCommand.selector);
+        const session = await catalog.loadSessionBySelector(selectorResolution.chatSelector);
         if (!session) {
           const elapsed_ms = 0;
-          const output = `No chat session matched selector "${resumeCommand.selector}".`;
+          const output = `No chat session matched selector "${selectorResolution.chatSelector}".`;
           this.emitEvent({
             type: "assistant_final",
             text: output,
@@ -2249,6 +2366,43 @@ export class ChatRunner {
       // fall through
     }
     return preview ? { preview } : {};
+  }
+
+  private async resolveChatResumeSelector(selector: string): Promise<{
+    chatSelector: string;
+    nonResumableMessage?: string;
+  }> {
+    if (selector.startsWith("session:conversation:")) {
+      return { chatSelector: selector.slice("session:conversation:".length) };
+    }
+
+    if (selector.startsWith("session:") || selector.startsWith("run:")) {
+      const registry = createRuntimeSessionRegistry({ stateManager: this.deps.stateManager });
+      if (selector.startsWith("session:")) {
+        const session = await registry.getSession(selector);
+        if (session?.kind === "conversation") {
+          return { chatSelector: selector.slice("session:conversation:".length) };
+        }
+        if (
+          session?.kind === "agent"
+          && session.resumable
+          && session.parent_session_id?.startsWith("session:conversation:")
+        ) {
+          return { chatSelector: session.parent_session_id.slice("session:conversation:".length) };
+        }
+        return {
+          chatSelector: selector,
+          nonResumableMessage: `Runtime session ${selector} is not chat-resumable. Inspect it with 'pulseed runtime session ${selector}'.`,
+        };
+      }
+
+      return {
+        chatSelector: selector,
+        nonResumableMessage: `Background run ${selector} is not chat-resumable. Inspect it with 'pulseed runtime run ${selector}'.`,
+      };
+    }
+
+    return { chatSelector: selector };
   }
 
   private parseResumeCommand(input: string): ResumeCommand | null {

--- a/src/interface/tui/__tests__/app-routing.test.ts
+++ b/src/interface/tui/__tests__/app-routing.test.ts
@@ -25,6 +25,8 @@ describe("TUI app routing helpers", () => {
   it("recognizes ChatRunner-owned slash commands from the TUI surface", () => {
     expect(isChatRunnerOwnedSlashCommand("/resume Work Session")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/sessions")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/status")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/status goal-1")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/history saved")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/compact")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/tend")).toBe(true);

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -145,6 +145,44 @@ describe("standalone slash command routing", () => {
 
     screen.unmount();
   });
+
+  it("routes /status to ChatRunner instead of standalone intent handlers", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const intentRecognizer = {
+      recognize: vi.fn(async () => ({ intent: "status", raw: "/status" })),
+    };
+    const actionHandler = {
+      handle: vi.fn(async () => ({ messages: ["unexpected"] })),
+    };
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      intentRecognizer: intentRecognizer as any,
+      actionHandler: actionHandler as any,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("/status");
+
+    expect(chatRunner.execute).toHaveBeenCalledWith("/status", "~/workspace");
+    expect(intentRecognizer.recognize).not.toHaveBeenCalled();
+    expect(actionHandler.handle).not.toHaveBeenCalled();
+
+    screen.unmount();
+  });
 });
 
 describe("daemon-mode chat routing", () => {

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -78,6 +78,7 @@ export function resolveFreeformInputRoute({
 const CHAT_RUNNER_OWNED_COMMANDS = new Set([
   "/resume",
   "/sessions",
+  "/status",
   "/history",
   "/compact",
   "/tend",


### PR DESCRIPTION
## Summary
- connect ChatRunner `/sessions` to the runtime session registry while keeping plain-text chat output
- append runtime session and background-run summaries to no-arg `/status`
- keep `/resume` chat-safe by mapping resumable runtime conversation/agent ids to their owning chat session and rejecting coreloop/process/run ids
- route TUI `/status` through ChatRunner instead of standalone intent handling

## Scope
- Phase 3 for #742
- no dashboard UX
- no durable BackgroundRun write model
- no attach UI

## Test plan
- `npx vitest run --config vitest.unit.config.ts src/interface/chat/__tests__/chat-runner.test.ts`
- `npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/app-routing.test.ts src/interface/tui/__tests__/app.test.ts`
- `npm run typecheck -- --pretty false`
- `npx eslint -c eslint.config.mjs --quiet src/interface/chat/chat-runner.ts src/interface/chat/__tests__/chat-runner.test.ts src/interface/tui/app.tsx src/interface/tui/__tests__/app-routing.test.ts src/interface/tui/__tests__/app.test.ts`
- `git diff --check`
- `npm run test:changed`
