### PR TITLE
feat(runtime): aggregate failed lineages

### DIFF
--- a/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
+++ b/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
@@ -386,6 +386,86 @@ describe("Dream review checkpoint trigger planning", () => {
     expect(normalized.next_strategy_candidates.map((candidate) => candidate.title)).toEqual(["特徴量アブレーション"]);
   });
 
+  it("carries repeated failed lineages into checkpoint requests and downranks similar candidates", () => {
+    const goal = makeGoal({ title: "Improve benchmark score" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 1,
+      result: makeEmptyIterationResult("goal-1", 1, { stallDetected: true }),
+      driveScores: [],
+      evidenceSummary: {
+        best_evidence: null,
+        recent_entries: [],
+        failed_lineages: [{
+          fingerprint: "threshold_sweep|balanced_accuracy|balanced_accuracy stayed inside noise",
+          count: 3,
+          first_seen_at: "2026-04-30T00:00:00.000Z",
+          last_seen_at: "2026-04-30T00:10:00.000Z",
+          strategy_family: "threshold_sweep",
+          hypothesis: "Repeat threshold sweep improves balanced accuracy",
+          primary_dimension: "balanced_accuracy",
+          task_action: "threshold_sweep",
+          failure_reason: "Balanced accuracy stayed inside noise.",
+          representative_entry_id: "failed-threshold-3",
+          representative_summary: "Threshold sweep failed.",
+          evidence_entry_ids: ["failed-threshold-1", "failed-threshold-2", "failed-threshold-3"],
+        }],
+      },
+    });
+    expect(request).toMatchObject({
+      failedLineages: [{
+        count: 3,
+        strategy_family: "threshold_sweep",
+        representative_entry_id: "failed-threshold-3",
+      }],
+    });
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "Plateau review.",
+      trigger: "plateau",
+      current_goal: "Improve benchmark score",
+      active_dimensions: ["balanced_accuracy"],
+      next_strategy_candidates: [
+        {
+          title: "threshold_sweep retry",
+          rationale: "Try another threshold_sweep attempt.",
+          target_dimensions: ["balanced_accuracy"],
+        },
+        {
+          title: "Feature ablation",
+          rationale: "Test a different mechanism for balanced_accuracy.",
+          target_dimensions: ["balanced_accuracy"],
+        },
+        {
+          title: "threshold_sweep with new calibration evidence",
+          rationale: "Retry threshold_sweep because calibration bins changed.",
+          target_dimensions: ["balanced_accuracy"],
+          retry_reason: "New calibration evidence changes the search space.",
+        },
+      ],
+      guidance: "Avoid repeating failed threshold sweeps without new evidence.",
+      uncertainty: [],
+      context_authority: "advisory_only",
+      confidence: 0.8,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+
+    expect(normalized.next_strategy_candidates.map((candidate) => candidate.title)).toEqual([
+      "Feature ablation",
+      "threshold_sweep with new calibration evidence",
+      "threshold_sweep retry",
+    ]);
+    expect(normalized.next_strategy_candidates[1]?.failed_lineage_warning).toMatchObject({
+      count: 3,
+      reason: expect.stringContaining("Retry override"),
+    });
+    expect(normalized.next_strategy_candidates[2]?.failed_lineage_warning).toMatchObject({
+      count: 3,
+      reason: expect.stringContaining("Similar to failed lineage"),
+    });
+  });
+
   it("normalizes deadline-backed finalization recommendations as auto-applied run control", () => {
     const goal = makeGoal({ title: "Submit final benchmark artifact" });
     const request = buildDreamReviewCheckpointRequest({

--- a/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
+++ b/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
@@ -3,10 +3,11 @@ import type { DriveScore } from "../../../base/types/drive.js";
 import type { DeadlineFinalizationStatus } from "../../../platform/time/deadline-finalization.js";
 import type { MetricTrendContext } from "../../../platform/drive/metric-history.js";
 import type { RuntimeDreamCheckpointContext } from "../../../runtime/store/dream-checkpoints.js";
-import type { RuntimeEvidenceEntry, RuntimeEvidenceSummary } from "../../../runtime/store/evidence-ledger.js";
+import type { RuntimeEvidenceEntry, RuntimeEvidenceSummary, RuntimeFailedLineageContext } from "../../../runtime/store/evidence-ledger.js";
 import type {
   DreamReviewActiveHypothesis,
   DreamReviewCheckpointEvidence,
+  DreamReviewFailedLineage,
   DreamReviewCheckpointTrigger,
   DreamReviewRejectedApproach,
   DreamRunControlPolicyDecision,
@@ -27,6 +28,7 @@ export interface DreamReviewCheckpointRequest {
   currentExecutionMode?: ExecutionModeState["mode"];
   activeHypotheses: DreamReviewActiveHypothesis[];
   rejectedApproaches: DreamReviewRejectedApproach[];
+  failedLineages: DreamReviewFailedLineage[];
   runControlPolicy: "auto_apply_low_risk_require_approval_for_high_cost_or_irreversible";
   memoryAuthorityPolicy: "soil_and_playbooks_are_advisory_only";
   maxGuidanceItems: number;
@@ -45,7 +47,7 @@ export interface BuildDreamReviewCheckpointRequestInput {
   finalizationStatus?: DeadlineFinalizationStatus;
   executionMode?: ExecutionModeState;
   recentCheckpoints?: RuntimeDreamCheckpointContext[];
-  evidenceSummary?: Pick<RuntimeEvidenceSummary, "best_evidence" | "recent_entries"> | null;
+  evidenceSummary?: Pick<RuntimeEvidenceSummary, "best_evidence" | "recent_entries" | "failed_lineages"> | null;
   requestedTrigger?: DreamReviewCheckpointTrigger;
   options?: DreamReviewCheckpointTriggerOptions;
 }
@@ -64,6 +66,7 @@ export function buildDreamReviewCheckpointRequest(
   const metricTrendSummary = input.result.metricTrendContext?.summary;
   const activeHypotheses = recentActiveHypotheses(input.recentCheckpoints ?? []);
   const rejectedApproaches = recentRejectedApproaches(input.recentCheckpoints ?? []);
+  const failedLineages = repeatedFailedLineages(input.evidenceSummary?.failed_lineages ?? []);
   return {
     trigger,
     reason: reasonForTrigger(trigger, input),
@@ -72,6 +75,7 @@ export function buildDreamReviewCheckpointRequest(
     recentStrategyFamilies: recentStrategyFamilies(input.evidenceSummary?.recent_entries ?? []),
     activeHypotheses,
     rejectedApproaches,
+    failedLineages,
     ...(metricTrendSummary ? { metricTrendSummary } : {}),
     ...(isPreFinalization(input.finalizationStatus) ? { finalizationReason: input.finalizationStatus?.reason } : {}),
     ...(input.executionMode?.mode ? { currentExecutionMode: input.executionMode.mode } : {}),
@@ -97,9 +101,12 @@ export function normalizeDreamReviewCheckpoint(
     })),
     active_hypotheses: output.active_hypotheses,
     rejected_approaches: output.rejected_approaches,
-    next_strategy_candidates: filterRejectedStrategyCandidates(
-      output.next_strategy_candidates,
-      output.rejected_approaches.length > 0 ? output.rejected_approaches : request.rejectedApproaches
+    next_strategy_candidates: downrankRepeatedFailedLineageCandidates(
+      filterRejectedStrategyCandidates(
+        output.next_strategy_candidates,
+        output.rejected_approaches.length > 0 ? output.rejected_approaches : request.rejectedApproaches
+      ),
+      request.failedLineages
     ),
     run_control_recommendations: normalizeRunControlRecommendations(output.run_control_recommendations, request),
     context_authority: "advisory_only",
@@ -272,6 +279,24 @@ function recentRejectedApproaches(checkpoints: RuntimeDreamCheckpointContext[]):
   ).slice(0, 8);
 }
 
+function repeatedFailedLineages(lineages: RuntimeFailedLineageContext[]): DreamReviewFailedLineage[] {
+  return lineages
+    .filter((lineage) => lineage.count >= 2)
+    .slice(0, 8)
+    .map((lineage) => ({
+      fingerprint: lineage.fingerprint,
+      count: lineage.count,
+      last_seen_at: lineage.last_seen_at,
+      ...(lineage.strategy_family ? { strategy_family: lineage.strategy_family } : {}),
+      ...(lineage.hypothesis ? { hypothesis: lineage.hypothesis } : {}),
+      ...(lineage.primary_dimension ? { primary_dimension: lineage.primary_dimension } : {}),
+      ...(lineage.task_action ? { task_action: lineage.task_action } : {}),
+      ...(lineage.failure_reason ? { failure_reason: lineage.failure_reason } : {}),
+      representative_entry_id: lineage.representative_entry_id,
+      representative_summary: lineage.representative_summary,
+    }));
+}
+
 function dedupeByText<T>(items: T[], keyFor: (item: T) => string): T[] {
   const seen = new Set<string>();
   const deduped: T[] = [];
@@ -291,6 +316,54 @@ function filterRejectedStrategyCandidates(
   if (rejectedApproaches.length === 0) return candidates;
   return candidates.filter((candidate) =>
     !rejectedApproaches.some((rejected) => rejectedCandidateMatches(candidate, rejected))
+  );
+}
+
+function downrankRepeatedFailedLineageCandidates(
+  candidates: DreamReviewStrategyCandidate[],
+  failedLineages: DreamReviewFailedLineage[]
+): DreamReviewStrategyCandidate[] {
+  if (failedLineages.length === 0) return candidates;
+  const allowed: DreamReviewStrategyCandidate[] = [];
+  const downranked: DreamReviewStrategyCandidate[] = [];
+  for (const candidate of candidates) {
+    const lineage = failedLineages.find((item) => failedLineageMatchesCandidate(item, candidate));
+    if (!lineage) {
+      allowed.push(candidate);
+      continue;
+    }
+    const annotated = {
+      ...candidate,
+      failed_lineage_warning: {
+        fingerprint: lineage.fingerprint,
+        count: lineage.count,
+        reason: candidate.retry_reason
+          ? `Retry override: ${candidate.retry_reason}`
+          : `Similar to failed lineage seen ${lineage.count} times: ${lineage.representative_summary}`,
+      },
+    };
+    if (candidate.retry_reason) {
+      allowed.push(annotated);
+    } else {
+      downranked.push(annotated);
+    }
+  }
+  return [...allowed, ...downranked];
+}
+
+function failedLineageMatchesCandidate(
+  lineage: DreamReviewFailedLineage,
+  candidate: DreamReviewStrategyCandidate
+): boolean {
+  const candidateText = normalizeApproachText(`${candidate.title} ${candidate.rationale}`);
+  if (!candidateText) return false;
+  const lineageTexts = [
+    lineage.strategy_family,
+    lineage.hypothesis,
+    lineage.task_action,
+  ].map((value) => normalizeApproachText(value ?? "")).filter(Boolean);
+  return lineageTexts.some((lineageText) =>
+    candidateText.includes(lineageText) || lineageText.includes(candidateText)
   );
 }
 

--- a/src/orchestrator/loop/core-loop/iteration-kernel.ts
+++ b/src/orchestrator/loop/core-loop/iteration-kernel.ts
@@ -236,6 +236,7 @@ export class CoreIterationKernel {
             recentStrategyFamilies: request.recentStrategyFamilies,
             activeHypotheses: request.activeHypotheses,
             rejectedApproaches: request.rejectedApproaches,
+            failedLineages: request.failedLineages,
             ...(request.metricTrendSummary ? { metricTrendSummary: request.metricTrendSummary } : {}),
             ...(request.finalizationReason ? { finalizationReason: request.finalizationReason } : {}),
             ...(request.currentExecutionMode ? { currentExecutionMode: request.currentExecutionMode } : {}),

--- a/src/orchestrator/loop/core-loop/phase-specs.ts
+++ b/src/orchestrator/loop/core-loop/phase-specs.ts
@@ -129,8 +129,28 @@ export const DreamReviewStrategyCandidateSchema = z.object({
   rationale: z.string().min(1),
   target_dimensions: z.array(z.string().min(1)).default([]),
   expected_evidence_gain: z.string().min(1).optional(),
+  retry_reason: z.string().min(1).optional(),
+  failed_lineage_warning: z.object({
+    fingerprint: z.string().min(1),
+    count: z.number().int().positive(),
+    reason: z.string().min(1),
+  }).strict().optional(),
 }).strict();
 export type DreamReviewStrategyCandidate = z.infer<typeof DreamReviewStrategyCandidateSchema>;
+
+export const DreamReviewFailedLineageSchema = z.object({
+  fingerprint: z.string().min(1),
+  count: z.number().int().positive(),
+  last_seen_at: z.string().datetime(),
+  strategy_family: z.string().min(1).optional(),
+  hypothesis: z.string().min(1).optional(),
+  primary_dimension: z.string().min(1).optional(),
+  task_action: z.string().min(1).optional(),
+  failure_reason: z.string().min(1).optional(),
+  representative_entry_id: z.string().min(1),
+  representative_summary: z.string().min(1),
+}).strict();
+export type DreamReviewFailedLineage = z.infer<typeof DreamReviewFailedLineageSchema>;
 
 export const DreamReviewActiveHypothesisSchema = z.object({
   hypothesis: z.string().min(1),
@@ -348,6 +368,7 @@ export function buildDreamReviewCheckpointSpec(): ReturnType<typeof baseSpec<{
   recentStrategyFamilies: string[];
   activeHypotheses: DreamReviewActiveHypothesis[];
   rejectedApproaches: DreamReviewRejectedApproach[];
+  failedLineages: DreamReviewFailedLineage[];
   metricTrendSummary?: string;
   finalizationReason?: string;
   currentExecutionMode?: "exploration" | "consolidation" | "finalization";
@@ -366,6 +387,7 @@ export function buildDreamReviewCheckpointSpec(): ReturnType<typeof baseSpec<{
       recentStrategyFamilies: z.array(z.string()).default([]),
       activeHypotheses: z.array(DreamReviewActiveHypothesisSchema).default([]),
       rejectedApproaches: z.array(DreamReviewRejectedApproachSchema).default([]),
+      failedLineages: z.array(DreamReviewFailedLineageSchema).default([]),
       metricTrendSummary: z.string().optional(),
       finalizationReason: z.string().optional(),
       currentExecutionMode: z.enum(["exploration", "consolidation", "finalization"]).optional(),

--- a/src/runtime/__tests__/dream-sidecar-review.test.ts
+++ b/src/runtime/__tests__/dream-sidecar-review.test.ts
@@ -146,7 +146,7 @@ describe("Runtime Dream sidecar review", () => {
           },
           {
             title: "Feature ablation",
-            rationale: "Test a different mechanism.",
+            rationale: "Test a different mechanism for balanced_accuracy.",
             target_dimensions: ["balanced_accuracy"],
           },
         ],
@@ -167,6 +167,77 @@ describe("Runtime Dream sidecar review", () => {
     expect(review.known_gaps).toContainEqual(expect.stringContaining("Rejected approach: 閾値スイープの再実行"));
     expect(review.suggested_next_moves).not.toContainEqual(expect.objectContaining({
       title: "閾値スイープの再実行",
+    }));
+    expect(review.suggested_next_moves).toContainEqual(expect.objectContaining({
+      title: "Feature ablation",
+      source: "dream_checkpoint",
+    }));
+  });
+
+  it("summarizes repeated failed lineages and avoids suggesting them without retry evidence", async () => {
+    await seedActiveRun("run:coreloop:failed-lineage");
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    for (let index = 0; index < 3; index += 1) {
+      await ledger.append({
+        id: `failed-threshold-${index + 1}`,
+        occurred_at: `2026-04-30T00:0${index}:00.000Z`,
+        kind: "failure",
+        scope: { run_id: "run:coreloop:failed-lineage", task_id: `task-threshold-${index + 1}` },
+        strategy: "threshold_sweep",
+        hypothesis: "Repeat threshold sweep improves balanced accuracy",
+        task: {
+          id: `task-threshold-${index + 1}`,
+          action: "threshold_sweep",
+          primary_dimension: "balanced_accuracy",
+        },
+        verification: { verdict: "fail", summary: "Balanced accuracy stayed inside noise." },
+        summary: "Threshold sweep failed.",
+        outcome: "failed",
+      });
+    }
+    await ledger.append({
+      kind: "dream_checkpoint",
+      scope: { run_id: "run:coreloop:failed-lineage", loop_index: 4, phase: "dream_review_checkpoint" },
+      dream_checkpoints: [{
+        trigger: "plateau",
+        summary: "Dream checkpoint proposed next moves.",
+        current_goal: "Improve benchmark",
+        active_dimensions: ["balanced_accuracy"],
+        recent_strategy_families: ["threshold_sweep"],
+        exhausted: ["threshold_sweep"],
+        promising: ["feature_ablation"],
+        relevant_memories: [],
+        active_hypotheses: [],
+        rejected_approaches: [],
+        next_strategy_candidates: [
+          {
+            title: "threshold_sweep retry",
+            rationale: "Try the same threshold_sweep again.",
+            target_dimensions: ["balanced_accuracy"],
+          },
+          {
+            title: "Feature ablation",
+            rationale: "Test a different mechanism.",
+            target_dimensions: ["balanced_accuracy"],
+          },
+        ],
+        guidance: "Avoid repeated failed lineages.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.88,
+      }],
+      summary: "Plateau checkpoint saved.",
+      outcome: "continued",
+    });
+
+    const review = await createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:coreloop:failed-lineage",
+    });
+
+    expect(review.known_gaps).toContainEqual(expect.stringContaining("Repeated failed lineage: threshold_sweep (count=3)"));
+    expect(review.suggested_next_moves).not.toContainEqual(expect.objectContaining({
+      title: "threshold_sweep retry",
     }));
     expect(review.suggested_next_moves).toContainEqual(expect.objectContaining({
       title: "Feature ablation",

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -259,6 +259,70 @@ describe("RuntimeEvidenceLedger", () => {
     expect(summary.best_evidence?.id).toBe("passed-verification");
   });
 
+  it("aggregates repeated failed approaches into failed lineages without mixing divergent approaches", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    for (let index = 0; index < 3; index += 1) {
+      await ledger.append({
+        id: `failed-threshold-${index + 1}`,
+        occurred_at: `2026-04-30T00:0${index}:00.000Z`,
+        kind: "failure",
+        scope: { goal_id: "goal-lineage", task_id: `task-threshold-${index + 1}` },
+        strategy: "threshold_sweep",
+        hypothesis: "Repeat threshold sweep improves balanced accuracy",
+        task: {
+          id: `task-threshold-${index + 1}`,
+          action: "threshold_sweep",
+          primary_dimension: "balanced_accuracy",
+        },
+        verification: {
+          verdict: "fail",
+          summary: [
+            "Balanced accuracy stayed inside noise.",
+            "No significant balanced accuracy gain.",
+            "Metric stayed flat after the sweep.",
+          ][index],
+        },
+        summary: "Threshold sweep failed.",
+        outcome: "failed",
+      });
+    }
+    await ledger.append({
+      id: "failed-ablation",
+      occurred_at: "2026-04-30T00:10:00.000Z",
+      kind: "failure",
+      scope: { goal_id: "goal-lineage", task_id: "task-ablation" },
+      strategy: "feature_ablation",
+      hypothesis: "Ablate leakage-prone feature group",
+      task: {
+        id: "task-ablation",
+        action: "feature_ablation",
+        primary_dimension: "balanced_accuracy",
+      },
+      verification: { verdict: "fail", summary: "Ablation reduced balanced accuracy." },
+      summary: "Ablation failed differently.",
+      outcome: "failed",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-lineage");
+
+    expect(summary.failed_lineages).toHaveLength(2);
+    expect(summary.failed_lineages[0]).toMatchObject({
+      count: 3,
+      strategy_family: "threshold_sweep",
+      primary_dimension: "balanced_accuracy",
+      representative_entry_id: "failed-threshold-3",
+    });
+    expect(summary.failed_lineages[0]?.evidence_entry_ids).toEqual([
+      "failed-threshold-1",
+      "failed-threshold-2",
+      "failed-threshold-3",
+    ]);
+    expect(summary.failed_lineages[1]).toMatchObject({
+      count: 1,
+      strategy_family: "feature_ablation",
+    });
+  });
+
   it("stores local and external evaluator observations with candidate provenance", async () => {
     const ledger = new RuntimeEvidenceLedger(runtimeRoot);
     await ledger.append({

--- a/src/runtime/dream-sidecar-review.ts
+++ b/src/runtime/dream-sidecar-review.ts
@@ -12,6 +12,7 @@ import type {
   RuntimeEvidenceEntry,
   RuntimeEvidenceDreamCheckpointRejectedApproach,
   RuntimeEvidenceDreamCheckpointStrategyCandidate,
+  RuntimeFailedLineageContext,
   RuntimeEvidenceSummary,
 } from "./store/evidence-ledger.js";
 import { BackgroundRunLedger } from "./store/background-run-store.js";
@@ -320,6 +321,9 @@ function buildKnownGaps(summary: RuntimeEvidenceSummary): string[] {
   for (const rejected of collectRejectedApproaches(summary).slice(0, 3)) {
     gaps.add(`Rejected approach: ${rejected.approach} (${rejected.rejection_reason})`);
   }
+  for (const lineage of summary.failed_lineages.filter((item) => item.count >= 2).slice(0, 3)) {
+    gaps.add(`Repeated failed lineage: ${lineageLabel(lineage)} (count=${lineage.count})`);
+  }
   if (!summary.best_evidence) gaps.add("No best evidence has been recorded for this run.");
   if (summary.metric_trends.length === 0) gaps.add("No progress metric history has been recorded for this run.");
   return [...gaps].slice(0, 6);
@@ -340,9 +344,11 @@ function buildStrategyFamilies(summary: RuntimeEvidenceSummary): string[] {
 function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamSidecarReview["suggested_next_moves"] {
   const moves: RuntimeDreamSidecarReview["suggested_next_moves"] = [];
   const rejectedApproaches = collectRejectedApproaches(summary);
+  const failedLineages = summary.failed_lineages.filter((lineage) => lineage.count >= 2);
   for (const checkpoint of summary.dream_checkpoints.slice(0, 2)) {
     for (const candidate of checkpoint.next_strategy_candidates) {
       if (isRejectedDreamCandidate(candidate, rejectedApproaches)) continue;
+      if (!candidate.retry_reason && isFailedLineageMove(candidate.title, candidate.rationale, failedLineages)) continue;
       moves.push({
         title: candidate.title,
         rationale: candidate.rationale,
@@ -360,6 +366,7 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
   for (const memo of summary.research_memos.slice(0, 2)) {
     for (const finding of memo.findings.slice(0, 2)) {
       if (isRejectedMove(finding.proposed_experiment, finding.applicability, rejectedApproaches)) continue;
+      if (isFailedLineageMove(finding.proposed_experiment, finding.applicability, failedLineages)) continue;
       moves.push({
         title: finding.proposed_experiment,
         rationale: finding.applicability,
@@ -382,6 +389,34 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
     });
   }
   return moves.slice(0, 6);
+}
+
+function isFailedLineageMove(
+  title: string,
+  rationale: string,
+  failedLineages: RuntimeFailedLineageContext[]
+): boolean {
+  if (failedLineages.length === 0) return false;
+  const moveText = normalizeRejectedMoveText(`${title} ${rationale}`);
+  if (!moveText) return false;
+  return failedLineages.some((lineage) => {
+    const lineageTexts = [
+      lineage.strategy_family,
+      lineage.hypothesis,
+      lineage.task_action,
+    ].map((value) => normalizeRejectedMoveText(value ?? "")).filter(Boolean);
+    return lineageTexts.some((lineageText) =>
+      moveText.includes(lineageText) || lineageText.includes(moveText)
+    );
+  });
+}
+
+function lineageLabel(lineage: RuntimeFailedLineageContext): string {
+  return lineage.strategy_family
+    ?? lineage.task_action
+    ?? lineage.hypothesis
+    ?? lineage.primary_dimension
+    ?? lineage.fingerprint;
 }
 
 function collectRejectedApproaches(summary: RuntimeEvidenceSummary): RuntimeEvidenceDreamCheckpointRejectedApproach[] {

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -205,6 +205,12 @@ export const RuntimeEvidenceDreamCheckpointStrategyCandidateSchema = z.object({
   rationale: z.string().min(1),
   target_dimensions: z.array(z.string().min(1)).default([]),
   expected_evidence_gain: z.string().min(1).optional(),
+  retry_reason: z.string().min(1).optional(),
+  failed_lineage_warning: z.object({
+    fingerprint: z.string().min(1),
+    count: z.number().int().positive(),
+    reason: z.string().min(1),
+  }).strict().optional(),
 }).strict();
 export type RuntimeEvidenceDreamCheckpointStrategyCandidate = z.infer<typeof RuntimeEvidenceDreamCheckpointStrategyCandidateSchema>;
 
@@ -372,6 +378,21 @@ export interface RuntimeEvidenceReadResult {
   warnings: RuntimeEvidenceReadWarning[];
 }
 
+export interface RuntimeFailedLineageContext {
+  fingerprint: string;
+  count: number;
+  first_seen_at: string;
+  last_seen_at: string;
+  strategy_family?: string;
+  hypothesis?: string;
+  primary_dimension?: string;
+  task_action?: string;
+  failure_reason?: string;
+  representative_entry_id: string;
+  representative_summary: string;
+  evidence_entry_ids: string[];
+}
+
 export interface RuntimeEvidenceSummary {
   schema_version: "runtime-evidence-summary-v1";
   generated_at: string;
@@ -388,6 +409,7 @@ export interface RuntimeEvidenceSummary {
   dream_checkpoints: RuntimeDreamCheckpointContext[];
   divergent_exploration: RuntimeEvidenceDivergentHypothesis[];
   recent_failed_attempts: RuntimeEvidenceEntry[];
+  failed_lineages: RuntimeFailedLineageContext[];
   recent_entries: RuntimeEvidenceEntry[];
   warnings: RuntimeEvidenceReadWarning[];
 }
@@ -539,9 +561,91 @@ function summarizeEvidence(
         || entry.verification?.verdict === "fail"
       )
       .slice(0, 5),
+    failed_lineages: summarizeFailedLineages(entries),
     recent_entries: newestFirst.slice(0, 10),
     warnings: read.warnings,
   };
+}
+
+function summarizeFailedLineages(entriesOldestFirst: RuntimeEvidenceEntry[]): RuntimeFailedLineageContext[] {
+  const lineages = new Map<string, RuntimeFailedLineageContext>();
+  for (const entry of entriesOldestFirst) {
+    if (!isFailedEvidenceEntry(entry)) continue;
+    const fingerprintInput = failedLineageFingerprintInput(entry);
+    const normalizedIdentityParts = [
+      normalizeLineageText(fingerprintInput.strategy_family),
+      normalizeLineageText(fingerprintInput.hypothesis),
+      normalizeLineageText(fingerprintInput.primary_dimension),
+      normalizeLineageText(fingerprintInput.task_action),
+    ].filter(Boolean);
+    const normalizedFallbackParts = [normalizeLineageText(fingerprintInput.failure_reason)].filter(Boolean);
+    const fingerprintParts = normalizedIdentityParts.length > 0 ? normalizedIdentityParts : normalizedFallbackParts;
+    if (fingerprintParts.length === 0) continue;
+    const fingerprint = fingerprintParts.join("|");
+    const summary = entry.summary
+      ?? entry.result?.summary
+      ?? entry.verification?.summary
+      ?? entry.result?.error
+      ?? `${entry.kind} failed`;
+    const existing = lineages.get(fingerprint);
+    if (!existing) {
+      lineages.set(fingerprint, {
+        fingerprint,
+        count: 1,
+        first_seen_at: entry.occurred_at,
+        last_seen_at: entry.occurred_at,
+        ...(fingerprintInput.strategy_family ? { strategy_family: fingerprintInput.strategy_family } : {}),
+        ...(fingerprintInput.hypothesis ? { hypothesis: fingerprintInput.hypothesis } : {}),
+        ...(fingerprintInput.primary_dimension ? { primary_dimension: fingerprintInput.primary_dimension } : {}),
+        ...(fingerprintInput.task_action ? { task_action: fingerprintInput.task_action } : {}),
+        ...(fingerprintInput.failure_reason ? { failure_reason: fingerprintInput.failure_reason } : {}),
+        representative_entry_id: entry.id,
+        representative_summary: summary,
+        evidence_entry_ids: [entry.id],
+      });
+      continue;
+    }
+    existing.count += 1;
+    existing.last_seen_at = entry.occurred_at;
+    existing.representative_entry_id = entry.id;
+    existing.representative_summary = summary;
+    existing.evidence_entry_ids = [...existing.evidence_entry_ids, entry.id].slice(-5);
+  }
+
+  return [...lineages.values()]
+    .sort((a, b) => b.count - a.count || b.last_seen_at.localeCompare(a.last_seen_at))
+    .slice(0, 10);
+}
+
+function isFailedEvidenceEntry(entry: RuntimeEvidenceEntry): boolean {
+  return entry.outcome === "failed"
+    || entry.outcome === "regressed"
+    || entry.kind === "failure"
+    || entry.result?.status === "failed"
+    || entry.verification?.verdict === "fail";
+}
+
+function failedLineageFingerprintInput(entry: RuntimeEvidenceEntry): {
+  strategy_family?: string;
+  hypothesis?: string;
+  primary_dimension?: string;
+  task_action?: string;
+  failure_reason?: string;
+} {
+  const strategyFamily = entry.strategy ?? entry.task?.action;
+  return {
+    ...(strategyFamily ? { strategy_family: strategyFamily } : {}),
+    ...(entry.hypothesis ? { hypothesis: entry.hypothesis } : {}),
+    ...(entry.task?.primary_dimension ? { primary_dimension: entry.task.primary_dimension } : {}),
+    ...(entry.task?.action ? { task_action: entry.task.action } : {}),
+    ...(entry.result?.error || entry.result?.summary || entry.verification?.summary
+      ? { failure_reason: entry.result?.error ?? entry.result?.summary ?? entry.verification?.summary }
+      : {}),
+  };
+}
+
+function normalizeLineageText(value: string | undefined): string {
+  return value?.normalize("NFKC").toLocaleLowerCase().replace(/[^\p{Letter}\p{Number}]+/gu, " ").trim() ?? "";
 }
 
 function chooseBestEvidence(entriesNewestFirst: RuntimeEvidenceEntry[]): RuntimeEvidenceEntry | null {


### PR DESCRIPTION
Closes #832

## Summary
- Add all-history failed-lineage aggregation to runtime evidence summaries.
- Carry repeated failed lineages into Dream checkpoint requests and downrank repeated candidates with `failed_lineage_warning` unless `retry_reason` is supplied.
- Surface repeated failed lineages in Dream sidecar known gaps and avoid repeating failed moves without retry evidence.

## Verification
- `npm run test:integration -- src/runtime/__tests__/runtime-evidence-ledger.test.ts src/runtime/__tests__/dream-sidecar-review.test.ts`
- `npm run test:unit -- src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings)
- `git diff --check`

## Known unresolved risks
- `npm run test:changed` still hits an unrelated related integration timeout in `src/interface/cli/__tests__/cli-runner-integration.test.ts > runs CoreLoop to completion with max_iterations=1 using MockLLM` at 60000ms. Focused issue tests and required static checks pass.
