### PR TITLE
Fix stale agentloop metadata in forked chat sessions

### DIFF
--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -1,10 +1,15 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ChatRunner } from "../chat-runner.js";
 import type { ChatRunnerDeps } from "../chat-runner.js";
+import { StateManager as RealStateManager } from "../../../base/state/state-manager.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
 import type { ChatAgentLoopRunner } from "../../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
 import type { ReviewAgentLoopRunner } from "../../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
+import { ChatSessionCatalog } from "../chat-session-store.js";
 
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -175,6 +180,68 @@ describe("ChatRunner policy commands", () => {
     expect(persistedSession["agentLoopResumable"]).toBeUndefined();
     expect(persistedSession["agentLoopUpdatedAt"]).toBeUndefined();
     expect(persistedSession["agentLoop"]).toBeUndefined();
+  });
+
+  it("loaded sessions do not rewrite stale nested agentloop metadata on the next persist", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-fork-load-persist-"));
+    try {
+      const stateManager = new RealStateManager(tmpDir);
+      await stateManager.init();
+      await stateManager.writeRaw("chat/sessions/forked-session.json", {
+        id: "forked-session",
+        cwd: "/repo",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        updatedAt: "2026-04-01T00:01:00.000Z",
+        title: "Forked Session",
+        messages: [],
+        agentLoopStatePath: "chat/agentloop/forked-session.state.json",
+        agentLoop: {
+          statePath: "chat/agentloop/source-session.state.json",
+          status: "running",
+          resumable: true,
+          updatedAt: "2026-04-01T00:02:00.000Z",
+        },
+      });
+      await stateManager.writeRaw("chat/agentloop/source-session.state.json", {
+        sessionId: "source-session",
+        traceId: "trace-source",
+        turnId: "turn-source",
+        goalId: "chat",
+        cwd: "/repo",
+        modelRef: "native:test",
+        messages: [],
+        modelTurns: 1,
+        toolCalls: 0,
+        compactions: 0,
+        completionValidationAttempts: 0,
+        calledTools: [],
+        lastToolLoopSignature: null,
+        repeatedToolLoopCount: 0,
+        finalText: "",
+        status: "failed",
+        updatedAt: "2026-04-01T00:02:00.000Z",
+      });
+
+      const catalog = new ChatSessionCatalog(stateManager);
+      const loaded = await catalog.loadSession("forked-session");
+      expect(loaded).not.toBeNull();
+
+      const runner = new ChatRunner(makeDeps({ stateManager, adapter: makeMockAdapter() }));
+      runner.startSessionFromLoadedSession(loaded!);
+      const result = await runner.execute("/title Renamed Session", "/repo");
+
+      expect(result.success).toBe(true);
+      const persisted = await stateManager.readRaw("chat/sessions/forked-session.json") as Record<string, unknown>;
+      expect(persisted["agentLoopStatePath"]).toBe("chat/agentloop/forked-session.state.json");
+      expect(persisted["agentLoopStatus"]).toBeUndefined();
+      expect(persisted["agentLoopResumable"]).toBeUndefined();
+      expect(persisted["agentLoopUpdatedAt"]).toBeUndefined();
+      expect(persisted["agentLoop"]).toEqual({
+        statePath: "chat/agentloop/forked-session.state.json",
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("/undo removes the latest turn from chat history", async () => {

--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -139,6 +139,44 @@ describe("ChatRunner policy commands", () => {
     expect(result.output).toContain("Forked chat session");
   });
 
+  it("/fork clears stale native agentloop metadata from the new session", async () => {
+    const stateManager = makeMockStateManager();
+    const runner = new ChatRunner(makeDeps({ stateManager }));
+    runner.startSessionFromLoadedSession({
+      id: "source-session",
+      cwd: "/repo",
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:01:00.000Z",
+      title: "Source",
+      messages: [
+        { role: "user", content: "continue", timestamp: "2026-04-01T00:00:00.000Z", turnIndex: 0 },
+      ],
+      agentLoopStatePath: "chat/agentloop/source-session.state.json",
+      agentLoopStatus: "running",
+      agentLoopResumable: true,
+      agentLoopUpdatedAt: "2026-04-01T00:02:00.000Z",
+      agentLoop: {
+        statePath: "chat/agentloop/source-session.state.json",
+        status: "running",
+        resumable: true,
+        updatedAt: "2026-04-01T00:02:00.000Z",
+      },
+    });
+
+    const result = await runner.execute("/fork Branch copy", "/repo");
+
+    expect(result.success).toBe(true);
+    const writeCalls = vi.mocked(stateManager.writeRaw).mock.calls;
+    expect(writeCalls.length).toBeGreaterThan(0);
+    const persistedSession = writeCalls.at(-1)?.[1] as Record<string, unknown>;
+    expect(persistedSession["id"]).not.toBe("source-session");
+    expect(persistedSession["agentLoopStatePath"]).toBe(`chat/agentloop/${persistedSession["id"]}.state.json`);
+    expect(persistedSession["agentLoopStatus"]).toBeUndefined();
+    expect(persistedSession["agentLoopResumable"]).toBeUndefined();
+    expect(persistedSession["agentLoopUpdatedAt"]).toBeUndefined();
+    expect(persistedSession["agentLoop"]).toBeUndefined();
+  });
+
   it("/undo removes the latest turn from chat history", async () => {
     const runner = new ChatRunner(makeDeps());
     runner.startSession("/repo");

--- a/src/interface/chat/__tests__/chat-session-store.test.ts
+++ b/src/interface/chat/__tests__/chat-session-store.test.ts
@@ -341,6 +341,48 @@ describe("ChatSessionCatalog", () => {
     expect(dryRun.retainedSessionIds).toContain("old-chat-fresh-agentloop");
   });
 
+  it("prefers the top-level agentloop path and does not fall back to stale nested metadata", async () => {
+    await stateManager.writeRaw(
+      "chat/sessions/forked-session.json",
+      {
+        ...makeSession({
+          id: "forked-session",
+          cwd: "/repo",
+          createdAt: "2026-04-01T00:00:00.000Z",
+          updatedAt: "2026-04-01T00:01:00.000Z",
+          messages: [],
+        }),
+        agentLoopStatePath: "chat/agentloop/forked-session.state.json",
+        agentLoop: {
+          statePath: "chat/agentloop/source-session.state.json",
+          status: "running",
+          resumable: true,
+          updatedAt: "2026-04-01T00:02:00.000Z",
+        },
+      }
+    );
+    await stateManager.writeRaw(
+      "chat/agentloop/source-session.state.json",
+      makeAgentLoopState({
+        sessionId: "source-session",
+        traceId: "trace-source",
+        turnId: "turn-source",
+        goalId: "goal-source",
+        cwd: "/repo",
+        modelRef: "model",
+        status: "failed",
+        updatedAt: "2026-04-01T00:02:00.000Z",
+      })
+    );
+
+    const loaded = await catalog.loadSession("forked-session");
+
+    expect(loaded).not.toBeNull();
+    expect(loaded?.agentLoopStatePath).toBe(path.join("chat", "agentloop", "forked-session.state.json"));
+    expect(loaded?.agentLoopStatus).toBe("missing");
+    expect(loaded?.agentLoopResumable).toBe(false);
+  });
+
   it("cleans up old sessions in dry-run and enforce modes while protecting the active session", async () => {
     const oldSession = makeSession({
       id: "old-session",

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -188,6 +188,14 @@ export class ChatHistory {
     }
   }
 
+  resetAgentLoopState(statePath: string | null): void {
+    this.setAgentLoopStatePath(statePath);
+    delete this.session.agentLoopStatus;
+    delete this.session.agentLoopResumable;
+    delete this.session.agentLoopUpdatedAt;
+    delete this.session.agentLoop;
+  }
+
   recordUsage(phase: string, usage: ChatUsageCounter): void {
     const normalized = normalizeUsageCounter(usage);
     const nextTotals = sumUsage(

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -414,7 +414,7 @@ export class ChatRunner {
     this.sessionCwd = gitRoot;
     this.sessionActive = true;
     this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
-    this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
+    this.history.resetAgentLoopState(this.nativeAgentLoopStatePath);
     this.sessionExecutionPolicy = null;
   }
 
@@ -1661,7 +1661,7 @@ export class ChatRunner {
     this.sessionCwd = resolveGitRoot(cwd);
     this.sessionActive = true;
     this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
-    this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
+    this.history.resetAgentLoopState(this.nativeAgentLoopStatePath);
     await this.history.persist();
     return {
       success: true,
@@ -1947,7 +1947,7 @@ export class ChatRunner {
       const sessionId = crypto.randomUUID();
       this.history = new ChatHistory(this.deps.stateManager, sessionId, gitRoot);
       this.nativeAgentLoopStatePath = `chat/agentloop/${sessionId}.state.json`;
-      this.history.setAgentLoopStatePath(this.nativeAgentLoopStatePath);
+      this.history.resetAgentLoopState(this.nativeAgentLoopStatePath);
     }
     const executionCwd = this.sessionCwd ?? resolvedCwd;
     const gitRoot = this.sessionCwd ?? resolvedCwd;

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -88,6 +88,19 @@ interface AgentLoopDiscovery {
   updatedAt: string | null;
 }
 
+function buildNormalizedAgentLoopMetadata(agentLoop: AgentLoopDiscovery): ChatSession["agentLoop"] | undefined {
+  if (!agentLoop.statePath && agentLoop.status === "missing" && !agentLoop.resumable && !agentLoop.updatedAt) {
+    return undefined;
+  }
+
+  return {
+    ...(agentLoop.statePath ? { statePath: agentLoop.statePath } : {}),
+    ...(agentLoop.status !== "missing" ? { status: agentLoop.status } : {}),
+    ...(agentLoop.resumable ? { resumable: true } : {}),
+    ...(agentLoop.updatedAt ? { updatedAt: agentLoop.updatedAt } : {}),
+  };
+}
+
 function optionalString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
 }
@@ -224,6 +237,7 @@ async function loadAgentLoopState(
 }
 
 function normalizeSessionRecord(session: LoadedChatSession, filePath: string, fileMtimeMs: number, agentLoop: AgentLoopDiscovery): SessionRecord {
+  const normalizedAgentLoop = buildNormalizedAgentLoopMetadata(agentLoop);
   return {
     session: {
       ...session,
@@ -232,6 +246,7 @@ function normalizeSessionRecord(session: LoadedChatSession, filePath: string, fi
       agentLoopStatus: agentLoop.status,
       agentLoopResumable: agentLoop.resumable,
       agentLoopUpdatedAt: agentLoop.updatedAt,
+      ...(normalizedAgentLoop ? { agentLoop: normalizedAgentLoop } : { agentLoop: undefined }),
     },
     filePath,
     activityAtMs: extractSessionActivityAtMs(session, fileMtimeMs),

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -149,9 +149,13 @@ function normalizeAgentLoopStatus(
   session: ChatSession,
   agentLoopState: AgentLoopSessionState | null,
 ): AgentLoopDiscovery {
-  const metadataStatus = session.agentLoopStatus ?? session.agentLoop?.status ?? null;
   const statePath = session.agentLoopStatePath ?? session.agentLoop?.statePath ?? null;
-  const resumableMetadata = session.agentLoopResumable ?? session.agentLoop?.resumable ?? null;
+  const topLevelStatePath = optionalString(session.agentLoopStatePath);
+  const nestedStatePath = optionalString(session.agentLoop?.statePath);
+  const allowNestedMetadata = !topLevelStatePath || topLevelStatePath === nestedStatePath;
+  const metadataStatus = session.agentLoopStatus ?? (allowNestedMetadata ? session.agentLoop?.status ?? null : null);
+  const resumableMetadata = session.agentLoopResumable ?? (allowNestedMetadata ? session.agentLoop?.resumable ?? null : null);
+  const metadataUpdatedAt = session.agentLoopUpdatedAt ?? (allowNestedMetadata ? session.agentLoop?.updatedAt ?? null : null);
 
   if (agentLoopState) {
     const status = agentLoopState.status;
@@ -168,7 +172,7 @@ function normalizeAgentLoopStatus(
       statePath,
       status: metadataStatus,
       resumable: resumableMetadata ?? metadataStatus !== "completed",
-      updatedAt: session.agentLoopUpdatedAt ?? session.agentLoop?.updatedAt ?? null,
+      updatedAt: metadataUpdatedAt,
     };
   }
 
@@ -176,7 +180,7 @@ function normalizeAgentLoopStatus(
     statePath,
     status: "missing",
     resumable: resumableMetadata ?? false,
-    updatedAt: session.agentLoopUpdatedAt ?? session.agentLoop?.updatedAt ?? null,
+    updatedAt: metadataUpdatedAt,
   };
 }
 
@@ -186,12 +190,12 @@ async function loadAgentLoopState(
   session: ChatSession,
 ): Promise<AgentLoopDiscovery> {
   const statePaths: string[] = [];
-  const metadataPaths = [
-    optionalString(session.agentLoopStatePath),
-    optionalString(session.agentLoop?.statePath),
-  ];
-  for (const candidate of metadataPaths) {
-    const resolved = resolvePathWithinBaseDir(baseDir, candidate);
+  const topLevelPath = resolvePathWithinBaseDir(baseDir, optionalString(session.agentLoopStatePath));
+  const nestedPath = !topLevelPath
+    ? resolvePathWithinBaseDir(baseDir, optionalString(session.agentLoop?.statePath))
+    : null;
+
+  for (const resolved of [topLevelPath, nestedPath]) {
     if (resolved && !statePaths.includes(resolved.relative)) statePaths.push(resolved.relative);
   }
 


### PR DESCRIPTION
## Summary
- clear native agent-loop metadata when starting a fresh or forked chat session
- prevent chat session discovery from falling back to stale nested agent-loop metadata when a fresh top-level state path is present
- add regression coverage for forked-session resume isolation

## Testing
- npm run test:unit -- src/interface/chat/__tests__/chat-runner-policy.test.ts src/interface/chat/__tests__/chat-session-store.test.ts
- npm run typecheck
- npm run build
- npm run test:unit
- npm run lint:boundaries