### PR TITLE
feat(profile): propose profile items from USER.md import

### DIFF
--- a/src/base/config/identity-loader.ts
+++ b/src/base/config/identity-loader.ts
@@ -151,14 +151,17 @@ function isUserContentMeaningful(user: string): boolean {
   return stripped.length > 0;
 }
 
-export function getUserFacingIdentity(): string {
-  return getUserFacingIdentityForIdentity(loadIdentity());
+export function getUserFacingIdentity(options: { includeUserContent?: boolean } = {}): string {
+  return getUserFacingIdentityForIdentity(loadIdentity(), options);
 }
 
-export function getUserFacingIdentityForIdentity(identity: Identity): string {
+export function getUserFacingIdentityForIdentity(
+  identity: Identity,
+  options: { includeUserContent?: boolean } = {}
+): string {
   const { name, seed, root, user } = identity;
   const parts = [getCoreIdentity(name), getRuntimeIdentitySlotContent(identity), seed.trim(), root.trim()];
-  if (isUserContentMeaningful(user)) {
+  if (options.includeUserContent !== false && isUserContentMeaningful(user)) {
     parts.push(user.trim());
   }
   return parts.join("\n\n---\n\n");

--- a/src/grounding/__tests__/gateway.test.ts
+++ b/src/grounding/__tests__/gateway.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { StateManager } from "../../base/state/state-manager.js";
 import { SqliteSoilRepository } from "../../platform/soil/sqlite-repository.js";
+import { buildStaticSystemPrompt } from "../../interface/chat/grounding.js";
 import { createGroundingGateway } from "../gateway.js";
 
 function makeStateManager(overrides: Partial<StateManager> = {}): StateManager {
@@ -78,6 +79,46 @@ describe("GroundingGateway", () => {
     expect(repoInstructions?.content).not.toContain("Node modules instruction");
     expect(bundle.warnings.some((warning) => warning.includes("Rejected repo instructions"))).toBe(true);
     expect(bundle.traces.source.some((source) => source.path?.endsWith("node_modules/pkg/AGENTS.md") && source.accepted === false)).toBe(true);
+  });
+
+  it("keeps raw USER.md out of agent-loop identity grounding while preserving chat identity", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-grounding-user-md-"));
+    const homeDir = path.join(tmpRoot, "home");
+    fs.mkdirSync(homeDir, { recursive: true });
+    fs.writeFileSync(path.join(homeDir, "SEED.md"), "# Seedy\n\nAgent seed.", "utf-8");
+    fs.writeFileSync(path.join(homeDir, "ROOT.md"), "# Root\n\nRoot policy.", "utf-8");
+    fs.writeFileSync(path.join(homeDir, "USER.md"), "# About You\n\nPrefer verbose status reports.", "utf-8");
+
+    const gateway = createGroundingGateway({ stateManager: makeStateManager() });
+    const agentLoop = await gateway.build({
+      surface: "agent_loop",
+      purpose: "task_execution",
+      homeDir,
+      workspaceRoot: "/repo",
+    });
+    const chat = await gateway.build({
+      surface: "chat",
+      purpose: "general_turn",
+      homeDir,
+      workspaceRoot: "/repo",
+    });
+
+    const agentIdentity = agentLoop.staticSections.find((section) => section.key === "identity")?.content ?? "";
+    const chatIdentity = chat.staticSections.find((section) => section.key === "identity")?.content ?? "";
+    expect(agentIdentity).not.toContain("Prefer verbose status reports.");
+    expect(chatIdentity).toContain("Prefer verbose status reports.");
+  });
+
+  it("keeps raw USER.md out of fallback static system prompt", () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-static-user-md-"));
+    fs.writeFileSync(path.join(tmpRoot, "SEED.md"), "# Seedy\n\nAgent seed.", "utf-8");
+    fs.writeFileSync(path.join(tmpRoot, "ROOT.md"), "# Root\n\nRoot policy.", "utf-8");
+    fs.writeFileSync(path.join(tmpRoot, "USER.md"), "# About You\n\nPrefer verbose status reports.", "utf-8");
+
+    const prompt = buildStaticSystemPrompt(tmpRoot);
+
+    expect(prompt).toContain("Agent seed.");
+    expect(prompt).not.toContain("Prefer verbose status reports.");
   });
 
   it("prefers Soil knowledge over broader knowledge results when Soil hits exist", async () => {

--- a/src/grounding/providers/static-policy-provider.ts
+++ b/src/grounding/providers/static-policy-provider.ts
@@ -7,7 +7,7 @@ import {
 import type { GroundingProvider } from "../contracts.js";
 import { makeSection, makeSource, resolveStateManagerBaseDir } from "./helpers.js";
 
-export function buildIdentitySectionContent(baseDir?: string): string {
+export function buildIdentitySectionContent(baseDir?: string, options: { includeUserContent?: boolean } = {}): string {
   const identity = baseDir ? loadIdentityFromBaseDir(baseDir) : loadIdentity();
   const { name } = identity;
 
@@ -21,7 +21,7 @@ export function buildIdentitySectionContent(baseDir?: string): string {
     "Your role is to help the user make concrete progress by inspecting the workspace, using tools directly when appropriate, delegating work when useful, and executing the next valid step.",
     "",
     "### Persona And Customization",
-    getUserFacingIdentityForIdentity(identity).trim(),
+    getUserFacingIdentityForIdentity(identity, { includeUserContent: options.includeUserContent }).trim(),
   ].join("\n");
 }
 
@@ -70,7 +70,8 @@ export const identityProvider: GroundingProvider = {
   kind: "static",
   async build(context) {
     const baseDir = context.request.homeDir ?? resolveStateManagerBaseDir(context.deps.stateManager);
-    return makeSection("identity", buildIdentitySectionContent(baseDir), [
+    const includeUserContent = context.profile.surface === "chat";
+    return makeSection("identity", buildIdentitySectionContent(baseDir, { includeUserContent }), [
       makeSource("identity", "identity-loader", { type: "derived", trusted: true, accepted: true }),
     ]);
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,6 +267,14 @@ export type {
   RelationshipProfileChangeProposal,
   RelationshipProfileProposalStore,
 } from "./platform/profile/profile-change-proposal.js";
+export {
+  parseRelationshipProfileCandidatesFromUserMd,
+  createRelationshipProfileProposalsFromUserMdImport,
+} from "./platform/profile/user-md-profile-import.js";
+export type {
+  UserMdRelationshipProfileCandidate,
+  UserMdProfileImportProposalResult,
+} from "./platform/profile/user-md-profile-import.js";
 export { CuriosityEngine } from "./platform/traits/curiosity-engine.js";
 export { GoalDependencyGraph } from "./orchestrator/goal/goal-dependency-graph.js";
 export { KnowledgeGraph } from "./platform/knowledge/knowledge-graph.js";

--- a/src/interface/chat/grounding.ts
+++ b/src/interface/chat/grounding.ts
@@ -123,7 +123,7 @@ export async function buildChatAgentLoopSystemPrompt(options: GroundingOptions):
 
 export function buildStaticSystemPrompt(baseDir?: string): string {
   return [
-    `## Identity\n${buildIdentitySectionContent(baseDir)}`,
+    `## Identity\n${buildIdentitySectionContent(baseDir, { includeUserContent: false })}`,
     buildExecutionPolicySectionContent(),
     `## Safety And Approval\n${buildApprovalPolicySectionContent()}`,
   ].join("\n\n").trim();

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -8,9 +8,12 @@ import {
   saveProviderConfig,
   validateProviderConfig,
 } from "../../../base/llm/provider-config.js";
+import { buildLLMClient } from "../../../base/llm/provider-factory.js";
+import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import type { ProviderConfig } from "../../../base/llm/provider-config.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
 import { seedRelationshipProfileFromSetup } from "../../../platform/profile/relationship-profile.js";
+import { createRelationshipProfileProposalsFromUserMdImport } from "../../../platform/profile/user-md-profile-import.js";
 import { updateGlobalConfig } from "../../../base/config/global-config.js";
 import { readCodexOAuthToken } from "../../../base/llm/provider-config.js";
 import { isDaemonRunning } from "../../../runtime/daemon/client.js";
@@ -710,6 +713,22 @@ export async function runSetupWizard(): Promise<number> {
       userName: finalAnswers.userName,
       importedUserContent: finalAnswers.importedUserContent,
     });
+    if (finalAnswers.importedUserContent !== undefined) {
+      let importLlmClient: ILLMClient | undefined;
+      try {
+        importLlmClient = await buildLLMClient();
+      } catch (err) {
+        p.log.warn(`USER.md profile extraction will use review-only fallback: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      const proposalResult = await createRelationshipProfileProposalsFromUserMdImport({
+        baseDir: dir,
+        importedUserContent: finalAnswers.importedUserContent,
+        llmClient: importLlmClient,
+      });
+      if (proposalResult.proposals.length > 0) {
+        p.log.info(`Created ${proposalResult.proposals.length} relationship profile proposal(s) from imported USER.md.`);
+      }
+    }
   } catch (err) {
     p.log.warn(`Setup saved, but could not seed relationship profile: ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/src/platform/profile/__tests__/user-md-profile-import.test.ts
+++ b/src/platform/profile/__tests__/user-md-profile-import.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ZodSchema } from "zod";
+import type { ILLMClient, LLMMessage, LLMRequestOptions, LLMResponse } from "../../../base/llm/llm-client.js";
+import {
+  createRelationshipProfileProposalsFromUserMdImport,
+  extractRelationshipProfileCandidatesFromUserMd,
+  parseRelationshipProfileCandidatesFromUserMd,
+} from "../user-md-profile-import.js";
+import {
+  applyRelationshipProfileChangeProposal,
+  approveRelationshipProfileChangeProposal,
+  loadRelationshipProfileProposalStore,
+} from "../profile-change-proposal.js";
+import {
+  formatRelationshipProfilePromptBlock,
+  loadRelationshipProfile,
+  seedRelationshipProfileFromSetup,
+  upsertRelationshipProfileItem,
+} from "../relationship-profile.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-user-md-profile-import-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function structuredUserMd(): string {
+  return `# About You
+
+Freeform note: Prefer verbose status reports.
+
+\`\`\`json
+{
+  "relationship_profile_proposals": [
+    {
+      "stable_key": "user.preference.status",
+      "kind": "preference",
+      "value": "Prefer concise status reports.",
+      "confidence": 0.91,
+      "sensitivity": "private",
+      "allowed_scopes": ["local_planning", "memory_retrieval", "user_facing_review"],
+      "consent_scopes": ["user_facing_review"],
+      "evidence_refs": ["setup:USER.md#status"],
+      "rationale": "Explicit structured USER.md import candidate."
+    },
+    {
+      "stable_key": "user.boundary.health",
+      "kind": "boundary",
+      "value": "Do not use health context outside explicit review.",
+      "confidence": 0.66,
+      "sensitivity": "sensitive",
+      "allowed_scopes": ["user_facing_review"],
+      "consent_scopes": ["user_facing_review"],
+      "rationale": "Sensitive structured USER.md import candidate."
+    }
+  ]
+}
+\`\`\`
+`;
+}
+
+function makeMockLLMClient(response: string): ILLMClient & {
+  messages: LLMMessage[][];
+  options: Array<LLMRequestOptions | undefined>;
+} {
+  const messages: LLMMessage[][] = [];
+  const options: Array<LLMRequestOptions | undefined> = [];
+  return {
+    messages,
+    options,
+    async sendMessage(inputMessages, inputOptions): Promise<LLMResponse> {
+      messages.push(inputMessages);
+      options.push(inputOptions);
+      return {
+        content: response,
+        usage: { input_tokens: 10, output_tokens: response.length },
+        stop_reason: "end_turn",
+      };
+    },
+    parseJSON<T>(content: string, schema: ZodSchema<T>): T {
+      return schema.parse(JSON.parse(content));
+    },
+  };
+}
+
+describe("USER.md relationship profile proposal import", () => {
+  it("parses structured USER.md candidates without classifying freeform text", () => {
+    const parsed = parseRelationshipProfileCandidatesFromUserMd(structuredUserMd());
+
+    expect(parsed.skipped_blocks).toEqual([]);
+    expect(parsed.candidates.map((candidate) => candidate.stable_key)).toEqual([
+      "user.preference.status",
+      "user.boundary.health",
+    ]);
+    expect(parsed.candidates[0]?.value).toBe("Prefer concise status reports.");
+    expect(parsed.candidates.some((candidate) => candidate.value === "Prefer verbose status reports.")).toBe(false);
+  });
+
+  it("turns unstructured USER.md into a review-only life-context proposal without semantic classification", () => {
+    const parsed = parseRelationshipProfileCandidatesFromUserMd("# About You\n\nPrefer concise status reports.\n");
+
+    expect(parsed.candidates).toHaveLength(0);
+  });
+
+  it("extracts structured candidates from ordinary imported USER.md content through the classifier contract", async () => {
+    const llmClient = makeMockLLMClient(JSON.stringify({
+      candidates: [
+        {
+          operation: "upsert_item",
+          stable_key: "user.preference.status_reports",
+          kind: "preference",
+          value: "Prefer concise status reports.",
+          confidence: 0.88,
+          sensitivity: "private",
+          allowed_scopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+          consent_scopes: ["user_facing_review"],
+          evidence_refs: ["setup:USER.md#preference-status-reports"],
+          rationale: "The USER.md content directly states the status report preference.",
+        },
+      ],
+    }));
+
+    const result = await extractRelationshipProfileCandidatesFromUserMd({
+      markdown: "# About You\n\nPrefer concise status reports.\n",
+      llmClient,
+    });
+
+    expect(result.extraction_source).toBe("classifier");
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]).toMatchObject({
+      stable_key: "user.preference.status_reports",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      allowed_scopes: ["local_planning", "memory_retrieval", "user_facing_review"],
+      consent_scopes: ["user_facing_review"],
+    });
+    expect(llmClient.messages[0]?.[0]?.content).toContain("Prefer concise status reports.");
+    expect(llmClient.options[0]).toMatchObject({ model_tier: "light", temperature: 0 });
+  });
+
+  it("falls back to a review-only life-context proposal when ordinary USER.md extraction is unavailable", async () => {
+    const baseDir = makeTempDir();
+    const result = await createRelationshipProfileProposalsFromUserMdImport({
+      baseDir,
+      importedUserContent: "# About You\n\nPrefer concise status reports.\n",
+      now: "2026-05-03T00:00:00.000Z",
+    });
+
+    expect(result.proposals).toHaveLength(1);
+    expect(result.extraction_source).toBe("review_only_fallback");
+    expect(result.proposals[0]).toMatchObject({
+      approval_state: "pending",
+      source: "setup_import",
+      proposed_item: {
+        stable_key: "user.imported_user_md.review",
+        kind: "life_context",
+        allowed_scopes: ["user_facing_review"],
+      },
+    });
+  });
+
+  it("creates approval-required proposals while keeping raw USER.md review-only", async () => {
+    const baseDir = makeTempDir();
+    const importedUserContent = structuredUserMd();
+
+    await seedRelationshipProfileFromSetup({
+      baseDir,
+      userName: "Imported USER.md",
+      importedUserContent,
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    const result = await createRelationshipProfileProposalsFromUserMdImport({
+      baseDir,
+      importedUserContent,
+      now: "2026-05-03T00:01:00.000Z",
+    });
+
+    expect(result.proposals).toHaveLength(2);
+    expect(result.proposals.map((proposal) => proposal.approval_state)).toEqual(["pending", "pending"]);
+    expect(result.proposals[1]?.sensitivity).toBe("sensitive");
+    expect(result.proposals[1]?.consent_scopes).toEqual(["user_facing_review"]);
+
+    const profile = await loadRelationshipProfile(baseDir);
+    expect(profile.items.find((item) => item.stable_key === "user.imported_user_md")?.allowed_scopes).toEqual([
+      "user_facing_review",
+    ]);
+    expect(formatRelationshipProfilePromptBlock(profile, "local_planning")).not.toContain("Prefer verbose status reports.");
+    expect(formatRelationshipProfilePromptBlock(profile, "memory_retrieval")).not.toContain("Prefer concise status reports.");
+  });
+
+  it("applies approved USER.md proposals through the shared proposal approval path", async () => {
+    const baseDir = makeTempDir();
+    const result = await createRelationshipProfileProposalsFromUserMdImport({
+      baseDir,
+      importedUserContent: structuredUserMd(),
+      now: "2026-05-03T00:00:00.000Z",
+    });
+
+    await approveRelationshipProfileChangeProposal(baseDir, result.proposals[0]!.id, {
+      now: "2026-05-03T00:01:00.000Z",
+    });
+    await applyRelationshipProfileChangeProposal(baseDir, result.proposals[0]!.id, {
+      now: "2026-05-03T00:02:00.000Z",
+    });
+
+    const profile = await loadRelationshipProfile(baseDir);
+    expect(formatRelationshipProfilePromptBlock(profile, "memory_retrieval")).toContain("Prefer concise status reports.");
+    expect(profile.audit_events.at(-1)?.proposal_id).toBe(result.proposals[0]!.id);
+  });
+
+  it("does not let stale raw imported text bypass a structured profile correction", async () => {
+    const baseDir = makeTempDir();
+    await seedRelationshipProfileFromSetup({
+      baseDir,
+      userName: "Imported USER.md",
+      importedUserContent: structuredUserMd(),
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    await createRelationshipProfileProposalsFromUserMdImport({
+      baseDir,
+      importedUserContent: structuredUserMd(),
+      now: "2026-05-03T00:01:00.000Z",
+    });
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer terse status reports.",
+      source: "user_correction",
+      allowedScopes: ["local_planning", "memory_retrieval"],
+      now: "2026-05-03T00:02:00.000Z",
+    });
+
+    const profile = await loadRelationshipProfile(baseDir);
+    const proposals = await loadRelationshipProfileProposalStore(baseDir);
+    const planningBlock = formatRelationshipProfilePromptBlock(profile, "local_planning");
+    const retrievalBlock = formatRelationshipProfilePromptBlock(profile, "memory_retrieval");
+
+    expect(proposals.proposals).toHaveLength(2);
+    expect(proposals.proposals.every((proposal) => proposal.approval_state === "pending")).toBe(true);
+    expect(planningBlock).toContain("Prefer terse status reports.");
+    expect(retrievalBlock).toContain("Prefer terse status reports.");
+    expect(planningBlock).not.toContain("Prefer verbose status reports.");
+    expect(retrievalBlock).not.toContain("Prefer concise status reports.");
+  });
+
+  it("rejects applying stale setup import proposals after a newer structured correction", async () => {
+    const baseDir = makeTempDir();
+    const result = await createRelationshipProfileProposalsFromUserMdImport({
+      baseDir,
+      importedUserContent: structuredUserMd(),
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer terse status reports.",
+      source: "user_correction",
+      allowedScopes: ["local_planning", "memory_retrieval"],
+      now: "2026-05-03T00:01:00.000Z",
+    });
+    await approveRelationshipProfileChangeProposal(baseDir, result.proposals[0]!.id, {
+      now: "2026-05-03T00:02:00.000Z",
+    });
+
+    await expect(applyRelationshipProfileChangeProposal(baseDir, result.proposals[0]!.id, {
+      now: "2026-05-03T00:03:00.000Z",
+    })).rejects.toThrow("stale setup import proposal");
+    const profile = await loadRelationshipProfile(baseDir);
+    expect(formatRelationshipProfilePromptBlock(profile, "memory_retrieval")).toContain("Prefer terse status reports.");
+    expect(formatRelationshipProfilePromptBlock(profile, "memory_retrieval")).not.toContain("Prefer concise status reports.");
+  });
+});

--- a/src/platform/profile/profile-change-proposal.ts
+++ b/src/platform/profile/profile-change-proposal.ts
@@ -381,6 +381,16 @@ export async function applyRelationshipProfileChangeProposal(
   if (proposal.approval_state !== "approved") {
     throw new Error(`only approved proposals can be applied: ${proposalId}`);
   }
+  if (proposal.source === "setup_import") {
+    const newerActiveItem = profileStore.items.find((item) =>
+      item.stable_key === proposal.proposed_item.stable_key &&
+      item.status === "active" &&
+      item.created_at > proposal.created_at
+    );
+    if (newerActiveItem) {
+      throw new Error(`stale setup import proposal cannot overwrite newer active profile item: ${proposal.id}`);
+    }
+  }
   let profileResult;
   if (proposal.operation === "upsert_item") {
     const kind = proposal.proposed_item.kind;

--- a/src/platform/profile/user-md-profile-import.ts
+++ b/src/platform/profile/user-md-profile-import.ts
@@ -1,0 +1,223 @@
+import { z } from "zod";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+import {
+  createRelationshipProfileChangeProposal,
+  RelationshipProfileProposalOperationSchema,
+  type RelationshipProfileChangeProposal,
+} from "./profile-change-proposal.js";
+import {
+  RelationshipProfileConsentScopeSchema,
+  RelationshipProfileItemKindSchema,
+  RelationshipProfileSensitivitySchema,
+} from "./relationship-profile.js";
+
+const UserMdRelationshipProfileCandidateSchema = z.object({
+  operation: RelationshipProfileProposalOperationSchema.default("upsert_item"),
+  stable_key: z.string().min(1),
+  kind: RelationshipProfileItemKindSchema,
+  value: z.string().min(1),
+  confidence: z.number().min(0).max(1).default(0.7),
+  sensitivity: RelationshipProfileSensitivitySchema.default("private"),
+  allowed_scopes: z.array(RelationshipProfileConsentScopeSchema).min(1).default(["user_facing_review"]),
+  consent_scopes: z.array(RelationshipProfileConsentScopeSchema).min(1).default(["user_facing_review"]),
+  evidence_refs: z.array(z.string().min(1)).default([]),
+  rationale: z.string().min(1),
+});
+
+const UserMdRelationshipProfileBlockSchema = z.object({
+  relationship_profile_proposals: z.array(UserMdRelationshipProfileCandidateSchema).default([]),
+});
+
+const UserMdExtractionSchema = z.object({
+  candidates: z.array(UserMdRelationshipProfileCandidateSchema).default([]),
+});
+
+export type UserMdRelationshipProfileCandidate = z.infer<typeof UserMdRelationshipProfileCandidateSchema>;
+
+export interface UserMdProfileImportProposalResult {
+  proposals: RelationshipProfileChangeProposal[];
+  candidate_count: number;
+  skipped_blocks: Array<{ index: number; reason: string }>;
+  extraction_source: "structured_block" | "classifier" | "review_only_fallback";
+}
+
+const USER_MD_PROFILE_EXTRACTION_SYSTEM = `Extract relationship-profile proposal candidates from imported USER.md content.
+
+Return JSON only:
+{
+  "candidates": [
+    {
+      "operation": "upsert_item",
+      "stable_key": "user.preference.status_reports",
+      "kind": "preference" | "boundary" | "value" | "communication_style" | "long_term_goal" | "life_context" | "intervention_policy",
+      "value": "one durable profile statement",
+      "confidence": 0.0-1.0,
+      "sensitivity": "public" | "private" | "sensitive",
+      "allowed_scopes": ["local_planning" | "resident_behavior" | "memory_retrieval" | "user_facing_review"],
+      "consent_scopes": ["user_facing_review"],
+      "evidence_refs": ["setup:USER.md"],
+      "rationale": "why this candidate follows from the USER.md text"
+    }
+  ]
+}
+
+Rules:
+- Produce typed candidates only when the USER.md text directly supports them.
+- Keep uncertain or sensitive candidates approval-required by using consent_scopes ["user_facing_review"].
+- Do not invent private facts, medical facts, legal facts, secrets, identities, or operational permissions.
+- Prefer stable_key values under user.preference.*, user.boundary.*, user.value.*, user.communication_style.*, user.long_term_goal.*, user.life_context.*, or user.intervention_policy.*.
+- If no durable relationship-profile item is supported, return {"candidates":[]}.`;
+
+function extractJsonCodeBlocks(markdown: string): string[] {
+  const blocks: string[] = [];
+  const lines = markdown.split(/\r?\n/);
+  let inJsonBlock = false;
+  let current: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!inJsonBlock && trimmed.startsWith("```")) {
+      const info = trimmed.slice(3).trim().toLowerCase();
+      inJsonBlock = info === "json" || info === "relationship_profile";
+      current = [];
+      continue;
+    }
+    if (inJsonBlock && trimmed === "```") {
+      blocks.push(current.join("\n"));
+      inJsonBlock = false;
+      current = [];
+      continue;
+    }
+    if (inJsonBlock) {
+      current.push(line);
+    }
+  }
+  return blocks;
+}
+
+function buildReviewOnlyFallbackCandidate(markdown: string): UserMdRelationshipProfileCandidate {
+  return UserMdRelationshipProfileCandidateSchema.parse({
+    operation: "upsert_item",
+    stable_key: "user.imported_user_md.review",
+    kind: "life_context",
+    value: markdown.trim(),
+    confidence: 0.45,
+    sensitivity: "private",
+    allowed_scopes: ["user_facing_review"],
+    consent_scopes: ["user_facing_review"],
+    evidence_refs: ["setup:USER.md"],
+    rationale: "Imported USER.md contained unstructured content. It is kept as a review-only relationship profile proposal until an operator approves or refines it.",
+  });
+}
+
+export function parseRelationshipProfileCandidatesFromUserMd(markdown: string): {
+  candidates: UserMdRelationshipProfileCandidate[];
+  skipped_blocks: Array<{ index: number; reason: string }>;
+} {
+  const candidates: UserMdRelationshipProfileCandidate[] = [];
+  const skipped_blocks: Array<{ index: number; reason: string }> = [];
+  const blocks = extractJsonCodeBlocks(markdown);
+  blocks.forEach((block, index) => {
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(block);
+    } catch {
+      skipped_blocks.push({ index, reason: "invalid JSON relationship profile import block" });
+      return;
+    }
+    const parsed = UserMdRelationshipProfileBlockSchema.safeParse(parsedJson);
+    if (!parsed.success) {
+      skipped_blocks.push({ index, reason: "JSON block does not match relationship_profile_proposals schema" });
+      return;
+    }
+    candidates.push(...parsed.data.relationship_profile_proposals);
+  });
+  return { candidates, skipped_blocks };
+}
+
+export async function extractRelationshipProfileCandidatesFromUserMd(params: {
+  markdown: string;
+  llmClient?: ILLMClient;
+}): Promise<{
+  candidates: UserMdRelationshipProfileCandidate[];
+  skipped_blocks: Array<{ index: number; reason: string }>;
+  extraction_source: UserMdProfileImportProposalResult["extraction_source"];
+}> {
+  const parsed = parseRelationshipProfileCandidatesFromUserMd(params.markdown);
+  if (parsed.candidates.length > 0 || params.markdown.trim().length === 0) {
+    return {
+      candidates: parsed.candidates,
+      skipped_blocks: parsed.skipped_blocks,
+      extraction_source: "structured_block",
+    };
+  }
+
+  if (params.llmClient) {
+    try {
+      const response = await params.llmClient.sendMessage(
+        [{ role: "user", content: params.markdown }],
+        {
+          system: USER_MD_PROFILE_EXTRACTION_SYSTEM,
+          max_tokens: 1400,
+          temperature: 0,
+          model_tier: "light",
+        }
+      );
+      const extraction = params.llmClient.parseJSON(response.content, UserMdExtractionSchema);
+      const extractedCandidates = z.array(UserMdRelationshipProfileCandidateSchema).parse(extraction.candidates ?? []);
+      if (extractedCandidates.length > 0) {
+        return {
+          candidates: extractedCandidates,
+          skipped_blocks: parsed.skipped_blocks,
+          extraction_source: "classifier",
+        };
+      }
+    } catch {
+      // Fall through to the explicit review-only proposal. Setup should remain usable
+      // even when the configured model is unavailable during import.
+    }
+  }
+
+  return {
+    candidates: [buildReviewOnlyFallbackCandidate(params.markdown)],
+    skipped_blocks: parsed.skipped_blocks,
+    extraction_source: "review_only_fallback",
+  };
+}
+
+export async function createRelationshipProfileProposalsFromUserMdImport(params: {
+  baseDir: string;
+  importedUserContent: string;
+  llmClient?: ILLMClient;
+  now?: string;
+}): Promise<UserMdProfileImportProposalResult> {
+  const parsed = await extractRelationshipProfileCandidatesFromUserMd({
+    markdown: params.importedUserContent,
+    llmClient: params.llmClient,
+  });
+  const proposals: RelationshipProfileChangeProposal[] = [];
+  for (const [index, candidate] of parsed.candidates.entries()) {
+    const result = await createRelationshipProfileChangeProposal(params.baseDir, {
+      operation: candidate.operation,
+      stableKey: candidate.stable_key,
+      kind: candidate.kind,
+      value: candidate.value,
+      source: "setup_import",
+      confidence: candidate.confidence,
+      sensitivity: candidate.sensitivity,
+      consentScopes: candidate.consent_scopes,
+      allowedScopes: candidate.allowed_scopes,
+      evidenceRefs: candidate.evidence_refs.length > 0
+        ? candidate.evidence_refs
+        : [`setup:USER.md#relationship_profile_proposals[${index}]`],
+      rationale: candidate.rationale,
+      now: params.now,
+    });
+    proposals.push(result.proposal);
+  }
+  return {
+    proposals,
+    candidate_count: parsed.candidates.length,
+    skipped_blocks: parsed.skipped_blocks,
+    extraction_source: parsed.extraction_source,
+  };
+}


### PR DESCRIPTION
Closes #931
Refs #896

## Summary
- add USER.md relationship profile proposal import for explicit structured blocks and ordinary USER.md content through a typed structured extraction contract
- wire setup import to create pending #927 proposals instead of active profile mutations
- keep raw USER.md compatibility while excluding raw USER.md from agent/core/static fallback grounding
- prevent stale setup-import proposals from overwriting newer structured profile corrections

## Verification
- `npm run typecheck`
- `npx vitest run src/platform/profile/__tests__/user-md-profile-import.test.ts src/platform/profile/__tests__/profile-change-proposal.test.ts src/platform/profile/__tests__/relationship-profile.test.ts src/grounding/__tests__/gateway.test.ts`
- `npm run lint:boundaries` (passes with pre-existing warnings)
- `npm run test:changed`
- `git diff --check`
- review agent re-review: no material findings

## Known unresolved risks
- `npm run lint:boundaries` still reports repo-wide pre-existing warnings, no lint errors.
- If the configured model is unavailable during setup import, ordinary USER.md content falls back to a review-only life_context proposal rather than blocking setup.