### PR TITLE
Protect PulSeed self-source writes

### DIFF
--- a/src/interface/cli/cli-runner.ts
+++ b/src/interface/cli/cli-runner.ts
@@ -92,12 +92,14 @@ export class CLIRunner {
 
     await this.init();
 
-    // Extract --yes / -y globally so it works regardless of position
+    // Extract --yes / -y and --dev globally so they work regardless of position
     let globalYes = false;
     const filteredArgv: string[] = [];
     for (const arg of argv) {
       if (arg === "--yes" || arg === "-y") {
         globalYes = true;
+      } else if (arg === "--dev") {
+        process.env["PULSEED_DEV"] = "1";
       } else {
         filteredArgv.push(arg);
       }

--- a/src/interface/cli/commands/goal-read.ts
+++ b/src/interface/cli/commands/goal-read.ts
@@ -10,6 +10,7 @@ import { ReportingEngine } from "../../../reporting/reporting-engine.js";
 import { formatOperationError } from "../utils.js";
 import { getCliLogger } from "../cli-logger.js";
 import { dimensionProgress } from "../../../platform/drive/gap-calculator.js";
+import { resolvePulSeedExecutionProfile } from "../../../orchestrator/execution/agent-loop/self-protection.js";
 
 async function printActiveGoals(
   stateManager: StateManager,
@@ -139,6 +140,9 @@ export async function cmdStatus(
   console.log(`# Status: ${goal.title}`);
   console.log(`\n**Goal ID**: ${goalId}`);
   console.log(`**Status**: ${goal.status}`);
+  if (resolvePulSeedExecutionProfile() === "dev") {
+    console.log("**Execution profile**: dev");
+  }
   if (goal.deadline) {
     console.log(`**Deadline**: ${goal.deadline}`);
   }

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
@@ -36,6 +36,7 @@ import {
   type AgentLoopModelRequest,
   type AgentLoopModelResponse,
 } from "../index.js";
+import { defaultExecutionPolicy } from "../execution-policy.js";
 
 class ScriptedModelClient implements AgentLoopModelClient {
   calls: AgentLoopModelRequest[] = [];
@@ -204,6 +205,188 @@ describe("agentloop phase 3 tools", () => {
     const image = await executor.execute("view_image", { path: imagePath }, context);
     expect(image.success).toBe(true);
     expect(image.artifacts).toEqual([imagePath]);
+  });
+
+  it("blocks production agent-loop file mutations inside protected PulSeed roots in consumer mode", async () => {
+    const previousRoots = process.env["PULSEED_SELF_PROTECTION_ROOTS"];
+    const previousDev = process.env["PULSEED_DEV"];
+    process.env["PULSEED_SELF_PROTECTION_ROOTS"] = tmpDir;
+    delete process.env["PULSEED_DEV"];
+    try {
+      const registry = new ToolRegistry();
+      registry.register(new ApplyPatchTool());
+      registry.register(new ShellCommandTool());
+      const { runtime } = makeRuntime(registry);
+      const policy = defaultExecutionPolicy(tmpDir);
+      const turn = {
+        session: createAgentLoopSession(),
+        turnId: "turn-1",
+        goalId: "goal-1",
+        cwd: tmpDir,
+        model: makeModelInfo().ref,
+        modelInfo: makeModelInfo(),
+        messages: [],
+        outputSchema: z.object({}),
+        budget: defaultBudgetForTest(),
+        toolPolicy: { allowedTools: ["apply_patch", "shell_command"] },
+        executionPolicy: policy,
+        toolCallContext: {
+          cwd: tmpDir,
+          goalId: "goal-1",
+          trustBalance: 100,
+          preApproved: true,
+          trusted: true,
+          approvalFn: async () => true,
+          executionPolicy: policy,
+        },
+      };
+
+      const outputs = await runtime.executeBatch([
+        {
+          id: "patch-1",
+          name: "apply_patch",
+          input: {
+            cwd: tmpDir,
+            patch: [
+              "diff --git a/file.txt b/file.txt",
+              "index 3367afd..3e75765 100644",
+              "--- a/file.txt",
+              "+++ b/file.txt",
+              "@@ -1 +1 @@",
+              "-old",
+              "+blocked",
+              "",
+            ].join("\n"),
+          },
+        },
+        {
+          id: "shell-1",
+          name: "shell_command",
+          input: { command: "touch consumer-blocked.txt", cwd: tmpDir },
+        },
+      ], turn);
+
+      expect(outputs[0].success).toBe(false);
+      expect(outputs[0].content).toContain("protected");
+      expect(outputs[1].success).toBe(false);
+      expect(outputs[1].content).toContain("protected PulSeed source root");
+      expect(await fsp.readFile(path.join(tmpDir, "file.txt"), "utf-8")).toBe("old\n");
+      expect(fs.existsSync(path.join(tmpDir, "consumer-blocked.txt"))).toBe(false);
+
+      const interpreterWrite = await runtime.executeBatch([
+        {
+          id: "shell-interpreter-1",
+          name: "shell_command",
+          input: { command: "node -e \"require('fs').writeFileSync('interpreter-blocked.txt','x')\"", cwd: tmpDir },
+        },
+      ], turn);
+      expect(interpreterWrite[0].success).toBe(false);
+      expect(interpreterWrite[0].content).toContain("protected PulSeed source root");
+      expect(fs.existsSync(path.join(tmpDir, "interpreter-blocked.txt"))).toBe(false);
+
+      const outsideDir = makeTempDir();
+      try {
+        const outsideOutput = await runtime.executeBatch([
+          {
+            id: "shell-absolute-1",
+            name: "shell_command",
+            input: { command: `touch ${path.join(tmpDir, "absolute-blocked.txt")}`, cwd: outsideDir },
+          },
+        ], turn);
+        expect(outsideOutput[0].success).toBe(false);
+        expect(outsideOutput[0].content).toContain("protected PulSeed source root");
+        expect(fs.existsSync(path.join(tmpDir, "absolute-blocked.txt"))).toBe(false);
+      } finally {
+        fs.rmSync(outsideDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+      }
+
+      const deletePatch = [
+        "diff --git a/file.txt b/file.txt",
+        "deleted file mode 100644",
+        "index 3367afd..0000000",
+        "--- a/file.txt",
+        "+++ /dev/null",
+        "@@ -1 +0,0 @@",
+        "-old",
+        "",
+      ].join("\n");
+      const deleteOutput = await runtime.executeBatch([
+        { id: "patch-delete-1", name: "apply_patch", input: { patch: deletePatch, cwd: tmpDir } },
+      ], turn);
+      expect(deleteOutput[0].success).toBe(false);
+      expect(deleteOutput[0].content).toContain("protected");
+      expect(fs.existsSync(path.join(tmpDir, "file.txt"))).toBe(true);
+    } finally {
+      if (previousRoots === undefined) delete process.env["PULSEED_SELF_PROTECTION_ROOTS"];
+      else process.env["PULSEED_SELF_PROTECTION_ROOTS"] = previousRoots;
+      if (previousDev === undefined) delete process.env["PULSEED_DEV"];
+      else process.env["PULSEED_DEV"] = previousDev;
+    }
+  });
+
+  it("allows the same protected root mutation when dev mode is explicitly enabled", async () => {
+    const previousRoots = process.env["PULSEED_SELF_PROTECTION_ROOTS"];
+    const previousDev = process.env["PULSEED_DEV"];
+    process.env["PULSEED_SELF_PROTECTION_ROOTS"] = tmpDir;
+    process.env["PULSEED_DEV"] = "1";
+    try {
+      const registry = new ToolRegistry();
+      registry.register(new ApplyPatchTool());
+      const { runtime } = makeRuntime(registry);
+      const policy = defaultExecutionPolicy(tmpDir);
+      const turn = {
+        session: createAgentLoopSession(),
+        turnId: "turn-1",
+        goalId: "goal-1",
+        cwd: tmpDir,
+        model: makeModelInfo().ref,
+        modelInfo: makeModelInfo(),
+        messages: [],
+        outputSchema: z.object({}),
+        budget: defaultBudgetForTest(),
+        toolPolicy: { allowedTools: ["apply_patch"] },
+        executionPolicy: policy,
+        toolCallContext: {
+          cwd: tmpDir,
+          goalId: "goal-1",
+          trustBalance: 100,
+          preApproved: true,
+          trusted: true,
+          approvalFn: async () => true,
+          executionPolicy: policy,
+        },
+      };
+
+      const outputs = await runtime.executeBatch([
+        {
+          id: "patch-1",
+          name: "apply_patch",
+          input: {
+            cwd: tmpDir,
+            patch: [
+              "diff --git a/file.txt b/file.txt",
+              "index 3367afd..3e75765 100644",
+              "--- a/file.txt",
+              "+++ b/file.txt",
+              "@@ -1 +1 @@",
+              "-old",
+              "+dev",
+              "",
+            ].join("\n"),
+          },
+        },
+      ], turn);
+
+      expect(policy.executionProfile).toBe("dev");
+      expect(policy.protectedPaths).toEqual([]);
+      expect(outputs[0].success).toBe(true);
+      expect(await fsp.readFile(path.join(tmpDir, "file.txt"), "utf-8")).toBe("dev\n");
+    } finally {
+      if (previousRoots === undefined) delete process.env["PULSEED_SELF_PROTECTION_ROOTS"];
+      else process.env["PULSEED_SELF_PROTECTION_ROOTS"] = previousRoots;
+      if (previousDev === undefined) delete process.env["PULSEED_DEV"];
+      else process.env["PULSEED_DEV"] = previousDev;
+    }
   });
 });
 

--- a/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
@@ -431,6 +431,7 @@ export function summarizeAgentLoopResolvedProfile(
 ): AgentLoopResolvedProfileSummary {
   const posture = executionPolicy
     ? [
+        `profile=${executionPolicy.executionProfile}`,
         `sandbox=${executionPolicy.sandboxMode}`,
         `approval=${executionPolicy.approvalPolicy}`,
         `network=${executionPolicy.networkAccess ? "on" : "off"}`,

--- a/src/orchestrator/execution/agent-loop/execution-policy.ts
+++ b/src/orchestrator/execution/agent-loop/execution-policy.ts
@@ -1,4 +1,6 @@
 import { resolve } from "node:path";
+import type { PulSeedExecutionProfile } from "./self-protection.js";
+import { resolvePulSeedExecutionProfile, resolvePulSeedProtectedRoots } from "./self-protection.js";
 
 export type AgentLoopSandboxMode = "read_only" | "workspace_write" | "danger_full_access";
 export type AgentLoopApprovalPolicy = "on_request" | "never" | "untrusted";
@@ -13,6 +15,7 @@ export interface AgentLoopSecurityConfig {
 }
 
 export interface ExecutionPolicy {
+  executionProfile: PulSeedExecutionProfile;
   sandboxMode: AgentLoopSandboxMode;
   approvalPolicy: AgentLoopApprovalPolicy;
   networkAccess: boolean;
@@ -22,12 +25,15 @@ export interface ExecutionPolicy {
 }
 
 export function defaultExecutionPolicy(workspaceRoot: string): ExecutionPolicy {
+  const resolvedWorkspaceRoot = resolve(workspaceRoot);
+  const executionProfile = resolvePulSeedExecutionProfile();
   return {
+    executionProfile,
     sandboxMode: "workspace_write",
     approvalPolicy: "on_request",
     networkAccess: false,
-    workspaceRoot: resolve(workspaceRoot),
-    protectedPaths: [],
+    workspaceRoot: resolvedWorkspaceRoot,
+    protectedPaths: resolvePulSeedProtectedRoots({ workspaceRoot: resolvedWorkspaceRoot }),
     trustProjectInstructions: true,
   };
 }
@@ -41,17 +47,19 @@ export function resolveExecutionPolicy(input: {
   if (!security) return base;
 
   return {
+    executionProfile: base.executionProfile,
     sandboxMode: security.sandbox_mode ?? base.sandboxMode,
     approvalPolicy: security.approval_policy ?? base.approvalPolicy,
     networkAccess: security.network_access ?? base.networkAccess,
     workspaceRoot: base.workspaceRoot,
-    protectedPaths: [...(security.protected_paths ?? [])],
+    protectedPaths: [...base.protectedPaths, ...(security.protected_paths ?? [])],
     trustProjectInstructions: security.trust_project_instructions ?? base.trustProjectInstructions,
   };
 }
 
 export function summarizeExecutionPolicy(policy: ExecutionPolicy): string {
   const lines = [
+    `execution_profile: ${policy.executionProfile}`,
     `sandbox_mode: ${policy.sandboxMode}`,
     `approval_policy: ${policy.approvalPolicy}`,
     `network_access: ${policy.networkAccess ? "on" : "off"}`,

--- a/src/orchestrator/execution/agent-loop/self-protection.ts
+++ b/src/orchestrator/execution/agent-loop/self-protection.ts
@@ -1,0 +1,81 @@
+import { existsSync, realpathSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type PulSeedExecutionProfile = "consumer" | "dev";
+
+export function resolvePulSeedExecutionProfile(env: NodeJS.ProcessEnv = process.env): PulSeedExecutionProfile {
+  return env["PULSEED_DEV"] === "1" ? "dev" : "consumer";
+}
+
+export function resolvePulSeedProtectedRoots(input: {
+  workspaceRoot: string;
+  env?: NodeJS.ProcessEnv;
+  packageRoot?: string;
+}): string[] {
+  const env = input.env ?? process.env;
+  if (resolvePulSeedExecutionProfile(env) === "dev") return [];
+
+  const roots = new Set<string>();
+  const packageRoot = input.packageRoot ?? findPackageRoot(dirname(fileURLToPath(import.meta.url)));
+  if (packageRoot) roots.add(canonicalPath(packageRoot));
+
+  const workspaceRoot = canonicalPath(input.workspaceRoot);
+  if (isPulSeedPackageRoot(workspaceRoot)) roots.add(workspaceRoot);
+
+  for (const rawRoot of splitEnvRoots(env["PULSEED_SELF_PROTECTION_ROOTS"])) {
+    roots.add(canonicalPath(rawRoot));
+  }
+
+  return [...roots];
+}
+
+export function isPathInsideProtectedRoots(pathname: string, protectedRoots: readonly string[]): boolean {
+  const target = canonicalPath(pathname);
+  return protectedRoots.some((root) => {
+    const protectedRoot = canonicalPath(root);
+    return target === protectedRoot || target.startsWith(`${protectedRoot}/`);
+  });
+}
+
+function findPackageRoot(startDir: string): string | null {
+  let current = canonicalPath(startDir);
+  while (true) {
+    if (isPulSeedPackageRoot(current)) return current;
+    const parent = dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+function isPulSeedPackageRoot(root: string): boolean {
+  const packageJsonPath = join(root, "package.json");
+  if (!existsSync(packageJsonPath)) return false;
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf-8")) as { name?: unknown };
+    return parsed.name === "pulseed";
+  } catch {
+    return false;
+  }
+}
+
+function splitEnvRoots(value: string | undefined): string[] {
+  return value?.split(":").map((part) => part.trim()).filter(Boolean) ?? [];
+}
+
+function canonicalPath(value: string): string {
+  try {
+    return realpathSync(value);
+  } catch {
+    const resolved = resolve(value);
+    let current = resolved;
+    const missingParts: string[] = [];
+    while (!existsSync(current)) {
+      const parent = dirname(current);
+      if (parent === current) return resolved;
+      missingParts.unshift(relative(parent, current));
+      current = parent;
+    }
+    return resolve(realpathSync(current), ...missingParts);
+  }
+}

--- a/src/tools/__tests__/permission.test.ts
+++ b/src/tools/__tests__/permission.test.ts
@@ -49,6 +49,7 @@ describe("ToolPermissionManager", () => {
       const tool = makeTool({ permissionLevel: "write_local", isReadOnly: false });
       const result = await manager.check(tool, {}, makeContext({
         executionPolicy: {
+          executionProfile: "consumer",
           sandboxMode: "read_only",
           approvalPolicy: "on_request",
           networkAccess: false,
@@ -65,6 +66,7 @@ describe("ToolPermissionManager", () => {
       const tool = makeTool({ permissionLevel: "write_remote", isReadOnly: false });
       const result = await manager.check(tool, {}, makeContext({
         executionPolicy: {
+          executionProfile: "consumer",
           sandboxMode: "workspace_write",
           approvalPolicy: "on_request",
           networkAccess: false,
@@ -86,6 +88,7 @@ describe("ToolPermissionManager", () => {
       });
       const result = await manager.check(tool, {}, makeContext({
         executionPolicy: {
+          executionProfile: "consumer",
           sandboxMode: "workspace_write",
           approvalPolicy: "on_request",
           networkAccess: false,
@@ -102,6 +105,7 @@ describe("ToolPermissionManager", () => {
       const tool = makeTool({ name: "shell", permissionLevel: "read_metrics", isReadOnly: false });
       const result = await manager.check(tool, { command: "git status" }, makeContext({
         executionPolicy: {
+          executionProfile: "consumer",
           sandboxMode: "read_only",
           approvalPolicy: "on_request",
           networkAccess: false,

--- a/src/tools/fs/ApplyPatchTool/ApplyPatchTool.ts
+++ b/src/tools/fs/ApplyPatchTool/ApplyPatchTool.ts
@@ -3,6 +3,7 @@ import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 import { z } from "zod";
 import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../types.js";
+import { validateProtectedPath } from "../FileValidationTool/protected-path-policy.js";
 
 export const ApplyPatchInputSchema = z.object({
   patch: z.string().min(1),
@@ -35,11 +36,22 @@ export class ApplyPatchTool implements ITool<ApplyPatchInput> {
     const started = Date.now();
     const cwd = input.cwd ?? context.cwd;
     if (input.patch.trimStart().startsWith("*** Begin Patch")) {
-      return this.callCodexPatch(input, cwd, started);
+      return this.callCodexPatch(input, cwd, started, context.executionPolicy?.protectedPaths);
+    }
+    const changedPaths = extractPatchPaths(input.patch);
+    const blockedPath = findBlockedPatchPath(changedPaths, cwd, context.executionPolicy?.protectedPaths);
+    if (blockedPath) {
+      return {
+        success: false,
+        data: { changedPaths, stdout: "", stderr: blockedPath.error, checkOnly: input.checkOnly },
+        summary: `Patch blocked: ${blockedPath.error}`,
+        error: blockedPath.error,
+        durationMs: Date.now() - started,
+        artifacts: changedPaths,
+      };
     }
     const args = input.checkOnly ? ["apply", "--check", "--whitespace=nowarn", "-"] : ["apply", "--whitespace=nowarn", "-"];
     const result = await runGitApply(args, input.patch, cwd);
-    const changedPaths = extractPatchPaths(input.patch);
     return {
       success: result.exitCode === 0,
       data: {
@@ -57,9 +69,14 @@ export class ApplyPatchTool implements ITool<ApplyPatchInput> {
     };
   }
 
-  private async callCodexPatch(input: ApplyPatchInput, cwd: string, started: number): Promise<ToolResult> {
+  private async callCodexPatch(input: ApplyPatchInput, cwd: string, started: number, protectedPaths?: string[]): Promise<ToolResult> {
     try {
       const operations = parseCodexPatch(input.patch);
+      const changedPaths = operations.map((operation) => operation.filePath);
+      const blockedPath = findBlockedPatchPath(changedPaths, cwd, protectedPaths);
+      if (blockedPath) {
+        throw new Error(blockedPath.error);
+      }
       if (input.checkOnly) {
         for (const operation of operations) {
           await validateCodexPatchOperation(operation, cwd);
@@ -69,7 +86,6 @@ export class ApplyPatchTool implements ITool<ApplyPatchInput> {
           await applyCodexPatchOperation(operation, cwd);
         }
       }
-      const changedPaths = operations.map((operation) => operation.filePath);
       return {
         success: true,
         data: {
@@ -132,8 +148,30 @@ function extractPatchPaths(patch: string): string[] {
     if (match?.[1] && match[1] !== "/dev/null") {
       paths.add(match[1]);
     }
+    const deletedMatch = line.match(/^---\s+a\/(.+)$/);
+    if (deletedMatch?.[1] && deletedMatch[1] !== "/dev/null") {
+      paths.add(deletedMatch[1]);
+    }
   }
   return [...paths];
+}
+
+function findBlockedPatchPath(
+  changedPaths: string[],
+  cwd: string,
+  protectedPaths?: string[],
+): { path: string; error: string } | null {
+  for (const changedPath of changedPaths) {
+    const validation = validateProtectedPath(changedPath, {
+      cwd,
+      workspaceRoot: cwd,
+      protectedPaths,
+    });
+    if (!validation.valid) {
+      return { path: changedPath, error: validation.error ?? `Blocked patch path: ${changedPath}` };
+    }
+  }
+  return null;
 }
 
 type CodexPatchOperation =

--- a/src/tools/fs/FileValidationTool/protected-path-policy.ts
+++ b/src/tools/fs/FileValidationTool/protected-path-policy.ts
@@ -51,6 +51,19 @@ export function validateProtectedPath(
   ];
   const normalized = normalizeForMatch(pathFromWorkspace === "" ? "." : pathFromWorkspace);
   for (const pattern of protectedPatterns) {
+    const expandedPattern = expandTildePath(pattern);
+    if (isAbsolute(expandedPattern)) {
+      const protectedRoot = canonicalPath(expandedPattern);
+      if (resolved === protectedRoot || resolved.startsWith(`${protectedRoot}${sep}`)) {
+        return {
+          valid: false,
+          resolved,
+          error: `Blocked: path targets protected area "${pattern}"`,
+        };
+      }
+      continue;
+    }
+
     const protectedPattern = normalizeForMatch(pattern);
     const isBroadToken = !protectedPattern.includes("/") && !protectedPattern.startsWith(".");
     if (

--- a/src/tools/system/ShellTool/ShellTool.ts
+++ b/src/tools/system/ShellTool/ShellTool.ts
@@ -56,7 +56,12 @@ export class ShellTool implements ITool<ShellInput, ShellOutput> {
   }
 
   async checkPermissions(input: ShellInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
-    const assessment = assessShellCommand(input.command, context?.executionPolicy, context?.trusted === true);
+    const assessment = assessShellCommand(
+      input.command,
+      context?.executionPolicy,
+      context?.trusted === true,
+      input.cwd ?? context?.cwd,
+    );
     if (assessment.status === "allowed") return { status: "allowed" };
     if (assessment.status === "needs_approval") {
       return { status: "needs_approval", reason: assessment.reason ?? "Shell command requires approval" };

--- a/src/tools/system/ShellTool/command-policy.ts
+++ b/src/tools/system/ShellTool/command-policy.ts
@@ -1,4 +1,6 @@
+import { isAbsolute, resolve } from "node:path";
 import type { ExecutionPolicy } from "../../../orchestrator/execution/agent-loop/execution-policy.js";
+import { isPathInsideProtectedRoots } from "../../../orchestrator/execution/agent-loop/self-protection.js";
 
 export interface ShellCommandAssessment {
   status: "allowed" | "needs_approval" | "denied";
@@ -63,6 +65,7 @@ export function assessShellCommand(
   command: string,
   policy?: ExecutionPolicy,
   trusted = false,
+  cwd?: string,
 ): ShellCommandAssessment {
   const trimmed = command.trim();
   const segments = trimmed.split(/\s*(?:&&|\|\||;)\s*/).map((segment) => segment.trim()).filter(Boolean);
@@ -94,6 +97,10 @@ export function assessShellCommand(
     if (network) capabilities.network = true;
     if (destructive) capabilities.destructive = true;
     if (protectedTarget) capabilities.protectedTarget = true;
+  }
+
+  if ((capabilities.localWrite || !capabilities.readOnly) && targetsProtectedRoot(trimmed, policy, cwd)) {
+    return { status: "denied", reason: "Shell command would mutate a protected PulSeed source root", capabilities };
   }
 
   if (trusted && !capabilities.protectedTarget) {
@@ -145,4 +152,25 @@ export function assessShellCommand(
   }
 
   return { status: "allowed", capabilities };
+}
+
+function targetsProtectedRoot(command: string, policy: ExecutionPolicy | undefined, cwd: string | undefined): boolean {
+  if (!policy?.protectedPaths || policy.protectedPaths.length === 0) return false;
+  const effectiveCwd = cwd ?? policy.workspaceRoot;
+  if (isPathInsideProtectedRoots(effectiveCwd, policy.protectedPaths)) return true;
+  return extractPathLikeTokens(command).some((token) => {
+    const resolved = isAbsolute(token) ? token : resolve(effectiveCwd, token);
+    return isPathInsideProtectedRoots(resolved, policy.protectedPaths);
+  });
+}
+
+function extractPathLikeTokens(command: string): string[] {
+  return command
+    .split(/\s+/)
+    .map((token) => token.replace(/^['"]|['"]$/g, ""))
+    .filter((token) =>
+      token.length > 0
+      && !token.startsWith("-")
+      && (token.startsWith("/") || token.startsWith("./") || token.startsWith("../") || token.includes("/"))
+    );
 }

--- a/tmp/autonomous-routing-safety-issues-status.md
+++ b/tmp/autonomous-routing-safety-issues-status.md
@@ -1,0 +1,32 @@
+# Autonomous Routing Safety Issues Status
+
+## 2026-05-03
+
+### Initial sync
+- Ran `git switch main && git pull --ff-only`: main was already up to date with `origin/main`.
+- Ran `gh issue list --state open --limit 100`: #914 and #912 are both open.
+- Read #914 and #912 with `gh issue view --json`.
+
+### Issue #914 plan
+- Branch: `codex/issue-914-self-source-protection`.
+- Scope: add explicit consumer/dev execution profile with `PULSEED_DEV=1` opt-in, protect PulSeed package/source roots from agent-loop writes in consumer mode, keep setup/config writes under `~/.pulseed` outside this guard, and show dev mode in CLI-visible profile posture.
+- Production path: enforce via `ExecutionPolicy.protectedPaths` consumed by file write/edit validation, apply-patch validation, and shell command assessment.
+- Tests: cover production agent-loop tool runtime calls for normal-mode block and dev-mode allow, plus setup/config path unaffected through direct config write flow where feasible.
+- Blockers: none yet.
+
+### Issue #914 implementation status
+- Added `consumer` / `dev` execution profile resolution. `PULSEED_DEV=1` and global CLI `--dev` opt into dev profile.
+- In consumer profile, `ExecutionPolicy.protectedPaths` now includes PulSeed package/source roots and optional `PULSEED_SELF_PROTECTION_ROOTS` test/override roots.
+- Agent-loop production tool path now blocks protected root mutation through `apply_patch`, `file_write` / `file_edit` existing path validation, and `shell_command` mutating commands including explicit protected-path targets.
+- Dev profile leaves protected roots empty, so the same mutation path is allowed.
+- CLI goal status prints `Execution profile: dev` when dev mode is active.
+- Setup/config updates under `~/.pulseed` are not added to protected roots; existing direct setup/config write paths remain outside the new agent-loop source protection gate.
+- Verification so far:
+  - `npx vitest run src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts src/tools/__tests__/permission.test.ts` passed.
+  - `npm run typecheck` passed.
+  - `npm run lint:boundaries` passed with pre-existing warnings.
+  - `npm run test:changed` passed.
+- Review agent found two material bypasses: interpreter-based shell writes from protected cwd and unified delete patches. Both were fixed and covered by tests.
+
+### Issue #912 plan
+- Pending until #914 is merged.


### PR DESCRIPTION
Closes #914

## Summary
- add consumer/dev execution profile resolution with `PULSEED_DEV=1` and global CLI `--dev` opt-in
- protect PulSeed package/source roots in consumer-mode execution policy
- block protected-root writes through production agent-loop tool paths for `apply_patch`, `file_write`, `file_edit`, and mutating/unknown `shell_command` calls
- show dev profile in CLI status/profile posture when enabled

## Verification
- `npx vitest run src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts src/tools/__tests__/permission.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed`
- `git diff --check`

## Known unresolved risks
- Shell protection intentionally blocks non-read-only shell commands when cwd or explicit targets are protected; unusual read-only commands not in the current safe command contract may require dev mode inside the PulSeed source tree.