### PR TITLE
feat(tui): capture fullscreen mouse interactions

### DIFF
--- a/src/interface/tui/__tests__/chat.test.ts
+++ b/src/interface/tui/__tests__/chat.test.ts
@@ -14,8 +14,12 @@ import {
   buildCollapsedPasteRange,
   buildComposerLines,
   buildFullscreenChatRenderLines,
+  buildTranscriptRenderLines,
   copySelectedInputText,
+  extractClickableTargetAt,
+  formatTranscript,
   getSelectedInputText,
+  getSelectedBodyText,
   shouldCollapsePastedText,
 } from "../fullscreen-chat.js";
 import { estimateMarkdownHeight, estimateWrappedLineCount, wrapTextToRows } from "../markdown-renderer.js";
@@ -259,6 +263,8 @@ describe("chat scroll keys", () => {
     expect(getScrollRequest("[6~", { pageDown: true })).toMatchObject({ direction: "down", kind: "page" });
     expect(getScrollRequest("u", { ctrl: true })).toMatchObject({ direction: "up", kind: "page" });
     expect(getScrollRequest("d", { ctrl: true })).toMatchObject({ direction: "down", kind: "page" });
+    expect(getScrollRequest("", { ctrl: true, home: true })).toMatchObject({ direction: "up", kind: "top" });
+    expect(getScrollRequest("", { ctrl: true, end: true })).toMatchObject({ direction: "down", kind: "bottom" });
     expect(getScrollRequest("", { upArrow: true })).toBeNull();
     expect(getScrollRequest("", { downArrow: true })).toBeNull();
   });
@@ -323,19 +329,83 @@ describe("composer clipboard selection", () => {
   });
 
   it("copies the selected composer text through the clipboard boundary", async () => {
-    const copy = vi.fn(async () => true);
+    const copy = vi.fn(async () => ({ ok: true as const, method: "osc52" as const }));
 
-    await expect(copySelectedInputText("copy this text", { anchor: 9, focus: 5 }, copy)).resolves.toBe(true);
+    await expect(copySelectedInputText("copy this text", { anchor: 9, focus: 5 }, copy)).resolves.toMatchObject({ ok: true });
 
     expect(copy).toHaveBeenCalledWith("this");
   });
 
   it("does not call the clipboard boundary for empty selections", async () => {
-    const copy = vi.fn(async () => true);
+    const copy = vi.fn(async () => ({ ok: true as const, method: "osc52" as const }));
 
-    await expect(copySelectedInputText("copy", { anchor: 2, focus: 2 }, copy)).resolves.toBe(false);
+    await expect(copySelectedInputText("copy", { anchor: 2, focus: 2 }, copy)).resolves.toMatchObject({ ok: false });
 
     expect(copy).not.toHaveBeenCalled();
+  });
+});
+
+describe("fullscreen body selection and transcript", () => {
+  it("extracts selected visible body rows in display order", () => {
+    const rows = [
+      { key: "a", kind: "pulseed" as const, text: "first row" },
+      { key: "b", kind: "pulseed" as const, text: "second row" },
+    ];
+
+    expect(getSelectedBodyText(rows, {
+      anchor: { rowIndex: 1, offset: 6 },
+      focus: { rowIndex: 0, offset: 0 },
+    })).toBe("first row\nsecond");
+  });
+
+  it("renders selected body text with selection styling", () => {
+    const viewport = buildChatViewport([
+      { id: "m1", role: "pulseed", text: "select this text", timestamp: new Date() },
+    ], 60, 4, 0);
+
+    const lines = buildFullscreenChatRenderLines({
+      availableCols: 60,
+      availableRows: 10,
+      viewport,
+      composerLines: [],
+      isProcessing: false,
+      spinnerGlyph: "",
+      spinnerVerb: "",
+      bodySelection: {
+        start: { rowIndex: 0, offset: 0 },
+        end: { rowIndex: 0, offset: 6 },
+      },
+    });
+
+    expect(lines.flatMap((line) => line.segments ?? []).some((segment) => (
+      segment.text.includes("select") && segment.backgroundColor
+    ))).toBe(true);
+  });
+
+  it("formats and renders transcript content for native search/export paths", () => {
+    const messages = [
+      { id: "u1", role: "user" as const, text: "hello", timestamp: new Date() },
+      { id: "p1", role: "pulseed" as const, text: "world", timestamp: new Date() },
+    ];
+
+    expect(formatTranscript(messages)).toContain("User:\nhello");
+
+    const transcript = buildTranscriptRenderLines({
+      messages,
+      cols: 40,
+      rows: 6,
+      scrollOffset: 0,
+      searchQuery: "world",
+      searchMode: false,
+    });
+
+    expect(transcript.totalRows).toBeGreaterThan(0);
+    expect(transcript.lines.map((line) => line.text ?? "").join("\n")).toContain("transcript");
+  });
+
+  it("detects clickable URLs and file paths under the mouse offset", () => {
+    expect(extractClickableTargetAt("open https://example.com/path now", 10)).toBe("https://example.com/path");
+    expect(extractClickableTargetAt("see ./src/file.ts:12", 8)).toBe("./src/file.ts:12");
   });
 });
 

--- a/src/interface/tui/__tests__/clipboard.test.ts
+++ b/src/interface/tui/__tests__/clipboard.test.ts
@@ -19,33 +19,40 @@ function makeFakeProc(exitCode: number) {
 describe("copyToClipboard", () => {
   const spawnMock = spawn as unknown as ReturnType<typeof vi.fn>;
   const originalPlatform = process.platform;
+  const originalTmux = process.env.TMUX;
 
   beforeEach(() => {
     spawnMock.mockReset();
+    delete process.env.TMUX;
   });
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    if (originalTmux === undefined) {
+      delete process.env.TMUX;
+    } else {
+      process.env.TMUX = originalTmux;
+    }
     setTrustedTuiControlStream(null);
   });
 
-  it("macOS: calls pbcopy and returns true on success", async () => {
+  it("macOS: calls pbcopy and reports the copy method on success", async () => {
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
     spawnMock.mockReturnValue(makeFakeProc(0));
 
     const result = await copyToClipboard("hello");
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ok: true, method: "pbcopy" });
     expect(spawnMock).toHaveBeenCalledWith("pbcopy", [], expect.any(Object));
   });
 
-  it("Linux: calls xclip and returns true on success", async () => {
+  it("Linux: calls xclip and reports the copy method on success", async () => {
     Object.defineProperty(process, "platform", { value: "linux", configurable: true });
     spawnMock.mockReturnValue(makeFakeProc(0));
 
     const result = await copyToClipboard("hello");
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ok: true, method: "xclip" });
     expect(spawnMock).toHaveBeenCalledWith("xclip", ["-selection", "clipboard"], expect.any(Object));
   });
 
@@ -57,7 +64,7 @@ describe("copyToClipboard", () => {
 
     const result = await copyToClipboard("hello");
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ok: true, method: "xsel" });
     expect(spawnMock).toHaveBeenNthCalledWith(2, "xsel", ["--clipboard", "--input"], expect.any(Object));
   });
 
