### PR TITLE
refactor(chat): replace interrupt redirect regex classification

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -58,6 +58,45 @@ function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
   };
 }
 
+function interruptDecision(kind: "diff" | "review" | "summary" | "background" | "redirect" | "unknown", confidence = 0.93): string {
+  return JSON.stringify({ kind, confidence, rationale: `test ${kind}` });
+}
+
+function makeInterruptibleAgentLoopRunner() {
+  let capturedSignal: AbortSignal | undefined;
+  let resolveActive: ((value: AgentResult) => void) | undefined;
+  const runner = {
+    execute: vi.fn().mockImplementation((input: { abortSignal?: AbortSignal }) => {
+      capturedSignal = input.abortSignal;
+      return new Promise<AgentResult>((resolve) => {
+        resolveActive = resolve;
+        input.abortSignal?.addEventListener("abort", () => {
+          resolve({
+            success: false,
+            output: "cancelled",
+            error: "cancelled",
+            exit_code: null,
+            elapsed_ms: 10,
+            stopped_reason: "error",
+          });
+        }, { once: true });
+      });
+    }),
+  } as unknown as ChatAgentLoopRunner;
+  return {
+    runner,
+    getSignal: () => capturedSignal,
+    resolveActive: (result: AgentResult = {
+      success: false,
+      output: "cancelled by test",
+      error: null,
+      exit_code: null,
+      elapsed_ms: 1,
+      stopped_reason: "error",
+    }) => resolveActive?.(result),
+  };
+}
+
 function makeAgentLoopState(overrides: Partial<{
   sessionId: string;
   status: "running" | "completed" | "failed";
@@ -2515,49 +2554,170 @@ describe("ChatRunner", () => {
     });
 
     it("does not abort the active turn for unsupported background redirect requests", async () => {
-      let capturedSignal: AbortSignal | undefined;
-      let resolveActive: ((value: {
-        success: boolean;
-        output: string;
-        error: null;
-        exit_code: null;
-        elapsed_ms: number;
-        stopped_reason: string;
-      }) => void) | undefined;
-      const chatAgentLoopRunner = {
-        execute: vi.fn().mockImplementation((input: { abortSignal?: AbortSignal }) => {
-          capturedSignal = input.abortSignal;
-          return new Promise((resolve) => {
-            resolveActive = resolve;
+      const interruptible = makeInterruptibleAgentLoopRunner();
+      const runner = new ChatRunner(makeDeps({
+        stateManager: makeMockStateManager(),
+        chatAgentLoopRunner: interruptible.runner,
+        llmClient: createSingleMockLLMClient(interruptDecision("background")),
+      }));
+      runner.startSession("/repo");
+
+      const active = runner.execute("Implement a feature", "/repo");
+      await vi.waitFor(() => expect(interruptible.runner.execute).toHaveBeenCalledOnce());
+
+      const redirected = await runner.interruptAndRedirect("continúa esto en segundo plano", "/repo");
+
+      expect(interruptible.getSignal()?.aborted).toBe(false);
+      expect(redirected.success).toBe(true);
+      expect(redirected.output).toContain("background is not available yet");
+      expect(runner.hasActiveTurn()).toBe(true);
+
+      interruptible.resolveActive();
+      await active;
+      expect(runner.hasActiveTurn()).toBe(false);
+    });
+
+    it("uses structured interrupt intent classification for multilingual diff redirects", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-interrupt-diff-"));
+      try {
+        execFileSync("git", ["init"], { cwd: tmpDir, stdio: "ignore" });
+        fs.writeFileSync(path.join(tmpDir, "changed.txt"), "hello\n");
+        const interruptible = makeInterruptibleAgentLoopRunner();
+        const runner = new ChatRunner(makeDeps({
+          stateManager: makeMockStateManager(),
+          chatAgentLoopRunner: interruptible.runner,
+          llmClient: createSingleMockLLMClient(interruptDecision("diff")),
+        }));
+        runner.startSession(tmpDir);
+
+        const active = runner.execute("Implement a feature", tmpDir);
+        await vi.waitFor(() => expect(interruptible.runner.execute).toHaveBeenCalledOnce());
+
+        const interrupted = await runner.interruptAndRedirect("変更点を見せてから止めて", tmpDir);
+
+        expect(interruptible.getSignal()?.aborted).toBe(true);
+        expect(interrupted.output).toContain("Current diff is shown above");
+        await active;
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("uses structured interrupt intent classification for multilingual review redirects", async () => {
+      const interruptible = makeInterruptibleAgentLoopRunner();
+      const reviewAgentLoopRunner = {
+        execute: vi.fn(async () => ({ success: true, output: "read-only review result", review: null })),
+      };
+      const runner = new ChatRunner(makeDeps({
+        stateManager: makeMockStateManager(),
+        chatAgentLoopRunner: interruptible.runner,
+        reviewAgentLoopRunner,
+        llmClient: createSingleMockLLMClient(interruptDecision("review")),
+      }));
+      runner.startSession("/repo");
+
+      const active = runner.execute("Implement a feature", "/repo");
+      await vi.waitFor(() => expect(interruptible.runner.execute).toHaveBeenCalledOnce());
+
+      const interrupted = await runner.interruptAndRedirect("passe en revue sans modifier", "/repo");
+
+      expect(interruptible.getSignal()?.aborted).toBe(true);
+      expect(reviewAgentLoopRunner.execute).toHaveBeenCalledOnce();
+      expect(interrupted.output).toContain("review-only mode");
+      expect(interrupted.output).toContain("read-only review result");
+      await active;
+    });
+
+    it("uses structured interrupt intent classification for multilingual summary redirects", async () => {
+      const interruptible = makeInterruptibleAgentLoopRunner();
+      const runner = new ChatRunner(makeDeps({
+        stateManager: makeMockStateManager(),
+        chatAgentLoopRunner: interruptible.runner,
+        llmClient: createSingleMockLLMClient(interruptDecision("summary")),
+      }));
+      runner.startSession("/repo");
+
+      const active = runner.execute("Implement a feature", "/repo");
+      await vi.waitFor(() => expect(interruptible.runner.execute).toHaveBeenCalledOnce());
+
+      const interrupted = await runner.interruptAndRedirect("bitte kurz zusammenfassen und stoppen", "/repo");
+
+      expect(interruptible.getSignal()?.aborted).toBe(true);
+      expect(interrupted.output).toContain("Interrupted the active turn");
+      expect(interrupted.output).toContain("Recent activity");
+      await active;
+    });
+
+    it("falls back to safe summary interruption for ambiguous interrupt text without keyword fallback", async () => {
+      const interruptible = makeInterruptibleAgentLoopRunner();
+      const runner = new ChatRunner(makeDeps({
+        stateManager: makeMockStateManager(),
+        chatAgentLoopRunner: interruptible.runner,
+        llmClient: createSingleMockLLMClient(interruptDecision("unknown", 0.3)),
+      }));
+      runner.startSession("/repo");
+
+      const active = runner.execute("Implement a feature", "/repo");
+      await vi.waitFor(() => expect(interruptible.runner.execute).toHaveBeenCalledOnce());
+
+      const interrupted = await runner.interruptAndRedirect("looks good maybe", "/repo");
+
+      expect(interruptible.getSignal()?.aborted).toBe(true);
+      expect(interrupted.output).toContain("Interrupted the active turn");
+      expect(interrupted.output).not.toContain("background is not available yet");
+      await active;
+    });
+
+    it("does not apply stale interrupt classification after the active turn finishes", async () => {
+      let releaseClassification!: () => void;
+      const llmClient = {
+        sendMessage: vi.fn(async () => {
+          await new Promise<void>((resolve) => {
+            releaseClassification = resolve;
           });
+          return {
+            content: interruptDecision("diff"),
+            usage: { input_tokens: 1, output_tokens: 1 },
+            stop_reason: "end_turn" as const,
+          };
         }),
+        parseJSON: createSingleMockLLMClient(interruptDecision("diff")).parseJSON,
+      };
+      let finishActive!: () => void;
+      const chatAgentLoopRunner = {
+        execute: vi.fn()
+          .mockImplementationOnce(() => new Promise<AgentResult>((resolve) => {
+            finishActive = () => resolve(CANNED_RESULT);
+          }))
+          .mockResolvedValueOnce({
+            success: true,
+            output: "fresh request executed",
+            error: null,
+            exit_code: 0,
+            elapsed_ms: 5,
+            stopped_reason: "completed",
+          } satisfies AgentResult),
       } as unknown as ChatAgentLoopRunner;
       const runner = new ChatRunner(makeDeps({
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner,
+        llmClient: llmClient as never,
       }));
       runner.startSession("/repo");
 
       const active = runner.execute("Implement a feature", "/repo");
       await vi.waitFor(() => expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce());
-
-      const redirected = await runner.interruptAndRedirect("continue in background", "/repo");
-
-      expect(capturedSignal?.aborted).toBe(false);
-      expect(redirected.success).toBe(true);
-      expect(redirected.output).toContain("background is not available yet");
-      expect(runner.hasActiveTurn()).toBe(true);
-
-      resolveActive?.({
-        success: false,
-        output: "cancelled by test",
-        error: null,
-        exit_code: null,
-        elapsed_ms: 1,
-        stopped_reason: "error",
-      });
+      const redirected = runner.interruptAndRedirect("muéstrame los cambios", "/repo");
+      await vi.waitFor(() => expect(llmClient.sendMessage).toHaveBeenCalledOnce());
+      finishActive();
       await active;
-      expect(runner.hasActiveTurn()).toBe(false);
+      releaseClassification();
+
+      await expect(redirected).resolves.toMatchObject({
+        success: true,
+        output: "fresh request executed",
+      });
+      expect(chatAgentLoopRunner.execute).toHaveBeenCalledTimes(2);
     });
 
     it("grounds native chat agentloop through systemPrompt instead of injecting workspace context into the message", async () => {

--- a/src/interface/chat/chat-runner-support.ts
+++ b/src/interface/chat/chat-runner-support.ts
@@ -1,6 +1,9 @@
 import { execFile } from "node:child_process";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
+import { z } from "zod";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+import { getInternalIdentityPrefix } from "../../base/config/identity-loader.js";
 
 const ACTIVITY_PREVIEW_CHARS = 40;
 export const DIFF_ARTIFACT_MAX_LINES = 80;
@@ -13,6 +16,23 @@ export interface GitDiffArtifact {
 }
 
 export type ChatInterruptRedirectKind = "diff" | "review" | "summary" | "background" | "redirect";
+const MIN_INTERRUPT_CONFIDENCE = 0.7;
+
+const InterruptRedirectDecisionSchema = z.object({
+  kind: z.enum(["diff", "review", "summary", "background", "redirect", "unknown"]),
+  confidence: z.number().min(0).max(1),
+  rationale: z.string().optional(),
+});
+
+export type ChatInterruptRedirectDecision = z.infer<typeof InterruptRedirectDecisionSchema>;
+
+export interface ChatInterruptRedirectContext {
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;
+  cwd: string;
+  activeTurnStartedAt: string;
+  recentEvents: string[];
+  sessionId?: string | null;
+}
 
 function runGit(cwd: string, args: string[], timeout = 5_000): Promise<string | null> {
   return new Promise((resolve) => {
@@ -106,21 +126,73 @@ export function previewActivityText(value: string, maxChars = ACTIVITY_PREVIEW_C
   return normalized.length > maxChars ? `${normalized.slice(0, maxChars)}...` : normalized;
 }
 
-export function classifyInterruptRedirect(input: string): ChatInterruptRedirectKind {
-  const normalized = input.trim().toLowerCase();
-  if (/\b(background|bg)\b|バックグラウンド|裏で|裏側|continue.*background/.test(normalized)) {
-    return "background";
-  }
-  if (/\b(review|read.?only|readonly)\b|レビュー|確認だけ|読むだけ/.test(normalized)) {
-    return "review";
-  }
-  if (/\b(diff|changes?|patch)\b|差分|変更.*見|変更内容/.test(normalized)) {
-    return "diff";
-  }
-  if (/\b(stop|pause|summary|summarize|interrupt)\b|止め|停止|中断|一旦|要約/.test(normalized)) {
+export async function classifyInterruptRedirect(
+  input: string,
+  context: ChatInterruptRedirectContext,
+): Promise<ChatInterruptRedirectKind> {
+  const exactCommand = parseExactInterruptRedirectCommand(input);
+  if (exactCommand) return exactCommand;
+
+  const trimmed = input.trim();
+  const llmClient = context.llmClient;
+  if (!trimmed || !llmClient) return "summary";
+
+  try {
+    const response = await llmClient.sendMessage(
+      [{ role: "user", content: trimmed }],
+      { system: getInterruptRedirectPrompt(context), max_tokens: 500, temperature: 0 },
+    );
+    const parsed = llmClient.parseJSON(response.content, InterruptRedirectDecisionSchema);
+    if (parsed.kind === "unknown" || parsed.confidence < MIN_INTERRUPT_CONFIDENCE) return "summary";
+    return parsed.kind;
+  } catch {
     return "summary";
   }
-  return "redirect";
+}
+
+function parseExactInterruptRedirectCommand(input: string): ChatInterruptRedirectKind | null {
+  const command = input.trim();
+  switch (command) {
+    case "/diff":
+      return "diff";
+    case "/review":
+      return "review";
+    case "/summary":
+    case "/interrupt":
+      return "summary";
+    case "/background":
+      return "background";
+    default:
+      return null;
+  }
+}
+
+function getInterruptRedirectPrompt(context: ChatInterruptRedirectContext): string {
+  return `${getInternalIdentityPrefix("assistant")} Classify the operator's message while an active chat turn is running.
+
+Return a typed interrupt redirect intent. Use the active turn context; do not infer a specialized route from vague text. If unclear, return unknown.
+
+Kinds:
+- background: operator explicitly wants the current active turn to continue in the background without aborting it.
+- review: operator wants to stop and switch to read-only review mode.
+- diff: operator wants to stop and inspect current working-tree changes.
+- summary: operator wants to stop/pause/interrupt and receive a short status summary.
+- redirect: operator wants to stop the current turn and redirect to a new instruction.
+- unknown: ambiguous or not enough evidence.
+
+Active turn:
+- cwd: ${context.cwd}
+- started_at: ${context.activeTurnStartedAt}
+- session_id: ${context.sessionId ?? "unknown"}
+- recent_events:
+${context.recentEvents.length > 0 ? context.recentEvents.slice(-8).map((event) => `  - ${event}`).join("\n") : "  - none"}
+
+Respond only as JSON:
+{
+  "kind": "diff" | "review" | "summary" | "background" | "redirect" | "unknown",
+  "confidence": 0.0-1.0,
+  "rationale": "short rationale"
+}`;
 }
 
 export function formatToolActivity(action: "Running" | "Finished" | "Failed", toolName: string, detail?: string): string {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -226,7 +226,16 @@ export class ChatRunner {
     }
 
     const start = Date.now();
-    const redirect = classifyInterruptRedirect(input);
+    const redirect = await classifyInterruptRedirect(input, {
+      llmClient: this.deps.llmClient,
+      cwd: activeTurn.cwd,
+      activeTurnStartedAt: new Date(activeTurn.startedAt).toISOString(),
+      recentEvents: activeTurn.recentEvents,
+      sessionId: this.getSessionId(),
+    });
+    if (this.eventBridge.getActiveTurn() !== activeTurn) {
+      return this.execute(input, cwd, timeoutMs);
+    }
     if (redirect === "background") {
       return this.eventBridge.emitEphemeralAssistantResult(input, [
         "Continuing this same turn in the background is not available yet.",


### PR DESCRIPTION
Closes #871

## 実装要約
- Replaced regex keyword interrupt redirect classification with a structured interrupt intent classifier using a typed Zod schema and confidence threshold.
- Passed active-turn context into classification: cwd, started time, recent events, and session id.
- Kept exact slash protocol commands (`/diff`, `/review`, `/summary`, `/interrupt`, `/background`) deterministic and separate from freeform semantics.
- Low-confidence, unknown, parse failure, or model unavailable now falls back to safe summary interruption instead of guessing diff/review/background.
- Preserved background behavior as non-aborting, and added stale active-turn revalidation after async classification.

## 検証コマンド
- `npm exec -- vitest run src/interface/chat/__tests__/chat-runner.test.ts` - pass
- `npm run typecheck` - pass
- `npm run lint:boundaries` - pass, 0 errors with existing warnings
- `npm run test:changed` - pass
- Fresh review agent - initial P1 stale active-turn race fixed; re-review LGTM

## 既知の未解決リスク
- Freeform interrupt classification depends on the configured LLM. If classification is unavailable or ambiguous, PulSeed intentionally uses the safe summary interruption path rather than choosing a specialized redirect.
