### PR TITLE
feat(runtime): rank Dream memories

### DIFF
--- a/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
+++ b/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
@@ -209,6 +209,77 @@ describe("Dream review checkpoint trigger planning", () => {
     expect(parsed.success).toBe(false);
   });
 
+  it("ranks Dream memories by relevance, reliability, route priority, and prior success", () => {
+    const goal = makeGoal({ title: "Improve benchmark score" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 1,
+      result: makeEmptyIterationResult("goal-1", 1, { stallDetected: true }),
+      driveScores: [],
+    });
+    expect(request).not.toBeNull();
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "Rank memories before guidance.",
+      trigger: "plateau",
+      current_goal: "Improve benchmark score",
+      active_dimensions: ["balanced_accuracy"],
+      relevant_memories: [
+        {
+          source_type: "runtime_evidence",
+          ref: "checkpoint://recent-low",
+          summary: "Recent but weak checkpoint memory.",
+          relevance_score: 0.25,
+          source_reliability: 0.4,
+          recency_score: 1,
+          retrieval: { kind: "checkpoint", confidence: 0.4 },
+          authority: "advisory_only",
+        },
+        {
+          source_type: "soil",
+          ref: "soil://old-high",
+          summary: "Older high-confidence route memory with prior success.",
+          relevance_score: 0.92,
+          source_reliability: 0.95,
+          recency_score: 0.15,
+          prior_success_contribution: 0.9,
+          retrieval: { kind: "route_hit", score: 0.92, confidence: 0.95 },
+          authority: "advisory_only",
+        },
+        {
+          source_type: "soil",
+          ref: "soil://fallback-mid",
+          summary: "Fallback memory with moderate score.",
+          relevance_score: 0.72,
+          source_reliability: 0.7,
+          recency_score: 0.7,
+          retrieval: { kind: "fallback_hit", score: 0.72, confidence: 0.7 },
+          authority: "advisory_only",
+        },
+      ],
+      guidance: "Use high-confidence advisory memory.",
+      uncertainty: [],
+      context_authority: "advisory_only",
+      confidence: 0.8,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+
+    expect(normalized.relevant_memories.map((memory) => memory.ref)).toEqual([
+      "soil://old-high",
+      "soil://fallback-mid",
+      "checkpoint://recent-low",
+    ]);
+    expect(normalized.relevant_memories[0]).toMatchObject({
+      authority: "advisory_only",
+      ranking_trace: {
+        decision: "admitted",
+        reason: expect.stringContaining("kind=route_hit"),
+      },
+    });
+    expect(normalized.context_authority).toBe("advisory_only");
+  });
+
   it("carries active hypotheses and rejected approaches into the next checkpoint request", () => {
     const request = buildDreamReviewCheckpointRequest({
       goal: makeGoal(),

--- a/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
+++ b/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
@@ -8,6 +8,7 @@ import type {
   DreamReviewActiveHypothesis,
   DreamReviewCheckpointEvidence,
   DreamReviewFailedLineage,
+  DreamReviewMemoryRef,
   DreamReviewCheckpointTrigger,
   DreamReviewRejectedApproach,
   DreamRunControlPolicyDecision,
@@ -95,10 +96,7 @@ export function normalizeDreamReviewCheckpoint(
     trigger: output.trigger ?? request.trigger,
     current_goal: output.current_goal || goal.title,
     active_dimensions: output.active_dimensions.length > 0 ? output.active_dimensions : request.activeDimensions,
-    relevant_memories: output.relevant_memories.map((memory) => ({
-      ...memory,
-      authority: "advisory_only",
-    })),
+    relevant_memories: rankDreamReviewMemories(output.relevant_memories, request.maxGuidanceItems),
     active_hypotheses: output.active_hypotheses,
     rejected_approaches: output.rejected_approaches,
     next_strategy_candidates: downrankRepeatedFailedLineageCandidates(
@@ -149,6 +147,62 @@ function normalizeRunControlRecommendations(
     id: recommendation.id ?? `${request.trigger}-run-control-${index + 1}`,
     policy_decision: decideRunControlPolicy(recommendation, request),
   }));
+}
+
+function rankDreamReviewMemories(
+  memories: DreamReviewMemoryRef[],
+  admitLimit: number
+): DreamReviewMemoryRef[] {
+  return memories
+    .map((memory) => ({
+      ...memory,
+      authority: "advisory_only" as const,
+      ranking_trace: {
+        score: memoryRankScore(memory),
+        decision: "admitted" as const,
+        reason: memoryRankReason(memory),
+      },
+    }))
+    .sort((a, b) =>
+      (b.ranking_trace?.score ?? 0) - (a.ranking_trace?.score ?? 0)
+    )
+    .map((memory, index) => ({
+      ...memory,
+      ranking_trace: {
+        score: memory.ranking_trace?.score ?? 0,
+        decision: index < admitLimit ? "admitted" : "rejected",
+        reason: index < admitLimit
+          ? memory.ranking_trace?.reason ?? "Ranked into Dream memory context."
+          : `Rejected by memory admission cap ${admitLimit}.`,
+      },
+    }));
+}
+
+function memoryRankScore(memory: DreamReviewMemoryRef): number {
+  const retrievalKind = memory.retrieval?.kind ?? (memory.source_type === "soil" ? "route_hit" : "checkpoint");
+  const routeScore =
+    retrievalKind === "route_hit" ? 0.2
+      : retrievalKind === "fallback_hit" ? 0.08
+        : retrievalKind === "checkpoint" ? 0.05
+          : 0;
+  const score =
+    (memory.relevance_score ?? memory.retrieval?.score ?? 0.5) * 0.35
+    + (memory.source_reliability ?? memory.retrieval?.confidence ?? 0.5) * 0.25
+    + (memory.prior_success_contribution ?? 0) * 0.2
+    + (memory.recency_score ?? 0.5) * 0.1
+    + routeScore;
+  return Math.max(0, Math.min(1, Number(score.toFixed(4))));
+}
+
+function memoryRankReason(memory: DreamReviewMemoryRef): string {
+  const retrievalKind = memory.retrieval?.kind ?? (memory.source_type === "soil" ? "route_hit" : "checkpoint");
+  return [
+    `kind=${retrievalKind}`,
+    `relevance=${memory.relevance_score ?? memory.retrieval?.score ?? "default"}`,
+    `reliability=${memory.source_reliability ?? memory.retrieval?.confidence ?? "default"}`,
+    `success=${memory.prior_success_contribution ?? 0}`,
+    `recency=${memory.recency_score ?? "default"}`,
+  ].join("; ");
 }
 
 function decideRunControlPolicy(

--- a/src/orchestrator/loop/core-loop/phase-specs.ts
+++ b/src/orchestrator/loop/core-loop/phase-specs.ts
@@ -121,6 +121,20 @@ export const DreamReviewMemoryRefSchema = z.object({
   ref: z.string().min(1).optional(),
   summary: z.string().min(1),
   authority: z.literal("advisory_only").default("advisory_only"),
+  relevance_score: z.number().min(0).max(1).optional(),
+  source_reliability: z.number().min(0).max(1).optional(),
+  recency_score: z.number().min(0).max(1).optional(),
+  prior_success_contribution: z.number().min(0).max(1).optional(),
+  retrieval: z.object({
+    kind: z.enum(["route_hit", "fallback_hit", "checkpoint", "manual", "unknown"]).default("unknown"),
+    score: z.number().min(0).max(1).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+  }).strict().optional(),
+  ranking_trace: z.object({
+    score: z.number().min(0).max(1),
+    decision: z.enum(["admitted", "rejected"]),
+    reason: z.string().min(1),
+  }).strict().optional(),
 }).strict();
 export type DreamReviewMemoryRef = z.infer<typeof DreamReviewMemoryRefSchema>;
 

--- a/src/runtime/__tests__/dream-sidecar-review.test.ts
+++ b/src/runtime/__tests__/dream-sidecar-review.test.ts
@@ -174,6 +174,120 @@ describe("Runtime Dream sidecar review", () => {
     }));
   });
 
+  it("ranks advisory memories across checkpoints and exposes ranking traces", async () => {
+    await seedActiveRun("run:coreloop:memory-rank");
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      id: "old-high-memory",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "dream_checkpoint",
+      scope: { run_id: "run:coreloop:memory-rank", loop_index: 1, phase: "dream_review_checkpoint" },
+      dream_checkpoints: [{
+        trigger: "plateau",
+        summary: "Older checkpoint with strong Soil memory.",
+        current_goal: "Improve benchmark",
+        active_dimensions: ["balanced_accuracy"],
+        recent_strategy_families: [],
+        exhausted: [],
+        promising: [],
+        relevant_memories: [{
+          source_type: "soil",
+          ref: "soil://old-high",
+          summary: "Older high-confidence route memory with prior success.",
+          relevance_score: 0.92,
+          source_reliability: 0.95,
+          recency_score: 0.1,
+          prior_success_contribution: 0.9,
+          retrieval: { kind: "route_hit", score: 0.92, confidence: 0.95 },
+          ranking_trace: {
+            score: 0.9,
+            decision: "rejected",
+            reason: "Rejected by checkpoint memory admission cap 1.",
+          },
+          authority: "advisory_only",
+        }],
+        active_hypotheses: [],
+        rejected_approaches: [],
+        next_strategy_candidates: [{
+          title: "Use old high memory",
+          rationale: "Follow the high-confidence Soil route memory.",
+          target_dimensions: ["balanced_accuracy"],
+        }],
+        guidance: "Preserve useful memory.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.8,
+      }],
+      summary: "Old memory checkpoint saved.",
+    });
+    await ledger.append({
+      id: "recent-low-memory",
+      occurred_at: "2026-04-30T00:10:00.000Z",
+      kind: "dream_checkpoint",
+      scope: { run_id: "run:coreloop:memory-rank", loop_index: 2, phase: "dream_review_checkpoint" },
+      dream_checkpoints: [{
+        trigger: "iteration",
+        summary: "Recent checkpoint with weak memory.",
+        current_goal: "Improve benchmark",
+        active_dimensions: ["balanced_accuracy"],
+        recent_strategy_families: [],
+        exhausted: [],
+        promising: [],
+        relevant_memories: [{
+          source_type: "runtime_evidence",
+          ref: "checkpoint://recent-low",
+          summary: "Recent but weak checkpoint memory.",
+          relevance_score: 0.25,
+          source_reliability: 0.4,
+          recency_score: 1,
+          retrieval: { kind: "checkpoint", confidence: 0.4 },
+          authority: "advisory_only",
+        }],
+        active_hypotheses: [],
+        rejected_approaches: [],
+        next_strategy_candidates: [{
+          title: "Use recent low memory",
+          rationale: "Follow the recent checkpoint memory.",
+          target_dimensions: ["balanced_accuracy"],
+        }],
+        guidance: "Preserve recency.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.8,
+      }],
+      summary: "Recent memory checkpoint saved.",
+    });
+
+    const review = await createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:coreloop:memory-rank",
+    });
+
+    expect(review.advisory_memories.map((memory) => memory.ref).slice(0, 2)).toEqual([
+      "soil://old-high",
+      "checkpoint://recent-low",
+    ]);
+    expect(review.advisory_memories[0]).toMatchObject({
+      authority: "advisory_only",
+      ranking_trace: {
+        decision: "admitted",
+        reason: expect.stringContaining("checkpoint_decision=rejected"),
+      },
+    });
+    expect(review.suggested_next_moves[0]).toMatchObject({
+      title: "Use old high memory",
+      source: "dream_checkpoint",
+    });
+    expect(review.advisory_memories[0]?.ranking_trace?.reason).not.toContain("Rejected by checkpoint memory admission cap 1.");
+    expect(review.advisory_memories[0]).toMatchObject({
+      authority: "advisory_only",
+      ranking_trace: {
+        decision: "admitted",
+        reason: expect.stringContaining("kind=route_hit"),
+      },
+    });
+  });
+
   it("summarizes repeated failed lineages and avoids suggesting them without retry evidence", async () => {
     await seedActiveRun("run:coreloop:failed-lineage");
     const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));

