### PR TITLE
feat(tui): add runtime operator console

### DIFF
--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -15,6 +15,7 @@ const testState = vi.hoisted(() => ({
   lastDashboardProps: null as null | Record<string, unknown>,
   runtimeSessionSnapshots: [] as Array<Record<string, unknown>>,
   runtimeSessionSnapshotCalls: 0,
+  summarizedRunIds: [] as string[],
 }));
 
 vi.mock("ink", async () => {
@@ -44,13 +45,17 @@ vi.mock("../fullscreen-chat.js", async () => {
   };
 });
 
-vi.mock("../dashboard.js", () => ({
-  Dashboard: (props: Record<string, unknown>) => {
-    testState.lastDashboardProps = props;
-    return null;
-  },
-  statusLabel: (status: string) => status,
-}));
+vi.mock("../dashboard.js", async () => {
+  const actual = await vi.importActual<typeof import("../dashboard.js")>("../dashboard.js");
+  return {
+    ...actual,
+    Dashboard: (props: Record<string, unknown>) => {
+      testState.lastDashboardProps = props;
+      return null;
+    },
+    statusLabel: (status: string) => status,
+  };
+});
 
 vi.mock("../../../runtime/session-registry/index.js", () => ({
   createRuntimeSessionRegistry: () => ({
@@ -63,6 +68,21 @@ vi.mock("../../../runtime/session-registry/index.js", () => ({
       return testState.runtimeSessionSnapshots[index] ?? null;
     }),
   }),
+}));
+
+vi.mock("../../../runtime/store/health-store.js", () => ({
+  RuntimeHealthStore: class {
+    loadSnapshot = vi.fn(async () => null);
+  },
+}));
+
+vi.mock("../../../runtime/store/evidence-ledger.js", () => ({
+  RuntimeEvidenceLedger: class {
+    summarizeRun = vi.fn(async (runId: string) => {
+      testState.summarizedRunIds.push(runId);
+      return null;
+    });
+  },
 }));
 
 vi.mock("../help-overlay.js", () => ({ HelpOverlay: () => null }));
@@ -380,6 +400,7 @@ describe("daemon-mode chat routing", () => {
     testState.lastDashboardProps = null;
     testState.runtimeSessionSnapshots = [];
     testState.runtimeSessionSnapshotCalls = 0;
+    testState.summarizedRunIds = [];
   });
 
   afterEach(() => {
@@ -613,6 +634,93 @@ describe("daemon-mode chat routing", () => {
       generated_at: "2026-05-02T00:00:05.000Z",
       background_runs: [expect.objectContaining({ id: "run-refresh" })],
     });
+
+    screen.unmount();
+    vi.useRealTimers();
+  });
+
+  it("loads evidence summaries for dashboard-selected runs instead of raw snapshot head", async () => {
+    vi.useFakeTimers();
+    const daemonClient = createDaemonClientMock();
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const now = new Date().toISOString();
+    const completedRuns = Array.from({ length: 9 }, (_, index) => ({
+      schema_version: "background-run-v1",
+      id: `run-completed-${index}`,
+      kind: "coreloop_run",
+      parent_session_id: null,
+      child_session_id: null,
+      process_session_id: null,
+      status: "succeeded",
+      notify_policy: "done_only",
+      reply_target_source: "none",
+      pinned_reply_target: null,
+      title: `Completed ${index}`,
+      workspace: "/repo",
+      created_at: now,
+      started_at: now,
+      updated_at: now,
+      completed_at: now,
+      summary: null,
+      error: null,
+      artifacts: [],
+      source_refs: [],
+    }));
+    testState.runtimeSessionSnapshots = [{
+      schema_version: "runtime-session-registry-v1",
+      generated_at: now,
+      sessions: [],
+      background_runs: [
+        ...completedRuns,
+        {
+          schema_version: "background-run-v1",
+          id: "run-active-selected",
+          kind: "coreloop_run",
+          parent_session_id: null,
+          child_session_id: null,
+          process_session_id: null,
+          status: "running",
+          notify_policy: "done_only",
+          reply_target_source: "none",
+          pinned_reply_target: null,
+          title: "Active selected run",
+          workspace: "/repo",
+          created_at: now,
+          started_at: now,
+          updated_at: now,
+          completed_at: null,
+          summary: null,
+          error: null,
+          artifacts: [],
+          source_refs: [],
+        },
+      ],
+      warnings: [],
+    }];
+
+    const screen = render(React.createElement(App, {
+      daemonClient: daemonClient as unknown as DaemonClient,
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await vi.runOnlyPendingTimersAsync();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("/dashboard");
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(testState.summarizedRunIds).toContain("run-active-selected");
 
     screen.unmount();
     vi.useRealTimers();

--- a/src/interface/tui/__tests__/dashboard.test.ts
+++ b/src/interface/tui/__tests__/dashboard.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { buildWorkDashboardRows } from "../dashboard.js";
+import { buildOperatorConsoleModel, buildWorkDashboardRows } from "../dashboard.js";
 import type {
   BackgroundRun,
   RuntimeSession,
   RuntimeSessionRegistrySnapshot,
 } from "../../../runtime/session-registry/types.js";
+import type { RuntimeEvidenceSummary } from "../../../runtime/store/evidence-ledger.js";
+import type { RuntimeHealthSnapshot } from "../../../runtime/store/runtime-schemas.js";
 
 const NOW = new Date("2026-05-02T00:00:00.000Z");
 
@@ -66,6 +68,104 @@ function snapshot(params: {
     sessions: params.sessions ?? [],
     background_runs: params.background_runs ?? [],
     warnings: [],
+  };
+}
+
+function health(overrides: Partial<RuntimeHealthSnapshot["long_running"]> = {}): RuntimeHealthSnapshot {
+  const checkedAt = NOW.getTime();
+  return {
+    status: "ok",
+    leader: true,
+    checked_at: checkedAt,
+    components: {
+      gateway: "ok",
+      queue: "ok",
+      leases: "ok",
+      approval: "ok",
+      outbox: "ok",
+      supervisor: "ok",
+    },
+    long_running: {
+      summary: "alive_and_progressing",
+      checked_at: checkedAt,
+      signals: {
+        process: { status: "alive", checked_at: checkedAt },
+        child_activity: { status: "active", active_count: 1, checked_at: checkedAt },
+        log_freshness: { status: "fresh", checked_at: checkedAt },
+        artifact_freshness: { status: "fresh", checked_at: checkedAt },
+        metric_freshness: { status: "fresh", metric_name: "score", checked_at: checkedAt },
+        metric_progress: { status: "improved", metric_name: "score", previous_value: 0.8, current_value: 0.84, checked_at: checkedAt },
+        blocker: { status: "none", checked_at: checkedAt },
+      },
+      ...overrides,
+    },
+  };
+}
+
+function evidenceSummary(overrides: Partial<RuntimeEvidenceSummary> = {}): RuntimeEvidenceSummary {
+  return {
+    schema_version: "runtime-evidence-summary-v1",
+    generated_at: NOW.toISOString(),
+    scope: { run_id: "run-1" },
+    total_entries: 1,
+    latest_strategy: null,
+    best_evidence: null,
+    metric_trends: [],
+    evaluator_summary: {
+      local_best: null,
+      external_best: null,
+      gap: null,
+      budgets: [],
+      calibration: [],
+      approval_required_actions: [],
+      observations: [],
+    },
+    research_memos: [],
+    dream_checkpoints: [],
+    divergent_exploration: [],
+    candidate_lineages: [],
+    recommended_candidate_portfolio: [],
+    candidate_selection_summary: {
+      primary_metric: null,
+      raw_best: null,
+      robust_best: null,
+      ranked: [],
+      final_portfolio: {
+        safe: null,
+        aggressive: null,
+        diverse: null,
+      },
+    },
+    near_miss_candidates: [],
+    artifact_retention: {
+      schema_version: "runtime-artifact-retention-summary-v1",
+      total_artifacts: 0,
+      total_size_bytes: 0,
+      unknown_size_count: 0,
+      protected_count: 0,
+      by_retention_class: {
+        final_deliverable: 0,
+        best_candidate: 0,
+        robust_candidate: 0,
+        near_miss: 0,
+        reproducibility_critical: 0,
+        evidence_report: 0,
+        low_value_smoke: 0,
+        cache_intermediate: 0,
+        duplicate_superseded: 0,
+        other: 0,
+      },
+      cleanup_plan: {
+        mode: "plan_only",
+        destructive_actions_default: "approval_required",
+        actions: [],
+      },
+    },
+    recent_failed_attempts: [],
+    failed_lineages: [],
+    recent_entries: [],
+    warnings: [],
+    ...overrides,
   };
 }
 
@@ -158,5 +258,195 @@ describe("buildWorkDashboardRows", () => {
         attention: true,
       },
     ]);
+  });
+});
+
+describe("buildOperatorConsoleModel", () => {
+  it("separates liveness from metric useful progress for active sessions", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({ id: "run-active" })],
+    }), health(), {
+      "run-active": evidenceSummary(),
+    }, NOW);
+
+    expect(model).toMatchObject({
+      selectedId: "run-active",
+      lifecycle: "running",
+      liveness: expect.stringContaining("alive"),
+      usefulProgress: expect.stringContaining("improved"),
+    });
+  });
+
+  it("shows stale sessions as stale rather than active", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      sessions: [session({
+        id: "session-stale",
+        last_event_at: "2026-05-01T21:00:00.000Z",
+        updated_at: "2026-05-01T21:00:00.000Z",
+      })],
+    }), null, {}, NOW);
+
+    expect(model).toMatchObject({
+      selectedId: "session-stale",
+      lifecycle: "stale",
+      liveness: "stale catalog heartbeat",
+      blockers: ["stale catalog state"],
+    });
+  });
+
+  it("shows blocked approval state distinctly", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({
+        id: "run-approval",
+        summary: "approval-required before submit",
+      })],
+    }), health({
+      summary: "alive_but_waiting",
+      signals: {
+        ...health().long_running!.signals,
+        blocker: { status: "approval_wait", reason: "submit needs operator approval", checked_at: NOW.getTime() },
+      },
+    }), {
+      "run-approval": evidenceSummary({
+        evaluator_summary: {
+          ...evidenceSummary().evaluator_summary,
+          approval_required_actions: [{
+            id: "submit-final",
+            label: "Approve final submission",
+            approval_required: true,
+            status: "approval_required",
+            entry_id: "entry-1",
+            evaluator_id: "kaggle",
+            signal: "external",
+            source: "submit",
+            candidate_id: "candidate-1",
+            observed_at: NOW.toISOString(),
+          }],
+        },
+      }),
+    }, NOW);
+
+    expect(model).toMatchObject({
+      lifecycle: "approval-required",
+      blockers: expect.arrayContaining([
+        "Approve final submission",
+      ]),
+    });
+  });
+
+  it("does not apply daemon aggregate health as selected-run lifecycle or progress", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({
+        id: "run-complete",
+        status: "succeeded",
+        completed_at: "2026-05-01T23:50:00.000Z",
+        updated_at: "2026-05-01T23:50:00.000Z",
+      })],
+    }), health({
+      summary: "alive_but_waiting",
+      signals: {
+        ...health().long_running!.signals,
+        metric_progress: { status: "improved", metric_name: "global_score", current_value: 0.99, checked_at: NOW.getTime() },
+        blocker: { status: "approval_wait", reason: "unrelated run approval", checked_at: NOW.getTime() },
+      },
+    }), {
+      "run-complete": evidenceSummary({
+        metric_trends: [{
+          metric_key: "selected_score",
+          direction: "maximize",
+          trend: "stalled",
+          latest_value: 0.72,
+          latest_observed_at: NOW.toISOString(),
+          best_value: 0.72,
+          best_observed_at: NOW.toISOString(),
+          observation_count: 4,
+          recent_slope_per_observation: 0,
+          best_delta: 0,
+          last_meaningful_improvement_delta: null,
+          last_breakthrough_delta: null,
+          time_since_last_meaningful_improvement_ms: null,
+          improvement_threshold: 0.01,
+          breakthrough_threshold: 0.05,
+          noise_band: 0.005,
+          confidence: 1,
+          source_refs: [],
+          summary: "stalled",
+        }],
+      }),
+    }, NOW);
+
+    expect(model).toMatchObject({
+      lifecycle: "completed",
+      usefulProgress: "selected_score stalled; latest 0.72; best 0.72",
+      blockers: ["No blockers detected."],
+    });
+  });
+
+  it("shows metric progress from evidence when health metric progress is missing", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({ id: "run-metric" })],
+    }), null, {
+      "run-metric": evidenceSummary({
+        metric_trends: [{
+          metric_key: "balanced_accuracy",
+          direction: "maximize",
+          trend: "breakthrough",
+          latest_value: 0.91,
+          latest_observed_at: NOW.toISOString(),
+          best_value: 0.91,
+          best_observed_at: NOW.toISOString(),
+          observation_count: 3,
+          recent_slope_per_observation: 0.02,
+          best_delta: 0.06,
+          last_meaningful_improvement_delta: 0.06,
+          last_breakthrough_delta: 0.06,
+          time_since_last_meaningful_improvement_ms: 0,
+          improvement_threshold: 0.01,
+          breakthrough_threshold: 0.05,
+          noise_band: 0.005,
+          confidence: 1,
+          source_refs: [],
+          summary: "breakthrough",
+        }],
+      }),
+    }, NOW);
+
+    expect(model?.usefulProgress).toBe("balanced_accuracy breakthrough; latest 0.91; best 0.91");
+    expect(model?.metrics).toContain("balanced_accuracy: latest 0.91, best 0.91, breakthrough");
+  });
+
+  it("shows completed session displays", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({
+        id: "run-complete",
+        status: "succeeded",
+        completed_at: "2026-05-01T23:50:00.000Z",
+        updated_at: "2026-05-01T23:50:00.000Z",
+        artifacts: [{ label: "report", path: "/repo/report.md", url: null, kind: "report" }],
+      })],
+    }), null, {}, NOW);
+
+    expect(model).toMatchObject({
+      lifecycle: "completed",
+      artifacts: expect.arrayContaining(["report: /repo/report.md"]),
+    });
+  });
+
+  it("shows failed session displays", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({
+        id: "run-failed",
+        status: "failed",
+        completed_at: "2026-05-01T23:50:00.000Z",
+        updated_at: "2026-05-01T23:50:00.000Z",
+        error: "training crashed",
+      })],
+    }), null, {}, NOW);
+
+    expect(model).toMatchObject({
+      lifecycle: "failed",
+      blockers: expect.arrayContaining(["training crashed"]),
+      latestEvents: expect.arrayContaining(["training crashed"]),
+    });
   });
 });

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -11,9 +11,10 @@
 
 import React, { useState, useCallback, useEffect, useRef } from "react";
 import { randomUUID } from "node:crypto";