@@ -71,16 +78,19 @@ describe("copyToClipboard", () => {
 
     const result = await copyToClipboard("hello");
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ok: true, method: "osc52" });
     expect(write).toHaveBeenCalledWith("\u001b]52;c;aGVsbG8=\u0007");
   });
 
-  it("always returns a boolean", async () => {
+  it("tmux: writes to the tmux paste buffer before platform clipboards", async () => {
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    process.env.TMUX = "/tmp/tmux-501/default,12345,0";
     spawnMock.mockReturnValue(makeFakeProc(0));
 
     const result = await copyToClipboard("test");
-    expect(typeof result).toBe("boolean");
+
+    expect(result).toEqual({ ok: true, method: "tmux" });
+    expect(spawnMock).toHaveBeenCalledWith("tmux", ["load-buffer", "-"], expect.any(Object));
   });
 
   it("fallback: writes a complete OSC52 clipboard sequence", async () => {
@@ -90,7 +100,7 @@ describe("copyToClipboard", () => {
 
     const result = await copyToClipboard("hello");
 
-    expect(result).toBe(true);
+    expect(result).toEqual({ ok: true, method: "osc52" });
     expect(write).toHaveBeenCalledWith("\u001b]52;c;aGVsbG8=\u0007");
   });
 });

--- a/src/interface/tui/__tests__/mouse-tracking.test.ts
+++ b/src/interface/tui/__tests__/mouse-tracking.test.ts
@@ -14,17 +14,25 @@ function createMockStream(): NodeJS.WriteStream & { _written: string[] } {
 }
 
 describe("mouse tracking", () => {
-  it("leaves mouse tracking disabled by default so terminal text selection works", () => {
+  it("enables mouse tracking by default for no-flicker fullscreen rendering", () => {
     const original = process.env.PULSEED_MOUSE_TRACKING;
+    const originalDisable = process.env.PULSEED_DISABLE_MOUSE;
     delete process.env.PULSEED_MOUSE_TRACKING;
+    delete process.env.PULSEED_DISABLE_MOUSE;
 
     try {
-      expect(isMouseTrackingEnabled()).toBe(false);
+      expect(isMouseTrackingEnabled(true)).toBe(true);
+      expect(isMouseTrackingEnabled(false)).toBe(false);
     } finally {
       if (original === undefined) {
         delete process.env.PULSEED_MOUSE_TRACKING;
       } else {
         process.env.PULSEED_MOUSE_TRACKING = original;
+      }
+      if (originalDisable === undefined) {
+        delete process.env.PULSEED_DISABLE_MOUSE;
+      } else {
+        process.env.PULSEED_DISABLE_MOUSE = originalDisable;
       }
     }
   });
@@ -40,6 +48,28 @@ describe("mouse tracking", () => {
         delete process.env.PULSEED_MOUSE_TRACKING;
       } else {
         process.env.PULSEED_MOUSE_TRACKING = original;
+      }
+    }
+  });
+
+  it("allows mouse capture to be explicitly disabled", () => {
+    const original = process.env.PULSEED_MOUSE_TRACKING;
+    const originalDisable = process.env.PULSEED_DISABLE_MOUSE;
+    process.env.PULSEED_MOUSE_TRACKING = "1";
+    process.env.PULSEED_DISABLE_MOUSE = "1";
+
+    try {
+      expect(isMouseTrackingEnabled(true)).toBe(false);
+    } finally {
+      if (original === undefined) {
+        delete process.env.PULSEED_MOUSE_TRACKING;
+      } else {
+        process.env.PULSEED_MOUSE_TRACKING = original;
+      }
+      if (originalDisable === undefined) {
+        delete process.env.PULSEED_DISABLE_MOUSE;
+      } else {
+        process.env.PULSEED_DISABLE_MOUSE = originalDisable;
       }
     }
   });

--- a/src/interface/tui/chat.tsx
+++ b/src/interface/tui/chat.tsx
@@ -18,7 +18,7 @@ import { isBashModeInput } from "./bash-mode.js";
 import { isRenderableFrameChunk } from "./render-output.js";
 import { estimateWrappedLineCount } from "./markdown-renderer.js";
 import { buildChatViewport } from "./chat/viewport.js";
-import { getScrollRequest, stripMouseEscapeSequences } from "./chat/scroll.js";
+import { getScrollLineStep, getScrollRequest, stripMouseEscapeSequences } from "./chat/scroll.js";
 import { getMatchingSuggestions, type Suggestion } from "./chat/suggestions.js";
 import type { ChatMessage } from "./chat/types.js";
 import { getTrustedTuiControlStream } from "./terminal-output.js";
@@ -330,10 +330,12 @@ export function Chat({
   );
   const logPaneHeight = viewport.maxVisibleRows + processingRows + SCROLL_INDICATOR_ROWS;
 
-  const applyScroll = useCallback((direction: "up" | "down", kind: "page" | "line") => {
+  const applyScroll = useCallback((direction: "up" | "down", kind: "page" | "line" | "top" | "bottom") => {
     setScrollOffset((prev) => {
       const maxOffset = Math.max(0, viewport.totalRows - viewport.maxVisibleRows);
-      const amount = kind === "page" ? viewport.maxVisibleRows : SCROLL_LINE_STEP;
+      if (kind === "top") return maxOffset;
+      if (kind === "bottom") return 0;
+      const amount = kind === "page" ? viewport.maxVisibleRows : SCROLL_LINE_STEP * getScrollLineStep();
       const delta = direction === "up" ? amount : -amount;
       return Math.max(0, Math.min(maxOffset, prev + delta));
     });

--- a/src/interface/tui/chat/scroll.ts
+++ b/src/interface/tui/chat/scroll.ts
@@ -16,6 +16,8 @@ type ScrollKey = {
   ctrl?: boolean;
   pageUp?: boolean;
   pageDown?: boolean;
+  home?: boolean;
+  end?: boolean;
 };
 
 export type ParsedMouseEvent =
@@ -106,6 +108,12 @@ export function getScrollRequest(
   if (key.ctrl && (inputChar === "d" || inputChar === "D")) {
     return { direction: "down", kind: "page" };
   }
+  if (key.ctrl && key.home) {
+    return { direction: "up", kind: "top" };
+  }
+  if (key.ctrl && key.end) {
+    return { direction: "down", kind: "bottom" };
+  }
   if (key.meta && key.upArrow) {
     return { direction: "up", kind: "line" };
   }
@@ -119,6 +127,14 @@ export function getScrollRequest(
     return { direction: "down", kind: "line" };
   }
   return null;
+}
+
+export function getScrollLineStep(): number {
+  const raw = process.env.PULSEED_SCROLL_SPEED;
+  if (!raw) return 1;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return 1;
+  return Math.max(1, Math.min(20, parsed));
 }
 
 export function stripMouseEscapeSequences(input: string): string {

--- a/src/interface/tui/chat/types.ts
+++ b/src/interface/tui/chat/types.ts
@@ -32,5 +32,5 @@ export interface ChatViewport {
 
 export interface ScrollRequest {
   direction: "up" | "down";
-  kind: "page" | "line";
+  kind: "page" | "line" | "top" | "bottom";
 }

--- a/src/interface/tui/clipboard.ts
+++ b/src/interface/tui/clipboard.ts
@@ -1,6 +1,13 @@
 import { spawn } from "child_process";
 import { writeTrustedTuiControl } from "./terminal-output.js";
 
+export type ClipboardMethod = "pbcopy" | "xclip" | "xsel" | "tmux" | "osc52";
+
+export interface ClipboardResult {
+  ok: boolean;
+  method?: ClipboardMethod;
+}
+
 function spawnWithStdin(cmd: string, args: string[], text: string): Promise<boolean> {
   return new Promise((resolve) => {
     const proc = spawn(cmd, args, { stdio: ["pipe", "ignore", "ignore"] });
@@ -10,24 +17,39 @@ function spawnWithStdin(cmd: string, args: string[], text: string): Promise<bool
   });
 }
 
-function writeOsc52(text: string): boolean {
+function writeOsc52(text: string): ClipboardResult {
   const b64 = Buffer.from(text).toString("base64");
   writeTrustedTuiControl(`\u001b]52;c;${b64}\u0007`);
-  return true;
+  return { ok: true, method: "osc52" };
 }
 
-export async function copyToClipboard(text: string): Promise<boolean> {
+function isInsideTmux(): boolean {
+  return Boolean(process.env.TMUX);
+}
+
+async function copyToTmux(text: string): Promise<ClipboardResult> {
+  if (!isInsideTmux()) {
+    return { ok: false };
+  }
+  const tmuxOk = await spawnWithStdin("tmux", ["load-buffer", "-"], text);
+  return tmuxOk ? { ok: true, method: "tmux" } : { ok: false };
+}
+
+export async function copyToClipboard(text: string): Promise<ClipboardResult> {
+  const tmuxResult = await copyToTmux(text);
+  if (tmuxResult.ok) return tmuxResult;
+
   if (process.platform === "darwin") {
     const pbcopyOk = await spawnWithStdin("pbcopy", [], text);
-    if (pbcopyOk) return true;
+    if (pbcopyOk) return { ok: true, method: "pbcopy" };
     return writeOsc52(text);
   }
 
   if (process.platform === "linux") {
     const xclipOk = await spawnWithStdin("xclip", ["-selection", "clipboard"], text);
-    if (xclipOk) return true;
+    if (xclipOk) return { ok: true, method: "xclip" };
     const xselOk = await spawnWithStdin("xsel", ["--clipboard", "--input"], text);
-    if (xselOk) return true;
+    if (xselOk) return { ok: true, method: "xsel" };
     return writeOsc52(text);
   }
 

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -500,7 +500,7 @@ async function buildDeps() {
 
 async function startTUIStandaloneMode(): Promise<void> {
   const noFlicker = await isNoFlickerEnabled();
-  const mouseTrackingEnabled = isMouseTrackingEnabled();
+  const mouseTrackingEnabled = isMouseTrackingEnabled(noFlicker);
   const outputController = noFlicker ? createNoFlickerOutputController() : null;
   outputController?.install();
   let cleanedUp = false;
@@ -588,7 +588,7 @@ async function startTUIDaemonMode(): Promise<void> {
   const { DaemonClient } = await import("../../runtime/daemon/client.js");
   const baseDir = process.env.PULSEED_HOME ?? getPulseedDirPath();
   const noFlicker = await isNoFlickerEnabled();
-  const mouseTrackingEnabled = isMouseTrackingEnabled();
+  const mouseTrackingEnabled = isMouseTrackingEnabled(noFlicker);
   const outputController = noFlicker ? createNoFlickerOutputController() : null;
   outputController?.install();
   let cleanedUp = false;

--- a/src/interface/tui/flicker/MouseTracking.tsx
+++ b/src/interface/tui/flicker/MouseTracking.tsx
@@ -4,12 +4,18 @@ import { getTrustedTuiControlStream } from "../terminal-output.js";
 
 type MouseTrackingStream = Pick<NodeJS.WriteStream, "write">;
 
-export function isMouseTrackingEnabled(): boolean {
-  const envVal = process.env.PULSEED_MOUSE_TRACKING;
-  if (!envVal) {
+export function isMouseTrackingEnabled(defaultEnabled = true): boolean {
+  const disableVal = process.env.PULSEED_DISABLE_MOUSE;
+  if (disableVal === "1" || disableVal?.toLowerCase() === "true") {
     return false;
   }
-  return envVal === "1" || envVal.toLowerCase() === "true";
+
+  const envVal = process.env.PULSEED_MOUSE_TRACKING;
+  if (envVal) {
+    return envVal === "1" || envVal.toLowerCase() === "true";
+  }
+
+  return defaultEnabled;
 }
 
 export function attachMouseTracking(stream: MouseTrackingStream): () => void {

--- a/src/interface/tui/fullscreen-chat.tsx
+++ b/src/interface/tui/fullscreen-chat.tsx
@@ -1,6 +1,10 @@
 import React, { useCallback, useState } from "react";
+import { spawnSync } from "child_process";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
 import { Box, Text, useInput } from "ink";
-import { copyToClipboard, getClipboardContent } from "./clipboard.js";
+import { copyToClipboard, getClipboardContent, type ClipboardResult } from "./clipboard.js";
 import { logTuiDebug } from "./debug-log.js";
 import { theme } from "./theme.js";
 import { pickSpinnerVerb } from "./spinner-verbs.js";
@@ -14,12 +18,22 @@ import { measureCharWidth, measureTextWidth } from "./text-width.js";
 import { isBashModeInput } from "./bash-mode.js";
 import { buildChatViewport } from "./chat/viewport.js";
 import {
+  getScrollLineStep,
   getScrollRequest,
   normalizeTerminalInputChunk,
   parseMouseEvent,
 } from "./chat/scroll.js";
 import { getMatchingSuggestions, type Suggestion } from "./chat/suggestions.js";
 import type { ChatMessage, ChatDisplayRow } from "./chat/types.js";
+import { writeTrustedTuiControl } from "./terminal-output.js";
+import {
+  CURSOR_HOME,
+  ENTER_ALT_SCREEN,
+  ERASE_SCREEN,
+  EXIT_ALT_SCREEN,
+  HIDE_CURSOR,
+  SHOW_CURSOR,
+} from "./flicker/dec.js";
 
 interface FullscreenChatProps {
   messages: ChatMessage[];
@@ -74,6 +88,8 @@ export type FullscreenChatRenderLinesInput = {
   isProcessing: boolean;
   spinnerGlyph: string;
   spinnerVerb: string;
+  bodySelection?: BodySelectionRange | null;
+  transcriptStatus?: string | null;
 };
 
 export type SelectionState = {
@@ -90,6 +106,21 @@ export type CollapsedPasteRange = {
   start: number;
   end: number;
   label: string;
+};
+
+export type BodySelectionPoint = {
+  rowIndex: number;
+  offset: number;
+};
+
+export type BodySelectionState = {
+  anchor: BodySelectionPoint;
+  focus: BodySelectionPoint;
+};
+
+export type BodySelectionRange = {
+  start: BodySelectionPoint;
+  end: BodySelectionPoint;
 };
 
 export type InputCell = {
@@ -265,13 +296,18 @@ export function getSelectedInputText(input: string, selection: SelectionState | 
 export async function copySelectedInputText(
   input: string,
   selection: SelectionState | null,
-  copy: (text: string) => Promise<boolean> = copyToClipboard,
-): Promise<boolean> {
+  copy: (text: string) => Promise<ClipboardResult> = copyToClipboard,
+): Promise<ClipboardResult> {
   const selectedText = getSelectedInputText(input, selection);
   if (!selectedText) {
-    return false;
+    return { ok: false };
   }
   return copy(selectedText);
+}
+
+function formatCopyToast(charCount: number, result: ClipboardResult): string {
+  const suffix = result.method ? ` via ${result.method}` : "";
+  return `copied ${charCount} chars${suffix}`;
 }
 
 function pushSegment(
@@ -498,6 +534,267 @@ function buildInputContentSegments(
   return segments;
 }
 
+function compareBodySelectionPoints(a: BodySelectionPoint, b: BodySelectionPoint): number {
+  if (a.rowIndex !== b.rowIndex) {
+    return a.rowIndex - b.rowIndex;
+  }
+  return a.offset - b.offset;
+}
+
+function normalizeBodySelection(selection: BodySelectionState | null): BodySelectionRange | null {
+  if (!selection || compareBodySelectionPoints(selection.anchor, selection.focus) === 0) {
+    return null;
+  }
+
+  return compareBodySelectionPoints(selection.anchor, selection.focus) <= 0
+    ? { start: selection.anchor, end: selection.focus }
+    : { start: selection.focus, end: selection.anchor };
+}
+
+function getBodySelectionForRow(
+  selection: BodySelectionRange | null,
+  rowIndex: number,
+  textLength: number,
+): SelectionRange | null {
+  if (!selection || rowIndex < selection.start.rowIndex || rowIndex > selection.end.rowIndex) {
+    return null;
+  }
+
+  const start = rowIndex === selection.start.rowIndex ? selection.start.offset : 0;
+  const end = rowIndex === selection.end.rowIndex ? selection.end.offset : textLength;
+  if (start === end) return null;
+  return { start: Math.max(0, start), end: Math.min(textLength, end) };
+}
+
+function getDisplayOffsetForText(text: string, col: number): number {
+  if (col <= 0) return 0;
+  let usedWidth = 0;
+  let offset = 0;
+  for (const ch of text) {
+    const width = charWidth(ch);
+    const midpoint = usedWidth + width / 2;
+    if (col <= midpoint) return offset;
+    offset += ch.length;
+    usedWidth += width;
+    if (col <= usedWidth) return offset;
+  }
+  return text.length;
+}
+
+function applySelectionToTextSegments(
+  text: string,
+  selection: SelectionRange | null,
+  style: Omit<RenderSegment, "text">,
+): RenderSegment[] {
+  if (!selection) {
+    return [{ text, ...style }];
+  }
+
+  const segments: RenderSegment[] = [];
+  const before = text.slice(0, selection.start);
+  const selected = text.slice(selection.start, selection.end);
+  const after = text.slice(selection.end);
+  pushSegment(segments, before, style);
+  pushSegment(segments, selected, {
+    ...style,
+    color: SELECTION_FOREGROUND,
+    backgroundColor: SELECTION_BACKGROUND,
+  });
+  pushSegment(segments, after, style);
+  return segments;
+}
+
+export function getSelectedBodyText(
+  rows: ChatDisplayRow[],
+  selection: BodySelectionState | null,
+): string {
+  const range = normalizeBodySelection(selection);
+  if (!range) return "";
+
+  const selectedRows: string[] = [];
+  for (let rowIndex = range.start.rowIndex; rowIndex <= range.end.rowIndex; rowIndex += 1) {
+    const row = rows[rowIndex];
+    if (!row || row.kind === "spacer") continue;
+    const rowRange = getBodySelectionForRow(range, rowIndex, row.text.length);
+    if (!rowRange) continue;
+    selectedRows.push(row.text.slice(rowRange.start, rowRange.end).trimEnd());
+  }
+
+  return selectedRows.join("\n").trim();
+}
+
+export function extractClickableTargetAt(text: string, offset: number): string | null {
+  const patterns = [
+    /https?:\/\/[^\s)>\]}]+/g,
+    /(?:\.{1,2}\/|\/)[^\s:]+(?::\d+)?/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      const value = match[0];
+      const start = match.index ?? 0;
+      const end = start + value.length;
+      if (offset >= start && offset <= end) {
+        return value;
+      }
+    }
+  }
+
+  return null;
+}
+
+function openClickableTarget(target: string): boolean {
+  if (/^https?:\/\//.test(target)) {
+    if (process.platform === "darwin") {
+      return spawnSync("open", [target], { stdio: "ignore" }).status === 0;
+    }
+    if (process.platform === "linux") {
+      return spawnSync("xdg-open", [target], { stdio: "ignore" }).status === 0;
+    }
+    return false;
+  }
+
+  const [filePart, linePart] = target.split(/:(\d+)$/);
+  const resolvedPath = path.resolve(process.cwd(), filePart || target);
+  const editor = process.env.VISUAL || process.env.EDITOR;
+  if (editor) {
+    const editorTarget = linePart ? `${resolvedPath}:${linePart}` : resolvedPath;
+    return spawnSync(editor, [editorTarget], { stdio: "ignore", shell: true }).status === 0;
+  }
+  if (process.platform === "darwin") {
+    return spawnSync("open", [resolvedPath], { stdio: "ignore" }).status === 0;
+  }
+  if (process.platform === "linux") {
+    return spawnSync("xdg-open", [resolvedPath], { stdio: "ignore" }).status === 0;
+  }
+  return false;
+}
+
+export function formatTranscript(messages: ChatMessage[]): string {
+  return messages
+    .map((message) => {
+      const label = message.role === "user" ? "User" : "PulSeed";
+      return `${label}:\n${message.text.trimEnd()}`;
+    })
+    .join("\n\n");
+}
+
+function wrapPlainTextToRows(text: string, width: number): string[] {
+  const rows: string[] = [];
+  for (const sourceLine of text.split("\n")) {
+    if (sourceLine.length === 0) {
+      rows.push("");
+      continue;
+    }
+    let current = "";
+    let currentWidth = 0;
+    for (const ch of sourceLine) {
+      const widthOfChar = charWidth(ch);
+      if (currentWidth + widthOfChar > width && current.length > 0) {
+        rows.push(current);
+        current = "";
+        currentWidth = 0;
+      }
+      current += ch;
+      currentWidth += widthOfChar;
+    }
+    rows.push(current);
+  }
+  return rows;
+}
+
+function buildTranscriptRows(messages: ChatMessage[], cols: number): string[] {
+  const rows: string[] = [];
+  for (const message of messages) {
+    const label = message.role === "user" ? "User" : "PulSeed";
+    rows.push(...wrapPlainTextToRows(`${label}:`, cols));
+    rows.push(...wrapPlainTextToRows(message.text.trimEnd(), cols));
+    rows.push("");
+  }
+  return rows;
+}
+
+export function buildTranscriptRenderLines(args: {
+  messages: ChatMessage[];
+  cols: number;
+  rows: number;
+  scrollOffset: number;
+  searchQuery: string;
+  searchMode: boolean;
+  status?: string | null;
+}): { lines: RenderLine[]; totalRows: number; maxScrollOffset: number } {
+  const { messages, cols, rows, scrollOffset, searchQuery, searchMode, status } = args;
+  const bodyRows = Math.max(1, rows - 2);
+  const transcriptRows = buildTranscriptRows(messages, cols);
+  const maxScrollOffset = Math.max(0, transcriptRows.length - bodyRows);
+  const clampedOffset = Math.max(0, Math.min(maxScrollOffset, scrollOffset));
+  const visibleRows = transcriptRows.slice(clampedOffset, clampedOffset + bodyRows);
+  const lines: RenderLine[] = [{
+    key: "transcript-header",
+    text: padToWidth("transcript  / search  n/N next  [ write scrollback  v editor  Esc return", cols),
+    color: theme.command,
+  }];
+
+  visibleRows.forEach((row, index) => {
+    lines.push({
+      key: `transcript-${clampedOffset + index}`,
+      text: padToWidth(row, cols),
+      backgroundColor:
+        searchQuery.length > 0 && row.toLowerCase().includes(searchQuery.toLowerCase())
+          ? "#3A3A22"
+          : undefined,
+    });
+  });
+
+  while (lines.length < rows - 1) {
+    lines.push({ key: `transcript-filler-${lines.length}`, text: " ".repeat(cols) });
+  }
+
+  lines.push({
+    key: "transcript-footer",
+    text: padToWidth(
+      searchMode
+        ? `/${searchQuery}`
+        : status
+          ? status
+        : `${clampedOffset + 1}-${Math.min(clampedOffset + bodyRows, transcriptRows.length)} / ${transcriptRows.length}`,
+      cols,
+    ),
+    dim: !searchMode && !status,
+    color: searchMode ? theme.command : undefined,
+  });
+
+  return { lines: lines.slice(0, rows), totalRows: transcriptRows.length, maxScrollOffset };
+}
+
+function writeTranscriptToNativeScrollback(messages: ChatMessage[]): void {
+  const transcript = formatTranscript(messages);
+  writeTrustedTuiControl(
+    SHOW_CURSOR +
+      EXIT_ALT_SCREEN +
+      `\n${transcript}\n` +
+      ENTER_ALT_SCREEN +
+      ERASE_SCREEN +
+      CURSOR_HOME +
+      HIDE_CURSOR,
+  );
+}
+
+function openTranscriptInEditor(messages: ChatMessage[]): ClipboardResult {
+  const editor = process.env.VISUAL || process.env.EDITOR;
+  if (!editor) {
+    return { ok: false };
+  }
+
+  const dir = mkdtempSync(path.join(tmpdir(), "pulseed-transcript-"));
+  const filePath = path.join(dir, "transcript.md");
+  writeFileSync(filePath, formatTranscript(messages), "utf8");
+  writeTrustedTuiControl(SHOW_CURSOR + EXIT_ALT_SCREEN);
+  const result = spawnSync(editor, [filePath], { stdio: "inherit", shell: true });
+  writeTrustedTuiControl(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME + HIDE_CURSOR);
+  return result.status === 0 ? { ok: true, method: "osc52" } : { ok: false };
+}
+
 function getCursorPositionFromComposerLayout(
   layout: ComposerLayout,
 ): { x: number; y: number } | null {
@@ -642,9 +939,28 @@ export function buildComposerLines(args: {
   };
 }
 
-function renderMessageRow(row: ChatDisplayRow, cols: number): RenderLine {
+function renderMessageRow(
+  row: ChatDisplayRow,
+  cols: number,
+  rowIndex: number,
+  bodySelection: BodySelectionRange | null,
+): RenderLine {
   if (row.kind === "spacer") {
     return { key: row.key, text: " ".repeat(cols) };
+  }
+
+  const selection = getBodySelectionForRow(bodySelection, rowIndex, row.text.length);
+  if (selection) {
+    const text = padToWidth(row.text, cols);
+    return {
+      key: row.key,
+      segments: applySelectionToTextSegments(text, selection, {
+        color: row.color,
+        backgroundColor: row.backgroundColor,
+        bold: row.bold,
+        dim: row.dim,
+      }),
+    };
   }
 
   return {
@@ -665,6 +981,8 @@ export function buildFullscreenChatRenderLines({
   isProcessing,
   spinnerGlyph,
   spinnerVerb,
+  bodySelection,
+  transcriptStatus,
 }: FullscreenChatRenderLinesInput): RenderLine[] {
   const lines: RenderLine[] = [];
   lines.push({
@@ -676,7 +994,9 @@ export function buildFullscreenChatRenderLines({
     dim: true,
   });
 
-  const renderedRows = viewport.rows.map((row) => renderMessageRow(row, availableCols));
+  const renderedRows = viewport.rows.map((row, index) => (
+    renderMessageRow(row, availableCols, index, bodySelection ?? null)
+  ));
   const fillerCount = Math.max(0, viewport.maxVisibleRows - renderedRows.length);
   for (let index = 0; index < fillerCount; index += 1) {
     lines.push({ key: `filler-${index}`, text: " ".repeat(availableCols) });
@@ -692,9 +1012,9 @@ export function buildFullscreenChatRenderLines({
   });
   lines.push({
     key: "processing",
-    text: padToWidth(isProcessing ? `${spinnerGlyph} ${spinnerVerb}...` : "", availableCols),
+    text: padToWidth(transcriptStatus ?? (isProcessing ? `${spinnerGlyph} ${spinnerVerb}...` : ""), availableCols),
     color: isProcessing ? theme.command : undefined,
-    dim: !isProcessing,
+    dim: !isProcessing && !transcriptStatus,
   });
   lines.push(...composerLines);
 
@@ -762,6 +1082,28 @@ function getMouseOffsetFromComposer(
   return row.endOffset;
 }
 
+function getMousePositionFromBody(
+  rows: ChatDisplayRow[],
+  x: number,
+  y: number,
+  fillerRows: number,
+): BodySelectionPoint | null {
+  const rowIndex = y - 2 - fillerRows;
+  if (rowIndex < 0 || rowIndex >= rows.length) {
+    return null;
+  }
+
+  const row = rows[rowIndex];
+  if (!row || row.kind === "spacer") {
+    return null;
+  }
+
+  return {
+    rowIndex,
+    offset: getDisplayOffsetForText(row.text, x - 1),
+  };
+}
+
 export function FullscreenChat({
   messages,
   onSubmit,
@@ -790,6 +1132,12 @@ export function FullscreenChat({
   const emptyHintTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const [scrollOffset, setScrollOffset] = React.useState(0);
   const [targetScrollOffset, setTargetScrollOffset] = React.useState(0);
+  const [bodySelection, setBodySelection] = React.useState<BodySelectionState | null>(null);
+  const bodySelectionAnchor = React.useRef<BodySelectionPoint | null>(null);
+  const [transcriptMode, setTranscriptMode] = React.useState(false);
+  const [transcriptScrollOffset, setTranscriptScrollOffset] = React.useState(0);
+  const [transcriptSearchQuery, setTranscriptSearchQuery] = React.useState("");
+  const [transcriptSearchMode, setTranscriptSearchMode] = React.useState(false);
   const [spinnerVerb, setSpinnerVerb] = React.useState(() => pickSpinnerVerb());
   const [spinnerFrameIndex, setSpinnerFrameIndex] = React.useState(0);
 
@@ -844,6 +1192,11 @@ export function FullscreenChat({
     setSelection(null);
   }, []);
 
+  const clearBodySelection = useCallback(() => {
+    bodySelectionAnchor.current = null;
+    setBodySelection(null);
+  }, []);
+
   const replaceInputRange = useCallback((
     start: number,
     end: number,
@@ -892,12 +1245,12 @@ export function FullscreenChat({
       return;
     }
 
-    void copySelectedInputText(input, nextSelection).then((copied) => {
-      if (!copied) {
+    void copySelectedInputText(input, nextSelection).then((result) => {
+      if (!result.ok) {
         return;
       }
 
-      setCopyToast(`copied ${selectedText.length} chars to clipboard`);
+      setCopyToast(formatCopyToast(selectedText.length, result));
       setTimeout(() => setCopyToast(null), 2000);
     });
   }, [input]);
@@ -928,6 +1281,17 @@ export function FullscreenChat({
     0,
     viewport.totalRows - viewport.maxVisibleRows,
   );
+  const bodySelectionRange = normalizeBodySelection(bodySelection);
+  const viewportFillerRows = Math.max(0, viewport.maxVisibleRows - viewport.rows.length);
+  const transcript = buildTranscriptRenderLines({
+    messages,
+    cols: availableCols,
+    rows: availableRows,
+    scrollOffset: transcriptScrollOffset,
+    searchQuery: transcriptSearchQuery,
+    searchMode: transcriptSearchMode,
+    status: copyToast,
+  });
   const composerLayout: ComposerLayout = {
     startLine: viewport.maxVisibleRows + 3 + composer.inputRowStartIndex + 1,
     contentStartCol: composer.contentStartCol,
@@ -958,6 +1322,10 @@ export function FullscreenChat({
   }, [maxScrollOffset]);
 
   React.useEffect(() => {
+    setTranscriptScrollOffset((prev) => Math.min(prev, transcript.maxScrollOffset));
+  }, [transcript.maxScrollOffset]);
+
+  React.useEffect(() => {
     if (scrollOffset === targetScrollOffset) {
       return;
     }
@@ -980,15 +1348,45 @@ export function FullscreenChat({
     return () => clearInterval(interval);
   }, [scrollOffset, targetScrollOffset]);
 
-  const applyScroll = useCallback((direction: "up" | "down", kind: "page" | "line") => {
+  const applyScroll = useCallback((direction: "up" | "down", kind: "page" | "line" | "top" | "bottom") => {
     setTargetScrollOffset((prev) => {
+      if (kind === "top") return maxScrollOffset;
+      if (kind === "bottom") return 0;
       const amount = kind === "page" ? viewport.maxVisibleRows : SCROLL_LINE_STEP;
-      const delta = direction === "up" ? amount : -amount;
+      const effectiveAmount = kind === "line" ? amount * getScrollLineStep() : amount;
+      const delta = direction === "up" ? effectiveAmount : -effectiveAmount;
       return Math.max(0, Math.min(maxScrollOffset, prev + delta));
     });
   }, [maxScrollOffset, viewport.maxVisibleRows]);
 
+  const applyTranscriptScroll = useCallback((direction: "up" | "down", kind: "page" | "line" | "top" | "bottom") => {
+    setTranscriptScrollOffset((prev) => {
+      if (kind === "top") return 0;
+      if (kind === "bottom") return transcript.maxScrollOffset;
+      const pageRows = Math.max(1, availableRows - 2);
+      const amount = kind === "page" ? pageRows : getScrollLineStep();
+      const delta = direction === "up" ? -amount : amount;
+      return Math.max(0, Math.min(transcript.maxScrollOffset, prev + delta));
+    });
+  }, [availableRows, transcript.maxScrollOffset]);
+
+  const jumpToTranscriptMatch = useCallback((direction: "next" | "previous") => {
+    if (!transcriptSearchQuery) return;
+    const rows = buildTranscriptRows(messages, availableCols);
+    const query = transcriptSearchQuery.toLowerCase();
+    const matches = rows
+      .map((row, index) => ({ row, index }))
+      .filter(({ row }) => row.toLowerCase().includes(query))
+      .map(({ index }) => index);
+    if (matches.length === 0) return;
+    const current = direction === "next"
+      ? matches.find((index) => index > transcriptScrollOffset)
+      : [...matches].reverse().find((index) => index < transcriptScrollOffset);
+    setTranscriptScrollOffset(current ?? (direction === "next" ? matches[0]! : matches[matches.length - 1]!));
+  }, [availableCols, messages, transcriptScrollOffset, transcriptSearchQuery]);
+
   useInput((inputChar, key) => {
+    if (transcriptMode) return;
     const scrollRequest = getScrollRequest(inputChar, key);
     if (!scrollRequest) return;
     logTuiDebug("fullscreen-chat", "processing-scroll-request", {
@@ -1038,6 +1436,94 @@ export function FullscreenChat({
   }, [clearSelection, hasMatches, isProcessing, onClear, onSubmit]);
 
   useInput((inputChar, key) => {
+    if (key.ctrl && (inputChar === "o" || inputChar === "O")) {
+      setTranscriptMode((prev) => !prev);
+      setTranscriptSearchMode(false);
+      return;
+    }
+
+    if (transcriptMode) {
+      if (transcriptSearchMode) {
+        if (key.escape) {
+          setTranscriptSearchMode(false);
+          return;
+        }
+        if (key.return) {
+          setTranscriptSearchMode(false);
+          jumpToTranscriptMatch("next");
+          return;
+        }
+        if (isBackspaceInput(inputChar, key)) {
+          setTranscriptSearchQuery((prev) => prev.slice(0, -1));
+          return;
+        }
+        if (inputChar && !key.ctrl && !key.meta) {
+          setTranscriptSearchQuery((prev) => prev + inputChar);
+        }
+        return;
+      }
+
+      if (key.escape || inputChar === "q") {
+        setTranscriptMode(false);
+        return;
+      }
+      if (inputChar === "/") {
+        setTranscriptSearchMode(true);
+        setTranscriptSearchQuery("");
+        return;
+      }
+      if (inputChar === "n") {
+        jumpToTranscriptMatch("next");
+        return;
+      }
+      if (inputChar === "N") {
+        jumpToTranscriptMatch("previous");
+        return;
+      }
+      if (inputChar === "[") {
+        writeTranscriptToNativeScrollback(messages);
+        setCopyToast("wrote transcript to terminal scrollback");
+        setTimeout(() => setCopyToast(null), 2000);
+        return;
+      }
+      if (inputChar === "v") {
+        const result = openTranscriptInEditor(messages);
+        setCopyToast(result.ok ? "opened transcript in editor" : "set VISUAL or EDITOR to open transcript");
+        setTimeout(() => setCopyToast(null), 2000);
+        return;
+      }
+      if (inputChar === "g" || key.home) {
+        applyTranscriptScroll("up", "top");
+        return;
+      }
+      if (inputChar === "G" || key.end) {
+        applyTranscriptScroll("down", "bottom");
+        return;
+      }
+      if (inputChar === "j" || key.downArrow) {
+        applyTranscriptScroll("down", "line");
+        return;
+      }
+      if (inputChar === "k" || key.upArrow) {
+        applyTranscriptScroll("up", "line");
+        return;
+      }
+      const transcriptScrollRequest = getScrollRequest(inputChar, key);
+      if (transcriptScrollRequest) {
+        applyTranscriptScroll(transcriptScrollRequest.direction, transcriptScrollRequest.kind);
+        return;
+      }
+      if (inputChar === " " || (key.ctrl && inputChar === "f")) {
+        applyTranscriptScroll("down", "page");
+        return;
+      }
+      if (inputChar === "b" || (key.ctrl && inputChar === "b")) {
+        applyTranscriptScroll("up", "page");
+        return;
+      }
+      return;
+    }
+
     logTuiDebug("fullscreen-chat", "input-event", {
       inputChar,
       key: summarizeKey(key as Record<string, unknown>),
@@ -1060,10 +1546,12 @@ export function FullscreenChat({
 
     const mouseEvent = parseMouseEvent(inputChar);
     if (mouseEvent && mouseEvent.kind !== "wheel" && mouseEvent.button === "left") {
+      const localMouseX = mouseEvent.x - cursorOriginX;
+      const localMouseY = mouseEvent.y - cursorOriginY;
       const offset = getMouseOffsetFromComposer(
         composerLayout,
-        mouseEvent.x,
-        mouseEvent.y,
+        localMouseX,
+        localMouseY,
         mouseEvent.kind !== "press" && selectionAnchor.current !== null,
       );
 
@@ -1089,10 +1577,52 @@ export function FullscreenChat({
         }
         return;
       }
+
+      const bodyPosition = getMousePositionFromBody(
+        viewport.rows,
+        localMouseX,
+        localMouseY,
+        viewportFillerRows,
+      );
+      if (bodyPosition !== null) {
+        clearSelection();
+        if (mouseEvent.kind === "press") {
+          bodySelectionAnchor.current = bodyPosition;
+          setBodySelection({ anchor: bodyPosition, focus: bodyPosition });
+          return;
+        }
+        if (mouseEvent.kind === "drag" && bodySelectionAnchor.current !== null) {
+          setBodySelection({ anchor: bodySelectionAnchor.current, focus: bodyPosition });
+          return;
+        }
+        if (mouseEvent.kind === "release" && bodySelectionAnchor.current !== null) {
+          const nextSelection = { anchor: bodySelectionAnchor.current, focus: bodyPosition };
+          bodySelectionAnchor.current = null;
+          setBodySelection(nextSelection);
+          const selectedText = getSelectedBodyText(viewport.rows, nextSelection);
+          if (selectedText) {
+            void copyToClipboard(selectedText).then((result) => {
+              if (!result.ok) return;
+              setCopyToast(formatCopyToast(selectedText.length, result));
+              setTimeout(() => setCopyToast(null), 2000);
+            });
+          } else {
+            const row = viewport.rows[bodyPosition.rowIndex];
+            const target = row ? extractClickableTargetAt(row.text, bodyPosition.offset) : null;
+            if (target) {
+              const opened = openClickableTarget(target);
+              setCopyToast(opened ? `opened ${target}` : `could not open ${target}`);
+              setTimeout(() => setCopyToast(null), 2000);
+            }
+          }
+          return;
+        }
+      }
     }
 
     if (key.return && key.shift) {
       logTuiDebug("fullscreen-chat", "insert-newline", { cursorOffset });
+      clearBodySelection();
       insertText("\n");
       return;
     }
@@ -1128,6 +1658,7 @@ export function FullscreenChat({
         setCursorOffset(0);
         setCollapsedPaste(null);
         clearSelection();
+        clearBodySelection();
         return;
       }
     }
@@ -1259,6 +1790,7 @@ export function FullscreenChat({
     if (inputChar && !key.ctrl && !key.meta) {
       const clean = normalizeTerminalInputChunk(inputChar);
       if (clean.length === 0) return;
+      clearBodySelection();
       insertText(clean, {
         collapsePaste: shouldCollapsePastedText(inputChar, clean),
       });
@@ -1276,15 +1808,19 @@ export function FullscreenChat({
   }, []);
 
   const spinnerGlyph = PROCESSING_SPINNER_FRAMES[spinnerFrameIndex] ?? PROCESSING_SPINNER_FRAMES[0];
-  const visibleLines = buildFullscreenChatRenderLines({
-    availableCols,
-    availableRows,
-    viewport,
-    composerLines: composer.lines,
-    isProcessing,
-    spinnerGlyph,
-    spinnerVerb,
-  });
+  const visibleLines = transcriptMode
+    ? transcript.lines
+    : buildFullscreenChatRenderLines({
+        availableCols,
+        availableRows,
+        viewport,
+        composerLines: composer.lines,
+        isProcessing,
+        spinnerGlyph,
+        spinnerVerb,
+        bodySelection: bodySelectionRange,
+        transcriptStatus: copyToast,
+      });
 
   return (
     <Box flexDirection="column" flexGrow={1} overflow="hidden">

--- a/src/interface/tui/help-overlay.tsx
+++ b/src/interface/tui/help-overlay.tsx
@@ -100,12 +100,29 @@ export function HelpOverlay({ onDismiss }: HelpOverlayProps) {
             <Box width={20}><Text color={theme.shortcut} bold>Ctrl-C ×2</Text></Box>
             <Text>Quit PulSeed (press twice)</Text>
           </Box>
+          <Box>
+            <Box width={20}><Text color={theme.shortcut} bold>PgUp / PgDn</Text></Box>
+            <Text>Scroll the chat viewport</Text>
+          </Box>
+          <Box>
+            <Box width={20}><Text color={theme.shortcut} bold>Ctrl-Home/End</Text></Box>
+            <Text>Jump to oldest or newest chat row</Text>
+          </Box>
+          <Box>
+            <Box width={20}><Text color={theme.shortcut} bold>Ctrl-O</Text></Box>
+            <Text>Open transcript mode for search and scrollback export</Text>
+          </Box>
+          <Box>
+            <Box width={20}><Text color={theme.shortcut} bold>Mouse drag</Text></Box>
+            <Text>Select and copy text in fullscreen mode</Text>
+          </Box>
 
         </Box>
       </Box>
 
       <Text dimColor>{separator}</Text>
       <Text dimColor>Type naturally to create goals or ask questions.</Text>
+      <Text dimColor>Set PULSEED_DISABLE_MOUSE=1 to keep native terminal mouse selection.</Text>
       <Text dimColor>Press ESC to close</Text>
     </Box>
   );

--- a/src/interface/tui/test-entry.ts
+++ b/src/interface/tui/test-entry.ts
@@ -30,7 +30,7 @@ export async function startTUITest(): Promise<void> {
   logTuiDebug("test-entry", "start", { logPath: getTuiDebugLogPath() });
 
   const noFlicker = await isNoFlickerEnabled();
-  const mouseTrackingEnabled = isMouseTrackingEnabled();
+  const mouseTrackingEnabled = isMouseTrackingEnabled(noFlicker);
   const outputController = noFlicker ? createNoFlickerOutputController() : null;
   outputController?.install();
   let cleanedUp = false;


### PR DESCRIPTION
## Summary
- enable mouse capture by default for no-flicker fullscreen TUI while keeping PULSEED_DISABLE_MOUSE/PULSEED_MOUSE_TRACKING overrides
- add tmux-aware clipboard method reporting, copy toasts, fullscreen body selection/click-to-open, and transcript search/export mode
- extend fullscreen/internal scrolling with Ctrl-Home/Ctrl-End and PULSEED_SCROLL_SPEED

## Verification
- npm run typecheck
- npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/chat.test.ts src/interface/tui/__tests__/clipboard.test.ts src/interface/tui/__tests__/mouse-tracking.test.ts src/interface/tui/__tests__/chat-processing-scroll.test.ts src/interface/tui/__tests__/test-entry.test.ts
- npm run build
- npm run test:changed
- npm run lint:boundaries (passes with existing warnings)