### PR TITLE
Surface diffs after chat mutations

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -238,6 +238,47 @@ describe("applyChatEventToMessages", () => {
     });
   });
 
+  it("keeps diff artifact rows visible after transient lifecycle activity ends", () => {
+    const withDiff = applyChatEventToMessages([], {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      kind: "diff",
+      message: "Changed files\nModified files\nM\tsrc/example.ts",
+      sourceId: "diff:working-tree",
+      transient: false,
+    }, 20);
+
+    const withStatus = applyChatEventToMessages(withDiff, {
+      type: "activity",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      kind: "lifecycle",
+      message: "Finalizing response...",
+      sourceId: "lifecycle:finalizing",
+      transient: true,
+    }, 20);
+
+    const afterEnd = applyChatEventToMessages(withStatus, {
+      type: "lifecycle_end",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:02.000Z",
+      status: "completed",
+      elapsedMs: 2000,
+      persisted: true,
+    }, 20);
+
+    expect(afterEnd).toHaveLength(1);
+    expect(afterEnd[0]!).toMatchObject({
+      id: "activity:turn-1:diff:working-tree",
+      text: "Changed files\nModified files\nM\tsrc/example.ts",
+      transient: false,
+    });
+  });
+
   it("preserves the latest few tool events and keeps tool logs after the turn ends", () => {
     let messages = [] as ReturnType<typeof applyChatEventToMessages>;
     for (let index = 1; index <= 6; index += 1) {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -273,6 +273,21 @@ describe("ChatRunner", () => {
             event.type === "activity" && event.kind === "checkpoint"
           )
           .map((event) => event.message);
+        const diffEvent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
+          event.type === "activity" && event.kind === "diff"
+        );
+        expect(diffEvent).toMatchObject({
+          type: "activity",
+          kind: "diff",
+          sourceId: "diff:working-tree",
+          transient: false,
+        });
+        expect(diffEvent?.message).toContain("Changed files");
+        expect(diffEvent?.message).toContain("Modified files");
+        expect(diffEvent?.message).toContain("M\tREADME.md");
+        expect(diffEvent?.message).toContain("Inline patch");
+        expect(diffEvent?.message).toContain("-before");
+        expect(diffEvent?.message).toContain("+after");
         expect(checkpointMessages).toEqual(expect.arrayContaining([
           expect.stringContaining("Context gathered"),
           expect.stringContaining("Adapter started"),
@@ -282,6 +297,125 @@ describe("ChatRunner", () => {
         ]));
         expect(checkpointMessages.findIndex((message) => message.includes("Changes detected")))
           .toBeLessThan(checkpointMessages.findIndex((message) => message.includes("Verification passed")));
+      } finally {
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
+    it("emits a diff artifact when a turn only creates an untracked file", async () => {
+      const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-untracked-diff-"));
+      const events: ChatEvent[] = [];
+      try {
+        execFileSync("git", ["init"], { cwd: workspaceDir, stdio: "ignore" });
+        execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: workspaceDir, stdio: "ignore" });
+        execFileSync("git", ["config", "user.name", "Test User"], { cwd: workspaceDir, stdio: "ignore" });
+        fs.writeFileSync(path.join(workspaceDir, "README.md"), "base\n", "utf-8");
+        execFileSync("git", ["add", "README.md"], { cwd: workspaceDir, stdio: "ignore" });
+        execFileSync("git", ["commit", "-m", "init"], { cwd: workspaceDir, stdio: "ignore" });
+
+        const adapter = {
+          adapterType: "mock",
+          execute: vi.fn().mockImplementation(async () => {
+            fs.writeFileSync(path.join(workspaceDir, "new-file.txt"), "new content\n", "utf-8");
+            return CANNED_RESULT;
+          }),
+        } as unknown as IAdapter;
+        const toolExecutor = {
+          execute: vi.fn().mockImplementation(async (toolName: string) => {
+            if (toolName === "git_diff") {
+              return { success: true, data: "", summary: "", durationMs: 0 };
+            }
+            return {
+              success: true,
+              data: { passed: 1, failed: 0, skipped: 0, total: 1, success: true, rawOutput: "PASS" },
+              summary: "",
+              durationMs: 0,
+            };
+          }),
+        } as unknown as NonNullable<ChatRunnerDeps["toolExecutor"]>;
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          toolExecutor,
+          onEvent: (event) => { events.push(event); },
+        }));
+
+        const result = await runner.execute("Create a new file", workspaceDir);
+
+        expect(result.success).toBe(true);
+        const diffEvent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
+          event.type === "activity" && event.kind === "diff"
+        );
+        expect(diffEvent?.message).toContain("A\tnew-file.txt");
+        expect(diffEvent?.message).toContain("+++ b/new-file.txt");
+        expect(diffEvent?.message).toContain("+new content");
+        expect(toolExecutor.execute).toHaveBeenCalledWith(
+          "test-runner",
+          { command: "npx vitest run", timeout: 30_000 },
+          expect.objectContaining({ cwd: workspaceDir })
+        );
+      } finally {
+        fs.rmSync(workspaceDir, { recursive: true, force: true });
+      }
+    });
+
+    it("emits the final diff after verification retry repairs files", async () => {
+      const workspaceDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-retry-diff-"));
+      const events: ChatEvent[] = [];
+      try {
+        execFileSync("git", ["init"], { cwd: workspaceDir, stdio: "ignore" });
+        execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: workspaceDir, stdio: "ignore" });
+        execFileSync("git", ["config", "user.name", "Test User"], { cwd: workspaceDir, stdio: "ignore" });
+        fs.writeFileSync(path.join(workspaceDir, "README.md"), "before\n", "utf-8");
+        execFileSync("git", ["add", "README.md"], { cwd: workspaceDir, stdio: "ignore" });
+        execFileSync("git", ["commit", "-m", "init"], { cwd: workspaceDir, stdio: "ignore" });
+
+        let adapterCalls = 0;
+        const adapter = {
+          adapterType: "mock",
+          execute: vi.fn().mockImplementation(async () => {
+            adapterCalls += 1;
+            fs.writeFileSync(path.join(workspaceDir, "README.md"), adapterCalls === 1 ? "bad\n" : "good\n", "utf-8");
+            return CANNED_RESULT;
+          }),
+        } as unknown as IAdapter;
+        let testRuns = 0;
+        const toolExecutor = {
+          execute: vi.fn().mockImplementation(async (toolName: string) => {
+            if (toolName === "git_diff") {
+              return { success: true, data: "diff --git a/README.md b/README.md", summary: "", durationMs: 0 };
+            }
+            testRuns += 1;
+            return {
+              success: true,
+              data: {
+                passed: testRuns === 1 ? 0 : 1,
+                failed: testRuns === 1 ? 1 : 0,
+                skipped: 0,
+                total: 1,
+                success: testRuns !== 1,
+                rawOutput: testRuns === 1 ? "FAIL README" : "PASS README",
+              },
+              summary: "",
+              durationMs: 0,
+            };
+          }),
+        } as unknown as NonNullable<ChatRunnerDeps["toolExecutor"]>;
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          toolExecutor,
+          onEvent: (event) => { events.push(event); },
+        }));
+
+        const result = await runner.execute("Fix README", workspaceDir);
+
+        expect(result.success).toBe(true);
+        expect(adapter.execute).toHaveBeenCalledTimes(2);
+        const diffEvents = events.filter((event): event is Extract<ChatEvent, { type: "activity" }> =>
+          event.type === "activity" && event.kind === "diff"
+        );
+        expect(diffEvents).toHaveLength(1);
+        expect(diffEvents[0]?.message).toContain("+good");
+        expect(diffEvents[0]?.message).not.toContain("+bad");
       } finally {
         fs.rmSync(workspaceDir, { recursive: true, force: true });
       }

