### PR TITLE
Route setup intents before agent loop

### DIFF
--- a/src/interface/chat/__tests__/chat-boundary-contract.test.ts
+++ b/src/interface/chat/__tests__/chat-boundary-contract.test.ts
@@ -229,6 +229,7 @@ describe("chat boundary contracts", () => {
       } as never,
       llmClient: createMockLLMClient([
         JSON.stringify({ intent: "none", reason: "ordinary greeting" }),
+        JSON.stringify({ kind: "execute", confidence: 0.93, rationale: "ordinary greeting" }),
         JSON.stringify({ intent: "restart_daemon", reason: "PulSeed を再起動して" }),
       ]),
       runtimeControlService,

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -62,6 +62,14 @@ function interruptDecision(kind: "diff" | "review" | "summary" | "background" | 
   return JSON.stringify({ kind, confidence, rationale: `test ${kind}` });
 }
 
+function freeformRouteDecision(kind: "assist" | "configure" | "execute" | "clarify", confidence = 0.93): string {
+  return JSON.stringify({ kind, confidence, rationale: `test ${kind}` });
+}
+
+function freeformExecuteDecision(): string {
+  return freeformRouteDecision("execute");
+}
+
 function makeInterruptibleAgentLoopRunner() {
   let capturedSignal: AbortSignal | undefined;
   let resolveActive: ((value: AgentResult) => void) | undefined;
@@ -2373,8 +2381,12 @@ describe("ChatRunner", () => {
       } as unknown as ChatAgentLoopRunner;
       const llmClient = {
         supportsToolCalling: () => true,
-        sendMessage: vi.fn().mockRejectedValue(new Error("sendMessage must not be called")),
-        parseJSON: vi.fn(),
+        sendMessage: vi.fn().mockResolvedValue({
+          content: freeformExecuteDecision(),
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: createSingleMockLLMClient(freeformExecuteDecision()).parseJSON,
       };
 
       const runner = new ChatRunner(makeDeps({
@@ -2387,7 +2399,7 @@ describe("ChatRunner", () => {
       const result = await runner.execute("Do something", "/repo");
 
       expect((chatAgentLoopRunner.execute as ReturnType<typeof vi.fn>)).toHaveBeenCalledOnce();
-      expect(llmClient.sendMessage).not.toHaveBeenCalled();
+      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Native agentloop response");
@@ -2436,8 +2448,12 @@ describe("ChatRunner", () => {
       } as unknown as ChatAgentLoopRunner;
       const llmClient = {
         supportsToolCalling: () => true,
-        sendMessage: vi.fn().mockRejectedValue(new Error("direct llm path must not be called")),
-        parseJSON: vi.fn(),
+        sendMessage: vi.fn().mockResolvedValue({
+          content: freeformExecuteDecision(),
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: createSingleMockLLMClient(freeformExecuteDecision()).parseJSON,
       };
 
       const runner = new ChatRunner(makeDeps({
@@ -2448,7 +2464,7 @@ describe("ChatRunner", () => {
       const result = await runner.execute("What route should answer this?", "/repo");
 
       expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
-      expect(llmClient.sendMessage).not.toHaveBeenCalled();
+      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Agentloop direct answer");
@@ -2562,7 +2578,9 @@ describe("ChatRunner", () => {
         chatAgentLoopRunner,
         llmClient: createMockLLMClient([
           JSON.stringify({ intent: "none", reason: "ordinary continuation" }),
+          freeformExecuteDecision(),
           JSON.stringify({ intent: "none", reason: "ordinary implementation finish request" }),
+          freeformExecuteDecision(),
         ]),
         runtimeControlService,
       }));
@@ -2594,11 +2612,11 @@ describe("ChatRunner", () => {
         const llmClient = {
           supportsToolCalling: () => true,
           sendMessage: vi.fn().mockResolvedValue({
-            content: "Improve the long-running task until the target metric is reached.",
+            content: freeformExecuteDecision(),
             usage: { input_tokens: 10, output_tokens: 12 },
             stop_reason: "stop",
           }),
-          parseJSON: vi.fn(),
+          parseJSON: createSingleMockLLMClient(freeformExecuteDecision()).parseJSON,
         };
         const goal = makeGoal("goal-long", {
           title: "Reach the long-running score target",
@@ -2630,7 +2648,7 @@ describe("ChatRunner", () => {
         expect(result.output).toBe("Agentloop handles handoff");
         expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
         expect(adapter.execute).not.toHaveBeenCalled();
-        expect(llmClient.sendMessage).not.toHaveBeenCalled();
+        expect(llmClient.sendMessage).toHaveBeenCalledOnce();
         expect(goalNegotiator.negotiate).not.toHaveBeenCalled();
         expect(daemonClient.startGoal).not.toHaveBeenCalled();
       } finally {
@@ -2680,7 +2698,7 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner: interruptible.runner,
-        llmClient: createSingleMockLLMClient(interruptDecision("background")),
+        llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("background")]),
       }));
       runner.startSession("/repo");
 
@@ -2708,7 +2726,7 @@ describe("ChatRunner", () => {
         const runner = new ChatRunner(makeDeps({
           stateManager: makeMockStateManager(),
           chatAgentLoopRunner: interruptible.runner,
-          llmClient: createSingleMockLLMClient(interruptDecision("diff")),
+          llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("diff")]),
         }));
         runner.startSession(tmpDir);
 
@@ -2734,7 +2752,7 @@ describe("ChatRunner", () => {
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner: interruptible.runner,
         reviewAgentLoopRunner,
-        llmClient: createSingleMockLLMClient(interruptDecision("review")),
+        llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("review")]),
       }));
       runner.startSession("/repo");
 
@@ -2755,7 +2773,7 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner: interruptible.runner,
-        llmClient: createSingleMockLLMClient(interruptDecision("summary")),
+        llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("summary")]),
       }));
       runner.startSession("/repo");
 
@@ -2775,7 +2793,7 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner: interruptible.runner,
-        llmClient: createSingleMockLLMClient(interruptDecision("unknown", 0.3)),
+        llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("unknown", 0.3)]),
       }));
       runner.startSession("/repo");
 
@@ -2792,8 +2810,24 @@ describe("ChatRunner", () => {
 
     it("does not apply stale interrupt classification after the active turn finishes", async () => {
       let releaseClassification!: () => void;
+      let sendMessageCount = 0;
       const llmClient = {
         sendMessage: vi.fn(async () => {
+          sendMessageCount += 1;
+          if (sendMessageCount === 1) {
+            return {
+              content: freeformExecuteDecision(),
+              usage: { input_tokens: 1, output_tokens: 1 },
+              stop_reason: "end_turn" as const,
+            };
+          }
+          if (sendMessageCount > 2) {
+            return {
+              content: freeformExecuteDecision(),
+              usage: { input_tokens: 1, output_tokens: 1 },
+              stop_reason: "end_turn" as const,
+            };
+          }
           await new Promise<void>((resolve) => {
             releaseClassification = resolve;
           });
@@ -2830,7 +2864,7 @@ describe("ChatRunner", () => {
       const active = runner.execute("Implement a feature", "/repo");
       await vi.waitFor(() => expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce());
       const redirected = runner.interruptAndRedirect("muéstrame los cambios", "/repo");
-      await vi.waitFor(() => expect(llmClient.sendMessage).toHaveBeenCalledOnce());
+      await vi.waitFor(() => expect(llmClient.sendMessage).toHaveBeenCalledTimes(2));
       finishActive();
       await active;
       releaseClassification();
@@ -3279,8 +3313,12 @@ describe("ChatRunner", () => {
       } as unknown as ChatAgentLoopRunner;
       const llmClient = {
         supportsToolCalling: () => true,
-        sendMessage: vi.fn().mockRejectedValue(new Error("direct llm path must not be called")),
-        parseJSON: vi.fn(),
+        sendMessage: vi.fn().mockResolvedValue({
+          content: JSON.stringify({ kind: "execute", confidence: 0.91, rationale: "needs repository inspection" }),
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn((content: string, schema: z.ZodType) => schema.parse(JSON.parse(content))),
       };
 
       const runner = new ChatRunner(makeDeps({
@@ -3291,7 +3329,7 @@ describe("ChatRunner", () => {
       const result = await runner.execute("What files changed?", "/repo");
 
       expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
-      expect(llmClient.sendMessage).not.toHaveBeenCalled();
+      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Agentloop checked it");
@@ -3311,8 +3349,12 @@ describe("ChatRunner", () => {
       } as unknown as ChatAgentLoopRunner;
       const llmClient = {
         supportsToolCalling: () => true,
-        sendMessage: vi.fn().mockRejectedValue(new Error("direct llm path must not be called")),
-        parseJSON: vi.fn(),
+        sendMessage: vi.fn().mockResolvedValue({
+          content: JSON.stringify({ kind: "execute", confidence: 0.9, rationale: "requires verification" }),
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn",
+        }),
+        parseJSON: vi.fn((content: string, schema: z.ZodType) => schema.parse(JSON.parse(content))),
       };
 
       const runner = new ChatRunner(makeDeps({
@@ -3323,10 +3365,102 @@ describe("ChatRunner", () => {
       const result = await runner.execute("Can you confirm whether this is safe?", "/repo");
 
       expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
-      expect(llmClient.sendMessage).not.toHaveBeenCalled();
+      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Confirmed with tools");
+    });
+
+    it("routes Japanese Telegram setup requests to guidance before agent-loop execution", async () => {
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
+      } as unknown as ChatAgentLoopRunner;
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "configure",
+          confidence: 0.94,
+          configure_target: "telegram_gateway",
+          rationale: "operator wants Telegram chat setup",
+        }),
+      ]);
+      const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner, llmClient }));
+
+      const result = await runner.execute("telegramからseedyと会話できるようにしたい", "/repo");
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("pulseed telegram setup");
+      expect(result.output).toContain("pulseed gateway setup");
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    });
+
+    it("routes English Telegram setup paraphrases to guidance before agent-loop execution", async () => {
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
+      } as unknown as ChatAgentLoopRunner;
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "configure",
+          confidence: 0.93,
+          configure_target: "telegram_gateway",
+          rationale: "operator wants Telegram gateway setup",
+        }),
+      ]);
+      const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner, llmClient }));
+
+      const result = await runner.execute("I want to talk to Seedy from Telegram.", "/repo");
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("pulseed telegram setup");
+      expect(result.output).toContain("pulseed daemon start");
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    });
+
+    it("asks for clarification on ambiguous freeform input instead of editing code", async () => {
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
+      } as unknown as ChatAgentLoopRunner;
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "clarify",
+          confidence: 0.62,
+          configure_target: "unknown",
+          rationale: "unclear desired action",
+        }),
+      ]);
+      const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner, llmClient }));
+
+      const result = await runner.execute("いい感じにして", "/repo");
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("one more detail");
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    });
+
+    it("continues explicit implementation requests into the coding agent-loop", async () => {
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "Implementation done",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
+        }),
+      } as unknown as ChatAgentLoopRunner;
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "execute",
+          confidence: 0.96,
+          rationale: "explicit code implementation request",
+        }),
+      ]);
+      const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner, llmClient }));
+
+      const result = await runner.execute("Implement the failing tests fix in this repo.", "/repo");
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe("Implementation done");
+      expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
     });
 
     it("keeps non-native-tool clients on the local LLM/tool loop instead of the adapter fallback", async () => {

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -4,7 +4,7 @@ import type { CrossPlatformChatSessionOptions } from "../cross-platform-session.
 import type { ChatRunnerDeps } from "../chat-runner.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adapter-layer.js";
-import { createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
+import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -318,10 +318,17 @@ describe("CrossPlatformChatSessionManager", () => {
       stateManager,
       adapter,
       chatAgentLoopRunner: chatAgentLoopRunner as never,
-      llmClient: createSingleMockLLMClient(JSON.stringify({
-        intent: "none",
-        reason: "ordinary implementation finish request",
-      })),
+      llmClient: createMockLLMClient([
+        JSON.stringify({
+          intent: "none",
+          reason: "ordinary implementation finish request",
+        }),
+        JSON.stringify({
+          kind: "execute",
+          confidence: 0.94,
+          rationale: "ordinary implementation finish request",
+        }),
+      ]),
       runtimeControlService,
       runtimeControlApprovalFn: vi.fn().mockResolvedValue(true),
     }));
@@ -343,6 +350,48 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
     expect(adapter.execute).not.toHaveBeenCalled();
     expect(runtimeControlService.request).not.toHaveBeenCalled();
+  });
+
+  it("routes gateway Telegram setup requests to configure guidance before agent-loop execution", async () => {
+    const stateManager = makeMockStateManager();
+    const adapter = makeMockAdapter();
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "agent loop should not run",
+        error: null,
+        exit_code: null,
+        elapsed_ms: 42,
+        stopped_reason: "completed",
+      }),
+    };
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager,
+      adapter,
+      chatAgentLoopRunner: chatAgentLoopRunner as never,
+      llmClient: createMockLLMClient([
+        JSON.stringify({
+          kind: "configure",
+          configure_target: "telegram_gateway",
+          confidence: 0.96,
+          rationale: "user wants Telegram chat setup",
+        }),
+      ]),
+    }));
+
+    const result = await manager.execute("telegramからseedyと会話できるようにしたい", {
+      identity_key: "owner",
+      platform: "telegram",
+      conversation_id: "telegram-chat-1",
+      user_id: "user-1",
+      cwd: "/repo",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("pulseed telegram setup");
+    expect(result.output).toContain("pulseed gateway setup");
+    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
   });
 
   it("routes long-running work through the native agent loop and leaves durable handoff to tools", async () => {

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -75,6 +75,80 @@ export async function executeRuntimeControlRoute(
   };
 }
 
+export async function executeConfigureRoute(
+  host: ChatRunnerRouteHost,
+  route: SelectedChatRoute,
+  eventContext: ChatEventContext,
+  assistantBuffer: AssistantBuffer,
+  history: { appendAssistantMessage(message: string): Promise<void> },
+  start: number,
+): Promise<ChatRunResult> {
+  if (route.kind !== "configure") {
+    throw new Error(`executeConfigureRoute received route kind ${route.kind}`);
+  }
+  const output = formatConfigureGuidance(route.intent.configure_target ?? "unknown");
+  return persistDirectRouteResult(host, output, eventContext, assistantBuffer, history, start);
+}
+
+export async function executeClarifyRoute(
+  host: ChatRunnerRouteHost,
+  _route: SelectedChatRoute,
+  eventContext: ChatEventContext,
+  assistantBuffer: AssistantBuffer,
+  history: { appendAssistantMessage(message: string): Promise<void> },
+  start: number,
+): Promise<ChatRunResult> {
+  const output = [
+    "I need one more detail before taking action.",
+    "",
+    "Tell me whether you want setup guidance, a configuration flow, or a code/test change.",
+  ].join("\n");
+  return persistDirectRouteResult(host, output, eventContext, assistantBuffer, history, start);
+}
+
+export async function executeAssistRoute(
+  host: ChatRunnerRouteHost,
+  params: {
+    input: string;
+    priorTurns: Array<{ role: string; content: string }>;
+    eventContext: ChatEventContext;
+    assistantBuffer: AssistantBuffer;
+    history: { appendAssistantMessage(message: string): Promise<void>; recordUsage(phase: string, usage: ChatUsageCounter): void };
+    start: number;
+  },
+): Promise<ChatRunResult> {
+  if (!host.deps.llmClient) {
+    return persistDirectRouteResult(
+      host,
+      "I can answer this as guidance, but no language model is configured for read-only chat.",
+      params.eventContext,
+      params.assistantBuffer,
+      params.history,
+      params.start,
+    );
+  }
+  host.eventBridge.emitCheckpoint("Read-only assist selected", "The message will be answered without coding-agent execution.", params.eventContext, "route");
+  const messages: LLMMessage[] = [
+    ...params.priorTurns.map((m): LLMMessage => ({ role: m.role === "assistant" ? "assistant" : "user", content: m.content })),
+    { role: "user", content: params.input },
+  ];
+  const response = await sendLLMMessage(host, host.deps.llmClient, messages, {
+    system: "Answer read-only. Provide concise operational guidance. Do not ask to edit files or run commands unless the user explicitly asks for execution.",
+    max_tokens: 1000,
+    temperature: 0,
+  }, params.assistantBuffer, params.eventContext);
+  const usage = usageFromLLMResponse(response);
+  if (hasUsage(usage)) params.history.recordUsage("assist", usage);
+  return persistDirectRouteResult(
+    host,
+    params.assistantBuffer.text || response.content || "(no response)",
+    params.eventContext,
+    params.assistantBuffer,
+    params.history,
+    params.start,
+  );
+}
+
 export async function executeAgentLoopRoute(
   host: ChatRunnerRouteHost,
   params: {
@@ -520,6 +594,57 @@ async function executeWithTools(
     output: lastAssistant?.content || "I was unable to complete the request within the allowed tool call limit.",
     usage,
   };
+}
+
+async function persistDirectRouteResult(
+  host: ChatRunnerRouteHost,
+  output: string,
+  eventContext: ChatEventContext,
+  assistantBuffer: AssistantBuffer,
+  history: { appendAssistantMessage(message: string): Promise<void> },
+  start: number,
+): Promise<ChatRunResult> {
+  const elapsed_ms = Date.now() - start;
+  if (!assistantBuffer.text) {
+    host.eventBridge.pushAssistantDelta(output, assistantBuffer, eventContext);
+  }
+  await history.appendAssistantMessage(output);
+  host.eventBridge.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
+  host.eventBridge.emitEvent({
+    type: "assistant_final",
+    text: output,
+    persisted: true,
+    ...host.eventBridge.eventBase(eventContext),
+  });
+  host.eventBridge.emitLifecycleEndEvent("completed", elapsed_ms, eventContext, true);
+  return { success: true, output, elapsed_ms };
+}
+
+function formatConfigureGuidance(target: "telegram_gateway" | "gateway" | "provider" | "daemon" | "notification" | "slack" | "unknown"): string {
+  if (target === "telegram_gateway") {
+    return [
+      "Telegram setup is a configuration flow, not a source-edit task.",
+      "",
+      "Run these from your shell:",
+      "1. `pulseed telegram setup`",
+      "2. `pulseed gateway setup`",
+      "3. `pulseed daemon start`",
+      "",
+      "After setup, send a message to the Telegram bot and confirm the gateway is running with `pulseed daemon status`.",
+    ].join("\n");
+  }
+  if (target === "gateway") {
+    return [
+      "Gateway setup is a configuration flow.",
+      "",
+      "Run `pulseed gateway setup`, then start or restart the daemon with `pulseed daemon start`.",
+    ].join("\n");
+  }
+  return [
+    "This looks like setup/configuration rather than a code-edit task.",
+    "",
+    "Use `pulseed setup` for the main wizard, `pulseed gateway setup` for chat channels, or the channel-specific setup command when available.",
+  ].join("\n");
 }
 
 async function dispatchToolCall(

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -56,11 +56,15 @@ import {
 } from "./chat-runner-runtime.js";
 import {
   executeAdapterRoute,
+  executeAssistRoute,
+  executeClarifyRoute,
+  executeConfigureRoute,
   executeAgentLoopRoute,
   executeRuntimeControlRoute,
   executeToolLoopRoute,
   resolveSessionExecutionPolicy,
 } from "./chat-runner-routes.js";
+import { classifyFreeformRouteIntent } from "./freeform-route-classifier.js";
 
 export interface ChatRunnerDeps {
   stateManager: StateManager;
@@ -474,6 +478,28 @@ export class ChatRunner {
       return runtimeControlResult;
     }
 
+    if (selectedRoute?.kind === "configure") {
+      const result = await executeConfigureRoute(this.routeHost(), selectedRoute, eventContext, assistantBuffer, history, start);
+      return result;
+    }
+
+    if (selectedRoute?.kind === "clarify") {
+      const result = await executeClarifyRoute(this.routeHost(), selectedRoute, eventContext, assistantBuffer, history, start);
+      return result;
+    }
+
+    if (selectedRoute?.kind === "assist") {
+      const result = await executeAssistRoute(this.routeHost(), {
+        input,
+        priorTurns,
+        eventContext,
+        assistantBuffer,
+        history,
+        start,
+      });
+      return result;
+    }
+
     const usesNativeAgentLoop = resumeOnly || selectedRoute?.kind === "agent_loop";
     const groundingWorkspaceContext = !resumeOnly && usesNativeAgentLoop
       ? await buildChatContext(input, executionCwd)
@@ -626,9 +652,13 @@ export class ChatRunner {
     const runtimeControlIntent = runtimeControlAllowed
       ? await recognizeRuntimeControlIntent(ingress.text, this.deps.llmClient)
       : null;
+    const freeformRouteIntent = runtimeControlIntent === null && capabilities.hasAgentLoop
+      ? await classifyFreeformRouteIntent(ingress.text, this.deps.llmClient)
+      : null;
     return standaloneIngressRouter.selectRoute(ingress, {
       ...capabilities,
       runtimeControlIntent,
+      freeformRouteIntent,
     });
   }
 

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -12,6 +12,7 @@ import {
   type SelectedChatRoute,
 } from "./ingress-router.js";
 import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
+import { classifyFreeformRouteIntent } from "./freeform-route-classifier.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { buildAdapterRegistry, buildLLMClient } from "../../base/llm/provider-factory.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
@@ -534,11 +535,16 @@ export class CrossPlatformChatSessionManager {
         capabilities.hasRuntimeControlService
         || (!capabilities.hasAgentLoop && !capabilities.hasToolLoop)
       );
+    const runtimeControlIntent = runtimeControlAllowed
+      ? await recognizeRuntimeControlIntent(ingress.text, this.deps.llmClient)
+      : null;
+    const freeformRouteIntent = runtimeControlIntent === null && capabilities.hasAgentLoop
+      ? await classifyFreeformRouteIntent(ingress.text, this.deps.llmClient)
+      : null;
     const selectedRoute = this.ingressRouter.selectRoute(ingress, {
       ...capabilities,
-      runtimeControlIntent: runtimeControlAllowed
-        ? await recognizeRuntimeControlIntent(ingress.text, this.deps.llmClient)
-        : null,
+      runtimeControlIntent,
+      freeformRouteIntent,
     });
     session.lastRoute = selectedRoute;
 

--- a/src/interface/chat/freeform-route-classifier.ts
+++ b/src/interface/chat/freeform-route-classifier.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+import { getInternalIdentityPrefix } from "../../base/config/identity-loader.js";
+
+export const FreeformRouteIntentSchema = z.object({
+  kind: z.enum(["assist", "configure", "execute", "clarify"]),
+  confidence: z.number().min(0).max(1),
+  configure_target: z.enum(["telegram_gateway", "gateway", "provider", "daemon", "notification", "slack", "unknown"]).optional(),
+  rationale: z.string().max(240),
+});
+
+export type FreeformRouteIntent = z.infer<typeof FreeformRouteIntentSchema>;
+
+export async function classifyFreeformRouteIntent(
+  input: string,
+  llmClient: ILLMClient | undefined,
+): Promise<FreeformRouteIntent | null> {
+  if (!llmClient) return null;
+  try {
+    const response = await llmClient.sendMessage(
+      [{ role: "user", content: input }],
+      { system: getFreeformRoutePrompt(), max_tokens: 500, temperature: 0 },
+    );
+    const parsed = llmClient.parseJSON(response.content, FreeformRouteIntentSchema);
+    return parsed instanceof Promise ? await parsed : parsed;
+  } catch {
+    return null;
+  }
+}
+
+function getFreeformRoutePrompt(): string {
+  return `${getInternalIdentityPrefix("assistant")} Route the operator's freeform chat message before any coding agent execution.
+
+Return only JSON:
+{
+  "kind": "assist" | "configure" | "execute" | "clarify",
+  "confidence": 0.0-1.0,
+  "configure_target": "telegram_gateway" | "gateway" | "provider" | "daemon" | "notification" | "slack" | "unknown",
+  "rationale": "short"
+}
+
+Routing contract:
+- assist: questions, how-to, status explanation, read-only guidance.
+- configure: setup/configuration of Telegram, Slack, daemon, provider, notifications, gateway, or channels.
+- execute: concrete repo edits, tests, implementation, commands, or goal execution that should enter the coding agent loop.
+- clarify: ambiguous or underspecified input where executing code would be unsafe.
+
+Use semantic intent, not literal phrase matching. Multilingual paraphrases should route by meaning.
+If the user wants to connect Seedy/PulSeed to a chat channel, configure the relevant gateway rather than execute source edits.
+If confidence is below 0.7, use clarify.`;
+}

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { ChatEventHandler } from "./chat-events.js";
 import type { RuntimeControlIntent } from "../../runtime/control/index.js";
+import type { FreeformRouteIntent } from "./freeform-route-classifier.js";
 import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
@@ -50,6 +51,14 @@ export interface ChatIngressMessage {
 
 export type SelectedChatRoute =
   | {
+      kind: "assist" | "configure" | "clarify";
+      reason: "freeform_semantic_route";
+      intent: FreeformRouteIntent;
+      replyTargetPolicy: ReplyTargetPolicy;
+      eventProjectionPolicy: EventProjectionPolicy;
+      concurrencyPolicy: ConcurrencyPolicy;
+    }
+  | {
       kind: "agent_loop" | "tool_loop" | "adapter";
       reason: "agent_loop_available" | "tool_loop_available" | "adapter_fallback";
       replyTargetPolicy: ReplyTargetPolicy;
@@ -70,6 +79,7 @@ export interface IngressRouterCapabilities {
   hasToolLoop: boolean;
   hasRuntimeControlService?: boolean;
   runtimeControlIntent?: RuntimeControlIntent | null;
+  freeformRouteIntent?: FreeformRouteIntent | null;
 }
 
 function selectRouteForText(
@@ -106,6 +116,26 @@ function selectRouteForText(
         ...runtimeControlPolicy,
       };
     }
+  }
+
+  const freeformIntent = deps.freeformRouteIntent ?? null;
+  if (freeformIntent && freeformIntent.confidence >= 0.7) {
+    if (freeformIntent.kind === "assist" || freeformIntent.kind === "configure" || freeformIntent.kind === "clarify") {
+      return {
+        kind: freeformIntent.kind,
+        reason: "freeform_semantic_route",
+        intent: freeformIntent,
+        ...baseTurnPolicy,
+      };
+    }
+  }
+  if (freeformIntent && freeformIntent.kind !== "execute") {
+    return {
+      kind: "clarify",
+      reason: "freeform_semantic_route",
+      intent: { ...freeformIntent, kind: "clarify" },
+      ...baseTurnPolicy,
+    };
   }
 
   if (deps.hasAgentLoop) {

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -4,6 +4,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DaemonClient } from "../../../runtime/daemon/client.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { TuiChatSurface } from "../chat-surface.js";
+import { ChatRunner } from "../../chat/chat-runner.js";
+import type { AgentResult, IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
+import type { ChatAgentLoopRunner } from "../../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
 import { App, DASHBOARD_REFRESH_INTERVAL_MS, formatDaemonConnectionState } from "../app.js";
 import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 
@@ -81,14 +84,18 @@ vi.mock("../../../runtime/store/health-store.js", () => ({
   },
 }));
 
-vi.mock("../../../runtime/store/evidence-ledger.js", () => ({
-  RuntimeEvidenceLedger: class {
+vi.mock("../../../runtime/store/evidence-ledger.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../runtime/store/evidence-ledger.js")>();
+  return {
+    ...actual,
+    RuntimeEvidenceLedger: class {
     summarizeRun = vi.fn(async (runId: string) => {
       testState.summarizedRunIds.push(runId);
       return testState.runtimeEvidenceSummaries[runId] ?? null;
     });
-  },
-}));
+    },
+  };
+});
 
 vi.mock("../help-overlay.js", () => ({ HelpOverlay: () => null }));
 vi.mock("../settings-overlay.js", () => ({ SettingsOverlay: () => null }));
@@ -128,6 +135,8 @@ function createStateManagerMock() {
     listGoalIds: vi.fn(async () => [] as string[]),
     loadGoal: vi.fn(async () => null),
     getBaseDir: vi.fn(() => "/tmp/pulseed-tui-test"),
+    writeRaw: vi.fn(async () => undefined),
+    readRaw: vi.fn(async () => null),
   };
 }
 
@@ -140,6 +149,22 @@ function createChatRunnerMock() {
     getConversationId: vi.fn(() => "tui-conversation-test"),
     onEvent: undefined,
   };
+}
+
+const CANNED_AGENT_RESULT: AgentResult = {
+  success: true,
+  output: "Task completed successfully.",
+  error: null,
+  exit_code: 0,
+  elapsed_ms: 50,
+  stopped_reason: "completed",
+};
+
+function createAdapterMock(result: AgentResult = CANNED_AGENT_RESULT): IAdapter {
+  return {
+    adapterType: "mock",
+    execute: vi.fn().mockResolvedValue(result),
+  } as unknown as IAdapter;
 }
 
 function nonEvidenceResponse(): string {
@@ -767,6 +792,89 @@ describe("standalone slash command routing", () => {
     expect(llmClient.callCount).toBe(2);
     expect(chatRunner.execute).toHaveBeenCalledWith("このタスクの進め方を説明して", "/work/kaggle");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+
+    screen.unmount();
+  });
+
+  it("routes Telegram setup freeform input through the production TUI ChatRunner path", async () => {
+    const stateManager = createStateManagerMock();
+    const adapter = createAdapterMock();
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "agent loop should not run",
+        error: null,
+        exit_code: null,
+        elapsed_ms: 42,
+        stopped_reason: "completed",
+      }),
+    } as unknown as ChatAgentLoopRunner;
+    const realRunner = new ChatRunner({
+      stateManager: stateManager as unknown as StateManager,
+      adapter,
+      chatAgentLoopRunner,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        kind: "configure",
+        configure_target: "telegram_gateway",
+        confidence: 0.97,
+        rationale: "user wants Telegram chat setup",
+      })) as never,
+    });
+    let chatRunnerOutput = "";
+    const chatRunner = {
+      startSession: vi.fn(),
+      execute: vi.fn(async (input: string, cwd: string) => {
+        const result = await realRunner.execute(input, cwd);
+        chatRunnerOutput = result.output;
+        return result;
+      }),
+      interruptAndRedirect: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
+      executeIngressMessage: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
+      getConversationId: vi.fn(() => "tui-conversation-test"),
+      onEvent: undefined,
+    };
+    const llmClient = createMockLLMClient([
+      JSON.stringify({
+        decision: "not_runtime_evidence_question",
+        topics: [],
+        confidence: 0.98,
+        rationale: "setup request, not runtime evidence",
+      }),
+      JSON.stringify({
+        decision: "not_run_spec_request",
+        confidence: 0.95,
+        missing_fields: [],
+      }),
+    ]);
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      llmClient,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/work/pulseed",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("telegramからseedyと会話できるようにしたい");
+    await flush();
+
+    expect(chatRunner.execute).toHaveBeenCalledWith("telegramからseedyと会話できるようにしたい", "/work/pulseed");
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(chatRunnerOutput).toContain("pulseed telegram setup"));
+    expect(chatRunnerOutput).toContain("pulseed telegram setup");
+    expect(chatRunnerOutput).toContain("pulseed gateway setup");
+    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
 
     screen.unmount();
   });

