### PR TITLE
feat(setup): add typed setup dialogue contract

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -530,13 +530,28 @@ describe("ChatRunner", () => {
       }));
 
       const intakeResult = await runner.execute(telegramToken, "/repo", 30_000);
-      const confirmResult = await runner.execute("/confirm-telegram-setup", "/repo", 30_000);
+      const persistedSession = (stateManager.writeRaw as ReturnType<typeof vi.fn>).mock.calls
+        .map(([, value]) => value)
+        .find((value) => value?.setupDialogue?.selectedChannel === "telegram");
+      const persistedDialogue = JSON.parse(JSON.stringify(persistedSession.setupDialogue));
+      const confirmResult = await runner.execute("/confirm-setup-write", "/repo", 30_000);
 
       const configPath = path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json");
       const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
-      expect(intakeResult.output).toContain("/confirm-telegram-setup");
+      expect(intakeResult.output).toContain("/confirm-setup-write");
       expect(confirmResult.success).toBe(true);
       expect(approvalFn).toHaveBeenCalledOnce();
+      expect(persistedDialogue).toMatchObject({
+        state: "confirm_write",
+        selectedChannel: "telegram",
+        action: {
+          kind: "write_gateway_config",
+          channel: "telegram",
+          command: "/confirm-setup-write",
+          requiresApproval: true,
+        },
+      });
+      expect(JSON.stringify(persistedDialogue)).not.toContain(telegramToken);
       expect(config.bot_token).toBe(telegramToken);
       expect(config.allow_all).toBe(false);
       expect(confirmResult.output).toContain("Restart the daemon");
@@ -563,7 +578,7 @@ describe("ChatRunner", () => {
       }));
 
       await runner.execute(telegramToken, "/repo", 30_000);
-      const confirmResult = await runner.execute("/confirm-telegram-setup", "/repo", 30_000);
+      const confirmResult = await runner.execute("/confirm-setup-write", "/repo", 30_000);
 
       const configPath = path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json");
       const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
@@ -595,7 +610,7 @@ describe("ChatRunner", () => {
 
       await runner.execute(telegramToken, "/repo", 30_000);
       const confirmResult = await runner.executeIngressMessage(
-        makeIngress("/confirm-telegram-setup"),
+        makeIngress("/confirm-setup-write"),
         "/repo",
         30_000,
         adapterRoute()
@@ -606,6 +621,92 @@ describe("ChatRunner", () => {
       expect(confirmResult.output).toContain("approval-capable chat surface");
       expect(runtimeControlApprovalFn).not.toHaveBeenCalled();
       expect(fs.existsSync(configPath)).toBe(false);
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it("rejects stale pending setup state when the selected channel is not Telegram", async () => {
+      const discordToken = "ABCDEFGHIJKLMNOPQRSTUVWX.abcdef.ABCDEFGHIJKLMNOPQRSTUVWXYZ1";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-discord-stale-"));
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const approvalFn = vi.fn().mockResolvedValue(true);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        approvalFn,
+      }));
+
+      const planResult = await runner.execute(discordToken, "/repo", 30_000);
+      const confirmResult = await runner.execute("/confirm-setup-write", "/repo", 30_000);
+
+      const persistedSession = (stateManager.writeRaw as ReturnType<typeof vi.fn>).mock.calls
+        .map(([, value]) => value)
+        .find((value) => value?.setupDialogue?.selectedChannel === "discord");
+      const discordConfigPath = path.join(baseDir, "gateway", "channels", "discord-bot", "config.json");
+      expect(planResult.output).toContain("Discord gateway setup plan");
+      expect(persistedSession.setupDialogue).toMatchObject({
+        state: "blocked",
+        selectedChannel: "discord",
+        action: {
+          kind: "adapter_plan",
+          channel: "discord",
+          status: "blocked",
+        },
+      });
+      expect(JSON.stringify(persistedSession.setupDialogue)).not.toContain(discordToken);
+      expect(confirmResult.success).toBe(false);
+      expect(confirmResult.output).toContain("pending setup dialogue is for discord");
+      expect(approvalFn).not.toHaveBeenCalled();
+      expect(fs.existsSync(discordConfigPath)).toBe(false);
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it("preserves Telegram setup dialogue across a gateway ingress confirmation turn", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-ingress-"));
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const runtimeControlApprovalFn = vi.fn().mockResolvedValue(true);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        runtimeControlApprovalFn,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "unconfigured",
+          configPath: path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"),
+          daemon: { running: true, port: 41700 },
+        })),
+      }));
+      const allowedIngress = (text: string): ChatIngressMessage => ({
+        ...makeIngress(text),
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      });
+
+      const intakeResult = await runner.executeIngressMessage(
+        allowedIngress(telegramToken),
+        "/repo",
+        30_000,
+        telegramConfigureRoute()
+      );
+      const confirmResult = await runner.executeIngressMessage(
+        allowedIngress("/confirm-setup-write"),
+        "/repo",
+        30_000,
+        adapterRoute()
+      );
+
+      const configPath = path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json");
+      const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+      expect(intakeResult.output).toContain("/confirm-setup-write");
+      expect(confirmResult.success).toBe(true);
+      expect(runtimeControlApprovalFn).toHaveBeenCalledOnce();
+      expect(config.bot_token).toBe(telegramToken);
+      expect(config.allow_all).toBe(false);
       fs.rmSync(baseDir, { recursive: true, force: true });
     });
 

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import type { StateManager } from "../../base/state/state-manager.js";
 import { RuntimeReplyTargetSchema, type RuntimeReplyTarget } from "../../runtime/session-registry/types.js";
 import { redactSetupSecrets, SetupSecretIntakeItemSchema } from "./setup-secret-intake.js";