--- a/src/interface/chat/__tests__/chat-verifier.test.ts
+++ b/src/interface/chat/__tests__/chat-verifier.test.ts
@@ -89,6 +89,17 @@ describe("verifyChatAction", () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  it("runs tests when verification is forced even if tracked diff is empty", async () => {
+    const execute = vi.fn()
+      .mockResolvedValueOnce({ success: true, data: "", summary: "", durationMs: 0 })
+      .mockResolvedValueOnce({ success: true, data: passedTestOutput(), summary: "", durationMs: 0 });
+    const executor = { execute } as unknown as ToolExecutor;
+    const result = await verifyChatAction("/fake/cwd", executor, { force: true });
+    expect(result.passed).toBe(true);
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute.mock.calls[1]?.[0]).toBe("test-runner");
+  });
+
   it("returns passed=true when git diff throws (graceful degradation)", async () => {
     const execute = vi.fn().mockRejectedValueOnce(new Error("git: command not found"));
     const executor = { execute } as unknown as ToolExecutor;

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -21,7 +21,7 @@ export interface AssistantFinalEvent extends ChatEventBase {
   persisted: boolean;
 }
 
-export type ActivityKind = "lifecycle" | "commentary" | "checkpoint" | "tool" | "plugin" | "skill";
+export type ActivityKind = "lifecycle" | "commentary" | "checkpoint" | "diff" | "tool" | "plugin" | "skill";
 
 export interface ActivityEvent extends ChatEventBase {
   type: "activity";

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -173,6 +173,7 @@ const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
 const MAX_TOOL_LOOPS = 5;
 const ACTIVITY_PREVIEW_CHARS = 40;
+const DIFF_ARTIFACT_MAX_LINES = 80;
 const standaloneIngressRouter = createIngressRouter();
 
 // ─── Command help text ───
@@ -221,6 +222,92 @@ function checkGitChanges(cwd: string): Promise<string | null> {
       resolve(err ? null : (stdout + stderr).trim());
     });
   });
