### PR TITLE
feat(profile): apply intervention policy to resident proactive behavior

### DIFF
--- a/src/platform/profile/relationship-profile.ts
+++ b/src/platform/profile/relationship-profile.ts
@@ -374,7 +374,7 @@ export function formatRelationshipProfilePromptBlock(
     "- Ignore superseded or retracted profile items even if they appear in older memory.",
     ...activeItems.map((item) => {
       const confidence = item.confidence.toFixed(2);
-      return `- [${item.kind}] ${item.stable_key}: ${item.value} (confidence=${confidence}; sensitivity=${item.sensitivity}; version=${item.version})`;
+      return `- [${item.kind}] ${item.stable_key}: ${item.value} (confidence=${confidence}; sensitivity=${item.sensitivity}; status=${item.status}; version=${item.version})`;
     }),
   ];
   return lines.join("\n");

--- a/src/platform/traits/curiosity-engine.ts
+++ b/src/platform/traits/curiosity-engine.ts
@@ -358,7 +358,8 @@ export class CuriosityEngine {
    */
   async generateProposals(
     triggers: CuriosityTrigger[],
-    goals: Goal[]
+    goals: Goal[],
+    options: { relationshipProfileContext?: string } = {}
   ): Promise<CuriosityProposal[]> {
     await this.ensureStateLoaded();
     const activeProposals = this.getActiveProposals();
@@ -374,6 +375,9 @@ export class CuriosityEngine {
         vectorIndex: this.vectorIndex,
         knowledgeTransfer: this.knowledgeTransfer,
         config: this.config,
+      },
+      {
+        relationshipProfileContext: options.relationshipProfileContext,
       }
     );
 

--- a/src/platform/traits/curiosity-proposals.ts
+++ b/src/platform/traits/curiosity-proposals.ts
@@ -74,8 +74,10 @@ export interface ProposalGenerationDeps {
 export function buildProposalPrompt(
   trigger: CuriosityTrigger,
   goals: Goal[],
-  learningRecords: LearningRecord[]
+  learningRecords: LearningRecord[],
+  options: { relationshipProfileContext?: string } = {}
 ): string {
+  const relationshipProfileContext = options.relationshipProfileContext?.trim() ?? "";
   const activeGoalsSummary = goals
     .filter((g) => g.status === "active" || g.status === "waiting")
     .map((g) => {
@@ -105,6 +107,9 @@ ${activeGoalsSummary || "(none)"}
 
 ## Recent Learning Records
 ${recentLearning || "(none)"}
+
+## Resident Relationship Profile Context
+${relationshipProfileContext || "(none)"}
 
 ## Task
 Based on the trigger and learning history, propose 1-3 curiosity goals that:
@@ -165,7 +170,8 @@ export async function generateProposals(
   goals: Goal[],
   state: CuriosityState,
   activeProposalCount: number,
-  deps: ProposalGenerationDeps
+  deps: ProposalGenerationDeps,
+  options: { relationshipProfileContext?: string } = {}
 ): Promise<CuriosityProposal[]> {
   const config: CuriosityConfig = CuriosityConfigSchema.parse(deps.config);
 
@@ -198,7 +204,9 @@ export async function generateProposals(
     let llmItems: LLMProposalItem[] = [];
 
     try {
-      const prompt = buildProposalPrompt(trigger, goals, state.learning_records);
+      const prompt = buildProposalPrompt(trigger, goals, state.learning_records, {
+        relationshipProfileContext: options.relationshipProfileContext,
+      });
       if (deps.gateway) {
         llmItems = await deps.gateway.execute({
           purpose: "curiosity_propose",

--- a/src/runtime/__tests__/daemon-runner.test.ts
+++ b/src/runtime/__tests__/daemon-runner.test.ts
@@ -17,6 +17,7 @@ import { createEnvelope } from "../types/envelope.js";
 import { runSupervisorMaintenanceCycleForDaemon } from "../daemon/maintenance.js";
 import type { DaemonState } from "../../base/types/daemon.js";
 import { restoreInterruptedGoals } from "../daemon/persistence.js";
+import { upsertRelationshipProfileItem } from "../../platform/profile/relationship-profile.js";
 
 vi.setConfig({ testTimeout: 20_000 });
 
@@ -554,6 +555,23 @@ describe("DaemonRunner durable runtime", () => {
   });
 
   it("runs resident curiosity investigation from idle proactive ticks", async () => {
+    await upsertRelationshipProfileItem(tmpDir, {
+      stableKey: "user.intervention.curiosity",
+      kind: "intervention_policy",
+      value: "Ask for confirmation before resident curiosity creates non-urgent proposals.",
+      source: "cli_update",
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      now: "2026-05-03T00:00:00.000Z",
+    });
+    await upsertRelationshipProfileItem(tmpDir, {
+      stableKey: "user.intervention.health",
+      kind: "intervention_policy",
+      value: "Use sensitive health context for curiosity timing.",
+      source: "cli_update",
+      sensitivity: "sensitive",
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      now: "2026-05-03T00:01:00.000Z",
+    });
     const curiosityEngine = {
       evaluateTriggers: vi.fn().mockResolvedValue([
         {
@@ -639,7 +657,18 @@ describe("DaemonRunner durable runtime", () => {
       suggestion_title: "Explore weak spots in idle daemon resident behavior.",
     }));
     expect(curiosityEngine.evaluateTriggers).toHaveBeenCalledOnce();
-    expect(curiosityEngine.generateProposals).toHaveBeenCalledOnce();
+    expect(curiosityEngine.generateProposals).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.any(Array),
+      expect.objectContaining({
+        relationshipProfileContext: expect.stringContaining(
+          "Ask for confirmation before resident curiosity creates non-urgent proposals."
+        ),
+      })
+    );
+    const relationshipProfileContext = curiosityEngine.generateProposals.mock.calls[0]?.[2]?.relationshipProfileContext ?? "";
+    expect(relationshipProfileContext).toContain("status=active; version=1");
+    expect(relationshipProfileContext).not.toContain("sensitive health context");
     expect(llmClient.sendMessage).not.toHaveBeenCalled();
 
     daemon.stop();

--- a/src/runtime/daemon/__tests__/maintenance-profile.test.ts
+++ b/src/runtime/daemon/__tests__/maintenance-profile.test.ts
@@ -3,7 +3,10 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { DaemonConfigSchema, DaemonStateSchema } from "../../types/daemon.js";
-import { upsertRelationshipProfileItem } from "../../../platform/profile/relationship-profile.js";
+import {
+  retractRelationshipProfileItem,
+  upsertRelationshipProfileItem,
+} from "../../../platform/profile/relationship-profile.js";
 import { runProactiveMaintenance } from "../maintenance.js";
 
 const tempDirs: string[] = [];
@@ -75,6 +78,89 @@ describe("runProactiveMaintenance relationship profile context", () => {
     const prompt = sendMessage.mock.calls[0]?.[0]?.[0]?.content ?? "";
     expect(prompt).toContain("Suggest only when the next action is clearly reversible.");
     expect(prompt).not.toContain("Use detailed weekly planning notes.");
+  });
+
+  it("uses the latest active intervention policy and ignores stale or sensitive policies", async () => {
+    const baseDir = makeTempDir();
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.intervention.nudge",
+      kind: "intervention_policy",
+      value: "Proactively notify for any minor observation.",
+      source: "cli_update",
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      now: "2026-05-02T00:00:00.000Z",
+    });
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.intervention.nudge",
+      kind: "intervention_policy",
+      value: "Ask for confirmation before non-urgent proactive suggestions.",
+      source: "user_correction",
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      now: "2026-05-02T00:01:00.000Z",
+    });
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.intervention.weekend",
+      kind: "intervention_policy",
+      value: "Send proactive weekend nudges without asking.",
+      source: "cli_update",
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      now: "2026-05-02T00:02:00.000Z",
+    });
+    await retractRelationshipProfileItem(baseDir, {
+      stableKey: "user.intervention.weekend",
+      reason: "No weekend nudges without explicit approval.",
+      source: "user_correction",
+      now: "2026-05-02T00:03:00.000Z",
+    });
+    await upsertRelationshipProfileItem(baseDir, {
+      stableKey: "user.intervention.health",
+      kind: "intervention_policy",
+      value: "Use sensitive health context to decide proactive timing.",
+      source: "cli_update",
+      sensitivity: "sensitive",
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      now: "2026-05-02T00:04:00.000Z",
+    });
+
+    const sendMessage = vi.fn().mockResolvedValue({ content: JSON.stringify({ action: "sleep", details: {} }) });
+    const llmClient = {
+      sendMessage,
+      parseJSON: vi.fn().mockImplementation((content: string, schema: { parse(value: unknown): unknown }) =>
+        schema.parse(JSON.parse(content))
+      ),
+    };
+
+    await runProactiveMaintenance({
+      config: DaemonConfigSchema.parse({
+        proactive_mode: true,
+        proactive_interval_ms: 1,
+        runtime_root: baseDir,
+      }),
+      llmClient: llmClient as never,
+      state: DaemonStateSchema.parse({
+        pid: 123,
+        started_at: "2026-05-02T00:00:00.000Z",
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: [],
+        status: "idle",
+      }),
+      lastProactiveTickAt: 0,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    const prompt = sendMessage.mock.calls[0]?.[0]?.[0]?.content ?? "";
+    expect(prompt).toContain("Ask for confirmation before non-urgent proactive suggestions.");
+    expect(prompt).toContain("status=active; version=2");
+    expect(prompt).toContain("sensitivity=private");
+    expect(prompt).not.toContain("Proactively notify for any minor observation.");
+    expect(prompt).not.toContain("Send proactive weekend nudges without asking.");
+    expect(prompt).not.toContain("sensitive health context");
   });
 
   it("uses latest active resident boundary and excludes sensitive boundary details", async () => {

--- a/src/runtime/daemon/runner-resident-curiosity.ts
+++ b/src/runtime/daemon/runner-resident-curiosity.ts
@@ -1,4 +1,5 @@
 import type { ResidentActivity } from "../../base/types/daemon.js";
+import { loadRelationshipProfilePromptBlock } from "../../platform/profile/relationship-profile.js";
 import type { DaemonRunnerResidentContext } from "./runner-resident-shared.js";
 import {
   gatherResidentWorkspaceContext,
@@ -133,7 +134,13 @@ export async function runResidentCuriosityCycle(
       return true;
     }
 
-    const proposals = await context.curiosityEngine.generateProposals(triggers, goals);
+    const relationshipProfileContext = loadRelationshipProfilePromptBlock(
+      context.stateManager.getBaseDir(),
+      "resident_behavior"
+    );
+    const proposals = await context.curiosityEngine.generateProposals(triggers, goals, {
+      relationshipProfileContext,
+    });
     if (proposals.length === 0) {
       await persistResidentActivity(context, {
         kind: "curiosity",


### PR DESCRIPTION
Closes #930
Refs #896

## Summary
- include profile item status metadata in active relationship profile prompt context
- pass typed `resident_behavior` relationship profile context into resident curiosity proposal generation before the fallback maintenance prompt
- add resident proactive coverage for latest active intervention policy, stale/retracted policy rejection, sensitive policy exclusion, and production idle curiosity caller path

## Verification
- `npm run typecheck`
- `npx vitest run src/runtime/daemon/__tests__/maintenance-profile.test.ts src/runtime/__tests__/daemon-runner.test.ts src/platform/profile/__tests__/relationship-profile.test.ts src/platform/traits/__tests__/curiosity-engine-proposals.test.ts`
- `npm run lint:boundaries` (passes with pre-existing warnings)
- `npm run test:changed`
- `git diff --check`
- review agent re-review: no material findings

## Known unresolved risks
- `npm run lint:boundaries` still reports existing repo-wide warnings; no new lint errors were introduced.