### PR TITLE
feat(runtime): preserve near-miss candidates

### DIFF
--- a/src/runtime/__tests__/dream-sidecar-review.test.ts
+++ b/src/runtime/__tests__/dream-sidecar-review.test.ts
@@ -359,6 +359,140 @@ describe("Runtime Dream sidecar review", () => {
     }));
   });
 
+  it("can promote near-miss follow-ups without retrying a repeated failed lineage", async () => {
+    await seedActiveRun("run:coreloop:near-miss-follow-up");
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    for (let index = 0; index < 3; index += 1) {
+      await ledger.append({
+        id: `failed-threshold-near-miss-${index + 1}`,
+        occurred_at: `2026-04-30T00:0${index}:00.000Z`,
+        kind: "failure",
+        scope: { run_id: "run:coreloop:near-miss-follow-up", task_id: `task-threshold-${index + 1}` },
+        strategy: "threshold_sweep",
+        hypothesis: "Repeat threshold sweep improves balanced accuracy",
+        task: {
+          id: `task-threshold-${index + 1}`,
+          action: "threshold_sweep",
+          primary_dimension: "balanced_accuracy",
+        },
+        verification: { verdict: "fail", summary: "Balanced accuracy stayed inside noise." },
+        summary: "Threshold sweep failed.",
+        outcome: "failed",
+      });
+    }
+    await ledger.append({
+      id: "near-miss-follow-up-snapshot",
+      occurred_at: "2026-04-30T00:10:00.000Z",
+      kind: "metric",
+      scope: { run_id: "run:coreloop:near-miss-follow-up", loop_index: 4 },
+      candidates: [
+        {
+          candidate_id: "raw-best-threshold",
+          lineage: {
+            strategy_family: "threshold_sweep",
+            feature_lineage: ["base"],
+            model_lineage: ["catboost"],
+            config_lineage: ["manual-threshold"],
+            seed_lineage: ["seed-42"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: ["threshold-0.48"],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.97042, direction: "maximize", confidence: 0.78 }],
+          artifacts: [],
+          similarity: [],
+          disposition: "promoted",
+        },
+        {
+          candidate_id: "threshold-near-miss",
+          lineage: {
+            strategy_family: "threshold_sweep",
+            feature_lineage: ["base"],
+            model_lineage: ["catboost"],
+            config_lineage: ["manual-threshold"],
+            seed_lineage: ["seed-99"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: ["threshold-0.49"],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.9702, direction: "maximize", confidence: 0.8 }],
+          artifacts: [],
+          similarity: [{ candidate_id: "raw-best-threshold", similarity: 0.91, signal: "declared" }],
+          near_miss: {
+            status: "retained",
+            reason_to_keep: ["close_to_best"],
+            weak_dimensions: [],
+            complementary_candidate_ids: [],
+            follow_up: {
+              title: "Run close near-miss follow-up",
+              rationale: "Retry the close-to-best candidate with a wider local validation pass.",
+              target_dimensions: ["balanced_accuracy"],
+            },
+            evidence_refs: [],
+            summary: "Close but from a repeatedly failed lineage.",
+          },
+          disposition: "retained",
+        },
+        {
+          candidate_id: "feature-ablation-near-miss",
+          lineage: {
+            strategy_family: "feature_ablation",
+            feature_lineage: ["remove-leaky-counts"],
+            model_lineage: ["catboost"],
+            config_lineage: ["smoke"],
+            seed_lineage: ["seed-314"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.9699, direction: "maximize", confidence: 0.88 }],
+          artifacts: [],
+          similarity: [{ candidate_id: "raw-best-threshold", similarity: 0.35, signal: "declared" }],
+          robustness: {
+            stability_score: 0.86,
+            risk_penalty: 0.02,
+            evidence_confidence: 0.88,
+            weak_dimensions: ["minority_class_recall"],
+            provenance_refs: ["runs/feature-ablation/per-class.json"],
+            summary: "Near miss improves minority class recall through a different mechanism.",
+          },
+          near_miss: {
+            status: "retained",
+            reason_to_keep: ["weak_dimension_improvement", "novelty"],
+            weak_dimensions: ["minority_class_recall"],
+            complementary_candidate_ids: [],
+            follow_up: {
+              title: "Feature ablation larger follow-up",
+              rationale: "Promote the distinct feature-ablation near miss that improved the weak class.",
+              target_dimensions: ["minority_class_recall", "balanced_accuracy"],
+            },
+            evidence_refs: ["runs/feature-ablation/per-class.json"],
+            summary: "Promising non-winner from a distinct strategy family.",
+          },
+          disposition: "retained",
+        },
+      ],
+      summary: "Near-miss snapshot after plateau.",
+      outcome: "continued",
+    });
+
+    const review = await createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:coreloop:near-miss-follow-up",
+    });
+
+    expect(review.status_summary).toContain("promising non-winners");
+    expect(review.promising_non_winners).toContainEqual(expect.objectContaining({
+      candidate_id: "feature-ablation-near-miss",
+      reason_to_keep: expect.arrayContaining(["weak_dimension_improvement", "novelty"]),
+      follow_up_title: "Feature ablation larger follow-up",
+    }));
+    expect(review.suggested_next_moves).not.toContainEqual(expect.objectContaining({
+      title: "Run close near-miss follow-up",
+    }));
+    expect(review.suggested_next_moves).toContainEqual(expect.objectContaining({
+      title: "Feature ablation larger follow-up",
+      source: "near_miss",
+    }));
+  });
+
   it("rejects a missing background run", async () => {
     await expect(createRuntimeDreamSidecarReview({
       stateManager,

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -940,6 +940,157 @@ describe("RuntimeEvidenceLedger", () => {
     });
   });
 
+  it("preserves near-miss non-winners during stalled candidate selection", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    for (const [index, value] of [0.9704, 0.97042, 0.97041].entries()) {
+      await ledger.append({
+        id: `stalled-balanced-accuracy-${index + 1}`,
+        occurred_at: `2026-04-30T00:0${index}:00.000Z`,
+        kind: "metric",
+        scope: { goal_id: "goal-near-miss-stall", loop_index: index },
+        metrics: [{ label: "balanced_accuracy", value, direction: "maximize", confidence: 0.9 }],
+        summary: "Balanced accuracy stayed inside the plateau band.",
+        outcome: "continued",
+      });
+    }
+    await ledger.append({
+      id: "near-miss-candidate-snapshot",
+      occurred_at: "2026-04-30T00:10:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-near-miss-stall", loop_index: 4 },
+      candidates: [
+        {
+          candidate_id: "raw-best-threshold",
+          label: "Raw best threshold",
+          lineage: {
+            strategy_family: "threshold_sweep",
+            feature_lineage: ["base"],
+            model_lineage: ["catboost"],
+            config_lineage: ["manual-threshold"],
+            seed_lineage: ["seed-42"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: ["threshold-0.48"],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.97042, direction: "maximize", confidence: 0.78 }],
+          artifacts: [],
+          similarity: [],
+          robustness: {
+            stability_score: 0.45,
+            risk_penalty: 0.2,
+            evidence_confidence: 0.72,
+            weak_dimensions: [],
+            provenance_refs: ["runs/raw-best/metrics.json"],
+          },
+          disposition: "promoted",
+          disposition_reason: "Highest local metric, but not the only promising path.",
+        },
+        {
+          candidate_id: "weak-class-near-miss",
+          label: "Weak class near miss",
+          lineage: {
+            strategy_family: "class_weight_focus",
+            feature_lineage: ["base"],
+            model_lineage: ["catboost"],
+            config_lineage: ["class-weight-minority"],
+            seed_lineage: ["seed-314"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.97001, direction: "maximize", confidence: 0.9 }],
+          artifacts: [],
+          similarity: [{ candidate_id: "raw-best-threshold", similarity: 0.42, signal: "metric_correlation" }],
+          robustness: {
+            stability_score: 0.88,
+            risk_penalty: 0.02,
+            evidence_confidence: 0.9,
+            weak_dimensions: ["minority_class_recall"],
+            provenance_refs: ["runs/weak-class/metrics.json", "runs/weak-class/per-class.json"],
+            summary: "Misses raw best but improves minority class recall under plateau.",
+          },
+          near_miss: {
+            status: "retained",
+            reason_to_keep: ["weak_dimension_improvement", "stability", "complementarity"],
+            weak_dimensions: ["minority_class_recall"],
+            complementary_candidate_ids: ["raw-best-threshold"],
+            follow_up: {
+              title: "Expand minority class weighting follow-up",
+              rationale: "Use the weak-class gain to test a larger class-weight schedule.",
+              target_dimensions: ["minority_class_recall", "balanced_accuracy"],
+              expected_evidence_gain: "Confirms whether the weak-dimension improvement survives a larger run.",
+            },
+            evidence_refs: ["runs/weak-class/per-class.json"],
+            summary: "Retained because it improves the weak class while staying near raw best.",
+          },
+          disposition: "retained",
+          disposition_reason: "Near miss retained for weak-dimension improvement.",
+        },
+        {
+          candidate_id: "tabnet-diverse-near-miss",
+          label: "TabNet diverse near miss",
+          lineage: {
+            strategy_family: "tabnet",
+            feature_lineage: ["encoded-categorical"],
+            model_lineage: ["tabnet"],
+            config_lineage: ["smoke"],
+            seed_lineage: ["seed-7"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.962, direction: "maximize", confidence: 0.82 }],
+          artifacts: [],
+          similarity: [{ candidate_id: "raw-best-threshold", similarity: 0.28, signal: "declared" }],
+          robustness: {
+            stability_score: 0.76,
+            risk_penalty: 0.03,
+            evidence_confidence: 0.82,
+            weak_dimensions: [],
+            provenance_refs: ["runs/tabnet-smoke/metrics.json"],
+            summary: "Lower score but a distinct strategy family with cheap follow-up potential.",
+          },
+          near_miss: {
+            status: "retained",
+            reason_to_keep: ["novelty"],
+            weak_dimensions: [],
+            complementary_candidate_ids: [],
+            follow_up: {
+              title: "Promote TabNet smoke to a bounded larger fold run",
+              rationale: "The distinct family can test whether the plateau is model-family specific.",
+              target_dimensions: ["balanced_accuracy"],
+            },
+            evidence_refs: ["runs/tabnet-smoke/metrics.json"],
+            summary: "Distinct strategy family kept despite lower local score.",
+          },
+          disposition: "retained",
+          disposition_reason: "Distinct strategy family preserved for stall recovery.",
+        },
+      ],
+      summary: "Stalled candidate snapshot with promising non-winners.",
+      outcome: "continued",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-near-miss-stall");
+
+    expect(summary.candidate_selection_summary.raw_best?.candidate_id).toBe("raw-best-threshold");
+    expect(summary.near_miss_candidates.map((candidate) => candidate.candidate_id)).toEqual([
+      "weak-class-near-miss",
+      "tabnet-diverse-near-miss",
+    ]);
+    expect(summary.near_miss_candidates[0]).toMatchObject({
+      candidate_id: "weak-class-near-miss",
+      raw_best_candidate_id: "raw-best-threshold",
+      reason_to_keep: expect.arrayContaining(["weak_dimension_improvement", "stability", "complementarity"]),
+      weak_dimensions: ["minority_class_recall"],
+      follow_up: {
+        title: "Expand minority class weighting follow-up",
+      },
+    });
+    expect(summary.near_miss_candidates[1]).toMatchObject({
+      candidate_id: "tabnet-diverse-near-miss",
+      strategy_family: "tabnet",
+      reason_to_keep: expect.arrayContaining(["novelty"]),
+    });
+  });
+
   it("stores local and external evaluator observations with candidate provenance", async () => {
     const ledger = new RuntimeEvidenceLedger(runtimeRoot);
     await ledger.append({

--- a/src/runtime/dream-sidecar-review.ts
+++ b/src/runtime/dream-sidecar-review.ts
@@ -75,6 +75,15 @@ export interface RuntimeDreamSidecarReview {
     outcome: RuntimeEvidenceEntry["outcome"] | null;
     occurred_at: string;
   } | null;
+  promising_non_winners: Array<{
+    candidate_id: string;
+    label?: string;
+    strategy_family: string;
+    raw_rank: number;
+    reason_to_keep: string[];
+    follow_up_title?: string;
+    summary?: string;
+  }>;
   known_gaps: string[];
   strategy_families: string[];
   trend_state: {
@@ -98,7 +107,7 @@ export interface RuntimeDreamSidecarReview {
   suggested_next_moves: Array<{
     title: string;
     rationale: string;
-    source: "dream_checkpoint" | "public_research" | "evaluator" | "fallback";
+    source: "dream_checkpoint" | "near_miss" | "public_research" | "evaluator" | "fallback";
   }>;
   operator_decisions: Array<{
     label: string;
@@ -190,6 +199,7 @@ export async function createRuntimeDreamSidecarReview(
       : null,
     status_summary: statusSummary,
     best_evidence: evidenceSummary.best_evidence ? compactEvidence(evidenceSummary.best_evidence) : null,
+    promising_non_winners: buildPromisingNonWinners(evidenceSummary),
     known_gaps: buildKnownGaps(evidenceSummary),
     strategy_families: buildStrategyFamilies(evidenceSummary),
     trend_state: trendState,
@@ -298,7 +308,10 @@ function buildStatusSummary(
   const title = run.title ? `${run.title} ` : "";
   const evidenceCount = `${summary.total_entries} evidence entr${summary.total_entries === 1 ? "y" : "ies"}`;
   const trend = trendState.summary ?? `trend=${trendState.state}`;
-  return `${title}${run.kind} ${run.status}; ${evidenceCount}; ${trend}.`;
+  const nearMissCount = summary.near_miss_candidates.length > 0
+    ? ` ${summary.near_miss_candidates.length} promising non-winner${summary.near_miss_candidates.length === 1 ? "" : "s"}.`
+    : "";
+  return `${title}${run.kind} ${run.status}; ${evidenceCount}; ${trend}.${nearMissCount}`;
 }
 
 function compactEvidence(entry: RuntimeEvidenceEntry): NonNullable<RuntimeDreamSidecarReview["best_evidence"]> {
@@ -309,6 +322,18 @@ function compactEvidence(entry: RuntimeEvidenceEntry): NonNullable<RuntimeDreamS
     outcome: entry.outcome ?? null,
     occurred_at: entry.occurred_at,
   };
+}
+
+function buildPromisingNonWinners(summary: RuntimeEvidenceSummary): RuntimeDreamSidecarReview["promising_non_winners"] {
+  return summary.near_miss_candidates.slice(0, 6).map((candidate) => ({
+    candidate_id: candidate.candidate_id,
+    ...(candidate.label ? { label: candidate.label } : {}),
+    strategy_family: candidate.strategy_family,
+    raw_rank: candidate.raw_rank,
+    reason_to_keep: candidate.reason_to_keep,
+    ...(candidate.follow_up?.title ? { follow_up_title: candidate.follow_up.title } : {}),
+    ...(candidate.summary ? { summary: candidate.summary } : {}),
+  }));
 }
 
 function buildKnownGaps(summary: RuntimeEvidenceSummary): string[] {
@@ -367,6 +392,19 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
         source: "dream_checkpoint",
       });
     }
+  }
+  for (const nearMiss of summary.near_miss_candidates.slice(0, 3)) {
+    const title = nearMiss.follow_up?.title ?? `Follow up near-miss candidate ${nearMiss.candidate_id}`;
+    const rationale = nearMiss.follow_up?.rationale
+      ?? nearMiss.summary
+      ?? `Candidate ${nearMiss.candidate_id} did not beat raw best but was retained for ${nearMiss.reason_to_keep.join(", ")}.`;
+    if (isRejectedMove(title, rationale, rejectedApproaches)) continue;
+    if (isFailedLineageMove(`${nearMiss.strategy_family} ${title}`, rationale, failedLineages)) continue;
+    moves.push({
+      title,
+      rationale,
+      source: "near_miss",
+    });
   }
   for (const memo of summary.research_memos.slice(0, 2)) {
     for (const finding of memo.findings.slice(0, 2)) {

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -96,6 +96,33 @@ export const RuntimeEvidenceCandidateSimilaritySchema = z.object({
 }).strict();
 export type RuntimeEvidenceCandidateSimilarity = z.infer<typeof RuntimeEvidenceCandidateSimilaritySchema>;
 
+export const RuntimeEvidenceCandidateNearMissReasonSchema = z.enum([
+  "close_to_best",
+  "stability",
+  "novelty",
+  "weak_dimension_improvement",
+  "complementarity",
+  "ensemble_potential",
+]);
+export type RuntimeEvidenceCandidateNearMissReason = z.infer<typeof RuntimeEvidenceCandidateNearMissReasonSchema>;
+
+export const RuntimeEvidenceCandidateNearMissSchema = z.object({
+  status: z.enum(["retained", "promoted", "rejected"]).default("retained"),
+  reason_to_keep: z.array(RuntimeEvidenceCandidateNearMissReasonSchema).min(1),
+  margin_to_best: z.number().min(0).optional(),
+  weak_dimensions: z.array(z.string().min(1)).default([]),
+  complementary_candidate_ids: z.array(z.string().min(1)).default([]),
+  follow_up: z.object({
+    title: z.string().min(1),
+    rationale: z.string().min(1),
+    target_dimensions: z.array(z.string().min(1)).default([]),
+    expected_evidence_gain: z.string().min(1).optional(),
+  }).strict().optional(),
+  evidence_refs: z.array(z.string().min(1)).default([]),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceCandidateNearMiss = z.infer<typeof RuntimeEvidenceCandidateNearMissSchema>;
+
 export const RuntimeEvidenceCandidateRecordSchema = z.object({
   candidate_id: z.string().min(1),
   label: z.string().min(1).optional(),
@@ -119,6 +146,7 @@ export const RuntimeEvidenceCandidateRecordSchema = z.object({
     provenance_refs: z.array(z.string().min(1)).default([]),
     summary: z.string().min(1).optional(),
   }).strict().optional(),
+  near_miss: RuntimeEvidenceCandidateNearMissSchema.optional(),
   disposition: RuntimeEvidenceCandidateDispositionSchema.default("retained"),
   disposition_reason: z.string().min(1).optional(),
   produced_at: z.string().datetime().optional(),
@@ -538,6 +566,30 @@ export interface RuntimeCandidateSelectionSummary {
   };
 }
 
+export interface RuntimeNearMissCandidateContext {
+  candidate_id: string;
+  label?: string;
+  strategy_family: string;
+  evidence_entry_id: string;
+  occurred_at: string;
+  raw_rank: number;
+  raw_metric?: CandidateComparableMetric;
+  raw_best_candidate_id?: string;
+  margin_to_raw_best?: number;
+  reason_to_keep: RuntimeEvidenceCandidateNearMissReason[];
+  weak_dimensions: string[];
+  complementary_candidate_ids: string[];
+  follow_up?: {
+    title: string;
+    rationale: string;
+    target_dimensions: string[];
+    expected_evidence_gain?: string;
+  };
+  retained_reason?: string;
+  evidence_refs: string[];
+  summary?: string;
+}
+
 export interface RuntimeEvidenceSummary {
   schema_version: "runtime-evidence-summary-v1";
   generated_at: string;
@@ -556,6 +608,7 @@ export interface RuntimeEvidenceSummary {
   candidate_lineages: RuntimeCandidateLineageContext[];
   recommended_candidate_portfolio: RuntimeCandidatePortfolioSlot[];
   candidate_selection_summary: RuntimeCandidateSelectionSummary;
+  near_miss_candidates: RuntimeNearMissCandidateContext[];
   recent_failed_attempts: RuntimeEvidenceEntry[];
   failed_lineages: RuntimeFailedLineageContext[];
   recent_entries: RuntimeEvidenceEntry[];
@@ -714,6 +767,7 @@ async function readSummaryIndex(
 function isCurrentEvidenceSummaryShape(summary: RuntimeEvidenceSummary): boolean {
   return Array.isArray(summary.candidate_lineages)
     && Array.isArray(summary.recommended_candidate_portfolio)
+    && Array.isArray(summary.near_miss_candidates)
     && typeof summary.candidate_selection_summary === "object"
     && summary.candidate_selection_summary !== null;
 }
@@ -801,6 +855,7 @@ function summarizeEvidence(
     candidate_lineages: summarizeCandidateLineages(entries),
     recommended_candidate_portfolio: selectDiversifiedCandidatePortfolio(entries),
     candidate_selection_summary: summarizeCandidateSelection(entries),
+    near_miss_candidates: summarizeNearMissCandidates(entries),
     recent_failed_attempts: newestFirst
       .filter((entry) =>
         entry.outcome === "failed"
@@ -823,7 +878,7 @@ interface CandidateEvidenceContext {
   metric: CandidateComparableMetric | null;
 }
 
-interface CandidateComparableMetric {
+export interface CandidateComparableMetric {
   label: string;
   value: number;
   direction: "maximize" | "minimize";
@@ -1041,6 +1096,161 @@ function selectDiverseCandidate(
       || b.robust_score - a.robust_score
       || a.raw_rank - b.raw_rank
     )[0] ?? null;
+}
+
+function summarizeNearMissCandidates(entriesOldestFirst: RuntimeEvidenceEntry[]): RuntimeNearMissCandidateContext[] {
+  const primaryMetric = resolvePrimaryCandidateMetricKey(entriesOldestFirst);
+  const contexts = extractCandidateEvidenceContexts(entriesOldestFirst, primaryMetric)
+    .filter((context) => context.candidate.disposition !== "retired");
+  const rawRanked = [...contexts].sort(compareCandidateEvidenceContexts);
+  const rawBest = rawRanked[0] ?? null;
+  const scoredByCandidateId = new Map(
+    scoreCandidateSelectionContexts(rawRanked).map((candidate) => [candidate.candidate_id, candidate])
+  );
+  const result: RuntimeNearMissCandidateContext[] = [];
+  for (const context of rawRanked) {
+    if (!rawBest || context.candidate.candidate_id === rawBest.candidate.candidate_id) continue;
+    const scored = scoredByCandidateId.get(context.candidate.candidate_id);
+    const reasons = nearMissReasonsForCandidate(context, rawBest, scored);
+    if (reasons.length === 0) continue;
+    const nearMiss = context.candidate.near_miss;
+    if (nearMiss?.status === "rejected") continue;
+    result.push({
+      candidate_id: context.candidate.candidate_id,
+      ...(context.candidate.label ? { label: context.candidate.label } : {}),
+      strategy_family: context.candidate.lineage.strategy_family,
+      evidence_entry_id: context.entry_id,
+      occurred_at: context.occurred_at,
+      raw_rank: scored?.raw_rank ?? rawRanked.indexOf(context) + 1,
+      ...(context.metric ? { raw_metric: context.metric } : {}),
+      raw_best_candidate_id: rawBest.candidate.candidate_id,
+      ...nearMissMarginContext(context, rawBest, nearMiss),
+      reason_to_keep: reasons,
+      weak_dimensions: nearMiss?.weak_dimensions ?? context.candidate.robustness?.weak_dimensions ?? [],
+      complementary_candidate_ids: nearMiss?.complementary_candidate_ids ?? complementaryCandidateIds(context.candidate),
+      ...(nearMiss?.follow_up ? { follow_up: nearMiss.follow_up } : {}),
+      ...(context.candidate.disposition_reason ? { retained_reason: context.candidate.disposition_reason } : {}),
+      evidence_refs: nearMiss?.evidence_refs ?? context.candidate.robustness?.provenance_refs ?? [],
+      ...(nearMiss?.summary ?? context.candidate.robustness?.summary
+        ? { summary: nearMiss?.summary ?? context.candidate.robustness?.summary }
+        : {}),
+    });
+  }
+  return result.sort((a, b) =>
+    nearMissReasonRank(b.reason_to_keep) - nearMissReasonRank(a.reason_to_keep)
+    || (b.raw_metric?.confidence ?? 0) - (a.raw_metric?.confidence ?? 0)
+    || a.raw_rank - b.raw_rank
+  ).slice(0, 8);
+}
+
+function nearMissReasonsForCandidate(
+  context: CandidateEvidenceContext,
+  rawBest: CandidateEvidenceContext,
+  scored: RuntimeCandidateSelectionCandidate | undefined
+): RuntimeEvidenceCandidateNearMissReason[] {
+  const explicit = context.candidate.near_miss?.reason_to_keep ?? [];
+  const reasons = new Set<RuntimeEvidenceCandidateNearMissReason>(explicit);
+  if (context.candidate.near_miss?.status === "retained" || context.candidate.near_miss?.status === "promoted") {
+    for (const reason of inferredNearMissReasons(context, rawBest, scored)) reasons.add(reason);
+  } else if (context.candidate.near_miss) {
+    for (const reason of inferredNearMissReasons(context, rawBest, scored)) reasons.add(reason);
+  } else if (isImplicitNearMiss(context, rawBest, scored)) {
+    for (const reason of inferredNearMissReasons(context, rawBest, scored)) reasons.add(reason);
+  }
+  return [...reasons];
+}
+
+function inferredNearMissReasons(
+  context: CandidateEvidenceContext,
+  rawBest: CandidateEvidenceContext,
+  scored: RuntimeCandidateSelectionCandidate | undefined
+): RuntimeEvidenceCandidateNearMissReason[] {
+  const reasons: RuntimeEvidenceCandidateNearMissReason[] = [];
+  const margin = candidateMetricMargin(context.metric, rawBest.metric);
+  if (margin !== null && isCloseToBestMargin(margin, rawBest.metric)) reasons.push("close_to_best");
+  if ((context.candidate.robustness?.stability_score ?? 0) >= 0.8) reasons.push("stability");
+  if ((context.candidate.near_miss?.weak_dimensions.length ?? context.candidate.robustness?.weak_dimensions.length ?? 0) > 0) {
+    reasons.push("weak_dimension_improvement");
+  }
+  if (context.candidate.lineage.strategy_family !== rawBest.candidate.lineage.strategy_family
+    && (scored?.diversity_score ?? inferredDiversityScore(context.candidate, rawBest.candidate.lineage.strategy_family, [context.candidate, rawBest.candidate])) >= 0.5) {
+    reasons.push("novelty");
+  }
+  if (complementaryCandidateIds(context.candidate).length > 0 || highestKnownSimilarity(context.candidate, [context.candidate, rawBest.candidate]) <= 0.5) {
+    reasons.push("complementarity");
+  }
+  const lineageText = [
+    ...context.candidate.lineage.model_lineage,
+    ...context.candidate.lineage.config_lineage,
+    ...(context.candidate.near_miss?.summary ? [context.candidate.near_miss.summary] : []),
+  ].map(normalizeLineageText).join(" ");
+  if (lineageText.includes("stack") || lineageText.includes("ensemble") || lineageText.includes("blend")) {
+    reasons.push("ensemble_potential");
+  }
+  return reasons;
+}
+
+function isImplicitNearMiss(
+  context: CandidateEvidenceContext,
+  rawBest: CandidateEvidenceContext,
+  scored: RuntimeCandidateSelectionCandidate | undefined
+): boolean {
+  if (context.candidate.disposition !== "retained" && context.candidate.disposition !== "promoted") return false;
+  const margin = candidateMetricMargin(context.metric, rawBest.metric);
+  const close = margin !== null && isCloseToBestMargin(margin, rawBest.metric);
+  const weakDimension = (context.candidate.robustness?.weak_dimensions.length ?? 0) > 0;
+  const distinctFamily = context.candidate.lineage.strategy_family !== rawBest.candidate.lineage.strategy_family
+    && (scored?.diversity_score ?? 0) >= 0.5;
+  return close || weakDimension || distinctFamily;
+}
+
+function nearMissMarginContext(
+  context: CandidateEvidenceContext,
+  rawBest: CandidateEvidenceContext,
+  nearMiss: RuntimeEvidenceCandidateNearMiss | undefined
+): Pick<RuntimeNearMissCandidateContext, "margin_to_raw_best"> {
+  const margin = nearMiss?.margin_to_best ?? candidateMetricMargin(context.metric, rawBest.metric);
+  return margin === null || margin === undefined ? {} : { margin_to_raw_best: Math.round(margin * 1_000_000) / 1_000_000 };
+}
+
+function candidateMetricMargin(
+  candidateMetric: CandidateComparableMetric | null,
+  bestMetric: CandidateComparableMetric | null
+): number | null {
+  if (!candidateMetric || !bestMetric || candidateMetric.direction !== bestMetric.direction) return null;
+  const margin = candidateMetric.direction === "maximize"
+    ? bestMetric.value - candidateMetric.value
+    : candidateMetric.value - bestMetric.value;
+  return Number.isFinite(margin) ? Math.max(0, margin) : null;
+}
+
+function isCloseToBestMargin(
+  margin: number,
+  bestMetric: CandidateComparableMetric | null
+): boolean {
+  if (!bestMetric) return false;
+  const tolerance = Math.max(Math.abs(bestMetric.value) * 0.005, 0.001);
+  return margin <= tolerance;
+}
+
+function complementaryCandidateIds(candidate: RuntimeEvidenceCandidateRecord): string[] {
+  const explicit = candidate.near_miss?.complementary_candidate_ids ?? [];
+  if (explicit.length > 0) return explicit;
+  return candidate.similarity
+    .filter((similarity) => similarity.signal === "metric_correlation" && similarity.similarity <= 0.5)
+    .map((similarity) => similarity.candidate_id);
+}
+
+function nearMissReasonRank(reasons: RuntimeEvidenceCandidateNearMissReason[]): number {
+  const weights: Record<RuntimeEvidenceCandidateNearMissReason, number> = {
+    weak_dimension_improvement: 5,
+    novelty: 4,
+    complementarity: 4,
+    ensemble_potential: 3,
+    stability: 2,
+    close_to_best: 1,
+  };
+  return reasons.reduce((score, reason) => score + weights[reason], 0);
 }
 
 function summarizeCandidateLineages(entriesOldestFirst: RuntimeEvidenceEntry[]): RuntimeCandidateLineageContext[] {


### PR DESCRIPTION
Closes #812

## Summary
- Add near-miss candidate metadata with durable reason_to_keep values for stability, novelty, weak-dimension improvement, complementarity, and ensemble potential.
- Summarize promising non-winners separately from raw best in runtime evidence summaries.
- Let Dream sidecar next moves promote near-miss follow-ups while suppressing repeated failed candidate lineages using the candidate strategy family.

## Verification
- npx vitest run src/runtime/__tests__/runtime-evidence-ledger.test.ts src/runtime/__tests__/dream-sidecar-review.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed (known pre-existing timeout in src/interface/cli/__tests__/cli-runner-integration.test.ts; related runtime tests passed)
- git diff --check

## Known unresolved risks
- npm run test:changed still reaches the pre-existing CLI runner integration 60s timeout observed on earlier PRs; focused runtime evidence and sidecar coverage passes.