### PR TITLE
Add runtime operator handoff records

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -19,6 +19,7 @@ import type { Task } from "../../../base/types/task.js";
 import type { ChatEvent } from "../chat-events.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
 import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
+import { RuntimeOperatorHandoffStore } from "../../../runtime/store/operator-handoff-store.js";
 // Mock context-provider so tests don't walk the real filesystem
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -1167,6 +1168,19 @@ describe("ChatRunner", () => {
           exitCode: null,
           signal: null,
         }));
+        await new RuntimeOperatorHandoffStore(path.join(tmpDir, "runtime")).create({
+          handoff_id: "handoff-deadline",
+          goal_id: "goal-a",
+          triggers: ["deadline", "finalization"],
+          title: "Deadline handoff",
+          summary: "Deadline finalization requires review.",
+          current_status: "mode=finalization",
+          recommended_action: "Review final artifact.",
+          next_action: {
+            label: "Review final artifact",
+            approval_required: true,
+          },
+        });
         const adapter = makeMockAdapter();
         const runner = new ChatRunner(makeDeps({ stateManager, adapter }));
 
@@ -1183,6 +1197,8 @@ describe("ChatRunner", () => {
         expect(status.output).toContain("run:agent:agent-runtime");
         expect(status.output).toContain("run:process:proc-failed");
         expect(status.output).toContain("run:process:proc-lost");
+        expect(status.output).toContain("Operator handoffs pending:");
+        expect(status.output).toContain("Deadline handoff");
         expect(focused.success).toBe(true);
         expect(focused.output).toContain("Goal status: Goal goal-a");
         expect(focused.output).toContain("Dimensions:");

--- a/src/interface/chat/__tests__/event-subscriber.test.ts
+++ b/src/interface/chat/__tests__/event-subscriber.test.ts
@@ -378,6 +378,21 @@ describe("EventSubscriber", () => {
       expect(received[0].message).toContain("Approve daily brief dispatch");
     });
 
+    it("formats operator handoff events as actionable approvals", () => {
+      const sub = makeSubscriber("goal-abc", "normal");
+      const received: TendNotification[] = [];
+      sub.on("notification", (n: TendNotification) => received.push(n));
+
+      const raw = `event: operator_handoff_required\ndata: {"goal_id":"goal-abc","handoff_id":"handoff-123","title":"Deadline handoff","recommended_action":"Review final artifact"}`;
+      (sub as any).parseSSEMessage(raw);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].type).toBe("approval");
+      expect(received[0].requestId).toBe("handoff-123");
+      expect(received[0].message).toContain("Deadline handoff");
+      expect(received[0].message).toContain("Review final artifact");
+    });
+
     it("projects loop_error events into notifications and chat events", () => {
       const sub = makeSubscriber("goal-abc", "normal");
       const notifications: TendNotification[] = [];
@@ -546,6 +561,61 @@ describe("EventSubscriber", () => {
         event.type === "activity"
         && event.message.includes("Approve daily brief dispatch")
         && event.sourceId === "daemon:goal-xyz:approval_required:approval-123"
+      ))).toBe(true);
+
+      vi.unstubAllGlobals();
+    });
+
+    it("projects snapshot operator handoffs into chat events during bootstrap", async () => {
+      const firstStream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+      const retryStream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+
+      const mockFetch = vi.fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            approvals: [],
+            operator_handoffs: [{
+              goal_id: "goal-xyz",
+              handoff_id: "handoff-123",
+              title: "Deadline handoff",
+              recommended_action: "Review final artifact",
+            }],
+            last_outbox_seq: 5,
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          body: firstStream,
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          body: retryStream,
+        });
+
+      vi.stubGlobal("fetch", mockFetch);
+
+      const sub = new EventSubscriber("http://localhost:9000", "goal-xyz", "normal");
+      const received: ChatEvent[] = [];
+      sub.on("chat_event", (event: ChatEvent) => received.push(event));
+
+      await sub.subscribe();
+
+      expect(received.some((event) => (
+        event.type === "activity"
+        && event.message.includes("Deadline handoff")
+        && event.sourceId === "daemon:goal-xyz:operator_handoff_required:handoff-123"
       ))).toBe(true);
 
       vi.unstubAllGlobals();

--- a/src/interface/chat/chat-runner-commands.ts
+++ b/src/interface/chat/chat-runner-commands.ts
@@ -47,6 +47,7 @@ import type { DaemonSnapshot } from "../../runtime/daemon/client.js";
 import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
 import { BrowserSessionStore } from "../../runtime/interactive-automation/index.js";
 import { GuardrailStore } from "../../runtime/guardrails/index.js";
