### PR TITLE
Add loaded-session normal-turn regression coverage

### DIFF
--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -244,6 +244,68 @@ describe("ChatRunner policy commands", () => {
     }
   });
 
+  it("loaded sessions keep stale nested agentloop metadata cleared on a normal chat turn", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-normal-persist-"));
+    try {
+      const stateManager = new RealStateManager(tmpDir);
+      await stateManager.init();
+      await stateManager.writeRaw("chat/sessions/forked-session.json", {
+        id: "forked-session",
+        cwd: "/repo",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        updatedAt: "2026-04-01T00:01:00.000Z",
+        title: "Forked Session",
+        messages: [],
+        agentLoopStatePath: "chat/agentloop/forked-session.state.json",
+        agentLoop: {
+          statePath: "chat/agentloop/source-session.state.json",
+          status: "running",
+          resumable: true,
+          updatedAt: "2026-04-01T00:02:00.000Z",
+        },
+      });
+      await stateManager.writeRaw("chat/agentloop/source-session.state.json", {
+        sessionId: "source-session",
+        traceId: "trace-source",
+        turnId: "turn-source",
+        goalId: "chat",
+        cwd: "/repo",
+        modelRef: "native:test",
+        messages: [],
+        modelTurns: 1,
+        toolCalls: 0,
+        compactions: 0,
+        completionValidationAttempts: 0,
+        calledTools: [],
+        lastToolLoopSignature: null,
+        repeatedToolLoopCount: 0,
+        finalText: "",
+        status: "failed",
+        updatedAt: "2026-04-01T00:02:00.000Z",
+      });
+
+      const catalog = new ChatSessionCatalog(stateManager);
+      const loaded = await catalog.loadSession("forked-session");
+      expect(loaded).not.toBeNull();
+
+      const runner = new ChatRunner(makeDeps({ stateManager, adapter: makeMockAdapter() }));
+      runner.startSessionFromLoadedSession(loaded!);
+      const result = await runner.execute("Continue from here", "/repo");
+
+      expect(result.success).toBe(true);
+      const persisted = await stateManager.readRaw("chat/sessions/forked-session.json") as Record<string, unknown>;
+      expect(persisted["agentLoopStatePath"]).toBe("chat/agentloop/forked-session.state.json");
+      expect(persisted["agentLoopStatus"]).toBeUndefined();
+      expect(persisted["agentLoopResumable"]).toBeUndefined();
+      expect(persisted["agentLoopUpdatedAt"]).toBeUndefined();
+      expect(persisted["agentLoop"]).toEqual({
+        statePath: "chat/agentloop/forked-session.state.json",
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("/undo removes the latest turn from chat history", async () => {
     const runner = new ChatRunner(makeDeps());
     runner.startSession("/repo");


### PR DESCRIPTION
## Summary
- add a regression test for a loaded chat session taking a normal non-command turn
- assert stale nested agentloop metadata stays cleared after the session persists again
- extend coverage beyond the existing /title load-to-persist path

## Testing
- npm run test:unit -- src/interface/chat/__tests__/chat-runner-policy.test.ts
- npm run typecheck
- npm run build