### PR TITLE
Add chat runtime helper regression tests

### DIFF
--- a/src/interface/chat/__tests__/chat-runner-runtime.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-runtime.test.ts
@@ -1,0 +1,226 @@
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StateManager } from "../../../base/state/state-manager.js";
+import {
+  buildRuntimeControlContextFromIngress,
+  buildStandaloneIngressMessageFromContext,
+  resolveChatResumeSelector,
+  type ChatRunnerRuntimeDeps,
+} from "../chat-runner-runtime.js";
+import { buildStandaloneIngressMessage } from "../ingress-router.js";
+
+const tempDirs: string[] = [];
+
+function trackedTempDir(): string {
+  const dir = path.join(os.tmpdir(), `pulseed-chat-runtime-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeDeps(overrides: Partial<ChatRunnerRuntimeDeps> = {}): ChatRunnerRuntimeDeps {
+  return {
+    stateManager: {
+      readRaw: vi.fn().mockResolvedValue(null),
+    },
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  while (tempDirs.length > 0) {
+    await fsp.rm(tempDirs.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("chat-runner runtime helpers", () => {
+  it("buildStandaloneIngressMessageFromContext prefers the current runtime reply target over stale fallback deps", () => {
+    const message = buildStandaloneIngressMessageFromContext(
+      "restart now",
+      {
+        actor: {
+          surface: "gateway",
+          platform: "telegram",
+          conversation_id: "telegram-thread",
+          identity_key: "owner",
+          user_id: "user-1",
+        },
+        replyTarget: {
+          surface: "gateway",
+          platform: "telegram",
+          conversation_id: "telegram-thread",
+          identity_key: "owner",
+          user_id: "user-1",
+          message_id: "msg-new",
+          deliveryMode: "thread_reply",
+          metadata: { source: "current-turn" },
+        },
+        approvalFn: async () => true,
+      },
+      makeDeps({
+        runtimeReplyTarget: {
+          surface: "gateway",
+          platform: "slack",
+          conversation_id: "slack-thread",
+          identity_key: "owner",
+          user_id: "user-1",
+          message_id: "msg-stale",
+        },
+      })
+    );
+
+    expect(message.channel).toBe("plugin_gateway");
+    expect(message.platform).toBe("telegram");
+    expect(message.conversation_id).toBe("telegram-thread");
+    expect(message.replyTarget).toMatchObject({
+      platform: "telegram",
+      conversation_id: "telegram-thread",
+      identity_key: "owner",
+      user_id: "user-1",
+      message_id: "msg-new",
+      deliveryMode: "thread_reply",
+      metadata: { source: "current-turn" },
+    });
+    expect(message.replyTarget.conversation_id).not.toBe("slack-thread");
+    expect(message.replyTarget.message_id).not.toBe("msg-stale");
+  });
+
+  it("buildRuntimeControlContextFromIngress auto-approves preapproved ingress without calling stale interactive approval handlers", async () => {
+    const staleApproval = vi.fn().mockResolvedValue(false);
+    const depsApproval = vi.fn().mockResolvedValue(false);
+    const ingress = buildStandaloneIngressMessage({
+      text: "restart",
+      channel: "plugin_gateway",
+      platform: "slack",
+      conversation_id: "C123",
+      user_id: "U123",
+      runtimeControl: {
+        allowed: true,
+        approvalMode: "preapproved",
+      },
+    });
+
+    const context = buildRuntimeControlContextFromIngress(
+      ingress,
+      {
+        actor: ingress.actor,
+        replyTarget: ingress.replyTarget,
+        approvalFn: staleApproval,
+      },
+      makeDeps({ approvalFn: depsApproval })
+    );
+
+    expect(context?.actor).toEqual(ingress.actor);
+    expect(context?.replyTarget).toEqual(ingress.replyTarget);
+    await expect(context?.approvalFn?.("approve?")).resolves.toBe(true);
+    expect(staleApproval).not.toHaveBeenCalled();
+    expect(depsApproval).not.toHaveBeenCalled();
+  });
+
+  it("buildRuntimeControlContextFromIngress keeps disallowed ingress from reusing a previous turn approval function", () => {
+    const staleApproval = vi.fn().mockResolvedValue(true);
+    const ingress = buildStandaloneIngressMessage({
+      text: "restart",
+      channel: "plugin_gateway",
+      platform: "discord",
+      conversation_id: "thread-1",
+      user_id: "user-1",
+      runtimeControl: {
+        allowed: false,
+        approvalMode: "disallowed",
+      },
+    });
+
+    const context = buildRuntimeControlContextFromIngress(
+      ingress,
+      {
+        actor: ingress.actor,
+        replyTarget: ingress.replyTarget,
+        approvalFn: staleApproval,
+      },
+      makeDeps()
+    );
+
+    expect(context?.approvalFn).toBeUndefined();
+  });
+
+  it("resolveChatResumeSelector resumes a real agent runtime session only when its owning conversation is still chat-resumable", async () => {
+    const baseDir = trackedTempDir();
+    const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+    await stateManager.init();
+
+    await stateManager.writeRaw("chat/sessions/chat-active.json", {
+      id: "chat-active",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:00:00.000Z",
+      updatedAt: "2026-04-25T00:10:00.000Z",
+      title: "Active session",
+      messages: [],
+      agentLoopStatePath: "chat/agentloop/active.state.json",
+      agentLoopStatus: "running",
+      agentLoopResumable: true,
+      agentLoopUpdatedAt: "2026-04-25T00:11:00.000Z",
+    });
+    await stateManager.writeRaw("chat/agentloop/active.state.json", {
+      sessionId: "agent-active",
+      traceId: "trace-active",
+      turnId: "turn-active",
+      goalId: "goal-active",
+      cwd: "/repo",
+      modelRef: "native:test",
+      messages: [],
+      modelTurns: 1,
+      toolCalls: 0,
+      compactions: 0,
+      completionValidationAttempts: 0,
+      calledTools: [],
+      lastToolLoopSignature: null,
+      repeatedToolLoopCount: 0,
+      finalText: "",
+      status: "running",
+      updatedAt: "2026-04-25T00:12:00.000Z",
+    });
+
+    await stateManager.writeRaw("chat/sessions/chat-stale.json", {
+      id: "chat-stale",
+      cwd: "/repo",
+      createdAt: "2026-04-25T00:20:00.000Z",
+      updatedAt: "2026-04-25T00:30:00.000Z",
+      title: "Stale session",
+      messages: [],
+      agentLoopStatePath: "chat/agentloop/stale.state.json",
+      agentLoopStatus: "completed",
+      agentLoopResumable: false,
+      agentLoopUpdatedAt: "2026-04-25T00:31:00.000Z",
+    });
+    await stateManager.writeRaw("chat/agentloop/stale.state.json", {
+      sessionId: "agent-stale",
+      traceId: "trace-stale",
+      turnId: "turn-stale",
+      goalId: "goal-stale",
+      cwd: "/repo",
+      modelRef: "native:test",
+      messages: [],
+      modelTurns: 1,
+      toolCalls: 0,
+      compactions: 0,
+      completionValidationAttempts: 0,
+      calledTools: [],
+      lastToolLoopSignature: null,
+      repeatedToolLoopCount: 0,
+      finalText: "",
+      status: "completed",
+      updatedAt: "2026-04-25T00:31:00.000Z",
+    });
+
+    const active = await resolveChatResumeSelector("session:agent:agent-active", { stateManager });
+    const stale = await resolveChatResumeSelector("session:agent:agent-stale", { stateManager });
+
+    expect(active).toEqual({ chatSelector: "chat-active" });
+    expect(stale.chatSelector).toBe("session:agent:agent-stale");
+    expect(stale.nonResumableMessage).toContain("is not chat-resumable");
+  });
+});

--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -24,6 +24,7 @@ import {
   StrategyManager as RealStrategyManager,
   type StrategyManager,
 } from "../../strategy/strategy-manager.js";
+import { PortfolioManager } from "../../strategy/portfolio-manager.js";
 import type { DriveSystem } from "../../../platform/drive/drive-system.js";
 import type { AdapterRegistry, IAdapter } from "../../execution/adapter-layer.js";
 import type { GapVector } from "../../../base/types/gap.js";
@@ -351,6 +352,44 @@ function createMockDeps(tmpDir: string): {
       adapterRegistry,
       adapter,
     },
+  };
+}
+
+function makeWaitStrategyForCoreLoop(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "wait-strategy-1",
+    goal_id: "goal-1",
+    target_dimensions: ["dim1"],
+    primary_dimension: "dim1",
+    hypothesis: "Wait for the training run to finish",
+    expected_effect: [],
+    resource_estimate: {
+      sessions: 0,
+      duration: { value: 1, unit: "hours" },
+      llm_calls: null,
+    },
+    state: "active",
+    allocation: 1,
+    created_at: "2026-04-24T00:00:00.000Z",
+    started_at: "2026-04-24T00:00:00.000Z",
+    completed_at: null,
+    gap_snapshot_at_start: 0.8,
+    tasks_generated: [],
+    effectiveness_score: null,
+    consecutive_stall_count: 0,
+    source_template_id: null,
+    cross_goal_context: null,
+    rollback_target_id: null,
+    max_pivot_count: 2,
+    pivot_count: 0,
+    toolset_locked: false,
+    allowed_tools: [],
+    required_tools: [],
+    wait_reason: "Observe Kaggle training completion",
+    wait_until: new Date(Date.now() - 100_000).toISOString(),
+    measurement_plan: "Resume when process exits and inspect metrics",
+    fallback_strategy_id: null,
+    ...overrides,
   };
 }
 
@@ -1188,6 +1227,131 @@ describe("CoreLoop", async () => {
       await loop.runOneIteration("goal-1", 0);
 
       expect(mocks.strategyManager.onStallDetected).toHaveBeenCalledWith("goal-1", 3, expect.any(String), undefined);
+    });
+
+    it("uses the real wait expiry path through PortfolioManager when the current process session has exited", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal({
+        dimensions: [makeDimension({ name: "dim1" })],
+      }));
+
+      const waitStrategy = makeWaitStrategyForCoreLoop();
+      const processSessionId = "sess-current";
+      const processSessionDir = path.join(tmpDir, "runtime", "process-sessions");
+      fs.mkdirSync(processSessionDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(processSessionDir, `${processSessionId}.json`),
+        JSON.stringify({ session_id: processSessionId, running: false, exitCode: 0, pid: 4242 }),
+      );
+
+      mocks.strategyManager.getPortfolio.mockReturnValue({
+        goal_id: "goal-1",
+        strategies: [waitStrategy],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+      await mocks.stateManager.writeRaw("gaps/goal-1/current.json", { dim1: 0.4 });
+      await mocks.stateManager.writeRaw(`strategies/goal-1/wait-meta/${waitStrategy.id}.json`, {
+        schema_version: 1,
+        wait_until: waitStrategy.wait_until,
+        conditions: [{ type: "process_session_exited", session_id: processSessionId }],
+        resume_plan: { action: "complete_wait" },
+        process_refs: [{
+          session_id: processSessionId,
+          metadata_relative_path: path.join("runtime", "process-sessions", `${processSessionId}.json`),
+        }],
+      });
+
+      const portfolioManager = new PortfolioManager(
+        mocks.strategyManager as unknown as RealStrategyManager,
+        mocks.stateManager,
+      );
+      const depsWithPM = { ...deps, portfolioManager };
+      const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
+      const result = await loop.runOneIteration("goal-1", 0);
+      const persistedWaitMeta = await mocks.stateManager.readRaw(`strategies/goal-1/wait-meta/${waitStrategy.id}.json`) as Record<string, unknown>;
+
+      expect(result.waitExpired).toBe(true);
+      expect(result.waitStrategyId).toBe(waitStrategy.id);
+      expect(result.waitExpiryOutcome).toMatchObject({ status: "improved", strategy_id: waitStrategy.id });
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toBe("wait_observe_only");
+      expect(mocks.strategyManager.updateState).toHaveBeenCalledWith(waitStrategy.id, "completed");
+      expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
+      expect(persistedWaitMeta["latest_observation"]).toMatchObject({
+        status: "satisfied",
+        resume_hint: "wait_conditions_satisfied",
+      });
+    });
+
+    it("does not resume from a stale previous process session when the current session is still running", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal({
+        dimensions: [makeDimension({ name: "dim1" })],
+      }));
+
+      const waitStrategy = makeWaitStrategyForCoreLoop();
+      const currentSessionId = "sess-current";
+      const staleSessionId = "sess-previous";
+      const processSessionDir = path.join(tmpDir, "runtime", "process-sessions");
+      fs.mkdirSync(processSessionDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(processSessionDir, `${currentSessionId}.json`),
+        JSON.stringify({ session_id: currentSessionId, running: true, exitCode: null }),
+      );
+      fs.writeFileSync(
+        path.join(processSessionDir, `${staleSessionId}.json`),
+        JSON.stringify({ session_id: staleSessionId, running: false, exitCode: 0, pid: 4141 }),
+      );
+
+      mocks.strategyManager.getPortfolio.mockReturnValue({
+        goal_id: "goal-1",
+        strategies: [waitStrategy],
+        rebalance_interval: { value: 7, unit: "days" },
+        last_rebalanced_at: new Date().toISOString(),
+      });
+      mocks.stallDetector.isSuppressed.mockReturnValue(true);
+      await mocks.stateManager.writeRaw("gaps/goal-1/current.json", { dim1: 0.4 });
+      await mocks.stateManager.writeRaw(`strategies/goal-1/wait-meta/${waitStrategy.id}.json`, {
+        schema_version: 1,
+        wait_until: waitStrategy.wait_until,
+        conditions: [{ type: "process_session_exited", session_id: currentSessionId }],
+        resume_plan: { action: "complete_wait" },
+        process_refs: [
+          {
+            session_id: staleSessionId,
+            metadata_relative_path: path.join("runtime", "process-sessions", `${staleSessionId}.json`),
+          },
+          {
+            session_id: currentSessionId,
+            metadata_relative_path: path.join("runtime", "process-sessions", `${currentSessionId}.json`),
+          },
+        ],
+      });
+
+      const portfolioManager = new PortfolioManager(
+        mocks.strategyManager as unknown as RealStrategyManager,
+        mocks.stateManager,
+      );
+      const depsWithPM = { ...deps, portfolioManager };
+      const loop = new CoreLoop(depsWithPM, { delayBetweenLoopsMs: 0 });
+      const result = await loop.runOneIteration("goal-1", 0);
+      const persistedWaitMeta = await mocks.stateManager.readRaw(`strategies/goal-1/wait-meta/${waitStrategy.id}.json`) as Record<string, unknown>;
+
+      expect(result.waitSuppressed).toBe(true);
+      expect(result.waitStrategyId).toBe(waitStrategy.id);
+      expect(result.waitExpiryOutcome).toMatchObject({
+        status: "not_due",
+        strategy_id: waitStrategy.id,
+      });
+      expect(result.skipped).toBe(true);
+      expect(result.skipReason).toBe("wait_not_due");
+      expect(mocks.strategyManager.updateState).not.toHaveBeenCalled();
+      expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
+      expect(persistedWaitMeta["latest_observation"]).toMatchObject({
+        status: "stale",
+        resume_hint: `process session still running: ${currentSessionId}`,
+      });
     });
 
     it("handles WaitStrategy expiry check — calls rebalance when handleWaitStrategyExpiry returns a trigger", async () => {


### PR DESCRIPTION
## Summary
- add focused regression tests for chat runtime helper boundaries
- verify current-turn runtime reply targets override stale fallback targets
- add CoreLoop wait/process session regression coverage for real wait-expiry routing paths

## Testing
- npx vitest run src/interface/chat/__tests__/chat-runner-runtime.test.ts --config vitest.unit.config.ts
- npx vitest run src/orchestrator/loop/__tests__/core-loop-integrations.test.ts --config vitest.unit.config.ts
- npm run typecheck
- npm run lint:boundaries -- --quiet
- npm run build
- npm run test:unit
- npm run test:smoke
- npm run test:integration
