### PR TITLE
feat(runtime): add resident run policies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,7 +229,10 @@ Common scriptable commands:
 |---|---|
 | `pulseed setup` | Configure provider, model, and adapter |
 | `pulseed goal add "<text>"` | Create a goal |
-| `pulseed run --goal <id>` | Execute CoreLoop for one goal |
+| `pulseed run --goal <id>` | Execute CoreLoop for one goal with bounded policy (default max 100 iterations) |
+| `pulseed run --goal <id> --resident` | Execute CoreLoop with resident policy; iteration count is telemetry, not a lifecycle cap |
+| `pulseed daemon start --iterations-per-cycle <n>` | Start daemon workers in bounded canary mode with `<n>` as the CoreLoop cap |
+| `pulseed daemon start --resident --iterations-per-cycle <n>` | Start daemon workers in resident mode with `<n>` as a telemetry window |
 | `pulseed status --goal <id>` | Inspect goal state |
 | `pulseed report --goal <id>` | Read the latest report |
 | `pulseed task list --goal <id>` | Inspect tasks |

--- a/src/interface/cli/__tests__/cli-daemon-start.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-start.test.ts
@@ -301,6 +301,69 @@ describe("cmdStart", () => {
     );
   });
 
+  it("treats --iterations-per-cycle as a bounded daemon canary cap by default", async () => {
+    process.env.PULSEED_WATCHDOG_CHILD = "1";
+
+    await cmdStart(
+      { getBaseDir: vi.fn().mockReturnValue("/tmp/pulseed-daemon-start-base") } as never,
+      {} as never,
+      ["--iterations-per-cycle", "1"]
+    );
+
+    expect(daemonRunnerArgs[0]).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          iterations_per_cycle: 1,
+          run_policy: { mode: "bounded", max_iterations: 1 },
+        }),
+      })
+    );
+  });
+
+  it("allows --resident to keep --iterations-per-cycle as daemon telemetry", async () => {
+    process.env.PULSEED_WATCHDOG_CHILD = "1";
+
+    await cmdStart(
+      { getBaseDir: vi.fn().mockReturnValue("/tmp/pulseed-daemon-start-base") } as never,
+      {} as never,
+      ["--resident", "--iterations-per-cycle", "3"]
+    );
+
+    expect(daemonRunnerArgs[0]).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          iterations_per_cycle: 3,
+          run_policy: { mode: "resident", max_iterations: null },
+        }),
+      })
+    );
+  });
+
+  it("keeps legacy daemon.json iterations_per_cycle configs bounded", async () => {
+    process.env.PULSEED_WATCHDOG_CHILD = "1";
+    fs.mkdirSync("/tmp/pulseed-daemon-start-base", { recursive: true });
+    fs.writeFileSync(
+      path.join("/tmp/pulseed-daemon-start-base", "daemon.json"),
+      JSON.stringify({ event_server_port: 0, iterations_per_cycle: 2 }),
+      "utf-8"
+    );
+
+    await cmdStart(
+      { getBaseDir: vi.fn().mockReturnValue("/tmp/pulseed-daemon-start-base") } as never,
+      {} as never,
+      []
+    );
+
+    expect(daemonRunnerArgs[0]).toEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          iterations_per_cycle: 2,
+          run_policy: { mode: "bounded", max_iterations: 2 },
+        }),
+      })
+    );
+  });
+
   it("launches RuntimeWatchdog on the top-level daemon start path", async () => {
     await cmdStart(
       { getBaseDir: vi.fn().mockReturnValue("/tmp/pulseed-daemon-start-base") } as never,

--- a/src/interface/cli/__tests__/cli-daemon-status.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-status.test.ts
@@ -648,7 +648,8 @@ describe("cmdDaemonStatus", () => {
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     expect(output).toContain("Config:");
     expect(output).toContain("5m (adaptive sleep: off)");
-    expect(output).toContain("10 per cycle");
+    expect(output).toContain("resident (unbounded; iterations reported as telemetry)");
+    expect(output).toContain("10 iteration telemetry window");
     expect(output).toContain("Proactive:     off");
     expect(output).toContain("Runtime:       durable auto-recovery");
     expect(output).toContain("enabled");
@@ -681,7 +682,8 @@ describe("cmdDaemonStatus", () => {
 
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     expect(output).toContain("2m (adaptive sleep: on)");
-    expect(output).toContain("5 per cycle");
+    expect(output).toContain("bounded (5 iterations max)");
+    expect(output).toContain("5 iterations max");
     expect(output).toContain("Proactive:     on");
     expect(output).toContain("Runtime:       durable auto-recovery");
     expect(output).toContain("/tmp/pulseed-runtime");
@@ -711,7 +713,8 @@ describe("cmdDaemonStatus", () => {
 
     const output = consoleSpy.mock.calls[0]?.[0] as string;
     expect(output).toContain("3m (adaptive sleep: off)");
-    expect(output).toContain("3 per cycle");
+    expect(output).toContain("bounded (3 iterations max)");
+    expect(output).toContain("3 iterations max");
     expect(output).toContain("Runtime:       durable auto-recovery");
   });
 
@@ -739,7 +742,8 @@ describe("cmdDaemonStatus", () => {
     await cmdDaemonStatus([]);
 
     const output = consoleSpy.mock.calls[0]?.[0] as string;
-    expect(output).toContain("7 per cycle");
+    expect(output).toContain("bounded (7 iterations max)");
+    expect(output).toContain("7 iterations max");
     expect(output).toContain("Runtime:       durable auto-recovery");
   });
 

--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -649,7 +649,33 @@ describe("run subcommand", async () => {
 
     expect(vi.mocked(CoreLoop)).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ maxIterations: 5 })
+      expect.objectContaining({
+        maxIterations: 5,
+        runPolicy: { mode: "bounded", maxIterations: 5 },
+      })
+    );
+  });
+
+  it("forwards --resident to CoreLoop as an unbounded resident policy", async () => {
+    await stateManager.saveGoal(makeGoal({ id: "g-resident" }));
+
+    vi.mocked(CoreLoop).mockImplementation(
+      function(_deps: unknown, config: unknown) { return {
+          run: vi.fn().mockResolvedValue(makeLoopResult()),
+          stop: vi.fn(),
+          _capturedConfig: config,
+          setTimeHorizonEngine: vi.fn(),
+        } as unknown as CoreLoop; }
+    );
+
+    await runCLI("run", "--goal", "g-resident", "--resident");
+
+    expect(vi.mocked(CoreLoop)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        maxIterations: null,
+        runPolicy: { mode: "resident", maxIterations: null },
+      })
     );
   });
 });