--- a/tmp/autonomous-routing-safety-issues-status.md
+++ b/tmp/autonomous-routing-safety-issues-status.md
@@ -29,4 +29,25 @@
 - Review agent found two material bypasses: interpreter-based shell writes from protected cwd and unified delete patches. Both were fixed and covered by tests.
 
 ### Issue #912 plan
-- Pending until #914 is merged.
+- Branch: `codex/issue-912-setup-help-routing`.
+- #914 dependency completed: PR #944 merged with green `unit (22)` and `integration (24)`.
+- Scope: add a typed freeform semantic routing contract before coding agent-loop execution, using structured LLM classification with confidence/clarification instead of keyword/includes logic.
+- Route classes: `assist`, `configure`, `execute`, `clarify`.
+- Configure route will return actionable setup guidance for Telegram/gateway setup without launching agent-loop.
+- Tests: ChatRunner production route tests for Japanese/English Telegram setup and ambiguous clarification, explicit execute still entering agent-loop, and a TUI caller-path test proving freeform input reaches ChatRunner rather than direct lower-level execution.
+- Blockers: none yet.
+
+### Issue #912 implementation status
+- Added `FreeformRouteIntentSchema` and an LLM-backed pre-agent route classifier for freeform ChatRunner input.
+- `IngressRouter` now accepts typed freeform route intent and selects `assist`, `configure`, `clarify`, or existing execution routes before coding agent-loop handoff.
+- `configure` returns actionable Telegram/gateway/setup guidance without invoking the coding agent loop; `clarify` asks for setup/config/code intent; `assist` stays read-only through the LLM response path.
+- Added ChatRunner production routing tests for Japanese and English Telegram setup requests, ambiguous clarification, and explicit implementation still entering agent-loop.
+- Added a TUI caller-path test confirming freeform Telegram setup input reaches the production ChatRunner entrypoint.
+- Verification so far:
+  - `npm run typecheck` passed.
+  - `npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/tui/__tests__/app.test.ts` passed.
+  - `npm run lint:boundaries` passed with pre-existing warnings.
+  - `npm run test:changed` passed.
+  - `git diff --check` passed.
+- Review: fresh review agent found a cross-platform gateway bypass and weak TUI route coverage. Fixed by passing `freeformRouteIntent` through `CrossPlatformChatSessionManager`, adding a Telegram gateway production session regression test, and strengthening the TUI test to execute a real ChatRunner route.
+- Additional regression update: `chat-boundary-contract` now accounts for the new freeform execute pre-route while preserving latest reply-target runtime-control behavior.


### PR DESCRIPTION
Closes #912

## Summary
- add a typed freeform route intent contract for assist/configure/execute/clarify before coding agent-loop execution
- route Telegram/gateway setup requests to actionable setup guidance without launching the agent loop
- wire the same semantic route through ChatRunner, TUI freeform flow, and cross-platform gateway sessions

## Verification
- npm run typecheck
- npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/tui/__tests__/app.test.ts
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known unresolved risks
- Freeform routing depends on the configured LLM classifier; parse/send failures intentionally fall back to existing execution routing rather than blocking all chat.
- Setup guidance is intentionally limited to current CLI commands and does not perform secret submission or irreversible configuration automatically.