### PR TITLE
test(kaggle): fix workspace prepare typecheck

### DIFF
--- a/src/tools/kaggle/__tests__/KaggleWorkspacePrepareTool.test.ts
+++ b/src/tools/kaggle/__tests__/KaggleWorkspacePrepareTool.test.ts
@@ -42,6 +42,7 @@ describe("KaggleWorkspacePrepareTool", () => {
       competition: "titanic",
       metric_name: "accuracy",
       metric_direction: "maximize",
+      overwrite_existing: false,
       target_column: "Survived",
       submission_format_hint: "PassengerId,Survived",
       notes: "baseline",
@@ -101,6 +102,7 @@ describe("KaggleWorkspacePrepareTool", () => {
       competition: "titanic",
       metric_name: "rmse",
       metric_direction: "minimize",
+      overwrite_existing: false,
     }, makeContext());
 
     expect(result.success).toBe(false);
@@ -115,6 +117,7 @@ describe("KaggleWorkspacePrepareTool", () => {
       competition: "titanic",
       metric_name: "rmse",
       metric_direction: "minimize",
+      overwrite_existing: false,
     }, makeContext());
 
     expect(result.success).toBe(true);
@@ -129,12 +132,14 @@ describe("KaggleWorkspacePrepareTool", () => {
       competition: "titanic",
       metric_name: "rmse",
       metric_direction: "minimize",
+      overwrite_existing: false,
     }, makeContext());
     const absolute = await tool.call({
       workspace: path.join(pulseedHome, "kaggle-runs"),
       competition: "titanic",
       metric_name: "rmse",
       metric_direction: "minimize",
+      overwrite_existing: false,
     }, makeContext());
 
     expect(stateRelative.success).toBe(true);
@@ -192,6 +197,7 @@ describe("KaggleWorkspacePrepareTool", () => {
       competition: "titanic",
       metric_name: "rmse",
       metric_direction: "minimize",
+      overwrite_existing: false,
     }, makeContext());
 
     expect(result.success).toBe(false);
@@ -210,6 +216,7 @@ describe("KaggleWorkspacePrepareTool", () => {
       competition: "titanic",
       metric_name: "rmse",
       metric_direction: "minimize",
+      overwrite_existing: false,
     }, makeContext());
 
     expect(result.success).toBe(false);
@@ -232,6 +239,7 @@ describe("KaggleWorkspacePrepareTool", () => {
       competition: "titanic",
       metric_name: "rmse",
       metric_direction: "minimize",
+      overwrite_existing: false,
     }, makeContext());
 
     expect(result.success).toBe(false);


### PR DESCRIPTION
## Summary

- Adds explicit `overwrite_existing: false` to direct `KaggleWorkspacePrepareTool.call()` unit-test inputs.
- Keeps runtime behavior unchanged while matching the validated schema output type expected by `call()`.
- Restores full `npm run typecheck` after #801.

## Verification

- `npx vitest run --config vitest.unit.config.ts src/tools/kaggle/__tests__/KaggleWorkspacePrepareTool.test.ts`
- `npm run typecheck`
- `npm run test:changed`
- `npm run build`

## Review

Separate review agent found no material findings.
