### PR TITLE
Restrict planner reuse to verified playbooks

### DIFF
--- a/src/orchestrator/execution/__tests__/reflection-generator.test.ts
+++ b/src/orchestrator/execution/__tests__/reflection-generator.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   generateReflection,
   saveReflectionAsKnowledge,
+  getFailureReflectionsForGoal,
   getReflectionsForGoal,
   formatReflectionsForPrompt,
 } from "../reflection-generator.js";
@@ -410,6 +411,59 @@ describe("getReflectionsForGoal()", () => {
     const results = await getReflectionsForGoal(km, "goal-1");
 
     expect(results).toHaveLength(0);
+  });
+});
+
+describe("getFailureReflectionsForGoal()", () => {
+  it("keeps searching past recent successes until it finds older failures", async () => {
+    const entries = [
+      makeKnowledgeEntry({
+        entry_id: "success-1",
+        acquired_at: "2026-03-20T13:00:00.000Z",
+        answer: JSON.stringify({
+          what_was_attempted: "Recent success 1",
+          outcome: "success",
+          why_it_worked_or_failed: "ok",
+          what_to_do_differently: "repeat",
+        }),
+      }),
+      makeKnowledgeEntry({
+        entry_id: "success-2",
+        acquired_at: "2026-03-20T12:00:00.000Z",
+        answer: JSON.stringify({
+          what_was_attempted: "Recent success 2",
+          outcome: "success",
+          why_it_worked_or_failed: "ok",
+          what_to_do_differently: "repeat",
+        }),
+      }),
+      makeKnowledgeEntry({
+        entry_id: "success-3",
+        acquired_at: "2026-03-20T11:00:00.000Z",
+        answer: JSON.stringify({
+          what_was_attempted: "Recent success 3",
+          outcome: "success",
+          why_it_worked_or_failed: "ok",
+          what_to_do_differently: "repeat",
+        }),
+      }),
+      makeKnowledgeEntry({
+        entry_id: "fail-1",
+        acquired_at: "2026-03-20T10:00:00.000Z",
+        answer: JSON.stringify({
+          what_was_attempted: "Older failure",
+          outcome: "fail",
+          why_it_worked_or_failed: "broke",
+          what_to_do_differently: "change approach",
+        }),
+      }),
+    ];
+    const km = makeMockKnowledgeManager(entries);
+
+    const results = await getFailureReflectionsForGoal(km, "goal-1", 1);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]!.reflection_id).toBe("fail-1");
   });
 });
 

