### PR TITLE
feat(runtime): add reproducibility manifests

### DIFF
--- a/src/orchestrator/goal/types/goal.ts
+++ b/src/orchestrator/goal/types/goal.ts
@@ -143,6 +143,7 @@ export const GoalFinalizationPolicySchema = z.object({
   consolidation_buffer_ms: z.number().int().nonnegative().default(0),
   deliverable_contract: z.string().min(1).optional(),
   best_artifact_selection: z.enum(["best_evidence", "latest_artifact", "latest_verified"]).default("best_evidence"),
+  require_reproducibility_manifest: z.boolean().default(false),
   verification_steps: z.array(z.string().min(1)).default([]),
   external_actions: z.array(GoalFinalizationExternalActionSchema).default([]),
 }).strict();

--- a/src/orchestrator/loop/__tests__/core-loop-decision-engine.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-decision-engine.test.ts
@@ -99,6 +99,11 @@ describe("CoreDecisionEngine", () => {
             deliverable_contract: "Prepare final report",
             best_artifact_selection: "best_evidence",
             best_artifact: null,
+            reproducibility_manifest: {
+              required: false,
+              status: "not_required",
+              reason: "Reproducibility manifest is not required by this finalization policy.",
+            },
             verification_steps: [],
             approval_required_actions: [],
             handoff_required: false,

--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -39,6 +39,7 @@ import { CapabilityDetector } from "../../../platform/observation/capability-det
 import { ApprovalStore } from "../../../runtime/store/approval-store.js";
 import { WaitDeadlineResolver, getDueWaitGoalIds } from "../../../runtime/daemon/wait-deadline-resolver.js";
 import { RuntimeEvidenceLedger } from "../../../runtime/store/evidence-ledger.js";
+import { RuntimeReproducibilityManifestStore } from "../../../runtime/store/reproducibility-manifest.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { makeDimension, makeGoal } from "../../../../tests/helpers/fixtures.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
@@ -418,6 +419,7 @@ describe("CoreLoop", async () => {
           consolidation_buffer_ms: 0,
           deliverable_contract: "Package the latest benchmark report",
           best_artifact_selection: "best_evidence",
+          require_reproducibility_manifest: false,
           verification_steps: ["Run final smoke test"],
           external_actions: [
             {
@@ -508,6 +510,7 @@ describe("CoreLoop", async () => {
           minimum_buffer_ms: 30 * 60_000,
           consolidation_buffer_ms: 10 * 60_000,
           best_artifact_selection: "best_evidence",
+          require_reproducibility_manifest: false,
           verification_steps: [],
           external_actions: [],
         },
@@ -537,6 +540,7 @@ describe("CoreLoop", async () => {
           minimum_buffer_ms: 30 * 60_000,
           consolidation_buffer_ms: 0,
           best_artifact_selection: "latest_artifact",
+          require_reproducibility_manifest: false,
           verification_steps: [],
           external_actions: [],
         },
@@ -588,6 +592,7 @@ describe("CoreLoop", async () => {
           minimum_buffer_ms: 30 * 60_000,
           consolidation_buffer_ms: 0,
           best_artifact_selection: "best_evidence",
+          require_reproducibility_manifest: false,
           verification_steps: [],
           external_actions: [],
         },
@@ -625,6 +630,116 @@ describe("CoreLoop", async () => {
       });
     });
 
+    it("observes a ready reproducibility manifest before final handoff", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      const deadline = new Date(Date.now() + 10 * 60_000).toISOString();
+      await mocks.stateManager.saveGoal(makeGoal({
+        deadline,
+        finalization_policy: {
+          minimum_buffer_ms: 30 * 60_000,
+          consolidation_buffer_ms: 0,
+          best_artifact_selection: "latest_artifact",
+          require_reproducibility_manifest: true,
+          verification_steps: [],
+          external_actions: [],
+        },
+      }));
+
+      const runtimeRoot = path.join(tmpDir, "runtime");
+      await fs.promises.mkdir(path.join(runtimeRoot, "runs/final"), { recursive: true });
+      await fs.promises.writeFile(path.join(runtimeRoot, "runs/final/report.md"), "# Final report\n", "utf8");
+      const evidenceLedger = new RuntimeEvidenceLedger(runtimeRoot);
+      await evidenceLedger.append({
+        id: "final-artifact",
+        occurred_at: "2026-04-30T00:10:00.000Z",
+        kind: "artifact",
+        scope: { goal_id: "goal-1" },
+        artifacts: [{ label: "reports/final.md", state_relative_path: "runs/final/report.md", kind: "report" }],
+        summary: "Final artifact ready.",
+        outcome: "improved",
+      });
+      const manifest = await new RuntimeReproducibilityManifestStore(runtimeRoot).createOrUpdateForCandidate({
+        goalId: "goal-1",
+        deliverableArtifact: {
+          label: "reports/final.md",
+          kind: "report",
+          state_relative_path: "runs/final/report.md",
+          source: "runtime_evidence_ledger",
+        },
+        codeState: { commit: "abc123", dirty: false },
+      });
+
+      const loop = new CoreLoop(
+        { ...deps, evidenceLedger },
+        { delayBetweenLoopsMs: 0, autoDecompose: false }
+      );
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(result.finalizationStatus?.finalization_plan).toMatchObject({
+        reproducibility_manifest: {
+          required: true,
+          status: "ready",
+          manifest_id: manifest.manifest_id,
+        },
+        handoff_required: false,
+      });
+    });
+
+    it("does not accept a ready manifest when no final artifact is selected", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      const deadline = new Date(Date.now() + 10 * 60_000).toISOString();
+      await mocks.stateManager.saveGoal(makeGoal({
+        deadline,
+        finalization_policy: {
+          minimum_buffer_ms: 30 * 60_000,
+          consolidation_buffer_ms: 0,
+          best_artifact_selection: "latest_verified",
+          require_reproducibility_manifest: true,
+          verification_steps: [],
+          external_actions: [],
+        },
+      }));
+
+      const runtimeRoot = path.join(tmpDir, "runtime");
+      await fs.promises.mkdir(path.join(runtimeRoot, "runs/final"), { recursive: true });
+      await fs.promises.writeFile(path.join(runtimeRoot, "runs/final/report.md"), "# Final report\n", "utf8");
+      const evidenceLedger = new RuntimeEvidenceLedger(runtimeRoot);
+      await evidenceLedger.append({
+        id: "unverified-final-artifact",
+        occurred_at: "2026-04-30T00:10:00.000Z",
+        kind: "artifact",
+        scope: { goal_id: "goal-1" },
+        artifacts: [{ label: "reports/final.md", state_relative_path: "runs/final/report.md", kind: "report" }],
+        summary: "Unverified artifact ready.",
+        outcome: "continued",
+      });
+      await new RuntimeReproducibilityManifestStore(runtimeRoot).createOrUpdateForCandidate({
+        goalId: "goal-1",
+        deliverableArtifact: {
+          label: "reports/final.md",
+          kind: "report",
+          state_relative_path: "runs/final/report.md",
+          source: "runtime_evidence_ledger",
+        },
+        codeState: { commit: "abc123", dirty: false },
+      });
+
+      const loop = new CoreLoop(
+        { ...deps, evidenceLedger },
+        { delayBetweenLoopsMs: 0, autoDecompose: false }
+      );
+      const result = await loop.runOneIteration("goal-1", 0);
+
+      expect(result.finalizationStatus?.finalization_plan).toMatchObject({
+        best_artifact: null,
+        reproducibility_manifest: {
+          required: true,
+          status: "required_missing",
+        },
+        handoff_required: true,
+      });
+    });
+
     it("can select the latest verified artifact for finalization", async () => {
       const { deps, mocks } = createMockDeps(tmpDir);
       const deadline = new Date(Date.now() + 10 * 60_000).toISOString();
@@ -634,6 +749,7 @@ describe("CoreLoop", async () => {
           minimum_buffer_ms: 30 * 60_000,
           consolidation_buffer_ms: 0,
           best_artifact_selection: "latest_verified",
+          require_reproducibility_manifest: false,
           verification_steps: [],
           external_actions: [],
         },

--- a/src/orchestrator/loop/core-loop/iteration-kernel.ts
+++ b/src/orchestrator/loop/core-loop/iteration-kernel.ts
@@ -1,4 +1,5 @@
 import type { Logger } from "../../../runtime/logger.js";
+import * as path from "node:path";
 import type { StateDiffCalculator } from "../state-diff.js";
 import { generateLoopReport } from "../loop-report-helper.js";
 import { makeEmptyIterationResult } from "../loop-result-types.js";
@@ -80,6 +81,7 @@ import type {
   RuntimeEvidenceOutcome,
   RuntimeEvidenceSummary,
 } from "../../../runtime/store/evidence-ledger.js";
+import { RuntimeReproducibilityManifestStore } from "../../../runtime/store/reproducibility-manifest.js";
 import type { TaskCycleResult } from "../../execution/task/task-execution-types.js";
 
 export interface CoreIterationKernelDeps {
@@ -341,16 +343,25 @@ export class CoreIterationKernel {
         .join(", ")}`
     );
 
-    const finalizationStatus = await runPhase("deadline-finalization", async () =>
-      buildDeadlineFinalizationStatus({
+    const finalizationStatus = await runPhase("deadline-finalization", async () => {
+      const bestArtifact = await loadBestFinalizationArtifact(
+        this.deps.deps.evidenceLedger,
+        goalId,
+        normalizeFinalizationPolicy(goal.finalization_policy).best_artifact_selection
+      );
+      const reproducibilityManifestId = await loadReadyFinalizationManifestId({
+        stateManager: this.deps.deps.stateManager,
+        goalId,
+        runId: runtimeEvidenceScope.run_id,
+        bestArtifact,
+        requireReproducibilityManifest: normalizeFinalizationPolicy(goal.finalization_policy).require_reproducibility_manifest,
+      });
+      return buildDeadlineFinalizationStatus({
         goal,
-        bestArtifact: await loadBestFinalizationArtifact(
-          this.deps.deps.evidenceLedger,
-          goalId,
-          normalizeFinalizationPolicy(goal.finalization_policy).best_artifact_selection
-        ),
-      })
-    );
+        bestArtifact,
+        reproducibilityManifestId,
+      });
+    });
     result.finalizationStatus = finalizationStatus;
     const executionMode = deriveExecutionModeFromDeadlineStatus(finalizationStatus);
     result.executionMode = executionMode;
@@ -943,6 +954,36 @@ async function loadBestFinalizationArtifact(
         ? newestFirst.find((entry) => entry.artifacts.length > 0 || entry.kind === "artifact")
         : selectLatestVerifiedArtifact(newestFirst);
     return selected ? bestArtifactFromEvidence(selected) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadReadyFinalizationManifestId(input: {
+  stateManager: CoreLoopDeps["stateManager"];
+  goalId: string;
+  runId?: string;
+  bestArtifact: DeadlineFinalizationArtifact | null;
+  requireReproducibilityManifest: boolean;
+}): Promise<string | null> {
+  if (!input.requireReproducibilityManifest) return null;
+  if (!input.bestArtifact) return null;
+  try {
+    const store = new RuntimeReproducibilityManifestStore(path.join(input.stateManager.getBaseDir(), "runtime"));
+    const manifest = await store.findReadyForFinalization({
+      goalId: input.goalId,
+      runId: input.runId,
+      deliverable: input.bestArtifact
+        ? {
+            ...(input.bestArtifact.id ? { id: input.bestArtifact.id } : {}),
+            label: input.bestArtifact.label,
+            ...(input.bestArtifact.path ? { path: input.bestArtifact.path } : {}),
+            ...(input.bestArtifact.state_relative_path ? { state_relative_path: input.bestArtifact.state_relative_path } : {}),
+            ...(input.bestArtifact.url ? { url: input.bestArtifact.url } : {}),
+          }
+        : null,
+    });
+    return manifest?.manifest_id ?? null;
   } catch {
     return null;
   }

--- a/src/platform/time/__tests__/deadline-finalization.test.ts
+++ b/src/platform/time/__tests__/deadline-finalization.test.ts
@@ -19,6 +19,7 @@ function finalizationPolicy(
     minimum_buffer_ms: 30 * 60_000,
     consolidation_buffer_ms: 0,
     best_artifact_selection: "best_evidence" as const,
+    require_reproducibility_manifest: false,
     verification_steps: [],
     external_actions: [],
     ...overrides,
@@ -91,6 +92,10 @@ describe("deadline finalization planning", () => {
     expect(status.finalization_plan).toMatchObject({
       deliverable_contract: "Final report ready for handoff",
       best_artifact: { label: "best-report.md" },
+      reproducibility_manifest: {
+        required: false,
+        status: "not_required",
+      },
       verification_steps: ["Run smoke test", "Confirm artifact path"],
     });
     expect(shouldStopExplorationForFinalization(status)).toBe(true);
@@ -139,5 +144,41 @@ describe("deadline finalization planning", () => {
       },
     ]);
     expect(status.finalization_plan?.handoff_required).toBe(true);
+  });
+
+  it("can require a reproducibility manifest before final delivery", () => {
+    const missing = buildDeadlineFinalizationStatus({
+      goal: makeGoal({
+        deadline: deadlineIn(10 * 60_000),
+        finalization_policy: finalizationPolicy({
+          require_reproducibility_manifest: true,
+        }),
+      }),
+      now: NOW,
+    });
+
+    expect(missing.finalization_plan?.reproducibility_manifest).toMatchObject({
+      required: true,
+      status: "required_missing",
+    });
+    expect(missing.finalization_plan?.handoff_required).toBe(true);
+
+    const ready = buildDeadlineFinalizationStatus({
+      goal: makeGoal({
+        deadline: deadlineIn(10 * 60_000),
+        finalization_policy: finalizationPolicy({
+          require_reproducibility_manifest: true,
+        }),
+      }),
+      now: NOW,
+      reproducibilityManifestId: "candidate:run:final:candidate-a",
+    });
+
+    expect(ready.finalization_plan?.reproducibility_manifest).toMatchObject({
+      required: true,
+      status: "ready",
+      manifest_id: "candidate:run:final:candidate-a",
+    });
+    expect(ready.finalization_plan?.handoff_required).toBe(false);
   });
 });

--- a/src/platform/time/deadline-finalization.ts
+++ b/src/platform/time/deadline-finalization.ts
@@ -35,9 +35,17 @@ export interface DeadlineFinalizationPlan {
   deliverable_contract: string | null;
   best_artifact_selection: GoalFinalizationPolicy["best_artifact_selection"];
   best_artifact: DeadlineFinalizationArtifact | null;
+  reproducibility_manifest: DeadlineReproducibilityManifestPreflight;
   verification_steps: string[];
   approval_required_actions: DeadlineFinalizationAction[];
   handoff_required: boolean;
+}
+
+export interface DeadlineReproducibilityManifestPreflight {
+  required: boolean;
+  status: "not_required" | "required_missing" | "ready";
+  manifest_id?: string;
+  reason: string;
 }
 
 export interface DeadlineFinalizationStatus {
@@ -56,12 +64,14 @@ export interface BuildDeadlineFinalizationStatusInput {
   goal: Goal;
   now?: Date;
   bestArtifact?: DeadlineFinalizationArtifact | null;
+  reproducibilityManifestId?: string | null;
 }
 
 export const DEFAULT_FINALIZATION_POLICY: GoalFinalizationPolicy = {
   minimum_buffer_ms: 30 * 60 * 1000,
   consolidation_buffer_ms: 0,
   best_artifact_selection: "best_evidence",
+  require_reproducibility_manifest: false,
   verification_steps: [],
   external_actions: [],
 };
@@ -126,7 +136,7 @@ export function buildDeadlineFinalizationStatus(
     reserved_finalization_ms: policy.minimum_buffer_ms,
     remaining_exploration_ms: remainingExplorationMs,
     consolidation_buffer_ms: policy.consolidation_buffer_ms,
-    finalization_plan: buildFinalizationPlan(policy, input.bestArtifact ?? null),
+    finalization_plan: buildFinalizationPlan(policy, input.bestArtifact ?? null, input.reproducibilityManifestId ?? null),
     reason: buildReason(mode, remainingMs, policy),
   };
 }
@@ -149,7 +159,8 @@ function classifyFinalizationMode(
 
 function buildFinalizationPlan(
   policy: GoalFinalizationPolicy,
-  bestArtifact: DeadlineFinalizationArtifact | null
+  bestArtifact: DeadlineFinalizationArtifact | null,
+  reproducibilityManifestId: string | null
 ): DeadlineFinalizationPlan {
   const approvalActions = policy.external_actions.map((action) => ({
     id: action.id,
@@ -159,13 +170,41 @@ function buildFinalizationPlan(
     approval_required: true as const,
   }));
 
+  const reproducibilityManifest = buildReproducibilityManifestPreflight(policy, reproducibilityManifestId);
   return {
     deliverable_contract: policy.deliverable_contract ?? null,
     best_artifact_selection: policy.best_artifact_selection,
     best_artifact: bestArtifact,
+    reproducibility_manifest: reproducibilityManifest,
     verification_steps: [...policy.verification_steps],
     approval_required_actions: approvalActions,
-    handoff_required: approvalActions.length > 0,
+    handoff_required: approvalActions.length > 0 || reproducibilityManifest.status === "required_missing",
+  };
+}
+
+function buildReproducibilityManifestPreflight(
+  policy: GoalFinalizationPolicy,
+  manifestId: string | null
+): DeadlineReproducibilityManifestPreflight {
+  if (!policy.require_reproducibility_manifest) {
+    return {
+      required: false,
+      status: "not_required",
+      reason: "Reproducibility manifest is not required by this finalization policy.",
+    };
+  }
+  if (manifestId) {
+    return {
+      required: true,
+      status: "ready",
+      manifest_id: manifestId,
+      reason: "Reproducibility manifest is ready before delivery/submission.",
+    };
+  }
+  return {
+    required: true,
+    status: "required_missing",
+    reason: "Reproducibility manifest is required before delivery/submission.",
   };
 }
 

--- a/src/runtime/__tests__/reproducibility-manifest.test.ts
+++ b/src/runtime/__tests__/reproducibility-manifest.test.ts
@@ -1,0 +1,284 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { createHash } from "node:crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
+import { RuntimeEvidenceLedger } from "../store/evidence-ledger.js";
+import { RuntimeReproducibilityManifestStore } from "../store/reproducibility-manifest.js";
+
+describe("RuntimeReproducibilityManifestStore", () => {
+  let runtimeRoot: string;
+  let workspaceDir: string;
+
+  beforeEach(async () => {
+    runtimeRoot = makeTempDir("pulseed-runtime-manifest-");
+    workspaceDir = makeTempDir("pulseed-workspace-manifest-");
+    await fsp.mkdir(path.join(runtimeRoot, "runs/final"), { recursive: true });
+    await fsp.mkdir(path.join(workspaceDir, "configs"), { recursive: true });
+    await fsp.mkdir(path.join(workspaceDir, "data"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(runtimeRoot, { recursive: true, force: true });
+    await fsp.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("creates a manifest for a selected candidate with artifact, config, data, and code provenance", async () => {
+    await fsp.writeFile(path.join(runtimeRoot, "runs/final/submission.csv"), "id,target\n1,0\n", "utf8");
+    await fsp.writeFile(path.join(runtimeRoot, "runs/final/metrics.json"), "{\"balanced_accuracy\":0.976}\n", "utf8");
+    await fsp.writeFile(path.join(workspaceDir, "configs/train.json"), "{\"seed\":314}\n", "utf8");
+    await fsp.writeFile(path.join(workspaceDir, "data/train.csv"), "id,x\n1,2\n", "utf8");
+
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "candidate-final-snapshot",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-manifest", run_id: "run:coreloop:manifest" },
+      candidates: [{
+        candidate_id: "cb_focus_base_default_rs314",
+        label: "CatBoost default rs314",
+        lineage: {
+          parent_candidate_id: "cb_focus_base",
+          source_strategy_id: "strategy-catboost-default",
+          strategy_family: "catboost_default",
+          feature_lineage: ["focus-base"],
+          model_lineage: ["catboost"],
+          config_lineage: ["configs/train.json"],
+          seed_lineage: ["seed-314"],
+          fold_lineage: ["5-fold-oof"],
+          postprocess_lineage: ["none"],
+        },
+        metrics: [{ label: "balanced_accuracy", value: 0.976, direction: "maximize", confidence: 0.9 }],
+        artifacts: [
+          { label: "submission", state_relative_path: "runs/final/submission.csv", kind: "other" },
+          { label: "metrics", state_relative_path: "runs/final/metrics.json", kind: "metrics" },
+        ],
+        similarity: [],
+        robustness: {
+          stability_score: 0.91,
+          diversity_score: 0.58,
+          risk_penalty: 0.02,
+          evidence_confidence: 0.9,
+          weak_dimensions: [],
+          provenance_refs: ["runs/final/metrics.json"],
+        },
+        disposition: "promoted",
+        disposition_reason: "Selected robust final candidate.",
+      }],
+      summary: "Final candidate snapshot.",
+      outcome: "improved",
+    });
+
+    const manifest = await new RuntimeReproducibilityManifestStore(runtimeRoot).createOrUpdateForCandidate({
+      goalId: "goal-manifest",
+      runId: "run:coreloop:manifest",
+      candidateId: "cb_focus_base_default_rs314",
+      workspaceDir,
+      command: {
+        command: "npm run train -- --config configs/train.json",
+        tool_name: "shell_command",
+        cwd: workspaceDir,
+      },
+      configPaths: ["configs/train.json"],
+      dataPaths: ["data/train.csv"],
+      codeState: {
+        commit: "abc123",
+        dirty: true,
+        diff: "diff --git a/train.ts b/train.ts\n",
+        source: "test-fixture",
+      },
+      runtime: { node: "v22.0.0", platform: "darwin" },
+      dependencies: { pulseed: "0.5.4" },
+    });
+
+    expect(manifest).toMatchObject({
+      schema_version: "runtime-reproducibility-manifest-v1",
+      scope: { goal_id: "goal-manifest", run_id: "run:coreloop:manifest" },
+      selected_candidate: {
+        candidate_id: "cb_focus_base_default_rs314",
+        evidence_entry_id: "candidate-final-snapshot",
+        lineage: {
+          strategy_family: "catboost_default",
+          seed_lineage: ["seed-314"],
+        },
+      },
+      finalization_preflight: {
+        manifest_required_before_delivery: true,
+        approval_required_before_external_submission: true,
+        status: "manifest_ready",
+        missing: [],
+      },
+      code_state: {
+        commit: "abc123",
+        dirty: true,
+      },
+      command: {
+        tool_name: "shell_command",
+      },
+      runtime: { node: "v22.0.0" },
+      dependencies: { pulseed: "0.5.4" },
+    });
+    expect(manifest.code_state.diff_sha256).toBe(createHash("sha256").update("diff --git a/train.ts b/train.ts\n").digest("hex"));
+    expect(manifest.artifacts).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        label: "submission",
+        state_relative_path: "runs/final/submission.csv",
+        hash_status: "hashed",
+        sha256: createHash("sha256").update("id,target\n1,0\n").digest("hex"),
+      }),
+      expect.objectContaining({
+        label: "metrics",
+        hash_status: "hashed",
+      }),
+    ]));
+    expect(manifest.configs[0]).toMatchObject({
+      label: "train.json",
+      hash_status: "hashed",
+    });
+    expect(manifest.data_inputs[0]).toMatchObject({
+      label: "train.csv",
+      hash_status: "hashed",
+    });
+  });
+
+  it("updates the same manifest with linked external evaluator feedback", async () => {
+    await fsp.writeFile(path.join(runtimeRoot, "runs/final/submission.csv"), "id,target\n1,0\n", "utf8");
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "candidate-manifest-before-feedback",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-manifest-update", run_id: "run:coreloop:manifest-update" },
+      candidates: [{
+        candidate_id: "candidate-final",
+        lineage: {
+          strategy_family: "catboost_default",
+          feature_lineage: ["focus-base"],
+          model_lineage: ["catboost"],
+          config_lineage: [],
+          seed_lineage: ["seed-314"],
+          fold_lineage: ["5-fold-oof"],
+          postprocess_lineage: [],
+        },
+        metrics: [{ label: "balanced_accuracy", value: 0.976, direction: "maximize" }],
+        artifacts: [{ label: "submission", state_relative_path: "runs/final/submission.csv", kind: "other" }],
+        similarity: [],
+        disposition: "promoted",
+      }],
+      summary: "Final candidate ready.",
+      outcome: "improved",
+    });
+
+    const store = new RuntimeReproducibilityManifestStore(runtimeRoot);
+    const before = await store.createOrUpdateForCandidate({
+      goalId: "goal-manifest-update",
+      runId: "run:coreloop:manifest-update",
+      candidateId: "candidate-final",
+      codeState: { commit: "abc123", dirty: false },
+    });
+
+    expect(before.evaluator_records).toEqual([]);
+
+    await ledger.append({
+      id: "external-feedback-final",
+      occurred_at: "2026-04-30T00:30:00.000Z",
+      kind: "evaluator",
+      scope: { goal_id: "goal-manifest-update", run_id: "run:coreloop:manifest-update" },
+      evaluators: [{
+        evaluator_id: "leaderboard",
+        signal: "external",
+        source: "public-leaderboard",
+        candidate_id: "candidate-final",
+        status: "passed",
+        score: 0.9692,
+        score_label: "balanced_accuracy",
+        direction: "maximize",
+        observed_at: "2026-04-30T00:31:00.000Z",
+        provenance: {
+          kind: "external_url",
+          url: "https://example.com/submissions/789",
+          external_id: "submission-789",
+        },
+        candidate_snapshot: {
+          evidence_entry_id: "candidate-manifest-before-feedback",
+          primary_metric_label: "balanced_accuracy",
+          local_metrics: [{ label: "balanced_accuracy", value: 0.976, direction: "maximize" }],
+        },
+        calibration: {
+          mode: "calibration_only",
+          use_for_selection: true,
+          direct_optimization_allowed: false,
+          minimum_observations: 1,
+          conclusion: "External feedback linked to manifest.",
+        },
+      }],
+      summary: "External evaluator feedback returned.",
+    });
+
+    const after = await store.createOrUpdateForCandidate({
+      goalId: "goal-manifest-update",
+      runId: "run:coreloop:manifest-update",
+      candidateId: "candidate-final",
+      codeState: { commit: "abc123", dirty: false },
+    });
+
+    expect(after.manifest_id).toBe(before.manifest_id);
+    expect(after.generated_at).toBe(before.generated_at);
+    expect(after.evaluator_records).toContainEqual(expect.objectContaining({
+      evaluator_id: "leaderboard",
+      signal: "external",
+      candidate_id: "candidate-final",
+      score: 0.9692,
+      evidence_entry_id: "external-feedback-final",
+      linked_manifest_id: before.manifest_id,
+      provenance: expect.objectContaining({ external_id: "submission-789" }),
+      calibration: expect.objectContaining({ mode: "calibration_only" }),
+    }));
+    expect(after.raw_evidence_refs.map((ref) => ref.entry_id)).toEqual([
+      "candidate-manifest-before-feedback",
+      "external-feedback-final",
+    ]);
+  });
+
+  it("creates a manifest for a deliverable artifact without candidate evidence", async () => {
+    await fsp.writeFile(path.join(runtimeRoot, "runs/final/report.md"), "# Final report\n", "utf8");
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "deliverable-report-entry",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "artifact",
+      scope: { goal_id: "goal-deliverable", run_id: "run:coreloop:deliverable" },
+      artifacts: [{ label: "final-report", state_relative_path: "runs/final/report.md", kind: "report" }],
+      summary: "Final report artifact ready.",
+      outcome: "continued",
+    });
+
+    const manifest = await new RuntimeReproducibilityManifestStore(runtimeRoot).createOrUpdateForCandidate({
+      goalId: "goal-deliverable",
+      runId: "run:coreloop:deliverable",
+      deliverableArtifact: {
+        label: "final-report",
+        kind: "report",
+        state_relative_path: "runs/final/report.md",
+        source: "runtime_evidence_ledger",
+      },
+      codeState: { commit: "def456", dirty: false },
+    });
+
+    expect(manifest.selected_candidate).toBeUndefined();
+    expect(manifest.selected_deliverable).toMatchObject({
+      label: "final-report",
+      state_relative_path: "runs/final/report.md",
+      source: "runtime_evidence_ledger",
+    });
+    expect(manifest.artifacts).toContainEqual(expect.objectContaining({
+      label: "final-report",
+      hash_status: "hashed",
+      sha256: createHash("sha256").update("# Final report\n").digest("hex"),
+    }));
+    expect(manifest.raw_evidence_refs).toContainEqual(expect.objectContaining({
+      entry_id: "deliverable-report-entry",
+    }));
+  });
+});

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -176,6 +176,11 @@ export {
   summarizeEvidenceEvaluatorResults,
 } from "./evaluator-results.js";
 export {
+  RuntimeReproducibilityFileRefSchema,
+  RuntimeReproducibilityManifestSchema,
+  RuntimeReproducibilityManifestStore,
+} from "./reproducibility-manifest.js";
+export {
   summarizeEvidenceDreamCheckpoints,
 } from "./dream-checkpoints.js";
 export type {
@@ -196,6 +201,14 @@ export type {
   RuntimeEvaluatorObservationContext,
   RuntimeEvaluatorSummary,
 } from "./evaluator-results.js";
+export type {
+  RuntimeReproducibilityCodeStateInput,
+  RuntimeReproducibilityCommandInput,
+  RuntimeReproducibilityFileRef,
+  RuntimeReproducibilityManifestLookupInput,
+  RuntimeReproducibilityManifest,
+  RuntimeReproducibilityManifestInput,
+} from "./reproducibility-manifest.js";
 export type {
   RuntimeControlOperationKind,
   RuntimeControlOperationState,

--- a/src/runtime/store/reproducibility-manifest.ts
+++ b/src/runtime/store/reproducibility-manifest.ts
@@ -1,0 +1,531 @@
+import { createHash } from "node:crypto";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { z } from "zod";
+import {
+  createRuntimeStorePaths,
+  ensureRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+import {
+  RuntimeEvidenceLedger,
+  type RuntimeEvidenceArtifactRef,
+  type RuntimeEvidenceCandidateRecord,
+  type RuntimeEvidenceEntry,
+  type RuntimeEvidenceEvaluatorObservation,
+} from "./evidence-ledger.js";
+
+export const RuntimeReproducibilityFileRefSchema = z.object({
+  label: z.string().min(1),
+  path: z.string().min(1).optional(),
+  state_relative_path: z.string().min(1).optional(),
+  kind: z.string().min(1).default("other"),
+  sha256: z.string().min(1).optional(),
+  size_bytes: z.number().int().nonnegative().optional(),
+  hash_status: z.enum(["hashed", "missing", "unreadable", "not_local"]).default("not_local"),
+  error: z.string().min(1).optional(),
+}).strict();
+export type RuntimeReproducibilityFileRef = z.infer<typeof RuntimeReproducibilityFileRefSchema>;
+
+export const RuntimeReproducibilityManifestSchema = z.object({
+  schema_version: z.literal("runtime-reproducibility-manifest-v1"),
+  manifest_id: z.string().min(1),
+  generated_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  scope: z.object({
+    goal_id: z.string().min(1).optional(),
+    run_id: z.string().min(1).optional(),
+  }).strict(),
+  selected_candidate: z.object({
+    candidate_id: z.string().min(1),
+    label: z.string().min(1).optional(),
+    evidence_entry_id: z.string().min(1),
+    lineage: z.unknown(),
+    metrics: z.array(z.unknown()).default([]),
+    robustness: z.unknown().optional(),
+    disposition: z.string().min(1).optional(),
+    disposition_reason: z.string().min(1).optional(),
+  }).strict().optional(),
+  selected_deliverable: z.object({
+    label: z.string().min(1),
+    id: z.string().min(1).optional(),
+    kind: z.string().min(1).optional(),
+    summary: z.string().min(1).optional(),
+    path: z.string().min(1).optional(),
+    state_relative_path: z.string().min(1).optional(),
+    url: z.string().url().optional(),
+    occurred_at: z.string().datetime().optional(),
+    source: z.string().min(1),
+  }).strict().optional(),
+  finalization_preflight: z.object({
+    manifest_required_before_delivery: z.boolean().default(true),
+    approval_required_before_external_submission: z.boolean().default(true),
+    status: z.enum(["manifest_ready", "manifest_incomplete"]),
+    missing: z.array(z.string().min(1)).default([]),
+  }).strict(),
+  code_state: z.object({
+    commit: z.string().min(1).optional(),
+    dirty: z.boolean().optional(),
+    diff_sha256: z.string().min(1).optional(),
+    source: z.string().min(1).default("provided"),
+  }).strict(),
+  command: z.object({
+    command: z.string().min(1).optional(),
+    tool_name: z.string().min(1).optional(),
+    args: z.array(z.string()).default([]),
+    cwd: z.string().min(1).optional(),
+  }).strict().optional(),
+  runtime: z.record(z.string(), z.unknown()).default({}),
+  dependencies: z.record(z.string(), z.unknown()).default({}),
+  artifacts: z.array(RuntimeReproducibilityFileRefSchema).default([]),
+  configs: z.array(RuntimeReproducibilityFileRefSchema).default([]),
+  data_inputs: z.array(RuntimeReproducibilityFileRefSchema).default([]),
+  evaluator_records: z.array(z.object({
+    evaluator_id: z.string().min(1),
+    signal: z.enum(["local", "external"]),
+    source: z.string().min(1),
+    candidate_id: z.string().min(1),
+    status: z.string().min(1),
+    score: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+    score_label: z.string().min(1).optional(),
+    direction: z.enum(["maximize", "minimize", "neutral"]).optional(),
+    observed_at: z.string().datetime().optional(),
+    evidence_entry_id: z.string().min(1),
+    provenance: z.unknown().optional(),
+    budget: z.unknown().optional(),
+    calibration: z.unknown().optional(),
+    linked_manifest_id: z.string().min(1),
+  }).strict()).default([]),
+  raw_evidence_refs: z.array(z.object({
+    entry_id: z.string().min(1),
+    kind: z.string().min(1),
+    occurred_at: z.string().datetime(),
+    summary: z.string().min(1).optional(),
+  }).strict()).default([]),
+}).strict();
+export type RuntimeReproducibilityManifest = z.infer<typeof RuntimeReproducibilityManifestSchema>;
+
+export interface RuntimeReproducibilityCodeStateInput {
+  commit?: string;
+  dirty?: boolean;
+  diff?: string;
+  diff_sha256?: string;
+  source?: string;
+}
+
+export interface RuntimeReproducibilityCommandInput {
+  command?: string;
+  tool_name?: string;
+  args?: string[];
+  cwd?: string;
+}
+
+export interface RuntimeReproducibilityManifestInput {
+  goalId?: string;
+  runId?: string;
+  candidateId?: string;
+  deliverableArtifact?: {
+    id?: string;
+    label: string;
+    kind?: string;
+    summary?: string;
+    path?: string;
+    state_relative_path?: string;
+    url?: string;
+    occurred_at?: string;
+    source: string;
+  };
+  workspaceDir?: string;
+  command?: RuntimeReproducibilityCommandInput;
+  configPaths?: string[];
+  dataPaths?: string[];
+  codeState?: RuntimeReproducibilityCodeStateInput;
+  runtime?: Record<string, unknown>;
+  dependencies?: Record<string, unknown>;
+  requireBeforeDelivery?: boolean;
+}
+
+export interface RuntimeReproducibilityManifestLookupInput {
+  goalId?: string;
+  runId?: string;
+  deliverable?: {
+    id?: string;
+    label?: string;
+    path?: string;
+    state_relative_path?: string;
+    url?: string;
+  } | null;
+}
+
+interface CandidateEvidenceMatch {
+  entry: RuntimeEvidenceEntry;
+  candidate: RuntimeEvidenceCandidateRecord;
+}
+
+export class RuntimeReproducibilityManifestStore {
+  private readonly paths: RuntimeStorePaths;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    this.paths = typeof runtimeRootOrPaths === "string"
+      ? createRuntimeStorePaths(runtimeRootOrPaths)
+      : runtimeRootOrPaths ?? createRuntimeStorePaths();
+  }
+
+  async createOrUpdateForCandidate(input: RuntimeReproducibilityManifestInput): Promise<RuntimeReproducibilityManifest> {
+    await ensureRuntimeStorePaths(this.paths);
+    const entries = await this.readEntries(input);
+    const match = input.candidateId ? findCandidate(entries, input.candidateId) : null;
+    if (input.candidateId && !match && !input.deliverableArtifact) {
+      throw new Error(`Candidate evidence not found for reproducibility manifest: ${input.candidateId}`);
+    }
+    if (!match && !input.deliverableArtifact) {
+      throw new Error("Candidate or deliverable artifact is required for reproducibility manifest.");
+    }
+
+    const manifestId = manifestIdFor(input);
+    const existing = await this.load(manifestId);
+    const now = new Date().toISOString();
+    const sourceArtifacts = match?.candidate.artifacts
+      ?? (input.deliverableArtifact ? [toEvidenceArtifactRef(input.deliverableArtifact)] : []);
+    const artifactRefs = await Promise.all(sourceArtifacts.map((artifact) =>
+      hashArtifactRef(artifact, this.paths.rootDir, input.workspaceDir)
+    ));
+    const configRefs = await Promise.all((input.configPaths ?? []).map((filePath) =>
+      hashPathRef(filePath, "config", input.workspaceDir)
+    ));
+    const dataRefs = await Promise.all((input.dataPaths ?? []).map((filePath) =>
+      hashPathRef(filePath, "data", input.workspaceDir)
+    ));
+    const evaluatorRecords = input.candidateId ? collectEvaluatorRecords(entries, input.candidateId, manifestId) : [];
+    const missing = manifestMissingFields(artifactRefs, configRefs, dataRefs, input);
+
+    const manifest = RuntimeReproducibilityManifestSchema.parse({
+      schema_version: "runtime-reproducibility-manifest-v1",
+      manifest_id: manifestId,
+      generated_at: existing?.generated_at ?? now,
+      updated_at: now,
+      scope: {
+        ...(input.goalId ? { goal_id: input.goalId } : {}),
+        ...(input.runId ? { run_id: input.runId } : {}),
+      },
+      ...(match
+        ? {
+            selected_candidate: {
+              candidate_id: match.candidate.candidate_id,
+              ...(match.candidate.label ? { label: match.candidate.label } : {}),
+              evidence_entry_id: match.entry.id,
+              lineage: match.candidate.lineage,
+              metrics: match.candidate.metrics,
+              ...(match.candidate.robustness ? { robustness: match.candidate.robustness } : {}),
+              disposition: match.candidate.disposition,
+              ...(match.candidate.disposition_reason ? { disposition_reason: match.candidate.disposition_reason } : {}),
+            },
+          }
+        : {}),
+      ...(input.deliverableArtifact ? { selected_deliverable: input.deliverableArtifact } : {}),
+      finalization_preflight: {
+        manifest_required_before_delivery: input.requireBeforeDelivery ?? true,
+        approval_required_before_external_submission: true,
+        status: missing.length === 0 ? "manifest_ready" : "manifest_incomplete",
+        missing,
+      },
+      code_state: buildCodeState(input.codeState),
+      ...(input.command ? { command: { args: [], ...input.command } } : {}),
+      runtime: input.runtime ?? {},
+      dependencies: input.dependencies ?? {},
+      artifacts: artifactRefs,
+      configs: configRefs,
+      data_inputs: dataRefs,
+      evaluator_records: evaluatorRecords,
+      raw_evidence_refs: collectEvidenceRefs(entries, input.candidateId, input.deliverableArtifact),
+    });
+
+    await fsp.writeFile(this.pathFor(manifestId), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    return manifest;
+  }
+
+  async load(manifestId: string): Promise<RuntimeReproducibilityManifest | null> {
+    try {
+      const raw = await fsp.readFile(this.pathFor(manifestId), "utf8");
+      return RuntimeReproducibilityManifestSchema.parse(JSON.parse(raw));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  async findReadyForFinalization(
+    input: RuntimeReproducibilityManifestLookupInput
+  ): Promise<RuntimeReproducibilityManifest | null> {
+    await ensureRuntimeStorePaths(this.paths);
+    let fileNames: string[];
+    try {
+      fileNames = await fsp.readdir(this.paths.reproducibilityManifestsDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+
+    const manifests: RuntimeReproducibilityManifest[] = [];
+    for (const fileName of fileNames) {
+      if (!fileName.endsWith(".json")) continue;
+      try {
+        const raw = await fsp.readFile(path.join(this.paths.reproducibilityManifestsDir, fileName), "utf8");
+        manifests.push(RuntimeReproducibilityManifestSchema.parse(JSON.parse(raw)));
+      } catch {
+        continue;
+      }
+    }
+
+    return manifests
+      .filter((manifest) =>
+        manifest.finalization_preflight.status === "manifest_ready"
+        && manifestScopeMatches(manifest, input)
+        && manifestDeliverableMatches(manifest, input.deliverable ?? null)
+      )
+      .sort((a, b) => b.updated_at.localeCompare(a.updated_at))[0] ?? null;
+  }
+
+  pathFor(manifestId: string): string {
+    return this.paths.reproducibilityManifestPath(manifestId);
+  }
+
+  private async readEntries(input: RuntimeReproducibilityManifestInput): Promise<RuntimeEvidenceEntry[]> {
+    const ledger = new RuntimeEvidenceLedger(this.paths);
+    const reads = await Promise.all([
+      input.goalId && ledger.readByGoal ? ledger.readByGoal(input.goalId) : Promise.resolve(null),
+      input.runId && ledger.readByRun ? ledger.readByRun(input.runId) : Promise.resolve(null),
+    ]);
+    const byId = new Map<string, RuntimeEvidenceEntry>();
+    for (const read of reads) {
+      for (const entry of read?.entries ?? []) byId.set(entry.id, entry);
+    }
+    return [...byId.values()].sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
+  }
+}
+
+function manifestIdFor(input: RuntimeReproducibilityManifestInput): string {
+  const scope = input.runId ? `run:${input.runId}` : `goal:${input.goalId ?? "unknown"}`;
+  const subject = input.candidateId
+    ? `candidate:${input.candidateId}`
+    : `deliverable:${input.deliverableArtifact?.id ?? input.deliverableArtifact?.label ?? "unknown"}`;
+  return `${safeManifestId(scope)}:${safeManifestId(subject)}`;
+}
+
+function safeManifestId(value: string): string {
+  return value.normalize("NFKC").replace(/[^a-zA-Z0-9:._-]+/g, "_");
+}
+
+function toEvidenceArtifactRef(
+  artifact: NonNullable<RuntimeReproducibilityManifestInput["deliverableArtifact"]>
+): RuntimeEvidenceArtifactRef {
+  return {
+    label: artifact.label,
+    ...(artifact.path ? { path: artifact.path } : {}),
+    ...(artifact.state_relative_path ? { state_relative_path: artifact.state_relative_path } : {}),
+    ...(artifact.url ? { url: artifact.url } : {}),
+    kind: artifact.kind === "log" || artifact.kind === "metrics" || artifact.kind === "report" || artifact.kind === "diff" || artifact.kind === "url"
+      ? artifact.kind
+      : "other",
+  };
+}
+
+function findCandidate(entries: RuntimeEvidenceEntry[], candidateId: string): CandidateEvidenceMatch | null {
+  for (const entry of [...entries].reverse()) {
+    const candidate = entry.candidates?.find((item) => item.candidate_id === candidateId);
+    if (candidate) return { entry, candidate };
+  }
+  return null;
+}
+
+async function hashArtifactRef(
+  artifact: RuntimeEvidenceArtifactRef,
+  runtimeRoot: string,
+  workspaceDir: string | undefined
+): Promise<RuntimeReproducibilityFileRef> {
+  const filePath = artifact.path
+    ?? (artifact.state_relative_path ? path.join(runtimeRoot, artifact.state_relative_path) : undefined);
+  return {
+    ...(await hashPath(filePath, workspaceDir)),
+    label: artifact.label,
+    ...(artifact.path ? { path: artifact.path } : {}),
+    ...(artifact.state_relative_path ? { state_relative_path: artifact.state_relative_path } : {}),
+    kind: artifact.kind,
+  };
+}
+
+async function hashPathRef(
+  filePath: string,
+  kind: string,
+  workspaceDir: string | undefined
+): Promise<RuntimeReproducibilityFileRef> {
+  return {
+    ...(await hashPath(filePath, workspaceDir)),
+    label: path.basename(filePath),
+    path: filePath,
+    kind,
+  };
+}
+
+async function hashPath(filePath: string | undefined, workspaceDir: string | undefined): Promise<{
+  sha256?: string;
+  size_bytes?: number;
+  hash_status: RuntimeReproducibilityFileRef["hash_status"];
+  error?: string;
+}> {
+  if (!filePath) return { hash_status: "not_local" };
+  const resolved = path.isAbsolute(filePath)
+    ? filePath
+    : path.resolve(workspaceDir ?? process.cwd(), filePath);
+  try {
+    const stat = await fsp.stat(resolved);
+    if (!stat.isFile()) return { hash_status: "unreadable", error: "path is not a file" };
+    const bytes = await fsp.readFile(resolved);
+    return {
+      sha256: createHash("sha256").update(bytes).digest("hex"),
+      size_bytes: stat.size,
+      hash_status: "hashed",
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return { hash_status: "missing" };
+    return {
+      hash_status: "unreadable",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function collectEvaluatorRecords(
+  entries: RuntimeEvidenceEntry[],
+  candidateId: string,
+  manifestId: string
+): RuntimeReproducibilityManifest["evaluator_records"] {
+  const records: RuntimeReproducibilityManifest["evaluator_records"] = [];
+  for (const entry of entries) {
+    for (const evaluator of entry.evaluators ?? []) {
+      if (evaluator.candidate_id !== candidateId) continue;
+      records.push(toManifestEvaluatorRecord(evaluator, entry.id, manifestId));
+    }
+  }
+  return records;
+}
+
+function toManifestEvaluatorRecord(
+  evaluator: RuntimeEvidenceEvaluatorObservation,
+  entryId: string,
+  manifestId: string
+): RuntimeReproducibilityManifest["evaluator_records"][number] {
+  return {
+    evaluator_id: evaluator.evaluator_id,
+    signal: evaluator.signal,
+    source: evaluator.source,
+    candidate_id: evaluator.candidate_id,
+    status: evaluator.status,
+    ...(evaluator.score !== undefined ? { score: evaluator.score } : {}),
+    ...(evaluator.score_label ? { score_label: evaluator.score_label } : {}),
+    ...(evaluator.direction ? { direction: evaluator.direction } : {}),
+    ...(evaluator.observed_at ? { observed_at: evaluator.observed_at } : {}),
+    evidence_entry_id: entryId,
+    ...(evaluator.provenance ? { provenance: evaluator.provenance } : {}),
+    ...(evaluator.budget ? { budget: evaluator.budget } : {}),
+    ...(evaluator.calibration ? { calibration: evaluator.calibration } : {}),
+    linked_manifest_id: manifestId,
+  };
+}
+
+function collectEvidenceRefs(
+  entries: RuntimeEvidenceEntry[],
+  candidateId: string | undefined,
+  deliverable: RuntimeReproducibilityManifestInput["deliverableArtifact"] | undefined
+): RuntimeReproducibilityManifest["raw_evidence_refs"] {
+  return entries
+    .filter((entry) => evidenceMatchesManifestSubject(entry, candidateId, deliverable))
+    .map((entry) => ({
+      entry_id: entry.id,
+      kind: entry.kind,
+      occurred_at: entry.occurred_at,
+      ...(entry.summary ? { summary: entry.summary } : {}),
+    }));
+}
+
+function evidenceMatchesManifestSubject(
+  entry: RuntimeEvidenceEntry,
+  candidateId: string | undefined,
+  deliverable: RuntimeReproducibilityManifestInput["deliverableArtifact"] | undefined
+): boolean {
+  if (candidateId && (
+    entry.candidates?.some((candidate) => candidate.candidate_id === candidateId)
+    || entry.evaluators?.some((evaluator) => evaluator.candidate_id === candidateId)
+  )) {
+    return true;
+  }
+  if (!deliverable) return false;
+  return entry.artifacts.some((artifact) =>
+    (deliverable.path && artifact.path === deliverable.path)
+    || (deliverable.state_relative_path && artifact.state_relative_path === deliverable.state_relative_path)
+    || artifact.label === deliverable.label
+  );
+}
+
+function manifestScopeMatches(
+  manifest: RuntimeReproducibilityManifest,
+  input: RuntimeReproducibilityManifestLookupInput
+): boolean {
+  if (input.goalId && manifest.scope.goal_id && manifest.scope.goal_id !== input.goalId) return false;
+  if (input.runId && manifest.scope.run_id && manifest.scope.run_id !== input.runId) return false;
+  if (input.goalId && !input.runId) return manifest.scope.goal_id === input.goalId;
+  if (input.runId) {
+    return manifest.scope.run_id === input.runId || manifest.scope.goal_id === input.goalId;
+  }
+  return true;
+}
+
+function manifestDeliverableMatches(
+  manifest: RuntimeReproducibilityManifest,
+  deliverable: RuntimeReproducibilityManifestLookupInput["deliverable"]
+): boolean {
+  if (!deliverable) return true;
+  if (manifest.selected_deliverable && deliverableRefMatches(manifest.selected_deliverable, deliverable)) return true;
+  return manifest.artifacts.some((artifact) => deliverableRefMatches(artifact, deliverable));
+}
+
+function deliverableRefMatches(
+  ref: {
+    id?: string;
+    label?: string;
+    path?: string;
+    state_relative_path?: string;
+    url?: string;
+  },
+  deliverable: NonNullable<RuntimeReproducibilityManifestLookupInput["deliverable"]>
+): boolean {
+  return (Boolean(deliverable.id) && ref.id === deliverable.id)
+    || (Boolean(deliverable.path) && ref.path === deliverable.path)
+    || (Boolean(deliverable.state_relative_path) && ref.state_relative_path === deliverable.state_relative_path)
+    || (Boolean(deliverable.url) && ref.url === deliverable.url)
+    || (Boolean(deliverable.label) && ref.label === deliverable.label);
+}
+
+function buildCodeState(input: RuntimeReproducibilityCodeStateInput | undefined): RuntimeReproducibilityManifest["code_state"] {
+  return {
+    ...(input?.commit ? { commit: input.commit } : {}),
+    ...(input?.dirty !== undefined ? { dirty: input.dirty } : {}),
+    ...(input?.diff_sha256 ? { diff_sha256: input.diff_sha256 } : input?.diff ? { diff_sha256: createHash("sha256").update(input.diff).digest("hex") } : {}),
+    source: input?.source ?? "provided",
+  };
+}
+
+function manifestMissingFields(
+  artifacts: RuntimeReproducibilityFileRef[],
+  configs: RuntimeReproducibilityFileRef[],
+  dataInputs: RuntimeReproducibilityFileRef[],
+  input: RuntimeReproducibilityManifestInput
+): string[] {
+  const missing: string[] = [];
+  if (artifacts.length === 0) missing.push("artifact_hashes");
+  if (artifacts.some((artifact) => artifact.hash_status !== "hashed")) missing.push("some_artifacts_unhashed");
+  if ((input.configPaths?.length ?? 0) > 0 && configs.some((config) => config.hash_status !== "hashed")) missing.push("some_configs_unhashed");
+  if ((input.dataPaths?.length ?? 0) > 0 && dataInputs.some((data) => data.hash_status !== "hashed")) missing.push("some_data_inputs_unhashed");
+  if (!input.codeState?.commit && !input.codeState?.diff_sha256 && !input.codeState?.diff) missing.push("code_state");
+  return missing;
+}

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -28,6 +28,7 @@ export interface RuntimeStorePaths {
   healthDir: string;
   guardrailsDir: string;
   guardrailBreakersDir: string;
+  reproducibilityManifestsDir: string;
   backpressureSnapshotPath: string;
   daemonHealthPath: string;
   componentsHealthPath: string;
@@ -42,6 +43,7 @@ export interface RuntimeStorePaths {
   evidenceRunPath(runId: string): string;
   safePausePath(goalId: string): string;
   guardrailBreakerPath(key: string): string;
+  reproducibilityManifestPath(manifestId: string): string;
   goalLeasePath(goalId: string): string;
   completedByIdempotencyPath(idempotencyKey: string): string;
   completedByMessagePath(messageId: string): string;
@@ -98,6 +100,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
   const healthDir = path.join(rootDir, "health");
   const guardrailsDir = path.join(rootDir, "guardrails");
   const guardrailBreakersDir = path.join(guardrailsDir, "breakers");
+  const reproducibilityManifestsDir = path.join(rootDir, "reproducibility-manifests");
 
   return {
     rootDir,
@@ -124,6 +127,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     healthDir,
     guardrailsDir,
     guardrailBreakersDir,
+    reproducibilityManifestsDir,
     backpressureSnapshotPath: path.join(guardrailsDir, "backpressure.json"),
     daemonHealthPath: path.join(healthDir, "daemon.json"),
     componentsHealthPath: path.join(healthDir, "components.json"),
@@ -159,6 +163,9 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     },
     guardrailBreakerPath(key: string) {
       return path.join(guardrailBreakersDir, recordFileName(encodeRuntimePathSegment(key)));
+    },
+    reproducibilityManifestPath(manifestId: string) {
+      return path.join(reproducibilityManifestsDir, recordFileName(encodeRuntimePathSegment(manifestId)));
     },
     goalLeasePath(goalId: string) {
       return path.join(goalLeasesDir, `${encodeRuntimePathSegment(goalId)}.json`);
@@ -201,6 +208,7 @@ export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise
       paths.healthDir,
       paths.guardrailsDir,
       paths.guardrailBreakersDir,
+      paths.reproducibilityManifestsDir,
     ].map((dir) => fsp.mkdir(dir, { recursive: true }))
   );
 }


### PR DESCRIPTION
Closes #825

## Summary
- add a runtime reproducibility manifest store for selected candidates and deliverable artifacts
- include artifact/config/data hashes, code state, command/runtime/dependency metadata, and evaluator provenance links
- wire deadline finalization to require and observe ready manifests before delivery/submission

## Verification
- npx vitest run src/orchestrator/loop/__tests__/core-loop-integrations.test.ts src/runtime/__tests__/reproducibility-manifest.test.ts src/platform/time/__tests__/deadline-finalization.test.ts
- npm run typecheck
- npm run lint:boundaries
- git diff --check
- npm run test:changed (known pre-existing timeout in src/interface/cli/__tests__/cli-runner-integration.test.ts:225 after related unit lane passed)

## Known unresolved risks
- npm run test:changed still hits the existing cli-runner integration 60s timeout unrelated to this slice
- manifest creation is a runtime-store contract/API slice; no automatic external publish/submit is performed
