### PR TITLE
feat(soil): track memory usage outcomes

### DIFF
--- a/src/grounding/__tests__/gateway.test.ts
+++ b/src/grounding/__tests__/gateway.test.ts
@@ -3,6 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { StateManager } from "../../base/state/state-manager.js";
+import { SqliteSoilRepository } from "../../platform/soil/sqlite-repository.js";
 import { createGroundingGateway } from "../gateway.js";
 
 function makeStateManager(overrides: Partial<StateManager> = {}): StateManager {
@@ -103,6 +104,88 @@ describe("GroundingGateway", () => {
     expect(bundle.dynamicSections.some((section) => section.key === "soil_knowledge")).toBe(true);
     expect(bundle.dynamicSections.some((section) => section.key === "knowledge_query")).toBe(false);
     expect(knowledgeQuery).not.toHaveBeenCalled();
+  });
+
+  it("records usage for admitted SQLite Soil grounding hits and preserves usage stats in context", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-grounding-soil-"));
+    const homeDir = path.join(tmpRoot, "home");
+    const rootDir = path.join(homeDir, "soil");
+    vi.stubEnv("OPENAI_API_KEY", "");
+    const repository = await SqliteSoilRepository.create({ rootDir });
+    try {
+      await repository.applyMutation({
+        records: [{
+          record_id: "rec-grounding",
+          record_key: "fact.grounding",
+          version: 1,
+          record_type: "fact",
+          soil_id: "knowledge/grounding",
+          title: "Grounding fact",
+          summary: "Grounding search target",
+          canonical_text: "Grounding search target comes from SQLite Soil.",
+          goal_id: null,
+          task_id: null,
+          status: "active",
+          confidence: 0.9,
+          importance: 0.7,
+          source_reliability: 0.8,
+          valid_from: null,
+          valid_to: null,
+          supersedes_record_id: null,
+          is_active: true,
+          source_type: "test",
+          source_id: "grounding-source",
+          metadata_json: {},
+          created_at: "2026-05-02T00:00:00.000Z",
+          updated_at: "2026-05-02T00:00:00.000Z",
+        }],
+        chunks: [{
+          chunk_id: "chunk-grounding",
+          record_id: "rec-grounding",
+          soil_id: "knowledge/grounding",
+          chunk_index: 0,
+          chunk_kind: "paragraph",
+          heading_path_json: ["Knowledge"],
+          chunk_text: "Grounding search target comes from SQLite Soil.",
+          token_count: 7,
+          checksum: "grounding-chunk",
+          created_at: "2026-05-02T00:00:00.000Z",
+        }],
+      });
+      await repository.recordOutcome(["rec-grounding"], {
+        outcome: "validated",
+        occurred_at: "2026-05-02T00:01:00.000Z",
+      });
+      await repository.recordOutcome(["rec-grounding"], {
+        outcome: "negative",
+        occurred_at: "2026-05-02T00:02:00.000Z",
+      });
+    } finally {
+      repository.close();
+    }
+
+    const gateway = createGroundingGateway({ stateManager: makeStateManager() });
+    const bundle = await gateway.build({
+      surface: "agent_loop",
+      purpose: "task_execution",
+      homeDir,
+      workspaceRoot: "/repo",
+      userMessage: "Use the grounding search target",
+      query: "Grounding search target",
+      knowledgeQuery: vi.fn(),
+    });
+    const soilSection = bundle.dynamicSections.find((section) => section.key === "soil_knowledge");
+    expect(soilSection?.content).toContain("usage used=0 validated=1 negative=1");
+
+    const updatedRepository = await SqliteSoilRepository.create({ rootDir });
+    try {
+      const [record] = await updatedRepository.loadRecords({ record_ids: ["rec-grounding"] });
+      expect(record?.use_count).toBe(1);
+      expect(record?.last_used_at).not.toBeNull();
+    } finally {
+      updatedRepository.close();
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it("does not reuse cached identity sections across runtime homes", async () => {

--- a/src/grounding/contracts.ts
+++ b/src/grounding/contracts.ts
@@ -116,11 +116,18 @@ export interface GroundingMessage {
 }
 
 export interface GroundingSoilHit {
+  recordId?: string;
   soilId: string;
   title: string;
   summary?: string | null;
   snippet?: string;
   score?: number;
+  usageStats?: {
+    last_used_at: string | null;
+    use_count: number;
+    validated_count: number;
+    negative_outcome_count: number;
+  };
 }
 
 export interface GroundingSoilResult {

--- a/src/grounding/providers/soil-provider.ts
+++ b/src/grounding/providers/soil-provider.ts
@@ -1,5 +1,6 @@
 import type { ToolCallContext } from "../../tools/types.js";
 import { SoilQueryTool } from "../../tools/query/SoilQueryTool/SoilQueryTool.js";
+import { SqliteSoilRepository } from "../../platform/soil/sqlite-repository.js";
 import type { GroundingProvider, GroundingSoilResult } from "../contracts.js";
 import { makeSection, makeSource, soilRootFromHome, resolveHomeDir } from "./helpers.js";
 
@@ -17,6 +18,23 @@ function shouldQuerySoil(query: string | undefined): query is string {
   return Boolean(query && query.trim().length >= 8);
 }
 
+function usageSummary(hit: { usageStats?: GroundingSoilResult["hits"][number]["usageStats"] }): string | null {
+  const usage = hit.usageStats;
+  if (!usage) return null;
+  return `usage used=${usage.use_count} validated=${usage.validated_count} negative=${usage.negative_outcome_count}`;
+}
+
+async function recordGroundingUsage(rootDir: string, recordIds: string[]): Promise<void> {
+  const ids = [...new Set(recordIds.filter((recordId) => recordId.length > 0))];
+  if (ids.length === 0) return;
+  const repository = await SqliteSoilRepository.create({ rootDir });
+  try {
+    await repository.recordUsage(ids);
+  } finally {
+    repository.close();
+  }
+}
+
 export const soilKnowledgeProvider: GroundingProvider = {
   key: "soil_knowledge",
   kind: "dynamic",
@@ -27,6 +45,7 @@ export const soilKnowledgeProvider: GroundingProvider = {
     }
 
     let result: GroundingSoilResult | null = null;
+    let defaultSqliteRootDir: string | null = null;
     if (context.request.soilQuery) {
       result = await context.request.soilQuery({
         query,
@@ -35,17 +54,18 @@ export const soilKnowledgeProvider: GroundingProvider = {
       });
     } else {
       const homeDir = resolveHomeDir(context.request.homeDir ?? context.deps.stateManager?.getBaseDir?.());
+      defaultSqliteRootDir = soilRootFromHome(homeDir);
       const tool = new SoilQueryTool();
       const toolResult = await tool.call({
         query,
-        rootDir: soilRootFromHome(homeDir),
+        rootDir: defaultSqliteRootDir,
         limit: context.profile.budgets.maxKnowledgeHits,
       }, buildToolContext(context.request.workspaceRoot ?? process.cwd(), context.request.goalId));
       if (toolResult.success) {
         const data = toolResult.data as {
           retrievalSource: "sqlite" | "index" | "manifest";
           warnings: string[];
-          hits: Array<{ soilId: string; title: string; summary?: string | null; snippet?: string; score?: number }>;
+          hits: GroundingSoilResult["hits"];
         };
         result = {
           retrievalSource: data.retrievalSource,
@@ -57,8 +77,12 @@ export const soilKnowledgeProvider: GroundingProvider = {
 
     const hits = result?.hits ?? [];
     context.runtime.set("soil_hit_count", hits.length);
-    const lines = hits.slice(0, context.profile.budgets.maxKnowledgeHits).map((hit) => {
-      const detail = [hit.summary, hit.snippet].filter(Boolean).join(" | ");
+    const admittedHits = hits.slice(0, context.profile.budgets.maxKnowledgeHits);
+    if (result?.retrievalSource === "sqlite" && defaultSqliteRootDir) {
+      await recordGroundingUsage(defaultSqliteRootDir, admittedHits.map((hit) => hit.recordId ?? ""));
+    }
+    const lines = admittedHits.map((hit) => {
+      const detail = [hit.summary, hit.snippet, usageSummary(hit)].filter(Boolean).join(" | ");
       return `- ${hit.title} (${hit.soilId})${detail ? `: ${detail}` : ""}`;
     });
     const warnings = result?.warnings ?? [];

--- a/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
+++ b/src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts
@@ -280,6 +280,77 @@ describe("Dream review checkpoint trigger planning", () => {
     expect(normalized.context_authority).toBe("advisory_only");
   });
 
+  it("uses soil usage outcomes as advisory ranking signal without changing authority", () => {
+    const goal = makeGoal({ title: "Improve benchmark score" });
+    const request = buildDreamReviewCheckpointRequest({
+      goal,
+      loopIndex: 1,
+      result: makeEmptyIterationResult("goal-1", 1, { stallDetected: true }),
+      driveScores: [],
+    });
+    expect(request).not.toBeNull();
+
+    const parsed = DreamReviewCheckpointEvidenceSchema.parse({
+      summary: "Rank usage-aware memories.",
+      trigger: "plateau",
+      current_goal: "Improve benchmark score",
+      active_dimensions: ["balanced_accuracy"],
+      relevant_memories: [
+        {
+          source_type: "soil",
+          ref: "soil://validated",
+          summary: "Validated memory with slightly lower base score.",
+          relevance_score: 0.7,
+          source_reliability: 0.75,
+          recency_score: 0.5,
+          retrieval: { kind: "route_hit", score: 0.7, confidence: 0.75 },
+          usage_stats: {
+            last_used_at: "2026-05-02T00:00:00.000Z",
+            use_count: 5,
+            validated_count: 5,
+            negative_outcome_count: 0,
+          },
+          authority: "advisory_only",
+        },
+        {
+          source_type: "soil",
+          ref: "soil://negative",
+          summary: "Negative memory with higher base score.",
+          relevance_score: 0.75,
+          source_reliability: 0.78,
+          recency_score: 0.5,
+          retrieval: { kind: "route_hit", score: 0.75, confidence: 0.78 },
+          usage_stats: {
+            last_used_at: "2026-05-02T00:00:00.000Z",
+            use_count: 9,
+            validated_count: 0,
+            negative_outcome_count: 5,
+          },
+          authority: "advisory_only",
+        },
+      ],
+      guidance: "Use validated advisory memory first.",
+      uncertainty: [],
+      context_authority: "advisory_only",
+      confidence: 0.8,
+    });
+
+    const normalized = normalizeDreamReviewCheckpoint(parsed, request!, goal);
+
+    expect(normalized.relevant_memories.map((memory) => memory.ref)).toEqual([
+      "soil://validated",
+      "soil://negative",
+    ]);
+    expect(normalized.relevant_memories[0]).toMatchObject({
+      authority: "advisory_only",
+      ranking_trace: {
+        decision: "admitted",
+        reason: expect.stringContaining("usage_outcome=0.0500"),
+      },
+    });
+    expect(normalized.context_authority).toBe("advisory_only");
+  });
+
   it("carries active hypotheses and rejected approaches into the next checkpoint request", () => {
     const request = buildDreamReviewCheckpointRequest({
       goal: makeGoal(),

--- a/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
+++ b/src/orchestrator/loop/core-loop/dream-review-checkpoint.ts
@@ -190,7 +190,8 @@ function memoryRankScore(memory: DreamReviewMemoryRef): number {
     + (memory.source_reliability ?? memory.retrieval?.confidence ?? 0.5) * 0.25
     + (memory.prior_success_contribution ?? 0) * 0.2
     + (memory.recency_score ?? 0.5) * 0.1
-    + routeScore;
+    + routeScore
+    + memoryUsageRankAdjustment(memory.usage_stats);
   return Math.max(0, Math.min(1, Number(score.toFixed(4))));
 }
 
@@ -202,7 +203,15 @@ function memoryRankReason(memory: DreamReviewMemoryRef): string {
     `reliability=${memory.source_reliability ?? memory.retrieval?.confidence ?? "default"}`,
     `success=${memory.prior_success_contribution ?? 0}`,
     `recency=${memory.recency_score ?? "default"}`,
+    `usage_outcome=${memoryUsageRankAdjustment(memory.usage_stats).toFixed(4)}`,
   ].join("; ");
+}
+
+function memoryUsageRankAdjustment(usage: DreamReviewMemoryRef["usage_stats"]): number {
+  if (!usage) return 0;
+  const validatedBoost = Math.min(usage.validated_count, 10) * 0.01;
+  const negativePenalty = Math.min(usage.negative_outcome_count, 10) * 0.02;
+  return validatedBoost - negativePenalty;
 }
 
 function decideRunControlPolicy(

--- a/src/orchestrator/loop/core-loop/phase-specs.ts
+++ b/src/orchestrator/loop/core-loop/phase-specs.ts
@@ -116,6 +116,14 @@ export const DreamReviewCheckpointTriggerSchema = z.enum([
 ]);
 export type DreamReviewCheckpointTrigger = z.infer<typeof DreamReviewCheckpointTriggerSchema>;
 
+export const DreamReviewMemoryUsageStatsSchema = z.object({
+  last_used_at: z.string().datetime().nullable().default(null),
+  use_count: z.number().int().nonnegative().default(0),
+  validated_count: z.number().int().nonnegative().default(0),
+  negative_outcome_count: z.number().int().nonnegative().default(0),
+}).strict();
+export type DreamReviewMemoryUsageStats = z.infer<typeof DreamReviewMemoryUsageStatsSchema>;
+
 export const DreamReviewMemoryRefSchema = z.object({
   source_type: z.enum(["soil", "playbook", "runtime_evidence", "other"]),
   ref: z.string().min(1).optional(),
@@ -130,6 +138,7 @@ export const DreamReviewMemoryRefSchema = z.object({
     score: z.number().min(0).max(1).optional(),
     confidence: z.number().min(0).max(1).optional(),
   }).strict().optional(),
+  usage_stats: DreamReviewMemoryUsageStatsSchema.optional(),
   ranking_trace: z.object({
     score: z.number().min(0).max(1),
     decision: z.enum(["admitted", "rejected"]),

--- a/src/platform/soil/__tests__/contracts.test.ts
+++ b/src/platform/soil/__tests__/contracts.test.ts
@@ -52,6 +52,28 @@ describe("soil contracts", () => {
     expect(parsed.supersedes_record_id).toBe("rec-0");
   });
 
+  it("defaults record usage and outcome statistics for existing records", () => {
+    const parsed = SoilRecordSchema.parse({
+      record_id: "rec-legacy",
+      record_key: "user.preference.legacy",
+      version: 1,
+      record_type: "preference",
+      soil_id: "identity/preferences/legacy",
+      title: "Legacy preference",
+      canonical_text: "Legacy records did not carry usage counters.",
+      status: "active",
+      source_type: "agent_memory",
+      source_id: "legacy-memory",
+      created_at: "2026-04-12T00:00:00.000Z",
+      updated_at: "2026-04-12T00:00:00.000Z",
+    });
+
+    expect(parsed.last_used_at).toBeNull();
+    expect(parsed.use_count).toBe(0);
+    expect(parsed.validated_count).toBe(0);
+    expect(parsed.negative_outcome_count).toBe(0);
+  });
+
   it("parses a page without embedding truth into projection metadata", () => {
     const parsed = SoilPageSchema.parse({
       page_id: "page-1",

--- a/src/platform/soil/__tests__/sqlite-repository.test.ts
+++ b/src/platform/soil/__tests__/sqlite-repository.test.ts
@@ -3,6 +3,7 @@ import Database from "better-sqlite3";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { cleanupTempDir, makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { compileSoilContextFromRepository } from "../context-compiler.js";
+import type { SoilRecordInput } from "../contracts.js";
 import { SqliteSoilRepository } from "../sqlite-repository.js";
 
 describe("SqliteSoilRepository", () => {
@@ -1782,4 +1783,193 @@ describe("SqliteSoilRepository", () => {
       ["dream-rec-v2", true],
     ]);
   });
+
+  it("tracks usage and outcome counters on soil records", async () => {
+    await repo.applyMutation({
+      records: [soilRecord({
+        record_id: "usage-rec",
+        record_key: "preference.usage",
+        soil_id: "identity/preferences/usage",
+        title: "Usage preference",
+        canonical_text: "Prefer usage-aware ranking.",
+      })],
+    });
+
+    await repo.recordUsage(["usage-rec"], { used_at: "2026-05-02T00:01:00.000Z" });
+    await repo.recordUsage(["usage-rec"], { used_at: "2026-05-02T00:02:00.000Z" });
+    await repo.recordOutcome(["usage-rec"], {
+      outcome: "validated",
+      occurred_at: "2026-05-02T00:03:00.000Z",
+    });
+    await repo.recordOutcome(["usage-rec"], {
+      outcome: "negative",
+      occurred_at: "2026-05-02T00:04:00.000Z",
+    });
+
+    const [record] = await repo.loadRecords({ record_ids: ["usage-rec"] });
+    const direct = await repo.lookupDirect({ query: "usage-rec" });
+
+    expect(record).toMatchObject({
+      last_used_at: "2026-05-02T00:02:00.000Z",
+      use_count: 2,
+      validated_count: 1,
+      negative_outcome_count: 1,
+    });
+    expect(direct.candidates[0]?.metadata_json).toMatchObject({
+      usage_stats: {
+        last_used_at: "2026-05-02T00:02:00.000Z",
+        use_count: 2,
+        validated_count: 1,
+        negative_outcome_count: 1,
+      },
+    });
+  });
+
+  it("migrates existing sqlite records that do not have usage columns before readonly open", async () => {
+    const legacyPath = path.join(tmpDir, "legacy-soil.db");
+    const legacyDb = new Database(legacyPath);
+    legacyDb.exec(`
+      CREATE TABLE soil_records (
+        record_id TEXT PRIMARY KEY,
+        record_key TEXT NOT NULL,
+        version INTEGER NOT NULL CHECK (version > 0),
+        record_type TEXT NOT NULL,
+        soil_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        summary TEXT,
+        canonical_text TEXT NOT NULL,
+        goal_id TEXT,
+        task_id TEXT,
+        status TEXT NOT NULL,
+        confidence REAL,
+        importance REAL,
+        source_reliability REAL,
+        valid_from TEXT,
+        valid_to TEXT,
+        supersedes_record_id TEXT,
+        is_active INTEGER NOT NULL DEFAULT 1 CHECK (is_active IN (0, 1)),
+        source_type TEXT NOT NULL,
+        source_id TEXT NOT NULL,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        UNIQUE (record_key, version)
+      );
+      INSERT INTO soil_records (
+        record_id, record_key, version, record_type, soil_id, title, summary, canonical_text,
+        goal_id, task_id, status, confidence, importance, source_reliability, valid_from, valid_to,
+        supersedes_record_id, is_active, source_type, source_id, metadata_json, created_at, updated_at
+      ) VALUES (
+        'legacy-rec', 'preference.legacy', 1, 'preference', 'identity/preferences/legacy',
+        'Legacy preference', NULL, 'Legacy record without usage counters.', NULL, NULL,
+        'active', 0.9, 0.6, 0.8, NULL, NULL, NULL, 1, 'agent_memory', 'legacy-memory',
+        '{}', '2026-05-02T00:00:00.000Z', '2026-05-02T00:00:00.000Z'
+      );
+    `);
+    legacyDb.close();
+
+    const legacyRepo = await SqliteSoilRepository.openExisting({
+      rootDir: path.join(tmpDir, "legacy-soil"),
+      indexPath: legacyPath,
+    });
+    expect(legacyRepo).not.toBeNull();
+    try {
+      const [record] = await legacyRepo!.loadRecords({ record_ids: ["legacy-rec"] });
+
+      expect(record).toMatchObject({
+        record_id: "legacy-rec",
+        last_used_at: null,
+        use_count: 0,
+        validated_count: 0,
+        negative_outcome_count: 0,
+      });
+    } finally {
+      legacyRepo?.close();
+    }
+  });
+
+  it("records usage when repository context compilation admits soil memories", async () => {
+    await repo.applyMutation({
+      records: [
+        soilRecord({
+          record_id: "admitted-rec",
+          record_key: "preference.admitted",
+          soil_id: "identity/preferences/admitted",
+          title: "Admitted preference",
+          canonical_text: "This route memory is admitted.",
+        }),
+        soilRecord({
+          record_id: "fallback-rec",
+          record_key: "preference.fallback",
+          soil_id: "identity/preferences/fallback",
+          title: "Fallback preference",
+          canonical_text: "This fallback memory is admitted.",
+        }),
+      ],
+    });
+
+    await compileSoilContextFromRepository({
+      retrievalId: "retrieval-usage",
+      now: () => new Date("2026-05-02T01:00:00.000Z"),
+      targetPaths: ["src/runtime/planning.ts"],
+      routes: [{
+        route_id: "route-admitted",
+        path_globs: ["src/runtime/*"],
+        soil_ids: ["identity/preferences/admitted"],
+        reason: "Route memory should enter planning context.",
+        created_at: "2026-05-02T00:00:00.000Z",
+        updated_at: "2026-05-02T00:00:00.000Z",
+      }],
+      includeFallbackWhenRouteMatched: true,
+      fallbackCandidates: [{
+        chunk_id: "candidate-fallback",
+        record_id: "fallback-rec",
+        soil_id: "identity/preferences/fallback",
+        lane: "lexical",
+        rank: 1,
+        score: 0.7,
+        snippet: "This fallback memory is admitted.",
+        page_id: null,
+        metadata_json: {},
+      }],
+    }, repo);
+
+    const records = await repo.loadRecords({
+      record_ids: ["admitted-rec", "fallback-rec"],
+    });
+
+    expect(records.map((record) => [record.record_id, record.last_used_at, record.use_count])).toEqual([
+      ["admitted-rec", "2026-05-02T01:00:00.000Z", 1],
+      ["fallback-rec", "2026-05-02T01:00:00.000Z", 1],
+    ]);
+  });
 });
+
+function soilRecord(overrides: Partial<SoilRecordInput>): SoilRecordInput {
+  return {
+    record_id: "rec-default",
+    record_key: "preference.default",
+    version: 1,
+    record_type: "preference",
+    soil_id: "identity/preferences/default",
+    title: "Default preference",
+    summary: null,
+    canonical_text: "Default preference.",
+    goal_id: null,
+    task_id: null,
+    status: "active",
+    confidence: 0.9,
+    importance: 0.6,
+    source_reliability: 0.8,
+    valid_from: null,
+    valid_to: null,
+    supersedes_record_id: null,
+    is_active: true,
+    source_type: "agent_memory",
+    source_id: "memory-default",
+    metadata_json: {},
+    created_at: "2026-05-02T00:00:00.000Z",
+    updated_at: "2026-05-02T00:00:00.000Z",
+    ...overrides,
+  };
+}

--- a/src/platform/soil/context-compiler.ts
+++ b/src/platform/soil/context-compiler.ts
@@ -27,6 +27,7 @@ export interface SoilRouteTargetState {
 
 export interface SoilContextCompilerRepository {
   loadRecords: SoilSearchRepository["loadRecords"];
+  recordUsage?: (recordIds: string[], input?: { used_at?: string }) => Promise<void>;
 }
 
 export interface SoilContextCompilerInput {
@@ -200,6 +201,7 @@ function routeTargetStatesForRecords(records: SoilRecord[]): SoilRouteTargetStat
     );
     const representative = activeRecord ?? recordsForSoil[0];
     states.push({
+      recordId: representative?.record_id,
       soilId,
       isActive: Boolean(activeRecord),
       status: representative?.status,
@@ -299,7 +301,8 @@ function compileRouteItems(
       warnings.push(staleWarning);
     }
     for (const soilId of route.soil_ids) {
-      const rejectionReason = routeTargetRejectionReason(targetStates.get(routeTargetStateKey("soil", soilId)));
+      const targetState = targetStates.get(routeTargetStateKey("soil", soilId));
+      const rejectionReason = routeTargetRejectionReason(targetState);
       if (rejectionReason) {
         warnings.push(`Route ${route.route_id} target ${soilId} was rejected: ${rejectionReason}.`);
         decisions.push({
@@ -319,12 +322,12 @@ function compileRouteItems(
         reason: route.reason,
         score: null,
         soil_id: soilId,
-        record_id: null,
+        record_id: targetState?.recordId ?? null,
         route_id: route.route_id,
       });
       items.push({
         soilId,
-        recordId: null,
+        recordId: targetState?.recordId ?? null,
         routeId: route.route_id,
         source: "route",
         reason: route.reason,
@@ -552,11 +555,18 @@ export async function compileSoilContextFromRepository(
         soil_ids: soilIds,
       })
     : [];
-  return compileSoilContext({
+  const compiled = compileSoilContext({
     ...input,
     routeTargetStates: [
       ...(input.routeTargetStates ?? []),
       ...routeTargetStatesForRecords([...recordsById, ...recordsBySoilId]),
     ],
   });
+  const admittedRecordIds = [...new Set(compiled.items
+    .map((item) => item.recordId)
+    .filter((recordId): recordId is string => recordId !== null))];
+  if (admittedRecordIds.length > 0) {
+    await repository.recordUsage?.(admittedRecordIds, { used_at: compiled.trace.timestamp });
+  }
+  return compiled;
 }

--- a/src/platform/soil/contracts.ts
+++ b/src/platform/soil/contracts.ts
@@ -87,6 +87,17 @@ export const SoilMemoryLifecycleStateSchema = z.enum([
 ]);
 export type SoilMemoryLifecycleState = z.infer<typeof SoilMemoryLifecycleStateSchema>;
 
+export const SoilRecordUsageStatsSchema = z.object({
+  last_used_at: z.string().datetime().nullable().default(null),
+  use_count: z.number().int().nonnegative().default(0),
+  validated_count: z.number().int().nonnegative().default(0),
+  negative_outcome_count: z.number().int().nonnegative().default(0),
+}).strict();
+export type SoilRecordUsageStats = z.infer<typeof SoilRecordUsageStatsSchema>;
+
+export const SoilRecordOutcomeKindSchema = z.enum(["validated", "negative"]);
+export type SoilRecordOutcomeKind = z.infer<typeof SoilRecordOutcomeKindSchema>;
+
 export const SoilRecordSchema = z.object({
   record_id: z.string().min(1),
   record_key: z.string().min(1),
@@ -109,10 +120,15 @@ export const SoilRecordSchema = z.object({
   source_type: z.string().min(1),
   source_id: z.string().min(1),
   metadata_json: z.record(z.unknown()).default({}),
+  last_used_at: z.string().datetime().nullable().default(null),
+  use_count: z.number().int().nonnegative().default(0),
+  validated_count: z.number().int().nonnegative().default(0),
+  negative_outcome_count: z.number().int().nonnegative().default(0),
   created_at: z.string().datetime(),
   updated_at: z.string().datetime(),
 });
 export type SoilRecord = z.infer<typeof SoilRecordSchema>;
+export type SoilRecordInput = z.input<typeof SoilRecordSchema>;
 
 export const SoilChunkSchema = z.object({
   chunk_id: z.string().min(1),
@@ -360,6 +376,8 @@ export interface SoilWriteRepository {
   applyMutation(mutation: SoilMutationInput): Promise<void>;
   queueReindex(recordIds: string[], reason: string): Promise<void>;
   loadCorrections?(recordIds?: string[]): Promise<SoilCorrectionEntry[]>;
+  recordUsage?(recordIds: string[], input?: { used_at?: string }): Promise<void>;
+  recordOutcome?(recordIds: string[], input: { outcome: SoilRecordOutcomeKind; occurred_at?: string }): Promise<void>;
 }
 
 export interface SoilSearchRepository {

--- a/src/platform/soil/ddl.ts
+++ b/src/platform/soil/ddl.ts
@@ -23,6 +23,10 @@ CREATE TABLE IF NOT EXISTS soil_records (
   source_type TEXT NOT NULL,
   source_id TEXT NOT NULL,
   metadata_json TEXT NOT NULL DEFAULT '{}',
+  last_used_at TEXT,
+  use_count INTEGER NOT NULL DEFAULT 0 CHECK (use_count >= 0),
+  validated_count INTEGER NOT NULL DEFAULT 0 CHECK (validated_count >= 0),
+  negative_outcome_count INTEGER NOT NULL DEFAULT 0 CHECK (negative_outcome_count >= 0),
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   UNIQUE (record_key, version)

--- a/src/platform/soil/display/materialize.ts
+++ b/src/platform/soil/display/materialize.ts
@@ -32,6 +32,10 @@ interface SoilRecordRow {
   source_type: string;
   source_id: string;
   metadata_json: string;
+  last_used_at: string | null;
+  use_count: number;
+  validated_count: number;
+  negative_outcome_count: number;
   created_at: string;
   updated_at: string;
 }

--- a/src/platform/soil/sqlite-repository-helpers.ts
+++ b/src/platform/soil/sqlite-repository-helpers.ts
@@ -34,6 +34,10 @@ export interface SoilRowRecord {
   source_type: string;
   source_id: string;
   metadata_json: string;
+  last_used_at: string | null;
+  use_count: number;
+  validated_count: number;
+  negative_outcome_count: number;
   created_at: string;
   updated_at: string;
 }

--- a/src/platform/soil/sqlite-repository-search.ts
+++ b/src/platform/soil/sqlite-repository-search.ts
@@ -18,6 +18,24 @@ import {
   unique,
 } from "./sqlite-repository-helpers.js";
 
+interface SoilUsageRow {
+  last_used_at: string | null;
+  use_count: number;
+  validated_count: number;
+  negative_outcome_count: number;
+}
+
+function usageStatsMetadata(row: SoilUsageRow): Record<string, unknown> {
+  return {
+    usage_stats: {
+      last_used_at: row.last_used_at,
+      use_count: row.use_count,
+      validated_count: row.validated_count,
+      negative_outcome_count: row.negative_outcome_count,
+    },
+  };
+}
+
 function hasExplicitMetadataFilter(request: SoilSearchRequest): boolean {
   const recordFilter = request.record_filter;
   const pageFilter = request.page_filter;
@@ -276,7 +294,10 @@ export function lookupDirectCandidates(db: SqliteDatabase, input: SoilSearchRequ
       score: 1,
       snippet: chunk ? buildSnippet(chunk.chunk_text, request.query) : row.summary ?? row.title,
       page_id,
-      metadata_json: parseJsonObject(row.metadata_json),
+      metadata_json: {
+        ...parseJsonObject(row.metadata_json),
+        ...usageStatsMetadata(row),
+      },
     });
   }
 
@@ -318,6 +339,10 @@ export function searchLexicalCandidates(db: SqliteDatabase, input: SoilSearchReq
       ${pageIdSql} AS page_id,
       r.title AS title,
       r.summary AS summary,
+      r.last_used_at AS last_used_at,
+      r.use_count AS use_count,
+      r.validated_count AS validated_count,
+      r.negative_outcome_count AS negative_outcome_count,
       sc.chunk_text AS chunk_text,
       bm25(soil_chunk_fts, 8.0, 5.0, 3.0, 1.0) AS score
     FROM soil_chunk_fts
@@ -333,6 +358,10 @@ export function searchLexicalCandidates(db: SqliteDatabase, input: SoilSearchReq
     page_id: string | null;
     title: string;
     summary: string | null;
+    last_used_at: string | null;
+    use_count: number;
+    validated_count: number;
+    negative_outcome_count: number;
     chunk_text: string;
     score: number;
   }>;
@@ -346,7 +375,7 @@ export function searchLexicalCandidates(db: SqliteDatabase, input: SoilSearchReq
     rank: index + 1,
     score: -1 * row.score,
     snippet: buildSnippet(row.chunk_text, request.query),
-    metadata_json: { title: row.title, summary: row.summary },
+    metadata_json: { title: row.title, summary: row.summary, ...usageStatsMetadata(row) },
   }));
   return dedupeCandidates(candidates, request.limit);
 }
@@ -404,6 +433,10 @@ export function searchDenseCandidates(
       sc.chunk_text,
       r.title,
       r.summary,
+      r.last_used_at,
+      r.use_count,
+      r.validated_count,
+      r.negative_outcome_count,
       ${pageIdSql} AS page_id
     FROM soil_embeddings se
     JOIN soil_chunks sc ON sc.chunk_id = se.chunk_id
@@ -416,7 +449,7 @@ export function searchDenseCandidates(
     title: string;
     summary: string | null;
     page_id: string | null;
-  }>;
+  } & SoilUsageRow>;
 
   const scored: Array<{ row: typeof rows[number]; similarity: number }> = [];
   for (const row of rows) {
@@ -439,7 +472,13 @@ export function searchDenseCandidates(
     rank: index + 1,
     score: similarity,
     snippet: buildSnippet(row.chunk_text, request.query),
-    metadata_json: { model: row.model, embedding_version: row.embedding_version, title: row.title, summary: row.summary },
+    metadata_json: {
+      model: row.model,
+      embedding_version: row.embedding_version,
+      title: row.title,
+      summary: row.summary,
+      ...usageStatsMetadata(row),
+    },
   }));
   return dedupeCandidates(candidates, request.limit);
 }

--- a/src/platform/soil/sqlite-repository-storage.ts
+++ b/src/platform/soil/sqlite-repository-storage.ts
@@ -7,6 +7,7 @@ import {
   SoilCorrectionEntrySchema,
   type SoilMutationInput,
   type SoilPageMember,
+  type SoilRecordOutcomeKind,
 } from "./contracts.js";
 import {
   encodeEmbedding,
@@ -21,10 +22,28 @@ export function initializeSoilSqlite(db: SqliteDatabase): void {
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");
   db.exec(SOIL_SCHEMA_SQL);
+  ensureSoilRecordUsageColumns(db);
 }
 
 export function initializeReadonlySoilSqlite(db: SqliteDatabase): void {
   db.pragma("query_only = ON");
+}
+
+function ensureSoilRecordUsageColumns(db: SqliteDatabase): void {
+  const columns = new Set(
+    (db.prepare("PRAGMA table_info(soil_records)").all() as Array<{ name: string }>).map((column) => column.name)
+  );
+  const additions = [
+    ["last_used_at", "TEXT"],
+    ["use_count", "INTEGER NOT NULL DEFAULT 0 CHECK (use_count >= 0)"],
+    ["validated_count", "INTEGER NOT NULL DEFAULT 0 CHECK (validated_count >= 0)"],
+    ["negative_outcome_count", "INTEGER NOT NULL DEFAULT 0 CHECK (negative_outcome_count >= 0)"],
+  ] as const;
+  for (const [column, definition] of additions) {
+    if (!columns.has(column)) {
+      db.prepare(`ALTER TABLE soil_records ADD COLUMN ${column} ${definition}`).run();
+    }
+  }
 }
 
 export function applySoilMutation(db: SqliteDatabase, input: SoilMutationInput): void {
@@ -45,12 +64,14 @@ export function applySoilMutation(db: SqliteDatabase, input: SoilMutationInput):
           record_id, record_key, version, record_type, soil_id, title, summary, canonical_text,
           goal_id, task_id, status, confidence, importance, source_reliability,
           valid_from, valid_to, supersedes_record_id, is_active, source_type, source_id,
-          metadata_json, created_at, updated_at
+          metadata_json, last_used_at, use_count, validated_count, negative_outcome_count,
+          created_at, updated_at
         ) VALUES (
           @record_id, @record_key, @version, @record_type, @soil_id, @title, @summary, @canonical_text,
           @goal_id, @task_id, @status, @confidence, @importance, @source_reliability,
           @valid_from, @valid_to, @supersedes_record_id, @is_active, @source_type, @source_id,
-          @metadata_json, @created_at, @updated_at
+          @metadata_json, @last_used_at, @use_count, @validated_count, @negative_outcome_count,
+          @created_at, @updated_at
         )
         ON CONFLICT(record_id) DO UPDATE SET
           record_key = excluded.record_key,
@@ -73,12 +94,25 @@ export function applySoilMutation(db: SqliteDatabase, input: SoilMutationInput):
           source_type = excluded.source_type,
           source_id = excluded.source_id,
           metadata_json = excluded.metadata_json,
+          last_used_at = CASE
+            WHEN soil_records.last_used_at IS NULL THEN excluded.last_used_at
+            WHEN excluded.last_used_at IS NULL THEN soil_records.last_used_at
+            WHEN excluded.last_used_at > soil_records.last_used_at THEN excluded.last_used_at
+            ELSE soil_records.last_used_at
+          END,
+          use_count = MAX(soil_records.use_count, excluded.use_count),
+          validated_count = MAX(soil_records.validated_count, excluded.validated_count),
+          negative_outcome_count = MAX(soil_records.negative_outcome_count, excluded.negative_outcome_count),
           created_at = excluded.created_at,
           updated_at = excluded.updated_at
       `).run({
         ...record,
         is_active: record.is_active ? 1 : 0,
         metadata_json: serializeJson(record.metadata_json),
+        last_used_at: record.last_used_at,
+        use_count: record.use_count,
+        validated_count: record.validated_count,
+        negative_outcome_count: record.negative_outcome_count,
       });
       contentMutatedRecordIds.add(record.record_id);
     }
@@ -281,6 +315,54 @@ export function applySoilMutation(db: SqliteDatabase, input: SoilMutationInput):
     }
   });
 
+  tx();
+}
+
+export function recordSoilUsage(db: SqliteDatabase, recordIds: string[], usedAt: string): void {
+  const ids = unique(recordIds);
+  if (ids.length === 0) return;
+  const tx = db.transaction(() => {
+    for (const recordId of ids) {
+      db.prepare(`
+        UPDATE soil_records
+        SET
+          last_used_at = CASE
+            WHEN last_used_at IS NULL OR ? > last_used_at THEN ?
+            ELSE last_used_at
+          END,
+          use_count = use_count + 1
+        WHERE record_id = ?
+      `).run(usedAt, usedAt, recordId);
+    }
+  });
+  tx();
+}
+
+export function recordSoilOutcome(
+  db: SqliteDatabase,
+  recordIds: string[],
+  outcome: SoilRecordOutcomeKind,
+  occurredAt: string
+): void {
+  const ids = unique(recordIds);
+  if (ids.length === 0) return;
+  const validatedIncrement = outcome === "validated" ? 1 : 0;
+  const negativeIncrement = outcome === "negative" ? 1 : 0;
+  const tx = db.transaction(() => {
+    for (const recordId of ids) {
+      db.prepare(`
+        UPDATE soil_records
+        SET
+          validated_count = validated_count + ?,
+          negative_outcome_count = negative_outcome_count + ?,
+          updated_at = CASE
+            WHEN ? > updated_at THEN ?
+            ELSE updated_at
+          END
+        WHERE record_id = ?
+      `).run(validatedIncrement, negativeIncrement, occurredAt, occurredAt, recordId);
+    }
+  });
   tx();
 }
 

--- a/src/platform/soil/sqlite-repository.ts
+++ b/src/platform/soil/sqlite-repository.ts
@@ -13,6 +13,7 @@ import {
   type SoilPageMember,
   type SoilRecord,
   type SoilRecordFilterInput,
+  type SoilRecordOutcomeKind,
   type SoilRepository,
   type SoilSearchRequestInput,
   type SoilSearchResult,
@@ -30,13 +31,16 @@ import {
   initializeReadonlySoilSqlite,
   initializeSoilSqlite,
   loadOpenEmbeddingReindexRecordIds,
+  recordSoilOutcome,
+  recordSoilUsage,
   replaceSoilPageMembers,
 } from "./sqlite-repository-storage.js";
 
 export class SqliteSoilRepository implements SoilRepository {
   private constructor(
     private readonly db: SqliteDatabase,
-    readonly dbPath: string
+    readonly dbPath: string,
+    private readonly writable: boolean
   ) {}
 
   static async create(configInput: SoilConfigInput = {}): Promise<SqliteSoilRepository> {
@@ -45,7 +49,7 @@ export class SqliteSoilRepository implements SoilRepository {
     await fsp.mkdir(path.dirname(indexPath), { recursive: true });
     const db = new Database(indexPath);
     initializeSoilSqlite(db);
-    return new SqliteSoilRepository(db, indexPath);
+    return new SqliteSoilRepository(db, indexPath, true);
   }
 
   static async openExisting(configInput: SoilConfigInput = {}): Promise<SqliteSoilRepository | null> {
@@ -56,9 +60,15 @@ export class SqliteSoilRepository implements SoilRepository {
     } catch {
       return null;
     }
+    const migrationDb = new Database(indexPath);
+    try {
+      initializeSoilSqlite(migrationDb);
+    } finally {
+      migrationDb.close();
+    }
     const db = new Database(indexPath, { readonly: true, fileMustExist: true });
     initializeReadonlySoilSqlite(db);
-    return new SqliteSoilRepository(db, indexPath);
+    return new SqliteSoilRepository(db, indexPath, false);
   }
 
   close(): void {
@@ -100,6 +110,19 @@ export class SqliteSoilRepository implements SoilRepository {
       JSON.stringify({ record_ids: ids }),
       new Date().toISOString()
     );
+  }
+
+  async recordUsage(recordIds: string[], input: { used_at?: string } = {}): Promise<void> {
+    if (!this.writable) return;
+    recordSoilUsage(this.db, recordIds, input.used_at ?? new Date().toISOString());
+  }
+
+  async recordOutcome(
+    recordIds: string[],
+    input: { outcome: SoilRecordOutcomeKind; occurred_at?: string }
+  ): Promise<void> {
+    if (!this.writable) return;
+    recordSoilOutcome(this.db, recordIds, input.outcome, input.occurred_at ?? new Date().toISOString());
   }
 
   async loadCorrections(recordIds: string[] = []): Promise<SoilCorrectionEntry[]> {

--- a/src/runtime/__tests__/dream-sidecar-review.test.ts
+++ b/src/runtime/__tests__/dream-sidecar-review.test.ts
@@ -370,6 +370,89 @@ describe("Runtime Dream sidecar review", () => {
     });
   });
 
+  it("uses usage outcomes when sidecar re-ranks advisory memories", async () => {
+    await seedActiveRun("run:coreloop:sidecar-usage-rank");
+    const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));
+    await ledger.append({
+      id: "usage-aware-memories",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "dream_checkpoint",
+      scope: { run_id: "run:coreloop:sidecar-usage-rank", loop_index: 1, phase: "dream_review_checkpoint" },
+      dream_checkpoints: [{
+        trigger: "plateau",
+        summary: "Checkpoint with usage-aware Soil memories.",
+        current_goal: "Improve benchmark",
+        active_dimensions: ["balanced_accuracy"],
+        recent_strategy_families: [],
+        exhausted: [],
+        promising: [],
+        relevant_memories: [
+          {
+            source_type: "soil",
+            ref: "soil://validated",
+            summary: "Validated memory with slightly lower base score.",
+            relevance_score: 0.7,
+            source_reliability: 0.75,
+            recency_score: 0.5,
+            retrieval: { kind: "route_hit", score: 0.7, confidence: 0.75 },
+            usage_stats: {
+              last_used_at: "2026-05-02T00:00:00.000Z",
+              use_count: 5,
+              validated_count: 5,
+              negative_outcome_count: 0,
+            },
+            authority: "advisory_only",
+          },
+          {
+            source_type: "soil",
+            ref: "soil://negative",
+            summary: "Negative memory with higher base score.",
+            relevance_score: 0.75,
+            source_reliability: 0.78,
+            recency_score: 0.5,
+            retrieval: { kind: "route_hit", score: 0.75, confidence: 0.78 },
+            usage_stats: {
+              last_used_at: "2026-05-02T00:00:00.000Z",
+              use_count: 9,
+              validated_count: 0,
+              negative_outcome_count: 5,
+            },
+            authority: "advisory_only",
+          },
+        ],
+        active_hypotheses: [],
+        rejected_approaches: [],
+        next_strategy_candidates: [],
+        guidance: "Prefer validated memory.",
+        uncertainty: [],
+        context_authority: "advisory_only",
+        confidence: 0.8,
+      }],
+      summary: "Usage-aware checkpoint saved.",
+    });
+
+    const review = await createRuntimeDreamSidecarReview({
+      stateManager,
+      runId: "run:coreloop:sidecar-usage-rank",
+    });
+
+    expect(review.advisory_memories.map((memory) => memory.ref).slice(0, 2)).toEqual([
+      "soil://validated",
+      "soil://negative",
+    ]);
+    expect(review.advisory_memories[0]).toMatchObject({
+      authority: "advisory_only",
+      usage_stats: expect.objectContaining({
+        validated_count: 5,
+        negative_outcome_count: 0,
+      }),
+      ranking_trace: {
+        decision: "admitted",
+        reason: expect.stringContaining("usage_outcome=0.0500"),
+      },
+    });
+  });
+
   it("summarizes repeated failed lineages and avoids suggesting them without retry evidence", async () => {
     await seedActiveRun("run:coreloop:failed-lineage");
     const ledger = new RuntimeEvidenceLedger(path.join(tmpDir, "runtime"));

--- a/src/runtime/dream-sidecar-review.ts
+++ b/src/runtime/dream-sidecar-review.ts
@@ -98,6 +98,7 @@ export interface RuntimeDreamSidecarReview {
     ref?: string;
     summary: string;
     authority: "advisory_only";
+    usage_stats?: RuntimeEvidenceSummary["dream_checkpoints"][number]["relevant_memories"][number]["usage_stats"];
     ranking_trace?: {
       score: number;
       decision: "admitted" | "rejected";
@@ -589,6 +590,7 @@ function buildAdvisoryMemories(summary: RuntimeEvidenceSummary): RuntimeDreamSid
       ...(memory.ref ? { ref: memory.ref } : {}),
       summary: memory.summary,
       authority: "advisory_only" as const,
+      ...(memory.usage_stats ? { usage_stats: memory.usage_stats } : {}),
       ranking_trace: {
         score: memory.ranking_trace?.score ?? sidecarMemoryRankScore(memory),
         decision: "admitted" as const,
@@ -622,7 +624,8 @@ function sidecarMemoryRankScore(
     + (memory.source_reliability ?? memory.retrieval?.confidence ?? 0.5) * 0.25
     + (memory.prior_success_contribution ?? 0) * 0.2
     + (memory.recency_score ?? 0.5) * 0.1
-    + routeScore;
+    + routeScore
+    + sidecarMemoryUsageRankAdjustment(memory.usage_stats);
   return Math.max(0, Math.min(1, Number(score.toFixed(4))));
 }
 
@@ -639,7 +642,17 @@ function sidecarMemoryRankReason(
     `reliability=${memory.source_reliability ?? memory.retrieval?.confidence ?? "default"}`,
     `success=${memory.prior_success_contribution ?? 0}`,
     `recency=${memory.recency_score ?? "default"}`,
+    `usage_outcome=${sidecarMemoryUsageRankAdjustment(memory.usage_stats).toFixed(4)}`,
   ].join("; ");
+}
+
+function sidecarMemoryUsageRankAdjustment(
+  usage: RuntimeEvidenceSummary["dream_checkpoints"][number]["relevant_memories"][number]["usage_stats"]
+): number {
+  if (!usage) return 0;
+  const validatedBoost = Math.min(usage.validated_count, 10) * 0.01;
+  const negativePenalty = Math.min(usage.negative_outcome_count, 10) * 0.02;
+  return validatedBoost - negativePenalty;
 }
 
 function buildWarnings(

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -348,6 +348,14 @@ export const RuntimeEvidenceDreamCheckpointTriggerSchema = z.enum([
 ]);
 export type RuntimeEvidenceDreamCheckpointTrigger = z.infer<typeof RuntimeEvidenceDreamCheckpointTriggerSchema>;
 
+export const RuntimeEvidenceMemoryUsageStatsSchema = z.object({
+  last_used_at: z.string().datetime().nullable().default(null),
+  use_count: z.number().int().nonnegative().default(0),
+  validated_count: z.number().int().nonnegative().default(0),
+  negative_outcome_count: z.number().int().nonnegative().default(0),
+}).strict();
+export type RuntimeEvidenceMemoryUsageStats = z.infer<typeof RuntimeEvidenceMemoryUsageStatsSchema>;
+
 export const RuntimeEvidenceDreamCheckpointMemoryRefSchema = z.object({
   source_type: z.enum(["soil", "playbook", "runtime_evidence", "other"]),
   ref: z.string().min(1).optional(),
@@ -365,6 +373,7 @@ export const RuntimeEvidenceDreamCheckpointMemoryRefSchema = z.object({
     score: z.number().min(0).max(1).optional(),
     confidence: z.number().min(0).max(1).optional(),
   }).strict().optional(),
+  usage_stats: RuntimeEvidenceMemoryUsageStatsSchema.optional(),
   ranking_trace: z.object({
     score: z.number().min(0).max(1),
     decision: z.enum(["admitted", "rejected"]),

--- a/src/tools/query/SoilQueryTool/SoilQueryTool.ts
+++ b/src/tools/query/SoilQueryTool/SoilQueryTool.ts
@@ -59,6 +59,7 @@ export interface SoilQueryPageItem {
 }
 
 export interface SoilQueryHitItem {
+  recordId?: string;
   soilId: string;
   relativePath: string;
   title: string;
@@ -68,6 +69,12 @@ export interface SoilQueryHitItem {
   summary: string | null;
   score: number;
   snippet?: string;
+  usageStats?: {
+    last_used_at: string | null;
+    use_count: number;
+    validated_count: number;
+    negative_outcome_count: number;
+  };
 }
 
 export interface SoilQueryOutput {
@@ -182,10 +189,31 @@ function metadataString(metadata: Record<string, unknown>, key: string): string 
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
+function metadataUsageStats(metadata: Record<string, unknown>): SoilQueryHitItem["usageStats"] | undefined {
+  const value = metadata["usage_stats"];
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined;
+  const usage = value as Record<string, unknown>;
+  if (
+    (typeof usage["last_used_at"] !== "string" && usage["last_used_at"] !== null) ||
+    typeof usage["use_count"] !== "number" ||
+    typeof usage["validated_count"] !== "number" ||
+    typeof usage["negative_outcome_count"] !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    last_used_at: usage["last_used_at"],
+    use_count: usage["use_count"],
+    validated_count: usage["validated_count"],
+    negative_outcome_count: usage["negative_outcome_count"],
+  };
+}
+
 function toSqliteHitItem(candidate: SoilCandidate, page: SoilPage | undefined): SoilQueryHitItem {
   const title = metadataString(candidate.metadata_json, "title") ?? page?.soil_id ?? candidate.soil_id;
   const summary = metadataString(candidate.metadata_json, "summary");
   return {
+    recordId: candidate.record_id,
     soilId: page?.soil_id ?? candidate.soil_id,
     relativePath: page?.relative_path ?? `${candidate.soil_id}.md`,
     title,
@@ -195,6 +223,7 @@ function toSqliteHitItem(candidate: SoilCandidate, page: SoilPage | undefined): 
     summary,
     score: candidate.score,
     snippet: candidate.snippet ?? undefined,
+    usageStats: metadataUsageStats(candidate.metadata_json),
   };
 }
 


### PR DESCRIPTION
Closes #885

## Summary
- add backward-compatible Soil record usage and outcome stats with SQLite migration support
- record usage when default SQLite Soil grounding admits memories and preserve usage stats through grounding/context payloads
- feed usage outcomes into Dream and sidecar memory ranking as bounded advisory signals while preserving advisory_only authority

## Verification
- npm run test:integration -- src/platform/soil/__tests__/contracts.test.ts src/platform/soil/__tests__/sqlite-repository.test.ts
- npm run test:integration -- src/platform/soil/__tests__/sqlite-repository.test.ts
- npx vitest run src/orchestrator/loop/__tests__/dream-review-checkpoint.test.ts src/runtime/__tests__/dream-sidecar-review.test.ts
- npx vitest run src/tools/query/SoilQueryTool/__tests__/SoilQueryTool.test.ts src/grounding/__tests__/gateway.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known risks
- custom injected soilQuery implementations cannot be usage-recorded unless they expose a writable repository/root; the default production SQLite grounding path is covered.
- usage/outcome ranking is intentionally bounded and advisory-only, so it may require follow-up tuning after operational data accumulates.