+import { SetupDialoguePublicStateSchema, type SetupDialoguePublicState } from "./setup-dialogue.js";
 
 // ─── Schemas ───
 
@@ -72,6 +73,7 @@ export const ChatSessionSchema = z.object({
   parentNotificationStatus: z.enum(["none", "pending", "sent", "failed"]).nullable().optional(),
   parentNotificationSummary: z.string().nullable().optional(),
   parentNotifiedAt: z.string().nullable().optional(),
+  setupDialogue: SetupDialoguePublicStateSchema.nullable().optional(),
   messages: z.array(ChatMessageSchema),
   compactionSummary: z.string().optional(),
   agentLoopStatePath: z.string().nullable().optional(),
@@ -220,6 +222,18 @@ export class ChatHistory {
       this.session.notificationReplyTarget = target;
     } else {
       delete this.session.notificationReplyTarget;
+    }
+  }
+
+  getSetupDialogue(): SetupDialoguePublicState | null {
+    return this.session.setupDialogue ?? null;
+  }
+
+  setSetupDialogue(dialogue: SetupDialoguePublicState | null): void {
+    if (dialogue) {
+      this.session.setupDialogue = dialogue;
+    } else {
+      delete this.session.setupDialogue;
     }
   }
 

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -21,6 +21,12 @@ import { resolveExecutionPolicy, type ExecutionPolicy } from "../../orchestrator
 import type { AssistantBuffer, ChatRunnerEventBridge } from "./chat-runner-event-bridge.js";
 import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
 import { createGatewaySetupStatusProvider, type TelegramSetupStatus } from "./gateway-setup-status.js";
+import {
+  createDiscordAdapterPlanDialogue,
+  createTelegramConfirmWriteDialogue,
+  SETUP_WRITE_CONFIRM_COMMAND,
+  type SetupDialogueRuntimeState,
+} from "./setup-dialogue.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
@@ -35,7 +41,7 @@ export interface ChatRunnerRouteHost {
   getNativeAgentLoopStatePath(): string | null;
   getProviderConfigBaseDir(): string;
   getSetupSecretIntake(): SetupSecretIntakeResult | null;
-  setPendingTelegramSetup(token: string): void;
+  setPendingSetupDialogue(dialogue: SetupDialogueRuntimeState): Promise<void>;
   getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
   setSessionExecutionPolicy(policy: ExecutionPolicy): void;
 }
@@ -637,11 +643,32 @@ async function formatConfigureGuidance(
     const suppliedTelegramToken = suppliedSecretKinds.includes("telegram_bot_token");
     const telegramSecret = setupSecretIntake?.suppliedSecrets.find((secret) => secret.kind === "telegram_bot_token");
     if (telegramSecret) {
-      host.setPendingTelegramSetup(telegramSecret.value);
+      await host.setPendingSetupDialogue(createTelegramConfirmWriteDialogue(telegramSecret));
     }
     return formatTelegramConfigureGuidance(status, suppliedTelegramToken, telegramSecret !== undefined);
   }
   if (target === "gateway") {
+    const discordSecret = setupSecretIntake?.suppliedSecrets.find((secret) => secret.kind === "discord_bot_token");
+    if (discordSecret) {
+      const dialogue = createDiscordAdapterPlanDialogue();
+      await host.setPendingSetupDialogue({ publicState: dialogue });
+      return [
+        "Discord gateway setup plan",
+        "",
+        "- Setup dialogue state: blocked.",
+        "- Selected channel: discord.",
+        "- A Discord bot token was supplied and redacted, but PulSeed needs application ID, home channel ID, identity key, webhook host/port, and access policy before a chat-assisted config write can be safe.",
+        "",
+        "Recommended command path:",
+        "```sh",
+        dialogue.action?.command ?? "pulseed gateway setup",
+        "pulseed daemon start",
+        "pulseed daemon status",
+        "```",
+        "",
+        "This uses the same typed setup dialogue contract as Telegram, but Discord remains an adapter-plan path until the missing non-secret fields can be collected safely.",
+      ].join("\n");
+    }
     return [
       "Gateway setup is a configuration flow.",
       "",
@@ -710,7 +737,7 @@ function formatTelegramConfigureGuidance(
     "",
     suppliedTelegramToken
       ? pendingActionCreated
-        ? "I received a Telegram bot token in this turn and kept it redacted from chat history and activity. Reply `/confirm-telegram-setup` to request an approval-gated config write."
+        ? `I received a Telegram bot token in this turn and kept it redacted from chat history and activity. Reply \`${SETUP_WRITE_CONFIRM_COMMAND}\` to request an approval-gated config write.`
         : "I received a Telegram bot token in this turn and kept it redacted from chat history and activity, but no setup action could be prepared."
       : "If you prefer chat-assisted setup, paste the token here; PulSeed will redact it from history and prepare an approval-gated confirmation before writing config."
   );

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -50,6 +50,10 @@ import {
 } from "./chat-runner-commands.js";
 import { ChatRunnerEventBridge, type AssistantBuffer } from "./chat-runner-event-bridge.js";
 import { intakeSetupSecrets } from "./setup-secret-intake.js";
+import {
+  isSetupWriteConfirmCommand,
+  type SetupDialogueRuntimeState,
+} from "./setup-dialogue.js";
 import type { TelegramGatewayConfig } from "../../runtime/gateway/telegram-gateway-adapter.js";
 import {
   buildRuntimeControlContextFromIngress,
@@ -168,7 +172,7 @@ export class ChatRunner {
   private sessionExecutionPolicy: ExecutionPolicy | null = null;
   private lastSelectedRoute: SelectedChatRoute | null = null;
   private setupSecretIntake: ReturnType<typeof intakeSetupSecrets> | null = null;
-  private pendingTelegramSetup: { token: string; createdAt: string } | null = null;
+  private pendingSetupDialogue: SetupDialogueRuntimeState | null = null;
 
   constructor(private readonly deps: ChatRunnerDeps) {
     this.groundingGateway = createChatGroundingGateway({
@@ -345,7 +349,7 @@ export class ChatRunner {
     const runtimeControlContext = options.runtimeControlContext ?? this.runtimeControlContext;
     const executionGoalId = options.goalId ?? this.deps.goalId;
 
-    const pendingTelegramSetupResult = await this.handlePendingTelegramSetupConfirmation(safeInput, runtimeControlContext);
+    const pendingTelegramSetupResult = await this.handlePendingSetupConfirmation(safeInput, runtimeControlContext);
     if (pendingTelegramSetupResult !== null) {
       return this.finalizeNonPersistentResult(pendingTelegramSetupResult, eventContext);
     }
@@ -703,8 +707,10 @@ export class ChatRunner {
       getNativeAgentLoopStatePath: () => this.nativeAgentLoopStatePath,
       getProviderConfigBaseDir: () => this.providerConfigBaseDir(),
       getSetupSecretIntake: () => this.setupSecretIntake,
-      setPendingTelegramSetup: (token: string) => {
-        this.pendingTelegramSetup = { token, createdAt: new Date().toISOString() };
+      setPendingSetupDialogue: async (dialogue: SetupDialogueRuntimeState) => {
+        this.pendingSetupDialogue = dialogue;
+        this.history?.setSetupDialogue(dialogue.publicState);
+        await this.history?.persist();
       },
       getSessionExecutionPolicy: () => this.getSessionExecutionPolicy(),
       setSessionExecutionPolicy: (policy: ExecutionPolicy) => { this.sessionExecutionPolicy = policy; },
@@ -716,16 +722,30 @@ export class ChatRunner {
     return typeof stateManager.getBaseDir === "function" ? stateManager.getBaseDir() : getPulseedDirPath();
   }
 
-  private async handlePendingTelegramSetupConfirmation(
+  private async handlePendingSetupConfirmation(
     input: string,
     runtimeControlContext: RuntimeControlChatContext | null
   ): Promise<ChatRunResult | null> {
-    if (input.trim() !== "/confirm-telegram-setup") return null;
-    const pending = this.pendingTelegramSetup;
+    if (!isSetupWriteConfirmCommand(input)) return null;
+    const pending = this.pendingSetupDialogue;
     if (!pending) {
       return {
         success: false,
-        output: "No pending Telegram setup token is available. Paste the token again to start a protected setup turn.",
+        output: "No pending setup write is available. Paste the secret again to start a protected setup turn.",
+        elapsed_ms: 0,
+      };
+    }
+    if (pending.publicState.selectedChannel !== "telegram" || pending.publicState.action?.kind !== "write_gateway_config") {
+      return {
+        success: false,
+        output: `The pending setup dialogue is for ${pending.publicState.selectedChannel}, so it cannot be confirmed as a Telegram config write. Start a new Telegram setup turn with a Telegram bot token.`,
+        elapsed_ms: 0,
+      };
+    }
+    if (!pending.secretValue) {
+      return {
+        success: false,
+        output: "The pending setup dialogue no longer has a transient secret value. Paste the token again so PulSeed can keep it protected through a fresh confirmation.",
         elapsed_ms: 0,
       };
     }
@@ -756,7 +776,9 @@ export class ChatRunner {
         : "Existing Telegram access policy will be preserved.",
     ].join(" "));
     if (!approved) {
-      this.pendingTelegramSetup = null;
+      this.pendingSetupDialogue = null;
+      this.history?.setSetupDialogue(null);
+      await this.history?.persist();
       return {
         success: false,
         output: "Telegram setup was not changed because approval was denied.",
@@ -764,7 +786,7 @@ export class ChatRunner {
       };
     }
     const nextConfig: TelegramGatewayConfig = {
-      bot_token: pending.token,
+      bot_token: pending.secretValue,
       ...(typeof current?.chat_id === "number" ? { chat_id: current.chat_id } : {}),
       allowed_user_ids: nextAllowedUserIds,
       denied_user_ids: Array.isArray(current?.denied_user_ids) ? current.denied_user_ids : [],
@@ -779,7 +801,18 @@ export class ChatRunner {
       ...(current?.identity_key ? { identity_key: current.identity_key } : {}),
     };
     await writeJsonFileAtomic(configPath, nextConfig);
-    this.pendingTelegramSetup = null;
+    this.pendingSetupDialogue = {
+      publicState: {
+        ...pending.publicState,
+        state: "restart_offer",
+        updatedAt: new Date().toISOString(),
+        action: pending.publicState.action
+          ? { ...pending.publicState.action, status: "completed" }
+          : pending.publicState.action,
+      },
+    };
+    this.history?.setSetupDialogue(this.pendingSetupDialogue.publicState);
+    await this.history?.persist();
     return {
       success: true,
       output: [

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -134,6 +134,19 @@ function selectRouteForText(
       ...baseTurnPolicy,
     };
   }
+  if (setupSecretKinds.has("discord_bot_token")) {
+    return {
+      kind: "configure",
+      reason: "freeform_semantic_route",
+      intent: {
+        kind: "configure",
+        confidence: 1,
+        configure_target: "gateway",
+        rationale: "typed setup secret intake detected a Discord bot token",
+      },
+      ...baseTurnPolicy,
+    };
+  }
 
   const freeformIntent = deps.freeformRouteIntent ?? null;
   if (freeformIntent && freeformIntent.confidence >= 0.7) {

--- a/src/interface/chat/setup-dialogue.ts
+++ b/src/interface/chat/setup-dialogue.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+import { randomUUID } from "node:crypto";
+import type { SetupSecretIntakeItem } from "./setup-secret-intake.js";
+
+export const SetupDialogueStateSchema = z.enum([
+  "diagnose",
+  "offer",
+  "awaiting_secret",
+  "confirm_write",
+  "writing",
+  "restart_offer",
+  "verify",
+  "done",
+  "blocked",
+]);
+export type SetupDialogueState = z.infer<typeof SetupDialogueStateSchema>;
+
+export const SetupDialogueChannelSchema = z.enum([
+  "telegram",
+  "discord",
+  "gateway",
+  "provider",
+]);
+export type SetupDialogueChannel = z.infer<typeof SetupDialogueChannelSchema>;
+
+export const SetupDialogueActionSchema = z.object({
+  kind: z.enum(["write_gateway_config", "adapter_plan"]),
+  channel: SetupDialogueChannelSchema,
+  command: z.string(),
+  requiresApproval: z.boolean(),
+  secretKinds: z.array(z.string()),
+  status: z.enum(["pending", "completed", "blocked"]).default("pending"),
+}).passthrough();
+export type SetupDialogueAction = z.infer<typeof SetupDialogueActionSchema>;
+
+export const SetupDialogueSecretRefSchema = z.object({
+  id: z.string(),
+  kind: z.string(),
+  redaction: z.string(),
+  suppliedAt: z.string(),
+});
+export type SetupDialogueSecretRef = z.infer<typeof SetupDialogueSecretRefSchema>;
+
+export const SetupDialoguePublicStateSchema = z.object({
+  id: z.string(),
+  state: SetupDialogueStateSchema,
+  selectedChannel: SetupDialogueChannelSchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  action: SetupDialogueActionSchema.optional(),
+  pendingSecret: SetupDialogueSecretRefSchema.optional(),
+  note: z.string().optional(),
+}).passthrough();
+export type SetupDialoguePublicState = z.infer<typeof SetupDialoguePublicStateSchema>;
+
+export interface SetupDialogueRuntimeState {
+  publicState: SetupDialoguePublicState;
+  secretValue?: string;
+}
+
+export const SETUP_WRITE_CONFIRM_COMMAND = "/confirm-setup-write";
+export const LEGACY_TELEGRAM_CONFIRM_COMMAND = "/confirm-telegram-setup";
+
+export function createTelegramConfirmWriteDialogue(
+  secret: SetupSecretIntakeItem,
+  now = new Date().toISOString()
+): SetupDialogueRuntimeState {
+  return {
+    publicState: {
+      id: randomUUID(),
+      state: "confirm_write",
+      selectedChannel: "telegram",
+      createdAt: now,
+      updatedAt: now,
+      pendingSecret: {
+        id: secret.id,
+        kind: secret.kind,
+        redaction: secret.redaction,
+        suppliedAt: secret.suppliedAt,
+      },
+      action: {
+        kind: "write_gateway_config",
+        channel: "telegram",
+        command: SETUP_WRITE_CONFIRM_COMMAND,
+        requiresApproval: true,
+        secretKinds: [secret.kind],
+        status: "pending",
+      },
+    },
+    secretValue: secret.value,
+  };
+}
+
+export function createDiscordAdapterPlanDialogue(now = new Date().toISOString()): SetupDialoguePublicState {
+  return {
+    id: randomUUID(),
+    state: "blocked",
+    selectedChannel: "discord",
+    createdAt: now,
+    updatedAt: now,
+    note: "Discord setup needs application_id, bot_token, channel_id, identity_key, host, port, and access policy before a chat-assisted write can be safely offered.",
+    action: {
+      kind: "adapter_plan",
+      channel: "discord",
+      command: "pulseed gateway setup",
+      requiresApproval: false,
+      secretKinds: ["discord_bot_token"],
+      status: "blocked",
+    },
+  };
+}
+
+export function isSetupWriteConfirmCommand(input: string): boolean {
+  const trimmed = input.trim();
+  return trimmed === SETUP_WRITE_CONFIRM_COMMAND || trimmed === LEGACY_TELEGRAM_CONFIRM_COMMAND;
+}


### PR DESCRIPTION
Closes #965

## Summary
- add a typed setup dialogue/action contract for setup states, selected channel, pending secret refs, and setup actions
- persist safe setup dialogue metadata in chat sessions without raw secret values
- replace Telegram-only pending token handling with generic `/confirm-setup-write` confirmation, while keeping the legacy command accepted as protocol compatibility
- add a Discord adapter-plan path using the same setup dialogue contract without performing unsafe partial Discord writes
- add two-turn, stale pending-state rejection, and gateway ingress coverage

## Verification
- `npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/ingress-router.test.ts`
- `npm run typecheck`
- `npm run test:changed`
- `npm run lint:boundaries` (passes with existing warnings)
- fresh review agent: no material findings

## Known unresolved risks
- Discord remains an adapter-plan path only; chat-assisted Discord config writes need a later flow for non-secret fields and access policy before they are safe to enable.
