### PR TITLE
fix(profile): enforce boundary sensitivity policy

### DIFF
--- a/src/base/config/__tests__/identity-loader.test.ts
+++ b/src/base/config/__tests__/identity-loader.test.ts
@@ -241,6 +241,78 @@ Content here.`);
     expect(result).toContain("Prefer concise status reports.");
     expect(result).not.toContain("Prefer verbose status reports.");
   });
+
+  it("keeps stale and sensitive boundaries out of lower-trust planning prompts unless explicitly allowed", () => {
+    withFiles({
+      "relationship-profile.json": JSON.stringify({
+        schema_version: 1,
+        profile_id: "default",
+        updated_at: "2026-05-03T00:00:00.000Z",
+        items: [
+          {
+            id: "old-boundary",
+            stable_key: "user.boundary.notifications",
+            kind: "boundary",
+            value: "Notify freely.",
+            status: "superseded",
+            version: 1,
+            confidence: 0.9,
+            sensitivity: "private",
+            allowed_scopes: ["local_planning", "user_facing_review"],
+            provenance: { source: "cli_update" },
+            created_at: "2026-05-02T00:00:00.000Z",
+            updated_at: "2026-05-03T00:00:00.000Z",
+            superseded_at: "2026-05-03T00:00:00.000Z",
+            superseded_by: "new-boundary",
+          },
+          {
+            id: "new-boundary",
+            stable_key: "user.boundary.notifications",
+            kind: "boundary",
+            value: "Ask before non-urgent notifications.",
+            status: "active",
+            version: 2,
+            confidence: 0.9,
+            sensitivity: "private",
+            allowed_scopes: ["local_planning", "user_facing_review"],
+            provenance: { source: "user_correction" },
+            created_at: "2026-05-03T00:00:00.000Z",
+            updated_at: "2026-05-03T00:00:00.000Z",
+            superseded_at: null,
+            superseded_by: null,
+          },
+          {
+            id: "sensitive-boundary",
+            stable_key: "user.boundary.health",
+            kind: "boundary",
+            value: "Do not use health context outside explicit review.",
+            status: "active",
+            version: 1,
+            confidence: 0.8,
+            sensitivity: "sensitive",
+            allowed_scopes: ["local_planning", "user_facing_review"],
+            provenance: { source: "cli_update" },
+            created_at: "2026-05-03T00:00:00.000Z",
+            updated_at: "2026-05-03T00:00:00.000Z",
+            superseded_at: null,
+            superseded_by: null,
+          },
+        ],
+        audit_events: [],
+      }),
+    });
+
+    const defaultPrompt = getInternalIdentityPrefix("planner", { profileScope: "local_planning" });
+    expect(defaultPrompt).toContain("Ask before non-urgent notifications.");
+    expect(defaultPrompt).not.toContain("Notify freely.");
+    expect(defaultPrompt).not.toContain("health context");
+
+    const explicitSensitivePrompt = getInternalIdentityPrefix("planner", {
+      profileScope: "local_planning",
+      includeSensitiveProfile: true,
+    });
+    expect(explicitSensitivePrompt).toContain("Do not use health context outside explicit review.");
+  });
 });
 
 describe("runtime identity slot", () => {

--- a/src/grounding/__tests__/gateway.test.ts
+++ b/src/grounding/__tests__/gateway.test.ts
@@ -296,6 +296,59 @@ describe("GroundingGateway", () => {
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
+  it("uses the latest active boundary and excludes sensitive boundary details in memory retrieval context", async () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-grounding-boundary-policy-"));
+    const homeDir = path.join(tmpRoot, "home");
+    fs.mkdirSync(homeDir, { recursive: true });
+    await upsertRelationshipProfileItem(homeDir, {
+      stableKey: "user.boundary.notifications",
+      kind: "boundary",
+      value: "Notify freely.",
+      source: "cli_update",
+      allowedScopes: ["memory_retrieval", "user_facing_review"],
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    await upsertRelationshipProfileItem(homeDir, {
+      stableKey: "user.boundary.notifications",
+      kind: "boundary",
+      value: "Ask before non-urgent notifications.",
+      source: "user_correction",
+      allowedScopes: ["memory_retrieval", "user_facing_review"],
+      now: "2026-05-03T00:01:00.000Z",
+    });
+    await upsertRelationshipProfileItem(homeDir, {
+      stableKey: "user.boundary.health",
+      kind: "boundary",
+      value: "Do not use health context outside explicit review.",
+      source: "cli_update",
+      sensitivity: "sensitive",
+      allowedScopes: ["memory_retrieval", "user_facing_review"],
+      now: "2026-05-03T00:02:00.000Z",
+    });
+
+    const knowledgeQuery = vi.fn().mockResolvedValue({
+      retrievalId: "knowledge:profile-boundary",
+      items: [{ id: "k1", content: "Knowledge result", source: "test" }],
+    });
+    const gateway = createGroundingGateway({ stateManager: makeStateManager({ getBaseDir: vi.fn().mockReturnValue(homeDir) }) });
+    await gateway.build({
+      surface: "agent_loop",
+      purpose: "task_execution",
+      homeDir,
+      workspaceRoot: "/repo",
+      userMessage: "Find relevant memory",
+      query: "Find relevant memory",
+      knowledgeQuery,
+    });
+
+    const profileContext = knowledgeQuery.mock.calls[0]?.[0]?.relationshipProfileContext;
+    expect((profileContext?.items as Array<{ value: string }> | undefined)?.map((item) => item.value)).toEqual([
+      "Ask before non-urgent notifications.",
+    ]);
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
   it("records usage for admitted SQLite Soil grounding hits and preserves usage stats in context", async () => {
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-grounding-soil-"));
     const homeDir = path.join(tmpRoot, "home");

--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -1461,6 +1461,56 @@ describe("profile command", () => {
     expect(output).not.toContain("Notify freely.");
   });
 
+  it("shows review-safe user-facing profile context without leaking sensitive details", async () => {
+    await runCLI(
+      "profile",
+      "update",
+      "--kind",
+      "boundary",
+      "--key",
+      "user.boundary.notifications",
+      "--value",
+      "Ask before non-urgent notifications.",
+      "--scope",
+      "user_facing_review"
+    );
+    await runCLI(
+      "profile",
+      "update",
+      "--kind",
+      "boundary",
+      "--key",
+      "user.boundary.health",
+      "--value",
+      "Do not use health context outside explicit review.",
+      "--scope",
+      "user_facing_review",
+      "--sensitivity",
+      "sensitive"
+    );
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const showCode = await runCLI("profile", "show", "--scope", "user_facing_review", "--json");
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    consoleSpy.mockRestore();
+
+    expect(showCode).toBe(0);
+    const parsed = JSON.parse(output) as { items: Array<{ stable_key: string; value: string; sensitivity: string }> };
+    expect(parsed.items.map((item) => item.stable_key)).toEqual(["user.boundary.notifications"]);
+    expect(parsed.items[0]?.value).toBe("Ask before non-urgent notifications.");
+    expect(output).not.toContain("health context");
+
+    const defaultConsoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const defaultShowCode = await runCLI("profile", "show", "--json");
+    const defaultOutput = defaultConsoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    defaultConsoleSpy.mockRestore();
+
+    expect(defaultShowCode).toBe(0);
+    const defaultParsed = JSON.parse(defaultOutput) as { items: Array<{ stable_key: string; value: string }> };
+    expect(defaultParsed.items.map((item) => item.stable_key)).toEqual(["user.boundary.notifications"]);
+    expect(defaultOutput).not.toContain("health context");
+  });
+
   it("shows history and retracts profile items through the production CLI entrypoint", async () => {
     await runCLI(
       "profile",

--- a/src/interface/cli/commands/profile.ts
+++ b/src/interface/cli/commands/profile.ts
@@ -109,7 +109,7 @@ export async function cmdProfile(stateManager: StateManager, argv: string[]): Pr
       ? store.items
       : scope
         ? selectActiveRelationshipProfileItems(store, scope)
-        : store.items.filter((item) => item.status === "active");
+        : selectActiveRelationshipProfileItems(store, "user_facing_review");
 
     if (values.json) {
       console.log(JSON.stringify({

--- a/src/runtime/daemon/__tests__/maintenance-profile.test.ts
+++ b/src/runtime/daemon/__tests__/maintenance-profile.test.ts
@@ -76,4 +76,70 @@ describe("runProactiveMaintenance relationship profile context", () => {
     expect(prompt).toContain("Suggest only when the next action is clearly reversible.");
     expect(prompt).not.toContain("Use detailed weekly planning notes.");
   });
+
+  it("uses latest active resident boundary and excludes sensitive boundary details", async () => {
+    const baseDir = makeTempDir();
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.boundary.notifications",
+      kind: "boundary",
+      value: "Notify freely.",
+      source: "cli_update",
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      now: "2026-05-02T00:00:00.000Z",
+    });
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.boundary.notifications",
+      kind: "boundary",
+      value: "Ask before non-urgent notifications.",
+      source: "user_correction",
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      now: "2026-05-02T00:01:00.000Z",
+    });
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.boundary.health",
+      kind: "boundary",
+      value: "Do not use health context outside explicit review.",
+      source: "cli_update",
+      sensitivity: "sensitive",
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      now: "2026-05-02T00:02:00.000Z",
+    });
+
+    const sendMessage = vi.fn().mockResolvedValue({ content: JSON.stringify({ action: "sleep", details: {} }) });
+    const llmClient = {
+      sendMessage,
+      parseJSON: vi.fn().mockImplementation((content: string, schema: { parse(value: unknown): unknown }) =>
+        schema.parse(JSON.parse(content))
+      ),
+    };
+
+    await runProactiveMaintenance({
+      config: DaemonConfigSchema.parse({
+        proactive_mode: true,
+        proactive_interval_ms: 1,
+        runtime_root: baseDir,
+      }),
+      llmClient: llmClient as never,
+      state: DaemonStateSchema.parse({
+        pid: 123,
+        started_at: "2026-05-02T00:00:00.000Z",
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: [],
+        status: "idle",
+      }),
+      lastProactiveTickAt: 0,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    const prompt = sendMessage.mock.calls[0]?.[0]?.[0]?.content ?? "";
+    expect(prompt).toContain("Ask before non-urgent notifications.");
+    expect(prompt).not.toContain("Notify freely.");
+    expect(prompt).not.toContain("health context");
+  });
 });


### PR DESCRIPTION
Closes #929
Refs #896

## Summary
- make default `profile show` use the review-safe typed profile selector instead of dumping every active item
- add production caller-path coverage for planning, resident proactive, memory retrieval, and CLI review surfaces
- assert latest active boundary wins, stale boundaries are excluded, and sensitive boundary details are withheld from lower-trust/review-safe surfaces unless explicitly allowed

## Verification
- `npm run typecheck`
- `npx vitest run src/platform/profile/__tests__/relationship-profile.test.ts src/base/config/__tests__/identity-loader.test.ts src/grounding/__tests__/gateway.test.ts src/runtime/daemon/__tests__/maintenance-profile.test.ts src/interface/cli/__tests__/cli-runner.test.ts`
- `npm run lint:boundaries` (passes with pre-existing warnings)
- `npm run test:changed`
- `git diff --check`
- review agent re-review: no material findings

## Known unresolved risks
- `npm run lint:boundaries` still reports existing repo-wide warnings; no new lint errors were introduced.