### PR TITLE
feat(runtime): distinguish raw and robust candidate best

### DIFF
--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -183,12 +183,14 @@ describe("RuntimeEvidenceLedger", () => {
     };
     delete staleIndex.summary.candidate_lineages;
     delete staleIndex.summary.recommended_candidate_portfolio;
+    delete staleIndex.summary.candidate_selection_summary;
     await fsp.writeFile(indexPath, `${JSON.stringify(staleIndex)}\n`, "utf8");
 
     const summary = await new RuntimeEvidenceLedger(runtimeRoot).summarizeRun("run:candidate-index");
 
     expect(summary.candidate_lineages).toHaveLength(1);
     expect(summary.recommended_candidate_portfolio[0]?.candidate_id).toBe("candidate-index-a");
+    expect(summary.candidate_selection_summary.raw_best?.candidate_id).toBe("candidate-index-a");
   });
 
   it("preserves full canonical history when append maintains an existing index", async () => {
@@ -703,6 +705,238 @@ describe("RuntimeEvidenceLedger", () => {
         label: "balanced_accuracy",
         value: 0.97,
       },
+    });
+  });
+
+  it("separates raw best from robust best and recommends safe aggressive diverse slots", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "robust-selection-snapshot",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-robust-selection" },
+      candidates: [
+        {
+          candidate_id: "manual-mvs-raw-best",
+          label: "Manual MVS raw best",
+          lineage: {
+            strategy_family: "catboost_manual_mvs",
+            feature_lineage: ["focus-base"],
+            model_lineage: ["catboost"],
+            config_lineage: ["manual-class-weight", "mvs"],
+            seed_lineage: ["seed-42"],
+            fold_lineage: ["5-fold-oof"],
+            postprocess_lineage: ["manual-threshold"],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.97084, direction: "maximize", confidence: 0.78 }],
+          artifacts: [{ label: "raw-best-metrics", state_relative_path: "runs/manual-mvs/metrics.json", kind: "metrics" }],
+          similarity: [],
+          robustness: {
+            stability_score: 0.42,
+            diversity_score: 0.25,
+            risk_penalty: 0.28,
+            evidence_confidence: 0.72,
+            repeated_evaluations: 1,
+            mean_score: 0.9688,
+            max_score: 0.97084,
+            score_stddev: 0.0018,
+            fold_score_range: 0.012,
+            seed_score_range: 0.009,
+            weak_dimensions: ["High recall"],
+            provenance_refs: ["runs/manual-mvs/metrics.json"],
+            summary: "Highest local score but unstable and post-processing dependent.",
+          },
+          disposition: "promoted",
+          disposition_reason: "Raw best local metric, kept as aggressive candidate.",
+        },
+        {
+          candidate_id: "default-rs314-robust",
+          label: "Default rs314 robust",
+          lineage: {
+            strategy_family: "catboost_default",
+            feature_lineage: ["focus-base"],
+            model_lineage: ["catboost"],
+            config_lineage: ["default-class-weight"],
+            seed_lineage: ["seed-314"],
+            fold_lineage: ["5-fold-oof"],
+            postprocess_lineage: ["none"],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.97041, direction: "maximize", confidence: 0.9 }],
+          artifacts: [{ label: "robust-metrics", state_relative_path: "runs/default-rs314/metrics.json", kind: "metrics" }],
+          similarity: [{ candidate_id: "manual-mvs-raw-best", similarity: 0.62, signal: "declared" }],
+          robustness: {
+            stability_score: 0.94,
+            diversity_score: 0.58,
+            risk_penalty: 0.02,
+            evidence_confidence: 0.92,
+            repeated_evaluations: 4,
+            mean_score: 0.97012,
+            max_score: 0.97041,
+            score_stddev: 0.0002,
+            fold_score_range: 0.003,
+            seed_score_range: 0.002,
+            weak_dimensions: [],
+            provenance_refs: ["runs/default-rs314/metrics.json", "runs/default-rs314/folds.json"],
+            summary: "Slightly lower local score but stable across folds and seeds.",
+          },
+          disposition: "retained",
+          disposition_reason: "Stable lower-score candidate selected as robust best.",
+        },
+        {
+          candidate_id: "renamed-catboost-duplicate",
+          label: "Renamed CatBoost duplicate",
+          lineage: {
+            strategy_family: "catboost_default_copy",
+            feature_lineage: ["focus-base"],
+            model_lineage: ["catboost"],
+            config_lineage: ["default-class-weight"],
+            seed_lineage: ["seed-2718"],
+            fold_lineage: ["5-fold-oof"],
+            postprocess_lineage: ["none"],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.968, direction: "maximize", confidence: 0.85 }],
+          artifacts: [{ label: "duplicate-metrics", state_relative_path: "runs/renamed-catboost/metrics.json", kind: "metrics" }],
+          similarity: [{ candidate_id: "default-rs314-robust", similarity: 0.94, signal: "declared" }],
+          robustness: {
+            stability_score: 0.8,
+            risk_penalty: 0.02,
+            evidence_confidence: 0.85,
+            repeated_evaluations: 2,
+            mean_score: 0.9679,
+            max_score: 0.968,
+            score_stddev: 0.0003,
+            fold_score_range: 0.003,
+            seed_score_range: 0.003,
+            weak_dimensions: [],
+            provenance_refs: ["runs/renamed-catboost/metrics.json"],
+            summary: "Family label differs, but declared similarity shows this is not a diverse lineage.",
+          },
+          disposition: "retained",
+          disposition_reason: "Near-duplicate retained as backup, not as diverse portfolio representative.",
+        },
+        {
+          candidate_id: "linear-stack-diverse",
+          label: "Linear stack diverse",
+          lineage: {
+            strategy_family: "linear_stack",
+            feature_lineage: ["rank-features"],
+            model_lineage: ["ridge-stack"],
+            config_lineage: ["stack-v1"],
+            seed_lineage: ["seed-7"],
+            fold_lineage: ["5-fold-oof"],
+            postprocess_lineage: ["class-prior-calibration"],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.963, direction: "maximize", confidence: 0.86 }],
+          artifacts: [{ label: "diverse-metrics", state_relative_path: "runs/linear-stack/metrics.json", kind: "metrics" }],
+          similarity: [{ candidate_id: "default-rs314-robust", similarity: 0.31, signal: "declared" }],
+          robustness: {
+            stability_score: 0.81,
+            risk_penalty: 0.05,
+            evidence_confidence: 0.84,
+            repeated_evaluations: 3,
+            mean_score: 0.9628,
+            max_score: 0.963,
+            score_stddev: 0.0004,
+            fold_score_range: 0.004,
+            seed_score_range: 0.003,
+            weak_dimensions: [],
+            provenance_refs: ["runs/linear-stack/metrics.json"],
+            summary: "Different lineage retained for complementary final selection.",
+          },
+          disposition: "retained",
+          disposition_reason: "Diverse lineage with stable evidence.",
+        },
+      ],
+      summary: "Robust candidate selection snapshot.",
+      outcome: "improved",
+    });
+
+    const selection = (await ledger.summarizeGoal("goal-robust-selection")).candidate_selection_summary;
+
+    expect(selection.primary_metric).toEqual({ label: "balanced_accuracy", direction: "maximize" });
+    expect(selection.raw_best).toMatchObject({
+      candidate_id: "manual-mvs-raw-best",
+      raw_rank: 1,
+      raw_metric: { value: 0.97084 },
+    });
+    expect(selection.robust_best).toMatchObject({
+      candidate_id: "default-rs314-robust",
+      raw_rank: 2,
+      stability_score: 0.94,
+      risk_penalty: 0.02,
+    });
+    expect(selection.robust_best?.robust_score).toBeGreaterThan(selection.raw_best?.robust_score ?? 0);
+    expect(selection.final_portfolio.safe?.candidate_id).toBe("default-rs314-robust");
+    expect(selection.final_portfolio.aggressive?.candidate_id).toBe("manual-mvs-raw-best");
+    expect(selection.final_portfolio.diverse?.candidate_id).toBe("linear-stack-diverse");
+    expect(selection.ranked.map((candidate) => candidate.candidate_id)).toContain("manual-mvs-raw-best");
+  });
+
+  it("does not fill the diverse slot with a declared near-duplicate from another family", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "near-duplicate-only-selection",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-no-diverse-near-duplicate" },
+      candidates: [
+        {
+          candidate_id: "stable-best",
+          lineage: {
+            strategy_family: "catboost_default",
+            feature_lineage: ["base"],
+            model_lineage: ["catboost"],
+            config_lineage: [],
+            seed_lineage: ["seed-1"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.97, direction: "maximize", confidence: 0.9 }],
+          artifacts: [],
+          similarity: [{ candidate_id: "renamed-near-duplicate", similarity: 0.95, signal: "declared" }],
+          robustness: {
+            stability_score: 0.9,
+            risk_penalty: 0.01,
+            evidence_confidence: 0.9,
+            weak_dimensions: [],
+            provenance_refs: [],
+          },
+          disposition: "retained",
+        },
+        {
+          candidate_id: "renamed-near-duplicate",
+          lineage: {
+            strategy_family: "catboost_renamed",
+            feature_lineage: ["base"],
+            model_lineage: ["catboost"],
+            config_lineage: [],
+            seed_lineage: ["seed-2"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.969, direction: "maximize", confidence: 0.88 }],
+          artifacts: [],
+          similarity: [],
+          robustness: {
+            stability_score: 0.88,
+            diversity_score: 0.9,
+            risk_penalty: 0.01,
+            evidence_confidence: 0.88,
+            weak_dimensions: [],
+            provenance_refs: [],
+          },
+          disposition: "retained",
+        },
+      ],
+      summary: "Near duplicate should not fill diverse slot.",
+      outcome: "continued",
+    });
+
+    const selection = (await ledger.summarizeGoal("goal-no-diverse-near-duplicate")).candidate_selection_summary;
+
+    expect(selection.final_portfolio.diverse).toBeNull();
+    expect(selection.ranked.find((candidate) => candidate.candidate_id === "renamed-near-duplicate")).toMatchObject({
+      diversity_score: 0.05,
     });
   });
 

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -103,6 +103,22 @@ export const RuntimeEvidenceCandidateRecordSchema = z.object({
   metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
   artifacts: z.array(RuntimeEvidenceArtifactRefSchema).default([]),
   similarity: z.array(RuntimeEvidenceCandidateSimilaritySchema).default([]),
+  robustness: z.object({
+    stability_score: z.number().min(0).max(1).optional(),
+    diversity_score: z.number().min(0).max(1).optional(),
+    risk_penalty: z.number().min(0).max(1).optional(),
+    robust_score: z.number().min(0).max(1).optional(),
+    evidence_confidence: z.number().min(0).max(1).optional(),
+    repeated_evaluations: z.number().int().nonnegative().optional(),
+    mean_score: z.number().optional(),
+    max_score: z.number().optional(),
+    score_stddev: z.number().min(0).optional(),
+    fold_score_range: z.number().min(0).optional(),
+    seed_score_range: z.number().min(0).optional(),
+    weak_dimensions: z.array(z.string().min(1)).default([]),
+    provenance_refs: z.array(z.string().min(1)).default([]),
+    summary: z.string().min(1).optional(),
+  }).strict().optional(),
   disposition: RuntimeEvidenceCandidateDispositionSchema.default("retained"),
   disposition_reason: z.string().min(1).optional(),
   produced_at: z.string().datetime().optional(),
@@ -489,6 +505,39 @@ export interface RuntimeDiversifiedCandidatePortfolioOptions {
   nearDuplicateSimilarity?: number;
 }
 
+export interface RuntimeCandidateSelectionCandidate {
+  candidate_id: string;
+  label?: string;
+  strategy_family: string;
+  evidence_entry_id: string;
+  raw_rank: number;
+  raw_metric?: {
+    label: string;
+    value: number;
+    direction: "maximize" | "minimize";
+    confidence: number;
+  };
+  robust_score: number;
+  metric_score: number;
+  stability_score: number;
+  diversity_score: number;
+  risk_penalty: number;
+  evidence_confidence: number;
+  reasons: string[];
+}
+
+export interface RuntimeCandidateSelectionSummary {
+  primary_metric: ComparableMetricKey | null;
+  raw_best: RuntimeCandidateSelectionCandidate | null;
+  robust_best: RuntimeCandidateSelectionCandidate | null;
+  ranked: RuntimeCandidateSelectionCandidate[];
+  final_portfolio: {
+    safe: RuntimeCandidateSelectionCandidate | null;
+    aggressive: RuntimeCandidateSelectionCandidate | null;
+    diverse: RuntimeCandidateSelectionCandidate | null;
+  };
+}
+
 export interface RuntimeEvidenceSummary {
   schema_version: "runtime-evidence-summary-v1";
   generated_at: string;
@@ -506,6 +555,7 @@ export interface RuntimeEvidenceSummary {
   divergent_exploration: RuntimeEvidenceDivergentHypothesis[];
   candidate_lineages: RuntimeCandidateLineageContext[];
   recommended_candidate_portfolio: RuntimeCandidatePortfolioSlot[];
+  candidate_selection_summary: RuntimeCandidateSelectionSummary;
   recent_failed_attempts: RuntimeEvidenceEntry[];
   failed_lineages: RuntimeFailedLineageContext[];
   recent_entries: RuntimeEvidenceEntry[];
@@ -663,7 +713,9 @@ async function readSummaryIndex(
 
 function isCurrentEvidenceSummaryShape(summary: RuntimeEvidenceSummary): boolean {
   return Array.isArray(summary.candidate_lineages)
-    && Array.isArray(summary.recommended_candidate_portfolio);
+    && Array.isArray(summary.recommended_candidate_portfolio)
+    && typeof summary.candidate_selection_summary === "object"
+    && summary.candidate_selection_summary !== null;
 }
 
 async function writeSummaryIndex(
@@ -748,6 +800,7 @@ function summarizeEvidence(
       .reverse(),
     candidate_lineages: summarizeCandidateLineages(entries),
     recommended_candidate_portfolio: selectDiversifiedCandidatePortfolio(entries),
+    candidate_selection_summary: summarizeCandidateSelection(entries),
     recent_failed_attempts: newestFirst
       .filter((entry) =>
         entry.outcome === "failed"
@@ -817,6 +870,177 @@ export function selectDiversifiedCandidatePortfolio(
   }
 
   return selected.map(toPortfolioSlot);
+}
+
+function summarizeCandidateSelection(entriesOldestFirst: RuntimeEvidenceEntry[]): RuntimeCandidateSelectionSummary {
+  const primaryMetric = resolvePrimaryCandidateMetricKey(entriesOldestFirst);
+  const contexts = extractCandidateEvidenceContexts(entriesOldestFirst, primaryMetric)
+    .filter((context) => context.candidate.disposition !== "retired");
+  const rawRanked = [...contexts].sort(compareCandidateEvidenceContexts);
+  const scored = scoreCandidateSelectionContexts(rawRanked);
+  const ranked = [...scored].sort((a, b) => b.robust_score - a.robust_score || a.raw_rank - b.raw_rank);
+  const rawBest = scored.find((candidate) => candidate.raw_rank === 1) ?? null;
+  const robustBest = ranked[0] ?? null;
+
+  return {
+    primary_metric: primaryMetric,
+    raw_best: rawBest,
+    robust_best: robustBest,
+    ranked,
+    final_portfolio: {
+      safe: selectSafeCandidate(scored),
+      aggressive: rawBest,
+      diverse: selectDiverseCandidate(scored, robustBest),
+    },
+  };
+}
+
+function scoreCandidateSelectionContexts(
+  rawRanked: CandidateEvidenceContext[]
+): RuntimeCandidateSelectionCandidate[] {
+  const metricValues = rawRanked
+    .map((context) => context.metric?.value)
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value));
+  const minMetric = metricValues.length > 0 ? Math.min(...metricValues) : 0;
+  const maxMetric = metricValues.length > 0 ? Math.max(...metricValues) : 0;
+  const rawBestFamily = rawRanked[0]?.candidate.lineage.strategy_family;
+  const allCandidates = rawRanked.map((context) => context.candidate);
+
+  return rawRanked.map((context, index) => {
+    const candidate = context.candidate;
+    const metricScore = normalizedMetricScore(context.metric, minMetric, maxMetric);
+    const stabilityScore = clamp01(candidate.robustness?.stability_score ?? context.metric?.confidence ?? 0.5);
+    const inferredDiversity = inferredDiversityScore(candidate, rawBestFamily, allCandidates);
+    const diversityScore = clamp01(candidate.robustness?.diversity_score === undefined
+      ? inferredDiversity
+      : Math.min(candidate.robustness.diversity_score, inferredDiversity));
+    const riskPenalty = clamp01(candidate.robustness?.risk_penalty ?? inferredCandidateRiskPenalty(candidate));
+    const evidenceConfidence = clamp01(candidate.robustness?.evidence_confidence ?? context.metric?.confidence ?? 0.5);
+    const robustScore = clamp01(candidate.robustness?.robust_score
+      ?? (metricScore * 0.45 + stabilityScore * 0.3 + diversityScore * 0.15 + evidenceConfidence * 0.1 - riskPenalty));
+
+    return {
+      candidate_id: candidate.candidate_id,
+      ...(candidate.label ? { label: candidate.label } : {}),
+      strategy_family: candidate.lineage.strategy_family,
+      evidence_entry_id: context.entry_id,
+      raw_rank: index + 1,
+      ...(context.metric ? { raw_metric: context.metric } : {}),
+      robust_score: roundScore(robustScore),
+      metric_score: roundScore(metricScore),
+      stability_score: roundScore(stabilityScore),
+      diversity_score: roundScore(diversityScore),
+      risk_penalty: roundScore(riskPenalty),
+      evidence_confidence: roundScore(evidenceConfidence),
+      reasons: candidateSelectionReasons(candidate, {
+        metricScore,
+        stabilityScore,
+        diversityScore,
+        riskPenalty,
+        evidenceConfidence,
+      }),
+    };
+  });
+}
+
+function normalizedMetricScore(
+  metric: CandidateComparableMetric | null,
+  minMetric: number,
+  maxMetric: number
+): number {
+  if (!metric) return 0;
+  if (maxMetric === minMetric) return 0.5;
+  const distance = metric.direction === "maximize"
+    ? (metric.value - minMetric) / (maxMetric - minMetric)
+    : (maxMetric - metric.value) / (maxMetric - minMetric);
+  return clamp01(distance);
+}
+
+function inferredDiversityScore(
+  candidate: RuntimeEvidenceCandidateRecord,
+  rawBestFamily: string | undefined,
+  allCandidates: RuntimeEvidenceCandidateRecord[]
+): number {
+  if (!rawBestFamily) return 0.5;
+  const highestSimilarity = highestKnownSimilarity(candidate, allCandidates);
+  const lineageBase = candidate.lineage.strategy_family !== rawBestFamily ? 0.75 : 0.45;
+  if (highestSimilarity > 0) return clamp01(Math.min(lineageBase, 1 - highestSimilarity));
+  return lineageBase;
+}
+
+function highestKnownSimilarity(
+  candidate: RuntimeEvidenceCandidateRecord,
+  allCandidates: RuntimeEvidenceCandidateRecord[]
+): number {
+  let highest = candidate.similarity.reduce((max, similarity) => Math.max(max, similarity.similarity), 0);
+  for (const other of allCandidates) {
+    if (other.candidate_id === candidate.candidate_id) continue;
+    for (const similarity of other.similarity) {
+      if (similarity.candidate_id === candidate.candidate_id) {
+        highest = Math.max(highest, similarity.similarity);
+      }
+    }
+  }
+  return highest;
+}
+
+function inferredCandidateRiskPenalty(candidate: RuntimeEvidenceCandidateRecord): number {
+  const lineageText = [
+    ...candidate.lineage.config_lineage,
+    ...candidate.lineage.postprocess_lineage,
+  ].map(normalizeLineageText).join(" ");
+  if (lineageText.includes("manual") || lineageText.includes("threshold") || lineageText.includes("postprocess")) {
+    return 0.15;
+  }
+  if (lineageText.includes("calibration") || lineageText.includes("weight")) {
+    return 0.08;
+  }
+  return 0;
+}
+
+function candidateSelectionReasons(
+  candidate: RuntimeEvidenceCandidateRecord,
+  scores: {
+    metricScore: number;
+    stabilityScore: number;
+    diversityScore: number;
+    riskPenalty: number;
+    evidenceConfidence: number;
+  }
+): string[] {
+  const reasons: string[] = [];
+  if (scores.stabilityScore >= 0.8) reasons.push("strong stability evidence");
+  if (scores.diversityScore >= 0.8) reasons.push("diverse lineage");
+  if (scores.riskPenalty >= 0.15) reasons.push("penalized for overfit-prone lineage or post-processing");
+  if (scores.metricScore >= 0.95) reasons.push("top raw metric evidence");
+  if (candidate.robustness?.summary) reasons.push(candidate.robustness.summary);
+  return reasons.length > 0 ? reasons : ["risk-adjusted candidate evidence"];
+}
+
+function selectSafeCandidate(
+  candidates: RuntimeCandidateSelectionCandidate[]
+): RuntimeCandidateSelectionCandidate | null {
+  return [...candidates].sort((a, b) =>
+    b.stability_score - a.stability_score
+    || a.risk_penalty - b.risk_penalty
+    || b.robust_score - a.robust_score
+    || a.raw_rank - b.raw_rank
+  )[0] ?? null;
+}
+
+function selectDiverseCandidate(
+  candidates: RuntimeCandidateSelectionCandidate[],
+  robustBest: RuntimeCandidateSelectionCandidate | null
+): RuntimeCandidateSelectionCandidate | null {
+  const robustFamily = robustBest?.strategy_family;
+  return [...candidates]
+    .filter((candidate) => !robustFamily || candidate.strategy_family !== robustFamily)
+    .filter((candidate) => candidate.diversity_score >= 0.5)
+    .sort((a, b) =>
+      b.diversity_score - a.diversity_score
+      || b.robust_score - a.robust_score
+      || a.raw_rank - b.raw_rank
+    )[0] ?? null;
 }
 
 function summarizeCandidateLineages(entriesOldestFirst: RuntimeEvidenceEntry[]): RuntimeCandidateLineageContext[] {
@@ -1151,6 +1375,15 @@ function failedLineageFingerprintInput(entry: RuntimeEvidenceEntry): {
 
 function normalizeLineageText(value: string | undefined): string {
   return value?.normalize("NFKC").toLocaleLowerCase().replace(/[^\p{Letter}\p{Number}]+/gu, " ").trim() ?? "";
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function roundScore(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
 }
 
 function chooseBestEvidence(entriesNewestFirst: RuntimeEvidenceEntry[]): RuntimeEvidenceEntry | null {


### PR DESCRIPTION
Closes #811

## Summary
- Adds candidate robustness metadata for stability, repeated evaluations, variance, provenance, risk penalty, and confidence.
- Adds `candidate_selection_summary` to runtime evidence summaries with raw best, robust best, risk-adjusted ranking, and safe/aggressive/diverse portfolio slots.
- Prevents direct or inverse near-duplicate similarity from filling the diverse slot, and keeps stale summary indexes from hiding the new selection surface.

## Verification
- `npx vitest run src/runtime/__tests__/runtime-evidence-ledger.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (0 errors; existing warnings remain)
- `npm run test:changed` (fails only in pre-existing `src/interface/cli/__tests__/cli-runner-integration.test.ts` 60s timeout; focused runtime evidence tests pass)

## Known unresolved risks
- `npm run test:changed` still hits the known local CLI runner integration timeout unrelated to this runtime evidence slice.
