### PR TITLE
Define channel-agnostic agent timeline events

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -56,6 +56,156 @@ describe("applyChatEventToMessages", () => {
     expect(messages[0]!.text).toContain("Reading shell_command - command=rg ChatEvent src/interface/chat");
   });
 
+  it("renders shared agent timeline items as chronological chat messages", () => {
+    const base = {
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+    };
+    const timelineBase = {
+      sourceEventId: "event-1",
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "agent-turn-1",
+      goalId: "goal-1",
+      visibility: "user" as const,
+    };
+    const events = [
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:commentary-1",
+          sourceEventId: "commentary-1",
+          sourceType: "assistant_message" as const,
+          createdAt: "2026-04-08T00:00:01.000Z",
+          kind: "assistant_message" as const,
+          phase: "commentary" as const,
+          text: "I will inspect the relevant files first.",
+          toolCallCount: 1,
+        },
+      },
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:tool-start-1",
+          sourceEventId: "tool-start-1",
+          sourceType: "tool_call_started" as const,
+          createdAt: "2026-04-08T00:00:02.000Z",
+          kind: "tool" as const,
+          status: "started" as const,
+          callId: "call-1",
+          toolName: "shell_command",
+          inputPreview: "{\"command\":\"pwd\"}",
+        },
+      },
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:tool-finish-1",
+          sourceEventId: "tool-finish-1",
+          sourceType: "tool_call_finished" as const,
+          createdAt: "2026-04-08T00:00:03.000Z",
+          kind: "tool" as const,
+          status: "finished" as const,
+          callId: "call-1",
+          toolName: "shell_command",
+          success: true,
+          outputPreview: "/repo",
+          durationMs: 10,
+        },
+      },
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:final-1",
+          sourceEventId: "final-1",
+          sourceType: "final" as const,
+          createdAt: "2026-04-08T00:00:04.000Z",
+          kind: "final" as const,
+          success: true,
+          outputPreview: "Done",
+        },
+      },
+    ];
+
+    const messages = events.reduce(
+      (current, event) => applyChatEventToMessages(current, event, 20),
+      [] as ReturnType<typeof applyChatEventToMessages>
+    );
+
+    expect(messages.map((message) => message.id)).toEqual([
+      "agent-timeline:turn-1:commentary-1",
+      "agent-timeline:turn-1:tool-start-1",
+      "agent-timeline:turn-1:tool-finish-1",
+      "agent-timeline:turn-1:final-1",
+    ]);
+    expect(messages.map((message) => message.text)).toEqual([
+      "I will inspect the relevant files first.",
+      "Started shell_command: {\"command\":\"pwd\"}",
+      "Finished shell_command: /repo",
+      "Done",
+    ]);
+
+    const afterFinal = applyChatEventToMessages(messages, {
+      type: "assistant_final",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:05.000Z",
+      text: "Done",
+      persisted: true,
+    }, 20);
+
+    expect(afterFinal.map((message) => message.id)).toEqual(["turn-1"]);
+    expect(afterFinal[0]!.text).toBe("Done");
+  });
+
+  it("drops transient timeline overflow before evicting durable chat messages", () => {
+    let messages = applyChatEventToMessages([], {
+      type: "assistant_final",
+      runId: "run-1",
+      turnId: "older-turn",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      text: "Earlier durable answer",
+      persisted: true,
+    }, 3);
+
+    for (let index = 1; index <= 4; index += 1) {
+      messages = applyChatEventToMessages(messages, {
+        type: "agent_timeline",
+        runId: "run-1",
+        turnId: "turn-1",
+        createdAt: `2026-04-08T00:00:0${index}.000Z`,
+        item: {
+          id: `agent-timeline:commentary-${index}`,
+          sourceEventId: `commentary-${index}`,
+          sourceType: "assistant_message",
+          sessionId: "session-1",
+          traceId: "trace-1",
+          turnId: "agent-turn-1",
+          goalId: "goal-1",
+          createdAt: `2026-04-08T00:00:0${index}.000Z`,
+          visibility: "user",
+          kind: "assistant_message",
+          phase: "commentary",
+          text: `Working step ${index}`,
+          toolCallCount: 0,
+        },
+      }, 3);
+    }
+
+    expect(messages.some((message) => message.id === "older-turn")).toBe(true);
+    expect(messages).toHaveLength(3);
+    expect(messages.filter((message) => message.transient)).toHaveLength(2);
+  });
+
   it("removes transient activity when assistant final arrives", () => {
     const withActivity = applyChatEventToMessages([], {
       type: "activity",

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -2330,30 +2330,57 @@ describe("ChatRunner", () => {
           eventSink?: { emit(event: unknown): Promise<void> | void };
           approvalFn?: (request: { reason: string }) => Promise<boolean>;
         }) => {
+          const base = {
+            sessionId: "session-1",
+            traceId: "trace-1",
+            turnId: "agent-turn",
+            goalId: "goal-1",
+            createdAt: new Date().toISOString(),
+          };
           await input.eventSink?.emit({
+            ...base,
+            type: "model_request",
+            eventId: "model-event-1",
+            model: "gpt-test",
+            toolCount: 2,
+          });
+          await input.eventSink?.emit({
+            ...base,
+            type: "assistant_message",
+            eventId: "commentary-event-1",
+            phase: "commentary",
+            contentPreview: "I will inspect the workspace first.",
+            toolCallCount: 1,
+          });
+          await input.eventSink?.emit({
+            ...base,
             type: "tool_call_started",
+            eventId: "tool-start-event-1",
             callId: "call-1",
             toolName: "shell_command",
             inputPreview: "{\"command\":\"pwd\"}",
           });
           await input.eventSink?.emit({
+            ...base,
             type: "plan_update",
             eventId: "plan-event-1",
-            turnId: "agent-turn",
-            createdAt: new Date().toISOString(),
             summary: "Inspect workspace, apply patch, then verify.",
           });
           await input.eventSink?.emit({
+            ...base,
             type: "approval_request",
+            eventId: "approval-event-1",
             callId: "call-approval",
-            turnId: "agent-turn",
-            createdAt: new Date().toISOString(),
             toolName: "apply_patch",
             reason: "needs confirmation",
+            permissionLevel: "workspace-write",
+            isDestructive: false,
           });
           await input.approvalFn?.({ reason: "needs confirmation" });
           await input.eventSink?.emit({
+            ...base,
             type: "tool_call_finished",
+            eventId: "tool-finish-event-1",
             callId: "call-1",
             toolName: "shell_command",
             success: true,
@@ -2361,13 +2388,28 @@ describe("ChatRunner", () => {
             durationMs: 12,
           });
           await input.eventSink?.emit({
+            ...base,
             type: "context_compaction",
+            eventId: "compaction-event-1",
             turnId: "agent-turn",
-            createdAt: new Date().toISOString(),
             phase: "mid_turn",
             reason: "context_limit",
             inputMessages: 10,
             outputMessages: 4,
+            summaryPreview: "Shorter context",
+          });
+          await input.eventSink?.emit({
+            ...base,
+            type: "final",
+            eventId: "final-event-1",
+            success: true,
+            outputPreview: "Native agentloop response",
+          });
+          await input.eventSink?.emit({
+            ...base,
+            type: "stopped",
+            eventId: "stopped-event-1",
+            reason: "completed",
           });
           return {
             success: true,
@@ -2432,6 +2474,21 @@ describe("ChatRunner", () => {
       expect(eventTypes).toContain("tool_start");
       expect(eventTypes).toContain("tool_end");
       expect(eventTypes).toContain("tool_update");
+      const timelineSourceTypes = seenEvents
+        .filter((event): event is Extract<ChatEvent, { type: "agent_timeline" }> =>
+          event.type === "agent_timeline"
+        )
+        .map((event) => event.item.sourceType);
+      expect(timelineSourceTypes).toEqual(expect.arrayContaining([
+        "model_request",
+        "assistant_message",
+        "tool_call_started",
+        "tool_call_finished",
+        "final",
+        "stopped",
+      ]));
+      expect(timelineSourceTypes.indexOf("assistant_message")).toBeLessThan(timelineSourceTypes.indexOf("tool_call_started"));
+      expect(timelineSourceTypes.indexOf("tool_call_finished")).toBeLessThan(timelineSourceTypes.indexOf("final"));
     });
 
     it("routes simple questions through chatAgentLoopRunner when configured", async () => {

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -1,5 +1,6 @@
 import type { ChatEvent } from "./chat-events.js";
 import { formatLifecycleFailureMessage } from "./failure-recovery.js";
+import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
 
 type ToolActivityState = "reading" | "planning" | "editing" | "verifying" | "waiting" | "running" | "completed" | "failed";
 
@@ -34,7 +35,20 @@ function upsertMessage(
     next[index] = nextMessage;
     return next;
   }
-  return [...next, nextMessage].slice(-maxMessages);
+  return trimMessages([...next, nextMessage], maxMessages);
+}
+
+function trimMessages(messages: StreamChatMessage[], maxMessages: number): StreamChatMessage[] {
+  if (messages.length <= maxMessages) return messages;
+  const overflow = messages.length - maxMessages;
+  let remainingTransientDrops = overflow;
+  const withoutTransientOverflow = messages.filter((message) => {
+    if (remainingTransientDrops <= 0 || !message.transient) return true;
+    remainingTransientDrops -= 1;
+    return false;
+  });
+  if (withoutTransientOverflow.length <= maxMessages) return withoutTransientOverflow;
+  return withoutTransientOverflow.slice(-maxMessages);
 }
 
 function removeTransientActivityForTurn(
@@ -42,7 +56,12 @@ function removeTransientActivityForTurn(
   turnId: string
 ): StreamChatMessage[] {
   const transientActivityId = `activity:${turnId}`;
-  return messages.filter((message) => !(message.id === transientActivityId && message.transient));
+  const transientTimelinePrefix = `agent-timeline:${turnId}:`;
+  return messages.filter((message) => {
+    if (!message.transient) return true;
+    if (message.id === transientActivityId) return false;
+    return !message.id.startsWith(transientTimelinePrefix);
+  });
 }
 
 function getToolLogId(turnId: string): string {
@@ -54,6 +73,43 @@ function getActivityMessageId(event: Extract<ChatEvent, { type: "activity" }>): 
     return `activity:${event.turnId}:${event.sourceId}`;
   }
   return `activity:${event.turnId}`;
+}
+
+function getTimelineMessageId(chatTurnId: string, item: AgentTimelineItem): string {
+  return `agent-timeline:${chatTurnId}:${item.sourceEventId}`;
+}
+
+function renderTimelineItem(item: AgentTimelineItem): string {
+  switch (item.kind) {
+    case "lifecycle":
+      if (item.status === "resumed") {
+        return `Resumed ${item.restoredMessages ?? 0} message(s) from ${item.fromUpdatedAt ?? "saved state"}.`;
+      }
+      return "Started work.";
+    case "turn_context":
+      return `Prepared turn context with ${item.model} and ${item.visibleTools.length} tool(s).`;
+    case "model_request":
+      return `Asked ${item.model} for the next step with ${item.toolCount} available tool(s).`;
+    case "assistant_message":
+      return item.text;
+    case "tool": {
+      const detail = item.status === "started" ? item.inputPreview : item.outputPreview;
+      const label = item.status === "started" ? "Started" : item.success ? "Finished" : "Failed";
+      return detail ? `${label} ${item.toolName}: ${detail}` : `${label} ${item.toolName}.`;
+    }
+    case "plan":
+      return `Plan updated: ${item.summary}`;
+    case "approval":
+      return item.status === "requested"
+        ? `Approval requested for ${item.toolName}: ${item.reason}`
+        : `Approval denied for ${item.toolName}: ${item.reason}`;
+    case "compaction":
+      return `Compacted context (${item.phase}, ${item.reason}): ${item.inputMessages} -> ${item.outputMessages}.`;
+    case "final":
+      return item.outputPreview;
+    case "stopped":
+      return item.reasonDetail ? `Stopped: ${item.reason} (${item.reasonDetail})` : `Stopped: ${item.reason}`;
+  }
 }
 
 function summarizeValue(value: unknown): string {
@@ -267,6 +323,20 @@ export function applyChatEventToMessages(
       timestamp,
       messageType: "info",
       transient: event.transient === true,
+    }, maxMessages);
+  }
+
+  if (event.type === "agent_timeline") {
+    if (event.item.visibility !== "user") return messages;
+    const text = renderTimelineItem(event.item).trim();
+    if (!text) return messages;
+    return upsertMessage(messages, {
+      id: getTimelineMessageId(event.turnId, event.item),
+      role: "pulseed",
+      text,
+      timestamp: new Date(event.item.createdAt),
+      messageType: event.item.kind === "stopped" ? "warning" : "info",
+      transient: true,
     }, maxMessages);
   }
 

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -1,4 +1,5 @@
 import type { FailureRecoveryGuidance } from "./failure-recovery.js";
+import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
 
 export interface ChatEventBase {
   runId: string;
@@ -57,6 +58,11 @@ export interface ToolEndEvent extends ChatEventBase {
   durationMs: number;
 }
 
+export interface AgentTimelineEvent extends ChatEventBase {
+  type: "agent_timeline";
+  item: AgentTimelineItem;
+}
+
 export interface LifecycleEndEvent extends ChatEventBase {
   type: "lifecycle_end";
   status: "completed" | "error";
@@ -77,6 +83,7 @@ export type ChatEvent =
   | AssistantDeltaEvent
   | AssistantFinalEvent
   | ActivityEvent
+  | AgentTimelineEvent
   | ToolStartEvent
   | ToolUpdateEvent
   | ToolEndEvent

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -3,6 +3,7 @@ import type {
   AgentLoopEvent,
   AgentLoopEventSink,
 } from "../../orchestrator/execution/agent-loop/agent-loop-events.js";
+import { projectAgentLoopEventToTimeline } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
 import {
   DIFF_ARTIFACT_MAX_LINES,
   formatIntentInput,
@@ -120,6 +121,12 @@ export class ChatRunnerEventBridge {
   createAgentLoopEventSink(eventContext: ChatEventContext): AgentLoopEventSink {
     return {
       emit: async (event: AgentLoopEvent) => {
+        this.emitEvent({
+          type: "agent_timeline",
+          item: projectAgentLoopEventToTimeline(event),
+          ...this.eventBase(eventContext),
+        });
+
         if (event.type === "tool_call_started") {
           const detail = event.inputPreview ? previewActivityText(event.inputPreview) : undefined;
           this.emitActivity("tool", formatToolActivity("Running", event.toolName, detail), eventContext, event.callId);

--- a/src/orchestrator/execution/agent-loop/agent-timeline.ts
+++ b/src/orchestrator/execution/agent-loop/agent-timeline.ts
@@ -1,0 +1,225 @@
+import type { AgentLoopEvent } from "./agent-loop-events.js";
+
+export type AgentTimelineItem =
+  | AgentTimelineLifecycleItem
+  | AgentTimelineTurnContextItem
+  | AgentTimelineModelRequestItem
+  | AgentTimelineAssistantMessageItem
+  | AgentTimelineToolItem
+  | AgentTimelinePlanItem
+  | AgentTimelineApprovalItem
+  | AgentTimelineCompactionItem
+  | AgentTimelineFinalItem
+  | AgentTimelineStoppedItem;
+
+export interface AgentTimelineBaseItem {
+  id: string;
+  sourceEventId: string;
+  sourceType: AgentLoopEvent["type"];
+  sessionId: string;
+  traceId: string;
+  turnId: string;
+  goalId: string;
+  taskId?: string;
+  createdAt: string;
+  visibility: "user" | "debug";
+}
+
+export interface AgentTimelineLifecycleItem extends AgentTimelineBaseItem {
+  kind: "lifecycle";
+  status: "started" | "resumed";
+  restoredMessages?: number;
+  fromUpdatedAt?: string;
+}
+
+export interface AgentTimelineTurnContextItem extends AgentTimelineBaseItem {
+  kind: "turn_context";
+  cwd: string;
+  model: string;
+  visibleTools: string[];
+}
+
+export interface AgentTimelineModelRequestItem extends AgentTimelineBaseItem {
+  kind: "model_request";
+  model: string;
+  toolCount: number;
+}
+
+export interface AgentTimelineAssistantMessageItem extends AgentTimelineBaseItem {
+  kind: "assistant_message";
+  phase: "commentary" | "final_candidate";
+  text: string;
+  toolCallCount: number;
+}
+
+export interface AgentTimelineToolItem extends AgentTimelineBaseItem {
+  kind: "tool";
+  status: "started" | "finished";
+  callId: string;
+  toolName: string;
+  inputPreview?: string;
+  success?: boolean;
+  disposition?: "respond_to_model" | "fatal" | "approval_denied" | "cancelled";
+  outputPreview?: string;
+  durationMs?: number;
+  artifacts?: string[];
+  truncated?: {
+    originalChars: number;
+    overflowPath?: string;
+  };
+}
+
+export interface AgentTimelinePlanItem extends AgentTimelineBaseItem {
+  kind: "plan";
+  summary: string;
+}
+
+export interface AgentTimelineApprovalItem extends AgentTimelineBaseItem {
+  kind: "approval";
+  status: "requested" | "denied";
+  callId?: string;
+  toolName: string;
+  reason: string;
+  permissionLevel?: string;
+  isDestructive?: boolean;
+}
+
+export interface AgentTimelineCompactionItem extends AgentTimelineBaseItem {
+  kind: "compaction";
+  phase: "pre_turn" | "mid_turn" | "standalone_turn";
+  reason: "context_limit" | "model_downshift" | "manual";
+  inputMessages: number;
+  outputMessages: number;
+  summaryPreview: string;
+}
+
+export interface AgentTimelineFinalItem extends AgentTimelineBaseItem {
+  kind: "final";
+  success: boolean;
+  outputPreview: string;
+}
+
+export interface AgentTimelineStoppedItem extends AgentTimelineBaseItem {
+  kind: "stopped";
+  reason: string;
+  reasonDetail?: string;
+}
+
+export function projectAgentLoopEventToTimeline(event: AgentLoopEvent): AgentTimelineItem {
+  const base = {
+    id: `agent-timeline:${event.eventId}`,
+    sourceEventId: event.eventId,
+    sourceType: event.type,
+    sessionId: event.sessionId,
+    traceId: event.traceId,
+    turnId: event.turnId,
+    goalId: event.goalId,
+    ...(event.taskId ? { taskId: event.taskId } : {}),
+    createdAt: event.createdAt,
+    visibility: "user" as const,
+  };
+
+  switch (event.type) {
+    case "started":
+      return { ...base, kind: "lifecycle", status: "started" };
+    case "resumed":
+      return {
+        ...base,
+        kind: "lifecycle",
+        status: "resumed",
+        restoredMessages: event.restoredMessages,
+        fromUpdatedAt: event.fromUpdatedAt,
+      };
+    case "turn_context":
+      return {
+        ...base,
+        kind: "turn_context",
+        cwd: event.cwd,
+        model: event.model,
+        visibleTools: event.visibleTools,
+      };
+    case "model_request":
+      return {
+        ...base,
+        kind: "model_request",
+        model: event.model,
+        toolCount: event.toolCount,
+      };
+    case "assistant_message":
+      return {
+        ...base,
+        kind: "assistant_message",
+        phase: event.phase,
+        text: event.contentPreview,
+        toolCallCount: event.toolCallCount,
+      };
+    case "tool_call_started":
+      return {
+        ...base,
+        kind: "tool",
+        status: "started",
+        callId: event.callId,
+        toolName: event.toolName,
+        inputPreview: event.inputPreview,
+      };
+    case "tool_call_finished":
+      return {
+        ...base,
+        kind: "tool",
+        status: "finished",
+        callId: event.callId,
+        toolName: event.toolName,
+        success: event.success,
+        ...(event.disposition ? { disposition: event.disposition } : {}),
+        outputPreview: event.outputPreview,
+        durationMs: event.durationMs,
+        ...(event.artifacts ? { artifacts: event.artifacts } : {}),
+        ...(event.truncated ? { truncated: event.truncated } : {}),
+      };
+    case "plan_update":
+      return { ...base, kind: "plan", summary: event.summary };
+    case "approval_request":
+      return {
+        ...base,
+        kind: "approval",
+        status: "requested",
+        callId: event.callId,
+        toolName: event.toolName,
+        reason: event.reason,
+        permissionLevel: event.permissionLevel,
+        isDestructive: event.isDestructive,
+      };
+    case "approval":
+      return {
+        ...base,
+        kind: "approval",
+        status: "denied",
+        toolName: event.toolName,
+        reason: event.reason,
+      };
+    case "context_compaction":
+      return {
+        ...base,
+        kind: "compaction",
+        phase: event.phase,
+        reason: event.reason,
+        inputMessages: event.inputMessages,
+        outputMessages: event.outputMessages,
+        summaryPreview: event.summaryPreview,
+      };
+    case "final":
+      return {
+        ...base,
+        kind: "final",
+        success: event.success,
+        outputPreview: event.outputPreview,
+      };
+    case "stopped":
+      return {
+        ...base,
+        kind: "stopped",
+        reason: event.reason,
+        ...(event.reasonDetail ? { reasonDetail: event.reasonDetail } : {}),
+      };
+  }
+}

--- a/tmp/shared-agent-timeline-status.md
+++ b/tmp/shared-agent-timeline-status.md
@@ -1,0 +1,14 @@
+# Shared Agent Timeline Status
+
+## 2026-05-03 - startup
+- Ran `git switch main && git pull --ff-only`: main was already current with origin/main.
+- Ran `gh issue list --state open --limit 100`: #945, #946, #947, #948, #949 are all open; newer open issues are intentionally ignored for this batch.
+
+## #945 plan
+- Define a typed, channel-agnostic timeline contract separate from TUI rendering.
+- Add an AgentLoopEvent -> shared timeline projection that preserves started/resumed/turn_context/model_request/commentary/tool/plan/approval/compaction/final/stopped ordering without terminal-only fields.
+- Bridge the projected timeline into chat events as the initial production consumer while keeping existing assistant final streaming compatible.
+- Add caller-path coverage for agent-loop events reaching chat/TUI message state through shared timeline events.
+- #945 verification so far: focused chat-event-state/chat-runner tests passed; `npm run typecheck` passed; `npm run lint:boundaries` exited 0 with existing warnings only.
+- #945 review: first review found duplicate final/stopped timeline rendering; fixed by making timeline rows transient and coalescing them before assistant final/lifecycle end. Second review found transient overflow could evict durable chat history; fixed cap trimming to drop transient rows before durable rows and added regression coverage. Final review LGTM.
+- #945 final verification: focused tests passed (114 tests), `npm run typecheck` passed, `npm run lint:boundaries` exited 0 with existing warnings, `npm run test:changed` passed (20 files passed, 2 skipped; 438 tests passed, 2 skipped).


### PR DESCRIPTION
Closes #945

## Summary
- Add a typed channel-agnostic AgentTimelineItem contract and AgentLoopEvent projection.
- Emit shared timeline events through the existing chat runner event bridge as the first consumer path.
- Render transient shared timeline rows in chat state while preserving existing assistant final behavior and protecting durable transcript messages from transient overflow.

## Verification
- npm test -- --run src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-runner.test.ts
- npm run typecheck
- npm run lint:boundaries (exits 0; existing warnings remain)
- npm run test:changed

## Known risks
- TUI still has the old tool activity aggregation until #947 replaces the renderer with durable shared timeline rows.