### PR TITLE
refactor(approvals): replace hard-coded confirmation phrase parsers

### DIFF
--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -195,6 +195,14 @@ function runSpecResponse(overrides: Record<string, unknown> = {}): string {
   });
 }
 
+function confirmationResponse(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    decision: "approve",
+    confidence: 0.94,
+    ...overrides,
+  });
+}
+
 function createEvidenceSummary(overrides: Record<string, unknown> = {}) {
   return {
     schema_version: "runtime-evidence-summary-v1",
@@ -471,6 +479,7 @@ describe("standalone slash command routing", () => {
     const llmClient = createMockLLMClient([
       nonEvidenceResponse(),
       runSpecResponse(),
+      confirmationResponse(),
     ]);
 
     const screen = render(React.createElement(App, {
@@ -527,6 +536,7 @@ describe("standalone slash command routing", () => {
           confidence: "high",
         },
       }),
+      confirmationResponse(),
     ]);
 
     const screen = render(React.createElement(App, {
@@ -575,6 +585,7 @@ describe("standalone slash command routing", () => {
       runSpecResponse({
         deadline: null,
       }),
+      confirmationResponse(),
     ]);
 
     const screen = render(React.createElement(App, {
@@ -933,6 +944,199 @@ describe("daemon-mode chat routing", () => {
     testState.lastApprovalProps?.onDecision(true);
 
     expect(daemonClient.approve).toHaveBeenCalledWith("goal-a", "handoff-1", true);
+    screen.unmount();
+  });
+
+  it("classifies multilingual freeform approval text inside a pending approval context", async () => {
+    const daemonClient = createDaemonClientMock();
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const llmClient = createSingleMockLLMClient(confirmationResponse({
+      decision: "approve",
+      confidence: 0.94,
+    }));
+
+    const screen = render(React.createElement(App, {
+      daemonClient: daemonClient as unknown as DaemonClient,
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      llmClient,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    daemonClient.handlers.get("operator_handoff_required")?.({
+      handoff_id: "handoff-approval",
+      goal_id: "goal-a",
+      title: "Submit handoff",
+      summary: "External submission requires approval.",
+      recommended_action: "Submit the result.",
+      triggers: ["approval_required"],
+      created_at: "2026-05-01T00:00:00.000Z",
+    });
+    await flush();
+
+    await testState.lastChatProps!.onSubmit("proceda con la entrega");
+
+    expect(daemonClient.approve).toHaveBeenCalledWith("goal-a", "handoff-approval", true);
+    expect(chatRunner.execute).not.toHaveBeenCalled();
+    screen.unmount();
+  });
+
+  it("classifies multilingual freeform cancellation inside a pending approval context", async () => {
+    const daemonClient = createDaemonClientMock();
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const llmClient = createSingleMockLLMClient(confirmationResponse({
+      decision: "cancel",
+      confidence: 0.93,
+    }));
+
+    const screen = render(React.createElement(App, {
+      daemonClient: daemonClient as unknown as DaemonClient,
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      llmClient,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    daemonClient.handlers.get("operator_handoff_required")?.({
+      handoff_id: "handoff-cancel",
+      goal_id: "goal-a",
+      title: "Publish handoff",
+      summary: "External publish requires approval.",
+      recommended_action: "Publish the result.",
+      triggers: ["approval_required"],
+      created_at: "2026-05-01T00:00:00.000Z",
+    });
+    await flush();
+
+    await testState.lastChatProps!.onSubmit("annule cette publication");
+
+    expect(daemonClient.approve).toHaveBeenCalledWith("goal-a", "handoff-cancel", false);
+    expect(chatRunner.execute).not.toHaveBeenCalled();
+    screen.unmount();
+  });
+
+  it("keeps ambiguous approval text pending and does not execute chat or approval", async () => {
+    const daemonClient = createDaemonClientMock();
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const llmClient = createSingleMockLLMClient(confirmationResponse({
+      decision: "unknown",
+      confidence: 0.45,
+      clarification: "Please explicitly approve or cancel.",
+    }));
+
+    const screen = render(React.createElement(App, {
+      daemonClient: daemonClient as unknown as DaemonClient,
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      llmClient,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    daemonClient.handlers.get("operator_handoff_required")?.({
+      handoff_id: "handoff-ambiguous",
+      goal_id: "goal-a",
+      title: "Secret handoff",
+      summary: "Secret handling requires approval.",
+      recommended_action: "Use the configured secret.",
+      triggers: ["approval_required"],
+      created_at: "2026-05-01T00:00:00.000Z",
+    });
+    await flush();
+
+    await testState.lastChatProps!.onSubmit("sounds fine maybe");
+
+    expect(daemonClient.approve).not.toHaveBeenCalled();
+    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+    expect(testState.lastApprovalProps?.task.work_description).toBe("Secret handoff");
+    screen.unmount();
+  });
+
+  it("ignores stale async freeform approval classification after the overlay button resolves", async () => {
+    const daemonClient = createDaemonClientMock();
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    let releaseClassification!: () => void;
+    const llmClient = {
+      sendMessage: vi.fn(async () => {
+        await new Promise<void>((resolve) => {
+          releaseClassification = resolve;
+        });
+        return {
+          content: confirmationResponse({ decision: "cancel", confidence: 0.93 }),
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn" as const,
+        };
+      }),
+      parseJSON: createSingleMockLLMClient(confirmationResponse()).parseJSON,
+    };
+
+    const screen = render(React.createElement(App, {
+      daemonClient: daemonClient as unknown as DaemonClient,
+      stateManager: stateManager as unknown as StateManager,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      llmClient,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "~/workspace",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    daemonClient.handlers.get("operator_handoff_required")?.({
+      handoff_id: "handoff-stale",
+      goal_id: "goal-a",
+      title: "Publish handoff",
+      summary: "External publish requires approval.",
+      recommended_action: "Publish the result.",
+      triggers: ["approval_required"],
+      created_at: "2026-05-01T00:00:00.000Z",
+    });
+    await flush();
+
+    const pendingSubmit = testState.lastChatProps!.onSubmit("please decide");
+    await vi.waitFor(() => expect(llmClient.sendMessage).toHaveBeenCalledOnce());
+    testState.lastApprovalProps?.onDecision(true);
+    releaseClassification();
+    await pendingSubmit;
+
+    expect(daemonClient.approve).toHaveBeenCalledTimes(1);
+    expect(daemonClient.approve).toHaveBeenCalledWith("goal-a", "handoff-stale", true);
     screen.unmount();
   });
 

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -52,6 +52,7 @@ import {
   type RunSpec,
 } from "../../runtime/run-spec/index.js";
 import { answerRuntimeEvidenceQuestion } from "../../runtime/evidence-answer.js";
+import { classifyConfirmationDecision } from "../../runtime/confirmation-decision.js";
 
 const MAX_MESSAGES = 200;
 const PULSEED_VERSION = getPulseedVersion(import.meta.url);
@@ -69,13 +70,6 @@ export type DaemonConnectionState = "connected" | "connecting" | "disconnected";
 export function formatDaemonConnectionState(state: DaemonConnectionState | undefined): string | undefined {
   if (!state) return undefined;
   return `  [daemon ${state}]`;
-}
-
-function parseApprovalDecisionInput(input: string): boolean | null {
-  const normalized = input.trim().toLowerCase();
-  if (/^(confirm|approve|yes|y|ok|実行|承認|はい|お願い|進めて)$/.test(normalized)) return true;
-  if (/^(cancel|reject|no|n|stop|やめて|キャンセル|却下)$/.test(normalized)) return false;
-  return null;
 }
 
 function normalizeApprovalTask(data: Record<string, unknown>): Task {
@@ -120,6 +114,17 @@ function normalizeApprovalTask(data: Record<string, unknown>): Task {
     heartbeat_at: null,
     created_at: String(data.created_at ?? new Date().toISOString()),
   };
+}
+
+function formatApprovalDecisionContext(task: Task): string {
+  return [
+    `Work: ${task.work_description}`,
+    `Rationale: ${task.rationale}`,
+    `Approach: ${task.approach}`,
+    `Constraints: ${task.constraints.join(", ")}`,
+    `Reversibility: ${task.reversibility}`,
+    `Category: ${task.task_category}`,
+  ].join("\n");
 }
 
 export type FreeformInputRoute = "daemon_goal_chat" | "chat_runner" | "unavailable";
@@ -565,19 +570,38 @@ export function App({
 
   const handleInput = useCallback(
     async (input: string) => {
-      const approvalDecision = approvalRequestRef.current ? parseApprovalDecisionInput(input) : null;
-      if (approvalDecision !== null && approvalRequestRef.current) {
+      if (approvalRequestRef.current) {
         const request = approvalRequestRef.current;
         setMessages((prev) => [...prev, { id: randomUUID(), role: "user" as const, text: input, timestamp: new Date() }].slice(-MAX_MESSAGES));
-        request.resolve(approvalDecision);
-        approvalRequestRef.current = null;
-        setApprovalRequest(null);
+        const approvalDecision = await classifyConfirmationDecision(input, {
+          kind: "approval",
+          llmClient,
+          allowedDecisions: ["approve", "cancel", "unknown"],
+          subject: formatApprovalDecisionContext(request.task),
+        });
+        if (approvalRequestRef.current !== request) {
+          return;
+        }
+        if (approvalDecision.decision === "approve" || approvalDecision.decision === "cancel") {
+          const approved = approvalDecision.decision === "approve";
+          request.resolve(approved);
+          approvalRequestRef.current = null;
+          setApprovalRequest(null);
+          setMessages((prev) => [...prev, {
+            id: randomUUID(),
+            role: "pulseed" as const,
+            text: approved ? "Approval confirmed." : "Approval cancelled.",
+            timestamp: new Date(),
+            messageType: "info" as const,
+          }].slice(-MAX_MESSAGES));
+          return;
+        }
         setMessages((prev) => [...prev, {
           id: randomUUID(),
           role: "pulseed" as const,
-          text: approvalDecision ? "Approval confirmed." : "Approval cancelled.",
+          text: approvalDecision.clarification ?? "Approval is still pending. Please approve or cancel explicitly.",
           timestamp: new Date(),
-          messageType: "info" as const,
+          messageType: "warning" as const,
         }].slice(-MAX_MESSAGES));
         return;
       }
@@ -655,8 +679,9 @@ export function App({
 
         if (pendingRunSpec && chatRunner) {
           const effectiveCwd = cwd ?? process.cwd();
-          const result = handleRunSpecConfirmationInput(pendingRunSpec, input, {
+          const result = await handleRunSpecConfirmationInput(pendingRunSpec, input, {
             timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            llmClient,
           });
           const savedRunSpec = await createRunSpecStore(stateManager).save(result.spec);
           if (result.kind === "cancelled") {
@@ -723,8 +748,9 @@ export function App({
             startLoop(result.startLoop.goalId);
           }
           if (result.stopLoop) {
-            if (approvalRequestRef.current) {
-              approvalRequestRef.current.resolve(false);
+            const pendingApproval = approvalRequestRef.current as ApprovalRequest | null;
+            if (pendingApproval) {
+              pendingApproval.resolve(false);
               approvalRequestRef.current = null;
               setApprovalRequest(null);
             }

--- a/src/runtime/confirmation-decision.ts
+++ b/src/runtime/confirmation-decision.ts
@@ -1,0 +1,136 @@
+import { z } from "zod";
+import type { ILLMClient } from "../base/llm/llm-client.js";
+import { getInternalIdentityPrefix } from "../base/config/identity-loader.js";
+
+const MIN_CONFIRMATION_CONFIDENCE = 0.7;
+
+const ConfirmationRevisionSchema = z.object({
+  workspace_path: z.string().min(1).nullable().optional(),
+  deadline: z.object({
+    raw: z.string().min(1),
+    iso_at: z.string().nullable().optional(),
+    timezone: z.string().nullable().optional(),
+    finalization_buffer_minutes: z.number().nullable().optional(),
+    confidence: z.enum(["high", "medium", "low"]).optional(),
+  }).nullable().optional(),
+  metric_direction: z.enum(["maximize", "minimize"]).nullable().optional(),
+}).optional();
+
+export const ConfirmationDecisionSchema = z.object({
+  decision: z.enum(["approve", "cancel", "revise", "unknown"]),
+  confidence: z.number().min(0).max(1),
+  revision: ConfirmationRevisionSchema,
+  clarification: z.string().optional(),
+  rationale: z.string().optional(),
+});
+
+export type ConfirmationDecision = z.infer<typeof ConfirmationDecisionSchema>;
+export type ConfirmationDecisionKind = ConfirmationDecision["decision"];
+
+export interface ConfirmationDecisionContext {
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;
+  kind: "approval" | "run_spec_confirmation";
+  subject: string;
+  allowedDecisions?: ConfirmationDecisionKind[];
+}
+
+export async function classifyConfirmationDecision(
+  input: string,
+  context: ConfirmationDecisionContext,
+): Promise<ConfirmationDecision> {
+  const commandDecision = parseExactConfirmationCommand(input);
+  if (commandDecision) return commandDecision;
+
+  const trimmed = input.trim();
+  const llmClient = context.llmClient;
+  if (!trimmed || !llmClient) return unknownDecision("Confirmation classifier is unavailable.");
+
+  try {
+    const response = await llmClient.sendMessage(
+      [{ role: "user", content: trimmed }],
+      { system: getConfirmationDecisionPrompt(context), max_tokens: 600, temperature: 0 },
+    );
+    const parsed = llmClient.parseJSON(response.content, ConfirmationDecisionSchema);
+    if (!isAllowedDecision(parsed.decision, context.allowedDecisions)) {
+      return unknownDecision("The response did not map to an allowed confirmation decision.");
+    }
+    if (parsed.decision !== "unknown" && parsed.confidence < MIN_CONFIRMATION_CONFIDENCE) {
+      return unknownDecision(parsed.clarification ?? "The confirmation response is ambiguous.");
+    }
+    if (parsed.decision === "revise" && !hasRevision(parsed)) {
+      return unknownDecision(parsed.clarification ?? "Please include the revision details.");
+    }
+    return parsed;
+  } catch {
+    return unknownDecision("Confirmation could not be classified.");
+  }
+}
+
+function parseExactConfirmationCommand(input: string): ConfirmationDecision | null {
+  const command = input.trim();
+  if (command === "/approve" || command === "/confirm") {
+    return { decision: "approve", confidence: 1 };
+  }
+  if (command === "/cancel" || command === "/reject") {
+    return { decision: "cancel", confidence: 1 };
+  }
+  return null;
+}
+
+function getConfirmationDecisionPrompt(context: ConfirmationDecisionContext): string {
+  const allowed = context.allowedDecisions?.join(", ") ?? "approve, cancel, revise, unknown";
+  return `${getInternalIdentityPrefix("assistant")} Classify the operator's reply inside an explicit pending confirmation context.
+
+Use the pending context as the guard. Do not infer approval from vague enthusiasm, acknowledgement, side comments, or unrelated chat. If the reply is ambiguous, return unknown.
+
+Allowed decisions: ${allowed}
+
+Decision meanings:
+- approve: explicitly approves or starts the pending approval/run.
+- cancel: explicitly rejects, cancels, or stops the pending approval/run.
+- revise: asks to change the pending RunSpec; include structured revision fields.
+- unknown: asks for clarification, discusses the request, or is too ambiguous.
+
+Context kind: ${context.kind}
+Pending context:
+${context.subject}
+
+Respond only as JSON:
+{
+  "decision": "approve" | "cancel" | "revise" | "unknown",
+  "confidence": 0.0-1.0,
+  "revision": {
+    "workspace_path": "/repo/path",
+    "deadline": {
+      "raw": "tomorrow morning",
+      "iso_at": "2026-05-03T00:00:00.000Z",
+      "timezone": "Asia/Tokyo",
+      "finalization_buffer_minutes": 60,
+      "confidence": "medium"
+    },
+    "metric_direction": "maximize" | "minimize"
+  },
+  "clarification": "short clarification request when unknown",
+  "rationale": "short rationale"
+}`;
+}
+
+function isAllowedDecision(
+  decision: ConfirmationDecisionKind,
+  allowed: ConfirmationDecisionKind[] | undefined,
+): boolean {
+  return !allowed || new Set(allowed).has(decision);
+}
+
+function hasRevision(decision: ConfirmationDecision): boolean {
+  const revision = decision.revision;
+  return Boolean(revision?.workspace_path || revision?.deadline || revision?.metric_direction);
+}
+
+export function unknownDecision(clarification: string): ConfirmationDecision {
+  return {
+    decision: "unknown",
+    confidence: 0,
+    clarification,
+  };
+}

--- a/src/runtime/run-spec/__tests__/run-spec.test.ts
+++ b/src/runtime/run-spec/__tests__/run-spec.test.ts
@@ -57,6 +57,14 @@ function llmDraft(overrides: Record<string, unknown> = {}) {
   }));
 }
 
+function confirmationDecision(overrides: Record<string, unknown> = {}) {
+  return createSingleMockLLMClient(JSON.stringify({
+    decision: "approve",
+    confidence: 0.94,
+    ...overrides,
+  }));
+}
+
 describe("RunSpec derivation", () => {
   it("derives a Kaggle RunSpec with separate metric and progress semantics", async () => {
     const spec = await deriveRunSpecFromText(
@@ -316,7 +324,10 @@ describe("RunSpec confirmation", () => {
     );
     expect(spec).not.toBeNull();
 
-    const result = handleRunSpecConfirmationInput(spec!, "confirm", { now: NOW });
+    const result = await handleRunSpecConfirmationInput(spec!, "Bitte starten", {
+      now: NOW,
+      llmClient: confirmationDecision(),
+    });
 
     expect(result.kind).toBe("confirmed");
     expect(result.spec.status).toBe("confirmed");
@@ -346,19 +357,35 @@ describe("RunSpec confirmation", () => {
     });
     expect(spec).not.toBeNull();
 
-    const revisedWorkspace = handleRunSpecConfirmationInput(spec!, "workspace /repo/kaggle", { now: NOW });
+    const revisedWorkspace = await handleRunSpecConfirmationInput(spec!, "Use /repo/kaggle and review tomorrow morning", {
+      now: NOW,
+      llmClient: confirmationDecision({
+        decision: "revise",
+        confidence: 0.91,
+        revision: {
+          workspace_path: "/repo/kaggle",
+          deadline: {
+            raw: "tomorrow morning",
+            iso_at: "2026-05-03T09:00:00.000Z",
+            timezone: "Asia/Tokyo",
+            finalization_buffer_minutes: 60,
+            confidence: "medium",
+          },
+        },
+      }),
+    });
     expect(revisedWorkspace.kind).toBe("revised");
     expect(revisedWorkspace.spec.workspace).toMatchObject({ path: "/repo/kaggle", source: "user" });
+    expect(revisedWorkspace.spec.deadline).toMatchObject({ raw: "tomorrow morning" });
 
-    const revisedDeadline = handleRunSpecConfirmationInput(revisedWorkspace.spec, "deadline tomorrow morning", { now: NOW });
-    expect(revisedDeadline.kind).toBe("revised");
-    expect(revisedDeadline.spec.deadline).toMatchObject({ raw: "tomorrow morning" });
-
-    const confirmed = handleRunSpecConfirmationInput(revisedDeadline.spec, "confirm", { now: NOW });
+    const confirmed = await handleRunSpecConfirmationInput(revisedWorkspace.spec, "adelante", {
+      now: NOW,
+      llmClient: confirmationDecision(),
+    });
     expect(confirmed.kind).toBe("confirmed");
   });
 
-  it("cancels a pending RunSpec", async () => {
+  it("cancels a pending RunSpec with multilingual freeform text", async () => {
     const spec = await deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
       cwd: "/repo/kaggle",
       now: NOW,
@@ -366,7 +393,10 @@ describe("RunSpec confirmation", () => {
     });
     expect(spec).not.toBeNull();
 
-    const result = handleRunSpecConfirmationInput(spec!, "cancel", { now: NOW });
+    const result = await handleRunSpecConfirmationInput(spec!, "annule cette exécution", {
+      now: NOW,
+      llmClient: confirmationDecision({ decision: "cancel", confidence: 0.93 }),
+    });
 
     expect(result.kind).toBe("cancelled");
     expect(result.spec.status).toBe("cancelled");
@@ -396,11 +426,49 @@ describe("RunSpec confirmation", () => {
     });
     expect(spec).not.toBeNull();
 
-    const result = handleRunSpecConfirmationInput(spec!, "confirm", { now: NOW });
+    const result = await handleRunSpecConfirmationInput(spec!, "start it", {
+      now: NOW,
+      llmClient: confirmationDecision(),
+    });
 
     expect(result.kind).toBe("blocked");
     expect(result.message).toContain("Which local or remote workspace");
     expect(result.message).toContain("What deadline or review time");
+  });
+
+  it("does not execute a pending RunSpec on ambiguous confirmation text", async () => {
+    const spec = await deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
+      cwd: "/repo/kaggle",
+      now: NOW,
+      llmClient: llmDraft(),
+    });
+    expect(spec).not.toBeNull();
+
+    const result = await handleRunSpecConfirmationInput(spec!, "looks interesting", {
+      now: NOW,
+      llmClient: confirmationDecision({
+        decision: "unknown",
+        confidence: 0.42,
+        clarification: "Please explicitly approve or cancel.",
+      }),
+    });
+
+    expect(result.kind).toBe("unrecognized");
+    expect(result.spec.status).toBe("draft");
+  });
+
+  it("does not use a phrase fallback when confirmation classifier is unavailable", async () => {
+    const spec = await deriveRunSpecFromText("Run Kaggle until tomorrow morning and aim for top 15%.", {
+      cwd: "/repo/kaggle",
+      now: NOW,
+      llmClient: llmDraft(),
+    });
+    expect(spec).not.toBeNull();
+
+    const result = await handleRunSpecConfirmationInput(spec!, "confirm", { now: NOW });
+
+    expect(result.kind).toBe("unrecognized");
+    expect(result.spec.status).toBe("draft");
   });
 
   it("shows risky external actions as approval-gated in the proposal", async () => {

--- a/src/runtime/run-spec/confirmation.ts
+++ b/src/runtime/run-spec/confirmation.ts
@@ -1,4 +1,9 @@
-import type { RunSpec, RunSpecDeadline, RunSpecMissingField } from "./types.js";
+import {
+  classifyConfirmationDecision,
+  type ConfirmationDecision,
+} from "../confirmation-decision.js";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+import type { RunSpec, RunSpecMissingField } from "./types.js";
 import { RunSpecSchema } from "./types.js";
 
 export type RunSpecConfirmationResult =
@@ -11,6 +16,7 @@ export type RunSpecConfirmationResult =
 export interface RunSpecConfirmationContext {
   now?: Date;
   timezone?: string;
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;
 }
 
 export function formatRunSpecSetupProposal(spec: RunSpec): string {
@@ -39,20 +45,25 @@ export function formatRunSpecSetupProposal(spec: RunSpec): string {
   return lines.join("\n");
 }
 
-export function handleRunSpecConfirmationInput(
+export async function handleRunSpecConfirmationInput(
   spec: RunSpec,
   input: string,
   context: RunSpecConfirmationContext = {},
-): RunSpecConfirmationResult {
-  const trimmed = input.trim();
+): Promise<RunSpecConfirmationResult> {
   const now = context.now ?? new Date();
+  const decision = await classifyConfirmationDecision(input, {
+    kind: "run_spec_confirmation",
+    llmClient: context.llmClient,
+    allowedDecisions: ["approve", "cancel", "revise", "unknown"],
+    subject: formatRunSpecConfirmationContext(spec),
+  });
 
-  if (/^(cancel|abort|stop|やめる|キャンセル)$/i.test(trimmed)) {
+  if (decision.decision === "cancel") {
     const cancelled = updateSpec(spec, { status: "cancelled", updated_at: now.toISOString() });
     return { kind: "cancelled", spec: cancelled, message: `RunSpec cancelled: ${cancelled.id}` };
   }
 
-  if (/^(confirm|start|start run|approve|ok|yes|開始|承認)$/i.test(trimmed)) {
+  if (decision.decision === "approve") {
     const required = requiredMissingFields(spec);
     if (required.length > 0) {
       return {
@@ -65,11 +76,21 @@ export function handleRunSpecConfirmationInput(
     return { kind: "confirmed", spec: confirmed, message: `RunSpec confirmed: ${confirmed.id}` };
   }
 
-  const revised = applyRunSpecRevision(spec, trimmed, {
-    now,
-    timezone: context.timezone,
-  });
-  if (revised) {
+  if (decision.decision === "revise") {
+    const revised = applyRunSpecRevision(spec, decision, {
+      now,
+      timezone: context.timezone,
+    });
+    if (!revised) {
+      return {
+        kind: "unrecognized",
+        spec,
+        message: [
+          "RunSpec revision needs structured workspace, deadline, or metric direction details.",
+          formatMissingFieldsMessage(requiredMissingFields(spec)),
+        ].filter(Boolean).join("\n"),
+      };
+    }
     return {
       kind: "revised",
       spec: revised,
@@ -82,7 +103,7 @@ export function handleRunSpecConfirmationInput(
     spec,
     message: [
       "RunSpec is awaiting confirmation.",
-      "Use confirm, cancel, or revise with a workspace, deadline, or metric direction.",
+      decision.clarification ?? "Please approve, cancel, or revise the pending RunSpec.",
       formatMissingFieldsMessage(requiredMissingFields(spec)),
     ].filter(Boolean).join("\n"),
   };
@@ -94,20 +115,21 @@ export function requiredMissingFields(spec: RunSpec): RunSpecMissingField[] {
 
 export function applyRunSpecRevision(
   spec: RunSpec,
-  input: string,
+  decision: ConfirmationDecision,
   context: RunSpecConfirmationContext = {},
 ): RunSpec | null {
   const now = context.now ?? new Date();
+  const revision = decision.revision;
+  if (!revision) return null;
   const updates: Partial<RunSpec> = {
     updated_at: now.toISOString(),
   };
   let changed = false;
   let missingFields = [...spec.missing_fields];
 
-  const workspace = parseWorkspace(input);
-  if (workspace) {
+  if (revision.workspace_path) {
     updates.workspace = {
-      path: workspace,
+      path: revision.workspace_path,
       source: "user",
       confidence: "high",
     };
@@ -115,23 +137,27 @@ export function applyRunSpecRevision(
     changed = true;
   }
 
-  const deadline = parseDeadline(input, now, context.timezone);
-  if (deadline) {
-    updates.deadline = deadline;
+  if (revision.deadline) {
+    updates.deadline = {
+      raw: revision.deadline.raw,
+      iso_at: revision.deadline.iso_at ?? null,
+      timezone: revision.deadline.timezone ?? context.timezone ?? null,
+      finalization_buffer_minutes: revision.deadline.finalization_buffer_minutes ?? null,
+      confidence: revision.deadline.confidence ?? "medium",
+    };
     updates.budget = {
       ...spec.budget,
-      max_wall_clock_minutes: deadline.iso_at ? minutesUntil(now, new Date(deadline.iso_at)) : spec.budget.max_wall_clock_minutes,
+      max_wall_clock_minutes: updates.deadline.iso_at ? minutesUntil(now, new Date(updates.deadline.iso_at)) : spec.budget.max_wall_clock_minutes,
       resident_policy: "until_deadline",
     };
     missingFields = removeMissing(missingFields, "deadline");
     changed = true;
   }
 
-  const metricDirection = parseMetricDirection(input);
-  if (metricDirection && spec.metric) {
+  if (revision.metric_direction && spec.metric) {
     updates.metric = {
       ...spec.metric,
-      direction: metricDirection,
+      direction: revision.metric_direction,
       confidence: "high",
     };
     missingFields = removeMissing(missingFields, "metric.direction");
@@ -145,6 +171,26 @@ export function applyRunSpecRevision(
   });
 }
 
+function formatRunSpecConfirmationContext(spec: RunSpec): string {
+  const required = requiredMissingFields(spec);
+  return [
+    `RunSpec ID: ${spec.id}`,
+    `Status: ${spec.status}`,
+    `Profile: ${spec.profile}`,
+    `Objective: ${spec.objective}`,
+    `Workspace: ${spec.workspace?.path ?? "unresolved"}`,
+    `Deadline: ${spec.deadline?.raw ?? "unresolved"}`,
+    `Metric: ${spec.metric ? `${spec.metric.name} (${spec.metric.direction})` : "unresolved"}`,
+    `Progress: ${spec.progress_contract.semantics}`,
+    `Submit policy: ${spec.approval_policy.submit}`,
+    `Publish policy: ${spec.approval_policy.publish}`,
+    `External actions: ${spec.approval_policy.external_action}`,
+    `Secret policy: ${spec.approval_policy.secret}`,
+    `Irreversible actions: ${spec.approval_policy.irreversible_action}`,
+    required.length > 0 ? `Required missing fields: ${required.map((field) => field.field).join(", ")}` : "Required missing fields: none",
+  ].join("\n");
+}
+
 function updateSpec(spec: RunSpec, updates: Partial<RunSpec>): RunSpec {
   return RunSpecSchema.parse({
     ...spec,
@@ -154,44 +200,6 @@ function updateSpec(spec: RunSpec, updates: Partial<RunSpec>): RunSpec {
 
 function removeMissing(fields: RunSpecMissingField[], field: string): RunSpecMissingField[] {
   return fields.filter((entry) => entry.field !== field);
-}
-
-function parseWorkspace(input: string): string | null {
-  return input.match(/(?:workspace|cwd|directory|dir|repo|path)\s+((?:~|\/)[^\s,]+)/i)?.[1]
-    ?? input.match(/(?:ワークスペース|ディレクトリ|リポジトリ)\s*((?:~|\/)[^\s,]+)/i)?.[1]
-    ?? null;
-}
-
-function parseMetricDirection(input: string): "maximize" | "minimize" | null {
-  if (/\b(maximi[sz]e|higher|increase)\b|最大|上げ|高く/i.test(input)) return "maximize";
-  if (/\b(minimi[sz]e|lower|decrease|reduce)\b|最小|下げ|低く/i.test(input)) return "minimize";
-  return null;
-}
-
-function parseDeadline(input: string, now: Date, timezone: string | undefined): RunSpecDeadline | null {
-  const lower = input.toLowerCase();
-  if (lower.includes("tomorrow morning") || /明日.*(朝|午前)/.test(input)) {
-    const at = new Date(now);
-    at.setDate(at.getDate() + 1);
-    at.setHours(9, 0, 0, 0);
-    return {
-      raw: lower.includes("tomorrow morning") ? "tomorrow morning" : "明日朝",
-      iso_at: at.toISOString(),
-      timezone: timezone ?? null,
-      finalization_buffer_minutes: 60,
-      confidence: "medium",
-    };
-  }
-  const hoursMatch = input.match(/\b(?:for|within|deadline)\s+(\d+)\s*(hours?|hrs?)\b/i);
-  if (!hoursMatch) return null;
-  const at = new Date(now.getTime() + Number(hoursMatch[1]) * 60 * 60 * 1000);
-  return {
-    raw: hoursMatch[0],
-    iso_at: at.toISOString(),
-    timezone: timezone ?? null,
-    finalization_buffer_minutes: 30,
-    confidence: "medium",
-  };
 }
 
 function formatMissingFieldsMessage(fields: RunSpecMissingField[]): string {


### PR DESCRIPTION
Closes #874

## 実装要約
- Added a shared typed `ConfirmationDecision` classifier for pending approval and RunSpec confirmation text.
- Removed hard-coded freeform approve/cancel phrase regexes from TUI approval handling and RunSpec confirmation.
- Kept exact slash protocol commands deterministic (`/approve`, `/confirm`, `/cancel`, `/reject`) while routing other freeform replies through structured classification with confidence and unknown handling.
- Converted RunSpec revision handling to structured workspace/deadline/metric updates.
- Added caller-path tests for multilingual approval, cancellation, ambiguous approval text, RunSpec confirmation/cancellation/revision, model-unavailable fallback, and stale async approval races.

## 検証コマンド
- `npm exec -- vitest run src/interface/tui/__tests__/app.test.ts src/runtime/run-spec/__tests__/run-spec.test.ts` - pass
- `npm run typecheck` - pass
- `npm run lint:boundaries` - pass, 0 errors with existing warnings
- `npm run test:changed` - pass, including smoke lane
- Fresh review agent - initial P1 stale async approval finding fixed; re-review LGTM

## 既知の未解決リスク
- Freeform confirmation quality depends on the configured LLM. If the model is unavailable, parsing fails, or confidence is low, the pending confirmation remains open and no approval-gated action is executed.
