### PR TITLE
Add runtime budget governance

### DIFF
--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -12,6 +12,7 @@ import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessio
 import { BackgroundRunLedger } from "../../../runtime/store/background-run-store.js";
 import { RuntimeEvidenceLedger } from "../../../runtime/store/evidence-ledger.js";
 import { RuntimeExperimentQueueStore } from "../../../runtime/store/experiment-queue-store.js";
+import { RuntimeBudgetStore } from "../../../runtime/store/budget-store.js";
 
 describe("runtime registry CLI commands", () => {
   let tmpDir: string;
@@ -495,6 +496,63 @@ describe("runtime registry CLI commands", () => {
     expect(detailOutput).toContain("Runtime experiment queue: queue-runtime");
     expect(detailOutput).toContain("Phase:       executing_frozen_queue");
     expect(detailOutput).toContain("Next item:   exp-a");
+  });
+
+  it("reports runtime budget remaining usage and task generation context", async () => {
+    const budgetStore = new RuntimeBudgetStore(path.join(tmpDir, "runtime"));
+    await budgetStore.create({
+      budget_id: "budget-runtime",
+      scope: { goal_id: "goal-runtime", run_id: "run:coreloop:goal-runtime" },
+      title: "Runtime budget",
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [
+        {
+          dimension: "evaluator_attempts",
+          limit: 3,
+          approval_at_remaining: 1,
+          mode_transition_at_remaining: { consolidation: 1 },
+        },
+      ],
+    });
+    await budgetStore.recordEvaluatorCall("budget-runtime", {
+      attempts: 2,
+      observed_at: "2026-05-01T00:01:00.000Z",
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const listCode = await runCLI("runtime", "budgets", "--json");
+    const listOutput = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const listParsed = JSON.parse(listOutput) as {
+      budgets: Array<{ budget: { budget_id: string }; status: { mode: string; approval_required: boolean } }>;
+    };
+
+    expect(listCode).toBe(0);
+    expect(listParsed.budgets).toContainEqual(expect.objectContaining({
+      budget: expect.objectContaining({ budget_id: "budget-runtime" }),
+      status: expect.objectContaining({
+        mode: "consolidation",
+        approval_required: true,
+      }),
+    }));
+
+    logSpy.mockClear();
+    const detailCode = await runCLI("runtime", "budget", "budget-runtime", "--json");
+    const detailOutput = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const detailParsed = JSON.parse(detailOutput) as {
+      status: { dimensions: Array<{ dimension: string; remaining: number }> };
+      task_generation_context: { mode: string; remaining: Record<string, number>; approval_required: boolean };
+    };
+
+    expect(detailCode).toBe(0);
+    expect(detailParsed.status.dimensions).toContainEqual(expect.objectContaining({
+      dimension: "evaluator_attempts",
+      remaining: 1,
+    }));
+    expect(detailParsed.task_generation_context).toMatchObject({
+      mode: "consolidation",
+      approval_required: true,
+      remaining: { evaluator_attempts: 1 },
+    });
   });
 
   async function writeConversationWithRunningAgent(): Promise<void> {

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -12,6 +12,10 @@ import {
   type RuntimeExperimentQueueRevision,
 } from "../../../runtime/store/experiment-queue-store.js";
 import {
+  RuntimeBudgetStore,
+  type RuntimeBudgetRecord,
+} from "../../../runtime/store/budget-store.js";
+import {
   createRuntimeDreamSidecarReview,
   RuntimeDreamSidecarReviewError,
   type RuntimeDreamSidecarReview,
@@ -220,6 +224,53 @@ function printExperimentQueueDetail(queue: RuntimeExperimentQueueRecord): void {
   console.log(`  Next item:   ${next ? `${next.item_id} (${next.idempotency_key})` : "-"}`);
 }
 
+function printBudgetRows(store: RuntimeBudgetStore, budgets: RuntimeBudgetRecord[]): void {
+  if (budgets.length === 0) {
+    console.log("No runtime budgets found.");
+    return;
+  }
+
+  console.log("Runtime budgets:\n");
+  console.log(
+    `${"ID".padEnd(ID_WIDTH)} ${"MODE".padEnd(14)} ${"UPDATED".padEnd(UPDATED_WIDTH)} ${"SCOPE".padEnd(WORKSPACE_WIDTH)} TITLE`
+  );
+  console.log("-".repeat(116));
+  for (const budget of budgets) {
+    const status = store.status(budget);
+    const scope = budget.scope.run_id ?? budget.scope.goal_id ?? "-";
+    console.log(
+      `${formatCell(budget.budget_id, ID_WIDTH).padEnd(ID_WIDTH)} ${status.mode.padEnd(14)} ${dateLabel(budget.updated_at).padEnd(UPDATED_WIDTH)} ${formatCell(scope, WORKSPACE_WIDTH).padEnd(WORKSPACE_WIDTH)} ${formatCell(budget.title, TITLE_WIDTH)}`
+    );
+  }
+  console.log(`\nTotal: ${budgets.length} budget(s)`);
+}
+
+function printBudgetDetail(store: RuntimeBudgetStore, budget: RuntimeBudgetRecord): void {
+  const status = store.status(budget);
+  console.log(`Runtime budget: ${budget.budget_id}`);
+  console.log(`  Title:       ${budget.title ?? "-"}`);
+  console.log(`  Goal:        ${budget.scope.goal_id ?? "-"}`);
+  console.log(`  Run:         ${budget.scope.run_id ?? "-"}`);
+  console.log(`  Mode:        ${status.mode}`);
+  console.log(`  Approval:    ${status.approval_required ? "required" : "-"}`);
+  console.log(`  Handoff:     ${status.handoff_required ? "required" : "-"}`);
+  console.log(`  Finalize:    ${status.finalization_required ? "required" : "-"}`);
+  console.log(`  Exhausted:   ${status.exhausted ? "yes" : "no"}`);
+  console.log("  Dimensions:");
+  for (const dimension of status.dimensions) {
+    const actions = dimension.threshold_actions.length > 0 ? ` actions=${dimension.threshold_actions.join(",")}` : "";
+    console.log(`    - ${dimension.dimension}: used=${dimension.used} remaining=${dimension.remaining} limit=${dimension.limit}${actions}`);
+  }
+  if (status.recent_consumption.length > 0) {
+    console.log("  Recent consumption:");
+    for (const entry of status.recent_consumption.slice(0, 5)) {
+      console.log(`    - ${entry.observed_at} ${entry.source} +${entry.amount}${entry.reason ? ` ${entry.reason}` : ""}`);
+    }
+  } else {
+    console.log("  Recent consumption: -");
+  }
+}
+
 function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
 }
@@ -297,7 +348,7 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
   const runtimeSubcommand = args[0];
 
   if (!runtimeSubcommand) {
-    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
+    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
     return 1;
   }
 
@@ -410,6 +461,40 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
     return 0;
   }
 
+  if (runtimeSubcommand === "budgets") {
+    const values = parseListArgs(args.slice(1), "budgets");
+    const store = new RuntimeBudgetStore(path.join(stateManager.getBaseDir(), "runtime"));
+    const budgets = await store.list();
+    if (values.json) {
+      printJson({
+        schema_version: "runtime-budgets-list-v1",
+        budgets: budgets.map((budget) => ({
+          budget,
+          status: store.status(budget),
+        })),
+      });
+    } else {
+      printBudgetRows(store, budgets);
+    }
+    return 0;
+  }
+
+  if (runtimeSubcommand === "budget") {
+    const values = parseDetailArgs(args.slice(1), "budget");
+    if (!values.id) {
+      logger.error("Error: budget ID is required. Usage: pulseed runtime budget <id> [--json]");
+      return 1;
+    }
+    const store = new RuntimeBudgetStore(path.join(stateManager.getBaseDir(), "runtime"));
+    const budget = await store.load(values.id);
+    if (!budget) {
+      console.error(`Runtime budget not found: ${values.id}`);
+      return 1;
+    }
+    values.json ? printJson({ budget, status: store.status(budget), task_generation_context: store.taskGenerationContext(budget) }) : printBudgetDetail(store, budget);
+    return 0;
+  }
+
   if (runtimeSubcommand === "dream-review") {
     const values = parseDreamReviewArgs(args.slice(1));
     if (!values.id) {
@@ -435,7 +520,7 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
   }
 
   logger.error(`Unknown runtime subcommand: "${runtimeSubcommand}"`);
-  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
+  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
   return 1;
 }
 

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -29,6 +29,7 @@ import { ReportingEngine } from "../../reporting/reporting-engine.js";
 import { CoreLoop } from "../../orchestrator/loop/core-loop.js";
 import { ScheduleEngine } from "../../runtime/schedule/engine.js";
 import { RuntimeEvidenceLedger } from "../../runtime/store/evidence-ledger.js";
+import { RuntimeBudgetStore } from "../../runtime/store/budget-store.js";
 import { TreeLoopOrchestrator } from "../../orchestrator/goal/tree-loop-orchestrator.js";
 import { GoalTreeManager } from "../../orchestrator/goal/goal-tree-manager.js";
 import { StateAggregator } from "../../orchestrator/goal/state-aggregator.js";
@@ -374,6 +375,7 @@ export async function buildDeps(
     stateManager, goalTreeManager, stateAggregator, satisficingJudge, goalRefiner
   );
 
+  const runtimeBudgetStore = new RuntimeBudgetStore(path.join(stateManager.getBaseDir(), "runtime"));
   const coreLoop = new CoreLoop({
     stateManager,
     observationEngine,
@@ -405,6 +407,7 @@ export async function buildDeps(
     toolRegistry,
     corePhaseRunner,
     evidenceLedger,
+    runtimeBudgetStore,
   }, config);
 
   coreLoop.setTimeHorizonEngine(new TimeHorizonEngine());

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -49,6 +49,8 @@ Usage:
   pulseed runtime run <id> [--json]   Show one background run
   pulseed runtime experiment-queues [--json]  List experiment queues
   pulseed runtime experiment-queue <id> [--json]  Show one experiment queue
+  pulseed runtime budgets [--json]    List runtime budgets
+  pulseed runtime budget <id> [--json]  Show one runtime budget
   pulseed runtime evidence <goal-id|run-id> [--json]  Summarize runtime evidence ledger
   pulseed runtime dream-review <run-id> [--json]  Read-only Dream sidecar review for active run
   pulseed log --goal <id>              View observation and gap history log

--- a/src/interface/tui/entry-deps.ts
+++ b/src/interface/tui/entry-deps.ts
@@ -32,6 +32,7 @@ export async function buildStandaloneTuiDeps() {
   const { TreeLoopOrchestrator } = await import("../../orchestrator/goal/tree-loop-orchestrator.js");
   const { ScheduleEngine } = await import("../../runtime/schedule/engine.js");
   const { RuntimeEvidenceLedger } = await import("../../runtime/store/evidence-ledger.js");
+  const { RuntimeBudgetStore } = await import("../../runtime/store/budget-store.js");
   const { MemoryLifecycleManager, DriveScoreAdapter } = await import("../../platform/knowledge/memory/memory-lifecycle.js");
   const { KnowledgeManager } = await import("../../platform/knowledge/knowledge-manager.js");
   const { CharacterConfigManager } = await import("../../platform/traits/character-config.js");
@@ -231,6 +232,7 @@ export async function buildStandaloneTuiDeps() {
     rankDimensions: DriveScorer.rankDimensions,
   };
 
+  const runtimeBudgetStore = new RuntimeBudgetStore(path.join(stateManager.getBaseDir(), "runtime"));
   const coreLoop = new CoreLoop({
     stateManager,
     observationEngine,
@@ -252,6 +254,7 @@ export async function buildStandaloneTuiDeps() {
     contextProvider,
     corePhaseRunner,
     evidenceLedger,
+    runtimeBudgetStore,
   });
 
   const scheduleEngine = new ScheduleEngine({

--- a/src/orchestrator/loop/__tests__/core-loop-phases-b-verify.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-phases-b-verify.test.ts
@@ -315,6 +315,52 @@ describe("Phase 7: verifyWithTools integration in runTaskCycleWithContext", () =
     expect(result.toolVerification).toBeUndefined();
   });
 
+  it("passes runtime budget context into the production task cycle path", async () => {
+    const taskCycleResult = makeTaskCycleResult([]);
+    const ctx = makeBasePhaseCtx(undefined);
+    const runTaskCycle = ctx.deps.taskLifecycle.runTaskCycle as ReturnType<typeof vi.fn>;
+    runTaskCycle.mockResolvedValue(taskCycleResult);
+
+    const result = makeEmptyIterationResult(goalId, 0);
+    const gapVector = [] as unknown as import("../../../base/types/gap.js").GapVector;
+    const driveScores = [] as unknown as import("../../../base/types/drive.js").DriveScore[];
+
+    await runTaskCycleWithContext(
+      ctx,
+      goalId,
+      goal,
+      gapVector,
+      driveScores,
+      [],
+      0,
+      result,
+      Date.now(),
+      baseCallbacks,
+      undefined,
+      {
+        budgetContext: {
+          budget_id: "budget-run",
+          mode: "consolidation",
+          remaining: { evaluator_attempts: 1 },
+          approval_required: true,
+        },
+      }
+    );
+
+    expect(runTaskCycle).toHaveBeenCalledWith(
+      goalId,
+      gapVector,
+      expect.anything(),
+      expect.anything(),
+      expect.stringContaining("Runtime budget context:"),
+      expect.anything(),
+      undefined,
+      expect.anything(),
+    );
+    expect(runTaskCycle.mock.calls[0]?.[4]).toContain('"approval_required": true');
+    expect(runTaskCycle.mock.calls[0]?.[4]).toContain('"evaluator_attempts": 1');
+  });
+
   it("Test 4: catches error from verifyWithTools without failing the loop (non-fatal)", async () => {
     const criteria = makeCriteria();
     const taskCycleResult = makeTaskCycleResult(criteria);

--- a/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { CoreLoop, makeEmptyIterationResult, type CoreLoopDeps } from "../core-loop.js";
 import { makeGoal } from "../../../../tests/helpers/fixtures.js";
+import { RuntimeBudgetStore } from "../../../runtime/store/budget-store.js";
 
 function makeDeps(): CoreLoopDeps {
   return {
@@ -24,6 +28,13 @@ function makeDeps(): CoreLoopDeps {
 }
 
 describe("CoreLoop run policies", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => fsp.rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
   it("keeps bounded maxIterations as a lifecycle cap", async () => {
     const loop = new CoreLoop(makeDeps(), {
       maxIterations: 2,
@@ -80,5 +91,124 @@ describe("CoreLoop run policies", () => {
 
     expect(result.finalStatus).toBe("stopped");
     expect(result.totalIterations).toBe(2);
+  });
+
+  it("persists runtime budget usage from the CoreLoop caller path", async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-core-budget-"));
+    tempDirs.push(tempDir);
+    const runtimeBudgetStore = new RuntimeBudgetStore(path.join(tempDir, "runtime"));
+    const deps = {
+      ...makeDeps(),
+      runtimeBudgetStore,
+      reportingEngine: { generateExecutionSummary: vi.fn(), saveReport: vi.fn() },
+    } as unknown as CoreLoopDeps;
+    const loop = new CoreLoop(deps, {
+      maxIterations: 2,
+      delayBetweenLoopsMs: 0,
+      autoDecompose: false,
+      runtimeBudget: {
+        budgetId: "budget-coreloop-test",
+        limits: [
+          { dimension: "iterations", limit: 2 },
+          { dimension: "tasks", limit: 2 },
+          { dimension: "wall_clock_ms", limit: 1000 },
+          { dimension: "process_ms", limit: 1000 },
+          { dimension: "llm_tokens", limit: 1000 },
+          { dimension: "artifacts", limit: 4 },
+        ],
+      },
+    });
+    vi.spyOn(loop, "runOneIteration").mockImplementation(async (goalId, loopIndex) =>
+      makeEmptyIterationResult(goalId, loopIndex, {
+        elapsedMs: 25,
+        tokensUsed: 123,
+        taskResult: {
+          action: "completed",
+          task: {
+            id: `task-${loopIndex}`,
+            goal_id: goalId,
+            strategy_id: null,
+            target_dimensions: [],
+            primary_dimension: "quality",
+            work_description: "Do work",
+            rationale: "Needed",
+            approach: "Patch",
+            success_criteria: [],
+            scope_boundary: { in_scope: [], out_of_scope: [], blast_radius: "" },
+            constraints: [],
+            plateau_until: null,
+            estimated_duration: null,
+            consecutive_failure_count: 0,
+            reversibility: "unknown",
+            status: "completed",
+            started_at: null,
+            completed_at: null,
+            timeout_at: null,
+            heartbeat_at: null,
+            created_at: new Date().toISOString(),
+            task_category: "normal",
+          },
+          verificationResult: {
+            task_id: `task-${loopIndex}`,
+            verdict: "pass",
+            confidence: 1,
+            evidence: [],
+            dimension_updates: [],
+            file_diffs: [{ path: `artifact-${loopIndex}.diff`, patch: "+x" }],
+            timestamp: new Date().toISOString(),
+          },
+          tokensUsed: 123,
+        },
+      })
+    );
+
+    await loop.run("goal-budgeted");
+
+    const budget = await runtimeBudgetStore.load("budget-coreloop-test");
+    const status = runtimeBudgetStore.status(budget!);
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "iterations", used: 2, remaining: 0 }));
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "tasks", used: 2, remaining: 0 }));
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "wall_clock_ms", used: 50, remaining: 950 }));
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "process_ms", used: 50, remaining: 950 }));
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "llm_tokens", used: 246, remaining: 754 }));
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "artifacts", used: 2, remaining: 2 }));
+  });
+
+  it("enforces stop exhaustion policy without asking for approval", async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-core-budget-stop-"));
+    tempDirs.push(tempDir);
+    const runtimeBudgetStore = new RuntimeBudgetStore(path.join(tempDir, "runtime"));
+    await runtimeBudgetStore.create({
+      budget_id: "budget-stop-policy",
+      scope: { goal_id: "goal-budget-stop" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [{ dimension: "iterations", limit: 1, exhaustion_policy: "stop" }],
+    });
+    await runtimeBudgetStore.recordTaskExecution("budget-stop-policy", { iterations: 1 });
+    const waitApprovalBroker = { requestApproval: vi.fn().mockResolvedValue(true) };
+    const loop = new CoreLoop({
+      ...makeDeps(),
+      runtimeBudgetStore,
+      waitApprovalBroker,
+      reportingEngine: { generateExecutionSummary: vi.fn(), saveReport: vi.fn() },
+    } as unknown as CoreLoopDeps, {
+      maxIterations: 2,
+      delayBetweenLoopsMs: 0,
+      autoDecompose: false,
+      runtimeBudget: {
+        budgetId: "budget-stop-policy",
+        limits: [{ dimension: "iterations", limit: 1, exhaustion_policy: "stop" }],
+      },
+    });
+    const runOneIteration = vi.spyOn(loop, "runOneIteration").mockResolvedValue(
+      makeEmptyIterationResult("goal-budget-stop", 0)
+    );
+
+    const result = await loop.run("goal-budget-stop");
+
+    expect(result.totalIterations).toBe(0);
+    expect(result.finalStatus).toBe("stopped");
+    expect(runOneIteration).not.toHaveBeenCalled();
+    expect(waitApprovalBroker.requestApproval).not.toHaveBeenCalled();
   });
 });

