### PR TITLE
feat(memory): add auditable correction ledger

### DIFF
--- a/src/interface/tui/__tests__/dashboard.test.ts
+++ b/src/interface/tui/__tests__/dashboard.test.ts
@@ -123,6 +123,8 @@ function evidenceSummary(overrides: Partial<RuntimeEvidenceSummary> = {}): Runti
     research_memos: [],
     dream_checkpoints: [],
     divergent_exploration: [],
+    corrections: [],
+    correction_state: {},
     candidate_lineages: [],
     recommended_candidate_portfolio: [],
     candidate_selection_summary: {

--- a/src/platform/corrections/__tests__/memory-correction-ledger.test.ts
+++ b/src/platform/corrections/__tests__/memory-correction-ledger.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import {
+  AgentMemoryEntrySchema,
+} from "../../knowledge/types/agent-memory.js";
+import {
+  correctionStateForTarget,
+  memoryCorrectionTargetKey,
+  MemoryCorrectionEntrySchema,
+  summarizeMemoryCorrectionState,
+} from "../memory-correction-ledger.js";
+
+describe("memory correction ledger", () => {
+  it("marks an agent memory as corrected while preserving the original entry for audit", () => {
+    const original = AgentMemoryEntrySchema.parse({
+      id: "memory-old",
+      key: "user.preference.editor",
+      value: "User prefers Vim.",
+      status: "compiled",
+      created_at: "2026-05-02T00:00:00.000Z",
+      updated_at: "2026-05-02T00:00:00.000Z",
+    });
+    const replacement = AgentMemoryEntrySchema.parse({
+      id: "memory-new",
+      key: "user.preference.editor",
+      value: "User prefers VS Code.",
+      status: "compiled",
+      supersedes_memory_id: original.id,
+      created_at: "2026-05-02T00:01:00.000Z",
+      updated_at: "2026-05-02T00:01:00.000Z",
+    });
+    const correction = MemoryCorrectionEntrySchema.parse({
+      correction_id: "corr-agent-memory",
+      target_ref: { kind: "agent_memory", id: original.id },
+      correction_kind: "corrected",
+      replacement_ref: { kind: "agent_memory", id: replacement.id },
+      actor: "user",
+      reason: "User corrected the stored editor preference.",
+      created_at: "2026-05-02T00:02:00.000Z",
+      provenance: { source: "user", confidence: 1 },
+    });
+
+    const state = correctionStateForTarget(
+      summarizeMemoryCorrectionState([correction]),
+      { kind: "agent_memory", id: original.id }
+    );
+
+    expect(original.value).toBe("User prefers Vim.");
+    expect(replacement.supersedes_memory_id).toBe(original.id);
+    expect(state).toMatchObject({
+      status: "corrected",
+      active: false,
+      latest_correction_id: "corr-agent-memory",
+      retained_for_audit: true,
+      replacement_ref: { kind: "agent_memory", id: replacement.id },
+    });
+  });
+
+  it("keeps scoped runtime targets distinct when ids are reused across runs", () => {
+    const runA = { kind: "runtime_evidence" as const, id: "entry-1", scope: { run_id: "run-a" } };
+    const runB = { kind: "runtime_evidence" as const, id: "entry-1", scope: { run_id: "run-b" } };
+
+    expect(memoryCorrectionTargetKey(runA)).toBe(JSON.stringify(["runtime_evidence", "entry-1", null, "run-a", null]));
+    expect(memoryCorrectionTargetKey(runB)).toBe(JSON.stringify(["runtime_evidence", "entry-1", null, "run-b", null]));
+    expect(memoryCorrectionTargetKey(runA)).not.toBe(memoryCorrectionTargetKey(runB));
+  });
+
+  it("does not collide when ids contain scope-like delimiters", () => {
+    const unscoped = { kind: "runtime_evidence" as const, id: "entry-1:run=run-a" };
+    const scoped = { kind: "runtime_evidence" as const, id: "entry-1", scope: { run_id: "run-a" } };
+
+    expect(memoryCorrectionTargetKey(unscoped)).not.toBe(memoryCorrectionTargetKey(scoped));
+  });
+});

--- a/src/platform/corrections/index.ts
+++ b/src/platform/corrections/index.ts
@@ -1,0 +1,1 @@
+export * from "./memory-correction-ledger.js";

--- a/src/platform/corrections/memory-correction-ledger.ts
+++ b/src/platform/corrections/memory-correction-ledger.ts
@@ -1,0 +1,149 @@
+import { z } from "zod";
+
+export const MemoryCorrectionTargetKindSchema = z.enum([
+  "agent_memory",
+  "soil_record",
+  "runtime_evidence",
+  "dream_checkpoint",
+]);
+export type MemoryCorrectionTargetKind = z.infer<typeof MemoryCorrectionTargetKindSchema>;
+
+export const MemoryCorrectionKindSchema = z.enum([
+  "corrected",
+  "superseded",
+  "retracted",
+  "forgotten",
+  "quarantined",
+]);
+export type MemoryCorrectionKind = z.infer<typeof MemoryCorrectionKindSchema>;
+
+export const MemoryCorrectionActorSchema = z.enum([
+  "user",
+  "dream_lint",
+  "runtime_verification",
+  "manual_tool",
+]);
+export type MemoryCorrectionActor = z.infer<typeof MemoryCorrectionActorSchema>;
+
+export const MemoryCorrectionAuditStatusSchema = z.enum([
+  "active",
+  "superseded",
+  "disputed",
+  "destructive_delete_requested",
+]);
+export type MemoryCorrectionAuditStatus = z.infer<typeof MemoryCorrectionAuditStatusSchema>;
+
+export const MemoryCorrectionTargetRefSchema = z.object({
+  kind: MemoryCorrectionTargetKindSchema,
+  id: z.string().min(1),
+  scope: z.object({
+    goal_id: z.string().min(1).optional(),
+    run_id: z.string().min(1).optional(),
+    task_id: z.string().min(1).optional(),
+  }).strict().optional(),
+}).strict();
+export type MemoryCorrectionTargetRef = z.infer<typeof MemoryCorrectionTargetRefSchema>;
+
+export const MemoryCorrectionProvenanceSchema = z.object({
+  source: MemoryCorrectionActorSchema,
+  source_ref: z.string().min(1).optional(),
+  evidence_ref: z.string().min(1).optional(),
+  confidence: z.number().min(0).max(1).nullable().default(null),
+  note: z.string().min(1).optional(),
+}).strict();
+export type MemoryCorrectionProvenance = z.infer<typeof MemoryCorrectionProvenanceSchema>;
+
+export const MemoryCorrectionAuditSchema = z.object({
+  status: MemoryCorrectionAuditStatusSchema.default("active"),
+  retained_for_audit: z.boolean().default(true),
+  destructive_delete_approved_at: z.string().datetime().nullable().default(null),
+}).strict();
+export type MemoryCorrectionAudit = z.infer<typeof MemoryCorrectionAuditSchema>;
+
+export const MemoryCorrectionEntrySchema = z.object({
+  schema_version: z.literal("memory-correction-entry-v1").default("memory-correction-entry-v1"),
+  correction_id: z.string().min(1),
+  target_ref: MemoryCorrectionTargetRefSchema,
+  correction_kind: MemoryCorrectionKindSchema,
+  replacement_ref: MemoryCorrectionTargetRefSchema.nullable().default(null),
+  actor: MemoryCorrectionActorSchema,
+  reason: z.string().min(1),
+  created_at: z.string().datetime(),
+  provenance: MemoryCorrectionProvenanceSchema,
+  audit: MemoryCorrectionAuditSchema.default({}),
+}).strict();
+export type MemoryCorrectionEntry = z.infer<typeof MemoryCorrectionEntrySchema>;
+export type MemoryCorrectionEntryInput = z.input<typeof MemoryCorrectionEntrySchema>;
+
+export const MemoryCorrectionLedgerFileSchema = z.object({
+  schema_version: z.literal("memory-correction-ledger-v1").default("memory-correction-ledger-v1"),
+  generated_at: z.string().datetime(),
+  entries: z.array(MemoryCorrectionEntrySchema).default([]),
+}).strict();
+export type MemoryCorrectionLedgerFile = z.infer<typeof MemoryCorrectionLedgerFileSchema>;
+
+export const MemoryCorrectionTargetStateSchema = z.object({
+  target_ref: MemoryCorrectionTargetRefSchema,
+  status: z.enum(["active", "corrected", "superseded", "retracted", "forgotten", "quarantined"]),
+  active: z.boolean(),
+  latest_correction_id: z.string().min(1).nullable().default(null),
+  replacement_ref: MemoryCorrectionTargetRefSchema.nullable().default(null),
+  retained_for_audit: z.boolean().default(true),
+  reason: z.string().min(1).nullable().default(null),
+  updated_at: z.string().datetime().nullable().default(null),
+}).strict();
+export type MemoryCorrectionTargetState = z.infer<typeof MemoryCorrectionTargetStateSchema>;
+
+const inactiveCorrectionKinds = new Set<MemoryCorrectionKind>([
+  "corrected",
+  "superseded",
+  "retracted",
+  "forgotten",
+  "quarantined",
+]);
+
+export function memoryCorrectionTargetKey(ref: MemoryCorrectionTargetRef): string {
+  return JSON.stringify([
+    ref.kind,
+    ref.id,
+    ref.scope?.goal_id ?? null,
+    ref.scope?.run_id ?? null,
+    ref.scope?.task_id ?? null,
+  ]);
+}
+
+export function isMemoryCorrectionInactive(kind: MemoryCorrectionKind): boolean {
+  return inactiveCorrectionKinds.has(kind);
+}
+
+export function summarizeMemoryCorrectionState(
+  entries: MemoryCorrectionEntry[]
+): Record<string, MemoryCorrectionTargetState> {
+  const states: Record<string, MemoryCorrectionTargetState> = {};
+  for (const entry of [...entries].sort((left, right) => left.created_at.localeCompare(right.created_at))) {
+    if (entry.audit.status !== "active") continue;
+    const key = memoryCorrectionTargetKey(entry.target_ref);
+    states[key] = MemoryCorrectionTargetStateSchema.parse({
+      target_ref: entry.target_ref,
+      status: entry.correction_kind,
+      active: !isMemoryCorrectionInactive(entry.correction_kind),
+      latest_correction_id: entry.correction_id,
+      replacement_ref: entry.replacement_ref,
+      retained_for_audit: entry.audit.retained_for_audit,
+      reason: entry.reason,
+      updated_at: entry.created_at,
+    });
+  }
+  return states;
+}
+
+export function correctionStateForTarget(
+  states: Record<string, MemoryCorrectionTargetState>,
+  ref: MemoryCorrectionTargetRef
+): MemoryCorrectionTargetState {
+  return states[memoryCorrectionTargetKey(ref)] ?? MemoryCorrectionTargetStateSchema.parse({
+    target_ref: ref,
+    status: "active",
+    active: true,
+  });
+}

--- a/src/platform/dream/dream-soil-mutation.ts
+++ b/src/platform/dream/dream-soil-mutation.ts
@@ -97,6 +97,16 @@ function soilRecordStatusForAgentMemoryStatus(status: AgentMemoryStatus): SoilRe
       return "confirmed";
     case "archived":
       return "archived";
+    case "corrected":
+      return "corrected";
+    case "superseded":
+      return "superseded";
+    case "retracted":
+      return "retracted";
+    case "forgotten":
+      return "forgotten";
+    case "quarantined":
+      return "quarantined";
   }
 }
 

