### PR TITLE
feat(setup): add secret-safe chat intake

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -17,6 +17,7 @@ import { RuntimeOperationStore } from "../../../runtime/store/runtime-operation-
 import type { Goal } from "../../../base/types/goal.js";
 import type { Task } from "../../../base/types/task.js";
 import type { ChatEvent } from "../chat-events.js";
+import type { ChatIngressMessage, SelectedChatRoute } from "../ingress-router.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
 import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
 import { RuntimeOperatorHandoffStore } from "../../../runtime/store/operator-handoff-store.js";
@@ -48,6 +49,59 @@ function makeMockStateManager(): StateManager {
     writeRaw: vi.fn().mockResolvedValue(undefined),
     readRaw: vi.fn().mockResolvedValue(null),
   } as unknown as StateManager;
+}
+
+function makeIngress(text: string): ChatIngressMessage {
+  return {
+    channel: "plugin_gateway",
+    platform: "telegram",
+    identity_key: "telegram:user-1",
+    conversation_id: "chat-1",
+    message_id: "message-1",
+    text,
+    actor: {
+      surface: "gateway",
+      identity_key: "telegram:user-1",
+    },
+    runtimeControl: {
+      allowed: false,
+      approvalMode: "disallowed",
+    },
+    metadata: {},
+    replyTarget: {
+      surface: "gateway",
+      channel: "plugin_gateway",
+      identity_key: "telegram:user-1",
+      conversation_id: "chat-1",
+      deliveryMode: "reply",
+    },
+  };
+}
+
+function adapterRoute(): SelectedChatRoute {
+  return {
+    kind: "adapter",
+    reason: "adapter_fallback",
+    replyTargetPolicy: "turn_reply_target",
+    eventProjectionPolicy: "turn_only",
+    concurrencyPolicy: "session_serial",
+  };
+}
+
+function telegramConfigureRoute(): SelectedChatRoute {
+  return {
+    kind: "configure",
+    reason: "freeform_semantic_route",
+    intent: {
+      kind: "configure",
+      confidence: 0.95,
+      configure_target: "telegram_gateway",
+      rationale: "test configure route",
+    },
+    replyTargetPolicy: "turn_reply_target",
+    eventProjectionPolicy: "turn_only",
+    concurrencyPolicy: "session_serial",
+  };
 }
 
 function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
