### PR TITLE
[codex] Add workspace artifact metric datasource

### DIFF
--- a/src/adapters/__tests__/artifact-metric-datasource.test.ts
+++ b/src/adapters/__tests__/artifact-metric-datasource.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
+import { makeDimension, makeGoal } from "../../../tests/helpers/fixtures.js";
+import { StateManager } from "../../base/state/state-manager.js";
+import { ObservationEngine } from "../../platform/observation/observation-engine.js";
+import {
+  ArtifactMetricDataSourceAdapter,
+  createWorkspaceArtifactMetricDataSource,
+} from "../datasources/artifact-metric-datasource.js";
+
+describe("ArtifactMetricDataSourceAdapter", () => {
+  let tmpDir: string;
+  let workspace: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    workspace = path.join(tmpDir, "workspace");
+    fs.mkdirSync(workspace, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it("scans nested workspace metrics and selects the best metric value", async () => {
+    writeJson(path.join(workspace, "artifacts", "probe_balanced_default", "metrics.json"), {
+      oof_balanced_accuracy: 0.9623128530945794,
+    });
+    writeJson(path.join(workspace, "artifacts", "probe_sweep", "base_d7_lr007_i700_l26", "metrics.json"), {
+      metrics: { balanced_accuracy: 0.94 },
+    });
+    writeJson(path.join(workspace, "artifacts", "experiments", "older", "metrics.json"), {
+      all_metrics: { balanced_accuracy: 0.91 },
+    });
+    writeJson(path.join(workspace, "data", "raw", "ignored", "metrics.json"), {
+      oof_balanced_accuracy: 0.99,
+    });
+    writeJson(path.join(workspace, ".venv", "ignored", "metrics.json"), {
+      oof_balanced_accuracy: 0.98,
+    });
+
+    const adapter = createWorkspaceArtifactMetricDataSource(workspace);
+    const result = await adapter.query({ dimension_name: "best_oof_balanced_accuracy" });
+
+    expect(result.value).toBe(0.9623128530945794);
+    expect(result.raw).toMatchObject({
+      inspected_metric_files: 3,
+      selected_key: "oof_balanced_accuracy",
+    });
+  });
+
+  it("counts validated metric artifacts when no experiment log exists", async () => {
+    writeJson(path.join(workspace, "artifacts", "probe-a", "metrics.json"), { score: 0.8 });
+    writeJson(path.join(workspace, "artifacts", "probe-b", "metrics.json"), { metrics: { accuracy: 0.7 } });
+    writeJson(path.join(workspace, "artifacts", "broken", "metrics.json"), { notes: "no numeric metrics" });
+
+    const adapter = createWorkspaceArtifactMetricDataSource(workspace);
+    const result = await adapter.query({ dimension_name: "validated_experiment_count" });
+
+    expect(result.value).toBe(2);
+    expect(result.raw).toMatchObject({
+      inspected_metric_files: 3,
+      matched_metric_files: 2,
+    });
+  });
+
+  it("updates CoreLoop-observed goal dimensions through ObservationEngine.observe", async () => {
+    writeJson(path.join(workspace, "artifacts", "probe-balanced", "metrics.json"), {
+      oof_balanced_accuracy: 0.88,
+    });
+    const stateManager = new StateManager(tmpDir);
+    const goal = makeGoal({
+      id: "goal-artifact-metrics",
+      constraints: [`workspace_path:${workspace}`],
+      dimensions: [
+        makeDimension({
+          name: "best_oof_balanced_accuracy",
+          label: "Best OOF balanced accuracy",
+          current_value: 0,
+          threshold: { type: "min", value: 0.95 },
+        }),
+      ],
+    });
+    await stateManager.saveGoal(goal);
+
+    const engine = new ObservationEngine(stateManager, [createWorkspaceArtifactMetricDataSource(workspace)]);
+    await engine.observe("goal-artifact-metrics", []);
+
+    const updated = await stateManager.loadGoal("goal-artifact-metrics");
+    expect(updated?.dimensions[0]?.current_value).toBe(0.88);
+    expect(updated?.dimensions[0]?.last_observed_layer).toBe("mechanical");
+  });
+
+  it("does not claim unrelated best-prefixed dimensions in the CoreLoop observation path", async () => {
+    const stateManager = new StateManager(tmpDir);
+    const goal = makeGoal({
+      id: "goal-non-metric-best",
+      constraints: [`workspace_path:${workspace}`],
+      dimensions: [
+        makeDimension({
+          name: "best_next_action",
+          label: "Best next action",
+          current_value: "investigate",
+          threshold: { type: "present" },
+        }),
+      ],
+    });
+    await stateManager.saveGoal(goal);
+
+    const engine = new ObservationEngine(stateManager, [createWorkspaceArtifactMetricDataSource(workspace)]);
+    await engine.observe("goal-non-metric-best", []);
+
+    const updated = await stateManager.loadGoal("goal-non-metric-best");
+    expect(updated?.dimensions[0]?.current_value).toBe("investigate");
+    expect(updated?.dimensions[0]?.last_observed_layer).toBeUndefined();
+  });
+
+  it("supports explicit metric keys and lower-is-better aggregation", async () => {
+    writeJson(path.join(workspace, "runs", "a", "result.json"), {
+      evidence: [{ kind: "metric", label: "validation_loss", value: 0.42 }],
+    });
+    writeJson(path.join(workspace, "runs", "b", "result.json"), {
+      evidence: [{ kind: "metric", label: "validation_loss", value: 0.31 }],
+    });
+    const adapter = new ArtifactMetricDataSourceAdapter({
+      id: "loss-artifacts",
+      name: "loss artifacts",
+      type: "artifact_metric",
+      connection: {
+        path: workspace,
+        dimension_metrics: { best_validation_loss: ["validation_loss"] },
+        dimension_aggregations: { best_validation_loss: "min" },
+      },
+      enabled: true,
+      created_at: new Date().toISOString(),
+    });
+
+    const result = await adapter.query({ dimension_name: "best_validation_loss" });
+
+    expect(result.value).toBe(0.31);
+    expect(result.raw).toMatchObject({
+      selected_key: "validation_loss",
+    });
+  });
+});
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/src/adapters/datasources/artifact-metric-datasource.ts
+++ b/src/adapters/datasources/artifact-metric-datasource.ts
@@ -1,0 +1,385 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { Dirent } from "node:fs";
+import type {
+  DataSourceConfig,
+  DataSourceQuery,
+  DataSourceResult,
+  DataSourceType,
+} from "../../base/types/data-source.js";
+import type { IDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
+
+type Aggregation = "max" | "min" | "count" | "file_count";
+
+interface MetricObservation {
+  path: string;
+  metrics: Map<string, number>;
+}
+
+const BUILTIN_SOURCE_ID = "ds_builtin_workspace_artifacts";
+const DEFAULT_METRIC_FILE_NAMES = ["metrics.json", "result.json"];
+const DEFAULT_EXCLUDE_DIRS = new Set([
+  ".cache",
+  ".git",
+  ".mypy_cache",
+  ".pytest_cache",
+  ".venv",
+  "__pycache__",
+  "env",
+  "node_modules",
+  "venv",
+]);
+const DEFAULT_EXCLUDE_PATHS = new Set(["data/raw"]);
+const DEFAULT_MAX_METRIC_FILES = 5_000;
+const DEFAULT_MAX_ARTIFACT_FILES = 100_000;
+
+export function createWorkspaceArtifactMetricDataSource(workspacePath = process.cwd()): ArtifactMetricDataSourceAdapter {
+  return new ArtifactMetricDataSourceAdapter({
+    id: BUILTIN_SOURCE_ID,
+    name: "builtin:workspace artifact metrics",
+    type: "artifact_metric",
+    connection: { path: workspacePath },
+    enabled: true,
+    created_at: new Date().toISOString(),
+  });
+}
+
+export class ArtifactMetricDataSourceAdapter implements IDataSourceAdapter {
+  readonly sourceId: string;
+  readonly sourceType: DataSourceType = "artifact_metric";
+  readonly config: DataSourceConfig;
+
+  constructor(config: DataSourceConfig) {
+    this.config = config;
+    this.sourceId = config.id;
+  }
+
+  async connect(): Promise<void> {
+    await fs.access(this.workspaceRoot());
+  }
+
+  async disconnect(): Promise<void> {
+    // no persistent connection
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      await fs.access(this.workspaceRoot());
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  getSupportedDimensions(): string[] {
+    const dimensions = new Set<string>([
+      ...Object.keys(this.config.dimension_mapping ?? {}),
+      ...Object.keys(this.config.connection.dimension_metrics ?? {}),
+      ...Object.keys(this.config.connection.dimension_aggregations ?? {}),
+      "validated_experiment_count",
+      "durable_artifact_count",
+    ]);
+    return Array.from(dimensions).sort();
+  }
+
+  supportsDimension(dimensionName: string): boolean {
+    return this.getSupportedDimensions().includes(dimensionName) || isRecognizedBestMetricDimension(dimensionName);
+  }
+
+  async query(params: DataSourceQuery): Promise<DataSourceResult> {
+    const root = this.workspaceRoot();
+    const expression = this.config.dimension_mapping?.[params.dimension_name] ?? params.expression;
+    const aggregation = resolveAggregation(params.dimension_name, expression, this.config);
+    const timestamp = new Date().toISOString();
+
+    if (aggregation === "file_count") {
+      const count = await countArtifactFiles(root, this.scanOptions());
+      return {
+        value: count,
+        raw: { root, aggregation, file_count: count },
+        timestamp,
+        source_id: this.sourceId,
+      };
+    }
+
+    const metricFiles = await findMetricFiles(root, this.scanOptions());
+    const observations = await readMetricObservations(metricFiles);
+
+    if (aggregation === "count") {
+      const keys = resolveMetricKeys(params.dimension_name, expression, this.config);
+      const count = observations.filter((observation) => hasAnyMetric(observation, keys)).length;
+      return {
+        value: count,
+        raw: {
+          root,
+          aggregation,
+          inspected_metric_files: metricFiles.length,
+          matched_metric_files: count,
+          metric_keys: keys,
+        },
+        timestamp,
+        source_id: this.sourceId,
+      };
+    }
+
+    const keys = resolveMetricKeys(params.dimension_name, expression, this.config);
+    const match = selectMetric(observations, keys, aggregation);
+    return {
+      value: match?.value ?? 0,
+      raw: {
+        root,
+        aggregation,
+        inspected_metric_files: metricFiles.length,
+        metric_keys: keys,
+        selected_path: match?.path ?? null,
+        selected_key: match?.key ?? null,
+        selected_value: match?.value ?? 0,
+      },
+      timestamp,
+      source_id: this.sourceId,
+    };
+  }
+
+  private workspaceRoot(): string {
+    const configuredPath = this.config.connection.path;
+    return configuredPath ? path.resolve(configuredPath) : process.cwd();
+  }
+
+  private scanOptions(): ScanOptions {
+    return {
+      metricFileNames: new Set(this.config.connection.metric_file_names ?? DEFAULT_METRIC_FILE_NAMES),
+      excludeDirs: new Set([...(this.config.connection.exclude_dirs ?? []), ...DEFAULT_EXCLUDE_DIRS]),
+      excludePaths: new Set([
+        ...Array.from(DEFAULT_EXCLUDE_PATHS),
+        ...(this.config.connection.exclude_paths ?? []),
+      ].map(normalizeRelativePath)),
+      maxMetricFiles: this.config.connection.max_metric_files ?? DEFAULT_MAX_METRIC_FILES,
+      maxArtifactFiles: this.config.connection.max_artifact_files ?? DEFAULT_MAX_ARTIFACT_FILES,
+    };
+  }
+}
+
+interface ScanOptions {
+  metricFileNames: Set<string>;
+  excludeDirs: Set<string>;
+  excludePaths: Set<string>;
+  maxMetricFiles: number;
+  maxArtifactFiles: number;
+}
+
+async function findMetricFiles(root: string, options: ScanOptions): Promise<string[]> {
+  const files: string[] = [];
+  await walkFiles(root, options, async (filePath) => {
+    if (options.metricFileNames.has(path.basename(filePath)) && files.length < options.maxMetricFiles) {
+      files.push(filePath);
+    }
+  });
+  return files;
+}
+
+async function countArtifactFiles(root: string, options: ScanOptions): Promise<number> {
+  let count = 0;
+  await walkFiles(root, options, async () => {
+    if (count < options.maxArtifactFiles) count += 1;
+  });
+  return count;
+}
+
+async function walkFiles(root: string, options: ScanOptions, onFile: (filePath: string) => Promise<void>): Promise<void> {
+  async function visit(dir: string): Promise<void> {
+    let entries: Dirent[];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      const relPath = normalizeRelativePath(path.relative(root, fullPath));
+      if (entry.isDirectory()) {
+        if (shouldSkipDirectory(entry.name, relPath, options)) continue;
+        await visit(fullPath);
+      } else if (entry.isFile()) {
+        await onFile(fullPath);
+      }
+    }
+  }
+
+  await visit(root);
+}
+
+function shouldSkipDirectory(name: string, relPath: string, options: ScanOptions): boolean {
+  if (options.excludeDirs.has(name)) return true;
+  for (const excludedPath of options.excludePaths) {
+    if (relPath === excludedPath || relPath.startsWith(`${excludedPath}/`)) return true;
+  }
+  return false;
+}
+
+async function readMetricObservations(files: string[]): Promise<MetricObservation[]> {
+  const observations: MetricObservation[] = [];
+  for (const filePath of files) {
+    try {
+      const parsed = JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+      const metrics = extractNumericMetrics(parsed);
+      if (metrics.size > 0) {
+        observations.push({ path: filePath, metrics });
+      }
+    } catch {
+      // Ignore incomplete or invalid artifacts while the long-running process is writing.
+    }
+  }
+  return observations;
+}
+
+function extractNumericMetrics(value: unknown): Map<string, number> {
+  const metrics = new Map<string, number>();
+  if (!isRecord(value)) return metrics;
+
+  for (const [key, field] of Object.entries(value)) {
+    addNumber(metrics, key, field);
+  }
+
+  const nestedMetrics = value["metrics"];
+  if (isRecord(nestedMetrics)) {
+    for (const [key, field] of Object.entries(nestedMetrics)) {
+      addNumber(metrics, key, field);
+    }
+  }
+
+  const allMetrics = value["all_metrics"];
+  if (isRecord(allMetrics)) {
+    for (const [key, field] of Object.entries(allMetrics)) {
+      addNumber(metrics, key, field);
+    }
+  }
+
+  const metricName = typeof value["metric_name"] === "string" ? value["metric_name"] : null;
+  if (metricName) {
+    addNumber(metrics, metricName, value["score"]);
+    addNumber(metrics, metricName, value["cv_score"]);
+  }
+
+  const evidence = value["evidence"];
+  if (Array.isArray(evidence)) {
+    for (const item of evidence) {
+      if (!isRecord(item)) continue;
+      const label = typeof item["label"] === "string" ? item["label"] : null;
+      if (!label) continue;
+      addNumber(metrics, label, item["value"]);
+    }
+  }
+
+  return metrics;
+}
+
+function addNumber(metrics: Map<string, number>, key: string, value: unknown): void {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    metrics.set(key, value);
+  }
+}
+
+function hasAnyMetric(observation: MetricObservation, keys: string[]): boolean {
+  if (keys.length === 0) return observation.metrics.size > 0;
+  return keys.some((key) => observation.metrics.has(key));
+}
+
+function selectMetric(
+  observations: MetricObservation[],
+  keys: string[],
+  aggregation: "max" | "min",
+): { path: string; key: string; value: number } | null {
+  let selected: { path: string; key: string; value: number } | null = null;
+  for (const observation of observations) {
+    for (const key of keys) {
+      const value = observation.metrics.get(key);
+      if (value === undefined) continue;
+      if (
+        selected === null ||
+        (aggregation === "max" && value > selected.value) ||
+        (aggregation === "min" && value < selected.value)
+      ) {
+        selected = { path: observation.path, key, value };
+      }
+    }
+  }
+  return selected;
+}
+
+function resolveAggregation(dimensionName: string, expression: string | undefined, config: DataSourceConfig): Aggregation {
+  const configured = config.connection.dimension_aggregations?.[dimensionName];
+  if (configured) return configured;
+  if (expression?.startsWith("min:")) return "min";
+  if (expression?.startsWith("max:")) return "max";
+  if (expression?.startsWith("count:") || expression === "count_valid_metrics") return "count";
+  if (expression === "file_count") return "file_count";
+  if (dimensionName === "durable_artifact_count") return "file_count";
+  if (dimensionName.endsWith("_count")) return "count";
+  return prefersLowerMetric(dimensionName) ? "min" : "max";
+}
+
+function resolveMetricKeys(dimensionName: string, expression: string | undefined, config: DataSourceConfig): string[] {
+  const configured = config.connection.dimension_metrics?.[dimensionName];
+  if (configured && configured.length > 0) return unique(configured);
+
+  if (expression) {
+    const [, rest] = /^(?:min|max|count):(.*)$/.exec(expression) ?? [];
+    const raw = rest ?? (expression === "count_valid_metrics" || expression === "file_count" ? "" : expression);
+    const keys = raw.split(",").map((item) => item.trim()).filter(Boolean);
+    if (keys.length > 0) return unique(keys);
+  }
+
+  if (dimensionName.endsWith("_count")) return [];
+
+  return deriveMetricKeys(dimensionName);
+}
+
+function deriveMetricKeys(dimensionName: string): string[] {
+  const keys = new Set<string>([dimensionName]);
+  const withoutBest = dimensionName.startsWith("best_") ? dimensionName.slice("best_".length) : dimensionName;
+  keys.add(withoutBest);
+
+  for (const prefix of ["oof_", "cv_", "mean_", "best_"]) {
+    if (withoutBest.startsWith(prefix)) {
+      keys.add(withoutBest.slice(prefix.length));
+    }
+  }
+
+  if (withoutBest.includes("balanced_accuracy")) {
+    keys.add("balanced_accuracy");
+    keys.add("oof_balanced_accuracy");
+    keys.add("cv_balanced_accuracy");
+  }
+  if (withoutBest.includes("accuracy")) {
+    keys.add("accuracy");
+    keys.add("oof_accuracy");
+    keys.add("cv_accuracy");
+  }
+  if (withoutBest.includes("score")) {
+    keys.add("score");
+    keys.add("cv_score");
+  }
+
+  return unique(Array.from(keys));
+}
+
+function isRecognizedBestMetricDimension(dimensionName: string): boolean {
+  return dimensionName.startsWith("best_") && deriveMetricKeys(dimensionName).length > 2;
+}
+
+function prefersLowerMetric(dimensionName: string): boolean {
+  return /loss|error|rmse|mae|mse/i.test(dimensionName);
+}
+
+function normalizeRelativePath(value: string): string {
+  return value.split(path.sep).join("/").replace(/^\.\//, "");
+}
+
+function unique(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,10 @@ export { NativeAgentLoopAdapter } from "./adapters/agents/native-agent-loop.js";
 export { GitHubIssueAdapter } from "./adapters/github-issue.js";
 export type { GitHubIssueAdapterConfig } from "./adapters/github-issue.js";
 export { GitHubIssueDataSourceAdapter } from "./adapters/datasources/github-issue-datasource.js";
+export {
+  ArtifactMetricDataSourceAdapter,
+  createWorkspaceArtifactMetricDataSource,
+} from "./adapters/datasources/artifact-metric-datasource.js";
 export { buildLLMClient, buildAdapterRegistry } from "./base/llm/provider-factory.js";
 export { CodexLLMClient } from "./base/llm/codex-llm-client.js";
 export type { CodexLLMClientConfig } from "./base/llm/codex-llm-client.js";

--- a/src/interface/cli/__tests__/datasource-command.test.ts
+++ b/src/interface/cli/__tests__/datasource-command.test.ts
@@ -7,6 +7,8 @@ import { getDatasourcesDir } from "../../../base/utils/paths.js";
 import { cmdDatasourceAdd } from "../commands/config.js";
 import { createCliDataSourceAdapter } from "../setup.js";
 import { PostgresDataSourceAdapter } from "../../../platform/observation/data-source-adapter.js";
+import { ArtifactMetricDataSourceAdapter } from "../../../adapters/datasources/artifact-metric-datasource.js";
+import { buildCliDataSourceRegistry } from "../data-source-bootstrap.js";
 
 describe("cmdDatasourceAdd(database)", () => {
   let tmpDir: string;
@@ -93,5 +95,35 @@ describe("createCliDataSourceAdapter", () => {
     });
 
     expect(adapter).toBeInstanceOf(PostgresDataSourceAdapter);
+  });
+
+  it("maps artifact_metric datasources to ArtifactMetricDataSourceAdapter", () => {
+    const adapter = createCliDataSourceAdapter({
+      id: "artifact-source",
+      name: "Workspace Artifacts",
+      type: "artifact_metric",
+      connection: { path: process.cwd() },
+      enabled: true,
+      created_at: new Date().toISOString(),
+    });
+
+    expect(adapter).toBeInstanceOf(ArtifactMetricDataSourceAdapter);
+  });
+
+  it("adds the builtin workspace artifact datasource even without saved configs", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-datasource-bootstrap-"));
+    const originalHome = process.env["PULSEED_HOME"];
+    process.env["PULSEED_HOME"] = tmpDir;
+    try {
+      const registry = await buildCliDataSourceRegistry(tmpDir);
+      expect(registry.listSources()).toContain("ds_builtin_workspace_artifacts");
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env["PULSEED_HOME"];
+      } else {
+        process.env["PULSEED_HOME"] = originalHome;
+      }
+      fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
   });
 });

