### PR TITLE
Route long-running chat work to daemon tend

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -2145,6 +2145,76 @@ describe("ChatRunner", () => {
       expect(result.diagnostics).toBeUndefined();
     });
 
+    it("routes explicit long-running work to daemon-backed tend instead of chatAgentLoopRunner", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-daemon-tend-route-"));
+      try {
+        const adapter = makeMockAdapter();
+        const chatAgentLoopRunner = {
+          execute: vi.fn().mockResolvedValue({
+            success: true,
+            output: "Agentloop should not run",
+            error: null,
+            exit_code: null,
+            elapsed_ms: 42,
+            stopped_reason: "completed",
+          }),
+        } as unknown as ChatAgentLoopRunner;
+        const llmClient = {
+          supportsToolCalling: () => true,
+          sendMessage: vi.fn().mockResolvedValue({
+            content: "Improve the long-running task until the target metric is reached.",
+            usage: { input_tokens: 10, output_tokens: 12 },
+            stop_reason: "stop",
+          }),
+          parseJSON: vi.fn(),
+        };
+        const goal = makeGoal("goal-long", {
+          title: "Reach the long-running score target",
+          description: "Improve the task until score target is reached.",
+        });
+        const goalNegotiator = {
+          negotiate: vi.fn().mockResolvedValue({ goal }),
+        };
+        const daemonClient = {
+          startGoal: vi.fn().mockResolvedValue(undefined),
+        };
+        const stateManager = {
+          ...makeMockStateManager(),
+          getBaseDir: vi.fn().mockReturnValue(tmpDir),
+        } as unknown as StateManager;
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          stateManager,
+          chatAgentLoopRunner,
+          llmClient: llmClient as never,
+          goalNegotiator: goalNegotiator as never,
+          daemonClient: daemonClient as never,
+        }));
+        runner.startSession("/repo");
+
+        const result = await runner.execute("coreloopの方でscore0.98行くまで取り組んで", "/repo");
+
+        expect(result.success).toBe(true);
+        expect(result.output).toContain("Tend to this goal?");
+        expect(result.output).toContain("Reach the long-running score target");
+        expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+        expect(adapter.execute).not.toHaveBeenCalled();
+        expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+        expect(goalNegotiator.negotiate).toHaveBeenCalledWith(
+          "Improve the long-running task until the target metric is reached.",
+          expect.objectContaining({
+            constraints: expect.arrayContaining(["source: tend (auto-generated from chat)"]),
+          })
+        );
+        expect(daemonClient.startGoal).not.toHaveBeenCalled();
+        expect((runner as unknown as { pendingTend: unknown }).pendingTend).toMatchObject({
+          goalId: "goal-long",
+        });
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("interruptAndRedirect aborts an active native agent loop and returns a summary", async () => {
       let capturedSignal: AbortSignal | undefined;
       const chatAgentLoopRunner = {

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -234,6 +234,58 @@ describe("CrossPlatformChatSessionManager", () => {
     });
   });
 
+  it("routes long-running work through durable tend with the current session target", async () => {
+    const stateManager = makeMockStateManager();
+    const adapter = makeMockAdapter();
+    const llmClient = {
+      supportsToolCalling: () => true,
+      sendMessage: vi.fn().mockResolvedValue({
+        content: "Keep improving the requested work until the target is reached.",
+        usage: { input_tokens: 7, output_tokens: 9 },
+        stop_reason: "stop",
+      }),
+      parseJSON: vi.fn(),
+    };
+    const goalNegotiator = {
+      negotiate: vi.fn().mockResolvedValue({
+        goal: {
+          id: "goal-long",
+          title: "Reach the long-running target",
+          description: "Keep improving the requested work.",
+          dimensions: [],
+          constraints: [],
+          created_at: "2026-04-26T00:00:00.000Z",
+          updated_at: "2026-04-26T00:00:00.000Z",
+        },
+      }),
+    };
+    const daemonClient = {
+      startGoal: vi.fn().mockResolvedValue(undefined),
+    };
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager,
+      adapter,
+      llmClient: llmClient as never,
+      goalNegotiator: goalNegotiator as never,
+      daemonClient: daemonClient as never,
+    }));
+
+    const result = await manager.execute("coreloopの方でscore0.98行くまで取り組んで", {
+      identity_key: "owner",
+      channel: "tui",
+      platform: "local_tui",
+      conversation_id: "tui-session",
+      cwd: "/repo",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Tend to this goal?");
+    expect(result.output).toContain("Reach the long-running target");
+    expect(adapter.execute).not.toHaveBeenCalled();
+    expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+    expect(daemonClient.startGoal).not.toHaveBeenCalled();
+  });
+
   it("serializes concurrent turns for the same shared session across channels", async () => {
     let activeCalls = 0;
     let maxConcurrentCalls = 0;

--- a/src/interface/chat/__tests__/ingress-router.test.ts
+++ b/src/interface/chat/__tests__/ingress-router.test.ts
@@ -112,6 +112,29 @@ describe("IngressRouter", () => {
     expect(route.eventProjectionPolicy).toBe("latest_active_reply_target");
   });
 
+  it("does not route long-running work to daemon-backed tend when ingress policy disallows durable control", () => {
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: "coreloopの方でscore0.98行くまで取り組んで",
+        channel: "plugin_gateway",
+        platform: "slack",
+        runtimeControl: {
+          allowed: false,
+          approvalMode: "disallowed",
+        },
+      }),
+      {
+        hasLightweightLlm: true,
+        hasAgentLoop: true,
+        hasToolLoop: true,
+        hasDaemonTend: true,
+      }
+    );
+
+    expect(route.kind).toBe("agent_loop");
+    expect(route.lane).toBe("fast");
+  });
+
   it("keeps explanatory long-running-task questions on the fast lane", () => {
     const route = router.selectRoute(
       buildStandaloneIngressMessage({

--- a/src/interface/chat/__tests__/ingress-router.test.ts
+++ b/src/interface/chat/__tests__/ingress-router.test.ts
@@ -87,4 +87,45 @@ describe("IngressRouter", () => {
     expect(route.kind).toBe("agent_loop");
     expect(route.lane).toBe("fast");
   });
+
+  it("routes explicit long-running work requests to daemon-backed tend", () => {
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: "coreloopの方でscore0.98行くまで取り組んで",
+        channel: "tui",
+        platform: "local_tui",
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      }),
+      {
+        hasLightweightLlm: true,
+        hasAgentLoop: true,
+        hasToolLoop: true,
+        hasDaemonTend: true,
+      }
+    );
+
+    expect(route.kind).toBe("daemon_tend");
+    expect(route.lane).toBe("durable");
+    expect(route.eventProjectionPolicy).toBe("latest_active_reply_target");
+  });
+
+  it("keeps explanatory long-running-task questions on the fast lane", () => {
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: "長期タスクだとどうしてエラーになるの？",
+      }),
+      {
+        hasLightweightLlm: true,
+        hasAgentLoop: true,
+        hasToolLoop: true,
+        hasDaemonTend: true,
+      }
+    );
+
+    expect(route.kind).toBe("agent_loop");
+    expect(route.lane).toBe("fast");
+  });
 });

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -556,12 +556,16 @@ export class ChatRunner {
     hasAgentLoop: boolean;
     hasToolLoop: boolean;
     hasRuntimeControlService: boolean;
+    hasDaemonTend: boolean;
   } {
     return {
       hasLightweightLlm: this.deps.llmClient !== undefined,
       hasAgentLoop: this.deps.chatAgentLoopRunner !== undefined,
       hasToolLoop: this.deps.llmClient !== undefined,
       hasRuntimeControlService: this.deps.runtimeControlService !== undefined,
+      hasDaemonTend: this.deps.llmClient !== undefined
+        && this.deps.goalNegotiator !== undefined
+        && this.deps.daemonClient !== undefined,
     };
   }
 
