### PR TITLE
Expose runtime sessions in daemon snapshot

### DIFF
--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -308,6 +308,7 @@ export async function cmdStart(
       port: resolvedDaemonConfig.event_server_port,
       eventsDir: getEventsDir(daemonBaseDir),
       runtimeRoot: resolveDaemonRuntimeRoot(daemonBaseDir, resolvedDaemonConfig.runtime_root),
+      stateManager: deps.stateManager,
     },
     logger
   );

--- a/src/runtime/__tests__/event-server.test.ts
+++ b/src/runtime/__tests__/event-server.test.ts
@@ -7,6 +7,8 @@ import type { PulSeedEvent } from "../../base/types/drive.js";
 import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
 import { OutboxStore } from "../store/outbox-store.js";
 import { BrowserSessionStore } from "../interactive-automation/index.js";
+import { StateManager } from "../../base/state/state-manager.js";
+import { BackgroundRunLedger } from "../store/background-run-store.js";
 
 // ─── Helpers ───
 
@@ -716,6 +718,88 @@ describe("snapshot and outbox replay", () => {
         iterations: 0,
       },
     ]);
+  });
+
+  it("includes runtime session catalog data in daemon snapshot when a state manager is configured", async () => {
+    const stateManager = new StateManager(tmpDir, undefined, { walEnabled: false });
+    await stateManager.init();
+    await stateManager.writeRaw("chat/sessions/chat-runtime.json", {
+      id: "chat-runtime",
+      cwd: "/repo",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:10:00.000Z",
+      title: "Runtime snapshot",
+      messages: [],
+      agentLoopStatePath: "chat/agentloop/agent-runtime.state.json",
+      agentLoopStatus: "running",
+      agentLoopResumable: true,
+      agentLoopUpdatedAt: "2026-05-01T00:11:00.000Z",
+    });
+    await stateManager.writeRaw("chat/agentloop/agent-runtime.state.json", {
+      sessionId: "agent-runtime",
+      traceId: "trace-runtime",
+      turnId: "turn-runtime",
+      goalId: "goal-runtime",
+      cwd: "/repo",
+      modelRef: "native:test",
+      messages: [],
+      modelTurns: 1,
+      toolCalls: 0,
+      compactions: 0,
+      completionValidationAttempts: 0,
+      calledTools: [],
+      lastToolLoopSignature: null,
+      repeatedToolLoopCount: 0,
+      finalText: "",
+      status: "running",
+      updatedAt: "2026-05-01T00:12:00.000Z",
+    });
+    await new BackgroundRunLedger(path.join(tmpDir, "runtime")).create({
+      id: "run:coreloop:ledger-active",
+      kind: "coreloop_run",
+      notify_policy: "silent",
+      status: "running",
+      child_session_id: "session:coreloop:ledger-active",
+      title: "Ledger active run",
+      workspace: "/repo",
+      created_at: "2026-05-01T00:05:00.000Z",
+      started_at: "2026-05-01T00:05:00.000Z",
+      updated_at: "2026-05-01T00:13:00.000Z",
+    });
+
+    server = new EventServer(mockDriveSystem as never, {
+      port: 0,
+      eventsDir: path.join(tmpDir, "events"),
+      stateManager,
+    });
+    await server.start();
+
+    const result = await makeRequest(server.getPort(), "GET", "/snapshot");
+    expect(result.status).toBe(200);
+
+    const snapshot = JSON.parse(result.body) as {
+      runtime_sessions?: {
+        schema_version: string;
+        sessions: Array<{ id: string; kind: string; status: string }>;
+        background_runs: Array<{ id: string; kind: string; status: string }>;
+      } | null;
+    };
+    expect(snapshot.runtime_sessions?.schema_version).toBe("runtime-session-registry-v1");
+    expect(snapshot.runtime_sessions?.sessions).toContainEqual(expect.objectContaining({
+      id: "session:agent:agent-runtime",
+      kind: "agent",
+      status: "active",
+    }));
+    expect(snapshot.runtime_sessions?.background_runs).toContainEqual(expect.objectContaining({
+      id: "run:agent:agent-runtime",
+      kind: "agent_run",
+      status: "running",
+    }));
+    expect(snapshot.runtime_sessions?.background_runs).toContainEqual(expect.objectContaining({
+      id: "run:coreloop:ledger-active",
+      kind: "coreloop_run",
+      status: "running",
+    }));
   });
 
   it("reads auth handoff sessions from an explicitly configured runtime root", async () => {

--- a/src/runtime/daemon/client.ts
+++ b/src/runtime/daemon/client.ts
@@ -33,6 +33,7 @@ export interface DaemonSnapshot {
   last_outbox_seq: number;
   auth_sessions?: unknown[];
   guardrails?: Record<string, unknown> | null;
+  runtime_sessions?: unknown;
 }
 
 export interface DaemonHealth {

--- a/src/runtime/event/server-snapshot-reader.ts
+++ b/src/runtime/event/server-snapshot-reader.ts
@@ -4,6 +4,9 @@ import type { ApprovalRequiredEvent } from "../approval-broker.js";
 import type { OutboxStore } from "../store/index.js";
 import { BrowserSessionStore } from "../interactive-automation/index.js";
 import { GuardrailStore } from "../guardrails/index.js";
+import type { StateManager } from "../../base/state/state-manager.js";
+import { createRuntimeSessionRegistry } from "../session-registry/index.js";
+import type { RuntimeSessionRegistrySnapshot } from "../session-registry/types.js";
 
 type ActiveWorkersProvider = () =>
   | Array<Record<string, unknown>>
@@ -17,12 +20,14 @@ export interface EventServerSnapshotData {
   last_outbox_seq: number;
   auth_sessions: Array<Record<string, unknown>>;
   guardrails: Record<string, unknown> | null;
+  runtime_sessions: RuntimeSessionRegistrySnapshot | null;
 }
 
 export class EventServerSnapshotReader {
   constructor(
     private readonly eventsDir: string,
     private readonly configuredRuntimeRoot?: string,
+    private readonly stateManager?: StateManager,
   ) {}
 
   async buildSnapshot(
@@ -30,13 +35,14 @@ export class EventServerSnapshotReader {
     outboxStore?: OutboxStore,
     activeWorkersProvider?: ActiveWorkersProvider
   ): Promise<EventServerSnapshotData> {
-    const [daemon, goals, latestOutbox, activeWorkers, authSessions, guardrails] = await Promise.all([
+    const [daemon, goals, latestOutbox, activeWorkers, authSessions, guardrails, runtimeSessions] = await Promise.all([
       this.readDaemonState(),
       this.readGoalSummaries(),
       outboxStore?.loadLatest() ?? Promise.resolve(null),
       activeWorkersProvider?.() ?? Promise.resolve([]),
       this.readPendingAuthSessions(),
       this.readGuardrailSnapshot(),
+      this.readRuntimeSessionSnapshot(),
     ]);
 
     return {
@@ -47,6 +53,7 @@ export class EventServerSnapshotReader {
       last_outbox_seq: latestOutbox?.seq ?? 0,
       auth_sessions: authSessions,
       guardrails,
+      runtime_sessions: runtimeSessions,
     };
   }
 
@@ -90,6 +97,12 @@ export class EventServerSnapshotReader {
       backpressure_active: backpressure?.active ?? [],
       backpressure_throttled: backpressure?.throttled ?? [],
     };
+  }
+
+  private async readRuntimeSessionSnapshot(): Promise<RuntimeSessionRegistrySnapshot | null> {
+    if (!this.stateManager) return null;
+    const registry = createRuntimeSessionRegistry({ stateManager: this.stateManager });
+    return registry.snapshot();
   }
 
   async readDaemonStateRaw(): Promise<string | null> {

--- a/src/runtime/event/server-types.ts
+++ b/src/runtime/event/server-types.ts
@@ -2,6 +2,7 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import type { TriggerMapper } from "../trigger-mapper.js";
 import type { ApprovalBroker, ApprovalRequiredEvent } from "../approval-broker.js";
 import type { OutboxStore } from "../store/index.js";
+import type { RuntimeSessionRegistrySnapshot } from "../session-registry/types.js";
 
 export interface EventServerConfig {
   host?: string;
@@ -24,6 +25,7 @@ export interface EventServerSnapshot {
   last_outbox_seq: number;
   auth_sessions?: unknown[];
   guardrails?: Record<string, unknown> | null;
+  runtime_sessions?: RuntimeSessionRegistrySnapshot | null;
 }
 
 export type ActiveWorkersProvider = () =>

--- a/src/runtime/event/server.ts
+++ b/src/runtime/event/server.ts
@@ -64,7 +64,7 @@ export class EventServer {
     this.logger = logger;
     this.approvalBroker = config?.approvalBroker;
     this.outboxStore = config?.outboxStore;
-    this.snapshotReader = new EventServerSnapshotReader(this.eventsDir, config?.runtimeRoot);
+    this.snapshotReader = new EventServerSnapshotReader(this.eventsDir, config?.runtimeRoot, config?.stateManager);
     this.sseManager = new EventServerSseManager(this.logger, this.approvalBroker, this.outboxStore);
     this.auth = new EventServerAuth(this.host, this.eventsDir, () => this.port, this.logger);
     this.fileIngestion = new EventServerFileIngestion(


### PR DESCRIPTION
Closes #742

## Summary
- Adds `runtime_sessions` to daemon `/snapshot` when the event server has a `StateManager`.
- Wires CLI daemon startup to pass its production `StateManager` into `EventServer`.
- Adds an HTTP caller-path contract test proving `/snapshot` exposes real chat/agent registry data plus active background-run ledger data.

## Verification
- `npx vitest run src/runtime/__tests__/event-server.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (0 errors; existing warnings remain)
- `npm run test:changed`
- Separate review agent: no material findings

## Known risks
- The snapshot field is null when `EventServer` is constructed without a `StateManager`, preserving existing lightweight test/server construction paths.
- This does not implement the #846-#850 TUI product workflow; it only exposes the runtime/evidence foundation needed by attach/bootstrap surfaces.
