### PR TITLE
refactor(notification): replace natural-language routing keyword matching

### DIFF
--- a/src/interface/cli/__tests__/cli-notify.test.ts
+++ b/src/interface/cli/__tests__/cli-notify.test.ts
@@ -11,8 +11,25 @@ vi.mock("../../../base/utils/paths.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../../../base/llm/provider-factory.js", () => ({
+  buildLLMClient: vi.fn(),
+}));
+
 import { getPulseedDirPath } from "../../../base/utils/paths.js";
+import { buildLLMClient } from "../../../base/llm/provider-factory.js";
 import { cmdNotify } from "../commands/notify.js";
+
+function mockRoutingDecision(decision: unknown): void {
+  vi.mocked(buildLLMClient).mockResolvedValue({
+    sendMessage: async () => ({
+      content: JSON.stringify(decision),
+      usage: { input_tokens: 0, output_tokens: 0 },
+      stop_reason: "stop",
+    }),
+    parseJSON: (content: string, schema: { parse: (value: unknown) => unknown }) =>
+      schema.parse(JSON.parse(content)),
+  } as never);
+}
 
 describe("cmdNotify", () => {
   let tmpDir: string;
@@ -22,6 +39,7 @@ describe("cmdNotify", () => {
   beforeEach(() => {
     tmpDir = makeTempDir("pulseed-notify-test-");
     vi.mocked(getPulseedDirPath).mockReturnValue(tmpDir);
+    vi.mocked(buildLLMClient).mockReset();
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -173,6 +191,16 @@ describe("cmdNotify", () => {
   });
 
   it("route updates plugin notifier routing from natural language", async () => {
+    mockRoutingDecision({
+      action: "update_routes",
+      selected_notifiers: ["whatsapp-webhook"],
+      report_types: ["urgent_alert", "approval_request"],
+      mode: "only",
+      enabled: true,
+      confidence: 0.93,
+      reason: "urgent WhatsApp exclusive route",
+    });
+
     const code = await cmdNotify(["route", "緊急通知はWhatsAppだけに送って"]);
 
     expect(code).toBe(0);
@@ -196,6 +224,15 @@ describe("cmdNotify", () => {
   });
 
   it("route rejects invalid existing config without overwriting it", async () => {
+    mockRoutingDecision({
+      action: "update_routes",
+      selected_notifiers: ["discord-bot"],
+      report_types: [],
+      mode: "only",
+      enabled: true,
+      confidence: 0.9,
+      reason: "exclusive discord route",
+    });
     const configPath = path.join(tmpDir, "notification.json");
     const invalidJson = JSON.stringify({ channels: [{ type: "webhook", url: "not-a-url" }] });
     fs.writeFileSync(configPath, invalidJson, "utf-8");
@@ -207,6 +244,25 @@ describe("cmdNotify", () => {
       expect.stringContaining("Invalid notification config")
     );
     expect(fs.readFileSync(configPath, "utf-8")).toBe(invalidJson);
+  });
+
+  it("route does not write config when parser returns ambiguous", async () => {
+    mockRoutingDecision({
+      action: "ambiguous",
+      selected_notifiers: [],
+      report_types: [],
+      mode: null,
+      enabled: null,
+      confidence: 0.3,
+      clarification: "Specify the notifier and report type.",
+      reason: "missing target",
+    });
+
+    const code = await cmdNotify(["route", "通知をいい感じにして"]);
+
+    expect(code).toBe(1);
+    expect(consoleErrSpy).toHaveBeenCalledWith(expect.stringContaining("unchanged"));
+    expect(fs.existsSync(path.join(tmpDir, "notification.json"))).toBe(false);
   });
 
   // ─── remove ───

--- a/src/interface/cli/commands/notify.ts
+++ b/src/interface/cli/commands/notify.ts
@@ -8,6 +8,7 @@ import {
   loadNotificationConfig,
   saveNotificationConfig,
 } from "../../../runtime/notification-routing.js";
+import { buildLLMClient } from "../../../base/llm/provider-factory.js";
 
 async function loadConfig(configPath: string): Promise<NotificationConfig> {
   return loadNotificationConfig(configPath);
@@ -290,7 +291,12 @@ async function cmdNotifyRoute(args: string[], configPath: string): Promise<numbe
   }
 
   try {
-    const update = await applyNaturalLanguageNotificationRouting(instruction, configPath);
+    const llmClient = await buildLLMClient();
+    const update = await applyNaturalLanguageNotificationRouting(instruction, configPath, { llmClient });
+    if (!update.applied) {
+      console.error(update.summary);
+      return 1;
+    }
     console.log(update.summary);
     return 0;
   } catch (err) {

--- a/src/runtime/__tests__/notification-routing.test.ts
+++ b/src/runtime/__tests__/notification-routing.test.ts
@@ -6,7 +6,21 @@ import { NotificationConfigSchema } from "../../base/types/notification.js";
 import {
   applyNaturalLanguageNotificationRouting,
   applyNaturalLanguageNotificationRoutingToConfig,
+  type NotificationRoutingDecision,
 } from "../notification-routing.js";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+
+function llmDecision(decision: NotificationRoutingDecision): Pick<ILLMClient, "sendMessage" | "parseJSON"> {
+  return {
+    sendMessage: async () => ({
+      content: JSON.stringify(decision),
+      usage: { input_tokens: 0, output_tokens: 0 },
+      stop_reason: "stop",
+    }),
+    parseJSON: ((content: string, schema: { parse: (value: unknown) => unknown }) =>
+      schema.parse(JSON.parse(content))) as Pick<ILLMClient, "sendMessage" | "parseJSON">["parseJSON"],
+  };
+}
 
 describe("notification routing natural language updates", () => {
   const tmpDirs: string[] = [];
@@ -17,14 +31,26 @@ describe("notification routing natural language updates", () => {
     }
   });
 
-  it("routes weekly reports only to Discord from a natural language instruction", () => {
+  it("routes weekly reports only to Discord from a natural language instruction", async () => {
     const config = NotificationConfigSchema.parse({});
 
-    const update = applyNaturalLanguageNotificationRoutingToConfig(
+    const update = await applyNaturalLanguageNotificationRoutingToConfig(
       config,
-      "週次レポートはDiscordだけに送って"
+      "週次レポートはDiscordだけに送って",
+      {
+        llmClient: llmDecision({
+          action: "update_routes",
+          selected_notifiers: ["discord-bot"],
+          report_types: ["weekly_report"],
+          mode: "only",
+          enabled: true,
+          confidence: 0.94,
+          reason: "weekly report exclusive route",
+        }),
+      }
     );
 
+    expect(update.applied).toBe(true);
     expect(update.config.plugin_notifiers.mode).toBe("only");
     expect(update.config.plugin_notifiers.routes).toEqual([
       {
@@ -35,14 +61,26 @@ describe("notification routing natural language updates", () => {
     ]);
   });
 
-  it("disables one notifier while leaving plugin routing in all mode", () => {
+  it("disables one notifier while leaving plugin routing in all mode", async () => {
     const config = NotificationConfigSchema.parse({});
 
-    const update = applyNaturalLanguageNotificationRoutingToConfig(
+    const update = await applyNaturalLanguageNotificationRoutingToConfig(
       config,
-      "WhatsAppには通知を送らない"
+      "WhatsAppには通知を送らない",
+      {
+        llmClient: llmDecision({
+          action: "update_routes",
+          selected_notifiers: ["whatsapp-webhook"],
+          report_types: [],
+          mode: "all",
+          enabled: false,
+          confidence: 0.91,
+          reason: "disable selected notifier",
+        }),
+      }
     );
 
+    expect(update.applied).toBe(true);
     expect(update.config.plugin_notifiers.mode).toBe("all");
     expect(update.config.plugin_notifiers.routes).toEqual([
       {
@@ -53,15 +91,101 @@ describe("notification routing natural language updates", () => {
     ]);
   });
 
-  it("can disable all plugin notifier delivery", () => {
+  it("can disable all plugin notifier delivery", async () => {
     const config = NotificationConfigSchema.parse({});
 
-    const update = applyNaturalLanguageNotificationRoutingToConfig(
+    const update = await applyNaturalLanguageNotificationRoutingToConfig(
       config,
-      "プラグイン通知は全部止めて"
+      "プラグイン通知は全部止めて",
+      {
+        llmClient: llmDecision({
+          action: "disable_all",
+          selected_notifiers: [],
+          report_types: [],
+          mode: "none",
+          enabled: false,
+          confidence: 0.96,
+          reason: "disable all plugin notifier delivery",
+        }),
+      }
     );
 
+    expect(update.applied).toBe(true);
     expect(update.config.plugin_notifiers.mode).toBe("none");
+  });
+
+  it("applies a multilingual route change through structured parser output", async () => {
+    const config = NotificationConfigSchema.parse({});
+
+    const update = await applyNaturalLanguageNotificationRoutingToConfig(
+      config,
+      "Envía solamente las alertas urgentes por Telegram",
+      {
+        llmClient: llmDecision({
+          action: "update_routes",
+          selected_notifiers: ["telegram-bot"],
+          report_types: ["urgent_alert", "approval_request"],
+          mode: "only",
+          enabled: true,
+          confidence: 0.9,
+          reason: "exclusive urgent notification route",
+        }),
+      }
+    );
+
+    expect(update.config.plugin_notifiers).toEqual({
+      mode: "only",
+      routes: [
+        {
+          id: "telegram-bot",
+          enabled: true,
+          report_types: ["urgent_alert", "approval_request"],
+        },
+      ],
+    });
+  });
+
+  it("does not mutate config for ambiguous instructions", async () => {
+    const config = NotificationConfigSchema.parse({
+      plugin_notifiers: {
+        mode: "all",
+        routes: [{ id: "discord-bot", enabled: true, report_types: ["weekly_report"] }],
+      },
+    });
+
+    const update = await applyNaturalLanguageNotificationRoutingToConfig(
+      config,
+      "いい感じに通知を調整して",
+      {
+        llmClient: llmDecision({
+          action: "ambiguous",
+          selected_notifiers: [],
+          report_types: [],
+          mode: null,
+          enabled: null,
+          confidence: 0.42,
+          clarification: "Specify the notifier and report types to route.",
+          reason: "missing route target",
+        }),
+      }
+    );
+
+    expect(update.applied).toBe(false);
+    expect(update.config).toEqual(config);
+    expect(update.summary).toContain("unchanged");
+  });
+
+  it("does not mutate config when the structured parser is unavailable", async () => {
+    const config = NotificationConfigSchema.parse({});
+
+    const update = await applyNaturalLanguageNotificationRoutingToConfig(
+      config,
+      "Send weekly reports to Slack"
+    );
+
+    expect(update.applied).toBe(false);
+    expect(update.config).toEqual(config);
+    expect(update.decision.action).toBe("unsupported");
   });
 
   it("does not overwrite an invalid notification config when applying a route", async () => {
@@ -72,7 +196,17 @@ describe("notification routing natural language updates", () => {
     fs.writeFileSync(configPath, invalidJson, "utf-8");
 
     await expect(
-      applyNaturalLanguageNotificationRouting("Discordだけ", configPath)
+      applyNaturalLanguageNotificationRouting("Discordだけ", configPath, {
+        llmClient: llmDecision({
+          action: "update_routes",
+          selected_notifiers: ["discord-bot"],
+          report_types: [],
+          mode: "only",
+          enabled: true,
+          confidence: 0.9,
+          reason: "exclusive discord route",
+        }),
+      })
     ).rejects.toThrow(/Invalid notification config/);
 
     expect(fs.readFileSync(configPath, "utf-8")).toBe(invalidJson);

--- a/src/runtime/notification-routing.ts
+++ b/src/runtime/notification-routing.ts
@@ -1,39 +1,62 @@
 import * as path from "node:path";
+import { z } from "zod";
 import { readJsonFileOrNull, writeJsonFileAtomic } from "../base/utils/json-io.js";
 import { getPulseedDirPath } from "../base/utils/paths.js";
 import { NotificationConfigSchema } from "../base/types/notification.js";
 import type { NotificationConfig, PluginNotifierRoute } from "../base/types/notification.js";
+import type { ILLMClient } from "../base/llm/llm-client.js";
+import { getInternalIdentityPrefix } from "../base/config/identity-loader.js";
 
 export interface NotificationRoutingUpdate {
   config: NotificationConfig;
   selected_notifiers: string[];
   report_types: string[];
   mode: "all" | "only" | "none";
+  enabled: boolean | null;
+  applied: boolean;
   summary: string;
+  decision: NotificationRoutingDecision;
 }
 
-interface NotifierAlias {
-  id: string;
-  labels: string[];
+const MIN_NOTIFICATION_ROUTING_CONFIDENCE = 0.7;
+
+export const PluginNotifierIdSchema = z.enum([
+  "discord-bot",
+  "whatsapp-webhook",
+  "signal-bridge",
+  "telegram-bot",
+  "slack-notifier",
+]);
+export type PluginNotifierId = z.infer<typeof PluginNotifierIdSchema>;
+
+export const NotificationReportTypeSchema = z.enum([
+  "urgent_alert",
+  "approval_request",
+  "stall_escalation",
+  "goal_completion",
+  "daily_summary",
+  "weekly_report",
+  "execution_summary",
+  "strategy_change",
+  "capability_escalation",
+]);
+export type NotificationReportType = z.infer<typeof NotificationReportTypeSchema>;
+
+export const NotificationRoutingDecisionSchema = z.object({
+  action: z.enum(["update_routes", "disable_all", "unsupported", "ambiguous"]),
+  selected_notifiers: z.array(PluginNotifierIdSchema).default([]),
+  report_types: z.array(NotificationReportTypeSchema).default([]),
+  mode: z.enum(["all", "only", "none"]).nullable().default(null),
+  enabled: z.boolean().nullable().default(null),
+  confidence: z.number().min(0).max(1),
+  clarification: z.string().optional(),
+  reason: z.string().optional(),
+});
+export type NotificationRoutingDecision = z.output<typeof NotificationRoutingDecisionSchema>;
+
+export interface NotificationRoutingParserContext {
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;
 }
-
-const NOTIFIER_ALIASES: NotifierAlias[] = [
-  { id: "discord-bot", labels: ["discord", "ディスコード"] },
-  { id: "whatsapp-webhook", labels: ["whatsapp", "what's app", "ワッツアップ", "ワッツアップ"] },
-  { id: "signal-bridge", labels: ["signal", "シグナル"] },
-  { id: "telegram-bot", labels: ["telegram", "テレグラム"] },
-  { id: "slack-notifier", labels: ["slack", "スラック"] },
-];
-
-const REPORT_TYPE_ALIASES: Array<{ reportTypes: string[]; labels: string[] }> = [
-  { reportTypes: ["urgent_alert", "approval_request"], labels: ["urgent", "緊急", "至急", "承認", "approval"] },
-  { reportTypes: ["stall_escalation"], labels: ["stall", "stuck", "停滞", "詰まり", "ブロック"] },
-  { reportTypes: ["goal_completion"], labels: ["complete", "completion", "完了", "達成"] },
-  { reportTypes: ["daily_summary"], labels: ["daily", "日次", "毎日", "朝", "夕方"] },
-  { reportTypes: ["weekly_report"], labels: ["weekly", "週次", "毎週"] },
-  { reportTypes: ["execution_summary"], labels: ["execution", "実行", "作業"] },
-  { reportTypes: ["strategy_change", "capability_escalation"], labels: ["strategy", "戦略", "方針", "capability", "能力"] },
-];
 
 export function getNotificationConfigPath(baseDir?: string): string {
   return path.join(baseDir ?? getPulseedDirPath(), "notification.json");
@@ -63,43 +86,78 @@ export async function saveNotificationConfig(configPath: string, config: Notific
 
 export async function applyNaturalLanguageNotificationRouting(
   instruction: string,
-  configPath = getNotificationConfigPath()
+  configPath = getNotificationConfigPath(),
+  context: NotificationRoutingParserContext = {},
 ): Promise<NotificationRoutingUpdate> {
   const config = await loadNotificationConfig(configPath, { invalid: "throw" });
-  const update = applyNaturalLanguageNotificationRoutingToConfig(config, instruction);
-  await saveNotificationConfig(configPath, update.config);
+  const update = await applyNaturalLanguageNotificationRoutingToConfig(config, instruction, context);
+  if (update.applied) {
+    await saveNotificationConfig(configPath, update.config);
+  }
   return update;
 }
 
-export function applyNaturalLanguageNotificationRoutingToConfig(
+export async function applyNaturalLanguageNotificationRoutingToConfig(
   config: NotificationConfig,
-  instruction: string
+  instruction: string,
+  context: NotificationRoutingParserContext = {},
+): Promise<NotificationRoutingUpdate> {
+  const decision = await parseNotificationRoutingInstruction(instruction, context);
+  return applyNotificationRoutingDecisionToConfig(config, decision, instruction);
+}
+
+export function applyNotificationRoutingDecisionToConfig(
+  config: NotificationConfig,
+  rawDecision: NotificationRoutingDecision,
+  instruction = "",
 ): NotificationRoutingUpdate {
-  const selected = detectNotifiers(instruction);
-  const reportTypes = detectReportTypes(instruction);
-  const mode = detectMode(instruction, selected.length);
+  const decision = normalizeRoutingDecision(rawDecision);
+  const selected = decision.selected_notifiers;
+  const reportTypes = decision.report_types;
 
   const nextConfig = NotificationConfigSchema.parse(config);
   const currentRoutes = nextConfig.plugin_notifiers.routes;
+  const blocked = decision.action === "ambiguous"
+    || decision.action === "unsupported"
+    || decision.confidence < MIN_NOTIFICATION_ROUTING_CONFIDENCE;
 
-  if (mode === "none") {
+  if (blocked) {
+    return {
+      config: nextConfig,
+      selected_notifiers: selected,
+      report_types: reportTypes,
+      mode: nextConfig.plugin_notifiers.mode,
+      enabled: null,
+      applied: false,
+      summary: buildBlockedSummary(decision, instruction),
+      decision,
+    };
+  }
+
+  if (decision.action === "disable_all") {
     nextConfig.plugin_notifiers = {
       mode: "none",
       routes: currentRoutes,
     };
   } else {
+    const mode = decision.mode ?? "all";
+    const enabled = decision.enabled ?? true;
     nextConfig.plugin_notifiers = {
       mode,
-      routes: mergeRoutes(currentRoutes, selected, reportTypes, !isDisableInstruction(instruction)),
+      routes: mergeRoutes(currentRoutes, selected, reportTypes, enabled),
     };
   }
 
+  const parsed = NotificationConfigSchema.parse(nextConfig);
   return {
-    config: NotificationConfigSchema.parse(nextConfig),
+    config: parsed,
     selected_notifiers: selected,
     report_types: reportTypes,
-    mode,
-    summary: buildSummary(mode, selected, reportTypes, instruction),
+    mode: parsed.plugin_notifiers.mode,
+    enabled: decision.action === "disable_all" ? false : decision.enabled ?? true,
+    applied: true,
+    summary: buildSummary(parsed.plugin_notifiers.mode, selected, reportTypes, decision, instruction),
+    decision,
   };
 }
 
@@ -121,72 +179,64 @@ function mergeRoutes(
   return Array.from(byId.values());
 }
 
-function detectNotifiers(instruction: string): string[] {
-  const normalized = instruction.toLowerCase();
-  const selected: string[] = [];
-  for (const alias of NOTIFIER_ALIASES) {
-    if (alias.labels.some((label) => normalized.includes(label.toLowerCase()))) {
-      selected.push(alias.id);
-    }
+export async function parseNotificationRoutingInstruction(
+  instruction: string,
+  context: NotificationRoutingParserContext = {},
+): Promise<NotificationRoutingDecision> {
+  const trimmed = instruction.trim();
+  const llmClient = context.llmClient;
+  if (!trimmed) {
+    return {
+      action: "ambiguous",
+      selected_notifiers: [],
+      report_types: [],
+      mode: null,
+      enabled: null,
+      confidence: 0,
+      clarification: "Provide the notification routing change to apply.",
+      reason: "empty instruction",
+    };
   }
-  return selected;
-}
-
-function detectReportTypes(instruction: string): string[] {
-  const normalized = instruction.toLowerCase();
-  const selected = new Set<string>();
-  for (const alias of REPORT_TYPE_ALIASES) {
-    if (alias.labels.some((label) => normalized.includes(label.toLowerCase()))) {
-      for (const reportType of alias.reportTypes) {
-        selected.add(reportType);
-      }
-    }
+  if (!llmClient) {
+    return {
+      action: "unsupported",
+      selected_notifiers: [],
+      report_types: [],
+      mode: null,
+      enabled: null,
+      confidence: 0,
+      clarification: "Notification routing changes need the structured routing parser, but no model client is available.",
+      reason: "model unavailable",
+    };
   }
-  const hasGenericReport = ["report", "レポート", "報告"].some((label) => normalized.includes(label));
-  const hasSpecificReport = ["daily_summary", "weekly_report", "execution_summary"]
-    .some((reportType) => selected.has(reportType));
-  if (hasGenericReport && !hasSpecificReport) {
-    selected.add("daily_summary");
-    selected.add("weekly_report");
-    selected.add("execution_summary");
+  try {
+    const response = await llmClient.sendMessage(
+      [{ role: "user", content: trimmed }],
+      { system: getNotificationRoutingPrompt(), max_tokens: 700, temperature: 0 },
+    );
+    const parsed = NotificationRoutingDecisionSchema.parse(
+      llmClient.parseJSON(response.content, NotificationRoutingDecisionSchema)
+    );
+    return normalizeRoutingDecision(parsed);
+  } catch (err) {
+    return {
+      action: "unsupported",
+      selected_notifiers: [],
+      report_types: [],
+      mode: null,
+      enabled: null,
+      confidence: 0,
+      clarification: "Notification routing instruction could not be parsed into the routing schema.",
+      reason: err instanceof Error ? err.message : String(err),
+    };
   }
-  return Array.from(selected);
-}
-
-function detectMode(instruction: string, selectedCount: number): "all" | "only" | "none" {
-  if (isDisableInstruction(instruction) && selectedCount === 0) {
-    return "none";
-  }
-  const normalized = instruction.toLowerCase();
-  if (
-    normalized.includes("only") ||
-    normalized.includes("だけ") ||
-    normalized.includes("のみ") ||
-    normalized.includes("一本化")
-  ) {
-    return "only";
-  }
-  return "all";
-}
-
-function isDisableInstruction(instruction: string): boolean {
-  const normalized = instruction.toLowerCase();
-  return (
-    normalized.includes("disable") ||
-    normalized.includes("off") ||
-    normalized.includes("mute") ||
-    normalized.includes("stop") ||
-    normalized.includes("送らない") ||
-    normalized.includes("送信しない") ||
-    normalized.includes("止め") ||
-    normalized.includes("無効")
-  );
 }
 
 function buildSummary(
   mode: "all" | "only" | "none",
   selected: string[],
   reportTypes: string[],
+  decision: NotificationRoutingDecision,
   instruction: string
 ): string {
   if (mode === "none") {
@@ -194,5 +244,93 @@ function buildSummary(
   }
   const target = selected.length > 0 ? selected.join(", ") : "(no specific plugin notifier)";
   const reportScope = reportTypes.length > 0 ? reportTypes.join(", ") : "all report types";
-  return `Plugin notification routing set to ${mode}: ${target} for ${reportScope}`;
+  const enabled = decision.enabled === false ? "disabled" : "enabled";
+  return `Plugin notification routing set to ${mode}: ${target} ${enabled} for ${reportScope}`;
+}
+
+function buildBlockedSummary(decision: NotificationRoutingDecision, instruction: string): string {
+  const reason = decision.clarification ?? decision.reason ?? "instruction was ambiguous or unsupported";
+  const source = instruction ? ` from instruction: ${instruction}` : "";
+  return `Plugin notification routing unchanged${source}. ${reason}`;
+}
+
+function normalizeRoutingDecision(decision: NotificationRoutingDecision): NotificationRoutingDecision {
+  const selected = unique(decision.selected_notifiers);
+  const reportTypes = unique(decision.report_types);
+  if (decision.action === "disable_all") {
+    return {
+      ...decision,
+      selected_notifiers: [],
+      report_types: [],
+      mode: "none",
+      enabled: false,
+    };
+  }
+  if (decision.action !== "update_routes") {
+    return {
+      ...decision,
+      selected_notifiers: selected,
+      report_types: reportTypes,
+      mode: null,
+      enabled: null,
+    };
+  }
+  if (selected.length === 0) {
+    return {
+      ...decision,
+      action: "ambiguous",
+      selected_notifiers: [],
+      report_types: reportTypes,
+      mode: null,
+      enabled: null,
+      clarification: decision.clarification ?? "No supported plugin notifier target was selected.",
+    };
+  }
+  return {
+    ...decision,
+    selected_notifiers: selected,
+    report_types: reportTypes,
+    mode: decision.mode ?? "all",
+    enabled: decision.enabled ?? true,
+  };
+}
+
+function unique<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+function getNotificationRoutingPrompt(): string {
+  return `${getInternalIdentityPrefix("assistant")} Convert the operator's notification-routing instruction into the typed PulSeed notification routing schema.
+
+Do not guess. If the instruction is vague, unsupported, or does not clearly ask to change plugin notification routing, return ambiguous or unsupported. If the user asks to disable every plugin notifier, return disable_all. If the user asks to disable one or more specific notifiers, return update_routes with enabled false. If the user asks for a single selected route to be exclusive, use mode only. Otherwise use mode all.
+
+Supported plugin notifier ids:
+- discord-bot
+- whatsapp-webhook
+- signal-bridge
+- telegram-bot
+- slack-notifier
+
+Supported report types:
+- urgent_alert
+- approval_request
+- stall_escalation
+- goal_completion
+- daily_summary
+- weekly_report
+- execution_summary
+- strategy_change
+- capability_escalation
+
+Respond only as JSON:
+{
+  "action": "update_routes" | "disable_all" | "unsupported" | "ambiguous",
+  "selected_notifiers": ["discord-bot"],
+  "report_types": ["weekly_report"],
+  "mode": "all" | "only" | "none" | null,
+  "enabled": true | false | null,
+  "confidence": 0.0-1.0,
+  "clarification": "question or explanation when ambiguous/unsupported",
+  "reason": "short rationale"
+}`;
 }

--- a/src/tools/mutation/ConfigureNotificationRoutingTool/ConfigureNotificationRoutingTool.ts
+++ b/src/tools/mutation/ConfigureNotificationRoutingTool/ConfigureNotificationRoutingTool.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMetadata, ToolDescriptionContext } from "../../types.js";
 import { applyNaturalLanguageNotificationRouting } from "../../../runtime/notification-routing.js";
+import { buildLLMClient } from "../../../base/llm/provider-factory.js";
+import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, READ_ONLY, PERMISSION_LEVEL } from "./constants.js";
 
@@ -8,6 +10,10 @@ export const ConfigureNotificationRoutingInputSchema = z.object({
   instruction: z.string().min(1, "instruction is required"),
 });
 export type ConfigureNotificationRoutingInput = z.infer<typeof ConfigureNotificationRoutingInputSchema>;
+
+export interface ConfigureNotificationRoutingToolDeps {
+  buildLLMClient?: () => Promise<Pick<ILLMClient, "sendMessage" | "parseJSON">>;
+}
 
 export class ConfigureNotificationRoutingTool implements ITool<ConfigureNotificationRoutingInput, unknown> {
   readonly metadata: ToolMetadata = {
@@ -24,6 +30,8 @@ export class ConfigureNotificationRoutingTool implements ITool<ConfigureNotifica
   };
   readonly inputSchema = ConfigureNotificationRoutingInputSchema;
 
+  constructor(private readonly deps: ConfigureNotificationRoutingToolDeps = {}) {}
+
   description(_context?: ToolDescriptionContext): string {
     return DESCRIPTION;
   }
@@ -31,11 +39,13 @@ export class ConfigureNotificationRoutingTool implements ITool<ConfigureNotifica
   async call(input: ConfigureNotificationRoutingInput, _context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
     try {
-      const update = await applyNaturalLanguageNotificationRouting(input.instruction);
+      const llmClient = await (this.deps.buildLLMClient ?? buildLLMClient)();
+      const update = await applyNaturalLanguageNotificationRouting(input.instruction, undefined, { llmClient });
       return {
-        success: true,
+        success: update.applied,
         data: update,
         summary: update.summary,
+        error: update.applied ? undefined : update.summary,
         durationMs: Date.now() - startTime,
       };
     } catch (err) {

--- a/src/tools/mutation/ConfigureNotificationRoutingTool/__tests__/ConfigureNotificationRoutingTool.test.ts
+++ b/src/tools/mutation/ConfigureNotificationRoutingTool/__tests__/ConfigureNotificationRoutingTool.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { ConfigureNotificationRoutingTool } from "../ConfigureNotificationRoutingTool.js";
 import type { ToolCallContext } from "../../../types.js";
+import type { ILLMClient } from "../../../../base/llm/llm-client.js";
 
 vi.mock("../../../../base/utils/paths.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../../base/utils/paths.js")>();
@@ -25,6 +26,18 @@ function makeContext(): ToolCallContext {
   };
 }
 
+function llmDecision(decision: unknown): Pick<ILLMClient, "sendMessage" | "parseJSON"> {
+  return {
+    sendMessage: async () => ({
+      content: JSON.stringify(decision),
+      usage: { input_tokens: 0, output_tokens: 0 },
+      stop_reason: "stop",
+    }),
+    parseJSON: ((content: string, schema: { parse: (value: unknown) => unknown }) =>
+      schema.parse(JSON.parse(content))) as Pick<ILLMClient, "sendMessage" | "parseJSON">["parseJSON"],
+  };
+}
+
 describe("ConfigureNotificationRoutingTool", () => {
   let tmpDir: string;
 
@@ -38,7 +51,17 @@ describe("ConfigureNotificationRoutingTool", () => {
   });
 
   it("writes plugin notifier routing from a natural language instruction", async () => {
-    const tool = new ConfigureNotificationRoutingTool();
+    const tool = new ConfigureNotificationRoutingTool({
+      buildLLMClient: async () => llmDecision({
+        action: "update_routes",
+        selected_notifiers: ["discord-bot"],
+        report_types: ["weekly_report"],
+        mode: "only",
+        enabled: true,
+        confidence: 0.94,
+        reason: "weekly report exclusive route",
+      }),
+    });
 
     const result = await tool.call(
       { instruction: "週次レポートはDiscordだけに送って" },
@@ -59,6 +82,29 @@ describe("ConfigureNotificationRoutingTool", () => {
         },
       ],
     });
+  });
+
+  it("does not write plugin notifier routing when the parser returns ambiguous", async () => {
+    const tool = new ConfigureNotificationRoutingTool({
+      buildLLMClient: async () => llmDecision({
+        action: "ambiguous",
+        selected_notifiers: [],
+        report_types: [],
+        mode: null,
+        enabled: null,
+        confidence: 0.25,
+        clarification: "Specify the notifier target.",
+        reason: "missing notifier",
+      }),
+    });
+
+    const result = await tool.call(
+      { instruction: "通知いい感じにして" },
+      makeContext()
+    );
+
+    expect(result.success).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, "notification.json"))).toBe(false);
   });
 
   it("requires approval when not pre-approved", async () => {


### PR DESCRIPTION
Closes #872

## 実装要約
- Replaced notification routing keyword/includes detectors with a typed `NotificationRoutingDecision` schema covering action, selected notifiers, report types, mode, enabled flag, confidence, clarification, and reason.
- Natural-language routing now goes through structured parser output via `llmClient.sendMessage` + `parseJSON`; ambiguous, unsupported, low-confidence, parse-failure, or model-unavailable decisions are no-op/blocked and do not save config.
- Wired the CLI `notify route` and `ConfigureNotificationRoutingTool` caller paths through the parser while preserving the existing tool approval gate and notification config schema/dispatcher compatibility.
- Added runtime, CLI, and tool tests for multilingual routing, selected notifier disable, disable-all, ambiguous no-op, parser-unavailable no-op, and invalid config preservation.

## 検証コマンド
- `npm exec -- vitest run src/runtime/__tests__/notification-routing.test.ts src/tools/mutation/ConfigureNotificationRoutingTool/__tests__/ConfigureNotificationRoutingTool.test.ts src/interface/cli/__tests__/cli-notify.test.ts` - pass, 27 tests
- `npm run typecheck` - pass
- `npm run lint:boundaries` - pass, 0 errors with existing warnings
- `npm run test:changed` - pass
- `npm run test:all` - pass
- Fresh review - LGTM

## 既知の未解決リスク
- `notify route` now requires an available model-backed structured parser for natural-language updates; when unavailable it intentionally returns no-op instead of falling back to keyword matching.
- Existing repository-wide lint warnings remain outside this change.