### PR TITLE
Fix wait strategy stall suppression and task mirroring

### DIFF
--- a/docs/design/core/stall-detection.md
+++ b/docs/design/core/stall-detection.md
@@ -103,9 +103,13 @@ A global stall is the most serious state. Something fundamental is likely wrong 
 
 ### 2.5 Suppressing Stall Detection During Intentional Waits (plateau_until)
 
-When the `plateau_until` field (see `task-lifecycle.md` §2.6) is set, stall detection behavior changes as follows.
+When an intentional wait is active, stall detection behavior changes as follows.
+In the current runtime, stall suppression keys off the active WaitStrategy's
+`wait_until`, while `task.plateau_until` is only a mirrored task-local hint for
+consumers that do not load the portfolio.
 
-**Suppression condition**: A task or dimension has `plateau_until` set, and the current time is before `plateau_until`.
+**Suppression condition**: The active wait timestamp is set, and the current
+time is before that timestamp.
 
 ```
 plateau_until is set AND current_time < plateau_until
@@ -113,9 +117,18 @@ plateau_until is set AND current_time < plateau_until
   → None of the detection types from §2.1–§2.4 are triggered
 ```
 
+**WaitStrategy mapping**: In the current CoreLoop integration, an active
+`WaitStrategy` contributes suppression only for its `primary_dimension`. Its
+`target_dimensions` are not suppressed automatically. This matches wait expiry,
+which also evaluates a single canonical dimension rather than a bundle of
+dimensions.
+
 **Lifting suppression**: Normal stall detection resumes the moment `plateau_until` becomes a past datetime. Gap changes that accumulated during the suppression period are evaluated in the first loop after suppression is lifted.
 
-**Preventing misuse**: `plateau_until` is a field for intentional waiting. Using it to "hide a stall" is prohibited. Only the strategy layer (the LLM when generating tasks) can set it; executors cannot change it ad hoc.
+**Preventing misuse**: This suppression window is for intentional waiting.
+Using it to "hide a stall" is prohibited. In practice, PulSeed derives it from
+strategy-layer wait state and mirrors it into task state; executors must not
+invent or extend it ad hoc.
 
 **Relationship to §6's plateau concept**: The "intentional 'waiting' strategy" described in §6 ("Stall vs. Plateau") is formalized through `plateau_until`. If `plateau_until` is set, suppression is applied mechanically. If a stall occurs without it being set, the graduated response in §4 applies normally.
 

--- a/docs/design/core/wait-strategy.md
+++ b/docs/design/core/wait-strategy.md
@@ -141,11 +141,12 @@ and expiry judgment are all anchored to one canonical dimension. The task field
 `plateau_until` is a mirror for task-local consumers that do not load the
 portfolio. Suppression lifts automatically once the wait timestamp becomes past.
 
-**Current gap**: The `canAffordWait` gate from TimeHorizonEngine is only
-partially wired. `StrategyManager.activateMultiple()` accepts a
-`canAffordWait` hook and blocks activation when the caller supplies one, but
-CoreLoop does not yet derive and pass the closure from
-`TimeHorizonEngine.getTimeBudget()`. See §6 for planned integration.
+**Current gap**: The `canAffordWait` gate from TimeHorizonEngine is now wired
+through CoreLoop stall recovery and wait-expiry fallback activation using
+dimension-specific gap history. The remaining limitation is architectural:
+external/manual activation paths can still omit the hook, and goals without
+usable per-dimension history currently fail closed (the wait cannot be afforded)
+rather than falling back to a softer heuristic.
 
 ---
 
@@ -153,7 +154,8 @@ CoreLoop does not yet derive and pass the closure from
 
 | Gap | Description |
 |-----|-------------|
-| **canAffordWait gate wiring** | `TimeHorizonEngine.getTimeBudget()` returns a `canAffordWait` closure, but CoreLoop does not yet pass that closure into `StrategyManager.activateMultiple()`. Activation-time enforcement exists once the caller supplies the hook. |
+| **canAffordWait coverage outside CoreLoop** | CoreLoop now passes a dimension-specific `canAffordWait` closure into wait activation and fallback activation, but callers outside that path can still invoke activation without supplying the hook. |
+| **History-poor wait activation policy** | When a wait candidate has insufficient per-dimension gap history to estimate velocity, the current policy is fail-closed (`canAffordWait` returns false). This is safer than silently allowing waits, but it may be too strict for very new goals. |
 | **Authoritative wait state is split across portfolio + task mirror** | The portfolio WaitStrategy is authoritative for CoreLoop suppression and expiry, while `task.plateau_until` is a best-effort mirror for task-local consumers. Consumers that only read task state must tolerate stale mirrors. |
 | **Effect latency estimation** | Heuristic categorization of action types (e.g., "deploy" → hours, "marketing" → days) to auto-suggest `wait_until` durations. Currently the LLM proposes durations without structured guidance. |
 | **Adaptive observation frequency** | Reducing observation frequency during waits to save tokens. `TimeHorizonEngine.suggestObservationInterval` exists (time-horizon.md §7) but is not connected to wait state. |

--- a/docs/design/core/wait-strategy.md
+++ b/docs/design/core/wait-strategy.md
@@ -27,9 +27,9 @@ for meaningful results — this sense of timing is also part of strategy.")
 |--------|----------------|
 | **TimeHorizonEngine** | "Can we afford to wait?" — `canAffordWait` closure inside `TimeBudgetWithWait` (time-horizon.md §10) |
 | **PortfolioManager** | "Should we wait?" — expiry handling via `handleWaitStrategyExpiry`, duck-type check via `isWaitStrategy` (portfolio-management.md §7) |
-| **StallDetector** | Suppresses stall alerts when `plateau_until` is set and in the future (stall-detection.md §2.5) |
-| **StrategyManager** | Creates WaitStrategy instances via `createWaitStrategy()` with `state=candidate`, `allocation=0` |
-| **CoreLoop (phases-b)** | Iterates portfolio strategies each tick; calls expiry handler for any WaitStrategy |
+| **StallDetector** | Evaluates `isSuppressed(plateauUntil)` when the loop decides whether a dimension should participate in stall detection (stall-detection.md §2.5) |
+| **StrategyManager** | Creates WaitStrategy instances via `createWaitStrategy()` with `state=candidate`, `allocation=0`, and mirrors `wait_until` into the active task's `plateau_until` on activation |
+| **CoreLoop task cycle** | Collects active WaitStrategies, suppresses stalled dimensions whose wait window is still open, and later calls expiry handling |
 
 No single module owns the full wait lifecycle. This is intentional — each module
 answers exactly one question.
@@ -55,7 +55,7 @@ Key base-schema fields used by wait logic:
 | Field | Type | Role |
 |-------|------|------|
 | `gap_snapshot_at_start` | `number \| null` | Baseline gap captured when strategy becomes active. `handleWaitStrategyExpiry` returns null (skips evaluation) if this is null. |
-| `primary_dimension` | `string` | Dimension used for gap comparison at expiry. |
+| `primary_dimension` | `string` | Canonical dimension for this wait. Expiry comparison and stall suppression both key off this field. |
 | `allocation` | `number` | Always `0` for WaitStrategy — it generates no tasks. |
 
 Duck-type detection (`isWaitStrategy` in `portfolio-allocation.ts`):
@@ -84,12 +84,15 @@ The lifecycle follows the path: **candidate → active → expiry check → outc
 **Creation** (`StrategyManager.createWaitStrategy`):
 - Sets `state="candidate"`, `allocation=0`, `gap_snapshot_at_start=null`.
 - WaitStrategy-specific fields (`wait_reason`, `wait_until`, `measurement_plan`,
-  `fallback_strategy_id`) are stored. The portfolio persists only base `Strategy`
-  fields (`StrategySchema.parse` strips extended fields on save).
+  `fallback_strategy_id`) are stored in the portfolio and mirrored into
+  `strategies/<goalId>/wait-meta/<strategyId>.json` for durable wait observation metadata.
 
 **Activation**:
 - Caller transitions state to `active`. At activation, `gap_snapshot_at_start`
   captures the current gap value — this becomes the baseline for expiry evaluation.
+- If the activated strategy is a WaitStrategy, `StrategyManager.activateMultiple()`
+  mirrors `wait_until` into the current task's `plateau_until`. The active task file
+  is preferred; `task-history.json` is only a fallback lookup path.
 
 **Expiry check** (`handleWaitStrategyExpiry` in `portfolio-rebalance.ts`):
 1. If `!isWaitStrategy(strategy)` → skip.
@@ -109,10 +112,16 @@ See portfolio-management.md §7.3 for the full wait execution flow.
 
 ## 5. CoreLoop Integration
 
-In `core-loop-phases-b.ts`, the `rebalancePortfolio` function handles
-WaitStrategy expiry on every loop tick:
+In the current CoreLoop implementation, `iteration-kernel.ts` first checks
+whether an active wait should keep the loop in observe-only mode. If the loop
+does proceed, `task-cycle.ts` performs stall suppression and
+`portfolio-manager.ts` handles WaitStrategy expiry:
 
 ```
+for each active WaitStrategy in portfolio.strategies:
+  if stallDetector.isSuppressed(strategy.wait_until):
+    skip dimension stall detection for strategy.primary_dimension
+
 for each strategy in portfolio.strategies:
   if portfolioManager.isWaitStrategy(strategy):
     trigger = portfolioManager.handleWaitStrategyExpiry(goalId, strategy.id)
@@ -120,17 +129,23 @@ for each strategy in portfolio.strategies:
       portfolioManager.rebalance(goalId, trigger)
 ```
 
-This runs after stall detection and portfolio rebalance. Errors are caught and
-treated as non-fatal — a WaitStrategy expiry failure does not abort the loop.
+The observe-only check happens before normal task generation. Later expiry and
+rebalance handling is non-fatal — a WaitStrategy failure does not abort the loop.
 
-**Stall suppression**: When a WaitStrategy is active and `plateau_until` is set,
-`StallDetector.isSuppressed(plateauUntil)` returns true, suppressing all stall
-detection for that dimension (stall-detection.md §2.5). Suppression lifts
-automatically once `plateau_until` becomes a past datetime.
+**Stall suppression**: The loop currently treats `WaitStrategy.wait_until` as the
+authoritative suppression source and uses `StallDetector.isSuppressed(waitUntil)`
+to suppress stall detection for the WaitStrategy's `primary_dimension`. This is
+intentionally narrower than `target_dimensions`: a wait may be informed by
+multiple dimensions, but the actual wait/no-wait decision, baseline snapshot,
+and expiry judgment are all anchored to one canonical dimension. The task field
+`plateau_until` is a mirror for task-local consumers that do not load the
+portfolio. Suppression lifts automatically once the wait timestamp becomes past.
 
-**Current gap**: The `canAffordWait` gate from TimeHorizonEngine is NOT wired
-into this path. CoreLoop does not call `canAffordWait` before entering a wait.
-See §6 for planned integration.
+**Current gap**: The `canAffordWait` gate from TimeHorizonEngine is only
+partially wired. `StrategyManager.activateMultiple()` accepts a
+`canAffordWait` hook and blocks activation when the caller supplies one, but
+CoreLoop does not yet derive and pass the closure from
+`TimeHorizonEngine.getTimeBudget()`. See §6 for planned integration.
 
 ---
 
@@ -138,8 +153,8 @@ See §6 for planned integration.
 
 | Gap | Description |
 |-----|-------------|
