### PR TITLE
refactor(run-spec): replace regex-based natural-language derivation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ export { PortfolioManager } from "./orchestrator/strategy/portfolio-manager.js";
 export { CoreLoop } from "./orchestrator/loop/core-loop.js";
 export type { CoreLoopDeps, LoopConfig, LoopResult } from "./orchestrator/loop/core-loop.js";
 export { RuntimeSessionRegistry, createRuntimeSessionRegistry } from "./runtime/session-registry/index.js";
-export { deriveRunSpecFromText, recognizeRunSpecIntent, createRunSpecStore } from "./runtime/run-spec/index.js";
+export { deriveRunSpecFromText, understandRunSpecDraft, createRunSpecStore } from "./runtime/run-spec/index.js";
 export {
   createRuntimeDreamSidecarReview,
   RuntimeDreamSidecarReviewError,

--- a/src/interface/chat/__tests__/ingress-router.test.ts
+++ b/src/interface/chat/__tests__/ingress-router.test.ts
@@ -136,7 +136,7 @@ describe("IngressRouter", () => {
     expect(route.eventProjectionPolicy).toBe("turn_only");
   });
 
-  it("classifies Kaggle long-running requests as needing RunSpec derivation on the caller path", () => {
+  it("does not attach keyword-derived RunSpec intent on the sync ingress route", () => {
     const route = router.selectRoute(
       buildStandaloneIngressMessage({
         text: "Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.",
@@ -154,10 +154,7 @@ describe("IngressRouter", () => {
     );
 
     expect(route.kind).toBe("agent_loop");
-    expect(route.runSpecIntent).toMatchObject({
-      needsRunSpec: true,
-      profile: "kaggle",
-    });
+    expect(route).not.toHaveProperty("runSpecIntent");
   });
 
   it("does not classify Japanese threshold phrasing with regex-based daemon routing", () => {

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { ChatEventHandler } from "./chat-events.js";
 import type { RuntimeControlIntent } from "../../runtime/control/index.js";
-import { recognizeRunSpecIntent, type RunSpecIntent } from "../../runtime/run-spec/index.js";
 import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
@@ -53,7 +52,6 @@ export type SelectedChatRoute =
   | {
       kind: "agent_loop" | "tool_loop" | "adapter";
       reason: "agent_loop_available" | "tool_loop_available" | "adapter_fallback";
-      runSpecIntent?: RunSpecIntent;
       replyTargetPolicy: ReplyTargetPolicy;
       eventProjectionPolicy: EventProjectionPolicy;
       concurrencyPolicy: ConcurrencyPolicy;
@@ -62,7 +60,6 @@ export type SelectedChatRoute =
       kind: "runtime_control";
       reason: "runtime_control_intent";
       intent: RuntimeControlIntent;
-      runSpecIntent?: RunSpecIntent;
       replyTargetPolicy: ReplyTargetPolicy;
       eventProjectionPolicy: EventProjectionPolicy;
       concurrencyPolicy: ConcurrencyPolicy;
@@ -76,7 +73,7 @@ export interface IngressRouterCapabilities {
 }
 
 function selectRouteForText(
-  text: string,
+  _text: string,
   runtimeControl: ChatIngressRuntimeControl,
   deps: IngressRouterCapabilities
 ): SelectedChatRoute {
@@ -92,7 +89,6 @@ function selectRouteForText(
   };
   const canUseRuntimeControlRoute =
     runtimeControl.allowed && runtimeControl.approvalMode !== "disallowed";
-  const runSpecIntent = recognizeRunSpecIntent(text) ?? undefined;
 
   if (canUseRuntimeControlRoute) {
     const intent = deps.runtimeControlIntent ?? null;
@@ -116,7 +112,6 @@ function selectRouteForText(
     return {
       kind: "agent_loop",
       reason: "agent_loop_available",
-      ...(runSpecIntent ? { runSpecIntent } : {}),
       ...baseTurnPolicy,
     };
   }
@@ -125,7 +120,6 @@ function selectRouteForText(
     return {
       kind: "tool_loop",
       reason: "tool_loop_available",
-      ...(runSpecIntent ? { runSpecIntent } : {}),
       ...baseTurnPolicy,
     };
   }
@@ -133,7 +127,6 @@ function selectRouteForText(
   return {
     kind: "adapter",
     reason: "adapter_fallback",
-    ...(runSpecIntent ? { runSpecIntent } : {}),
     ...baseTurnPolicy,
   };
 }

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -5,7 +5,7 @@ import type { DaemonClient } from "../../../runtime/daemon/client.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { TuiChatSurface } from "../chat-surface.js";
 import { App, DASHBOARD_REFRESH_INTERVAL_MS, formatDaemonConnectionState } from "../app.js";
-import { createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
+import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 
 const testState = vi.hoisted(() => ({
   lastChatProps: null as null | { onSubmit: (value: string) => Promise<void> },
@@ -140,6 +140,59 @@ function createChatRunnerMock() {
     getConversationId: vi.fn(() => "tui-conversation-test"),
     onEvent: undefined,
   };
+}
+
+function nonEvidenceResponse(): string {
+  return JSON.stringify({
+    decision: "not_runtime_evidence_question",
+    topics: [],
+    confidence: 0.95,
+  });
+}
+
+function runSpecResponse(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    decision: "run_spec_request",
+    confidence: 0.92,
+    profile: "kaggle",
+    objective: "Run Kaggle competition until review time",
+    metric: {
+      name: "leaderboard_rank_percentile",
+      direction: "minimize",
+      target: null,
+      target_rank_percent: 15,
+      datasource: "kaggle_leaderboard",
+      confidence: "high",
+    },
+    progress_contract: {
+      kind: "rank_percentile",
+      dimension: "leaderboard_rank_percentile",
+      threshold: 15,
+      semantics: "Reach a leaderboard rank percentile at or below 15.",
+      confidence: "high",
+    },
+    deadline: {
+      raw: "tomorrow morning",
+      iso_at: "2026-05-03T00:00:00.000Z",
+      timezone: "Asia/Tokyo",
+      finalization_buffer_minutes: 60,
+      confidence: "medium",
+    },
+    budget: {
+      max_trials: null,
+      max_wall_clock_minutes: null,
+      resident_policy: "until_deadline",
+    },
+    approval_policy: {
+      submit: "approval_required",
+      publish: "unspecified",
+      secret: "approval_required",
+      external_action: "approval_required",
+      irreversible_action: "approval_required",
+    },
+    missing_fields: [],
+    ...overrides,
+  });
 }
 
 function createEvidenceSummary(overrides: Record<string, unknown> = {}) {
@@ -415,9 +468,14 @@ describe("standalone slash command routing", () => {
   it("persists a RunSpec draft and waits for confirmation before forwarding long-running runs", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
+    const llmClient = createMockLLMClient([
+      nonEvidenceResponse(),
+      runSpecResponse(),
+    ]);
 
     const screen = render(React.createElement(App, {
       stateManager: stateManager as unknown as StateManager,
+      llmClient,
       chatRunner: chatRunner as unknown as TuiChatSurface,
       noFlicker: false,
       controlStream: process.stdout,
@@ -457,12 +515,71 @@ describe("standalone slash command routing", () => {
     screen.unmount();
   });
 
-  it("does not start a long-running run when required RunSpec fields remain unresolved", async () => {
+  it("executes a confirmed RunSpec in the structured workspace rather than the stale TUI cwd", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
+    const llmClient = createMockLLMClient([
+      nonEvidenceResponse(),
+      runSpecResponse({
+        workspace: {
+          path: "/work/explicit-kaggle",
+          source: "user",
+          confidence: "high",
+        },
+      }),
+    ]);
 
     const screen = render(React.createElement(App, {
       stateManager: stateManager as unknown as StateManager,
+      llmClient,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/work/stale-tui-cwd",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("Run the Kaggle competition in /work/explicit-kaggle until tomorrow morning.");
+    await flush();
+    await testState.lastChatProps!.onSubmit("confirm");
+
+    expect(chatRunner.executeIngressMessage).toHaveBeenCalledOnce();
+    const calls = chatRunner.executeIngressMessage.mock.calls as unknown as Array<[
+      { cwd: string; metadata: Record<string, unknown> },
+      string,
+    ]>;
+    const [ingress, cwd] = calls[0]!;
+    expect(cwd).toBe("/work/explicit-kaggle");
+    expect(ingress.cwd).toBe("/work/explicit-kaggle");
+    expect(ingress.metadata).toMatchObject({
+      run_spec_profile: "kaggle",
+      run_spec_status: "confirmed",
+    });
+
+    screen.unmount();
+  });
+
+  it("does not start a long-running run when required RunSpec fields remain unresolved", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const llmClient = createMockLLMClient([
+      nonEvidenceResponse(),
+      runSpecResponse({
+        deadline: null,
+      }),
+    ]);
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      llmClient,
       chatRunner: chatRunner as unknown as TuiChatSurface,
       noFlicker: false,
       controlStream: process.stdout,
@@ -484,6 +601,46 @@ describe("standalone slash command routing", () => {
 
     expect(chatRunner.execute).not.toHaveBeenCalled();
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+
+    screen.unmount();
+  });
+
+  it.each([
+    ["Japanese", "明日のレビューまでコンペの改善を進めて、提出は承認制にして"],
+    ["Spanish", "Sigue trabajando en la competición hasta la revisión y no envíes nada sin aprobación."],
+  ])("persists a RunSpec draft for %s caller-path phrasing", async (_label, requestText) => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const llmClient = createMockLLMClient([
+      nonEvidenceResponse(),
+      runSpecResponse(),
+    ]);
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      llmClient,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/work/kaggle",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit(requestText);
+    await flush();
+
+    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+    expect(llmClient.callCount).toBe(2);
+    expect(testState.lastChatMessages.map((message) => message.text).join("\n")).toContain("Proposed long-running run");
 
     screen.unmount();
   });
@@ -561,12 +718,19 @@ describe("standalone slash command routing", () => {
   it("routes non-evidence multilingual chat through ChatRunner when classifier says not evidence", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
-    const llmClient = createSingleMockLLMClient(JSON.stringify({
-      decision: "not_runtime_evidence_question",
-      topics: [],
-      confidence: 0.96,
-      rationale: "asks for an explanation, not persisted runtime evidence",
-    }));
+    const llmClient = createMockLLMClient([
+      JSON.stringify({
+        decision: "not_runtime_evidence_question",
+        topics: [],
+        confidence: 0.96,
+        rationale: "asks for an explanation, not persisted runtime evidence",
+      }),
+      JSON.stringify({
+        decision: "not_run_spec_request",
+        confidence: 0.95,
+        missing_fields: [],
+      }),
+    ]);
 
     const screen = render(React.createElement(App, {
       stateManager: stateManager as unknown as StateManager,
@@ -589,7 +753,7 @@ describe("standalone slash command routing", () => {
     await testState.lastChatProps!.onSubmit("このタスクの進め方を説明して");
     await flush();
 
-    expect(llmClient.callCount).toBe(1);
+    expect(llmClient.callCount).toBe(2);
     expect(chatRunner.execute).toHaveBeenCalledWith("このタスクの進め方を説明して", "/work/kaggle");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
 
@@ -599,12 +763,19 @@ describe("standalone slash command routing", () => {
   it("routes natural-language runtime control through ChatRunner from the TUI freeform input", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
-    const llmClient = createSingleMockLLMClient(JSON.stringify({
-      decision: "not_runtime_evidence_question",
-      topics: [],
-      confidence: 0.97,
-      rationale: "runtime-control request, not evidence Q&A",
-    }));
+    const llmClient = createMockLLMClient([
+      JSON.stringify({
+        decision: "not_runtime_evidence_question",
+        topics: [],
+        confidence: 0.97,
+        rationale: "runtime-control request, not evidence Q&A",
+      }),
+      JSON.stringify({
+        decision: "not_run_spec_request",
+        confidence: 0.95,
+        missing_fields: [],
+      }),
+    ]);
 
     const screen = render(React.createElement(App, {
       stateManager: stateManager as unknown as StateManager,
@@ -629,7 +800,7 @@ describe("standalone slash command routing", () => {
 
     expect(chatRunner.execute).toHaveBeenCalledWith("この実行を一時停止して", "/work/kaggle");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
-    expect(llmClient.callCount).toBe(1);
+    expect(llmClient.callCount).toBe(2);
 
     screen.unmount();
   });

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -215,6 +215,10 @@ function buildRunSpecIngress(input: string, spec: RunSpec, effectiveCwd: string)
   };
 }
 
+function resolveRunSpecExecutionCwd(spec: RunSpec, fallbackCwd: string): string {
+  return spec.workspace?.path ?? fallbackCwd;
+}
+
 interface AppProps {
   // Daemon mode (thin client — events via SSE, commands via REST)
   daemonClient?: DaemonClient;
@@ -670,9 +674,10 @@ export function App({
             messageType: result.kind === "blocked" || result.kind === "unrecognized" ? ("warning" as const) : ("info" as const),
           }].slice(-MAX_MESSAGES));
           if (result.kind === "confirmed") {
+            const runSpecCwd = resolveRunSpecExecutionCwd(savedRunSpec, effectiveCwd);
             await chatRunner.executeIngressMessage(
-              buildRunSpecIngress(savedRunSpec.source_text, savedRunSpec, effectiveCwd),
-              effectiveCwd,
+              buildRunSpecIngress(savedRunSpec.source_text, savedRunSpec, runSpecCwd),
+              runSpecCwd,
             );
           }
           return;
@@ -796,10 +801,11 @@ export function App({
             }
           } else if (freeformRoute === "chat_runner" && chatRunner) {
             const effectiveCwd = cwd ?? process.cwd();
-            const runSpec = deriveRunSpecFromText(input, {
+            const runSpec = await deriveRunSpecFromText(input, {
               cwd: effectiveCwd,
               conversationId: chatRunner.getConversationId?.() ?? null,
               timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              llmClient,
             });
             if (runSpec) {
               const savedRunSpec = await createRunSpecStore(stateManager).save(runSpec);

--- a/src/runtime/run-spec/__tests__/run-spec.test.ts
+++ b/src/runtime/run-spec/__tests__/run-spec.test.ts
@@ -2,23 +2,70 @@ import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
-import { deriveRunSpecFromText, recognizeRunSpecIntent } from "../derive.js";
+import { deriveRunSpecFromText, understandRunSpecDraft } from "../derive.js";
 import { createRunSpecStore } from "../store.js";
 import {
   formatRunSpecSetupProposal,
   handleRunSpecConfirmationInput,
 } from "../confirmation.js";
+import { createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 
 const NOW = new Date("2026-05-02T00:00:00.000Z");
 
+function llmDraft(overrides: Record<string, unknown> = {}) {
+  return createSingleMockLLMClient(JSON.stringify({
+    decision: "run_spec_request",
+    confidence: 0.92,
+    profile: "kaggle",
+    objective: "Run Kaggle competition until review time",
+    metric: {
+      name: "leaderboard_rank_percentile",
+      direction: "minimize",
+      target: null,
+      target_rank_percent: 15,
+      datasource: "kaggle_leaderboard",
+      confidence: "high",
+    },
+    progress_contract: {
+      kind: "rank_percentile",
+      dimension: "leaderboard_rank_percentile",
+      threshold: 15,
+      semantics: "Reach a leaderboard rank percentile at or below 15.",
+      confidence: "high",
+    },
+    deadline: {
+      raw: "tomorrow morning",
+      iso_at: "2026-05-03T00:00:00.000Z",
+      timezone: "Asia/Tokyo",
+      finalization_buffer_minutes: 60,
+      confidence: "medium",
+    },
+    budget: {
+      max_trials: null,
+      max_wall_clock_minutes: null,
+      resident_policy: "until_deadline",
+    },
+    approval_policy: {
+      submit: "approval_required",
+      publish: "unspecified",
+      secret: "approval_required",
+      external_action: "approval_required",
+      irreversible_action: "approval_required",
+    },
+    missing_fields: [],
+    ...overrides,
+  }));
+}
+
 describe("RunSpec derivation", () => {
-  it("derives a Kaggle RunSpec with separate metric and progress semantics", () => {
-    const spec = deriveRunSpecFromText(
+  it("derives a Kaggle RunSpec with separate metric and progress semantics", async () => {
+    const spec = await deriveRunSpecFromText(
       "Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.",
       {
         cwd: "/work/kaggle/playground",
         now: NOW,
         timezone: "Asia/Tokyo",
+        llmClient: llmDraft(),
       },
     );
 
@@ -43,12 +90,31 @@ describe("RunSpec derivation", () => {
     expect(spec!.missing_fields).toEqual([]);
   });
 
-  it("derives a generic long-running RunSpec", () => {
-    const spec = deriveRunSpecFromText(
-      "Keep this background optimization running until tomorrow morning and maximize accuracy 0.91.",
+  it("derives a generic long-running RunSpec", async () => {
+    const spec = await deriveRunSpecFromText(
+      "Please keep optimizing the model while I am away and stop at the review checkpoint.",
       {
         cwd: "/repo/app",
         now: NOW,
+        llmClient: llmDraft({
+          profile: "generic",
+          objective: "Optimize the model until review time",
+          metric: {
+            name: "accuracy",
+            direction: "maximize",
+            target: 0.91,
+            target_rank_percent: null,
+            datasource: null,
+            confidence: "medium",
+          },
+          progress_contract: {
+            kind: "metric_target",
+            dimension: "accuracy",
+            threshold: 0.91,
+            semantics: "Reach accuracy of at least 0.91.",
+            confidence: "high",
+          },
+        }),
       },
     );
 
@@ -66,12 +132,30 @@ describe("RunSpec derivation", () => {
     });
   });
 
-  it("preserves ambiguous metric direction as a required missing field", () => {
-    const spec = deriveRunSpecFromText(
-      "Run this long-running task until tomorrow morning and reach score 0.98.",
+  it("preserves ambiguous metric direction as a required missing field", async () => {
+    const spec = await deriveRunSpecFromText(
+      "Please continue the benchmark work through tomorrow and get score 0.98 if possible.",
       {
         cwd: "/repo/app",
         now: NOW,
+        llmClient: llmDraft({
+          profile: "generic",
+          metric: {
+            name: "score",
+            direction: "unknown",
+            target: 0.98,
+            target_rank_percent: null,
+            datasource: null,
+            confidence: "medium",
+          },
+          progress_contract: {
+            kind: "metric_target",
+            dimension: "score",
+            threshold: 0.98,
+            semantics: "Reach score 0.98.",
+            confidence: "medium",
+          },
+        }),
       },
     );
 
@@ -92,9 +176,27 @@ describe("RunSpec derivation", () => {
     });
   });
 
-  it("does not guess missing workspace and deadline", () => {
-    const spec = deriveRunSpecFromText("Run a long-running Kaggle experiment for top 20%.", {
+  it("does not guess missing workspace and deadline", async () => {
+    const spec = await deriveRunSpecFromText("Please take over the competition work and target the top cohort.", {
       now: NOW,
+      llmClient: llmDraft({
+        metric: {
+          name: "leaderboard_rank_percentile",
+          direction: "minimize",
+          target: null,
+          target_rank_percent: 20,
+          datasource: "kaggle_leaderboard",
+          confidence: "medium",
+        },
+        progress_contract: {
+          kind: "rank_percentile",
+          dimension: "leaderboard_rank_percentile",
+          threshold: 20,
+          semantics: "Reach top 20 percent leaderboard rank.",
+          confidence: "medium",
+        },
+        deadline: null,
+      }),
     });
 
     expect(spec).not.toBeNull();
@@ -103,17 +205,77 @@ describe("RunSpec derivation", () => {
     expect(spec!.missing_fields.map((field) => field.field)).toEqual(["workspace", "deadline"]);
   });
 
-  it("does not treat explanatory long-running questions as run requests", () => {
-    expect(recognizeRunSpecIntent("Why do long-running tasks fail?")).toBeNull();
+  it("does not treat explanatory long-running questions as run requests", async () => {
+    const spec = await deriveRunSpecFromText("Why do long-running tasks fail?", {
+      now: NOW,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "not_run_spec_request",
+        confidence: 0.96,
+        missing_fields: [],
+      })),
+    });
+
+    expect(spec).toBeNull();
+  });
+
+  it("supports Japanese request phrasing through the same structured draft path", async () => {
+    const spec = await deriveRunSpecFromText("明日のレビューまでコンペの改善を進めて、提出は承認制にして", {
+      cwd: "/repo/kaggle",
+      now: NOW,
+      llmClient: llmDraft({
+        objective: "明日のレビューまでコンペ改善を進める",
+      }),
+    });
+
+    expect(spec).not.toBeNull();
+    expect(spec!.profile).toBe("kaggle");
+    expect(spec!.approval_policy.submit).toBe("approval_required");
+  });
+
+  it("supports third-language request phrasing through the same structured draft path", async () => {
+    const spec = await deriveRunSpecFromText("Sigue trabajando en la competición hasta la revisión y no envíes nada sin aprobación.", {
+      cwd: "/repo/kaggle",
+      now: NOW,
+      llmClient: llmDraft({
+        objective: "Continue competition work until review",
+      }),
+    });
+
+    expect(spec).not.toBeNull();
+    expect(spec!.profile).toBe("kaggle");
+    expect(spec!.workspace?.path).toBe("/repo/kaggle");
+  });
+
+  it("does not use a keyword fallback when the model is unavailable", async () => {
+    const spec = await deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
+      cwd: "/repo/kaggle",
+      now: NOW,
+    });
+
+    expect(spec).toBeNull();
+  });
+
+  it("returns null for low-confidence draft decisions", async () => {
+    const draft = await understandRunSpecDraft("maybe do something overnight?", {
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "run_spec_request",
+        confidence: 0.41,
+        profile: "generic",
+        missing_fields: [],
+      })),
+    });
+
+    expect(draft).toBeNull();
   });
 });
 
 describe("RunSpecStore", () => {
   it("persists and reloads a RunSpec under the state root", async () => {
     const baseDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-runspec-"));
-    const spec = deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
+    const spec = await deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
       cwd: "/repo/kaggle",
       now: NOW,
+      llmClient: llmDraft(),
     });
     expect(spec).not.toBeNull();
 
@@ -129,9 +291,10 @@ describe("RunSpecStore", () => {
 
   it("rejects path-like ids before RunSpec store file I/O", async () => {
     const baseDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-runspec-"));
-    const spec = deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
+    const spec = await deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
       cwd: "/repo/kaggle",
       now: NOW,
+      llmClient: llmDraft(),
     });
     expect(spec).not.toBeNull();
     const store = createRunSpecStore({ getBaseDir: () => baseDir });
@@ -142,12 +305,13 @@ describe("RunSpecStore", () => {
 });
 
 describe("RunSpec confirmation", () => {
-  it("confirms a complete RunSpec", () => {
-    const spec = deriveRunSpecFromText(
+  it("confirms a complete RunSpec", async () => {
+    const spec = await deriveRunSpecFromText(
       "Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.",
       {
         cwd: "/repo/kaggle",
         now: NOW,
+        llmClient: llmDraft(),
       },
     );
     expect(spec).not.toBeNull();
@@ -158,9 +322,27 @@ describe("RunSpec confirmation", () => {
     expect(result.spec.status).toBe("confirmed");
   });
 
-  it("revises missing required fields before confirmation", () => {
-    const spec = deriveRunSpecFromText("Run a long-running Kaggle experiment for top 20%.", {
+  it("revises missing required fields before confirmation", async () => {
+    const spec = await deriveRunSpecFromText("Run a long-running Kaggle experiment for top 20%.", {
       now: NOW,
+      llmClient: llmDraft({
+        metric: {
+          name: "leaderboard_rank_percentile",
+          direction: "minimize",
+          target: null,
+          target_rank_percent: 20,
+          datasource: "kaggle_leaderboard",
+          confidence: "medium",
+        },
+        progress_contract: {
+          kind: "rank_percentile",
+          dimension: "leaderboard_rank_percentile",
+          threshold: 20,
+          semantics: "Reach top 20 percent leaderboard rank.",
+          confidence: "medium",
+        },
+        deadline: null,
+      }),
     });
     expect(spec).not.toBeNull();
 
@@ -176,10 +358,11 @@ describe("RunSpec confirmation", () => {
     expect(confirmed.kind).toBe("confirmed");
   });
 
-  it("cancels a pending RunSpec", () => {
-    const spec = deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
+  it("cancels a pending RunSpec", async () => {
+    const spec = await deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
       cwd: "/repo/kaggle",
       now: NOW,
+      llmClient: llmDraft(),
     });
     expect(spec).not.toBeNull();
 
@@ -189,9 +372,27 @@ describe("RunSpec confirmation", () => {
     expect(result.spec.status).toBe("cancelled");
   });
 
-  it("blocks confirmation while required fields remain unresolved", () => {
-    const spec = deriveRunSpecFromText("Run a long-running Kaggle experiment for top 20%.", {
+  it("blocks confirmation while required fields remain unresolved", async () => {
+    const spec = await deriveRunSpecFromText("Run a long-running Kaggle experiment for top 20%.", {
       now: NOW,
+      llmClient: llmDraft({
+        metric: {
+          name: "leaderboard_rank_percentile",
+          direction: "minimize",
+          target: null,
+          target_rank_percent: 20,
+          datasource: "kaggle_leaderboard",
+          confidence: "medium",
+        },
+        progress_contract: {
+          kind: "rank_percentile",
+          dimension: "leaderboard_rank_percentile",
+          threshold: 20,
+          semantics: "Reach top 20 percent leaderboard rank.",
+          confidence: "medium",
+        },
+        deadline: null,
+      }),
     });
     expect(spec).not.toBeNull();
 
@@ -202,12 +403,13 @@ describe("RunSpec confirmation", () => {
     expect(result.message).toContain("What deadline or review time");
   });
 
-  it("shows risky external actions as approval-gated in the proposal", () => {
-    const spec = deriveRunSpecFromText(
+  it("shows risky external actions as approval-gated in the proposal", async () => {
+    const spec = await deriveRunSpecFromText(
       "Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.",
       {
         cwd: "/repo/kaggle",
         now: NOW,
+        llmClient: llmDraft(),
       },
     );
     expect(spec).not.toBeNull();

--- a/src/runtime/run-spec/derive.ts
+++ b/src/runtime/run-spec/derive.ts
@@ -1,8 +1,12 @@
 import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+import { getInternalIdentityPrefix } from "../../base/config/identity-loader.js";
 import type {
   RunSpec,
   RunSpecApprovalPolicy,
   RunSpecArtifactContract,
+  RunSpecConfidence,
   RunSpecDeadline,
   RunSpecDerivationContext,
   RunSpecMetric,
@@ -10,131 +14,205 @@ import type {
   RunSpecProgressContract,
 } from "./types.js";
 
-const LONG_RUNNING_TERMS = [
-  /\blong[-\s]?running\b/i,
-  /\bbackground\b/i,
-  /\brun\b.+\buntil\b/i,
-  /\bkeep\b.+\brunning\b/i,
-  /\bcontinue\b.+\buntil\b/i,
-  /\bdaemon\b/i,
-  /\bcoreloop\b/i,
-  /長期/,
-  /常駐/,
-  /まで.*(実行|走|回|取り組|続け)/,
-];
+const MIN_RUNSPEC_CONFIDENCE = 0.7;
 
-const KAGGLE_TERMS = [
-  /\bkaggle\b/i,
-  /\bcompetition\b/i,
-  /\bleaderboard\b/i,
-  /\bsubmission\b/i,
-  /\bsubmit\b/i,
-  /コンペ/,
-  /提出/,
-];
+const DraftConfidenceSchema = z.enum(["high", "medium", "low"]).optional();
 
-const EXPLANATORY_QUESTION_TERMS = [
-  /\bwhy\b/i,
-  /\bhow does\b/i,
-  /\bwhat is\b/i,
-  /\?/,
-  /なぜ/,
-  /どうして/,
-  /とは/,
-];
+const DraftWorkspaceSchema = z.object({
+  path: z.string().min(1),
+  source: z.enum(["user", "context"]).optional(),
+  confidence: DraftConfidenceSchema,
+}).nullable();
+
+const DraftExecutionTargetSchema = z.object({
+  kind: z.enum(["local", "daemon", "remote"]),
+  remote_host: z.string().nullable().optional(),
+  confidence: DraftConfidenceSchema,
+}).optional();
+
+const DraftMetricSchema = z.object({
+  name: z.string().min(1),
+  direction: z.enum(["maximize", "minimize", "unknown"]),
+  target: z.number().nullable().optional(),
+  target_rank_percent: z.number().nullable().optional(),
+  datasource: z.string().nullable().optional(),
+  confidence: DraftConfidenceSchema,
+}).nullable();
+
+const DraftProgressContractSchema = z.object({
+  kind: z.enum(["metric_target", "rank_percentile", "deadline_only", "open_ended", "unknown"]),
+  dimension: z.string().nullable().optional(),
+  threshold: z.number().nullable().optional(),
+  semantics: z.string().min(1),
+  confidence: DraftConfidenceSchema,
+}).optional();
+
+const DraftDeadlineSchema = z.object({
+  raw: z.string().min(1),
+  iso_at: z.string().nullable().optional(),
+  timezone: z.string().nullable().optional(),
+  finalization_buffer_minutes: z.number().nullable().optional(),
+  confidence: DraftConfidenceSchema,
+}).nullable();
+
+const DraftBudgetSchema = z.object({
+  max_trials: z.number().nullable().optional(),
+  max_wall_clock_minutes: z.number().nullable().optional(),
+  resident_policy: z.enum(["until_deadline", "best_effort", "unknown"]).optional(),
+}).optional();
+
+const DraftApprovalPolicySchema = z.object({
+  submit: z.enum(["approval_required", "allowed", "disallowed", "unspecified"]).optional(),
+  publish: z.enum(["approval_required", "allowed", "disallowed", "unspecified"]).optional(),
+  secret: z.enum(["approval_required", "disallowed", "unspecified"]).optional(),
+  external_action: z.enum(["approval_required", "allowed", "disallowed", "unspecified"]).optional(),
+  irreversible_action: z.enum(["approval_required", "disallowed", "unspecified"]).optional(),
+}).optional();
+
+const DraftArtifactContractSchema = z.object({
+  expected_artifacts: z.array(z.string()).optional(),
+  discovery_globs: z.array(z.string()).optional(),
+  primary_outputs: z.array(z.string()).optional(),
+}).optional();
+
+const RunSpecDraftSchema = z.object({
+  decision: z.enum(["run_spec_request", "not_run_spec_request"]),
+  confidence: z.number().min(0).max(1),
+  profile: z.enum(["generic", "kaggle"]).optional(),
+  objective: z.string().optional(),
+  workspace: DraftWorkspaceSchema.optional(),
+  execution_target: DraftExecutionTargetSchema,
+  metric: DraftMetricSchema.optional(),
+  progress_contract: DraftProgressContractSchema,
+  deadline: DraftDeadlineSchema.optional(),
+  budget: DraftBudgetSchema,
+  approval_policy: DraftApprovalPolicySchema,
+  artifact_contract: DraftArtifactContractSchema,
+  missing_fields: z.array(z.object({
+    field: z.string().min(1),
+    question: z.string().min(1),
+    severity: z.enum(["required", "confirmation"]),
+  })).default([]),
+  reason: z.string().optional(),
+});
+
+type RunSpecDraft = z.infer<typeof RunSpecDraftSchema>;
 
 export interface RunSpecIntent {
   needsRunSpec: true;
   profile: "generic" | "kaggle";
   reason: string;
+  confidence: number;
 }
 
-export function recognizeRunSpecIntent(text: string): RunSpecIntent | null {
-  const trimmed = text.trim();
-  if (!trimmed) return null;
-  const profile = KAGGLE_TERMS.some((pattern) => pattern.test(trimmed)) ? "kaggle" : "generic";
-  const longRunning = LONG_RUNNING_TERMS.some((pattern) => pattern.test(trimmed));
-  const hasThreshold = /(top\s*\d+(?:\.\d+)?\s*%|score\s*[<>=>]*\s*\d|accuracy\s*[<>=>]*\s*\d|auc\s*[<>=>]*\s*\d|rmse\s*[<>=>]*\s*\d|loss\s*[<>=>]*\s*\d)/i.test(trimmed);
-  const asksForExplanation = EXPLANATORY_QUESTION_TERMS.some((pattern) => pattern.test(trimmed));
-  const hasOperatorVerb = /\b(run|keep|continue|start|execute|optimi[sz]e|improve|aim|reach)\b|実行|走|回|取り組|続け|目指/i.test(trimmed);
+function getRunSpecDraftPrompt(context: RunSpecDerivationContext): string {
+  const cwdLine = context.cwd ? `Current workspace context: ${context.cwd}` : "Current workspace context: unavailable";
+  const timezoneLine = context.timezone ? `Timezone: ${context.timezone}` : "Timezone: unavailable";
+  const nowLine = `Current time: ${(context.now ?? new Date()).toISOString()}`;
+  return `${getInternalIdentityPrefix("assistant")} Convert an operator message into a PulSeed long-running RunSpec draft only when the user is asking PulSeed to run, continue, optimize, evaluate, or monitor autonomous work over time.
 
-  if (asksForExplanation && !/\b(run|keep|continue|start|do|execute)\b/i.test(trimmed)) {
+Return not_run_spec_request for ordinary chat, explanations, questions about how PulSeed works, runtime-control commands, and ambiguous text that does not clearly request long-running work.
+
+When it is a run spec request, extract a typed draft:
+- profile: kaggle for Kaggle/competition/leaderboard/submission workflows, otherwise generic.
+- objective: concise operator objective in the user's meaning.
+- workspace: explicit user workspace path if named. If none is named, omit it; the caller may use context.
+- execution_target: local, daemon, or remote; include remote_host only when explicitly known.
+- metric: metric name, direction, numeric target or rank percentile target, datasource when known.
+- progress_contract: measurable progress semantics, or deadline/open ended when no metric target exists.
+- deadline: raw user deadline plus ISO timestamp if the user gave enough information. Use the provided current time and timezone.
+- budget: max trials, wall-clock minutes, resident policy if specified or implied by deadline.
+- approval_policy: mark submit/publish/external/irreversible/secret actions approval_required unless the user explicitly allows or disallows them.
+- missing_fields: required clarifications for workspace, deadline, metric direction, target, or approval policy that must not be guessed.
+
+${cwdLine}
+${timezoneLine}
+${nowLine}
+
+Respond only as JSON with this shape:
+{
+  "decision": "run_spec_request" | "not_run_spec_request",
+  "confidence": 0.0-1.0,
+  "profile": "generic" | "kaggle",
+  "objective": "...",
+  "workspace": { "path": "...", "source": "user", "confidence": "high" } | null,
+  "execution_target": { "kind": "local" | "daemon" | "remote", "remote_host": null, "confidence": "medium" },
+  "metric": { "name": "...", "direction": "maximize" | "minimize" | "unknown", "target": 0.91, "target_rank_percent": null, "datasource": "...", "confidence": "medium" } | null,
+  "progress_contract": { "kind": "metric_target" | "rank_percentile" | "deadline_only" | "open_ended" | "unknown", "dimension": "...", "threshold": 0.91, "semantics": "...", "confidence": "medium" },
+  "deadline": { "raw": "...", "iso_at": "2026-05-03T00:00:00.000Z", "timezone": "...", "finalization_buffer_minutes": 60, "confidence": "medium" } | null,
+  "budget": { "max_trials": null, "max_wall_clock_minutes": null, "resident_policy": "until_deadline" },
+  "approval_policy": { "submit": "approval_required", "publish": "unspecified", "secret": "approval_required", "external_action": "approval_required", "irreversible_action": "approval_required" },
+  "artifact_contract": { "expected_artifacts": ["..."], "discovery_globs": ["..."], "primary_outputs": ["..."] },
+  "missing_fields": [{ "field": "deadline", "question": "...", "severity": "required" }],
+  "reason": "short rationale"
+}`;
+}
+
+export async function understandRunSpecDraft(
+  text: string,
+  context: RunSpecDerivationContext = {},
+): Promise<RunSpecDraft | null> {
+  const trimmed = text.trim();
+  const llmClient = context.llmClient;
+  if (!trimmed || !llmClient) return null;
+  try {
+    const response = await llmClient.sendMessage(
+      [{ role: "user", content: trimmed }],
+      { system: getRunSpecDraftPrompt(context), max_tokens: 900, temperature: 0 },
+    );
+    const draft = llmClient.parseJSON(response.content, RunSpecDraftSchema);
+    if (draft.decision !== "run_spec_request" || draft.confidence < MIN_RUNSPEC_CONFIDENCE) {
+      return null;
+    }
+    return {
+      ...draft,
+      missing_fields: draft.missing_fields ?? [],
+    };
+  } catch {
     return null;
   }
-
-  if (profile === "kaggle" && hasOperatorVerb && (longRunning || hasThreshold || /\buntil\b/i.test(trimmed))) {
-    return { needsRunSpec: true, profile, reason: "kaggle_long_running_request" };
-  }
-  if (longRunning && hasOperatorVerb && !asksForExplanation) {
-    return { needsRunSpec: true, profile, reason: "long_running_request" };
-  }
-  return null;
 }
 
-export function deriveRunSpecFromText(text: string, context: RunSpecDerivationContext = {}): RunSpec | null {
-  const intent = recognizeRunSpecIntent(text);
-  if (!intent) return null;
+export async function deriveRunSpecFromText(
+  text: string,
+  context: RunSpecDerivationContext = {},
+): Promise<RunSpec | null> {
+  const draft = await understandRunSpecDraft(text, context);
+  if (!draft) return null;
 
   const now = context.now ?? new Date();
   const createdAt = now.toISOString();
-  const missingFields: RunSpecMissingField[] = [];
-  const workspace = deriveWorkspace(text, context.cwd);
-  if (!workspace) {
-    missingFields.push({
-      field: "workspace",
-      question: "Which local or remote workspace should PulSeed use for this run?",
-      severity: "required",
-    });
-  }
-
-  const deadline = deriveDeadline(text, now, context.timezone);
-  if (!deadline) {
-    missingFields.push({
-      field: "deadline",
-      question: "What deadline or review time should PulSeed plan around?",
-      severity: "required",
-    });
-  }
-
-  const metric = deriveMetric(text, intent.profile);
-  if (metric && metric.direction === "unknown" && metric.target !== null) {
-    missingFields.push({
-      field: "metric.direction",
-      question: `Should ${metric.name} be maximized or minimized?`,
-      severity: "required",
-    });
-  }
-
-  const progressContract = deriveProgressContract(text, metric, deadline);
-  const approvalPolicy = deriveApprovalPolicy(text);
-  const artifactContract = deriveArtifactContract(intent.profile);
-  const objective = text.trim().replace(/\s+/g, " ");
-  const confidence = missingFields.some((field) => field.severity === "required")
-    ? "medium"
-    : "high";
+  const profile = draft.profile ?? "generic";
+  const workspace = normalizeWorkspace(draft, context);
+  const deadline = normalizeDeadline(draft, context);
+  const metric = normalizeMetric(draft);
+  const progressContract = normalizeProgressContract(draft, metric, deadline);
+  const approvalPolicy = normalizeApprovalPolicy(draft.approval_policy);
+  const missingFields = normalizeMissingFields(draft, workspace, deadline, metric);
 
   return {
     schema_version: "run-spec-v1",
     id: `runspec-${randomUUID()}`,
     status: "draft",
-    profile: intent.profile,
+    profile,
     source_text: text,
-    objective,
+    objective: normalizeObjective(draft.objective, text),
     workspace,
-    execution_target: deriveExecutionTarget(text),
+    execution_target: normalizeExecutionTarget(draft),
     metric,
     progress_contract: progressContract,
     deadline,
     budget: {
-      max_trials: deriveMaxTrials(text),
-      max_wall_clock_minutes: deadline?.iso_at ? minutesUntil(now, new Date(deadline.iso_at)) : null,
-      resident_policy: deadline ? "until_deadline" : "unknown",
+      max_trials: draft.budget?.max_trials ?? null,
+      max_wall_clock_minutes: draft.budget?.max_wall_clock_minutes
+        ?? (deadline?.iso_at ? minutesUntil(now, new Date(deadline.iso_at)) : null),
+      resident_policy: draft.budget?.resident_policy ?? (deadline ? "until_deadline" : "unknown"),
     },
     approval_policy: approvalPolicy,
-    artifact_contract: artifactContract,
+    artifact_contract: normalizeArtifactContract(profile, draft.artifact_contract),
     risk_flags: deriveRiskFlags(approvalPolicy),
     missing_fields: missingFields,
-    confidence,
+    confidence: deriveSpecConfidence(draft.confidence, missingFields),
     links: {
       goal_id: null,
       runtime_session_id: null,
@@ -145,75 +223,63 @@ export function deriveRunSpecFromText(text: string, context: RunSpecDerivationCo
   };
 }
 
-function deriveWorkspace(text: string, cwd: string | undefined) {
-  const explicitPath = text.match(/(?:workspace|cwd|directory|dir|repo|path)\s+((?:~|\/)[^\s,]+)/i)?.[1]
-    ?? text.match(/(?:ワークスペース|ディレクトリ|repo|リポジトリ)[^\s/]*(\/[^\s,]+)/i)?.[1];
-  if (explicitPath) {
-    return { path: explicitPath, source: "user" as const, confidence: "high" as const };
+function normalizeWorkspace(draft: RunSpecDraft, context: RunSpecDerivationContext): RunSpec["workspace"] {
+  if (draft.workspace?.path) {
+    return {
+      path: draft.workspace.path,
+      source: draft.workspace.source ?? "user",
+      confidence: toConfidence(draft.workspace.confidence, "high"),
+    };
   }
-  const normalizedCwd = cwd?.trim();
+  const normalizedCwd = context.cwd?.trim();
   if (normalizedCwd) {
-    return { path: normalizedCwd, source: "context" as const, confidence: "medium" as const };
+    return { path: normalizedCwd, source: "context", confidence: "medium" };
   }
   return null;
 }
 
-function deriveExecutionTarget(text: string) {
-  const remoteHost = text.match(/\b(?:on|host|ssh)\s+([a-zA-Z0-9_.-]+)\b/i)?.[1] ?? null;
-  if (remoteHost) {
-    return { kind: "remote" as const, remote_host: remoteHost, confidence: "medium" as const };
-  }
-  if (/\bdaemon\b|coreloop/i.test(text)) {
-    return { kind: "daemon" as const, remote_host: null, confidence: "medium" as const };
-  }
-  return { kind: "local" as const, remote_host: null, confidence: "low" as const };
-}
-
-function deriveMetric(text: string, profile: "generic" | "kaggle"): RunSpecMetric | null {
-  const topMatch = text.match(/\btop\s*(\d+(?:\.\d+)?)\s*%/i);
-  if (topMatch) {
-    return {
-      name: "leaderboard_rank_percentile",
-      direction: "minimize",
-      target: null,
-      target_rank_percent: Number(topMatch[1]),
-      datasource: profile === "kaggle" ? "kaggle_leaderboard" : null,
-      confidence: "high",
-    };
-  }
-
-  const metricMatch = text.match(/\b(accuracy|auc|rmse|mae|loss|score|balanced_accuracy)\b[^\d<>=>-]*[<>=>]*\s*(-?\d+(?:\.\d+)?)/i);
-  if (!metricMatch) return null;
-  const name = metricMatch[1].toLowerCase();
+function normalizeExecutionTarget(draft: RunSpecDraft): RunSpec["execution_target"] {
+  const target = draft.execution_target;
   return {
-    name,
-    direction: inferMetricDirection(text, name),
-    target: Number(metricMatch[2]),
-    target_rank_percent: null,
-    datasource: profile === "kaggle" ? "kaggle_metrics" : null,
-    confidence: "medium",
+    kind: target?.kind ?? "local",
+    remote_host: target?.remote_host ?? null,
+    confidence: toConfidence(target?.confidence, target ? "medium" : "low"),
   };
 }
 
-function inferMetricDirection(text: string, metricName: string): "maximize" | "minimize" | "unknown" {
-  if (/\b(maximi[sz]e|increase|higher|best|improve|上げ|高く|最大)\b/i.test(text)) return "maximize";
-  if (/\b(minimi[sz]e|decrease|lower|reduce|下げ|低く|最小)\b/i.test(text)) return "minimize";
-  if (/^(accuracy|auc|balanced_accuracy)$/.test(metricName)) return "maximize";
-  if (/^(rmse|mae|loss)$/.test(metricName)) return "minimize";
-  return "unknown";
+function normalizeMetric(draft: RunSpecDraft): RunSpecMetric | null {
+  const metric = draft.metric;
+  if (!metric) return null;
+  return {
+    name: metric.name,
+    direction: metric.direction,
+    target: metric.target ?? null,
+    target_rank_percent: metric.target_rank_percent ?? null,
+    datasource: metric.datasource ?? null,
+    confidence: toConfidence(metric.confidence, "medium"),
+  };
 }
 
-function deriveProgressContract(
-  text: string,
+function normalizeProgressContract(
+  draft: RunSpecDraft,
   metric: RunSpecMetric | null,
   deadline: RunSpecDeadline | null,
 ): RunSpecProgressContract {
+  if (draft.progress_contract) {
+    return {
+      kind: draft.progress_contract.kind,
+      dimension: draft.progress_contract.dimension ?? null,
+      threshold: draft.progress_contract.threshold ?? null,
+      semantics: draft.progress_contract.semantics,
+      confidence: toConfidence(draft.progress_contract.confidence, "medium"),
+    };
+  }
   if (metric?.target_rank_percent !== null && metric?.target_rank_percent !== undefined) {
     return {
       kind: "rank_percentile",
       dimension: metric.name,
       threshold: metric.target_rank_percent,
-      semantics: "Reach a leaderboard rank percentile at or below the threshold.",
+      semantics: "Reach the requested rank percentile threshold.",
       confidence: "high",
     };
   }
@@ -226,7 +292,7 @@ function deriveProgressContract(
       confidence: metric.direction === "unknown" ? "medium" : "high",
     };
   }
-  if (deadline && /\buntil\b|まで|期限|deadline/i.test(text)) {
+  if (deadline) {
     return {
       kind: "deadline_only",
       dimension: "time",
@@ -236,60 +302,48 @@ function deriveProgressContract(
     };
   }
   return {
-    kind: "open_ended",
+    kind: "unknown",
     dimension: null,
     threshold: null,
-    semantics: "Long-running work requested without an explicit measurable threshold.",
+    semantics: "RunSpec request needs a measurable progress contract.",
     confidence: "low",
   };
 }
 
-function deriveDeadline(text: string, now: Date, timezone: string | undefined): RunSpecDeadline | null {
-  const lower = text.toLowerCase();
-  if (lower.includes("tomorrow morning") || /明日.*(朝|午前)/.test(text)) {
-    const at = new Date(now);
-    at.setDate(at.getDate() + 1);
-    at.setHours(9, 0, 0, 0);
-    return {
-      raw: lower.includes("tomorrow morning") ? "tomorrow morning" : "明日朝",
-      iso_at: at.toISOString(),
-      timezone: timezone ?? null,
-      finalization_buffer_minutes: 60,
-      confidence: "medium",
-    };
-  }
-  const hoursMatch = text.match(/\b(?:for|within)\s+(\d+)\s*(hours?|hrs?)\b/i);
-  if (hoursMatch) {
-    const at = new Date(now.getTime() + Number(hoursMatch[1]) * 60 * 60 * 1000);
-    return {
-      raw: hoursMatch[0],
-      iso_at: at.toISOString(),
-      timezone: timezone ?? null,
-      finalization_buffer_minutes: 30,
-      confidence: "medium",
-    };
-  }
-  return null;
-}
-
-function deriveMaxTrials(text: string): number | null {
-  const match = text.match(/\b(?:max\s*)?(\d+)\s+(?:trials|runs|experiments)\b/i);
-  return match ? Number(match[1]) : null;
-}
-
-function deriveApprovalPolicy(text: string): RunSpecApprovalPolicy {
-  const approvalGated = /approval[-\s]?gated|approval required|ask before|確認して|承認/i.test(text);
-  const submitMentioned = /\b(submit|submission|publish|external)\b|提出|公開/i.test(text);
+function normalizeDeadline(draft: RunSpecDraft, context: RunSpecDerivationContext): RunSpecDeadline | null {
+  if (!draft.deadline) return null;
   return {
-    submit: approvalGated || submitMentioned ? "approval_required" : "unspecified",
-    publish: approvalGated && /\bpublish\b|公開/i.test(text) ? "approval_required" : "unspecified",
-    secret: "approval_required",
-    external_action: approvalGated || submitMentioned ? "approval_required" : "unspecified",
-    irreversible_action: "approval_required",
+    raw: draft.deadline.raw,
+    iso_at: draft.deadline.iso_at ?? null,
+    timezone: draft.deadline.timezone ?? context.timezone ?? null,
+    finalization_buffer_minutes: draft.deadline.finalization_buffer_minutes ?? null,
+    confidence: toConfidence(draft.deadline.confidence, "medium"),
   };
 }
 
-function deriveArtifactContract(profile: "generic" | "kaggle"): RunSpecArtifactContract {
+function normalizeApprovalPolicy(policy: RunSpecDraft["approval_policy"]): RunSpecApprovalPolicy {
+  return {
+    submit: policy?.submit ?? "unspecified",
+    publish: policy?.publish ?? "unspecified",
+    secret: policy?.secret ?? "approval_required",
+    external_action: policy?.external_action ?? "unspecified",
+    irreversible_action: policy?.irreversible_action ?? "approval_required",
+  };
+}
+
+function normalizeArtifactContract(
+  profile: "generic" | "kaggle",
+  draft: RunSpecDraft["artifact_contract"],
+): RunSpecArtifactContract {
+  const fallback = defaultArtifactContract(profile);
+  return {
+    expected_artifacts: nonEmpty(draft?.expected_artifacts) ?? fallback.expected_artifacts,
+    discovery_globs: nonEmpty(draft?.discovery_globs) ?? fallback.discovery_globs,
+    primary_outputs: nonEmpty(draft?.primary_outputs) ?? fallback.primary_outputs,
+  };
+}
+
+function defaultArtifactContract(profile: "generic" | "kaggle"): RunSpecArtifactContract {
   if (profile === "kaggle") {
     return {
       expected_artifacts: ["submission files", "leaderboard metrics", "experiment notes", "model artifacts"],
@@ -298,19 +352,86 @@ function deriveArtifactContract(profile: "generic" | "kaggle"): RunSpecArtifactC
     };
   }
   return {
-    expected_artifacts: ["progress report", "metrics", "logs"],
-    discovery_globs: ["reports/**/*.md", "**/metrics*.json", "**/*.log"],
-    primary_outputs: ["progress summary", "final report"],
+    expected_artifacts: ["progress evidence", "final deliverable", "run report"],
+    discovery_globs: ["reports/**/*.md", "artifacts/**/*", "outputs/**/*"],
+    primary_outputs: ["run report"],
   };
 }
 
+function normalizeMissingFields(
+  draft: RunSpecDraft,
+  workspace: RunSpec["workspace"],
+  deadline: RunSpecDeadline | null,
+  metric: RunSpecMetric | null,
+): RunSpecMissingField[] {
+  const fields = [...draft.missing_fields];
+  if (!workspace) {
+    fields.push({
+      field: "workspace",
+      question: "Which local or remote workspace should PulSeed use for this run?",
+      severity: "required",
+    });
+  }
+  if (!deadline) {
+    fields.push({
+      field: "deadline",
+      question: "What deadline or review time should PulSeed plan around?",
+      severity: "required",
+    });
+  }
+  if (metric && metric.direction === "unknown" && metric.target !== null) {
+    fields.push({
+      field: "metric.direction",
+      question: `Should ${metric.name} be maximized or minimized?`,
+      severity: "required",
+    });
+  }
+  return dedupeMissingFields(fields);
+}
+
+function dedupeMissingFields(fields: RunSpecMissingField[]): RunSpecMissingField[] {
+  const seen = new Set<string>();
+  const result: RunSpecMissingField[] = [];
+  for (const field of fields) {
+    if (seen.has(field.field)) continue;
+    seen.add(field.field);
+    result.push(field);
+  }
+  return result;
+}
+
+function deriveSpecConfidence(confidence: number, missingFields: RunSpecMissingField[]): RunSpecConfidence {
+  if (missingFields.some((field) => field.severity === "required")) return "medium";
+  if (confidence >= 0.85) return "high";
+  if (confidence >= MIN_RUNSPEC_CONFIDENCE) return "medium";
+  return "low";
+}
+
 function deriveRiskFlags(policy: RunSpecApprovalPolicy): string[] {
-  const flags = ["secret_use_requires_approval", "irreversible_actions_require_approval"];
+  const flags: string[] = [];
   if (policy.submit === "approval_required") flags.push("external_submit_requires_approval");
-  if (policy.publish === "approval_required") flags.push("external_publish_requires_approval");
+  if (policy.publish === "approval_required") flags.push("publish_requires_approval");
+  if (policy.secret === "approval_required") flags.push("secrets_require_approval");
+  if (policy.external_action === "approval_required") flags.push("external_actions_require_approval");
+  if (policy.irreversible_action === "approval_required") flags.push("irreversible_actions_require_approval");
   return flags;
 }
 
-function minutesUntil(from: Date, to: Date): number {
-  return Math.max(0, Math.round((to.getTime() - from.getTime()) / 60_000));
+function normalizeObjective(objective: string | undefined, text: string): string {
+  const trimmed = objective?.trim();
+  return trimmed ? trimmed : text.trim().replace(/\s+/g, " ");
+}
+
+function toConfidence(value: RunSpecConfidence | undefined, fallback: RunSpecConfidence): RunSpecConfidence {
+  return value ?? fallback;
+}
+
+function nonEmpty(values: string[] | undefined): string[] | undefined {
+  return values && values.length > 0 ? values : undefined;
+}
+
+function minutesUntil(now: Date, target: Date): number | null {
+  const deltaMs = target.getTime() - now.getTime();
+  if (!Number.isFinite(deltaMs) || deltaMs <= 0) return null;
+  return Math.ceil(deltaMs / 60_000);
 }

--- a/src/runtime/run-spec/index.ts
+++ b/src/runtime/run-spec/index.ts
@@ -1,4 +1,4 @@
-export { deriveRunSpecFromText, recognizeRunSpecIntent, type RunSpecIntent } from "./derive.js";
+export { deriveRunSpecFromText, understandRunSpecDraft, type RunSpecIntent } from "./derive.js";
 export { createRunSpecStore, RunSpecStore } from "./store.js";
 export {
   applyRunSpecRevision,

--- a/src/runtime/run-spec/types.ts
+++ b/src/runtime/run-spec/types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
 
 export const RunSpecProfileSchema = z.enum(["generic", "kaggle"]);
 export type RunSpecProfile = z.infer<typeof RunSpecProfileSchema>;
@@ -122,4 +123,5 @@ export interface RunSpecDerivationContext {
   conversationId?: string | null;
   now?: Date;
   timezone?: string;
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;
 }


### PR DESCRIPTION
Closes #868

## 実装要約
- Replaced regex/keyword RunSpec intent and field extraction with an LLM-backed structured RunSpec draft schema parsed through Zod.
- Added confidence-gated `understandRunSpecDraft`; low-confidence, parse failure, or model unavailable returns `null` so ordinary chat continues without keyword fallback.
- Updated TUI freeform caller path to await structured derivation with the production LLM client, and removed the unused chat ingress `runSpecIntent` keyword side channel.
- Preserved confirmation/missing-field behavior and fixed confirmed RunSpec execution to use the structured workspace instead of stale TUI cwd.

## 検証コマンド
- `npm exec -- vitest run src/runtime/run-spec/__tests__/run-spec.test.ts src/interface/tui/__tests__/app.test.ts src/interface/chat/__tests__/ingress-router.test.ts` - pass
- `npm run typecheck` - pass
- `npm run lint:boundaries` - pass, 0 errors with existing warnings
- `npm run test:changed` - pass, including smoke lane
- Fresh review agent - initial P1 stale workspace cwd finding fixed; re-review LGTM

## 既知の未解決リスク
- Structured classification quality depends on the configured LLM. When unavailable or low confidence, RunSpec derivation now intentionally falls back to ordinary chat/null rather than guessing.
