### PR TITLE
feat(memory): add user correction operations

### DIFF
--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -36,6 +36,7 @@ import { cmdStart, cmdStop, cmdCron, cmdDaemonStatus, cmdDaemonPing } from "./co
 import { cmdSuggest, cmdImprove } from "./commands/suggest.js";
 import { cmdSetup } from "./commands/setup.js";
 import { cmdKnowledgeList, cmdKnowledgeSearch, cmdKnowledgeStats } from "./commands/knowledge.js";
+import { cmdMemory } from "./commands/memory.js";
 import { cmdTaskList, cmdTaskShow } from "./commands/task-read.js";
 import { cmdDoctor } from "./commands/doctor.js";
 import { cmdLogs } from "./commands/logs.js";
@@ -513,6 +514,10 @@ export async function dispatchCommand(
     logger.error(`Unknown knowledge subcommand: "${knowledgeSubcommand}"`);
     logger.error("Available: knowledge list, knowledge search, knowledge stats");
     return 1;
+  }
+
+  if (subcommand === "memory") {
+    return await cmdMemory(stateManager, argv.slice(1));
   }
 
   if (subcommand === "task") {

--- a/src/interface/cli/commands/__tests__/memory.test.ts
+++ b/src/interface/cli/commands/__tests__/memory.test.ts
@@ -1,0 +1,85 @@
+import * as fsp from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
+import { StateManager } from "../../../../base/state/state-manager.js";
+import { AGENT_MEMORY_PATH } from "../../../../platform/knowledge/knowledge-manager-internals.js";
+import { AgentMemoryStoreSchema } from "../../../../platform/knowledge/types/agent-memory.js";
+import { cmdMemory } from "../memory.js";
+
+describe("cmdMemory", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+  let logs: string[];
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir("pulseed-cli-memory-");
+    stateManager = new StateManager(tmpDir);
+    await stateManager.init();
+    logs = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    });
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await stateManager.writeRaw(AGENT_MEMORY_PATH, {
+      entries: [{
+        id: "memory-forget",
+        key: "temporary-fact",
+        value: "This should no longer be used.",
+        tags: [],
+        memory_type: "fact",
+        status: "raw",
+        created_at: "2026-05-02T00:00:00.000Z",
+        updated_at: "2026-05-02T00:00:00.000Z",
+      }],
+      corrections: [],
+      last_consolidated_at: null,
+    });
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("forgets agent memory by tombstoning it and preserving correction history", async () => {
+    const forgetExit = await cmdMemory(stateManager, [
+      "forget",
+      "agent_memory:memory-forget",
+      "--reason",
+      "User asked PulSeed to forget this fact.",
+    ]);
+
+    expect(forgetExit).toBe(0);
+    const rawStore = await stateManager.readRaw(AGENT_MEMORY_PATH);
+    const store = AgentMemoryStoreSchema.parse(rawStore);
+    expect(store.entries).toHaveLength(1);
+    expect(store.entries[0]).toMatchObject({
+      id: "memory-forget",
+      status: "forgotten",
+      correction_state: { status: "forgotten", active: false, retained_for_audit: true },
+    });
+    expect(store.corrections).toHaveLength(1);
+    expect(store.corrections[0]).toMatchObject({
+      correction_kind: "forgotten",
+      actor: "user",
+    });
+
+    const historyExit = await cmdMemory(stateManager, ["history", "agent_memory:memory-forget"]);
+
+    expect(historyExit).toBe(0);
+    expect(logs.join("\n")).toContain(store.corrections[0]!.correction_id);
+  });
+
+  it("rejects destructive deletion from the default memory command", async () => {
+    const exitCode = await cmdMemory(stateManager, [
+      "forget",
+      "agent_memory:memory-forget",
+      "--destructive-delete",
+    ]);
+
+    expect(exitCode).toBe(1);
+    const store = AgentMemoryStoreSchema.parse(await stateManager.readRaw(AGENT_MEMORY_PATH));
+    expect(store.entries[0]!.status).toBe("raw");
+    expect(store.corrections).toEqual([]);
+  });
+});

