### PR TITLE
Add deterministic agent timeline activity summaries

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -251,6 +251,7 @@ describe("applyChatEventToMessages", () => {
       callId: "call-1",
       toolName: "shell_command",
       success: true,
+      inputPreview: "{\"command\":\"rg ChatRunner src/interface/chat\"}",
       outputPreview: "src/interface/chat/chat-runner.ts",
       durationMs: 12,
     });
@@ -269,6 +270,12 @@ describe("applyChatEventToMessages", () => {
       success: true,
       outputPreview: "Done",
     });
+    await sink.emit({
+      ...base,
+      type: "stopped",
+      eventId: "stopped-1",
+      reason: "completed",
+    });
 
     const messages = events.reduce(
       (current, event) => applyChatEventToMessages(current, event, 20),
@@ -281,8 +288,11 @@ describe("applyChatEventToMessages", () => {
       "Started shell_command: {\"command\":\"rg ChatRunner src/interface/chat\"}",
       "Finished shell_command: src/interface/chat/chat-runner.ts",
       "I found the bridge path, so I will update the contract test next.",
+      "searched 1 search",
       "Done",
+      "Stopped: completed",
     ]);
+    expect(timelineMessages.filter((message) => message.text === "searched 1 search")).toHaveLength(1);
   });
 
   it("renders shared timeline tool and approval rows chronologically without a latest-five cap", () => {
@@ -481,6 +491,82 @@ describe("applyChatEventToMessages", () => {
     expect(transcript).not.toContain("Updated plan:");
     expect(transcript).not.toContain("Current activity");
     expect(transcript).not.toContain("Recent activity");
+  });
+
+  it("renders shared activity summary rows without replacing detailed timeline rows", () => {
+    const base = {
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+    };
+    const timelineBase = {
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "agent-turn-1",
+      goalId: "goal-1",
+      visibility: "user" as const,
+    };
+    const events = [
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:commentary-1",
+          sourceEventId: "commentary-1",
+          sourceType: "assistant_message" as const,
+          createdAt: "2026-04-08T00:00:01.000Z",
+          kind: "assistant_message" as const,
+          phase: "commentary" as const,
+          text: "I will inspect the files first.",
+          toolCallCount: 1,
+        },
+      },
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:tool-finish-1",
+          sourceEventId: "tool-finish-1",
+          sourceType: "tool_call_finished" as const,
+          createdAt: "2026-04-08T00:00:02.000Z",
+          kind: "tool" as const,
+          status: "finished" as const,
+          callId: "call-1",
+          toolName: "shell_command",
+          success: true,
+          inputPreview: "{\"command\":\"rg Timeline src\"}",
+          outputPreview: "src/orchestrator/execution/agent-loop/agent-timeline.ts",
+          durationMs: 10,
+        },
+      },
+      {
+        type: "agent_timeline" as const,
+        ...base,
+        item: {
+          ...timelineBase,
+          id: "agent-timeline:summary-1",
+          sourceEventId: "summary-1",
+          sourceType: "tool_call_finished" as const,
+          createdAt: "2026-04-08T00:00:03.000Z",
+          kind: "activity_summary" as const,
+          buckets: [{ kind: "search" as const, count: 1 }],
+          text: "searched 1 search",
+        },
+      },
+    ];
+
+    const messages = events.reduce(
+      (current, event) => applyChatEventToMessages(current, event, 20),
+      [] as ReturnType<typeof applyChatEventToMessages>
+    );
+
+    expect(messages.map((message) => message.text)).toEqual([
+      "I will inspect the files first.",
+      "Finished shell_command: src/orchestrator/execution/agent-loop/agent-timeline.ts",
+      "searched 1 search",
+    ]);
   });
 
   it("keeps shared timeline rendering compatible when no commentary is emitted", async () => {

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -103,6 +103,8 @@ function renderTimelineItem(item: AgentTimelineItem): string {
         : `Approval denied for ${item.toolName}: ${item.reason}`;
     case "compaction":
       return `Compacted context (${item.phase}, ${item.reason}): ${item.inputMessages} -> ${item.outputMessages}.`;
+    case "activity_summary":
+      return item.text;
     case "final":
       return item.outputPreview;
     case "stopped":

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -3,7 +3,11 @@ import type {
   AgentLoopEvent,
   AgentLoopEventSink,
 } from "../../orchestrator/execution/agent-loop/agent-loop-events.js";
-import { projectAgentLoopEventToTimeline } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
+import {
+  createAgentTimelineActivitySummary,
+  projectAgentLoopEventToTimeline,
+  type AgentTimelineItem,
+} from "../../orchestrator/execution/agent-loop/agent-timeline.js";
 import {
   DIFF_ARTIFACT_MAX_LINES,
   formatIntentInput,
@@ -38,6 +42,7 @@ export interface ActiveChatTurn {
 
 export class ChatRunnerEventBridge {
   private activeTurn: ActiveChatTurn | null = null;
+  private readonly timelineActivityItemsByRun = new Map<string, AgentTimelineItem[]>();
 
   constructor(
     private readonly onEventGetter: () => ((event: ChatEvent) => void) | undefined,
@@ -87,6 +92,7 @@ export class ChatRunnerEventBridge {
     if (!activeTurn || activeTurn.context.runId !== context.runId) return;
     activeTurn.resolveFinished();
     this.activeTurn = null;
+    this.timelineActivityItemsByRun.delete(context.runId);
   }
 
   waitForActiveTurn(turn: ActiveChatTurn, timeoutMs: number): Promise<boolean> {
@@ -121,9 +127,12 @@ export class ChatRunnerEventBridge {
   createAgentLoopEventSink(eventContext: ChatEventContext): AgentLoopEventSink {
     return {
       emit: async (event: AgentLoopEvent) => {
+        const timelineItem = projectAgentLoopEventToTimeline(event);
+        this.emitTimelineSummaryBeforeCompletion(eventContext, timelineItem);
+        this.rememberTimelineActivityItem(eventContext, timelineItem);
         this.emitEvent({
           type: "agent_timeline",
-          item: projectAgentLoopEventToTimeline(event),
+          item: timelineItem,
           ...this.eventBase(eventContext),
         });
 
@@ -282,6 +291,35 @@ export class ChatRunnerEventBridge {
   emitEvent(event: ChatEvent): void {
     this.rememberActiveTurnEvent(event);
     this.onEventGetter()?.(event);
+  }
+
+  private rememberTimelineActivityItem(eventContext: ChatEventContext, item: AgentTimelineItem): void {
+    if (item.kind !== "tool" && item.kind !== "approval") return;
+    const existing = this.timelineActivityItemsByRun.get(eventContext.runId) ?? [];
+    this.timelineActivityItemsByRun.set(eventContext.runId, [...existing, item]);
+  }
+
+  private emitTimelineSummaryBeforeCompletion(eventContext: ChatEventContext, nextItem: AgentTimelineItem): void {
+    if (nextItem.kind !== "final" && nextItem.kind !== "stopped") return;
+    const items = this.timelineActivityItemsByRun.get(eventContext.runId) ?? [];
+    const summary = createAgentTimelineActivitySummary({
+      id: `agent-timeline:${eventContext.turnId}:activity-summary:${nextItem.sourceEventId}`,
+      sourceEventId: `activity-summary:${nextItem.sourceEventId}`,
+      sessionId: nextItem.sessionId,
+      traceId: nextItem.traceId,
+      turnId: nextItem.turnId,
+      goalId: nextItem.goalId,
+      ...(nextItem.taskId ? { taskId: nextItem.taskId } : {}),
+      createdAt: nextItem.createdAt,
+      items,
+    });
+    if (!summary) return;
+    this.timelineActivityItemsByRun.delete(eventContext.runId);
+    this.emitEvent({
+      type: "agent_timeline",
+      item: summary,
+      ...this.eventBase(eventContext),
+    });
   }
 
   emitActivity(

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  createAgentTimelineActivitySummary,
+  projectAgentLoopEventToTimeline,
+  summarizeAgentTimelineActivity,
+} from "../agent-timeline.js";
+import type { AgentLoopEvent } from "../agent-loop-events.js";
+
+function baseEvent(input: Partial<AgentLoopEvent> & { type: AgentLoopEvent["type"]; eventId: string }): AgentLoopEvent {
+  return {
+    sessionId: "session-1",
+    traceId: "trace-1",
+    turnId: "turn-1",
+    goalId: "goal-1",
+    createdAt: "2026-04-08T00:00:00.000Z",
+    ...input,
+  } as AgentLoopEvent;
+}
+
+function finishedTool(eventId: string, toolName: string, inputPreview: string): AgentLoopEvent {
+  return baseEvent({
+    type: "tool_call_finished",
+    eventId,
+    callId: eventId,
+    toolName,
+    success: true,
+    inputPreview,
+    outputPreview: "ok",
+    durationMs: 1,
+  } as Partial<AgentLoopEvent> & { type: AgentLoopEvent["type"]; eventId: string });
+}
+
+describe("agent timeline activity summaries", () => {
+  it("classifies structured activity deterministically", () => {
+    const items = [
+      finishedTool("search-1", "shell_command", JSON.stringify({ command: "rg ChatRunner src/interface/chat" })),
+      finishedTool("read-1", "read_file", JSON.stringify({ path: "src/interface/chat/chat-runner.ts" })),
+      finishedTool("command-1", "shell_command", JSON.stringify({ command: "node scripts/build.js" })),
+      finishedTool("create-1", "file_write", JSON.stringify({ path: "src/new-file.ts" })),
+      finishedTool("modify-1", "apply_patch", JSON.stringify({ path: "src/existing.ts" })),
+      finishedTool("test-1", "shell_command", JSON.stringify({ command: "npm run typecheck" })),
+      baseEvent({
+        type: "approval_request",
+        eventId: "approval-1",
+        callId: "approval-1",
+        toolName: "apply_patch",
+        reason: "modify src/existing.ts",
+        permissionLevel: "workspace-write",
+        isDestructive: false,
+      }),
+    ].map(projectAgentLoopEventToTimeline);
+
+    expect(summarizeAgentTimelineActivity(items)).toEqual([
+      { kind: "search", count: 1 },
+      { kind: "read", count: 1 },
+      { kind: "command", count: 1 },
+      { kind: "file_create", count: 1 },
+      { kind: "file_modify", count: 1 },
+      { kind: "test", count: 1 },
+      { kind: "approval", count: 1 },
+    ]);
+  });
+
+  it("creates a shared summary item separate from detailed timeline items", () => {
+    const items = [
+      finishedTool("search-1", "shell_command", JSON.stringify({ command: "rg Timeline src" })),
+      finishedTool("command-1", "shell_command", JSON.stringify({ command: "node scripts/build.js" })),
+    ].map(projectAgentLoopEventToTimeline);
+
+    const summary = createAgentTimelineActivitySummary({
+      id: "agent-timeline:summary-1",
+      sourceEventId: "summary-1",
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "turn-1",
+      goalId: "goal-1",
+      createdAt: "2026-04-08T00:00:10.000Z",
+      items,
+    });
+
+    expect(summary).toMatchObject({
+      kind: "activity_summary",
+      text: "searched 1 search, ran 1 command",
+      buckets: [
+        { kind: "search", count: 1 },
+        { kind: "command", count: 1 },
+      ],
+    });
+    expect(items).toHaveLength(2);
+  });
+});

--- a/src/orchestrator/execution/agent-loop/agent-loop-events.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-events.ts
@@ -74,6 +74,7 @@ export interface AgentLoopToolCallFinishedEvent extends AgentLoopBaseEvent {
   type: "tool_call_finished";
   callId: string;
   toolName: string;
+  inputPreview?: string;
   success: boolean;
   disposition?: "respond_to_model" | "fatal" | "approval_denied" | "cancelled";
   outputPreview: string;

--- a/src/orchestrator/execution/agent-loop/agent-timeline.ts
+++ b/src/orchestrator/execution/agent-loop/agent-timeline.ts
@@ -9,8 +9,18 @@ export type AgentTimelineItem =
   | AgentTimelinePlanItem
   | AgentTimelineApprovalItem
   | AgentTimelineCompactionItem
+  | AgentTimelineActivitySummaryItem
   | AgentTimelineFinalItem
   | AgentTimelineStoppedItem;
+
+export type AgentTimelineActivityKind =
+  | "search"
+  | "read"
+  | "command"
+  | "file_create"
+  | "file_modify"
+  | "test"
+  | "approval";
 
 export interface AgentTimelineBaseItem {
   id: string;
@@ -93,6 +103,17 @@ export interface AgentTimelineCompactionItem extends AgentTimelineBaseItem {
   summaryPreview: string;
 }
 
+export interface AgentTimelineActivitySummaryItem extends AgentTimelineBaseItem {
+  kind: "activity_summary";
+  buckets: AgentTimelineActivitySummaryBucket[];
+  text: string;
+}
+
+export interface AgentTimelineActivitySummaryBucket {
+  kind: AgentTimelineActivityKind;
+  count: number;
+}
+
 export interface AgentTimelineFinalItem extends AgentTimelineBaseItem {
   kind: "final";
   success: boolean;
@@ -170,6 +191,7 @@ export function projectAgentLoopEventToTimeline(event: AgentLoopEvent): AgentTim
         callId: event.callId,
         toolName: event.toolName,
         success: event.success,
+        ...(event.inputPreview ? { inputPreview: event.inputPreview } : {}),
         ...(event.disposition ? { disposition: event.disposition } : {}),
         outputPreview: event.outputPreview,
         durationMs: event.durationMs,
@@ -223,3 +245,149 @@ export function projectAgentLoopEventToTimeline(event: AgentLoopEvent): AgentTim
       };
   }
 }
+
+export function summarizeAgentTimelineActivity(items: AgentTimelineItem[]): AgentTimelineActivitySummaryBucket[] {
+  const counts = new Map<AgentTimelineActivityKind, number>();
+  for (const item of items) {
+    const kind = classifyTimelineActivity(item);
+    if (!kind) continue;
+    counts.set(kind, (counts.get(kind) ?? 0) + 1);
+  }
+  return ACTIVITY_SUMMARY_ORDER
+    .map((kind) => ({ kind, count: counts.get(kind) ?? 0 }))
+    .filter((bucket) => bucket.count > 0);
+}
+
+export function createAgentTimelineActivitySummary(input: {
+  id: string;
+  sourceEventId: string;
+  sessionId: string;
+  traceId: string;
+  turnId: string;
+  goalId: string;
+  taskId?: string;
+  createdAt: string;
+  items: AgentTimelineItem[];
+}): AgentTimelineActivitySummaryItem | null {
+  const buckets = summarizeAgentTimelineActivity(input.items);
+  if (buckets.length === 0) return null;
+  return {
+    id: input.id,
+    sourceEventId: input.sourceEventId,
+    sourceType: "tool_call_finished",
+    sessionId: input.sessionId,
+    traceId: input.traceId,
+    turnId: input.turnId,
+    goalId: input.goalId,
+    ...(input.taskId ? { taskId: input.taskId } : {}),
+    createdAt: input.createdAt,
+    visibility: "user",
+    kind: "activity_summary",
+    buckets,
+    text: formatAgentTimelineActivitySummary(buckets),
+  };
+}
+
+export function formatAgentTimelineActivitySummary(buckets: AgentTimelineActivitySummaryBucket[]): string {
+  return buckets.map((bucket) => {
+    const label = ACTIVITY_SUMMARY_LABELS[bucket.kind];
+    return `${label} ${bucket.count} ${bucket.count === 1 ? ACTIVITY_SUMMARY_NOUNS[bucket.kind].singular : ACTIVITY_SUMMARY_NOUNS[bucket.kind].plural}`;
+  }).join(", ");
+}
+
+function classifyTimelineActivity(item: AgentTimelineItem): AgentTimelineActivityKind | null {
+  if (item.kind === "approval" && item.status === "requested") return "approval";
+  if (item.kind !== "tool" || item.status !== "finished") return null;
+  return classifyToolActivity(item.toolName, item.inputPreview);
+}
+
+function classifyToolActivity(toolName: string, inputPreview?: string): AgentTimelineActivityKind {
+  const normalizedTool = normalizeToolToken(toolName);
+  const input = parseToolInputPreview(inputPreview);
+  const command = stringField(input, "command") ?? stringField(input, "cmd");
+  if (command) return classifyCommandActivity(command);
+  if (hasAny(normalizedTool, ["test", "verify", "check"])) return "test";
+  if (hasAny(normalizedTool, ["search", "grep", "query"])) return "search";
+  if (hasAny(normalizedTool, ["read", "list", "dir", "log", "diff"])) return "read";
+  if (hasAny(normalizedTool, ["write", "create"])) return "file_create";
+  if (hasAny(normalizedTool, ["edit", "patch", "apply"])) return "file_modify";
+  return "command";
+}
+
+function classifyCommandActivity(command: string): AgentTimelineActivityKind {
+  const trimmed = command.trim();
+  const executable = firstCommandToken(trimmed);
+  if (["rg", "grep", "ag", "ack"].includes(executable)) return "search";
+  if (["cat", "sed", "awk", "ls", "find", "pwd", "head", "tail"].includes(executable)) return "read";
+  if (executable === "git") {
+    const subcommand = firstCommandToken(trimmed.split(/\s+/).slice(1).join(" "));
+    if (["grep"].includes(subcommand)) return "search";
+    if (["show", "log", "status", "diff", "ls-files"].includes(subcommand)) return "read";
+  }
+  if (["npm", "pnpm", "yarn", "bun"].includes(executable)) {
+    if (/\b(test|vitest|jest|typecheck|lint|check|verify)\b/.test(trimmed)) return "test";
+  }
+  if (["pytest", "vitest", "jest"].includes(executable)) return "test";
+  if (executable === "go" && /\btest\b/.test(trimmed)) return "test";
+  if (executable === "cargo" && /\btest\b/.test(trimmed)) return "test";
+  return "command";
+}
+
+function parseToolInputPreview(inputPreview?: string): Record<string, unknown> | null {
+  if (!inputPreview) return null;
+  try {
+    const parsed = JSON.parse(inputPreview);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringField(input: Record<string, unknown> | null, field: string): string | null {
+  const value = input?.[field];
+  return typeof value === "string" ? value : null;
+}
+
+function normalizeToolToken(value: string): string {
+  return value.toLowerCase().replace(/[-_]/g, "");
+}
+
+function hasAny(value: string, needles: string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
+}
+
+function firstCommandToken(command: string): string {
+  return command.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? "";
+}
+
+const ACTIVITY_SUMMARY_ORDER: AgentTimelineActivityKind[] = [
+  "search",
+  "read",
+  "command",
+  "file_create",
+  "file_modify",
+  "test",
+  "approval",
+];
+
+const ACTIVITY_SUMMARY_LABELS: Record<AgentTimelineActivityKind, string> = {
+  search: "searched",
+  read: "read",
+  command: "ran",
+  file_create: "created",
+  file_modify: "modified",
+  test: "verified",
+  approval: "requested",
+};
+
+const ACTIVITY_SUMMARY_NOUNS: Record<AgentTimelineActivityKind, { singular: string; plural: string }> = {
+  search: { singular: "search", plural: "searches" },
+  read: { singular: "file", plural: "files" },
+  command: { singular: "command", plural: "commands" },
+  file_create: { singular: "file", plural: "files" },
+  file_modify: { singular: "file", plural: "files" },
+  test: { singular: "check", plural: "checks" },
+  approval: { singular: "approval", plural: "approvals" },
+};

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -325,6 +325,7 @@ export class BoundedAgentLoopRunner {
           ...this.baseEvent(turn),
           callId: result.callId,
           toolName: result.toolName,
+          inputPreview: this.preview(this.stringify(response.toolCalls.find((call) => call.id === result.callId)?.input ?? {})),
           success: result.success,
           disposition: result.disposition,
           outputPreview: this.preview(result.content),

--- a/tmp/shared-agent-timeline-status.md
+++ b/tmp/shared-agent-timeline-status.md
@@ -32,3 +32,11 @@
 - Replace chat/TUI-facing Intent/Checkpoint/Updated plan labels with natural user-facing text while preserving structured event kinds/source ids for raw/debug traceability.
 - Add transcript tests that assert normal output does not expose the internal labels while plan, approval, compaction, resume, and recovery information remains visible.
 - #948 verification: focused chat state/chat runner tests passed (118 tests), `npm run typecheck` passed, `npm run lint:boundaries` exited 0 with existing warnings, review agent LGTM, `npm run test:changed` passed (20 files passed, 2 skipped; 442 tests passed, 2 skipped).
+
+## #949 plan
+- Confirmed #949 is open after syncing main.
+- Add a shared deterministic activity-summary timeline item and projection helper generated from structured timeline/tool metadata, not LLM output.
+- Classify search/read, command execution, file create/modify, test/verification, and approval from tool metadata.
+- Render summary rows through the existing chat/TUI shared timeline consumer while preserving detailed timeline rows.
+- #949 review: first review found activity summaries were only test-constructible and not emitted by production bridge; fixed by accumulating shared timeline activity and emitting a summary before final/stopped. Second review found duplicate final/stopped summaries; fixed by clearing accumulated activity after summary emission. Final review LGTM.
+- #949 verification: focused agent-timeline/chat-state tests passed (21 tests), `npm run typecheck` passed, `npm run lint:boundaries` exited 0 with existing warnings, `npm run test:changed` passed (38 files passed, 3 skipped; 552 tests passed, 3 skipped).


### PR DESCRIPTION
Closes #949

## Summary
- Add shared activity_summary timeline items generated deterministically from structured tool and approval metadata.
- Classify search/read, command, file create/modify, test/verification, and approval activity in the shared timeline layer.
- Emit summary rows from the chat agent-loop bridge before completion while preserving detailed timeline rows, and render them through the existing chat/TUI timeline consumer.

## Verification
- npm test -- --run src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts src/interface/chat/__tests__/chat-event-state.test.ts
- npm run typecheck
- npm run lint:boundaries (exits 0; existing warnings remain)
- npm run test:changed

## Known risks
- Summary wording is intentionally compact and deterministic; it does not inspect or summarize noisy tool output.