### PR TITLE
feat(memory): add personal data governance

### DIFF
--- a/src/interface/cli/commands/__tests__/memory.test.ts
+++ b/src/interface/cli/commands/__tests__/memory.test.ts
@@ -28,6 +28,23 @@ describe("cmdMemory", () => {
         tags: [],
         memory_type: "fact",
         status: "raw",
+        governance: {
+          sensitivity: "local",
+          consent: {
+            scope_id: "local_planning",
+            allowed_contexts: ["local_planning"],
+            source_actor: "user",
+            collection_context: "test",
+          },
+          retention: {
+            policy_id: "retain_until_retracted",
+            retain_until: null,
+            review_after: null,
+            delete_requires_approval: true,
+          },
+          export_visibility: "listed",
+          owner_ref: "user",
+        },
         created_at: "2026-05-02T00:00:00.000Z",
         updated_at: "2026-05-02T00:00:00.000Z",
       }],
@@ -81,5 +98,20 @@ describe("cmdMemory", () => {
     const store = AgentMemoryStoreSchema.parse(await stateManager.readRaw(AGENT_MEMORY_PATH));
     expect(store.entries[0]!.status).toBe("raw");
     expect(store.corrections).toEqual([]);
+  });
+
+  it("exports governance metadata for remembered user data", async () => {
+    const exitCode = await cmdMemory(stateManager, ["export", "--consent-scope", "local_planning"]);
+
+    expect(exitCode).toBe(0);
+    const output = JSON.parse(logs.at(-1) ?? "{}") as {
+      entries: Array<{ key: string; governance: { sensitivity: string } }>;
+    };
+    expect(output.entries).toEqual([
+      expect.objectContaining({
+        key: "temporary-fact",
+        governance: expect.objectContaining({ sensitivity: "local" }),
+      }),
+    ]);
   });
 });

--- a/src/interface/cli/commands/memory.ts
+++ b/src/interface/cli/commands/memory.ts
@@ -1,6 +1,8 @@
 import { getCliLogger } from "../cli-logger.js";
 import { formatOperationError } from "../utils.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
