### PR TITLE
Add durable background run ledger

### DIFF
--- a/src/runtime/__tests__/runtime-store-basics.test.ts
+++ b/src/runtime/__tests__/runtime-store-basics.test.ts
@@ -9,6 +9,10 @@ import {
   runtimeDateKey,
 } from "../store/runtime-paths.js";
 import {
+  BackgroundRunLedger,
+  normalizeTerminalStatus,
+} from "../store/background-run-store.js";
+import {
   RuntimeJournal,
   listRuntimeJson,
   loadRuntimeJson,
@@ -43,6 +47,9 @@ describe("runtime store basics", () => {
       path.join(tmpDir, "approvals", "pending", "approval-1.json")
     );
     expect(paths.outboxRecordPath(12)).toBe(path.join(tmpDir, "outbox", "000000000012.json"));
+    expect(paths.backgroundRunPath("run:agent/a")).toBe(
+      path.join(tmpDir, "background-runs", `${encodeRuntimePathSegment("run:agent/a")}.json`)
+    );
     const goalId = "goal%/a";
     expect(paths.goalLeasePath(goalId)).toBe(
       path.join(tmpDir, "leases", "goal", `${encodeRuntimePathSegment(goalId)}.json`)
@@ -57,7 +64,98 @@ describe("runtime store basics", () => {
     expect(fs.existsSync(paths.leaderDir)).toBe(true);
     expect(fs.existsSync(paths.approvalsPendingDir)).toBe(true);
     expect(fs.existsSync(paths.outboxDir)).toBe(true);
+    expect(fs.existsSync(paths.backgroundRunsDir)).toBe(true);
     expect(fs.existsSync(paths.healthDir)).toBe(true);
+  });
+
+  it("persists background runs with pinned reply targets across ledger reloads", async () => {
+    const ledger = new BackgroundRunLedger(paths);
+    await ledger.ensureReady();
+
+    await ledger.create({
+      id: "run:agent:durable",
+      kind: "agent_run",
+      notify_policy: "done_only",
+      reply_target_source: "pinned_run",
+      pinned_reply_target: {
+        channel: "slack",
+        target_id: "C123",
+        thread_id: "1700000000.000100",
+        metadata: { team: "T123" },
+      },
+      parent_session_id: "session:conversation:chat-a",
+      title: "Durable run",
+      workspace: "/repo",
+      created_at: "2026-04-25T00:00:00.000Z",
+    });
+    await ledger.link("run:agent:durable", {
+      child_session_id: "session:agent:durable",
+      updated_at: "2026-04-25T00:01:00.000Z",
+    });
+    await ledger.started("run:agent:durable", {
+      started_at: "2026-04-25T00:02:00.000Z",
+    });
+    await ledger.terminal("run:agent:durable", {
+      status: "completed",
+      completed_at: "2026-04-25T00:03:00.000Z",
+      summary: "done",
+    });
+
+    const reloaded = await new BackgroundRunLedger(paths).load("run:agent:durable");
+
+    expect(reloaded).toMatchObject({
+      id: "run:agent:durable",
+      child_session_id: "session:agent:durable",
+      status: "succeeded",
+      reply_target_source: "pinned_run",
+      pinned_reply_target: {
+        channel: "slack",
+        target_id: "C123",
+        thread_id: "1700000000.000100",
+      },
+      completed_at: "2026-04-25T00:03:00.000Z",
+      summary: "done",
+    });
+  });
+
+  it("rejects non-silent background runs without a durable pinned reply source", async () => {
+    const ledger = new BackgroundRunLedger(paths);
+    await ledger.ensureReady();
+
+    await expect(ledger.create({
+      id: "run:agent:no-target",
+      kind: "agent_run",
+      notify_policy: "done_only",
+      reply_target_source: "parent_session",
+      pinned_reply_target: null,
+      created_at: "2026-04-25T00:00:00.000Z",
+    })).rejects.toThrow(/requires pinned_run reply target/);
+  });
+
+  it("normalizes terminal background run statuses to the durable terminal set", async () => {
+    const ledger = new BackgroundRunLedger(paths);
+    await ledger.ensureReady();
+
+    expect(normalizeTerminalStatus("completed")).toBe("succeeded");
+    expect(normalizeTerminalStatus("timeout")).toBe("timed_out");
+    expect(normalizeTerminalStatus("canceled")).toBe("cancelled");
+    expect(() => normalizeTerminalStatus("running" as never)).toThrow(/Unsupported/);
+
+    await ledger.create({
+      id: "run:agent:terminal",
+      kind: "agent_run",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      created_at: "2026-04-25T00:00:00.000Z",
+    });
+
+    const terminal = await ledger.terminal("run:agent:terminal", {
+      status: "timedout",
+      completed_at: "2026-04-25T00:05:00.000Z",
+    });
+
+    expect(terminal.status).toBe("timed_out");
+    expect(terminal.completed_at).toBe("2026-04-25T00:05:00.000Z");
   });
 
   it("formats date buckets deterministically", () => {

--- a/src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
+++ b/src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
@@ -8,6 +8,7 @@ import {
   RuntimeSessionRegistrySnapshotSchema,
 } from "../index.js";
 import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
+import { BackgroundRunLedger } from "../../store/background-run-store.js";
 
 describe("RuntimeSessionRegistry", () => {
   let tmpDir: string;
@@ -133,6 +134,127 @@ describe("RuntimeSessionRegistry", () => {
       id: "run:process:proc-terminal",
       status: "succeeded",
       completed_at: "2026-04-25T01:00:00.000Z",
+    }));
+  });
+
+  it("projects durable pinned reply targets after restart without in-memory active routing", async () => {
+    const ledger = new BackgroundRunLedger(path.join(tmpDir, "runtime"));
+    await ledger.ensureReady();
+    await ledger.create({
+      id: "run:agent:restart-safe",
+      kind: "agent_run",
+      notify_policy: "done_only",
+      reply_target_source: "pinned_run",
+      pinned_reply_target: {
+        channel: "slack",
+        target_id: "C123",
+        thread_id: "1700000000.000200",
+      },
+      parent_session_id: "session:conversation:chat-a",
+      title: "Restart safe",
+      workspace: "/repo",
+      created_at: "2026-04-25T00:00:00.000Z",
+    });
+    await ledger.terminal("run:agent:restart-safe", {
+      status: "succeeded",
+      completed_at: "2026-04-25T00:10:00.000Z",
+      summary: "completed after restart",
+    });
+
+    const snapshot = await new RuntimeSessionRegistry({ stateManager }).snapshot();
+
+    expect(snapshot.background_runs).toContainEqual(expect.objectContaining({
+      id: "run:agent:restart-safe",
+      status: "succeeded",
+      reply_target_source: "pinned_run",
+      pinned_reply_target: expect.objectContaining({
+        channel: "slack",
+        target_id: "C123",
+        thread_id: "1700000000.000200",
+      }),
+      summary: "completed after restart",
+    }));
+  });
+
+  it("lets durable ledger records beat synthetic process projections with the same run id", async () => {
+    await stateManager.writeRaw("runtime/process-sessions/proc-ledger.json", makeProcessSnapshot({
+      session_id: "proc-ledger",
+      running: true,
+      pid: process.pid,
+      label: "synthetic process",
+    }));
+
+    const ledger = new BackgroundRunLedger(path.join(tmpDir, "runtime"));
+    await ledger.ensureReady();
+    await ledger.create({
+      id: "run:process:proc-ledger",
+      kind: "process_run",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      process_session_id: "proc-ledger",
+      title: "durable process",
+      workspace: "/repo",
+      created_at: "2026-04-25T00:00:00.000Z",
+      started_at: "2026-04-25T00:00:00.000Z",
+      status: "running",
+    });
+    await ledger.terminal("run:process:proc-ledger", {
+      status: "failed",
+      completed_at: "2026-04-25T00:30:00.000Z",
+      error: "durable failure",
+    });
+
+    const snapshot = await new RuntimeSessionRegistry({ stateManager }).snapshot();
+    const run = snapshot.background_runs.find((candidate) => candidate.id === "run:process:proc-ledger");
+
+    expect(run).toMatchObject({
+      id: "run:process:proc-ledger",
+      kind: "process_run",
+      status: "failed",
+      title: "durable process",
+      error: "durable failure",
+      reply_target_source: "none",
+    });
+    expect(snapshot.background_runs.filter((candidate) => candidate.id === "run:process:proc-ledger")).toHaveLength(1);
+  });
+
+  it("does not let a stale running ledger record hide a dead process sidecar", async () => {
+    await stateManager.writeRaw("runtime/process-sessions/proc-stale-ledger.json", makeProcessSnapshot({
+      session_id: "proc-stale-ledger",
+      running: true,
+      pid: 999_999,
+      label: "stale ledger process",
+    }));
+
+    const ledger = new BackgroundRunLedger(path.join(tmpDir, "runtime"));
+    await ledger.ensureReady();
+    await ledger.create({
+      id: "run:process:proc-stale-ledger",
+      kind: "process_run",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      process_session_id: "proc-stale-ledger",
+      title: "durable running process",
+      workspace: "/repo",
+      created_at: "2026-04-25T00:00:00.000Z",
+      started_at: "2026-04-25T00:00:00.000Z",
+      status: "running",
+    });
+
+    const snapshot = await new RuntimeSessionRegistry({
+      stateManager,
+      isPidAlive: () => false,
+    }).snapshot();
+    const run = snapshot.background_runs.find((candidate) => candidate.id === "run:process:proc-stale-ledger");
+
+    expect(run).toMatchObject({
+      id: "run:process:proc-stale-ledger",
+      status: "lost",
+      title: "durable running process",
+      process_session_id: "proc-stale-ledger",
+    });
+    expect(snapshot.warnings).toContainEqual(expect.objectContaining({
+      code: "dead_process_sidecar",
     }));
   });
 

--- a/src/runtime/session-registry/registry.ts
+++ b/src/runtime/session-registry/registry.ts
@@ -4,6 +4,7 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import { ChatSessionCatalog } from "../../interface/chat/chat-session-store.js";
 import { normalizeAgentLoopSessionState } from "../../orchestrator/execution/agent-loop/agent-loop-session-state.js";
 import type { ProcessSessionManager, ProcessSessionSnapshot } from "../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
+import { BackgroundRunLedger } from "../store/background-run-store.js";
 import {
   BackgroundRunSchema,
   RuntimeSessionRegistrySnapshotSchema,
@@ -23,6 +24,7 @@ interface RuntimeSessionRegistryDeps {
   stateManager: StateManager;
   stateBaseDir?: string;
   processSessionManager?: Pick<ProcessSessionManager, "list">;
+  backgroundRunLedger?: Pick<BackgroundRunLedger, "list">;
   now?: () => Date;
   isPidAlive?: (pid: number) => boolean | "unknown";
 }
@@ -39,6 +41,7 @@ export class RuntimeSessionRegistry {
   private readonly stateBaseDir: string;
   private readonly chatCatalog: ChatSessionCatalog;
   private readonly processSessionManager?: Pick<ProcessSessionManager, "list">;
+  private readonly backgroundRunLedger: Pick<BackgroundRunLedger, "list">;
   private readonly now: () => Date;
   private readonly isPidAlive: (pid: number) => boolean | "unknown";
 
@@ -47,6 +50,7 @@ export class RuntimeSessionRegistry {
     this.stateBaseDir = deps.stateBaseDir ?? deps.stateManager.getBaseDir();
     this.chatCatalog = new ChatSessionCatalog(this.stateManager);
     this.processSessionManager = deps.processSessionManager;
+    this.backgroundRunLedger = deps.backgroundRunLedger ?? new BackgroundRunLedger(path.join(this.stateBaseDir, "runtime"));
     this.now = deps.now ?? (() => new Date());
     this.isPidAlive = deps.isPidAlive ?? defaultIsPidAlive;
   }
@@ -60,6 +64,7 @@ export class RuntimeSessionRegistry {
     await this.projectChatAndAgentSessions(sessions, backgroundRuns, warnings);
     await this.projectSupervisorState(sessions, backgroundRuns, warnings);
     await this.projectProcessSessions(backgroundRuns, warnings);
+    await this.projectLedgerRuns(backgroundRuns, warnings);
 
     sessions.sort(compareByUpdatedAtThenId);
     backgroundRuns.sort(compareByUpdatedAtThenId);
@@ -225,6 +230,8 @@ export class RuntimeSessionRegistry {
         process_session_id: null,
         status: agentStatusToRunStatus(normalizedStatus),
         notify_policy: "done_only",
+        reply_target_source: "none",
+        pinned_reply_target: null,
         title: chat.title ?? stableAgentId,
         workspace: chat.cwd,
         created_at: chat.createdAt,
@@ -312,6 +319,8 @@ export class RuntimeSessionRegistry {
           process_session_id: null,
           status: agentStatusToRunStatus(state.status),
           notify_policy: "done_only",
+          reply_target_source: "none",
+          pinned_reply_target: null,
           title: state.taskId ?? state.goalId,
           workspace: state.cwd,
           created_at: null,
@@ -394,6 +403,8 @@ export class RuntimeSessionRegistry {
         process_session_id: null,
         status: "running",
         notify_policy: "state_changes",
+        reply_target_source: "none",
+        pinned_reply_target: null,
         title,
         workspace: null,
         created_at: startedAt,
@@ -442,6 +453,8 @@ export class RuntimeSessionRegistry {
         process_session_id: snapshot.session_id,
         status,
         notify_policy: "done_only",
+        reply_target_source: "none",
+        pinned_reply_target: null,
         title: snapshot.label ?? `${snapshot.command} ${snapshot.args.join(" ")}`.trim(),
         workspace: snapshot.cwd,
         created_at: snapshot.startedAt,
@@ -459,6 +472,29 @@ export class RuntimeSessionRegistry {
         ],
       }));
     }
+  }
+
+  private async projectLedgerRuns(
+    backgroundRuns: BackgroundRun[],
+    warnings: RuntimeSessionRegistryWarning[],
+  ): Promise<void> {
+    let ledgerRuns: BackgroundRun[];
+    try {
+      ledgerRuns = await this.backgroundRunLedger.list();
+    } catch (error) {
+      warnings.push({
+        code: "source_unavailable",
+        source: sourceRef("task_ledger", null, null, path.join("runtime", "background-runs"), null),
+        message: `Failed to list background run ledger records: ${messageFromError(error)}`,
+      });
+      return;
+    }
+
+    const byId = new Map(backgroundRuns.map((run) => [run.id, run]));
+    for (const run of ledgerRuns) {
+      byId.set(run.id, mergeLedgerRunWithProjection(run, byId.get(run.id)));
+    }
+    backgroundRuns.splice(0, backgroundRuns.length, ...byId.values());
   }
 
   private async readProcessSidecars(warnings: RuntimeSessionRegistryWarning[]): Promise<ProcessSessionSnapshot[]> {
@@ -573,6 +609,26 @@ function filterRuns(runs: BackgroundRun[], filter: BackgroundRunFilter): Backgro
     if (filter.attentionOnly && run.status !== "failed" && run.status !== "timed_out" && run.status !== "lost") return false;
     return true;
   });
+}
+
+function mergeLedgerRunWithProjection(ledgerRun: BackgroundRun, projectedRun: BackgroundRun | undefined): BackgroundRun {
+  if (!projectedRun) return ledgerRun;
+  if (!isActiveRunStatus(ledgerRun.status) || isActiveRunStatus(projectedRun.status)) {
+    return ledgerRun;
+  }
+
+  return BackgroundRunSchema.parse({
+    ...ledgerRun,
+    status: projectedRun.status,
+    updated_at: projectedRun.updated_at ?? ledgerRun.updated_at,
+    completed_at: projectedRun.completed_at ?? ledgerRun.completed_at,
+    error: projectedRun.error ?? ledgerRun.error,
+    source_refs: [...ledgerRun.source_refs, ...projectedRun.source_refs],
+  });
+}
+
+function isActiveRunStatus(status: BackgroundRunStatus): boolean {
+  return status === "queued" || status === "running";
 }
 
 function sourceRef(

--- a/src/runtime/session-registry/types.ts
+++ b/src/runtime/session-registry/types.ts
@@ -21,6 +21,9 @@ export const BackgroundRunStatusSchema = z.enum([
 ]);
 export type BackgroundRunStatus = z.infer<typeof BackgroundRunStatusSchema>;
 
+export const BackgroundRunReplyTargetSourceSchema = z.enum(["pinned_run", "parent_session", "none"]);
+export type BackgroundRunReplyTargetSource = z.infer<typeof BackgroundRunReplyTargetSourceSchema>;
+
 export const RuntimeSessionRefKindSchema = z.enum([
   "chat_session",
   "agentloop_state",
@@ -102,6 +105,8 @@ export const BackgroundRunSchema = z.object({
   process_session_id: z.string().nullable(),
   status: BackgroundRunStatusSchema,
   notify_policy: z.enum(["silent", "done_only", "state_changes"]),
+  reply_target_source: BackgroundRunReplyTargetSourceSchema,
+  pinned_reply_target: RuntimeReplyTargetSchema.nullable(),
   title: z.string().nullable(),
   workspace: z.string().nullable(),
   created_at: z.string().nullable(),

--- a/src/runtime/store/background-run-store.ts
+++ b/src/runtime/store/background-run-store.ts
@@ -1,0 +1,238 @@
+import {
+  BackgroundRunSchema,
+  type BackgroundRun,
+  type BackgroundRunKind,
+  type BackgroundRunStatus,
+  type RuntimeArtifactRef,
+  type RuntimeReplyTarget,
+  type RuntimeSessionRef,
+} from "../session-registry/types.js";
+import {
+  createRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+import { RuntimeJournal } from "./runtime-journal.js";
+
+const TERMINAL_STATUS_ALIASES = {
+  success: "succeeded",
+  completed: "succeeded",
+  complete: "succeeded",
+  error: "failed",
+  timeout: "timed_out",
+  timedout: "timed_out",
+  canceled: "cancelled",
+  cancel: "cancelled",
+  missing: "lost",
+} as const satisfies Record<string, BackgroundRunTerminalStatus>;
+
+const BackgroundRunLedgerRecordSchema = BackgroundRunSchema.superRefine((run, ctx) => {
+  if (run.reply_target_source === "pinned_run" && run.pinned_reply_target === null) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["pinned_reply_target"],
+      message: "pinned_run requires pinned_reply_target",
+    });
+  }
+  if (run.reply_target_source !== "pinned_run" && run.pinned_reply_target !== null) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["pinned_reply_target"],
+      message: `pinned_reply_target is invalid when reply_target_source is ${run.reply_target_source}`,
+    });
+  }
+  if (run.notify_policy !== "silent" && run.reply_target_source !== "pinned_run") {
+    ctx.addIssue({
+      code: "custom",
+      path: ["reply_target_source"],
+      message: "non-silent runs require pinned_run reply target",
+    });
+  }
+});
+
+export type BackgroundRunTerminalStatus = Extract<
+  BackgroundRunStatus,
+  "succeeded" | "failed" | "timed_out" | "cancelled" | "lost"
+>;
+
+export interface BackgroundRunCreateInput {
+  id: string;
+  kind: BackgroundRunKind;
+  notify_policy?: BackgroundRun["notify_policy"];
+  reply_target_source?: BackgroundRun["reply_target_source"];
+  pinned_reply_target?: RuntimeReplyTarget | null;
+  parent_session_id?: string | null;
+  child_session_id?: string | null;
+  process_session_id?: string | null;
+  status?: Extract<BackgroundRunStatus, "queued" | "running">;
+  title?: string | null;
+  workspace?: string | null;
+  created_at?: string | null;
+  started_at?: string | null;
+  updated_at?: string | null;
+  summary?: string | null;
+  error?: string | null;
+  artifacts?: RuntimeArtifactRef[];
+  source_refs?: RuntimeSessionRef[];
+}
+
+export interface BackgroundRunLinkInput {
+  parent_session_id?: string | null;
+  child_session_id?: string | null;
+  process_session_id?: string | null;
+  updated_at?: string | null;
+  source_refs?: RuntimeSessionRef[];
+}
+
+export interface BackgroundRunStartedInput {
+  started_at?: string | null;
+  updated_at?: string | null;
+  process_session_id?: string | null;
+  child_session_id?: string | null;
+  source_refs?: RuntimeSessionRef[];
+}
+
+export interface BackgroundRunTerminalInput {
+  status: BackgroundRunTerminalStatus | keyof typeof TERMINAL_STATUS_ALIASES;
+  completed_at?: string | null;
+  updated_at?: string | null;
+  summary?: string | null;
+  error?: string | null;
+  artifacts?: RuntimeArtifactRef[];
+  source_refs?: RuntimeSessionRef[];
+}
+
+export class BackgroundRunLedger {
+  private readonly paths: RuntimeStorePaths;
+  private readonly journal: RuntimeJournal;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+    this.journal = new RuntimeJournal(this.paths);
+  }
+
+  async ensureReady(): Promise<void> {
+    await this.journal.ensureReady();
+  }
+
+  async load(runId: string): Promise<BackgroundRun | null> {
+    return this.journal.load(this.paths.backgroundRunPath(runId), BackgroundRunLedgerRecordSchema);
+  }
+
+  async list(): Promise<BackgroundRun[]> {
+    return this.journal.list(this.paths.backgroundRunsDir, BackgroundRunLedgerRecordSchema);
+  }
+
+  async create(input: BackgroundRunCreateInput): Promise<BackgroundRun> {
+    const createdAt = input.created_at ?? input.updated_at ?? new Date().toISOString();
+    return this.save({
+      schema_version: "background-run-v1",
+      id: input.id,
+      kind: input.kind,
+      parent_session_id: input.parent_session_id ?? null,
+      child_session_id: input.child_session_id ?? null,
+      process_session_id: input.process_session_id ?? null,
+      status: input.status ?? "queued",
+      notify_policy: input.notify_policy ?? "done_only",
+      reply_target_source: input.reply_target_source ?? (input.pinned_reply_target ? "pinned_run" : "none"),
+      pinned_reply_target: input.pinned_reply_target ?? null,
+      title: input.title ?? null,
+      workspace: input.workspace ?? null,
+      created_at: createdAt,
+      started_at: input.started_at ?? null,
+      updated_at: input.updated_at ?? createdAt,
+      completed_at: null,
+      summary: input.summary ?? null,
+      error: input.error ?? null,
+      artifacts: input.artifacts ?? [],
+      source_refs: input.source_refs ?? [],
+    });
+  }
+
+  async link(runId: string, input: BackgroundRunLinkInput): Promise<BackgroundRun> {
+    return this.update(runId, (run) => ({
+      ...run,
+      parent_session_id: input.parent_session_id ?? run.parent_session_id,
+      child_session_id: input.child_session_id ?? run.child_session_id,
+      process_session_id: input.process_session_id ?? run.process_session_id,
+      updated_at: input.updated_at ?? run.updated_at,
+      source_refs: input.source_refs ?? run.source_refs,
+    }));
+  }
+
+  async started(runId: string, input: BackgroundRunStartedInput = {}): Promise<BackgroundRun> {
+    const updatedAt = input.updated_at ?? input.started_at ?? new Date().toISOString();
+    return this.update(runId, (run) => ({
+      ...run,
+      status: "running",
+      started_at: input.started_at ?? run.started_at ?? updatedAt,
+      updated_at: updatedAt,
+      process_session_id: input.process_session_id ?? run.process_session_id,
+      child_session_id: input.child_session_id ?? run.child_session_id,
+      source_refs: input.source_refs ?? run.source_refs,
+    }));
+  }
+
+  async terminal(runId: string, input: BackgroundRunTerminalInput): Promise<BackgroundRun> {
+    const status = normalizeTerminalStatus(input.status);
+    const completedAt = input.completed_at ?? input.updated_at ?? new Date().toISOString();
+    return this.update(runId, (run) => ({
+      ...run,
+      status,
+      completed_at: completedAt,
+      updated_at: input.updated_at ?? completedAt,
+      summary: input.summary ?? run.summary,
+      error: input.error ?? run.error,
+      artifacts: input.artifacts ?? run.artifacts,
+      source_refs: input.source_refs ?? run.source_refs,
+    }));
+  }
+
+  async save(run: BackgroundRun): Promise<BackgroundRun> {
+    const parsed = validateBackgroundRunLedgerRecord(run);
+    await this.journal.save(this.paths.backgroundRunPath(parsed.id), BackgroundRunLedgerRecordSchema, parsed);
+    return parsed;
+  }
+
+  private async update(
+    runId: string,
+    updater: (run: BackgroundRun) => BackgroundRun,
+  ): Promise<BackgroundRun> {
+    const existing = await this.load(runId);
+    if (!existing) {
+      throw new Error(`BackgroundRun ${runId} does not exist`);
+    }
+    return this.save(updater(existing));
+  }
+}
+
+export function normalizeTerminalStatus(
+  status: BackgroundRunTerminalInput["status"],
+): BackgroundRunTerminalStatus {
+  if (status === "succeeded"
+    || status === "failed"
+    || status === "timed_out"
+    || status === "cancelled"
+    || status === "lost") {
+    return status;
+  }
+  const normalized = TERMINAL_STATUS_ALIASES[status];
+  if (normalized) return normalized;
+  throw new Error(`Unsupported BackgroundRun terminal status: ${status}`);
+}
+
+export function validateBackgroundRunLedgerRecord(run: BackgroundRun): BackgroundRun {
+  const parsed = BackgroundRunSchema.parse(run);
+  if (parsed.reply_target_source === "pinned_run" && parsed.pinned_reply_target === null) {
+    throw new Error(`BackgroundRun ${parsed.id} uses pinned_run without pinned_reply_target`);
+  }
+  if (parsed.reply_target_source !== "pinned_run" && parsed.pinned_reply_target !== null) {
+    throw new Error(`BackgroundRun ${parsed.id} pins a reply target with source ${parsed.reply_target_source}`);
+  }
+  if (parsed.notify_policy !== "silent" && parsed.reply_target_source !== "pinned_run") {
+    throw new Error(`BackgroundRun ${parsed.id} with notify_policy ${parsed.notify_policy} requires pinned_run reply target`);
+  }
+  return parsed;
+}

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -78,3 +78,15 @@ export type { ApprovalResolutionInput } from "./approval-store.js";
 export { OutboxStore } from "./outbox-store.js";
 export { RuntimeHealthStore } from "./health-store.js";
 export { RuntimeOperationStore } from "./runtime-operation-store.js";
+export {
+  BackgroundRunLedger,
+  normalizeTerminalStatus,
+  validateBackgroundRunLedgerRecord,
+} from "./background-run-store.js";
+export type {
+  BackgroundRunCreateInput,
+  BackgroundRunLinkInput,
+  BackgroundRunStartedInput,
+  BackgroundRunTerminalInput,
+  BackgroundRunTerminalStatus,
+} from "./background-run-store.js";

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -16,6 +16,7 @@ export interface RuntimeStorePaths {
   approvalsPendingDir: string;
   approvalsResolvedDir: string;
   outboxDir: string;
+  backgroundRunsDir: string;
   leasesDir: string;
   goalLeasesDir: string;
   dlqDir: string;
@@ -27,6 +28,7 @@ export interface RuntimeStorePaths {
   approvalPendingPath(approvalId: string): string;
   approvalResolvedPath(approvalId: string): string;
   outboxRecordPath(seq: number): string;
+  backgroundRunPath(runId: string): string;
   goalLeasePath(goalId: string): string;
   completedByIdempotencyPath(idempotencyKey: string): string;
   completedByMessagePath(messageId: string): string;
@@ -71,6 +73,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
   const approvalsPendingDir = path.join(approvalsDir, "pending");
   const approvalsResolvedDir = path.join(approvalsDir, "resolved");
   const outboxDir = path.join(rootDir, "outbox");
+  const backgroundRunsDir = path.join(rootDir, "background-runs");
   const leasesDir = path.join(rootDir, "leases");
   const goalLeasesDir = path.join(leasesDir, "goal");
   const dlqDir = path.join(rootDir, "dlq");
@@ -89,6 +92,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     approvalsPendingDir,
     approvalsResolvedDir,
     outboxDir,
+    backgroundRunsDir,
     leasesDir,
     goalLeasesDir,
     dlqDir,
@@ -109,6 +113,9 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     },
     outboxRecordPath(seq: number) {
       return path.join(outboxDir, outboxFileName(seq));
+    },
+    backgroundRunPath(runId: string) {
+      return path.join(backgroundRunsDir, recordFileName(encodeRuntimePathSegment(runId)));
     },
     goalLeasePath(goalId: string) {
       return path.join(goalLeasesDir, `${encodeRuntimePathSegment(goalId)}.json`);
@@ -139,6 +146,7 @@ export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise
       paths.approvalsPendingDir,
       paths.approvalsResolvedDir,
       paths.outboxDir,
+      paths.backgroundRunsDir,
       paths.leasesDir,
       paths.goalLeasesDir,
       paths.dlqDir,


### PR DESCRIPTION
## Summary
- add `BackgroundRunLedger` persisted under `runtime/background-runs/*.json`
- make run-level `pinned_reply_target` the durable routing source of truth for non-silent background runs
- project durable ledger records through `RuntimeSessionRegistry`, with ledger metadata preserved and stale running process state still allowed to fall to `lost`
- add path/store/registry coverage for reload safety, terminal normalization, pinned reply validation, and ledger-vs-synthetic merge behavior

## Scope
- Phase 4 for #742
- no `/background` command
- no dashboard/TUI attach UI
- no CoreLoop handoff UX or completion delivery wiring

## Test plan
- `npx vitest run --config vitest.integration.config.ts src/runtime/__tests__/runtime-store-basics.test.ts src/runtime/session-registry/__tests__/runtime-session-registry.test.ts`
- `npm run typecheck -- --pretty false`
- `npx eslint -c eslint.config.mjs --quiet src/runtime/store/background-run-store.ts src/runtime/store/runtime-paths.ts src/runtime/store/index.ts src/runtime/session-registry/types.ts src/runtime/session-registry/registry.ts src/runtime/__tests__/runtime-store-basics.test.ts src/runtime/session-registry/__tests__/runtime-session-registry.test.ts`
- `git diff --check`
- `npx vitest run --config vitest.unit.config.ts src/interface/cli/__tests__/runtime-command.test.ts`

Note: local `npm run test:changed` reached the daemon e2e lane but was blocked by an existing resident PulSeed daemon already listening on `127.0.0.1:41700`; focused tests and lint/typecheck passed locally, and CI should run in a clean port environment.
