### PR TITLE
Add frozen experiment queue store

### DIFF
--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -11,6 +11,7 @@ import type { CoreLoop } from "../../../orchestrator/loop/core-loop.js";
 import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
 import { BackgroundRunLedger } from "../../../runtime/store/background-run-store.js";
 import { RuntimeEvidenceLedger } from "../../../runtime/store/evidence-ledger.js";
+import { RuntimeExperimentQueueStore } from "../../../runtime/store/experiment-queue-store.js";
 
 describe("runtime registry CLI commands", () => {
   let tmpDir: string;
@@ -449,6 +450,51 @@ describe("runtime registry CLI commands", () => {
     expect(code).toBe(0);
     expect(parsed.scope.run_id).toBe("dummy-runtime-run");
     expect(parsed.total_entries).toBe(1);
+  });
+
+  it("reports experiment queue phase separately from frozen execution status", async () => {
+    const queueStore = new RuntimeExperimentQueueStore(path.join(tmpDir, "runtime"));
+    await queueStore.create({
+      queue_id: "queue-runtime",
+      goal_id: "goal-runtime",
+      run_id: "run:coreloop:goal-runtime",
+      title: "Frozen queue",
+      created_at: "2026-05-01T00:00:00.000Z",
+      provenance: { source: "test-plan", evidence_refs: ["evidence:plan"] },
+      items: [{
+        item_id: "exp-a",
+        title: "Experiment A",
+        config: { model: "catboost" },
+        provenance: { source: "test-plan" },
+      }],
+    });
+    await queueStore.freeze("queue-runtime", "2026-05-01T00:01:00.000Z");
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const listCode = await runCLI("runtime", "experiment-queues", "--json");
+    const listOutput = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const listParsed = JSON.parse(listOutput) as {
+      queues: Array<{ queue_id: string; current_version: number; revisions: Array<{ phase: string; status: string }> }>;
+    };
+
+    expect(listCode).toBe(0);
+    expect(listParsed.queues).toContainEqual(expect.objectContaining({
+      queue_id: "queue-runtime",
+      current_version: 1,
+      revisions: [expect.objectContaining({
+        phase: "executing_frozen_queue",
+        status: "frozen",
+      })],
+    }));
+
+    logSpy.mockClear();
+    const detailCode = await runCLI("runtime", "experiment-queue", "queue-runtime");
+    const detailOutput = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(detailCode).toBe(0);
+    expect(detailOutput).toContain("Runtime experiment queue: queue-runtime");
+    expect(detailOutput).toContain("Phase:       executing_frozen_queue");
+    expect(detailOutput).toContain("Next item:   exp-a");
   });
 
   async function writeConversationWithRunningAgent(): Promise<void> {

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -7,6 +7,11 @@ import { StateManager } from "../../../base/state/state-manager.js";
 import { createRuntimeSessionRegistry } from "../../../runtime/session-registry/index.js";
 import { RuntimeEvidenceLedger, type RuntimeEvidenceEntry, type RuntimeEvidenceSummary } from "../../../runtime/store/evidence-ledger.js";
 import {
+  RuntimeExperimentQueueStore,
+  type RuntimeExperimentQueueRecord,
+  type RuntimeExperimentQueueRevision,
+} from "../../../runtime/store/experiment-queue-store.js";
+import {
   createRuntimeDreamSidecarReview,
   RuntimeDreamSidecarReviewError,
   type RuntimeDreamSidecarReview,
@@ -164,6 +169,57 @@ function printRunDetail(run: BackgroundRun): void {
   console.log(`  Sources:     ${run.source_refs.map(refLabel).join(", ") || "-"}`);
 }
 
+function currentExperimentQueueRevision(queue: RuntimeExperimentQueueRecord): RuntimeExperimentQueueRevision {
+  const revision = queue.revisions.find((candidate) => candidate.version === queue.current_version);
+  if (!revision) {
+    throw new Error(`Experiment queue ${queue.queue_id} is missing current version ${queue.current_version}`);
+  }
+  return revision;
+}
+
+function printExperimentQueueRows(queues: RuntimeExperimentQueueRecord[]): void {
+  if (queues.length === 0) {
+    console.log("No runtime experiment queues found.");
+    return;
+  }
+
+  console.log("Runtime experiment queues:\n");
+  console.log(
+    `${"ID".padEnd(ID_WIDTH)} ${"VERSION".padEnd(8)} ${"PHASE".padEnd(24)} ${"STATUS".padEnd(10)} ${"UPDATED".padEnd(UPDATED_WIDTH)} TITLE`
+  );
+  console.log("-".repeat(116));
+  for (const queue of queues) {
+    const revision = currentExperimentQueueRevision(queue);
+    console.log(
+      `${formatCell(queue.queue_id, ID_WIDTH).padEnd(ID_WIDTH)} ${String(revision.version).padEnd(8)} ${revision.phase.padEnd(24)} ${revision.status.padEnd(10)} ${dateLabel(revision.updated_at).padEnd(UPDATED_WIDTH)} ${formatCell(queue.title, TITLE_WIDTH)}`
+    );
+  }
+  console.log(`\nTotal: ${queues.length} experiment queue(s)`);
+}
+
+function printExperimentQueueDetail(queue: RuntimeExperimentQueueRecord): void {
+  const revision = currentExperimentQueueRevision(queue);
+  const pending = revision.items.filter((item) => item.status === "pending").length;
+  const running = revision.items.filter((item) => item.status === "running").length;
+  const terminal = revision.items.filter((item) => item.status === "succeeded" || item.status === "failed" || item.status === "skipped" || item.status === "cancelled").length;
+  console.log(`Runtime experiment queue: ${queue.queue_id}`);
+  console.log(`  Title:       ${queue.title ?? "-"}`);
+  console.log(`  Goal:        ${queue.goal_id ?? "-"}`);
+  console.log(`  Run:         ${queue.run_id ?? "-"}`);
+  console.log(`  Version:     ${revision.version}`);
+  console.log(`  Phase:       ${revision.phase}`);
+  console.log(`  Status:      ${revision.status}`);
+  console.log(`  Created:     ${revision.created_at}`);
+  console.log(`  Frozen:      ${revision.frozen_at ?? "-"}`);
+  console.log(`  Updated:     ${revision.updated_at}`);
+  console.log(`  Revision of: ${revision.revision_of ?? "-"}`);
+  console.log(`  Reason:      ${revision.revision_reason ?? "-"}`);
+  console.log(`  Items:       ${revision.items.length} total, ${pending} pending, ${running} running, ${terminal} terminal`);
+  console.log(`  Provenance:  ${revision.provenance.source}`);
+  const next = revision.items.find((item) => item.status === "pending");
+  console.log(`  Next item:   ${next ? `${next.item_id} (${next.idempotency_key})` : "-"}`);
+}
+
 function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
 }
@@ -241,7 +297,7 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
   const runtimeSubcommand = args[0];
 
   if (!runtimeSubcommand) {
-    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
+    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
     return 1;
   }
 
@@ -323,6 +379,37 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
     return 0;
   }
 
+  if (runtimeSubcommand === "experiment-queues") {
+    const values = parseListArgs(args.slice(1), "experiment-queues");
+    const store = new RuntimeExperimentQueueStore(path.join(stateManager.getBaseDir(), "runtime"));
+    const queues = await store.list();
+    if (values.json) {
+      printJson({
+        schema_version: "runtime-experiment-queues-list-v1",
+        queues,
+      });
+    } else {
+      printExperimentQueueRows(queues);
+    }
+    return 0;
+  }
+
+  if (runtimeSubcommand === "experiment-queue") {
+    const values = parseDetailArgs(args.slice(1), "experiment-queue");
+    if (!values.id) {
+      logger.error("Error: queue ID is required. Usage: pulseed runtime experiment-queue <id> [--json]");
+      return 1;
+    }
+    const store = new RuntimeExperimentQueueStore(path.join(stateManager.getBaseDir(), "runtime"));
+    const queue = await store.load(values.id);
+    if (!queue) {
+      console.error(`Runtime experiment queue not found: ${values.id}`);
+      return 1;
+    }
+    values.json ? printJson(queue) : printExperimentQueueDetail(queue);
+    return 0;
+  }
+
   if (runtimeSubcommand === "dream-review") {
     const values = parseDreamReviewArgs(args.slice(1));
     if (!values.id) {
@@ -348,7 +435,7 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
   }
 
   logger.error(`Unknown runtime subcommand: "${runtimeSubcommand}"`);
-  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
+  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
   return 1;
 }
 

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -47,6 +47,8 @@ Usage:
   pulseed runtime runs [--json] [--active] [--attention]  List background runs
   pulseed runtime session <id> [--json]  Show one runtime session
   pulseed runtime run <id> [--json]   Show one background run
+  pulseed runtime experiment-queues [--json]  List experiment queues
+  pulseed runtime experiment-queue <id> [--json]  Show one experiment queue
   pulseed runtime evidence <goal-id|run-id> [--json]  Summarize runtime evidence ledger
   pulseed runtime dream-review <run-id> [--json]  Read-only Dream sidecar review for active run
   pulseed log --goal <id>              View observation and gap history log

--- a/src/runtime/__tests__/experiment-queue-store.test.ts
+++ b/src/runtime/__tests__/experiment-queue-store.test.ts
@@ -1,0 +1,241 @@
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RuntimeExperimentQueueStore } from "../store/experiment-queue-store.js";
+
+describe("RuntimeExperimentQueueStore", () => {
+  let tmpDir: string;
+  let store: RuntimeExperimentQueueStore;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-experiment-queue-"));
+    store = new RuntimeExperimentQueueStore(path.join(tmpDir, "runtime"));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("resumes frozen queue execution after a restart without reselecting completed items", async () => {
+    await store.create({
+      queue_id: "queue-a",
+      goal_id: "goal-a",
+      run_id: "run:coreloop:goal-a",
+      title: "Ablation queue",
+      created_at: "2026-05-01T00:00:00.000Z",
+      provenance: provenance("experiment-bank-v1"),
+      items: [
+        item("exp-a", { model: "catboost", seed: 1 }),
+        item("exp-b", { model: "catboost", seed: 2 }),
+      ],
+    });
+    await store.freeze("queue-a", "2026-05-01T00:01:00.000Z");
+    await store.recordItemResult("queue-a", {
+      item_id: "exp-a",
+      status: "succeeded",
+      completed_at: "2026-05-01T00:05:00.000Z",
+      output_artifacts: [{ label: "exp-a metrics", state_relative_path: "runs/exp-a/metrics.json", kind: "metrics" }],
+      metrics: [{ label: "cv", value: 0.842, direction: "maximize" }],
+    });
+
+    const restarted = new RuntimeExperimentQueueStore(path.join(tmpDir, "runtime"));
+    const directive = await restarted.nextExecutionDirective("queue-a");
+
+    expect(directive).toMatchObject({
+      mode: "execute_frozen_queue_item",
+      queue_id: "queue-a",
+      version: 1,
+      phase: "executing_frozen_queue",
+      item: { item_id: "exp-b", status: "pending" },
+    });
+    const queue = await restarted.load("queue-a");
+    const revision = queue?.revisions.find((candidate) => candidate.version === 1);
+    expect(revision?.items.find((candidate) => candidate.item_id === "exp-a")).toMatchObject({
+      status: "succeeded",
+      output_artifacts: [expect.objectContaining({ state_relative_path: "runs/exp-a/metrics.json" })],
+    });
+  });
+
+  it("rejects duplicate queue materialization so revisions cannot be overwritten silently", async () => {
+    await store.create({
+      queue_id: "queue-duplicate",
+      created_at: "2026-05-01T00:00:00.000Z",
+      provenance: provenance("experiment-bank-v1"),
+      items: [item("exp-a", { seed: 1 })],
+    });
+    await store.freeze("queue-duplicate", "2026-05-01T00:01:00.000Z");
+    await store.recordItemResult("queue-duplicate", {
+      item_id: "exp-a",
+      status: "succeeded",
+      completed_at: "2026-05-01T00:02:00.000Z",
+    });
+
+    await expect(store.create({
+      queue_id: "queue-duplicate",
+      created_at: "2026-05-01T00:03:00.000Z",
+      provenance: provenance("accidental-rerun"),
+      items: [item("exp-b", { seed: 2 })],
+    })).rejects.toThrow("use appendRevision");
+
+    const queue = await store.load("queue-duplicate");
+    expect(queue?.revisions).toHaveLength(1);
+    expect(queue?.revisions[0].items).toContainEqual(expect.objectContaining({
+      item_id: "exp-a",
+      status: "succeeded",
+    }));
+  });
+
+  it("resumes a running frozen item after restart using the same idempotency key", async () => {
+    await store.create({
+      queue_id: "queue-running-resume",
+      created_at: "2026-05-01T00:00:00.000Z",
+      provenance: provenance("experiment-bank-v1"),
+      items: [item("exp-a", { fold: 1 })],
+    });
+    await store.freeze("queue-running-resume", "2026-05-01T00:01:00.000Z");
+    await store.markItemRunning("queue-running-resume", {
+      item_id: "exp-a",
+      claimed_by: "worker-a",
+      started_at: "2026-05-01T00:02:00.000Z",
+    });
+
+    const restarted = new RuntimeExperimentQueueStore(path.join(tmpDir, "runtime"));
+    const directive = await restarted.nextExecutionDirective("queue-running-resume");
+
+    expect(directive).toMatchObject({
+      mode: "execute_frozen_queue_item",
+      queue_id: "queue-running-resume",
+      resume: true,
+      item: {
+        item_id: "exp-a",
+        status: "running",
+      },
+    });
+    expect(directive?.summary).toContain("Resume frozen experiment queue");
+  });
+
+  it("requires explicit frozen execution before item execution and keeps terminal updates idempotent", async () => {
+    await store.create({
+      queue_id: "queue-idempotent",
+      created_at: "2026-05-01T00:00:00.000Z",
+      provenance: provenance("designer"),
+      items: [item("exp-a", { depth: 8 })],
+    });
+
+    await expect(store.nextExecutionDirective("queue-idempotent")).rejects.toThrow("still in designing");
+    await store.freeze("queue-idempotent", "2026-05-01T00:01:00.000Z");
+    await store.recordItemResult("queue-idempotent", {
+      item_id: "exp-a",
+      status: "failed",
+      completed_at: "2026-05-01T00:02:00.000Z",
+      error: "training crashed",
+    });
+    await store.recordItemResult("queue-idempotent", {
+      item_id: "exp-a",
+      status: "failed",
+      completed_at: "2026-05-01T00:03:00.000Z",
+      error: "duplicate retry result",
+    });
+
+    const queue = await store.load("queue-idempotent");
+    expect(queue?.revisions[0].items[0]).toMatchObject({
+      status: "failed",
+      completed_at: "2026-05-01T00:02:00.000Z",
+      error: "training crashed",
+    });
+    await expect(store.recordItemResult("queue-idempotent", {
+      item_id: "exp-a",
+      status: "succeeded",
+    })).rejects.toThrow("already finished as failed");
+  });
+
+  it("derives stable idempotency keys from nested item config", async () => {
+    await store.create({
+      queue_id: "queue-nested-config",
+      created_at: "2026-05-01T00:00:00.000Z",
+      provenance: provenance("designer"),
+      items: [
+        item("exp-a", { params: { depth: 8, learning_rate: 0.03 }, seed: 1 }),
+        item("exp-b", { seed: 1, params: { learning_rate: 0.03, depth: 10 } }),
+      ],
+    });
+
+    const queue = await store.load("queue-nested-config");
+    const keys = queue?.revisions[0].items.map((candidate) => candidate.idempotency_key) ?? [];
+
+    expect(keys[0]).toContain('"depth":8');
+    expect(keys[1]).toContain('"depth":10');
+    expect(keys[0]).not.toBe(keys[1]);
+  });
+
+  it("appends explicit queue revisions while preserving previous frozen results", async () => {
+    await store.create({
+      queue_id: "queue-revision",
+      created_at: "2026-05-01T00:00:00.000Z",
+      provenance: provenance("experiment-bank-v1"),
+      items: [item("exp-a", { features: ["base"] })],
+    });
+    await store.freeze("queue-revision", "2026-05-01T00:01:00.000Z");
+    await store.recordItemResult("queue-revision", {
+      item_id: "exp-a",
+      status: "succeeded",
+      completed_at: "2026-05-01T00:05:00.000Z",
+      metrics: [{ label: "cv", value: 0.81, direction: "maximize" }],
+    });
+
+    await store.appendRevision("queue-revision", {
+      reason: "Add missing seed coverage after reviewing v1 results",
+      created_at: "2026-05-01T00:10:00.000Z",
+      provenance: provenance("revision-plan"),
+      items: [
+        item("exp-a-seed2", { features: ["base"], seed: 2 }),
+        item("exp-a-seed3", { features: ["base"], seed: 3 }),
+      ],
+    });
+
+    const queue = await store.load("queue-revision");
+    expect(queue).toMatchObject({
+      current_version: 2,
+      revisions: [
+        expect.objectContaining({
+          version: 1,
+          phase: "executing_frozen_queue",
+          items: [expect.objectContaining({
+            item_id: "exp-a",
+            status: "succeeded",
+            metrics: [expect.objectContaining({ label: "cv", value: 0.81 })],
+          })],
+        }),
+        expect.objectContaining({
+          version: 2,
+          phase: "designing",
+          status: "draft",
+          revision_of: 1,
+          revision_reason: "Add missing seed coverage after reviewing v1 results",
+          items: [
+            expect.objectContaining({ item_id: "exp-a-seed2", status: "pending" }),
+            expect.objectContaining({ item_id: "exp-a-seed3", status: "pending" }),
+          ],
+        }),
+      ],
+    });
+  });
+});
+
+function provenance(source: string) {
+  return {
+    source,
+    created_by: "test",
+    evidence_refs: [`evidence:${source}`],
+  };
+}
+
+function item(itemId: string, config: Record<string, unknown>) {
+  return {
+    item_id: itemId,
+    title: itemId,
+    config,
+    provenance: provenance(`item:${itemId}`),
+  };
+}

--- a/src/runtime/store/experiment-queue-store.ts
+++ b/src/runtime/store/experiment-queue-store.ts
@@ -1,0 +1,435 @@
+import { z } from "zod";
+import {
+  createRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+import { RuntimeJournal } from "./runtime-journal.js";
+import {
+  RuntimeEvidenceArtifactRefSchema,
+  RuntimeEvidenceMetricSchema,
+  type RuntimeEvidenceArtifactRef,
+  type RuntimeEvidenceMetric,
+} from "./evidence-ledger.js";
+
+export const RuntimeExperimentQueuePhaseSchema = z.enum(["designing", "executing_frozen_queue"]);
+export type RuntimeExperimentQueuePhase = z.infer<typeof RuntimeExperimentQueuePhaseSchema>;
+
+export const RuntimeExperimentQueueRevisionStatusSchema = z.enum([
+  "draft",
+  "frozen",
+  "executing",
+  "completed",
+  "blocked",
+]);
+export type RuntimeExperimentQueueRevisionStatus = z.infer<typeof RuntimeExperimentQueueRevisionStatusSchema>;
+
+export const RuntimeExperimentQueueItemStatusSchema = z.enum([
+  "pending",
+  "running",
+  "succeeded",
+  "failed",
+  "skipped",
+  "cancelled",
+]);
+export type RuntimeExperimentQueueItemStatus = z.infer<typeof RuntimeExperimentQueueItemStatusSchema>;
+
+export const RuntimeExperimentQueueProvenanceSchema = z.object({
+  source: z.string().min(1),
+  created_by: z.string().min(1).optional(),
+  evidence_refs: z.array(z.string().min(1)).optional(),
+  artifact_refs: z.array(z.string().min(1)).optional(),
+  notes: z.string().min(1).optional(),
+}).strict();
+export type RuntimeExperimentQueueProvenance = z.infer<typeof RuntimeExperimentQueueProvenanceSchema>;
+export type RuntimeExperimentQueueProvenanceInput = z.input<typeof RuntimeExperimentQueueProvenanceSchema>;
+
+export const RuntimeExperimentQueueItemSchema = z.object({
+  item_id: z.string().min(1),
+  idempotency_key: z.string().min(1),
+  title: z.string().min(1).optional(),
+  config: z.record(z.unknown()),
+  status: RuntimeExperimentQueueItemStatusSchema,
+  output_artifacts: z.array(RuntimeEvidenceArtifactRefSchema),
+  metrics: z.array(RuntimeEvidenceMetricSchema),
+  error: z.string().min(1).optional(),
+  claimed_by: z.string().min(1).optional(),
+  started_at: z.string().datetime().optional(),
+  completed_at: z.string().datetime().optional(),
+  updated_at: z.string().datetime(),
+  provenance: RuntimeExperimentQueueProvenanceSchema,
+}).strict();
+export type RuntimeExperimentQueueItem = z.infer<typeof RuntimeExperimentQueueItemSchema>;
+
+export const RuntimeExperimentQueueRevisionSchema = z.object({
+  version: z.number().int().positive(),
+  phase: RuntimeExperimentQueuePhaseSchema,
+  status: RuntimeExperimentQueueRevisionStatusSchema,
+  revision_of: z.number().int().positive().nullable(),
+  revision_reason: z.string().min(1).nullable(),
+  created_at: z.string().datetime(),
+  frozen_at: z.string().datetime().nullable(),
+  updated_at: z.string().datetime(),
+  provenance: RuntimeExperimentQueueProvenanceSchema,
+  items: z.array(RuntimeExperimentQueueItemSchema),
+}).strict();
+export type RuntimeExperimentQueueRevision = z.infer<typeof RuntimeExperimentQueueRevisionSchema>;
+
+export const RuntimeExperimentQueueRecordSchema = z.object({
+  schema_version: z.literal("runtime-experiment-queue-v1"),
+  queue_id: z.string().min(1),
+  goal_id: z.string().min(1).optional(),
+  run_id: z.string().min(1).optional(),
+  title: z.string().min(1).optional(),
+  current_version: z.number().int().positive(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  revisions: z.array(RuntimeExperimentQueueRevisionSchema).min(1),
+}).strict().superRefine((queue, ctx) => {
+  if (!queue.revisions.some((revision) => revision.version === queue.current_version)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["current_version"],
+      message: `current_version ${queue.current_version} is not present in revisions`,
+    });
+  }
+  for (const revision of queue.revisions) {
+    const seen = new Set<string>();
+    for (const item of revision.items) {
+      if (seen.has(item.item_id)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["revisions", revision.version, "items", item.item_id],
+          message: `duplicate experiment queue item_id: ${item.item_id}`,
+        });
+      }
+      seen.add(item.item_id);
+    }
+  }
+});
+export type RuntimeExperimentQueueRecord = z.infer<typeof RuntimeExperimentQueueRecordSchema>;
+const RuntimeExperimentQueueRecordRuntimeSchema = RuntimeExperimentQueueRecordSchema as unknown as z.ZodType<RuntimeExperimentQueueRecord>;
+
+export interface RuntimeExperimentQueueItemInput {
+  item_id: string;
+  idempotency_key?: string;
+  title?: string;
+  config: Record<string, unknown>;
+  provenance: RuntimeExperimentQueueProvenanceInput;
+}
+
+export interface RuntimeExperimentQueueCreateInput {
+  queue_id: string;
+  goal_id?: string;
+  run_id?: string;
+  title?: string;
+  created_at?: string;
+  provenance: RuntimeExperimentQueueProvenanceInput;
+  items: RuntimeExperimentQueueItemInput[];
+}
+
+export interface RuntimeExperimentQueueRevisionInput {
+  reason: string;
+  created_at?: string;
+  provenance: RuntimeExperimentQueueProvenanceInput;
+  items: RuntimeExperimentQueueItemInput[];
+}
+
+export interface RuntimeExperimentQueueItemResultInput {
+  version?: number;
+  item_id: string;
+  status: Extract<RuntimeExperimentQueueItemStatus, "succeeded" | "failed" | "skipped" | "cancelled">;
+  completed_at?: string;
+  output_artifacts?: RuntimeEvidenceArtifactRef[];
+  metrics?: RuntimeEvidenceMetric[];
+  error?: string;
+}
+
+export interface RuntimeExperimentQueueExecutionDirective {
+  mode: "execute_frozen_queue_item";
+  queue_id: string;
+  version: number;
+  phase: RuntimeExperimentQueuePhase;
+  item: RuntimeExperimentQueueItem;
+  idempotency_key: string;
+  resume: boolean;
+  summary: string;
+}
+
+const TERMINAL_ITEM_STATUSES = new Set<RuntimeExperimentQueueItemStatus>([
+  "succeeded",
+  "failed",
+  "skipped",
+  "cancelled",
+]);
+
+export class RuntimeExperimentQueueStore {
+  private readonly paths: RuntimeStorePaths;
+  private readonly journal: RuntimeJournal;
+  private readonly now: () => Date;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths, options: { now?: () => Date } = {}) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+    this.journal = new RuntimeJournal(this.paths);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async load(queueId: string): Promise<RuntimeExperimentQueueRecord | null> {
+    return this.journal.load(this.paths.experimentQueuePath(queueId), RuntimeExperimentQueueRecordRuntimeSchema);
+  }
+
+  async list(): Promise<RuntimeExperimentQueueRecord[]> {
+    return this.journal.list(this.paths.experimentQueuesDir, RuntimeExperimentQueueRecordRuntimeSchema);
+  }
+
+  async create(input: RuntimeExperimentQueueCreateInput): Promise<RuntimeExperimentQueueRecord> {
+    const existing = await this.load(input.queue_id);
+    if (existing) {
+      throw new Error(`Experiment queue already exists: ${input.queue_id}; use appendRevision for explicit queue changes`);
+    }
+    const createdAt = input.created_at ?? this.nowIso();
+    const queue: RuntimeExperimentQueueRecord = {
+      schema_version: "runtime-experiment-queue-v1",
+      queue_id: input.queue_id,
+      ...(input.goal_id ? { goal_id: input.goal_id } : {}),
+      ...(input.run_id ? { run_id: input.run_id } : {}),
+      ...(input.title ? { title: input.title } : {}),
+      current_version: 1,
+      created_at: createdAt,
+      updated_at: createdAt,
+      revisions: [{
+        version: 1,
+        phase: "designing",
+        status: "draft",
+        revision_of: null,
+        revision_reason: null,
+        created_at: createdAt,
+        frozen_at: null,
+        updated_at: createdAt,
+        provenance: this.normalizeProvenance(input.provenance),
+        items: input.items.map((item) => this.normalizeItem(item, createdAt)),
+      }],
+    };
+    return this.save(queue);
+  }
+
+  async freeze(queueId: string, frozenAt = this.nowIso()): Promise<RuntimeExperimentQueueRecord> {
+    return this.update(queueId, (queue) => {
+      const revision = this.currentRevision(queue);
+      if (revision.phase === "executing_frozen_queue") return queue;
+      return {
+        ...queue,
+        updated_at: frozenAt,
+        revisions: queue.revisions.map((candidate) =>
+          candidate.version === revision.version
+            ? {
+                ...candidate,
+                phase: "executing_frozen_queue",
+                status: "frozen",
+                frozen_at: frozenAt,
+                updated_at: frozenAt,
+              }
+            : candidate
+        ),
+      };
+    });
+  }
+
+  async appendRevision(queueId: string, input: RuntimeExperimentQueueRevisionInput): Promise<RuntimeExperimentQueueRecord> {
+    return this.update(queueId, (queue) => {
+      const current = this.currentRevision(queue);
+      const createdAt = input.created_at ?? this.nowIso();
+      const nextVersion = Math.max(...queue.revisions.map((revision) => revision.version)) + 1;
+      return {
+        ...queue,
+        current_version: nextVersion,
+        updated_at: createdAt,
+        revisions: [
+          ...queue.revisions,
+          {
+            version: nextVersion,
+            phase: "designing",
+            status: "draft",
+            revision_of: current.version,
+            revision_reason: input.reason,
+            created_at: createdAt,
+            frozen_at: null,
+            updated_at: createdAt,
+            provenance: this.normalizeProvenance(input.provenance),
+            items: input.items.map((item) => this.normalizeItem(item, createdAt)),
+          },
+        ],
+      };
+    });
+  }
+
+  async markItemRunning(
+    queueId: string,
+    input: { version?: number; item_id: string; claimed_by?: string; started_at?: string }
+  ): Promise<RuntimeExperimentQueueRecord> {
+    return this.updateItem(queueId, input.version, input.item_id, (item, revision) => {
+      this.assertFrozenExecution(revision);
+      if (TERMINAL_ITEM_STATUSES.has(item.status)) return item;
+      const startedAt = input.started_at ?? this.nowIso();
+      return {
+        ...item,
+        status: "running",
+        ...(input.claimed_by ? { claimed_by: input.claimed_by } : {}),
+        started_at: item.started_at ?? startedAt,
+        updated_at: startedAt,
+      };
+    });
+  }
+
+  async recordItemResult(
+    queueId: string,
+    input: RuntimeExperimentQueueItemResultInput
+  ): Promise<RuntimeExperimentQueueRecord> {
+    return this.updateItem(queueId, input.version, input.item_id, (item, revision) => {
+      this.assertFrozenExecution(revision);
+      if (TERMINAL_ITEM_STATUSES.has(item.status)) {
+        if (item.status !== input.status) {
+          throw new Error(`Experiment queue item ${item.item_id} already finished as ${item.status}`);
+        }
+        return item;
+      }
+      const completedAt = input.completed_at ?? this.nowIso();
+      return {
+        ...item,
+        status: input.status,
+        output_artifacts: input.output_artifacts ?? item.output_artifacts,
+        metrics: input.metrics ?? item.metrics,
+        ...(input.error ? { error: input.error } : {}),
+        completed_at: completedAt,
+        updated_at: completedAt,
+      };
+    });
+  }
+
+  async nextExecutionDirective(queueId: string): Promise<RuntimeExperimentQueueExecutionDirective | null> {
+    const queue = await this.load(queueId);
+    if (!queue) return null;
+    const revision = this.currentRevision(queue);
+    this.assertFrozenExecution(revision);
+    const item = revision.items.find((candidate) => candidate.status === "running")
+      ?? revision.items.find((candidate) => candidate.status === "pending");
+    if (!item) return null;
+    const resume = item.status === "running";
+    return {
+      mode: "execute_frozen_queue_item",
+      queue_id: queue.queue_id,
+      version: revision.version,
+      phase: revision.phase,
+      item,
+      idempotency_key: item.idempotency_key,
+      resume,
+      summary: `${resume ? "Resume" : "Execute"} frozen experiment queue ${queue.queue_id} v${revision.version} item ${item.item_id}`,
+    };
+  }
+
+  currentRevision(queue: RuntimeExperimentQueueRecord): RuntimeExperimentQueueRevision {
+    const revision = queue.revisions.find((candidate) => candidate.version === queue.current_version);
+    if (!revision) throw new Error(`Experiment queue ${queue.queue_id} current version is missing`);
+    return revision;
+  }
+
+  private async update(
+    queueId: string,
+    updater: (queue: RuntimeExperimentQueueRecord) => RuntimeExperimentQueueRecord,
+  ): Promise<RuntimeExperimentQueueRecord> {
+    const queue = await this.load(queueId);
+    if (!queue) throw new Error(`Experiment queue not found: ${queueId}`);
+    return this.save(updater(queue));
+  }
+
+  private async updateItem(
+    queueId: string,
+    version: number | undefined,
+    itemId: string,
+    updater: (item: RuntimeExperimentQueueItem, revision: RuntimeExperimentQueueRevision) => RuntimeExperimentQueueItem,
+  ): Promise<RuntimeExperimentQueueRecord> {
+    return this.update(queueId, (queue) => {
+      const targetVersion = version ?? queue.current_version;
+      let revisionFound = false;
+      let itemFound = false;
+      const updatedAt = this.nowIso();
+      const revisions = queue.revisions.map((revision) => {
+        if (revision.version !== targetVersion) return revision;
+        revisionFound = true;
+        const items = revision.items.map((item) => {
+          if (item.item_id !== itemId) return item;
+          itemFound = true;
+          return updater(item, revision);
+        });
+        if (!itemFound) return revision;
+        const complete = items.length > 0 && items.every((item) => TERMINAL_ITEM_STATUSES.has(item.status));
+        const status: RuntimeExperimentQueueRevisionStatus = complete ? "completed" : "executing";
+        return {
+          ...revision,
+          status,
+          updated_at: updatedAt,
+          items,
+        };
+      });
+      if (!revisionFound) throw new Error(`Experiment queue revision not found: ${queueId} v${targetVersion}`);
+      if (!itemFound) throw new Error(`Experiment queue item not found: ${queueId} v${targetVersion} ${itemId}`);
+      return {
+        ...queue,
+        updated_at: updatedAt,
+        revisions,
+      };
+    });
+  }
+
+  private async save(queue: RuntimeExperimentQueueRecord): Promise<RuntimeExperimentQueueRecord> {
+    return this.journal.save(this.paths.experimentQueuePath(queue.queue_id), RuntimeExperimentQueueRecordRuntimeSchema, queue);
+  }
+
+  private normalizeItem(input: RuntimeExperimentQueueItemInput, updatedAt: string): RuntimeExperimentQueueItem {
+    return RuntimeExperimentQueueItemSchema.parse({
+      item_id: input.item_id,
+      idempotency_key: input.idempotency_key ?? `${input.item_id}:${stableConfigKey(input.config)}`,
+      title: input.title,
+      config: input.config,
+      status: "pending",
+      output_artifacts: [],
+      metrics: [],
+      updated_at: updatedAt,
+      provenance: this.normalizeProvenance(input.provenance),
+    });
+  }
+
+  private normalizeProvenance(input: RuntimeExperimentQueueProvenanceInput): RuntimeExperimentQueueProvenance {
+    return RuntimeExperimentQueueProvenanceSchema.parse(input);
+  }
+
+  private assertFrozenExecution(revision: RuntimeExperimentQueueRevision): void {
+    if (revision.phase !== "executing_frozen_queue") {
+      throw new Error(`Experiment queue revision v${revision.version} is still in ${revision.phase}`);
+    }
+  }
+
+  private nowIso(): string {
+    return this.now().toISOString();
+  }
+}
+
+function stableConfigKey(config: Record<string, unknown>): string {
+  return stableStringify(config);
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    const entries = Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value);
+}

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -128,6 +128,31 @@ export {
   RuntimeEvidenceMetricSchema,
   RuntimeEvidenceOutcomeSchema,
 } from "./evidence-ledger.js";
