### PR TITLE
Render shared agent timeline in chat transcript

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -37,7 +37,7 @@ describe("applyChatEventToMessages", () => {
     });
   });
 
-  it("shows raw tool events as a current activity row", () => {
+  it("shows raw tool events without current/recent activity headings", () => {
     const messages = applyChatEventToMessages([], {
       type: "tool_start",
       runId: "run-1",
@@ -54,7 +54,8 @@ describe("applyChatEventToMessages", () => {
       role: "pulseed",
       messageType: "info",
     });
-    expect(messages[0]!.text).toContain("Current activity");
+    expect(messages[0]!.text).not.toContain("Current activity");
+    expect(messages[0]!.text).not.toContain("Recent activity");
     expect(messages[0]!.text).toContain("Reading shell_command - command=rg ChatEvent src/interface/chat");
   });
 
@@ -165,8 +166,13 @@ describe("applyChatEventToMessages", () => {
       persisted: true,
     }, 20);
 
-    expect(afterFinal.map((message) => message.id)).toEqual(["turn-1"]);
-    expect(afterFinal[0]!.text).toBe("Done");
+    expect(afterFinal.map((message) => message.id)).toEqual([
+      "agent-timeline:turn-1:commentary-1",
+      "agent-timeline:turn-1:tool-start-1",
+      "agent-timeline:turn-1:tool-finish-1",
+      "turn-1",
+    ]);
+    expect(afterFinal.at(-1)!.text).toBe("Done");
   });
 
   it("drops transient timeline overflow before evicting durable chat messages", () => {
@@ -186,19 +192,18 @@ describe("applyChatEventToMessages", () => {
         turnId: "turn-1",
         createdAt: `2026-04-08T00:00:0${index}.000Z`,
         item: {
-          id: `agent-timeline:commentary-${index}`,
-          sourceEventId: `commentary-${index}`,
-          sourceType: "assistant_message",
+          id: `agent-timeline:final-${index}`,
+          sourceEventId: `final-${index}`,
+          sourceType: "final",
           sessionId: "session-1",
           traceId: "trace-1",
           turnId: "agent-turn-1",
           goalId: "goal-1",
           createdAt: `2026-04-08T00:00:0${index}.000Z`,
           visibility: "user",
-          kind: "assistant_message",
-          phase: "commentary",
-          text: `Working step ${index}`,
-          toolCallCount: 0,
+          kind: "final",
+          success: true,
+          outputPreview: `Candidate final ${index}`,
         },
       }, 3);
     }
@@ -278,6 +283,108 @@ describe("applyChatEventToMessages", () => {
       "I found the bridge path, so I will update the contract test next.",
       "Done",
     ]);
+  });
+
+  it("renders shared timeline tool and approval rows chronologically without a latest-five cap", () => {
+    const base = {
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+    };
+    const timelineBase = {
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "agent-turn-1",
+      goalId: "goal-1",
+      visibility: "user" as const,
+    };
+    const events = [
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:commentary-1",
+          sourceEventId: "commentary-1",
+          sourceType: "assistant_message" as const,
+          createdAt: "2026-04-08T00:00:01.000Z",
+          kind: "assistant_message" as const,
+          phase: "commentary" as const,
+          text: "I will inspect the files first.",
+          toolCallCount: 6,
+        },
+      },
+      ...Array.from({ length: 6 }, (_, offset) => {
+        const index = offset + 1;
+        return {
+          type: "agent_timeline" as const,
+          ...base,
+          item: {
+            ...timelineBase,
+            id: `agent-timeline:tool-start-${index}`,
+            sourceEventId: `tool-start-${index}`,
+            sourceType: "tool_call_started" as const,
+            createdAt: `2026-04-08T00:00:0${index + 1}.000Z`,
+            kind: "tool" as const,
+            status: "started" as const,
+            callId: `call-${index}`,
+            toolName: "read_file",
+            inputPreview: `src/file-${index}.ts`,
+          },
+        };
+      }),
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:approval-1",
+          sourceEventId: "approval-1",
+          sourceType: "approval_request" as const,
+          createdAt: "2026-04-08T00:00:08.000Z",
+          kind: "approval" as const,
+          status: "requested" as const,
+          callId: "call-approval",
+          toolName: "apply_patch",
+          reason: "modify src/example.ts",
+          permissionLevel: "workspace-write",
+          isDestructive: false,
+        },
+      },
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:final-1",
+          sourceEventId: "final-1",
+          sourceType: "final" as const,
+          createdAt: "2026-04-08T00:00:09.000Z",
+          kind: "final" as const,
+          success: true,
+          outputPreview: "Done",
+        },
+      },
+    ];
+
+    const messages = events.reduce(
+      (current, event) => applyChatEventToMessages(current, event, 20),
+      [] as ReturnType<typeof applyChatEventToMessages>
+    );
+
+    expect(messages.map((message) => message.text)).toEqual([
+      "I will inspect the files first.",
+      "Started read_file: src/file-1.ts",
+      "Started read_file: src/file-2.ts",
+      "Started read_file: src/file-3.ts",
+      "Started read_file: src/file-4.ts",
+      "Started read_file: src/file-5.ts",
+      "Started read_file: src/file-6.ts",
+      "Approval requested for apply_patch: modify src/example.ts",
+      "Done",
+    ]);
+    expect(messages.map((message) => message.text).join("\n")).not.toContain("Current activity");
+    expect(messages.map((message) => message.text).join("\n")).not.toContain("Recent activity");
   });
 
   it("keeps shared timeline rendering compatible when no commentary is emitted", async () => {
@@ -546,7 +653,7 @@ describe("applyChatEventToMessages", () => {
     });
   });
 