--- a/src/interface/cli/commands/memory.ts
+++ b/src/interface/cli/commands/memory.ts
@@ -1,0 +1,78 @@
+import { getCliLogger } from "../cli-logger.js";
+import { formatOperationError } from "../utils.js";
+import type { StateManager } from "../../../base/state/state-manager.js";
+import {
+  parseMemoryCorrectionRef,
+  runUserMemoryOperation,
+  UserMemoryOperationSchema,
+  type UserMemoryOperation,
+} from "../../../platform/corrections/user-memory-operations.js";
+
+function optionValue(argv: string[], name: string): string | undefined {
+  const index = argv.indexOf(name);
+  if (index < 0) return undefined;
+  return argv[index + 1];
+}
+
+function hasOption(argv: string[], name: string): boolean {
+  return argv.indexOf(name) >= 0;
+}
+
+function printUsage(): void {
+  getCliLogger().error("Usage: pulseed memory <correct|forget|retract|history> <kind:id> [--reason text] [--value text] [--replacement-ref kind:id] [--goal id] [--run id] [--task id]");
+}
+
+export async function cmdMemory(stateManager: StateManager, argv: string[]): Promise<number> {
+  const operation = argv[0] as UserMemoryOperation | undefined;
+  const refValue = argv[1];
+  if (!operation || !UserMemoryOperationSchema.safeParse(operation).success || !refValue) {
+    printUsage();
+    return 1;
+  }
+  if (hasOption(argv, "--destructive-delete")) {
+    getCliLogger().error("Destructive memory deletion requires a separate explicit approval flow; use forget/retract for the default auditable path.");
+    return 1;
+  }
+
+  try {
+    const targetRef = parseMemoryCorrectionRef(refValue);
+    const replacementRefValue = optionValue(argv, "--replacement-ref");
+    const result = await runUserMemoryOperation(stateManager, {
+      operation,
+      targetRef,
+      reason: optionValue(argv, "--reason"),
+      replacementValue: optionValue(argv, "--value"),
+      replacementKey: optionValue(argv, "--replacement-key"),
+      replacementRef: replacementRefValue ? parseMemoryCorrectionRef(replacementRefValue) : null,
+      goalId: optionValue(argv, "--goal"),
+      runId: optionValue(argv, "--run"),
+      taskId: optionValue(argv, "--task"),
+    });
+
+    if (operation === "history") {
+      console.log(`Correction history for ${refValue}:`);
+      if (result.history.length === 0) {
+        console.log("  No correction entries found.");
+        return 0;
+      }
+      for (const entry of result.history) {
+        console.log(`  ${entry.created_at} ${entry.correction_kind} ${entry.correction_id}`);
+        console.log(`    reason: ${entry.reason}`);
+        if (entry.replacement_ref) {
+          console.log(`    replacement: ${entry.replacement_ref.kind}:${entry.replacement_ref.id}`);
+        }
+      }
+      return 0;
+    }
+
+    console.log(`Memory ${operation} recorded: ${result.correction?.correction_id}`);
+    console.log(`Target: ${result.target_ref.kind}:${result.target_ref.id}`);
+    if (result.replacement) {
+      console.log(`Replacement: ${result.replacement.ref.kind}:${result.replacement.ref.id}`);
+    }
+    return 0;
+  } catch (err) {
+    getCliLogger().error(formatOperationError(`memory ${operation}`, err));
+    return 1;
+  }
+}

--- a/src/platform/corrections/__tests__/user-memory-operations.test.ts
+++ b/src/platform/corrections/__tests__/user-memory-operations.test.ts
@@ -1,0 +1,79 @@
+import * as fsp from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { StateManager } from "../../../base/state/state-manager.js";
+import type { ILLMClient } from "../../../base/llm/llm-client.js";
+import { KnowledgeManager } from "../../knowledge/knowledge-manager.js";
+import { AGENT_MEMORY_PATH } from "../../knowledge/knowledge-manager-internals.js";
+import type { AgentMemoryEntry } from "../../knowledge/types/agent-memory.js";
+import { runUserMemoryOperation } from "../user-memory-operations.js";
+
+function memoryEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntry {
+  return {
+    id: "memory-old",
+    key: "favorite-editor",
+    value: "The user prefers Atom.",
+    tags: ["preference"],
+    memory_type: "preference",
+    status: "raw",
+    created_at: "2026-05-02T00:00:00.000Z",
+    updated_at: "2026-05-02T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("user memory correction operations", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir("pulseed-user-memory-ops-");
+    stateManager = new StateManager(tmpDir);
+    await stateManager.init();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("records a user correction event and keeps stale agent memory out of default recall", async () => {
+    await stateManager.writeRaw(AGENT_MEMORY_PATH, {
+      entries: [memoryEntry()],
+      corrections: [],
+      last_consolidated_at: null,
+    });
+
+    const result = await runUserMemoryOperation(stateManager, {
+      operation: "correct",
+      targetRef: { kind: "agent_memory", id: "memory-old" },
+      reason: "User corrected their editor preference.",
+      replacementValue: "The user prefers VS Code.",
+      replacementKey: "favorite-editor-current",
+      now: "2026-05-02T01:00:00.000Z",
+    });
+
+    expect(result.correction).toMatchObject({
+      target_ref: { kind: "agent_memory", id: "memory-old" },
+      correction_kind: "corrected",
+      actor: "user",
+    });
+    expect(result.replacement?.ref.kind).toBe("agent_memory");
+
+    const manager = new KnowledgeManager(stateManager, {} as ILLMClient);
+    expect(await manager.recallAgentMemory("favorite-editor", { exact: true })).toEqual([]);
+    expect(await manager.recallAgentMemory("favorite-editor-current", { exact: true })).toEqual([
+      expect.objectContaining({
+        key: "favorite-editor-current",
+        value: "The user prefers VS Code.",
+        supersedes_memory_id: "memory-old",
+      }),
+    ]);
+
+    const store = await manager.loadAgentMemoryStore();
+    expect(store.entries.find((entry) => entry.id === "memory-old")).toMatchObject({
+      status: "corrected",
+      correction_state: { status: "corrected", active: false, retained_for_audit: true },
+    });
+    expect(store.corrections).toHaveLength(1);
+  });
+});

