### PR TITLE
Add Kaggle validation discipline

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/kaggle-training-benchmark.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/kaggle-training-benchmark.test.ts
@@ -47,6 +47,22 @@ function metricsJson(experimentId: string, score: number): Record<string, unknow
   };
 }
 
+function validationContract() {
+  return {
+    competition_metric: { name: "accuracy", direction: "maximize" as const, source: "competition_rules" as const },
+    cv: { strategy: "stratified_kfold", fold_count: 5, stratified: true },
+    oof: { present: true, path: "oof.csv", coverage: 1, leak_checked: true },
+    leak_checks: {
+      target_encoding_oof_only: true,
+      stacking_oof_only: true,
+      train_test_boundary_checked: true,
+      duplicate_or_id_leak_checked: true,
+      notes: [],
+    },
+    train_test_drift: { checked: true, adversarial_validation_auc: 0.55 },
+  };
+}
+
 async function waitFor(expectation: () => Promise<boolean>): Promise<void> {
   const deadline = Date.now() + 3_000;
   while (Date.now() < deadline) {
@@ -160,8 +176,9 @@ const fs = require("node:fs");
 console.log("benchmark training started");
 fs.writeFileSync("experiments/exp-benchmark-a/metrics.json", JSON.stringify(${JSON.stringify(metricsJson("exp-benchmark-a", 0.82))}));
 console.log("benchmark training completed");
-`],
+        `],
         artifact_refs: [],
+        validation_contract: validationContract(),
       }, context);
       expect(started.success).toBe(true);
 

--- a/src/tools/kaggle/KaggleExperimentTools.ts
+++ b/src/tools/kaggle/KaggleExperimentTools.ts
@@ -10,11 +10,15 @@ import type {
   ToolResult,
 } from "../types.js";
 import {
+  KAGGLE_VALIDATION_CHECKLIST,
   KaggleMetricDirectionSchema,
+  KaggleLongRunValidationContractSchema,
   type KaggleMetricParseResult,
   type KaggleMetrics,
+  type KaggleLongRunValidationContract,
   normalizedMetricScore,
   parseKaggleMetricsCompatible,
+  summarizeKaggleValidation,
 } from "./metrics.js";
 import {
   ensureDirectoryWithinStateRoot,
@@ -44,6 +48,7 @@ export const KaggleExperimentStartInputSchema = z.object({
   task_id: z.string().optional(),
   expected_metrics_path: z.string().min(1).optional(),
   artifact_refs: z.array(z.string().min(1)).default([]),
+  validation_contract: KaggleLongRunValidationContractSchema,
 }).strict();
 export type KaggleExperimentStartInput = z.infer<typeof KaggleExperimentStartInputSchema>;
 
@@ -118,6 +123,8 @@ interface ExperimentMetadata {
     args: string[];
     env_keys: string[];
   };
+  validation_contract: KaggleLongRunValidationContract;
+  validation_checklist: typeof KAGGLE_VALIDATION_CHECKLIST;
   process: {
     session_id: string;
     metadata_path?: string;
@@ -158,6 +165,10 @@ type CompareRow = {
   direction: "maximize" | "minimize";
   score: number;
   normalized_score: number;
+  robust_score: number;
+  raw_rank?: number;
+  robust_rank?: number;
+  validation: ReturnType<typeof summarizeKaggleValidation>;
   metrics: KaggleMetrics;
   metrics_source_schema: "strict" | "loose";
   metrics_warnings: string[];
@@ -206,6 +217,7 @@ export class KaggleExperimentStartTool extends KaggleToolBase<KaggleExperimentSt
     try {
       const commandArgs = input.args ?? [];
       const artifactRefs = input.artifact_refs ?? [];
+      const validationContract = KaggleLongRunValidationContractSchema.parse(input.validation_contract);
       const experimentId = input.experiment_id
         ? validateKaggleExperimentId(input.experiment_id)
         : generateExperimentId();
@@ -230,6 +242,8 @@ export class KaggleExperimentStartTool extends KaggleToolBase<KaggleExperimentSt
         metrics_path: metricsPath,
         report_path: resolved.reportPath,
         next_action_path: resolved.nextActionPath,
+        validation_contract: validationContract,
+        validation_checklist: KAGGLE_VALIDATION_CHECKLIST,
       };
       await fs.writeFile(resolved.commandPath, `${JSON.stringify(commandMetadata, null, 2)}\n`, "utf-8");
 
@@ -263,7 +277,7 @@ export class KaggleExperimentStartTool extends KaggleToolBase<KaggleExperimentSt
         ],
       }, resolved.workspaceRoot, context);
 
-      const metadata = experimentMetadata({ ...input, args: commandArgs, artifact_refs: artifactRefs }, resolved, experimentId, metricsPath, extraRefs, session);
+      const metadata = experimentMetadata({ ...input, args: commandArgs, artifact_refs: artifactRefs, validation_contract: validationContract }, resolved, experimentId, metricsPath, extraRefs, session);
       await fs.writeFile(resolved.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, "utf-8");
       await fs.writeFile(resolved.processPath, `${JSON.stringify(session, null, 2)}\n`, "utf-8");
 
@@ -271,6 +285,8 @@ export class KaggleExperimentStartTool extends KaggleToolBase<KaggleExperimentSt
         experiment_id: experimentId,
         competition: input.competition,
         process: session,
