### PR TITLE
feat(approvals): route requests through originating conversation

### DIFF
--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -2,9 +2,12 @@ import { describe, it, expect, vi } from "vitest";
 import { CrossPlatformChatSessionManager } from "../cross-platform-session.js";
 import type { CrossPlatformChatSessionOptions } from "../cross-platform-session.js";
 import type { ChatRunnerDeps } from "../chat-runner.js";
+import { ApprovalBroker } from "../../../runtime/approval-broker.js";
+import { ApprovalStore } from "../../../runtime/store/approval-store.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adapter-layer.js";
 import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
+import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
 
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -324,6 +327,156 @@ describe("CrossPlatformChatSessionManager", () => {
         }),
       })
     );
+  });
+
+  it("routes runtime-control approval through the originating conversation metadata", async () => {
+    const tmpDir = makeTempDir();
+    const events: string[] = [];
+    try {
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "approval-cross-platform",
+      });
+      const runtimeControlService = {
+        request: vi.fn(async (request: {
+          approvalFn?: (description: string) => Promise<boolean>;
+        }) => {
+          const approved = await request.approvalFn?.("Restart the resident daemon.");
+          return {
+            success: approved === true,
+            message: approved === true ? "restart queued" : "not approved",
+            operationId: "op-approval",
+            state: approved === true ? "acknowledged" as const : "blocked" as const,
+          };
+        }),
+      };
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        llmClient: createSingleMockLLMClient(JSON.stringify({
+          intent: "restart_daemon",
+          reason: "PulSeed を再起動して",
+        })),
+        runtimeControlService,
+        approvalBroker,
+      }));
+
+      const resultPromise = manager.processIncomingMessage({
+        text: "PulSeed を再起動して",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        onEvent: (event) => {
+          if (event.type === "activity") {
+            events.push(event.message);
+          }
+        },
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      });
+
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline && !events.some((message) => message.includes("Approval ID: approval-cross-platform"))) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      await expect(manager.processIncomingMessage({
+        text: "",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        approvalResponse: {
+          approval_id: "approval-cross-platform",
+          approved: true,
+        },
+      })).resolves.toBe("Approval response recorded.");
+
+      const result = await resultPromise;
+      expect(result).toBe("restart queued");
+      expect(events.some((message) =>
+        message.includes("Approval required.")
+        && message.includes("Restart the resident daemon.")
+        && message.includes("Approval ID: approval-cross-platform")
+      )).toBe(true);
+      const resolved = await store.loadResolved("approval-cross-platform");
+      expect(resolved).toMatchObject({
+        state: "approved",
+        response_channel: "slack",
+        origin: {
+          channel: "slack",
+          conversation_id: "C123:1700.1",
+          user_id: "U123",
+          session_id: "identity:workspace:U123",
+          turn_id: "1700.2",
+        },
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("fails closed when the originating conversation delivery handler rejects", async () => {
+    const tmpDir = makeTempDir();
+    try {
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "approval-delivery-failure",
+      });
+      const runtimeControlService = {
+        request: vi.fn(async (request: {
+          approvalFn?: (description: string) => Promise<boolean>;
+        }) => {
+          const approved = await request.approvalFn?.("Restart the resident daemon.");
+          return {
+            success: approved === true,
+            message: approved === true ? "restart queued" : "not approved",
+            operationId: "op-approval",
+            state: approved === true ? "acknowledged" as const : "blocked" as const,
+          };
+        }),
+      };
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        llmClient: createSingleMockLLMClient(JSON.stringify({
+          intent: "restart_daemon",
+          reason: "PulSeed を再起動して",
+        })),
+        runtimeControlService,
+        approvalBroker,
+      }));
+
+      const result = await manager.processIncomingMessage({
+        text: "PulSeed を再起動して",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        onEvent: async () => {
+          throw new Error("slack delivery failed");
+        },
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      });
+
+      expect(result).toContain("not approved");
+      const resolved = await store.loadResolved("approval-delivery-failure");
+      expect(resolved).toMatchObject({
+        state: "denied",
+        response_channel: "slack",
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
   });
 
   it("does not route broad finish text to runtime control without run context", async () => {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -30,6 +30,7 @@ import type { ChatEvent } from "./chat-events.js";
 import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
 import type { ReviewAgentLoopRunner } from "../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
 import type { RuntimeControlService } from "../../runtime/control/index.js";
+import type { ApprovalBroker } from "../../runtime/approval-broker.js";
 import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
 import { classifyConfirmationDecision } from "../../runtime/confirmation-decision.js";
 import type {
@@ -105,6 +106,7 @@ export interface ChatRunnerDeps {
   chatAgentLoopRunner?: ChatAgentLoopRunner;
   reviewAgentLoopRunner?: Pick<ReviewAgentLoopRunner, "execute">;
   runtimeControlService?: Pick<RuntimeControlService, "request">;
+  approvalBroker?: Pick<ApprovalBroker, "requestConversationalApproval" | "resolveConversationalApproval">;
   runtimeControlApprovalFn?: (description: string) => Promise<boolean>;
   runtimeReplyTarget?: RuntimeControlReplyTarget;
   runtimeControlActor?: RuntimeControlActor;

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -43,8 +43,11 @@ import {
   RuntimeControlService,
   createDaemonRuntimeControlExecutor,
 } from "../../runtime/control/index.js";
+import { ApprovalBroker } from "../../runtime/approval-broker.js";
+import { ApprovalStore, createRuntimeStorePaths } from "../../runtime/store/index.js";
 import { registerGlobalCrossPlatformChatSessionManager } from "./cross-platform-session-global.js";
 import type { RuntimeControlActor } from "../../runtime/store/runtime-operation-schemas.js";
+import type { ApprovalOrigin } from "../../runtime/store/runtime-schemas.js";
 
 export interface CrossPlatformChatSessionOptions {
   /**
@@ -102,6 +105,10 @@ export interface CrossPlatformIncomingChatMessage {
   replyTarget?: Partial<ChatIngressReplyTarget>;
   runtimeControl?: Partial<ChatIngressRuntimeControl>;
   metadata?: Record<string, unknown>;
+  approvalResponse?: {
+    approval_id: string;
+    approved: boolean;
+  };
   onEvent?: ChatEventHandler;
 }
 
@@ -303,6 +310,7 @@ function safeInvoke(handler: ChatEventHandler | undefined, event: ChatEvent): vo
 
 export class CrossPlatformChatSessionManager {
   private readonly sessions = new Map<string, ManagedChatSession>();
+  private readonly activeApprovalEventHandlers = new Map<string, ChatEventHandler>();
   private readonly ingressRouter = createIngressRouter();
 
   constructor(private readonly deps: ChatRunnerDeps) {}
@@ -342,7 +350,11 @@ export class CrossPlatformChatSessionManager {
   }
 
   async processIncomingMessage(input: CrossPlatformIncomingChatMessage): Promise<string> {
-    const result = await this.executeIngress(this.createIngressMessage(input), input);
+    const ingress = this.createIngressMessage(input);
+    if (input.approvalResponse) {
+      return this.resolveConversationalApprovalIngress(ingress, input.approvalResponse);
+    }
+    const result = await this.executeIngress(ingress, input);
     return result.output;
   }
 
@@ -375,6 +387,28 @@ export class CrossPlatformChatSessionManager {
     const queueEntry = session.queue.then(() => this.executeInSession(session, ingress, options));
     session.queue = queueEntry.then(() => undefined, () => undefined);
     return queueEntry;
+  }
+
+  private async resolveConversationalApprovalIngress(
+    ingress: CrossPlatformIngressMessage,
+    response: { approval_id: string; approved: boolean }
+  ): Promise<string> {
+    const broker = this.deps.approvalBroker;
+    if (!broker) {
+      return "Approval response could not be recorded because approval handling is unavailable.";
+    }
+    const origin = createApprovalOriginFromIngress(ingress);
+    if (!origin) {
+      return "Approval response could not be recorded because the conversation origin is incomplete.";
+    }
+    const resolved = await broker.resolveConversationalApproval(
+      response.approval_id,
+      response.approved,
+      origin
+    );
+    return resolved
+      ? "Approval response recorded."
+      : "Approval response did not match an active approval for this conversation.";
   }
 
   handleIncomingMessage(input: CrossPlatformIncomingChatMessage): Promise<string> {
@@ -474,9 +508,6 @@ export class CrossPlatformChatSessionManager {
     }
 
     const cwd = resolveGitRoot(cwdOverride?.trim() || process.cwd());
-    const runner = new ChatRunner(this.deps);
-    runner.startSession(cwd);
-
     const now = new Date().toISOString();
     const info: CrossPlatformChatSessionInfo = {
       session_key: sessionKey,
@@ -489,6 +520,13 @@ export class CrossPlatformChatSessionManager {
       last_used_at: now,
       metadata: {},
     };
+    const approvalFn = this.createApprovalFn(info);
+    const runner = new ChatRunner({
+      ...this.deps,
+      approvalFn: approvalFn ?? this.deps.approvalFn,
+      runtimeControlApprovalFn: approvalFn ?? this.deps.runtimeControlApprovalFn,
+    });
+    runner.startSession(cwd);
 
     const created: ManagedChatSession = {
       runner,
@@ -498,6 +536,55 @@ export class CrossPlatformChatSessionManager {
     };
     this.sessions.set(sessionKey, created);
     return created;
+  }
+
+  private createApprovalFn(info: CrossPlatformChatSessionInfo): ((description: string) => Promise<boolean>) | null {
+    const broker = this.deps.approvalBroker;
+    if (!broker) {
+      return null;
+    }
+    return async (description: string) => {
+      const origin = createApprovalOriginFromSessionInfo(info);
+      if (!origin) {
+        return false;
+      }
+      const goalId = typeof info.metadata.goal_id === "string" && info.metadata.goal_id.trim()
+        ? info.metadata.goal_id.trim()
+        : "chat";
+      return broker.requestConversationalApproval(goalId, {
+        id: info.last_message_id ?? info.session_key,
+        description,
+        action: "chat_approval",
+      }, {
+        origin,
+        deliverConversationalApproval: async ({ prompt }) => {
+          const handler = this.activeApprovalEventHandlers.get(info.session_key);
+          if (!handler) {
+            return {
+              delivered: false,
+              reason: "originating_conversation_unreachable",
+            };
+          }
+          try {
+            await handler({
+              type: "activity",
+              kind: "checkpoint",
+              message: prompt,
+              sourceId: `approval:${info.last_message_id ?? info.session_key}`,
+              runId: info.session_key,
+              turnId: info.last_message_id ?? info.session_key,
+              createdAt: new Date().toISOString(),
+            });
+            return { delivered: true };
+          } catch (err) {
+            return {
+              delivered: false,
+              reason: err instanceof Error ? err.message : "originating_conversation_unreachable",
+            };
+          }
+        },
+      });
+    };
   }
 
   private async executeInSession(
@@ -555,6 +642,7 @@ export class CrossPlatformChatSessionManager {
     const previousOnEvent = session.runner.onEvent;
     if (options.onEvent) {
       const handler = options.onEvent;
+      this.activeApprovalEventHandlers.set(session.info.session_key, handler);
       const upstream = this.deps.onEvent;
       session.runner.onEvent = (event: ChatEvent) => {
         safeInvoke(handler, event);
@@ -563,6 +651,7 @@ export class CrossPlatformChatSessionManager {
         }
       };
     } else {
+      this.activeApprovalEventHandlers.delete(session.info.session_key);
       session.runner.onEvent = undefined;
     }
 
@@ -574,9 +663,76 @@ export class CrossPlatformChatSessionManager {
         selectedRoute
       );
     } finally {
+      this.activeApprovalEventHandlers.delete(session.info.session_key);
       session.runner.onEvent = previousOnEvent;
     }
   }
+}
+
+export function createApprovalOriginFromSessionInfo(
+  info: CrossPlatformChatSessionInfo
+): ApprovalOrigin | null {
+  const replyTarget = info.active_reply_target;
+  const channel = normalizeIdentity(
+    replyTarget?.platform
+    ?? replyTarget?.channel
+    ?? replyTarget?.surface
+    ?? info.platform
+  );
+  const conversationId = normalizeIdentity(
+    replyTarget?.conversation_id
+    ?? info.conversation_id
+    ?? info.identity_key
+    ?? info.session_key
+  );
+  if (!channel || !conversationId) {
+    return null;
+  }
+  const userId = normalizeIdentity(replyTarget?.user_id ?? info.user_id) ?? undefined;
+  const turnId = normalizeIdentity(replyTarget?.message_id ?? info.last_message_id) ?? undefined;
+  return {
+    channel,
+    conversation_id: conversationId,
+    ...(userId ? { user_id: userId } : {}),
+    session_id: info.session_key,
+    ...(turnId ? { turn_id: turnId } : {}),
+    reply_target: {
+      ...replyTarget,
+      metadata: replyTarget?.metadata ? { ...replyTarget.metadata } : undefined,
+    },
+  };
+}
+
+function createApprovalOriginFromIngress(
+  ingress: CrossPlatformIngressMessage
+): ApprovalOrigin | null {
+  const channel = normalizeIdentity(
+    ingress.replyTarget.platform
+    ?? ingress.replyTarget.channel
+    ?? ingress.replyTarget.surface
+    ?? ingress.platform
+  );
+  const conversationId = normalizeIdentity(
+    ingress.replyTarget.conversation_id
+    ?? ingress.conversation_id
+    ?? ingress.identity_key
+  );
+  const userId = normalizeIdentity(ingress.replyTarget.user_id ?? ingress.user_id) ?? undefined;
+  const turnId = normalizeIdentity(ingress.replyTarget.message_id ?? ingress.message_id) ?? undefined;
+  if (!channel || !conversationId || !userId || !turnId) {
+    return null;
+  }
+  return {
+    channel,
+    conversation_id: conversationId,
+    user_id: userId,
+    session_id: buildSessionKeyFromParts(ingress),
+    turn_id: turnId,
+    reply_target: {
+      ...ingress.replyTarget,
+      metadata: cloneMetadata(ingress.replyTarget.metadata),
+    },
+  };
 }
 
 let globalManagerPromise: Promise<CrossPlatformChatSessionManager> | null = null;
@@ -673,6 +829,11 @@ async function createGlobalCrossPlatformChatSessionManager(): Promise<CrossPlatf
       })
     : undefined;
 
+  const runtimeRoot = path.join(stateManager.getBaseDir(), "runtime");
+  const approvalBroker = new ApprovalBroker({
+    store: new ApprovalStore(createRuntimeStorePaths(runtimeRoot)),
+  });
+
   return new CrossPlatformChatSessionManager({
     stateManager,
     adapter,
@@ -681,8 +842,9 @@ async function createGlobalCrossPlatformChatSessionManager(): Promise<CrossPlatf
     toolExecutor,
     chatAgentLoopRunner,
     reviewAgentLoopRunner,
+    approvalBroker,
     runtimeControlService: new RuntimeControlService({
-      runtimeRoot: path.join(stateManager.getBaseDir(), "runtime"),
+      runtimeRoot,
       stateManager,
       executor: createDaemonRuntimeControlExecutor({
         baseDir: stateManager.getBaseDir(),

--- a/src/runtime/__tests__/approval-broker.test.ts
+++ b/src/runtime/__tests__/approval-broker.test.ts
@@ -190,4 +190,244 @@ describe("ApprovalBroker", () => {
     expect(resolved.state).toBe("denied");
     expect(resolved.response_channel).toBe("http");
   });
+
+  it("routes conversational approvals to the originating channel with structured context", async () => {
+    tmpDir = makeTempDir();
+    const store = new ApprovalStore(tmpDir);
+    const delivered = vi.fn(async () => ({ delivered: true }));
+    const broadcast = vi.fn();
+    const origin = {
+      channel: "slack",
+      conversation_id: "thread-1",
+      user_id: "user-1",
+      session_id: "session-1",
+      turn_id: "turn-1",
+      reply_target: { channel: "C1", thread_ts: "1700.1" },
+    };
+    const broker = new ApprovalBroker({
+      store,
+      broadcast,
+      deliverConversationalApproval: delivered,
+      createId: () => "approval-conversation",
+    });
+
+    const request = broker.requestConversationalApproval("goal-1", {
+      id: "task-3",
+      description: "Deploy production changes",
+      action: "deploy",
+    }, {
+      origin,
+    });
+
+    await waitForBroadcast(broadcast, "approval_required", "approval-conversation");
+    expect(delivered).toHaveBeenCalledWith({
+      record: expect.objectContaining({
+        approval_id: "approval-conversation",
+        origin,
+        payload: {
+          task: {
+            id: "task-3",
+            description: "Deploy production changes",
+            action: "deploy",
+          },
+        },
+      }),
+      origin,
+      prompt: expect.stringContaining("Deploy production changes"),
+    });
+    expect(broadcast).toHaveBeenCalledWith(
+      "approval_required",
+      expect.objectContaining({
+        requestId: "approval-conversation",
+        origin,
+        prompt: expect.stringContaining("Approval ID: approval-conversation"),
+      })
+    );
+
+    await expect(broker.resolveConversationalApproval("approval-conversation", true, origin)).resolves.toBe(true);
+    await expect(request).resolves.toBe(true);
+    const resolved = await store.loadResolved("approval-conversation");
+    expect(resolved).toMatchObject({
+      state: "approved",
+      response_channel: "slack",
+      origin,
+    });
+  });
+
+  it("does not resolve conversational approvals from stale or mismatched origins", async () => {
+    tmpDir = makeTempDir();
+    const store = new ApprovalStore(tmpDir);
+    const origin = {
+      channel: "telegram",
+      conversation_id: "chat-1",
+      user_id: "user-1",
+      session_id: "session-current",
+      turn_id: "turn-current",
+    };
+    const broker = new ApprovalBroker({
+      store,
+      deliverConversationalApproval: async () => ({ delivered: true }),
+      createId: () => "approval-bound",
+    });
+
+    const request = broker.requestConversationalApproval("goal-1", {
+      id: "task-bound",
+      description: "Delete remote artifact",
+      action: "delete",
+    }, {
+      origin,
+    });
+    await waitForFile(createRuntimeStorePaths(tmpDir).approvalPendingPath("approval-bound"));
+
+    await expect(broker.resolveConversationalApproval("approval-bound", true, {
+      ...origin,
+      channel: "slack",
+    })).resolves.toBe(false);
+    await expect(broker.resolveConversationalApproval("approval-bound", true, {
+      ...origin,
+      user_id: "user-2",
+    })).resolves.toBe(false);
+    await expect(broker.resolveConversationalApproval("approval-bound", true, {
+      ...origin,
+      turn_id: "turn-previous",
+    })).resolves.toBe(false);
+    expect(await store.loadPending("approval-bound")).toMatchObject({ state: "pending", origin });
+
+    await expect(broker.resolveConversationalApproval("approval-bound", false, origin)).resolves.toBe(true);
+    await expect(request).resolves.toBe(false);
+  });
+
+  it("does not resolve conversational approvals when binding metadata is incomplete", async () => {
+    tmpDir = makeTempDir();
+    const store = new ApprovalStore(tmpDir);
+    const broker = new ApprovalBroker({
+      store,
+      deliverConversationalApproval: async () => ({ delivered: true }),
+      createId: () => "approval-incomplete-origin",
+    });
+
+    const request = broker.requestConversationalApproval("goal-1", {
+      id: "task-incomplete-origin",
+      description: "Restart daemon",
+      action: "restart",
+    }, {
+      origin: {
+        channel: "slack",
+        conversation_id: "thread-1",
+      },
+    });
+    await waitForFile(createRuntimeStorePaths(tmpDir).approvalPendingPath("approval-incomplete-origin"));
+
+    await expect(broker.resolveConversationalApproval("approval-incomplete-origin", true, {
+      channel: "slack",
+      conversation_id: "thread-1",
+      user_id: "user-1",
+      session_id: "session-1",
+      turn_id: "turn-1",
+    })).resolves.toBe(false);
+    expect(await store.loadPending("approval-incomplete-origin")).toMatchObject({
+      state: "pending",
+      origin: {
+        channel: "slack",
+        conversation_id: "thread-1",
+      },
+    });
+
+    await expect(broker.resolveApproval("approval-incomplete-origin", false, "system")).resolves.toBe(false);
+    await broker.stop();
+    void request.catch(() => undefined);
+  });
+
+  it("does not let generic approval channels resolve origin-bound approvals", async () => {
+    tmpDir = makeTempDir();
+    const store = new ApprovalStore(tmpDir);
+    const origin = {
+      channel: "slack",
+      conversation_id: "thread-1",
+      user_id: "user-1",
+      session_id: "session-1",
+      turn_id: "turn-1",
+    };
+    const broker = new ApprovalBroker({
+      store,
+      deliverConversationalApproval: async () => ({ delivered: true }),
+      createId: () => "approval-origin-only",
+    });
+
+    const request = broker.requestConversationalApproval("goal-1", {
+      id: "task-origin-only",
+      description: "Deploy production changes",
+      action: "deploy",
+    }, {
+      origin,
+    });
+    await waitForFile(createRuntimeStorePaths(tmpDir).approvalPendingPath("approval-origin-only"));
+
+    await expect(broker.resolveApproval("approval-origin-only", true, "http")).resolves.toBe(false);
+    expect(await store.loadPending("approval-origin-only")).toMatchObject({ state: "pending", origin });
+
+    await expect(broker.resolveConversationalApproval("approval-origin-only", false, origin)).resolves.toBe(true);
+    await expect(request).resolves.toBe(false);
+  });
+
+  it("denies conversational approvals when the originating channel is unreachable", async () => {
+    tmpDir = makeTempDir();
+    const store = new ApprovalStore(tmpDir);
+    const broker = new ApprovalBroker({
+      store,
+      deliverConversationalApproval: async () => ({
+        delivered: false,
+        reason: "channel_unreachable",
+      }),
+      createId: () => "approval-undelivered",
+    });
+
+    const request = broker.requestConversationalApproval("goal-1", {
+      id: "task-undelivered",
+      description: "Publish external report",
+      action: "publish",
+    }, {
+      origin: {
+        channel: "discord",
+        conversation_id: "thread-1",
+        user_id: "user-1",
+      },
+    });
+
+    await expect(request).resolves.toBe(false);
+    const resolved = await store.loadResolved("approval-undelivered");
+    expect(resolved).toMatchObject({
+      state: "denied",
+      response_channel: "discord",
+    });
+  });
+
+  it("denies conversational approvals when no delivery surface is configured", async () => {
+    tmpDir = makeTempDir();
+    const store = new ApprovalStore(tmpDir);
+    const broker = new ApprovalBroker({
+      store,
+      createId: () => "approval-no-delivery",
+    });
+
+    const request = broker.requestConversationalApproval("goal-1", {
+      id: "task-no-delivery",
+      description: "Rotate production secret",
+      action: "rotate_secret",
+    }, {
+      origin: {
+        channel: "slack",
+        conversation_id: "thread-1",
+        user_id: "user-1",
+        session_id: "session-1",
+        turn_id: "turn-1",
+      },
+    });
+
+    await expect(request).resolves.toBe(false);
+    expect(await store.loadResolved("approval-no-delivery")).toMatchObject({
+      state: "denied",
+      response_channel: "slack",
+    });
+  });
 });

--- a/src/runtime/approval-broker.ts
+++ b/src/runtime/approval-broker.ts
@@ -1,6 +1,6 @@
 import type { Logger } from "./logger.js";
 import { ApprovalStore } from "./store/approval-store.js";
-import type { ApprovalRecord } from "./store/runtime-schemas.js";
+import type { ApprovalOrigin, ApprovalRecord } from "./store/runtime-schemas.js";
 
 export interface ApprovalTaskRequest {
   id: string;
@@ -14,12 +14,37 @@ export interface ApprovalRequiredEvent {
   task: ApprovalTaskRequest;
   expiresAt: number;
   restored?: boolean;
+  origin?: ApprovalOrigin;
+  prompt?: string;
+}
+
+export interface ConversationalApprovalDelivery {
+  delivered: boolean;
+  reason?: string;
+}
+
+export interface ConversationalApprovalRequest {
+  record: ApprovalRecord;
+  origin: ApprovalOrigin;
+  prompt: string;
+}
+
+export interface ConversationalApprovalOptions {
+  origin: ApprovalOrigin;
+  timeoutMs?: number;
+  approvalId?: string;
+  deliverConversationalApproval?: (
+    request: ConversationalApprovalRequest
+  ) => Promise<ConversationalApprovalDelivery> | ConversationalApprovalDelivery;
 }
 
 export interface ApprovalBrokerOptions {
   store: ApprovalStore;
   logger?: Logger;
   broadcast?: (eventType: string, data: unknown) => void;
+  deliverConversationalApproval?: (
+    request: ConversationalApprovalRequest
+  ) => Promise<ConversationalApprovalDelivery> | ConversationalApprovalDelivery;
   now?: () => number;
   createId?: () => string;
   defaultTimeoutMs?: number;
@@ -37,6 +62,9 @@ export class ApprovalBroker {
   private readonly store: ApprovalStore;
   private readonly logger?: Logger;
   private broadcast?: (eventType: string, data: unknown) => void;
+  private readonly deliverConversationalApproval?: (
+    request: ConversationalApprovalRequest
+  ) => Promise<ConversationalApprovalDelivery> | ConversationalApprovalDelivery;
   private readonly now: () => number;
   private readonly createId: () => string;
   private readonly defaultTimeoutMs: number;
@@ -47,6 +75,7 @@ export class ApprovalBroker {
     this.store = options.store;
     this.logger = options.logger;
     this.broadcast = options.broadcast;
+    this.deliverConversationalApproval = options.deliverConversationalApproval;
     this.now = options.now ?? (() => Date.now());
     this.createId =
       options.createId ??
@@ -107,26 +136,32 @@ export class ApprovalBroker {
       payload: { task },
     };
 
-    return new Promise<boolean>((resolve, reject) => {
-      const ready = this.store.savePending(record).then(
-        () => {
-          const session = this.pending.get(approvalId);
-          if (session && !session.finalizing) {
-            this.emitApprovalRequired(record, false);
-          }
-        },
-        (err) => {
-          const session = this.pending.get(approvalId);
-          if (session) {
-            clearTimeout(session.timer);
-            this.pending.delete(approvalId);
-          }
-          reject(err);
-        }
-      );
-      this.trackPending(record, resolve, ready);
-      void ready.catch(() => undefined);
-    });
+    return this.trackApprovalRequest(record);
+  }
+
+  async requestConversationalApproval(
+    goalId: string,
+    task: ApprovalTaskRequest,
+    options: ConversationalApprovalOptions
+  ): Promise<boolean> {
+    await this.start();
+
+    const approvalId = options.approvalId ?? this.createId();
+    const timeoutMs = options.timeoutMs ?? this.defaultTimeoutMs;
+    const createdAt = this.now();
+    const record: ApprovalRecord = {
+      approval_id: approvalId,
+      goal_id: goalId,
+      request_envelope_id: approvalId,
+      correlation_id: approvalId,
+      state: "pending",
+      created_at: createdAt,
+      expires_at: createdAt + timeoutMs,
+      origin: options.origin,
+      payload: { task },
+    };
+
+    return this.trackApprovalRequest(record, options.deliverConversationalApproval);
   }
 
   async resolveApproval(
@@ -134,10 +169,31 @@ export class ApprovalBroker {
     approved: boolean,
     responseChannel = "http"
   ): Promise<boolean> {
+    const pendingRecord = this.pending.get(approvalId)?.record ?? await this.store.loadPending(approvalId);
+    if (pendingRecord?.origin) {
+      return false;
+    }
     const resolved = await this.finalizeApproval(approvalId, {
       state: approved ? "approved" : "denied",
       approved,
       responseChannel,
+    });
+    return resolved !== null;
+  }
+
+  async resolveConversationalApproval(
+    approvalId: string,
+    approved: boolean,
+    origin: ApprovalOrigin
+  ): Promise<boolean> {
+    const record = await this.store.loadPending(approvalId);
+    if (record === null || !approvalOriginMatches(record.origin, origin)) {
+      return false;
+    }
+    const resolved = await this.finalizeApproval(approvalId, {
+      state: approved ? "approved" : "denied",
+      approved,
+      responseChannel: origin.channel,
     });
     return resolved !== null;
   }
@@ -175,6 +231,90 @@ export class ApprovalBroker {
     }, msUntilExpiry);
 
     this.pending.set(record.approval_id, { record, resolve, timer, ready });
+  }
+
+  private trackApprovalRequest(
+    record: ApprovalRecord,
+    deliverOverride?: (
+      request: ConversationalApprovalRequest
+    ) => Promise<ConversationalApprovalDelivery> | ConversationalApprovalDelivery
+  ): Promise<boolean> {
+    return new Promise<boolean>((resolve, reject) => {
+      const ready = this.store.savePending(record).then(
+        () => {
+          const session = this.pending.get(record.approval_id);
+          if (!session || session.finalizing) {
+            return;
+          }
+          this.emitApprovalRequired(record, false);
+          void this.deliverIfConversational(record, deliverOverride).catch((err) => {
+            this.logger?.error("ApprovalBroker: conversational approval delivery failed", {
+              approvalId: record.approval_id,
+              error: String(err),
+            });
+          });
+        },
+        (err) => {
+          const session = this.pending.get(record.approval_id);
+          if (session) {
+            clearTimeout(session.timer);
+            this.pending.delete(record.approval_id);
+          }
+          reject(err);
+        }
+      );
+      this.trackPending(record, resolve, ready);
+      void ready.catch(() => undefined);
+    });
+  }
+
+  private async deliverIfConversational(
+    record: ApprovalRecord,
+    deliverOverride?: (
+      request: ConversationalApprovalRequest
+    ) => Promise<ConversationalApprovalDelivery> | ConversationalApprovalDelivery
+  ): Promise<void> {
+    if (!record.origin) {
+      return;
+    }
+
+    const deliver = deliverOverride ?? this.deliverConversationalApproval;
+    if (!deliver) {
+      await this.finalizeApproval(record.approval_id, {
+        state: "denied",
+        approved: false,
+        reason: "approval_channel_unreachable",
+        responseChannel: record.origin.channel,
+      });
+      return;
+    }
+
+    try {
+      const delivery = await deliver({
+        record,
+        origin: record.origin,
+        prompt: renderConversationalApprovalPrompt(record),
+      });
+      if (!delivery.delivered) {
+        await this.finalizeApproval(record.approval_id, {
+          state: "denied",
+          approved: false,
+          reason: delivery.reason ?? "approval_channel_unreachable",
+          responseChannel: record.origin.channel,
+        });
+      }
+    } catch (err) {
+      this.logger?.error("ApprovalBroker: conversational approval delivery failed", {
+        approvalId: record.approval_id,
+        error: String(err),
+      });
+      await this.finalizeApproval(record.approval_id, {
+        state: "denied",
+        approved: false,
+        reason: "approval_channel_unreachable",
+        responseChannel: record.origin.channel,
+      });
+    }
   }
 
   private async finalizeApproval(
@@ -228,12 +368,43 @@ export class ApprovalBroker {
 
   private toApprovalRequiredEvent(record: ApprovalRecord, restored: boolean): ApprovalRequiredEvent {
     const payload = record.payload as { task?: ApprovalTaskRequest };
+    const prompt = record.origin ? renderConversationalApprovalPrompt(record) : undefined;
     return {
       requestId: record.approval_id,
       goalId: record.goal_id,
       task: payload.task ?? { id: "", description: "", action: "" },
       expiresAt: record.expires_at,
       restored,
+      ...(record.origin ? { origin: record.origin } : {}),
+      ...(prompt ? { prompt } : {}),
     };
   }
+}
+
+function renderConversationalApprovalPrompt(record: ApprovalRecord): string {
+  const payload = record.payload as { task?: ApprovalTaskRequest };
+  const task = payload.task ?? { id: record.approval_id, description: "Approval required", action: "unknown" };
+  return [
+    "Approval required.",
+    `Action: ${task.action}`,
+    `Target: ${task.id}`,
+    `Details: ${task.description}`,
+    `Approval ID: ${record.approval_id}`,
+    "Reply in this conversation to approve, reject, or ask for clarification.",
+  ].join("\n");
+}
+
+function approvalOriginMatches(expected: ApprovalOrigin | undefined, actual: ApprovalOrigin): boolean {
+  if (!expected) {
+    return false;
+  }
+  return expected.channel === actual.channel
+    && expected.conversation_id === actual.conversation_id
+    && requiredFieldMatches(expected.user_id, actual.user_id)
+    && requiredFieldMatches(expected.session_id, actual.session_id)
+    && requiredFieldMatches(expected.turn_id, actual.turn_id);
+}
+
+function requiredFieldMatches(expected: string | undefined, actual: string | undefined): boolean {
+  return expected !== undefined && expected === actual;
 }

--- a/src/runtime/store/runtime-schemas.ts
+++ b/src/runtime/store/runtime-schemas.ts
@@ -100,6 +100,16 @@ export type GoalLeaseRecord = z.infer<typeof GoalLeaseRecordSchema>;
 export const ApprovalStateSchema = z.enum(["pending", "approved", "denied", "expired", "cancelled"]);
 export type ApprovalState = z.infer<typeof ApprovalStateSchema>;
 
+export const ApprovalOriginSchema = z.object({
+  channel: z.string().min(1),
+  conversation_id: z.string().min(1),
+  user_id: z.string().min(1).optional(),
+  session_id: z.string().min(1).optional(),
+  turn_id: z.string().min(1).optional(),
+  reply_target: z.unknown().optional(),
+});
+export type ApprovalOrigin = z.infer<typeof ApprovalOriginSchema>;
+
 export const ApprovalRecordSchema = z.object({
   approval_id: z.string(),
   goal_id: z.string().optional(),
@@ -110,6 +120,7 @@ export const ApprovalRecordSchema = z.object({
   expires_at: z.number().int().nonnegative(),
   resolved_at: z.number().int().nonnegative().optional(),
   response_channel: z.string().optional(),
+  origin: ApprovalOriginSchema.optional(),
   payload: z.unknown(),
 });
 export type ApprovalRecord = z.infer<typeof ApprovalRecordSchema>;


### PR DESCRIPTION
Closes #968

## Summary
- adds durable approval origin metadata and broker APIs for origin-bound conversational approvals
- routes cross-platform chat approval prompts back through the originating conversation event stream
- handles typed conversational approval replies through ingress without using mechanical approval channels, and keeps generic approval resolution from resolving origin-bound requests
- fails closed when the originating conversation cannot receive the prompt

## Verification
- npm run typecheck
- npx vitest run src/runtime/__tests__/approval-broker.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts
- npm run lint:boundaries (passes with existing warnings only)
- npm run test:changed
- git diff --check

## Known unresolved risks
- Natural-language approval reply classification is still intentionally left to #969; this PR only accepts typed approvalResponse payloads from the conversation ingress.
- Mechanical approval UI removal is intentionally left to #970 after conversational parity is merged.