-  it("preserves the latest few tool events and keeps tool logs after the turn ends", () => {
+  it("keeps all raw tool activities visible without current/recent headings", () => {
     let messages = [] as ReturnType<typeof applyChatEventToMessages>;
     for (let index = 1; index <= 6; index += 1) {
       messages = applyChatEventToMessages(messages, {
@@ -561,9 +668,11 @@ describe("applyChatEventToMessages", () => {
     }
 
     const toolLog = messages.find((message) => message.id === "tool-log:turn-1");
-    expect(toolLog?.text).not.toContain("file-1.ts");
+    expect(toolLog?.text).toContain("file-1.ts");
     expect(toolLog?.text).toContain("file-2.ts");
     expect(toolLog?.text).toContain("file-6.ts");
+    expect(toolLog?.text).not.toContain("Current activity");
+    expect(toolLog?.text).not.toContain("Recent activity");
 
     const afterEnd = applyChatEventToMessages(messages, {
       type: "lifecycle_end",
@@ -575,7 +684,8 @@ describe("applyChatEventToMessages", () => {
       persisted: true,
     }, 20);
 
-    expect(afterEnd.find((message) => message.id === "tool-log:turn-1")?.text).toContain("Recent activity");
+    expect(afterEnd.find((message) => message.id === "tool-log:turn-1")?.text).not.toContain("Recent activity");
+    expect(afterEnd.find((message) => message.id === "tool-log:turn-1")?.text).toContain("file-1.ts");
   });
 
   it("keeps tool intent categories across updates and distinguishes waiting for approval", () => {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -2746,7 +2746,7 @@ describe("ChatRunner", () => {
       expect(capturedSignal?.aborted).toBe(true);
       expect(interrupted.success).toBe(true);
       expect(interrupted.output).toContain("Interrupted the active turn");
-      expect(interrupted.output).toContain("Recent activity");
+      expect(interrupted.output).toContain("Activity before interruption");
       await active;
     });
 
@@ -2841,7 +2841,7 @@ describe("ChatRunner", () => {
 
       expect(interruptible.getSignal()?.aborted).toBe(true);
       expect(interrupted.output).toContain("Interrupted the active turn");
-      expect(interrupted.output).toContain("Recent activity");
+      expect(interrupted.output).toContain("Activity before interruption");
       await active;
     });
 

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -22,8 +22,6 @@ export interface StreamChatMessage {
   toolActivities?: StreamToolActivity[];
 }
 
-const MAX_TOOL_ACTIVITIES = 5;
-
 function upsertMessage(
   messages: StreamChatMessage[],
   nextMessage: StreamChatMessage,
@@ -110,6 +108,11 @@ function renderTimelineItem(item: AgentTimelineItem): string {
     case "stopped":
       return item.reasonDetail ? `Stopped: ${item.reason} (${item.reasonDetail})` : `Stopped: ${item.reason}`;
   }
+}
+
+function isTransientTimelineItem(item: AgentTimelineItem): boolean {
+  if (item.kind === "final") return true;
+  return item.kind === "stopped" && item.reason === "completed";
 }
 
 function summarizeValue(value: unknown): string {
@@ -222,13 +225,12 @@ function formatToolActivityState(state: ToolActivityState): string {
   }
 }
 
-function renderToolActivityMessage(activities: StreamToolActivity[], current: boolean): string {
-  const heading = current ? "Current activity" : "Recent activity";
+function renderToolActivityMessage(activities: StreamToolActivity[]): string {
   const lines = activities.map((activity) => {
     const detail = activity.detail ? ` - ${activity.detail}` : "";
     return `- ${formatToolActivityState(activity.state)} ${activity.toolName}${detail}`;
   });
-  return [heading, ...lines].join("\n");
+  return lines.join("\n");
 }
 
 function closeToolActivityForTurn(messages: StreamChatMessage[], turnId: string): StreamChatMessage[] {
@@ -237,7 +239,7 @@ function closeToolActivityForTurn(messages: StreamChatMessage[], turnId: string)
     if (message.id !== toolLogId || !message.toolActivities) return message;
     return {
       ...message,
-      text: renderToolActivityMessage(message.toolActivities, false),
+      text: renderToolActivityMessage(message.toolActivities),
       transient: false,
     };
   });
@@ -275,12 +277,12 @@ function upsertToolActivity(
   const nextActivities = [
     ...previousActivities.filter((activity) => activity.id !== event.toolCallId),
     nextActivity,
-  ].slice(-MAX_TOOL_ACTIVITIES);
+  ];
 
   return upsertMessage(messages, {
     id: toolLogId,
     role: "pulseed",
-    text: renderToolActivityMessage(nextActivities, true),
+    text: renderToolActivityMessage(nextActivities),
     timestamp,
     messageType: "info",
     toolActivities: nextActivities,
@@ -336,7 +338,7 @@ export function applyChatEventToMessages(
       text,
       timestamp: new Date(event.item.createdAt),
       messageType: event.item.kind === "stopped" ? "warning" : "info",
-      transient: true,
+      transient: isTransientTimelineItem(event.item),
     }, maxMessages);
   }
 
@@ -358,14 +360,17 @@ export function applyChatEventToMessages(
   }
 
   if (event.type === "tool_start") {
+    if (event.presentation?.suppressTranscript) return messages;
     return upsertToolActivity(messages, event, maxMessages);
   }
 
   if (event.type === "tool_update") {
+    if (event.presentation?.suppressTranscript) return messages;
     return upsertToolActivity(messages, event, maxMessages);
   }
 
   if (event.type === "tool_end") {
+    if (event.presentation?.suppressTranscript) return messages;
     return upsertToolActivity(messages, event, maxMessages);
   }
 

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -39,6 +39,9 @@ export interface ToolStartEvent extends ChatEventBase {
   toolCallId: string;
   toolName: string;
   args: Record<string, unknown>;
+  presentation?: {
+    suppressTranscript?: boolean;
+  };
 }
 
 export interface ToolUpdateEvent extends ChatEventBase {
@@ -47,6 +50,9 @@ export interface ToolUpdateEvent extends ChatEventBase {
   toolName: string;
   status: "awaiting_approval" | "running" | "result";
   message: string;
+  presentation?: {
+    suppressTranscript?: boolean;
+  };
 }
 
 export interface ToolEndEvent extends ChatEventBase {
@@ -56,6 +62,9 @@ export interface ToolEndEvent extends ChatEventBase {
   success: boolean;
   summary: string;
   durationMs: number;
+  presentation?: {
+    suppressTranscript?: boolean;
+  };
 }
 
 export interface AgentTimelineEvent extends ChatEventBase {

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -135,6 +135,7 @@ export class ChatRunnerEventBridge {
             toolCallId: event.callId,
             toolName: event.toolName,
             args: this.parseAgentLoopPreview(event.inputPreview),
+            presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
           this.emitEvent({
@@ -143,6 +144,7 @@ export class ChatRunnerEventBridge {
             toolName: event.toolName,
             status: "running",
             message: "started",
+            presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
           return;
@@ -174,6 +176,7 @@ export class ChatRunnerEventBridge {
             success: event.success,
             summary: event.outputPreview,
             durationMs: event.durationMs,
+            presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
           return;
@@ -193,6 +196,7 @@ export class ChatRunnerEventBridge {
             toolName: "update_plan",
             status: "result",
             message: event.summary,
+            presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
           return;
@@ -214,6 +218,7 @@ export class ChatRunnerEventBridge {
             toolName: event.toolName,
             status: "awaiting_approval",
             message: event.reason,
+            presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
           return;
@@ -232,6 +237,7 @@ export class ChatRunnerEventBridge {
             toolName: event.toolName,
             status: "result",
             message: `approval ${event.status}: ${event.reason}`,
+            presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
           return;
@@ -244,6 +250,7 @@ export class ChatRunnerEventBridge {
             toolName: "agentloop_resume",
             status: "result",
             message: `resumed ${event.restoredMessages} message(s) from ${event.fromUpdatedAt}`,
+            presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
           return;
@@ -256,6 +263,7 @@ export class ChatRunnerEventBridge {
             toolName: "context_compaction",
             status: "result",
             message: `${event.phase} ${event.reason}: ${event.inputMessages} -> ${event.outputMessages}`,
+            presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
         }

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -282,7 +282,7 @@ export class ChatRunner {
       output = [
         "Interrupted the active turn.",
         "",
-        "Recent activity",
+        "Activity before interruption",
         ...(activeTurn.recentEvents.length > 0
           ? activeTurn.recentEvents.slice(-6).map((event) => `- ${event}`)
           : ["- No activity was captured before the interrupt."]),

--- a/tmp/shared-agent-timeline-status.md
+++ b/tmp/shared-agent-timeline-status.md
@@ -19,3 +19,10 @@
 - Keep commentary as `assistant_message` / shared timeline `assistant_message` items, separate from tool rows and future deterministic summaries.
 - Add caller-path coverage for `commentary -> tool start -> tool result -> commentary -> final` through the chat event bridge and chat state consumer, plus no-commentary compatibility.
 - #946 verification: focused commentary/chat prompt tests passed (28 tests), `npm run typecheck` passed, `npm run lint:boundaries` exited 0 with existing warnings, review agent LGTM, `npm run test:changed` passed (31 files passed, 3 skipped; 476 tests passed, 3 skipped).
+
+## #947 plan
+- Confirmed #947 is open after syncing main.
+- Remove user-facing `Current activity` / `Recent activity` aggregation from chat/TUI state.
+- Render shared timeline tool/commentary/approval/final items as chronological transcript rows with normal retention, not latest-five activity retention.
+- Keep raw/debug events available by continuing to emit structured chat events, while normal transcript rendering uses shared timeline rows.
+- #947 verification: focused chat state/chat runner tests passed (117 tests), `npm run typecheck` passed, `npm run lint:boundaries` exited 0 with existing warnings, review agent LGTM, `npm run test:changed` passed (20 files passed, 2 skipped; 441 tests passed, 2 skipped).


### PR DESCRIPTION
Closes #947

## Summary
- Render shared timeline rows chronologically in chat/TUI state and keep tool/commentary/approval rows durable while coalescing final completion with assistant final.
- Suppress legacy agent-loop tool transcript rows via presentation metadata so the shared timeline is the normal transcript source.
- Remove user-facing Current activity / Recent activity aggregation and the latest-five tool activity cap.

## Verification
- npm test -- --run src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-runner.test.ts
- npm run typecheck
- npm run lint:boundaries (exits 0; existing warnings remain)
- npm run test:changed

## Known risks
- Raw non-agent-loop tool events still use the existing per-turn tool-log row, but without Current/Recent headings or latest-five truncation; agent-loop/TUI shared timeline uses distinct chronological rows.