### PR TITLE
feat(runtime): add dream run-control recommendations

### DIFF
--- a/src/orchestrator/execution/task/task-lifecycle-runner.ts
+++ b/src/orchestrator/execution/task/task-lifecycle-runner.ts
@@ -35,6 +35,7 @@ export interface TaskCycleRunOptionsShape {
   targetDimensionOverride?: string;
   knowledgeContextPrefix?: string;
   executionMode?: ExecutionModeState;
+  runControlRecommendationContext?: string;
 }
 
 export interface TaskLifecycleTaskCycleContext {
@@ -154,9 +155,11 @@ export async function runTaskLifecycleCycle(context: TaskLifecycleTaskCycleConte
     logger?.info("TaskLifecycle: using target dimension override", { goalId, targetDimension });
   }
 
-  const baseKnowledgeContext = options?.knowledgeContextPrefix
-    ? [options.knowledgeContextPrefix, knowledgeContext].filter(Boolean).join("\n\n")
-    : knowledgeContext;
+  const baseKnowledgeContext = [
+    options?.knowledgeContextPrefix,
+    options?.runControlRecommendationContext,
+    knowledgeContext,
+  ].filter(Boolean).join("\n\n") || undefined;
 
   const enrichedKnowledgeContext = await runPhase("enrich-knowledge-context", () =>
     buildEnrichedKnowledgeContext({

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -132,6 +132,7 @@ export interface TaskCycleRunOptions {
   targetDimensionOverride?: string;
   knowledgeContextPrefix?: string;
   executionMode?: ExecutionModeState;
+  runControlRecommendationContext?: string;
 }
 
 export interface TaskLifecycleDeps extends TaskLifecycleCoreDeps {

--- a/src/orchestrator/loop/__tests__/core-loop-agentic-phases.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-agentic-phases.test.ts
@@ -208,6 +208,18 @@ function createDeps(tmpDir: string, options?: { stall?: boolean; publicResearch?
             target_dimensions: ["dim1"],
             expected_evidence_gain: "Shows whether the plateau is strategy-driven.",
           }],
+          run_control_recommendations: [{
+            action: "widen_exploration",
+            target_strategy_family: "bounded_variant",
+            rationale: "Repeated same-lineage attempts have stopped moving the metric.",
+            evidence: [{
+              kind: "lineage",
+              ref: "lineage:continue",
+              summary: "Recent task history repeats the same implementation family.",
+            }],
+            risk: "low",
+            confidence: 0.82,
+          }],
           guidance: "Use the bounded variant before generating the next task.",
           uncertainty: ["Need one more metric sample."],
           context_authority: "advisory_only",
@@ -538,15 +550,23 @@ describe("CoreLoop agentic phase hooks", () => {
         summary: "dream-summary",
         context_authority: "advisory_only",
         relevant_memories: [expect.objectContaining({ authority: "advisory_only" })],
+        run_control_recommendations: [expect.objectContaining({
+          action: "widen_exploration",
+          policy_decision: expect.objectContaining({ disposition: "auto_apply" }),
+        })],
       })],
       raw_refs: expect.arrayContaining([
         expect.objectContaining({ kind: "dream_soil_memory", id: "soil://goal-1/checkpoint" }),
+        expect.objectContaining({ kind: "dream_run_control_lineage", id: "lineage:continue" }),
       ]),
     }));
     const taskCycleArgs = (mocks.taskLifecycle.runTaskCycle as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(taskCycleArgs[4]).toContain("dream-summary");
     expect(taskCycleArgs[4]).toContain("Use the bounded variant before generating the next task.");
     expect(taskCycleArgs[4]).toContain("Bounded variant: Changes one factor and preserves the current proof lane.");
+    expect(taskCycleArgs[7]).toMatchObject({
+      runControlRecommendationContext: expect.stringContaining("widen_exploration"),
+    });
   });
 
   it("keeps wait observation on a short read-only budget separate from normal AgentLoop execution", async () => {

--- a/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
+++ b/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
@@ -6,6 +6,9 @@ import type { MetricTrendContext } from "../../../platform/drive/metric-history.
 import { makeEmptyIterationResult } from "../loop-result-types.js";
 import {
   buildDreamReviewCheckpointRequest,
+  dreamCheckpointRawRefs,
+  formatDreamRunControlRecommendationContext,
+  normalizeDreamReviewCheckpoint,
 } from "../core-loop/dream-review-checkpoint.js";
 import { DreamReviewCheckpointEvidenceSchema } from "../core-loop/phase-specs.js";
 
@@ -198,5 +201,283 @@ describe("Dream review checkpoint trigger planning", () => {
     });
 
     expect(parsed.success).toBe(false);
+  });
+
+  it("normalizes deadline-backed finalization recommendations as auto-applied run control", () => {
+    const goal = makeGoal({ title: "Submit final benchmark artifact" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 3,
+      result: makeEmptyIterationResult("goal-1", 3),
+      driveScores: [],
+      finalizationStatus: makeFinalizationStatus(),
+    });
+    expect(request).not.toBeNull();
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "Deadline is inside finalization buffer.",
+      trigger: "pre_finalization",
+      current_goal: "Submit final benchmark artifact",
+      active_dimensions: ["dim1"],
+      run_control_recommendations: [{
+        action: "enter_finalization",
+        target_mode: "finalization",
+        rationale: "The deadline buffer has started, so remaining work should freeze candidates and package artifacts.",
+        evidence: [{
+          kind: "deadline",
+          ref: "deadline:goal-1",
+          summary: "Reserved finalization buffer has started.",
+        }],
+        risk: "low",
+        confidence: 0.9,
+      }],
+      guidance: "Enter finalization and verify the best artifact.",
+      uncertainty: [],
+      context_authority: "advisory_only",
+      confidence: 0.9,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+
+    expect(normalized.run_control_recommendations[0]).toMatchObject({
+      action: "enter_finalization",
+      policy_decision: {
+        disposition: "auto_apply",
+      },
+    });
+  });
+
+  it("builds task-generation context for divergent exploration after repeated lineage evidence", () => {
+    const goal = makeGoal({ title: "Improve benchmark score" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 1,
+      result: makeEmptyIterationResult("goal-1", 1, {
+        stallDetected: true,
+        metricTrendContext: makeMetricTrendContext({
+          trend: "stalled",
+          summary: "Same CatBoost lineage has not improved balanced accuracy across six observations.",
+        }),
+      }),
+      driveScores: [],
+    });
+    expect(request).not.toBeNull();
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "The current lineage is repeating low-value attempts.",
+      trigger: "plateau",
+      current_goal: "Improve benchmark score",
+      active_dimensions: ["dim1"],
+      recent_strategy_families: ["catboost_thresholding", "catboost_thresholding", "catboost_thresholding"],
+      exhausted: ["catboost_thresholding"],
+      promising: ["lightgbm_ranked_features"],
+      run_control_recommendations: [{
+        action: "widen_exploration",
+        target_strategy_family: "lightgbm_ranked_features",
+        rationale: "Repeated same-lineage attempts have stopped moving the metric.",
+        evidence: [
+          {
+            kind: "lineage",
+            ref: "lineage:catboost_thresholding",
+            summary: "Three recent attempts stayed in the same CatBoost thresholding family.",
+          },
+          {
+            kind: "metric",
+            ref: "metric:balanced_accuracy",
+            summary: "Balanced accuracy trend is stalled.",
+          },
+        ],
+        risk: "low",
+        confidence: 0.82,
+      }],
+      guidance: "Try a divergent low-cost branch before another same-lineage task.",
+      uncertainty: ["Need one smoke validation."],
+      context_authority: "advisory_only",
+      confidence: 0.82,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+    const context = formatDreamRunControlRecommendationContext(normalized.run_control_recommendations);
+
+    expect(normalized.run_control_recommendations[0]).toMatchObject({
+      action: "widen_exploration",
+      target_strategy_family: "lightgbm_ranked_features",
+      policy_decision: {
+        disposition: "auto_apply",
+      },
+    });
+    expect(context).toContain("Dream run-control recommendations:");
+    expect(context).toContain("widen_exploration");
+    expect(context).toContain("lineage: Three recent attempts stayed in the same CatBoost thresholding family.");
+    expect(dreamCheckpointRawRefs(normalized)).toEqual(expect.arrayContaining([
+      { kind: "dream_run_control_lineage", id: "lineage:catboost_thresholding" },
+      { kind: "dream_run_control_metric", id: "metric:balanced_accuracy" },
+    ]));
+  });
+
+  it("does not feed advisory-only recommendations into task generation context", () => {
+    const context = formatDreamRunControlRecommendationContext([{
+      id: "medium-risk-widen",
+      action: "widen_exploration",
+      target_strategy_family: "expensive_gpu_sweep",
+      rationale: "Could uncover a better family but needs budget review.",
+      evidence: [{
+        kind: "lineage",
+        ref: "lineage:current",
+        summary: "Current lineage is narrowing.",
+      }],
+      candidate_refs: [],
+      lineage_refs: [],
+      approval_required: false,
+      risk: "medium",
+      confidence: 0.7,
+      policy_decision: {
+        disposition: "advisory_only",
+        reason: "Preserved for review but not auto-applied.",
+      },
+    }]);
+
+    expect(context).toBeUndefined();
+  });
+
+  it("keeps default medium-risk recommendations advisory-only", () => {
+    const goal = makeGoal({ title: "Improve benchmark score" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 1,
+      result: makeEmptyIterationResult("goal-1", 1, {
+        stallDetected: true,
+      }),
+      driveScores: [],
+    });
+    expect(request).not.toBeNull();
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "Consolidation could help but confidence is incomplete.",
+      trigger: "plateau",
+      current_goal: "Improve benchmark score",
+      active_dimensions: ["dim1"],
+      run_control_recommendations: [{
+        action: "consolidate_candidates",
+        target_mode: "consolidation",
+        rationale: "Candidate evidence should be organized before more exploration.",
+        evidence: [{
+          kind: "artifact",
+          ref: "artifact:candidate-report",
+          summary: "A candidate report exists but has not been revalidated.",
+        }],
+        confidence: 0.7,
+      }],
+      guidance: "Consider consolidation.",
+      uncertainty: [],
+      context_authority: "advisory_only",
+      confidence: 0.7,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+
+    expect(normalized.run_control_recommendations[0]).toMatchObject({
+      risk: "medium",
+      policy_decision: {
+        disposition: "advisory_only",
+      },
+    });
+    expect(formatDreamRunControlRecommendationContext(normalized.run_control_recommendations)).toBeUndefined();
+  });
+
+  it("keeps default medium-risk finalization recommendations advisory-only even with deadline evidence", () => {
+    const goal = makeGoal({ title: "Submit final benchmark artifact" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 3,
+      result: makeEmptyIterationResult("goal-1", 3),
+      driveScores: [],
+      finalizationStatus: makeFinalizationStatus(),
+    });
+    expect(request).not.toBeNull();
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "Deadline is inside finalization buffer.",
+      trigger: "pre_finalization",
+      current_goal: "Submit final benchmark artifact",
+      active_dimensions: ["dim1"],
+      run_control_recommendations: [{
+        action: "enter_finalization",
+        target_mode: "finalization",
+        rationale: "The deadline buffer has started.",
+        evidence: [{
+          kind: "deadline",
+          ref: "deadline:goal-1",
+          summary: "Reserved finalization buffer has started.",
+        }],
+        confidence: 0.9,
+      }],
+      guidance: "Consider finalization.",
+      uncertainty: [],
+      context_authority: "advisory_only",
+      confidence: 0.9,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+
+    expect(normalized.run_control_recommendations[0]).toMatchObject({
+      risk: "medium",
+      policy_decision: {
+        disposition: "advisory_only",
+      },
+    });
+    expect(formatDreamRunControlRecommendationContext(normalized.run_control_recommendations)).toBeUndefined();
+  });
+
+  it("does not treat ordinary deadline status reasons as finalization-window approval for queue freeze", () => {
+    const goal = makeGoal({ title: "Improve benchmark score" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 1,
+      result: makeEmptyIterationResult("goal-1", 1, {
+        stallDetected: true,
+      }),
+      driveScores: [],
+      finalizationStatus: makeFinalizationStatus({
+        mode: "no_deadline",
+        deadline: null,
+        remaining_ms: null,
+        remaining_exploration_ms: null,
+        reason: "Goal has no deadline.",
+      }),
+    });
+    expect(request).not.toBeNull();
+    expect(request?.finalizationReason).toBeUndefined();
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "Queue freeze is not yet justified.",
+      trigger: "plateau",
+      current_goal: "Improve benchmark score",
+      active_dimensions: ["dim1"],
+      run_control_recommendations: [{
+        action: "freeze_experiment_queue",
+        rationale: "Freeze current queue.",
+        evidence: [{
+          kind: "runtime_state",
+          ref: "queue:active",
+          summary: "The queue has pending experiments.",
+        }],
+        risk: "low",
+        confidence: 0.8,
+      }],
+      guidance: "Do not freeze without finalization.",
+      uncertainty: [],
+      context_authority: "advisory_only",
+      confidence: 0.8,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+
+    expect(normalized.run_control_recommendations[0]).toMatchObject({
+      policy_decision: {
+        disposition: "approval_required",
+      },
+    });
+    expect(formatDreamRunControlRecommendationContext(normalized.run_control_recommendations)).toBeUndefined();
   });
 });

