### PR TITLE
feat(runtime): select metric-aware best evidence

### DIFF
--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -38,6 +38,7 @@ import { ReportingEngine as RealReportingEngine } from "../../../reporting/repor
 import { CapabilityDetector } from "../../../platform/observation/capability-detector.js";
 import { ApprovalStore } from "../../../runtime/store/approval-store.js";
 import { WaitDeadlineResolver, getDueWaitGoalIds } from "../../../runtime/daemon/wait-deadline-resolver.js";
+import { RuntimeEvidenceLedger } from "../../../runtime/store/evidence-ledger.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { makeDimension, makeGoal } from "../../../../tests/helpers/fixtures.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
@@ -576,6 +577,52 @@ describe("CoreLoop", async () => {
         label: "reports/latest.md",
       });
       expect(evidenceLedger.readByGoal).toHaveBeenCalledWith("goal-1");
+    });
+
+    it("uses metric-aware best evidence for best_evidence finalization artifacts", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      const deadline = new Date(Date.now() + 10 * 60_000).toISOString();
+      await mocks.stateManager.saveGoal(makeGoal({
+        deadline,
+        finalization_policy: {
+          minimum_buffer_ms: 30 * 60_000,
+          consolidation_buffer_ms: 0,
+          best_artifact_selection: "best_evidence",
+          verification_steps: [],
+          external_actions: [],
+        },
+      }));
+      const evidenceLedger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+      await evidenceLedger.append({
+        id: "old-improved",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+        kind: "metric",
+        scope: { goal_id: "goal-1" },
+        metrics: [{ label: "accuracy", value: 0.72, direction: "maximize" }],
+        artifacts: [{ label: "reports/old.md", path: "reports/old.md", kind: "report" }],
+        summary: "Old improved artifact.",
+        outcome: "improved",
+      });
+      await evidenceLedger.append({
+        id: "new-best",
+        occurred_at: "2026-04-30T00:10:00.000Z",
+        kind: "metric",
+        scope: { goal_id: "goal-1" },
+        metrics: [{ label: "accuracy", value: 0.91, direction: "maximize" }],
+        artifacts: [{ label: "reports/new.md", path: "reports/new.md", kind: "report" }],
+        summary: "New best metric artifact.",
+        outcome: "continued",
+      });
+
+      const loop = new CoreLoop(
+        { ...deps, evidenceLedger },
+        { delayBetweenLoopsMs: 0, autoDecompose: false }
+      );
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(result.finalizationStatus?.finalization_plan?.best_artifact).toMatchObject({
+        label: "reports/new.md",
+      });
     });
 
     it("can select the latest verified artifact for finalization", async () => {

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -118,6 +118,147 @@ describe("RuntimeEvidenceLedger", () => {
     expect(summary.metric_trends[0]?.source_refs[0]?.metric_source).toBe("local-metrics.json");
   });
 
+  it("selects the best maximize metric evidence ahead of an older improved entry", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "old-improved",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-maximize" },
+      metrics: [{ label: "accuracy", value: 0.72, direction: "maximize", confidence: 0.9 }],
+      artifacts: [{ label: "old-metrics", state_relative_path: "runs/old/metrics.json", kind: "metrics" }],
+      summary: "Old shallow improvement.",
+      outcome: "improved",
+    });
+    await ledger.append({
+      id: "new-best",
+      occurred_at: "2026-04-30T00:10:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-maximize" },
+      metrics: [{ label: "accuracy", value: 0.91, direction: "maximize", confidence: 0.8 }],
+      artifacts: [{ label: "new-metrics", state_relative_path: "runs/new/metrics.json", kind: "metrics" }],
+      summary: "New stronger metric evidence.",
+      outcome: "continued",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-maximize");
+
+    expect(summary.best_evidence?.id).toBe("new-best");
+    expect(summary.best_evidence?.artifacts[0]?.state_relative_path).toBe("runs/new/metrics.json");
+  });
+
+  it("selects the best minimize metric evidence", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "higher-loss",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-minimize" },
+      metrics: [{ label: "validation_loss", value: 0.42, direction: "minimize" }],
+      summary: "Loss improved from baseline.",
+      outcome: "improved",
+    });
+    await ledger.append({
+      id: "lower-loss",
+      occurred_at: "2026-04-30T00:05:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-minimize" },
+      metrics: [{ label: "validation_loss", value: 0.31, direction: "minimize" }],
+      summary: "Loss reached the best value.",
+      outcome: "continued",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-minimize");
+
+    expect(summary.best_evidence?.id).toBe("lower-loss");
+  });
+
+  it("does not compare metric entries that reuse a label with the opposite direction", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "old-minimize-score",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-direction-key" },
+      metrics: [{ label: "score", value: 0.1, direction: "minimize" }],
+      artifacts: [{ label: "old-score", state_relative_path: "runs/old-score/metrics.json", kind: "metrics" }],
+      summary: "Old score used a minimize contract.",
+      outcome: "improved",
+    });
+    await ledger.append({
+      id: "new-maximize-score",
+      occurred_at: "2026-04-30T00:10:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-direction-key" },
+      metrics: [{ label: "score", value: 0.9, direction: "maximize" }],
+      artifacts: [{ label: "new-score", state_relative_path: "runs/new-score/metrics.json", kind: "metrics" }],
+      summary: "New score uses the active maximize contract.",
+      outcome: "continued",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-direction-key");
+
+    expect(summary.best_evidence?.id).toBe("new-maximize-score");
+  });
+
+  it("treats the first directed numeric metric as primary when secondary metrics differ", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "best-primary",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-primary" },
+      metrics: [
+        { label: "accuracy", value: 0.9, direction: "maximize" },
+        { label: "latency_ms", value: 320, direction: "minimize" },
+      ],
+      summary: "Best primary accuracy with weaker latency.",
+      outcome: "improved",
+    });
+    await ledger.append({
+      id: "best-secondary",
+      occurred_at: "2026-04-30T00:10:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-primary" },
+      metrics: [
+        { label: "accuracy", value: 0.86, direction: "maximize" },
+        { label: "latency_ms", value: 120, direction: "minimize" },
+      ],
+      summary: "Secondary latency improved while primary regressed.",
+      outcome: "continued",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-primary");
+
+    expect(summary.best_evidence?.id).toBe("best-primary");
+  });
+
+  it("preserves compatible fallback selection for non-metric evidence", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "passed-verification",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "verification",
+      scope: { goal_id: "goal-fallback" },
+      verification: { verdict: "pass", confidence: 0.9, summary: "smoke passed" },
+      summary: "Verification passed.",
+      outcome: "continued",
+    });
+    await ledger.append({
+      id: "latest-artifact",
+      occurred_at: "2026-04-30T00:10:00.000Z",
+      kind: "artifact",
+      scope: { goal_id: "goal-fallback" },
+      artifacts: [{ label: "report", state_relative_path: "runs/latest/report.md", kind: "report" }],
+      summary: "Latest artifact without metric.",
+      outcome: "continued",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-fallback");
+
+    expect(summary.best_evidence?.id).toBe("passed-verification");
+  });
+
   it("stores local and external evaluator observations with candidate provenance", async () => {
     const ledger = new RuntimeEvidenceLedger(runtimeRoot);
     await ledger.append({

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -525,9 +525,128 @@ function summarizeEvidence(
 }
 
 function chooseBestEvidence(entriesNewestFirst: RuntimeEvidenceEntry[]): RuntimeEvidenceEntry | null {
+  const metricBest = chooseBestMetricEvidence(entriesNewestFirst);
+  if (metricBest) return metricBest;
+
+  return chooseBestFallbackEvidence(entriesNewestFirst);
+}
+
+function chooseBestFallbackEvidence(entriesNewestFirst: RuntimeEvidenceEntry[]): RuntimeEvidenceEntry | null {
   return entriesNewestFirst.find((entry) => entry.outcome === "improved")
     ?? entriesNewestFirst.find((entry) => entry.verification?.verdict === "pass")
     ?? entriesNewestFirst.find((entry) => entry.metrics.length > 0)
     ?? entriesNewestFirst.find((entry) => entry.kind === "artifact")
     ?? null;
+}
+
+interface ComparableEvidenceMetric {
+  entry: RuntimeEvidenceEntry;
+  metric: RuntimeEvidenceMetric;
+  value: number;
+  direction: "maximize" | "minimize";
+  primary_metric: ComparableMetricKey;
+  improvement_strength: number;
+  confidence: number;
+  has_pass_verification: boolean;
+  has_artifact: boolean;
+}
+
+interface ComparableMetricKey {
+  label: string;
+  direction: "maximize" | "minimize";
+}
+
+function chooseBestMetricEvidence(entriesNewestFirst: RuntimeEvidenceEntry[]): RuntimeEvidenceEntry | null {
+  const primaryMetric = resolvePrimaryMetricKey(entriesNewestFirst);
+  if (!primaryMetric) return null;
+
+  const oldestFirst = [...entriesNewestFirst].reverse();
+  const baseline = findComparableMetric(oldestFirst, primaryMetric)?.value;
+  const candidates = entriesNewestFirst
+    .map((entry) => {
+      const metric = findComparableMetric([entry], primaryMetric);
+      if (!metric) return null;
+      return {
+        entry,
+        metric: metric.metric,
+        value: metric.value,
+        direction: metric.direction,
+        primary_metric: primaryMetric,
+        improvement_strength: baseline === undefined
+          ? 0
+          : metric.direction === "maximize"
+            ? metric.value - baseline
+            : baseline - metric.value,
+        confidence: metric.metric.confidence ?? entry.verification?.confidence ?? 1,
+        has_pass_verification: entry.verification?.verdict === "pass",
+        has_artifact: entry.artifacts.length > 0 || entry.kind === "artifact",
+      } satisfies ComparableEvidenceMetric;
+    })
+    .filter((candidate): candidate is ComparableEvidenceMetric => Boolean(candidate));
+
+  if (candidates.length === 0) return null;
+  return candidates.sort(compareComparableEvidenceMetrics)[0]?.entry ?? null;
+}
+
+function resolvePrimaryMetricKey(entriesNewestFirst: RuntimeEvidenceEntry[]): ComparableMetricKey | null {
+  for (const entry of entriesNewestFirst) {
+    const metric = findFirstDirectedNumericMetric(entry);
+    if (metric?.direction === "maximize" || metric?.direction === "minimize") {
+      return { label: metric.label, direction: metric.direction };
+    }
+  }
+  return null;
+}
+
+function findComparableMetric(
+  entries: RuntimeEvidenceEntry[],
+  key: ComparableMetricKey
+): { metric: RuntimeEvidenceMetric; value: number; direction: "maximize" | "minimize" } | null {
+  for (const entry of entries) {
+    for (const metric of entry.metrics) {
+      if (metric.label !== key.label || metric.direction !== key.direction) continue;
+      const comparable = toComparableMetric(metric);
+      if (comparable) return comparable;
+    }
+  }
+  return null;
+}
+
+function findFirstDirectedNumericMetric(entry: RuntimeEvidenceEntry): RuntimeEvidenceMetric | null {
+  for (const metric of entry.metrics) {
+    if (toComparableMetric(metric)) return metric;
+  }
+  return null;
+}
+
+function toComparableMetric(
+  metric: RuntimeEvidenceMetric
+): { metric: RuntimeEvidenceMetric; value: number; direction: "maximize" | "minimize" } | null {
+  if (typeof metric.value !== "number" || !Number.isFinite(metric.value)) return null;
+  if (metric.direction !== "maximize" && metric.direction !== "minimize") return null;
+  return {
+    metric,
+    value: metric.value,
+    direction: metric.direction,
+  };
+}
+
+function compareComparableEvidenceMetrics(a: ComparableEvidenceMetric, b: ComparableEvidenceMetric): number {
+  const direction = a.direction;
+  const valueDelta = direction === "maximize" ? b.value - a.value : a.value - b.value;
+  if (valueDelta !== 0) return valueDelta;
+
+  const passDelta = Number(b.has_pass_verification) - Number(a.has_pass_verification);
+  if (passDelta !== 0) return passDelta;
+
+  const artifactDelta = Number(b.has_artifact) - Number(a.has_artifact);
+  if (artifactDelta !== 0) return artifactDelta;
+
+  const confidenceDelta = b.confidence - a.confidence;
+  if (confidenceDelta !== 0) return confidenceDelta;
+
+  const improvementDelta = b.improvement_strength - a.improvement_strength;
+  if (improvementDelta !== 0) return improvementDelta;
+
+  return b.entry.occurred_at.localeCompare(a.entry.occurred_at);
 }


### PR DESCRIPTION
Closes #830

## Summary
- Select best evidence from directed numeric metrics before falling back to legacy evidence category ordering.
- Treat comparable metric identity as metric label plus direction, with the first directed numeric metric acting as the primary metric contract.
- Keep non-metric fallback behavior compatible and route `best_evidence` finalization artifacts through the metric-aware summary path.

## Verification
- `npm run test:integration -- src/runtime/__tests__/runtime-evidence-ledger.test.ts`
- `npm run test:unit -- src/orchestrator/loop/__tests__/core-loop-integrations.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings)
- `git diff --check`

## Known unresolved risks
- `npm run test:changed` hit an unrelated related integration timeout in `src/interface/cli/__tests__/cli-runner-integration.test.ts > runs CoreLoop to completion with max_iterations=1 using MockLLM` at 60000ms. Focused issue tests and required static checks pass.