@@ -237,6 +291,100 @@ function makeTask(id: string, goalId: string, overrides: Partial<Task> = {}): Ta
 
 describe("ChatRunner", () => {
   describe("normal execution", () => {
+    it("redacts setup secrets through the production ingress entrypoint before persistence, events, and adapter prompts", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const stateManager = makeMockStateManager();
+      const adapter = makeMockAdapter();
+      const events: ChatEvent[] = [];
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        adapter,
+        onEvent: (event) => events.push(event),
+      }));
+
+      await runner.executeIngressMessage(
+        makeIngress(`telegram setup token ${telegramToken}`),
+        "/repo",
+        30_000,
+        adapterRoute()
+      );
+
+      const persistedSession = (stateManager.writeRaw as ReturnType<typeof vi.fn>).mock.calls
+        .map(([, value]) => value)
+        .find((value) => value && typeof value === "object" && Array.isArray(value.messages));
+      expect(JSON.stringify(persistedSession)).not.toContain(telegramToken);
+      expect(persistedSession.messages[0].content).toContain("[REDACTED:telegram_bot_token:setup_secret_1]");
+      expect(persistedSession.messages[0].setupSecretIntake).toEqual([
+        expect.objectContaining({
+          id: "setup_secret_1",
+          kind: "telegram_bot_token",
+          redaction: "[REDACTED:telegram_bot_token:setup_secret_1]",
+        }),
+      ]);
+      expect(JSON.stringify(events)).not.toContain(telegramToken);
+      expect(JSON.stringify((adapter.execute as ReturnType<typeof vi.fn>).mock.calls)).not.toContain(telegramToken);
+    });
+
+    it("redacts non-Telegram setup secret shapes through the production chat entrypoint", async () => {
+      const apiKey = "sk-proj_abcdefghijklmnopqrstuvwxyz1234567890";
+      const stateManager = makeMockStateManager();
+      const runner = new ChatRunner(makeDeps({ stateManager }));
+
+      await runner.execute(`provider key is ${apiKey}`, "/repo", 30_000);
+
+      const persistedSession = (stateManager.writeRaw as ReturnType<typeof vi.fn>).mock.calls
+        .map(([, value]) => value)
+        .find((value) => value && typeof value === "object" && Array.isArray(value.messages));
+      expect(JSON.stringify(persistedSession)).not.toContain(apiKey);
+      expect(persistedSession.messages[0].setupSecretIntake).toEqual([
+        expect.objectContaining({ kind: "openai_api_key" }),
+      ]);
+    });
+
+    it("routes token-only setup input through standalone ChatRunner typed intake", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const adapter = makeMockAdapter();
+      const runner = new ChatRunner(makeDeps({ adapter }));
+
+      const result = await runner.execute(telegramToken, "/repo", 30_000);
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("I received a Telegram bot token");
+      expect(result.output).not.toContain(telegramToken);
+      expect(adapter.execute).not.toHaveBeenCalled();
+    });
+
+    it("keeps supplied setup secret facts available to the configure route without persisting raw assistant echoes", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const echoedToken = "sk-proj_echoedsecretabcdefghijklmnopqrstuvwxyz";
+      const stateManager = makeMockStateManager();
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        adapter: makeMockAdapter({
+          ...CANNED_RESULT,
+          output: `adapter echoed ${echoedToken}`,
+        }),
+      }));
+
+      const configureResult = await runner.executeIngressMessage(
+        makeIngress(`telegram setup token ${telegramToken}`),
+        "/repo",
+        30_000,
+        telegramConfigureRoute()
+      );
+      await runner.execute(`regular turn ${echoedToken}`, "/repo", 30_000);
+
+      const persistedSession = (stateManager.writeRaw as ReturnType<typeof vi.fn>).mock.calls
+        .map(([, value]) => value)
+        .filter((value) => value && typeof value === "object" && Array.isArray(value.messages))
+        .at(-1);
+      expect(configureResult.output).not.toContain(telegramToken);
+      expect(configureResult.output).toContain("I received a Telegram bot token");
+      expect(JSON.stringify(persistedSession)).not.toContain(telegramToken);
+      expect(JSON.stringify(persistedSession)).not.toContain(echoedToken);
+      expect(JSON.stringify(persistedSession)).toContain("[REDACTED:openai_api_key:setup_secret_1]");
+    });
+
     it("calls adapter.execute with correct AgentTask shape", async () => {
       const adapter = makeMockAdapter();
       const runner = new ChatRunner(makeDeps({ adapter }));
@@ -3495,7 +3643,7 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("pulseed gateway setup");
       expect(result.output).toContain("pulseed daemon start");
       expect(result.output).toContain("pulseed daemon status");
-      expect(result.output).toContain("Do not paste the token into chat");
+      expect(result.output).toContain("If you paste the token here, PulSeed will redact it from history");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     });
 

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -50,6 +50,37 @@ function getSessionPaths(stateManager: StateManager): string[] {
 }
 
 describe("CrossPlatformChatSessionManager", () => {
+  it("routes token-only setup follow-up through typed secret intake instead of adapter execution", async () => {
+    const token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+    const stateManager = makeMockStateManager();
+    const adapter = makeMockAdapter();
+    const llmClient = createMockLLMClient([
+      JSON.stringify({ kind: "assist", confidence: 0.95, rationale: "generic fallback" }),
+    ]);
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager,
+      adapter,
+      llmClient,
+      chatAgentLoopRunner: {
+        execute: vi.fn(),
+      } as never,
+    }));
+
+    const result = await manager.execute(token, {
+      identity_key: "telegram:user-1",
+      platform: "telegram",
+      conversation_id: "telegram-chat-1",
+      user_id: "user-1",
+      cwd: "/repo",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("I received a Telegram bot token");
+    expect(result.output).not.toContain(token);
+    expect(adapter.execute).not.toHaveBeenCalled();
+    expect(JSON.stringify((stateManager.writeRaw as ReturnType<typeof vi.fn>).mock.calls)).not.toContain(token);
+  });
+
   it("reuses the same ChatRunner session for the same identity_key across platforms", async () => {
     const stateManager = makeMockStateManager();
     const manager = new CrossPlatformChatSessionManager(makeDeps({ stateManager }));

--- a/src/interface/chat/__tests__/setup-secret-intake.test.ts
+++ b/src/interface/chat/__tests__/setup-secret-intake.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { intakeSetupSecrets } from "../setup-secret-intake.js";
+
+describe("setup secret intake", () => {
+  it("stores the detected Telegram token as transient value without offset artifacts", () => {
+    const token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+    const result = intakeSetupSecrets(`telegram token ${token}`);
+
+    expect(result.redactedText).toBe("telegram token [REDACTED:telegram_bot_token:setup_secret_1]");
+    expect(result.suppliedSecrets).toEqual([
+      expect.objectContaining({
+        kind: "telegram_bot_token",
+        value: token,
+      }),
+    ]);
+  });
+
+  it("redacts URL query secret values while preserving the query key", () => {
+    const result = intakeSetupSecrets("https://example.test/callback?token=abcdef1234567890&ok=1");
+
+    expect(result.redactedText).toBe("https://example.test/callback?token=[REDACTED:url_token_secret:setup_secret_1]&ok=1");
+    expect(result.suppliedSecrets).toEqual([
+      expect.objectContaining({
+        kind: "url_token_secret",
+        value: "abcdef1234567890",
+      }),
+    ]);
+  });
+});

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -1,6 +1,7 @@
 import type { ChatEvent } from "./chat-events.js";
 import { formatLifecycleFailureMessage } from "./failure-recovery.js";
 import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
+import { redactSetupSecrets } from "./setup-secret-intake.js";
 
 type ToolActivityState = "reading" | "planning" | "editing" | "verifying" | "waiting" | "running" | "completed" | "failed";
 
@@ -89,26 +90,26 @@ function renderTimelineItem(item: AgentTimelineItem): string {
     case "model_request":
       return `Asked ${item.model} for the next step with ${item.toolCount} available tool(s).`;
     case "assistant_message":
-      return item.text;
+      return redactSetupSecrets(item.text);
     case "tool": {
       const detail = item.status === "started" ? item.inputPreview : item.outputPreview;
       const label = item.status === "started" ? "Started" : item.success ? "Finished" : "Failed";
-      return detail ? `${label} ${item.toolName}: ${detail}` : `${label} ${item.toolName}.`;
+      return detail ? `${label} ${item.toolName}: ${redactSetupSecrets(detail)}` : `${label} ${item.toolName}.`;
     }
     case "plan":
-      return `Plan changed: ${item.summary}`;
+      return `Plan changed: ${redactSetupSecrets(item.summary)}`;
     case "approval":
       return item.status === "requested"
-        ? `Approval requested for ${item.toolName}: ${item.reason}`
-        : `Approval denied for ${item.toolName}: ${item.reason}`;
+        ? `Approval requested for ${item.toolName}: ${redactSetupSecrets(item.reason)}`
+        : `Approval denied for ${item.toolName}: ${redactSetupSecrets(item.reason)}`;
     case "compaction":
       return `Compacted context (${item.phase}, ${item.reason}): ${item.inputMessages} -> ${item.outputMessages}.`;
     case "activity_summary":
-      return item.text;
+      return redactSetupSecrets(item.text);
     case "final":
-      return item.outputPreview;
+      return redactSetupSecrets(item.outputPreview);
     case "stopped":
-      return item.reasonDetail ? `Stopped: ${item.reason} (${item.reasonDetail})` : `Stopped: ${item.reason}`;
+      return item.reasonDetail ? `Stopped: ${item.reason} (${redactSetupSecrets(item.reasonDetail)})` : `Stopped: ${item.reason}`;
   }
 }
 
@@ -119,7 +120,7 @@ function isTransientTimelineItem(item: AgentTimelineItem): boolean {
 
 function summarizeValue(value: unknown): string {
   if (typeof value === "string") {
-    const normalized = value.replace(/\s+/g, " ").trim();
+    const normalized = redactSetupSecrets(value).replace(/\s+/g, " ").trim();
     return normalized.length > 80 ? `${normalized.slice(0, 77)}...` : normalized;
   }
   if (typeof value === "number" || typeof value === "boolean") {

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -6,6 +6,7 @@
 import { z } from "zod";
 import type { StateManager } from "../../base/state/state-manager.js";
 import { RuntimeReplyTargetSchema, type RuntimeReplyTarget } from "../../runtime/session-registry/types.js";
+import { redactSetupSecrets, SetupSecretIntakeItemSchema } from "./setup-secret-intake.js";
 
 // ─── Schemas ───
 
@@ -14,6 +15,7 @@ export const ChatMessageSchema = z.object({
   content: z.string(),
   timestamp: z.string(), // ISO 8601
   turnIndex: z.number().int().min(0),
+  setupSecretIntake: z.array(SetupSecretIntakeItemSchema.omit({ value: true })).optional(),
 }).passthrough();
 export type ChatMessage = z.infer<typeof ChatMessageSchema>;
 
@@ -117,12 +119,15 @@ export class ChatHistory {
   }
 
   /** Append a user message and persist to disk BEFORE adapter execution. */
-  async appendUserMessage(content: string): Promise<void> {
+  async appendUserMessage(content: string, options: { setupSecretIntake?: Array<Omit<z.infer<typeof SetupSecretIntakeItemSchema>, "value">> } = {}): Promise<void> {
     this.session.messages.push({
       role: "user",
       content,
       timestamp: new Date().toISOString(),
       turnIndex: this.session.messages.length,
+      ...(options.setupSecretIntake && options.setupSecretIntake.length > 0
+        ? { setupSecretIntake: options.setupSecretIntake }
+        : {}),
     });
     await this.persist();
   }
@@ -131,7 +136,7 @@ export class ChatHistory {
   async appendAssistantMessage(content: string): Promise<void> {
     this.session.messages.push({
       role: "assistant",
-      content,
+      content: redactSetupSecrets(content),
       timestamp: new Date().toISOString(),
       turnIndex: this.session.messages.length,
     });

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -23,6 +23,7 @@ import {
   type FailureRecoverySignal,
 } from "./failure-recovery.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
+import { redactSetupSecrets, redactSetupSecretsDeep } from "./setup-secret-intake.js";
 
 export interface AssistantBuffer {
   text: string;
@@ -289,8 +290,9 @@ export class ChatRunnerEventBridge {
   }
 
   emitEvent(event: ChatEvent): void {
-    this.rememberActiveTurnEvent(event);
-    this.onEventGetter()?.(event);
+    const safeEvent = redactChatEvent(event);
+    this.rememberActiveTurnEvent(safeEvent);
+    this.onEventGetter()?.(safeEvent);
   }
 
   private rememberTimelineActivityItem(eventContext: ChatEventContext, item: AgentTimelineItem): void {
@@ -329,11 +331,12 @@ export class ChatRunnerEventBridge {
     sourceId?: string,
     transient = true
   ): void {
-    if (!message.trim()) return;
+    const safeMessage = redactSetupSecrets(message);
+    if (!safeMessage.trim()) return;
     this.emitEvent({
       type: "activity",
       kind,
-      message,
+      message: safeMessage,
       ...(sourceId ? { sourceId } : {}),
       transient,
       ...this.eventBase(eventContext),
@@ -418,10 +421,11 @@ export class ChatRunnerEventBridge {
     eventContext: ChatEventContext
   ): void {
     if (!delta) return;
-    assistantBuffer.text += delta;
+    const safeDelta = redactSetupSecrets(delta);
+    assistantBuffer.text += safeDelta;
     this.emitEvent({
       type: "assistant_delta",
-      delta,
+      delta: safeDelta,
       text: assistantBuffer.text,
       ...this.eventBase(eventContext),
     });
@@ -536,6 +540,10 @@ export class ChatRunnerEventBridge {
     } catch {
       // fall through
     }
-    return preview ? { preview } : {};
+    return preview ? { preview: redactSetupSecrets(preview) } : {};
   }
+}
+
+function redactChatEvent(event: ChatEvent): ChatEvent {
+  return redactSetupSecretsDeep(event);
 }

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -19,6 +19,7 @@ import type { ChatEventContext } from "./chat-events.js";
 import type { AgentLoopSessionState } from "../../orchestrator/execution/agent-loop/agent-loop-session-state.js";
 import { resolveExecutionPolicy, type ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 import type { AssistantBuffer, ChatRunnerEventBridge } from "./chat-runner-event-bridge.js";
+import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
@@ -31,6 +32,7 @@ export interface ChatRunnerRouteHost {
   getConversationSessionId(): string | null;
   getSessionCwd(): string | null;
   getNativeAgentLoopStatePath(): string | null;
+  getSetupSecretIntake(): SetupSecretIntakeResult | null;
   getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
   setSessionExecutionPolicy(policy: ExecutionPolicy): void;
 }
@@ -86,7 +88,7 @@ export async function executeConfigureRoute(
   if (route.kind !== "configure") {
     throw new Error(`executeConfigureRoute received route kind ${route.kind}`);
   }
-  const output = formatConfigureGuidance(route.intent.configure_target ?? "unknown");
+  const output = formatConfigureGuidance(route.intent.configure_target ?? "unknown", host.getSetupSecretIntake());
   return persistDirectRouteResult(host, output, eventContext, assistantBuffer, history, start);
 }
 
@@ -620,8 +622,13 @@ async function persistDirectRouteResult(
   return { success: true, output, elapsed_ms };
 }
 
-function formatConfigureGuidance(target: "telegram_gateway" | "gateway" | "provider" | "daemon" | "notification" | "slack" | "unknown"): string {
+function formatConfigureGuidance(
+  target: "telegram_gateway" | "gateway" | "provider" | "daemon" | "notification" | "slack" | "unknown",
+  setupSecretIntake: SetupSecretIntakeResult | null = null,
+): string {
+  const suppliedSecretKinds = setupSecretIntake?.suppliedSecrets.map((secret) => secret.kind) ?? [];
   if (target === "telegram_gateway") {
+    const suppliedTelegramToken = suppliedSecretKinds.includes("telegram_bot_token");
     return [
       "Telegram setup is a configuration flow, not a source-edit task.",
       "",
@@ -633,7 +640,9 @@ function formatConfigureGuidance(target: "telegram_gateway" | "gateway" | "provi
       "5. Send a message to the Telegram bot.",
       "6. Verify the daemon/gateway with `pulseed daemon status` and check logs if the message does not arrive.",
       "",
-      "Do not paste the token into chat; enter it only in the setup command.",
+      suppliedTelegramToken
+        ? "I received a Telegram bot token in this turn and kept it redacted from chat history and activity. I can continue only after an explicit confirmation step."
+        : "The recommended path is the setup command. If you paste the token here, PulSeed will redact it from history and ask for confirmation before writing config.",
     ].join("\n");
   }
   if (target === "gateway") {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -46,6 +46,7 @@ import {
   type PendingTendState,
 } from "./chat-runner-commands.js";
 import { ChatRunnerEventBridge, type AssistantBuffer } from "./chat-runner-event-bridge.js";
+import { intakeSetupSecrets } from "./setup-secret-intake.js";
 import {
   buildRuntimeControlContextFromIngress,
   buildStandaloneIngressMessageFromContext,
@@ -161,6 +162,7 @@ export class ChatRunner {
   private runtimeControlContext: RuntimeControlChatContext | null = null;
   private sessionExecutionPolicy: ExecutionPolicy | null = null;
   private lastSelectedRoute: SelectedChatRoute | null = null;
+  private setupSecretIntake: ReturnType<typeof intakeSetupSecrets> | null = null;
 
   constructor(private readonly deps: ChatRunnerDeps) {
     this.groundingGateway = createChatGroundingGateway({
@@ -330,16 +332,20 @@ export class ChatRunner {
     const activeTurn = this.eventBridge.beginActiveTurn(eventContext, resolvedCwd);
     const resumeCommand = this.commandHandler.parseResumeCommand(input);
     const resumeOnly = resumeCommand !== null;
+    const setupSecretIntake = intakeSetupSecrets(input);
+    this.setupSecretIntake = setupSecretIntake;
+    const safeInput = setupSecretIntake.redactedText;
+    const persistedSecretIntake = setupSecretIntake.suppliedSecrets.map(({ value: _value, ...metadata }) => metadata);
     const runtimeControlContext = options.runtimeControlContext ?? this.runtimeControlContext;
     const executionGoalId = options.goalId ?? this.deps.goalId;
 
-    const commandResult = resumeOnly ? null : await this.commandHandler.handleCommand(input, resolvedCwd);
+    const commandResult = resumeOnly ? null : await this.commandHandler.handleCommand(safeInput, resolvedCwd);
     if (commandResult !== null) {
       return this.finalizeNonPersistentResult(commandResult, eventContext);
     }
 
     if (this.pendingTend !== null && !resumeOnly) {
-      const confirmationResult = await this.commandHandler.handleTendConfirmation(input.trim(), Date.now());
+      const confirmationResult = await this.commandHandler.handleTendConfirmation(safeInput.trim(), Date.now());
       return this.finalizeNonPersistentResult(confirmationResult, eventContext);
     }
 
@@ -388,12 +394,12 @@ export class ChatRunner {
 
     this.eventBridge.emitEvent({
       type: "lifecycle_start",
-      input,
+      input: safeInput,
       ...this.eventBridge.eventBase(eventContext),
     });
 
     if (!resumeOnly) {
-      await history.appendUserMessage(input);
+      await history.appendUserMessage(safeInput, { setupSecretIntake: persistedSecretIntake });
     }
 
     if (this.cachedStaticSystemPrompt === null) {
@@ -419,13 +425,13 @@ export class ChatRunner {
 
     const selectedRoute = resumeOnly
       ? null
-      : (options.selectedRoute ?? await this.resolveRouteFromInput(input, runtimeControlContext));
+      : (options.selectedRoute ?? await this.resolveRouteFromInput(safeInput, runtimeControlContext));
     this.lastSelectedRoute = selectedRoute;
-    this.eventBridge.emitIntent(input, selectedRoute, eventContext);
+    this.eventBridge.emitIntent(safeInput, selectedRoute, eventContext);
 
     const start = Date.now();
     const assistantBuffer: AssistantBuffer = { text: "" };
-    const identityResponse = resumeOnly ? null : resolveSelfIdentityResponse(input, this.providerConfigBaseDir());
+    const identityResponse = resumeOnly ? null : resolveSelfIdentityResponse(safeInput, this.providerConfigBaseDir());
 
     if (identityResponse !== null) {
       const elapsed_ms = Date.now() - start;
@@ -490,7 +496,7 @@ export class ChatRunner {
 
     if (selectedRoute?.kind === "assist") {
       const result = await executeAssistRoute(this.routeHost(), {
-        input,
+        input: safeInput,
         priorTurns,
         eventContext,
         assistantBuffer,
@@ -502,7 +508,7 @@ export class ChatRunner {
 
     const usesNativeAgentLoop = resumeOnly || selectedRoute?.kind === "agent_loop";
     const groundingWorkspaceContext = !resumeOnly && usesNativeAgentLoop
-      ? await buildChatContext(input, executionCwd)
+      ? await buildChatContext(safeInput, executionCwd)
       : undefined;
 
     let systemPrompt = this.cachedStaticSystemPrompt ?? "";
@@ -515,7 +521,7 @@ export class ChatRunner {
             pluginLoader: this.deps.pluginLoader,
             workspaceRoot: executionCwd,
             goalId: executionGoalId,
-            userMessage: input,
+            userMessage: safeInput,
             trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
             workspaceContext: groundingWorkspaceContext,
           });
@@ -525,8 +531,8 @@ export class ChatRunner {
             purpose: "general_turn",
             workspaceRoot: executionCwd,
             goalId: executionGoalId,
-            userMessage: input,
-            query: input,
+            userMessage: safeInput,
+            query: safeInput,
             trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
           });
           systemPrompt = String(groundingBundle.render("prompt"));
@@ -546,8 +552,8 @@ export class ChatRunner {
       .join("\n\n")
       .trim();
 
-    const context = resumeOnly || usesNativeAgentLoop ? "" : await buildChatContext(input, gitRoot);
-    const basePrompt = resumeOnly ? "" : (context ? `${context}\n\n${input}` : input);
+    const context = resumeOnly || usesNativeAgentLoop ? "" : await buildChatContext(safeInput, gitRoot);
+    const basePrompt = resumeOnly ? "" : (context ? `${context}\n\n${safeInput}` : safeInput);
     const prompt = historyBlock ? `${historyBlock}${basePrompt}` : basePrompt;
 
     if (resumeOnly && !this.deps.chatAgentLoopRunner) {
@@ -659,6 +665,7 @@ export class ChatRunner {
       ...capabilities,
       runtimeControlIntent,
       freeformRouteIntent,
+      setupSecretIntake: this.setupSecretIntake,
     });
   }
 
@@ -683,6 +690,7 @@ export class ChatRunner {
       getConversationSessionId: () => this.history?.getSessionId() ?? null,
       getSessionCwd: () => this.sessionCwd,
       getNativeAgentLoopStatePath: () => this.nativeAgentLoopStatePath,
+      getSetupSecretIntake: () => this.setupSecretIntake,
       getSessionExecutionPolicy: () => this.getSessionExecutionPolicy(),
       setSessionExecutionPolicy: (policy: ExecutionPolicy) => { this.sessionExecutionPolicy = policy; },
     };

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -13,6 +13,7 @@ import {
 } from "./ingress-router.js";
 import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
 import { classifyFreeformRouteIntent } from "./freeform-route-classifier.js";
+import { intakeSetupSecrets } from "./setup-secret-intake.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { buildAdapterRegistry, buildLLMClient } from "../../base/llm/provider-factory.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
@@ -535,16 +536,19 @@ export class CrossPlatformChatSessionManager {
         capabilities.hasRuntimeControlService
         || (!capabilities.hasAgentLoop && !capabilities.hasToolLoop)
       );
+    const setupSecretIntake = intakeSetupSecrets(ingress.text);
+    const safeIngressText = setupSecretIntake.redactedText;
     const runtimeControlIntent = runtimeControlAllowed
-      ? await recognizeRuntimeControlIntent(ingress.text, this.deps.llmClient)
+      ? await recognizeRuntimeControlIntent(safeIngressText, this.deps.llmClient)
       : null;
     const freeformRouteIntent = runtimeControlIntent === null && capabilities.hasAgentLoop
-      ? await classifyFreeformRouteIntent(ingress.text, this.deps.llmClient)
+      ? await classifyFreeformRouteIntent(safeIngressText, this.deps.llmClient)
       : null;
     const selectedRoute = this.ingressRouter.selectRoute(ingress, {
       ...capabilities,
       runtimeControlIntent,
       freeformRouteIntent,
+      setupSecretIntake,
     });
     session.lastRoute = selectedRoute;
 

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { ChatEventHandler } from "./chat-events.js";
 import type { RuntimeControlIntent } from "../../runtime/control/index.js";
 import type { FreeformRouteIntent } from "./freeform-route-classifier.js";
+import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
 import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
@@ -80,6 +81,7 @@ export interface IngressRouterCapabilities {
   hasRuntimeControlService?: boolean;
   runtimeControlIntent?: RuntimeControlIntent | null;
   freeformRouteIntent?: FreeformRouteIntent | null;
+  setupSecretIntake?: SetupSecretIntakeResult | null;
 }
 
 function selectRouteForText(
@@ -116,6 +118,21 @@ function selectRouteForText(
         ...runtimeControlPolicy,
       };
     }
+  }
+
+  const setupSecretKinds = new Set((deps.setupSecretIntake?.suppliedSecrets ?? []).map((secret) => secret.kind));
+  if (setupSecretKinds.has("telegram_bot_token")) {
+    return {
+      kind: "configure",
+      reason: "freeform_semantic_route",
+      intent: {
+        kind: "configure",
+        confidence: 1,
+        configure_target: "telegram_gateway",
+        rationale: "typed setup secret intake detected a Telegram bot token",
+      },
+      ...baseTurnPolicy,
+    };
   }
 
   const freeformIntent = deps.freeformRouteIntent ?? null;

--- a/src/interface/chat/setup-secret-intake.ts
+++ b/src/interface/chat/setup-secret-intake.ts
@@ -1,0 +1,103 @@
+import { z } from "zod";
+
+export const SetupSecretKindSchema = z.enum([
+  "telegram_bot_token",
+  "openai_api_key",
+  "slack_bot_token",
+  "discord_bot_token",
+  "url_token_secret",
+]);
+export type SetupSecretKind = z.infer<typeof SetupSecretKindSchema>;
+
+export const SetupSecretIntakeItemSchema = z.object({
+  id: z.string(),
+  kind: SetupSecretKindSchema,
+  redaction: z.string(),
+  suppliedAt: z.string(),
+  value: z.string(),
+});
+export type SetupSecretIntakeItem = z.infer<typeof SetupSecretIntakeItemSchema>;
+
+export const SetupSecretIntakeResultSchema = z.object({
+  redactedText: z.string(),
+  suppliedSecrets: z.array(SetupSecretIntakeItemSchema),
+});
+export type SetupSecretIntakeResult = z.infer<typeof SetupSecretIntakeResultSchema>;
+
+type SecretDetector = {
+  kind: SetupSecretKind;
+  pattern: RegExp;
+  replacement: "whole_match" | "query_value";
+};
+
+const SECRET_DETECTORS: SecretDetector[] = [
+  {
+    kind: "telegram_bot_token",
+    pattern: /\b\d{6,12}:[A-Za-z0-9_-]{30,80}\b/g,
+    replacement: "whole_match",
+  },
+  {
+    kind: "openai_api_key",
+    pattern: /\bsk-[A-Za-z0-9_-]{20,}\b/g,
+    replacement: "whole_match",
+  },
+  {
+    kind: "slack_bot_token",
+    pattern: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
+    replacement: "whole_match",
+  },
+  {
+    kind: "discord_bot_token",
+    pattern: /\b[A-Za-z0-9_-]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b/g,
+    replacement: "whole_match",
+  },
+  {
+    kind: "url_token_secret",
+    pattern: /([?&](?:access_token|api_key|token|key|secret)=)([^&\s"'<>]{8,})/gi,
+    replacement: "query_value",
+  },
+];
+
+export function intakeSetupSecrets(text: string, suppliedAt = new Date().toISOString()): SetupSecretIntakeResult {
+  const suppliedSecrets: SetupSecretIntakeItem[] = [];
+  let redactedText = text;
+
+  for (const detector of SECRET_DETECTORS) {
+    redactedText = redactedText.replace(detector.pattern, (...args: unknown[]) => {
+      const match = String(args[0]);
+      const prefix = detector.replacement === "query_value" ? String(args[1] ?? "") : "";
+      const value = detector.replacement === "query_value" ? String(args[2] ?? "") : match;
+      const id = `setup_secret_${suppliedSecrets.length + 1}`;
+      const redaction = `[REDACTED:${detector.kind}:${id}]`;
+      suppliedSecrets.push({
+        id,
+        kind: detector.kind,
+        redaction,
+        suppliedAt,
+        value,
+      });
+      return detector.replacement === "query_value" ? `${prefix}${redaction}` : redaction;
+    });
+  }
+
+  return { redactedText, suppliedSecrets };
+}
+
+export function redactSetupSecrets(value: string): string {
+  return intakeSetupSecrets(value).redactedText;
+}
+
+export function redactSetupSecretsDeep<T>(value: T): T {
+  if (typeof value === "string") {
+    return redactSetupSecrets(value) as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSetupSecretsDeep(item)) as T;
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, redactSetupSecretsDeep(entry)])
+    ) as T;
+  }
+  return value;
+}

--- a/src/orchestrator/execution/agent-loop/agent-loop-trace-store.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-trace-store.ts
@@ -1,6 +1,7 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { AgentLoopEvent } from "./agent-loop-events.js";
+import { redactSetupSecretsDeep } from "../../../interface/chat/setup-secret-intake.js";
 
 export interface AgentLoopTraceStore {
   append(event: AgentLoopEvent): Promise<void>;
@@ -11,7 +12,7 @@ export class InMemoryAgentLoopTraceStore implements AgentLoopTraceStore {
   private readonly events: AgentLoopEvent[] = [];
 
   async append(event: AgentLoopEvent): Promise<void> {
-    this.events.push(event);
+    this.events.push(redactSetupSecretsDeep(event));
   }
 
   async list(traceId?: string): Promise<AgentLoopEvent[]> {
@@ -27,9 +28,10 @@ export class JsonlAgentLoopTraceStore implements AgentLoopTraceStore {
   constructor(private readonly filePath: string) {}
 
   async append(event: AgentLoopEvent): Promise<void> {
-    this.events.push(event);
+    const safeEvent = redactSetupSecretsDeep(event);
+    this.events.push(safeEvent);
     await mkdir(dirname(this.filePath), { recursive: true });
-    await appendFile(this.filePath, `${JSON.stringify(event)}\n`, "utf-8");
+    await appendFile(this.filePath, `${JSON.stringify(safeEvent)}\n`, "utf-8");
   }
 
   async list(traceId?: string): Promise<AgentLoopEvent[]> {

--- a/src/runtime/__tests__/logger.test.ts
+++ b/src/runtime/__tests__/logger.test.ts
@@ -107,6 +107,18 @@ describe("log levels — file output", () => {
     expect(content).toContain('"loop":5');
   });
 
+  it("redacts setup secrets from message and nested context before console or file output", async () => {
+    const token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const logger = new Logger({ dir: tmpDir, consoleOutput: true });
+    logger.info(`token ${token}`, { nested: { token } });
+
+    const content = await readLogFile(logger, tmpDir);
+    expect(content).not.toContain(token);
+    expect(content).toContain("[REDACTED:telegram_bot_token:setup_secret_1]");
+    expect(consoleSpy.mock.calls.join("\n")).not.toContain(token);
+  });
+
   it("does not include context JSON when context is not provided", async () => {
     const logger = new Logger({ dir: tmpDir, consoleOutput: false });
     logger.info("no context here");

--- a/src/runtime/gateway/__tests__/signal-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/signal-gateway-adapter.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { SignalGatewayAdapter, type SignalGatewayConfig } from "../signal-gateway-adapter.js";
+
+function makeConfig(): SignalGatewayConfig {
+  return {
+    bridge_url: "http://localhost:8080",
+    account: "+10000000000",
+    recipient_id: "+10000000001",
+    identity_key: "signal:user",
+    allowed_sender_ids: [],
+    denied_sender_ids: [],
+    allowed_conversation_ids: [],
+    denied_conversation_ids: [],
+    runtime_control_allowed_sender_ids: [],
+    conversation_goal_map: {},
+    sender_goal_map: {},
+    poll_interval_ms: 5000,
+    receive_timeout_ms: 2000,
+  };
+}
+
+describe("SignalGatewayAdapter", () => {
+  it("does not include token-only message text in fallback message ids", () => {
+    const token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+    const adapter = new SignalGatewayAdapter(makeConfig());
+    const normalized = (adapter as unknown as {
+      normalizeMessage(message: unknown): { messageId: string } | null;
+    }).normalizeMessage({
+      sender: "+10000000002",
+      timestamp: 123456,
+      message: token,
+    });
+
+    expect(normalized?.messageId).not.toContain(token);
+    expect(normalized?.messageId).toContain("+10000000002:123456:");
+  });
+});

--- a/src/runtime/gateway/signal-gateway-adapter.ts
+++ b/src/runtime/gateway/signal-gateway-adapter.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { randomUUID } from "node:crypto";
 import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
 import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
 import { formatPlaintextNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
@@ -170,7 +171,7 @@ export class SignalGatewayAdapter implements ChannelAdapter {
     if (text === null || senderId === null) {
       return null;
     }
-    const messageId = message.id ?? `${senderId}:${message.timestamp ?? Date.now()}:${text}`;
+    const messageId = message.id ?? `${senderId}:${message.timestamp ?? Date.now()}:${randomUUID()}`;
     const conversationId = message.groupId ?? message.conversationId ?? senderId;
     return {
       messageId,

--- a/src/runtime/logger.ts
+++ b/src/runtime/logger.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
+import { redactSetupSecretsDeep } from "../interface/chat/setup-secret-intake.js";
 
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
@@ -133,8 +134,10 @@ export class Logger {
     if (LOG_LEVELS[level] < this.level) return;
 
     const timestamp = new Date().toISOString();
-    const contextStr = context ? " " + JSON.stringify(context) : "";
-    const line = `[${timestamp}] [${level.toUpperCase().padEnd(5)}] ${message}${contextStr}\n`;
+    const safeMessage = redactSetupSecretsDeep(message);
+    const safeContext = context ? redactSetupSecretsDeep(context) : undefined;
+    const contextStr = safeContext ? " " + JSON.stringify(safeContext) : "";
+    const line = `[${timestamp}] [${level.toUpperCase().padEnd(5)}] ${safeMessage}${contextStr}\n`;
 
     // Console output
     if (this.consoleOutput) {


### PR DESCRIPTION
Closes #966

## Summary
- Add typed setup secret intake/redaction for Telegram, provider/API, Slack, Discord, and URL query secret shapes.
- Redact setup secrets before chat history persistence, lifecycle/chat events, timeline/TUI activity rendering, agent-loop trace persistence, and logger output.
- Preserve non-durable typed intake metadata for setup/configure routing, including token-only Telegram setup follow-ups on standalone and cross-platform chat entrypoints.
- Avoid raw message text in Signal fallback message ids so token-only gateway messages do not leak into persisted reply targets.

## Verification
- `npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/setup-secret-intake.test.ts src/runtime/gateway/__tests__/signal-gateway-adapter.test.ts src/runtime/__tests__/logger.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings)
- `npm run test:changed` (rerun passed after one timing-related agent-loop unit test passed in isolation)

## Known unresolved risks
- Chat-assisted config writes are still approval-gated follow-up work for #964/#965; this PR only provides the secret-safe intake and routing foundation.
