### PR TITLE
Preserve channel-agnostic agent commentary

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { applyChatEventToMessages } from "../chat-event-state.js";
+import { ChatRunnerEventBridge } from "../chat-runner-event-bridge.js";
+import type { ChatEvent } from "../chat-events.js";
 import { classifyFailureRecovery } from "../failure-recovery.js";
 
 describe("applyChatEventToMessages", () => {
@@ -204,6 +206,117 @@ describe("applyChatEventToMessages", () => {
     expect(messages.some((message) => message.id === "older-turn")).toBe(true);
     expect(messages).toHaveLength(3);
     expect(messages.filter((message) => message.transient)).toHaveLength(2);
+  });
+
+  it("preserves agent commentary around tool work through the shared timeline caller path", async () => {
+    const events: ChatEvent[] = [];
+    const bridge = new ChatRunnerEventBridge(() => (event) => {
+      events.push(event);
+    });
+    const context = { runId: "run-1", turnId: "turn-1" };
+    const sink = bridge.createAgentLoopEventSink(context);
+    const base = {
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "agent-turn-1",
+      goalId: "goal-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+    };
+
+    await sink.emit({
+      ...base,
+      type: "assistant_message",
+      eventId: "commentary-1",
+      phase: "commentary",
+      contentPreview: "I will inspect the entrypoint first.",
+      toolCallCount: 1,
+    });
+    await sink.emit({
+      ...base,
+      type: "tool_call_started",
+      eventId: "tool-start-1",
+      callId: "call-1",
+      toolName: "shell_command",
+      inputPreview: "{\"command\":\"rg ChatRunner src/interface/chat\"}",
+    });
+    await sink.emit({
+      ...base,
+      type: "tool_call_finished",
+      eventId: "tool-finish-1",
+      callId: "call-1",
+      toolName: "shell_command",
+      success: true,
+      outputPreview: "src/interface/chat/chat-runner.ts",
+      durationMs: 12,
+    });
+    await sink.emit({
+      ...base,
+      type: "assistant_message",
+      eventId: "commentary-2",
+      phase: "commentary",
+      contentPreview: "I found the bridge path, so I will update the contract test next.",
+      toolCallCount: 0,
+    });
+    await sink.emit({
+      ...base,
+      type: "final",
+      eventId: "final-1",
+      success: true,
+      outputPreview: "Done",
+    });
+
+    const messages = events.reduce(
+      (current, event) => applyChatEventToMessages(current, event, 20),
+      [] as ReturnType<typeof applyChatEventToMessages>
+    );
+    const timelineMessages = messages.filter((message) => message.id.startsWith("agent-timeline:turn-1:"));
+
+    expect(timelineMessages.map((message) => message.text)).toEqual([
+      "I will inspect the entrypoint first.",
+      "Started shell_command: {\"command\":\"rg ChatRunner src/interface/chat\"}",
+      "Finished shell_command: src/interface/chat/chat-runner.ts",
+      "I found the bridge path, so I will update the contract test next.",
+      "Done",
+    ]);
+  });
+
+  it("keeps shared timeline rendering compatible when no commentary is emitted", async () => {
+    const events: ChatEvent[] = [];
+    const bridge = new ChatRunnerEventBridge(() => (event) => {
+      events.push(event);
+    });
+    const sink = bridge.createAgentLoopEventSink({ runId: "run-1", turnId: "turn-1" });
+    const base = {
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "agent-turn-1",
+      goalId: "goal-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+    };
+
+    await sink.emit({
+      ...base,
+      type: "tool_call_started",
+      eventId: "tool-start-1",
+      callId: "call-1",
+      toolName: "shell_command",
+      inputPreview: "{\"command\":\"pwd\"}",
+    });
+    await sink.emit({
+      ...base,
+      type: "final",
+      eventId: "final-1",
+      success: true,
+      outputPreview: "Done",
+    });
+
+    const messages = events.reduce(
+      (current, event) => applyChatEventToMessages(current, event, 20),
+      [] as ReturnType<typeof applyChatEventToMessages>
+    );
+
+    expect(messages.map((message) => message.text)).toContain("Started shell_command: {\"command\":\"pwd\"}");
+    expect(messages.map((message) => message.text)).toContain("Done");
   });
 
   it("removes transient activity when assistant final arrives", () => {

--- a/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
@@ -270,6 +270,10 @@ describe("chat agentloop final-answer contract", () => {
     expect(chatPrompt).toContain("user-visible Markdown");
     expect(chatPrompt).toContain("Do not wrap the final answer in JSON");
     expect(chatPrompt).toContain("short headings and bullets");
+    expect(chatPrompt).toContain("Emit short user-facing commentary");
+    expect(chatPrompt).toContain("before edits");
+    expect(chatPrompt).toContain("before verification");
+    expect(chatPrompt).toContain("Do not summarize tool output as commentary");
     expect(chatPrompt).not.toContain("finalAnswer");
     expect(taskPrompt).not.toContain("Do not wrap the final answer in JSON");
     expect(structuredPrompt).toContain("Return only JSON");

--- a/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-prompts.ts
@@ -20,6 +20,9 @@ export function buildAgentLoopBaseInstructions(options?: {
     "Start with targeted inspection first; avoid repo-wide glob or grep sweeps unless the task truly needs broad discovery.",
     "Keep changes scoped to the requested task. Avoid unrelated edits and avoid fixing unrelated failures.",
     "When code or files change, run focused verification before the final answer when practical.",
+    "Emit short user-facing commentary as assistant messages before or between meaningful work phases: initial orientation, after broad exploration, before edits, before verification, and when changing approach.",
+    "Keep commentary natural and brief. Do not use internal labels such as Checkpoint or Intent as a substitute for commentary.",
+    "Do not summarize tool output as commentary. Let tool results and deterministic activity metadata remain separate from assistant commentary.",
     "Preserve and follow AGENTS.md and project instructions from the workspace context.",
     ...(mode === "chat"
       ? [

--- a/tmp/shared-agent-timeline-status.md
+++ b/tmp/shared-agent-timeline-status.md
@@ -12,3 +12,10 @@
 - #945 verification so far: focused chat-event-state/chat-runner tests passed; `npm run typecheck` passed; `npm run lint:boundaries` exited 0 with existing warnings only.
 - #945 review: first review found duplicate final/stopped timeline rendering; fixed by making timeline rows transient and coalescing them before assistant final/lifecycle end. Second review found transient overflow could evict durable chat history; fixed cap trimming to drop transient rows before durable rows and added regression coverage. Final review LGTM.
 - #945 final verification: focused tests passed (114 tests), `npm run typecheck` passed, `npm run lint:boundaries` exited 0 with existing warnings, `npm run test:changed` passed (20 files passed, 2 skipped; 438 tests passed, 2 skipped).
+
+## #946 plan
+- Confirmed #946 is open after syncing main.
+- Add explicit agent-loop prompt/profile guidance requiring short user-facing commentary before major phases: initial orientation, after broad exploration, before edits, before verification, and approach changes.
+- Keep commentary as `assistant_message` / shared timeline `assistant_message` items, separate from tool rows and future deterministic summaries.
+- Add caller-path coverage for `commentary -> tool start -> tool result -> commentary -> final` through the chat event bridge and chat state consumer, plus no-commentary compatibility.
+- #946 verification: focused commentary/chat prompt tests passed (28 tests), `npm run typecheck` passed, `npm run lint:boundaries` exited 0 with existing warnings, review agent LGTM, `npm run test:changed` passed (31 files passed, 3 skipped; 476 tests passed, 3 skipped).


### PR DESCRIPTION
Closes #946

## Summary
- Clarify the agent-loop prompt contract to emit short user-facing commentary before meaningful work phases.
- Keep commentary natural and separate from tool output, deterministic summaries, and internal labels.
- Add caller-path tests proving commentary reaches the shared timeline/chat consumer in commentary -> tool start -> tool result -> commentary -> final order and that missing commentary remains compatible.

## Verification
- npm test -- --run src/interface/chat/__tests__/chat-event-state.test.ts src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
- npm run typecheck
- npm run lint:boundaries (exits 0; existing warnings remain)
- npm run test:changed

## Known risks
- Prompt guidance depends on model compliance; this PR preserves and renders commentary events but does not synthesize commentary from tool output.