--- a/src/runtime/dream-sidecar-review.ts
+++ b/src/runtime/dream-sidecar-review.ts
@@ -89,6 +89,11 @@ export interface RuntimeDreamSidecarReview {
     ref?: string;
     summary: string;
     authority: "advisory_only";
+    ranking_trace?: {
+      score: number;
+      decision: "admitted" | "rejected";
+      reason: string;
+    };
   }>;
   suggested_next_moves: Array<{
     title: string;
@@ -345,7 +350,7 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
   const moves: RuntimeDreamSidecarReview["suggested_next_moves"] = [];
   const rejectedApproaches = collectRejectedApproaches(summary);
   const failedLineages = summary.failed_lineages.filter((lineage) => lineage.count >= 2);
-  for (const checkpoint of summary.dream_checkpoints.slice(0, 2)) {
+  for (const checkpoint of rankCheckpointsByMemory(summary).slice(0, 2)) {
     for (const candidate of checkpoint.next_strategy_candidates) {
       if (isRejectedDreamCandidate(candidate, rejectedApproaches)) continue;
       if (!candidate.retry_reason && isFailedLineageMove(candidate.title, candidate.rationale, failedLineages)) continue;
@@ -389,6 +394,19 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
     });
   }
   return moves.slice(0, 6);
+}
+
+function rankCheckpointsByMemory(summary: RuntimeEvidenceSummary): RuntimeEvidenceSummary["dream_checkpoints"] {
+  return [...summary.dream_checkpoints].sort((a, b) =>
+    checkpointMemoryScore(b) - checkpointMemoryScore(a)
+    || b.occurred_at.localeCompare(a.occurred_at)
+  );
+}
+
+function checkpointMemoryScore(checkpoint: RuntimeEvidenceSummary["dream_checkpoints"][number]): number {
+  return Math.max(0, ...checkpoint.relevant_memories.map((memory) =>
+    memory.ranking_trace?.score ?? sidecarMemoryRankScore(memory)
+  ));
 }
 
 function isFailedLineageMove(
@@ -541,9 +559,57 @@ function buildAdvisoryMemories(summary: RuntimeEvidenceSummary): RuntimeDreamSid
       ...(memory.ref ? { ref: memory.ref } : {}),
       summary: memory.summary,
       authority: "advisory_only" as const,
+      ranking_trace: {
+        score: memory.ranking_trace?.score ?? sidecarMemoryRankScore(memory),
+        decision: "admitted" as const,
+        reason: sidecarMemoryRankReason(memory, memory.ranking_trace?.decision),
+      },
     }))
   );
