### PR TITLE
Show stable intent before chat execution

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -156,6 +156,47 @@ describe("applyChatEventToMessages", () => {
     expect(afterEnd[0]!.text).toBe("Pinned note");
   });
 
+  it("keeps non-transient sourced activity separate from transient status updates", () => {
+    const withIntent = applyChatEventToMessages([], {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      kind: "commentary",
+      message: "Intent\n- Confirm: inspect the repo",
+      sourceId: "intent:first-step",
+      transient: false,
+    }, 20);
+
+    const withStatus = applyChatEventToMessages(withIntent, {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      kind: "lifecycle",
+      message: "Preparing context...",
+      sourceId: "lifecycle:context",
+      transient: true,
+    }, 20);
+
+    const afterEnd = applyChatEventToMessages(withStatus, {
+      type: "lifecycle_end",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:02.000Z",
+      status: "completed",
+      elapsedMs: 2000,
+      persisted: true,
+    }, 20);
+
+    expect(afterEnd).toHaveLength(1);
+    expect(afterEnd[0]!).toMatchObject({
+      id: "activity:turn-1:intent:first-step",
+      text: "Intent\n- Confirm: inspect the repo",
+      transient: false,
+    });
+  });
+
   it("preserves the latest few tool events and keeps tool logs after the turn ends", () => {
     let messages = [] as ReturnType<typeof applyChatEventToMessages>;
     for (let index = 1; index <= 6; index += 1) {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -226,7 +226,8 @@ describe("ChatRunner", () => {
 
       await runner.execute("Do something", "/repo");
 
-      expect(events[0]).toBe("lifecycle:Preparing context...");
+      expect(events[0]).toContain("commentary:Intent\n- Confirm: Do something");
+      expect(events.indexOf("lifecycle:Preparing context...")).toBeGreaterThan(0);
       expect(events).toContain("lifecycle:Calling adapter...");
     });
 
@@ -1716,7 +1717,7 @@ describe("ChatRunner", () => {
 
   describe("agent loop and native tool protocol routing", () => {
     it("routes to chatAgentLoopRunner when configured", async () => {
-      const seenEvents: string[] = [];
+      const seenEvents: ChatEvent[] = [];
       const approvalFn = vi.fn().mockResolvedValue(true);
       const adapter = makeMockAdapter();
       const chatAgentLoopRunner = {
@@ -1777,7 +1778,7 @@ describe("ChatRunner", () => {
         chatAgentLoopRunner,
         llmClient: llmClient as never,
         approvalFn,
-        onEvent: (event) => { seenEvents.push(event.type); },
+        onEvent: (event) => { seenEvents.push(event); },
       }));
       const result = await runner.execute("Do something", "/repo");
 
@@ -1787,9 +1788,23 @@ describe("ChatRunner", () => {
       expect(result.success).toBe(true);
       expect(result.output).toBe("Native agentloop response");
       expect(approvalFn).toHaveBeenCalledWith("needs confirmation");
-      expect(seenEvents).toContain("tool_start");
-      expect(seenEvents).toContain("tool_end");
-      expect(seenEvents).toContain("tool_update");
+      const eventTypes = seenEvents.map((event) => event.type);
+      const intentIndex = seenEvents.findIndex((event) =>
+        event.type === "activity" && event.sourceId === "intent:first-step"
+      );
+      const firstToolIndex = eventTypes.indexOf("tool_start");
+      expect(intentIndex).toBeGreaterThanOrEqual(0);
+      expect(firstToolIndex).toBeGreaterThanOrEqual(0);
+      expect(intentIndex).toBeLessThan(firstToolIndex);
+      expect(seenEvents[intentIndex]).toMatchObject({
+        type: "activity",
+        kind: "commentary",
+        transient: false,
+        message: expect.stringContaining("Intent\n- Confirm: Do something"),
+      });
+      expect(eventTypes).toContain("tool_start");
+      expect(eventTypes).toContain("tool_end");
+      expect(eventTypes).toContain("tool_update");
     });
 
     it("routes simple questions through chatAgentLoopRunner when configured", async () => {
@@ -2105,14 +2120,35 @@ describe("ChatRunner", () => {
         }),
         parseJSON: vi.fn(),
       };
+      const events: ChatEvent[] = [];
 
       try {
-        const runner = new ChatRunner(makeDeps({ adapter, stateManager, llmClient: llmClient as never }));
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          stateManager,
+          llmClient: llmClient as never,
+          onEvent: (event) => { events.push(event); },
+        }));
         const result = await runner.execute("What is this lane?", "/repo");
 
         expect(result.success).toBe(true);
         expect(result.output).toBe("Plain answer");
         expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+        const intentIndex = events.findIndex((event) =>
+          event.type === "activity" && event.sourceId === "intent:first-step"
+        );
+        const modelIndex = events.findIndex((event) =>
+          event.type === "activity" && event.sourceId === "lifecycle:model"
+        );
+        expect(intentIndex).toBeGreaterThanOrEqual(0);
+        expect(modelIndex).toBeGreaterThanOrEqual(0);
+        expect(intentIndex).toBeLessThan(modelIndex);
+        expect(events[intentIndex]).toMatchObject({
+          type: "activity",
+          kind: "commentary",
+          transient: false,
+          message: expect.stringContaining("the router classified this as a simple question"),
+        });
         const options = llmClient.sendMessage.mock.calls[0]?.[1] as { system?: string } | undefined;
         expect(options?.system).toContain("StaticPromptSeed");
         expect(options?.system).toContain("configured agent identity running PulSeed");

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -48,6 +48,13 @@ function getToolLogId(turnId: string): string {
   return `tool-log:${turnId}`;
 }
 
+function getActivityMessageId(event: Extract<ChatEvent, { type: "activity" }>): string {
+  if (event.transient === false && event.sourceId) {
+    return `activity:${event.turnId}:${event.sourceId}`;
+  }
+  return `activity:${event.turnId}`;
+}
+
 function summarizeValue(value: unknown): string {
   if (typeof value === "string") {
     const normalized = value.replace(/\s+/g, " ").trim();
@@ -253,7 +260,7 @@ export function applyChatEventToMessages(
 
   if (event.type === "activity") {
     return upsertMessage(messages, {
-      id: `activity:${event.turnId}`,
+      id: getActivityMessageId(event),
       role: "pulseed",
       text: event.message,
       timestamp,

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -233,6 +233,11 @@ function formatToolActivity(action: "Running" | "Finished" | "Failed", toolName:
   return preview ? `${action} tool: ${toolName} - ${preview}` : `${action} tool: ${toolName}`;
 }
 
+function formatIntentInput(input: string, maxChars = 96): string {
+  const normalized = input.replace(/\s+/g, " ").trim();
+  return normalized.length > maxChars ? `${normalized.slice(0, maxChars - 3)}...` : normalized;
+}
+
 function resolveSelfIdentityResponse(input: string, baseDir: string): string | null {
   const normalized = input.trim().toLowerCase().replace(/\s+/g, "");
   if (!normalized) return null;
@@ -1716,6 +1721,11 @@ export class ChatRunner {
       ? null
       : (options.selectedRoute ?? this.resolveRouteFromInput(input, runtimeControlContext));
     const directPrompt = historyBlock ? `${historyBlock}${input}` : input;
+    if (!resumeOnly) {
+      this.emitIntent(input, selectedRoute, eventContext);
+    } else if (resumeOnly) {
+      this.emitIntent(input, null, eventContext);
+    }
 
     const start = Date.now();
     const assistantBuffer: AssistantBuffer = { text: "" };
@@ -2667,7 +2677,8 @@ export class ChatRunner {
     kind: ActivityKind,
     message: string,
     eventContext: ChatEventContext,
-    sourceId?: string
+    sourceId?: string,
+    transient = true
   ): void {
     if (!message.trim()) return;
     this.emitEvent({
@@ -2675,9 +2686,42 @@ export class ChatRunner {
       kind,
       message,
       ...(sourceId ? { sourceId } : {}),
-      transient: true,
+      transient,
       ...this.eventBase(eventContext),
     });
+  }
+
+  private emitIntent(
+    input: string,
+    selectedRoute: SelectedChatRoute | null,
+    eventContext: ChatEventContext
+  ): void {
+    const subject = formatIntentInput(input);
+    let nextStep = "resume the saved agent loop state before continuing.";
+    let reason = "resume needs the prior runtime context before any further action.";
+    if (selectedRoute?.kind === "runtime_control") {
+      nextStep = `prepare the ${selectedRoute.intent.kind} runtime-control request.`;
+      reason = "runtime changes need an explicit operation plan and approval path.";
+    } else if (selectedRoute?.kind === "direct_answer") {
+      nextStep = "ask the lightweight model for a concise direct answer.";
+      reason = "the router classified this as a simple question that does not need tools.";
+    } else if (selectedRoute?.kind === "agent_loop") {
+      nextStep = "gather workspace context, then let the agent loop inspect or change files with visible tool activity.";
+      reason = "this request may require multiple tool-backed steps.";
+    } else if (selectedRoute?.kind === "tool_loop") {
+      nextStep = "call the model with the tool catalog, then execute selected tools with visible activity.";
+      reason = "the available tools are needed to answer from current project state.";
+    } else if (selectedRoute?.kind === "adapter") {
+      nextStep = "prepare project context before handing the turn to the configured adapter.";
+      reason = "the adapter needs the current workspace context to act correctly.";
+    }
+    const message = [
+      "Intent",
+      `- Confirm: ${subject || "the current request"}`,
+      `- Next: ${nextStep}`,
+      `- Why: ${reason}`,
+    ].join("\n");
+    this.emitActivity("commentary", message, eventContext, "intent:first-step", false);
   }
 
   private pushAssistantDelta(


### PR DESCRIPTION
## Summary
- emit a stable non-transient intent activity before direct-answer, agent-loop, tool-loop, adapter, and resume execution
- keep sourced non-transient activity rows separate from transient lifecycle status updates
- cover intent ordering before adapter, agent-loop tools, and direct-answer model calls

Closes #751

## Verification
- npm test -- --run src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-runner.test.ts
- npm run test:changed
- npm run typecheck
- independent review agent: fixed direct-answer gap, then no material issues