### PR TITLE
feat(profile): add governed proposal contract

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -246,6 +246,27 @@ export type {
   RelationshipProfileConsentScope,
   RelationshipProfileSensitivity,
 } from "./platform/profile/relationship-profile.js";
+export {
+  RelationshipProfileProposalOperationSchema,
+  RelationshipProfileProposalSourceSchema,
+  RelationshipProfileProposalStateSchema,
+  RelationshipProfileChangeProposalSchema,
+  RelationshipProfileProposalStoreSchema,
+  loadRelationshipProfileProposalStore,
+  loadRelationshipProfileProposalStoreSync,
+  saveRelationshipProfileProposalStore,
+  createRelationshipProfileChangeProposal,
+  approveRelationshipProfileChangeProposal,
+  rejectRelationshipProfileChangeProposal,
+  applyRelationshipProfileChangeProposal,
+} from "./platform/profile/profile-change-proposal.js";
+export type {
+  RelationshipProfileProposalOperation,
+  RelationshipProfileProposalSource,
+  RelationshipProfileProposalState,
+  RelationshipProfileChangeProposal,
+  RelationshipProfileProposalStore,
+} from "./platform/profile/profile-change-proposal.js";
 export { CuriosityEngine } from "./platform/traits/curiosity-engine.js";
 export { GoalDependencyGraph } from "./orchestrator/goal/goal-dependency-graph.js";
 export { KnowledgeGraph } from "./platform/knowledge/knowledge-graph.js";

--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -173,6 +173,7 @@ import { getPulseedVersion } from "../../../base/utils/pulseed-meta.js";
 import { ensureProviderConfig } from "../ensure-api-key.js";
 import { DaemonClient } from "../../../runtime/daemon/client.js";
 import { ProactiveInterventionStore } from "../../../runtime/store/proactive-intervention-store.js";
+import { createRelationshipProfileChangeProposal } from "../../../platform/profile/profile-change-proposal.js";
 import type { LoopResult } from "../../../orchestrator/loop/core-loop.js";
 import type { Goal } from "../../../base/types/goal.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
@@ -1566,6 +1567,88 @@ describe("profile command", () => {
     expect(allCode).toBe(0);
     expect(allProfile.items.map((item) => item.status)).toEqual(["superseded", "retracted"]);
     expect(allProfile.audit_events).toHaveLength(4);
+  });
+
+  it("lists, inspects, approves, applies, and rejects profile proposals through the production CLI entrypoint", async () => {
+    const applyCandidate = await createRelationshipProfileChangeProposal(tmpDir, {
+      operation: "upsert_item",
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "cli_proposal",
+      confidence: 0.9,
+      sensitivity: "private",
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+      evidenceRefs: ["cli:proposal"],
+      rationale: "Operator wants this preference governed before use.",
+    });
+    const rejectCandidate = await createRelationshipProfileChangeProposal(tmpDir, {
+      operation: "upsert_item",
+      stableKey: "user.boundary.notifications",
+      kind: "boundary",
+      value: "Allow every proactive notification.",
+      source: "cli_proposal",
+      confidence: 0.6,
+      sensitivity: "private",
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["resident_behavior", "memory_retrieval", "user_facing_review"],
+      evidenceRefs: ["cli:rejected-proposal"],
+      rationale: "This proposal should not affect runtime context after rejection.",
+    });
+
+    const listSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const listCode = await runCLI("profile", "proposal", "list", "--state", "pending", "--json");
+    const listOutput = listSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    listSpy.mockRestore();
+
+    expect(listCode).toBe(0);
+    expect(JSON.parse(listOutput).proposals).toHaveLength(2);
+
+    const inspectSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const inspectCode = await runCLI("profile", "proposal", "inspect", applyCandidate.proposal.id, "--json");
+    const inspectOutput = inspectSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    inspectSpy.mockRestore();
+
+    expect(inspectCode).toBe(0);
+    expect(JSON.parse(inspectOutput).proposal.proposed_item.stable_key).toBe("user.preference.status");
+
+    const approveCode = await runCLI("profile", "proposal", "approve", applyCandidate.proposal.id, "--reason", "Approved by operator.");
+    expect(approveCode).toBe(0);
+    const applyCode = await runCLI("profile", "proposal", "apply", applyCandidate.proposal.id);
+    expect(applyCode).toBe(0);
+
+    const rejectCode = await runCLI("profile", "proposal", "reject", rejectCandidate.proposal.id, "--reason", "Rejected by operator.");
+    expect(rejectCode).toBe(0);
+
+    const showSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const showCode = await runCLI("profile", "show", "--scope", "memory_retrieval", "--json");
+    const showOutput = showSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    showSpy.mockRestore();
+
+    const profile = JSON.parse(showOutput) as { items: Array<{ stable_key: string; value: string }> };
+    expect(showCode).toBe(0);
+    expect(profile.items.map((item) => item.stable_key)).toEqual(["user.preference.status"]);
+    expect(profile.items[0]?.value).toBe("Prefer concise status reports.");
+    expect(showOutput).not.toContain("Allow every proactive notification.");
+
+    const proposalStore = JSON.parse(fs.readFileSync(path.join(tmpDir, "relationship-profile-proposals.json"), "utf-8"));
+    expect(proposalStore.proposals.map((proposal: { approval_state: string }) => proposal.approval_state).sort()).toEqual([
+      "applied",
+      "rejected",
+    ]);
+    const profileStore = JSON.parse(fs.readFileSync(path.join(tmpDir, "relationship-profile.json"), "utf-8"));
+    expect(profileStore.audit_events.at(-1).proposal_id).toBe(applyCandidate.proposal.id);
+  });
+
+  it("rejects invalid profile proposal state filters through the production CLI entrypoint", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const code = await runCLI("profile", "proposal", "list", "--state", "pendng");
+    const output = errorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    errorSpy.mockRestore();
+
+    expect(code).toBe(1);
+    expect(output).toContain("invalid proposal state");
   });
 });
 

