### PR TITLE
refactor(runtime-evidence): replace keyword topic detection

### DIFF
--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -5,6 +5,7 @@ import type { DaemonClient } from "../../../runtime/daemon/client.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { TuiChatSurface } from "../chat-surface.js";
 import { App, DASHBOARD_REFRESH_INTERVAL_MS, formatDaemonConnectionState } from "../app.js";
+import { createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 
 const testState = vi.hoisted(() => ({
   lastChatProps: null as null | { onSubmit: (value: string) => Promise<void> },
@@ -490,6 +491,11 @@ describe("standalone slash command routing", () => {
   it("answers natural-language run progress questions from runtime evidence before ChatRunner", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
+    const llmClient = createSingleMockLLMClient(JSON.stringify({
+      decision: "runtime_evidence_question",
+      topics: ["progress", "metric"],
+      confidence: 0.93,
+    }));
     testState.runtimeSessionSnapshots = [{
       schema_version: "runtime-session-registry-v1",
       generated_at: "2026-05-02T00:00:00.000Z",
@@ -524,6 +530,7 @@ describe("standalone slash command routing", () => {
 
     const screen = render(React.createElement(App, {
       stateManager: stateManager as unknown as StateManager,
+      llmClient,
       chatRunner: chatRunner as unknown as TuiChatSurface,
       noFlicker: false,
       controlStream: process.stdout,
@@ -544,8 +551,47 @@ describe("standalone slash command routing", () => {
 
     expect(chatRunner.execute).not.toHaveBeenCalled();
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+    expect(llmClient.callCount).toBe(1);
     expect(testState.lastChatMessages.map((message) => message.text).join("\n")).toContain("Runtime evidence answer for run run-evidence");
     expect(testState.lastChatMessages.map((message) => message.text).join("\n")).toContain("balanced_accuracy");
+
+    screen.unmount();
+  });
+
+  it("routes non-evidence multilingual chat through ChatRunner when classifier says not evidence", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const llmClient = createSingleMockLLMClient(JSON.stringify({
+      decision: "not_runtime_evidence_question",
+      topics: [],
+      confidence: 0.96,
+      rationale: "asks for an explanation, not persisted runtime evidence",
+    }));
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      llmClient,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/work/kaggle",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("このタスクの進め方を説明して");
+    await flush();
+
+    expect(llmClient.callCount).toBe(1);
+    expect(chatRunner.execute).toHaveBeenCalledWith("このタスクの進め方を説明して", "/work/kaggle");
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
 
     screen.unmount();
   });
@@ -553,9 +599,16 @@ describe("standalone slash command routing", () => {
   it("routes natural-language runtime control through ChatRunner from the TUI freeform input", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
+    const llmClient = createSingleMockLLMClient(JSON.stringify({
+      decision: "not_runtime_evidence_question",
+      topics: [],
+      confidence: 0.97,
+      rationale: "runtime-control request, not evidence Q&A",
+    }));
 
     const screen = render(React.createElement(App, {
       stateManager: stateManager as unknown as StateManager,
+      llmClient,
       chatRunner: chatRunner as unknown as TuiChatSurface,
       noFlicker: false,
       controlStream: process.stdout,
@@ -576,6 +629,7 @@ describe("standalone slash command routing", () => {
 
     expect(chatRunner.execute).toHaveBeenCalledWith("この実行を一時停止して", "/work/kaggle");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+    expect(llmClient.callCount).toBe(1);
 
     screen.unmount();
   });

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -30,6 +30,7 @@ import type { ActionHandler } from "./actions.js";
 import type { IntentRecognizer } from "./intent-recognizer.js";
 import type { CoreLoop } from "../../orchestrator/loop/core-loop.js";
 import type { StateManager } from "../../base/state/state-manager.js";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
 import type { TrustManager } from "../../platform/traits/trust-manager.js";
 import type { Task } from "../../base/types/task.js";
 import type { TuiChatSurface } from "./chat-surface.js";
@@ -222,6 +223,7 @@ interface AppProps {
   trustManager?: TrustManager;
   actionHandler?: ActionHandler;
   intentRecognizer?: IntentRecognizer;
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;
   chatRunner?: TuiChatSurface;
   onApprovalReady?: (requestFn: (req: ApprovalRequest) => void) => void;
   // Shared
@@ -275,6 +277,7 @@ export function App({
   trustManager,
   actionHandler,
   intentRecognizer,
+  llmClient,
   chatRunner,
   onApprovalReady,
   cwd,
@@ -757,6 +760,7 @@ export function App({
           const evidenceAnswer = await answerRuntimeEvidenceQuestion({
             text: input,
             stateManager,
+            llmClient,
           });
           if (evidenceAnswer.kind === "answered" && evidenceAnswer.message) {
             const message = evidenceAnswer.message;
@@ -836,7 +840,7 @@ export function App({
         setIsProcessing(false);
       }
     },
-    [intentRecognizer, actionHandler, chatRunner, daemonClient, isDaemonMode, daemonLoopState.goalId, startLoop, stopLoop, isProcessing, cwd, stateManager, pendingRunSpec]
+    [intentRecognizer, actionHandler, llmClient, chatRunner, daemonClient, isDaemonMode, daemonLoopState.goalId, startLoop, stopLoop, isProcessing, cwd, stateManager, pendingRunSpec]
   );
 
   // goalCount: 1 when there is an active goal in the loop, 0 otherwise

--- a/src/interface/tui/entry-deps.ts
+++ b/src/interface/tui/entry-deps.ts
@@ -9,6 +9,7 @@ import { getCliLogger } from "../cli/cli-logger.js";
 import type { Task } from "../../base/types/task.js";
 import { createApprovalQueue, createChatToolApprovalTask } from "./entry-approval.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
 
 export async function buildStandaloneTuiDeps() {
   const { buildLLMClient, buildAdapterRegistry } = await import("../../base/llm/provider-factory.js");
@@ -376,6 +377,7 @@ export async function buildDaemonModeChatSurface(
   daemonPort: number
 ): Promise<{
   chatRunner: TuiChatSurface | undefined;
+  llmClient: ILLMClient | undefined;
   setRequestApproval: (fn: (req: ApprovalRequest) => void) => void;
 }> {
   const { TrustManager } = await import("../../platform/traits/trust-manager.js");
@@ -414,6 +416,7 @@ export async function buildDaemonModeChatSurface(
     approvalQueue.enqueueApproval(createChatToolApprovalTask(description));
 
   let chatRunner: TuiChatSurface | undefined;
+  let llmClient: ILLMClient | undefined;
   const providerConfig = await loadProviderConfig();
   try {
     const { SharedManagerTuiChatSurface } = await import("./chat-surface.js");
@@ -427,7 +430,7 @@ export async function buildDaemonModeChatSurface(
     const { EthicsGate } = await import("../../platform/traits/ethics-gate.js");
     const { ObservationEngine } = await import("../../platform/observation/observation-engine.js");
     const { RuntimeControlService, createDaemonRuntimeControlExecutor } = await import("../../runtime/control/index.js");
-    const llmClient = await buildLLMClient();
+    llmClient = await buildLLMClient();
     const adapterRegistry = await buildAdapterRegistry(llmClient);
     const observationEngine = new ObservationEngine(stateManager, dataSourceRegistry.getAllSources(), llmClient);
     const ethicsGate = new EthicsGate(stateManager, llmClient);
@@ -490,6 +493,7 @@ export async function buildDaemonModeChatSurface(
 
   return {
     chatRunner,
+    llmClient,
     setRequestApproval: approvalQueue.setRequestApproval,
   };
 }

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -55,7 +55,7 @@ async function startTUIStandaloneMode(): Promise<void> {
       process.exit(1);
     }
 
-    const { stateManager, trustManager, coreLoop, actionHandler, intentRecognizer, setRequestApproval, chatRunner } = deps;
+    const { stateManager, llmClient, trustManager, coreLoop, actionHandler, intentRecognizer, setRequestApproval, chatRunner } = deps;
 
     process.on("SIGTERM", () => { coreLoop.stop(); process.exit(0); });
 
@@ -80,6 +80,7 @@ async function startTUIStandaloneMode(): Promise<void> {
       trustManager,
       actionHandler,
       intentRecognizer,
+      llmClient,
       chatRunner,
       onApprovalReady: setRequestApproval,
       noFlicker,
@@ -161,7 +162,7 @@ async function startTUIDaemonMode(): Promise<void> {
 
     const stateManager = new StateManager(baseDir);
     await stateManager.init();
-    const { chatRunner, setRequestApproval } = await buildDaemonModeChatSurface(
+    const { chatRunner, llmClient, setRequestApproval } = await buildDaemonModeChatSurface(
       baseDir,
       stateManager,
       daemonClient,
@@ -189,6 +190,7 @@ async function startTUIDaemonMode(): Promise<void> {
     const appElement = React.createElement(App, {
       daemonClient,
       stateManager,
+      llmClient,
       cwd,
       gitBranch,
       providerName,

--- a/src/runtime/__tests__/runtime-evidence-answer.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-answer.test.ts
@@ -5,11 +5,12 @@ import { describe, expect, it } from "vitest";
 import {
   answerRuntimeEvidenceQuestion,
   buildRuntimeEvidenceAnswer,
-  recognizeRuntimeEvidenceQuestion,
+  understandRuntimeEvidenceQuestion,
 } from "../evidence-answer.js";
 import type { BackgroundRun } from "../session-registry/types.js";
 import { BackgroundRunLedger } from "../store/background-run-store.js";
 import { RuntimeEvidenceLedger, type RuntimeEvidenceSummary } from "../store/evidence-ledger.js";
+import { createSingleMockLLMClient } from "../../../tests/helpers/mock-llm.js";
 
 const NOW = new Date("2026-05-02T00:30:00.000Z");
 
@@ -106,12 +107,69 @@ function summary(overrides: Partial<RuntimeEvidenceSummary> = {}): RuntimeEviden
   };
 }
 
-describe("recognizeRuntimeEvidenceQuestion", () => {
-  it("recognizes evidence questions without treating long-run start requests as questions", () => {
-    expect(recognizeRuntimeEvidenceQuestion("Progress?")).toContain("progress");
-    expect(recognizeRuntimeEvidenceQuestion("What strategy is it trying now?")).toContain("strategy");
-    expect(recognizeRuntimeEvidenceQuestion("Which artifact is best?")).toEqual(expect.arrayContaining(["metric", "artifact"]));
-    expect(recognizeRuntimeEvidenceQuestion("Run this Kaggle competition until tomorrow morning")).toEqual([]);
+describe("understandRuntimeEvidenceQuestion", () => {
+  it("uses structured query understanding for evidence topics", async () => {
+    const llmClient = createSingleMockLLMClient(JSON.stringify({
+      decision: "runtime_evidence_question",
+      topics: ["metric", "artifact"],
+      confidence: 0.92,
+      rationale: "asks which persisted artifact is best",
+    }));
+
+    const result = await understandRuntimeEvidenceQuestion("Which artifact is best?", llmClient);
+
+    expect(result.decision).toBe("runtime_evidence_question");
+    expect(result.topics).toEqual(["metric", "artifact"]);
+    expect(result.confidence).toBe(0.92);
+    expect(llmClient.callCount).toBe(1);
+  });
+
+  it("returns not_runtime_evidence_question for ordinary work instructions", async () => {
+    const llmClient = createSingleMockLLMClient(JSON.stringify({
+      decision: "not_runtime_evidence_question",
+      topics: [],
+      confidence: 0.95,
+      rationale: "asks to start new work, not to inspect persisted evidence",
+    }));
+
+    const result = await understandRuntimeEvidenceQuestion("Run this Kaggle competition until tomorrow morning", llmClient);
+
+    expect(result.decision).toBe("not_runtime_evidence_question");
+    expect(result.topics).toEqual([]);
+  });
+
+  it("handles multilingual evidence questions through the same structured classifier", async () => {
+    const llmClient = createSingleMockLLMClient(JSON.stringify({
+      decision: "runtime_evidence_question",
+      topics: ["progress", "strategy"],
+      confidence: 0.88,
+    }));
+
+    const result = await understandRuntimeEvidenceQuestion("今の実行はどこまで進んでいて、次の作戦は何？", llmClient);
+
+    expect(result.decision).toBe("runtime_evidence_question");
+    expect(result.topics).toEqual(["progress", "strategy"]);
+  });
+
+  it("does not classify low-confidence model output as evidence Q&A", async () => {
+    const llmClient = createSingleMockLLMClient(JSON.stringify({
+      decision: "runtime_evidence_question",
+      topics: ["progress"],
+      confidence: 0.42,
+      rationale: "ambiguous",
+    }));
+
+    const result = await understandRuntimeEvidenceQuestion("maybe tell me about it later", llmClient);
+
+    expect(result.decision).toBe("not_runtime_evidence_question");
+    expect(result.topics).toEqual([]);
+  });
+
+  it("does not use a keyword fallback when the classifier is unavailable", async () => {
+    const result = await understandRuntimeEvidenceQuestion("Progress?");
+
+    expect(result.decision).toBe("not_runtime_evidence_question");
+    expect(result.topics).toEqual([]);
   });
 });
 
@@ -330,6 +388,11 @@ describe("buildRuntimeEvidenceAnswer", () => {
     const result = await answerRuntimeEvidenceQuestion({
       text: "Progress?",
       stateManager,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "runtime_evidence_question",
+        topics: ["progress"],
+        confidence: 0.94,
+      })),
       now: NOW,
     });
 
@@ -339,6 +402,121 @@ describe("buildRuntimeEvidenceAnswer", () => {
     expect(result.message).toContain("Runtime evidence answer for run run-active");
     expect(result.message).toContain("Evidence missing");
     expect(result.message).not.toContain("score");
+  });
+
+  it("uses explicit classifier target run IDs when they match the catalog", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-evidence-target-run-"));
+    const stateManager = { getBaseDir: () => tmp };
+    const ledger = new RuntimeEvidenceLedger(path.join(tmp, "runtime"));
+    const runLedger = new BackgroundRunLedger(path.join(tmp, "runtime"));
+    await ledger.append({
+      kind: "metric",
+      scope: { run_id: "run-target" },
+      occurred_at: "2026-05-02T00:20:00.000Z",
+      metrics: [{ label: "score", value: 0.97, direction: "maximize", observed_at: "2026-05-02T00:20:00.000Z" }],
+      summary: "target run evidence",
+    });
+    await runLedger.create({
+      id: "run-active",
+      kind: "coreloop_run",
+      status: "running",
+      notify_policy: "silent",
+      title: "Active run",
+      workspace: "/repo",
+      created_at: "2026-05-02T00:00:00.000Z",
+      started_at: "2026-05-02T00:00:00.000Z",
+      updated_at: "2026-05-02T00:25:00.000Z",
+    });
+    for (let index = 0; index < 9; index += 1) {
+      await runLedger.create({
+        id: `run-recent-${index}`,
+        kind: "coreloop_run",
+        status: "running",
+        notify_policy: "silent",
+        title: `Recent run ${index}`,
+        workspace: "/repo",
+        created_at: `2026-05-02T00:${String(index + 1).padStart(2, "0")}:00.000Z`,
+        started_at: `2026-05-02T00:${String(index + 1).padStart(2, "0")}:00.000Z`,
+        updated_at: `2026-05-02T00:${String(index + 1).padStart(2, "0")}:00.000Z`,
+      });
+    }
+    await runLedger.create({
+      id: "run-target",
+      kind: "coreloop_run",
+      status: "running",
+      notify_policy: "silent",
+      title: "Target run",
+      workspace: "/repo",
+      created_at: "2026-05-01T00:00:00.000Z",
+      started_at: "2026-05-01T00:00:00.000Z",
+      updated_at: "2026-05-01T01:00:00.000Z",
+    });
+    await runLedger.terminal("run-target", {
+      status: "succeeded",
+      completed_at: "2026-05-01T01:00:00.000Z",
+      updated_at: "2026-05-01T01:00:00.000Z",
+      summary: "target run",
+    });
+
+    const result = await answerRuntimeEvidenceQuestion({
+      text: "What was the best metric for run-target?",
+      stateManager,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "runtime_evidence_question",
+        topics: ["metric"],
+        confidence: 0.93,
+        targetRunId: "run-target",
+      })),
+      now: NOW,
+    });
+
+    expect(result.kind).toBe("answered");
+    expect(result.targetRunId).toBe("run-target");
+    expect(result.message).toContain("score");
+    expect(result.message).toContain("0.97");
+  });
+
+  it("does not fall back to another run when an explicit classifier target is missing", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-evidence-missing-target-"));
+    const stateManager = { getBaseDir: () => tmp };
+    const ledger = new RuntimeEvidenceLedger(path.join(tmp, "runtime"));
+    const runLedger = new BackgroundRunLedger(path.join(tmp, "runtime"));
+    await ledger.append({
+      kind: "metric",
+      scope: { run_id: "run-active" },
+      occurred_at: "2026-05-02T00:20:00.000Z",
+      metrics: [{ label: "score", value: 0.12, direction: "maximize", observed_at: "2026-05-02T00:20:00.000Z" }],
+      summary: "active run evidence",
+    });
+    await runLedger.create({
+      id: "run-active",
+      kind: "coreloop_run",
+      status: "running",
+      notify_policy: "silent",
+      title: "Active run",
+      workspace: "/repo",
+      created_at: "2026-05-02T00:00:00.000Z",
+      started_at: "2026-05-02T00:00:00.000Z",
+      updated_at: "2026-05-02T00:25:00.000Z",
+    });
+
+    const result = await answerRuntimeEvidenceQuestion({
+      text: "What was the best metric for run-missing?",
+      stateManager,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "runtime_evidence_question",
+        topics: ["metric"],
+        confidence: 0.93,
+        targetRunId: "run-missing",
+      })),
+      now: NOW,
+    });
+
+    expect(result.kind).toBe("answered");
+    expect(result.targetRunId).toBe("run-missing");
+    expect(result.messageType).toBe("warning");
+    expect(result.message).toContain("requested run was not found");
+    expect(result.message).not.toContain("0.12");
   });
 
   it("redacts evaluator gap summaries in blocker output", () => {

--- a/src/runtime/evidence-answer.ts
+++ b/src/runtime/evidence-answer.ts
@@ -1,5 +1,8 @@
 import * as path from "node:path";
+import { z } from "zod";
 import type { StateManager } from "../base/state/state-manager.js";
+import type { ILLMClient } from "../base/llm/llm-client.js";
+import { getInternalIdentityPrefix } from "../base/config/identity-loader.js";
 import { createRuntimeSessionRegistry } from "./session-registry/index.js";
 import type {
   BackgroundRun,
@@ -23,12 +26,22 @@ export interface RuntimeEvidenceAnswerResult {
   messageType?: "info" | "warning";
   targetRunId?: string;
   topics?: RuntimeEvidenceQuestionTopic[];
+  confidence?: number;
 }
 
 export interface RuntimeEvidenceAnswerInput {
   text: string;
   stateManager: Pick<StateManager, "getBaseDir">;
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;
   now?: Date;
+}
+
+export interface RuntimeEvidenceQueryUnderstanding {
+  decision: "runtime_evidence_question" | "not_runtime_evidence_question";
+  topics: RuntimeEvidenceQuestionTopic[];
+  confidence: number;
+  targetRunId?: string;
+  rationale?: string;
 }
 
 interface RuntimeEvidenceAnswerModelInput {
@@ -42,28 +55,77 @@ interface RuntimeEvidenceAnswerModelInput {
 }
 
 const STALE_EVIDENCE_MS = 30 * 60 * 1000;
+const MIN_QUERY_CONFIDENCE = 0.7;
 
-export function recognizeRuntimeEvidenceQuestion(text: string): RuntimeEvidenceQuestionTopic[] {
-  const normalized = text.trim().toLowerCase();
-  if (!normalized) return [];
-  const questionish = /[?？]$/.test(normalized)
-    || /^(what|which|where|how|did|does|is|are|can|show|tell|status|progress|best|artifact|strategy|blocker|approval|report)\b/.test(normalized);
-  if (!questionish) return [];
+const RuntimeEvidenceQueryUnderstandingSchema = z.object({
+  decision: z.enum(["runtime_evidence_question", "not_runtime_evidence_question"]),
+  topics: z.array(z.enum(["progress", "metric", "artifact", "strategy", "blocker", "report"])).default([]),
+  confidence: z.number().min(0).max(1),
+  targetRunId: z.string().min(1).optional(),
+  rationale: z.string().optional(),
+});
 
-  const topics = new Set<RuntimeEvidenceQuestionTopic>();
-  if (/\b(progress|status|health|how far|where is|current state|running|alive|stalled|plateau|breakthrough)\b/.test(normalized)) topics.add("progress");
-  if (/\b(metric|score|best|beat|leaderboard|accuracy|recall|precision|loss|auc|f1|current best|cumulative best)\b/.test(normalized)) topics.add("metric");
-  if (/\b(artifact|output|candidate|submission|report file|file|produced|manifest)\b/.test(normalized)) topics.add("artifact");
-  if (/\b(strategy|hypothesis|trying|plan|next|dream|approach|experiment)\b/.test(normalized)) topics.add("strategy");
-  if (/\b(blocker|blocked|approval|approve|waiting|secret|submit|publish|finali[sz]e|ready)\b/.test(normalized)) topics.add("blocker");
-  if (/\b(report|postmortem|summary|writeup|what should be included)\b/.test(normalized)) topics.add("report");
-  if (topics.size === 0 && /^(progress|status|best|strategy|artifacts?)$/.test(normalized)) topics.add("progress");
-  return [...topics];
+function getQueryUnderstandingPrompt(): string {
+  return `${getInternalIdentityPrefix("assistant")} You classify whether an operator message is asking for persisted PulSeed runtime evidence.
+
+Runtime evidence questions ask about a current or recent background run using Runtime Session Catalog, Runtime Evidence Ledger, or Runtime Health. Supported evidence topics:
+- progress: current state, liveness, latest evidence, stale/lost/stalled status
+- metric: scores, best metric, leaderboard-like evidence, evaluator observations
+- artifact: outputs, candidates, reports, manifests, retained artifacts
+- strategy: hypotheses, approaches, experiment plan, Dream checkpoint guidance
+- blocker: blockers, approval gates, missing secrets, failed attempts, external publish/submit readiness
+- report: what should be included in a report/postmortem/writeup
+
+Return not_runtime_evidence_question for ordinary chat, requests to start/stop/pause/control a run, instructions to do new work, explanatory questions not asking for persisted runtime evidence, or ambiguous/low-confidence text.
+
+Respond only as JSON: { "decision": "runtime_evidence_question" | "not_runtime_evidence_question", "topics": ["progress"], "confidence": 0.0-1.0, "targetRunId": "optional exact run id if explicitly named", "rationale": "short" }`;
+}
+
+export async function understandRuntimeEvidenceQuestion(
+  text: string,
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">,
+): Promise<RuntimeEvidenceQueryUnderstanding> {
+  const trimmed = text.trim();
+  if (!trimmed || !llmClient) {
+    return { decision: "not_runtime_evidence_question", topics: [], confidence: 0 };
+  }
+  try {
+    const response = await llmClient.sendMessage(
+      [{ role: "user", content: trimmed }],
+      { system: getQueryUnderstandingPrompt(), max_tokens: 384, temperature: 0 },
+    );
+    const parsed = llmClient.parseJSON(response.content, RuntimeEvidenceQueryUnderstandingSchema);
+    const topics = [...new Set(parsed.topics)];
+    if (
+      parsed.decision !== "runtime_evidence_question"
+      || parsed.confidence < MIN_QUERY_CONFIDENCE
+      || topics.length === 0
+    ) {
+      return {
+        decision: "not_runtime_evidence_question",
+        topics: [],
+        confidence: parsed.confidence,
+        targetRunId: parsed.targetRunId,
+        rationale: parsed.rationale,
+      };
+    }
+    return {
+      decision: "runtime_evidence_question",
+      topics,
+      confidence: parsed.confidence,
+      targetRunId: parsed.targetRunId,
+      rationale: parsed.rationale,
+    };
+  } catch {
+    return { decision: "not_runtime_evidence_question", topics: [], confidence: 0 };
+  }
 }
 
 export async function answerRuntimeEvidenceQuestion(input: RuntimeEvidenceAnswerInput): Promise<RuntimeEvidenceAnswerResult> {
-  const topics = recognizeRuntimeEvidenceQuestion(input.text);
-  if (topics.length === 0) return { kind: "not_runtime_evidence_question" };
+  const query = await understandRuntimeEvidenceQuestion(input.text, input.llmClient);
+  if (query.decision !== "runtime_evidence_question") {
+    return { kind: "not_runtime_evidence_question", confidence: query.confidence };
+  }
 
   const runtimeRoot = path.join(input.stateManager.getBaseDir(), "runtime");
   const registry = createRuntimeSessionRegistry({ stateManager: input.stateManager as StateManager });
@@ -75,23 +137,40 @@ export async function answerRuntimeEvidenceQuestion(input: RuntimeEvidenceAnswer
     healthStore.loadSnapshot().catch(() => null),
   ]);
   const candidates = selectCandidateRuns(snapshot);
-  const summaries = await Promise.all(candidates.slice(0, 8).map(async (run) => {
+  const targetRun = query.targetRunId
+    ? candidates.find((run) => run.id === query.targetRunId)
+    : undefined;
+  if (query.targetRunId && !targetRun) {
+    return {
+      kind: "answered",
+      message: [
+        `Runtime evidence answer for run ${query.targetRunId}.`,
+        "Evidence missing: the requested run was not found in the Runtime Session Catalog.",
+      ].join("\n"),
+      messageType: "warning",
+      targetRunId: query.targetRunId,
+      topics: query.topics,
+      confidence: query.confidence,
+    };
+  }
+  const runsToSummarize = selectRunsForEvidenceSummary(candidates, targetRun);
+  const summaries = await Promise.all(runsToSummarize.map(async (run) => {
     const summary = await ledger.summarizeRun(run.id).catch(() => null);
     return { run, summary };
   }));
-  const selected = summaries[0] ?? { run: null, summary: null };
+  const selected = selectUnderstoodRun(summaries, query.targetRunId);
   return buildRuntimeEvidenceAnswer({
     text: input.text,
-    topics,
+    topics: query.topics,
     snapshot,
     health,
     run: selected.run,
     summary: selected.summary,
     now: input.now,
-  });
+  }, query.confidence);
 }
 
-export function buildRuntimeEvidenceAnswer(input: RuntimeEvidenceAnswerModelInput): RuntimeEvidenceAnswerResult {
+export function buildRuntimeEvidenceAnswer(input: RuntimeEvidenceAnswerModelInput, confidence?: number): RuntimeEvidenceAnswerResult {
   const { topics, run, summary } = input;
   const target = run ? `run ${run.id}` : "runtime work";
   const lines: string[] = [`Runtime evidence answer for ${target}.`];
@@ -104,6 +183,7 @@ export function buildRuntimeEvidenceAnswer(input: RuntimeEvidenceAnswerModelInpu
       message: lines.join("\n"),
       messageType: "warning",
       topics,
+      confidence,
     };
   }
 
@@ -127,6 +207,7 @@ export function buildRuntimeEvidenceAnswer(input: RuntimeEvidenceAnswerModelInpu
       messageType: "warning",
       targetRunId: run.id,
       topics,
+      confidence,
     };
   }
 
@@ -148,7 +229,27 @@ export function buildRuntimeEvidenceAnswer(input: RuntimeEvidenceAnswerModelInpu
     messageType: warningLines.length > 0 ? "warning" : "info",
     targetRunId: run.id,
     topics,
+    confidence,
   };
+}
+
+function selectRunsForEvidenceSummary(candidates: BackgroundRun[], targetRun: BackgroundRun | undefined): BackgroundRun[] {
+  const runs = candidates.slice(0, 8);
+  if (targetRun && !runs.some((run) => run.id === targetRun.id)) {
+    runs.push(targetRun);
+  }
+  return runs;
+}
+
+function selectUnderstoodRun(
+  summaries: Array<{ run: BackgroundRun; summary: RuntimeEvidenceSummary | null }>,
+  targetRunId: string | undefined,
+): { run: BackgroundRun | null; summary: RuntimeEvidenceSummary | null } {
+  if (targetRunId) {
+    const matched = summaries.find(({ run }) => run.id === targetRunId);
+    if (matched) return matched;
+  }
+  return summaries[0] ?? { run: null, summary: null };
 }
 
 function selectCandidateRuns(snapshot: RuntimeSessionRegistrySnapshot | null): BackgroundRun[] {


### PR DESCRIPTION
Closes #869

## Implementation Summary

- Replaced regex topic detection in runtime evidence Q&A with a structured query-understanding classifier schema.
- Added typed `runtime_evidence_question` / `not_runtime_evidence_question` decisions, topic arrays, confidence, and optional explicit target run IDs.
- Low-confidence, parser failure, model-unavailable, and ordinary chat/runtime-control inputs now fall through as non-evidence instead of keyword guessing.
- Preserved Runtime Session Catalog / Evidence Ledger / Runtime Health answer formatting.
- Fixed explicit target-run handling so named runs outside the default summary window are included, and missing explicit targets return a warning instead of falling back to a different run.
- Wired TUI standalone and daemon paths to pass the configured LLM client into evidence Q&A.

## Verification Commands

- `npm exec -- vitest run src/runtime/__tests__/runtime-evidence-answer.test.ts src/interface/tui/__tests__/app.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (0 errors, existing warnings)
- `npm run test:changed`
- Fresh review: found explicit target-run fallback bug; fixed it
- Fresh re-review: LGTM, no material findings

## Known Remaining Risks

- Evidence Q&A now requires the configured LLM classifier to be available; when unavailable it intentionally returns non-evidence so normal chat/runtime-control routing can continue.
- Exact target run selection only matches explicit catalog run IDs returned by the classifier, not fuzzy titles.
