### PR TITLE
Hide internal labels from chat transcripts

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -387,6 +387,102 @@ describe("applyChatEventToMessages", () => {
     expect(messages.map((message) => message.text).join("\n")).not.toContain("Recent activity");
   });
 
+  it("keeps operational timeline information visible without internal presentation labels", () => {
+    const base = {
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+    };
+    const timelineBase = {
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "agent-turn-1",
+      goalId: "goal-1",
+      visibility: "user" as const,
+    };
+    const events = [
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:resume-1",
+          sourceEventId: "resume-1",
+          sourceType: "resumed" as const,
+          createdAt: "2026-04-08T00:00:01.000Z",
+          kind: "lifecycle" as const,
+          status: "resumed" as const,
+          restoredMessages: 3,
+          fromUpdatedAt: "2026-04-08T00:00:00.000Z",
+        },
+      },
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:plan-1",
+          sourceEventId: "plan-1",
+          sourceType: "plan_update" as const,
+          createdAt: "2026-04-08T00:00:02.000Z",
+          kind: "plan" as const,
+          summary: "Inspect, edit, then verify.",
+        },
+      },
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:approval-1",
+          sourceEventId: "approval-1",
+          sourceType: "approval_request" as const,
+          createdAt: "2026-04-08T00:00:03.000Z",
+          kind: "approval" as const,
+          status: "requested" as const,
+          callId: "call-approval",
+          toolName: "apply_patch",
+          reason: "modify src/example.ts",
+          permissionLevel: "workspace-write",
+          isDestructive: false,
+        },
+      },
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:compaction-1",
+          sourceEventId: "compaction-1",
+          sourceType: "context_compaction" as const,
+          createdAt: "2026-04-08T00:00:04.000Z",
+          kind: "compaction" as const,
+          phase: "mid_turn" as const,
+          reason: "context_limit" as const,
+          inputMessages: 10,
+          outputMessages: 4,
+          summaryPreview: "Shorter context",
+        },
+      },
+    ];
+
+    const messages = events.reduce(
+      (current, event) => applyChatEventToMessages(current, event, 20),
+      [] as ReturnType<typeof applyChatEventToMessages>
+    );
+    const transcript = messages.map((message) => message.text).join("\n");
+
+    expect(transcript).toContain("Resumed 3 message(s)");
+    expect(transcript).toContain("Plan changed: Inspect, edit, then verify.");
+    expect(transcript).toContain("Approval requested for apply_patch: modify src/example.ts");
+    expect(transcript).toContain("Compacted context (mid_turn, context_limit): 10 -> 4.");
+    expect(transcript).not.toContain("Checkpoint");
+    expect(transcript).not.toContain("Intent");
+    expect(transcript).not.toContain("Updated plan:");
+    expect(transcript).not.toContain("Current activity");
+    expect(transcript).not.toContain("Recent activity");
+  });
+
   it("keeps shared timeline rendering compatible when no commentary is emitted", async () => {
     const events: ChatEvent[] = [];
     const bridge = new ChatRunnerEventBridge(() => (event) => {
@@ -537,7 +633,7 @@ describe("applyChatEventToMessages", () => {
       turnId: "turn-1",
       createdAt: "2026-04-08T00:00:00.000Z",
       kind: "commentary",
-      message: "Intent\n- Confirm: inspect the repo",
+      message: "I understand the request as inspect the repo.",
       sourceId: "intent:first-step",
       transient: false,
     }, 20);
@@ -566,9 +662,10 @@ describe("applyChatEventToMessages", () => {
     expect(afterEnd).toHaveLength(1);
     expect(afterEnd[0]!).toMatchObject({
       id: "activity:turn-1:intent:first-step",
-      text: "Intent\n- Confirm: inspect the repo",
+      text: "I understand the request as inspect the repo.",
       transient: false,
     });
+    expect(afterEnd[0]!.text).not.toContain("Intent");
   });
 
   it("keeps checkpoint rows visible after transient lifecycle activity ends", () => {
@@ -578,7 +675,7 @@ describe("applyChatEventToMessages", () => {
       turnId: "turn-1",
       createdAt: "2026-04-08T00:00:00.000Z",
       kind: "checkpoint",
-      message: "Checkpoint\n- Context gathered: Workspace grounding is ready.",
+      message: "Context gathered: Workspace grounding is ready.",
       sourceId: "checkpoint:context",
       transient: false,
     }, 20);
@@ -607,9 +704,10 @@ describe("applyChatEventToMessages", () => {
     expect(afterEnd).toHaveLength(1);
     expect(afterEnd[0]!).toMatchObject({
       id: "activity:turn-1:checkpoint:context",
-      text: "Checkpoint\n- Context gathered: Workspace grounding is ready.",
+      text: "Context gathered: Workspace grounding is ready.",
       transient: false,
     });
+    expect(afterEnd[0]!.text).not.toContain("Checkpoint");
   });
 
   it("keeps diff artifact rows visible after transient lifecycle activity ends", () => {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -276,19 +276,23 @@ describe("ChatRunner", () => {
 
       await runner.execute("Do something", "/repo");
 
-      expect(events[0]).toContain("commentary:Intent\n- Confirm: Do something");
+      expect(events[0]).toContain("commentary:I understand the request as Do something.");
       expect(events.indexOf("lifecycle:Preparing context...")).toBeGreaterThan(0);
       const contextCheckpointIndex = events.findIndex((event) =>
-        event.includes("checkpoint:Checkpoint\n- Context gathered:")
+        event.includes("checkpoint:Context gathered:")
       );
       const adapterCheckpointIndex = events.findIndex((event) =>
-        event.includes("checkpoint:Checkpoint\n- Adapter started:")
+        event.includes("checkpoint:Adapter started:")
       );
       const adapterActivityIndex = events.indexOf("lifecycle:Calling adapter...");
       expect(contextCheckpointIndex).toBeGreaterThan(events.indexOf("lifecycle:Preparing context..."));
       expect(adapterCheckpointIndex).toBeGreaterThan(contextCheckpointIndex);
       expect(adapterActivityIndex).toBeGreaterThan(adapterCheckpointIndex);
       expect(events).toContain("lifecycle:Calling adapter...");
+      const transcript = events.join("\n");
+      expect(transcript).not.toContain("Intent");
+      expect(transcript).not.toContain("Checkpoint");
+      expect(transcript).not.toContain("Updated plan:");
     });
 
     it("emits verification checkpoints when adapter execution changes the working tree", async () => {
@@ -2458,7 +2462,7 @@ describe("ChatRunner", () => {
         type: "activity",
         kind: "commentary",
         transient: false,
-        message: expect.stringContaining("Intent\n- Confirm: Do something"),
+        message: expect.stringContaining("I understand the request as Do something."),
       });
       const checkpointMessages = seenEvents
         .filter((event): event is Extract<ChatEvent, { type: "activity" }> =>

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -96,7 +96,7 @@ function renderTimelineItem(item: AgentTimelineItem): string {
       return detail ? `${label} ${item.toolName}: ${detail}` : `${label} ${item.toolName}.`;
     }
     case "plan":
-      return `Plan updated: ${item.summary}`;
+      return `Plan changed: ${item.summary}`;
     case "approval":
       return item.status === "requested"
         ? `Approval requested for ${item.toolName}: ${item.reason}`

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -188,7 +188,7 @@ export class ChatRunnerEventBridge {
         }
 
         if (event.type === "plan_update") {
-          this.emitActivity("tool", `Updated plan: ${previewActivityText(event.summary)}`, eventContext, `plan:${event.turnId}`);
+          this.emitActivity("tool", `Plan changed: ${previewActivityText(event.summary)}`, eventContext, `plan:${event.turnId}`);
           this.emitCheckpoint("Plan updated", previewActivityText(event.summary, 160), eventContext, `plan:${event.eventId}`);
           this.emitEvent({
             type: "tool_update",
@@ -324,10 +324,9 @@ export class ChatRunnerEventBridge {
       reason = "the adapter needs the current workspace context to act correctly.";
     }
     const message = [
-      "Intent",
-      `- Confirm: ${subject || "the current request"}`,
-      `- Next: ${nextStep}`,
-      `- Why: ${reason}`,
+      `I understand the request as ${subject || "the current request"}.`,
+      `Next I will ${nextStep}`,
+      `This is needed because ${reason}`,
     ].join("\n");
     this.emitActivity("commentary", message, eventContext, "intent:first-step", false);
   }
@@ -338,9 +337,7 @@ export class ChatRunnerEventBridge {
     eventContext: ChatEventContext,
     sourceKey: string
   ): void {
-    const message = detail
-      ? `Checkpoint\n- ${title}: ${detail}`
-      : `Checkpoint\n- ${title}`;
+    const message = detail ? `${title}: ${detail}` : title;
     this.emitActivity("checkpoint", message, eventContext, `checkpoint:${sourceKey}`, false);
   }
 

--- a/tmp/shared-agent-timeline-status.md
+++ b/tmp/shared-agent-timeline-status.md
@@ -26,3 +26,9 @@
 - Render shared timeline tool/commentary/approval/final items as chronological transcript rows with normal retention, not latest-five activity retention.
 - Keep raw/debug events available by continuing to emit structured chat events, while normal transcript rendering uses shared timeline rows.
 - #947 verification: focused chat state/chat runner tests passed (117 tests), `npm run typecheck` passed, `npm run lint:boundaries` exited 0 with existing warnings, review agent LGTM, `npm run test:changed` passed (20 files passed, 2 skipped; 441 tests passed, 2 skipped).
+
+## #948 plan
+- Confirmed #948 is open after syncing main.
+- Replace chat/TUI-facing Intent/Checkpoint/Updated plan labels with natural user-facing text while preserving structured event kinds/source ids for raw/debug traceability.
+- Add transcript tests that assert normal output does not expose the internal labels while plan, approval, compaction, resume, and recovery information remains visible.
+- #948 verification: focused chat state/chat runner tests passed (118 tests), `npm run typecheck` passed, `npm run lint:boundaries` exited 0 with existing warnings, review agent LGTM, `npm run test:changed` passed (20 files passed, 2 skipped; 442 tests passed, 2 skipped).


### PR DESCRIPTION
Closes #948

## Summary
- Replace user-facing Intent/Checkpoint/Updated plan labels with natural transcript text while preserving structured event kind/source ids for tracing.
- Render shared timeline plan rows as Plan changed and add transcript tests for plan, approval, resume, and compaction visibility without internal labels.
- Keep raw/debug event information intact; this changes presentation text rather than parsing labels out after render.

## Verification
- npm test -- --run src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-runner.test.ts
- npm run typecheck
- npm run lint:boundaries (exits 0; existing warnings remain)
- npm run test:changed

## Known risks
- Some internal class/type names still contain Intent/Checkpoint in code and tests, but normal chat/TUI transcript strings no longer use those labels.