-| **canAffordWait gate wiring** | `TimeHorizonEngine.getTimeBudget()` returns a `canAffordWait` closure, but no caller in the orchestrator layer invokes it. Future: wire into CoreLoop or PortfolioManager before activating a WaitStrategy. |
-| **plateau_until write path** | portfolio-management.md §7.3 specifies "set `wait_until` as `plateau_until`" but no code writes `plateau_until` when a WaitStrategy becomes active. `StallDetector.isSuppressed` exists but is never called from the CoreLoop stall path. Owner and storage location TBD. |
+| **canAffordWait gate wiring** | `TimeHorizonEngine.getTimeBudget()` returns a `canAffordWait` closure, but CoreLoop does not yet pass that closure into `StrategyManager.activateMultiple()`. Activation-time enforcement exists once the caller supplies the hook. |
+| **Authoritative wait state is split across portfolio + task mirror** | The portfolio WaitStrategy is authoritative for CoreLoop suppression and expiry, while `task.plateau_until` is a best-effort mirror for task-local consumers. Consumers that only read task state must tolerate stale mirrors. |
 | **Effect latency estimation** | Heuristic categorization of action types (e.g., "deploy" → hours, "marketing" → days) to auto-suggest `wait_until` durations. Currently the LLM proposes durations without structured guidance. |
 | **Adaptive observation frequency** | Reducing observation frequency during waits to save tokens. `TimeHorizonEngine.suggestObservationInterval` exists (time-horizon.md §7) but is not connected to wait state. |
 | **LLM-assisted duration estimation** | Using the LLM to estimate effect latency based on action type and domain context. |
@@ -155,10 +170,11 @@ See §6 for planned integration.
 | `isWaitStrategy` duck-type check | `src/orchestrator/strategy/portfolio-allocation.ts` |
 | `createWaitStrategy` | `src/orchestrator/strategy/strategy-manager.ts` |
 | `handleWaitStrategyExpiry` | `src/orchestrator/strategy/portfolio-rebalance.ts` (called via `portfolio-manager.ts`) |
+| Activation-time `plateau_until` mirror | `src/orchestrator/strategy/strategy-manager.ts` (`activateMultiple()` / `_applyWaitStrategyPlateauUntil()`) |
 | `canAffordWait` closure | `src/platform/time/time-horizon-engine.ts` (`getTimeBudget` return value) |
 | `TimeBudgetWithWait` type | `src/base/types/time-horizon.ts` |
 | `isSuppressed` (plateau_until) | `src/platform/drive/stall-detector.ts` |
-| CoreLoop wait iteration | `src/orchestrator/loop/core-loop-phases-b.ts` (`rebalancePortfolio`) |
+| CoreLoop wait iteration + stall suppression | `src/orchestrator/loop/core-loop/task-cycle.ts` / `src/orchestrator/loop/core-loop/iteration-kernel.ts` |
 
 ---
 
@@ -205,5 +221,6 @@ exists only as an in-memory computation result, never persisted.
 | Duck-type detection | Strategies are plain Zod-parsed objects; no class hierarchy |
 | Closure for `canAffordWait` | Captures time snapshot consistently; avoids passing 5 parameters per call |
 | `fallback_strategy_id` nullable | Not every wait has a fallback; null means rebalance from scratch |
-| `plateau_until` owned by StallDetector | Suppression is a detection concern, not a strategy concern |
+| `plateau_until` mirrored onto tasks from WaitStrategy activation | Wait ownership starts in the strategy layer, while task-local mirroring keeps non-portfolio consumers aligned |
+| Stall suppression is `primary_dimension`-only | Wait expiry also evaluates one canonical dimension; suppressing every `target_dimension` would hide unrelated stalls behind one wait |
 | `allocation=0` for waits | WaitStrategy generates no tasks; allocation is nominal |

--- a/src/orchestrator/execution/agent-loop/__tests__/kaggle-training-benchmark.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/kaggle-training-benchmark.test.ts
@@ -204,6 +204,7 @@ console.log("benchmark training completed");
         () => true,
         async () => 0.5,
         async () => undefined,
+        async () => undefined,
         async () => [],
         async () => ({
           schema_version: 1,
@@ -217,7 +218,7 @@ console.log("benchmark training completed");
         }),
         async () => ({ capabilities: [], last_checked: "2026-04-25T00:00:00.000Z" }),
         async () => null,
