### PR TITLE
feat(profile): wire memory retrieval profile context

### DIFF
--- a/src/grounding/__tests__/gateway.test.ts
+++ b/src/grounding/__tests__/gateway.test.ts
@@ -4,6 +4,10 @@ import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { StateManager } from "../../base/state/state-manager.js";
 import { SqliteSoilRepository } from "../../platform/soil/sqlite-repository.js";
+import {
+  retractRelationshipProfileItem,
+  upsertRelationshipProfileItem,
+} from "../../platform/profile/relationship-profile.js";
 import { buildStaticSystemPrompt } from "../../interface/chat/grounding.js";
 import { createGroundingGateway } from "../gateway.js";
 
@@ -145,6 +149,151 @@ describe("GroundingGateway", () => {
     expect(bundle.dynamicSections.some((section) => section.key === "soil_knowledge")).toBe(true);
     expect(bundle.dynamicSections.some((section) => section.key === "knowledge_query")).toBe(false);
     expect(knowledgeQuery).not.toHaveBeenCalled();
+  });
+
+  it("passes active memory-retrieval relationship profile context to production knowledge grounding", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-grounding-profile-memory-"));
+    const homeDir = path.join(tmpRoot, "home");
+    fs.mkdirSync(homeDir, { recursive: true });
+    await upsertRelationshipProfileItem(homeDir, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer detailed status reports.",
+      source: "cli_update",
+      allowedScopes: ["memory_retrieval", "user_facing_review"],
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    await upsertRelationshipProfileItem(homeDir, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "cli_update",
+      allowedScopes: ["memory_retrieval", "user_facing_review"],
+      now: "2026-05-03T00:01:00.000Z",
+    });
+    const knowledgeQuery = vi.fn().mockResolvedValue({
+      retrievalId: "knowledge:profile-context",
+      items: [{ id: "k1", content: "Knowledge result", source: "test" }],
+    });
+
+    const gateway = createGroundingGateway({ stateManager: makeStateManager({ getBaseDir: vi.fn().mockReturnValue(homeDir) }) });
+    await gateway.build({
+      surface: "agent_loop",
+      purpose: "task_execution",
+      homeDir,
+      workspaceRoot: "/repo",
+      userMessage: "Find relevant memory",
+      query: "Find relevant memory",
+      knowledgeQuery,
+    });
+
+    expect(knowledgeQuery).toHaveBeenCalledTimes(1);
+    const profileContext = knowledgeQuery.mock.calls[0]?.[0]?.relationshipProfileContext;
+    expect(profileContext).toMatchObject({
+      scope: "memory_retrieval",
+      includeSensitive: false,
+    });
+    expect((profileContext?.items as Array<{ value: string }> | undefined)?.map((item) => item.value)).toEqual(["Prefer concise status reports."]);
+    expect((profileContext?.items as Array<{ status: string }> | undefined)?.map((item) => item.status)).toEqual(["active"]);
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("attaches typed relationship profile context to prefetched knowledge grounding", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-grounding-prefetched-profile-"));
+    const homeDir = path.join(tmpRoot, "home");
+    fs.mkdirSync(homeDir, { recursive: true });
+    await upsertRelationshipProfileItem(homeDir, {
+      stableKey: "user.preference.status",
+      kind: "preference",
+      value: "Prefer concise status reports.",
+      source: "cli_update",
+      allowedScopes: ["memory_retrieval", "user_facing_review"],
+      now: "2026-05-03T00:00:00.000Z",
+    });
+
+    const gateway = createGroundingGateway({ stateManager: makeStateManager({ getBaseDir: vi.fn().mockReturnValue(homeDir) }) });
+    const bundle = await gateway.build({
+      surface: "agent_loop",
+      purpose: "task_execution",
+      homeDir,
+      workspaceRoot: "/repo",
+      userMessage: "Find relevant memory",
+      query: "Find relevant memory",
+      knowledgeContext: "Prefetched knowledge",
+    });
+
+    const knowledgeSource = bundle.traces.source.find((source) => source.sectionKey === "knowledge_query");
+    const profileContext = knowledgeSource?.metadata?.["relationshipProfileContext"] as { items?: Array<{ value: string }> } | undefined;
+    expect(profileContext?.items?.map((item) => item.value)).toEqual(["Prefer concise status reports."]);
+    const knowledgeSection = bundle.dynamicSections.find((section) => section.key === "knowledge_query");
+    expect(knowledgeSection?.content).toContain("Relationship profile retrieval context");
+    expect(knowledgeSection?.content).toContain("Prefer concise status reports.");
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("excludes retracted and sensitive relationship profile items from lower-trust memory retrieval", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-grounding-profile-sensitive-"));
+    const homeDir = path.join(tmpRoot, "home");
+    fs.mkdirSync(homeDir, { recursive: true });
+    await upsertRelationshipProfileItem(homeDir, {
+      stableKey: "user.preference.editor",
+      kind: "preference",
+      value: "Prefer VS Code.",
+      source: "cli_update",
+      allowedScopes: ["memory_retrieval", "user_facing_review"],
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    await retractRelationshipProfileItem(homeDir, {
+      stableKey: "user.preference.editor",
+      reason: "No longer current.",
+      now: "2026-05-03T00:01:00.000Z",
+    });
+    await upsertRelationshipProfileItem(homeDir, {
+      stableKey: "user.boundary.health",
+      kind: "boundary",
+      value: "Do not retrieve health context unless explicitly allowed.",
+      source: "cli_update",
+      sensitivity: "sensitive",
+      allowedScopes: ["memory_retrieval", "user_facing_review"],
+      now: "2026-05-03T00:02:00.000Z",
+    });
+    const knowledgeQuery = vi.fn().mockResolvedValue({
+      retrievalId: "knowledge:profile-context",
+      items: [{ id: "k1", content: "Knowledge result", source: "test" }],
+    });
+    const gateway = createGroundingGateway({ stateManager: makeStateManager({ getBaseDir: vi.fn().mockReturnValue(homeDir) }) });
+
+    await gateway.build({
+      surface: "agent_loop",
+      purpose: "task_execution",
+      homeDir,
+      workspaceRoot: "/repo",
+      userMessage: "Find relevant memory",
+      query: "Find relevant memory",
+      knowledgeQuery,
+    });
+    await gateway.build({
+      surface: "agent_loop",
+      purpose: "task_execution",
+      homeDir,
+      workspaceRoot: "/repo",
+      userMessage: "Find relevant memory",
+      query: "Find relevant memory",
+      relationshipProfileRetrieval: { includeSensitive: true },
+      knowledgeQuery,
+    });
+
+    expect(knowledgeQuery.mock.calls[0]?.[0]?.relationshipProfileContext?.items).toEqual([]);
+    expect(knowledgeQuery.mock.calls[1]?.[0]?.relationshipProfileContext).toMatchObject({
+      includeSensitive: true,
+    });
+    expect((knowledgeQuery.mock.calls[1]?.[0]?.relationshipProfileContext?.items as Array<{ value: string }> | undefined)?.map((item) => item.value)).toEqual([
+      "Do not retrieve health context unless explicitly allowed.",
+    ]);
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
   it("records usage for admitted SQLite Soil grounding hits and preserves usage stats in context", async () => {

--- a/src/grounding/contracts.ts
+++ b/src/grounding/contracts.ts
@@ -1,4 +1,5 @@
 import type { StateManager } from "../base/state/state-manager.js";
+import type { RelationshipProfileRetrievalContext } from "../platform/profile/retrieval-context.js";
 
 export type GroundingSurface = "chat" | "agent_loop" | "core_loop";
 
@@ -168,11 +169,20 @@ export interface GroundingRequest {
   trustProjectInstructions?: boolean;
   workspaceContext?: string;
   knowledgeContext?: string;
+  relationshipProfileContext?: RelationshipProfileRetrievalContext;
   recentMessages?: GroundingMessage[];
   compactionSummary?: string;
   soilQuery?: (input: { query: string; rootDir: string; limit: number }) => Promise<GroundingSoilResult | null>;
-  knowledgeQuery?: (input: { query: string; goalId?: string; limit: number }) => Promise<GroundingKnowledgeResult | null>;
+  knowledgeQuery?: (input: {
+    query: string;
+    goalId?: string;
+    limit: number;
+    relationshipProfileContext?: RelationshipProfileRetrievalContext;
+  }) => Promise<GroundingKnowledgeResult | null>;
   lessonsQuery?: (input: { query: string; goalId?: string; limit: number }) => Promise<GroundingLessonResult | null>;
+  relationshipProfileRetrieval?: {
+    includeSensitive?: boolean;
+  };
 }
 
 export interface GroundingGatewayDeps {

--- a/src/grounding/providers/knowledge-provider.ts
+++ b/src/grounding/providers/knowledge-provider.ts
@@ -1,5 +1,20 @@
-import type { GroundingKnowledgeResult, GroundingProvider } from "../contracts.js";
-import { makeSection, makeSource } from "./helpers.js";
+import { loadRelationshipProfileRetrievalContext } from "../../platform/profile/retrieval-context.js";
+import { formatRelationshipProfileRetrievalContext } from "../../platform/profile/retrieval-context.js";
+import type {
+  GroundingKnowledgeResult,
+  GroundingProvider,
+} from "../contracts.js";
+import { makeSection, makeSource, resolveHomeDir, resolveStateManagerBaseDir } from "./helpers.js";
+
+async function buildRelationshipProfileRetrievalContext(
+  context: Parameters<GroundingProvider["build"]>[0]
+): ReturnType<typeof loadRelationshipProfileRetrievalContext> {
+  const baseDir = resolveHomeDir(context.request.homeDir ?? resolveStateManagerBaseDir(context.deps.stateManager));
+  return loadRelationshipProfileRetrievalContext({
+    baseDir,
+    includeSensitive: context.request.relationshipProfileRetrieval?.includeSensitive,
+  });
+}
 
 export const knowledgeQueryProvider: GroundingProvider = {
   key: "knowledge_query",
@@ -15,9 +30,14 @@ export const knowledgeQueryProvider: GroundingProvider = {
     }
 
     let result: GroundingKnowledgeResult | null = null;
+    const relationshipProfileContext = context.request.relationshipProfileContext
+      ?? await buildRelationshipProfileRetrievalContext(context);
     if (context.request.knowledgeContext?.trim()) {
       result = {
         retrievalId: "knowledge:prefetched",
+        warnings: relationshipProfileContext.items.length > 0
+          ? [`relationship_profile_context_items:${relationshipProfileContext.items.length}`]
+          : undefined,
         items: [
           {
             id: "knowledge:prefetched",
@@ -31,15 +51,20 @@ export const knowledgeQueryProvider: GroundingProvider = {
         query,
         goalId: context.request.goalId,
         limit: context.profile.budgets.maxKnowledgeHits,
+        relationshipProfileContext,
       });
     }
 
     const items = result?.items ?? [];
     context.runtime.set("knowledge_hit_count", items.length);
+    const relationshipProfileBlock = formatRelationshipProfileRetrievalContext(relationshipProfileContext);
     return makeSection(
       "knowledge_query",
       items.length > 0
-        ? items.slice(0, context.profile.budgets.maxKnowledgeHits).map((item) => `- ${item.content}`).join("\n")
+        ? [
+          relationshipProfileBlock,
+          items.slice(0, context.profile.budgets.maxKnowledgeHits).map((item) => `- ${item.content}`).join("\n"),
+        ].filter((part) => part.trim().length > 0).join("\n\n")
         : "No broader knowledge results.",
       [
         makeSource("knowledge_query", "knowledge query", {
@@ -47,7 +72,10 @@ export const knowledgeQueryProvider: GroundingProvider = {
           trusted: true,
           accepted: true,
           retrievalId: items.length > 0 ? result?.retrievalId ?? "knowledge:query" : "none:knowledge_query",
-          metadata: result?.warnings ? { warnings: result.warnings } : undefined,
+          metadata: {
+            ...(result?.warnings ? { warnings: result.warnings } : {}),
+            relationshipProfileContext,
+          },
         }),
       ],
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,6 +275,13 @@ export type {
   UserMdRelationshipProfileCandidate,
   UserMdProfileImportProposalResult,
 } from "./platform/profile/user-md-profile-import.js";
+export {
+  loadRelationshipProfileRetrievalContext,
+  formatRelationshipProfileRetrievalContext,
+} from "./platform/profile/retrieval-context.js";
+export type {
+  RelationshipProfileRetrievalContext,
+} from "./platform/profile/retrieval-context.js";
 export { CuriosityEngine } from "./platform/traits/curiosity-engine.js";
 export { GoalDependencyGraph } from "./orchestrator/goal/goal-dependency-graph.js";
 export { KnowledgeGraph } from "./platform/knowledge/knowledge-graph.js";

--- a/src/orchestrator/execution/agent-loop/agent-loop-context-assembler.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-context-assembler.ts
@@ -3,6 +3,7 @@ import type { Task } from "../../../base/types/task.js";
 import { createGroundingGateway, type GroundingGateway } from "../../../grounding/gateway.js";
 import { discoverAgentInstructionCandidates } from "../../../grounding/providers/agents-provider.js";
 import type { GroundingSection } from "../../../grounding/contracts.js";
+import type { RelationshipProfileRetrievalContext } from "../../../platform/profile/retrieval-context.js";
 import { renderPromptSections } from "../../../grounding/renderers/prompt-renderer.js";
 
 export interface AgentLoopContextBlock {
@@ -30,6 +31,7 @@ export interface TaskAgentLoopAssemblyInput {
   cwd?: string;
   workspaceContext?: string;
   knowledgeContext?: string;
+  relationshipProfileContext?: RelationshipProfileRetrievalContext;
   soilPrefetch?: (query: SoilPrefetchQuery) => Promise<SoilPrefetchResult | null>;
   maxProjectDocChars?: number;
   trustProjectInstructions?: boolean;
@@ -97,6 +99,7 @@ export class AgentLoopContextAssembler {
       trustProjectInstructions: input.trustProjectInstructions ?? true,
       workspaceContext: input.workspaceContext,
       knowledgeContext: input.knowledgeContext,
+      relationshipProfileContext: input.relationshipProfileContext,
       soilQuery,
       include: {
         session_history: false,

--- a/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-integrations.test.ts
@@ -32,6 +32,10 @@ import type { CompletionJudgment } from "../../../base/types/satisficing.js";
 import type { StallReport } from "../../../base/types/stall.js";
 import type { DriveScore } from "../../../base/types/drive.js";
 import { saveDreamConfig } from "../../../platform/dream/dream-config.js";
+import {
+  retractRelationshipProfileItem,
+  upsertRelationshipProfileItem,
+} from "../../../platform/profile/relationship-profile.js";
 import { SessionManager } from "../../execution/session-manager.js";
 import { TrustManager } from "../../../platform/traits/trust-manager.js";
 import { ReportingEngine as RealReportingEngine } from "../../../reporting/reporting-engine.js";
@@ -997,10 +1001,112 @@ describe("CoreLoop", async () => {
       const loop = new CoreLoop(depsWithKM, { delayBetweenLoopsMs: 0 });
       await loop.runOneIteration("goal-1", 0);
 
-      expect(knowledgeManager.getRelevantKnowledge).toHaveBeenCalledWith("goal-1", expect.any(String));
+      expect(knowledgeManager.getRelevantKnowledge).toHaveBeenCalledWith(
+        "goal-1",
+        expect.any(String),
+        expect.objectContaining({
+          relationshipProfileContext: expect.objectContaining({ scope: "memory_retrieval" }),
+        })
+      );
       // runTaskCycle should receive knowledgeContext as the 5th argument
       const callArgs = mocks.taskLifecycle.runTaskCycle.mock.calls[0];
       expect(callArgs![4]).toContain("JWT tokens");
+    });
+
+    it("passes active memory-retrieval relationship profile context through production task-cycle recall", async () => {
+      const { deps, mocks } = createMockDeps(tmpDir);
+      await mocks.stateManager.saveGoal(makeGoal());
+      await saveDreamConfig({
+        activation: {
+          verifiedPlannerHintsOnly: false,
+          semanticWorkingMemory: false,
+          crossGoalLessons: false,
+          semanticContext: true,
+          autoAcquireKnowledge: false,
+          learnedPatternHints: false,
+          playbookHints: false,
+          workflowHints: false,
+          strategyTemplates: false,
+          decisionHeuristics: false,
+          graphTraversal: false,
+        },
+      }, mocks.stateManager.getBaseDir());
+      await upsertRelationshipProfileItem(mocks.stateManager.getBaseDir(), {
+        stableKey: "user.preference.status",
+        kind: "preference",
+        value: "Prefer verbose status reports.",
+        source: "cli_update",
+        allowedScopes: ["memory_retrieval", "user_facing_review"],
+        now: "2026-05-03T00:00:00.000Z",
+      });
+      await upsertRelationshipProfileItem(mocks.stateManager.getBaseDir(), {
+        stableKey: "user.preference.status",
+        kind: "preference",
+        value: "Prefer concise status reports.",
+        source: "cli_update",
+        allowedScopes: ["memory_retrieval", "user_facing_review"],
+        now: "2026-05-03T00:01:00.000Z",
+      });
+      await upsertRelationshipProfileItem(mocks.stateManager.getBaseDir(), {
+        stableKey: "user.boundary.health",
+        kind: "boundary",
+        value: "Do not retrieve health context unless explicitly allowed.",
+        source: "cli_update",
+        sensitivity: "sensitive",
+        allowedScopes: ["memory_retrieval", "user_facing_review"],
+        now: "2026-05-03T00:02:00.000Z",
+      });
+      await upsertRelationshipProfileItem(mocks.stateManager.getBaseDir(), {
+        stableKey: "user.preference.editor",
+        kind: "preference",
+        value: "Prefer VS Code.",
+        source: "cli_update",
+        allowedScopes: ["memory_retrieval", "user_facing_review"],
+        now: "2026-05-03T00:03:00.000Z",
+      });
+      await retractRelationshipProfileItem(mocks.stateManager.getBaseDir(), {
+        stableKey: "user.preference.editor",
+        reason: "No longer current.",
+        now: "2026-05-03T00:04:00.000Z",
+      });
+
+      const knowledgeManager = {
+        detectKnowledgeGap: vi.fn().mockResolvedValue(null),
+        generateAcquisitionTask: vi.fn(),
+        getRelevantKnowledge: vi.fn().mockResolvedValue([]),
+        searchKnowledge: vi.fn().mockResolvedValue([]),
+        saveKnowledge: vi.fn(),
+        loadKnowledge: vi.fn().mockResolvedValue([]),
+        checkContradiction: vi.fn(),
+      };
+
+      const loop = new CoreLoop({ ...deps, knowledgeManager: knowledgeManager as any }, { delayBetweenLoopsMs: 0 });
+      await loop.runOneIteration("goal-1", 0);
+
+      const semanticQuery = knowledgeManager.searchKnowledge.mock.calls[0]?.[0] as string;
+      const relevantOptions = knowledgeManager.getRelevantKnowledge.mock.calls[0]?.[2];
+      const semanticOptions = knowledgeManager.searchKnowledge.mock.calls[0]?.[2];
+      expect(relevantOptions?.relationshipProfileContext).toMatchObject({
+        scope: "memory_retrieval",
+        includeSensitive: false,
+      });
+      expect(relevantOptions?.relationshipProfileContext.items.map((item: { value: string }) => item.value)).toEqual([
+        "Prefer concise status reports.",
+      ]);
+      expect(semanticOptions?.relationshipProfileContext.items.map((item: { value: string }) => item.value)).toEqual([
+        "Prefer concise status reports.",
+      ]);
+      expect(semanticQuery).toContain("Relationship profile retrieval context");
+      expect(semanticQuery).toContain("Prefer concise status reports.");
+      expect(semanticQuery).not.toContain("Prefer verbose status reports.");
+      expect(semanticQuery).not.toContain("Do not retrieve health context");
+      expect(semanticQuery).not.toContain("Prefer VS Code.");
+      const callArgs = mocks.taskLifecycle.runTaskCycle.mock.calls[0];
+      expect(callArgs![4]).toContain("Relationship profile retrieval context");
+      expect(callArgs![4]).toContain("Prefer concise status reports.");
+      expect(callArgs![4]).not.toContain("Prefer verbose status reports.");
+      expect(callArgs![4]).not.toContain("Do not retrieve health context");
+      expect(callArgs![4]).not.toContain("Prefer VS Code.");
     });
 
     it("adds cross-goal lessons when activation flag is enabled", async () => {

--- a/src/orchestrator/loop/core-loop/task-cycle.ts
+++ b/src/orchestrator/loop/core-loop/task-cycle.ts
@@ -23,6 +23,10 @@ import {
   expandKnowledgeEntriesWithGraph,
   mergeWorkingMemorySelections,
 } from "../../execution/context/context-builder.js";
+import {
+  formatRelationshipProfileRetrievalContext,
+  loadRelationshipProfileRetrievalContext,
+} from "../../../platform/profile/retrieval-context.js";
 import type { CapabilityAcquisitionOutcome } from "./capability.js";
 import type { CoreLoopEvidenceLedger } from "./evidence-ledger.js";
 import type { ExecutionModeState } from "../../../platform/time/execution-mode.js";
@@ -227,21 +231,42 @@ export async function runTaskCycleWithContext(
 
     // Collect knowledge context
     let knowledgeContext: string | undefined;
+    const relationshipProfileRetrievalContext = baseDir
+      ? await loadRelationshipProfileRetrievalContext({ baseDir }).catch(() => null)
+      : null;
+    const relationshipProfileRetrievalBlock = relationshipProfileRetrievalContext
+      ? formatRelationshipProfileRetrievalContext(relationshipProfileRetrievalContext)
+      : "";
     if (ctx.deps.knowledgeManager) {
       try {
         await runPhase("collect-knowledge-context", async () => {
           if (activationFlags?.verifiedPlannerHintsOnly) return;
           const topDimension = driveScores[0]?.dimension_name ?? goal.dimensions[0]?.name;
           if (!topDimension) return;
-          let entries = await ctx.deps.knowledgeManager!.getRelevantKnowledge(goalId, topDimension);
+          let entries = await ctx.deps.knowledgeManager!.getRelevantKnowledge(
+            goalId,
+            topDimension,
+            relationshipProfileRetrievalContext
+              ? { relationshipProfileContext: relationshipProfileRetrievalContext }
+              : undefined
+          );
 
           if (
             activationFlags?.semanticContext &&
             typeof ctx.deps.knowledgeManager!.searchKnowledge === "function"
           ) {
+            const semanticQuery = [
+              goal.title,
+              goal.description,
+              topDimension,
+              relationshipProfileRetrievalBlock,
+            ].filter((part) => part.trim().length > 0).join("\n");
             const semanticEntries = await ctx.deps.knowledgeManager!.searchKnowledge(
-              `${goal.title} ${goal.description} ${topDimension}`,
-              5
+              semanticQuery,
+              5,
+              relationshipProfileRetrievalContext
+                ? { relationshipProfileContext: relationshipProfileRetrievalContext }
+                : undefined
             ).catch(() => []);
             entries = mergeUniqueKnowledgeEntries(entries, semanticEntries, 8);
           }
@@ -279,6 +304,12 @@ export async function runTaskCycleWithContext(
       } catch {
         // Knowledge retrieval failure is non-fatal
       }
+    }
+
+    if (relationshipProfileRetrievalBlock.trim().length > 0) {
+      knowledgeContext = knowledgeContext
+        ? `${relationshipProfileRetrievalBlock}\n\n${knowledgeContext}`
+        : relationshipProfileRetrievalBlock;
     }
 
     if (

--- a/src/platform/knowledge/knowledge-manager.ts
+++ b/src/platform/knowledge/knowledge-manager.ts
@@ -66,6 +66,10 @@ import {
 import type { MemoryQuarantineState } from "../corrections/memory-quarantine.js";
 import type { MemoryProvenance, MemoryVerificationStatus } from "../corrections/memory-quarantine.js";
 import type { MemoryGovernanceInput, MemorySensitivity } from "../corrections/memory-governance.js";
+import {
+  formatRelationshipProfileRetrievalContext,
+  type RelationshipProfileRetrievalContext,
+} from "../profile/retrieval-context.js";
 import type {
   MemoryCorrectionEntry,
   MemoryCorrectionKind,
@@ -187,9 +191,15 @@ export class KnowledgeManager {
    */
   async getRelevantKnowledge(
     goalId: string,
-    dimensionName: string
+    dimensionName: string,
+    options: { relationshipProfileContext?: RelationshipProfileRetrievalContext } = {}
   ): Promise<KnowledgeEntry[]> {
-    return this.loadKnowledge(goalId, [dimensionName]);
+    const entries = await this.loadKnowledge(goalId, [dimensionName]);
+    const profileEntries = this.relationshipProfileContextToKnowledgeEntries(
+      goalId,
+      options.relationshipProfileContext
+    );
+    return [...profileEntries, ...entries];
   }
 
   // ─── searchKnowledge (Phase 2) ───
@@ -200,13 +210,45 @@ export class KnowledgeManager {
    */
   async searchKnowledge(
     query: string,
-    topK: number = 5
+    topK: number = 5,
+    options: { relationshipProfileContext?: RelationshipProfileRetrievalContext } = {}
   ): Promise<KnowledgeEntry[]> {
+    const profileEntries = this.relationshipProfileContextToKnowledgeEntries(
+      null,
+      options.relationshipProfileContext
+    );
+    const profileQuery = options.relationshipProfileContext
+      ? formatRelationshipProfileRetrievalContext(options.relationshipProfileContext)
+      : "";
     return searchKnowledge(
       { stateManager: this.stateManager, vectorIndex: this.vectorIndex },
-      query,
+      [query, profileQuery].filter((part) => part.trim().length > 0).join("\n"),
       topK
-    );
+    ).then((entries) => [...profileEntries, ...entries]);
+  }
+
+  private relationshipProfileContextToKnowledgeEntries(
+    goalId: string | null,
+    context?: RelationshipProfileRetrievalContext
+  ): KnowledgeEntry[] {
+    if (!context || context.items.length === 0) return [];
+    const acquiredAt = new Date(0).toISOString();
+    return context.items.map((item) => ({
+      entry_id: `relationship-profile:${item.id}`,
+      question: `Relationship profile context: ${item.stable_key}`,
+      answer: item.value,
+      sources: [{
+        type: "document",
+        reference: item.provenance.evidence_ref ?? item.id,
+        reliability: item.confidence >= 0.8 ? "high" : item.confidence >= 0.5 ? "medium" : "low",
+      }],
+      confidence: item.confidence,
+      acquired_at: acquiredAt,
+      acquisition_task_id: "relationship-profile",
+      superseded_by: null,
+      embedding_id: null,
+      tags: [item.kind, context.scope, ...(goalId ? [goalId] : [])],
+    }));
   }
 
   // ─── searchAcrossGoals (Phase 2) ───

--- a/src/platform/profile/retrieval-context.ts
+++ b/src/platform/profile/retrieval-context.ts
@@ -1,0 +1,38 @@
+import {
+  loadRelationshipProfile,
+  selectActiveRelationshipProfileItems,
+  type RelationshipProfileItem,
+} from "./relationship-profile.js";
+
+export interface RelationshipProfileRetrievalContext {
+  scope: "memory_retrieval";
+  includeSensitive: boolean;
+  items: RelationshipProfileItem[];
+}
+
+export async function loadRelationshipProfileRetrievalContext(params: {
+  baseDir: string;
+  includeSensitive?: boolean;
+}): Promise<RelationshipProfileRetrievalContext> {
+  const includeSensitive = params.includeSensitive === true;
+  const store = await loadRelationshipProfile(params.baseDir);
+  return {
+    scope: "memory_retrieval",
+    includeSensitive,
+    items: selectActiveRelationshipProfileItems(store, "memory_retrieval", { includeSensitive }),
+  };
+}
+
+export function formatRelationshipProfileRetrievalContext(
+  context: RelationshipProfileRetrievalContext
+): string {
+  if (context.items.length === 0) return "";
+  return [
+    `Relationship profile retrieval context (scope=${context.scope}; include_sensitive=${context.includeSensitive})`,
+    "- Use these active profile items only as retrieval context.",
+    "- Ignore superseded or retracted relationship profile items from older memory.",
+    ...context.items.map((item) =>
+      `- [${item.kind}] ${item.stable_key}: ${item.value} (confidence=${item.confidence.toFixed(2)}; sensitivity=${item.sensitivity}; version=${item.version})`
+    ),
+  ].join("\n");
+}


### PR DESCRIPTION
Closes #928
Refs #896

## Summary
- add typed relationship profile retrieval context for active memory_retrieval profile items
- pass typed profile context through production CoreLoop knowledge recall and KnowledgeManager search paths
- render active profile context in prefetched grounding while excluding stale/retracted and sensitive items by default
- keep sensitive profile context behind an explicit includeSensitive typed option

## Verification
- `npm run typecheck`
- `npx vitest run src/grounding/__tests__/gateway.test.ts src/orchestrator/loop/__tests__/core-loop-integrations.test.ts src/platform/knowledge/__tests__/knowledge-manager.test.ts src/platform/profile/__tests__/relationship-profile.test.ts`
- `npm run lint:boundaries` (passes with pre-existing warnings)
- `npm run test:changed`
- `git diff --check`
- review agent re-review: no material findings

## Known unresolved risks
- `npm run lint:boundaries` still reports repo-wide pre-existing warnings, no lint errors.