### PR TITLE
feat(runtime): add safe pause resume checkpoints

### DIFF
--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -464,6 +464,9 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   const runtimeHealth = await new RuntimeHealthStore(runtimeRoot).loadSnapshot();
   const supervisorState = await readSupervisorState(runtimeRoot);
   const taskKpis = await summarizeTaskOutcomeLedgers(baseDir);
+  const safePauseGoals = Object.values(data.safe_pause_goals ?? {});
+  const hasPauseRequested = safePauseGoals.some((pause) => pause.state === "pause_requested");
+  const hasPaused = safePauseGoals.some((pause) => pause.state === "paused");
 
   const status =
     !resolvedRuntimeAlive
@@ -474,6 +477,10 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
           : data.status === "stopping"
             ? "stopping"
             : "stopped"
+      : hasPauseRequested
+        ? "pause requested"
+        : hasPaused && data.active_goals.length === 0
+          ? "paused"
       : data.status === "crashed" || data.status === "stopping"
         ? data.status
         : data.status === "idle"
@@ -561,6 +568,23 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
     lines.push(`Resident note:   ${data.resident_activity.summary}`);
     if (data.resident_activity.goal_id) {
       lines.push(`Resident goal:   ${data.resident_activity.goal_id}`);
+    }
+  }
+
+  if (safePauseGoals.length > 0) {
+    lines.push("");
+    lines.push("Safe pause:");
+    for (const pause of safePauseGoals.slice(0, 5)) {
+      const checkpoint = pause.checkpoint?.checkpointed_at
+        ? `, checkpoint ${formatRelativeTimestamp(new Date(pause.checkpoint.checkpointed_at).getTime())}`
+        : "";
+      lines.push(`  - ${pause.goal_id}: ${pause.state}${checkpoint}`);
+      if (pause.checkpoint?.next_action) {
+        lines.push(`    Next action: ${pause.checkpoint.next_action}`);
+      }
+    }
+    if (safePauseGoals.length > 5) {
+      lines.push(`  ... ${safePauseGoals.length - 5} more safe-pause record${safePauseGoals.length === 6 ? "" : "s"}`);
     }
   }
 