--- a/src/platform/corrections/user-memory-operations.ts
+++ b/src/platform/corrections/user-memory-operations.ts
@@ -1,0 +1,195 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { z } from "zod";
+import type { StateManager } from "../../base/state/state-manager.js";
+import { RuntimeEvidenceLedger } from "../../runtime/store/evidence-ledger.js";
+import {
+  MemoryCorrectionEntrySchema,
+  MemoryCorrectionTargetKindSchema,
+  memoryCorrectionTargetKey,
+  type MemoryCorrectionEntry,
+  type MemoryCorrectionKind,
+  type MemoryCorrectionTargetRef,
+} from "./memory-correction-ledger.js";
+import {
+  AgentMemoryStoreSchema,
+  type AgentMemoryEntry,
+} from "../knowledge/types/agent-memory.js";
+import { AGENT_MEMORY_PATH } from "../knowledge/knowledge-manager-internals.js";
+import {
+  applyAgentMemoryCorrection,
+  listAgentMemoryCorrectionHistory,
+  type AgentMemoryHost,
+} from "../knowledge/knowledge-manager-agent-memory.js";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+
+export const UserMemoryOperationSchema = z.enum(["correct", "forget", "retract", "history"]);
+export type UserMemoryOperation = z.infer<typeof UserMemoryOperationSchema>;
+
+const RefPattern = /^(agent_memory|soil_record|runtime_evidence|dream_checkpoint):(.+)$/;
+
+export function parseMemoryCorrectionRef(value: string): MemoryCorrectionTargetRef {
+  const match = RefPattern.exec(value);
+  if (!match) {
+    throw new Error("memory ref must use <kind>:<id>, where kind is agent_memory, soil_record, runtime_evidence, or dream_checkpoint");
+  }
+  return {
+    kind: MemoryCorrectionTargetKindSchema.parse(match[1]),
+    id: match[2]!,
+  };
+}
+
+export interface UserMemoryOperationInput {
+  operation: UserMemoryOperation;
+  targetRef: MemoryCorrectionTargetRef;
+  reason?: string;
+  replacementValue?: string;
+  replacementRef?: MemoryCorrectionTargetRef | null;
+  replacementKey?: string;
+  goalId?: string;
+  runId?: string;
+  taskId?: string;
+  now?: string;
+}
+
+export interface UserMemoryOperationResult {
+  operation: UserMemoryOperation;
+  target_ref: MemoryCorrectionTargetRef;
+  correction: MemoryCorrectionEntry | null;
+  history: MemoryCorrectionEntry[];
+  replacement?: { ref: MemoryCorrectionTargetRef; entry?: AgentMemoryEntry };
+}
+
+function correctionKindForOperation(operation: Exclude<UserMemoryOperation, "history">): MemoryCorrectionKind {
+  if (operation === "correct") return "corrected";
+  if (operation === "forget") return "forgotten";
+  return "retracted";
+}
+
+function scopeFor(input: UserMemoryOperationInput): { goal_id?: string; run_id?: string; task_id?: string } {
+  return {
+    ...(input.goalId ? { goal_id: input.goalId } : {}),
+    ...(input.runId ? { run_id: input.runId } : {}),
+    ...(input.taskId ? { task_id: input.taskId } : {}),
+  };
+}
+
+function correctionReason(input: UserMemoryOperationInput): string {
+  return input.reason ?? `User requested ${input.operation} for ${input.targetRef.kind}:${input.targetRef.id}`;
+}
+
+function stateManagerAgentMemoryHost(stateManager: StateManager): AgentMemoryHost {
+  const llmClient = {} as ILLMClient;
+  return {
+    llmClient,
+    loadAgentMemoryStore: async () => {
+      const raw = await stateManager.readRaw(AGENT_MEMORY_PATH);
+      return AgentMemoryStoreSchema.parse(raw ?? { entries: [], corrections: [], last_consolidated_at: null });
+    },
+    saveAgentMemoryStore: async (store) => {
+      await stateManager.writeRaw(AGENT_MEMORY_PATH, store);
+    },
+  };
+}
+
+function runtimeEvidenceLedgerForState(stateManager: StateManager): RuntimeEvidenceLedger {
+  return new RuntimeEvidenceLedger(path.join(stateManager.getBaseDir(), "runtime"));
+}
+
+function assertRuntimeScope(input: UserMemoryOperationInput): void {
+  const scope = scopeFor(input);
+  if (!scope.goal_id && !scope.run_id) {
+    throw new Error("non-agent memory operations require --goal or --run so the audit entry can be scoped");
+  }
+}
+
+export async function runUserMemoryOperation(
+  stateManager: StateManager,
+  input: UserMemoryOperationInput
+): Promise<UserMemoryOperationResult> {
+  if (input.operation === "history") {
+    return {
+      operation: input.operation,
+      target_ref: input.targetRef,
+      correction: null,
+      history: await readCorrectionHistory(stateManager, input),
+    };
+  }
+
+  const correctionKind = correctionKindForOperation(input.operation);
+  if (input.targetRef.kind === "agent_memory") {
+    const result = await applyAgentMemoryCorrection(stateManagerAgentMemoryHost(stateManager), {
+      targetId: input.targetRef.id,
+      correctionKind: correctionKind as "corrected" | "forgotten" | "retracted",
+      reason: correctionReason(input),
+      replacementValue: input.replacementValue,
+      replacementKey: input.replacementKey,
+      actor: "user",
+      createdAt: input.now,
+      provenanceRef: "pulseed memory command",
+    });
+    return {
+      operation: input.operation,
+      target_ref: input.targetRef,
+      correction: result.correction,
+      history: await listAgentMemoryCorrectionHistory(stateManagerAgentMemoryHost(stateManager), input.targetRef),
+      ...(result.replacement
+        ? { replacement: { ref: { kind: "agent_memory", id: result.replacement.id }, entry: result.replacement } }
+        : {}),
+    };
+  }
+
+  const now = input.now ?? new Date().toISOString();
+  assertRuntimeScope(input);
+  const scopedTarget: MemoryCorrectionTargetRef = {
+    ...input.targetRef,
+    ...(Object.keys(scopeFor(input)).length > 0 ? { scope: scopeFor(input) } : {}),
+  };
+  const correction = MemoryCorrectionEntrySchema.parse({
+    correction_id: `user-memory-correction-${randomUUID()}`,
+    target_ref: scopedTarget,
+    correction_kind: correctionKind,
+    replacement_ref: input.replacementRef ?? null,
+    actor: "user",
+    reason: correctionReason(input),
+    created_at: now,
+    provenance: { source: "user", source_ref: "pulseed memory command", confidence: 1 },
+  });
+  const ledger = runtimeEvidenceLedgerForState(stateManager);
+  await ledger.appendCorrection({
+    ...correction,
+    scope: scopeFor(input),
+  });
+  return {
+    operation: input.operation,
+    target_ref: scopedTarget,
+    correction,
+    history: await readCorrectionHistory(stateManager, { ...input, targetRef: scopedTarget }),
+  };
+}
+
+async function readCorrectionHistory(
+  stateManager: StateManager,
+  input: UserMemoryOperationInput
+): Promise<MemoryCorrectionEntry[]> {
+  if (input.targetRef.kind === "agent_memory") {
+    return listAgentMemoryCorrectionHistory(stateManagerAgentMemoryHost(stateManager), input.targetRef);
+  }
+  const ledger = runtimeEvidenceLedgerForState(stateManager);
+  const summaries = await Promise.all([
+    input.runId ? ledger.summarizeRun(input.runId).catch(() => null) : null,
+    input.goalId ? ledger.summarizeGoal(input.goalId).catch(() => null) : null,
+  ]);
+  const deduped = new Map<string, MemoryCorrectionEntry>();
+  for (const correction of summaries.flatMap((summary) => summary?.corrections ?? [])) {
+    deduped.set(correction.correction_id, correction);
+  }
+  const expectedTarget = {
+    ...input.targetRef,
+    ...(Object.keys(scopeFor(input)).length > 0 ? { scope: scopeFor(input) } : {}),
+  };
+  const expectedKey = memoryCorrectionTargetKey(expectedTarget);
+  return [...deduped.values()].filter((correction) =>
+    memoryCorrectionTargetKey(correction.target_ref) === expectedKey
+  );
+}