--- a/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
+++ b/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
@@ -7,8 +7,11 @@ import type { RuntimeEvidenceEntry, RuntimeEvidenceSummary } from "../../../runt
 import type {
   DreamReviewCheckpointEvidence,
   DreamReviewCheckpointTrigger,
+  DreamRunControlPolicyDecision,
+  DreamRunControlRecommendation,
 } from "./phase-specs.js";
 import type { LoopIterationResult } from "../loop-result-types.js";
+import type { ExecutionModeState } from "../../../platform/time/execution-mode.js";
 
 export interface DreamReviewCheckpointRequest {
   trigger: DreamReviewCheckpointTrigger;
@@ -18,6 +21,8 @@ export interface DreamReviewCheckpointRequest {
   recentStrategyFamilies: string[];
   metricTrendSummary?: string;
   finalizationReason?: string;
+  currentExecutionMode?: ExecutionModeState["mode"];
+  runControlPolicy: "auto_apply_low_risk_require_approval_for_high_cost_or_irreversible";
   memoryAuthorityPolicy: "soil_and_playbooks_are_advisory_only";
   maxGuidanceItems: number;
 }
@@ -33,6 +38,7 @@ export interface BuildDreamReviewCheckpointRequestInput {
   result: LoopIterationResult;
   driveScores: DriveScore[];
   finalizationStatus?: DeadlineFinalizationStatus;
+  executionMode?: ExecutionModeState;
   recentCheckpoints?: RuntimeDreamCheckpointContext[];
   evidenceSummary?: Pick<RuntimeEvidenceSummary, "best_evidence" | "recent_entries"> | null;
   requestedTrigger?: DreamReviewCheckpointTrigger;
@@ -58,7 +64,9 @@ export function buildDreamReviewCheckpointRequest(
     ...(input.evidenceSummary?.best_evidence ? { bestEvidenceSummary: entrySummary(input.evidenceSummary.best_evidence) } : {}),
     recentStrategyFamilies: recentStrategyFamilies(input.evidenceSummary?.recent_entries ?? []),
     ...(metricTrendSummary ? { metricTrendSummary } : {}),
-    ...(input.finalizationStatus?.reason ? { finalizationReason: input.finalizationStatus.reason } : {}),
+    ...(isPreFinalization(input.finalizationStatus) ? { finalizationReason: input.finalizationStatus?.reason } : {}),
+    ...(input.executionMode?.mode ? { currentExecutionMode: input.executionMode.mode } : {}),
+    runControlPolicy: "auto_apply_low_risk_require_approval_for_high_cost_or_irreversible",
     memoryAuthorityPolicy: "soil_and_playbooks_are_advisory_only",
     maxGuidanceItems: 3,
   };
@@ -78,16 +86,151 @@ export function normalizeDreamReviewCheckpoint(
       ...memory,
       authority: "advisory_only",
     })),
