### PR TITLE
feat(tui): derive typed RunSpec drafts from long-running requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ export { PortfolioManager } from "./orchestrator/strategy/portfolio-manager.js";
 export { CoreLoop } from "./orchestrator/loop/core-loop.js";
 export type { CoreLoopDeps, LoopConfig, LoopResult } from "./orchestrator/loop/core-loop.js";
 export { RuntimeSessionRegistry, createRuntimeSessionRegistry } from "./runtime/session-registry/index.js";
+export { deriveRunSpecFromText, recognizeRunSpecIntent, createRunSpecStore } from "./runtime/run-spec/index.js";
 export {
   createRuntimeDreamSidecarReview,
   RuntimeDreamSidecarReviewError,

--- a/src/interface/chat/__tests__/ingress-router.test.ts
+++ b/src/interface/chat/__tests__/ingress-router.test.ts
@@ -123,6 +123,30 @@ describe("IngressRouter", () => {
     expect(route.eventProjectionPolicy).toBe("turn_only");
   });
 
+  it("classifies Kaggle long-running requests as needing RunSpec derivation on the caller path", () => {
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: "Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.",
+        channel: "tui",
+        platform: "local_tui",
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      }),
+      {
+        hasAgentLoop: true,
+        hasToolLoop: true,
+      }
+    );
+
+    expect(route.kind).toBe("agent_loop");
+    expect(route.runSpecIntent).toMatchObject({
+      needsRunSpec: true,
+      profile: "kaggle",
+    });
+  });
+
   it("does not classify Japanese threshold phrasing with regex-based daemon routing", () => {
     const route = router.selectRoute(
       buildStandaloneIngressMessage({

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { ChatEventHandler } from "./chat-events.js";
 import { recognizeRuntimeControlIntent, type RuntimeControlIntent } from "../../runtime/control/index.js";
+import { recognizeRunSpecIntent, type RunSpecIntent } from "../../runtime/run-spec/index.js";
 import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
@@ -52,6 +53,7 @@ export type SelectedChatRoute =
   | {
       kind: "agent_loop" | "tool_loop" | "adapter";
       reason: "agent_loop_available" | "tool_loop_available" | "adapter_fallback";
+      runSpecIntent?: RunSpecIntent;
       replyTargetPolicy: ReplyTargetPolicy;
       eventProjectionPolicy: EventProjectionPolicy;
       concurrencyPolicy: ConcurrencyPolicy;
@@ -60,6 +62,7 @@ export type SelectedChatRoute =
       kind: "runtime_control";
       reason: "runtime_control_intent";
       intent: RuntimeControlIntent;
+      runSpecIntent?: RunSpecIntent;
       replyTargetPolicy: ReplyTargetPolicy;
       eventProjectionPolicy: EventProjectionPolicy;
       concurrencyPolicy: ConcurrencyPolicy;
@@ -88,6 +91,7 @@ function selectRouteForText(
   };
   const canUseRuntimeControlRoute =
     runtimeControl.allowed && runtimeControl.approvalMode !== "disallowed";
+  const runSpecIntent = recognizeRunSpecIntent(text) ?? undefined;
 
   if (canUseRuntimeControlRoute) {
     const intent = recognizeRuntimeControlIntent(text);
@@ -111,6 +115,7 @@ function selectRouteForText(
     return {
       kind: "agent_loop",
       reason: "agent_loop_available",
+      ...(runSpecIntent ? { runSpecIntent } : {}),
       ...baseTurnPolicy,
     };
   }
@@ -119,6 +124,7 @@ function selectRouteForText(
     return {
       kind: "tool_loop",
       reason: "tool_loop_available",
+      ...(runSpecIntent ? { runSpecIntent } : {}),
       ...baseTurnPolicy,
     };
   }
@@ -126,6 +132,7 @@ function selectRouteForText(
   return {
     kind: "adapter",
     reason: "adapter_fallback",
+    ...(runSpecIntent ? { runSpecIntent } : {}),
     ...baseTurnPolicy,
   };
 }

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -83,6 +83,7 @@ function createStateManagerMock() {
   return {
     listGoalIds: vi.fn(async () => [] as string[]),
     loadGoal: vi.fn(async () => null),
+    getBaseDir: vi.fn(() => "/tmp/pulseed-tui-test"),
   };
 }
 
@@ -233,6 +234,46 @@ describe("standalone slash command routing", () => {
     expect(chatRunner.execute).toHaveBeenNthCalledWith(2, "/config", "~/workspace");
     expect(intentRecognizer.recognize).not.toHaveBeenCalled();
     expect(actionHandler.handle).not.toHaveBeenCalled();
+
+    screen.unmount();
+  });
+
+  it("persists a RunSpec draft and forwards typed metadata for natural-language long-running runs", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/work/kaggle",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.");
+
+    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.executeIngressMessage).toHaveBeenCalledOnce();
+    const calls = chatRunner.executeIngressMessage.mock.calls as unknown as Array<[
+      { metadata: Record<string, unknown> },
+      string,
+    ]>;
+    const [ingress, cwd] = calls[0]!;
+    expect(cwd).toBe("/work/kaggle");
+    expect(ingress.metadata).toMatchObject({
+      run_spec_profile: "kaggle",
+      run_spec_status: "draft",
+    });
+    expect(String(ingress.metadata.run_spec_id)).toMatch(/^runspec-/);
 
     screen.unmount();
   });

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -37,6 +37,7 @@ import { ShellTool } from "../../tools/system/ShellTool/ShellTool.js";
 import { getPulseedVersion } from "../../base/utils/pulseed-meta.js";
 import { applyChatEventToMessages } from "../chat/chat-event-state.js";
 import { setActiveCursorEscape } from "./cursor-tracker.js";
+import { createRunSpecStore, deriveRunSpecFromText, type RunSpec } from "../../runtime/run-spec/index.js";
 
 const MAX_MESSAGES = 200;
 const PULSEED_VERSION = getPulseedVersion(import.meta.url);
@@ -156,6 +157,27 @@ export function deriveDaemonGoalIdFromActiveGoals(
 ): string | null {
   if (activeGoals.length === 0) return null;
   return currentGoalId && activeGoals.includes(currentGoalId) ? currentGoalId : activeGoals[0]!;
+}
+
+function formatRunSpecDraftMessage(spec: RunSpec): string {
+  const missing = spec.missing_fields.map((field) => field.question);
+  const lines = [
+    `RunSpec draft saved: ${spec.id}`,
+    `Profile: ${spec.profile}`,
+    `Objective: ${spec.objective}`,
+    `Workspace: ${spec.workspace?.path ?? "unresolved"}`,
+    `Progress: ${spec.progress_contract.semantics}`,
+  ];
+  if (spec.metric) {
+    lines.push(`Metric: ${spec.metric.name} (${spec.metric.direction})`);
+  }
+  if (spec.deadline) {
+    lines.push(`Deadline: ${spec.deadline.raw}${spec.deadline.iso_at ? ` (${spec.deadline.iso_at})` : ""}`);
+  }
+  if (missing.length > 0) {
+    lines.push("Questions:", ...missing.map((question) => `- ${question}`));
+  }
+  return lines.join("\n");
 }
 
 interface AppProps {
@@ -614,7 +636,54 @@ export function App({
               }].slice(-MAX_MESSAGES));
             }
           } else if (freeformRoute === "chat_runner" && chatRunner) {
-            await chatRunner.execute(input, cwd ?? process.cwd());
+            const effectiveCwd = cwd ?? process.cwd();
+            const runSpec = deriveRunSpecFromText(input, {
+              cwd: effectiveCwd,
+              timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            });
+            if (runSpec) {
+              const savedRunSpec = await createRunSpecStore(stateManager).save(runSpec);
+              setMessages((prev) => [...prev, {
+                id: randomUUID(),
+                role: "pulseed" as const,
+                text: formatRunSpecDraftMessage(savedRunSpec),
+                timestamp: new Date(),
+                messageType: savedRunSpec.missing_fields.length > 0 ? ("warning" as const) : ("info" as const),
+              }].slice(-MAX_MESSAGES));
+              await chatRunner.executeIngressMessage({
+                ingress_id: randomUUID(),
+                received_at: new Date().toISOString(),
+                channel: "tui",
+                platform: "local_tui",
+                text: input,
+                actor: {
+                  surface: "tui",
+                  platform: "local_tui",
+                },
+                runtimeControl: {
+                  allowed: true,
+                  approvalMode: "interactive",
+                },
+                metadata: {
+                  run_spec_id: savedRunSpec.id,
+                  run_spec_profile: savedRunSpec.profile,
+                  run_spec_status: savedRunSpec.status,
+                },
+                replyTarget: {
+                  surface: "tui",
+                  channel: "tui",
+                  platform: "local_tui",
+                  metadata: {
+                    run_spec_id: savedRunSpec.id,
+                    run_spec_profile: savedRunSpec.profile,
+                    run_spec_status: savedRunSpec.status,
+                  },
+                },
+                cwd: effectiveCwd,
+              }, effectiveCwd);
+            } else {
+              await chatRunner.execute(input, effectiveCwd);
+            }
           } else {
             setMessages((prev) => [...prev, {
               id: randomUUID(), role: "pulseed" as const,
@@ -641,7 +710,7 @@ export function App({
         setIsProcessing(false);
       }
     },
-    [intentRecognizer, actionHandler, chatRunner, daemonClient, isDaemonMode, daemonLoopState.goalId, startLoop, stopLoop, isProcessing, cwd]
+    [intentRecognizer, actionHandler, chatRunner, daemonClient, isDaemonMode, daemonLoopState.goalId, startLoop, stopLoop, isProcessing, cwd, stateManager]
   );
 
   // goalCount: 1 when there is an active goal in the loop, 0 otherwise

--- a/src/runtime/run-spec/__tests__/run-spec.test.ts
+++ b/src/runtime/run-spec/__tests__/run-spec.test.ts
@@ -1,0 +1,138 @@
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { deriveRunSpecFromText, recognizeRunSpecIntent } from "../derive.js";
+import { createRunSpecStore } from "../store.js";
+
+const NOW = new Date("2026-05-02T00:00:00.000Z");
+
+describe("RunSpec derivation", () => {
+  it("derives a Kaggle RunSpec with separate metric and progress semantics", () => {
+    const spec = deriveRunSpecFromText(
+      "Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.",
+      {
+        cwd: "/work/kaggle/playground",
+        now: NOW,
+        timezone: "Asia/Tokyo",
+      },
+    );
+
+    expect(spec).not.toBeNull();
+    expect(spec!.profile).toBe("kaggle");
+    expect(spec!.workspace).toMatchObject({ path: "/work/kaggle/playground", source: "context" });
+    expect(spec!.metric).toMatchObject({
+      name: "leaderboard_rank_percentile",
+      direction: "minimize",
+      target_rank_percent: 15,
+    });
+    expect(spec!.progress_contract).toMatchObject({
+      kind: "rank_percentile",
+      threshold: 15,
+    });
+    expect(spec!.deadline).toMatchObject({
+      raw: "tomorrow morning",
+      finalization_buffer_minutes: 60,
+    });
+    expect(spec!.approval_policy.submit).toBe("approval_required");
+    expect(spec!.risk_flags).toContain("external_submit_requires_approval");
+    expect(spec!.missing_fields).toEqual([]);
+  });
+
+  it("derives a generic long-running RunSpec", () => {
+    const spec = deriveRunSpecFromText(
+      "Keep this background optimization running until tomorrow morning and maximize accuracy 0.91.",
+      {
+        cwd: "/repo/app",
+        now: NOW,
+      },
+    );
+
+    expect(spec).not.toBeNull();
+    expect(spec!.profile).toBe("generic");
+    expect(spec!.metric).toMatchObject({
+      name: "accuracy",
+      direction: "maximize",
+      target: 0.91,
+    });
+    expect(spec!.progress_contract).toMatchObject({
+      kind: "metric_target",
+      dimension: "accuracy",
+      threshold: 0.91,
+    });
+  });
+
+  it("preserves ambiguous metric direction as a required missing field", () => {
+    const spec = deriveRunSpecFromText(
+      "Run this long-running task until tomorrow morning and reach score 0.98.",
+      {
+        cwd: "/repo/app",
+        now: NOW,
+      },
+    );
+
+    expect(spec).not.toBeNull();
+    expect(spec!.metric).toMatchObject({
+      name: "score",
+      direction: "unknown",
+      target: 0.98,
+    });
+    expect(spec!.progress_contract).toMatchObject({
+      kind: "metric_target",
+      threshold: 0.98,
+    });
+    expect(spec!.missing_fields).toContainEqual({
+      field: "metric.direction",
+      question: "Should score be maximized or minimized?",
+      severity: "required",
+    });
+  });
+
+  it("does not guess missing workspace and deadline", () => {
+    const spec = deriveRunSpecFromText("Run a long-running Kaggle experiment for top 20%.", {
+      now: NOW,
+    });
+
+    expect(spec).not.toBeNull();
+    expect(spec!.workspace).toBeNull();
+    expect(spec!.deadline).toBeNull();
+    expect(spec!.missing_fields.map((field) => field.field)).toEqual(["workspace", "deadline"]);
+  });
+
+  it("does not treat explanatory long-running questions as run requests", () => {
+    expect(recognizeRunSpecIntent("Why do long-running tasks fail?")).toBeNull();
+  });
+});
+
+describe("RunSpecStore", () => {
+  it("persists and reloads a RunSpec under the state root", async () => {
+    const baseDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-runspec-"));
+    const spec = deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
+      cwd: "/repo/kaggle",
+      now: NOW,
+    });
+    expect(spec).not.toBeNull();
+
+    const store = createRunSpecStore({ getBaseDir: () => baseDir });
+    await store.save(spec!);
+
+    await expect(store.load(spec!.id)).resolves.toMatchObject({
+      id: spec!.id,
+      profile: "kaggle",
+      schema_version: "run-spec-v1",
+    });
+  });
+
+  it("rejects path-like ids before RunSpec store file I/O", async () => {
+    const baseDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-runspec-"));
+    const spec = deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
+      cwd: "/repo/kaggle",
+      now: NOW,
+    });
+    expect(spec).not.toBeNull();
+    const store = createRunSpecStore({ getBaseDir: () => baseDir });
+
+    await expect(store.save({ ...spec!, id: "../sessions/foo" })).rejects.toThrow();
+    await expect(store.load("../sessions/foo")).rejects.toThrow();
+  });
+});

--- a/src/runtime/run-spec/derive.ts
+++ b/src/runtime/run-spec/derive.ts
@@ -1,0 +1,316 @@
+import { randomUUID } from "node:crypto";
+import type {
+  RunSpec,
+  RunSpecApprovalPolicy,
+  RunSpecArtifactContract,
+  RunSpecDeadline,
+  RunSpecDerivationContext,
+  RunSpecMetric,
+  RunSpecMissingField,
+  RunSpecProgressContract,
+} from "./types.js";
+
+const LONG_RUNNING_TERMS = [
+  /\blong[-\s]?running\b/i,
+  /\bbackground\b/i,
+  /\brun\b.+\buntil\b/i,
+  /\bkeep\b.+\brunning\b/i,
+  /\bcontinue\b.+\buntil\b/i,
+  /\bdaemon\b/i,
+  /\bcoreloop\b/i,
+  /長期/,
+  /常駐/,
+  /まで.*(実行|走|回|取り組|続け)/,
+];
+
+const KAGGLE_TERMS = [
+  /\bkaggle\b/i,
+  /\bcompetition\b/i,
+  /\bleaderboard\b/i,
+  /\bsubmission\b/i,
+  /\bsubmit\b/i,
+  /コンペ/,
+  /提出/,
+];
+
+const EXPLANATORY_QUESTION_TERMS = [
+  /\bwhy\b/i,
+  /\bhow does\b/i,
+  /\bwhat is\b/i,
+  /\?/,
+  /なぜ/,
+  /どうして/,
+  /とは/,
+];
+
+export interface RunSpecIntent {
+  needsRunSpec: true;
+  profile: "generic" | "kaggle";
+  reason: string;
+}
+
+export function recognizeRunSpecIntent(text: string): RunSpecIntent | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  const profile = KAGGLE_TERMS.some((pattern) => pattern.test(trimmed)) ? "kaggle" : "generic";
+  const longRunning = LONG_RUNNING_TERMS.some((pattern) => pattern.test(trimmed));
+  const hasThreshold = /(top\s*\d+(?:\.\d+)?\s*%|score\s*[<>=>]*\s*\d|accuracy\s*[<>=>]*\s*\d|auc\s*[<>=>]*\s*\d|rmse\s*[<>=>]*\s*\d|loss\s*[<>=>]*\s*\d)/i.test(trimmed);
+  const asksForExplanation = EXPLANATORY_QUESTION_TERMS.some((pattern) => pattern.test(trimmed));
+  const hasOperatorVerb = /\b(run|keep|continue|start|execute|optimi[sz]e|improve|aim|reach)\b|実行|走|回|取り組|続け|目指/i.test(trimmed);
+
+  if (asksForExplanation && !/\b(run|keep|continue|start|do|execute)\b/i.test(trimmed)) {
+    return null;
+  }
+
+  if (profile === "kaggle" && hasOperatorVerb && (longRunning || hasThreshold || /\buntil\b/i.test(trimmed))) {
+    return { needsRunSpec: true, profile, reason: "kaggle_long_running_request" };
+  }
+  if (longRunning && hasOperatorVerb && !asksForExplanation) {
+    return { needsRunSpec: true, profile, reason: "long_running_request" };
+  }
+  return null;
+}
+
+export function deriveRunSpecFromText(text: string, context: RunSpecDerivationContext = {}): RunSpec | null {
+  const intent = recognizeRunSpecIntent(text);
+  if (!intent) return null;
+
+  const now = context.now ?? new Date();
+  const createdAt = now.toISOString();
+  const missingFields: RunSpecMissingField[] = [];
+  const workspace = deriveWorkspace(text, context.cwd);
+  if (!workspace) {
+    missingFields.push({
+      field: "workspace",
+      question: "Which local or remote workspace should PulSeed use for this run?",
+      severity: "required",
+    });
+  }
+
+  const deadline = deriveDeadline(text, now, context.timezone);
+  if (!deadline) {
+    missingFields.push({
+      field: "deadline",
+      question: "What deadline or review time should PulSeed plan around?",
+      severity: "required",
+    });
+  }
+
+  const metric = deriveMetric(text, intent.profile);
+  if (metric && metric.direction === "unknown" && metric.target !== null) {
+    missingFields.push({
+      field: "metric.direction",
+      question: `Should ${metric.name} be maximized or minimized?`,
+      severity: "required",
+    });
+  }
+
+  const progressContract = deriveProgressContract(text, metric, deadline);
+  const approvalPolicy = deriveApprovalPolicy(text);
+  const artifactContract = deriveArtifactContract(intent.profile);
+  const objective = text.trim().replace(/\s+/g, " ");
+  const confidence = missingFields.some((field) => field.severity === "required")
+    ? "medium"
+    : "high";
+
+  return {
+    schema_version: "run-spec-v1",
+    id: `runspec-${randomUUID()}`,
+    status: "draft",
+    profile: intent.profile,
+    source_text: text,
+    objective,
+    workspace,
+    execution_target: deriveExecutionTarget(text),
+    metric,
+    progress_contract: progressContract,
+    deadline,
+    budget: {
+      max_trials: deriveMaxTrials(text),
+      max_wall_clock_minutes: deadline?.iso_at ? minutesUntil(now, new Date(deadline.iso_at)) : null,
+      resident_policy: deadline ? "until_deadline" : "unknown",
+    },
+    approval_policy: approvalPolicy,
+    artifact_contract: artifactContract,
+    risk_flags: deriveRiskFlags(approvalPolicy),
+    missing_fields: missingFields,
+    confidence,
+    links: {
+      goal_id: null,
+      runtime_session_id: null,
+      conversation_id: context.conversationId ?? null,
+    },
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
+function deriveWorkspace(text: string, cwd: string | undefined) {
+  const explicitPath = text.match(/(?:workspace|cwd|directory|dir|repo|path)\s+((?:~|\/)[^\s,]+)/i)?.[1]
+    ?? text.match(/(?:ワークスペース|ディレクトリ|repo|リポジトリ)[^\s/]*(\/[^\s,]+)/i)?.[1];
+  if (explicitPath) {
+    return { path: explicitPath, source: "user" as const, confidence: "high" as const };
+  }
+  const normalizedCwd = cwd?.trim();
+  if (normalizedCwd) {
+    return { path: normalizedCwd, source: "context" as const, confidence: "medium" as const };
+  }
+  return null;
+}
+
+function deriveExecutionTarget(text: string) {
+  const remoteHost = text.match(/\b(?:on|host|ssh)\s+([a-zA-Z0-9_.-]+)\b/i)?.[1] ?? null;
+  if (remoteHost) {
+    return { kind: "remote" as const, remote_host: remoteHost, confidence: "medium" as const };
+  }
+  if (/\bdaemon\b|coreloop/i.test(text)) {
+    return { kind: "daemon" as const, remote_host: null, confidence: "medium" as const };
+  }
+  return { kind: "local" as const, remote_host: null, confidence: "low" as const };
+}
+
+function deriveMetric(text: string, profile: "generic" | "kaggle"): RunSpecMetric | null {
+  const topMatch = text.match(/\btop\s*(\d+(?:\.\d+)?)\s*%/i);
+  if (topMatch) {
+    return {
+      name: "leaderboard_rank_percentile",
+      direction: "minimize",
+      target: null,
+      target_rank_percent: Number(topMatch[1]),
+      datasource: profile === "kaggle" ? "kaggle_leaderboard" : null,
+      confidence: "high",
+    };
+  }
+
+  const metricMatch = text.match(/\b(accuracy|auc|rmse|mae|loss|score|balanced_accuracy)\b[^\d<>=>-]*[<>=>]*\s*(-?\d+(?:\.\d+)?)/i);
+  if (!metricMatch) return null;
+  const name = metricMatch[1].toLowerCase();
+  return {
+    name,
+    direction: inferMetricDirection(text, name),
+    target: Number(metricMatch[2]),
+    target_rank_percent: null,
+    datasource: profile === "kaggle" ? "kaggle_metrics" : null,
+    confidence: "medium",
+  };
+}
+
+function inferMetricDirection(text: string, metricName: string): "maximize" | "minimize" | "unknown" {
+  if (/\b(maximi[sz]e|increase|higher|best|improve|上げ|高く|最大)\b/i.test(text)) return "maximize";
+  if (/\b(minimi[sz]e|decrease|lower|reduce|下げ|低く|最小)\b/i.test(text)) return "minimize";
+  if (/^(accuracy|auc|balanced_accuracy)$/.test(metricName)) return "maximize";
+  if (/^(rmse|mae|loss)$/.test(metricName)) return "minimize";
+  return "unknown";
+}
+
+function deriveProgressContract(
+  text: string,
+  metric: RunSpecMetric | null,
+  deadline: RunSpecDeadline | null,
+): RunSpecProgressContract {
+  if (metric?.target_rank_percent !== null && metric?.target_rank_percent !== undefined) {
+    return {
+      kind: "rank_percentile",
+      dimension: metric.name,
+      threshold: metric.target_rank_percent,
+      semantics: "Reach a leaderboard rank percentile at or below the threshold.",
+      confidence: "high",
+    };
+  }
+  if (metric?.target !== null && metric?.target !== undefined) {
+    return {
+      kind: "metric_target",
+      dimension: metric.name,
+      threshold: metric.target,
+      semantics: "Reach the requested metric target; metric direction is tracked separately.",
+      confidence: metric.direction === "unknown" ? "medium" : "high",
+    };
+  }
+  if (deadline && /\buntil\b|まで|期限|deadline/i.test(text)) {
+    return {
+      kind: "deadline_only",
+      dimension: "time",
+      threshold: null,
+      semantics: "Keep useful work going until the requested deadline or review time.",
+      confidence: "medium",
+    };
+  }
+  return {
+    kind: "open_ended",
+    dimension: null,
+    threshold: null,
+    semantics: "Long-running work requested without an explicit measurable threshold.",
+    confidence: "low",
+  };
+}
+
+function deriveDeadline(text: string, now: Date, timezone: string | undefined): RunSpecDeadline | null {
+  const lower = text.toLowerCase();
+  if (lower.includes("tomorrow morning") || /明日.*(朝|午前)/.test(text)) {
+    const at = new Date(now);
+    at.setDate(at.getDate() + 1);
+    at.setHours(9, 0, 0, 0);
+    return {
+      raw: lower.includes("tomorrow morning") ? "tomorrow morning" : "明日朝",
+      iso_at: at.toISOString(),
+      timezone: timezone ?? null,
+      finalization_buffer_minutes: 60,
+      confidence: "medium",
+    };
+  }
+  const hoursMatch = text.match(/\b(?:for|within)\s+(\d+)\s*(hours?|hrs?)\b/i);
+  if (hoursMatch) {
+    const at = new Date(now.getTime() + Number(hoursMatch[1]) * 60 * 60 * 1000);
+    return {
+      raw: hoursMatch[0],
+      iso_at: at.toISOString(),
+      timezone: timezone ?? null,
+      finalization_buffer_minutes: 30,
+      confidence: "medium",
+    };
+  }
+  return null;
+}
+
+function deriveMaxTrials(text: string): number | null {
+  const match = text.match(/\b(?:max\s*)?(\d+)\s+(?:trials|runs|experiments)\b/i);
+  return match ? Number(match[1]) : null;
+}
+
+function deriveApprovalPolicy(text: string): RunSpecApprovalPolicy {
+  const approvalGated = /approval[-\s]?gated|approval required|ask before|確認して|承認/i.test(text);
+  const submitMentioned = /\b(submit|submission|publish|external)\b|提出|公開/i.test(text);
+  return {
+    submit: approvalGated || submitMentioned ? "approval_required" : "unspecified",
+    publish: approvalGated && /\bpublish\b|公開/i.test(text) ? "approval_required" : "unspecified",
+    secret: "approval_required",
+    external_action: approvalGated || submitMentioned ? "approval_required" : "unspecified",
+    irreversible_action: "approval_required",
+  };
+}
+
+function deriveArtifactContract(profile: "generic" | "kaggle"): RunSpecArtifactContract {
+  if (profile === "kaggle") {
+    return {
+      expected_artifacts: ["submission files", "leaderboard metrics", "experiment notes", "model artifacts"],
+      discovery_globs: ["**/submission*.csv", "**/leaderboard*.json", "**/metrics*.json", "reports/**/*.md"],
+      primary_outputs: ["submission.csv", "metrics summary", "run report"],
+    };
+  }
+  return {
+    expected_artifacts: ["progress report", "metrics", "logs"],
+    discovery_globs: ["reports/**/*.md", "**/metrics*.json", "**/*.log"],
+    primary_outputs: ["progress summary", "final report"],
+  };
+}
+
+function deriveRiskFlags(policy: RunSpecApprovalPolicy): string[] {
+  const flags = ["secret_use_requires_approval", "irreversible_actions_require_approval"];
+  if (policy.submit === "approval_required") flags.push("external_submit_requires_approval");
+  if (policy.publish === "approval_required") flags.push("external_publish_requires_approval");
+  return flags;
+}
+
+function minutesUntil(from: Date, to: Date): number {
+  return Math.max(0, Math.round((to.getTime() - from.getTime()) / 60_000));
+}

--- a/src/runtime/run-spec/index.ts
+++ b/src/runtime/run-spec/index.ts
@@ -1,0 +1,11 @@
+export { deriveRunSpecFromText, recognizeRunSpecIntent, type RunSpecIntent } from "./derive.js";
+export { createRunSpecStore, RunSpecStore } from "./store.js";
+export {
+  RunSpecSchema,
+  RunSpecIdSchema,
+  RunSpecProfileSchema,
+  RunSpecMetricDirectionSchema,
+  type RunSpec,
+  type RunSpecDerivationContext,
+  type RunSpecMissingField,
+} from "./types.js";

--- a/src/runtime/run-spec/store.ts
+++ b/src/runtime/run-spec/store.ts
@@ -1,0 +1,36 @@
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { atomicWrite } from "../../base/state/state-manager.js";
+import type { StateManager } from "../../base/state/state-manager.js";
+import { RunSpecIdSchema, RunSpecSchema, type RunSpec } from "./types.js";
+
+export class RunSpecStore {
+  constructor(private readonly stateManager: Pick<StateManager, "getBaseDir">) {}
+
+  async save(spec: RunSpec): Promise<RunSpec> {
+    const parsed = RunSpecSchema.parse(spec);
+    const dir = this.runSpecsDir();
+    await fsp.mkdir(dir, { recursive: true });
+    await atomicWrite(path.join(dir, `${parsed.id}.json`), parsed);
+    return parsed;
+  }
+
+  async load(id: string): Promise<RunSpec | null> {
+    const parsedId = RunSpecIdSchema.parse(id);
+    try {
+      const raw = await fsp.readFile(path.join(this.runSpecsDir(), `${parsedId}.json`), "utf8");
+      return RunSpecSchema.parse(JSON.parse(raw));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw err;
+    }
+  }
+
+  private runSpecsDir(): string {
+    return path.join(this.stateManager.getBaseDir(), "run-specs");
+  }
+}
+
+export function createRunSpecStore(stateManager: Pick<StateManager, "getBaseDir">): RunSpecStore {
+  return new RunSpecStore(stateManager);
+}

--- a/src/runtime/run-spec/types.ts
+++ b/src/runtime/run-spec/types.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+
+export const RunSpecProfileSchema = z.enum(["generic", "kaggle"]);
+export type RunSpecProfile = z.infer<typeof RunSpecProfileSchema>;
+
+export const RunSpecIdSchema = z.string().regex(
+  /^runspec-[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+);
+export type RunSpecId = z.infer<typeof RunSpecIdSchema>;
+
+export const RunSpecMetricDirectionSchema = z.enum(["maximize", "minimize", "unknown"]);
+export type RunSpecMetricDirection = z.infer<typeof RunSpecMetricDirectionSchema>;
+
+export const RunSpecConfidenceSchema = z.enum(["high", "medium", "low"]);
+export type RunSpecConfidence = z.infer<typeof RunSpecConfidenceSchema>;
+
+export const RunSpecMissingFieldSchema = z.object({
+  field: z.string(),
+  question: z.string(),
+  severity: z.enum(["required", "confirmation"]),
+});
+export type RunSpecMissingField = z.infer<typeof RunSpecMissingFieldSchema>;
+
+export const RunSpecWorkspaceSchema = z.object({
+  path: z.string(),
+  source: z.enum(["user", "context"]),
+  confidence: RunSpecConfidenceSchema,
+});
+export type RunSpecWorkspace = z.infer<typeof RunSpecWorkspaceSchema>;
+
+export const RunSpecExecutionTargetSchema = z.object({
+  kind: z.enum(["local", "daemon", "remote"]),
+  remote_host: z.string().nullable(),
+  confidence: RunSpecConfidenceSchema,
+});
+export type RunSpecExecutionTarget = z.infer<typeof RunSpecExecutionTargetSchema>;
+
+export const RunSpecMetricSchema = z.object({
+  name: z.string(),
+  direction: RunSpecMetricDirectionSchema,
+  target: z.number().nullable(),
+  target_rank_percent: z.number().nullable(),
+  datasource: z.string().nullable(),
+  confidence: RunSpecConfidenceSchema,
+});
+export type RunSpecMetric = z.infer<typeof RunSpecMetricSchema>;
+
+export const RunSpecProgressContractSchema = z.object({
+  kind: z.enum(["metric_target", "rank_percentile", "deadline_only", "open_ended", "unknown"]),
+  dimension: z.string().nullable(),
+  threshold: z.number().nullable(),
+  semantics: z.string(),
+  confidence: RunSpecConfidenceSchema,
+});
+export type RunSpecProgressContract = z.infer<typeof RunSpecProgressContractSchema>;
+
+export const RunSpecDeadlineSchema = z.object({
+  raw: z.string(),
+  iso_at: z.string().nullable(),
+  timezone: z.string().nullable(),
+  finalization_buffer_minutes: z.number().nullable(),
+  confidence: RunSpecConfidenceSchema,
+});
+export type RunSpecDeadline = z.infer<typeof RunSpecDeadlineSchema>;
+
+export const RunSpecBudgetSchema = z.object({
+  max_trials: z.number().nullable(),
+  max_wall_clock_minutes: z.number().nullable(),
+  resident_policy: z.enum(["until_deadline", "best_effort", "unknown"]),
+});
+export type RunSpecBudget = z.infer<typeof RunSpecBudgetSchema>;
+
+export const RunSpecApprovalPolicySchema = z.object({
+  submit: z.enum(["approval_required", "allowed", "disallowed", "unspecified"]),
+  publish: z.enum(["approval_required", "allowed", "disallowed", "unspecified"]),
+  secret: z.enum(["approval_required", "disallowed", "unspecified"]),
+  external_action: z.enum(["approval_required", "allowed", "disallowed", "unspecified"]),
+  irreversible_action: z.enum(["approval_required", "disallowed", "unspecified"]),
+});
+export type RunSpecApprovalPolicy = z.infer<typeof RunSpecApprovalPolicySchema>;
+
+export const RunSpecArtifactContractSchema = z.object({
+  expected_artifacts: z.array(z.string()),
+  discovery_globs: z.array(z.string()),
+  primary_outputs: z.array(z.string()),
+});
+export type RunSpecArtifactContract = z.infer<typeof RunSpecArtifactContractSchema>;
+
+export const RunSpecLinksSchema = z.object({
+  goal_id: z.string().nullable(),
+  runtime_session_id: z.string().nullable(),
+  conversation_id: z.string().nullable(),
+});
+export type RunSpecLinks = z.infer<typeof RunSpecLinksSchema>;
+
+export const RunSpecSchema = z.object({
+  schema_version: z.literal("run-spec-v1"),
+  id: RunSpecIdSchema,
+  status: z.enum(["draft", "confirmed", "cancelled", "attached"]),
+  profile: RunSpecProfileSchema,
+  source_text: z.string(),
+  objective: z.string(),
+  workspace: RunSpecWorkspaceSchema.nullable(),
+  execution_target: RunSpecExecutionTargetSchema,
+  metric: RunSpecMetricSchema.nullable(),
+  progress_contract: RunSpecProgressContractSchema,
+  deadline: RunSpecDeadlineSchema.nullable(),
+  budget: RunSpecBudgetSchema,
+  approval_policy: RunSpecApprovalPolicySchema,
+  artifact_contract: RunSpecArtifactContractSchema,
+  risk_flags: z.array(z.string()),
+  missing_fields: z.array(RunSpecMissingFieldSchema),
+  confidence: RunSpecConfidenceSchema,
+  links: RunSpecLinksSchema,
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+export type RunSpec = z.infer<typeof RunSpecSchema>;
+
+export interface RunSpecDerivationContext {
+  cwd?: string;
+  conversationId?: string | null;
+  now?: Date;
+  timezone?: string;
+}


### PR DESCRIPTION
Closes #847

## Summary
- Add a typed `run-spec-v1` schema, deterministic derivation, and state-root RunSpec store for long-running requests.
- Classify long-running Kaggle/generic caller-path ingress with `runSpecIntent` while preserving existing agent-loop routing.
- Persist TUI RunSpec drafts and forward `run_spec_id`, profile, and status metadata to the existing ChatRunner ingress path.
- Preserve missing workspace/deadline/ambiguous metric direction as required questions, and keep metric direction separate from progress-threshold semantics.

## Verification
- `npm run typecheck`
- `npm run lint:boundaries`
- `npx vitest run --config vitest.unit.config.ts src/interface/chat/__tests__/ingress-router.test.ts`
- `npx vitest run --config vitest.integration.config.ts src/runtime/run-spec/__tests__/run-spec.test.ts src/interface/tui/__tests__/app.test.ts`
- `npm run test:changed`
- `npm run test:all`

## Known unresolved risks
- This PR only creates and persists draft RunSpecs; the guided confirm/revise/cancel start gate is intentionally left for #848.
- Natural-language derivation is deterministic and conservative; broader phrasing coverage should be expanded with tests as #848/#850 add more operator flows.