--- a/src/interface/cli/commands/profile.ts
+++ b/src/interface/cli/commands/profile.ts
@@ -3,6 +3,13 @@ import type { StateManager } from "../../../base/state/state-manager.js";
 import { getCliLogger } from "../cli-logger.js";
 import { formatOperationError } from "../utils.js";
 import {
+  applyRelationshipProfileChangeProposal,
+  approveRelationshipProfileChangeProposal,
+  loadRelationshipProfileProposalStore,
+  rejectRelationshipProfileChangeProposal,
+  RelationshipProfileProposalStateSchema,
+} from "../../../platform/profile/profile-change-proposal.js";
+import {
   loadRelationshipProfile,
   getRelationshipProfileHistory,
   RelationshipProfileConsentScopeSchema,
@@ -24,6 +31,11 @@ function usage(): string {
   pulseed profile update --kind <kind> --key <stable_key> --value <value> [--scope <scope>] [--sensitivity <public|private|sensitive>] [--confidence <0-1>] [--source <source>] [--evidence-ref <ref>]
   pulseed profile history <stable_key> [--json]
   pulseed profile retract --key <stable_key> --reason <reason> [--source <source>] [--json]
+  pulseed profile proposal list [--state <state>] [--json]
+  pulseed profile proposal inspect <proposal_id> [--json]
+  pulseed profile proposal approve <proposal_id> [--reason <reason>] [--json]
+  pulseed profile proposal reject <proposal_id> --reason <reason> [--json]
+  pulseed profile proposal apply <proposal_id> [--json]
 
 Scopes: local_planning, resident_behavior, memory_retrieval, user_facing_review
 Kinds: identity_fact, preference, dislike, value, boundary, communication_style, notification_preference, long_term_goal, life_context, intervention_policy`;
@@ -60,6 +72,10 @@ export async function cmdProfile(stateManager: StateManager, argv: string[]): Pr
   if (!subcommand || subcommand === "--help" || subcommand === "-h" || subcommand === "help") {
     console.log(usage());
     return 0;
+  }
+
+  if (subcommand === "proposal") {
+    return cmdProfileProposal(stateManager, argv.slice(1));
   }
 
   if (subcommand === "show") {
@@ -345,4 +361,182 @@ export async function cmdProfile(stateManager: StateManager, argv: string[]): Pr
   getCliLogger().error(`Unknown profile subcommand: "${subcommand}"`);
   console.log(usage());
   return 1;
+}
+
+async function cmdProfileProposal(stateManager: StateManager, argv: string[]): Promise<number> {
+  const subcommand = argv[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h" || subcommand === "help") {
+    console.log(usage());
+    return 0;
+  }
+
+  if (subcommand === "list") {
+    let values: { state?: string; json?: boolean };
+    try {
+      ({ values } = parseArgs({
+        args: argv.slice(1),
+        options: {
+          state: { type: "string" },
+          json: { type: "boolean" },
+        },
+        strict: true,
+      }) as { values: { state?: string; json?: boolean } });
+    } catch (err) {
+      getCliLogger().error(formatOperationError("parse profile proposal list arguments", err));
+      return 1;
+    }
+    const state = parseEnum(
+      values.state,
+      "proposal state",
+      (value) => RelationshipProfileProposalStateSchema.safeParse(value)
+    );
+    if (values.state !== undefined && !state) return 1;
+    const store = await loadRelationshipProfileProposalStore(stateManager.getBaseDir());
+    const proposals = state
+      ? store.proposals.filter((proposal) => proposal.approval_state === state)
+      : store.proposals;
+    if (values.json) {
+      console.log(JSON.stringify({ ...store, proposals }, null, 2));
+      return 0;
+    }
+    if (proposals.length === 0) {
+      console.log("No relationship profile proposals.");
+      return 0;
+    }
+    console.log("Relationship profile proposals:");
+    for (const proposal of proposals) {
+      console.log(
+        `- ${proposal.id} ${proposal.approval_state} ${proposal.operation} ${proposal.proposed_item.stable_key}` +
+          ` (source=${proposal.source}; confidence=${proposal.confidence.toFixed(2)}; sensitivity=${proposal.sensitivity})`
+      );
+    }
+    return 0;
+  }
+
+  if (subcommand === "inspect") {
+    const parsed = parseProposalIdArgs("inspect", argv.slice(1));
+    if (!parsed) return 1;
+    const store = await loadRelationshipProfileProposalStore(stateManager.getBaseDir());
+    const proposal = store.proposals.find((candidate) => candidate.id === parsed.proposalId);
+    if (!proposal) {
+      getCliLogger().error(`Error: relationship profile proposal not found: ${parsed.proposalId}`);
+      return 1;
+    }
+    if (parsed.json) {
+      console.log(JSON.stringify({
+        proposal,
+        audit_events: store.audit_events.filter((event) => event.proposal_id === proposal.id),
+      }, null, 2));
+      return 0;
+    }
+    console.log(`Relationship profile proposal ${proposal.id}:`);
+    console.log(`- state: ${proposal.approval_state}`);
+    console.log(`- operation: ${proposal.operation}`);
+    console.log(`- key: ${proposal.proposed_item.stable_key}`);
+    if (proposal.proposed_item.kind) console.log(`- kind: ${proposal.proposed_item.kind}`);
+    if (proposal.proposed_item.value) console.log(`- value: ${proposal.proposed_item.value}`);
+    console.log(`- rationale: ${proposal.rationale}`);
+    return 0;
+  }
+
+  if (subcommand === "approve") {
+    const parsed = parseProposalIdArgs("approve", argv.slice(1), { allowReason: true });
+    if (!parsed) return 1;
+    try {
+      const result = await approveRelationshipProfileChangeProposal(stateManager.getBaseDir(), parsed.proposalId, {
+        reason: parsed.reason,
+      });
+      if (parsed.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Approved relationship profile proposal ${result.proposal.id}.`);
+      }
+      return 0;
+    } catch (err) {
+      getCliLogger().error(formatOperationError("approve relationship profile proposal", err));
+      return 1;
+    }
+  }
+
+  if (subcommand === "reject") {
+    const parsed = parseProposalIdArgs("reject", argv.slice(1), { requireReason: true });
+    if (!parsed || !parsed.reason) return 1;
+    try {
+      const result = await rejectRelationshipProfileChangeProposal(stateManager.getBaseDir(), parsed.proposalId, {
+        reason: parsed.reason,
+      });
+      if (parsed.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Rejected relationship profile proposal ${result.proposal.id}.`);
+      }
+      return 0;
+    } catch (err) {
+      getCliLogger().error(formatOperationError("reject relationship profile proposal", err));
+      return 1;
+    }
+  }
+
+  if (subcommand === "apply") {
+    const parsed = parseProposalIdArgs("apply", argv.slice(1));
+    if (!parsed) return 1;
+    try {
+      const result = await applyRelationshipProfileChangeProposal(stateManager.getBaseDir(), parsed.proposalId);
+      if (parsed.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Applied relationship profile proposal ${result.proposal.id} to ${result.item.stable_key} v${result.item.version}.`);
+      }
+      return 0;
+    } catch (err) {
+      getCliLogger().error(formatOperationError("apply relationship profile proposal", err));
+      return 1;
+    }
+  }
+
+  getCliLogger().error(`Unknown profile proposal subcommand: "${subcommand}"`);
+  console.log(usage());
+  return 1;
+}
+
+function parseProposalIdArgs(
+  label: string,
+  args: string[],
+  options: { allowReason?: boolean; requireReason?: boolean } = {}
+): { proposalId: string; reason?: string; json?: boolean } | null {
+  let values: { reason?: string; json?: boolean };
+  let positionals: string[];
+  try {
+    const parsed = parseArgs({
+      args,
+      options: {
+        ...(options.allowReason || options.requireReason ? { reason: { type: "string" as const } } : {}),
+        json: { type: "boolean" },
+      },
+      allowPositionals: true,
+      strict: true,
+    }) as { values: { reason?: string; json?: boolean }; positionals: string[] };
+    values = parsed.values;
+    positionals = parsed.positionals;
+  } catch (err) {
+    getCliLogger().error(formatOperationError(`parse profile proposal ${label} arguments`, err));
+    return null;
+  }
+  const proposalId = positionals[0]?.trim();
+  if (!proposalId || positionals.length > 1) {
+    getCliLogger().error(`Error: profile proposal ${label} requires exactly one <proposal_id> argument.`);
+    console.log(usage());
+    return null;
+  }
+  const reason = values.reason?.trim();
+  if (options.requireReason && !reason) {
+    getCliLogger().error("Error: --reason is required.");
+    console.log(usage());
+    return null;
+  }
+  return {
+    proposalId,
+    ...(reason ? { reason } : {}),
+    json: values.json,
+  };
 }