+    run_control_recommendations: normalizeRunControlRecommendations(output.run_control_recommendations, request),
     context_authority: "advisory_only",
+  };
+}
+
+export function formatDreamRunControlRecommendationContext(
+  recommendations: DreamRunControlRecommendation[] | undefined
+): string | undefined {
+  const actionable = (recommendations ?? []).filter((recommendation) =>
+    recommendation.policy_decision?.disposition === "auto_apply"
+  );
+  if (actionable.length === 0) return undefined;
+
+  return [
+    "Dream run-control recommendations:",
+    ...actionable.slice(0, 5).map((recommendation, index) => {
+      const evidence = recommendation.evidence
+        .map((item) => `${item.kind}: ${item.summary}`)
+        .join("; ");
+      const policy = recommendation.policy_decision
+        ? `${recommendation.policy_decision.disposition}: ${recommendation.policy_decision.reason}`
+        : "advisory_only";
+      return [
+        `${index + 1}. ${recommendation.action}`,
+        `rationale=${recommendation.rationale}`,
+        `evidence=${evidence}`,
+        `policy=${policy}`,
+      ].join(" | ");
+    }),
+  ].join("\n");
+}
+
+function normalizeRunControlRecommendations(
+  recommendations: DreamRunControlRecommendation[],
+  request: DreamReviewCheckpointRequest
+): DreamRunControlRecommendation[] {
+  return recommendations.map((recommendation, index) => ({
+    ...recommendation,
+    id: recommendation.id ?? `${request.trigger}-run-control-${index + 1}`,
+    policy_decision: decideRunControlPolicy(recommendation, request),
+  }));
+}
+
+function decideRunControlPolicy(
+  recommendation: DreamRunControlRecommendation,
+  request: DreamReviewCheckpointRequest
+): DreamRunControlPolicyDecision {
+  if (
+    recommendation.approval_required
+    || recommendation.risk === "high"
+    || recommendation.action === "request_operator_approval"
+  ) {
+    return {
+      disposition: "approval_required",
+      reason: "High-cost, irreversible, or explicit operator-approval recommendations cannot be auto-applied.",
+    };
+  }
+
+  if (recommendation.action === "enter_finalization") {
+    if (recommendation.risk !== "low") {
+      return {
+        disposition: "advisory_only",
+        reason: "Only low-risk finalization recommendations are auto-applied as task-generation guidance.",
+      };
+    }
+    const hasDeadlineEvidence = recommendation.evidence.some((evidence) => evidence.kind === "deadline");
+    if (request.finalizationReason || hasDeadlineEvidence) {
+      return {
+        disposition: "auto_apply",
+        reason: "Finalization recommendation is backed by deadline-state evidence.",
+      };
+    }
+    return {
+      disposition: "approval_required",
+      reason: "Entering finalization without deadline evidence requires operator approval.",
+    };
+  }
+
+  if (recommendation.action === "freeze_experiment_queue") {
+    if (recommendation.risk !== "low") {
+      return {
+        disposition: "advisory_only",
+        reason: "Only low-risk queue-freeze recommendations are auto-applied as task-generation guidance.",
+      };
+    }
+    if (request.finalizationReason) {
+      return {
+        disposition: "auto_apply",
+        reason: "Freezing the queue is allowed inside the finalization window.",
+      };
+    }
+    return {
+      disposition: "approval_required",
+      reason: "Freezing active work outside finalization requires operator approval.",
+    };
+  }
+
+  if (
+    recommendation.action === "widen_exploration"
+    && request.trigger === "plateau"
+    && recommendation.evidence.some((evidence) => evidence.kind === "lineage" || evidence.kind === "task_history")
+  ) {
+    return {
+      disposition: recommendation.risk === "low" ? "auto_apply" : "advisory_only",
+      reason: "Plateau evidence supports feeding divergent exploration guidance into task generation.",
+    };
+  }
+
+  if (
+    recommendation.action === "stay_current_mode"
+    || recommendation.action === "consolidate_candidates"
+    || recommendation.action === "preserve_near_miss_candidates"
+    || recommendation.action === "retire_low_value_lineage"
+  ) {
+    if (recommendation.risk !== "low") {
+      return {
+        disposition: "advisory_only",
+        reason: "Only low-risk run-control recommendations are auto-applied as task-generation guidance.",
+      };
+    }
+    return {
+      disposition: "auto_apply",
+      reason: "Low-risk run-control recommendation can be applied as task-generation guidance.",
+    };
+  }
+
+  return {
+    disposition: "advisory_only",
+    reason: "Recommendation is preserved for operator/runtime review but is not auto-applied.",
   };
 }
 
 export function dreamCheckpointRawRefs(
   output: DreamReviewCheckpointEvidence
 ): Array<{ kind: string; id?: string }> {
-  return output.relevant_memories
+  const memoryRefs = output.relevant_memories
     .map((memory) => memory.ref ? { kind: `dream_${memory.source_type}_memory`, id: memory.ref } : null)
     .filter((ref): ref is { kind: string; id: string } => ref !== null);
+  const recommendationEvidenceRefs = output.run_control_recommendations
+    .flatMap((recommendation) => recommendation.evidence)
+    .map((evidence) => evidence.ref
+      ? { kind: `dream_run_control_${evidence.kind}`, id: evidence.ref }
+      : null)
+    .filter((ref): ref is { kind: string; id: string } => ref !== null);
+  return [...memoryRefs, ...recommendationEvidenceRefs];
 }
 
 function inferCheckpointTrigger(

--- a/src/orchestrator/loop/core-loop/iteration-kernel.ts
+++ b/src/orchestrator/loop/core-loop/iteration-kernel.ts
@@ -37,6 +37,7 @@ import {
   buildStallInvestigationSpec,
   buildWaitObservationSpec,
   buildVerificationEvidenceSpec,
+  type DreamReviewCheckpointEvidence,
 } from "./phase-specs.js";
 import type { CorePhasePolicyRegistry } from "./phase-policy.js";
 import type { CoreDecisionEngine } from "./decision-engine.js";
@@ -60,6 +61,7 @@ import {
 import {
   buildDreamReviewCheckpointRequest,
   dreamCheckpointRawRefs,
+  formatDreamRunControlRecommendationContext,
   normalizeDreamReviewCheckpoint,
   type DreamReviewCheckpointRequest,
 } from "./dream-review-checkpoint.js";
@@ -194,9 +196,10 @@ export class CoreIterationKernel {
       gapAggregate: number;
       driveScores: DriveScore[];
       finalizationStatus?: DeadlineFinalizationStatus;
+      executionMode?: ReturnType<typeof deriveExecutionModeFromDeadlineStatus>;
       requestedTrigger?: "iteration" | "plateau" | "breakthrough" | "pre_finalization";
-    }): Promise<void> => {
-      if (dreamReviewCheckpointRan) return;
+    }): Promise<DreamReviewCheckpointEvidence | null> => {
+      if (dreamReviewCheckpointRan) return null;
       const evidenceSummary = await loadDreamReviewEvidenceSummary(this.deps.deps.evidenceLedger, goalId);
       const request = buildDreamReviewCheckpointRequest({
         goal: input.goal,
@@ -204,11 +207,12 @@ export class CoreIterationKernel {
         result,
         driveScores: input.driveScores,
         finalizationStatus: input.finalizationStatus,
+        executionMode: input.executionMode,
         evidenceSummary,
         recentCheckpoints: evidenceSummary?.dream_checkpoints,
         ...(input.requestedTrigger ? { requestedTrigger: input.requestedTrigger } : {}),
       });
-      if (!request) return;
+      if (!request) return null;
 
       const dreamReview = await runPhase("dream-review-checkpoint", () =>
         corePhaseRuntime.run(
@@ -232,6 +236,8 @@ export class CoreIterationKernel {
             recentStrategyFamilies: request.recentStrategyFamilies,
             ...(request.metricTrendSummary ? { metricTrendSummary: request.metricTrendSummary } : {}),
             ...(request.finalizationReason ? { finalizationReason: request.finalizationReason } : {}),
+            ...(request.currentExecutionMode ? { currentExecutionMode: request.currentExecutionMode } : {}),
+            runControlPolicy: request.runControlPolicy,
             memoryAuthorityPolicy: request.memoryAuthorityPolicy,
             maxGuidanceItems: request.maxGuidanceItems,
           },
@@ -239,8 +245,12 @@ export class CoreIterationKernel {
         )
       );
       rememberPhase(dreamReview);
-      await appendDreamReviewCheckpointEvidence(appendRuntimeEvidence, dreamReview, request, input.goal);
+      const checkpoint = await appendDreamReviewCheckpointEvidence(appendRuntimeEvidence, dreamReview, request, input.goal);
+      if (checkpoint?.run_control_recommendations.length) {
+        result.dreamRunControlRecommendations = checkpoint.run_control_recommendations;
+      }
       dreamReviewCheckpointRan = dreamReview.status !== "skipped";
+      return checkpoint;
     };
 
     this.deps.logger?.info(`[CoreLoop] iteration ${loopIndex + 1} starting`, { goalId, loopIndex });
@@ -347,6 +357,7 @@ export class CoreIterationKernel {
         gapAggregate,
         driveScores: [],
         finalizationStatus,
+        executionMode,
         requestedTrigger: "pre_finalization",
       });
       result.skipped = true;
@@ -546,12 +557,16 @@ export class CoreIterationKernel {
       });
     }
 
