### PR TITLE
feat(runtime): add deadline finalization planning

### DIFF
--- a/src/interface/cli/commands/run.ts
+++ b/src/interface/cli/commands/run.ts
@@ -117,6 +117,21 @@ export async function cmdRun(
   console.log(`Total iterations: ${result.totalIterations}`);
   console.log(`Started at:       ${result.startedAt}`);
   console.log(`Completed at:     ${result.completedAt}`);
+  const finalizationStatus = result.iterations.at(-1)?.finalizationStatus;
+  if (finalizationStatus && finalizationStatus.mode !== "no_deadline") {
+    console.log(`Finalization:     ${finalizationStatus.mode}`);
+    console.log(`Exploration left: ${formatDurationMs(finalizationStatus.remaining_exploration_ms)}`);
+    console.log(`Reserved buffer:  ${formatDurationMs(finalizationStatus.reserved_finalization_ms)}`);
+    const plan = finalizationStatus.finalization_plan;
+    if (plan?.best_artifact) {
+      console.log(`Best artifact:    ${plan.best_artifact.label}`);
+    }
+    if (plan && plan.approval_required_actions.length > 0) {
+      console.log(
+        `Approval needed:  ${plan.approval_required_actions.map((action) => action.label).join(", ")}`
+      );
+    }
+  }
 
   switch (result.finalStatus) {
     case "completed":
@@ -130,4 +145,14 @@ export async function cmdRun(
     default:
       return 0;
   }
+}
+
+function formatDurationMs(value: number | null): string {
+  if (value === null) return "-";
+  if (value <= 0) return "0m";
+  const minutes = Math.ceil(value / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder === 0 ? `${hours}h` : `${hours}h ${remainder}m`;
 }

--- a/src/orchestrator/goal/types/goal.ts
+++ b/src/orchestrator/goal/types/goal.ts
@@ -125,6 +125,29 @@ export const ObservationOptimizationSchema = z.object({
 });
 export type ObservationOptimization = z.infer<typeof ObservationOptimizationSchema>;
 
+// --- Deadline finalization policy ---
+
+export const GoalFinalizationExternalActionSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  tool_name: z.string().min(1).optional(),
+  payload_ref: z.string().min(1).optional(),
+  approval_required: z.literal(true).default(true),
+}).strict();
+export type GoalFinalizationExternalAction = z.infer<typeof GoalFinalizationExternalActionSchema>;
+
+export const GoalFinalizationPolicySchema = z.object({
+  /** Minimum time that must be reserved before a deadline for final packaging/checks. */
+  minimum_buffer_ms: z.number().int().nonnegative(),
+  /** Earlier warning window for switching from open exploration to consolidation. */
+  consolidation_buffer_ms: z.number().int().nonnegative().default(0),
+  deliverable_contract: z.string().min(1).optional(),
+  best_artifact_selection: z.enum(["best_evidence", "latest_artifact", "latest_verified"]).default("best_evidence"),
+  verification_steps: z.array(z.string().min(1)).default([]),
+  external_actions: z.array(GoalFinalizationExternalActionSchema).default([]),
+}).strict();
+export type GoalFinalizationPolicy = z.infer<typeof GoalFinalizationPolicySchema>;
+
 // --- Goal (a node in the goal tree) ---
 
 export const GoalSchema = z.object({
@@ -154,6 +177,7 @@ export const GoalSchema = z.object({
 
   // Deadline & scheduling
   deadline: z.string().datetime().nullable().default(null),
+  finalization_policy: GoalFinalizationPolicySchema.nullable().optional(),
 
   // Negotiation metadata
   confidence_flag: z.enum(["high", "medium", "low"]).nullable().default(null),

--- a/src/orchestrator/loop/__tests__/core-loop-decision-engine.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-decision-engine.test.ts
@@ -82,6 +82,45 @@ describe("CoreDecisionEngine", () => {
     expect(decision.finalStatus).toBe("stalled");
   });
 
+  it("stops as finalization when the deadline buffer requires handoff", () => {
+    const engine = new CoreDecisionEngine();
+    const decision = engine.evaluateRunDecision({
+      iterationResult: makeIterationResult({
+        finalizationStatus: {
+          mode: "finalization",
+          deadline: "2026-04-30T01:00:00.000Z",
+          evaluated_at: "2026-04-30T00:45:00.000Z",
+          remaining_ms: 15 * 60_000,
+          reserved_finalization_ms: 30 * 60_000,
+          remaining_exploration_ms: 0,
+          consolidation_buffer_ms: 0,
+          reason: "Inside finalization buffer.",
+          finalization_plan: {
+            deliverable_contract: "Prepare final report",
+            best_artifact_selection: "best_evidence",
+            best_artifact: null,
+            verification_steps: [],
+            approval_required_actions: [],
+            handoff_required: false,
+          },
+        },
+        skipped: true,
+        skipReason: "deadline_finalization",
+      }),
+      loopIndex: 0,
+      minIterations: 1,
+      maxConsecutiveErrors: 3,
+      counters: {
+        consecutiveErrors: 0,
+        consecutiveDenied: 0,
+        consecutiveEscalations: 0,
+      },
+    });
+
+    expect(decision.shouldStop).toBe(true);
+    expect(decision.finalStatus).toBe("finalization");
+  });
+
   it("requests knowledge acquisition only for worthwhile high-confidence refresh evidence", () => {
     const engine = new CoreDecisionEngine();
     const decision = engine.evaluateKnowledgeAcquisition({

--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -406,6 +406,209 @@ describe("CoreLoop", async () => {
     fs.rmSync(tmpDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
   });
 
+  describe("deadline finalization", () => {
+    it("skips exploratory task generation at the finalization buffer and exposes the handoff plan", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      const deadline = new Date(Date.now() + 10 * 60_000).toISOString();
+      await mocks.stateManager.saveGoal(makeGoal({
+        deadline,
+        finalization_policy: {
+          minimum_buffer_ms: 30 * 60_000,
+          consolidation_buffer_ms: 0,
+          deliverable_contract: "Package the latest benchmark report",
+          best_artifact_selection: "best_evidence",
+          verification_steps: ["Run final smoke test"],
+          external_actions: [
+            {
+              id: "publish-report",
+              label: "Publish report",
+              tool_name: "publish_report",
+              payload_ref: "artifact:best",
+              approval_required: true,
+            },
+          ],
+        },
+      }));
+      const evidenceLedger = {
+        append: vi.fn().mockResolvedValue([]),
+        summarizeGoal: vi.fn().mockResolvedValue({
+          best_evidence: {
+            id: "evidence-1",
+            occurred_at: new Date().toISOString(),
+            kind: "artifact",
+            scope: { goal_id: "goal-1" },
+            metrics: [],
+            artifacts: [
+              {
+                label: "reports/final.md",
+                path: "reports/final.md",
+                kind: "report",
+              },
+            ],
+            raw_refs: [],
+            summary: "Best benchmark report",
+          },
+        }),
+      };
+
+      const loop = new CoreLoop(
+        { ...deps, evidenceLedger: evidenceLedger as any },
+        { delayBetweenLoopsMs: 0, autoDecompose: false }
+      );
+      const result = await loop.run("goal-1", { maxIterations: 3 });
+      const iteration = result.iterations[0]!;
+
+      expect(result.finalStatus).toBe("finalization");
+      expect(result.totalIterations).toBe(1);
+      expect(iteration.skipped).toBe(true);
+      expect(iteration.skipReason).toBe("deadline_finalization");
+      expect(iteration.finalizationStatus).toMatchObject({
+        mode: "finalization",
+        finalization_plan: {
+          deliverable_contract: "Package the latest benchmark report",
+          best_artifact: { label: "reports/final.md" },
+          verification_steps: ["Run final smoke test"],
+          approval_required_actions: [
+            {
+              id: "publish-report",
+              label: "Publish report",
+              tool_name: "publish_report",
+              payload_ref: "artifact:best",
+              approval_required: true,
+            },
+          ],
+        },
+      });
+      expect(mocks.taskLifecycle.runTaskCycle).not.toHaveBeenCalled();
+      expect(evidenceLedger.append).toHaveBeenCalledWith(expect.objectContaining({
+        kind: "decision",
+        scope: expect.objectContaining({ phase: "deadline_finalization" }),
+        result: expect.objectContaining({ status: "finalization" }),
+      }));
+      expect(mocks.reportingEngine.generateExecutionSummary).toHaveBeenCalledWith(
+        expect.objectContaining({
+          finalizationStatus: expect.objectContaining({ mode: "finalization" }),
+        })
+      );
+    });
+
+    it("uses the goal artifact selection rule instead of always using best_evidence", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      const deadline = new Date(Date.now() + 10 * 60_000).toISOString();
+      await mocks.stateManager.saveGoal(makeGoal({
+        deadline,
+        finalization_policy: {
+          minimum_buffer_ms: 30 * 60_000,
+          consolidation_buffer_ms: 0,
+          best_artifact_selection: "latest_artifact",
+          verification_steps: [],
+          external_actions: [],
+        },
+      }));
+      const oldBestEvidence = {
+        id: "best-evidence",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+        kind: "artifact",
+        scope: { goal_id: "goal-1" },
+        metrics: [],
+        artifacts: [{ label: "reports/best.md", path: "reports/best.md", kind: "report" }],
+        raw_refs: [],
+        summary: "Best evidence",
+      };
+      const latestArtifact = {
+        id: "latest-artifact",
+        occurred_at: "2026-04-30T00:10:00.000Z",
+        kind: "artifact",
+        scope: { goal_id: "goal-1" },
+        metrics: [],
+        artifacts: [{ label: "reports/latest.md", path: "reports/latest.md", kind: "report" }],
+        raw_refs: [],
+        summary: "Latest artifact",
+      };
+      const evidenceLedger = {
+        append: vi.fn().mockResolvedValue([]),
+        summarizeGoal: vi.fn().mockResolvedValue({ best_evidence: oldBestEvidence, recent_entries: [latestArtifact, oldBestEvidence] }),
+        readByGoal: vi.fn().mockResolvedValue({ entries: [oldBestEvidence, latestArtifact], warnings: [] }),
+      };
+
+      const loop = new CoreLoop(
+        { ...deps, evidenceLedger: evidenceLedger as any },
+        { delayBetweenLoopsMs: 0, autoDecompose: false }
+      );
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(result.finalizationStatus?.finalization_plan?.best_artifact).toMatchObject({
+        label: "reports/latest.md",
+      });
+      expect(evidenceLedger.readByGoal).toHaveBeenCalledWith("goal-1");
+    });
+
+    it("can select the latest verified artifact for finalization", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      const deadline = new Date(Date.now() + 10 * 60_000).toISOString();
+      await mocks.stateManager.saveGoal(makeGoal({
+        deadline,
+        finalization_policy: {
+          minimum_buffer_ms: 30 * 60_000,
+          consolidation_buffer_ms: 0,
+          best_artifact_selection: "latest_verified",
+          verification_steps: [],
+          external_actions: [],
+        },
+      }));
+      const latestArtifact = {
+        id: "latest-artifact",
+        occurred_at: "2026-04-30T00:10:00.000Z",
+        kind: "artifact",
+        scope: { goal_id: "goal-1" },
+        metrics: [],
+        artifacts: [{ label: "reports/latest-unverified.md", path: "reports/latest-unverified.md", kind: "report" }],
+        raw_refs: [],
+        summary: "Latest artifact without verification",
+      };
+      const latestVerified = {
+        id: "latest-verified",
+        occurred_at: "2026-04-30T00:05:00.000Z",
+        kind: "verification",
+        scope: { goal_id: "goal-1", task_id: "task-verified" },
+        verification: { verdict: "pass", confidence: 0.9, summary: "smoke passed" },
+        metrics: [],
+        artifacts: [],
+        raw_refs: [],
+        outcome: "improved",
+        summary: "Verification pass for task-verified",
+      };
+      const verifiedExecution = {
+        id: "verified-execution",
+        occurred_at: "2026-04-30T00:04:00.000Z",
+        kind: "execution",
+        scope: { goal_id: "goal-1", task_id: "task-verified" },
+        metrics: [],
+        artifacts: [{ label: "reports/verified.md", path: "reports/verified.md", kind: "report" }],
+        raw_refs: [],
+        outcome: "improved",
+        summary: "Verified artifact execution",
+      };
+      const evidenceLedger = {
+        append: vi.fn().mockResolvedValue([]),
+        readByGoal: vi.fn().mockResolvedValue({
+          entries: [latestArtifact, verifiedExecution, latestVerified],
+          warnings: [],
+        }),
+      };
+
+      const loop = new CoreLoop(
+        { ...deps, evidenceLedger: evidenceLedger as any },
+        { delayBetweenLoopsMs: 0, autoDecompose: false }
+      );
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(result.finalizationStatus?.finalization_plan?.best_artifact).toMatchObject({
+        label: "reports/verified.md",
+      });
+    });
+  });
+
   // ─── KnowledgeManager integration ───
 
   describe("KnowledgeManager integration", async () => {

--- a/src/orchestrator/loop/core-loop/contracts.ts
+++ b/src/orchestrator/loop/core-loop/contracts.ts
@@ -35,6 +35,7 @@ import type { CorePhasePolicyRegistry } from "./phase-policy.js";
 import type { CoreDecisionEngine } from "./decision-engine.js";
 import type { GoalRunActivationContext } from "../../../base/types/goal-activation.js";
 import type { RuntimeEvidenceLedgerPort } from "../../../runtime/store/evidence-ledger.js";
+import type { DeadlineFinalizationStatus } from "../../../platform/time/deadline-finalization.js";
 export type {
   LoopIterationResult,
   LoopResult,
@@ -94,6 +95,7 @@ export interface ExecutionSummaryParams {
     expired?: boolean;
     skipReason?: string;
   };
+  finalizationStatus?: DeadlineFinalizationStatus;
 }
 
 export interface ReportingEngine {

--- a/src/orchestrator/loop/core-loop/decision-engine.ts
+++ b/src/orchestrator/loop/core-loop/decision-engine.ts
@@ -188,6 +188,13 @@ export class CoreDecisionEngine {
     const next: CoreLoopRunCounters = { ...input.counters };
     const taskAction = input.iterationResult.taskResult?.action ?? null;
 
+    if (
+      input.iterationResult.finalizationStatus?.mode === "finalization" ||
+      input.iterationResult.finalizationStatus?.mode === "missed_deadline"
+    ) {
+      return { counters: next, shouldStop: true, finalStatus: "finalization" };
+    }
+
     if (input.iterationResult.completionJudgment.is_complete && input.loopIndex >= input.minIterations - 1) {
       return { counters: next, shouldStop: true, finalStatus: "completed" };
     }

--- a/src/orchestrator/loop/core-loop/iteration-kernel.ts
+++ b/src/orchestrator/loop/core-loop/iteration-kernel.ts
@@ -39,6 +39,12 @@ import {
 import type { CorePhasePolicyRegistry } from "./phase-policy.js";
 import type { CoreDecisionEngine } from "./decision-engine.js";
 import type { ITimeHorizonEngine } from "../../../platform/time/time-horizon-engine.js";
+import {
+  buildDeadlineFinalizationStatus,
+  normalizeFinalizationPolicy,
+  shouldStopExplorationForFinalization,
+  type DeadlineFinalizationArtifact,
+} from "../../../platform/time/deadline-finalization.js";
 import type { DriveScore } from "../../../base/types/drive.js";
 import type { CorePhaseKind } from "../../execution/agent-loop/core-phase-runner.js";
 import { findActiveWaitObservationInput } from "./iteration-kernel-wait.js";
@@ -48,6 +54,7 @@ import {
 } from "./iteration-kernel-knowledge.js";
 import type { GoalRunActivationContext } from "../../../base/types/goal-activation.js";
 import type {
+  RuntimeEvidenceEntry,
   RuntimeEvidenceEntryInput,
   RuntimeEvidenceEntryKind,
   RuntimeEvidenceOutcome,
@@ -247,6 +254,39 @@ export class CoreIterationKernel {
         .map((g: any) => `${g.dimension_name}=${g.normalized_weighted_gap.toFixed(2)}`)
         .join(", ")}`
     );
+
+    const finalizationStatus = await runPhase("deadline-finalization", async () =>
+      buildDeadlineFinalizationStatus({
+        goal,
+        bestArtifact: await loadBestFinalizationArtifact(
+          this.deps.deps.evidenceLedger,
+          goalId,
+          normalizeFinalizationPolicy(goal.finalization_policy).best_artifact_selection
+        ),
+      })
+    );
+    result.finalizationStatus = finalizationStatus;
+    if (shouldStopExplorationForFinalization(finalizationStatus)) {
+      result.skipped = true;
+      result.skipReason =
+        finalizationStatus.mode === "missed_deadline"
+          ? "deadline_missed_finalization"
+          : "deadline_finalization";
+      await appendRuntimeEvidence({
+        kind: "decision",
+        summary: finalizationStatus.reason,
+        outcome: "blocked",
+        decision_reason: finalizationStatus.reason,
+        scope: { phase: "deadline_finalization" },
+        result: {
+          status: finalizationStatus.mode,
+          summary: finalizationStatus.finalization_plan?.deliverable_contract ?? finalizationStatus.reason,
+        },
+      });
+      await generateLoopReport(goalId, loopIndex, result, goal, this.deps.deps.reportingEngine, this.deps.logger);
+      result.elapsedMs = Date.now() - startTime;
+      return result;
+    }
 
     const activeWait = await findActiveWaitObservationInput(
       this.deps.deps,
@@ -613,6 +653,69 @@ export class CoreIterationKernel {
     result.elapsedMs = Date.now() - startTime;
     return result;
   }
+}
+
+async function loadBestFinalizationArtifact(
+  evidenceLedger: CoreLoopDeps["evidenceLedger"],
+  goalId: string,
+  selection: "best_evidence" | "latest_artifact" | "latest_verified"
+): Promise<DeadlineFinalizationArtifact | null> {
+  if (!evidenceLedger) return null;
+  try {
+    if (selection === "best_evidence") {
+      const summary = await evidenceLedger.summarizeGoal?.(goalId);
+      return summary?.best_evidence ? bestArtifactFromEvidence(summary.best_evidence) : null;
+    }
+
+    const entries = evidenceLedger.readByGoal
+      ? (await evidenceLedger.readByGoal(goalId)).entries
+      : (await evidenceLedger.summarizeGoal?.(goalId))?.recent_entries ?? [];
+    const newestFirst = [...entries].sort((a, b) => b.occurred_at.localeCompare(a.occurred_at));
+    const selected =
+      selection === "latest_artifact"
+        ? newestFirst.find((entry) => entry.artifacts.length > 0 || entry.kind === "artifact")
+        : selectLatestVerifiedArtifact(newestFirst);
+    return selected ? bestArtifactFromEvidence(selected) : null;
+  } catch {
+    return null;
+  }
+}
+
+function selectLatestVerifiedArtifact(
+  entriesNewestFirst: RuntimeEvidenceEntry[]
+): RuntimeEvidenceEntry | undefined {
+  for (const verification of entriesNewestFirst) {
+    const verified =
+      verification.verification?.verdict === "pass"
+      || (verification.kind === "verification" && verification.outcome === "improved");
+    if (!verified) continue;
+    if (verification.artifacts.length > 0) return verification;
+
+    const taskId = verification.scope.task_id;
+    if (!taskId) continue;
+    const matchedArtifact = entriesNewestFirst.find((entry) =>
+      entry.scope.task_id === taskId
+      && entry.occurred_at <= verification.occurred_at
+      && entry.artifacts.length > 0
+    );
+    if (matchedArtifact) return matchedArtifact;
+  }
+  return undefined;
+}
+
+function bestArtifactFromEvidence(entry: RuntimeEvidenceEntry): DeadlineFinalizationArtifact {
+  const primaryArtifact = entry.artifacts[0];
+  return {
+    id: primaryArtifact?.label ?? entry.id,
+    label: primaryArtifact?.label ?? entry.summary ?? entry.result?.summary ?? entry.id,
+    kind: primaryArtifact?.kind ?? entry.kind,
+    summary: entry.summary ?? entry.result?.summary ?? entry.verification?.summary,
+    path: primaryArtifact?.path,
+    state_relative_path: primaryArtifact?.state_relative_path,
+    url: primaryArtifact?.url,
+    occurred_at: entry.occurred_at,
+    source: "runtime_evidence_ledger",
+  };
 }
 
 async function appendPhaseEvidence(

--- a/src/orchestrator/loop/loop-report-helper.ts
+++ b/src/orchestrator/loop/loop-report-helper.ts
@@ -60,6 +60,9 @@ export async function generateLoopReport(
       pivotOccurred: iterationResult.pivotOccurred,
       elapsedMs: iterationResult.elapsedMs,
       ...(waitStatus ? { waitStatus } : {}),
+      ...(iterationResult.finalizationStatus && iterationResult.finalizationStatus.mode !== "no_deadline"
+        ? { finalizationStatus: iterationResult.finalizationStatus }
+        : {}),
     });
     await reportingEngine.saveReport(report);
   } catch (err) {

--- a/src/orchestrator/loop/loop-result-types.ts
+++ b/src/orchestrator/loop/loop-result-types.ts
@@ -2,6 +2,7 @@ import type { DriveScore } from "../../base/types/drive.js";
 import type { CompletionJudgment } from "../../base/types/satisficing.js";
 import type { StallAnalysis, StallReport } from "../../base/types/stall.js";
 import type { MetricTrendContext } from "../../platform/drive/metric-history.js";
+import type { DeadlineFinalizationStatus } from "../../platform/time/deadline-finalization.js";
 import type { TransferCandidate } from "../../base/types/cross-portfolio.js";
 import type { WaitExpiryOutcome } from "../../base/types/strategy.js";
 import type { TaskCycleResult } from "../execution/task/task-execution-types.js";
@@ -40,6 +41,8 @@ export interface LoopIterationResult {
   stallAnalysis?: StallAnalysis;
   /** Outcome metric trend that informed stall/recovery decisions. */
   metricTrendContext?: MetricTrendContext;
+  /** Deadline-aware finalization planning state for this iteration. */
+  finalizationStatus?: DeadlineFinalizationStatus;
   pivotOccurred: boolean;
   completionJudgment: CompletionJudgment;
   elapsedMs: number;
@@ -114,7 +117,7 @@ export function makeEmptyIterationResult(
 export interface LoopResult {
   goalId: string;
   totalIterations: number;
-  finalStatus: "completed" | "stalled" | "max_iterations" | "error" | "stopped";
+  finalStatus: "completed" | "stalled" | "max_iterations" | "error" | "stopped" | "finalization";
   iterations: LoopIterationResult[];
   startedAt: string;
   completedAt: string;

--- a/src/platform/time/__tests__/deadline-finalization.test.ts
+++ b/src/platform/time/__tests__/deadline-finalization.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import type { Goal } from "../../../base/types/goal.js";
+import { makeGoal } from "../../../../tests/helpers/fixtures.js";
+import {
+  buildDeadlineFinalizationStatus,
+  shouldStopExplorationForFinalization,
+} from "../deadline-finalization.js";
+
+const NOW = new Date("2026-04-30T00:00:00.000Z");
+
+function deadlineIn(ms: number): string {
+  return new Date(NOW.getTime() + ms).toISOString();
+}
+
+function finalizationPolicy(
+  overrides: Partial<NonNullable<Goal["finalization_policy"]>> = {}
+): NonNullable<Goal["finalization_policy"]> {
+  return {
+    minimum_buffer_ms: 30 * 60_000,
+    consolidation_buffer_ms: 0,
+    best_artifact_selection: "best_evidence" as const,
+    verification_steps: [],
+    external_actions: [],
+    ...overrides,
+  };
+}
+
+describe("deadline finalization planning", () => {
+  it("returns no_deadline when the goal has no deadline", () => {
+    const status = buildDeadlineFinalizationStatus({
+      goal: makeGoal({ deadline: null }),
+      now: NOW,
+    });
+
+    expect(status.mode).toBe("no_deadline");
+    expect(status.remaining_exploration_ms).toBeNull();
+    expect(status.finalization_plan).toBeNull();
+    expect(shouldStopExplorationForFinalization(status)).toBe(false);
+  });
+
+  it("keeps exploration open when the deadline is far beyond the reserved buffer", () => {
+    const status = buildDeadlineFinalizationStatus({
+      goal: makeGoal({
+        deadline: deadlineIn(120 * 60_000),
+        finalization_policy: finalizationPolicy({
+          consolidation_buffer_ms: 15 * 60_000,
+        }),
+      }),
+      now: NOW,
+    });
+
+    expect(status.mode).toBe("exploration");
+    expect(status.remaining_exploration_ms).toBe(90 * 60_000);
+    expect(shouldStopExplorationForFinalization(status)).toBe(false);
+  });
+
+  it("enters consolidation before the finalization buffer is reached", () => {
+    const status = buildDeadlineFinalizationStatus({
+      goal: makeGoal({
+        deadline: deadlineIn(40 * 60_000),
+        finalization_policy: finalizationPolicy({
+          consolidation_buffer_ms: 15 * 60_000,
+        }),
+      }),
+      now: NOW,
+    });
+
+    expect(status.mode).toBe("consolidation");
+    expect(status.remaining_exploration_ms).toBe(10 * 60_000);
+    expect(shouldStopExplorationForFinalization(status)).toBe(false);
+  });
+
+  it("enters finalization when the reserved buffer threshold is reached", () => {
+    const status = buildDeadlineFinalizationStatus({
+      goal: makeGoal({
+        deadline: deadlineIn(25 * 60_000),
+        finalization_policy: finalizationPolicy({
+          deliverable_contract: "Final report ready for handoff",
+          verification_steps: ["Run smoke test", "Confirm artifact path"],
+        }),
+      }),
+      now: NOW,
+      bestArtifact: {
+        id: "artifact-1",
+        label: "best-report.md",
+        source: "runtime_evidence_ledger",
+      },
+    });
+
+    expect(status.mode).toBe("finalization");
+    expect(status.finalization_plan).toMatchObject({
+      deliverable_contract: "Final report ready for handoff",
+      best_artifact: { label: "best-report.md" },
+      verification_steps: ["Run smoke test", "Confirm artifact path"],
+    });
+    expect(shouldStopExplorationForFinalization(status)).toBe(true);
+  });
+
+  it("marks a missed deadline as handoff-only finalization", () => {
+    const status = buildDeadlineFinalizationStatus({
+      goal: makeGoal({
+        deadline: deadlineIn(-1_000),
+        finalization_policy: finalizationPolicy(),
+      }),
+      now: NOW,
+    });
+
+    expect(status.mode).toBe("missed_deadline");
+    expect(status.remaining_ms).toBe(-1_000);
+    expect(shouldStopExplorationForFinalization(status)).toBe(true);
+  });
+
+  it("keeps external final actions approval-gated", () => {
+    const status = buildDeadlineFinalizationStatus({
+      goal: makeGoal({
+        deadline: deadlineIn(10 * 60_000),
+        finalization_policy: finalizationPolicy({
+          external_actions: [
+            {
+              id: "submit",
+              label: "Submit final artifact",
+              tool_name: "external_submit",
+              payload_ref: "artifact:best",
+              approval_required: true,
+            },
+          ],
+        }),
+      }),
+      now: NOW,
+    });
+
+    expect(status.finalization_plan?.approval_required_actions).toEqual([
+      {
+        id: "submit",
+        label: "Submit final artifact",
+        tool_name: "external_submit",
+        payload_ref: "artifact:best",
+        approval_required: true,
+      },
+    ]);
+    expect(status.finalization_plan?.handoff_required).toBe(true);
+  });
+});

--- a/src/platform/time/deadline-finalization.ts
+++ b/src/platform/time/deadline-finalization.ts
@@ -1,0 +1,196 @@
+import type {
+  Goal,
+  GoalFinalizationExternalAction,
+  GoalFinalizationPolicy,
+} from "../../base/types/goal.js";
+
+export type DeadlineFinalizationMode =
+  | "no_deadline"
+  | "exploration"
+  | "consolidation"
+  | "finalization"
+  | "missed_deadline";
+
+export interface DeadlineFinalizationArtifact {
+  id?: string;
+  label: string;
+  kind?: string;
+  summary?: string;
+  path?: string;
+  state_relative_path?: string;
+  url?: string;
+  occurred_at?: string;
+  source: "runtime_evidence_ledger" | "policy" | "none";
+}
+
+export interface DeadlineFinalizationAction {
+  id: string;
+  label: string;
+  tool_name?: string;
+  payload_ref?: string;
+  approval_required: true;
+}
+
+export interface DeadlineFinalizationPlan {
+  deliverable_contract: string | null;
+  best_artifact_selection: GoalFinalizationPolicy["best_artifact_selection"];
+  best_artifact: DeadlineFinalizationArtifact | null;
+  verification_steps: string[];
+  approval_required_actions: DeadlineFinalizationAction[];
+  handoff_required: boolean;
+}
+
+export interface DeadlineFinalizationStatus {
+  mode: DeadlineFinalizationMode;
+  deadline: string | null;
+  evaluated_at: string;
+  remaining_ms: number | null;
+  reserved_finalization_ms: number;
+  remaining_exploration_ms: number | null;
+  consolidation_buffer_ms: number;
+  finalization_plan: DeadlineFinalizationPlan | null;
+  reason: string;
+}
+
+export interface BuildDeadlineFinalizationStatusInput {
+  goal: Goal;
+  now?: Date;
+  bestArtifact?: DeadlineFinalizationArtifact | null;
+}
+
+export const DEFAULT_FINALIZATION_POLICY: GoalFinalizationPolicy = {
+  minimum_buffer_ms: 30 * 60 * 1000,
+  consolidation_buffer_ms: 0,
+  best_artifact_selection: "best_evidence",
+  verification_steps: [],
+  external_actions: [],
+};
+
+export function normalizeFinalizationPolicy(
+  policy: Goal["finalization_policy"] | null | undefined
+): GoalFinalizationPolicy {
+  return {
+    ...DEFAULT_FINALIZATION_POLICY,
+    ...(policy ?? {}),
+    external_actions: (policy?.external_actions ?? []).map(normalizeExternalAction),
+    verification_steps: [...(policy?.verification_steps ?? DEFAULT_FINALIZATION_POLICY.verification_steps)],
+  };
+}
+
+export function buildDeadlineFinalizationStatus(
+  input: BuildDeadlineFinalizationStatusInput
+): DeadlineFinalizationStatus {
+  const now = input.now ?? new Date();
+  const evaluatedAt = now.toISOString();
+  const deadline = input.goal.deadline ?? null;
+  const policy = normalizeFinalizationPolicy(input.goal.finalization_policy);
+
+  if (!deadline) {
+    return {
+      mode: "no_deadline",
+      deadline: null,
+      evaluated_at: evaluatedAt,
+      remaining_ms: null,
+      reserved_finalization_ms: policy.minimum_buffer_ms,
+      remaining_exploration_ms: null,
+      consolidation_buffer_ms: policy.consolidation_buffer_ms,
+      finalization_plan: null,
+      reason: "Goal has no deadline.",
+    };
+  }
+
+  const deadlineMs = Date.parse(deadline);
+  if (!Number.isFinite(deadlineMs)) {
+    return {
+      mode: "no_deadline",
+      deadline,
+      evaluated_at: evaluatedAt,
+      remaining_ms: null,
+      reserved_finalization_ms: policy.minimum_buffer_ms,
+      remaining_exploration_ms: null,
+      consolidation_buffer_ms: policy.consolidation_buffer_ms,
+      finalization_plan: null,
+      reason: "Goal deadline is not parseable.",
+    };
+  }
+
+  const remainingMs = deadlineMs - now.getTime();
+  const remainingExplorationMs = Math.max(0, remainingMs - policy.minimum_buffer_ms);
+  const mode = classifyFinalizationMode(remainingMs, policy);
+
+  return {
+    mode,
+    deadline,
+    evaluated_at: evaluatedAt,
+    remaining_ms: remainingMs,
+    reserved_finalization_ms: policy.minimum_buffer_ms,
+    remaining_exploration_ms: remainingExplorationMs,
+    consolidation_buffer_ms: policy.consolidation_buffer_ms,
+    finalization_plan: buildFinalizationPlan(policy, input.bestArtifact ?? null),
+    reason: buildReason(mode, remainingMs, policy),
+  };
+}
+
+export function shouldStopExplorationForFinalization(status: DeadlineFinalizationStatus): boolean {
+  return status.mode === "finalization" || status.mode === "missed_deadline";
+}
+
+function classifyFinalizationMode(
+  remainingMs: number,
+  policy: GoalFinalizationPolicy
+): DeadlineFinalizationMode {
+  if (remainingMs <= 0) return "missed_deadline";
+  if (remainingMs <= policy.minimum_buffer_ms) return "finalization";
+  if (remainingMs <= policy.minimum_buffer_ms + policy.consolidation_buffer_ms) {
+    return "consolidation";
+  }
+  return "exploration";
+}
+
+function buildFinalizationPlan(
+  policy: GoalFinalizationPolicy,
+  bestArtifact: DeadlineFinalizationArtifact | null
+): DeadlineFinalizationPlan {
+  const approvalActions = policy.external_actions.map((action) => ({
+    id: action.id,
+    label: action.label,
+    ...(action.tool_name ? { tool_name: action.tool_name } : {}),
+    ...(action.payload_ref ? { payload_ref: action.payload_ref } : {}),
+    approval_required: true as const,
+  }));
+
+  return {
+    deliverable_contract: policy.deliverable_contract ?? null,
+    best_artifact_selection: policy.best_artifact_selection,
+    best_artifact: bestArtifact,
+    verification_steps: [...policy.verification_steps],
+    approval_required_actions: approvalActions,
+    handoff_required: approvalActions.length > 0,
+  };
+}
+
+function normalizeExternalAction(
+  action: GoalFinalizationExternalAction
+): GoalFinalizationExternalAction {
+  return {
+    ...action,
+    approval_required: true,
+  };
+}
+
+function buildReason(
+  mode: DeadlineFinalizationMode,
+  remainingMs: number,
+  policy: GoalFinalizationPolicy
+): string {
+  if (mode === "missed_deadline") {
+    return "Deadline has passed; preserve the best artifact and prepare operator handoff.";
+  }
+  if (mode === "finalization") {
+    return `Remaining time is inside the reserved finalization buffer (${policy.minimum_buffer_ms}ms).`;
+  }
+  if (mode === "consolidation") {
+    return `Remaining time is inside the consolidation window (${policy.minimum_buffer_ms + policy.consolidation_buffer_ms}ms).`;
+  }
+  return `Exploration may continue with ${Math.max(0, remainingMs - policy.minimum_buffer_ms)}ms before the reserved finalization buffer.`;
+}

--- a/src/reporting/report-formatters.ts
+++ b/src/reporting/report-formatters.ts
@@ -118,13 +118,18 @@ export function buildExecutionSummaryContent(
     pivotOccurred,
     elapsedMs,
     waitStatus,
+    finalizationStatus,
   } = params;
 
   const now = new Date().toISOString();
   const elapsedSec = (elapsedMs / 1000).toFixed(1);
 
   const isStructuralEvent =
-    stallDetected || pivotOccurred || taskResult === null || waitStatus !== undefined;
+    stallDetected
+    || pivotOccurred
+    || taskResult === null
+    || waitStatus !== undefined
+    || finalizationStatus !== undefined;
   const useBrief = verbosity === "brief" && !isStructuralEvent;
 
   if (useBrief) {
@@ -161,6 +166,7 @@ export function buildExecutionSummaryContent(
   const stallStatus = stallDetected ? "Yes" : "No";
   const pivotStatus = pivotOccurred ? "Yes" : "No";
   const waitSection = waitStatus ? formatWaitStatusSection(waitStatus) : "";
+  const finalizationSection = finalizationStatus ? formatFinalizationStatusSection(finalizationStatus) : "";
 
   return (
     `## Execution Summary — Loop ${loopIndex}\n\n` +
@@ -173,6 +179,7 @@ export function buildExecutionSummaryContent(
     `- **Stall detected**: ${stallStatus}\n` +
     `- **Strategy pivot**: ${pivotStatus}\n\n` +
     waitSection +
+    finalizationSection +
     `### Elapsed Time\n\n${elapsedSec}s`
   );
 }
@@ -207,6 +214,48 @@ function formatWaitStatusSection(waitStatus: NonNullable<ExecutionSummaryParams[
   }
 
   return `${lines.join("\n")}\n\n`;
+}
+
+function formatFinalizationStatusSection(
+  status: NonNullable<ExecutionSummaryParams["finalizationStatus"]>
+): string {
+  const lines = [
+    "### Deadline Finalization",
+    "",
+    `- **Mode**: ${status.mode}`,
+    `- **Deadline**: ${status.deadline ?? "-"}`,
+    `- **Remaining exploration**: ${formatDurationMs(status.remaining_exploration_ms)}`,
+    `- **Reserved finalization**: ${formatDurationMs(status.reserved_finalization_ms)}`,
+    `- **Reason**: ${status.reason}`,
+  ];
+
+  const plan = status.finalization_plan;
+  if (plan) {
+    lines.push(`- **Deliverable**: ${plan.deliverable_contract ?? "-"}`);
+    lines.push(`- **Best artifact**: ${plan.best_artifact?.label ?? "-"}`);
+    if (plan.verification_steps.length > 0) {
+      lines.push(`- **Verification steps**: ${plan.verification_steps.join("; ")}`);
+    }
+    if (plan.approval_required_actions.length > 0) {
+      lines.push(
+        `- **Approval-required actions**: ${plan.approval_required_actions
+          .map((action) => action.label)
+          .join("; ")}`
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n\n`;
+}
+
+function formatDurationMs(value: number | null): string {
+  if (value === null) return "-";
+  if (value <= 0) return "0m";
+  const minutes = Math.ceil(value / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+  return remainder === 0 ? `${hours}h` : `${hours}h ${remainder}m`;
 }
 
 // ─── buildNotificationContent ───

--- a/src/reporting/reporting-engine.ts
+++ b/src/reporting/reporting-engine.ts
@@ -64,7 +64,7 @@ export class ReportingEngine {
   // ─── generateExecutionSummary ───
 
   generateExecutionSummary(params: ExecutionSummaryParams): Report {
-    const { goalId, loopIndex, gapAggregate, stallDetected, pivotOccurred, elapsedMs, taskResult, waitStatus } = params;
+    const { goalId, loopIndex, gapAggregate, stallDetected, pivotOccurred, elapsedMs, taskResult, waitStatus, finalizationStatus } = params;
 
     const now = new Date().toISOString();
     const verbosity = getVerbosityLevel(this.characterConfig);
@@ -90,6 +90,7 @@ export class ReportingEngine {
         task_action: taskResult?.action ?? null,
         task_verification_diffs: taskResult?.verificationDiffs,
         wait_status: waitStatus ?? null,
+        finalization_status: finalizationStatus ?? null,
       },
     });
 

--- a/src/reporting/reporting-types.ts
+++ b/src/reporting/reporting-types.ts
@@ -1,4 +1,5 @@
 import type { VerificationFileDiff } from "../base/types/task.js";
+import type { DeadlineFinalizationStatus } from "../platform/time/deadline-finalization.js";
 
 export type ExecutionSummaryWaitStatus = {
   strategyId?: string;
@@ -26,6 +27,7 @@ export type ExecutionSummaryParams = {
   pivotOccurred: boolean;
   elapsedMs: number;
   waitStatus?: ExecutionSummaryWaitStatus;
+  finalizationStatus?: DeadlineFinalizationStatus;
 };
 
 export type NotificationType =

--- a/src/runtime/__tests__/loop-supervisor.test.ts
+++ b/src/runtime/__tests__/loop-supervisor.test.ts
@@ -511,6 +511,46 @@ describe("LoopSupervisor", () => {
     }
   });
 
+  it("marks deadline finalization background runs as successful handoff terminals", async () => {
+    const runId = "run:coreloop:bg-finalization";
+    const { supervisor, deps, runtimeRoot } = makeSupervisor(async (goalId: string) =>
+      makeLoopResult({ goalId, totalIterations: 1, finalStatus: "finalization" })
+    );
+    const ledger = new BackgroundRunLedger(runtimeRoot);
+    await ledger.ensureReady();
+    await ledger.create({
+      id: runId,
+      kind: "coreloop_run",
+      parent_session_id: "session:conversation:chat-bg",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      title: "Deadline handoff CoreLoop",
+    });
+    (deps as { backgroundRunLedger?: BackgroundRunLedger }).backgroundRunLedger = ledger;
+
+    try {
+      await supervisor.start([]);
+      supervisor.activateGoal("g-finalization", {
+        backgroundRun: {
+          backgroundRunId: runId,
+          parentSessionId: "session:conversation:chat-bg",
+        },
+      });
+
+      const runFile = path.join(runtimeRoot, "background-runs", `${encodeURIComponent(runId)}.json`);
+      const terminal = await pollForJsonMatch<any>(runFile, (value) =>
+        value.status === "succeeded" &&
+        value.summary === "CoreLoop finalization after 1 iteration(s)."
+      );
+      await supervisor.shutdown();
+
+      expect(terminal.error).toBeNull();
+    } finally {
+      await supervisor.shutdown();
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+
   it("settles coalesced CoreLoop background runs instead of leaving them queued", async () => {
     const initialRunId = "run:coreloop:bg-initial";
     const coalescedRunId = "run:coreloop:bg-coalesced";

--- a/src/runtime/daemon/runner-goal-cycle.ts
+++ b/src/runtime/daemon/runner-goal-cycle.ts
@@ -24,6 +24,18 @@ function buildLoopCompletePayload(goalId: string, result: LoopResult): Record<st
           observeOnly: lastIteration.waitObserveOnly ?? false,
         }
       : undefined,
+    finalization: lastIteration?.finalizationStatus && lastIteration.finalizationStatus.mode !== "no_deadline"
+      ? {
+          mode: lastIteration.finalizationStatus.mode,
+          deadline: lastIteration.finalizationStatus.deadline,
+          remainingMs: lastIteration.finalizationStatus.remaining_ms,
+          remainingExplorationMs: lastIteration.finalizationStatus.remaining_exploration_ms,
+          reservedFinalizationMs: lastIteration.finalizationStatus.reserved_finalization_ms,
+          bestArtifact: lastIteration.finalizationStatus.finalization_plan?.best_artifact?.label ?? null,
+          approvalRequiredActions:
+            lastIteration.finalizationStatus.finalization_plan?.approval_required_actions.map((action) => action.label) ?? [],
+        }
+      : undefined,
   };
 }
 

--- a/src/runtime/executor/goal-worker.ts
+++ b/src/runtime/executor/goal-worker.ts
@@ -11,7 +11,7 @@ export type WorkerStatus = 'idle' | 'running' | 'crashed';
 
 export interface WorkerResult {
   goalId: string;
-  status: 'completed' | 'stalled' | 'max_iterations' | 'error' | 'stopped';
+  status: 'completed' | 'stalled' | 'max_iterations' | 'error' | 'stopped' | 'finalization';
   totalIterations: number;
   durationMs: number;
   error?: string;

--- a/src/runtime/executor/loop-supervisor.ts
+++ b/src/runtime/executor/loop-supervisor.ts
@@ -89,7 +89,7 @@ const DEFAULT_CONFIG: SupervisorConfig = {
 function workerStatusToBackgroundRunStatus(
   status: WorkerResult['status'],
 ): 'succeeded' | 'failed' | 'cancelled' {
-  if (status === 'completed') return 'succeeded';
+  if (status === 'completed' || status === 'finalization') return 'succeeded';
   if (status === 'stopped') return 'cancelled';
   return 'failed';
 }

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -138,6 +138,8 @@ export interface RuntimeEvidenceLedgerPort {
   append(input: RuntimeEvidenceEntryInput): Promise<RuntimeEvidenceEntry[]>;
   readByGoal?(goalId: string): Promise<RuntimeEvidenceReadResult>;
   readByRun?(runId: string): Promise<RuntimeEvidenceReadResult>;
+  summarizeGoal?(goalId: string): Promise<RuntimeEvidenceSummary>;
+  summarizeRun?(runId: string): Promise<RuntimeEvidenceSummary>;
 }
 
 export class RuntimeEvidenceLedger implements RuntimeEvidenceLedgerPort {


### PR DESCRIPTION
Closes #794

## Summary
- add goal finalization policy fields for deadline buffer, deliverable contract, artifact selection, verification steps, and approval-required external actions
- add deadline finalization planner and wire CoreLoop to stop exploration with finalStatus `finalization` when the reserved buffer or missed deadline is reached
- surface finalization state in loop reports, daemon loop-complete payloads, CLI run output, and background run terminal projection
- select final artifacts from Runtime Evidence Ledger using `best_evidence`, `latest_artifact`, or `latest_verified` policy while keeping external actions approval-gated only

## Verification
- `npx vitest run --config vitest.unit.config.ts src/platform/time/__tests__/deadline-finalization.test.ts src/orchestrator/loop/__tests__/core-loop-integrations.test.ts`
- `npx vitest run --config vitest.unit.config.ts src/platform/time/__tests__/deadline-finalization.test.ts src/orchestrator/loop/__tests__/core-loop-decision-engine.test.ts src/orchestrator/loop/__tests__/core-loop-integrations.test.ts && npm run typecheck`
- `npx vitest run src/runtime/__tests__/loop-supervisor.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed` related unit lane passed; related integration lane hit existing `src/interface/cli/__tests__/cli-runner-integration.test.ts` 60s native CoreLoop timeout, same as #793 local verification

## Known risks
- `finalization` is treated as successful handoff/terminal status for CoreLoop background runs; external publish/submit actions remain represented as approval-required plan items and are not executed automatically.