### PR TITLE
Fix Kaggle workspace and tilde cwd smoke blockers

### DIFF
--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -429,7 +429,7 @@ export class ChatRunner {
   startSessionFromLoadedSession(session: LoadedChatSession): void {
     const chatSession = this.loadedSessionToChatSession(session);
     this.history = ChatHistory.fromSession(this.deps.stateManager, chatSession);
-    this.sessionCwd = session.cwd;
+    this.sessionCwd = resolveGitRoot(session.cwd);
     this.sessionActive = true;
     this.nativeAgentLoopStatePath = session.agentLoopStatePath ?? `chat/agentloop/${session.id}.state.json`;
     this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
@@ -1676,7 +1676,7 @@ export class ChatRunner {
       title: title || (baseSession.title ? `${baseSession.title} (fork)` : "Forked session"),
     };
     this.history = ChatHistory.fromSession(this.deps.stateManager, forkedSession);
-    this.sessionCwd = cwd;
+    this.sessionCwd = resolveGitRoot(cwd);
     this.sessionActive = true;
     this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
     this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
@@ -1873,14 +1873,15 @@ export class ChatRunner {
     options: ChatRunnerExecutionOptions = {}
   ): Promise<ChatRunResult> {
     const eventContext = this.createEventContext();
-    const activeTurn = this.beginActiveTurn(eventContext, resolveGitRoot(cwd));
+    const resolvedCwd = resolveGitRoot(cwd);
+    const activeTurn = this.beginActiveTurn(eventContext, resolvedCwd);
     const resumeCommand = this.parseResumeCommand(input);
     const resumeOnly = resumeCommand !== null;
     const runtimeControlContext = options.runtimeControlContext ?? this.runtimeControlContext;
     const executionGoalId = options.goalId ?? this.deps.goalId;
 
     // Intercept commands before any adapter call
-    const commandResult = resumeOnly ? null : await this.handleCommand(input, cwd);
+    const commandResult = resumeOnly ? null : await this.handleCommand(input, resolvedCwd);
     if (commandResult !== null) {
       if (commandResult.output) {
         this.emitEvent({
@@ -1960,14 +1961,14 @@ export class ChatRunner {
 
     // Reuse session (interactive mode) or create a fresh one per call (1-shot mode)
     if (!this.sessionActive) {
-      const gitRoot = resolveGitRoot(cwd);
+      const gitRoot = resolvedCwd;
       const sessionId = crypto.randomUUID();
       this.history = new ChatHistory(this.deps.stateManager, sessionId, gitRoot);
       this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
       this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
     }
-    const executionCwd = this.sessionCwd ?? cwd;
-    const gitRoot = this.sessionCwd ?? resolveGitRoot(cwd);
+    const executionCwd = this.sessionCwd ?? resolvedCwd;
+    const gitRoot = this.sessionCwd ?? resolvedCwd;
     activeTurn.cwd = gitRoot;
 
     // history is always assigned by this point (either by startSession or the block above)

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -16,6 +16,7 @@ import { buildAdapterRegistry, buildLLMClient } from "../../base/llm/provider-fa
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
 import { TrustManager } from "../../platform/traits/trust-manager.js";
 import { ObservationEngine } from "../../platform/observation/observation-engine.js";
+import { resolveGitRoot } from "../../platform/observation/context-provider.js";
 import { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
 import { GoalDependencyGraph } from "../../orchestrator/goal/goal-dependency-graph.js";
 import { SessionManager } from "../../orchestrator/execution/session-manager.js";
@@ -469,7 +470,7 @@ export class CrossPlatformChatSessionManager {
       return existing;
     }
 
-    const cwd = cwdOverride?.trim() || process.cwd();
+    const cwd = resolveGitRoot(cwdOverride?.trim() || process.cwd());
     const runner = new ChatRunner(this.deps);
     runner.startSession(cwd);
 

--- a/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import * as os from "node:os";
 import { z } from "zod";
 import { ChatAgentLoopRunner } from "../chat-agent-loop-runner.js";
 import { buildAgentLoopBaseInstructions, buildChatStructuredOutputInstructions } from "../agent-loop-prompts.js";
@@ -66,6 +67,17 @@ describe("chat agentloop final-answer contract", () => {
     expect(result.structuredOutput).toBeUndefined();
     expect(boundedRunner.run).toHaveBeenCalledWith(expect.objectContaining({
       finalOutputMode: "display_text",
+    }));
+  });
+
+  it("expands tilde cwd before building the turn context", async () => {
+    const { runner, boundedRunner } = makeRunner(null, "ok");
+
+    await runner.execute({ message: "test", cwd: "~" });
+
+    expect(boundedRunner.run).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: os.homedir(),
+      toolCallContext: expect.objectContaining({ cwd: os.homedir() }),
     }));
   });
 

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -18,6 +18,7 @@ import { buildAgentLoopBaseInstructions, buildChatStructuredOutputInstructions }
 import type { ApprovalRequest, ToolCallContext } from "../../../tools/types.js";
 import type { ExecutionPolicy, SubagentRole } from "./execution-policy.js";
 import { normalizeAssistantDisplayText } from "./chat-display-output.js";
+import { resolveGitRoot } from "../../../platform/observation/context-provider.js";
 
 const ChatAgentLoopFinalAnswerSectionSchema = z.object({
   title: z.string(),
@@ -114,7 +115,7 @@ export class ChatAgentLoopRunner {
     const started = Date.now();
     const model = input.model ?? this.deps.defaultModel ?? await this.deps.modelRegistry.defaultModel();
     const modelInfo = await this.deps.modelClient.getModelInfo(model);
-    const cwd = input.cwd ?? this.deps.cwd ?? process.cwd();
+    const cwd = resolveGitRoot(input.cwd ?? this.deps.cwd ?? process.cwd());
     const turnId = randomUUID();
     const outputMode = input.outputMode ?? { kind: "display_text" as const };
     const outputSchema: z.ZodType<unknown, z.ZodTypeDef, unknown> = outputMode.kind === "structured"

--- a/src/platform/observation/context-provider.ts
+++ b/src/platform/observation/context-provider.ts
@@ -1,8 +1,9 @@
 import { execFile } from "node:child_process";
 import { accessSync } from "fs";
+import { homedir } from "node:os";
 import { promisify } from "node:util";
 import { readFile } from "fs/promises";
-import { join, dirname } from "path";
+import { join, dirname, resolve } from "path";
 import type { MemoryTier } from "../../base/types/memory-lifecycle.js";
 import type { ToolExecutor } from "../../tools/executor.js";
 import type { ToolCallContext } from "../../tools/types.js";
@@ -518,17 +519,28 @@ export async function buildChatContext(
  * Returns cwd itself if no git root is found.
  */
 export function resolveGitRoot(cwd: string): string {
-  let dir = cwd;
+  const resolvedCwd = expandWorkspacePath(cwd);
+  let dir = resolvedCwd;
   while (true) {
     try {
       accessSync(join(dir, ".git"));
       return dir;
     } catch {
       const parent = dirname(dir);
-      if (parent === dir) return cwd;
+      if (parent === dir) return resolvedCwd;
       dir = parent;
     }
   }
+}
+
+function expandWorkspacePath(value: string): string {
+  if (value === "~") {
+    return homedir();
+  }
+  if (value.startsWith("~/")) {
+    return resolve(homedir(), value.slice(2));
+  }
+  return resolve(value);
 }
 
 /**

--- a/src/tools/fs/FileValidationTool/__tests__/FileValidationTool.test.ts
+++ b/src/tools/fs/FileValidationTool/__tests__/FileValidationTool.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import * as os from "node:os";
 import { validateFilePath } from "../FileValidationTool.js";
 
 describe("validateFilePath", () => {
@@ -50,5 +51,10 @@ describe("validateFilePath", () => {
     const result = validateFilePath("build/output.txt", cwd, ["build"]);
     expect(result.valid).toBe(false);
     expect(result.error).toContain("build");
+  });
+
+  it("expands tilde paths before resolving", () => {
+    const result = validateFilePath("~/pulseed-test-file.txt", os.homedir());
+    expect(result.resolved).toBe(`${os.homedir()}/pulseed-test-file.txt`);
   });
 });

--- a/src/tools/fs/FileValidationTool/protected-path-policy.ts
+++ b/src/tools/fs/FileValidationTool/protected-path-policy.ts
@@ -1,5 +1,6 @@
 import { realpathSync } from "node:fs";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { homedir } from "node:os";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 
 const DEFAULT_PROTECTED_PATH_PATTERNS = [
   ".git",
@@ -34,8 +35,10 @@ export function validateProtectedPath(
   filePath: string,
   input: ProtectedPathPolicyInput,
 ): ProtectedPathValidationResult {
+  const cwd = canonicalPath(input.cwd);
   const workspaceRoot = canonicalPath(input.workspaceRoot ?? input.cwd);
-  const resolved = canonicalPath(resolve(input.cwd, filePath));
+  const requestedPath = expandTildePath(filePath);
+  const resolved = canonicalPath(isAbsolute(requestedPath) ? requestedPath : resolve(cwd, requestedPath));
   const pathFromWorkspace = relative(workspaceRoot, resolved);
 
   if (pathFromWorkspace.startsWith("..") || isAbsolute(pathFromWorkspace)) {
@@ -67,11 +70,22 @@ export function validateProtectedPath(
   return { valid: true, resolved };
 }
 
+export function expandTildePath(value: string): string {
+  if (value === "~") {
+    return homedir();
+  }
+  if (value.startsWith("~/")) {
+    return join(homedir(), value.slice(2));
+  }
+  return value;
+}
+
 function canonicalPath(value: string): string {
+  const expanded = expandTildePath(value);
   try {
-    return realpathSync(value);
+    return realpathSync(expanded);
   } catch {
-    return resolve(value);
+    return resolve(expanded);
   }
 }
 

--- a/src/tools/fs/ListDirTool/ListDirTool.ts
+++ b/src/tools/fs/ListDirTool/ListDirTool.ts
@@ -43,7 +43,7 @@ export class ListDirTool implements ITool<ListDirInput, DirEntry[]> {
 
   async call(input: ListDirInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
-    const dirPath = path.isAbsolute(input.path) ? input.path : path.resolve(context.cwd, input.path);
+    const dirPath = validateFilePath(input.path, context.cwd, context.executionPolicy?.protectedPaths).resolved;
     try {
       const entries = await listDir(dirPath, input.recursive, input.maxDepth, input.includeHidden, 0);
       return {

--- a/src/tools/fs/ListDirTool/__tests__/ListDirTool.test.ts
+++ b/src/tools/fs/ListDirTool/__tests__/ListDirTool.test.ts
@@ -94,6 +94,12 @@ describe("ListDirTool", () => {
       expect(names).not.toContain(".hidden");
     });
 
+    it("expands tilde cwd before listing relative paths", async () => {
+      const result = await tool.call({ path: ".", recursive: false, maxDepth: 1, includeHidden: false }, makeContext("~"));
+      expect(result.success).toBe(true);
+      expect(result.summary).toContain(os.homedir());
+    });
+
     it("includes hidden files when includeHidden is true", async () => {
       const result = await tool.call({ path: tmpDir, recursive: false, maxDepth: 2, includeHidden: true }, makeContext());
       expect(result.success).toBe(true);
@@ -150,7 +156,7 @@ describe("ListDirTool", () => {
 
     it("artifacts contains the queried path", async () => {
       const result = await tool.call({ path: tmpDir, recursive: false, maxDepth: 2, includeHidden: false }, makeContext());
-      expect(result.artifacts).toContain(tmpDir);
+      expect(result.artifacts).toContain(await fs.realpath(tmpDir));
     });
   });
 });

--- a/src/tools/kaggle/__tests__/KaggleExperimentTools.test.ts
+++ b/src/tools/kaggle/__tests__/KaggleExperimentTools.test.ts
@@ -200,6 +200,20 @@ fs.writeFileSync("experiments/exp-restart/metrics.json", JSON.stringify(${JSON.s
     ]));
   });
 
+  it("lists experiments when the model passes the Kaggle runs root instead of the competition workspace", async () => {
+    await writeMetrics(pulseedHome, "exp-files", "maximize", 0.7);
+    const listTool = new KaggleExperimentListTool(manager);
+
+    const listed = await listTool.call({
+      workspace: path.join(pulseedHome, "kaggle-runs"),
+      competition: "titanic",
+      include_exited: true,
+    }, makeContext(pulseedHome));
+
+    expect(listed.success).toBe(true);
+    expect((listed.data as Array<{ experiment_id: string }>).map((item) => item.experiment_id)).toContain("exp-files");
+  });
+
   it("stops the process session linked to an experiment", async () => {
     const startTool = new KaggleExperimentStartTool(manager);
     const stopTool = new KaggleExperimentStopTool(manager);

--- a/src/tools/kaggle/__tests__/KaggleSubmissionTools.test.ts
+++ b/src/tools/kaggle/__tests__/KaggleSubmissionTools.test.ts
@@ -372,6 +372,23 @@ describe("Kaggle submission tools", () => {
     }]);
   });
 
+  it("lists submissions when the model passes the Kaggle runs root instead of the competition workspace", async () => {
+    const runner = new RecordingRunner({ exitCode: 0, stdout: "date,description,status\n", stderr: "" });
+    const tool = new KaggleListSubmissionsTool(runner);
+    const result = await tool.call({
+      workspace: path.join(pulseedHome, "kaggle-runs"),
+      competition: "titanic",
+      timeoutMs: 10_000,
+    }, makeContext(pulseedHome));
+
+    expect(result.success).toBe(true);
+    expect(runner.calls).toEqual([{
+      command: "kaggle",
+      cwd: workspaceRoot,
+      args: ["competitions", "submissions", "titanic", "-v", "-q"],
+    }]);
+  });
+
   it("stores leaderboard snapshots under the Kaggle workspace", async () => {
     const runner = new RecordingRunner({ exitCode: 0, stdout: "team,score\nA,0.9\n", stderr: "" });
     const tool = new KaggleLeaderboardSnapshotTool(runner);

--- a/src/tools/kaggle/__tests__/KaggleWorkspacePrepareTool.test.ts
+++ b/src/tools/kaggle/__tests__/KaggleWorkspacePrepareTool.test.ts
@@ -122,6 +122,27 @@ describe("KaggleWorkspacePrepareTool", () => {
     expect(data.workspace.state_relative_path).toBe("kaggle-runs/titanic");
   });
 
+  it("accepts the Kaggle runs root when competition identifies the workspace", async () => {
+    const tool = new KaggleWorkspacePrepareTool();
+    const stateRelative = await tool.call({
+      workspace: "kaggle-runs",
+      competition: "titanic",
+      metric_name: "rmse",
+      metric_direction: "minimize",
+    }, makeContext());
+    const absolute = await tool.call({
+      workspace: path.join(pulseedHome, "kaggle-runs"),
+      competition: "titanic",
+      metric_name: "rmse",
+      metric_direction: "minimize",
+    }, makeContext());
+
+    expect(stateRelative.success).toBe(true);
+    expect(absolute.success).toBe(true);
+    expect((stateRelative.data as { workspace: { state_relative_path: string } }).workspace.state_relative_path).toBe("kaggle-runs/titanic");
+    expect((absolute.data as { workspace: { state_relative_path: string } }).workspace.state_relative_path).toBe("kaggle-runs/titanic");
+  });
+
   it("rejects absolute workspace paths outside the fixed competition root", async () => {
     const tool = new KaggleWorkspacePrepareTool();
     const outside = await fs.mkdtemp(path.join(os.tmpdir(), "pulseed-kaggle-outside-"));

--- a/src/tools/kaggle/paths.ts
+++ b/src/tools/kaggle/paths.ts
@@ -69,6 +69,11 @@ export function resolveKaggleWorkspaceInput(workspace: string, competition: stri
   let resolved: string;
   if (path.isAbsolute(requested)) {
     resolved = path.resolve(requested);
+    if (resolved === runsRoot) {
+      resolved = expected;
+    }
+  } else if (requested === KAGGLE_RUNS_DIR) {
+    resolved = expected;
   } else if (requested === competition) {
     resolved = expected;
   } else if (requested === path.join(KAGGLE_RUNS_DIR, competition)) {

--- a/src/tools/system/ShellTool/ShellTool.ts
+++ b/src/tools/system/ShellTool/ShellTool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata } from "../../types.js";
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
+import { expandTildePath } from "../../fs/FileValidationTool/protected-path-policy.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, MAX_OUTPUT_CHARS, PERMISSION_LEVEL } from "./constants.js";
 import { assessShellCommand } from "./command-policy.js";
@@ -30,7 +31,7 @@ export class ShellTool implements ITool<ShellInput, ShellOutput> {
 
   async call(input: ShellInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
-    const cwd = input.cwd ?? context.cwd;
+    const cwd = expandTildePath(input.cwd ?? context.cwd);
     try {
       const shell = process.env.SHELL ?? "/bin/zsh";
       const result = await execFileNoThrow(shell, ["-c", input.command], { cwd, timeoutMs: input.timeoutMs });


### PR DESCRIPTION
## Summary
- treat `kaggle-runs` and the absolute Kaggle runs root as the competition workspace when `competition` is provided
- normalize chat / agent-loop cwd values like `~` before grounding and tool dispatch
- expand tilde paths in file validation, list_dir, and shell cwd handling
- add regression coverage for Kaggle runs-root inputs and tilde cwd/path resolution

## Tests
- npx vitest run --config vitest.unit.config.ts src/tools/kaggle/__tests__/KaggleWorkspacePrepareTool.test.ts src/tools/kaggle/__tests__/KaggleExperimentTools.test.ts src/tools/kaggle/__tests__/KaggleSubmissionTools.test.ts
- npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts src/tools/fs/FileValidationTool/__tests__/FileValidationTool.test.ts src/tools/fs/ListDirTool/__tests__/ListDirTool.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts
- npm run typecheck
- npm run test:changed
- git diff --check