-    await maybeRunDreamReviewCheckpoint({
+    const dreamCheckpoint = await maybeRunDreamReviewCheckpoint({
       goal,
       gapAggregate,
       driveScores,
       finalizationStatus,
+      executionMode,
     });
+    const dreamRunControlRecommendationContext = formatDreamRunControlRecommendationContext(
+      dreamCheckpoint?.run_control_recommendations
+    );
 
     const publicResearchRequest = buildPublicResearchRequest({
       goal,
@@ -703,6 +718,7 @@ export class CoreIterationKernel {
       targetDimensionOverride: taskGenerationHints.targetDimensionOverride ?? pendingDirective?.focusDimension,
       knowledgeContextPrefix: taskGenerationHints.knowledgeContextPrefix,
       executionMode,
+      runControlRecommendationContext: dreamRunControlRecommendationContext,
     };
     if (!shouldPreferReplanningContext && replanningOptions?.status === "completed") {
       this.deps.logger?.debug("CoreLoop: replanning evidence collected but not adopted as preferred context", {
@@ -851,8 +867,8 @@ async function appendDreamReviewCheckpointEvidence(
   },
   request: DreamReviewCheckpointRequest,
   goal: Goal,
-): Promise<void> {
-  if (execution.status === "skipped") return;
+): Promise<DreamReviewCheckpointEvidence | null> {
+  if (execution.status === "skipped") return null;
   const output = buildDreamReviewCheckpointSpec().outputSchema.safeParse(execution.output);
   if (!output.success) {
     await appendRuntimeEvidence({
@@ -866,7 +882,7 @@ async function appendDreamReviewCheckpointEvidence(
         error: output.error.issues.map((issue) => issue.message).join("; "),
       },
     });
-    return;
+    return null;
   }
 
   const checkpoint = normalizeDreamReviewCheckpoint(output.data, request, goal);
@@ -888,6 +904,7 @@ async function appendDreamReviewCheckpointEvidence(
       ...(execution.turnId ? [{ kind: "agentloop_turn", id: execution.turnId }] : []),
     ],
   });
+  return checkpoint;
 }
 
 async function loadDreamReviewEvidenceSummary(

--- a/src/orchestrator/loop/core-loop/phase-specs.ts
+++ b/src/orchestrator/loop/core-loop/phase-specs.ts
@@ -132,6 +132,47 @@ export const DreamReviewStrategyCandidateSchema = z.object({
 }).strict();
 export type DreamReviewStrategyCandidate = z.infer<typeof DreamReviewStrategyCandidateSchema>;
 
+export const DreamRunControlRecommendationActionSchema = z.enum([
+  "stay_current_mode",
+  "widen_exploration",
+  "consolidate_candidates",
+  "freeze_experiment_queue",
+  "enter_finalization",
+  "preserve_near_miss_candidates",
+  "retire_low_value_lineage",
+  "request_operator_approval",
+]);
+export type DreamRunControlRecommendationAction = z.infer<typeof DreamRunControlRecommendationActionSchema>;
+
+export const DreamRunControlEvidenceRefSchema = z.object({
+  kind: z.enum(["metric", "artifact", "lineage", "task_history", "deadline", "external_feedback", "memory", "runtime_state"]),
+  ref: z.string().min(1).optional(),
+  summary: z.string().min(1),
+}).strict();
+export type DreamRunControlEvidenceRef = z.infer<typeof DreamRunControlEvidenceRefSchema>;
+
+export const DreamRunControlPolicyDecisionSchema = z.object({
+  disposition: z.enum(["auto_apply", "approval_required", "advisory_only"]),
+  reason: z.string().min(1),
+}).strict();
+export type DreamRunControlPolicyDecision = z.infer<typeof DreamRunControlPolicyDecisionSchema>;
+
+export const DreamRunControlRecommendationSchema = z.object({
+  id: z.string().min(1).optional(),
+  action: DreamRunControlRecommendationActionSchema,
+  rationale: z.string().min(1),
+  evidence: z.array(DreamRunControlEvidenceRefSchema).min(1),
+  target_mode: z.enum(["exploration", "consolidation", "finalization"]).optional(),
+  target_strategy_family: z.string().min(1).optional(),
+  candidate_refs: z.array(z.string().min(1)).default([]),
+  lineage_refs: z.array(z.string().min(1)).default([]),
+  approval_required: z.boolean().default(false),
+  risk: z.enum(["low", "medium", "high"]).default("medium"),
+  confidence: z.number().min(0).max(1).default(0.5),
+  policy_decision: DreamRunControlPolicyDecisionSchema.optional(),
+}).strict();
+export type DreamRunControlRecommendation = z.infer<typeof DreamRunControlRecommendationSchema>;
+
 export const DreamReviewCheckpointEvidenceSchema = z.object({
   summary: z.string().min(1),
   trigger: DreamReviewCheckpointTriggerSchema,
@@ -143,6 +184,7 @@ export const DreamReviewCheckpointEvidenceSchema = z.object({
   promising: z.array(z.string().min(1)).default([]),
   relevant_memories: z.array(DreamReviewMemoryRefSchema).default([]),
   next_strategy_candidates: z.array(DreamReviewStrategyCandidateSchema).default([]),
+  run_control_recommendations: z.array(DreamRunControlRecommendationSchema).default([]),
   guidance: z.string().min(1),
   uncertainty: z.array(z.string().min(1)).default([]),
   context_authority: z.literal("advisory_only").default("advisory_only"),
@@ -286,6 +328,8 @@ export function buildDreamReviewCheckpointSpec(): ReturnType<typeof baseSpec<{
   recentStrategyFamilies: string[];
   metricTrendSummary?: string;
   finalizationReason?: string;
+  currentExecutionMode?: "exploration" | "consolidation" | "finalization";
+  runControlPolicy: "auto_apply_low_risk_require_approval_for_high_cost_or_irreversible";
   memoryAuthorityPolicy: "soil_and_playbooks_are_advisory_only";
   maxGuidanceItems: number;
 }, DreamReviewCheckpointEvidence>> {
@@ -300,6 +344,8 @@ export function buildDreamReviewCheckpointSpec(): ReturnType<typeof baseSpec<{
       recentStrategyFamilies: z.array(z.string()).default([]),
       metricTrendSummary: z.string().optional(),
       finalizationReason: z.string().optional(),
+      currentExecutionMode: z.enum(["exploration", "consolidation", "finalization"]).optional(),
+      runControlPolicy: z.literal("auto_apply_low_risk_require_approval_for_high_cost_or_irreversible"),
       memoryAuthorityPolicy: z.literal("soil_and_playbooks_are_advisory_only"),
       maxGuidanceItems: z.number().int().positive().max(5).default(3),
     }),

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -151,6 +151,7 @@ export interface TaskGenerationHints {
   targetDimensionOverride?: string;
   knowledgeContextPrefix?: string;
   executionMode?: ExecutionModeState;
+  runControlRecommendationContext?: string;
 }
 
 export interface StallActionHints {

--- a/src/orchestrator/loop/loop-result-types.ts
+++ b/src/orchestrator/loop/loop-result-types.ts
@@ -4,6 +4,7 @@ import type { StallAnalysis, StallReport } from "../../base/types/stall.js";
 import type { MetricTrendContext } from "../../platform/drive/metric-history.js";
 import type { DeadlineFinalizationStatus } from "../../platform/time/deadline-finalization.js";
 import type { ExecutionModeState } from "../../platform/time/execution-mode.js";
+import type { DreamRunControlRecommendation } from "./core-loop/phase-specs.js";
 import type { TransferCandidate } from "../../base/types/cross-portfolio.js";
 import type { WaitExpiryOutcome } from "../../base/types/strategy.js";
 import type { RuntimeEvidenceDivergentHypothesis } from "../../runtime/store/evidence-ledger.js";
@@ -53,6 +54,8 @@ export interface LoopIterationResult {
   finalizationStatus?: DeadlineFinalizationStatus;
   /** Current runtime execution mode and transition evidence for this iteration. */
   executionMode?: ExecutionModeState;
+  /** Structured Dream checkpoint run-control recommendations accepted by runtime policy. */
+  dreamRunControlRecommendations?: DreamRunControlRecommendation[];
   pivotOccurred: boolean;
   completionJudgment: CompletionJudgment;
   elapsedMs: number;

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -208,6 +208,38 @@ export const RuntimeEvidenceDreamCheckpointStrategyCandidateSchema = z.object({
 }).strict();
 export type RuntimeEvidenceDreamCheckpointStrategyCandidate = z.infer<typeof RuntimeEvidenceDreamCheckpointStrategyCandidateSchema>;
 
+export const RuntimeEvidenceDreamRunControlRecommendationSchema = z.object({
+  id: z.string().min(1).optional(),
+  action: z.enum([
+    "stay_current_mode",
+    "widen_exploration",
+    "consolidate_candidates",
+    "freeze_experiment_queue",
+    "enter_finalization",
+    "preserve_near_miss_candidates",
+    "retire_low_value_lineage",
+    "request_operator_approval",
+  ]),
+  rationale: z.string().min(1),
+  evidence: z.array(z.object({
+    kind: z.enum(["metric", "artifact", "lineage", "task_history", "deadline", "external_feedback", "memory", "runtime_state"]),
+    ref: z.string().min(1).optional(),
+    summary: z.string().min(1),
+  }).strict()).min(1),
+  target_mode: z.enum(["exploration", "consolidation", "finalization"]).optional(),
+  target_strategy_family: z.string().min(1).optional(),
+  candidate_refs: z.array(z.string().min(1)).default([]),
+  lineage_refs: z.array(z.string().min(1)).default([]),
+  approval_required: z.boolean().default(false),
+  risk: z.enum(["low", "medium", "high"]).default("medium"),
+  confidence: z.number().min(0).max(1).default(0.5),
+  policy_decision: z.object({
+    disposition: z.enum(["auto_apply", "approval_required", "advisory_only"]),
+    reason: z.string().min(1),
+  }).strict().optional(),
+}).strict();
+export type RuntimeEvidenceDreamRunControlRecommendation = z.infer<typeof RuntimeEvidenceDreamRunControlRecommendationSchema>;
+
 export const RuntimeEvidenceDreamCheckpointSchema = z.object({
   trigger: RuntimeEvidenceDreamCheckpointTriggerSchema,
   summary: z.string().min(1),
@@ -219,6 +251,7 @@ export const RuntimeEvidenceDreamCheckpointSchema = z.object({
   promising: z.array(z.string().min(1)).default([]),
   relevant_memories: z.array(RuntimeEvidenceDreamCheckpointMemoryRefSchema).default([]),
   next_strategy_candidates: z.array(RuntimeEvidenceDreamCheckpointStrategyCandidateSchema).default([]),
+  run_control_recommendations: z.array(RuntimeEvidenceDreamRunControlRecommendationSchema).optional(),
   guidance: z.string().min(1),
   uncertainty: z.array(z.string().min(1)).default([]),
   context_authority: z.literal("advisory_only").default("advisory_only"),


### PR DESCRIPTION
Closes #817

## Summary
- Add structured Dream checkpoint run-control recommendations with observable evidence refs and runtime policy decisions.
- Preserve recommendation evidence in runtime evidence/raw refs, and store normalized recommendations on CoreLoop iterations.
- Feed only auto-applied, low-risk recommendations into TaskLifecycle task-generation context; advisory/approval-required recommendations are retained but not auto-applied.

## Verification
- npm run typecheck
- npx vitest run src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts src/orchestrator/loop/__tests__/core-loop-agentic-phases.test.ts src/runtime/__tests__/runtime-evidence-ledger.test.ts
- npm run lint:boundaries (0 errors; existing warnings remain)
- npm run test:changed (related unit tests passed: 61 files / 851 tests; related integration then hit known cli-runner-integration timeout at src/interface/cli/__tests__/cli-runner-integration.test.ts:225)

## Known unresolved risks
- Recommendations are applied as task-generation guidance only; this PR does not add a persistent operator/Dream mode override store or approval UI.
- High/medium-risk and approval-required recommendations are preserved for review but not auto-applied.
- The recurring local cli-runner-integration timeout remains outside this slice; PR CI is the merge gate.