### PR TITLE
ci(runtime): add long-run degradation lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   ci:
@@ -37,3 +38,44 @@ jobs:
       - if: ${{ matrix.run-build }}
         run: npm run build
       - run: ${{ matrix.test-command }}
+
+  runtime-long-run-degradation:
+    name: runtime-long-run-degradation (24)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Detect runtime long-run relevant changes
+        id: changes
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "push" ]]; then
+            echo "run_long_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" > /tmp/changed-files.txt
+          if grep -E '^(src/runtime/|src/platform/(soil|dream)/|src/orchestrator/loop/|tests/slow/|vitest\.runtime-long-run\.config\.ts|package(-lock)?\.json|\.github/workflows/ci\.yml)' /tmp/changed-files.txt; then
+            echo "run_long_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_long_run=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Use Node.js 24
+        if: ${{ steps.changes.outputs.run_long_run == 'true' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "npm"
+      - name: Install dependencies
+        if: ${{ steps.changes.outputs.run_long_run == 'true' }}
+        run: npm ci
+      - name: Build
+        if: ${{ steps.changes.outputs.run_long_run == 'true' }}
+        run: npm run build
+      - name: Run runtime long-run degradation tests
+        if: ${{ steps.changes.outputs.run_long_run == 'true' }}
+        run: npm run test:runtime-long-run
+      - name: Skip runtime long-run degradation tests
+        if: ${{ steps.changes.outputs.run_long_run != 'true' }}
+        run: echo "No runtime/evidence/soil/Dream long-run relevant changes detected."


### PR DESCRIPTION
Closes #886

## Summary
- add an explicit `runtime-long-run-degradation (24)` GitHub Actions job
- run `npm run test:runtime-long-run` on push to main, manual dispatch, and PRs touching runtime/evidence/soil/Dream/slow-test config paths
- skip the heavy lane for unrelated PRs with a visible skip message

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml ok"'\n- npm run test:runtime-long-run\n- npm run typecheck\n- npm run lint:boundaries\n- npm run test:changed\n\n## Known Risks\n- Path filtering is intentionally scoped; future long-run-sensitive directories should be added to the detector when introduced.