### PR TITLE
feat(runtime): track proactive intervention quality

### DIFF
--- a/src/interface/cli/__tests__/cli-daemon-status.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-status.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../../base/utils/paths.js", async (importOriginal) => {
 import { getPulseedDirPath } from "../../../base/utils/paths.js";
 import { cmdDaemonStatus } from "../commands/daemon.js";
 import { PIDManager } from "../../../runtime/pid-manager.js";
+import { ProactiveInterventionStore } from "../../../runtime/store/proactive-intervention-store.js";
 
 function mockPidInspectRunning(runtimePid: number, ownerPid = runtimePid) {
   return vi.spyOn(PIDManager.prototype, "inspect").mockResolvedValue({
@@ -531,6 +532,56 @@ describe("cmdDaemonStatus", () => {
     expect(output).toContain("Resident:        negotiation");
     expect(output).toContain("Resident note:   Resident discovery negotiated a new goal");
     expect(output).toContain("Resident goal:   resident-goal");
+  });
+
+  it("shows proactive quality summary when feedback history exists", async () => {
+    const state = {
+      pid: process.pid,
+      started_at: new Date(Date.now() - 60_000).toISOString(),
+      last_loop_at: null,
+      loop_count: 1,
+      active_goals: ["resident-goal"],
+      status: "running",
+      crash_count: 0,
+      last_error: null,
+      last_resident_at: new Date(Date.now() - 5_000).toISOString(),
+      resident_activity: {
+        intervention_id: "resident-feedback-status",
+        kind: "suggestion",
+        trigger: "proactive_tick",
+        summary: "Resident suggested a new goal.",
+        recorded_at: new Date(Date.now() - 5_000).toISOString(),
+        goal_id: "resident-goal",
+      } as const,
+    };
+    fs.writeFileSync(path.join(tmpDir, "daemon-state.json"), JSON.stringify(state));
+    fs.writeFileSync(
+      path.join(tmpDir, "pulseed.pid"),
+      JSON.stringify({
+        pid: process.pid,
+        runtime_pid: process.pid,
+        owner_pid: process.pid,
+        started_at: new Date().toISOString(),
+      })
+    );
+    const store = new ProactiveInterventionStore(path.join(tmpDir, "runtime"));
+    await store.appendIntervention({
+      activity: state.resident_activity,
+    });
+    await store.appendFeedback({
+      interventionId: "resident-feedback-status",
+      outcome: "accepted",
+      recordedAt: new Date().toISOString(),
+    });
+    const inspectSpy = mockPidInspectRunning(process.pid);
+
+    await cmdDaemonStatus([]);
+    inspectSpy.mockRestore();
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain("Resident event:  resident-feedback-status");
+    expect(output).toContain("Proactive quality:");
+    expect(output).toContain("Accepted:      1");
   });
 
   it("shows dream resident activity without requiring a goal id", async () => {

--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -172,6 +172,7 @@ import { GoalRefiner } from "../../../orchestrator/goal/goal-refiner.js";
 import { getPulseedVersion } from "../../../base/utils/pulseed-meta.js";
 import { ensureProviderConfig } from "../ensure-api-key.js";
 import { DaemonClient } from "../../../runtime/daemon/client.js";
+import { ProactiveInterventionStore } from "../../../runtime/store/proactive-intervention-store.js";
 import type { LoopResult } from "../../../orchestrator/loop/core-loop.js";
 import type { Goal } from "../../../base/types/goal.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
@@ -1457,6 +1458,44 @@ describe("profile command", () => {
     expect(showCode).toBe(0);
     expect(output).toContain("Ask before non-urgent notifications.");
     expect(output).not.toContain("Notify freely.");
+  });
+});
+
+describe("runtime proactive feedback commands", () => {
+  it("records typed proactive feedback through the production CLI entrypoint", async () => {
+    const store = new ProactiveInterventionStore(path.join(tmpDir, "runtime"));
+    await store.appendIntervention({
+      activity: {
+        intervention_id: "intervention-cli-feedback",
+        kind: "suggestion",
+        trigger: "proactive_tick",
+        summary: "Suggested a follow-up.",
+        recorded_at: "2026-05-02T00:00:00.000Z",
+      },
+    });
+
+    const feedbackCode = await runCLI(
+      "runtime",
+      "proactive-feedback",
+      "--intervention",
+      "intervention-cli-feedback",
+      "--outcome",
+      "overreach",
+      "--overreach-indicator",
+      "too_frequent",
+      "--reason",
+      "Too many suggestions"
+    );
+    expect(feedbackCode).toBe(0);
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const qualityCode = await runCLI("runtime", "proactive-quality");
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    consoleSpy.mockRestore();
+
+    expect(qualityCode).toBe(0);
+    expect(output).toContain("Overreach:     1");
+    expect(output).toContain("reduce_frequency");
   });
 });
 

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -22,7 +22,7 @@ import {
 import { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import { RuntimeWatchdog } from "../../../runtime/watchdog.js";
 import { LeaderLockManager } from "../../../runtime/leader-lock-manager.js";
-import { RuntimeHealthStore } from "../../../runtime/store/index.js";
+import { ProactiveInterventionStore, RuntimeHealthStore } from "../../../runtime/store/index.js";
 import { isDaemonRunning, probeDaemonHealth } from "../../../runtime/daemon/client.js";
 import { PluginLoader } from "../../../runtime/plugin-loader.js";
 import { NotifierRegistry } from "../../../runtime/notifier-registry.js";
@@ -472,6 +472,7 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   const cfg = await loadDaemonConfig(baseDir);
   const runtimeRoot = resolveDaemonRuntimeRoot(baseDir, cfg.runtime_root);
   const runtimeHealth = await new RuntimeHealthStore(runtimeRoot).loadSnapshot();
+  const proactiveSummary = await new ProactiveInterventionStore(runtimeRoot).summarize();
   const supervisorState = await readSupervisorState(runtimeRoot);
   const taskKpis = await summarizeTaskOutcomeLedgers(baseDir);
   const safePauseGoals = Object.values(data.safe_pause_goals ?? {});
@@ -575,9 +576,24 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   if (data.resident_activity) {
     const residentAgo = formatRelativeTime(data.resident_activity.recorded_at);
     lines.push(`Resident:        ${data.resident_activity.kind} (${residentAgo})`);
+    if (data.resident_activity.intervention_id) {
+      lines.push(`Resident event:  ${data.resident_activity.intervention_id}`);
+    }
     lines.push(`Resident note:   ${data.resident_activity.summary}`);
     if (data.resident_activity.goal_id) {
       lines.push(`Resident goal:   ${data.resident_activity.goal_id}`);
+    }
+  }
+  if (proactiveSummary.total_interventions > 0) {
+    lines.push("");
+    lines.push("Proactive quality:");
+    lines.push(`  Interventions: ${proactiveSummary.total_interventions} (${proactiveSummary.pending_count} pending feedback)`);
+    lines.push(`  Accepted:      ${proactiveSummary.accepted_count} (${formatPercent(proactiveSummary.accepted_rate)})`);
+    lines.push(`  Ignored:       ${proactiveSummary.ignored_count} (${formatPercent(proactiveSummary.ignored_rate)})`);
+    lines.push(`  Corrected:     ${proactiveSummary.corrected_count} (${formatPercent(proactiveSummary.correction_rate)})`);
+    lines.push(`  Overreach:     ${proactiveSummary.overreach_count} (${formatPercent(proactiveSummary.overreach_rate)})`);
+    if (proactiveSummary.policy_adjustment_recommendation) {
+      lines.push(`  Policy:        ${proactiveSummary.policy_adjustment_recommendation.suggested_action} for ${proactiveSummary.policy_adjustment_recommendation.relationship_profile_key}`);
     }
   }
 

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -20,6 +20,12 @@ import {
   type RuntimePostmortemReport,
 } from "../../../runtime/store/postmortem-report.js";
 import {
+  ProactiveInterventionOutcomeSchema,
+  ProactiveInterventionStore,
+  ProactiveOverreachIndicatorSchema,
+  type ProactiveInterventionSummary,
+} from "../../../runtime/store/proactive-intervention-store.js";
+import {
   createRuntimeDreamSidecarReview,
   RuntimeDreamSidecarReviewError,
   type RuntimeDreamSidecarReview,
@@ -32,6 +38,7 @@ import type {
 } from "../../../runtime/session-registry/types.js";
 import { getCliLogger } from "../cli-logger.js";
 import { formatOperationError } from "../utils.js";
+import { resolveConfiguredDaemonRuntimeRoot } from "../../../runtime/daemon/runtime-root.js";
 
 const ID_WIDTH = 34;
 const KIND_WIDTH = 12;
@@ -50,6 +57,15 @@ type RuntimeDreamReviewValues = {
   id?: string;
   json?: boolean;
   requestGuidanceInjection?: boolean;
+};
+
+type RuntimeProactiveFeedbackValues = {
+  interventionId?: string;
+  outcome?: string;
+  reason?: string;
+  overreachIndicator?: string[];
+  followThroughSuccess?: boolean;
+  json?: boolean;
 };
 
 function formatCell(value: string | null | undefined, maxLen: number): string {
@@ -275,6 +291,25 @@ function printBudgetDetail(store: RuntimeBudgetStore, budget: RuntimeBudgetRecor
   }
 }
 
+function printProactiveSummary(summary: ProactiveInterventionSummary): void {
+  console.log("Proactive intervention quality:");
+  console.log(`  Interventions: ${summary.total_interventions}`);
+  console.log(`  Pending:       ${summary.pending_count}`);
+  console.log(`  Accepted:      ${summary.accepted_count}`);
+  console.log(`  Ignored:       ${summary.ignored_count}`);
+  console.log(`  Dismissed:     ${summary.dismissed_count}`);
+  console.log(`  Corrected:     ${summary.corrected_count}`);
+  console.log(`  Overreach:     ${summary.overreach_count}`);
+  if (summary.average_time_to_response_ms !== null) {
+    console.log(`  Avg response:  ${Math.round(summary.average_time_to_response_ms)}ms`);
+  }
+  if (summary.policy_adjustment_recommendation) {
+    console.log(
+      `  Policy:        ${summary.policy_adjustment_recommendation.suggested_action} for ${summary.policy_adjustment_recommendation.relationship_profile_key}`
+    );
+  }
+}
+
 function printJson(value: unknown): void {
   console.log(JSON.stringify(value, null, 2));
 }
@@ -347,12 +382,49 @@ function parseDreamReviewArgs(args: string[]): RuntimeDreamReviewValues {
   }
 }
 
+function parseProactiveFeedbackArgs(args: string[]): RuntimeProactiveFeedbackValues {
+  try {
+    const { values } = parseArgs({
+      args,
+      options: {
+        intervention: { type: "string" },
+        outcome: { type: "string" },
+        reason: { type: "string" },
+        "overreach-indicator": { type: "string", multiple: true },
+        "follow-through-success": { type: "boolean" },
+        json: { type: "boolean" },
+      },
+      strict: false,
+    }) as {
+      values: {
+        intervention?: string;
+        outcome?: string;
+        reason?: string;
+        "overreach-indicator"?: string[];
+        "follow-through-success"?: boolean;
+        json?: boolean;
+      };
+    };
+    return {
+      interventionId: values.intervention,
+      outcome: values.outcome,
+      reason: values.reason,
+      overreachIndicator: values["overreach-indicator"],
+      followThroughSuccess: values["follow-through-success"],
+      json: values.json,
+    };
+  } catch (err) {
+    getCliLogger().error(formatOperationError("parse runtime proactive-feedback arguments", err));
+    return {};
+  }
+}
+
 export async function cmdRuntime(stateManager: StateManager, args: string[]): Promise<number> {
   const logger = getCliLogger();
   const runtimeSubcommand = args[0];
 
   if (!runtimeSubcommand) {
-    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime postmortem <goal-id|run-id>, runtime dream-review <run-id>");
+    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime postmortem <goal-id|run-id>, runtime dream-review <run-id>, runtime proactive-quality, runtime proactive-feedback");
     return 1;
   }
 
@@ -536,8 +608,57 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
     }
   }
 
+  if (runtimeSubcommand === "proactive-quality") {
+    const values = parseListArgs(args.slice(1), "proactive-quality");
+    const store = new ProactiveInterventionStore(resolveConfiguredDaemonRuntimeRoot(stateManager.getBaseDir()));
+    const summary = await store.summarize();
+    values.json ? printJson(summary) : printProactiveSummary(summary);
+    return 0;
+  }
+
+  if (runtimeSubcommand === "proactive-feedback") {
+    const values = parseProactiveFeedbackArgs(args.slice(1));
+    if (!values.interventionId || !values.outcome) {
+      logger.error("Error: --intervention <id> and --outcome <accepted|ignored|dismissed|corrected|overreach> are required.");
+      return 1;
+    }
+    const outcome = ProactiveInterventionOutcomeSchema.safeParse(values.outcome);
+    if (!outcome.success) {
+      logger.error(`Error: invalid proactive feedback outcome: ${values.outcome}`);
+      return 1;
+    }
+    const indicators = values.overreachIndicator ?? [];
+    const parsedIndicators = indicators.map((indicator) => ProactiveOverreachIndicatorSchema.safeParse(indicator));
+    const invalidIndicator = parsedIndicators.find((indicator) => !indicator.success);
+    if (invalidIndicator) {
+      logger.error(`Error: invalid overreach indicator. Valid: too_frequent, wrong_context, sensitive, unwanted_timing`);
+      return 1;
+    }
+    const overreachIndicators = parsedIndicators.flatMap((indicator) => indicator.success ? [indicator.data] : []);
+    const store = new ProactiveInterventionStore(resolveConfiguredDaemonRuntimeRoot(stateManager.getBaseDir()));
+    const event = await store.appendFeedback({
+      interventionId: values.interventionId,
+      outcome: outcome.data,
+      reason: values.reason,
+      overreachIndicators,
+      followThroughSuccess: values.followThroughSuccess,
+      channel: "cli",
+    });
+    const summary = await store.summarize();
+    if (values.json) {
+      printJson({ event, summary });
+    } else {
+      console.log(`Recorded proactive feedback: ${event.outcome} for ${event.intervention_id}`);
+      if (event.policy_adjustment_recommendation) {
+        console.log(`Policy recommendation: ${event.policy_adjustment_recommendation.suggested_action} for ${event.policy_adjustment_recommendation.relationship_profile_key}`);
+      }
+      printProactiveSummary(summary);
+    }
+    return 0;
+  }
+
   logger.error(`Unknown runtime subcommand: "${runtimeSubcommand}"`);
-  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime postmortem <goal-id|run-id>, runtime dream-review <run-id>");
+  logger.error("Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime postmortem <goal-id|run-id>, runtime dream-review <run-id>, runtime proactive-quality, runtime proactive-feedback");
   return 1;
 }
 

--- a/src/runtime/__tests__/daemon-maintenance.test.ts
+++ b/src/runtime/__tests__/daemon-maintenance.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { makeTempDir, cleanupTempDir } from "../../../tests/helpers/temp-dir.js";
-import { ApprovalStore, OutboxStore, RuntimeHealthStore, createRuntimeStorePaths } from "../store/index.js";
+import { ApprovalStore, OutboxStore, RuntimeHealthStore, ProactiveInterventionStore, createRuntimeStorePaths } from "../store/index.js";
 import { ApprovalRecordSchema, OutboxRecordSchema } from "../store/runtime-schemas.js";
 import { runRuntimeStoreMaintenanceCycle } from "../daemon/maintenance.js";
 
@@ -143,6 +143,39 @@ describe("runRuntimeStoreMaintenanceCycle", () => {
     expect(report.health.repaired).toBe(true);
     expect(await healthStore.loadSnapshot()).not.toBeNull();
     expect(await healthStore.loadComponentsHealth()).not.toBeNull();
+  });
+
+  it("includes proactive intervention quality in runtime health details", async () => {
+    const interventionStore = new ProactiveInterventionStore(paths);
+    await interventionStore.appendIntervention({
+      activity: {
+        intervention_id: "health-proactive-1",
+        kind: "suggestion",
+        trigger: "proactive_tick",
+        summary: "Suggested a goal.",
+        recorded_at: "2026-05-02T00:00:00.000Z",
+      },
+    });
+    await interventionStore.appendFeedback({
+      interventionId: "health-proactive-1",
+      outcome: "corrected",
+      recordedAt: "2026-05-02T00:01:00.000Z",
+    });
+
+    await runRuntimeStoreMaintenanceCycle({
+      runtimeRoot,
+      approvalStore,
+      outboxStore,
+      runtimeHealthStore: healthStore,
+      logger: logger(),
+      now: 10_000,
+    });
+
+    const snapshot = await healthStore.loadSnapshot();
+    expect(snapshot?.details?.proactive_interventions).toMatchObject({
+      total_interventions: 1,
+      corrected_count: 1,
+    });
   });
 
   it("prunes stale claim artifacts from the runtime claims directory", async () => {

--- a/src/runtime/daemon/__tests__/resident-activity-ledger.test.ts
+++ b/src/runtime/daemon/__tests__/resident-activity-ledger.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { DaemonConfigSchema, DaemonStateSchema } from "../../types/daemon.js";
+import { ProactiveInterventionStore } from "../../store/proactive-intervention-store.js";
+import { persistResidentActivity } from "../runner-resident-shared.js";
+
+describe("persistResidentActivity proactive intervention ledger", () => {
+  let baseDir: string;
+
+  afterEach(() => {
+    cleanupTempDir(baseDir);
+  });
+
+  it("keeps latest daemon state and appends resident activity history", async () => {
+    baseDir = makeTempDir("pulseed-resident-activity-");
+    const state = DaemonStateSchema.parse({
+      pid: 123,
+      started_at: "2026-05-02T00:00:00.000Z",
+      last_loop_at: null,
+      loop_count: 0,
+      active_goals: [],
+      status: "idle" as const,
+      crash_count: 0,
+      last_error: null,
+    });
+
+    await persistResidentActivity({
+      baseDir,
+      config: DaemonConfigSchema.parse({ runtime_root: "runtime" }),
+      state,
+      saveDaemonState: vi.fn().mockResolvedValue(undefined),
+      logger: { warn: vi.fn() } as never,
+    }, {
+      intervention_id: "resident-intervention-1",
+      kind: "suggestion",
+      trigger: "proactive_tick",
+      summary: "Resident suggested a follow-up.",
+      recorded_at: "2026-05-02T00:01:00.000Z",
+    });
+
+    expect(state.resident_activity?.intervention_id).toBe("resident-intervention-1");
+    const events = await new ProactiveInterventionStore(`${baseDir}/runtime`).list();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event_type: "intervention",
+      intervention_id: "resident-intervention-1",
+    });
+  });
+});

--- a/src/runtime/daemon/maintenance.ts
+++ b/src/runtime/daemon/maintenance.ts
@@ -10,7 +10,7 @@ import { createEnvelope } from "../types/envelope.js";
 import type { Envelope } from "../types/envelope.js";
 import type { ScheduleEngine } from "../schedule/engine.js";
 import type { Logger } from "../logger.js";
-import { ApprovalStore, OutboxStore, RuntimeHealthStore, createRuntimeStorePaths } from "../store/index.js";
+import { ApprovalStore, OutboxStore, RuntimeHealthStore, ProactiveInterventionStore, createRuntimeStorePaths } from "../store/index.js";
 
 export interface RuntimeMaintenanceLogger {
   debug(message: string, context?: Record<string, unknown>): void;
@@ -263,6 +263,21 @@ export async function runRuntimeStoreMaintenanceCycle(params: {
     now,
   });
   const health = await runtimeHealthStore.reconcile(now);
+  const proactiveInterventions = await new ProactiveInterventionStore(runtimePaths).summarize();
+  health.details = {
+    ...health.details,
+    proactive_interventions: proactiveInterventions,
+  };
+  try {
+    await runtimeHealthStore.saveSnapshot(health);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+    params.logger.warn("Skipped proactive intervention health detail update because runtime health storage disappeared", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
   const claims = await pruneStaleFiles(
     runtimePaths.claimsDir,
     options.claimRetentionMs ?? 7 * 24 * 60 * 60 * 1000,

--- a/src/runtime/daemon/runner-resident-shared.ts
+++ b/src/runtime/daemon/runner-resident-shared.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import type { Goal } from "../../base/types/goal.js";
 import type { DaemonConfig, DaemonState, ResidentActivity } from "../../base/types/daemon.js";
 import { ResidentActivitySchema } from "../../base/types/daemon.js";
@@ -13,6 +14,8 @@ import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manage
 import type { Logger } from "../logger.js";
 import type { LoopSupervisor } from "../executor/index.js";
 import type { ScheduleEngine } from "../schedule/engine.js";
+import { ProactiveInterventionStore } from "../store/proactive-intervention-store.js";
+import { resolveDaemonRuntimeRoot } from "./runtime-root.js";
 
 export function resolveResidentWorkspaceDir(configuredPath?: string): string {
   const trimmed = configuredPath?.trim();
@@ -130,14 +133,28 @@ export async function loadKnownGoals(
 }
 
 export async function persistResidentActivity(
-  context: Pick<DaemonRunnerResidentContext, "state" | "saveDaemonState">,
+  context: Pick<DaemonRunnerResidentContext, "state" | "saveDaemonState"> &
+    Partial<Pick<DaemonRunnerResidentContext, "baseDir" | "config" | "logger">>,
   activity: Omit<ResidentActivity, "recorded_at"> & { recorded_at?: string },
 ): Promise<void> {
+  const interventionId = activity.intervention_id ?? `resident-${randomUUID()}`;
   const residentActivity = ResidentActivitySchema.parse({
     ...activity,
+    intervention_id: interventionId,
     recorded_at: activity.recorded_at ?? new Date().toISOString(),
   });
   context.state.last_resident_at = residentActivity.recorded_at;
   context.state.resident_activity = residentActivity;
+  if (context.baseDir && context.config) {
+    const runtimeRoot = resolveDaemonRuntimeRoot(context.baseDir, context.config.runtime_root);
+    await new ProactiveInterventionStore(runtimeRoot)
+      .appendIntervention({ activity: residentActivity, channel: "daemon" })
+      .catch((err: unknown) => {
+        context.logger?.warn("Failed to append proactive intervention event", {
+          error: err instanceof Error ? err.message : String(err),
+          intervention_id: interventionId,
+        });
+      });
+  }
   await context.saveDaemonState();
 }

--- a/src/runtime/daemon/runtime-ownership.ts
+++ b/src/runtime/daemon/runtime-ownership.ts
@@ -2,6 +2,7 @@ import * as path from "node:path";
 import * as fsp from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import type { Logger } from "../logger.js";
+import { ProactiveInterventionStore } from "../store/index.js";
 import type { ApprovalStore, OutboxStore, RuntimeHealthStore } from "../store/index.js";
 import type { LeaderLockManager } from "../leader-lock-manager.js";
 import { summarizeTaskOutcomeLedgers } from "../../orchestrator/execution/task/task-outcome-ledger.js";
@@ -124,6 +125,7 @@ export class RuntimeOwnershipCoordinator {
       details.task_success_rate = taskOutcome.success_rate;
       details.task_outcome = taskOutcome;
     }
+    details.proactive_interventions = await new ProactiveInterventionStore(this.deps.runtimeRoot ?? undefined).summarize();
     return details;
   }
 

--- a/src/runtime/store/__tests__/proactive-intervention-store.test.ts
+++ b/src/runtime/store/__tests__/proactive-intervention-store.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { ProactiveInterventionStore } from "../proactive-intervention-store.js";
+
+describe("ProactiveInterventionStore", () => {
+  let runtimeRoot: string;
+  let store: ProactiveInterventionStore;
+
+  beforeEach(() => {
+    runtimeRoot = makeTempDir("pulseed-proactive-interventions-");
+    store = new ProactiveInterventionStore(runtimeRoot);
+  });
+
+  afterEach(() => {
+    cleanupTempDir(runtimeRoot);
+  });
+
+  it("summarizes accepted, ignored, corrected, and overreach feedback", async () => {
+    await store.appendIntervention({
+      activity: {
+        intervention_id: "intervention-accepted",
+        kind: "suggestion",
+        trigger: "proactive_tick",
+        summary: "Suggested a goal.",
+        recorded_at: "2026-05-02T00:00:00.000Z",
+      },
+    });
+    await store.appendIntervention({
+      activity: {
+        intervention_id: "intervention-ignored",
+        kind: "sleep",
+        trigger: "proactive_tick",
+        summary: "Stayed idle.",
+        recorded_at: "2026-05-02T00:01:00.000Z",
+      },
+    });
+    await store.appendIntervention({
+      activity: {
+        intervention_id: "intervention-corrected",
+        kind: "observation",
+        trigger: "proactive_tick",
+        summary: "Queued a check.",
+        recorded_at: "2026-05-02T00:02:00.000Z",
+      },
+    });
+    await store.appendIntervention({
+      activity: {
+        intervention_id: "intervention-overreach",
+        kind: "suggestion",
+        trigger: "proactive_tick",
+        summary: "Suggested at the wrong time.",
+        recorded_at: "2026-05-02T00:03:00.000Z",
+      },
+    });
+
+    await store.appendFeedback({
+      interventionId: "intervention-accepted",
+      outcome: "accepted",
+      recordedAt: "2026-05-02T00:05:00.000Z",
+      followThroughSuccess: true,
+    });
+    await store.appendFeedback({
+      interventionId: "intervention-ignored",
+      outcome: "ignored",
+      recordedAt: "2026-05-02T00:06:00.000Z",
+    });
+    await store.appendFeedback({
+      interventionId: "intervention-corrected",
+      outcome: "corrected",
+      recordedAt: "2026-05-02T00:07:00.000Z",
+      reason: "Wrong goal context.",
+    });
+    await store.appendFeedback({
+      interventionId: "intervention-overreach",
+      outcome: "overreach",
+      overreachIndicators: ["too_frequent"],
+      recordedAt: "2026-05-02T00:08:00.000Z",
+    });
+
+    const summary = await store.summarize();
+    expect(summary.total_interventions).toBe(4);
+    expect(summary.accepted_count).toBe(1);
+    expect(summary.ignored_count).toBe(1);
+    expect(summary.corrected_count).toBe(1);
+    expect(summary.overreach_count).toBe(1);
+    expect(summary.pending_count).toBe(0);
+    expect(summary.by_kind.suggestion).toBe(2);
+    expect(summary.policy_adjustment_recommendation).toMatchObject({
+      relationship_profile_key: "user.intervention.proactivity",
+      suggested_action: "reduce_frequency",
+    });
+  });
+});

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -306,6 +306,18 @@ export { ApprovalStore } from "./approval-store.js";
 export type { ApprovalResolutionInput } from "./approval-store.js";
 export { OutboxStore } from "./outbox-store.js";
 export { RuntimeHealthStore } from "./health-store.js";
+export {
+  ProactiveInterventionStore,
+  ProactiveInterventionOutcomeSchema,
+  ProactiveOverreachIndicatorSchema,
+  summarizeProactiveInterventions,
+} from "./proactive-intervention-store.js";
+export type {
+  ProactiveInterventionEvent,
+  ProactiveInterventionOutcome,
+  ProactiveInterventionSummary,
+  ProactiveOverreachIndicator,
+} from "./proactive-intervention-store.js";
 export { RuntimeSafePauseStore } from "./safe-pause-store.js";
 export { RuntimeOperationStore } from "./runtime-operation-store.js";
 export {

--- a/src/runtime/store/proactive-intervention-store.ts
+++ b/src/runtime/store/proactive-intervention-store.ts
@@ -1,0 +1,292 @@
+import * as fsp from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { ResidentActivitySchema } from "../../base/types/daemon.js";
+import {
+  createRuntimeStorePaths,
+  type RuntimeStorePaths,
+} from "./runtime-paths.js";
+
+export const ProactiveInterventionOutcomeSchema = z.enum([
+  "accepted",
+  "ignored",
+  "dismissed",
+  "corrected",
+  "overreach",
+]);
+
+export const ProactiveOverreachIndicatorSchema = z.enum([
+  "too_frequent",
+  "wrong_context",
+  "sensitive",
+  "unwanted_timing",
+]);
+
+const ProactiveInterventionBaseEventSchema = z.object({
+  schema_version: z.literal("runtime-proactive-intervention-event-v1"),
+  event_id: z.string().min(1),
+  intervention_id: z.string().min(1),
+  recorded_at: z.string().datetime(),
+  channel: z.enum(["daemon", "cli", "gateway"]).default("daemon"),
+});
+
+export const ProactiveInterventionActivityEventSchema = ProactiveInterventionBaseEventSchema.extend({
+  event_type: z.literal("intervention"),
+  activity: ResidentActivitySchema,
+});
+
+export const ProactiveInterventionFeedbackEventSchema = ProactiveInterventionBaseEventSchema.extend({
+  event_type: z.literal("feedback"),
+  outcome: ProactiveInterventionOutcomeSchema,
+  reason: z.string().optional(),
+  overreach_indicators: z.array(ProactiveOverreachIndicatorSchema).default([]),
+  follow_through_success: z.boolean().nullable().default(null),
+  policy_adjustment_recommendation: z.object({
+    relationship_profile_key: z.string().min(1),
+    suggested_action: z.enum(["reduce_frequency", "require_confirmation", "narrow_scope", "avoid_sensitive_context"]),
+    reason: z.string().min(1),
+  }).nullable().default(null),
+});
+
+export const ProactiveInterventionEventSchema = z.discriminatedUnion("event_type", [
+  ProactiveInterventionActivityEventSchema,
+  ProactiveInterventionFeedbackEventSchema,
+]);
+
+export const ProactiveInterventionSummarySchema = z.object({
+  total_interventions: z.number().int().nonnegative(),
+  pending_count: z.number().int().nonnegative(),
+  response_count: z.number().int().nonnegative(),
+  accepted_count: z.number().int().nonnegative(),
+  ignored_count: z.number().int().nonnegative(),
+  dismissed_count: z.number().int().nonnegative(),
+  corrected_count: z.number().int().nonnegative(),
+  overreach_count: z.number().int().nonnegative(),
+  response_rate: z.number().min(0).max(1).nullable(),
+  accepted_rate: z.number().min(0).max(1).nullable(),
+  ignored_rate: z.number().min(0).max(1).nullable(),
+  correction_rate: z.number().min(0).max(1).nullable(),
+  overreach_rate: z.number().min(0).max(1).nullable(),
+  average_time_to_response_ms: z.number().nonnegative().nullable(),
+  by_kind: z.record(z.number().int().nonnegative()),
+  by_channel: z.record(z.number().int().nonnegative()),
+  latest_feedback_at: z.string().datetime().nullable(),
+  policy_adjustment_recommendation: z.object({
+    relationship_profile_key: z.string().min(1),
+    suggested_action: z.enum(["reduce_frequency", "require_confirmation", "narrow_scope", "avoid_sensitive_context"]),
+    reason: z.string().min(1),
+  }).nullable(),
+});
+
+export type ProactiveInterventionOutcome = z.infer<typeof ProactiveInterventionOutcomeSchema>;
+export type ProactiveOverreachIndicator = z.infer<typeof ProactiveOverreachIndicatorSchema>;
+export type ProactiveInterventionActivityEvent = z.infer<typeof ProactiveInterventionActivityEventSchema>;
+export type ProactiveInterventionFeedbackEvent = z.infer<typeof ProactiveInterventionFeedbackEventSchema>;
+export type ProactiveInterventionEvent = z.infer<typeof ProactiveInterventionEventSchema>;
+export type ProactiveInterventionSummary = z.infer<typeof ProactiveInterventionSummarySchema>;
+
+export interface ProactiveFeedbackInput {
+  interventionId: string;
+  outcome: ProactiveInterventionOutcome;
+  reason?: string;
+  overreachIndicators?: ProactiveOverreachIndicator[];
+  followThroughSuccess?: boolean | null;
+  channel?: "daemon" | "cli" | "gateway";
+  recordedAt?: string;
+}
+
+function eventId(prefix: string): string {
+  return `${prefix}-${randomUUID()}`;
+}
+
+function countRate(count: number, total: number): number | null {
+  return total > 0 ? count / total : null;
+}
+
+function recommendationForFeedback(input: {
+  outcome: ProactiveInterventionOutcome;
+  overreachIndicators: ProactiveOverreachIndicator[];
+  reason?: string;
+}): ProactiveInterventionFeedbackEvent["policy_adjustment_recommendation"] {
+  if (input.outcome === "overreach") {
+    const suggestedAction = input.overreachIndicators.includes("sensitive")
+      ? "avoid_sensitive_context"
+      : input.overreachIndicators.includes("too_frequent")
+        ? "reduce_frequency"
+        : input.overreachIndicators.includes("wrong_context")
+          ? "narrow_scope"
+          : "require_confirmation";
+    return {
+      relationship_profile_key: "user.intervention.proactivity",
+      suggested_action: suggestedAction,
+      reason: input.reason ?? `User marked proactive intervention as overreach (${input.overreachIndicators.join(", ") || "unspecified"}).`,
+    };
+  }
+  if (input.outcome === "corrected") {
+    return {
+      relationship_profile_key: "user.intervention.correction_policy",
+      suggested_action: "require_confirmation",
+      reason: input.reason ?? "User corrected a proactive intervention.",
+    };
+  }
+  return null;
+}
+
+export class ProactiveInterventionStore {
+  private readonly paths: RuntimeStorePaths;
+
+  constructor(runtimeRootOrPaths?: string | RuntimeStorePaths) {
+    this.paths =
+      typeof runtimeRootOrPaths === "string"
+        ? createRuntimeStorePaths(runtimeRootOrPaths)
+        : runtimeRootOrPaths ?? createRuntimeStorePaths();
+  }
+
+  async ensureReady(): Promise<void> {
+    await fsp.mkdir(this.paths.proactiveInterventionsDir, { recursive: true });
+  }
+
+  async appendIntervention(input: {
+    activity: z.infer<typeof ResidentActivitySchema>;
+    channel?: "daemon" | "cli" | "gateway";
+  }): Promise<ProactiveInterventionActivityEvent> {
+    const activity = ResidentActivitySchema.parse(input.activity);
+    const interventionId = activity.intervention_id ?? eventId("proactive-intervention");
+    const event = ProactiveInterventionActivityEventSchema.parse({
+      schema_version: "runtime-proactive-intervention-event-v1",
+      event_id: eventId("proactive-event"),
+      intervention_id: interventionId,
+      recorded_at: activity.recorded_at,
+      channel: input.channel ?? "daemon",
+      event_type: "intervention",
+      activity: {
+        ...activity,
+        intervention_id: interventionId,
+      },
+    });
+    return this.append(event);
+  }
+
+  async appendFeedback(input: ProactiveFeedbackInput): Promise<ProactiveInterventionFeedbackEvent> {
+    const overreachIndicators = input.overreachIndicators ?? [];
+    const event = ProactiveInterventionFeedbackEventSchema.parse({
+      schema_version: "runtime-proactive-intervention-event-v1",
+      event_id: eventId("proactive-event"),
+      intervention_id: input.interventionId,
+      recorded_at: input.recordedAt ?? new Date().toISOString(),
+      channel: input.channel ?? "cli",
+      event_type: "feedback",
+      outcome: input.outcome,
+      reason: input.reason,
+      overreach_indicators: overreachIndicators,
+      follow_through_success: input.followThroughSuccess ?? null,
+      policy_adjustment_recommendation: recommendationForFeedback({
+        outcome: input.outcome,
+        overreachIndicators,
+        reason: input.reason,
+      }),
+    });
+    return this.append(event);
+  }
+
+  async append<T extends ProactiveInterventionEvent>(event: T): Promise<T> {
+    const parsed = ProactiveInterventionEventSchema.parse(event) as T;
+    await this.ensureReady();
+    await fsp.appendFile(this.paths.proactiveInterventionLedgerPath, `${JSON.stringify(parsed)}\n`, "utf8");
+    return parsed;
+  }
+
+  async list(limit?: number): Promise<ProactiveInterventionEvent[]> {
+    const raw = await fsp.readFile(this.paths.proactiveInterventionLedgerPath, "utf8").catch(() => "");
+    if (!raw.trim()) return [];
+    const events: ProactiveInterventionEvent[] = [];
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      try {
+        events.push(ProactiveInterventionEventSchema.parse(JSON.parse(line)));
+      } catch {
+        // Malformed history should not block operational health surfaces.
+      }
+    }
+    const effectiveLimit = limit ?? events.length;
+    return events.slice(Math.max(0, events.length - effectiveLimit));
+  }
+
+  async summarize(): Promise<ProactiveInterventionSummary> {
+    return summarizeProactiveInterventions(await this.list());
+  }
+}
+
+export function summarizeProactiveInterventions(events: ProactiveInterventionEvent[]): ProactiveInterventionSummary {
+  const interventions = events.filter((event): event is ProactiveInterventionActivityEvent => event.event_type === "intervention");
+  const feedbacks = events.filter((event): event is ProactiveInterventionFeedbackEvent => event.event_type === "feedback");
+  const byKind: Record<string, number> = {};
+  const byChannel: Record<string, number> = {};
+  const interventionsById = new Map(interventions.map((event) => [event.intervention_id, event]));
+  const feedbackByIntervention = new Map<string, ProactiveInterventionFeedbackEvent>();
+  let accepted = 0;
+  let ignored = 0;
+  let dismissed = 0;
+  let corrected = 0;
+  let overreach = 0;
+  let latestFeedbackAt: string | null = null;
+  let responseTimeTotal = 0;
+  let responseTimeCount = 0;
+  let latestRecommendation: ProactiveInterventionFeedbackEvent["policy_adjustment_recommendation"] = null;
+
+  for (const intervention of interventions) {
+    byKind[intervention.activity.kind] = (byKind[intervention.activity.kind] ?? 0) + 1;
+    byChannel[intervention.channel] = (byChannel[intervention.channel] ?? 0) + 1;
+  }
+
+  for (const feedback of feedbacks) {
+    const existing = feedbackByIntervention.get(feedback.intervention_id);
+    if (!existing || feedback.recorded_at >= existing.recorded_at) {
+      feedbackByIntervention.set(feedback.intervention_id, feedback);
+    }
+    if (latestFeedbackAt === null || feedback.recorded_at > latestFeedbackAt) {
+      latestFeedbackAt = feedback.recorded_at;
+    }
+    if (feedback.policy_adjustment_recommendation) {
+      latestRecommendation = feedback.policy_adjustment_recommendation;
+    }
+  }
+
+  for (const [interventionId, feedback] of feedbackByIntervention) {
+    const intervention = interventionsById.get(interventionId);
+    if (!intervention) continue;
+    if (feedback.outcome === "accepted") accepted += 1;
+    if (feedback.outcome === "ignored") ignored += 1;
+    if (feedback.outcome === "dismissed") dismissed += 1;
+    if (feedback.outcome === "corrected") corrected += 1;
+    if (feedback.outcome === "overreach") overreach += 1;
+    const delta = new Date(feedback.recorded_at).getTime() - new Date(intervention.recorded_at).getTime();
+    if (Number.isFinite(delta) && delta >= 0) {
+      responseTimeTotal += delta;
+      responseTimeCount += 1;
+    }
+  }
+
+  const total = interventions.length;
+  const responseCount = [...feedbackByIntervention.keys()].filter((interventionId) => interventionsById.has(interventionId)).length;
+  return ProactiveInterventionSummarySchema.parse({
+    total_interventions: total,
+    pending_count: Math.max(0, total - responseCount),
+    response_count: responseCount,
+    accepted_count: accepted,
+    ignored_count: ignored,
+    dismissed_count: dismissed,
+    corrected_count: corrected,
+    overreach_count: overreach,
+    response_rate: countRate(responseCount, total),
+    accepted_rate: countRate(accepted, total),
+    ignored_rate: countRate(ignored, total),
+    correction_rate: countRate(corrected, total),
+    overreach_rate: countRate(overreach, total),
+    average_time_to_response_ms: responseTimeCount > 0 ? responseTimeTotal / responseTimeCount : null,
+    by_kind: byKind,
+    by_channel: byChannel,
+    latest_feedback_at: latestFeedbackAt,
+    policy_adjustment_recommendation: latestRecommendation,
+  });
+}

--- a/src/runtime/store/runtime-paths.ts
+++ b/src/runtime/store/runtime-paths.ts
@@ -28,12 +28,14 @@ export interface RuntimeStorePaths {
   healthDir: string;
   guardrailsDir: string;
   guardrailBreakersDir: string;
+  proactiveInterventionsDir: string;
   reproducibilityManifestsDir: string;
   experimentQueuesDir: string;
   budgetsDir: string;
   operatorHandoffsDir: string;
   postmortemsDir: string;
   backpressureSnapshotPath: string;
+  proactiveInterventionLedgerPath: string;
   daemonHealthPath: string;
   componentsHealthPath: string;
   inboxBucketDir(dateKey: string): string;
@@ -110,6 +112,7 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
   const healthDir = path.join(rootDir, "health");
   const guardrailsDir = path.join(rootDir, "guardrails");
   const guardrailBreakersDir = path.join(guardrailsDir, "breakers");
+  const proactiveInterventionsDir = path.join(rootDir, "proactive-interventions");
   const reproducibilityManifestsDir = path.join(rootDir, "reproducibility-manifests");
   const experimentQueuesDir = path.join(rootDir, "experiment-queues");
   const budgetsDir = path.join(rootDir, "budgets");
@@ -141,12 +144,14 @@ export function createRuntimeStorePaths(runtimeRoot?: string): RuntimeStorePaths
     healthDir,
     guardrailsDir,
     guardrailBreakersDir,
+    proactiveInterventionsDir,
     reproducibilityManifestsDir,
     experimentQueuesDir,
     budgetsDir,
     operatorHandoffsDir,
     postmortemsDir,
     backpressureSnapshotPath: path.join(guardrailsDir, "backpressure.json"),
+    proactiveInterventionLedgerPath: path.join(proactiveInterventionsDir, "events.jsonl"),
     daemonHealthPath: path.join(healthDir, "daemon.json"),
     componentsHealthPath: path.join(healthDir, "components.json"),
     inboxBucketDir(dateKey: string) {
@@ -244,6 +249,7 @@ export async function ensureRuntimeStorePaths(paths: RuntimeStorePaths): Promise
       paths.healthDir,
       paths.guardrailsDir,
       paths.guardrailBreakersDir,
+      paths.proactiveInterventionsDir,
       paths.reproducibilityManifestsDir,
       paths.experimentQueuesDir,
       paths.budgetsDir,

--- a/src/runtime/types/daemon.ts
+++ b/src/runtime/types/daemon.ts
@@ -76,6 +76,7 @@ export const DaemonConfigSchema = z.preprocess(applyLegacyDaemonRunPolicy, Daemo
 export type DaemonConfig = z.infer<typeof DaemonConfigSchema>;
 
 export const ResidentActivitySchema = z.object({
+  intervention_id: z.string().optional(),
   kind: z.enum(["sleep", "suggestion", "negotiation", "curiosity", "dream", "observation", "skipped", "error"]),
   trigger: z.enum(["proactive_tick", "schedule", "external"]).default("proactive_tick"),
   summary: z.string(),


### PR DESCRIPTION
Closes #898

## Summary
- add a typed append-only proactive intervention JSONL ledger with intervention and feedback events
- record resident proactive activities into history while preserving latest daemon-state activity
- expose proactive quality summaries through runtime health, daemon status, `runtime proactive-quality`, and typed `runtime proactive-feedback` outcomes

## Verification
- `npm run typecheck`
- `npx vitest run src/runtime/store/__tests__/proactive-intervention-store.test.ts src/runtime/daemon/__tests__/resident-activity-ledger.test.ts src/runtime/__tests__/daemon-maintenance.test.ts src/interface/cli/__tests__/cli-daemon-status.test.ts src/interface/cli/__tests__/cli-runner.test.ts`
- `npm run lint:boundaries`
- `npm run test:changed`
- `git diff --check`

## Known risks
- Feedback for an unknown intervention can still be recorded by id, but orphan feedback is excluded from summary rates so quality metrics cannot exceed known intervention counts.