### PR TITLE
[codex] Add runtime evidence ledger

### DIFF
--- a/src/base/types/goal-activation.ts
+++ b/src/base/types/goal-activation.ts
@@ -10,6 +10,14 @@ export const WaitResumeActivationSchema = z.object({
 
 export type WaitResumeActivation = z.infer<typeof WaitResumeActivationSchema>;
 
+export const BackgroundRunActivationSchema = z.object({
+  backgroundRunId: z.string(),
+  parentSessionId: z.string().nullable().optional(),
+});
+
+export type BackgroundRunActivation = z.infer<typeof BackgroundRunActivationSchema>;
+
 export interface GoalRunActivationContext {
   waitResume?: WaitResumeActivation;
+  backgroundRun?: BackgroundRunActivation;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,6 +173,26 @@ export type {
 } from "./runtime/control/index.js";
 export { RuntimeOperationStore } from "./runtime/store/runtime-operation-store.js";
 export {
+  RuntimeEvidenceArtifactRefSchema,
+  RuntimeEvidenceEntryKindSchema,
+  RuntimeEvidenceEntrySchema,
+  RuntimeEvidenceLedger,
+  RuntimeEvidenceMetricSchema,
+  RuntimeEvidenceOutcomeSchema,
+} from "./runtime/store/evidence-ledger.js";
+export type {
+  RuntimeEvidenceArtifactRef,
+  RuntimeEvidenceEntry,
+  RuntimeEvidenceEntryInput,
+  RuntimeEvidenceEntryKind,
+  RuntimeEvidenceLedgerPort,
+  RuntimeEvidenceMetric,
+  RuntimeEvidenceOutcome,
+  RuntimeEvidenceReadResult,
+  RuntimeEvidenceReadWarning,
+  RuntimeEvidenceSummary,
+} from "./runtime/store/evidence-ledger.js";
+export {
   RuntimeControlActorSchema,
   RuntimeControlOperationKindSchema,
   RuntimeControlOperationSchema,

--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -9,6 +9,7 @@ import { dispatchCommand } from "../cli-command-registry.js";
 import { CLIRunner } from "../cli-runner.js";
 import type { CoreLoop } from "../../../orchestrator/loop/core-loop.js";
 import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
+import { RuntimeEvidenceLedger } from "../../../runtime/store/evidence-ledger.js";
 
 describe("runtime registry CLI commands", () => {
   let tmpDir: string;
@@ -153,6 +154,58 @@ describe("runtime registry CLI commands", () => {
 
     expect(code).toBe(1);
     expect(errors).toContain("Runtime run not found: run:process:missing");
+  });
+
+  it("summarizes runtime evidence for a goal as text and JSON", async () => {
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      kind: "strategy",
+      scope: { goal_id: "goal-evidence", loop_index: 0 },
+      summary: "Continue with the narrowed implementation path.",
+      outcome: "continued",
+    });
+    await ledger.append({
+      kind: "verification",
+      scope: { goal_id: "goal-evidence", task_id: "task-evidence", loop_index: 0 },
+      verification: { verdict: "pass", confidence: 0.95, summary: "focused test passed" },
+      summary: "Focused test passed.",
+      outcome: "improved",
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const textCode = await runCLI("runtime", "evidence", "goal-evidence");
+    const textOutput = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(textCode).toBe(0);
+    expect(textOutput).toContain("Runtime evidence: goal goal-evidence");
+    expect(textOutput).toContain("Best evidence:");
+
+    logSpy.mockClear();
+    const jsonCode = await runCLI("runtime", "evidence", "goal-evidence", "--json");
+    const jsonOutput = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(jsonOutput) as { total_entries: number; best_evidence: { kind: string } };
+    expect(jsonCode).toBe(0);
+    expect(parsed.total_entries).toBe(2);
+    expect(parsed.best_evidence.kind).toBe("verification");
+  });
+
+  it("summarizes run-scoped evidence for non-prefixed long-running run IDs", async () => {
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      kind: "artifact",
+      scope: { run_id: "dummy-runtime-run" },
+      summary: "Long-running report written.",
+      artifacts: [{ label: "summary.md", path: "/tmp/summary.md", kind: "report" }],
+      outcome: "improved",
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("runtime", "evidence", "dummy-runtime-run", "--json");
+    const output = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(output) as { scope: { run_id?: string }; total_entries: number };
+
+    expect(code).toBe(0);
+    expect(parsed.scope.run_id).toBe("dummy-runtime-run");
+    expect(parsed.total_entries).toBe(1);
   });
 
   async function writeConversationWithRunningAgent(): Promise<void> {

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -1,9 +1,11 @@
 // ─── pulseed runtime commands (read-only) ───
 
 import { parseArgs } from "node:util";
+import * as path from "node:path";
 
 import { StateManager } from "../../../base/state/state-manager.js";
 import { createRuntimeSessionRegistry } from "../../../runtime/session-registry/index.js";
+import { RuntimeEvidenceLedger, type RuntimeEvidenceEntry, type RuntimeEvidenceSummary } from "../../../runtime/store/evidence-ledger.js";
 import type {
   BackgroundRun,
   RuntimeSession,
@@ -197,7 +199,7 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
   const runtimeSubcommand = args[0];
 
   if (!runtimeSubcommand) {
-    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>");
+    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime evidence <goal-id|run-id>");
     return 1;
   }
 
@@ -267,7 +269,59 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
     return 0;
   }
 
+  if (runtimeSubcommand === "evidence") {
+    const values = parseDetailArgs(args.slice(1), "evidence");
+    if (!values.id) {
+      logger.error("Error: goal ID or run ID is required. Usage: pulseed runtime evidence <goal-id|run-id> [--json]");
+      return 1;
+    }
+    const ledger = new RuntimeEvidenceLedger(path.join(stateManager.getBaseDir(), "runtime"));
+    const summary = await summarizeEvidenceTarget(ledger, values.id);
+    values.json ? printJson(summary) : printEvidenceSummary(summary);
+    return 0;
+  }
+
   logger.error(`Unknown runtime subcommand: "${runtimeSubcommand}"`);
-  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>");
+  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime evidence <goal-id|run-id>");
   return 1;
+}
+
+async function summarizeEvidenceTarget(ledger: RuntimeEvidenceLedger, id: string): Promise<RuntimeEvidenceSummary> {
+  if (id.startsWith("run:")) {
+    return ledger.summarizeRun(id);
+  }
+  const goalSummary = await ledger.summarizeGoal(id);
+  if (goalSummary.total_entries > 0) {
+    return goalSummary;
+  }
+  const runSummary = await ledger.summarizeRun(id);
+  return runSummary.total_entries > 0 ? runSummary : goalSummary;
+}
+
+function printEvidenceSummary(summary: RuntimeEvidenceSummary): void {
+  const target = summary.scope.run_id
+    ? `run ${summary.scope.run_id}`
+    : `goal ${summary.scope.goal_id ?? "-"}`;
+  console.log(`Runtime evidence: ${target}`);
+  console.log(`  Entries:         ${summary.total_entries}`);
+  console.log(`  Latest strategy: ${entryLabel(summary.latest_strategy)}`);
+  console.log(`  Best evidence:   ${entryLabel(summary.best_evidence)}`);
+  if (summary.recent_failed_attempts.length > 0) {
+    console.log("  Recent failures:");
+    for (const entry of summary.recent_failed_attempts) {
+      console.log(`    - ${entryLabel(entry)}`);
+    }
+  } else {
+    console.log("  Recent failures: -");
+  }
+  if (summary.warnings.length > 0) {
+    console.log(`  Warnings:        ${summary.warnings.length}`);
+  }
+}
+
+function entryLabel(entry: RuntimeEvidenceEntry | null): string {
+  if (!entry) return "-";
+  const status = entry.outcome ?? entry.result?.status ?? entry.verification?.verdict ?? entry.kind;
+  const summary = entry.summary ?? entry.result?.summary ?? entry.decision_reason ?? entry.task?.description ?? "-";
+  return `${entry.occurred_at} ${entry.kind}/${status}: ${formatCell(summary, 96)}`;
 }

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -28,6 +28,7 @@ import { TaskLifecycle } from "../../orchestrator/execution/task/task-lifecycle.
 import { ReportingEngine } from "../../reporting/reporting-engine.js";
 import { CoreLoop } from "../../orchestrator/loop/core-loop.js";
 import { ScheduleEngine } from "../../runtime/schedule/engine.js";
+import { RuntimeEvidenceLedger } from "../../runtime/store/evidence-ledger.js";
 import { TreeLoopOrchestrator } from "../../orchestrator/goal/tree-loop-orchestrator.js";
 import { GoalTreeManager } from "../../orchestrator/goal/goal-tree-manager.js";
 import { StateAggregator } from "../../orchestrator/goal/state-aggregator.js";
@@ -79,6 +80,7 @@ export async function buildDeps(
   const driveSystem = new DriveSystem(stateManager);
   const adapterRegistry = await buildAdapterRegistry(llmClient);
   const toolRegistry = new ToolRegistry();
+  const evidenceLedger = new RuntimeEvidenceLedger(path.join(stateManager.getBaseDir(), "runtime"));
   const registerBuiltinTools = (deps?: Parameters<typeof createBuiltinTools>[0]) => {
     for (const tool of createBuiltinTools(deps)) {
       const existing = toolRegistry.get(tool.metadata.name);
@@ -402,6 +404,7 @@ export async function buildDeps(
     toolExecutor,
     toolRegistry,
     corePhaseRunner,
+    evidenceLedger,
   }, config);
 
   coreLoop.setTimeHorizonEngine(new TimeHorizonEngine());

--- a/src/interface/tui/entry-deps.ts
+++ b/src/interface/tui/entry-deps.ts
@@ -31,6 +31,7 @@ export async function buildStandaloneTuiDeps() {
   const { GoalDependencyGraph } = await import("../../orchestrator/goal/goal-dependency-graph.js");
   const { TreeLoopOrchestrator } = await import("../../orchestrator/goal/tree-loop-orchestrator.js");
   const { ScheduleEngine } = await import("../../runtime/schedule/engine.js");
+  const { RuntimeEvidenceLedger } = await import("../../runtime/store/evidence-ledger.js");
   const { MemoryLifecycleManager, DriveScoreAdapter } = await import("../../platform/knowledge/memory/memory-lifecycle.js");
   const { KnowledgeManager } = await import("../../platform/knowledge/knowledge-manager.js");
   const { CharacterConfigManager } = await import("../../platform/traits/character-config.js");
@@ -58,6 +59,7 @@ export async function buildStandaloneTuiDeps() {
   const driveSystem = new DriveSystem(stateManager);
   const dataSourceRegistry = await buildCliDataSourceRegistry(process.cwd(), getCliLogger());
   const toolRegistry = new ToolRegistry();
+  const evidenceLedger = new RuntimeEvidenceLedger(path.join(stateManager.getBaseDir(), "runtime"));
   const registerToolIfMissing = (tool: ReturnType<typeof createBuiltinTools>[number]) => {
     if (!toolRegistry.get(tool.metadata.name)) {
       toolRegistry.register(tool);
@@ -249,6 +251,7 @@ export async function buildStandaloneTuiDeps() {
     driveScoreAdapter,
     contextProvider,
     corePhaseRunner,
+    evidenceLedger,
   });
 
   const scheduleEngine = new ScheduleEngine({

--- a/src/orchestrator/loop/__tests__/core-loop-agentic-phases.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-agentic-phases.test.ts
@@ -310,6 +310,8 @@ describe("CoreLoop agentic phase hooks", () => {
 
   it("feeds observe and replanning summaries into task cycle context and records phase results", async () => {
     const { deps, mocks } = createDeps(tmpDir);
+    const evidenceLedger = { append: vi.fn().mockResolvedValue([]) };
+    deps.evidenceLedger = evidenceLedger;
     await mocks.stateManager.saveGoal(makeGoal());
 
     const loop = new CoreLoop(deps, { delayBetweenLoopsMs: 0 });
@@ -327,6 +329,20 @@ describe("CoreLoop agentic phase hooks", () => {
     expect(taskCycleArgs[6]).toContain("observe-summary");
     expect(taskCycleArgs[7]).toEqual(expect.objectContaining({ targetDimensionOverride: "dim1" }));
     expect(taskCycleArgs[7]?.knowledgeContextPrefix).toContain("Replanning directive:");
+    expect(evidenceLedger.append).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "task_generation",
+      scope: expect.objectContaining({ goal_id: "goal-1", task_id: "task-1", loop_index: 0 }),
+    }));
+    expect(evidenceLedger.append).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "execution",
+      outcome: "improved",
+      scope: expect.objectContaining({ goal_id: "goal-1", task_id: "task-1", loop_index: 0 }),
+    }));
+    expect(evidenceLedger.append).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "verification",
+      outcome: "improved",
+      scope: expect.objectContaining({ goal_id: "goal-1", task_id: "task-1", loop_index: 0 }),
+    }));
   });
 
   it("runs stall investigation when stall is detected", async () => {

--- a/src/orchestrator/loop/core-loop/contracts.ts
+++ b/src/orchestrator/loop/core-loop/contracts.ts
@@ -34,6 +34,7 @@ import type { CorePhaseRunner } from "../../execution/agent-loop/core-phase-runn
 import type { CorePhasePolicyRegistry } from "./phase-policy.js";
 import type { CoreDecisionEngine } from "./decision-engine.js";
 import type { GoalRunActivationContext } from "../../../base/types/goal-activation.js";
+import type { RuntimeEvidenceLedgerPort } from "../../../runtime/store/evidence-ledger.js";
 export type {
   LoopIterationResult,
   LoopResult,
@@ -278,6 +279,8 @@ export interface CoreLoopDeps extends ObservationDeps, TreeDeps, StallDeps, Task
   toolExecutor?: ToolExecutor;
   /** Optional ToolRegistry for context-aware tool assembly. */
   toolRegistry?: ToolRegistry;
+  /** Optional durable evidence ledger for long-running autonomous work review/resume. */
+  evidenceLedger?: RuntimeEvidenceLedgerPort;
   /** Optional bounded agentloop runner for core phases. */
   corePhaseRunner?: CorePhaseRunner;
   /** Optional live approval broker for wait/resume approvals. */

--- a/src/orchestrator/loop/core-loop/iteration-kernel.ts
+++ b/src/orchestrator/loop/core-loop/iteration-kernel.ts
@@ -47,6 +47,12 @@ import {
   autoAcquireKnowledgeForRefresh,
 } from "./iteration-kernel-knowledge.js";
 import type { GoalRunActivationContext } from "../../../base/types/goal-activation.js";
+import type {
+  RuntimeEvidenceEntryInput,
+  RuntimeEvidenceEntryKind,
+  RuntimeEvidenceOutcome,
+} from "../../../runtime/store/evidence-ledger.js";
+import type { TaskCycleResult } from "../../execution/task/task-execution-types.js";
 
 export interface CoreIterationKernelDeps {
   deps: CoreLoopDeps;
@@ -111,6 +117,32 @@ export class CoreIterationKernel {
     const result: LoopIterationResult = makeEmptyIterationResult(goalId, loopIndex);
     const activationContext = this.deps.getActivationContext();
     const evidenceLedger = new CoreLoopEvidenceLedger();
+    const runtimeEvidenceScope = {
+      goal_id: goalId,
+      ...(activationContext?.backgroundRun?.backgroundRunId
+        ? { run_id: activationContext.backgroundRun.backgroundRunId }
+        : {}),
+      loop_index: loopIndex,
+    };
+    const appendRuntimeEvidence = async (entry: Omit<RuntimeEvidenceEntryInput, "scope"> & { scope?: RuntimeEvidenceEntryInput["scope"] }) => {
+      if (config.dryRun || !this.deps.deps.evidenceLedger) return;
+      try {
+        await this.deps.deps.evidenceLedger.append({
+          ...entry,
+          scope: {
+            ...runtimeEvidenceScope,
+            ...entry.scope,
+          },
+        });
+      } catch (err) {
+        this.deps.logger?.warn("CoreLoop: failed to append runtime evidence ledger entry", {
+          goalId,
+          loopIndex,
+          kind: entry.kind,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    };
     const corePhaseRuntime = new CorePhaseRuntime({
       phaseRunner: this.deps.deps.corePhaseRunner,
       policyRegistry: this.deps.corePhasePolicyRegistry,
@@ -184,6 +216,7 @@ export class CoreIterationKernel {
       )
     );
     rememberPhase(observeEvidence);
+    await appendPhaseEvidence(appendRuntimeEvidence, observeEvidence, "observation");
 
     goal = await runPhase("observe", () => observeAndReload(ctx, goalId, goal, loopIndex));
 
@@ -235,6 +268,7 @@ export class CoreIterationKernel {
         )
       );
       rememberPhase(waitObservationPhase);
+      await appendPhaseEvidence(appendRuntimeEvidence, waitObservationPhase, "observation");
     }
 
     const waitObservationDecision = await runPhase("wait-observation", () =>
@@ -304,6 +338,7 @@ export class CoreIterationKernel {
         )
       : null;
     if (knowledgeRefresh) rememberPhase(knowledgeRefresh);
+    if (knowledgeRefresh) await appendPhaseEvidence(appendRuntimeEvidence, knowledgeRefresh, "strategy");
 
     const replanningOptions = this.deps.coreDecisionEngine.shouldRunReplanningOptions({
       skipTaskGeneration: Boolean(skipTaskGeneration),
@@ -328,6 +363,7 @@ export class CoreIterationKernel {
         )
       : null;
     if (replanningOptions) rememberPhase(replanningOptions);
+    if (replanningOptions) await appendPhaseEvidence(appendRuntimeEvidence, replanningOptions, "strategy");
 
     await runPhase("completion-check", () =>
       checkCompletionAndMilestones(ctx, goalId, goal, result, startTime)
@@ -370,6 +406,7 @@ export class CoreIterationKernel {
         )
       : null;
     if (stallInvestigation) rememberPhase(stallInvestigation);
+    if (stallInvestigation) await appendPhaseEvidence(appendRuntimeEvidence, stallInvestigation, "failure");
 
     if (result.stallDetected && result.stallReport) {
       this.deps.logger?.warn(`[iter ${loopIndex}] stall detected: ${result.stallReport.stall_type}`, {
@@ -412,6 +449,7 @@ export class CoreIterationKernel {
             goalDimensions: goal.dimensions.map((dimension) => dimension.name),
             fallbackFocusDimension: driveScores[0]?.dimension_name ?? pendingDirective?.focusDimension,
           });
+          await appendDecisionEvidence(appendRuntimeEvidence, result.nextIterationDirective, "knowledge_refresh_auto_acquire");
           this.deps.logger?.info("CoreLoop: knowledge_refresh auto-acquired knowledge and skipped execution", {
             goalId,
             acquiredCount,
@@ -465,6 +503,7 @@ export class CoreIterationKernel {
         goalDimensions: goal.dimensions.map((dimension) => dimension.name),
         fallbackFocusDimension: driveScores[0]?.dimension_name ?? pendingDirective?.focusDimension,
       });
+      await appendDecisionEvidence(appendRuntimeEvidence, result.nextIterationDirective, "skip_task_generation");
       await generateLoopReport(goalId, loopIndex, result, goal, this.deps.deps.reportingEngine, this.deps.logger);
       result.elapsedMs = Date.now() - startTime;
       return result;
@@ -532,6 +571,9 @@ export class CoreIterationKernel {
     if (!taskCycleOk) return result;
 
     const completedTaskResult = result.taskResult;
+    if (completedTaskResult) {
+      await appendTaskCycleEvidence(appendRuntimeEvidence, completedTaskResult);
+    }
     if (this.deps.coreDecisionEngine.shouldRunVerificationEvidence(result) && completedTaskResult) {
       const verificationPhase = await runPhase("verification-evidence", () =>
         corePhaseRuntime.run(
@@ -553,6 +595,9 @@ export class CoreIterationKernel {
         )
       );
       rememberPhase(verificationPhase);
+      await appendPhaseEvidence(appendRuntimeEvidence, verificationPhase, "verification", {
+        task_id: completedTaskResult.task.id,
+      });
     }
 
     result.nextIterationDirective = this.deps.coreDecisionEngine.buildNextIterationDirective({
@@ -561,10 +606,152 @@ export class CoreIterationKernel {
       goalDimensions: goal.dimensions.map((dimension) => dimension.name),
       fallbackFocusDimension: driveScores[0]?.dimension_name ?? pendingDirective?.focusDimension,
     });
+    await appendDecisionEvidence(appendRuntimeEvidence, result.nextIterationDirective, "next_iteration_directive");
 
     await generateLoopReport(goalId, loopIndex, result, goal, this.deps.deps.reportingEngine, this.deps.logger);
 
     result.elapsedMs = Date.now() - startTime;
     return result;
   }
+}
+
+async function appendPhaseEvidence(
+  appendRuntimeEvidence: (entry: Omit<RuntimeEvidenceEntryInput, "scope"> & { scope?: RuntimeEvidenceEntryInput["scope"] }) => Promise<void>,
+  execution: {
+    phase: CorePhaseKind;
+    status: "skipped" | "completed" | "low_confidence" | "failed";
+    summary?: string;
+    traceId?: string;
+    sessionId?: string;
+    turnId?: string;
+    error?: string;
+  },
+  kind: RuntimeEvidenceEntryKind,
+  scope?: RuntimeEvidenceEntryInput["scope"],
+): Promise<void> {
+  if (execution.status === "skipped") return;
+  await appendRuntimeEvidence({
+    kind,
+    scope: { ...scope, phase: execution.phase },
+    summary: execution.summary ?? `${execution.phase} ${execution.status}`,
+    outcome: phaseStatusToOutcome(execution.status),
+    result: {
+      status: execution.status,
+      ...(execution.error ? { error: execution.error } : {}),
+      ...(execution.summary ? { summary: execution.summary } : {}),
+    },
+    raw_refs: [
+      ...(execution.traceId ? [{ kind: "agentloop_trace", id: execution.traceId }] : []),
+      ...(execution.sessionId ? [{ kind: "agentloop_state", id: execution.sessionId }] : []),
+      ...(execution.turnId ? [{ kind: "agentloop_turn", id: execution.turnId }] : []),
+    ],
+  });
+}
+
+async function appendDecisionEvidence(
+  appendRuntimeEvidence: (entry: Omit<RuntimeEvidenceEntryInput, "scope"> & { scope?: RuntimeEvidenceEntryInput["scope"] }) => Promise<void>,
+  directive: LoopIterationResult["nextIterationDirective"],
+  fallbackReason: string,
+): Promise<void> {
+  if (!directive) return;
+  await appendRuntimeEvidence({
+    kind: "decision",
+    summary: directive.reason,
+    strategy: directive.preferredAction,
+    outcome: "continued",
+    decision_reason: directive.reason,
+    scope: { phase: directive.sourcePhase },
+    result: {
+      status: fallbackReason,
+      summary: directive.reason,
+    },
+  });
+}
+
+async function appendTaskCycleEvidence(
+  appendRuntimeEvidence: (entry: Omit<RuntimeEvidenceEntryInput, "scope"> & { scope?: RuntimeEvidenceEntryInput["scope"] }) => Promise<void>,
+  taskResult: TaskCycleResult,
+): Promise<void> {
+  const task = taskResult.task;
+  await appendRuntimeEvidence({
+    kind: "task_generation",
+    scope: { task_id: task.id },
+    hypothesis: task.rationale,
+    strategy: task.approach,
+    task: {
+      id: task.id,
+      description: task.work_description,
+      primary_dimension: task.primary_dimension,
+    },
+    summary: task.work_description,
+    outcome: "continued",
+    decision_reason: task.rationale,
+  });
+
+  await appendRuntimeEvidence({
+    kind: taskResult.action === "completed" ? "execution" : "failure",
+    scope: { task_id: task.id },
+    task: {
+      id: task.id,
+      description: task.work_description,
+      action: taskResult.action,
+      primary_dimension: task.primary_dimension,
+    },
+    artifacts: taskResult.verificationResult.file_diffs?.map((diff) => ({
+      label: diff.path,
+      path: diff.path,
+      kind: "diff" as const,
+    })) ?? [],
+    result: {
+      status: taskResult.action,
+      ...(task.execution_output ? { summary: truncateOneLine(task.execution_output, 500) } : {}),
+    },
+    outcome: taskActionToOutcome(taskResult.action),
+    summary: `Task ${task.id} ${taskResult.action}`,
+  });
+
+  await appendRuntimeEvidence({
+    kind: taskResult.verificationResult.verdict === "pass" ? "verification" : "failure",
+    scope: { task_id: task.id },
+    verification: {
+      verdict: taskResult.verificationResult.verdict,
+      confidence: taskResult.verificationResult.confidence,
+      summary: summarizeVerificationEvidence(taskResult.verificationResult.evidence),
+    },
+    result: {
+      status: taskResult.verificationResult.verdict,
+      summary: summarizeVerificationEvidence(taskResult.verificationResult.evidence),
+    },
+    outcome: verificationToOutcome(taskResult.verificationResult.verdict),
+    summary: `Verification ${taskResult.verificationResult.verdict} for ${task.id}`,
+  });
+}
+
+function phaseStatusToOutcome(status: "skipped" | "completed" | "low_confidence" | "failed"): RuntimeEvidenceOutcome {
+  if (status === "completed") return "continued";
+  if (status === "failed") return "failed";
+  return "inconclusive";
+}
+
+function taskActionToOutcome(action: TaskCycleResult["action"]): RuntimeEvidenceOutcome {
+  if (action === "completed") return "improved";
+  if (action === "approval_denied" || action === "capability_acquiring") return "blocked";
+  if (action === "discard" || action === "escalate") return "failed";
+  return "inconclusive";
+}
+
+function verificationToOutcome(verdict: TaskCycleResult["verificationResult"]["verdict"]): RuntimeEvidenceOutcome {
+  if (verdict === "pass") return "improved";
+  if (verdict === "fail") return "failed";
+  return "inconclusive";
+}
+
+function summarizeVerificationEvidence(evidence: TaskCycleResult["verificationResult"]["evidence"]): string | undefined {
+  const summary = evidence.map((item) => item.description).filter(Boolean).join("; ");
+  return summary ? truncateOneLine(summary, 500) : undefined;
+}
+
+function truncateOneLine(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 3)}...` : normalized;
 }

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -1,0 +1,69 @@
+import * as fsp from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
+import { RuntimeEvidenceLedger } from "../store/evidence-ledger.js";
+
+describe("RuntimeEvidenceLedger", () => {
+  let runtimeRoot: string;
+
+  beforeEach(() => {
+    runtimeRoot = makeTempDir("pulseed-runtime-evidence-");
+  });
+
+  afterEach(async () => {
+    await fsp.rm(runtimeRoot, { recursive: true, force: true });
+  });
+
+  it("appends entries and reads them after constructing a new ledger", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      kind: "strategy",
+      scope: { goal_id: "goal-a", run_id: "run:coreloop:a", loop_index: 0 },
+      strategy: "continue",
+      summary: "Try the direct implementation path.",
+      outcome: "continued",
+    });
+
+    const reloaded = new RuntimeEvidenceLedger(runtimeRoot);
+    await reloaded.append({
+      kind: "verification",
+      scope: { goal_id: "goal-a", run_id: "run:coreloop:a", task_id: "task-a", loop_index: 0 },
+      verification: { verdict: "pass", confidence: 0.9, summary: "unit test passed" },
+      summary: "Verification pass for task-a",
+      outcome: "improved",
+    });
+
+    const byGoal = await reloaded.readByGoal("goal-a");
+    const byRun = await reloaded.readByRun("run:coreloop:a");
+
+    expect(byGoal.warnings).toEqual([]);
+    expect(byGoal.entries).toHaveLength(2);
+    expect(byRun.entries.map((entry) => entry.kind)).toEqual(["strategy", "verification"]);
+  });
+
+  it("tolerates malformed JSONL rows and summarizes recent evidence", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      kind: "failure",
+      scope: { goal_id: "goal-b", task_id: "task-b" },
+      summary: "Verification failed.",
+      verification: { verdict: "fail", confidence: 1, summary: "grep failed" },
+      outcome: "failed",
+    });
+    await ledger.append({
+      kind: "metric",
+      scope: { goal_id: "goal-b" },
+      metrics: [{ label: "accuracy", value: 0.82, direction: "maximize" }],
+      summary: "Accuracy improved to 0.82.",
+      outcome: "improved",
+    });
+    await fsp.appendFile(ledger.goalPath("goal-b"), "{not-json\n", "utf8");
+
+    const summary = await new RuntimeEvidenceLedger(runtimeRoot).summarizeGoal("goal-b");
+
+    expect(summary.total_entries).toBe(2);
+    expect(summary.warnings).toHaveLength(1);
+    expect(summary.best_evidence?.summary).toBe("Accuracy improved to 0.82.");
+    expect(summary.recent_failed_attempts[0]?.summary).toBe("Verification failed.");
+  });
+});

--- a/src/runtime/executor/loop-supervisor.ts
+++ b/src/runtime/executor/loop-supervisor.ts
@@ -440,6 +440,7 @@ export class LoopSupervisor {
 
     try {
       const result: WorkerResult = await worker.execute(goalId, {
+        ...(activation.backgroundRun ? { backgroundRun: activation.backgroundRun } : {}),
         ...(activation.waitResume ? { waitResume: activation.waitResume } : {}),
       });
 
@@ -522,6 +523,17 @@ export class LoopSupervisor {
     };
   }
 
+  private evidenceLedgerRef(activation: GoalActivation): RuntimeSessionRef {
+    const runId = activation.backgroundRun?.backgroundRunId ?? null;
+    return {
+      kind: 'evidence_ledger',
+      id: runId,
+      path: null,
+      relative_path: runId ? `runtime/evidence-ledger/runs/${encodeURIComponent(runId)}.jsonl` : null,
+      updated_at: null,
+    };
+  }
+
   private async mergeBackgroundRunSourceRefs(
     runId: string,
     refs: RuntimeSessionRef[],
@@ -544,7 +556,10 @@ export class LoopSupervisor {
   private async markBackgroundRunStarted(activation: GoalActivation, worker: GoalWorker): Promise<void> {
     const runId = activation.backgroundRun?.backgroundRunId;
     if (!runId || !this.deps.backgroundRunLedger) return;
-    const sourceRefs = await this.mergeBackgroundRunSourceRefs(runId, [this.supervisorStateRef()]);
+    const sourceRefs = await this.mergeBackgroundRunSourceRefs(runId, [
+      this.supervisorStateRef(),
+      this.evidenceLedgerRef(activation),
+    ]);
     try {
       if (activation.backgroundRun?.parentSessionId !== undefined) {
         await this.deps.backgroundRunLedger.link(runId, {
@@ -569,7 +584,10 @@ export class LoopSupervisor {
   private async markBackgroundRunTerminal(activation: GoalActivation, result: WorkerResult): Promise<void> {
     const runId = activation.backgroundRun?.backgroundRunId;
     if (!runId || !this.deps.backgroundRunLedger) return;
-    const sourceRefs = await this.mergeBackgroundRunSourceRefs(runId, [this.supervisorStateRef()]);
+    const sourceRefs = await this.mergeBackgroundRunSourceRefs(runId, [
+      this.supervisorStateRef(),
+      this.evidenceLedgerRef(activation),
+    ]);
     try {
       const run = await this.deps.backgroundRunLedger.terminal(runId, {
         status: workerStatusToBackgroundRunStatus(result.status),
@@ -592,7 +610,10 @@ export class LoopSupervisor {
   private async markCoalescedBackgroundRun(activation: GoalActivation, activeWorker: GoalWorker): Promise<void> {
     const runId = activation.backgroundRun?.backgroundRunId;
     if (!runId || !this.deps.backgroundRunLedger) return;
-    const sourceRefs = await this.mergeBackgroundRunSourceRefs(runId, [this.supervisorStateRef()]);
+    const sourceRefs = await this.mergeBackgroundRunSourceRefs(runId, [
+      this.supervisorStateRef(),
+      this.evidenceLedgerRef(activation),
+    ]);
     const childSessionId = this.coreLoopSessionId(activeWorker);
     try {
       await this.deps.backgroundRunLedger.link(runId, {

--- a/src/runtime/session-registry/types.ts
+++ b/src/runtime/session-registry/types.ts
@@ -31,6 +31,7 @@ export const RuntimeSessionRefKindSchema = z.enum([
   "daemon_snapshot",
   "supervisor_state",
   "task_ledger",
+  "evidence_ledger",
   "process_session",
   "runtime_health",
   "artifact",

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -1,0 +1,274 @@
+import { randomUUID } from "node:crypto";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { z } from "zod";
+import {
+  createRuntimeStorePaths,
+  ensureRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+
+export const RuntimeEvidenceOutcomeSchema = z.enum([
+  "improved",
+  "regressed",
+  "inconclusive",
+  "failed",
+  "blocked",
+  "continued",
+]);
+export type RuntimeEvidenceOutcome = z.infer<typeof RuntimeEvidenceOutcomeSchema>;
+
+export const RuntimeEvidenceEntryKindSchema = z.enum([
+  "observation",
+  "strategy",
+  "task_generation",
+  "execution",
+  "verification",
+  "decision",
+  "metric",
+  "artifact",
+  "failure",
+  "other",
+]);
+export type RuntimeEvidenceEntryKind = z.infer<typeof RuntimeEvidenceEntryKindSchema>;
+
+export const RuntimeEvidenceArtifactRefSchema = z.object({
+  label: z.string().min(1),
+  path: z.string().min(1).optional(),
+  state_relative_path: z.string().min(1).optional(),
+  url: z.string().url().optional(),
+  kind: z.enum(["log", "metrics", "report", "diff", "url", "other"]).default("other"),
+}).strict();
+export type RuntimeEvidenceArtifactRef = z.infer<typeof RuntimeEvidenceArtifactRefSchema>;
+
+export const RuntimeEvidenceMetricSchema = z.object({
+  label: z.string().min(1),
+  value: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+  unit: z.string().min(1).optional(),
+  direction: z.enum(["maximize", "minimize", "neutral"]).optional(),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceMetric = z.infer<typeof RuntimeEvidenceMetricSchema>;
+
+export const RuntimeEvidenceEntrySchema = z.object({
+  schema_version: z.literal("runtime-evidence-entry-v1"),
+  id: z.string().min(1),
+  occurred_at: z.string().datetime(),
+  kind: RuntimeEvidenceEntryKindSchema,
+  scope: z.object({
+    goal_id: z.string().min(1).optional(),
+    run_id: z.string().min(1).optional(),
+    task_id: z.string().min(1).optional(),
+    loop_index: z.number().int().nonnegative().optional(),
+    phase: z.string().min(1).optional(),
+  }).strict(),
+  hypothesis: z.string().min(1).optional(),
+  strategy: z.string().min(1).optional(),
+  task: z.object({
+    id: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
+    action: z.string().min(1).optional(),
+    primary_dimension: z.string().min(1).optional(),
+  }).strict().optional(),
+  verification: z.object({
+    command: z.string().min(1).optional(),
+    verdict: z.string().min(1).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+    summary: z.string().min(1).optional(),
+  }).strict().optional(),
+  metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
+  artifacts: z.array(RuntimeEvidenceArtifactRefSchema).default([]),
+  result: z.object({
+    status: z.string().min(1).optional(),
+    summary: z.string().min(1).optional(),
+    error: z.string().min(1).optional(),
+  }).strict().optional(),
+  outcome: RuntimeEvidenceOutcomeSchema.optional(),
+  decision_reason: z.string().min(1).optional(),
+  raw_refs: z.array(z.object({
+    kind: z.string().min(1),
+    id: z.string().min(1).optional(),
+    path: z.string().min(1).optional(),
+    state_relative_path: z.string().min(1).optional(),
+    url: z.string().url().optional(),
+  }).strict()).default([]),
+  summary: z.string().min(1).optional(),
+}).strict().refine((entry) => entry.scope.goal_id || entry.scope.run_id, {
+  message: "goal_id or run_id is required",
+  path: ["scope"],
+});
+export type RuntimeEvidenceEntry = z.infer<typeof RuntimeEvidenceEntrySchema>;
+export type RuntimeEvidenceEntryInput = Omit<
+  RuntimeEvidenceEntry,
+  "schema_version" | "id" | "occurred_at" | "metrics" | "artifacts" | "raw_refs"
+> & Partial<Pick<RuntimeEvidenceEntry, "id" | "occurred_at" | "metrics" | "artifacts" | "raw_refs">>;
+
+export interface RuntimeEvidenceReadWarning {
+  file: string;
+  line: number;
+  message: string;
+}
+
+export interface RuntimeEvidenceReadResult {
+  entries: RuntimeEvidenceEntry[];
+  warnings: RuntimeEvidenceReadWarning[];
+}
+
+export interface RuntimeEvidenceSummary {
+  schema_version: "runtime-evidence-summary-v1";
+  generated_at: string;
+  scope: {
+    goal_id?: string;
+    run_id?: string;
+  };
+  total_entries: number;
+  latest_strategy: RuntimeEvidenceEntry | null;
+  best_evidence: RuntimeEvidenceEntry | null;
+  recent_failed_attempts: RuntimeEvidenceEntry[];
+  recent_entries: RuntimeEvidenceEntry[];
+  warnings: RuntimeEvidenceReadWarning[];
+}
+
+export interface RuntimeEvidenceLedgerPort {
+  append(input: RuntimeEvidenceEntryInput): Promise<RuntimeEvidenceEntry[]>;
+}
+
+export class RuntimeEvidenceLedger implements RuntimeEvidenceLedgerPort {
+  private readonly paths: RuntimeStorePaths;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+  }
+
+  async ensureReady(): Promise<void> {
+    await ensureRuntimeStorePaths(this.paths);
+  }
+
+  goalPath(goalId: string): string {
+    return this.paths.evidenceGoalPath(goalId);
+  }
+
+  runPath(runId: string): string {
+    return this.paths.evidenceRunPath(runId);
+  }
+
+  async append(input: RuntimeEvidenceEntryInput): Promise<RuntimeEvidenceEntry[]> {
+    const entry = RuntimeEvidenceEntrySchema.parse({
+      schema_version: "runtime-evidence-entry-v1",
+      id: input.id ?? randomUUID(),
+      occurred_at: input.occurred_at ?? new Date().toISOString(),
+      metrics: input.metrics ?? [],
+      artifacts: input.artifacts ?? [],
+      raw_refs: input.raw_refs ?? [],
+      ...input,
+    });
+    await this.ensureReady();
+
+    const targets = new Set<string>();
+    if (entry.scope.goal_id) targets.add(this.paths.evidenceGoalPath(entry.scope.goal_id));
+    if (entry.scope.run_id) targets.add(this.paths.evidenceRunPath(entry.scope.run_id));
+    await Promise.all([...targets].map(async (target) => {
+      await fsp.mkdir(path.dirname(target), { recursive: true });
+      await fsp.appendFile(target, `${JSON.stringify(entry)}\n`, "utf8");
+    }));
+    return [entry];
+  }
+
+  async readByGoal(goalId: string): Promise<RuntimeEvidenceReadResult> {
+    return readEvidenceFile(this.paths.evidenceGoalPath(goalId));
+  }
+
+  async readByRun(runId: string): Promise<RuntimeEvidenceReadResult> {
+    return readEvidenceFile(this.paths.evidenceRunPath(runId));
+  }
+
+  async summarizeGoal(goalId: string): Promise<RuntimeEvidenceSummary> {
+    const read = await this.readByGoal(goalId);
+    return summarizeEvidence({ goal_id: goalId }, read);
+  }
+
+  async summarizeRun(runId: string): Promise<RuntimeEvidenceSummary> {
+    const read = await this.readByRun(runId);
+    return summarizeEvidence({ run_id: runId }, read);
+  }
+}
+
+async function readEvidenceFile(filePath: string): Promise<RuntimeEvidenceReadResult> {
+  let text: string;
+  try {
+    text = await fsp.readFile(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { entries: [], warnings: [] };
+    }
+    throw err;
+  }
+
+  const entries: RuntimeEvidenceEntry[] = [];
+  const warnings: RuntimeEvidenceReadWarning[] = [];
+  const lines = text.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line?.trim()) continue;
+    try {
+      const parsed = RuntimeEvidenceEntrySchema.safeParse(JSON.parse(line));
+      if (parsed.success) {
+        entries.push(parsed.data);
+      } else {
+        warnings.push({
+          file: filePath,
+          line: index + 1,
+          message: parsed.error.issues.map((issue) => issue.message).join("; "),
+        });
+      }
+    } catch (err) {
+      warnings.push({
+        file: filePath,
+        line: index + 1,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return { entries, warnings };
+}
+
+function summarizeEvidence(
+  scope: RuntimeEvidenceSummary["scope"],
+  read: RuntimeEvidenceReadResult
+): RuntimeEvidenceSummary {
+  const entries = [...read.entries].sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
+  const newestFirst = [...entries].reverse();
+  return {
+    schema_version: "runtime-evidence-summary-v1",
+    generated_at: new Date().toISOString(),
+    scope,
+    total_entries: entries.length,
+    latest_strategy: newestFirst.find((entry) =>
+      entry.kind === "strategy" || Boolean(entry.strategy) || Boolean(entry.decision_reason)
+    ) ?? null,
+    best_evidence: chooseBestEvidence(newestFirst),
+    recent_failed_attempts: newestFirst
+      .filter((entry) =>
+        entry.outcome === "failed"
+        || entry.outcome === "regressed"
+        || entry.kind === "failure"
+        || entry.result?.status === "failed"
+        || entry.verification?.verdict === "fail"
+      )
+      .slice(0, 5),
+    recent_entries: newestFirst.slice(0, 10),
+    warnings: read.warnings,
+  };
+}
+
+function chooseBestEvidence(entriesNewestFirst: RuntimeEvidenceEntry[]): RuntimeEvidenceEntry | null {
+  return entriesNewestFirst.find((entry) => entry.outcome === "improved")
+    ?? entriesNewestFirst.find((entry) => entry.verification?.verdict === "pass")
+    ?? entriesNewestFirst.find((entry) => entry.metrics.length > 0)
+    ?? entriesNewestFirst.find((entry) => entry.kind === "artifact")
+    ?? null;
+}

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -77,6 +77,27 @@ export {
   RuntimeControlOperationSchema,
   isTerminalRuntimeControlState,
 } from "./runtime-operation-schemas.js";
+
+export {
+  RuntimeEvidenceArtifactRefSchema,
+  RuntimeEvidenceEntryKindSchema,
+  RuntimeEvidenceEntrySchema,
+  RuntimeEvidenceLedger,
+  RuntimeEvidenceMetricSchema,
+  RuntimeEvidenceOutcomeSchema,
+} from "./evidence-ledger.js";
+export type {
+  RuntimeEvidenceArtifactRef,
+  RuntimeEvidenceEntry,
+  RuntimeEvidenceEntryInput,
+  RuntimeEvidenceEntryKind,
+  RuntimeEvidenceLedgerPort,
+  RuntimeEvidenceMetric,
+  RuntimeEvidenceOutcome,
+  RuntimeEvidenceReadResult,
+  RuntimeEvidenceReadWarning,
+  RuntimeEvidenceSummary,
+} from "./evidence-ledger.js";
 export type {
   RuntimeControlOperationKind,
   RuntimeControlOperationState,

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -18,6 +18,9 @@ export interface RuntimeStorePaths {
   outboxDir: string;
   backgroundRunsDir: string;
   browserSessionsDir: string;
+  evidenceLedgerDir: string;
+  evidenceLedgerGoalsDir: string;
+  evidenceLedgerRunsDir: string;
   leasesDir: string;
   goalLeasesDir: string;
   dlqDir: string;
@@ -34,6 +37,8 @@ export interface RuntimeStorePaths {
   outboxRecordPath(seq: number): string;
   backgroundRunPath(runId: string): string;
   browserSessionPath(sessionId: string): string;
+  evidenceGoalPath(goalId: string): string;
+  evidenceRunPath(runId: string): string;
   guardrailBreakerPath(key: string): string;
   goalLeasePath(goalId: string): string;
   completedByIdempotencyPath(idempotencyKey: string): string;
@@ -81,6 +86,9 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
   const outboxDir = path.join(rootDir, "outbox");
   const backgroundRunsDir = path.join(rootDir, "background-runs");
   const browserSessionsDir = path.join(rootDir, "browser-sessions");
+  const evidenceLedgerDir = path.join(rootDir, "evidence-ledger");
+  const evidenceLedgerGoalsDir = path.join(evidenceLedgerDir, "goals");
+  const evidenceLedgerRunsDir = path.join(evidenceLedgerDir, "runs");
   const leasesDir = path.join(rootDir, "leases");
   const goalLeasesDir = path.join(leasesDir, "goal");
   const dlqDir = path.join(rootDir, "dlq");
@@ -103,6 +111,9 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     outboxDir,
     backgroundRunsDir,
     browserSessionsDir,
+    evidenceLedgerDir,
+    evidenceLedgerGoalsDir,
+    evidenceLedgerRunsDir,
     leasesDir,
     goalLeasesDir,
     dlqDir,
@@ -132,6 +143,12 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     },
     browserSessionPath(sessionId: string) {
       return path.join(browserSessionsDir, recordFileName(encodeRuntimePathSegment(sessionId)));
+    },
+    evidenceGoalPath(goalId: string) {
+      return path.join(evidenceLedgerGoalsDir, `${encodeRuntimePathSegment(goalId)}.jsonl`);
+    },
+    evidenceRunPath(runId: string) {
+      return path.join(evidenceLedgerRunsDir, `${encodeRuntimePathSegment(runId)}.jsonl`);
     },
     guardrailBreakerPath(key: string) {
       return path.join(guardrailBreakersDir, recordFileName(encodeRuntimePathSegment(key)));
@@ -167,6 +184,9 @@ export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise
       paths.outboxDir,
       paths.backgroundRunsDir,
       paths.browserSessionsDir,
+      paths.evidenceLedgerDir,
+      paths.evidenceLedgerGoalsDir,
+      paths.evidenceLedgerRunsDir,
       paths.leasesDir,
       paths.goalLeasesDir,
       paths.dlqDir,

--- a/src/tools/runtime/LongRunningRuntimeTools.ts
+++ b/src/tools/runtime/LongRunningRuntimeTools.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { z } from "zod";
 import { getPulseedDirPath } from "../../base/utils/paths.js";
 import { BackgroundRunLedger } from "../../runtime/store/background-run-store.js";
+import { RuntimeEvidenceLedger } from "../../runtime/store/evidence-ledger.js";
 import type { BackgroundRun, RuntimeArtifactRef, RuntimeSessionRef } from "../../runtime/session-registry/types.js";
 import type {
   ITool,
@@ -210,6 +211,13 @@ export class RuntimeReportWriteTool implements ITool<RuntimeReportWriteInput, Ru
         const warning = await linkBackgroundRunArtifacts(runId, result, output);
         if (warning) warnings.push(warning);
       }
+
+      const evidenceWarning = await appendLongRunningEvidence(result, output, {
+        runId: input.run_id,
+        backgroundRunId: input.background_run_id ?? result.source.background_run_id,
+        processSessionId: input.process_session_id ?? result.source.process_session_id,
+      });
+      if (evidenceWarning) warnings.push(evidenceWarning);
 
       const data: RuntimeReportWriteOutput = {
         result,
@@ -688,6 +696,58 @@ async function linkBackgroundRunArtifacts(
   } catch (err) {
     return `Could not link artifacts to background run ${runId}: ${messageFromError(err)}`;
   }
+}
+
+async function appendLongRunningEvidence(
+  result: LongRunningResult,
+  output: { files: RuntimeReportWriteOutput["files"] },
+  ids: { runId?: string; backgroundRunId?: string; processSessionId?: string },
+): Promise<string | null> {
+  const runId = ids.backgroundRunId ?? ids.runId ?? result.source.background_run_id ?? result.source.process_session_id;
+  if (!runId) return null;
+  try {
+    const ledger = new RuntimeEvidenceLedger();
+    await ledger.append({
+      kind: result.status === "failed" || result.status === "blocked" ? "failure" : "artifact",
+      scope: { run_id: runId },
+      summary: result.next_action.summary,
+      outcome: longRunningStatusToOutcome(result.status),
+      metrics: result.evidence.map((item) => ({
+        label: item.label,
+        value: item.value,
+        unit: item.unit,
+        summary: item.summary,
+      })),
+      artifacts: [
+        { label: "summary.md", path: output.files.summary, state_relative_path: output.files.state_relative_directory + "/summary.md", kind: "report" },
+        { label: "result.json", path: output.files.result, state_relative_path: output.files.state_relative_directory + "/result.json", kind: "metrics" },
+        { label: "next-action.json", path: output.files.next_action, state_relative_path: output.files.state_relative_directory + "/next-action.json", kind: "other" },
+        ...result.artifacts,
+      ],
+      result: {
+        status: result.status,
+        summary: result.next_action.summary,
+        ...(result.failures[0] ? { error: result.failures[0] } : {}),
+      },
+      decision_reason: result.next_action.reason ?? result.next_action.summary,
+      raw_refs: [
+        ...(ids.processSessionId ? [{ kind: "process_session", id: ids.processSessionId }] : []),
+        ...(ids.backgroundRunId ? [{ kind: "background_run", id: ids.backgroundRunId }] : []),
+        ...(result.source.path ? [{ kind: result.source.kind, path: result.source.path }] : []),
+      ],
+    });
+    return null;
+  } catch (err) {
+    return `Could not append long-running evidence for ${runId}: ${messageFromError(err)}`;
+  }
+}
+
+function longRunningStatusToOutcome(status: LongRunningStatus) {
+  if (status === "succeeded") return "improved";
+  if (status === "failed") return "failed";
+  if (status === "blocked") return "blocked";
+  if (status === "running") return "continued";
+  return "inconclusive";
 }
 
 function mapResultStatusToBackgroundStatus(existing: BackgroundRun, status: LongRunningStatus): BackgroundRun["status"] {


### PR DESCRIPTION
## Summary
- Add a runtime evidence ledger persisted under the PulSeed runtime state root as append-only JSONL.
- Record CoreLoop phase, task generation, execution, verification, and next-decision evidence for autonomous long-running work.
- Link long-running report artifacts and background CoreLoop runs to evidence ledger refs.
- Add `pulseed runtime evidence <goal-id|run-id> [--json]` for latest strategy, best evidence, and recent failed attempts.

## Validation
- `npm run typecheck`
- `npx vitest run src/runtime/__tests__/runtime-evidence-ledger.test.ts src/tools/runtime/__tests__/LongRunningRuntimeTools.test.ts src/runtime/__tests__/loop-supervisor.test.ts src/interface/cli/__tests__/runtime-command.test.ts src/orchestrator/loop/__tests__/core-loop-agentic-phases.test.ts`
- `npm run lint:boundaries` (passes with existing warnings)

## Note
- `npm run test:changed` passed related unit tests (49 files / 733 tests). The related integration lane still times out in the existing `src/interface/cli/__tests__/cli-runner-integration.test.ts` CoreLoop MockLLM test, and the same test times out when run alone.
