### PR TITLE
feat(runtime): calibrate external evaluator feedback

### DIFF
--- a/src/runtime/__tests__/runtime-evaluator-results.test.ts
+++ b/src/runtime/__tests__/runtime-evaluator-results.test.ts
@@ -188,6 +188,122 @@ describe("runtime evaluator result summaries", () => {
     expect(summary.gap?.score_delta).toBeCloseTo(0.003);
   });
 
+  it("summarizes evaluator budget and calibration without allowing direct optimization", () => {
+    const summary = summarizeEvidenceEvaluatorResults([
+      evidenceEntry({
+        id: "entry-external-calibration",
+        occurred_at: "2026-04-30T00:20:00.000Z",
+        evaluators: [{
+          evaluator_id: "leaderboard",
+          signal: "external",
+          source: "public-leaderboard",
+          candidate_id: "candidate-b",
+          status: "passed",
+          score: 0.9692,
+          score_label: "balanced_accuracy",
+          expected_score: 0.9704,
+          direction: "maximize",
+          budget: {
+            policy_id: "daily-public-lb",
+            max_attempts: 5,
+            used_attempts: 3,
+            remaining_attempts: 2,
+            approval_required: true,
+            phase: "consolidation",
+            portfolio_policy: {
+              diversified_portfolio_required: true,
+              reserve_for_finalization: true,
+              min_strategy_families: 2,
+            },
+          },
+          candidate_snapshot: {
+            evidence_entry_id: "candidate-snapshot-b",
+            primary_metric_label: "balanced_accuracy",
+            local_metrics: [
+              { label: "loss", value: 0.24, direction: "minimize" },
+              { label: "balanced_accuracy", value: 0.9704, direction: "maximize" },
+            ],
+            robust_selection: {
+              raw_rank: 3,
+              robust_score: 0.84,
+              portfolio_role: "diverse",
+            },
+          },
+          calibration: {
+            mode: "calibration_only",
+            use_for_selection: true,
+            direct_optimization_allowed: false,
+            minimum_observations: 2,
+            conclusion: "Public leaderboard shows local OOF is slightly optimistic.",
+          },
+          provenance: {
+            kind: "external_url",
+            external_id: "submission-789",
+          },
+        }],
+      }),
+    ]);
+
+    expect(summary.budgets).toContainEqual(expect.objectContaining({
+      evaluator_id: "leaderboard",
+      remaining_attempts: 2,
+      approval_required: true,
+      diversified_portfolio_required: true,
+      reserve_for_finalization: true,
+      min_strategy_families: 2,
+    }));
+    expect(summary.calibration).toContainEqual(expect.objectContaining({
+      candidate_id: "candidate-b",
+      local_evidence_entry_id: "candidate-snapshot-b",
+      local_score: 0.9704,
+      external_score: 0.9692,
+      direct_optimization_allowed: false,
+      use_for_selection: true,
+      selection_adjustment: expect.any(Number),
+      provenance: expect.objectContaining({ external_id: "submission-789" }),
+    }));
+    expect(summary.calibration[0]?.selection_adjustment).toBeLessThan(0);
+  });
+
+  it("does not compute calibration gaps from unlabeled local metrics", () => {
+    const summary = summarizeEvidenceEvaluatorResults([
+      evidenceEntry({
+        id: "entry-unlabeled-calibration",
+        occurred_at: "2026-04-30T00:20:00.000Z",
+        evaluators: [{
+          evaluator_id: "leaderboard",
+          signal: "external",
+          source: "public-leaderboard",
+          candidate_id: "candidate-unlabeled",
+          status: "passed",
+          score: 0.9692,
+          expected_score: 0.9704,
+          direction: "maximize",
+          candidate_snapshot: {
+            local_metrics: [
+              { label: "loss", value: 0.24, direction: "minimize" },
+              { label: "balanced_accuracy", value: 0.9704, direction: "maximize" },
+            ],
+          },
+          calibration: {
+            mode: "calibration_only",
+            use_for_selection: true,
+            direct_optimization_allowed: false,
+            minimum_observations: 1,
+          },
+        }],
+      }),
+    ]);
+
+    expect(summary.calibration[0]).toMatchObject({
+      candidate_id: "candidate-unlabeled",
+      external_score: 0.9692,
+      selection_adjustment: 0,
+    });
+    expect(summary.calibration[0]?.local_score).toBeUndefined();
+    expect(summary.calibration[0]?.score_delta).toBeUndefined();
+  });
+
   it("classifies external regression against local expectations", () => {
     const summary = summarizeEvidenceEvaluatorResults([
       evidenceEntry({

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -1162,6 +1162,334 @@ describe("RuntimeEvidenceLedger", () => {
     });
   });
 
+  it("uses external evaluator gaps as calibration without chasing external scores directly", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "calibrated-candidate-snapshot",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-external-calibration", run_id: "run:coreloop:external-calibration" },
+      candidates: [
+        {
+          candidate_id: "raw-local-best",
+          label: "Raw local best",
+          lineage: {
+            strategy_family: "catboost_manual",
+            feature_lineage: ["focus-base"],
+            model_lineage: ["catboost"],
+            config_lineage: ["manual-class-weight"],
+            seed_lineage: ["seed-42"],
+            fold_lineage: ["5-fold-oof"],
+            postprocess_lineage: ["manual-threshold"],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.980, direction: "maximize", confidence: 0.86 }],
+          artifacts: [{ label: "raw-submission", state_relative_path: "runs/raw/submission.csv", kind: "other" }],
+          similarity: [],
+          robustness: {
+            stability_score: 0.84,
+            diversity_score: 0.4,
+            risk_penalty: 0.04,
+            evidence_confidence: 0.86,
+            weak_dimensions: [],
+            provenance_refs: ["runs/raw/metrics.json"],
+          },
+          disposition: "promoted",
+          disposition_reason: "Highest local validation metric.",
+        },
+        {
+          candidate_id: "calibrated-robust",
+          label: "Calibrated robust",
+          lineage: {
+            strategy_family: "catboost_default",
+            feature_lineage: ["focus-base"],
+            model_lineage: ["catboost"],
+            config_lineage: ["default-class-weight"],
+            seed_lineage: ["seed-314"],
+            fold_lineage: ["5-fold-oof"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.976, direction: "maximize", confidence: 0.9 }],
+          artifacts: [{ label: "robust-submission", state_relative_path: "runs/robust/submission.csv", kind: "other" }],
+          similarity: [{ candidate_id: "raw-local-best", similarity: 0.55, signal: "declared" }],
+          robustness: {
+            stability_score: 0.9,
+            diversity_score: 0.58,
+            risk_penalty: 0.02,
+            evidence_confidence: 0.9,
+            weak_dimensions: [],
+            provenance_refs: ["runs/robust/metrics.json"],
+          },
+          disposition: "retained",
+          disposition_reason: "Stable default candidate selected after calibration.",
+        },
+        {
+          candidate_id: "external-spike",
+          label: "External spike",
+          lineage: {
+            strategy_family: "public_probe",
+            feature_lineage: ["probe"],
+            model_lineage: ["catboost"],
+            config_lineage: ["public-probe"],
+            seed_lineage: ["seed-7"],
+            fold_lineage: ["5-fold-oof"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.930, direction: "maximize", confidence: 0.72 }],
+          artifacts: [{ label: "spike-submission", state_relative_path: "runs/spike/submission.csv", kind: "other" }],
+          similarity: [],
+          robustness: {
+            stability_score: 0.5,
+            diversity_score: 0.75,
+            risk_penalty: 0.12,
+            evidence_confidence: 0.62,
+            weak_dimensions: [],
+            provenance_refs: ["runs/spike/metrics.json"],
+          },
+          disposition: "retained",
+          disposition_reason: "External spike retained as evidence, not a direct optimization target.",
+        },
+      ],
+      summary: "Local candidate snapshot before external feedback.",
+      outcome: "continued",
+    });
+    await ledger.append({
+      id: "external-calibration-feedback",
+      occurred_at: "2026-04-30T00:30:00.000Z",
+      kind: "evaluator",
+      scope: { goal_id: "goal-external-calibration", run_id: "run:coreloop:external-calibration" },
+      evaluators: [
+        {
+          evaluator_id: "leaderboard",
+          signal: "external",
+          source: "public-leaderboard",
+          candidate_id: "raw-local-best",
+          status: "passed",
+          score: 0.900,
+          score_label: "balanced_accuracy",
+          expected_score: 0.980,
+          direction: "maximize",
+          budget: {
+            policy_id: "daily-public-lb",
+            max_attempts: 5,
+            used_attempts: 3,
+            remaining_attempts: 2,
+            approval_required: true,
+            phase: "consolidation",
+            portfolio_policy: {
+              diversified_portfolio_required: true,
+              reserve_for_finalization: true,
+              min_strategy_families: 2,
+            },
+          },
+          candidate_snapshot: {
+            evidence_entry_id: "calibrated-candidate-snapshot",
+            primary_metric_label: "balanced_accuracy",
+            local_metrics: [
+              { label: "logloss", value: 0.15, direction: "minimize" },
+              { label: "balanced_accuracy", value: 0.980, direction: "maximize" },
+            ],
+            robust_selection: {
+              raw_rank: 1,
+              robust_score: 0.83,
+              stability_score: 0.84,
+              diversity_score: 0.4,
+              risk_penalty: 0.04,
+              portfolio_role: "aggressive",
+            },
+          },
+          calibration: {
+            mode: "calibration_only",
+            use_for_selection: true,
+            direct_optimization_allowed: false,
+            minimum_observations: 2,
+            conclusion: "Manual threshold lineage overstates local validation.",
+          },
+          provenance: {
+            kind: "external_url",
+            external_id: "submission-raw",
+          },
+        },
+        {
+          evaluator_id: "leaderboard",
+          signal: "external",
+          source: "public-leaderboard",
+          candidate_id: "calibrated-robust",
+          status: "passed",
+          score: 0.975,
+          score_label: "balanced_accuracy",
+          expected_score: 0.976,
+          direction: "maximize",
+          budget: {
+            policy_id: "daily-public-lb",
+            max_attempts: 5,
+            used_attempts: 3,
+            remaining_attempts: 2,
+            approval_required: true,
+            phase: "consolidation",
+            portfolio_policy: {
+              diversified_portfolio_required: true,
+              reserve_for_finalization: true,
+              min_strategy_families: 2,
+            },
+          },
+          candidate_snapshot: {
+            evidence_entry_id: "calibrated-candidate-snapshot",
+            primary_metric_label: "balanced_accuracy",
+            local_metrics: [
+              { label: "logloss", value: 0.16, direction: "minimize" },
+              { label: "balanced_accuracy", value: 0.976, direction: "maximize" },
+            ],
+            robust_selection: {
+              raw_rank: 2,
+              robust_score: 0.86,
+              stability_score: 0.9,
+              diversity_score: 0.58,
+              risk_penalty: 0.02,
+              portfolio_role: "robust_best",
+            },
+          },
+          calibration: {
+            mode: "calibration_only",
+            use_for_selection: true,
+            direct_optimization_allowed: false,
+            minimum_observations: 2,
+            conclusion: "Default lineage tracks external feedback better than raw best.",
+          },
+          provenance: {
+            kind: "external_url",
+            external_id: "submission-robust",
+          },
+        },
+        {
+          evaluator_id: "leaderboard",
+          signal: "external",
+          source: "public-leaderboard",
+          candidate_id: "raw-local-best",
+          status: "passed",
+          score: 0.902,
+          score_label: "balanced_accuracy",
+          expected_score: 0.980,
+          direction: "maximize",
+          observed_at: "2026-04-30T00:35:00.000Z",
+          candidate_snapshot: {
+            evidence_entry_id: "calibrated-candidate-snapshot",
+            primary_metric_label: "balanced_accuracy",
+            local_metrics: [{ label: "balanced_accuracy", value: 0.980, direction: "maximize" }],
+            robust_selection: {
+              raw_rank: 1,
+              robust_score: 0.83,
+              portfolio_role: "aggressive",
+            },
+          },
+          calibration: {
+            mode: "calibration_only",
+            use_for_selection: true,
+            direct_optimization_allowed: false,
+            minimum_observations: 2,
+            conclusion: "Second external sample confirms manual threshold optimism.",
+          },
+          provenance: {
+            kind: "external_url",
+            external_id: "submission-raw-repeat",
+          },
+        },
+        {
+          evaluator_id: "leaderboard",
+          signal: "external",
+          source: "public-leaderboard",
+          candidate_id: "calibrated-robust",
+          status: "passed",
+          score: 0.974,
+          score_label: "balanced_accuracy",
+          expected_score: 0.976,
+          direction: "maximize",
+          observed_at: "2026-04-30T00:36:00.000Z",
+          candidate_snapshot: {
+            evidence_entry_id: "calibrated-candidate-snapshot",
+            primary_metric_label: "balanced_accuracy",
+            local_metrics: [{ label: "balanced_accuracy", value: 0.976, direction: "maximize" }],
+            robust_selection: {
+              raw_rank: 2,
+              robust_score: 0.86,
+              portfolio_role: "robust_best",
+            },
+          },
+          calibration: {
+            mode: "calibration_only",
+            use_for_selection: true,
+            direct_optimization_allowed: false,
+            minimum_observations: 2,
+            conclusion: "Second external sample keeps default lineage close to local validation.",
+          },
+          provenance: {
+            kind: "external_url",
+            external_id: "submission-robust-repeat",
+          },
+        },
+        {
+          evaluator_id: "leaderboard",
+          signal: "external",
+          source: "public-leaderboard",
+          candidate_id: "external-spike",
+          status: "passed",
+          score: 0.990,
+          score_label: "balanced_accuracy",
+          expected_score: 0.930,
+          direction: "maximize",
+          candidate_snapshot: {
+            evidence_entry_id: "calibrated-candidate-snapshot",
+            primary_metric_label: "balanced_accuracy",
+            local_metrics: [{ label: "balanced_accuracy", value: 0.930, direction: "maximize" }],
+            robust_selection: {
+              raw_rank: 3,
+              robust_score: 0.42,
+              portfolio_role: "other",
+            },
+          },
+          calibration: {
+            mode: "calibration_only",
+            use_for_selection: true,
+            direct_optimization_allowed: false,
+            minimum_observations: 2,
+            conclusion: "Single public spike is not enough to chase directly.",
+          },
+          provenance: {
+            kind: "external_url",
+            external_id: "submission-spike",
+          },
+        },
+      ],
+      summary: "External evaluator feedback is recorded as calibration evidence.",
+    });
+
+    const summary = await ledger.summarizeGoal("goal-external-calibration");
+    const selection = summary.candidate_selection_summary;
+
+    expect(selection.primary_metric).toEqual({ label: "balanced_accuracy", direction: "maximize" });
+    expect(selection.raw_best?.candidate_id).toBe("raw-local-best");
+    expect(selection.robust_best?.candidate_id).toBe("calibrated-robust");
+    expect(selection.ranked.find((candidate) => candidate.candidate_id === "raw-local-best")).toMatchObject({
+      calibration_adjustment: -0.08,
+      reasons: expect.arrayContaining(["external feedback calibrates local validation downward"]),
+    });
+    expect(selection.ranked.find((candidate) => candidate.candidate_id === "external-spike")).toMatchObject({
+      calibration_adjustment: 0,
+    });
+    expect(selection.robust_best?.candidate_id).not.toBe("external-spike");
+    expect(summary.evaluator_summary.budgets).toContainEqual(expect.objectContaining({
+      remaining_attempts: 2,
+      approval_required: true,
+      diversified_portfolio_required: true,
+      reserve_for_finalization: true,
+    }));
+    expect(summary.evaluator_summary.calibration).toContainEqual(expect.objectContaining({
+      candidate_id: "calibrated-robust",
+      direct_optimization_allowed: false,
+      local_evidence_entry_id: "calibrated-candidate-snapshot",
+      provenance: expect.objectContaining({ external_id: "submission-robust" }),
+    }));
+  });
+
   it("stores public research evidence with source URLs and applicability notes", async () => {
     const ledger = new RuntimeEvidenceLedger(runtimeRoot);
     await ledger.append({

--- a/src/runtime/store/evaluator-results.ts
+++ b/src/runtime/store/evaluator-results.ts
@@ -1,10 +1,14 @@
 import type {
   RuntimeEvidenceArtifactRef,
   RuntimeEvidenceEntry,
+  RuntimeEvidenceEvaluatorBudget,
+  RuntimeEvidenceEvaluatorCalibration,
+  RuntimeEvidenceEvaluatorCandidateSnapshot,
   RuntimeEvidenceEvaluatorObservation,
   RuntimeEvidenceEvaluatorProvenance,
   RuntimeEvidenceEvaluatorPublishAction,
   RuntimeEvidenceEvaluatorStatus,
+  RuntimeEvidenceMetric,
 } from "./evidence-ledger.js";
 
 type EvaluatorDirection = "maximize" | "minimize" | "neutral";
@@ -31,6 +35,9 @@ export interface RuntimeEvaluatorObservationContext {
   validation?: RuntimeEvidenceEvaluatorObservation["validation"];
   publish_action?: RuntimeEvidenceEvaluatorPublishAction;
   provenance?: RuntimeEvidenceEvaluatorProvenance;
+  budget?: RuntimeEvidenceEvaluatorBudget;
+  candidate_snapshot?: RuntimeEvidenceEvaluatorCandidateSnapshot;
+  calibration?: RuntimeEvidenceEvaluatorCalibration;
   summary?: string;
   raw_refs: RuntimeEvidenceEntry["raw_refs"];
 }
@@ -65,10 +72,48 @@ export interface RuntimeEvaluatorGap {
   direction?: EvaluatorDirection;
 }
 
+export interface RuntimeEvaluatorBudgetSummary {
+  evaluator_id: string;
+  source: string;
+  policy_id?: string;
+  max_attempts?: number;
+  used_attempts?: number;
+  remaining_attempts: number;
+  approval_required: boolean;
+  deadline_at?: string;
+  phase?: "exploration" | "consolidation" | "finalization" | "other";
+  diversified_portfolio_required: boolean;
+  reserve_for_finalization: boolean;
+  min_strategy_families?: number;
+  observed_at: string;
+}
+
+export interface RuntimeEvaluatorCalibrationContext {
+  evaluator_id: string;
+  source: string;
+  candidate_id: string;
+  observed_at: string;
+  local_evidence_entry_id?: string;
+  external_evidence_entry_id: string;
+  local_score?: number;
+  external_score?: number;
+  score_delta?: number;
+  direction?: EvaluatorDirection;
+  use_for_selection: boolean;
+  direct_optimization_allowed: false;
+  minimum_observations: number;
+  selection_adjustment: number;
+  conclusion: string;
+  provenance?: RuntimeEvidenceEvaluatorProvenance;
+  candidate_snapshot?: RuntimeEvidenceEvaluatorCandidateSnapshot;
+}
+
 export interface RuntimeEvaluatorSummary {
   local_best: RuntimeEvaluatorObservationContext | null;
   external_best: RuntimeEvaluatorObservationContext | null;
   gap: RuntimeEvaluatorGap | null;
+  budgets: RuntimeEvaluatorBudgetSummary[];
+  calibration: RuntimeEvaluatorCalibrationContext[];
   approval_required_actions: RuntimeEvaluatorApprovalRequiredAction[];
   observations: RuntimeEvaluatorObservationContext[];
 }
@@ -97,6 +142,8 @@ export function summarizeEvidenceEvaluatorResults(entries: RuntimeEvidenceEntry[
     local_best: localBest,
     external_best: externalBest,
     gap: classifyEvaluatorGap(localBest, externalBest, externalObservations, approvalRequiredActions),
+    budgets: summarizeEvaluatorBudgets(observations),
+    calibration: summarizeEvaluatorCalibration(observations),
     approval_required_actions: approvalRequiredActions,
     observations,
   };
@@ -128,9 +175,121 @@ function toObservationContext(
     ...(evaluator.validation ? { validation: evaluator.validation } : {}),
     ...(evaluator.publish_action ? { publish_action: evaluator.publish_action } : {}),
     ...(evaluator.provenance ? { provenance: evaluator.provenance } : {}),
+    ...(evaluator.budget ? { budget: evaluator.budget } : {}),
+    ...(evaluator.candidate_snapshot ? { candidate_snapshot: evaluator.candidate_snapshot } : {}),
+    ...(evaluator.calibration ? { calibration: evaluator.calibration } : {}),
     ...(evaluator.summary ? { summary: evaluator.summary } : {}),
     raw_refs: entry.raw_refs,
   };
+}
+
+function summarizeEvaluatorBudgets(
+  observations: RuntimeEvaluatorObservationContext[]
+): RuntimeEvaluatorBudgetSummary[] {
+  const latest = new Map<string, RuntimeEvaluatorBudgetSummary>();
+  for (const observation of observations) {
+    if (!observation.budget) continue;
+    const policyId = observation.budget.policy_id ?? "default";
+    const key = `${observation.evaluator_id}:${observation.source}:${policyId}`;
+    const summary: RuntimeEvaluatorBudgetSummary = {
+      evaluator_id: observation.evaluator_id,
+      source: observation.source,
+      ...(observation.budget.policy_id ? { policy_id: observation.budget.policy_id } : {}),
+      ...(observation.budget.max_attempts !== undefined ? { max_attempts: observation.budget.max_attempts } : {}),
+      ...(observation.budget.used_attempts !== undefined ? { used_attempts: observation.budget.used_attempts } : {}),
+      remaining_attempts: observation.budget.remaining_attempts,
+      approval_required: observation.budget.approval_required,
+      ...(observation.budget.deadline_at ? { deadline_at: observation.budget.deadline_at } : {}),
+      ...(observation.budget.phase ? { phase: observation.budget.phase } : {}),
+      diversified_portfolio_required: observation.budget.portfolio_policy?.diversified_portfolio_required ?? false,
+      reserve_for_finalization: observation.budget.portfolio_policy?.reserve_for_finalization ?? false,
+      ...(observation.budget.portfolio_policy?.min_strategy_families
+        ? { min_strategy_families: observation.budget.portfolio_policy.min_strategy_families }
+        : {}),
+      observed_at: observation.observed_at,
+    };
+    const existing = latest.get(key);
+    if (!existing || existing.observed_at <= summary.observed_at) latest.set(key, summary);
+  }
+  return [...latest.values()].sort((a, b) =>
+    a.evaluator_id.localeCompare(b.evaluator_id)
+    || a.source.localeCompare(b.source)
+    || a.observed_at.localeCompare(b.observed_at)
+  );
+}
+
+function summarizeEvaluatorCalibration(
+  observations: RuntimeEvaluatorObservationContext[]
+): RuntimeEvaluatorCalibrationContext[] {
+  return observations
+    .filter((observation) => observation.signal === "external" && observation.calibration?.mode === "calibration_only")
+    .map((observation) => toCalibrationContext(observation))
+    .filter((calibration): calibration is RuntimeEvaluatorCalibrationContext => Boolean(calibration))
+    .sort((a, b) => a.observed_at.localeCompare(b.observed_at));
+}
+
+function toCalibrationContext(
+  observation: RuntimeEvaluatorObservationContext
+): RuntimeEvaluatorCalibrationContext | null {
+  const calibration = observation.calibration;
+  if (!calibration) return null;
+  const externalScore = numericScore(observation.score);
+  const localScore = candidateSnapshotPrimaryScore(observation);
+  const direction = observation.direction;
+  const scoreDelta = externalScore !== null && localScore !== null ? externalScore - localScore : undefined;
+  const directionalGap = scoreDelta === undefined || !direction || direction === "neutral"
+    ? 0
+    : direction === "maximize"
+      ? scoreDelta
+      : -scoreDelta;
+  return {
+    evaluator_id: observation.evaluator_id,
+    source: observation.source,
+    candidate_id: observation.candidate_id,
+    observed_at: observation.observed_at,
+    ...(observation.candidate_snapshot?.evidence_entry_id ? { local_evidence_entry_id: observation.candidate_snapshot.evidence_entry_id } : {}),
+    external_evidence_entry_id: observation.entry_id,
+    ...(localScore !== null ? { local_score: localScore } : {}),
+    ...(externalScore !== null ? { external_score: externalScore } : {}),
+    ...(scoreDelta !== undefined ? { score_delta: scoreDelta } : {}),
+    ...(direction ? { direction } : {}),
+    use_for_selection: calibration.use_for_selection,
+    direct_optimization_allowed: false,
+    minimum_observations: calibration.minimum_observations,
+    selection_adjustment: roundCalibrationAdjustment(directionalGap * 4),
+    conclusion: calibration.conclusion ?? "External evaluator feedback is calibration evidence only; primary optimization remains local validation.",
+    ...(observation.provenance ? { provenance: observation.provenance } : {}),
+    ...(observation.candidate_snapshot ? { candidate_snapshot: observation.candidate_snapshot } : {}),
+  };
+}
+
+function candidateSnapshotPrimaryScore(observation: RuntimeEvaluatorObservationContext): number | null {
+  const metrics = observation.candidate_snapshot?.local_metrics ?? [];
+  const metric = findLocalMetricForExternalScore(metrics, observation.score_label)
+    ?? findLocalMetricForExternalScore(metrics, observation.candidate_snapshot?.primary_metric_label);
+  return typeof metric?.value === "number" ? metric.value : null;
+}
+
+function findLocalMetricForExternalScore(
+  metrics: RuntimeEvidenceMetric[],
+  scoreLabel: string | undefined
+): RuntimeEvidenceMetric | undefined {
+  if (!scoreLabel) return undefined;
+  const normalizedScoreLabel = normalizeMetricLabel(scoreLabel);
+  return metrics.find((metric) =>
+    normalizeMetricLabel(metric.label) === normalizedScoreLabel
+    && typeof metric.value === "number"
+    && Number.isFinite(metric.value)
+  );
+}
+
+function normalizeMetricLabel(label: string): string {
+  return label.normalize("NFKC").toLocaleLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function roundCalibrationAdjustment(value: number): number {
+  const clamped = Math.min(0.08, Math.max(-0.08, Number.isFinite(value) ? value : 0));
+  return Math.round(clamped * 1_000_000) / 1_000_000;
 }
 
 function selectArtifacts(

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -10,6 +10,7 @@ import {
 import { summarizeEvidenceMetricTrends, type MetricTrendContext } from "./metric-history.js";
 import {
   summarizeEvidenceEvaluatorResults,
+  type RuntimeEvaluatorCalibrationContext,
   type RuntimeEvaluatorSummary,
 } from "./evaluator-results.js";
 import {
@@ -199,6 +200,47 @@ export const RuntimeEvidenceEvaluatorProvenanceSchema = z.object({
 }).strict();
 export type RuntimeEvidenceEvaluatorProvenance = z.infer<typeof RuntimeEvidenceEvaluatorProvenanceSchema>;
 
+export const RuntimeEvidenceEvaluatorBudgetSchema = z.object({
+  policy_id: z.string().min(1).optional(),
+  max_attempts: z.number().int().positive().optional(),
+  used_attempts: z.number().int().nonnegative().optional(),
+  remaining_attempts: z.number().int().nonnegative(),
+  approval_required: z.boolean().default(true),
+  deadline_at: z.string().datetime().optional(),
+  phase: z.enum(["exploration", "consolidation", "finalization", "other"]).optional(),
+  portfolio_policy: z.object({
+    diversified_portfolio_required: z.boolean().default(false),
+    reserve_for_finalization: z.boolean().default(false),
+    min_strategy_families: z.number().int().positive().optional(),
+  }).strict().optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorBudget = z.infer<typeof RuntimeEvidenceEvaluatorBudgetSchema>;
+
+export const RuntimeEvidenceEvaluatorCandidateSnapshotSchema = z.object({
+  evidence_entry_id: z.string().min(1).optional(),
+  primary_metric_label: z.string().min(1).optional(),
+  local_metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
+  robust_selection: z.object({
+    raw_rank: z.number().int().positive().optional(),
+    robust_score: z.number().min(0).max(1).optional(),
+    stability_score: z.number().min(0).max(1).optional(),
+    diversity_score: z.number().min(0).max(1).optional(),
+    risk_penalty: z.number().min(0).max(1).optional(),
+    portfolio_role: z.enum(["raw_best", "robust_best", "safe", "aggressive", "diverse", "near_miss", "other"]).optional(),
+  }).strict().optional(),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorCandidateSnapshot = z.infer<typeof RuntimeEvidenceEvaluatorCandidateSnapshotSchema>;
+
+export const RuntimeEvidenceEvaluatorCalibrationSchema = z.object({
+  mode: z.literal("calibration_only").default("calibration_only"),
+  use_for_selection: z.boolean().default(false),
+  direct_optimization_allowed: z.literal(false).default(false),
+  minimum_observations: z.number().int().positive().default(1),
+  conclusion: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorCalibration = z.infer<typeof RuntimeEvidenceEvaluatorCalibrationSchema>;
+
 export const RuntimeEvidenceEvaluatorObservationSchema = z.object({
   evaluator_id: z.string().min(1),
   signal: RuntimeEvidenceEvaluatorSignalSchema,
@@ -217,6 +259,9 @@ export const RuntimeEvidenceEvaluatorObservationSchema = z.object({
   validation: RuntimeEvidenceEvaluatorValidationSchema.optional(),
   publish_action: RuntimeEvidenceEvaluatorPublishActionSchema.optional(),
   provenance: RuntimeEvidenceEvaluatorProvenanceSchema.optional(),
+  budget: RuntimeEvidenceEvaluatorBudgetSchema.optional(),
+  candidate_snapshot: RuntimeEvidenceEvaluatorCandidateSnapshotSchema.optional(),
+  calibration: RuntimeEvidenceEvaluatorCalibrationSchema.optional(),
   summary: z.string().min(1).optional(),
 }).strict();
 export type RuntimeEvidenceEvaluatorObservation = z.infer<typeof RuntimeEvidenceEvaluatorObservationSchema>;
@@ -546,6 +591,7 @@ export interface RuntimeCandidateSelectionCandidate {
     confidence: number;
   };
   robust_score: number;
+  calibration_adjustment: number;
   metric_score: number;
   stability_score: number;
   diversity_score: number;
@@ -768,6 +814,8 @@ function isCurrentEvidenceSummaryShape(summary: RuntimeEvidenceSummary): boolean
   return Array.isArray(summary.candidate_lineages)
     && Array.isArray(summary.recommended_candidate_portfolio)
     && Array.isArray(summary.near_miss_candidates)
+    && Array.isArray(summary.evaluator_summary.budgets)
+    && Array.isArray(summary.evaluator_summary.calibration)
     && typeof summary.candidate_selection_summary === "object"
     && summary.candidate_selection_summary !== null;
 }
@@ -835,6 +883,7 @@ function summarizeEvidence(
 ): RuntimeEvidenceSummary {
   const entries = [...read.entries].sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
   const newestFirst = [...entries].reverse();
+  const evaluatorSummary = summarizeEvidenceEvaluatorResults(entries);
   return {
     schema_version: "runtime-evidence-summary-v1",
     generated_at: new Date().toISOString(),
@@ -845,7 +894,7 @@ function summarizeEvidence(
     ) ?? null,
     best_evidence: chooseBestEvidence(newestFirst),
     metric_trends: summarizeEvidenceMetricTrends(entries),
-    evaluator_summary: summarizeEvidenceEvaluatorResults(entries),
+    evaluator_summary: evaluatorSummary,
     research_memos: summarizeEvidenceResearchMemos(entries),
     dream_checkpoints: summarizeEvidenceDreamCheckpoints(entries),
     divergent_exploration: entries
@@ -854,7 +903,7 @@ function summarizeEvidence(
       .reverse(),
     candidate_lineages: summarizeCandidateLineages(entries),
     recommended_candidate_portfolio: selectDiversifiedCandidatePortfolio(entries),
-    candidate_selection_summary: summarizeCandidateSelection(entries),
+    candidate_selection_summary: summarizeCandidateSelection(entries, evaluatorSummary),
     near_miss_candidates: summarizeNearMissCandidates(entries),
     recent_failed_attempts: newestFirst
       .filter((entry) =>
@@ -927,12 +976,15 @@ export function selectDiversifiedCandidatePortfolio(
   return selected.map(toPortfolioSlot);
 }
 
-function summarizeCandidateSelection(entriesOldestFirst: RuntimeEvidenceEntry[]): RuntimeCandidateSelectionSummary {
+function summarizeCandidateSelection(
+  entriesOldestFirst: RuntimeEvidenceEntry[],
+  evaluatorSummary?: RuntimeEvaluatorSummary
+): RuntimeCandidateSelectionSummary {
   const primaryMetric = resolvePrimaryCandidateMetricKey(entriesOldestFirst);
   const contexts = extractCandidateEvidenceContexts(entriesOldestFirst, primaryMetric)
     .filter((context) => context.candidate.disposition !== "retired");
   const rawRanked = [...contexts].sort(compareCandidateEvidenceContexts);
-  const scored = scoreCandidateSelectionContexts(rawRanked);
+  const scored = scoreCandidateSelectionContexts(rawRanked, evaluatorSummary?.calibration ?? []);
   const ranked = [...scored].sort((a, b) => b.robust_score - a.robust_score || a.raw_rank - b.raw_rank);
   const rawBest = scored.find((candidate) => candidate.raw_rank === 1) ?? null;
   const robustBest = ranked[0] ?? null;
@@ -951,7 +1003,8 @@ function summarizeCandidateSelection(entriesOldestFirst: RuntimeEvidenceEntry[])
 }
 
 function scoreCandidateSelectionContexts(
-  rawRanked: CandidateEvidenceContext[]
+  rawRanked: CandidateEvidenceContext[],
+  calibration: RuntimeEvaluatorCalibrationContext[] = []
 ): RuntimeCandidateSelectionCandidate[] {
   const metricValues = rawRanked
     .map((context) => context.metric?.value)
@@ -971,8 +1024,9 @@ function scoreCandidateSelectionContexts(
       : Math.min(candidate.robustness.diversity_score, inferredDiversity));
     const riskPenalty = clamp01(candidate.robustness?.risk_penalty ?? inferredCandidateRiskPenalty(candidate));
     const evidenceConfidence = clamp01(candidate.robustness?.evidence_confidence ?? context.metric?.confidence ?? 0.5);
+    const calibrationAdjustment = evaluatorCalibrationAdjustment(candidate.candidate_id, calibration);
     const robustScore = clamp01(candidate.robustness?.robust_score
-      ?? (metricScore * 0.45 + stabilityScore * 0.3 + diversityScore * 0.15 + evidenceConfidence * 0.1 - riskPenalty));
+      ?? (metricScore * 0.45 + stabilityScore * 0.3 + diversityScore * 0.15 + evidenceConfidence * 0.1 - riskPenalty + calibrationAdjustment));
 
     return {
       candidate_id: candidate.candidate_id,
@@ -982,6 +1036,7 @@ function scoreCandidateSelectionContexts(
       raw_rank: index + 1,
       ...(context.metric ? { raw_metric: context.metric } : {}),
       robust_score: roundScore(robustScore),
+      calibration_adjustment: roundScore(calibrationAdjustment),
       metric_score: roundScore(metricScore),
       stability_score: roundScore(stabilityScore),
       diversity_score: roundScore(diversityScore),
@@ -993,9 +1048,25 @@ function scoreCandidateSelectionContexts(
         diversityScore,
         riskPenalty,
         evidenceConfidence,
+        calibrationAdjustment,
       }),
     };
   });
+}
+
+function evaluatorCalibrationAdjustment(
+  candidateId: string,
+  calibration: RuntimeEvaluatorCalibrationContext[]
+): number {
+  const relevant = calibration.filter((item) =>
+    item.candidate_id === candidateId
+    && item.use_for_selection
+    && item.direct_optimization_allowed === false
+  );
+  if (relevant.length === 0) return 0;
+  const average = relevant.reduce((sum, item) => sum + item.selection_adjustment, 0) / relevant.length;
+  if (relevant.length < Math.max(...relevant.map((item) => item.minimum_observations))) return 0;
+  return Math.min(0.08, Math.max(-0.08, average));
 }
 
 function normalizedMetricScore(
@@ -1061,6 +1132,7 @@ function candidateSelectionReasons(
     diversityScore: number;
     riskPenalty: number;
     evidenceConfidence: number;
+    calibrationAdjustment: number;
   }
 ): string[] {
   const reasons: string[] = [];
@@ -1068,6 +1140,8 @@ function candidateSelectionReasons(
   if (scores.diversityScore >= 0.8) reasons.push("diverse lineage");
   if (scores.riskPenalty >= 0.15) reasons.push("penalized for overfit-prone lineage or post-processing");
   if (scores.metricScore >= 0.95) reasons.push("top raw metric evidence");
+  if (scores.calibrationAdjustment > 0) reasons.push("external feedback calibrates local validation upward");
+  if (scores.calibrationAdjustment < 0) reasons.push("external feedback calibrates local validation downward");
   if (candidate.robustness?.summary) reasons.push(candidate.robustness.summary);
   return reasons.length > 0 ? reasons : ["risk-adjusted candidate evidence"];
 }

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -104,6 +104,9 @@ export {
 
 export {
   RuntimeEvidenceArtifactRefSchema,
+  RuntimeEvidenceEvaluatorBudgetSchema,
+  RuntimeEvidenceEvaluatorCalibrationSchema,
+  RuntimeEvidenceEvaluatorCandidateSnapshotSchema,
   RuntimeEvidenceEvaluatorObservationSchema,
   RuntimeEvidenceEvaluatorProvenanceSchema,
   RuntimeEvidenceEvaluatorPublishActionSchema,
@@ -127,6 +130,9 @@ export {
 } from "./evidence-ledger.js";
 export type {
   RuntimeEvidenceArtifactRef,
+  RuntimeEvidenceEvaluatorBudget,
+  RuntimeEvidenceEvaluatorCalibration,
+  RuntimeEvidenceEvaluatorCandidateSnapshot,
   RuntimeEvidenceEvaluatorObservation,
   RuntimeEvidenceEvaluatorProvenance,
   RuntimeEvidenceEvaluatorPublishAction,
@@ -183,6 +189,8 @@ export type {
 } from "./research-evidence.js";
 export type {
   RuntimeEvaluatorApprovalRequiredAction,
+  RuntimeEvaluatorBudgetSummary,
+  RuntimeEvaluatorCalibrationContext,
   RuntimeEvaluatorGap,
   RuntimeEvaluatorGapKind,
   RuntimeEvaluatorObservationContext,


### PR DESCRIPTION
Closes #815

## Summary
- Add evaluator budget, candidate snapshot, and calibration-only metadata to runtime evidence.
- Summarize evaluator budget/remaining attempts, diversified portfolio policy, and calibration contexts with provenance.
- Apply external feedback only as capped calibration after enough labeled observations, while keeping local validation as the primary candidate metric.

## Verification
- npx vitest run src/runtime/__tests__/runtime-evaluator-results.test.ts src/runtime/__tests__/runtime-evidence-ledger.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed (known pre-existing timeout in src/interface/cli/__tests__/cli-runner-integration.test.ts; related runtime tests passed)
- git diff --check

## Known unresolved risks
- npm run test:changed continues to hit the pre-existing CLI runner integration 60s timeout seen on earlier PRs; focused runtime evaluator/evidence coverage passes.