+        validation_contract: validationContract,
+        validation_checklist: KAGGLE_VALIDATION_CHECKLIST,
         metadata: artifactRef(resolved.workspaceRoot, resolved.metadataPath),
         artifacts: {
           log: artifactRef(resolved.workspaceRoot, resolved.logPath),
@@ -671,6 +687,7 @@ export class KaggleMetricReportTool extends KaggleToolBase<KaggleMetricReportInp
         metrics: metrics.metrics,
         metrics_source_schema: metrics.source_schema,
         warnings,
+        validation_checklist: KAGGLE_VALIDATION_CHECKLIST,
         artifact: artifactRef(workspaceRoot, metricsPath),
         wait_metadata: {
           metrics: {
@@ -749,6 +766,7 @@ export class KaggleCompareExperimentsTool extends KaggleToolBase<KaggleCompareEx
         }
         const direction = input.metric_direction ?? metrics.metrics.direction;
         const normalizedScore = direction === "maximize" ? metrics.metrics.cv_score : -metrics.metrics.cv_score;
+        const validation = summarizeKaggleValidation(metrics.metrics);
         rows.push({
           experiment_id: experimentId,
           status: "ok",
@@ -756,6 +774,8 @@ export class KaggleCompareExperimentsTool extends KaggleToolBase<KaggleCompareEx
           direction,
           score: metrics.metrics.cv_score,
           normalized_score: normalizedScore,
+          robust_score: normalizedScore - validation.robust_penalty,
+          validation,
           metrics: metrics.metrics,
           metrics_source_schema: metrics.source_schema,
           metrics_warnings: metrics.warnings,
@@ -799,24 +819,46 @@ export class KaggleCompareExperimentsTool extends KaggleToolBase<KaggleCompareEx
         };
       }
 
-      const best = validRows[0]!;
-      const runnerUp = validRows[1];
-      const delta = runnerUp ? best.normalized_score - runnerUp.normalized_score : null;
+      const rawRows = [...validRows].sort((a, b) => b.normalized_score - a.normalized_score);
+      const robustRows = [...validRows].sort((a, b) =>
+        b.robust_score - a.robust_score || b.normalized_score - a.normalized_score
+      );
+      const best = robustRows[0]!;
+      const rawBest = rawRows[0]!;
+      const runnerUp = robustRows[1];
+      const delta = runnerUp ? best.robust_score - runnerUp.robust_score : null;
       const rankTable = rows.map((row) => row.status === "ok"
-        ? { ...row, rank: validRows.findIndex((valid) => valid.experiment_id === row.experiment_id) + 1 }
+        ? {
+          ...row,
+          rank: rawRows.findIndex((valid) => valid.experiment_id === row.experiment_id) + 1,
+          raw_rank: rawRows.findIndex((valid) => valid.experiment_id === row.experiment_id) + 1,
+          robust_rank: robustRows.findIndex((valid) => valid.experiment_id === row.experiment_id) + 1,
+        }
         : { ...row, rank: null });
       return {
         success: true,
         data: {
           status: rows.length === validRows.length ? "ok" : "inconclusive",
           best_experiment_id: best.experiment_id,
+          raw_best_experiment_id: rawBest.experiment_id,
+          recommendation_mode: "validation_adjusted",
+          raw_cv_delta: rawRows[1] ? rawBest.normalized_score - rawRows[1]!.normalized_score : null,
           direction: best.direction,
           metric_name: best.metric_name,
           delta,
           rows: rankTable,
+          final_report_sections: [
+            "local_cv_oof",
+            "public_leaderboard_gap",
+            "private_leaderboard_uncertainty",
+            "portfolio_slot_rationale",
+          ],
+          validation_checklist: KAGGLE_VALIDATION_CHECKLIST,
           recommendation: delta === null
             ? `Use ${best.experiment_id}; it is the only valid experiment.`
-            : `Use ${best.experiment_id}; it leads by ${delta}.`,
+            : best.experiment_id === rawBest.experiment_id
+              ? `Use ${best.experiment_id}; it leads after CV stability, OOF safety, leakage, drift, and public-gap checks.`
+              : `Use ${best.experiment_id}; raw CV top-1 ${rawBest.experiment_id} is not the safe recommendation after validation risk adjustment.`,
         },
         summary: `Best Kaggle experiment is ${best.experiment_id} (${best.metric_name}=${best.score}, ${best.direction})`,
         durationMs: Date.now() - startTime,
@@ -911,6 +953,8 @@ function experimentMetadata(
       args: input.args,
       env_keys: Object.keys(input.env ?? {}).sort(),
     },
+    validation_contract: input.validation_contract,
+    validation_checklist: KAGGLE_VALIDATION_CHECKLIST,
     process: {
       session_id: session.session_id,
       metadata_path: session.metadataPath,

--- a/src/tools/kaggle/KaggleSubmissionTools.ts
+++ b/src/tools/kaggle/KaggleSubmissionTools.ts
@@ -22,6 +22,7 @@ import { KaggleMetricsSchema, parseKaggleMetricsCompatible, type KaggleMetrics }
 const DEFAULT_MAX_OUTPUT_CHARS = 20_000;
 const SUBMISSION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const OUTPUT_FILENAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const KagglePortfolioSlotSchema = z.enum(["safe", "aggressive", "diverse"]);
 
 export interface KaggleCommandResult {
   exitCode: number;
@@ -80,6 +81,7 @@ export const KaggleSubmissionPrepareInputSchema = z.object({
   metrics_path: z.string().min(1).optional(),
   submission_id: z.string().regex(SUBMISSION_ID_PATTERN).optional(),
   output_filename: z.string().regex(OUTPUT_FILENAME_PATTERN).optional(),
+  portfolio_slot: KagglePortfolioSlotSchema.optional(),
   message: z.string().min(1).optional(),
   notes: z.string().min(1).optional(),
 }).strict();
@@ -132,6 +134,7 @@ const PreparedSubmissionMetadataSchema = z.object({
   submission_id: z.string().regex(SUBMISSION_ID_PATTERN),
   message: z.string().nullable(),
   notes: z.string().nullable(),
+  portfolio_slot: KagglePortfolioSlotSchema.default("safe"),
   source: ArtifactRefSchema,
   prepared: ArtifactRefSchema,
   provenance: z.object({
@@ -215,6 +218,7 @@ export class KaggleSubmissionPrepareTool implements ITool<KaggleSubmissionPrepar
       await fs.copyFile(sourcePath, preparedPath);
 
       const now = new Date().toISOString();
+      const portfolioSlot = input.portfolio_slot ?? "safe";
       const metadata = {
         schema_version: "kaggle-submission-v1",
         created_at: now,
@@ -222,6 +226,7 @@ export class KaggleSubmissionPrepareTool implements ITool<KaggleSubmissionPrepar
         submission_id: submissionId,
         message: input.message ?? null,
         notes: input.notes ?? null,
+        portfolio_slot: portfolioSlot,
         source: artifactRef(workspaceRoot, sourcePath),
         prepared: artifactRef(workspaceRoot, preparedPath),
         provenance: {
@@ -248,6 +253,8 @@ export class KaggleSubmissionPrepareTool implements ITool<KaggleSubmissionPrepar
             file: workspaceRelativePath(workspaceRoot, preparedPath),
             message: input.message ?? "",
           },
+          portfolio_slot: portfolioSlot,
+          portfolio_policy: portfolioPolicyForSlot(portfolioSlot),
         },
         summary: `Prepared Kaggle submission ${submissionId} for ${input.competition}`,
         durationMs: Date.now() - startTime,
@@ -268,6 +275,12 @@ export class KaggleSubmissionPrepareTool implements ITool<KaggleSubmissionPrepar
   isConcurrencySafe(_input: KaggleSubmissionPrepareInput): boolean {
     return false;
   }
+}
+
+function portfolioPolicyForSlot(slot: z.infer<typeof KagglePortfolioSlotSchema>): string {
+  if (slot === "safe") return "Prefer validation-adjusted candidates with OOF-safe CV, stable folds/seeds, low leakage risk, and acceptable public-gap evidence.";
+  if (slot === "aggressive") return "Allow a higher local CV/public LB candidate when risk is explicit and it diversifies the submission set.";
+  return "Prefer a candidate from a distinct model/feature/seed lineage to reduce correlated private leaderboard failure.";
 }
 
 export class KaggleSubmitTool extends KaggleSubmissionToolBase<KaggleSubmitInput> {

--- a/src/tools/kaggle/__tests__/KaggleExperimentTools.test.ts
+++ b/src/tools/kaggle/__tests__/KaggleExperimentTools.test.ts
@@ -8,6 +8,7 @@ import {
   KaggleCompareExperimentsTool,
   KaggleExperimentListTool,
   KaggleExperimentReadTool,
+  KaggleExperimentStartInputSchema,
   KaggleExperimentStartTool,
   KaggleExperimentStopTool,
   KaggleMetricReportTool,
@@ -28,6 +29,7 @@ function metricsJson(
   experimentId: string,
   direction: KaggleMetricDirection,
   score: number,
+  overrides: Record<string, unknown> = {},
 ): Record<string, unknown> {
   return {
     experiment_id: experimentId,
@@ -45,13 +47,36 @@ function metricsJson(
     artifacts: {
       log: `experiments/${experimentId}/train.log`,
     },
+    ...overrides,
   };
 }
 
-async function writeMetrics(root: string, experimentId: string, direction: KaggleMetricDirection, score: number): Promise<void> {
+function validationContract(metricName = "accuracy", direction: KaggleMetricDirection = "maximize") {
+  return {
+    competition_metric: { name: metricName, direction, source: "competition_rules" as const },
+    cv: { strategy: "stratified_kfold", fold_count: 5, stratified: true },
+    oof: { present: true, path: "oof.csv", coverage: 1, leak_checked: true },
+    leak_checks: {
+      target_encoding_oof_only: true,
+      stacking_oof_only: true,
+      train_test_boundary_checked: true,
+      duplicate_or_id_leak_checked: true,
+      notes: [],
+    },
+    train_test_drift: { checked: true, adversarial_validation_auc: 0.55 },
+  };
+}
+
+async function writeMetrics(
+  root: string,
+  experimentId: string,
+  direction: KaggleMetricDirection,
+  score: number,
+  overrides: Record<string, unknown> = {},
+): Promise<void> {
   const dir = path.join(root, "kaggle-runs", "titanic", "experiments", experimentId);
   await fs.mkdir(dir, { recursive: true });
-  await fs.writeFile(path.join(dir, "metrics.json"), `${JSON.stringify(metricsJson(experimentId, direction, score), null, 2)}\n`);
+  await fs.writeFile(path.join(dir, "metrics.json"), `${JSON.stringify(metricsJson(experimentId, direction, score, overrides), null, 2)}\n`);
   await fs.writeFile(path.join(dir, "train.log"), "durable log\n");
 }
 
@@ -85,6 +110,53 @@ describe("Kaggle experiment tools", () => {
     await fs.rm(pulseedHome, { recursive: true, force: true });
   });
 
+  it("rejects starting long-running experiments without the validation contract foundation", () => {
+    const baseInput = {
+      workspace: "titanic",
+      competition: "titanic",
+      experiment_id: "missing-validation",
+      command: process.execPath,
+      args: [],
+      artifact_refs: [],
+    };
+    const parsed = KaggleExperimentStartInputSchema.safeParse({
+      ...baseInput,
+      validation_contract: {},
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((issue) => issue.path.join("."))).toEqual(expect.arrayContaining([
+      "validation_contract.competition_metric",
+      "validation_contract.cv",
+      "validation_contract.oof",
+      "validation_contract.leak_checks",
+      "validation_contract.train_test_drift",
+    ]));
+
+    const unsafe = KaggleExperimentStartInputSchema.safeParse({
+      ...baseInput,
+      experiment_id: "unsafe-validation",
+      validation_contract: {
+        competition_metric: { name: "accuracy", direction: "maximize", source: "competition_rules" },
+        cv: { strategy: "holdout_only" },
+        oof: { present: false, leak_checked: false },
+        leak_checks: {},
+        train_test_drift: { checked: false },
+      },
+    });
+    expect(unsafe.success).toBe(false);
+    expect(unsafe.error?.issues.map((issue) => issue.path.join("."))).toEqual(expect.arrayContaining([
+      "validation_contract.cv.fold_count",
+      "validation_contract.oof.present",
+      "validation_contract.oof.leak_checked",
+      "validation_contract.leak_checks.target_encoding_oof_only",
+      "validation_contract.leak_checks.stacking_oof_only",
+      "validation_contract.leak_checks.train_test_boundary_checked",
+      "validation_contract.leak_checks.duplicate_or_id_leak_checked",
+      "validation_contract.train_test_drift.checked",
+    ]));
+  });
+
   it("starts a process session, writes experiment metadata, and reads durable log and metrics", async () => {
     const startTool = new KaggleExperimentStartTool(manager);
     const readTool = new KaggleExperimentReadTool(manager);
@@ -102,11 +174,19 @@ console.log("training done");
       artifact_refs: [],
       strategy_id: "strategy-1",
       task_id: "task-1",
+      validation_contract: validationContract(),
     }, makeContext(pulseedHome));
 
     expect(result.success).toBe(true);
-    const data = result.data as { process: { session_id: string }; artifacts: { log: { state_relative_path: string } } };
+    const data = result.data as {
+      process: { session_id: string };
+      artifacts: { log: { state_relative_path: string } };
+      validation_checklist: string[];
+      validation_contract: { oof: { leak_checked: boolean } };
+    };
     expect(data.artifacts.log.state_relative_path).toBe("kaggle-runs/titanic/experiments/exp-start/train.log");
+    expect(data.validation_checklist).toEqual(expect.arrayContaining(["cv_split_strategy_declared", "oof_predictions_present_and_leak_checked"]));
+    expect(data.validation_contract.oof.leak_checked).toBe(true);
 
     await waitFor(async () => {
       const raw = await fs.readFile(path.join(pulseedHome, "kaggle-runs", "titanic", "experiments", "exp-start", "train.log"), "utf-8");
@@ -157,6 +237,8 @@ console.log("training done");
     });
     await expect(fs.readFile(path.join(pulseedHome, "kaggle-runs", "titanic", "experiments", "exp-start", "config.json"), "utf-8"))
       .resolves.toContain(data.process.session_id);
+    await expect(fs.readFile(path.join(pulseedHome, "kaggle-runs", "titanic", "experiments", "exp-start", "command.json"), "utf-8"))
+      .resolves.toContain("validation_checklist");
   });
 
   it("recovers experiment reads from files and process metadata without a live process buffer", async () => {
@@ -170,8 +252,9 @@ console.log("training done");
 const fs = require("node:fs");
 console.log("persisted output");
 fs.writeFileSync("experiments/exp-restart/metrics.json", JSON.stringify(${JSON.stringify(metricsJson("exp-restart", "minimize", 0.12))}));
-`],
+      `],
       artifact_refs: [],
+      validation_contract: validationContract("rmse", "minimize"),
     }, makeContext(pulseedHome));
     expect(result.success).toBe(true);
 
@@ -209,6 +292,7 @@ fs.writeFileSync("experiments/exp-restart/metrics.json", JSON.stringify(${JSON.s
       command: process.execPath,
       args: ["-e", "setInterval(() => {}, 1000)"],
       artifact_refs: [],
+      validation_contract: validationContract(),
     }, makeContext(pulseedHome));
     expect(result.success).toBe(true);
 
@@ -252,8 +336,9 @@ fs.writeFileSync("experiments/exp-restart/metrics.json", JSON.stringify(${JSON.s
       args: ["-e", `
 const fs = require("node:fs");
 setInterval(() => fs.writeFileSync("experiments/exp-stop/heartbeat.txt", String(Date.now())), 50);
-`],
+      `],
       artifact_refs: [],
+      validation_contract: validationContract(),
     }, makeContext(pulseedHome));
     expect(result.success).toBe(true);
     const heartbeatPath = path.join(pulseedHome, "kaggle-runs", "titanic", "experiments", "exp-stop", "heartbeat.txt");
@@ -408,6 +493,79 @@ setInterval(() => fs.writeFileSync("experiments/exp-stop/heartbeat.txt", String(
       best_experiment_id: null,
       recommendation: "Experiments must share metric_name and direction before comparison.",
     });
+  });
+
+  it("does not recommend raw CV top-1 as the safe candidate when validation risk is high", async () => {
+    await writeMetrics(pulseedHome, "raw-oof-top", "maximize", 0.835, {
+      cv_std: 0.04,
+      validation: {
+        competition_metric: { name: "accuracy", direction: "maximize", source: "competition_rules" },
+        cv: { strategy: "stratified_kfold", fold_count: 5, stratified: true },
+        oof: { present: true, path: "experiments/raw-oof-top/oof.csv", coverage: 1, leak_checked: false },
+        leak_checks: {
+          target_encoding_oof_only: false,
+          stacking_oof_only: false,
+          train_test_boundary_checked: false,
+        },
+        train_test_drift: { checked: true, adversarial_validation_auc: 0.74 },
+        public_leaderboard: { score: 0.76, submission_id: "raw-oof-top-public", observed_at: "2026-04-25T00:00:00.000Z" },
+      },
+    });
+    await writeMetrics(pulseedHome, "stable-safe", "maximize", 0.821, {
+      cv_std: 0.006,
+      validation: {
+        competition_metric: { name: "accuracy", direction: "maximize", source: "competition_rules" },
+        cv: { strategy: "repeated_stratified_kfold", fold_count: 5, repeated_seed_count: 3, stratified: true },
+        oof: { present: true, path: "experiments/stable-safe/oof.csv", coverage: 1, leak_checked: true },
+        leak_checks: {
+          target_encoding_oof_only: true,
+          stacking_oof_only: true,
+          train_test_boundary_checked: true,
+          duplicate_or_id_leak_checked: true,
+        },
+        stability: { repeated_seed_count: 3, seed_score_std: 0.005 },
+        train_test_drift: { checked: true, adversarial_validation_auc: 0.53 },
+        public_leaderboard: { score: 0.819, submission_id: "stable-safe-public", observed_at: "2026-04-25T00:10:00.000Z" },
+      },
+    });
+
+    const tool = new KaggleCompareExperimentsTool(manager);
+    const result = await tool.call({
+      workspace: "titanic",
+      competition: "titanic",
+      experiment_ids: ["raw-oof-top", "stable-safe"],
+    }, makeContext(pulseedHome));
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      best_experiment_id: "stable-safe",
+      raw_best_experiment_id: "raw-oof-top",
+      recommendation_mode: "validation_adjusted",
+      recommendation: expect.stringContaining("raw CV top-1 raw-oof-top is not the safe recommendation"),
+      final_report_sections: expect.arrayContaining(["local_cv_oof", "public_leaderboard_gap", "private_leaderboard_uncertainty"]),
+      validation_checklist: expect.arrayContaining([
+        "oof_predictions_present_and_leak_checked",
+        "target_encoding_and_stacking_are_oof_only",
+        "final_report_separates_local_cv_public_lb_private_uncertainty",
+      ]),
+    });
+    expect((result.data as { rows: Array<{ experiment_id: string; raw_rank?: number; robust_rank?: number; validation?: { risk_level: string; leak_risks: string[] } }> }).rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        experiment_id: "raw-oof-top",
+        raw_rank: 1,
+        robust_rank: 2,
+        validation: expect.objectContaining({
+          risk_level: "high",
+          leak_risks: expect.arrayContaining(["target_encoding_not_oof_safe", "stacking_not_oof_safe"]),
+        }),
+      }),
+      expect.objectContaining({
+        experiment_id: "stable-safe",
+        raw_rank: 2,
+        robust_rank: 1,
+        validation: expect.objectContaining({ risk_level: "low" }),
+      }),
+    ]));
   });
 
 });

--- a/src/tools/kaggle/__tests__/KaggleSubmissionTools.test.ts
+++ b/src/tools/kaggle/__tests__/KaggleSubmissionTools.test.ts
@@ -109,8 +109,12 @@ describe("Kaggle submission tools", () => {
       file: { state_relative_path: string; workspace_relative_path: string };
       metadata: { path: string; state_relative_path: string };
       submit_hint: { file: string; message: string };
+      portfolio_slot: string;
+      portfolio_policy: string;
     };
     expect(data.submission_id).toBe("exp-a-public");
+    expect(data.portfolio_slot).toBe("safe");
+    expect(data.portfolio_policy).toContain("validation-adjusted candidates");
     expect(data.file).toMatchObject({
       workspace_relative_path: "submissions/exp-a-public.csv",
       state_relative_path: "kaggle-runs/titanic/submissions/exp-a-public.csv",
@@ -128,6 +132,7 @@ describe("Kaggle submission tools", () => {
       competition: "titanic",
       submission_id: "exp-a-public",
       message: "exp-a public submit",
+      portfolio_slot: "safe",
       provenance: {
         selected_experiment_id: "exp-a",
         local_metrics: {
@@ -137,6 +142,41 @@ describe("Kaggle submission tools", () => {
           artifact: { workspace_relative_path: "experiments/exp-a/metrics.json" },
         },
       },
+    });
+  });
+
+  it("records aggressive and diverse submission portfolio slot intent in local metadata", async () => {
+    const tool = new KaggleSubmissionPrepareTool();
+    const aggressive = await tool.call({
+      workspace: "titanic",
+      competition: "titanic",
+      source_file: "experiments/exp-a/submission.csv",
+      selected_experiment_id: "exp-a",
+      submission_id: "exp-a-aggressive",
+      output_filename: "exp-a-aggressive.csv",
+      portfolio_slot: "aggressive",
+    }, makeContext(pulseedHome));
+    expect(aggressive.success).toBe(true);
+    expect(aggressive.data).toMatchObject({
+      portfolio_slot: "aggressive",
+      portfolio_policy: expect.stringContaining("higher local CV/public LB candidate"),
+    });
+    await expect(fs.readFile(path.join(workspaceRoot, "submissions", "exp-a-aggressive.json"), "utf-8"))
+      .resolves.toContain("\"portfolio_slot\": \"aggressive\"");
+
+    const diverse = await tool.call({
+      workspace: "titanic",
+      competition: "titanic",
+      source_file: "experiments/exp-a/submission.csv",
+      selected_experiment_id: "exp-a",
+      submission_id: "exp-a-diverse",
+      output_filename: "exp-a-diverse.csv",
+      portfolio_slot: "diverse",
+    }, makeContext(pulseedHome));
+    expect(diverse.success).toBe(true);
+    expect(diverse.data).toMatchObject({
+      portfolio_slot: "diverse",
+      portfolio_policy: expect.stringContaining("distinct model/feature/seed lineage"),
     });
   });
 

--- a/src/tools/kaggle/__tests__/metrics.test.ts
+++ b/src/tools/kaggle/__tests__/metrics.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { KaggleMetricsSchema, metricThresholdHintForDirection, parseKaggleMetricsCompatible } from "../metrics.js";
+import {
+  KaggleMetricsSchema,
+  metricThresholdHintForDirection,
+  parseKaggleMetricsCompatible,
+  summarizeKaggleValidation,
+} from "../metrics.js";
 
 describe("Kaggle metrics helpers", () => {
   it("maps maximize metrics to gte threshold hints", () => {
@@ -82,5 +87,89 @@ describe("Kaggle metrics helpers", () => {
       "train_rows missing; normalized to 0",
       "valid_rows missing; normalized to 0",
     ]));
+  });
+
+  it("preserves validation evidence when normalizing loose real-run metrics", () => {
+    const result = parseKaggleMetricsCompatible({
+      metric_name: "balanced_accuracy",
+      metric_value: 0.84,
+      metric_direction: "higher_is_better",
+      validation: {
+        oof: { present: true, path: "experiments/exp-loose/oof.csv", coverage: 1, leak_checked: true },
+        leak_checks: {
+          target_encoding_oof_only: true,
+          stacking_oof_only: true,
+          train_test_boundary_checked: true,
+        },
+        train_test_drift: { checked: true, adversarial_validation_auc: 0.52 },
+        public_leaderboard: { score: 0.838, submission_id: "exp-loose-public", observed_at: "2026-04-25T00:00:00.000Z" },
+      },
+    }, {
+      experiment_id: "exp-loose",
+      competition: "playground-series-s6e4",
+      log_path: "experiments/exp-loose/train.log",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      source_schema: "loose",
+      metrics: {
+        validation: {
+          oof: { present: true, leak_checked: true },
+          public_leaderboard: { score: 0.838 },
+        },
+      },
+    });
+    expect(result.ok && summarizeKaggleValidation(result.metrics)).toMatchObject({
+      oof_present: true,
+      oof_leak_checked: true,
+      public_lb_score: 0.838,
+      drift_checked: true,
+      risk_level: "medium",
+    });
+  });
+
+  it("keeps usable loose validation sections when one section is malformed or has extra fields", () => {
+    const result = parseKaggleMetricsCompatible({
+      metric_name: "balanced_accuracy",
+      metric_value: 0.84,
+      metric_direction: "higher_is_better",
+      validation: {
+        oof: {
+          present: true,
+          path: "experiments/exp-loose/oof.csv",
+          coverage: 1,
+          leak_checked: true,
+          producer: "local-cv-script",
+        },
+        leak_checks: {
+          target_encoding_oof_only: true,
+          stacking_oof_only: true,
+          train_test_boundary_checked: true,
+          duplicate_or_id_leak_checked: true,
+          inspected_by: "fixture",
+        },
+        train_test_drift: { checked: true, adversarial_validation_auc: 0.52 },
+        public_leaderboard: { score: 0.838, observed_at: "not-a-date" },
+      },
+    }, {
+      experiment_id: "exp-loose",
+      competition: "playground-series-s6e4",
+      log_path: "experiments/exp-loose/train.log",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      source_schema: "loose",
+      metrics: {
+        validation: {
+          oof: { present: true, leak_checked: true },
+          leak_checks: { duplicate_or_id_leak_checked: true },
+          train_test_drift: { checked: true },
+          public_leaderboard: { score: 0.838 },
+        },
+      },
+      warnings: expect.arrayContaining(["validation.public_leaderboard.observed_at malformed; ignored"]),
+    });
   });
 });

--- a/src/tools/kaggle/index.ts
+++ b/src/tools/kaggle/index.ts
@@ -44,15 +44,22 @@ export {
 export {
   KaggleMetricDirectionSchema,
   KaggleMetricsSchema,
+  KaggleLongRunValidationContractSchema,
+  KaggleValidationContractSchema,
+  KAGGLE_VALIDATION_CHECKLIST,
   compareMetricScores,
   metricThresholdHintForDirection,
   normalizedMetricScore,
   parseKaggleMetrics,
   parseKaggleMetricsCompatible,
+  summarizeKaggleValidation,
   type KaggleMetricsCompatibilityFallback,
   type KaggleMetricDirection,
   type KaggleMetricParseResult,
   type KaggleMetrics,
+  type KaggleLongRunValidationContract,
+  type KaggleValidationContract,
+  type KaggleValidationDiscipline,
   type MetricThresholdHint,
 } from "./metrics.js";
 export {

--- a/src/tools/kaggle/metrics.ts
+++ b/src/tools/kaggle/metrics.ts
@@ -3,6 +3,115 @@ import { z } from "zod";
 export const KaggleMetricDirectionSchema = z.enum(["maximize", "minimize"]);
 export type KaggleMetricDirection = z.infer<typeof KaggleMetricDirectionSchema>;
 
+export const KAGGLE_VALIDATION_CHECKLIST = [
+  "competition_metric_from_rules",
+  "cv_split_strategy_declared",
+  "oof_predictions_present_and_leak_checked",
+  "target_encoding_and_stacking_are_oof_only",
+  "seed_or_fold_stability_recorded",
+  "train_test_drift_checked",
+  "submission_portfolio_slot_declared",
+  "final_report_separates_local_cv_public_lb_private_uncertainty",
+] as const;
+
+const KaggleValidationCompetitionMetricSchema = z.object({
+    name: z.string().min(1),
+    direction: KaggleMetricDirectionSchema,
+    source: z.enum(["competition_rules", "inferred", "manual"]).default("manual"),
+  }).strict();
+const KaggleValidationCvSchema = z.object({
+    strategy: z.string().min(1),
+    fold_count: z.number().int().positive().optional(),
+    repeated_seed_count: z.number().int().positive().optional(),
+    stratified: z.boolean().optional(),
+    group_aware: z.boolean().optional(),
+    time_aware: z.boolean().optional(),
+  }).strict();
+const KaggleValidationOofSchema = z.object({
+    present: z.boolean(),
+    path: z.string().min(1).optional(),
+    rows: z.number().int().nonnegative().optional(),
+    coverage: z.number().min(0).max(1).optional(),
+    leak_checked: z.boolean().optional(),
+  }).strict();
+const KaggleValidationLeakChecksSchema = z.object({
+    target_encoding_oof_only: z.boolean().optional(),
+    stacking_oof_only: z.boolean().optional(),
+    train_test_boundary_checked: z.boolean().optional(),
+    duplicate_or_id_leak_checked: z.boolean().optional(),
+    notes: z.array(z.string().min(1)).default([]),
+  }).strict();
+const KaggleValidationStabilitySchema = z.object({
+    repeated_seed_count: z.number().int().positive().optional(),
+    fold_score_min: z.number().finite().optional(),
+    fold_score_max: z.number().finite().optional(),
+    seed_score_std: z.number().finite().nonnegative().optional(),
+  }).strict();
+const KaggleValidationTrainTestDriftSchema = z.object({
+    checked: z.boolean(),
+    adversarial_validation_auc: z.number().min(0).max(1).optional(),
+    summary: z.string().min(1).optional(),
+  }).strict();
+const KaggleValidationPublicLeaderboardSchema = z.object({
+    score: z.number().finite().optional(),
+    submission_id: z.string().min(1).optional(),
+    observed_at: z.string().datetime().optional(),
+    notes: z.string().min(1).optional(),
+  }).strict();
+
+export const KaggleValidationContractSchema = z.object({
+  competition_metric: KaggleValidationCompetitionMetricSchema.optional(),
+  cv: KaggleValidationCvSchema.optional(),
+  oof: KaggleValidationOofSchema.optional(),
+  leak_checks: KaggleValidationLeakChecksSchema.optional(),
+  stability: KaggleValidationStabilitySchema.optional(),
+  train_test_drift: KaggleValidationTrainTestDriftSchema.optional(),
+  public_leaderboard: KaggleValidationPublicLeaderboardSchema.optional(),
+}).strict();
+export type KaggleValidationContract = z.infer<typeof KaggleValidationContractSchema>;
+
+export const KaggleLongRunValidationContractSchema = KaggleValidationContractSchema.superRefine((contract, ctx) => {
+  if (!contract.competition_metric) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "competition_metric is required before starting a Kaggle long run", path: ["competition_metric"] });
+  }
+  if (!contract.cv) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "cv split strategy is required before starting a Kaggle long run", path: ["cv"] });
+  } else if ((contract.cv.fold_count ?? 0) < 2) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "cv.fold_count must declare at least two folds before starting a Kaggle long run", path: ["cv", "fold_count"] });
+  }
+  if (!contract.oof) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "OOF generation contract is required before starting a Kaggle long run", path: ["oof"] });
+  } else {
+    if (contract.oof.present !== true) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "OOF predictions must be planned before starting a Kaggle long run", path: ["oof", "present"] });
+    }
+    if (contract.oof.leak_checked !== true) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "OOF leakage check must be required before starting a Kaggle long run", path: ["oof", "leak_checked"] });
+    }
+  }
+  if (!contract.leak_checks) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "leak-check contract is required before starting a Kaggle long run", path: ["leak_checks"] });
+  } else {
+    const requiredChecks: Array<[keyof NonNullable<KaggleValidationContract["leak_checks"]>, string]> = [
+      ["target_encoding_oof_only", "target encoding must be constrained to OOF-safe transforms"],
+      ["stacking_oof_only", "stacking must be constrained to OOF-safe transforms"],
+      ["train_test_boundary_checked", "train/test boundary check must be required"],
+      ["duplicate_or_id_leak_checked", "duplicate/id leakage check must be required"],
+    ];
+    for (const [key, message] of requiredChecks) {
+      if (contract.leak_checks[key] !== true) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message, path: ["leak_checks", key] });
+      }
+    }
+  }
+  if (!contract.train_test_drift) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "train/test drift contract is required before starting a Kaggle long run", path: ["train_test_drift"] });
+  } else if (contract.train_test_drift.checked !== true) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "train/test drift check must be required before starting a Kaggle long run", path: ["train_test_drift", "checked"] });
+  }
+});
+export type KaggleLongRunValidationContract = z.infer<typeof KaggleLongRunValidationContractSchema>;
+
 export const KaggleMetricsSchema = z.object({
   experiment_id: z.string().min(1),
   competition: z.string().min(1),
@@ -21,9 +130,25 @@ export const KaggleMetricsSchema = z.object({
     submission: z.string().min(1).optional(),
     log: z.string().min(1),
   }).strict(),
+  validation: KaggleValidationContractSchema.optional(),
 }).strict();
 
 export type KaggleMetrics = z.infer<typeof KaggleMetricsSchema>;
+
+export interface KaggleValidationDiscipline {
+  oof_present: boolean;
+  oof_leak_checked: boolean;
+  cv_stability_available: boolean;
+  cv_std: number | null;
+  public_lb_score: number | null;
+  public_lb_gap: number | null;
+  drift_checked: boolean;
+  drift_risk: "unknown" | "low" | "high";
+  leak_risks: string[];
+  warnings: string[];
+  risk_level: "low" | "medium" | "high";
+  robust_penalty: number;
+}
 
 export interface KaggleMetricsCompatibilityFallback {
   experiment_id?: string;
@@ -119,6 +244,131 @@ export function compareMetricScores(a: KaggleMetrics, b: KaggleMetrics): number 
   return normalizedMetricScore(b) - normalizedMetricScore(a);
 }
 
+export function summarizeKaggleValidation(metrics: KaggleMetrics): KaggleValidationDiscipline {
+  const warnings: string[] = [];
+  const leakRisks: string[] = [];
+  const validation = metrics.validation;
+  const oofPresent = validation?.oof?.present ?? false;
+  const oofLeakChecked = validation?.oof?.leak_checked ?? false;
+  const cvStd = metrics.cv_std ?? validation?.stability?.seed_score_std ?? null;
+  const publicScore = validation?.public_leaderboard?.score ?? null;
+  const publicGap = publicScore === null
+    ? null
+    : normalizedMetricScore(metrics) - (metrics.direction === "maximize" ? publicScore : -publicScore);
+  const driftAuc = validation?.train_test_drift?.adversarial_validation_auc;
+  const driftChecked = validation?.train_test_drift?.checked ?? false;
+  const driftRisk = !driftChecked
+    ? "unknown"
+    : typeof driftAuc === "number" && driftAuc >= 0.65
+      ? "high"
+      : "low";
+
+  if (!oofPresent) warnings.push("OOF predictions are missing");
+  if (oofPresent && !oofLeakChecked) warnings.push("OOF leakage check is missing");
+  if (cvStd === null) warnings.push("CV stability is missing");
+  if (!driftChecked) warnings.push("train/test drift check is missing");
+  if (publicGap !== null && publicGap > 0.03) warnings.push(`public leaderboard trails local CV by ${publicGap}`);
+  if (validation?.leak_checks?.target_encoding_oof_only === false) leakRisks.push("target_encoding_not_oof_safe");
+  if (validation?.leak_checks?.stacking_oof_only === false) leakRisks.push("stacking_not_oof_safe");
+  if (validation?.leak_checks?.train_test_boundary_checked === false) leakRisks.push("train_test_boundary_not_checked");
+  if (validation?.leak_checks?.duplicate_or_id_leak_checked === false) leakRisks.push("duplicate_or_id_leak_not_checked");
+
+  const robustPenalty =
+    (cvStd ?? 0.04) * 1.5
+    + (!oofPresent ? 0.08 : 0)
+    + (oofPresent && !oofLeakChecked ? 0.04 : 0)
+    + (publicGap !== null && publicGap > 0 ? publicGap * 1.5 : 0)
+    + (driftRisk === "high" ? 0.06 : driftRisk === "unknown" ? 0.02 : 0)
+    + leakRisks.length * 0.08;
+  const riskLevel = leakRisks.length > 0 || !oofPresent || (publicGap !== null && publicGap > 0.05) || driftRisk === "high"
+    ? "high"
+    : warnings.length > 0
+      ? "medium"
+      : "low";
+
+  return {
+    oof_present: oofPresent,
+    oof_leak_checked: oofLeakChecked,
+    cv_stability_available: cvStd !== null,
+    cv_std: cvStd,
+    public_lb_score: publicScore,
+    public_lb_gap: publicGap,
+    drift_checked: driftChecked,
+    drift_risk: driftRisk,
+    leak_risks: leakRisks,
+    warnings,
+    risk_level: riskLevel,
+    robust_penalty: robustPenalty,
+  };
+}
+
+function normalizeLooseValidationContract(value: unknown, warnings: string[]): KaggleValidationContract | undefined {
+  if (!isRecord(value)) return undefined;
+  const normalized: KaggleValidationContract = {};
+  const competitionMetric = KaggleValidationCompetitionMetricSchema.strip().safeParse(value["competition_metric"]);
+  if (competitionMetric.success) {
+    normalized.competition_metric = competitionMetric.data;
+  } else if ("competition_metric" in value) {
+    warnings.push("validation.competition_metric malformed; ignored");
+  }
+  const cv = KaggleValidationCvSchema.strip().safeParse(value["cv"]);
+  if (cv.success) {
+    normalized.cv = cv.data;
+  } else if ("cv" in value) {
+    warnings.push("validation.cv malformed; ignored");
+  }
+  const oof = KaggleValidationOofSchema.strip().safeParse(value["oof"]);
+  if (oof.success) {
+    normalized.oof = oof.data;
+  } else if ("oof" in value) {
+    warnings.push("validation.oof malformed; ignored");
+  }
+  const leakChecks = KaggleValidationLeakChecksSchema.strip().safeParse(value["leak_checks"]);
+  if (leakChecks.success) {
+    normalized.leak_checks = leakChecks.data;
+  } else if ("leak_checks" in value) {
+    warnings.push("validation.leak_checks malformed; ignored");
+  }
+  const stability = KaggleValidationStabilitySchema.strip().safeParse(value["stability"]);
+  if (stability.success) {
+    normalized.stability = stability.data;
+  } else if ("stability" in value) {
+    warnings.push("validation.stability malformed; ignored");
+  }
+  const drift = KaggleValidationTrainTestDriftSchema.strip().safeParse(value["train_test_drift"]);
+  if (drift.success) {
+    normalized.train_test_drift = drift.data;
+  } else if ("train_test_drift" in value) {
+    warnings.push("validation.train_test_drift malformed; ignored");
+  }
+  const publicLeaderboard = normalizeLoosePublicLeaderboard(value["public_leaderboard"], warnings);
+  if (publicLeaderboard) {
+    normalized.public_leaderboard = publicLeaderboard;
+  } else if ("public_leaderboard" in value) {
+    warnings.push("validation.public_leaderboard malformed; ignored");
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+function normalizeLoosePublicLeaderboard(
+  value: unknown,
+  warnings: string[],
+): KaggleValidationContract["public_leaderboard"] | undefined {
+  if (!isRecord(value)) return undefined;
+  const score = numberField(value, "score");
+  const submissionId = stringField(value, "submission_id");
+  const observedAtRaw = stringField(value, "observed_at");
+  const observedAt = normalizeDateTime(observedAtRaw ?? undefined);
+  const notes = stringField(value, "notes");
+  const normalized: KaggleValidationContract["public_leaderboard"] = {};
+  if (score !== null) normalized.score = score;
+  if (submissionId) normalized.submission_id = submissionId;
+  if (observedAt) normalized.observed_at = observedAt;
+  if (observedAtRaw && !observedAt) warnings.push("validation.public_leaderboard.observed_at malformed; ignored");
+  if (notes) normalized.notes = notes;
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
 function normalizeLooseKaggleMetrics(
   value: unknown,
   fallback: KaggleMetricsCompatibilityFallback,
@@ -175,22 +425,28 @@ function normalizeLooseKaggleMetrics(
   if (numberField(value, "train_rows") === null) warnings.push("train_rows missing; normalized to 0");
   if (numberField(value, "valid_rows") === null) warnings.push("valid_rows missing; normalized to 0");
 
+  const normalized: KaggleMetrics = {
+    experiment_id: experimentId,
+    competition,
+    metric_name: metricName,
+    direction,
+    cv_score: score,
+    cv_std: numberField(value, "cv_std") ?? stdFromFoldScores(value["fold_scores"]),
+    holdout_score: numberField(value, "holdout_score"),
+    train_rows: intField(value, "train_rows") ?? 0,
+    valid_rows: intField(value, "valid_rows") ?? 0,
+    seed: intField(value, "seed") ?? 0,
+    created_at: createdAt,
+    status: normalizeStatus(stringField(value, "status")),
+    artifacts,
+  };
+  const validation = normalizeLooseValidationContract(value["validation"], warnings);
+  if (validation) {
+    normalized.validation = validation;
+  }
+
   return {
-    metrics: {
-      experiment_id: experimentId,
-      competition,
-      metric_name: metricName,
-      direction,
-      cv_score: score,
-      cv_std: numberField(value, "cv_std") ?? stdFromFoldScores(value["fold_scores"]),
-      holdout_score: numberField(value, "holdout_score"),
-      train_rows: intField(value, "train_rows") ?? 0,
-      valid_rows: intField(value, "valid_rows") ?? 0,
-      seed: intField(value, "seed") ?? 0,
-      created_at: createdAt,
-      status: normalizeStatus(stringField(value, "status")),
-      artifacts,
-    },
+    metrics: normalized,
     warnings,
   };
 }


### PR DESCRIPTION
Closes #818

## Summary
- add Kaggle validation contracts/checklist for competition metric, CV split, OOF leakage, drift, public LB, final-report separation, and long-run start gating
- make experiment comparison report raw vs validation-adjusted ranking so risky raw CV/OOF top-1 is not automatically the safe recommendation
- persist submission portfolio slot intent (`safe`, `aggressive`, `diverse`) in prepared submission metadata/output
- preserve loose real-run validation evidence, including public LB score salvage when optional observed timestamps are malformed

## Verification
- `npm run typecheck`
- `npx vitest run src/tools/kaggle/__tests__/metrics.test.ts src/tools/kaggle/__tests__/KaggleExperimentTools.test.ts src/tools/kaggle/__tests__/KaggleSubmissionTools.test.ts src/tools/kaggle/__tests__/KaggleWorkspacePrepareTool.test.ts src/orchestrator/execution/agent-loop/__tests__/kaggle-training-benchmark.test.ts`
- `npm run lint:boundaries` (0 errors, existing warnings)
- `npm run test:changed`
- `git diff --check`

## Known risks
- Validation-adjusted ranking uses conservative heuristic penalties; it records raw rank alongside robust rank so operators can inspect tradeoffs before choosing a portfolio slot.
