### PR TITLE
Fix direct route intent copy

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -3433,6 +3433,7 @@ describe("ChatRunner", () => {
     });
 
     it("routes Japanese Telegram setup requests to guidance before agent-loop execution", async () => {
+      const events: ChatEvent[] = [];
       const chatAgentLoopRunner = {
         execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
       } as unknown as ChatAgentLoopRunner;
@@ -3444,7 +3445,11 @@ describe("ChatRunner", () => {
           rationale: "operator wants Telegram chat setup",
         }),
       ]);
-      const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner, llmClient }));
+      const runner = new ChatRunner(makeDeps({
+        chatAgentLoopRunner,
+        llmClient,
+        onEvent: (event) => { events.push(event); },
+      }));
 
       const result = await runner.execute("telegramからseedyと会話できるようにしたい", "/repo");
 
@@ -3452,6 +3457,11 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("pulseed telegram setup");
       expect(result.output).toContain("pulseed gateway setup");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
+        event.type === "activity" && event.sourceId === "intent:first-step"
+      );
+      expect(intent?.message).toContain("prepare configuration guidance");
+      expect(intent?.message).not.toContain("resume the saved agent loop state");
     });
 
     it("routes English Telegram setup paraphrases to guidance before agent-loop execution", async () => {
@@ -3477,6 +3487,7 @@ describe("ChatRunner", () => {
     });
 
     it("asks for clarification on ambiguous freeform input instead of editing code", async () => {
+      const events: ChatEvent[] = [];
       const chatAgentLoopRunner = {
         execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
       } as unknown as ChatAgentLoopRunner;
@@ -3488,16 +3499,26 @@ describe("ChatRunner", () => {
           rationale: "unclear desired action",
         }),
       ]);
-      const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner, llmClient }));
+      const runner = new ChatRunner(makeDeps({
+        chatAgentLoopRunner,
+        llmClient,
+        onEvent: (event) => { events.push(event); },
+      }));
 
       const result = await runner.execute("いい感じにして", "/repo");
 
       expect(result.success).toBe(true);
       expect(result.output).toContain("one more detail");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
+        event.type === "activity" && event.sourceId === "intent:first-step"
+      );
+      expect(intent?.message).toContain("ask for the missing detail");
+      expect(intent?.message).not.toContain("resume the saved agent loop state");
     });
 
     it("continues explicit implementation requests into the coding agent-loop", async () => {
+      const events: ChatEvent[] = [];
       const chatAgentLoopRunner = {
         execute: vi.fn().mockResolvedValue({
           success: true,
@@ -3515,13 +3536,52 @@ describe("ChatRunner", () => {
           rationale: "explicit code implementation request",
         }),
       ]);
-      const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner, llmClient }));
+      const runner = new ChatRunner(makeDeps({
+        chatAgentLoopRunner,
+        llmClient,
+        onEvent: (event) => { events.push(event); },
+      }));
 
       const result = await runner.execute("Implement the failing tests fix in this repo.", "/repo");
 
       expect(result.success).toBe(true);
       expect(result.output).toBe("Implementation done");
       expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
