### PR TITLE
feat(runtime): add metric history trend signals

### DIFF
--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -306,6 +306,14 @@ function printEvidenceSummary(summary: RuntimeEvidenceSummary): void {
   console.log(`  Entries:         ${summary.total_entries}`);
   console.log(`  Latest strategy: ${entryLabel(summary.latest_strategy)}`);
   console.log(`  Best evidence:   ${entryLabel(summary.best_evidence)}`);
+  if (summary.metric_trends.length > 0) {
+    console.log("  Metric trends:");
+    for (const trend of summary.metric_trends) {
+      console.log(`    - ${trend.metric_key} ${trend.trend}: latest=${trend.latest_value}, best=${trend.best_value}, confidence=${trend.confidence.toFixed(2)}`);
+    }
+  } else {
+    console.log("  Metric trends:   -");
+  }
   if (summary.recent_failed_attempts.length > 0) {
     console.log("  Recent failures:");
     for (const entry of summary.recent_failed_attempts) {

--- a/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
@@ -34,6 +34,7 @@ import type { GoalRefiner } from "../../goal/goal-refiner.js";
 import type { Goal } from "../../../base/types/goal.js";
 import type { StallReport } from "../../../base/types/stall.js";
 import type { ITimeHorizonEngine } from "../../../platform/time/time-horizon-engine.js";
+import type { RuntimeEvidenceEntry } from "../../../runtime/store/evidence-ledger.js";
 import type { LoopIterationResult } from "../core-loop/contracts.js";
 import type { PhaseCtx } from "../core-loop/preparation.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
@@ -374,6 +375,71 @@ describe("detectStallsAndRebalance — reRefineLeaf on observation-failure stall
 
     expect(result.stallDetected).toBe(true);
     expect(mockRefiner.reRefineLeaf).not.toHaveBeenCalled();
+  });
+
+  it("feeds runtime metric trend context into stall recovery", async () => {
+    const deps = createBaseDeps(tmpDir);
+    const goal = makeGoal({ id: "goal-1" });
+    await deps.stateManager.saveGoal(goal);
+    await deps.stateManager.saveGapHistory("goal-1", makeGapHistoryWithStall("dim1", 5));
+
+    const metricEntries: RuntimeEvidenceEntry[] = [
+      {
+        schema_version: "runtime-evidence-entry-v1",
+        id: "entry-a",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+        kind: "metric",
+        scope: { goal_id: "goal-1" },
+        metrics: [{ label: "dim1", value: 0.5, direction: "maximize", confidence: 0.9 }],
+        artifacts: [{ label: "metrics-a", state_relative_path: "runs/a/metrics.json", kind: "metrics" }],
+        raw_refs: [],
+        outcome: "continued",
+        summary: "Initial metric.",
+      },
+      {
+        schema_version: "runtime-evidence-entry-v1",
+        id: "entry-b",
+        occurred_at: "2026-04-30T00:05:00.000Z",
+        kind: "metric",
+        scope: { goal_id: "goal-1" },
+        metrics: [{ label: "dim1", value: 0.7, direction: "maximize", confidence: 0.95 }],
+        artifacts: [{ label: "metrics-b", state_relative_path: "runs/b/metrics.json", kind: "metrics" }],
+        raw_refs: [],
+        outcome: "improved",
+        summary: "Breakthrough metric.",
+      },
+    ];
+    deps.evidenceLedger = {
+      append: vi.fn().mockResolvedValue([]),
+      readByGoal: vi.fn().mockResolvedValue({ entries: metricEntries, warnings: [] }),
+    };
+
+    (deps.stallDetector.checkDimensionStall as ReturnType<typeof vi.fn>).mockImplementation(
+      (_goalId, _dimensionName, _history, _feedbackCategory, metricTrendContext) =>
+        makeStallReport({ metric_trend_context: metricTrendContext })
+    );
+    (deps.strategyManager.onStallDetected as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "strategy-next", state: "active" });
+
+    const ctx = buildPhaseCtx(deps, { maxIterations: 10, adapterType: "openai_codex_cli" });
+    const result = makeIterationResult();
+
+    await detectStallsAndRebalance(ctx, "goal-1", goal, result);
+
+    expect(deps.stallDetector.checkDimensionStall).toHaveBeenCalledWith(
+      "goal-1",
+      "dim1",
+      expect.any(Array),
+      undefined,
+      expect.objectContaining({ metric_key: "dim1", trend: "breakthrough", latest_value: 0.7 })
+    );
+    expect(deps.strategyManager.onStallDetected).toHaveBeenCalledWith(
+      "goal-1",
+      1,
+      goal.origin ?? "general",
+      undefined,
+      expect.objectContaining({ metric_key: "dim1", trend: "breakthrough" })
+    );
+    expect(result.metricTrendContext).toMatchObject({ metric_key: "dim1", trend: "breakthrough" });
   });
 
   it("does NOT call reRefineLeaf() when goalRefiner is absent (backward compat)", async () => {
@@ -829,7 +895,9 @@ describe("detectStallsAndRebalance — gap history indexing reuse", () => {
     expect(depsWithPortfolio.stallDetector.checkDimensionStall).toHaveBeenCalledWith(
       "goal-1",
       "dim2",
-      [expect.objectContaining({ normalized_gap: 0.4 })]
+      [expect.objectContaining({ normalized_gap: 0.4 })],
+      undefined,
+      undefined
     );
     const globalHistory = globalCheck.mock.calls[0]?.[1] as Map<string, Array<{ normalized_gap: number; timestamp?: string }>>;
     expect(globalHistory.has("dim1")).toBe(false);
@@ -934,7 +1002,9 @@ describe("detectStallsAndRebalance — gap history indexing reuse", () => {
     expect(depsWithPortfolio.stallDetector.checkDimensionStall).toHaveBeenCalledWith(
       "goal-1",
       "dim2",
-      [expect.objectContaining({ normalized_gap: 0.4 })]
+      [expect.objectContaining({ normalized_gap: 0.4 })],
+      undefined,
+      undefined
     );
     const globalHistory = globalCheck.mock.calls[0]?.[1] as Map<string, Array<{ normalized_gap: number; timestamp?: string }>>;
     expect(globalHistory.has("dim1")).toBe(false);

--- a/src/orchestrator/loop/core-loop/task-cycle-stall.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle-stall.ts
@@ -2,7 +2,12 @@ import { randomUUID } from "node:crypto";
 import type { Goal } from "../../../base/types/goal.js";
 import type { GapHistoryEntry } from "../../../base/types/gap.js";
 import type { StallReport } from "../../../base/types/stall.js";
+import type { MetricTrendContext } from "../../../platform/drive/metric-history.js";
 import type { GapObservation } from "../../../base/types/time-horizon.js";
+import {
+  selectMetricTrendForDimension,
+  summarizeEvidenceMetricTrends,
+} from "../../../runtime/store/metric-history.js";
 import { gatherStallEvidence } from "../stall-evidence.js";
 import type { LoopIterationResult } from "./contracts.js";
 import type { PhaseCtx } from "./preparation.js";
@@ -13,6 +18,14 @@ type DimensionGapSample = {
   normalized_gap: number;
   timestamp: string;
 };
+
+type StrategyStallArgs = [
+  goalId: string,
+  stallCount: number,
+  goalType?: string,
+  activationContext?: WaitStrategyActivationContext,
+  metricTrendContext?: MetricTrendContext,
+];
 
 function resolveGoalWorkspacePath(goal: Goal): string | undefined {
   const constraint = goal.constraints.find((entry) => entry.startsWith("workspace_path:"));
@@ -128,6 +141,17 @@ async function applyStallAction(
 
   const activeStrategyForRecord = await Promise.resolve(ctx.deps.strategyManager.getActiveStrategy(goalId)).catch(() => null);
   const strategyIdForRecord = activeStrategyForRecord?.id ?? "unknown";
+  const metricTrendContext = stallReport.metric_trend_context;
+  if (metricTrendContext) {
+    result.metricTrendContext = metricTrendContext;
+    ctx.logger?.info(`CoreLoop: ${logPrefix}metric trend evidence — ${metricTrendContext.summary}`, {
+      goalId,
+      metricTrend: metricTrendContext.trend,
+      metricKey: metricTrendContext.metric_key,
+      latestValue: metricTrendContext.latest_value,
+      bestValue: metricTrendContext.best_value,
+    });
+  }
   const analysis = ctx.deps.stallDetector.analyzeStallCause?.(dimHistory);
   result.stallAnalysis = analysis;
   const selectedAction = analysis?.recommended_action === "escalate"
@@ -159,12 +183,13 @@ async function applyStallAction(
       goalId,
       evidence: analysis?.evidence,
     });
-    await ctx.deps.strategyManager.onStallDetected(
+    await callStrategyOnStall(ctx, [
       goalId,
       3,
       goal.origin ?? "general",
-      waitActivationContext
-    );
+      waitActivationContext,
+      metricTrendContext,
+    ]);
     result.pivotOccurred = true;
   } else {
     const portfolio = await ctx.deps.strategyManager.getPortfolio(goalId);
@@ -178,20 +203,22 @@ async function applyStallAction(
         pivotCount,
         maxPivotCount,
       });
-      await ctx.deps.strategyManager.onStallDetected(
+      await callStrategyOnStall(ctx, [
         goalId,
         3,
         goal.origin ?? "general",
-        waitActivationContext
-      );
+        waitActivationContext,
+        metricTrendContext,
+      ]);
       result.pivotOccurred = true;
     } else {
-      const newStrategy = await ctx.deps.strategyManager.onStallDetected(
+      const newStrategy = await callStrategyOnStall(ctx, [
         goalId,
         escalationLevel + 1,
         goal.origin ?? "general",
-        waitActivationContext
-      );
+        waitActivationContext,
+        metricTrendContext,
+      ]);
       if (newStrategy) {
         result.pivotOccurred = true;
         if (activeStrategy?.id) {
@@ -235,6 +262,38 @@ async function applyStallAction(
 
   if (incrementDimName) {
     await ctx.deps.stallDetector.incrementEscalation(goalId, incrementDimName);
+  }
+}
+
+async function callStrategyOnStall(
+  ctx: PhaseCtx,
+  args: StrategyStallArgs
+) {
+  const [goalId, stallCount, goalType, activationContext, metricTrendContext] = args;
+  if (metricTrendContext) {
+    return ctx.deps.strategyManager.onStallDetected(
+      goalId,
+      stallCount,
+      goalType,
+      activationContext,
+      metricTrendContext
+    );
+  }
+  return ctx.deps.strategyManager.onStallDetected(goalId, stallCount, goalType, activationContext);
+}
+
+async function loadMetricTrendContexts(ctx: PhaseCtx, goalId: string): Promise<MetricTrendContext[]> {
+  const readByGoal = ctx.deps.evidenceLedger?.readByGoal;
+  if (!readByGoal) return [];
+  try {
+    const read = await readByGoal.call(ctx.deps.evidenceLedger, goalId);
+    return summarizeEvidenceMetricTrends(read.entries);
+  } catch (err) {
+    ctx.logger?.warn("CoreLoop: metric trend history unavailable (non-fatal)", {
+      goalId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
   }
 }
 
@@ -322,6 +381,7 @@ export async function detectStallsAndRebalance(
   try {
     const gapHistory = await ctx.deps.stateManager.loadGapHistory(goalId);
     const gapHistoryByDimension = indexGapHistoryByDimension(goal, gapHistory);
+    const metricTrends = await loadMetricTrendContexts(ctx, goalId);
     const waitActivationContext = buildWaitStrategyActivationContext(
       ctx,
       goalId,
@@ -379,7 +439,17 @@ export async function detectStallsAndRebalance(
     for (const dim of goal.dimensions) {
       if (suppressedDimensions.has(dim.name)) continue;
       const dimGapHistory = gapHistoryByDimension.get(dim.name) ?? [];
-      const stallReport = ctx.deps.stallDetector.checkDimensionStall(goalId, dim.name, dimGapHistory);
+      const metricTrendContext = selectMetricTrendForDimension(metricTrends, dim.name);
+      if (metricTrendContext) {
+        result.metricTrendContext = metricTrendContext;
+      }
+      const stallReport = ctx.deps.stallDetector.checkDimensionStall(
+        goalId,
+        dim.name,
+        dimGapHistory,
+        undefined,
+        metricTrendContext
+      );
 
       if (stallReport) {
         result.stallDetected = true;
@@ -391,7 +461,10 @@ export async function detectStallsAndRebalance(
         ) {
           ctx.logger?.info(
             `CoreLoop: early warning ${stallReport.stall_type} — monitoring, no pivot`,
-            { goalId },
+            {
+              goalId,
+              metricTrend: stallReport.metric_trend_context?.summary,
+            },
           );
           continue;
         }

--- a/src/orchestrator/loop/loop-result-types.ts
+++ b/src/orchestrator/loop/loop-result-types.ts
@@ -1,6 +1,7 @@
 import type { DriveScore } from "../../base/types/drive.js";
 import type { CompletionJudgment } from "../../base/types/satisficing.js";
 import type { StallAnalysis, StallReport } from "../../base/types/stall.js";
+import type { MetricTrendContext } from "../../platform/drive/metric-history.js";
 import type { TransferCandidate } from "../../base/types/cross-portfolio.js";
 import type { WaitExpiryOutcome } from "../../base/types/strategy.js";
 import type { TaskCycleResult } from "../execution/task/task-execution-types.js";
@@ -37,6 +38,8 @@ export interface LoopIterationResult {
   stallReport: StallReport | null;
   /** M14-S2: cause analysis result when a stall is detected */
   stallAnalysis?: StallAnalysis;
+  /** Outcome metric trend that informed stall/recovery decisions. */
+  metricTrendContext?: MetricTrendContext;
   pivotOccurred: boolean;
   completionJudgment: CompletionJudgment;
   elapsedMs: number;

--- a/src/orchestrator/strategy/strategy-helpers.ts
+++ b/src/orchestrator/strategy/strategy-helpers.ts
@@ -5,6 +5,7 @@ import { KnowledgeGapSignalSchema } from "../../base/types/knowledge.js";
 import type { StrategyState } from "../../base/types/core.js";
 import type { Strategy } from "../../base/types/strategy.js";
 import type { KnowledgeGapSignal } from "../../base/types/knowledge.js";
+import { formatMetricTrendContext, type MetricTrendContext } from "../../platform/drive/metric-history.js";
 
 // ─── Valid state transitions ───
 
@@ -69,7 +70,7 @@ export function buildGenerationPrompt(
   goalId: string,
   primaryDimension: string,
   targetDimensions: string[],
-  context: { currentGap: number; pastStrategies: Strategy[] },
+  context: { currentGap: number; pastStrategies: Strategy[]; metricTrendContext?: MetricTrendContext },
   enrichment?: { templatesBlock?: string; lessonsBlock?: string; workspaceBlock?: string }
 ): string {
   // Sort all past strategies most recent first
@@ -138,6 +139,7 @@ export function buildGenerationPrompt(
 Primary dimension to improve: ${primaryDimension}
 All target dimensions: ${targetDimensions.join(", ")}
 Current gap score: ${context.currentGap} (0=closed, 1=fully open)
+${context.metricTrendContext ? `Metric trend evidence: ${formatMetricTrendContext(context.metricTrendContext)}\nUse this outcome curve when deciding whether to exploit, pivot, or broaden exploration.` : ""}
 
 Past strategies tried:
 ${pastSummary}

--- a/src/orchestrator/strategy/strategy-manager-base.ts
+++ b/src/orchestrator/strategy/strategy-manager-base.ts
@@ -13,6 +13,7 @@ import type { Logger } from "../../runtime/logger.js";
 import type { ToolExecutor } from "../../tools/executor.js";
 import type { ToolCallContext } from "../../tools/types.js";
 import type { ToolRegistry } from "../../tools/registry.js";
+import type { MetricTrendContext } from "../../platform/drive/metric-history.js";
 import { WorkspaceContextCache, formatWorkspaceContext } from "./strategy-workspace.js";
 import type { WorkspaceContext } from "./strategy-workspace.js";
 import {
@@ -152,6 +153,7 @@ export class StrategyManagerBase {
     context: {
       currentGap: number;
       pastStrategies: Strategy[];
+      metricTrendContext?: MetricTrendContext;
     },
     enrichment?: { templatesBlock?: string; lessonsBlock?: string },
     toolContext?: { toolCallContext: ToolCallContext; iteration: number }
@@ -494,7 +496,8 @@ export class StrategyManagerBase {
     goalId: string,
     stallCount: number,
     goalType?: string,
-    activationContext?: WaitStrategyActivationContext
+    activationContext?: WaitStrategyActivationContext,
+    metricTrendContext?: MetricTrendContext
   ): Promise<Strategy | null> {
     if (stallCount < 2) {
       return null;
@@ -546,6 +549,7 @@ export class StrategyManagerBase {
         {
           currentGap: active?.gap_snapshot_at_start ?? 1.0,
           pastStrategies,
+          ...(metricTrendContext ? { metricTrendContext } : {}),
         },
         undefined,
         toolContext

--- a/src/platform/drive/__tests__/metric-history.test.ts
+++ b/src/platform/drive/__tests__/metric-history.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { classifyMetricTrend, type MetricObservation } from "../metric-history.js";
+
+function observations(values: number[]): MetricObservation[] {
+  return values.map((value, index) => ({
+    observed_at: new Date(Date.UTC(2026, 3, 30, 0, index, 0)).toISOString(),
+    metric_key: "accuracy",
+    value,
+    direction: "maximize",
+    confidence: 1,
+    source: { entry_id: `entry-${index}`, kind: "metric" },
+  }));
+}
+
+describe("classifyMetricTrend", () => {
+  it("classifies monotonic improvement", () => {
+    const trend = classifyMetricTrend(observations([0.4, 0.45, 0.5, 0.56]), {
+      improvementThreshold: 0.02,
+      breakthroughThreshold: 0.2,
+    });
+
+    expect(trend?.trend).toBe("improving");
+    expect(trend?.best_value).toBe(0.56);
+  });
+
+  it("classifies a flat stall", () => {
+    const trend = classifyMetricTrend(observations([0.7, 0.7, 0.7, 0.7]), {
+      improvementThreshold: 0.02,
+    });
+
+    expect(trend?.trend).toBe("stalled");
+  });
+
+  it("classifies an early breakthrough followed by a plateau as stalled", () => {
+    const trend = classifyMetricTrend(observations([0.45, 0.96, 0.961, 0.9605, 0.9607]), {
+      improvementThreshold: 0.01,
+      breakthroughThreshold: 0.1,
+      noiseBand: 0.002,
+    });
+
+    expect(trend?.trend).toBe("stalled");
+    expect(trend?.best_value).toBe(0.961);
+  });
+
+  it("classifies small noise as inconclusive instead of improvement", () => {
+    const trend = classifyMetricTrend(observations([0.7, 0.704, 0.699, 0.703]), {
+      improvementThreshold: 0.02,
+      noiseBand: 0.01,
+    });
+
+    expect(trend?.trend).toBe("noisy");
+  });
+
+  it("classifies regression", () => {
+    const trend = classifyMetricTrend(observations([0.76, 0.72, 0.69, 0.66]), {
+      improvementThreshold: 0.02,
+    });
+
+    expect(trend?.trend).toBe("regressing");
+  });
+
+  it("classifies meaningful drawdown after a breakthrough as regression", () => {
+    const trend = classifyMetricTrend(observations([0.45, 0.96, 0.955, 0.94, 0.93]), {
+      improvementThreshold: 0.01,
+      breakthroughThreshold: 0.1,
+    });
+
+    expect(trend?.trend).toBe("regressing");
+    expect(trend?.best_value).toBe(0.96);
+    expect(trend?.latest_value).toBe(0.93);
+  });
+
+  it("classifies a large breakthrough jump", () => {
+    const trend = classifyMetricTrend(observations([0.51, 0.52, 0.53, 0.76]), {
+      improvementThreshold: 0.02,
+      breakthroughThreshold: 0.1,
+    });
+
+    expect(trend?.trend).toBe("breakthrough");
+    expect(trend?.last_breakthrough_delta).toBeCloseTo(0.23);
+  });
+});

--- a/src/platform/drive/__tests__/stall-detector.test.ts
+++ b/src/platform/drive/__tests__/stall-detector.test.ts
@@ -5,10 +5,36 @@ import { StateManager } from "../../../base/state/state-manager.js";
 import { StallDetector } from "../stall-detector.js";
 import { ProgressPredictor } from "../progress-predictor.js";
 import type { StallState } from "../../../base/types/stall.js";
+import type { MetricTrendContext } from "../metric-history.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 
 function makeGapHistory(values: number[]): Array<{ normalized_gap: number }> {
   return values.map((v) => ({ normalized_gap: v }));
+}
+
+function makeMetricTrendContext(overrides: Partial<MetricTrendContext> = {}): MetricTrendContext {
+  return {
+    metric_key: "dim-a",
+    direction: "maximize",
+    trend: "stalled",
+    latest_value: 0.7,
+    latest_observed_at: "2026-04-30T00:05:00.000Z",
+    best_value: 0.7,
+    best_observed_at: "2026-04-30T00:00:00.000Z",
+    observation_count: 6,
+    recent_slope_per_observation: 0,
+    best_delta: 0,
+    last_meaningful_improvement_delta: null,
+    last_breakthrough_delta: null,
+    time_since_last_meaningful_improvement_ms: null,
+    improvement_threshold: 0.01,
+    breakthrough_threshold: 0.05,
+    noise_band: 0.005,
+    confidence: 0.9,
+    source_refs: [{ entry_id: "entry-1", kind: "metric" }],
+    summary: "dim-a trend is stalled",
+    ...overrides,
+  };
 }
 
 // ─── Test Setup ───
@@ -140,6 +166,38 @@ describe("checkDimensionStall", () => {
     // Improvement of 0.10 (from 0.5 to 0.40) — at or above MIN_IMPROVEMENT_DELTA → no stall
     const history = makeGapHistory([0.5, 0.5, 0.5, 0.5, 0.5, 0.40]);
     const result = detector.checkDimensionStall("goal-1", "dim-a", history);
+    expect(result).toBeNull();
+  });
+
+  it("uses stalled metric history as stronger stall evidence even when gap history is short", () => {
+    const result = detector.checkDimensionStall(
+      "goal-1",
+      "dim-a",
+      makeGapHistory([0.5, 0.5]),
+      undefined,
+      makeMetricTrendContext({ trend: "stalled" })
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.stall_type).toBe("dimension_stall");
+    expect(result?.metric_trend_context?.trend).toBe("stalled");
+  });
+
+  it("suppresses gap-only stall when metric history shows a breakthrough", () => {
+    const result = detector.checkDimensionStall(
+      "goal-1",
+      "dim-a",
+      makeGapHistory([0.5, 0.5, 0.5, 0.5, 0.5, 0.5]),
+      undefined,
+      makeMetricTrendContext({
+        trend: "breakthrough",
+        latest_value: 0.9,
+        best_value: 0.9,
+        best_delta: 0.2,
+        last_breakthrough_delta: 0.2,
+      })
+    );
+
     expect(result).toBeNull();
   });
 });

--- a/src/platform/drive/metric-history.ts
+++ b/src/platform/drive/metric-history.ts
@@ -1,0 +1,296 @@
+export type MetricDirection = "maximize" | "minimize";
+
+export type MetricTrend = "improving" | "stalled" | "noisy" | "regressing" | "breakthrough";
+
+export interface MetricObservationSource {
+  entry_id: string;
+  kind: string;
+  summary?: string;
+  metric_source?: string;
+  artifacts?: Array<{ label: string; path?: string; state_relative_path?: string; url?: string }>;
+  raw_refs?: Array<{ kind: string; id?: string; path?: string; state_relative_path?: string; url?: string }>;
+}
+
+export interface MetricObservation {
+  observed_at: string;
+  metric_key: string;
+  value: number;
+  direction: MetricDirection;
+  confidence: number;
+  source: MetricObservationSource;
+}
+
+export interface MetricTrendContext {
+  metric_key: string;
+  direction: MetricDirection;
+  trend: MetricTrend;
+  latest_value: number;
+  latest_observed_at: string;
+  best_value: number;
+  best_observed_at: string;
+  observation_count: number;
+  recent_slope_per_observation: number;
+  best_delta: number;
+  last_meaningful_improvement_delta: number | null;
+  last_breakthrough_delta: number | null;
+  time_since_last_meaningful_improvement_ms: number | null;
+  improvement_threshold: number;
+  breakthrough_threshold: number;
+  noise_band: number;
+  confidence: number;
+  source_refs: MetricObservationSource[];
+  summary: string;
+}
+
+export interface MetricTrendClassificationOptions {
+  improvementThreshold?: number;
+  breakthroughThreshold?: number;
+  noiseBand?: number;
+  now?: Date;
+  recentWindowSize?: number;
+}
+
+const DEFAULT_IMPROVEMENT_THRESHOLD = 0.01;
+const DEFAULT_BREAKTHROUGH_THRESHOLD = 0.05;
+const DEFAULT_NOISE_BAND = 0.005;
+const DEFAULT_RECENT_WINDOW_SIZE = 5;
+
+export function classifyMetricTrend(
+  observations: MetricObservation[],
+  options: MetricTrendClassificationOptions = {}
+): MetricTrendContext | null {
+  const sorted = observations
+    .filter((observation) => Number.isFinite(observation.value))
+    .sort((left, right) => left.observed_at.localeCompare(right.observed_at));
+  if (sorted.length === 0) return null;
+
+  const metricKey = sorted[0]!.metric_key;
+  const direction = sorted[0]!.direction;
+  const sameMetric = sorted.filter((observation) =>
+    observation.metric_key === metricKey && observation.direction === direction
+  );
+  if (sameMetric.length === 0) return null;
+
+  const improvementThreshold = options.improvementThreshold ?? DEFAULT_IMPROVEMENT_THRESHOLD;
+  const breakthroughThreshold = options.breakthroughThreshold ?? DEFAULT_BREAKTHROUGH_THRESHOLD;
+  const noiseBand = options.noiseBand ?? DEFAULT_NOISE_BAND;
+  const now = options.now ?? new Date();
+  const recentWindowSize = options.recentWindowSize ?? DEFAULT_RECENT_WINDOW_SIZE;
+  const normalized = sameMetric.map((observation) => normalizeValue(observation.value, direction));
+  const firstNormalized = normalized[0]!;
+  const latest = sameMetric[sameMetric.length - 1]!;
+  const latestNormalized = normalized[normalized.length - 1]!;
+  const bestIndex = indexOfMax(normalized);
+  const best = sameMetric[bestIndex]!;
+  const bestNormalized = normalized[bestIndex]!;
+  const previousBestNormalized = normalized.length > 1
+    ? Math.max(...normalized.slice(0, -1))
+    : firstNormalized;
+  const latestBestDelta = latestNormalized - previousBestNormalized;
+  const latestDeltaFromBest = latestNormalized - bestNormalized;
+  const bestDelta = bestNormalized - firstNormalized;
+  const recentNormalized = normalized.slice(-recentWindowSize);
+  const recentSlope = linearSlope(recentNormalized);
+  const minRecent = Math.min(...recentNormalized);
+  const maxRecent = Math.max(...recentNormalized);
+  const recentRange = maxRecent - minRecent;
+  const latestDeltaFromFirst = latestNormalized - firstNormalized;
+  const meaningfulDeltas = normalized
+    .slice(1)
+    .map((value, index) => ({
+      delta: value - normalized[index]!,
+      observedAt: sameMetric[index + 1]!.observed_at,
+      observedIndex: index + 1,
+    }))
+    .filter((entry) => entry.delta >= improvementThreshold);
+  const breakthroughDeltas = normalized
+    .slice(1)
+    .map((value, index) => value - normalized[index]!)
+    .filter((delta) => delta >= breakthroughThreshold);
+  const lastMeaningfulImprovement = meaningfulDeltas[meaningfulDeltas.length - 1] ?? null;
+  const postImprovementValues = lastMeaningfulImprovement
+    ? normalized.slice(lastMeaningfulImprovement.observedIndex)
+    : normalized;
+  const postImprovementRange = postImprovementValues.length > 0
+    ? Math.max(...postImprovementValues) - Math.min(...postImprovementValues)
+    : 0;
+  const observationsSinceLastMeaningfulImprovement = lastMeaningfulImprovement
+    ? (normalized.length - 1) - lastMeaningfulImprovement.observedIndex
+    : null;
+  const timeSinceLastMeaningfulImprovementMs = lastMeaningfulImprovement
+    ? Math.max(0, now.getTime() - Date.parse(lastMeaningfulImprovement.observedAt))
+    : null;
+
+  const trend = classifyTrend({
+    count: sameMetric.length,
+    latestBestDelta,
+    latestDeltaFromBest,
+    latestDeltaFromFirst,
+    bestDelta,
+    recentSlope,
+    recentRange,
+    postImprovementRange,
+    observationsSinceLastMeaningfulImprovement,
+    improvementThreshold,
+    breakthroughThreshold,
+    noiseBand,
+  });
+  const confidence = computeConfidence(sameMetric, trend, recentRange, noiseBand);
+  const context: MetricTrendContext = {
+    metric_key: metricKey,
+    direction,
+    trend,
+    latest_value: latest.value,
+    latest_observed_at: latest.observed_at,
+    best_value: best.value,
+    best_observed_at: best.observed_at,
+    observation_count: sameMetric.length,
+    recent_slope_per_observation: denormalizeDelta(recentSlope, direction),
+    best_delta: denormalizeDelta(bestDelta, direction),
+    last_meaningful_improvement_delta: lastMeaningfulImprovement
+      ? denormalizeDelta(lastMeaningfulImprovement.delta, direction)
+      : null,
+    last_breakthrough_delta: breakthroughDeltas.length > 0
+      ? denormalizeDelta(breakthroughDeltas[breakthroughDeltas.length - 1]!, direction)
+      : null,
+    time_since_last_meaningful_improvement_ms: timeSinceLastMeaningfulImprovementMs,
+    improvement_threshold: denormalizeDelta(improvementThreshold, direction),
+    breakthrough_threshold: denormalizeDelta(breakthroughThreshold, direction),
+    noise_band: denormalizeDelta(noiseBand, direction),
+    confidence,
+    source_refs: sameMetric.slice(-recentWindowSize).map((observation) => observation.source),
+    summary: buildMetricTrendSummary(metricKey, trend, latest.value, best.value, sameMetric.length),
+  };
+  return context;
+}
+
+export function summarizeMetricTrends(
+  observations: MetricObservation[],
+  options: MetricTrendClassificationOptions = {}
+): MetricTrendContext[] {
+  const groups = new Map<string, MetricObservation[]>();
+  for (const observation of observations) {
+    const key = `${observation.metric_key}\0${observation.direction}`;
+    const existing = groups.get(key) ?? [];
+    existing.push(observation);
+    groups.set(key, existing);
+  }
+  return [...groups.values()]
+    .map((group) => classifyMetricTrend(group, options))
+    .filter((trend): trend is MetricTrendContext => trend !== null);
+}
+
+export function formatMetricTrendContext(context: MetricTrendContext): string {
+  const since = context.time_since_last_meaningful_improvement_ms === null
+    ? "no meaningful improvement recorded"
+    : `${Math.round(context.time_since_last_meaningful_improvement_ms / 60_000)}m since meaningful improvement`;
+  return `${context.metric_key} ${context.trend}: latest=${context.latest_value}, best=${context.best_value}, slope=${roundMetric(context.recent_slope_per_observation)}, ${since}`;
+}
+
+function classifyTrend(input: {
+  count: number;
+  latestBestDelta: number;
+  latestDeltaFromBest: number;
+  latestDeltaFromFirst: number;
+  bestDelta: number;
+  recentSlope: number;
+  recentRange: number;
+  postImprovementRange: number;
+  observationsSinceLastMeaningfulImprovement: number | null;
+  improvementThreshold: number;
+  breakthroughThreshold: number;
+  noiseBand: number;
+}): MetricTrend {
+  if (input.count < 2) return "noisy";
+  if (input.latestBestDelta >= input.breakthroughThreshold) return "breakthrough";
+  if (input.latestBestDelta >= input.improvementThreshold) return "improving";
+  if (input.latestDeltaFromBest <= -input.improvementThreshold) {
+    return "regressing";
+  }
+  if (
+    input.observationsSinceLastMeaningfulImprovement !== null
+    && input.observationsSinceLastMeaningfulImprovement >= 2
+    && input.postImprovementRange <= input.noiseBand
+  ) {
+    return "stalled";
+  }
+  if (input.latestDeltaFromFirst <= -input.improvementThreshold || input.recentSlope <= -input.improvementThreshold) {
+    return "regressing";
+  }
+  if (input.recentSlope >= input.improvementThreshold) {
+    return "improving";
+  }
+  if (input.recentRange === 0 || input.recentRange <= Number.EPSILON) return "stalled";
+  if (input.recentRange <= input.noiseBand || Math.abs(input.recentSlope) < input.noiseBand) {
+    return input.bestDelta >= input.improvementThreshold ? "stalled" : "noisy";
+  }
+  if (input.bestDelta < input.improvementThreshold) return "stalled";
+  return "noisy";
+}
+
+function computeConfidence(
+  observations: MetricObservation[],
+  trend: MetricTrend,
+  recentRange: number,
+  noiseBand: number
+): number {
+  const meanObservationConfidence = observations.reduce((sum, observation) => sum + observation.confidence, 0) / observations.length;
+  const sampleConfidence = Math.min(1, observations.length / 5);
+  const trendConfidence = trend === "noisy"
+    ? Math.max(0.35, Math.min(0.75, noiseBand / Math.max(recentRange, Number.EPSILON)))
+    : 1;
+  return clamp01(meanObservationConfidence * sampleConfidence * trendConfidence);
+}
+
+function normalizeValue(value: number, direction: MetricDirection): number {
+  return direction === "maximize" ? value : -value;
+}
+
+function denormalizeDelta(delta: number, direction: MetricDirection): number {
+  return direction === "maximize" ? delta : -delta;
+}
+
+function indexOfMax(values: number[]): number {
+  let bestIndex = 0;
+  for (let index = 1; index < values.length; index += 1) {
+    if (values[index]! > values[bestIndex]!) bestIndex = index;
+  }
+  return bestIndex;
+}
+
+function linearSlope(values: number[]): number {
+  const n = values.length;
+  if (n < 2) return 0;
+  let sumX = 0;
+  let sumY = 0;
+  let sumXY = 0;
+  let sumXX = 0;
+  for (let index = 0; index < n; index += 1) {
+    const value = values[index]!;
+    sumX += index;
+    sumY += value;
+    sumXY += index * value;
+    sumXX += index * index;
+  }
+  const denominator = n * sumXX - sumX * sumX;
+  if (denominator === 0) return 0;
+  return (n * sumXY - sumX * sumY) / denominator;
+}
+
+function buildMetricTrendSummary(
+  metricKey: string,
+  trend: MetricTrend,
+  latestValue: number,
+  bestValue: number,
+  observationCount: number
+): string {
+  return `${metricKey} trend is ${trend} from ${observationCount} observation(s); latest=${latestValue}, best=${bestValue}`;
+}
+
+function roundMetric(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
+function clamp01(value: number): number {
+  return Math.max(0, Math.min(1, value));
+}

--- a/src/platform/drive/progress-predictor.ts
+++ b/src/platform/drive/progress-predictor.ts
@@ -1,3 +1,5 @@
+import type { MetricTrendContext } from "./metric-history.js";
+
 export interface PredictionResult {
   predictedGapScore: number;              // predicted next gap score (clamped 0-1)
   confidence: number;                     // R² of linear fit (0-1)
@@ -107,6 +109,31 @@ export class ProgressPredictor {
       trend,
       predictedIterationsToGoal,
       slopePerIteration: slope,
+    };
+  }
+
+  /**
+   * Convert outcome-metric trend context into the existing gap-oriented
+   * prediction shape. Metric trend slope is outcome-oriented, so improving
+   * metrics map to decreasing gap.
+   */
+  predictMetricTrend(context: MetricTrendContext): PredictionResult {
+    const trend =
+      context.trend === "regressing" ? "worsening"
+        : context.trend === "stalled" || context.trend === "noisy" ? "stable"
+          : "improving";
+    const slopePerIteration = -Math.abs(context.recent_slope_per_observation);
+    const gapSlope = trend === "worsening"
+      ? Math.abs(context.recent_slope_per_observation)
+      : trend === "stable"
+        ? 0
+        : slopePerIteration;
+    return {
+      predictedGapScore: trend === "worsening" ? 1 : trend === "stable" ? 0.5 : 0,
+      confidence: context.confidence,
+      trend,
+      predictedIterationsToGoal: null,
+      slopePerIteration: gapSlope,
     };
   }
 }

--- a/src/platform/drive/stall-detector.ts
+++ b/src/platform/drive/stall-detector.ts
@@ -11,6 +11,7 @@ import {
   getAdjustedN,
   isZeroProgress,
 } from "./stall-detector/thresholds.js";
+import type { MetricTrendContext } from "./metric-history.js";
 
 // ─── Minimum score-improvement delta to reset stall detection ───
 // Improvements smaller than this are treated as noise (no reset).
@@ -92,8 +93,14 @@ export class StallDetector {
     goalId: string,
     dimensionName: string,
     gapHistory: Array<{ normalized_gap: number }>,
-    feedbackCategory?: string
+    feedbackCategory?: string,
+    metricTrendContext?: MetricTrendContext
   ): StallReport | null {
+    const metricTrendReport = this.checkMetricTrendStall(goalId, dimensionName, metricTrendContext);
+    if (metricTrendReport || metricTrendContext?.trend === "improving" || metricTrendContext?.trend === "breakthrough") {
+      return metricTrendReport;
+    }
+
     const n = this.getAdjustedN(feedbackCategory);
 
     if (gapHistory.length < n + 1) {
@@ -113,6 +120,7 @@ export class StallDetector {
         escalation_level: 0,
         suggested_cause: "approach_failure",
         decay_factor: DECAY_FACTOR_STALLED,
+        ...(metricTrendContext ? { metric_trend_context: metricTrendContext } : {}),
       });
     }
 
@@ -141,6 +149,7 @@ export class StallDetector {
       escalation_level: 0,
       suggested_cause: "approach_failure",
       decay_factor: DECAY_FACTOR_STALLED,
+      ...(metricTrendContext ? { metric_trend_context: metricTrendContext } : {}),
     });
   }
 
@@ -472,6 +481,44 @@ export class StallDetector {
     }
 
     return null;
+  }
+
+  private checkMetricTrendStall(
+    goalId: string,
+    dimensionName: string,
+    metricTrendContext?: MetricTrendContext
+  ): StallReport | null {
+    if (!metricTrendContext) return null;
+    if (metricTrendContext.trend === "improving" || metricTrendContext.trend === "breakthrough") {
+      if (this.predictor) {
+        this.predictor.predictMetricTrend(metricTrendContext);
+      }
+      return null;
+    }
+    if (metricTrendContext.trend === "noisy") {
+      if (this.predictor) {
+        this.predictor.predictMetricTrend(metricTrendContext);
+      }
+      return null;
+    }
+
+    const prediction = this.predictor?.predictMetricTrend(metricTrendContext);
+    const decayFactor = metricTrendContext.trend === "regressing"
+      ? 0.5
+      : prediction?.trend === "stable"
+        ? 0.3
+        : DECAY_FACTOR_STALLED;
+    return StallReportSchema.parse({
+      stall_type: "dimension_stall",
+      goal_id: goalId,
+      dimension_name: dimensionName,
+      task_id: null,
+      detected_at: new Date().toISOString(),
+      escalation_level: 0,
+      suggested_cause: "approach_failure",
+      decay_factor: decayFactor,
+      metric_trend_context: metricTrendContext,
+    });
   }
 
   /**

--- a/src/platform/drive/types/stall.ts
+++ b/src/platform/drive/types/stall.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { StallTypeEnum, StallCauseEnum } from "../../../base/types/core.js";
+import type { MetricTrendContext } from "../metric-history.js";
 
 // --- StallAnalysis (M14-S2: cause analysis for PIVOT/REFINE/ESCALATE) ---
 
@@ -22,6 +23,7 @@ export const StallReportSchema = z.object({
   escalation_level: z.number().min(0).max(3).default(0),
   suggested_cause: StallCauseEnum,
   decay_factor: z.number().min(0).max(1),
+  metric_trend_context: z.custom<MetricTrendContext>().optional(),
 });
 export type StallReport = z.infer<typeof StallReportSchema>;
 

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -64,6 +64,57 @@ describe("RuntimeEvidenceLedger", () => {
     expect(summary.total_entries).toBe(2);
     expect(summary.warnings).toHaveLength(1);
     expect(summary.best_evidence?.summary).toBe("Accuracy improved to 0.82.");
+    expect(summary.metric_trends[0]).toMatchObject({
+      metric_key: "accuracy",
+      trend: "noisy",
+      latest_value: 0.82,
+    });
     expect(summary.recent_failed_attempts[0]?.summary).toBe("Verification failed.");
+  });
+
+  it("stores metric provenance fields and summarizes trend history", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      kind: "metric",
+      scope: { goal_id: "goal-c" },
+      metrics: [{
+        label: "accuracy",
+        value: 0.72,
+        direction: "maximize",
+        confidence: 0.8,
+        observed_at: "2026-04-30T00:00:00.000Z",
+        source: "local-metrics.json",
+      }],
+      artifacts: [{ label: "metrics", state_relative_path: "experiments/a/metrics.json", kind: "metrics" }],
+      summary: "Initial local metric.",
+      outcome: "continued",
+    });
+    await ledger.append({
+      kind: "metric",
+      scope: { goal_id: "goal-c" },
+      metrics: [{
+        label: "accuracy",
+        value: 0.91,
+        direction: "maximize",
+        confidence: 0.9,
+        observed_at: "2026-04-30T00:10:00.000Z",
+        source: "local-metrics.json",
+      }],
+      artifacts: [{ label: "metrics", state_relative_path: "experiments/b/metrics.json", kind: "metrics" }],
+      summary: "New best local metric.",
+      outcome: "improved",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-c");
+
+    expect(summary.metric_trends).toHaveLength(1);
+    expect(summary.metric_trends[0]).toMatchObject({
+      metric_key: "accuracy",
+      trend: "breakthrough",
+      best_value: 0.91,
+      latest_value: 0.91,
+    });
+    expect(summary.metric_trends[0]?.source_refs[0]?.artifacts?.[0]?.state_relative_path).toBe("experiments/a/metrics.json");
+    expect(summary.metric_trends[0]?.source_refs[0]?.metric_source).toBe("local-metrics.json");
   });
 });

--- a/src/runtime/__tests__/runtime-metric-history.test.ts
+++ b/src/runtime/__tests__/runtime-metric-history.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { selectMetricTrendForDimension, type MetricTrendContext } from "../store/metric-history.js";
+
+function trend(metricKey: string): MetricTrendContext {
+  return {
+    metric_key: metricKey,
+    direction: "maximize",
+    trend: "improving",
+    latest_value: 0.8,
+    latest_observed_at: "2026-04-30T00:05:00.000Z",
+    best_value: 0.8,
+    best_observed_at: "2026-04-30T00:05:00.000Z",
+    observation_count: 2,
+    recent_slope_per_observation: 0.1,
+    best_delta: 0.1,
+    last_meaningful_improvement_delta: 0.1,
+    last_breakthrough_delta: null,
+    time_since_last_meaningful_improvement_ms: 0,
+    improvement_threshold: 0.01,
+    breakthrough_threshold: 0.05,
+    noise_band: 0.005,
+    confidence: 0.8,
+    source_refs: [{ entry_id: `${metricKey}-entry`, kind: "metric" }],
+    summary: `${metricKey} improving`,
+  };
+}
+
+describe("runtime metric-history selection", () => {
+  it("does not apply unrelated metric trends to a dimension", () => {
+    expect(selectMetricTrendForDimension([trend("accuracy")], "latency")).toBeUndefined();
+  });
+
+  it("allows exact or contained dimension matches", () => {
+    expect(selectMetricTrendForDimension([trend("accuracy")], "model_accuracy")?.metric_key).toBe("accuracy");
+    expect(selectMetricTrendForDimension([trend("latency")], "latency")?.metric_key).toBe("latency");
+  });
+});

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -7,6 +7,7 @@ import {
   ensureRuntimeStorePaths,
   type RuntimeStorePaths,
 } from "./runtime-paths.js";
+import { summarizeEvidenceMetricTrends, type MetricTrendContext } from "./metric-history.js";
 
 export const RuntimeEvidenceOutcomeSchema = z.enum([
   "improved",
@@ -46,6 +47,9 @@ export const RuntimeEvidenceMetricSchema = z.object({
   value: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
   unit: z.string().min(1).optional(),
   direction: z.enum(["maximize", "minimize", "neutral"]).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  observed_at: z.string().datetime().optional(),
+  source: z.string().min(1).optional(),
   summary: z.string().min(1).optional(),
 }).strict();
 export type RuntimeEvidenceMetric = z.infer<typeof RuntimeEvidenceMetricSchema>;
@@ -124,6 +128,7 @@ export interface RuntimeEvidenceSummary {
   total_entries: number;
   latest_strategy: RuntimeEvidenceEntry | null;
   best_evidence: RuntimeEvidenceEntry | null;
+  metric_trends: MetricTrendContext[];
   recent_failed_attempts: RuntimeEvidenceEntry[];
   recent_entries: RuntimeEvidenceEntry[];
   warnings: RuntimeEvidenceReadWarning[];
@@ -131,6 +136,8 @@ export interface RuntimeEvidenceSummary {
 
 export interface RuntimeEvidenceLedgerPort {
   append(input: RuntimeEvidenceEntryInput): Promise<RuntimeEvidenceEntry[]>;
+  readByGoal?(goalId: string): Promise<RuntimeEvidenceReadResult>;
+  readByRun?(runId: string): Promise<RuntimeEvidenceReadResult>;
 }
 
 export class RuntimeEvidenceLedger implements RuntimeEvidenceLedgerPort {
@@ -251,6 +258,7 @@ function summarizeEvidence(
       entry.kind === "strategy" || Boolean(entry.strategy) || Boolean(entry.decision_reason)
     ) ?? null,
     best_evidence: chooseBestEvidence(newestFirst),
+    metric_trends: summarizeEvidenceMetricTrends(entries),
     recent_failed_attempts: newestFirst
       .filter((entry) =>
         entry.outcome === "failed"

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -98,6 +98,19 @@ export type {
   RuntimeEvidenceReadWarning,
   RuntimeEvidenceSummary,
 } from "./evidence-ledger.js";
+export {
+  classifyMetricTrend,
+  extractMetricObservationsFromEvidence,
+  selectMetricTrendForDimension,
+  summarizeEvidenceMetricTrends,
+  summarizeMetricTrends,
+} from "./metric-history.js";
+export type {
+  MetricDirection,
+  MetricObservation,
+  MetricTrendClassificationOptions,
+  MetricTrendContext,
+} from "./metric-history.js";
 export type {
   RuntimeControlOperationKind,
   RuntimeControlOperationState,

--- a/src/runtime/store/metric-history.ts
+++ b/src/runtime/store/metric-history.ts
@@ -1,0 +1,82 @@
+import type { RuntimeEvidenceEntry } from "./evidence-ledger.js";
+import {
+  summarizeMetricTrends,
+  type MetricDirection,
+  type MetricObservation,
+  type MetricTrendClassificationOptions,
+  type MetricTrendContext,
+} from "../../platform/drive/metric-history.js";
+
+export {
+  classifyMetricTrend,
+  summarizeMetricTrends,
+  type MetricDirection,
+  type MetricObservation,
+  type MetricTrendClassificationOptions,
+  type MetricTrendContext,
+} from "../../platform/drive/metric-history.js";
+
+export function extractMetricObservationsFromEvidence(
+  entries: RuntimeEvidenceEntry[],
+  options: { metricKey?: string; direction?: MetricDirection } = {}
+): MetricObservation[] {
+  const observations: MetricObservation[] = [];
+  for (const entry of entries) {
+    for (const metric of entry.metrics) {
+      if (typeof metric.value !== "number" || !Number.isFinite(metric.value)) continue;
+      if (options.metricKey && metric.label !== options.metricKey) continue;
+      const direction = resolveMetricDirection(metric.direction, options.direction);
+      if (!direction) continue;
+      observations.push({
+        observed_at: metric.observed_at ?? entry.occurred_at,
+        metric_key: metric.label,
+        value: metric.value,
+        direction,
+        confidence: metric.confidence ?? entry.verification?.confidence ?? 1,
+        source: {
+          entry_id: entry.id,
+          kind: entry.kind,
+          ...(entry.summary ? { summary: entry.summary } : {}),
+          ...(metric.source ? { metric_source: metric.source } : {}),
+          artifacts: entry.artifacts.map((artifact) => ({
+            label: artifact.label,
+            ...(artifact.path ? { path: artifact.path } : {}),
+            ...(artifact.state_relative_path ? { state_relative_path: artifact.state_relative_path } : {}),
+            ...(artifact.url ? { url: artifact.url } : {}),
+          })),
+          raw_refs: entry.raw_refs.map((ref) => ({
+            kind: ref.kind,
+            ...(ref.id ? { id: ref.id } : {}),
+            ...(ref.path ? { path: ref.path } : {}),
+            ...(ref.state_relative_path ? { state_relative_path: ref.state_relative_path } : {}),
+            ...(ref.url ? { url: ref.url } : {}),
+          })),
+        },
+      });
+    }
+  }
+  return observations;
+}
+
+export function summarizeEvidenceMetricTrends(
+  entries: RuntimeEvidenceEntry[],
+  options: MetricTrendClassificationOptions = {}
+): MetricTrendContext[] {
+  return summarizeMetricTrends(extractMetricObservationsFromEvidence(entries), options);
+}
+
+export function selectMetricTrendForDimension(
+  trends: MetricTrendContext[],
+  dimensionName: string
+): MetricTrendContext | undefined {
+  return trends.find((trend) => trend.metric_key === dimensionName)
+    ?? trends.find((trend) => dimensionName.includes(trend.metric_key) || trend.metric_key.includes(dimensionName));
+}
+
+function resolveMetricDirection(
+  direction: "maximize" | "minimize" | "neutral" | undefined,
+  fallback: MetricDirection | undefined
+): MetricDirection | null {
+  if (direction === "maximize" || direction === "minimize") return direction;
+  return fallback ?? null;
+}


### PR DESCRIPTION
Closes #793

## Summary
- add provenance-aware runtime metric trend extraction from Runtime Evidence Ledger entries
- classify metric history as improving, stalled, noisy, regressing, or breakthrough, including plateau-after-breakthrough and best-so-far drawdown cases
- feed matching metric trend context into StallDetector, CoreLoop stall recovery, StrategyManager generation prompts, and runtime evidence summaries

## Verification
- npm run typecheck
- npm run lint:boundaries
- npm run test:unit
- npx vitest run --config vitest.unit.config.ts src/platform/drive/__tests__/metric-history.test.ts src/runtime/__tests__/runtime-metric-history.test.ts src/platform/drive/__tests__/stall-detector.test.ts src/runtime/__tests__/runtime-evidence-ledger.test.ts src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
- npm run test:changed (unit related tests passed; integration related lane timed out in src/interface/cli/__tests__/cli-runner-integration.test.ts, reproduced with clean HOME and appears unrelated to this diff/native-agent-loop local path)

## Known risks
- Trend-to-dimension matching is intentionally conservative: unmatched metric keys are not applied to unrelated dimensions.
- Local test:changed integration timeout is recorded in tmp/nightly-issues-793-plus-status.md and should be compared against PR CI.
