### PR TITLE
feat(profile): add relationship profile store

### DIFF
--- a/src/base/config/__tests__/identity-loader.test.ts
+++ b/src/base/config/__tests__/identity-loader.test.ts
@@ -193,6 +193,54 @@ Content here.`);
     const result = getInternalIdentityPrefix("planner");
     expect(result).toContain("Pebble");
   });
+
+  it("adds only active relationship profile items for the requested scope", () => {
+    withFiles({
+      "relationship-profile.json": JSON.stringify({
+        schema_version: 1,
+        profile_id: "default",
+        updated_at: "2026-05-02T00:00:00.000Z",
+        items: [
+          {
+            id: "current",
+            stable_key: "user.preference.status",
+            kind: "preference",
+            value: "Prefer concise status reports.",
+            status: "active",
+            version: 2,
+            confidence: 0.9,
+            sensitivity: "private",
+            allowed_scopes: ["local_planning"],
+            provenance: { source: "cli_update" },
+            created_at: "2026-05-02T00:00:00.000Z",
+            updated_at: "2026-05-02T00:00:00.000Z",
+            superseded_at: null,
+            superseded_by: null,
+          },
+          {
+            id: "old",
+            stable_key: "user.preference.status",
+            kind: "preference",
+            value: "Prefer verbose status reports.",
+            status: "superseded",
+            version: 1,
+            confidence: 0.9,
+            sensitivity: "private",
+            allowed_scopes: ["local_planning"],
+            provenance: { source: "cli_update" },
+            created_at: "2026-05-01T00:00:00.000Z",
+            updated_at: "2026-05-02T00:00:00.000Z",
+            superseded_at: "2026-05-02T00:00:00.000Z",
+            superseded_by: "current",
+          },
+        ],
+        audit_events: [],
+      }),
+    });
+    const result = getInternalIdentityPrefix("planner", { profileScope: "local_planning" });
+    expect(result).toContain("Prefer concise status reports.");
+    expect(result).not.toContain("Prefer verbose status reports.");
+  });
 });
 
 describe("runtime identity slot", () => {

--- a/src/base/config/identity-loader.ts
+++ b/src/base/config/identity-loader.ts
@@ -6,6 +6,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { getPulseedDirPath } from "../utils/paths.js";
+import {
+  loadRelationshipProfilePromptBlock,
+  type RelationshipProfileConsentScope,
+} from "../../platform/profile/relationship-profile.js";
 
 export interface Identity {
   name: string;
@@ -119,9 +123,27 @@ export function getSelfIdentityResponse(language: SelfIdentityLanguage = "ja", i
   return `私は${name}です。PulSeedを動かす設定済みエージェントとして応答しています。自己認識はPulSeed runtimeのSEED.md/ROOT.md/USER.mdで管理され、プロバイダーやモデル名ではなく、このruntime identityに従います。`;
 }
 
-export function getInternalIdentityPrefix(role: string): string {
-  const { name } = loadIdentity();
-  return `You are ${name}, PulSeed's ${role}. ${getCoreIdentity(name)}`;
+export function getInternalIdentityPrefix(
+  role: string,
+  options: {
+    baseDir?: string;
+    profileScope?: RelationshipProfileConsentScope;
+    includeSensitiveProfile?: boolean;
+  } = {}
+): string {
+  const baseDir = options.baseDir ?? getPulseedDirPath();
+  const identity = options.baseDir ? loadIdentityFromBaseDir(options.baseDir) : loadIdentity();
+  const profileBlock = options.profileScope
+    ? loadRelationshipProfilePromptBlock(
+        baseDir,
+        options.profileScope,
+        { includeSensitive: options.includeSensitiveProfile }
+      )
+    : "";
+  return [
+    `You are ${identity.name}, PulSeed's ${role}. ${getCoreIdentity(identity.name)}`,
+    profileBlock,
+  ].filter((part) => part.trim().length > 0).join("\n\n");
 }
 
 function isUserContentMeaningful(user: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,6 +223,27 @@ export { MemoryLifecycleManager } from "./platform/knowledge/memory/memory-lifec
 export { CharacterConfigManager } from "./platform/traits/character-config.js";
 export { CharacterConfigSchema, DEFAULT_CHARACTER_CONFIG } from "./base/types/character.js";
 export type { CharacterConfig } from "./base/types/character.js";
+export {
+  RelationshipProfileItemKindSchema,
+  RelationshipProfileConsentScopeSchema,
+  RelationshipProfileSensitivitySchema,
+  RelationshipProfileItemStatusSchema,
+  RelationshipProfileStoreSchema,
+  loadRelationshipProfile,
+  loadRelationshipProfileSync,
+  saveRelationshipProfile,
+  upsertRelationshipProfileItem,
+  selectActiveRelationshipProfileItems,
+  formatRelationshipProfilePromptBlock,
+  seedRelationshipProfileFromSetup,
+} from "./platform/profile/relationship-profile.js";
+export type {
+  RelationshipProfileItem,
+  RelationshipProfileStore,
+  RelationshipProfileItemKind,
+  RelationshipProfileConsentScope,
+  RelationshipProfileSensitivity,
+} from "./platform/profile/relationship-profile.js";
 export { CuriosityEngine } from "./platform/traits/curiosity-engine.js";
 export { GoalDependencyGraph } from "./orchestrator/goal/goal-dependency-graph.js";
 export { KnowledgeGraph } from "./platform/knowledge/knowledge-graph.js";

--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -1390,6 +1390,76 @@ describe("ANTHROPIC_API_KEY", async () => {
   });
 });
 
