### PR TITLE
Fix plugin CLI docs and npm plugin discovery

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -249,6 +249,11 @@ Common scriptable commands:
 | `pulseed schedule history <id>` | Show recent schedule execution history |
 | `pulseed skills list` | List discovered skills |
 | `pulseed skills install <path>` | Install a local skill file |
+| `pulseed plugin list` | List installed plugins |
+| `pulseed plugin install <path|package>` | Install a plugin from a local path or npm package |
+| `pulseed plugin update <name>` | Update an installed npm-backed plugin |
+| `pulseed plugin search <keyword>` | Search `@pulseed-plugins` packages |
+| `pulseed plugin remove <name>` | Remove an installed plugin |
 | `pulseed playbook list` | List stored verified playbooks |
 | `pulseed playbook show <id>` | Show one playbook as JSON |
 | `pulseed playbook promote <id>` | Mark a playbook as promoted |

--- a/docs/design/infrastructure/plugin-architecture.md
+++ b/docs/design/infrastructure/plugin-architecture.md
@@ -744,7 +744,7 @@ CoreLoop (unchanged)
 - `NotifierRegistry` (`src/notifier-registry.ts`)
 - `PluginLoader` (`src/plugin-loader.ts`) — discovery, loading, validation, registration
 - `NotifierRegistry` integration into `NotificationDispatcher`
-- CLI: `pulseed plugin list`, `pulseed plugin install <path>`, `pulseed plugin remove <name>`
+- CLI: `pulseed plugin list`, `pulseed plugin install <path|package>`, `pulseed plugin update <name>`, `pulseed plugin search <keyword>`, `pulseed plugin remove <name>`
 - Phase 1 `plugin_config` field support in goal definitions
 
 **Completion criteria**:
@@ -782,7 +782,7 @@ CoreLoop (unchanged)
 
 | Phase | Details |
 |-------|---------|
-| Plugin marketplace | Search and install community plugins with `pulseed plugin search <keyword>` |
+| Plugin marketplace | Add a curated registry UI or index on top of the existing `pulseed plugin search <keyword>` npm search command |
 | Version management | Enforce `min_pulseed_version` / `max_pulseed_version`, migration support for breaking changes |
 | Worker Thread isolation | Isolate from the same process to improve crash resilience |
 | Plugin signing | Tamper detection via code signing |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,7 @@ Automatically generate Zod schemas from natural-language observation dimension n
 
 ### Plugin Marketplace / Registry
 
-A discoverable registry of community plugins (data sources, notifiers, adapters). The plugin architecture (M12) and npm scope `@pulseed-plugins/` are already established. A registry UI or CLI command (`pulseed plugin search`) would make the ecosystem navigable.
+A richer discoverable registry of community plugins (data sources, notifiers, adapters). The plugin architecture (M12), npm scope `@pulseed-plugins/`, and basic package search command (`pulseed plugin search <keyword>`) are already established. A curated registry UI or index would make the ecosystem easier to navigate than raw npm search.
 
 ### Circuit Breaker
 

--- a/src/interface/cli/__tests__/cli-plugin.test.ts
+++ b/src/interface/cli/__tests__/cli-plugin.test.ts
@@ -270,6 +270,16 @@ describe("cmdPluginRemove", () => {
     expect(exitCode).toBe(1);
   });
 