+      const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
+        event.type === "activity" && event.sourceId === "intent:first-step"
+      );
+      expect(intent?.message).toContain("let the agent loop inspect or change files");
+    });
+
+    it("routes direct assist without agent-loop resume intent copy", async () => {
+      const events: ChatEvent[] = [];
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "assist",
+          confidence: 0.91,
+          rationale: "operator asks for explanatory help",
+        }),
+        "Here is the explanation.",
+      ]);
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
+      } as unknown as ChatAgentLoopRunner;
+      const runner = new ChatRunner(makeDeps({
+        chatAgentLoopRunner,
+        llmClient,
+        onEvent: (event) => { events.push(event); },
+      }));
+
+      const result = await runner.execute("Explain how this works.", "/repo");
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe("Here is the explanation.");
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
+        event.type === "activity" && event.sourceId === "intent:first-step"
+      );
+      expect(intent?.message).toContain("answer directly from the current conversation context");
+      expect(intent?.message).not.toContain("resume the saved agent loop state");
     });
 
     it("keeps non-native-tool clients on the local LLM/tool loop instead of the adapter fallback", async () => {

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -351,6 +351,15 @@ export class ChatRunnerEventBridge {
     if (selectedRoute?.kind === "runtime_control" && selectedRoute.intent) {
       nextStep = `prepare the ${selectedRoute.intent.kind} runtime-control request.`;
       reason = "runtime changes need an explicit operation plan and approval path.";
+    } else if (selectedRoute?.kind === "configure") {
+      nextStep = "prepare configuration guidance for the requested setup flow.";
+      reason = "setup requests should return actionable configuration steps before any agent-loop execution.";
+    } else if (selectedRoute?.kind === "assist") {
+      nextStep = "answer directly from the current conversation context.";
+      reason = "this request can be handled as assistance without resuming an agent loop.";
+    } else if (selectedRoute?.kind === "clarify") {
+      nextStep = "ask for the missing detail needed to choose the right next action.";
+      reason = "the current request is ambiguous and needs clarification before execution.";
     } else if (selectedRoute?.kind === "agent_loop") {
       nextStep = "gather workspace context, then let the agent loop inspect or change files with visible tool activity.";
       reason = "this request may require multiple tool-backed steps.";

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -809,6 +809,7 @@ describe("standalone slash command routing", () => {
         stopped_reason: "completed",
       }),
     } as unknown as ChatAgentLoopRunner;
+    let tuiEventHandler: TuiChatSurface["onEvent"];
     const realRunner = new ChatRunner({
       stateManager: stateManager as unknown as StateManager,
       adapter,
@@ -819,6 +820,7 @@ describe("standalone slash command routing", () => {
         confidence: 0.97,
         rationale: "user wants Telegram chat setup",
       })) as never,
+      onEvent: (event) => tuiEventHandler?.(event),
     });
     let chatRunnerOutput = "";
     const chatRunner = {
@@ -831,7 +833,12 @@ describe("standalone slash command routing", () => {
       interruptAndRedirect: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
       executeIngressMessage: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
       getConversationId: vi.fn(() => "tui-conversation-test"),
-      onEvent: undefined,
+      get onEvent() {
+        return tuiEventHandler;
+      },
+      set onEvent(handler) {
+        tuiEventHandler = handler;
+      },
     };
     const llmClient = createMockLLMClient([
       JSON.stringify({
@@ -873,6 +880,12 @@ describe("standalone slash command routing", () => {
     await vi.waitFor(() => expect(chatRunnerOutput).toContain("pulseed telegram setup"));
     expect(chatRunnerOutput).toContain("pulseed telegram setup");
     expect(chatRunnerOutput).toContain("pulseed gateway setup");
+    await vi.waitFor(() => {
+      const visibleText = testState.lastChatMessages.map((message) => message.text).join("\n");
+      expect(visibleText).toContain("prepare configuration guidance");
+      expect(visibleText).toContain("pulseed telegram setup");
+      expect(visibleText).not.toContain("resume the saved agent loop state");
+    });
     expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     expect(adapter.execute).not.toHaveBeenCalled();
 


### PR DESCRIPTION
Closes #958

## Summary
- Add route-aware intent copy for direct configure, assist, and clarify routes.
- Keep useful agent-loop first-step commentary for agent_loop execution.
- Cover ChatRunner route events and the TUI production caller path for Telegram setup visible messages.

## Verification
- npm run typecheck
- npm test -- --run src/interface/chat/__tests__/chat-runner.test.ts
- npm run test:integration -- --run src/interface/tui/__tests__/app.test.ts
- npm run lint:boundaries (passed with existing warnings)
- npm run test:changed

## Known unresolved risks
- None identified. `tmp/autonomous-tui-telegram-setup-followups-status.md` is intentionally local/ignored as requested status tracking.