### PR TITLE
Fix TUI long text rendering and paste display

### DIFF
--- a/src/interface/tui/__tests__/chat-processing-scroll.test.ts
+++ b/src/interface/tui/__tests__/chat-processing-scroll.test.ts
@@ -1,0 +1,70 @@
+import React from "react";
+import { renderToString } from "ink";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatMessage } from "../chat.js";
+
+const useInputMock = vi.hoisted(() => vi.fn());
+const stdoutMock = vi.hoisted(() => ({
+  columns: 80,
+  rows: 24,
+  write: vi.fn(() => true),
+}));
+
+vi.mock("ink", async () => {
+  const actual = await vi.importActual<typeof import("ink")>("ink");
+  return {
+    ...actual,
+    useInput: useInputMock,
+    useStdout: () => ({ stdout: stdoutMock }),
+  };
+});
+
+describe("TUI chat processing scroll input", () => {
+  afterEach(() => {
+    useInputMock.mockReset();
+    stdoutMock.write = vi.fn(() => true);
+  });
+
+  it("keeps normal chat scroll input active while text input is locked during processing", async () => {
+    const { Chat } = await import("../chat.js");
+    const messages: ChatMessage[] = Array.from({ length: 30 }, (_, index) => ({
+      id: `m-${index}`,
+      role: "pulseed",
+      text: `message ${index}`,
+      timestamp: new Date(),
+    }));
+
+    renderToString(React.createElement(Chat, {
+      messages,
+      onSubmit: () => {},
+      isProcessing: true,
+      availableRows: 12,
+      availableCols: 60,
+      controlStream: { write: vi.fn() },
+    }), { columns: 60 });
+
+    expect(useInputMock).toHaveBeenCalledWith(expect.any(Function), { isActive: true });
+    expect(useInputMock).toHaveBeenCalledWith(expect.any(Function), { isActive: false });
+  });
+
+  it("keeps fullscreen chat scroll input active during processing", async () => {
+    const { FullscreenChat } = await import("../fullscreen-chat.js");
+    const messages: ChatMessage[] = Array.from({ length: 30 }, (_, index) => ({
+      id: `m-${index}`,
+      role: "pulseed",
+      text: `message ${index}`,
+      timestamp: new Date(),
+    }));
+
+    renderToString(React.createElement(FullscreenChat, {
+      messages,
+      onSubmit: () => {},
+      isProcessing: true,
+      availableRows: 12,
+      availableCols: 60,
+    }), { columns: 60 });
+
+    expect(useInputMock).toHaveBeenCalledWith(expect.any(Function), { isActive: true });
+    expect(useInputMock).toHaveBeenCalledWith(expect.any(Function), { isActive: false });
+  });
+});

--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -10,8 +10,16 @@ import {
   getScrollRequest,
   stripMouseEscapeSequences,
 } from "../chat.js";
-import { buildFullscreenChatRenderLines, copySelectedInputText, getSelectedInputText } from "../fullscreen-chat.js";
+import {
+  buildCollapsedPasteRange,
+  buildComposerLines,
+  buildFullscreenChatRenderLines,
+  copySelectedInputText,
+  getSelectedInputText,
+  shouldCollapsePastedText,
+} from "../fullscreen-chat.js";
 import { estimateMarkdownHeight, estimateWrappedLineCount, wrapTextToRows } from "../markdown-renderer.js";