+import * as path from "node:path";
 import { Box, Text, useInput, useStdout } from "ink";
 import { theme } from "./theme.js";
-import { Dashboard, statusLabel } from "./dashboard.js";
+import { buildWorkDashboardRows, Dashboard, statusLabel } from "./dashboard.js";
 import { Chat, type ChatMessage } from "./chat.js";
 import { FullscreenChat } from "./fullscreen-chat.js";
 import { HelpOverlay } from "./help-overlay.js";
@@ -39,6 +40,9 @@ import { applyChatEventToMessages } from "../chat/chat-event-state.js";
 import { setActiveCursorEscape } from "./cursor-tracker.js";
 import { createRuntimeSessionRegistry } from "../../runtime/session-registry/index.js";
 import type { RuntimeSessionRegistrySnapshot } from "../../runtime/session-registry/types.js";
+import { RuntimeEvidenceLedger, type RuntimeEvidenceSummary } from "../../runtime/store/evidence-ledger.js";
+import { RuntimeHealthStore } from "../../runtime/store/health-store.js";
+import type { RuntimeHealthSnapshot } from "../../runtime/store/runtime-schemas.js";
 import {
   createRunSpecStore,
   deriveRunSpecFromText,
@@ -278,6 +282,8 @@ export function App({
   const termRows = stdout?.rows ?? 24;
   const [showSidebar, setShowSidebar] = useState(false);
   const [runtimeSessionSnapshot, setRuntimeSessionSnapshot] = useState<RuntimeSessionRegistrySnapshot | null>(null);
+  const [runtimeHealthSnapshot, setRuntimeHealthSnapshot] = useState<RuntimeHealthSnapshot | null>(null);
+  const [runtimeEvidenceSummaries, setRuntimeEvidenceSummaries] = useState<Record<string, RuntimeEvidenceSummary>>({});
 
   // ── Loop state ──
   // In standalone mode, useLoop() manages state via CoreLoop.
@@ -421,10 +427,40 @@ export function App({
     const refreshRuntimeSessions = async () => {
       try {
         const registry = createRuntimeSessionRegistry({ stateManager });
+        const runtimeRoot = path.join(stateManager.getBaseDir(), "runtime");
+        const healthStore = new RuntimeHealthStore(runtimeRoot);
+        const evidenceLedger = new RuntimeEvidenceLedger(runtimeRoot);
         const snapshot = await registry.snapshot();
-        if (!cancelled) setRuntimeSessionSnapshot(snapshot);
+        const dashboardRunIds = new Set<string>();
+        const rows = buildWorkDashboardRows(snapshot);
+        for (const row of rows.slice(0, 12)) {
+          if (row.kind === "run") {
+            dashboardRunIds.add(row.id);
+            continue;
+          }
+          const relatedRun = snapshot.background_runs.find((run) =>
+            run.child_session_id === row.id || run.parent_session_id === row.id || run.process_session_id === row.id
+          );
+          if (relatedRun) dashboardRunIds.add(relatedRun.id);
+        }
+        const [health, summaries] = await Promise.all([
+          healthStore.loadSnapshot().catch(() => null),
+          Promise.all([...dashboardRunIds].map(async (runId) => {
+            const summary = await evidenceLedger.summarizeRun(runId).catch(() => null);
+            return [runId, summary] as const;
+          })),
+        ]);
+        if (!cancelled) {
+          setRuntimeSessionSnapshot(snapshot);
+          setRuntimeHealthSnapshot(health);
+          setRuntimeEvidenceSummaries(Object.fromEntries(summaries.filter((entry): entry is readonly [string, RuntimeEvidenceSummary] => entry[1] !== null)));
+        }
       } catch {
-        if (!cancelled) setRuntimeSessionSnapshot(null);
+        if (!cancelled) {
+          setRuntimeSessionSnapshot(null);
+          setRuntimeHealthSnapshot(null);
+          setRuntimeEvidenceSummaries({});
+        }
       }
     };
 
@@ -816,7 +852,12 @@ export function App({
             paddingX={1}
             overflow="hidden"
           >
-            <Dashboard state={loopState} runtimeSessions={runtimeSessionSnapshot} />
+            <Dashboard
+              state={loopState}
+              runtimeSessions={runtimeSessionSnapshot}
+              runtimeHealth={runtimeHealthSnapshot}
+              evidenceSummaries={runtimeEvidenceSummaries}
+            />
           </Box>
         )}
 

--- a/src/interface/tui/dashboard.tsx
+++ b/src/interface/tui/dashboard.tsx
@@ -8,11 +8,15 @@ import type {
   RuntimeSession,
   RuntimeSessionRegistrySnapshot,
 } from "../../runtime/session-registry/types.js";
+import type { RuntimeEvidenceSummary } from "../../runtime/store/evidence-ledger.js";
+import type { RuntimeHealthSnapshot } from "../../runtime/store/runtime-schemas.js";
 
 interface DashboardProps {
   state: LoopState;
   maxIterations?: number;
   runtimeSessions?: RuntimeSessionRegistrySnapshot | null;
+  runtimeHealth?: RuntimeHealthSnapshot | null;
+  evidenceSummaries?: RuntimeEvidenceSummaryByRun;
 }
 
 const BAR_WIDTH = 20;
@@ -33,6 +37,22 @@ export interface WorkDashboardRow {
   workspace: string | null;
   attention: boolean;
   stale: boolean;
+}
+
+export type RuntimeEvidenceSummaryByRun = Record<string, RuntimeEvidenceSummary>;
+
+export interface OperatorConsoleModel {
+  selectedId: string;
+  selectedTitle: string;
+  lifecycle: string;
+  liveness: string;
+  usefulProgress: string;
+  currentMode: string;
+  latestEvents: string[];
+  artifacts: string[];
+  metrics: string[];
+  blockers: string[];
+  controls: string[];
 }
 
 function renderBar(progress: number): string {
@@ -86,6 +106,137 @@ function runAttention(run: BackgroundRun): boolean {
     || run.status === "lost"
     || run.status === "unknown"
     || /approval[-_ ]required|blocked|waiting/i.test(`${run.summary ?? ""} ${run.error ?? ""}`);
+}
+
+function runLifecycle(run: BackgroundRun | null, row: WorkDashboardRow): string {
+  if (row.stale) return "stale";
+  if (!run) return row.status;
+  if (/approval[-_ ]required/i.test(`${run.summary ?? ""} ${run.error ?? ""}`)) return "approval-required";
+  if (/blocked|waiting/i.test(`${run.summary ?? ""} ${run.error ?? ""}`)) return "blocked";
+  if (run.status === "succeeded") return "completed";
+  if (run.status === "failed" || run.status === "timed_out" || run.status === "lost" || run.status === "unknown") return "failed";
+  return run.status;
+}
+
+function summarizeLiveness(row: WorkDashboardRow, health: RuntimeHealthSnapshot | null | undefined): string {
+  const longRunning = health?.long_running;
+  if (!longRunning) {
+    if (row.stale) return "stale catalog heartbeat";
+    return row.group === "active" ? "catalog current" : "not active";
+  }
+  const process = longRunning.signals.process.status;
+  const logFreshness = longRunning.signals.log_freshness.status;
+  const selected = row.stale ? "stale catalog heartbeat" : row.group === "active" ? "catalog current" : "not active";
+  return `${selected}; daemon aggregate ${process}; logs ${logFreshness}; ${longRunning.summary}`;
+}
+
+function summarizeUsefulProgress(summary: RuntimeEvidenceSummary | undefined, health: RuntimeHealthSnapshot | null | undefined): string {
+  const trend = summary?.metric_trends[0];
+  if (trend) {
+    return `${trend.metric_key} ${trend.trend}; latest ${trend.latest_value}; best ${trend.best_value}`;
+  }
+  const metricProgress = health?.long_running?.signals.metric_progress;
+  if (metricProgress && metricProgress.status !== "unknown") {
+    const metric = metricProgress.metric_name ? `${metricProgress.metric_name} ` : "";
+    const values = typeof metricProgress.current_value === "number"
+      ? ` current ${metricProgress.current_value}`
+      : "";
+    return `no selected metric progress evidence; daemon aggregate ${metric}${metricProgress.status}${values}`.trim();
+  }
+  return "no selected metric progress evidence";
+}
+
+function summarizeMode(summary: RuntimeEvidenceSummary | undefined): string {
+  const phase = summary?.evaluator_summary.budgets.find((budget) => budget.phase)?.phase;
+  if (phase) return phase;
+  const strategyText = [
+    summary?.latest_strategy?.strategy,
+    summary?.latest_strategy?.summary,
+    summary?.latest_strategy?.decision_reason,
+  ].filter(Boolean).join(" ");
+  if (/final/i.test(strategyText)) return "finalization";
+  if (/consolidat|stabil|ensemble|portfolio/i.test(strategyText)) return "consolidation";
+  if (strategyText) return "exploration";
+  return "unknown";
+}
+
+function summarizeMetrics(summary: RuntimeEvidenceSummary | undefined): string[] {
+  if (!summary) return ["No metric evidence yet."];
+  const trends = summary.metric_trends.slice(0, 3).map((trend) =>
+    `${trend.metric_key}: latest ${trend.latest_value}, best ${trend.best_value}, ${trend.trend}`
+  );
+  if (trends.length > 0) return trends;
+  const bestMetric = summary.best_evidence?.metrics.find((metric) => typeof metric.value === "number");
+  return bestMetric ? [`${bestMetric.label}: ${bestMetric.value}`] : ["No metric evidence yet."];
+}
+
+function summarizeArtifacts(run: BackgroundRun | null, summary: RuntimeEvidenceSummary | undefined): string[] {
+  const artifacts = [
+    ...(run?.artifacts ?? []).map((artifact) => `${artifact.label}: ${artifact.path ?? artifact.url ?? artifact.kind}`),
+    ...(summary?.artifact_retention.cleanup_plan.actions ?? []).map((artifact) =>
+      `${artifact.label}: ${artifact.path ?? artifact.state_relative_path ?? artifact.url ?? artifact.kind}`
+    ),
+    ...(summary?.recent_entries ?? []).flatMap((entry) =>
+      entry.artifacts.map((artifact) => `${artifact.label}: ${artifact.path ?? artifact.state_relative_path ?? artifact.url ?? artifact.kind}`)
+    ),
+  ];
+  return [...new Set(artifacts)].slice(0, 4);
+}
+
+function summarizeEvents(run: BackgroundRun | null, summary: RuntimeEvidenceSummary | undefined): string[] {
+  const events = [
+    ...(run?.summary ? [run.summary] : []),
+    ...(run?.error ? [run.error] : []),
+    ...(summary?.recent_entries ?? []).map((entry) => entry.summary ?? `${entry.kind} ${entry.outcome}`),
+  ];
+  return events.filter(Boolean).slice(0, 4);
+}
+
+function summarizeBlockers(row: WorkDashboardRow, run: BackgroundRun | null, summary: RuntimeEvidenceSummary | undefined): string[] {
+  const blockers: string[] = [];
+  if (row.attention) blockers.push(row.status === "stale" ? "stale catalog state" : row.summary);
+  if (run?.error) blockers.push(run.error);
+  blockers.push(...(summary?.evaluator_summary.approval_required_actions ?? []).map((action) => action.label));
+  return [...new Set(blockers.filter(Boolean))].slice(0, 4);
+}
+
+function findRelatedRun(snapshot: RuntimeSessionRegistrySnapshot, row: WorkDashboardRow): BackgroundRun | null {
+  if (row.kind === "run") return snapshot.background_runs.find((run) => run.id === row.id) ?? null;
+  return snapshot.background_runs.find((run) =>
+    run.child_session_id === row.id || run.parent_session_id === row.id || run.process_session_id === row.id
+  ) ?? null;
+}
+
+export function buildOperatorConsoleModel(
+  snapshot: RuntimeSessionRegistrySnapshot | null | undefined,
+  health: RuntimeHealthSnapshot | null | undefined,
+  evidenceSummaries: RuntimeEvidenceSummaryByRun = {},
+  now: Date = new Date(),
+): OperatorConsoleModel | null {
+  const rows = buildWorkDashboardRows(snapshot, now);
+  if (!snapshot || rows.length === 0) return null;
+  const selected = rows.find((row) => row.attention) ?? rows.find((row) => row.group === "active") ?? rows[0]!;
+  const run = findRelatedRun(snapshot, selected);
+  const summary = run ? evidenceSummaries[run.id] : undefined;
+  const artifacts = summarizeArtifacts(run, summary);
+  const latestEvents = summarizeEvents(run, summary);
+  const blockers = summarizeBlockers(selected, run, summary);
+  return {
+    selectedId: selected.id,
+    selectedTitle: selected.title,
+    lifecycle: runLifecycle(run, selected),
+    liveness: summarizeLiveness(selected, health),
+    usefulProgress: summarizeUsefulProgress(summary, health),
+    currentMode: summarizeMode(summary),
+    latestEvents: latestEvents.length > 0 ? latestEvents : ["No recent events or logs found."],
+    artifacts: artifacts.length > 0 ? artifacts : ["No produced artifacts found."],
+    metrics: summarizeMetrics(summary),
+    blockers: blockers.length > 0 ? blockers : ["No blockers detected."],
+    controls: [
+      "inspect: available",
+      "pause/resume/finalize: unavailable until a typed TUI runtime API exists",
+    ],
+  };
 }
 
 function compact(value: string | null | undefined, fallback: string): string {
@@ -246,10 +397,56 @@ function WorkDashboard({ rows }: { rows: WorkDashboardRow[] }) {
   );
 }
 
-export function Dashboard({ state, runtimeSessions }: DashboardProps) {
+function OperatorConsole({ model }: { model: OperatorConsoleModel }) {
+  return (
+    <Box flexDirection="column" marginTop={1}>
+      <Text bold color={theme.brand}>Operator Console</Text>
+      <Text>
+        <Text color={theme.success}>{model.selectedTitle}</Text>
+        <Text dimColor>{"  "}{model.selectedId}</Text>
+      </Text>
+      <Text>
+        <Text dimColor>Lifecycle </Text>
+        <Text color={model.lifecycle === "failed" || model.lifecycle === "blocked" || model.lifecycle === "approval-required" ? theme.warning : theme.text}>
+          {model.lifecycle}
+        </Text>
+      </Text>
+      <Text>
+        <Text dimColor>Liveness </Text>
+        <Text>{model.liveness}</Text>
+      </Text>
+      <Text>
+        <Text dimColor>Useful progress </Text>
+        <Text>{model.usefulProgress}</Text>
+      </Text>
+      <Text>
+        <Text dimColor>Mode </Text>
+        <Text>{model.currentMode}</Text>
+      </Text>
+      <Text color={theme.warning}>Blockers</Text>
+      {model.blockers.slice(0, 3).map((line, index) => <Text key={`blocker-${index}`} dimColor>{"  "}{line}</Text>)}
+      <Text dimColor>Metrics</Text>
+      {model.metrics.slice(0, 3).map((line, index) => <Text key={`metric-${index}`} dimColor>{"  "}{line}</Text>)}
+      <Text dimColor>Recent events</Text>
+      {model.latestEvents.slice(0, 3).map((line, index) => <Text key={`event-${index}`} dimColor>{"  "}{line}</Text>)}
+      <Text dimColor>Artifacts</Text>
+      {model.artifacts.slice(0, 3).map((line, index) => <Text key={`artifact-${index}`} dimColor>{"  "}{line}</Text>)}
+      <Text dimColor>Controls</Text>
+      {model.controls.map((line, index) => <Text key={`control-${index}`} dimColor>{"  "}{line}</Text>)}
+    </Box>
+  );
+}
+
+export function Dashboard({ state, runtimeSessions, runtimeHealth, evidenceSummaries }: DashboardProps) {
   const workRows = buildWorkDashboardRows(runtimeSessions);
+  const operatorConsole = buildOperatorConsoleModel(runtimeSessions, runtimeHealth, evidenceSummaries);
   if (workRows.length > 0) {
-    return <WorkDashboard rows={workRows} />;
+    return (
+      <Box flexDirection="column" overflow="hidden">
+        <WorkDashboard rows={workRows} />
+        {operatorConsole && <OperatorConsole model={operatorConsole} />}
+      </Box>
+    );
   }
 
   if (state.status === "idle") {


### PR DESCRIPTION
Closes #849

## Summary
- add a Runtime Session Catalog-backed operator console below the TUI work dashboard
- show selected lifecycle, liveness, useful progress, mode, events, artifacts, metrics, blockers, approval-required actions, and safe control availability
- load Runtime Health and Runtime Evidence summaries during dashboard refresh, using dashboard-selected candidate runs rather than raw snapshot order

## Verification
- npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/dashboard.test.ts src/interface/tui/__tests__/app.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check
- npm run test:all

## Known unresolved risks
- pause/resume/finalize are shown as unavailable because the current typed TUI runtime-control API does not expose selected-run controls; this PR does not shell out or expose unsupported controls
- Runtime Health is shown as daemon aggregate liveness context, not selected-run truth, until per-run health linking exists