### PR TITLE
feat(profile): add lifecycle commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -233,6 +233,8 @@ export {
   loadRelationshipProfileSync,
   saveRelationshipProfile,
   upsertRelationshipProfileItem,
+  retractRelationshipProfileItem,
+  getRelationshipProfileHistory,
   selectActiveRelationshipProfileItems,
   formatRelationshipProfilePromptBlock,
   seedRelationshipProfileFromSetup,

--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -1459,6 +1459,114 @@ describe("profile command", () => {
     expect(output).toContain("Ask before non-urgent notifications.");
     expect(output).not.toContain("Notify freely.");
   });
+
+  it("shows history and retracts profile items through the production CLI entrypoint", async () => {
+    await runCLI(
+      "profile",
+      "update",
+      "--kind",
+      "preference",
+      "--key",
+      "user.preference.status",
+      "--value",
+      "Prefer verbose status reports.",
+      "--scope",
+      "local_planning",
+      "--scope",
+      "resident_behavior",
+      "--evidence-ref",
+      "cli:first"
+    );
+    await runCLI(
+      "profile",
+      "update",
+      "--kind",
+      "preference",
+      "--key",
+      "user.preference.status",
+      "--value",
+      "Prefer concise status reports.",
+      "--scope",
+      "local_planning",
+      "--scope",
+      "resident_behavior",
+      "--source",
+      "user_correction",
+      "--evidence-ref",
+      "cli:correction"
+    );
+
+    const historySpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const historyCode = await runCLI("profile", "history", "user.preference.status", "--json");
+    const historyOutput = historySpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    historySpy.mockRestore();
+
+    expect(historyCode).toBe(0);
+    const history = JSON.parse(historyOutput) as {
+      items: Array<{ version: number; status: string; provenance: { evidence_ref?: string } }>;
+      audit_events: Array<{ action: string }>;
+    };
+    expect(history.items.map((item) => [item.version, item.status])).toEqual([
+      [1, "superseded"],
+      [2, "active"],
+    ]);
+    expect(history.items[1]?.provenance.evidence_ref).toBe("cli:correction");
+    expect(history.audit_events.map((event) => event.action)).toEqual(["seeded", "superseded", "created"]);
+
+    const retractSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const retractCode = await runCLI(
+      "profile",
+      "retract",
+      "--key",
+      "user.preference.status",
+      "--reason",
+      "User said this should no longer be used.",
+      "--json"
+    );
+    const retractOutput = retractSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    retractSpy.mockRestore();
+
+    expect(retractCode).toBe(0);
+    expect(JSON.parse(retractOutput).item.status).toBe("retracted");
+
+    const showSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const showCode = await runCLI("profile", "show", "--scope", "resident_behavior", "--json");
+    const showOutput = showSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    showSpy.mockRestore();
+
+    expect(showCode).toBe(0);
+    const scopedShow = JSON.parse(showOutput) as { items: Array<{ value: string; status: string }> };
+    expect(scopedShow.items).toEqual([]);
+
+    const afterRetractSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const afterRetractCode = await runCLI("profile", "history", "user.preference.status", "--json");
+    const afterRetractOutput = afterRetractSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    afterRetractSpy.mockRestore();
+
+    const afterRetractHistory = JSON.parse(afterRetractOutput) as {
+      items: Array<{ version: number; status: string }>;
+      audit_events: Array<{ action: string; reason?: string }>;
+    };
+    expect(afterRetractCode).toBe(0);
+    expect(afterRetractHistory.items.map((item) => [item.version, item.status])).toEqual([
+      [1, "superseded"],
+      [2, "retracted"],
+    ]);
+    expect(afterRetractHistory.audit_events.at(-1)).toMatchObject({
+      action: "retracted",
+      reason: "User said this should no longer be used.",
+    });
+
+    const allSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const allCode = await runCLI("profile", "show", "--all", "--json");
+    const allOutput = allSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    allSpy.mockRestore();
+
+    const allProfile = JSON.parse(allOutput) as { items: Array<{ value: string; status: string }>; audit_events: unknown[] };
+    expect(allCode).toBe(0);
+    expect(allProfile.items.map((item) => item.status)).toEqual(["superseded", "retracted"]);
+    expect(allProfile.audit_events).toHaveLength(4);
+  });
 });
 
 describe("runtime proactive feedback commands", () => {

--- a/src/interface/cli/commands/profile.ts
+++ b/src/interface/cli/commands/profile.ts
@@ -4,10 +4,12 @@ import { getCliLogger } from "../cli-logger.js";
 import { formatOperationError } from "../utils.js";
 import {
   loadRelationshipProfile,
+  getRelationshipProfileHistory,
   RelationshipProfileConsentScopeSchema,
   RelationshipProfileItemKindSchema,
   RelationshipProfileSensitivitySchema,
   RelationshipProfileSourceSchema,
+  retractRelationshipProfileItem,
   selectActiveRelationshipProfileItems,
   upsertRelationshipProfileItem,
   type RelationshipProfileConsentScope,
@@ -20,6 +22,8 @@ function usage(): string {
   return `Usage:
   pulseed profile show [--scope <scope>] [--all] [--json]
   pulseed profile update --kind <kind> --key <stable_key> --value <value> [--scope <scope>] [--sensitivity <public|private|sensitive>] [--confidence <0-1>] [--source <source>] [--evidence-ref <ref>]
+  pulseed profile history <stable_key> [--json]
+  pulseed profile retract --key <stable_key> --reason <reason> [--source <source>] [--json]
 
 Scopes: local_planning, resident_behavior, memory_retrieval, user_facing_review
 Kinds: identity_fact, preference, dislike, value, boundary, communication_style, notification_preference, long_term_goal, life_context, intervention_policy`;
@@ -76,11 +80,6 @@ export async function cmdProfile(stateManager: StateManager, argv: string[]): Pr
     }
 
     const store = await loadRelationshipProfile(stateManager.getBaseDir());
-    if (values.json) {
-      console.log(JSON.stringify(store, null, 2));
-      return 0;
-    }
-
     let scope: RelationshipProfileConsentScope | null = null;
     if (values.scope !== undefined) {
       const parsed = RelationshipProfileConsentScopeSchema.safeParse(values.scope);
@@ -96,6 +95,17 @@ export async function cmdProfile(stateManager: StateManager, argv: string[]): Pr
         ? selectActiveRelationshipProfileItems(store, scope)
         : store.items.filter((item) => item.status === "active");
 
+    if (values.json) {
+      console.log(JSON.stringify({
+        schema_version: store.schema_version,
+        profile_id: store.profile_id,
+        items,
+        ...(values.all ? { audit_events: store.audit_events } : {}),
+        updated_at: store.updated_at,
+      }, null, 2));
+      return 0;
+    }
+
     if (items.length === 0) {
       console.log("No relationship profile items.");
       return 0;
@@ -109,6 +119,67 @@ export async function cmdProfile(stateManager: StateManager, argv: string[]): Pr
       );
     }
     return 0;
+  }
+
+  if (subcommand === "history") {
+    let values: { json?: boolean };
+    let positionals: string[];
+    try {
+      const parsed = parseArgs({
+        args: argv.slice(1),
+        options: {
+          json: { type: "boolean" },
+        },
+        allowPositionals: true,
+        strict: true,
+      }) as { values: { json?: boolean }; positionals: string[] };
+      values = parsed.values;
+      positionals = parsed.positionals;
+    } catch (err) {
+      getCliLogger().error(formatOperationError("parse profile history arguments", err));
+      return 1;
+    }
+
+    const stableKey = positionals[0]?.trim();
+    if (!stableKey || positionals.length > 1) {
+      getCliLogger().error("Error: profile history requires exactly one <stable_key> argument.");
+      console.log(usage());
+      return 1;
+    }
+
+    try {
+      const store = await loadRelationshipProfile(stateManager.getBaseDir());
+      const history = getRelationshipProfileHistory(store, stableKey);
+      if (values.json) {
+        console.log(JSON.stringify(history, null, 2));
+        return 0;
+      }
+      if (history.items.length === 0 && history.audit_events.length === 0) {
+        console.log(`No relationship profile history for ${stableKey}.`);
+        return 0;
+      }
+      console.log(`Relationship profile history for ${history.stable_key}:`);
+      for (const item of history.items) {
+        const evidence = item.provenance.evidence_ref ? `; evidence=${item.provenance.evidence_ref}` : "";
+        const note = item.provenance.note ? `; note=${item.provenance.note}` : "";
+        console.log(
+          `- item v${item.version} ${item.status}: ${item.value}` +
+            ` (source=${item.provenance.source}; scopes=${item.allowed_scopes.join(",")}; sensitivity=${item.sensitivity}; confidence=${item.confidence.toFixed(2)}${evidence}${note})`
+        );
+      }
+      if (history.audit_events.length > 0) {
+        console.log("Audit events:");
+        for (const event of history.audit_events) {
+          const reason = event.reason ? `; reason=${event.reason}` : "";
+          const previous = event.previous_item_id ? `; previous=${event.previous_item_id}` : "";
+          console.log(`- ${event.at} ${event.action} v${event.version} item=${event.item_id} source=${event.source}${previous}${reason}`);
+        }
+      }
+      return 0;
+    } catch (err) {
+      getCliLogger().error(formatOperationError("show relationship profile history", err));
+      return 1;
+    }
   }
 
   if (subcommand === "update") {
@@ -214,6 +285,59 @@ export async function cmdProfile(stateManager: StateManager, argv: string[]): Pr
       return 0;
     } catch (err) {
       getCliLogger().error(formatOperationError("update relationship profile", err));
+      return 1;
+    }
+  }
+
+  if (subcommand === "retract") {
+    let values: {
+      key?: string;
+      reason?: string;
+      source?: string;
+      json?: boolean;
+    };
+    try {
+      ({ values } = parseArgs({
+        args: argv.slice(1),
+        options: {
+          key: { type: "string" },
+          reason: { type: "string" },
+          source: { type: "string" },
+          json: { type: "boolean" },
+        },
+        strict: true,
+      }) as { values: { key?: string; reason?: string; source?: string; json?: boolean } });
+    } catch (err) {
+      getCliLogger().error(formatOperationError("parse profile retract arguments", err));
+      return 1;
+    }
+
+    const source = parseEnum<RelationshipProfileSource>(
+      values.source ?? "cli_update",
+      "source",
+      (value) => RelationshipProfileSourceSchema.safeParse(value) as never
+    );
+    if (!source) return 1;
+    if (!values.key?.trim() || !values.reason?.trim()) {
+      getCliLogger().error("Error: --key and --reason are required.");
+      console.log(usage());
+      return 1;
+    }
+
+    try {
+      const result = await retractRelationshipProfileItem(stateManager.getBaseDir(), {
+        stableKey: values.key,
+        reason: values.reason,
+        source,
+      });
+      if (values.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Retracted relationship profile item ${result.item.stable_key} v${result.item.version}.`);
+      }
+      return 0;
+    } catch (err) {
+      getCliLogger().error(formatOperationError("retract relationship profile item", err));
       return 1;
     }
   }

--- a/src/platform/profile/__tests__/relationship-profile.test.ts
+++ b/src/platform/profile/__tests__/relationship-profile.test.ts
@@ -4,8 +4,10 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
   formatRelationshipProfilePromptBlock,
+  getRelationshipProfileHistory,
   loadRelationshipProfile,
   relationshipProfilePath,
+  retractRelationshipProfileItem,
   seedRelationshipProfileFromSetup,
   selectActiveRelationshipProfileItems,
   upsertRelationshipProfileItem,
@@ -59,6 +61,79 @@ describe("relationship profile store", () => {
     const block = formatRelationshipProfilePromptBlock(store, "local_planning");
     expect(block).toContain("The user prefers VS Code.");
     expect(block).not.toContain("The user prefers Atom.");
+  });
+
+  it("tracks active to superseded to retracted lifecycle and keeps stale items out of scoped context", async () => {
+    const baseDir = makeTempDir();
+
+    const first = await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.editor",
+      kind: "preference",
+      value: "The user prefers Atom.",
+      source: "cli_update",
+      allowedScopes: ["local_planning", "resident_behavior", "memory_retrieval", "user_facing_review"],
+      evidenceRef: "cli:first",
+      now: "2026-05-02T00:00:00.000Z",
+    });
+    const second = await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.editor",
+      kind: "preference",
+      value: "The user prefers VS Code.",
+      source: "user_correction",
+      allowedScopes: ["local_planning", "resident_behavior", "memory_retrieval", "user_facing_review"],
+      evidenceRef: "cli:second",
+      now: "2026-05-02T01:00:00.000Z",
+    });
+    const retracted = await retractRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.editor",
+      reason: "User said this preference is no longer true.",
+      source: "cli_update",
+      now: "2026-05-02T02:00:00.000Z",
+    });
+
+    const store = await loadRelationshipProfile(baseDir);
+    expect(first.item.version).toBe(1);
+    expect(second.item.version).toBe(2);
+    expect(retracted.item.id).toBe(second.item.id);
+    expect(store.items.find((item) => item.id === first.item.id)?.status).toBe("superseded");
+    expect(store.items.find((item) => item.id === second.item.id)?.status).toBe("retracted");
+
+    for (const scope of ["local_planning", "resident_behavior", "memory_retrieval", "user_facing_review"] as const) {
+      expect(selectActiveRelationshipProfileItems(store, scope)).toHaveLength(0);
+      expect(formatRelationshipProfilePromptBlock(store, scope)).not.toContain("VS Code");
+      expect(formatRelationshipProfilePromptBlock(store, scope)).not.toContain("Atom");
+    }
+
+    const history = getRelationshipProfileHistory(store, "user.preference.editor");
+    expect(history.items.map((item) => [item.version, item.status])).toEqual([
+      [1, "superseded"],
+      [2, "retracted"],
+    ]);
+    expect(history.audit_events.map((event) => event.action)).toEqual(["seeded", "superseded", "created", "retracted"]);
+    expect(history.audit_events.at(-1)?.reason).toBe("User said this preference is no longer true.");
+  });
+
+  it("rejects retracting a stale key without an active item", async () => {
+    const baseDir = makeTempDir();
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.editor",
+      kind: "preference",
+      value: "The user prefers VS Code.",
+      source: "cli_update",
+      allowedScopes: ["local_planning"],
+      now: "2026-05-02T00:00:00.000Z",
+    });
+    await retractRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.editor",
+      reason: "No longer current.",
+      now: "2026-05-02T01:00:00.000Z",
+    });
+
+    await expect(retractRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.editor",
+      reason: "Second retract should fail.",
+      now: "2026-05-02T02:00:00.000Z",
+    })).rejects.toThrow("no active relationship profile item found");
   });
 
   it("keeps sensitive boundary items out of prompts unless explicitly allowed", async () => {

--- a/src/platform/profile/relationship-profile.ts
+++ b/src/platform/profile/relationship-profile.ts
@@ -65,6 +65,7 @@ export const RelationshipProfileAuditEventSchema = z.object({
   version: z.number().int().positive(),
   source: RelationshipProfileSourceSchema,
   previous_item_id: z.string().min(1).optional(),
+  reason: z.string().min(1).optional(),
 });
 
 export const RelationshipProfileStoreSchema = z.object({
@@ -92,6 +93,13 @@ export interface RelationshipProfileItemInput {
   allowedScopes?: RelationshipProfileConsentScope[];
   evidenceRef?: string;
   note?: string;
+  now?: string;
+}
+
+export interface RelationshipProfileRetractionInput {
+  stableKey: string;
+  reason: string;
+  source?: RelationshipProfileSource;
   now?: string;
 }
 
@@ -236,6 +244,93 @@ export async function upsertRelationshipProfileItem(
   const result = upsertRelationshipProfileItemInStore(loaded, input);
   await saveRelationshipProfile(baseDir, result.store);
   return { item: result.item, superseded: result.superseded };
+}
+
+function normalizeRetractionInput(input: RelationshipProfileRetractionInput): Required<RelationshipProfileRetractionInput> {
+  const stableKey = input.stableKey.trim();
+  const reason = input.reason.trim();
+  if (!stableKey) throw new Error("stable key is required");
+  if (!reason) throw new Error("retraction reason is required");
+  return {
+    stableKey,
+    reason,
+    source: input.source ?? "cli_update",
+    now: input.now ?? new Date().toISOString(),
+  };
+}
+
+export function retractRelationshipProfileItemInStore(
+  store: RelationshipProfileStore,
+  input: RelationshipProfileRetractionInput
+): { store: RelationshipProfileStore; item: RelationshipProfileItem } {
+  const normalized = normalizeRetractionInput(input);
+  const active = store.items.filter((item) => item.stable_key === normalized.stableKey && item.status === "active");
+  if (active.length === 0) {
+    throw new Error(`no active relationship profile item found for key: ${normalized.stableKey}`);
+  }
+  if (active.length > 1) {
+    throw new Error(`multiple active relationship profile items found for key: ${normalized.stableKey}`);
+  }
+
+  const target = active[0]!;
+  let retracted: RelationshipProfileItem | null = null;
+  const items = store.items.map((item) => {
+    if (item.id !== target.id) return item;
+    retracted = RelationshipProfileItemSchema.parse({
+      ...item,
+      status: "retracted",
+      updated_at: normalized.now,
+    });
+    return retracted;
+  });
+
+  const event = RelationshipProfileAuditEventSchema.parse({
+    id: `profile-event-${randomUUID()}`,
+    at: normalized.now,
+    action: "retracted",
+    item_id: target.id,
+    stable_key: target.stable_key,
+    version: target.version,
+    source: normalized.source,
+    reason: normalized.reason,
+  });
+
+  return {
+    store: RelationshipProfileStoreSchema.parse({
+      ...store,
+      items,
+      audit_events: [...store.audit_events, event],
+      updated_at: normalized.now,
+    }),
+    item: retracted ?? target,
+  };
+}
+
+export async function retractRelationshipProfileItem(
+  baseDir: string,
+  input: RelationshipProfileRetractionInput
+): Promise<{ item: RelationshipProfileItem }> {
+  const loaded = await loadRelationshipProfile(baseDir);
+  const result = retractRelationshipProfileItemInStore(loaded, input);
+  await saveRelationshipProfile(baseDir, result.store);
+  return { item: result.item };
+}
+
+export function getRelationshipProfileHistory(
+  store: RelationshipProfileStore,
+  stableKey: string
+): { stable_key: string; items: RelationshipProfileItem[]; audit_events: z.infer<typeof RelationshipProfileAuditEventSchema>[] } {
+  const key = stableKey.trim();
+  if (!key) throw new Error("stable key is required");
+  return {
+    stable_key: key,
+    items: store.items
+      .filter((item) => item.stable_key === key)
+      .sort((a, b) => a.version - b.version),
+    audit_events: store.audit_events
+      .filter((event) => event.stable_key === key)
+      .sort((a, b) => a.at.localeCompare(b.at)),
+  };
 }
 
 export function selectActiveRelationshipProfileItems(


### PR DESCRIPTION
Closes #926
Refs #896

## Summary
- add relationship profile history and retraction helpers with audit reason metadata
- add `pulseed profile history <stable_key>` and `pulseed profile retract --key <stable_key> --reason <reason>` with JSON output
- ensure `profile show --json` follows active/scope filtering unless `--all` is explicitly requested
- cover active -> superseded -> retracted lifecycle and production CLI entrypoints

## Verification
- `npm run typecheck`
- `npx vitest run src/platform/profile/__tests__/relationship-profile.test.ts src/interface/cli/__tests__/cli-runner.test.ts`
- `npm run lint:boundaries` (passes with pre-existing warnings)
- `npm run test:changed`
- `git diff --check`

## Known unresolved risks
- `npm run lint:boundaries` still reports the repo-wide pre-existing warning set, but no lint errors.
- Proposal approval/import/proactive feedback flows are intentionally left for #927, #931, and #932.