### PR TITLE
feat(tui): confirm long-running RunSpec drafts before start

### DIFF
--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -93,6 +93,7 @@ function createChatRunnerMock() {
     execute: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
     interruptAndRedirect: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
     executeIngressMessage: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
+    getConversationId: vi.fn(() => "tui-conversation-test"),
     onEvent: undefined,
   };
 }
@@ -238,7 +239,7 @@ describe("standalone slash command routing", () => {
     screen.unmount();
   });
 
-  it("persists a RunSpec draft and forwards typed metadata for natural-language long-running runs", async () => {
+  it("persists a RunSpec draft and waits for confirmation before forwarding long-running runs", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
 
@@ -262,6 +263,11 @@ describe("standalone slash command routing", () => {
     await testState.lastChatProps!.onSubmit("Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.");
 
     expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+
+    await flush();
+    await testState.lastChatProps!.onSubmit("confirm");
+
     expect(chatRunner.executeIngressMessage).toHaveBeenCalledOnce();
     const calls = chatRunner.executeIngressMessage.mock.calls as unknown as Array<[
       { metadata: Record<string, unknown> },
@@ -271,9 +277,40 @@ describe("standalone slash command routing", () => {
     expect(cwd).toBe("/work/kaggle");
     expect(ingress.metadata).toMatchObject({
       run_spec_profile: "kaggle",
-      run_spec_status: "draft",
+      run_spec_status: "confirmed",
     });
     expect(String(ingress.metadata.run_spec_id)).toMatch(/^runspec-/);
+
+    screen.unmount();
+  });
+
+  it("does not start a long-running run when required RunSpec fields remain unresolved", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/work/kaggle",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("Run this Kaggle competition and aim for top 15%. Keep submissions approval-gated.");
+    await flush();
+    await testState.lastChatProps!.onSubmit("confirm");
+
+    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
 
     screen.unmount();
   });

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -37,7 +37,13 @@ import { ShellTool } from "../../tools/system/ShellTool/ShellTool.js";
 import { getPulseedVersion } from "../../base/utils/pulseed-meta.js";
 import { applyChatEventToMessages } from "../chat/chat-event-state.js";
 import { setActiveCursorEscape } from "./cursor-tracker.js";
-import { createRunSpecStore, deriveRunSpecFromText, type RunSpec } from "../../runtime/run-spec/index.js";
+import {
+  createRunSpecStore,
+  deriveRunSpecFromText,
+  formatRunSpecSetupProposal,
+  handleRunSpecConfirmationInput,
+  type RunSpec,
+} from "../../runtime/run-spec/index.js";
 
 const MAX_MESSAGES = 200;
 const PULSEED_VERSION = getPulseedVersion(import.meta.url);
@@ -159,25 +165,38 @@ export function deriveDaemonGoalIdFromActiveGoals(
   return currentGoalId && activeGoals.includes(currentGoalId) ? currentGoalId : activeGoals[0]!;
 }
 
-function formatRunSpecDraftMessage(spec: RunSpec): string {
-  const missing = spec.missing_fields.map((field) => field.question);
-  const lines = [
-    `RunSpec draft saved: ${spec.id}`,
-    `Profile: ${spec.profile}`,
-    `Objective: ${spec.objective}`,
-    `Workspace: ${spec.workspace?.path ?? "unresolved"}`,
-    `Progress: ${spec.progress_contract.semantics}`,
-  ];
-  if (spec.metric) {
-    lines.push(`Metric: ${spec.metric.name} (${spec.metric.direction})`);
-  }
-  if (spec.deadline) {
-    lines.push(`Deadline: ${spec.deadline.raw}${spec.deadline.iso_at ? ` (${spec.deadline.iso_at})` : ""}`);
-  }
-  if (missing.length > 0) {
-    lines.push("Questions:", ...missing.map((question) => `- ${question}`));
-  }
-  return lines.join("\n");
+function buildRunSpecIngress(input: string, spec: RunSpec, effectiveCwd: string) {
+  return {
+    ingress_id: randomUUID(),
+    received_at: new Date().toISOString(),
+    channel: "tui" as const,
+    platform: "local_tui",
+    text: input,
+    actor: {
+      surface: "tui" as const,
+      platform: "local_tui",
+    },
+    runtimeControl: {
+      allowed: true,
+      approvalMode: "interactive" as const,
+    },
+    metadata: {
+      run_spec_id: spec.id,
+      run_spec_profile: spec.profile,
+      run_spec_status: spec.status,
+    },
+    replyTarget: {
+      surface: "tui" as const,
+      channel: "tui" as const,
+      platform: "local_tui",
+      metadata: {
+        run_spec_id: spec.id,
+        run_spec_profile: spec.profile,
+        run_spec_status: spec.status,
+      },
+    },
+    cwd: effectiveCwd,
+  };
 }
 
 interface AppProps {
@@ -374,6 +393,7 @@ export function App({
   const [reportToShow, setReportToShow] = useState<Report | null>(null);
   const [approvalRequest, setApprovalRequest] = useState<ApprovalRequest | null>(null);
   const approvalRequestRef = useRef<ApprovalRequest | null>(null);
+  const [pendingRunSpec, setPendingRunSpec] = useState<RunSpec | null>(null);
 
   // Ctrl-C double-press exit state
   const [ctrlCPending, setCtrlCPending] = useState(false);
@@ -536,6 +556,35 @@ export function App({
           return;
         }
 
+        if (pendingRunSpec && chatRunner) {
+          const effectiveCwd = cwd ?? process.cwd();
+          const result = handleRunSpecConfirmationInput(pendingRunSpec, input, {
+            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+          });
+          const savedRunSpec = await createRunSpecStore(stateManager).save(result.spec);
+          if (result.kind === "cancelled") {
+            setPendingRunSpec(null);
+          } else if (result.kind === "confirmed") {
+            setPendingRunSpec(null);
+          } else {
+            setPendingRunSpec(savedRunSpec);
+          }
+          setMessages((prev) => [...prev, {
+            id: randomUUID(),
+            role: "pulseed" as const,
+            text: result.message,
+            timestamp: new Date(),
+            messageType: result.kind === "blocked" || result.kind === "unrecognized" ? ("warning" as const) : ("info" as const),
+          }].slice(-MAX_MESSAGES));
+          if (result.kind === "confirmed") {
+            await chatRunner.executeIngressMessage(
+              buildRunSpecIngress(savedRunSpec.source_text, savedRunSpec, effectiveCwd),
+              effectiveCwd,
+            );
+          }
+          return;
+        }
+
         // Slash commands go through IntentRecognizer -> ActionHandler (standalone)
         // or through daemon REST API (daemon mode)
         if (input.startsWith("/") && intentRecognizer && actionHandler) {
@@ -639,48 +688,19 @@ export function App({
             const effectiveCwd = cwd ?? process.cwd();
             const runSpec = deriveRunSpecFromText(input, {
               cwd: effectiveCwd,
+              conversationId: chatRunner.getConversationId?.() ?? null,
               timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
             });
             if (runSpec) {
               const savedRunSpec = await createRunSpecStore(stateManager).save(runSpec);
+              setPendingRunSpec(savedRunSpec);
               setMessages((prev) => [...prev, {
                 id: randomUUID(),
                 role: "pulseed" as const,
-                text: formatRunSpecDraftMessage(savedRunSpec),
+                text: formatRunSpecSetupProposal(savedRunSpec),
                 timestamp: new Date(),
                 messageType: savedRunSpec.missing_fields.length > 0 ? ("warning" as const) : ("info" as const),
               }].slice(-MAX_MESSAGES));
-              await chatRunner.executeIngressMessage({
-                ingress_id: randomUUID(),
-                received_at: new Date().toISOString(),
-                channel: "tui",
-                platform: "local_tui",
-                text: input,
-                actor: {
-                  surface: "tui",
-                  platform: "local_tui",
-                },
-                runtimeControl: {
-                  allowed: true,
-                  approvalMode: "interactive",
-                },
-                metadata: {
-                  run_spec_id: savedRunSpec.id,
-                  run_spec_profile: savedRunSpec.profile,
-                  run_spec_status: savedRunSpec.status,
-                },
-                replyTarget: {
-                  surface: "tui",
-                  channel: "tui",
-                  platform: "local_tui",
-                  metadata: {
-                    run_spec_id: savedRunSpec.id,
-                    run_spec_profile: savedRunSpec.profile,
-                    run_spec_status: savedRunSpec.status,
-                  },
-                },
-                cwd: effectiveCwd,
-              }, effectiveCwd);
             } else {
               await chatRunner.execute(input, effectiveCwd);
             }
@@ -710,7 +730,7 @@ export function App({
         setIsProcessing(false);
       }
     },
-    [intentRecognizer, actionHandler, chatRunner, daemonClient, isDaemonMode, daemonLoopState.goalId, startLoop, stopLoop, isProcessing, cwd, stateManager]
+    [intentRecognizer, actionHandler, chatRunner, daemonClient, isDaemonMode, daemonLoopState.goalId, startLoop, stopLoop, isProcessing, cwd, stateManager, pendingRunSpec]
   );
 
   // goalCount: 1 when there is an active goal in the loop, 0 otherwise

--- a/src/interface/tui/chat-surface.ts
+++ b/src/interface/tui/chat-surface.ts
@@ -7,6 +7,7 @@ import type { CrossPlatformIngressMessage } from "../chat/cross-platform-session
 export interface TuiChatSurface {
   onEvent?: ChatEventHandler;
   startSession(cwd: string): void;
+  getConversationId?(): string;
   execute(input: string, cwd: string): Promise<ChatRunResult>;
   interruptAndRedirect(input: string, cwd: string): Promise<ChatRunResult>;
   executeIngressMessage(ingress: CrossPlatformIngressMessage, cwd: string): Promise<ChatRunResult>;
@@ -25,6 +26,10 @@ export class SharedManagerTuiChatSurface implements TuiChatSurface {
 
   startSession(cwd: string): void {
     this.sessionCwd = cwd;
+  }
+
+  getConversationId(): string {
+    return this.conversationId;
   }
 
   execute(input: string, cwd: string): Promise<ChatRunResult> {

--- a/src/runtime/run-spec/__tests__/run-spec.test.ts
+++ b/src/runtime/run-spec/__tests__/run-spec.test.ts
@@ -4,6 +4,10 @@ import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 import { deriveRunSpecFromText, recognizeRunSpecIntent } from "../derive.js";
 import { createRunSpecStore } from "../store.js";
+import {
+  formatRunSpecSetupProposal,
+  handleRunSpecConfirmationInput,
+} from "../confirmation.js";
 
 const NOW = new Date("2026-05-02T00:00:00.000Z");
 
@@ -134,5 +138,86 @@ describe("RunSpecStore", () => {
 
     await expect(store.save({ ...spec!, id: "../sessions/foo" })).rejects.toThrow();
     await expect(store.load("../sessions/foo")).rejects.toThrow();
+  });
+});
+
+describe("RunSpec confirmation", () => {
+  it("confirms a complete RunSpec", () => {
+    const spec = deriveRunSpecFromText(
+      "Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.",
+      {
+        cwd: "/repo/kaggle",
+        now: NOW,
+      },
+    );
+    expect(spec).not.toBeNull();
+
+    const result = handleRunSpecConfirmationInput(spec!, "confirm", { now: NOW });
+
+    expect(result.kind).toBe("confirmed");
+    expect(result.spec.status).toBe("confirmed");
+  });
+
+  it("revises missing required fields before confirmation", () => {
+    const spec = deriveRunSpecFromText("Run a long-running Kaggle experiment for top 20%.", {
+      now: NOW,
+    });
+    expect(spec).not.toBeNull();
+
+    const revisedWorkspace = handleRunSpecConfirmationInput(spec!, "workspace /repo/kaggle", { now: NOW });
+    expect(revisedWorkspace.kind).toBe("revised");
+    expect(revisedWorkspace.spec.workspace).toMatchObject({ path: "/repo/kaggle", source: "user" });
+
+    const revisedDeadline = handleRunSpecConfirmationInput(revisedWorkspace.spec, "deadline tomorrow morning", { now: NOW });
+    expect(revisedDeadline.kind).toBe("revised");
+    expect(revisedDeadline.spec.deadline).toMatchObject({ raw: "tomorrow morning" });
+
+    const confirmed = handleRunSpecConfirmationInput(revisedDeadline.spec, "confirm", { now: NOW });
+    expect(confirmed.kind).toBe("confirmed");
+  });
+
+  it("cancels a pending RunSpec", () => {
+    const spec = deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
+      cwd: "/repo/kaggle",
+      now: NOW,
+    });
+    expect(spec).not.toBeNull();
+
+    const result = handleRunSpecConfirmationInput(spec!, "cancel", { now: NOW });
+
+    expect(result.kind).toBe("cancelled");
+    expect(result.spec.status).toBe("cancelled");
+  });
+
+  it("blocks confirmation while required fields remain unresolved", () => {
+    const spec = deriveRunSpecFromText("Run a long-running Kaggle experiment for top 20%.", {
+      now: NOW,
+    });
+    expect(spec).not.toBeNull();
+
+    const result = handleRunSpecConfirmationInput(spec!, "confirm", { now: NOW });
+
+    expect(result.kind).toBe("blocked");
+    expect(result.message).toContain("Which local or remote workspace");
+    expect(result.message).toContain("What deadline or review time");
+  });
+
+  it("shows risky external actions as approval-gated in the proposal", () => {
+    const spec = deriveRunSpecFromText(
+      "Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.",
+      {
+        cwd: "/repo/kaggle",
+        now: NOW,
+      },
+    );
+    expect(spec).not.toBeNull();
+
+    const proposal = formatRunSpecSetupProposal(spec!);
+
+    expect(proposal).toContain("Submit policy: approval_required");
+    expect(proposal).toContain("Publish policy: unspecified");
+    expect(proposal).toContain("External actions: approval_required");
+    expect(proposal).toContain("Secret policy: approval_required");
+    expect(proposal).toContain("Irreversible actions: approval_required");
   });
 });

--- a/src/runtime/run-spec/confirmation.ts
+++ b/src/runtime/run-spec/confirmation.ts
@@ -1,0 +1,207 @@
+import type { RunSpec, RunSpecDeadline, RunSpecMissingField } from "./types.js";
+import { RunSpecSchema } from "./types.js";
+
+export type RunSpecConfirmationResult =
+  | { kind: "confirmed"; spec: RunSpec; message: string }
+  | { kind: "cancelled"; spec: RunSpec; message: string }
+  | { kind: "revised"; spec: RunSpec; message: string }
+  | { kind: "blocked"; spec: RunSpec; message: string }
+  | { kind: "unrecognized"; spec: RunSpec; message: string };
+
+export interface RunSpecConfirmationContext {
+  now?: Date;
+  timezone?: string;
+}
+
+export function formatRunSpecSetupProposal(spec: RunSpec): string {
+  const lines = [
+    `Proposed long-running run: ${spec.id}`,
+    `Profile: ${spec.profile}`,
+    `Objective: ${spec.objective}`,
+    `Workspace: ${spec.workspace?.path ?? "unresolved"}`,
+    `Execution: ${spec.execution_target.kind}${spec.execution_target.remote_host ? ` (${spec.execution_target.remote_host})` : ""}`,
+    `Progress: ${spec.progress_contract.semantics}`,
+  ];
+  if (spec.metric) {
+    lines.push(`Metric: ${spec.metric.name} (${spec.metric.direction})`);
+  }
+  if (spec.deadline) {
+    lines.push(`Deadline: ${spec.deadline.raw}${spec.deadline.iso_at ? ` (${spec.deadline.iso_at})` : ""}`);
+  }
+  lines.push(`Submit policy: ${spec.approval_policy.submit}`);
+  lines.push(`Publish policy: ${spec.approval_policy.publish}`);
+  lines.push(`External actions: ${spec.approval_policy.external_action}`);
+  lines.push(`Secret policy: ${spec.approval_policy.secret}`);
+  lines.push(`Irreversible actions: ${spec.approval_policy.irreversible_action}`);
+  if (spec.missing_fields.length > 0) {
+    lines.push("Questions:", ...spec.missing_fields.map((field) => `- ${field.question}`));
+  }
+  return lines.join("\n");
+}
+
+export function handleRunSpecConfirmationInput(
+  spec: RunSpec,
+  input: string,
+  context: RunSpecConfirmationContext = {},
+): RunSpecConfirmationResult {
+  const trimmed = input.trim();
+  const now = context.now ?? new Date();
+
+  if (/^(cancel|abort|stop|やめる|キャンセル)$/i.test(trimmed)) {
+    const cancelled = updateSpec(spec, { status: "cancelled", updated_at: now.toISOString() });
+    return { kind: "cancelled", spec: cancelled, message: `RunSpec cancelled: ${cancelled.id}` };
+  }
+
+  if (/^(confirm|start|start run|approve|ok|yes|開始|承認)$/i.test(trimmed)) {
+    const required = requiredMissingFields(spec);
+    if (required.length > 0) {
+      return {
+        kind: "blocked",
+        spec,
+        message: formatMissingFieldsMessage(required),
+      };
+    }
+    const confirmed = updateSpec(spec, { status: "confirmed", updated_at: now.toISOString() });
+    return { kind: "confirmed", spec: confirmed, message: `RunSpec confirmed: ${confirmed.id}` };
+  }
+
+  const revised = applyRunSpecRevision(spec, trimmed, {
+    now,
+    timezone: context.timezone,
+  });
+  if (revised) {
+    return {
+      kind: "revised",
+      spec: revised,
+      message: formatRunSpecSetupProposal(revised),
+    };
+  }
+
+  return {
+    kind: "unrecognized",
+    spec,
+    message: [
+      "RunSpec is awaiting confirmation.",
+      "Use confirm, cancel, or revise with a workspace, deadline, or metric direction.",
+      formatMissingFieldsMessage(requiredMissingFields(spec)),
+    ].filter(Boolean).join("\n"),
+  };
+}
+
+export function requiredMissingFields(spec: RunSpec): RunSpecMissingField[] {
+  return spec.missing_fields.filter((field) => field.severity === "required");
+}
+
+export function applyRunSpecRevision(
+  spec: RunSpec,
+  input: string,
+  context: RunSpecConfirmationContext = {},
+): RunSpec | null {
+  const now = context.now ?? new Date();
+  const updates: Partial<RunSpec> = {
+    updated_at: now.toISOString(),
+  };
+  let changed = false;
+  let missingFields = [...spec.missing_fields];
+
+  const workspace = parseWorkspace(input);
+  if (workspace) {
+    updates.workspace = {
+      path: workspace,
+      source: "user",
+      confidence: "high",
+    };
+    missingFields = removeMissing(missingFields, "workspace");
+    changed = true;
+  }
+
+  const deadline = parseDeadline(input, now, context.timezone);
+  if (deadline) {
+    updates.deadline = deadline;
+    updates.budget = {
+      ...spec.budget,
+      max_wall_clock_minutes: deadline.iso_at ? minutesUntil(now, new Date(deadline.iso_at)) : spec.budget.max_wall_clock_minutes,
+      resident_policy: "until_deadline",
+    };
+    missingFields = removeMissing(missingFields, "deadline");
+    changed = true;
+  }
+
+  const metricDirection = parseMetricDirection(input);
+  if (metricDirection && spec.metric) {
+    updates.metric = {
+      ...spec.metric,
+      direction: metricDirection,
+      confidence: "high",
+    };
+    missingFields = removeMissing(missingFields, "metric.direction");
+    changed = true;
+  }
+
+  if (!changed) return null;
+  return updateSpec(spec, {
+    ...updates,
+    missing_fields: missingFields,
+  });
+}
+
+function updateSpec(spec: RunSpec, updates: Partial<RunSpec>): RunSpec {
+  return RunSpecSchema.parse({
+    ...spec,
+    ...updates,
+  });
+}
+
+function removeMissing(fields: RunSpecMissingField[], field: string): RunSpecMissingField[] {
+  return fields.filter((entry) => entry.field !== field);
+}
+
+function parseWorkspace(input: string): string | null {
+  return input.match(/(?:workspace|cwd|directory|dir|repo|path)\s+((?:~|\/)[^\s,]+)/i)?.[1]
+    ?? input.match(/(?:ワークスペース|ディレクトリ|リポジトリ)\s*((?:~|\/)[^\s,]+)/i)?.[1]
+    ?? null;
+}
+
+function parseMetricDirection(input: string): "maximize" | "minimize" | null {
+  if (/\b(maximi[sz]e|higher|increase)\b|最大|上げ|高く/i.test(input)) return "maximize";
+  if (/\b(minimi[sz]e|lower|decrease|reduce)\b|最小|下げ|低く/i.test(input)) return "minimize";
+  return null;
+}
+
+function parseDeadline(input: string, now: Date, timezone: string | undefined): RunSpecDeadline | null {
+  const lower = input.toLowerCase();
+  if (lower.includes("tomorrow morning") || /明日.*(朝|午前)/.test(input)) {
+    const at = new Date(now);
+    at.setDate(at.getDate() + 1);
+    at.setHours(9, 0, 0, 0);
+    return {
+      raw: lower.includes("tomorrow morning") ? "tomorrow morning" : "明日朝",
+      iso_at: at.toISOString(),
+      timezone: timezone ?? null,
+      finalization_buffer_minutes: 60,
+      confidence: "medium",
+    };
+  }
+  const hoursMatch = input.match(/\b(?:for|within|deadline)\s+(\d+)\s*(hours?|hrs?)\b/i);
+  if (!hoursMatch) return null;
+  const at = new Date(now.getTime() + Number(hoursMatch[1]) * 60 * 60 * 1000);
+  return {
+    raw: hoursMatch[0],
+    iso_at: at.toISOString(),
+    timezone: timezone ?? null,
+    finalization_buffer_minutes: 30,
+    confidence: "medium",
+  };
+}
+
+function formatMissingFieldsMessage(fields: RunSpecMissingField[]): string {
+  if (fields.length === 0) return "";
+  return [
+    "Run cannot start until required fields are resolved:",
+    ...fields.map((field) => `- ${field.question}`),
+  ].join("\n");
+}
+
+function minutesUntil(from: Date, to: Date): number {
+  return Math.max(0, Math.round((to.getTime() - from.getTime()) / 60_000));
+}

--- a/src/runtime/run-spec/index.ts
+++ b/src/runtime/run-spec/index.ts
@@ -1,6 +1,13 @@
 export { deriveRunSpecFromText, recognizeRunSpecIntent, type RunSpecIntent } from "./derive.js";
 export { createRunSpecStore, RunSpecStore } from "./store.js";
 export {
+  applyRunSpecRevision,
+  formatRunSpecSetupProposal,
+  handleRunSpecConfirmationInput,
+  requiredMissingFields,
+  type RunSpecConfirmationResult,
+} from "./confirmation.js";
+export {
   RunSpecSchema,
   RunSpecIdSchema,
   RunSpecProfileSchema,


### PR DESCRIPTION
Closes #848

## Summary
- Add RunSpec confirmation helpers for compact proposals, required-field blocking, targeted revisions, confirm, and cancel.
- Update the TUI long-running path to persist a pending RunSpec and wait for explicit confirmation before forwarding to ChatRunner/runtime handoff.
- Persist cancelled/revised/confirmed RunSpecs, and include TUI conversation context in RunSpec links/metadata.
- Surface approval-gated submit, publish, external action, secret, and irreversible-action policies before confirmation.

## Verification
- `npm run typecheck`
- `npm run lint:boundaries`
- `npx vitest run --config vitest.unit.config.ts src/interface/chat/__tests__/ingress-router.test.ts`
- `npx vitest run --config vitest.integration.config.ts src/runtime/run-spec/__tests__/run-spec.test.ts src/interface/tui/__tests__/app.test.ts`
- `npm run test:changed`
- `git diff --check`
- `npm run test:all`

## Known unresolved risks
- Confirmed RunSpecs are linked to the TUI conversation and forwarded as ChatRunner ingress metadata; direct CoreLoop goal/runtime-session id backfill remains a follow-up once the start path returns a typed created-session record.
- Revision parsing is intentionally narrow for this slice: workspace, deadline, and metric direction only.