--- a/src/platform/profile/__tests__/profile-change-proposal.test.ts
+++ b/src/platform/profile/__tests__/profile-change-proposal.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  applyRelationshipProfileChangeProposal,
+  approveRelationshipProfileChangeProposal,
+  createRelationshipProfileChangeProposal,
+  loadRelationshipProfileProposalStore,
+  RelationshipProfileChangeProposalSchema,
+  rejectRelationshipProfileChangeProposal,
+} from "../profile-change-proposal.js";
+import {
+  formatRelationshipProfilePromptBlock,
+  loadRelationshipProfile,
+  saveRelationshipProfile,
+  selectActiveRelationshipProfileItems,
+  upsertRelationshipProfileItemInStore,
+} from "../relationship-profile.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-profile-proposal-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("relationship profile proposal store", () => {
+  it("approves and applies proposals through the relationship profile lifecycle path", async () => {
+    const baseDir = makeTempDir();
+    const created = await createRelationshipProfileChangeProposal(baseDir, {
+      operation: "upsert_item",
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "cli_proposal",
+      confidence: 0.88,
+      sensitivity: "private",
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+      evidenceRefs: ["proposal:test"],
+      rationale: "The user explicitly corrected the status-report preference.",
+      now: "2026-05-03T00:00:00.000Z",
+    });
+
+    const approved = await approveRelationshipProfileChangeProposal(baseDir, created.proposal.id, {
+      reason: "Operator approved.",
+      now: "2026-05-03T00:01:00.000Z",
+    });
+    const applied = await applyRelationshipProfileChangeProposal(baseDir, approved.proposal.id, {
+      now: "2026-05-03T00:02:00.000Z",
+    });
+
+    expect(created.proposal.approval_state).toBe("pending");
+    expect(approved.proposal.approval_state).toBe("approved");
+    expect(applied.proposal.approval_state).toBe("applied");
+    expect(applied.item.stable_key).toBe("user.preference.status");
+
+    const profile = await loadRelationshipProfile(baseDir);
+    expect(selectActiveRelationshipProfileItems(profile, "memory_retrieval").map((item) => item.value)).toEqual([
+      "Prefer concise status reports.",
+    ]);
+    expect(profile.audit_events.at(-1)).toMatchObject({
+      action: "seeded",
+      proposal_id: created.proposal.id,
+    });
+
+    const proposals = await loadRelationshipProfileProposalStore(baseDir);
+    expect(proposals.audit_events.map((event) => event.action)).toEqual(["created", "approved", "applied"]);
+    expect(proposals.proposals[0]?.applied_profile_item_id).toBe(applied.item.id);
+  });
+
+  it("rejects proposals without affecting prompt or retrieval contexts", async () => {
+    const baseDir = makeTempDir();
+    const created = await createRelationshipProfileChangeProposal(baseDir, {
+      operation: "upsert_item",
+      stableKey: "user.boundary.notifications",
+      kind: "boundary",
+      value: "Allow every proactive notification.",
+      source: "cli_proposal",
+      confidence: 0.5,
+      sensitivity: "private",
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["local_planning", "memory_retrieval", "resident_behavior", "user_facing_review"],
+      evidenceRefs: ["proposal:rejected"],
+      rationale: "A rejected proposal should remain review-only.",
+      now: "2026-05-03T00:00:00.000Z",
+    });
+
+    const rejected = await rejectRelationshipProfileChangeProposal(baseDir, created.proposal.id, {
+      reason: "Operator rejected.",
+      now: "2026-05-03T00:01:00.000Z",
+    });
+
+    expect(rejected.proposal.approval_state).toBe("rejected");
+    const profile = await loadRelationshipProfile(baseDir);
+    expect(selectActiveRelationshipProfileItems(profile, "memory_retrieval")).toEqual([]);
+    expect(formatRelationshipProfilePromptBlock(profile, "resident_behavior")).not.toContain("Allow every proactive notification.");
+    await expect(applyRelationshipProfileChangeProposal(baseDir, created.proposal.id)).rejects.toThrow("only approved proposals");
+  });
+
+  it("rejects invalid upsert proposals at the schema boundary", () => {
+    const parsed = RelationshipProfileChangeProposalSchema.safeParse({
+      id: "profile-proposal-invalid",
+      operation: "upsert_item",
+      proposed_item: {
+        stable_key: "user.preference.status",
+        allowed_scopes: ["local_planning"],
+        sensitivity: "private",
+      },
+      source: "cli_proposal",
+      confidence: 0.8,
+      sensitivity: "private",
+      consent_scopes: ["user_facing_review"],
+      evidence_refs: [],
+      rationale: "Invalid because the proposed item is incomplete.",
+      approval_state: "pending",
+      created_at: "2026-05-03T00:00:00.000Z",
+      updated_at: "2026-05-03T00:00:00.000Z",
+    });
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((issue) => issue.path.join("."))).toEqual([
+      "proposed_item.kind",
+      "proposed_item.value",
+    ]);
+  });
+
+  it("recovers an approved proposal already linked from profile audit without replaying the mutation", async () => {
+    const baseDir = makeTempDir();
+    const created = await createRelationshipProfileChangeProposal(baseDir, {
+      operation: "upsert_item",
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "cli_proposal",
+      confidence: 0.88,
+      sensitivity: "private",
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+      evidenceRefs: ["proposal:recover"],
+      rationale: "The user explicitly corrected the status-report preference.",
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    await approveRelationshipProfileChangeProposal(baseDir, created.proposal.id, {
+      now: "2026-05-03T00:01:00.000Z",
+    });
+
+    const profileStore = await loadRelationshipProfile(baseDir);
+    const profileResult = upsertRelationshipProfileItemInStore(profileStore, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "user_correction",
+      confidence: 0.88,
+      sensitivity: "private",
+      allowedScopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+      evidenceRef: "proposal:recover",
+      note: "The user explicitly corrected the status-report preference.",
+      proposalId: created.proposal.id,
+      now: "2026-05-03T00:02:00.000Z",
+    });
+    await saveRelationshipProfile(baseDir, profileResult.store);
+
+    const recovered = await applyRelationshipProfileChangeProposal(baseDir, created.proposal.id, {
+      now: "2026-05-03T00:03:00.000Z",
+    });
+    const after = await loadRelationshipProfile(baseDir);
+
+    expect(recovered.proposal.approval_state).toBe("applied");
+    expect(recovered.item.id).toBe(profileResult.item.id);
+    expect(after.items).toHaveLength(1);
+    expect(after.items[0]?.version).toBe(1);
+  });
+
+  it("treats repeated apply of an already-applied proposal as idempotent", async () => {
+    const baseDir = makeTempDir();
+    const created = await createRelationshipProfileChangeProposal(baseDir, {
+      operation: "upsert_item",
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "cli_proposal",
+      confidence: 0.88,
+      sensitivity: "private",
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+      evidenceRefs: ["proposal:idempotent"],
+      rationale: "The user explicitly corrected the status-report preference.",
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    await approveRelationshipProfileChangeProposal(baseDir, created.proposal.id, {
+      now: "2026-05-03T00:01:00.000Z",
+    });
+    const firstApply = await applyRelationshipProfileChangeProposal(baseDir, created.proposal.id, {
+      now: "2026-05-03T00:02:00.000Z",
+    });
+    const secondApply = await applyRelationshipProfileChangeProposal(baseDir, created.proposal.id, {
+      now: "2026-05-03T00:03:00.000Z",
+    });
+    const profile = await loadRelationshipProfile(baseDir);
+
+    expect(secondApply.proposal.approval_state).toBe("applied");
+    expect(secondApply.item.id).toBe(firstApply.item.id);
+    expect(profile.items).toHaveLength(1);
+    expect(profile.items[0]?.version).toBe(1);
+    expect(profile.audit_events.filter((event) => event.proposal_id === created.proposal.id)).toHaveLength(1);
+  });
+
+  it("recovers replacement upserts to the created item instead of the superseded item", async () => {
+    const baseDir = makeTempDir();
+    let profileStore = await loadRelationshipProfile(baseDir);
+    const original = upsertRelationshipProfileItemInStore(profileStore, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer verbose status reports.",
+      source: "cli_update",
+      allowedScopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    await saveRelationshipProfile(baseDir, original.store);
+
+    const created = await createRelationshipProfileChangeProposal(baseDir, {
+      operation: "upsert_item",
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "cli_proposal",
+      confidence: 0.88,
+      sensitivity: "private",
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+      evidenceRefs: ["proposal:replacement-recover"],
+      rationale: "The user corrected the prior preference.",
+      now: "2026-05-03T00:01:00.000Z",
+    });
+    await approveRelationshipProfileChangeProposal(baseDir, created.proposal.id, {
+      now: "2026-05-03T00:02:00.000Z",
+    });
+
+    profileStore = await loadRelationshipProfile(baseDir);
+    const replacement = upsertRelationshipProfileItemInStore(profileStore, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "user_correction",
+      confidence: 0.88,
+      sensitivity: "private",
+      allowedScopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+      evidenceRef: "proposal:replacement-recover",
+      note: "The user corrected the prior preference.",
+      proposalId: created.proposal.id,
+      now: "2026-05-03T00:03:00.000Z",
+    });
+    await saveRelationshipProfile(baseDir, replacement.store);
+
+    const recovered = await applyRelationshipProfileChangeProposal(baseDir, created.proposal.id, {
+      now: "2026-05-03T00:04:00.000Z",
+    });
+    const after = await loadRelationshipProfile(baseDir);
+
+    expect(recovered.item.id).toBe(replacement.item.id);
+    expect(recovered.item.status).toBe("active");
+    expect(after.items.map((item) => [item.version, item.status])).toEqual([
+      [1, "superseded"],
+      [2, "active"],
+    ]);
+  });
+});

--- a/src/platform/profile/profile-change-proposal.ts
+++ b/src/platform/profile/profile-change-proposal.ts
@@ -1,0 +1,421 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../../base/utils/json-io.js";
+import {
+  loadRelationshipProfile,
+  saveRelationshipProfile,
+  upsertRelationshipProfileItemInStore,
+  retractRelationshipProfileItemInStore,
+  RelationshipProfileConsentScopeSchema,
+  RelationshipProfileItemKindSchema,
+  RelationshipProfileSensitivitySchema,
+  RelationshipProfileSourceSchema,
+  type RelationshipProfileConsentScope,
+  type RelationshipProfileItem,
+  type RelationshipProfileItemKind,
+  type RelationshipProfileSensitivity,
+  type RelationshipProfileSource,
+} from "./relationship-profile.js";
+
+export const RelationshipProfileProposalOperationSchema = z.enum(["upsert_item", "retract_item"]);
+export const RelationshipProfileProposalSourceSchema = z.enum([
+  "cli_proposal",
+  "setup_import",
+  "proactive_feedback",
+  "system_migration",
+]);
+export const RelationshipProfileProposalStateSchema = z.enum([
+  "pending",
+  "approved",
+  "rejected",
+  "applied",
+  "superseded",
+  "expired",
+]);
+
+export const RelationshipProfileProposalItemDataSchema = z.object({
+  stable_key: z.string().min(1),
+  kind: RelationshipProfileItemKindSchema.optional(),
+  value: z.string().min(1).optional(),
+  sensitivity: RelationshipProfileSensitivitySchema.default("private"),
+  allowed_scopes: z.array(RelationshipProfileConsentScopeSchema).min(1).default(["local_planning", "user_facing_review"]),
+});
+
+export const RelationshipProfileChangeProposalSchema = z.object({
+  id: z.string().min(1),
+  operation: RelationshipProfileProposalOperationSchema,
+  proposed_item: RelationshipProfileProposalItemDataSchema,
+  source: RelationshipProfileProposalSourceSchema,
+  confidence: z.number().min(0).max(1).default(0.7),
+  sensitivity: RelationshipProfileSensitivitySchema.default("private"),
+  consent_scopes: z.array(RelationshipProfileConsentScopeSchema).min(1).default(["user_facing_review"]),
+  evidence_refs: z.array(z.string().min(1)).default([]),
+  rationale: z.string().min(1),
+  approval_state: RelationshipProfileProposalStateSchema.default("pending"),
+  rejection_reason: z.string().min(1).optional(),
+  approval_reason: z.string().min(1).optional(),
+  applied_profile_item_id: z.string().min(1).optional(),
+  applied_at: z.string().datetime().nullable().default(null),
+  expires_at: z.string().datetime().nullable().default(null),
+  created_at: z.string().datetime(),
+  updated_at: z.string().datetime(),
+}).superRefine((proposal, ctx) => {
+  if (proposal.operation === "upsert_item") {
+    if (!proposal.proposed_item.kind) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["proposed_item", "kind"],
+        message: "kind is required for upsert proposals",
+      });
+    }
+    if (!proposal.proposed_item.value) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["proposed_item", "value"],
+        message: "value is required for upsert proposals",
+      });
+    }
+  }
+});
+
+export const RelationshipProfileProposalAuditEventSchema = z.object({
+  id: z.string().min(1),
+  proposal_id: z.string().min(1),
+  at: z.string().datetime(),
+  action: z.enum(["created", "approved", "rejected", "applied", "superseded", "expired"]),
+  reason: z.string().min(1).optional(),
+  profile_item_id: z.string().min(1).optional(),
+});
+
+export const RelationshipProfileProposalStoreSchema = z.object({
+  schema_version: z.literal(1).default(1),
+  profile_id: z.string().min(1).default("default"),
+  proposals: z.array(RelationshipProfileChangeProposalSchema).default([]),
+  audit_events: z.array(RelationshipProfileProposalAuditEventSchema).default([]),
+  updated_at: z.string().datetime().nullable().default(null),
+});
+
+export type RelationshipProfileProposalOperation = z.infer<typeof RelationshipProfileProposalOperationSchema>;
+export type RelationshipProfileProposalSource = z.infer<typeof RelationshipProfileProposalSourceSchema>;
+export type RelationshipProfileProposalState = z.infer<typeof RelationshipProfileProposalStateSchema>;
+export type RelationshipProfileChangeProposal = z.infer<typeof RelationshipProfileChangeProposalSchema>;
+export type RelationshipProfileProposalStore = z.infer<typeof RelationshipProfileProposalStoreSchema>;
+
+export interface RelationshipProfileProposalInput {
+  operation: RelationshipProfileProposalOperation;
+  stableKey: string;
+  kind?: RelationshipProfileItemKind;
+  value?: string;
+  source: RelationshipProfileProposalSource;
+  confidence?: number;
+  sensitivity?: RelationshipProfileSensitivity;
+  consentScopes?: RelationshipProfileConsentScope[];
+  allowedScopes?: RelationshipProfileConsentScope[];
+  evidenceRefs?: string[];
+  rationale: string;
+  expiresAt?: string | null;
+  now?: string;
+}
+
+export function relationshipProfileProposalPath(baseDir: string): string {
+  return path.join(baseDir, "relationship-profile-proposals.json");
+}
+
+export function createEmptyRelationshipProfileProposalStore(now: string | null = null): RelationshipProfileProposalStore {
+  return RelationshipProfileProposalStoreSchema.parse({
+    schema_version: 1,
+    profile_id: "default",
+    proposals: [],
+    audit_events: [],
+    updated_at: now,
+  });
+}
+
+export async function loadRelationshipProfileProposalStore(baseDir: string): Promise<RelationshipProfileProposalStore> {
+  const raw = await readJsonFileOrNull(relationshipProfileProposalPath(baseDir));
+  const parsed = RelationshipProfileProposalStoreSchema.safeParse(raw);
+  return parsed.success ? parsed.data : createEmptyRelationshipProfileProposalStore();
+}
+
+export function loadRelationshipProfileProposalStoreSync(baseDir: string): RelationshipProfileProposalStore {
+  try {
+    const raw = JSON.parse(fs.readFileSync(relationshipProfileProposalPath(baseDir), "utf-8")) as unknown;
+    const parsed = RelationshipProfileProposalStoreSchema.safeParse(raw);
+    return parsed.success ? parsed.data : createEmptyRelationshipProfileProposalStore();
+  } catch {
+    return createEmptyRelationshipProfileProposalStore();
+  }
+}
+
+export async function saveRelationshipProfileProposalStore(
+  baseDir: string,
+  store: RelationshipProfileProposalStore
+): Promise<void> {
+  await writeJsonFileAtomic(relationshipProfileProposalPath(baseDir), RelationshipProfileProposalStoreSchema.parse(store), {
+    mode: 0o600,
+    directoryMode: 0o700,
+  });
+}
+
+function normalizeProposalInput(input: RelationshipProfileProposalInput): RelationshipProfileProposalInput & {
+  stableKey: string;
+  rationale: string;
+  confidence: number;
+  sensitivity: RelationshipProfileSensitivity;
+  consentScopes: RelationshipProfileConsentScope[];
+  allowedScopes: RelationshipProfileConsentScope[];
+  evidenceRefs: string[];
+  now: string;
+} {
+  const stableKey = input.stableKey.trim();
+  const rationale = input.rationale.trim();
+  const value = input.value?.trim();
+  if (!stableKey) throw new Error("stable key is required");
+  if (!rationale) throw new Error("proposal rationale is required");
+  if (input.operation === "upsert_item") {
+    if (!input.kind) throw new Error("kind is required for upsert proposals");
+    if (!value) throw new Error("value is required for upsert proposals");
+  }
+  if (input.confidence !== undefined && (!Number.isFinite(input.confidence) || input.confidence < 0 || input.confidence > 1)) {
+    throw new Error("proposal confidence must be between 0 and 1");
+  }
+  const consentScopes: RelationshipProfileConsentScope[] = input.consentScopes && input.consentScopes.length > 0
+    ? [...new Set(input.consentScopes)]
+    : ["user_facing_review"];
+  const allowedScopes: RelationshipProfileConsentScope[] = input.allowedScopes && input.allowedScopes.length > 0
+    ? [...new Set(input.allowedScopes)]
+    : ["local_planning", "user_facing_review"];
+  return {
+    ...input,
+    stableKey,
+    ...(value ? { value } : {}),
+    rationale,
+    confidence: input.confidence ?? 0.7,
+    sensitivity: input.sensitivity ?? "private",
+    consentScopes,
+    allowedScopes,
+    evidenceRefs: [...new Set(input.evidenceRefs ?? [])],
+    now: input.now ?? new Date().toISOString(),
+  };
+}
+
+export function createRelationshipProfileChangeProposalInStore(
+  store: RelationshipProfileProposalStore,
+  input: RelationshipProfileProposalInput
+): { store: RelationshipProfileProposalStore; proposal: RelationshipProfileChangeProposal } {
+  const normalized = normalizeProposalInput(input);
+  const id = `profile-proposal-${randomUUID()}`;
+  const proposal = RelationshipProfileChangeProposalSchema.parse({
+    id,
+    operation: normalized.operation,
+    proposed_item: {
+      stable_key: normalized.stableKey,
+      ...(normalized.kind ? { kind: normalized.kind } : {}),
+      ...(normalized.value ? { value: normalized.value } : {}),
+      sensitivity: normalized.sensitivity,
+      allowed_scopes: normalized.allowedScopes,
+    },
+    source: normalized.source,
+    confidence: normalized.confidence,
+    sensitivity: normalized.sensitivity,
+    consent_scopes: normalized.consentScopes,
+    evidence_refs: normalized.evidenceRefs,
+    rationale: normalized.rationale,
+    approval_state: "pending",
+    expires_at: normalized.expiresAt ?? null,
+    created_at: normalized.now,
+    updated_at: normalized.now,
+  });
+  const event = RelationshipProfileProposalAuditEventSchema.parse({
+    id: `profile-proposal-event-${randomUUID()}`,
+    proposal_id: proposal.id,
+    at: normalized.now,
+    action: "created",
+  });
+  return {
+    store: RelationshipProfileProposalStoreSchema.parse({
+      ...store,
+      proposals: [...store.proposals, proposal],
+      audit_events: [...store.audit_events, event],
+      updated_at: normalized.now,
+    }),
+    proposal,
+  };
+}
+
+export async function createRelationshipProfileChangeProposal(
+  baseDir: string,
+  input: RelationshipProfileProposalInput
+): Promise<{ proposal: RelationshipProfileChangeProposal }> {
+  const loaded = await loadRelationshipProfileProposalStore(baseDir);
+  const result = createRelationshipProfileChangeProposalInStore(loaded, input);
+  await saveRelationshipProfileProposalStore(baseDir, result.store);
+  return { proposal: result.proposal };
+}
+
+function transitionProposal(
+  store: RelationshipProfileProposalStore,
+  proposalId: string,
+  toState: RelationshipProfileProposalState,
+  action: z.infer<typeof RelationshipProfileProposalAuditEventSchema>["action"],
+  params: { reason?: string; profileItemId?: string; now?: string } = {}
+): { store: RelationshipProfileProposalStore; proposal: RelationshipProfileChangeProposal } {
+  const id = proposalId.trim();
+  if (!id) throw new Error("proposal id is required");
+  const now = params.now ?? new Date().toISOString();
+  const existing = store.proposals.find((proposal) => proposal.id === id);
+  if (!existing) throw new Error(`relationship profile proposal not found: ${id}`);
+  const terminalStates: RelationshipProfileProposalState[] = ["rejected", "applied", "superseded", "expired"];
+  if (terminalStates.includes(existing.approval_state)) {
+    throw new Error(`cannot transition ${existing.approval_state} proposal: ${id}`);
+  }
+  if (toState === "approved" && existing.approval_state !== "pending") {
+    throw new Error(`only pending proposals can be approved: ${id}`);
+  }
+  if (toState === "rejected" && existing.approval_state !== "pending") {
+    throw new Error(`only pending proposals can be rejected: ${id}`);
+  }
+  if (toState === "applied" && existing.approval_state !== "approved") {
+    throw new Error(`only approved proposals can be applied: ${id}`);
+  }
+
+  let updatedProposal: RelationshipProfileChangeProposal | null = null;
+  const proposals = store.proposals.map((proposal) => {
+    if (proposal.id !== id) return proposal;
+    updatedProposal = RelationshipProfileChangeProposalSchema.parse({
+      ...proposal,
+      approval_state: toState,
+      ...(toState === "approved" && params.reason ? { approval_reason: params.reason } : {}),
+      ...(toState === "rejected" && params.reason ? { rejection_reason: params.reason } : {}),
+      ...(toState === "applied" ? {
+        applied_profile_item_id: params.profileItemId,
+        applied_at: now,
+      } : {}),
+      updated_at: now,
+    });
+    return updatedProposal;
+  });
+  const event = RelationshipProfileProposalAuditEventSchema.parse({
+    id: `profile-proposal-event-${randomUUID()}`,
+    proposal_id: id,
+    at: now,
+    action,
+    ...(params.reason ? { reason: params.reason } : {}),
+    ...(params.profileItemId ? { profile_item_id: params.profileItemId } : {}),
+  });
+  return {
+    store: RelationshipProfileProposalStoreSchema.parse({
+      ...store,
+      proposals,
+      audit_events: [...store.audit_events, event],
+      updated_at: now,
+    }),
+    proposal: updatedProposal ?? existing,
+  };
+}
+
+export async function approveRelationshipProfileChangeProposal(
+  baseDir: string,
+  proposalId: string,
+  params: { reason?: string; now?: string } = {}
+): Promise<{ proposal: RelationshipProfileChangeProposal }> {
+  const loaded = await loadRelationshipProfileProposalStore(baseDir);
+  const result = transitionProposal(loaded, proposalId, "approved", "approved", params);
+  await saveRelationshipProfileProposalStore(baseDir, result.store);
+  return { proposal: result.proposal };
+}
+
+export async function rejectRelationshipProfileChangeProposal(
+  baseDir: string,
+  proposalId: string,
+  params: { reason: string; now?: string }
+): Promise<{ proposal: RelationshipProfileChangeProposal }> {
+  const loaded = await loadRelationshipProfileProposalStore(baseDir);
+  const result = transitionProposal(loaded, proposalId, "rejected", "rejected", params);
+  await saveRelationshipProfileProposalStore(baseDir, result.store);
+  return { proposal: result.proposal };
+}
+
+function profileSourceForProposal(source: RelationshipProfileProposalSource): RelationshipProfileSource {
+  if (source === "setup_import") return "setup_import";
+  if (source === "system_migration") return "system_migration";
+  return "user_correction";
+}
+
+export async function applyRelationshipProfileChangeProposal(
+  baseDir: string,
+  proposalId: string,
+  params: { now?: string } = {}
+): Promise<{ proposal: RelationshipProfileChangeProposal; item: RelationshipProfileItem }> {
+  const proposalStore = await loadRelationshipProfileProposalStore(baseDir);
+  const proposal = proposalStore.proposals.find((candidate) => candidate.id === proposalId.trim());
+  if (!proposal) throw new Error(`relationship profile proposal not found: ${proposalId}`);
+  const now = params.now ?? new Date().toISOString();
+  const profileStore = await loadRelationshipProfile(baseDir);
+  const linkedProfileEvents = profileStore.audit_events.filter((event) => event.proposal_id === proposal.id);
+  const recoveredProfileEvent = proposal.applied_profile_item_id
+    ? linkedProfileEvents.find((event) => event.item_id === proposal.applied_profile_item_id)
+    : linkedProfileEvents.find((event) => {
+      if (proposal.operation === "upsert_item") return event.action === "created" || event.action === "seeded";
+      return event.action === "retracted";
+    });
+  if (recoveredProfileEvent) {
+    const recoveredItem = profileStore.items.find((item) => item.id === recoveredProfileEvent.item_id);
+    if (!recoveredItem) {
+      throw new Error(`proposal ${proposal.id} is linked to missing profile item ${recoveredProfileEvent.item_id}`);
+    }
+    if (proposal.approval_state === "applied") {
+      return { proposal, item: recoveredItem };
+    }
+    if (proposal.approval_state === "approved") {
+      const proposalResult = transitionProposal(proposalStore, proposal.id, "applied", "applied", {
+        profileItemId: recoveredItem.id,
+        now,
+      });
+      await saveRelationshipProfileProposalStore(baseDir, proposalResult.store);
+      return { proposal: proposalResult.proposal, item: recoveredItem };
+    }
+  }
+  if (proposal.approval_state !== "approved") {
+    throw new Error(`only approved proposals can be applied: ${proposalId}`);
+  }
+  let profileResult;
+  if (proposal.operation === "upsert_item") {
+    const kind = proposal.proposed_item.kind;
+    const value = proposal.proposed_item.value;
+    if (!kind || !value) {
+      throw new Error(`invalid upsert proposal missing kind or value: ${proposal.id}`);
+    }
+    profileResult = upsertRelationshipProfileItemInStore(profileStore, {
+      stableKey: proposal.proposed_item.stable_key,
+      kind,
+      value,
+      source: profileSourceForProposal(proposal.source),
+      confidence: proposal.confidence,
+      sensitivity: proposal.proposed_item.sensitivity,
+      allowedScopes: proposal.proposed_item.allowed_scopes,
+      evidenceRef: proposal.evidence_refs[0],
+      note: proposal.rationale,
+      proposalId: proposal.id,
+      now,
+    });
+  } else {
+    profileResult = retractRelationshipProfileItemInStore(profileStore, {
+      stableKey: proposal.proposed_item.stable_key,
+      reason: proposal.rationale,
+      source: profileSourceForProposal(proposal.source),
+      proposalId: proposal.id,
+      now,
+    });
+  }
+  const item = profileResult.item;
+  const proposalResult = transitionProposal(proposalStore, proposal.id, "applied", "applied", {
+    profileItemId: item.id,
+    now,
+  });
+  await saveRelationshipProfile(baseDir, profileResult.store);
+  await saveRelationshipProfileProposalStore(baseDir, proposalResult.store);
+  return { proposal: proposalResult.proposal, item };
+}