--- a/src/orchestrator/execution/__tests__/task-context-enricher.test.ts
+++ b/src/orchestrator/execution/__tests__/task-context-enricher.test.ts
@@ -1,23 +1,30 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { buildEnrichedKnowledgeContext } from "../task/task-context-enricher.js";
 
 vi.mock("../reflection-generator.js", () => ({
   getFailureReflectionsForGoal: vi.fn(),
+  getReflectionsForGoal: vi.fn(),
   formatReflectionsForPrompt: vi.fn(),
 }));
 
 import {
   getFailureReflectionsForGoal,
+  getReflectionsForGoal,
   formatReflectionsForPrompt,
 } from "../reflection-generator.js";
 
 describe("buildEnrichedKnowledgeContext", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("appends transfer snippets and formatted reflections", async () => {
     const tmpDir = makeTempDir("context-enricher-");
     const stateManager = new StateManager(tmpDir);
     vi.mocked(getFailureReflectionsForGoal).mockResolvedValue([{ id: "r1" }] as never);
+    vi.mocked(getReflectionsForGoal).mockResolvedValue([] as never);
     vi.mocked(formatReflectionsForPrompt).mockReturnValue("reflection context");
 
     try {
@@ -43,6 +50,7 @@ describe("buildEnrichedKnowledgeContext", () => {
     const tmpDir = makeTempDir("context-enricher-fail-");
     const stateManager = new StateManager(tmpDir);
     vi.mocked(getFailureReflectionsForGoal).mockResolvedValue([]);
+    vi.mocked(getReflectionsForGoal).mockResolvedValue([] as never);
     vi.mocked(formatReflectionsForPrompt).mockReturnValue("");
     const warn = vi.fn();
 
@@ -59,6 +67,50 @@ describe("buildEnrichedKnowledgeContext", () => {
 
       expect(result).toBe("base context");
       expect(warn).not.toHaveBeenCalled();
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("restores full reflection history when verified-only mode is disabled", async () => {
+    const tmpDir = makeTempDir("context-enricher-optout-");
+    const stateManager = new StateManager(tmpDir);
+    vi.mocked(getFailureReflectionsForGoal).mockResolvedValue([] as never);
+    vi.mocked(getReflectionsForGoal).mockResolvedValue([{ id: "r-full" }] as never);
+    vi.mocked(formatReflectionsForPrompt).mockReturnValue("full reflection context");
+
+    await stateManager.writeRaw("dream/config.json", {
+      activation: {
+        verifiedPlannerHintsOnly: false,
+        semanticWorkingMemory: false,
+        crossGoalLessons: false,
+        semanticContext: false,
+        autoAcquireKnowledge: false,
+        learnedPatternHints: false,
+        playbookHints: false,
+        workflowHints: false,
+        strategyTemplates: false,
+        decisionHeuristics: false,
+        graphTraversal: false,
+      },
+    });
+
+    try {
+      const result = await buildEnrichedKnowledgeContext({
+        goalId: "goal-3",
+        knowledgeContext: "base context",
+        knowledgeTransfer: {
+          detectCandidatesRealtime: vi.fn().mockResolvedValue({
+            contextSnippets: ["snippet A"],
+          }),
+        } as never,
+        knowledgeManager: {} as never,
+        stateManager,
+      });
+
+      expect(result).toBe("base context\nsnippet A\nfull reflection context");
+      expect(getReflectionsForGoal).toHaveBeenCalledOnce();
+      expect(getFailureReflectionsForGoal).not.toHaveBeenCalled();
     } finally {
       cleanupTempDir(tmpDir);
     }

--- a/src/orchestrator/execution/__tests__/task-context-enricher.test.ts
+++ b/src/orchestrator/execution/__tests__/task-context-enricher.test.ts
@@ -1,50 +1,66 @@
 import { describe, expect, it, vi } from "vitest";
+import { StateManager } from "../../../base/state/state-manager.js";
+import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { buildEnrichedKnowledgeContext } from "../task/task-context-enricher.js";
 
 vi.mock("../reflection-generator.js", () => ({
-  getReflectionsForGoal: vi.fn(),
+  getFailureReflectionsForGoal: vi.fn(),
   formatReflectionsForPrompt: vi.fn(),
 }));
 
 import {
-  getReflectionsForGoal,
+  getFailureReflectionsForGoal,
   formatReflectionsForPrompt,
 } from "../reflection-generator.js";
 
 describe("buildEnrichedKnowledgeContext", () => {
   it("appends transfer snippets and formatted reflections", async () => {
-    vi.mocked(getReflectionsForGoal).mockResolvedValue([{ id: "r1" }] as never);
+    const tmpDir = makeTempDir("context-enricher-");
+    const stateManager = new StateManager(tmpDir);
+    vi.mocked(getFailureReflectionsForGoal).mockResolvedValue([{ id: "r1" }] as never);
     vi.mocked(formatReflectionsForPrompt).mockReturnValue("reflection context");
 
-    const result = await buildEnrichedKnowledgeContext({
-      goalId: "goal-1",
-      knowledgeContext: "base context",
-      knowledgeTransfer: {
-        detectCandidatesRealtime: vi.fn().mockResolvedValue({
-          contextSnippets: ["snippet A", "snippet B"],
-        }),
-      } as never,
-      knowledgeManager: {} as never,
-    });
+    try {
+      const result = await buildEnrichedKnowledgeContext({
+        goalId: "goal-1",
+        knowledgeContext: "base context",
+        knowledgeTransfer: {
+          detectCandidatesRealtime: vi.fn().mockResolvedValue({
+            contextSnippets: ["snippet A", "snippet B"],
+          }),
+        } as never,
+        knowledgeManager: {} as never,
+        stateManager,
+      });
 
-    expect(result).toBe("base context\nsnippet A\nsnippet B\nreflection context");
+      expect(result).toBe("base context\nreflection context");
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
   });
 
   it("continues without enrichment when transfer lookup fails", async () => {
-    vi.mocked(getReflectionsForGoal).mockResolvedValue([]);
+    const tmpDir = makeTempDir("context-enricher-fail-");
+    const stateManager = new StateManager(tmpDir);
+    vi.mocked(getFailureReflectionsForGoal).mockResolvedValue([]);
     vi.mocked(formatReflectionsForPrompt).mockReturnValue("");
     const warn = vi.fn();
 
-    const result = await buildEnrichedKnowledgeContext({
-      goalId: "goal-2",
-      knowledgeContext: "base context",
-      knowledgeTransfer: {
-        detectCandidatesRealtime: vi.fn().mockRejectedValue(new Error("boom")),
-      } as never,
-      logger: { warn } as never,
-    });
+    try {
+      const result = await buildEnrichedKnowledgeContext({
+        goalId: "goal-2",
+        knowledgeContext: "base context",
+        knowledgeTransfer: {
+          detectCandidatesRealtime: vi.fn().mockRejectedValue(new Error("boom")),
+        } as never,
+        logger: { warn } as never,
+        stateManager,
+      });
 
-    expect(result).toBe("base context");
-    expect(warn).toHaveBeenCalled();
+      expect(result).toBe("base context");
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
   });
 });

--- a/src/orchestrator/execution/__tests__/task-generation-trust-gate.test.ts
+++ b/src/orchestrator/execution/__tests__/task-generation-trust-gate.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { StateManager } from "../../../base/state/state-manager.js";
+import { StrategyManager } from "../../strategy/strategy-manager.js";
+import type {
+  ILLMClient,
+  LLMMessage,
+  LLMRequestOptions,
+  LLMResponse,
+} from "../../../base/llm/llm-client.js";
+import { saveDreamConfig } from "../../../platform/dream/dream-config.js";
+import { generateTask } from "../task/task-generation.js";
+import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { makeGoal } from "../../../../tests/helpers/fixtures.js";
+
+function createSpyLLMClient(response: string): ILLMClient & {
+  calls: Array<{ messages: LLMMessage[]; options?: LLMRequestOptions }>;
+} {
+  const calls: Array<{ messages: LLMMessage[]; options?: LLMRequestOptions }> = [];
+  return {
+    calls,
+    async sendMessage(messages: LLMMessage[], options?: LLMRequestOptions): Promise<LLMResponse> {
+      calls.push({ messages, options });
+      return {
+        content: response,
+        usage: { input_tokens: 0, output_tokens: 0 },
+        stop_reason: "end_turn",
+      };
+    },
+    parseJSON<T>(content: string, schema: z.ZodSchema<T>): T {
+      const match = content.match(/```json\n?([\s\S]*?)\n?```/) ?? [null, content];
+      return schema.parse(JSON.parse(match[1] ?? content));
+    },
+  };
+}
+
+const VALID_TASK_RESPONSE = `\`\`\`json
+{
+  "work_description": "Repair the verification boundary",
+  "rationale": "Keep the planner aligned with verified guidance",
+  "approach": "Patch the narrow verification seam and rerun focused checks",
+  "success_criteria": [
+    {
+      "description": "Focused verification passes",
+      "verification_method": "npm test -- verification",
+      "is_blocking": true
+    }
+  ],
+  "scope_boundary": {
+    "in_scope": ["verification boundary"],
+    "out_of_scope": ["broad unrelated refactors"],
+    "blast_radius": "verification path only"
+  },
+  "constraints": ["Keep changes narrow"],
+  "reversibility": "reversible",
+  "estimated_duration": null
+}
+\`\`\``;
+
+describe("generateTask planner trust gate", () => {
+  let tmpDir = "";
+  let stateManager: StateManager;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir("task-generation-trust-gate-");
+    stateManager = new StateManager(tmpDir);
+    await stateManager.saveGoal(makeGoal({
+      id: "goal-1",
+      title: "Stabilize verification",
+      description: "Prefer only verified procedural guidance",
+      dimensions: [{
+        name: "verification",
+        label: "verification",
+        current_value: 0.2,
+        threshold: { type: "min", value: 0.8 },
+        confidence: 0.9,
+        observation_method: {
+          type: "mechanical",
+          source: "test",
+          schedule: null,
+          endpoint: null,
+          confidence_tier: "mechanical",
+        },
+        last_updated: new Date().toISOString(),
+        history: [],
+        weight: 1,
+        uncertainty_weight: null,
+        state_integrity: "ok",
+        dimension_mapping: null,
+      }],
+    }) as any);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  it("uses failure reflections only and suppresses unverified lessons by default", async () => {
+    const llmClient = createSpyLLMClient(VALID_TASK_RESPONSE);
+    const strategyManager = new StrategyManager(stateManager, llmClient);
+    const knowledgeManager = {
+      loadKnowledge: async () => [
+        {
+          entry_id: "reflection-success",
+          question: "Reflection: success",
+          answer: JSON.stringify({
+            what_was_attempted: "Applied a broad workaround",
+            outcome: "success",
+            why_it_worked_or_failed: "Looked good locally",
+            what_to_do_differently: "Repeat the workaround",
+          }),
+          sources: [],
+          confidence: 0.9,
+          acquired_at: "2026-04-28T00:00:00.000Z",
+          acquisition_task_id: "task-success",
+          superseded_by: null,
+          tags: ["reflection"],
+          embedding_id: null,
+        },
+        {
+          entry_id: "reflection-fail",
+          question: "Reflection: fail",
+          answer: JSON.stringify({
+            what_was_attempted: "Retried the same flaky command",
+            outcome: "fail",
+            why_it_worked_or_failed: "The command was nondeterministic",
+            what_to_do_differently: "Use focused verification instead",
+          }),
+          sources: [],
+          confidence: 0.3,
+          acquired_at: "2026-04-28T01:00:00.000Z",
+          acquisition_task_id: "task-fail",
+          superseded_by: null,
+          tags: ["reflection"],
+          embedding_id: null,
+        },
+      ],
+    } as const;
+    const memoryLifecycle = {
+      selectForWorkingMemory: async () => ({
+        shortTerm: [],
+        lessons: [
+          { type: "failure_pattern", lesson: "Do not trust green self-report without verification", relevance_tags: ["HIGH"] },
+        ],
+      }),
+    };
+
+    await generateTask(
+      {
+        stateManager,
+        llmClient,
+        strategyManager,
+        knowledgeManager: knowledgeManager as never,
+        memoryLifecycle,
+      },
+      "goal-1",
+      "verification",
+    );
+
+    const userMessage = llmClient.calls[0]!.messages[0]!.content;
+    expect(userMessage).toContain("The command was nondeterministic");
+    expect(userMessage).toContain("Use focused verification instead");
+    expect(userMessage).not.toContain("Looked good locally");
+    expect(userMessage).not.toContain("Repeat the workaround");
+    expect(userMessage).not.toContain("lessons_learned");
+  });
+
+  it("allows raw lessons and successful reflections when verified-only mode is disabled", async () => {
+    const llmClient = createSpyLLMClient(VALID_TASK_RESPONSE);
+    const strategyManager = new StrategyManager(stateManager, llmClient);
+    const knowledgeManager = {
+      loadKnowledge: async () => [
+        {
+          entry_id: "reflection-success",
+          question: "Reflection: success",
+          answer: JSON.stringify({
+            what_was_attempted: "Applied a broad workaround",
+            outcome: "success",
+            why_it_worked_or_failed: "Looked good locally",
+            what_to_do_differently: "Repeat the workaround",
+          }),
+          sources: [],
+          confidence: 0.9,
+          acquired_at: "2026-04-28T00:00:00.000Z",
+          acquisition_task_id: "task-success",
+          superseded_by: null,
+          tags: ["reflection"],
+          embedding_id: null,
+        },
+      ],
+    } as const;
+    const memoryLifecycle = {
+      selectForWorkingMemory: async () => ({
+        shortTerm: [],
+        lessons: [
+          { type: "failure_pattern", lesson: "Carry over the raw lesson block", relevance_tags: ["HIGH"] },
+        ],
+      }),
+    };
+    await saveDreamConfig({
+      activation: {
+        verifiedPlannerHintsOnly: false,
+        semanticWorkingMemory: true,
+        crossGoalLessons: true,
+        semanticContext: true,
+        autoAcquireKnowledge: true,
+        learnedPatternHints: true,
+        playbookHints: true,
+        workflowHints: true,
+        strategyTemplates: true,
+        decisionHeuristics: true,
+        graphTraversal: true,
+      },
+    }, stateManager.getBaseDir());
+
+    await generateTask(
+      {
+        stateManager,
+        llmClient,
+        strategyManager,
+        knowledgeManager: knowledgeManager as never,
+        memoryLifecycle,
+      },
+      "goal-1",
+      "verification",
+    );
+
+    const userMessage = llmClient.calls[0]!.messages[0]!.content;
+    expect(userMessage).toContain("Looked good locally");
+    expect(userMessage).toContain("Repeat the workaround");
+    expect(userMessage).toContain("lessons_learned");
+    expect(userMessage).toContain("Carry over the raw lesson block");
+  });
+});

--- a/src/orchestrator/execution/__tests__/task-lifecycle-cycle-helpers.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-cycle-helpers.test.ts
@@ -12,6 +12,7 @@ import { TaskLifecycle } from "../task/task-lifecycle.js";
 import type { Task } from "../../../base/types/task.js";
 import type { GapVector } from "../../../base/types/gap.js";
 import type { DriveContext } from "../../../base/types/drive.js";
+import { saveDreamConfig } from "../../../platform/dream/dream-config.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 
@@ -180,7 +181,7 @@ describe("TaskLifecycle — runTaskCycle helper branches", () => {
     expect(result.task.work_description).toContain("skipped");
   });
 
-  it("enriches knowledge context when realtime transfer returns snippets", async () => {
+  it("skips realtime transfer enrichment by default when verified-only mode is enabled", async () => {
     const llm = createMockLLMClient([VALID_TASK_RESPONSE, LLM_REVIEW_PASS]);
     const knowledgeTransfer = {
       detectCandidatesRealtime: vi.fn().mockResolvedValue({
@@ -201,7 +202,48 @@ describe("TaskLifecycle — runTaskCycle helper branches", () => {
       createMockAdapter()
     );
 
-    expect(knowledgeTransfer.detectCandidatesRealtime).toHaveBeenCalledWith("goal-kt");
+    expect(knowledgeTransfer.detectCandidatesRealtime).not.toHaveBeenCalled();
+    expect(result.task).toBeDefined();
+  });
+
+  it("enriches knowledge context with realtime transfer snippets when verified-only mode is disabled", async () => {
+    await saveDreamConfig({
+      activation: {
+        verifiedPlannerHintsOnly: false,
+        semanticWorkingMemory: false,
+        crossGoalLessons: false,
+        semanticContext: false,
+        autoAcquireKnowledge: false,
+        learnedPatternHints: false,
+        playbookHints: false,
+        workflowHints: false,
+        strategyTemplates: false,
+        decisionHeuristics: false,
+        graphTraversal: false,
+      },
+    }, stateManager.getBaseDir());
+
+    const llm = createMockLLMClient([VALID_TASK_RESPONSE, LLM_REVIEW_PASS]);
+    const knowledgeTransfer = {
+      detectCandidatesRealtime: vi.fn().mockResolvedValue({
+        contextSnippets: ["Snippet A", "Snippet B"],
+        candidates: [],
+      }),
+    };
+
+    const lifecycle = createLifecycle(llm, {
+      approvalFn: async () => true,
+      knowledgeTransfer: knowledgeTransfer as unknown as import("../../knowledge/transfer/knowledge-transfer.js").KnowledgeTransfer,
+    });
+
+    const result = await lifecycle.runTaskCycle(
+      "goal-kt-optout",
+      makeGapVector("goal-kt-optout", [{ name: "coverage", gap: 0.5 }]),
+      makeDriveContext(["coverage"]),
+      createMockAdapter()
+    );
+
+    expect(knowledgeTransfer.detectCandidatesRealtime).toHaveBeenCalledWith("goal-kt-optout");
     expect(result.task).toBeDefined();
   });
 

--- a/src/orchestrator/execution/__tests__/task-lifecycle-generation.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-generation.test.ts
@@ -162,7 +162,7 @@ describe("TaskLifecycle", async () => {
       expect(userMessage).toContain("goal-42");
     });
 
-    it("injects learned pattern hints into task generation when dream activation is enabled", async () => {
+    it("does not inject learned pattern hints when verified-only planner mode is enabled", async () => {
       const spy = createSpyLLMClient([VALID_TASK_RESPONSE]);
       const lifecycle = createLifecycle(spy);
 
@@ -194,6 +194,7 @@ describe("TaskLifecycle", async () => {
       ]);
       await saveDreamConfig({
         activation: {
+          verifiedPlannerHintsOnly: true,
           semanticWorkingMemory: false,
           crossGoalLessons: false,
           semanticContext: false,
@@ -210,11 +211,11 @@ describe("TaskLifecycle", async () => {
       await lifecycle.generateTask("goal-42", "completion_rate");
 
       const userMessage = spy.calls[0]!.messages[0]!.content;
-      expect(userMessage).toContain("Learned pattern hints");
-      expect(userMessage).toContain("step-by-step signup hints");
+      expect(userMessage).not.toContain("Learned pattern hints");
+      expect(userMessage).not.toContain("step-by-step signup hints");
     });
 
-    it("injects workflow recovery hints into task generation when dream activation is enabled", async () => {
+    it("does not inject workflow recovery hints when verified-only planner mode is enabled", async () => {
       const spy = createSpyLLMClient([VALID_TASK_RESPONSE]);
       const lifecycle = createLifecycle(spy);
 
@@ -261,6 +262,128 @@ describe("TaskLifecycle", async () => {
       });
       await saveDreamConfig({
         activation: {
+          verifiedPlannerHintsOnly: true,
+          semanticWorkingMemory: false,
+          crossGoalLessons: false,
+          semanticContext: false,
+          autoAcquireKnowledge: false,
+          learnedPatternHints: false,
+          playbookHints: false,
+          workflowHints: true,
+          strategyTemplates: false,
+          decisionHeuristics: false,
+          graphTraversal: false,
+        },
+      }, stateManager.getBaseDir());
+
+      await lifecycle.generateTask("goal-42", "verification");
+
+      const userMessage = spy.calls[0]!.messages[0]!.content;
+      expect(userMessage).not.toContain("Workflow recovery hints");
+      expect(userMessage).not.toContain("Stall recovery: confidence stall");
+    });
+
+    it("allows learned pattern hints when verified-only planner mode is explicitly disabled", async () => {
+      const spy = createSpyLLMClient([VALID_TASK_RESPONSE]);
+      const lifecycle = createLifecycle(spy);
+
+      await stateManager.saveGoal({
+        id: "goal-42",
+        title: "Improve onboarding completion",
+        description: "Reduce user drop-off during signup",
+        status: "active",
+        dimensions: [],
+        parent_id: null,
+        child_goal_ids: [],
+        success_criteria: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      } as any);
+      await stateManager.writeRaw("learning/goal-42_patterns.json", [
+        {
+          pattern_id: "pat-1",
+          type: "task_generation",
+          description: "Use step-by-step signup hints before proposing new UI changes",
+          confidence: 0.82,
+          evidence_count: 4,
+          source_goal_ids: ["goal-42"],
+          applicable_domains: ["signup", "onboarding"],
+          embedding_id: null,
+          created_at: new Date().toISOString(),
+          last_applied_at: null,
+        },
+      ]);
+      await saveDreamConfig({
+        activation: {
+          verifiedPlannerHintsOnly: false,
+          semanticWorkingMemory: false,
+          crossGoalLessons: false,
+          semanticContext: false,
+          autoAcquireKnowledge: false,
+          learnedPatternHints: true,
+          playbookHints: false,
+          workflowHints: false,
+          strategyTemplates: false,
+          decisionHeuristics: false,
+          graphTraversal: false,
+        },
+      }, stateManager.getBaseDir());
+
+      await lifecycle.generateTask("goal-42", "completion_rate");
+
+      const userMessage = spy.calls[0]!.messages[0]!.content;
+      expect(userMessage).toContain("Learned pattern hints");
+      expect(userMessage).toContain("step-by-step signup hints");
+    });
+
+    it("allows workflow recovery hints when verified-only planner mode is explicitly disabled", async () => {
+      const spy = createSpyLLMClient([VALID_TASK_RESPONSE]);
+      const lifecycle = createLifecycle(spy);
+
+      await stateManager.saveGoal({
+        id: "goal-42",
+        title: "Improve daemon recovery",
+        description: "Avoid repeated confidence stalls during verification",
+        status: "active",
+        dimensions: [],
+        parent_id: null,
+        child_goal_ids: [],
+        success_criteria: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      } as any);
+      await stateManager.writeRaw("dream/workflows.json", {
+        version: "dream-workflows-v1",
+        generated_at: new Date().toISOString(),
+        workflows: [
+          {
+            workflow_id: "dream-workflow:test-stall",
+            type: "stall_recovery",
+            title: "Stall recovery: confidence stall",
+            description: "Change strategy when verification confidence stalls.",
+            applicability: {
+              goal_ids: ["goal-42"],
+              task_ids: [],
+              event_types: ["StallDetected"],
+              signals: ["confidence_stall", "verification"],
+            },
+            preconditions: ["A stall was detected."],
+            steps: ["Pause repeated attempts.", "Inspect the verification signal.", "Change strategy."],
+            failure_modes: ["confidence_stall"],
+            recovery_steps: ["Re-plan before retrying."],
+            evidence_refs: ["dream/events/goal-42.jsonl#L1"],
+            evidence_count: 2,
+            success_count: 0,
+            failure_count: 2,
+            confidence: 0.73,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        ],
+      });
+      await saveDreamConfig({
+        activation: {
+          verifiedPlannerHintsOnly: false,
           semanticWorkingMemory: false,
           crossGoalLessons: false,
           semanticContext: false,
@@ -348,6 +471,7 @@ describe("TaskLifecycle", async () => {
       });
       await saveDreamConfig({
         activation: {
+          verifiedPlannerHintsOnly: true,
           semanticWorkingMemory: false,
           crossGoalLessons: false,
           semanticContext: false,
@@ -450,6 +574,7 @@ describe("TaskLifecycle", async () => {
       });
       await saveDreamConfig({
         activation: {
+          verifiedPlannerHintsOnly: true,
           semanticWorkingMemory: false,
           crossGoalLessons: false,
           semanticContext: false,

--- a/src/orchestrator/execution/reflection-generator.ts
+++ b/src/orchestrator/execution/reflection-generator.ts
@@ -151,7 +151,15 @@ export async function getReflectionsForGoal(
   logger?: ReflectionLogger,
 ): Promise<ReflectionNote[]> {
   const entries = await knowledgeManager.loadKnowledge(goalId, ["reflection"]);
+  return parseReflectionEntries(entries, goalId, logger)
+    .slice(0, limit);
+}
 
+function parseReflectionEntries(
+  entries: Awaited<ReturnType<KnowledgeManager["loadKnowledge"]>>,
+  goalId: string,
+  logger?: ReflectionLogger,
+): ReflectionNote[] {
   const reflections: ReflectionNote[] = [];
   for (const entry of entries) {
     try {
@@ -171,8 +179,7 @@ export async function getReflectionsForGoal(
   }
 
   return reflections
-    .sort((a, b) => b.created_at.localeCompare(a.created_at))
-    .slice(0, limit);
+    .sort((a, b) => b.created_at.localeCompare(a.created_at));
 }
 
 export async function getFailureReflectionsForGoal(
@@ -181,13 +188,8 @@ export async function getFailureReflectionsForGoal(
   limit = 5,
   logger?: ReflectionLogger,
 ): Promise<ReflectionNote[]> {
-  const reflections = await getReflectionsForGoal(
-    knowledgeManager,
-    goalId,
-    limit * 3,
-    logger,
-  );
-  return reflections
+  const entries = await knowledgeManager.loadKnowledge(goalId, ["reflection"]);
+  return parseReflectionEntries(entries, goalId, logger)
     .filter((reflection) => reflection.outcome !== "success")
     .slice(0, limit);
 }

--- a/src/orchestrator/execution/reflection-generator.ts
+++ b/src/orchestrator/execution/reflection-generator.ts
@@ -175,6 +175,23 @@ export async function getReflectionsForGoal(
     .slice(0, limit);
 }
 
+export async function getFailureReflectionsForGoal(
+  knowledgeManager: KnowledgeManager,
+  goalId: string,
+  limit = 5,
+  logger?: ReflectionLogger,
+): Promise<ReflectionNote[]> {
+  const reflections = await getReflectionsForGoal(
+    knowledgeManager,
+    goalId,
+    limit * 3,
+    logger,
+  );
+  return reflections
+    .filter((reflection) => reflection.outcome !== "success")
+    .slice(0, limit);
+}
+
 // --- formatReflectionsForPrompt ---
 
 export function formatReflectionsForPrompt(reflections: ReflectionNote[]): string {

--- a/src/orchestrator/execution/task/task-context-enricher.ts
+++ b/src/orchestrator/execution/task/task-context-enricher.ts
@@ -1,13 +1,16 @@
 import type { Logger } from "../../../runtime/logger.js";
 import type { KnowledgeTransfer } from "../../../platform/knowledge/transfer/knowledge-transfer.js";
 import type { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
-import { getReflectionsForGoal, formatReflectionsForPrompt } from "../reflection-generator.js";
+import type { StateManager } from "../../../base/state/state-manager.js";
+import { loadDreamActivationState } from "../../../platform/dream/dream-activation.js";
+import { getFailureReflectionsForGoal, formatReflectionsForPrompt } from "../reflection-generator.js";
 
 interface BuildEnrichedKnowledgeContextParams {
   goalId: string;
   knowledgeContext?: string;
   knowledgeTransfer?: KnowledgeTransfer;
   knowledgeManager?: KnowledgeManager;
+  stateManager: StateManager;
   logger?: Logger;
 }
 
@@ -19,12 +22,15 @@ export async function buildEnrichedKnowledgeContext(
     knowledgeContext,
     knowledgeTransfer,
     knowledgeManager,
+    stateManager,
     logger,
   } = params;
 
   let enrichedKnowledgeContext = knowledgeContext;
+  const dreamActivation = await loadDreamActivationState(stateManager.getBaseDir()).catch(() => null);
+  const verifiedPlannerHintsOnly = dreamActivation?.flags.verifiedPlannerHintsOnly ?? true;
 
-  if (knowledgeTransfer) {
+  if (knowledgeTransfer && !verifiedPlannerHintsOnly) {
     try {
       const { contextSnippets } = await knowledgeTransfer.detectCandidatesRealtime(goalId);
       if (contextSnippets.length > 0) {
@@ -43,7 +49,7 @@ export async function buildEnrichedKnowledgeContext(
   if (!knowledgeManager) return enrichedKnowledgeContext;
 
   try {
-    const pastReflections = await getReflectionsForGoal(knowledgeManager, goalId, 5, logger);
+    const pastReflections = await getFailureReflectionsForGoal(knowledgeManager, goalId, 5, logger);
     if (pastReflections.length > 0) {
       const reflectionText = formatReflectionsForPrompt(pastReflections);
       enrichedKnowledgeContext = enrichedKnowledgeContext

--- a/src/orchestrator/execution/task/task-context-enricher.ts
+++ b/src/orchestrator/execution/task/task-context-enricher.ts
@@ -3,7 +3,11 @@ import type { KnowledgeTransfer } from "../../../platform/knowledge/transfer/kno
 import type { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import { loadDreamActivationState } from "../../../platform/dream/dream-activation.js";
-import { getFailureReflectionsForGoal, formatReflectionsForPrompt } from "../reflection-generator.js";
+import {
+  getFailureReflectionsForGoal,
+  getReflectionsForGoal,
+  formatReflectionsForPrompt,
+} from "../reflection-generator.js";
 
 interface BuildEnrichedKnowledgeContextParams {
   goalId: string;
@@ -49,7 +53,9 @@ export async function buildEnrichedKnowledgeContext(
   if (!knowledgeManager) return enrichedKnowledgeContext;
 
   try {
-    const pastReflections = await getFailureReflectionsForGoal(knowledgeManager, goalId, 5, logger);
+    const pastReflections = verifiedPlannerHintsOnly
+      ? await getFailureReflectionsForGoal(knowledgeManager, goalId, 5, logger)
+      : await getReflectionsForGoal(knowledgeManager, goalId, 5, logger);
     if (pastReflections.length > 0) {
       const reflectionText = formatReflectionsForPrompt(pastReflections);
       enrichedKnowledgeContext = enrichedKnowledgeContext

--- a/src/orchestrator/execution/task/task-generation.ts
+++ b/src/orchestrator/execution/task/task-generation.ts
@@ -11,7 +11,8 @@ import { TaskGroupSchema } from "../../../base/types/index.js";
 import type { TaskGroup } from "../../../base/types/index.js";
 import type { TaskPipeline } from "../../../base/types/pipeline.js";
 import { wrapXmlTag, formatReflections, formatLessons } from "../../../prompt/formatters.js";
-import { getReflectionsForGoal } from "../reflection-generator.js";
+import { loadDreamActivationState } from "../../../platform/dream/dream-activation.js";
+import { getFailureReflectionsForGoal, getReflectionsForGoal } from "../reflection-generator.js";
 import type { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
 import type { IPromptGateway } from "../../../prompt/gateway.js";
 
@@ -265,13 +266,17 @@ export async function generateTask(
     adapterType === "openai_codex_cli" || adapterType === "claude_code_cli";
   const maxGenerationTokens = isCodeExecutionContext ? 1024 : 1536;
   const modelTier: "light" | "main" = isCodeExecutionContext ? "light" : "main";
+  const dreamActivation = await loadDreamActivationState(deps.stateManager.getBaseDir()).catch(() => null);
+  const verifiedPlannerHintsOnly = dreamActivation?.flags.verifiedPlannerHintsOnly ?? true;
   // Build optional reflections and lessons XML blocks
   let reflectionsBlock = "";
   let lessonsBlock = "";
 
   if (deps.knowledgeManager) {
     try {
-      const reflections = await getReflectionsForGoal(deps.knowledgeManager, goalId, 5, deps.logger);
+      const reflections = verifiedPlannerHintsOnly
+        ? await getFailureReflectionsForGoal(deps.knowledgeManager, goalId, 5, deps.logger)
+        : await getReflectionsForGoal(deps.knowledgeManager, goalId, 5, deps.logger);
       if (reflections.length > 0) {
         reflectionsBlock = wrapXmlTag(
           "past_reflections",
@@ -289,7 +294,7 @@ export async function generateTask(
     }
   }
 
-  if (deps.memoryLifecycle) {
+  if (deps.memoryLifecycle && !verifiedPlannerHintsOnly) {
     try {
       const memory = await deps.memoryLifecycle.selectForWorkingMemory(
         goalId,

--- a/src/orchestrator/execution/task/task-lifecycle-runner.ts
+++ b/src/orchestrator/execution/task/task-lifecycle-runner.ts
@@ -158,6 +158,7 @@ export async function runTaskLifecycleCycle(context: TaskLifecycleTaskCycleConte
     buildEnrichedKnowledgeContext({
       goalId,
       knowledgeContext: baseKnowledgeContext,
+      stateManager: context.stateManager,
       ...context.enrichmentDeps(),
     })
   );

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -271,6 +271,7 @@ export class TaskLifecycle {
     try {
       const baseDir = this.stateManager.getBaseDir();
       const dreamActivation = await loadDreamActivationState(baseDir);
+      const verifiedPlannerHintsOnly = dreamActivation.flags.verifiedPlannerHintsOnly ?? true;
       if (
         dreamActivation.flags.learnedPatternHints ||
         dreamActivation.flags.playbookHints ||
@@ -284,7 +285,7 @@ export class TaskLifecycle {
           knowledgeContext ?? "",
         ].join(" ");
 
-        if (dreamActivation.flags.learnedPatternHints) {
+        if (dreamActivation.flags.learnedPatternHints && !verifiedPlannerHintsOnly) {
           const patterns = await loadLearnedPatterns(baseDir, goalId);
           const hints = selectPatternHints(patterns, query);
           const formattedHints = formatPatternHints(hints);
@@ -309,7 +310,7 @@ export class TaskLifecycle {
           }
         }
 
-        if (dreamActivation.flags.workflowHints) {
+        if (dreamActivation.flags.workflowHints && !verifiedPlannerHintsOnly) {
           const workflows = await loadDreamWorkflows(baseDir);
           const hints = selectWorkflowHints(workflows, query, { goalId, targetDimension });
           const formattedHints = formatWorkflowHints(hints);
@@ -627,6 +628,7 @@ export class TaskLifecycle {
     return {
       knowledgeTransfer: this.knowledgeTransfer,
       knowledgeManager: this.knowledgeManager,
+      stateManager: this.stateManager,
       logger: this.logger,
     };
   }

--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -535,6 +535,7 @@ describe("CoreLoop", async () => {
       await mocks.stateManager.saveGoal(makeGoal());
       await saveDreamConfig({
         activation: {
+          verifiedPlannerHintsOnly: false,
           semanticWorkingMemory: false,
           crossGoalLessons: true,
           semanticContext: false,
@@ -639,6 +640,7 @@ describe("CoreLoop", async () => {
       await mocks.stateManager.saveGoal(makeGoal());
       await saveDreamConfig({
         activation: {
+          verifiedPlannerHintsOnly: true,
           semanticWorkingMemory: false,
           crossGoalLessons: false,
           semanticContext: false,

--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -496,6 +496,21 @@ describe("CoreLoop", async () => {
     it("injects relevant knowledge into task generation context", async () => {
       const { deps, mocks } = createMockDeps(tmpDir);
       await mocks.stateManager.saveGoal(makeGoal());
+      await saveDreamConfig({
+        activation: {
+          verifiedPlannerHintsOnly: false,
+          semanticWorkingMemory: false,
+          crossGoalLessons: false,
+          semanticContext: false,
+          autoAcquireKnowledge: false,
+          learnedPatternHints: false,
+          playbookHints: false,
+          workflowHints: false,
+          strategyTemplates: false,
+          decisionHeuristics: false,
+          graphTraversal: false,
+        },
+      }, mocks.stateManager.getBaseDir());
 
       const knowledgeEntries = [
         {
@@ -577,6 +592,168 @@ describe("CoreLoop", async () => {
       const callArgs = mocks.taskLifecycle.runTaskCycle.mock.calls[0];
       expect(callArgs![4]).toContain("Cross-goal lessons");
       expect(callArgs![4]).toContain("migration checklist");
+    });
+
+    it("does not inject raw knowledge or semantic working memory when verified-only mode is enabled", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal());
+      await saveDreamConfig({
+        activation: {
+          verifiedPlannerHintsOnly: true,
+          semanticWorkingMemory: true,
+          crossGoalLessons: false,
+          semanticContext: true,
+          autoAcquireKnowledge: false,
+          learnedPatternHints: false,
+          playbookHints: false,
+          workflowHints: false,
+          strategyTemplates: false,
+          decisionHeuristics: false,
+          graphTraversal: false,
+        },
+      }, mocks.stateManager.getBaseDir());
+
+      const knowledgeManager = {
+        detectKnowledgeGap: vi.fn().mockResolvedValue(null),
+        generateAcquisitionTask: vi.fn(),
+        getRelevantKnowledge: vi.fn().mockResolvedValue([
+          {
+            entry_id: "e1",
+            question: "Raw knowledge",
+            answer: "should not be injected",
+            sources: [],
+            confidence: 0.9,
+            acquired_at: new Date().toISOString(),
+            acquisition_task_id: "t1",
+            superseded_by: null,
+            tags: ["dim1"],
+          },
+        ]),
+        searchKnowledge: vi.fn().mockResolvedValue([
+          {
+            entry_id: "e2",
+            question: "Semantic knowledge",
+            answer: "should also stay out",
+            sources: [],
+            confidence: 0.7,
+            acquired_at: new Date().toISOString(),
+            acquisition_task_id: "t2",
+            superseded_by: null,
+            tags: ["dim1"],
+          },
+        ]),
+        saveKnowledge: vi.fn(),
+        loadKnowledge: vi.fn().mockResolvedValue([]),
+        checkContradiction: vi.fn(),
+      };
+      const memoryLifecycleManager = {
+        selectForWorkingMemoryTierAware: vi.fn().mockResolvedValue({
+          shortTerm: [{ data_type: "note", data: { value: "raw working memory" } }],
+          lessons: [],
+        }),
+        selectForWorkingMemorySemantic: vi.fn().mockResolvedValue({
+          shortTerm: [{ data_type: "note", data: { value: "semantic working memory" } }],
+          lessons: [],
+        }),
+        onSatisficingJudgment: vi.fn(),
+      };
+
+      const loop = new CoreLoop(
+        {
+          ...deps,
+          knowledgeManager: knowledgeManager as any,
+          memoryLifecycleManager: memoryLifecycleManager as any,
+        },
+        { delayBetweenLoopsMs: 0 }
+      );
+      await loop.runOneIteration("goal-1", 0);
+
+      expect(knowledgeManager.getRelevantKnowledge).not.toHaveBeenCalled();
+      expect(knowledgeManager.searchKnowledge).not.toHaveBeenCalled();
+      expect(memoryLifecycleManager.selectForWorkingMemoryTierAware).not.toHaveBeenCalled();
+      expect(memoryLifecycleManager.selectForWorkingMemorySemantic).not.toHaveBeenCalled();
+      const callArgs = mocks.taskLifecycle.runTaskCycle.mock.calls[0];
+      expect(callArgs![4]).toBeUndefined();
+    });
+
+    it("restores raw knowledge injection when verified-only mode is disabled", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal());
+      await saveDreamConfig({
+        activation: {
+          verifiedPlannerHintsOnly: false,
+          semanticWorkingMemory: true,
+          crossGoalLessons: false,
+          semanticContext: true,
+          autoAcquireKnowledge: false,
+          learnedPatternHints: false,
+          playbookHints: false,
+          workflowHints: false,
+          strategyTemplates: false,
+          decisionHeuristics: false,
+          graphTraversal: false,
+        },
+      }, mocks.stateManager.getBaseDir());
+
+      const knowledgeManager = {
+        detectKnowledgeGap: vi.fn().mockResolvedValue(null),
+        generateAcquisitionTask: vi.fn(),
+        getRelevantKnowledge: vi.fn().mockResolvedValue([
+          {
+            entry_id: "e1",
+            question: "Raw knowledge",
+            answer: "allowed when gate is off",
+            sources: [],
+            confidence: 0.9,
+            acquired_at: new Date().toISOString(),
+            acquisition_task_id: "t1",
+            superseded_by: null,
+            tags: ["dim1"],
+          },
+        ]),
+        searchKnowledge: vi.fn().mockResolvedValue([
+          {
+            entry_id: "e2",
+            question: "Semantic knowledge",
+            answer: "also allowed when gate is off",
+            sources: [],
+            confidence: 0.7,
+            acquired_at: new Date().toISOString(),
+            acquisition_task_id: "t2",
+            superseded_by: null,
+            tags: ["dim1"],
+          },
+        ]),
+        saveKnowledge: vi.fn(),
+        loadKnowledge: vi.fn().mockResolvedValue([]),
+        checkContradiction: vi.fn(),
+      };
+      const memoryLifecycleManager = {
+        selectForWorkingMemoryTierAware: vi.fn().mockResolvedValue({ shortTerm: [], lessons: [] }),
+        selectForWorkingMemorySemantic: vi.fn().mockResolvedValue({
+          shortTerm: [{ data_type: "note", data: { value: "semantic working memory" } }],
+          lessons: [],
+        }),
+        onSatisficingJudgment: vi.fn(),
+      };
+
+      const loop = new CoreLoop(
+        {
+          ...deps,
+          knowledgeManager: knowledgeManager as any,
+          memoryLifecycleManager: memoryLifecycleManager as any,
+        },
+        { delayBetweenLoopsMs: 0 }
+      );
+      await loop.runOneIteration("goal-1", 0);
+
+      expect(knowledgeManager.getRelevantKnowledge).toHaveBeenCalledOnce();
+      expect(knowledgeManager.searchKnowledge).toHaveBeenCalledOnce();
+      expect(memoryLifecycleManager.selectForWorkingMemoryTierAware).toHaveBeenCalledOnce();
+      expect(memoryLifecycleManager.selectForWorkingMemorySemantic).toHaveBeenCalledOnce();
+      const callArgs = mocks.taskLifecycle.runTaskCycle.mock.calls[0];
+      expect(callArgs![4]).toContain("allowed when gate is off");
+      expect(callArgs![4]).toContain("semantic working memory");
     });
 
     it("skips knowledge injection gracefully when getRelevantKnowledge returns empty", async () => {

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -276,7 +276,11 @@ export async function runTaskCycleWithContext(
       }
     }
 
-    if (activationFlags?.crossGoalLessons && ctx.deps.memoryLifecycleManager) {
+    if (
+      activationFlags?.crossGoalLessons &&
+      ctx.deps.memoryLifecycleManager &&
+      !activationFlags.verifiedPlannerHintsOnly
+    ) {
       try {
         await runPhase("collect-cross-goal-lessons", async () => {
           const topDimension = driveScores[0]?.dimension_name ?? goal.dimensions[0]?.name ?? "";

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -226,6 +226,7 @@ export async function runTaskCycleWithContext(
     if (ctx.deps.knowledgeManager) {
       try {
         await runPhase("collect-knowledge-context", async () => {
+          if (activationFlags?.verifiedPlannerHintsOnly) return;
           const topDimension = driveScores[0]?.dimension_name ?? goal.dimensions[0]?.name;
           if (!topDimension) return;
           let entries = await ctx.deps.knowledgeManager!.getRelevantKnowledge(goalId, topDimension);
@@ -305,6 +306,7 @@ export async function runTaskCycleWithContext(
     if (ctx.deps.memoryLifecycleManager) {
       try {
         await runPhase("select-working-memory", async () => {
+          if (activationFlags?.verifiedPlannerHintsOnly) return;
           const dimensions = goal.dimensions.map((d) => d.name);
           const maxDissatisfaction = driveScores.length > 0
             ? Math.max(...driveScores.map((s) => s.dissatisfaction))

--- a/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
@@ -89,6 +89,7 @@ function makeStrategy(overrides: Partial<Strategy> = {}): Strategy {
 }
 
 const STRATEGY_TEMPLATES_ACTIVATION = {
+  verifiedPlannerHintsOnly: false,
   semanticWorkingMemory: false,
   crossGoalLessons: false,
   semanticContext: false,

--- a/src/orchestrator/strategy/strategy-manager-base.ts
+++ b/src/orchestrator/strategy/strategy-manager-base.ts
@@ -238,7 +238,8 @@ export class StrategyManagerBase {
 
     try {
       const activation = await loadDreamActivationState(this.stateManager.getBaseDir());
-      if (activation.flags.strategyTemplates) {
+      const verifiedPlannerHintsOnly = activation.flags.verifiedPlannerHintsOnly ?? true;
+      if (activation.flags.strategyTemplates && !verifiedPlannerHintsOnly) {
         const goal = await this.stateManager.loadGoal(goalId);
         const templates = await loadStrategyTemplates(this.stateManager.getBaseDir());
         const matchedTemplates = selectTemplateCandidates(
@@ -269,7 +270,7 @@ export class StrategyManagerBase {
         }
       }
 
-      if (activation.flags.decisionHeuristics) {
+      if (activation.flags.decisionHeuristics && !verifiedPlannerHintsOnly) {
         const heuristics = await loadDecisionHeuristics(this.stateManager.getBaseDir());
         candidates = applyDecisionHeuristicsToCandidates(candidates, heuristics, {
           stallCount: Math.max(

--- a/src/platform/dream/__tests__/dream-consolidator.test.ts
+++ b/src/platform/dream/__tests__/dream-consolidator.test.ts
@@ -55,6 +55,7 @@ describe("DreamConsolidator", () => {
         agentMemoryEntries: 1,
         learnedPatterns: 0,
         workflowRecords: 0,
+        verifiedPlaybooks: 0,
         previousRecords: 0,
         recordsWritten: 1,
         recordsSuperseded: 0,

--- a/src/platform/dream/__tests__/dream-soil-sync.test.ts
+++ b/src/platform/dream/__tests__/dream-soil-sync.test.ts
@@ -78,6 +78,7 @@ describe("dream soil sync", () => {
       agentMemoryEntries: 1,
       learnedPatterns: 1,
       workflowRecords: 0,
+      verifiedPlaybooks: 0,
       previousRecords: 0,
       recordsWritten: 2,
       chunksWritten: 2,
@@ -112,6 +113,7 @@ describe("dream soil sync", () => {
     });
     expect(repository.applyMutation).not.toHaveBeenCalled();
     expect(report.recordsWritten).toBe(0);
+    expect(report.verifiedPlaybooks).toBe(0);
   });
 
   it("tombstones previous Dream-origin records when current files are gone", async () => {
@@ -154,6 +156,7 @@ describe("dream soil sync", () => {
       agentMemoryEntries: 0,
       learnedPatterns: 0,
       workflowRecords: 0,
+      verifiedPlaybooks: 0,
       previousRecords: 1,
       recordsWritten: 0,
       chunksWritten: 0,
@@ -218,6 +221,7 @@ describe("dream soil sync", () => {
       agentMemoryEntries: 0,
       learnedPatterns: 0,
       workflowRecords: 1,
+      verifiedPlaybooks: 0,
       recordsWritten: 1,
       chunksWritten: 1,
     });
@@ -227,5 +231,78 @@ describe("dream soil sync", () => {
     expect(workflowPage?.frontmatter.compiled_memory_schema).toBe("soil-compiled-memory-v1");
     expect(workflowPage?.body).toContain("Change strategy when confidence stalls.");
     expect(workflowPage?.body).toContain("dream/events/goal-a.jsonl#L1");
+  });
+
+  it("projects promoted playbooks into Soil while leaving raw dream records out of planner mutation paths", async () => {
+    tmpDir = makeTempDir("dream-soil-sync-playbook-");
+    await fs.mkdir(path.join(tmpDir, "dream", "playbooks"), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpDir, "dream", "playbooks", "verified-provider.json"),
+      JSON.stringify({
+        playbook_id: "dream-playbook-provider",
+        status: "promoted",
+        kind: "verified_execution",
+        title: "Repair provider config boundary",
+        summary: "Verified workflow for provider boundary fixes.",
+        source_signature: "provider-boundary",
+        applicability: {
+          goal_ids: ["goal-a"],
+          primary_dimensions: ["type_safety"],
+          task_categories: ["verification"],
+          terms: ["provider", "config", "typecheck"],
+        },
+        preconditions: ["Constraint: keep validation strict"],
+        recommended_steps: ["Patch the narrow boundary", "Run focused typecheck"],
+        verification_checks: [
+          {
+            description: "Focused typecheck passes",
+            verification_method: "npm run typecheck",
+            blocking: true,
+          },
+        ],
+        failure_warnings: ["Do not widen runtime acceptance"],
+        evidence_refs: ["Focused typecheck passed"],
+        source_task_ids: ["task-provider"],
+        verification: {
+          verdict: "pass",
+          confidence: 0.91,
+          last_verified_at: "2026-04-12T06:00:00.000Z",
+        },
+        usage: {
+          retrieved_count: 0,
+          verified_success_count: 2,
+          successful_reuse_count: 0,
+          failed_reuse_count: 0,
+        },
+        governance: {
+          created_by: "dream",
+          review_state: "verified",
+          auto_generated: true,
+          user_editable: true,
+          auto_mutation: "forbidden",
+        },
+        created_at: "2026-04-12T05:00:00.000Z",
+        updated_at: "2026-04-12T06:00:00.000Z",
+      }),
+      "utf8"
+    );
+    const repository: DreamSoilSyncRepository = {
+      loadRecords: vi.fn().mockResolvedValue([]),
+      applyMutation: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const report = await syncDreamOutputsToSoil({ baseDir: tmpDir, repository });
+
+    expect(report).toMatchObject({
+      verifiedPlaybooks: 1,
+      recordsWritten: 0,
+    });
+    expect(repository.applyMutation).not.toHaveBeenCalled();
+
+    const playbookPage = await readSoilMarkdownFile(path.join(tmpDir, "soil", "dream", "playbooks", "index.md"));
+    expect(playbookPage?.frontmatter.soil_id).toBe("dream/playbooks/index");
+    expect(playbookPage?.frontmatter.compiled_memory_schema).toBe("soil-compiled-memory-v1");
+    expect(playbookPage?.body).toContain("Repair provider config boundary");
+    expect(playbookPage?.body).toContain("Focused typecheck passes");
   });
 });

--- a/src/platform/dream/dream-soil-sync.ts
+++ b/src/platform/dream/dream-soil-sync.ts
@@ -10,6 +10,7 @@ import { projectDreamKnowledgeToSoil, projectSoilFeedbackToSoil } from "../soil/
 import { loadSoilCompileMissObservations } from "../soil/feedback-store.js";
 import { inspectSoilMemoryHealth } from "../soil/health.js";
 import { loadDreamWorkflowRecords } from "./dream-event-workflows.js";
+import { loadDreamPlaybooks, type DreamPlaybookRecord } from "./playbook-memory.js";
 import { buildDreamSoilMutationIntent } from "./dream-soil-mutation.js";
 
 export interface DreamSoilSyncRepository {
@@ -27,6 +28,7 @@ export interface DreamSoilSyncReport {
   agentMemoryEntries: number;
   learnedPatterns: number;
   workflowRecords: number;
+  verifiedPlaybooks: number;
   previousRecords: number;
   recordsWritten: number;
   recordsSuperseded: number;
@@ -64,11 +66,16 @@ async function loadLearnedPatterns(baseDir: string): Promise<LearnedPattern[]> {
   return patterns;
 }
 
+async function loadVerifiedPlaybooks(baseDir: string): Promise<DreamPlaybookRecord[]> {
+  return loadDreamPlaybooks(baseDir, { statuses: ["promoted"] });
+}
+
 export async function syncDreamOutputsToSoil(input: DreamSoilSyncInput): Promise<DreamSoilSyncReport> {
-  const [agentMemoryEntries, learnedPatterns, workflowRecords] = await Promise.all([
+  const [agentMemoryEntries, learnedPatterns, workflowRecords, verifiedPlaybooks] = await Promise.all([
     loadAgentMemoryEntries(input.baseDir),
     loadLearnedPatterns(input.baseDir),
     loadDreamWorkflowRecords(input.baseDir),
+    loadVerifiedPlaybooks(input.baseDir),
   ]);
   const previousRecords = await input.repository.loadRecords({
     active_only: false,
@@ -97,6 +104,7 @@ export async function syncDreamOutputsToSoil(input: DreamSoilSyncInput): Promise
   await projectDreamKnowledgeToSoil({
     baseDir: input.baseDir,
     learnedPatterns,
+    verifiedPlaybooks,
     workflowRecords,
   });
   const compileMissObservations = await loadSoilCompileMissObservations({ baseDir: input.baseDir, limit: 500 });
@@ -113,6 +121,7 @@ export async function syncDreamOutputsToSoil(input: DreamSoilSyncInput): Promise
     agentMemoryEntries: agentMemoryEntries.length,
     learnedPatterns: learnedPatterns.length,
     workflowRecords: workflowRecords.length,
+    verifiedPlaybooks: verifiedPlaybooks.length,
     previousRecords: previousRecords.length,
     recordsWritten: intent.mutation.records.length,
     recordsSuperseded: intent.mutation.records.filter((record) => record.supersedes_record_id !== null).length,

--- a/src/platform/dream/dream-types.ts
+++ b/src/platform/dream/dream-types.ts
@@ -170,6 +170,7 @@ export const DreamLogConfigSchema = z.object({
     deepTokenBudget: z.number().int().positive().default(200_000),
   }).default({}),
   activation: z.object({
+    verifiedPlannerHintsOnly: z.boolean().default(true),
     semanticWorkingMemory: z.boolean().default(true),
     crossGoalLessons: z.boolean().default(true),
     semanticContext: z.boolean().default(true),

--- a/src/platform/soil/__tests__/soil-content-projections.test.ts
+++ b/src/platform/soil/__tests__/soil-content-projections.test.ts
@@ -211,6 +211,7 @@ describe("Soil content projections", () => {
       await projectDreamKnowledgeToSoil({
         baseDir,
         learnedPatterns: [],
+        verifiedPlaybooks: [],
         workflowRecords: [],
         clock: fixedClock,
       });
@@ -251,6 +252,7 @@ describe("Soil content projections", () => {
       await projectDreamKnowledgeToSoil({
         baseDir,
         learnedPatterns: [],
+        verifiedPlaybooks: [],
         workflowRecords: [taskOnlyWorkflow],
         clock: fixedClock,
       });

--- a/src/platform/soil/compiled-memory-projections.ts
+++ b/src/platform/soil/compiled-memory-projections.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import type { DreamWorkflowRecord } from "../dream/dream-event-workflows.js";
+import type { DreamPlaybookRecord } from "../dream/playbook-memory.js";
 import type { LearnedPattern } from "../knowledge/types/learning.js";
 import type { SoilMemoryHealthSnapshot } from "./health.js";
 import {
@@ -74,6 +75,31 @@ function dreamWorkflowSection(workflow: DreamWorkflowRecord): string {
   return lines.join("\n");
 }
 
+function dreamPlaybookSection(playbook: DreamPlaybookRecord): string {
+  const lines = [
+    `## ${playbook.playbook_id}`,
+    "",
+    `- Status: ${playbook.status}`,
+    `- Title: ${playbook.title}`,
+    `- Summary: ${trimText(playbook.summary, 360)}`,
+    `- Verification confidence: ${playbook.verification.confidence}`,
+    `- Verified successes: ${playbook.usage.verified_success_count}`,
+    `- Successful / failed reuse: ${playbook.usage.successful_reuse_count} / ${playbook.usage.failed_reuse_count}`,
+    `- Goal IDs: ${bulletList(playbook.applicability.goal_ids, "none")}`,
+    `- Dimensions: ${bulletList(playbook.applicability.primary_dimensions, "none")}`,
+    `- Categories: ${bulletList(playbook.applicability.task_categories, "none")}`,
+    `- Last verified: ${playbook.verification.last_verified_at}`,
+    `- Updated: ${playbook.updated_at}`,
+    "",
+    ...sectionList("### Preconditions", playbook.preconditions),
+    ...sectionList("### Recommended steps", playbook.recommended_steps),
+    ...sectionList("### Verification checks", playbook.verification_checks.map((check) => `${check.description} (${check.verification_method})`)),
+    ...sectionList("### Failure warnings", playbook.failure_warnings),
+    ...sectionList("### Evidence", playbook.evidence_refs),
+  ];
+  return lines.join("\n");
+}
+
 function healthFindingSection(snapshot: SoilMemoryHealthSnapshot): string[] {
   if (snapshot.findings.length === 0) {
     return ["No health findings."];
@@ -110,14 +136,18 @@ function compileMissBucketSection(snapshot: SoilMemoryHealthSnapshot): string[] 
 
 export async function projectDreamKnowledgeToSoil(input: SoilProjectionOptions & {
   learnedPatterns: LearnedPattern[];
+  verifiedPlaybooks: DreamPlaybookRecord[];
   workflowRecords: DreamWorkflowRecord[];
 }): Promise<void> {
   const generatedAt = nowIso(input.clock);
   const learningSourcePath = path.join(input.baseDir, "learning");
+  const playbookSourcePath = path.join(input.baseDir, "dream", "playbooks");
   const workflowSourcePath = path.join(input.baseDir, "dream", "workflows.json");
   const learningSourceHash = await sourceHashFromFileOrValue(learningSourcePath, input.learnedPatterns);
+  const playbookSourceHash = await sourceHashFromFileOrValue(playbookSourcePath, input.verifiedPlaybooks);
   const workflowSourceHash = await sourceHashFromFileOrValue(workflowSourcePath, input.workflowRecords);
   const learnedPatterns = sortByDate(input.learnedPatterns, (pattern) => pattern.created_at);
+  const verifiedPlaybooks = sortByDate(input.verifiedPlaybooks, (playbook) => playbook.updated_at);
   const workflowRecords = sortByDate(input.workflowRecords, (workflow) => workflow.updated_at);
 
   await writeProjectedPage(input, {
@@ -149,6 +179,39 @@ export async function projectDreamKnowledgeToSoil(input: SoilProjectionOptions &
       "## Patterns",
       "",
       ...(learnedPatterns.length > 0 ? learnedPatterns.map((pattern) => learnedPatternSection(pattern)) : ["No learned patterns."]),
+      "",
+    ].join("\n"),
+  });
+
+  await writeProjectedPage(input, {
+    frontmatter: SoilPageFrontmatterSchema.parse({
+      ...baseFrontmatter({
+        soilId: "dream/playbooks/index",
+        title: "Verified playbooks",
+        kind: "knowledge",
+        route: "knowledge",
+        createdAt: verifiedPlaybooks.at(-1)?.created_at ?? generatedAt,
+        updatedAt: verifiedPlaybooks.at(0)?.updated_at ?? generatedAt,
+        generatedAt,
+        sourceRefs: sourceRefsFromPaths("runtime_json", [{ sourcePath: playbookSourcePath, sourceHash: playbookSourceHash, reliability: "high" }]),
+        sourceTruth: "runtime_json",
+        renderedFrom: "dream-consolidator",
+        domain: "verified-playbooks",
+        summary: `${verifiedPlaybooks.length} verified playbook records`,
+        inputChecksums: { [playbookSourcePath]: playbookSourceHash },
+      }),
+      compiled_memory_schema: SOIL_COMPILED_MEMORY_SCHEMA_VERSION,
+    }),
+    body: [
+      "# Verified playbooks",
+      "",
+      `- Playbooks: ${verifiedPlaybooks.length}`,
+      `- Statuses: ${bulletList([...new Set(verifiedPlaybooks.map((playbook) => playbook.status))].sort(), "none")}`,
+      `- Generated: ${generatedAt}`,
+      "",
+      "## Playbooks",
+      "",
+      ...(verifiedPlaybooks.length > 0 ? verifiedPlaybooks.map((playbook) => dreamPlaybookSection(playbook)) : ["No verified playbooks."]),
       "",
     ].join("\n"),
   });


### PR DESCRIPTION
## Summary
- add a verified-only planner gate so task and strategy planning stop consuming raw learned patterns, workflows, cross-goal lessons, and decision heuristics by default
- keep failure reflections available for planning while suppressing unverified lesson injection unless the gate is explicitly disabled
- project promoted Dream playbooks into Soil as the verified procedural memory surface for planner reuse

## Testing
- npm run typecheck
- npm run test:unit -- src/orchestrator/execution/__tests__/task-context-enricher.test.ts src/orchestrator/execution/__tests__/task-generation-trust-gate.test.ts src/orchestrator/execution/__tests__/task-lifecycle-generation.test.ts src/platform/dream/__tests__/dream-soil-sync.test.ts src/platform/dream/__tests__/dream-consolidator.test.ts src/orchestrator/loop/__tests__/core-loop-integrations.test.ts src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts src/platform/soil/__tests__/soil-content-projections.test.ts