--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -86,13 +86,15 @@ export async function dispatchCommand(
   const subcommand = argv[0];
 
   if (subcommand === "run") {
-    let values: { goal?: string[]; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean; workspace?: string };
+    let values: { goal?: string[]; "max-iterations"?: string; resident?: boolean; "no-max-iterations"?: boolean; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean; workspace?: string };
     try {
       ({ values } = parseArgs({
         args: argv.slice(1),
         options: {
           goal: { type: "string", multiple: true },
           "max-iterations": { type: "string" },
+          resident: { type: "boolean" },
+          "no-max-iterations": { type: "boolean" },
           adapter: { type: "string" },
           tree: { type: "boolean" },
           yes: { type: "boolean", short: "y" },
@@ -100,7 +102,7 @@ export async function dispatchCommand(
           workspace: { type: "string" },
         },
         strict: false,
-      }) as { values: { goal?: string[]; "max-iterations"?: string; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean; workspace?: string } });
+      }) as { values: { goal?: string[]; "max-iterations"?: string; resident?: boolean; "no-max-iterations"?: boolean; adapter?: string; tree?: boolean; yes?: boolean; verbose?: boolean; workspace?: string } });
     } catch (err) {
       logger.error(formatOperationError("parse run command arguments", err));
       values = {};
@@ -108,11 +110,11 @@ export async function dispatchCommand(
 
     const goalIds = values.goal ?? [];
     if (goalIds.length === 0) {
-      logger.error(formatGoalRequiredError("run", "pulseed run --goal <id> [--max-iterations <n>] [--adapter <type>] [--tree] [--workspace <path>] [--yes]"));
+      logger.error(formatGoalRequiredError("run", "pulseed run --goal <id> [--max-iterations <n>|--resident] [--adapter <type>] [--tree] [--workspace <path>] [--yes]"));
       return 1;
     }
     if (goalIds.length > 1) {
-      logger.error(formatMultiGoalError("run", "pulseed run --goal <id> [--max-iterations <n>] [--adapter <type>] [--tree] [--workspace <path>] [--yes]"));
+      logger.error(formatMultiGoalError("run", "pulseed run --goal <id> [--max-iterations <n>|--resident] [--adapter <type>] [--tree] [--workspace <path>] [--yes]"));
       return 1;
     }
     const goalId = goalIds[0];
@@ -149,10 +151,23 @@ export async function dispatchCommand(
     }
 
     const loopConfig: LoopConfig = {};
+    const residentRequested = values.resident === true || values["no-max-iterations"] === true;
+    if (residentRequested && values["max-iterations"] !== undefined) {
+      logger.error("Error: use either --max-iterations <n> for bounded runs or --resident/--no-max-iterations for resident runs, not both.");
+      return 1;
+    }
+    if (residentRequested) {
+      loopConfig.runPolicy = { mode: "resident", maxIterations: null };
+      loopConfig.maxIterations = null;
+    }
     if (values["max-iterations"] !== undefined) {
       const parsed = parseInt(values["max-iterations"], 10);
-      if (!isNaN(parsed)) {
+      if (!isNaN(parsed) && parsed > 0) {
+        loopConfig.runPolicy = { mode: "bounded", maxIterations: parsed };
         loopConfig.maxIterations = parsed;
+      } else {
+        logger.error("--max-iterations must be a positive integer");
+        return 1;
       }
     }
     if (values.adapter !== undefined) {

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -61,7 +61,7 @@ export async function cmdStart(
   characterConfigManager: CharacterConfigManager,
   args: string[]
 ): Promise<void> {
-  let values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; "max-concurrent-goals"?: string; workspace?: string };
+  let values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; resident?: boolean; "max-concurrent-goals"?: string; workspace?: string };
   try {
     ({ values } = parseArgs({
       args,
@@ -72,11 +72,12 @@ export async function cmdStart(
         detach: { type: "boolean", short: "d" },
         "check-interval-ms": { type: "string" },
         "iterations-per-cycle": { type: "string" },
+        resident: { type: "boolean" },
         "max-concurrent-goals": { type: "string" },
         workspace: { type: "string" },
       },
       strict: false,
-    }) as { values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; "max-concurrent-goals"?: string; workspace?: string } });
+    }) as { values: { "api-key"?: string; config?: string; goal?: string[]; detach?: boolean; "check-interval-ms"?: string; "iterations-per-cycle"?: string; resident?: boolean; "max-concurrent-goals"?: string; workspace?: string } });
   } catch (err) {
     getCliLogger().error(formatOperationError("parse start command arguments", err));
     values = {};
@@ -126,6 +127,14 @@ export async function cmdStart(
     }
     daemonConfig = daemonConfig ?? {};
     daemonConfig.iterations_per_cycle = parsed;
+    if (values.resident === true) {
+      daemonConfig.run_policy = { mode: "resident", max_iterations: null };
+    } else {
+      daemonConfig.run_policy = { mode: "bounded", max_iterations: parsed };
+    }
+  } else if (values.resident === true) {
+    daemonConfig = daemonConfig ?? {};
+    daemonConfig.run_policy = { mode: "resident", max_iterations: null };
   }
   if (values["max-concurrent-goals"]) {
     const parsed = parseInt(values["max-concurrent-goals"], 10);
@@ -651,11 +660,20 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   const proactive = cfg.proactive_mode ? "on" : "off";
   const crashEnabled = cfg.crash_recovery.enabled ? "enabled" : "disabled";
   const maxRetries = cfg.crash_recovery.max_retries;
+  const runPolicy =
+    cfg.run_policy.mode === "resident"
+      ? "resident (unbounded; iterations reported as telemetry)"
+      : `bounded (${cfg.run_policy.max_iterations ?? cfg.iterations_per_cycle} iterations max)`;
+  const workerCycle =
+    cfg.run_policy.mode === "resident"
+      ? `${cfg.iterations_per_cycle} iteration telemetry window`
+      : `${cfg.run_policy.max_iterations ?? cfg.iterations_per_cycle} iterations max`;
 
   lines.push("");
   lines.push("Config:");
   lines.push(`  Interval:      ${intervalMin}m (adaptive sleep: ${adaptiveSleep})`);
-  lines.push(`  Iterations:    ${cfg.iterations_per_cycle} per cycle`);
+  lines.push(`  Run policy:    ${runPolicy}`);
+  lines.push(`  Worker cycle:  ${workerCycle}`);
   lines.push(`  Concurrency:   ${cfg.max_concurrent_goals} goal${cfg.max_concurrent_goals === 1 ? "" : "s"}`);
   lines.push(`  Proactive:     ${proactive}`);
   lines.push("  Runtime:       durable auto-recovery");

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -100,7 +100,8 @@ Usage:
 
 Options (pulseed run):
   --goal <id>                         Goal ID to run (required)
-  --max-iterations <n>               Override max iterations (default: 100)
+  --max-iterations <n>               Bounded run cap (default: 100)
+  --resident, --no-max-iterations    Resident run policy; no iteration-count lifecycle cap
   --adapter <type>                    Adapter: claude_api | claude_code_cli | github_issue (default: claude_api)
   --tree                              Enable tree mode (iterate across all tree nodes)
   --yes, -y                           Auto-approve all tasks (skip approval prompts)

--- a/src/interface/cli/utils/loop-runner.ts
+++ b/src/interface/cli/utils/loop-runner.ts
@@ -24,7 +24,8 @@ export function buildLoopLogger(): Logger {
 export function buildProgressHandler(): (event: ProgressEvent) => void {
   let lastIterationLogged = -1;
   return (event: ProgressEvent): void => {
-    const prefix = `[${event.iteration}/${event.maxIterations}]`;
+    const limit = event.maxIterations === null ? "resident" : String(event.maxIterations);
+    const prefix = `[${event.iteration}/${limit}]`;
     if (event.phase === "Observing...") {
       if (event.iteration !== lastIterationLogged) {
         lastIterationLogged = event.iteration;

--- a/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { CoreLoop, makeEmptyIterationResult, type CoreLoopDeps } from "../core-loop.js";
+import { makeGoal } from "../../../../tests/helpers/fixtures.js";
+
+function makeDeps(): CoreLoopDeps {
+  return {
+    stateManager: {
+      loadGoal: vi.fn(async (goalId: string) => makeGoal({ id: goalId, status: "active", dimensions: [] })),
+      saveGoal: vi.fn(),
+      archiveGoal: vi.fn(),
+      restoreFromCheckpoint: vi.fn(async () => 0),
+    },
+    stallDetector: {
+      resetEscalation: vi.fn(),
+    },
+    strategyManager: {
+      setStrategyTemplateRegistry: vi.fn(),
+    },
+    hookManager: {
+      emit: vi.fn(),
+      getDreamCollector: vi.fn(() => null),
+    },
+  } as unknown as CoreLoopDeps;
+}
+
+describe("CoreLoop run policies", () => {
+  it("keeps bounded maxIterations as a lifecycle cap", async () => {
+    const loop = new CoreLoop(makeDeps(), {
+      maxIterations: 2,
+      delayBetweenLoopsMs: 0,
+      dryRun: true,
+      autoDecompose: false,
+    });
+    vi.spyOn(loop, "runOneIteration").mockImplementation(async (goalId, loopIndex) =>
+      makeEmptyIterationResult(goalId, loopIndex)
+    );
+
+    const result = await loop.run("goal-bounded");
+
+    expect(result.finalStatus).toBe("max_iterations");
+    expect(result.totalIterations).toBe(2);
+  });
+
+  it("lets resident runs continue without an iteration-count lifecycle cap until explicitly stopped", async () => {
+    const loop = new CoreLoop(makeDeps(), {
+      maxIterations: null,
+      runPolicy: "resident",
+      delayBetweenLoopsMs: 0,
+      dryRun: true,
+      autoDecompose: false,
+    });
+    vi.spyOn(loop, "runOneIteration").mockImplementation(async (goalId, loopIndex) => {
+      if (loopIndex === 2) {
+        loop.stop();
+      }
+      return makeEmptyIterationResult(goalId, loopIndex);
+    });
+
+    const result = await loop.run("goal-resident");
+
+    expect(result.finalStatus).toBe("stopped");
+    expect(result.totalIterations).toBe(3);
+  });
+
+  it("treats a maxIterations null run override as resident even on a bounded loop", async () => {
+    const loop = new CoreLoop(makeDeps(), {
+      maxIterations: 100,
+      delayBetweenLoopsMs: 0,
+      dryRun: true,
+      autoDecompose: false,
+    });
+    vi.spyOn(loop, "runOneIteration").mockImplementation(async (goalId, loopIndex) => {
+      if (loopIndex === 1) {
+        loop.stop();
+      }
+      return makeEmptyIterationResult(goalId, loopIndex);
+    });
+
+    const result = await loop.run("goal-null-override", { maxIterations: null });
+
+    expect(result.finalStatus).toBe("stopped");
+    expect(result.totalIterations).toBe(2);
+  });
+});

--- a/src/orchestrator/loop/core-loop.ts
+++ b/src/orchestrator/loop/core-loop.ts
@@ -10,6 +10,7 @@ import type {
   LoopConfig,
   ResolvedLoopConfig,
   CoreLoopDeps,
+  LoopRunPolicyMode,
 } from "./core-loop/contracts.js";
 import {
   runTreeIteration as runTreeIterationImpl,
@@ -24,6 +25,7 @@ import { CoreDecisionEngine } from "./core-loop/decision-engine.js";
 import type { CorePhasePolicyRegistry } from "./core-loop/phase-policy.js";
 import { CoreIterationKernel } from "./core-loop/iteration-kernel.js";
 import type { GoalRunActivationContext } from "../../base/types/goal-activation.js";
+import { resolveLoopConfig, resolveLoopRunPolicy } from "./run-policy.js";
 
 // Re-export types for backward compatibility
 export type {
@@ -37,6 +39,7 @@ export type {
   CoreLoopDeps,
   ProgressEvent,
   ProgressPhase,
+  LoopRunPolicyMode,
 } from "./core-loop/contracts.js";
 export type {
   LoopIterationResult,
@@ -47,6 +50,7 @@ export { makeEmptyIterationResult } from "./loop-result-types.js";
 
 const DEFAULT_CONFIG: Required<Omit<LoopConfig, "iterationBudget">> = {
   maxIterations: 100,
+  runPolicy: { mode: "bounded", maxIterations: 100 },
   maxConsecutiveErrors: 3,
   delayBetweenLoopsMs: 1000,
   adapterType: "openai_codex_cli",
@@ -94,7 +98,14 @@ export class CoreLoop {
 
   constructor(deps: CoreLoopDeps, config?: LoopConfig, stateDiff?: StateDiffCalculator) {
     this.deps = deps;
-    this.config = { ...DEFAULT_CONFIG, ...config };
+    const mergedConfig: LoopConfig = { ...DEFAULT_CONFIG, ...config };
+    if (config?.maxIterations === undefined && typeof config?.runPolicy === "object") {
+      mergedConfig.maxIterations = config.runPolicy.maxIterations;
+    }
+    if (config?.maxIterations === undefined && config?.runPolicy === "resident") {
+      mergedConfig.maxIterations = null;
+    }
+    this.config = resolveLoopConfig(mergedConfig) as ResolvedLoopConfig;
     this.logger = deps.logger;
     this.stateDiff = stateDiff;
     this.corePhasePolicyRegistry = deps.corePhasePolicyRegistry ?? new StaticCorePhasePolicyRegistry();
@@ -110,20 +121,26 @@ export class CoreLoop {
 
   /**
    * Run the full loop until completion or stop condition.
-   * @param options.maxIterations - Override config.maxIterations for this run only (e.g. per-cycle budget from DaemonRunner).
+   * @param options.maxIterations - Override config.maxIterations for this run only. Use null for resident/unbounded policy.
    */
   async run(
     goalId: string,
-    options?: { maxIterations?: number; onProgress?: CoreLoopDeps["onProgress"]; activation?: GoalRunActivationContext }
+    options?: { maxIterations?: number | null; runPolicy?: LoopConfig["runPolicy"]; onProgress?: CoreLoopDeps["onProgress"]; activation?: GoalRunActivationContext }
   ): Promise<LoopResult> {
     const depsWithMutableProgress = this.deps as CoreLoopDeps;
     const previousOnProgress = depsWithMutableProgress.onProgress;
     const previousMaxIterations = this.config.maxIterations;
+    const previousRunPolicy = this.config.runPolicy;
     if (options?.onProgress) {
       depsWithMutableProgress.onProgress = options.onProgress;
     }
-    if (options?.maxIterations !== undefined) {
-      this.config.maxIterations = options.maxIterations;
+    if (options?.maxIterations !== undefined || options?.runPolicy !== undefined) {
+      const runPolicy = resolveLoopRunPolicy({
+        runPolicy: options?.runPolicy ?? this.config.runPolicy,
+        maxIterations: options?.maxIterations !== undefined ? options.maxIterations : this.config.maxIterations,
+      });
+      this.config.maxIterations = runPolicy.maxIterations;
+      this.config.runPolicy = runPolicy;
     }
     this.currentActivationContext = options?.activation;
 
@@ -186,26 +203,34 @@ export class CoreLoop {
       consecutiveDenied: 0,
       consecutiveEscalations: 0,
     };
-    let finalStatus: LoopResult["finalStatus"] = "max_iterations";
+    let finalStatus: LoopResult["finalStatus"] = this.config.runPolicy?.mode === "bounded" ? "max_iterations" : "stopped";
 
-    // Effective maxIterations: runtime override takes precedence over config.
-    const effectiveMaxIterations = options?.maxIterations ?? this.config.maxIterations;
+    const effectiveRunPolicy = this.config.runPolicy ?? resolveLoopRunPolicy({ maxIterations: this.config.maxIterations });
+    const effectiveMaxIterations = effectiveRunPolicy.maxIterations;
+    const hasIterationCap = effectiveRunPolicy.mode === "bounded" && effectiveMaxIterations !== null;
 
     // Use the provided iterationBudget if set; otherwise create a local one.
-    const budget: IterationBudget = this.config.iterationBudget
-      ?? new IterationBudget(effectiveMaxIterations);
+    const budget: IterationBudget | null = this.config.iterationBudget
+      ?? (hasIterationCap ? new IterationBudget(effectiveMaxIterations) : null);
 
     // Per-node iteration tracking for tree mode.
     const nodeConsumedMap = new Map<string, number>();
 
-    for (let loopIndex = startLoopIndex; loopIndex < startLoopIndex + effectiveMaxIterations; loopIndex++) {
+    for (
+      let loopIndex = startLoopIndex;
+      hasIterationCap ? loopIndex < startLoopIndex + effectiveMaxIterations : true;
+      loopIndex++
+    ) {
       if (this.stopped) {
         finalStatus = "stopped";
         break;
       }
 
-      if (budget.exhausted) {
+      if (budget?.exhausted) {
         this.logger?.info("Iteration budget exhausted, stopping loop");
+        if (effectiveRunPolicy.mode === "bounded") {
+          finalStatus = "max_iterations";
+        }
         break;
       }
 
@@ -237,7 +262,7 @@ export class CoreLoop {
 
       // Only consume budget for non-skipped iterations.
       if (!iterationResult.skipped) {
-        const { allowed, warnings } = budget.consume();
+        const { allowed, warnings } = budget ? budget.consume() : { allowed: true, warnings: [] };
         for (const w of warnings) { this.logger?.warn(w); }
         if (!allowed) {
           this.logger?.info("Iteration budget exhausted, stopping loop");
@@ -324,7 +349,10 @@ export class CoreLoop {
       }
 
       // Delay between loops (skip on last iteration)
-      if (loopIndex < startLoopIndex + effectiveMaxIterations - 1 && this.config.delayBetweenLoopsMs > 0) {
+      const shouldDelay =
+        this.config.delayBetweenLoopsMs > 0 &&
+        (!hasIterationCap || loopIndex < startLoopIndex + effectiveMaxIterations - 1);
+      if (shouldDelay) {
         // Gap 4: adaptive observation frequency — scale delay by pacing status when
         // a TimeHorizonEngine is available. Falls back to fixed delayBetweenLoopsMs.
         let delay = this.config.delayBetweenLoopsMs;
@@ -367,6 +395,7 @@ export class CoreLoop {
       this.currentActivationContext = undefined;
       depsWithMutableProgress.onProgress = previousOnProgress;
       this.config.maxIterations = previousMaxIterations;
+      this.config.runPolicy = previousRunPolicy;
     }
   }
 

--- a/src/orchestrator/loop/core-loop/contracts.ts
+++ b/src/orchestrator/loop/core-loop/contracts.ts
@@ -118,10 +118,34 @@ export interface WaitApprovalBroker {
  * LoopConfig with all required fields resolved (except iterationBudget which remains optional).
  * Used as the internal config type throughout CoreLoop and its sub-modules.
  */
-export type ResolvedLoopConfig = Required<Omit<LoopConfig, "iterationBudget">> & Pick<LoopConfig, "iterationBudget">;
+export type LoopRunPolicyMode = "bounded" | "resident";
+
+export interface LoopRunPolicy {
+  mode: LoopRunPolicyMode;
+  maxIterations: number | null;
+}
+
+export type LoopRunPolicyInput =
+  | LoopRunPolicyMode
+  | Partial<LoopRunPolicy>;
+
+export type ResolvedLoopConfig =
+  Required<Omit<LoopConfig, "iterationBudget" | "runPolicy" | "maxIterations">>
+  & Pick<LoopConfig, "iterationBudget">
+  & {
+    maxIterations: number | null;
+    runPolicy?: LoopRunPolicy;
+  };
 
 export interface LoopConfig {
-  maxIterations?: number;
+  maxIterations?: number | null;
+  /**
+   * Bounded runs use maxIterations as a lifecycle cap. Resident runs use
+   * iteration count only as telemetry/checkpoint metadata and continue until
+   * completion, stall, explicit stop/pause, error policy, or another lifecycle
+   * controller stops them.
+   */
+  runPolicy?: LoopRunPolicyInput;
   maxConsecutiveErrors?: number;
   delayBetweenLoopsMs?: number;
   adapterType?: string;
@@ -305,7 +329,7 @@ export interface ProgressEvent {
   /** 1-based iteration number */
   iteration: number;
   /** Maximum iterations configured */
-  maxIterations: number;
+  maxIterations: number | null;
   /** Current phase label */
   phase: ProgressPhase;
   /** Gap aggregate from latest gap calculation (undefined before first gap calc) */

--- a/src/orchestrator/loop/run-policy.ts
+++ b/src/orchestrator/loop/run-policy.ts
@@ -1,0 +1,40 @@
+import type { LoopConfig, LoopRunPolicy, LoopRunPolicyInput } from "./core-loop/contracts.js";
+
+export function resolveLoopRunPolicy(input?: {
+  runPolicy?: LoopRunPolicyInput;
+  maxIterations?: number | null;
+}): LoopRunPolicy {
+  const rawPolicy = input?.runPolicy;
+  const rawMaxIterations = input?.maxIterations;
+
+  if (rawMaxIterations === null) {
+    return { mode: "resident", maxIterations: null };
+  }
+
+  if (rawPolicy === "resident" || (typeof rawPolicy === "object" && rawPolicy.mode === "resident")) {
+    return { mode: "resident", maxIterations: null };
+  }
+
+  if (rawPolicy === "bounded" || (typeof rawPolicy === "object" && rawPolicy.mode === "bounded")) {
+    const maxIterations = rawMaxIterations ?? (typeof rawPolicy === "object" ? rawPolicy.maxIterations : undefined);
+    return { mode: "bounded", maxIterations: normalizeBoundedMaxIterations(maxIterations) };
+  }
+
+  return { mode: "bounded", maxIterations: normalizeBoundedMaxIterations(rawMaxIterations) };
+}
+
+export function resolveLoopConfig(config: LoopConfig = {}): LoopConfig & { runPolicy: LoopRunPolicy; maxIterations: number | null } {
+  const runPolicy = resolveLoopRunPolicy(config);
+  return {
+    ...config,
+    maxIterations: runPolicy.maxIterations,
+    runPolicy,
+  };
+}
+
+function normalizeBoundedMaxIterations(value: number | null | undefined): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.trunc(value);
+  }
+  return 100;
+}

--- a/src/runtime/__tests__/goal-worker.test.ts
+++ b/src/runtime/__tests__/goal-worker.test.ts
@@ -70,6 +70,39 @@ describe("GoalWorker", () => {
   // ─── 2. WorkerResult mapping ───
 
   describe("execute() returns correct WorkerResult", () => {
+    it("passes resident run policy without a numeric max iteration cap", async () => {
+      const loopResult = makeLoopResult({ goalId: "g1", totalIterations: 2, finalStatus: "stopped" });
+      const coreLoop = makeMockCoreLoop(loopResult);
+      const worker = new GoalWorker(coreLoop as any, {
+        iterationsPerCycle: 5,
+        runPolicy: "resident",
+      });
+
+      await worker.execute("g1");
+
+      expect(coreLoop.run).toHaveBeenCalledWith("g1", {
+        maxIterations: null,
+        runPolicy: "resident",
+      });
+    });
+
+    it("passes bounded run policy maxIterations instead of the telemetry cycle size", async () => {
+      const loopResult = makeLoopResult({ goalId: "g1", totalIterations: 7, finalStatus: "max_iterations" });
+      const coreLoop = makeMockCoreLoop(loopResult);
+      const worker = new GoalWorker(coreLoop as any, {
+        iterationsPerCycle: 5,
+        maxIterations: 7,
+        runPolicy: "bounded",
+      });
+
+      await worker.execute("g1");
+
+      expect(coreLoop.run).toHaveBeenCalledWith("g1", {
+        maxIterations: 7,
+        runPolicy: "bounded",
+      });
+    });
+
     it("maps completed LoopResult to completed WorkerResult", async () => {
       const loopResult = makeLoopResult({ goalId: "g1", totalIterations: 5, finalStatus: "completed" });
       const worker = new GoalWorker(makeMockCoreLoop(loopResult) as any);

--- a/src/runtime/__tests__/runner-goal-cycle.test.ts
+++ b/src/runtime/__tests__/runner-goal-cycle.test.ts
@@ -96,7 +96,8 @@ describe("runDaemonGoalCycleLoop", () => {
     expect(run).toHaveBeenCalledWith(
       "goal-1",
       expect.objectContaining({
-        maxIterations: 1,
+        maxIterations: null,
+        runPolicy: "resident",
         onProgress: expect.any(Function),
       })
     );

--- a/src/runtime/__tests__/schedule-engine.test.ts
+++ b/src/runtime/__tests__/schedule-engine.test.ts
@@ -1489,7 +1489,7 @@ describe("Escalation", () => {
 
     await eng.tick();
 
-    expect(coreLoop.run).toHaveBeenCalledWith("goal-target", { maxIterations: 2 });
+    expect(coreLoop.run).toHaveBeenCalledWith("goal-target", { maxIterations: 2, runPolicy: "bounded" });
     const updatedTarget = eng.getEntries().find((e) => e.id === targetEntry.id)!;
     expect(updatedTarget.last_fired_at).not.toBeNull();
   });
@@ -1531,7 +1531,10 @@ describe("Escalation", () => {
 
     expect(results[0]!.status).toBe("escalated");
     expect(results[0]!.escalated_to).toBe("goal-direct");
-    expect(coreLoop.run).toHaveBeenCalledWith("goal-direct");
+    expect(coreLoop.run).toHaveBeenCalledWith("goal-direct", {
+      maxIterations: 10,
+      runPolicy: "bounded",
+    });
   });
 });
 
@@ -2057,7 +2060,35 @@ describe("GoalTrigger execution (Phase 3)", () => {
     const result = await (eng as any).executeGoalTrigger(entry);
 
     expect(result.status).toBe("ok");
-    expect(mockCoreLoop.run).toHaveBeenCalledWith("test-goal-id", { maxIterations: 5 });
+    expect(mockCoreLoop.run).toHaveBeenCalledWith("test-goal-id", { maxIterations: 5, runPolicy: "bounded" });
+  });
+
+  it("executeGoalTrigger can run a resident policy without a numeric max iteration cap", async () => {
+    const mockCoreLoop = {
+      run: vi.fn().mockResolvedValue({ finalStatus: "stopped", totalIterations: 3 }),
+    };
+
+    const eng = new ScheduleEngine({
+      baseDir: tempDir,
+      coreLoop: mockCoreLoop,
+    });
+
+    const entry = await eng.addEntry({
+      ...makeGoalTriggerEntry(),
+      goal_trigger: {
+        goal_id: "test-goal-id",
+        run_policy: "resident",
+        max_iterations: null,
+        skip_if_active: false,
+      },
+    });
+    const result = await (eng as any).executeGoalTrigger(entry);
+
+    expect(result.status).toBe("ok");
+    expect(mockCoreLoop.run).toHaveBeenCalledWith("test-goal-id", {
+      maxIterations: null,
+      runPolicy: "resident",
+    });
   });
 
   it("executeGoalTrigger skips when goal is active and skip_if_active is true", async () => {
@@ -2419,7 +2450,7 @@ describe("GoalTrigger execution — token accumulation (Phase 3)", () => {
     expect(result.status).toBe("ok");
     // tokens_used is 0 until LoopResult exposes token usage (Phase 4 TODO)
     expect(result.tokens_used).toBe(0);
-    expect(mockCoreLoop.run).toHaveBeenCalledWith("test-goal-id", { maxIterations: 3 });
+    expect(mockCoreLoop.run).toHaveBeenCalledWith("test-goal-id", { maxIterations: 3, runPolicy: "bounded" });
   });
 });
 
@@ -2762,7 +2793,7 @@ describe("GoalTrigger token tracking (Phase 4)", () => {
 
     expect(result.status).toBe("ok");
     expect(result.tokens_used).toBe(1500);
-    expect(mockCoreLoop.run).toHaveBeenCalledWith("goal-abc", { maxIterations: 5 });
+    expect(mockCoreLoop.run).toHaveBeenCalledWith("goal-abc", { maxIterations: 5, runPolicy: "bounded" });
   });
 });
 

--- a/src/runtime/daemon/runner-goal-cycle.ts
+++ b/src/runtime/daemon/runner-goal-cycle.ts
@@ -109,8 +109,11 @@ export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): P
 
         try {
           const iterationsPerCycle = context.config.iterations_per_cycle ?? 1;
+          const runPolicy = context.config.run_policy?.mode ?? "resident";
+          const boundedMaxIterations = context.config.run_policy?.max_iterations ?? iterationsPerCycle;
           const result: LoopResult = await context.coreLoop.run(goalId, {
-            maxIterations: iterationsPerCycle,
+            maxIterations: runPolicy === "resident" ? null : boundedMaxIterations,
+            runPolicy,
             onProgress: (event: ProgressEvent) => {
               if (!context.eventServer) return;
               void context.eventServer.broadcast?.("progress", {

--- a/src/runtime/daemon/runner-startup.ts
+++ b/src/runtime/daemon/runner-startup.ts
@@ -233,6 +233,8 @@ export async function startDaemonRunner(
         {
           concurrency: context.config.max_concurrent_goals,
           iterationsPerCycle: context.config.iterations_per_cycle,
+          maxIterations: context.config.run_policy?.max_iterations ?? undefined,
+          runPolicy: context.config.run_policy?.mode ?? "resident",
           stateFilePath: path.join(context.runtimeRoot!, "supervisor-state.json"),
         }
       );

--- a/src/runtime/executor/goal-worker.ts
+++ b/src/runtime/executor/goal-worker.ts
@@ -1,10 +1,13 @@
 import { randomUUID } from 'node:crypto';
 import type { CoreLoop } from '../../orchestrator/loop/core-loop.js';
 import type { LoopResult } from '../../orchestrator/loop/core-loop.js';
+import type { LoopRunPolicyMode } from '../../orchestrator/loop/core-loop.js';
 import type { GoalRunActivationContext } from '../../base/types/goal-activation.js';
 
 export interface GoalWorkerConfig {
   iterationsPerCycle: number; // default 5
+  maxIterations?: number | null;
+  runPolicy?: LoopRunPolicyMode;
 }
 
 export type WorkerStatus = 'idle' | 'running' | 'crashed';
@@ -53,8 +56,13 @@ export class GoalWorker {
       let cumulativeIterations = 0;
       do {
         this.extendRequested = false;
+        const maxIterations =
+          this.config.runPolicy === 'resident'
+            ? null
+            : this.config.maxIterations ?? this.config.iterationsPerCycle;
         lastResult = await this.coreLoop.run(goalId, {
-          maxIterations: this.config.iterationsPerCycle,
+          maxIterations,
+          ...(this.config.runPolicy ? { runPolicy: this.config.runPolicy } : {}),
           ...(activation ? { activation } : {}),
         });
         cumulativeIterations += lastResult.totalIterations;

--- a/src/runtime/executor/loop-supervisor.ts
+++ b/src/runtime/executor/loop-supervisor.ts
@@ -13,16 +13,19 @@ import { getPulseedDirPath } from '../../base/utils/paths.js';
 import type { BackgroundRunLedger } from '../store/background-run-store.js';
 import type { BackgroundRun, RuntimeSessionRef } from '../session-registry/types.js';
 import type { WaitResumeActivation } from '../../base/types/goal-activation.js';
+import type { LoopRunPolicyMode } from '../../orchestrator/loop/core-loop.js';
 
 export interface SupervisorConfig {
   concurrency: number;
   iterationsPerCycle: number;
+  maxIterations?: number | null;
   maxCrashCount: number;
   crashBackoffBaseMs: number;
   stateFilePath: string;
   pollIntervalMs: number;
   claimLeaseMs: number;
   leaseRenewIntervalMs: number;
+  runPolicy: LoopRunPolicyMode;
 }
 
 export interface SupervisorDeps {
@@ -84,6 +87,7 @@ const DEFAULT_CONFIG: SupervisorConfig = {
   pollIntervalMs: 100,
   claimLeaseMs: 30_000,
   leaseRenewIntervalMs: 10_000,
+  runPolicy: 'resident',
 };
 
 function workerStatusToBackgroundRunStatus(
@@ -120,7 +124,11 @@ export class LoopSupervisor {
   }
 
   async start(initialGoalIds: string[]): Promise<void> {
-    const workerCfg: GoalWorkerConfig = { iterationsPerCycle: this.config.iterationsPerCycle };
+    const workerCfg: GoalWorkerConfig = {
+      iterationsPerCycle: this.config.iterationsPerCycle,
+      maxIterations: this.config.maxIterations,
+      runPolicy: this.config.runPolicy,
+    };
     for (let i = 0; i < this.config.concurrency; i++) {
       this.workers.push(new GoalWorker(this.deps.coreLoopFactory(), workerCfg, {
         onRunStart: () => {
@@ -194,7 +202,11 @@ export class LoopSupervisor {
       return;
     }
 
-    const workerCfg: GoalWorkerConfig = { iterationsPerCycle: this.config.iterationsPerCycle };
+    const workerCfg: GoalWorkerConfig = {
+      iterationsPerCycle: this.config.iterationsPerCycle,
+      maxIterations: this.config.maxIterations,
+      runPolicy: this.config.runPolicy,
+    };
     this.workers = [];
     for (let i = 0; i < this.config.concurrency; i++) {
       this.workers.push(new GoalWorker(coreLoopFactory(), workerCfg, {

--- a/src/runtime/schedule/engine-execution.ts
+++ b/src/runtime/schedule/engine-execution.ts
@@ -254,7 +254,7 @@ export async function executeEscalationTargetEntryForEngine(
 }
 
 export async function executeEscalationTargetGoalForEngine(
-  host: Pick<ScheduleExecutionHost, "logger"> & { coreLoop?: { run(goalId: string, options?: { maxIterations?: number }): Promise<any> } },
+  host: Pick<ScheduleExecutionHost, "logger"> & { coreLoop?: { run(goalId: string, options?: { maxIterations?: number | null; runPolicy?: "bounded" | "resident" }): Promise<any> } },
   goalId: string
 ): Promise<ScheduleResult> {
   const now = new Date().toISOString();
@@ -272,7 +272,7 @@ export async function executeEscalationTargetGoalForEngine(
 
   const startedAt = Date.now();
   try {
-    const result = await host.coreLoop.run(goalId);
+    const result = await host.coreLoop.run(goalId, { maxIterations: 10, runPolicy: "bounded" });
     return ScheduleResultSchema.parse({
       entry_id: randomUUID(),
       status: "ok",

--- a/src/runtime/schedule/engine-layers.ts
+++ b/src/runtime/schedule/engine-layers.ts
@@ -23,7 +23,7 @@ interface LayerDeps {
   dataSourceRegistry?: Map<string, IDataSourceAdapter> | DataSourceRegistry;
   llmClient?: ILLMClient;
   notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<any> };
-  coreLoop?: { run(goalId: string, options?: { maxIterations?: number; activation?: GoalRunActivationContext }): Promise<any> };
+  coreLoop?: { run(goalId: string, options?: { maxIterations?: number | null; runPolicy?: "bounded" | "resident"; activation?: GoalRunActivationContext }): Promise<any> };
   stateManager?: StateManager;
   reportingEngine?: { generateNotification(type: string, context: Record<string, unknown>): Promise<any> };
   hookManager?: HookManager;
@@ -259,7 +259,9 @@ export async function executeGoalTrigger(entry: ScheduleEntry, deps: LayerDeps):
       });
     }
 
-    const result = await deps.coreLoop.run(cfg.goal_id, { maxIterations: cfg.max_iterations });
+    const result = cfg.run_policy === "resident"
+      ? await deps.coreLoop.run(cfg.goal_id, { maxIterations: null, runPolicy: "resident" })
+      : await deps.coreLoop.run(cfg.goal_id, { maxIterations: cfg.max_iterations ?? 10, runPolicy: "bounded" });
     const tokensUsed = result?.tokensUsed ?? 0;
     if (result) {
       deps.logger.info(`GoalTrigger "${entry.name}" completed: status=${result.finalStatus}, iterations=${result.totalIterations}`);

--- a/src/runtime/schedule/engine.ts
+++ b/src/runtime/schedule/engine.ts
@@ -62,7 +62,7 @@ interface ScheduleEngineDeps {
   // Using Record<string,unknown> here allows ScheduleEngine to dispatch without constructing
   // a full Report object. Full Report integration deferred to Phase 4.
   notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<any> };
-  coreLoop?: { run(goalId: string, options?: { maxIterations?: number; activation?: GoalRunActivationContext }): Promise<any> };
+  coreLoop?: { run(goalId: string, options?: { maxIterations?: number | null; runPolicy?: "bounded" | "resident"; activation?: GoalRunActivationContext }): Promise<any> };
   stateManager?: StateManager;
   reportingEngine?: { generateNotification(type: string, context: Record<string, unknown>): Promise<any> };
   hookManager?: HookManager;
@@ -83,7 +83,7 @@ export class ScheduleEngine {
   private dataSourceRegistry?: Map<string, IDataSourceAdapter> | DataSourceRegistry;
   private llmClient?: ILLMClient;
   private notificationDispatcher?: { dispatch(report: Record<string, unknown>): Promise<any> };
-  private coreLoop?: { run(goalId: string, options?: { maxIterations?: number; activation?: GoalRunActivationContext }): Promise<any> };
+  private coreLoop?: { run(goalId: string, options?: { maxIterations?: number | null; runPolicy?: "bounded" | "resident"; activation?: GoalRunActivationContext }): Promise<any> };
   private stateManager?: StateManager;
   private reportingEngine?: { generateNotification(type: string, context: Record<string, unknown>): Promise<any> };
   private hookManager?: HookManager;

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -3,8 +3,29 @@ import { RuntimeSafePauseRecordSchema } from "../store/runtime-schemas.js";
 
 const PID_EPOCH_ISO = "1970-01-01T00:00:00.000Z";
 
+function applyLegacyDaemonRunPolicy(raw: unknown): unknown {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    return raw;
+  }
+  const input = raw as Record<string, unknown>;
+  if (
+    Object.prototype.hasOwnProperty.call(input, "run_policy")
+    || !Object.prototype.hasOwnProperty.call(input, "iterations_per_cycle")
+  ) {
+    return raw;
+  }
+  const iterationsPerCycle = input.iterations_per_cycle;
+  if (typeof iterationsPerCycle !== "number" || !Number.isInteger(iterationsPerCycle) || iterationsPerCycle <= 0) {
+    return raw;
+  }
+  return {
+    ...input,
+    run_policy: { mode: "bounded", max_iterations: iterationsPerCycle },
+  };
+}
+
 // Daemon configuration
-export const DaemonConfigSchema = z.object({
+const DaemonConfigObjectSchema = z.object({
   // Deprecated compatibility flag. Durable runtime recovery is always enabled.
   runtime_journal_v2: z.boolean().default(true),
   check_interval_ms: z.number().int().positive().default(300_000), // 5 min default
@@ -23,7 +44,7 @@ export const DaemonConfigSchema = z.object({
     graceful_shutdown_timeout_ms: z.number().int().positive().optional(),
   }).default({}),
   goal_intervals: z.record(z.string(), z.number().int().positive()).optional(), // goal_id -> interval_ms override
-  iterations_per_cycle: z.number().int().positive().default(10), // max CoreLoop iterations per daemon cycle
+  iterations_per_cycle: z.number().int().positive().default(10), // telemetry window in resident mode; bounded fallback cap
   max_concurrent_goals: z.number().int().positive().default(4), // max goals the supervisor may execute at once
   event_server_port: z.number().int().nonnegative().default(41700), // EventServer HTTP port (0 = OS-assigned, safe for tests)
   gateway: z.object({
@@ -36,6 +57,10 @@ export const DaemonConfigSchema = z.object({
     }).default({}),
   }).default({}),
   proactive_mode: z.boolean().default(false),
+  run_policy: z.object({
+    mode: z.enum(["bounded", "resident"]).default("resident"),
+    max_iterations: z.number().int().positive().nullable().default(null),
+  }).default({}),
   proactive_interval_ms: z.number().default(3_600_000), // 1 hour minimum between proactive ticks
   goal_review_interval_ms: z.number().int().nonnegative().default(7 * 24 * 60 * 60 * 1000), // weekly goal review cadence
   adaptive_sleep: z.object({
@@ -47,6 +72,7 @@ export const DaemonConfigSchema = z.object({
     night_multiplier: z.number().default(2.0),          // 2x interval at night
   }).default({}),
 });
+export const DaemonConfigSchema = z.preprocess(applyLegacyDaemonRunPolicy, DaemonConfigObjectSchema);
 export type DaemonConfig = z.infer<typeof DaemonConfigSchema>;
 
 export const ResidentActivitySchema = z.object({

--- a/src/runtime/types/schedule.ts
+++ b/src/runtime/types/schedule.ts
@@ -57,8 +57,17 @@ export type CronConfig = z.infer<typeof CronConfigSchema>;
 
 export const GoalTriggerConfigSchema = z.object({
   goal_id: z.string(),
-  max_iterations: z.number().default(10),
+  run_policy: z.enum(["bounded", "resident"]).default("bounded"),
+  max_iterations: z.number().int().positive().nullable().default(10),
   skip_if_active: z.boolean().default(true),
+}).superRefine((value, ctx) => {
+  if (value.run_policy === "bounded" && value.max_iterations === null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["max_iterations"],
+      message: "bounded goal triggers require max_iterations",
+    });
+  }
 });
 
 export type GoalTriggerConfig = z.infer<typeof GoalTriggerConfigSchema>;


### PR DESCRIPTION
Closes #826

## Summary
- add explicit bounded vs resident CoreLoop run policy resolution, including per-run resident overrides via `maxIterations: null`
- wire resident/bounded policy through CLI run, daemon config/start/status, supervisor/worker execution, schedule goal triggers, and direct escalation targets
- preserve bounded canary behavior for `--max-iterations`, legacy `iterations_per_cycle` daemon configs, and schedule/benchmark paths

## Verification
- `npx vitest run src/runtime/__tests__/schedule-engine.test.ts src/runtime/__tests__/goal-worker.test.ts src/runtime/__tests__/loop-supervisor.test.ts src/runtime/__tests__/runner-goal-cycle.test.ts src/interface/cli/__tests__/cli-daemon-start.test.ts src/interface/cli/__tests__/cli-daemon-status.test.ts src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts src/interface/cli/__tests__/cli-runner.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed` (related unit passed; related integration still times out in `src/interface/cli/__tests__/cli-runner-integration.test.ts:225`)
- `npx vitest run src/interface/cli/__tests__/cli-runner-integration.test.ts -t "runs CoreLoop to completion with max_iterations=1 using MockLLM"` (same timeout reproduced in isolation)

## Known unresolved risks
- The existing real CLI integration test `cli-runner-integration.test.ts:225` still times out after 60s and logs a provider-config warning about `gpt-5.4-mini` with `anthropic`; this appears to be the same pre-existing integration-lane issue observed in earlier issues, not a resident-policy regression.
