### PR TITLE
feat(gateway): add state-aware Telegram setup guidance

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -18,6 +18,7 @@ import type { Goal } from "../../../base/types/goal.js";
 import type { Task } from "../../../base/types/task.js";
 import type { ChatEvent } from "../chat-events.js";
 import type { ChatIngressMessage, SelectedChatRoute } from "../ingress-router.js";
+import type { TelegramSetupStatus } from "../gateway-setup-status.js";
 import { clearIdentityCache } from "../../../base/config/identity-loader.js";
 import type { ProcessSessionSnapshot } from "../../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
 import { RuntimeOperatorHandoffStore } from "../../../runtime/store/operator-handoff-store.js";
@@ -85,6 +86,48 @@ function adapterRoute(): SelectedChatRoute {
     replyTargetPolicy: "turn_reply_target",
     eventProjectionPolicy: "turn_only",
     concurrencyPolicy: "session_serial",
+  };
+}
+
+type TelegramSetupStatusOverrides = Partial<Omit<TelegramSetupStatus, "daemon" | "config">> & {
+  daemon?: Partial<TelegramSetupStatus["daemon"]>;
+  config?: Partial<TelegramSetupStatus["config"]>;
+};
+
+function makeTelegramSetupStatus(overrides: TelegramSetupStatusOverrides = {}): TelegramSetupStatus {
+  const base: TelegramSetupStatus = {
+    channel: "telegram",
+    state: "unconfigured",
+    configPath: "/tmp/pulseed/gateway/channels/telegram-bot/config.json",
+    daemon: {
+      running: true,
+      port: 41700,
+    },
+    gateway: {
+      loadState: "unknown",
+    },
+    config: {
+      exists: false,
+      hasBotToken: false,
+      hasHomeChat: false,
+      allowAll: false,
+      allowedUserCount: 0,
+      runtimeControlAllowedUserCount: 0,
+      identityKeyConfigured: false,
+    },
+  };
+  return {
+    ...base,
+    ...overrides,
+    daemon: { ...base.daemon, ...(overrides.daemon ?? {}) },
+    gateway: { ...base.gateway, ...(overrides.gateway ?? {}) },
+    config: { ...base.config, ...(overrides.config ?? {}) },
+  };
+}
+
+function makeTelegramStatusProvider(status: TelegramSetupStatus): NonNullable<ChatRunnerDeps["gatewaySetupStatusProvider"]> {
+  return {
+    getTelegramStatus: vi.fn().mockResolvedValue(status),
   };
 }
 
@@ -354,6 +397,89 @@ describe("ChatRunner", () => {
       expect(adapter.execute).not.toHaveBeenCalled();
     });
 