-        async (_goalId, _strategyId, metadata) => {
+        async (_goalId: string, _strategyId: string, metadata: unknown) => {
           writtenWaitMetadata = metadata as unknown as Record<string, unknown>;
         },
         () => pulseedHome,

--- a/src/orchestrator/loop/__tests__/core-loop-flow.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-flow.test.ts
@@ -455,7 +455,8 @@ describe("CoreLoop", async () => {
       expect(mocks.strategyManager.onStallDetected).toHaveBeenCalledWith(
         "goal-1",
         expect.any(Number),
-        expect.any(String)
+        expect.any(String),
+        undefined
       );
     });
 

--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -1008,7 +1008,7 @@ describe("CoreLoop", async () => {
       const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
       await loop.runOneIteration("goal-1", 0);
 
-      expect(mocks.strategyManager.onStallDetected).toHaveBeenCalledWith("goal-1", 3, expect.any(String));
+      expect(mocks.strategyManager.onStallDetected).toHaveBeenCalledWith("goal-1", 3, expect.any(String), undefined);
     });
 
     it("handles WaitStrategy expiry check — calls rebalance when handleWaitStrategyExpiry returns a trigger", async () => {
@@ -1046,7 +1046,7 @@ describe("CoreLoop", async () => {
       const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
       await loop.runOneIteration("goal-1", 0);
 
-      expect(portfolioManager.handleWaitStrategyExpiry).toHaveBeenCalledWith("goal-1", waitStrategy.id);
+      expect(portfolioManager.handleWaitStrategyExpiry).toHaveBeenCalledWith("goal-1", waitStrategy.id, undefined);
       expect(portfolioManager.rebalance).toHaveBeenCalledWith("goal-1", waitTrigger);
     });
 
@@ -1093,7 +1093,7 @@ describe("CoreLoop", async () => {
 
       expect(result.waitExpired).toBe(true);
       expect(result.waitObserveOnly).toBe(false);
-      expect(mocks.strategyManager.onStallDetected).toHaveBeenCalledWith("goal-1", 3, expect.any(String));
+      expect(mocks.strategyManager.onStallDetected).toHaveBeenCalledWith("goal-1", 3, expect.any(String), undefined);
       expect(mocks.taskLifecycle.runTaskCycle).toHaveBeenCalledOnce();
     });
 
@@ -1405,7 +1405,7 @@ describe("CoreLoop", async () => {
       const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
       const result = await loop.runOneIteration("goal-1", 0);
 
-      expect(portfolioManager.handleWaitStrategyExpiry).toHaveBeenCalledWith("goal-1", waitStrategy.id);
+      expect(portfolioManager.handleWaitStrategyExpiry).toHaveBeenCalledWith("goal-1", waitStrategy.id, undefined);
       expect(mocks.stallDetector.isSuppressed).not.toHaveBeenCalled();
       expect(mocks.stallDetector.checkDimensionStall).not.toHaveBeenCalled();
       expect(result.waitSuppressed).toBe(true);

--- a/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
@@ -33,6 +33,7 @@ import type { AdapterRegistry } from "../../execution/adapter-layer.js";
 import type { GoalRefiner } from "../../goal/goal-refiner.js";
 import type { Goal } from "../../../base/types/goal.js";
 import type { StallReport } from "../../../base/types/stall.js";
+import type { ITimeHorizonEngine } from "../../../platform/time/time-horizon-engine.js";
 import type { LoopIterationResult } from "../core-loop/contracts.js";
 import type { PhaseCtx } from "../core-loop/preparation.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
@@ -637,17 +638,17 @@ describe("detectStallsAndRebalance — gap history indexing reuse", () => {
       },
     ]);
 
-    const dimensionHistories = new Map<string, Array<{ normalized_gap: number }>>();
+    const dimensionHistories = new Map<string, Array<{ normalized_gap: number; timestamp?: string }>>();
     (deps.stallDetector.checkDimensionStall as ReturnType<typeof vi.fn>).mockImplementation(
-      (_goalId: string, dimName: string, dimGapHistory: Array<{ normalized_gap: number }>) => {
+      (_goalId: string, dimName: string, dimGapHistory: Array<{ normalized_gap: number; timestamp?: string }>) => {
         dimensionHistories.set(dimName, dimGapHistory);
         return null;
       }
     );
 
-    const globalHistories: Array<Map<string, Array<{ normalized_gap: number }>>> = [];
+    const globalHistories: Array<Map<string, Array<{ normalized_gap: number; timestamp?: string }>>> = [];
     (deps.stallDetector.checkGlobalStall as ReturnType<typeof vi.fn>).mockImplementation(
-      (_goalId: string, allDimGaps: Map<string, Array<{ normalized_gap: number }>>) => {
+      (_goalId: string, allDimGaps: Map<string, Array<{ normalized_gap: number; timestamp?: string }>>) => {
         globalHistories.push(allDimGaps);
         return null;
       }
@@ -659,12 +660,12 @@ describe("detectStallsAndRebalance — gap history indexing reuse", () => {
     await detectStallsAndRebalance(ctx, "goal-1", goal, result);
 
     expect(dimensionHistories.get("dim1")).toEqual([
-      { normalized_gap: 0.8 },
-      { normalized_gap: 0.6 },
+      expect.objectContaining({ normalized_gap: 0.8 }),
+      expect.objectContaining({ normalized_gap: 0.6 }),
     ]);
     expect(dimensionHistories.get("dim2")).toEqual([
-      { normalized_gap: 0.4 },
-      { normalized_gap: 0.3 },
+      expect.objectContaining({ normalized_gap: 0.4 }),
+      expect.objectContaining({ normalized_gap: 0.3 }),
     ]);
 
     const globalHistory = globalHistories[0];
@@ -828,11 +829,11 @@ describe("detectStallsAndRebalance — gap history indexing reuse", () => {
     expect(depsWithPortfolio.stallDetector.checkDimensionStall).toHaveBeenCalledWith(
       "goal-1",
       "dim2",
-      [{ normalized_gap: 0.4 }]
+      [expect.objectContaining({ normalized_gap: 0.4 })]
     );
-    const globalHistory = globalCheck.mock.calls[0]?.[1] as Map<string, Array<{ normalized_gap: number }>>;
+    const globalHistory = globalCheck.mock.calls[0]?.[1] as Map<string, Array<{ normalized_gap: number; timestamp?: string }>>;
     expect(globalHistory.has("dim1")).toBe(false);
-    expect(globalHistory.get("dim2")).toEqual([{ normalized_gap: 0.4 }]);
+    expect(globalHistory.get("dim2")).toEqual([expect.objectContaining({ normalized_gap: 0.4 })]);
   });
 
   it("suppresses only the WaitStrategy primary_dimension, not every target_dimension", async () => {
@@ -924,7 +925,7 @@ describe("detectStallsAndRebalance — gap history indexing reuse", () => {
     const globalCheck = depsWithPortfolio.stallDetector.checkGlobalStall as ReturnType<typeof vi.fn>;
     globalCheck.mockReturnValue(null);
 
-    const ctx = buildPhaseCtx(depsWithPortfolio, { maxIterations: 10, adapterType: "openai_codex_cli" });
+    const ctx = buildPhaseCtx(depsWithPortfolio as unknown as CoreLoopDeps, { maxIterations: 10, adapterType: "openai_codex_cli" });
     const result = makeIterationResult();
 
     await detectStallsAndRebalance(ctx, "goal-1", goal, result);
@@ -933,9 +934,9 @@ describe("detectStallsAndRebalance — gap history indexing reuse", () => {
     expect(depsWithPortfolio.stallDetector.checkDimensionStall).toHaveBeenCalledWith(
       "goal-1",
       "dim2",
-      [{ normalized_gap: 0.4 }]
+      [expect.objectContaining({ normalized_gap: 0.4 })]
     );
-    const globalHistory = globalCheck.mock.calls[0]?.[1] as Map<string, Array<{ normalized_gap: number }>>;
+    const globalHistory = globalCheck.mock.calls[0]?.[1] as Map<string, Array<{ normalized_gap: number; timestamp?: string }>>;
     expect(globalHistory.has("dim1")).toBe(false);
     expect(globalHistory.has("dim2")).toBe(true);
   });
@@ -1011,5 +1012,122 @@ describe("detectStallsAndRebalance — gap history indexing reuse", () => {
     expect(depsWithPortfolio.stallDetector.checkGlobalStall).not.toHaveBeenCalled();
     expect(result.stallDetected).toBe(false);
     expect(result.waitSuppressed).toBe(true);
+  });
+
+  it("passes a TimeHorizon-derived canAffordWait hook into stall-driven regeneration", async () => {
+    const deps = createBaseDeps(tmpDir);
+    const goal = makeGoal({
+      id: "goal-1",
+      deadline: "2026-05-01T00:00:00.000Z",
+      dimensions: [
+        {
+          name: "dim1",
+          label: "Dim 1",
+          current_value: 0.2,
+          threshold: { type: "min", value: 1.0 },
+          confidence: 0.5,
+          observation_method: {
+            type: "manual",
+            source: "manual",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "self_report",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await deps.stateManager.saveGoal(goal);
+    await deps.stateManager.saveGapHistory("goal-1", [
+      {
+        iteration: 0,
+        timestamp: "2026-04-27T00:00:00.000Z",
+        gap_vector: [{ dimension_name: "dim1", normalized_weighted_gap: 0.8 }],
+        confidence_vector: [],
+      },
+      {
+        iteration: 1,
+        timestamp: "2026-04-27T01:00:00.000Z",
+        gap_vector: [{ dimension_name: "dim1", normalized_weighted_gap: 0.6 }],
+        confidence_vector: [],
+      },
+    ]);
+
+    const timeHorizonEngine: ITimeHorizonEngine = {
+      evaluatePacing: vi.fn().mockReturnValue({
+        status: "on_track",
+        velocityPerHour: 0.2,
+        velocityStddev: 0,
+        projectedCompletionDate: null,
+        timeRemainingHours: 48,
+        pacingRatio: 1,
+        confidence: 1,
+        recommendation: "maintain_course",
+      }),
+      projectCompletion: vi.fn(),
+      suggestObservationInterval: vi.fn(),
+      getTimeBudget: vi.fn().mockReturnValue({
+        totalHours: 48,
+        elapsedHours: 1,
+        remainingHours: 47,
+        percentElapsed: 0.02,
+        percentGapRemaining: 0.6,
+        canAffordWait: (waitHours: number) => waitHours <= 4,
+      }),
+    };
+
+    const ctx = {
+      ...buildPhaseCtx(deps, { maxIterations: 10, adapterType: "openai_codex_cli" }),
+      timeHorizonEngine,
+    };
+    const result = makeIterationResult();
+    (deps.stallDetector.checkDimensionStall as ReturnType<typeof vi.fn>).mockReturnValue(
+      makeStallReport({ escalation_level: 1 })
+    );
+    (deps.strategyManager.onStallDetected as ReturnType<typeof vi.fn>).mockImplementation(
+      async (_goalId: string, _stallCount: number, _goalType: string | undefined, activationContext?: {
+        canAffordWait?: (input: {
+          strategy: { primary_dimension: string };
+          waitHours: number;
+          currentGap: number;
+          initialGap: number;
+          startedAt: string;
+        }) => boolean | Promise<boolean>;
+      }) => {
+        const canAfford = await activationContext?.canAffordWait?.({
+          strategy: { primary_dimension: "dim1" },
+          waitHours: 3,
+          currentGap: 0.6,
+          initialGap: 0.8,
+          startedAt: "2026-04-27T01:00:00.000Z",
+        });
+        return canAfford ? { id: "wait-1", state: "active" } : null;
+      }
+    );
+
+    await detectStallsAndRebalance(ctx, "goal-1", goal, result);
+
+    expect(deps.strategyManager.onStallDetected).toHaveBeenCalledWith(
+      "goal-1",
+      1,
+      goal.origin ?? "general",
+      expect.objectContaining({
+        canAffordWait: expect.any(Function),
+      })
+    );
+    expect(timeHorizonEngine.evaluatePacing).toHaveBeenCalled();
+    expect(timeHorizonEngine.getTimeBudget).toHaveBeenCalledWith(
+      goal.deadline,
+      goal.created_at,
+      0.6,
+      0.8,
+      0.2
+    );
+    expect(result.pivotOccurred).toBe(true);
   });
 });

--- a/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
@@ -727,4 +727,289 @@ describe("detectStallsAndRebalance — gap history indexing reuse", () => {
     expect(globalHistory.has("dim1")).toBe(true);
     expect(globalHistory.has("stale-dim")).toBe(false);
   });
+
+  it("excludes wait-suppressed dimensions from global stall checks", async () => {
+    const deps = createBaseDeps(tmpDir);
+    const goal = makeGoal({
+      id: "goal-1",
+      dimensions: [
+        {
+          name: "dim1",
+          label: "Dim 1",
+          current_value: 0.2,
+          threshold: { type: "min", value: 1.0 },
+          confidence: 0.5,
+          observation_method: {
+            type: "manual",
+            source: "manual",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "self_report",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+        {
+          name: "dim2",
+          label: "Dim 2",
+          current_value: 0.4,
+          threshold: { type: "min", value: 1.0 },
+          confidence: 0.5,
+          observation_method: {
+            type: "manual",
+            source: "manual",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "self_report",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await deps.stateManager.saveGoal(goal);
+    await deps.stateManager.saveGapHistory("goal-1", [
+      {
+        iteration: 0,
+        timestamp: new Date().toISOString(),
+        gap_vector: [
+          { dimension_name: "dim1", normalized_weighted_gap: 0.8 },
+          { dimension_name: "dim2", normalized_weighted_gap: 0.4 },
+        ],
+        confidence_vector: [],
+      },
+    ]);
+
+    const portfolioManager = {
+      isWaitStrategy: vi.fn().mockImplementation(
+        (strategy: Record<string, unknown>) => typeof strategy["wait_until"] === "string"
+      ),
+      shouldRebalance: vi.fn(),
+      rebalance: vi.fn(),
+    };
+    const depsWithPortfolio = {
+      ...deps,
+      portfolioManager,
+      strategyManager: {
+        ...deps.strategyManager,
+        getPortfolio: vi.fn().mockResolvedValue({
+          goal_id: "goal-1",
+          strategies: [
+            {
+              id: "wait-1",
+              state: "active",
+              primary_dimension: "dim1",
+              wait_until: new Date(Date.now() + 60_000).toISOString(),
+            },
+          ],
+        }),
+      } as unknown as StrategyManager,
+    };
+    (depsWithPortfolio.stallDetector.isSuppressed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (depsWithPortfolio.stallDetector.checkDimensionStall as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const globalCheck = depsWithPortfolio.stallDetector.checkGlobalStall as ReturnType<typeof vi.fn>;
+    globalCheck.mockReturnValue(null);
+
+    const ctx = buildPhaseCtx(depsWithPortfolio as unknown as CoreLoopDeps, { maxIterations: 10, adapterType: "openai_codex_cli" });
+    const result = makeIterationResult();
+
+    await detectStallsAndRebalance(ctx, "goal-1", goal, result);
+
+    expect(result.waitSuppressed).toBe(true);
+    expect(depsWithPortfolio.stallDetector.checkDimensionStall).toHaveBeenCalledTimes(1);
+    expect(depsWithPortfolio.stallDetector.checkDimensionStall).toHaveBeenCalledWith(
+      "goal-1",
+      "dim2",
+      [{ normalized_gap: 0.4 }]
+    );
+    const globalHistory = globalCheck.mock.calls[0]?.[1] as Map<string, Array<{ normalized_gap: number }>>;
+    expect(globalHistory.has("dim1")).toBe(false);
+    expect(globalHistory.get("dim2")).toEqual([{ normalized_gap: 0.4 }]);
+  });
+
+  it("suppresses only the WaitStrategy primary_dimension, not every target_dimension", async () => {
+    const deps = createBaseDeps(tmpDir);
+    const goal = makeGoal({
+      id: "goal-1",
+      dimensions: [
+        {
+          name: "dim1",
+          label: "Dim 1",
+          current_value: 0.2,
+          threshold: { type: "min", value: 1.0 },
+          confidence: 0.5,
+          observation_method: {
+            type: "manual",
+            source: "manual",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "self_report",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+        {
+          name: "dim2",
+          label: "Dim 2",
+          current_value: 0.4,
+          threshold: { type: "min", value: 1.0 },
+          confidence: 0.5,
+          observation_method: {
+            type: "manual",
+            source: "manual",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "self_report",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await deps.stateManager.saveGoal(goal);
+    await deps.stateManager.saveGapHistory("goal-1", [
+      {
+        iteration: 0,
+        timestamp: new Date().toISOString(),
+        gap_vector: [
+          { dimension_name: "dim1", normalized_weighted_gap: 0.8 },
+          { dimension_name: "dim2", normalized_weighted_gap: 0.4 },
+        ],
+        confidence_vector: [],
+      },
+    ]);
+
+    const portfolioManager = {
+      isWaitStrategy: vi.fn().mockReturnValue(true),
+      shouldRebalance: vi.fn(),
+      rebalance: vi.fn(),
+    };
+    const depsWithPortfolio = {
+      ...deps,
+      portfolioManager,
+      strategyManager: {
+        ...deps.strategyManager,
+        getPortfolio: vi.fn().mockResolvedValue({
+          goal_id: "goal-1",
+          strategies: [
+            {
+              id: "wait-1",
+              state: "active",
+              primary_dimension: "dim1",
+              target_dimensions: ["dim1", "dim2"],
+              wait_until: new Date(Date.now() + 60_000).toISOString(),
+            },
+          ],
+        }),
+      } as unknown as StrategyManager,
+    };
+    (depsWithPortfolio.stallDetector.isSuppressed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (depsWithPortfolio.stallDetector.checkDimensionStall as ReturnType<typeof vi.fn>).mockReturnValue(null);
+    const globalCheck = depsWithPortfolio.stallDetector.checkGlobalStall as ReturnType<typeof vi.fn>;
+    globalCheck.mockReturnValue(null);
+
+    const ctx = buildPhaseCtx(depsWithPortfolio, { maxIterations: 10, adapterType: "openai_codex_cli" });
+    const result = makeIterationResult();
+
+    await detectStallsAndRebalance(ctx, "goal-1", goal, result);
+
+    expect(depsWithPortfolio.stallDetector.checkDimensionStall).toHaveBeenCalledTimes(1);
+    expect(depsWithPortfolio.stallDetector.checkDimensionStall).toHaveBeenCalledWith(
+      "goal-1",
+      "dim2",
+      [{ normalized_gap: 0.4 }]
+    );
+    const globalHistory = globalCheck.mock.calls[0]?.[1] as Map<string, Array<{ normalized_gap: number }>>;
+    expect(globalHistory.has("dim1")).toBe(false);
+    expect(globalHistory.has("dim2")).toBe(true);
+  });
+
+  it("skips global stall checks when every dimension is wait-suppressed", async () => {
+    const deps = createBaseDeps(tmpDir);
+    const goal = makeGoal({
+      id: "goal-1",
+      dimensions: [
+        {
+          name: "dim1",
+          label: "Dim 1",
+          current_value: 0.2,
+          threshold: { type: "min", value: 1.0 },
+          confidence: 0.5,
+          observation_method: {
+            type: "manual",
+            source: "manual",
+            schedule: null,
+            endpoint: null,
+            confidence_tier: "self_report",
+          },
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await deps.stateManager.saveGoal(goal);
+    await deps.stateManager.saveGapHistory("goal-1", [
+      {
+        iteration: 0,
+        timestamp: new Date().toISOString(),
+        gap_vector: [{ dimension_name: "dim1", normalized_weighted_gap: 0.8 }],
+        confidence_vector: [],
+      },
+    ]);
+
+    const depsWithPortfolio = {
+      ...deps,
+      portfolioManager: {
+        isWaitStrategy: vi.fn().mockReturnValue(true),
+        shouldRebalance: vi.fn(),
+        rebalance: vi.fn(),
+      },
+      strategyManager: {
+        ...deps.strategyManager,
+        getPortfolio: vi.fn().mockResolvedValue({
+          goal_id: "goal-1",
+          strategies: [
+            {
+              id: "wait-1",
+              state: "active",
+              primary_dimension: "dim1",
+              wait_until: new Date(Date.now() + 60_000).toISOString(),
+            },
+          ],
+        }),
+      } as unknown as StrategyManager,
+    };
+    (depsWithPortfolio.stallDetector.isSuppressed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    (depsWithPortfolio.stallDetector.checkDimensionStall as ReturnType<typeof vi.fn>).mockReturnValue(null);
+
+    const ctx = buildPhaseCtx(depsWithPortfolio as unknown as CoreLoopDeps, { maxIterations: 10, adapterType: "openai_codex_cli" });
+    const result = makeIterationResult();
+
+    await detectStallsAndRebalance(ctx, "goal-1", goal, result);
+
+    expect(depsWithPortfolio.stallDetector.checkDimensionStall).not.toHaveBeenCalled();
+    expect(depsWithPortfolio.stallDetector.checkGlobalStall).not.toHaveBeenCalled();
+    expect(result.stallDetected).toBe(false);
+    expect(result.waitSuppressed).toBe(true);
+  });
 });

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -31,11 +31,18 @@ import type { CapabilityAcquisitionOutcome } from "./capability.js";
 import type { CoreLoopEvidenceLedger } from "./evidence-ledger.js";
 import { ApprovalStore } from "../../../runtime/store/approval-store.js";
 import { buildWaitApprovalId } from "../../strategy/portfolio-rebalance.js";
+import type { WaitStrategyActivationContext } from "../../strategy/strategy-manager-base.js";
+import type { GapObservation } from "../../../base/types/time-horizon.js";
 
 // ─── Phase 5 ───
 
 const WAIT_APPROVAL_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 const WAIT_APPROVAL_REMINDER_MS = 15 * 60 * 1000;
+
+type DimensionGapSample = {
+  normalized_gap: number;
+  timestamp: string;
+};
 
 function resolveGoalWorkspacePath(goal: Goal): string | undefined {
   const constraint = goal.constraints.find((entry) => entry.startsWith("workspace_path:"));
@@ -137,6 +144,12 @@ export async function detectStallsAndRebalance(
   try {
     const gapHistory = await ctx.deps.stateManager.loadGapHistory(goalId);
     const gapHistoryByDimension = indexGapHistoryByDimension(goal, gapHistory);
+    const waitActivationContext = buildWaitStrategyActivationContext(
+      ctx,
+      goalId,
+      goal,
+      gapHistoryByDimension
+    );
 
     // Gather tool-based workspace evidence for stall detection (Phase 6)
     if (ctx.toolExecutor) {
@@ -220,7 +233,19 @@ export async function detectStallsAndRebalance(
         }
 
         const escalationLevel = await ctx.deps.stallDetector.getEscalationLevel(goalId, dim.name);
-        await applyStallAction(ctx, goalId, goal, dimGapHistory, stallReport, escalationLevel, dim.name, result, "", stallActionHints);
+        await applyStallAction(
+          ctx,
+          goalId,
+          goal,
+          dimGapHistory,
+          stallReport,
+          escalationLevel,
+          dim.name,
+          result,
+          "",
+          stallActionHints,
+          waitActivationContext
+        );
         break;
       }
     }
@@ -234,13 +259,14 @@ export async function detectStallsAndRebalance(
         result,
         gapHistoryByDimension,
         suppressedDimensions,
-        stallActionHints
+        stallActionHints,
+        waitActivationContext
       );
     }
 
     // Portfolio: check rebalance after stall detection
     if (ctx.deps.portfolioManager) {
-      await rebalancePortfolio(ctx, goalId, goal);
+      await rebalancePortfolio(ctx, goalId, goal, waitActivationContext);
     }
   } catch (err) {
     ctx.logger?.warn("CoreLoop: stall detection failed (non-fatal)", { error: err instanceof Error ? err.message : String(err) });
@@ -250,8 +276,8 @@ export async function detectStallsAndRebalance(
 function indexGapHistoryByDimension(
   goal: Goal,
   gapHistory: GapHistoryEntry[]
-): Map<string, Array<{ normalized_gap: number }>> {
-  const indexedHistory = new Map<string, Array<{ normalized_gap: number }>>();
+): Map<string, DimensionGapSample[]> {
+  const indexedHistory = new Map<string, DimensionGapSample[]>();
 
   for (const dim of goal.dimensions) {
     indexedHistory.set(dim.name, []);
@@ -268,12 +294,69 @@ function indexGapHistoryByDimension(
         continue;
       }
 
-      const normalizedGap = { normalized_gap: gap.normalized_weighted_gap ?? 1 };
+      const normalizedGap = {
+        normalized_gap: gap.normalized_weighted_gap ?? 1,
+        timestamp: entry.timestamp,
+      };
       dimHistory.push(normalizedGap);
     }
   }
 
   return indexedHistory;
+}
+
+function buildWaitStrategyActivationContext(
+  ctx: PhaseCtx,
+  goalId: string,
+  goal: Goal,
+  gapHistoryByDimension: ReadonlyMap<string, DimensionGapSample[]>
+): WaitStrategyActivationContext | undefined {
+  if (!ctx.timeHorizonEngine) {
+    return undefined;
+  }
+
+  const velocityByDimension = new Map<string, number>();
+  for (const [dimensionName, dimHistory] of gapHistoryByDimension.entries()) {
+    if (dimHistory.length < 2) continue;
+    const currentGap = dimHistory[dimHistory.length - 1]?.normalized_gap;
+    if (typeof currentGap !== "number" || !Number.isFinite(currentGap)) continue;
+    const observations: GapObservation[] = dimHistory.map((entry) => ({
+      timestamp: entry.timestamp,
+      normalizedGap: entry.normalized_gap,
+    }));
+    const pacing = ctx.timeHorizonEngine.evaluatePacing(
+      goalId,
+      currentGap,
+      goal.deadline ?? null,
+      observations
+    );
+    if (Number.isFinite(pacing.velocityPerHour)) {
+      velocityByDimension.set(dimensionName, pacing.velocityPerHour);
+    }
+  }
+
+  return {
+    getCurrentGap: (_goalId, dimension) => {
+      const history = gapHistoryByDimension.get(dimension);
+      return history && history.length > 0
+        ? history[history.length - 1]?.normalized_gap ?? null
+        : null;
+    },
+    canAffordWait: ({ strategy, waitHours, currentGap, initialGap, startedAt }) => {
+      const velocityPerHour = velocityByDimension.get(strategy.primary_dimension);
+      if (velocityPerHour === undefined) {
+        return false;
+      }
+      const budget = ctx.timeHorizonEngine!.getTimeBudget(
+        goal.deadline ?? null,
+        goal.created_at ?? startedAt,
+        currentGap,
+        initialGap,
+        velocityPerHour
+      );
+      return budget.canAffordWait(waitHours);
+    },
+  };
 }
 
 // ─── Shared stall-action helper ───
@@ -289,13 +372,14 @@ async function applyStallAction(
   ctx: PhaseCtx,
   goalId: string,
   goal: Goal,
-  dimHistory: Array<{ normalized_gap: number }>,
+  dimHistory: DimensionGapSample[],
   stallReport: StallReport,
   escalationLevel: number,
   incrementDimName: string,
   result: LoopIterationResult,
   logPrefix: string,
-  stallActionHints?: StallActionHints
+  stallActionHints?: StallActionHints,
+  waitActivationContext?: WaitStrategyActivationContext
 ): Promise<void> {
   if (ctx.deps.learningPipeline) {
     try {
@@ -344,7 +428,12 @@ async function applyStallAction(
       goalId,
       evidence: analysis?.evidence,
     });
-    await ctx.deps.strategyManager.onStallDetected(goalId, 3, goal.origin ?? "general");
+    await ctx.deps.strategyManager.onStallDetected(
+      goalId,
+      3,
+      goal.origin ?? "general",
+      waitActivationContext
+    );
     result.pivotOccurred = true;
   } else {
     // PIVOT: switch strategy, but check pivot count limit first
@@ -360,13 +449,19 @@ async function applyStallAction(
         pivotCount,
         maxPivotCount,
       });
-      await ctx.deps.strategyManager.onStallDetected(goalId, 3, goal.origin ?? "general");
+      await ctx.deps.strategyManager.onStallDetected(
+        goalId,
+        3,
+        goal.origin ?? "general",
+        waitActivationContext
+      );
       result.pivotOccurred = true;
     } else {
       const newStrategy = await ctx.deps.strategyManager.onStallDetected(
         goalId,
         escalationLevel + 1,
-        goal.origin ?? "general"
+        goal.origin ?? "general",
+        waitActivationContext
       );
       if (newStrategy) {
         result.pivotOccurred = true;
@@ -421,9 +516,10 @@ async function checkGlobalStall(
   goalId: string,
   goal: Goal,
   result: LoopIterationResult,
-  gapHistoryByDimension: Map<string, Array<{ normalized_gap: number }>>,
+  gapHistoryByDimension: Map<string, DimensionGapSample[]>,
   suppressedDimensions: ReadonlySet<string>,
-  stallActionHints?: StallActionHints
+  stallActionHints?: StallActionHints,
+  waitActivationContext?: WaitStrategyActivationContext
 ): Promise<void> {
   const activeGapHistoryByDimension =
     suppressedDimensions.size === 0
@@ -451,14 +547,27 @@ async function checkGlobalStall(
   const firstDimName = firstActiveDimension;
 
   // Pass escalationLevel=1 so that escalationLevel+1=2, preserving the original global PIVOT level
-  await applyStallAction(ctx, goalId, goal, firstDimHistory, globalStall, 1, firstDimName, result, "global ", stallActionHints);
+  await applyStallAction(
+    ctx,
+    goalId,
+    goal,
+    firstDimHistory,
+    globalStall,
+    1,
+    firstDimName,
+    result,
+    "global ",
+    stallActionHints,
+    waitActivationContext
+  );
 }
 
 /** Portfolio rebalance: check for normal rebalance triggers after stall detection. */
 async function rebalancePortfolio(
   ctx: PhaseCtx,
   goalId: string,
-  goal: Goal
+  goal: Goal,
+  waitActivationContext?: WaitStrategyActivationContext
 ): Promise<void> {
   if (!ctx.deps.portfolioManager) return;
   try {
@@ -466,7 +575,12 @@ async function rebalancePortfolio(
     if (rebalanceTrigger) {
       const rebalanceResult = await ctx.deps.portfolioManager.rebalance(goalId, rebalanceTrigger);
       if (rebalanceResult.new_generation_needed) {
-        await ctx.deps.strategyManager.onStallDetected(goalId, 3, goal.origin ?? "general");
+        await ctx.deps.strategyManager.onStallDetected(
+          goalId,
+          3,
+          goal.origin ?? "general",
+          waitActivationContext
+        );
       }
     }
   } catch {
@@ -541,6 +655,13 @@ export async function evaluateWaitStrategiesForObserveOnly(
     return { observeOnly: false, newGenerationNeeded: false, outcome: null };
   }
 
+  const waitActivationContext = buildWaitStrategyActivationContext(
+    ctx,
+    goalId,
+    goal,
+    indexGapHistoryByDimension(goal, await ctx.deps.stateManager.loadGapHistory(goalId))
+  );
+
   try {
     const portfolio = await ctx.deps.strategyManager.getPortfolio(goalId);
     if (!portfolio) {
@@ -556,7 +677,8 @@ export async function evaluateWaitStrategiesForObserveOnly(
 
       const waitOutcome = await ctx.deps.portfolioManager.handleWaitStrategyExpiry(
         goalId,
-        strategy.id
+        strategy.id,
+        waitActivationContext
       );
       if (!waitOutcome) {
         continue;
@@ -580,7 +702,12 @@ export async function evaluateWaitStrategiesForObserveOnly(
       if (waitTrigger) {
         const rebalanceResult = await ctx.deps.portfolioManager.rebalance(goalId, waitTrigger);
         if (rebalanceResult.new_generation_needed) {
-          await ctx.deps.strategyManager.onStallDetected(goalId, 3, goal.origin ?? "general");
+          await ctx.deps.strategyManager.onStallDetected(
+            goalId,
+            3,
+            goal.origin ?? "general",
+            waitActivationContext
+          );
           result.waitObserveOnly = false;
           return { observeOnly: false, newGenerationNeeded: true, outcome: waitOutcome };
         }

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -172,7 +172,9 @@ export async function detectStallsAndRebalance(
             const ws = s as Record<string, unknown>;
             const waitUntil = typeof ws["wait_until"] === "string" ? ws["wait_until"] as string : null;
             if (!ctx.deps.stallDetector.isSuppressed(waitUntil)) continue;
-            // Suppress only the primary_dimension of this WaitStrategy
+            // Suppression is intentionally primary_dimension-only. Wait expiry,
+            // baseline capture, and outcome evaluation are all keyed to the
+            // canonical wait dimension rather than every target_dimension.
             const primaryDim = typeof ws["primary_dimension"] === "string" ? ws["primary_dimension"] as string : null;
             if (primaryDim) {
               suppressedDimensions.add(primaryDim);
@@ -225,7 +227,15 @@ export async function detectStallsAndRebalance(
 
     // Global stall check
     if (!result.stallDetected) {
-      await checkGlobalStall(ctx, goalId, goal, result, gapHistoryByDimension, stallActionHints);
+      await checkGlobalStall(
+        ctx,
+        goalId,
+        goal,
+        result,
+        gapHistoryByDimension,
+        suppressedDimensions,
+        stallActionHints
+      );
     }
 
     // Portfolio: check rebalance after stall detection
@@ -412,16 +422,33 @@ async function checkGlobalStall(
   goal: Goal,
   result: LoopIterationResult,
   gapHistoryByDimension: Map<string, Array<{ normalized_gap: number }>>,
+  suppressedDimensions: ReadonlySet<string>,
   stallActionHints?: StallActionHints
 ): Promise<void> {
-  const globalStall = ctx.deps.stallDetector.checkGlobalStall(goalId, gapHistoryByDimension);
+  const activeGapHistoryByDimension =
+    suppressedDimensions.size === 0
+      ? gapHistoryByDimension
+      : new Map(
+          Array.from(gapHistoryByDimension.entries()).filter(
+            ([dimensionName]) => !suppressedDimensions.has(dimensionName)
+          )
+        );
+  if (activeGapHistoryByDimension.size === 0) {
+    return;
+  }
+
+  const globalStall = ctx.deps.stallDetector.checkGlobalStall(goalId, activeGapHistoryByDimension);
   if (!globalStall) return;
 
   result.stallDetected = true;
   result.stallReport = globalStall;
 
-  const firstDimHistory = gapHistoryByDimension.get(goal.dimensions[0]?.name ?? "") ?? [];
-  const firstDimName = goal.dimensions[0]?.name ?? "";
+  const firstActiveDimension =
+    goal.dimensions.find((dimension) => !suppressedDimensions.has(dimension.name))?.name
+    ?? activeGapHistoryByDimension.keys().next().value
+    ?? "";
+  const firstDimHistory = activeGapHistoryByDimension.get(firstActiveDimension) ?? [];
+  const firstDimName = firstActiveDimension;
 
   // Pass escalationLevel=1 so that escalationLevel+1=2, preserving the original global PIVOT level
   await applyStallAction(ctx, goalId, goal, firstDimHistory, globalStall, 1, firstDimName, result, "global ", stallActionHints);

--- a/src/orchestrator/strategy/__tests__/portfolio-manager.test.ts
+++ b/src/orchestrator/strategy/__tests__/portfolio-manager.test.ts
@@ -713,34 +713,18 @@ describe("PortfolioManager", () => {
   describe("activateStrategies", () => {
     it("single strategy gets allocation 1.0", async () => {
       const s1 = makeStrategy({ id: "s1", state: "candidate", allocation: 0 });
-      const portfolio = makePortfolio([s1]);
-      (mockStrategyManager.getPortfolio as ReturnType<typeof vi.fn>).mockReturnValue(portfolio);
-
-      pm.activateStrategies("goal-1", ["s1"]);
-      await Promise.resolve(); // flush microtasks so async updateStrategyAllocation completes
-
-      expect(mockStrategyManager.updateState).toHaveBeenCalledWith("s1", "active");
-      expect(mockStrategyManager.savePortfolio).toHaveBeenCalled();
+      await pm.activateStrategies("goal-1", ["s1"]);
+      expect(mockStrategyManager.activateMultiple).toHaveBeenCalledWith("goal-1", ["s1"], undefined);
     });
 
     it("multiple strategies get equal split", async () => {
-      const s1 = makeStrategy({ id: "s1", state: "candidate", allocation: 0 });
-      const s2 = makeStrategy({ id: "s2", state: "candidate", allocation: 0 });
-      const s3 = makeStrategy({ id: "s3", state: "candidate", allocation: 0 });
-      const portfolio = makePortfolio([s1, s2, s3]);
-      (mockStrategyManager.getPortfolio as ReturnType<typeof vi.fn>).mockReturnValue(portfolio);
-
-      pm.activateStrategies("goal-1", ["s1", "s2", "s3"]);
-      await Promise.resolve(); // flush microtasks so async updateStrategyAllocation completes
-
-      expect(mockStrategyManager.updateState).toHaveBeenCalledTimes(3);
-      // savePortfolio called once per strategy for allocation update
-      expect(mockStrategyManager.savePortfolio).toHaveBeenCalledTimes(3);
+      await pm.activateStrategies("goal-1", ["s1", "s2", "s3"]);
+      expect(mockStrategyManager.activateMultiple).toHaveBeenCalledWith("goal-1", ["s1", "s2", "s3"], undefined);
     });
 
     it("does nothing when no strategy IDs provided", async () => {
-      pm.activateStrategies("goal-1", []);
-      expect(mockStrategyManager.updateState).not.toHaveBeenCalled();
+      await pm.activateStrategies("goal-1", []);
+      expect(mockStrategyManager.activateMultiple).not.toHaveBeenCalled();
     });
   });
 
@@ -839,8 +823,52 @@ describe("PortfolioManager", () => {
 
       expect(result).toMatchObject({ status: "fallback_activated", strategy_id: "ws1" });
       expect(result?.rebalance_trigger).toBeUndefined();
-      expect(mockStrategyManager.updateState).toHaveBeenNthCalledWith(1, "fallback-1", "active");
-      expect(mockStrategyManager.updateState).toHaveBeenNthCalledWith(2, "ws1", "terminated");
+      expect(mockStrategyManager.activateMultiple).toHaveBeenCalledWith("goal-1", ["fallback-1"], undefined);
+      expect(mockStrategyManager.updateState).toHaveBeenCalledWith("ws1", "terminated");
+    });
+
+    it("terminates and returns a rebalance trigger when fallback activation is denied", async () => {
+      const fallback = makeWaitStrategy({
+        id: "fallback-1",
+        state: "candidate",
+        allocation: 0,
+      });
+      const wait = makeWaitStrategy({
+        id: "ws1",
+        state: "active",
+        wait_until: new Date(Date.now() - 100_000).toISOString(),
+        gap_snapshot_at_start: 0.5,
+        primary_dimension: "quality",
+        fallback_strategy_id: fallback.id,
+      });
+      const portfolio = makePortfolio([wait, fallback]);
+      (mockStrategyManager.getPortfolio as ReturnType<typeof vi.fn>).mockReturnValue(portfolio);
+      (mockStateManager.readRaw as ReturnType<typeof vi.fn>).mockResolvedValue({ quality: 0.5 });
+      (mockStrategyManager.activateMultiple as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("cannot be activated because the goal cannot afford waiting")
+      );
+
+      const result = await pm.handleWaitStrategyExpiry("goal-1", "ws1", {
+        canAffordWait: async () => false,
+      });
+
+      expect(result).toMatchObject({
+        status: "unchanged",
+        strategy_id: "ws1",
+        rebalance_trigger: {
+          type: "stall_detected",
+          strategy_id: "ws1",
+        },
+      });
+      expect(result?.details).toContain("could not be activated");
+      expect(mockStrategyManager.activateMultiple).toHaveBeenCalledWith(
+        "goal-1",
+        ["fallback-1"],
+        expect.objectContaining({
+          canAffordWait: expect.any(Function),
+        })
+      );
+      expect(mockStrategyManager.updateState).toHaveBeenCalledWith("ws1", "terminated");
     });
 
     it("terminates and returns rebalance trigger when expired and gap worsened", async () => {

--- a/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import { z } from "zod";
 import { StateManager } from "../../../base/state/state-manager.js";
@@ -421,6 +421,33 @@ describe("activateBestCandidate", () => {
 
     expect(activated.started_at! >= before).toBe(true);
     expect(activated.started_at! <= after).toBe(true);
+  });
+
+  it("routes wait candidates through activateMultiple so canAffordWait is enforced", async () => {
+    const mock = createMockLLMClient([]);
+    const manager = new StrategyManager(stateManager, mock);
+    const wait = await manager.createWaitStrategy("goal-1", {
+      hypothesis: "Wait for external signal",
+      wait_reason: "Awaiting external signal",
+      wait_until: new Date(Date.now() + 3 * 60 * 60 * 1000).toISOString(),
+      measurement_plan: "Check signal after wait",
+      fallback_strategy_id: null,
+      target_dimensions: ["word_count"],
+      primary_dimension: "word_count",
+    });
+    const canAffordWait = vi.fn().mockReturnValue(false);
+
+    await expect(
+      manager.activateBestCandidate("goal-1", {
+        getCurrentGap: async () => 0.5,
+        canAffordWait,
+      })
+    ).rejects.toThrow("cannot be activated because the goal cannot afford waiting");
+
+    expect(canAffordWait).toHaveBeenCalledTimes(1);
+    const portfolio = await manager.getPortfolio("goal-1");
+    const stored = portfolio!.strategies.find((strategy) => strategy.id === wait.id);
+    expect(stored?.state).toBe("candidate");
   });
 });
 

--- a/src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts
@@ -440,6 +440,38 @@ describe("Phase 2 methods", () => {
       expect(targetTask["plateau_until"]).toBe(waitUntil);
       expect(otherTask["plateau_until"]).toBeNull();
     });
+
+    it("does not mirror wait_until into a task owned by a different strategy", async () => {
+      const mock = createMockLLMClient([]);
+      const manager = new StrategyManager(stateManager, mock);
+      const waitUntil = "2026-04-27T03:00:00.000Z";
+      const wait = await manager.createWaitStrategy("goal-1", {
+        hypothesis: "Wait for external signal",
+        wait_reason: "Awaiting external signal",
+        wait_until: waitUntil,
+        measurement_plan: "Check signal after wait",
+        fallback_strategy_id: null,
+        target_dimensions: ["quality"],
+        primary_dimension: "quality",
+      });
+      await writeTaskFixture("goal-1", "task-other", {
+        status: "running",
+        started_at: "2026-04-27T00:30:00.000Z",
+        strategy_id: "other-strategy",
+      });
+      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
+        {
+          task_id: "task-other",
+          strategy_id: "other-strategy",
+          status: "running",
+        },
+      ]);
+
+      await manager.activateMultiple("goal-1", [wait.id]);
+
+      const otherTask = await stateManager.readRaw("tasks/goal-1/task-other.json") as Record<string, unknown>;
+      expect(otherTask["plateau_until"]).toBeNull();
+    });
   });
 
   describe("terminateStrategy", () => {

--- a/src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts
@@ -254,11 +254,6 @@ describe("Phase 2 methods", () => {
       const mock = createMockLLMClient([]);
       const manager = new StrategyManager(stateManager, mock);
       const waitUntil = "2026-04-27T03:00:00.000Z";
-      await writeTaskFixture("goal-1", "task-running", {
-        status: "running",
-        started_at: "2026-04-27T00:00:00.000Z",
-      });
-
       const wait = await manager.createWaitStrategy("goal-1", {
         hypothesis: "Wait for external signal",
         wait_reason: "Awaiting external signal",
@@ -267,6 +262,11 @@ describe("Phase 2 methods", () => {
         fallback_strategy_id: null,
         target_dimensions: ["quality"],
         primary_dimension: "quality",
+      });
+      await writeTaskFixture("goal-1", "task-running", {
+        status: "running",
+        started_at: "2026-04-27T00:00:00.000Z",
+        strategy_id: wait.id,
       });
 
       await manager.activateMultiple("goal-1", [wait.id]);
@@ -279,14 +279,6 @@ describe("Phase 2 methods", () => {
       const mock = createMockLLMClient([]);
       const manager = new StrategyManager(stateManager, mock);
       const waitUntil = "2026-04-27T03:00:00.000Z";
-      await writeTaskFixture("goal-1", "task-pending");
-      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
-        {
-          task_id: "task-pending",
-          status: "pending",
-        },
-      ]);
-
       const wait = await manager.createWaitStrategy("goal-1", {
         hypothesis: "Wait for external signal",
         wait_reason: "Awaiting external signal",
@@ -296,6 +288,16 @@ describe("Phase 2 methods", () => {
         target_dimensions: ["quality"],
         primary_dimension: "quality",
       });
+      await writeTaskFixture("goal-1", "task-pending", {
+        strategy_id: wait.id,
+      });
+      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
+        {
+          task_id: "task-pending",
+          strategy_id: wait.id,
+          status: "pending",
+        },
+      ]);
 
       await manager.activateMultiple("goal-1", [wait.id]);
 
@@ -307,14 +309,6 @@ describe("Phase 2 methods", () => {
       const mock = createMockLLMClient([]);
       const manager = new StrategyManager(stateManager, mock);
       const waitUntil = "2026-04-27T03:00:00.000Z";
-      await writeTaskFixture("goal-1", "task-legacy");
-      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
-        {
-          id: "task-legacy",
-          status: "pending",
-        },
-      ]);
-
       const wait = await manager.createWaitStrategy("goal-1", {
         hypothesis: "Wait for external signal",
         wait_reason: "Awaiting external signal",
@@ -324,6 +318,16 @@ describe("Phase 2 methods", () => {
         target_dimensions: ["quality"],
         primary_dimension: "quality",
       });
+      await writeTaskFixture("goal-1", "task-legacy", {
+        strategy_id: wait.id,
+      });
+      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
+        {
+          id: "task-legacy",
+          strategy_id: wait.id,
+          status: "pending",
+        },
+      ]);
 
       await manager.activateMultiple("goal-1", [wait.id]);
 
@@ -335,18 +339,6 @@ describe("Phase 2 methods", () => {
       const mock = createMockLLMClient([]);
       const manager = new StrategyManager(stateManager, mock);
       const waitUntil = "2026-04-27T03:00:00.000Z";
-      await writeTaskFixture("goal-1", "task-running", {
-        status: "running",
-        started_at: "2026-04-27T00:00:00.000Z",
-      });
-      await writeTaskFixture("goal-1", "task-stale");
-      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
-        {
-          task_id: "task-stale",
-          status: "pending",
-        },
-      ]);
-
       const wait = await manager.createWaitStrategy("goal-1", {
         hypothesis: "Wait for external signal",
         wait_reason: "Awaiting external signal",
@@ -356,6 +348,18 @@ describe("Phase 2 methods", () => {
         target_dimensions: ["quality"],
         primary_dimension: "quality",
       });
+      await writeTaskFixture("goal-1", "task-running", {
+        status: "running",
+        started_at: "2026-04-27T00:00:00.000Z",
+        strategy_id: wait.id,
+      });
+      await writeTaskFixture("goal-1", "task-stale");
+      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
+        {
+          task_id: "task-stale",
+          status: "pending",
+        },
+      ]);
 
       await manager.activateMultiple("goal-1", [wait.id]);
 
@@ -363,6 +367,78 @@ describe("Phase 2 methods", () => {
       const staleTask = await stateManager.readRaw("tasks/goal-1/task-stale.json") as Record<string, unknown>;
       expect(runningTask["plateau_until"]).toBe(waitUntil);
       expect(staleTask["plateau_until"]).toBeNull();
+    });
+
+    it("prefers a strategy-matching running task over a newer unrelated running task", async () => {
+      const mock = createMockLLMClient([]);
+      const manager = new StrategyManager(stateManager, mock);
+      const waitUntil = "2026-04-27T03:00:00.000Z";
+      const wait = await manager.createWaitStrategy("goal-1", {
+        hypothesis: "Wait for external signal",
+        wait_reason: "Awaiting external signal",
+        wait_until: waitUntil,
+        measurement_plan: "Check signal after wait",
+        fallback_strategy_id: null,
+        target_dimensions: ["quality"],
+        primary_dimension: "quality",
+      });
+      await writeTaskFixture("goal-1", "task-target", {
+        status: "running",
+        started_at: "2026-04-27T00:00:00.000Z",
+        strategy_id: wait.id,
+      });
+      await writeTaskFixture("goal-1", "task-other", {
+        status: "running",
+        started_at: "2026-04-27T00:30:00.000Z",
+        strategy_id: "other-strategy",
+      });
+
+      await manager.activateMultiple("goal-1", [wait.id]);
+
+      const targetTask = await stateManager.readRaw("tasks/goal-1/task-target.json") as Record<string, unknown>;
+      const otherTask = await stateManager.readRaw("tasks/goal-1/task-other.json") as Record<string, unknown>;
+      expect(targetTask["plateau_until"]).toBe(waitUntil);
+      expect(otherTask["plateau_until"]).toBeNull();
+    });
+
+    it("prefers a strategy-matching task-history entry over unrelated pending tasks", async () => {
+      const mock = createMockLLMClient([]);
+      const manager = new StrategyManager(stateManager, mock);
+      const waitUntil = "2026-04-27T03:00:00.000Z";
+      const wait = await manager.createWaitStrategy("goal-1", {
+        hypothesis: "Wait for external signal",
+        wait_reason: "Awaiting external signal",
+        wait_until: waitUntil,
+        measurement_plan: "Check signal after wait",
+        fallback_strategy_id: null,
+        target_dimensions: ["quality"],
+        primary_dimension: "quality",
+      });
+      await writeTaskFixture("goal-1", "task-other", {
+        strategy_id: "other-strategy",
+      });
+      await writeTaskFixture("goal-1", "task-target", {
+        strategy_id: wait.id,
+      });
+      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
+        {
+          task_id: "task-other",
+          strategy_id: "other-strategy",
+          status: "pending",
+        },
+        {
+          task_id: "task-target",
+          strategy_id: wait.id,
+          status: "pending",
+        },
+      ]);
+
+      await manager.activateMultiple("goal-1", [wait.id]);
+
+      const targetTask = await stateManager.readRaw("tasks/goal-1/task-target.json") as Record<string, unknown>;
+      const otherTask = await stateManager.readRaw("tasks/goal-1/task-other.json") as Record<string, unknown>;
+      expect(targetTask["plateau_until"]).toBe(waitUntil);
+      expect(otherTask["plateau_until"]).toBeNull();
     });
   });
 

--- a/src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts
@@ -67,6 +67,42 @@ afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
 });
 
+async function writeTaskFixture(
+  goalId: string,
+  taskId: string,
+  overrides: Record<string, unknown> = {}
+): Promise<void> {
+  await stateManager.writeRaw(`tasks/${goalId}/${taskId}.json`, {
+    id: taskId,
+    goal_id: goalId,
+    strategy_id: null,
+    target_dimensions: ["quality"],
+    primary_dimension: "quality",
+    work_description: "Wait for an external signal",
+    rationale: "Track the active task linked to the wait strategy",
+    approach: "Observe only",
+    success_criteria: [],
+    scope_boundary: {
+      in_scope: ["observation"],
+      out_of_scope: ["execution"],
+      blast_radius: "none",
+    },
+    constraints: [],
+    plateau_until: null,
+    estimated_duration: null,
+    consecutive_failure_count: 0,
+    reversibility: "unknown",
+    task_category: "observation",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: "2026-04-27T00:00:00.000Z",
+    ...overrides,
+  });
+}
+
 // ─── Phase 2 methods ───
 
 describe("Phase 2 methods", () => {
@@ -212,6 +248,121 @@ describe("Phase 2 methods", () => {
       const portfolio = await manager.getPortfolio("goal-1");
       const stored = portfolio!.strategies.find((s) => s.id === wait.id);
       expect(stored!.gap_snapshot_at_start).toBe(0.42);
+    });
+
+    it("mirrors wait_until into a currently running task plateau_until", async () => {
+      const mock = createMockLLMClient([]);
+      const manager = new StrategyManager(stateManager, mock);
+      const waitUntil = "2026-04-27T03:00:00.000Z";
+      await writeTaskFixture("goal-1", "task-running", {
+        status: "running",
+        started_at: "2026-04-27T00:00:00.000Z",
+      });
+
+      const wait = await manager.createWaitStrategy("goal-1", {
+        hypothesis: "Wait for external signal",
+        wait_reason: "Awaiting external signal",
+        wait_until: waitUntil,
+        measurement_plan: "Check signal after wait",
+        fallback_strategy_id: null,
+        target_dimensions: ["quality"],
+        primary_dimension: "quality",
+      });
+
+      await manager.activateMultiple("goal-1", [wait.id]);
+
+      const storedTask = await stateManager.readRaw("tasks/goal-1/task-running.json") as Record<string, unknown>;
+      expect(storedTask["plateau_until"]).toBe(waitUntil);
+    });
+
+    it("falls back to task-history task_id entries when no running task file is found", async () => {
+      const mock = createMockLLMClient([]);
+      const manager = new StrategyManager(stateManager, mock);
+      const waitUntil = "2026-04-27T03:00:00.000Z";
+      await writeTaskFixture("goal-1", "task-pending");
+      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
+        {
+          task_id: "task-pending",
+          status: "pending",
+        },
+      ]);
+
+      const wait = await manager.createWaitStrategy("goal-1", {
+        hypothesis: "Wait for external signal",
+        wait_reason: "Awaiting external signal",
+        wait_until: waitUntil,
+        measurement_plan: "Check signal after wait",
+        fallback_strategy_id: null,
+        target_dimensions: ["quality"],
+        primary_dimension: "quality",
+      });
+
+      await manager.activateMultiple("goal-1", [wait.id]);
+
+      const storedTask = await stateManager.readRaw("tasks/goal-1/task-pending.json") as Record<string, unknown>;
+      expect(storedTask["plateau_until"]).toBe(waitUntil);
+    });
+
+    it("supports legacy task-history entries that only store id", async () => {
+      const mock = createMockLLMClient([]);
+      const manager = new StrategyManager(stateManager, mock);
+      const waitUntil = "2026-04-27T03:00:00.000Z";
+      await writeTaskFixture("goal-1", "task-legacy");
+      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
+        {
+          id: "task-legacy",
+          status: "pending",
+        },
+      ]);
+
+      const wait = await manager.createWaitStrategy("goal-1", {
+        hypothesis: "Wait for external signal",
+        wait_reason: "Awaiting external signal",
+        wait_until: waitUntil,
+        measurement_plan: "Check signal after wait",
+        fallback_strategy_id: null,
+        target_dimensions: ["quality"],
+        primary_dimension: "quality",
+      });
+
+      await manager.activateMultiple("goal-1", [wait.id]);
+
+      const storedTask = await stateManager.readRaw("tasks/goal-1/task-legacy.json") as Record<string, unknown>;
+      expect(storedTask["plateau_until"]).toBe(waitUntil);
+    });
+
+    it("prefers the live running task file over stale task-history entries", async () => {
+      const mock = createMockLLMClient([]);
+      const manager = new StrategyManager(stateManager, mock);
+      const waitUntil = "2026-04-27T03:00:00.000Z";
+      await writeTaskFixture("goal-1", "task-running", {
+        status: "running",
+        started_at: "2026-04-27T00:00:00.000Z",
+      });
+      await writeTaskFixture("goal-1", "task-stale");
+      await stateManager.writeRaw("tasks/goal-1/task-history.json", [
+        {
+          task_id: "task-stale",
+          status: "pending",
+        },
+      ]);
+
+      const wait = await manager.createWaitStrategy("goal-1", {
+        hypothesis: "Wait for external signal",
+        wait_reason: "Awaiting external signal",
+        wait_until: waitUntil,
+        measurement_plan: "Check signal after wait",
+        fallback_strategy_id: null,
+        target_dimensions: ["quality"],
+        primary_dimension: "quality",
+      });
+
+      await manager.activateMultiple("goal-1", [wait.id]);
+
+      const runningTask = await stateManager.readRaw("tasks/goal-1/task-running.json") as Record<string, unknown>;
+      const staleTask = await stateManager.readRaw("tasks/goal-1/task-stale.json") as Record<string, unknown>;
+      expect(runningTask["plateau_until"]).toBe(waitUntil);
+      expect(staleTask["plateau_until"]).toBeNull();
     });
   });
 

--- a/src/orchestrator/strategy/__tests__/strategy-manager-stall.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-stall.test.ts
@@ -76,6 +76,30 @@ afterEach(() => {
 // ─── onStallDetected ───
 
 describe("onStallDetected", () => {
+  it("activateBestCandidate enforces wait budgets for WaitStrategy candidates", async () => {
+    const manager = new StrategyManager(stateManager, createMockLLMClient([]));
+    const wait = await manager.createWaitStrategy("goal-1", {
+      hypothesis: "Wait for external signal",
+      wait_reason: "External process needs time",
+      wait_until: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      measurement_plan: "Check again later",
+      fallback_strategy_id: null,
+      target_dimensions: ["word_count"],
+      primary_dimension: "word_count",
+    });
+
+    await expect(
+      manager.activateBestCandidate("goal-1", {
+        getCurrentGap: async () => 0.4,
+        canAffordWait: async () => false,
+      })
+    ).rejects.toThrow("cannot be activated because the goal cannot afford waiting");
+
+    const stored = await manager.getPortfolio("goal-1");
+    const candidate = stored?.strategies.find((strategy) => strategy.id === wait.id);
+    expect(candidate?.state).toBe("candidate");
+  });
+
   it("returns null when stallCount === 1", async () => {
     const mock = createMockLLMClient([CANDIDATE_RESPONSE_ONE]);
     const manager = new StrategyManager(stateManager, mock);

--- a/src/orchestrator/strategy/portfolio-manager.ts
+++ b/src/orchestrator/strategy/portfolio-manager.ts
@@ -27,6 +27,7 @@ import {
   isWaitStrategy,
   checkStrategyTermination,
 } from "./portfolio-allocation.js";
+import type { WaitStrategyActivationContext } from "./strategy-manager-base.js";
 
 /**
  * PortfolioManager provides portfolio-level orchestration on top of StrategyManager.
@@ -351,19 +352,17 @@ export class PortfolioManager {
    * Single strategy: allocation = 1.0
    * Multiple: equal split as default, respecting min 0.1 and max 0.7, sum = 1.0
    */
-  activateStrategies(goalId: string, strategyIds: string[]): void {
+  async activateStrategies(
+    goalId: string,
+    strategyIds: string[],
+    activationContext?: WaitStrategyActivationContext
+  ): Promise<void> {
     if (strategyIds.length === 0) return;
-
-    const allocations = calculateInitialAllocations(
-      strategyIds.length,
-      this.config
+    await this.strategyManager.activateMultiple(
+      goalId,
+      strategyIds,
+      activationContext
     );
-
-    for (let i = 0; i < strategyIds.length; i++) {
-      const strategyId = strategyIds[i];
-      this.strategyManager.updateState(strategyId, "active");
-      this.updateStrategyAllocation(goalId, strategyId, allocations[i]);
-    }
   }
 
   /**
@@ -383,7 +382,8 @@ export class PortfolioManager {
    */
   async handleWaitStrategyExpiry(
     goalId: string,
-    strategyId: string
+    strategyId: string,
+    activationContext?: WaitStrategyActivationContext
   ): Promise<WaitExpiryOutcome | null> {
     const portfolio = await this.strategyManager.getPortfolio(goalId);
     if (!portfolio) return null;
@@ -398,6 +398,9 @@ export class PortfolioManager {
       (s) => this.isWaitStrategy(s),
       (gId, dim) => this.getCurrentGapForDimension(gId, dim),
       (sId, state) => this.strategyManager.updateState(sId, state as StrategyState),
+      async (gId, sId) => {
+        await this.strategyManager.activateMultiple(gId, [sId], activationContext);
+      },
       async (gId) => (await this.strategyManager.getPortfolio(gId))?.strategies ?? [],
       (gId, sId) => this.stateManager.readRaw(`strategies/${gId}/wait-meta/${sId}.json`),
       () => this.stateManager.readRaw("capability_registry.json"),

--- a/src/orchestrator/strategy/portfolio-rebalance.ts
+++ b/src/orchestrator/strategy/portfolio-rebalance.ts
@@ -304,6 +304,7 @@ export async function handleWaitStrategyExpiry(
   isWaitStrategy: (s: Strategy) => boolean,
   getGap: (goalId: string, dimension: string) => number | null | Promise<number | null>,
   updateState: (strategyId: string, state: string) => void | Promise<void>,
+  activateStrategy: ((goalId: string, strategyId: string) => void | Promise<void>) | undefined,
   getPortfolioStrategies: (goalId: string) => Strategy[] | Promise<Strategy[]>,
   getWaitMetadata?: (goalId: string, strategyId: string) => unknown | null | Promise<unknown | null>,
   getCapabilityRegistry?: () => unknown | null | Promise<unknown | null>,
@@ -428,14 +429,34 @@ export async function handleWaitStrategyExpiry(
         (s) => s.id === waitStrategy.fallback_strategy_id
       );
       if (fallback && fallback.state === "candidate") {
-        await updateState(fallback.id, "active");
-        await updateState(strategyId, "terminated");
-        return {
-          status: "fallback_activated",
-          goal_id: goalId,
-          strategy_id: strategyId,
-          details: `WaitStrategy expired unchanged; activated fallback strategy ${fallback.id}`,
-        };
+        try {
+          if (activateStrategy) {
+            await activateStrategy(goalId, fallback.id);
+          } else {
+            await updateState(fallback.id, "active");
+          }
+          await updateState(strategyId, "terminated");
+          return {
+            status: "fallback_activated",
+            goal_id: goalId,
+            strategy_id: strategyId,
+            details: `WaitStrategy expired unchanged; activated fallback strategy ${fallback.id}`,
+          };
+        } catch (err) {
+          await updateState(strategyId, "terminated");
+          const details = `WaitStrategy expired unchanged; fallback strategy ${fallback.id} could not be activated: ${err instanceof Error ? err.message : String(err)}`;
+          return {
+            status: "unchanged",
+            goal_id: goalId,
+            strategy_id: strategyId,
+            details,
+            rebalance_trigger: {
+              type: "stall_detected",
+              strategy_id: strategyId,
+              details,
+            },
+          };
+        }
       }
     }
     await updateState(strategyId, "terminated");

--- a/src/orchestrator/strategy/strategy-manager-base.ts
+++ b/src/orchestrator/strategy/strategy-manager-base.ts
@@ -42,6 +42,20 @@ export interface ExecutionFeedback {
   timestamp: number;
 }
 
+export interface WaitStrategyActivationContext {
+  getCurrentGap?: (
+    goalId: string,
+    dimension: string
+  ) => number | null | Promise<number | null>;
+  canAffordWait?: (input: {
+    strategy: Strategy;
+    waitHours: number;
+    currentGap: number;
+    initialGap: number;
+    startedAt: string;
+  }) => boolean | Promise<boolean>;
+}
+
 /**
  * Base class for StrategyManager.
  * Contains constructor, core lifecycle methods, and private persistence helpers.
@@ -288,7 +302,10 @@ export class StrategyManagerBase {
    * Activate the first candidate strategy for a goal.
    * Sets state="active" and started_at=now.
    */
-  async activateBestCandidate(goalId: string): Promise<Strategy> {
+  async activateBestCandidate(
+    goalId: string,
+    activationContext?: WaitStrategyActivationContext
+  ): Promise<Strategy> {
     const portfolio = await this.loadOrCreatePortfolio(goalId);
     const candidates = portfolio.strategies.filter(
       (s) => s.state === "candidate"
@@ -347,23 +364,32 @@ export class StrategyManagerBase {
         best = candidates[0]!;
       }
     }
-    const now = new Date().toISOString();
+    const multiActivator = (this as unknown as {
+      activateMultiple?: (
+        goalId: string,
+        strategyIds: string[],
+        activationContext?: WaitStrategyActivationContext
+      ) => Promise<Strategy[]>;
+    }).activateMultiple;
+    if (typeof multiActivator === "function") {
+      const activated = await multiActivator.call(this, goalId, [best.id], activationContext);
+      if (!activated[0]) {
+        throw new Error(`activateBestCandidate: failed to activate strategy "${best.id}"`);
+      }
+      return activated[0];
+    }
 
+    const now = new Date().toISOString();
     const activated = parseStrategy({
       ...best,
       state: "active",
       started_at: now,
     });
-
-    // Update in portfolio
     portfolio.strategies = portfolio.strategies.map((s) =>
       s.id === activated.id ? activated : s
     );
     await this.savePortfolio(goalId, portfolio);
-
-    // Ensure index entry
     this.strategyIndex.set(activated.id, goalId);
-
     return activated;
   }
 
@@ -457,7 +483,8 @@ export class StrategyManagerBase {
   async onStallDetected(
     goalId: string,
     stallCount: number,
-    goalType?: string
+    goalType?: string,
+    activationContext?: WaitStrategyActivationContext
   ): Promise<Strategy | null> {
     if (stallCount < 2) {
       return null;
@@ -547,7 +574,7 @@ export class StrategyManagerBase {
     }
 
     try {
-      return await this.activateBestCandidate(goalId);
+      return await this.activateBestCandidate(goalId, activationContext);
     } catch (err) {
       this.logger?.warn(`[StrategyManager] activateBestCandidate failed: ${String(err)}`);
       return null;

--- a/src/orchestrator/strategy/strategy-manager.ts
+++ b/src/orchestrator/strategy/strategy-manager.ts
@@ -162,9 +162,11 @@ export class StrategyManager extends StrategyManagerBase {
           startedAtMs: number;
           createdAtMs: number;
         }>(tasks: T[]): T | undefined => {
-          const sorted = [...tasks].sort((left, right) =>
-            Number(right.strategyId === strategy.id) - Number(left.strategyId === strategy.id)
-            || right.statusRank - left.statusRank
+          const matchingTasks = tasks.filter((task) => task.strategyId === strategy.id);
+          const unscopedTasks = tasks.filter((task) => task.strategyId === null);
+          const eligibleTasks = matchingTasks.length > 0 ? matchingTasks : unscopedTasks;
+          const sorted = [...eligibleTasks].sort((left, right) =>
+            right.statusRank - left.statusRank
             || right.startedAtMs - left.startedAtMs
             || right.createdAtMs - left.createdAtMs
             || left.id.localeCompare(right.id)

--- a/src/orchestrator/strategy/strategy-manager.ts
+++ b/src/orchestrator/strategy/strategy-manager.ts
@@ -5,25 +5,14 @@ import { StrategySchema, WaitStrategySchema, buildDefaultWaitMetadata, parseStra
 import { isWaitStrategy } from "./portfolio-allocation.js";
 import type { Strategy } from "../../base/types/strategy.js";
 import { redistributeAllocation } from "./strategy-helpers.js";
-import { StrategyManagerBase } from "./strategy-manager-base.js";
+import {
+  StrategyManagerBase,
+  type WaitStrategyActivationContext,
+} from "./strategy-manager-base.js";
 import { getCurrentGapForDimension } from "./portfolio-rebalance.js";
 
 export { VALID_TRANSITIONS, StrategyArraySchema, buildGenerationPrompt, redistributeAllocation, detectStrategyGap } from "./strategy-helpers.js";
 export { StrategyManagerBase } from "./strategy-manager-base.js";
-
-export interface WaitStrategyActivationContext {
-  getCurrentGap?: (
-    goalId: string,
-    dimension: string
-  ) => number | null | Promise<number | null>;
-  canAffordWait?: (input: {
-    strategy: Strategy;
-    waitHours: number;
-    currentGap: number;
-    initialGap: number;
-    startedAt: string;
-  }) => boolean | Promise<boolean>;
-}
 
 /**
  * StrategyManager manages strategy lifecycle for a goal:
@@ -166,10 +155,28 @@ export class StrategyManager extends StrategyManagerBase {
         // exists only as tasks/{goalId}/{taskId}.json with status="running". Scan directory first.
         let taskId: string | undefined;
         const tasksDir = path.join(this.stateManager.getBaseDir(), "tasks", goalId);
+        const preferMatchingStrategyTask = <T extends {
+          id: string;
+          strategyId: string | null;
+          statusRank: number;
+          startedAtMs: number;
+          createdAtMs: number;
+        }>(tasks: T[]): T | undefined => {
+          const sorted = [...tasks].sort((left, right) =>
+            Number(right.strategyId === strategy.id) - Number(left.strategyId === strategy.id)
+            || right.statusRank - left.statusRank
+            || right.startedAtMs - left.startedAtMs
+            || right.createdAtMs - left.createdAtMs
+            || left.id.localeCompare(right.id)
+          );
+          return sorted[0];
+        };
         try {
           const files = await fsp.readdir(tasksDir);
           const runningTasks: Array<{
             id: string;
+            strategyId: string | null;
+            statusRank: number;
             startedAtMs: number;
             createdAtMs: number;
           }> = [];
@@ -187,17 +194,14 @@ export class StrategyManager extends StrategyManagerBase {
                 : Number.NaN;
               runningTasks.push({
                 id: raw["id"] as string,
+                strategyId: typeof raw["strategy_id"] === "string" ? raw["strategy_id"] : null,
+                statusRank: raw["status"] === "running" ? 3 : raw["status"] === "in_progress" ? 2 : 1,
                 startedAtMs: Number.isFinite(startedAtMs) ? startedAtMs : Number.NEGATIVE_INFINITY,
                 createdAtMs: Number.isFinite(createdAtMs) ? createdAtMs : Number.NEGATIVE_INFINITY,
               });
             }
           }
-          runningTasks.sort((left, right) =>
-            right.startedAtMs - left.startedAtMs
-            || right.createdAtMs - left.createdAtMs
-            || left.id.localeCompare(right.id)
-          );
-          taskId = runningTasks[0]?.id;
+          taskId = preferMatchingStrategyTask(runningTasks)?.id;
         } catch {
           // Directory may not exist yet — fall through to history scan
         }
@@ -209,24 +213,38 @@ export class StrategyManager extends StrategyManagerBase {
           );
           if (Array.isArray(rawHistory) && rawHistory.length > 0) {
             const history = rawHistory as Array<Record<string, unknown>>;
-            let targetTask: Record<string, unknown> | undefined;
-            for (let i = history.length - 1; i >= 0; i--) {
-              const entry = history[i];
-              if (!entry) continue;
-              if (entry["status"] === "running" || entry["status"] === "in_progress" || entry["status"] === "pending") {
-                targetTask = entry;
-                break;
-              }
-            }
-            if (!targetTask) {
-              targetTask = history[history.length - 1];
-            }
+            const rankedHistory = history
+              .map((entry, index) => {
+                if (!entry) return null;
+                const tid = typeof entry["task_id"] === "string"
+                  ? entry["task_id"]
+                  : entry["id"];
+                if (typeof tid !== "string") return null;
+                const status = entry["status"];
+                const statusRank =
+                  status === "running" ? 3 :
+                  status === "in_progress" ? 2 :
+                  status === "pending" ? 1 :
+                  0;
+                return {
+                  id: tid,
+                  strategyId: typeof entry["strategy_id"] === "string" ? entry["strategy_id"] : null,
+                  statusRank,
+                  startedAtMs: index,
+                  createdAtMs: index,
+                };
+              })
+              .filter((entry): entry is {
+                id: string;
+                strategyId: string | null;
+                statusRank: number;
+                startedAtMs: number;
+                createdAtMs: number;
+              } => entry !== null);
+            const targetTask = preferMatchingStrategyTask(rankedHistory);
             if (targetTask) {
               // Support both the current { task_id } shape and older { id } entries.
-              const tid = typeof targetTask["task_id"] === "string"
-                ? targetTask["task_id"]
-                : targetTask["id"];
-              if (typeof tid === "string") taskId = tid;
+              taskId = targetTask.id;
             }
           }
         }

--- a/src/orchestrator/strategy/strategy-manager.ts
+++ b/src/orchestrator/strategy/strategy-manager.ts
@@ -168,16 +168,36 @@ export class StrategyManager extends StrategyManagerBase {
         const tasksDir = path.join(this.stateManager.getBaseDir(), "tasks", goalId);
         try {
           const files = await fsp.readdir(tasksDir);
+          const runningTasks: Array<{
+            id: string;
+            startedAtMs: number;
+            createdAtMs: number;
+          }> = [];
           for (const file of files) {
             if (!file.endsWith(".json") || file === "task-history.json") continue;
             const raw = await this.stateManager.readRaw(
               `tasks/${goalId}/${file}`
             ) as Record<string, unknown> | null;
             if (raw && raw["status"] === "running" && typeof raw["id"] === "string") {
-              taskId = raw["id"] as string;
-              break;
+              const startedAtMs = typeof raw["started_at"] === "string"
+                ? Date.parse(raw["started_at"])
+                : Number.NaN;
+              const createdAtMs = typeof raw["created_at"] === "string"
+                ? Date.parse(raw["created_at"])
+                : Number.NaN;
+              runningTasks.push({
+                id: raw["id"] as string,
+                startedAtMs: Number.isFinite(startedAtMs) ? startedAtMs : Number.NEGATIVE_INFINITY,
+                createdAtMs: Number.isFinite(createdAtMs) ? createdAtMs : Number.NEGATIVE_INFINITY,
+              });
             }
           }
+          runningTasks.sort((left, right) =>
+            right.startedAtMs - left.startedAtMs
+            || right.createdAtMs - left.createdAtMs
+            || left.id.localeCompare(right.id)
+          );
+          taskId = runningTasks[0]?.id;
         } catch {
           // Directory may not exist yet — fall through to history scan
         }
@@ -202,8 +222,10 @@ export class StrategyManager extends StrategyManagerBase {
               targetTask = history[history.length - 1];
             }
             if (targetTask) {
-              // Bug 1 fix: appendTaskHistory writes { task_id: task.id, ... }
-              const tid = targetTask["task_id"];
+              // Support both the current { task_id } shape and older { id } entries.
+              const tid = typeof targetTask["task_id"] === "string"
+                ? targetTask["task_id"]
+                : targetTask["id"];
               if (typeof tid === "string") taskId = tid;
             }
           }


### PR DESCRIPTION
## Summary
- exclude wait-suppressed dimensions from global stall detection and skip global stall checks when every active dimension is intentionally waiting
- harden WaitStrategy task mirroring so activation prefers the newest running task and still falls back to both `task_id` and legacy `id` history entries
- update wait-strategy and stall-detection design docs to match the current runtime behavior and ownership model

## Testing
- npm run test:unit -- src/orchestrator/strategy/__tests__/strategy-manager-phase2.test.ts src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
- npm run check:docs