+  it("accepts the manifest name when removing a sanitized npm plugin directory", async () => {
+    const pluginDir = path.join(pluginsDir, "pulseed-plugins__removable");
+    writePluginManifest(pluginDir, { name: "@pulseed-plugins/removable" });
+
+    const exitCode = await cmdPluginRemove(pluginsDir, ["@pulseed-plugins/removable"]);
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(pluginDir)).toBe(false);
+  });
+
   it("returns 1 when name argument is missing", async () => {
     const exitCode = await cmdPluginRemove(pluginsDir, []);
 
@@ -372,9 +382,15 @@ describe("cmdPluginInstall — npm flow", () => {
     );
 
     expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(pluginsDir, "mock-npm-plugin", "plugin.yaml"))).toBe(true);
     const allOutput = consoleLogs.join("\n");
     expect(allOutput).toMatch(/installed from npm/i);
     expect(allOutput).toContain("mock-npm-plugin");
+
+    consoleLogs = [];
+    const listExitCode = await cmdPluginList(pluginsDir);
+    expect(listExitCode).toBe(0);
+    expect(consoleLogs.join("\n")).toContain("mock-npm-plugin");
   });
 
   it("returns 1 when plugin requires higher PulSeed version", async () => {
@@ -423,32 +439,96 @@ describe("cmdPluginUpdate", () => {
     expect(exitCode).toBe(1);
   });
 
-  it("runs npm update --prefix <dir> and returns 0", async () => {
+  it("reinstalls the npm package, refreshes the runtime copy, and returns 0", async () => {
     const pluginDir = path.join(pluginsDir, "my-npm-plugin");
     fs.mkdirSync(pluginDir, { recursive: true });
+    writePluginManifest(pluginDir, { name: "my-npm-plugin", version: "1.0.0" });
 
     let capturedArgs: string[] = [];
     const mockExecFile = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
       capturedArgs = args;
+      const prefixIndex = args.indexOf("--prefix");
+      if (prefixIndex !== -1) {
+        const prefixDir = args[prefixIndex + 1];
+        const pkgName = args[args.length - 1];
+        const nodeModulesDir = path.join(prefixDir, "node_modules", pkgName);
+        fs.mkdirSync(nodeModulesDir, { recursive: true });
+        writePluginManifest(nodeModulesDir, { name: "my-npm-plugin", version: "1.2.0" });
+      }
       return { stdout: "", stderr: "" };
     });
 
     const exitCode = await cmdPluginUpdate(pluginsDir, ["my-npm-plugin"], mockExecFile as never);
 
     expect(exitCode).toBe(0);
-    expect(mockExecFile).toHaveBeenCalledWith("npm", expect.arrayContaining(["update", "--prefix"]));
+    expect(mockExecFile).toHaveBeenCalledWith("npm", expect.arrayContaining(["install", "--prefix", "my-npm-plugin"]));
     expect(capturedArgs).toContain("--prefix");
     expect(capturedArgs).toContain(pluginDir);
+    expect(fs.readFileSync(path.join(pluginDir, "plugin.yaml"), "utf-8")).toContain("1.2.0");
     const allOutput = consoleLogs.join("\n");
     expect(allOutput).toContain("my-npm-plugin");
     expect(allOutput).toMatch(/updated/i);
   });
 
-  it("returns 1 when npm update fails", async () => {
-    const pluginDir = path.join(pluginsDir, "broken-plugin");
-    fs.mkdirSync(pluginDir, { recursive: true });
+  it("removes stale runtime-root files when an npm plugin changes manifest format", async () => {
+    const pluginDir = path.join(pluginsDir, "format-switch-plugin");
+    writePluginManifest(pluginDir, { name: "format-switch-plugin", version: "1.0.0" });
 
-    const mockExecFile = vi.fn().mockRejectedValue(new Error("npm update failed"));
+    const mockExecFile = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      const prefixIndex = args.indexOf("--prefix");
+      if (prefixIndex !== -1) {
+        const prefixDir = args[prefixIndex + 1];
+        const pkgName = args[args.length - 1];
+        const nodeModulesDir = path.join(prefixDir, "node_modules", pkgName);
+        fs.mkdirSync(nodeModulesDir, { recursive: true });
+        fs.writeFileSync(path.join(nodeModulesDir, "plugin.json"), JSON.stringify({
+          name: "format-switch-plugin",
+          version: "2.0.0",
+          type: "notifier",
+          capabilities: ["notify"],
+          description: "Updated manifest format",
+          permissions: {},
+        }), "utf-8");
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const exitCode = await cmdPluginUpdate(pluginsDir, ["format-switch-plugin"], mockExecFile as never);
+
+    expect(exitCode).toBe(0);
+    expect(fs.existsSync(path.join(pluginDir, "plugin.yaml"))).toBe(false);
+    expect(fs.readFileSync(path.join(pluginDir, "plugin.json"), "utf-8")).toContain("2.0.0");
+  });
+
+  it("accepts the manifest name when updating a sanitized npm plugin directory", async () => {
+    const pluginDir = path.join(pluginsDir, "pulseed-plugins__scoped");
+    writePluginManifest(pluginDir, { name: "@pulseed-plugins/scoped" });
+
+    let capturedArgs: string[] = [];
+    const mockExecFile = vi.fn().mockImplementation(async (_cmd: string, args: string[]) => {
+      capturedArgs = args;
+      const prefixIndex = args.indexOf("--prefix");
+      if (prefixIndex !== -1) {
+        const prefixDir = args[prefixIndex + 1];
+        const pkgName = args[args.length - 1];
+        const nodeModulesDir = path.join(prefixDir, "node_modules", pkgName);
+        fs.mkdirSync(nodeModulesDir, { recursive: true });
+        writePluginManifest(nodeModulesDir, { name: "@pulseed-plugins/scoped" });
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const exitCode = await cmdPluginUpdate(pluginsDir, ["@pulseed-plugins/scoped"], mockExecFile as never);
+
+    expect(exitCode).toBe(0);
+    expect(capturedArgs).toContain(pluginDir);
+  });
+
+  it("returns 1 when npm install fails during update", async () => {
+    const pluginDir = path.join(pluginsDir, "broken-plugin");
+    writePluginManifest(pluginDir, { name: "broken-plugin" });
+
+    const mockExecFile = vi.fn().mockRejectedValue(new Error("npm install failed"));
 
     const exitCode = await cmdPluginUpdate(pluginsDir, ["broken-plugin"], mockExecFile as never);
 

--- a/src/interface/cli/cli-command-registry.ts
+++ b/src/interface/cli/cli-command-registry.ts
@@ -413,7 +413,7 @@ export async function dispatchCommand(
     const pluginSubcommand = argv[1];
 
     if (!pluginSubcommand) {
-      logger.error("Error: plugin subcommand required. Available: plugin list, plugin install, plugin remove");
+      logger.error("Error: plugin subcommand required. Available: plugin list, plugin install, plugin remove, plugin update, plugin search");
       return 1;
     }
 

--- a/src/interface/cli/commands/plugin.ts
+++ b/src/interface/cli/commands/plugin.ts
@@ -12,6 +12,7 @@ import { getPluginsDir } from "../../../base/utils/paths.js";
 import { parseSemver, compareSemver, satisfiesRange } from "../../../runtime/plugin-loader.js";
 
 const execFile = promisify(cp.execFile);
+const NPM_SOURCE_METADATA = ".pulseed-plugin-source.json";
 
 function defaultPluginsDir(): string {
   return getPluginsDir();
@@ -111,13 +112,89 @@ function isNpmPackage(arg: string): boolean {
 }
 
 /** Read and validate plugin manifest from an npm-installed package directory. */
-async function readNpmManifest(pluginDir: string, packageName: string) {
+function getNpmPackageRoot(pluginDir: string, packageName: string): string {
   // Resolve the package dir inside node_modules
   const pkgName = packageName.startsWith("@")
     ? packageName.split("/").slice(0, 2).join("/")
     : packageName.split("/")[0];
-  const nodeModulesDir = path.join(pluginDir, "node_modules", pkgName);
-  return readManifest(nodeModulesDir);
+  return path.join(pluginDir, "node_modules", pkgName);
+}
+
+/** Read and validate plugin manifest from an npm-installed package directory. */
+async function readNpmManifest(pluginDir: string, packageName: string) {
+  return readManifest(getNpmPackageRoot(pluginDir, packageName));
+}
+
+async function copyPackageRootToPluginDir(packageRoot: string, pluginDir: string): Promise<void> {
+  const existingEntries = await fsp.readdir(pluginDir, { withFileTypes: true });
+  for (const entry of existingEntries) {
+    if (entry.name === "node_modules" || entry.name === NPM_SOURCE_METADATA) continue;
+    await fsp.rm(path.join(pluginDir, entry.name), { recursive: true, force: true });
+  }
+
+  const entries = await fsp.readdir(packageRoot, { withFileTypes: true });
+  for (const entry of entries) {
+    if (entry.name === "node_modules") continue;
+    const source = path.join(packageRoot, entry.name);
+    const destination = path.join(pluginDir, entry.name);
+    await fsp.cp(source, destination, { recursive: true });
+  }
+}
+
+async function writeNpmSourceMetadata(pluginDir: string, packageName: string): Promise<void> {
+  await fsp.writeFile(
+    path.join(pluginDir, NPM_SOURCE_METADATA),
+    `${JSON.stringify({ type: "npm", packageName }, null, 2)}\n`,
+    "utf-8",
+  );
+}
+
+async function readNpmSourceMetadata(pluginDir: string): Promise<{ packageName: string } | null> {
+  try {
+    const raw = await fsp.readFile(path.join(pluginDir, NPM_SOURCE_METADATA), "utf-8");
+    const parsed = JSON.parse(raw) as { type?: unknown; packageName?: unknown };
+    if (parsed.type === "npm" && typeof parsed.packageName === "string" && parsed.packageName.length > 0) {
+      return { packageName: parsed.packageName };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function findPluginDirByName(pluginsDir: string, name: string): Promise<string | null> {
+  const direct = path.join(pluginsDir, name);
+  if (await pathExists(direct)) return direct;
+
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(pluginsDir);
+  } catch {
+    return null;
+  }
+
+  for (const entry of entries) {
+    const candidate = path.join(pluginsDir, entry);
+    let stat: Awaited<ReturnType<typeof fsp.stat>>;
+    try {
+      stat = await fsp.stat(candidate);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+
+    let manifest: Awaited<ReturnType<typeof readManifest>>;
+    try {
+      manifest = await readManifest(candidate);
+    } catch {
+      continue;
+    }
+    if (manifest?.success && manifest.data.name === name) {
+      return candidate;
+    }
+  }
+
+  return null;
 }
 
 /** Check PulSeed version compatibility, log a warning if incompatible, return false to abort. */
@@ -173,6 +250,9 @@ export async function cmdPluginInstall(
     }
 
     try {
+      if (force) {
+        await fsp.rm(pluginDir, { recursive: true, force: true });
+      }
       await fsp.mkdir(pluginDir, { recursive: true });
     } catch (err) {
       logger.error(formatOperationError("create plugin directory", err));
@@ -203,6 +283,20 @@ export async function cmdPluginInstall(
 
     if (manifest.permissions.shell) {
       logger.warn(`Plugin "${manifest.name}" requests shell execution permission.`);
+    }
+
+    try {
+      await copyPackageRootToPluginDir(getNpmPackageRoot(pluginDir, packageName), pluginDir);
+      await writeNpmSourceMetadata(pluginDir, packageName);
+    } catch (err) {
+      logger.error(formatOperationError("prepare npm plugin for runtime discovery", err));
+      return 1;
+    }
+
+    const verify = await readManifest(pluginDir);
+    if (!verify || !verify.success) {
+      logger.error(`Error: plugin install failed — manifest unreadable after preparing npm package.`);
+      return 1;
     }
 
     console.log(`Plugin "${manifest.name}" v${manifest.version} installed from npm.`);
@@ -275,21 +369,52 @@ export async function cmdPluginUpdate(
     return 1;
   }
 
-  const pluginDir = path.join(dir, name);
-  if (!(await pathExists(pluginDir))) {
+  const pluginDir = await findPluginDirByName(dir, name);
+  if (!pluginDir) {
     logger.error(`Error: plugin "${name}" not found.`);
     return 1;
   }
 
+  const metadata = await readNpmSourceMetadata(pluginDir);
+  const manifest = await readManifest(pluginDir);
+  const packageName = metadata?.packageName ?? (manifest?.success ? manifest.data.name : name);
   const execFn = _execFileFn ?? execFile;
   try {
-    await execFn("npm", ["update", "--prefix", pluginDir]);
+    await execFn("npm", ["install", "--prefix", pluginDir, packageName]);
   } catch (err) {
-    logger.error(formatOperationError("npm update", err));
+    logger.error(formatOperationError("npm install", err));
     return 1;
   }
 
-  console.log(`Plugin "${name}" updated.`);
+  const result = await readNpmManifest(pluginDir, packageName);
+  if (!result) {
+    logger.error(`Error: plugin manifest not found after npm install of "${packageName}".`);
+    return 1;
+  }
+  if (!result.success) {
+    logger.error(`Error: invalid plugin manifest — ${result.error.message}`);
+    return 1;
+  }
+
+  const updatedManifest = result.data;
+  const pulseedVer = getPulseedVersion();
+  if (!checkVersionCompat(updatedManifest, pulseedVer)) return 1;
+
+  try {
+    await copyPackageRootToPluginDir(getNpmPackageRoot(pluginDir, packageName), pluginDir);
+    await writeNpmSourceMetadata(pluginDir, packageName);
+  } catch (err) {
+    logger.error(formatOperationError("prepare npm plugin for runtime discovery", err));
+    return 1;
+  }
+
+  const verify = await readManifest(pluginDir);
+  if (!verify || !verify.success) {
+    logger.error(`Error: plugin update failed — manifest unreadable after preparing npm package.`);
+    return 1;
+  }
+
+  console.log(`Plugin "${updatedManifest.name}" updated.`);
   return 0;
 }
 
@@ -350,9 +475,8 @@ export async function cmdPluginRemove(pluginsDir: string | undefined, argv: stri
     return 1;
   }
 
-  const pluginDir = path.join(dir, name);
-
-  if (!(await pathExists(pluginDir))) {
+  const pluginDir = await findPluginDirByName(dir, name);
+  if (!pluginDir) {
     logger.error(`Error: plugin "${name}" not found.`);
     return 1;
   }

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -84,7 +84,9 @@ Usage:
   pulseed playbook disable <id>        Disable a playbook from retrieval
   pulseed playbook delete <id>         Delete a stored playbook
   pulseed plugin list                  List installed plugins
-  pulseed plugin install <path>        Install a plugin from a local directory
+  pulseed plugin install <path|package> Install a plugin from a local path or npm package
+  pulseed plugin update <name>         Update an installed npm-backed plugin
+  pulseed plugin search <keyword>      Search @pulseed-plugins packages
   pulseed plugin remove <name>         Remove an installed plugin
   pulseed logs                          View daemon logs (last 50 lines)
   pulseed logs --follow                Tail daemon logs in real-time


### PR DESCRIPTION
## Summary\n- Document implemented plugin update/search commands in CLI help and public docs\n- Make npm-installed plugins discoverable by copying the installed package root into the runtime plugin directory\n- Refresh the runtime copy on plugin update and resolve update/remove by manifest name for scoped packages\n\n## Verification\n- npm run check:docs\n- git diff --check\n- NPM_CONFIG_CACHE=/private/tmp/pulseed-npm-cache npm pack --dry-run --ignore-scripts --loglevel=notice\n\n## Not run\n- npm run typecheck (blocked: node_modules absent; tsc not found)\n- targeted Vitest plugin tests (blocked: node_modules absent; vitest not found)\n- npm ci --ignore-scripts --prefer-offline (blocked: npm failed locally with "Exit handler never called!")