### PR TITLE
feat(tui): answer runtime evidence questions

### DIFF
--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -8,6 +8,7 @@ import { App, DASHBOARD_REFRESH_INTERVAL_MS, formatDaemonConnectionState } from 
 
 const testState = vi.hoisted(() => ({
   lastChatProps: null as null | { onSubmit: (value: string) => Promise<void> },
+  lastChatMessages: [] as Array<{ role: string; text: string; messageType?: string }>,
   lastApprovalProps: null as null | {
     task: { work_description: string; rationale: string; goal_id: string };
     onDecision: (approved: boolean) => void;
@@ -16,6 +17,7 @@ const testState = vi.hoisted(() => ({
   runtimeSessionSnapshots: [] as Array<Record<string, unknown>>,
   runtimeSessionSnapshotCalls: 0,
   summarizedRunIds: [] as string[],
+  runtimeEvidenceSummaries: {} as Record<string, unknown>,
 }));
 
 vi.mock("ink", async () => {
@@ -31,6 +33,7 @@ vi.mock("../chat.js", async () => {
   return {
     Chat: (props: Record<string, unknown>) => {
       testState.lastChatProps = props as any;
+      testState.lastChatMessages = (props.messages as Array<{ role: string; text: string; messageType?: string }>) ?? [];
       return null;
     },
   };
@@ -40,6 +43,7 @@ vi.mock("../fullscreen-chat.js", async () => {
   return {
     FullscreenChat: (props: Record<string, unknown>) => {
       testState.lastChatProps = props as any;
+      testState.lastChatMessages = (props.messages as Array<{ role: string; text: string; messageType?: string }>) ?? [];
       return null;
     },
   };
@@ -80,7 +84,7 @@ vi.mock("../../../runtime/store/evidence-ledger.js", () => ({
   RuntimeEvidenceLedger: class {
     summarizeRun = vi.fn(async (runId: string) => {
       testState.summarizedRunIds.push(runId);
-      return null;
+      return testState.runtimeEvidenceSummaries[runId] ?? null;
     });
   },
 }));
@@ -137,6 +141,89 @@ function createChatRunnerMock() {
   };
 }
 
+function createEvidenceSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    schema_version: "runtime-evidence-summary-v1",
+    generated_at: "2026-05-02T00:00:00.000Z",
+    scope: { run_id: "run-evidence" },
+    total_entries: 1,
+    latest_strategy: null,
+    best_evidence: null,
+    metric_trends: [{
+      metric_key: "balanced_accuracy",
+      direction: "maximize",
+      trend: "breakthrough",
+      latest_value: 0.91,
+      latest_observed_at: "2026-05-02T00:00:00.000Z",
+      best_value: 0.91,
+      best_observed_at: "2026-05-02T00:00:00.000Z",
+      observation_count: 3,
+      recent_slope_per_observation: 0.03,
+      best_delta: 0.08,
+      last_meaningful_improvement_delta: 0.04,
+      last_breakthrough_delta: 0.08,
+      time_since_last_meaningful_improvement_ms: 0,
+      improvement_threshold: 0.01,
+      breakthrough_threshold: 0.05,
+      noise_band: 0.005,
+      confidence: 1,
+      source_refs: [],
+      summary: "balanced_accuracy breakthrough",
+    }],
+    evaluator_summary: {
+      local_best: null,
+      external_best: null,
+      gap: null,
+      budgets: [],
+      calibration: [],
+      approval_required_actions: [],
+      observations: [],
+    },
+    research_memos: [],
+    dream_checkpoints: [],
+    divergent_exploration: [],
+    candidate_lineages: [],
+    recommended_candidate_portfolio: [],
+    candidate_selection_summary: {
+      primary_metric: null,
+      raw_best: null,
+      robust_best: null,
+      ranked: [],
+      final_portfolio: { safe: null, aggressive: null, diverse: null },
+    },
+    near_miss_candidates: [],
+    artifact_retention: {
+      schema_version: "runtime-artifact-retention-summary-v1",
+      total_artifacts: 0,
+      total_size_bytes: 0,
+      unknown_size_count: 0,
+      protected_count: 0,
+      by_retention_class: {
+        final_deliverable: 0,
+        best_candidate: 0,
+        robust_candidate: 0,
+        near_miss: 0,
+        reproducibility_critical: 0,
+        evidence_report: 0,
+        low_value_smoke: 0,
+        cache_intermediate: 0,
+        duplicate_superseded: 0,
+        other: 0,
+      },
+      cleanup_plan: {
+        mode: "plan_only",
+        destructive_actions_default: "approval_required",
+        actions: [],
+      },
+    },
+    recent_failed_attempts: [],
+    failed_lineages: [],
+    recent_entries: [],
+    warnings: [],
+    ...overrides,
+  };
+}
+
 async function flush() {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
@@ -156,6 +243,11 @@ describe("formatDaemonConnectionState", () => {
 describe("standalone slash command routing", () => {
   beforeEach(() => {
     testState.lastChatProps = null;
+    testState.lastChatMessages = [];
+    testState.runtimeSessionSnapshots = [];
+    testState.runtimeSessionSnapshotCalls = 0;
+    testState.summarizedRunIds = [];
+    testState.runtimeEvidenceSummaries = {};
   });
 
   afterEach(() => {
@@ -355,6 +447,69 @@ describe("standalone slash command routing", () => {
     screen.unmount();
   });
 
+  it("answers natural-language run progress questions from runtime evidence before ChatRunner", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    testState.runtimeSessionSnapshots = [{
+      schema_version: "runtime-session-registry-v1",
+      generated_at: "2026-05-02T00:00:00.000Z",
+      sessions: [],
+      background_runs: [{
+        schema_version: "background-run-v1",
+        id: "run-evidence",
+        kind: "coreloop_run",
+        parent_session_id: null,
+        child_session_id: null,
+        process_session_id: null,
+        status: "running",
+        notify_policy: "done_only",
+        reply_target_source: "none",
+        pinned_reply_target: null,
+        title: "Evidence run",
+        workspace: "/repo",
+        created_at: "2026-05-02T00:00:00.000Z",
+        started_at: "2026-05-02T00:00:00.000Z",
+        updated_at: "2026-05-02T00:00:00.000Z",
+        completed_at: null,
+        summary: "Kaggle run is executing",
+        error: null,
+        artifacts: [],
+        source_refs: [],
+      }],
+      warnings: [],
+    }];
+    testState.runtimeEvidenceSummaries = {
+      "run-evidence": createEvidenceSummary(),
+    };
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/work/kaggle",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("Progress?");
+    await flush();
+
+    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+    expect(testState.lastChatMessages.map((message) => message.text).join("\n")).toContain("Runtime evidence answer for run run-evidence");
+    expect(testState.lastChatMessages.map((message) => message.text).join("\n")).toContain("balanced_accuracy");
+
+    screen.unmount();
+  });
+
   it("routes input during processing to ChatRunner interrupt redirect", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
@@ -396,11 +551,13 @@ describe("standalone slash command routing", () => {
 describe("daemon-mode chat routing", () => {
   beforeEach(() => {
     testState.lastChatProps = null;
+    testState.lastChatMessages = [];
     testState.lastApprovalProps = null;
     testState.lastDashboardProps = null;
     testState.runtimeSessionSnapshots = [];
     testState.runtimeSessionSnapshotCalls = 0;
     testState.summarizedRunIds = [];
+    testState.runtimeEvidenceSummaries = {};
   });
 
   afterEach(() => {

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -50,6 +50,7 @@ import {
   handleRunSpecConfirmationInput,
   type RunSpec,
 } from "../../runtime/run-spec/index.js";
+import { answerRuntimeEvidenceQuestion } from "../../runtime/evidence-answer.js";
 
 const MAX_MESSAGES = 200;
 const PULSEED_VERSION = getPulseedVersion(import.meta.url);
@@ -729,6 +730,22 @@ export function App({
             }].slice(-MAX_MESSAGES));
           }
         } else {
+          const evidenceAnswer = await answerRuntimeEvidenceQuestion({
+            text: input,
+            stateManager,
+          });
+          if (evidenceAnswer.kind === "answered" && evidenceAnswer.message) {
+            const message = evidenceAnswer.message;
+            setMessages((prev) => [...prev, {
+              id: randomUUID(),
+              role: "pulseed" as const,
+              text: message,
+              timestamp: new Date(),
+              messageType: evidenceAnswer.messageType ?? ("info" as const),
+            }].slice(-MAX_MESSAGES));
+            return;
+          }
+
           const freeformRoute = resolveFreeformInputRoute({
             isDaemonMode,
             daemonGoalId: daemonLoopState.goalId,

--- a/src/runtime/__tests__/runtime-evidence-answer.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-answer.test.ts
@@ -1,0 +1,368 @@
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  answerRuntimeEvidenceQuestion,
+  buildRuntimeEvidenceAnswer,
+  recognizeRuntimeEvidenceQuestion,
+} from "../evidence-answer.js";
+import type { BackgroundRun } from "../session-registry/types.js";
+import { BackgroundRunLedger } from "../store/background-run-store.js";
+import { RuntimeEvidenceLedger, type RuntimeEvidenceSummary } from "../store/evidence-ledger.js";
+
+const NOW = new Date("2026-05-02T00:30:00.000Z");
+
+function run(overrides: Partial<BackgroundRun> = {}): BackgroundRun {
+  return {
+    schema_version: "background-run-v1",
+    id: "run-1",
+    kind: "coreloop_run",
+    parent_session_id: null,
+    child_session_id: null,
+    process_session_id: null,
+    status: "running",
+    notify_policy: "done_only",
+    reply_target_source: "none",
+    pinned_reply_target: null,
+    title: "Kaggle run",
+    workspace: "/repo",
+    created_at: "2026-05-02T00:00:00.000Z",
+    started_at: "2026-05-02T00:00:00.000Z",
+    updated_at: "2026-05-02T00:25:00.000Z",
+    completed_at: null,
+    summary: null,
+    error: null,
+    artifacts: [],
+    source_refs: [],
+    ...overrides,
+  };
+}
+
+function summary(overrides: Partial<RuntimeEvidenceSummary> = {}): RuntimeEvidenceSummary {
+  return {
+    schema_version: "runtime-evidence-summary-v1",
+    generated_at: "2026-05-02T00:25:00.000Z",
+    scope: { run_id: "run-1" },
+    total_entries: 1,
+    latest_strategy: null,
+    best_evidence: null,
+    metric_trends: [],
+    evaluator_summary: {
+      local_best: null,
+      external_best: null,
+      gap: null,
+      budgets: [],
+      calibration: [],
+      approval_required_actions: [],
+      observations: [],
+    },
+    research_memos: [],
+    dream_checkpoints: [],
+    divergent_exploration: [],
+    candidate_lineages: [],
+    recommended_candidate_portfolio: [],
+    candidate_selection_summary: {
+      primary_metric: null,
+      raw_best: null,
+      robust_best: null,
+      ranked: [],
+      final_portfolio: {
+        safe: null,
+        aggressive: null,
+        diverse: null,
+      },
+    },
+    near_miss_candidates: [],
+    artifact_retention: {
+      schema_version: "runtime-artifact-retention-summary-v1",
+      total_artifacts: 0,
+      total_size_bytes: 0,
+      unknown_size_count: 0,
+      protected_count: 0,
+      by_retention_class: {
+        final_deliverable: 0,
+        best_candidate: 0,
+        robust_candidate: 0,
+        near_miss: 0,
+        reproducibility_critical: 0,
+        evidence_report: 0,
+        low_value_smoke: 0,
+        cache_intermediate: 0,
+        duplicate_superseded: 0,
+        other: 0,
+      },
+      cleanup_plan: {
+        mode: "plan_only",
+        destructive_actions_default: "approval_required",
+        actions: [],
+      },
+    },
+    recent_failed_attempts: [],
+    failed_lineages: [],
+    recent_entries: [],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+describe("recognizeRuntimeEvidenceQuestion", () => {
+  it("recognizes evidence questions without treating long-run start requests as questions", () => {
+    expect(recognizeRuntimeEvidenceQuestion("Progress?")).toContain("progress");
+    expect(recognizeRuntimeEvidenceQuestion("What strategy is it trying now?")).toContain("strategy");
+    expect(recognizeRuntimeEvidenceQuestion("Which artifact is best?")).toEqual(expect.arrayContaining(["metric", "artifact"]));
+    expect(recognizeRuntimeEvidenceQuestion("Run this Kaggle competition until tomorrow morning")).toEqual([]);
+  });
+});
+
+describe("buildRuntimeEvidenceAnswer", () => {
+  it("answers progress and cumulative best metric from persisted runtime evidence", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-evidence-answer-"));
+    const ledger = new RuntimeEvidenceLedger(path.join(tmp, "runtime"));
+    await ledger.append({
+      kind: "metric",
+      scope: { run_id: "run-1" },
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      metrics: [{ label: "balanced_accuracy", value: 0.82, direction: "maximize", observed_at: "2026-05-02T00:00:00.000Z" }],
+      summary: "baseline scored",
+    });
+    await ledger.append({
+      kind: "metric",
+      scope: { run_id: "run-1" },
+      occurred_at: "2026-05-02T00:20:00.000Z",
+      metrics: [{ label: "balanced_accuracy", value: 0.91, direction: "maximize", observed_at: "2026-05-02T00:20:00.000Z" }],
+      summary: "new candidate scored",
+    });
+
+    const result = buildRuntimeEvidenceAnswer({
+      text: "Progress and best metric?",
+      topics: ["progress", "metric"],
+      snapshot: null,
+      health: null,
+      run: run(),
+      summary: await ledger.summarizeRun("run-1"),
+      now: NOW,
+    });
+
+    expect(result.kind).toBe("answered");
+    expect(result.message).toContain("balanced_accuracy");
+    expect(result.message).toContain("cumulative best 0.91");
+    expect(result.message).toContain("breakthrough");
+  });
+
+  it("answers artifact and candidate questions without leaking secrets", () => {
+    const result = buildRuntimeEvidenceAnswer({
+      text: "Which artifact is best?",
+      topics: ["artifact"],
+      snapshot: null,
+      health: null,
+      run: run({
+        artifacts: [{ label: "report", path: "/repo/report.md?token=secret-token-value", url: null, kind: "report" }],
+      }),
+      summary: summary({
+        recommended_candidate_portfolio: [{
+          candidate_id: "candidate-a",
+          label: "Candidate A",
+          strategy_family: "tabular-ensemble",
+          role: "top_metric",
+          evidence_entry_id: "entry-1",
+          occurred_at: "2026-05-02T00:20:00.000Z",
+          metric: {
+            label: "balanced_accuracy",
+            value: 0.91,
+            direction: "maximize",
+            confidence: 1,
+          },
+          disposition: "retained",
+        }],
+      }),
+      now: NOW,
+    });
+
+    expect(result.message).toContain("report: /repo/report.md?token=[REDACTED]");
+    expect(result.message).toContain("Candidate A");
+    expect(result.message).not.toContain("secret-token-value");
+  });
+
+  it("answers strategy questions from strategy and Dream checkpoint evidence", () => {
+    const strategy = {
+      schema_version: "runtime-evidence-entry-v1" as const,
+      id: "entry-strategy",
+      occurred_at: "2026-05-02T00:10:00.000Z",
+      kind: "strategy" as const,
+      scope: { run_id: "run-1" },
+      metrics: [],
+      artifacts: [],
+      raw_refs: [],
+      summary: "Testing calibrated ensemble features.",
+    };
+    const result = buildRuntimeEvidenceAnswer({
+      text: "What strategy is it trying now?",
+      topics: ["strategy"],
+      snapshot: null,
+      health: null,
+      run: run(),
+      summary: summary({
+        latest_strategy: strategy,
+        dream_checkpoints: [{
+          entry_id: "entry-dream",
+          occurred_at: "2026-05-02T00:20:00.000Z",
+          trigger: "plateau",
+          summary: "Plateau suggests shifting to a diversified ensemble.",
+          current_goal: "Improve Kaggle score",
+          active_dimensions: ["balanced_accuracy"],
+          recent_strategy_families: ["feature-search"],
+          exhausted: [],
+          promising: ["ensemble"],
+          relevant_memories: [],
+          active_hypotheses: [{
+            hypothesis: "Class recall imbalance is limiting the score.",
+            target_metric_or_dimension: "balanced_accuracy",
+            expected_next_observation: "minority recall improves",
+            status: "testing",
+          }],
+          rejected_approaches: [],
+          next_strategy_candidates: [{
+            title: "Blend calibrated candidates",
+            rationale: "Reduce variance across folds.",
+            target_dimensions: ["balanced_accuracy"],
+          }],
+          guidance: "Try the ensemble next.",
+          uncertainty: [],
+          context_authority: "advisory_only",
+          confidence: 0.8,
+        }],
+      }),
+      now: NOW,
+    });
+
+    expect(result.message).toContain("Testing calibrated ensemble features");
+    expect(result.message).toContain("Blend calibrated candidates");
+    expect(result.message).toContain("Class recall imbalance");
+  });
+
+  it("marks stale evidence explicitly", () => {
+    const result = buildRuntimeEvidenceAnswer({
+      text: "Status?",
+      topics: ["progress"],
+      snapshot: null,
+      health: null,
+      run: run(),
+      summary: summary({
+        generated_at: "2026-05-01T22:00:00.000Z",
+        recent_entries: [{
+          schema_version: "runtime-evidence-entry-v1",
+          id: "entry-old",
+          occurred_at: "2026-05-01T22:00:00.000Z",
+          kind: "observation",
+          scope: { run_id: "run-1" },
+          metrics: [],
+          artifacts: [],
+          raw_refs: [],
+          summary: "old status",
+        }],
+      }),
+      now: NOW,
+    });
+
+    expect(result.messageType).toBe("warning");
+    expect(result.message).toContain("Evidence may be stale");
+    expect(result.message).toContain("Latest evidence may be stale");
+  });
+
+  it("answers missing evidence cases instead of falling back to model memory", () => {
+    const result = buildRuntimeEvidenceAnswer({
+      text: "Progress?",
+      topics: ["progress"],
+      snapshot: null,
+      health: null,
+      run: run(),
+      summary: null,
+      now: NOW,
+    });
+
+    expect(result.messageType).toBe("warning");
+    expect(result.message).toContain("Evidence missing");
+  });
+
+  it("keeps the highest-priority active run selected even when only an older run has evidence", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-evidence-active-run-"));
+    const stateManager = { getBaseDir: () => tmp };
+    const ledger = new RuntimeEvidenceLedger(path.join(tmp, "runtime"));
+    const runLedger = new BackgroundRunLedger(path.join(tmp, "runtime"));
+    await ledger.append({
+      kind: "metric",
+      scope: { run_id: "run-old" },
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      metrics: [{ label: "score", value: 0.9, direction: "maximize", observed_at: "2026-05-02T00:00:00.000Z" }],
+      summary: "older completed run evidence",
+    });
+    await runLedger.create({
+      id: "run-old",
+      kind: "coreloop_run",
+      status: "running",
+      notify_policy: "silent",
+      title: "Old run",
+      workspace: "/repo",
+      created_at: "2026-05-01T00:00:00.000Z",
+      started_at: "2026-05-01T00:00:00.000Z",
+      updated_at: "2026-05-01T01:00:00.000Z",
+    });
+    await runLedger.terminal("run-old", {
+      status: "succeeded",
+        completed_at: "2026-05-01T01:00:00.000Z",
+      updated_at: "2026-05-01T01:00:00.000Z",
+      summary: "old run",
+    });
+    await runLedger.create({
+      id: "run-active",
+      kind: "coreloop_run",
+      status: "running",
+      notify_policy: "silent",
+      title: "Active run",
+      workspace: "/repo",
+      created_at: "2026-05-02T00:00:00.000Z",
+      started_at: "2026-05-02T00:00:00.000Z",
+      updated_at: "2026-05-02T00:25:00.000Z",
+      summary: "active run",
+    });
+
+    const result = await answerRuntimeEvidenceQuestion({
+      text: "Progress?",
+      stateManager,
+      now: NOW,
+    });
+
+    expect(result.kind).toBe("answered");
+    expect(result.targetRunId).toBe("run-active");
+    expect(result.messageType).toBe("warning");
+    expect(result.message).toContain("Runtime evidence answer for run run-active");
+    expect(result.message).toContain("Evidence missing");
+    expect(result.message).not.toContain("score");
+  });
+
+  it("redacts evaluator gap summaries in blocker output", () => {
+    const result = buildRuntimeEvidenceAnswer({
+      text: "What is blocked?",
+      topics: ["blocker"],
+      snapshot: null,
+      health: null,
+      run: run(),
+      summary: summary({
+        evaluator_summary: {
+          ...summary().evaluator_summary,
+          gap: {
+            kind: "candidate_mismatch",
+            summary: "Local candidate token=super-secret-value differs from external best.",
+            local_candidate_id: "local",
+            external_candidate_id: "external",
+          },
+        },
+      }),
+      now: NOW,
+    });
+
+    expect(result.message).toContain("[REDACTED]");
+    expect(result.message).not.toContain("super-secret-value");
+  });
+});

--- a/src/runtime/evidence-answer.ts
+++ b/src/runtime/evidence-answer.ts
@@ -1,0 +1,332 @@
+import * as path from "node:path";
+import type { StateManager } from "../base/state/state-manager.js";
+import { createRuntimeSessionRegistry } from "./session-registry/index.js";
+import type {
+  BackgroundRun,
+  RuntimeSessionRegistrySnapshot,
+} from "./session-registry/types.js";
+import { RuntimeEvidenceLedger, type RuntimeEvidenceSummary } from "./store/evidence-ledger.js";
+import { RuntimeHealthStore } from "./store/health-store.js";
+import type { RuntimeHealthSnapshot } from "./store/runtime-schemas.js";
+
+export type RuntimeEvidenceQuestionTopic =
+  | "progress"
+  | "metric"
+  | "artifact"
+  | "strategy"
+  | "blocker"
+  | "report";
+
+export interface RuntimeEvidenceAnswerResult {
+  kind: "not_runtime_evidence_question" | "answered";
+  message?: string;
+  messageType?: "info" | "warning";
+  targetRunId?: string;
+  topics?: RuntimeEvidenceQuestionTopic[];
+}
+
+export interface RuntimeEvidenceAnswerInput {
+  text: string;
+  stateManager: Pick<StateManager, "getBaseDir">;
+  now?: Date;
+}
+
+interface RuntimeEvidenceAnswerModelInput {
+  text: string;
+  topics: RuntimeEvidenceQuestionTopic[];
+  snapshot: RuntimeSessionRegistrySnapshot | null;
+  health: RuntimeHealthSnapshot | null;
+  run: BackgroundRun | null;
+  summary: RuntimeEvidenceSummary | null;
+  now?: Date;
+}
+
+const STALE_EVIDENCE_MS = 30 * 60 * 1000;
+
+export function recognizeRuntimeEvidenceQuestion(text: string): RuntimeEvidenceQuestionTopic[] {
+  const normalized = text.trim().toLowerCase();
+  if (!normalized) return [];
+  const questionish = /[?？]$/.test(normalized)
+    || /^(what|which|where|how|did|does|is|are|can|show|tell|status|progress|best|artifact|strategy|blocker|approval|report)\b/.test(normalized);
+  if (!questionish) return [];
+
+  const topics = new Set<RuntimeEvidenceQuestionTopic>();
+  if (/\b(progress|status|health|how far|where is|current state|running|alive|stalled|plateau|breakthrough)\b/.test(normalized)) topics.add("progress");
+  if (/\b(metric|score|best|beat|leaderboard|accuracy|recall|precision|loss|auc|f1|current best|cumulative best)\b/.test(normalized)) topics.add("metric");
+  if (/\b(artifact|output|candidate|submission|report file|file|produced|manifest)\b/.test(normalized)) topics.add("artifact");
+  if (/\b(strategy|hypothesis|trying|plan|next|dream|approach|experiment)\b/.test(normalized)) topics.add("strategy");
+  if (/\b(blocker|blocked|approval|approve|waiting|secret|submit|publish|finali[sz]e|ready)\b/.test(normalized)) topics.add("blocker");
+  if (/\b(report|postmortem|summary|writeup|what should be included)\b/.test(normalized)) topics.add("report");
+  if (topics.size === 0 && /^(progress|status|best|strategy|artifacts?)$/.test(normalized)) topics.add("progress");
+  return [...topics];
+}
+
+export async function answerRuntimeEvidenceQuestion(input: RuntimeEvidenceAnswerInput): Promise<RuntimeEvidenceAnswerResult> {
+  const topics = recognizeRuntimeEvidenceQuestion(input.text);
+  if (topics.length === 0) return { kind: "not_runtime_evidence_question" };
+
+  const runtimeRoot = path.join(input.stateManager.getBaseDir(), "runtime");
+  const registry = createRuntimeSessionRegistry({ stateManager: input.stateManager as StateManager });
+  const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+  const healthStore = new RuntimeHealthStore(runtimeRoot);
+
+  const [snapshot, health] = await Promise.all([
+    registry.snapshot().catch(() => null),
+    healthStore.loadSnapshot().catch(() => null),
+  ]);
+  const candidates = selectCandidateRuns(snapshot);
+  const summaries = await Promise.all(candidates.slice(0, 8).map(async (run) => {
+    const summary = await ledger.summarizeRun(run.id).catch(() => null);
+    return { run, summary };
+  }));
+  const selected = summaries[0] ?? { run: null, summary: null };
+  return buildRuntimeEvidenceAnswer({
+    text: input.text,
+    topics,
+    snapshot,
+    health,
+    run: selected.run,
+    summary: selected.summary,
+    now: input.now,
+  });
+}
+
+export function buildRuntimeEvidenceAnswer(input: RuntimeEvidenceAnswerModelInput): RuntimeEvidenceAnswerResult {
+  const { topics, run, summary } = input;
+  const target = run ? `run ${run.id}` : "runtime work";
+  const lines: string[] = [`Runtime evidence answer for ${target}.`];
+  const warningLines: string[] = [];
+
+  if (!run) {
+    lines.push("Evidence missing: no active or recent Runtime Session Catalog run was found.");
+    return {
+      kind: "answered",
+      message: lines.join("\n"),
+      messageType: "warning",
+      topics,
+    };
+  }
+
+  lines.push(`Sources: Runtime Session Catalog${summary ? ", Runtime Evidence Ledger" : ""}${input.health ? ", Runtime Health" : ""}.`);
+  lines.push(`Catalog status: ${run.status}${run.summary ? `; ${sanitize(run.summary)}` : ""}.`);
+  if (run.error) warningLines.push(`Run error: ${sanitize(run.error)}`);
+  if (input.health?.long_running) {
+    const health = input.health.long_running;
+    lines.push(`Liveness: daemon aggregate ${health.signals.process.status}; logs ${health.signals.log_freshness.status}; ${health.summary}.`);
+  }
+
+  if (!summary || summary.total_entries === 0) {
+    lines.push("Evidence missing: no persisted runtime evidence entries were found for the selected run.");
+    if (input.snapshot?.warnings.length) {
+      warningLines.push(...input.snapshot.warnings.slice(0, 3).map((warning) => `Catalog warning: ${sanitize(warning.message)}`));
+    }
+    appendWarnings(lines, warningLines);
+    return {
+      kind: "answered",
+      message: lines.join("\n"),
+      messageType: "warning",
+      targetRunId: run.id,
+      topics,
+    };
+  }
+
+  lines.push(`Evidence entries: ${summary.total_entries}; generated ${summary.generated_at}.`);
+  collectStalenessWarnings(summary, input.now ?? new Date(), warningLines);
+
+  if (topics.includes("progress")) appendProgress(lines, summary);
+  if (topics.includes("metric")) appendMetrics(lines, summary);
+  if (topics.includes("artifact")) appendArtifacts(lines, run, summary);
+  if (topics.includes("strategy")) appendStrategy(lines, summary);
+  if (topics.includes("blocker")) appendBlockers(lines, summary);
+  if (topics.includes("report")) appendReportSummary(lines, run, summary);
+  if (topics.length === 0) appendProgress(lines, summary);
+
+  appendEvidenceWarnings(lines, summary, warningLines);
+  return {
+    kind: "answered",
+    message: lines.join("\n"),
+    messageType: warningLines.length > 0 ? "warning" : "info",
+    targetRunId: run.id,
+    topics,
+  };
+}
+
+function selectCandidateRuns(snapshot: RuntimeSessionRegistrySnapshot | null): BackgroundRun[] {
+  if (!snapshot) return [];
+  const rank = (run: BackgroundRun): number => {
+    if (run.status === "running" || run.status === "queued") return 0;
+    if (run.status === "failed" || run.status === "timed_out" || run.status === "lost" || run.status === "unknown") return 1;
+    return 2;
+  };
+  return [...snapshot.background_runs].sort((left, right) => {
+    const rankDelta = rank(left) - rank(right);
+    if (rankDelta !== 0) return rankDelta;
+    return timestamp(right.updated_at ?? right.completed_at ?? right.started_at ?? right.created_at)
+      - timestamp(left.updated_at ?? left.completed_at ?? left.started_at ?? left.created_at);
+  });
+}
+
+function appendProgress(lines: string[], summary: RuntimeEvidenceSummary): void {
+  const latest = summary.recent_entries[0] ?? summary.best_evidence ?? summary.latest_strategy;
+  lines.push("Progress:");
+  lines.push(`- Latest evidence: ${latest ? entryLabel(latest) : "none"}.`);
+  if (summary.metric_trends.length > 0) {
+    const trend = summary.metric_trends[0]!;
+    lines.push(`- Metric state: ${trend.metric_key} is ${trend.trend}; latest ${trend.latest_value}, best ${trend.best_value}, observations ${trend.observation_count}.`);
+  }
+  if (summary.recent_failed_attempts.length > 0) {
+    lines.push(`- Recent failures: ${summary.recent_failed_attempts.slice(0, 2).map(entryLabel).join("; ")}.`);
+  }
+}
+
+function appendMetrics(lines: string[], summary: RuntimeEvidenceSummary): void {
+  lines.push("Metrics:");
+  if (summary.metric_trends.length === 0) {
+    lines.push("- No metric trend evidence found.");
+  } else {
+    for (const trend of summary.metric_trends.slice(0, 4)) {
+      lines.push(`- ${trend.metric_key}: latest ${trend.latest_value} at ${trend.latest_observed_at}; cumulative best ${trend.best_value} at ${trend.best_observed_at}; trend ${trend.trend}; confidence ${round(trend.confidence)}.`);
+    }
+  }
+  const evaluator = summary.evaluator_summary;
+  if (evaluator.local_best) lines.push(`- Local best: ${evaluatorObservationLabel(evaluator.local_best)}.`);
+  if (evaluator.external_best) lines.push(`- External best: ${evaluatorObservationLabel(evaluator.external_best)}.`);
+  if (summary.candidate_selection_summary.raw_best) lines.push(`- Raw best candidate: ${candidateLabel(summary.candidate_selection_summary.raw_best)}.`);
+  if (summary.candidate_selection_summary.robust_best) lines.push(`- Robust best candidate: ${candidateLabel(summary.candidate_selection_summary.robust_best)}.`);
+}
+
+function appendArtifacts(lines: string[], run: BackgroundRun, summary: RuntimeEvidenceSummary): void {
+  lines.push("Artifacts and candidates:");
+  const artifacts = [
+    ...run.artifacts.map((artifact) => `${artifact.label}: ${artifact.path ?? artifact.url ?? artifact.kind}`),
+    ...summary.artifact_retention.cleanup_plan.actions.map((artifact) =>
+      `${artifact.label}: ${artifact.path ?? artifact.state_relative_path ?? artifact.url ?? artifact.kind}`
+    ),
+    ...summary.recent_entries.flatMap((entry) =>
+      entry.artifacts.map((artifact) => `${artifact.label}: ${artifact.path ?? artifact.state_relative_path ?? artifact.url ?? artifact.kind}`)
+    ),
+  ];
+  const uniqueArtifacts = [...new Set(artifacts.map(sanitize))].slice(0, 5);
+  if (uniqueArtifacts.length === 0) lines.push("- No artifact evidence found.");
+  else for (const artifact of uniqueArtifacts) lines.push(`- ${artifact}.`);
+  const portfolio = summary.recommended_candidate_portfolio.slice(0, 3).map(candidateLabel);
+  if (portfolio.length > 0) lines.push(`- Recommended candidates: ${portfolio.join("; ")}.`);
+  if (summary.near_miss_candidates.length > 0) {
+    lines.push(`- Near misses: ${summary.near_miss_candidates.slice(0, 3).map((candidate) => sanitize(candidate.label ?? candidate.candidate_id)).join("; ")}.`);
+  }
+}
+
+function appendStrategy(lines: string[], summary: RuntimeEvidenceSummary): void {
+  lines.push("Strategy:");
+  if (summary.latest_strategy) lines.push(`- Latest strategy evidence: ${entryLabel(summary.latest_strategy)}.`);
+  const checkpoint = summary.dream_checkpoints[0];
+  if (checkpoint) {
+    lines.push(`- Dream checkpoint: ${sanitize(checkpoint.trigger)}; ${sanitize(checkpoint.summary)}.`);
+    if (checkpoint.next_strategy_candidates.length > 0) {
+      lines.push(`- Next candidates: ${checkpoint.next_strategy_candidates.slice(0, 3).map((candidate) => sanitize(candidate.title)).join("; ")}.`);
+    }
+    if (checkpoint.active_hypotheses.length > 0) {
+      lines.push(`- Active hypotheses: ${checkpoint.active_hypotheses.slice(0, 2).map((hypothesis) => sanitize(hypothesis.hypothesis)).join("; ")}.`);
+    }
+  }
+  if (!summary.latest_strategy && !checkpoint) lines.push("- No strategy or Dream checkpoint evidence found.");
+}
+
+function appendBlockers(lines: string[], summary: RuntimeEvidenceSummary): void {
+  lines.push("Blockers and approvals:");
+  const blockers = [
+    ...summary.evaluator_summary.approval_required_actions.map((action) => `approval required: ${action.label}`),
+    ...summary.recent_failed_attempts.map(entryLabel),
+    ...summary.failed_lineages.map((lineage) => lineage.representative_summary),
+  ].map(sanitize);
+  if (summary.evaluator_summary.gap) blockers.push(sanitize(`${summary.evaluator_summary.gap.kind}: ${summary.evaluator_summary.gap.summary}`));
+  if (blockers.length === 0) lines.push("- No blocker evidence found.");
+  else for (const blocker of blockers.slice(0, 5)) lines.push(`- ${blocker}.`);
+}
+
+function appendReportSummary(lines: string[], run: BackgroundRun, summary: RuntimeEvidenceSummary): void {
+  lines.push("Report-ready summary:");
+  lines.push(`- Include catalog status ${run.status}, ${summary.total_entries} evidence entries, and ${summary.metric_trends.length} metric trend(s).`);
+  if (summary.best_evidence) lines.push(`- Best evidence: ${entryLabel(summary.best_evidence)}.`);
+  if (summary.artifact_retention.total_artifacts > 0) lines.push(`- Artifact footprint: ${summary.artifact_retention.total_artifacts} artifact(s), ${summary.artifact_retention.protected_count} protected.`);
+  if (summary.research_memos.length > 0) lines.push(`- Research memo themes: ${summary.research_memos.slice(0, 2).map((memo) => sanitize(memo.summary)).join("; ")}.`);
+  if (summary.dream_checkpoints.length > 0) lines.push(`- Dream checkpoints: ${summary.dream_checkpoints.slice(0, 2).map((checkpoint) => sanitize(checkpoint.summary)).join("; ")}.`);
+}
+
+function appendEvidenceWarnings(lines: string[], summary: RuntimeEvidenceSummary, warningLines: string[]): void {
+  if (summary.warnings.length > 0) {
+    warningLines.push(...summary.warnings.slice(0, 3).map((warning) =>
+      `Evidence warning ${warning.file}:${warning.line}: ${warning.message}`
+    ));
+  }
+  if (summary.evaluator_summary.gap) {
+    warningLines.push(`Conflicting evaluator evidence: ${summary.evaluator_summary.gap.summary}`);
+  }
+  appendWarnings(lines, warningLines);
+}
+
+function appendWarnings(lines: string[], warnings: string[]): void {
+  if (warnings.length === 0) return;
+  lines.push("Evidence caveats:");
+  for (const warning of [...new Set(warnings.map(sanitize))].slice(0, 5)) lines.push(`- ${warning}.`);
+}
+
+function collectStalenessWarnings(summary: RuntimeEvidenceSummary, now: Date, warnings: string[]): void {
+  const generatedAt = Date.parse(summary.generated_at);
+  if (Number.isFinite(generatedAt) && now.getTime() - generatedAt > STALE_EVIDENCE_MS) {
+    warnings.push(`Evidence may be stale: summary generated ${summary.generated_at}`);
+  }
+  const latestEntry = summary.recent_entries[0] ?? summary.best_evidence ?? summary.latest_strategy;
+  if (latestEntry) {
+    const latestAt = Date.parse(latestEntry.occurred_at);
+    if (Number.isFinite(latestAt) && now.getTime() - latestAt > STALE_EVIDENCE_MS) {
+      warnings.push(`Latest evidence may be stale: ${latestEntry.occurred_at}`);
+    }
+  }
+}
+
+type EvidenceEntryLike = NonNullable<RuntimeEvidenceSummary["latest_strategy"]>;
+type EvaluatorObservation = NonNullable<RuntimeEvidenceSummary["evaluator_summary"]["local_best"]>;
+type CandidateSelection = NonNullable<RuntimeEvidenceSummary["candidate_selection_summary"]["raw_best"]>;
+type PortfolioSlot = RuntimeEvidenceSummary["recommended_candidate_portfolio"][number];
+
+function entryLabel(entry: EvidenceEntryLike): string {
+  const status = entry.outcome ?? entry.result?.status ?? entry.verification?.verdict ?? entry.kind;
+  const summary = entry.summary ?? entry.result?.summary ?? entry.decision_reason ?? entry.task?.description ?? "-";
+  return sanitize(`${entry.occurred_at} ${entry.kind}/${status}: ${summary}`);
+}
+
+function evaluatorObservationLabel(observation: EvaluatorObservation): string {
+  const candidate = observation.candidate_label ?? observation.candidate_id;
+  const score = observation.score === undefined ? "" : ` score=${String(observation.score)}`;
+  return sanitize(`${observation.evaluator_id}/${observation.source} ${candidate} status=${observation.status}${score}`);
+}
+
+function candidateLabel(candidate: CandidateSelection | PortfolioSlot): string {
+  const metric = isCandidateSelection(candidate) ? candidate.raw_metric : candidate.metric;
+  const score = metric ? ` ${metric.label}=${metric.value}` : "";
+  return sanitize(`${candidate.label ?? candidate.candidate_id} (${candidate.strategy_family}${score})`);
+}
+
+function isCandidateSelection(candidate: CandidateSelection | PortfolioSlot): candidate is CandidateSelection {
+  return "raw_rank" in candidate;
+}
+
+function timestamp(value: string | null | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function round(value: number): string {
+  return Number.isFinite(value) ? value.toFixed(2) : String(value);
+}
+
+function sanitize(value: string): string {
+  return value
+    .replace(/sk-[A-Za-z0-9_-]{12,}/g, "sk-[REDACTED]")
+    .replace(/gh[pousr]_[A-Za-z0-9_]{12,}/g, "gh_[REDACTED]")
+    .replace(/xox[baprs]-[A-Za-z0-9-]{12,}/g, "xox-[REDACTED]")
+    .replace(/([?&](?:token|key|secret|password)=)[^&\s]+/gi, "$1[REDACTED]")
+    .replace(/(^|\s)(?:token|secret|password|api_key)=\S+/gi, "$1[REDACTED]");
+}


### PR DESCRIPTION
Closes #850

## Summary
- add a deterministic runtime evidence answer layer for progress, metrics, artifacts/candidates, strategy, blockers/approvals, and report-summary questions
- route TUI natural-language evidence questions through Runtime Session Catalog, Runtime Evidence Ledger, and Runtime Health before generic ChatRunner fallback
- explicitly report missing, stale, and conflicting evidence; redact common token/secret forms in rendered answers
- keep answer handling read-only with no submit/publish/external mutation behavior

## Verification
- npx vitest run --config vitest.integration.config.ts src/runtime/__tests__/runtime-evidence-answer.test.ts src/interface/tui/__tests__/app.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check
- npm run test:all

## Known unresolved risks
- TUI integration is local-first; non-TUI chat surfaces still route evidence questions through their existing chat path
- Run selection is intentionally conservative and answers the highest-priority active/attention/recent run, reporting missing evidence for that run rather than falling back to older evidenced runs