### PR TITLE
Guard broad search roots and tool timeouts

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -35,6 +35,8 @@ import {
   type AgentLoopModelInfo,
   type AgentLoopModelRequest,
   type AgentLoopModelResponse,
+  type AgentLoopToolOutput,
+  type AgentLoopTurnContext,
 } from "../index.js";
 
 class EchoTool implements ITool<{ value: string }> {
@@ -492,6 +494,65 @@ describe("agentloop phase 1", () => {
     expect(result.success).toBe(false);
     expect(result.stopReason).toBe("cancelled");
     expect(executeBatch).not.toHaveBeenCalled();
+  });
+
+  it("bounds native tool execution with the remaining wall-clock budget", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{ id: "call-1", name: "echo", input: { value: "hello" } }],
+        stopReason: "tool_use",
+      },
+      { content: finalJson(), toolCalls: [], stopReason: "end_turn" },
+    ]);
+    const { router } = makeToolRuntime();
+    let capturedTimeoutMs: number | undefined;
+    let capturedSignalAborted = false;
+    const runtime = {
+      executeBatch: vi.fn(async (_calls, turn: AgentLoopTurnContext<unknown>): Promise<AgentLoopToolOutput[]> => {
+        capturedTimeoutMs = turn.toolCallContext.timeoutMs;
+        await new Promise<void>((resolve) => turn.abortSignal?.addEventListener("abort", () => resolve(), { once: true }));
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        capturedSignalAborted = turn.abortSignal?.aborted === true;
+        return [{
+          callId: "call-1",
+          toolName: "echo",
+          success: false,
+          content: "aborted",
+          durationMs: capturedTimeoutMs ?? 0,
+          disposition: "cancelled",
+        }];
+      }),
+    };
+    const runner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+
+    const result = await runner.run({
+      session: createAgentLoopSession(),
+      turnId: "turn-1",
+      goalId: "goal-1",
+      taskId: "task-1",
+      cwd: process.cwd(),
+      model: modelInfo.ref,
+      modelInfo,
+      messages: [{ role: "user", content: "do it" }],
+      outputSchema: z.object({ status: z.literal("done"), finalAnswer: z.string() }),
+      budget: withDefaultBudget({ maxWallClockMs: 150, maxModelTurns: 4 }),
+      toolPolicy: {},
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.stopReason).toBe("timeout");
+    expect(capturedTimeoutMs).toBeGreaterThan(0);
+    expect(capturedTimeoutMs).toBeLessThanOrEqual(150);
+    expect(capturedSignalAborted).toBe(true);
   });
 
   it("falls back to a text protocol when the LLM client cannot use native tools", async () => {

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -306,7 +306,7 @@ export class BoundedAgentLoopRunner {
         });
       }
 
