### PR TITLE
Add failure recovery guidance

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { applyChatEventToMessages } from "../chat-event-state.js";
+import { classifyFailureRecovery } from "../failure-recovery.js";
 
 describe("applyChatEventToMessages", () => {
   it("keeps activity as one updatable row per turn", () => {
@@ -99,11 +100,14 @@ describe("applyChatEventToMessages", () => {
       error: "boom",
       partialText: "Partial",
       persisted: false,
+      recovery: classifyFailureRecovery("boom"),
     }, 20);
 
     expect(afterError).toHaveLength(1);
     expect(afterError[0]!.id).toBe("turn-1");
     expect(afterError[0]!.messageType).toBe("error");
+    expect(afterError[0]!.text).toContain("Recovery");
+    expect(afterError[0]!.text).toContain("Next actions");
   });
 
   it("removes transient activity on lifecycle end", () => {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -428,7 +428,9 @@ describe("ChatRunner", () => {
       const result = await runner.execute("Do something risky", "/repo");
 
       expect(result.success).toBe(false);
-      expect(result.output).toBe("Agent failed");
+      expect(result.output).toContain("Agent failed");
+      expect(result.output).toContain("Recovery");
+      expect(result.output).toContain("Next actions");
     });
   });
 
@@ -745,6 +747,20 @@ describe("ChatRunner", () => {
       expect(adapter.execute).not.toHaveBeenCalled();
     });
 
+    it("/retry explains safe recovery options without replaying the prior turn", async () => {
+      const adapter = makeMockAdapter();
+      const runner = new ChatRunner(makeDeps({ adapter }));
+
+      const result = await runner.execute("/retry", "/repo");
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("/retry is not supported yet");
+      expect(result.output).toContain("Retry unavailable");
+      expect(result.output).toContain("/review");
+      expect(result.output).toContain("/resume");
+      expect(adapter.execute).not.toHaveBeenCalled();
+    });
+
     it("unknown /command returns error message without calling adapter", async () => {
       const adapter = makeMockAdapter();
       const runner = new ChatRunner(makeDeps({ adapter }));
@@ -823,6 +839,25 @@ describe("ChatRunner", () => {
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
       expect(writeRawMock).toHaveBeenCalledTimes(1);
       expect((stateManager.readRaw as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("/resume without saved state returns recovery guidance", async () => {
+      const stateManager = makeMockStateManager();
+      (stateManager.readRaw as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+      const chatAgentLoopRunner = {
+        execute: vi.fn(),
+      } as unknown as ChatAgentLoopRunner;
+      const runner = new ChatRunner(makeDeps({ stateManager, chatAgentLoopRunner }));
+
+      runner.startSession("/repo");
+      const result = await runner.execute("/resume", "/repo");
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("No resumable native agentloop state found");
+      expect(result.output).toContain("Type: Resume failure");
+      expect(result.output).toContain("/sessions");
+      expect(result.output).toContain("/resume <id|title>");
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     });
 
     it("/resume <selector> loads the selected session before resuming native agentloop state", async () => {
@@ -1792,6 +1827,8 @@ describe("ChatRunner", () => {
       const result = await runner.execute("Break the stream", "/repo");
 
       expect(result.success).toBe(false);
+      expect(result.output).toContain("Recovery");
+      expect(result.output).toContain("Type: Runtime interruption");
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
       expect(writeRawMock).toHaveBeenCalledTimes(1);
       const onlyWrite = writeRawMock.mock.calls[0][1] as { messages: Array<{ role: string; content: string }> };

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -151,6 +151,32 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(events.at(-1)?.type).toBe("lifecycle_end");
   });
 
+  it("returns recovery guidance for gateway-visible failures", async () => {
+    const adapter = makeMockAdapter({
+      ...CANNED_RESULT,
+      success: false,
+      output: "Agent failed",
+      error: "boom",
+      exit_code: 1,
+    });
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager: makeMockStateManager(),
+      adapter,
+    }));
+
+    const result = await manager.processIncomingMessage({
+      text: "do risky work",
+      platform: "slack",
+      conversation_id: "C_GENERAL",
+      sender_id: "U123",
+      cwd: "/repo",
+    });
+
+    expect(result).toContain("Agent failed");
+    expect(result).toContain("Recovery");
+    expect(result).toContain("Next actions");
+  });
+
   it("routes natural-language restart with the current platform reply target", async () => {
     const stateManager = makeMockStateManager();
     const adapter = makeMockAdapter();

--- a/src/interface/chat/__tests__/failure-recovery.test.ts
+++ b/src/interface/chat/__tests__/failure-recovery.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { classifyFailureRecovery, formatLifecycleFailureMessage } from "../failure-recovery.js";
+
+describe("failure recovery guidance", () => {
+  it("classifies verification failures with review guidance", () => {
+    const guidance = classifyFailureRecovery("Changes applied but tests are still failing after 2 retries.");
+
+    expect(guidance.kind).toBe("verification");
+    expect(guidance.label).toBe("Verification failure");
+    expect(guidance.nextActions.join("\n")).toContain("/review");
+  });
+
+  it("classifies missing resumable state with session guidance", () => {
+    const guidance = classifyFailureRecovery("No resumable native agentloop state found.");
+
+    expect(guidance.kind).toBe("resume");
+    expect(guidance.nextActions.join("\n")).toContain("/sessions");
+    expect(guidance.nextActions.join("\n")).toContain("/resume <id|title>");
+  });
+
+  it("formats lifecycle errors without hiding the original interruption", () => {
+    const text = formatLifecycleFailureMessage("stream aborted", "Partial answer");
+
+    expect(text).toContain("Partial answer");
+    expect(text).toContain("[interrupted: stream aborted]");
+    expect(text).toContain("Type: Runtime interruption");
+    expect(text).toContain("Next actions:");
+  });
+});

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -1,4 +1,5 @@
 import type { ChatEvent } from "./chat-events.js";
+import { formatLifecycleFailureMessage } from "./failure-recovery.js";
 
 type ToolActivityState = "reading" | "planning" | "editing" | "verifying" | "waiting" | "running" | "completed" | "failed";
 
@@ -272,9 +273,7 @@ export function applyChatEventToMessages(
   if (event.type === "lifecycle_error") {
     const next = closeToolActivityForTurn(removeTransientActivityForTurn(messages, event.turnId), event.turnId);
     const messageId = event.partialText ? event.turnId : `error:${event.runId}`;
-    const text = event.partialText
-      ? `${event.partialText}\n\n[interrupted: ${event.error}]`
-      : `Error: ${event.error}`;
+    const text = formatLifecycleFailureMessage(event.error, event.partialText, event.recovery);
     return upsertMessage(next, {
       id: messageId,
       role: "pulseed",

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -1,3 +1,5 @@
+import type { FailureRecoveryGuidance } from "./failure-recovery.js";
+
 export interface ChatEventBase {
   runId: string;
   turnId: string;
@@ -67,6 +69,7 @@ export interface LifecycleErrorEvent extends ChatEventBase {
   error: string;
   partialText: string;
   persisted: false;
+  recovery: FailureRecoveryGuidance;
 }
 
 export type ChatEvent =

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -48,6 +48,7 @@ import {
   buildPromptedToolProtocolSystemPrompt,
   extractPromptedToolCalls,
 } from "../../orchestrator/execution/agent-loop/prompted-tool-protocol.js";
+import { classifyFailureRecovery, formatFailureRecovery, formatLifecycleFailureMessage } from "./failure-recovery.js";
 import type { RuntimeControlService } from "../../runtime/control/index.js";
 import type {
   RuntimeControlActor,
@@ -1317,6 +1318,26 @@ export class ChatRunner {
     if (cmd === "/undo") {
       return this.handleUndo(start);
     }
+    if (cmd === "/retry") {
+      return {
+        success: false,
+        output: [
+          "/retry is not supported yet.",
+          "",
+          formatFailureRecovery({
+            kind: "runtime_interruption",
+            label: "Retry unavailable",
+            summary: "PulSeed does not yet have a safe replay contract for the previous turn.",
+            nextActions: [
+              "Use /review to inspect any current diff before continuing.",
+              "Use /resume when PulSeed reports resumable agent-loop state.",
+              "Ask for the exact next step to rerun instead of replaying the full turn.",
+            ],
+          }),
+        ].join("\n"),
+        elapsed_ms: Date.now() - start,
+      };
+    }
     if (cmd === "/exit") {
       return { success: true, output: "Exiting chat mode.", elapsed_ms: Date.now() - start };
     }
@@ -1857,7 +1878,7 @@ export class ChatRunner {
         });
         this.emitLifecycleEndEvent("completed", runtimeControlResult.elapsed_ms, eventContext, true);
       } else {
-        this.emitLifecycleErrorEvent(runtimeControlResult.output, assistantBuffer.text, eventContext);
+        runtimeControlResult.output = this.emitLifecycleErrorEvent(runtimeControlResult.output, assistantBuffer.text, eventContext);
         this.emitLifecycleEndEvent("error", runtimeControlResult.elapsed_ms, eventContext, false);
       }
       return runtimeControlResult;
@@ -1910,13 +1931,11 @@ export class ChatRunner {
         };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        this.emitLifecycleErrorEvent(message, assistantBuffer.text, eventContext);
+        const output = this.emitLifecycleErrorEvent(message, assistantBuffer.text, eventContext);
         this.emitLifecycleEndEvent("error", Date.now() - start, eventContext, false);
         return {
           success: false,
-          output: assistantBuffer.text
-            ? `${assistantBuffer.text}\n\n[interrupted: ${message}]`
-            : `Error: ${message}`,
+          output,
           elapsed_ms: Date.now() - start,
           diagnostics: {
             route: "direct",
@@ -1980,13 +1999,11 @@ export class ChatRunner {
 
     if (resumeOnly && !this.deps.chatAgentLoopRunner) {
       const elapsed_ms = Date.now() - start;
-      const output = "Resume requires the native chat agentloop runtime.";
-      this.emitEvent({
-        type: "assistant_final",
-        text: output,
-        persisted: false,
-        ...this.eventBase(eventContext),
-      });
+      const output = this.emitLifecycleErrorEvent(
+        "Resume requires the native chat agentloop runtime.",
+        assistantBuffer.text,
+        eventContext
+      );
       this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
       return {
         success: false,
@@ -2001,13 +2018,11 @@ export class ChatRunner {
         const resumeState = resumeOnly ? await this.loadResumableAgentLoopState() : null;
         if (resumeOnly && !resumeState) {
           const elapsed_ms = Date.now() - start;
-          const output = "No resumable native agentloop state found.";
-          this.emitEvent({
-            type: "assistant_final",
-            text: output,
-            persisted: false,
-            ...this.eventBase(eventContext),
-          });
+          const output = this.emitLifecycleErrorEvent(
+            "No resumable native agentloop state found.",
+            assistantBuffer.text,
+            eventContext
+          );
           this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
           return {
             success: false,
@@ -2068,7 +2083,7 @@ export class ChatRunner {
           });
           this.emitLifecycleEndEvent("completed", elapsed_ms, eventContext, true);
         } else {
-          this.emitLifecycleErrorEvent(result.output || result.error || "Unknown error", assistantBuffer.text, eventContext);
+          result.output = this.emitLifecycleErrorEvent(result.output || result.error || "Unknown error", assistantBuffer.text, eventContext);
           this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
         }
         return {
@@ -2078,13 +2093,11 @@ export class ChatRunner {
         };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        this.emitLifecycleErrorEvent(message, assistantBuffer.text, eventContext);
+        const output = this.emitLifecycleErrorEvent(message, assistantBuffer.text, eventContext);
         this.emitLifecycleEndEvent("error", Date.now() - start, eventContext, false);
         return {
           success: false,
-          output: assistantBuffer.text
-            ? `${assistantBuffer.text}\n\n[interrupted: ${message}]`
-            : `Error: ${message}`,
+          output,
           elapsed_ms: Date.now() - start,
         };
       }
@@ -2122,13 +2135,11 @@ export class ChatRunner {
         return { success: true, output: toolResult.output, elapsed_ms };
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        this.emitLifecycleErrorEvent(message, assistantBuffer.text, eventContext);
+        const output = this.emitLifecycleErrorEvent(message, assistantBuffer.text, eventContext);
         this.emitLifecycleEndEvent("error", Date.now() - start, eventContext, false);
         return {
           success: false,
-          output: assistantBuffer.text
-            ? `${assistantBuffer.text}\n\n[interrupted: ${message}]`
-            : `Error: ${message}`,
+          output,
           elapsed_ms: Date.now() - start,
         };
       }
@@ -2136,8 +2147,7 @@ export class ChatRunner {
 
     if (!resumeOnly && selectedRoute && selectedRoute.kind !== "adapter") {
       const elapsed_ms = Date.now() - start;
-      const output = `Unsupported chat route: ${selectedRoute.kind}`;
-      this.emitLifecycleErrorEvent(output, assistantBuffer.text, eventContext);
+      const output = this.emitLifecycleErrorEvent(`Unsupported chat route: ${selectedRoute.kind}`, assistantBuffer.text, eventContext);
       this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
       return {
         success: false,
@@ -2199,7 +2209,7 @@ export class ChatRunner {
           this.emitDiffArtifact(finalDiffArtifact, eventContext);
         }
         this.emitCheckpoint("Verification failed", `Checks are still failing after ${MAX_VERIFY_RETRIES} retries.`, eventContext, "verification");
-        this.emitLifecycleErrorEvent(
+        const failureOutput = this.emitLifecycleErrorEvent(
           `Changes applied but tests are still failing after ${MAX_VERIFY_RETRIES} retries.`,
           assistantBuffer.text,
           eventContext
@@ -2207,7 +2217,7 @@ export class ChatRunner {
         this.emitLifecycleEndEvent("error", Date.now() - start, eventContext, false);
         return {
           success: false,
-          output: `${assistantBuffer.text}\n\n[interrupted: tests are still failing after ${MAX_VERIFY_RETRIES} retries]\n\nTest output:\n${verification.testOutput ?? verification.errors.join("\n")}`.trim(),
+          output: `${failureOutput}\n\nTest output:\n${verification.testOutput ?? verification.errors.join("\n")}`.trim(),
           elapsed_ms: Date.now() - start,
         };
       }
@@ -2231,7 +2241,7 @@ export class ChatRunner {
       this.emitLifecycleEndEvent("completed", elapsed_ms, eventContext, true);
     } else {
       const partialText = assistantBuffer.text !== result.output ? assistantBuffer.text : "";
-      this.emitLifecycleErrorEvent(result.output || result.error || "Unknown error", partialText, eventContext);
+      result.output = this.emitLifecycleErrorEvent(result.output || result.error || "Unknown error", partialText, eventContext);
       this.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
     }
 
@@ -2921,14 +2931,17 @@ export class ChatRunner {
     error: string,
     partialText: string,
     eventContext: ChatEventContext
-  ): void {
+  ): string {
+    const recovery = classifyFailureRecovery(error);
     this.emitEvent({
       type: "lifecycle_error",
       error,
       partialText,
       persisted: false,
+      recovery,
       ...this.eventBase(eventContext),
     });
+    return formatLifecycleFailureMessage(error, partialText, recovery);
   }
 
   /** Build a ToolCallContext from ChatRunnerDeps for tool dispatch. */

--- a/src/interface/chat/failure-recovery.ts
+++ b/src/interface/chat/failure-recovery.ts
@@ -1,0 +1,137 @@
+export type FailureRecoveryKind =
+  | "permission"
+  | "tool_input"
+  | "verification"
+  | "runtime_interruption"
+  | "daemon_loop"
+  | "resume"
+  | "adapter"
+  | "unknown";
+
+export interface FailureRecoveryGuidance {
+  kind: FailureRecoveryKind;
+  label: string;
+  summary: string;
+  nextActions: string[];
+}
+
+export function classifyFailureRecovery(error: string): FailureRecoveryGuidance {
+  const normalized = error.toLowerCase();
+  if (/\b(permission|approval|approved|denied|sandbox|eacces|eperm|unauthorized|forbidden)\b/.test(normalized)) {
+    return {
+      kind: "permission",
+      label: "Permission failure",
+      summary: "The turn stopped because the requested action was blocked by permissions or approval policy.",
+      nextActions: [
+        "Inspect the requested action before retrying.",
+        "Use /permissions to review the current execution policy.",
+        "Re-run with a narrower request or explicit approval if the action is expected.",
+      ],
+    };
+  }
+  if (/\b(verification|checks?|tests?|vitest|typecheck|lint)\b.*\b(fail|failing|failed|error)\b|\b(fail|failing|failed)\b.*\b(verification|checks?|tests?|vitest|typecheck|lint)\b/.test(normalized)) {
+    return {
+      kind: "verification",
+      label: "Verification failure",
+      summary: "Changes were made, but the configured checks did not pass.",
+      nextActions: [
+        "Run /review to inspect the current diff and verification context.",
+        "Inspect the test output shown with this failure.",
+        "Ask for a focused fix for the failing check before continuing.",
+      ],
+    };
+  }
+  if (/\b(resume|resumable|session state|agentloop state)\b/.test(normalized)) {
+    return {
+      kind: "resume",
+      label: "Resume failure",
+      summary: "PulSeed could not find or load the session state needed to continue this turn.",
+      nextActions: [
+        "Run /sessions to find the intended chat session.",
+        "Run /resume <id|title> when the target session is available.",
+        "Start a new turn with the missing context if no resumable state exists.",
+      ],
+    };
+  }
+  if (/\b(daemon|core loop|goal stalled|loop ended|runtime control|background)\b/.test(normalized)) {
+    return {
+      kind: "daemon_loop",
+      label: "Daemon loop failure",
+      summary: "A background loop or runtime-control path stopped before completing successfully.",
+      nextActions: [
+        "Run /status to inspect the active goal or daemon state.",
+        "Use /resume when the session has resumable state.",
+        "Check the daemon logs if the failure references runtime internals.",
+      ],
+    };
+  }
+  if (/\b(timed out|timeout|aborted|interrupted|cancelled|canceled|signal|disconnect|stream)\b/.test(normalized)) {
+    return {
+      kind: "runtime_interruption",
+      label: "Runtime interruption",
+      summary: "The active turn was interrupted before it could produce a complete final response.",
+      nextActions: [
+        "Use /resume if PulSeed reports resumable agent-loop state.",
+        "Ask for a narrower continuation from the last visible step.",
+        "Run /review first if files may have changed before the interruption.",
+      ],
+    };
+  }
+  if (/\b(schema|invalid|parse|missing|required|argument|input)\b/.test(normalized)) {
+    return {
+      kind: "tool_input",
+      label: "Tool input failure",
+      summary: "A tool or command received input it could not validate.",
+      nextActions: [
+        "Retry with the exact file, command, or option you want PulSeed to use.",
+        "Ask PulSeed to inspect the target before attempting the tool again.",
+        "Use /review if the failure happened after a file change.",
+      ],
+    };
+  }
+  if (/\b(adapter|model|provider|api|rate limit|llm)\b/.test(normalized)) {
+    return {
+      kind: "adapter",
+      label: "Adapter failure",
+      summary: "The configured model or adapter path failed before the turn completed.",
+      nextActions: [
+        "Retry the turn after checking provider availability.",
+        "Use /model to confirm the active provider and adapter.",
+        "Narrow the request if the failure happened during a long turn.",
+      ],
+    };
+  }
+  return {
+    kind: "unknown",
+    label: "Unclassified failure",
+    summary: "PulSeed could not classify this failure from the error text alone.",
+    nextActions: [
+      "Run /review if the turn may have changed files.",
+      "Retry with a narrower request that names the intended next step.",
+      "Use /sessions or /status when the failure relates to session or daemon state.",
+    ],
+  };
+}
+
+export function formatFailureRecovery(guidance: FailureRecoveryGuidance): string {
+  return [
+    "Recovery",
+    `Type: ${guidance.label}`,
+    guidance.summary,
+    "Next actions:",
+    ...guidance.nextActions.map((action) => `- ${action}`),
+  ].join("\n");
+}
+
+export function formatLifecycleFailureMessage(
+  error: string,
+  partialText: string,
+  guidance: FailureRecoveryGuidance = classifyFailureRecovery(error)
+): string {
+  const normalizedPartial = partialText.trim();
+  const normalizedError = error.trim();
+  const base = normalizedPartial && normalizedPartial !== normalizedError
+    ? `${partialText}\n\n[interrupted: ${error}]`
+    : normalizedPartial || `Error: ${error}`;
+  return `${base}\n\n${formatFailureRecovery(guidance)}`;
+}

--- a/src/interface/tui/__tests__/app-routing.test.ts
+++ b/src/interface/tui/__tests__/app-routing.test.ts
@@ -31,6 +31,7 @@ describe("TUI app routing helpers", () => {
     expect(isChatRunnerOwnedSlashCommand("/compact")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/tend")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/permissions read-only")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/retry")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/start goal-1")).toBe(false);
   });
 

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -83,6 +83,7 @@ const CHAT_RUNNER_OWNED_COMMANDS = new Set([
   "/compact",
   "/tend",
   "/permissions",
+  "/retry",
 ]);
 
 export function isChatRunnerOwnedSlashCommand(input: string): boolean {

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -5,6 +5,7 @@ import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
 import { formatTelegramNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
 import { writeJsonFileAtomic } from "../../base/utils/json-io.js";
 import type { ChatEvent, ChatEventHandler } from "../../interface/chat/chat-events.js";
+import { formatLifecycleFailureMessage } from "../../interface/chat/failure-recovery.js";
 import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
 import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
 
@@ -345,7 +346,7 @@ class TelegramChatEventAdapter {
         );
         return;
       case "lifecycle_error":
-        await this.sendFinalFallback(event.partialText ? `${event.partialText}\n\n[interrupted: ${event.error}]` : `Error: ${event.error}`);
+        await this.sendFinalFallback(formatLifecycleFailureMessage(event.error, event.partialText, event.recovery));
         return;
       case "lifecycle_end":
         return;


### PR DESCRIPTION
## Summary
- classify lifecycle failures into recovery categories and show compact next actions
- return the same recovery guidance through ChatRunResult output so gateway replies receive it
- keep /retry unsupported while showing safe alternatives, and route it through the TUI ChatRunner path
- add recovery coverage for failed turns, missing resume state, gateway-visible failures, and TUI routing

Closes #754

## Verification
- npm test -- --run src/interface/chat/__tests__/failure-recovery.test.ts src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts
- npm run test:integration -- --run src/interface/tui/__tests__/app-routing.test.ts src/runtime/gateway/__tests__/ingress-runtime-control-contract.test.ts
- npm run typecheck
- git diff --check
- npm run test:changed (unit related passed; related daemon e2e failed locally because existing pulseed daemon is listening on 127.0.0.1:41700)
- independent review agent: initial blockers fixed, then no material blockers