--- a/src/orchestrator/execution/agent-loop/core-loop-control-tools.ts
+++ b/src/orchestrator/execution/agent-loop/core-loop-control-tools.ts
@@ -122,7 +122,7 @@ class CoreLoopControlTool<TInput> implements ITool<TInput> {
 export interface DaemonBackedCoreLoopControlDeps {
   stateManager: StateManager;
   host?: string;
-  daemonClientFactory?: () => Promise<Pick<DaemonClient, "startGoal" | "stopGoal" | "getSnapshot">>;
+  daemonClientFactory?: () => Promise<Pick<DaemonClient, "startGoal" | "stopGoal" | "pauseGoal" | "resumeGoal" | "getSnapshot">>;
 }
 
 export function createDaemonBackedCoreLoopControlToolset(
@@ -165,7 +165,7 @@ export function createDaemonBackedCoreLoopControlToolset(
     return { goalId, goal };
   };
 
-  const getDaemonClient = async (): Promise<Pick<DaemonClient, "startGoal" | "stopGoal" | "getSnapshot">> => {
+  const getDaemonClient = async (): Promise<Pick<DaemonClient, "startGoal" | "stopGoal" | "pauseGoal" | "resumeGoal" | "getSnapshot">> => {
     if (deps.daemonClientFactory) return deps.daemonClientFactory();
 
     const baseDir = deps.stateManager.getBaseDir();
@@ -245,11 +245,12 @@ export function createDaemonBackedCoreLoopControlToolset(
     },
     goalStart: startGoal,
     async goalResume(input) {
-      return startGoal(input);
+      const client = await getDaemonClient();
+      return { ...(await client.resumeGoal(input.goalId)), goalId: input.goalId };
     },
     async goalPause(input) {
       const client = await getDaemonClient();
-      return { ...(await client.stopGoal(input.goalId)), goalId: input.goalId };
+      return { ...(await client.pauseGoal(input.goalId)), goalId: input.goalId };
     },
     async goalCancel(input) {
       const client = await getDaemonClient();

--- a/src/runtime/__tests__/daemon-client.test.ts
+++ b/src/runtime/__tests__/daemon-client.test.ts
@@ -215,6 +215,39 @@ describe("DaemonClient snapshot + replay", () => {
     });
   });
 
+  it("sends safe pause and resume requests as distinct daemon command envelopes", async () => {
+    const envelopes: unknown[] = [];
+    server.setCommandEnvelopeHook((envelope) => {
+      envelopes.push(envelope);
+    });
+    await server.start();
+
+    const client = new DaemonClient({
+      host: "127.0.0.1",
+      port: server.getPort(),
+      authToken: server.getAuthToken(),
+    });
+
+    await expect(client.pauseGoal("goal-bg")).resolves.toEqual({ ok: true, goalId: "goal-bg" });
+    await expect(client.resumeGoal("goal-bg")).resolves.toEqual({ ok: true, goalId: "goal-bg" });
+
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[0]).toMatchObject({
+      type: "command",
+      name: "goal_pause",
+      goal_id: "goal-bg",
+      dedupe_key: "goal_pause:goal-bg",
+      payload: { goalId: "goal-bg" },
+    });
+    expect(envelopes[1]).toMatchObject({
+      type: "command",
+      name: "goal_resume",
+      goal_id: "goal-bg",
+      dedupe_key: "goal_resume:goal-bg",
+      payload: { goalId: "goal-bg" },
+    });
+  });
+
   it("sends schedule run-now requests as daemon command envelopes", async () => {
     const envelopes: unknown[] = [];
     server.setCommandEnvelopeHook((envelope) => {

--- a/src/runtime/command-dispatcher.ts
+++ b/src/runtime/command-dispatcher.ts
@@ -12,6 +12,8 @@ export interface CommandDispatcherDeps {
   logger?: Logger;
   onGoalStart?: (goalId: string, envelope: Envelope) => Promise<void> | void;
   onGoalStop?: (goalId: string, envelope: Envelope) => Promise<void> | void;
+  onGoalPause?: (goalId: string, envelope: Envelope) => Promise<void> | void;
+  onGoalResume?: (goalId: string, envelope: Envelope) => Promise<void> | void;
   onChatMessage?: (
     goalId: string,
     message: string,
@@ -132,6 +134,22 @@ export class CommandDispatcher {
           throw new Error("goal_stop command is missing goalId");
         }
         await this.deps.onGoalStop?.(goalId, envelope);
+        return;
+      }
+      case "goal_pause": {
+        const goalId = envelope.goal_id ?? this.readStringField(envelope.payload, "goalId");
+        if (!goalId) {
+          throw new Error("goal_pause command is missing goalId");
+        }
+        await this.deps.onGoalPause?.(goalId, envelope);
+        return;
+      }
+      case "goal_resume": {
+        const goalId = envelope.goal_id ?? this.readStringField(envelope.payload, "goalId");
+        if (!goalId) {
+          throw new Error("goal_resume command is missing goalId");
+        }
+        await this.deps.onGoalResume?.(goalId, envelope);
         return;
       }
       case "chat_message": {

--- a/src/runtime/daemon/__tests__/runner-commands-safe-pause.test.ts
+++ b/src/runtime/daemon/__tests__/runner-commands-safe-pause.test.ts
@@ -1,0 +1,342 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { createEnvelope } from "../../types/envelope.js";
+import { JournalBackedQueue } from "../../queue/journal-backed-queue.js";
+import { GoalLeaseManager } from "../../goal-lease-manager.js";
+import { LoopSupervisor } from "../../executor/loop-supervisor.js";
+import { RuntimeSafePauseStore } from "../../store/safe-pause-store.js";
+import { CommandDispatcher } from "../../command-dispatcher.js";
+import {
+  checkpointPauseIfRequested,
+  handleGoalPauseCommand,
+  handleGoalResumeCommand,
+  handleGoalStopCommand,
+  restoreSafePauseStateFromStore,
+} from "../runner-commands.js";
+import type { DaemonState } from "../../types/daemon.js";
+
+describe("daemon safe pause commands", () => {
+  let tmpDir: string;
+  let state: DaemonState;
+  let currentGoalIds: string[];
+  let journalQueue: JournalBackedQueue;
+  let saveDaemonState: ReturnType<typeof vi.fn>;
+  let broadcastGoalUpdated: ReturnType<typeof vi.fn>;
+  let supervisor: {
+    getState: ReturnType<typeof vi.fn>;
+    deactivateGoal: ReturnType<typeof vi.fn>;
+    activateGoal: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    tmpDir = makeTempDir("safe-pause-command-");
+    currentGoalIds = ["goal-1"];
+    state = {
+      pid: process.pid,
+      started_at: new Date().toISOString(),
+      last_loop_at: null,
+      loop_count: 0,
+      active_goals: [...currentGoalIds],
+      status: "running",
+      runtime_root: tmpDir,
+      crash_count: 0,
+      last_error: null,
+      last_resident_at: null,
+      resident_activity: null,
+    };
+    journalQueue = new JournalBackedQueue({ journalPath: path.join(tmpDir, "queue.json") });
+    journalQueue.accept(createEnvelope({
+      type: "event",
+      name: "goal_activated",
+      source: "test",
+      goal_id: "goal-1",
+      payload: { goalId: "goal-1" },
+      priority: "normal",
+    }));
+    saveDaemonState = vi.fn(async () => {
+      fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+    });
+    broadcastGoalUpdated = vi.fn();
+    supervisor = {
+      getState: vi.fn(() => ({
+        workers: [
+          {
+            workerId: "worker-1",
+            goalId: "goal-1",
+            startedAt: Date.now(),
+            iterations: 1,
+            backgroundRunId: "run-1",
+          },
+        ],
+        crashCounts: {},
+        suspendedGoals: [],
+        updatedAt: Date.now(),
+      })),
+      deactivateGoal: vi.fn(),
+      activateGoal: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    cleanupTempDir(tmpDir);
+  });
+
+  function context() {
+    return {
+      runtimeRoot: tmpDir,
+      currentGoalIds,
+      state,
+      journalQueue,
+      supervisor,
+      refreshOperationalState: vi.fn(() => {
+        state.active_goals = [...currentGoalIds];
+        state.status = currentGoalIds.length > 0 ? "running" : "idle";
+      }),
+      saveDaemonState,
+      abortSleep: vi.fn(),
+      broadcastGoalUpdated,
+    } as never;
+  }
+
+  it("records pause-requested during active execution, then persists a paused checkpoint at the safe boundary", async () => {
+    await handleGoalPauseCommand(context(), "goal-1");
+
+    expect(state.safe_pause_goals?.["goal-1"]?.state).toBe("pause_requested");
+    expect(currentGoalIds).toEqual(["goal-1"]);
+    expect(supervisor.deactivateGoal).toHaveBeenCalledWith("goal-1");
+    expect(broadcastGoalUpdated).toHaveBeenCalledWith("goal-1", "pause_requested");
+
+    await checkpointPauseIfRequested(context(), "goal-1");
+
+    const stored = await new RuntimeSafePauseStore(tmpDir).load("goal-1");
+    expect(stored?.state).toBe("paused");
+    expect(stored?.checkpoint).toMatchObject({
+      active_goals: ["goal-1"],
+      queued_goal_ids: ["goal-1"],
+      current_mode: "running",
+      background_run_ids: ["run-1"],
+      next_action: "resume goal to continue from the saved queue/evidence/artifact context",
+    });
+    expect(currentGoalIds).toEqual([]);
+    expect(state.safe_pause_goals?.["goal-1"]?.state).toBe("paused");
+    expect(broadcastGoalUpdated).toHaveBeenLastCalledWith("goal-1", "paused");
+  });
+
+  it("resumes a paused goal without duplicating the active goal dispatch target", async () => {
+    await handleGoalPauseCommand(context(), "goal-1");
+    await checkpointPauseIfRequested(context(), "goal-1");
+
+    await handleGoalResumeCommand(context(), "goal-1");
+    await handleGoalResumeCommand(context(), "goal-1");
+
+    expect(currentGoalIds).toEqual(["goal-1"]);
+    expect(state.safe_pause_goals?.["goal-1"]?.state).toBe("resumed");
+    expect(state.safe_pause_goals?.["goal-1"]?.checkpoint).toMatchObject({
+      current_mode: "running",
+      candidate_evidence_refs: expect.arrayContaining([`${tmpDir}/evidence-ledger/goals/goal-1.jsonl`]),
+      artifact_refs: expect.arrayContaining([`${tmpDir}/artifacts`, "background-run:run-1"]),
+      next_action: "resume goal to continue from the saved queue/evidence/artifact context",
+    });
+    expect(supervisor.activateGoal).toHaveBeenLastCalledWith("goal-1", {
+      waitResume: expect.objectContaining({
+        type: "wait_resume",
+        strategyId: "safe-pause-resume",
+        waitReason: expect.stringContaining("mode=running"),
+      }),
+    });
+    expect(supervisor.activateGoal).toHaveBeenCalledTimes(1);
+    expect(broadcastGoalUpdated).toHaveBeenLastCalledWith("goal-1", "resumed");
+  });
+
+  it("resumes only the selected paused goal instead of every checkpoint-active goal", async () => {
+    currentGoalIds = [];
+    state.active_goals = [];
+    await new RuntimeSafePauseStore(tmpDir).markPaused({
+      goalId: "goal-1",
+      checkpoint: {
+        checkpoint_id: "checkpoint-mixed-active-goals",
+        checkpointed_at: new Date().toISOString(),
+        active_goals: ["goal-1", "goal-2"],
+        queued_goal_ids: ["goal-1", "goal-2"],
+        current_mode: "running",
+        candidate_evidence_refs: ["evidence-ref"],
+        artifact_refs: ["artifact-ref"],
+        next_action: "resume selected goal",
+        supervisor_state_ref: path.join(tmpDir, "supervisor-state.json"),
+        background_run_ids: [],
+      },
+    });
+
+    await handleGoalResumeCommand(context(), "goal-1");
+
+    expect(currentGoalIds).toEqual(["goal-1"]);
+    expect(supervisor.activateGoal).toHaveBeenCalledWith("goal-1", expect.anything());
+  });
+
+  it("resumes through the real command dispatcher and supervisor queue without duplicate task dispatch", async () => {
+    const realQueue = new JournalBackedQueue({ journalPath: path.join(tmpDir, "real-queue.json") });
+    const completedGoalIds: string[] = [];
+    const supervisorStatePath = path.join(tmpDir, "real-supervisor-state.json");
+    const realSupervisor = new LoopSupervisor({
+      coreLoopFactory: () => ({
+        run: vi.fn(async (goalId: string) => ({
+          goalId,
+          totalIterations: 1,
+          finalStatus: "completed",
+          iterations: [],
+          startedAt: new Date().toISOString(),
+          completedAt: new Date().toISOString(),
+        })),
+      } as never),
+      journalQueue: realQueue,
+      goalLeaseManager: new GoalLeaseManager(tmpDir),
+      driveSystem: {} as never,
+      stateManager: {} as never,
+      onGoalComplete: (goalId) => {
+        completedGoalIds.push(goalId);
+      },
+    }, {
+      concurrency: 1,
+      iterationsPerCycle: 1,
+      stateFilePath: supervisorStatePath,
+      pollIntervalMs: 20,
+      claimLeaseMs: 1_000,
+      leaseRenewIntervalMs: 100,
+    });
+    await realSupervisor.start([]);
+    const realState: DaemonState = {
+      ...state,
+      active_goals: [],
+      status: "idle",
+    };
+    const realCurrentGoalIds: string[] = [];
+    const realContext = {
+      runtimeRoot: tmpDir,
+      currentGoalIds: realCurrentGoalIds,
+      state: realState,
+      journalQueue: realQueue,
+      supervisor: realSupervisor,
+      refreshOperationalState: vi.fn(() => {
+        realState.active_goals = [...realCurrentGoalIds];
+        realState.status = realCurrentGoalIds.length > 0 ? "running" : "idle";
+      }),
+      saveDaemonState: vi.fn(),
+      abortSleep: vi.fn(),
+      broadcastGoalUpdated: vi.fn(),
+    } as never;
+
+    try {
+      await new RuntimeSafePauseStore(tmpDir).markPaused({
+        goalId: "goal-1",
+        checkpoint: {
+          checkpoint_id: "checkpoint-1",
+          checkpointed_at: new Date().toISOString(),
+          active_goals: ["goal-1"],
+          queued_goal_ids: ["goal-1"],
+          current_mode: "exploration",
+          candidate_evidence_refs: ["evidence-ref"],
+          artifact_refs: ["artifact-ref"],
+          next_action: "continue from checkpoint",
+          supervisor_state_ref: supervisorStatePath,
+          background_run_ids: [],
+        },
+      });
+      realQueue.accept(createEnvelope({
+        type: "command",
+        name: "goal_resume",
+        source: "test",
+        goal_id: "goal-1",
+        payload: { goalId: "goal-1" },
+        priority: "normal",
+      }));
+      realQueue.accept(createEnvelope({
+        type: "command",
+        name: "goal_resume",
+        source: "test",
+        goal_id: "goal-1",
+        payload: { goalId: "goal-1" },
+        priority: "normal",
+      }));
+      const dispatcher = new CommandDispatcher({
+        journalQueue: realQueue,
+        onGoalResume: async (goalId) => handleGoalResumeCommand(realContext, goalId),
+      }, {
+        pollIntervalMs: 20,
+        claimLeaseMs: 1_000,
+      });
+
+      await dispatcher.start();
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      await dispatcher.shutdown();
+
+      expect(completedGoalIds).toEqual(["goal-1"]);
+      expect(realCurrentGoalIds).toEqual(["goal-1"]);
+
+      realQueue.accept(createEnvelope({
+        type: "command",
+        name: "goal_resume",
+        source: "test",
+        goal_id: "goal-1",
+        payload: { goalId: "goal-1" },
+        priority: "normal",
+      }));
+      await dispatcher.start();
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      await dispatcher.shutdown();
+
+      expect(completedGoalIds).toEqual(["goal-1"]);
+    } finally {
+      await realSupervisor.shutdown();
+    }
+  });
+
+  it("restores paused safe-pause state from the durable store on daemon restart", async () => {
+    await new RuntimeSafePauseStore(tmpDir).markPaused({
+      goalId: "goal-1",
+      checkpoint: {
+        checkpoint_id: "checkpoint-restart",
+        checkpointed_at: new Date().toISOString(),
+        active_goals: ["goal-1"],
+        queued_goal_ids: ["goal-1"],
+        current_mode: "running",
+        candidate_evidence_refs: ["evidence-ref"],
+        artifact_refs: ["artifact-ref"],
+        next_action: "resume after restart",
+        supervisor_state_ref: path.join(tmpDir, "supervisor-state.json"),
+        background_run_ids: [],
+      },
+    });
+
+    await restoreSafePauseStateFromStore(context());
+
+    expect(currentGoalIds).toEqual([]);
+    expect(state.active_goals).toEqual([]);
+    const queuedActivation = journalQueue
+      .snapshot()
+      .deadletter
+      .map((messageId) => journalQueue.get(messageId))
+      .find((record) => record?.envelope.goal_id === "goal-1" && record.envelope.name === "goal_activated");
+    expect(queuedActivation?.status).toBe("deadletter");
+    expect(queuedActivation?.deadletterReason).toBe("goal is paused by safe-pause checkpoint");
+    expect(state.safe_pause_goals?.["goal-1"]).toMatchObject({
+      state: "paused",
+      checkpoint: {
+        current_mode: "running",
+        next_action: "resume after restart",
+      },
+    });
+    const persisted = JSON.parse(fs.readFileSync(path.join(tmpDir, "daemon-state.json"), "utf8"));
+    expect(persisted.safe_pause_goals["goal-1"].state).toBe("paused");
+  });
+
+  it("keeps emergency stop separate from safe pause", async () => {
+    await handleGoalStopCommand(context(), "goal-1");
+
+    const stored = await new RuntimeSafePauseStore(tmpDir).load("goal-1");
+    expect(stored?.state).toBe("emergency_stopped");
+    expect(currentGoalIds).toEqual([]);
+    expect(broadcastGoalUpdated).toHaveBeenCalledWith("goal-1", "stopped");
+  });
+});

--- a/src/runtime/daemon/__tests__/runner-startup-active-workers.test.ts
+++ b/src/runtime/daemon/__tests__/runner-startup-active-workers.test.ts
@@ -207,4 +207,129 @@ describe("runner startup active workers snapshot", () => {
     beginGracefulShutdown(context as never);
     await startupPromise;
   });
+
+  it("does not enqueue paused goals that safe-pause restore removed during startup", async () => {
+    const runtimeRoot = path.join(tmpDir, "runtime");
+    const eventsDir = path.join(runtimeRoot, "events");
+    const logger = new Logger({
+      dir: path.join(tmpDir, "logs"),
+      level: "error",
+      consoleOutput: false,
+    });
+    const eventServer = new EventServer(
+      {
+        writeEvent: vi.fn().mockResolvedValue(undefined),
+      } as never,
+      {
+        port: 0,
+        eventsDir,
+      },
+      logger,
+    );
+    const supervisor = {
+      start: vi.fn().mockResolvedValue(undefined),
+      shutdown: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockReturnValue({
+        workers: [],
+        crashCounts: {},
+        suspendedGoals: [],
+        updatedAt: Date.now(),
+      }),
+    };
+
+    const context = {
+      config: {
+        event_server_port: 0,
+        check_interval_ms: 50,
+        max_concurrent_goals: 1,
+        iterations_per_cycle: 1,
+        crash_recovery: {
+          graceful_shutdown_timeout_ms: 1_000,
+        },
+      },
+      state: {
+        pid: process.pid,
+        started_at: new Date().toISOString(),
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: [],
+        status: "stopped",
+        crash_count: 0,
+        last_error: null,
+        last_resident_at: null,
+        resident_activity: null,
+      },
+      driveSystem: {
+        startWatcher: vi.fn(),
+        stopWatcher: vi.fn(),
+        writeEvent: vi.fn(),
+      },
+      deps: {
+        shutdownSignalTarget: undefined,
+      },
+      eventServer,
+      eventDispatcher: {
+        start: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      },
+      commandDispatcher: {
+        start: vi.fn().mockResolvedValue(undefined),
+        shutdown: vi.fn().mockResolvedValue(undefined),
+      },
+      supervisor,
+      logger,
+      runtimeRoot,
+      currentGoalIds: [] as string[],
+      running: true,
+      shuttingDown: false,
+      initializeRuntimeFoundation: vi.fn().mockResolvedValue(undefined),
+      acquireRuntimeLeadership: vi.fn().mockResolvedValue(undefined),
+      saveRuntimeHealthSnapshot: vi.fn().mockResolvedValue(undefined),
+      restoreSafePauseState: vi.fn(function (this: { currentGoalIds: string[]; state: Record<string, unknown> }) {
+        this.currentGoalIds = [];
+        this.state.active_goals = [];
+        this.state.safe_pause_goals = {
+          "goal-1": {
+            schema_version: "runtime-safe-pause-v1",
+            goal_id: "goal-1",
+            state: "paused",
+            requested_at: new Date().toISOString(),
+            paused_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        };
+      }),
+      startStartupRuntimeStoreMaintenance: vi.fn(),
+      stopStatusHeartbeat: null,
+      shutdownCoordinator: null,
+      queueClaimSweeper: null,
+      approvalBroker: null,
+      gateway: null,
+      approvalFn: undefined,
+      restoreState: vi.fn().mockImplementation(async (goalIds: string[]) => goalIds),
+      reconcileInterruptedExecutions: vi.fn().mockResolvedValue([]),
+      saveDaemonState: vi.fn().mockResolvedValue(undefined),
+      writeShutdownMarker: vi.fn().mockResolvedValue(undefined),
+      runSupervisorMaintenanceCycle: vi.fn().mockResolvedValue(undefined),
+      reconcileRuntimeControlOperationsAfterStartup: vi.fn().mockResolvedValue(undefined),
+      startStartupRuntimeStoreMaintenancePromise: null,
+      drainStartupRuntimeStoreMaintenance: vi.fn().mockResolvedValue(undefined),
+      releaseStartupOwnership: vi.fn().mockResolvedValue(undefined),
+      captureProviderRuntimeFingerprint: vi.fn().mockResolvedValue(null),
+      handleInboundEnvelope: vi.fn().mockResolvedValue(undefined),
+      onEventReceived: vi.fn(),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    };
+    shutdownContext = context;
+
+    startupPromise = startDaemonRunner(context as never, ["goal-1"]);
+
+    await waitFor(() => supervisor.start.mock.calls.length > 0);
+
+    expect(context.restoreSafePauseState).toHaveBeenCalled();
+    expect(supervisor.start).toHaveBeenCalledWith([]);
+
+    beginGracefulShutdown(context as never);
+    await startupPromise;
+  });
 });

--- a/src/runtime/daemon/client.ts
+++ b/src/runtime/daemon/client.ts
@@ -317,6 +317,14 @@ export class DaemonClient {
     return this.post(`/goals/${encodeURIComponent(goalId)}/stop`, {});
   }
 
+  async pauseGoal(goalId: string): Promise<{ ok: boolean; goalId?: string }> {
+    return this.post(`/goals/${encodeURIComponent(goalId)}/pause`, {});
+  }
+
+  async resumeGoal(goalId: string): Promise<{ ok: boolean; goalId?: string }> {
+    return this.post(`/goals/${encodeURIComponent(goalId)}/resume`, {});
+  }
+
   async approve(goalId: string, requestId: string, approved: boolean): Promise<{ ok: boolean }> {
     return this.post(`/goals/${encodeURIComponent(goalId)}/approve`, { requestId, approved });
   }

--- a/src/runtime/daemon/runner-commands.ts
+++ b/src/runtime/daemon/runner-commands.ts
@@ -1,5 +1,11 @@
 import { resolveScheduleEntry } from "../schedule/entry-resolver.js";
-import { RuntimeOperationStore, type RuntimeControlOperationKind } from "../store/index.js";
+import {
+  RuntimeOperationStore,
+  RuntimeSafePauseStore,
+  type RuntimeControlOperationKind,
+  type RuntimeSafePauseCheckpoint,
+  type RuntimeSafePauseRecord,
+} from "../store/index.js";
 import type { Logger } from "../logger.js";
 import type { EventServer } from "../event/server.js";
 import type { ScheduleEngine } from "../schedule/engine.js";
@@ -169,7 +175,7 @@ function extractWaitResume(payload: unknown): WaitResumeActivation | undefined {
 export async function handleGoalStopCommand(
   context: Pick<
     DaemonRunnerCommandContext,
-    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state"
+    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state" | "runtimeRoot"
   >,
   goalId: string,
 ): Promise<void> {
@@ -178,10 +184,278 @@ export async function handleGoalStopCommand(
   if (context.state.interrupted_goals) {
     context.state.interrupted_goals = context.state.interrupted_goals.filter((id) => id !== goalId);
   }
+  const store = safePauseStore(context);
+  if (store) {
+    const stopped = await store.markEmergencyStopped(goalId, "goal_stop command requested emergency stop");
+    context.state.safe_pause_goals = {
+      ...(context.state.safe_pause_goals ?? {}),
+      [goalId]: stopped,
+    };
+  }
   await context.saveDaemonState();
   context.supervisor?.deactivateGoal(goalId);
   context.abortSleep();
   await context.broadcastGoalUpdated(goalId, "stopped");
+}
+
+function safePauseStore(context: Pick<DaemonRunnerCommandContext, "runtimeRoot">): RuntimeSafePauseStore | null {
+  return context.runtimeRoot ? new RuntimeSafePauseStore(context.runtimeRoot) : null;
+}
+
+function activeWorkerCount(context: Pick<DaemonRunnerCommandContext, "supervisor">, goalId: string): number {
+  return context.supervisor?.getState().workers.filter((worker) => worker.goalId === goalId).length ?? 0;
+}
+
+function buildSafePauseCheckpoint(
+  context: Pick<DaemonRunnerCommandContext, "currentGoalIds" | "journalQueue" | "supervisor" | "runtimeRoot" | "state">,
+  goalId: string,
+  reason?: string,
+) {
+  const queueSnapshot = context.journalQueue?.snapshot();
+  const queuedGoalIds = queueSnapshot
+    ? Object.values(queueSnapshot.pending)
+        .flat()
+        .map((messageId) => context.journalQueue?.get(messageId)?.envelope.goal_id)
+        .filter((id): id is string => typeof id === "string")
+    : [];
+  const supervisorState = context.supervisor?.getState();
+  const backgroundRunIds = supervisorState?.workers
+    .filter((worker) => worker.goalId === goalId && worker.backgroundRunId)
+    .map((worker) => worker.backgroundRunId!)
+    ?? [];
+  return {
+    checkpoint_id: `safe-pause:${goalId}:${Date.now()}`,
+    checkpointed_at: new Date().toISOString(),
+    reason,
+    active_goals: [...context.currentGoalIds],
+    queued_goal_ids: [...new Set(queuedGoalIds)],
+    current_mode: context.state.status,
+    candidate_evidence_refs: [
+      ...(context.runtimeRoot ? [`${context.runtimeRoot}/evidence-ledger/goals/${encodeURIComponent(goalId)}.jsonl`] : []),
+      ...(queueSnapshot ? [`queue:pending:${Object.values(queueSnapshot.pending).flat().length}`] : []),
+    ],
+    artifact_refs: [
+      ...(context.runtimeRoot ? [`${context.runtimeRoot}/artifacts`] : []),
+      ...(backgroundRunIds.map((runId) => `background-run:${runId}`)),
+    ],
+    next_action: "resume goal to continue from the saved queue/evidence/artifact context",
+    supervisor_state_ref: context.runtimeRoot ? `${context.runtimeRoot}/supervisor-state.json` : null,
+    background_run_ids: [...new Set(backgroundRunIds)],
+  };
+}
+
+function uniqueGoalIds(goalIds: string[]): string[] {
+  return [...new Set(goalIds.filter((goalId) => goalId.trim() !== ""))];
+}
+
+function buildResumeGoalIds(currentGoalIds: string[], goalId: string): string[] {
+  return uniqueGoalIds([...currentGoalIds, goalId]);
+}
+
+function isResumableSafePauseState(record: RuntimeSafePauseRecord | null): boolean {
+  return record?.state === "pause_requested" || record?.state === "paused";
+}
+
+function buildSafePauseResumeReason(checkpoint: RuntimeSafePauseCheckpoint | undefined): string | null {
+  if (!checkpoint) {
+    return null;
+  }
+  const parts = [
+    checkpoint.next_action,
+    checkpoint.current_mode ? `mode=${checkpoint.current_mode}` : null,
+    checkpoint.candidate_evidence_refs.length > 0
+      ? `evidence=${checkpoint.candidate_evidence_refs.join(",")}`
+      : null,
+    checkpoint.artifact_refs.length > 0 ? `artifacts=${checkpoint.artifact_refs.join(",")}` : null,
+  ].filter((part): part is string => Boolean(part));
+  return parts.length > 0 ? parts.join(" | ") : null;
+}
+
+export async function checkpointPauseIfRequested(
+  context: Pick<
+    DaemonRunnerCommandContext,
+    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state" | "runtimeRoot" | "journalQueue"
+  >,
+  goalId: string,
+): Promise<boolean> {
+  const current = context.state.safe_pause_goals?.[goalId];
+  if (current?.state !== "pause_requested") {
+    return false;
+  }
+
+  const store = safePauseStore(context);
+  const checkpoint = buildSafePauseCheckpoint(context, goalId, current.reason);
+  const paused = store
+    ? await store.markPaused({ goalId, checkpoint })
+    : {
+        schema_version: "runtime-safe-pause-v1" as const,
+        goal_id: goalId,
+        state: "paused" as const,
+        requested_at: current.requested_at,
+        paused_at: checkpoint.checkpointed_at,
+        updated_at: checkpoint.checkpointed_at,
+        reason: current.reason,
+        checkpoint,
+      };
+  context.state.safe_pause_goals = {
+    ...(context.state.safe_pause_goals ?? {}),
+    [goalId]: paused,
+  };
+  context.currentGoalIds.splice(0, context.currentGoalIds.length, ...context.currentGoalIds.filter((id) => id !== goalId));
+  context.refreshOperationalState();
+  context.supervisor?.deactivateGoal(goalId);
+  await context.saveDaemonState();
+  context.abortSleep();
+  await context.broadcastGoalUpdated(goalId, "paused");
+  return true;
+}
+
+export async function handleGoalPauseCommand(
+  context: Pick<
+    DaemonRunnerCommandContext,
+    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state" | "runtimeRoot" | "journalQueue"
+  >,
+  goalId: string,
+  reason = "safe pause requested",
+): Promise<void> {
+  const store = safePauseStore(context);
+  const requested = store
+    ? await store.requestPause({ goalId, reason, requestedBy: "daemon-command" })
+    : {
+        schema_version: "runtime-safe-pause-v1" as const,
+        goal_id: goalId,
+        state: "pause_requested" as const,
+        requested_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        requested_by: "daemon-command",
+        reason,
+      };
+  context.state.safe_pause_goals = {
+    ...(context.state.safe_pause_goals ?? {}),
+    [goalId]: requested,
+  };
+  context.refreshOperationalState();
+  await context.saveDaemonState();
+  context.supervisor?.deactivateGoal(goalId);
+  context.abortSleep();
+
+  if (!context.currentGoalIds.includes(goalId) || activeWorkerCount(context, goalId) === 0) {
+    await checkpointPauseIfRequested(context, goalId);
+    return;
+  }
+
+  await context.broadcastGoalUpdated(goalId, "pause_requested");
+}
+
+export async function handleGoalResumeCommand(
+  context: Pick<
+    DaemonRunnerCommandContext,
+    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state" | "runtimeRoot"
+  >,
+  goalId: string,
+): Promise<void> {
+  const store = safePauseStore(context);
+  const existing = store ? await store.load(goalId) : context.state.safe_pause_goals?.[goalId] ?? null;
+  if (!isResumableSafePauseState(existing)) {
+    if (existing) {
+      context.state.safe_pause_goals = {
+        ...(context.state.safe_pause_goals ?? {}),
+        [goalId]: existing,
+      };
+      context.refreshOperationalState();
+      await context.saveDaemonState();
+      await context.broadcastGoalUpdated(goalId, existing.state);
+    }
+    return;
+  }
+  const resumed = store
+    ? await store.markResumed(goalId)
+    : {
+        schema_version: "runtime-safe-pause-v1" as const,
+        goal_id: goalId,
+        state: "resumed" as const,
+        resumed_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+  const resumeMetadata = existing?.checkpoint
+    ? {
+        waitResume: {
+          type: "wait_resume" as const,
+          strategyId: "safe-pause-resume",
+          waitReason: buildSafePauseResumeReason(existing.checkpoint),
+        },
+      }
+    : undefined;
+  context.state.safe_pause_goals = {
+    ...(context.state.safe_pause_goals ?? {}),
+    [goalId]: resumed,
+  };
+  context.currentGoalIds.splice(
+    0,
+    context.currentGoalIds.length,
+    ...buildResumeGoalIds(context.currentGoalIds, goalId),
+  );
+  context.refreshOperationalState();
+  await context.saveDaemonState();
+  context.supervisor?.activateGoal(goalId, resumeMetadata);
+  context.abortSleep();
+  await context.broadcastGoalUpdated(goalId, "active");
+}
+
+export async function restoreSafePauseStateFromStore(
+  context: Pick<
+    DaemonRunnerCommandContext,
+    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "state" | "runtimeRoot" | "journalQueue"
+  >,
+): Promise<RuntimeSafePauseRecord[]> {
+  if (!context.runtimeRoot) {
+    return [];
+  }
+  const records = await new RuntimeSafePauseStore(context.runtimeRoot).list();
+  if (records.length === 0) {
+    return [];
+  }
+  context.state.safe_pause_goals = Object.fromEntries(records.map((record) => [record.goal_id, record]));
+  const pausedGoalIds = new Set(records
+    .filter((record) => record.state === "pause_requested" || record.state === "paused")
+    .map((record) => record.goal_id));
+  if (pausedGoalIds.size > 0) {
+    context.currentGoalIds.splice(
+      0,
+      context.currentGoalIds.length,
+      ...context.currentGoalIds.filter((goalId) => !pausedGoalIds.has(goalId)),
+    );
+    deadletterPausedGoalActivations(context, pausedGoalIds);
+    context.refreshOperationalState();
+  }
+  await context.saveDaemonState();
+  return records;
+}
+
+function deadletterPausedGoalActivations(
+  context: Pick<DaemonRunnerCommandContext, "journalQueue">,
+  pausedGoalIds: ReadonlySet<string>,
+): void {
+  if (!context.journalQueue) {
+    return;
+  }
+  const snapshot = context.journalQueue.snapshot();
+  const messageIds = [
+    ...Object.values(snapshot.pending).flat(),
+    ...Object.values(snapshot.inflight).map((claim) => claim.messageId),
+  ];
+  for (const messageId of messageIds) {
+    const record = context.journalQueue.get(messageId);
+    const envelope = record?.envelope;
+    if (
+      envelope?.type === "event" &&
+      envelope.name === "goal_activated" &&
+      envelope.goal_id &&
+      pausedGoalIds.has(envelope.goal_id)
+    ) {
+      context.journalQueue.deadletter(messageId, "goal is paused by safe-pause checkpoint");
+    }
+  }
 }
 
 export async function handleRuntimeControlCommand(

--- a/src/runtime/daemon/runner-goal-cycle.ts
+++ b/src/runtime/daemon/runner-goal-cycle.ts
@@ -147,6 +147,7 @@ export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): P
             void context.eventServer.broadcast?.("loop_complete", buildLoopCompletePayload(goalId, result));
           }
           await context.broadcastGoalUpdated(goalId, result.finalStatus);
+          await context.checkpointPauseIfRequested?.(goalId);
         } catch (err) {
           if (context.eventServer) {
             void context.eventServer.broadcast?.("loop_error", buildLoopErrorPayload(goalId, err, context));

--- a/src/runtime/daemon/runner-startup.ts
+++ b/src/runtime/daemon/runner-startup.ts
@@ -255,6 +255,10 @@ export async function startDaemonRunner(
             context.handleGoalStartCommand(goalId, extractGoalStartMetadata(envelope))),
         onGoalStop: async (goalId) =>
           context.runCommandWithHealth("goal_stop", () => context.handleGoalStopCommand(goalId)),
+        onGoalPause: async (goalId) =>
+          context.runCommandWithHealth("goal_pause", () => context.handleGoalPauseCommand(goalId)),
+        onGoalResume: async (goalId) =>
+          context.runCommandWithHealth("goal_resume", () => context.handleGoalResumeCommand(goalId)),
         onChatMessage: async (goalId, message) =>
           context.runCommandWithHealth("chat_message", () => context.handleChatMessageCommand(goalId, message)),
         onApprovalResponse: async (goalId, requestId, approved) =>
@@ -279,6 +283,7 @@ export async function startDaemonRunner(
         supervisor: context.supervisor ? "ok" : "degraded",
       }
     );
+    await context.restoreSafePauseState?.();
     context.startStartupRuntimeStoreMaintenance();
 
     startupReady = true;
@@ -287,7 +292,7 @@ export async function startDaemonRunner(
       await context.eventDispatcher?.start();
       await context.commandDispatcher?.start();
       if (context.supervisor) {
-        await context.supervisor.start(mergedGoalIds);
+        await context.supervisor.start([...context.currentGoalIds]);
         const maintenanceIntervalMs = context.config.check_interval_ms;
         await context.runSupervisorMaintenanceCycle();
         await context.reconcileRuntimeControlOperationsAfterStartup();

--- a/src/runtime/daemon/runner.ts
+++ b/src/runtime/daemon/runner.ts
@@ -22,7 +22,7 @@ import { generateCronEntry } from "./signals.js";
 import type { IngressGateway } from "../gateway/index.js";
 import type { Envelope } from "../types/envelope.js";
 import type { LoopSupervisor } from "../executor/index.js";
-import type { ApprovalStore, OutboxStore, RuntimeHealthStore } from "../store/index.js";
+import { type ApprovalStore, type OutboxStore, type RuntimeHealthStore } from "../store/index.js";
 import type { RuntimeControlOperationKind } from "../store/index.js";
 import type { LeaderLockManager } from "../leader-lock-manager.js";
 import type { GoalLeaseManager } from "../goal-lease-manager.js";
@@ -62,11 +62,15 @@ import {
   acceptRuntimeEnvelope as acceptRuntimeEnvelopeFn,
   handleApprovalResponseCommand as handleApprovalResponseCommandFn,
   handleChatMessageCommand as handleChatMessageCommandFn,
+  handleGoalPauseCommand as handleGoalPauseCommandFn,
+  handleGoalResumeCommand as handleGoalResumeCommandFn,
   handleGoalStartCommand as handleGoalStartCommandFn,
   handleGoalStopCommand as handleGoalStopCommandFn,
   handleInboundEnvelope as handleInboundEnvelopeFn,
   handleRuntimeControlCommand as handleRuntimeControlCommandFn,
   handleScheduleRunNowCommand as handleScheduleRunNowCommandFn,
+  checkpointPauseIfRequested as checkpointPauseIfRequestedFn,
+  restoreSafePauseStateFromStore as restoreSafePauseStateFromStoreFn,
   type GoalStartMetadata,
 } from "./runner-commands.js";
 import { runDaemonGoalCycleLoop } from "./runner-goal-cycle.js";
@@ -282,6 +286,10 @@ export class DaemonRunner {
     this.refreshResidentDeps = deps.refreshResidentDeps;
 
     this.state = createInitialDaemonState(this.runtimeRoot);
+  }
+
+  private async restoreSafePauseState(): Promise<void> {
+    await restoreSafePauseStateFromStoreFn(this as never);
   }
 
   private refreshOperationalState(): void {
@@ -571,6 +579,18 @@ export class DaemonRunner {
     await handleGoalStopCommandFn(this as never, goalId);
   }
 
+  private async handleGoalPauseCommand(goalId: string): Promise<void> {
+    await handleGoalPauseCommandFn(this as never, goalId);
+  }
+
+  private async handleGoalResumeCommand(goalId: string): Promise<void> {
+    await handleGoalResumeCommandFn(this as never, goalId);
+  }
+
+  private async checkpointPauseIfRequested(goalId: string): Promise<boolean> {
+    return checkpointPauseIfRequestedFn(this as never, goalId);
+  }
+
   private async handleRuntimeControlCommand(
     operationId: string,
     kind: RuntimeControlOperationKind
@@ -624,6 +644,7 @@ export class DaemonRunner {
       });
     }
     await this.broadcastGoalUpdated(goalId, result.status);
+    await this.checkpointPauseIfRequested(goalId);
   }
 
   private async loadExistingGoalTitles(): Promise<string[]> {

--- a/src/runtime/event/server-command-handler.ts
+++ b/src/runtime/event/server-command-handler.ts
@@ -72,6 +72,38 @@ export class EventServerCommandHandler {
       return;
     }
 
+    if (action === "pause") {
+      try {
+        await this.dispatchCommandEnvelope({
+          name: "goal_pause",
+          goalId,
+          dedupeKey: `goal_pause:${goalId}`,
+          payload: { goalId },
+        });
+        await this.broadcast("goal_pause_requested", { goalId });
+        writeJson(res, 200, { ok: true, goalId });
+      } catch (err) {
+        writeJsonError(res, 500, "Command accept failed", err);
+      }
+      return;
+    }
+
+    if (action === "resume") {
+      try {
+        await this.dispatchCommandEnvelope({
+          name: "goal_resume",
+          goalId,
+          dedupeKey: `goal_resume:${goalId}`,
+          payload: { goalId },
+        });
+        await this.broadcast("goal_resume_requested", { goalId });
+        writeJson(res, 200, { ok: true, goalId });
+      } catch (err) {
+        writeJsonError(res, 500, "Command accept failed", err);
+      }
+      return;
+    }
+
     if (action === "approve") {
       try {
         const body = await readBody(req);

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -22,6 +22,9 @@ export {
   RuntimeEnvelopeSchema,
   RuntimeQueueStateSchema,
   RuntimeQueueRecordSchema,
+  RuntimeSafePauseStateSchema,
+  RuntimeSafePauseCheckpointSchema,
+  RuntimeSafePauseRecordSchema,
   GoalLeaseRecordSchema,
   ApprovalStateSchema,
   ApprovalRecordSchema,
@@ -59,6 +62,9 @@ export type {
   RuntimeEnvelopePriority,
   RuntimeQueueState,
   RuntimeQueueRecord,
+  RuntimeSafePauseState,
+  RuntimeSafePauseCheckpoint,
+  RuntimeSafePauseRecord,
   GoalLeaseRecord,
   ApprovalState,
   ApprovalRecord,
@@ -194,6 +200,7 @@ export { ApprovalStore } from "./approval-store.js";
 export type { ApprovalResolutionInput } from "./approval-store.js";
 export { OutboxStore } from "./outbox-store.js";
 export { RuntimeHealthStore } from "./health-store.js";
+export { RuntimeSafePauseStore } from "./safe-pause-store.js";
 export { RuntimeOperationStore } from "./runtime-operation-store.js";
 export {
   BackgroundRunLedger,

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -21,6 +21,7 @@ export interface RuntimeStorePaths {
   evidenceLedgerDir: string;
   evidenceLedgerGoalsDir: string;
   evidenceLedgerRunsDir: string;
+  safePausesDir: string;
   leasesDir: string;
   goalLeasesDir: string;
   dlqDir: string;
@@ -39,6 +40,7 @@ export interface RuntimeStorePaths {
   browserSessionPath(sessionId: string): string;
   evidenceGoalPath(goalId: string): string;
   evidenceRunPath(runId: string): string;
+  safePausePath(goalId: string): string;
   guardrailBreakerPath(key: string): string;
   goalLeasePath(goalId: string): string;
   completedByIdempotencyPath(idempotencyKey: string): string;
@@ -89,6 +91,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
   const evidenceLedgerDir = path.join(rootDir, "evidence-ledger");
   const evidenceLedgerGoalsDir = path.join(evidenceLedgerDir, "goals");
   const evidenceLedgerRunsDir = path.join(evidenceLedgerDir, "runs");
+  const safePausesDir = path.join(rootDir, "safe-pauses");
   const leasesDir = path.join(rootDir, "leases");
   const goalLeasesDir = path.join(leasesDir, "goal");
   const dlqDir = path.join(rootDir, "dlq");
@@ -114,6 +117,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     evidenceLedgerDir,
     evidenceLedgerGoalsDir,
     evidenceLedgerRunsDir,
+    safePausesDir,
     leasesDir,
     goalLeasesDir,
     dlqDir,
@@ -149,6 +153,9 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     },
     evidenceRunPath(runId: string) {
       return path.join(evidenceLedgerRunsDir, `${encodeRuntimePathSegment(runId)}.jsonl`);
+    },
+    safePausePath(goalId: string) {
+      return path.join(safePausesDir, `${encodeRuntimePathSegment(goalId)}.json`);
     },
     guardrailBreakerPath(key: string) {
       return path.join(guardrailBreakersDir, recordFileName(encodeRuntimePathSegment(key)));
@@ -187,6 +194,7 @@ export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise
       paths.evidenceLedgerDir,
       paths.evidenceLedgerGoalsDir,
       paths.evidenceLedgerRunsDir,
+      paths.safePausesDir,
       paths.leasesDir,
       paths.goalLeasesDir,
       paths.dlqDir,

--- a/src/runtime/store/runtime-schemas.ts
+++ b/src/runtime/store/runtime-schemas.ts
@@ -46,6 +46,46 @@ export const RuntimeQueueRecordSchema = z.object({
 });
 export type RuntimeQueueRecord = z.infer<typeof RuntimeQueueRecordSchema>;
 
+export const RuntimeSafePauseStateSchema = z.enum([
+  "running",
+  "pause_requested",
+  "paused",
+  "resumed",
+  "emergency_stopped",
+  "completed",
+]);
+export type RuntimeSafePauseState = z.infer<typeof RuntimeSafePauseStateSchema>;
+
+export const RuntimeSafePauseCheckpointSchema = z.object({
+  checkpoint_id: z.string().min(1),
+  checkpointed_at: z.string().datetime(),
+  reason: z.string().optional(),
+  active_goals: z.array(z.string()),
+  queued_goal_ids: z.array(z.string()),
+  current_mode: z.string().nullable(),
+  candidate_evidence_refs: z.array(z.string()),
+  artifact_refs: z.array(z.string()),
+  next_action: z.string().nullable(),
+  supervisor_state_ref: z.string().nullable(),
+  background_run_ids: z.array(z.string()),
+});
+export type RuntimeSafePauseCheckpoint = z.infer<typeof RuntimeSafePauseCheckpointSchema>;
+
+export const RuntimeSafePauseRecordSchema = z.object({
+  schema_version: z.literal("runtime-safe-pause-v1"),
+  goal_id: z.string().min(1),
+  state: RuntimeSafePauseStateSchema,
+  requested_at: z.string().datetime().optional(),
+  paused_at: z.string().datetime().optional(),
+  resumed_at: z.string().datetime().optional(),
+  completed_at: z.string().datetime().optional(),
+  updated_at: z.string().datetime(),
+  requested_by: z.string().optional(),
+  reason: z.string().optional(),
+  checkpoint: RuntimeSafePauseCheckpointSchema.optional(),
+});
+export type RuntimeSafePauseRecord = z.infer<typeof RuntimeSafePauseRecordSchema>;
+
 export const GoalLeaseRecordSchema = z.object({
   goal_id: z.string(),
   owner_token: z.string(),

--- a/src/runtime/store/safe-pause-store.ts
+++ b/src/runtime/store/safe-pause-store.ts
@@ -1,0 +1,133 @@
+import {
+  RuntimeSafePauseRecordSchema,
+  type RuntimeSafePauseCheckpoint,
+  type RuntimeSafePauseRecord,
+} from "./runtime-schemas.js";
+import {
+  createRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+import { RuntimeJournal } from "./runtime-journal.js";
+
+export interface RuntimeSafePauseRequestInput {
+  goalId: string;
+  reason?: string;
+  requestedBy?: string;
+  now?: string;
+}
+
+export interface RuntimeSafePauseCheckpointInput {
+  goalId: string;
+  checkpoint: RuntimeSafePauseCheckpoint;
+  now?: string;
+}
+
+export class RuntimeSafePauseStore {
+  private readonly paths: RuntimeStorePaths;
+  private readonly journal: RuntimeJournal;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+    this.journal = new RuntimeJournal(this.paths);
+  }
+
+  async ensureReady(): Promise<void> {
+    await this.journal.ensureReady();
+  }
+
+  async load(goalId: string): Promise<RuntimeSafePauseRecord | null> {
+    return this.journal.load(this.paths.safePausePath(goalId), RuntimeSafePauseRecordSchema);
+  }
+
+  async list(): Promise<RuntimeSafePauseRecord[]> {
+    return this.journal.list(this.paths.safePausesDir, RuntimeSafePauseRecordSchema);
+  }
+
+  async requestPause(input: RuntimeSafePauseRequestInput): Promise<RuntimeSafePauseRecord> {
+    const now = input.now ?? new Date().toISOString();
+    const existing = await this.load(input.goalId);
+    return this.save({
+      schema_version: "runtime-safe-pause-v1",
+      goal_id: input.goalId,
+      state: "pause_requested",
+      requested_at: existing?.requested_at ?? now,
+      updated_at: now,
+      requested_by: input.requestedBy,
+      reason: input.reason,
+      checkpoint: existing?.checkpoint,
+    });
+  }
+
+  async markPaused(input: RuntimeSafePauseCheckpointInput): Promise<RuntimeSafePauseRecord> {
+    const now = input.now ?? new Date().toISOString();
+    const existing = await this.load(input.goalId);
+    return this.save({
+      schema_version: "runtime-safe-pause-v1",
+      goal_id: input.goalId,
+      state: "paused",
+      requested_at: existing?.requested_at ?? now,
+      paused_at: existing?.paused_at ?? now,
+      updated_at: now,
+      requested_by: existing?.requested_by,
+      reason: existing?.reason,
+      checkpoint: input.checkpoint,
+    });
+  }
+
+  async markResumed(goalId: string, now = new Date().toISOString()): Promise<RuntimeSafePauseRecord> {
+    const existing = await this.load(goalId);
+    return this.save({
+      schema_version: "runtime-safe-pause-v1",
+      goal_id: goalId,
+      state: "resumed",
+      requested_at: existing?.requested_at,
+      paused_at: existing?.paused_at,
+      resumed_at: now,
+      updated_at: now,
+      requested_by: existing?.requested_by,
+      reason: existing?.reason,
+      checkpoint: existing?.checkpoint,
+    });
+  }
+
+  async markEmergencyStopped(goalId: string, reason: string, now = new Date().toISOString()): Promise<RuntimeSafePauseRecord> {
+    const existing = await this.load(goalId);
+    return this.save({
+      schema_version: "runtime-safe-pause-v1",
+      goal_id: goalId,
+      state: "emergency_stopped",
+      requested_at: existing?.requested_at,
+      paused_at: existing?.paused_at,
+      completed_at: now,
+      updated_at: now,
+      requested_by: existing?.requested_by,
+      reason,
+      checkpoint: existing?.checkpoint,
+    });
+  }
+
+  async markCompleted(goalId: string, now = new Date().toISOString()): Promise<RuntimeSafePauseRecord> {
+    const existing = await this.load(goalId);
+    return this.save({
+      schema_version: "runtime-safe-pause-v1",
+      goal_id: goalId,
+      state: "completed",
+      requested_at: existing?.requested_at,
+      paused_at: existing?.paused_at,
+      completed_at: now,
+      updated_at: now,
+      requested_by: existing?.requested_by,
+      reason: existing?.reason,
+      checkpoint: existing?.checkpoint,
+    });
+  }
+
+  async save(record: RuntimeSafePauseRecord): Promise<RuntimeSafePauseRecord> {
+    const parsed = RuntimeSafePauseRecordSchema.parse(record);
+    await this.journal.save(this.paths.safePausePath(parsed.goal_id), RuntimeSafePauseRecordSchema, parsed);
+    return parsed;
+  }
+}

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { RuntimeSafePauseRecordSchema } from "../store/runtime-schemas.js";
 
 const PID_EPOCH_ISO = "1970-01-01T00:00:00.000Z";
 
@@ -86,6 +87,7 @@ export const DaemonStateSchema = z.object({
   last_observe_at: z.string().datetime().nullable().optional(),
   last_wait_reason: z.string().nullable().optional(),
   approval_pending_count: z.number().int().nonnegative().optional(),
+  safe_pause_goals: z.record(RuntimeSafePauseRecordSchema).optional(),
 });
 export type DaemonState = z.infer<typeof DaemonStateSchema>;
 


### PR DESCRIPTION
Closes #820

## Implementation summary
- Add durable safe-pause records/checkpoints for pause requested, paused, resumed, emergency stopped, and completed states.
- Add daemon HTTP/client/command/tool paths for safe pause and resume, separate from emergency stop.
- Persist checkpoint context for queue/current goal, mode, evidence/artifacts, next action, supervisor state, and background runs.
- Restore safe-pause state on daemon startup, prevent paused goals from re-entering supervisor dispatch, and deadletter stale paused activations.
- Surface safe-pause state in daemon status and protect delayed duplicate resume retries.

## Verification commands
- `npx vitest run src/runtime/daemon/__tests__/runner-startup-active-workers.test.ts src/runtime/daemon/__tests__/runner-commands-safe-pause.test.ts src/runtime/__tests__/daemon-client.test.ts src/interface/cli/__tests__/cli-daemon-status.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed` (related unit tests passed; related integration still times out in pre-existing `src/interface/cli/__tests__/cli-runner-integration.test.ts` / `runs CoreLoop to completion with max_iterations=1 using MockLLM`, same as PR #827 local evidence)

## Known unresolved risks
- Local `npm run test:changed` still hits the existing unrelated CLI runner integration timeout; focused safe-pause coverage and CI should be used as the gate for this slice.
