### PR TITLE
feat(tui): show runtime work dashboard

### DIFF
--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { act } from "react";
 import { render } from "ink";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DaemonClient } from "../../../runtime/daemon/client.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { TuiChatSurface } from "../chat-surface.js";
-import { App, formatDaemonConnectionState } from "../app.js";
+import { App, DASHBOARD_REFRESH_INTERVAL_MS, formatDaemonConnectionState } from "../app.js";
 
 const testState = vi.hoisted(() => ({
   lastChatProps: null as null | { onSubmit: (value: string) => Promise<void> },
@@ -12,6 +12,9 @@ const testState = vi.hoisted(() => ({
     task: { work_description: string; rationale: string; goal_id: string };
     onDecision: (approved: boolean) => void;
   },
+  lastDashboardProps: null as null | Record<string, unknown>,
+  runtimeSessionSnapshots: [] as Array<Record<string, unknown>>,
+  runtimeSessionSnapshotCalls: 0,
 }));
 
 vi.mock("ink", async () => {
@@ -42,8 +45,24 @@ vi.mock("../fullscreen-chat.js", async () => {
 });
 
 vi.mock("../dashboard.js", () => ({
-  Dashboard: () => null,
+  Dashboard: (props: Record<string, unknown>) => {
+    testState.lastDashboardProps = props;
+    return null;
+  },
   statusLabel: (status: string) => status,
+}));
+
+vi.mock("../../../runtime/session-registry/index.js", () => ({
+  createRuntimeSessionRegistry: () => ({
+    snapshot: vi.fn(async () => {
+      const index = Math.min(
+        testState.runtimeSessionSnapshotCalls,
+        Math.max(0, testState.runtimeSessionSnapshots.length - 1),
+      );
+      testState.runtimeSessionSnapshotCalls += 1;
+      return testState.runtimeSessionSnapshots[index] ?? null;
+    }),
+  }),
 }));
 
 vi.mock("../help-overlay.js", () => ({ HelpOverlay: () => null }));
@@ -120,6 +139,7 @@ describe("standalone slash command routing", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -357,9 +377,13 @@ describe("daemon-mode chat routing", () => {
   beforeEach(() => {
     testState.lastChatProps = null;
     testState.lastApprovalProps = null;
+    testState.lastDashboardProps = null;
+    testState.runtimeSessionSnapshots = [];
+    testState.runtimeSessionSnapshotCalls = 0;
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
@@ -510,5 +534,87 @@ describe("daemon-mode chat routing", () => {
     expect(daemonClient.chat).not.toHaveBeenCalled();
 
     screen.unmount();
+  });
+
+  it("refreshes runtime session snapshots while the dashboard remains open", async () => {
+    vi.useFakeTimers();
+    const daemonClient = createDaemonClientMock();
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    testState.runtimeSessionSnapshots = [
+      {
+        schema_version: "runtime-session-registry-v1",
+        generated_at: "2026-05-02T00:00:00.000Z",
+        sessions: [],
+        background_runs: [],
+        warnings: [],
+      },
+      {
+        schema_version: "runtime-session-registry-v1",
+        generated_at: "2026-05-02T00:00:05.000Z",
+        sessions: [],
+        background_runs: [{
+          schema_version: "background-run-v1",
+          id: "run-refresh",
+          kind: "coreloop_run",
+          parent_session_id: null,
+          child_session_id: null,
+          process_session_id: null,
+          status: "running",
+          notify_policy: "done_only",
+          reply_target_source: "none",
+          pinned_reply_target: null,
+          title: "Refreshed work",
+          workspace: "/repo",
+          created_at: "2026-05-02T00:00:00.000Z",
+          started_at: "2026-05-02T00:00:00.000Z",
+          updated_at: "2026-05-02T00:00:05.000Z",
+          completed_at: null,
+          summary: null,
+          error: null,
+          artifacts: [],
+          source_refs: [],
+        }],
+        warnings: [],
+      },
+    ];
+
+    const screen = render(React.createElement(App, {
+      daemonClient: daemonClient as unknown as DaemonClient,
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("/dashboard");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(testState.lastDashboardProps?.runtimeSessions).toMatchObject({
+      generated_at: "2026-05-02T00:00:00.000Z",
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DASHBOARD_REFRESH_INTERVAL_MS + 1);
+    });
+
+    expect(testState.runtimeSessionSnapshotCalls).toBeGreaterThanOrEqual(2);
+    expect(testState.lastDashboardProps?.runtimeSessions).toMatchObject({
+      generated_at: "2026-05-02T00:00:05.000Z",
+      background_runs: [expect.objectContaining({ id: "run-refresh" })],
+    });
+
+    screen.unmount();
+    vi.useRealTimers();
   });
 });

--- a/src/interface/tui/__tests__/dashboard.test.ts
+++ b/src/interface/tui/__tests__/dashboard.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { buildWorkDashboardRows } from "../dashboard.js";
+import type {
+  BackgroundRun,
+  RuntimeSession,
+  RuntimeSessionRegistrySnapshot,
+} from "../../../runtime/session-registry/types.js";
+
+const NOW = new Date("2026-05-02T00:00:00.000Z");
+
+function session(overrides: Partial<RuntimeSession>): RuntimeSession {
+  return {
+    schema_version: "runtime-session-v1",
+    id: "session-1",
+    kind: "agent",
+    parent_session_id: null,
+    title: "Agent session",
+    workspace: "/repo",
+    status: "active",
+    created_at: "2026-05-01T23:00:00.000Z",
+    updated_at: "2026-05-01T23:55:00.000Z",
+    last_event_at: "2026-05-01T23:55:00.000Z",
+    transcript_ref: null,
+    state_ref: null,
+    reply_target: null,
+    resumable: true,
+    attachable: true,
+    source_refs: [],
+    ...overrides,
+  };
+}
+
+function run(overrides: Partial<BackgroundRun>): BackgroundRun {
+  return {
+    schema_version: "background-run-v1",
+    id: "run-1",
+    kind: "coreloop_run",
+    parent_session_id: null,
+    child_session_id: null,
+    process_session_id: null,
+    status: "running",
+    notify_policy: "done_only",
+    reply_target_source: "none",
+    pinned_reply_target: null,
+    title: "Benchmark run",
+    workspace: "/repo",
+    created_at: "2026-05-01T23:00:00.000Z",
+    started_at: "2026-05-01T23:30:00.000Z",
+    updated_at: "2026-05-01T23:58:00.000Z",
+    completed_at: null,
+    summary: null,
+    error: null,
+    artifacts: [],
+    source_refs: [],
+    ...overrides,
+  };
+}
+
+function snapshot(params: {
+  sessions?: RuntimeSession[];
+  background_runs?: BackgroundRun[];
+}): RuntimeSessionRegistrySnapshot {
+  return {
+    schema_version: "runtime-session-registry-v1",
+    generated_at: NOW.toISOString(),
+    sessions: params.sessions ?? [],
+    background_runs: params.background_runs ?? [],
+    warnings: [],
+  };
+}
+
+describe("buildWorkDashboardRows", () => {
+  it("shows active sessions and running runs as active work", () => {
+    const rows = buildWorkDashboardRows(snapshot({
+      sessions: [session({ id: "session-active" })],
+      background_runs: [run({ id: "run-active" })],
+    }), NOW);
+
+    expect(rows.map((row) => [row.id, row.group, row.attention])).toEqual([
+      ["run-active", "active", false],
+      ["session-active", "active", false],
+    ]);
+  });
+
+  it("shows recently completed runs as recent work", () => {
+    const rows = buildWorkDashboardRows(snapshot({
+      background_runs: [run({
+        id: "run-done",
+        status: "succeeded",
+        completed_at: "2026-05-01T23:50:00.000Z",
+        updated_at: "2026-05-01T23:50:00.000Z",
+      })],
+    }), NOW);
+
+    expect(rows).toMatchObject([
+      {
+        id: "run-done",
+        group: "recent",
+        attention: false,
+      },
+    ]);
+  });
+
+  it("does not show stale current sessions as active work", () => {
+    const rows = buildWorkDashboardRows(snapshot({
+      sessions: [session({
+        id: "session-stale",
+        status: "active",
+        last_event_at: "2026-05-01T21:00:00.000Z",
+        updated_at: "2026-05-01T21:00:00.000Z",
+      })],
+    }), NOW);
+
+    expect(rows).toMatchObject([
+      {
+        id: "session-stale",
+        group: "recent",
+        status: "stale",
+        attention: true,
+      },
+    ]);
+  });
+
+  it("marks attention-needed run states separately from normal work", () => {
+    const rows = buildWorkDashboardRows(snapshot({
+      background_runs: [run({
+        id: "run-failed",
+        status: "failed",
+        completed_at: "2026-05-01T23:40:00.000Z",
+        updated_at: "2026-05-01T23:40:00.000Z",
+        error: "approval-required before submit",
+      })],
+    }), NOW);
+
+    expect(rows).toMatchObject([
+      {
+        id: "run-failed",
+        group: "recent",
+        attention: true,
+        summary: "approval-required before submit",
+      },
+    ]);
+  });
+
+  it("marks waiting blocked and approval-required sessions as attention-needed", () => {
+    const rows = buildWorkDashboardRows(snapshot({
+      sessions: [session({
+        id: "session-waiting-approval",
+        title: "Waiting for approval-required submit",
+        status: "active",
+      })],
+    }), NOW);
+
+    expect(rows).toMatchObject([
+      {
+        id: "session-waiting-approval",
+        group: "active",
+        attention: true,
+      },
+    ]);
+  });
+});

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -37,6 +37,8 @@ import { ShellTool } from "../../tools/system/ShellTool/ShellTool.js";
 import { getPulseedVersion } from "../../base/utils/pulseed-meta.js";
 import { applyChatEventToMessages } from "../chat/chat-event-state.js";
 import { setActiveCursorEscape } from "./cursor-tracker.js";
+import { createRuntimeSessionRegistry } from "../../runtime/session-registry/index.js";
+import type { RuntimeSessionRegistrySnapshot } from "../../runtime/session-registry/types.js";
 import {
   createRunSpecStore,
   deriveRunSpecFromText,
@@ -47,6 +49,7 @@ import {
 
 const MAX_MESSAGES = 200;
 const PULSEED_VERSION = getPulseedVersion(import.meta.url);
+export const DASHBOARD_REFRESH_INTERVAL_MS = 5_000;
 export const APP_HEADER_ROWS = SEEDY_PIXEL.split("\n").length;
 const STATUS_BAR_ROWS = 3;
 
@@ -274,6 +277,7 @@ export function App({
   const termCols = stdout?.columns ?? 80;
   const termRows = stdout?.rows ?? 24;
   const [showSidebar, setShowSidebar] = useState(false);
+  const [runtimeSessionSnapshot, setRuntimeSessionSnapshot] = useState<RuntimeSessionRegistrySnapshot | null>(null);
 
   // ── Loop state ──
   // In standalone mode, useLoop() manages state via CoreLoop.
@@ -409,6 +413,31 @@ export function App({
       onApprovalReady(showApprovalRequest);
     }
   }, [onApprovalReady, showApprovalRequest]);
+
+  useEffect(() => {
+    if (!showSidebar) return;
+    let cancelled = false;
+
+    const refreshRuntimeSessions = async () => {
+      try {
+        const registry = createRuntimeSessionRegistry({ stateManager });
+        const snapshot = await registry.snapshot();
+        if (!cancelled) setRuntimeSessionSnapshot(snapshot);
+      } catch {
+        if (!cancelled) setRuntimeSessionSnapshot(null);
+      }
+    };
+
+    void refreshRuntimeSessions();
+    const interval = setInterval(() => {
+      void refreshRuntimeSessions();
+    }, DASHBOARD_REFRESH_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [showSidebar, stateManager]);
 
   // Start ChatRunner session on mount (standalone mode)
   useEffect(() => {
@@ -787,7 +816,7 @@ export function App({
             paddingX={1}
             overflow="hidden"
           >
-            <Dashboard state={loopState} />
+            <Dashboard state={loopState} runtimeSessions={runtimeSessionSnapshot} />
           </Box>
         )}
 

--- a/src/interface/tui/dashboard.tsx
+++ b/src/interface/tui/dashboard.tsx
@@ -3,18 +3,149 @@ import { Box, Text } from "ink";
 import { CheckerboardSpinner } from "./checkerboard-spinner.js";
 import type { LoopState, DimensionProgress } from "./use-loop.js";
 import { theme, statusColor, progressColor } from "./theme.js";
+import type {
+  BackgroundRun,
+  RuntimeSession,
+  RuntimeSessionRegistrySnapshot,
+} from "../../runtime/session-registry/types.js";
 
 interface DashboardProps {
   state: LoopState;
   maxIterations?: number;
+  runtimeSessions?: RuntimeSessionRegistrySnapshot | null;
 }
 
 const BAR_WIDTH = 20;
+const CURRENT_STALE_MS = 60 * 60 * 1000;
+const RECENT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+export type WorkDashboardRowKind = "session" | "run";
+export type WorkDashboardRowGroup = "active" | "recent";
+
+export interface WorkDashboardRow {
+  kind: WorkDashboardRowKind;
+  group: WorkDashboardRowGroup;
+  id: string;
+  title: string;
+  status: string;
+  summary: string;
+  updatedAt: string | null;
+  workspace: string | null;
+  attention: boolean;
+  stale: boolean;
+}
 
 function renderBar(progress: number): string {
   const filled = Math.round((Math.min(100, Math.max(0, progress)) / 100) * BAR_WIDTH);
   const empty = BAR_WIDTH - filled;
   return "█".repeat(filled) + "░".repeat(empty);
+}
+
+function timestampMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function latestSessionTime(session: RuntimeSession): string | null {
+  return session.last_event_at ?? session.updated_at ?? session.created_at;
+}
+
+function latestRunTime(run: BackgroundRun): string | null {
+  return run.completed_at ?? run.updated_at ?? run.started_at ?? run.created_at;
+}
+
+function isStaleCurrent(updatedAt: string | null, now: Date): boolean {
+  const ms = timestampMs(updatedAt);
+  if (ms === null) return true;
+  return now.getTime() - ms > CURRENT_STALE_MS;
+}
+
+function isRecent(updatedAt: string | null, now: Date): boolean {
+  const ms = timestampMs(updatedAt);
+  if (ms === null) return false;
+  return now.getTime() - ms <= RECENT_WINDOW_MS;
+}
+
+function sessionAttention(session: RuntimeSession, stale: boolean): boolean {
+  const attentionText = [
+    session.title,
+    session.id,
+    session.reply_target ? JSON.stringify(session.reply_target) : null,
+    ...session.source_refs.flatMap((ref) => [ref.id, ref.relative_path]),
+  ].filter(Boolean).join(" ");
+  return stale
+    || session.status === "lost"
+    || session.status === "unknown"
+    || /approval[-_ ]required|blocked|waiting/i.test(attentionText);
+}
+
+function runAttention(run: BackgroundRun): boolean {
+  return run.status === "failed"
+    || run.status === "timed_out"
+    || run.status === "lost"
+    || run.status === "unknown"
+    || /approval[-_ ]required|blocked|waiting/i.test(`${run.summary ?? ""} ${run.error ?? ""}`);
+}
+
+function compact(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
+export function buildWorkDashboardRows(
+  snapshot: RuntimeSessionRegistrySnapshot | null | undefined,
+  now: Date = new Date(),
+): WorkDashboardRow[] {
+  if (!snapshot) return [];
+  const rows: WorkDashboardRow[] = [];
+
+  for (const session of snapshot.sessions) {
+    const updatedAt = latestSessionTime(session);
+    const stale = isStaleCurrent(updatedAt, now);
+    const activeState = (session.status === "active" || session.status === "idle") && !stale;
+    const recentState = !activeState && isRecent(updatedAt, now);
+    if (!activeState && !recentState) continue;
+    rows.push({
+      kind: "session",
+      group: activeState ? "active" : "recent",
+      id: session.id,
+      title: compact(session.title, session.id),
+      status: stale ? "stale" : session.status,
+      summary: session.attachable ? "attachable runtime session" : "runtime session",
+      updatedAt,
+      workspace: session.workspace,
+      attention: sessionAttention(session, stale),
+      stale,
+    });
+  }
+
+  for (const run of snapshot.background_runs) {
+    const updatedAt = latestRunTime(run);
+    const stale = isStaleCurrent(updatedAt, now);
+    const activeState = (run.status === "queued" || run.status === "running") && !stale;
+    const terminalState = ["succeeded", "failed", "timed_out", "cancelled", "lost", "unknown"].includes(run.status);
+    const recentState = !activeState && (terminalState || stale) && isRecent(updatedAt, now);
+    if (!activeState && !recentState) continue;
+    rows.push({
+      kind: "run",
+      group: activeState ? "active" : "recent",
+      id: run.id,
+      title: compact(run.title, run.id),
+      status: stale ? "stale" : run.status,
+      summary: compact(run.error ?? run.summary, run.kind),
+      updatedAt,
+      workspace: run.workspace,
+      attention: runAttention(run) || stale,
+      stale,
+    });
+  }
+
+  return rows.sort((a, b) => {
+    if (a.group !== b.group) return a.group === "active" ? -1 : 1;
+    if (a.attention !== b.attention) return a.attention ? -1 : 1;
+    return (timestampMs(b.updatedAt) ?? 0) - (timestampMs(a.updatedAt) ?? 0);
+  });
 }
 
 export function statusLabel(status: string): string {
@@ -57,7 +188,70 @@ function DimensionRow({ dim }: { dim: DimensionProgress }) {
   );
 }
 
-export function Dashboard({ state }: DashboardProps) {
+function formatUpdated(value: string | null): string {
+  if (!value) return "unknown";
+  return value.replace("T", " ").replace(/\.\d{3}Z$/, "Z");
+}
+
+function WorkRow({ row }: { row: WorkDashboardRow }) {
+  const marker = row.attention ? "!" : row.group === "active" ? ">" : "-";
+  const color = row.attention ? theme.warning : row.group === "active" ? theme.success : theme.text;
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text color={color}>
+        {marker} {row.title} <Text dimColor>({row.kind}:{row.id})</Text>
+      </Text>
+      <Text>
+        <Text dimColor>{"  "}{row.group} / </Text>
+        <Text color={color}>{row.status}</Text>
+        <Text dimColor>{" / updated "}{formatUpdated(row.updatedAt)}</Text>
+      </Text>
+      <Text dimColor>{"  "}{row.summary}</Text>
+      {row.workspace && <Text dimColor>{"  "}{row.workspace}</Text>}
+    </Box>
+  );
+}
+
+function WorkDashboard({ rows }: { rows: WorkDashboardRow[] }) {
+  const activeRows = rows.filter((row) => row.group === "active");
+  const recentRows = rows.filter((row) => row.group === "recent").slice(0, 6);
+  const attentionRows = rows.filter((row) => row.attention);
+  return (
+    <Box flexDirection="column" paddingX={1} paddingY={1} overflow="hidden">
+      <Text bold color={theme.brand}>Work Dashboard</Text>
+      <Text dimColor>
+        Active {activeRows.length}  Recent {recentRows.length}  Attention {attentionRows.length}
+      </Text>
+      <Text> </Text>
+      {attentionRows.length > 0 && (
+        <>
+          <Text color={theme.warning}>Attention needed</Text>
+          {attentionRows.slice(0, 4).map((row) => <WorkRow key={`${row.kind}:${row.id}`} row={row} />)}
+        </>
+      )}
+      <Text color={theme.success}>Active work</Text>
+      {activeRows.length === 0 ? (
+        <Text dimColor>{"  No active background work."}</Text>
+      ) : (
+        activeRows.slice(0, 6).map((row) => <WorkRow key={`${row.kind}:${row.id}`} row={row} />)
+      )}
+      <Text> </Text>
+      <Text dimColor>Recent work</Text>
+      {recentRows.length === 0 ? (
+        <Text dimColor>{"  No recent background work."}</Text>
+      ) : (
+        recentRows.map((row) => <WorkRow key={`${row.kind}:${row.id}`} row={row} />)
+      )}
+    </Box>
+  );
+}
+
+export function Dashboard({ state, runtimeSessions }: DashboardProps) {
+  const workRows = buildWorkDashboardRows(runtimeSessions);
+  if (workRows.length > 0) {
+    return <WorkDashboard rows={workRows} />;
+  }
+
   if (state.status === "idle") {
     return (
       <Box


### PR DESCRIPTION
Closes #743

## Summary
- Add a Runtime Session Catalog-backed work dashboard for active and recent background work in the TUI `d` sidebar.
- Demote stale active records into recent attention rows instead of showing them as current work.
- Distinguish attention-needed work for stale/lost/unknown sessions, failed/timed-out/lost/unknown runs, and waiting/blocked/approval-required evidence.
- Refresh the catalog snapshot while the dashboard remains open.

## Verification
- `npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/dashboard.test.ts src/interface/tui/__tests__/app.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed`
- `npm run test:all`

## Known unresolved risks
- This PR is scoped to the dashboard foundation; #849 will add selected-session operator console details and controls.
- Session attention state is inferred from current Runtime Session Catalog fields because session status does not yet expose typed waiting/blocked/approval-required values.