### PR TITLE
feat(runtime): add artifact retention planning

### DIFF
--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -169,6 +169,7 @@ describe("runtime registry CLI commands", () => {
       kind: "verification",
       scope: { goal_id: "goal-evidence", task_id: "task-evidence", loop_index: 0 },
       verification: { verdict: "pass", confidence: 0.95, summary: "focused test passed" },
+      artifacts: [{ label: "final-report", state_relative_path: "reports/final.md", kind: "report", retention_class: "final_deliverable", size_bytes: 42 }],
       summary: "Focused test passed.",
       outcome: "improved",
     });
@@ -179,14 +180,17 @@ describe("runtime registry CLI commands", () => {
     expect(textCode).toBe(0);
     expect(textOutput).toContain("Runtime evidence: goal goal-evidence");
     expect(textOutput).toContain("Best evidence:");
+    expect(textOutput).toContain("Artifact footprint:");
+    expect(textOutput).toContain("1 protected");
 
     logSpy.mockClear();
     const jsonCode = await runCLI("runtime", "evidence", "goal-evidence", "--json");
     const jsonOutput = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
-    const parsed = JSON.parse(jsonOutput) as { total_entries: number; best_evidence: { kind: string } };
+    const parsed = JSON.parse(jsonOutput) as { total_entries: number; best_evidence: { kind: string }; artifact_retention: { total_artifacts: number; protected_count: number } };
     expect(jsonCode).toBe(0);
     expect(parsed.total_entries).toBe(2);
     expect(parsed.best_evidence.kind).toBe("verification");
+    expect(parsed.artifact_retention).toMatchObject({ total_artifacts: 1, protected_count: 1 });
   });
 
   it("shows evaluator local best, external best, gap, and approval gate in runtime evidence", async () => {

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -381,6 +381,7 @@ function printEvidenceSummary(summary: RuntimeEvidenceSummary): void {
     console.log("  Metric trends:   -");
   }
   printEvaluatorSummary(summary.evaluator_summary);
+  printArtifactRetentionSummary(summary);
   printResearchMemos(summary);
   printDreamCheckpoints(summary);
   if (summary.recent_failed_attempts.length > 0) {
@@ -394,6 +395,18 @@ function printEvidenceSummary(summary: RuntimeEvidenceSummary): void {
   if (summary.warnings.length > 0) {
     console.log(`  Warnings:        ${summary.warnings.length}`);
   }
+}
+
+function printArtifactRetentionSummary(summary: RuntimeEvidenceSummary): void {
+  const retention = summary.artifact_retention;
+  if (retention.total_artifacts === 0) {
+    console.log("  Artifact footprint: -");
+    return;
+  }
+  const cleanupCandidates = retention.cleanup_plan.actions.filter((action) => action.destructive).length;
+  console.log(`  Artifact footprint: ${retention.total_artifacts} artifacts, ${retention.total_size_bytes} bytes known, ${retention.protected_count} protected`);
+  console.log(`  Retention classes: final=${retention.by_retention_class.final_deliverable}, best=${retention.by_retention_class.best_candidate}, robust=${retention.by_retention_class.robust_candidate}, near_miss=${retention.by_retention_class.near_miss}, repro=${retention.by_retention_class.reproducibility_critical}`);
+  console.log(`  Cleanup plan:     ${cleanupCandidates} destructive candidates, approval_required`);
 }
 
 function printDreamSidecarReview(review: RuntimeDreamSidecarReview): void {

--- a/src/runtime/__tests__/artifact-retention.test.ts
+++ b/src/runtime/__tests__/artifact-retention.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from "vitest";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
+import { summarizeArtifactRetention } from "../store/artifact-retention.js";
+import { RuntimeEvidenceLedger, type RuntimeEvidenceEntry } from "../store/evidence-ledger.js";
+import { RuntimeReproducibilityManifestSchema, RuntimeReproducibilityManifestStore } from "../store/reproducibility-manifest.js";
+
+describe("artifact retention planning", () => {
+  it("protects best, robust, near-miss, and final artifacts while gating cleanup candidates", () => {
+    const summary = summarizeArtifactRetention([
+      entry({
+        id: "candidate-entry",
+        candidates: [
+          {
+            candidate_id: "raw-best",
+            lineage: candidateLineage("catboost"),
+            metrics: [{ label: "score", value: 0.98, direction: "maximize" }],
+            artifacts: [{ label: "raw-best", state_relative_path: "runs/raw/submission.csv", kind: "other", size_bytes: 100 }],
+            similarity: [],
+            disposition: "retained",
+          },
+          {
+            candidate_id: "robust-best",
+            lineage: candidateLineage("linear-stack"),
+            metrics: [{ label: "score", value: 0.96, direction: "maximize" }],
+            artifacts: [{ label: "robust-best", state_relative_path: "runs/robust/submission.csv", kind: "other", size_bytes: 120 }],
+            similarity: [],
+            robustness: {
+              stability_score: 0.94,
+              diversity_score: 0.8,
+              evidence_confidence: 0.9,
+              weak_dimensions: [],
+              provenance_refs: [],
+            },
+            disposition: "retained",
+          },
+          {
+            candidate_id: "near-miss",
+            lineage: candidateLineage("lightgbm"),
+            metrics: [{ label: "score", value: 0.93, direction: "maximize" }],
+            artifacts: [{ label: "near-miss", state_relative_path: "runs/near/submission.csv", kind: "other", size_bytes: 90 }],
+            similarity: [],
+            near_miss: {
+              status: "retained",
+              reason_to_keep: ["novelty"],
+              weak_dimensions: [],
+              complementary_candidate_ids: [],
+              evidence_refs: [],
+            },
+            disposition: "retained",
+          },
+        ],
+      }),
+      entry({
+        id: "artifact-entry",
+        kind: "artifact",
+        occurred_at: "2026-04-30T00:10:00.000Z",
+        artifacts: [
+          { label: "final-report", state_relative_path: "reports/final.md", kind: "report", retention_class: "final_deliverable", size_bytes: 80 },
+          { label: "smoke-cache", state_relative_path: "runs/smoke/cache.bin", kind: "other", retention_class: "low_value_smoke", size_bytes: 500 },
+        ],
+      }),
+    ] satisfies RuntimeEvidenceEntry[]);
+
+    expect(summary.total_artifacts).toBe(5);
+    expect(summary.protected_count).toBe(4);
+    expect(summary.by_retention_class.best_candidate).toBe(1);
+    expect(summary.by_retention_class.robust_candidate).toBe(1);
+    expect(summary.by_retention_class.near_miss).toBe(1);
+    expect(summary.by_retention_class.final_deliverable).toBe(1);
+    expect(summary.cleanup_plan).toMatchObject({
+      mode: "plan_only",
+      destructive_actions_default: "approval_required",
+    });
+    expect(summary.cleanup_plan.actions).toContainEqual(expect.objectContaining({
+      label: "smoke-cache",
+      cleanup_action: "delete_candidate",
+      destructive: true,
+      approval_required: true,
+    }));
+  });
+
+  it("protects artifacts linked from reproducibility manifests", () => {
+    const manifest = RuntimeReproducibilityManifestSchema.parse({
+      schema_version: "runtime-reproducibility-manifest-v1",
+      manifest_id: "goal:goal-retention:deliverable:final-report",
+      generated_at: "2026-04-30T00:00:00.000Z",
+      updated_at: "2026-04-30T00:00:00.000Z",
+      scope: { goal_id: "goal-retention" },
+      selected_deliverable: {
+        label: "final-report",
+        state_relative_path: "runs/final/report.md",
+        source: "runtime_evidence_ledger",
+      },
+      finalization_preflight: {
+        manifest_required_before_delivery: true,
+        approval_required_before_external_submission: true,
+        status: "manifest_ready",
+        missing: [],
+      },
+      code_state: { commit: "abc123", dirty: false, source: "test" },
+      artifacts: [{ label: "final-report", state_relative_path: "runs/final/report.md", kind: "report", hash_status: "hashed" }],
+    });
+
+    const summary = summarizeArtifactRetention([
+      entry({
+        id: "report-entry",
+        kind: "artifact",
+        artifacts: [{ label: "final-report", state_relative_path: "runs/final/report.md", kind: "report", retention_class: "low_value_smoke" }],
+      }),
+    ] satisfies RuntimeEvidenceEntry[], { manifests: [manifest] });
+
+    expect(summary.cleanup_plan.actions).toContainEqual(expect.objectContaining({
+      label: "final-report",
+      retention_class: "reproducibility_critical",
+      protected: true,
+      cleanup_action: "protect",
+      approval_required: false,
+      protection_reasons: expect.arrayContaining(["reproducibility_manifest"]),
+    }));
+  });
+
+  it("does not let explicit cleanup classes override protected candidate or final artifacts", () => {
+    const summary = summarizeArtifactRetention([
+      entry({
+        id: "protected-overrides",
+        kind: "artifact",
+        outcome: "improved",
+        artifacts: [{
+          label: "final-report",
+          state_relative_path: "reports/final.md",
+          kind: "report",
+          retention_class: "low_value_smoke",
+        }],
+        candidates: [{
+          candidate_id: "near-miss",
+          lineage: candidateLineage("tabnet"),
+          metrics: [{ label: "score", value: 0.91, direction: "maximize" }],
+          artifacts: [{
+            label: "near-miss-submission",
+            state_relative_path: "runs/near/submission.csv",
+            kind: "other",
+            retention_class: "duplicate_superseded",
+          }],
+          similarity: [],
+          near_miss: {
+            status: "retained",
+            reason_to_keep: ["ensemble_potential"],
+            weak_dimensions: [],
+            complementary_candidate_ids: [],
+            evidence_refs: [],
+          },
+          disposition: "retained",
+        }],
+      }),
+    ]);
+
+    expect(summary.cleanup_plan.actions).toContainEqual(expect.objectContaining({
+      label: "final-report",
+      retention_class: "final_deliverable",
+      cleanup_action: "protect",
+      destructive: false,
+    }));
+    expect(summary.cleanup_plan.actions).toContainEqual(expect.objectContaining({
+      label: "near-miss-submission",
+      retention_class: "near_miss",
+      cleanup_action: "protect",
+      destructive: false,
+    }));
+  });
+
+  it("uses manifest protection in the runtime evidence summary path", async () => {
+    const runtimeRoot = makeTempDir("pulseed-retention-runtime-");
+    try {
+      await fsp.mkdir(path.join(runtimeRoot, "runs/final"), { recursive: true });
+      await fsp.writeFile(path.join(runtimeRoot, "runs/final/report.md"), "# Final report\n", "utf8");
+      const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+      await ledger.append({
+        id: "low-value-report",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+        kind: "artifact",
+        scope: { goal_id: "goal-retention" },
+        artifacts: [{
+          label: "final-report",
+          state_relative_path: "runs/final/report.md",
+          kind: "report",
+          retention_class: "low_value_smoke",
+        }],
+        summary: "Report artifact.",
+      });
+      await new RuntimeReproducibilityManifestStore(runtimeRoot).createOrUpdateForCandidate({
+        goalId: "goal-retention",
+        deliverableArtifact: {
+          label: "final-report",
+          kind: "report",
+          state_relative_path: "runs/final/report.md",
+          source: "runtime_evidence_ledger",
+        },
+        codeState: { commit: "abc123", dirty: false },
+      });
+
+      const summary = await ledger.summarizeGoal("goal-retention");
+
+      expect(summary.artifact_retention.cleanup_plan.actions).toContainEqual(expect.objectContaining({
+        label: "final-report",
+        retention_class: "reproducibility_critical",
+        cleanup_action: "protect",
+        destructive: false,
+      }));
+    } finally {
+      await fsp.rm(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not crash on manifest JSON that relies on defaults or contains invalid artifact refs", async () => {
+    const runtimeRoot = makeTempDir("pulseed-retention-runtime-defaults-");
+    try {
+      const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+      await ledger.append({
+        id: "report-entry",
+        occurred_at: "2026-04-30T00:00:00.000Z",
+        kind: "artifact",
+        scope: { goal_id: "goal-retention-defaults" },
+        artifacts: [{ label: "summary", state_relative_path: "runs/summary.md", kind: "report" }],
+        summary: "Report artifact.",
+      });
+      await fsp.mkdir(path.join(runtimeRoot, "reproducibility-manifests"), { recursive: true });
+      await fsp.writeFile(path.join(runtimeRoot, "reproducibility-manifests", "manifest-defaults.json"), JSON.stringify({
+        schema_version: "runtime-reproducibility-manifest-v1",
+        manifest_id: "manifest-defaults",
+        generated_at: "2026-04-30T00:00:00.000Z",
+        updated_at: "2026-04-30T00:00:00.000Z",
+        scope: { goal_id: "goal-retention-defaults" },
+        finalization_preflight: {
+          manifest_required_before_delivery: true,
+          approval_required_before_external_submission: true,
+          status: "manifest_ready",
+          missing: [],
+        },
+        code_state: { commit: "abc123", dirty: false, source: "test" },
+      }), "utf8");
+      await fsp.writeFile(path.join(runtimeRoot, "reproducibility-manifests", "manifest-invalid-artifacts.json"), JSON.stringify({
+        schema_version: "runtime-reproducibility-manifest-v1",
+        manifest_id: "manifest-invalid-artifacts",
+        generated_at: "2026-04-30T00:00:00.000Z",
+        updated_at: "2026-04-30T00:00:00.000Z",
+        scope: { goal_id: "goal-retention-defaults" },
+        finalization_preflight: {
+          manifest_required_before_delivery: true,
+          approval_required_before_external_submission: true,
+          status: "manifest_ready",
+          missing: [],
+        },
+        code_state: { commit: "abc123", dirty: false, source: "test" },
+        artifacts: [null, "bad-ref", { label: "valid-manifest-ref", state_relative_path: "runs/valid.md", kind: "report" }],
+      }), "utf8");
+
+      await expect(ledger.summarizeGoal("goal-retention-defaults")).resolves.toMatchObject({
+        artifact_retention: { total_artifacts: 1 },
+      });
+    } finally {
+      await fsp.rm(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+function entry(overrides: Partial<RuntimeEvidenceEntry>): RuntimeEvidenceEntry {
+  return {
+    schema_version: "runtime-evidence-entry-v1",
+    id: "entry",
+    occurred_at: "2026-04-30T00:00:00.000Z",
+    kind: "metric",
+    scope: { goal_id: "goal-retention" },
+    metrics: [],
+    evaluators: [],
+    research: [],
+    dream_checkpoints: [],
+    divergent_exploration: [],
+    candidates: [],
+    artifacts: [],
+    raw_refs: [],
+    ...overrides,
+  };
+}
+
+function candidateLineage(strategyFamily: string) {
+  return {
+    strategy_family: strategyFamily,
+    feature_lineage: [],
+    model_lineage: [],
+    config_lineage: [],
+    seed_lineage: [],
+    fold_lineage: [],
+    postprocess_lineage: [],
+  };
+}

--- a/src/runtime/store/artifact-retention.ts
+++ b/src/runtime/store/artifact-retention.ts
@@ -1,0 +1,333 @@
+import { z } from "zod";
+import type {
+  RuntimeEvidenceArtifactRef,
+  RuntimeEvidenceCandidateRecord,
+  RuntimeEvidenceEntry,
+} from "./evidence-ledger.js";
+import type { RuntimeReproducibilityManifest } from "./reproducibility-manifest.js";
+
+export const RuntimeArtifactRetentionClassSchema = z.enum([
+  "final_deliverable",
+  "best_candidate",
+  "robust_candidate",
+  "near_miss",
+  "reproducibility_critical",
+  "evidence_report",
+  "low_value_smoke",
+  "cache_intermediate",
+  "duplicate_superseded",
+  "other",
+]);
+export type RuntimeArtifactRetentionClass = z.infer<typeof RuntimeArtifactRetentionClassSchema>;
+
+export type RuntimeArtifactCleanupActionKind =
+  | "protect"
+  | "retain"
+  | "compress_or_summarize"
+  | "delete_candidate"
+  | "review";
+
+export interface RuntimeArtifactRetentionDecision {
+  key: string;
+  label: string;
+  path?: string;
+  state_relative_path?: string;
+  url?: string;
+  kind: RuntimeEvidenceArtifactRef["kind"];
+  retention_class: RuntimeArtifactRetentionClass;
+  protected: boolean;
+  protection_reasons: string[];
+  size_bytes?: number;
+  source?: string;
+  dependency_refs: string[];
+  evidence_entry_ids: string[];
+  candidate_ids: string[];
+  cleanup_action: RuntimeArtifactCleanupActionKind;
+  destructive: boolean;
+  approval_required: boolean;
+  reason: string;
+}
+
+export interface RuntimeArtifactCleanupPlan {
+  mode: "plan_only";
+  destructive_actions_default: "approval_required";
+  actions: RuntimeArtifactRetentionDecision[];
+}
+
+export interface RuntimeArtifactRetentionSummary {
+  schema_version: "runtime-artifact-retention-summary-v1";
+  total_artifacts: number;
+  total_size_bytes: number;
+  unknown_size_count: number;
+  protected_count: number;
+  by_retention_class: Record<RuntimeArtifactRetentionClass, number>;
+  cleanup_plan: RuntimeArtifactCleanupPlan;
+}
+
+interface ArtifactRecord {
+  artifact: RuntimeEvidenceArtifactRef;
+  entry: RuntimeEvidenceEntry;
+  candidate?: RuntimeEvidenceCandidateRecord;
+  candidateRole?: "raw_best" | "robust_best" | "safe" | "aggressive" | "diverse" | "near_miss";
+  manifestCritical?: boolean;
+}
+
+export function summarizeArtifactRetention(
+  entries: RuntimeEvidenceEntry[],
+  options: { manifests?: RuntimeReproducibilityManifest[] } = {}
+): RuntimeArtifactRetentionSummary {
+  const records = collectArtifactRecords(entries, options.manifests ?? []);
+  const decisions = [...records.values()].map(classifyArtifactRecord);
+  const byRetentionClass = emptyRetentionClassCounts();
+  let totalSizeBytes = 0;
+  let unknownSizeCount = 0;
+  let protectedCount = 0;
+
+  for (const decision of decisions) {
+    byRetentionClass[decision.retention_class] += 1;
+    if (decision.size_bytes === undefined) unknownSizeCount += 1;
+    else totalSizeBytes += decision.size_bytes;
+    if (decision.protected) protectedCount += 1;
+  }
+
+  return {
+    schema_version: "runtime-artifact-retention-summary-v1",
+    total_artifacts: decisions.length,
+    total_size_bytes: totalSizeBytes,
+    unknown_size_count: unknownSizeCount,
+    protected_count: protectedCount,
+    by_retention_class: byRetentionClass,
+    cleanup_plan: {
+      mode: "plan_only",
+      destructive_actions_default: "approval_required",
+      actions: decisions,
+    },
+  };
+}
+
+function collectArtifactRecords(
+  entries: RuntimeEvidenceEntry[],
+  manifests: RuntimeReproducibilityManifest[]
+): Map<string, ArtifactRecord> {
+  const candidateRoles = candidateRoleMap(entries);
+  const manifestArtifactKeys = new Set<string>();
+  for (const manifest of manifests) {
+    for (const artifact of manifest.artifacts ?? []) {
+      manifestArtifactKeys.add(artifactKey(artifact));
+    }
+  }
+
+  const records = new Map<string, ArtifactRecord>();
+  for (const entry of entries) {
+    for (const artifact of entry.artifacts) {
+      addRecord(records, {
+        artifact,
+        entry,
+        manifestCritical: manifestArtifactKeys.has(artifactKey(artifact)),
+      });
+    }
+    for (const candidate of entry.candidates ?? []) {
+      for (const artifact of candidate.artifacts) {
+        addRecord(records, {
+          artifact,
+          entry,
+          candidate,
+          candidateRole: candidateRoles.get(candidate.candidate_id),
+          manifestCritical: manifestArtifactKeys.has(artifactKey(artifact)),
+        });
+      }
+    }
+  }
+  return records;
+}
+
+function addRecord(records: Map<string, ArtifactRecord>, incoming: ArtifactRecord): void {
+  const key = artifactKey(incoming.artifact);
+  const existing = records.get(key);
+  if (!existing) {
+    records.set(key, incoming);
+    return;
+  }
+  records.set(key, mergeArtifactRecords(existing, incoming));
+}
+
+function mergeArtifactRecords(existing: ArtifactRecord, incoming: ArtifactRecord): ArtifactRecord {
+  const artifact: RuntimeEvidenceArtifactRef = {
+    ...existing.artifact,
+    ...incoming.artifact,
+    dependency_refs: unique([
+      ...(existing.artifact.dependency_refs ?? []),
+      ...(incoming.artifact.dependency_refs ?? []),
+    ]),
+  };
+  return {
+    artifact,
+    entry: newerEntry(existing.entry, incoming.entry),
+    candidate: incoming.candidate ?? existing.candidate,
+    candidateRole: strongerCandidateRole(existing.candidateRole, incoming.candidateRole),
+    manifestCritical: Boolean(existing.manifestCritical || incoming.manifestCritical),
+  };
+}
+
+function classifyArtifactRecord(record: ArtifactRecord): RuntimeArtifactRetentionDecision {
+  const retentionClass = inferRetentionClass(record);
+  const protectionReasons = protectionReasonsFor(retentionClass, record);
+  const cleanupAction = cleanupActionFor(retentionClass, protectionReasons.length > 0);
+  const destructive = cleanupAction === "delete_candidate";
+  return {
+    key: artifactKey(record.artifact),
+    label: record.artifact.label,
+    ...(record.artifact.path ? { path: record.artifact.path } : {}),
+    ...(record.artifact.state_relative_path ? { state_relative_path: record.artifact.state_relative_path } : {}),
+    ...(record.artifact.url ? { url: record.artifact.url } : {}),
+    kind: record.artifact.kind,
+    retention_class: retentionClass,
+    protected: protectionReasons.length > 0,
+    protection_reasons: protectionReasons,
+    ...(record.artifact.size_bytes !== undefined ? { size_bytes: record.artifact.size_bytes } : {}),
+    ...(record.artifact.source ? { source: record.artifact.source } : {}),
+    dependency_refs: record.artifact.dependency_refs ?? [],
+    evidence_entry_ids: [record.entry.id],
+    candidate_ids: record.candidate ? [record.candidate.candidate_id] : [],
+    cleanup_action: cleanupAction,
+    destructive,
+    approval_required: destructive,
+    reason: cleanupReasonFor(retentionClass, cleanupAction, protectionReasons),
+  };
+}
+
+function inferRetentionClass(record: ArtifactRecord): RuntimeArtifactRetentionClass {
+  if (record.manifestCritical) return "reproducibility_critical";
+  if (record.candidate?.near_miss) return "near_miss";
+  if (record.candidateRole === "robust_best" || record.candidateRole === "safe") return "robust_candidate";
+  if (record.candidateRole === "raw_best" || record.candidateRole === "aggressive") return "best_candidate";
+  if (record.entry.kind === "artifact" && record.entry.outcome === "improved") return "final_deliverable";
+  if (record.artifact.retention_class) return record.artifact.retention_class;
+  if (record.artifact.kind === "report" || record.artifact.kind === "metrics" || record.entry.kind === "verification") {
+    return "evidence_report";
+  }
+  const haystack = `${record.artifact.label} ${record.artifact.path ?? ""} ${record.artifact.state_relative_path ?? ""}`.toLowerCase();
+  if (haystack.includes("smoke")) return "low_value_smoke";
+  if (haystack.includes("cache") || haystack.includes("tmp/") || haystack.includes("intermediate")) return "cache_intermediate";
+  return "other";
+}
+
+function protectionReasonsFor(
+  retentionClass: RuntimeArtifactRetentionClass,
+  record: ArtifactRecord
+): string[] {
+  const reasons: string[] = [];
+  if (record.manifestCritical) reasons.push("reproducibility_manifest");
+  if (retentionClass === "final_deliverable") reasons.push("final_deliverable");
+  if (retentionClass === "best_candidate") reasons.push("best_candidate");
+  if (retentionClass === "robust_candidate") reasons.push("robust_candidate");
+  if (retentionClass === "near_miss") reasons.push("near_miss");
+  if (retentionClass === "reproducibility_critical") reasons.push("reproducibility_critical");
+  return unique(reasons);
+}
+
+function cleanupActionFor(
+  retentionClass: RuntimeArtifactRetentionClass,
+  isProtected: boolean
+): RuntimeArtifactCleanupActionKind {
+  if (isProtected) return "protect";
+  if (retentionClass === "low_value_smoke") return "delete_candidate";
+  if (retentionClass === "cache_intermediate" || retentionClass === "duplicate_superseded") return "delete_candidate";
+  if (retentionClass === "evidence_report") return "retain";
+  return "review";
+}
+
+function cleanupReasonFor(
+  retentionClass: RuntimeArtifactRetentionClass,
+  cleanupAction: RuntimeArtifactCleanupActionKind,
+  protectionReasons: string[]
+): string {
+  if (cleanupAction === "protect") return `Protected: ${protectionReasons.join(", ")}`;
+  if (cleanupAction === "delete_candidate") return `${retentionClass} may be deleted only after operator approval.`;
+  if (cleanupAction === "retain") return `${retentionClass} retained for status and reporting.`;
+  return `${retentionClass} requires operator review before cleanup.`;
+}
+
+function candidateRoleMap(entries: RuntimeEvidenceEntry[]): Map<string, ArtifactRecord["candidateRole"]> {
+  const contexts = [...entries]
+    .sort((a, b) => a.occurred_at.localeCompare(b.occurred_at))
+    .flatMap((entry) => (entry.candidates ?? []).map((candidate) => ({ entry, candidate })));
+  const roles = new Map<string, ArtifactRecord["candidateRole"]>();
+  const latestCandidates = new Map<string, RuntimeEvidenceCandidateRecord>();
+  for (const context of contexts) latestCandidates.set(context.candidate.candidate_id, context.candidate);
+  for (const candidate of latestCandidates.values()) {
+    if (candidate.near_miss) roles.set(candidate.candidate_id, "near_miss");
+  }
+  const scored = [...contexts].flatMap(({ candidate }) => {
+    const metric = candidate.metrics.find((item) => typeof item.value === "number");
+    return metric && typeof metric.value === "number" ? [{ candidate, metric: { value: metric.value, direction: metric.direction } }] : [];
+  });
+  if (scored.length === 0) return roles;
+  const ranked = scored.sort((a, b) => {
+    const direction = a.metric.direction ?? "maximize";
+    return direction === "minimize" ? a.metric.value - b.metric.value : b.metric.value - a.metric.value;
+  });
+  const rawBest = ranked[0]?.candidate;
+  if (rawBest) roles.set(rawBest.candidate_id, "raw_best");
+  const robust = ranked
+    .filter(({ candidate }) => candidate.robustness?.stability_score !== undefined || candidate.robustness?.robust_score !== undefined)
+    .sort((a, b) => robustnessScore(b.candidate) - robustnessScore(a.candidate))[0]?.candidate;
+  if (robust) roles.set(robust.candidate_id, "robust_best");
+  return roles;
+}
+
+function robustnessScore(candidate: RuntimeEvidenceCandidateRecord): number {
+  const robustness = candidate.robustness;
+  if (!robustness) return 0;
+  return robustness.robust_score
+    ?? ((robustness.stability_score ?? 0) + (robustness.diversity_score ?? 0) + (robustness.evidence_confidence ?? 0)) / 3;
+}
+
+function artifactKey(artifact: {
+  label?: string;
+  path?: string;
+  state_relative_path?: string;
+  url?: string;
+}): string {
+  return artifact.path ?? artifact.state_relative_path ?? artifact.url ?? artifact.label ?? "unknown";
+}
+
+function newerEntry(a: RuntimeEvidenceEntry, b: RuntimeEvidenceEntry): RuntimeEvidenceEntry {
+  return a.occurred_at >= b.occurred_at ? a : b;
+}
+
+function strongerCandidateRole(
+  a: ArtifactRecord["candidateRole"],
+  b: ArtifactRecord["candidateRole"]
+): ArtifactRecord["candidateRole"] {
+  const rank: Record<NonNullable<ArtifactRecord["candidateRole"]>, number> = {
+    robust_best: 6,
+    safe: 5,
+    raw_best: 4,
+    aggressive: 3,
+    near_miss: 2,
+    diverse: 1,
+  };
+  if (!a) return b;
+  if (!b) return a;
+  return rank[b] > rank[a] ? b : a;
+}
+
+function emptyRetentionClassCounts(): Record<RuntimeArtifactRetentionClass, number> {
+  return {
+    final_deliverable: 0,
+    best_candidate: 0,
+    robust_candidate: 0,
+    near_miss: 0,
+    reproducibility_critical: 0,
+    evidence_report: 0,
+    low_value_smoke: 0,
+    cache_intermediate: 0,
+    duplicate_superseded: 0,
+    other: 0,
+  };
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -21,6 +21,12 @@ import {
   summarizeEvidenceDreamCheckpoints,
   type RuntimeDreamCheckpointContext,
 } from "./dream-checkpoints.js";
+import {
+  summarizeArtifactRetention,
+  RuntimeArtifactRetentionClassSchema,
+  type RuntimeArtifactRetentionSummary,
+} from "./artifact-retention.js";
+import type { RuntimeReproducibilityManifest } from "./reproducibility-manifest.js";
 
 export const RuntimeEvidenceOutcomeSchema = z.enum([
   "improved",
@@ -55,6 +61,10 @@ export const RuntimeEvidenceArtifactRefSchema = z.object({
   state_relative_path: z.string().min(1).optional(),
   url: z.string().url().optional(),
   kind: z.enum(["log", "metrics", "report", "diff", "url", "other"]).default("other"),
+  retention_class: RuntimeArtifactRetentionClassSchema.optional(),
+  size_bytes: z.number().int().nonnegative().optional(),
+  source: z.string().min(1).optional(),
+  dependency_refs: z.array(z.string().min(1)).optional(),
 }).strict();
 export type RuntimeEvidenceArtifactRef = z.infer<typeof RuntimeEvidenceArtifactRefSchema>;
 
@@ -655,6 +665,7 @@ export interface RuntimeEvidenceSummary {
   recommended_candidate_portfolio: RuntimeCandidatePortfolioSlot[];
   candidate_selection_summary: RuntimeCandidateSelectionSummary;
   near_miss_candidates: RuntimeNearMissCandidateContext[];
+  artifact_retention: RuntimeArtifactRetentionSummary;
   recent_failed_attempts: RuntimeEvidenceEntry[];
   failed_lineages: RuntimeFailedLineageContext[];
   recent_entries: RuntimeEvidenceEntry[];
@@ -727,7 +738,7 @@ export class RuntimeEvidenceLedger implements RuntimeEvidenceLedgerPort {
       await fsp.appendFile(target, `${JSON.stringify(entry)}\n`, "utf8");
     }));
     await Promise.all([...targets].map(async (target) => {
-      await rebuildSummaryIndex(target);
+      await rebuildSummaryIndex(target, this.paths);
     }));
     return [entry];
   }
@@ -741,34 +752,41 @@ export class RuntimeEvidenceLedger implements RuntimeEvidenceLedgerPort {
   }
 
   async summarizeGoal(goalId: string): Promise<RuntimeEvidenceSummary> {
-    const indexed = await readSummaryIndex(this.paths.evidenceGoalPath(goalId), { goal_id: goalId });
+    const manifests = await readReproducibilityManifests(this.paths, { goal_id: goalId });
+    const indexed = manifests.length === 0
+      ? await readSummaryIndex(this.paths.evidenceGoalPath(goalId), { goal_id: goalId })
+      : null;
     if (indexed) return indexed.summary;
     const read = await this.readByGoal(goalId);
-    const summary = summarizeEvidence({ goal_id: goalId }, read);
+    const summary = summarizeEvidence({ goal_id: goalId }, read, manifests);
     return summary;
   }
 
   async summarizeRun(runId: string): Promise<RuntimeEvidenceSummary> {
-    const indexed = await readSummaryIndex(this.paths.evidenceRunPath(runId), { run_id: runId });
+    const manifests = await readReproducibilityManifests(this.paths, { run_id: runId });
+    const indexed = manifests.length === 0
+      ? await readSummaryIndex(this.paths.evidenceRunPath(runId), { run_id: runId })
+      : null;
     if (indexed) return indexed.summary;
     const read = await this.readByRun(runId);
-    const summary = summarizeEvidence({ run_id: runId }, read);
+    const summary = summarizeEvidence({ run_id: runId }, read, manifests);
     return summary;
   }
 
   async rebuildSummaryIndexForGoal(goalId: string): Promise<RuntimeEvidenceSummary> {
-    return rebuildSummaryIndex(this.paths.evidenceGoalPath(goalId));
+    return rebuildSummaryIndex(this.paths.evidenceGoalPath(goalId), this.paths);
   }
 
   async rebuildSummaryIndexForRun(runId: string): Promise<RuntimeEvidenceSummary> {
-    return rebuildSummaryIndex(this.paths.evidenceRunPath(runId));
+    return rebuildSummaryIndex(this.paths.evidenceRunPath(runId), this.paths);
   }
 }
 
-async function rebuildSummaryIndex(canonicalPath: string): Promise<RuntimeEvidenceSummary> {
+async function rebuildSummaryIndex(canonicalPath: string, paths: RuntimeStorePaths): Promise<RuntimeEvidenceSummary> {
   const scope = summaryScopeFromPath(canonicalPath);
   const read = await readEvidenceFile(canonicalPath);
-  const summary = summarizeEvidence(scope, read);
+  const manifests = await readReproducibilityManifests(paths, scope);
+  const summary = summarizeEvidence(scope, read, manifests);
   await writeSummaryIndex(canonicalPath, summary);
   return summary;
 }
@@ -781,6 +799,43 @@ function summaryScopeFromPath(canonicalPath: string): RuntimeEvidenceSummary["sc
   const basename = path.basename(canonicalPath, ".jsonl");
   const decoded = decodeURIComponent(basename);
   return canonicalPath.includes(`${path.sep}runs${path.sep}`) ? { run_id: decoded } : { goal_id: decoded };
+}
+
+async function readReproducibilityManifests(
+  paths: RuntimeStorePaths,
+  scope: RuntimeEvidenceSummary["scope"]
+): Promise<RuntimeReproducibilityManifest[]> {
+  let fileNames: string[];
+  try {
+    fileNames = await fsp.readdir(paths.reproducibilityManifestsDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const manifests: RuntimeReproducibilityManifest[] = [];
+  for (const fileName of fileNames) {
+    if (!fileName.endsWith(".json")) continue;
+    try {
+      const parsed = JSON.parse(await fsp.readFile(path.join(paths.reproducibilityManifestsDir, fileName), "utf8")) as Partial<RuntimeReproducibilityManifest>;
+      if (parsed.schema_version !== "runtime-reproducibility-manifest-v1") continue;
+      if (scope.goal_id && parsed.scope?.goal_id !== scope.goal_id) continue;
+      if (scope.run_id && parsed.scope?.run_id !== scope.run_id) continue;
+      manifests.push({
+        ...parsed,
+        artifacts: Array.isArray(parsed.artifacts) ? parsed.artifacts.filter(isManifestArtifactRef) : [],
+      } as RuntimeReproducibilityManifest);
+    } catch {
+      continue;
+    }
+  }
+  return manifests;
+}
+
+function isManifestArtifactRef(value: unknown): value is RuntimeReproducibilityManifest["artifacts"][number] {
+  return typeof value === "object"
+    && value !== null
+    && typeof (value as { label?: unknown }).label === "string";
 }
 
 async function readSummaryIndex(
@@ -814,6 +869,8 @@ function isCurrentEvidenceSummaryShape(summary: RuntimeEvidenceSummary): boolean
   return Array.isArray(summary.candidate_lineages)
     && Array.isArray(summary.recommended_candidate_portfolio)
     && Array.isArray(summary.near_miss_candidates)
+    && typeof summary.artifact_retention === "object"
+    && summary.artifact_retention !== null
     && Array.isArray(summary.evaluator_summary.budgets)
     && Array.isArray(summary.evaluator_summary.calibration)
     && typeof summary.candidate_selection_summary === "object"
@@ -879,7 +936,8 @@ async function readEvidenceFile(filePath: string): Promise<RuntimeEvidenceReadRe
 
 function summarizeEvidence(
   scope: RuntimeEvidenceSummary["scope"],
-  read: RuntimeEvidenceReadResult
+  read: RuntimeEvidenceReadResult,
+  manifests: RuntimeReproducibilityManifest[] = []
 ): RuntimeEvidenceSummary {
   const entries = [...read.entries].sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
   const newestFirst = [...entries].reverse();
@@ -905,6 +963,7 @@ function summarizeEvidence(
     recommended_candidate_portfolio: selectDiversifiedCandidatePortfolio(entries),
     candidate_selection_summary: summarizeCandidateSelection(entries, evaluatorSummary),
     near_miss_candidates: summarizeNearMissCandidates(entries),
+    artifact_retention: summarizeArtifactRetention(entries, { manifests }),
     recent_failed_attempts: newestFirst
       .filter((entry) =>
         entry.outcome === "failed"

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -159,6 +159,17 @@ export type {
   RuntimeEvidenceSummary,
 } from "./evidence-ledger.js";
 export {
+  RuntimeArtifactRetentionClassSchema,
+  summarizeArtifactRetention,
+} from "./artifact-retention.js";
+export type {
+  RuntimeArtifactCleanupActionKind,
+  RuntimeArtifactCleanupPlan,
+  RuntimeArtifactRetentionClass,
+  RuntimeArtifactRetentionDecision,
+  RuntimeArtifactRetentionSummary,
+} from "./artifact-retention.js";
+export {
   classifyMetricTrend,
   extractMetricObservationsFromEvidence,
   selectMetricTrendForDimension,


### PR DESCRIPTION
Closes #823

## Summary
- add runtime artifact retention summaries and plan-only cleanup decisions
- protect best, robust, near-miss, final, and reproducibility-manifest artifacts
- surface artifact footprint and approval-gated cleanup candidates in runtime evidence output

## Verification
- npx vitest run src/runtime/__tests__/artifact-retention.test.ts src/interface/cli/__tests__/runtime-command.test.ts src/runtime/__tests__/runtime-evidence-ledger.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known unresolved risks
- destructive cleanup is intentionally plan-only and approval-required; this PR does not execute artifact deletion.