--- a/src/interface/cli/data-source-bootstrap.ts
+++ b/src/interface/cli/data-source-bootstrap.ts
@@ -3,6 +3,11 @@ import * as path from "node:path";
 import { GitHubIssueDataSourceAdapter } from "../../adapters/datasources/github-issue-datasource.js";
 import { FileExistenceDataSourceAdapter } from "../../adapters/datasources/file-existence-datasource.js";
 import { ShellDataSourceAdapter } from "../../adapters/datasources/shell-datasource.js";
+import {
+  ArtifactMetricDataSourceAdapter,
+  createWorkspaceArtifactMetricDataSource,
+} from "../../adapters/datasources/artifact-metric-datasource.js";
+import type { ShellCommandSpec } from "../../adapters/datasources/shell-datasource.js";
 import type { DataSourceConfig } from "../../base/types/data-source.js";
 import { readJsonFile } from "../../base/utils/json-io.js";
 import { getDatasourcesDir } from "../../base/utils/paths.js";
@@ -46,13 +51,22 @@ export function createCliDataSourceAdapter(
   if (cfg.type === "shell") {
     const adapter = new ShellDataSourceAdapter(
       cfg.id,
-      (cfg.connection.commands ?? {}) as Record<string, import("../../adapters/datasources/shell-datasource.js").ShellCommandSpec>,
+      (cfg.connection.commands ?? {}) as Record<string, ShellCommandSpec>,
       cfg.connection?.path ?? workspacePath
     );
     if (cfg.scope_goal_id) {
       (adapter.config as Record<string, unknown>).scope_goal_id = cfg.scope_goal_id;
     }
     return adapter;
+  }
+  if (cfg.type === "artifact_metric") {
+    return new ArtifactMetricDataSourceAdapter({
+      ...cfg,
+      connection: {
+        ...cfg.connection,
+        path: cfg.connection.path ?? workspacePath,
+      },
+    });
   }
 
   return null;
@@ -68,22 +82,25 @@ export async function buildCliDataSourceRegistry(
   try {
     let dsExists = false;
     try { await fsp.access(dsDir); dsExists = true; } catch { /* not found */ }
-    if (!dsExists) {
-      return registry;
-    }
-
-    const files = (await fsp.readdir(dsDir)).filter(f => f.endsWith(".json"));
-    for (const file of files) {
-      const cfg = await readJsonFile<DataSourceConfig>(path.join(dsDir, file));
-      const adapter = createCliDataSourceAdapter(cfg, workspacePath);
-      if (adapter) {
-        registry.register(adapter);
-      } else {
-        logger.warn(`[pulseed] Unsupported built-in datasource type "${cfg.type}" in ${file}; skipping`);
+    if (dsExists) {
+      const files = (await fsp.readdir(dsDir)).filter(f => f.endsWith(".json"));
+      for (const file of files) {
+        const cfg = await readJsonFile<DataSourceConfig>(path.join(dsDir, file));
+        const adapter = createCliDataSourceAdapter(cfg, workspacePath);
+        if (adapter) {
+          registry.register(adapter);
+        } else {
+          logger.warn(`[pulseed] Unsupported built-in datasource type "${cfg.type}" in ${file}; skipping`);
+        }
       }
     }
   } catch (err) {
     logger.error(`[pulseed] Failed to load datasource configurations from "${dsDir}": ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  const workspaceArtifacts = createWorkspaceArtifactMetricDataSource(workspacePath);
+  if (!registry.has(workspaceArtifacts.sourceId)) {
+    registry.register(workspaceArtifacts);
   }
 
   return registry;

--- a/src/platform/observation/data-source-adapter.ts
+++ b/src/platform/observation/data-source-adapter.ts
@@ -39,6 +39,7 @@ export interface IDataSourceAdapter {
   disconnect(): Promise<void>;
   healthCheck(): Promise<boolean>;
   getSupportedDimensions?(): string[];
+  supportsDimension?(dimensionName: string, goalId?: string): boolean;
 }
 
 // ─── FileDataSourceAdapter ───

--- a/src/platform/observation/observation-datasource.ts
+++ b/src/platform/observation/observation-datasource.ts
@@ -15,6 +15,7 @@ export function findDataSourceForDimension(
   goalId?: string
 ): IDataSourceAdapter | null {
   const matches = (ds: IDataSourceAdapter): boolean => {
+    if (ds.supportsDimension?.(dimensionName, goalId)) return true;
     const dims = ds.getSupportedDimensions?.() ?? [];
     if (dims.includes(dimensionName)) return true;
     if (ds.config?.dimension_mapping && dimensionName in ds.config.dimension_mapping) return true;

--- a/src/platform/observation/types/data-source.ts
+++ b/src/platform/observation/types/data-source.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 // --- DataSourceType ---
 
-export const DataSourceTypeEnum = z.enum(["file", "http_api", "database", "custom", "github_issue", "file_existence", "shell", "websocket", "sse", "mcp"]);
+export const DataSourceTypeEnum = z.enum(["file", "http_api", "database", "custom", "github_issue", "file_existence", "shell", "artifact_metric", "websocket", "sse", "mcp"]);
 export type DataSourceType = z.infer<typeof DataSourceTypeEnum>;
 
 // --- PollingConfig ---
@@ -27,6 +27,13 @@ export const DataSourceConfigSchema = z.object({
     headers: z.record(z.string(), z.string()).optional(),
     body_template: z.string().optional(),
     commands: z.record(z.string(), z.unknown()).optional(),
+    metric_file_names: z.array(z.string()).optional(),
+    exclude_dirs: z.array(z.string()).optional(),
+    exclude_paths: z.array(z.string()).optional(),
+    max_metric_files: z.number().int().positive().optional(),
+    max_artifact_files: z.number().int().positive().optional(),
+    dimension_metrics: z.record(z.string(), z.array(z.string())).optional(),
+    dimension_aggregations: z.record(z.string(), z.enum(["max", "min", "count", "file_count"])).optional(),
   }),
   polling: PollingConfigSchema.optional(),
   auth: z


### PR DESCRIPTION
## Summary
- add a generic artifact_metric datasource for CoreLoop observation of workspace metrics/result artifacts
- register a builtin workspace artifact datasource in CLI/CoreLoop dependency bootstrap
- cover nested metrics, validated artifact counts, explicit metric mappings, and non-metric best_* fallback behavior

Fixes #790

## Validation
- npx vitest run src/adapters/__tests__/artifact-metric-datasource.test.ts src/interface/cli/__tests__/datasource-command.test.ts
- npm run build
- npm run test:changed
- npm run lint:boundaries (0 errors; existing warnings remain)

## Review
- independent review found an overbroad best_* matcher; fixed by recognizing only metric-like best_* dimensions and adding a caller-path regression test
