### PR TITLE
feat(chat): polish Telegram setup confirmation

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -595,6 +595,133 @@ describe("ChatRunner", () => {
       fs.rmSync(baseDir, { recursive: true, force: true });
     });
 
+    it("confirms pending Telegram setup write from Japanese natural language through the production route", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-ja-confirm-"));
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const approvalFn = vi.fn().mockResolvedValue(true);
+      const llmClient = createMockLLMClient([
+        JSON.stringify({ decision: "approve", confidence: 0.94, rationale: "user approved pending setup write" }),
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        approvalFn,
+        llmClient,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "unconfigured",
+          configPath: path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"),
+          daemon: { running: true, port: 41700 },
+        })),
+      }));
+
+      const intakeResult = await runner.execute(`このtokenで進めて ${telegramToken}`, "/repo", 30_000);
+      const confirmResult = await runner.execute("設定して", "/repo", 30_000);
+
+      const configPath = path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json");
+      const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+      expect(intakeResult.output).toContain("自然文で承認");
+      expect(confirmResult.success).toBe(true);
+      expect(confirmResult.output).toContain("Telegram gateway config を書き込みました");
+      expect(confirmResult.output).not.toContain(telegramToken);
+      expect(JSON.stringify((stateManager.writeRaw as ReturnType<typeof vi.fn>).mock.calls)).not.toContain(telegramToken);
+      expect(config.bot_token).toBe(telegramToken);
+      expect(approvalFn).toHaveBeenCalledOnce();
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it("confirms pending Telegram setup write from English natural language through the production route", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-en-confirm-"));
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const approvalFn = vi.fn().mockResolvedValue(true);
+      const llmClient = createMockLLMClient([
+        JSON.stringify({ decision: "approve", confidence: 0.95, rationale: "user approved pending setup write" }),
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        approvalFn,
+        llmClient,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "unconfigured",
+          configPath: path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"),
+          daemon: { running: true, port: 41700 },
+        })),
+      }));
+
+      const intakeResult = await runner.execute(`configure it with ${telegramToken}`, "/repo", 30_000);
+      const confirmResult = await runner.execute("yes, configure it", "/repo", 30_000);
+
+      const configPath = path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json");
+      const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+      expect(intakeResult.output).toContain("approve in natural language");
+      expect(confirmResult.success).toBe(true);
+      expect(confirmResult.output).toContain("Telegram gateway config was written");
+      expect(confirmResult.output).not.toContain(telegramToken);
+      expect(config.bot_token).toBe(telegramToken);
+      expect(approvalFn).toHaveBeenCalledOnce();
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it("warns that confirming a new Telegram token replaces the existing configured token", async () => {
+      const oldToken = "111111111:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const newToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-replace-"));
+      const configDir = path.join(baseDir, "gateway", "channels", "telegram-bot");
+      fs.mkdirSync(configDir, { recursive: true });
+      fs.writeFileSync(path.join(configDir, "config.json"), JSON.stringify({
+        bot_token: oldToken,
+        allowed_user_ids: [],
+        denied_user_ids: [],
+        allowed_chat_ids: [],
+        denied_chat_ids: [],
+        runtime_control_allowed_user_ids: [],
+        chat_goal_map: {},
+        user_goal_map: {},
+        allow_all: false,
+        polling_timeout: 30,
+      }), "utf-8");
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const approvalFn = vi.fn().mockResolvedValue(true);
+      const llmClient = createMockLLMClient([
+        JSON.stringify({ decision: "approve", confidence: 0.95, rationale: "user approved replacement" }),
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        approvalFn,
+        llmClient,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "configured",
+          configPath: path.join(configDir, "config.json"),
+          daemon: { running: true, port: 41700 },
+          config: { exists: true, hasBotToken: true, hasHomeChat: false },
+        })),
+      }));
+
+      const intakeResult = await runner.execute(`use this new token ${newToken}`, "/repo", 30_000);
+      const persistedSession = (stateManager.writeRaw as ReturnType<typeof vi.fn>).mock.calls
+        .map(([, value]) => value)
+        .find((value) => value?.setupDialogue?.selectedChannel === "telegram");
+      const confirmResult = await runner.execute("yes, configure it", "/repo", 30_000);
+
+      const config = JSON.parse(fs.readFileSync(path.join(configDir, "config.json"), "utf-8"));
+      expect(intakeResult.output).toContain("replace the existing configured token");
+      expect(persistedSession.setupDialogue).toMatchObject({ replacesExistingSecret: true });
+      expect(approvalFn).toHaveBeenCalledWith(expect.stringContaining("replace the existing configured Telegram bot token"));
+      expect(confirmResult.success).toBe(true);
+      expect(config.bot_token).toBe(newToken);
+      expect(JSON.stringify(persistedSession)).not.toContain(newToken);
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
     it("does not let disallowed gateway ingress confirm Telegram config through global approval", async () => {
       const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
       const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-denied-"));
@@ -3943,9 +4070,9 @@ describe("ChatRunner", () => {
       const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
         event.type === "activity" && event.sourceId === "intent:first-step"
       );
-      expect(intent?.message).toContain("設定ガイダンスを準備");
-      expect(intent?.languageHint).toMatchObject({ language: "ja" });
-      expect(intent?.message).not.toContain("resume the saved agent loop state");
+      expect(intent).toBeUndefined();
+      expect(events.map((event) => event.type === "activity" ? event.message : "").join("\n"))
+        .not.toContain("I understand the request");
       const progressEvents = events.filter((event): event is Extract<ChatEvent, { type: "operation_progress" }> =>
         event.type === "operation_progress"
       );

--- a/src/interface/chat/__tests__/turn-language.test.ts
+++ b/src/interface/chat/__tests__/turn-language.test.ts
@@ -20,4 +20,10 @@ describe("turn language hint", () => {
     expect(sameLanguageResponseInstruction({ language: "ja", confidence: 0.9, source: "input_script" }))
       .toContain("Do not translate command names");
   });
+
+  it("ignores setup secret redaction markers when detecting the user's language", () => {
+    const hint = detectTurnLanguageHint("このtokenで進めて [REDACTED:telegram_bot_token:setup_secret_1]");
+
+    expect(hint).toMatchObject({ language: "ja", source: "input_script" });
+  });
 });

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -697,7 +697,9 @@ async function formatConfigureGuidance(
     const suppliedTelegramToken = suppliedSecretKinds.includes("telegram_bot_token");
     const telegramSecret = setupSecretIntake?.suppliedSecrets.find((secret) => secret.kind === "telegram_bot_token");
     if (telegramSecret) {
-      await host.setPendingSetupDialogue(createTelegramConfirmWriteDialogue(telegramSecret));
+      await host.setPendingSetupDialogue(createTelegramConfirmWriteDialogue(telegramSecret, {
+        replacesExistingSecret: status.config.hasBotToken,
+      }));
     }
     host.eventBridge.emitOperationProgress(createOperationProgressItem({
       id: "telegram-configure:planned-action",
@@ -706,8 +708,12 @@ async function formatConfigureGuidance(
       title: shouldRenderJapanese(languageHint) ? "次の手順を準備しました" : "Prepared next setup step",
       detail: telegramSecret
         ? shouldRenderJapanese(languageHint)
-          ? "redacted token から approval-gated config write を準備しました。"
-          : "Prepared an approval-gated config write from the redacted token."
+          ? status.config.hasBotToken
+            ? "redacted token から approval-gated config write を準備しました。confirm すると既存 token を置き換えます。"
+            : "redacted token から approval-gated config write を準備しました。"
+          : status.config.hasBotToken
+            ? "Prepared an approval-gated config write from the redacted token. Confirming will replace the existing token."
+            : "Prepared an approval-gated config write from the redacted token."
         : shouldRenderJapanese(languageHint)
           ? "guidance を返します。token が貼られた場合は redaction 後に confirmation を準備します。"
           : "Returning guidance. If a token is pasted, PulSeed will redact it and prepare confirmation.",
@@ -858,7 +864,9 @@ function formatTelegramConfigureGuidance(
     "",
     suppliedTelegramToken
       ? pendingActionCreated
-        ? `I received a Telegram bot token in this turn and kept it redacted from chat history and activity. Reply \`${SETUP_WRITE_CONFIRM_COMMAND}\` to request an approval-gated config write.`
+        ? status.config.hasBotToken
+          ? `I received a Telegram bot token in this turn and kept it redacted from chat history and activity. Confirming will replace the existing configured token. Reply \`${SETUP_WRITE_CONFIRM_COMMAND}\` or approve in natural language to request an approval-gated config write.`
+          : `I received a Telegram bot token in this turn and kept it redacted from chat history and activity. Reply \`${SETUP_WRITE_CONFIRM_COMMAND}\` or approve in natural language to request an approval-gated config write.`
         : "I received a Telegram bot token in this turn and kept it redacted from chat history and activity, but no setup action could be prepared."
       : "If you prefer chat-assisted setup, paste the token here; PulSeed will redact it from history and prepare an approval-gated confirmation before writing config."
   );
@@ -933,7 +941,9 @@ function formatTelegramConfigureGuidanceJa(
     "",
     suppliedTelegramToken
       ? pendingActionCreated
-        ? `この turn で Telegram bot token を受け取り、chat history と activity には redacted のまま保持しました。approval-gated config write を依頼するには \`${SETUP_WRITE_CONFIRM_COMMAND}\` と返信してください。`
+        ? status.config.hasBotToken
+          ? `この turn で Telegram bot token を受け取り、chat history と activity には redacted のまま保持しました。confirm すると既存の configured token を置き換えます。approval-gated config write を依頼するには \`${SETUP_WRITE_CONFIRM_COMMAND}\` または自然文で承認してください。`
+          : `この turn で Telegram bot token を受け取り、chat history と activity には redacted のまま保持しました。approval-gated config write を依頼するには \`${SETUP_WRITE_CONFIRM_COMMAND}\` または自然文で承認してください。`
         : "この turn で Telegram bot token を受け取り、chat history と activity には redacted のまま保持しましたが、setup action は準備できませんでした。"
       : "chat-assisted setup を使う場合は、ここに token を貼ってください。PulSeed は history から redaction し、config 書き込み前に approval-gated confirmation を準備します。"
   );

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -31,6 +31,7 @@ import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loo
 import type { ReviewAgentLoopRunner } from "../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
 import type { RuntimeControlService } from "../../runtime/control/index.js";
 import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
+import { classifyConfirmationDecision } from "../../runtime/confirmation-decision.js";
 import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
@@ -52,6 +53,7 @@ import { ChatRunnerEventBridge, type AssistantBuffer } from "./chat-runner-event
 import { intakeSetupSecrets } from "./setup-secret-intake.js";
 import {
   isSetupWriteConfirmCommand,
+  SETUP_WRITE_CONFIRM_COMMAND,
   type SetupDialogueRuntimeState,
 } from "./setup-dialogue.js";
 import {
@@ -158,6 +160,27 @@ function resolveSelfIdentityResponse(input: string, baseDir: string): string | n
 
   if (!isIdentityQuestion && !isEnglishIdentityQuestion) return null;
   return getSelfIdentityResponseForBaseDir(baseDir, isEnglishIdentityQuestion ? "en" : "ja");
+}
+
+function formatPendingSetupConfirmationSubject(publicState: SetupDialogueRuntimeState["publicState"]): string {
+  const lines = [
+    `Setup dialogue: ${publicState.selectedChannel}`,
+    `State: ${publicState.state}`,
+    `Action: ${publicState.action?.kind ?? "unknown"}`,
+    `Command fallback: ${publicState.action?.command ?? SETUP_WRITE_CONFIRM_COMMAND}`,
+    publicState.replacesExistingSecret
+      ? "Confirming will replace an existing configured Telegram bot token."
+      : "Confirming will write a Telegram gateway config from a redacted chat-supplied token.",
+    "Approval is still required before writing config.",
+  ];
+  return lines.join("\n");
+}
+
+function formatSetupConfirmationCancelled(languageHint: TurnLanguageHint): string {
+  if (languageHint.language === "ja") {
+    return "Telegram setup の config write はキャンセルしました。token は書き込んでいません。";
+  }
+  return "Telegram setup config write was cancelled. No token was written.";
 }
 
 export class ChatRunner {
@@ -451,7 +474,9 @@ export class ChatRunner {
       ? null
       : (options.selectedRoute ?? await this.resolveRouteFromInput(safeInput, runtimeControlContext));
     this.lastSelectedRoute = selectedRoute;
-    this.eventBridge.emitIntent(safeInput, selectedRoute, eventContext);
+    if (selectedRoute?.kind !== "configure") {
+      this.eventBridge.emitIntent(safeInput, selectedRoute, eventContext);
+    }
 
     const start = Date.now();
     const assistantBuffer: AssistantBuffer = { text: "" };
@@ -737,7 +762,28 @@ export class ChatRunner {
     input: string,
     runtimeControlContext: RuntimeControlChatContext | null
   ): Promise<ChatRunResult | null> {
-    if (!isSetupWriteConfirmCommand(input)) return null;
+    const commandConfirmed = isSetupWriteConfirmCommand(input);
+    const pendingAtInput = this.pendingSetupDialogue;
+    if (!commandConfirmed) {
+      if (!pendingAtInput || pendingAtInput.publicState.state !== "confirm_write") return null;
+      const decision = await classifyConfirmationDecision(input, {
+        llmClient: this.deps.llmClient,
+        kind: "approval",
+        subject: formatPendingSetupConfirmationSubject(pendingAtInput.publicState),
+        allowedDecisions: ["approve", "cancel", "unknown"],
+      });
+      if (decision.decision === "cancel") {
+        this.pendingSetupDialogue = null;
+        this.history?.setSetupDialogue(null);
+        await this.history?.persist();
+        return {
+          success: false,
+          output: formatSetupConfirmationCancelled(this.turnLanguageHint),
+          elapsed_ms: 0,
+        };
+      }
+      if (decision.decision !== "approve") return null;
+    }
     const pending = this.pendingSetupDialogue;
     if (!pending) {
       return {
@@ -782,10 +828,13 @@ export class ChatRunner {
     const accessClosedByDefault = !nextAllowAll && nextAllowedUserIds.length === 0 && nextRuntimeControlAllowedUserIds.length === 0;
     const approved = await approvalFn([
       "Write Telegram gateway config from the redacted chat-supplied bot token.",
+      pending.publicState.replacesExistingSecret
+        ? "This will replace the existing configured Telegram bot token."
+        : "",
       accessClosedByDefault
         ? "Access will remain closed by default with allow_all=false until allowed Telegram user IDs are configured."
         : "Existing Telegram access policy will be preserved.",
-    ].join(" "));
+    ].filter(Boolean).join(" "));
     if (!approved) {
       this.pendingSetupDialogue = null;
       this.history?.setSetupDialogue(null);
@@ -827,15 +876,25 @@ export class ChatRunner {
     return {
       success: true,
       output: [
-        "Telegram gateway config was written from the redacted chat-supplied token.",
+        this.turnLanguageHint.language === "ja"
+          ? "redacted chat-supplied token から Telegram gateway config を書き込みました。"
+          : "Telegram gateway config was written from the redacted chat-supplied token.",
         "",
-        "Next steps:",
-        "- Restart the daemon so the gateway loads the updated config.",
+        this.turnLanguageHint.language === "ja" ? "Next steps:" : "Next steps:",
+        this.turnLanguageHint.language === "ja"
+          ? "- daemon を再起動して、gateway に updated config を読み込ませてください。"
+          : "- Restart the daemon so the gateway loads the updated config.",
         ...(accessClosedByDefault
-          ? ["- Access remains closed until you configure allowed Telegram user IDs or intentionally enable `allow_all` with `pulseed telegram setup`."]
+          ? [this.turnLanguageHint.language === "ja"
+            ? "- allowed Telegram user IDs を設定するか、`pulseed telegram setup` で意図的に `allow_all` を有効にするまで access は closed のままです。"
+            : "- Access remains closed until you configure allowed Telegram user IDs or intentionally enable `allow_all` with `pulseed telegram setup`."]
           : []),
-        "- Send `/sethome` from Telegram if no home chat is configured yet.",
-        "- Run `pulseed daemon status` to verify.",
+        this.turnLanguageHint.language === "ja"
+          ? "- home chat が未設定なら Telegram から `/sethome` を送ってください。"
+          : "- Send `/sethome` from Telegram if no home chat is configured yet.",
+        this.turnLanguageHint.language === "ja"
+          ? "- `pulseed daemon status` で確認してください。"
+          : "- Run `pulseed daemon status` to verify.",
       ].join("\n"),
       elapsed_ms: 0,
     };

--- a/src/interface/chat/setup-dialogue.ts
+++ b/src/interface/chat/setup-dialogue.ts
@@ -49,6 +49,7 @@ export const SetupDialoguePublicStateSchema = z.object({
   updatedAt: z.string(),
   action: SetupDialogueActionSchema.optional(),
   pendingSecret: SetupDialogueSecretRefSchema.optional(),
+  replacesExistingSecret: z.boolean().optional(),
   note: z.string().optional(),
 }).passthrough();
 export type SetupDialoguePublicState = z.infer<typeof SetupDialoguePublicStateSchema>;
@@ -63,8 +64,9 @@ export const LEGACY_TELEGRAM_CONFIRM_COMMAND = "/confirm-telegram-setup";
 
 export function createTelegramConfirmWriteDialogue(
   secret: SetupSecretIntakeItem,
-  now = new Date().toISOString()
+  options: { replacesExistingSecret?: boolean; now?: string } = {}
 ): SetupDialogueRuntimeState {
+  const now = options.now ?? new Date().toISOString();
   return {
     publicState: {
       id: randomUUID(),
@@ -86,6 +88,7 @@ export function createTelegramConfirmWriteDialogue(
         secretKinds: [secret.kind],
         status: "pending",
       },
+      ...(options.replacesExistingSecret ? { replacesExistingSecret: true } : {}),
     },
     secretValue: secret.value,
   };

--- a/src/interface/chat/turn-language.ts
+++ b/src/interface/chat/turn-language.ts
@@ -15,7 +15,8 @@ export const UNKNOWN_TURN_LANGUAGE_HINT: TurnLanguageHint = {
 };
 
 export function detectTurnLanguageHint(input: string): TurnLanguageHint {
-  const letters = Array.from(input).filter((char) => /\p{Letter}/u.test(char));
+  const languageText = input.replace(/\[REDACTED:[^\]]+\]/g, " ");
+  const letters = Array.from(languageText).filter((char) => /\p{Letter}/u.test(char));
   if (letters.length === 0) return UNKNOWN_TURN_LANGUAGE_HINT;
 
   const japanese = letters.filter((char) => /[\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Han}]/u.test(char)).length;

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -882,8 +882,11 @@ describe("standalone slash command routing", () => {
     expect(chatRunnerOutput).toContain("pulseed gateway setup");
     await vi.waitFor(() => {
       const visibleText = testState.lastChatMessages.map((message) => message.text).join("\n");
-      expect(visibleText).toContain("設定ガイダンスを準備");
+      expect(visibleText).toContain("Telegram setup を開始しました");
       expect(visibleText).toContain("pulseed telegram setup");
+      expect(visibleText).not.toContain("I understand the request");
+      expect(visibleText).not.toContain("Next I will");
+      expect(visibleText).not.toContain("This is needed");
       expect(visibleText).not.toContain("resume the saved agent loop state");
     });
     expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();

--- a/tmp/autonomous-chat-setup-ux-status.md
+++ b/tmp/autonomous-chat-setup-ux-status.md
@@ -51,3 +51,23 @@ Updated: 2026-05-03
 - Re-verification: `npm run test:changed` passed, including related unit/integration and smoke lanes.
 - Re-verification: `npm run lint:boundaries` passed with existing warnings only (0 errors, 610 warnings).
 - Re-review after Telegram gateway fix: no material findings.
+
+## #975 shared operation progress timeline
+- Status: merged.
+- PR: #978 (`feat(chat): add shared operation progress`).
+- CI: `unit (22)` passed; `integration (24)` passed.
+
+## #974 setup copy and natural-language confirmation
+- Status: in progress.
+- Issue body read with `gh issue view 974`.
+- Plan: suppress internal setup preamble in rendered chat output, add typed setup confirmation intent via LLM/classifier state rather than phrase tables, explicitly mark replacement when an existing token is configured, keep slash fallback, and verify Japanese/English production chat route plus redaction.
+- Implemented direct configure preamble suppression by keeping configure progress on the shared `operation_progress` surface without emitting the generic `intent:first-step` activity.
+- Added natural-language confirmation for pending Telegram setup writes through `classifyConfirmationDecision` using the typed setup dialogue state as the subject; `/confirm-setup-write` remains the deterministic fallback command.
+- Added `replacesExistingSecret` to setup dialogue public state, surfaced replacement warnings before confirmation, and included replacement risk in the approval reason.
+- Preserved secret redaction in rendered output, persisted setup dialogue state, progress metadata, and approval text.
+- Added Japanese/English production ChatRunner coverage for natural-language confirmation, replacement warning coverage, and TUI coverage that rejects the internal preamble.
+- Verification: focused Vitest for turn language and chat-runner setup confirmation passed.
+- Verification: `npm run typecheck` passed.
+- Verification: `npm run test:changed` passed, including related unit/integration and smoke lanes.
+- Verification: `npm run lint:boundaries` passed with existing warnings only (0 errors, 610 warnings).
+- Review agent reported no high-confidence material findings. Residual risk: natural-language confirmation quality depends on the production LLM confirmation classifier.


### PR DESCRIPTION
Closes #974

## Summary
- suppress the internal configure preamble for direct Telegram setup and keep setup status on shared operation progress
- allow pending Telegram setup writes to be confirmed through natural-language approval via the typed setup dialogue state, while keeping `/confirm-setup-write` as fallback
- warn before replacing an existing Telegram token and keep raw tokens out of rendered output, progress, persisted dialogue state, and approval text

## Verification
- `npx vitest run src/interface/chat/__tests__/turn-language.test.ts src/interface/chat/__tests__/chat-runner.test.ts -t "turn language hint|natural language|replaces the existing|Japanese Telegram setup requests|writes Telegram config only after explicit"`
- `npm run typecheck`
- `npm run test:changed`
- `npm run lint:boundaries` (0 errors, existing warnings only)
- independent review agent: no high-confidence material findings

## Known unresolved risks
- Natural-language confirmation quality depends on the production LLM confirmation classifier; tests mock classifier output while exercising the production chat/TUI route shape.