### PR TITLE
Add runtime postmortem reports

### DIFF
--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -195,6 +195,55 @@ describe("runtime registry CLI commands", () => {
     expect(parsed.artifact_retention).toMatchObject({ total_artifacts: 1, protected_count: 1 });
   });
 
+  it("generates a durable runtime postmortem from the CLI", async () => {
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      id: "postmortem-cli-start",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-postmortem-cli" },
+      metrics: [{ label: "score", value: 0.5, direction: "maximize", observed_at: "2026-04-30T00:00:00.000Z" }],
+      summary: "Initial score recorded.",
+    });
+    await ledger.append({
+      id: "postmortem-cli-final",
+      occurred_at: "2026-04-30T01:00:00.000Z",
+      kind: "artifact",
+      scope: { goal_id: "goal-postmortem-cli" },
+      metrics: [{ label: "score", value: 0.6, direction: "maximize", observed_at: "2026-04-30T01:00:00.000Z" }],
+      artifacts: [{ label: "final-report", state_relative_path: "reports/final.md", kind: "report", retention_class: "final_deliverable" }],
+      summary: "Final report is ready.",
+      outcome: "improved",
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const textCode = await runCLI("runtime", "postmortem", "goal-postmortem-cli");
+    const textOutput = logSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+
+    expect(textCode).toBe(0);
+    expect(textOutput).toContain("Runtime postmortem: goal goal-postmortem-cli");
+    expect(textOutput).toContain("Follow-ups:");
+    expect(textOutput).toContain("postmortem.md");
+
+    logSpy.mockClear();
+    const jsonCode = await runCLI("runtime", "postmortem", "goal-postmortem-cli", "--json");
+    const jsonOutput = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(jsonOutput) as {
+      schema_version: string;
+      metric_timeline: Array<{ metric_key: string; best_value: number }>;
+      final_outputs: Array<{ label: string }>;
+      artifact_paths: { markdown_path: string };
+      follow_up_actions: Array<{ auto_create: boolean }>;
+    };
+
+    expect(jsonCode).toBe(0);
+    expect(parsed.schema_version).toBe("runtime-postmortem-v1");
+    expect(parsed.metric_timeline).toContainEqual(expect.objectContaining({ metric_key: "score", best_value: 0.6 }));
+    expect(parsed.final_outputs).toContainEqual(expect.objectContaining({ label: "final-report" }));
+    expect(parsed.follow_up_actions.every((action) => action.auto_create === false)).toBe(true);
+    await expect(fsp.readFile(parsed.artifact_paths.markdown_path, "utf8")).resolves.toContain("Runtime Postmortem");
+  });
+
   it("shows evaluator local best, external best, gap, and approval gate in runtime evidence", async () => {
     const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
     await ledger.append({
@@ -451,6 +500,29 @@ describe("runtime registry CLI commands", () => {
     expect(code).toBe(0);
     expect(parsed.scope.run_id).toBe("dummy-runtime-run");
     expect(parsed.total_entries).toBe(1);
+  });
+
+  it("generates a postmortem for non-prefixed long-running run IDs", async () => {
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      id: "dummy-run-postmortem-evidence",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "artifact",
+      scope: { run_id: "dummy-runtime-run-postmortem" },
+      summary: "Long-running final report written.",
+      artifacts: [{ label: "summary.md", path: "/tmp/summary.md", kind: "report", retention_class: "final_deliverable" }],
+      outcome: "improved",
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("runtime", "postmortem", "dummy-runtime-run-postmortem", "--json");
+    const output = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(output) as { scope: { run_id?: string; goal_id?: string }; final_outputs: Array<{ label: string }> };
+
+    expect(code).toBe(0);
+    expect(parsed.scope.run_id).toBe("dummy-runtime-run-postmortem");
+    expect(parsed.scope.goal_id).toBeUndefined();
+    expect(parsed.final_outputs).toContainEqual(expect.objectContaining({ label: "summary.md" }));
   });
 
   it("reports experiment queue phase separately from frozen execution status", async () => {

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -3,7 +3,7 @@
 import { parseArgs } from "node:util";
 import * as path from "node:path";
 
-import { StateManager } from "../../../base/state/state-manager.js";
+import type { StateManager } from "../../../base/state/state-manager.js";
 import { createRuntimeSessionRegistry } from "../../../runtime/session-registry/index.js";
 import { RuntimeEvidenceLedger, type RuntimeEvidenceEntry, type RuntimeEvidenceSummary } from "../../../runtime/store/evidence-ledger.js";
 import {
@@ -15,6 +15,10 @@ import {
   RuntimeBudgetStore,
   type RuntimeBudgetRecord,
 } from "../../../runtime/store/budget-store.js";
+import {
+  RuntimePostmortemReportStore,
+  type RuntimePostmortemReport,
+} from "../../../runtime/store/postmortem-report.js";
 import {
   createRuntimeDreamSidecarReview,
   RuntimeDreamSidecarReviewError,
@@ -348,7 +352,7 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
   const runtimeSubcommand = args[0];
 
   if (!runtimeSubcommand) {
-    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
+    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime postmortem <goal-id|run-id>, runtime dream-review <run-id>");
     return 1;
   }
 
@@ -427,6 +431,19 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
     const ledger = new RuntimeEvidenceLedger(path.join(stateManager.getBaseDir(), "runtime"));
     const summary = await summarizeEvidenceTarget(ledger, values.id);
     values.json ? printJson(summary) : printEvidenceSummary(summary);
+    return 0;
+  }
+
+  if (runtimeSubcommand === "postmortem") {
+    const values = parseDetailArgs(args.slice(1), "postmortem");
+    if (!values.id) {
+      logger.error("Error: goal ID or run ID is required. Usage: pulseed runtime postmortem <goal-id|run-id> [--json]");
+      return 1;
+    }
+    const runtimeRoot = path.join(stateManager.getBaseDir(), "runtime");
+    const store = new RuntimePostmortemReportStore(runtimeRoot);
+    const report = await generatePostmortemTarget(store, values.id, runtimeRoot);
+    values.json ? printJson(report) : printPostmortemSummary(report);
     return 0;
   }
 
@@ -520,7 +537,7 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
   }
 
   logger.error(`Unknown runtime subcommand: "${runtimeSubcommand}"`);
-  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime dream-review <run-id>");
+  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime postmortem <goal-id|run-id>, runtime dream-review <run-id>");
   return 1;
 }
 
@@ -534,6 +551,44 @@ async function summarizeEvidenceTarget(ledger: RuntimeEvidenceLedger, id: string
   }
   const runSummary = await ledger.summarizeRun(id);
   return runSummary.total_entries > 0 ? runSummary : goalSummary;
+}
+
+async function generatePostmortemTarget(
+  store: RuntimePostmortemReportStore,
+  id: string,
+  runtimeRoot: string
+): Promise<RuntimePostmortemReport> {
+  if (id.startsWith("run:")) {
+    return store.generate({ runId: id, trigger: "operator_request" });
+  }
+  const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+  const goalSummary = await ledger.summarizeGoal(id);
+  if (goalSummary.total_entries > 0) {
+    return store.generate({ goalId: id, trigger: "operator_request" });
+  }
+  const runSummary = await ledger.summarizeRun(id);
+  return runSummary.total_entries > 0
+    ? store.generate({ runId: id, trigger: "operator_request" })
+    : store.generate({ goalId: id, trigger: "operator_request" });
+}
+
+function printPostmortemSummary(report: RuntimePostmortemReport): void {
+  const target = report.scope.run_id
+    ? `run ${report.scope.run_id}`
+    : `goal ${report.scope.goal_id ?? "-"}`;
+  console.log(`Runtime postmortem: ${target}`);
+  console.log(`  Status:       ${report.final_status}`);
+  console.log(`  Generated:    ${report.generated_at}`);
+  console.log(`  Markdown:     ${report.artifact_paths.markdown_path}`);
+  console.log(`  JSON:         ${report.artifact_paths.json_path}`);
+  console.log(`  Timeline:     ${report.timeline.length} event(s)`);
+  console.log(`  Metrics:      ${report.metric_timeline.length} trend(s)`);
+  console.log(`  Outputs:      ${report.final_outputs.length}`);
+  console.log(`  Manifests:    ${report.manifests.length}`);
+  console.log(`  Follow-ups:   ${report.follow_up_actions.length} proposed, auto_create=false`);
+  if (report.warnings.length > 0) {
+    console.log(`  Warnings:     ${report.warnings.length}`);
+  }
 }
 
 function printEvidenceSummary(summary: RuntimeEvidenceSummary): void {

--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -31,6 +31,7 @@ import { ScheduleEngine } from "../../runtime/schedule/engine.js";
 import { RuntimeEvidenceLedger } from "../../runtime/store/evidence-ledger.js";
 import { RuntimeBudgetStore } from "../../runtime/store/budget-store.js";
 import { RuntimeOperatorHandoffStore } from "../../runtime/store/operator-handoff-store.js";
+import { RuntimePostmortemReportStore } from "../../runtime/store/postmortem-report.js";
 import { TreeLoopOrchestrator } from "../../orchestrator/goal/tree-loop-orchestrator.js";
 import { GoalTreeManager } from "../../orchestrator/goal/goal-tree-manager.js";
 import { StateAggregator } from "../../orchestrator/goal/state-aggregator.js";
@@ -323,6 +324,7 @@ export async function buildDeps(
   const runtimeRoot = path.join(stateManager.getBaseDir(), "runtime");
   const runtimeBudgetStore = new RuntimeBudgetStore(runtimeRoot);
   const operatorHandoffStore = new RuntimeOperatorHandoffStore(runtimeRoot);
+  const postmortemReportStore = new RuntimePostmortemReportStore(runtimeRoot);
 
   const taskLifecycle = new TaskLifecycle({
     stateManager,
@@ -414,6 +416,7 @@ export async function buildDeps(
     evidenceLedger,
     runtimeBudgetStore,
     operatorHandoffStore,
+    postmortemReportStore,
   }, config);
 
   coreLoop.setTimeHorizonEngine(new TimeHorizonEngine());

--- a/src/interface/tui/entry-deps.ts
+++ b/src/interface/tui/entry-deps.ts
@@ -34,6 +34,7 @@ export async function buildStandaloneTuiDeps() {
   const { RuntimeEvidenceLedger } = await import("../../runtime/store/evidence-ledger.js");
   const { RuntimeBudgetStore } = await import("../../runtime/store/budget-store.js");
   const { RuntimeOperatorHandoffStore } = await import("../../runtime/store/operator-handoff-store.js");
+  const { RuntimePostmortemReportStore } = await import("../../runtime/store/postmortem-report.js");
   const { MemoryLifecycleManager, DriveScoreAdapter } = await import("../../platform/knowledge/memory/memory-lifecycle.js");
   const { KnowledgeManager } = await import("../../platform/knowledge/knowledge-manager.js");
   const { CharacterConfigManager } = await import("../../platform/traits/character-config.js");
@@ -209,6 +210,7 @@ export async function buildStandaloneTuiDeps() {
   const runtimeRoot = path.join(stateManager.getBaseDir(), "runtime");
   const runtimeBudgetStore = new RuntimeBudgetStore(runtimeRoot);
   const operatorHandoffStore = new RuntimeOperatorHandoffStore(runtimeRoot);
+  const postmortemReportStore = new RuntimePostmortemReportStore(runtimeRoot);
 
   const taskLifecycle = new TaskLifecycle({
     stateManager,
@@ -261,6 +263,7 @@ export async function buildStandaloneTuiDeps() {
     evidenceLedger,
     runtimeBudgetStore,
     operatorHandoffStore,
+    postmortemReportStore,
   });
 
   const scheduleEngine = new ScheduleEngine({

--- a/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
@@ -6,6 +6,7 @@ import { CoreLoop, makeEmptyIterationResult, type CoreLoopDeps } from "../core-l
 import { makeGoal } from "../../../../tests/helpers/fixtures.js";
 import { RuntimeBudgetStore } from "../../../runtime/store/budget-store.js";
 import { RuntimeOperatorHandoffStore } from "../../../runtime/store/operator-handoff-store.js";
+import { RuntimePostmortemReportStore } from "../../../runtime/store/postmortem-report.js";
 
 function makeDeps(): CoreLoopDeps {
   return {
@@ -175,6 +176,49 @@ describe("CoreLoop run policies", () => {
     expect(status.dimensions).toContainEqual(expect.objectContaining({ dimension: "artifacts", used: 2, remaining: 2 }));
   });
 
+  it("generates a durable run postmortem when a background run completes", async () => {
+    const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-core-postmortem-"));
+    tempDirs.push(tempDir);
+    const runtimeRoot = path.join(tempDir, "runtime");
+    const postmortemReportStore = new RuntimePostmortemReportStore(runtimeRoot);
+    const loop = new CoreLoop({
+      ...makeDeps(),
+      postmortemReportStore,
+      reportingEngine: { generateExecutionSummary: vi.fn(), saveReport: vi.fn() },
+    } as unknown as CoreLoopDeps, {
+      maxIterations: 3,
+      delayBetweenLoopsMs: 0,
+      autoDecompose: false,
+    });
+    vi.spyOn(loop, "runOneIteration").mockResolvedValue(
+      makeEmptyIterationResult("goal-postmortem-complete", 0, {
+        completionJudgment: {
+          is_complete: true,
+          blocking_dimensions: [],
+          low_confidence_dimensions: [],
+          needs_verification_task: false,
+          checked_at: new Date().toISOString(),
+        },
+      })
+    );
+
+    const result = await loop.run("goal-postmortem-complete", {
+      activation: { backgroundRun: { backgroundRunId: "run-postmortem-complete" } },
+    });
+
+    const report = await postmortemReportStore.latestFor({ runId: "run-postmortem-complete" });
+    expect(result.finalStatus).toBe("completed");
+    expect(report).toMatchObject({
+      scope: {
+        goal_id: "goal-postmortem-complete",
+        run_id: "run-postmortem-complete",
+      },
+      final_status: "completed",
+      trigger: "completion",
+    });
+    expect(await fsp.readFile(report!.artifact_paths.markdown_path, "utf8")).toContain("Runtime Postmortem");
+  });
+
   it("enforces stop exhaustion policy without asking for approval", async () => {
     const tempDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-core-budget-stop-"));
     tempDirs.push(tempDir);
@@ -219,6 +263,7 @@ describe("CoreLoop run policies", () => {
     const runtimeRoot = path.join(tempDir, "runtime");
     const runtimeBudgetStore = new RuntimeBudgetStore(runtimeRoot);
     const operatorHandoffStore = new RuntimeOperatorHandoffStore(runtimeRoot);
+    const postmortemReportStore = new RuntimePostmortemReportStore(runtimeRoot);
     await runtimeBudgetStore.create({
       budget_id: "budget-finalize",
       scope: { goal_id: "goal-budget-finalize" },
@@ -231,6 +276,7 @@ describe("CoreLoop run policies", () => {
       ...makeDeps(),
       runtimeBudgetStore,
       operatorHandoffStore,
+      postmortemReportStore,
       reportingEngine: { generateExecutionSummary: vi.fn(), saveReport: vi.fn() },
     } as unknown as CoreLoopDeps, {
       maxIterations: 2,
@@ -261,6 +307,10 @@ describe("CoreLoop run policies", () => {
         }),
       }),
     ]);
+    expect(await postmortemReportStore.latestFor({ goalId: "goal-budget-finalize" })).toMatchObject({
+      final_status: "finalization",
+      trigger: "finalization",
+    });
   });
 
   it("uses the budget approval request id for handoff records that also require approval", async () => {

--- a/src/orchestrator/loop/core-loop.ts
+++ b/src/orchestrator/loop/core-loop.ts
@@ -391,6 +391,7 @@ export class CoreLoop {
     await runPostLoopHooks({
       goalId,
       sessionId,
+      runId: this.currentActivationContext?.backgroundRun?.backgroundRunId,
       completedAt,
       totalTokensUsed: totalTokens,
       finalStatus,

--- a/src/orchestrator/loop/core-loop/contracts.ts
+++ b/src/orchestrator/loop/core-loop/contracts.ts
@@ -40,6 +40,7 @@ import type {
   RuntimeBudgetStore,
 } from "../../../runtime/store/budget-store.js";
 import type { RuntimeOperatorHandoffStore } from "../../../runtime/store/operator-handoff-store.js";
+import type { RuntimePostmortemReportStore } from "../../../runtime/store/postmortem-report.js";
 import type { DeadlineFinalizationStatus } from "../../../platform/time/deadline-finalization.js";
 import type { ExecutionModeState } from "../../../platform/time/execution-mode.js";
 export type {
@@ -330,6 +331,8 @@ export interface CoreLoopDeps extends ObservationDeps, TreeDeps, StallDeps, Task
   runtimeBudgetStore?: RuntimeBudgetStore;
   /** Optional durable operator handoff store for deadline, budget, and approval gates. */
   operatorHandoffStore?: RuntimeOperatorHandoffStore;
+  /** Optional durable postmortem report store for terminal and paused long-running runs. */
+  postmortemReportStore?: RuntimePostmortemReportStore;
   /** Optional bounded agentloop runner for core phases. */
   corePhaseRunner?: CorePhaseRunner;
   /** Optional live approval broker for wait/resume approvals. */

--- a/src/orchestrator/loop/post-loop-hooks.ts
+++ b/src/orchestrator/loop/post-loop-hooks.ts
@@ -16,6 +16,7 @@ import type { Logger } from "../../runtime/logger.js";
 export interface PostLoopHooksParams {
   goalId: string;
   sessionId: string;
+  runId?: string;
   completedAt: string;
   totalTokensUsed: number;
   finalStatus: LoopResult["finalStatus"];
@@ -38,6 +39,7 @@ export async function runPostLoopHooks(params: PostLoopHooksParams): Promise<voi
   const {
     goalId,
     sessionId,
+    runId,
     completedAt,
     totalTokensUsed,
     finalStatus,
@@ -169,4 +171,37 @@ export async function runPostLoopHooks(params: PostLoopHooksParams): Promise<voi
       });
     }
   }
+
+  if (!config.dryRun && deps.postmortemReportStore && shouldGeneratePostmortem(finalStatus)) {
+    try {
+      await deps.postmortemReportStore.generate({
+        goalId,
+        runId,
+        finalStatus,
+        trigger: postmortemTriggerFor(finalStatus),
+      });
+    } catch (err) {
+      logger?.warn("CoreLoop: postmortem report generation failed", {
+        goalId,
+        runId,
+        finalStatus,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+function shouldGeneratePostmortem(finalStatus: LoopResult["finalStatus"]): boolean {
+  return finalStatus === "completed"
+    || finalStatus === "finalization"
+    || finalStatus === "stopped"
+    || finalStatus === "stalled"
+    || finalStatus === "max_iterations"
+    || finalStatus === "error";
+}
+
+function postmortemTriggerFor(finalStatus: LoopResult["finalStatus"]): "completion" | "pause" | "finalization" {
+  if (finalStatus === "completed") return "completion";
+  if (finalStatus === "finalization") return "finalization";
+  return "pause";
 }

--- a/src/runtime/__tests__/postmortem-report.test.ts
+++ b/src/runtime/__tests__/postmortem-report.test.ts
@@ -1,0 +1,277 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTempDir } from "../../../tests/helpers/temp-dir.js";
+import { RuntimeEvidenceLedger } from "../store/evidence-ledger.js";
+import { RuntimeOperatorHandoffStore } from "../store/operator-handoff-store.js";
+import { RuntimePostmortemReportStore } from "../store/postmortem-report.js";
+import { RuntimeReproducibilityManifestStore } from "../store/reproducibility-manifest.js";
+
+describe("RuntimePostmortemReportStore", () => {
+  let runtimeRoot: string;
+
+  beforeEach(async () => {
+    runtimeRoot = makeTempDir("pulseed-runtime-postmortem-");
+    await fsp.mkdir(path.join(runtimeRoot, "runs/final"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fsp.rm(runtimeRoot, { recursive: true, force: true });
+  });
+
+  it("generates durable evidence-backed postmortem artifacts from synthetic run evidence", async () => {
+    await fsp.writeFile(path.join(runtimeRoot, "runs/final/submission.csv"), "id,target\n1,0\n", "utf8");
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "metric-baseline",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-postmortem", run_id: "run:coreloop:postmortem", loop_index: 0 },
+      metrics: [{ label: "balanced_accuracy", value: 0.71, direction: "maximize", observed_at: "2026-04-30T00:00:00.000Z" }],
+      summary: "Baseline metric recorded.",
+      outcome: "continued",
+    });
+    await ledger.append({
+      id: "candidate-final",
+      occurred_at: "2026-04-30T01:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-postmortem", run_id: "run:coreloop:postmortem", loop_index: 3 },
+      metrics: [{ label: "balanced_accuracy", value: 0.78, direction: "maximize", observed_at: "2026-04-30T01:00:00.000Z" }],
+      candidates: [{
+        candidate_id: "candidate-a",
+        label: "Candidate A",
+        lineage: {
+          strategy_family: "catboost_default",
+          feature_lineage: ["focus-base"],
+          model_lineage: ["catboost"],
+          config_lineage: ["configs/train.json"],
+          seed_lineage: ["seed-314"],
+          fold_lineage: ["5-fold"],
+          postprocess_lineage: [],
+        },
+        metrics: [{ label: "balanced_accuracy", value: 0.78, direction: "maximize", confidence: 0.9 }],
+        artifacts: [{
+          label: "submission",
+          state_relative_path: "runs/final/submission.csv",
+          kind: "other",
+          retention_class: "final_deliverable",
+        }],
+        similarity: [],
+        disposition: "promoted",
+        disposition_reason: "Best robust candidate.",
+      }, {
+        candidate_id: "candidate-near",
+        label: "Near miss",
+        lineage: {
+          strategy_family: "lightgbm_variant",
+          feature_lineage: ["focus-base"],
+          model_lineage: ["lightgbm"],
+          config_lineage: [],
+          seed_lineage: ["seed-7"],
+          fold_lineage: ["5-fold"],
+          postprocess_lineage: [],
+        },
+        metrics: [{ label: "balanced_accuracy", value: 0.775, direction: "maximize", confidence: 0.8 }],
+        artifacts: [],
+        similarity: [],
+        near_miss: {
+          status: "retained",
+          reason_to_keep: ["close_to_best"],
+          margin_to_best: 0.005,
+          weak_dimensions: ["stability"],
+          complementary_candidate_ids: ["candidate-a"],
+          evidence_refs: ["candidate-final"],
+          follow_up: {
+            title: "Re-test near miss with stability folds",
+            rationale: "Near miss stayed close to the best candidate but needs stability evidence.",
+            target_dimensions: ["stability"],
+          },
+        },
+        disposition: "retained",
+      }],
+      artifacts: [{
+        label: "submission",
+        state_relative_path: "runs/final/submission.csv",
+        kind: "other",
+        retention_class: "final_deliverable",
+      }],
+      summary: "Final candidate and near miss recorded.",
+      outcome: "improved",
+    });
+    await ledger.append({
+      id: "external-gap",
+      occurred_at: "2026-04-30T01:15:00.000Z",
+      kind: "evaluator",
+      scope: { goal_id: "goal-postmortem", run_id: "run:coreloop:postmortem" },
+      evaluators: [{
+        evaluator_id: "leaderboard",
+        signal: "external",
+        source: "public-leaderboard",
+        candidate_id: "candidate-a",
+        status: "approval_required",
+        score_label: "balanced_accuracy",
+        direction: "maximize",
+        publish_action: {
+          id: "submit-candidate-a",
+          label: "Submit candidate A",
+          approval_required: true,
+        },
+      }],
+      summary: "External evaluator still requires approval.",
+    });
+    await ledger.append({
+      id: "other-run-candidate",
+      occurred_at: "2026-04-30T01:30:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-postmortem", run_id: "run:coreloop:other" },
+      candidates: [{
+        candidate_id: "candidate-other-run",
+        label: "Other run candidate",
+        lineage: {
+          strategy_family: "other",
+          feature_lineage: [],
+          model_lineage: [],
+          config_lineage: [],
+          seed_lineage: [],
+          fold_lineage: [],
+          postprocess_lineage: [],
+        },
+        metrics: [{ label: "balanced_accuracy", value: 0.65, direction: "maximize" }],
+        artifacts: [{
+          label: "other-run-output",
+          state_relative_path: "runs/final/other.csv",
+          kind: "other",
+          retention_class: "final_deliverable",
+        }],
+        similarity: [],
+        disposition: "retired",
+      }],
+      artifacts: [{
+        label: "other-run-output",
+        state_relative_path: "runs/final/other.csv",
+        kind: "other",
+        retention_class: "final_deliverable",
+      }],
+      summary: "Other run candidate should not leak into this run postmortem.",
+    });
+
+    const manifest = await new RuntimeReproducibilityManifestStore(runtimeRoot).createOrUpdateForCandidate({
+      goalId: "goal-postmortem",
+      runId: "run:coreloop:postmortem",
+      candidateId: "candidate-a",
+      codeState: { commit: "abc123", dirty: false },
+    });
+    const otherRunManifest = await new RuntimeReproducibilityManifestStore(runtimeRoot).createOrUpdateForCandidate({
+      goalId: "goal-postmortem",
+      runId: "run:coreloop:other",
+      candidateId: "candidate-other-run",
+      codeState: { commit: "def456", dirty: false },
+    });
+    await new RuntimeOperatorHandoffStore(runtimeRoot).create({
+      handoff_id: "handoff-finalization",
+      goal_id: "goal-postmortem",
+      run_id: "run:coreloop:postmortem",
+      triggers: ["finalization", "external_action"],
+      title: "Review final submission",
+      summary: "Final output needs operator review.",
+      current_status: "manifest_ready",
+      recommended_action: "Approve or pause final submission.",
+      required_approvals: ["submit-candidate-a"],
+      next_action: {
+        label: "Approve final submission",
+        approval_required: true,
+      },
+      evidence_refs: [{ kind: "reproducibility_manifest", ref: manifest.manifest_id, observed_at: manifest.updated_at }],
+    });
+    await new RuntimeOperatorHandoffStore(runtimeRoot).create({
+      handoff_id: "handoff-goal-only-approval",
+      goal_id: "goal-postmortem",
+      triggers: ["external_action"],
+      title: "Goal-scoped external action approval",
+      summary: "External action was recorded before run linkage was available.",
+      current_status: "approval_required",
+      recommended_action: "Review the goal-scoped external action before final delivery.",
+      required_approvals: ["external-submit"],
+      next_action: {
+        label: "Review goal-scoped external action",
+        approval_required: true,
+      },
+      evidence_refs: [{ kind: "runtime_evidence", ref: "external-gap", observed_at: "2026-04-30T01:15:00.000Z" }],
+    });
+    await new RuntimeOperatorHandoffStore(runtimeRoot).create({
+      handoff_id: "handoff-other-run",
+      goal_id: "goal-postmortem",
+      run_id: "run:coreloop:other",
+      triggers: ["finalization"],
+      title: "Other run handoff",
+      summary: "This belongs to a different run.",
+      current_status: "other_run",
+      recommended_action: "Do not include in target run postmortem.",
+      required_approvals: [],
+      next_action: {
+        label: "Review other run",
+        approval_required: true,
+      },
+      evidence_refs: [{ kind: "reproducibility_manifest", ref: otherRunManifest.manifest_id }],
+    });
+
+    const store = new RuntimePostmortemReportStore(runtimeRoot);
+    const report = await store.generate({
+      goalId: "goal-postmortem",
+      runId: "run:coreloop:postmortem",
+      finalStatus: "finalization",
+      trigger: "finalization",
+    });
+
+    expect(report).toMatchObject({
+      schema_version: "runtime-postmortem-v1",
+      scope: { goal_id: "goal-postmortem", run_id: "run:coreloop:postmortem" },
+      final_status: "finalization",
+      trigger: "finalization",
+    });
+    expect(report.metric_timeline).toContainEqual(expect.objectContaining({
+      metric_key: "balanced_accuracy",
+      best_value: 0.78,
+      observation_count: 2,
+      source_refs: expect.arrayContaining([
+        expect.objectContaining({ ref: "metric-baseline", observed_at: "2026-04-30T00:00:00.000Z" }),
+        expect.objectContaining({ ref: "candidate-final", observed_at: "2026-04-30T01:00:00.000Z" }),
+      ]),
+    }));
+    expect(report.final_outputs).toContainEqual(expect.objectContaining({
+      label: "submission",
+      state_relative_path: "runs/final/submission.csv",
+      manifest_id: manifest.manifest_id,
+    }));
+    expect(report.manifests).toContainEqual(expect.objectContaining({ manifest_id: manifest.manifest_id }));
+    expect(report.manifests).not.toContainEqual(expect.objectContaining({ manifest_id: otherRunManifest.manifest_id }));
+    expect(report.handoffs).toContainEqual(expect.objectContaining({ handoff_id: "handoff-finalization" }));
+    expect(report.handoffs).toContainEqual(expect.objectContaining({ handoff_id: "handoff-goal-only-approval" }));
+    expect(report.handoffs).not.toContainEqual(expect.objectContaining({ handoff_id: "handoff-other-run" }));
+    expect(report.final_outputs).not.toContainEqual(expect.objectContaining({ label: "other-run-output" }));
+    expect(report.follow_up_actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ title: "Re-test near miss with stability folds", auto_create: false }),
+      expect.objectContaining({ title: "Approve final submission", approval_required: true, auto_create: false }),
+      expect.objectContaining({ title: "Review goal-scoped external action", approval_required: true, auto_create: false }),
+    ]));
+    expect(report.evidence_refs).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "runtime_evidence", ref: "candidate-final", observed_at: "2026-04-30T01:00:00.000Z" }),
+      expect.objectContaining({ kind: "reproducibility_manifest", ref: manifest.manifest_id }),
+    ]));
+
+    await expect(fsp.stat(report.artifact_paths.json_path)).resolves.toMatchObject({ isFile: expect.any(Function) });
+    const markdown = await fsp.readFile(report.artifact_paths.markdown_path, "utf8");
+    expect(markdown).toContain("Runtime Postmortem");
+    expect(markdown).toContain("Metric Timeline");
+    expect(markdown).toContain("candidate-final");
+
+    const runEvidence = await ledger.readByRun("run:coreloop:postmortem");
+    expect(runEvidence.entries).toContainEqual(expect.objectContaining({
+      id: `${report.postmortem_id}:artifact`,
+      kind: "artifact",
+      artifacts: expect.arrayContaining([
+        expect.objectContaining({ label: "postmortem.md", retention_class: "evidence_report" }),
+      ]),
+    }));
+  });
+});

--- a/src/runtime/daemon/__tests__/runner-commands-safe-pause.test.ts
+++ b/src/runtime/daemon/__tests__/runner-commands-safe-pause.test.ts
@@ -6,6 +6,7 @@ import { createEnvelope } from "../../types/envelope.js";
 import { JournalBackedQueue } from "../../queue/journal-backed-queue.js";
 import { GoalLeaseManager } from "../../goal-lease-manager.js";
 import { LoopSupervisor } from "../../executor/loop-supervisor.js";
+import { RuntimePostmortemReportStore } from "../../store/postmortem-report.js";
 import { RuntimeSafePauseStore } from "../../store/safe-pause-store.js";
 import { CommandDispatcher } from "../../command-dispatcher.js";
 import {
@@ -121,6 +122,18 @@ describe("daemon safe pause commands", () => {
     });
     expect(currentGoalIds).toEqual([]);
     expect(state.safe_pause_goals?.["goal-1"]?.state).toBe("paused");
+    expect(await new RuntimePostmortemReportStore(tmpDir).latestFor({ goalId: "goal-1" })).toMatchObject({
+      final_status: "paused",
+      trigger: "pause",
+    });
+    expect(await new RuntimePostmortemReportStore(tmpDir).latestFor({ runId: "run-1" })).toMatchObject({
+      scope: {
+        goal_id: "goal-1",
+        run_id: "run-1",
+      },
+      final_status: "paused",
+      trigger: "pause",
+    });
     expect(broadcastGoalUpdated).toHaveBeenLastCalledWith("goal-1", "paused");
   });
 

--- a/src/runtime/daemon/runner-commands.ts
+++ b/src/runtime/daemon/runner-commands.ts
@@ -1,6 +1,7 @@
 import { resolveScheduleEntry } from "../schedule/entry-resolver.js";
 import {
   RuntimeOperationStore,
+  RuntimePostmortemReportStore,
   RuntimeSafePauseStore,
   type RuntimeControlOperationKind,
   type RuntimeSafePauseCheckpoint,
@@ -274,7 +275,7 @@ function buildSafePauseResumeReason(checkpoint: RuntimeSafePauseCheckpoint | und
 export async function checkpointPauseIfRequested(
   context: Pick<
     DaemonRunnerCommandContext,
-    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state" | "runtimeRoot" | "journalQueue"
+    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state" | "runtimeRoot" | "journalQueue" | "logger"
   >,
   goalId: string,
 ): Promise<boolean> {
@@ -305,6 +306,29 @@ export async function checkpointPauseIfRequested(
   context.refreshOperationalState();
   context.supervisor?.deactivateGoal(goalId);
   await context.saveDaemonState();
+  if (context.runtimeRoot) {
+    try {
+      const postmortemStore = new RuntimePostmortemReportStore(context.runtimeRoot);
+      await postmortemStore.generate({
+        goalId,
+        finalStatus: "paused",
+        trigger: "pause",
+      });
+      for (const runId of checkpoint.background_run_ids) {
+        await postmortemStore.generate({
+          goalId,
+          runId,
+          finalStatus: "paused",
+          trigger: "pause",
+        });
+      }
+    } catch (err) {
+      context.logger?.warn("Failed to generate safe-pause postmortem", {
+        goalId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
   context.abortSleep();
   await context.broadcastGoalUpdated(goalId, "paused");
   return true;
@@ -313,7 +337,7 @@ export async function checkpointPauseIfRequested(
 export async function handleGoalPauseCommand(
   context: Pick<
     DaemonRunnerCommandContext,
-    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state" | "runtimeRoot" | "journalQueue"
+    "currentGoalIds" | "refreshOperationalState" | "saveDaemonState" | "supervisor" | "abortSleep" | "broadcastGoalUpdated" | "state" | "runtimeRoot" | "journalQueue" | "logger"
   >,
   goalId: string,
   reason = "safe pause requested",

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -154,6 +154,12 @@ export {
   RuntimeOperatorHandoffStore,
   RuntimeOperatorHandoffTriggerSchema,
 } from "./operator-handoff-store.js";
+export {
+  RuntimePostmortemEvidenceRefSchema,
+  RuntimePostmortemReportSchema,
+  RuntimePostmortemReportStore,
+  RuntimePostmortemScopeSchema,
+} from "./postmortem-report.js";
 export type {
   RuntimeBudgetCreateInput,
   RuntimeBudgetDimension,
@@ -175,6 +181,12 @@ export type {
   RuntimeOperatorHandoffStatus,
   RuntimeOperatorHandoffTrigger,
 } from "./operator-handoff-store.js";
+export type {
+  RuntimePostmortemEvidenceRef,
+  RuntimePostmortemGenerateInput,
+  RuntimePostmortemReport,
+  RuntimePostmortemScope,
+} from "./postmortem-report.js";
 export type {
   RuntimeExperimentQueueCreateInput,
   RuntimeExperimentQueueExecutionDirective,

--- a/src/runtime/store/postmortem-report.ts
+++ b/src/runtime/store/postmortem-report.ts
@@ -1,0 +1,650 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { z } from "zod";
+import {
+  createRuntimeStorePaths,
+  ensureRuntimeStorePaths,
+  encodeRuntimePathSegment,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+import {
+  RuntimeEvidenceLedger,
+  type RuntimeEvidenceEntry,
+  type RuntimeEvidenceSummary,
+} from "./evidence-ledger.js";
+import { extractMetricObservationsFromEvidence } from "./metric-history.js";
+import {
+  RuntimeReproducibilityManifestSchema,
+  type RuntimeReproducibilityManifest,
+} from "./reproducibility-manifest.js";
+import { RuntimeOperatorHandoffStore, type RuntimeOperatorHandoffRecord } from "./operator-handoff-store.js";
+import { RuntimeExperimentQueueStore, type RuntimeExperimentQueueRecord } from "./experiment-queue-store.js";
+import { RuntimeBudgetStore, type RuntimeBudgetRecord } from "./budget-store.js";
+
+export const RuntimePostmortemScopeSchema = z.object({
+  goal_id: z.string().min(1).optional(),
+  run_id: z.string().min(1).optional(),
+}).strict().refine((scope) => Boolean(scope.goal_id || scope.run_id), {
+  message: "goal_id or run_id is required",
+});
+export type RuntimePostmortemScope = z.infer<typeof RuntimePostmortemScopeSchema>;
+
+export const RuntimePostmortemEvidenceRefSchema = z.object({
+  kind: z.string().min(1),
+  ref: z.string().min(1),
+  observed_at: z.string().datetime().optional(),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimePostmortemEvidenceRef = z.infer<typeof RuntimePostmortemEvidenceRefSchema>;
+
+export const RuntimePostmortemReportSchema = z.object({
+  schema_version: z.literal("runtime-postmortem-v1"),
+  postmortem_id: z.string().min(1),
+  generated_at: z.string().datetime(),
+  scope: RuntimePostmortemScopeSchema,
+  final_status: z.string().min(1),
+  trigger: z.enum(["completion", "pause", "finalization", "operator_request"]),
+  artifact_paths: z.object({
+    json_path: z.string().min(1),
+    markdown_path: z.string().min(1),
+    state_relative_json_path: z.string().min(1),
+    state_relative_markdown_path: z.string().min(1),
+  }).strict(),
+  timeline: z.array(z.object({
+    occurred_at: z.string().datetime(),
+    kind: z.string().min(1),
+    summary: z.string().min(1),
+    evidence_refs: z.array(RuntimePostmortemEvidenceRefSchema).default([]),
+  }).strict()).default([]),
+  metric_timeline: z.array(z.object({
+    metric_key: z.string().min(1),
+    direction: z.enum(["maximize", "minimize"]),
+    trend: z.string().min(1),
+    latest_value: z.number(),
+    best_value: z.number(),
+    observation_count: z.number().int().nonnegative(),
+    source_refs: z.array(RuntimePostmortemEvidenceRefSchema).default([]),
+    summary: z.string().min(1),
+  }).strict()).default([]),
+  candidate_decisions: z.object({
+    lineages: z.array(z.unknown()).default([]),
+    selection_summary: z.unknown(),
+    recommended_portfolio: z.array(z.unknown()).default([]),
+    near_misses: z.array(z.unknown()).default([]),
+    failed_lineages: z.array(z.unknown()).default([]),
+  }).strict(),
+  final_outputs: z.array(z.object({
+    label: z.string().min(1),
+    path: z.string().min(1).optional(),
+    state_relative_path: z.string().min(1).optional(),
+    url: z.string().url().optional(),
+    kind: z.string().min(1).optional(),
+    retention_class: z.string().min(1).optional(),
+    evidence_entry_ids: z.array(z.string().min(1)).default([]),
+    manifest_id: z.string().min(1).optional(),
+    sha256: z.string().min(1).optional(),
+    observed_at: z.string().datetime().optional(),
+  }).strict()).default([]),
+  evaluator_gaps: z.array(z.unknown()).default([]),
+  handoffs: z.array(z.unknown()).default([]),
+  manifests: z.array(z.unknown()).default([]),
+  budgets: z.array(z.unknown()).default([]),
+  experiment_queues: z.array(z.unknown()).default([]),
+  follow_up_actions: z.array(z.object({
+    title: z.string().min(1),
+    rationale: z.string().min(1),
+    evidence_refs: z.array(RuntimePostmortemEvidenceRefSchema).default([]),
+    approval_required: z.boolean().default(false),
+    auto_create: z.literal(false).default(false),
+  }).strict()).default([]),
+  evidence_refs: z.array(RuntimePostmortemEvidenceRefSchema).default([]),
+  warnings: z.array(z.string().min(1)).default([]),
+}).strict();
+export type RuntimePostmortemReport = z.infer<typeof RuntimePostmortemReportSchema>;
+
+export interface RuntimePostmortemGenerateInput {
+  goalId?: string;
+  runId?: string;
+  finalStatus?: string;
+  trigger?: RuntimePostmortemReport["trigger"];
+}
+
+export class RuntimePostmortemReportStore {
+  private readonly paths: RuntimeStorePaths;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    this.paths = typeof runtimeRootOrPaths === "string"
+      ? createRuntimeStorePaths(runtimeRootOrPaths)
+      : runtimeRootOrPaths ?? createRuntimeStorePaths();
+  }
+
+  async generate(input: RuntimePostmortemGenerateInput): Promise<RuntimePostmortemReport> {
+    const scope = RuntimePostmortemScopeSchema.parse({
+      ...(input.goalId ? { goal_id: input.goalId } : {}),
+      ...(input.runId ? { run_id: input.runId } : {}),
+    });
+    await ensureRuntimeStorePaths(this.paths);
+    const postmortemId = postmortemIdFor(scope);
+    const generatedAt = new Date().toISOString();
+    const ledger = new RuntimeEvidenceLedger(this.paths);
+    const { entries, summary } = await this.readEvidence(scope, ledger);
+    const scopeContext = buildScopeContext(scope, entries);
+    const manifests = await this.readManifests(scopeContext);
+    const handoffs = await this.readHandoffs(scopeContext);
+    const budgets = await this.readBudgets(scopeContext);
+    const experimentQueues = await this.readExperimentQueues(scopeContext);
+    const reportPaths = this.reportPaths(postmortemId);
+
+    const report = RuntimePostmortemReportSchema.parse({
+      schema_version: "runtime-postmortem-v1",
+      postmortem_id: postmortemId,
+      generated_at: generatedAt,
+      scope,
+      final_status: input.finalStatus ?? inferFinalStatus(scope, summary, handoffs),
+      trigger: input.trigger ?? inferTrigger(input.finalStatus, handoffs),
+      artifact_paths: reportPaths,
+      timeline: buildTimeline(entries),
+      metric_timeline: buildMetricTimeline(entries, summary),
+      candidate_decisions: {
+        lineages: summary.candidate_lineages,
+        selection_summary: summary.candidate_selection_summary,
+        recommended_portfolio: summary.recommended_candidate_portfolio,
+        near_misses: summary.near_miss_candidates,
+        failed_lineages: summary.failed_lineages,
+      },
+      final_outputs: buildFinalOutputs(summary, manifests, entries),
+      evaluator_gaps: summary.evaluator_summary.gap ? [summary.evaluator_summary.gap] : [],
+      handoffs: handoffs.map(summarizeHandoff),
+      manifests: manifests.map(summarizeManifest),
+      budgets: budgets.map((budget) => ({
+        budget_id: budget.budget_id,
+        scope: budget.scope,
+        title: budget.title,
+        updated_at: budget.updated_at,
+        status: new RuntimeBudgetStore(this.paths).status(budget),
+      })),
+      experiment_queues: experimentQueues.map(summarizeExperimentQueue),
+      follow_up_actions: buildFollowUpActions(summary, handoffs),
+      evidence_refs: collectEvidenceRefs(entries, manifests, handoffs),
+      warnings: summary.warnings.map((warning) => `${warning.file}:${warning.line} ${warning.message}`),
+    });
+
+    await this.writeReport(report);
+    await this.appendEvidenceEntry(ledger, report);
+    return report;
+  }
+
+  async load(postmortemId: string): Promise<RuntimePostmortemReport | null> {
+    try {
+      const raw = await fsp.readFile(this.paths.postmortemJsonPath(postmortemId), "utf8");
+      return RuntimePostmortemReportSchema.parse(JSON.parse(raw));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  async latestFor(input: { goalId?: string; runId?: string }): Promise<RuntimePostmortemReport | null> {
+    const scope = RuntimePostmortemScopeSchema.parse({
+      ...(input.goalId ? { goal_id: input.goalId } : {}),
+      ...(input.runId ? { run_id: input.runId } : {}),
+    });
+    return this.load(postmortemIdFor(scope));
+  }
+
+  markdownFor(report: RuntimePostmortemReport): string {
+    return renderPostmortemMarkdown(report);
+  }
+
+  private async readEvidence(
+    scope: RuntimePostmortemScope,
+    ledger: RuntimeEvidenceLedger
+  ): Promise<{ entries: RuntimeEvidenceEntry[]; summary: RuntimeEvidenceSummary }> {
+    if (scope.run_id) {
+      const [read, summary] = await Promise.all([
+        ledger.readByRun(scope.run_id),
+        ledger.summarizeRun(scope.run_id),
+      ]);
+      return { entries: read.entries, summary };
+    }
+    const [read, summary] = await Promise.all([
+      ledger.readByGoal(scope.goal_id!),
+      ledger.summarizeGoal(scope.goal_id!),
+    ]);
+    return { entries: read.entries, summary };
+  }
+
+  private async readManifests(scope: RuntimePostmortemScopeContext): Promise<RuntimeReproducibilityManifest[]> {
+    let fileNames: string[];
+    try {
+      fileNames = await fsp.readdir(this.paths.reproducibilityManifestsDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+    const manifests: RuntimeReproducibilityManifest[] = [];
+    for (const fileName of fileNames) {
+      if (!fileName.endsWith(".json")) continue;
+      try {
+        const parsed = RuntimeReproducibilityManifestSchema.parse(JSON.parse(
+          await fsp.readFile(path.join(this.paths.reproducibilityManifestsDir, fileName), "utf8")
+        ));
+        if (scopeMatches(scope, parsed.scope)) manifests.push(parsed);
+      } catch {
+        continue;
+      }
+    }
+    return manifests.sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+  }
+
+  private async readHandoffs(scope: RuntimePostmortemScopeContext): Promise<RuntimeOperatorHandoffRecord[]> {
+    const store = new RuntimeOperatorHandoffStore(this.paths);
+    const handoffs = await store.list();
+    return handoffs.filter((handoff) => scopeMatches(scope, { goal_id: handoff.goal_id, run_id: handoff.run_id }));
+  }
+
+  private async readBudgets(scope: RuntimePostmortemScopeContext): Promise<RuntimeBudgetRecord[]> {
+    const store = new RuntimeBudgetStore(this.paths);
+    const budgets = await store.list();
+    return budgets.filter((budget) => scopeMatches(scope, budget.scope));
+  }
+
+  private async readExperimentQueues(scope: RuntimePostmortemScopeContext): Promise<RuntimeExperimentQueueRecord[]> {
+    const store = new RuntimeExperimentQueueStore(this.paths);
+    const queues = await store.list();
+    return queues.filter((queue) => scopeMatches(scope, { goal_id: queue.goal_id, run_id: queue.run_id }));
+  }
+
+  private reportPaths(postmortemId: string): RuntimePostmortemReport["artifact_paths"] {
+    const dirName = encodeRuntimePathSegment(postmortemId);
+    return {
+      json_path: this.paths.postmortemJsonPath(postmortemId),
+      markdown_path: this.paths.postmortemMarkdownPath(postmortemId),
+      state_relative_json_path: path.join("postmortems", dirName, "postmortem.json"),
+      state_relative_markdown_path: path.join("postmortems", dirName, "postmortem.md"),
+    };
+  }
+
+  private async writeReport(report: RuntimePostmortemReport): Promise<void> {
+    await fsp.mkdir(this.paths.postmortemDir(report.postmortem_id), { recursive: true });
+    await Promise.all([
+      fsp.writeFile(report.artifact_paths.json_path, `${JSON.stringify(report, null, 2)}\n`, "utf8"),
+      fsp.writeFile(report.artifact_paths.markdown_path, renderPostmortemMarkdown(report), "utf8"),
+    ]);
+  }
+
+  private async appendEvidenceEntry(ledger: RuntimeEvidenceLedger, report: RuntimePostmortemReport): Promise<void> {
+    const evidenceId = `${report.postmortem_id}:artifact`;
+    const read = report.scope.run_id
+      ? await ledger.readByRun(report.scope.run_id)
+      : await ledger.readByGoal(report.scope.goal_id!);
+    if (read.entries.some((entry) => entry.id === evidenceId)) return;
+    await ledger.append({
+      id: evidenceId,
+      occurred_at: report.generated_at,
+      kind: "artifact",
+      scope: {
+        ...(report.scope.goal_id ? { goal_id: report.scope.goal_id } : {}),
+        ...(report.scope.run_id ? { run_id: report.scope.run_id } : {}),
+      },
+      artifacts: [
+        {
+          label: "postmortem.md",
+          path: report.artifact_paths.markdown_path,
+          state_relative_path: report.artifact_paths.state_relative_markdown_path,
+          kind: "report",
+          retention_class: "evidence_report",
+        },
+        {
+          label: "postmortem.json",
+          path: report.artifact_paths.json_path,
+          state_relative_path: report.artifact_paths.state_relative_json_path,
+          kind: "metrics",
+          retention_class: "evidence_report",
+        },
+      ],
+      raw_refs: [{ kind: "runtime_postmortem", id: report.postmortem_id }],
+      summary: `Postmortem generated for ${report.scope.run_id ?? report.scope.goal_id}.`,
+      outcome: "continued",
+    });
+  }
+}
+
+function postmortemIdFor(scope: RuntimePostmortemScope): string {
+  return scope.run_id ? `postmortem:run:${scope.run_id}` : `postmortem:goal:${scope.goal_id}`;
+}
+
+interface RuntimePostmortemScopeContext extends RuntimePostmortemScope {
+  linked_goal_ids: string[];
+}
+
+function buildScopeContext(
+  scope: RuntimePostmortemScope,
+  entries: RuntimeEvidenceEntry[]
+): RuntimePostmortemScopeContext {
+  const linkedGoalIds = new Set<string>();
+  if (scope.goal_id) linkedGoalIds.add(scope.goal_id);
+  for (const entry of entries) {
+    if (entry.scope.goal_id) linkedGoalIds.add(entry.scope.goal_id);
+  }
+  return {
+    ...scope,
+    linked_goal_ids: [...linkedGoalIds],
+  };
+}
+
+function scopeMatches(
+  requested: RuntimePostmortemScopeContext,
+  candidate: { goal_id?: string; run_id?: string }
+): boolean {
+  if (requested.run_id) {
+    if (candidate.run_id) return candidate.run_id === requested.run_id;
+    return Boolean(candidate.goal_id && requested.linked_goal_ids.includes(candidate.goal_id));
+  }
+  if (candidate.goal_id && requested.linked_goal_ids.includes(candidate.goal_id)) return true;
+  return !requested.run_id && candidate.goal_id === requested.goal_id;
+}
+
+function buildTimeline(entries: RuntimeEvidenceEntry[]): RuntimePostmortemReport["timeline"] {
+  return entries
+    .slice()
+    .sort((a, b) => a.occurred_at.localeCompare(b.occurred_at))
+    .map((entry) => ({
+      occurred_at: entry.occurred_at,
+      kind: entry.kind,
+      summary: entry.summary ?? entry.result?.summary ?? entry.decision_reason ?? entry.id,
+      evidence_refs: refsForEntry(entry),
+    }));
+}
+
+function buildMetricTimeline(
+  entries: RuntimeEvidenceEntry[],
+  summary: RuntimeEvidenceSummary
+): RuntimePostmortemReport["metric_timeline"] {
+  const observations = extractMetricObservationsFromEvidence(entries);
+  return summary.metric_trends.map((trend) => ({
+    metric_key: trend.metric_key,
+    direction: trend.direction,
+    trend: trend.trend,
+    latest_value: trend.latest_value,
+    best_value: trend.best_value,
+    observation_count: trend.observation_count,
+    source_refs: observations
+      .filter((observation) => observation.metric_key === trend.metric_key && observation.direction === trend.direction)
+      .map((observation) => ({
+        kind: observation.source.kind,
+        ref: observation.source.entry_id,
+        observed_at: observation.observed_at,
+        ...(observation.source.summary ? { summary: observation.source.summary } : {}),
+      })),
+    summary: trend.summary,
+  }));
+}
+
+function buildFinalOutputs(
+  summary: RuntimeEvidenceSummary,
+  manifests: RuntimeReproducibilityManifest[],
+  entries: RuntimeEvidenceEntry[]
+): RuntimePostmortemReport["final_outputs"] {
+  const outputs = new Map<string, RuntimePostmortemReport["final_outputs"][number]>();
+  for (const action of summary.artifact_retention.cleanup_plan.actions) {
+    if (!action.protected && action.retention_class !== "final_deliverable") continue;
+    const key = action.path ?? action.state_relative_path ?? action.url ?? action.key;
+    outputs.set(key, {
+      label: action.label,
+      ...(action.path ? { path: action.path } : {}),
+      ...(action.state_relative_path ? { state_relative_path: action.state_relative_path } : {}),
+      ...(action.url ? { url: action.url } : {}),
+      kind: action.kind,
+      retention_class: action.retention_class,
+      evidence_entry_ids: action.evidence_entry_ids,
+    });
+  }
+  for (const manifest of manifests) {
+    for (const artifact of manifest.artifacts) {
+      const key = artifact.path ?? artifact.state_relative_path ?? artifact.label;
+      const existing = outputs.get(key);
+      outputs.set(key, {
+        label: artifact.label,
+        ...(artifact.path ? { path: artifact.path } : {}),
+        ...(artifact.state_relative_path ? { state_relative_path: artifact.state_relative_path } : {}),
+        kind: artifact.kind,
+        evidence_entry_ids: existing?.evidence_entry_ids ?? evidenceIdsForArtifact(entries, artifact),
+        manifest_id: manifest.manifest_id,
+        ...(artifact.sha256 ? { sha256: artifact.sha256 } : {}),
+        ...(existing?.observed_at ? { observed_at: existing.observed_at } : {}),
+      });
+    }
+  }
+  return [...outputs.values()];
+}
+
+function buildFollowUpActions(
+  summary: RuntimeEvidenceSummary,
+  handoffs: RuntimeOperatorHandoffRecord[]
+): RuntimePostmortemReport["follow_up_actions"] {
+  const actions: RuntimePostmortemReport["follow_up_actions"] = [];
+  for (const nearMiss of summary.near_miss_candidates) {
+    if (!nearMiss.follow_up) continue;
+    actions.push({
+      title: nearMiss.follow_up.title,
+      rationale: nearMiss.follow_up.rationale,
+      evidence_refs: nearMiss.evidence_refs.map((ref) => ({ kind: "evidence", ref })),
+      approval_required: false,
+      auto_create: false,
+    });
+  }
+  for (const failed of summary.failed_lineages.slice(0, 3)) {
+    actions.push({
+      title: `Revisit failed lineage: ${failed.fingerprint}`,
+      rationale: failed.failure_reason ?? failed.representative_summary,
+      evidence_refs: failed.evidence_entry_ids.map((ref) => ({ kind: "evidence", ref })),
+      approval_required: false,
+      auto_create: false,
+    });
+  }
+  for (const handoff of handoffs.filter((item) => item.status === "open").slice(0, 5)) {
+    actions.push({
+      title: handoff.next_action.label,
+      rationale: handoff.recommended_action,
+      evidence_refs: handoff.evidence_refs.map((ref) => ({
+        kind: ref.kind,
+        ref: ref.ref,
+        ...(ref.observed_at ? { observed_at: ref.observed_at } : {}),
+      })),
+      approval_required: handoff.next_action.approval_required,
+      auto_create: false,
+    });
+  }
+  if (summary.evaluator_summary.gap && summary.evaluator_summary.gap.kind !== "none") {
+    actions.push({
+      title: `Resolve evaluator gap: ${summary.evaluator_summary.gap.kind}`,
+      rationale: summary.evaluator_summary.gap.summary,
+      evidence_refs: [],
+      approval_required: summary.evaluator_summary.approval_required_actions.length > 0,
+      auto_create: false,
+    });
+  }
+  return actions;
+}
+
+function collectEvidenceRefs(
+  entries: RuntimeEvidenceEntry[],
+  manifests: RuntimeReproducibilityManifest[],
+  handoffs: RuntimeOperatorHandoffRecord[]
+): RuntimePostmortemEvidenceRef[] {
+  const refs = new Map<string, RuntimePostmortemEvidenceRef>();
+  for (const entry of entries) {
+    refs.set(`evidence:${entry.id}`, {
+      kind: "runtime_evidence",
+      ref: entry.id,
+      observed_at: entry.occurred_at,
+      ...(entry.summary ? { summary: entry.summary } : {}),
+    });
+    for (const artifact of entry.artifacts) {
+      const ref = artifact.state_relative_path ?? artifact.path ?? artifact.url;
+      if (ref) refs.set(`artifact:${ref}`, { kind: "artifact", ref, observed_at: entry.occurred_at, summary: artifact.label });
+    }
+  }
+  for (const manifest of manifests) {
+    refs.set(`manifest:${manifest.manifest_id}`, {
+      kind: "reproducibility_manifest",
+      ref: manifest.manifest_id,
+      observed_at: manifest.updated_at,
+      summary: manifest.finalization_preflight.status,
+    });
+  }
+  for (const handoff of handoffs) {
+    refs.set(`handoff:${handoff.handoff_id}`, {
+      kind: "operator_handoff",
+      ref: handoff.handoff_id,
+      observed_at: handoff.created_at,
+      summary: handoff.title,
+    });
+  }
+  return [...refs.values()].sort((a, b) => (a.observed_at ?? "").localeCompare(b.observed_at ?? ""));
+}
+
+function refsForEntry(entry: RuntimeEvidenceEntry): RuntimePostmortemEvidenceRef[] {
+  return [
+    {
+      kind: "runtime_evidence",
+      ref: entry.id,
+      observed_at: entry.occurred_at,
+      ...(entry.summary ? { summary: entry.summary } : {}),
+    },
+    ...entry.raw_refs.map((ref) => ({
+      kind: ref.kind,
+      ref: ref.state_relative_path ?? ref.path ?? ref.url ?? ref.id ?? entry.id,
+      observed_at: entry.occurred_at,
+    })),
+  ];
+}
+
+function evidenceIdsForArtifact(
+  entries: RuntimeEvidenceEntry[],
+  artifact: { label: string; path?: string; state_relative_path?: string }
+): string[] {
+  return entries
+    .filter((entry) => entry.artifacts.some((candidate) =>
+      candidate.label === artifact.label
+      || (artifact.path && candidate.path === artifact.path)
+      || (artifact.state_relative_path && candidate.state_relative_path === artifact.state_relative_path)
+    ))
+    .map((entry) => entry.id);
+}
+
+function summarizeManifest(manifest: RuntimeReproducibilityManifest): Record<string, unknown> {
+  return {
+    manifest_id: manifest.manifest_id,
+    updated_at: manifest.updated_at,
+    scope: manifest.scope,
+    selected_candidate: manifest.selected_candidate?.candidate_id ?? null,
+    selected_deliverable: manifest.selected_deliverable?.label ?? null,
+    finalization_preflight: manifest.finalization_preflight,
+    artifact_count: manifest.artifacts.length,
+    evaluator_record_count: manifest.evaluator_records.length,
+  };
+}
+
+function summarizeHandoff(handoff: RuntimeOperatorHandoffRecord): Record<string, unknown> {
+  return {
+    handoff_id: handoff.handoff_id,
+    status: handoff.status,
+    triggers: handoff.triggers,
+    title: handoff.title,
+    created_at: handoff.created_at,
+    resolved_at: handoff.resolved_at ?? null,
+    recommended_action: handoff.recommended_action,
+    required_approvals: handoff.required_approvals,
+    evidence_refs: handoff.evidence_refs,
+  };
+}
+
+function summarizeExperimentQueue(queue: RuntimeExperimentQueueRecord): Record<string, unknown> {
+  const revision = queue.revisions.find((candidate) => candidate.version === queue.current_version) ?? queue.revisions.at(-1)!;
+  return {
+    queue_id: queue.queue_id,
+    goal_id: queue.goal_id ?? null,
+    run_id: queue.run_id ?? null,
+    title: queue.title ?? null,
+    current_version: queue.current_version,
+    phase: revision.phase,
+    status: revision.status,
+    updated_at: queue.updated_at,
+    items: {
+      total: revision.items.length,
+      succeeded: revision.items.filter((item) => item.status === "succeeded").length,
+      failed: revision.items.filter((item) => item.status === "failed").length,
+      pending: revision.items.filter((item) => item.status === "pending").length,
+      running: revision.items.filter((item) => item.status === "running").length,
+    },
+  };
+}
+
+function inferFinalStatus(
+  scope: RuntimePostmortemScope,
+  summary: RuntimeEvidenceSummary,
+  handoffs: RuntimeOperatorHandoffRecord[]
+): string {
+  const recentStatus = summary.recent_entries.find((entry) => entry.result?.status)?.result?.status;
+  if (recentStatus) return recentStatus;
+  if (handoffs.some((handoff) => handoff.triggers.includes("finalization"))) return "finalization";
+  return scope.run_id ? "completed_or_paused" : "completed";
+}
+
+function inferTrigger(
+  finalStatus: string | undefined,
+  handoffs: RuntimeOperatorHandoffRecord[]
+): RuntimePostmortemReport["trigger"] {
+  if (finalStatus === "finalization" || handoffs.some((handoff) => handoff.triggers.includes("finalization"))) return "finalization";
+  if (finalStatus === "stopped" || finalStatus === "paused") return "pause";
+  return finalStatus === "completed" ? "completion" : "operator_request";
+}
+
+function renderPostmortemMarkdown(report: RuntimePostmortemReport): string {
+  const lines: string[] = [
+    `# Runtime Postmortem: ${report.scope.run_id ?? report.scope.goal_id}`,
+    "",
+    `- Generated: ${report.generated_at}`,
+    `- Final status: ${report.final_status}`,
+    `- Trigger: ${report.trigger}`,
+    "",
+    "## Metric Timeline",
+    ...sectionLines(report.metric_timeline, (metric) =>
+      `- ${metric.metric_key}: ${metric.trend}, latest=${metric.latest_value}, best=${metric.best_value}, observations=${metric.observation_count}`
+    ),
+    "",
+    "## Candidate Decisions",
+    `- Candidate lineages: ${report.candidate_decisions.lineages.length}`,
+    `- Recommended portfolio items: ${report.candidate_decisions.recommended_portfolio.length}`,
+    `- Near misses: ${report.candidate_decisions.near_misses.length}`,
+    `- Failed lineages: ${report.candidate_decisions.failed_lineages.length}`,
+    "",
+    "## Final Outputs",
+    ...sectionLines(report.final_outputs, (artifact) =>
+      `- ${artifact.label}: ${artifact.state_relative_path ?? artifact.path ?? artifact.url ?? "no path"}${artifact.manifest_id ? ` (manifest ${artifact.manifest_id})` : ""}`
+    ),
+    "",
+    "## Operator Handoffs",
+    ...sectionLines(report.handoffs as Array<{ handoff_id?: string; status?: string; title?: string }>, (handoff) =>
+      `- ${handoff.handoff_id ?? "-"}: ${handoff.status ?? "-"} ${handoff.title ?? ""}`.trim()
+    ),
+    "",
+    "## Follow-up Actions",
+    ...sectionLines(report.follow_up_actions, (action) =>
+      `- ${action.title}: ${action.rationale} (auto_create=${action.auto_create}, approval_required=${action.approval_required})`
+    ),
+    "",
+    "## Evidence",
+    ...sectionLines(report.evidence_refs.slice(0, 40), (ref) =>
+      `- ${ref.kind}: ${ref.ref}${ref.observed_at ? ` @ ${ref.observed_at}` : ""}${ref.summary ? ` - ${ref.summary}` : ""}`
+    ),
+    "",
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+function sectionLines<T>(items: T[], format: (item: T) => string): string[] {
+  return items.length > 0 ? items.map(format) : ["- (none)"];
+}

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -32,6 +32,7 @@ export interface RuntimeStorePaths {
   experimentQueuesDir: string;
   budgetsDir: string;
   operatorHandoffsDir: string;
+  postmortemsDir: string;
   backpressureSnapshotPath: string;
   daemonHealthPath: string;
   componentsHealthPath: string;
@@ -50,6 +51,9 @@ export interface RuntimeStorePaths {
   experimentQueuePath(queueId: string): string;
   budgetPath(budgetId: string): string;
   operatorHandoffPath(handoffId: string): string;
+  postmortemDir(postmortemId: string): string;
+  postmortemJsonPath(postmortemId: string): string;
+  postmortemMarkdownPath(postmortemId: string): string;
   goalLeasePath(goalId: string): string;
   completedByIdempotencyPath(idempotencyKey: string): string;
   completedByMessagePath(messageId: string): string;
@@ -110,6 +114,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
   const experimentQueuesDir = path.join(rootDir, "experiment-queues");
   const budgetsDir = path.join(rootDir, "budgets");
   const operatorHandoffsDir = path.join(rootDir, "operator-handoffs");
+  const postmortemsDir = path.join(rootDir, "postmortems");
 
   return {
     rootDir,
@@ -140,6 +145,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     experimentQueuesDir,
     budgetsDir,
     operatorHandoffsDir,
+    postmortemsDir,
     backpressureSnapshotPath: path.join(guardrailsDir, "backpressure.json"),
     daemonHealthPath: path.join(healthDir, "daemon.json"),
     componentsHealthPath: path.join(healthDir, "components.json"),
@@ -188,6 +194,15 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     operatorHandoffPath(handoffId: string) {
       return path.join(operatorHandoffsDir, recordFileName(encodeRuntimePathSegment(handoffId)));
     },
+    postmortemDir(postmortemId: string) {
+      return path.join(postmortemsDir, encodeRuntimePathSegment(postmortemId));
+    },
+    postmortemJsonPath(postmortemId: string) {
+      return path.join(postmortemsDir, encodeRuntimePathSegment(postmortemId), "postmortem.json");
+    },
+    postmortemMarkdownPath(postmortemId: string) {
+      return path.join(postmortemsDir, encodeRuntimePathSegment(postmortemId), "postmortem.md");
+    },
     goalLeasePath(goalId: string) {
       return path.join(goalLeasesDir, `${encodeRuntimePathSegment(goalId)}.json`);
     },
@@ -233,6 +248,7 @@ export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise
       paths.experimentQueuesDir,
       paths.budgetsDir,
       paths.operatorHandoffsDir,
+      paths.postmortemsDir,
     ].map((dir) => fsp.mkdir(dir, { recursive: true }))
   );
 }


### PR DESCRIPTION
Closes #824

## Summary
- add a durable RuntimePostmortemReportStore that writes postmortem JSON and Markdown artifacts and appends local evidence-report artifact refs
- include evidence timeline, metric trends, candidate decisions, final outputs, reproducibility manifests, operator handoffs, budgets, experiment queues, and follow-up recommendations with auto_create=false
- expose `pulseed runtime postmortem <goal-id|run-id> [--json]` and wire automatic generation into CoreLoop terminal paths plus daemon safe-pause checkpoints
- keep run-scoped reports isolated to exact run records while still allowing goal-only linked records

## Verification
- `npm run typecheck`
- `npx vitest run src/runtime/__tests__/postmortem-report.test.ts src/runtime/daemon/__tests__/runner-commands-safe-pause.test.ts src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts src/interface/cli/__tests__/runtime-command.test.ts`
- `npm run lint:boundaries` (0 errors, existing warnings)
- `npm run test:changed`
- `git diff --check`
- review agent: no high-confidence material blockers after fixes

## Known Risks
- Existing lint warning noise remains unchanged.
- Postmortem generation is best-effort on terminal hooks and logs warnings instead of failing the run when report creation fails.