@@ -1369,7 +1373,7 @@ export class ChatRunner {
       "Turn context",
       `- last_selected_route: ${this.formatRoute(this.lastSelectedRoute)}`,
       `- reply_target: ${replyTargetParts.length > 0 ? replyTargetParts.join(":") : "none"}`,
-      `- route_capabilities: light_llm=${routeCapabilities.hasLightweightLlm}, agent_loop=${routeCapabilities.hasAgentLoop}, tool_loop=${routeCapabilities.hasToolLoop}, runtime_control=${routeCapabilities.hasRuntimeControlService}`,
+      `- route_capabilities: light_llm=${routeCapabilities.hasLightweightLlm}, agent_loop=${routeCapabilities.hasAgentLoop}, tool_loop=${routeCapabilities.hasToolLoop}, runtime_control=${routeCapabilities.hasRuntimeControlService}, daemon_tend=${routeCapabilities.hasDaemonTend}`,
       "",
       "Working assumptions",
       "- this view exposes operational context, not hidden reasoning",
@@ -2066,6 +2070,27 @@ export class ChatRunner {
         this.emitLifecycleEndEvent("error", runtimeControlResult.elapsed_ms, eventContext, false);
       }
       return runtimeControlResult;
+    }
+
+    if (selectedRoute?.kind === "daemon_tend") {
+      this.emitCheckpoint("Durable goal selected", "This long-running request is being prepared for daemon-backed CoreLoop execution.", eventContext, "route");
+      const tendResult = await this.handleTend("", start);
+      if (tendResult.success) {
+        await history.appendAssistantMessage(tendResult.output);
+        this.emitCheckpoint("Durable goal prepared", "The daemon-backed goal confirmation is ready.", eventContext, "complete");
+        this.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
+        this.emitEvent({
+          type: "assistant_final",
+          text: tendResult.output,
+          persisted: true,
+          ...this.eventBase(eventContext),
+        });
+        this.emitLifecycleEndEvent("completed", tendResult.elapsed_ms, eventContext, true);
+      } else {
+        tendResult.output = this.emitLifecycleErrorEvent(tendResult.output, assistantBuffer.text, eventContext);
+        this.emitLifecycleEndEvent("error", tendResult.elapsed_ms, eventContext, false);
+      }
+      return tendResult;
     }
 
     if (selectedRoute?.kind === "direct_answer") {
@@ -3106,6 +3131,9 @@ export class ChatRunner {
     if (selectedRoute?.kind === "runtime_control") {
       nextStep = `prepare the ${selectedRoute.intent.kind} runtime-control request.`;
       reason = "runtime changes need an explicit operation plan and approval path.";
+    } else if (selectedRoute?.kind === "daemon_tend") {
+      nextStep = "convert the request into a daemon-backed CoreLoop goal confirmation.";
+      reason = "long-running work should survive chat turn timeouts and run through durable runtime state.";
     } else if (selectedRoute?.kind === "direct_answer") {
       nextStep = "ask the lightweight model for a concise direct answer.";
       reason = "the router classified this as a simple question that does not need tools.";

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -525,6 +525,9 @@ export class CrossPlatformChatSessionManager {
       hasAgentLoop: this.deps.chatAgentLoopRunner !== undefined,
       hasToolLoop: this.deps.llmClient !== undefined,
       hasRuntimeControlService: this.deps.runtimeControlService !== undefined,
+      hasDaemonTend: this.deps.llmClient !== undefined
+        && this.deps.goalNegotiator !== undefined
+        && this.deps.daemonClient !== undefined,
     });
     session.lastRoute = selectedRoute;
 

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -165,8 +165,10 @@ function selectRouteForText(
     concurrencyPolicy: "session_serial" as const,
     daemonChatPolicy: "compatibility_only" as const,
   };
+  const canUseDurableControl =
+    runtimeControl.allowed && runtimeControl.approvalMode !== "disallowed";
 
-  if (runtimeControl.allowed && runtimeControl.approvalMode !== "disallowed") {
+  if (canUseDurableControl) {
     const intent = recognizeRuntimeControlIntent(text);
     if (intent !== null) {
       return {
@@ -179,7 +181,7 @@ function selectRouteForText(
     }
   }
 
-  if (deps.hasDaemonTend && shouldUseDaemonTendRoute(text)) {
+  if (canUseDurableControl && deps.hasDaemonTend && shouldUseDaemonTendRoute(text)) {
     return {
       lane: "durable",
       kind: "daemon_tend",

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -79,6 +79,15 @@ export type SelectedChatRoute =
       eventProjectionPolicy: EventProjectionPolicy;
       concurrencyPolicy: ConcurrencyPolicy;
       daemonChatPolicy: DaemonChatPolicy;
+    }
+  | {
+      lane: "durable";
+      kind: "daemon_tend";
+      reason: "long_running_goal_intent";
+      replyTargetPolicy: ReplyTargetPolicy;
+      eventProjectionPolicy: EventProjectionPolicy;
+      concurrencyPolicy: ConcurrencyPolicy;
+      daemonChatPolicy: DaemonChatPolicy;
     };
 
 export interface IngressRouterCapabilities {
@@ -86,6 +95,7 @@ export interface IngressRouterCapabilities {
   hasAgentLoop: boolean;
   hasToolLoop: boolean;
   hasRuntimeControlService?: boolean;
+  hasDaemonTend?: boolean;
 }
 
 function shouldUseDirectAnswerRoute(input: string): boolean {
@@ -111,6 +121,31 @@ function shouldUseDirectAnswerRoute(input: string): boolean {
     /(\.(ts|tsx|js|jsx|json|md|yml|yaml|toml|py|go|rs|sh|sql)\b|\/[^/\s]+\.[A-Za-z0-9]+$)/,
   ];
   return !workSignals.some((pattern) => pattern.test(lowered));
+}
+
+function shouldUseDaemonTendRoute(input: string): boolean {
+  const normalized = input.trim();
+  if (!normalized || normalized.startsWith("/")) return false;
+
+  const lowered = normalized.toLowerCase();
+  const durableSignals = [
+    /\b(core\s*loop|coreloop|daemon|background|durable|autonomous|long[-\s]?running|overnight)\b/i,
+    /(コア\s*ループ|coreloop|デーモン|daemon|バックグラウンド|長期|常駐|自律|継続実行|数時間|数日|数週間)/,
+  ];
+  const actionSignals = [
+    /\b(work on|keep working|continue|run|start|execute|optimi[sz]e|improve|pursue|tend)\b/i,
+    /\b(until|to completion|in the background|as a background run)\b/i,
+    /(取り組んで|進めて|回して|走らせて|実行して|続けて|改善して|最適化して|任せて|達成して|完了まで|終わるまで|行くまで|到達するまで)/,
+  ];
+  const explanationSignals = [
+    /[?？]/,
+    /\b(why|how|what|explain|describe)\b/i,
+    /(なぜ|なんで|どうして|説明|教えて|どう思う)/,
+  ];
+
+  if (!durableSignals.some((pattern) => pattern.test(lowered))) return false;
+  if (!actionSignals.some((pattern) => pattern.test(lowered))) return false;
+  return !explanationSignals.some((pattern) => pattern.test(lowered));
 }
 
 function selectRouteForText(
@@ -142,6 +177,15 @@ function selectRouteForText(
         ...baseDurablePolicy,
       };
     }
+  }
+
+  if (deps.hasDaemonTend && shouldUseDaemonTendRoute(text)) {
+    return {
+      lane: "durable",
+      kind: "daemon_tend",
+      reason: "long_running_goal_intent",
+      ...baseDurablePolicy,
+    };
   }
 
   if (!deps.hasAgentLoop && deps.hasLightweightLlm && shouldUseDirectAnswerRoute(text)) {

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -604,16 +604,19 @@ async function startTUIDaemonMode(): Promise<void> {
 
   try {
     let daemonClient: InstanceType<typeof DaemonClient>;
+    let daemonPort: number;
 
     try {
       const existingConnection = await resolveRunningDaemonConnection(baseDir);
 
       if (existingConnection) {
         daemonClient = new DaemonClient({ host: "127.0.0.1", ...existingConnection, baseDir });
+        daemonPort = existingConnection.port;
       } else {
         await startDaemonDetached(baseDir);
         const ready = await waitForDaemon(baseDir, 10_000);
         daemonClient = new DaemonClient({ host: "127.0.0.1", port: ready.port, authToken: ready.authToken, baseDir });
+        daemonPort = ready.port;
       }
 
       daemonClient.connect();
@@ -721,8 +724,23 @@ async function startTUIDaemonMode(): Promise<void> {
         createNativeReviewAgentLoopRunner,
         shouldUseNativeTaskAgentLoop,
       } = await import("../../orchestrator/execution/agent-loop/index.js");
+      const { GoalNegotiator } = await import("../../orchestrator/goal/goal-negotiator.js");
+      const { EthicsGate } = await import("../../platform/traits/ethics-gate.js");
+      const { ObservationEngine } = await import("../../platform/observation/observation-engine.js");
       const llmClient = await buildLLMClient();
       const adapterRegistry = await buildAdapterRegistry(llmClient);
+      const observationEngine = new ObservationEngine(stateManager, dataSourceRegistry.getAllSources(), llmClient);
+      const ethicsGate = new EthicsGate(stateManager, llmClient);
+      const goalNegotiator = new GoalNegotiator(
+        stateManager,
+        llmClient,
+        ethicsGate,
+        observationEngine,
+        undefined,
+        undefined,
+        undefined,
+        adapterRegistry.getAdapterCapabilities()
+      );
       const adapterType = providerConfig.adapter ?? "claude_code_cli";
       const adapter = adapterRegistry.getAdapter(adapterType);
       const chatAgentLoopRunner = shouldUseNativeTaskAgentLoop(providerConfig, llmClient)
@@ -754,6 +772,9 @@ async function startTUIDaemonMode(): Promise<void> {
         toolExecutor,
         chatAgentLoopRunner,
         reviewAgentLoopRunner,
+        goalNegotiator,
+        daemonClient,
+        daemonBaseUrl: `http://127.0.0.1:${daemonPort}`,
         approvalFn: chatToolApprovalFn,
       });
     } catch (err) {


### PR DESCRIPTION
## Summary
- add a durable `daemon_tend` chat route for explicit long-running/CoreLoop/background work requests
- route those turns through the existing `/tend` daemon-backed goal confirmation flow instead of fast chat AgentLoop
- wire daemon tend capability through cross-platform/TUI daemon-mode chat and cover the routing path with tests

## Tests
- pnpm vitest run src/interface/chat/__tests__/ingress-router.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/tui/__tests__/chat-surface.test.ts
- pnpm exec tsc -p tsconfig.json --noEmit
- pnpm run test:changed