-      const toolResults = await this.deps.toolRuntime.executeBatch(response.toolCalls, turn as AgentLoopTurnContext<unknown>);
+      const { results: toolResults, timedOut: toolBatchTimedOut } = await this.executeToolBatchWithinBudget(response.toolCalls, turn, startedAt);
       for (const result of toolResults) {
         calledTools.add(result.toolName);
         toolCalls++;
@@ -372,7 +372,7 @@ export class BoundedAgentLoopRunner {
           return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         if (result.disposition === "cancelled") {
-          return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, toolBatchTimedOut ? "timeout" : "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         if (consecutiveToolErrors >= turn.budget.maxConsecutiveToolErrors) {
           return this.stop(turn, "consecutive_tool_errors", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
@@ -583,6 +583,44 @@ export class BoundedAgentLoopRunner {
     }
     const contextLimit = turn.modelInfo.capabilities.contextLimitTokens;
     return contextLimit && contextLimit > 0 ? Math.floor(contextLimit * 0.9) : undefined;
+  }
+
+  private async executeToolBatchWithinBudget<TOutput>(
+    calls: Parameters<AgentLoopToolRuntime["executeBatch"]>[0],
+    turn: AgentLoopTurnContext<TOutput>,
+    startedAt: number,
+  ): Promise<{ results: Awaited<ReturnType<AgentLoopToolRuntime["executeBatch"]>>; timedOut: boolean }> {
+    const remainingMs = Math.max(1, turn.budget.maxWallClockMs - (Date.now() - startedAt));
+    const controller = new AbortController();
+    const parentSignal = turn.abortSignal;
+    let timedOut = false;
+    const abortFromParent = () => controller.abort();
+    if (parentSignal?.aborted) {
+      controller.abort();
+    } else {
+      parentSignal?.addEventListener("abort", abortFromParent, { once: true });
+    }
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, remainingMs);
+    const timeoutMs = Math.min(turn.toolCallContext.timeoutMs ?? remainingMs, remainingMs);
+    const boundedTurn = {
+      ...turn,
+      abortSignal: controller.signal,
+      toolCallContext: {
+        ...turn.toolCallContext,
+        abortSignal: controller.signal,
+        timeoutMs,
+      },
+    } as AgentLoopTurnContext<unknown>;
+
+    try {
+      return { results: await this.deps.toolRuntime.executeBatch(calls, boundedTurn), timedOut };
+    } finally {
+      clearTimeout(timer);
+      parentSignal?.removeEventListener("abort", abortFromParent);
+    }
   }
 
   private responseUsageTokens(response: { usage?: { inputTokens: number; outputTokens: number } }): number | undefined {

--- a/src/platform/soil/retriever.ts
+++ b/src/platform/soil/retriever.ts
@@ -35,15 +35,81 @@ export interface SoilQueryHit {
   snippet: string;
 }
 
+export interface SoilScanStats {
+  rootDir: string;
+  scannedDirs: number;
+  matchedFiles: number;
+  maxFiles: number;
+  maxDepth: number;
+  deadlineMs: number;
+  truncated: boolean;
+  reason?: "max_files" | "max_depth" | "deadline";
+}
+
+export interface SoilScanOptions {
+  maxFiles?: number;
+  maxDepth?: number;
+  deadlineMs?: number;
+  ignoredDirectoryNames?: readonly string[];
+}
+
 export interface SoilPageStore {
   listMarkdownFiles(rootDir: string): Promise<string[]>;
   readMarkdownFile(filePath: string): Promise<string>;
+  getLastScanStats?(): SoilScanStats | null;
 }
 
+const DEFAULT_SOIL_SCAN_OPTIONS = {
+  maxFiles: 500,
+  maxDepth: 8,
+  deadlineMs: 5_000,
+  ignoredDirectoryNames: [
+    "node_modules",
+    "dist",
+    "build",
+    "coverage",
+    "tmp",
+    "temp",
+    "vendor",
+    "Library",
+    "Applications",
+    "Downloads",
+    "Movies",
+    "Music",
+    "Pictures",
+  ],
+} satisfies Required<SoilScanOptions>;
+
 export class FileSoilPageStore implements SoilPageStore {
+  private readonly options: Required<SoilScanOptions>;
+  private lastScanStats: SoilScanStats | null = null;
+
+  constructor(options: SoilScanOptions = {}) {
+    this.options = {
+      maxFiles: options.maxFiles ?? DEFAULT_SOIL_SCAN_OPTIONS.maxFiles,
+      maxDepth: options.maxDepth ?? DEFAULT_SOIL_SCAN_OPTIONS.maxDepth,
+      deadlineMs: options.deadlineMs ?? DEFAULT_SOIL_SCAN_OPTIONS.deadlineMs,
+      ignoredDirectoryNames: options.ignoredDirectoryNames ?? DEFAULT_SOIL_SCAN_OPTIONS.ignoredDirectoryNames,
+    };
+  }
+
   async listMarkdownFiles(rootDir: string): Promise<string[]> {
     const files: string[] = [];
-    await this.walk(rootDir, files);
+    const resolvedRoot = path.resolve(rootDir);
+    const startedAt = Date.now();
+    this.lastScanStats = {
+      rootDir: resolvedRoot,
+      scannedDirs: 0,
+      matchedFiles: 0,
+      maxFiles: this.options.maxFiles,
+      maxDepth: this.options.maxDepth,
+      deadlineMs: this.options.deadlineMs,
+      truncated: false,
+    };
+    await this.walk(resolvedRoot, files, 0, startedAt + this.options.deadlineMs);
+    if (this.lastScanStats) {
+      this.lastScanStats.matchedFiles = files.length;
+    }
     return files;
   }
 
@@ -51,20 +117,64 @@ export class FileSoilPageStore implements SoilPageStore {
     return fsp.readFile(filePath, "utf-8");
   }
 
-  private async walk(dir: string, files: string[]): Promise<void> {
+  getLastScanStats(): SoilScanStats | null {
+    return this.lastScanStats;
+  }
+
+  private async walk(dir: string, files: string[], depth: number, deadlineAt: number): Promise<void> {
+    if (this.shouldStop(files, deadlineAt)) {
+      return;
+    }
+    if (depth > this.options.maxDepth) {
+      this.markTruncated("max_depth");
+      return;
+    }
+    this.lastScanStats!.scannedDirs += 1;
     const entries = await fsp.readdir(dir, { withFileTypes: true }).catch(() => []);
     for (const entry of entries) {
-      if (entry.name.startsWith(".")) {
+      if (this.shouldStop(files, deadlineAt)) {
+        return;
+      }
+      if (entry.name.startsWith(".") || this.options.ignoredDirectoryNames.includes(entry.name)) {
         continue;
       }
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        await this.walk(fullPath, files);
+        await this.walk(fullPath, files, depth + 1, deadlineAt);
         continue;
       }
       if (entry.isFile() && entry.name.endsWith(".md")) {
         files.push(fullPath);
+        if (files.length >= this.options.maxFiles) {
+          this.markTruncated("max_files");
+          return;
+        }
       }
+    }
+  }
+
+  private shouldStop(files: string[], deadlineAt: number): boolean {
+    if (files.length >= this.options.maxFiles) {
+      this.markTruncated("max_files");
+      return true;
+    }
+    if (Date.now() >= deadlineAt) {
+      this.markTruncated("deadline");
+      return true;
+    }
+    return false;
+  }
+
+  private markTruncated(reason: SoilScanStats["reason"]): void {
+    if (!this.lastScanStats) {
+      return;
+    }
+    if (!this.lastScanStats.truncated) {
+      this.lastScanStats = {
+        ...this.lastScanStats,
+        truncated: true,
+        ...(reason ? { reason } : {}),
+      };
     }
   }
 }
@@ -74,6 +184,7 @@ export interface SoilManifest {
   pages: SoilPageRecord[];
   bySoilId: Map<string, SoilPageRecord[]>;
   byRelativePath: Map<string, SoilPageRecord>;
+  scan?: SoilScanStats;
 }
 
 export async function loadSoilManifest(
@@ -123,7 +234,8 @@ export async function loadSoilManifest(
     byRelativePath.set(relativePath, record);
   }
 
-  return { rootDir: config.rootDir, pages, bySoilId, byRelativePath };
+  const scan = store.getLastScanStats?.() ?? undefined;
+  return { rootDir: config.rootDir, pages, bySoilId, byRelativePath, ...(scan ? { scan } : {}) };
 }
 
 function buildSearchText(frontmatter: SoilPageFrontmatter, body: string): string {
@@ -260,6 +372,10 @@ export class SoilRetriever {
   async list(): Promise<SoilPageRecord[]> {
     const manifest = await this.getManifest();
     return [...manifest.pages];
+  }
+
+  getLastScanStats(): SoilScanStats | null {
+    return this.manifest?.scan ?? this.store.getLastScanStats?.() ?? null;
   }
 
   async getBySoilId(soilId: string): Promise<SoilPageRecord | null> {

--- a/src/platform/soil/sqlite-repository.ts
+++ b/src/platform/soil/sqlite-repository.ts
@@ -463,6 +463,19 @@ export class SqliteSoilRepository implements SoilRepository {
     return new SqliteSoilRepository(db, indexPath);
   }
 
+  static async openExisting(configInput: SoilConfigInput = {}): Promise<SqliteSoilRepository | null> {
+    const rootDir = resolveSoilRootDir(configInput.rootDir);
+    const indexPath = configInput.indexPath ? path.resolve(configInput.indexPath) : getDefaultSoilSqliteIndexPath(rootDir);
+    try {
+      await fsp.access(indexPath);
+    } catch {
+      return null;
+    }
+    const db = new Database(indexPath, { readonly: true, fileMustExist: true });
+    db.pragma("query_only = ON");
+    return new SqliteSoilRepository(db, indexPath);
+  }
+
   close(): void {
     this.db.close();
   }

--- a/src/tools/query/CodeSearchRepairTool/CodeSearchRepairTool.ts
+++ b/src/tools/query/CodeSearchRepairTool/CodeSearchRepairTool.ts
@@ -3,6 +3,7 @@ import { SearchOrchestrator } from "../../../platform/code-search/orchestrator.j
 import { parseVerificationSignal } from "../../../platform/code-search/verification-retrieval.js";
 import { validateFilePath } from "../../fs/FileValidationTool/FileValidationTool.js";
 import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../types.js";
+import { resolveCodeSearchRoot } from "../code-search-root.js";
 import { MAX_OUTPUT_CHARS, PERMISSION_LEVEL, READ_ONLY, TAGS } from "./constants.js";
 import { DESCRIPTION } from "./prompt.js";
 
@@ -44,7 +45,18 @@ export class CodeSearchRepairTool implements ITool<CodeSearchRepairInput, unknow
 
   async call(input: CodeSearchRepairInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
-    const cwd = input.path ? validateFilePath(input.path, context.cwd).resolved : context.cwd;
+    let cwd: string;
+    try {
+      cwd = resolveCodeSearchRoot(input, context, "code_search_repair");
+    } catch (err) {
+      return {
+        success: false,
+        data: { candidates: [], focusedTestSuggestions: [], warnings: [(err as Error).message] },
+        summary: `Repair code search failed: ${(err as Error).message}`,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
     const signal = parseVerificationSignal(input.verificationOutput);
     const orchestrator = new SearchOrchestrator(cwd);
     const prior = {
@@ -89,7 +101,13 @@ export class CodeSearchRepairTool implements ITool<CodeSearchRepairInput, unknow
   }
 
   async checkPermissions(input: CodeSearchRepairInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
-    if (!context || !input.path) return { status: "allowed" };
+    if (!context) return { status: "allowed" };
+    try {
+      resolveCodeSearchRoot(input, context, "code_search_repair");
+    } catch (err) {
+      return { status: "denied", reason: (err as Error).message };
+    }
+    if (!input.path) return { status: "allowed" };
     const validation = validateFilePath(input.path, context.cwd, context.executionPolicy?.protectedPaths);
     if (!validation.valid) {
       return { status: "needs_approval", reason: `Searching outside the working directory: ${validation.resolved}` };

--- a/src/tools/query/CodeSearchTool/CodeSearchTool.ts
+++ b/src/tools/query/CodeSearchTool/CodeSearchTool.ts
@@ -1,3 +1,6 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { z } from "zod";
 import { SearchOrchestrator } from "../../../platform/code-search/orchestrator.js";
 import type { RankedCandidate } from "../../../platform/code-search/contracts.js";
@@ -43,6 +46,41 @@ function compactCandidate(candidate: RankedCandidate): Record<string, unknown> {
   };
 }
 
+function isBroadRoot(root: string): boolean {
+  const resolved = path.resolve(root);
+  const homeDir = path.resolve(os.homedir());
+  return resolved === path.parse(resolved).root || resolved === path.dirname(homeDir) || resolved === homeDir;
+}
+
+function findProjectRoot(cwd: string): string | null {
+  let current = path.resolve(cwd);
+  while (true) {
+    if (fs.existsSync(path.join(current, ".git")) || fs.existsSync(path.join(current, "package.json"))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+function resolveSearchRoot(input: CodeSearchInput, context: ToolCallContext): string {
+  if (input.path) {
+    return validateFilePath(input.path, context.cwd).resolved;
+  }
+  const projectRoot = findProjectRoot(context.cwd);
+  if (projectRoot && !isBroadRoot(projectRoot)) {
+    return projectRoot;
+  }
+  const resolvedCwd = path.resolve(context.cwd);
+  if (isBroadRoot(resolvedCwd)) {
+    throw new Error(`code_search requires a project working directory or an explicit path; refused broad root "${resolvedCwd}".`);
+  }
+  throw new Error(`code_search requires a project working directory or an explicit path; no project root found from "${resolvedCwd}".`);
+}
+
 export class CodeSearchTool implements ITool<CodeSearchInput, unknown> {
   readonly metadata: ToolMetadata = {
     name: "code_search",
@@ -64,7 +102,18 @@ export class CodeSearchTool implements ITool<CodeSearchInput, unknown> {
 
   async call(input: CodeSearchInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
-    const cwd = input.path ? validateFilePath(input.path, context.cwd).resolved : context.cwd;
+    let cwd: string;
+    try {
+      cwd = resolveSearchRoot(input, context);
+    } catch (err) {
+      return {
+        success: false,
+        data: { candidates: [], candidateIds: [], totalCandidates: 0, warnings: [(err as Error).message] },
+        summary: `Code search failed: ${(err as Error).message}`,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
     const orchestrator = new SearchOrchestrator(cwd);
     const session = await orchestrator.searchWithState({ ...input, cwd });
     saveCodeSearchSession(session, cwd);
@@ -89,7 +138,15 @@ export class CodeSearchTool implements ITool<CodeSearchInput, unknown> {
   }
 
   async checkPermissions(input: CodeSearchInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
-    if (!context || !input.path) return { status: "allowed" };
+    if (!context) return { status: "allowed" };
+    if (!input.path) {
+      try {
+        resolveSearchRoot(input, context);
+      } catch (err) {
+        return { status: "denied", reason: (err as Error).message };
+      }
+      return { status: "allowed" };
+    }
     const validation = validateFilePath(input.path, context.cwd, context.executionPolicy?.protectedPaths);
     if (!validation.valid) {
       return { status: "needs_approval", reason: `Searching outside the working directory: ${validation.resolved}` };

--- a/src/tools/query/CodeSearchTool/CodeSearchTool.ts
+++ b/src/tools/query/CodeSearchTool/CodeSearchTool.ts
@@ -68,7 +68,11 @@ function findProjectRoot(cwd: string): string | null {
 
 function resolveSearchRoot(input: CodeSearchInput, context: ToolCallContext): string {
   if (input.path) {
-    return validateFilePath(input.path, context.cwd).resolved;
+    const resolvedPath = validateFilePath(input.path, context.cwd).resolved;
+    if (isBroadRoot(resolvedPath)) {
+      throw new Error(`code_search refused broad explicit path "${resolvedPath}".`);
+    }
+    return resolvedPath;
   }
   const projectRoot = findProjectRoot(context.cwd);
   if (projectRoot && !isBroadRoot(projectRoot)) {
@@ -139,12 +143,12 @@ export class CodeSearchTool implements ITool<CodeSearchInput, unknown> {
 
   async checkPermissions(input: CodeSearchInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
     if (!context) return { status: "allowed" };
+    try {
+      resolveSearchRoot(input, context);
+    } catch (err) {
+      return { status: "denied", reason: (err as Error).message };
+    }
     if (!input.path) {
-      try {
-        resolveSearchRoot(input, context);
-      } catch (err) {
-        return { status: "denied", reason: (err as Error).message };
-      }
       return { status: "allowed" };
     }
     const validation = validateFilePath(input.path, context.cwd, context.executionPolicy?.protectedPaths);

--- a/src/tools/query/CodeSearchTool/CodeSearchTool.ts
+++ b/src/tools/query/CodeSearchTool/CodeSearchTool.ts
@@ -1,12 +1,10 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
 import { z } from "zod";
 import { SearchOrchestrator } from "../../../platform/code-search/orchestrator.js";
 import type { RankedCandidate } from "../../../platform/code-search/contracts.js";
 import { saveCodeSearchSession } from "../../../platform/code-search/session-store.js";
 import { validateFilePath } from "../../fs/FileValidationTool/FileValidationTool.js";
 import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../types.js";
+import { resolveCodeSearchRoot } from "../code-search-root.js";
 import { MAX_OUTPUT_CHARS, PERMISSION_LEVEL, READ_ONLY, TAGS } from "./constants.js";
 import { DESCRIPTION } from "./prompt.js";
 
@@ -46,45 +44,6 @@ function compactCandidate(candidate: RankedCandidate): Record<string, unknown> {
   };
 }
 
-function isBroadRoot(root: string): boolean {
-  const resolved = path.resolve(root);
-  const homeDir = path.resolve(os.homedir());
-  return resolved === path.parse(resolved).root || resolved === path.dirname(homeDir) || resolved === homeDir;
-}
-
-function findProjectRoot(cwd: string): string | null {
-  let current = path.resolve(cwd);
-  while (true) {
-    if (fs.existsSync(path.join(current, ".git")) || fs.existsSync(path.join(current, "package.json"))) {
-      return current;
-    }
-    const parent = path.dirname(current);
-    if (parent === current) {
-      return null;
-    }
-    current = parent;
-  }
-}
-
-function resolveSearchRoot(input: CodeSearchInput, context: ToolCallContext): string {
-  if (input.path) {
-    const resolvedPath = validateFilePath(input.path, context.cwd).resolved;
-    if (isBroadRoot(resolvedPath)) {
-      throw new Error(`code_search refused broad explicit path "${resolvedPath}".`);
-    }
-    return resolvedPath;
-  }
-  const projectRoot = findProjectRoot(context.cwd);
-  if (projectRoot && !isBroadRoot(projectRoot)) {
-    return projectRoot;
-  }
-  const resolvedCwd = path.resolve(context.cwd);
-  if (isBroadRoot(resolvedCwd)) {
-    throw new Error(`code_search requires a project working directory or an explicit path; refused broad root "${resolvedCwd}".`);
-  }
-  throw new Error(`code_search requires a project working directory or an explicit path; no project root found from "${resolvedCwd}".`);
-}
-
 export class CodeSearchTool implements ITool<CodeSearchInput, unknown> {
   readonly metadata: ToolMetadata = {
     name: "code_search",
@@ -108,7 +67,7 @@ export class CodeSearchTool implements ITool<CodeSearchInput, unknown> {
     const startTime = Date.now();
     let cwd: string;
     try {
-      cwd = resolveSearchRoot(input, context);
+      cwd = resolveCodeSearchRoot(input, context, "code_search");
     } catch (err) {
       return {
         success: false,
@@ -144,7 +103,7 @@ export class CodeSearchTool implements ITool<CodeSearchInput, unknown> {
   async checkPermissions(input: CodeSearchInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
     if (!context) return { status: "allowed" };
     try {
-      resolveSearchRoot(input, context);
+      resolveCodeSearchRoot(input, context, "code_search");
     } catch (err) {
       return { status: "denied", reason: (err as Error).message };
     }

--- a/src/tools/query/CodeSearchTool/__tests__/CodeSearchTool.test.ts
+++ b/src/tools/query/CodeSearchTool/__tests__/CodeSearchTool.test.ts
@@ -126,6 +126,28 @@ describe("code search tools", () => {
     expect((read.data as { ranges: Array<{ file: string }> }).ranges[0].file).toBe("src/alpha.ts");
   });
 
+  it("refuses to default-search the home directory", async () => {
+    const result = await new CodeSearchTool().call(
+      { task: "find alphaValue", intent: "explain" },
+      { ...context, cwd: os.homedir() },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("refused broad root");
+  });
+
+  it("defaults nested package searches to the project root", async () => {
+    const nested = path.join(root, "src");
+    const result = await new CodeSearchTool().call(
+      { task: "find alphaValue", intent: "explain" },
+      { ...context, cwd: nested },
+    );
+
+    expect(result.success).toBe(true);
+    const data = result.data as { candidates: Array<{ file: string }> };
+    expect(data.candidates[0]?.file).toBe("src/alpha.ts");
+  });
+
   it("code_search_repair parses verification output and suggests candidates", async () => {
     const result = await new CodeSearchRepairTool().call({
       priorTask: { task: "fix alphaValue", intent: "bugfix" },

--- a/src/tools/query/CodeSearchTool/__tests__/CodeSearchTool.test.ts
+++ b/src/tools/query/CodeSearchTool/__tests__/CodeSearchTool.test.ts
@@ -136,6 +136,32 @@ describe("code search tools", () => {
     expect(result.error).toContain("refused broad root");
   });
 
+  it("refuses explicit broad paths before permission approval can allow them", async () => {
+    const tool = new CodeSearchTool();
+    const permission = await tool.checkPermissions(
+      { task: "find alphaValue", intent: "explain", path: os.homedir() },
+      context,
+    );
+    expect(permission).toMatchObject({ status: "denied" });
+
+    const registry = new ToolRegistry();
+    registry.register(tool);
+    const executor = new ToolExecutor({
+      registry,
+      permissionManager: new ToolPermissionManager({}),
+      concurrency: new ConcurrencyController(),
+    });
+
+    const result = await executor.execute("code_search", {
+      task: "find alphaValue",
+      intent: "explain",
+      path: os.homedir(),
+    }, context);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("refused broad explicit path");
+  });
+
   it("defaults nested package searches to the project root", async () => {
     const nested = path.join(root, "src");
     const result = await new CodeSearchTool().call(

--- a/src/tools/query/CodeSearchTool/__tests__/CodeSearchTool.test.ts
+++ b/src/tools/query/CodeSearchTool/__tests__/CodeSearchTool.test.ts
@@ -184,4 +184,37 @@ describe("code search tools", () => {
     expect((result.data as { signal: { kind: string }; candidates: unknown[] }).signal.kind).toBe("undefined_symbol");
     expect((result.data as { candidates: unknown[] }).candidates.length).toBeGreaterThan(0);
   });
+
+  it("code_search_repair refuses broad explicit and implicit roots through the executor", async () => {
+    const repair = new CodeSearchRepairTool();
+    const permission = await repair.checkPermissions({
+      priorTask: { task: "fix alphaValue", intent: "bugfix" },
+      verificationOutput: "ReferenceError: alphaValue is not defined\n    at src/alpha.ts:1:1",
+      path: os.homedir(),
+    }, context);
+    expect(permission).toMatchObject({ status: "denied" });
+
+    const registry = new ToolRegistry();
+    registry.register(repair);
+    const executor = new ToolExecutor({
+      registry,
+      permissionManager: new ToolPermissionManager({}),
+      concurrency: new ConcurrencyController(),
+    });
+
+    const explicit = await executor.execute("code_search_repair", {
+      priorTask: { task: "fix alphaValue", intent: "bugfix" },
+      verificationOutput: "ReferenceError: alphaValue is not defined\n    at src/alpha.ts:1:1",
+      path: os.homedir(),
+    }, context);
+    expect(explicit.success).toBe(false);
+    expect(explicit.error).toContain("refused broad explicit path");
+
+    const implicit = await repair.call({
+      priorTask: { task: "fix alphaValue", intent: "bugfix" },
+      verificationOutput: "ReferenceError: alphaValue is not defined\n    at src/alpha.ts:1:1",
+    }, { ...context, cwd: os.homedir() });
+    expect(implicit.success).toBe(false);
+    expect(implicit.error).toContain("refused broad root");
+  });
 });

--- a/src/tools/query/SoilQueryTool/SoilQueryTool.ts
+++ b/src/tools/query/SoilQueryTool/SoilQueryTool.ts
@@ -1,3 +1,5 @@
+import * as os from "node:os";
+import * as path from "node:path";
 import { z } from "zod";
 import type {
   ITool,
@@ -17,7 +19,7 @@ import {
 } from "../../../platform/soil/index.js";
 import { DESCRIPTION } from "./prompt.js";
 import { ALIASES, MAX_OUTPUT_CHARS, PERMISSION_LEVEL, READ_ONLY, TAGS, TOOL_NAME } from "./constants.js";
-import type { SoilPageRecord, SoilQueryHit } from "../../../platform/soil/retriever.js";
+import type { SoilPageRecord, SoilQueryHit, SoilScanStats } from "../../../platform/soil/retriever.js";
 import type { SoilCandidate, SoilPage } from "../../../platform/soil/contracts.js";
 import {
   OllamaEmbeddingClient,
@@ -223,6 +225,37 @@ function dedupeByKey<T>(records: T[], keyFn: (record: T) => string): T[] {
   return deduped;
 }
 
+function isUnsafeBroadRoot(rootDir: string): boolean {
+  const resolved = path.resolve(rootDir);
+  const homeDir = path.resolve(os.homedir());
+  const homeParent = path.dirname(homeDir);
+  const filesystemRoot = path.parse(homeDir).root;
+  return resolved === filesystemRoot || resolved === homeParent || resolved === homeDir;
+}
+
+function resolveSoilQueryRoot(input: SoilQueryInput, warnings: string[]): string {
+  const defaultRoot = createSoilConfig().rootDir;
+  if (!input.rootDir) {
+    return defaultRoot;
+  }
+  const requestedRoot = path.resolve(input.rootDir);
+  if (!isUnsafeBroadRoot(requestedRoot)) {
+    return requestedRoot;
+  }
+  warnings.push(`Ignored unsafe Soil rootDir "${requestedRoot}"; using default Soil root "${defaultRoot}".`);
+  return defaultRoot;
+}
+
+function appendScanWarnings(warnings: string[], scan: SoilScanStats | null): void {
+  if (!scan?.truncated) {
+    return;
+  }
+  const reason = scan.reason ?? "scan_limit";
+  warnings.push(
+    `Soil manifest scan stopped early (${reason}; matched ${scan.matchedFiles}/${scan.maxFiles} Markdown files, scanned ${scan.scannedDirs} dirs).`
+  );
+}
+
 export class SoilQueryTool implements ITool<SoilQueryInput, SoilQueryOutput> {
   private readonly queryEmbedding: QueryEmbeddingConfig | null;
 
@@ -259,35 +292,37 @@ export class SoilQueryTool implements ITool<SoilQueryInput, SoilQueryOutput> {
 
     try {
       const parsedInput = this.inputSchema.parse(input);
-      const retriever = SoilRetriever.create({ rootDir: parsedInput.rootDir });
-      const config = createSoilConfig({ rootDir: parsedInput.rootDir });
+      const warnings: string[] = [];
+      const effectiveRootDir = resolveSoilQueryRoot(parsedInput, warnings);
+      const effectiveInput = { ...parsedInput, rootDir: effectiveRootDir };
+      const retriever = SoilRetriever.create({ rootDir: effectiveRootDir });
+      const config = createSoilConfig({ rootDir: effectiveRootDir });
       const pages: SoilQueryPageItem[] = [];
       const hits: SoilQueryHitItem[] = [];
       let retrievalSource: SoilQueryOutput["retrievalSource"] = "manifest";
-      const warnings: string[] = [];
 
       if (parsedInput.soil_id || parsedInput.path) {
-        const directRecords = await this.lookupDirectRecords(retriever, parsedInput);
+        const directRecords = await this.lookupDirectRecords(retriever, effectiveInput);
         for (const record of directRecords) {
           pages.push(toDirectItem(record));
         }
       }
 
       if (parsedInput.query) {
-        const sqliteResult = await this.querySqlite(parsedInput);
+        const sqliteResult = await this.querySqlite(effectiveInput);
         warnings.push(...sqliteResult.warnings);
         if (sqliteResult.hits.length > 0) {
           retrievalSource = "sqlite";
           hits.push(...sqliteResult.hits);
         }
 
-        const indexSnapshot = hits.length === 0 ? await loadSoilIndexSnapshot({ rootDir: parsedInput.rootDir }) : null;
+        const indexSnapshot = hits.length === 0 ? await loadSoilIndexSnapshot({ rootDir: effectiveRootDir }) : null;
         const freshness = indexSnapshot
-          ? await checkSoilIndexFresh({ rootDir: parsedInput.rootDir })
+          ? await checkSoilIndexFresh({ rootDir: effectiveRootDir })
           : null;
         if (hits.length === 0 && indexSnapshot && freshness?.fresh) {
           retrievalSource = "index";
-          const queried = await querySoilIndexSnapshot(parsedInput.query, parsedInput.limit, { rootDir: parsedInput.rootDir });
+          const queried = await querySoilIndexSnapshot(parsedInput.query, parsedInput.limit, { rootDir: effectiveRootDir });
           for (const hit of queried) {
             hits.push(toIndexHitItem(hit));
           }
@@ -308,6 +343,7 @@ export class SoilQueryTool implements ITool<SoilQueryInput, SoilQueryOutput> {
           pages.push(toSummaryItem(record));
         }
       }
+      appendScanWarnings(warnings, retriever.getLastScanStats());
 
       const dedupedPages = dedupeByKey(pages, (record) => `${record.soilId}:${record.relativePath}`);
       const output: SoilQueryOutput = {
@@ -387,7 +423,10 @@ export class SoilQueryTool implements ITool<SoilQueryInput, SoilQueryOutput> {
     let repository: SqliteSoilRepository | null = null;
     const warnings: string[] = [];
     try {
-      repository = await SqliteSoilRepository.create({ rootDir: input.rootDir });
+      repository = await SqliteSoilRepository.openExisting({ rootDir: input.rootDir });
+      if (!repository) {
+        return { hits: [], warnings };
+      }
       const embedding = await this.embedQuery(input.query);
       if (embedding.warning) {
         warnings.push(embedding.warning);

--- a/src/tools/query/SoilQueryTool/__tests__/SoilQueryTool.test.ts
+++ b/src/tools/query/SoilQueryTool/__tests__/SoilQueryTool.test.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import * as fsp from "node:fs/promises";
+import * as os from "node:os";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SoilCompiler } from "../../../../platform/soil/compiler.js";
 import { rebuildSoilIndex } from "../../../../platform/soil/index-store.js";
@@ -252,6 +253,24 @@ describe("SoilQueryTool", () => {
       expect(data.hits).toHaveLength(1);
       expect(data.hits[0].score).toBeGreaterThan(0);
       expect(data.pages).toHaveLength(0);
+    });
+
+    it("does not create a SQLite index while querying an unindexed root", async () => {
+      const result = await tool.call({ query: "missing", limit: 10, rootDir }, makeContext());
+
+      expect(result.success).toBe(true);
+      await expect(fsp.access(path.join(rootDir, ".index", "soil.sqlite"))).rejects.toThrow();
+    });
+
+    it("ignores unsafe broad home roots from model input", async () => {
+      const homeDir = os.homedir();
+
+      const result = await tool.call({ query: "missing", limit: 10, rootDir: homeDir }, makeContext());
+
+      expect(result.success).toBe(true);
+      const data = result.data as { rootDir: string; warnings: string[] };
+      expect(path.resolve(data.rootDir)).not.toBe(path.resolve(homeDir));
+      expect(data.warnings[0]).toContain("Ignored unsafe Soil rootDir");
     });
 
     it("uses SQLite retrieval when the SQLite soil index has hits", async () => {

--- a/src/tools/query/code-search-root.ts
+++ b/src/tools/query/code-search-root.ts
@@ -1,0 +1,52 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { validateFilePath } from "../fs/FileValidationTool/FileValidationTool.js";
+import type { ToolCallContext } from "../types.js";
+
+export interface CodeSearchRootInput {
+  path?: string;
+}
+
+export function isBroadCodeSearchRoot(root: string): boolean {
+  const resolved = path.resolve(root);
+  const homeDir = path.resolve(os.homedir());
+  return resolved === path.parse(resolved).root || resolved === path.dirname(homeDir) || resolved === homeDir;
+}
+
+export function findCodeSearchProjectRoot(cwd: string): string | null {
+  let current = path.resolve(cwd);
+  while (true) {
+    if (fs.existsSync(path.join(current, ".git")) || fs.existsSync(path.join(current, "package.json"))) {
+      return current;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return null;
+    }
+    current = parent;
+  }
+}
+
+export function resolveCodeSearchRoot(
+  input: CodeSearchRootInput,
+  context: ToolCallContext,
+  toolName: string,
+): string {
+  if (input.path) {
+    const resolvedPath = validateFilePath(input.path, context.cwd).resolved;
+    if (isBroadCodeSearchRoot(resolvedPath)) {
+      throw new Error(`${toolName} refused broad explicit path "${resolvedPath}".`);
+    }
+    return resolvedPath;
+  }
+  const projectRoot = findCodeSearchProjectRoot(context.cwd);
+  if (projectRoot && !isBroadCodeSearchRoot(projectRoot)) {
+    return projectRoot;
+  }
+  const resolvedCwd = path.resolve(context.cwd);
+  if (isBroadCodeSearchRoot(resolvedCwd)) {
+    throw new Error(`${toolName} requires a project working directory or an explicit path; refused broad root "${resolvedCwd}".`);
+  }
+  throw new Error(`${toolName} requires a project working directory or an explicit path; no project root found from "${resolvedCwd}".`);
+}


### PR DESCRIPTION
## Summary
- keep soil_query read-only for SQLite lookups and ignore broad home/root soil roots
- bound Soil Markdown fallback scans with file/depth/deadline guards and warnings
- constrain code_search implicit roots to project roots and pass wall-clock budget into native tool batches

## Tests
- npx vitest run --config vitest.unit.config.ts src/tools/query/SoilQueryTool/__tests__/SoilQueryTool.test.ts
- npx vitest run --config vitest.unit.config.ts src/tools/query/CodeSearchTool/__tests__/CodeSearchTool.test.ts
- npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
- npm run typecheck
- npm run test:changed
- git diff --check