+export {
+  RuntimeExperimentQueueItemSchema,
+  RuntimeExperimentQueueItemStatusSchema,
+  RuntimeExperimentQueuePhaseSchema,
+  RuntimeExperimentQueueProvenanceSchema,
+  RuntimeExperimentQueueRecordSchema,
+  RuntimeExperimentQueueRevisionSchema,
+  RuntimeExperimentQueueRevisionStatusSchema,
+  RuntimeExperimentQueueStore,
+} from "./experiment-queue-store.js";
+export type {
+  RuntimeExperimentQueueCreateInput,
+  RuntimeExperimentQueueExecutionDirective,
+  RuntimeExperimentQueueItem,
+  RuntimeExperimentQueueItemInput,
+  RuntimeExperimentQueueItemResultInput,
+  RuntimeExperimentQueueItemStatus,
+  RuntimeExperimentQueuePhase,
+  RuntimeExperimentQueueProvenance,
+  RuntimeExperimentQueueProvenanceInput,
+  RuntimeExperimentQueueRecord,
+  RuntimeExperimentQueueRevision,
+  RuntimeExperimentQueueRevisionInput,
+  RuntimeExperimentQueueRevisionStatus,
+} from "./experiment-queue-store.js";
 export type {
   RuntimeEvidenceArtifactRef,
   RuntimeEvidenceEvaluatorBudget,

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -29,6 +29,7 @@ export interface RuntimeStorePaths {
   guardrailsDir: string;
   guardrailBreakersDir: string;
   reproducibilityManifestsDir: string;
+  experimentQueuesDir: string;
   backpressureSnapshotPath: string;
   daemonHealthPath: string;
   componentsHealthPath: string;
@@ -44,6 +45,7 @@ export interface RuntimeStorePaths {
   safePausePath(goalId: string): string;
   guardrailBreakerPath(key: string): string;
   reproducibilityManifestPath(manifestId: string): string;
+  experimentQueuePath(queueId: string): string;
   goalLeasePath(goalId: string): string;
   completedByIdempotencyPath(idempotencyKey: string): string;
   completedByMessagePath(messageId: string): string;
@@ -101,6 +103,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
   const guardrailsDir = path.join(rootDir, "guardrails");
   const guardrailBreakersDir = path.join(guardrailsDir, "breakers");
   const reproducibilityManifestsDir = path.join(rootDir, "reproducibility-manifests");
+  const experimentQueuesDir = path.join(rootDir, "experiment-queues");
 
   return {
     rootDir,
@@ -128,6 +131,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     guardrailsDir,
     guardrailBreakersDir,
     reproducibilityManifestsDir,
+    experimentQueuesDir,
     backpressureSnapshotPath: path.join(guardrailsDir, "backpressure.json"),
     daemonHealthPath: path.join(healthDir, "daemon.json"),
     componentsHealthPath: path.join(healthDir, "components.json"),
@@ -166,6 +170,9 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     },
     reproducibilityManifestPath(manifestId: string) {
       return path.join(reproducibilityManifestsDir, recordFileName(encodeRuntimePathSegment(manifestId)));
+    },
+    experimentQueuePath(queueId: string) {
+      return path.join(experimentQueuesDir, recordFileName(encodeRuntimePathSegment(queueId)));
     },
     goalLeasePath(goalId: string) {
       return path.join(goalLeasesDir, `${encodeRuntimePathSegment(goalId)}.json`);
@@ -209,6 +216,7 @@ export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise
       paths.guardrailsDir,
       paths.guardrailBreakersDir,
       paths.reproducibilityManifestsDir,
+      paths.experimentQueuesDir,
     ].map((dir) => fsp.mkdir(dir, { recursive: true }))
   );
 }


### PR DESCRIPTION
Closes #814

## Summary
- Adds a durable `RuntimeExperimentQueueStore` under `runtime/experiment-queues/` for versioned experiment queues.
- Represents queue revisions, `designing` vs `executing_frozen_queue` phases, item identity/config/status/output/provenance, and explicit freeze/revision flow.
- Supports restart-safe frozen execution directives, duplicate queue protection, idempotent terminal item updates, and running-item resume with the same idempotency key.
- Adds read-only `pulseed runtime experiment-queues` and `pulseed runtime experiment-queue <id>` reporting.

## Verification
- `npx vitest run src/runtime/__tests__/experiment-queue-store.test.ts src/interface/cli/__tests__/runtime-command.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (0 errors; existing warnings remain)
- `npm run test:changed`
- Separate review agent: initial material findings fixed; re-review no material findings

## Known risks
- This defines the runtime/evidence contract and read-only reporting only; it does not wire task generation policy to automatically consume the queue yet.
- This intentionally does not touch #811/#812 candidate ranking or #846-#850 TUI product workflow implementation.
