### PR TITLE
Add sidecar Dream review sessions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,16 @@ export { PortfolioManager } from "./orchestrator/strategy/portfolio-manager.js";
 export { CoreLoop } from "./orchestrator/loop/core-loop.js";
 export type { CoreLoopDeps, LoopConfig, LoopResult } from "./orchestrator/loop/core-loop.js";
 export { RuntimeSessionRegistry, createRuntimeSessionRegistry } from "./runtime/session-registry/index.js";
+export {
+  createRuntimeDreamSidecarReview,
+  RuntimeDreamSidecarReviewError,
+} from "./runtime/dream-sidecar-review.js";
+export type {
+  RuntimeDreamSidecarReview,
+  RuntimeDreamSidecarReviewErrorCode,
+  RuntimeDreamSidecarReviewInput,
+  RuntimeDreamSidecarReviewRef,
+} from "./runtime/dream-sidecar-review.js";
 export type {
   RuntimeSession,
   RuntimeSessionRegistrySnapshot,

--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -9,6 +9,7 @@ import { dispatchCommand } from "../cli-command-registry.js";
 import { CLIRunner } from "../cli-runner.js";
 import type { CoreLoop } from "../../../orchestrator/loop/core-loop.js";
 import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
+import { BackgroundRunLedger } from "../../../runtime/store/background-run-store.js";
 import { RuntimeEvidenceLedger } from "../../../runtime/store/evidence-ledger.js";
 
 describe("runtime registry CLI commands", () => {
@@ -376,6 +377,52 @@ describe("runtime registry CLI commands", () => {
       context_authority: "advisory_only",
       relevant_memories: [{ authority: "advisory_only" }],
     });
+  });
+
+  it("prints read-only sidecar Dream review for an active runtime run", async () => {
+    const runLedger = new BackgroundRunLedger(path.join(tmpDir, "runtime"));
+    await runLedger.create({
+      id: "run:coreloop:review-cli",
+      kind: "coreloop_run",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      status: "running",
+      title: "Review CLI target",
+      workspace: "/repo",
+      started_at: "2026-04-30T00:00:00.000Z",
+      updated_at: "2026-04-30T00:10:00.000Z",
+      summary: "Running review target.",
+    });
+    const evidenceLedger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await evidenceLedger.append({
+      kind: "strategy",
+      scope: { run_id: "run:coreloop:review-cli", loop_index: 0 },
+      strategy: "bounded ablation",
+      summary: "Try a bounded ablation first.",
+      outcome: "continued",
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const textCode = await runCLI("runtime", "dream-review", "run:coreloop:review-cli", "--inject-guidance");
+    const textOutput = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(textCode).toBe(0);
+    expect(textOutput).toContain("Runtime Dream review: run:coreloop:review-cli");
+    expect(textOutput).toContain("Mode:            read_only");
+    expect(textOutput).toContain("Guidance injection: approval_required");
+
+    logSpy.mockClear();
+    const jsonCode = await runCLI("runtime", "dream-review", "run:coreloop:review-cli", "--json");
+    const jsonOutput = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(jsonOutput) as {
+      attach_status: string;
+      read_only_enforced: boolean;
+      strategy_families: string[];
+    };
+    expect(jsonCode).toBe(0);
+    expect(parsed.attach_status).toBe("active");
+    expect(parsed.read_only_enforced).toBe(true);
+    expect(parsed.strategy_families).toContain("bounded ablation");
   });
 
   it("summarizes run-scoped evidence for non-prefixed long-running run IDs", async () => {

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -6,6 +6,11 @@ import * as path from "node:path";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { createRuntimeSessionRegistry } from "../../../runtime/session-registry/index.js";
 import { RuntimeEvidenceLedger, type RuntimeEvidenceEntry, type RuntimeEvidenceSummary } from "../../../runtime/store/evidence-ledger.js";
+import {
+  createRuntimeDreamSidecarReview,
+  RuntimeDreamSidecarReviewError,
+  type RuntimeDreamSidecarReview,
+} from "../../../runtime/dream-sidecar-review.js";
 import type {
   BackgroundRun,
   RuntimeSession,
@@ -26,6 +31,12 @@ type RuntimeListValues = {
   json?: boolean;
   active?: boolean;
   attention?: boolean;
+};
+
+type RuntimeDreamReviewValues = {
+  id?: string;
+  json?: boolean;
+  requestGuidanceInjection?: boolean;
 };
 
 function formatCell(value: string | null | undefined, maxLen: number): string {
@@ -194,12 +205,43 @@ function parseDetailArgs(args: string[], command: string): { id?: string; json?:
   }
 }
 
+function parseDreamReviewArgs(args: string[]): RuntimeDreamReviewValues {
+  const logger = getCliLogger();
+  try {
+    const { values, positionals } = parseArgs({
+      args,
+      options: {
+        json: { type: "boolean" },
+        "request-guidance-injection": { type: "boolean" },
+        "inject-guidance": { type: "boolean" },
+      },
+      allowPositionals: true,
+      strict: false,
+    }) as {
+      values: {
+        json?: boolean;
+        "request-guidance-injection"?: boolean;
+        "inject-guidance"?: boolean;
+      };
+      positionals: string[];
+    };
+    return {
+      id: positionals[0],
+      json: values.json,
+      requestGuidanceInjection: values["request-guidance-injection"] === true || values["inject-guidance"] === true,
+    };
+  } catch (err) {
+    logger.error(formatOperationError("parse runtime dream-review arguments", err));
+    return {};
+  }
+}
+
 export async function cmdRuntime(stateManager: StateManager, args: string[]): Promise<number> {
   const logger = getCliLogger();
   const runtimeSubcommand = args[0];
 
   if (!runtimeSubcommand) {
-    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime evidence <goal-id|run-id>");
+    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
     return 1;
   }
 
@@ -281,8 +323,32 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
     return 0;
   }
 
+  if (runtimeSubcommand === "dream-review") {
+    const values = parseDreamReviewArgs(args.slice(1));
+    if (!values.id) {
+      logger.error("Error: run ID is required. Usage: pulseed runtime dream-review <run-id> [--json] [--request-guidance-injection]");
+      return 1;
+    }
+    try {
+      const review = await createRuntimeDreamSidecarReview({
+        stateManager,
+        runId: values.id,
+        requestGuidanceInjection: values.requestGuidanceInjection === true,
+      });
+      values.json ? printJson(review) : printDreamSidecarReview(review);
+      return 0;
+    } catch (err) {
+      if (err instanceof RuntimeDreamSidecarReviewError) {
+        console.error(`${err.code}: ${err.message}`);
+        return 1;
+      }
+      console.error(formatOperationError("runtime dream-review", err));
+      return 1;
+    }
+  }
+
   logger.error(`Unknown runtime subcommand: "${runtimeSubcommand}"`);
-  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime evidence <goal-id|run-id>");
+  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
   return 1;
 }
 
@@ -327,6 +393,44 @@ function printEvidenceSummary(summary: RuntimeEvidenceSummary): void {
   }
   if (summary.warnings.length > 0) {
     console.log(`  Warnings:        ${summary.warnings.length}`);
+  }
+}
+
+function printDreamSidecarReview(review: RuntimeDreamSidecarReview): void {
+  console.log(`Runtime Dream review: ${review.run.id}`);
+  console.log(`  Mode:            ${review.sidecar_session.mode}`);
+  console.log(`  Run status:      ${review.run.kind}/${review.run.status}`);
+  console.log(`  Runtime session: ${review.runtime_session?.id ?? "-"}`);
+  console.log(`  Summary:         ${formatCell(review.status_summary, 120)}`);
+  console.log(`  Trend:           ${review.trend_state.state}${review.trend_state.metric_key ? ` (${review.trend_state.metric_key})` : ""}`);
+  console.log(`  Best evidence:   ${review.best_evidence ? `${review.best_evidence.kind}: ${formatCell(review.best_evidence.summary ?? review.best_evidence.id, 96)}` : "-"}`);
+  console.log(`  Strategies:      ${review.strategy_families.join(", ") || "-"}`);
+  if (review.known_gaps.length > 0) {
+    console.log("  Known gaps:");
+    for (const gap of review.known_gaps.slice(0, 4)) {
+      console.log(`    - ${formatCell(gap, 100)}`);
+    }
+  } else {
+    console.log("  Known gaps:      -");
+  }
+  console.log("  Suggested next moves:");
+  for (const move of review.suggested_next_moves.slice(0, 5)) {
+    console.log(`    - ${formatCell(move.title, 80)} (${move.source})`);
+    console.log(`      ${formatCell(move.rationale, 100)}`);
+  }
+  if (review.operator_decisions.length > 0) {
+    console.log("  Operator decisions:");
+    for (const decision of review.operator_decisions.slice(0, 5)) {
+      console.log(`    - ${formatCell(decision.label, 80)} approval_required=${decision.approval_required}`);
+    }
+  } else {
+    console.log("  Operator decisions: -");
+  }
+  console.log(`  Guidance injection: ${review.guidance_injection.status}`);
+  console.log(`  Evidence refs:    ${review.evidence_refs.length}`);
+  console.log(`  Artifacts:        ${review.artifact_refs.map((artifact) => artifact.label).join(", ") || "-"}`);
+  if (review.warnings.length > 0) {
+    console.log(`  Warnings:         ${review.warnings.length}`);
   }
 }
 

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -47,6 +47,8 @@ Usage:
   pulseed runtime runs [--json] [--active] [--attention]  List background runs
   pulseed runtime session <id> [--json]  Show one runtime session
   pulseed runtime run <id> [--json]   Show one background run
+  pulseed runtime evidence <goal-id|run-id> [--json]  Summarize runtime evidence ledger
+  pulseed runtime dream-review <run-id> [--json]  Read-only Dream sidecar review for active run
   pulseed log --goal <id>              View observation and gap history log
   pulseed tui                          Launch the interactive TUI
   pulseed start --goal <id>            Start daemon mode for one or more goals

--- a/src/runtime/__tests__/dream-sidecar-review.test.ts
+++ b/src/runtime/__tests__/dream-sidecar-review.test.ts
@@ -1,0 +1,303 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StateManager } from "../../base/state/state-manager.js";
+import {
+  createRuntimeDreamSidecarReview,
+} from "../dream-sidecar-review.js";
+import { BackgroundRunLedger } from "../store/background-run-store.js";
+import { RuntimeEvidenceLedger } from "../store/evidence-ledger.js";
+import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
+
+describe("Runtime Dream sidecar review", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir("pulseed-dream-sidecar-");
+    stateManager = new StateManager(tmpDir, undefined, { walEnabled: false });
+    await stateManager.init();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("attaches to an active background run and returns a read-only review shape", async () => {
+    await seedActiveRun("run:coreloop:sidecar");
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      kind: "metric",
+      scope: { run_id: "run:coreloop:sidecar", loop_index: 0 },
+      metrics: [{
+        label: "accuracy",
+        value: 0.72,
+        direction: "maximize",
+        observed_at: "2026-04-30T00:00:00.000Z",
+      }],
+      summary: "Initial accuracy.",
+      outcome: "continued",
+    });
+    await ledger.append({
+      kind: "dream_checkpoint",
+      scope: { run_id: "run:coreloop:sidecar", loop_index: 3, phase: "dream_review_checkpoint" },
+      metrics: [{
+        label: "accuracy",
+        value: 0.91,
+        direction: "maximize",
+        observed_at: "2026-04-30T00:10:00.000Z",
+      }],
+      dream_checkpoints: [{
+        trigger: "breakthrough",
+        summary: "Dream checkpoint found a metric breakthrough.",
+        current_goal: "Improve benchmark",
+        active_dimensions: ["accuracy"],
+        recent_strategy_families: ["bounded ablation"],
+        exhausted: ["repeat baseline"],
+        promising: ["lock current approach"],
+        relevant_memories: [{
+          source_type: "soil",
+          ref: "soil://run/sidecar",
+          summary: "Prior run preserved a breakthrough before finalization.",
+          authority: "advisory_only",
+        }],
+        next_strategy_candidates: [{
+          title: "Lock current approach",
+          rationale: "Confirm the breakthrough is stable before broadening.",
+          target_dimensions: ["accuracy"],
+        }],
+        guidance: "Preserve the breakthrough before generating broader tasks.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.88,
+      }],
+      raw_refs: [{ kind: "dream_soil_memory", id: "soil://run/sidecar" }],
+      summary: "Breakthrough checkpoint saved.",
+      outcome: "improved",
+    });
+
+    const review = await createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:coreloop:sidecar",
+    });
+
+    expect(review).toMatchObject({
+      schema_version: "runtime-dream-sidecar-review-v1",
+      attach_status: "active",
+      read_only_enforced: true,
+      run: { id: "run:coreloop:sidecar", status: "running" },
+      runtime_session: { id: "session:coreloop:sidecar-worker", attachable: true },
+      trend_state: { state: "breakthrough", metric_key: "accuracy" },
+      best_evidence: { kind: "dream_checkpoint", outcome: "improved" },
+      guidance_injection: { status: "not_requested", approval_required: false },
+    });
+    expect(review.strategy_families).toContain("bounded ablation");
+    expect(review.advisory_memories).toContainEqual(expect.objectContaining({
+      ref: "soil://run/sidecar",
+      authority: "advisory_only",
+    }));
+    expect(review.suggested_next_moves).toContainEqual(expect.objectContaining({
+      title: "Lock current approach",
+      source: "dream_checkpoint",
+    }));
+    expect(review.evidence_refs).toContainEqual(expect.objectContaining({
+      kind: "evidence_ledger",
+      id: "run:coreloop:sidecar",
+    }));
+  });
+
+  it("rejects a missing background run", async () => {
+    await expect(createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:missing",
+    })).rejects.toMatchObject({
+      code: "missing_run",
+    });
+  });
+
+  it("rejects a stale non-active background run", async () => {
+    await seedActiveRun("run:coreloop:stale");
+    await new BackgroundRunLedger(path.join(tmpDir, "runtime")).terminal("run:coreloop:stale", {
+      status: "succeeded",
+      completed_at: "2026-04-30T01:00:00.000Z",
+      summary: "Done.",
+    });
+
+    await expect(createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:coreloop:stale",
+    })).rejects.toMatchObject({
+      code: "stale_run",
+    });
+  });
+
+  it("keeps optional guidance injection approval-gated", async () => {
+    await seedActiveRun("run:coreloop:inject");
+
+    const review = await createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:coreloop:inject",
+      requestGuidanceInjection: true,
+    });
+
+    expect(review.read_only_enforced).toBe(true);
+    expect(review.guidance_injection).toMatchObject({
+      status: "approval_required",
+      approval_required: true,
+      target_run_id: "run:coreloop:inject",
+    });
+    expect(review.operator_decisions).toContainEqual(expect.objectContaining({
+      source: "guidance_injection",
+      approval_required: true,
+    }));
+    expect(await new BackgroundRunLedger(path.join(tmpDir, "runtime")).load("run:coreloop:inject")).toMatchObject({
+      status: "running",
+      summary: "Active sidecar target.",
+    });
+  });
+
+  it("does not signal or pid-probe a process sidecar while reviewing a ledger run", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    await stateManager.writeRaw("runtime/process-sessions/proc-sidecar.json", {
+      session_id: "proc-sidecar",
+      label: "training",
+      command: "node",
+      args: ["train.js"],
+      cwd: "/repo",
+      pid: 424242,
+      running: true,
+      exitCode: null,
+      signal: null,
+      startedAt: "2026-04-30T00:00:00.000Z",
+      bufferedChars: 0,
+      metadataRelativePath: "runtime/process-sessions/proc-sidecar.json",
+      artifactRefs: [],
+    });
+    const ledger = new BackgroundRunLedger(path.join(tmpDir, "runtime"));
+    await ledger.create({
+      id: "run:process:proc-sidecar",
+      kind: "process_run",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      process_session_id: "proc-sidecar",
+      status: "running",
+      title: "Training",
+      workspace: "/repo",
+      started_at: "2026-04-30T00:00:00.000Z",
+      updated_at: "2026-04-30T00:10:00.000Z",
+      source_refs: [{
+        kind: "process_session",
+        id: "proc-sidecar",
+        path: null,
+        relative_path: "runtime/process-sessions/proc-sidecar.json",
+        updated_at: "2026-04-30T00:10:00.000Z",
+      }],
+    });
+
+    try {
+      const review = await createRuntimeDreamSidecarReview({
+        stateManager,
+        runId: "run:process:proc-sidecar",
+      });
+
+      expect(review.run).toMatchObject({
+        id: "run:process:proc-sidecar",
+        status: "running",
+        process_session_id: "proc-sidecar",
+      });
+      expect(review.read_only_enforced).toBe(true);
+      expect(killSpy).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  it("rejects a ledger-running process run when the process sidecar is terminal", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    await stateManager.writeRaw("runtime/process-sessions/proc-stale.json", {
+      session_id: "proc-stale",
+      label: "training",
+      command: "node",
+      args: ["train.js"],
+      cwd: "/repo",
+      pid: 424243,
+      running: false,
+      exitCode: 0,
+      signal: null,
+      startedAt: "2026-04-30T00:00:00.000Z",
+      exitedAt: "2026-04-30T00:12:00.000Z",
+      bufferedChars: 0,
+      metadataRelativePath: "runtime/process-sessions/proc-stale.json",
+      artifactRefs: [],
+    });
+    const ledger = new BackgroundRunLedger(path.join(tmpDir, "runtime"));
+    await ledger.create({
+      id: "run:process:proc-stale",
+      kind: "process_run",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      process_session_id: "proc-stale",
+      status: "running",
+      title: "Training",
+      workspace: "/repo",
+      started_at: "2026-04-30T00:00:00.000Z",
+      updated_at: "2026-04-30T00:10:00.000Z",
+      source_refs: [{
+        kind: "process_session",
+        id: "proc-stale",
+        path: null,
+        relative_path: "runtime/process-sessions/proc-stale.json",
+        updated_at: "2026-04-30T00:10:00.000Z",
+      }],
+    });
+
+    try {
+      await expect(createRuntimeDreamSidecarReview({
+        stateManager,
+        runId: "run:process:proc-stale",
+      })).rejects.toMatchObject({
+        code: "stale_run",
+      });
+      expect(killSpy).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  async function seedActiveRun(runId: string): Promise<void> {
+    await stateManager.writeRaw("supervisor-state.json", {
+      workers: [{
+        workerId: "sidecar-worker",
+        goalId: "goal-sidecar",
+        startedAt: Date.parse("2026-04-30T00:00:00.000Z"),
+        iterations: 3,
+      }],
+      crashCounts: {},
+      suspendedGoals: [],
+      updatedAt: Date.parse("2026-04-30T00:30:00.000Z"),
+    });
+    const ledger = new BackgroundRunLedger(path.join(tmpDir, "runtime"));
+    await ledger.create({
+      id: runId,
+      kind: "coreloop_run",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      child_session_id: "session:coreloop:sidecar-worker",
+      title: "Sidecar target",
+      workspace: "/repo",
+      status: "running",
+      started_at: "2026-04-30T00:00:00.000Z",
+      updated_at: "2026-04-30T00:30:00.000Z",
+      summary: "Active sidecar target.",
+      artifacts: [{ label: "metrics.json", path: "/repo/runs/metrics.json", url: null, kind: "metrics" }],
+      source_refs: [{
+        kind: "supervisor_state",
+        id: null,
+        path: null,
+        relative_path: "runtime/supervisor-state.json",
+        updated_at: "2026-04-30T00:30:00.000Z",
+      }],
+    });
+  }
+});

--- a/src/runtime/dream-sidecar-review.ts
+++ b/src/runtime/dream-sidecar-review.ts
@@ -1,0 +1,477 @@
+import path from "node:path";
+import type { StateManager } from "../base/state/state-manager.js";
+import { createRuntimeSessionRegistry } from "./session-registry/index.js";
+import { coreLoopSessionFromLedgerRun } from "./session-registry/registry-helpers.js";
+import type {
+  BackgroundRun,
+  RuntimeArtifactRef,
+  RuntimeSession,
+  RuntimeSessionRef,
+} from "./session-registry/types.js";
+import type {
+  RuntimeEvidenceEntry,
+  RuntimeEvidenceSummary,
+} from "./store/evidence-ledger.js";
+import { BackgroundRunLedger } from "./store/background-run-store.js";
+import { RuntimeEvidenceLedger } from "./store/evidence-ledger.js";
+
+export type RuntimeDreamSidecarReviewErrorCode = "missing_run" | "stale_run";
+
+export class RuntimeDreamSidecarReviewError extends Error {
+  constructor(readonly code: RuntimeDreamSidecarReviewErrorCode, message: string) {
+    super(message);
+    this.name = "RuntimeDreamSidecarReviewError";
+  }
+}
+
+export interface RuntimeDreamSidecarReviewInput {
+  stateManager: StateManager;
+  runId: string;
+  requestGuidanceInjection?: boolean;
+}
+
+export interface RuntimeDreamSidecarReviewRef {
+  kind: string;
+  id?: string | null;
+  path?: string | null;
+  relative_path?: string | null;
+  url?: string | null;
+  updated_at?: string | null;
+}
+
+export interface RuntimeDreamSidecarReview {
+  schema_version: "runtime-dream-sidecar-review-v1";
+  sidecar_session: {
+    id: string;
+    attached_run_id: string;
+    mode: "read_only";
+    created_at: string;
+  };
+  attach_status: "active";
+  reviewed_at: string;
+  read_only_enforced: true;
+  run: Pick<
+    BackgroundRun,
+    | "id"
+    | "kind"
+    | "status"
+    | "title"
+    | "workspace"
+    | "parent_session_id"
+    | "child_session_id"
+    | "process_session_id"
+    | "started_at"
+    | "updated_at"
+  >;
+  runtime_session: Pick<RuntimeSession, "id" | "kind" | "status" | "attachable" | "state_ref" | "source_refs"> | null;
+  status_summary: string;
+  best_evidence: {
+    id: string;
+    kind: RuntimeEvidenceEntry["kind"];
+    summary: string | null;
+    outcome: RuntimeEvidenceEntry["outcome"] | null;
+    occurred_at: string;
+  } | null;
+  known_gaps: string[];
+  strategy_families: string[];
+  trend_state: {
+    state: "breakthrough" | "plateau" | "progressing" | "unknown";
+    metric_key?: string;
+    summary?: string;
+  };
+  evidence_refs: RuntimeDreamSidecarReviewRef[];
+  artifact_refs: RuntimeArtifactRef[];
+  advisory_memories: Array<{
+    source_type: string;
+    ref?: string;
+    summary: string;
+    authority: "advisory_only";
+  }>;
+  suggested_next_moves: Array<{
+    title: string;
+    rationale: string;
+    source: "dream_checkpoint" | "public_research" | "evaluator" | "fallback";
+  }>;
+  operator_decisions: Array<{
+    label: string;
+    reason: string;
+    approval_required: true;
+    source: "evaluator" | "public_research" | "guidance_injection";
+  }>;
+  guidance_injection: {
+    status: "not_requested" | "approval_required";
+    approval_required: boolean;
+    target_run_id: string;
+    reason: string;
+  };
+  warnings: string[];
+}
+
+export async function createRuntimeDreamSidecarReview(
+  input: RuntimeDreamSidecarReviewInput
+): Promise<RuntimeDreamSidecarReview> {
+  const runtimeRoot = path.join(input.stateManager.getBaseDir(), "runtime");
+  const ledgerRun = await new BackgroundRunLedger(runtimeRoot).load(input.runId);
+  const projected = await resolveProjectedRun(input.stateManager, input.runId);
+  const resolved = selectResolvedRun(ledgerRun, projected) ?? (ledgerRun
+    ? {
+        run: ledgerRun,
+        runtimeSession: runtimeSessionFromLedgerRun(ledgerRun),
+      }
+    : null);
+  const run = resolved?.run ?? null;
+  if (!run) {
+    throw new RuntimeDreamSidecarReviewError("missing_run", `Background run not found: ${input.runId}`);
+  }
+  if (!isActiveRun(run)) {
+    throw new RuntimeDreamSidecarReviewError(
+      "stale_run",
+      `Background run ${input.runId} is not active: ${run.status}`
+    );
+  }
+
+  const runtimeSession = resolved?.runtimeSession ?? null;
+  const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+  const evidenceSummary = await ledger.summarizeRun(run.id);
+  const reviewedAt = new Date().toISOString();
+  const trendState = summarizeTrendState(evidenceSummary);
+  const statusSummary = buildStatusSummary(run, evidenceSummary, trendState);
+  const suggestedNextMoves = buildSuggestedNextMoves(evidenceSummary);
+  const operatorDecisions = buildOperatorDecisions(evidenceSummary);
+  if (input.requestGuidanceInjection) {
+    operatorDecisions.push({
+      label: "Inject sidecar guidance into active run",
+      reason: "Sidecar guidance can influence the active run and requires explicit operator approval.",
+      approval_required: true,
+      source: "guidance_injection",
+    });
+  }
+
+  return {
+    schema_version: "runtime-dream-sidecar-review-v1",
+    sidecar_session: {
+      id: `sidecar:dream-review:${run.id}`,
+      attached_run_id: run.id,
+      mode: "read_only",
+      created_at: reviewedAt,
+    },
+    attach_status: "active",
+    reviewed_at: reviewedAt,
+    read_only_enforced: true,
+    run: {
+      id: run.id,
+      kind: run.kind,
+      status: run.status,
+      title: run.title,
+      workspace: run.workspace,
+      parent_session_id: run.parent_session_id,
+      child_session_id: run.child_session_id,
+      process_session_id: run.process_session_id,
+      started_at: run.started_at,
+      updated_at: run.updated_at,
+    },
+    runtime_session: runtimeSession
+      ? {
+          id: runtimeSession.id,
+          kind: runtimeSession.kind,
+          status: runtimeSession.status,
+          attachable: runtimeSession.attachable,
+          state_ref: runtimeSession.state_ref,
+          source_refs: runtimeSession.source_refs,
+        }
+      : null,
+    status_summary: statusSummary,
+    best_evidence: evidenceSummary.best_evidence ? compactEvidence(evidenceSummary.best_evidence) : null,
+    known_gaps: buildKnownGaps(evidenceSummary),
+    strategy_families: buildStrategyFamilies(evidenceSummary),
+    trend_state: trendState,
+    evidence_refs: buildEvidenceRefs(run, runtimeSession, evidenceSummary),
+    artifact_refs: run.artifacts,
+    advisory_memories: buildAdvisoryMemories(evidenceSummary),
+    suggested_next_moves: suggestedNextMoves,
+    operator_decisions: operatorDecisions,
+    guidance_injection: input.requestGuidanceInjection
+      ? {
+          status: "approval_required",
+          approval_required: true,
+          target_run_id: run.id,
+          reason: "Guidance injection into an active run is mutation-prone and must be approved explicitly.",
+        }
+      : {
+          status: "not_requested",
+          approval_required: false,
+          target_run_id: run.id,
+          reason: "Sidecar review is read-only; no active-run guidance injection was requested.",
+        },
+    warnings: buildWarnings(run, runtimeSession, evidenceSummary),
+  };
+}
+
+function selectResolvedRun(
+  ledgerRun: BackgroundRun | null,
+  projected: { run: BackgroundRun; runtimeSession: RuntimeSession | null } | null,
+): { run: BackgroundRun; runtimeSession: RuntimeSession | null } | null {
+  if (!projected) return null;
+  if (ledgerRun && projected.run.status === "unknown" && isActiveRun(ledgerRun)) {
+    return {
+      run: ledgerRun,
+      runtimeSession: runtimeSessionFromLedgerRun(ledgerRun) ?? projected.runtimeSession,
+    };
+  }
+  return projected;
+}
+
+async function resolveProjectedRun(
+  stateManager: StateManager,
+  runId: string,
+): Promise<{ run: BackgroundRun; runtimeSession: RuntimeSession | null } | null> {
+  const registry = createRuntimeSessionRegistry({
+    stateManager,
+    // Sidecar review must never signal/probe active process PIDs. If a run is
+    // not represented by the durable ledger, the registry projection remains
+    // conservative rather than using process.kill(pid, 0).
+    isPidAlive: () => "unknown",
+  });
+  const snapshot = await registry.snapshot();
+  const run = snapshot.background_runs.find((candidate) => candidate.id === runId);
+  if (!run) return null;
+  return {
+    run,
+    runtimeSession: run.child_session_id
+      ? snapshot.sessions.find((session) => session.id === run.child_session_id) ?? null
+      : null,
+  };
+}
+
+function runtimeSessionFromLedgerRun(run: BackgroundRun): RuntimeSession | null {
+  if (run.kind === "coreloop_run" && run.child_session_id) {
+    return coreLoopSessionFromLedgerRun(run);
+  }
+  return null;
+}
+
+function isActiveRun(run: BackgroundRun): boolean {
+  return run.status === "queued" || run.status === "running";
+}
+
+function summarizeTrendState(summary: RuntimeEvidenceSummary): RuntimeDreamSidecarReview["trend_state"] {
+  const breakthrough = summary.metric_trends.find((trend) => trend.trend === "breakthrough");
+  if (breakthrough) {
+    return {
+      state: "breakthrough",
+      metric_key: breakthrough.metric_key,
+      summary: breakthrough.summary,
+    };
+  }
+  const plateau = summary.metric_trends.find((trend) => trend.trend === "stalled" || trend.trend === "regressing");
+  if (plateau) {
+    return {
+      state: "plateau",
+      metric_key: plateau.metric_key,
+      summary: plateau.summary,
+    };
+  }
+  const progressing = summary.metric_trends.find((trend) => trend.trend === "improving");
+  if (progressing) {
+    return {
+      state: "progressing",
+      metric_key: progressing.metric_key,
+      summary: progressing.summary,
+    };
+  }
+  return { state: "unknown" };
+}
+
+function buildStatusSummary(
+  run: BackgroundRun,
+  summary: RuntimeEvidenceSummary,
+  trendState: RuntimeDreamSidecarReview["trend_state"],
+): string {
+  const title = run.title ? `${run.title} ` : "";
+  const evidenceCount = `${summary.total_entries} evidence entr${summary.total_entries === 1 ? "y" : "ies"}`;
+  const trend = trendState.summary ?? `trend=${trendState.state}`;
+  return `${title}${run.kind} ${run.status}; ${evidenceCount}; ${trend}.`;
+}
+
+function compactEvidence(entry: RuntimeEvidenceEntry): NonNullable<RuntimeDreamSidecarReview["best_evidence"]> {
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    summary: entry.summary ?? entry.result?.summary ?? entry.verification?.summary ?? null,
+    outcome: entry.outcome ?? null,
+    occurred_at: entry.occurred_at,
+  };
+}
+
+function buildKnownGaps(summary: RuntimeEvidenceSummary): string[] {
+  const gaps = new Set<string>();
+  for (const failure of summary.recent_failed_attempts) {
+    gaps.add(failure.summary ?? failure.result?.summary ?? failure.verification?.summary ?? `${failure.kind} failed`);
+  }
+  for (const memo of summary.research_memos.slice(0, 3)) {
+    for (const finding of memo.findings) {
+      if (finding.risks_constraints.length > 0) {
+        gaps.add(finding.risks_constraints.join("; "));
+      }
+    }
+  }
+  if (!summary.best_evidence) gaps.add("No best evidence has been recorded for this run.");
+  if (summary.metric_trends.length === 0) gaps.add("No progress metric history has been recorded for this run.");
+  return [...gaps].slice(0, 6);
+}
+
+function buildStrategyFamilies(summary: RuntimeEvidenceSummary): string[] {
+  const families = new Set<string>();
+  for (const checkpoint of summary.dream_checkpoints) {
+    for (const family of checkpoint.recent_strategy_families) families.add(family);
+  }
+  for (const entry of summary.recent_entries) {
+    const candidate = entry.strategy ?? entry.task?.action ?? entry.task?.primary_dimension;
+    if (candidate) families.add(candidate);
+  }
+  return [...families].slice(0, 8);
+}
+
+function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamSidecarReview["suggested_next_moves"] {
+  const moves: RuntimeDreamSidecarReview["suggested_next_moves"] = [];
+  for (const checkpoint of summary.dream_checkpoints.slice(0, 2)) {
+    for (const candidate of checkpoint.next_strategy_candidates) {
+      moves.push({
+        title: candidate.title,
+        rationale: candidate.rationale,
+        source: "dream_checkpoint",
+      });
+    }
+    if (checkpoint.guidance && moves.length === 0) {
+      moves.push({
+        title: "Apply latest Dream checkpoint guidance",
+        rationale: checkpoint.guidance,
+        source: "dream_checkpoint",
+      });
+    }
+  }
+  for (const memo of summary.research_memos.slice(0, 2)) {
+    for (const finding of memo.findings.slice(0, 2)) {
+      moves.push({
+        title: finding.proposed_experiment,
+        rationale: finding.applicability,
+        source: "public_research",
+      });
+    }
+  }
+  if (summary.evaluator_summary.gap?.kind === "pending_external") {
+    moves.push({
+      title: "Resolve pending evaluator decision",
+      rationale: summary.evaluator_summary.gap.summary,
+      source: "evaluator",
+    });
+  }
+  if (moves.length === 0) {
+    moves.push({
+      title: "Continue read-only monitoring",
+      rationale: "No checkpoint, research, or evaluator action has produced a stronger next move yet.",
+      source: "fallback",
+    });
+  }
+  return moves.slice(0, 6);
+}
+
+function buildOperatorDecisions(summary: RuntimeEvidenceSummary): RuntimeDreamSidecarReview["operator_decisions"] {
+  const decisions: RuntimeDreamSidecarReview["operator_decisions"] = [];
+  for (const action of summary.evaluator_summary.approval_required_actions) {
+    decisions.push({
+      label: action.label,
+      reason: `External evaluator action for candidate ${action.candidate_id} requires approval.`,
+      approval_required: true,
+      source: "evaluator",
+    });
+  }
+  for (const memo of summary.research_memos) {
+    for (const action of memo.external_actions) {
+      decisions.push({
+        label: action.label,
+        reason: action.reason,
+        approval_required: true,
+        source: "public_research",
+      });
+    }
+  }
+  return decisions.slice(0, 8);
+}
+
+function buildEvidenceRefs(
+  run: BackgroundRun,
+  runtimeSession: RuntimeSession | null,
+  summary: RuntimeEvidenceSummary,
+): RuntimeDreamSidecarReviewRef[] {
+  const refs: RuntimeDreamSidecarReviewRef[] = [
+    ...run.source_refs.map(convertSessionRef),
+    ...(runtimeSession?.source_refs.map(convertSessionRef) ?? []),
+    ...(runtimeSession?.state_ref ? [convertSessionRef(runtimeSession.state_ref)] : []),
+    ...summary.recent_entries.flatMap((entry) =>
+      entry.raw_refs.map((ref) => ({
+        kind: ref.kind,
+        id: ref.id ?? null,
+        path: ref.path ?? null,
+        relative_path: ref.state_relative_path ?? null,
+        url: ref.url ?? null,
+      }))
+    ),
+  ];
+  refs.push({
+    kind: "evidence_ledger",
+    id: run.id,
+    relative_path: `runtime/evidence-ledger/runs/${encodeURIComponent(run.id)}.jsonl`,
+  });
+  return dedupeRefs(refs).slice(0, 20);
+}
+
+function convertSessionRef(ref: RuntimeSessionRef): RuntimeDreamSidecarReviewRef {
+  return {
+    kind: ref.kind,
+    id: ref.id,
+    path: ref.path,
+    relative_path: ref.relative_path,
+    updated_at: ref.updated_at,
+  };
+}
+
+function dedupeRefs(refs: RuntimeDreamSidecarReviewRef[]): RuntimeDreamSidecarReviewRef[] {
+  const seen = new Set<string>();
+  const deduped: RuntimeDreamSidecarReviewRef[] = [];
+  for (const ref of refs) {
+    const key = `${ref.kind}:${ref.id ?? ""}:${ref.path ?? ""}:${ref.relative_path ?? ""}:${ref.url ?? ""}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(ref);
+  }
+  return deduped;
+}
+
+function buildAdvisoryMemories(summary: RuntimeEvidenceSummary): RuntimeDreamSidecarReview["advisory_memories"] {
+  const memories = summary.dream_checkpoints.flatMap((checkpoint) =>
+    checkpoint.relevant_memories.map((memory) => ({
+      source_type: memory.source_type,
+      ...(memory.ref ? { ref: memory.ref } : {}),
+      summary: memory.summary,
+      authority: "advisory_only" as const,
+    }))
+  );
+  return memories.slice(0, 8);
+}
+
+function buildWarnings(
+  run: BackgroundRun,
+  runtimeSession: RuntimeSession | null,
+  summary: RuntimeEvidenceSummary,
+): string[] {
+  const warnings: string[] = [];
+  if (run.child_session_id && !runtimeSession) {
+    warnings.push(`Run child session ${run.child_session_id} was not found in the Runtime Session Catalog.`);
+  }
+  if (summary.total_entries === 0) {
+    warnings.push("No run-scoped Runtime Evidence Ledger entries were found.");
+  }
+  warnings.push(...summary.warnings.map((warning) => warning.message));
+  return warnings;
+}

--- a/src/tools/query/__tests__/runtime-session-tools.test.ts
+++ b/src/tools/query/__tests__/runtime-session-tools.test.ts
@@ -4,6 +4,7 @@ import * as fsp from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { StateManager } from "../../../base/state/state-manager.js";
+import { BackgroundRunLedger } from "../../../runtime/store/background-run-store.js";
 import { OutboxStore } from "../../../runtime/store/outbox-store.js";
 import type { ITool, ToolCallContext } from "../../types.js";
 import { createRuntimeSessionTools } from "../runtime-session-tools.js";
@@ -386,6 +387,50 @@ describe("runtime session tools", () => {
       sessionStatus: "failed",
       sessionSummary: "User canceled this delegated branch",
       parentNotificationStatus: "sent",
+    });
+  });
+
+  it("exposes read-only Dream sidecar reviews for active background runs", async () => {
+    const ledger = new BackgroundRunLedger(path.join(tmpDir, "runtime"));
+    await ledger.create({
+      id: "run:coreloop:tool-sidecar",
+      kind: "coreloop_run",
+      notify_policy: "silent",
+      reply_target_source: "none",
+      status: "running",
+      title: "Tool sidecar target",
+      workspace: "/repo",
+      started_at: "2026-04-30T00:00:00.000Z",
+      updated_at: "2026-04-30T00:10:00.000Z",
+      summary: "Running tool sidecar target.",
+    });
+
+    const review = tools.get("runtime_dream_review")!;
+    expect(review.metadata.isReadOnly).toBe(true);
+    expect(review.metadata.permissionLevel).toBe("read_only");
+    await expect(review.checkPermissions({
+      run_id: "run:coreloop:tool-sidecar",
+      request_guidance_injection: false,
+    }, makeContext())).resolves.toMatchObject({ status: "allowed" });
+
+    const result = await review.call({
+      run_id: "run:coreloop:tool-sidecar",
+      request_guidance_injection: true,
+    }, makeContext());
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      attach_status: "active",
+      read_only_enforced: true,
+      guidance_injection: {
+        status: "approval_required",
+        approval_required: true,
+        target_run_id: "run:coreloop:tool-sidecar",
+      },
+    });
+    expect(await ledger.load("run:coreloop:tool-sidecar")).toMatchObject({
+      status: "running",
+      summary: "Running tool sidecar target.",
     });
   });
 });

--- a/src/tools/query/runtime-dream-review-tool.ts
+++ b/src/tools/query/runtime-dream-review-tool.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import type { StateManager } from "../../base/state/state-manager.js";
+import {
+  createRuntimeDreamSidecarReview,
+  RuntimeDreamSidecarReviewError,
+} from "../../runtime/dream-sidecar-review.js";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../types.js";
+
+export const RuntimeDreamReviewInputSchema = z.object({
+  run_id: z.string().min(1, "run_id is required"),
+  request_guidance_injection: z.boolean().default(false),
+});
+export type RuntimeDreamReviewInput = z.infer<typeof RuntimeDreamReviewInputSchema>;
+
+export class RuntimeDreamReviewTool implements ITool<RuntimeDreamReviewInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: "runtime_dream_review",
+    aliases: ["dream_review_run", "runtime_sidecar_dream_review"],
+    permissionLevel: "read_only",
+    isReadOnly: true,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: 16000,
+    tags: ["session", "runtime", "dream", "self-grounding"],
+  };
+  readonly inputSchema = RuntimeDreamReviewInputSchema;
+
+  constructor(private readonly stateManager: StateManager) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return "Attach a read-only Dream sidecar review to an active runtime/background run by id.";
+  }
+
+  async call(input: RuntimeDreamReviewInput, _context: ToolCallContext): Promise<ToolResult> {
+    const started = Date.now();
+    try {
+      const review = await createRuntimeDreamSidecarReview({
+        stateManager: this.stateManager,
+        runId: input.run_id,
+        requestGuidanceInjection: input.request_guidance_injection,
+      });
+      return {
+        success: true,
+        data: review,
+        summary: `Read-only Dream review attached to ${review.run.id}: ${review.trend_state.state}`,
+        durationMs: Date.now() - started,
+      };
+    } catch (error) {
+      const code = error instanceof RuntimeDreamSidecarReviewError ? error.code : "unknown";
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        success: false,
+        data: { code },
+        summary: `runtime_dream_review failed: ${message}`,
+        error: message,
+        durationMs: Date.now() - started,
+      };
+    }
+  }
+
+  async checkPermissions(): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(): boolean {
+    return true;
+  }
+}

--- a/src/tools/query/runtime-session-tools.ts
+++ b/src/tools/query/runtime-session-tools.ts
@@ -6,6 +6,7 @@ import { ChatSessionCatalog, type LoadedChatSession } from "../../interface/chat
 import { createRuntimeSessionRegistry } from "../../runtime/session-registry/index.js";
 import type { BackgroundRun, RuntimeReplyTarget, RuntimeSession } from "../../runtime/session-registry/types.js";
 import { OutboxStore } from "../../runtime/store/outbox-store.js";
+import { RuntimeDreamReviewTool } from "./runtime-dream-review-tool.js";
 import type {
   ITool,
   PermissionCheckResult,
@@ -1184,5 +1185,6 @@ export function createRuntimeSessionTools(stateManager: StateManager): ITool[] {
     new RuntimeSessionsClaimTool(service),
     new RuntimeSessionsCancelTool(service),
     new RuntimeSessionsRetryTool(service),
+    new RuntimeDreamReviewTool(stateManager),
   ];
 }


### PR DESCRIPTION
Closes #798

## Summary
- add `createRuntimeDreamSidecarReview` for read-only attachment to active background runs
- expose sidecar review through `pulseed runtime dream-review <run-id>` and read-only `runtime_dream_review` tool
- include status, trend, strategy, evidence/artifact refs, suggested moves, and approval-required guidance injection metadata

## Verification
- `npx vitest run src/runtime/__tests__/dream-sidecar-review.test.ts src/tools/query/__tests__/runtime-session-tools.test.ts src/interface/cli/__tests__/runtime-command.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing repo-wide warnings)
- `npm run test:changed` (related unit passed; related integration still hits existing `src/interface/cli/__tests__/cli-runner-integration.test.ts` native CoreLoop 60s timeout)

## Known Risks
- Sidecar guidance injection intentionally remains approval-required and is not applied automatically.
- Local `test:changed` retains the pre-existing CLI runner integration timeout observed across prior #793+ PRs; GitHub CI should be the merge gate.