### PR TITLE
Add durable session control and completion routing

### DIFF
--- a/src/interface/chat/__tests__/event-subscriber.test.ts
+++ b/src/interface/chat/__tests__/event-subscriber.test.ts
@@ -454,6 +454,50 @@ describe("EventSubscriber", () => {
       });
     });
 
+    it("projects session_completion into first-class notifications and chat events", () => {
+      const sub = makeSubscriber("goal-abc", "normal");
+      const notifications: TendNotification[] = [];
+      const chatEvents: ChatEvent[] = [];
+      sub.on("notification", (n: TendNotification) => notifications.push(n));
+      sub.on("chat_event", (event: ChatEvent) => chatEvents.push(event));
+
+      const raw = `id: 12\nevent: session_completion\ndata: {"session_id":"child-1","status":"completed","summary":"Heavy work finished"}`;
+      (sub as any).parseSSEMessage(raw);
+
+      expect(notifications).toHaveLength(1);
+      expect(notifications[0]).toMatchObject({
+        type: "complete",
+        goalId: "goal-abc",
+      });
+      expect(notifications[0].message).toContain("child-1");
+      expect(notifications[0].message).toContain("Heavy work finished");
+
+      expect(chatEvents).toHaveLength(1);
+      expect(chatEvents[0]).toMatchObject({
+        type: "activity",
+        kind: "commentary",
+      });
+      if (chatEvents[0].type === "activity") {
+        expect(chatEvents[0].message).toContain("Heavy work finished");
+        expect(chatEvents[0].sourceId).toBe("daemon:goal-abc:session_completion:child-1:completed");
+      }
+    });
+
+    it("uses failed session_completion status in projected source ids to avoid stale completed routing", () => {
+      const sub = makeSubscriber("goal-abc", "normal");
+      const chatEvents: ChatEvent[] = [];
+      sub.on("chat_event", (event: ChatEvent) => chatEvents.push(event));
+
+      const raw = `id: 13\nevent: session_completion\ndata: {"session_id":"child-1","status":"failed","summary":"Tests still failing"}`;
+      (sub as any).parseSSEMessage(raw);
+
+      expect(chatEvents).toHaveLength(1);
+      if (chatEvents[0].type === "activity") {
+        expect(chatEvents[0].sourceId).toBe("daemon:goal-abc:session_completion:child-1:failed");
+        expect(chatEvents[0].message).toContain("Tests still failing");
+      }
+    });
+
     it("projects snapshot approvals into chat events during bootstrap", async () => {
       const firstStream = new ReadableStream({
         start(controller) {

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -5,6 +5,7 @@
 
 import { z } from "zod";
 import type { StateManager } from "../../base/state/state-manager.js";
+import { RuntimeReplyTargetSchema, type RuntimeReplyTarget } from "../../runtime/session-registry/types.js";
 
 // ─── Schemas ───
 
@@ -48,6 +49,27 @@ export const ChatSessionSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string().optional(),
   title: z.string().trim().min(1).max(200).nullable().optional(),
+  parentSessionId: z.string().nullable().optional(),
+  spawnedBySessionId: z.string().nullable().optional(),
+  spawnedByRuntimeSessionId: z.string().nullable().optional(),
+  spawnedAt: z.string().nullable().optional(),
+  sessionStatus: z.enum(["idle", "queued", "running", "waiting", "completed", "failed"]).nullable().optional(),
+  sessionSummary: z.string().nullable().optional(),
+  completedAt: z.string().nullable().optional(),
+  goalId: z.string().nullable().optional(),
+  strategyId: z.string().nullable().optional(),
+  notificationPolicy: z.enum(["silent", "important_only", "periodic", "all_terminal"]).nullable().optional(),
+  ownerId: z.string().nullable().optional(),
+  ownerClaimedAt: z.string().nullable().optional(),
+  waitingUntil: z.string().nullable().optional(),
+  waitingCondition: z.string().nullable().optional(),
+  retryCount: z.number().int().nonnegative().nullable().optional(),
+  lastRetryAt: z.string().nullable().optional(),
+  lastResumedAt: z.string().nullable().optional(),
+  notificationReplyTarget: RuntimeReplyTargetSchema.nullable().optional(),
+  parentNotificationStatus: z.enum(["none", "pending", "sent", "failed"]).nullable().optional(),
+  parentNotificationSummary: z.string().nullable().optional(),
+  parentNotifiedAt: z.string().nullable().optional(),
   messages: z.array(ChatMessageSchema),
   compactionSummary: z.string().optional(),
   agentLoopStatePath: z.string().nullable().optional(),
@@ -185,6 +207,98 @@ export class ChatHistory {
       this.session.agentLoopStatePath = statePath;
     } else {
       delete this.session.agentLoopStatePath;
+    }
+  }
+
+  setNotificationReplyTarget(target: RuntimeReplyTarget | null): void {
+    if (target) {
+      this.session.notificationReplyTarget = target;
+    } else {
+      delete this.session.notificationReplyTarget;
+    }
+  }
+
+  setSessionLifecycle(input: {
+    status?: "idle" | "queued" | "running" | "waiting" | "completed" | "failed" | null;
+    summary?: string | null;
+    completedAt?: string | null;
+    goalId?: string | null;
+    strategyId?: string | null;
+    notificationPolicy?: "silent" | "important_only" | "periodic" | "all_terminal" | null;
+    ownerId?: string | null;
+    ownerClaimedAt?: string | null;
+    waitingUntil?: string | null;
+    waitingCondition?: string | null;
+    retryCount?: number | null;
+    lastRetryAt?: string | null;
+    lastResumedAt?: string | null;
+    parentNotificationStatus?: "none" | "pending" | "sent" | "failed" | null;
+    parentNotificationSummary?: string | null;
+    parentNotifiedAt?: string | null;
+  }): void {
+    if (input.status !== undefined) {
+      if (input.status) this.session.sessionStatus = input.status;
+      else delete this.session.sessionStatus;
+    }
+    if (input.summary !== undefined) {
+      if (input.summary !== null) this.session.sessionSummary = input.summary;
+      else delete this.session.sessionSummary;
+    }
+    if (input.completedAt !== undefined) {
+      if (input.completedAt !== null) this.session.completedAt = input.completedAt;
+      else delete this.session.completedAt;
+    }
+    if (input.goalId !== undefined) {
+      if (input.goalId !== null) this.session.goalId = input.goalId;
+      else delete this.session.goalId;
+    }
+    if (input.strategyId !== undefined) {
+      if (input.strategyId !== null) this.session.strategyId = input.strategyId;
+      else delete this.session.strategyId;
+    }
+    if (input.notificationPolicy !== undefined) {
+      if (input.notificationPolicy !== null) this.session.notificationPolicy = input.notificationPolicy;
+      else delete this.session.notificationPolicy;
+    }
+    if (input.ownerId !== undefined) {
+      if (input.ownerId !== null) this.session.ownerId = input.ownerId;
+      else delete this.session.ownerId;
+    }
+    if (input.ownerClaimedAt !== undefined) {
+      if (input.ownerClaimedAt !== null) this.session.ownerClaimedAt = input.ownerClaimedAt;
+      else delete this.session.ownerClaimedAt;
+    }
+    if (input.waitingUntil !== undefined) {
+      if (input.waitingUntil !== null) this.session.waitingUntil = input.waitingUntil;
+      else delete this.session.waitingUntil;
+    }
+    if (input.waitingCondition !== undefined) {
+      if (input.waitingCondition !== null) this.session.waitingCondition = input.waitingCondition;
+      else delete this.session.waitingCondition;
+    }
+    if (input.retryCount !== undefined) {
+      if (input.retryCount !== null) this.session.retryCount = input.retryCount;
+      else delete this.session.retryCount;
+    }
+    if (input.lastRetryAt !== undefined) {
+      if (input.lastRetryAt !== null) this.session.lastRetryAt = input.lastRetryAt;
+      else delete this.session.lastRetryAt;
+    }
+    if (input.lastResumedAt !== undefined) {
+      if (input.lastResumedAt !== null) this.session.lastResumedAt = input.lastResumedAt;
+      else delete this.session.lastResumedAt;
+    }
+    if (input.parentNotificationStatus !== undefined) {
+      if (input.parentNotificationStatus) this.session.parentNotificationStatus = input.parentNotificationStatus;
+      else delete this.session.parentNotificationStatus;
+    }
+    if (input.parentNotificationSummary !== undefined) {
+      if (input.parentNotificationSummary !== null) this.session.parentNotificationSummary = input.parentNotificationSummary;
+      else delete this.session.parentNotificationSummary;
+    }
+    if (input.parentNotifiedAt !== undefined) {
+      if (input.parentNotifiedAt !== null) this.session.parentNotifiedAt = input.parentNotifiedAt;
+      else delete this.session.parentNotifiedAt;
     }
   }
 

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -28,6 +28,7 @@ export interface ChatRunnerRouteHost {
   deps: ChatRunnerDeps;
   eventBridge: ChatRunnerEventBridge;
   activatedTools: Set<string>;
+  getConversationSessionId(): string | null;
   getSessionCwd(): string | null;
   getNativeAgentLoopStatePath(): string | null;
   getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
@@ -145,6 +146,7 @@ export async function executeAgentLoopRoute(
       },
       toolCallContext: {
         executionPolicy: await host.getSessionExecutionPolicy(),
+        ...(host.getConversationSessionId() ? { conversationSessionId: host.getConversationSessionId()! } : {}),
       },
       ...(host.getNativeAgentLoopStatePath() ? { resumeStatePath: host.getNativeAgentLoopStatePath()! } : {}),
       ...(resumeState ? { resumeState } : {}),

--- a/src/interface/chat/chat-runner-runtime.ts
+++ b/src/interface/chat/chat-runner-runtime.ts
@@ -37,6 +37,27 @@ export function loadedSessionToChatSession(session: LoadedChatSession): ChatSess
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
     messages: [...session.messages],
+    ...(session.parentSessionId ? { parentSessionId: session.parentSessionId } : {}),
+    ...(session.spawnedBySessionId ? { spawnedBySessionId: session.spawnedBySessionId } : {}),
+    ...(session.spawnedByRuntimeSessionId ? { spawnedByRuntimeSessionId: session.spawnedByRuntimeSessionId } : {}),
+    ...(session.spawnedAt ? { spawnedAt: session.spawnedAt } : {}),
+    ...(session.sessionStatus ? { sessionStatus: session.sessionStatus } : {}),
+    ...(session.sessionSummary ? { sessionSummary: session.sessionSummary } : {}),
+    ...(session.completedAt ? { completedAt: session.completedAt } : {}),
+    ...(session.goalId ? { goalId: session.goalId } : {}),
+    ...(session.strategyId ? { strategyId: session.strategyId } : {}),
+    ...(session.notificationPolicy ? { notificationPolicy: session.notificationPolicy } : {}),
+    ...(session.ownerId ? { ownerId: session.ownerId } : {}),
+    ...(session.ownerClaimedAt ? { ownerClaimedAt: session.ownerClaimedAt } : {}),
+    ...(session.waitingUntil ? { waitingUntil: session.waitingUntil } : {}),
+    ...(session.waitingCondition ? { waitingCondition: session.waitingCondition } : {}),
+    ...(session.retryCount !== null && session.retryCount !== undefined ? { retryCount: session.retryCount } : {}),
+    ...(session.lastRetryAt ? { lastRetryAt: session.lastRetryAt } : {}),
+    ...(session.lastResumedAt ? { lastResumedAt: session.lastResumedAt } : {}),
+    ...(session.notificationReplyTarget ? { notificationReplyTarget: session.notificationReplyTarget } : {}),
+    ...(session.parentNotificationStatus ? { parentNotificationStatus: session.parentNotificationStatus } : {}),
+    ...(session.parentNotificationSummary ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
+    ...(session.parentNotifiedAt ? { parentNotifiedAt: session.parentNotifiedAt } : {}),
     ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
     ...(session.title ? { title: session.title } : {}),
     ...(session.agentLoopStatePath ? { agentLoopStatePath: session.agentLoopStatePath } : {}),
@@ -219,10 +240,11 @@ function compactSessionLine(session: RuntimeSession): string {
   const title = formatRuntimeTitle(session.title);
   const updated = formatRuntimeTimestamp(session.updated_at ?? session.last_event_at ?? session.created_at);
   const workspace = session.workspace ? `, cwd ${session.workspace}` : "";
+  const parent = session.parent_session_id ? `, parent ${session.parent_session_id}` : "";
   const resumable = session.resumable ? ", resumable" : "";
   const attachable = session.attachable ? ", attachable" : "";
   const runtimeId = displayId === session.id ? "" : `, runtime ${session.id}`;
-  return `- ${displayId}${title} [${session.kind}, ${session.status}], updated ${updated}${workspace}${resumable}${attachable}${runtimeId}`;
+  return `- ${displayId}${title} [${session.kind}, ${session.status}], updated ${updated}${workspace}${parent}${resumable}${attachable}${runtimeId}`;
 }
 
 export function formatRuntimeSessionsList(snapshot: RuntimeSessionRegistrySnapshot): string {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -31,6 +31,7 @@ import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
 } from "../../runtime/store/runtime-operation-schemas.js";
+import type { RuntimeReplyTarget } from "../../runtime/session-registry/types.js";
 import type { ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 import {
   createIngressRouter,
@@ -106,6 +107,21 @@ export interface ChatRunnerExecutionOptions {
 }
 
 const DEFAULT_TIMEOUT_MS = 120_000;
+
+function normalizePinnedReplyTarget(replyTarget: RuntimeControlReplyTarget | null): RuntimeReplyTarget | null {
+  if (!replyTarget) return null;
+  const channel = replyTarget.channel ?? replyTarget.surface;
+  if (!channel) return null;
+  return {
+    channel,
+    target_id: replyTarget.conversation_id ?? replyTarget.identity_key ?? replyTarget.response_channel ?? null,
+    thread_id: replyTarget.message_id ?? null,
+    metadata: {
+      ...replyTarget,
+      ...(replyTarget.metadata ?? {}),
+    },
+  };
+}
 const standaloneIngressRouter = createIngressRouter();
 
 function resolveSelfIdentityResponse(input: string, baseDir: string): string | null {
@@ -349,6 +365,12 @@ export class ChatRunner {
     const gitRoot = this.sessionCwd ?? resolvedCwd;
     activeTurn.cwd = gitRoot;
     const history = this.history!;
+    const pinnedReplyTarget = normalizePinnedReplyTarget(
+      runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget ?? null,
+    );
+    if (pinnedReplyTarget) {
+      history.setNotificationReplyTarget(pinnedReplyTarget);
+    }
 
     this.eventBridge.emitEvent({
       type: "lifecycle_start",
@@ -581,6 +603,7 @@ export class ChatRunner {
       deps: this.deps,
       eventBridge: this.eventBridge,
       activatedTools: this.activatedTools,
+      getConversationSessionId: () => this.history?.getSessionId() ?? null,
       getSessionCwd: () => this.sessionCwd,
       getNativeAgentLoopStatePath: () => this.nativeAgentLoopStatePath,
       getSessionExecutionPolicy: () => this.getSessionExecutionPolicy(),

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -19,6 +19,17 @@ export interface ChatSessionCatalogEntry {
   messageCount: number;
   createdAt: string;
   updatedAt: string;
+  parentSessionId: string | null;
+  sessionStatus?: "idle" | "queued" | "running" | "waiting" | "completed" | "failed" | null;
+  sessionSummary?: string | null;
+  completedAt?: string | null;
+  goalId?: string | null;
+  strategyId?: string | null;
+  notificationPolicy?: "silent" | "important_only" | "periodic" | "all_terminal" | null;
+  ownerId?: string | null;
+  waitingUntil?: string | null;
+  waitingCondition?: string | null;
+  notificationReplyTarget?: ChatSession["notificationReplyTarget"];
   agentLoopStatePath: string | null;
   agentLoopStatus: ChatSessionAgentLoopStatus;
   agentLoopResumable: boolean;
@@ -32,6 +43,27 @@ export interface LoadedChatSession {
   title: string | null;
   messages: ChatSession["messages"];
   compactionSummary?: string;
+  parentSessionId?: string | null;
+  spawnedBySessionId?: string | null;
+  spawnedByRuntimeSessionId?: string | null;
+  spawnedAt?: string | null;
+  sessionStatus?: "idle" | "queued" | "running" | "waiting" | "completed" | "failed" | null;
+  sessionSummary?: string | null;
+  completedAt?: string | null;
+  goalId?: string | null;
+  strategyId?: string | null;
+  notificationPolicy?: "silent" | "important_only" | "periodic" | "all_terminal" | null;
+  ownerId?: string | null;
+  ownerClaimedAt?: string | null;
+  waitingUntil?: string | null;
+  waitingCondition?: string | null;
+  retryCount?: number | null;
+  lastRetryAt?: string | null;
+  lastResumedAt?: string | null;
+  notificationReplyTarget?: ChatSession["notificationReplyTarget"];
+  parentNotificationStatus?: "none" | "pending" | "sent" | "failed" | null;
+  parentNotificationSummary?: string | null;
+  parentNotifiedAt?: string | null;
   agentLoopStatePath: string | null;
   agentLoopStatus: ChatSessionAgentLoopStatus;
   agentLoopResumable: boolean;
@@ -284,6 +316,27 @@ async function readSessionRecordWithMetadata(
     updatedAt: parsed.data.updatedAt ?? parsed.data.createdAt,
     title: normalizeTitle(parsed.data.title),
     messages: [...parsed.data.messages],
+    parentSessionId: optionalString(parsed.data.parentSessionId),
+    ...(optionalString(parsed.data.spawnedBySessionId) ? { spawnedBySessionId: optionalString(parsed.data.spawnedBySessionId) } : {}),
+    ...(optionalString(parsed.data.spawnedByRuntimeSessionId) ? { spawnedByRuntimeSessionId: optionalString(parsed.data.spawnedByRuntimeSessionId) } : {}),
+    ...(optionalString(parsed.data.spawnedAt) ? { spawnedAt: optionalString(parsed.data.spawnedAt) } : {}),
+    ...(parsed.data.sessionStatus ? { sessionStatus: parsed.data.sessionStatus } : {}),
+    ...(optionalString(parsed.data.sessionSummary) !== null ? { sessionSummary: optionalString(parsed.data.sessionSummary) } : {}),
+    ...(optionalString(parsed.data.completedAt) !== null ? { completedAt: optionalString(parsed.data.completedAt) } : {}),
+    ...(optionalString(parsed.data.goalId) !== null ? { goalId: optionalString(parsed.data.goalId) } : {}),
+    ...(optionalString(parsed.data.strategyId) !== null ? { strategyId: optionalString(parsed.data.strategyId) } : {}),
+    ...(parsed.data.notificationPolicy ? { notificationPolicy: parsed.data.notificationPolicy } : {}),
+    ...(optionalString(parsed.data.ownerId) !== null ? { ownerId: optionalString(parsed.data.ownerId) } : {}),
+    ...(optionalString(parsed.data.ownerClaimedAt) !== null ? { ownerClaimedAt: optionalString(parsed.data.ownerClaimedAt) } : {}),
+    ...(optionalString(parsed.data.waitingUntil) !== null ? { waitingUntil: optionalString(parsed.data.waitingUntil) } : {}),
+    ...(optionalString(parsed.data.waitingCondition) !== null ? { waitingCondition: optionalString(parsed.data.waitingCondition) } : {}),
+    ...(typeof parsed.data.retryCount === "number" ? { retryCount: parsed.data.retryCount } : {}),
+    ...(optionalString(parsed.data.lastRetryAt) !== null ? { lastRetryAt: optionalString(parsed.data.lastRetryAt) } : {}),
+    ...(optionalString(parsed.data.lastResumedAt) !== null ? { lastResumedAt: optionalString(parsed.data.lastResumedAt) } : {}),
+    ...(parsed.data.notificationReplyTarget ? { notificationReplyTarget: parsed.data.notificationReplyTarget } : {}),
+    ...(parsed.data.parentNotificationStatus ? { parentNotificationStatus: parsed.data.parentNotificationStatus } : {}),
+    ...(optionalString(parsed.data.parentNotificationSummary) !== null ? { parentNotificationSummary: optionalString(parsed.data.parentNotificationSummary) } : {}),
+    ...(optionalString(parsed.data.parentNotifiedAt) !== null ? { parentNotifiedAt: optionalString(parsed.data.parentNotifiedAt) } : {}),
     ...(parsed.data.compactionSummary ? { compactionSummary: parsed.data.compactionSummary } : {}),
     agentLoopStatePath: discovery.statePath,
     agentLoopStatus: discovery.status,
@@ -305,6 +358,17 @@ function buildCatalogEntry(record: SessionRecord): ChatSessionCatalogEntry {
     messageCount: session.messages.length,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
+    parentSessionId: session.parentSessionId ?? null,
+    sessionStatus: session.sessionStatus ?? null,
+    sessionSummary: session.sessionSummary ?? null,
+    completedAt: session.completedAt ?? null,
+    goalId: session.goalId ?? null,
+    strategyId: session.strategyId ?? null,
+    notificationPolicy: session.notificationPolicy ?? null,
+    ownerId: session.ownerId ?? null,
+    waitingUntil: session.waitingUntil ?? null,
+    waitingCondition: session.waitingCondition ?? null,
+    notificationReplyTarget: session.notificationReplyTarget ?? null,
     agentLoopStatePath: session.agentLoopStatePath,
     agentLoopStatus: session.agentLoopStatus,
     agentLoopResumable: session.agentLoopResumable,
@@ -318,6 +382,27 @@ function toPersistedSession(session: LoadedChatSession): ChatSession {
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
     messages: [...session.messages],
+    ...(session.parentSessionId !== null ? { parentSessionId: session.parentSessionId } : {}),
+    ...(session.spawnedBySessionId !== null && session.spawnedBySessionId !== undefined ? { spawnedBySessionId: session.spawnedBySessionId } : {}),
+    ...(session.spawnedByRuntimeSessionId !== null && session.spawnedByRuntimeSessionId !== undefined ? { spawnedByRuntimeSessionId: session.spawnedByRuntimeSessionId } : {}),
+    ...(session.spawnedAt !== null && session.spawnedAt !== undefined ? { spawnedAt: session.spawnedAt } : {}),
+    ...(session.sessionStatus !== null && session.sessionStatus !== undefined ? { sessionStatus: session.sessionStatus } : {}),
+    ...(session.sessionSummary !== null && session.sessionSummary !== undefined ? { sessionSummary: session.sessionSummary } : {}),
+    ...(session.completedAt !== null && session.completedAt !== undefined ? { completedAt: session.completedAt } : {}),
+    ...(session.goalId !== null && session.goalId !== undefined ? { goalId: session.goalId } : {}),
+    ...(session.strategyId !== null && session.strategyId !== undefined ? { strategyId: session.strategyId } : {}),
+    ...(session.notificationPolicy !== null && session.notificationPolicy !== undefined ? { notificationPolicy: session.notificationPolicy } : {}),
+    ...(session.ownerId !== null && session.ownerId !== undefined ? { ownerId: session.ownerId } : {}),
+    ...(session.ownerClaimedAt !== null && session.ownerClaimedAt !== undefined ? { ownerClaimedAt: session.ownerClaimedAt } : {}),
+    ...(session.waitingUntil !== null && session.waitingUntil !== undefined ? { waitingUntil: session.waitingUntil } : {}),
+    ...(session.waitingCondition !== null && session.waitingCondition !== undefined ? { waitingCondition: session.waitingCondition } : {}),
+    ...(session.retryCount !== null && session.retryCount !== undefined ? { retryCount: session.retryCount } : {}),
+    ...(session.lastRetryAt !== null && session.lastRetryAt !== undefined ? { lastRetryAt: session.lastRetryAt } : {}),
+    ...(session.lastResumedAt !== null && session.lastResumedAt !== undefined ? { lastResumedAt: session.lastResumedAt } : {}),
+    ...(session.notificationReplyTarget !== null && session.notificationReplyTarget !== undefined ? { notificationReplyTarget: session.notificationReplyTarget } : {}),
+    ...(session.parentNotificationStatus !== null && session.parentNotificationStatus !== undefined ? { parentNotificationStatus: session.parentNotificationStatus } : {}),
+    ...(session.parentNotificationSummary !== null && session.parentNotificationSummary !== undefined ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
+    ...(session.parentNotifiedAt !== null && session.parentNotifiedAt !== undefined ? { parentNotifiedAt: session.parentNotifiedAt } : {}),
     ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
     ...(session.title !== null ? { title: session.title } : {}),
     ...(session.agentLoopStatePath !== null ? { agentLoopStatePath: session.agentLoopStatePath } : {}),
@@ -473,6 +558,27 @@ export class ChatSessionCatalog {
       updatedAt,
       title: normalizedTitle,
       messages: [...session.messages],
+      parentSessionId: session.parentSessionId,
+      ...(session.spawnedBySessionId ? { spawnedBySessionId: session.spawnedBySessionId } : {}),
+      ...(session.spawnedByRuntimeSessionId ? { spawnedByRuntimeSessionId: session.spawnedByRuntimeSessionId } : {}),
+      ...(session.spawnedAt ? { spawnedAt: session.spawnedAt } : {}),
+      ...(session.sessionStatus ? { sessionStatus: session.sessionStatus } : {}),
+      ...(session.sessionSummary ? { sessionSummary: session.sessionSummary } : {}),
+      ...(session.completedAt ? { completedAt: session.completedAt } : {}),
+      ...(session.goalId ? { goalId: session.goalId } : {}),
+      ...(session.strategyId ? { strategyId: session.strategyId } : {}),
+      ...(session.notificationPolicy ? { notificationPolicy: session.notificationPolicy } : {}),
+      ...(session.ownerId ? { ownerId: session.ownerId } : {}),
+      ...(session.ownerClaimedAt ? { ownerClaimedAt: session.ownerClaimedAt } : {}),
+      ...(session.waitingUntil ? { waitingUntil: session.waitingUntil } : {}),
+      ...(session.waitingCondition ? { waitingCondition: session.waitingCondition } : {}),
+      ...(session.retryCount !== null && session.retryCount !== undefined ? { retryCount: session.retryCount } : {}),
+      ...(session.lastRetryAt ? { lastRetryAt: session.lastRetryAt } : {}),
+      ...(session.lastResumedAt ? { lastResumedAt: session.lastResumedAt } : {}),
+      ...(session.notificationReplyTarget ? { notificationReplyTarget: session.notificationReplyTarget } : {}),
+      ...(session.parentNotificationStatus ? { parentNotificationStatus: session.parentNotificationStatus } : {}),
+      ...(session.parentNotificationSummary ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
+      ...(session.parentNotifiedAt ? { parentNotifiedAt: session.parentNotifiedAt } : {}),
       ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
       agentLoopStatePath: session.agentLoopStatePath,
       agentLoopStatus: session.agentLoopStatus,

--- a/src/interface/chat/event-subscriber.ts
+++ b/src/interface/chat/event-subscriber.ts
@@ -37,6 +37,23 @@ interface RawChatResponseEvent {
   goal_id?: string;
   message?: string;
   status?: string;
+  session_completion?: {
+    session_id?: string;
+    runtime_session_id?: string;
+    parent_session_id?: string;
+    status?: string;
+    summary?: string;
+    completed_at?: string;
+  };
+}
+
+interface RawSessionCompletionEvent {
+  session_id?: string;
+  runtime_session_id?: string;
+  parent_session_id?: string;
+  status?: string;
+  summary?: string;
+  completed_at?: string;
 }
 
 interface RawLoopErrorEvent {
@@ -332,6 +349,22 @@ export class EventSubscriber extends EventEmitter {
       };
     }
 
+    if (eventType === "session_completion") {
+      const ev = data as RawSessionCompletionEvent;
+      const sessionId = ev.session_id ?? ev.runtime_session_id ?? "session";
+      const status = ev.status ?? "completed";
+      const summary = typeof ev.summary === "string" && ev.summary.trim().length > 0
+        ? ev.summary.trim()
+        : "No summary provided";
+      const icon = status === "failed" ? "⚠️" : "✅";
+      const label = status === "failed" ? "Failed" : "Completed";
+      return {
+        type: status === "failed" ? "error" : "complete",
+        goalId: this.goalId,
+        message: `${icon} [tend] ${shortId}: Child session ${sessionId} ${label.toLowerCase()} — ${summary}`,
+      };
+    }
+
     return null;
   }
 
@@ -348,6 +381,25 @@ export class EventSubscriber extends EventEmitter {
         type: "assistant_final",
         text,
         persisted: false,
+        ...this.createChatEventBase(eventType, data),
+      };
+    }
+
+    if (eventType === "session_completion") {
+      const completion = data as RawSessionCompletionEvent;
+      const summary = typeof completion.summary === "string" && completion.summary.trim().length > 0
+        ? completion.summary.trim()
+        : "Session completed";
+      return {
+        type: "activity",
+        kind: "commentary",
+        message: notification?.message ?? summary,
+        sourceId: this.createChatSourceId(eventType, data, notification ?? {
+          type: "complete",
+          goalId: this.goalId,
+          message: summary,
+        }),
+        transient: false,
         ...this.createChatEventBase(eventType, data),
       };
     }
@@ -434,6 +486,11 @@ export class EventSubscriber extends EventEmitter {
       return `${eventType}:${requestId}`;
     }
 
+    const sessionId = record?.["session_id"];
+    if (typeof sessionId === "string" && sessionId) {
+      return `${eventType}:${sessionId}`;
+    }
+
     if (this.lastOutboxSeq > 0) {
       return `${eventType}:${this.lastOutboxSeq}`;
     }
@@ -461,6 +518,10 @@ export class EventSubscriber extends EventEmitter {
       : null;
     const status = record?.["status"];
     if (typeof status === "string" && status) {
+      const sessionId = record?.["session_id"];
+      if (typeof sessionId === "string" && sessionId) {
+        return `daemon:${this.goalId}:${eventType}:${sessionId}:${status}`;
+      }
       return `daemon:${this.goalId}:${eventType}:${status}`;
     }
 

--- a/src/runtime/__tests__/daemon-runner.test.ts
+++ b/src/runtime/__tests__/daemon-runner.test.ts
@@ -150,6 +150,7 @@ function makeDeps(tmpDir: string, overrides: Partial<DaemonDeps> = {}): DaemonDe
 
   const mockStateManager = {
     getBaseDir: vi.fn().mockReturnValue(tmpDir),
+    readRaw: vi.fn().mockResolvedValue(null),
     loadGoal: vi.fn().mockResolvedValue(null),
     listGoalIds: vi.fn().mockResolvedValue([]),
   };

--- a/src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
+++ b/src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
@@ -67,6 +67,70 @@ describe("RuntimeSessionRegistry", () => {
     });
   });
 
+  it("projects spawned child conversations with their parent conversation runtime id", async () => {
+    await stateManager.writeRaw("chat/sessions/chat-parent.json", {
+      id: "chat-parent",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:10:00.000Z",
+      title: "Parent chat",
+      messages: [],
+    });
+    await stateManager.writeRaw("chat/sessions/chat-child.json", {
+      id: "chat-child",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:15:00.000Z",
+      updatedAt: "2026-04-25T00:20:00.000Z",
+      title: "Child chat",
+      parentSessionId: "chat-parent",
+      spawnedBySessionId: "chat-parent",
+      spawnedAt: "2026-04-25T00:15:00.000Z",
+      messages: [],
+    });
+
+    const snapshot = await new RuntimeSessionRegistry({ stateManager }).snapshot();
+    const childConversation = snapshot.sessions.find((session) => session.id === "session:conversation:chat-child");
+
+    expect(childConversation).toMatchObject({
+      id: "session:conversation:chat-child",
+      kind: "conversation",
+      parent_session_id: "session:conversation:chat-parent",
+    });
+  });
+
+  it("projects conversation lifecycle status and durable reply target from chat session metadata", async () => {
+    await stateManager.writeRaw("chat/sessions/chat-notify.json", {
+      id: "chat-notify",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:20:00.000Z",
+      title: "Notify chat",
+      sessionStatus: "completed",
+      sessionSummary: "done",
+      completedAt: "2026-04-25T00:30:00.000Z",
+      notificationReplyTarget: {
+        channel: "plugin_gateway",
+        target_id: "chat-123",
+        thread_id: "msg-1",
+      },
+      messages: [],
+    });
+
+    const snapshot = await new RuntimeSessionRegistry({ stateManager }).snapshot();
+    const conversation = snapshot.sessions.find((session) => session.id === "session:conversation:chat-notify");
+
+    expect(conversation).toMatchObject({
+      id: "session:conversation:chat-notify",
+      status: "ended",
+      updated_at: "2026-04-25T00:30:00.000Z",
+      reply_target: expect.objectContaining({
+        channel: "plugin_gateway",
+        target_id: "chat-123",
+      }),
+      resumable: false,
+    });
+  });
+
   it("does not report a running process sidecar with a dead pid as running", async () => {
     await stateManager.writeRaw("runtime/process-sessions/proc-dead.json", makeProcessSnapshot({
       session_id: "proc-dead",

--- a/src/runtime/session-registry/registry.ts
+++ b/src/runtime/session-registry/registry.ts
@@ -58,6 +58,12 @@ interface SupervisorStateLike {
   updatedAt?: unknown;
 }
 
+function chatLifecycleToRuntimeStatus(status: string | null | undefined): RuntimeSession["status"] {
+  if (status === "queued" || status === "running" || status === "waiting") return "active";
+  if (status === "completed" || status === "failed") return "ended";
+  return "idle";
+}
+
 const PROCESS_SESSION_DIR = path.join("runtime", "process-sessions");
 
 export class RuntimeSessionRegistry {
@@ -150,17 +156,17 @@ export class RuntimeSessionRegistry {
         schema_version: "runtime-session-v1",
         id: conversationId,
         kind: "conversation",
-        parent_session_id: null,
+        parent_session_id: chat.parentSessionId ? conversationSessionId(chat.parentSessionId) : null,
         title: chat.title,
         workspace: chat.cwd,
-        status: "idle",
+        status: chatLifecycleToRuntimeStatus(chat.sessionStatus),
         created_at: chat.createdAt,
-        updated_at: chat.updatedAt,
-        last_event_at: chat.updatedAt,
+        updated_at: chat.completedAt ?? chat.updatedAt,
+        last_event_at: chat.completedAt ?? chat.updatedAt,
         transcript_ref: chatSource,
         state_ref: null,
-        reply_target: null,
-        resumable: true,
+        reply_target: chat.notificationReplyTarget ?? null,
+        resumable: chat.sessionStatus !== "completed",
         attachable: false,
         source_refs: [chatSource],
       });

--- a/src/tools/builtin/factory.ts
+++ b/src/tools/builtin/factory.ts
@@ -82,6 +82,7 @@ import { TaskGetTool } from "../query/TaskGetTool/TaskGetTool.js";
 import { TaskListTool } from "../query/TaskListTool/TaskListTool.js";
 import { ToolSearchTool } from "../query/ToolSearchTool/ToolSearchTool.js";
 import { TrustStateTool } from "../query/TrustStateTool/TrustStateTool.js";
+import { createRuntimeSessionTools } from "../query/runtime-session-tools.js";
 import { CreateScheduleTool } from "../schedule/CreateScheduleTool/CreateScheduleTool.js";
 import { GetScheduleTool } from "../schedule/GetScheduleTool/GetScheduleTool.js";
 import { ListSchedulesTool } from "../schedule/ListSchedulesTool/ListSchedulesTool.js";
@@ -201,6 +202,7 @@ export function createBuiltinTools(deps?: BuiltinToolDeps): ITool[] {
       new GoalStateTool(deps.stateManager),
       new TrustStateTool(deps.stateManager),
       new SessionHistoryTool(deps.stateManager),
+      ...createRuntimeSessionTools(deps.stateManager),
       new ProgressHistoryTool(deps.stateManager),
       new TaskListTool(deps.stateManager),
       new TaskGetTool(deps.stateManager),

--- a/src/tools/query/__tests__/runtime-session-tools.test.ts
+++ b/src/tools/query/__tests__/runtime-session-tools.test.ts
@@ -1,0 +1,391 @@
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fsp from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { StateManager } from "../../../base/state/state-manager.js";
+import { OutboxStore } from "../../../runtime/store/outbox-store.js";
+import type { ITool, ToolCallContext } from "../../types.js";
+import { createRuntimeSessionTools } from "../runtime-session-tools.js";
+
+function makeContext(overrides: Partial<ToolCallContext> = {}): ToolCallContext {
+  return {
+    cwd: "/repo",
+    goalId: "chat",
+    trustBalance: 0,
+    preApproved: true,
+    approvalFn: async () => true,
+    ...overrides,
+  };
+}
+
+describe("runtime session tools", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+  let tools: Map<string, ITool>;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-runtime-session-tools-"));
+    stateManager = new StateManager(tmpDir, undefined, { walEnabled: false });
+    await stateManager.init();
+    tools = new Map(createRuntimeSessionTools(stateManager).map((tool) => [tool.metadata.name, tool]));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("spawns a child conversation session and scopes tree listing to spawned descendants", async () => {
+    await stateManager.writeRaw("chat/sessions/root.json", {
+      id: "root",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:00:00.000Z",
+      title: "Root",
+      messages: [],
+    });
+    await stateManager.writeRaw("chat/sessions/external.json", {
+      id: "external",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:00:00.000Z",
+      title: "External",
+      messages: [],
+    });
+
+    const spawn = tools.get("sessions_spawn")!;
+    const spawned = await spawn.call({
+      title: "Delegated child",
+      message: "Investigate this in a separate session",
+    }, makeContext({ conversationSessionId: "root", sessionId: "agent-runtime-1" }));
+    expect(spawned.success).toBe(true);
+
+    const spawnedData = spawned.data as { sessionId: string; runtimeSessionId: string; parentSessionId: string | null };
+    expect(spawnedData.parentSessionId).toBe("root");
+    expect(spawnedData.runtimeSessionId).toBe(`session:conversation:${spawnedData.sessionId}`);
+
+    const history = tools.get("sessions_history")!;
+    const loaded = await history.call({
+      session_id: spawnedData.runtimeSessionId,
+      limit: 10,
+    }, makeContext());
+    expect(loaded.success).toBe(true);
+    expect(loaded.data).toMatchObject({
+      sessionId: spawnedData.sessionId,
+      parentSessionId: "root",
+      messages: [
+        expect.objectContaining({
+          role: "user",
+          content: "Investigate this in a separate session",
+        }),
+      ],
+    });
+
+    const list = tools.get("sessions_list")!;
+    const treeScoped = await list.call({
+      scope: "tree",
+      includeRuns: false,
+    }, makeContext({ conversationSessionId: "root" }));
+    expect(treeScoped.success).toBe(true);
+    const treeSessions = (treeScoped.data as { sessions: Array<{ id: string }> }).sessions;
+    expect(treeSessions.map((session) => session.id)).toContain("session:conversation:root");
+    expect(treeSessions.map((session) => session.id)).toContain(spawnedData.runtimeSessionId);
+    expect(treeSessions.map((session) => session.id)).not.toContain("session:conversation:external");
+  });
+
+  it("sends a queued message into another conversation session", async () => {
+    await stateManager.writeRaw("chat/sessions/target.json", {
+      id: "target",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:00:00.000Z",
+      title: "Target",
+      messages: [],
+    });
+
+    const send = tools.get("sessions_send")!;
+    const result = await send.call({
+      session_id: "session:conversation:target",
+      message: "Please continue the heavy work here",
+    }, makeContext());
+
+    expect(result.success).toBe(true);
+    expect(result.contextModifier).toContain("Resume session:conversation:target later");
+
+    const history = tools.get("sessions_history")!;
+    const loaded = await history.call({
+      session_id: "target",
+      limit: 10,
+    }, makeContext());
+    expect(loaded.success).toBe(true);
+    expect(loaded.data).toMatchObject({
+      sessionId: "target",
+      messages: [
+        expect.objectContaining({
+          content: "Please continue the heavy work here",
+        }),
+      ],
+    });
+  });
+
+  it("marks a child session completed, appends a parent summary, and writes durable outbox notifications", async () => {
+    await stateManager.writeRaw("chat/sessions/parent.json", {
+      id: "parent",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:00:00.000Z",
+      title: "Parent",
+      messages: [],
+      notificationReplyTarget: {
+        channel: "plugin_gateway",
+        target_id: "chat-123",
+        thread_id: "msg-1",
+      },
+    });
+    await stateManager.writeRaw("chat/sessions/child.json", {
+      id: "child",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:01:00.000Z",
+      updatedAt: "2026-04-25T00:01:00.000Z",
+      title: "Child",
+      parentSessionId: "parent",
+      spawnedBySessionId: "parent",
+      spawnedAt: "2026-04-25T00:01:00.000Z",
+      sessionStatus: "running",
+      messages: [],
+    });
+
+    const read = tools.get("sessions_read")!;
+    const before = await read.call({ session_id: "child" }, makeContext());
+    expect(before.success).toBe(true);
+    expect(before.data).toMatchObject({
+      sessionId: "child",
+      parentSessionId: "parent",
+      sessionStatus: "running",
+    });
+
+    const update = tools.get("sessions_update")!;
+    const result = await update.call({
+      session_id: "session:conversation:child",
+      status: "completed",
+      summary: "Heavy work is done.",
+      append_assistant_message: true,
+      notify_parent: true,
+    }, makeContext());
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      sessionId: "child",
+      status: "completed",
+      parentNotificationStatus: "sent",
+      notified: true,
+    });
+
+    const after = await read.call({ session_id: "child" }, makeContext());
+    expect(after.success).toBe(true);
+    expect(after.data).toMatchObject({
+      sessionId: "child",
+      sessionStatus: "completed",
+      sessionSummary: "Heavy work is done.",
+      parentNotificationStatus: "sent",
+    });
+
+    const parentHistory = tools.get("sessions_history")!;
+    const parentLoaded = await parentHistory.call({ session_id: "parent", limit: 10 }, makeContext());
+    expect(parentLoaded.success).toBe(true);
+    expect(parentLoaded.data).toMatchObject({
+      sessionId: "parent",
+      messages: [
+        expect.objectContaining({
+          role: "assistant",
+          content: expect.stringContaining('Session child "Child" completed: Heavy work is done.'),
+        }),
+      ],
+    });
+
+    const outbox = await new OutboxStore(tmpDir).list();
+    expect(outbox).toHaveLength(2);
+    expect(outbox[0]).toMatchObject({
+      event_type: "session_completion",
+      correlation_id: "child",
+      payload: expect.objectContaining({
+        session_id: "child",
+        parent_session_id: "parent",
+        status: "completed",
+        summary: "Heavy work is done.",
+      }),
+    });
+    expect(outbox[1]).toMatchObject({
+      event_type: "chat_response",
+      correlation_id: "child",
+      payload: expect.objectContaining({
+        status: "completed",
+        session_completion: expect.objectContaining({
+          session_id: "child",
+          summary: "Heavy work is done.",
+        }),
+      }),
+    });
+  });
+
+  it("persists goal linkage, waiting conditions, and ownership across spawn, claim, children, and update paths", async () => {
+    await stateManager.writeRaw("chat/sessions/root.json", {
+      id: "root",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:00:00.000Z",
+      title: "Root",
+      messages: [],
+      notificationReplyTarget: {
+        channel: "plugin_gateway",
+        target_id: "chat-123",
+      },
+    });
+
+    const spawn = tools.get("sessions_spawn")!;
+    const spawned = await spawn.call({
+      title: "Delegated child",
+      goal_id: "goal-742",
+      strategy_id: "strategy-investigate",
+      notification_policy: "periodic",
+      owner_id: "agent-alpha",
+    }, makeContext({ conversationSessionId: "root", sessionId: "agent-runtime-1" }));
+    expect(spawned.success).toBe(true);
+
+    const childSessionId = (spawned.data as { sessionId: string }).sessionId;
+
+    const claim = tools.get("sessions_claim")!;
+    const claimResult = await claim.call({
+      session_id: childSessionId,
+      owner_id: "agent-beta",
+    }, makeContext());
+    expect(claimResult.success).toBe(true);
+    expect(claimResult.data).toMatchObject({
+      sessionId: childSessionId,
+      ownerId: "agent-beta",
+    });
+
+    const update = tools.get("sessions_update")!;
+    const waiting = await update.call({
+      session_id: childSessionId,
+      status: "waiting",
+      waiting_until: "2026-04-29T00:00:00.000Z",
+      waiting_condition: "wait for user confirmation",
+      notification_policy: "periodic",
+    }, makeContext());
+    expect(waiting.success).toBe(true);
+
+    const read = tools.get("sessions_read")!;
+    const loaded = await read.call({ session_id: childSessionId }, makeContext());
+    expect(loaded.success).toBe(true);
+    expect(loaded.data).toMatchObject({
+      sessionId: childSessionId,
+      goalId: "goal-742",
+      strategyId: "strategy-investigate",
+      notificationPolicy: "periodic",
+      ownerId: "agent-beta",
+      waitingUntil: "2026-04-29T00:00:00.000Z",
+      waitingCondition: "wait for user confirmation",
+      parentSessionId: "root",
+    });
+
+    const children = tools.get("sessions_children")!;
+    const tree = await children.call({ session_id: "root" }, makeContext());
+    expect(tree.success).toBe(true);
+    expect(tree.data).toMatchObject({
+      sessionId: "root",
+      children: [
+        expect.objectContaining({
+          sessionId: childSessionId,
+          goalId: "goal-742",
+          strategyId: "strategy-investigate",
+          waitingUntil: "2026-04-29T00:00:00.000Z",
+          ownerId: "agent-beta",
+        }),
+      ],
+    });
+  });
+
+  it("retries a waiting child session, clears stale waiting fields, and supports explicit cancellation", async () => {
+    await stateManager.writeRaw("chat/sessions/parent.json", {
+      id: "parent",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:00:00.000Z",
+      title: "Parent",
+      messages: [],
+      notificationReplyTarget: {
+        channel: "plugin_gateway",
+        target_id: "chat-123",
+      },
+    });
+    await stateManager.writeRaw("chat/sessions/child.json", {
+      id: "child",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:01:00.000Z",
+      updatedAt: "2026-04-25T00:01:00.000Z",
+      title: "Child",
+      parentSessionId: "parent",
+      sessionStatus: "waiting",
+      waitingUntil: "2026-04-30T00:00:00.000Z",
+      waitingCondition: "wait for deployment window",
+      retryCount: 1,
+      messages: [],
+    });
+
+    const retry = tools.get("sessions_retry")!;
+    const retried = await retry.call({
+      session_id: "session:conversation:child",
+      message: "Retry after the window opens",
+    }, makeContext());
+    expect(retried.success).toBe(true);
+    expect(retried.data).toMatchObject({
+      sessionId: "child",
+      retryCount: 2,
+      status: "queued",
+    });
+
+    const read = tools.get("sessions_read")!;
+    const afterRetry = await read.call({ session_id: "child" }, makeContext());
+    expect(afterRetry.success).toBe(true);
+    expect(afterRetry.data).toMatchObject({
+      sessionId: "child",
+      sessionStatus: "queued",
+      retryCount: 2,
+      waitingUntil: null,
+      waitingCondition: null,
+      parentNotificationStatus: "pending",
+    });
+
+    const history = tools.get("sessions_history")!;
+    const retriedHistory = await history.call({ session_id: "child", limit: 10 }, makeContext());
+    expect(retriedHistory.success).toBe(true);
+    expect(retriedHistory.data).toMatchObject({
+      messages: [
+        expect.objectContaining({
+          role: "user",
+          content: "Retry after the window opens",
+        }),
+      ],
+    });
+
+    const cancel = tools.get("sessions_cancel")!;
+    const canceled = await cancel.call({
+      session_id: "child",
+      reason: "User canceled this delegated branch",
+    }, makeContext());
+    expect(canceled.success).toBe(true);
+    expect(canceled.data).toMatchObject({
+      sessionId: "child",
+      status: "failed",
+    });
+
+    const afterCancel = await read.call({ session_id: "child" }, makeContext());
+    expect(afterCancel.success).toBe(true);
+    expect(afterCancel.data).toMatchObject({
+      sessionId: "child",
+      sessionStatus: "failed",
+      sessionSummary: "User canceled this delegated branch",
+      parentNotificationStatus: "sent",
+    });
+  });
+});

--- a/src/tools/query/runtime-session-tools.ts
+++ b/src/tools/query/runtime-session-tools.ts
@@ -1,0 +1,1188 @@
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import type { StateManager } from "../../base/state/state-manager.js";
+import { ChatHistory, ChatSessionSchema, type ChatMessage, type ChatSession } from "../../interface/chat/chat-history.js";
+import { ChatSessionCatalog, type LoadedChatSession } from "../../interface/chat/chat-session-store.js";
+import { createRuntimeSessionRegistry } from "../../runtime/session-registry/index.js";
+import type { BackgroundRun, RuntimeReplyTarget, RuntimeSession } from "../../runtime/session-registry/types.js";
+import { OutboxStore } from "../../runtime/store/outbox-store.js";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../types.js";
+
+const READ_ONLY = true;
+const READ_PERMISSION = "read_only" as const;
+const WRITE_PERMISSION = "write_local" as const;
+const TAGS = ["session", "self-grounding"] as const;
+
+function normalizeConversationSelector(selector: string): string {
+  return selector.startsWith("session:conversation:")
+    ? selector.slice("session:conversation:".length)
+    : selector;
+}
+
+function toConversationRuntimeId(sessionId: string): string {
+  return `session:conversation:${sessionId}`;
+}
+
+function buildCompletionMessage(session: LoadedChatSession, status: "completed" | "failed", summary: string): string {
+  const title = session.title ? ` "${session.title}"` : "";
+  return `Session ${session.id}${title} ${status}: ${summary}`;
+}
+
+function summarizeMessages(messages: ChatMessage[], limit: number): Array<{
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  turnIndex: number;
+}> {
+  return messages.slice(-limit).map((message) => ({
+    role: message.role,
+    content: message.content,
+    timestamp: message.timestamp,
+    turnIndex: message.turnIndex,
+  }));
+}
+
+function reindexMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((message, index) => ({
+    role: message.role,
+    content: message.content,
+    timestamp: message.timestamp,
+    turnIndex: index,
+  }));
+}
+
+function toChatSessionRecord(session: LoadedChatSession): ChatSession {
+  return {
+    id: session.id,
+    cwd: session.cwd,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+    messages: [...session.messages],
+    ...(session.parentSessionId ? { parentSessionId: session.parentSessionId } : {}),
+    ...(session.spawnedBySessionId ? { spawnedBySessionId: session.spawnedBySessionId } : {}),
+    ...(session.spawnedByRuntimeSessionId ? { spawnedByRuntimeSessionId: session.spawnedByRuntimeSessionId } : {}),
+    ...(session.spawnedAt ? { spawnedAt: session.spawnedAt } : {}),
+    ...(session.sessionStatus ? { sessionStatus: session.sessionStatus } : {}),
+    ...(session.sessionSummary ? { sessionSummary: session.sessionSummary } : {}),
+    ...(session.completedAt ? { completedAt: session.completedAt } : {}),
+    ...(session.goalId ? { goalId: session.goalId } : {}),
+    ...(session.strategyId ? { strategyId: session.strategyId } : {}),
+    ...(session.notificationPolicy ? { notificationPolicy: session.notificationPolicy } : {}),
+    ...(session.ownerId ? { ownerId: session.ownerId } : {}),
+    ...(session.ownerClaimedAt ? { ownerClaimedAt: session.ownerClaimedAt } : {}),
+    ...(session.waitingUntil ? { waitingUntil: session.waitingUntil } : {}),
+    ...(session.waitingCondition ? { waitingCondition: session.waitingCondition } : {}),
+    ...(session.retryCount !== null && session.retryCount !== undefined ? { retryCount: session.retryCount } : {}),
+    ...(session.lastRetryAt ? { lastRetryAt: session.lastRetryAt } : {}),
+    ...(session.lastResumedAt ? { lastResumedAt: session.lastResumedAt } : {}),
+    ...(session.notificationReplyTarget ? { notificationReplyTarget: session.notificationReplyTarget } : {}),
+    ...(session.parentNotificationStatus ? { parentNotificationStatus: session.parentNotificationStatus } : {}),
+    ...(session.parentNotificationSummary ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
+    ...(session.parentNotifiedAt ? { parentNotifiedAt: session.parentNotifiedAt } : {}),
+    ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
+    ...(session.title ? { title: session.title } : {}),
+    ...(session.agentLoopStatePath ? { agentLoopStatePath: session.agentLoopStatePath } : {}),
+    ...(session.agentLoopStatus === "running" || session.agentLoopStatus === "completed" || session.agentLoopStatus === "failed"
+      ? { agentLoopStatus: session.agentLoopStatus }
+      : {}),
+    ...(session.agentLoopResumable ? { agentLoopResumable: true } : {}),
+    ...(session.agentLoopUpdatedAt ? { agentLoopUpdatedAt: session.agentLoopUpdatedAt } : {}),
+    ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
+    ...(session.usage ? { usage: session.usage } : {}),
+  };
+}
+
+class RuntimeSessionToolService {
+  constructor(private readonly stateManager: StateManager) {}
+
+  private catalog(): ChatSessionCatalog {
+    return new ChatSessionCatalog(this.stateManager);
+  }
+
+  private registry() {
+    return createRuntimeSessionRegistry({ stateManager: this.stateManager });
+  }
+
+  private outbox() {
+    return new OutboxStore(this.stateManager.getBaseDir());
+  }
+
+  async listSessions(
+    input: RuntimeSessionsListInput,
+    context: ToolCallContext,
+  ): Promise<{ sessions: RuntimeSession[]; runs?: BackgroundRun[] }> {
+    const snapshot = await this.registry().snapshot();
+    const allowedConversationIds = await this.allowedConversationIds(input.scope, context);
+    const runtimeAllowedIds = allowedConversationIds
+      ? new Set(Array.from(allowedConversationIds, (id) => toConversationRuntimeId(id)))
+      : null;
+    const kindFilter = input.kinds?.length ? new Set(input.kinds) : null;
+
+    const sessions = snapshot.sessions.filter((session) => {
+      if (kindFilter && !kindFilter.has(session.kind)) return false;
+      if (input.activeOnly && session.status !== "active") return false;
+      if (!runtimeAllowedIds) return true;
+      if (session.kind === "conversation") return runtimeAllowedIds.has(session.id);
+      return session.parent_session_id ? runtimeAllowedIds.has(session.parent_session_id) : false;
+    });
+
+    if (!input.includeRuns) {
+      return { sessions };
+    }
+
+    const runs = snapshot.background_runs.filter((run) => {
+      if (!runtimeAllowedIds) return true;
+      if (run.parent_session_id && runtimeAllowedIds.has(run.parent_session_id)) return true;
+      return run.child_session_id ? sessions.some((session) => session.id === run.child_session_id) : false;
+    });
+    return { sessions, runs };
+  }
+
+  async loadHistory(selector: string, limit: number): Promise<{
+    sessionId: string;
+    runtimeSessionId: string;
+    title: string | null;
+    parentSessionId: string | null;
+    cwd: string;
+    createdAt: string;
+    updatedAt: string;
+    compactionSummary?: string;
+    messages: Array<{ role: "user" | "assistant"; content: string; timestamp: string; turnIndex: number }>;
+  }> {
+    const session = await this.resolveConversationSession(selector);
+    return {
+      sessionId: session.id,
+      runtimeSessionId: toConversationRuntimeId(session.id),
+      title: session.title,
+      parentSessionId: session.parentSessionId ?? null,
+      cwd: session.cwd,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+      ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
+      messages: summarizeMessages(session.messages, limit),
+    };
+  }
+
+  async readSession(selector: string): Promise<{
+    sessionId: string;
+    runtimeSessionId: string;
+    title: string | null;
+    parentSessionId: string | null;
+    childSessionIds: string[];
+    cwd: string;
+    createdAt: string;
+    updatedAt: string;
+    sessionStatus: string | null;
+    sessionSummary: string | null;
+    completedAt: string | null;
+    goalId: string | null;
+    strategyId: string | null;
+    notificationPolicy: string | null;
+    ownerId: string | null;
+    ownerClaimedAt: string | null;
+    waitingUntil: string | null;
+    waitingCondition: string | null;
+    retryCount: number | null;
+    lastRetryAt: string | null;
+    lastResumedAt: string | null;
+    parentNotificationStatus: string | null;
+    parentNotifiedAt: string | null;
+    notificationReplyTarget: RuntimeReplyTarget | null;
+  }> {
+    const session = await this.resolveConversationSession(selector);
+    const entries = await this.catalog().listSessions();
+    return {
+      sessionId: session.id,
+      runtimeSessionId: toConversationRuntimeId(session.id),
+      title: session.title,
+      parentSessionId: session.parentSessionId ?? null,
+      childSessionIds: entries.filter((entry) => entry.parentSessionId === session.id).map((entry) => entry.id),
+      cwd: session.cwd,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+      sessionStatus: session.sessionStatus ?? null,
+      sessionSummary: session.sessionSummary ?? null,
+      completedAt: session.completedAt ?? null,
+      goalId: session.goalId ?? null,
+      strategyId: session.strategyId ?? null,
+      notificationPolicy: session.notificationPolicy ?? null,
+      ownerId: session.ownerId ?? null,
+      ownerClaimedAt: session.ownerClaimedAt ?? null,
+      waitingUntil: session.waitingUntil ?? null,
+      waitingCondition: session.waitingCondition ?? null,
+      retryCount: session.retryCount ?? null,
+      lastRetryAt: session.lastRetryAt ?? null,
+      lastResumedAt: session.lastResumedAt ?? null,
+      parentNotificationStatus: session.parentNotificationStatus ?? null,
+      parentNotifiedAt: session.parentNotifiedAt ?? null,
+      notificationReplyTarget: session.notificationReplyTarget ?? null,
+    };
+  }
+
+  async listChildren(selector: string): Promise<{
+    sessionId: string;
+    runtimeSessionId: string;
+    children: Array<{
+      sessionId: string;
+      runtimeSessionId: string;
+      title: string | null;
+      sessionStatus: string | null;
+      goalId: string | null;
+      strategyId: string | null;
+      waitingUntil: string | null;
+      ownerId: string | null;
+    }>;
+  }> {
+    const session = await this.resolveConversationSession(selector);
+    const entries = await this.catalog().listSessions();
+    const loadedChildren = await Promise.all(
+      entries
+        .filter((entry) => entry.parentSessionId === session.id)
+        .map((entry) => this.catalog().loadSession(entry.id)),
+    );
+    return {
+      sessionId: session.id,
+      runtimeSessionId: toConversationRuntimeId(session.id),
+      children: loadedChildren
+        .filter((child): child is LoadedChatSession => child !== null)
+        .map((child) => ({
+          sessionId: child.id,
+          runtimeSessionId: toConversationRuntimeId(child.id),
+          title: child.title,
+          sessionStatus: child.sessionStatus ?? null,
+          goalId: child.goalId ?? null,
+          strategyId: child.strategyId ?? null,
+          waitingUntil: child.waitingUntil ?? null,
+          ownerId: child.ownerId ?? null,
+        })),
+    };
+  }
+
+  async spawnSession(
+    input: RuntimeSessionsSpawnInput,
+    context: ToolCallContext,
+  ): Promise<{
+    sessionId: string;
+    runtimeSessionId: string;
+    parentSessionId: string | null;
+    resumeCommand: string;
+    messageQueued: boolean;
+  }> {
+    const now = new Date().toISOString();
+    const sessionId = randomUUID();
+    const parentSessionId = context.conversationSessionId ?? null;
+    const baseSession = input.copy_recent_messages && parentSessionId
+      ? await this.catalog().loadSession(parentSessionId)
+      : null;
+    const seededMessages = input.copy_recent_messages && baseSession
+      ? reindexMessages(baseSession.messages.slice(-input.recent_message_limit))
+      : [];
+
+    const persisted = ChatSessionSchema.parse({
+      id: sessionId,
+      cwd: input.cwd?.trim() || context.cwd,
+      createdAt: now,
+      updatedAt: now,
+      messages: seededMessages,
+      ...(input.title?.trim() ? { title: input.title.trim() } : {}),
+      ...(parentSessionId ? { parentSessionId } : {}),
+      ...(parentSessionId ? { spawnedBySessionId: parentSessionId } : {}),
+      ...(context.sessionId ? { spawnedByRuntimeSessionId: context.sessionId } : {}),
+      spawnedAt: now,
+      ...(input.goal_id?.trim() ? { goalId: input.goal_id.trim() } : {}),
+      ...(input.strategy_id?.trim() ? { strategyId: input.strategy_id.trim() } : {}),
+      notificationPolicy: input.notification_policy ?? (parentSessionId ? "all_terminal" : "important_only"),
+      ...(input.owner_id?.trim() ? { ownerId: input.owner_id.trim() } : {}),
+      ...(input.owner_id?.trim() ? { ownerClaimedAt: now } : {}),
+      sessionStatus: input.message?.trim() ? "queued" : "idle",
+      parentNotificationStatus: parentSessionId ? "pending" : "none",
+      ...(baseSession?.notificationReplyTarget ? { notificationReplyTarget: baseSession.notificationReplyTarget } : {}),
+      agentLoopStatePath: `chat/agentloop/${sessionId}.state.json`,
+    });
+
+    const history = ChatHistory.fromSession(this.stateManager, persisted);
+    if (input.message?.trim()) {
+      await history.appendUserMessage(input.message.trim());
+    } else {
+      await history.persist();
+    }
+
+    return {
+      sessionId,
+      runtimeSessionId: toConversationRuntimeId(sessionId),
+      parentSessionId,
+      resumeCommand: `/resume session:conversation:${sessionId}`,
+      messageQueued: Boolean(input.message?.trim()),
+    };
+  }
+
+  async sendToSession(selector: string, message: string): Promise<{
+    sessionId: string;
+    runtimeSessionId: string;
+    messageCount: number;
+    updatedAt: string;
+  }> {
+    const session = await this.resolveConversationSession(selector);
+    const history = ChatHistory.fromSession(this.stateManager, toChatSessionRecord(session));
+    history.setSessionLifecycle({ status: "queued" });
+    await history.appendUserMessage(message.trim());
+    const updated = history.getSessionData();
+    return {
+      sessionId: session.id,
+      runtimeSessionId: toConversationRuntimeId(session.id),
+      messageCount: updated.messages.length,
+      updatedAt: updated.updatedAt ?? updated.createdAt,
+    };
+  }
+
+  async updateSession(selector: string, input: RuntimeSessionsUpdateInput): Promise<{
+    sessionId: string;
+    runtimeSessionId: string;
+    status: string;
+    parentSessionId: string | null;
+    parentNotificationStatus: string | null;
+    notified: boolean;
+  }> {
+    const session = await this.resolveConversationSession(selector);
+    const history = ChatHistory.fromSession(this.stateManager, toChatSessionRecord(session));
+    const completedAt = input.status === "completed" || input.status === "failed"
+      ? (input.completed_at ?? new Date().toISOString())
+      : null;
+    history.setSessionLifecycle({
+      status: input.status,
+      summary: input.summary ?? undefined,
+      completedAt,
+      goalId: input.goal_id ?? undefined,
+      strategyId: input.strategy_id ?? undefined,
+      notificationPolicy: input.notification_policy ?? undefined,
+      waitingUntil: input.waiting_until ?? (input.status === "waiting" ? null : undefined),
+      waitingCondition: input.waiting_condition ?? (input.status === "waiting" ? null : undefined),
+      lastResumedAt: input.status === "running" ? new Date().toISOString() : undefined,
+      parentNotificationStatus: session.parentSessionId && input.notify_parent ? "pending" : undefined,
+    });
+    if (input.append_assistant_message && input.summary?.trim()) {
+      await history.appendAssistantMessage(input.summary.trim());
+    } else {
+      await history.persist();
+    }
+
+    let notified = false;
+    let parentNotificationStatus: "none" | "pending" | "sent" | "failed" | null =
+      session.parentNotificationStatus ?? null;
+    if (
+      session.parentSessionId
+      && input.notify_parent
+      && input.summary?.trim()
+      && (input.status === "completed" || input.status === "failed")
+    ) {
+      try {
+        await this.notifyParentSession(session, input.status, input.summary.trim(), completedAt ?? new Date().toISOString());
+        parentNotificationStatus = "sent";
+        notified = true;
+      } catch {
+        parentNotificationStatus = "failed";
+      }
+      const refreshed = ChatHistory.fromSession(this.stateManager, {
+        ...history.getSessionData(),
+      });
+      refreshed.setSessionLifecycle({
+        parentNotificationStatus,
+        parentNotificationSummary: input.summary.trim(),
+        parentNotifiedAt: notified ? new Date().toISOString() : null,
+      });
+      await refreshed.persist();
+    }
+
+    return {
+      sessionId: session.id,
+      runtimeSessionId: toConversationRuntimeId(session.id),
+      status: input.status,
+      parentSessionId: session.parentSessionId ?? null,
+      parentNotificationStatus,
+      notified,
+    };
+  }
+
+  async claimSession(selector: string, ownerId: string): Promise<{
+    sessionId: string;
+    runtimeSessionId: string;
+    ownerId: string;
+    ownerClaimedAt: string;
+  }> {
+    const session = await this.resolveConversationSession(selector);
+    const history = ChatHistory.fromSession(this.stateManager, toChatSessionRecord(session));
+    const ownerClaimedAt = new Date().toISOString();
+    history.setSessionLifecycle({ ownerId, ownerClaimedAt });
+    await history.persist();
+    return {
+      sessionId: session.id,
+      runtimeSessionId: toConversationRuntimeId(session.id),
+      ownerId,
+      ownerClaimedAt,
+    };
+  }
+
+  async cancelSession(selector: string, reason: string): Promise<{
+    sessionId: string;
+    runtimeSessionId: string;
+    status: "failed";
+  }> {
+    await this.updateSession(selector, {
+      session_id: selector,
+      status: "failed",
+      summary: reason,
+      append_assistant_message: false,
+      notify_parent: true,
+    });
+    const session = await this.resolveConversationSession(selector);
+    return {
+      sessionId: session.id,
+      runtimeSessionId: toConversationRuntimeId(session.id),
+      status: "failed",
+    };
+  }
+
+  async retrySession(selector: string, message?: string): Promise<{
+    sessionId: string;
+    runtimeSessionId: string;
+    retryCount: number;
+    status: "queued";
+  }> {
+    const session = await this.resolveConversationSession(selector);
+    const history = ChatHistory.fromSession(this.stateManager, toChatSessionRecord(session));
+    const retryCount = (session.retryCount ?? 0) + 1;
+    const now = new Date().toISOString();
+    history.setSessionLifecycle({
+      status: "queued",
+      completedAt: null,
+      summary: null,
+      retryCount,
+      lastRetryAt: now,
+      waitingUntil: null,
+      waitingCondition: null,
+      parentNotificationStatus: session.parentSessionId ? "pending" : session.parentNotificationStatus ?? null,
+    });
+    if (message?.trim()) {
+      await history.appendUserMessage(message.trim());
+    } else {
+      await history.persist();
+    }
+    return {
+      sessionId: session.id,
+      runtimeSessionId: toConversationRuntimeId(session.id),
+      retryCount,
+      status: "queued",
+    };
+  }
+
+  private async notifyParentSession(
+    childSession: LoadedChatSession,
+    status: "completed" | "failed",
+    summary: string,
+    completedAt: string,
+  ): Promise<void> {
+    const parentSession = await this.resolveConversationSession(childSession.parentSessionId!);
+    const parentHistory = ChatHistory.fromSession(this.stateManager, toChatSessionRecord(parentSession));
+    const message = buildCompletionMessage(childSession, status, summary);
+    await parentHistory.appendAssistantMessage(message);
+
+    const replyTarget = parentSession.notificationReplyTarget ?? childSession.notificationReplyTarget ?? null;
+    if (!replyTarget) return;
+
+    const outbox = this.outbox();
+    const createdAt = Date.now();
+    await outbox.append({
+      event_type: "session_completion",
+      correlation_id: childSession.id,
+      created_at: createdAt,
+      payload: {
+        session_id: childSession.id,
+        runtime_session_id: toConversationRuntimeId(childSession.id),
+        parent_session_id: childSession.parentSessionId,
+        status,
+        summary,
+        completed_at: completedAt,
+        reply_target: replyTarget,
+      },
+    });
+    await outbox.append({
+      event_type: "chat_response",
+      correlation_id: childSession.id,
+      created_at: Date.now(),
+      payload: {
+        goalId: `session:${childSession.id}`,
+        goal_id: `session:${childSession.id}`,
+        message,
+        status,
+        reply_target: replyTarget,
+        session_completion: {
+          session_id: childSession.id,
+          runtime_session_id: toConversationRuntimeId(childSession.id),
+          parent_session_id: childSession.parentSessionId,
+          status,
+          summary,
+          completed_at: completedAt,
+        },
+      },
+    });
+  }
+
+  private async resolveConversationSession(selector: string): Promise<LoadedChatSession> {
+    const session = await this.catalog().loadSessionBySelector(normalizeConversationSelector(selector));
+    if (!session) {
+      throw new Error(`No chat session matched selector "${selector}".`);
+    }
+    return session;
+  }
+
+  private async allowedConversationIds(
+    scope: RuntimeSessionsScope,
+    context: ToolCallContext,
+  ): Promise<Set<string> | null> {
+    const currentConversationId = context.conversationSessionId ?? null;
+    if (scope === "all" || !currentConversationId) return null;
+    if (scope === "self") return new Set([currentConversationId]);
+
+    const entries = await this.catalog().listSessions();
+    const descendants = new Set<string>([currentConversationId]);
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const entry of entries) {
+        if (!entry.parentSessionId) continue;
+        if (descendants.has(entry.parentSessionId) && !descendants.has(entry.id)) {
+          descendants.add(entry.id);
+          changed = true;
+        }
+      }
+    }
+    return descendants;
+  }
+}
+
+export const RuntimeSessionsListInputSchema = z.object({
+  scope: z.enum(["self", "tree", "all"]).default("tree"),
+  kinds: z.array(z.enum(["conversation", "agent", "coreloop"])).optional(),
+  activeOnly: z.boolean().default(false),
+  includeRuns: z.boolean().default(false),
+});
+export type RuntimeSessionsScope = z.infer<typeof RuntimeSessionsListInputSchema>["scope"];
+export type RuntimeSessionsListInput = z.infer<typeof RuntimeSessionsListInputSchema>;
+
+export class RuntimeSessionsListTool implements ITool<RuntimeSessionsListInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_list",
+    aliases: ["list_sessions", "runtime_sessions_list"],
+    permissionLevel: READ_PERMISSION,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: 12000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsListInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return "List PulSeed runtime sessions. Supports current-session scope, spawned-session tree scope, or all sessions.";
+  }
+
+  async call(input: RuntimeSessionsListInput, context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.listSessions(input, context);
+      return {
+        success: true,
+        data,
+        summary: `Found ${data.sessions.length} session(s)`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_list failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return true;
+  }
+}
+
+export const RuntimeSessionsHistoryInputSchema = z.object({
+  session_id: z.string().min(1, "session_id is required"),
+  limit: z.number().int().positive().max(100).default(20),
+});
+export type RuntimeSessionsHistoryInput = z.infer<typeof RuntimeSessionsHistoryInputSchema>;
+
+export class RuntimeSessionsHistoryTool implements ITool<RuntimeSessionsHistoryInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_history",
+    aliases: ["read_session_history", "runtime_session_history"],
+    permissionLevel: READ_PERMISSION,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: 12000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsHistoryInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return "Read recent message history from a PulSeed chat conversation session by chat id or runtime session id.";
+  }
+
+  async call(input: RuntimeSessionsHistoryInput, _context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.loadHistory(input.session_id, input.limit);
+      return {
+        success: true,
+        data,
+        summary: `Loaded ${data.messages.length} message(s) from session ${data.sessionId}`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_history failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return true;
+  }
+}
+
+export const RuntimeSessionsReadInputSchema = z.object({
+  session_id: z.string().min(1, "session_id is required"),
+});
+export type RuntimeSessionsReadInput = z.infer<typeof RuntimeSessionsReadInputSchema>;
+
+export class RuntimeSessionsReadTool implements ITool<RuntimeSessionsReadInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_read",
+    aliases: ["read_session", "runtime_session_read"],
+    permissionLevel: READ_PERMISSION,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: 12000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsReadInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(): string {
+    return "Read one PulSeed conversation session with parent/child relationships, lifecycle state, and notification metadata.";
+  }
+
+  async call(input: RuntimeSessionsReadInput, _context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.readSession(input.session_id);
+      return {
+        success: true,
+        data,
+        summary: `Loaded session ${data.sessionId}`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_read failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return true;
+  }
+}
+
+export const RuntimeSessionsChildrenInputSchema = z.object({
+  session_id: z.string().min(1, "session_id is required"),
+});
+export type RuntimeSessionsChildrenInput = z.infer<typeof RuntimeSessionsChildrenInputSchema>;
+
+export class RuntimeSessionsChildrenTool implements ITool<RuntimeSessionsChildrenInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_children",
+    aliases: ["list_session_children", "runtime_session_children"],
+    permissionLevel: READ_PERMISSION,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: 12000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsChildrenInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(): string {
+    return "List child conversation sessions spawned from a PulSeed conversation session.";
+  }
+
+  async call(input: RuntimeSessionsChildrenInput, _context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.listChildren(input.session_id);
+      return {
+        success: true,
+        data,
+        summary: `Loaded ${data.children.length} child session(s) for ${data.sessionId}`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_children failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return true;
+  }
+}
+
+export const RuntimeSessionsSpawnInputSchema = z.object({
+  title: z.string().trim().min(1).max(200).optional(),
+  message: z.string().trim().min(1).optional(),
+  cwd: z.string().trim().min(1).optional(),
+  goal_id: z.string().trim().min(1).optional(),
+  strategy_id: z.string().trim().min(1).optional(),
+  notification_policy: z.enum(["silent", "important_only", "periodic", "all_terminal"]).optional(),
+  owner_id: z.string().trim().min(1).optional(),
+  copy_recent_messages: z.boolean().default(false),
+  recent_message_limit: z.number().int().positive().max(20).default(6),
+});
+export type RuntimeSessionsSpawnInput = z.infer<typeof RuntimeSessionsSpawnInputSchema>;
+
+export class RuntimeSessionsSpawnTool implements ITool<RuntimeSessionsSpawnInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_spawn",
+    aliases: ["spawn_session_runtime", "delegate_session"],
+    permissionLevel: WRITE_PERMISSION,
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 8000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsSpawnInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return "Create a new PulSeed chat conversation session, optionally seeded with a task message, so work can be moved into a separate session.";
+  }
+
+  async call(input: RuntimeSessionsSpawnInput, context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.spawnSession(input, context);
+      return {
+        success: true,
+        data,
+        summary: `Spawned session ${data.sessionId}`,
+        contextModifier: `Use ${data.resumeCommand} to continue the delegated work in that separate session.`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_spawn failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return false;
+  }
+}
+
+export const RuntimeSessionsSendInputSchema = z.object({
+  session_id: z.string().min(1, "session_id is required"),
+  message: z.string().trim().min(1, "message is required"),
+});
+export type RuntimeSessionsSendInput = z.infer<typeof RuntimeSessionsSendInputSchema>;
+
+export class RuntimeSessionsSendTool implements ITool<RuntimeSessionsSendInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_send",
+    aliases: ["send_session_message", "enqueue_session_message"],
+    permissionLevel: WRITE_PERMISSION,
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 8000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsSendInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return "Append a user message to another PulSeed chat conversation session by chat id or runtime session id.";
+  }
+
+  async call(input: RuntimeSessionsSendInput, _context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.sendToSession(input.session_id, input.message);
+      return {
+        success: true,
+        data,
+        summary: `Queued a message for session ${data.sessionId}`,
+        contextModifier: `Resume ${data.runtimeSessionId} later to act on the queued message in that separate session.`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_send failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return false;
+  }
+}
+
+export const RuntimeSessionsUpdateInputSchema = z.object({
+  session_id: z.string().min(1, "session_id is required"),
+  status: z.enum(["queued", "running", "waiting", "completed", "failed"]),
+  summary: z.string().trim().min(1).optional(),
+  goal_id: z.string().trim().min(1).optional(),
+  strategy_id: z.string().trim().min(1).optional(),
+  notification_policy: z.enum(["silent", "important_only", "periodic", "all_terminal"]).optional(),
+  waiting_until: z.string().trim().min(1).nullable().optional(),
+  waiting_condition: z.string().trim().min(1).nullable().optional(),
+  append_assistant_message: z.boolean().default(false),
+  notify_parent: z.boolean().default(false),
+  completed_at: z.string().optional(),
+}).superRefine((value, ctx) => {
+  if ((value.status === "completed" || value.status === "failed") && !value.summary) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["summary"],
+      message: "summary is required when marking a session completed or failed",
+    });
+  }
+  if (value.status === "waiting" && !value.waiting_until && !value.waiting_condition) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["waiting_until"],
+      message: "waiting_until or waiting_condition is required when marking a session waiting",
+    });
+  }
+});
+export type RuntimeSessionsUpdateInput = z.infer<typeof RuntimeSessionsUpdateInputSchema>;
+
+export class RuntimeSessionsUpdateTool implements ITool<RuntimeSessionsUpdateInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_update",
+    aliases: ["update_session_status", "complete_session", "fail_session"],
+    permissionLevel: WRITE_PERMISSION,
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 8000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsUpdateInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(): string {
+    return "Update a PulSeed conversation session lifecycle state. Can mark child sessions completed or failed and notify the parent session durably.";
+  }
+
+  async call(input: RuntimeSessionsUpdateInput, _context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.updateSession(input.session_id, input);
+      return {
+        success: true,
+        data,
+        summary: `Updated session ${data.sessionId} to ${data.status}`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_update failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return false;
+  }
+}
+
+export const RuntimeSessionsClaimInputSchema = z.object({
+  session_id: z.string().min(1, "session_id is required"),
+  owner_id: z.string().trim().min(1, "owner_id is required"),
+});
+export type RuntimeSessionsClaimInput = z.infer<typeof RuntimeSessionsClaimInputSchema>;
+
+export class RuntimeSessionsClaimTool implements ITool<RuntimeSessionsClaimInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_claim",
+    aliases: ["claim_session", "runtime_session_claim"],
+    permissionLevel: WRITE_PERMISSION,
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 8000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsClaimInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(): string {
+    return "Claim ownership of a PulSeed conversation session so delegated work has an explicit owner.";
+  }
+
+  async call(input: RuntimeSessionsClaimInput, _context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.claimSession(input.session_id, input.owner_id);
+      return {
+        success: true,
+        data,
+        summary: `Claimed session ${data.sessionId} for ${data.ownerId}`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_claim failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return false;
+  }
+}
+
+export const RuntimeSessionsCancelInputSchema = z.object({
+  session_id: z.string().min(1, "session_id is required"),
+  reason: z.string().trim().min(1, "reason is required"),
+});
+export type RuntimeSessionsCancelInput = z.infer<typeof RuntimeSessionsCancelInputSchema>;
+
+export class RuntimeSessionsCancelTool implements ITool<RuntimeSessionsCancelInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_cancel",
+    aliases: ["cancel_session", "runtime_session_cancel"],
+    permissionLevel: WRITE_PERMISSION,
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 8000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsCancelInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(): string {
+    return "Cancel a PulSeed conversation session by marking it failed and notifying its parent if configured.";
+  }
+
+  async call(input: RuntimeSessionsCancelInput, _context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.cancelSession(input.session_id, input.reason);
+      return {
+        success: true,
+        data,
+        summary: `Canceled session ${data.sessionId}`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_cancel failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return false;
+  }
+}
+
+export const RuntimeSessionsRetryInputSchema = z.object({
+  session_id: z.string().min(1, "session_id is required"),
+  message: z.string().trim().min(1).optional(),
+});
+export type RuntimeSessionsRetryInput = z.infer<typeof RuntimeSessionsRetryInputSchema>;
+
+export class RuntimeSessionsRetryTool implements ITool<RuntimeSessionsRetryInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "sessions_retry",
+    aliases: ["retry_session", "runtime_session_retry"],
+    permissionLevel: WRITE_PERMISSION,
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 1,
+    maxOutputChars: 8000,
+    tags: [...TAGS],
+  };
+  readonly inputSchema = RuntimeSessionsRetryInputSchema;
+
+  constructor(private readonly service: RuntimeSessionToolService) {}
+
+  description(): string {
+    return "Re-queue a PulSeed conversation session for another attempt, preserving retry metadata.";
+  }
+
+  async call(input: RuntimeSessionsRetryInput, _context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const data = await this.service.retrySession(input.session_id, input.message);
+      return {
+        success: true,
+        data,
+        summary: `Retried session ${data.sessionId}`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        data: null,
+        summary: `sessions_retry failed: ${error instanceof Error ? error.message : String(error)}`,
+        error: error instanceof Error ? error.message : String(error),
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return false;
+  }
+}
+
+export function createRuntimeSessionTools(stateManager: StateManager): ITool[] {
+  const service = new RuntimeSessionToolService(stateManager);
+  return [
+    new RuntimeSessionsListTool(service),
+    new RuntimeSessionsHistoryTool(service),
+    new RuntimeSessionsReadTool(service),
+    new RuntimeSessionsChildrenTool(service),
+    new RuntimeSessionsSpawnTool(service),
+    new RuntimeSessionsSendTool(service),
+    new RuntimeSessionsUpdateTool(service),
+    new RuntimeSessionsClaimTool(service),
+    new RuntimeSessionsCancelTool(service),
+    new RuntimeSessionsRetryTool(service),
+  ];
+}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -163,6 +163,8 @@ export interface ToolCallContext {
   timeoutMs?: number;
   /** Session identifier for correlation in audit logs */
   sessionId?: string;
+  /** Owning chat conversation session id when the tool runs inside chat. */
+  conversationSessionId?: string;
   /** Unique call identifier for correlation in audit logs */
   callId?: string;
   /** Optional logger for audit-trail events */


### PR DESCRIPTION
## Summary
- add durable runtime session tools for spawn, read, children, claim, retry, cancel, and lifecycle updates
- persist parent-child session control metadata including waiting conditions, ownership, retry state, goal linkage, and notification policy
- project session completion events into first-class chat notifications and add caller-path coverage for session control flows

## Testing
- npm run typecheck
- npx vitest run --config vitest.unit.config.ts src/tools/query/__tests__/runtime-session-tools.test.ts src/interface/chat/__tests__/event-subscriber.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/interface/cli/__tests__/runtime-command.test.ts
- npx vitest run --config vitest.integration.config.ts src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