+    it("reports daemon-running unconfigured Telegram state through the production configure route", async () => {
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "configure",
+          confidence: 0.94,
+          configure_target: "telegram_gateway",
+          rationale: "operator wants Telegram setup",
+        }),
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        llmClient,
+        chatAgentLoopRunner: { execute: vi.fn() } as never,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "unconfigured",
+          daemon: { running: true, port: 41700 },
+          config: { exists: false, hasBotToken: false, hasHomeChat: false },
+        })),
+      }));
+
+      const result = await runner.execute("telegram繋げたい", "/repo");
+
+      expect(result.output).toContain("Daemon: running on port 41700; gateway load state is not proven");
+      expect(result.output).toContain("Telegram: not configured");
+      expect(result.output).toContain("pulseed telegram setup");
+      expect(result.output).toContain("pulseed gateway setup");
+      expect(result.output).toContain("If you prefer chat-assisted setup");
+    });
+
+    it("reports configured Telegram state and only points to verification when home chat exists", async () => {
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "configure",
+          confidence: 0.94,
+          configure_target: "telegram_gateway",
+          rationale: "operator wants Telegram setup",
+        }),
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        llmClient,
+        chatAgentLoopRunner: { execute: vi.fn() } as never,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "configured",
+          daemon: { running: true, port: 41700 },
+          config: { exists: true, hasBotToken: true, hasHomeChat: true },
+        })),
+      }));
+
+      const result = await runner.execute("telegram繋げたい", "/repo");
+
+      expect(result.output).toContain("Telegram config: configured");
+      expect(result.output).toContain("Home chat: configured");
+      expect(result.output).toContain("Gateway loaded in daemon: unknown");
+      expect(result.output).toContain("Verification:");
+      expect(result.output).not.toContain("Send `/sethome`");
+    });
+
+    it("reports partially configured Telegram state and directs /sethome through the production configure route", async () => {
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "configure",
+          confidence: 0.94,
+          configure_target: "telegram_gateway",
+          rationale: "operator wants Telegram setup",
+        }),
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        llmClient,
+        chatAgentLoopRunner: { execute: vi.fn() } as never,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "partially_configured",
+          daemon: { running: false, port: 41700 },
+          config: { exists: true, hasBotToken: true, hasHomeChat: false },
+        })),
+      }));
+
+      const result = await runner.execute("telegram繋げたい", "/repo");
+
+      expect(result.output).toContain("Daemon: not responding on port 41700");
+      expect(result.output).toContain("bot token is configured, but no home chat is set");
+      expect(result.output).toContain("Send `/sethome`");
+      expect(result.output).toContain("The config will not take effect until the daemon is started or restarted");
+    });
+
     it("keeps supplied setup secret facts available to the configure route without persisting raw assistant echoes", async () => {
       const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
       const echoedToken = "sk-proj_echoedsecretabcdefghijklmnopqrstuvwxyz";
@@ -383,6 +509,104 @@ describe("ChatRunner", () => {
       expect(JSON.stringify(persistedSession)).not.toContain(telegramToken);
       expect(JSON.stringify(persistedSession)).not.toContain(echoedToken);
       expect(JSON.stringify(persistedSession)).toContain("[REDACTED:openai_api_key:setup_secret_1]");
+    });
+
+    it("writes Telegram config only after explicit confirmation and approval", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-"));
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const approvalFn = vi.fn().mockResolvedValue(true);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        approvalFn,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "unconfigured",
+          configPath: path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"),
+          daemon: { running: true, port: 41700 },
+        })),
+      }));
+
+      const intakeResult = await runner.execute(telegramToken, "/repo", 30_000);
+      const confirmResult = await runner.execute("/confirm-telegram-setup", "/repo", 30_000);
+
+      const configPath = path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json");
+      const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+      expect(intakeResult.output).toContain("/confirm-telegram-setup");
+      expect(confirmResult.success).toBe(true);
+      expect(approvalFn).toHaveBeenCalledOnce();
+      expect(config.bot_token).toBe(telegramToken);
+      expect(config.allow_all).toBe(false);
+      expect(confirmResult.output).toContain("Restart the daemon");
+      expect(confirmResult.output).toContain("Access remains closed");
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it("uses runtime control approval for chat-assisted Telegram config confirmation", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-runtime-"));
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const runtimeControlApprovalFn = vi.fn().mockResolvedValue(true);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        runtimeControlApprovalFn,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "unconfigured",
+          configPath: path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"),
+          daemon: { running: true, port: 41700 },
+        })),
+      }));
+
+      await runner.execute(telegramToken, "/repo", 30_000);
+      const confirmResult = await runner.execute("/confirm-telegram-setup", "/repo", 30_000);
+
+      const configPath = path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json");
+      const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+      expect(confirmResult.success).toBe(true);
+      expect(runtimeControlApprovalFn).toHaveBeenCalledOnce();
+      expect(runtimeControlApprovalFn).toHaveBeenCalledWith(expect.stringContaining("allow_all=false"));
+      expect(config.bot_token).toBe(telegramToken);
+      expect(config.allow_all).toBe(false);
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it("does not let disallowed gateway ingress confirm Telegram config through global approval", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-denied-"));
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const runtimeControlApprovalFn = vi.fn().mockResolvedValue(true);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        runtimeControlApprovalFn,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "unconfigured",
+          configPath: path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"),
+          daemon: { running: true, port: 41700 },
+        })),
+      }));
+
+      await runner.execute(telegramToken, "/repo", 30_000);
+      const confirmResult = await runner.executeIngressMessage(
+        makeIngress("/confirm-telegram-setup"),
+        "/repo",
+        30_000,
+        adapterRoute()
+      );
+
+      const configPath = path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json");
+      expect(confirmResult.success).toBe(false);
+      expect(confirmResult.output).toContain("approval-capable chat surface");
+      expect(runtimeControlApprovalFn).not.toHaveBeenCalled();
+      expect(fs.existsSync(configPath)).toBe(false);
+      fs.rmSync(baseDir, { recursive: true, force: true });
     });
 
     it("calls adapter.execute with correct AgentTask shape", async () => {
@@ -3602,17 +3826,13 @@ describe("ChatRunner", () => {
       const result = await runner.execute("telegramからseedyと会話できるようにしたい", "/repo");
 
       expect(result.success).toBe(true);
-      expect(result.output).toContain("configuration flow, not a source-edit task");
-      expect(result.output).toContain("@BotFather");
-      expect(result.output).toContain("bot token");
+      expect(result.output).toContain("Telegram gateway status");
+      expect(result.output).toContain("Telegram: not configured");
       expect(result.output).toContain("pulseed telegram setup");
-      expect(result.output).toContain("allowed Telegram user IDs");
-      expect(result.output).toContain("/sethome");
       expect(result.output).toContain("pulseed gateway setup");
       expect(result.output).toContain("pulseed daemon start");
-      expect(result.output).toContain("Send a message to the Telegram bot");
       expect(result.output).toContain("pulseed daemon status");
-      expect(result.output).toContain("check logs");
+      expect(result.output).toContain("If you prefer chat-assisted setup");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
       const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
         event.type === "activity" && event.sourceId === "intent:first-step"
@@ -3643,7 +3863,7 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("pulseed gateway setup");
       expect(result.output).toContain("pulseed daemon start");
       expect(result.output).toContain("pulseed daemon status");
-      expect(result.output).toContain("If you paste the token here, PulSeed will redact it from history");
+      expect(result.output).toContain("If you prefer chat-assisted setup");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     });
 

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -424,7 +424,8 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(result.output).toContain("pulseed gateway setup");
     expect(result.output).toContain("pulseed daemon start");
     expect(result.output).toContain("pulseed daemon status");
-    expect(result.output).toContain("Telegram setup is a configuration flow");
+    expect(result.output).toContain("Telegram gateway status");
+    expect(result.output).toContain("Telegram: not configured");
     expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     expect(adapter.execute).not.toHaveBeenCalled();
   });

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -20,6 +20,7 @@ import type { AgentLoopSessionState } from "../../orchestrator/execution/agent-l
 import { resolveExecutionPolicy, type ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 import type { AssistantBuffer, ChatRunnerEventBridge } from "./chat-runner-event-bridge.js";
 import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
+import { createGatewaySetupStatusProvider, type TelegramSetupStatus } from "./gateway-setup-status.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
@@ -32,7 +33,9 @@ export interface ChatRunnerRouteHost {
   getConversationSessionId(): string | null;
   getSessionCwd(): string | null;
   getNativeAgentLoopStatePath(): string | null;
+  getProviderConfigBaseDir(): string;
   getSetupSecretIntake(): SetupSecretIntakeResult | null;
+  setPendingTelegramSetup(token: string): void;
   getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
   setSessionExecutionPolicy(policy: ExecutionPolicy): void;
 }
@@ -88,7 +91,7 @@ export async function executeConfigureRoute(
   if (route.kind !== "configure") {
     throw new Error(`executeConfigureRoute received route kind ${route.kind}`);
   }
-  const output = formatConfigureGuidance(route.intent.configure_target ?? "unknown", host.getSetupSecretIntake());
+  const output = await formatConfigureGuidance(host, route.intent.configure_target ?? "unknown", host.getSetupSecretIntake());
   return persistDirectRouteResult(host, output, eventContext, assistantBuffer, history, start);
 }
 
@@ -622,28 +625,21 @@ async function persistDirectRouteResult(
   return { success: true, output, elapsed_ms };
 }
 
-function formatConfigureGuidance(
+async function formatConfigureGuidance(
+  host: ChatRunnerRouteHost,
   target: "telegram_gateway" | "gateway" | "provider" | "daemon" | "notification" | "slack" | "unknown",
   setupSecretIntake: SetupSecretIntakeResult | null = null,
-): string {
+): Promise<string> {
   const suppliedSecretKinds = setupSecretIntake?.suppliedSecrets.map((secret) => secret.kind) ?? [];
   if (target === "telegram_gateway") {
+    const provider = host.deps.gatewaySetupStatusProvider ?? createGatewaySetupStatusProvider();
+    const status = await provider.getTelegramStatus(host.getProviderConfigBaseDir());
     const suppliedTelegramToken = suppliedSecretKinds.includes("telegram_bot_token");
-    return [
-      "Telegram setup is a configuration flow, not a source-edit task.",
-      "",
-      "First-time setup:",
-      "1. Create or open a bot with @BotFather and copy the bot token.",
-      "2. Run `pulseed telegram setup`, then enter the token and allowed Telegram user IDs or home chat settings. You can leave the home chat blank and send `/sethome` later.",
-      "3. If you need to choose gateway channels, run `pulseed gateway setup` and select Telegram.",
-      "4. Start or restart PulSeed with `pulseed daemon start`.",
-      "5. Send a message to the Telegram bot.",
-      "6. Verify the daemon/gateway with `pulseed daemon status` and check logs if the message does not arrive.",
-      "",
-      suppliedTelegramToken
-        ? "I received a Telegram bot token in this turn and kept it redacted from chat history and activity. I can continue only after an explicit confirmation step."
-        : "The recommended path is the setup command. If you paste the token here, PulSeed will redact it from history and ask for confirmation before writing config.",
-    ].join("\n");
+    const telegramSecret = setupSecretIntake?.suppliedSecrets.find((secret) => secret.kind === "telegram_bot_token");
+    if (telegramSecret) {
+      host.setPendingTelegramSetup(telegramSecret.value);
+    }
+    return formatTelegramConfigureGuidance(status, suppliedTelegramToken, telegramSecret !== undefined);
   }
   if (target === "gateway") {
     return [
@@ -657,6 +653,81 @@ function formatConfigureGuidance(
     "",
     "Use `pulseed setup` for the main wizard, `pulseed gateway setup` for chat channels, or the channel-specific setup command when available.",
   ].join("\n");
+}
+
+function formatTelegramConfigureGuidance(
+  status: TelegramSetupStatus,
+  suppliedTelegramToken: boolean,
+  pendingActionCreated: boolean
+): string {
+  const lines = [
+    "Telegram gateway status",
+    "",
+    status.daemon.running
+      ? `- Daemon: running on port ${status.daemon.port}; gateway load state is not proven from chat status.`
+      : `- Daemon: not responding on port ${status.daemon.port}.`,
+  ];
+
+  if (status.state === "unconfigured") {
+    lines.push(
+      "- Telegram: not configured.",
+      "",
+      "Recommended command path:",
+      "```sh",
+      "pulseed telegram setup",
+      "pulseed gateway setup",
+      "pulseed daemon start",
+      "pulseed daemon status",
+      "```",
+      "",
+      "Create or open a bot with @BotFather, then enter the token in `pulseed telegram setup`."
+    );
+  } else if (status.state === "partially_configured") {
+    lines.push(
+      "- Telegram config: bot token is configured, but no home chat is set.",
+      "- Gateway loaded in daemon: unknown from chat status.",
+      "",
+      "Next step:",
+      "- Send `/sethome` to the Telegram bot from the chat that should receive PulSeed replies.",
+      "- Then run `pulseed daemon status` to verify the gateway."
+    );
+  } else {
+    lines.push(
+      "- Telegram config: configured.",
+      status.config.hasHomeChat
+        ? "- Home chat: configured."
+        : "- Home chat: not set; send `/sethome` if this bot should reply into a specific chat.",
+      "- Gateway loaded in daemon: unknown from chat status.",
+      "",
+      "Verification:",
+      "- Send a message to the Telegram bot.",
+      "- Run `pulseed daemon status` if delivery does not work.",
+      "- If this config was added or changed while the daemon was already running, restart the daemon so the gateway loads the updated config."
+    );
+  }
+
+  lines.push(
+    "",
+    suppliedTelegramToken
+      ? pendingActionCreated
+        ? "I received a Telegram bot token in this turn and kept it redacted from chat history and activity. Reply `/confirm-telegram-setup` to request an approval-gated config write."
+        : "I received a Telegram bot token in this turn and kept it redacted from chat history and activity, but no setup action could be prepared."
+      : "If you prefer chat-assisted setup, paste the token here; PulSeed will redact it from history and prepare an approval-gated confirmation before writing config."
+  );
+
+  if (!status.daemon.running && status.state !== "unconfigured") {
+    lines.push(
+      "",
+      "The config will not take effect until the daemon is started or restarted."
+    );
+  } else if (status.daemon.running && status.state !== "unconfigured") {
+    lines.push(
+      "",
+      "If Telegram was configured or changed after this daemon started, restart the daemon so the gateway loads the latest config."
+    );
+  }
+
+  return lines.join("\n");
 }
 
 async function dispatchToolCall(

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -7,6 +7,8 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import type { IAdapter } from "../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { getPulseedDirPath } from "../../base/utils/paths.js";
+import { getGatewayChannelDir } from "../../base/utils/paths.js";
+import { readJsonFileOrNull, writeJsonFileAtomic } from "../../base/utils/json-io.js";
 import { getSelfIdentityResponseForBaseDir } from "../../base/config/identity-loader.js";
 import { ChatHistory, type ChatSession } from "./chat-history.js";
 import {
@@ -22,6 +24,7 @@ import type { ApprovalLevel } from "./mutation-tool-defs.js";
 import type { ToolRegistry } from "../../tools/registry.js";
 import type { ToolExecutor } from "../../tools/executor.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
+import type { GatewaySetupStatusProvider } from "./gateway-setup-status.js";
 import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
 import type { ChatEvent } from "./chat-events.js";
 import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
@@ -47,6 +50,7 @@ import {
 } from "./chat-runner-commands.js";
 import { ChatRunnerEventBridge, type AssistantBuffer } from "./chat-runner-event-bridge.js";
 import { intakeSetupSecrets } from "./setup-secret-intake.js";
+import type { TelegramGatewayConfig } from "../../runtime/gateway/telegram-gateway-adapter.js";
 import {
   buildRuntimeControlContextFromIngress,
   buildStandaloneIngressMessageFromContext,
@@ -92,6 +96,7 @@ export interface ChatRunnerDeps {
   runtimeControlApprovalFn?: (description: string) => Promise<boolean>;
   runtimeReplyTarget?: RuntimeControlReplyTarget;
   runtimeControlActor?: RuntimeControlActor;
+  gatewaySetupStatusProvider?: GatewaySetupStatusProvider;
 }
 
 export interface ChatRunResult {
@@ -163,6 +168,7 @@ export class ChatRunner {
   private sessionExecutionPolicy: ExecutionPolicy | null = null;
   private lastSelectedRoute: SelectedChatRoute | null = null;
   private setupSecretIntake: ReturnType<typeof intakeSetupSecrets> | null = null;
+  private pendingTelegramSetup: { token: string; createdAt: string } | null = null;
 
   constructor(private readonly deps: ChatRunnerDeps) {
     this.groundingGateway = createChatGroundingGateway({
@@ -338,6 +344,11 @@ export class ChatRunner {
     const persistedSecretIntake = setupSecretIntake.suppliedSecrets.map(({ value: _value, ...metadata }) => metadata);
     const runtimeControlContext = options.runtimeControlContext ?? this.runtimeControlContext;
     const executionGoalId = options.goalId ?? this.deps.goalId;
+
+    const pendingTelegramSetupResult = await this.handlePendingTelegramSetupConfirmation(safeInput, runtimeControlContext);
+    if (pendingTelegramSetupResult !== null) {
+      return this.finalizeNonPersistentResult(pendingTelegramSetupResult, eventContext);
+    }
 
     const commandResult = resumeOnly ? null : await this.commandHandler.handleCommand(safeInput, resolvedCwd);
     if (commandResult !== null) {
@@ -690,7 +701,11 @@ export class ChatRunner {
       getConversationSessionId: () => this.history?.getSessionId() ?? null,
       getSessionCwd: () => this.sessionCwd,
       getNativeAgentLoopStatePath: () => this.nativeAgentLoopStatePath,
+      getProviderConfigBaseDir: () => this.providerConfigBaseDir(),
       getSetupSecretIntake: () => this.setupSecretIntake,
+      setPendingTelegramSetup: (token: string) => {
+        this.pendingTelegramSetup = { token, createdAt: new Date().toISOString() };
+      },
       getSessionExecutionPolicy: () => this.getSessionExecutionPolicy(),
       setSessionExecutionPolicy: (policy: ExecutionPolicy) => { this.sessionExecutionPolicy = policy; },
     };
@@ -699,6 +714,87 @@ export class ChatRunner {
   private providerConfigBaseDir(): string {
     const stateManager = this.deps.stateManager as StateManager & { getBaseDir?: () => string };
     return typeof stateManager.getBaseDir === "function" ? stateManager.getBaseDir() : getPulseedDirPath();
+  }
+
+  private async handlePendingTelegramSetupConfirmation(
+    input: string,
+    runtimeControlContext: RuntimeControlChatContext | null
+  ): Promise<ChatRunResult | null> {
+    if (input.trim() !== "/confirm-telegram-setup") return null;
+    const pending = this.pendingTelegramSetup;
+    if (!pending) {
+      return {
+        success: false,
+        output: "No pending Telegram setup token is available. Paste the token again to start a protected setup turn.",
+        elapsed_ms: 0,
+      };
+    }
+    const approvalFn = runtimeControlContext
+      ? runtimeControlContext.approvalFn
+      : this.deps.runtimeControlApprovalFn ?? this.deps.approvalFn;
+    if (!approvalFn) {
+      return {
+        success: false,
+        output: "Telegram setup requires an approval-capable chat surface before writing config. Use `pulseed telegram setup` instead.",
+        elapsed_ms: 0,
+      };
+    }
+    const baseDir = this.providerConfigBaseDir();
+    const configDir = getGatewayChannelDir("telegram-bot", baseDir);
+    const configPath = `${configDir}/config.json`;
+    const current = await readJsonFileOrNull<Partial<TelegramGatewayConfig>>(configPath);
+    const nextAllowAll = typeof current?.allow_all === "boolean" ? current.allow_all : false;
+    const nextAllowedUserIds = Array.isArray(current?.allowed_user_ids) ? current.allowed_user_ids : [];
+    const nextRuntimeControlAllowedUserIds = Array.isArray(current?.runtime_control_allowed_user_ids)
+      ? current.runtime_control_allowed_user_ids
+      : [];
+    const accessClosedByDefault = !nextAllowAll && nextAllowedUserIds.length === 0 && nextRuntimeControlAllowedUserIds.length === 0;
+    const approved = await approvalFn([
+      "Write Telegram gateway config from the redacted chat-supplied bot token.",
+      accessClosedByDefault
+        ? "Access will remain closed by default with allow_all=false until allowed Telegram user IDs are configured."
+        : "Existing Telegram access policy will be preserved.",
+    ].join(" "));
+    if (!approved) {
+      this.pendingTelegramSetup = null;
+      return {
+        success: false,
+        output: "Telegram setup was not changed because approval was denied.",
+        elapsed_ms: 0,
+      };
+    }
+    const nextConfig: TelegramGatewayConfig = {
+      bot_token: pending.token,
+      ...(typeof current?.chat_id === "number" ? { chat_id: current.chat_id } : {}),
+      allowed_user_ids: nextAllowedUserIds,
+      denied_user_ids: Array.isArray(current?.denied_user_ids) ? current.denied_user_ids : [],
+      allowed_chat_ids: Array.isArray(current?.allowed_chat_ids) ? current.allowed_chat_ids : [],
+      denied_chat_ids: Array.isArray(current?.denied_chat_ids) ? current.denied_chat_ids : [],
+      runtime_control_allowed_user_ids: nextRuntimeControlAllowedUserIds,
+      chat_goal_map: current?.chat_goal_map ?? {},
+      user_goal_map: current?.user_goal_map ?? {},
+      ...(current?.default_goal_id ? { default_goal_id: current.default_goal_id } : {}),
+      allow_all: nextAllowAll,
+      polling_timeout: current?.polling_timeout ?? 30,
+      ...(current?.identity_key ? { identity_key: current.identity_key } : {}),
+    };
+    await writeJsonFileAtomic(configPath, nextConfig);
+    this.pendingTelegramSetup = null;
+    return {
+      success: true,
+      output: [
+        "Telegram gateway config was written from the redacted chat-supplied token.",
+        "",
+        "Next steps:",
+        "- Restart the daemon so the gateway loads the updated config.",
+        ...(accessClosedByDefault
+          ? ["- Access remains closed until you configure allowed Telegram user IDs or intentionally enable `allow_all` with `pulseed telegram setup`."]
+          : []),
+        "- Send `/sethome` from Telegram if no home chat is configured yet.",
+        "- Run `pulseed daemon status` to verify.",
+      ].join("\n"),
+      elapsed_ms: 0,
+    };
   }
 
   private finalizeNonPersistentResult(result: ChatRunResult, eventContext: Parameters<ChatRunnerEventBridge["eventBase"]>[0]): ChatRunResult {

--- a/src/interface/chat/gateway-setup-status.ts
+++ b/src/interface/chat/gateway-setup-status.ts
@@ -1,0 +1,79 @@
+import * as path from "node:path";
+import { readJsonFileOrNull } from "../../base/utils/json-io.js";
+import { getGatewayChannelDir, getPulseedDirPath } from "../../base/utils/paths.js";
+import { isDaemonRunning } from "../../runtime/daemon/client.js";
+import type { TelegramGatewayConfig } from "../../runtime/gateway/telegram-gateway-adapter.js";
+
+export type TelegramSetupState = "unconfigured" | "partially_configured" | "configured";
+
+export interface TelegramSetupStatus {
+  channel: "telegram";
+  state: TelegramSetupState;
+  configPath: string;
+  daemon: {
+    running: boolean;
+    port: number;
+  };
+  gateway: {
+    loadState: "unknown";
+  };
+  config: {
+    exists: boolean;
+    hasBotToken: boolean;
+    hasHomeChat: boolean;
+    allowAll: boolean;
+    allowedUserCount: number;
+    runtimeControlAllowedUserCount: number;
+    identityKeyConfigured: boolean;
+  };
+}
+
+export interface GatewaySetupStatusProvider {
+  getTelegramStatus(baseDir?: string): Promise<TelegramSetupStatus>;
+}
+
+export interface GatewaySetupStatusProviderDeps {
+  daemonStatus?: (baseDir: string) => Promise<{ running: boolean; port: number }>;
+}
+
+export function createGatewaySetupStatusProvider(
+  deps: GatewaySetupStatusProviderDeps = {}
+): GatewaySetupStatusProvider {
+  return {
+    async getTelegramStatus(baseDir = getPulseedDirPath()): Promise<TelegramSetupStatus> {
+      const configPath = path.join(getGatewayChannelDir("telegram-bot", baseDir), "config.json");
+      const config = await readJsonFileOrNull<Partial<TelegramGatewayConfig>>(configPath);
+      const daemon = await (deps.daemonStatus ?? isDaemonRunning)(baseDir);
+      const hasBotToken = typeof config?.bot_token === "string" && config.bot_token.trim().length > 0;
+      const hasHomeChat = typeof config?.chat_id === "number";
+      const state: TelegramSetupState = !hasBotToken
+        ? "unconfigured"
+        : hasHomeChat
+          ? "configured"
+          : "partially_configured";
+      return {
+        channel: "telegram",
+        state,
+        configPath,
+        daemon: {
+          running: daemon.running,
+          port: daemon.port,
+        },
+        gateway: {
+          loadState: "unknown",
+        },
+        config: {
+          exists: config !== null,
+          hasBotToken,
+          hasHomeChat,
+          allowAll: config?.allow_all === true,
+          allowedUserCount: Array.isArray(config?.allowed_user_ids) ? config.allowed_user_ids.length : 0,
+          runtimeControlAllowedUserCount: Array.isArray(config?.runtime_control_allowed_user_ids)
+            ? config.runtime_control_allowed_user_ids.length
+            : 0,
+          identityKeyConfigured: typeof config?.identity_key === "string" && config.identity_key.trim().length > 0,
+        },
+      };
+    },
+  };
+}


### PR DESCRIPTION
Closes #964

## Summary
- add a reusable Telegram setup status provider that reads daemon liveness and Telegram gateway config state
- route Telegram configure guidance through live status for unconfigured, partially configured, and configured states
- add a redacted, approval-gated `/confirm-telegram-setup` path that preserves existing access policy and defaults new chat-assisted configs to `allow_all=false`
- explicitly report that gateway load state is unknown from chat status so stale daemon/config cases are not overclaimed

## Verification
- `npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings)
- `npm run test:changed`
- fresh review agent: no material findings after fixes

## Known unresolved risks
- Chat status still cannot prove whether a running daemon has already loaded the Telegram adapter; guidance now states this explicitly and directs restart/verification when needed.