--- a/src/orchestrator/loop/__tests__/core-loop-tree.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-tree.test.ts
@@ -21,6 +21,7 @@ import type { DriveScore } from "../../../base/types/drive.js";
 import type { TreeLoopOrchestrator } from "../../goal/tree-loop-orchestrator.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { makeGoal } from "../../../../tests/helpers/fixtures.js";
+import { RuntimeBudgetStore } from "../../../runtime/store/budget-store.js";
 
 function makeGapVector(goalId = "goal-1"): GapVector {
   return {
@@ -747,6 +748,44 @@ describe("CoreLoop tree mode (14C)", async () => {
     expect(orchestratorMock.selectPreferredNode).toHaveBeenCalledWith("root-1", ["node-id-2"]);
     expect(orchestratorMock.selectNextNode).toHaveBeenCalledWith("root-1");
     expect(iterResult.goalId).toBe("node-id-1");
+  });
+
+  it("tree-mode task generation receives runtime budget context", async () => {
+    const orchestratorMock = createTreeLoopOrchestratorMock("node-id-1");
+    const { deps, mocks } = createTreeModeDeps(tmpDir, orchestratorMock);
+    const runtimeBudgetStore = new RuntimeBudgetStore(`${tmpDir}/runtime`);
+    await runtimeBudgetStore.create({
+      budget_id: "budget-tree",
+      scope: { goal_id: "root-1" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [
+        { dimension: "iterations", limit: 3 },
+        { dimension: "evaluator_attempts", limit: 3, approval_at_remaining: 1 },
+      ],
+    });
+    await runtimeBudgetStore.recordEvaluatorCall("budget-tree", { observed_at: "2026-05-01T00:01:00.000Z" });
+
+    const rootGoal = makeGoal({ id: "root-1", children_ids: ["node-id-1"] });
+    const nodeGoal = makeGoal({ id: "node-id-1", parent_id: "root-1" });
+    await mocks.stateManager.saveGoal(rootGoal);
+    await mocks.stateManager.saveGoal(nodeGoal);
+
+    const loop = new CoreLoop({ ...deps, runtimeBudgetStore }, {
+      treeMode: true,
+      maxIterations: 1,
+      delayBetweenLoopsMs: 0,
+      runtimeBudget: {
+        budgetId: "budget-tree",
+        limits: [{ dimension: "iterations", limit: 3 }],
+      },
+    });
+
+    await loop.run("root-1");
+
+    const knowledgeContext = mocks.taskLifecycle.runTaskCycle.mock.calls[0]?.[4];
+    expect(knowledgeContext).toContain("Runtime budget context:");
+    expect(knowledgeContext).toContain('"budget_id": "budget-tree"');
+    expect(knowledgeContext).toContain('"evaluator_attempts": 2');
   });
 
   it("runTreeIteration with null node returns rootId and no task", async () => {

--- a/src/orchestrator/loop/core-loop.ts
+++ b/src/orchestrator/loop/core-loop.ts
@@ -26,6 +26,11 @@ import type { CorePhasePolicyRegistry } from "./core-loop/phase-policy.js";
 import { CoreIterationKernel } from "./core-loop/iteration-kernel.js";
 import type { GoalRunActivationContext } from "../../base/types/goal-activation.js";
 import { resolveLoopConfig, resolveLoopRunPolicy } from "./run-policy.js";
+import type {
+  RuntimeBudgetLimitInput,
+  RuntimeBudgetRecord,
+  RuntimeBudgetStatus,
+} from "../../runtime/store/budget-store.js";
 
 // Re-export types for backward compatibility
 export type {
@@ -48,7 +53,7 @@ export type {
 export { buildDriveContext } from "./core-loop/contracts.js";
 export { makeEmptyIterationResult } from "./loop-result-types.js";
 
-const DEFAULT_CONFIG: Required<Omit<LoopConfig, "iterationBudget">> = {
+const DEFAULT_CONFIG: Required<Omit<LoopConfig, "iterationBudget" | "runtimeBudget">> = {
   maxIterations: 100,
   runPolicy: { mode: "bounded", maxIterations: 100 },
   maxConsecutiveErrors: 3,
@@ -208,6 +213,13 @@ export class CoreLoop {
     const effectiveRunPolicy = this.config.runPolicy ?? resolveLoopRunPolicy({ maxIterations: this.config.maxIterations });
     const effectiveMaxIterations = effectiveRunPolicy.maxIterations;
     const hasIterationCap = effectiveRunPolicy.mode === "bounded" && effectiveMaxIterations !== null;
+    const runtimeBudgetId = await this.ensureRuntimeBudgetForRun({
+      goalId,
+      startedAt,
+      runId: this.currentActivationContext?.backgroundRun?.backgroundRunId,
+      hasIterationCap,
+      effectiveMaxIterations,
+    });
 
     // Use the provided iterationBudget if set; otherwise create a local one.
     const budget: IterationBudget | null = this.config.iterationBudget
@@ -233,14 +245,19 @@ export class CoreLoop {
         }
         break;
       }
+      const budgetGate = await this.evaluateRuntimeBudgetGate(goalId, runtimeBudgetId);
+      if (budgetGate.stop) {
+        finalStatus = budgetGate.finalStatus;
+        break;
+      }
 
       void this.deps.hookManager?.emit("LoopCycleStart", { goal_id: goalId, data: { loopIndex } });
 
       let iterationResult: LoopIterationResult;
       try {
         iterationResult = this.config.treeMode && this.deps.treeLoopOrchestrator
-          ? await this.runTreeIteration(goalId, loopIndex, nodeConsumedMap)
-          : await this.runOneIteration(goalId, loopIndex, loopIndex === startLoopIndex);
+          ? await this.runTreeIteration(goalId, loopIndex, nodeConsumedMap, runtimeBudgetId)
+          : await this.runOneIteration(goalId, loopIndex, loopIndex === startLoopIndex, runtimeBudgetId);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         this.logger?.error(`[CoreLoop] unexpected error in iteration ${loopIndex}: ${msg}`);
@@ -269,6 +286,7 @@ export class CoreLoop {
           break;
         }
       }
+      await this.recordRuntimeBudgetUsage(runtimeBudgetId, iterationResult);
       void this.deps.hookManager?.emit("LoopCycleEnd", { goal_id: goalId, data: { loopIndex, status: iterationResult.error ? "error" : "ok" } });
 
       iterations.push(iterationResult);
@@ -405,7 +423,8 @@ export class CoreLoop {
   async runOneIteration(
     goalId: string,
     loopIndex: number,
-    isFirstIteration?: boolean
+    isFirstIteration?: boolean,
+    runtimeBudgetId?: string | null
   ): Promise<LoopIterationResult> {
     const result = await new CoreIterationKernel({
       deps: this.deps,
@@ -424,6 +443,7 @@ export class CoreLoop {
       incrementTransferCounter: () => this.learning.incrementTransferCounter(),
       getPendingDirective: (id) => this.pendingIterationDirectives.get(id),
       getActivationContext: () => this.currentActivationContext,
+      getRuntimeBudgetContext: () => this.loadRuntimeBudgetTaskContext(runtimeBudgetId),
     }).run({ goalId, loopIndex, isFirstIteration });
     if (result.nextIterationDirective) {
       this.pendingIterationDirectives.set(goalId, result.nextIterationDirective);
@@ -437,9 +457,14 @@ export class CoreLoop {
    * Tree-mode iteration: select one node via TreeLoopOrchestrator, run a
    * normal observe→gap→score→task cycle on that node, then aggregate upward.
    */
-  async runTreeIteration(rootId: string, loopIndex: number, nodeConsumedMap: Map<string, number>): Promise<LoopIterationResult> {
+  async runTreeIteration(
+    rootId: string,
+    loopIndex: number,
+    nodeConsumedMap: Map<string, number>,
+    runtimeBudgetId?: string | null
+  ): Promise<LoopIterationResult> {
     return runTreeIterationImpl(rootId, loopIndex, this.deps, this.config, this.logger,
-      (id, idx) => this.runOneIteration(id, idx), nodeConsumedMap, {
+      (id, idx) => this.runOneIteration(id, idx, undefined, runtimeBudgetId), nodeConsumedMap, {
         getPendingDirective: (id) => this.pendingIterationDirectives.get(id),
       });
   }
@@ -479,6 +504,129 @@ export class CoreLoop {
    */
   isStopped(): boolean {
     return this.stopped;
+  }
+
+  private async ensureRuntimeBudgetForRun(input: {
+    goalId: string;
+    startedAt: string;
+    runId?: string;
+    hasIterationCap: boolean;
+    effectiveMaxIterations: number | null;
+  }): Promise<string | null> {
+    if (this.config.dryRun || !this.deps.runtimeBudgetStore) return null;
+    const configuredLimits = this.config.runtimeBudget?.limits;
+    const defaultLimits: RuntimeBudgetLimitInput[] =
+      configuredLimits ?? (
+        input.hasIterationCap && input.effectiveMaxIterations !== null
+          ? [{
+              dimension: "iterations",
+              limit: input.effectiveMaxIterations,
+              approval_at_remaining: 0,
+              finalization_at_remaining: 0,
+              exhaustion_policy: "approval_required",
+            }]
+          : []
+      );
+    if (defaultLimits.length === 0) return null;
+    const budgetId = this.config.runtimeBudget?.budgetId
+      ?? `runtime-budget:${input.runId ?? `goal:${input.goalId}`}`;
+    const existing = await this.deps.runtimeBudgetStore.load(budgetId);
+    if (existing) return budgetId;
+    try {
+      await this.deps.runtimeBudgetStore.create({
+        budget_id: budgetId,
+        scope: {
+          goal_id: input.goalId,
+          ...(input.runId ? { run_id: input.runId } : {}),
+        },
+        title: this.config.runtimeBudget?.title ?? `Runtime budget for ${input.goalId}`,
+        created_at: input.startedAt,
+        limits: defaultLimits,
+      });
+    } catch (err) {
+      const loaded = await this.deps.runtimeBudgetStore.load(budgetId);
+      if (!loaded) throw err;
+    }
+    return budgetId;
+  }
+
+  private async evaluateRuntimeBudgetGate(goalId: string, budgetId: string | null): Promise<{
+    stop: boolean;
+    finalStatus: LoopResult["finalStatus"];
+  }> {
+    const status = await this.loadRuntimeBudgetStatus(budgetId);
+    if (!status) return { stop: false, finalStatus: "stopped" };
+    if (status.finalization_required) return { stop: true, finalStatus: "finalization" };
+    if (status.dimensions.some((dimension) => dimension.exhausted && dimension.exhaustion_policy === "stop")) {
+      return { stop: true, finalStatus: "stopped" };
+    }
+    if (!status.exhausted && !status.approval_required && !status.handoff_required) {
+      return { stop: false, finalStatus: "stopped" };
+    }
+    if (status.approval_required && this.deps.waitApprovalBroker) {
+      const approved = await this.deps.waitApprovalBroker.requestApproval(
+        goalId,
+        {
+          id: `budget:${status.budget_id}`,
+          description: `Runtime budget threshold reached for ${status.budget_id}.`,
+          action: "continue_after_budget_threshold",
+        },
+        undefined,
+        `budget:${status.budget_id}`,
+      );
+      if (approved) return { stop: false, finalStatus: "stopped" };
+    }
+    return { stop: true, finalStatus: "stopped" };
+  }
+
+  private async loadRuntimeBudgetTaskContext(budgetId: string | null | undefined): Promise<Record<string, unknown> | undefined> {
+    if (!budgetId || !this.deps.runtimeBudgetStore) return undefined;
+    const budget = await this.deps.runtimeBudgetStore.load(budgetId);
+    return budget ? this.deps.runtimeBudgetStore.taskGenerationContext(budget) : undefined;
+  }
+
+  private async loadRuntimeBudgetStatus(budgetId: string | null | undefined): Promise<RuntimeBudgetStatus | null> {
+    const budget = await this.loadRuntimeBudgetRecord(budgetId);
+    return budget && this.deps.runtimeBudgetStore ? this.deps.runtimeBudgetStore.status(budget) : null;
+  }
+
+  private async loadRuntimeBudgetRecord(budgetId: string | null | undefined): Promise<RuntimeBudgetRecord | null> {
+    if (!budgetId || !this.deps.runtimeBudgetStore) return null;
+    return this.deps.runtimeBudgetStore.load(budgetId);
+  }
+
+  private async recordRuntimeBudgetUsage(budgetId: string | null, iterationResult: LoopIterationResult): Promise<void> {
+    if (!budgetId || !this.deps.runtimeBudgetStore || this.config.dryRun) return;
+    try {
+      await this.deps.runtimeBudgetStore.recordTaskExecution(budgetId, {
+        iterations: 1,
+        tasks: iterationResult.taskResult ? 1 : 0,
+        process_ms: Math.max(0, iterationResult.elapsedMs),
+        wall_clock_ms: Math.max(0, iterationResult.elapsedMs),
+        reason: `coreloop iteration ${iterationResult.loopIndex}`,
+      });
+      if (iterationResult.tokensUsed && iterationResult.tokensUsed > 0) {
+        await this.deps.runtimeBudgetStore.recordToolUsage(budgetId, {
+          llm_tokens: iterationResult.tokensUsed,
+          reason: `coreloop iteration ${iterationResult.loopIndex}`,
+        });
+      }
+      const artifactCount = iterationResult.taskResult?.verificationResult.file_diffs?.length
+        ?? 0;
+      if (artifactCount > 0) {
+        await this.deps.runtimeBudgetStore.recordArtifactGeneration(budgetId, {
+          artifacts: artifactCount,
+          reason: `coreloop iteration ${iterationResult.loopIndex}`,
+        });
+      }
+    } catch (err) {
+      this.logger?.warn("CoreLoop: failed to record runtime budget usage", {
+        budgetId,
+        goalId: iterationResult.goalId,
+        loopIndex: iterationResult.loopIndex,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
 }

--- a/src/orchestrator/loop/core-loop/contracts.ts
+++ b/src/orchestrator/loop/core-loop/contracts.ts
@@ -35,6 +35,10 @@ import type { CorePhasePolicyRegistry } from "./phase-policy.js";
 import type { CoreDecisionEngine } from "./decision-engine.js";
 import type { GoalRunActivationContext } from "../../../base/types/goal-activation.js";
 import type { RuntimeEvidenceLedgerPort } from "../../../runtime/store/evidence-ledger.js";
+import type {
+  RuntimeBudgetLimitInput,
+  RuntimeBudgetStore,
+} from "../../../runtime/store/budget-store.js";
 import type { DeadlineFinalizationStatus } from "../../../platform/time/deadline-finalization.js";
 import type { ExecutionModeState } from "../../../platform/time/execution-mode.js";
 export type {
@@ -132,12 +136,18 @@ export type LoopRunPolicyInput =
   | Partial<LoopRunPolicy>;
 
 export type ResolvedLoopConfig =
-  Required<Omit<LoopConfig, "iterationBudget" | "runPolicy" | "maxIterations">>
-  & Pick<LoopConfig, "iterationBudget">
+  Required<Omit<LoopConfig, "iterationBudget" | "runPolicy" | "maxIterations" | "runtimeBudget">>
+  & Pick<LoopConfig, "iterationBudget" | "runtimeBudget">
   & {
     maxIterations: number | null;
     runPolicy?: LoopRunPolicy;
   };
+
+export interface RuntimeBudgetConfig {
+  budgetId?: string;
+  title?: string;
+  limits?: RuntimeBudgetLimitInput[];
+}
 
 export interface LoopConfig {
   maxIterations?: number | null;
@@ -190,6 +200,12 @@ export interface LoopConfig {
    * If not set, maxIterations acts as the sole upper bound.
    */
   iterationBudget?: IterationBudget;
+  /**
+   * Optional durable runtime budget governance for long-running goal/run work.
+   * When omitted, bounded runs get an iteration budget record derived from maxIterations
+   * if a RuntimeBudgetStore is available.
+   */
+  runtimeBudget?: RuntimeBudgetConfig;
   /**
    * When true (default), automatically consolidate agent memory when a goal completes
    * and raw entry count exceeds consolidationRawThreshold.
@@ -309,6 +325,8 @@ export interface CoreLoopDeps extends ObservationDeps, TreeDeps, StallDeps, Task
   toolRegistry?: ToolRegistry;
   /** Optional durable evidence ledger for long-running autonomous work review/resume. */
   evidenceLedger?: RuntimeEvidenceLedgerPort;
+  /** Optional durable budget store for long-running goal/run budget governance. */
+  runtimeBudgetStore?: RuntimeBudgetStore;
   /** Optional bounded agentloop runner for core phases. */
   corePhaseRunner?: CorePhaseRunner;
   /** Optional live approval broker for wait/resume approvals. */

--- a/src/orchestrator/loop/core-loop/iteration-kernel.ts
+++ b/src/orchestrator/loop/core-loop/iteration-kernel.ts
@@ -99,6 +99,7 @@ export interface CoreIterationKernelDeps {
   incrementTransferCounter: () => number;
   getPendingDirective: (goalId: string) => NextIterationDirective | undefined;
   getActivationContext: () => GoalRunActivationContext | undefined;
+  getRuntimeBudgetContext?: () => Promise<Record<string, unknown> | undefined>;
 }
 
 export interface RunCoreIterationInput {
@@ -728,9 +729,18 @@ export class CoreIterationKernel {
       phase: replanningOptions,
       goalDimensions: goal.dimensions.map((dimension) => dimension.name),
     });
+    const runtimeBudgetContext = await this.deps.getRuntimeBudgetContext?.().catch((err) => {
+      this.deps.logger?.warn("CoreLoop: failed to load runtime budget context", {
+        goalId,
+        loopIndex,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return undefined;
+    });
     const mergedTaskGenerationHints = {
       targetDimensionOverride: taskGenerationHints.targetDimensionOverride ?? pendingDirective?.focusDimension,
       knowledgeContextPrefix: taskGenerationHints.knowledgeContextPrefix,
+      budgetContext: runtimeBudgetContext,
       executionMode,
       runControlRecommendationContext: dreamRunControlRecommendationContext,
     };

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -150,6 +150,7 @@ export interface LoopCallbacks {
 export interface TaskGenerationHints {
   targetDimensionOverride?: string;
   knowledgeContextPrefix?: string;
+  budgetContext?: Record<string, unknown>;
   executionMode?: ExecutionModeState;
   runControlRecommendationContext?: string;
 }
@@ -388,6 +389,8 @@ export async function runTaskCycleWithContext(
       }
     }
 
+    const budgetContextBlock = formatBudgetContext(taskGenerationHints?.budgetContext);
+    knowledgeContext = [budgetContextBlock, knowledgeContext].filter(Boolean).join("\n\n") || undefined;
     knowledgeContext = evidenceLedger?.augmentKnowledgeContext(knowledgeContext) ?? knowledgeContext;
     workspaceContext = evidenceLedger?.augmentWorkspaceContext(workspaceContext) ?? workspaceContext;
 
@@ -523,4 +526,9 @@ export async function runTaskCycleWithContext(
   }
 
   return true;
+}
+
+function formatBudgetContext(context: Record<string, unknown> | undefined): string | undefined {
+  if (!context) return undefined;
+  return `Runtime budget context:\n${JSON.stringify(context, null, 2)}`;
 }

--- a/src/runtime/__tests__/budget-store.test.ts
+++ b/src/runtime/__tests__/budget-store.test.ts
@@ -1,0 +1,177 @@
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RuntimeBudgetStore } from "../store/budget-store.js";
+
+describe("RuntimeBudgetStore", () => {
+  let tmpDir: string;
+  let store: RuntimeBudgetStore;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-budget-store-"));
+    store = new RuntimeBudgetStore(path.join(tmpDir, "runtime"));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("persists budget definitions and current usage across task/artifact/tool/evaluator updates", async () => {
+    await store.create({
+      budget_id: "budget-run",
+      scope: { goal_id: "goal-a", run_id: "run-a" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [
+        { dimension: "iterations", limit: 10 },
+        { dimension: "disk_bytes", limit: 1000 },
+        { dimension: "llm_tokens", limit: 5000 },
+        { dimension: "evaluator_attempts", limit: 3 },
+      ],
+    });
+    await store.recordTaskExecution("budget-run", { iterations: 2, observed_at: "2026-05-01T00:01:00.000Z" });
+    await store.recordArtifactGeneration("budget-run", { disk_bytes: 250, observed_at: "2026-05-01T00:02:00.000Z" });
+    await store.recordToolUsage("budget-run", { llm_tokens: 1000, observed_at: "2026-05-01T00:03:00.000Z" });
+    await store.recordEvaluatorCall("budget-run", { observed_at: "2026-05-01T00:04:00.000Z" });
+
+    const restarted = new RuntimeBudgetStore(path.join(tmpDir, "runtime"));
+    const budget = await restarted.load("budget-run");
+    const status = restarted.status(budget!);
+
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "iterations", used: 2, remaining: 8 }));
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "disk_bytes", used: 250, remaining: 750 }));
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "llm_tokens", used: 1000, remaining: 4000 }));
+    expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "evaluator_attempts", used: 1, remaining: 2 }));
+    expect(status.recent_consumption[0]).toMatchObject({ source: "evaluator_call", amount: 1 });
+  });
+
+  it("marks exhaustion and applies the configured exhaustion policy", async () => {
+    await store.create({
+      budget_id: "budget-exhausted",
+      scope: { goal_id: "goal-a" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [
+        {
+          dimension: "tasks",
+          limit: 2,
+          exhaustion_policy: "handoff_required",
+        },
+      ],
+    });
+
+    await store.recordTaskExecution("budget-exhausted", { tasks: 2, observed_at: "2026-05-01T00:01:00.000Z" });
+    const status = store.status((await store.load("budget-exhausted"))!);
+
+    expect(status).toMatchObject({
+      mode: "exhausted",
+      exhausted: true,
+      approval_required: false,
+      handoff_required: true,
+    });
+    expect(status.dimensions[0]).toMatchObject({
+      dimension: "tasks",
+      remaining: 0,
+      exhausted: true,
+      exhaustion_policy: "handoff_required",
+      threshold_actions: ["handoff_required"],
+    });
+  });
+
+  it("does not convert stop exhaustion policy into approval-required continuation", async () => {
+    await store.create({
+      budget_id: "budget-stop",
+      scope: { goal_id: "goal-a" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [
+        {
+          dimension: "tasks",
+          limit: 1,
+          exhaustion_policy: "stop",
+        },
+      ],
+    });
+
+    await store.recordTaskExecution("budget-stop", { tasks: 1, observed_at: "2026-05-01T00:01:00.000Z" });
+    const status = store.status((await store.load("budget-stop"))!);
+
+    expect(status.exhausted).toBe(true);
+    expect(status.approval_required).toBe(false);
+    expect(status.dimensions[0]).toMatchObject({
+      dimension: "tasks",
+      exhaustion_policy: "stop",
+      threshold_actions: [],
+    });
+  });
+
+  it("triggers approval before a high-cost branch when remaining budget crosses threshold", async () => {
+    await store.create({
+      budget_id: "budget-approval",
+      scope: { run_id: "run-a" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [
+        {
+          dimension: "evaluator_attempts",
+          limit: 3,
+          approval_at_remaining: 1,
+        },
+      ],
+    });
+
+    await store.recordEvaluatorCall("budget-approval", { attempts: 2, observed_at: "2026-05-01T00:01:00.000Z" });
+    const status = store.status((await store.load("budget-approval"))!);
+
+    expect(status.approval_required).toBe(true);
+    expect(status.dimensions[0]).toMatchObject({
+      dimension: "evaluator_attempts",
+      used: 2,
+      remaining: 1,
+      threshold_actions: ["approval_required"],
+    });
+  });
+
+  it("switches task generation context from exploration to consolidation and finalization by remaining budget", async () => {
+    await store.create({
+      budget_id: "budget-mode",
+      scope: { goal_id: "goal-a" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [
+        {
+          dimension: "wall_clock_ms",
+          limit: 1000,
+          finalization_at_remaining: 150,
+          mode_transition_at_remaining: {
+            consolidation: 400,
+            finalization: 150,
+          },
+        },
+      ],
+    });
+
+    await store.updateUsage("budget-mode", {
+      dimension: "wall_clock_ms",
+      amount: 650,
+      source: "manual",
+      observed_at: "2026-05-01T00:01:00.000Z",
+    });
+    let budget = (await store.load("budget-mode"))!;
+    expect(store.taskGenerationContext(budget)).toMatchObject({
+      mode: "consolidation",
+      finalization_required: false,
+      remaining: { wall_clock_ms: 350 },
+    });
+
+    await store.updateUsage("budget-mode", {
+      dimension: "wall_clock_ms",
+      amount: 250,
+      source: "manual",
+      observed_at: "2026-05-01T00:02:00.000Z",
+    });
+    budget = (await store.load("budget-mode"))!;
+
+    expect(store.taskGenerationContext(budget)).toMatchObject({
+      mode: "finalization",
+      finalization_required: true,
+      remaining: { wall_clock_ms: 100 },
+    });
+  });
+});

--- a/src/runtime/store/budget-store.ts
+++ b/src/runtime/store/budget-store.ts
@@ -1,0 +1,384 @@
+import { z } from "zod";
+import {
+  createRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+import { RuntimeJournal } from "./runtime-journal.js";
+
+export const RuntimeBudgetDimensionSchema = z.enum([
+  "wall_clock_ms",
+  "iterations",
+  "tasks",
+  "process_ms",
+  "disk_bytes",
+  "artifacts",
+  "llm_tokens",
+  "tool_calls",
+  "evaluator_attempts",
+]);
+export type RuntimeBudgetDimension = z.infer<typeof RuntimeBudgetDimensionSchema>;
+
+export const RuntimeBudgetModeSchema = z.enum([
+  "exploration",
+  "consolidation",
+  "finalization",
+  "exhausted",
+]);
+export type RuntimeBudgetMode = z.infer<typeof RuntimeBudgetModeSchema>;
+
+export const RuntimeBudgetThresholdActionSchema = z.enum([
+  "approval_required",
+  "handoff_required",
+  "finalization_required",
+]);
+export type RuntimeBudgetThresholdAction = z.infer<typeof RuntimeBudgetThresholdActionSchema>;
+
+export const RuntimeBudgetScopeSchema = z.object({
+  goal_id: z.string().min(1).optional(),
+  run_id: z.string().min(1).optional(),
+}).strict().refine((scope) => Boolean(scope.goal_id || scope.run_id), {
+  message: "budget scope requires goal_id or run_id",
+});
+export type RuntimeBudgetScope = z.infer<typeof RuntimeBudgetScopeSchema>;
+
+export const RuntimeBudgetLimitSchema = z.object({
+  dimension: RuntimeBudgetDimensionSchema,
+  limit: z.number().nonnegative(),
+  warn_at_remaining: z.number().nonnegative().optional(),
+  approval_at_remaining: z.number().nonnegative().optional(),
+  handoff_at_remaining: z.number().nonnegative().optional(),
+  finalization_at_remaining: z.number().nonnegative().optional(),
+  mode_transition_at_remaining: z.object({
+    consolidation: z.number().nonnegative().optional(),
+    finalization: z.number().nonnegative().optional(),
+  }).strict().optional(),
+  exhaustion_policy: z.enum(["stop", "approval_required", "handoff_required", "finalize"]).default("approval_required"),
+}).strict();
+export type RuntimeBudgetLimit = z.infer<typeof RuntimeBudgetLimitSchema>;
+export type RuntimeBudgetLimitInput = z.input<typeof RuntimeBudgetLimitSchema>;
+
+export const RuntimeBudgetUsageSchema = z.object({
+  dimension: RuntimeBudgetDimensionSchema,
+  used: z.number().nonnegative(),
+  updated_at: z.string().datetime(),
+  recent: z.array(z.object({
+    amount: z.number().nonnegative(),
+    source: z.enum(["task_execution", "artifact_generation", "tool_usage", "evaluator_call", "manual"]),
+    reason: z.string().min(1).optional(),
+    observed_at: z.string().datetime(),
+  }).strict()).default([]),
+}).strict();
+export type RuntimeBudgetUsage = z.infer<typeof RuntimeBudgetUsageSchema>;
+export type RuntimeBudgetUsageInput = z.input<typeof RuntimeBudgetUsageSchema>;
+
+export const RuntimeBudgetRecordSchema = z.object({
+  schema_version: z.literal("runtime-budget-v1"),
+  budget_id: z.string().min(1),
+  scope: RuntimeBudgetScopeSchema,
+  title: z.string().min(1).optional(),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  limits: z.array(RuntimeBudgetLimitSchema).min(1),
+  usage: z.array(RuntimeBudgetUsageSchema),
+  notes: z.string().min(1).optional(),
+}).strict().superRefine((budget, ctx) => {
+  const seenLimits = new Set<string>();
+  for (const limit of budget.limits) {
+    if (seenLimits.has(limit.dimension)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["limits", limit.dimension],
+        message: `duplicate budget limit dimension: ${limit.dimension}`,
+      });
+    }
+    seenLimits.add(limit.dimension);
+  }
+  const seenUsage = new Set<string>();
+  for (const usage of budget.usage) {
+    if (seenUsage.has(usage.dimension)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["usage", usage.dimension],
+        message: `duplicate budget usage dimension: ${usage.dimension}`,
+      });
+    }
+    seenUsage.add(usage.dimension);
+  }
+});
+export type RuntimeBudgetRecord = z.infer<typeof RuntimeBudgetRecordSchema>;
+const RuntimeBudgetRecordRuntimeSchema = RuntimeBudgetRecordSchema as unknown as z.ZodType<RuntimeBudgetRecord>;
+
+export interface RuntimeBudgetCreateInput {
+  budget_id: string;
+  scope: RuntimeBudgetScope;
+  title?: string;
+  created_at?: string;
+  limits: RuntimeBudgetLimitInput[];
+  notes?: string;
+}
+
+export interface RuntimeBudgetUsageUpdateInput {
+  dimension: RuntimeBudgetDimension;
+  amount: number;
+  source: RuntimeBudgetUsage["recent"][number]["source"];
+  reason?: string;
+  observed_at?: string;
+}
+
+export interface RuntimeBudgetDimensionStatus {
+  dimension: RuntimeBudgetDimension;
+  limit: number;
+  used: number;
+  remaining: number;
+  exhausted: boolean;
+  exhaustion_policy: RuntimeBudgetLimit["exhaustion_policy"];
+  threshold_actions: RuntimeBudgetThresholdAction[];
+}
+
+export interface RuntimeBudgetStatus {
+  budget_id: string;
+  scope: RuntimeBudgetScope;
+  mode: RuntimeBudgetMode;
+  dimensions: RuntimeBudgetDimensionStatus[];
+  approval_required: boolean;
+  handoff_required: boolean;
+  finalization_required: boolean;
+  exhausted: boolean;
+  recent_consumption: RuntimeBudgetUsage["recent"];
+}
+
+export class RuntimeBudgetStore {
+  private readonly paths: RuntimeStorePaths;
+  private readonly journal: RuntimeJournal;
+  private readonly now: () => Date;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths, options: { now?: () => Date } = {}) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+    this.journal = new RuntimeJournal(this.paths);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async load(budgetId: string): Promise<RuntimeBudgetRecord | null> {
+    return this.journal.load(this.paths.budgetPath(budgetId), RuntimeBudgetRecordRuntimeSchema);
+  }
+
+  async list(): Promise<RuntimeBudgetRecord[]> {
+    return this.journal.list(this.paths.budgetsDir, RuntimeBudgetRecordRuntimeSchema);
+  }
+
+  async create(input: RuntimeBudgetCreateInput): Promise<RuntimeBudgetRecord> {
+    const existing = await this.load(input.budget_id);
+    if (existing) throw new Error(`Runtime budget already exists: ${input.budget_id}`);
+    const createdAt = input.created_at ?? this.nowIso();
+    const usage = input.limits.map((limit) => ({
+      dimension: limit.dimension,
+      used: 0,
+      updated_at: createdAt,
+      recent: [],
+    }));
+    return this.save({
+      schema_version: "runtime-budget-v1",
+      budget_id: input.budget_id,
+      scope: input.scope,
+      ...(input.title ? { title: input.title } : {}),
+      created_at: createdAt,
+      updated_at: createdAt,
+      limits: input.limits.map((limit) => RuntimeBudgetLimitSchema.parse(limit)),
+      usage,
+      ...(input.notes ? { notes: input.notes } : {}),
+    });
+  }
+
+  async updateUsage(budgetId: string, input: RuntimeBudgetUsageUpdateInput): Promise<RuntimeBudgetRecord> {
+    if (input.amount < 0) throw new Error("Budget usage amount must be non-negative");
+    return this.update(budgetId, (budget) => {
+      const observedAt = input.observed_at ?? this.nowIso();
+      const hasLimit = budget.limits.some((limit) => limit.dimension === input.dimension);
+      if (!hasLimit) throw new Error(`Budget ${budgetId} has no limit for ${input.dimension}`);
+      const usageByDimension = new Map(budget.usage.map((usage) => [usage.dimension, usage]));
+      const existing = usageByDimension.get(input.dimension) ?? {
+        dimension: input.dimension,
+        used: 0,
+        updated_at: observedAt,
+        recent: [],
+      };
+      const nextUsage: RuntimeBudgetUsage = {
+        ...existing,
+        used: existing.used + input.amount,
+        updated_at: observedAt,
+        recent: [
+          {
+            amount: input.amount,
+            source: input.source,
+            ...(input.reason ? { reason: input.reason } : {}),
+            observed_at: observedAt,
+          },
+          ...existing.recent,
+        ].slice(0, 20),
+      };
+      usageByDimension.set(input.dimension, nextUsage);
+      return {
+        ...budget,
+        updated_at: observedAt,
+        usage: budget.limits.map((limit) => usageByDimension.get(limit.dimension) ?? {
+          dimension: limit.dimension,
+          used: 0,
+          updated_at: observedAt,
+          recent: [],
+        }),
+      };
+    });
+  }
+
+  async recordTaskExecution(budgetId: string, input: { iterations?: number; tasks?: number; process_ms?: number; wall_clock_ms?: number; observed_at?: string; reason?: string }): Promise<RuntimeBudgetRecord> {
+    let budget = await this.mustLoad(budgetId);
+    for (const [dimension, amount] of [
+      ["iterations", input.iterations],
+      ["tasks", input.tasks],
+      ["process_ms", input.process_ms],
+      ["wall_clock_ms", input.wall_clock_ms],
+    ] as const) {
+      if (amount && amount > 0 && this.hasLimit(budget, dimension)) {
+        budget = await this.updateUsage(budgetId, { dimension, amount, source: "task_execution", observed_at: input.observed_at, reason: input.reason });
+      }
+    }
+    return budget;
+  }
+
+  async recordArtifactGeneration(budgetId: string, input: { disk_bytes?: number; artifacts?: number; observed_at?: string; reason?: string }): Promise<RuntimeBudgetRecord> {
+    let budget = await this.mustLoad(budgetId);
+    for (const [dimension, amount] of [
+      ["disk_bytes", input.disk_bytes],
+      ["artifacts", input.artifacts],
+    ] as const) {
+      if (amount && amount > 0 && this.hasLimit(budget, dimension)) {
+        budget = await this.updateUsage(budgetId, { dimension, amount, source: "artifact_generation", observed_at: input.observed_at, reason: input.reason });
+      }
+    }
+    return budget;
+  }
+
+  async recordToolUsage(budgetId: string, input: { llm_tokens?: number; tool_calls?: number; observed_at?: string; reason?: string }): Promise<RuntimeBudgetRecord> {
+    let budget = await this.mustLoad(budgetId);
+    for (const [dimension, amount] of [
+      ["llm_tokens", input.llm_tokens],
+      ["tool_calls", input.tool_calls],
+    ] as const) {
+      if (amount && amount > 0 && this.hasLimit(budget, dimension)) {
+        budget = await this.updateUsage(budgetId, { dimension, amount, source: "tool_usage", observed_at: input.observed_at, reason: input.reason });
+      }
+    }
+    return budget;
+  }
+
+  async recordEvaluatorCall(budgetId: string, input: { attempts?: number; observed_at?: string; reason?: string }): Promise<RuntimeBudgetRecord> {
+    const attempts = input.attempts ?? 1;
+    return this.updateUsage(budgetId, {
+      dimension: "evaluator_attempts",
+      amount: attempts,
+      source: "evaluator_call",
+      observed_at: input.observed_at,
+      reason: input.reason,
+    });
+  }
+
+  status(budget: RuntimeBudgetRecord): RuntimeBudgetStatus {
+    const usageByDimension = new Map(budget.usage.map((usage) => [usage.dimension, usage]));
+    const dimensions = budget.limits.map((limit) => {
+      const used = usageByDimension.get(limit.dimension)?.used ?? 0;
+      const remaining = Math.max(0, limit.limit - used);
+      const thresholdActions = thresholdActionsFor(limit, remaining, used);
+      return {
+        dimension: limit.dimension,
+        limit: limit.limit,
+        used,
+        remaining,
+        exhausted: used >= limit.limit,
+        exhaustion_policy: limit.exhaustion_policy,
+        threshold_actions: thresholdActions,
+      };
+    });
+    const recent = budget.usage.flatMap((usage) => usage.recent).sort((a, b) => b.observed_at.localeCompare(a.observed_at)).slice(0, 10);
+    const mode = budgetMode(budget.limits, dimensions);
+    return {
+      budget_id: budget.budget_id,
+      scope: budget.scope,
+      mode,
+      dimensions,
+      approval_required: dimensions.some((dimension) => dimension.threshold_actions.includes("approval_required")),
+      handoff_required: dimensions.some((dimension) => dimension.threshold_actions.includes("handoff_required")),
+      finalization_required: dimensions.some((dimension) => dimension.threshold_actions.includes("finalization_required")),
+      exhausted: dimensions.some((dimension) => dimension.exhausted),
+      recent_consumption: recent,
+    };
+  }
+
+  taskGenerationContext(budget: RuntimeBudgetRecord): Record<string, unknown> {
+    const status = this.status(budget);
+    return {
+      budget_id: status.budget_id,
+      scope: status.scope,
+      mode: status.mode,
+      exhausted: status.exhausted,
+      approval_required: status.approval_required,
+      handoff_required: status.handoff_required,
+      finalization_required: status.finalization_required,
+      remaining: Object.fromEntries(status.dimensions.map((dimension) => [dimension.dimension, dimension.remaining])),
+      recent_consumption: status.recent_consumption,
+    };
+  }
+
+  private async mustLoad(budgetId: string): Promise<RuntimeBudgetRecord> {
+    const budget = await this.load(budgetId);
+    if (!budget) throw new Error(`Runtime budget not found: ${budgetId}`);
+    return budget;
+  }
+
+  private hasLimit(budget: RuntimeBudgetRecord, dimension: RuntimeBudgetDimension): boolean {
+    return budget.limits.some((limit) => limit.dimension === dimension);
+  }
+
+  private async update(
+    budgetId: string,
+    updater: (budget: RuntimeBudgetRecord) => RuntimeBudgetRecord,
+  ): Promise<RuntimeBudgetRecord> {
+    const budget = await this.mustLoad(budgetId);
+    return this.save(updater(budget));
+  }
+
+  private async save(budget: RuntimeBudgetRecord): Promise<RuntimeBudgetRecord> {
+    return this.journal.save(this.paths.budgetPath(budget.budget_id), RuntimeBudgetRecordRuntimeSchema, budget);
+  }
+
+  private nowIso(): string {
+    return this.now().toISOString();
+  }
+}
+
+function thresholdActionsFor(limit: RuntimeBudgetLimit, remaining: number, used: number): RuntimeBudgetThresholdAction[] {
+  const actions = new Set<RuntimeBudgetThresholdAction>();
+  if (limit.approval_at_remaining !== undefined && remaining <= limit.approval_at_remaining) actions.add("approval_required");
+  if (limit.handoff_at_remaining !== undefined && remaining <= limit.handoff_at_remaining) actions.add("handoff_required");
+  if (limit.finalization_at_remaining !== undefined && remaining <= limit.finalization_at_remaining) actions.add("finalization_required");
+  if (used >= limit.limit) {
+    if (limit.exhaustion_policy === "handoff_required") actions.add("handoff_required");
+    if (limit.exhaustion_policy === "finalize") actions.add("finalization_required");
+    if (limit.exhaustion_policy === "approval_required") actions.add("approval_required");
+  }
+  return [...actions];
+}
+
+function budgetMode(limits: RuntimeBudgetLimit[], dimensions: RuntimeBudgetDimensionStatus[]): RuntimeBudgetMode {
+  if (dimensions.some((dimension) => dimension.exhausted)) return "exhausted";
+  let mode: RuntimeBudgetMode = "exploration";
+  for (const status of dimensions) {
+    const limit = limits.find((candidate) => candidate.dimension === status.dimension);
+    const transitions = limit?.mode_transition_at_remaining;
+    if (transitions?.finalization !== undefined && status.remaining <= transitions.finalization) return "finalization";
+    if (transitions?.consolidation !== undefined && status.remaining <= transitions.consolidation) mode = "consolidation";
+  }
+  return mode;
+}

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -138,6 +138,31 @@ export {
   RuntimeExperimentQueueRevisionStatusSchema,
   RuntimeExperimentQueueStore,
 } from "./experiment-queue-store.js";
+export {
+  RuntimeBudgetDimensionSchema,
+  RuntimeBudgetLimitSchema,
+  RuntimeBudgetModeSchema,
+  RuntimeBudgetRecordSchema,
+  RuntimeBudgetScopeSchema,
+  RuntimeBudgetStore,
+  RuntimeBudgetThresholdActionSchema,
+  RuntimeBudgetUsageSchema,
+} from "./budget-store.js";
+export type {
+  RuntimeBudgetCreateInput,
+  RuntimeBudgetDimension,
+  RuntimeBudgetDimensionStatus,
+  RuntimeBudgetLimit,
+  RuntimeBudgetLimitInput,
+  RuntimeBudgetMode,
+  RuntimeBudgetRecord,
+  RuntimeBudgetScope,
+  RuntimeBudgetStatus,
+  RuntimeBudgetThresholdAction,
+  RuntimeBudgetUsage,
+  RuntimeBudgetUsageInput,
+  RuntimeBudgetUsageUpdateInput,
+} from "./budget-store.js";
 export type {
   RuntimeExperimentQueueCreateInput,
   RuntimeExperimentQueueExecutionDirective,

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -30,6 +30,7 @@ export interface RuntimeStorePaths {
   guardrailBreakersDir: string;
   reproducibilityManifestsDir: string;
   experimentQueuesDir: string;
+  budgetsDir: string;
   backpressureSnapshotPath: string;
   daemonHealthPath: string;
   componentsHealthPath: string;
@@ -46,6 +47,7 @@ export interface RuntimeStorePaths {
   guardrailBreakerPath(key: string): string;
   reproducibilityManifestPath(manifestId: string): string;
   experimentQueuePath(queueId: string): string;
+  budgetPath(budgetId: string): string;
   goalLeasePath(goalId: string): string;
   completedByIdempotencyPath(idempotencyKey: string): string;
   completedByMessagePath(messageId: string): string;
@@ -104,6 +106,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
   const guardrailBreakersDir = path.join(guardrailsDir, "breakers");
   const reproducibilityManifestsDir = path.join(rootDir, "reproducibility-manifests");
   const experimentQueuesDir = path.join(rootDir, "experiment-queues");
+  const budgetsDir = path.join(rootDir, "budgets");
 
   return {
     rootDir,
@@ -132,6 +135,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     guardrailBreakersDir,
     reproducibilityManifestsDir,
     experimentQueuesDir,
+    budgetsDir,
     backpressureSnapshotPath: path.join(guardrailsDir, "backpressure.json"),
     daemonHealthPath: path.join(healthDir, "daemon.json"),
     componentsHealthPath: path.join(healthDir, "components.json"),
@@ -173,6 +177,9 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     },
     experimentQueuePath(queueId: string) {
       return path.join(experimentQueuesDir, recordFileName(encodeRuntimePathSegment(queueId)));
+    },
+    budgetPath(budgetId: string) {
+      return path.join(budgetsDir, recordFileName(encodeRuntimePathSegment(budgetId)));
     },
     goalLeasePath(goalId: string) {
       return path.join(goalLeasesDir, `${encodeRuntimePathSegment(goalId)}.json`);
@@ -217,6 +224,7 @@ export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise
       paths.guardrailBreakersDir,
       paths.reproducibilityManifestsDir,
       paths.experimentQueuesDir,
+      paths.budgetsDir,
     ].map((dir) => fsp.mkdir(dir, { recursive: true }))
   );
 }


### PR DESCRIPTION
Closes #822

## Summary
- Add durable runtime budget records for goal/run scope with limits, usage, recent consumption, threshold actions, mode transitions, and exhaustion policies.
- Wire RuntimeBudgetStore into CLI/TUI CoreLoop setup so production runs create/load budgets, pass budget context into task generation, gate on approval/handoff/finalization/stop policy, and record iteration/task/wall-clock/process/token/artifact usage.
- Add read-only runtime budget CLI reporting plus focused store, CLI, CoreLoop caller-path, and tree-mode budget-context tests.

## Verification
- `npx vitest run src/runtime/__tests__/budget-store.test.ts src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts src/orchestrator/loop/__tests__/core-loop-tree.test.ts src/orchestrator/loop/__tests__/core-loop-phases-b-verify.test.ts src/interface/cli/__tests__/runtime-command.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed`
- `git diff --check`

## Known risks
- Budget creation is minimal and config-driven/default-iteration-driven; richer operator-authored budget profiles can build on this foundation.
- Handoff records themselves are left to #821; this PR exposes handoff-required budget state without implementing that follow-on record type.
