### PR TITLE
refactor(tui): remove keyword-first intent recognizer

### DIFF
--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -371,6 +371,46 @@ describe("standalone slash command routing", () => {
     screen.unmount();
   });
 
+  it("keeps bare command-like natural text on the freeform caller path", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const intentRecognizer = {
+      recognize: vi.fn(async () => ({ intent: "loop_start", raw: "run" })),
+    };
+    const actionHandler = {
+      handle: vi.fn(async () => ({ messages: ["unexpected"] })),
+    };
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      intentRecognizer: intentRecognizer as any,
+      actionHandler: actionHandler as any,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("run");
+    await testState.lastChatProps!.onSubmit("estado actual del trabajo");
+
+    expect(chatRunner.execute).toHaveBeenNthCalledWith(1, "run", "~/workspace");
+    expect(chatRunner.execute).toHaveBeenNthCalledWith(2, "estado actual del trabajo", "~/workspace");
+    expect(intentRecognizer.recognize).not.toHaveBeenCalled();
+    expect(actionHandler.handle).not.toHaveBeenCalled();
+
+    screen.unmount();
+  });
+
   it("persists a RunSpec draft and waits for confirmation before forwarding long-running runs", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();

--- a/src/interface/tui/__tests__/intent-recognizer.test.ts
+++ b/src/interface/tui/__tests__/intent-recognizer.test.ts
@@ -1,18 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { z } from "zod";
+import type { ZodSchema } from "zod";
 import { IntentRecognizer } from "../intent-recognizer.js";
-import type { ILLMClient, LLMMessage, LLMRequestOptions, LLMResponse } from "../../../base/llm/llm-client.js";
+import type { ILLMClient, LLMResponse } from "../../../base/llm/llm-client.js";
 import { createSingleMockLLMClient as makeMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 
-// ─── Keyword matching ───
+// ─── Exact command grammar ───
 
-describe("IntentRecognizer — keyword matching", () => {
-  const recognizer = new IntentRecognizer(); // no LLM
+describe("IntentRecognizer — exact command grammar", () => {
+  const recognizer = new IntentRecognizer();
 
   it("recognizes loop_stop: '/stop'", async () => {
     const result = await recognizer.recognize("/stop");
     expect(result.intent).toBe("loop_stop");
     expect(result.raw).toBe("/stop");
+    expect(result.source).toBe("command");
+    expect(result.confidence).toBe(1);
   });
 
   it("recognizes loop_stop: '/quit'", async () => {
@@ -60,10 +62,11 @@ describe("IntentRecognizer — keyword matching", () => {
     expect(result.intent).toBe("help");
   });
 
-  it("returns unknown for unrecognized input without LLM", async () => {
+  it("returns typed unknown for natural-language input without a classifier", async () => {
     const result = await recognizer.recognize("READMEを書いてほしい");
     expect(result.intent).toBe("unknown");
     expect(result.raw).toBe("READMEを書いてほしい");
+    expect(result.source).toBe("unavailable");
   });
 
   it("preserves original raw input", async () => {
@@ -72,44 +75,42 @@ describe("IntentRecognizer — keyword matching", () => {
     expect(result.raw).toBe(input);
   });
 
-  // ─── Bare words without / prefix are NOT commands ───
-
-  it("bare 'help' is NOT the help command (treated as unknown without LLM)", async () => {
+  it("bare 'help' is NOT the help command without a classifier", async () => {
     const result = await recognizer.recognize("help");
     expect(result.intent).toBe("unknown");
   });
 
-  it("bare 'run' is NOT the run command (treated as unknown without LLM)", async () => {
+  it("bare 'run' is NOT the run command without a classifier", async () => {
     const result = await recognizer.recognize("run");
     expect(result.intent).toBe("unknown");
   });
 
-  it("bare 'stop' is NOT the stop command (treated as unknown without LLM)", async () => {
+  it("bare 'stop' is NOT the stop command without a classifier", async () => {
     const result = await recognizer.recognize("stop");
     expect(result.intent).toBe("unknown");
   });
 
-  it("bare 'status' is NOT the status command (treated as unknown without LLM)", async () => {
+  it("bare 'status' is NOT the status command without a classifier", async () => {
     const result = await recognizer.recognize("status");
     expect(result.intent).toBe("unknown");
   });
 
-  it("bare 'report' is NOT the report command (treated as unknown without LLM)", async () => {
+  it("bare 'report' is NOT the report command without a classifier", async () => {
     const result = await recognizer.recognize("report");
     expect(result.intent).toBe("unknown");
   });
 
-  it("bare 'goals' is NOT the goal_list command (treated as unknown without LLM)", async () => {
+  it("bare 'goals' is NOT the goal_list command without a classifier", async () => {
     const result = await recognizer.recognize("goals");
     expect(result.intent).toBe("unknown");
   });
 
-  it("natural sentence 'how does help work?' is NOT the help command", async () => {
+  it("natural sentence 'how does help work?' is NOT the help command without a classifier", async () => {
     const result = await recognizer.recognize("how does help work?");
     expect(result.intent).toBe("unknown");
   });
 
-  it("natural sentence 'how do I run this?' is NOT the run command", async () => {
+  it("natural sentence 'how do I run this?' is NOT the run command without a classifier", async () => {
     const result = await recognizer.recognize("how do I run this?");
     expect(result.intent).toBe("unknown");
   });
@@ -130,12 +131,13 @@ describe("IntentRecognizer — keyword matching", () => {
   });
 });
 
-// ─── LLM fallback ───
+// ─── Natural-language classifier ───
 
-describe("IntentRecognizer — LLM fallback", () => {
+describe("IntentRecognizer — structured natural-language classifier", () => {
   it("returns chat intent with response for conversational input", async () => {
     const mockResponse = JSON.stringify({
       intent: "chat",
+      confidence: 0.95,
       response: "PulSeed manages goals with measurable dimensions. You currently have no active goals.",
     });
     const llm = makeMockLLMClient(mockResponse);
@@ -144,11 +146,14 @@ describe("IntentRecognizer — LLM fallback", () => {
     const result = await recognizer.recognize("What can PulSeed do?");
     expect(result.intent).toBe("chat");
     expect(result.response).toBe("PulSeed manages goals with measurable dimensions. You currently have no active goals.");
+    expect(result.source).toBe("classifier");
+    expect(result.confidence).toBe(0.95);
   });
 
   it("returns goal_create intent with description in params when user clearly wants to create a goal", async () => {
     const mockResponse = JSON.stringify({
       intent: "goal_create",
+      confidence: 0.93,
       response: "Creating goal: write a README",
       params: { description: "READMEを書く" },
     });
@@ -158,11 +163,13 @@ describe("IntentRecognizer — LLM fallback", () => {
     const result = await recognizer.recognize("READMEを書いてほしい");
     expect(result.intent).toBe("goal_create");
     expect(result.params?.["description"]).toBe("READMEを書く");
+    expect(result.confidence).toBe(0.93);
   });
 
-  it("LLM fallback returns loop_start intent with goalId param", async () => {
+  it("structured classifier returns loop_start intent with goalId param", async () => {
     const mockResponse = JSON.stringify({
       intent: "loop_start",
+      confidence: 0.91,
       response: "Starting goal goal-123.",
       params: { goalId: "goal-123" },
     });
@@ -174,12 +181,12 @@ describe("IntentRecognizer — LLM fallback", () => {
     expect(result.params?.["goalId"]).toBe("goal-123");
   });
 
-  it("falls back to unknown on LLM error", async () => {
+  it("returns unknown on classifier error without retrying command grammar", async () => {
     const llm: ILLMClient = {
       async sendMessage(): Promise<LLMResponse> {
         throw new Error("LLM unavailable");
       },
-      parseJSON<T>(_c: string, _s: z.ZodSchema<T>): T {
+      parseJSON<T>(_c: string, _s: ZodSchema<T>): T {
         throw new Error("unreachable");
       },
     };
@@ -187,11 +194,13 @@ describe("IntentRecognizer — LLM fallback", () => {
 
     const result = await recognizer.recognize("something unknown");
     expect(result.intent).toBe("unknown");
+    expect(result.source).toBe("unavailable");
   });
 
   it("chat intent populates response field on RecognizedIntent", async () => {
     const mockResponse = JSON.stringify({
       intent: "chat",
+      confidence: 0.89,
       response: "You can use 'run' to start the goal loop.",
     });
     const llm = makeMockLLMClient(mockResponse);
@@ -203,16 +212,18 @@ describe("IntentRecognizer — LLM fallback", () => {
   });
 
   it("returns unknown intent when LLM responds with 'unknown'", async () => {
-    const mockResponse = JSON.stringify({ intent: "unknown" });
+    const mockResponse = JSON.stringify({ intent: "unknown", confidence: 0.8 });
     const llm = makeMockLLMClient(mockResponse);
     const recognizer = new IntentRecognizer(llm);
 
     const result = await recognizer.recognize("some ambiguous input");
     expect(result.intent).toBe("unknown");
+    expect(result.source).toBe("classifier");
+    expect(result.confidence).toBe(0.8);
   });
 
   it("does not include empty params object when no params returned", async () => {
-    const mockResponse = JSON.stringify({ intent: "chat", response: "Hello!" });
+    const mockResponse = JSON.stringify({ intent: "chat", confidence: 0.9, response: "Hello!" });
     const llm = makeMockLLMClient(mockResponse);
     const recognizer = new IntentRecognizer(llm);
 
@@ -220,5 +231,82 @@ describe("IntentRecognizer — LLM fallback", () => {
     // params will contain the response string but not description/goalId keys
     expect(result.params?.["description"]).toBeUndefined();
     expect(result.params?.["goalId"]).toBeUndefined();
+  });
+
+  it("routes bare command-like words through the classifier instead of command grammar", async () => {
+    const llm = makeMockLLMClient(JSON.stringify({
+      intent: "chat",
+      confidence: 0.92,
+      response: "Tell me which goal you want to run.",
+    }));
+    const recognizer = new IntentRecognizer(llm);
+
+    const result = await recognizer.recognize("run");
+
+    expect(llm.callCount).toBe(1);
+    expect(result.intent).toBe("chat");
+    expect(result.source).toBe("classifier");
+  });
+
+  it("routes broad English phrases through the classifier instead of broad command matching", async () => {
+    const llm = makeMockLLMClient(JSON.stringify({
+      intent: "chat",
+      confidence: 0.9,
+      response: "Here is how to inspect status.",
+    }));
+    const recognizer = new IntentRecognizer(llm);
+
+    const result = await recognizer.recognize("can you show me the status of the current run?");
+
+    expect(llm.callCount).toBe(1);
+    expect(result.intent).toBe("chat");
+  });
+
+  it("routes Japanese natural-language requests through the same classifier path", async () => {
+    const llm = makeMockLLMClient(JSON.stringify({
+      intent: "goal_create",
+      confidence: 0.94,
+      response: "Creating goal.",
+      params: { description: "READMEを更新する" },
+    }));
+    const recognizer = new IntentRecognizer(llm);
+
+    const result = await recognizer.recognize("READMEを更新するゴールを作って");
+
+    expect(llm.callCount).toBe(1);
+    expect(result.intent).toBe("goal_create");
+    expect(result.params?.["description"]).toBe("READMEを更新する");
+    expect(result.source).toBe("classifier");
+  });
+
+  it("routes third-language natural-language requests through the same classifier path", async () => {
+    const llm = makeMockLLMClient(JSON.stringify({
+      intent: "loop_start",
+      confidence: 0.88,
+      response: "Starting the requested goal.",
+      params: { goalId: "goal-es" },
+    }));
+    const recognizer = new IntentRecognizer(llm);
+
+    const result = await recognizer.recognize("inicia el objetivo goal-es, por favor");
+
+    expect(llm.callCount).toBe(1);
+    expect(result.intent).toBe("loop_start");
+    expect(result.params?.["goalId"]).toBe("goal-es");
+  });
+
+  it("returns typed unknown for low-confidence natural-language classifications", async () => {
+    const llm = makeMockLLMClient(JSON.stringify({
+      intent: "loop_stop",
+      confidence: 0.41,
+      response: "I am not sure whether you want to stop.",
+    }));
+    const recognizer = new IntentRecognizer(llm);
+
+    const result = await recognizer.recognize("maybe pause later or explain stopping?");
+
+    expect(result.intent).toBe("unknown");
+    expect(result.source).toBe("classifier");
+    expect(result.confidence).toBe(0.41);
   });
 });

--- a/src/interface/tui/intent-recognizer.ts
+++ b/src/interface/tui/intent-recognizer.ts
@@ -21,49 +21,30 @@ export interface RecognizedIntent {
   params?: Record<string, string>; // e.g., { description: "write a README" }
   response?: string; // conversational response text for "chat" intent
   raw: string; // original user input
+  source?: "command" | "classifier" | "unavailable";
+  confidence?: number;
 }
 
-// ─── Keyword table ───
+// ─── Exact command grammar ───
 
-interface KeywordRule {
-  pattern: RegExp;
-  intent: IntentType;
-}
-
-const KEYWORD_RULES: KeywordRule[] = [
-  {
-    pattern: /^\/?\?(help)?$/i,
-    intent: "help",
-  },
-  {
-    pattern: /^\/(stop|quit|exit)/i,
-    intent: "loop_stop",
-  },
-  {
-    pattern: /^\/(run|start)(\s+.*)?$/i,
-    intent: "loop_start",
-  },
-  {
-    pattern: /^\/status$/i,
-    intent: "status",
-  },
-  {
-    pattern: /^\/report$/i,
-    intent: "report",
-  },
-  {
-    pattern: /^\/(goals?\s*(list)?)$/i,
-    intent: "goal_list",
-  },
-  {
-    pattern: /^\/help$/i,
-    intent: "help",
-  },
-  {
-    pattern: /^\/(dashboard|d)$/i,
-    intent: "dashboard",
-  },
-];
+const COMMAND_ALIASES: Record<string, IntentType> = {
+  "?": "help",
+  "/?": "help",
+  "/help": "help",
+  "/stop": "loop_stop",
+  "/quit": "loop_stop",
+  "/exit": "loop_stop",
+  "/run": "loop_start",
+  "/start": "loop_start",
+  "/status": "status",
+  "/report": "report",
+  "/goals": "goal_list",
+  "/goal": "goal_list",
+  "/goals list": "goal_list",
+  "/goal list": "goal_list",
+  "/dashboard": "dashboard",
+  "/d": "dashboard",
+};
 
 // ─── LLM response schema ───
 
@@ -75,12 +56,15 @@ const LLMIntentSchema = z.object({
     "chat",
     "unknown",
   ]),
+  confidence: z.number().min(0).max(1),
   response: z.string().optional(),
   params: z.object({
     description: z.string().optional(),
     goalId: z.string().optional(),
   }).optional(),
 });
+
+const MIN_CLASSIFIER_CONFIDENCE = 0.7;
 
 function getSystemPrompt(): string {
   return `${getInternalIdentityPrefix("assistant")} PulSeed is an AI agent orchestrator that manages goals with measurable dimensions.
@@ -90,56 +74,66 @@ Available actions you can trigger:
 - loop_start: When the user wants to start executing a goal.
 - loop_stop: When the user wants to stop execution.
 
-For any other input, respond conversationally. Explain PulSeed's state, answer questions, or suggest what to do.
+For any other input, respond conversationally. Explain PulSeed's state, answer questions, or suggest what to do. If the user's intent is ambiguous or too low-confidence to act on, return unknown.
 
-Respond in JSON: { "intent": "chat" | "goal_create" | "loop_start" | "loop_stop", "response": "your response text", "params": { "description": "..." } }`;
+Respond in JSON: { "intent": "chat" | "goal_create" | "loop_start" | "loop_stop" | "unknown", "confidence": 0.0-1.0, "response": "your response text", "params": { "description": "..." } }`;
 }
 
 // ─── IntentRecognizer ───
 
 /**
- * Hybrid intent recognizer: tries keyword regex first (free), falls back to LLM.
+ * TUI intent recognizer.
+ *
+ * Exact slash/symbol commands are parsed as command grammar. Freeform
+ * natural-language input is classified through the structured LLM contract.
  */
 export class IntentRecognizer {
   constructor(private llmClient?: ILLMClient) {}
 
   async recognize(input: string): Promise<RecognizedIntent> {
-    // 1. Try keyword match first (cost: $0, instant)
-    const keywordResult = this.keywordMatch(input);
-    if (keywordResult) return keywordResult;
+    const commandResult = this.parseExactCommand(input);
+    if (commandResult) return commandResult;
 
-    // 2. LLM fallback if available
-    if (this.llmClient) return this.llmFallback(input);
+    if (this.llmClient) return this.classifyNaturalLanguage(input);
 
-    // 3. No match, no LLM
-    return { intent: "unknown", raw: input };
+    return { intent: "unknown", raw: input, source: "unavailable" };
   }
 
-  private keywordMatch(input: string): RecognizedIntent | null {
+  private parseExactCommand(input: string): RecognizedIntent | null {
     const trimmed = input.trim();
-    for (const rule of KEYWORD_RULES) {
-      if (rule.pattern.test(trimmed)) {
-        // For loop_start, extract optional goal argument (number or name)
-        if (rule.intent === "loop_start") {
-          const match = trimmed.match(/^\/(run|start)\s+(.+)$/i);
-          const goalArg = match ? match[2].trim() : undefined;
-          const params: Record<string, string> = goalArg ? { goalArg } : {};
-          return {
-            intent: rule.intent,
-            params: Object.keys(params).length > 0 ? params : undefined,
-            raw: input,
-          };
-        }
-        return { intent: rule.intent, raw: input };
-      }
+    const normalized = trimmed.toLowerCase().replace(/\s+/g, " ");
+    const [commandToken, ...argTokens] = normalized.split(" ");
+    if (!commandToken) return null;
+    const command = COMMAND_ALIASES[normalized] ?? COMMAND_ALIASES[commandToken];
+    if (!command) return null;
+
+    if (command === "loop_start" && (commandToken === "/run" || commandToken === "/start")) {
+      const originalTokens = trimmed.split(/\s+/);
+      const goalArg = originalTokens.slice(1).join(" ").trim();
+      return {
+        intent: command,
+        params: goalArg ? { goalArg } : undefined,
+        raw: input,
+        source: "command",
+        confidence: 1,
+      };
     }
-    return null;
+
+    if (argTokens.length > 0 && !COMMAND_ALIASES[normalized]) {
+      return null;
+    }
+
+    return {
+      intent: command,
+      raw: input,
+      source: "command",
+      confidence: 1,
+    };
   }
 
-  private async llmFallback(input: string): Promise<RecognizedIntent> {
-    // llmFallback is only called when this.llmClient is defined (see recognize())
+  private async classifyNaturalLanguage(input: string): Promise<RecognizedIntent> {
     const llmClient = this.llmClient;
-    if (!llmClient) return { intent: "unknown", raw: input };
+    if (!llmClient) return { intent: "unknown", raw: input, source: "unavailable" };
     try {
       const llmResponse = await llmClient.sendMessage(
         [{ role: "user", content: input }],
@@ -148,10 +142,19 @@ export class IntentRecognizer {
 
       const parsed = llmClient.parseJSON(llmResponse.content, LLMIntentSchema);
 
+      if (parsed.intent === "unknown" || parsed.confidence < MIN_CLASSIFIER_CONFIDENCE) {
+        return {
+          intent: "unknown",
+          raw: input,
+          source: "classifier",
+          confidence: parsed.confidence,
+          response: parsed.response,
+        };
+      }
+
       const params: Record<string, string> = {};
       if (parsed.params?.description) params["description"] = parsed.params.description;
       if (parsed.params?.goalId) params["goalId"] = parsed.params.goalId;
-      // For chat intent, also expose response text via params for legacy compatibility
       if (parsed.response) params["response"] = parsed.response;
 
       return {
@@ -159,11 +162,13 @@ export class IntentRecognizer {
         params: Object.keys(params).length > 0 ? params : undefined,
         response: parsed.response,
         raw: input,
+        source: "classifier",
+        confidence: parsed.confidence,
       };
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      console.error(`[IntentRecognizer] LLM fallback failed: ${msg}`);
-      return { intent: "unknown", raw: input };
+      console.error(`[IntentRecognizer] natural-language classifier failed: ${msg}`);
+      return { intent: "unknown", raw: input, source: "unavailable" };
     }
   }
 }


### PR DESCRIPTION
Closes #870

## Implementation Summary

- Replaced the TUI intent recognizer's regex rule table with an exact command grammar for slash/symbol protocol commands.
- Added a confidence-bearing structured natural-language classifier path for freeform TUI intent recognition.
- Return typed `unknown` for low-confidence, parse-failure, or model-unavailable cases instead of falling back to keyword matching.
- Added recognizer coverage for bare command-like words, broad English phrasing, Japanese input, Spanish input, and a TUI caller-path regression that keeps bare natural text off standalone slash handlers.

## Verification Commands

- `npm exec -- vitest run src/interface/tui/__tests__/intent-recognizer.test.ts`
- `npm exec -- vitest run src/interface/tui/__tests__/intent-recognizer.test.ts src/interface/tui/__tests__/app.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (0 errors, existing warnings)
- `npm run test:changed`
- Fresh review agent: LGTM, no material findings

## Known Remaining Risks

- The natural-language classifier still depends on the configured LLM being available; unavailable/invalid responses now return typed `unknown` instead of guessing.
- Exact slash command aliases remain intentionally deterministic command grammar.