+import { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
+import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import {
   parseMemoryCorrectionRef,
   runUserMemoryOperation,
@@ -19,10 +21,20 @@ function hasOption(argv: string[], name: string): boolean {
 }
 
 function printUsage(): void {
-  getCliLogger().error("Usage: pulseed memory <correct|forget|retract|history> <kind:id> [--reason text] [--value text] [--replacement-ref kind:id] [--goal id] [--run id] [--task id]");
+  getCliLogger().error("Usage: pulseed memory <correct|forget|retract|history> <kind:id> ... | pulseed memory export [--consent-scope id] [--include-secret]");
 }
 
 export async function cmdMemory(stateManager: StateManager, argv: string[]): Promise<number> {
+  if (argv[0] === "export") {
+    const manager = new KnowledgeManager(stateManager, {} as ILLMClient);
+    const entries = await manager.exportAgentMemoryGovernance({
+      consent_scope: optionValue(argv, "--consent-scope"),
+      include_secret: hasOption(argv, "--include-secret"),
+    });
+    console.log(JSON.stringify({ entries }, null, 2));
+    return 0;
+  }
+
   const operation = argv[0] as UserMemoryOperation | undefined;
   const refValue = argv[1];
   if (!operation || !UserMemoryOperationSchema.safeParse(operation).success || !refValue) {

--- a/src/platform/corrections/__tests__/user-memory-operations.test.ts
+++ b/src/platform/corrections/__tests__/user-memory-operations.test.ts
@@ -5,11 +5,11 @@ import { StateManager } from "../../../base/state/state-manager.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import { KnowledgeManager } from "../../knowledge/knowledge-manager.js";
 import { AGENT_MEMORY_PATH } from "../../knowledge/knowledge-manager-internals.js";
-import type { AgentMemoryEntry } from "../../knowledge/types/agent-memory.js";
+import { AgentMemoryEntrySchema, type AgentMemoryEntry } from "../../knowledge/types/agent-memory.js";
 import { runUserMemoryOperation } from "../user-memory-operations.js";
 
 function memoryEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntry {
-  return {
+  return AgentMemoryEntrySchema.parse({
     id: "memory-old",
     key: "favorite-editor",
     value: "The user prefers Atom.",
@@ -19,7 +19,7 @@ function memoryEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntr
     created_at: "2026-05-02T00:00:00.000Z",
     updated_at: "2026-05-02T00:00:00.000Z",
     ...overrides,
-  };
+  });
 }
 
 describe("user memory correction operations", () => {
@@ -75,5 +75,62 @@ describe("user memory correction operations", () => {
       correction_state: { status: "corrected", active: false, retained_for_audit: true },
     });
     expect(store.corrections).toHaveLength(1);
+  });
+
+  it("preserves governance when correcting sensitive user memory", async () => {
+    await stateManager.writeRaw(AGENT_MEMORY_PATH, {
+      entries: [
+        memoryEntry({
+          governance: {
+            sensitivity: "secret",
+            consent: {
+              scope_id: "private_chat",
+              allowed_contexts: ["private_chat"],
+              source_actor: "user",
+              collection_context: "chat",
+            },
+            retention: {
+              policy_id: "retain_until_retracted",
+              retain_until: null,
+              review_after: null,
+              delete_requires_approval: true,
+            },
+            export_visibility: "redacted",
+            owner_ref: "user",
+          },
+        }),
+      ],
+      corrections: [],
+      last_consolidated_at: null,
+    });
+
+    await runUserMemoryOperation(stateManager, {
+      operation: "correct",
+      targetRef: { kind: "agent_memory", id: "memory-old" },
+      reason: "User corrected a sensitive detail.",
+      replacementValue: "Corrected sensitive detail.",
+      replacementKey: "sensitive-detail-current",
+      now: "2026-05-02T01:00:00.000Z",
+    });
+
+    const manager = new KnowledgeManager(stateManager, {} as ILLMClient);
+    expect(await manager.recallAgentMemory("sensitive-detail-current", {
+      exact: true,
+      consent_scope: "local_planning",
+      max_sensitivity: "local",
+    })).toEqual([]);
+    expect(await manager.recallAgentMemory("sensitive-detail-current", {
+      exact: true,
+      consent_scope: "private_chat",
+      max_sensitivity: "secret",
+    })).toEqual([
+      expect.objectContaining({
+        key: "sensitive-detail-current",
+        governance: expect.objectContaining({
+          sensitivity: "secret",
+          export_visibility: "redacted",
+        }),
+      }),
+    ]);
   });
 });

--- a/src/platform/corrections/memory-governance.ts
+++ b/src/platform/corrections/memory-governance.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+export const MemorySensitivitySchema = z.enum(["public", "local", "private", "secret"]);
+export type MemorySensitivity = z.infer<typeof MemorySensitivitySchema>;
+
+export const MemoryConsentScopeSchema = z.object({
+  scope_id: z.string().min(1).default("local_planning"),
+  allowed_contexts: z.array(z.string().min(1)).default(["local_planning"]),
+  source_actor: z.string().min(1).default("user"),
+  collection_context: z.string().min(1).default("memory_save"),
+  granted_at: z.string().datetime().optional(),
+}).strict();
+export type MemoryConsentScope = z.infer<typeof MemoryConsentScopeSchema>;
+
+export const MemoryRetentionPolicySchema = z.object({
+  policy_id: z.string().min(1).default("retain_until_retracted"),
+  retain_until: z.string().datetime().nullable().default(null),
+  review_after: z.string().datetime().nullable().default(null),
+  delete_requires_approval: z.boolean().default(true),
+}).strict();
+export type MemoryRetentionPolicy = z.infer<typeof MemoryRetentionPolicySchema>;
+
+export const MemoryGovernanceSchema = z.object({
+  sensitivity: MemorySensitivitySchema.default("local"),
+  consent: MemoryConsentScopeSchema.default({}),
+  retention: MemoryRetentionPolicySchema.default({}),
+  export_visibility: z.enum(["listed", "redacted", "hidden"]).default("listed"),
+  owner_ref: z.string().min(1).default("user"),
+}).strict();
+export type MemoryGovernance = z.infer<typeof MemoryGovernanceSchema>;
+export type MemoryGovernanceInput = z.input<typeof MemoryGovernanceSchema>;
+
+const sensitivityRank: Record<MemorySensitivity, number> = {
+  public: 0,
+  local: 1,
+  private: 2,
+  secret: 3,
+};
+
+export function isSensitivityAllowed(actual: MemorySensitivity, max: MemorySensitivity): boolean {
+  return sensitivityRank[actual] <= sensitivityRank[max];
+}

--- a/src/platform/dream/__tests__/dream-soil-mutation.test.ts
+++ b/src/platform/dream/__tests__/dream-soil-mutation.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vitest";
-import type { AgentMemoryEntry } from "../../knowledge/types/agent-memory.js";
+import { AgentMemoryEntrySchema, type AgentMemoryEntry } from "../../knowledge/types/agent-memory.js";
 import type { LearnedPattern } from "../../knowledge/types/learning.js";
 import type { DreamWorkflowRecord } from "../dream-event-workflows.js";
 import { buildDreamSoilMutationIntent } from "../dream-soil-mutation.js";
 
 function makeAgentMemoryEntry(overrides: Partial<AgentMemoryEntry> & Pick<AgentMemoryEntry, "id" | "key" | "value" | "created_at" | "updated_at">): AgentMemoryEntry {
-  return {
+  return AgentMemoryEntrySchema.parse({
     tags: [],
     memory_type: "fact",
     status: "raw",
     ...overrides,
-  };
+  });
 }
 
 function makeLearnedPattern(overrides: Partial<LearnedPattern> & Pick<LearnedPattern, "pattern_id" | "type" | "description" | "confidence" | "evidence_count" | "source_goal_ids" | "applicable_domains" | "created_at">): LearnedPattern {

--- a/src/platform/knowledge/__tests__/knowledge-manager-governance.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-manager-governance.test.ts
@@ -1,0 +1,86 @@
+import * as fsp from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { StateManager } from "../../../base/state/state-manager.js";
+import type { ILLMClient } from "../../../base/llm/llm-client.js";
+import { KnowledgeManager } from "../knowledge-manager.js";
+
+describe("KnowledgeManager memory governance", () => {
+  let tmpDir: string;
+  let manager: KnowledgeManager;
+
+  beforeEach(async () => {
+    tmpDir = makeTempDir("pulseed-memory-governance-");
+    const stateManager = new StateManager(tmpDir);
+    await stateManager.init();
+    manager = new KnowledgeManager(stateManager, {} as ILLMClient);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("filters retrieval by consent scope and sensitivity", async () => {
+    await manager.saveAgentMemory({
+      key: "public-note",
+      value: "Useful local note.",
+      governance: {
+        sensitivity: "local",
+        consent: {
+          scope_id: "local_planning",
+          allowed_contexts: ["local_planning"],
+          source_actor: "user",
+          collection_context: "memory_save",
+        },
+        retention: {
+          policy_id: "retain_until_retracted",
+          retain_until: null,
+          review_after: null,
+          delete_requires_approval: true,
+        },
+        export_visibility: "listed",
+        owner_ref: "user",
+      },
+    });
+    await manager.saveAgentMemory({
+      key: "secret-note",
+      value: "Secret value.",
+      governance: {
+        sensitivity: "secret",
+        consent: {
+          scope_id: "private_chat",
+          allowed_contexts: ["private_chat"],
+          source_actor: "user",
+          collection_context: "chat",
+        },
+        retention: {
+          policy_id: "retain_until_retracted",
+          retain_until: null,
+          review_after: null,
+          delete_requires_approval: true,
+        },
+        export_visibility: "listed",
+        owner_ref: "user",
+      },
+    });
+
+    expect((await manager.listAgentMemory({
+      consent_scope: "local_planning",
+      max_sensitivity: "local",
+      limit: 10,
+    })).map((entry) => entry.key)).toEqual(["public-note"]);
+  });
+
+  it("exports governance metadata while hiding secret memories by default", async () => {
+    await manager.saveAgentMemory({ key: "local-note", value: "Local", governance: { sensitivity: "local" } });
+    await manager.saveAgentMemory({ key: "secret-note", value: "Secret", governance: { sensitivity: "secret" } });
+
+    const visible = await manager.exportAgentMemoryGovernance();
+    const withSecret = await manager.exportAgentMemoryGovernance({ include_secret: true });
+
+    expect(visible.map((entry) => entry.key)).toEqual(["local-note"]);
+    expect(withSecret.map((entry) => entry.key).sort()).toEqual(["local-note", "secret-note"]);
+    expect(withSecret[0]!.governance).toHaveProperty("retention");
+    expect(withSecret[0]!.governance).toHaveProperty("consent");
+  });
+});

--- a/src/platform/knowledge/__tests__/knowledge-manager-lint.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-manager-lint.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { lintAgentMemory } from "../knowledge-manager-lint.js";
 import type { KnowledgeManager } from "../knowledge-manager.js";
-import type { AgentMemoryEntry } from "../types/agent-memory.js";
+import { AgentMemoryEntrySchema, type AgentMemoryEntry } from "../types/agent-memory.js";
 
 // ─── Mock helpers ───
 
 function makeEntry(overrides: Partial<AgentMemoryEntry> & { id: string; key: string }): AgentMemoryEntry {
-  return {
+  return AgentMemoryEntrySchema.parse({
     id: overrides.id,
     key: overrides.key,
     value: overrides.value ?? "some value",
@@ -21,7 +21,7 @@ function makeEntry(overrides: Partial<AgentMemoryEntry> & { id: string; key: str
     compiled_from: overrides.compiled_from,
     created_at: overrides.created_at ?? "2026-01-01T00:00:00.000Z",
     updated_at: overrides.updated_at ?? "2026-01-01T00:00:00.000Z",
-  };
+  });
 }
 
 function makeKM(entries: AgentMemoryEntry[] = []): {

--- a/src/platform/knowledge/__tests__/knowledge-manager-semantic-recall.test.ts
+++ b/src/platform/knowledge/__tests__/knowledge-manager-semantic-recall.test.ts
@@ -7,7 +7,7 @@ import type { IEmbeddingClient } from "../embedding-client.js";
 import { cosineSimilarity } from "../embedding-client.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
-import type { AgentMemoryEntry } from "../types/agent-memory.js";
+import { AgentMemoryEntrySchema, type AgentMemoryEntry } from "../types/agent-memory.js";
 
 // ─── Helpers ───
 
@@ -28,7 +28,7 @@ function makeKM(embeddingClient?: IEmbeddingClient): KnowledgeManager {
 }
 
 function makeEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntry {
-  return {
+  return AgentMemoryEntrySchema.parse({
     id: `mem-${Math.random().toString(36).slice(2)}`,
     key: "test.key",
     value: "test value",
@@ -39,7 +39,7 @@ function makeEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntry 
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,
-  };
+  });
 }
 
 async function seedMemory(km: KnowledgeManager, entries: AgentMemoryEntry[]): Promise<void> {

--- a/src/platform/knowledge/knowledge-manager-agent-memory.ts
+++ b/src/platform/knowledge/knowledge-manager-agent-memory.ts
@@ -14,6 +14,13 @@ import {
 import { MemoryQuarantineStateSchema, type MemoryQuarantineState } from "../corrections/memory-quarantine.js";
 import type { MemoryProvenance, MemoryVerificationStatus } from "../corrections/memory-quarantine.js";
 import {
+  isSensitivityAllowed,
+  MemoryGovernanceSchema,
+  type MemoryGovernance,
+  type MemoryGovernanceInput,
+  type MemorySensitivity,
+} from "../corrections/memory-governance.js";
+import {
   AgentMemoryEntrySchema,
 } from "./types/agent-memory.js";
 import type { AgentMemoryEntry, AgentMemoryStatus, AgentMemoryStore, AgentMemoryType } from "./types/agent-memory.js";
@@ -50,6 +57,7 @@ export async function saveAgentMemoryEntry(
     memory_type?: AgentMemoryType;
     verification_status?: MemoryVerificationStatus;
     provenance?: MemoryProvenance;
+    governance?: MemoryGovernanceInput;
   }
 ): Promise<AgentMemoryEntry> {
   const store = await host.loadAgentMemoryStore();
@@ -67,6 +75,7 @@ export async function saveAgentMemoryEntry(
       memory_type: entry.memory_type ?? prev.memory_type,
       verification_status: entry.verification_status ?? prev.verification_status,
       provenance: entry.provenance ?? prev.provenance,
+      governance: entry.governance ? MemoryGovernanceSchema.parse(entry.governance) : prev.governance,
       status: prev.status,
       updated_at: now,
     });
@@ -81,6 +90,7 @@ export async function saveAgentMemoryEntry(
       memory_type: entry.memory_type ?? "fact",
       verification_status: entry.verification_status,
       provenance: entry.provenance,
+      governance: entry.governance ? MemoryGovernanceSchema.parse(entry.governance) : undefined,
       created_at: now,
       updated_at: now,
     });
@@ -101,13 +111,26 @@ export async function recallAgentMemoryEntries(
     limit?: number;
     include_archived?: boolean;
     semantic?: boolean;
+    consent_scope?: string;
+    max_sensitivity?: MemorySensitivity;
   }
 ): Promise<AgentMemoryEntry[]> {
   const store = await host.loadAgentMemoryStore();
-  const { exact = false, category, memory_type, limit = 10, include_archived = false, semantic = false } = opts ?? {};
+  const {
+    exact = false,
+    category,
+    memory_type,
+    limit = 10,
+    include_archived = false,
+    semantic = false,
+    consent_scope,
+    max_sensitivity,
+  } = opts ?? {};
 
   const candidates = store.entries.filter((e) => {
     if (!include_archived && !isAgentMemoryEntryActive(e)) return false;
+    if (consent_scope && !e.governance.consent.allowed_contexts.includes(consent_scope)) return false;
+    if (max_sensitivity && !isSensitivityAllowed(e.governance.sensitivity, max_sensitivity)) return false;
     const matchesCategory = category ? e.category === category : true;
     const matchesType = memory_type ? e.memory_type === memory_type : true;
     return matchesCategory && matchesType;
@@ -151,13 +174,17 @@ export async function listAgentMemoryEntries(
     memory_type?: AgentMemoryType;
     limit?: number;
     include_archived?: boolean;
+    consent_scope?: string;
+    max_sensitivity?: MemorySensitivity;
   }
 ): Promise<AgentMemoryEntry[]> {
   const store = await host.loadAgentMemoryStore();
-  const { category, memory_type, limit = 10, include_archived = false } = opts ?? {};
+  const { category, memory_type, limit = 10, include_archived = false, consent_scope, max_sensitivity } = opts ?? {};
 
   const results = store.entries.filter((e) => {
     if (!include_archived && !isAgentMemoryEntryActive(e)) return false;
+    if (consent_scope && !e.governance.consent.allowed_contexts.includes(consent_scope)) return false;
+    if (max_sensitivity && !isSensitivityAllowed(e.governance.sensitivity, max_sensitivity)) return false;
     const matchesCategory = category ? e.category === category : true;
     const matchesType = memory_type ? e.memory_type === memory_type : true;
     return matchesCategory && matchesType;
@@ -270,6 +297,9 @@ export async function applyAgentMemoryCorrection(
       tags: target.tags,
       category: target.category,
       memory_type: target.memory_type,
+      governance: target.governance,
+      provenance: target.provenance,
+      verification_status: target.verification_status,
       status: target.status === "compiled" ? "compiled" : "raw",
       supersedes_memory_id: target.id,
       created_at: now,
@@ -315,6 +345,35 @@ export async function listAgentMemoryCorrectionHistory(
   if (!target) return corrections;
   const targetKey = memoryCorrectionTargetKey(target);
   return corrections.filter((correction) => memoryCorrectionTargetKey(correction.target_ref) === targetKey);
+}
+
+export async function exportAgentMemoryGovernance(
+  host: AgentMemoryHost,
+  opts?: {
+    consent_scope?: string;
+    include_secret?: boolean;
+  }
+): Promise<Array<{
+  id: string;
+  key: string;
+  summary: string | null;
+  status: AgentMemoryEntry["status"];
+  governance: AgentMemoryEntry["governance"];
+  provenance: AgentMemoryEntry["provenance"] | null;
+}>> {
+  const store = await host.loadAgentMemoryStore();
+  return store.entries
+    .filter((entry) => opts?.include_secret || entry.governance.sensitivity !== "secret")
+    .filter((entry) => !opts?.consent_scope || entry.governance.consent.allowed_contexts.includes(opts.consent_scope))
+    .filter((entry) => entry.governance.export_visibility !== "hidden")
+    .map((entry) => ({
+      id: entry.id,
+      key: entry.governance.export_visibility === "redacted" ? "[redacted]" : entry.key,
+      summary: entry.governance.export_visibility === "redacted" ? null : entry.summary ?? entry.value,
+      status: entry.status,
+      governance: entry.governance,
+      provenance: entry.provenance ?? null,
+    }));
 }
 
 export async function consolidateAgentMemoryEntries(

--- a/src/platform/knowledge/knowledge-manager.ts
+++ b/src/platform/knowledge/knowledge-manager.ts
@@ -55,6 +55,7 @@ import {
   autoConsolidateAgentMemory,
   consolidateAgentMemoryEntries,
   deleteAgentMemoryEntry,
+  exportAgentMemoryGovernance,
   getAgentMemoryStatsForHost,
   listAgentMemoryCorrectionHistory,
   listAgentMemoryEntries,
@@ -64,6 +65,7 @@ import {
 } from "./knowledge-manager-agent-memory.js";
 import type { MemoryQuarantineState } from "../corrections/memory-quarantine.js";
 import type { MemoryProvenance, MemoryVerificationStatus } from "../corrections/memory-quarantine.js";
+import type { MemoryGovernanceInput, MemorySensitivity } from "../corrections/memory-governance.js";
 import type {
   MemoryCorrectionEntry,
   MemoryCorrectionKind,
@@ -378,6 +380,7 @@ export class KnowledgeManager {
     memory_type?: AgentMemoryType;
     verification_status?: MemoryVerificationStatus;
     provenance?: MemoryProvenance;
+    governance?: MemoryGovernanceInput;
   }): Promise<AgentMemoryEntry> {
     return saveAgentMemoryEntry(this.agentMemoryHost(), entry);
   }
@@ -399,6 +402,8 @@ export class KnowledgeManager {
       limit?: number;
       include_archived?: boolean;
       semantic?: boolean;
+      consent_scope?: string;
+      max_sensitivity?: MemorySensitivity;
     }
   ): Promise<AgentMemoryEntry[]> {
     return recallAgentMemoryEntries(this.agentMemoryHost(), query, opts);
@@ -413,6 +418,8 @@ export class KnowledgeManager {
     memory_type?: AgentMemoryType;
     limit?: number;
     include_archived?: boolean;
+    consent_scope?: string;
+    max_sensitivity?: MemorySensitivity;
   }): Promise<AgentMemoryEntry[]> {
     return listAgentMemoryEntries(this.agentMemoryHost(), opts);
   }
@@ -438,6 +445,13 @@ export class KnowledgeManager {
 
   async listAgentMemoryCorrectionHistory(target?: MemoryCorrectionTargetRef): Promise<MemoryCorrectionEntry[]> {
     return listAgentMemoryCorrectionHistory(this.agentMemoryHost(), target);
+  }
+
+  async exportAgentMemoryGovernance(opts?: {
+    consent_scope?: string;
+    include_secret?: boolean;
+  }): Promise<Awaited<ReturnType<typeof exportAgentMemoryGovernance>>> {
+    return exportAgentMemoryGovernance(this.agentMemoryHost(), opts);
   }
 
   async quarantineAgentMemory(input: {

--- a/src/platform/knowledge/types/agent-memory.ts
+++ b/src/platform/knowledge/types/agent-memory.ts
@@ -8,6 +8,7 @@ import {
   MemoryQuarantineStateSchema,
   MemoryVerificationStatusSchema,
 } from "../../corrections/memory-quarantine.js";
+import { MemoryGovernanceSchema } from "../../corrections/memory-governance.js";
 
 // --- AgentMemoryType ---
 
@@ -39,6 +40,7 @@ export const AgentMemoryEntrySchema = z.object({
   verification_status: MemoryVerificationStatusSchema.optional(),
   provenance: MemoryProvenanceSchema.optional(),
   quarantine_state: MemoryQuarantineStateSchema.optional(),
+  governance: MemoryGovernanceSchema.default({}),
   supersedes_memory_id: z.string().min(1).optional(),
   compiled_from: z.array(z.string()).optional(),
   created_at: z.string(),

--- a/src/platform/soil/__tests__/soil-content-projections.test.ts
+++ b/src/platform/soil/__tests__/soil-content-projections.test.ts
@@ -8,7 +8,7 @@ import type {
   SharedKnowledgeEntry,
 } from "../../../base/types/knowledge.js";
 import type { DreamWorkflowRecord } from "../../dream/dream-event-workflows.js";
-import type { AgentMemoryStore } from "../../knowledge/types/agent-memory.js";
+import { AgentMemoryStoreSchema, type AgentMemoryStore } from "../../knowledge/types/agent-memory.js";
 import type { SoilMemoryHealthSnapshot } from "../health.js";
 import { readSoilMarkdownFile } from "../io.js";
 import {
@@ -97,7 +97,7 @@ describe("Soil content projections", () => {
   it("projects memory, decision, and soil system pages", async () => {
     const baseDir = makeTempDir("soil-memory-projection-");
     try {
-      const store: AgentMemoryStore = {
+      const store: AgentMemoryStore = AgentMemoryStoreSchema.parse({
         entries: [
           {
             id: "mem-1",
@@ -121,6 +121,23 @@ describe("Soil content projections", () => {
             status: "raw",
             created_at: "2026-04-11T08:00:00.000Z",
             updated_at: "2026-04-11T08:30:00.000Z",
+          },
+          {
+            id: "mem-secret",
+            key: "private-health-detail",
+            value: "Sensitive detail should not become planning context.",
+            tags: ["private"],
+            memory_type: "observation",
+            status: "raw",
+            governance: {
+              sensitivity: "secret",
+              consent: {
+                scope_id: "private_chat",
+                allowed_contexts: ["private_chat"],
+              },
+            },
+            created_at: "2026-04-11T08:20:00.000Z",
+            updated_at: "2026-04-11T08:25:00.000Z",
           },
           {
             id: "mem-quarantined",
@@ -152,7 +169,7 @@ describe("Soil content projections", () => {
         ],
         corrections: [],
         last_consolidated_at: "2026-04-11T09:15:00.000Z",
-      };
+      });
 
       const decisions: DecisionRecord[] = [
         {
@@ -181,6 +198,7 @@ describe("Soil content projections", () => {
       expect(memoryPage?.body).toContain("Last consolidated at: 2026-04-11T09:15:00.000Z");
       expect(memoryPage?.body).toContain("Quarantined entries: 1");
       expect(memoryPage?.body).not.toContain("poisoned-web-memory");
+      expect(memoryPage?.body).not.toContain("private-health-detail");
 
       const preferencesPage = await readSoilMarkdownFile(path.join(baseDir, "soil", "memory", "preferences.md"));
       expect(preferencesPage?.body).toContain("Be concise and direct.");

--- a/src/platform/soil/content-projections.ts
+++ b/src/platform/soil/content-projections.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../base/types/knowledge.js";
 import type { AgentMemoryEntry, AgentMemoryStore } from "../knowledge/types/agent-memory.js";
 import { AgentMemoryStoreSchema } from "../knowledge/types/agent-memory.js";
+import { isSensitivityAllowed } from "../corrections/memory-governance.js";
 import { readTextFileOrNull } from "./io.js";
 import { SoilPageFrontmatterSchema, type SoilPageFrontmatter } from "./types.js";
 import {
@@ -93,7 +94,11 @@ function memoryEntrySection(entry: AgentMemoryEntry): string {
 }
 
 function isPlanningEligibleMemoryEntry(entry: AgentMemoryEntry): boolean {
-  return entry.status === "raw" || entry.status === "compiled";
+  return (
+    (entry.status === "raw" || entry.status === "compiled") &&
+    entry.governance.consent.allowed_contexts.includes("local_planning") &&
+    isSensitivityAllowed(entry.governance.sensitivity, "local")
+  );
 }
 
 function decisionSection(record: DecisionRecord): string {

--- a/src/tools/execution/MemorySaveTool/MemorySaveTool.ts
+++ b/src/tools/execution/MemorySaveTool/MemorySaveTool.ts
@@ -12,6 +12,7 @@ import {
   MemoryProvenanceSchema,
   MemoryVerificationStatusSchema,
 } from "../../../platform/corrections/memory-quarantine.js";
+import { MemoryGovernanceSchema } from "../../../platform/corrections/memory-governance.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, READ_ONLY, PERMISSION_LEVEL, TOOL_NAME, ALIASES } from "./constants.js";
 
@@ -27,6 +28,7 @@ export const MemorySaveInputSchema = z.object({
   tags: z.array(z.string()).optional().describe("Tags for filtering and search"),
   verification_status: MemoryVerificationStatusSchema.optional(),
   provenance: MemoryProvenanceSchema.optional(),
+  governance: MemoryGovernanceSchema.optional(),
 });
 export type MemorySaveInput = z.infer<typeof MemorySaveInputSchema>;
 
@@ -63,6 +65,7 @@ export class MemorySaveTool implements ITool<MemorySaveInput, unknown> {
         tags: input.tags,
         verification_status: input.verification_status,
         provenance: input.provenance,
+        governance: input.governance,
       });
       return {
         success: true,

--- a/src/tools/execution/MemorySaveTool/__tests__/MemorySaveTool.test.ts
+++ b/src/tools/execution/MemorySaveTool/__tests__/MemorySaveTool.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemorySaveTool } from "../MemorySaveTool.js";
 import type { KnowledgeManager } from "../../../../platform/knowledge/knowledge-manager.js";
 import type { ToolCallContext } from "../../../types.js";
-import type { AgentMemoryEntry } from "../../../../platform/knowledge/types/agent-memory.js";
+import { AgentMemoryEntrySchema, type AgentMemoryEntry } from "../../../../platform/knowledge/types/agent-memory.js";
 
 const makeContext = (): ToolCallContext => ({
   cwd: "/tmp",
@@ -14,7 +14,7 @@ const makeContext = (): ToolCallContext => ({
 });
 
 function makeSavedEntry(key: string): AgentMemoryEntry {
-  return {
+  return AgentMemoryEntrySchema.parse({
     id: "entry-id-1",
     key,
     value: "some value",
@@ -24,7 +24,7 @@ function makeSavedEntry(key: string): AgentMemoryEntry {
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     summary: "",
-  } as AgentMemoryEntry;
+  });
 }
 
 function makeMockKM(overrides: Partial<KnowledgeManager> = {}): KnowledgeManager {
@@ -140,6 +140,39 @@ describe("MemorySaveTool", () => {
           provenance: expect.objectContaining({
             source_type: "web",
             raw_refs: ["snapshot:1"],
+          }),
+        })
+      );
+    });
+
+    it("passes governance metadata to saveAgentMemory", async () => {
+      await tool.call({
+        key: "k",
+        value: "v",
+        memory_type: "fact",
+        governance: {
+          sensitivity: "private",
+          consent: {
+            scope_id: "chat_only",
+            allowed_contexts: ["chat"],
+            source_actor: "user",
+            collection_context: "chat",
+          },
+          retention: {
+            policy_id: "review",
+            retain_until: null,
+            review_after: null,
+            delete_requires_approval: true,
+          },
+          export_visibility: "listed",
+          owner_ref: "user",
+        },
+      }, makeContext());
+      expect(vi.mocked(km.saveAgentMemory)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          governance: expect.objectContaining({
+            sensitivity: "private",
+            consent: expect.objectContaining({ allowed_contexts: ["chat"] }),
           }),
         })
       );

--- a/src/tools/query/MemoryRecallTool/MemoryRecallTool.ts
+++ b/src/tools/query/MemoryRecallTool/MemoryRecallTool.ts
@@ -11,6 +11,7 @@ import { DESCRIPTION } from "./prompt.js";
 import { TAGS, PERMISSION_LEVEL, MAX_OUTPUT_CHARS } from "./constants.js";
 import type { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
 import type { AgentMemoryEntry } from "../../../platform/knowledge/types/agent-memory.js";
+import { MemorySensitivitySchema } from "../../../platform/corrections/memory-governance.js";
 
 export const MemoryRecallInputSchema = z.object({
   query: z
@@ -48,6 +49,15 @@ export const MemoryRecallInputSchema = z.object({
     .optional()
     .default("keyword")
     .describe("Search mode: keyword (substring match) or semantic (embedding-based similarity)"),
+  consent_scope: z
+    .string()
+    .optional()
+    .default("local_planning")
+    .describe("Typed consent context required for returned memories"),
+  max_sensitivity: MemorySensitivitySchema
+    .optional()
+    .default("local")
+    .describe("Maximum sensitivity allowed in returned memories"),
 });
 export type MemoryRecallInput = z.input<typeof MemoryRecallInputSchema>;
 
@@ -97,6 +107,8 @@ export class MemoryRecallTool
           limit: parsedInput.limit,
           include_archived: parsedInput.include_archived,
           semantic: parsedInput.mode === "semantic",
+          consent_scope: parsedInput.consent_scope,
+          max_sensitivity: parsedInput.max_sensitivity,
         }
       );
 

--- a/src/tools/query/MemoryRecallTool/__tests__/MemoryRecallTool.test.ts
+++ b/src/tools/query/MemoryRecallTool/__tests__/MemoryRecallTool.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRecallTool } from "../MemoryRecallTool.js";
 import type { KnowledgeManager } from "../../../../platform/knowledge/knowledge-manager.js";
 import type { ToolCallContext } from "../../../types.js";
-import type { AgentMemoryEntry } from "../../../../platform/knowledge/types/agent-memory.js";
+import { AgentMemoryEntrySchema, type AgentMemoryEntry } from "../../../../platform/knowledge/types/agent-memory.js";
 
 const makeContext = (): ToolCallContext => ({
   cwd: "/tmp",
@@ -13,7 +13,7 @@ const makeContext = (): ToolCallContext => ({
 });
 
 function makeEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntry {
-  return {
+  return AgentMemoryEntrySchema.parse({
     id: "mem-1",
     key: "user.language",
     value: "TypeScript",
@@ -24,7 +24,7 @@ function makeEntry(overrides: Partial<AgentMemoryEntry> = {}): AgentMemoryEntry 
     created_at: new Date().toISOString(),
     updated_at: new Date().toISOString(),
     ...overrides,
-  };
+  });
 }
 
 function makeMockKnowledgeManager(
@@ -189,6 +189,37 @@ describe("MemoryRecallTool", () => {
       );
       const data = result.data as { entries: AgentMemoryEntry[]; totalFound: number };
       expect(data.entries).toHaveLength(2);
+    });
+
+    it("defaults planning recall to local consent and local sensitivity", async () => {
+      vi.mocked(km.recallAgentMemory).mockResolvedValue([]);
+
+      await tool.call({ query: "preference" }, makeContext());
+
+      expect(vi.mocked(km.recallAgentMemory)).toHaveBeenCalledWith(
+        "preference",
+        expect.objectContaining({
+          consent_scope: "local_planning",
+          max_sensitivity: "local",
+        })
+      );
+    });
+
+    it("passes explicit typed governance filters", async () => {
+      vi.mocked(km.recallAgentMemory).mockResolvedValue([]);
+
+      await tool.call(
+        { query: "preference", consent_scope: "private_chat", max_sensitivity: "private" },
+        makeContext()
+      );
+
+      expect(vi.mocked(km.recallAgentMemory)).toHaveBeenCalledWith(
+        "preference",
+        expect.objectContaining({
+          consent_scope: "private_chat",
+          max_sensitivity: "private",
+        })
+      );
     });
   });
 


### PR DESCRIPTION
Closes #895

## Summary
- add typed memory governance metadata for sensitivity, consent scope, retention, export visibility, and owner refs
- carry governance through memory save and correction replacement paths
- filter recall/list, memory recall tool, and Soil planning projections by consent scope and sensitivity
- add `pulseed memory export` for governance-aware user-facing export

## Verification
- npm run typecheck
- npm exec vitest run src/platform/corrections/__tests__/user-memory-operations.test.ts src/platform/knowledge/__tests__/knowledge-manager-governance.test.ts src/tools/query/MemoryRecallTool/__tests__/MemoryRecallTool.test.ts src/platform/soil/__tests__/soil-content-projections.test.ts src/interface/cli/commands/__tests__/memory.test.ts src/tools/execution/MemorySaveTool/__tests__/MemorySaveTool.test.ts
- npm run lint:boundaries
- npm run test:changed

## Known risks
- Existing memories without explicit governance default to local planning visibility for backward compatibility.
- `pulseed memory export` is JSON-only in this slice; richer presentation can be added later.
