### PR TITLE
Support mid-run interrupt redirects

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -501,6 +501,32 @@ describe("ChatRunner", () => {
       expect(adapter.execute).not.toHaveBeenCalled();
     });
 
+    it("interruptAndRedirect executes normally when no turn is active", async () => {
+      const adapter = makeMockAdapter();
+      const runner = new ChatRunner(makeDeps({ adapter }));
+      runner.startSession("/repo");
+
+      const result = await runner.interruptAndRedirect("next request", "/repo");
+
+      expect(result.success).toBe(true);
+      expect(adapter.execute).toHaveBeenCalledOnce();
+    });
+
+    it("clears the active turn when an adapter turn times out", async () => {
+      const adapter = {
+        adapterType: "mock",
+        execute: vi.fn().mockImplementation(() => new Promise(() => {})),
+      } as unknown as IAdapter;
+      const runner = new ChatRunner(makeDeps({ adapter }));
+      runner.startSession("/repo");
+
+      const result = await runner.execute("Make a small change", "/repo", 1);
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("timed out");
+      expect(runner.hasActiveTurn()).toBe(false);
+    });
+
     it("/usage reports session totals and phase breakdown", async () => {
       const stateManager = makeMockStateManager();
       const llmClient = {
@@ -2117,6 +2143,89 @@ describe("ChatRunner", () => {
       expect(result.success).toBe(true);
       expect(result.output).toBe("Agentloop direct answer");
       expect(result.diagnostics).toBeUndefined();
+    });
+
+    it("interruptAndRedirect aborts an active native agent loop and returns a summary", async () => {
+      let capturedSignal: AbortSignal | undefined;
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockImplementation((input: { abortSignal?: AbortSignal }) => {
+          capturedSignal = input.abortSignal;
+          return new Promise((resolve) => {
+            input.abortSignal?.addEventListener("abort", () => {
+              resolve({
+                success: false,
+                output: "cancelled",
+                error: "cancelled",
+                exit_code: null,
+                elapsed_ms: 10,
+                stopped_reason: "error",
+              });
+            }, { once: true });
+          });
+        }),
+      } as unknown as ChatAgentLoopRunner;
+      const runner = new ChatRunner(makeDeps({
+        stateManager: makeMockStateManager(),
+        chatAgentLoopRunner,
+      }));
+      runner.startSession("/repo");
+
+      const active = runner.execute("Implement a feature", "/repo");
+      await vi.waitFor(() => expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce());
+
+      const interrupted = await runner.interruptAndRedirect("stop and summarize", "/repo");
+
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(interrupted.success).toBe(true);
+      expect(interrupted.output).toContain("Interrupted the active turn");
+      expect(interrupted.output).toContain("Recent activity");
+      await active;
+    });
+
+    it("does not abort the active turn for unsupported background redirect requests", async () => {
+      let capturedSignal: AbortSignal | undefined;
+      let resolveActive: ((value: {
+        success: boolean;
+        output: string;
+        error: null;
+        exit_code: null;
+        elapsed_ms: number;
+        stopped_reason: string;
+      }) => void) | undefined;
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockImplementation((input: { abortSignal?: AbortSignal }) => {
+          capturedSignal = input.abortSignal;
+          return new Promise((resolve) => {
+            resolveActive = resolve;
+          });
+        }),
+      } as unknown as ChatAgentLoopRunner;
+      const runner = new ChatRunner(makeDeps({
+        stateManager: makeMockStateManager(),
+        chatAgentLoopRunner,
+      }));
+      runner.startSession("/repo");
+
+      const active = runner.execute("Implement a feature", "/repo");
+      await vi.waitFor(() => expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce());
+
+      const redirected = await runner.interruptAndRedirect("continue in background", "/repo");
+
+      expect(capturedSignal?.aborted).toBe(false);
+      expect(redirected.success).toBe(true);
+      expect(redirected.output).toContain("background is not available yet");
+      expect(runner.hasActiveTurn()).toBe(true);
+
+      resolveActive?.({
+        success: false,
+        output: "cancelled by test",
+        error: null,
+        exit_code: null,
+        elapsed_ms: 1,
+        stopped_reason: "error",
+      });
+      await active;
+      expect(runner.hasActiveTurn()).toBe(false);
     });
 
     it("grounds native chat agentloop through systemPrompt instead of injecting workspace context into the message", async () => {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -156,6 +156,19 @@ interface AssistantBuffer {
   text: string;
 }
 
+type ChatInterruptRedirectKind = "diff" | "review" | "summary" | "background" | "redirect";
+
+interface ActiveChatTurn {
+  context: ChatEventContext;
+  cwd: string;
+  startedAt: number;
+  abortController: AbortController;
+  finished: Promise<void>;
+  resolveFinished: () => void;
+  recentEvents: string[];
+  interruptRequested: boolean;
+}
+
 interface ResumeCommand {
   selector?: string;
 }
@@ -317,6 +330,23 @@ function previewActivityText(value: string, maxChars = ACTIVITY_PREVIEW_CHARS): 
   return normalized.length > maxChars ? `${normalized.slice(0, maxChars)}...` : normalized;
 }
 
+function classifyInterruptRedirect(input: string): ChatInterruptRedirectKind {
+  const normalized = input.trim().toLowerCase();
+  if (/\b(background|bg)\b|バックグラウンド|裏で|裏側|continue.*background/.test(normalized)) {
+    return "background";
+  }
+  if (/\b(review|read.?only|readonly)\b|レビュー|確認だけ|読むだけ/.test(normalized)) {
+    return "review";
+  }
+  if (/\b(diff|changes?|patch)\b|差分|変更.*見|変更内容/.test(normalized)) {
+    return "diff";
+  }
+  if (/\b(stop|pause|summary|summarize|interrupt)\b|止め|停止|中断|一旦|要約/.test(normalized)) {
+    return "summary";
+  }
+  return "redirect";
+}
+
 function formatToolActivity(action: "Running" | "Finished" | "Failed", toolName: string, detail?: string): string {
   const preview = detail ? previewActivityText(detail) : "";
   return preview ? `${action} tool: ${toolName} - ${preview}` : `${action} tool: ${toolName}`;
@@ -370,6 +400,7 @@ export class ChatRunner {
   private runtimeControlContext: RuntimeControlChatContext | null = null;
   private sessionExecutionPolicy: ExecutionPolicy | null = null;
   private lastSelectedRoute: SelectedChatRoute | null = null;
+  private activeTurn: ActiveChatTurn | null = null;
 
   constructor(deps: ChatRunnerDeps) {
     this.deps = deps;
@@ -411,6 +442,78 @@ export class ChatRunner {
 
   getCurrentSessionMessages(): ChatSession["messages"] {
     return this.history?.getMessages() ?? [];
+  }
+
+  hasActiveTurn(): boolean {
+    return this.activeTurn !== null;
+  }
+
+  async interruptAndRedirect(input: string, cwd: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<ChatRunResult> {
+    const activeTurn = this.activeTurn;
+    if (!activeTurn) {
+      return this.execute(input, cwd, timeoutMs);
+    }
+
+    const start = Date.now();
+    const redirect = classifyInterruptRedirect(input);
+    if (redirect === "background") {
+      return this.emitEphemeralAssistantResult(input, [
+        "Continuing this same turn in the background is not available yet.",
+        "",
+        "The active turn is still running in the foreground.",
+        "Use /tend for daemon-backed work, or send a narrower follow-up request.",
+      ].join("\n"), true, start);
+    }
+
+    activeTurn.interruptRequested = true;
+    if (!activeTurn.abortController.signal.aborted) {
+      activeTurn.abortController.abort();
+    }
+    this.emitCheckpoint("Interrupt requested", `Redirect: ${previewActivityText(input, 120)}`, activeTurn.context, "interrupt");
+
+    const stopped = await this.waitForActiveTurn(activeTurn, 2_000);
+    if (!stopped) {
+      return this.emitEphemeralAssistantResult(
+        input,
+        "Interrupt requested. The active turn will stop at the next safe point.",
+        false,
+        start
+      );
+    }
+
+    if (redirect === "redirect") {
+      return this.execute(input, cwd, timeoutMs);
+    }
+
+    let output: string;
+    if (redirect === "diff") {
+      const diff = await collectGitDiffArtifact(activeTurn.cwd);
+      if (diff) {
+        const context = this.createEventContext();
+        this.emitDiffArtifact(diff, context);
+        output = "Interrupted the active turn. Current diff is shown above.";
+      } else {
+        output = "Interrupted the active turn. No working-tree changes were detected.";
+      }
+    } else if (redirect === "review") {
+      const review = await this.handleReview(start);
+      output = `Interrupted the active turn and switched to review-only mode.\n\n${review.output}`;
+    } else {
+      output = [
+        "Interrupted the active turn.",
+        "",
+        "Recent activity",
+        ...(activeTurn.recentEvents.length > 0
+          ? activeTurn.recentEvents.slice(-6).map((event) => `- ${event}`)
+          : ["- No activity was captured before the interrupt."]),
+        "",
+        "Next actions",
+        "- Ask for the exact continuation you want.",
+        "- Ask to show diff or switch to review if files may have changed.",
+      ].join("\n");
+    }
+
+    return this.emitEphemeralAssistantResult(input, output, true, start);
   }
 
   setRuntimeControlContext(context: RuntimeControlChatContext | null): void {
@@ -1766,6 +1869,7 @@ export class ChatRunner {
     options: ChatRunnerExecutionOptions = {}
   ): Promise<ChatRunResult> {
     const eventContext = this.createEventContext();
+    const activeTurn = this.beginActiveTurn(eventContext, resolveGitRoot(cwd));
     const resumeCommand = this.parseResumeCommand(input);
     const resumeOnly = resumeCommand !== null;
     const runtimeControlContext = options.runtimeControlContext ?? this.runtimeControlContext;
@@ -1860,6 +1964,7 @@ export class ChatRunner {
     }
     const executionCwd = this.sessionCwd ?? cwd;
     const gitRoot = this.sessionCwd ?? resolveGitRoot(cwd);
+    activeTurn.cwd = gitRoot;
 
     // history is always assigned by this point (either by startSession or the block above)
     const history = this.history!;
@@ -2135,6 +2240,7 @@ export class ChatRunner {
           ...(resumeState ? { resumeState } : {}),
           ...(resumeOnly ? { resumeOnly: true } : {}),
           ...(agentLoopSystemPrompt ? { systemPrompt: agentLoopSystemPrompt } : {}),
+          abortSignal: activeTurn.abortController.signal,
         });
         const elapsed_ms = Date.now() - start;
         const agentLoopUsage = result.agentLoop?.usage
@@ -2249,7 +2355,20 @@ export class ChatRunner {
     const timeoutPromise = new Promise<never>((_, reject) =>
       setTimeout(() => reject(new Error(`Chat adapter timed out after ${resolvedTimeoutMs}ms`)), resolvedTimeoutMs)
     );
-    let result = await Promise.race([adapterPromise, timeoutPromise]);
+    let result: Awaited<ReturnType<IAdapter["execute"]>>;
+    try {
+      result = await Promise.race([adapterPromise, timeoutPromise]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const output = this.emitLifecycleErrorEvent(message, assistantBuffer.text, eventContext);
+      const timeoutElapsedMs = Date.now() - start;
+      this.emitLifecycleEndEvent("error", timeoutElapsedMs, eventContext, false);
+      return {
+        success: false,
+        output,
+        elapsed_ms: timeoutElapsedMs,
+      };
+    }
     // Surface adapter errors into output when output is empty
     if (!result.output && result.error) {
       result = { ...result, output: `Error: ${result.error}` };
@@ -2884,7 +3003,76 @@ export class ChatRunner {
     return { ...context, createdAt: new Date().toISOString() };
   }
 
+  private beginActiveTurn(context: ChatEventContext, cwd: string): ActiveChatTurn {
+    let resolveFinished: () => void = () => {};
+    const finished = new Promise<void>((resolve) => {
+      resolveFinished = resolve;
+    });
+    const turn: ActiveChatTurn = {
+      context,
+      cwd,
+      startedAt: Date.now(),
+      abortController: new AbortController(),
+      finished,
+      resolveFinished,
+      recentEvents: [],
+      interruptRequested: false,
+    };
+    this.activeTurn = turn;
+    return turn;
+  }
+
+  private finishActiveTurn(context: ChatEventContext): void {
+    const activeTurn = this.activeTurn;
+    if (!activeTurn || activeTurn.context.runId !== context.runId) return;
+    activeTurn.resolveFinished();
+    this.activeTurn = null;
+  }
+
+  private waitForActiveTurn(turn: ActiveChatTurn, timeoutMs: number): Promise<boolean> {
+    return Promise.race([
+      turn.finished.then(() => true),
+      new Promise<boolean>((resolve) => setTimeout(() => resolve(false), timeoutMs)),
+    ]);
+  }
+
+  private emitEphemeralAssistantResult(input: string, output: string, success: boolean, start: number): ChatRunResult {
+    const context = this.createEventContext();
+    this.emitEvent({
+      type: "lifecycle_start",
+      input,
+      ...this.eventBase(context),
+    });
+    this.emitEvent({
+      type: "assistant_final",
+      text: output,
+      persisted: false,
+      ...this.eventBase(context),
+    });
+    const elapsed_ms = Date.now() - start;
+    this.emitLifecycleEndEvent(success ? "completed" : "error", elapsed_ms, context, false);
+    return { success, output, elapsed_ms };
+  }
+
+  private rememberActiveTurnEvent(event: ChatEvent): void {
+    const activeTurn = this.activeTurn;
+    if (!activeTurn || activeTurn.context.turnId !== event.turnId) return;
+    let summary: string | null = null;
+    if (event.type === "activity") {
+      summary = previewActivityText(event.message, 140);
+    } else if (event.type === "tool_start") {
+      summary = `Started ${event.toolName}`;
+    } else if (event.type === "tool_update") {
+      summary = `${event.toolName}: ${previewActivityText(event.message, 100)}`;
+    } else if (event.type === "tool_end") {
+      summary = `${event.success ? "Finished" : "Failed"} ${event.toolName}: ${previewActivityText(event.summary, 100)}`;
+    }
+    if (!summary) return;
+    activeTurn.recentEvents = [...activeTurn.recentEvents, summary].slice(-12);
+  }
+
   private emitEvent(event: ChatEvent): void {
+    this.rememberActiveTurnEvent(event);
     const handler = this.onEvent ?? this.deps.onEvent;
     handler?.(event);
   }
@@ -3004,6 +3192,7 @@ export class ChatRunner {
       persisted,
       ...this.eventBase(eventContext),
     });
+    this.finishActiveTurn(eventContext);
   }
 
   private emitLifecycleErrorEvent(

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -342,6 +342,27 @@ export class CrossPlatformChatSessionManager {
     return result.output;
   }
 
+  async interruptAndRedirect(input: CrossPlatformIncomingChatMessage): Promise<ChatRunResult> {
+    const ingress = this.createIngressMessage(input);
+    const session = this.getOrCreateSession(ingress, input.cwd);
+    const previousOnEvent = session.runner.onEvent;
+    if (input.onEvent) {
+      const handler = input.onEvent;
+      const upstream = this.deps.onEvent;
+      session.runner.onEvent = (event: ChatEvent) => {
+        safeInvoke(handler, event);
+        if (upstream && upstream !== handler) {
+          safeInvoke(upstream, event);
+        }
+      };
+    }
+    try {
+      return await session.runner.interruptAndRedirect(input.text, session.info.cwd, input.timeoutMs);
+    } finally {
+      session.runner.onEvent = previousOnEvent;
+    }
+  }
+
   async executeIngress(
     ingress: CrossPlatformIngressMessage,
     options: Pick<CrossPlatformIncomingChatMessage, "cwd" | "timeoutMs" | "onEvent" | "conversation_name" | "user_name"> = {}

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -78,6 +78,7 @@ function createChatRunnerMock() {
   return {
     startSession: vi.fn(),
     execute: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
+    interruptAndRedirect: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
     executeIngressMessage: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
     onEvent: undefined,
   };
@@ -181,6 +182,43 @@ describe("standalone slash command routing", () => {
     expect(intentRecognizer.recognize).not.toHaveBeenCalled();
     expect(actionHandler.handle).not.toHaveBeenCalled();
 
+    screen.unmount();
+  });
+
+  it("routes input during processing to ChatRunner interrupt redirect", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    let resolveExecute: () => void = () => {};
+    chatRunner.execute = vi.fn(() => new Promise((resolve) => {
+      resolveExecute = () => resolve({ success: true, output: "", elapsed_ms: 0 });
+    }));
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    const firstSubmit = testState.lastChatProps!.onSubmit("long running task");
+    await flush();
+    await testState.lastChatProps!.onSubmit("show me the diff first");
+
+    expect(chatRunner.execute).toHaveBeenCalledWith("long running task", "~/workspace");
+    expect(chatRunner.interruptAndRedirect).toHaveBeenCalledWith("show me the diff first", "~/workspace");
+
+    resolveExecute();
+    await firstSubmit;
     screen.unmount();
   });
 });

--- a/src/interface/tui/__tests__/chat-processing-scroll.test.ts
+++ b/src/interface/tui/__tests__/chat-processing-scroll.test.ts
@@ -25,7 +25,7 @@ describe("TUI chat processing scroll input", () => {
     stdoutMock.write = vi.fn(() => true);
   });
 
-  it("keeps normal chat scroll input active while text input is locked during processing", async () => {
+  it("keeps normal chat scroll input active while processing", async () => {
     const { Chat } = await import("../chat.js");
     const messages: ChatMessage[] = Array.from({ length: 30 }, (_, index) => ({
       id: `m-${index}`,
@@ -47,7 +47,7 @@ describe("TUI chat processing scroll input", () => {
     expect(useInputMock).toHaveBeenCalledWith(expect.any(Function), { isActive: false });
   });
 
-  it("keeps fullscreen chat scroll input active during processing", async () => {
+  it("keeps fullscreen chat input active during processing", async () => {
     const { FullscreenChat } = await import("../fullscreen-chat.js");
     const messages: ChatMessage[] = Array.from({ length: 30 }, (_, index) => ({
       id: `m-${index}`,
@@ -65,6 +65,6 @@ describe("TUI chat processing scroll input", () => {
     }), { columns: 60 });
 
     expect(useInputMock).toHaveBeenCalledWith(expect.any(Function), { isActive: true });
-    expect(useInputMock).toHaveBeenCalledWith(expect.any(Function), { isActive: false });
+    expect(useInputMock).not.toHaveBeenCalledWith(expect.any(Function), { isActive: false });
   });
 });

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -383,7 +383,23 @@ export function App({
 
   const handleInput = useCallback(
     async (input: string) => {
-      if (isProcessing) return;
+      if (isProcessing) {
+        if (!chatRunner) return;
+        setMessages((prev) => [...prev, { id: randomUUID(), role: "user" as const, text: input, timestamp: new Date() }].slice(-MAX_MESSAGES));
+        try {
+          await chatRunner.interruptAndRedirect(input, cwd ?? process.cwd());
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          setMessages((prev) => [...prev, {
+            id: randomUUID(),
+            role: "pulseed" as const,
+            text: `Interrupt error: ${message}`,
+            timestamp: new Date(),
+            messageType: "error" as const,
+          }].slice(-MAX_MESSAGES));
+        }
+        return;
+      }
       // Add user message
       setMessages((prev) => [...prev, { id: randomUUID(), role: "user" as const, text: input, timestamp: new Date() }].slice(-MAX_MESSAGES));
       setIsProcessing(true);

--- a/src/interface/tui/chat-surface.ts
+++ b/src/interface/tui/chat-surface.ts
@@ -8,6 +8,7 @@ export interface TuiChatSurface {
   onEvent?: ChatEventHandler;
   startSession(cwd: string): void;
   execute(input: string, cwd: string): Promise<ChatRunResult>;
+  interruptAndRedirect(input: string, cwd: string): Promise<ChatRunResult>;
   executeIngressMessage(ingress: CrossPlatformIngressMessage, cwd: string): Promise<ChatRunResult>;
 }
 
@@ -44,6 +45,18 @@ export class SharedManagerTuiChatSurface implements TuiChatSurface {
         platform: "local_tui",
         conversation_id: this.conversationId,
       },
+    });
+  }
+
+  interruptAndRedirect(input: string, cwd: string): Promise<ChatRunResult> {
+    const effectiveCwd = this.sessionCwd ?? cwd;
+    return this.manager.interruptAndRedirect({
+      channel: "tui",
+      platform: "local_tui",
+      conversation_id: this.conversationId,
+      cwd: effectiveCwd,
+      text: input,
+      onEvent: this.onEvent,
     });
   }
 

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -474,7 +474,6 @@ export function Chat({
 
   const handleSubmit = (value: string) => {
     if (hasMatches) return; // let useInput handle enter when suggestions are shown
-    if (isProcessing) return;
     if (!value.trim()) {
       // Show empty-enter hint
       setEmptyHint(true);
@@ -626,7 +625,7 @@ export function Chat({
             <Text>{INPUT_MARKER}</Text>
             <TextInput
               value={input}
-              focus={!isProcessing}
+              focus={true}
               onChange={(val) => {
                 justSelected.current = false;
                 setInput(stripMouseEscapeSequences(val));

--- a/src/interface/tui/fullscreen-chat.tsx
+++ b/src/interface/tui/fullscreen-chat.tsx
@@ -1004,7 +1004,7 @@ export function FullscreenChat({
       hasMatches,
       isProcessing,
     });
-    if (hasMatches || isProcessing) return;
+    if (hasMatches) return;
     if (!value.trim()) {
       setEmptyHint(true);
       if (emptyHintTimer.current) clearTimeout(emptyHintTimer.current);
@@ -1052,7 +1052,9 @@ export function FullscreenChat({
         direction: scrollRequest.direction,
         kind: scrollRequest.kind,
       });
-      applyScroll(scrollRequest.direction, scrollRequest.kind);
+      if (!isProcessing) {
+        applyScroll(scrollRequest.direction, scrollRequest.kind);
+      }
       return;
     }
 
@@ -1261,7 +1263,7 @@ export function FullscreenChat({
         collapsePaste: shouldCollapsePastedText(inputChar, clean),
       });
     }
-  }, { isActive: !isProcessing });
+  }, { isActive: true });
 
   React.useEffect(() => {
     setSelectedIdx(0);

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -442,6 +442,58 @@ describe("agentloop phase 1", () => {
     expect(assistantMessages[1]).toMatchObject({ phase: "final_candidate" });
   });
 
+  it("stops after an abort that arrives with the model response before running tools", async () => {
+    const modelInfo = makeModelInfo();
+    const abortController = new AbortController();
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(): Promise<AgentLoopModelResponse> {
+        throw new Error("createTurn should not be used");
+      },
+      async createTurnProtocol() {
+        abortController.abort();
+        return {
+          assistant: [{ content: "Calling echo", phase: "commentary" }],
+          toolCalls: [{ id: "call-1", name: "echo", input: { value: "hello" } }],
+          stopReason: "tool_use",
+          responseCompleted: true,
+        };
+      },
+    };
+    const { router, runtime } = makeToolRuntime();
+    const executeBatch = vi.spyOn(runtime, "executeBatch");
+    const runner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+    const session = createAgentLoopSession();
+
+    const result = await runner.run({
+      session,
+      turnId: "turn-1",
+      goalId: "goal-1",
+      taskId: "task-1",
+      cwd: process.cwd(),
+      model: modelInfo.ref,
+      modelInfo,
+      messages: [{ role: "user", content: "do it" }],
+      outputSchema: z.object({ status: z.literal("done"), finalAnswer: z.string() }),
+      budget: withDefaultBudget({ maxModelTurns: 4 }),
+      toolPolicy: {},
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+      abortSignal: abortController.signal,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.stopReason).toBe("cancelled");
+    expect(executeBatch).not.toHaveBeenCalled();
+  });
+
   it("falls back to a text protocol when the LLM client cannot use native tools", async () => {
     const modelInfo = makeModelInfo({ capabilities: { ...defaultAgentLoopCapabilities, toolCalling: false } });
     const llmCalls: Array<{ messages: LLMMessage[]; options?: LLMRequestOptions }> = [];

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -127,6 +127,9 @@ export class BoundedAgentLoopRunner {
       if (!protocol.responseCompleted) {
         return this.stop(turn, "protocol_incomplete", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
+      if (turn.abortSignal?.aborted) {
+        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+      }
 
       const response = this.protocolToResponse(protocol);
       modelTurns++;
@@ -288,6 +291,9 @@ export class BoundedAgentLoopRunner {
 
       if (repeatedToolLoopCount > turn.budget.maxRepeatedToolCalls) {
         return this.stop(turn, "stalled_tool_loop", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+      }
+      if (turn.abortSignal?.aborted) {
+        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
 
       for (const call of response.toolCalls) {

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -102,6 +102,7 @@ export interface ChatAgentLoopInput {
   resumeState?: AgentLoopSessionState;
   resumeStatePath?: string;
   resumeOnly?: boolean;
+  abortSignal?: AbortSignal;
   role?: SubagentRole;
   outputMode?: ChatAgentLoopOutputMode;
 }
@@ -165,6 +166,7 @@ export class ChatAgentLoopRunner {
         toolPolicy: { ...this.deps.defaultToolPolicy, ...input.toolPolicy },
         ...(input.resumeState ? { resumeState: input.resumeState } : {}),
         loadPersistedState: input.resumeOnly === true || input.resumeState !== undefined,
+        ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
         ...(this.deps.defaultExecutionPolicy ? { executionPolicy: this.deps.defaultExecutionPolicy } : {}),
         toolCallContext: {
           cwd,


### PR DESCRIPTION
## Summary
- keep TUI chat input active during processing and route in-flight input to interrupt redirects
- track the active ChatRunner turn with an AbortController, recent activity, and ephemeral redirect responses
- pass abort signals into the native chat agent loop and re-check cancellation after model responses before tools run
- support summary/diff/review/background/fallback redirect handling, with background requests preserving the foreground run

## Validation
- git diff --check
- npm run typecheck
- npm test -- --run src/interface/chat/__tests__/chat-runner.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
- npm run test:changed
- subagent re-review: LGTM, no material blockers

Closes #755