### PR TITLE
Improve Telegram configure guidance

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -3454,8 +3454,17 @@ describe("ChatRunner", () => {
       const result = await runner.execute("telegramからseedyと会話できるようにしたい", "/repo");
 
       expect(result.success).toBe(true);
+      expect(result.output).toContain("configuration flow, not a source-edit task");
+      expect(result.output).toContain("@BotFather");
+      expect(result.output).toContain("bot token");
       expect(result.output).toContain("pulseed telegram setup");
+      expect(result.output).toContain("allowed Telegram user IDs");
+      expect(result.output).toContain("/sethome");
       expect(result.output).toContain("pulseed gateway setup");
+      expect(result.output).toContain("pulseed daemon start");
+      expect(result.output).toContain("Send a message to the Telegram bot");
+      expect(result.output).toContain("pulseed daemon status");
+      expect(result.output).toContain("check logs");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
       const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
         event.type === "activity" && event.sourceId === "intent:first-step"
@@ -3481,8 +3490,12 @@ describe("ChatRunner", () => {
       const result = await runner.execute("I want to talk to Seedy from Telegram.", "/repo");
 
       expect(result.success).toBe(true);
+      expect(result.output).toContain("@BotFather");
       expect(result.output).toContain("pulseed telegram setup");
+      expect(result.output).toContain("pulseed gateway setup");
       expect(result.output).toContain("pulseed daemon start");
+      expect(result.output).toContain("pulseed daemon status");
+      expect(result.output).toContain("Do not paste the token into chat");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     });
 

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -388,8 +388,12 @@ describe("CrossPlatformChatSessionManager", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(result.output).toContain("@BotFather");
     expect(result.output).toContain("pulseed telegram setup");
     expect(result.output).toContain("pulseed gateway setup");
+    expect(result.output).toContain("pulseed daemon start");
+    expect(result.output).toContain("pulseed daemon status");
+    expect(result.output).toContain("Telegram setup is a configuration flow");
     expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     expect(adapter.execute).not.toHaveBeenCalled();
   });

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -625,12 +625,15 @@ function formatConfigureGuidance(target: "telegram_gateway" | "gateway" | "provi
     return [
       "Telegram setup is a configuration flow, not a source-edit task.",
       "",
-      "Run these from your shell:",
-      "1. `pulseed telegram setup`",
-      "2. `pulseed gateway setup`",
-      "3. `pulseed daemon start`",
+      "First-time setup:",
+      "1. Create or open a bot with @BotFather and copy the bot token.",
+      "2. Run `pulseed telegram setup`, then enter the token and allowed Telegram user IDs or home chat settings. You can leave the home chat blank and send `/sethome` later.",
+      "3. If you need to choose gateway channels, run `pulseed gateway setup` and select Telegram.",
+      "4. Start or restart PulSeed with `pulseed daemon start`.",
+      "5. Send a message to the Telegram bot.",
+      "6. Verify the daemon/gateway with `pulseed daemon status` and check logs if the message does not arrive.",
       "",
-      "After setup, send a message to the Telegram bot and confirm the gateway is running with `pulseed daemon status`.",
+      "Do not paste the token into chat; enter it only in the setup command.",
     ].join("\n");
   }
   if (target === "gateway") {


### PR DESCRIPTION
Closes #960

## Summary
- Expand deterministic Telegram configure guidance into a first-time setup checklist.
- Align the guidance with the existing Telegram CLI setup flow: BotFather token, allowed user/home chat settings, optional gateway setup, daemon start, bot-message verification, and daemon status/log checks.
- Assert the important setup steps for Japanese, English, and cross-platform Telegram setup requests before agent-loop execution.

## Verification
- npm run typecheck
- npm test -- --run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts
- npm run lint:boundaries (passed with existing warnings)
- npm run test:changed

## Known unresolved risks
- None identified. `tmp/autonomous-tui-telegram-setup-followups-status.md` is intentionally local/ignored as requested status tracking.