### PR TITLE
refactor(chat): replace failure recovery regex classification

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -2161,12 +2161,49 @@ describe("ChatRunner", () => {
 
       expect(result.success).toBe(false);
       expect(result.output).toContain("Recovery");
-      expect(result.output).toContain("Type: Runtime interruption");
+      expect(result.output).toContain("Type: Unclassified failure");
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
       expect(writeRawMock).toHaveBeenCalledTimes(1);
       const onlyWrite = writeRawMock.mock.calls[0][1] as { messages: Array<{ role: string; content: string }> };
       expect(onlyWrite.messages).toHaveLength(1);
       expect(capturedEvents).toContainEqual({ type: "lifecycle_error", partialText: "Partial answer" });
+    });
+
+    it("uses confidence-aware fallback on the production lifecycle-error path when structured evidence is absent", async () => {
+      const stateManager = makeMockStateManager();
+      const capturedEvents: Array<{ type: string; recoveryKind?: string }> = [];
+      const llmClient = {
+        supportsToolCalling: () => true,
+        sendMessageStream: vi.fn().mockImplementation(async (_messages, _options, handlers) => {
+          handlers.onTextDelta?.("Partial answer");
+          throw new Error("provider returned overloaded");
+        }),
+        sendMessage: vi.fn().mockResolvedValue({
+          content: JSON.stringify({ kind: "adapter", confidence: 0.92, rationale: "provider unavailable" }),
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn((content: string, schema: z.ZodSchema<unknown>) => schema.parse(JSON.parse(content))),
+      } as unknown as ILLMClient;
+
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        llmClient,
+        onEvent: (event) => {
+          if (event.type === "lifecycle_error") {
+            capturedEvents.push({ type: event.type, recoveryKind: event.recovery.kind });
+            return;
+          }
+          capturedEvents.push({ type: event.type });
+        },
+      }));
+
+      const result = await runner.execute("Break the provider", "/repo");
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Type: Adapter failure");
+      expect(capturedEvents).toContainEqual({ type: "lifecycle_error", recoveryKind: "adapter" });
+      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
     });
   });
 
