### PR TITLE
feat(runtime): filter retracted memory from planning context

### DIFF
--- a/src/interface/tui/__tests__/dashboard.test.ts
+++ b/src/interface/tui/__tests__/dashboard.test.ts
@@ -105,6 +105,7 @@ function health(overrides: Partial<RuntimeHealthSnapshot["long_running"]> = {}):
 function evidenceSummary(overrides: Partial<RuntimeEvidenceSummary> = {}): RuntimeEvidenceSummary {
   return {
     schema_version: "runtime-evidence-summary-v1",
+    context_policy_version: "correction-filtered-planning-context-v1",
     generated_at: NOW.toISOString(),
     scope: { run_id: "run-1" },
     total_entries: 1,

--- a/src/platform/soil/__tests__/context-compiler.test.ts
+++ b/src/platform/soil/__tests__/context-compiler.test.ts
@@ -30,6 +30,10 @@ describe("Soil context compiler", () => {
       fallbackCandidates: [
         candidate({ chunk_id: "fallback-1", record_id: "record-fallback", soil_id: "knowledge/fallback" }),
       ],
+      routeTargetStates: [
+        { soilId: "context-routes", isActive: true, status: "active", lifecycleState: "active" },
+        { recordId: "record-route", isActive: true, status: "active", lifecycleState: "active" },
+      ],
       routes: [
         {
           route_id: "route-soil-platform",
@@ -161,6 +165,9 @@ describe("Soil context compiler", () => {
       fallbackCandidates: [
         candidate({ chunk_id: "fallback-1", record_id: "record-fallback", soil_id: "knowledge/fallback" }),
       ],
+      routeTargetStates: [
+        { soilId: "context-routes", isActive: true, status: "active", lifecycleState: "active" },
+      ],
       routes: [
         {
           route_id: "route-soil-platform",
@@ -229,6 +236,9 @@ describe("Soil context compiler", () => {
       now: () => new Date("2026-04-13T00:00:00.000Z"),
       targetPaths: ["src/platform/soil/context-compiler.ts"],
       staleRouteAfterMs: 24 * 60 * 60 * 1000,
+      routeTargetStates: [
+        { soilId: "context-routes", isActive: true, status: "active", lifecycleState: "active" },
+      ],
       routes: [
         {
           route_id: "route-soil-platform",
@@ -247,5 +257,41 @@ describe("Soil context compiler", () => {
       "Route route-soil-platform has not been evaluated since 2026-04-01T00:00:00.000Z.",
     ]);
     expect(compiled.trace.warnings).toEqual(compiled.warnings);
+  });
+
+  it("rejects route-provided inactive targets instead of admitting them into context", () => {
+    const compiled = compileSoilContext({
+      retrievalId: "retrieval-tombstoned-route",
+      now: () => new Date("2026-05-02T00:00:00.000Z"),
+      targetPaths: ["src/platform/soil/context-compiler.ts"],
+      routeTargetStates: [
+        {
+          recordId: "record-tombstoned",
+          isActive: false,
+          status: "retracted",
+          lifecycleState: "tombstoned",
+        },
+      ],
+      routes: [
+        {
+          route_id: "route-tombstoned",
+          path_globs: ["src/platform/soil/*"],
+          record_ids: ["record-tombstoned"],
+          reason: "Route points at old memory.",
+          created_at: "2026-05-02T00:00:00.000Z",
+          updated_at: "2026-05-02T00:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(compiled.items).toEqual([]);
+    expect(compiled.warnings).toEqual([
+      "Route route-tombstoned target record-tombstoned was rejected: route target is inactive and excluded from default context.",
+    ]);
+    expect(compiled.trace.decisions).toContainEqual(expect.objectContaining({
+      candidate_id: "route:route-tombstoned:record:record-tombstoned",
+      decision: "rejected",
+      reason: "route target is inactive and excluded from default context",
+    }));
   });
 });

--- a/src/platform/soil/__tests__/context-evaluation.test.ts
+++ b/src/platform/soil/__tests__/context-evaluation.test.ts
@@ -64,6 +64,9 @@ describe("Soil context evaluation", () => {
                 metadata_json: {},
               },
             ],
+            routeTargetStates: [
+              { soilId: "context-routes", isActive: true, status: "active", lifecycleState: "active" },
+            ],
             routes: [
               {
                 route_id: "route-soil",
@@ -141,4 +144,3 @@ describe("Soil context evaluation", () => {
     });
   });
 });
-

--- a/src/platform/soil/__tests__/sqlite-repository.test.ts
+++ b/src/platform/soil/__tests__/sqlite-repository.test.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { compileSoilContextFromRepository } from "../context-compiler.js";
 import { SqliteSoilRepository } from "../sqlite-repository.js";
 
 describe("SqliteSoilRepository", () => {
@@ -323,6 +324,163 @@ describe("SqliteSoilRepository", () => {
       replacement_ref: { kind: "soil_record", id: "soil-new" },
       audit: { retained_for_audit: true },
     });
+  });
+
+  it("excludes corrected records from default direct, lexical, dense, and hybrid retrieval", async () => {
+    await repo.applyMutation({
+      records: [
+        {
+          record_id: "retrieval-old",
+          record_key: "preference.retrieval.old",
+          version: 1,
+          record_type: "preference",
+          soil_id: "memory/preferences/retrieval-old",
+          title: "Retrieval preference old",
+          summary: "Stale retrieval preference.",
+          canonical_text: "Use the retired retrieval memory.",
+          goal_id: null,
+          task_id: null,
+          status: "active",
+          confidence: 0.8,
+          importance: null,
+          source_reliability: 0.8,
+          valid_from: null,
+          valid_to: null,
+          supersedes_record_id: null,
+          is_active: true,
+          source_type: "agent_memory",
+          source_id: "retrieval-old",
+          metadata_json: {},
+          created_at: "2026-05-02T00:00:00.000Z",
+          updated_at: "2026-05-02T00:00:00.000Z",
+        },
+        {
+          record_id: "retrieval-new",
+          record_key: "preference.retrieval.new",
+          version: 1,
+          record_type: "preference",
+          soil_id: "memory/preferences/retrieval-new",
+          title: "Retrieval preference new",
+          summary: "Active retrieval preference.",
+          canonical_text: "Use the active retrieval memory.",
+          goal_id: null,
+          task_id: null,
+          status: "active",
+          confidence: 1,
+          importance: null,
+          source_reliability: 1,
+          valid_from: null,
+          valid_to: null,
+          supersedes_record_id: null,
+          is_active: true,
+          source_type: "manual_tool",
+          source_id: "retrieval-new",
+          metadata_json: {},
+          created_at: "2026-05-02T00:01:00.000Z",
+          updated_at: "2026-05-02T00:01:00.000Z",
+        },
+      ],
+      chunks: [
+        {
+          chunk_id: "retrieval-old-chunk",
+          record_id: "retrieval-old",
+          soil_id: "memory/preferences/retrieval-old",
+          chunk_index: 0,
+          chunk_kind: "paragraph",
+          heading_path_json: [],
+          chunk_text: "Use the retired retrieval memory.",
+          token_count: 5,
+          checksum: "retrieval-old",
+          created_at: "2026-05-02T00:00:00.000Z",
+        },
+        {
+          chunk_id: "retrieval-new-chunk",
+          record_id: "retrieval-new",
+          soil_id: "memory/preferences/retrieval-new",
+          chunk_index: 0,
+          chunk_kind: "paragraph",
+          heading_path_json: [],
+          chunk_text: "Use the active retrieval memory.",
+          token_count: 5,
+          checksum: "retrieval-new",
+          created_at: "2026-05-02T00:01:00.000Z",
+        },
+      ],
+      embeddings: [
+        {
+          chunk_id: "retrieval-old-chunk",
+          model: "test-model",
+          embedding_version: 1,
+          encoding: "json",
+          embedding: [1, 0, 0],
+          embedded_at: "2026-05-02T00:00:00.000Z",
+        },
+        {
+          chunk_id: "retrieval-new-chunk",
+          model: "test-model",
+          embedding_version: 1,
+          encoding: "json",
+          embedding: [1, 0, 0],
+          embedded_at: "2026-05-02T00:01:00.000Z",
+        },
+      ],
+      corrections: [{
+        correction_id: "corr-retrieval-old",
+        target_ref: { kind: "soil_record", id: "retrieval-old" },
+        correction_kind: "retracted",
+        replacement_ref: { kind: "soil_record", id: "retrieval-new" },
+        actor: "manual_tool",
+        reason: "Retracted stale retrieval memory.",
+        created_at: "2026-05-02T00:02:00.000Z",
+        provenance: { source: "manual_tool", source_ref: "memory-retract", confidence: 1 },
+      }],
+    });
+
+    const direct = await repo.lookupDirect({ query: "memory/preferences/retrieval-old" });
+    const lexical = await repo.searchLexical({ query: "retired retrieval memory" });
+    const dense = await repo.searchDense({ query: "retrieval", query_embedding: [1, 0, 0] });
+    const hybrid = await repo.searchHybrid({ query: "retired retrieval memory", query_embedding: [1, 0, 0] });
+
+    expect(direct.candidates.map((item) => item.record_id)).not.toContain("retrieval-old");
+    expect(lexical.map((item) => item.record_id)).not.toContain("retrieval-old");
+    expect(dense.map((item) => item.record_id)).not.toContain("retrieval-old");
+    expect(hybrid.map((item) => item.record_id)).not.toContain("retrieval-old");
+    expect(dense.map((item) => item.record_id)).toContain("retrieval-new");
+
+    const compiled = await compileSoilContextFromRepository({
+      retrievalId: "retrieval-route-retracted",
+      now: () => new Date("2026-05-02T00:03:00.000Z"),
+      targetPaths: ["src/runtime/planning.ts"],
+      routeTargetStates: [
+        { recordId: "retrieval-old", isActive: true, status: "active", lifecycleState: "active" },
+      ],
+      routes: [{
+        route_id: "route-retracted-record",
+        path_globs: ["src/runtime/*"],
+        record_ids: ["retrieval-old"],
+        soil_ids: ["memory/preferences/retrieval-new"],
+        reason: "Route points at mixed active and retracted memory.",
+        created_at: "2026-05-02T00:00:00.000Z",
+        updated_at: "2026-05-02T00:00:00.000Z",
+      }],
+    }, repo);
+
+    expect(compiled.items).toEqual([
+      expect.objectContaining({
+        source: "route",
+        soilId: "memory/preferences/retrieval-new",
+      }),
+    ]);
+    expect(compiled.trace.decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        candidate_id: "route:route-retracted-record:record:retrieval-old",
+        decision: "rejected",
+      }),
+      expect.objectContaining({
+        candidate_id: "route:route-retracted-record:soil:memory/preferences/retrieval-new",
+        decision: "routed",
+      }),
+    ]));
   });
 
   it("stores non-active Soil correction audit entries without invalidating the target", async () => {

--- a/src/platform/soil/context-compiler.ts
+++ b/src/platform/soil/context-compiler.ts
@@ -10,9 +10,24 @@ import {
   type SoilContextRoute,
   type SoilContextRouteInput,
   type SoilMemoryLifecycleState,
+  type SoilRecord,
+  type SoilRecordStatus,
+  type SoilSearchRepository,
   type SoilRetrievalDecision,
   type SoilRetrievalTrace,
 } from "./contracts.js";
+
+export interface SoilRouteTargetState {
+  recordId?: string;
+  soilId?: string;
+  isActive: boolean;
+  status?: SoilRecordStatus;
+  lifecycleState?: SoilMemoryLifecycleState;
+}
+
+export interface SoilContextCompilerRepository {
+  loadRecords: SoilSearchRepository["loadRecords"];
+}
 
 export interface SoilContextCompilerInput {
   routes?: SoilContextRouteInput[];
@@ -26,6 +41,7 @@ export interface SoilContextCompilerInput {
   includeFallbackWhenRouteMatched?: boolean;
   minFallbackScore?: number;
   maxFallbackAdmitted?: number;
+  routeTargetStates?: SoilRouteTargetState[];
   staleRouteAfterMs?: number;
   now?: () => Date;
   retrievalId?: string;
@@ -51,6 +67,17 @@ export interface SoilCompiledContext {
 const DEFAULT_MIN_FALLBACK_SCORE = 0.2;
 const DEFAULT_MAX_FALLBACK_ADMITTED = 3;
 const DEFAULT_STALE_ROUTE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+const EXCLUDED_ROUTE_RECORD_STATUSES = new Set<SoilRecordStatus>([
+  "archived",
+  "deleted",
+  "expired",
+  "rejected",
+  "superseded",
+  "corrected",
+  "retracted",
+  "forgotten",
+  "quarantined",
+]);
 
 function nowIso(now?: () => Date): string {
   return (now?.() ?? new Date()).toISOString();
@@ -122,6 +149,78 @@ function fallbackRejectionReason(candidate: SoilCandidate, minScore: number): st
   return null;
 }
 
+function routeTargetStateKey(kind: "record" | "soil", id: string): string {
+  return JSON.stringify([kind, id]);
+}
+
+function routeTargetStateIndex(states: SoilRouteTargetState[] = []): Map<string, SoilRouteTargetState> {
+  const index = new Map<string, SoilRouteTargetState>();
+  for (const state of states) {
+    if (state.recordId) index.set(routeTargetStateKey("record", state.recordId), state);
+    if (state.soilId) index.set(routeTargetStateKey("soil", state.soilId), state);
+  }
+  return index;
+}
+
+function routeIdsForStateLookup(routes: SoilContextRouteInput[] = []): {
+  recordIds: string[];
+  soilIds: string[];
+} {
+  const recordIds = new Set<string>();
+  const soilIds = new Set<string>();
+  for (const route of routes) {
+    for (const recordId of route.record_ids ?? []) recordIds.add(recordId);
+    for (const soilId of route.soil_ids ?? []) soilIds.add(soilId);
+  }
+  return { recordIds: [...recordIds], soilIds: [...soilIds] };
+}
+
+function routeTargetStatesForRecords(records: SoilRecord[]): SoilRouteTargetState[] {
+  const states: SoilRouteTargetState[] = records.map((record) => ({
+    recordId: record.record_id,
+    soilId: record.soil_id,
+    isActive: record.is_active,
+    status: record.status,
+    lifecycleState: record.is_active ? "active" : "tombstoned",
+  }));
+  const recordsBySoilId = new Map<string, SoilRecord[]>();
+  for (const record of records) {
+    const recordsForSoil = recordsBySoilId.get(record.soil_id) ?? [];
+    recordsForSoil.push(record);
+    recordsBySoilId.set(record.soil_id, recordsForSoil);
+  }
+  for (const [soilId, recordsForSoil] of recordsBySoilId) {
+    const activeRecord = recordsForSoil.find((record) =>
+      record.is_active && routeTargetRejectionReason({
+        soilId,
+        isActive: true,
+        status: record.status,
+        lifecycleState: "active",
+      }) === null
+    );
+    const representative = activeRecord ?? recordsForSoil[0];
+    states.push({
+      soilId,
+      isActive: Boolean(activeRecord),
+      status: representative?.status,
+      lifecycleState: activeRecord ? "active" : "tombstoned",
+    });
+  }
+  return states;
+}
+
+function routeTargetRejectionReason(state: SoilRouteTargetState | undefined): string | null {
+  if (!state) return "route target state is unknown and excluded from default context";
+  if (!state.isActive) return "route target is inactive and excluded from default context";
+  if (state.lifecycleState && state.lifecycleState !== "active") {
+    return `route target lifecycle state ${state.lifecycleState} is excluded from default context`;
+  }
+  if (state.status && EXCLUDED_ROUTE_RECORD_STATUSES.has(state.status)) {
+    return `route target record status ${state.status} is excluded from default context`;
+  }
+  return null;
+}
+
 function dedupeItems(items: SoilCompiledContextItem[]): SoilCompiledContextItem[] {
   const seen = new Set<string>();
   const deduped: SoilCompiledContextItem[] = [];
@@ -183,7 +282,8 @@ function selectMatchingRoutes(input: SoilContextCompilerInput): RouteSelectionRe
 function compileRouteItems(
   routes: SoilContextRoute[],
   timestamp: string,
-  staleAfterMs: number
+  staleAfterMs: number,
+  targetStates: Map<string, SoilRouteTargetState>
 ): {
   warnings: string[];
   decisions: SoilRetrievalDecision[];
@@ -199,6 +299,20 @@ function compileRouteItems(
       warnings.push(staleWarning);
     }
     for (const soilId of route.soil_ids) {
+      const rejectionReason = routeTargetRejectionReason(targetStates.get(routeTargetStateKey("soil", soilId)));
+      if (rejectionReason) {
+        warnings.push(`Route ${route.route_id} target ${soilId} was rejected: ${rejectionReason}.`);
+        decisions.push({
+          candidate_id: `route:${route.route_id}:soil:${soilId}`,
+          decision: "rejected",
+          reason: rejectionReason,
+          score: null,
+          soil_id: soilId,
+          record_id: null,
+          route_id: route.route_id,
+        });
+        continue;
+      }
       decisions.push({
         candidate_id: `route:${route.route_id}:soil:${soilId}`,
         decision: "routed",
@@ -218,6 +332,20 @@ function compileRouteItems(
       });
     }
     for (const recordId of route.record_ids) {
+      const rejectionReason = routeTargetRejectionReason(targetStates.get(routeTargetStateKey("record", recordId)));
+      if (rejectionReason) {
+        warnings.push(`Route ${route.route_id} target ${recordId} was rejected: ${rejectionReason}.`);
+        decisions.push({
+          candidate_id: `route:${route.route_id}:record:${recordId}`,
+          decision: "rejected",
+          reason: rejectionReason,
+          score: null,
+          soil_id: null,
+          record_id: recordId,
+          route_id: route.route_id,
+        });
+        continue;
+      }
       decisions.push({
         candidate_id: `route:${route.route_id}:record:${recordId}`,
         decision: "routed",
@@ -359,7 +487,8 @@ export function compileSoilContext(input: SoilContextCompilerInput): SoilCompile
   const routeCompilation = compileRouteItems(
     routeSelection.routes,
     timestamp,
-    input.staleRouteAfterMs ?? DEFAULT_STALE_ROUTE_AFTER_MS
+    input.staleRouteAfterMs ?? DEFAULT_STALE_ROUTE_AFTER_MS,
+    routeTargetStateIndex(input.routeTargetStates)
   );
   const fallbackCandidates = fallbackCandidatesFor(input, routeSelection.routes);
 
@@ -404,4 +533,30 @@ export function compileSoilContext(input: SoilContextCompilerInput): SoilCompile
     compileMissObservations,
     warnings,
   };
+}
+
+export async function compileSoilContextFromRepository(
+  input: SoilContextCompilerInput,
+  repository: SoilContextCompilerRepository
+): Promise<SoilCompiledContext> {
+  const { recordIds, soilIds } = routeIdsForStateLookup(input.routes);
+  const recordsById = recordIds.length > 0
+    ? await repository.loadRecords({
+        active_only: false,
+        record_ids: recordIds,
+      })
+    : [];
+  const recordsBySoilId = soilIds.length > 0
+    ? await repository.loadRecords({
+        active_only: false,
+        soil_ids: soilIds,
+      })
+    : [];
+  return compileSoilContext({
+    ...input,
+    routeTargetStates: [
+      ...(input.routeTargetStates ?? []),
+      ...routeTargetStatesForRecords([...recordsById, ...recordsBySoilId]),
+    ],
+  });
 }

--- a/src/platform/soil/contracts.ts
+++ b/src/platform/soil/contracts.ts
@@ -198,6 +198,7 @@ export type SoilPageFilter = z.infer<typeof SoilPageFilterSchema>;
 
 export const SoilRecordFilterSchema = z.object({
   record_ids: z.array(z.string().min(1)).optional(),
+  soil_ids: z.array(z.string().min(1)).optional(),
   record_keys: z.array(z.string().min(1)).optional(),
   record_types: z.array(SoilRecordTypeSchema).optional(),
   statuses: z.array(SoilRecordStatusSchema).optional(),

--- a/src/platform/soil/sqlite-repository-search.ts
+++ b/src/platform/soil/sqlite-repository-search.ts
@@ -23,6 +23,7 @@ function hasExplicitMetadataFilter(request: SoilSearchRequest): boolean {
   const pageFilter = request.page_filter;
   return Boolean(
     recordFilter.record_ids?.length ||
+      recordFilter.soil_ids?.length ||
       recordFilter.record_keys?.length ||
       recordFilter.record_types?.length ||
       recordFilter.statuses?.length ||
@@ -51,6 +52,10 @@ export function buildRecordFilterSql(request: SoilSearchRequest, params: unknown
   if (filter.record_ids?.length) {
     clauses.push(`r.record_id IN (${filter.record_ids.map(() => "?").join(", ")})`);
     params.push(...filter.record_ids);
+  }
+  if (filter.soil_ids?.length) {
+    clauses.push(`r.soil_id IN (${filter.soil_ids.map(() => "?").join(", ")})`);
+    params.push(...filter.soil_ids);
   }
   if (filter.record_keys?.length) {
     clauses.push(`r.record_key IN (${filter.record_keys.map(() => "?").join(", ")})`);
@@ -170,6 +175,17 @@ export function lookupDirectCandidates(db: SqliteDatabase, input: SoilSearchRequ
   const pageParams: unknown[] = [request.query, request.query, request.query];
   const pageWhere = ["(soil_id = ? OR relative_path = ? OR page_id = ?)"];
   pageWhere.push(...buildPageFilterSql(request, pageParams));
+  if (request.record_filter.active_only) {
+    pageWhere.push(`
+      EXISTS (
+        SELECT 1
+        FROM soil_page_members active_spm
+        JOIN soil_records active_record ON active_record.record_id = active_spm.record_id
+        WHERE active_spm.page_id = p.page_id
+          AND active_record.is_active = 1
+      )
+    `);
+  }
   pageParams.push(request.limit);
   const pageMatches = db.prepare(`
     SELECT page_id, soil_id
@@ -224,8 +240,10 @@ export function lookupDirectCandidates(db: SqliteDatabase, input: SoilSearchRequ
       .prepare(`
         SELECT spm.page_id, spm.record_id, sc.chunk_id, sc.chunk_text
         FROM soil_page_members spm
+        JOIN soil_records r ON r.record_id = spm.record_id
         LEFT JOIN soil_chunks sc ON sc.record_id = spm.record_id
         WHERE spm.page_id IN (${pageIds.map(() => "?").join(", ")})
+          ${request.record_filter.active_only ? "AND r.is_active = 1" : ""}
         ORDER BY spm.page_id, spm.ordinal, sc.chunk_index
       `)
       .all(...pageIds) as Array<{

--- a/src/runtime/__tests__/dream-sidecar-review.test.ts
+++ b/src/runtime/__tests__/dream-sidecar-review.test.ts
@@ -109,6 +109,86 @@ describe("Runtime Dream sidecar review", () => {
     }));
   });
 
+  it("does not surface Dream checkpoint moves or memories backed by retracted memory refs", async () => {
+    await seedActiveRun("run:coreloop:retracted-memory");
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      id: "checkpoint-retracted-memory",
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      kind: "dream_checkpoint",
+      scope: { run_id: "run:coreloop:retracted-memory", loop_index: 1, phase: "dream_review_checkpoint" },
+      dream_checkpoints: [{
+        trigger: "iteration",
+        summary: "Checkpoint relied on a stale memory ref.",
+        current_goal: "Avoid stale memory",
+        active_dimensions: ["accuracy"],
+        recent_strategy_families: ["stale-memory-plan"],
+        exhausted: [],
+        promising: ["Use stale memory plan"],
+        relevant_memories: [{
+          source_type: "soil",
+          ref: "soil://memory/retracted",
+          summary: "Retracted memory.",
+          authority: "advisory_only",
+          relevance_score: 0.95,
+          source_reliability: 0.95,
+        }, {
+          source_type: "soil",
+          ref: "soil://memory/active",
+          summary: "Active memory.",
+          authority: "advisory_only",
+          relevance_score: 0.8,
+          source_reliability: 0.8,
+        }],
+        active_hypotheses: [],
+        rejected_approaches: [],
+        next_strategy_candidates: [{
+          title: "Use stale memory plan",
+          rationale: "This move is only justified by the retracted memory.",
+          target_dimensions: ["accuracy"],
+        }],
+        guidance: "Follow stale memory.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.9,
+      }],
+      raw_refs: [{ kind: "dream_soil_memory", id: "soil://memory/retracted" }],
+      summary: "Checkpoint with retracted memory.",
+      outcome: "continued",
+    });
+    await ledger.appendCorrection({
+      correction_id: "corr-sidecar-retracted-memory",
+      scope: { run_id: "run:coreloop:retracted-memory" },
+      target_ref: {
+        kind: "dream_checkpoint",
+        id: "soil://memory/retracted",
+        scope: { run_id: "run:coreloop:retracted-memory" },
+      },
+      correction_kind: "retracted",
+      replacement_ref: null,
+      actor: "dream_lint",
+      reason: "Memory ref was retracted before sidecar review.",
+      created_at: "2026-05-02T00:01:00.000Z",
+      provenance: { source: "dream_lint", evidence_ref: "checkpoint-retracted-memory", confidence: 1 },
+    });
+
+    const review = await createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:coreloop:retracted-memory",
+    });
+
+    expect(review.advisory_memories).not.toContainEqual(expect.objectContaining({
+      ref: "soil://memory/retracted",
+    }));
+    expect(review.advisory_memories).toContainEqual(expect.objectContaining({
+      ref: "soil://memory/active",
+    }));
+    expect(review.suggested_next_moves).not.toContainEqual(expect.objectContaining({
+      title: "Use stale memory plan",
+      source: "dream_checkpoint",
+    }));
+  });
+
   it("does not blindly re-suggest a rejected Dream approach", async () => {
     await seedActiveRun("run:coreloop:rejected");
     const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
@@ -134,12 +214,14 @@ describe("Runtime Dream sidecar review", () => {
         rejected_approaches: [{
           approach: "閾値スイープの再実行",
           rejection_reason: "3回のスイープが指標ノイズ内に収まった.",
+          candidate_ref: "candidate:threshold-sweep-repeat",
           evidence_ref: "lineage:threshold-sweep",
           revisit_condition: "new calibration evidence appears",
           confidence: 0.9,
         }],
         next_strategy_candidates: [
           {
+            candidate_ref: "candidate:threshold-sweep-repeat",
             title: "閾値スイープの再実行",
             rationale: "同じ探索をもう一度行う.",
             target_dimensions: ["balanced_accuracy"],
@@ -328,6 +410,11 @@ describe("Runtime Dream sidecar review", () => {
             title: "threshold_sweep retry",
             rationale: "Try the same threshold_sweep again.",
             target_dimensions: ["balanced_accuracy"],
+            failed_lineage_warning: {
+              fingerprint: "threshold sweep|balanced accuracy|threshold sweep",
+              count: 3,
+              reason: "Repeated failed lineage.",
+            },
           },
           {
             title: "Feature ablation",
@@ -426,7 +513,7 @@ describe("Runtime Dream sidecar review", () => {
               rationale: "Retry the close-to-best candidate with a wider local validation pass.",
               target_dimensions: ["balanced_accuracy"],
             },
-            evidence_refs: [],
+            evidence_refs: ["threshold sweep|repeat threshold sweep improves balanced accuracy|balanced accuracy|threshold sweep"],
             summary: "Close but from a repeatedly failed lineage.",
           },
           disposition: "retained",

--- a/src/runtime/__tests__/runtime-evidence-answer.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-answer.test.ts
@@ -43,6 +43,7 @@ function run(overrides: Partial<BackgroundRun> = {}): BackgroundRun {
 function summary(overrides: Partial<RuntimeEvidenceSummary> = {}): RuntimeEvidenceSummary {
   return {
     schema_version: "runtime-evidence-summary-v1",
+    context_policy_version: "correction-filtered-planning-context-v1",
     generated_at: "2026-05-02T00:25:00.000Z",
     scope: { run_id: "run-1" },
     total_entries: 1,

--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -143,7 +143,7 @@ describe("RuntimeEvidenceLedger", () => {
 
     const summary = await new RuntimeEvidenceLedger(runtimeRoot).summarizeRun("run:dream");
 
-    expect(summary.dream_checkpoints[0]?.relevant_memories[0]?.ref).toBe("soil://memory/stale");
+    expect(summary.dream_checkpoints).toEqual([]);
     expect(summary.correction_state[JSON.stringify([
       "dream_checkpoint",
       "soil://memory/stale",
@@ -155,6 +155,129 @@ describe("RuntimeEvidenceLedger", () => {
       active: false,
       latest_correction_id: "corr-dream-checkpoint",
     });
+    const goalSummary = await new RuntimeEvidenceLedger(runtimeRoot).summarizeGoal("goal-dream");
+    expect(goalSummary.dream_checkpoints).toEqual([]);
+  });
+
+  it("excludes retracted runtime evidence from best evidence, trends, failures, and recent entries", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "retracted-best",
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      kind: "metric",
+      scope: { run_id: "run:retracted-summary" },
+      metrics: [{ label: "accuracy", value: 0.99, direction: "maximize" }],
+      verification: { verdict: "pass", confidence: 0.99, summary: "later retracted" },
+      summary: "Retracted high metric.",
+      outcome: "improved",
+    });
+    await ledger.append({
+      id: "active-best",
+      occurred_at: "2026-05-02T00:01:00.000Z",
+      kind: "metric",
+      scope: { run_id: "run:retracted-summary" },
+      metrics: [{ label: "accuracy", value: 0.72, direction: "maximize" }],
+      summary: "Active lower metric.",
+      outcome: "continued",
+    });
+    await ledger.append({
+      id: "retracted-failure",
+      occurred_at: "2026-05-02T00:02:00.000Z",
+      kind: "failure",
+      scope: { run_id: "run:retracted-summary" },
+      strategy: "bad-lineage",
+      verification: { verdict: "fail", summary: "invalid failure" },
+      summary: "Retracted failure.",
+      outcome: "failed",
+    });
+    await ledger.appendCorrection({
+      correction_id: "corr-retracted-best",
+      scope: { run_id: "run:retracted-summary" },
+      target_ref: { kind: "runtime_evidence", id: "retracted-best", scope: { run_id: "run:retracted-summary" } },
+      correction_kind: "retracted",
+      replacement_ref: { kind: "runtime_evidence", id: "active-best", scope: { run_id: "run:retracted-summary" } },
+      actor: "runtime_verification",
+      reason: "Metric artifact was invalid.",
+      created_at: "2026-05-02T00:03:00.000Z",
+      provenance: { source: "runtime_verification", confidence: 1 },
+    });
+    await ledger.appendCorrection({
+      correction_id: "corr-retracted-failure",
+      scope: { run_id: "run:retracted-summary" },
+      target_ref: { kind: "runtime_evidence", id: "retracted-failure", scope: { run_id: "run:retracted-summary" } },
+      correction_kind: "retracted",
+      replacement_ref: null,
+      actor: "runtime_verification",
+      reason: "Failure belonged to an invalid run.",
+      created_at: "2026-05-02T00:04:00.000Z",
+      provenance: { source: "runtime_verification", confidence: 1 },
+    });
+
+    const summary = await new RuntimeEvidenceLedger(runtimeRoot).summarizeRun("run:retracted-summary");
+
+    expect(summary.total_entries).toBe(5);
+    expect(summary.best_evidence?.id).toBe("active-best");
+    expect(summary.metric_trends[0]?.best_value).toBe(0.72);
+    expect(summary.recent_entries.map((entry) => entry.id)).toEqual(["active-best"]);
+    expect(summary.recent_failed_attempts).toEqual([]);
+    expect(summary.failed_lineages).toEqual([]);
+  });
+
+  it("ignores legacy summary indexes that predate correction-filtered planning context", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "legacy-retracted-best",
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      kind: "metric",
+      scope: { run_id: "run:legacy-summary" },
+      metrics: [{ label: "accuracy", value: 0.99, direction: "maximize" }],
+      verification: { verdict: "pass", confidence: 0.99, summary: "legacy stale cache" },
+      summary: "Retracted high metric.",
+      outcome: "improved",
+    });
+    await ledger.append({
+      id: "legacy-active-best",
+      occurred_at: "2026-05-02T00:01:00.000Z",
+      kind: "metric",
+      scope: { run_id: "run:legacy-summary" },
+      metrics: [{ label: "accuracy", value: 0.7, direction: "maximize" }],
+      summary: "Active metric.",
+      outcome: "continued",
+    });
+    await ledger.appendCorrection({
+      correction_id: "corr-legacy-retracted-best",
+      scope: { run_id: "run:legacy-summary" },
+      target_ref: { kind: "runtime_evidence", id: "legacy-retracted-best", scope: { run_id: "run:legacy-summary" } },
+      correction_kind: "retracted",
+      replacement_ref: { kind: "runtime_evidence", id: "legacy-active-best", scope: { run_id: "run:legacy-summary" } },
+      actor: "runtime_verification",
+      reason: "Legacy cache should not re-admit this metric.",
+      created_at: "2026-05-02T00:02:00.000Z",
+      provenance: { source: "runtime_verification", confidence: 1 },
+    });
+
+    const canonicalPath = path.join(runtimeRoot, "evidence-ledger", "runs", `${encodeURIComponent("run:legacy-summary")}.jsonl`);
+    const stat = await fsp.stat(canonicalPath);
+    const entries = (await ledger.readByRun("run:legacy-summary")).entries;
+    const staleSummary = await ledger.rebuildSummaryIndexForRun("run:legacy-summary");
+    const legacySummary = {
+      ...staleSummary,
+      best_evidence: entries.find((entry) => entry.id === "legacy-retracted-best") ?? null,
+    } as Record<string, unknown>;
+    delete legacySummary.context_policy_version;
+    await fsp.writeFile(`${canonicalPath}.summary.json`, JSON.stringify({
+      schema_version: "runtime-evidence-summary-index-v1",
+      generated_at: "2026-05-02T00:03:00.000Z",
+      canonical_log_path: canonicalPath,
+      canonical_log_size: stat.size,
+      canonical_log_mtime_ms: stat.mtimeMs,
+      summary: legacySummary,
+    }));
+
+    const summary = await new RuntimeEvidenceLedger(runtimeRoot).summarizeRun("run:legacy-summary");
+
+    expect(summary.context_policy_version).toBe("correction-filtered-planning-context-v1");
+    expect(summary.best_evidence?.id).toBe("legacy-active-best");
   });
 
   it("tolerates malformed JSONL rows and summarizes recent evidence", async () => {

--- a/src/runtime/dream-sidecar-review.ts
+++ b/src/runtime/dream-sidecar-review.ts
@@ -376,21 +376,23 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
   const rejectedApproaches = collectRejectedApproaches(summary);
   const failedLineages = summary.failed_lineages.filter((lineage) => lineage.count >= 2);
   for (const checkpoint of rankCheckpointsByMemory(summary).slice(0, 2)) {
-    for (const candidate of checkpoint.next_strategy_candidates) {
-      if (isRejectedDreamCandidate(candidate, rejectedApproaches)) continue;
-      if (!candidate.retry_reason && isFailedLineageMove(candidate.title, candidate.rationale, failedLineages)) continue;
-      moves.push({
-        title: candidate.title,
-        rationale: candidate.rationale,
-        source: "dream_checkpoint",
-      });
-    }
-    if (checkpoint.guidance && moves.length === 0) {
-      moves.push({
-        title: "Apply latest Dream checkpoint guidance",
-        rationale: checkpoint.guidance,
-        source: "dream_checkpoint",
-      });
+    if (checkpoint.planning_context_status !== "partially_retracted") {
+      for (const candidate of checkpoint.next_strategy_candidates) {
+        if (isRejectedDreamCandidate(candidate, rejectedApproaches)) continue;
+        if (!candidate.retry_reason && isFailedLineageCandidate(candidate, failedLineages)) continue;
+        moves.push({
+          title: candidate.title,
+          rationale: candidate.rationale,
+          source: "dream_checkpoint",
+        });
+      }
+      if (checkpoint.guidance && moves.length === 0) {
+        moves.push({
+          title: "Apply latest Dream checkpoint guidance",
+          rationale: checkpoint.guidance,
+          source: "dream_checkpoint",
+        });
+      }
     }
   }
   for (const nearMiss of summary.near_miss_candidates.slice(0, 3)) {
@@ -398,8 +400,8 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
     const rationale = nearMiss.follow_up?.rationale
       ?? nearMiss.summary
       ?? `Candidate ${nearMiss.candidate_id} did not beat raw best but was retained for ${nearMiss.reason_to_keep.join(", ")}.`;
-    if (isRejectedMove(title, rationale, rejectedApproaches)) continue;
-    if (isFailedLineageMove(`${nearMiss.strategy_family} ${title}`, rationale, failedLineages)) continue;
+    if (isRejectedRef([nearMiss.candidate_id, ...nearMiss.evidence_refs], rejectedApproaches)) continue;
+    if (isFailedLineageRef(nearMiss.evidence_refs, failedLineages)) continue;
     moves.push({
       title,
       rationale,
@@ -408,8 +410,6 @@ function buildSuggestedNextMoves(summary: RuntimeEvidenceSummary): RuntimeDreamS
   }
   for (const memo of summary.research_memos.slice(0, 2)) {
     for (const finding of memo.findings.slice(0, 2)) {
-      if (isRejectedMove(finding.proposed_experiment, finding.applicability, rejectedApproaches)) continue;
-      if (isFailedLineageMove(finding.proposed_experiment, finding.applicability, failedLineages)) continue;
       moves.push({
         title: finding.proposed_experiment,
         rationale: finding.applicability,
@@ -447,24 +447,23 @@ function checkpointMemoryScore(checkpoint: RuntimeEvidenceSummary["dream_checkpo
   ));
 }
 
-function isFailedLineageMove(
-  title: string,
-  rationale: string,
+function isFailedLineageCandidate(
+  candidate: RuntimeEvidenceDreamCheckpointStrategyCandidate,
   failedLineages: RuntimeFailedLineageContext[]
 ): boolean {
-  if (failedLineages.length === 0) return false;
-  const moveText = normalizeRejectedMoveText(`${title} ${rationale}`);
-  if (!moveText) return false;
-  return failedLineages.some((lineage) => {
-    const lineageTexts = [
-      lineage.strategy_family,
-      lineage.hypothesis,
-      lineage.task_action,
-    ].map((value) => normalizeRejectedMoveText(value ?? "")).filter(Boolean);
-    return lineageTexts.some((lineageText) =>
-      moveText.includes(lineageText) || lineageText.includes(moveText)
-    );
-  });
+  const warning = candidate.failed_lineage_warning;
+  if (!warning || warning.count < 2) return false;
+  return failedLineages.length === 0 || failedLineages.some((lineage) =>
+    lineage.fingerprint === warning.fingerprint
+  ) || warning.count >= 2;
+}
+
+function isFailedLineageRef(
+  refs: string[],
+  failedLineages: RuntimeFailedLineageContext[]
+): boolean {
+  const refSet = new Set(refs);
+  return failedLineages.some((lineage) => refSet.has(lineage.fingerprint));
 }
 
 function lineageLabel(lineage: RuntimeFailedLineageContext): string {
@@ -480,7 +479,7 @@ function collectRejectedApproaches(summary: RuntimeEvidenceSummary): RuntimeEvid
   const rejectedApproaches: RuntimeEvidenceDreamCheckpointRejectedApproach[] = [];
   for (const checkpoint of summary.dream_checkpoints) {
     for (const rejected of checkpoint.rejected_approaches ?? []) {
-      const key = normalizeRejectedMoveText(rejected.approach);
+      const key = rejected.candidate_ref ?? rejected.evidence_ref;
       if (!key || seen.has(key)) continue;
       seen.add(key);
       rejectedApproaches.push(rejected);
@@ -493,29 +492,22 @@ function isRejectedDreamCandidate(
   candidate: RuntimeEvidenceDreamCheckpointStrategyCandidate,
   rejectedApproaches: RuntimeEvidenceDreamCheckpointRejectedApproach[]
 ): boolean {
-  return isRejectedMove(candidate.title, candidate.rationale, rejectedApproaches);
+  return isRejectedRef([
+    ...(candidate.candidate_ref ? [candidate.candidate_ref] : []),
+  ], rejectedApproaches);
 }
 
-function isRejectedMove(
-  title: string,
-  rationale: string,
+function isRejectedRef(
+  refs: string[],
   rejectedApproaches: RuntimeEvidenceDreamCheckpointRejectedApproach[]
 ): boolean {
   if (rejectedApproaches.length === 0) return false;
-  const moveText = normalizeRejectedMoveText(`${title} ${rationale}`);
-  if (!moveText) return false;
-  return rejectedApproaches.some((rejected) => {
-    const approachText = normalizeRejectedMoveText(rejected.approach);
-    if (!approachText) return false;
-    const matchesApproach = moveText.includes(approachText) || approachText.includes(moveText);
-    if (!matchesApproach) return false;
-    const revisitText = normalizeRejectedMoveText(rejected.revisit_condition ?? "");
-    return !revisitText || !moveText.includes(revisitText);
-  });
-}
-
-function normalizeRejectedMoveText(value: string): string {
-  return value.normalize("NFKC").toLocaleLowerCase().replace(/[^\p{Letter}\p{Number}]+/gu, " ").trim();
+  const refSet = new Set(refs);
+  if (refSet.size === 0) return false;
+  return rejectedApproaches.some((rejected) =>
+    Boolean(rejected.candidate_ref && refSet.has(rejected.candidate_ref))
+    || Boolean(rejected.evidence_ref && refSet.has(rejected.evidence_ref))
+  );
 }
 
 function buildOperatorDecisions(summary: RuntimeEvidenceSummary): RuntimeDreamSidecarReview["operator_decisions"] {

--- a/src/runtime/store/dream-checkpoints.ts
+++ b/src/runtime/store/dream-checkpoints.ts
@@ -6,8 +6,11 @@ import type {
 export interface RuntimeDreamCheckpointContext extends RuntimeEvidenceDreamCheckpoint {
   entry_id: string;
   occurred_at: string;
+  goal_id?: string;
+  run_id?: string;
   loop_index?: number;
   phase?: string;
+  planning_context_status?: "active" | "partially_retracted";
 }
 
 export function summarizeEvidenceDreamCheckpoints(
@@ -20,6 +23,8 @@ export function summarizeEvidenceDreamCheckpoints(
         ...checkpoint,
         entry_id: entry.id,
         occurred_at: entry.occurred_at,
+        ...(entry.scope.goal_id ? { goal_id: entry.scope.goal_id } : {}),
+        ...(entry.scope.run_id ? { run_id: entry.scope.run_id } : {}),
         ...(entry.scope.loop_index !== undefined ? { loop_index: entry.scope.loop_index } : {}),
         ...(entry.scope.phase ? { phase: entry.scope.phase } : {}),
       });

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -8,12 +8,14 @@ import {
   type RuntimeStorePaths,
 } from "./runtime-paths.js";
 import {
+  correctionStateForTarget,
   MemoryCorrectionEntrySchema,
   MemoryCorrectionTargetStateSchema,
   summarizeMemoryCorrectionState,
   type MemoryCorrectionEntry,
   type MemoryCorrectionEntryInput,
   type MemoryCorrectionTargetState,
+  type MemoryCorrectionTargetRef,
 } from "../../platform/corrections/memory-correction-ledger.js";
 import { summarizeEvidenceMetricTrends, type MetricTrendContext } from "./metric-history.js";
 import {
@@ -363,6 +365,7 @@ export const RuntimeEvidenceDreamCheckpointMemoryRefSchema = z.object({
 export type RuntimeEvidenceDreamCheckpointMemoryRef = z.infer<typeof RuntimeEvidenceDreamCheckpointMemoryRefSchema>;
 
 export const RuntimeEvidenceDreamCheckpointStrategyCandidateSchema = z.object({
+  candidate_ref: z.string().min(1).optional(),
   title: z.string().min(1),
   rationale: z.string().min(1),
   target_dimensions: z.array(z.string().min(1)).default([]),
@@ -388,6 +391,7 @@ export type RuntimeEvidenceDreamCheckpointActiveHypothesis = z.infer<typeof Runt
 export const RuntimeEvidenceDreamCheckpointRejectedApproachSchema = z.object({
   approach: z.string().min(1),
   rejection_reason: z.string().min(1),
+  candidate_ref: z.string().min(1).optional(),
   evidence_ref: z.string().min(1).optional(),
   revisit_condition: z.string().min(1).optional(),
   confidence: z.number().min(0).max(1).default(0.5),
@@ -659,6 +663,7 @@ export interface RuntimeNearMissCandidateContext {
 
 export interface RuntimeEvidenceSummary {
   schema_version: "runtime-evidence-summary-v1";
+  context_policy_version: "correction-filtered-planning-context-v1";
   generated_at: string;
   scope: {
     goal_id?: string;
@@ -904,7 +909,8 @@ async function readSummaryIndex(
 }
 
 function isCurrentEvidenceSummaryShape(summary: RuntimeEvidenceSummary): boolean {
-  return Array.isArray(summary.candidate_lineages)
+  return summary.context_policy_version === "correction-filtered-planning-context-v1"
+    && Array.isArray(summary.candidate_lineages)
     && Array.isArray(summary.corrections)
     && typeof summary.correction_state === "object"
     && summary.correction_state !== null
@@ -983,10 +989,17 @@ function summarizeEvidence(
   const entries = [...read.entries].sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
   const corrections = entries.flatMap((entry) => entry.correction ? [entry.correction] : []);
   const correctionState = summarizeMemoryCorrectionState(corrections);
-  const newestFirst = [...entries].reverse();
-  const evaluatorSummary = summarizeEvidenceEvaluatorResults(entries);
+  const activeEntries = entries.filter((entry) => isRuntimeEvidenceEntryActive(entry, correctionState));
+  const newestFirst = [...activeEntries].reverse();
+  const evaluatorSummary = summarizeEvidenceEvaluatorResults(activeEntries);
+  const activeDreamCheckpoints = filterRetractedDreamCheckpointMemories(
+    summarizeEvidenceDreamCheckpoints(activeEntries),
+    correctionState,
+    scope
+  );
   return {
     schema_version: "runtime-evidence-summary-v1",
+    context_policy_version: "correction-filtered-planning-context-v1",
     generated_at: new Date().toISOString(),
     scope,
     total_entries: entries.length,
@@ -994,21 +1007,21 @@ function summarizeEvidence(
       entry.kind === "strategy" || Boolean(entry.strategy) || Boolean(entry.decision_reason)
     ) ?? null,
     best_evidence: chooseBestEvidence(newestFirst),
-    metric_trends: summarizeEvidenceMetricTrends(entries),
+    metric_trends: summarizeEvidenceMetricTrends(activeEntries),
     evaluator_summary: evaluatorSummary,
-    research_memos: summarizeEvidenceResearchMemos(entries),
-    dream_checkpoints: summarizeEvidenceDreamCheckpoints(entries),
-    divergent_exploration: entries
+    research_memos: summarizeEvidenceResearchMemos(activeEntries),
+    dream_checkpoints: activeDreamCheckpoints,
+    divergent_exploration: activeEntries
       .flatMap((entry) => entry.divergent_exploration ?? [])
       .slice(-10)
       .reverse(),
     corrections,
     correction_state: correctionState,
-    candidate_lineages: summarizeCandidateLineages(entries),
-    recommended_candidate_portfolio: selectDiversifiedCandidatePortfolio(entries),
-    candidate_selection_summary: summarizeCandidateSelection(entries, evaluatorSummary),
-    near_miss_candidates: summarizeNearMissCandidates(entries),
-    artifact_retention: summarizeArtifactRetention(entries, { manifests }),
+    candidate_lineages: summarizeCandidateLineages(activeEntries),
+    recommended_candidate_portfolio: selectDiversifiedCandidatePortfolio(activeEntries),
+    candidate_selection_summary: summarizeCandidateSelection(activeEntries, evaluatorSummary),
+    near_miss_candidates: summarizeNearMissCandidates(activeEntries),
+    artifact_retention: summarizeArtifactRetention(activeEntries, { manifests }),
     recent_failed_attempts: newestFirst
       .filter((entry) =>
         entry.outcome === "failed"
@@ -1018,10 +1031,87 @@ function summarizeEvidence(
         || entry.verification?.verdict === "fail"
       )
       .slice(0, 5),
-    failed_lineages: summarizeFailedLineages(entries),
+    failed_lineages: summarizeFailedLineages(activeEntries),
     recent_entries: newestFirst.slice(0, 10),
     warnings: read.warnings,
   };
+}
+
+function isRuntimeEvidenceEntryActive(
+  entry: RuntimeEvidenceEntry,
+  correctionState: Record<string, MemoryCorrectionTargetState>
+): boolean {
+  if (entry.kind === "correction") return false;
+  return runtimeEvidenceCorrectionRefs(entry).every((ref) =>
+    correctionStateForTarget(correctionState, ref).active
+  );
+}
+
+function runtimeEvidenceCorrectionRefs(entry: RuntimeEvidenceEntry): MemoryCorrectionTargetRef[] {
+  const refs: MemoryCorrectionTargetRef[] = [
+    { kind: "runtime_evidence", id: entry.id },
+  ];
+  if (entry.scope.run_id) {
+    refs.push({ kind: "runtime_evidence", id: entry.id, scope: { run_id: entry.scope.run_id } });
+  }
+  if (entry.scope.goal_id) {
+    refs.push({ kind: "runtime_evidence", id: entry.id, scope: { goal_id: entry.scope.goal_id } });
+  }
+  if (entry.scope.goal_id || entry.scope.run_id || entry.scope.task_id) {
+    refs.push({
+      kind: "runtime_evidence",
+      id: entry.id,
+      scope: {
+        ...(entry.scope.goal_id ? { goal_id: entry.scope.goal_id } : {}),
+        ...(entry.scope.run_id ? { run_id: entry.scope.run_id } : {}),
+        ...(entry.scope.task_id ? { task_id: entry.scope.task_id } : {}),
+      },
+    });
+  }
+  return refs;
+}
+
+function filterRetractedDreamCheckpointMemories(
+  checkpoints: RuntimeDreamCheckpointContext[],
+  correctionState: Record<string, MemoryCorrectionTargetState>,
+  scope: RuntimeEvidenceSummary["scope"]
+): RuntimeDreamCheckpointContext[] {
+  return checkpoints
+    .map((checkpoint) => {
+      const relevant_memories = checkpoint.relevant_memories.filter((memory) =>
+        !memory.ref || dreamMemoryCorrectionRefs(memory.ref, checkpoint, scope).every((ref) =>
+          correctionStateForTarget(correctionState, ref).active
+        )
+      );
+      return {
+        checkpoint,
+        relevant_memories,
+        planning_context_status: relevant_memories.length === checkpoint.relevant_memories.length
+          ? "active" as const
+          : "partially_retracted" as const,
+      };
+    })
+    .filter(({ checkpoint, relevant_memories }) =>
+      checkpoint.relevant_memories.length === 0 || relevant_memories.length > 0
+    )
+    .map(({ checkpoint, relevant_memories, planning_context_status }) => ({
+      ...checkpoint,
+      relevant_memories,
+      planning_context_status,
+    }));
+}
+
+function dreamMemoryCorrectionRefs(
+  ref: string,
+  checkpoint: RuntimeDreamCheckpointContext,
+  scope: RuntimeEvidenceSummary["scope"]
+): MemoryCorrectionTargetRef[] {
+  const refs: MemoryCorrectionTargetRef[] = [{ kind: "dream_checkpoint", id: ref }];
+  if (checkpoint.run_id) refs.push({ kind: "dream_checkpoint", id: ref, scope: { run_id: checkpoint.run_id } });
+  if (checkpoint.goal_id) refs.push({ kind: "dream_checkpoint", id: ref, scope: { goal_id: checkpoint.goal_id } });
+  if (scope.run_id) refs.push({ kind: "dream_checkpoint", id: ref, scope: { run_id: scope.run_id } });
+  if (scope.goal_id) refs.push({ kind: "dream_checkpoint", id: ref, scope: { goal_id: scope.goal_id } });
+  return refs;
 }
 
 interface CandidateEvidenceContext {


### PR DESCRIPTION
Closes #890

## Summary
- Exclude inactive, superseded, retracted, forgotten, quarantined, or unknown Soil route targets from default compiled context, with repository-backed target state lookup.
- Filter runtime evidence summaries and Dream checkpoint context through correction state before default planning surfaces are built.
- Reject legacy runtime evidence summary indexes that predate correction-filtered planning context.
- Prevent partially retracted Dream checkpoints from contributing sidecar next moves or guidance, and use typed refs/fingerprints for sidecar rejection checks.

## Verification
- npm run typecheck
- npx vitest run src/platform/soil/__tests__/context-compiler.test.ts src/platform/soil/__tests__/context-evaluation.test.ts src/platform/soil/__tests__/sqlite-repository.test.ts src/runtime/__tests__/runtime-evidence-ledger.test.ts src/runtime/__tests__/dream-sidecar-review.test.ts src/runtime/__tests__/runtime-evidence-answer.test.ts src/interface/tui/__tests__/dashboard.test.ts
- npm run lint:boundaries (passes with existing warnings)
- npm run test:changed

## Known risks
- Existing lint warnings remain unrelated to this change.
- Route-only callers without repository state now fail closed for explicit route targets unless active typed state is supplied.