+import { RuntimeOperatorHandoffStore } from "../../runtime/store/operator-handoff-store.js";
 import * as path from "node:path";
 
 export const COMMAND_HELP = `Available commands:
@@ -433,12 +434,25 @@ export class ChatRunnerCommandHandler {
     const remoteGuardrails = snapshot?.guardrails && typeof snapshot.guardrails === "object"
       ? snapshot.guardrails
       : null;
+    const remoteOperatorHandoffs = Array.isArray(snapshot?.operator_handoffs)
+      ? snapshot.operator_handoffs
+      : null;
     const pendingAuth = remoteAuthSessions ?? await this.loadPendingAuthSessionsFromRuntime();
+    const operatorHandoffs = remoteOperatorHandoffs ?? await this.loadOpenOperatorHandoffsFromRuntime();
     const { openBreakers, backpressureActiveCount } = remoteGuardrails
       ? this.extractGuardrailSummaryFromSnapshot(remoteGuardrails)
       : await this.loadGuardrailsFromRuntime();
     const lines: string[] = [];
+    if (operatorHandoffs.length > 0) {
+      lines.push("Operator handoffs pending:");
+      for (const handoff of operatorHandoffs.slice(0, 5)) {
+        const record = handoff as Record<string, unknown>;
+        const triggers = Array.isArray(record["triggers"]) ? record["triggers"].join(",") : "unknown";
+        lines.push(`- ${String(record["title"] ?? record["handoff_id"] ?? "handoff")} [${triggers}] ${String(record["recommended_action"] ?? "")}`);
+      }
+    }
     if (pendingAuth.length > 0) {
+      if (lines.length > 0) lines.push("");
       lines.push("Auth handoffs pending:");
       for (const session of pendingAuth.slice(0, 5)) {
         const record = session as Record<string, unknown>;
@@ -463,6 +477,11 @@ export class ChatRunnerCommandHandler {
   private async loadPendingAuthSessionsFromRuntime(): Promise<Array<Record<string, unknown>>> {
     const runtimeRoot = path.join(this.host.deps.stateManager.getBaseDir(), "runtime");
     return new BrowserSessionStore(runtimeRoot).listPendingAuth() as Promise<Array<Record<string, unknown>>>;
+  }
+
+  private async loadOpenOperatorHandoffsFromRuntime(): Promise<Array<Record<string, unknown>>> {
+    const runtimeRoot = path.join(this.host.deps.stateManager.getBaseDir(), "runtime");
+    return new RuntimeOperatorHandoffStore(runtimeRoot).listOpen() as Promise<Array<Record<string, unknown>>>;
   }
 
   private async loadGuardrailsFromRuntime(): Promise<{

--- a/src/interface/chat/event-subscriber.ts
+++ b/src/interface/chat/event-subscriber.ts
@@ -306,6 +306,22 @@ export class EventSubscriber extends EventEmitter {
       };
     }
 
+    if (eventType === "operator_handoff_required") {
+      const ev = data as {
+        handoff_id?: string;
+        title?: string;
+        recommended_action?: string;
+      };
+      const title = ev.title ?? "Operator handoff required";
+      const action = ev.recommended_action ? ` — ${ev.recommended_action}` : "";
+      return {
+        type: "approval",
+        goalId: this.goalId,
+        requestId: ev.handoff_id,
+        message: `🛂 [tend] ${shortId}: ${title}${action}`,
+      };
+    }
+
     if (eventType === "approval_resolved") {
       const ev = data as { approved?: boolean };
       const decision = ev.approved ? "approved" : "rejected";
@@ -435,6 +451,7 @@ export class EventSubscriber extends EventEmitter {
       }
       const snapshot = await res.json() as {
         approvals?: unknown[];
+        operator_handoffs?: unknown[];
         last_outbox_seq?: number;
       };
       this.snapshotBootstrapped = true;
@@ -442,6 +459,10 @@ export class EventSubscriber extends EventEmitter {
       for (const approval of snapshot.approvals ?? []) {
         if (!this.matchesGoal(approval)) continue;
         this.emitProjectedEvent("approval_required", approval);
+      }
+      for (const handoff of snapshot.operator_handoffs ?? []) {
+        if (!this.matchesGoal(handoff)) continue;
+        this.emitProjectedEvent("operator_handoff_required", handoff);
       }
     } catch {
       // Snapshot bootstrap is best-effort.
@@ -484,6 +505,11 @@ export class EventSubscriber extends EventEmitter {
     const requestId = record?.["requestId"];
     if (typeof requestId === "string" && requestId) {
       return `${eventType}:${requestId}`;
+    }
+
+    const handoffId = record?.["handoff_id"];
+    if (typeof handoffId === "string" && handoffId) {
+      return `${eventType}:${handoffId}`;
     }
 
     const sessionId = record?.["session_id"];

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -30,6 +30,7 @@ import { CoreLoop } from "../../orchestrator/loop/core-loop.js";
 import { ScheduleEngine } from "../../runtime/schedule/engine.js";
 import { RuntimeEvidenceLedger } from "../../runtime/store/evidence-ledger.js";
 import { RuntimeBudgetStore } from "../../runtime/store/budget-store.js";
+import { RuntimeOperatorHandoffStore } from "../../runtime/store/operator-handoff-store.js";
 import { TreeLoopOrchestrator } from "../../orchestrator/goal/tree-loop-orchestrator.js";
 import { GoalTreeManager } from "../../orchestrator/goal/goal-tree-manager.js";
 import { StateAggregator } from "../../orchestrator/goal/state-aggregator.js";
@@ -319,6 +320,10 @@ export async function buildDeps(
       })
     : undefined;
 
+  const runtimeRoot = path.join(stateManager.getBaseDir(), "runtime");
+  const runtimeBudgetStore = new RuntimeBudgetStore(runtimeRoot);
+  const operatorHandoffStore = new RuntimeOperatorHandoffStore(runtimeRoot);
+
   const taskLifecycle = new TaskLifecycle({
     stateManager,
     llmClient,
@@ -338,6 +343,7 @@ export async function buildDeps(
       agentLoopRunner,
       revertCwd: resolvedWorkspacePath,
       healthCheckCwd: resolvedWorkspacePath,
+      operatorHandoffStore,
     },
   });
 
@@ -375,7 +381,6 @@ export async function buildDeps(
     stateManager, goalTreeManager, stateAggregator, satisficingJudge, goalRefiner
   );
 
-  const runtimeBudgetStore = new RuntimeBudgetStore(path.join(stateManager.getBaseDir(), "runtime"));
   const coreLoop = new CoreLoop({
     stateManager,
     observationEngine,
@@ -408,6 +413,7 @@ export async function buildDeps(
     corePhaseRunner,
     evidenceLedger,
     runtimeBudgetStore,
+    operatorHandoffStore,
   }, config);
 
   coreLoop.setTimeHorizonEngine(new TimeHorizonEngine());

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -8,6 +8,10 @@ import { App, formatDaemonConnectionState } from "../app.js";
 
 const testState = vi.hoisted(() => ({
   lastChatProps: null as null | { onSubmit: (value: string) => Promise<void> },
+  lastApprovalProps: null as null | {
+    task: { work_description: string; rationale: string; goal_id: string };
+    onDecision: (approved: boolean) => void;
+  },
 }));
 
 vi.mock("ink", async () => {
@@ -44,7 +48,15 @@ vi.mock("../dashboard.js", () => ({
 
 vi.mock("../help-overlay.js", () => ({ HelpOverlay: () => null }));
 vi.mock("../settings-overlay.js", () => ({ SettingsOverlay: () => null }));
-vi.mock("../approval-overlay.js", () => ({ ApprovalOverlay: () => null }));
+vi.mock("../approval-overlay.js", () => ({
+  ApprovalOverlay: (props: {
+    task: { work_description: string; rationale: string; goal_id: string };
+    onDecision: (approved: boolean) => void;
+  }) => {
+    testState.lastApprovalProps = props;
+    return null;
+  },
+}));
 vi.mock("../report-view.js", () => ({ ReportView: () => null }));
 
 function createDaemonClientMock() {
@@ -266,6 +278,7 @@ describe("standalone slash command routing", () => {
 describe("daemon-mode chat routing", () => {
   beforeEach(() => {
     testState.lastChatProps = null;
+    testState.lastApprovalProps = null;
   });
 
   afterEach(() => {
@@ -303,6 +316,48 @@ describe("daemon-mode chat routing", () => {
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
     expect(daemonClient.chat).not.toHaveBeenCalled();
 
+    screen.unmount();
+  });
+
+  it("surfaces operator handoffs from daemon events through the approval overlay", async () => {
+    const daemonClient = createDaemonClientMock();
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+
+    const screen = render(React.createElement(App, {
+      daemonClient: daemonClient as unknown as DaemonClient,
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+
+    expect(daemonClient.on).toHaveBeenCalledWith("operator_handoff_required", expect.any(Function));
+    daemonClient.handlers.get("operator_handoff_required")?.({
+      handoff_id: "handoff-1",
+      goal_id: "goal-a",
+      title: "Deadline handoff",
+      summary: "Deadline finalization requires review.",
+      recommended_action: "Review final artifact.",
+      triggers: ["deadline"],
+      created_at: "2026-05-01T00:00:00.000Z",
+    });
+    await flush();
+
+    expect(testState.lastApprovalProps?.task.work_description).toBe("Deadline handoff");
+    expect(testState.lastApprovalProps?.task.rationale).toBe("Deadline finalization requires review.");
+    testState.lastApprovalProps?.onDecision(true);
+
+    expect(daemonClient.approve).toHaveBeenCalledWith("goal-a", "handoff-1", true);
     screen.unmount();
   });
 

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -55,6 +55,50 @@ export function formatDaemonConnectionState(state: DaemonConnectionState | undef
   return `  [daemon ${state}]`;
 }
 
+function normalizeApprovalTask(data: Record<string, unknown>): Task {
+  const rawTask = data.task;
+  if (rawTask && typeof rawTask === "object") {
+    return rawTask as Task;
+  }
+  const goalId = String(data.goalId ?? data.goal_id ?? "");
+  const title = String(data.title ?? "Operator handoff required");
+  const summary = String(data.summary ?? data.recommended_action ?? "Review this operator handoff before continuing.");
+  const currentStatus = String(data.current_status ?? "");
+  const triggers = Array.isArray(data.triggers) ? data.triggers.map(String).join(", ") : "operator_handoff";
+  return {
+    id: String(data.handoff_id ?? data.requestId ?? "operator_handoff"),
+    goal_id: goalId,
+    strategy_id: null,
+    target_dimensions: [],
+    primary_dimension: "operator_handoff",
+    work_description: title,
+    rationale: summary,
+    approach: String(data.recommended_action ?? currentStatus ?? "Operator decision required."),
+    success_criteria: [{
+      description: "Operator has approved or rejected the handoff.",
+      verification_method: "daemon approval response",
+      is_blocking: true,
+    }],
+    scope_boundary: {
+      in_scope: [triggers],
+      out_of_scope: [],
+      blast_radius: "operator handoff",
+    },
+    constraints: ["Requires explicit operator approval."],
+    plateau_until: null,
+    estimated_duration: null,
+    consecutive_failure_count: 0,
+    reversibility: "unknown",
+    task_category: "normal",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: String(data.created_at ?? new Date().toISOString()),
+  };
+}
+
 export type FreeformInputRoute = "daemon_goal_chat" | "chat_runner" | "unavailable";
 
 export function resolveFreeformInputRoute({
@@ -260,9 +304,10 @@ export function App({
 
     const onApproval = (data: unknown) => {
       const d = data as Record<string, unknown>;
-      const task = d.task as Task;
-      const requestId = d.requestId as string;
-      const goalId = d.goalId as string;
+      const task = normalizeApprovalTask(d);
+      const requestId = String(d.requestId ?? d.handoff_id ?? "");
+      const goalId = String(d.goalId ?? d.goal_id ?? task.goal_id);
+      if (!requestId || !goalId) return;
 
       approvalRequestRef.current = {
         task,
@@ -278,6 +323,7 @@ export function App({
     daemonClient.on("loop_update", onLoopUpdate);
     daemonClient.on("daemon_status", onDaemonStatus);
     daemonClient.on("approval_required", onApproval);
+    daemonClient.on("operator_handoff_required", onApproval);
 
     return () => {
       daemonClient.off("_connected", onConnected);
@@ -285,6 +331,7 @@ export function App({
       daemonClient.off("loop_update", onLoopUpdate);
       daemonClient.off("daemon_status", onDaemonStatus);
       daemonClient.off("approval_required", onApproval);
+      daemonClient.off("operator_handoff_required", onApproval);
     };
   }, [isDaemonMode, daemonClient]);
 

--- a/src/interface/tui/entry-deps.ts
+++ b/src/interface/tui/entry-deps.ts
@@ -33,6 +33,7 @@ export async function buildStandaloneTuiDeps() {
   const { ScheduleEngine } = await import("../../runtime/schedule/engine.js");
   const { RuntimeEvidenceLedger } = await import("../../runtime/store/evidence-ledger.js");
   const { RuntimeBudgetStore } = await import("../../runtime/store/budget-store.js");
+  const { RuntimeOperatorHandoffStore } = await import("../../runtime/store/operator-handoff-store.js");
   const { MemoryLifecycleManager, DriveScoreAdapter } = await import("../../platform/knowledge/memory/memory-lifecycle.js");
   const { KnowledgeManager } = await import("../../platform/knowledge/knowledge-manager.js");
   const { CharacterConfigManager } = await import("../../platform/traits/character-config.js");
@@ -205,6 +206,10 @@ export async function buildStandaloneTuiDeps() {
       })
     : undefined;
 
+  const runtimeRoot = path.join(stateManager.getBaseDir(), "runtime");
+  const runtimeBudgetStore = new RuntimeBudgetStore(runtimeRoot);
+  const operatorHandoffStore = new RuntimeOperatorHandoffStore(runtimeRoot);
+
   const taskLifecycle = new TaskLifecycle({
     stateManager,
     llmClient,
@@ -218,6 +223,7 @@ export async function buildStandaloneTuiDeps() {
       agentLoopRunner,
       revertCwd: process.cwd(),
       healthCheckCwd: process.cwd(),
+      operatorHandoffStore,
     },
   });
 
@@ -232,7 +238,6 @@ export async function buildStandaloneTuiDeps() {
     rankDimensions: DriveScorer.rankDimensions,
   };
 
-  const runtimeBudgetStore = new RuntimeBudgetStore(path.join(stateManager.getBaseDir(), "runtime"));
   const coreLoop = new CoreLoop({
     stateManager,
     observationEngine,
@@ -255,6 +260,7 @@ export async function buildStandaloneTuiDeps() {
     corePhaseRunner,
     evidenceLedger,
     runtimeBudgetStore,
+    operatorHandoffStore,
   });
 
   const scheduleEngine = new ScheduleEngine({

--- a/src/orchestrator/execution/__tests__/task-lifecycle-generation.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-generation.test.ts
@@ -18,6 +18,7 @@ import { saveDreamConfig } from "../../../platform/dream/dream-config.js";
 import { upsertDreamPlaybook } from "../../../platform/dream/playbook-memory.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { RuntimeOperatorHandoffStore } from "../../../runtime/store/operator-handoff-store.js";
 
 // ─── Spy LLM Client ───
 
@@ -131,6 +132,7 @@ describe("TaskLifecycle", async () => {
       logger?: import("../../../runtime/logger.js").Logger;
       adapterRegistry?: import("../task/task-lifecycle.js").AdapterRegistry;
       execFileSyncFn?: (cmd: string, args: string[], opts: { cwd: string; encoding: "utf-8" }) => string;
+      operatorHandoffStore?: RuntimeOperatorHandoffStore;
     }
   ): TaskLifecycle {
     strategyManager = new StrategyManager(stateManager, llmClient);
@@ -982,6 +984,68 @@ describe("TaskLifecycle", async () => {
       const result = await lifecycle.checkIrreversibleApproval(task, 0.8);
       // With high trust + high confidence + reversible → should skip approval
       expect(result).toBe(true);
+    });
+
+    it("requires approval and records a handoff for external submission tasks even when otherwise reversible", async () => {
+      let approvalCalled = false;
+      const handoffStore = new RuntimeOperatorHandoffStore(`${tmpDir}/runtime`);
+      const llm = createMockLLMClient([]);
+      const lifecycle = createLifecycle(llm, {
+        approvalFn: async () => {
+          approvalCalled = true;
+          return false;
+        },
+        operatorHandoffStore: handoffStore,
+      });
+      await trustManager.setOverride("normal", 50, "test");
+
+      const task = makeTask({
+        work_description: "Submit the final Kaggle submission.csv to the external competition",
+        approach: "Upload submission.csv through the Kaggle submit workflow",
+        reversibility: "reversible",
+      });
+      const result = await lifecycle.checkIrreversibleApproval(task, 0.9);
+
+      expect(result).toBe(false);
+      expect(approvalCalled).toBe(true);
+      expect(await handoffStore.listOpen()).toEqual([]);
+      expect(await handoffStore.load("handoff:goal-1:task:task-1:approval-required")).toMatchObject({
+        goal_id: "goal-1",
+        status: "dismissed",
+        triggers: ["external_action"],
+        required_approvals: [task.work_description],
+        gate: expect.objectContaining({
+          external_action_requires_approval: true,
+        }),
+      });
+    });
+
+    it("resolves external submission handoffs as approved when the operator approves", async () => {
+      const handoffStore = new RuntimeOperatorHandoffStore(`${tmpDir}/runtime`);
+      const llm = createMockLLMClient([]);
+      let receivedApprovalRequestId: string | undefined;
+      const lifecycle = createLifecycle(llm, {
+        approvalFn: async (task) => {
+          receivedApprovalRequestId = (task as unknown as { approval_request_id?: string }).approval_request_id;
+          return true;
+        },
+        operatorHandoffStore: handoffStore,
+      });
+      await trustManager.setOverride("normal", 50, "test");
+
+      const task = makeTask({
+        work_description: "Publish the final report to an external service",
+        reversibility: "reversible",
+      });
+      const result = await lifecycle.checkIrreversibleApproval(task, 0.9);
+
+      expect(result).toBe(true);
+      expect(receivedApprovalRequestId).toBe("handoff:goal-1:task:task-1:approval-required");
+      expect(await handoffStore.listOpen()).toEqual([]);
+      expect(await handoffStore.load("handoff:goal-1:task:task-1:approval-required")).toMatchObject({
+        status: "approved",
+        triggers: ["external_action"],
+      });
     });
 
     it("uses default confidence of 0.5 when not provided", async () => {

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -46,7 +46,6 @@ export { LLMGeneratedTaskSchema } from "./task-generation.js";
 import { generateTask as _generateTask } from "./task-generation.js";
 import { durationToMs } from "./task-executor.js";
 import { executeTaskWithGuards, verifyExecutionWithGitDiff } from "./task-execution-helpers.js";
-import { checkIrreversibleApproval as _checkIrreversibleApproval } from "./task-approval-check.js";
 import { runPipelineTaskCycle as runPipelineTaskCycleFn } from "./task-pipeline-cycle.js";
 import type { PipelineCycleOptions } from "./task-pipeline-types.js";
 import type { KnowledgeTransfer } from "../../../platform/knowledge/transfer/knowledge-transfer.js";
@@ -60,6 +59,10 @@ import type { TaskAgentLoopRunner } from "../agent-loop/task-agent-loop-runner.j
 import { taskAgentLoopResultToAgentResult } from "../agent-loop/task-agent-loop-result.js";
 import type { IPromptGateway } from "../../../prompt/gateway.js";
 import type { ExecutionModeState } from "../../../platform/time/execution-mode.js";
+import type {
+  RuntimeOperatorHandoffStore,
+  RuntimeOperatorHandoffTrigger,
+} from "../../../runtime/store/operator-handoff-store.js";
 import {
   formatPlaybookHints,
   formatPatternHints,
@@ -126,6 +129,8 @@ export interface TaskLifecycleOptions {
   revertCwd?: string;
   /** Optional explicit workspace root for post-execution health checks. */
   healthCheckCwd?: string;
+  /** Optional durable operator handoff store for approval-required execution gates. */
+  operatorHandoffStore?: RuntimeOperatorHandoffStore;
 }
 
 export interface TaskCycleRunOptions {
@@ -170,6 +175,7 @@ export class TaskLifecycle {
   private readonly gateway?: IPromptGateway;
   private readonly revertCwd?: string;
   private readonly healthCheckCwd?: string;
+  private readonly operatorHandoffStore?: RuntimeOperatorHandoffStore;
   private onTaskComplete?: (strategyId: string) => void;
 
   constructor(deps: TaskLifecycleDeps);
@@ -228,6 +234,7 @@ export class TaskLifecycle {
     this.gateway = resolvedOptions?.gateway;
     this.revertCwd = resolvedOptions?.revertCwd;
     this.healthCheckCwd = resolvedOptions?.healthCheckCwd;
+    this.operatorHandoffStore = resolvedOptions?.operatorHandoffStore;
   }
 
   /** Register a callback invoked when a task completes successfully (used by PortfolioManager). */
@@ -357,7 +364,97 @@ export class TaskLifecycle {
 
   /** Check whether the task requires human approval and request it if so. */
   async checkIrreversibleApproval(task: Task, confidence: number = 0.5): Promise<boolean> {
-    return _checkIrreversibleApproval(this.trustManager, this.approvalFn, task, confidence);
+    const domain = task.task_category;
+    const trustNeedsApproval = await this.trustManager.requiresApproval(
+      task.reversibility,
+      domain,
+      confidence,
+      task.task_category
+    );
+    const externalAction = isExternalActionTask(task);
+    if (!trustNeedsApproval && !externalAction) {
+      return true;
+    }
+
+    const handoffId = taskApprovalHandoffId(task);
+    const recordedHandoffId = await this.recordApprovalHandoff(task, handoffId, {
+      trustNeedsApproval,
+      externalAction,
+    });
+    const approved = await this.approvalFn({
+      ...task,
+      approval_request_id: handoffId,
+      operator_handoff_id: handoffId,
+    } as Task);
+    if (recordedHandoffId) {
+      await this.resolveApprovalHandoff(recordedHandoffId, approved);
+    }
+    return approved;
+  }
+
+  private async recordApprovalHandoff(
+    task: Task,
+    handoffId: string,
+    input: { trustNeedsApproval: boolean; externalAction: boolean }
+  ): Promise<string | null> {
+    if (!this.operatorHandoffStore) return null;
+    const triggers: RuntimeOperatorHandoffTrigger[] = [];
+    if (input.trustNeedsApproval) triggers.push("irreversible_action");
+    if (input.externalAction) triggers.push("external_action");
+    try {
+      const record = await this.operatorHandoffStore.create({
+        handoff_id: handoffId,
+        goal_id: task.goal_id,
+        triggers,
+        title: `Approval required: ${task.work_description}`,
+        summary: input.externalAction
+          ? "Task appears to perform an external or submission action and cannot proceed without operator approval."
+          : "Task reversibility/trust policy requires operator approval before execution.",
+        current_status: `task=${task.id}, reversibility=${task.reversibility}, category=${task.task_category}`,
+        recommended_action: "Review the task scope and approve only if the external or irreversible action is intended.",
+        risks: [
+          ...(input.externalAction ? ["External submission/publish/send actions can mutate systems outside local runtime state."] : []),
+          ...(input.trustNeedsApproval ? ["Irreversible task execution may be difficult or impossible to roll back."] : []),
+        ],
+        required_approvals: [task.work_description],
+        approval_request_id: handoffId,
+        next_action: {
+          label: task.work_description,
+          approval_required: true,
+        },
+        gate: {
+          autonomous_task_generation: "constrain",
+          external_action_requires_approval: true,
+        },
+        evidence_refs: [{
+          kind: "task",
+          ref: `tasks/${task.goal_id}/${task.id}.json`,
+          observed_at: task.created_at,
+        }],
+        created_at: task.created_at,
+      });
+      return record.handoff_id;
+    } catch (err) {
+      this.logger?.warn("TaskLifecycle: failed to record operator handoff", {
+        goalId: task.goal_id,
+        taskId: task.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  private async resolveApprovalHandoff(handoffId: string, approved: boolean): Promise<void> {
+    if (!this.operatorHandoffStore) return;
+    try {
+      await this.operatorHandoffStore.resolve(handoffId, approved ? "approved" : "dismissed");
+    } catch (err) {
+      this.logger?.warn("TaskLifecycle: failed to resolve operator handoff", {
+        handoffId,
+        approved,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   private async buildDimensionSelectionBackoff(goalId: string): Promise<DimensionSelectionOptions> {
@@ -682,4 +779,22 @@ export class TaskLifecycle {
   private static isDepsObject(value: StateManager | TaskLifecycleDeps): value is TaskLifecycleDeps {
     return "stateManager" in value;
   }
+}
+
+function isExternalActionTask(task: Task): boolean {
+  const haystack = [
+    task.work_description,
+    task.approach,
+    task.rationale,
+    ...task.constraints,
+    ...task.success_criteria.map((criterion) => `${criterion.description} ${criterion.verification_method}`),
+    task.scope_boundary.blast_radius,
+    ...task.scope_boundary.in_scope,
+    ...task.scope_boundary.out_of_scope,
+  ].join("\n").toLowerCase();
+  return /\b(submit|submission|publish|deploy|release|upload|send|email|notify|external|production)\b/.test(haystack);
+}
+
+function taskApprovalHandoffId(task: Task): string {
+  return `handoff:${task.goal_id}:task:${task.id}:approval-required`;
 }

--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -40,6 +40,7 @@ import { ApprovalStore } from "../../../runtime/store/approval-store.js";
 import { WaitDeadlineResolver, getDueWaitGoalIds } from "../../../runtime/daemon/wait-deadline-resolver.js";
 import { RuntimeEvidenceLedger } from "../../../runtime/store/evidence-ledger.js";
 import { RuntimeReproducibilityManifestStore } from "../../../runtime/store/reproducibility-manifest.js";
+import { RuntimeOperatorHandoffStore } from "../../../runtime/store/operator-handoff-store.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { makeDimension, makeGoal } from "../../../../tests/helpers/fixtures.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
@@ -453,9 +454,10 @@ describe("CoreLoop", async () => {
           },
         }),
       };
+      const operatorHandoffStore = new RuntimeOperatorHandoffStore(path.join(tmpDir, "runtime"));
 
       const loop = new CoreLoop(
-        { ...deps, evidenceLedger: evidenceLedger as any },
+        { ...deps, evidenceLedger: evidenceLedger as any, operatorHandoffStore },
         { delayBetweenLoopsMs: 0, autoDecompose: false }
       );
       const result = await loop.run("goal-1", { maxIterations: 3 });
@@ -499,6 +501,22 @@ describe("CoreLoop", async () => {
           executionMode: expect.objectContaining({ mode: "finalization" }),
         })
       );
+      expect(await operatorHandoffStore.listOpen()).toEqual([
+        expect.objectContaining({
+          goal_id: "goal-1",
+          triggers: ["deadline", "finalization", "external_action"],
+          required_approvals: ["Publish report"],
+          next_action: expect.objectContaining({
+            label: "Publish report",
+            tool_name: "publish_report",
+            approval_required: true,
+          }),
+          gate: expect.objectContaining({
+            autonomous_task_generation: "pause",
+            external_action_requires_approval: true,
+          }),
+        }),
+      ]);
     });
 
     it("passes consolidation execution mode into task generation before the finalization cutoff", async () => {

--- a/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { CoreLoop, makeEmptyIterationResult, type CoreLoopDeps } from "../core-loop.js";
 import { makeGoal } from "../../../../tests/helpers/fixtures.js";
 import { RuntimeBudgetStore } from "../../../runtime/store/budget-store.js";
+import { RuntimeOperatorHandoffStore } from "../../../runtime/store/operator-handoff-store.js";
 
 function makeDeps(): CoreLoopDeps {
   return {
@@ -210,5 +211,116 @@ describe("CoreLoop run policies", () => {
     expect(result.finalStatus).toBe("stopped");
     expect(runOneIteration).not.toHaveBeenCalled();
     expect(waitApprovalBroker.requestApproval).not.toHaveBeenCalled();
+  });
+
+  it("records a budget handoff before stopping at finalization threshold", async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-core-budget-handoff-"));
+    tempDirs.push(tempDir);
+    const runtimeRoot = path.join(tempDir, "runtime");
+    const runtimeBudgetStore = new RuntimeBudgetStore(runtimeRoot);
+    const operatorHandoffStore = new RuntimeOperatorHandoffStore(runtimeRoot);
+    await runtimeBudgetStore.create({
+      budget_id: "budget-finalize",
+      scope: { goal_id: "goal-budget-finalize" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [{ dimension: "iterations", limit: 2, finalization_at_remaining: 0 }],
+    });
+    await runtimeBudgetStore.recordTaskExecution("budget-finalize", { iterations: 2 });
+
+    const loop = new CoreLoop({
+      ...makeDeps(),
+      runtimeBudgetStore,
+      operatorHandoffStore,
+      reportingEngine: { generateExecutionSummary: vi.fn(), saveReport: vi.fn() },
+    } as unknown as CoreLoopDeps, {
+      maxIterations: 2,
+      delayBetweenLoopsMs: 0,
+      autoDecompose: false,
+      runtimeBudget: {
+        budgetId: "budget-finalize",
+        limits: [{ dimension: "iterations", limit: 2, finalization_at_remaining: 0 }],
+      },
+    });
+    const runOneIteration = vi.spyOn(loop, "runOneIteration").mockResolvedValue(
+      makeEmptyIterationResult("goal-budget-finalize", 0)
+    );
+
+    const result = await loop.run("goal-budget-finalize");
+
+    expect(result.totalIterations).toBe(0);
+    expect(result.finalStatus).toBe("finalization");
+    expect(runOneIteration).not.toHaveBeenCalled();
+    expect(await operatorHandoffStore.listOpen()).toEqual([
+      expect.objectContaining({
+        handoff_id: "budget:budget-finalize",
+        goal_id: "goal-budget-finalize",
+        triggers: ["budget"],
+        title: "Budget handoff: budget-finalize",
+        gate: expect.objectContaining({
+          autonomous_task_generation: "pause",
+        }),
+      }),
+    ]);
+  });
+
+  it("uses the budget approval request id for handoff records that also require approval", async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-core-budget-approval-handoff-"));
+    tempDirs.push(tempDir);
+    const runtimeRoot = path.join(tempDir, "runtime");
+    const runtimeBudgetStore = new RuntimeBudgetStore(runtimeRoot);
+    const operatorHandoffStore = new RuntimeOperatorHandoffStore(runtimeRoot);
+    await runtimeBudgetStore.create({
+      budget_id: "budget-review",
+      scope: { goal_id: "goal-budget-review" },
+      created_at: "2026-05-01T00:00:00.000Z",
+      limits: [{
+        dimension: "iterations",
+        limit: 2,
+        approval_at_remaining: 0,
+        handoff_at_remaining: 0,
+      }],
+    });
+    await runtimeBudgetStore.recordTaskExecution("budget-review", { iterations: 2 });
+    const waitApprovalBroker = { requestApproval: vi.fn().mockResolvedValue(true) };
+
+    const loop = new CoreLoop({
+      ...makeDeps(),
+      runtimeBudgetStore,
+      operatorHandoffStore,
+      waitApprovalBroker,
+      reportingEngine: { generateExecutionSummary: vi.fn(), saveReport: vi.fn() },
+    } as unknown as CoreLoopDeps, {
+      maxIterations: 1,
+      delayBetweenLoopsMs: 0,
+      autoDecompose: false,
+      runtimeBudget: {
+        budgetId: "budget-review",
+        limits: [{
+          dimension: "iterations",
+          limit: 2,
+          approval_at_remaining: 0,
+          handoff_at_remaining: 0,
+        }],
+      },
+    });
+    const runOneIteration = vi.spyOn(loop, "runOneIteration").mockResolvedValue(
+      makeEmptyIterationResult("goal-budget-review", 0)
+    );
+
+    await loop.run("goal-budget-review");
+
+    expect(waitApprovalBroker.requestApproval).toHaveBeenCalledWith(
+      "goal-budget-review",
+      expect.objectContaining({ id: "budget:budget-review" }),
+      undefined,
+      "budget:budget-review",
+    );
+    expect(await operatorHandoffStore.load("budget:budget-review")).toMatchObject({
+      handoff_id: "budget:budget-review",
+      approval_request_id: "budget:budget-review",
+      status: "open",
+      triggers: ["budget"],
+    });
+    expect(runOneIteration).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/orchestrator/loop/core-loop.ts
+++ b/src/orchestrator/loop/core-loop.ts
@@ -31,6 +31,10 @@ import type {
   RuntimeBudgetRecord,
   RuntimeBudgetStatus,
 } from "../../runtime/store/budget-store.js";
+import type {
+  RuntimeOperatorHandoffInput,
+  RuntimeOperatorHandoffTrigger,
+} from "../../runtime/store/operator-handoff-store.js";
 
 // Re-export types for backward compatibility
 export type {
@@ -287,6 +291,7 @@ export class CoreLoop {
         }
       }
       await this.recordRuntimeBudgetUsage(runtimeBudgetId, iterationResult);
+      await this.recordOperatorHandoffForIteration(goalId, runtimeBudgetId, iterationResult);
       void this.deps.hookManager?.emit("LoopCycleEnd", { goal_id: goalId, data: { loopIndex, status: iterationResult.error ? "error" : "ok" } });
 
       iterations.push(iterationResult);
@@ -556,6 +561,9 @@ export class CoreLoop {
   }> {
     const status = await this.loadRuntimeBudgetStatus(budgetId);
     if (!status) return { stop: false, finalStatus: "stopped" };
+    if (status.finalization_required || status.handoff_required) {
+      await this.recordBudgetOperatorHandoff(goalId, status);
+    }
     if (status.finalization_required) return { stop: true, finalStatus: "finalization" };
     if (status.dimensions.some((dimension) => dimension.exhausted && dimension.exhaustion_policy === "stop")) {
       return { stop: true, finalStatus: "stopped" };
@@ -576,6 +584,7 @@ export class CoreLoop {
       );
       if (approved) return { stop: false, finalStatus: "stopped" };
     }
+    await this.recordBudgetOperatorHandoff(goalId, status);
     return { stop: true, finalStatus: "stopped" };
   }
 
@@ -629,4 +638,118 @@ export class CoreLoop {
     }
   }
 
+  private async recordOperatorHandoffForIteration(
+    goalId: string,
+    budgetId: string | null,
+    iterationResult: LoopIterationResult
+  ): Promise<void> {
+    if (this.config.dryRun || !this.deps.operatorHandoffStore) return;
+    const finalization = iterationResult.finalizationStatus;
+    if (!finalization) return;
+    const plan = finalization.finalization_plan;
+    const isDeadlineWindow = finalization.mode === "finalization" || finalization.mode === "missed_deadline";
+    if (!isDeadlineWindow && !plan?.handoff_required) return;
+
+    const approvalActions = plan?.approval_required_actions ?? [];
+    const triggers: RuntimeOperatorHandoffTrigger[] = ["deadline", "finalization"];
+    if (approvalActions.length > 0) triggers.push("external_action");
+    if (plan?.reproducibility_manifest.status === "required_missing") triggers.push("policy");
+
+    const firstAction = approvalActions[0];
+    const bestArtifact = plan?.best_artifact ?? null;
+    await this.createOperatorHandoff({
+      handoff_id: `handoff:${this.currentActivationContext?.backgroundRun?.backgroundRunId ?? goalId}:deadline-finalization`,
+      goal_id: goalId,
+      ...(this.currentActivationContext?.backgroundRun?.backgroundRunId
+        ? { run_id: this.currentActivationContext.backgroundRun.backgroundRunId }
+        : {}),
+      triggers: uniqueTriggers(triggers),
+      title: `Operator handoff: ${goalId}`,
+      summary: finalization.reason,
+      current_status: [
+        `mode=${finalization.mode}`,
+        finalization.deadline ? `deadline=${finalization.deadline}` : null,
+        finalization.remaining_ms !== null ? `remaining_ms=${finalization.remaining_ms}` : null,
+        budgetId ? `budget=${budgetId}` : null,
+      ].filter(Boolean).join(", "),
+      recommended_action: approvalActions.length > 0
+        ? `Review and approve required finalization action: ${approvalActions.map((action) => action.label).join(", ")}.`
+        : "Review the deadline finalization state before continuing autonomous work.",
+      candidate_options: bestArtifact
+        ? [{
+            id: bestArtifact.id ?? bestArtifact.path ?? bestArtifact.state_relative_path ?? "best_artifact",
+            label: bestArtifact.label,
+            tradeoff: bestArtifact.summary ?? "Use the current best observable artifact for handoff/finalization.",
+          }]
+        : [],
+      risks: [
+        "Continuing autonomous exploration may miss or has already missed the deadline window.",
+        ...(approvalActions.length > 0 ? ["External or irreversible finalization actions remain blocked until approval."] : []),
+      ],
+      required_approvals: approvalActions.map((action) => action.label),
+      next_action: {
+        label: firstAction?.label ?? "Review deadline finalization",
+        ...(firstAction?.tool_name ? { tool_name: firstAction.tool_name } : {}),
+        ...(firstAction?.payload_ref ? { payload_ref: firstAction.payload_ref } : {}),
+        approval_required: true,
+      },
+      gate: {
+        autonomous_task_generation: isDeadlineWindow ? "pause" : "constrain",
+        external_action_requires_approval: true,
+      },
+      evidence_refs: [
+        { kind: "deadline_finalization_status", ref: `goal:${goalId}:iteration:${iterationResult.loopIndex}`, observed_at: finalization.evaluated_at },
+        ...(bestArtifact?.path ? [{ kind: bestArtifact.kind ?? "artifact", ref: bestArtifact.path, observed_at: bestArtifact.occurred_at }] : []),
+        ...(bestArtifact?.state_relative_path ? [{ kind: "state_artifact", ref: bestArtifact.state_relative_path, observed_at: bestArtifact.occurred_at }] : []),
+      ],
+      created_at: finalization.evaluated_at,
+    });
+  }
+
+  private async recordBudgetOperatorHandoff(goalId: string, status: RuntimeBudgetStatus): Promise<void> {
+    if (this.config.dryRun || !this.deps.operatorHandoffStore) return;
+    if (!status.handoff_required && !status.approval_required && !status.finalization_required) return;
+    const approvalRequestId = `budget:${status.budget_id}`;
+    await this.createOperatorHandoff({
+      handoff_id: approvalRequestId,
+      goal_id: goalId,
+      ...(status.scope.run_id ? { run_id: status.scope.run_id } : {}),
+      triggers: ["budget"],
+      title: `Budget handoff: ${status.budget_id}`,
+      summary: "Runtime budget threshold reached before autonomous work can continue.",
+      current_status: status.dimensions
+        .map((dimension) => `${dimension.dimension}: used=${dimension.used}/${dimension.limit}, remaining=${dimension.remaining}`)
+        .join("; "),
+      recommended_action: "Review budget usage and approve, finalize, or pause the run.",
+      risks: ["Continuing without an operator decision can exceed the configured runtime budget."],
+      required_approvals: status.approval_required ? ["continue_after_budget_threshold"] : [],
+      ...(status.approval_required ? { approval_request_id: approvalRequestId } : {}),
+      next_action: {
+        label: status.finalization_required ? "Finalize run" : "Review budget threshold",
+        approval_required: true,
+      },
+      gate: {
+        autonomous_task_generation: status.finalization_required || status.handoff_required ? "pause" : "constrain",
+        external_action_requires_approval: true,
+      },
+      evidence_refs: [{ kind: "runtime_budget", ref: status.budget_id }],
+    });
+  }
+
+  private async createOperatorHandoff(input: RuntimeOperatorHandoffInput): Promise<void> {
+    try {
+      await this.deps.operatorHandoffStore?.create(input);
+    } catch (err) {
+      this.logger?.warn("CoreLoop: failed to record operator handoff", {
+        goalId: input.goal_id,
+        handoffId: input.handoff_id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+}
+
+function uniqueTriggers(triggers: RuntimeOperatorHandoffTrigger[]): RuntimeOperatorHandoffTrigger[] {
+  return [...new Set(triggers)];
 }

--- a/src/orchestrator/loop/core-loop/contracts.ts
+++ b/src/orchestrator/loop/core-loop/contracts.ts
@@ -39,6 +39,7 @@ import type {
   RuntimeBudgetLimitInput,
   RuntimeBudgetStore,
 } from "../../../runtime/store/budget-store.js";
+import type { RuntimeOperatorHandoffStore } from "../../../runtime/store/operator-handoff-store.js";
 import type { DeadlineFinalizationStatus } from "../../../platform/time/deadline-finalization.js";
 import type { ExecutionModeState } from "../../../platform/time/execution-mode.js";
 export type {
@@ -327,6 +328,8 @@ export interface CoreLoopDeps extends ObservationDeps, TreeDeps, StallDeps, Task
   evidenceLedger?: RuntimeEvidenceLedgerPort;
   /** Optional durable budget store for long-running goal/run budget governance. */
   runtimeBudgetStore?: RuntimeBudgetStore;
+  /** Optional durable operator handoff store for deadline, budget, and approval gates. */
+  operatorHandoffStore?: RuntimeOperatorHandoffStore;
   /** Optional bounded agentloop runner for core phases. */
   corePhaseRunner?: CorePhaseRunner;
   /** Optional live approval broker for wait/resume approvals. */

--- a/src/runtime/__tests__/daemon-client.test.ts
+++ b/src/runtime/__tests__/daemon-client.test.ts
@@ -10,6 +10,7 @@ import {
 import { EventServer } from "../event-server.js";
 import { DEFAULT_PORT } from "../port-utils.js";
 import { OutboxStore } from "../store/outbox-store.js";
+import { RuntimeOperatorHandoffStore } from "../store/operator-handoff-store.js";
 import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
 
 function createMockDriveSystem() {
@@ -122,6 +123,49 @@ describe("DaemonClient snapshot + replay", () => {
         message: "queued",
         status: "queued",
       });
+    } finally {
+      client.disconnect();
+    }
+  });
+
+  it("emits operator handoffs from snapshot bootstrap", async () => {
+    const runtimeRoot = path.join(tmpDir, "runtime");
+    await new RuntimeOperatorHandoffStore(runtimeRoot).create({
+      handoff_id: "handoff-snapshot",
+      goal_id: "goal-1",
+      triggers: ["deadline"],
+      title: "Deadline handoff",
+      summary: "Deadline finalization requires review.",
+      current_status: "mode=finalization",
+      recommended_action: "Review final artifact.",
+      next_action: {
+        label: "Review final artifact",
+        approval_required: true,
+      },
+    });
+    server = new EventServer(createMockDriveSystem() as never, {
+      port: 0,
+      eventsDir: path.join(tmpDir, "events"),
+      runtimeRoot,
+      outboxStore: new OutboxStore(tmpDir),
+    });
+    await server.start();
+
+    const client = new DaemonClient({
+      host: "127.0.0.1",
+      port: server.getPort(),
+      reconnectInterval: 50,
+      maxReconnectAttempts: 2,
+      authToken: server.getAuthToken(),
+    });
+
+    try {
+      const handoff = waitForEvent(client, "operator_handoff_required");
+      client.connect();
+      await expect(handoff).resolves.toEqual(expect.objectContaining({
+        handoff_id: "handoff-snapshot",
+        goal_id: "goal-1",
+      }));
     } finally {
       client.disconnect();
     }

--- a/src/runtime/__tests__/event-server-approval.test.ts
+++ b/src/runtime/__tests__/event-server-approval.test.ts
@@ -6,6 +6,7 @@ import { EventServer } from "../event-server.js";
 import { ApprovalBroker } from "../approval-broker.js";
 import { ApprovalStore } from "../store/approval-store.js";
 import { createRuntimeStorePaths } from "../store/runtime-paths.js";
+import { RuntimeOperatorHandoffStore } from "../store/operator-handoff-store.js";
 import type { ApprovalRecord } from "../store/runtime-schemas.js";
 import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
 
@@ -188,6 +189,105 @@ describe("EventServer durable approval integration", () => {
       const resolvedPath = paths.approvalResolvedPath("approval-http");
       const resolved = JSON.parse(fs.readFileSync(resolvedPath, "utf-8")) as ApprovalRecord;
       expect(resolved.state).toBe("approved");
+    } finally {
+      await server.stop();
+    }
+  }, 15_000);
+
+  it("resolves durable operator handoffs through the goal approval endpoint", async () => {
+    const runtimeRoot = path.join(tmpDir, "runtime");
+    const handoffStore = new RuntimeOperatorHandoffStore(runtimeRoot);
+    await handoffStore.create({
+      handoff_id: "handoff-http",
+      goal_id: "goal-1",
+      triggers: ["deadline", "finalization"],
+      title: "Deadline handoff",
+      summary: "Deadline finalization requires review.",
+      current_status: "mode=finalization",
+      recommended_action: "Approve finalization.",
+      next_action: {
+        label: "Approve finalization",
+        approval_required: true,
+      },
+    });
+    const server = new EventServer(
+      createMockDriveSystem() as never,
+      {
+        port: 0,
+        eventsDir: path.join(tmpDir, "events"),
+        runtimeRoot,
+      }
+    );
+
+    try {
+      await server.start();
+      const result = await request(server.getPort(), "POST", "/goals/goal-1/approve", {
+        requestId: "handoff-http",
+        approved: true,
+      }, server.getAuthToken());
+
+      expect(result.status).toBe(200);
+      expect(await handoffStore.listOpen()).toEqual([]);
+      expect(await handoffStore.load("handoff-http")).toMatchObject({
+        status: "approved",
+        resolved_at: expect.any(String),
+      });
+    } finally {
+      await server.stop();
+    }
+  }, 15_000);
+
+  it("resolves both ApprovalBroker and durable handoff when they share a handoff request id", async () => {
+    const runtimeRoot = path.join(tmpDir, "runtime");
+    const handoffStore = new RuntimeOperatorHandoffStore(runtimeRoot);
+    await handoffStore.create({
+      handoff_id: "handoff-shared",
+      goal_id: "goal-1",
+      triggers: ["external_action"],
+      title: "External action handoff",
+      summary: "External action requires approval.",
+      current_status: "task=pending",
+      recommended_action: "Approve external action.",
+      approval_request_id: "handoff-shared",
+      next_action: {
+        label: "Approve external action",
+        approval_required: true,
+      },
+    });
+    const broker = new ApprovalBroker({
+      store: new ApprovalStore(runtimeRoot),
+      createId: () => "unused-approval",
+    });
+    const server = new EventServer(
+      createMockDriveSystem() as never,
+      {
+        port: 0,
+        eventsDir: path.join(tmpDir, "events"),
+        runtimeRoot,
+        approvalBroker: broker,
+      }
+    );
+
+    try {
+      await server.start();
+      const approval = server.requestApproval("goal-1", {
+        id: "task-1",
+        description: "Approve external action",
+        action: "submit",
+      }, { requestId: "handoff-shared" });
+
+      const result = await request(server.getPort(), "POST", "/goals/goal-1/approve", {
+        requestId: "handoff-shared",
+        approved: true,
+      }, server.getAuthToken());
+
+      expect(result.status).toBe(200);
+      await expect(approval).resolves.toBe(true);
+      expect(await handoffStore.listOpen()).toEqual([]);
+      expect(await handoffStore.load("handoff-shared")).toMatchObject({
+        status: "approved",
+        resolved_at: expect.any(String),
+      });
     } finally {
       await server.stop();
     }

--- a/src/runtime/__tests__/event-server.test.ts
+++ b/src/runtime/__tests__/event-server.test.ts
@@ -9,6 +9,7 @@ import { OutboxStore } from "../store/outbox-store.js";
 import { BrowserSessionStore } from "../interactive-automation/index.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { BackgroundRunLedger } from "../store/background-run-store.js";
+import { RuntimeOperatorHandoffStore } from "../store/operator-handoff-store.js";
 
 // ─── Helpers ───
 
@@ -832,6 +833,44 @@ describe("snapshot and outbox replay", () => {
         provider_id: "browser-auth",
         service_key: "mail.google.com",
         state: "auth_required",
+      }),
+    ]);
+  });
+
+  it("includes open operator handoffs in daemon snapshot", async () => {
+    const runtimeRoot = path.join(tmpDir, "custom-runtime");
+    await new RuntimeOperatorHandoffStore(runtimeRoot).create({
+      handoff_id: "handoff-deadline",
+      goal_id: "goal-1",
+      triggers: ["deadline", "finalization"],
+      title: "Deadline handoff",
+      summary: "Deadline finalization requires review.",
+      current_status: "mode=finalization",
+      recommended_action: "Review final artifact.",
+      next_action: {
+        label: "Review final artifact",
+        approval_required: true,
+      },
+    });
+
+    server = new EventServer(mockDriveSystem as never, {
+      port: 0,
+      eventsDir: path.join(tmpDir, "events"),
+      runtimeRoot,
+    });
+
+    await server.start();
+
+    const result = await makeRequest(server.getPort(), "GET", "/snapshot");
+    expect(result.status).toBe(200);
+
+    const snapshot = JSON.parse(result.body) as { operator_handoffs?: unknown[] };
+    expect(snapshot.operator_handoffs).toEqual([
+      expect.objectContaining({
+        handoff_id: "handoff-deadline",
+        goal_id: "goal-1",
+        status: "open",
+        triggers: ["deadline", "finalization"],
       }),
     ]);
   });

--- a/src/runtime/__tests__/operator-handoff-store.test.ts
+++ b/src/runtime/__tests__/operator-handoff-store.test.ts
@@ -1,0 +1,59 @@
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RuntimeOperatorHandoffStore } from "../store/operator-handoff-store.js";
+
+describe("RuntimeOperatorHandoffStore", () => {
+  let tmpDir: string;
+  let store: RuntimeOperatorHandoffStore;
+
+  beforeEach(async () => {
+    tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-operator-handoff-"));
+    store = new RuntimeOperatorHandoffStore(path.join(tmpDir, "runtime"), {
+      now: () => new Date("2026-05-01T00:00:00.000Z"),
+    });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("persists open handoffs and resolves them durably", async () => {
+    const created = await store.create({
+      handoff_id: "handoff-run-1",
+      goal_id: "goal-1",
+      run_id: "run-1",
+      triggers: ["deadline", "external_action"],
+      title: "Operator handoff",
+      summary: "Deadline finalization requires approval.",
+      current_status: "mode=finalization",
+      recommended_action: "Approve or skip the external action.",
+      required_approvals: ["Publish report"],
+      next_action: {
+        label: "Publish report",
+        tool_name: "publish_report",
+        payload_ref: "artifact:best",
+        approval_required: true,
+      },
+      evidence_refs: [{ kind: "artifact", ref: "reports/final.md" }],
+    });
+
+    expect(created).toMatchObject({
+      schema_version: "runtime-operator-handoff-v1",
+      status: "open",
+      handoff_id: "handoff-run-1",
+      required_approvals: ["Publish report"],
+    });
+
+    const restarted = new RuntimeOperatorHandoffStore(path.join(tmpDir, "runtime"));
+    expect(await restarted.listOpen()).toHaveLength(1);
+
+    await restarted.resolve("handoff-run-1", "approved");
+    expect(await restarted.listOpen()).toHaveLength(0);
+    expect(await restarted.load("handoff-run-1")).toMatchObject({
+      status: "approved",
+      resolved_at: expect.any(String),
+    });
+  });
+});

--- a/src/runtime/__tests__/runner-goal-cycle.test.ts
+++ b/src/runtime/__tests__/runner-goal-cycle.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { runDaemonGoalCycleLoop } from "../daemon/runner-goal-cycle.js";
 import type { LoopResult, ProgressEvent } from "../../orchestrator/loop/core-loop.js";
+import { RuntimeOperatorHandoffStore } from "../store/operator-handoff-store.js";
 
 function makeLoopResult(overrides: Partial<LoopResult> = {}): LoopResult {
   return {
@@ -118,6 +122,86 @@ describe("runDaemonGoalCycleLoop", () => {
         status: "completed",
       })
     );
+  });
+
+  it("broadcasts newly persisted operator handoffs to live daemon subscribers", async () => {
+    const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-runner-handoff-"));
+    try {
+      const broadcast = vi.fn();
+      const handoffStore = new RuntimeOperatorHandoffStore(path.join(tmpDir, "runtime"));
+      const run = vi.fn().mockImplementation(async () => {
+        await handoffStore.create({
+          handoff_id: "handoff-live",
+          goal_id: "goal-1",
+          triggers: ["deadline", "finalization"],
+          title: "Deadline handoff",
+          summary: "Deadline finalization requires review.",
+          current_status: "mode=finalization",
+          recommended_action: "Review final artifact.",
+          next_action: {
+            label: "Review final artifact",
+            approval_required: true,
+          },
+        });
+        return makeLoopResult({ finalStatus: "finalization" });
+      });
+
+      let context: Record<string, unknown>;
+      context = {
+        running: true,
+        shuttingDown: false,
+        currentGoalIds: ["goal-1"],
+        config: { iterations_per_cycle: 1 },
+        state: {
+          loop_count: 0,
+          last_loop_at: null,
+          status: "running",
+          active_goals: ["goal-1"],
+        },
+        consecutiveIdleCycles: 0,
+        currentLoopIndex: 0,
+        coreLoop: { run },
+        eventServer: { broadcast },
+        stateManager: {
+          getBaseDir: () => tmpDir,
+          loadGoal: vi.fn().mockResolvedValue({ status: "active" }),
+        },
+        logger: { info: vi.fn(), warn: vi.fn() },
+        refreshOperationalState: vi.fn(),
+        collectGoalCycleSnapshot: vi.fn().mockResolvedValue([]),
+        determineActiveGoals: vi.fn().mockResolvedValue(["goal-1"]),
+        maybeRefreshProviderRuntime: vi.fn().mockResolvedValue(undefined),
+        broadcastGoalUpdated: vi.fn().mockResolvedValue(undefined),
+        handleLoopError: vi.fn(),
+        saveDaemonState: vi.fn().mockResolvedValue(undefined),
+        processCronTasks: vi.fn().mockResolvedValue(undefined),
+        processScheduleEntries: vi.fn().mockResolvedValue(undefined),
+        expireCronTasks: vi.fn().mockResolvedValue(undefined),
+        proactiveTick: vi.fn().mockResolvedValue(undefined),
+        runRuntimeStoreMaintenance: vi.fn().mockResolvedValue(undefined),
+        getNextInterval: vi.fn().mockReturnValue(1),
+        getMaxGapScore: vi.fn().mockResolvedValue(0.5),
+        calculateAdaptiveInterval: vi.fn().mockReturnValue(1),
+        sleep: vi.fn().mockImplementation(async () => {
+          context.running = false;
+        }),
+        handleCriticalError: vi.fn(),
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await runDaemonGoalCycleLoop(context);
+
+      expect(broadcast).toHaveBeenCalledWith(
+        "operator_handoff_required",
+        expect.objectContaining({
+          handoff_id: "handoff-live",
+          goal_id: "goal-1",
+          status: "open",
+        })
+      );
+    } finally {
+      await fsp.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("broadcasts loop_error when the CoreLoop run fails", async () => {

--- a/src/runtime/daemon/client.ts
+++ b/src/runtime/daemon/client.ts
@@ -34,6 +34,7 @@ export interface DaemonSnapshot {
   auth_sessions?: unknown[];
   guardrails?: Record<string, unknown> | null;
   runtime_sessions?: unknown;
+  operator_handoffs?: unknown[];
 }
 
 export interface DaemonHealth {
@@ -416,6 +417,9 @@ export class DaemonClient {
       }
       for (const approval of snapshot.approvals ?? []) {
         this.emit("approval_required", approval);
+      }
+      for (const handoff of snapshot.operator_handoffs ?? []) {
+        this.emit("operator_handoff_required", handoff);
       }
     } catch {
       // Snapshot bootstrap is optional; fall back to a direct stream connect.

--- a/src/runtime/daemon/runner-goal-cycle.ts
+++ b/src/runtime/daemon/runner-goal-cycle.ts
@@ -1,6 +1,7 @@
+import * as path from "node:path";
 import type { LoopResult } from "../../orchestrator/loop/core-loop.js";
 import type { ProgressEvent } from "../../orchestrator/loop/core-loop.js";
-import type { GoalCycleScheduleSnapshotEntry } from "./maintenance.js";
+import { RuntimeOperatorHandoffStore } from "../store/operator-handoff-store.js";
 import { errorMessage } from "./runner-errors.js";
 import { getDueWaitGoalIds } from "./wait-deadline-resolver.js";
 
@@ -89,6 +90,35 @@ function buildLoopErrorPayload(goalId: string, error: unknown, context: GoalCycl
   };
 }
 
+async function broadcastOpenOperatorHandoffs(context: GoalCycleRunnerContext, goalId: string): Promise<void> {
+  if (!context.eventServer) return;
+  const runtimeRoot = context.runtimeRoot
+    ?? (typeof context.stateManager?.getBaseDir === "function"
+      ? path.join(context.stateManager.getBaseDir(), "runtime")
+      : null);
+  if (!runtimeRoot) return;
+
+  const broadcasted = context.operatorHandoffBroadcastedIds instanceof Set
+    ? context.operatorHandoffBroadcastedIds
+    : new Set<string>();
+  context.operatorHandoffBroadcastedIds = broadcasted;
+
+  try {
+    const handoffs = await new RuntimeOperatorHandoffStore(runtimeRoot).listOpen();
+    for (const handoff of handoffs) {
+      if (handoff.goal_id && handoff.goal_id !== goalId) continue;
+      if (broadcasted.has(handoff.handoff_id)) continue;
+      broadcasted.add(handoff.handoff_id);
+      await context.eventServer.broadcast("operator_handoff_required", handoff);
+    }
+  } catch (err) {
+    context.logger?.warn?.("Failed to broadcast operator handoffs", {
+      goalId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): Promise<void> {
   while (context.running && !context.shuttingDown) {
     try {
@@ -156,6 +186,7 @@ export async function runDaemonGoalCycleLoop(context: GoalCycleRunnerContext): P
               loopCount: context.state.loop_count,
               status: goal?.status ?? "unknown",
             });
+            await broadcastOpenOperatorHandoffs(context, goalId);
             void context.eventServer.broadcast?.("loop_complete", buildLoopCompletePayload(goalId, result));
           }
           await context.broadcastGoalUpdated(goalId, result.finalStatus);

--- a/src/runtime/daemon/runner-startup.ts
+++ b/src/runtime/daemon/runner-startup.ts
@@ -101,6 +101,11 @@ export async function startDaemonRunner(
         const description = String(task["description"] ?? "");
         const action = String(task["action"] ?? "");
         const taskId = String(task["id"] ?? "");
+        const approvalRequestId = typeof task["approval_request_id"] === "string"
+          ? task["approval_request_id"]
+          : typeof task["operator_handoff_id"] === "string"
+            ? task["operator_handoff_id"]
+            : undefined;
 
         if (context.reportingEngine) {
           try {
@@ -121,7 +126,7 @@ export async function startDaemonRunner(
           id: taskId,
           description,
           action,
-        });
+        }, approvalRequestId ? { requestId: approvalRequestId } : {});
       };
     }
 

--- a/src/runtime/event/server-command-handler.ts
+++ b/src/runtime/event/server-command-handler.ts
@@ -1,6 +1,5 @@
 import type * as http from "node:http";
 import { createEnvelope, type Envelope } from "../types/envelope.js";
-import type { ApprovalBroker } from "../approval-broker.js";
 import type { SlackChannelAdapter } from "../gateway/slack-channel-adapter.js";
 import { RuntimeControlOperationKindSchema } from "../store/index.js";
 import { readBody, writeJson, writeJsonError } from "./server-http.js";
@@ -9,9 +8,8 @@ export class EventServerCommandHandler {
   constructor(
     private readonly broadcast: (eventType: string, data: unknown) => Promise<void>,
     private readonly getCommandEnvelopeHook: () => ((envelope: Envelope) => void | Promise<void>) | undefined,
-    private readonly hasPendingApprovalRequest: (requestId: string) => boolean,
+    private readonly canResolveApproval: (requestId: string) => Promise<boolean>,
     private readonly resolveApproval: (requestId: string, approved: boolean) => Promise<boolean>,
-    private readonly getApprovalBroker: () => ApprovalBroker | undefined,
     private readonly getSlackChannelAdapter: () => SlackChannelAdapter | undefined
   ) {}
 
@@ -108,7 +106,7 @@ export class EventServerCommandHandler {
       try {
         const body = await readBody(req);
         const { requestId, approved } = JSON.parse(body) as { requestId: string; approved: boolean };
-        if (!this.getApprovalBroker() && !this.hasPendingApprovalRequest(requestId)) {
+        if (!(await this.canResolveApproval(requestId))) {
           writeJson(res, 404, { ok: false });
           return;
         }

--- a/src/runtime/event/server-snapshot-reader.ts
+++ b/src/runtime/event/server-snapshot-reader.ts
@@ -7,6 +7,10 @@ import { GuardrailStore } from "../guardrails/index.js";
 import type { StateManager } from "../../base/state/state-manager.js";
 import { createRuntimeSessionRegistry } from "../session-registry/index.js";
 import type { RuntimeSessionRegistrySnapshot } from "../session-registry/types.js";
+import {
+  RuntimeOperatorHandoffStore,
+  type RuntimeOperatorHandoffRecord,
+} from "../store/operator-handoff-store.js";
 
 type ActiveWorkersProvider = () =>
   | Array<Record<string, unknown>>
@@ -21,6 +25,7 @@ export interface EventServerSnapshotData {
   auth_sessions: Array<Record<string, unknown>>;
   guardrails: Record<string, unknown> | null;
   runtime_sessions: RuntimeSessionRegistrySnapshot | null;
+  operator_handoffs: RuntimeOperatorHandoffRecord[];
 }
 
 export class EventServerSnapshotReader {
@@ -35,7 +40,7 @@ export class EventServerSnapshotReader {
     outboxStore?: OutboxStore,
     activeWorkersProvider?: ActiveWorkersProvider
   ): Promise<EventServerSnapshotData> {
-    const [daemon, goals, latestOutbox, activeWorkers, authSessions, guardrails, runtimeSessions] = await Promise.all([
+    const [daemon, goals, latestOutbox, activeWorkers, authSessions, guardrails, runtimeSessions, operatorHandoffs] = await Promise.all([
       this.readDaemonState(),
       this.readGoalSummaries(),
       outboxStore?.loadLatest() ?? Promise.resolve(null),
@@ -43,6 +48,7 @@ export class EventServerSnapshotReader {
       this.readPendingAuthSessions(),
       this.readGuardrailSnapshot(),
       this.readRuntimeSessionSnapshot(),
+      this.readOpenOperatorHandoffs(),
     ]);
 
     return {
@@ -54,6 +60,7 @@ export class EventServerSnapshotReader {
       auth_sessions: authSessions,
       guardrails,
       runtime_sessions: runtimeSessions,
+      operator_handoffs: operatorHandoffs,
     };
   }
 
@@ -103,6 +110,10 @@ export class EventServerSnapshotReader {
     if (!this.stateManager) return null;
     const registry = createRuntimeSessionRegistry({ stateManager: this.stateManager });
     return registry.snapshot();
+  }
+
+  private async readOpenOperatorHandoffs(): Promise<RuntimeOperatorHandoffRecord[]> {
+    return new RuntimeOperatorHandoffStore(this.runtimeRoot()).listOpen();
   }
 
   async readDaemonStateRaw(): Promise<string | null> {

--- a/src/runtime/event/server-types.ts
+++ b/src/runtime/event/server-types.ts
@@ -3,6 +3,7 @@ import type { TriggerMapper } from "../trigger-mapper.js";
 import type { ApprovalBroker, ApprovalRequiredEvent } from "../approval-broker.js";
 import type { OutboxStore } from "../store/index.js";
 import type { RuntimeSessionRegistrySnapshot } from "../session-registry/types.js";
+import type { RuntimeOperatorHandoffRecord } from "../store/operator-handoff-store.js";
 
 export interface EventServerConfig {
   host?: string;
@@ -26,6 +27,7 @@ export interface EventServerSnapshot {
   auth_sessions?: unknown[];
   guardrails?: Record<string, unknown> | null;
   runtime_sessions?: RuntimeSessionRegistrySnapshot | null;
+  operator_handoffs?: RuntimeOperatorHandoffRecord[];
 }
 
 export type ActiveWorkersProvider = () =>

--- a/src/runtime/event/server.ts
+++ b/src/runtime/event/server.ts
@@ -1,5 +1,6 @@
 import * as fsp from "node:fs/promises";
 import * as http from "node:http";
+import * as path from "node:path";
 import type { DriveSystem } from "../../platform/drive/drive-system.js";
 import { PulSeedEventSchema } from "../../base/types/drive.js";
 import { getEventsDir } from "../../base/utils/paths.js";
@@ -7,6 +8,7 @@ import type { Logger } from "../logger.js";
 import { DEFAULT_PORT } from "../port-utils.js";
 import type { ApprovalBroker } from "../approval-broker.js";
 import type { OutboxStore } from "../store/index.js";
+import { RuntimeOperatorHandoffStore } from "../store/operator-handoff-store.js";
 import type { Envelope } from "../types/envelope.js";
 import type { SlackChannelAdapter } from "../gateway/slack-channel-adapter.js";
 import { EventServerAuth } from "./server-auth.js";
@@ -20,7 +22,6 @@ import { EventServerTriggerHandler } from "./server-trigger-handler.js";
 import type {
   ActiveWorkersProvider,
   EventServerConfig,
-  EventServerSnapshot,
 } from "./server-types.js";
 
 const DEFAULT_EVENT_FILE_MAX_ATTEMPTS = 3;
@@ -33,6 +34,7 @@ export class EventServer {
   private readonly host: string;
   private port: number;
   private readonly eventsDir: string;
+  private readonly runtimeRoot: string;
   private readonly logger?: Logger;
   private approvalBroker?: ApprovalBroker;
   private outboxStore?: OutboxStore;
@@ -61,6 +63,7 @@ export class EventServer {
     this.host = config?.host ?? "127.0.0.1";
     this.port = config?.port ?? DEFAULT_PORT;
     this.eventsDir = config?.eventsDir ?? getEventsDir();
+    this.runtimeRoot = config?.runtimeRoot ?? path.join(path.dirname(this.eventsDir), "runtime");
     this.logger = logger;
     this.approvalBroker = config?.approvalBroker;
     this.outboxStore = config?.outboxStore;
@@ -83,9 +86,8 @@ export class EventServer {
     this.commandHandler = new EventServerCommandHandler(
       async (eventType, data) => this.broadcast(eventType, data),
       () => this.commandEnvelopeHook,
-      (requestId) => this.approvalQueue.has(requestId),
+      async (requestId) => this.canResolveApproval(requestId),
       async (requestId, approved) => this.resolveApproval(requestId, approved),
-      () => this.approvalBroker,
       () => this.slackChannelAdapter,
     );
     this.router = new EventServerRouter({
@@ -162,11 +164,15 @@ export class EventServer {
     await this.sseManager.broadcast(eventType, data);
   }
 
-  async requestApproval(goalId: string, task: { id: string; description: string; action: string }): Promise<boolean> {
+  async requestApproval(
+    goalId: string,
+    task: { id: string; description: string; action: string },
+    options: { requestId?: string } = {}
+  ): Promise<boolean> {
     if (this.approvalBroker) {
-      return this.approvalBroker.requestApproval(goalId, task);
+      return this.approvalBroker.requestApproval(goalId, task, undefined, options.requestId);
     }
-    const requestId = `approval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const requestId = options.requestId ?? `approval-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     return new Promise<boolean>((resolve) => {
       const timer = setTimeout(() => {
         this.approvalQueue.delete(requestId);
@@ -180,14 +186,46 @@ export class EventServer {
 
   async resolveApproval(requestId: string, approved: boolean): Promise<boolean> {
     if (this.approvalBroker) {
-      return this.approvalBroker.resolveApproval(requestId, approved, "http");
+      const resolved = await this.approvalBroker.resolveApproval(requestId, approved, "http");
+      if (resolved) {
+        await this.resolveOperatorHandoffApproval(requestId, approved, { allowAlreadyResolved: true });
+        return true;
+      }
     }
     const entry = this.approvalQueue.get(requestId);
-    if (!entry) return false;
-    clearTimeout(entry.timer);
-    this.approvalQueue.delete(requestId);
-    entry.resolve(approved);
-    void this.broadcast("approval_resolved", { requestId, approved });
+    if (entry) {
+      clearTimeout(entry.timer);
+      this.approvalQueue.delete(requestId);
+      entry.resolve(approved);
+      void this.broadcast("approval_resolved", { requestId, approved });
+      await this.resolveOperatorHandoffApproval(requestId, approved, { allowAlreadyResolved: true });
+      return true;
+    }
+    return this.resolveOperatorHandoffApproval(requestId, approved);
+  }
+
+  private async canResolveApproval(requestId: string): Promise<boolean> {
+    if (this.approvalBroker || this.approvalQueue.has(requestId)) return true;
+    const handoff = await new RuntimeOperatorHandoffStore(this.runtimeRoot).load(requestId);
+    return handoff?.status === "open";
+  }
+
+  private async resolveOperatorHandoffApproval(
+    requestId: string,
+    approved: boolean,
+    options: { allowAlreadyResolved?: boolean } = {}
+  ): Promise<boolean> {
+    const store = new RuntimeOperatorHandoffStore(this.runtimeRoot);
+    const existing = await store.load(requestId);
+    if (!existing) return false;
+    if (existing.status !== "open") return options.allowAlreadyResolved === true;
+    const resolved = await store.resolve(requestId, approved ? "approved" : "dismissed");
+    void this.broadcast("approval_resolved", {
+      requestId,
+      goalId: resolved.goal_id,
+      approved,
+      kind: "operator_handoff",
+    });
     return true;
   }
 

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -148,6 +148,12 @@ export {
   RuntimeBudgetThresholdActionSchema,
   RuntimeBudgetUsageSchema,
 } from "./budget-store.js";
+export {
+  RuntimeOperatorHandoffRecordSchema,
+  RuntimeOperatorHandoffStatusSchema,
+  RuntimeOperatorHandoffStore,
+  RuntimeOperatorHandoffTriggerSchema,
+} from "./operator-handoff-store.js";
 export type {
   RuntimeBudgetCreateInput,
   RuntimeBudgetDimension,
@@ -163,6 +169,12 @@ export type {
   RuntimeBudgetUsageInput,
   RuntimeBudgetUsageUpdateInput,
 } from "./budget-store.js";
+export type {
+  RuntimeOperatorHandoffInput,
+  RuntimeOperatorHandoffRecord,
+  RuntimeOperatorHandoffStatus,
+  RuntimeOperatorHandoffTrigger,
+} from "./operator-handoff-store.js";
 export type {
   RuntimeExperimentQueueCreateInput,
   RuntimeExperimentQueueExecutionDirective,

--- a/src/runtime/store/operator-handoff-store.ts
+++ b/src/runtime/store/operator-handoff-store.ts
@@ -1,0 +1,147 @@
+import { z } from "zod";
+import {
+  createRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+import { RuntimeJournal } from "./runtime-journal.js";
+
+export const RuntimeOperatorHandoffTriggerSchema = z.enum([
+  "deadline",
+  "budget",
+  "auth",
+  "external_action",
+  "irreversible_action",
+  "finalization",
+  "policy",
+]);
+export type RuntimeOperatorHandoffTrigger = z.infer<typeof RuntimeOperatorHandoffTriggerSchema>;
+
+export const RuntimeOperatorHandoffStatusSchema = z.enum([
+  "open",
+  "approved",
+  "resolved",
+  "dismissed",
+]);
+export type RuntimeOperatorHandoffStatus = z.infer<typeof RuntimeOperatorHandoffStatusSchema>;
+
+export const RuntimeOperatorHandoffRecordSchema = z.object({
+  schema_version: z.literal("runtime-operator-handoff-v1"),
+  handoff_id: z.string().min(1),
+  goal_id: z.string().min(1).optional(),
+  run_id: z.string().min(1).optional(),
+  status: RuntimeOperatorHandoffStatusSchema.default("open"),
+  triggers: z.array(RuntimeOperatorHandoffTriggerSchema).min(1),
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  current_status: z.string().min(1),
+  recommended_action: z.string().min(1),
+  candidate_options: z.array(z.object({
+    id: z.string().min(1),
+    label: z.string().min(1),
+    tradeoff: z.string().min(1),
+  }).strict()).default([]),
+  risks: z.array(z.string().min(1)).default([]),
+  required_approvals: z.array(z.string().min(1)).default([]),
+  required_credentials: z.array(z.string().min(1)).default([]),
+  approval_request_id: z.string().min(1).optional(),
+  next_action: z.object({
+    label: z.string().min(1),
+    command: z.string().min(1).optional(),
+    tool_name: z.string().min(1).optional(),
+    payload_ref: z.string().min(1).optional(),
+    approval_required: z.boolean().default(true),
+  }).strict(),
+  gate: z.object({
+    autonomous_task_generation: z.enum(["pause", "constrain", "none"]).default("constrain"),
+    external_action_requires_approval: z.boolean().default(true),
+  }).strict().default({}),
+  evidence_refs: z.array(z.object({
+    kind: z.string().min(1),
+    ref: z.string().min(1),
+    observed_at: z.string().datetime().optional(),
+  }).strict()).default([]),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  resolved_at: z.string().datetime().nullable().default(null),
+}).strict();
+export type RuntimeOperatorHandoffRecord = z.infer<typeof RuntimeOperatorHandoffRecordSchema>;
+export type RuntimeOperatorHandoffInput = Omit<
+  z.input<typeof RuntimeOperatorHandoffRecordSchema>,
+  "schema_version" | "status" | "created_at" | "updated_at" | "resolved_at"
+> & {
+  handoff_id?: string;
+  status?: RuntimeOperatorHandoffStatus;
+  created_at?: string;
+};
+
+const RuntimeOperatorHandoffRecordRuntimeSchema =
+  RuntimeOperatorHandoffRecordSchema as unknown as z.ZodType<RuntimeOperatorHandoffRecord>;
+
+export class RuntimeOperatorHandoffStore {
+  private readonly paths: RuntimeStorePaths;
+  private readonly journal: RuntimeJournal;
+  private readonly now: () => Date;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths, options: { now?: () => Date } = {}) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+    this.journal = new RuntimeJournal(this.paths);
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async load(handoffId: string): Promise<RuntimeOperatorHandoffRecord | null> {
+    return this.journal.load(this.paths.operatorHandoffPath(handoffId), RuntimeOperatorHandoffRecordRuntimeSchema);
+  }
+
+  async list(): Promise<RuntimeOperatorHandoffRecord[]> {
+    return this.journal.list(this.paths.operatorHandoffsDir, RuntimeOperatorHandoffRecordRuntimeSchema);
+  }
+
+  async listOpen(): Promise<RuntimeOperatorHandoffRecord[]> {
+    return (await this.list()).filter((record) => record.status === "open");
+  }
+
+  async create(input: RuntimeOperatorHandoffInput): Promise<RuntimeOperatorHandoffRecord> {
+    const now = input.created_at ?? this.nowIso();
+    const handoffId = input.handoff_id ?? deterministicHandoffId(input);
+    const existing = await this.load(handoffId);
+    const record = RuntimeOperatorHandoffRecordSchema.parse({
+      ...existing,
+      ...input,
+      schema_version: "runtime-operator-handoff-v1",
+      handoff_id: handoffId,
+      status: existing?.status ?? input.status ?? "open",
+      created_at: existing?.created_at ?? now,
+      updated_at: now,
+      resolved_at: existing?.resolved_at ?? null,
+    });
+    return this.journal.save(this.paths.operatorHandoffPath(handoffId), RuntimeOperatorHandoffRecordRuntimeSchema, record);
+  }
+
+  async resolve(handoffId: string, status: Exclude<RuntimeOperatorHandoffStatus, "open">): Promise<RuntimeOperatorHandoffRecord> {
+    const existing = await this.load(handoffId);
+    if (!existing) throw new Error(`Runtime operator handoff not found: ${handoffId}`);
+    const now = this.nowIso();
+    return this.journal.save(this.paths.operatorHandoffPath(handoffId), RuntimeOperatorHandoffRecordRuntimeSchema, {
+      ...existing,
+      status,
+      updated_at: now,
+      resolved_at: now,
+    });
+  }
+
+  private nowIso(): string {
+    return this.now().toISOString();
+  }
+}
+
+function deterministicHandoffId(input: RuntimeOperatorHandoffInput): string {
+  const scope = input.run_id ?? input.goal_id ?? "global";
+  return `handoff:${scope}:${input.triggers.join("+")}:${slug(input.next_action.label)}`;
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 48) || "action";
+}

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -31,6 +31,7 @@ export interface RuntimeStorePaths {
   reproducibilityManifestsDir: string;
   experimentQueuesDir: string;
   budgetsDir: string;
+  operatorHandoffsDir: string;
   backpressureSnapshotPath: string;
   daemonHealthPath: string;
   componentsHealthPath: string;
@@ -48,6 +49,7 @@ export interface RuntimeStorePaths {
   reproducibilityManifestPath(manifestId: string): string;
   experimentQueuePath(queueId: string): string;
   budgetPath(budgetId: string): string;
+  operatorHandoffPath(handoffId: string): string;
   goalLeasePath(goalId: string): string;
   completedByIdempotencyPath(idempotencyKey: string): string;
   completedByMessagePath(messageId: string): string;
@@ -107,6 +109,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
   const reproducibilityManifestsDir = path.join(rootDir, "reproducibility-manifests");
   const experimentQueuesDir = path.join(rootDir, "experiment-queues");
   const budgetsDir = path.join(rootDir, "budgets");
+  const operatorHandoffsDir = path.join(rootDir, "operator-handoffs");
 
   return {
     rootDir,
@@ -136,6 +139,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     reproducibilityManifestsDir,
     experimentQueuesDir,
     budgetsDir,
+    operatorHandoffsDir,
     backpressureSnapshotPath: path.join(guardrailsDir, "backpressure.json"),
     daemonHealthPath: path.join(healthDir, "daemon.json"),
     componentsHealthPath: path.join(healthDir, "components.json"),
@@ -181,6 +185,9 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     budgetPath(budgetId: string) {
       return path.join(budgetsDir, recordFileName(encodeRuntimePathSegment(budgetId)));
     },
+    operatorHandoffPath(handoffId: string) {
+      return path.join(operatorHandoffsDir, recordFileName(encodeRuntimePathSegment(handoffId)));
+    },
     goalLeasePath(goalId: string) {
       return path.join(goalLeasesDir, `${encodeRuntimePathSegment(goalId)}.json`);
     },
@@ -225,6 +232,7 @@ export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise
       paths.reproducibilityManifestsDir,
       paths.experimentQueuesDir,
       paths.budgetsDir,
+      paths.operatorHandoffsDir,
     ].map((dir) => fsp.mkdir(dir, { recursive: true }))
   );
 }


### PR DESCRIPTION
Closes #821

## Summary
- add durable runtime operator handoff records for deadline/finalization, budget thresholds, and approval-gated external/irreversible actions
- expose open handoffs through daemon snapshots, chat status/events, daemon reconnect replay, and the TUI approval overlay
- align handoff approval IDs with live ApprovalBroker request IDs so operator decisions unblock broker waits

## Verification
- `npx vitest run src/runtime/__tests__/event-server-approval.test.ts src/orchestrator/execution/__tests__/task-lifecycle-generation.test.ts src/runtime/__tests__/daemon-client.test.ts src/interface/tui/__tests__/app.test.ts src/runtime/__tests__/runner-goal-cycle.test.ts src/interface/chat/__tests__/event-subscriber.test.ts`
- `npx vitest run src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts src/runtime/__tests__/event-server-approval.test.ts src/interface/tui/__tests__/app.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed`
- `git diff --check`

## Known Risks
- `npm run lint:boundaries` still reports existing repo warnings, but 0 errors.
- TUI product workflow issues #846-#850 are intentionally out of scope; this PR only adds runtime/status/approval surfaces needed before that work.

## Review
- Independent review found and the patch fixed approval handoffs staying open after decisions, missing live handoff broadcasts, durable handoff approval endpoint gaps, and budget handoff/broker ID divergence.
- Final re-review reported no material findings.