### PR TITLE
feat(chat): add turn language hints

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -418,11 +418,11 @@ describe("ChatRunner", () => {
 
       const result = await runner.execute("telegram繋げたい", "/repo");
 
-      expect(result.output).toContain("Daemon: running on port 41700; gateway load state is not proven");
-      expect(result.output).toContain("Telegram: not configured");
+      expect(result.output).toContain("Daemon: port 41700 で起動中です");
+      expect(result.output).toContain("Telegram: まだ設定されていません");
       expect(result.output).toContain("pulseed telegram setup");
       expect(result.output).toContain("pulseed gateway setup");
-      expect(result.output).toContain("If you prefer chat-assisted setup");
+      expect(result.output).toContain("chat-assisted setup を使う場合");
     });
 
     it("reports configured Telegram state and only points to verification when home chat exists", async () => {
@@ -446,11 +446,11 @@ describe("ChatRunner", () => {
 
       const result = await runner.execute("telegram繋げたい", "/repo");
 
-      expect(result.output).toContain("Telegram config: configured");
-      expect(result.output).toContain("Home chat: configured");
-      expect(result.output).toContain("Gateway loaded in daemon: unknown");
+      expect(result.output).toContain("Telegram config: 設定済みです");
+      expect(result.output).toContain("Home chat: 設定済みです");
+      expect(result.output).toContain("Gateway loaded in daemon: chat status からは未確認です");
       expect(result.output).toContain("Verification:");
-      expect(result.output).not.toContain("Send `/sethome`");
+      expect(result.output).not.toContain("`/sethome` を送ってください");
     });
 
     it("reports partially configured Telegram state and directs /sethome through the production configure route", async () => {
@@ -474,10 +474,10 @@ describe("ChatRunner", () => {
 
       const result = await runner.execute("telegram繋げたい", "/repo");
 
-      expect(result.output).toContain("Daemon: not responding on port 41700");
-      expect(result.output).toContain("bot token is configured, but no home chat is set");
-      expect(result.output).toContain("Send `/sethome`");
-      expect(result.output).toContain("The config will not take effect until the daemon is started or restarted");
+      expect(result.output).toContain("Daemon: port 41700 で応答していません");
+      expect(result.output).toContain("bot token は設定済みですが、home chat が未設定です");
+      expect(result.output).toContain("`/sethome` を送ってください");
+      expect(result.output).toContain("config は daemon を起動または再起動するまで反映されません");
     });
 
     it("keeps supplied setup secret facts available to the configure route without persisting raw assistant echoes", async () => {
@@ -3905,7 +3905,7 @@ describe("ChatRunner", () => {
       expect(result.output).toBe("Confirmed with tools");
     });
 
-    it("routes Japanese Telegram setup requests to guidance before agent-loop execution", async () => {
+    it("routes Japanese Telegram setup requests to Japanese guidance before agent-loop execution", async () => {
       const events: ChatEvent[] = [];
       const chatAgentLoopRunner = {
         execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
@@ -3924,21 +3924,22 @@ describe("ChatRunner", () => {
         onEvent: (event) => { events.push(event); },
       }));
 
-      const result = await runner.execute("telegramからseedyと会話できるようにしたい", "/repo");
+      const result = await runner.execute("telegram繋げたい", "/repo");
 
       expect(result.success).toBe(true);
       expect(result.output).toContain("Telegram gateway status");
-      expect(result.output).toContain("Telegram: not configured");
+      expect(result.output).toContain("Telegram: まだ設定されていません");
       expect(result.output).toContain("pulseed telegram setup");
       expect(result.output).toContain("pulseed gateway setup");
       expect(result.output).toContain("pulseed daemon start");
       expect(result.output).toContain("pulseed daemon status");
-      expect(result.output).toContain("If you prefer chat-assisted setup");
+      expect(result.output).toContain("chat-assisted setup を使う場合");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
       const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
         event.type === "activity" && event.sourceId === "intent:first-step"
       );
-      expect(intent?.message).toContain("prepare configuration guidance");
+      expect(intent?.message).toContain("設定ガイダンスを準備");
+      expect(intent?.languageHint).toMatchObject({ language: "ja" });
       expect(intent?.message).not.toContain("resume the saved agent loop state");
     });
 

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -425,7 +425,7 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(result.output).toContain("pulseed daemon start");
     expect(result.output).toContain("pulseed daemon status");
     expect(result.output).toContain("Telegram gateway status");
-    expect(result.output).toContain("Telegram: not configured");
+    expect(result.output).toContain("Telegram: まだ設定されていません");
     expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     expect(adapter.execute).not.toHaveBeenCalled();
   });

--- a/src/interface/chat/__tests__/turn-language.test.ts
+++ b/src/interface/chat/__tests__/turn-language.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { detectTurnLanguageHint, sameLanguageResponseInstruction } from "../turn-language.js";
+
+describe("turn language hint", () => {
+  it("detects Japanese from script without semantic phrase matching", () => {
+    const hint = detectTurnLanguageHint("telegram繋げたい");
+
+    expect(hint).toMatchObject({ language: "ja", source: "input_script" });
+    expect(hint.confidence).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it("detects English from Latin script", () => {
+    const hint = detectTurnLanguageHint("I want to talk to Seedy from Telegram.");
+
+    expect(hint).toMatchObject({ language: "en", source: "input_script" });
+    expect(hint.confidence).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it("keeps protocol tokens untranslated in the response instruction", () => {
+    expect(sameLanguageResponseInstruction({ language: "ja", confidence: 0.9, source: "input_script" }))
+      .toContain("Do not translate command names");
+  });
+});

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -1,10 +1,12 @@
 import type { FailureRecoveryGuidance } from "./failure-recovery.js";
 import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
+import type { TurnLanguageHint } from "./turn-language.js";
 
 export interface ChatEventBase {
   runId: string;
   turnId: string;
   createdAt: string;
+  languageHint?: TurnLanguageHint;
 }
 
 export interface LifecycleStartEvent extends ChatEventBase {
@@ -104,4 +106,5 @@ export type ChatEventHandler = (event: ChatEvent) => Promise<void> | void;
 export interface ChatEventContext {
   runId: string;
   turnId: string;
+  languageHint?: TurnLanguageHint;
 }

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -24,6 +24,7 @@ import {
 } from "./failure-recovery.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { redactSetupSecrets, redactSetupSecretsDeep } from "./setup-secret-intake.js";
+import { shouldRenderJapanese } from "./turn-language.js";
 
 export interface AssistantBuffer {
   text: string;
@@ -355,8 +356,13 @@ export class ChatRunnerEventBridge {
       nextStep = `prepare the ${selectedRoute.intent.kind} runtime-control request.`;
       reason = "runtime changes need an explicit operation plan and approval path.";
     } else if (selectedRoute?.kind === "configure") {
-      nextStep = "prepare configuration guidance for the requested setup flow.";
-      reason = "setup requests should return actionable configuration steps before any agent-loop execution.";
+      if (shouldRenderJapanese(eventContext.languageHint)) {
+        nextStep = "requested setup flow の設定ガイダンスを準備します。";
+        reason = "setup request は agent-loop 実行前に実行可能な設定手順を返す必要があります。";
+      } else {
+        nextStep = "prepare configuration guidance for the requested setup flow.";
+        reason = "setup requests should return actionable configuration steps before any agent-loop execution.";
+      }
     } else if (selectedRoute?.kind === "assist") {
       nextStep = "answer directly from the current conversation context.";
       reason = "this request can be handled as assistance without resuming an agent loop.";
@@ -374,9 +380,15 @@ export class ChatRunnerEventBridge {
       reason = "the adapter needs the current workspace context to act correctly.";
     }
     const message = [
-      `I understand the request as ${subject || "the current request"}.`,
-      `Next I will ${nextStep}`,
-      `This is needed because ${reason}`,
+      shouldRenderJapanese(eventContext.languageHint)
+        ? `このリクエストは ${subject || "現在のリクエスト"} として扱います。`
+        : `I understand the request as ${subject || "the current request"}.`,
+      shouldRenderJapanese(eventContext.languageHint)
+        ? `次に ${nextStep}`
+        : `Next I will ${nextStep}`,
+      shouldRenderJapanese(eventContext.languageHint)
+        ? `理由: ${reason}`
+        : `This is needed because ${reason}`,
     ].join("\n");
     this.emitActivity("commentary", message, eventContext, "intent:first-step", false);
   }

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -27,6 +27,11 @@ import {
   SETUP_WRITE_CONFIRM_COMMAND,
   type SetupDialogueRuntimeState,
 } from "./setup-dialogue.js";
+import {
+  sameLanguageResponseInstruction,
+  shouldRenderJapanese,
+  type TurnLanguageHint,
+} from "./turn-language.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
@@ -41,6 +46,7 @@ export interface ChatRunnerRouteHost {
   getNativeAgentLoopStatePath(): string | null;
   getProviderConfigBaseDir(): string;
   getSetupSecretIntake(): SetupSecretIntakeResult | null;
+  getTurnLanguageHint(): TurnLanguageHint;
   setPendingSetupDialogue(dialogue: SetupDialogueRuntimeState): Promise<void>;
   getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
   setSessionExecutionPolicy(policy: ExecutionPolicy): void;
@@ -97,7 +103,7 @@ export async function executeConfigureRoute(
   if (route.kind !== "configure") {
     throw new Error(`executeConfigureRoute received route kind ${route.kind}`);
   }
-  const output = await formatConfigureGuidance(host, route.intent.configure_target ?? "unknown", host.getSetupSecretIntake());
+  const output = await formatConfigureGuidance(host, route.intent.configure_target ?? "unknown", host.getSetupSecretIntake(), host.getTurnLanguageHint());
   return persistDirectRouteResult(host, output, eventContext, assistantBuffer, history, start);
 }
 
@@ -144,7 +150,10 @@ export async function executeAssistRoute(
     { role: "user", content: params.input },
   ];
   const response = await sendLLMMessage(host, host.deps.llmClient, messages, {
-    system: "Answer read-only. Provide concise operational guidance. Do not ask to edit files or run commands unless the user explicitly asks for execution.",
+    system: [
+      "Answer read-only. Provide concise operational guidance. Do not ask to edit files or run commands unless the user explicitly asks for execution.",
+      sameLanguageResponseInstruction(host.getTurnLanguageHint()),
+    ].join(" "),
     max_tokens: 1000,
     temperature: 0,
   }, params.assistantBuffer, params.eventContext);
@@ -635,6 +644,7 @@ async function formatConfigureGuidance(
   host: ChatRunnerRouteHost,
   target: "telegram_gateway" | "gateway" | "provider" | "daemon" | "notification" | "slack" | "unknown",
   setupSecretIntake: SetupSecretIntakeResult | null = null,
+  languageHint: TurnLanguageHint,
 ): Promise<string> {
   const suppliedSecretKinds = setupSecretIntake?.suppliedSecrets.map((secret) => secret.kind) ?? [];
   if (target === "telegram_gateway") {
@@ -645,13 +655,31 @@ async function formatConfigureGuidance(
     if (telegramSecret) {
       await host.setPendingSetupDialogue(createTelegramConfirmWriteDialogue(telegramSecret));
     }
-    return formatTelegramConfigureGuidance(status, suppliedTelegramToken, telegramSecret !== undefined);
+    return formatTelegramConfigureGuidance(status, suppliedTelegramToken, telegramSecret !== undefined, languageHint);
   }
   if (target === "gateway") {
     const discordSecret = setupSecretIntake?.suppliedSecrets.find((secret) => secret.kind === "discord_bot_token");
     if (discordSecret) {
       const dialogue = createDiscordAdapterPlanDialogue();
       await host.setPendingSetupDialogue({ publicState: dialogue });
+      if (shouldRenderJapanese(languageHint)) {
+        return [
+          "Discord gateway setup plan",
+          "",
+          "- Setup dialogue state: blocked.",
+          "- Selected channel: discord.",
+          "- Discord bot token は受け取り redacted しましたが、chat-assisted config write を安全に準備するには application ID、home channel ID、identity key、webhook host/port、access policy が必要です。",
+          "",
+          "Recommended command path:",
+          "```sh",
+          dialogue.action?.command ?? "pulseed gateway setup",
+          "pulseed daemon start",
+          "pulseed daemon status",
+          "```",
+          "",
+          "Telegram と同じ typed setup dialogue contract を使っていますが、Discord は不足している non-secret field を安全に集められるまで adapter-plan path のままです。",
+        ].join("\n");
+      }
       return [
         "Discord gateway setup plan",
         "",
@@ -669,10 +697,24 @@ async function formatConfigureGuidance(
         "This uses the same typed setup dialogue contract as Telegram, but Discord remains an adapter-plan path until the missing non-secret fields can be collected safely.",
       ].join("\n");
     }
+    if (shouldRenderJapanese(languageHint)) {
+      return [
+        "Gateway setup は configuration flow です。",
+        "",
+        "`pulseed gateway setup` を実行し、その後 `pulseed daemon start` で daemon を起動または再起動してください。",
+      ].join("\n");
+    }
     return [
       "Gateway setup is a configuration flow.",
       "",
       "Run `pulseed gateway setup`, then start or restart the daemon with `pulseed daemon start`.",
+    ].join("\n");
+  }
+  if (shouldRenderJapanese(languageHint)) {
+    return [
+      "これは code-edit task ではなく、setup/configuration のリクエストに見えます。",
+      "",
+      "main wizard には `pulseed setup`、chat channel には `pulseed gateway setup`、利用可能な場合は channel-specific setup command を使ってください。",
     ].join("\n");
   }
   return [
@@ -685,8 +727,12 @@ async function formatConfigureGuidance(
 function formatTelegramConfigureGuidance(
   status: TelegramSetupStatus,
   suppliedTelegramToken: boolean,
-  pendingActionCreated: boolean
+  pendingActionCreated: boolean,
+  languageHint: TurnLanguageHint
 ): string {
+  if (shouldRenderJapanese(languageHint)) {
+    return formatTelegramConfigureGuidanceJa(status, suppliedTelegramToken, pendingActionCreated);
+  }
   const lines = [
     "Telegram gateway status",
     "",
@@ -751,6 +797,81 @@ function formatTelegramConfigureGuidance(
     lines.push(
       "",
       "If Telegram was configured or changed after this daemon started, restart the daemon so the gateway loads the latest config."
+    );
+  }
+
+  return lines.join("\n");
+}
+
+function formatTelegramConfigureGuidanceJa(
+  status: TelegramSetupStatus,
+  suppliedTelegramToken: boolean,
+  pendingActionCreated: boolean
+): string {
+  const lines = [
+    "Telegram gateway status",
+    "",
+    status.daemon.running
+      ? `- Daemon: port ${status.daemon.port} で起動中です。chat status だけでは gateway の load state までは確定できません。`
+      : `- Daemon: port ${status.daemon.port} で応答していません。`,
+  ];
+
+  if (status.state === "unconfigured") {
+    lines.push(
+      "- Telegram: まだ設定されていません。",
+      "",
+      "Recommended command path:",
+      "```sh",
+      "pulseed telegram setup",
+      "pulseed gateway setup",
+      "pulseed daemon start",
+      "pulseed daemon status",
+      "```",
+      "",
+      "@BotFather で bot を作成または開き、`pulseed telegram setup` で token を入力してください。"
+    );
+  } else if (status.state === "partially_configured") {
+    lines.push(
+      "- Telegram config: bot token は設定済みですが、home chat が未設定です。",
+      "- Gateway loaded in daemon: chat status からは未確認です。",
+      "",
+      "Next step:",
+      "- PulSeed の返信先にしたい Telegram chat から bot に `/sethome` を送ってください。",
+      "- その後 `pulseed daemon status` で gateway を確認してください。"
+    );
+  } else {
+    lines.push(
+      "- Telegram config: 設定済みです。",
+      status.config.hasHomeChat
+        ? "- Home chat: 設定済みです。"
+        : "- Home chat: 未設定です。この bot が特定 chat に返信する必要がある場合は `/sethome` を送ってください。",
+      "- Gateway loaded in daemon: chat status からは未確認です。",
+      "",
+      "Verification:",
+      "- Telegram bot にメッセージを送ってください。",
+      "- 配信されない場合は `pulseed daemon status` を実行してください。",
+      "- daemon 起動後に config を追加または変更した場合は、daemon を再起動して gateway に最新 config を読み込ませてください。"
+    );
+  }
+
+  lines.push(
+    "",
+    suppliedTelegramToken
+      ? pendingActionCreated
+        ? `この turn で Telegram bot token を受け取り、chat history と activity には redacted のまま保持しました。approval-gated config write を依頼するには \`${SETUP_WRITE_CONFIRM_COMMAND}\` と返信してください。`
+        : "この turn で Telegram bot token を受け取り、chat history と activity には redacted のまま保持しましたが、setup action は準備できませんでした。"
+      : "chat-assisted setup を使う場合は、ここに token を貼ってください。PulSeed は history から redaction し、config 書き込み前に approval-gated confirmation を準備します。"
+  );
+
+  if (!status.daemon.running && status.state !== "unconfigured") {
+    lines.push(
+      "",
+      "config は daemon を起動または再起動するまで反映されません。"
+    );
+  } else if (status.daemon.running && status.state !== "unconfigured") {
+    lines.push(
+      "",
+      "Telegram config を daemon 起動後に追加または変更した場合は、daemon を再起動して最新 config を読み込ませてください。"
     );
   }
 

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -54,6 +54,12 @@ import {
   isSetupWriteConfirmCommand,
   type SetupDialogueRuntimeState,
 } from "./setup-dialogue.js";
+import {
+  detectTurnLanguageHint,
+  sameLanguageResponseInstruction,
+  UNKNOWN_TURN_LANGUAGE_HINT,
+  type TurnLanguageHint,
+} from "./turn-language.js";
 import type { TelegramGatewayConfig } from "../../runtime/gateway/telegram-gateway-adapter.js";
 import {
   buildRuntimeControlContextFromIngress,
@@ -172,6 +178,7 @@ export class ChatRunner {
   private sessionExecutionPolicy: ExecutionPolicy | null = null;
   private lastSelectedRoute: SelectedChatRoute | null = null;
   private setupSecretIntake: ReturnType<typeof intakeSetupSecrets> | null = null;
+  private turnLanguageHint: TurnLanguageHint = UNKNOWN_TURN_LANGUAGE_HINT;
   private pendingSetupDialogue: SetupDialogueRuntimeState | null = null;
 
   constructor(private readonly deps: ChatRunnerDeps) {
@@ -345,6 +352,8 @@ export class ChatRunner {
     const setupSecretIntake = intakeSetupSecrets(input);
     this.setupSecretIntake = setupSecretIntake;
     const safeInput = setupSecretIntake.redactedText;
+    this.turnLanguageHint = detectTurnLanguageHint(safeInput);
+    eventContext.languageHint = this.turnLanguageHint;
     const persistedSecretIntake = setupSecretIntake.suppliedSecrets.map(({ value: _value, ...metadata }) => metadata);
     const runtimeControlContext = options.runtimeControlContext ?? this.runtimeControlContext;
     const executionGoalId = options.goalId ?? this.deps.goalId;
@@ -561,6 +570,7 @@ export class ChatRunner {
     }
     const agentLoopSystemPrompt = [
       systemPrompt,
+      sameLanguageResponseInstruction(this.turnLanguageHint),
       compactionSummary ? `## Compacted Chat Summary\n${compactionSummary}` : "",
     ]
       .filter((section) => section && section.trim().length > 0)
@@ -707,6 +717,7 @@ export class ChatRunner {
       getNativeAgentLoopStatePath: () => this.nativeAgentLoopStatePath,
       getProviderConfigBaseDir: () => this.providerConfigBaseDir(),
       getSetupSecretIntake: () => this.setupSecretIntake,
+      getTurnLanguageHint: () => this.turnLanguageHint,
       setPendingSetupDialogue: async (dialogue: SetupDialogueRuntimeState) => {
         this.pendingSetupDialogue = dialogue;
         this.history?.setSetupDialogue(dialogue.publicState);

--- a/src/interface/chat/turn-language.ts
+++ b/src/interface/chat/turn-language.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+export const TurnLanguageHintSchema = z.object({
+  language: z.enum(["en", "ja", "unknown"]),
+  confidence: z.number().min(0).max(1),
+  source: z.enum(["input_script", "caller", "unknown"]),
+});
+
+export type TurnLanguageHint = z.infer<typeof TurnLanguageHintSchema>;
+
+export const UNKNOWN_TURN_LANGUAGE_HINT: TurnLanguageHint = {
+  language: "unknown",
+  confidence: 0,
+  source: "unknown",
+};
+
+export function detectTurnLanguageHint(input: string): TurnLanguageHint {
+  const letters = Array.from(input).filter((char) => /\p{Letter}/u.test(char));
+  if (letters.length === 0) return UNKNOWN_TURN_LANGUAGE_HINT;
+
+  const japanese = letters.filter((char) => /[\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}]/u.test(char)).length;
+  const latin = letters.filter((char) => /\p{Script=Latin}/u.test(char)).length;
+  const total = letters.length;
+
+  if (japanese > 0 && japanese / total >= 0.25) {
+    return { language: "ja", confidence: Math.min(0.99, Math.max(0.75, japanese / total)), source: "input_script" };
+  }
+  if (latin > 0 && latin / total >= 0.6) {
+    return { language: "en", confidence: Math.min(0.95, Math.max(0.7, latin / total)), source: "input_script" };
+  }
+  return UNKNOWN_TURN_LANGUAGE_HINT;
+}
+
+export function shouldRenderJapanese(hint: TurnLanguageHint | null | undefined): boolean {
+  return hint?.language === "ja" && hint.confidence >= 0.5;
+}
+
+export function sameLanguageResponseInstruction(hint: TurnLanguageHint | null | undefined): string {
+  const base = "Reply in the same language as the user's current input. Do not translate command names, slash commands, file paths, config keys, environment variables, protocol tokens, or code.";
+  if (hint?.language === "ja") {
+    return `${base} The current turn language hint is Japanese, so user-facing prose should be Japanese.`;
+  }
+  if (hint?.language === "en") {
+    return `${base} The current turn language hint is English, so user-facing prose should be English.`;
+  }
+  return base;
+}

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -882,7 +882,7 @@ describe("standalone slash command routing", () => {
     expect(chatRunnerOutput).toContain("pulseed gateway setup");
     await vi.waitFor(() => {
       const visibleText = testState.lastChatMessages.map((message) => message.text).join("\n");
-      expect(visibleText).toContain("prepare configuration guidance");
+      expect(visibleText).toContain("設定ガイダンスを準備");
       expect(visibleText).toContain("pulseed telegram setup");
       expect(visibleText).not.toContain("resume the saved agent loop state");
     });

--- a/tmp/autonomous-chat-setup-ux-status.md
+++ b/tmp/autonomous-chat-setup-ux-status.md
@@ -1,0 +1,27 @@
+# Autonomous chat/setup UX status
+
+Updated: 2026-05-03
+
+## Initial refresh
+- Ran `git switch main && git pull --ff-only`: main was already up to date.
+- Ran `gh issue list --state open --limit 100`: #976, #975, #974 are open. New adjacent issues #970-#967 and #957/#956 exist, but current batch remains #976 -> #975 -> #974 unless they become blockers.
+
+## #976 language hint
+- Status: in progress.
+- Issue body read with `gh issue view 976`.
+- Plan: add a typed turn-level language hint at chat ingress, pass it through configure/direct route formatting, add same-language prompt guidance, and test Japanese/English direct configure through the production ChatRunner path without adding keyword/regex semantic routing.
+- Implemented typed `TurnLanguageHint` and routed it through ChatRunner direct configure/assist paths.
+- Added Japanese Telegram configure copy while preserving protocol tokens and commands.
+- Verification: `npx vitest run src/interface/chat/__tests__/turn-language.test.ts src/interface/chat/__tests__/chat-runner.test.ts -t "turn language hint|routes Japanese Telegram setup requests|routes English Telegram setup paraphrases"` passed.
+- Verification: `npm run typecheck` passed.
+- Verification: `npm run lint:boundaries` passed with existing warnings only (0 errors, 610 warnings).
+- Review agent reported two material #976 gaps: non-Telegram configure fallback copy ignored language hint, and activity events did not carry language hints.
+- Fixed both: direct configure fallbacks now render Japanese when hinted, and chat events carry `languageHint`; configure intent activity is localized for Japanese.
+- Re-verification: focused Vitest passed.
+- Re-verification: `npm run typecheck` passed.
+- Re-verification: `npm run test:changed` passed (21 files, 460 tests; 2 skipped).
+- Re-verification: `npm run lint:boundaries` passed with existing warnings only (0 errors, 610 warnings).
+- Re-review after fixes: no material findings.
+- PR #977 CI: `unit (22)` passed; `integration (24)` failed because `src/interface/tui/__tests__/app.test.ts` still expected the old English intent activity text.
+- Fixed the integration expectation to the localized Japanese activity text and verified `npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/app.test.ts -t "routes Telegram setup freeform input"` passed.
+- Re-verification after CI fix: `npm run typecheck` passed.


### PR DESCRIPTION
Closes #976

## Summary
- add a typed turn-level language hint for chat turns
- pass language hints through direct configure guidance, assist prompts, agent-loop prompts, and chat activity events
- render Telegram setup guidance and configure fallback copy in Japanese for Japanese input while preserving commands and protocol tokens

## Verification
- `npx vitest run src/interface/chat/__tests__/turn-language.test.ts src/interface/chat/__tests__/chat-runner.test.ts -t "turn language hint|routes Japanese Telegram setup requests|routes English Telegram setup paraphrases"`
- `npm run typecheck`
- `npm run test:changed`
- `npm run lint:boundaries` (0 errors; existing warnings only)

## Known unresolved risks
- Language detection is a turn-level script hint, not a full locale model; ambiguous or mixed-script text falls back to unknown/English-style copy until a richer locale source is added.
- Broader non-setup routes can consume the hint, but only direct configure/assist/agent-loop prompt surfaces are updated in this slice.