+}
+
+function runGit(cwd: string, args: string[], timeout = 5_000): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("git", args, { cwd, timeout }, (err, stdout, stderr) => {
+      if (err) {
+        resolve(null);
+        return;
+      }
+      resolve((stdout + stderr).trim());
+    });
+  });
+}
+
+interface GitDiffArtifact {
+  stat: string;
+  nameStatus: string;
+  patch: string;
+  truncated: boolean;
+}
+
+function parseGitLines(output: string | null): string[] {
+  return output ? output.split("\n").map((line) => line.trim()).filter(Boolean) : [];
+}
+
+async function buildUntrackedFilePatch(cwd: string, relativePath: string): Promise<string> {
+  const absolutePath = path.resolve(cwd, relativePath);
+  const relativeFromCwd = path.relative(cwd, absolutePath);
+  if (relativeFromCwd.startsWith("..") || path.isAbsolute(relativeFromCwd)) {
+    return `diff --git a/${relativePath} b/${relativePath}\nnew file skipped: path outside workspace`;
+  }
+  try {
+    const stat = await fsp.stat(absolutePath);
+    if (!stat.isFile()) {
+      return `diff --git a/${relativePath} b/${relativePath}\nnew file skipped: not a regular file`;
+    }
+    if (stat.size > 100_000) {
+      return `diff --git a/${relativePath} b/${relativePath}\nnew file skipped: ${stat.size} bytes`;
+    }
+    const content = await fsp.readFile(absolutePath, "utf-8");
+    const lines = content.split("\n");
+    const body = lines.map((line) => `+${line}`).join("\n");
+    return [
+      `diff --git a/${relativePath} b/${relativePath}`,
+      "new file mode 100644",
+      "--- /dev/null",
+      `+++ b/${relativePath}`,
+      `@@ -0,0 +1,${lines.length} @@`,
+      body,
+    ].join("\n");
+  } catch {
+    return `diff --git a/${relativePath} b/${relativePath}\nnew file skipped: unreadable`;
+  }
+}
+
+async function collectGitDiffArtifact(cwd: string): Promise<GitDiffArtifact | null> {
+  const trackedStat = await runGit(cwd, ["diff", "HEAD", "--stat"]);
+  const untrackedFiles = parseGitLines(await runGit(cwd, ["ls-files", "--others", "--exclude-standard"]));
+  if (!trackedStat && untrackedFiles.length === 0) return null;
+  const trackedNameStatus = await runGit(cwd, ["diff", "HEAD", "--name-status"]) ?? "";
+  const trackedPatch = await runGit(cwd, ["diff", "HEAD", "--patch", "--unified=3"], 10_000) ?? "";
+  const untrackedPatchParts = await Promise.all(
+    untrackedFiles.slice(0, 10).map((file) => buildUntrackedFilePatch(cwd, file))
+  );
+  if (untrackedFiles.length > 10) {
+    untrackedPatchParts.push(`... ${untrackedFiles.length - 10} additional untracked file(s) omitted`);
+  }
+  const stat = [
+    trackedStat,
+    untrackedFiles.length > 0
+      ? ["Untracked files:", ...untrackedFiles.map((file) => `  ${file}`)].join("\n")
+      : "",
+  ].filter(Boolean).join("\n");
+  const nameStatus = [
+    trackedNameStatus,
+    ...untrackedFiles.map((file) => `A\t${file}`),
+  ].filter(Boolean).join("\n");
+  const patch = [trackedPatch, ...untrackedPatchParts].filter(Boolean).join("\n");
+  const patchLines = patch.split("\n");
+  const truncated = patchLines.length > DIFF_ARTIFACT_MAX_LINES;
+  return {
+    stat,
+    nameStatus,
+    patch: patchLines.slice(0, DIFF_ARTIFACT_MAX_LINES).join("\n"),
+    truncated,
+  };
 }
 
 function previewActivityText(value: string, maxChars = ACTIVITY_PREVIEW_CHARS): string {
@@ -1796,6 +1883,10 @@ export class ChatRunner {
         if (this.hasUsage(turnUsage)) {
           history.recordUsage("execution", turnUsage);
         }
+        const diffArtifact = await collectGitDiffArtifact(gitRoot);
+        if (diffArtifact) {
+          this.emitDiffArtifact(diffArtifact, eventContext);
+        }
         await history.appendAssistantMessage(output);
         this.emitCheckpoint("Response ready", "The direct answer has been persisted for this turn.", eventContext, "complete");
         this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
@@ -1962,6 +2053,10 @@ export class ChatRunner {
           this.pushAssistantDelta(result.output, assistantBuffer, eventContext);
         }
         if (result.success) {
+          const diffArtifact = await collectGitDiffArtifact(gitRoot);
+          if (diffArtifact) {
+            this.emitDiffArtifact(diffArtifact, eventContext);
+          }
           await history.appendAssistantMessage(result.output);
           this.emitCheckpoint("Response ready", "The agent-loop response has been persisted for this turn.", eventContext, "complete");
           this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
@@ -2009,6 +2104,10 @@ export class ChatRunner {
         const elapsed_ms = Date.now() - start;
         if (this.hasUsage(toolResult.usage)) {
           history.recordUsage("execution", toolResult.usage);
+        }
+        const diffArtifact = await collectGitDiffArtifact(gitRoot);
+        if (diffArtifact) {
+          this.emitDiffArtifact(diffArtifact, eventContext);
         }
         await history.appendAssistantMessage(toolResult.output);
         this.emitCheckpoint("Response ready", "The tool-loop response has been persisted for this turn.", eventContext, "complete");
@@ -2072,14 +2171,14 @@ export class ChatRunner {
     }
 
     // Verification loop: check if git has uncommitted changes; if so, run tests
-    const gitChanges = await checkGitChanges(gitRoot);
-    if (gitChanges !== null && gitChanges !== "") {
+    const diffArtifact = await collectGitDiffArtifact(gitRoot);
+    if (diffArtifact) {
       let retries = 0;
       const VERIFY_TIMEOUT_MS = 30_000;
       this.emitCheckpoint("Changes detected", "Verification is starting because the turn changed the working tree.", eventContext, "changes");
       this.emitActivity("lifecycle", "Checking result...", eventContext, "lifecycle:checking");
       let verification = await Promise.race([
-        verifyChatAction(gitRoot, this.deps.toolExecutor),
+        verifyChatAction(gitRoot, this.deps.toolExecutor, { force: true }),
         new Promise<{ passed: true }>((resolve) =>
           setTimeout(() => resolve({ passed: true }), VERIFY_TIMEOUT_MS)
         ),
@@ -2091,10 +2190,14 @@ export class ChatRunner {
         const retryPrompt = `The previous changes caused test failures. Please fix them.\n\nTest output:\n${verification.testOutput ?? verification.errors.join("\n")}`;
         const retryTask: AgentTask = { ...task, prompt: retryPrompt };
         result = await this.deps.adapter.execute(retryTask);
-        verification = await verifyChatAction(gitRoot, this.deps.toolExecutor);
+        verification = await verifyChatAction(gitRoot, this.deps.toolExecutor, { force: true });
       }
 
       if (!verification.passed) {
+        const finalDiffArtifact = await collectGitDiffArtifact(gitRoot);
+        if (finalDiffArtifact) {
+          this.emitDiffArtifact(finalDiffArtifact, eventContext);
+        }
         this.emitCheckpoint("Verification failed", `Checks are still failing after ${MAX_VERIFY_RETRIES} retries.`, eventContext, "verification");
         this.emitLifecycleErrorEvent(
           `Changes applied but tests are still failing after ${MAX_VERIFY_RETRIES} retries.`,
@@ -2107,6 +2210,10 @@ export class ChatRunner {
           output: `${assistantBuffer.text}\n\n[interrupted: tests are still failing after ${MAX_VERIFY_RETRIES} retries]\n\nTest output:\n${verification.testOutput ?? verification.errors.join("\n")}`.trim(),
           elapsed_ms: Date.now() - start,
         };
+      }
+      const finalDiffArtifact = await collectGitDiffArtifact(gitRoot);
+      if (finalDiffArtifact) {
+        this.emitDiffArtifact(finalDiffArtifact, eventContext);
       }
       this.emitCheckpoint("Verification passed", "Changed files passed the configured chat verification.", eventContext, "verification");
     }
@@ -2754,6 +2861,30 @@ export class ChatRunner {
       ? `Checkpoint\n- ${title}: ${detail}`
       : `Checkpoint\n- ${title}`;
     this.emitActivity("checkpoint", message, eventContext, `checkpoint:${sourceKey}`, false);
+  }
+
+  private emitDiffArtifact(
+    artifact: GitDiffArtifact,
+    eventContext: ChatEventContext
+  ): void {
+    const sections = [
+      "Changed files",
+      "",
+      "Modified files",
+      artifact.nameStatus || artifact.stat,
+      "",
+      "Diff summary",
+      artifact.stat,
+      "",
+      "Inline patch",
+      "```diff",
+      artifact.patch || "(patch unavailable)",
+      artifact.truncated ? `... truncated after ${DIFF_ARTIFACT_MAX_LINES} lines; run /review for the full diff.` : "",
+      "```",
+      "",
+      "Files inspected are shown separately in the activity log.",
+    ].filter((line) => line !== "").join("\n");
+    this.emitActivity("diff", sections, eventContext, "diff:working-tree", false);
   }
 
   private pushAssistantDelta(

--- a/src/interface/chat/chat-verifier.ts
+++ b/src/interface/chat/chat-verifier.ts
@@ -28,6 +28,7 @@ function makeContext(cwd: string): ToolCallContext {
 export async function verifyChatAction(
   cwd: string,
   toolExecutor?: ToolExecutor,
+  options: { force?: boolean } = {},
 ): Promise<ChatVerificationResult> {
   if (!toolExecutor) return { passed: true, errors: [] };
 
@@ -41,7 +42,7 @@ export async function verifyChatAction(
   ).catch(() => null);
 
   if (!diffResult || !diffResult.success) return { passed: true, errors: [] };
-  if (!diffResult.data || (diffResult.data as string).trim() === "") {
+  if (!options.force && (!diffResult.data || (diffResult.data as string).trim() === "")) {
     return { passed: true, errors: [] };
   }
 


### PR DESCRIPTION
## Summary
- emit a stable diff activity after mutation turns so changed files are visible in the same chat turn
- include tracked and untracked files, changed-file summary, and an inline patch excerpt
- verify untracked-only mutation turns by forcing chat verification when the diff artifact detects changes
- emit final post-retry diffs from the final working tree

Closes #752

## Verification
- npm test -- --run src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-verifier.test.ts
- npm run test:changed
- npm run typecheck
- independent review agent: fixed P1 findings, then no material issues