--- a/src/platform/profile/relationship-profile.ts
+++ b/src/platform/profile/relationship-profile.ts
@@ -66,6 +66,7 @@ export const RelationshipProfileAuditEventSchema = z.object({
   source: RelationshipProfileSourceSchema,
   previous_item_id: z.string().min(1).optional(),
   reason: z.string().min(1).optional(),
+  proposal_id: z.string().min(1).optional(),
 });
 
 export const RelationshipProfileStoreSchema = z.object({
@@ -93,6 +94,7 @@ export interface RelationshipProfileItemInput {
   allowedScopes?: RelationshipProfileConsentScope[];
   evidenceRef?: string;
   note?: string;
+  proposalId?: string;
   now?: string;
 }
 
@@ -100,6 +102,7 @@ export interface RelationshipProfileRetractionInput {
   stableKey: string;
   reason: string;
   source?: RelationshipProfileSource;
+  proposalId?: string;
   now?: string;
 }
 
@@ -211,6 +214,7 @@ export function upsertRelationshipProfileItemInStore(
       version: previous.version,
       source: normalized.source,
       previous_item_id: previous.id,
+      ...(normalized.proposalId ? { proposal_id: normalized.proposalId } : {}),
     })),
     RelationshipProfileAuditEventSchema.parse({
       id: `profile-event-${randomUUID()}`,
@@ -221,6 +225,7 @@ export function upsertRelationshipProfileItemInStore(
       version: item.version,
       source: normalized.source,
       previous_item_id: superseded.at(-1)?.id,
+      ...(normalized.proposalId ? { proposal_id: normalized.proposalId } : {}),
     }),
   ];
 
