### PR TITLE
feat(profile): propose changes from proactive feedback

### DIFF
--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -1729,6 +1729,16 @@ describe("runtime proactive feedback commands", () => {
     );
     expect(feedbackCode).toBe(0);
 
+    const proposalStore = JSON.parse(fs.readFileSync(path.join(tmpDir, "relationship-profile-proposals.json"), "utf-8"));
+    expect(proposalStore.proposals[0]).toMatchObject({
+      source: "proactive_feedback",
+      approval_state: "pending",
+      proposed_item: {
+        stable_key: "user.intervention.proactivity",
+        kind: "intervention_policy",
+      },
+    });
+
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const qualityCode = await runCLI("runtime", "proactive-quality");
     const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -25,6 +25,7 @@ import {
   ProactiveOverreachIndicatorSchema,
   type ProactiveInterventionSummary,
 } from "../../../runtime/store/proactive-intervention-store.js";
+import { createRelationshipProfileProposalsFromProactiveFeedback } from "../../../platform/profile/proactive-feedback-proposals.js";
 import {
   createRuntimeDreamSidecarReview,
   RuntimeDreamSidecarReviewError,
@@ -644,11 +645,15 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
       followThroughSuccess: values.followThroughSuccess,
       channel: "cli",
     });
+    const proposalResult = await createRelationshipProfileProposalsFromProactiveFeedback(stateManager.getBaseDir(), event);
     const summary = await store.summarize();
     if (values.json) {
-      printJson({ event, summary });
+      printJson({ event, proposals: proposalResult.proposals, summary });
     } else {
       console.log(`Recorded proactive feedback: ${event.outcome} for ${event.intervention_id}`);
+      if (proposalResult.proposals.length > 0) {
+        console.log(`Created ${proposalResult.proposals.length} relationship profile proposal(s).`);
+      }
       if (event.policy_adjustment_recommendation) {
         console.log(`Policy recommendation: ${event.policy_adjustment_recommendation.suggested_action} for ${event.policy_adjustment_recommendation.relationship_profile_key}`);
       }

--- a/src/platform/profile/__tests__/proactive-feedback-proposals.test.ts
+++ b/src/platform/profile/__tests__/proactive-feedback-proposals.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { DaemonConfigSchema, DaemonStateSchema } from "../../../runtime/types/daemon.js";
+import { runProactiveMaintenance } from "../../../runtime/daemon/maintenance.js";
+import { ProactiveInterventionStore } from "../../../runtime/store/proactive-intervention-store.js";
+import { rejectRelationshipProfileChangeProposal } from "../profile-change-proposal.js";
+import { loadRelationshipProfile } from "../relationship-profile.js";
+import { createRelationshipProfileProposalsFromProactiveFeedback } from "../proactive-feedback-proposals.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-proactive-feedback-proposals-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("proactive feedback relationship profile proposals", () => {
+  it("creates reduce-frequency and confirmation proposals from typed feedback outcomes", async () => {
+    const baseDir = makeTempDir();
+    const store = new ProactiveInterventionStore(baseDir);
+
+    const overreach = await store.appendFeedback({
+      interventionId: "intervention-overreach",
+      outcome: "overreach",
+      overreachIndicators: ["too_frequent"],
+      reason: "Too many proactive suggestions.",
+      recordedAt: "2026-05-03T00:00:00.000Z",
+    });
+    const corrected = await store.appendFeedback({
+      interventionId: "intervention-corrected",
+      outcome: "corrected",
+      reason: "The suggestion needed confirmation first.",
+      recordedAt: "2026-05-03T00:01:00.000Z",
+    });
+
+    const overreachResult = await createRelationshipProfileProposalsFromProactiveFeedback(baseDir, overreach);
+    const correctedResult = await createRelationshipProfileProposalsFromProactiveFeedback(baseDir, corrected);
+
+    expect(overreachResult.proposals[0]).toMatchObject({
+      source: "proactive_feedback",
+      approval_state: "pending",
+      proposed_item: {
+        stable_key: "user.intervention.proactivity",
+        kind: "intervention_policy",
+        value: "Reduce the frequency of non-urgent proactive interventions and prefer fewer, higher-confidence suggestions.",
+        allowed_scopes: ["resident_behavior", "user_facing_review"],
+      },
+      consent_scopes: ["user_facing_review"],
+      evidence_refs: [
+        `proactive-intervention:event:${overreach.event_id}`,
+        "proactive-intervention:intervention:intervention-overreach",
+      ],
+    });
+    expect(correctedResult.proposals[0]?.proposed_item).toMatchObject({
+      stable_key: "user.intervention.correction_policy",
+      kind: "intervention_policy",
+      value: "Ask for confirmation before acting on non-urgent proactive suggestions.",
+    });
+  });
+
+  it("creates governed candidates for ignored, dismissed, and accepted successful outcomes", async () => {
+    const baseDir = makeTempDir();
+    const store = new ProactiveInterventionStore(baseDir);
+    const ignored = await store.appendFeedback({
+      interventionId: "intervention-ignored",
+      outcome: "ignored",
+      recordedAt: "2026-05-03T00:00:00.000Z",
+    });
+    const dismissed = await store.appendFeedback({
+      interventionId: "intervention-dismissed",
+      outcome: "dismissed",
+      recordedAt: "2026-05-03T00:01:00.000Z",
+    });
+    const accepted = await store.appendFeedback({
+      interventionId: "intervention-accepted",
+      outcome: "accepted",
+      followThroughSuccess: true,
+      recordedAt: "2026-05-03T00:02:00.000Z",
+    });
+
+    const proposals = [
+      ...(await createRelationshipProfileProposalsFromProactiveFeedback(baseDir, ignored)).proposals,
+      ...(await createRelationshipProfileProposalsFromProactiveFeedback(baseDir, dismissed)).proposals,
+      ...(await createRelationshipProfileProposalsFromProactiveFeedback(baseDir, accepted)).proposals,
+    ];
+
+    expect(proposals.map((proposal) => proposal.approval_state)).toEqual(["pending", "pending", "pending"]);
+    expect(proposals.map((proposal) => proposal.proposed_item.stable_key)).toEqual([
+      "user.intervention.confirmation_preference",
+      "user.intervention.proactivity",
+      "user.intervention.proactivity",
+    ]);
+    expect(proposals.every((proposal) => proposal.source === "proactive_feedback")).toBe(true);
+  });
+
+  it("avoids sensitive details when creating sensitive-overreach proposals", async () => {
+    const baseDir = makeTempDir();
+    const event = await new ProactiveInterventionStore(baseDir).appendFeedback({
+      interventionId: "intervention-sensitive",
+      outcome: "overreach",
+      overreachIndicators: ["sensitive"],
+      reason: "Health details were used in a proactive suggestion.",
+      recordedAt: "2026-05-03T00:02:00.000Z",
+    });
+
+    const result = await createRelationshipProfileProposalsFromProactiveFeedback(baseDir, event);
+    const serialized = JSON.stringify(result.proposals[0]);
+
+    expect(result.proposals[0]?.proposed_item.value).toBe(
+      "Avoid using sensitive context for proactive interventions unless the user explicitly confirms it."
+    );
+    expect(serialized).not.toContain("Health details");
+  });
+
+  it("keeps rejected feedback proposals out of resident behavior", async () => {
+    const baseDir = makeTempDir();
+    const event = await new ProactiveInterventionStore(baseDir).appendFeedback({
+      interventionId: "intervention-rejected",
+      outcome: "overreach",
+      overreachIndicators: ["too_frequent"],
+      reason: "Too many proactive suggestions.",
+      recordedAt: "2026-05-03T00:03:00.000Z",
+    });
+    const result = await createRelationshipProfileProposalsFromProactiveFeedback(baseDir, event);
+    await rejectRelationshipProfileChangeProposal(baseDir, result.proposals[0]!.id, {
+      reason: "Do not change resident behavior from this feedback.",
+      now: "2026-05-03T00:04:00.000Z",
+    });
+
+    const profile = await loadRelationshipProfile(baseDir);
+    expect(profile.items).toHaveLength(0);
+
+    const sendMessage = vi.fn().mockResolvedValue({ content: JSON.stringify({ action: "sleep", details: {} }) });
+    const llmClient = {
+      sendMessage,
+      parseJSON: vi.fn().mockImplementation((content: string, schema: { parse(value: unknown): unknown }) =>
+        schema.parse(JSON.parse(content))
+      ),
+    };
+
+    await runProactiveMaintenance({
+      config: DaemonConfigSchema.parse({
+        proactive_mode: true,
+        proactive_interval_ms: 1,
+        runtime_root: baseDir,
+      }),
+      llmClient: llmClient as never,
+      state: DaemonStateSchema.parse({
+        pid: 123,
+        started_at: "2026-05-03T00:00:00.000Z",
+        last_loop_at: null,
+        loop_count: 0,
+        active_goals: [],
+        status: "idle",
+      }),
+      lastProactiveTickAt: 0,
+      logger: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+
+    const prompt = sendMessage.mock.calls[0]?.[0]?.[0]?.content ?? "";
+    expect(prompt).not.toContain("Reduce the frequency of non-urgent proactive interventions");
+  });
+});

--- a/src/platform/profile/proactive-feedback-proposals.ts
+++ b/src/platform/profile/proactive-feedback-proposals.ts
@@ -1,0 +1,128 @@
+import type { ProactiveInterventionFeedbackEvent } from "../../runtime/store/proactive-intervention-store.js";
+import {
+  createRelationshipProfileChangeProposal,
+  type RelationshipProfileChangeProposal,
+  type RelationshipProfileProposalInput,
+} from "./profile-change-proposal.js";
+import type { RelationshipProfileSensitivity } from "./relationship-profile.js";
+
+type FeedbackProposalDraft = Omit<RelationshipProfileProposalInput, "source" | "now">;
+
+function evidenceRefsForFeedback(event: ProactiveInterventionFeedbackEvent): string[] {
+  return [
+    `proactive-intervention:event:${event.event_id}`,
+    `proactive-intervention:intervention:${event.intervention_id}`,
+  ];
+}
+
+function proposalSensitivity(event: ProactiveInterventionFeedbackEvent): RelationshipProfileSensitivity {
+  return event.overreach_indicators.includes("sensitive") ? "private" : "private";
+}
+
+function policyValueForRecommendation(event: ProactiveInterventionFeedbackEvent): string | null {
+  const recommendation = event.policy_adjustment_recommendation;
+  if (!recommendation) return null;
+  if (recommendation.suggested_action === "avoid_sensitive_context") {
+    return "Avoid using sensitive context for proactive interventions unless the user explicitly confirms it.";
+  }
+  if (recommendation.suggested_action === "reduce_frequency") {
+    return "Reduce the frequency of non-urgent proactive interventions and prefer fewer, higher-confidence suggestions.";
+  }
+  if (recommendation.suggested_action === "require_confirmation") {
+    return "Ask for confirmation before acting on non-urgent proactive suggestions.";
+  }
+  if (recommendation.suggested_action === "narrow_scope") {
+    return "Narrow proactive interventions to the current task context unless the user explicitly broadens scope.";
+  }
+  return null;
+}
+
+export function buildRelationshipProfileProposalDraftsFromProactiveFeedback(
+  event: ProactiveInterventionFeedbackEvent
+): FeedbackProposalDraft[] {
+  const evidenceRefs = evidenceRefsForFeedback(event);
+  const sensitivity = proposalSensitivity(event);
+  const recommendation = event.policy_adjustment_recommendation;
+  const recommendedValue = policyValueForRecommendation(event);
+
+  if (recommendation && recommendedValue) {
+    return [{
+      operation: "upsert_item",
+      stableKey: recommendation.relationship_profile_key,
+      kind: "intervention_policy",
+      value: recommendedValue,
+      confidence: event.outcome === "overreach" ? 0.86 : 0.78,
+      sensitivity,
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      evidenceRefs,
+      rationale: event.overreach_indicators.includes("sensitive")
+        ? `Proactive feedback ${event.event_id} marked an intervention as sensitive overreach; route the policy update through approval before applying.`
+        : `Proactive feedback ${event.event_id} produced a typed ${recommendation.suggested_action} recommendation for ${recommendation.relationship_profile_key}.`,
+    }];
+  }
+
+  if (event.outcome === "ignored") {
+    return [{
+      operation: "upsert_item",
+      stableKey: "user.intervention.confirmation_preference",
+      kind: "intervention_policy",
+      value: "Ask for confirmation before repeating proactive interventions that the user ignores.",
+      confidence: 0.58,
+      sensitivity,
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      evidenceRefs,
+      rationale: `Proactive feedback ${event.event_id} was recorded as ignored; require approval before changing intervention behavior.`,
+    }];
+  }
+
+  if (event.outcome === "dismissed") {
+    return [{
+      operation: "upsert_item",
+      stableKey: "user.intervention.proactivity",
+      kind: "intervention_policy",
+      value: "Reduce non-urgent proactive interventions after dismissed suggestions.",
+      confidence: 0.62,
+      sensitivity,
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      evidenceRefs,
+      rationale: `Proactive feedback ${event.event_id} was dismissed; route any policy change through approval before applying.`,
+    }];
+  }
+
+  if (event.outcome === "accepted" && event.follow_through_success === true) {
+    return [{
+      operation: "upsert_item",
+      stableKey: "user.intervention.proactivity",
+      kind: "intervention_policy",
+      value: "Continue similar proactive interventions when confidence is high and the context is non-sensitive.",
+      confidence: 0.55,
+      sensitivity,
+      consentScopes: ["user_facing_review"],
+      allowedScopes: ["resident_behavior", "user_facing_review"],
+      evidenceRefs,
+      rationale: `Proactive feedback ${event.event_id} was accepted with successful follow-through; keep the change governed as a proposal.`,
+    }];
+  }
+
+  return [];
+}
+
+export async function createRelationshipProfileProposalsFromProactiveFeedback(
+  baseDir: string,
+  event: ProactiveInterventionFeedbackEvent,
+  params: { now?: string } = {}
+): Promise<{ proposals: RelationshipProfileChangeProposal[] }> {
+  const proposals: RelationshipProfileChangeProposal[] = [];
+  for (const draft of buildRelationshipProfileProposalDraftsFromProactiveFeedback(event)) {
+    const result = await createRelationshipProfileChangeProposal(baseDir, {
+      ...draft,
+      source: "proactive_feedback",
+      now: params.now ?? event.recorded_at,
+    });
+    proposals.push(result.proposal);
+  }
+  return { proposals };
+}


### PR DESCRIPTION
Closes #932
Refs #896

## Summary
- convert typed proactive intervention feedback outcomes into pending relationship profile change proposals
- wire `runtime proactive-feedback` to create governed `proactive_feedback` proposals without mutating profile items directly
- add coverage for overreach/reduce-frequency, corrected/confirmation, ignored/dismissed/accepted proposal candidates, sensitive-overreach detail avoidance, and rejected proposal no-op resident behavior

## Verification
- `npm run typecheck`
- `npx vitest run src/platform/profile/__tests__/proactive-feedback-proposals.test.ts src/platform/profile/__tests__/profile-change-proposal.test.ts src/interface/cli/__tests__/cli-runner.test.ts src/runtime/daemon/__tests__/maintenance-profile.test.ts`
- `npm run lint:boundaries` (passes with pre-existing warnings)
- `npm run test:changed`
- `git diff --check`
- review agent: no material findings

## Known unresolved risks
- `npm run lint:boundaries` still reports existing repo-wide warnings; no new lint errors were introduced.