### PR TITLE
refactor(tui): replace dashboard summary keyword classification

### DIFF
--- a/src/interface/tui/__tests__/dashboard.test.ts
+++ b/src/interface/tui/__tests__/dashboard.test.ts
@@ -242,7 +242,7 @@ describe("buildWorkDashboardRows", () => {
     ]);
   });
 
-  it("marks waiting blocked and approval-required sessions as attention-needed", () => {
+  it("does not mark sessions as attention-needed from title keywords alone", () => {
     const rows = buildWorkDashboardRows(snapshot({
       sessions: [session({
         id: "session-waiting-approval",
@@ -255,7 +255,60 @@ describe("buildWorkDashboardRows", () => {
       {
         id: "session-waiting-approval",
         group: "active",
+        attention: false,
+      },
+    ]);
+  });
+
+  it("marks runs as attention-needed from structured approval evidence", () => {
+    const rows = buildWorkDashboardRows(snapshot({
+      background_runs: [run({
+        id: "run-approval",
+        summary: "提出前に人間の確認が必要です",
+      })],
+    }), NOW, {
+      "run-approval": evidenceSummary({
+        evaluator_summary: {
+          ...evidenceSummary().evaluator_summary,
+          approval_required_actions: [{
+            id: "submit-final",
+            label: "Approve final submission",
+            approval_required: true,
+            status: "approval_required",
+            entry_id: "entry-1",
+            evaluator_id: "kaggle",
+            signal: "external",
+            source: "submit",
+            candidate_id: "candidate-1",
+            observed_at: NOW.toISOString(),
+          }],
+        },
+      }),
+    });
+
+    expect(rows).toMatchObject([
+      {
+        id: "run-approval",
+        group: "active",
         attention: true,
+      },
+    ]);
+  });
+
+  it("does not derive run attention from non-English free-text summary or error", () => {
+    const rows = buildWorkDashboardRows(snapshot({
+      background_runs: [run({
+        id: "run-localized",
+        summary: "承認待ちです",
+        error: "ブロックされています",
+      })],
+    }), NOW);
+
+    expect(rows).toMatchObject([
+      {
+        id: "run-localized",
+        group: "active",
+        attention: false,
       },
     ]);
   });
@@ -298,7 +351,7 @@ describe("buildOperatorConsoleModel", () => {
     const model = buildOperatorConsoleModel(snapshot({
       background_runs: [run({
         id: "run-approval",
-        summary: "approval-required before submit",
+        summary: "提出前に確認が必要です",
       })],
     }), health({
       summary: "alive_but_waiting",
@@ -332,6 +385,83 @@ describe("buildOperatorConsoleModel", () => {
         "Approve final submission",
       ]),
     });
+  });
+
+  it("shows structured blocked state without using summary keywords", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({
+        id: "run-blocked",
+        summary: "外部評価の結果待ちです",
+      })],
+    }), null, {
+      "run-blocked": evidenceSummary({
+        evaluator_summary: {
+          ...evidenceSummary().evaluator_summary,
+          gap: {
+            kind: "pending_external",
+            summary: "external evaluator has not returned a confirmed result",
+          },
+        },
+      }),
+    }, NOW);
+
+    expect(model).toMatchObject({
+      lifecycle: "blocked",
+      blockers: expect.arrayContaining([
+        "external evaluator has not returned a confirmed result",
+      ]),
+    });
+  });
+
+  it("keeps non-English run summaries display-only when structured state is missing", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({
+        id: "run-localized",
+        summary: "承認待ちです",
+        error: "ブロックされています",
+      })],
+    }), null, {}, NOW);
+
+    expect(model).toMatchObject({
+      lifecycle: "running",
+      blockers: ["No blockers detected."],
+      latestEvents: expect.arrayContaining(["承認待ちです", "ブロックされています"]),
+    });
+  });
+
+  it("uses typed phase metadata instead of strategy text for mode labels", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({ id: "run-phase" })],
+    }), null, {
+      "run-phase": evidenceSummary({
+        latest_strategy: {
+          schema_version: "runtime-evidence-entry-v1",
+          id: "strategy-1",
+          occurred_at: NOW.toISOString(),
+          kind: "strategy",
+          scope: { run_id: "run-phase" },
+          strategy: "finalization candidate with final portfolio language",
+          metrics: [],
+          artifacts: [],
+          raw_refs: [],
+        },
+        evaluator_summary: {
+          ...evidenceSummary().evaluator_summary,
+          budgets: [{
+            evaluator_id: "kaggle",
+            source: "local",
+            remaining_attempts: 2,
+            approval_required: true,
+            phase: "exploration",
+            diversified_portfolio_required: false,
+            reserve_for_finalization: false,
+            observed_at: NOW.toISOString(),
+          }],
+        },
+      }),
+    }, NOW);
+
+    expect(model?.currentMode).toBe("exploration");
   });
 
   it("does not apply daemon aggregate health as selected-run lifecycle or progress", () => {
@@ -378,6 +508,23 @@ describe("buildOperatorConsoleModel", () => {
     expect(model).toMatchObject({
       lifecycle: "completed",
       usefulProgress: "selected_score stalled; latest 0.72; best 0.72",
+      blockers: ["No blockers detected."],
+    });
+  });
+
+  it("does not attribute daemon aggregate approval waits to an active selected run", () => {
+    const model = buildOperatorConsoleModel(snapshot({
+      background_runs: [run({ id: "run-active" })],
+    }), health({
+      summary: "alive_but_waiting",
+      signals: {
+        ...health().long_running!.signals,
+        blocker: { status: "approval_wait", reason: "unrelated run approval", checked_at: NOW.getTime() },
+      },
+    }), {}, NOW);
+
+    expect(model).toMatchObject({
+      lifecycle: "running",
       blockers: ["No blockers detected."],
     });
   });

--- a/src/interface/tui/dashboard.tsx
+++ b/src/interface/tui/dashboard.tsx
@@ -88,31 +88,47 @@ function isRecent(updatedAt: string | null, now: Date): boolean {
 }
 
 function sessionAttention(session: RuntimeSession, stale: boolean): boolean {
-  const attentionText = [
-    session.title,
-    session.id,
-    session.reply_target ? JSON.stringify(session.reply_target) : null,
-    ...session.source_refs.flatMap((ref) => [ref.id, ref.relative_path]),
-  ].filter(Boolean).join(" ");
   return stale
     || session.status === "lost"
-    || session.status === "unknown"
-    || /approval[-_ ]required|blocked|waiting/i.test(attentionText);
+    || session.status === "unknown";
 }
 
-function runAttention(run: BackgroundRun): boolean {
+function summaryHasOpenApproval(summary: RuntimeEvidenceSummary | undefined): boolean {
+  return Boolean(summary?.evaluator_summary.approval_required_actions.some((action) =>
+    action.status === "approval_required" || action.status === "blocked"
+  ));
+}
+
+function summaryHasStructuredBlocker(summary: RuntimeEvidenceSummary | undefined): boolean {
+  if (!summary) return false;
+  return Boolean(
+    summary.evaluator_summary.gap && summary.evaluator_summary.gap.kind !== "none"
+  )
+    || summary.evaluator_summary.observations.some((observation) =>
+      observation.status === "blocked" || observation.validation?.status === "blocked"
+    )
+    || summary.recent_failed_attempts.length > 0
+    || summary.failed_lineages.length > 0;
+}
+
+function runAttention(run: BackgroundRun, summary?: RuntimeEvidenceSummary): boolean {
   return run.status === "failed"
     || run.status === "timed_out"
     || run.status === "lost"
     || run.status === "unknown"
-    || /approval[-_ ]required|blocked|waiting/i.test(`${run.summary ?? ""} ${run.error ?? ""}`);
+    || summaryHasOpenApproval(summary)
+    || summaryHasStructuredBlocker(summary);
 }
 
-function runLifecycle(run: BackgroundRun | null, row: WorkDashboardRow): string {
+function runLifecycle(
+  run: BackgroundRun | null,
+  row: WorkDashboardRow,
+  summary: RuntimeEvidenceSummary | undefined
+): string {
   if (row.stale) return "stale";
   if (!run) return row.status;
-  if (/approval[-_ ]required/i.test(`${run.summary ?? ""} ${run.error ?? ""}`)) return "approval-required";
-  if (/blocked|waiting/i.test(`${run.summary ?? ""} ${run.error ?? ""}`)) return "blocked";
+  if (summaryHasOpenApproval(summary)) return "approval-required";
+  if (summaryHasStructuredBlocker(summary)) return "blocked";
   if (run.status === "succeeded") return "completed";
   if (run.status === "failed" || run.status === "timed_out" || run.status === "lost" || run.status === "unknown") return "failed";
   return run.status;
@@ -149,14 +165,22 @@ function summarizeUsefulProgress(summary: RuntimeEvidenceSummary | undefined, he
 function summarizeMode(summary: RuntimeEvidenceSummary | undefined): string {
   const phase = summary?.evaluator_summary.budgets.find((budget) => budget.phase)?.phase;
   if (phase) return phase;
-  const strategyText = [
-    summary?.latest_strategy?.strategy,
-    summary?.latest_strategy?.summary,
-    summary?.latest_strategy?.decision_reason,
-  ].filter(Boolean).join(" ");
-  if (/final/i.test(strategyText)) return "finalization";
-  if (/consolidat|stabil|ensemble|portfolio/i.test(strategyText)) return "consolidation";
-  if (strategyText) return "exploration";
+  const portfolio = summary?.candidate_selection_summary.final_portfolio;
+  if (portfolio && (portfolio.safe || portfolio.aggressive || portfolio.diverse)) return "finalization";
+  if (
+    summary?.candidate_selection_summary.robust_best
+    || summary?.candidate_selection_summary.raw_best
+    || (summary?.recommended_candidate_portfolio.length ?? 0) > 0
+  ) {
+    return "consolidation";
+  }
+  if (
+    summary?.latest_strategy
+    || (summary?.dream_checkpoints.length ?? 0) > 0
+    || (summary?.divergent_exploration.length ?? 0) > 0
+  ) {
+    return "exploration";
+  }
   return "unknown";
 }
 
@@ -195,8 +219,16 @@ function summarizeEvents(run: BackgroundRun | null, summary: RuntimeEvidenceSumm
 function summarizeBlockers(row: WorkDashboardRow, run: BackgroundRun | null, summary: RuntimeEvidenceSummary | undefined): string[] {
   const blockers: string[] = [];
   if (row.attention) blockers.push(row.status === "stale" ? "stale catalog state" : row.summary);
-  if (run?.error) blockers.push(run.error);
+  if (
+    run?.error
+    && (row.attention || run.status === "failed" || run.status === "timed_out" || run.status === "lost" || run.status === "unknown")
+  ) {
+    blockers.push(run.error);
+  }
   blockers.push(...(summary?.evaluator_summary.approval_required_actions ?? []).map((action) => action.label));
+  if (summary?.evaluator_summary.gap && summary.evaluator_summary.gap.kind !== "none") {
+    blockers.push(summary.evaluator_summary.gap.summary);
+  }
   return [...new Set(blockers.filter(Boolean))].slice(0, 4);
 }
 
@@ -213,7 +245,7 @@ export function buildOperatorConsoleModel(
   evidenceSummaries: RuntimeEvidenceSummaryByRun = {},
   now: Date = new Date(),
 ): OperatorConsoleModel | null {
-  const rows = buildWorkDashboardRows(snapshot, now);
+  const rows = buildWorkDashboardRows(snapshot, now, evidenceSummaries);
   if (!snapshot || rows.length === 0) return null;
   const selected = rows.find((row) => row.attention) ?? rows.find((row) => row.group === "active") ?? rows[0]!;
   const run = findRelatedRun(snapshot, selected);
@@ -224,7 +256,7 @@ export function buildOperatorConsoleModel(
   return {
     selectedId: selected.id,
     selectedTitle: selected.title,
-    lifecycle: runLifecycle(run, selected),
+    lifecycle: runLifecycle(run, selected, summary),
     liveness: summarizeLiveness(selected, health),
     usefulProgress: summarizeUsefulProgress(summary, health),
     currentMode: summarizeMode(summary),
@@ -247,6 +279,7 @@ function compact(value: string | null | undefined, fallback: string): string {
 export function buildWorkDashboardRows(
   snapshot: RuntimeSessionRegistrySnapshot | null | undefined,
   now: Date = new Date(),
+  evidenceSummaries: RuntimeEvidenceSummaryByRun = {},
 ): WorkDashboardRow[] {
   if (!snapshot) return [];
   const rows: WorkDashboardRow[] = [];
@@ -287,7 +320,7 @@ export function buildWorkDashboardRows(
       summary: compact(run.error ?? run.summary, run.kind),
       updatedAt,
       workspace: run.workspace,
-      attention: runAttention(run) || stale,
+      attention: runAttention(run, evidenceSummaries[run.id]) || stale,
       stale,
     });
   }
@@ -438,7 +471,7 @@ function OperatorConsole({ model }: { model: OperatorConsoleModel }) {
 }
 
 export function Dashboard({ state, runtimeSessions, runtimeHealth, evidenceSummaries }: DashboardProps) {
-  const workRows = buildWorkDashboardRows(runtimeSessions);
+  const workRows = buildWorkDashboardRows(runtimeSessions, new Date(), evidenceSummaries);
   const operatorConsole = buildOperatorConsoleModel(runtimeSessions, runtimeHealth, evidenceSummaries);
   if (workRows.length > 0) {
     return (


### PR DESCRIPTION
Closes #875

## 実装要約
- Dashboard row attention and operator lifecycle now use Runtime Session Catalog status plus run-scoped Runtime Evidence approvals, gaps, observations, and failure metadata instead of matching title/summary/error text.
- Mode labels now come from typed evaluator phase, candidate portfolio, and evidence presence rather than strategy prose regexes.
- Free-text summaries/errors remain display-only; daemon aggregate Runtime Health is kept as liveness/progress context and is not promoted into selected-run lifecycle.
- Added caller-path dashboard model tests for structured approval/blocker precedence, non-English display-only summaries/errors, active-run aggregate-health non-attribution, and typed phase precedence over English finalization prose.

## 検証コマンド
- `npm exec -- vitest run src/interface/tui/__tests__/dashboard.test.ts` - pass, 18 tests
- `npm run typecheck` - pass
- `npm run lint:boundaries` - pass, 0 errors with existing warnings
- `npm run test:changed` - pass
- Fresh review - initial findings fixed; re-review LGTM

## 既知の未解決リスク
- Operator handoff / approval broker records are not directly loaded by this dashboard component yet; this slice uses the Runtime Session Catalog, Runtime Health, and Runtime Evidence summaries already passed to the dashboard.
- Existing repository-wide lint warnings remain outside this change.