+import { measureTextWidth } from "../text-width.js";
 import { extractBashCommand, isBashModeInput, isSafeBashCommand, createShellApprovalTask, formatShellOutput } from "../bash-mode.js";
 import {
   CARET_MARKER,
@@ -103,6 +111,13 @@ describe("markdown sizing helpers", () => {
   it("wraps plain text into terminal rows", () => {
     expect(wrapTextToRows("abcdefghij", 5)).toEqual(["abcde", "fghij"]);
   });
+
+  it("wraps full-width unbroken text by terminal display width", () => {
+    const rows = wrapTextToRows("これは改行のない長い日本語文章です".repeat(3), 20);
+
+    expect(rows.length).toBeGreaterThan(1);
+    expect(rows.every((row) => measureTextWidth(row) <= 20)).toBe(true);
+  });
 });
 
 describe("chat viewport", () => {
@@ -164,6 +179,22 @@ describe("chat viewport", () => {
     const keys = lines.map((line) => line.key);
     expect(keys.indexOf("indicator-bottom")).toBeLessThan(keys.indexOf("processing"));
     expect(keys.indexOf("processing")).toBeLessThan(keys.indexOf("composer-helper"));
+  });
+
+  it("keeps wrapped user rows within the terminal display width including the prompt", () => {
+    const viewport = buildChatViewport([
+      {
+        id: "m1",
+        role: "user" as const,
+        text: "これは改行のない長い日本語文章です".repeat(3),
+        timestamp: new Date(),
+      },
+    ], 32, 20, 0);
+
+    const userRows = viewport.rows.filter((row) => row.kind === "user");
+
+    expect(userRows.length).toBeGreaterThan(1);
+    expect(userRows.every((row) => measureTextWidth(row.text) <= 26)).toBe(true);
   });
 });
 
@@ -305,6 +336,38 @@ describe("composer clipboard selection", () => {
     await expect(copySelectedInputText("copy", { anchor: 2, focus: 2 }, copy)).resolves.toBe(false);
 
     expect(copy).not.toHaveBeenCalled();
+  });
+});
+
+describe("collapsed paste composer display", () => {
+  it("detects long pasted chunks without collapsing short typing chunks", () => {
+    expect(shouldCollapsePastedText("hello", "hello")).toBe(false);
+    expect(shouldCollapsePastedText("a".repeat(120), "a".repeat(120))).toBe(true);
+    expect(shouldCollapsePastedText("[200~line 1\nline 2\n".repeat(4) + "[201~", "line 1\nline 2\n".repeat(4))).toBe(true);
+  });
+
+  it("renders a collapsed paste label while preserving the original input range", () => {
+    const pasted = "word ".repeat(40);
+    const collapsedPaste = buildCollapsedPasteRange(pasted, 0);
+    const composer = buildComposerLines({
+      cols: 80,
+      input: pasted,
+      cursorOffset: pasted.length,
+      bashMode: false,
+      emptyHint: false,
+      matches: [],
+      selectedIdx: 0,
+      copyToast: null,
+      selection: null,
+      collapsedPaste,
+    });
+    const rendered = composer.lines
+      .flatMap((line) => line.segments?.map((segment) => segment.text) ?? [line.text ?? ""])
+      .join("");
+
+    expect(collapsedPaste.end).toBe(pasted.length);
+    expect(rendered).toContain("[pasted 200 chars]");
+    expect(rendered).not.toContain(pasted.slice(0, 40));
   });
 });
 

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -342,6 +342,15 @@ export function Chat({
   useInput(
     (inputChar, key) => {
       const scrollRequest = getScrollRequest(inputChar, key);
+      if (!scrollRequest) return;
+      applyScroll(scrollRequest.direction, scrollRequest.kind);
+    },
+    { isActive: isProcessing },
+  );
+
+  useInput(
+    (inputChar, key) => {
+      const scrollRequest = getScrollRequest(inputChar, key);
       if (scrollRequest) {
         applyScroll(scrollRequest.direction, scrollRequest.kind);
         return;
@@ -617,6 +626,7 @@ export function Chat({
             <Text>{INPUT_MARKER}</Text>
             <TextInput
               value={input}
+              focus={!isProcessing}
               onChange={(val) => {
                 justSelected.current = false;
                 setInput(stripMouseEscapeSequences(val));

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -483,9 +483,9 @@ export function Chat({
       setScrollOffset(0);
       return;
     }
-    onSubmit(trimmed);
+    onSubmit(value);
     setInput("");
-    setHistory((prev) => [...prev, trimmed]);
+    setHistory((prev) => [...prev, value]);
     setHistoryIdx(-1);
     setScrollOffset(0);
   };

--- a/src/interface/tui/chat/viewport.ts
+++ b/src/interface/tui/chat/viewport.ts
@@ -3,11 +3,14 @@ import {
   splitMarkdownLineToRows,
   wrapTextToRows,
 } from "../markdown-renderer.js";
+import { measureTextWidth } from "../text-width.js";
 import { getMessageTypeColor } from "../theme.js";
 import type { ChatDisplayRow, ChatMessage, ChatViewport } from "./types.js";
 const DEFAULT_MESSAGE_WIDTH_PADDING = 4;
 const MESSAGE_INNER_PADDING = 2;
 const MIN_MESSAGE_WIDTH = 10;
+const USER_PROMPT_PREFIX = "◉ ";
+const USER_CONTINUATION_PREFIX = "  ";
 
 function getRowWidth(termCols: number): number {
   return Math.max(
@@ -17,8 +20,13 @@ function getRowWidth(termCols: number): number {
 }
 
 function wrapUserMessageRows(text: string, width: number): string[] {
-  const wrapped = wrapTextToRows(text, width);
-  return wrapped.map((line, index) => (index === 0 ? `◉ ${line}` : `  ${line}`));
+  const contentWidth = Math.max(1, width - measureTextWidth(USER_PROMPT_PREFIX));
+  const wrapped = wrapTextToRows(text, contentWidth);
+  return wrapped.map((line, index) => (
+    index === 0
+      ? `${USER_PROMPT_PREFIX}${line}`
+      : `${USER_CONTINUATION_PREFIX}${line}`
+  ));
 }
 
 function buildMessageRows(msg: ChatMessage, width: number): ChatDisplayRow[] {

--- a/src/interface/tui/fullscreen-chat.tsx
+++ b/src/interface/tui/fullscreen-chat.tsx
@@ -988,6 +988,16 @@ export function FullscreenChat({
     });
   }, [maxScrollOffset, viewport.maxVisibleRows]);
 
+  useInput((inputChar, key) => {
+    const scrollRequest = getScrollRequest(inputChar, key);
+    if (!scrollRequest) return;
+    logTuiDebug("fullscreen-chat", "processing-scroll-request", {
+      direction: scrollRequest.direction,
+      kind: scrollRequest.kind,
+    });
+    applyScroll(scrollRequest.direction, scrollRequest.kind);
+  }, { isActive: isProcessing });
+
   const handleSubmit = useCallback((value: string) => {
     logTuiDebug("fullscreen-chat", "submit-attempt", {
       value,

--- a/src/interface/tui/fullscreen-chat.tsx
+++ b/src/interface/tui/fullscreen-chat.tsx
@@ -44,8 +44,10 @@ const SELECTION_FOREGROUND = "#1F2329";
 const FAKE_CURSOR_GLYPH = "▌";
 const PROCESSING_SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] as const;
 const PROCESSING_SPINNER_INTERVAL_MS = 80;
+const COLLAPSED_PASTE_MIN_CHARS = 120;
+const COLLAPSED_PASTE_MIN_MULTILINE_CHARS = 40;
 
-type RenderSegment = {
+export type RenderSegment = {
   text: string;
   color?: string;
   backgroundColor?: string;
@@ -53,7 +55,7 @@ type RenderSegment = {
   dim?: boolean;
 };
 
-type RenderLine = {
+export type RenderLine = {
   key: string;
   text?: string;
   segments?: RenderSegment[];
@@ -64,7 +66,7 @@ type RenderLine = {
   protected?: boolean;
 };
 
-type FullscreenChatRenderLinesInput = {
+export type FullscreenChatRenderLinesInput = {
   availableCols: number;
   availableRows: number;
   viewport: ReturnType<typeof buildChatViewport>;
@@ -84,22 +86,29 @@ export type SelectionRange = {
   end: number;
 };
 
-type InputCell = {
+export type CollapsedPasteRange = {
+  start: number;
+  end: number;
+  label: string;
+};
+
+export type InputCell = {
   text: string;
   width: number;
   offsetBefore: number;
   offsetAfter: number;
   selected?: boolean;
   placeholder?: boolean;
+  dim?: boolean;
 };
 
-type InputRow = {
+export type InputRow = {
   cells: InputCell[];
   startOffset: number;
   endOffset: number;
 };
 
-type ComposerRender = {
+export type ComposerRender = {
   lines: RenderLine[];
   inputRows: InputRow[];
   inputRowStartIndex: number;
@@ -209,6 +218,34 @@ function formatSuggestionLabel(suggestion: Suggestion): string {
     : `  ${suggestion.name.padEnd(20)}${suggestion.description}`;
 }
 
+function countTextLines(text: string): number {
+  return text.length === 0 ? 0 : text.split("\n").length;
+}
+
+export function shouldCollapsePastedText(rawInput: string, normalizedInput: string): boolean {
+  const isBracketedPaste = rawInput.includes("[200~") || rawInput.includes("\u001b[200~");
+  if (normalizedInput.length >= COLLAPSED_PASTE_MIN_CHARS) {
+    return true;
+  }
+  if (normalizedInput.includes("\n") && normalizedInput.length >= COLLAPSED_PASTE_MIN_MULTILINE_CHARS) {
+    return true;
+  }
+  return isBracketedPaste && normalizedInput.length >= COLLAPSED_PASTE_MIN_MULTILINE_CHARS;
+}
+
+export function buildCollapsedPasteRange(text: string, start: number): CollapsedPasteRange {
+  const lineCount = countTextLines(text);
+  const charCount = Array.from(text).length;
+  const label = lineCount > 1
+    ? `[pasted ${lineCount} lines, ${charCount} chars]`
+    : `[pasted ${charCount} chars]`;
+  return {
+    start,
+    end: start + text.length,
+    label,
+  };
+}
+
 function normalizeSelection(selection: SelectionState | null): SelectionRange | null {
   if (!selection || selection.anchor === selection.focus) {
     return null;
@@ -265,6 +302,7 @@ function buildInputRows(
   contentWidth: number,
   placeholder: string,
   selection: SelectionRange | null,
+  collapsedPaste: CollapsedPasteRange | null,
 ): {
   rows: InputRow[];
 } {
@@ -315,6 +353,11 @@ function buildInputRows(
   let currentWidth = 0;
   let rowStartOffset = 0;
   let rowEndOffset = 0;
+  const activeCollapsedPaste = collapsedPaste
+    && !(cursorOffset > collapsedPaste.start && cursorOffset < collapsedPaste.end)
+    && !(selection && selection.start < collapsedPaste.end && selection.end > collapsedPaste.start)
+    ? collapsedPaste
+    : null;
   const pushRow = () => {
     rows.push({
       cells: currentCells,
@@ -343,6 +386,29 @@ function buildInputRows(
 
     if (offset === input.length) {
       break;
+    }
+
+    if (activeCollapsedPaste && offset === activeCollapsedPaste.start) {
+      const label = stringWidth(activeCollapsedPaste.label) <= contentWidth
+        ? activeCollapsedPaste.label
+        : trimToWidth("[paste]", contentWidth);
+      const labelWidth = stringWidth(label);
+      if (currentWidth + labelWidth > contentWidth && currentCells.length > 0) {
+        pushRow();
+        rowStartOffset = offset;
+        rowEndOffset = offset;
+      }
+      currentCells.push({
+        text: label,
+        width: labelWidth,
+        offsetBefore: activeCollapsedPaste.start,
+        offsetAfter: activeCollapsedPaste.end,
+        dim: true,
+      });
+      currentWidth += labelWidth;
+      rowEndOffset = activeCollapsedPaste.end;
+      offset = activeCollapsedPaste.end;
+      continue;
     }
 
     const codePoint = input.codePointAt(offset) ?? 0;
@@ -419,7 +485,7 @@ function buildInputContentSegments(
 
     pushSegment(segments, cell.text, {
       color: defaultColor,
-      dim: cell.placeholder,
+      dim: cell.placeholder || cell.dim,
     });
   }
 
@@ -454,7 +520,7 @@ function getCursorPositionFromComposerLayout(
   return null;
 }
 
-function buildComposerLines(args: {
+export function buildComposerLines(args: {
   cols: number;
   input: string;
   cursorOffset: number;
@@ -464,6 +530,7 @@ function buildComposerLines(args: {
   selectedIdx: number;
   copyToast: string | null;
   selection: SelectionRange | null;
+  collapsedPaste: CollapsedPasteRange | null;
 }): ComposerRender {
   const {
     cols,
@@ -475,6 +542,7 @@ function buildComposerLines(args: {
     selectedIdx,
     copyToast,
     selection,
+    collapsedPaste,
   } = args;
 
   const lines: RenderLine[] = [];
@@ -495,6 +563,7 @@ function buildComposerLines(args: {
     contentWidth,
     getPlaceholder(bashMode),
     selection,
+    collapsedPaste,
   );
   const inputRows = inputRender.rows;
 
@@ -707,6 +776,7 @@ export function FullscreenChat({
   const [input, setInput] = useState("");
   const [cursorOffset, setCursorOffset] = useState(0);
   const [selection, setSelection] = useState<SelectionState | null>(null);
+  const [collapsedPaste, setCollapsedPaste] = useState<CollapsedPasteRange | null>(null);
   const selectionAnchor = React.useRef<number | null>(null);
   const [selectedIdx, setSelectedIdx] = useState(0);
   const justSelected = React.useRef(false);
@@ -778,24 +848,31 @@ export function FullscreenChat({
     start: number,
     end: number,
     replacement: string,
+    nextCollapsedPaste: CollapsedPasteRange | null = null,
   ) => {
     const next = input.slice(0, start) + replacement + input.slice(end);
     setInput(next);
     setCursorOffset(start + replacement.length);
+    setCollapsedPaste(nextCollapsedPaste);
     clearSelection();
   }, [clearSelection, input]);
 
-  const insertText = useCallback((text: string) => {
+  const insertText = useCallback((text: string, options: { collapsePaste?: boolean } = {}) => {
     justSelected.current = false;
     const selectedRange = normalizeSelection(selection);
+    const start = selectedRange ? selectedRange.start : cursorOffset;
+    const nextCollapsedPaste = options.collapsePaste
+      ? buildCollapsedPasteRange(text, start)
+      : null;
     if (selectedRange) {
-      replaceInputRange(selectedRange.start, selectedRange.end, text);
+      replaceInputRange(selectedRange.start, selectedRange.end, text, nextCollapsedPaste);
       return;
     }
 
     const next = input.slice(0, cursorOffset) + text + input.slice(cursorOffset);
     setInput(next);
     setCursorOffset(cursorOffset + text.length);
+    setCollapsedPaste(nextCollapsedPaste);
     clearSelection();
   }, [clearSelection, cursorOffset, input, replaceInputRange, selection]);
 
@@ -839,6 +916,7 @@ export function FullscreenChat({
     selectedIdx,
     copyToast,
     selection: normalizedSelection,
+    collapsedPaste,
   });
 
   const messageRows = Math.max(
@@ -929,6 +1007,7 @@ export function FullscreenChat({
       onClear?.();
       setInput("");
       setCursorOffset(0);
+      setCollapsedPaste(null);
       clearSelection();
       setHistory((prev) => [...prev, trimmed]);
       setHistoryIdx(-1);
@@ -937,11 +1016,12 @@ export function FullscreenChat({
       return;
     }
 
-    onSubmit(trimmed);
+    onSubmit(value);
     setInput("");
     setCursorOffset(0);
+    setCollapsedPaste(null);
     clearSelection();
-    setHistory((prev) => [...prev, trimmed]);
+    setHistory((prev) => [...prev, value]);
     setHistoryIdx(-1);
     setScrollOffset(0);
     setTargetScrollOffset(0);
@@ -1023,6 +1103,7 @@ export function FullscreenChat({
               : selected.name;
           setInput(value);
           setCursorOffset(value.length);
+          setCollapsedPaste(null);
           clearSelection();
           setSelectedIdx(0);
           justSelected.current = true;
@@ -1033,6 +1114,7 @@ export function FullscreenChat({
         setSelectedIdx(0);
         setInput("");
         setCursorOffset(0);
+        setCollapsedPaste(null);
         clearSelection();
         return;
       }
@@ -1088,6 +1170,7 @@ export function FullscreenChat({
         const next = input.slice(0, previousOffset) + input.slice(cursorOffset);
         setInput(next);
         setCursorOffset(previousOffset);
+        setCollapsedPaste(null);
         logTuiDebug("fullscreen-chat", "backspace-applied", {
           previousOffset,
           next,
@@ -1113,6 +1196,7 @@ export function FullscreenChat({
         const nextOffset = getNextOffset(input, cursorOffset);
         const next = input.slice(0, cursorOffset) + input.slice(nextOffset);
         setInput(next);
+        setCollapsedPaste(null);
         logTuiDebug("fullscreen-chat", "delete-applied", {
           nextOffset,
           next,
@@ -1132,11 +1216,13 @@ export function FullscreenChat({
           setHistoryIdx(idx);
           setInput(history[idx]!);
           setCursorOffset(history[idx]!.length);
+          setCollapsedPaste(null);
         } else if (historyIdx > 0) {
           const idx = historyIdx - 1;
           setHistoryIdx(idx);
           setInput(history[idx]!);
           setCursorOffset(history[idx]!.length);
+          setCollapsedPaste(null);
         }
       }
       return;
@@ -1148,10 +1234,12 @@ export function FullscreenChat({
         setHistoryIdx(idx);
         setInput(history[idx]!);
         setCursorOffset(history[idx]!.length);
+        setCollapsedPaste(null);
       } else {
         setHistoryIdx(-1);
         setInput(draft);
         setCursorOffset(draft.length);
+        setCollapsedPaste(null);
       }
       return;
     }
@@ -1159,7 +1247,9 @@ export function FullscreenChat({
     if (inputChar && !key.ctrl && !key.meta) {
       const clean = normalizeTerminalInputChunk(inputChar);
       if (clean.length === 0) return;
-      insertText(clean);
+      insertText(clean, {
+        collapsePaste: shouldCollapsePastedText(inputChar, clean),
+      });
     }
   }, { isActive: !isProcessing });
 

--- a/src/interface/tui/markdown-renderer.ts
+++ b/src/interface/tui/markdown-renderer.ts
@@ -10,6 +10,7 @@
 
 import * as os from "node:os";
 import * as path from "node:path";
+import { measureCharWidth, measureTextWidth } from "./text-width.js";
 import { theme } from "./theme.js";
 
 export interface MarkdownSegment {
@@ -34,6 +35,29 @@ const WORD_SEGMENTER =
     ? new Intl.Segmenter("en", { granularity: "word" })
     : null;
 
+function splitTextToWidth(text: string, width: number): string[] {
+  const safeWidth = Math.max(1, Math.floor(width));
+  const rows: string[] = [];
+  let current = "";
+  let currentWidth = 0;
+
+  for (const ch of text) {
+    const charWidth = measureCharWidth(ch);
+    if (current && currentWidth + charWidth > safeWidth) {
+      rows.push(current);
+      current = "";
+      currentWidth = 0;
+    }
+    current += ch;
+    currentWidth += charWidth;
+  }
+
+  if (current) {
+    rows.push(current);
+  }
+  return rows;
+}
+
 /**
  * Wrap plain text to terminal rows at the given width.
  * This is intentionally lightweight and shared by the TUI viewport logic.
@@ -54,23 +78,26 @@ export function wrapTextToRows(text: string, width: number): string[] {
       : paragraph.match(/\S+\s*|\s+/g) ?? [paragraph];
 
     let current = "";
+    let currentWidth = 0;
 
     for (const piece of pieces) {
       if (!piece) continue;
 
-      if (piece.length > safeWidth) {
+      const pieceWidth = measureTextWidth(piece);
+
+      if (pieceWidth > safeWidth) {
         if (current) {
           rows.push(current);
           current = "";
+          currentWidth = 0;
         }
-        for (let i = 0; i < piece.length; i += safeWidth) {
-          rows.push(piece.slice(i, i + safeWidth));
-        }
+        rows.push(...splitTextToWidth(piece, safeWidth));
         continue;
       }
 
-      if (current.length + piece.length <= safeWidth) {
+      if (currentWidth + pieceWidth <= safeWidth) {
         current += piece;
+        currentWidth += pieceWidth;
         continue;
       }
 
@@ -78,6 +105,7 @@ export function wrapTextToRows(text: string, width: number): string[] {
         rows.push(current);
       }
       current = piece.trimStart();
+      currentWidth = measureTextWidth(current);
     }
 
     if (current) {
@@ -150,6 +178,11 @@ export function splitMarkdownLineToRows(line: MarkdownLine, width: number): Mark
     currentText += piece;
   };
 
+  const pushSegmentPiece = (piece: string, segment: MarkdownSegment): void => {
+    appendPiece(piece, segment);
+    currentWidth += measureTextWidth(piece);
+  };
+
   const piecesFor = (text: string): string[] => {
     if (text === "") {
       return [""];
@@ -164,24 +197,26 @@ export function splitMarkdownLineToRows(line: MarkdownLine, width: number): Mark
     for (const piece of pieces) {
       if (!piece) continue;
 
-      if (piece.length > safeWidth) {
+      const pieceWidth = measureTextWidth(piece);
+
+      if (pieceWidth > safeWidth) {
         if (currentWidth > 0) {
           pushRow();
         }
-        for (let index = 0; index < piece.length; index += safeWidth) {
+        for (const wrappedPiece of splitTextToWidth(piece, safeWidth)) {
           rows.push({
-            text: piece.slice(index, index + safeWidth),
+            text: wrappedPiece,
             bold: line.bold,
             dim: line.dim,
             italic: line.italic,
-            segments: [{ ...segment, text: piece.slice(index, index + safeWidth) }],
+            segments: [{ ...segment, text: wrappedPiece }],
             language: line.language,
           });
         }
         continue;
       }
 
-      if (currentWidth + piece.length > safeWidth && currentWidth > 0) {
+      if (currentWidth + pieceWidth > safeWidth && currentWidth > 0) {
         pushRow();
       }
 
@@ -190,8 +225,7 @@ export function splitMarkdownLineToRows(line: MarkdownLine, width: number): Mark
         continue;
       }
 
-      appendPiece(rowPiece, segment);
-      currentWidth += rowPiece.length;
+      pushSegmentPiece(rowPiece, segment);
 
       if (currentWidth >= safeWidth) {
         pushRow();


### PR DESCRIPTION
## Summary
- wrap TUI chat text by terminal display width instead of JS string length
- account for the user prompt prefix when wrapping user messages
- collapse long pasted chunks in the fullscreen composer while preserving the full submitted payload
- keep chat scroll input active during processing while text editing remains locked

## Tests
- npx vitest run src/interface/tui/__tests__/chat.test.ts
- npx vitest run src/interface/tui/__tests__/chat.test.ts src/interface/tui/__tests__/chat-processing-scroll.test.ts
- npx tsc -p tsconfig.typecheck.json --noEmit --pretty false
- git diff --check