--- a/src/platform/dream/dream-types.ts
+++ b/src/platform/dream/dream-types.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MemoryCorrectionTargetStateSchema } from "../corrections/memory-correction-ledger.js";
 import { LearnedPatternSchema } from "../knowledge/types/learning.js";
 import { ScheduleTriggerSchema } from "../../runtime/types/schedule.js";
 
@@ -364,6 +365,7 @@ export const DreamActivationArtifactSchema = z.object({
   summary: z.string().min(1),
   payload: z.record(z.string(), z.unknown()).default({}),
   evidence_refs: z.array(z.string()).default([]),
+  correction_state: MemoryCorrectionTargetStateSchema.optional(),
   confidence: z.number().min(0).max(1),
   valid_from: z.string(),
   valid_to: z.string().nullable().default(null),

--- a/src/platform/knowledge/types/agent-memory.ts
+++ b/src/platform/knowledge/types/agent-memory.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MemoryCorrectionTargetStateSchema } from "../../corrections/memory-correction-ledger.js";
 
 // --- AgentMemoryType ---
 
@@ -12,7 +13,7 @@ export type AgentMemoryType = z.infer<typeof AgentMemoryTypeEnum>;
 
 // --- AgentMemoryStatus ---
 
-export const AgentMemoryStatusEnum = z.enum(["raw", "compiled", "archived"]);
+export const AgentMemoryStatusEnum = z.enum(["raw", "compiled", "archived", "corrected", "superseded", "retracted", "forgotten", "quarantined"]);
 export type AgentMemoryStatus = z.infer<typeof AgentMemoryStatusEnum>;
 
 // --- AgentMemoryEntry ---
@@ -26,6 +27,8 @@ export const AgentMemoryEntrySchema = z.object({
   category: z.string().optional(),
   memory_type: AgentMemoryTypeEnum.default("fact"),
   status: AgentMemoryStatusEnum.default("raw"),
+  correction_state: MemoryCorrectionTargetStateSchema.optional(),
+  supersedes_memory_id: z.string().min(1).optional(),
   compiled_from: z.array(z.string()).optional(),
   created_at: z.string(),
   updated_at: z.string(),

--- a/src/platform/soil/__tests__/sqlite-repository.test.ts
+++ b/src/platform/soil/__tests__/sqlite-repository.test.ts
@@ -243,6 +243,144 @@ describe("SqliteSoilRepository", () => {
     expect(pages.get("rec-1")?.[0]?.relative_path).toBe("identity/preferences.md");
   });
 
+  it("records auditable corrections for Soil records without deleting the original", async () => {
+    await repo.applyMutation({
+      records: [
+        {
+          record_id: "soil-old",
+          record_key: "preference.editor",
+          version: 1,
+          record_type: "preference",
+          soil_id: "memory/preferences/editor-old",
+          title: "Editor preference",
+          summary: "User prefers Vim.",
+          canonical_text: "User prefers Vim.",
+          goal_id: null,
+          task_id: null,
+          status: "active",
+          confidence: 0.8,
+          importance: null,
+          source_reliability: 0.8,
+          valid_from: null,
+          valid_to: null,
+          supersedes_record_id: null,
+          is_active: true,
+          source_type: "agent_memory",
+          source_id: "memory-old",
+          metadata_json: {},
+          created_at: "2026-05-02T00:00:00.000Z",
+          updated_at: "2026-05-02T00:00:00.000Z",
+        },
+        {
+          record_id: "soil-new",
+          record_key: "preference.editor.corrected",
+          version: 1,
+          record_type: "preference",
+          soil_id: "memory/preferences/editor-new",
+          title: "Editor preference corrected",
+          summary: "User prefers VS Code.",
+          canonical_text: "User prefers VS Code.",
+          goal_id: null,
+          task_id: null,
+          status: "active",
+          confidence: 1,
+          importance: null,
+          source_reliability: 1,
+          valid_from: null,
+          valid_to: null,
+          supersedes_record_id: null,
+          is_active: true,
+          source_type: "manual_tool",
+          source_id: "correction",
+          metadata_json: {},
+          created_at: "2026-05-02T00:01:00.000Z",
+          updated_at: "2026-05-02T00:01:00.000Z",
+        },
+      ],
+      corrections: [{
+        correction_id: "corr-soil",
+        target_ref: { kind: "soil_record", id: "soil-old" },
+        correction_kind: "corrected",
+        replacement_ref: { kind: "soil_record", id: "soil-new" },
+        actor: "manual_tool",
+        reason: "Corrected editor preference.",
+        created_at: "2026-05-02T00:02:00.000Z",
+        provenance: { source: "manual_tool", source_ref: "memory-correct", confidence: 1 },
+      }],
+    });
+
+    const records = await repo.loadRecords({ active_only: false, record_ids: ["soil-old", "soil-new"] });
+    const corrections = await repo.loadCorrections(["soil-old"]);
+
+    expect(records.find((record) => record.record_id === "soil-old")).toMatchObject({
+      status: "corrected",
+      is_active: false,
+    });
+    expect(records.find((record) => record.record_id === "soil-new")?.supersedes_record_id).toBe("soil-old");
+    expect(corrections[0]).toMatchObject({
+      correction_id: "corr-soil",
+      target_ref: { kind: "soil_record", id: "soil-old" },
+      replacement_ref: { kind: "soil_record", id: "soil-new" },
+      audit: { retained_for_audit: true },
+    });
+  });
+
+  it("stores non-active Soil correction audit entries without invalidating the target", async () => {
+    await repo.applyMutation({
+      records: [
+        {
+          record_id: "soil-disputed",
+          record_key: "preference.shell",
+          version: 1,
+          record_type: "preference",
+          soil_id: "memory/preferences/shell",
+          title: "Shell preference",
+          summary: "User prefers zsh.",
+          canonical_text: "User prefers zsh.",
+          goal_id: null,
+          task_id: null,
+          status: "active",
+          confidence: 0.8,
+          importance: null,
+          source_reliability: 0.8,
+          valid_from: null,
+          valid_to: null,
+          supersedes_record_id: null,
+          is_active: true,
+          source_type: "agent_memory",
+          source_id: "memory-shell",
+          metadata_json: {},
+          created_at: "2026-05-02T00:00:00.000Z",
+          updated_at: "2026-05-02T00:00:00.000Z",
+        },
+      ],
+      corrections: [{
+        correction_id: "corr-soil-disputed",
+        target_ref: { kind: "soil_record", id: "soil-disputed" },
+        correction_kind: "retracted",
+        replacement_ref: null,
+        actor: "manual_tool",
+        reason: "Operator opened a dispute but did not activate the correction.",
+        created_at: "2026-05-02T00:03:00.000Z",
+        provenance: { source: "manual_tool", source_ref: "memory-history", confidence: 0.4 },
+        audit: { status: "disputed", retained_for_audit: true, destructive_delete_approved_at: null },
+      }],
+    });
+
+    const records = await repo.loadRecords({ active_only: false, record_ids: ["soil-disputed"] });
+    const corrections = await repo.loadCorrections(["soil-disputed"]);
+
+    expect(records[0]).toMatchObject({
+      status: "active",
+      is_active: true,
+      updated_at: "2026-05-02T00:00:00.000Z",
+    });
+    expect(corrections[0]).toMatchObject({
+      correction_id: "corr-soil-disputed",
+      audit: { status: "disputed" },
+    });
+  });
+
   it("deactivates older active versions for the same record_key", async () => {
     await repo.applyMutation({
       records: [

--- a/src/platform/soil/contracts.ts
+++ b/src/platform/soil/contracts.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { MemoryCorrectionEntrySchema } from "../corrections/memory-correction-ledger.js";
 import { SoilKindSchema, SoilRouteSchema, SoilStatusSchema } from "./types.js";
 
 export const SoilRecordTypeSchema = z.enum([
@@ -29,6 +30,10 @@ export const SoilRecordStatusSchema = z.enum([
   "deleted",
   "unreachable",
   "replaced",
+  "corrected",
+  "retracted",
+  "forgotten",
+  "quarantined",
 ]);
 export type SoilRecordStatus = z.infer<typeof SoilRecordStatusSchema>;
 
@@ -171,6 +176,15 @@ export const SoilTombstoneSchema = z.object({
   deleted_at: z.string().datetime(),
 });
 export type SoilTombstone = z.infer<typeof SoilTombstoneSchema>;
+
+export const SoilCorrectionEntrySchema = MemoryCorrectionEntrySchema.refine(
+  (entry) => entry.target_ref.kind === "soil_record",
+  {
+    message: "soil correction entries must target a soil_record",
+    path: ["target_ref", "kind"],
+  }
+);
+export type SoilCorrectionEntry = z.infer<typeof SoilCorrectionEntrySchema>;
 
 export const SoilPageFilterSchema = z.object({
   page_ids: z.array(z.string().min(1)).optional(),
@@ -336,6 +350,7 @@ export const SoilMutationSchema = z.object({
   embeddings: z.array(SoilEmbeddingSchema).default([]),
   edges: z.array(SoilEdgeSchema).default([]),
   tombstones: z.array(SoilTombstoneSchema).default([]),
+  corrections: z.array(SoilCorrectionEntrySchema).default([]),
 });
 export type SoilMutation = z.infer<typeof SoilMutationSchema>;
 export type SoilMutationInput = z.input<typeof SoilMutationSchema>;
@@ -343,6 +358,7 @@ export type SoilMutationInput = z.input<typeof SoilMutationSchema>;
 export interface SoilWriteRepository {
   applyMutation(mutation: SoilMutationInput): Promise<void>;
   queueReindex(recordIds: string[], reason: string): Promise<void>;
+  loadCorrections?(recordIds?: string[]): Promise<SoilCorrectionEntry[]>;
 }
 
 export interface SoilSearchRepository {

--- a/src/platform/soil/ddl.ts
+++ b/src/platform/soil/ddl.ts
@@ -115,6 +115,21 @@ CREATE TABLE IF NOT EXISTS soil_tombstones (
 CREATE INDEX IF NOT EXISTS soil_tombstones_lookup_idx
   ON soil_tombstones(record_key, version, deleted_at);
 
+CREATE TABLE IF NOT EXISTS soil_corrections (
+  correction_id TEXT PRIMARY KEY,
+  target_ref_json TEXT NOT NULL,
+  correction_kind TEXT NOT NULL,
+  replacement_ref_json TEXT,
+  actor TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  provenance_json TEXT NOT NULL,
+  audit_json TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS soil_corrections_target_idx
+  ON soil_corrections(correction_kind, created_at);
+
 CREATE TABLE IF NOT EXISTS soil_reindex_jobs (
   job_id TEXT PRIMARY KEY,
   scope TEXT NOT NULL,

--- a/src/platform/soil/sqlite-repository-storage.ts
+++ b/src/platform/soil/sqlite-repository-storage.ts
@@ -4,6 +4,7 @@ import {
   SoilEmbeddingSchema,
   SoilMutationSchema,
   SoilPageMemberSchema,
+  SoilCorrectionEntrySchema,
   type SoilMutationInput,
   type SoilPageMember,
 } from "./contracts.js";
@@ -203,6 +204,55 @@ export function applySoilMutation(db: SqliteDatabase, input: SoilMutationInput):
         for (const row of rows) {
           contentMutatedRecordIds.add(row.record_id);
         }
+      }
+    }
+
+    for (const correction of mutation.corrections) {
+      const parsed = SoilCorrectionEntrySchema.parse(correction);
+      db.prepare(`
+        INSERT INTO soil_corrections (
+          correction_id, target_ref_json, correction_kind, replacement_ref_json,
+          actor, reason, created_at, provenance_json, audit_json
+        ) VALUES (
+          @correction_id, @target_ref_json, @correction_kind, @replacement_ref_json,
+          @actor, @reason, @created_at, @provenance_json, @audit_json
+        )
+        ON CONFLICT(correction_id) DO UPDATE SET
+          target_ref_json = excluded.target_ref_json,
+          correction_kind = excluded.correction_kind,
+          replacement_ref_json = excluded.replacement_ref_json,
+          actor = excluded.actor,
+          reason = excluded.reason,
+          created_at = excluded.created_at,
+          provenance_json = excluded.provenance_json,
+          audit_json = excluded.audit_json
+      `).run({
+        correction_id: parsed.correction_id,
+        target_ref_json: serializeJson(parsed.target_ref),
+        correction_kind: parsed.correction_kind,
+        replacement_ref_json: parsed.replacement_ref ? serializeJson(parsed.replacement_ref) : null,
+        actor: parsed.actor,
+        reason: parsed.reason,
+        created_at: parsed.created_at,
+        provenance_json: serializeJson(parsed.provenance),
+        audit_json: serializeJson(parsed.audit),
+      });
+      if (parsed.audit.status !== "active") {
+        continue;
+      }
+      db.prepare(`
+        UPDATE soil_records
+        SET status = ?, is_active = 0, updated_at = ?
+        WHERE record_id = ?
+      `).run(parsed.correction_kind, parsed.created_at, parsed.target_ref.id);
+      contentMutatedRecordIds.add(parsed.target_ref.id);
+      if (parsed.replacement_ref?.kind === "soil_record") {
+        db.prepare(`
+          UPDATE soil_records
+          SET supersedes_record_id = COALESCE(supersedes_record_id, ?)
+          WHERE record_id = ?
+        `).run(parsed.target_ref.id, parsed.replacement_ref.id);
+        contentMutatedRecordIds.add(parsed.replacement_ref.id);
       }
     }
 

--- a/src/platform/soil/sqlite-repository.ts
+++ b/src/platform/soil/sqlite-repository.ts
@@ -7,6 +7,7 @@ import {
   SoilRecordFilterSchema,
   SoilSearchRequestSchema,
   type SoilCandidate,
+  type SoilCorrectionEntry,
   type SoilMutationInput,
   type SoilPage,
   type SoilPageMember,
@@ -99,6 +100,40 @@ export class SqliteSoilRepository implements SoilRepository {
       JSON.stringify({ record_ids: ids }),
       new Date().toISOString()
     );
+  }
+
+  async loadCorrections(recordIds: string[] = []): Promise<SoilCorrectionEntry[]> {
+    const ids = unique(recordIds);
+    const rows = this.db.prepare(`
+      SELECT *
+      FROM soil_corrections
+      ${ids.length > 0 ? `WHERE json_extract(target_ref_json, '$.id') IN (${ids.map(() => "?").join(", ")})` : ""}
+      ORDER BY created_at, correction_id
+    `).all(...ids) as Array<{
+      correction_id: string;
+      target_ref_json: string;
+      correction_kind: SoilCorrectionEntry["correction_kind"];
+      replacement_ref_json: string | null;
+      actor: SoilCorrectionEntry["actor"];
+      reason: string;
+      created_at: string;
+      provenance_json: string;
+      audit_json: string;
+    }>;
+    return rows.map((row) => ({
+      schema_version: "memory-correction-entry-v1",
+      correction_id: row.correction_id,
+      target_ref: JSON.parse(row.target_ref_json) as SoilCorrectionEntry["target_ref"],
+      correction_kind: row.correction_kind,
+      replacement_ref: row.replacement_ref_json
+        ? JSON.parse(row.replacement_ref_json) as SoilCorrectionEntry["replacement_ref"]
+        : null,
+      actor: row.actor,
+      reason: row.reason,
+      created_at: row.created_at,
+      provenance: JSON.parse(row.provenance_json) as SoilCorrectionEntry["provenance"],
+      audit: JSON.parse(row.audit_json) as SoilCorrectionEntry["audit"],
+    }));
   }
 
   async upsertPages(pages: SoilPage[]): Promise<void> {

--- a/src/runtime/__tests__/runtime-evidence-answer.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-answer.test.ts
@@ -61,6 +61,8 @@ function summary(overrides: Partial<RuntimeEvidenceSummary> = {}): RuntimeEviden
     research_memos: [],
     dream_checkpoints: [],
     divergent_exploration: [],
+    corrections: [],
+    correction_state: {},
     candidate_lineages: [],
     recommended_candidate_portfolio: [],
     candidate_selection_summary: {

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -42,6 +42,121 @@ describe("RuntimeEvidenceLedger", () => {
     expect(byRun.entries.map((entry) => entry.kind)).toEqual(["strategy", "verification"]);
   });
 
+  it("records runtime evidence corrections and exposes target correction state in summaries", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "runtime-evidence-old",
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      kind: "observation",
+      scope: { goal_id: "goal-correction", run_id: "run:correction" },
+      summary: "Incorrect observation kept for audit.",
+      outcome: "continued",
+    });
+    await ledger.append({
+      id: "runtime-evidence-new",
+      occurred_at: "2026-05-02T00:01:00.000Z",
+      kind: "observation",
+      scope: { goal_id: "goal-correction", run_id: "run:correction" },
+      summary: "Corrected observation.",
+      outcome: "continued",
+    });
+    await ledger.appendCorrection({
+      correction_id: "corr-runtime-evidence",
+      scope: { goal_id: "goal-correction", run_id: "run:correction" },
+      target_ref: { kind: "runtime_evidence", id: "runtime-evidence-old", scope: { run_id: "run:correction" } },
+      correction_kind: "superseded",
+      replacement_ref: { kind: "runtime_evidence", id: "runtime-evidence-new", scope: { run_id: "run:correction" } },
+      actor: "runtime_verification",
+      reason: "Verification superseded stale runtime evidence.",
+      created_at: "2026-05-02T00:02:00.000Z",
+      provenance: { source: "runtime_verification", evidence_ref: "runtime-evidence-new", confidence: 0.95 },
+    });
+
+    const summary = await new RuntimeEvidenceLedger(runtimeRoot).summarizeRun("run:correction");
+
+    expect(summary.total_entries).toBe(3);
+    expect(summary.corrections[0]).toMatchObject({
+      correction_id: "corr-runtime-evidence",
+      target_ref: { kind: "runtime_evidence", id: "runtime-evidence-old" },
+      replacement_ref: { kind: "runtime_evidence", id: "runtime-evidence-new" },
+    });
+    expect(summary.correction_state[JSON.stringify([
+      "runtime_evidence",
+      "runtime-evidence-old",
+      null,
+      "run:correction",
+      null,
+    ])]).toMatchObject({
+      status: "superseded",
+      active: false,
+      retained_for_audit: true,
+    });
+    expect((await ledger.readByRun("run:correction")).entries.map((entry) => entry.id)).toContain("runtime-evidence-old");
+  });
+
+  it("records Dream checkpoint memory-ref corrections in runtime summaries", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "dream-checkpoint-entry",
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      kind: "dream_checkpoint",
+      scope: { goal_id: "goal-dream", run_id: "run:dream" },
+      dream_checkpoints: [{
+        trigger: "iteration",
+        summary: "Checkpoint referenced a stale Soil memory.",
+        current_goal: "goal-dream",
+        active_dimensions: [],
+        best_evidence_so_far: "dream-checkpoint-entry",
+        recent_strategy_families: [],
+        exhausted: [],
+        promising: [],
+        relevant_memories: [{
+          source_type: "soil",
+          ref: "soil://memory/stale",
+          summary: "Stale memory ref.",
+          authority: "advisory_only",
+          source_reliability: 0.9,
+          retrieval: { kind: "checkpoint", confidence: 0.9 },
+        }],
+        active_hypotheses: [],
+        rejected_approaches: [],
+        next_strategy_candidates: [],
+        guidance: "Use stale memory.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.7,
+      }],
+      summary: "Dream checkpoint with stale memory.",
+      outcome: "continued",
+    });
+    await ledger.appendCorrection({
+      correction_id: "corr-dream-checkpoint",
+      scope: { goal_id: "goal-dream", run_id: "run:dream" },
+      target_ref: { kind: "dream_checkpoint", id: "soil://memory/stale", scope: { run_id: "run:dream" } },
+      correction_kind: "retracted",
+      replacement_ref: null,
+      actor: "dream_lint",
+      reason: "Dream lint retracted the stale memory ref.",
+      created_at: "2026-05-02T00:01:00.000Z",
+      provenance: { source: "dream_lint", evidence_ref: "dream-checkpoint-entry", confidence: 0.8 },
+    });
+
+    const summary = await new RuntimeEvidenceLedger(runtimeRoot).summarizeRun("run:dream");
+
+    expect(summary.dream_checkpoints[0]?.relevant_memories[0]?.ref).toBe("soil://memory/stale");
+    expect(summary.correction_state[JSON.stringify([
+      "dream_checkpoint",
+      "soil://memory/stale",
+      null,
+      "run:dream",
+      null,
+    ])]).toMatchObject({
+      status: "retracted",
+      active: false,
+      latest_correction_id: "corr-dream-checkpoint",
+    });
+  });
+
   it("tolerates malformed JSONL rows and summarizes recent evidence", async () => {
     const ledger = new RuntimeEvidenceLedger(runtimeRoot);
     await ledger.append({

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -7,6 +7,14 @@ import {
   ensureRuntimeStorePaths,
   type RuntimeStorePaths,
 } from "./runtime-paths.js";
+import {
+  MemoryCorrectionEntrySchema,
+  MemoryCorrectionTargetStateSchema,
+  summarizeMemoryCorrectionState,
+  type MemoryCorrectionEntry,
+  type MemoryCorrectionEntryInput,
+  type MemoryCorrectionTargetState,
+} from "../../platform/corrections/memory-correction-ledger.js";
 import { summarizeEvidenceMetricTrends, type MetricTrendContext } from "./metric-history.js";
 import {
   summarizeEvidenceEvaluatorResults,
@@ -51,6 +59,7 @@ export const RuntimeEvidenceEntryKindSchema = z.enum([
   "dream_checkpoint",
   "artifact",
   "failure",
+  "correction",
   "other",
 ]);
 export type RuntimeEvidenceEntryKind = z.infer<typeof RuntimeEvidenceEntryKindSchema>;
@@ -494,6 +503,8 @@ export const RuntimeEvidenceEntrySchema = z.object({
   research: z.array(RuntimeEvidenceResearchMemoSchema).optional(),
   dream_checkpoints: z.array(RuntimeEvidenceDreamCheckpointSchema).optional(),
   divergent_exploration: z.array(RuntimeEvidenceDivergentHypothesisSchema).optional(),
+  correction: MemoryCorrectionEntrySchema.optional(),
+  correction_state: MemoryCorrectionTargetStateSchema.optional(),
   candidates: z.array(RuntimeEvidenceCandidateRecordSchema).optional(),
   artifacts: z.array(RuntimeEvidenceArtifactRefSchema).default([]),
   result: z.object({
@@ -661,6 +672,8 @@ export interface RuntimeEvidenceSummary {
   research_memos: RuntimeResearchMemoContext[];
   dream_checkpoints: RuntimeDreamCheckpointContext[];
   divergent_exploration: RuntimeEvidenceDivergentHypothesis[];
+  corrections: MemoryCorrectionEntry[];
+  correction_state: Record<string, MemoryCorrectionTargetState>;
   candidate_lineages: RuntimeCandidateLineageContext[];
   recommended_candidate_portfolio: RuntimeCandidatePortfolioSlot[];
   candidate_selection_summary: RuntimeCandidateSelectionSummary;
@@ -683,6 +696,10 @@ export interface RuntimeEvidenceSummaryIndex {
 
 export interface RuntimeEvidenceLedgerPort {
   append(input: RuntimeEvidenceEntryInput): Promise<RuntimeEvidenceEntry[]>;
+  appendCorrection?(input: MemoryCorrectionEntryInput & {
+    scope: RuntimeEvidenceEntry["scope"];
+    evidence_id?: string;
+  }): Promise<MemoryCorrectionEntry>;
   readByGoal?(goalId: string): Promise<RuntimeEvidenceReadResult>;
   readByRun?(runId: string): Promise<RuntimeEvidenceReadResult>;
   summarizeGoal?(goalId: string): Promise<RuntimeEvidenceSummary>;
@@ -741,6 +758,27 @@ export class RuntimeEvidenceLedger implements RuntimeEvidenceLedgerPort {
       await rebuildSummaryIndex(target, this.paths);
     }));
     return [entry];
+  }
+
+  async appendCorrection(input: MemoryCorrectionEntryInput & {
+    scope: RuntimeEvidenceEntry["scope"];
+    evidence_id?: string;
+  }): Promise<MemoryCorrectionEntry> {
+    const { scope, evidence_id, ...correctionInput } = input;
+    const correction = MemoryCorrectionEntrySchema.parse(correctionInput);
+    await this.append({
+      id: evidence_id ?? correction.correction_id,
+      occurred_at: correction.created_at,
+      kind: "correction",
+      scope,
+      correction,
+      summary: correction.reason,
+      raw_refs: [{
+        kind: correction.target_ref.kind,
+        id: correction.target_ref.id,
+      }],
+    });
+    return correction;
   }
 
   async readByGoal(goalId: string): Promise<RuntimeEvidenceReadResult> {
@@ -867,6 +905,9 @@ async function readSummaryIndex(
 
 function isCurrentEvidenceSummaryShape(summary: RuntimeEvidenceSummary): boolean {
   return Array.isArray(summary.candidate_lineages)
+    && Array.isArray(summary.corrections)
+    && typeof summary.correction_state === "object"
+    && summary.correction_state !== null
     && Array.isArray(summary.recommended_candidate_portfolio)
     && Array.isArray(summary.near_miss_candidates)
     && typeof summary.artifact_retention === "object"
@@ -940,6 +981,8 @@ function summarizeEvidence(
   manifests: RuntimeReproducibilityManifest[] = []
 ): RuntimeEvidenceSummary {
   const entries = [...read.entries].sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
+  const corrections = entries.flatMap((entry) => entry.correction ? [entry.correction] : []);
+  const correctionState = summarizeMemoryCorrectionState(corrections);
   const newestFirst = [...entries].reverse();
   const evaluatorSummary = summarizeEvidenceEvaluatorResults(entries);
   return {
@@ -959,6 +1002,8 @@ function summarizeEvidence(
       .flatMap((entry) => entry.divergent_exploration ?? [])
       .slice(-10)
       .reverse(),
+    corrections,
+    correction_state: correctionState,
     candidate_lineages: summarizeCandidateLineages(entries),
     recommended_candidate_portfolio: selectDiversifiedCandidatePortfolio(entries),
     candidate_selection_summary: summarizeCandidateSelection(entries, evaluatorSummary),


### PR DESCRIPTION
Closes #889

## Summary
- Add a typed memory correction ledger for agent memory, Soil records, runtime evidence, and Dream checkpoint refs.
- Persist Soil correction entries and expose runtime correction entries/state in evidence summaries while retaining original records for audit.
- Add lifecycle statuses and replacement links for corrected/superseded/retracted/forgotten/quarantined memory paths.

## Verification
- npm run typecheck
- npm run lint:boundaries (passes with existing warnings)
- npx vitest run src/platform/corrections/__tests__/memory-correction-ledger.test.ts src/runtime/__tests__/runtime-evidence-ledger.test.ts src/platform/soil/__tests__/sqlite-repository.test.ts
- npm run test:changed
- git diff --check

## Known risks
- Downstream filtering of retracted/default planning context is intentionally left for #890.
- Local better-sqlite3 needed `npm rebuild better-sqlite3` before SQLite tests could run under the active Node ABI.