@@ -2415,6 +2452,91 @@ describe("ChatRunner", () => {
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Agentloop direct answer");
+    });
+
+    it("classifies native agent-loop lifecycle failures from structured runner and tool metadata", async () => {
+      const seenEvents: ChatEvent[] = [];
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockImplementation(async (input: {
+          eventSink?: { emit(event: unknown): Promise<void> | void };
+        }) => {
+          await input.eventSink?.emit({
+            type: "tool_call_finished",
+            callId: "call-denied",
+            toolName: "shell_command",
+            success: false,
+            disposition: "approval_denied",
+            outputPreview: "プロバイダ固有の拒否文言",
+            durationMs: 1,
+          });
+          return {
+            success: false,
+            output: "localized failure text without keywords",
+            error: null,
+            exit_code: null,
+            elapsed_ms: 42,
+            stopped_reason: "error",
+            agentLoop: {
+              traceId: "trace-1",
+              sessionId: "session-1",
+              turnId: "turn-1",
+              stopReason: "consecutive_tool_errors",
+              modelTurns: 1,
+              toolCalls: 1,
+              compactions: 0,
+            },
+          };
+        }),
+      } as unknown as ChatAgentLoopRunner;
+
+      const runner = new ChatRunner(makeDeps({
+        chatAgentLoopRunner,
+        onEvent: (event) => { seenEvents.push(event); },
+      }));
+      const result = await runner.execute("Do something requiring tools", "/repo");
+
+      expect(result.success).toBe(false);
+      const lifecycleError = seenEvents.find((event): event is Extract<ChatEvent, { type: "lifecycle_error" }> =>
+        event.type === "lifecycle_error"
+      );
+      expect(lifecycleError?.recovery.kind).toBe("permission");
+      expect(result.output).toContain("Type: Permission failure");
+    });
+
+    it("uses native runner stop reason instead of provider text for runtime interruption recovery", async () => {
+      const seenEvents: ChatEvent[] = [];
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockResolvedValue({
+          success: false,
+          output: "モデルからの非英語エラー",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "timeout",
+          agentLoop: {
+            traceId: "trace-1",
+            sessionId: "session-1",
+            turnId: "turn-1",
+            stopReason: "timeout",
+            modelTurns: 1,
+            toolCalls: 0,
+            compactions: 0,
+          },
+        }),
+      } as unknown as ChatAgentLoopRunner;
+
+      const runner = new ChatRunner(makeDeps({
+        chatAgentLoopRunner,
+        onEvent: (event) => { seenEvents.push(event); },
+      }));
+      const result = await runner.execute("Please inspect the repo", "/repo");
+
+      expect(result.success).toBe(false);
+      const lifecycleError = seenEvents.find((event): event is Extract<ChatEvent, { type: "lifecycle_error" }> =>
+        event.type === "lifecycle_error"
+      );
+      expect(lifecycleError?.recovery.kind).toBe("runtime_interruption");
+      expect(result.output).toContain("Type: Runtime interruption");
     });
 
     it("leaves broad continue and finish prompts on the agent loop even when runtime control is wired", async () => {

--- a/src/interface/chat/__tests__/failure-recovery.test.ts
+++ b/src/interface/chat/__tests__/failure-recovery.test.ts
@@ -1,25 +1,109 @@
 import { describe, expect, it } from "vitest";
-import { classifyFailureRecovery, formatLifecycleFailureMessage } from "../failure-recovery.js";
+import {
+  classifyFailureRecovery,
+  classifyFailureRecoveryWithFallback,
+  formatLifecycleFailureMessage,
+} from "../failure-recovery.js";
+import type { ILLMClient } from "../../../base/llm/llm-client.js";
 
 describe("failure recovery guidance", () => {
-  it("classifies verification failures with review guidance", () => {
-    const guidance = classifyFailureRecovery("Changes applied but tests are still failing after 2 retries.");
+  it("classifies verification failures from structured verification evidence", () => {
+    const guidance = classifyFailureRecovery({
+      error: "変更後の確認が通りませんでした。",
+      signals: [{ kind: "verification", status: "failed" }],
+    });
 
     expect(guidance.kind).toBe("verification");
     expect(guidance.label).toBe("Verification failure");
     expect(guidance.nextActions.join("\n")).toContain("/review");
   });
 
-  it("classifies missing resumable state with session guidance", () => {
-    const guidance = classifyFailureRecovery("No resumable native agentloop state found.");
+  it("classifies missing resumable state from exact stop code", () => {
+    const guidance = classifyFailureRecovery({
+      error: "No resumable native agentloop state found.",
+      code: "resume_state_missing",
+    });
 
     expect(guidance.kind).toBe("resume");
     expect(guidance.nextActions.join("\n")).toContain("/sessions");
     expect(guidance.nextActions.join("\n")).toContain("/resume <id|title>");
   });
 
+  it("classifies permission failures from approval and tool dispositions", () => {
+    expect(classifyFailureRecovery({
+      error: "action was not performed",
+      signals: [{ kind: "approval", status: "denied", toolName: "apply_patch" }],
+    }).kind).toBe("permission");
+
+    expect(classifyFailureRecovery({
+      error: "provider-specific denial text",
+      signals: [{ kind: "tool", toolName: "shell", status: "approval_denied", disposition: "approval_denied" }],
+    }).kind).toBe("permission");
+  });
+
+  it("classifies runtime interruption and adapter failures from typed stop metadata", () => {
+    expect(classifyFailureRecovery({
+      error: "ストリームが終了しました",
+      stoppedReason: "timeout",
+    }).kind).toBe("runtime_interruption");
+
+    expect(classifyFailureRecovery({
+      error: "modelo no disponible temporalmente",
+      signals: [{ kind: "adapter", adapterType: "codex", stoppedReason: "error" }],
+    }).kind).toBe("adapter");
+  });
+
+  it("does not classify localized/provider-specific text without structured evidence", () => {
+    const guidance = classifyFailureRecovery("権限っぽい失敗かもしれないが構造化シグナルがない");
+
+    expect(guidance.kind).toBe("unknown");
+  });
+
+  it("uses confidence-aware model fallback only when structured evidence is absent", async () => {
+    const llmClient = {
+      sendMessage: async () => ({
+        content: JSON.stringify({ kind: "adapter", confidence: 0.91, rationale: "provider outage" }),
+        usage: { input_tokens: 1, output_tokens: 1 },
+        stop_reason: "end_turn",
+      }),
+      parseJSON: (content: string, schema: { parse(value: unknown): unknown }) => schema.parse(JSON.parse(content)),
+    } as unknown as Pick<ILLMClient, "sendMessage" | "parseJSON">;
+
+    await expect(classifyFailureRecoveryWithFallback("provider returned overloaded", llmClient)).resolves.toMatchObject({
+      kind: "adapter",
+    });
+    await expect(classifyFailureRecoveryWithFallback({
+      error: "model guessed adapter, but typed verification wins",
+      signals: [{ kind: "verification", status: "failed" }],
+    }, llmClient)).resolves.toMatchObject({
+      kind: "verification",
+    });
+  });
+
+  it("keeps low-confidence or unavailable model fallback unknown", async () => {
+    const lowConfidenceClient = {
+      sendMessage: async () => ({
+        content: JSON.stringify({ kind: "permission", confidence: 0.4 }),
+        usage: { input_tokens: 1, output_tokens: 1 },
+        stop_reason: "end_turn",
+      }),
+      parseJSON: (content: string, schema: { parse(value: unknown): unknown }) => schema.parse(JSON.parse(content)),
+    } as unknown as Pick<ILLMClient, "sendMessage" | "parseJSON">;
+
+    await expect(classifyFailureRecoveryWithFallback("ambiguous provider text", lowConfidenceClient)).resolves.toMatchObject({
+      kind: "unknown",
+    });
+    await expect(classifyFailureRecoveryWithFallback("ambiguous provider text")).resolves.toMatchObject({
+      kind: "unknown",
+    });
+  });
+
   it("formats lifecycle errors without hiding the original interruption", () => {
-    const text = formatLifecycleFailureMessage("stream aborted", "Partial answer");
+    const text = formatLifecycleFailureMessage(
+      "stream aborted",
+      "Partial answer",
+      classifyFailureRecovery({ error: "stream aborted", stoppedReason: "aborted" })
+    );
 
     expect(text).toContain("Partial answer");
     expect(text).toContain("[interrupted: stream aborted]");

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -10,7 +10,14 @@ import {
   previewActivityText,
   type GitDiffArtifact,
 } from "./chat-runner-support.js";
-import { classifyFailureRecovery, formatLifecycleFailureMessage } from "./failure-recovery.js";
+import {
+  classifyFailureRecovery,
+  classifyFailureRecoveryWithFallback,
+  formatLifecycleFailureMessage,
+  type FailureRecoveryEvidence,
+  type FailureRecoverySignal,
+} from "./failure-recovery.js";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
 
 export interface AssistantBuffer {
   text: string;
@@ -24,6 +31,7 @@ export interface ActiveChatTurn {
   finished: Promise<void>;
   resolveFinished: () => void;
   recentEvents: string[];
+  recentFailureSignals: FailureRecoverySignal[];
   interruptRequested: boolean;
 }
 
@@ -66,6 +74,7 @@ export class ChatRunnerEventBridge {
       finished,
       resolveFinished,
       recentEvents: [],
+      recentFailureSignals: [],
       interruptRequested: false,
     };
     this.activeTurn = turn;
@@ -133,6 +142,18 @@ export class ChatRunnerEventBridge {
         }
 
         if (event.type === "tool_call_finished") {
+          if (!event.success) {
+            this.rememberActiveTurnFailureSignal(eventContext, {
+              kind: "tool",
+              toolName: event.toolName,
+              status: event.disposition === "cancelled"
+                ? "cancelled"
+                : event.disposition === "approval_denied"
+                  ? "approval_denied"
+                  : "failed",
+              ...(event.disposition ? { disposition: event.disposition } : {}),
+            });
+          }
           this.emitActivity(
             "tool",
             formatToolActivity(event.success ? "Finished" : "Failed", event.toolName, event.outputPreview),
@@ -171,6 +192,13 @@ export class ChatRunnerEventBridge {
         }
 
         if (event.type === "approval_request") {
+          this.rememberActiveTurnFailureSignal(eventContext, {
+            kind: "approval",
+            status: "requested",
+            toolName: event.toolName,
+            permissionLevel: event.permissionLevel,
+            isDestructive: event.isDestructive,
+          });
           this.emitActivity("tool", formatToolActivity("Running", event.toolName, `awaiting approval: ${event.reason}`), eventContext, event.callId);
           this.emitCheckpoint("Approval requested", `${event.toolName}: ${event.reason}`, eventContext, `approval:${event.callId}`);
           this.emitEvent({
@@ -185,6 +213,11 @@ export class ChatRunnerEventBridge {
         }
 
         if (event.type === "approval") {
+          this.rememberActiveTurnFailureSignal(eventContext, {
+            kind: "approval",
+            status: event.status,
+            toolName: event.toolName,
+          });
           this.emitActivity("tool", formatToolActivity("Finished", event.toolName, `approval ${event.status}: ${event.reason}`), eventContext);
           this.emitEvent({
             type: "tool_update",
@@ -217,6 +250,14 @@ export class ChatRunnerEventBridge {
             status: "result",
             message: `${event.phase} ${event.reason}: ${event.inputMessages} -> ${event.outputMessages}`,
             ...this.eventBase(eventContext),
+          });
+        }
+
+        if (event.type === "stopped") {
+          this.rememberActiveTurnFailureSignal(eventContext, {
+            kind: "runtime",
+            stoppedReason: event.reason,
+            operationState: "agent_loop",
           });
         }
       },
@@ -346,9 +387,10 @@ export class ChatRunnerEventBridge {
   emitLifecycleErrorEvent(
     error: string,
     partialText: string,
-    eventContext: ChatEventContext
+    eventContext: ChatEventContext,
+    evidence: FailureRecoveryEvidence = {}
   ): string {
-    const recovery = classifyFailureRecovery(error);
+    const recovery = classifyFailureRecovery(this.buildFailureRecoveryEvidence(error, eventContext, evidence));
     this.emitEvent({
       type: "lifecycle_error",
       error,
@@ -358,6 +400,55 @@ export class ChatRunnerEventBridge {
       ...this.eventBase(eventContext),
     });
     return formatLifecycleFailureMessage(error, partialText, recovery);
+  }
+
+  async emitLifecycleErrorEventWithFallback(
+    error: string,
+    partialText: string,
+    eventContext: ChatEventContext,
+    evidence: FailureRecoveryEvidence = {},
+    llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">
+  ): Promise<string> {
+    const recovery = await classifyFailureRecoveryWithFallback(
+      this.buildFailureRecoveryEvidence(error, eventContext, evidence),
+      llmClient
+    );
+    this.emitEvent({
+      type: "lifecycle_error",
+      error,
+      partialText,
+      persisted: false,
+      recovery,
+      ...this.eventBase(eventContext),
+    });
+    return formatLifecycleFailureMessage(error, partialText, recovery);
+  }
+
+  private buildFailureRecoveryEvidence(
+    error: string,
+    eventContext: ChatEventContext,
+    evidence: FailureRecoveryEvidence
+  ): FailureRecoveryEvidence {
+    return {
+      ...evidence,
+      error,
+      signals: [
+        ...this.collectActiveTurnFailureSignals(eventContext),
+        ...(evidence.signals ?? []),
+      ],
+    };
+  }
+
+  private rememberActiveTurnFailureSignal(eventContext: ChatEventContext, signal: FailureRecoverySignal): void {
+    const activeTurn = this.activeTurn;
+    if (!activeTurn || activeTurn.context.turnId !== eventContext.turnId) return;
+    activeTurn.recentFailureSignals = [...activeTurn.recentFailureSignals, signal].slice(-12);
+  }
+
+  private collectActiveTurnFailureSignals(eventContext: ChatEventContext): FailureRecoverySignal[] {
+    const activeTurn = this.activeTurn;
+    if (!activeTurn || activeTurn.context.turnId !== eventContext.turnId) return [];
+    return activeTurn.recentFailureSignals;
   }
 
   private rememberActiveTurnEvent(event: ChatEvent): void {

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -113,10 +113,15 @@ export async function executeAgentLoopRoute(
     const resumeState = resumeOnly ? await loadResumableAgentLoopState(host) : null;
     if (resumeOnly && !resumeState) {
       const elapsed_ms = Date.now() - start;
-      const output = host.eventBridge.emitLifecycleErrorEvent(
+      const output = await host.eventBridge.emitLifecycleErrorEventWithFallback(
         "No resumable native agentloop state found.",
         assistantBuffer.text,
-        eventContext
+        eventContext,
+        {
+          code: "resume_state_missing",
+          stoppedReason: "resume_state_missing",
+        },
+        host.deps.llmClient
       );
       host.eventBridge.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
       return {
@@ -180,7 +185,16 @@ export async function executeAgentLoopRoute(
       });
       host.eventBridge.emitLifecycleEndEvent("completed", elapsed_ms, eventContext, true);
     } else {
-      result.output = host.eventBridge.emitLifecycleErrorEvent(result.output || result.error || "Unknown error", assistantBuffer.text, eventContext);
+      result.output = await host.eventBridge.emitLifecycleErrorEventWithFallback(
+        result.output || result.error || "Unknown error",
+        assistantBuffer.text,
+        eventContext,
+        {
+          stoppedReason: result.stopped_reason,
+          agentLoopStopReason: result.agentLoop?.stopReason,
+        },
+        host.deps.llmClient
+      );
       host.eventBridge.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
     }
     return {
@@ -190,7 +204,13 @@ export async function executeAgentLoopRoute(
     };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const output = host.eventBridge.emitLifecycleErrorEvent(message, assistantBuffer.text, eventContext);
+    const output = await host.eventBridge.emitLifecycleErrorEventWithFallback(
+      message,
+      assistantBuffer.text,
+      eventContext,
+      {},
+      host.deps.llmClient
+    );
     host.eventBridge.emitLifecycleEndEvent("error", Date.now() - start, eventContext, false);
     return {
       success: false,
@@ -247,7 +267,13 @@ export async function executeToolLoopRoute(
     return { success: true, output: toolResult.output, elapsed_ms };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const output = host.eventBridge.emitLifecycleErrorEvent(message, params.assistantBuffer.text, params.eventContext);
+    const output = await host.eventBridge.emitLifecycleErrorEventWithFallback(
+      message,
+      params.assistantBuffer.text,
+      params.eventContext,
+      {},
+      host.deps.llmClient
+    );
     host.eventBridge.emitLifecycleEndEvent("error", Date.now() - params.start, params.eventContext, false);
     return {
       success: false,
@@ -292,7 +318,13 @@ export async function executeAdapterRoute(
     result = await Promise.race([adapterPromise, timeoutPromise]);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    const output = host.eventBridge.emitLifecycleErrorEvent(message, params.assistantBuffer.text, params.eventContext);
+    const output = await host.eventBridge.emitLifecycleErrorEventWithFallback(
+      message,
+      params.assistantBuffer.text,
+      params.eventContext,
+      {},
+      host.deps.llmClient
+    );
     const timeoutElapsedMs = Date.now() - params.start;
     host.eventBridge.emitLifecycleEndEvent("error", timeoutElapsedMs, params.eventContext, false);
     return {
@@ -337,10 +369,15 @@ export async function executeAdapterRoute(
         host.eventBridge.emitDiffArtifact(finalDiffArtifact, params.eventContext);
       }
       host.eventBridge.emitCheckpoint("Verification failed", `Checks are still failing after ${MAX_VERIFY_RETRIES} retries.`, params.eventContext, "verification");
-      const failureOutput = host.eventBridge.emitLifecycleErrorEvent(
+      const failureOutput = await host.eventBridge.emitLifecycleErrorEventWithFallback(
         `Changes applied but tests are still failing after ${MAX_VERIFY_RETRIES} retries.`,
         params.assistantBuffer.text,
-        params.eventContext
+        params.eventContext,
+        {
+          code: "verification_failed",
+          signals: [{ kind: "verification", status: "failed" }],
+        },
+        host.deps.llmClient
       );
       host.eventBridge.emitLifecycleEndEvent("error", Date.now() - params.start, params.eventContext, false);
       return {
@@ -369,7 +406,20 @@ export async function executeAdapterRoute(
     host.eventBridge.emitLifecycleEndEvent("completed", elapsed_ms, params.eventContext, true);
   } else {
     const partialText = params.assistantBuffer.text !== result.output ? params.assistantBuffer.text : "";
-    result.output = host.eventBridge.emitLifecycleErrorEvent(result.output || result.error || "Unknown error", partialText, params.eventContext);
+    result.output = await host.eventBridge.emitLifecycleErrorEventWithFallback(
+      result.output || result.error || "Unknown error",
+      partialText,
+      params.eventContext,
+      {
+        stoppedReason: result.stopped_reason,
+        signals: [{
+          kind: "adapter",
+          adapterType: host.deps.adapter.adapterType,
+          stoppedReason: result.stopped_reason,
+        }],
+      },
+      host.deps.llmClient
+    );
     host.eventBridge.emitLifecycleEndEvent("error", elapsed_ms, params.eventContext, false);
   }
 

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -456,7 +456,19 @@ export class ChatRunner {
         });
         this.eventBridge.emitLifecycleEndEvent("completed", runtimeControlResult.elapsed_ms, eventContext, true);
       } else {
-        runtimeControlResult.output = this.eventBridge.emitLifecycleErrorEvent(runtimeControlResult.output, assistantBuffer.text, eventContext);
+        runtimeControlResult.output = await this.eventBridge.emitLifecycleErrorEventWithFallback(
+          runtimeControlResult.output,
+          assistantBuffer.text,
+          eventContext,
+          {
+            signals: [{
+              kind: "runtime",
+              operationState: "runtime_control",
+              stoppedReason: "runtime_control_failed",
+            }],
+          },
+          this.deps.llmClient
+        );
         this.eventBridge.emitLifecycleEndEvent("error", runtimeControlResult.elapsed_ms, eventContext, false);
       }
       return runtimeControlResult;
@@ -514,10 +526,15 @@ export class ChatRunner {
 
     if (resumeOnly && !this.deps.chatAgentLoopRunner) {
       const elapsed_ms = Date.now() - start;
-      const output = this.eventBridge.emitLifecycleErrorEvent(
+      const output = await this.eventBridge.emitLifecycleErrorEventWithFallback(
         "Resume requires the native chat agentloop runtime.",
         assistantBuffer.text,
-        eventContext
+        eventContext,
+        {
+          code: "resume_state_missing",
+          stoppedReason: "resume_state_missing",
+        },
+        this.deps.llmClient
       );
       this.eventBridge.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
       return { success: false, output, elapsed_ms };
@@ -555,7 +572,13 @@ export class ChatRunner {
 
     if (!resumeOnly && selectedRoute && selectedRoute.kind !== "adapter") {
       const elapsed_ms = Date.now() - start;
-      const output = this.eventBridge.emitLifecycleErrorEvent(`Unsupported chat route: ${selectedRoute.kind}`, assistantBuffer.text, eventContext);
+      const output = await this.eventBridge.emitLifecycleErrorEventWithFallback(
+        `Unsupported chat route: ${selectedRoute.kind}`,
+        assistantBuffer.text,
+        eventContext,
+        {},
+        this.deps.llmClient
+      );
       this.eventBridge.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
       return { success: false, output, elapsed_ms };
     }

--- a/src/interface/chat/failure-recovery.ts
+++ b/src/interface/chat/failure-recovery.ts
@@ -1,3 +1,6 @@
+import { z } from "zod";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+
 export type FailureRecoveryKind =
   | "permission"
   | "tool_input"
@@ -15,102 +18,354 @@ export interface FailureRecoveryGuidance {
   nextActions: string[];
 }
 
-export function classifyFailureRecovery(error: string): FailureRecoveryGuidance {
-  const normalized = error.toLowerCase();
-  if (/\b(permission|approval|approved|denied|sandbox|eacces|eperm|unauthorized|forbidden)\b/.test(normalized)) {
-    return {
-      kind: "permission",
-      label: "Permission failure",
-      summary: "The turn stopped because the requested action was blocked by permissions or approval policy.",
-      nextActions: [
-        "Inspect the requested action before retrying.",
-        "Use /permissions to review the current execution policy.",
-        "Re-run with a narrower request or explicit approval if the action is expected.",
-      ],
-    };
-  }
-  if (/\b(verification|checks?|tests?|vitest|typecheck|lint)\b.*\b(fail|failing|failed|error)\b|\b(fail|failing|failed)\b.*\b(verification|checks?|tests?|vitest|typecheck|lint)\b/.test(normalized)) {
-    return {
-      kind: "verification",
-      label: "Verification failure",
-      summary: "Changes were made, but the configured checks did not pass.",
-      nextActions: [
-        "Run /review to inspect the current diff and verification context.",
-        "Inspect the test output shown with this failure.",
-        "Ask for a focused fix for the failing check before continuing.",
-      ],
-    };
-  }
-  if (/\b(resume|resumable|session state|agentloop state)\b/.test(normalized)) {
-    return {
-      kind: "resume",
-      label: "Resume failure",
-      summary: "PulSeed could not find or load the session state needed to continue this turn.",
-      nextActions: [
-        "Run /sessions to find the intended chat session.",
-        "Run /resume <id|title> when the target session is available.",
-        "Start a new turn with the missing context if no resumable state exists.",
-      ],
-    };
-  }
-  if (/\b(daemon|core loop|goal stalled|loop ended|runtime control|background)\b/.test(normalized)) {
-    return {
-      kind: "daemon_loop",
-      label: "Daemon loop failure",
-      summary: "A background loop or runtime-control path stopped before completing successfully.",
-      nextActions: [
-        "Run /status to inspect the active goal or daemon state.",
-        "Use /resume when the session has resumable state.",
-        "Check the daemon logs if the failure references runtime internals.",
-      ],
-    };
-  }
-  if (/\b(timed out|timeout|aborted|interrupted|cancelled|canceled|signal|disconnect|stream)\b/.test(normalized)) {
-    return {
-      kind: "runtime_interruption",
-      label: "Runtime interruption",
-      summary: "The active turn was interrupted before it could produce a complete final response.",
-      nextActions: [
-        "Use /resume if PulSeed reports resumable agent-loop state.",
-        "Ask for a narrower continuation from the last visible step.",
-        "Run /review first if files may have changed before the interruption.",
-      ],
-    };
-  }
-  if (/\b(schema|invalid|parse|missing|required|argument|input)\b/.test(normalized)) {
-    return {
-      kind: "tool_input",
-      label: "Tool input failure",
-      summary: "A tool or command received input it could not validate.",
-      nextActions: [
-        "Retry with the exact file, command, or option you want PulSeed to use.",
-        "Ask PulSeed to inspect the target before attempting the tool again.",
-        "Use /review if the failure happened after a file change.",
-      ],
-    };
-  }
-  if (/\b(adapter|model|provider|api|rate limit|llm)\b/.test(normalized)) {
-    return {
-      kind: "adapter",
-      label: "Adapter failure",
-      summary: "The configured model or adapter path failed before the turn completed.",
-      nextActions: [
-        "Retry the turn after checking provider availability.",
-        "Use /model to confirm the active provider and adapter.",
-        "Narrow the request if the failure happened during a long turn.",
-      ],
-    };
-  }
-  return {
+export interface FailureRecoveryToolSignal {
+  kind: "tool";
+  toolName: string;
+  status: "failed" | "cancelled" | "approval_denied";
+  disposition?: "respond_to_model" | "fatal" | "approval_denied" | "cancelled";
+  code?: string;
+}
+
+export interface FailureRecoveryApprovalSignal {
+  kind: "approval";
+  status: "requested" | "denied" | "blocked";
+  toolName?: string;
+  permissionLevel?: string;
+  isDestructive?: boolean;
+  code?: string;
+}
+
+export interface FailureRecoveryRuntimeSignal {
+  kind: "runtime";
+  stoppedReason?: string;
+  operationState?: "daemon_loop" | "runtime_control" | "background_run" | "agent_loop";
+  code?: string;
+}
+
+export interface FailureRecoveryVerificationSignal {
+  kind: "verification";
+  status: "failed" | "passed" | "not_run";
+  code?: string;
+}
+
+export interface FailureRecoveryAdapterSignal {
+  kind: "adapter";
+  adapterType?: string;
+  stoppedReason?: string;
+  code?: string;
+}
+
+export type FailureRecoverySignal =
+  | FailureRecoveryToolSignal
+  | FailureRecoveryApprovalSignal
+  | FailureRecoveryRuntimeSignal
+  | FailureRecoveryVerificationSignal
+  | FailureRecoveryAdapterSignal;
+
+export interface FailureRecoveryEvidence {
+  error?: string;
+  stoppedReason?: string | null;
+  agentLoopStopReason?: string | null;
+  code?: string | null;
+  signals?: FailureRecoverySignal[];
+}
+
+const MIN_MODEL_CONFIDENCE = 0.7;
+
+const FailureRecoveryFallbackDecisionSchema = z.object({
+  kind: z.enum([
+    "permission",
+    "tool_input",
+    "verification",
+    "runtime_interruption",
+    "daemon_loop",
+    "resume",
+    "adapter",
+    "unknown",
+  ]),
+  confidence: z.number().min(0).max(1),
+  rationale: z.string().optional(),
+});
+
+const GUIDANCE_BY_KIND: Record<FailureRecoveryKind, FailureRecoveryGuidance> = {
+  permission: {
+    kind: "permission",
+    label: "Permission failure",
+    summary: "The turn stopped because the requested action was blocked by permissions or approval policy.",
+    nextActions: [
+      "Inspect the requested action before retrying.",
+      "Use /permissions to review the current execution policy.",
+      "Re-run with a narrower request or explicit approval if the action is expected.",
+    ],
+  },
+  verification: {
+    kind: "verification",
+    label: "Verification failure",
+    summary: "Changes were made, but the configured checks did not pass.",
+    nextActions: [
+      "Run /review to inspect the current diff and verification context.",
+      "Inspect the test output shown with this failure.",
+      "Ask for a focused fix for the failing check before continuing.",
+    ],
+  },
+  resume: {
+    kind: "resume",
+    label: "Resume failure",
+    summary: "PulSeed could not find or load the session state needed to continue this turn.",
+    nextActions: [
+      "Run /sessions to find the intended chat session.",
+      "Run /resume <id|title> when the target session is available.",
+      "Start a new turn with the missing context if no resumable state exists.",
+    ],
+  },
+  daemon_loop: {
+    kind: "daemon_loop",
+    label: "Daemon loop failure",
+    summary: "A background loop or runtime-control path stopped before completing successfully.",
+    nextActions: [
+      "Run /status to inspect the active goal or daemon state.",
+      "Use /resume when the session has resumable state.",
+      "Check the daemon logs if the failure references runtime internals.",
+    ],
+  },
+  runtime_interruption: {
+    kind: "runtime_interruption",
+    label: "Runtime interruption",
+    summary: "The active turn was interrupted before it could produce a complete final response.",
+    nextActions: [
+      "Use /resume if PulSeed reports resumable agent-loop state.",
+      "Ask for a narrower continuation from the last visible step.",
+      "Run /review first if files may have changed before the interruption.",
+    ],
+  },
+  tool_input: {
+    kind: "tool_input",
+    label: "Tool input failure",
+    summary: "A tool or command received input it could not validate.",
+    nextActions: [
+      "Retry with the exact file, command, or option you want PulSeed to use.",
+      "Ask PulSeed to inspect the target before attempting the tool again.",
+      "Use /review if the failure happened after a file change.",
+    ],
+  },
+  adapter: {
+    kind: "adapter",
+    label: "Adapter failure",
+    summary: "The configured model or adapter path failed before the turn completed.",
+    nextActions: [
+      "Retry the turn after checking provider availability.",
+      "Use /model to confirm the active provider and adapter.",
+      "Narrow the request if the failure happened during a long turn.",
+    ],
+  },
+  unknown: {
     kind: "unknown",
     label: "Unclassified failure",
-    summary: "PulSeed could not classify this failure from the error text alone.",
+    summary: "PulSeed did not receive enough structured failure evidence to classify this safely.",
     nextActions: [
       "Run /review if the turn may have changed files.",
       "Retry with a narrower request that names the intended next step.",
       "Use /sessions or /status when the failure relates to session or daemon state.",
     ],
-  };
+  },
+};
+
+const PERMISSION_CODES = new Set([
+  "permission_denied",
+  "approval_denied",
+  "approval_required",
+  "sandbox_denied",
+  "eacces",
+  "eperm",
+  "unauthorized",
+  "forbidden",
+]);
+
+const TOOL_INPUT_CODES = new Set([
+  "invalid_tool_input",
+  "schema_validation_failed",
+  "missing_required_argument",
+  "invalid_argument",
+  "parse_error",
+]);
+
+const VERIFICATION_CODES = new Set([
+  "verification_failed",
+  "checks_failed",
+  "test_failed",
+  "typecheck_failed",
+  "lint_failed",
+]);
+
+const RESUME_CODES = new Set([
+  "resume_state_missing",
+  "session_state_missing",
+  "agent_loop_state_missing",
+]);
+
+const ADAPTER_CODES = new Set([
+  "adapter_error",
+  "model_error",
+  "provider_error",
+  "rate_limited",
+  "llm_error",
+]);
+
+const RUNTIME_INTERRUPTION_REASONS = new Set([
+  "timeout",
+  "aborted",
+  "abort",
+  "cancelled",
+  "canceled",
+  "interrupted",
+  "disconnect",
+  "disconnected",
+]);
+
+const DAEMON_LOOP_REASONS = new Set([
+  "daemon_loop_failed",
+  "core_loop_failed",
+  "runtime_control_failed",
+  "background_run_failed",
+  "stalled_tool_loop",
+]);
+
+const TOOL_INPUT_REASONS = new Set([
+  "invalid_tool_input",
+  "schema_validation_failed",
+]);
+
+const RESUME_REASONS = new Set([
+  "resume_state_missing",
+  "session_state_missing",
+  "agent_loop_state_missing",
+]);
+
+export function classifyFailureRecovery(input: string | FailureRecoveryEvidence): FailureRecoveryGuidance {
+  const evidence = normalizeFailureRecoveryEvidence(input);
+  const kind = classifyFromStructuredEvidence(evidence);
+  return guidanceFor(kind);
+}
+
+export async function classifyFailureRecoveryWithFallback(
+  input: string | FailureRecoveryEvidence,
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">
+): Promise<FailureRecoveryGuidance> {
+  const evidence = normalizeFailureRecoveryEvidence(input);
+  const structuredKind = classifyFromStructuredEvidence(evidence);
+  if (structuredKind !== "unknown") return guidanceFor(structuredKind);
+  const modelKind = await classifyFailureRecoveryFallback(evidence, llmClient);
+  return guidanceFor(modelKind);
+}
+
+function normalizeFailureRecoveryEvidence(input: string | FailureRecoveryEvidence): FailureRecoveryEvidence {
+  if (typeof input === "string") return { error: input, signals: [] };
+  return { ...input, signals: input.signals ?? [] };
+}
+
+function classifyFromStructuredEvidence(evidence: FailureRecoveryEvidence): FailureRecoveryKind {
+  const signals = evidence.signals ?? [];
+  const codes = collectCodes(evidence, signals);
+  if (signals.some((signal) => signal.kind === "approval" && (signal.status === "denied" || signal.status === "blocked"))
+    || signals.some((signal) => signal.kind === "tool" && signal.disposition === "approval_denied")
+    || hasAny(codes, PERMISSION_CODES)) {
+    return "permission";
+  }
+  if (signals.some((signal) => signal.kind === "verification" && signal.status === "failed")
+    || hasAny(codes, VERIFICATION_CODES)) {
+    return "verification";
+  }
+  if (hasReason(evidence, RESUME_REASONS) || hasAny(codes, RESUME_CODES)) {
+    return "resume";
+  }
+  if (
+    signals.some((signal) => signal.kind === "runtime" && signal.operationState === "daemon_loop")
+    || hasReason(evidence, DAEMON_LOOP_REASONS)
+  ) {
+    return "daemon_loop";
+  }
+  if (
+    signals.some((signal) => signal.kind === "tool" && signal.disposition === "cancelled")
+    || hasReason(evidence, RUNTIME_INTERRUPTION_REASONS)
+  ) {
+    return "runtime_interruption";
+  }
+  if (
+    signals.some((signal) => signal.kind === "tool" && signal.disposition === "fatal")
+    || hasReason(evidence, TOOL_INPUT_REASONS)
+    || hasAny(codes, TOOL_INPUT_CODES)
+  ) {
+    return "tool_input";
+  }
+  if (signals.some((signal) => signal.kind === "adapter" && signal.stoppedReason && signal.stoppedReason !== "completed")
+    || hasAny(codes, ADAPTER_CODES)) {
+    return "adapter";
+  }
+  return "unknown";
+}
+
+async function classifyFailureRecoveryFallback(
+  evidence: FailureRecoveryEvidence,
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">
+): Promise<FailureRecoveryKind> {
+  if (!llmClient || !evidence.error?.trim()) return "unknown";
+  try {
+    const response = await llmClient.sendMessage(
+      [{ role: "user", content: JSON.stringify({ error: evidence.error }) }],
+      {
+        system: getFailureRecoveryFallbackPrompt(),
+        max_tokens: 256,
+        temperature: 0,
+        model_tier: "light",
+      }
+    );
+    const decision = llmClient.parseJSON(response.content, FailureRecoveryFallbackDecisionSchema);
+    if (decision.confidence < MIN_MODEL_CONFIDENCE) return "unknown";
+    return decision.kind;
+  } catch {
+    return "unknown";
+  }
+}
+
+function getFailureRecoveryFallbackPrompt(): string {
+  return `You classify a PulSeed chat lifecycle failure only when structured runtime evidence is unavailable.
+
+Return JSON: { "kind": "permission" | "tool_input" | "verification" | "runtime_interruption" | "daemon_loop" | "resume" | "adapter" | "unknown", "confidence": 0.0-1.0, "rationale": "short" }.
+
+Use unknown for ambiguous, provider-specific, localized, or low-evidence messages. Do not infer approval, verification, session, runtime, or provider state unless the failure text clearly states that category.`;
+}
+
+function collectCodes(evidence: FailureRecoveryEvidence, signals: FailureRecoverySignal[]): Set<string> {
+  return new Set([
+    normalizeToken(evidence.code),
+    ...signals.map((signal) => normalizeToken(signal.code)),
+  ].filter((token): token is string => Boolean(token)));
+}
+
+function hasAny(values: Set<string>, candidates: Set<string>): boolean {
+  for (const value of values) {
+    if (candidates.has(value)) return true;
+  }
+  return false;
+}
+
+function hasReason(evidence: FailureRecoveryEvidence, candidates: Set<string>): boolean {
+  const reasons = [
+    normalizeToken(evidence.stoppedReason),
+    normalizeToken(evidence.agentLoopStopReason),
+    ...(evidence.signals ?? [])
+      .map((signal) => signal.kind === "runtime" || signal.kind === "adapter" ? normalizeToken(signal.stoppedReason) : null),
+  ].filter((token): token is string => Boolean(token));
+  return reasons.some((reason) => candidates.has(reason));
+}
+
+function normalizeToken(value: string | null | undefined): string | null {
+  const token = value?.trim().toLowerCase().replaceAll("-", "_").replaceAll(" ", "_");
+  return token || null;
+}
+
+function guidanceFor(kind: FailureRecoveryKind): FailureRecoveryGuidance {
+  return GUIDANCE_BY_KIND[kind];
 }
 
 export function formatFailureRecovery(guidance: FailureRecoveryGuidance): string {


### PR DESCRIPTION
Closes #873

## 実装要約
- Replaced raw error-text regex classification in chat failure recovery with typed `FailureRecoveryEvidence` and exact structured signals: stop reasons, error codes, approval/tool dispositions, verification state, runtime operation state, and adapter metadata.
- Added confidence-aware structured LLM fallback for failures that lack structured evidence; low confidence, parse failure, or unavailable model returns typed `unknown` instead of keyword fallback.
- Wired production ChatRunner lifecycle-error paths to use the fallback and added caller-path tests for native agent-loop failures and stream/provider failures.

## 検証コマンド
- `npm exec -- vitest run src/interface/chat/__tests__/failure-recovery.test.ts src/interface/chat/__tests__/chat-runner.test.ts` - pass
- `npm run typecheck` - pass
- `npm run lint:boundaries` - pass, 0 errors with existing warnings
- `npm run test:changed` - pass
- `npm run test:all` - pass
- Fresh review: initial production fallback wiring finding fixed; re-review LGTM

## 既知の未解決リスク
- Synchronous compatibility callers still use structured-only classification unless they already pass a `FailureRecoveryGuidance`; the chat production path now uses the async fallback.
- Existing lint warnings outside this change remain.