### PR TITLE
Make agent tool activity visible in TUI chat

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -34,18 +34,25 @@ describe("applyChatEventToMessages", () => {
     });
   });
 
-  it("does not add separate chat rows for raw tool events", () => {
+  it("shows raw tool events as a current activity row", () => {
     const messages = applyChatEventToMessages([], {
       type: "tool_start",
       runId: "run-1",
       turnId: "turn-1",
       createdAt: "2026-04-08T00:00:00.000Z",
       toolCallId: "tool-1",
-      toolName: "grep",
-      args: { pattern: "ChatEvent" },
+      toolName: "shell_command",
+      args: { command: "rg ChatEvent src/interface/chat", cwd: "/repo" },
     }, 20);
 
-    expect(messages).toEqual([]);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]!).toMatchObject({
+      id: "tool-log:turn-1",
+      role: "pulseed",
+      messageType: "info",
+    });
+    expect(messages[0]!.text).toContain("Current activity");
+    expect(messages[0]!.text).toContain("Reading shell_command - command=rg ChatEvent src/interface/chat");
   });
 
   it("removes transient activity when assistant final arrives", () => {
@@ -147,5 +154,103 @@ describe("applyChatEventToMessages", () => {
     expect(afterEnd).toHaveLength(1);
     expect(afterEnd[0]!.id).toBe("activity:turn-1");
     expect(afterEnd[0]!.text).toBe("Pinned note");
+  });
+
+  it("preserves the latest few tool events and keeps tool logs after the turn ends", () => {
+    let messages = [] as ReturnType<typeof applyChatEventToMessages>;
+    for (let index = 1; index <= 6; index += 1) {
+      messages = applyChatEventToMessages(messages, {
+        type: "tool_start",
+        runId: "run-1",
+        turnId: "turn-1",
+        createdAt: `2026-04-08T00:00:0${index}.000Z`,
+        toolCallId: `tool-${index}`,
+        toolName: "read_file",
+        args: { path: `src/file-${index}.ts` },
+      }, 20);
+    }
+
+    const toolLog = messages.find((message) => message.id === "tool-log:turn-1");
+    expect(toolLog?.text).not.toContain("file-1.ts");
+    expect(toolLog?.text).toContain("file-2.ts");
+    expect(toolLog?.text).toContain("file-6.ts");
+
+    const afterEnd = applyChatEventToMessages(messages, {
+      type: "lifecycle_end",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:10.000Z",
+      status: "completed",
+      elapsedMs: 10_000,
+      persisted: true,
+    }, 20);
+
+    expect(afterEnd.find((message) => message.id === "tool-log:turn-1")?.text).toContain("Recent activity");
+  });
+
+  it("keeps tool intent categories across updates and distinguishes waiting for approval", () => {
+    const started = applyChatEventToMessages([], {
+      type: "tool_start",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      toolCallId: "tool-1",
+      toolName: "shell_command",
+      args: { command: "npm run test:changed -- --run" },
+    }, 20);
+
+    const running = applyChatEventToMessages(started, {
+      type: "tool_update",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      toolCallId: "tool-1",
+      toolName: "shell_command",
+      status: "running",
+      message: "running",
+    }, 20);
+
+    expect(running[0]!.text).toContain("Verifying shell_command");
+    expect(running[0]!.text).toContain("command=npm run test:changed -- --run");
+
+    const waiting = applyChatEventToMessages(running, {
+      type: "tool_update",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:02.000Z",
+      toolCallId: "tool-2",
+      toolName: "apply_patch",
+      status: "awaiting_approval",
+      message: "write src/example.ts",
+    }, 20);
+
+    expect(waiting[0]!.text).toContain("Waiting for approval apply_patch - write src/example.ts");
+  });
+
+  it("moves a tool out of waiting once execution resumes after approval", () => {
+    const waiting = applyChatEventToMessages([], {
+      type: "tool_update",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      toolCallId: "tool-1",
+      toolName: "apply_patch",
+      status: "awaiting_approval",
+      message: "write src/example.ts",
+    }, 20);
+
+    const running = applyChatEventToMessages(waiting, {
+      type: "tool_update",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      toolCallId: "tool-1",
+      toolName: "apply_patch",
+      status: "running",
+      message: "running",
+    }, 20);
+
+    expect(running[0]!.text).not.toContain("Waiting for approval apply_patch");
+    expect(running[0]!.text).toContain("Editing apply_patch - write src/example.ts");
   });
 });

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -1,5 +1,15 @@
 import type { ChatEvent } from "./chat-events.js";
 
