### PR TITLE
feat(runtime): add external evaluator evidence

### DIFF
--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -188,6 +188,83 @@ describe("runtime registry CLI commands", () => {
     expect(parsed.best_evidence.kind).toBe("verification");
   });
 
+  it("shows evaluator local best, external best, gap, and approval gate in runtime evidence", async () => {
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      kind: "evaluator",
+      scope: { goal_id: "goal-evaluator-cli" },
+      evaluators: [{
+        evaluator_id: "ci",
+        signal: "local",
+        source: "local-tests",
+        candidate_id: "candidate-a",
+        status: "ready",
+        score: 1,
+        direction: "maximize",
+        publish_action: {
+          id: "publish-ci-artifact",
+          label: "Publish CI artifact",
+          approval_required: true,
+        },
+      }],
+      summary: "Local tests selected candidate A.",
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const pendingCode = await runCLI("runtime", "evidence", "goal-evaluator-cli");
+    const pendingOutput = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(pendingCode).toBe(0);
+    expect(pendingOutput).toContain("Approval needed:");
+    expect(pendingOutput).toContain("pending_external");
+
+    logSpy.mockClear();
+    await ledger.append({
+      kind: "evaluator",
+      scope: { goal_id: "goal-evaluator-cli" },
+      evaluators: [{
+        evaluator_id: "ci",
+        signal: "external",
+        source: "github-actions",
+        candidate_id: "candidate-a",
+        status: "passed",
+        score: 1,
+        expected_score: 1,
+        direction: "maximize",
+        provenance: {
+          kind: "ci",
+          url: "https://example.com/actions/runs/123",
+          run_id: "gha-123",
+        },
+      }],
+      summary: "External CI passed.",
+    });
+
+    const textCode = await runCLI("runtime", "evidence", "goal-evaluator-cli");
+    const textOutput = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(textCode).toBe(0);
+    expect(textOutput).toContain("Evaluators:");
+    expect(textOutput).toContain("Local best:");
+    expect(textOutput).toContain("External best:");
+    expect(textOutput).toContain("external_success");
+
+    logSpy.mockClear();
+    const jsonCode = await runCLI("runtime", "evidence", "goal-evaluator-cli", "--json");
+    const jsonOutput = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(jsonOutput) as {
+      evaluator_summary: {
+        local_best: { candidate_id: string };
+        external_best: { provenance: { run_id: string } };
+        gap: { kind: string };
+      };
+    };
+    expect(jsonCode).toBe(0);
+    expect(parsed.evaluator_summary.local_best.candidate_id).toBe("candidate-a");
+    expect(parsed.evaluator_summary.external_best.provenance.run_id).toBe("gha-123");
+    expect(parsed.evaluator_summary.gap.kind).toBe("external_success");
+  });
+
   it("summarizes run-scoped evidence for non-prefixed long-running run IDs", async () => {
     const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
     await ledger.append({

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -314,6 +314,7 @@ function printEvidenceSummary(summary: RuntimeEvidenceSummary): void {
   } else {
     console.log("  Metric trends:   -");
   }
+  printEvaluatorSummary(summary.evaluator_summary);
   if (summary.recent_failed_attempts.length > 0) {
     console.log("  Recent failures:");
     for (const entry of summary.recent_failed_attempts) {
@@ -327,9 +328,35 @@ function printEvidenceSummary(summary: RuntimeEvidenceSummary): void {
   }
 }
 
+function printEvaluatorSummary(summary: RuntimeEvidenceSummary["evaluator_summary"]): void {
+  if (summary.observations.length === 0 && summary.approval_required_actions.length === 0) {
+    console.log("  Evaluators:      -");
+    return;
+  }
+  console.log("  Evaluators:");
+  console.log(`    Local best:      ${evaluatorObservationLabel(summary.local_best)}`);
+  console.log(`    External best:   ${evaluatorObservationLabel(summary.external_best)}`);
+  console.log(`    Gap:             ${summary.gap ? `${summary.gap.kind}: ${formatCell(summary.gap.summary, 96)}` : "-"}`);
+  if (summary.approval_required_actions.length > 0) {
+    console.log("    Approval needed:");
+    for (const action of summary.approval_required_actions) {
+      console.log(`      - ${formatCell(action.label, 48)} candidate=${formatCell(action.candidate_id, 32)} source=${formatCell(action.source, 32)}`);
+    }
+  }
+}
+
 function entryLabel(entry: RuntimeEvidenceEntry | null): string {
   if (!entry) return "-";
   const status = entry.outcome ?? entry.result?.status ?? entry.verification?.verdict ?? entry.kind;
   const summary = entry.summary ?? entry.result?.summary ?? entry.decision_reason ?? entry.task?.description ?? "-";
   return `${entry.occurred_at} ${entry.kind}/${status}: ${formatCell(summary, 96)}`;
+}
+
+function evaluatorObservationLabel(
+  observation: RuntimeEvidenceSummary["evaluator_summary"]["local_best"]
+): string {
+  if (!observation) return "-";
+  const candidate = observation.candidate_label ?? observation.candidate_id;
+  const score = observation.score === undefined ? "" : ` score=${String(observation.score)}`;
+  return `${observation.evaluator_id}/${observation.source} ${candidate} status=${observation.status}${score}`;
 }

--- a/src/runtime/__tests__/runtime-evaluator-results.test.ts
+++ b/src/runtime/__tests__/runtime-evaluator-results.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import {
+  RuntimeEvidenceEntrySchema,
+  RuntimeEvidenceEvaluatorObservationSchema,
+  type RuntimeEvidenceEntry,
+} from "../store/evidence-ledger.js";
+import { summarizeEvidenceEvaluatorResults } from "../store/evaluator-results.js";
+
+describe("runtime evaluator result summaries", () => {
+  it("keeps local-only progress distinct from external confirmation", () => {
+    const summary = summarizeEvidenceEvaluatorResults([
+      evidenceEntry({
+        id: "entry-local-a",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+        artifacts: [{ label: "candidate-a", state_relative_path: "runs/a/submission.csv", kind: "other" }],
+        evaluators: [{
+          evaluator_id: "leaderboard",
+          signal: "local",
+          source: "local-validation",
+          candidate_id: "candidate-a",
+          candidate_label: "Candidate A",
+          artifact_labels: ["candidate-a"],
+          status: "passed",
+          score: 0.91,
+          direction: "maximize",
+        }],
+      }),
+    ]);
+
+    expect(summary.local_best).toMatchObject({
+      signal: "local",
+      candidate_id: "candidate-a",
+      score: 0.91,
+      artifacts: [{ state_relative_path: "runs/a/submission.csv" }],
+    });
+    expect(summary.external_best).toBeNull();
+    expect(summary.gap).toMatchObject({ kind: "local_only", candidate_id: "candidate-a" });
+  });
+
+  it("records approval-required publish actions without treating them as submitted", () => {
+    const summary = summarizeEvidenceEvaluatorResults([
+      evidenceEntry({
+        id: "entry-ready-a",
+        occurred_at: "2026-04-30T00:05:00.000Z",
+        evaluators: [{
+          evaluator_id: "public-leaderboard",
+          signal: "local",
+          source: "local-validation",
+          candidate_id: "candidate-a",
+          status: "ready",
+          score: 0.92,
+          direction: "maximize",
+          publish_action: {
+            id: "submit-candidate-a",
+            label: "Submit Candidate A",
+            tool_name: "kaggle_submit",
+            payload_ref: "runs/a/submission.csv",
+            approval_required: true,
+          },
+        }],
+      }),
+    ]);
+
+    expect(summary.approval_required_actions).toHaveLength(1);
+    expect(summary.approval_required_actions[0]).toMatchObject({
+      id: "submit-candidate-a",
+      approval_required: true,
+      status: "approval_required",
+      candidate_id: "candidate-a",
+    });
+    expect(summary.gap?.kind).toBe("pending_external");
+  });
+
+  it("clears stale approval requests after the same publish action advances", () => {
+    const summary = summarizeEvidenceEvaluatorResults([
+      evidenceEntry({
+        id: "entry-ready-a",
+        occurred_at: "2026-04-30T00:05:00.000Z",
+        evaluators: [{
+          evaluator_id: "public-leaderboard",
+          signal: "local",
+          source: "local-validation",
+          candidate_id: "candidate-a",
+          status: "ready",
+          score: 0.92,
+          direction: "maximize",
+          publish_action: {
+            id: "submit-candidate-a",
+            label: "Submit Candidate A",
+            payload_ref: "runs/a/submission.csv",
+            approval_required: true,
+          },
+        }],
+      }),
+      evidenceEntry({
+        id: "entry-submitted-a",
+        occurred_at: "2026-04-30T00:10:00.000Z",
+        evaluators: [{
+          evaluator_id: "public-leaderboard",
+          signal: "local",
+          source: "submission-preflight",
+          candidate_id: "candidate-a",
+          status: "submitted",
+          score: 0.92,
+          direction: "maximize",
+          publish_action: {
+            id: "submit-candidate-a",
+            label: "Submit Candidate A",
+            payload_ref: "runs/a/submission.csv",
+            approval_required: true,
+            status: "submitted",
+          },
+        }],
+      }),
+    ]);
+
+    expect(summary.approval_required_actions).toEqual([]);
+  });
+
+  it("rejects external publish actions that are not approval gated", () => {
+    const parsed = RuntimeEvidenceEvaluatorObservationSchema.safeParse({
+      evaluator_id: "public-leaderboard",
+      signal: "local",
+      source: "local-validation",
+      candidate_id: "candidate-a",
+      publish_action: {
+        id: "unsafe-submit",
+        label: "Unsafe submit",
+        approval_required: false,
+      },
+    });
+
+    expect(parsed.success).toBe(false);
+  });
+
+  it("links external success to the same candidate artifact and preserves provenance", () => {
+    const summary = summarizeEvidenceEvaluatorResults([
+      evidenceEntry({
+        id: "entry-local-a",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+        artifacts: [{ label: "candidate-a", state_relative_path: "runs/a/submission.csv", kind: "other" }],
+        evaluators: [{
+          evaluator_id: "leaderboard",
+          signal: "local",
+          source: "local-validation",
+          candidate_id: "candidate-a",
+          artifact_labels: ["candidate-a"],
+          status: "passed",
+          score: 0.91,
+          direction: "maximize",
+        }],
+      }),
+      evidenceEntry({
+        id: "entry-external-a",
+        occurred_at: "2026-04-30T00:20:00.000Z",
+        artifacts: [{ label: "candidate-a", state_relative_path: "runs/a/submission.csv", kind: "other" }],
+        evaluators: [{
+          evaluator_id: "leaderboard",
+          signal: "external",
+          source: "public-leaderboard",
+          candidate_id: "candidate-a",
+          artifact_labels: ["candidate-a"],
+          status: "passed",
+          score: 0.913,
+          expected_score: 0.91,
+          direction: "maximize",
+          provenance: {
+            kind: "external_url",
+            url: "https://example.com/leaderboard/submissions/123",
+            external_id: "submission-123",
+            retrieved_at: "2026-04-30T00:21:00.000Z",
+          },
+        }],
+      }),
+    ]);
+
+    expect(summary.external_best).toMatchObject({
+      signal: "external",
+      candidate_id: "candidate-a",
+      score: 0.913,
+      provenance: { external_id: "submission-123" },
+      artifacts: [{ state_relative_path: "runs/a/submission.csv" }],
+    });
+    expect(summary.gap).toMatchObject({
+      kind: "external_success",
+      candidate_id: "candidate-a",
+    });
+    expect(summary.gap?.score_delta).toBeCloseTo(0.003);
+  });
+
+  it("classifies external regression against local expectations", () => {
+    const summary = summarizeEvidenceEvaluatorResults([
+      evidenceEntry({
+        id: "entry-local-a",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+        evaluators: [{
+          evaluator_id: "leaderboard",
+          signal: "local",
+          source: "local-validation",
+          candidate_id: "candidate-a",
+          status: "passed",
+          score: 0.91,
+          direction: "maximize",
+        }],
+      }),
+      evidenceEntry({
+        id: "entry-external-a",
+        occurred_at: "2026-04-30T00:20:00.000Z",
+        evaluators: [{
+          evaluator_id: "leaderboard",
+          signal: "external",
+          source: "public-leaderboard",
+          candidate_id: "candidate-a",
+          status: "regressed",
+          score: 0.72,
+          expected_score: 0.91,
+          direction: "maximize",
+          provenance: {
+            kind: "benchmark",
+            run_id: "external-run-1",
+          },
+        }],
+      }),
+    ]);
+
+    expect(summary.external_best).toBeNull();
+    expect(summary.gap).toMatchObject({
+      kind: "external_regression",
+      candidate_id: "candidate-a",
+      direction: "maximize",
+    });
+    expect(summary.gap?.score_delta).toBeCloseTo(-0.19);
+  });
+});
+
+function evidenceEntry(
+  overrides: Partial<RuntimeEvidenceEntry>
+): RuntimeEvidenceEntry {
+  return RuntimeEvidenceEntrySchema.parse({
+    schema_version: "runtime-evidence-entry-v1",
+    id: "entry",
+    occurred_at: "2026-04-30T00:00:00.000Z",
+    kind: "evaluator",
+    scope: { goal_id: "goal-evaluator" },
+    ...overrides,
+  });
+}

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -117,4 +117,75 @@ describe("RuntimeEvidenceLedger", () => {
     expect(summary.metric_trends[0]?.source_refs[0]?.artifacts?.[0]?.state_relative_path).toBe("experiments/a/metrics.json");
     expect(summary.metric_trends[0]?.source_refs[0]?.metric_source).toBe("local-metrics.json");
   });
+
+  it("stores local and external evaluator observations with candidate provenance", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      kind: "evaluator",
+      scope: { goal_id: "goal-evaluator", run_id: "run:coreloop:evaluator" },
+      artifacts: [{ label: "submission-a", state_relative_path: "runs/a/submission.csv", kind: "other" }],
+      evaluators: [{
+        evaluator_id: "leaderboard",
+        signal: "local",
+        source: "local-validation",
+        candidate_id: "candidate-a",
+        candidate_label: "Candidate A",
+        artifact_labels: ["submission-a"],
+        status: "ready",
+        score: 0.88,
+        direction: "maximize",
+        publish_action: {
+          id: "submit-candidate-a",
+          label: "Submit Candidate A",
+          payload_ref: "runs/a/submission.csv",
+          approval_required: true,
+        },
+      }],
+      summary: "Candidate A is ready for external evaluation.",
+    });
+    await ledger.append({
+      kind: "evaluator",
+      scope: { goal_id: "goal-evaluator", run_id: "run:coreloop:evaluator" },
+      artifacts: [{ label: "submission-a", state_relative_path: "runs/a/submission.csv", kind: "other" }],
+      evaluators: [{
+        evaluator_id: "leaderboard",
+        signal: "external",
+        source: "public-leaderboard",
+        candidate_id: "candidate-a",
+        artifact_labels: ["submission-a"],
+        status: "passed",
+        score: 0.89,
+        expected_score: 0.88,
+        direction: "maximize",
+        provenance: {
+          kind: "external_url",
+          url: "https://example.com/submissions/456",
+          external_id: "submission-456",
+        },
+      }],
+      summary: "External leaderboard confirmed Candidate A.",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-evaluator");
+
+    expect(summary.evaluator_summary.local_best).toMatchObject({
+      signal: "local",
+      candidate_id: "candidate-a",
+      artifacts: [{ state_relative_path: "runs/a/submission.csv" }],
+    });
+    expect(summary.evaluator_summary.external_best).toMatchObject({
+      signal: "external",
+      candidate_id: "candidate-a",
+      provenance: { external_id: "submission-456" },
+    });
+    expect(summary.evaluator_summary.observations[0]?.publish_action).toMatchObject({
+      id: "submit-candidate-a",
+      approval_required: true,
+    });
+    expect(summary.evaluator_summary.approval_required_actions).toEqual([]);
+    expect(summary.evaluator_summary.gap).toMatchObject({
+      kind: "external_success",
+      candidate_id: "candidate-a",
+    });
+  });
 });

--- a/src/runtime/store/evaluator-results.ts
+++ b/src/runtime/store/evaluator-results.ts
@@ -1,0 +1,388 @@
+import type {
+  RuntimeEvidenceArtifactRef,
+  RuntimeEvidenceEntry,
+  RuntimeEvidenceEvaluatorObservation,
+  RuntimeEvidenceEvaluatorProvenance,
+  RuntimeEvidenceEvaluatorPublishAction,
+  RuntimeEvidenceEvaluatorStatus,
+} from "./evidence-ledger.js";
+
+type EvaluatorDirection = "maximize" | "minimize" | "neutral";
+
+export interface RuntimeEvaluatorObservationContext {
+  entry_id: string;
+  entry_kind: RuntimeEvidenceEntry["kind"];
+  occurred_at: string;
+  observed_at: string;
+  evaluator_id: string;
+  signal: "local" | "external";
+  source: string;
+  candidate_id: string;
+  candidate_label?: string;
+  artifact_labels: string[];
+  artifacts: RuntimeEvidenceArtifactRef[];
+  status: RuntimeEvidenceEvaluatorStatus;
+  score?: string | number | boolean | null;
+  score_label?: string;
+  direction?: EvaluatorDirection;
+  expected_score?: string | number | boolean | null;
+  expected_status?: RuntimeEvidenceEvaluatorStatus;
+  expectation_source?: string;
+  validation?: RuntimeEvidenceEvaluatorObservation["validation"];
+  publish_action?: RuntimeEvidenceEvaluatorPublishAction;
+  provenance?: RuntimeEvidenceEvaluatorProvenance;
+  summary?: string;
+  raw_refs: RuntimeEvidenceEntry["raw_refs"];
+}
+
+export interface RuntimeEvaluatorApprovalRequiredAction extends Omit<RuntimeEvidenceEvaluatorPublishAction, "status"> {
+  status: "approval_required" | "approved" | "submitted" | "completed" | "blocked";
+  entry_id: string;
+  evaluator_id: string;
+  signal: "local" | "external";
+  source: string;
+  candidate_id: string;
+  observed_at: string;
+}
+
+export type RuntimeEvaluatorGapKind =
+  | "none"
+  | "local_only"
+  | "pending_external"
+  | "external_success"
+  | "external_regression"
+  | "candidate_mismatch"
+  | "inconclusive";
+
+export interface RuntimeEvaluatorGap {
+  kind: RuntimeEvaluatorGapKind;
+  summary: string;
+  evaluator_id?: string;
+  candidate_id?: string;
+  local_candidate_id?: string;
+  external_candidate_id?: string;
+  score_delta?: number;
+  direction?: EvaluatorDirection;
+}
+
+export interface RuntimeEvaluatorSummary {
+  local_best: RuntimeEvaluatorObservationContext | null;
+  external_best: RuntimeEvaluatorObservationContext | null;
+  gap: RuntimeEvaluatorGap | null;
+  approval_required_actions: RuntimeEvaluatorApprovalRequiredAction[];
+  observations: RuntimeEvaluatorObservationContext[];
+}
+
+export function extractEvaluatorObservationsFromEvidence(
+  entries: RuntimeEvidenceEntry[]
+): RuntimeEvaluatorObservationContext[] {
+  const observations: RuntimeEvaluatorObservationContext[] = [];
+  for (const entry of entries) {
+    for (const evaluator of entry.evaluators ?? []) {
+      observations.push(toObservationContext(entry, evaluator));
+    }
+  }
+  return observations.sort(compareObservationTime);
+}
+
+export function summarizeEvidenceEvaluatorResults(entries: RuntimeEvidenceEntry[]): RuntimeEvaluatorSummary {
+  const observations = extractEvaluatorObservationsFromEvidence(entries);
+  const localObservations = observations.filter((observation) => observation.signal === "local");
+  const externalObservations = observations.filter((observation) => observation.signal === "external");
+  const localBest = selectBestObservation(localObservations);
+  const externalBest = selectBestObservation(externalObservations.filter(isConfirmedExternalObservation));
+  const approvalRequiredActions = collectApprovalRequiredActions(observations);
+
+  return {
+    local_best: localBest,
+    external_best: externalBest,
+    gap: classifyEvaluatorGap(localBest, externalBest, externalObservations, approvalRequiredActions),
+    approval_required_actions: approvalRequiredActions,
+    observations,
+  };
+}
+
+function toObservationContext(
+  entry: RuntimeEvidenceEntry,
+  evaluator: RuntimeEvidenceEvaluatorObservation
+): RuntimeEvaluatorObservationContext {
+  return {
+    entry_id: entry.id,
+    entry_kind: entry.kind,
+    occurred_at: entry.occurred_at,
+    observed_at: evaluator.observed_at ?? entry.occurred_at,
+    evaluator_id: evaluator.evaluator_id,
+    signal: evaluator.signal,
+    source: evaluator.source,
+    candidate_id: evaluator.candidate_id,
+    ...(evaluator.candidate_label ? { candidate_label: evaluator.candidate_label } : {}),
+    artifact_labels: evaluator.artifact_labels ?? [],
+    artifacts: selectArtifacts(entry.artifacts, evaluator.artifact_labels ?? []),
+    status: evaluator.status,
+    ...(evaluator.score !== undefined ? { score: evaluator.score } : {}),
+    ...(evaluator.score_label ? { score_label: evaluator.score_label } : {}),
+    ...(evaluator.direction ? { direction: evaluator.direction } : {}),
+    ...(evaluator.expected_score !== undefined ? { expected_score: evaluator.expected_score } : {}),
+    ...(evaluator.expected_status ? { expected_status: evaluator.expected_status } : {}),
+    ...(evaluator.expectation_source ? { expectation_source: evaluator.expectation_source } : {}),
+    ...(evaluator.validation ? { validation: evaluator.validation } : {}),
+    ...(evaluator.publish_action ? { publish_action: evaluator.publish_action } : {}),
+    ...(evaluator.provenance ? { provenance: evaluator.provenance } : {}),
+    ...(evaluator.summary ? { summary: evaluator.summary } : {}),
+    raw_refs: entry.raw_refs,
+  };
+}
+
+function selectArtifacts(
+  artifacts: RuntimeEvidenceArtifactRef[],
+  artifactLabels: string[]
+): RuntimeEvidenceArtifactRef[] {
+  if (artifactLabels.length === 0) return artifacts;
+  const wanted = new Set(artifactLabels);
+  return artifacts.filter((artifact) => wanted.has(artifact.label));
+}
+
+function collectApprovalRequiredActions(
+  observations: RuntimeEvaluatorObservationContext[]
+): RuntimeEvaluatorApprovalRequiredAction[] {
+  const actions = new Map<string, RuntimeEvaluatorApprovalRequiredAction>();
+  for (const observation of observations) {
+    const action = observation.publish_action;
+    if (!action?.approval_required) continue;
+    if (hasLaterExternalResult(observations, observation)) continue;
+    const key = `${observation.evaluator_id}:${observation.candidate_id}:${action.id}`;
+    if (action.status && action.status !== "approval_required") {
+      actions.delete(key);
+      continue;
+    }
+    actions.set(key, {
+      ...action,
+      status: action.status ?? "approval_required",
+      entry_id: observation.entry_id,
+      evaluator_id: observation.evaluator_id,
+      signal: observation.signal,
+      source: observation.source,
+      candidate_id: observation.candidate_id,
+      observed_at: observation.observed_at,
+    });
+  }
+  return [...actions.values()].sort((a, b) => a.observed_at.localeCompare(b.observed_at));
+}
+
+function hasLaterExternalResult(
+  observations: RuntimeEvaluatorObservationContext[],
+  actionObservation: RuntimeEvaluatorObservationContext
+): boolean {
+  return observations.some((observation) =>
+    observation.signal === "external"
+    && observation.evaluator_id === actionObservation.evaluator_id
+    && observation.candidate_id === actionObservation.candidate_id
+    && observation.observed_at >= actionObservation.observed_at
+    && isTerminalExternalStatus(observation.status)
+  );
+}
+
+function isTerminalExternalStatus(status: RuntimeEvidenceEvaluatorStatus): boolean {
+  return status === "passed"
+    || status === "succeeded"
+    || status === "completed"
+    || status === "failed"
+    || status === "regressed"
+    || status === "blocked";
+}
+
+function selectBestObservation(
+  observations: RuntimeEvaluatorObservationContext[]
+): RuntimeEvaluatorObservationContext | null {
+  let best: RuntimeEvaluatorObservationContext | null = null;
+  for (const observation of observations) {
+    if (!best || compareObservationQuality(observation, best) > 0) {
+      best = observation;
+    }
+  }
+  return best;
+}
+
+function classifyEvaluatorGap(
+  localBest: RuntimeEvaluatorObservationContext | null,
+  externalBest: RuntimeEvaluatorObservationContext | null,
+  externalObservations: RuntimeEvaluatorObservationContext[],
+  approvalRequiredActions: RuntimeEvaluatorApprovalRequiredAction[]
+): RuntimeEvaluatorGap | null {
+  if (!localBest && !externalBest && externalObservations.length === 0) return null;
+  if (!localBest) {
+    return {
+      kind: "inconclusive",
+      summary: "External evaluator evidence exists, but no local baseline has been recorded.",
+      ...(externalBest ? { evaluator_id: externalBest.evaluator_id, external_candidate_id: externalBest.candidate_id } : {}),
+    };
+  }
+
+  const externalForLocal = latestExternalForLocalCandidate(externalObservations, localBest);
+  if (!externalForLocal) {
+    if (externalBest && externalBest.candidate_id !== localBest.candidate_id) {
+      return {
+        kind: "candidate_mismatch",
+        summary: `Local best is ${candidateLabel(localBest)}, but externally confirmed best is ${candidateLabel(externalBest)}.`,
+        evaluator_id: localBest.evaluator_id,
+        local_candidate_id: localBest.candidate_id,
+        external_candidate_id: externalBest.candidate_id,
+      };
+    }
+    const pendingAction = approvalRequiredActions.find((action) =>
+      action.evaluator_id === localBest.evaluator_id && action.candidate_id === localBest.candidate_id
+    );
+    return {
+      kind: pendingAction ? "pending_external" : "local_only",
+      summary: pendingAction
+        ? `Local best ${candidateLabel(localBest)} is ready for external evaluation, but ${pendingAction.label} requires approval.`
+        : `Local best ${candidateLabel(localBest)} has no external evaluator result yet.`,
+      evaluator_id: localBest.evaluator_id,
+      candidate_id: localBest.candidate_id,
+    };
+  }
+
+  const scoreDelta = computeScoreDelta(localBest, externalForLocal);
+  const direction = externalForLocal.direction ?? localBest.direction;
+  if (isExternalRegression(localBest, externalForLocal)) {
+    return {
+      kind: "external_regression",
+      summary: `External evaluator result for ${candidateLabel(localBest)} regressed against local expectations.`,
+      evaluator_id: localBest.evaluator_id,
+      candidate_id: localBest.candidate_id,
+      ...(scoreDelta !== null ? { score_delta: scoreDelta } : {}),
+      ...(direction ? { direction } : {}),
+    };
+  }
+
+  if (isConfirmedExternalObservation(externalForLocal)) {
+    return {
+      kind: "external_success",
+      summary: `External evaluator confirmed local best ${candidateLabel(localBest)}.`,
+      evaluator_id: localBest.evaluator_id,
+      candidate_id: localBest.candidate_id,
+      ...(scoreDelta !== null ? { score_delta: scoreDelta } : {}),
+      ...(direction ? { direction } : {}),
+    };
+  }
+
+  if (externalForLocal.status === "pending" || externalForLocal.status === "submitted" || externalForLocal.status === "approval_required") {
+    return {
+      kind: "pending_external",
+      summary: `External evaluator result for ${candidateLabel(localBest)} is still pending.`,
+      evaluator_id: localBest.evaluator_id,
+      candidate_id: localBest.candidate_id,
+    };
+  }
+
+  return {
+    kind: "inconclusive",
+    summary: `External evaluator result for ${candidateLabel(localBest)} is not yet comparable to local evidence.`,
+    evaluator_id: localBest.evaluator_id,
+    candidate_id: localBest.candidate_id,
+  };
+}
+
+function latestExternalForLocalCandidate(
+  externalObservations: RuntimeEvaluatorObservationContext[],
+  localBest: RuntimeEvaluatorObservationContext
+): RuntimeEvaluatorObservationContext | null {
+  const newestFirst = [...externalObservations].reverse();
+  return newestFirst.find((observation) =>
+    observation.evaluator_id === localBest.evaluator_id
+    && observation.candidate_id === localBest.candidate_id
+  )
+    ?? newestFirst.find((observation) => observation.candidate_id === localBest.candidate_id)
+    ?? null;
+}
+
+function isExternalRegression(
+  localBest: RuntimeEvaluatorObservationContext,
+  externalObservation: RuntimeEvaluatorObservationContext
+): boolean {
+  if (externalObservation.status === "failed" || externalObservation.status === "regressed") return true;
+  const baseline = numericScore(externalObservation.expected_score) ?? numericScore(localBest.score);
+  const externalScore = numericScore(externalObservation.score);
+  const direction = externalObservation.direction ?? localBest.direction;
+  if (baseline === null || externalScore === null || !direction || direction === "neutral") return false;
+  return direction === "maximize"
+    ? externalScore < baseline
+    : externalScore > baseline;
+}
+
+function isConfirmedExternalObservation(observation: RuntimeEvaluatorObservationContext): boolean {
+  return observation.signal === "external"
+    && (
+      observation.status === "passed"
+      || observation.status === "succeeded"
+      || observation.status === "completed"
+    );
+}
+
+function compareObservationQuality(
+  left: RuntimeEvaluatorObservationContext,
+  right: RuntimeEvaluatorObservationContext
+): number {
+  const direction = left.direction ?? right.direction;
+  const leftScore = numericScore(left.score);
+  const rightScore = numericScore(right.score);
+  if (leftScore !== null && rightScore !== null && direction && direction !== "neutral") {
+    return direction === "maximize"
+      ? leftScore - rightScore
+      : rightScore - leftScore;
+  }
+
+  const statusDelta = statusRank(left.status) - statusRank(right.status);
+  if (statusDelta !== 0) return statusDelta;
+  return left.observed_at.localeCompare(right.observed_at);
+}
+
+function compareObservationTime(
+  left: RuntimeEvaluatorObservationContext,
+  right: RuntimeEvaluatorObservationContext
+): number {
+  const observedDelta = left.observed_at.localeCompare(right.observed_at);
+  if (observedDelta !== 0) return observedDelta;
+  return left.entry_id.localeCompare(right.entry_id);
+}
+
+function statusRank(status: RuntimeEvidenceEvaluatorStatus): number {
+  switch (status) {
+    case "passed":
+    case "succeeded":
+    case "completed":
+      return 5;
+    case "ready":
+    case "submitted":
+      return 4;
+    case "approval_required":
+    case "pending":
+      return 3;
+    case "unknown":
+      return 2;
+    case "blocked":
+      return 1;
+    case "failed":
+    case "regressed":
+      return 0;
+  }
+}
+
+function computeScoreDelta(
+  localBest: RuntimeEvaluatorObservationContext,
+  externalObservation: RuntimeEvaluatorObservationContext
+): number | null {
+  const baseline = numericScore(externalObservation.expected_score) ?? numericScore(localBest.score);
+  const externalScore = numericScore(externalObservation.score);
+  if (baseline === null || externalScore === null) return null;
+  return externalScore - baseline;
+}
+
+function numericScore(score: RuntimeEvaluatorObservationContext["score"] | undefined): number | null {
+  if (typeof score !== "number") return null;
+  return Number.isFinite(score) ? score : null;
+}
+
+function candidateLabel(observation: RuntimeEvaluatorObservationContext): string {
+  return observation.candidate_label ?? observation.candidate_id;
+}

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -8,6 +8,10 @@ import {
   type RuntimeStorePaths,
 } from "./runtime-paths.js";
 import { summarizeEvidenceMetricTrends, type MetricTrendContext } from "./metric-history.js";
+import {
+  summarizeEvidenceEvaluatorResults,
+  type RuntimeEvaluatorSummary,
+} from "./evaluator-results.js";
 
 export const RuntimeEvidenceOutcomeSchema = z.enum([
   "improved",
@@ -27,6 +31,7 @@ export const RuntimeEvidenceEntryKindSchema = z.enum([
   "verification",
   "decision",
   "metric",
+  "evaluator",
   "artifact",
   "failure",
   "other",
@@ -53,6 +58,74 @@ export const RuntimeEvidenceMetricSchema = z.object({
   summary: z.string().min(1).optional(),
 }).strict();
 export type RuntimeEvidenceMetric = z.infer<typeof RuntimeEvidenceMetricSchema>;
+
+export const RuntimeEvidenceEvaluatorSignalSchema = z.enum(["local", "external"]);
+export type RuntimeEvidenceEvaluatorSignal = z.infer<typeof RuntimeEvidenceEvaluatorSignalSchema>;
+
+export const RuntimeEvidenceEvaluatorStatusSchema = z.enum([
+  "pending",
+  "ready",
+  "approval_required",
+  "submitted",
+  "passed",
+  "succeeded",
+  "completed",
+  "failed",
+  "regressed",
+  "blocked",
+  "unknown",
+]);
+export type RuntimeEvidenceEvaluatorStatus = z.infer<typeof RuntimeEvidenceEvaluatorStatusSchema>;
+
+export const RuntimeEvidenceEvaluatorPublishActionSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  tool_name: z.string().min(1).optional(),
+  payload_ref: z.string().min(1).optional(),
+  approval_required: z.literal(true).default(true),
+  status: z.enum(["approval_required", "approved", "submitted", "completed", "blocked"]).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorPublishAction = z.infer<typeof RuntimeEvidenceEvaluatorPublishActionSchema>;
+
+export const RuntimeEvidenceEvaluatorValidationSchema = z.object({
+  status: z.enum(["pending", "passed", "failed", "blocked", "unknown"]).default("unknown"),
+  command: z.string().min(1).optional(),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorValidation = z.infer<typeof RuntimeEvidenceEvaluatorValidationSchema>;
+
+export const RuntimeEvidenceEvaluatorProvenanceSchema = z.object({
+  kind: z.enum(["local_command", "external_url", "ci", "benchmark", "human_review", "other"]).default("other"),
+  command: z.string().min(1).optional(),
+  url: z.string().url().optional(),
+  run_id: z.string().min(1).optional(),
+  external_id: z.string().min(1).optional(),
+  raw_ref: z.string().min(1).optional(),
+  retrieved_at: z.string().datetime().optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorProvenance = z.infer<typeof RuntimeEvidenceEvaluatorProvenanceSchema>;
+
+export const RuntimeEvidenceEvaluatorObservationSchema = z.object({
+  evaluator_id: z.string().min(1),
+  signal: RuntimeEvidenceEvaluatorSignalSchema,
+  source: z.string().min(1),
+  candidate_id: z.string().min(1),
+  candidate_label: z.string().min(1).optional(),
+  artifact_labels: z.array(z.string().min(1)).optional(),
+  status: RuntimeEvidenceEvaluatorStatusSchema.default("unknown"),
+  score: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+  score_label: z.string().min(1).optional(),
+  direction: z.enum(["maximize", "minimize", "neutral"]).optional(),
+  observed_at: z.string().datetime().optional(),
+  expected_score: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+  expected_status: RuntimeEvidenceEvaluatorStatusSchema.optional(),
+  expectation_source: z.string().min(1).optional(),
+  validation: RuntimeEvidenceEvaluatorValidationSchema.optional(),
+  publish_action: RuntimeEvidenceEvaluatorPublishActionSchema.optional(),
+  provenance: RuntimeEvidenceEvaluatorProvenanceSchema.optional(),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorObservation = z.infer<typeof RuntimeEvidenceEvaluatorObservationSchema>;
 
 export const RuntimeEvidenceEntrySchema = z.object({
   schema_version: z.literal("runtime-evidence-entry-v1"),
@@ -81,6 +154,7 @@ export const RuntimeEvidenceEntrySchema = z.object({
     summary: z.string().min(1).optional(),
   }).strict().optional(),
   metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
+  evaluators: z.array(RuntimeEvidenceEvaluatorObservationSchema).optional(),
   artifacts: z.array(RuntimeEvidenceArtifactRefSchema).default([]),
   result: z.object({
     status: z.string().min(1).optional(),
@@ -104,8 +178,8 @@ export const RuntimeEvidenceEntrySchema = z.object({
 export type RuntimeEvidenceEntry = z.infer<typeof RuntimeEvidenceEntrySchema>;
 export type RuntimeEvidenceEntryInput = Omit<
   RuntimeEvidenceEntry,
-  "schema_version" | "id" | "occurred_at" | "metrics" | "artifacts" | "raw_refs"
-> & Partial<Pick<RuntimeEvidenceEntry, "id" | "occurred_at" | "metrics" | "artifacts" | "raw_refs">>;
+  "schema_version" | "id" | "occurred_at" | "metrics" | "evaluators" | "artifacts" | "raw_refs"
+> & Partial<Pick<RuntimeEvidenceEntry, "id" | "occurred_at" | "metrics" | "evaluators" | "artifacts" | "raw_refs">>;
 
 export interface RuntimeEvidenceReadWarning {
   file: string;
@@ -129,6 +203,7 @@ export interface RuntimeEvidenceSummary {
   latest_strategy: RuntimeEvidenceEntry | null;
   best_evidence: RuntimeEvidenceEntry | null;
   metric_trends: MetricTrendContext[];
+  evaluator_summary: RuntimeEvaluatorSummary;
   recent_failed_attempts: RuntimeEvidenceEntry[];
   recent_entries: RuntimeEvidenceEntry[];
   warnings: RuntimeEvidenceReadWarning[];
@@ -170,6 +245,7 @@ export class RuntimeEvidenceLedger implements RuntimeEvidenceLedgerPort {
       id: input.id ?? randomUUID(),
       occurred_at: input.occurred_at ?? new Date().toISOString(),
       metrics: input.metrics ?? [],
+      evaluators: input.evaluators ?? [],
       artifacts: input.artifacts ?? [],
       raw_refs: input.raw_refs ?? [],
       ...input,
@@ -261,6 +337,7 @@ function summarizeEvidence(
     ) ?? null,
     best_evidence: chooseBestEvidence(newestFirst),
     metric_trends: summarizeEvidenceMetricTrends(entries),
+    evaluator_summary: summarizeEvidenceEvaluatorResults(entries),
     recent_failed_attempts: newestFirst
       .filter((entry) =>
         entry.outcome === "failed"

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -80,6 +80,12 @@ export {
 
 export {
   RuntimeEvidenceArtifactRefSchema,
+  RuntimeEvidenceEvaluatorObservationSchema,
+  RuntimeEvidenceEvaluatorProvenanceSchema,
+  RuntimeEvidenceEvaluatorPublishActionSchema,
+  RuntimeEvidenceEvaluatorSignalSchema,
+  RuntimeEvidenceEvaluatorStatusSchema,
+  RuntimeEvidenceEvaluatorValidationSchema,
   RuntimeEvidenceEntryKindSchema,
   RuntimeEvidenceEntrySchema,
   RuntimeEvidenceLedger,
@@ -88,6 +94,12 @@ export {
 } from "./evidence-ledger.js";
 export type {
   RuntimeEvidenceArtifactRef,
+  RuntimeEvidenceEvaluatorObservation,
+  RuntimeEvidenceEvaluatorProvenance,
+  RuntimeEvidenceEvaluatorPublishAction,
+  RuntimeEvidenceEvaluatorSignal,
+  RuntimeEvidenceEvaluatorStatus,
+  RuntimeEvidenceEvaluatorValidation,
   RuntimeEvidenceEntry,
   RuntimeEvidenceEntryInput,
   RuntimeEvidenceEntryKind,
@@ -111,6 +123,17 @@ export type {
   MetricTrendClassificationOptions,
   MetricTrendContext,
 } from "./metric-history.js";
+export {
+  extractEvaluatorObservationsFromEvidence,
+  summarizeEvidenceEvaluatorResults,
+} from "./evaluator-results.js";
+export type {
+  RuntimeEvaluatorApprovalRequiredAction,
+  RuntimeEvaluatorGap,
+  RuntimeEvaluatorGapKind,
+  RuntimeEvaluatorObservationContext,
+  RuntimeEvaluatorSummary,
+} from "./evaluator-results.js";
 export type {
   RuntimeControlOperationKind,
   RuntimeControlOperationState,


### PR DESCRIPTION
Closes #795

## Summary
- add structured Runtime Evidence Ledger evaluator observations for local and external signals, candidate artifacts, provenance, validation, and approval-required publish actions
- summarize evaluator state with local best, externally confirmed best, pending approval actions, and local-vs-external gap classification
- show evaluator status in `pulseed runtime evidence` text and JSON output

## Verification
- `npx vitest run src/runtime/__tests__/runtime-evaluator-results.test.ts src/runtime/__tests__/runtime-evidence-ledger.test.ts src/interface/cli/__tests__/runtime-command.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed` (related unit lane passed; related integration lane hit existing `src/interface/cli/__tests__/cli-runner-integration.test.ts` native CoreLoop timeout after 60s)

## Known risks
- Local `test:changed` still reaches the pre-existing native CoreLoop integration timeout also seen in #793/#794 local runs; focused tests, typecheck, and boundary lint pass.
- No external submit/publish action is executed by this change; publish actions are represented as approval-required evidence only.