### PR TITLE
Add visible checkpoints during chat runs

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -197,6 +197,47 @@ describe("applyChatEventToMessages", () => {
     });
   });
 
+  it("keeps checkpoint rows visible after transient lifecycle activity ends", () => {
+    const withCheckpoint = applyChatEventToMessages([], {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      kind: "checkpoint",
+      message: "Checkpoint\n- Context gathered: Workspace grounding is ready.",
+      sourceId: "checkpoint:context",
+      transient: false,
+    }, 20);
+
+    const withStatus = applyChatEventToMessages(withCheckpoint, {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      kind: "lifecycle",
+      message: "Calling adapter...",
+      sourceId: "lifecycle:adapter",
+      transient: true,
+    }, 20);
+
+    const afterEnd = applyChatEventToMessages(withStatus, {
+      type: "lifecycle_end",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:02.000Z",
+      status: "completed",
+      elapsedMs: 2000,
+      persisted: true,
+    }, 20);
+
+    expect(afterEnd).toHaveLength(1);
+    expect(afterEnd[0]!).toMatchObject({
+      id: "activity:turn-1:checkpoint:context",
+      text: "Checkpoint\n- Context gathered: Workspace grounding is ready.",
+      transient: false,
+    });
+  });
+
   it("preserves the latest few tool events and keeps tool logs after the turn ends", () => {
     let messages = [] as ReturnType<typeof applyChatEventToMessages>;
     for (let index = 1; index <= 6; index += 1) {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { execFileSync } from "node:child_process";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { z } from "zod";
 import { ChatRunner } from "../chat-runner.js";
@@ -228,7 +229,62 @@ describe("ChatRunner", () => {
 
       expect(events[0]).toContain("commentary:Intent\n- Confirm: Do something");
       expect(events.indexOf("lifecycle:Preparing context...")).toBeGreaterThan(0);
+      const contextCheckpointIndex = events.findIndex((event) =>
+        event.includes("checkpoint:Checkpoint\n- Context gathered:")
+      );
+      const adapterCheckpointIndex = events.findIndex((event) =>
+        event.includes("checkpoint:Checkpoint\n- Adapter started:")
+      );
+      const adapterActivityIndex = events.indexOf("lifecycle:Calling adapter...");
+      expect(contextCheckpointIndex).toBeGreaterThan(events.indexOf("lifecycle:Preparing context..."));
+      expect(adapterCheckpointIndex).toBeGreaterThan(contextCheckpointIndex);
+      expect(adapterActivityIndex).toBeGreaterThan(adapterCheckpointIndex);
       expect(events).toContain("lifecycle:Calling adapter...");
+    });
+
+    it("emits verification checkpoints when adapter execution changes the working tree", async () => {
+      const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-checkpoints-"));
+      const events: ChatEvent[] = [];
+      try {
+        execFileSync("git", ["init"], { cwd: workspaceDir, stdio: "ignore" });
+        execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: workspaceDir, stdio: "ignore" });
+        execFileSync("git", ["config", "user.name", "Test User"], { cwd: workspaceDir, stdio: "ignore" });
+        fs.writeFileSync(path.join(workspaceDir, "README.md"), "before\n", "utf-8");
+        execFileSync("git", ["add", "README.md"], { cwd: workspaceDir, stdio: "ignore" });
+        execFileSync("git", ["commit", "-m", "init"], { cwd: workspaceDir, stdio: "ignore" });
+
+        const adapter = {
+          adapterType: "mock",
+          execute: vi.fn().mockImplementation(async () => {
+            fs.writeFileSync(path.join(workspaceDir, "README.md"), "after\n", "utf-8");
+            return CANNED_RESULT;
+          }),
+        } as unknown as IAdapter;
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          onEvent: (event) => { events.push(event); },
+        }));
+
+        const result = await runner.execute("Change the README", workspaceDir);
+
+        expect(result.success).toBe(true);
+        const checkpointMessages = events
+          .filter((event): event is Extract<ChatEvent, { type: "activity" }> =>
+            event.type === "activity" && event.kind === "checkpoint"
+          )
+          .map((event) => event.message);
+        expect(checkpointMessages).toEqual(expect.arrayContaining([
+          expect.stringContaining("Context gathered"),
+          expect.stringContaining("Adapter started"),
+          expect.stringContaining("Changes detected"),
+          expect.stringContaining("Verification passed"),
+          expect.stringContaining("Response ready"),
+        ]));
+        expect(checkpointMessages.findIndex((message) => message.includes("Changes detected")))
+          .toBeLessThan(checkpointMessages.findIndex((message) => message.includes("Verification passed")));
+      } finally {
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+      }
     });
 
     it("propagates adapter failure to ChatRunResult", async () => {
@@ -1732,6 +1788,13 @@ describe("ChatRunner", () => {
             inputPreview: "{\"command\":\"pwd\"}",
           });
           await input.eventSink?.emit({
+            type: "plan_update",
+            eventId: "plan-event-1",
+            turnId: "agent-turn",
+            createdAt: new Date().toISOString(),
+            summary: "Inspect workspace, apply patch, then verify.",
+          });
+          await input.eventSink?.emit({
             type: "approval_request",
             callId: "call-approval",
             turnId: "agent-turn",
@@ -1802,6 +1865,17 @@ describe("ChatRunner", () => {
         transient: false,
         message: expect.stringContaining("Intent\n- Confirm: Do something"),
       });
+      const checkpointMessages = seenEvents
+        .filter((event): event is Extract<ChatEvent, { type: "activity" }> =>
+          event.type === "activity" && event.kind === "checkpoint"
+        )
+        .map((event) => event.message);
+      expect(checkpointMessages).toEqual(expect.arrayContaining([
+        expect.stringContaining("Agent loop started"),
+        expect.stringContaining("Plan updated"),
+        expect.stringContaining("Approval requested"),
+        expect.stringContaining("Response ready"),
+      ]));
       expect(eventTypes).toContain("tool_start");
       expect(eventTypes).toContain("tool_end");
       expect(eventTypes).toContain("tool_update");

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -21,7 +21,7 @@ export interface AssistantFinalEvent extends ChatEventBase {
   persisted: boolean;
 }
 
-export type ActivityKind = "lifecycle" | "commentary" | "tool" | "plugin" | "skill";
+export type ActivityKind = "lifecycle" | "commentary" | "checkpoint" | "tool" | "plugin" | "skill";
 
 export interface ActivityEvent extends ChatEventBase {
   type: "activity";

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -1751,6 +1751,7 @@ export class ChatRunner {
     }
 
     if (selectedRoute?.kind === "runtime_control") {
+      this.emitCheckpoint("Runtime control selected", `${selectedRoute.intent.kind} request recognized.`, eventContext, "route");
       const runtimeControlResult = await this.executeRuntimeControlRoute(
         selectedRoute,
         runtimeControlContext,
@@ -1759,6 +1760,7 @@ export class ChatRunner {
       );
       if (runtimeControlResult.success) {
         await history.appendAssistantMessage(runtimeControlResult.output);
+        this.emitCheckpoint("Runtime control completed", "The runtime-control operation produced a result.", eventContext, "complete");
         this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
         this.emitEvent({
           type: "assistant_final",
@@ -1795,6 +1797,7 @@ export class ChatRunner {
           history.recordUsage("execution", turnUsage);
         }
         await history.appendAssistantMessage(output);
+        this.emitCheckpoint("Response ready", "The direct answer has been persisted for this turn.", eventContext, "complete");
         this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
         this.emitEvent({
           type: "assistant_final",
@@ -1868,6 +1871,9 @@ export class ChatRunner {
       } catch {
         systemPrompt = this.cachedStaticSystemPrompt ?? "";
       }
+      this.emitCheckpoint("Context gathered", usesNativeAgentLoop
+        ? "Workspace and agent-loop grounding are ready."
+        : "Workspace grounding is ready.", eventContext, "context");
     }
     const agentLoopSystemPrompt = [
       systemPrompt,
@@ -1918,6 +1924,9 @@ export class ChatRunner {
             elapsed_ms,
           };
         }
+        this.emitCheckpoint(resumeOnly ? "Session resumed" : "Agent loop started", resumeOnly
+          ? "Resumable agent-loop state is loaded."
+          : "The agent loop can now inspect, plan, edit, or verify with visible tool activity.", eventContext, "execution");
         this.emitActivity("lifecycle", "Calling model...", eventContext, "lifecycle:model");
         const result = await chatAgentLoopRunner!.execute({
           message: basePrompt,
@@ -1954,6 +1963,7 @@ export class ChatRunner {
         }
         if (result.success) {
           await history.appendAssistantMessage(result.output);
+          this.emitCheckpoint("Response ready", "The agent-loop response has been persisted for this turn.", eventContext, "complete");
           this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
           this.emitEvent({
             type: "assistant_final",
@@ -1988,6 +1998,7 @@ export class ChatRunner {
     // Prefer the local LLM/tool loop over the external adapter fallback whenever a client is available.
     if (selectedRoute?.kind === "tool_loop") {
       try {
+        this.emitCheckpoint("Tool loop started", "The model will choose tools from the active catalog.", eventContext, "execution");
         const toolResult = await this.executeWithTools(
           prompt,
           eventContext,
@@ -2000,6 +2011,7 @@ export class ChatRunner {
           history.recordUsage("execution", toolResult.usage);
         }
         await history.appendAssistantMessage(toolResult.output);
+        this.emitCheckpoint("Response ready", "The tool-loop response has been persisted for this turn.", eventContext, "complete");
         this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
         this.emitEvent({
           type: "assistant_final",
@@ -2043,6 +2055,7 @@ export class ChatRunner {
       ...(systemPrompt ? { system_prompt: systemPrompt } : {}),
     };
     const resolvedTimeoutMs = task.timeout_ms ?? DEFAULT_TIMEOUT_MS;
+    this.emitCheckpoint("Adapter started", "The configured adapter has the current prompt and project context.", eventContext, "execution");
     this.emitActivity("lifecycle", "Calling adapter...", eventContext, "lifecycle:adapter");
     const adapterPromise = this.deps.adapter.execute(task);
     const timeoutPromise = new Promise<never>((_, reject) =>
@@ -2063,6 +2076,7 @@ export class ChatRunner {
     if (gitChanges !== null && gitChanges !== "") {
       let retries = 0;
       const VERIFY_TIMEOUT_MS = 30_000;
+      this.emitCheckpoint("Changes detected", "Verification is starting because the turn changed the working tree.", eventContext, "changes");
       this.emitActivity("lifecycle", "Checking result...", eventContext, "lifecycle:checking");
       let verification = await Promise.race([
         verifyChatAction(gitRoot, this.deps.toolExecutor),
@@ -2073,6 +2087,7 @@ export class ChatRunner {
 
       while (!verification.passed && retries < MAX_VERIFY_RETRIES) {
         retries++;
+        this.emitCheckpoint("Verification retry", `Attempt ${retries} of ${MAX_VERIFY_RETRIES} is repairing failed checks.`, eventContext, `verification-retry-${retries}`);
         const retryPrompt = `The previous changes caused test failures. Please fix them.\n\nTest output:\n${verification.testOutput ?? verification.errors.join("\n")}`;
         const retryTask: AgentTask = { ...task, prompt: retryPrompt };
         result = await this.deps.adapter.execute(retryTask);
@@ -2080,6 +2095,7 @@ export class ChatRunner {
       }
 
       if (!verification.passed) {
+        this.emitCheckpoint("Verification failed", `Checks are still failing after ${MAX_VERIFY_RETRIES} retries.`, eventContext, "verification");
         this.emitLifecycleErrorEvent(
           `Changes applied but tests are still failing after ${MAX_VERIFY_RETRIES} retries.`,
           assistantBuffer.text,
@@ -2092,10 +2108,12 @@ export class ChatRunner {
           elapsed_ms: Date.now() - start,
         };
       }
+      this.emitCheckpoint("Verification passed", "Changed files passed the configured chat verification.", eventContext, "verification");
     }
 
     if (result.success) {
       await history.appendAssistantMessage(result.output);
+      this.emitCheckpoint("Response ready", "The assistant response has been persisted for this turn.", eventContext, "complete");
       this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
       this.emitEvent({
         type: "assistant_final",
@@ -2325,6 +2343,7 @@ export class ChatRunner {
 
         if (event.type === "plan_update") {
           this.emitActivity("tool", `Updated plan: ${previewActivityText(event.summary)}`, eventContext, `plan:${event.turnId}`);
+          this.emitCheckpoint("Plan updated", previewActivityText(event.summary, 160), eventContext, `plan:${event.eventId}`);
           this.emitEvent({
             type: "tool_update",
             toolCallId: `plan:${event.turnId}:${event.createdAt}`,
@@ -2338,6 +2357,7 @@ export class ChatRunner {
 
         if (event.type === "approval_request") {
           this.emitActivity("tool", formatToolActivity("Running", event.toolName, `awaiting approval: ${event.reason}`), eventContext, event.callId);
+          this.emitCheckpoint("Approval requested", `${event.toolName}: ${event.reason}`, eventContext, `approval:${event.callId}`);
           this.emitEvent({
             type: "tool_update",
             toolCallId: event.callId,
@@ -2722,6 +2742,18 @@ export class ChatRunner {
       `- Why: ${reason}`,
     ].join("\n");
     this.emitActivity("commentary", message, eventContext, "intent:first-step", false);
+  }
+
+  private emitCheckpoint(
+    title: string,
+    detail: string,
+    eventContext: ChatEventContext,
+    sourceKey: string
+  ): void {
+    const message = detail
+      ? `Checkpoint\n- ${title}: ${detail}`
+      : `Checkpoint\n- ${title}`;
+    this.emitActivity("checkpoint", message, eventContext, `checkpoint:${sourceKey}`, false);
   }
 
   private pushAssistantDelta(


### PR DESCRIPTION
## Summary
- add a `checkpoint` chat activity kind for stable stage-boundary rows
- emit checkpoints for context gathering, route execution, plan updates, approval requests, verification, and response persistence
- keep checkpoint rows visible after transient lifecycle updates and cover adapter/agent-loop/verification ordering

Closes #753

## Verification
- npm test -- --run src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-runner.test.ts
- npm run test:changed
- npm run typecheck
- independent review agent: no material issues