+type ToolActivityState = "reading" | "planning" | "editing" | "verifying" | "waiting" | "running" | "completed" | "failed";
+
+interface StreamToolActivity {
+  id: string;
+  toolName: string;
+  state: ToolActivityState;
+  detail: string;
+  timestamp: Date;
+}
+
 export interface StreamChatMessage {
   id: string;
   role: "user" | "pulseed";
@@ -7,7 +17,10 @@ export interface StreamChatMessage {
   timestamp: Date;
   messageType?: "info" | "error" | "warning" | "success";
   transient?: boolean;
+  toolActivities?: StreamToolActivity[];
 }
+
+const MAX_TOOL_ACTIVITIES = 5;
 
 function upsertMessage(
   messages: StreamChatMessage[],
@@ -29,6 +42,185 @@ function removeTransientActivityForTurn(
 ): StreamChatMessage[] {
   const transientActivityId = `activity:${turnId}`;
   return messages.filter((message) => !(message.id === transientActivityId && message.transient));
+}
+
+function getToolLogId(turnId: string): string {
+  return `tool-log:${turnId}`;
+}
+
+function summarizeValue(value: unknown): string {
+  if (typeof value === "string") {
+    const normalized = value.replace(/\s+/g, " ").trim();
+    return normalized.length > 80 ? `${normalized.slice(0, 77)}...` : normalized;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.length} item${value.length === 1 ? "" : "s"}]`;
+  }
+  if (value && typeof value === "object") {
+    const keys = Object.keys(value as Record<string, unknown>);
+    return keys.length > 0 ? `{${keys.slice(0, 3).join(", ")}}` : "{}";
+  }
+  return "";
+}
+
+function summarizeToolArgs(args: Record<string, unknown>): string {
+  const priorityKeys = [
+    "command",
+    "cmd",
+    "path",
+    "file",
+    "filename",
+    "cwd",
+    "pattern",
+    "query",
+    "url",
+    "target",
+    "plan_id",
+  ];
+  const entries = priorityKeys
+    .filter((key) => Object.prototype.hasOwnProperty.call(args, key))
+    .map((key) => {
+      const value = summarizeValue(args[key]);
+      return value ? `${key}=${value}` : "";
+    })
+    .filter(Boolean);
+  if (entries.length > 0) return entries.slice(0, 2).join(", ");
+  const keys = Object.keys(args);
+  if (keys.length === 0) return "";
+  return keys.slice(0, 3).map((key) => `${key}=${summarizeValue(args[key])}`).filter(Boolean).join(", ");
+}
+
+function classifyCommand(command: string): ToolActivityState {
+  const normalized = command.trim().toLowerCase();
+  if (/^(rg|grep|cat|sed|awk|ls|find|pwd|git (show|log|status|diff\b|grep))\b/.test(normalized)) {
+    return "reading";
+  }
+  if (/(npm|pnpm|yarn|bun) (run )?(test|check|typecheck|lint|verify)\b|pytest\b|vitest\b|cargo test\b|go test\b/.test(normalized)) {
+    return "verifying";
+  }
+  if (/^(apply_patch|git apply|python .*write|node .*write)\b/.test(normalized)) {
+    return "editing";
+  }
+  return "running";
+}
+
+function classifyTool(toolName: string, args: Record<string, unknown>, status?: "awaiting_approval" | "running" | "result"): ToolActivityState {
+  if (status === "awaiting_approval") return "waiting";
+  const normalized = toolName.toLowerCase().replace(/[-_]/g, "");
+  const command = typeof args["command"] === "string"
+    ? args["command"]
+    : typeof args["cmd"] === "string"
+      ? args["cmd"]
+      : null;
+  if (command) return classifyCommand(command);
+  if (normalized.includes("plan")) return "planning";
+  if (normalized.includes("write") || normalized.includes("edit") || normalized.includes("patch") || normalized.includes("delete")) {
+    return "editing";
+  }
+  if (normalized.includes("test") || normalized.includes("verify") || normalized.includes("check")) {
+    return "verifying";
+  }
+  if (
+    normalized.includes("read") ||
+    normalized.includes("list") ||
+    normalized.includes("search") ||
+    normalized.includes("grep") ||
+    normalized.includes("diff") ||
+    normalized.includes("log") ||
+    normalized.includes("status")
+  ) {
+    return "reading";
+  }
+  return "running";
+}
+
+function formatToolActivityState(state: ToolActivityState): string {
+  switch (state) {
+    case "reading":
+      return "Reading";
+    case "planning":
+      return "Planning";
+    case "editing":
+      return "Editing";
+    case "verifying":
+      return "Verifying";
+    case "waiting":
+      return "Waiting for approval";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "running":
+      return "Running";
+  }
+}
+
+function renderToolActivityMessage(activities: StreamToolActivity[], current: boolean): string {
+  const heading = current ? "Current activity" : "Recent activity";
+  const lines = activities.map((activity) => {
+    const detail = activity.detail ? ` - ${activity.detail}` : "";
+    return `- ${formatToolActivityState(activity.state)} ${activity.toolName}${detail}`;
+  });
+  return [heading, ...lines].join("\n");
+}
+
+function closeToolActivityForTurn(messages: StreamChatMessage[], turnId: string): StreamChatMessage[] {
+  const toolLogId = getToolLogId(turnId);
+  return messages.map((message) => {
+    if (message.id !== toolLogId || !message.toolActivities) return message;
+    return {
+      ...message,
+      text: renderToolActivityMessage(message.toolActivities, false),
+      transient: false,
+    };
+  });
+}
+
+function upsertToolActivity(
+  messages: StreamChatMessage[],
+  event: Extract<ChatEvent, { type: "tool_start" | "tool_update" | "tool_end" }>,
+  maxMessages: number
+): StreamChatMessage[] {
+  const timestamp = new Date(event.createdAt);
+  const toolLogId = getToolLogId(event.turnId);
+  const previous = messages.find((message) => message.id === toolLogId);
+  const previousActivities = previous?.toolActivities ?? [];
+  const existing = previousActivities.find((activity) => activity.id === event.toolCallId);
+  const args = event.type === "tool_start" ? event.args : {};
+  const fallbackDetail = event.type === "tool_start"
+    ? summarizeToolArgs(event.args)
+    : event.type === "tool_update"
+      ? (event.status === "running" ? existing?.detail ?? event.message : event.message)
+      : event.summary;
+  const detail = fallbackDetail || existing?.detail || "";
+  const state = event.type === "tool_end"
+    ? event.success ? "completed" : "failed"
+    : event.type === "tool_update" && event.status !== "awaiting_approval" && existing && existing.state !== "waiting"
+      ? existing.state
+      : classifyTool(event.toolName, args, event.type === "tool_update" ? event.status : "running");
+  const nextActivity: StreamToolActivity = {
+    id: event.toolCallId,
+    toolName: event.toolName,
+    state,
+    detail,
+    timestamp,
+  };
+  const nextActivities = [
+    ...previousActivities.filter((activity) => activity.id !== event.toolCallId),
+    nextActivity,
+  ].slice(-MAX_TOOL_ACTIVITIES);
+
+  return upsertMessage(messages, {
+    id: toolLogId,
+    role: "pulseed",
+    text: renderToolActivityMessage(nextActivities, true),
+    timestamp,
+    messageType: "info",
+    toolActivities: nextActivities,
+  }, maxMessages);
 }
 
 export function applyChatEventToMessages(
@@ -71,7 +263,7 @@ export function applyChatEventToMessages(
   }
 
   if (event.type === "lifecycle_error") {
-    const next = removeTransientActivityForTurn(messages, event.turnId);
+    const next = closeToolActivityForTurn(removeTransientActivityForTurn(messages, event.turnId), event.turnId);
     const messageId = event.partialText ? event.turnId : `error:${event.runId}`;
     const text = event.partialText
       ? `${event.partialText}\n\n[interrupted: ${event.error}]`
@@ -86,19 +278,19 @@ export function applyChatEventToMessages(
   }
 
   if (event.type === "lifecycle_end") {
-    return removeTransientActivityForTurn(messages, event.turnId);
+    return closeToolActivityForTurn(removeTransientActivityForTurn(messages, event.turnId), event.turnId);
   }
 
   if (event.type === "tool_start") {
-    return messages;
+    return upsertToolActivity(messages, event, maxMessages);
   }
 
   if (event.type === "tool_update") {
-    return messages;
+    return upsertToolActivity(messages, event, maxMessages);
   }
 
   if (event.type === "tool_end") {
-    return messages;
+    return upsertToolActivity(messages, event, maxMessages);
   }
 
   return messages;


### PR DESCRIPTION
## Summary
- render tool_start/tool_update/tool_end as a per-turn current activity row instead of dropping them
- classify visible activity as Reading, Planning, Editing, Verifying, Waiting for approval, Completed, or Failed
- keep the latest five tool activities as a short recent log after the turn ends

Closes #750

## Verification
- npm test -- --run src/interface/chat/__tests__/chat-event-state.test.ts
- npm run test:changed
- npm run typecheck
- independent review agent: no material issues after fixing approval transition