+describe("profile command", () => {
+  it("updates and shows relationship profile items through the production CLI entrypoint", async () => {
+    const updateCode = await runCLI(
+      "profile",
+      "update",
+      "--kind",
+      "preference",
+      "--key",
+      "user.preference.status",
+      "--value",
+      "Prefer concise status reports.",
+      "--scope",
+      "local_planning",
+      "--scope",
+      "resident_behavior",
+      "--confidence",
+      "0.9"
+    );
+    expect(updateCode).toBe(0);
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const showCode = await runCLI("profile", "show", "--scope", "resident_behavior");
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    consoleSpy.mockRestore();
+
+    expect(showCode).toBe(0);
+    expect(output).toContain("user.preference.status");
+    expect(output).toContain("Prefer concise status reports.");
+    expect(JSON.parse(fs.readFileSync(path.join(tmpDir, "relationship-profile.json"), "utf-8")).items).toHaveLength(1);
+  });
+
+  it("supersedes stale profile values on update", async () => {
+    await runCLI(
+      "profile",
+      "update",
+      "--kind",
+      "boundary",
+      "--key",
+      "user.boundary.notifications",
+      "--value",
+      "Notify freely.",
+      "--scope",
+      "resident_behavior"
+    );
+    await runCLI(
+      "profile",
+      "update",
+      "--kind",
+      "boundary",
+      "--key",
+      "user.boundary.notifications",
+      "--value",
+      "Ask before non-urgent notifications.",
+      "--scope",
+      "resident_behavior",
+      "--source",
+      "user_correction"
+    );
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const showCode = await runCLI("profile", "show", "--scope", "resident_behavior");
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    consoleSpy.mockRestore();
+
+    expect(showCode).toBe(0);
+    expect(output).toContain("Ask before non-urgent notifications.");
+    expect(output).not.toContain("Notify freely.");
+  });
+});
+
 // ─── Directory initialisation ─────────────────────────────────────────────────
 
 describe("directory initialisation", () => {

--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -37,6 +37,7 @@ import { cmdSuggest, cmdImprove } from "./commands/suggest.js";
 import { cmdSetup } from "./commands/setup.js";
 import { cmdKnowledgeList, cmdKnowledgeSearch, cmdKnowledgeStats } from "./commands/knowledge.js";
 import { cmdMemory } from "./commands/memory.js";
+import { cmdProfile } from "./commands/profile.js";
 import { cmdTaskList, cmdTaskShow } from "./commands/task-read.js";
 import { cmdDoctor } from "./commands/doctor.js";
 import { cmdLogs } from "./commands/logs.js";
@@ -518,6 +519,10 @@ export async function dispatchCommand(
 
   if (subcommand === "memory") {
     return await cmdMemory(stateManager, argv.slice(1));
+  }
+
+  if (subcommand === "profile") {
+    return await cmdProfile(stateManager, argv.slice(1));
   }
 
   if (subcommand === "task") {

--- a/src/interface/cli/commands/profile.ts
+++ b/src/interface/cli/commands/profile.ts
@@ -1,0 +1,224 @@
+import { parseArgs } from "node:util";
+import type { StateManager } from "../../../base/state/state-manager.js";
+import { getCliLogger } from "../cli-logger.js";
+import { formatOperationError } from "../utils.js";
+import {
+  loadRelationshipProfile,
+  RelationshipProfileConsentScopeSchema,
+  RelationshipProfileItemKindSchema,
+  RelationshipProfileSensitivitySchema,
+  RelationshipProfileSourceSchema,
+  selectActiveRelationshipProfileItems,
+  upsertRelationshipProfileItem,
+  type RelationshipProfileConsentScope,
+  type RelationshipProfileItemKind,
+  type RelationshipProfileSensitivity,
+  type RelationshipProfileSource,
+} from "../../../platform/profile/relationship-profile.js";
+
+function usage(): string {
+  return `Usage:
+  pulseed profile show [--scope <scope>] [--all] [--json]
+  pulseed profile update --kind <kind> --key <stable_key> --value <value> [--scope <scope>] [--sensitivity <public|private|sensitive>] [--confidence <0-1>] [--source <source>] [--evidence-ref <ref>]
+
+Scopes: local_planning, resident_behavior, memory_retrieval, user_facing_review
+Kinds: identity_fact, preference, dislike, value, boundary, communication_style, notification_preference, long_term_goal, life_context, intervention_policy`;
+}
+
+function parseEnum<T extends string>(
+  raw: string | undefined,
+  label: string,
+  parse: (value: string) => { success: true; data: T } | { success: false }
+): T | null {
+  if (raw === undefined) return null;
+  const result = parse(raw);
+  if (result.success) return result.data;
+  getCliLogger().error(`Error: invalid ${label}: ${raw}`);
+  return null;
+}
+
+function parseScopeList(raw: string[] | undefined): RelationshipProfileConsentScope[] | null {
+  if (!raw || raw.length === 0) return null;
+  const parsed: RelationshipProfileConsentScope[] = [];
+  for (const value of raw) {
+    const result = RelationshipProfileConsentScopeSchema.safeParse(value);
+    if (!result.success) {
+      getCliLogger().error(`Error: invalid scope: ${value}`);
+      return null;
+    }
+    parsed.push(result.data);
+  }
+  return [...new Set(parsed)];
+}
+
+export async function cmdProfile(stateManager: StateManager, argv: string[]): Promise<number> {
+  const subcommand = argv[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h" || subcommand === "help") {
+    console.log(usage());
+    return 0;
+  }
+
+  if (subcommand === "show") {
+    let values: { scope?: string; all?: boolean; json?: boolean };
+    try {
+      ({ values } = parseArgs({
+        args: argv.slice(1),
+        options: {
+          scope: { type: "string" },
+          all: { type: "boolean" },
+          json: { type: "boolean" },
+        },
+        strict: true,
+      }) as { values: { scope?: string; all?: boolean; json?: boolean } });
+    } catch (err) {
+      getCliLogger().error(formatOperationError("parse profile show arguments", err));
+      return 1;
+    }
+
+    const store = await loadRelationshipProfile(stateManager.getBaseDir());
+    if (values.json) {
+      console.log(JSON.stringify(store, null, 2));
+      return 0;
+    }
+
+    let scope: RelationshipProfileConsentScope | null = null;
+    if (values.scope !== undefined) {
+      const parsed = RelationshipProfileConsentScopeSchema.safeParse(values.scope);
+      if (!parsed.success) {
+        getCliLogger().error(`Error: invalid scope: ${values.scope}`);
+        return 1;
+      }
+      scope = parsed.data;
+    }
+    const items = values.all
+      ? store.items
+      : scope
+        ? selectActiveRelationshipProfileItems(store, scope)
+        : store.items.filter((item) => item.status === "active");
+
+    if (items.length === 0) {
+      console.log("No relationship profile items.");
+      return 0;
+    }
+
+    console.log("Relationship profile:");
+    for (const item of items) {
+      console.log(
+        `- ${item.stable_key} [${item.kind}] v${item.version} ${item.status}: ${item.value}` +
+          ` (scopes=${item.allowed_scopes.join(",")}; sensitivity=${item.sensitivity}; confidence=${item.confidence.toFixed(2)})`
+      );
+    }
+    return 0;
+  }
+
+  if (subcommand === "update") {
+    let values: {
+      kind?: string;
+      key?: string;
+      value?: string;
+      scope?: string[];
+      sensitivity?: string;
+      confidence?: string;
+      source?: string;
+      "evidence-ref"?: string;
+      note?: string;
+      json?: boolean;
+    };
+    try {
+      ({ values } = parseArgs({
+        args: argv.slice(1),
+        options: {
+          kind: { type: "string" },
+          key: { type: "string" },
+          value: { type: "string" },
+          scope: { type: "string", multiple: true },
+          sensitivity: { type: "string" },
+          confidence: { type: "string" },
+          source: { type: "string" },
+          "evidence-ref": { type: "string" },
+          note: { type: "string" },
+          json: { type: "boolean" },
+        },
+        strict: true,
+      }) as {
+        values: {
+          kind?: string;
+          key?: string;
+          value?: string;
+          scope?: string[];
+          sensitivity?: string;
+          confidence?: string;
+          source?: string;
+          "evidence-ref"?: string;
+          note?: string;
+          json?: boolean;
+        };
+      });
+    } catch (err) {
+      getCliLogger().error(formatOperationError("parse profile update arguments", err));
+      return 1;
+    }
+
+    const kind = parseEnum<RelationshipProfileItemKind>(
+      values.kind,
+      "kind",
+      (value) => RelationshipProfileItemKindSchema.safeParse(value) as never
+    );
+    const sensitivity = parseEnum<RelationshipProfileSensitivity>(
+      values.sensitivity ?? "private",
+      "sensitivity",
+      (value) => RelationshipProfileSensitivitySchema.safeParse(value) as never
+    );
+    const source = parseEnum<RelationshipProfileSource>(
+      values.source ?? "cli_update",
+      "source",
+      (value) => RelationshipProfileSourceSchema.safeParse(value) as never
+    );
+    const allowedScopes = parseScopeList(values.scope);
+    if (!kind || !sensitivity || !source || values.scope && !allowedScopes) return 1;
+    if (!values.key?.trim() || !values.value?.trim()) {
+      getCliLogger().error("Error: --key and --value are required.");
+      console.log(usage());
+      return 1;
+    }
+
+    let confidence: number | undefined;
+    if (values.confidence !== undefined) {
+      confidence = Number(values.confidence);
+      if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+        getCliLogger().error(`Error: --confidence must be a number between 0 and 1 (got: ${values.confidence})`);
+        return 1;
+      }
+    }
+
+    try {
+      const result = await upsertRelationshipProfileItem(stateManager.getBaseDir(), {
+        stableKey: values.key,
+        kind,
+        value: values.value,
+        source,
+        sensitivity,
+        confidence,
+        allowedScopes: allowedScopes ?? undefined,
+        evidenceRef: values["evidence-ref"],
+        note: values.note,
+      });
+      if (values.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Updated relationship profile item ${result.item.stable_key} v${result.item.version}.`);
+        if (result.superseded.length > 0) {
+          console.log(`Superseded ${result.superseded.length} previous active item(s).`);
+        }
+      }
+      return 0;
+    } catch (err) {
+      getCliLogger().error(formatOperationError("update relationship profile", err));
+      return 1;
+    }
+  }
+
+  getCliLogger().error(`Unknown profile subcommand: "${subcommand}"`);
+  console.log(usage());
+  return 1;
+}

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../base/llm/provider-config.js";
 import type { ProviderConfig } from "../../../base/llm/provider-config.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
+import { seedRelationshipProfileFromSetup } from "../../../platform/profile/relationship-profile.js";
 import { updateGlobalConfig } from "../../../base/config/global-config.js";
 import { readCodexOAuthToken } from "../../../base/llm/provider-config.js";
 import { isDaemonRunning } from "../../../runtime/daemon/client.js";
@@ -702,6 +703,15 @@ export async function runSetupWizard(): Promise<number> {
     writeUserMd(dir, finalAnswers.userName, finalAnswers.importedUserContent);
   } else {
     writeUserMd(dir, finalAnswers.userName);
+  }
+  try {
+    await seedRelationshipProfileFromSetup({
+      baseDir: dir,
+      userName: finalAnswers.userName,
+      importedUserContent: finalAnswers.importedUserContent,
+    });
+  } catch (err) {
+    p.log.warn(`Setup saved, but could not seed relationship profile: ${err instanceof Error ? err.message : String(err)}`);
   }
   clearIdentityCache();
 

--- a/src/interface/cli/commands/setup/__tests__/steps-runtime.test.ts
+++ b/src/interface/cli/commands/setup/__tests__/steps-runtime.test.ts
@@ -7,6 +7,7 @@ import {
   getSelfIdentityResponseForBaseDir,
   loadIdentityFromBaseDir,
 } from "../../../../../base/config/identity-loader.js";
+import { loadRelationshipProfile, seedRelationshipProfileFromSetup } from "../../../../../platform/profile/relationship-profile.js";
 import { renderSeedMd, writeSeedMd } from "../steps-runtime.js";
 
 const tempDirs: string[] = [];
@@ -46,5 +47,23 @@ describe("setup runtime identity files", () => {
     expect(slot).toContain("SEED.md is the canonical local setup file");
     expect(slot).toContain("Active agent name: Sprout");
     expect(response).toContain("私はSproutです");
+  });
+
+  it("seeds a versioned relationship profile without replacing USER.md compatibility", async () => {
+    const dir = makeTempDir();
+    fs.writeFileSync(path.join(dir, "USER.md"), "# About You\n\nName: Yu\n", "utf-8");
+
+    await seedRelationshipProfileFromSetup({
+      baseDir: dir,
+      userName: "Yu",
+      now: "2026-05-02T00:00:00.000Z",
+    });
+
+    const identity = loadIdentityFromBaseDir(dir);
+    const profile = await loadRelationshipProfile(dir);
+    expect(identity.user).toContain("Name: Yu");
+    expect(profile.items).toHaveLength(1);
+    expect(profile.items[0]?.stable_key).toBe("user.identity.name");
+    expect(profile.items[0]?.allowed_scopes).toContain("resident_behavior");
   });
 });

--- a/src/platform/profile/__tests__/relationship-profile.test.ts
+++ b/src/platform/profile/__tests__/relationship-profile.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  formatRelationshipProfilePromptBlock,
+  loadRelationshipProfile,
+  relationshipProfilePath,
+  seedRelationshipProfileFromSetup,
+  selectActiveRelationshipProfileItems,
+  upsertRelationshipProfileItem,
+} from "../relationship-profile.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-relationship-profile-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("relationship profile store", () => {
+  it("versions preference changes and rejects stale active items", async () => {
+    const baseDir = makeTempDir();
+
+    const first = await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.editor",
+      kind: "preference",
+      value: "The user prefers Atom.",
+      source: "cli_update",
+      allowedScopes: ["local_planning", "resident_behavior"],
+      now: "2026-05-02T00:00:00.000Z",
+    });
+    const second = await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.editor",
+      kind: "preference",
+      value: "The user prefers VS Code.",
+      source: "user_correction",
+      allowedScopes: ["local_planning", "resident_behavior"],
+      now: "2026-05-02T01:00:00.000Z",
+    });
+
+    const store = await loadRelationshipProfile(baseDir);
+    expect(first.item.version).toBe(1);
+    expect(second.item.version).toBe(2);
+    expect(second.superseded.map((item) => item.id)).toEqual([first.item.id]);
+    expect(store.items.find((item) => item.id === first.item.id)?.status).toBe("superseded");
+
+    const active = selectActiveRelationshipProfileItems(store, "local_planning");
+    expect(active).toHaveLength(1);
+    expect(active[0]?.value).toBe("The user prefers VS Code.");
+
+    const block = formatRelationshipProfilePromptBlock(store, "local_planning");
+    expect(block).toContain("The user prefers VS Code.");
+    expect(block).not.toContain("The user prefers Atom.");
+  });
+
+  it("keeps sensitive boundary items out of prompts unless explicitly allowed", async () => {
+    const baseDir = makeTempDir();
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.boundary.health",
+      kind: "boundary",
+      value: "Do not use health context outside explicit review.",
+      source: "cli_update",
+      sensitivity: "sensitive",
+      allowedScopes: ["local_planning", "user_facing_review"],
+      now: "2026-05-02T00:00:00.000Z",
+    });
+
+    const store = await loadRelationshipProfile(baseDir);
+    expect(formatRelationshipProfilePromptBlock(store, "local_planning")).not.toContain("health context");
+    expect(formatRelationshipProfilePromptBlock(store, "local_planning", { includeSensitive: true })).toContain("health context");
+  });
+
+  it("seeds setup identity separately from USER.md compatibility", async () => {
+    const baseDir = makeTempDir();
+    await seedRelationshipProfileFromSetup({
+      baseDir,
+      userName: "Yu",
+      importedUserContent: "# About You\n\nPrefer concise status reports.",
+      now: "2026-05-02T00:00:00.000Z",
+    });
+
+    const store = await loadRelationshipProfile(baseDir);
+    expect(fs.existsSync(relationshipProfilePath(baseDir))).toBe(true);
+    expect(store.items.map((item) => item.stable_key).sort()).toEqual([
+      "user.identity.name",
+      "user.imported_user_md",
+    ]);
+    expect(store.items.find((item) => item.stable_key === "user.identity.name")?.allowed_scopes).toContain("resident_behavior");
+    expect(store.items.find((item) => item.stable_key === "user.imported_user_md")?.allowed_scopes).toEqual([
+      "user_facing_review",
+    ]);
+    expect(store.items.find((item) => item.stable_key === "user.imported_user_md")?.value).toContain("Prefer concise");
+  });
+
+  it("does not feed raw imported USER.md into planning prompts after structured corrections", async () => {
+    const baseDir = makeTempDir();
+    await seedRelationshipProfileFromSetup({
+      baseDir,
+      userName: "Imported USER.md",
+      importedUserContent: "# About You\n\nPrefer verbose status reports.",
+      now: "2026-05-02T00:00:00.000Z",
+    });
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "user_correction",
+      allowedScopes: ["local_planning"],
+      now: "2026-05-02T01:00:00.000Z",
+    });
+
+    const store = await loadRelationshipProfile(baseDir);
+    const block = formatRelationshipProfilePromptBlock(store, "local_planning");
+    expect(block).toContain("Prefer concise status reports.");
+    expect(block).not.toContain("Prefer verbose status reports.");
+  });
+});

--- a/src/platform/profile/relationship-profile.ts
+++ b/src/platform/profile/relationship-profile.ts
@@ -1,0 +1,331 @@
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../../base/utils/json-io.js";
+
+export const RelationshipProfileItemKindSchema = z.enum([
+  "identity_fact",
+  "preference",
+  "dislike",
+  "value",
+  "boundary",
+  "communication_style",
+  "notification_preference",
+  "long_term_goal",
+  "life_context",
+  "intervention_policy",
+]);
+
+export const RelationshipProfileConsentScopeSchema = z.enum([
+  "local_planning",
+  "resident_behavior",
+  "memory_retrieval",
+  "user_facing_review",
+]);
+
+export const RelationshipProfileSensitivitySchema = z.enum(["public", "private", "sensitive"]);
+export const RelationshipProfileItemStatusSchema = z.enum(["active", "superseded", "retracted"]);
+export const RelationshipProfileSourceSchema = z.enum([
+  "setup_user",
+  "setup_import",
+  "cli_update",
+  "user_correction",
+  "system_migration",
+]);
+
+export const RelationshipProfileItemSchema = z.object({
+  id: z.string().min(1),
+  stable_key: z.string().min(1),
+  kind: RelationshipProfileItemKindSchema,
+  value: z.string().min(1),
+  status: RelationshipProfileItemStatusSchema.default("active"),
+  version: z.number().int().positive(),
+  confidence: z.number().min(0).max(1).default(0.8),
+  sensitivity: RelationshipProfileSensitivitySchema.default("private"),
+  allowed_scopes: z.array(RelationshipProfileConsentScopeSchema).min(1).default(["local_planning", "user_facing_review"]),
+  provenance: z.object({
+    source: RelationshipProfileSourceSchema,
+    evidence_ref: z.string().min(1).optional(),
+    note: z.string().min(1).optional(),
+  }),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+  superseded_at: z.string().datetime().nullable().default(null),
+  superseded_by: z.string().nullable().default(null),
+});
+
+export const RelationshipProfileAuditEventSchema = z.object({
+  id: z.string().min(1),
+  at: z.string().datetime(),
+  action: z.enum(["created", "superseded", "retracted", "seeded"]),
+  item_id: z.string().min(1),
+  stable_key: z.string().min(1),
+  version: z.number().int().positive(),
+  source: RelationshipProfileSourceSchema,
+  previous_item_id: z.string().min(1).optional(),
+});
+
+export const RelationshipProfileStoreSchema = z.object({
+  schema_version: z.literal(1).default(1),
+  profile_id: z.string().min(1).default("default"),
+  items: z.array(RelationshipProfileItemSchema).default([]),
+  audit_events: z.array(RelationshipProfileAuditEventSchema).default([]),
+  updated_at: z.string().datetime().nullable().default(null),
+});
+
+export type RelationshipProfileItemKind = z.infer<typeof RelationshipProfileItemKindSchema>;
+export type RelationshipProfileConsentScope = z.infer<typeof RelationshipProfileConsentScopeSchema>;
+export type RelationshipProfileSensitivity = z.infer<typeof RelationshipProfileSensitivitySchema>;
+export type RelationshipProfileSource = z.infer<typeof RelationshipProfileSourceSchema>;
+export type RelationshipProfileItem = z.infer<typeof RelationshipProfileItemSchema>;
+export type RelationshipProfileStore = z.infer<typeof RelationshipProfileStoreSchema>;
+
+export interface RelationshipProfileItemInput {
+  stableKey: string;
+  kind: RelationshipProfileItemKind;
+  value: string;
+  source: RelationshipProfileSource;
+  confidence?: number;
+  sensitivity?: RelationshipProfileSensitivity;
+  allowedScopes?: RelationshipProfileConsentScope[];
+  evidenceRef?: string;
+  note?: string;
+  now?: string;
+}
+
+export function relationshipProfilePath(baseDir: string): string {
+  return path.join(baseDir, "relationship-profile.json");
+}
+
+export function createEmptyRelationshipProfile(now: string | null = null): RelationshipProfileStore {
+  return RelationshipProfileStoreSchema.parse({
+    schema_version: 1,
+    profile_id: "default",
+    items: [],
+    audit_events: [],
+    updated_at: now,
+  });
+}
+
+export async function loadRelationshipProfile(baseDir: string): Promise<RelationshipProfileStore> {
+  const raw = await readJsonFileOrNull(relationshipProfilePath(baseDir));
+  const parsed = RelationshipProfileStoreSchema.safeParse(raw);
+  return parsed.success ? parsed.data : createEmptyRelationshipProfile();
+}
+
+export function loadRelationshipProfileSync(baseDir: string): RelationshipProfileStore {
+  try {
+    const raw = JSON.parse(fs.readFileSync(relationshipProfilePath(baseDir), "utf-8")) as unknown;
+    const parsed = RelationshipProfileStoreSchema.safeParse(raw);
+    return parsed.success ? parsed.data : createEmptyRelationshipProfile();
+  } catch {
+    return createEmptyRelationshipProfile();
+  }
+}
+
+export async function saveRelationshipProfile(baseDir: string, store: RelationshipProfileStore): Promise<void> {
+  await writeJsonFileAtomic(relationshipProfilePath(baseDir), RelationshipProfileStoreSchema.parse(store), {
+    mode: 0o600,
+    directoryMode: 0o700,
+  });
+}
+
+function normalizeProfileInput(input: RelationshipProfileItemInput): RelationshipProfileItemInput {
+  const stableKey = input.stableKey.trim();
+  const value = input.value.trim();
+  if (!stableKey) throw new Error("stable key is required");
+  if (!value) throw new Error("profile value is required");
+  const allowedScopes: RelationshipProfileConsentScope[] = input.allowedScopes && input.allowedScopes.length > 0
+    ? [...new Set(input.allowedScopes)]
+    : ["local_planning", "user_facing_review"];
+  return { ...input, stableKey, value, allowedScopes };
+}
+
+function nextVersion(store: RelationshipProfileStore, stableKey: string): number {
+  return store.items
+    .filter((item) => item.stable_key === stableKey)
+    .reduce((max, item) => Math.max(max, item.version), 0) + 1;
+}
+
+export function upsertRelationshipProfileItemInStore(
+  store: RelationshipProfileStore,
+  input: RelationshipProfileItemInput
+): { store: RelationshipProfileStore; item: RelationshipProfileItem; superseded: RelationshipProfileItem[] } {
+  const normalized = normalizeProfileInput(input);
+  const now = normalized.now ?? new Date().toISOString();
+  const itemId = `profile-item-${randomUUID()}`;
+  const superseded: RelationshipProfileItem[] = [];
+
+  const items = store.items.map((item) => {
+    if (item.stable_key !== normalized.stableKey || item.status !== "active") return item;
+    const updated = RelationshipProfileItemSchema.parse({
+      ...item,
+      status: "superseded",
+      superseded_at: now,
+      superseded_by: itemId,
+      updated_at: now,
+    });
+    superseded.push(updated);
+    return updated;
+  });
+
+  const item = RelationshipProfileItemSchema.parse({
+    id: itemId,
+    stable_key: normalized.stableKey,
+    kind: normalized.kind,
+    value: normalized.value,
+    status: "active",
+    version: nextVersion(store, normalized.stableKey),
+    confidence: normalized.confidence ?? 0.8,
+    sensitivity: normalized.sensitivity ?? "private",
+    allowed_scopes: normalized.allowedScopes,
+    provenance: {
+      source: normalized.source,
+      ...(normalized.evidenceRef ? { evidence_ref: normalized.evidenceRef } : {}),
+      ...(normalized.note ? { note: normalized.note } : {}),
+    },
+    created_at: now,
+    updated_at: now,
+    superseded_at: null,
+    superseded_by: null,
+  });
+
+  const auditEvents = [
+    ...store.audit_events,
+    ...superseded.map((previous) => RelationshipProfileAuditEventSchema.parse({
+      id: `profile-event-${randomUUID()}`,
+      at: now,
+      action: "superseded",
+      item_id: previous.id,
+      stable_key: previous.stable_key,
+      version: previous.version,
+      source: normalized.source,
+      previous_item_id: previous.id,
+    })),
+    RelationshipProfileAuditEventSchema.parse({
+      id: `profile-event-${randomUUID()}`,
+      at: now,
+      action: store.items.some((existing) => existing.stable_key === normalized.stableKey) ? "created" : "seeded",
+      item_id: item.id,
+      stable_key: item.stable_key,
+      version: item.version,
+      source: normalized.source,
+      previous_item_id: superseded.at(-1)?.id,
+    }),
+  ];
+
+  return {
+    store: RelationshipProfileStoreSchema.parse({
+      ...store,
+      items: [...items, item],
+      audit_events: auditEvents,
+      updated_at: now,
+    }),
+    item,
+    superseded,
+  };
+}
+
+export async function upsertRelationshipProfileItem(
+  baseDir: string,
+  input: RelationshipProfileItemInput
+): Promise<{ item: RelationshipProfileItem; superseded: RelationshipProfileItem[] }> {
+  const loaded = await loadRelationshipProfile(baseDir);
+  const result = upsertRelationshipProfileItemInStore(loaded, input);
+  await saveRelationshipProfile(baseDir, result.store);
+  return { item: result.item, superseded: result.superseded };
+}
+
+export function selectActiveRelationshipProfileItems(
+  store: RelationshipProfileStore,
+  scope: RelationshipProfileConsentScope,
+  options: { includeSensitive?: boolean } = {}
+): RelationshipProfileItem[] {
+  return store.items
+    .filter((item) => item.status === "active")
+    .filter((item) => item.allowed_scopes.includes(scope))
+    .filter((item) => options.includeSensitive === true || item.sensitivity !== "sensitive")
+    .sort((a, b) => {
+      const kindCompare = a.kind.localeCompare(b.kind);
+      if (kindCompare !== 0) return kindCompare;
+      return a.stable_key.localeCompare(b.stable_key);
+    });
+}
+
+export function formatRelationshipProfilePromptBlock(
+  store: RelationshipProfileStore,
+  scope: RelationshipProfileConsentScope,
+  options: { includeSensitive?: boolean } = {}
+): string {
+  const activeItems = selectActiveRelationshipProfileItems(store, scope, options);
+  if (activeItems.length === 0) return "";
+  const lines = [
+    `Relationship Profile (active items only; consent scope: ${scope})`,
+    "- Use these items as user-provided relationship context.",
+    "- Ignore superseded or retracted profile items even if they appear in older memory.",
+    ...activeItems.map((item) => {
+      const confidence = item.confidence.toFixed(2);
+      return `- [${item.kind}] ${item.stable_key}: ${item.value} (confidence=${confidence}; sensitivity=${item.sensitivity}; version=${item.version})`;
+    }),
+  ];
+  return lines.join("\n");
+}
+
+export function loadRelationshipProfilePromptBlock(
+  baseDir: string,
+  scope: RelationshipProfileConsentScope,
+  options: { includeSensitive?: boolean } = {}
+): string {
+  return formatRelationshipProfilePromptBlock(loadRelationshipProfileSync(baseDir), scope, options);
+}
+
+export async function seedRelationshipProfileFromSetup(params: {
+  baseDir: string;
+  userName?: string;
+  importedUserContent?: string;
+  now?: string;
+}): Promise<RelationshipProfileStore> {
+  const store = await loadRelationshipProfile(params.baseDir);
+  let next = store;
+  const now = params.now ?? new Date().toISOString();
+
+  const userName = params.userName?.trim();
+  if (userName && userName !== "Imported USER.md") {
+    next = upsertRelationshipProfileItemInStore(next, {
+      stableKey: "user.identity.name",
+      kind: "identity_fact",
+      value: userName,
+      source: "setup_user",
+      confidence: 0.9,
+      sensitivity: "private",
+      allowedScopes: ["local_planning", "resident_behavior", "memory_retrieval", "user_facing_review"],
+      evidenceRef: "setup:userName",
+      now,
+    }).store;
+  }
+
+  const imported = params.importedUserContent?.trim();
+  if (imported) {
+    next = upsertRelationshipProfileItemInStore(next, {
+      stableKey: "user.imported_user_md",
+      kind: "life_context",
+      value: imported,
+      source: "setup_import",
+      confidence: 0.7,
+      sensitivity: "private",
+      allowedScopes: ["user_facing_review"],
+      evidenceRef: "setup:USER.md",
+      note: "Imported raw USER.md remains compatible as USER.md and is review-only until structured profile items are explicitly added.",
+      now,
+    }).store;
+  }
+
+  if (next !== store) {
+    await saveRelationshipProfile(params.baseDir, next);
+  } else {
+    await fsp.mkdir(params.baseDir, { recursive: true });
+  }
+  return next;
+}

--- a/src/reflection/__tests__/morning-planning.test.ts
+++ b/src/reflection/__tests__/morning-planning.test.ts
@@ -5,6 +5,7 @@ import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js"
 import { createMockLLMClient } from "../../../tests/helpers/mock-llm.js";
 import { runMorningPlanning } from "../morning-planning.js";
 import type { Goal } from "../../base/types/goal.js";
+import { upsertRelationshipProfileItem } from "../../platform/profile/relationship-profile.js";
 
 // ─── Fixtures ───
 
@@ -135,6 +136,46 @@ describe("runMorningPlanning", () => {
     expect(fs.existsSync(filePath)).toBe(true);
     const content = JSON.parse(fs.readFileSync(filePath, "utf-8"));
     expect(content.goals_reviewed).toBe(1);
+  });
+
+  it("includes active local-planning relationship profile items in the planning prompt", async () => {
+    tmpDir = makeTempDir();
+    await upsertRelationshipProfileItem(tmpDir, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise planning summaries.",
+      source: "cli_update",
+      allowedScopes: ["local_planning"],
+      now: "2026-05-02T00:00:00.000Z",
+    });
+    await upsertRelationshipProfileItem(tmpDir, {
+      stableKey: "user.preference.proactive_status",
+      kind: "preference",
+      value: "Prefer lengthy planning summaries.",
+      source: "cli_update",
+      allowedScopes: ["resident_behavior"],
+      now: "2026-05-02T01:00:00.000Z",
+    });
+    const goals = [makeGoal("g1")];
+    const stateManager = makeStateManager(goals);
+    const sendMessage = vi.fn().mockResolvedValue({ content: VALID_LLM_RESPONSE });
+    const llmClient = {
+      sendMessage,
+      parseJSON: vi.fn().mockImplementation((content: string, schema: { parse(value: unknown): unknown }) =>
+        schema.parse(JSON.parse(content))
+      ),
+    };
+
+    await runMorningPlanning({
+      stateManager: stateManager as never,
+      llmClient: llmClient as never,
+      baseDir: tmpDir,
+    });
+
+    const prompt = sendMessage.mock.calls[0]?.[0]?.[0]?.content ?? "";
+    expect(prompt).toContain("Relationship Profile");
+    expect(prompt).toContain("Prefer concise planning summaries.");
+    expect(prompt).not.toContain("Prefer lengthy planning summaries.");
   });
 
   it("LLM error: returns partial report without crashing", async () => {

--- a/src/reflection/evening-catchup.ts
+++ b/src/reflection/evening-catchup.ts
@@ -56,7 +56,10 @@ export async function runEveningCatchup(deps: {
       // No morning report available
     }
 
-    const prompt = `${getInternalIdentityPrefix("evening catch-up assistant")} Review today's goal progress.
+    const prompt = `${getInternalIdentityPrefix("evening catch-up assistant", {
+      baseDir,
+      profileScope: "local_planning",
+    })} Review today's goal progress.
 
 Current goal state:
 ${JSON.stringify(goalSummaries, null, 2)}

--- a/src/reflection/morning-planning.ts
+++ b/src/reflection/morning-planning.ts
@@ -48,7 +48,10 @@ export async function runMorningPlanning(deps: {
   let concerns: string[] = [];
 
   if (goalSummaries.length > 0) {
-    const prompt = `${getInternalIdentityPrefix("morning planner")} Review these active goals and create a daily plan.
+    const prompt = `${getInternalIdentityPrefix("morning planner", {
+      baseDir,
+      profileScope: "local_planning",
+    })} Review these active goals and create a daily plan.
 
 Goals:
 ${JSON.stringify(goalSummaries, null, 2)}

--- a/src/reflection/weekly-review.ts
+++ b/src/reflection/weekly-review.ts
@@ -89,7 +89,10 @@ export async function runWeeklyReview(deps: {
   let summary = "";
 
   if (goalSummaries.length > 0) {
-    const prompt = `${getInternalIdentityPrefix("weekly reviewer")} Analyze this week's goal progress and provide a strategic review.
+    const prompt = `${getInternalIdentityPrefix("weekly reviewer", {
+      baseDir,
+      profileScope: "local_planning",
+    })} Analyze this week's goal progress and provide a strategic review.
 
 Goals (weekly_delta = how much gap closed this week, 0-1):
 ${JSON.stringify(goalSummaries, null, 2)}

--- a/src/runtime/daemon/__tests__/maintenance-profile.test.ts
+++ b/src/runtime/daemon/__tests__/maintenance-profile.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { DaemonConfigSchema, DaemonStateSchema } from "../../types/daemon.js";
+import { upsertRelationshipProfileItem } from "../../../platform/profile/relationship-profile.js";
+import { runProactiveMaintenance } from "../maintenance.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-proactive-profile-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("runProactiveMaintenance relationship profile context", () => {
+  it("uses only active resident-behavior profile items", async () => {
+    const baseDir = makeTempDir();
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.intervention.nudge",
+      kind: "intervention_policy",
+      value: "Suggest only when the next action is clearly reversible.",
+      source: "cli_update",
+      allowedScopes: ["resident_behavior"],
+      now: "2026-05-02T00:00:00.000Z",
+    });
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.planning",
+      kind: "preference",
+      value: "Use detailed weekly planning notes.",
+      source: "cli_update",
+      allowedScopes: ["local_planning"],
+      now: "2026-05-02T00:00:00.000Z",
+    });
+
+    const sendMessage = vi.fn().mockResolvedValue({ content: JSON.stringify({ action: "sleep", details: {} }) });
+    const llmClient = {
+      sendMessage,
+      parseJSON: vi.fn().mockImplementation((content: string, schema: { parse(value: unknown): unknown }) =>
+        schema.parse(JSON.parse(content))
+      ),
+    };
+
+    await runProactiveMaintenance({
+      config: DaemonConfigSchema.parse({
+        proactive_mode: true,
+        proactive_interval_ms: 1,
+        runtime_root: baseDir,
+      }),
+      llmClient: llmClient as never,
+      state: DaemonStateSchema.parse({
+        pid: 123,
+        started_at: "2026-05-02T00:00:00.000Z",
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: [],
+        status: "idle",
+      }),
+      lastProactiveTickAt: 0,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    const prompt = sendMessage.mock.calls[0]?.[0]?.[0]?.content ?? "";
+    expect(prompt).toContain("Suggest only when the next action is clearly reversible.");
+    expect(prompt).not.toContain("Use detailed weekly planning notes.");
+  });
+});

--- a/src/runtime/daemon/maintenance.ts
+++ b/src/runtime/daemon/maintenance.ts
@@ -315,7 +315,10 @@ export async function runProactiveMaintenance(params: {
       ? state.active_goals.map((id) => `- ${id}`).join("\n")
       : "(no active goals)";
 
-    const prompt = `${getInternalIdentityPrefix("proactive engine")} Given the current state of all goals:\n${goalSummaries}\n\nDecide what action to take:\n- "suggest_goal": A new goal should be created (provide title + description)\n- "investigate": Something needs investigation (provide what and why)\n- "preemptive_check": Run a pre-emptive observation (provide goal_id)\n- "sleep": Nothing needs attention right now\n\nRespond with JSON: { "action": "...", "details": { ... } }`;
+    const prompt = `${getInternalIdentityPrefix("proactive engine", {
+      baseDir: config.runtime_root,
+      profileScope: "resident_behavior",
+    })} Given the current state of all goals:\n${goalSummaries}\n\nDecide what action to take:\n- "suggest_goal": A new goal should be created (provide title + description)\n- "investigate": Something needs investigation (provide what and why)\n- "preemptive_check": Run a pre-emptive observation (provide goal_id)\n- "sleep": Nothing needs attention right now\n\nRespond with JSON: { "action": "...", "details": { ... } }`;
 
     const response = await llmClient.sendMessage(
       [{ role: "user", content: prompt }],


### PR DESCRIPTION
Closes #896

## Summary
- add a typed versioned relationship-profile store separate from raw USER.md
- seed setup/import profile data while preserving USER.md compatibility, with raw imported USER.md scoped to user-facing review only
- add `pulseed profile show/update` and active/superseded item handling through the production CLI entrypoint
- feed active, consent-scoped profile items into planning and resident proactive prompts only where callers explicitly opt in

## Verification
- npm run typecheck
- npx vitest run src/platform/profile/__tests__/relationship-profile.test.ts src/base/config/__tests__/identity-loader.test.ts src/interface/cli/commands/setup/__tests__/steps-runtime.test.ts src/reflection/__tests__/morning-planning.test.ts src/runtime/daemon/__tests__/maintenance-profile.test.ts src/interface/cli/__tests__/cli-runner.test.ts
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known risks
- imported freeform USER.md is intentionally review-only until structured profile items are added; richer extraction from freeform text should be a separate governed flow.
- profile prompt usage is currently limited to planning/reflection and resident proactive prompts to avoid biasing unrelated semantic classifiers.