-  return memories.slice(0, 8);
+  return memories
+    .sort((a, b) => (b.ranking_trace?.score ?? 0) - (a.ranking_trace?.score ?? 0))
+    .map((memory, index) => ({
+      ...memory,
+      ranking_trace: {
+        score: memory.ranking_trace?.score ?? 0,
+        decision: index < 8 ? "admitted" : "rejected",
+        reason: index < 8 ? memory.ranking_trace?.reason ?? "Ranked into sidecar memory context." : "Rejected by sidecar memory cap 8.",
+      },
+    }));
+}
+
+function sidecarMemoryRankScore(
+  memory: RuntimeEvidenceSummary["dream_checkpoints"][number]["relevant_memories"][number]
+): number {
+  const retrievalKind = memory.retrieval?.kind ?? (memory.source_type === "soil" ? "route_hit" : "checkpoint");
+  const routeScore =
+    retrievalKind === "route_hit" ? 0.2
+      : retrievalKind === "fallback_hit" ? 0.08
+        : retrievalKind === "checkpoint" ? 0.05
+          : 0;
+  const score =
+    (memory.relevance_score ?? memory.retrieval?.score ?? 0.5) * 0.35
+    + (memory.source_reliability ?? memory.retrieval?.confidence ?? 0.5) * 0.25
+    + (memory.prior_success_contribution ?? 0) * 0.2
+    + (memory.recency_score ?? 0.5) * 0.1
+    + routeScore;
+  return Math.max(0, Math.min(1, Number(score.toFixed(4))));
+}
+
+function sidecarMemoryRankReason(
+  memory: RuntimeEvidenceSummary["dream_checkpoints"][number]["relevant_memories"][number],
+  checkpointDecision?: "admitted" | "rejected"
+): string {
+  const retrievalKind = memory.retrieval?.kind ?? (memory.source_type === "soil" ? "route_hit" : "checkpoint");
+  return [
+    `sidecar_rank=advisory`,
+    ...(checkpointDecision ? [`checkpoint_decision=${checkpointDecision}`] : []),
+    `kind=${retrievalKind}`,
+    `relevance=${memory.relevance_score ?? memory.retrieval?.score ?? "default"}`,
+    `reliability=${memory.source_reliability ?? memory.retrieval?.confidence ?? "default"}`,
+    `success=${memory.prior_success_contribution ?? 0}`,
+    `recency=${memory.recency_score ?? "default"}`,
+  ].join("; ");
 }
 
 function buildWarnings(

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -197,6 +197,20 @@ export const RuntimeEvidenceDreamCheckpointMemoryRefSchema = z.object({
   ref: z.string().min(1).optional(),
   summary: z.string().min(1),
   authority: z.literal("advisory_only").default("advisory_only"),
+  relevance_score: z.number().min(0).max(1).optional(),
+  source_reliability: z.number().min(0).max(1).optional(),
+  recency_score: z.number().min(0).max(1).optional(),
+  prior_success_contribution: z.number().min(0).max(1).optional(),
+  retrieval: z.object({
+    kind: z.enum(["route_hit", "fallback_hit", "checkpoint", "manual", "unknown"]).default("unknown"),
+    score: z.number().min(0).max(1).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+  }).strict().optional(),
+  ranking_trace: z.object({
+    score: z.number().min(0).max(1),
+    decision: z.enum(["admitted", "rejected"]),
+    reason: z.string().min(1),
+  }).strict().optional(),
 }).strict();
 export type RuntimeEvidenceDreamCheckpointMemoryRef = z.infer<typeof RuntimeEvidenceDreamCheckpointMemoryRefSchema>;
 


### PR DESCRIPTION
Closes #831

## Summary
- Add advisory memory ranking inputs and trace fields to Dream checkpoint memory refs.
- Rank Dream checkpoint memories by relevance, reliability/confidence, route/fallback source signal, recency, and prior success contribution.
- Rank sidecar advisory memories across checkpoints and let stronger ranked memory context influence sidecar next-move ordering while keeping `advisory_only` authority.

## Verification
- `npm run test:unit -- src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts`
- `npm run test:integration -- src/runtime/__tests__/dream-sidecar-review.test.ts src/runtime/__tests__/runtime-evidence-ledger.test.ts`
- `npm run test:integration -- src/runtime/__tests__/dream-sidecar-review.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings)
- `git diff --check`

## Known unresolved risks
- `npm run test:changed` still hits an unrelated related integration timeout in `src/interface/cli/__tests__/cli-runner-integration.test.ts > runs CoreLoop to completion with max_iterations=1 using MockLLM` at 60000ms. Focused issue tests and required static checks pass.
