### PR TITLE
feat(runtime): record Dream checkpoint hypotheses and rejections

### DIFF
--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -341,6 +341,8 @@ describe("runtime registry CLI commands", () => {
           summary: "Checkpoint before finalization.",
           authority: "advisory_only",
         }],
+        active_hypotheses: [],
+        rejected_approaches: [],
         next_strategy_candidates: [{
           title: "Lock current approach",
           rationale: "Avoid losing a high-signal breakthrough.",

--- a/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
+++ b/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
@@ -84,6 +84,8 @@ describe("Dream review checkpoint trigger planning", () => {
         exhausted: [],
         promising: [],
         relevant_memories: [],
+        active_hypotheses: [],
+        rejected_approaches: [],
         next_strategy_candidates: [],
         guidance: "Try one bounded variant.",
         uncertainty: [],
@@ -136,6 +138,8 @@ describe("Dream review checkpoint trigger planning", () => {
         exhausted: [],
         promising: [],
         relevant_memories: [],
+        active_hypotheses: [],
+        rejected_approaches: [],
         next_strategy_candidates: [],
         guidance: "Try one bounded variant.",
         uncertainty: [],
@@ -169,6 +173,8 @@ describe("Dream review checkpoint trigger planning", () => {
         exhausted: [],
         promising: [],
         relevant_memories: [],
+        active_hypotheses: [],
+        rejected_approaches: [],
         next_strategy_candidates: [],
         guidance: "Try one bounded variant.",
         uncertainty: [],
@@ -201,6 +207,183 @@ describe("Dream review checkpoint trigger planning", () => {
     });
 
     expect(parsed.success).toBe(false);
+  });
+
+  it("carries active hypotheses and rejected approaches into the next checkpoint request", () => {
+    const request = buildDreamReviewCheckpointRequest({
+      goal: makeGoal(),
+      loopIndex: 5,
+      result: makeEmptyIterationResult("goal-1", 5, { stallDetected: true }),
+      driveScores: [],
+      recentCheckpoints: [{
+        trigger: "plateau",
+        summary: "Previous checkpoint rejected repeat sweep.",
+        current_goal: "Improve benchmark score",
+        active_dimensions: ["dim1"],
+        recent_strategy_families: ["threshold_sweep"],
+        exhausted: ["repeat threshold sweep"],
+        promising: ["feature ablation"],
+        relevant_memories: [],
+        active_hypotheses: [{
+          hypothesis: "特徴量アブレーションがリーク感度を示す.",
+          supporting_evidence_ref: "metric:balanced_accuracy",
+          target_metric_or_dimension: "balanced_accuracy",
+          expected_next_observation: "Ablation changes balanced accuracy by more than noise.",
+          status: "testing",
+        }],
+        rejected_approaches: [{
+          approach: "閾値スイープの再実行",
+          rejection_reason: "3回のスイープが指標ノイズ内に収まった.",
+          evidence_ref: "lineage:threshold-sweep",
+          revisit_condition: "new calibration evidence appears",
+          confidence: 0.88,
+        }],
+        next_strategy_candidates: [],
+        guidance: "Avoid repeating threshold sweeps.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.8,
+        entry_id: "entry-checkpoint",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+        loop_index: 2,
+      }],
+    });
+
+    expect(request).toMatchObject({
+      activeHypotheses: [{
+        hypothesis: "特徴量アブレーションがリーク感度を示す.",
+        target_metric_or_dimension: "balanced_accuracy",
+      }],
+      rejectedApproaches: [{
+        approach: "閾値スイープの再実行",
+        evidence_ref: "lineage:threshold-sweep",
+      }],
+    });
+  });
+
+  it("normalizes rejected approaches and suppresses matching next candidates", () => {
+    const goal = makeGoal({ title: "Improve benchmark score" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 1,
+      result: makeEmptyIterationResult("goal-1", 1, { stallDetected: true }),
+      driveScores: [],
+      recentCheckpoints: [{
+        trigger: "plateau",
+        summary: "Previous checkpoint rejected repeat sweep.",
+        current_goal: "Improve benchmark score",
+        active_dimensions: ["dim1"],
+        recent_strategy_families: [],
+        exhausted: ["repeat threshold sweep"],
+        promising: [],
+        relevant_memories: [],
+        active_hypotheses: [],
+        rejected_approaches: [{
+          approach: "repeat threshold sweep",
+          rejection_reason: "Three attempts did not improve the metric.",
+          evidence_ref: "lineage:threshold-sweep",
+          revisit_condition: "new calibration evidence appears",
+          confidence: 0.86,
+        }],
+        next_strategy_candidates: [],
+        guidance: "Avoid repeating threshold sweeps.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.8,
+        entry_id: "entry-checkpoint",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+      }],
+    });
+    expect(request).not.toBeNull();
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "Plateau review.",
+      trigger: "plateau",
+      current_goal: "Improve benchmark score",
+      active_dimensions: ["dim1"],
+      active_hypotheses: [{
+        hypothesis: "Feature ablation is now the active path.",
+        supporting_evidence_ref: "metric:balanced_accuracy",
+        target_metric_or_dimension: "balanced_accuracy",
+        expected_next_observation: "Ablation moves balanced accuracy.",
+        status: "active",
+      }],
+      rejected_approaches: [{
+        approach: "repeat threshold sweep",
+        rejection_reason: "Three attempts did not improve the metric.",
+        evidence_ref: "lineage:threshold-sweep",
+        revisit_condition: "new calibration evidence appears",
+        confidence: 0.86,
+      }],
+      next_strategy_candidates: [
+        {
+          title: "Repeat threshold sweep",
+          rationale: "Try the same thresholds again.",
+          target_dimensions: ["dim1"],
+        },
+        {
+          title: "Feature ablation",
+          rationale: "Test a different mechanism.",
+          target_dimensions: ["dim1"],
+        },
+      ],
+      guidance: "Try feature ablation.",
+      uncertainty: [],
+      context_authority: "advisory_only",
+      confidence: 0.8,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+
+    expect(normalized.next_strategy_candidates.map((candidate) => candidate.title)).toEqual(["Feature ablation"]);
+    expect(dreamCheckpointRawRefs(normalized)).toEqual(expect.arrayContaining([
+      { kind: "dream_active_hypothesis_evidence", id: "metric:balanced_accuracy" },
+      { kind: "dream_rejected_approach_evidence", id: "lineage:threshold-sweep" },
+    ]));
+  });
+
+  it("suppresses non-ASCII rejected candidates during normalization", () => {
+    const goal = makeGoal({ title: "Improve benchmark score" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 1,
+      result: makeEmptyIterationResult("goal-1", 1, { stallDetected: true }),
+      driveScores: [],
+    });
+    expect(request).not.toBeNull();
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "Plateau review.",
+      trigger: "plateau",
+      current_goal: "Improve benchmark score",
+      active_dimensions: ["dim1"],
+      rejected_approaches: [{
+        approach: "閾値スイープの再実行",
+        rejection_reason: "3回の試行で改善しなかった.",
+        evidence_ref: "lineage:threshold-sweep",
+        confidence: 0.9,
+      }],
+      next_strategy_candidates: [
+        {
+          title: "閾値スイープの再実行",
+          rationale: "同じ探索をもう一度行う.",
+          target_dimensions: ["dim1"],
+        },
+        {
+          title: "特徴量アブレーション",
+          rationale: "別の仮説を検証する.",
+          target_dimensions: ["dim1"],
+        },
+      ],
+      guidance: "Try feature ablation.",
+      uncertainty: [],
+      context_authority: "advisory_only",
+      confidence: 0.8,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+
+    expect(normalized.next_strategy_candidates.map((candidate) => candidate.title)).toEqual(["特徴量アブレーション"]);
   });
 
   it("normalizes deadline-backed finalization recommendations as auto-applied run control", () => {

--- a/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
+++ b/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
@@ -5,10 +5,13 @@ import type { MetricTrendContext } from "../../../platform/drive/metric-history.
 import type { RuntimeDreamCheckpointContext } from "../../../runtime/store/dream-checkpoints.js";
 import type { RuntimeEvidenceEntry, RuntimeEvidenceSummary } from "../../../runtime/store/evidence-ledger.js";
 import type {
+  DreamReviewActiveHypothesis,
   DreamReviewCheckpointEvidence,
   DreamReviewCheckpointTrigger,
+  DreamReviewRejectedApproach,
   DreamRunControlPolicyDecision,
   DreamRunControlRecommendation,
+  DreamReviewStrategyCandidate,
 } from "./phase-specs.js";
 import type { LoopIterationResult } from "../loop-result-types.js";
 import type { ExecutionModeState } from "../../../platform/time/execution-mode.js";
@@ -22,6 +25,8 @@ export interface DreamReviewCheckpointRequest {
   metricTrendSummary?: string;
   finalizationReason?: string;
   currentExecutionMode?: ExecutionModeState["mode"];
+  activeHypotheses: DreamReviewActiveHypothesis[];
+  rejectedApproaches: DreamReviewRejectedApproach[];
   runControlPolicy: "auto_apply_low_risk_require_approval_for_high_cost_or_irreversible";
   memoryAuthorityPolicy: "soil_and_playbooks_are_advisory_only";
   maxGuidanceItems: number;
@@ -57,12 +62,16 @@ export function buildDreamReviewCheckpointRequest(
 
   const activeDimensions = topDimensions(input.driveScores, input.goal);
   const metricTrendSummary = input.result.metricTrendContext?.summary;
+  const activeHypotheses = recentActiveHypotheses(input.recentCheckpoints ?? []);
+  const rejectedApproaches = recentRejectedApproaches(input.recentCheckpoints ?? []);
   return {
     trigger,
     reason: reasonForTrigger(trigger, input),
     activeDimensions,
     ...(input.evidenceSummary?.best_evidence ? { bestEvidenceSummary: entrySummary(input.evidenceSummary.best_evidence) } : {}),
     recentStrategyFamilies: recentStrategyFamilies(input.evidenceSummary?.recent_entries ?? []),
+    activeHypotheses,
+    rejectedApproaches,
     ...(metricTrendSummary ? { metricTrendSummary } : {}),
     ...(isPreFinalization(input.finalizationStatus) ? { finalizationReason: input.finalizationStatus?.reason } : {}),
     ...(input.executionMode?.mode ? { currentExecutionMode: input.executionMode.mode } : {}),
@@ -86,6 +95,12 @@ export function normalizeDreamReviewCheckpoint(
       ...memory,
       authority: "advisory_only",
     })),
+    active_hypotheses: output.active_hypotheses,
+    rejected_approaches: output.rejected_approaches,
+    next_strategy_candidates: filterRejectedStrategyCandidates(
+      output.next_strategy_candidates,
+      output.rejected_approaches.length > 0 ? output.rejected_approaches : request.rejectedApproaches
+    ),
     run_control_recommendations: normalizeRunControlRecommendations(output.run_control_recommendations, request),
     context_authority: "advisory_only",
   };
@@ -230,7 +245,70 @@ export function dreamCheckpointRawRefs(
       ? { kind: `dream_run_control_${evidence.kind}`, id: evidence.ref }
       : null)
     .filter((ref): ref is { kind: string; id: string } => ref !== null);
-  return [...memoryRefs, ...recommendationEvidenceRefs];
+  const hypothesisRefs = output.active_hypotheses
+    .map((hypothesis) => hypothesis.supporting_evidence_ref
+      ? { kind: "dream_active_hypothesis_evidence", id: hypothesis.supporting_evidence_ref }
+      : null)
+    .filter((ref): ref is { kind: string; id: string } => ref !== null);
+  const rejectedRefs = output.rejected_approaches
+    .map((approach) => approach.evidence_ref
+      ? { kind: "dream_rejected_approach_evidence", id: approach.evidence_ref }
+      : null)
+    .filter((ref): ref is { kind: string; id: string } => ref !== null);
+  return [...memoryRefs, ...recommendationEvidenceRefs, ...hypothesisRefs, ...rejectedRefs];
+}
+
+function recentActiveHypotheses(checkpoints: RuntimeDreamCheckpointContext[]): DreamReviewActiveHypothesis[] {
+  return dedupeByText(
+    checkpoints.flatMap((checkpoint) => checkpoint.active_hypotheses ?? []),
+    (hypothesis) => hypothesis.hypothesis,
+  ).slice(0, 5);
+}
+
+function recentRejectedApproaches(checkpoints: RuntimeDreamCheckpointContext[]): DreamReviewRejectedApproach[] {
+  return dedupeByText(
+    checkpoints.flatMap((checkpoint) => checkpoint.rejected_approaches ?? []),
+    (approach) => approach.approach,
+  ).slice(0, 8);
+}
+
+function dedupeByText<T>(items: T[], keyFor: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  const deduped: T[] = [];
+  for (const item of items) {
+    const key = normalizeApproachText(keyFor(item));
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(item);
+  }
+  return deduped;
+}
+
+function filterRejectedStrategyCandidates(
+  candidates: DreamReviewStrategyCandidate[],
+  rejectedApproaches: DreamReviewRejectedApproach[]
+): DreamReviewStrategyCandidate[] {
+  if (rejectedApproaches.length === 0) return candidates;
+  return candidates.filter((candidate) =>
+    !rejectedApproaches.some((rejected) => rejectedCandidateMatches(candidate, rejected))
+  );
+}
+
+function rejectedCandidateMatches(
+  candidate: DreamReviewStrategyCandidate,
+  rejected: DreamReviewRejectedApproach
+): boolean {
+  const candidateText = normalizeApproachText(`${candidate.title} ${candidate.rationale}`);
+  const approachText = normalizeApproachText(rejected.approach);
+  if (!candidateText || !approachText) return false;
+  const matchesApproach = candidateText.includes(approachText) || approachText.includes(candidateText);
+  if (!matchesApproach) return false;
+  const revisitText = normalizeApproachText(rejected.revisit_condition ?? "");
+  return !revisitText || !candidateText.includes(revisitText);
+}
+
+function normalizeApproachText(value: string): string {
+  return value.normalize("NFKC").toLocaleLowerCase().replace(/[^\p{Letter}\p{Number}]+/gu, " ").trim();
 }
 
 function inferCheckpointTrigger(

--- a/src/orchestrator/loop/core-loop/iteration-kernel.ts
+++ b/src/orchestrator/loop/core-loop/iteration-kernel.ts
@@ -234,6 +234,8 @@ export class CoreIterationKernel {
             activeDimensions: request.activeDimensions,
             ...(request.bestEvidenceSummary ? { bestEvidenceSummary: request.bestEvidenceSummary } : {}),
             recentStrategyFamilies: request.recentStrategyFamilies,
+            activeHypotheses: request.activeHypotheses,
+            rejectedApproaches: request.rejectedApproaches,
             ...(request.metricTrendSummary ? { metricTrendSummary: request.metricTrendSummary } : {}),
             ...(request.finalizationReason ? { finalizationReason: request.finalizationReason } : {}),
             ...(request.currentExecutionMode ? { currentExecutionMode: request.currentExecutionMode } : {}),

--- a/src/orchestrator/loop/core-loop/phase-specs.ts
+++ b/src/orchestrator/loop/core-loop/phase-specs.ts
@@ -132,6 +132,24 @@ export const DreamReviewStrategyCandidateSchema = z.object({
 }).strict();
 export type DreamReviewStrategyCandidate = z.infer<typeof DreamReviewStrategyCandidateSchema>;
 
+export const DreamReviewActiveHypothesisSchema = z.object({
+  hypothesis: z.string().min(1),
+  supporting_evidence_ref: z.string().min(1).optional(),
+  target_metric_or_dimension: z.string().min(1),
+  expected_next_observation: z.string().min(1),
+  status: z.enum(["active", "testing", "supported", "weakened"]).default("active"),
+}).strict();
+export type DreamReviewActiveHypothesis = z.infer<typeof DreamReviewActiveHypothesisSchema>;
+
+export const DreamReviewRejectedApproachSchema = z.object({
+  approach: z.string().min(1),
+  rejection_reason: z.string().min(1),
+  evidence_ref: z.string().min(1).optional(),
+  revisit_condition: z.string().min(1).optional(),
+  confidence: z.number().min(0).max(1).default(0.5),
+}).strict();
+export type DreamReviewRejectedApproach = z.infer<typeof DreamReviewRejectedApproachSchema>;
+
 export const DreamRunControlRecommendationActionSchema = z.enum([
   "stay_current_mode",
   "widen_exploration",
@@ -183,6 +201,8 @@ export const DreamReviewCheckpointEvidenceSchema = z.object({
   exhausted: z.array(z.string().min(1)).default([]),
   promising: z.array(z.string().min(1)).default([]),
   relevant_memories: z.array(DreamReviewMemoryRefSchema).default([]),
+  active_hypotheses: z.array(DreamReviewActiveHypothesisSchema).default([]),
+  rejected_approaches: z.array(DreamReviewRejectedApproachSchema).default([]),
   next_strategy_candidates: z.array(DreamReviewStrategyCandidateSchema).default([]),
   run_control_recommendations: z.array(DreamRunControlRecommendationSchema).default([]),
   guidance: z.string().min(1),
@@ -326,6 +346,8 @@ export function buildDreamReviewCheckpointSpec(): ReturnType<typeof baseSpec<{
   activeDimensions: string[];
   bestEvidenceSummary?: string;
   recentStrategyFamilies: string[];
+  activeHypotheses: DreamReviewActiveHypothesis[];
+  rejectedApproaches: DreamReviewRejectedApproach[];
   metricTrendSummary?: string;
   finalizationReason?: string;
   currentExecutionMode?: "exploration" | "consolidation" | "finalization";
@@ -342,6 +364,8 @@ export function buildDreamReviewCheckpointSpec(): ReturnType<typeof baseSpec<{
       activeDimensions: z.array(z.string()).default([]),
       bestEvidenceSummary: z.string().optional(),
       recentStrategyFamilies: z.array(z.string()).default([]),
+      activeHypotheses: z.array(DreamReviewActiveHypothesisSchema).default([]),
+      rejectedApproaches: z.array(DreamReviewRejectedApproachSchema).default([]),
       metricTrendSummary: z.string().optional(),
       finalizationReason: z.string().optional(),
       currentExecutionMode: z.enum(["exploration", "consolidation", "finalization"]).optional(),

--- a/src/runtime/__tests__/dream-sidecar-review.test.ts
+++ b/src/runtime/__tests__/dream-sidecar-review.test.ts
@@ -62,6 +62,8 @@ describe("Runtime Dream sidecar review", () => {
           summary: "Prior run preserved a breakthrough before finalization.",
           authority: "advisory_only",
         }],
+        active_hypotheses: [],
+        rejected_approaches: [],
         next_strategy_candidates: [{
           title: "Lock current approach",
           rationale: "Confirm the breakthrough is stable before broadening.",
@@ -104,6 +106,71 @@ describe("Runtime Dream sidecar review", () => {
     expect(review.evidence_refs).toContainEqual(expect.objectContaining({
       kind: "evidence_ledger",
       id: "run:coreloop:sidecar",
+    }));
+  });
+
+  it("does not blindly re-suggest a rejected Dream approach", async () => {
+    await seedActiveRun("run:coreloop:rejected");
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      kind: "dream_checkpoint",
+      scope: { run_id: "run:coreloop:rejected", loop_index: 4, phase: "dream_review_checkpoint" },
+      dream_checkpoints: [{
+        trigger: "plateau",
+        summary: "Dream checkpoint rejected the repeated sweep.",
+        current_goal: "Improve benchmark",
+        active_dimensions: ["balanced_accuracy"],
+        recent_strategy_families: ["threshold_sweep"],
+        exhausted: ["閾値スイープの再実行"],
+        promising: ["feature ablation"],
+        relevant_memories: [],
+        active_hypotheses: [{
+          hypothesis: "Feature ablation may expose a stronger path.",
+          supporting_evidence_ref: "metric:balanced_accuracy",
+          target_metric_or_dimension: "balanced_accuracy",
+          expected_next_observation: "Ablation moves balanced accuracy.",
+          status: "active",
+        }],
+        rejected_approaches: [{
+          approach: "閾値スイープの再実行",
+          rejection_reason: "3回のスイープが指標ノイズ内に収まった.",
+          evidence_ref: "lineage:threshold-sweep",
+          revisit_condition: "new calibration evidence appears",
+          confidence: 0.9,
+        }],
+        next_strategy_candidates: [
+          {
+            title: "閾値スイープの再実行",
+            rationale: "同じ探索をもう一度行う.",
+            target_dimensions: ["balanced_accuracy"],
+          },
+          {
+            title: "Feature ablation",
+            rationale: "Test a different mechanism.",
+            target_dimensions: ["balanced_accuracy"],
+          },
+        ],
+        guidance: "Avoid repeating threshold sweeps.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.88,
+      }],
+      summary: "Plateau checkpoint saved.",
+      outcome: "continued",
+    });
+
+    const review = await createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:coreloop:rejected",
+    });
+
+    expect(review.known_gaps).toContainEqual(expect.stringContaining("Rejected approach: 閾値スイープの再実行"));
+    expect(review.suggested_next_moves).not.toContainEqual(expect.objectContaining({
+      title: "閾値スイープの再実行",
+    }));
+    expect(review.suggested_next_moves).toContainEqual(expect.objectContaining({
+      title: "Feature ablation",
+      source: "dream_checkpoint",
     }));
   });
 

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -402,6 +402,20 @@ describe("RuntimeEvidenceLedger", () => {
           summary: "Earlier run improved after an ablation.",
           authority: "advisory_only",
         }],
+        active_hypotheses: [{
+          hypothesis: "Bounded ablation separates search saturation from model saturation.",
+          supporting_evidence_ref: "metric:accuracy",
+          target_metric_or_dimension: "accuracy",
+          expected_next_observation: "Accuracy changes after one-factor ablation.",
+          status: "testing",
+        }],
+        rejected_approaches: [{
+          approach: "repeat baseline threshold sweep",
+          rejection_reason: "Three previous sweeps did not move accuracy.",
+          evidence_ref: "lineage:baseline-threshold-sweep",
+          revisit_condition: "new validation split exposes threshold instability",
+          confidence: 0.84,
+        }],
         next_strategy_candidates: [{
           title: "Bounded ablation",
           rationale: "Changes one factor before broadening exploration.",
@@ -429,6 +443,14 @@ describe("RuntimeEvidenceLedger", () => {
         source_type: "soil",
         ref: "soil://goal-dream/checkpoint",
         authority: "advisory_only",
+      }],
+      active_hypotheses: [{
+        target_metric_or_dimension: "accuracy",
+        status: "testing",
+      }],
+      rejected_approaches: [{
+        approach: "repeat baseline threshold sweep",
+        evidence_ref: "lineage:baseline-threshold-sweep",
       }],
       next_strategy_candidates: [{ title: "Bounded ablation" }],
     });

--- a/src/runtime/dream-sidecar-review.ts
+++ b/src/runtime/dream-sidecar-review.ts
@@ -10,6 +10,8 @@ import type {
 } from "./session-registry/types.js";
 import type {
   RuntimeEvidenceEntry,
+  RuntimeEvidenceDreamCheckpointRejectedApproach,
+  RuntimeEvidenceDreamCheckpointStrategyCandidate,
   RuntimeEvidenceSummary,
 } from "./store/evidence-ledger.js";
 import { BackgroundRunLedger } from "./store/background-run-store.js";
@@ -315,6 +317,9 @@ function buildKnownGaps(summary: RuntimeEvidenceSummary): string[] {
       }
     }
   }
+  for (const rejected of collectRejectedApproaches(summary).slice(0, 3)) {
+    gaps.add(`Rejected approach: ${rejected.approach} (${rejected.rejection_reason})`);
+  }
   if (!summary.best_evidence) gaps.add("No best evidence has been recorded for this run.");
   if (summary.metric_trends.length === 0) gaps.add("No progress metric history has been recorded for this run.");
   return [...gaps].slice(0, 6);
@@ -334,8 +339,10 @@ function buildStrategyFamilies(summary: RuntimeEvidenceSummary): string[] {
 
 function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamSidecarReview["suggested_next_moves"] {
   const moves: RuntimeDreamSidecarReview["suggested_next_moves"] = [];
+  const rejectedApproaches = collectRejectedApproaches(summary);
   for (const checkpoint of summary.dream_checkpoints.slice(0, 2)) {
     for (const candidate of checkpoint.next_strategy_candidates) {
+      if (isRejectedDreamCandidate(candidate, rejectedApproaches)) continue;
       moves.push({
         title: candidate.title,
         rationale: candidate.rationale,
@@ -352,6 +359,7 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
   }
   for (const memo of summary.research_memos.slice(0, 2)) {
     for (const finding of memo.findings.slice(0, 2)) {
+      if (isRejectedMove(finding.proposed_experiment, finding.applicability, rejectedApproaches)) continue;
       moves.push({
         title: finding.proposed_experiment,
         rationale: finding.applicability,
@@ -374,6 +382,49 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
     });
   }
   return moves.slice(0, 6);
+}
+
+function collectRejectedApproaches(summary: RuntimeEvidenceSummary): RuntimeEvidenceDreamCheckpointRejectedApproach[] {
+  const seen = new Set<string>();
+  const rejectedApproaches: RuntimeEvidenceDreamCheckpointRejectedApproach[] = [];
+  for (const checkpoint of summary.dream_checkpoints) {
+    for (const rejected of checkpoint.rejected_approaches ?? []) {
+      const key = normalizeRejectedMoveText(rejected.approach);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      rejectedApproaches.push(rejected);
+    }
+  }
+  return rejectedApproaches;
+}
+
+function isRejectedDreamCandidate(
+  candidate: RuntimeEvidenceDreamCheckpointStrategyCandidate,
+  rejectedApproaches: RuntimeEvidenceDreamCheckpointRejectedApproach[]
+): boolean {
+  return isRejectedMove(candidate.title, candidate.rationale, rejectedApproaches);
+}
+
+function isRejectedMove(
+  title: string,
+  rationale: string,
+  rejectedApproaches: RuntimeEvidenceDreamCheckpointRejectedApproach[]
+): boolean {
+  if (rejectedApproaches.length === 0) return false;
+  const moveText = normalizeRejectedMoveText(`${title} ${rationale}`);
+  if (!moveText) return false;
+  return rejectedApproaches.some((rejected) => {
+    const approachText = normalizeRejectedMoveText(rejected.approach);
+    if (!approachText) return false;
+    const matchesApproach = moveText.includes(approachText) || approachText.includes(moveText);
+    if (!matchesApproach) return false;
+    const revisitText = normalizeRejectedMoveText(rejected.revisit_condition ?? "");
+    return !revisitText || !moveText.includes(revisitText);
+  });
+}
+
+function normalizeRejectedMoveText(value: string): string {
+  return value.normalize("NFKC").toLocaleLowerCase().replace(/[^\p{Letter}\p{Number}]+/gu, " ").trim();
 }
 
 function buildOperatorDecisions(summary: RuntimeEvidenceSummary): RuntimeDreamSidecarReview["operator_decisions"] {

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -208,6 +208,24 @@ export const RuntimeEvidenceDreamCheckpointStrategyCandidateSchema = z.object({
 }).strict();
 export type RuntimeEvidenceDreamCheckpointStrategyCandidate = z.infer<typeof RuntimeEvidenceDreamCheckpointStrategyCandidateSchema>;
 
+export const RuntimeEvidenceDreamCheckpointActiveHypothesisSchema = z.object({
+  hypothesis: z.string().min(1),
+  supporting_evidence_ref: z.string().min(1).optional(),
+  target_metric_or_dimension: z.string().min(1),
+  expected_next_observation: z.string().min(1),
+  status: z.enum(["active", "testing", "supported", "weakened"]).default("active"),
+}).strict();
+export type RuntimeEvidenceDreamCheckpointActiveHypothesis = z.infer<typeof RuntimeEvidenceDreamCheckpointActiveHypothesisSchema>;
+
+export const RuntimeEvidenceDreamCheckpointRejectedApproachSchema = z.object({
+  approach: z.string().min(1),
+  rejection_reason: z.string().min(1),
+  evidence_ref: z.string().min(1).optional(),
+  revisit_condition: z.string().min(1).optional(),
+  confidence: z.number().min(0).max(1).default(0.5),
+}).strict();
+export type RuntimeEvidenceDreamCheckpointRejectedApproach = z.infer<typeof RuntimeEvidenceDreamCheckpointRejectedApproachSchema>;
+
 export const RuntimeEvidenceDreamRunControlRecommendationSchema = z.object({
   id: z.string().min(1).optional(),
   action: z.enum([
@@ -250,6 +268,8 @@ export const RuntimeEvidenceDreamCheckpointSchema = z.object({
   exhausted: z.array(z.string().min(1)).default([]),
   promising: z.array(z.string().min(1)).default([]),
   relevant_memories: z.array(RuntimeEvidenceDreamCheckpointMemoryRefSchema).default([]),
+  active_hypotheses: z.array(RuntimeEvidenceDreamCheckpointActiveHypothesisSchema).default([]),
+  rejected_approaches: z.array(RuntimeEvidenceDreamCheckpointRejectedApproachSchema).default([]),
   next_strategy_candidates: z.array(RuntimeEvidenceDreamCheckpointStrategyCandidateSchema).default([]),
   run_control_recommendations: z.array(RuntimeEvidenceDreamRunControlRecommendationSchema).optional(),
   guidance: z.string().min(1),


### PR DESCRIPTION
Closes #833

## Summary
- Add backward-compatible `active_hypotheses` and `rejected_approaches` fields to Dream checkpoint schemas.
- Carry recent hypotheses/rejections into the next Dream checkpoint request and suppress repeated rejected strategy candidates during normalization.
- Surface rejected approaches in Dream sidecar known gaps and filter suggested next moves, including Japanese/non-ASCII approach text.

## Verification
- `npm run test:unit -- src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts`
- `npm run test:integration -- src/runtime/__tests__/dream-sidecar-review.test.ts src/runtime/__tests__/runtime-evidence-ledger.test.ts`
- `npm run test:unit -- src/interface/cli/__tests__/runtime-command.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings)
- `git diff --check`

## Known unresolved risks
- `npm run test:changed` still hits an unrelated related integration timeout in `src/interface/cli/__tests__/cli-runner-integration.test.ts > runs CoreLoop to completion with max_iterations=1 using MockLLM` at 60000ms. Focused issue tests and required static checks pass.