@@ -246,7 +251,12 @@ export async function upsertRelationshipProfileItem(
   return { item: result.item, superseded: result.superseded };
 }
 
-function normalizeRetractionInput(input: RelationshipProfileRetractionInput): Required<RelationshipProfileRetractionInput> {
+function normalizeRetractionInput(input: RelationshipProfileRetractionInput): RelationshipProfileRetractionInput & {
+  stableKey: string;
+  reason: string;
+  source: RelationshipProfileSource;
+  now: string;
+} {
   const stableKey = input.stableKey.trim();
   const reason = input.reason.trim();
   if (!stableKey) throw new Error("stable key is required");
@@ -255,6 +265,7 @@ function normalizeRetractionInput(input: RelationshipProfileRetractionInput): Re
     stableKey,
     reason,
     source: input.source ?? "cli_update",
+    ...(input.proposalId ? { proposalId: input.proposalId } : {}),
     now: input.now ?? new Date().toISOString(),
   };
 }
@@ -293,6 +304,7 @@ export function retractRelationshipProfileItemInStore(
     version: target.version,
     source: normalized.source,
     reason: normalized.reason,
+    ...(normalized.proposalId ? { proposal_id: normalized.proposalId } : {}),
   });
 
   return {


### PR DESCRIPTION
Closes #927
Refs #896

## Summary
- add a separate typed relationship profile proposal store with explicit pending/approved/rejected/applied/superseded/expired states
- add proposal create/approve/reject/apply helpers and `pulseed profile proposal list|inspect|approve|reject|apply`
- route applied proposals through the existing relationship profile lifecycle path with proposal-linked audit events
- keep rejected proposals isolated from active prompt/retrieval profile context
- add idempotent apply recovery for uncertain completion and replacement upsert cases

## Verification
- `npm run typecheck`
- `npx vitest run src/platform/profile/__tests__/relationship-profile.test.ts src/platform/profile/__tests__/profile-change-proposal.test.ts src/interface/cli/__tests__/cli-runner.test.ts`
- `npm run lint:boundaries` (passes with pre-existing warnings)
- `npm run test:changed`
- `git diff --check`

## Known unresolved risks
- `npm run lint:boundaries` still reports the repo-wide pre-existing warning set, but no lint errors.
- USER.md extraction and proactive-feedback proposal generation are intentionally left for #931 and #932.