### PR TITLE
feat(chat): add shared operation progress

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -37,6 +37,59 @@ describe("applyChatEventToMessages", () => {
     });
   });
 
+  it("renders operation progress separately from the final assistant answer", () => {
+    const progress = applyChatEventToMessages([], {
+      type: "operation_progress",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      item: {
+        id: "telegram-configure:read-config",
+        kind: "read_config",
+        operation: "telegram_setup",
+        title: "Read Telegram config",
+        detail: "Bot token is configured, but no home chat is set.",
+        createdAt: "2026-04-08T00:00:00.000Z",
+      },
+    }, 20);
+
+    const final = applyChatEventToMessages(progress, {
+      type: "assistant_final",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:01.000Z",
+      text: "Final setup guidance.",
+      persisted: true,
+    }, 20);
+
+    expect(final.map((message) => message.text)).toEqual([
+      "Read Telegram config: Bot token is configured, but no home chat is set.",
+      "Final setup guidance.",
+    ]);
+  });
+
+  it("redacts setup secrets from rendered operation progress", () => {
+    const token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+    const messages = applyChatEventToMessages([], {
+      type: "operation_progress",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      item: {
+        id: "secret-progress",
+        kind: "awaiting_approval",
+        operation: "telegram_setup",
+        title: "Prepared config write",
+        detail: `Token ${token} is ready.`,
+        createdAt: "2026-04-08T00:00:00.000Z",
+        metadata: { token },
+      },
+    }, 20);
+
+    expect(JSON.stringify(messages)).not.toContain(token);
+    expect(messages[0]!.text).toContain("[REDACTED:telegram_bot_token");
+  });
+
   it("shows raw tool events without current/recent activity headings", () => {
     const messages = applyChatEventToMessages([], {
       type: "tool_start",
@@ -282,6 +335,7 @@ describe("applyChatEventToMessages", () => {
       [] as ReturnType<typeof applyChatEventToMessages>
     );
     const timelineMessages = messages.filter((message) => message.id.startsWith("agent-timeline:turn-1:"));
+    const operationProgressMessages = messages.filter((message) => message.id.startsWith("operation-progress:turn-1:"));
 
     expect(timelineMessages.map((message) => message.text)).toEqual([
       "I will inspect the entrypoint first.",
@@ -293,6 +347,9 @@ describe("applyChatEventToMessages", () => {
       "Stopped: completed",
     ]);
     expect(timelineMessages.filter((message) => message.text === "searched 1 search")).toHaveLength(1);
+    expect(operationProgressMessages.map((message) => message.text)).toEqual([
+      "Agent-loop activity summarized: searched 1 search",
+    ]);
   });
 
   it("renders shared timeline tool and approval rows chronologically without a latest-five cap", () => {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -484,8 +484,10 @@ describe("ChatRunner", () => {
       const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
       const echoedToken = "sk-proj_echoedsecretabcdefghijklmnopqrstuvwxyz";
       const stateManager = makeMockStateManager();
+      const events: ChatEvent[] = [];
       const runner = new ChatRunner(makeDeps({
         stateManager,
+        onEvent: (event) => { events.push(event); },
         adapter: makeMockAdapter({
           ...CANNED_RESULT,
           output: `adapter echoed ${echoedToken}`,
@@ -509,6 +511,9 @@ describe("ChatRunner", () => {
       expect(JSON.stringify(persistedSession)).not.toContain(telegramToken);
       expect(JSON.stringify(persistedSession)).not.toContain(echoedToken);
       expect(JSON.stringify(persistedSession)).toContain("[REDACTED:openai_api_key:setup_secret_1]");
+      const progressEvents = events.filter((event) => event.type === "operation_progress");
+      expect(progressEvents.map((event) => event.item.kind)).toContain("awaiting_approval");
+      expect(JSON.stringify(progressEvents)).not.toContain(telegramToken);
     });
 
     it("writes Telegram config only after explicit confirmation and approval", async () => {
@@ -3941,6 +3946,17 @@ describe("ChatRunner", () => {
       expect(intent?.message).toContain("設定ガイダンスを準備");
       expect(intent?.languageHint).toMatchObject({ language: "ja" });
       expect(intent?.message).not.toContain("resume the saved agent loop state");
+      const progressEvents = events.filter((event): event is Extract<ChatEvent, { type: "operation_progress" }> =>
+        event.type === "operation_progress"
+      );
+      expect(progressEvents.map((event) => event.item.kind)).toEqual([
+        "started",
+        "checked_status",
+        "read_config",
+        "planned_action",
+      ]);
+      expect(progressEvents.map((event) => event.item.title).join("\n")).toContain("Daemon status を確認しました");
+      expect(JSON.stringify(progressEvents)).not.toContain("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi");
     });
 
     it("routes English Telegram setup paraphrases to guidance before agent-loop execution", async () => {

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -1,6 +1,7 @@
 import type { ChatEvent } from "./chat-events.js";
 import { formatLifecycleFailureMessage } from "./failure-recovery.js";
 import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
+import { renderOperationProgress } from "./operation-progress.js";
 import { redactSetupSecrets } from "./setup-secret-intake.js";
 
 type ToolActivityState = "reading" | "planning" | "editing" | "verifying" | "waiting" | "running" | "completed" | "failed";
@@ -76,6 +77,10 @@ function getActivityMessageId(event: Extract<ChatEvent, { type: "activity" }>): 
 
 function getTimelineMessageId(chatTurnId: string, item: AgentTimelineItem): string {
   return `agent-timeline:${chatTurnId}:${item.sourceEventId}`;
+}
+
+function getOperationProgressMessageId(turnId: string, itemId: string): string {
+  return `operation-progress:${turnId}:${itemId}`;
 }
 
 function renderTimelineItem(item: AgentTimelineItem): string {
@@ -342,6 +347,18 @@ export function applyChatEventToMessages(
       timestamp: new Date(event.item.createdAt),
       messageType: event.item.kind === "stopped" ? "warning" : "info",
       transient: isTransientTimelineItem(event.item),
+    }, maxMessages);
+  }
+
+  if (event.type === "operation_progress") {
+    const text = renderOperationProgress(event.item).trim();
+    if (!text) return messages;
+    return upsertMessage(messages, {
+      id: getOperationProgressMessageId(event.turnId, event.item.id),
+      role: "pulseed",
+      text,
+      timestamp: new Date(event.item.createdAt),
+      messageType: event.item.kind === "blocked" ? "warning" : "info",
     }, maxMessages);
   }
 

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -1,6 +1,7 @@
 import type { FailureRecoveryGuidance } from "./failure-recovery.js";
 import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
 import type { TurnLanguageHint } from "./turn-language.js";
+import type { OperationProgressItem } from "./operation-progress.js";
 
 export interface ChatEventBase {
   runId: string;
@@ -74,6 +75,11 @@ export interface AgentTimelineEvent extends ChatEventBase {
   item: AgentTimelineItem;
 }
 
+export interface OperationProgressEvent extends ChatEventBase {
+  type: "operation_progress";
+  item: OperationProgressItem;
+}
+
 export interface LifecycleEndEvent extends ChatEventBase {
   type: "lifecycle_end";
   status: "completed" | "error";
@@ -95,6 +101,7 @@ export type ChatEvent =
   | AssistantFinalEvent
   | ActivityEvent
   | AgentTimelineEvent
+  | OperationProgressEvent
   | ToolStartEvent
   | ToolUpdateEvent
   | ToolEndEvent

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -25,6 +25,11 @@ import {
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { redactSetupSecrets, redactSetupSecretsDeep } from "./setup-secret-intake.js";
 import { shouldRenderJapanese } from "./turn-language.js";
+import {
+  createOperationProgressItem,
+  operationProgressFromAgentActivitySummary,
+  type OperationProgressItem,
+} from "./operation-progress.js";
 
 export interface AssistantBuffer {
   text: string;
@@ -318,9 +323,22 @@ export class ChatRunnerEventBridge {
     });
     if (!summary) return;
     this.timelineActivityItemsByRun.delete(eventContext.runId);
+    this.emitOperationProgress(operationProgressFromAgentActivitySummary(summary, eventContext.languageHint), eventContext);
     this.emitEvent({
       type: "agent_timeline",
       item: summary,
+      ...this.eventBase(eventContext),
+    });
+  }
+
+  emitOperationProgress(item: OperationProgressItem, eventContext: ChatEventContext): void {
+    const safeItem = createOperationProgressItem({
+      ...item,
+      ...(eventContext.languageHint && !item.languageHint ? { languageHint: eventContext.languageHint } : {}),
+    });
+    this.emitEvent({
+      type: "operation_progress",
+      item: safeItem,
       ...this.eventBase(eventContext),
     });
   }

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -32,6 +32,7 @@ import {
   shouldRenderJapanese,
   type TurnLanguageHint,
 } from "./turn-language.js";
+import { createOperationProgressItem } from "./operation-progress.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
@@ -103,7 +104,7 @@ export async function executeConfigureRoute(
   if (route.kind !== "configure") {
     throw new Error(`executeConfigureRoute received route kind ${route.kind}`);
   }
-  const output = await formatConfigureGuidance(host, route.intent.configure_target ?? "unknown", host.getSetupSecretIntake(), host.getTurnLanguageHint());
+  const output = await formatConfigureGuidance(host, route.intent.configure_target ?? "unknown", host.getSetupSecretIntake(), host.getTurnLanguageHint(), eventContext);
   return persistDirectRouteResult(host, output, eventContext, assistantBuffer, history, start);
 }
 
@@ -645,16 +646,77 @@ async function formatConfigureGuidance(
   target: "telegram_gateway" | "gateway" | "provider" | "daemon" | "notification" | "slack" | "unknown",
   setupSecretIntake: SetupSecretIntakeResult | null = null,
   languageHint: TurnLanguageHint,
+  eventContext: ChatEventContext,
 ): Promise<string> {
   const suppliedSecretKinds = setupSecretIntake?.suppliedSecrets.map((secret) => secret.kind) ?? [];
   if (target === "telegram_gateway") {
     const provider = host.deps.gatewaySetupStatusProvider ?? createGatewaySetupStatusProvider();
+    host.eventBridge.emitOperationProgress(createOperationProgressItem({
+      id: "telegram-configure:started",
+      kind: "started",
+      operation: "telegram_setup",
+      title: shouldRenderJapanese(languageHint) ? "Telegram setup を開始しました" : "Started Telegram setup",
+      detail: shouldRenderJapanese(languageHint) ? "daemon と gateway config の状態を確認します。" : "Checking daemon and gateway config state.",
+      createdAt: new Date().toISOString(),
+      languageHint,
+    }), eventContext);
     const status = await provider.getTelegramStatus(host.getProviderConfigBaseDir());
+    host.eventBridge.emitOperationProgress(createOperationProgressItem({
+      id: "telegram-configure:checked-status",
+      kind: "checked_status",
+      operation: "telegram_setup",
+      title: shouldRenderJapanese(languageHint) ? "Daemon status を確認しました" : "Checked daemon status",
+      detail: status.daemon.running
+        ? shouldRenderJapanese(languageHint)
+          ? `port ${status.daemon.port} で起動中です。`
+          : `Running on port ${status.daemon.port}.`
+        : shouldRenderJapanese(languageHint)
+          ? `port ${status.daemon.port} で応答していません。`
+          : `Not responding on port ${status.daemon.port}.`,
+      createdAt: new Date().toISOString(),
+      languageHint,
+      metadata: {
+        daemon_running: status.daemon.running,
+        daemon_port: status.daemon.port,
+      },
+    }), eventContext);
+    host.eventBridge.emitOperationProgress(createOperationProgressItem({
+      id: "telegram-configure:read-config",
+      kind: "read_config",
+      operation: "telegram_setup",
+      title: shouldRenderJapanese(languageHint) ? "Telegram config を読み取りました" : "Read Telegram config",
+      detail: formatTelegramConfigProgressDetail(status, languageHint),
+      createdAt: new Date().toISOString(),
+      languageHint,
+      metadata: {
+        config_exists: status.config.exists,
+        has_bot_token: status.config.hasBotToken,
+        has_home_chat: status.config.hasHomeChat,
+      },
+    }), eventContext);
     const suppliedTelegramToken = suppliedSecretKinds.includes("telegram_bot_token");
     const telegramSecret = setupSecretIntake?.suppliedSecrets.find((secret) => secret.kind === "telegram_bot_token");
     if (telegramSecret) {
       await host.setPendingSetupDialogue(createTelegramConfirmWriteDialogue(telegramSecret));
     }
+    host.eventBridge.emitOperationProgress(createOperationProgressItem({
+      id: "telegram-configure:planned-action",
+      kind: telegramSecret ? "awaiting_approval" : "planned_action",
+      operation: "telegram_setup",
+      title: shouldRenderJapanese(languageHint) ? "次の手順を準備しました" : "Prepared next setup step",
+      detail: telegramSecret
+        ? shouldRenderJapanese(languageHint)
+          ? "redacted token から approval-gated config write を準備しました。"
+          : "Prepared an approval-gated config write from the redacted token."
+        : shouldRenderJapanese(languageHint)
+          ? "guidance を返します。token が貼られた場合は redaction 後に confirmation を準備します。"
+          : "Returning guidance. If a token is pasted, PulSeed will redact it and prepare confirmation.",
+      createdAt: new Date().toISOString(),
+      languageHint,
+      metadata: {
+        pending_write: telegramSecret !== undefined,
+      },
+    }), eventContext);
     return formatTelegramConfigureGuidance(status, suppliedTelegramToken, telegramSecret !== undefined, languageHint);
   }
   if (target === "gateway") {
@@ -722,6 +784,19 @@ async function formatConfigureGuidance(
     "",
     "Use `pulseed setup` for the main wizard, `pulseed gateway setup` for chat channels, or the channel-specific setup command when available.",
   ].join("\n");
+}
+
+function formatTelegramConfigProgressDetail(status: TelegramSetupStatus, languageHint: TurnLanguageHint): string {
+  if (shouldRenderJapanese(languageHint)) {
+    if (!status.config.exists) return "config file はまだありません。";
+    if (!status.config.hasBotToken) return "config file はありますが bot token が未設定です。";
+    if (!status.config.hasHomeChat) return "bot token は設定済みですが home chat が未設定です。";
+    return "bot token と home chat は設定済みです。";
+  }
+  if (!status.config.exists) return "Config file does not exist yet.";
+  if (!status.config.hasBotToken) return "Config file exists, but no bot token is configured.";
+  if (!status.config.hasHomeChat) return "Bot token is configured, but no home chat is set.";
+  return "Bot token and home chat are configured.";
 }
 
 function formatTelegramConfigureGuidance(

--- a/src/interface/chat/operation-progress.ts
+++ b/src/interface/chat/operation-progress.ts
@@ -1,0 +1,58 @@
+import type { AgentTimelineActivitySummaryItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
+import { redactSetupSecretsDeep } from "./setup-secret-intake.js";
+import type { TurnLanguageHint } from "./turn-language.js";
+
+export type OperationProgressKind =
+  | "started"
+  | "checked_status"
+  | "read_config"
+  | "planned_action"
+  | "awaiting_approval"
+  | "wrote_config"
+  | "verified"
+  | "completed"
+  | "blocked";
+
+export interface OperationProgressItem {
+  id: string;
+  kind: OperationProgressKind;
+  operation: string;
+  title: string;
+  detail?: string;
+  createdAt: string;
+  languageHint?: TurnLanguageHint;
+  metadata?: Record<string, unknown>;
+}
+
+export function createOperationProgressItem(input: OperationProgressItem): OperationProgressItem {
+  return {
+    ...input,
+    title: redactSetupSecretsDeep(input.title) as string,
+    ...(input.detail ? { detail: redactSetupSecretsDeep(input.detail) as string } : {}),
+    ...(input.metadata ? { metadata: redactSetupSecretsDeep(input.metadata) as Record<string, unknown> } : {}),
+  };
+}
+
+export function operationProgressFromAgentActivitySummary(
+  summary: AgentTimelineActivitySummaryItem,
+  languageHint?: TurnLanguageHint,
+): OperationProgressItem {
+  return createOperationProgressItem({
+    id: `operation-progress:${summary.sourceEventId}`,
+    kind: "completed",
+    operation: "agent_loop",
+    title: "Agent-loop activity summarized",
+    detail: summary.text,
+    createdAt: summary.createdAt,
+    ...(languageHint ? { languageHint } : {}),
+    metadata: {
+      source: "agent_timeline_activity_summary",
+      buckets: summary.buckets,
+    },
+  });
+}
+
+export function renderOperationProgress(item: OperationProgressItem): string {
+  const line = `${item.title}${item.detail ? `: ${item.detail}` : ""}`;
+  return redactSetupSecretsDeep(line) as string;
+}

--- a/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
@@ -96,6 +96,96 @@ describe("TelegramGatewayAdapter", () => {
       })
     );
   });
+
+  it("renders operation progress events before the final Telegram reply", async () => {
+    const configDir = await writeConfig({
+      bot_token: "test-token",
+      allowed_user_ids: [42],
+      denied_user_ids: [],
+      allowed_chat_ids: [],
+      denied_chat_ids: [],
+      runtime_control_allowed_user_ids: [42],
+      chat_goal_map: {},
+      user_goal_map: {},
+      allow_all: true,
+      polling_timeout: 30,
+      identity_key: "seedy",
+    });
+    const sentMessages: string[] = [];
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const method = String(url).split("/").at(-1);
+      if (method === "getMe") {
+        return telegramResponse({ id: 1, username: "pulseed_test_bot" });
+      }
+      if (method === "getUpdates") {
+        return telegramResponse([
+          {
+            update_id: 100,
+            message: {
+              message_id: 2718,
+              from: { id: 42 },
+              chat: { id: 314 },
+              text: "telegram setup",
+            },
+          },
+        ]);
+      }
+      if (method === "sendMessage") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+        sentMessages.push(body.text ?? "");
+        return telegramResponse({ message_id: 9000 + sentMessages.length });
+      }
+      if (method === "editMessageText") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+        sentMessages.push(body.text ?? "");
+        return telegramResponse({ message_id: 9100 + sentMessages.length });
+      }
+      throw new Error(`unexpected Telegram method: ${method}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = TelegramGatewayAdapter.fromConfigDir(configDir);
+    adapters.push(adapter);
+    vi.mocked(dispatchGatewayChatInput).mockImplementationOnce(async (input) => {
+      await input.onEvent?.({
+        type: "lifecycle_start",
+        runId: "run-1",
+        turnId: "turn-1",
+        createdAt: "2026-04-08T00:00:00.000Z",
+        input: "telegram setup",
+      });
+      await input.onEvent?.({
+        type: "operation_progress",
+        runId: "run-1",
+        turnId: "turn-1",
+        createdAt: "2026-04-08T00:00:01.000Z",
+        item: {
+          id: "telegram-configure:read-config",
+          kind: "read_config",
+          operation: "telegram_setup",
+          title: "Read Telegram config",
+          detail: "Config file does not exist yet.",
+          createdAt: "2026-04-08T00:00:01.000Z",
+        },
+      });
+      await input.onEvent?.({
+        type: "assistant_final",
+        runId: "run-1",
+        turnId: "turn-1",
+        createdAt: "2026-04-08T00:00:02.000Z",
+        text: "Final setup guidance.",
+        persisted: true,
+      });
+      await adapter.stop();
+      return "Final setup guidance.";
+    });
+
+    await adapter.start();
+
+    await vi.waitFor(() => {
+      expect(sentMessages).toContain("Read Telegram config: Config file does not exist yet.");
+      expect(sentMessages).toContain("Final setup guidance.");
+    });
+  });
 });
 
 async function writeConfig(config: Record<string, unknown>): Promise<string> {

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -5,6 +5,7 @@ import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
 import { formatTelegramNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
 import { writeJsonFileAtomic } from "../../base/utils/json-io.js";
 import type { ChatEvent } from "../../interface/chat/chat-events.js";
+import { renderOperationProgress } from "../../interface/chat/operation-progress.js";
 import { formatLifecycleFailureMessage } from "../../interface/chat/failure-recovery.js";
 import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
 import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
@@ -333,6 +334,9 @@ class TelegramChatEventAdapter {
         if (event.kind === "plugin" || event.kind === "skill") {
           await this.upsertActivityMessage(event.sourceId ?? event.kind, `[${event.kind}] ${event.message}`);
         }
+        return;
+      case "operation_progress":
+        await this.upsertActivityMessage(event.item.id, renderOperationProgress(event.item));
         return;
       case "tool_start":
         await this.upsertToolMessage(event.toolCallId, `[tool] ${event.toolName} started`);

--- a/tmp/autonomous-chat-setup-ux-status.md
+++ b/tmp/autonomous-chat-setup-ux-status.md
@@ -25,3 +25,29 @@ Updated: 2026-05-03
 - PR #977 CI: `unit (22)` passed; `integration (24)` failed because `src/interface/tui/__tests__/app.test.ts` still expected the old English intent activity text.
 - Fixed the integration expectation to the localized Japanese activity text and verified `npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/app.test.ts -t "routes Telegram setup freeform input"` passed.
 - Re-verification after CI fix: `npm run typecheck` passed.
+
+## #976 language hint
+- Status: merged.
+- PR: #977 (`feat(chat): add turn language hints`).
+- CI: `unit (22)` passed; `integration (24)` passed after updating the TUI integration expectation.
+
+## #975 shared operation progress timeline
+- Status: in progress.
+- Issue body read with `gh issue view 975`.
+- Plan: define typed `operation_progress` chat event/model, adapt agent-loop timeline summaries into it without breaking #949, emit deterministic setup/configure progress from direct Telegram route, render it through the existing chat event reducer/TUI path, and cover secret redaction.
+- Implemented typed `operation_progress` chat events and `OperationProgressItem` model.
+- Added direct Telegram configure progress producer for started/status/config/next-step states, with language hints and setup-secret redaction.
+- Adapted agent-loop activity summary into the same operation progress model while preserving existing `agent_timeline` behavior.
+- Added chat reducer rendering so progress remains separate from final assistant output.
+- Verification: focused Vitest for operation progress/direct route/agent-loop adapter passed.
+- Verification: `npm run typecheck` passed.
+- Verification: `npm run test:changed` passed (20 files, 459 tests; 2 skipped).
+- Verification: `npm run lint:boundaries` passed with existing warnings only (0 errors, 610 warnings).
+- Review agent found P1: Telegram gateway adapter ignored `operation_progress`, so gateway users would not see incremental progress.
+- Fixed Telegram gateway event adapter to render `operation_progress` via the shared renderer before final replies.
+- Added Telegram gateway integration coverage for progress plus final guidance dispatch.
+- Re-verification: focused Vitest for chat progress and Telegram gateway progress passed.
+- Re-verification: `npm run typecheck` passed.
+- Re-verification: `npm run test:changed` passed, including related unit/integration and smoke lanes.
+- Re-verification: `npm run lint:boundaries` passed with existing warnings only (0 errors, 610 warnings).
+- Re-review after Telegram gateway fix: no material findings.


### PR DESCRIPTION
Closes #975

## Summary
- add a typed `operation_progress` chat event and shared `OperationProgressItem` model
- emit direct Telegram setup/configure progress for status checks, config reads, and next-step planning before final guidance
- adapt agent-loop activity summaries into the same progress model while keeping existing `agent_timeline` behavior
- render progress in chat/TUI state and Telegram gateway surfaces with setup-secret redaction

## Verification
- `npx vitest run src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-runner.test.ts -t "operation progress|renders operation progress|routes Japanese Telegram setup requests|keeps supplied setup secret facts|preserves agent commentary"`
- `npm run typecheck`
- `npm run test:changed`
- `npm run lint:boundaries` (0 errors; existing warnings only)

## Known unresolved risks
- Runtime-control does not emit a route-specific progress producer in this slice, but the shared event/model is route-agnostic and can be used by runtime-control without UI-specific plumbing.
- Agent-loop progress is adapted from the existing deterministic activity summary to preserve #949 behavior rather than replacing the full agent timeline.