### PR TITLE
feat(runtime): add CoreLoop background handoff

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -460,7 +460,21 @@ describe("ChatRunner", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       try {
+        const stateManager = {
+          ...makeMockStateManager(),
+          getBaseDir: vi.fn().mockReturnValue(fs.mkdtempSync(path.join(os.tmpdir(), "chat-runner-tend-"))),
+          loadGoal: vi.fn().mockResolvedValue({
+            id: "goal-xyz",
+            title: "Tend test goal",
+            description: "Exercise tend confirmation.",
+            dimensions: [],
+            constraints: [],
+            created_at: "2026-04-25T00:00:00.000Z",
+            updated_at: "2026-04-25T00:00:00.000Z",
+          } as unknown as Goal),
+        } as unknown as StateManager;
         const runner = new ChatRunner(makeDeps({
+          stateManager,
           daemonClient: daemonClient as never,
           daemonBaseUrl: "http://localhost:9000",
           onNotification: (message) => { notifications.push(message); },
@@ -472,7 +486,11 @@ describe("ChatRunner", () => {
         await new Promise((resolve) => setTimeout(resolve, 0));
 
         expect(result.success).toBe(true);
-        expect(daemonClient.startGoal).toHaveBeenCalledWith("goal-xyz");
+        expect(daemonClient.startGoal).toHaveBeenCalledWith("goal-xyz", expect.objectContaining({
+          backgroundRun: expect.objectContaining({
+            backgroundRunId: expect.stringMatching(/^run:coreloop:/),
+          }),
+        }));
         expect((mockFetch as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(2);
         expect((mockFetch as ReturnType<typeof vi.fn>).mock.invocationCallOrder[1]).toBeLessThan(
           (daemonClient.startGoal as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]

--- a/src/interface/chat/__tests__/tend-command.test.ts
+++ b/src/interface/chat/__tests__/tend-command.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { TendCommand } from "../tend-command.js";
 import type { TendDeps } from "../tend-command.js";
 import type { ILLMClient, LLMResponse } from "../../../base/llm/llm-client.js";
@@ -7,6 +10,7 @@ import type { DaemonClient } from "../../../runtime/daemon-client.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { Goal } from "../../../base/types/goal.js";
 import type { ChatMessage } from "../chat-history.js";
+import { BackgroundRunLedger } from "../../../runtime/store/background-run-store.js";
 
 // ─── Factories ───
 
@@ -61,14 +65,35 @@ function makeMockGoalNegotiator(goal: Goal): GoalNegotiator {
 
 function makeMockDaemonClient(): DaemonClient {
   return {
-    startGoal: vi.fn().mockResolvedValue(undefined),
+    startGoal: vi.fn().mockResolvedValue({ ok: true }),
   } as unknown as DaemonClient;
 }
 
 function makeMockStateManager(goal: Goal | null = null): StateManager {
   return {
     loadGoal: vi.fn().mockResolvedValue(goal),
+    getBaseDir: vi.fn().mockReturnValue(fs.mkdtempSync(path.join(os.tmpdir(), "tend-state-"))),
   } as unknown as StateManager;
+}
+
+function makeMockBackgroundRunLedger() {
+  return {
+    create: vi.fn().mockImplementation(async (input) => ({
+      schema_version: "background-run-v1",
+      child_session_id: null,
+      process_session_id: null,
+      status: "queued",
+      started_at: null,
+      completed_at: null,
+      summary: null,
+      error: null,
+      artifacts: [],
+      ...input,
+      created_at: input.created_at ?? "2026-04-25T00:00:00.000Z",
+      updated_at: input.updated_at ?? "2026-04-25T00:00:00.000Z",
+    })),
+    terminal: vi.fn().mockResolvedValue(undefined),
+  };
 }
 
 function makeChatHistory(): ChatMessage[] {
@@ -86,6 +111,7 @@ function makeDeps(overrides: Partial<TendDeps> = {}): TendDeps {
     daemonClient: makeMockDaemonClient(),
     stateManager: makeMockStateManager(),
     chatHistory: makeChatHistory(),
+    backgroundRunLedger: makeMockBackgroundRunLedger() as never,
     ...overrides,
   };
 }
@@ -192,8 +218,161 @@ describe("TendCommand", () => {
       const result = await cmd.execute("goal-abc", deps);
       expect(result.success).toBe(true);
       expect(result.goalId).toBe("goal-abc");
-      expect(daemonClient.startGoal).toHaveBeenCalledWith("goal-abc");
+      expect(daemonClient.startGoal).toHaveBeenCalledWith("goal-abc", expect.objectContaining({
+        backgroundRun: expect.objectContaining({
+          backgroundRunId: expect.stringMatching(/^run:coreloop:/),
+        }),
+      }));
       expect(result.message).toContain("Started");
+    });
+
+    it("creates a durable coreloop background run with parent conversation and forwards metadata", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "tend-bg-"));
+      const runtimeRoot = path.join(tmpDir, "runtime");
+      const goal = makeTestGoal();
+      const ledger = new BackgroundRunLedger(runtimeRoot);
+      await ledger.ensureReady();
+      const daemonClient = makeMockDaemonClient();
+      const deps = makeDeps({
+        daemonClient,
+        stateManager: makeMockStateManager(goal),
+        sessionId: "chat-session-1",
+        workspace: "/repo",
+        replyTarget: {
+          surface: "gateway",
+          channel: "plugin_gateway",
+          conversation_id: "C123",
+          message_id: "1710000000.000100",
+          deliveryMode: "thread_reply",
+          metadata: { team: "T123" },
+        },
+        backgroundRunLedger: ledger,
+      });
+
+      try {
+        const result = await cmd.execute("goal-abc", deps);
+        expect(result.success).toBe(true);
+        expect(result.backgroundRunId).toMatch(/^run:coreloop:/);
+        expect(result.message).toContain(result.backgroundRunId!);
+        const run = await ledger.load(result.backgroundRunId!);
+
+        expect(run).toMatchObject({
+          id: result.backgroundRunId,
+          kind: "coreloop_run",
+          parent_session_id: "session:conversation:chat-session-1",
+          status: "queued",
+          notify_policy: "done_only",
+          reply_target_source: "pinned_run",
+          pinned_reply_target: expect.objectContaining({
+            channel: "plugin_gateway",
+            target_id: "C123",
+            thread_id: "1710000000.000100",
+          }),
+          title: "Fix the login bug",
+          workspace: "/repo",
+        });
+        expect(run?.source_refs).toEqual([
+          expect.objectContaining({
+            kind: "chat_session",
+            id: "chat-session-1",
+            relative_path: "chat/sessions/chat-session-1.json",
+          }),
+        ]);
+        expect(daemonClient.startGoal).toHaveBeenCalledWith("goal-abc", {
+          backgroundRun: expect.objectContaining({
+            backgroundRunId: result.backgroundRunId,
+            parentSessionId: "session:conversation:chat-session-1",
+            notifyPolicy: "done_only",
+            replyTargetSource: "pinned_run",
+            pinnedReplyTarget: expect.objectContaining({
+              channel: "plugin_gateway",
+              target_id: "C123",
+            }),
+          }),
+        });
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("writes the background run to configured daemon runtime_root", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "tend-runtime-root-"));
+      fs.writeFileSync(path.join(baseDir, "daemon.json"), JSON.stringify({
+        runtime_root: "runtime-v2",
+      }), "utf-8");
+      const daemonRuntimeRoot = path.join(baseDir, "runtime-v2");
+      const goal = makeTestGoal();
+      const daemonClient = makeMockDaemonClient();
+      const stateManager = {
+        ...makeMockStateManager(goal),
+        getBaseDir: vi.fn().mockReturnValue(baseDir),
+      } as unknown as StateManager;
+      const deps = makeDeps({
+        daemonClient,
+        stateManager,
+        sessionId: "chat-runtime-root",
+        backgroundRunLedger: undefined,
+      });
+
+      try {
+        const result = await cmd.execute("goal-abc", deps);
+
+        expect(result.success).toBe(true);
+        expect(result.backgroundRunId).toMatch(/^run:coreloop:/);
+        const run = await new BackgroundRunLedger(daemonRuntimeRoot).load(result.backgroundRunId!);
+        expect(run).toMatchObject({
+          id: result.backgroundRunId,
+          kind: "coreloop_run",
+          parent_session_id: "session:conversation:chat-runtime-root",
+          status: "queued",
+        });
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
+    });
+
+    it("prefers the running daemon-state runtime_root used by external --config", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "tend-daemon-state-root-"));
+      const daemonRuntimeRoot = path.join(baseDir, "external-runtime");
+      fs.writeFileSync(path.join(baseDir, "daemon-state.json"), JSON.stringify({
+        pid: process.pid,
+        started_at: "2026-04-25T00:00:00.000Z",
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: ["goal-abc"],
+        status: "running",
+        runtime_root: daemonRuntimeRoot,
+        crash_count: 0,
+        last_error: null,
+        last_resident_at: null,
+        resident_activity: null,
+      }), "utf-8");
+      const goal = makeTestGoal();
+      const stateManager = {
+        ...makeMockStateManager(goal),
+        getBaseDir: vi.fn().mockReturnValue(baseDir),
+      } as unknown as StateManager;
+      const deps = makeDeps({
+        daemonClient: makeMockDaemonClient(),
+        stateManager,
+        sessionId: "chat-external-runtime",
+        backgroundRunLedger: undefined,
+      });
+
+      try {
+        const result = await cmd.execute("goal-abc", deps);
+
+        expect(result.success).toBe(true);
+        const run = await new BackgroundRunLedger(daemonRuntimeRoot).load(result.backgroundRunId!);
+        expect(run).toMatchObject({
+          id: result.backgroundRunId,
+          parent_session_id: "session:conversation:chat-external-runtime",
+          status: "queued",
+        });
+        expect(await new BackgroundRunLedger(path.join(baseDir, "runtime")).load(result.backgroundRunId!)).toBeNull();
+      } finally {
+        fs.rmSync(baseDir, { recursive: true, force: true });
+      }
     });
 
     it("returns error for non-existent goal", async () => {
@@ -292,7 +471,7 @@ describe("TendCommand", () => {
       const deps = makeDeps({ stateManager: makeMockStateManager(goal), daemonClient });
       const result = await cmd.execute("goal-abc", deps);
       expect(result.success).toBe(true);
-      expect(daemonClient.startGoal).toHaveBeenCalledWith("goal-abc");
+      expect(daemonClient.startGoal).toHaveBeenCalledWith("goal-abc", expect.any(Object));
     });
 
     it("handles empty string as no goal-id", async () => {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -1435,6 +1435,9 @@ export class ChatRunner {
       daemonClient: this.deps.daemonClient,
       stateManager: this.deps.stateManager,
       chatHistory: history,
+      sessionId: this.history?.getSessionId() ?? null,
+      workspace: this.sessionCwd ?? process.cwd(),
+      replyTarget: this.runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget ?? null,
     };
 
     const tendCommand = new TendCommand();
@@ -1511,7 +1514,34 @@ export class ChatRunner {
     }
 
     try {
-      await this.deps.daemonClient.startGoal(goalId);
+      const tendDeps: TendDeps = {
+        llmClient: this.deps.llmClient as ILLMClient,
+        goalNegotiator: this.deps.goalNegotiator as GoalNegotiator,
+        daemonClient: this.deps.daemonClient,
+        stateManager: this.deps.stateManager,
+        chatHistory: this.history?.getMessages() ?? [],
+        sessionId: this.history?.getSessionId() ?? null,
+        workspace: this.sessionCwd ?? process.cwd(),
+        replyTarget: this.runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget ?? null,
+      };
+      const result = await new TendCommand().startAcceptedGoal(goalId, maxIterations, tendDeps);
+      if (!result.success) {
+        if (subscriber) {
+          subscriber.unsubscribe();
+          this.activeSubscribers.delete(goalId);
+        }
+        return {
+          success: false,
+          output: result.message,
+          elapsed_ms: Date.now() - start,
+        };
+      }
+      const shortId = goalId.length > 12 ? goalId.slice(0, 12) : goalId;
+      return {
+        success: true,
+        output: `[tend] ${shortId}: Started — daemon is now tending your goal${maxIterations !== undefined ? ` (max ${maxIterations} iterations)` : ""}.\nBackground run: ${result.backgroundRunId}\nRun 'pulseed status' to check progress.`,
+        elapsed_ms: Date.now() - start,
+      };
     } catch (err) {
       if (subscriber) {
         subscriber.unsubscribe();
@@ -1524,14 +1554,6 @@ export class ChatRunner {
         elapsed_ms: Date.now() - start,
       };
     }
-
-    const iterNote = maxIterations !== undefined ? ` (max ${maxIterations} iterations)` : "";
-    const shortId = goalId.length > 12 ? goalId.slice(0, 12) : goalId;
-    return {
-      success: true,
-      output: `[tend] ${shortId}: Started — daemon is now tending your goal${iterNote}.\nRun 'pulseed status' to check progress.`,
-      elapsed_ms: Date.now() - start,
-    };
   }
 
   /**

--- a/src/interface/chat/tend-command.ts
+++ b/src/interface/chat/tend-command.ts
@@ -4,12 +4,20 @@
 // Summarizes chat history via LLM, generates a structured goal,
 // confirms with the user, then starts a daemon to work on it autonomously.
 
+import { randomUUID } from "node:crypto";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
 import type { StateManager } from "../../base/state/state-manager.js";
 import type { Goal } from "../../base/types/goal.js";
 import type { ChatMessage } from "./chat-history.js";
+import {
+  BackgroundRunLedger,
+  type BackgroundRunCreateInput,
+} from "../../runtime/store/background-run-store.js";
+import { resolveConfiguredDaemonRuntimeRoot } from "../../runtime/daemon/runtime-root.js";
+import type { RuntimeControlReplyTarget } from "../../runtime/store/runtime-operation-schemas.js";
+import type { RuntimeReplyTarget, RuntimeSessionRef } from "../../runtime/session-registry/types.js";
 
 // --- Types ---
 
@@ -19,12 +27,17 @@ export interface TendDeps {
   daemonClient: DaemonClient;
   stateManager: StateManager;
   chatHistory: ChatMessage[];
+  sessionId?: string | null;
+  workspace?: string | null;
+  replyTarget?: RuntimeControlReplyTarget | null;
+  backgroundRunLedger?: Pick<BackgroundRunLedger, "create" | "terminal">;
 }
 
 export interface TendResult {
   success: boolean;
   goalId?: string;
   goalTitle?: string;
+  backgroundRunId?: string;
   /** maxIterations from parsed args, carried through confirmation flow. */
   maxIterations?: number;
   /** Formatted message for chat display. */
@@ -104,6 +117,21 @@ export class TendCommand {
     return result.goal;
   }
 
+  async startAcceptedGoal(
+    goalId: string,
+    maxIterations: number | undefined,
+    deps: TendDeps
+  ): Promise<TendResult> {
+    const goal = await deps.stateManager.loadGoal(goalId);
+    if (!goal) {
+      return {
+        success: false,
+        message: `Goal not found: ${goalId}`,
+      };
+    }
+    return this.startDaemon(goal, maxIterations, deps);
+  }
+
   /**
    * Format a goal for the confirmation prompt shown to the user before daemon start.
    * Prefixed with the seedling symbol per design spec.
@@ -155,7 +183,7 @@ export class TendCommand {
         message: `Goal not found: ${goalId}`,
       };
     }
-    return this.startDaemon(goal, maxIterations, deps.daemonClient);
+    return this.startDaemon(goal, maxIterations, deps);
   }
 
   private async tendFromChat(
@@ -199,25 +227,89 @@ export class TendCommand {
   private async startDaemon(
     goal: Goal,
     maxIterations: number | undefined,
-    daemonClient: DaemonClient
+    deps: TendDeps
   ): Promise<TendResult> {
+    const run = await createCoreLoopBackgroundRun(goal, deps);
     try {
-      await daemonClient.startGoal(goal.id);
+      await deps.daemonClient.startGoal(goal.id, {
+        backgroundRun: {
+          backgroundRunId: run.id,
+          parentSessionId: run.parent_session_id,
+          notifyPolicy: run.notify_policy,
+          replyTargetSource: run.reply_target_source,
+          pinnedReplyTarget: run.pinned_reply_target,
+        },
+      });
       const iterNote = maxIterations !== undefined ? ` (max ${maxIterations} iterations)` : "";
       return {
         success: true,
         goalId: goal.id,
         goalTitle: goal.title,
-        message: `🌱 [tend] ${goal.id}: Started — "${goal.title}"${iterNote}\nRun 'pulseed status' to check progress.`,
+        backgroundRunId: run.id,
+        message: `🌱 [tend] ${goal.id}: Started — "${goal.title}"${iterNote}\nBackground run: ${run.id}\nRun 'pulseed status' to check progress.`,
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
+      await getBackgroundRunLedger(deps).terminal(run.id, {
+        status: "failed",
+        completed_at: new Date().toISOString(),
+        error: msg,
+      }).catch(() => undefined);
       return {
         success: false,
+        backgroundRunId: run.id,
         message: `Daemon unavailable: ${msg}. Start the daemon with 'pulseed daemon start' first.`,
       };
     }
   }
+}
+
+async function createCoreLoopBackgroundRun(goal: Goal, deps: TendDeps) {
+  const pinnedReplyTarget = normalizePinnedReplyTarget(deps.replyTarget ?? null);
+  const parentSessionId = deps.sessionId ? `session:conversation:${deps.sessionId}` : null;
+  const sourceRefs = deps.sessionId ? [chatSessionSourceRef(deps.sessionId)] : [];
+  const input: BackgroundRunCreateInput = {
+    id: `run:coreloop:${randomUUID()}`,
+    kind: "coreloop_run",
+    parent_session_id: parentSessionId,
+    notify_policy: pinnedReplyTarget ? "done_only" : "silent",
+    reply_target_source: pinnedReplyTarget ? "pinned_run" : "none",
+    pinned_reply_target: pinnedReplyTarget,
+    title: goal.title,
+    workspace: deps.workspace ?? null,
+    source_refs: sourceRefs,
+  };
+  return getBackgroundRunLedger(deps).create(input);
+}
+
+function getBackgroundRunLedger(deps: TendDeps): Pick<BackgroundRunLedger, "create" | "terminal"> {
+  if (deps.backgroundRunLedger) return deps.backgroundRunLedger;
+  return new BackgroundRunLedger(resolveConfiguredDaemonRuntimeRoot(deps.stateManager.getBaseDir()));
+}
+
+function chatSessionSourceRef(sessionId: string): RuntimeSessionRef {
+  return {
+    kind: "chat_session",
+    id: sessionId,
+    path: null,
+    relative_path: `chat/sessions/${sessionId}.json`,
+    updated_at: null,
+  };
+}
+
+function normalizePinnedReplyTarget(replyTarget: RuntimeControlReplyTarget | null): RuntimeReplyTarget | null {
+  if (!replyTarget) return null;
+  const channel = replyTarget.channel ?? replyTarget.surface;
+  if (!channel) return null;
+  return {
+    channel,
+    target_id: replyTarget.conversation_id ?? replyTarget.identity_key ?? replyTarget.response_channel ?? null,
+    thread_id: replyTarget.message_id ?? null,
+    metadata: {
+      ...replyTarget,
+      ...(replyTarget.metadata ?? {}),
+    },
+  };
 }
 
 // --- Arg parsing ---

--- a/src/runtime/__tests__/daemon-client.test.ts
+++ b/src/runtime/__tests__/daemon-client.test.ts
@@ -161,6 +161,60 @@ describe("DaemonClient snapshot + replay", () => {
     });
   });
 
+  it("sends goal start background run metadata as a daemon command envelope", async () => {
+    const envelopes: unknown[] = [];
+    server.setCommandEnvelopeHook((envelope) => {
+      envelopes.push(envelope);
+    });
+    await server.start();
+
+    const client = new DaemonClient({
+      host: "127.0.0.1",
+      port: server.getPort(),
+      authToken: server.getAuthToken(),
+    });
+
+    await expect(client.startGoal("goal-bg", {
+      backgroundRun: {
+        backgroundRunId: "run:coreloop:goal-bg",
+        parentSessionId: "session:conversation:chat-bg",
+        notifyPolicy: "done_only",
+        replyTargetSource: "pinned_run",
+        pinnedReplyTarget: {
+          channel: "plugin_gateway",
+          target_id: "C123",
+          thread_id: "1710000000.000100",
+        },
+      },
+    })).resolves.toEqual({
+      ok: true,
+      goalId: "goal-bg",
+      backgroundRunId: "run:coreloop:goal-bg",
+    });
+
+    expect(envelopes).toHaveLength(1);
+    expect(envelopes[0]).toMatchObject({
+      type: "command",
+      name: "goal_start",
+      source: "http",
+      goal_id: "goal-bg",
+      payload: {
+        goalId: "goal-bg",
+        backgroundRun: {
+          backgroundRunId: "run:coreloop:goal-bg",
+          parentSessionId: "session:conversation:chat-bg",
+          notifyPolicy: "done_only",
+          replyTargetSource: "pinned_run",
+          pinnedReplyTarget: {
+            channel: "plugin_gateway",
+            target_id: "C123",
+            thread_id: "1710000000.000100",
+          },
+        },
+      },
+    });
+  });
+
   it("sends schedule run-now requests as daemon command envelopes", async () => {
     const envelopes: unknown[] = [];
     server.setCommandEnvelopeHook((envelope) => {

--- a/src/runtime/__tests__/loop-supervisor.test.ts
+++ b/src/runtime/__tests__/loop-supervisor.test.ts
@@ -9,6 +9,7 @@ import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
 import { GoalLeaseManager } from "../goal-lease-manager.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { makeGoal } from "../../../tests/helpers/fixtures.js";
+import { BackgroundRunLedger } from "../store/background-run-store.js";
 
 function makeLoopResult(o: Partial<LoopResult> = {}): LoopResult {
   return { goalId: "g", totalIterations: 1, finalStatus: "completed", iterations: [],
@@ -447,6 +448,125 @@ describe("LoopSupervisor", () => {
       expect(journalQueue.inflightSize()).toBe(0);
       expect(await goalLeaseManager.read("g-durable")).toBeNull();
     } finally {
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("links CoreLoop background runs to the worker session and marks terminal", async () => {
+    const runId = "run:coreloop:bg";
+    const { supervisor, deps, runtimeRoot } = makeSupervisor(async (goalId: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      return makeLoopResult({ goalId, totalIterations: 2 });
+    });
+    const ledger = new BackgroundRunLedger(runtimeRoot);
+    await ledger.ensureReady();
+    await ledger.create({
+      id: runId,
+      kind: "coreloop_run",
+      parent_session_id: "session:conversation:chat-bg",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      title: "Background CoreLoop",
+      workspace: "/repo",
+    });
+    (deps as { backgroundRunLedger?: BackgroundRunLedger }).backgroundRunLedger = ledger;
+
+    try {
+      await supervisor.start([]);
+      supervisor.activateGoal("g-bg", {
+        backgroundRun: {
+          backgroundRunId: runId,
+          parentSessionId: "session:conversation:chat-bg",
+        },
+      });
+
+      await waitFor(() => supervisor.getState().workers.some((worker) =>
+        worker.goalId === "g-bg" &&
+        worker.backgroundRunId === runId &&
+        worker.parentSessionId === "session:conversation:chat-bg" &&
+        worker.sessionId?.startsWith("session:coreloop:")
+      ));
+
+      const runFile = path.join(runtimeRoot, "background-runs", `${encodeURIComponent(runId)}.json`);
+      const terminal = await pollForJsonMatch<any>(runFile, (value) =>
+        value.status === "succeeded" &&
+        typeof value.child_session_id === "string" &&
+        value.child_session_id.startsWith("session:coreloop:")
+      );
+      await supervisor.shutdown();
+
+      expect(terminal).toMatchObject({
+        id: runId,
+        parent_session_id: "session:conversation:chat-bg",
+        status: "succeeded",
+        summary: "CoreLoop completed after 2 iteration(s).",
+      });
+      expect(terminal.source_refs).toContainEqual(expect.objectContaining({
+        kind: "supervisor_state",
+        path: path.join(runtimeRoot, "supervisor-state.json"),
+      }));
+    } finally {
+      await supervisor.shutdown();
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("settles coalesced CoreLoop background runs instead of leaving them queued", async () => {
+    const initialRunId = "run:coreloop:bg-initial";
+    const coalescedRunId = "run:coreloop:bg-coalesced";
+    const { supervisor, deps, runtimeRoot } = makeSupervisor(async (goalId: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 160));
+      return makeLoopResult({ goalId, totalIterations: 2 });
+    });
+    const ledger = new BackgroundRunLedger(runtimeRoot);
+    await ledger.ensureReady();
+    for (const runId of [initialRunId, coalescedRunId]) {
+      await ledger.create({
+        id: runId,
+        kind: "coreloop_run",
+        parent_session_id: "session:conversation:chat-bg",
+        notify_policy: "silent",
+        reply_target_source: "none",
+        title: runId,
+      });
+    }
+    (deps as { backgroundRunLedger?: BackgroundRunLedger }).backgroundRunLedger = ledger;
+
+    try {
+      await supervisor.start([]);
+      supervisor.activateGoal("g-bg", {
+        backgroundRun: {
+          backgroundRunId: initialRunId,
+          parentSessionId: "session:conversation:chat-bg",
+        },
+      });
+      await waitFor(() => supervisor.getState().workers.some((worker) =>
+        worker.goalId === "g-bg" && worker.backgroundRunId === initialRunId
+      ));
+
+      supervisor.activateGoal("g-bg", {
+        backgroundRun: {
+          backgroundRunId: coalescedRunId,
+          parentSessionId: "session:conversation:chat-bg",
+        },
+      });
+
+      const coalescedFile = path.join(runtimeRoot, "background-runs", `${encodeURIComponent(coalescedRunId)}.json`);
+      const settled = await pollForJsonMatch<any>(coalescedFile, (value) =>
+        value.status === "cancelled" &&
+        typeof value.child_session_id === "string" &&
+        value.child_session_id.startsWith("session:coreloop:")
+      );
+      await supervisor.shutdown();
+
+      expect(settled).toMatchObject({
+        id: coalescedRunId,
+        parent_session_id: "session:conversation:chat-bg",
+        status: "cancelled",
+      });
+      expect(settled.summary).toContain("coalesced into active worker");
+    } finally {
+      await supervisor.shutdown();
       fs.rmSync(runtimeRoot, { recursive: true, force: true });
     }
   });

--- a/src/runtime/daemon/client.ts
+++ b/src/runtime/daemon/client.ts
@@ -52,6 +52,18 @@ export interface DaemonScheduleRunNowResponse {
   scheduleId: string;
 }
 
+export interface DaemonStartGoalBackgroundRunMetadata {
+  backgroundRunId: string;
+  parentSessionId?: string | null;
+  notifyPolicy?: "silent" | "done_only" | "state_changes";
+  replyTargetSource?: "pinned_run" | "parent_session" | "none";
+  pinnedReplyTarget?: Record<string, unknown> | null;
+}
+
+export interface DaemonStartGoalOptions {
+  backgroundRun?: DaemonStartGoalBackgroundRunMetadata;
+}
+
 type EventHandler = (data: unknown) => void;
 
 const DAEMON_TOKEN_FILENAME = "daemon-token.json";
@@ -295,8 +307,8 @@ export class DaemonClient {
 
   // ─── REST Commands ───
 
-  async startGoal(goalId: string): Promise<{ ok: boolean }> {
-    return this.post(`/goals/${encodeURIComponent(goalId)}/start`, {});
+  async startGoal(goalId: string, options: DaemonStartGoalOptions = {}): Promise<{ ok: boolean; goalId?: string; backgroundRunId?: string }> {
+    return this.post(`/goals/${encodeURIComponent(goalId)}/start`, options);
   }
 
   async stopGoal(goalId: string): Promise<{ ok: boolean }> {

--- a/src/runtime/daemon/runner-commands.ts
+++ b/src/runtime/daemon/runner-commands.ts
@@ -12,6 +12,14 @@ import type { JournalBackedQueue, JournalBackedQueueAcceptResult } from "../queu
 import { writeChatMessageEvent } from "./maintenance.js";
 import { runCommandWithHealth as runCommandWithHealthFn } from "./runner-errors.js";
 
+export interface BackgroundRunStartMetadata {
+  backgroundRunId: string;
+  parentSessionId?: string | null;
+  notifyPolicy?: "silent" | "done_only" | "state_changes";
+  replyTargetSource?: "pinned_run" | "parent_session" | "none";
+  pinnedReplyTarget?: Record<string, unknown> | null;
+}
+
 export interface DaemonRunnerCommandContext {
   runtimeRoot?: string;
   logger: Logger;
@@ -80,15 +88,47 @@ export async function handleGoalStartCommand(
     "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state"
   >,
   goalId: string,
+  metadata?: BackgroundRunStartMetadata,
 ): Promise<void> {
   if (!context.currentGoalIds.includes(goalId)) {
     context.currentGoalIds.push(goalId);
   }
   context.refreshOperationalState();
   await context.saveDaemonState();
-  context.supervisor?.activateGoal(goalId);
+  context.supervisor?.activateGoal(goalId, metadata?.backgroundRunId ? { backgroundRun: metadata } : undefined);
   context.abortSleep();
   await context.broadcastGoalUpdated(goalId, "active");
+}
+
+export function extractBackgroundRunStartMetadata(envelope: Envelope): BackgroundRunStartMetadata | undefined {
+  const payload = envelope.payload;
+  if (!payload || typeof payload !== "object") return undefined;
+  const backgroundRun = (payload as Record<string, unknown>)["backgroundRun"];
+  if (!backgroundRun || typeof backgroundRun !== "object") return undefined;
+  const input = backgroundRun as Record<string, unknown>;
+  const backgroundRunId = input["backgroundRunId"];
+  if (typeof backgroundRunId !== "string" || backgroundRunId.trim() === "") return undefined;
+
+  const parentSessionId = input["parentSessionId"];
+  const notifyPolicy = input["notifyPolicy"];
+  const replyTargetSource = input["replyTargetSource"];
+  const pinnedReplyTarget = input["pinnedReplyTarget"];
+
+  return {
+    backgroundRunId,
+    ...(typeof parentSessionId === "string" || parentSessionId === null ? { parentSessionId } : {}),
+    ...(notifyPolicy === "silent" || notifyPolicy === "done_only" || notifyPolicy === "state_changes"
+      ? { notifyPolicy }
+      : {}),
+    ...(replyTargetSource === "pinned_run" || replyTargetSource === "parent_session" || replyTargetSource === "none"
+      ? { replyTargetSource }
+      : {}),
+    ...(pinnedReplyTarget && typeof pinnedReplyTarget === "object"
+      ? { pinnedReplyTarget: pinnedReplyTarget as Record<string, unknown> }
+      : pinnedReplyTarget === null
+        ? { pinnedReplyTarget: null }
+        : {}),
+  };
 }
 
 export async function handleGoalStopCommand(

--- a/src/runtime/daemon/runner-startup.ts
+++ b/src/runtime/daemon/runner-startup.ts
@@ -15,6 +15,8 @@ import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
 import type { CoreLoop } from "../../orchestrator/loop/core-loop.js";
 import { CommandDispatcher } from "../command-dispatcher.js";
 import { EventDispatcher } from "../event/dispatcher.js";
+import { BackgroundRunLedger } from "../store/background-run-store.js";
+import { extractBackgroundRunStartMetadata } from "./runner-commands.js";
 
 const RUNTIME_LEADER_LEASE_MS = 30_000;
 const RUNTIME_LEADER_HEARTBEAT_MS = 10_000;
@@ -205,7 +207,25 @@ export async function startDaemonRunner(
           driveSystem: context.driveSystem,
           stateManager: context.stateManager,
           logger: context.logger,
+          backgroundRunLedger: new BackgroundRunLedger(context.runtimeRoot ?? undefined),
           onGoalComplete: async (goalId, result) => context.handleGoalCompletion(goalId, result),
+          onBackgroundRunTerminal: async (run, result) => {
+            if (!context.eventServer || !run.pinned_reply_target) return;
+            const message = `Background run ${run.id} ${run.status}: ${run.summary ?? result.status}`;
+            await context.eventServer.broadcast("background_run_terminal", {
+              run_id: run.id,
+              run,
+              reply_target: run.pinned_reply_target,
+            });
+            await context.eventServer.broadcast("chat_response", {
+              goalId: `background_run:${run.id}`,
+              goal_id: `background_run:${run.id}`,
+              message,
+              status: run.status,
+              reply_target: run.pinned_reply_target,
+              background_run: run,
+            });
+          },
           onEscalation: (goalId, crashCount, lastError) => {
             context.logger.error(`Goal ${goalId} suspended after ${crashCount} crashes: ${lastError}`);
           },
@@ -230,8 +250,9 @@ export async function startDaemonRunner(
       context.commandDispatcher = new CommandDispatcher({
         journalQueue: context.journalQueue!,
         logger: context.logger,
-        onGoalStart: async (goalId) =>
-          context.runCommandWithHealth("goal_start", () => context.handleGoalStartCommand(goalId)),
+        onGoalStart: async (goalId, envelope) =>
+          context.runCommandWithHealth("goal_start", () =>
+            context.handleGoalStartCommand(goalId, extractBackgroundRunStartMetadata(envelope))),
         onGoalStop: async (goalId) =>
           context.runCommandWithHealth("goal_stop", () => context.handleGoalStopCommand(goalId)),
         onChatMessage: async (goalId, message) =>

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -89,6 +89,7 @@ import {
   handleInboundEnvelope as handleInboundEnvelopeFn,
   handleRuntimeControlCommand as handleRuntimeControlCommandFn,
   handleScheduleRunNowCommand as handleScheduleRunNowCommandFn,
+  type BackgroundRunStartMetadata,
 } from "./runner-commands.js";
 import { runDaemonGoalCycleLoop } from "./runner-goal-cycle.js";
 import { WaitDeadlineResolver, type WaitDeadlineResolution } from "./wait-deadline-resolver.js";
@@ -321,6 +322,7 @@ export class DaemonRunner {
       loop_count: 0,
       active_goals: [],
       status: "stopped",
+      runtime_root: this.runtimeRoot,
       crash_count: 0,
       last_error: null,
       last_resident_at: null,
@@ -646,8 +648,8 @@ export class DaemonRunner {
     await handleInboundEnvelopeFn(this as never, envelope);
   }
 
-  private async handleGoalStartCommand(goalId: string): Promise<void> {
-    await handleGoalStartCommandFn(this as never, goalId);
+  private async handleGoalStartCommand(goalId: string, metadata?: BackgroundRunStartMetadata): Promise<void> {
+    await handleGoalStartCommandFn(this as never, goalId, metadata);
   }
 
   private async handleGoalStopCommand(goalId: string): Promise<void> {

--- a/src/runtime/daemon/runtime-root.ts
+++ b/src/runtime/daemon/runtime-root.ts
@@ -1,0 +1,54 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { DaemonConfigSchema, DaemonStateSchema, type DaemonConfig } from "../../base/types/daemon.js";
+
+export function resolveDaemonRuntimeRoot(baseDir: string, configuredRoot?: string): string {
+  if (!configuredRoot || configuredRoot.trim() === "") {
+    return path.join(baseDir, "runtime");
+  }
+  return path.isAbsolute(configuredRoot)
+    ? configuredRoot
+    : path.resolve(baseDir, configuredRoot);
+}
+
+export function loadDaemonConfigSync(baseDir: string): DaemonConfig {
+  for (const fileName of ["daemon.json", "daemon-config.json"]) {
+    const filePath = path.join(baseDir, fileName);
+    if (!fs.existsSync(filePath)) continue;
+    try {
+      const parsed = DaemonConfigSchema.safeParse(JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown);
+      if (parsed.success) return parsed.data;
+    } catch {
+      // Ignore invalid daemon config here; callers fall back to the default runtime root.
+    }
+  }
+  return DaemonConfigSchema.parse({});
+}
+
+export function resolveConfiguredDaemonRuntimeRoot(baseDir: string): string {
+  const runningStateRoot = readRunningDaemonRuntimeRoot(baseDir);
+  if (runningStateRoot) return runningStateRoot;
+  const config = loadDaemonConfigSync(baseDir);
+  return resolveDaemonRuntimeRoot(baseDir, config.runtime_root);
+}
+
+function readRunningDaemonRuntimeRoot(baseDir: string): string | null {
+  const statePath = path.join(baseDir, "daemon-state.json");
+  if (!fs.existsSync(statePath)) return null;
+  try {
+    const parsed = DaemonStateSchema.safeParse(JSON.parse(fs.readFileSync(statePath, "utf-8")) as unknown);
+    if (!parsed.success) return null;
+    const state = parsed.data;
+    if (state.status !== "running" && state.status !== "idle") return null;
+    if (state.pid) {
+      try {
+        process.kill(state.pid, 0);
+      } catch {
+        return null;
+      }
+    }
+    return state.runtime_root ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/runtime/event/server-command-handler.ts
+++ b/src/runtime/event/server-command-handler.ts
@@ -23,14 +23,35 @@ export class EventServerCommandHandler {
   ): Promise<void> {
     if (action === "start") {
       try {
+        const body = await readBody(req);
+        const parsed = body.trim() ? JSON.parse(body) as Record<string, unknown> : {};
+        const backgroundRun = normalizeBackgroundRunMetadata(parsed["backgroundRun"]);
         await this.dispatchCommandEnvelope({
           name: "goal_start",
           goalId,
-          payload: { goalId },
+          payload: {
+            goalId,
+            ...(backgroundRun ? { backgroundRun } : {}),
+          },
         });
-        await this.broadcast("goal_start_requested", { goalId });
-        writeJson(res, 200, { ok: true, goalId });
+        await this.broadcast("goal_start_requested", {
+          goalId,
+          ...(backgroundRun?.backgroundRunId ? { backgroundRunId: backgroundRun.backgroundRunId } : {}),
+        });
+        writeJson(res, 200, {
+          ok: true,
+          goalId,
+          ...(backgroundRun?.backgroundRunId ? { backgroundRunId: backgroundRun.backgroundRunId } : {}),
+        });
       } catch (err) {
+        if (err instanceof Error && err.message === "Payload too large") {
+          writeJsonError(res, 413, "Payload too large");
+          return;
+        }
+        if (err instanceof SyntaxError) {
+          writeJsonError(res, 400, "Invalid goal start request", err);
+          return;
+        }
         writeJsonError(res, 500, "Command accept failed", err);
       }
       return;
@@ -215,4 +236,34 @@ export class EventServerCommandHandler {
       })
     );
   }
+}
+
+function normalizeBackgroundRunMetadata(value: unknown): {
+  backgroundRunId: string;
+  parentSessionId?: string | null;
+  notifyPolicy?: string;
+  replyTargetSource?: string;
+  pinnedReplyTarget?: Record<string, unknown> | null;
+} | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const input = value as Record<string, unknown>;
+  const backgroundRunId = input["backgroundRunId"];
+  if (typeof backgroundRunId !== "string" || backgroundRunId.trim() === "") return undefined;
+
+  const parentSessionId = input["parentSessionId"];
+  const notifyPolicy = input["notifyPolicy"];
+  const replyTargetSource = input["replyTargetSource"];
+  const pinnedReplyTarget = input["pinnedReplyTarget"];
+
+  return {
+    backgroundRunId,
+    ...(typeof parentSessionId === "string" || parentSessionId === null ? { parentSessionId } : {}),
+    ...(typeof notifyPolicy === "string" ? { notifyPolicy } : {}),
+    ...(typeof replyTargetSource === "string" ? { replyTargetSource } : {}),
+    ...(pinnedReplyTarget && typeof pinnedReplyTarget === "object"
+      ? { pinnedReplyTarget: pinnedReplyTarget as Record<string, unknown> }
+      : pinnedReplyTarget === null
+        ? { pinnedReplyTarget: null }
+        : {}),
+  };
 }

--- a/src/runtime/executor/goal-worker.ts
+++ b/src/runtime/executor/goal-worker.ts
@@ -32,6 +32,7 @@ export class GoalWorker {
     private readonly coreLoop: CoreLoop,
     private readonly config: GoalWorkerConfig = { iterationsPerCycle: 5 },
     private readonly hooks?: {
+      onRunStart?: (goalId: string) => Promise<void> | void;
       onRunComplete?: (result: LoopResult, cumulativeIterations: number) => Promise<void> | void;
     }
   ) {
@@ -44,6 +45,7 @@ export class GoalWorker {
     this.startedAt = Date.now();
     this.currentIterations = 0;
     this.extendRequested = false;
+    await this.hooks?.onRunStart?.(goalId);
 
     try {
       let lastResult: LoopResult | undefined;

--- a/src/runtime/executor/loop-supervisor.ts
+++ b/src/runtime/executor/loop-supervisor.ts
@@ -10,6 +10,8 @@ import { GoalLeaseManager } from '../goal-lease-manager.js';
 import { JournalBackedQueue, type JournalBackedQueueClaim } from '../queue/journal-backed-queue.js';
 import { StateFenceError } from '../../base/utils/errors.js';
 import { getPulseedDirPath } from '../../base/utils/paths.js';
+import type { BackgroundRunLedger } from '../store/background-run-store.js';
+import type { BackgroundRun, RuntimeSessionRef } from '../session-registry/types.js';
 
 export interface SupervisorConfig {
   concurrency: number;
@@ -29,8 +31,10 @@ export interface SupervisorDeps {
   driveSystem: DriveSystem;
   stateManager: StateManager;
   logger?: Logger;
+  backgroundRunLedger?: Pick<BackgroundRunLedger, 'load' | 'link' | 'started' | 'terminal'>;
   onCycleComplete?: (goalId: string, result: WorkerResult) => Promise<void> | void;
   onGoalComplete?: (goalId: string, result: WorkerResult) => Promise<void> | void;
+  onBackgroundRunTerminal?: (run: BackgroundRun, result: WorkerResult) => Promise<void> | void;
   onEscalation?: (goalId: string, crashCount: number, lastError: string) => void;
 }
 
@@ -40,6 +44,9 @@ export interface SupervisorState {
     goalId: string | null;
     startedAt: number;
     iterations: number;
+    backgroundRunId?: string | null;
+    sessionId?: string | null;
+    parentSessionId?: string | null;
   }>;
   crashCounts: Record<string, number>;
   suspendedGoals: string[];
@@ -51,9 +58,19 @@ interface DurableGoalActivation {
   claim: JournalBackedQueueClaim;
   ownerToken: string;
   attemptId: string;
+  backgroundRun?: GoalActivationBackgroundRun;
 }
 
 type GoalActivation = DurableGoalActivation;
+
+export interface GoalActivationBackgroundRun {
+  backgroundRunId: string;
+  parentSessionId?: string | null;
+}
+
+export interface ActivateGoalOptions {
+  backgroundRun?: GoalActivationBackgroundRun;
+}
 
 const DEFAULT_CONFIG: SupervisorConfig = {
   concurrency: 4,
@@ -66,9 +83,22 @@ const DEFAULT_CONFIG: SupervisorConfig = {
   leaseRenewIntervalMs: 10_000,
 };
 
+function workerStatusToBackgroundRunStatus(
+  status: WorkerResult['status'],
+): 'succeeded' | 'failed' | 'cancelled' {
+  if (status === 'completed') return 'succeeded';
+  if (status === 'stopped') return 'cancelled';
+  return 'failed';
+}
+
 export class LoopSupervisor {
   private workers: GoalWorker[] = [];
   private activeGoals: Map<string, GoalWorker> = new Map();
+  private activeBackgroundRuns: Map<string, {
+    backgroundRunId: string;
+    sessionId: string;
+    parentSessionId: string | null;
+  }> = new Map();
   private crashCounts: Map<string, number> = new Map();
   private suspendedGoals: Set<string> = new Set();
   private stoppedGoals: Set<string> = new Set();
@@ -90,6 +120,9 @@ export class LoopSupervisor {
     const workerCfg: GoalWorkerConfig = { iterationsPerCycle: this.config.iterationsPerCycle };
     for (let i = 0; i < this.config.concurrency; i++) {
       this.workers.push(new GoalWorker(this.deps.coreLoopFactory(), workerCfg, {
+        onRunStart: () => {
+          this.persistState();
+        },
         onRunComplete: async (loopResult, cumulativeIterations) => {
           await this.deps.onCycleComplete?.(loopResult.goalId, {
             goalId: loopResult.goalId,
@@ -131,12 +164,22 @@ export class LoopSupervisor {
 
   getState(): SupervisorState {
     return {
-      workers: this.workers.map(w => ({
-        workerId: w.id,
-        goalId: w.getCurrentGoalId(),
-        startedAt: w.getStartedAt(),
-        iterations: w.getIterations(),
-      })),
+      workers: this.workers.map(w => {
+        const backgroundRun = this.activeBackgroundRuns.get(w.id);
+        return {
+          workerId: w.id,
+          goalId: w.getCurrentGoalId(),
+          startedAt: w.getStartedAt(),
+          iterations: w.getIterations(),
+          ...(backgroundRun
+            ? {
+                backgroundRunId: backgroundRun.backgroundRunId,
+                sessionId: backgroundRun.sessionId,
+                parentSessionId: backgroundRun.parentSessionId,
+              }
+            : {}),
+        };
+      }),
       crashCounts: Object.fromEntries(this.crashCounts),
       suspendedGoals: [...this.suspendedGoals],
       updatedAt: Date.now(),
@@ -166,10 +209,10 @@ export class LoopSupervisor {
     }
   }
 
-  activateGoal(goalId: string): void {
+  activateGoal(goalId: string, options: ActivateGoalOptions = {}): void {
     this.stoppedGoals.delete(goalId);
     this.suspendedGoals.delete(goalId);
-    this.enqueueGoalActivation(goalId);
+    this.enqueueGoalActivation(goalId, options);
   }
 
   deactivateGoal(goalId: string): void {
@@ -189,19 +232,29 @@ export class LoopSupervisor {
     });
   }
 
-  private enqueueGoalActivation(goalId: string): void {
+  private enqueueGoalActivation(goalId: string, options: ActivateGoalOptions = {}): void {
     if (this.stoppedGoals.has(goalId)) {
       return;
     }
 
+    const backgroundRunId = options.backgroundRun?.backgroundRunId;
     const envelope = createEnvelope({
       type: 'event',
       name: 'goal_activated',
       source: 'supervisor',
       goal_id: goalId,
-      payload: {},
+      payload: backgroundRunId
+        ? {
+            backgroundRun: {
+              backgroundRunId,
+              ...(options.backgroundRun?.parentSessionId !== undefined
+                ? { parentSessionId: options.backgroundRun.parentSessionId }
+                : {}),
+            },
+          }
+        : {},
       priority: 'normal',
-      dedupe_key: `goal_activated:${goalId}`,
+      dedupe_key: backgroundRunId ? `goal_activated:${goalId}:${backgroundRunId}` : `goal_activated:${goalId}`,
     });
 
     const accepted = this.deps.journalQueue.accept(envelope);
@@ -226,7 +279,9 @@ export class LoopSupervisor {
 
         const goalId = dispatch.goalId;
         if (this.activeGoals.has(goalId)) {
-          this.activeGoals.get(goalId)!.requestExtend();
+          const activeWorker = this.activeGoals.get(goalId)!;
+          activeWorker.requestExtend();
+          await this.markCoalescedBackgroundRun(dispatch, activeWorker);
           await this.completeClaim(dispatch);
           continue;
         }
@@ -274,6 +329,21 @@ export class LoopSupervisor {
       claim,
       ownerToken: claim.claimToken,
       attemptId: claim.claimToken,
+      backgroundRun: this.extractActivationBackgroundRun(claim.envelope.payload),
+    };
+  }
+
+  private extractActivationBackgroundRun(payload: unknown): GoalActivationBackgroundRun | undefined {
+    if (!payload || typeof payload !== 'object') return undefined;
+    const backgroundRun = (payload as Record<string, unknown>)['backgroundRun'];
+    if (!backgroundRun || typeof backgroundRun !== 'object') return undefined;
+    const input = backgroundRun as Record<string, unknown>;
+    const backgroundRunId = input['backgroundRunId'];
+    if (typeof backgroundRunId !== 'string' || backgroundRunId.trim() === '') return undefined;
+    const parentSessionId = input['parentSessionId'];
+    return {
+      backgroundRunId,
+      ...(typeof parentSessionId === 'string' || parentSessionId === null ? { parentSessionId } : {}),
     };
   }
 
@@ -341,6 +411,8 @@ export class LoopSupervisor {
     const stopRenewal = this.startLeaseRenewLoop(activation, () => {
       ownershipLost = true;
     });
+    this.setActiveBackgroundRun(worker, activation);
+    await this.markBackgroundRunStarted(activation, worker);
 
     try {
       const result: WorkerResult = await worker.execute(goalId);
@@ -356,6 +428,7 @@ export class LoopSupervisor {
             crashCount: count,
           });
           this.deps.onEscalation?.(goalId, count, result.error ?? 'unknown error');
+          await this.markBackgroundRunTerminal(activation, result);
           await this.failClaim(
             activation,
             result.error ?? 'goal suspended after max crashes',
@@ -387,13 +460,143 @@ export class LoopSupervisor {
         });
       }
 
+      await this.markBackgroundRunTerminal(activation, result);
       await this.completeClaim(activation, ownershipLost);
     } finally {
       stopRenewal();
       this.clearWriteFence(goalId);
       await this.releaseExecutionLease(activation);
       this.activeGoals.delete(goalId);
+      this.activeBackgroundRuns.delete(worker.id);
       this.persistState();
+    }
+  }
+
+  private coreLoopSessionId(worker: GoalWorker): string {
+    return `session:coreloop:${worker.id}`;
+  }
+
+  private setActiveBackgroundRun(worker: GoalWorker, activation: GoalActivation): void {
+    const runId = activation.backgroundRun?.backgroundRunId;
+    if (!runId) return;
+    this.activeBackgroundRuns.set(worker.id, {
+      backgroundRunId: runId,
+      sessionId: this.coreLoopSessionId(worker),
+      parentSessionId: activation.backgroundRun?.parentSessionId ?? null,
+    });
+  }
+
+  private supervisorStateRef(): RuntimeSessionRef {
+    return {
+      kind: 'supervisor_state',
+      id: null,
+      path: this.config.stateFilePath,
+      relative_path: null,
+      updated_at: null,
+    };
+  }
+
+  private async mergeBackgroundRunSourceRefs(
+    runId: string,
+    refs: RuntimeSessionRef[],
+  ): Promise<RuntimeSessionRef[]> {
+    const existing = await this.deps.backgroundRunLedger?.load(runId).catch(() => null);
+    const currentRefs = existing?.source_refs ?? [];
+    const merged = [...currentRefs];
+    for (const ref of refs) {
+      const duplicate = merged.some((existingRef) =>
+        existingRef.kind === ref.kind
+        && existingRef.id === ref.id
+        && existingRef.path === ref.path
+        && existingRef.relative_path === ref.relative_path
+      );
+      if (!duplicate) merged.push(ref);
+    }
+    return merged;
+  }
+
+  private async markBackgroundRunStarted(activation: GoalActivation, worker: GoalWorker): Promise<void> {
+    const runId = activation.backgroundRun?.backgroundRunId;
+    if (!runId || !this.deps.backgroundRunLedger) return;
+    const sourceRefs = await this.mergeBackgroundRunSourceRefs(runId, [this.supervisorStateRef()]);
+    try {
+      if (activation.backgroundRun?.parentSessionId !== undefined) {
+        await this.deps.backgroundRunLedger.link(runId, {
+          parent_session_id: activation.backgroundRun.parentSessionId,
+          child_session_id: this.coreLoopSessionId(worker),
+          source_refs: sourceRefs,
+        });
+      }
+      await this.deps.backgroundRunLedger.started(runId, {
+        child_session_id: this.coreLoopSessionId(worker),
+        source_refs: sourceRefs,
+      });
+    } catch (err) {
+      this.deps.logger?.warn('Failed to mark background run started', {
+        goalId: activation.goalId,
+        backgroundRunId: runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private async markBackgroundRunTerminal(activation: GoalActivation, result: WorkerResult): Promise<void> {
+    const runId = activation.backgroundRun?.backgroundRunId;
+    if (!runId || !this.deps.backgroundRunLedger) return;
+    const sourceRefs = await this.mergeBackgroundRunSourceRefs(runId, [this.supervisorStateRef()]);
+    try {
+      const run = await this.deps.backgroundRunLedger.terminal(runId, {
+        status: workerStatusToBackgroundRunStatus(result.status),
+        summary: `CoreLoop ${result.status} after ${result.totalIterations} iteration(s).`,
+        error: result.error ?? null,
+        source_refs: sourceRefs,
+      });
+      if (run.notify_policy !== 'silent' && run.pinned_reply_target) {
+        await this.deps.onBackgroundRunTerminal?.(run, result);
+      }
+    } catch (err) {
+      this.deps.logger?.warn('Failed to mark background run terminal', {
+        goalId: activation.goalId,
+        backgroundRunId: runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private async markCoalescedBackgroundRun(activation: GoalActivation, activeWorker: GoalWorker): Promise<void> {
+    const runId = activation.backgroundRun?.backgroundRunId;
+    if (!runId || !this.deps.backgroundRunLedger) return;
+    const sourceRefs = await this.mergeBackgroundRunSourceRefs(runId, [this.supervisorStateRef()]);
+    const childSessionId = this.coreLoopSessionId(activeWorker);
+    try {
+      await this.deps.backgroundRunLedger.link(runId, {
+        parent_session_id: activation.backgroundRun?.parentSessionId ?? null,
+        child_session_id: childSessionId,
+        source_refs: sourceRefs,
+      });
+      await this.deps.backgroundRunLedger.started(runId, {
+        child_session_id: childSessionId,
+        source_refs: sourceRefs,
+      });
+      const run = await this.deps.backgroundRunLedger.terminal(runId, {
+        status: "cancelled",
+        summary: `CoreLoop activation coalesced into active worker ${activeWorker.id}.`,
+        source_refs: sourceRefs,
+      });
+      if (run.notify_policy !== 'silent' && run.pinned_reply_target) {
+        await this.deps.onBackgroundRunTerminal?.(run, {
+          goalId: activation.goalId,
+          status: 'stopped',
+          totalIterations: 0,
+          durationMs: 0,
+        });
+      }
+    } catch (err) {
+      this.deps.logger?.warn('Failed to settle coalesced background run', {
+        goalId: activation.goalId,
+        backgroundRunId: runId,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
+++ b/src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
@@ -288,6 +288,69 @@ describe("RuntimeSessionRegistry", () => {
     }));
   });
 
+  it("projects a completed CoreLoop handoff graph from durable ledger records", async () => {
+    await stateManager.writeRaw("chat/sessions/chat-coreloop.json", {
+      id: "chat-coreloop",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:01:00.000Z",
+      title: "CoreLoop handoff",
+      messages: [],
+    });
+
+    const ledger = new BackgroundRunLedger(path.join(tmpDir, "runtime"));
+    await ledger.ensureReady();
+    await ledger.create({
+      id: "run:coreloop:handoff",
+      kind: "coreloop_run",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      parent_session_id: "session:conversation:chat-coreloop",
+      child_session_id: "session:coreloop:worker-handoff",
+      title: "CoreLoop handoff",
+      workspace: "/repo",
+      created_at: "2026-04-25T00:02:00.000Z",
+      started_at: "2026-04-25T00:03:00.000Z",
+      status: "running",
+      source_refs: [{
+        kind: "supervisor_state",
+        id: null,
+        path: null,
+        relative_path: "runtime/supervisor-state.json",
+        updated_at: "2026-04-25T00:03:00.000Z",
+      }],
+    });
+    await ledger.terminal("run:coreloop:handoff", {
+      status: "succeeded",
+      completed_at: "2026-04-25T00:04:00.000Z",
+      summary: "CoreLoop completed.",
+    });
+
+    const snapshot = await new RuntimeSessionRegistry({ stateManager }).snapshot();
+
+    expect(snapshot.sessions).toContainEqual(expect.objectContaining({
+      id: "session:conversation:chat-coreloop",
+      kind: "conversation",
+    }));
+    expect(snapshot.background_runs).toContainEqual(expect.objectContaining({
+      id: "run:coreloop:handoff",
+      kind: "coreloop_run",
+      parent_session_id: "session:conversation:chat-coreloop",
+      child_session_id: "session:coreloop:worker-handoff",
+      status: "succeeded",
+    }));
+    expect(snapshot.sessions).toContainEqual(expect.objectContaining({
+      id: "session:coreloop:worker-handoff",
+      kind: "coreloop",
+      parent_session_id: "session:conversation:chat-coreloop",
+      status: "ended",
+      attachable: false,
+      state_ref: expect.objectContaining({
+        relative_path: "runtime/supervisor-state.json",
+      }),
+    }));
+  });
+
   it("does not project idle supervisor workers as active CoreLoop runs", async () => {
     await stateManager.writeRaw("supervisor-state.json", {
       workers: [

--- a/src/runtime/session-registry/registry.ts
+++ b/src/runtime/session-registry/registry.ts
@@ -64,7 +64,7 @@ export class RuntimeSessionRegistry {
     await this.projectChatAndAgentSessions(sessions, backgroundRuns, warnings);
     await this.projectSupervisorState(sessions, backgroundRuns, warnings);
     await this.projectProcessSessions(backgroundRuns, warnings);
-    await this.projectLedgerRuns(backgroundRuns, warnings);
+    await this.projectLedgerRuns(sessions, backgroundRuns, warnings);
 
     sessions.sort(compareByUpdatedAtThenId);
     backgroundRuns.sort(compareByUpdatedAtThenId);
@@ -374,13 +374,15 @@ export class RuntimeSessionRegistry {
       const goalId = stringField(worker, "goalId");
       if (!goalId) continue;
       const startedAt = numberToIso(worker["startedAt"]) ?? updatedAt;
-      const sessionId = coreLoopSessionId(workerId);
+      const sessionId = stringField(worker, "sessionId") ?? coreLoopSessionId(workerId);
+      const runId = stringField(worker, "backgroundRunId") ?? coreLoopRunId(workerId);
+      const parentSessionId = stringField(worker, "parentSessionId");
       const title = goalId ? `CoreLoop goal ${goalId}` : `CoreLoop worker ${workerId}`;
       sessions.push({
         schema_version: "runtime-session-v1",
         id: sessionId,
         kind: "coreloop",
-        parent_session_id: null,
+        parent_session_id: parentSessionId,
         title,
         workspace: null,
         status: "active",
@@ -396,9 +398,9 @@ export class RuntimeSessionRegistry {
       });
       backgroundRuns.push(BackgroundRunSchema.parse({
         schema_version: "background-run-v1",
-        id: coreLoopRunId(workerId),
+        id: runId,
         kind: "coreloop_run",
-        parent_session_id: null,
+        parent_session_id: parentSessionId,
         child_session_id: sessionId,
         process_session_id: null,
         status: "running",
@@ -475,6 +477,7 @@ export class RuntimeSessionRegistry {
   }
 
   private async projectLedgerRuns(
+    sessions: RuntimeSession[],
     backgroundRuns: BackgroundRun[],
     warnings: RuntimeSessionRegistryWarning[],
   ): Promise<void> {
@@ -491,8 +494,14 @@ export class RuntimeSessionRegistry {
     }
 
     const byId = new Map(backgroundRuns.map((run) => [run.id, run]));
+    const sessionIds = new Set(sessions.map((session) => session.id));
     for (const run of ledgerRuns) {
-      byId.set(run.id, mergeLedgerRunWithProjection(run, byId.get(run.id)));
+      const merged = mergeLedgerRunWithProjection(run, byId.get(run.id));
+      byId.set(run.id, merged);
+      if (merged.kind === "coreloop_run" && merged.child_session_id && !sessionIds.has(merged.child_session_id)) {
+        sessions.push(coreLoopSessionFromLedgerRun(merged));
+        sessionIds.add(merged.child_session_id);
+      }
     }
     backgroundRuns.splice(0, backgroundRuns.length, ...byId.values());
   }
@@ -625,6 +634,36 @@ function mergeLedgerRunWithProjection(ledgerRun: BackgroundRun, projectedRun: Ba
     error: projectedRun.error ?? ledgerRun.error,
     source_refs: [...ledgerRun.source_refs, ...projectedRun.source_refs],
   });
+}
+
+function coreLoopSessionFromLedgerRun(run: BackgroundRun): RuntimeSession {
+  const stateRef = run.source_refs.find((ref) => ref.kind === "supervisor_state") ?? null;
+  const createdAt = run.started_at ?? run.created_at;
+  return {
+    schema_version: "runtime-session-v1",
+    id: run.child_session_id!,
+    kind: "coreloop",
+    parent_session_id: run.parent_session_id,
+    title: run.title ?? run.id,
+    workspace: run.workspace,
+    status: coreLoopSessionStatusFromRunStatus(run.status),
+    created_at: createdAt,
+    updated_at: run.updated_at,
+    last_event_at: run.updated_at,
+    transcript_ref: null,
+    state_ref: stateRef,
+    reply_target: null,
+    resumable: false,
+    attachable: isActiveRunStatus(run.status),
+    source_refs: run.source_refs,
+  };
+}
+
+function coreLoopSessionStatusFromRunStatus(status: BackgroundRunStatus): RuntimeSessionStatus {
+  if (status === "queued" || status === "running") return "active";
+  if (status === "lost") return "lost";
+  if (status === "unknown") return "unknown";
+  return "ended";
 }
 
 function isActiveRunStatus(status: BackgroundRunStatus): boolean {

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -66,6 +66,7 @@ export const DaemonStateSchema = z.object({
   loop_count: z.number().int().nonnegative(),
   active_goals: z.array(z.string()),
   status: z.enum(["idle", "running", "stopping", "stopped", "crashed"]),
+  runtime_root: z.string().optional(),
   crash_count: z.number().int().nonnegative().default(0),
   last_error: z.string().nullable().default(null),
   interrupted_goals: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- create durable coreloop_run BackgroundRun records from /tend and forward run metadata through daemon start commands
- update LoopSupervisor to link/start/terminal CoreLoop background runs, including coalesced duplicate starts
- project durable CoreLoop run/session graphs in RuntimeSessionRegistry and persist daemon runtime_root for shared ledger resolution

## Tests
- npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/tend-command.test.ts
- npm run test:integration -- src/runtime/__tests__/daemon-client.test.ts src/runtime/__tests__/loop-supervisor.test.ts src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
- npm run typecheck
- npm run test:changed (unit + related integration passed; e2e milestone4-daemon failed only on existing local 127.0.0.1:41700 EADDRINUSE from resident daemon)

Refs #742