--- a/src/platform/knowledge/knowledge-manager-agent-memory.ts
+++ b/src/platform/knowledge/knowledge-manager-agent-memory.ts
@@ -1,9 +1,20 @@
 import { z } from "zod";
+import { randomUUID } from "node:crypto";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
+import {
+  MemoryCorrectionEntrySchema,
+  correctionStateForTarget,
+  memoryCorrectionTargetKey,
+  summarizeMemoryCorrectionState,
+  type MemoryCorrectionEntry,
+  type MemoryCorrectionEntryInput,
+  type MemoryCorrectionKind,
+  type MemoryCorrectionTargetRef,
+} from "../corrections/memory-correction-ledger.js";
 import {
   AgentMemoryEntrySchema,
 } from "./types/agent-memory.js";
-import type { AgentMemoryEntry, AgentMemoryStore, AgentMemoryType } from "./types/agent-memory.js";
+import type { AgentMemoryEntry, AgentMemoryStatus, AgentMemoryStore, AgentMemoryType } from "./types/agent-memory.js";
 import { cosineSimilarity } from "./embedding-client.js";
 import type { IEmbeddingClient } from "./embedding-client.js";
 
@@ -12,6 +23,19 @@ export interface AgentMemoryHost {
   embeddingClient?: IEmbeddingClient;
   loadAgentMemoryStore(): Promise<AgentMemoryStore>;
   saveAgentMemoryStore(store: AgentMemoryStore): Promise<void>;
+}
+
+const inactiveAgentMemoryStatuses = new Set<AgentMemoryStatus>([
+  "archived",
+  "corrected",
+  "superseded",
+  "retracted",
+  "forgotten",
+  "quarantined",
+]);
+
+function isAgentMemoryEntryActive(entry: AgentMemoryEntry): boolean {
+  return !inactiveAgentMemoryStatuses.has(entry.status);
 }
 
 export async function saveAgentMemoryEntry(
@@ -75,7 +99,7 @@ export async function recallAgentMemoryEntries(
   const { exact = false, category, memory_type, limit = 10, include_archived = false, semantic = false } = opts ?? {};
 
   const candidates = store.entries.filter((e) => {
-    if (!include_archived && e.status === "archived") return false;
+    if (!include_archived && !isAgentMemoryEntryActive(e)) return false;
     const matchesCategory = category ? e.category === category : true;
     const matchesType = memory_type ? e.memory_type === memory_type : true;
     return matchesCategory && matchesType;
@@ -125,7 +149,7 @@ export async function listAgentMemoryEntries(
   const { category, memory_type, limit = 10, include_archived = false } = opts ?? {};
 
   const results = store.entries.filter((e) => {
-    if (!include_archived && e.status === "archived") return false;
+    if (!include_archived && !isAgentMemoryEntryActive(e)) return false;
     const matchesCategory = category ? e.category === category : true;
     const matchesType = memory_type ? e.memory_type === memory_type : true;
     return matchesCategory && matchesType;
@@ -142,6 +166,104 @@ export async function deleteAgentMemoryEntry(host: AgentMemoryHost, key: string)
   store.entries.splice(idx, 1);
   await host.saveAgentMemoryStore(store);
   return true;
+}
+
+export interface AgentMemoryCorrectionInput {
+  targetId: string;
+  correctionKind: Extract<MemoryCorrectionKind, "corrected" | "forgotten" | "retracted">;
+  reason: string;
+  replacementValue?: string;
+  replacementKey?: string;
+  actor?: MemoryCorrectionEntry["actor"];
+  createdAt?: string;
+  provenanceRef?: string;
+}
+
+export interface AgentMemoryCorrectionResult {
+  correction: MemoryCorrectionEntry;
+  target: AgentMemoryEntry;
+  replacement: AgentMemoryEntry | null;
+}
+
+function agentMemoryRef(id: string): MemoryCorrectionTargetRef {
+  return { kind: "agent_memory", id };
+}
+
+function statusForAgentMemoryCorrection(kind: AgentMemoryCorrectionInput["correctionKind"]): AgentMemoryEntry["status"] {
+  if (kind === "corrected") return "corrected";
+  if (kind === "forgotten") return "forgotten";
+  return "retracted";
+}
+
+export async function applyAgentMemoryCorrection(
+  host: AgentMemoryHost,
+  input: AgentMemoryCorrectionInput
+): Promise<AgentMemoryCorrectionResult> {
+  const store = await host.loadAgentMemoryStore();
+  const targetIndex = store.entries.findIndex((entry) => entry.id === input.targetId);
+  if (targetIndex < 0) {
+    throw new Error(`agent memory not found: ${input.targetId}`);
+  }
+
+  const now = input.createdAt ?? new Date().toISOString();
+  const target = store.entries[targetIndex]!;
+  let replacement: AgentMemoryEntry | null = null;
+  if (input.correctionKind === "corrected") {
+    if (!input.replacementValue) {
+      throw new Error("replacementValue is required for corrected agent memory");
+    }
+    replacement = AgentMemoryEntrySchema.parse({
+      id: randomUUID(),
+      key: input.replacementKey ?? `${target.key}.corrected.${now.replace(/[^0-9]/g, "").slice(0, 14)}`,
+      value: input.replacementValue,
+      tags: target.tags,
+      category: target.category,
+      memory_type: target.memory_type,
+      status: target.status === "compiled" ? "compiled" : "raw",
+      supersedes_memory_id: target.id,
+      created_at: now,
+      updated_at: now,
+    });
+    store.entries.push(replacement);
+  }
+
+  const correction = MemoryCorrectionEntrySchema.parse({
+    correction_id: `agent-memory-correction-${randomUUID()}`,
+    target_ref: agentMemoryRef(target.id),
+    correction_kind: input.correctionKind,
+    replacement_ref: replacement ? agentMemoryRef(replacement.id) : null,
+    actor: input.actor ?? "user",
+    reason: input.reason,
+    created_at: now,
+    provenance: {
+      source: input.actor ?? "user",
+      ...(input.provenanceRef ? { source_ref: input.provenanceRef } : {}),
+      confidence: 1,
+    },
+  } satisfies MemoryCorrectionEntryInput);
+  store.corrections.push(correction);
+  const correctionState = summarizeMemoryCorrectionState(store.corrections);
+  const targetState = correctionStateForTarget(correctionState, agentMemoryRef(target.id));
+  const updatedTarget = AgentMemoryEntrySchema.parse({
+    ...target,
+    status: statusForAgentMemoryCorrection(input.correctionKind),
+    correction_state: targetState,
+    updated_at: now,
+  });
+  store.entries[targetIndex] = updatedTarget;
+  await host.saveAgentMemoryStore(store);
+  return { correction, target: updatedTarget, replacement };
+}
+
+export async function listAgentMemoryCorrectionHistory(
+  host: AgentMemoryHost,
+  target?: MemoryCorrectionTargetRef
+): Promise<MemoryCorrectionEntry[]> {
+  const store = await host.loadAgentMemoryStore();
+  const corrections = [...(store.corrections ?? [])].sort((a, b) => a.created_at.localeCompare(b.created_at));
+  if (!target) return corrections;
+  const targetKey = memoryCorrectionTargetKey(target);
+  return corrections.filter((correction) => memoryCorrectionTargetKey(correction.target_ref) === targetKey);
 }
 
 export async function consolidateAgentMemoryEntries(

--- a/src/platform/knowledge/knowledge-manager.ts
+++ b/src/platform/knowledge/knowledge-manager.ts
@@ -51,14 +51,21 @@ import {
 } from "./knowledge-manager-internals.js";
 import {
   archiveAgentMemoryEntries,
+  applyAgentMemoryCorrection,
   autoConsolidateAgentMemory,
   consolidateAgentMemoryEntries,
   deleteAgentMemoryEntry,
   getAgentMemoryStatsForHost,
+  listAgentMemoryCorrectionHistory,
   listAgentMemoryEntries,
   recallAgentMemoryEntries,
   saveAgentMemoryEntry,
 } from "./knowledge-manager-agent-memory.js";
+import type {
+  MemoryCorrectionEntry,
+  MemoryCorrectionKind,
+  MemoryCorrectionTargetRef,
+} from "../corrections/memory-correction-ledger.js";
 import {
   saveDomainKnowledgeEntry,
   saveSharedKnowledgeEntry,
@@ -411,6 +418,21 @@ export class KnowledgeManager {
    */
   async deleteAgentMemory(key: string): Promise<boolean> {
     return deleteAgentMemoryEntry(this.agentMemoryHost(), key);
+  }
+
+  async correctAgentMemory(input: {
+    targetId: string;
+    correctionKind: Extract<MemoryCorrectionKind, "corrected" | "forgotten" | "retracted">;
+    reason: string;
+    replacementValue?: string;
+    replacementKey?: string;
+    provenanceRef?: string;
+  }): Promise<Awaited<ReturnType<typeof applyAgentMemoryCorrection>>> {
+    return applyAgentMemoryCorrection(this.agentMemoryHost(), input);
+  }
+
+  async listAgentMemoryCorrectionHistory(target?: MemoryCorrectionTargetRef): Promise<MemoryCorrectionEntry[]> {
+    return listAgentMemoryCorrectionHistory(this.agentMemoryHost(), target);
   }
 
   // ─── consolidateAgentMemory ───

--- a/src/platform/knowledge/types/agent-memory.ts
+++ b/src/platform/knowledge/types/agent-memory.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
-import { MemoryCorrectionTargetStateSchema } from "../../corrections/memory-correction-ledger.js";
+import {
+  MemoryCorrectionEntrySchema,
+  MemoryCorrectionTargetStateSchema,
+} from "../../corrections/memory-correction-ledger.js";
 
 // --- AgentMemoryType ---
 
@@ -39,6 +42,7 @@ export type AgentMemoryEntry = z.infer<typeof AgentMemoryEntrySchema>;
 
 export const AgentMemoryStoreSchema = z.object({
   entries: z.array(AgentMemoryEntrySchema),
+  corrections: z.array(MemoryCorrectionEntrySchema).default([]),
   last_consolidated_at: z.string().nullable().default(null),
 });
 export type AgentMemoryStore = z.infer<typeof AgentMemoryStoreSchema>;

--- a/src/platform/soil/__tests__/soil-content-projections.test.ts
+++ b/src/platform/soil/__tests__/soil-content-projections.test.ts
@@ -123,6 +123,7 @@ describe("Soil content projections", () => {
             updated_at: "2026-04-11T08:30:00.000Z",
           },
         ],
+        corrections: [],
         last_consolidated_at: "2026-04-11T09:15:00.000Z",
       };
 

--- a/src/tools/builtin/exports.ts
+++ b/src/tools/builtin/exports.ts
@@ -91,6 +91,7 @@ export { RunAdapterTool } from "../execution/RunAdapterTool/RunAdapterTool.js";
 export { SpawnSessionTool } from "../execution/SpawnSessionTool/SpawnSessionTool.js";
 export { WriteKnowledgeTool } from "../execution/WriteKnowledgeTool/WriteKnowledgeTool.js";
 export { MemorySaveTool } from "../execution/MemorySaveTool/MemorySaveTool.js";
+export { MemoryCorrectionTool } from "../execution/MemoryCorrectionTool/MemoryCorrectionTool.js";
 export { MemoryConsolidateTool } from "../execution/MemoryConsolidateTool/MemoryConsolidateTool.js";
 export { MemoryLintTool } from "../execution/MemoryLintTool/MemoryLintTool.js";
 export { MemoryRecallTool } from "../query/MemoryRecallTool/MemoryRecallTool.js";

--- a/src/tools/builtin/factory.ts
+++ b/src/tools/builtin/factory.ts
@@ -50,6 +50,7 @@ import { TogglePluginTool } from "../mutation/TogglePluginTool/TogglePluginTool.
 import { UpdateConfigTool } from "../mutation/UpdateConfigTool/UpdateConfigTool.js";
 import { UpdateGoalTool } from "../mutation/UpdateGoalTool/UpdateGoalTool.js";
 import { MemoryConsolidateTool } from "../execution/MemoryConsolidateTool/MemoryConsolidateTool.js";
+import { MemoryCorrectionTool } from "../execution/MemoryCorrectionTool/MemoryCorrectionTool.js";
 import { MemoryLintTool } from "../execution/MemoryLintTool/MemoryLintTool.js";
 import { MemorySaveTool } from "../execution/MemorySaveTool/MemorySaveTool.js";
 import { ObserveGoalTool } from "../execution/ObserveGoalTool/ObserveGoalTool.js";
@@ -227,6 +228,7 @@ export function createBuiltinTools(deps?: BuiltinToolDeps): ITool[] {
       new ProgressHistoryTool(deps.stateManager),
       new TaskListTool(deps.stateManager),
       new TaskGetTool(deps.stateManager),
+      new MemoryCorrectionTool(deps.stateManager),
     );
     tools.push(...createCoreLoopControlTools(
       deps.coreLoopControl ?? createDaemonBackedCoreLoopControlToolset({ stateManager: deps.stateManager }),

--- a/src/tools/execution/MemoryCorrectionTool/MemoryCorrectionTool.ts
+++ b/src/tools/execution/MemoryCorrectionTool/MemoryCorrectionTool.ts
@@ -1,0 +1,94 @@
+import { z } from "zod";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolDescriptionContext,
+  ToolMetadata,
+  ToolResult,
+} from "../../types.js";
+import type { StateManager } from "../../../base/state/state-manager.js";
+import {
+  parseMemoryCorrectionRef,
+  runUserMemoryOperation,
+} from "../../../platform/corrections/user-memory-operations.js";
+import { DESCRIPTION } from "./prompt.js";
+import { ALIASES, PERMISSION_LEVEL, READ_ONLY, TAGS, TOOL_NAME } from "./constants.js";
+
+export const MemoryCorrectionInputSchema = z.object({
+  operation: z.enum(["correct", "forget", "retract", "history"]),
+  target_ref: z.string().min(1).describe("Exact typed ref: agent_memory:<id>, runtime_evidence:<id>, dream_checkpoint:<ref>, or soil_record:<id>"),
+  reason: z.string().min(1).optional(),
+  replacement_value: z.string().min(1).optional(),
+  replacement_ref: z.string().min(1).optional(),
+  replacement_key: z.string().min(1).optional(),
+  goal_id: z.string().min(1).optional(),
+  run_id: z.string().min(1).optional(),
+  task_id: z.string().min(1).optional(),
+});
+export type MemoryCorrectionInput = z.infer<typeof MemoryCorrectionInputSchema>;
+
+export class MemoryCorrectionTool implements ITool<MemoryCorrectionInput, unknown> {
+  readonly metadata: ToolMetadata = {
+    name: TOOL_NAME,
+    aliases: [...ALIASES],
+    permissionLevel: PERMISSION_LEVEL,
+    isReadOnly: READ_ONLY,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: 2000,
+    tags: [...TAGS],
+  };
+
+  readonly inputSchema = MemoryCorrectionInputSchema;
+
+  constructor(private readonly stateManager: StateManager) {}
+
+  description(_context?: ToolDescriptionContext): string {
+    return DESCRIPTION;
+  }
+
+  async call(input: MemoryCorrectionInput, _context: ToolCallContext): Promise<ToolResult> {
+    const startTime = Date.now();
+    try {
+      const result = await runUserMemoryOperation(this.stateManager, {
+        operation: input.operation,
+        targetRef: parseMemoryCorrectionRef(input.target_ref),
+        reason: input.reason,
+        replacementValue: input.replacement_value,
+        replacementKey: input.replacement_key,
+        replacementRef: input.replacement_ref ? parseMemoryCorrectionRef(input.replacement_ref) : null,
+        goalId: input.goal_id,
+        runId: input.run_id,
+        taskId: input.task_id,
+      });
+      return {
+        success: true,
+        data: result,
+        summary: input.operation === "history"
+          ? `Found ${result.history.length} correction history entries`
+          : `Memory ${input.operation} recorded: ${result.correction?.correction_id}`,
+        durationMs: Date.now() - startTime,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        data: null,
+        summary: "MemoryCorrectionTool failed: " + (err as Error).message,
+        error: (err as Error).message,
+        durationMs: Date.now() - startTime,
+      };
+    }
+  }
+
+  async checkPermissions(input: MemoryCorrectionInput, _context: ToolCallContext): Promise<PermissionCheckResult> {
+    if (input.operation === "history") return { status: "allowed" };
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(_input: MemoryCorrectionInput): boolean {
+    return false;
+  }
+}

--- a/src/tools/execution/MemoryCorrectionTool/__tests__/MemoryCorrectionTool.test.ts
+++ b/src/tools/execution/MemoryCorrectionTool/__tests__/MemoryCorrectionTool.test.ts
@@ -1,0 +1,133 @@
+import * as fsp from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
+import { StateManager } from "../../../../base/state/state-manager.js";
+import { RuntimeEvidenceLedger } from "../../../../runtime/store/evidence-ledger.js";
+import type { ToolCallContext } from "../../../types.js";
+import { MemoryCorrectionTool } from "../MemoryCorrectionTool.js";
+
+const context: ToolCallContext = {
+  cwd: "/tmp",
+  goalId: "goal-memory",
+  trustBalance: 50,
+  preApproved: false,
+  approvalFn: async () => false,
+  sessionId: "session-memory",
+};
+
+describe("MemoryCorrectionTool", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir("pulseed-memory-correction-tool-");
+    stateManager = new StateManager(tmpDir);
+    await stateManager.init();
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns structured refs and retracts runtime evidence from default summaries", async () => {
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      id: "evidence-stale",
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      kind: "observation",
+      scope: { goal_id: "goal-memory", run_id: "run:memory" },
+      summary: "Stale evidence that should not plan.",
+      outcome: "continued",
+    });
+
+    const tool = new MemoryCorrectionTool(stateManager);
+    const result = await tool.call({
+      operation: "retract",
+      target_ref: "runtime_evidence:evidence-stale",
+      reason: "User identified the evidence as incorrect.",
+      goal_id: "goal-memory",
+      run_id: "run:memory",
+    }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      operation: "retract",
+      target_ref: {
+        kind: "runtime_evidence",
+        id: "evidence-stale",
+        scope: { goal_id: "goal-memory", run_id: "run:memory" },
+      },
+      correction: {
+        correction_kind: "retracted",
+        target_ref: {
+          kind: "runtime_evidence",
+          id: "evidence-stale",
+          scope: { goal_id: "goal-memory", run_id: "run:memory" },
+        },
+      },
+    });
+
+    const summary = await new RuntimeEvidenceLedger(path.join(tmpDir, "runtime")).summarizeRun("run:memory");
+    expect(summary.corrections).toHaveLength(1);
+    expect(summary.recent_entries.map((entry) => entry.id)).not.toContain("evidence-stale");
+  });
+
+  it("keeps runtime evidence history scoped when ids repeat across runs", async () => {
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      id: "evidence-shared",
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      kind: "observation",
+      scope: { goal_id: "goal-memory", run_id: "run:a" },
+      summary: "Stale evidence in run A.",
+      outcome: "continued",
+    });
+    await ledger.append({
+      id: "evidence-shared",
+      occurred_at: "2026-05-02T00:00:00.000Z",
+      kind: "observation",
+      scope: { goal_id: "goal-memory", run_id: "run:b" },
+      summary: "Stale evidence in run B.",
+      outcome: "continued",
+    });
+
+    const tool = new MemoryCorrectionTool(stateManager);
+    await tool.call({
+      operation: "retract",
+      target_ref: "runtime_evidence:evidence-shared",
+      reason: "Run A evidence was incorrect.",
+      goal_id: "goal-memory",
+      run_id: "run:a",
+    }, context);
+    await tool.call({
+      operation: "retract",
+      target_ref: "runtime_evidence:evidence-shared",
+      reason: "Run B evidence was incorrect.",
+      goal_id: "goal-memory",
+      run_id: "run:b",
+    }, context);
+
+    const result = await tool.call({
+      operation: "history",
+      target_ref: "runtime_evidence:evidence-shared",
+      goal_id: "goal-memory",
+      run_id: "run:a",
+    }, context);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toMatchObject({
+      history: [
+        expect.objectContaining({
+          reason: "Run A evidence was incorrect.",
+          target_ref: {
+            kind: "runtime_evidence",
+            id: "evidence-shared",
+            scope: { goal_id: "goal-memory", run_id: "run:a" },
+          },
+        }),
+      ],
+    });
+    expect(JSON.stringify(result.data)).not.toContain("Run B evidence was incorrect.");
+  });
+});

--- a/src/tools/execution/MemoryCorrectionTool/constants.ts
+++ b/src/tools/execution/MemoryCorrectionTool/constants.ts
@@ -1,0 +1,5 @@
+export const TOOL_NAME = "memory_correction";
+export const ALIASES = ["memory_correct", "memory_forget", "memory_retract", "memory_history"] as const;
+export const TAGS = ["memory", "correction", "write"] as const;
+export const READ_ONLY = false;
+export const PERMISSION_LEVEL = "write_local" as const;

--- a/src/tools/execution/MemoryCorrectionTool/prompt.ts
+++ b/src/tools/execution/MemoryCorrectionTool/prompt.ts
@@ -1,0 +1,1 @@
+export const DESCRIPTION = "Record auditable user memory corrections, forget/retract requests, or inspect correction history using typed memory refs.";


### PR DESCRIPTION
Closes #891

## Summary
- add auditable agent-memory correct/forget/retract/history operations backed by correction ledger entries
- add `pulseed memory correct|forget|retract|history <kind:id>` and reject destructive deletion from the default command path
- add `memory_correction` built-in tool with structured target/replacement refs and runtime evidence retraction support
- keep inactive agent memories out of default list/recall while preserving originals for audit

## Verification
- npm run typecheck
- npm exec vitest run src/platform/corrections/__tests__/user-memory-operations.test.ts src/interface/cli/commands/__tests__/memory.test.ts src/tools/execution/MemoryCorrectionTool/__tests__/MemoryCorrectionTool.test.ts src/platform/soil/__tests__/soil-content-projections.test.ts
- npm run lint:boundaries
- npm run test:changed

## Known risks
- non-agent memory refs require `--goal` or `--run` so correction audit entries can be scoped in the runtime evidence ledger
