### PR TITLE
feat(approvals): classify conversational approval replies

### DIFF
--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -421,6 +421,186 @@ describe("CrossPlatformChatSessionManager", () => {
     }
   });
 
+  it("parses a same-conversation natural-language approval reply through the production ingress path", async () => {
+    const tmpDir = makeTempDir();
+    const events: string[] = [];
+    try {
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "approval-natural-language",
+      });
+      const runtimeControlService = {
+        request: vi.fn(async (request: {
+          approvalFn?: (description: string) => Promise<boolean>;
+        }) => {
+          const approved = await request.approvalFn?.("Restart the resident daemon.");
+          return {
+            success: approved === true,
+            message: approved === true ? "restart queued" : "not approved",
+            operationId: "op-natural-language",
+            state: approved === true ? "acknowledged" as const : "blocked" as const,
+          };
+        }),
+      };
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        llmClient: createMockLLMClient([
+          JSON.stringify({
+            intent: "restart_daemon",
+            reason: "PulSeed を再起動して",
+          }),
+          JSON.stringify({
+            decision: "approve",
+            confidence: 0.94,
+            rationale: "The reply explicitly authorizes the active restart request.",
+          }),
+        ]),
+        runtimeControlService,
+        approvalBroker,
+      }));
+
+      const resultPromise = manager.processIncomingMessage({
+        text: "PulSeed を再起動して",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        onEvent: (event) => {
+          if (event.type === "activity") {
+            events.push(event.message);
+          }
+        },
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      });
+
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline && !events.some((message) => message.includes("approval-natural-language"))) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      await expect(manager.processIncomingMessage({
+        text: "問題ありません。進めてください",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.3",
+        cwd: "/repo",
+      })).resolves.toBe("Approval response recorded.");
+
+      await expect(resultPromise).resolves.toBe("restart queued");
+      await expect(store.loadResolved("approval-natural-language")).resolves.toMatchObject({
+        state: "approved",
+        response_channel: "slack",
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("keeps approvals pending for clarification replies and rejects wrong-context replies", async () => {
+    const tmpDir = makeTempDir();
+    try {
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "approval-clarify",
+      });
+      const runtimeControlService = {
+        request: vi.fn(async (request: {
+          approvalFn?: (description: string) => Promise<boolean>;
+        }) => {
+          const approved = await request.approvalFn?.("Restart the resident daemon.");
+          return {
+            success: approved === true,
+            message: approved === true ? "restart queued" : "not approved",
+            operationId: "op-clarify",
+            state: approved === true ? "acknowledged" as const : "blocked" as const,
+          };
+        }),
+      };
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        llmClient: createMockLLMClient([
+          JSON.stringify({
+            intent: "restart_daemon",
+            reason: "PulSeed を再起動して",
+          }),
+          JSON.stringify({
+            decision: "clarify",
+            confidence: 0.92,
+            clarification: "Approval is still pending while the restart target is clarified.",
+          }),
+        ]),
+        runtimeControlService,
+        approvalBroker,
+      }));
+
+      const resultPromise = manager.processIncomingMessage({
+        text: "PulSeed を再起動して",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        onEvent: () => undefined,
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      });
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline && (await store.loadPending("approval-clarify")) === null) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      await expect(manager.processIncomingMessage({
+        text: "Before deciding, which daemon will restart?",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.3",
+        cwd: "/repo",
+      })).resolves.toBe("Approval is still pending while the restart target is clarified.");
+      await expect(store.loadPending("approval-clarify")).resolves.toMatchObject({
+        state: "pending",
+      });
+
+      await expect(manager.processIncomingMessage({
+        text: "",
+        platform: "slack",
+        identity_key: "workspace:U999",
+        conversation_id: "C123:1700.1",
+        sender_id: "U999",
+        message_id: "1700.4",
+        cwd: "/repo",
+        approvalResponse: {
+          approval_id: "approval-clarify",
+          approved: true,
+        },
+      })).resolves.toBe("Approval response did not match an active approval for this conversation.");
+      await expect(store.loadPending("approval-clarify")).resolves.toMatchObject({
+        state: "pending",
+      });
+
+      await approvalBroker.resolveConversationalApproval("approval-clarify", false, {
+        channel: "slack",
+        conversation_id: "C123:1700.1",
+        user_id: "U123",
+        session_id: "identity:workspace:U123",
+        turn_id: "1700.2",
+      });
+      await expect(resultPromise).resolves.toContain("not approved");
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
   it("fails closed when the originating conversation delivery handler rejects", async () => {
     const tmpDir = makeTempDir();
     try {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -106,7 +106,10 @@ export interface ChatRunnerDeps {
   chatAgentLoopRunner?: ChatAgentLoopRunner;
   reviewAgentLoopRunner?: Pick<ReviewAgentLoopRunner, "execute">;
   runtimeControlService?: Pick<RuntimeControlService, "request">;
-  approvalBroker?: Pick<ApprovalBroker, "requestConversationalApproval" | "resolveConversationalApproval">;
+  approvalBroker?: Pick<
+    ApprovalBroker,
+    "requestConversationalApproval" | "resolveConversationalApproval" | "findPendingConversationalApproval"
+  >;
   runtimeControlApprovalFn?: (description: string) => Promise<boolean>;
   runtimeReplyTarget?: RuntimeControlReplyTarget;
   runtimeControlActor?: RuntimeControlActor;

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -45,6 +45,7 @@ import {
 } from "../../runtime/control/index.js";
 import { ApprovalBroker } from "../../runtime/approval-broker.js";
 import { ApprovalStore, createRuntimeStorePaths } from "../../runtime/store/index.js";
+import { classifyConversationalApprovalDecision } from "../../runtime/conversational-approval-decision.js";
 import { registerGlobalCrossPlatformChatSessionManager } from "./cross-platform-session-global.js";
 import type { RuntimeControlActor } from "../../runtime/store/runtime-operation-schemas.js";
 import type { ApprovalOrigin } from "../../runtime/store/runtime-schemas.js";
@@ -354,6 +355,10 @@ export class CrossPlatformChatSessionManager {
     if (input.approvalResponse) {
       return this.resolveConversationalApprovalIngress(ingress, input.approvalResponse);
     }
+    const approvalReply = await this.tryResolveConversationalApprovalReply(ingress);
+    if (approvalReply) {
+      return approvalReply;
+    }
     const result = await this.executeIngress(ingress, input);
     return result.output;
   }
@@ -409,6 +414,54 @@ export class CrossPlatformChatSessionManager {
     return resolved
       ? "Approval response recorded."
       : "Approval response did not match an active approval for this conversation.";
+  }
+
+  private async tryResolveConversationalApprovalReply(
+    ingress: CrossPlatformIngressMessage
+  ): Promise<string | null> {
+    const broker = this.deps.approvalBroker;
+    if (!broker) {
+      return null;
+    }
+    const origin = createApprovalOriginFromIngress(ingress);
+    if (!origin) {
+      return null;
+    }
+    const lookup = await broker.findPendingConversationalApproval(origin);
+    if (lookup.status === "none") {
+      return null;
+    }
+    if (lookup.status === "ambiguous") {
+      return "Multiple active approvals match this conversation. Please use the specific approval response.";
+    }
+    const approval = lookup.approval;
+
+    const decision = await classifyConversationalApprovalDecision(ingress.text, {
+      approval,
+      replyOrigin: origin,
+      llmClient: this.deps.llmClient,
+      priorTurnState: this.describeLastRouteForApproval(ingress),
+    });
+    if (decision.decision === "approve" || decision.decision === "reject") {
+      const resolved = await broker.resolveConversationalApproval(
+        approval.approval_id,
+        decision.decision === "approve",
+        approval.origin ?? origin
+      );
+      return resolved
+        ? "Approval response recorded."
+        : "Approval response did not match an active approval for this conversation.";
+    }
+    if (decision.decision === "clarify") {
+      return decision.clarification ?? "Approval is still pending. Please clarify what you need before approving or rejecting.";
+    }
+    return decision.clarification ?? "Approval reply was ambiguous. The approval remains pending.";
+  }
+
+  private describeLastRouteForApproval(ingress: CrossPlatformIngressMessage): string {
+    const session = this.sessions.get(buildSessionKeyFromParts(ingress));
+    const route = session?.lastRoute;
+    return route ? JSON.stringify(route) : "none";
   }
 
   handleIncomingMessage(input: CrossPlatformIncomingChatMessage): Promise<string> {

--- a/src/runtime/__tests__/conversational-approval-decision.test.ts
+++ b/src/runtime/__tests__/conversational-approval-decision.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { classifyConversationalApprovalDecision } from "../conversational-approval-decision.js";
+import type { ApprovalRecord } from "../store/runtime-schemas.js";
+import { createSingleMockLLMClient } from "../../../tests/helpers/mock-llm.js";
+
+const approval: ApprovalRecord = {
+  approval_id: "approval-1",
+  goal_id: "goal-1",
+  request_envelope_id: "approval-1",
+  correlation_id: "approval-1",
+  state: "pending",
+  created_at: 10,
+  expires_at: 10_000,
+  origin: {
+    channel: "slack",
+    conversation_id: "thread-1",
+    user_id: "user-1",
+    session_id: "session-1",
+    turn_id: "turn-1",
+  },
+  payload: {
+    task: {
+      id: "production-deploy",
+      description: "Deploy production changes",
+      action: "deploy",
+    },
+  },
+};
+
+describe("classifyConversationalApprovalDecision", () => {
+  it("accepts exact protocol approve and reject commands without model classification", async () => {
+    await expect(classifyConversationalApprovalDecision("/approve", {
+      approval,
+      replyOrigin: approval.origin!,
+    })).resolves.toMatchObject({ decision: "approve", confidence: 1 });
+    await expect(classifyConversationalApprovalDecision("/reject", {
+      approval,
+      replyOrigin: approval.origin!,
+    })).resolves.toMatchObject({ decision: "reject", confidence: 1 });
+  });
+
+  it("classifies paraphrased multilingual approval replies through the shared contract", async () => {
+    const decision = await classifyConversationalApprovalDecision("問題ありません。進めてください", {
+      approval,
+      replyOrigin: approval.origin!,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "approve",
+        confidence: 0.93,
+        rationale: "Explicit approval for the active deployment request.",
+      })),
+    });
+
+    expect(decision).toMatchObject({ decision: "approve", confidence: 0.93 });
+  });
+
+  it("keeps clarification separate from approval or rejection", async () => {
+    const decision = await classifyConversationalApprovalDecision("Before deciding, what target will change?", {
+      approval,
+      replyOrigin: approval.origin!,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "clarify",
+        confidence: 0.91,
+        clarification: "The approval is still pending while the target is clarified.",
+      })),
+    });
+
+    expect(decision).toMatchObject({
+      decision: "clarify",
+      clarification: "The approval is still pending while the target is clarified.",
+    });
+  });
+
+  it("downgrades low-confidence replies to unknown", async () => {
+    const decision = await classifyConversationalApprovalDecision("sounds fine I guess", {
+      approval,
+      replyOrigin: approval.origin!,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "approve",
+        confidence: 0.42,
+        clarification: "Please explicitly approve or reject the active request.",
+      })),
+    });
+
+    expect(decision).toMatchObject({
+      decision: "unknown",
+      confidence: 0,
+      clarification: "Please explicitly approve or reject the active request.",
+    });
+  });
+});

--- a/src/runtime/approval-broker.ts
+++ b/src/runtime/approval-broker.ts
@@ -38,6 +38,11 @@ export interface ConversationalApprovalOptions {
   ) => Promise<ConversationalApprovalDelivery> | ConversationalApprovalDelivery;
 }
 
+export type PendingConversationalApprovalLookup =
+  | { status: "found"; approval: ApprovalRecord }
+  | { status: "none" }
+  | { status: "ambiguous" };
+
 export interface ApprovalBrokerOptions {
   store: ApprovalStore;
   logger?: Logger;
@@ -196,6 +201,20 @@ export class ApprovalBroker {
       responseChannel: origin.channel,
     });
     return resolved !== null;
+  }
+
+  async findPendingConversationalApproval(origin: ApprovalOrigin): Promise<PendingConversationalApprovalLookup> {
+    await this.start();
+    const matches = (await this.store.listPending())
+      .filter((record) => conversationalApprovalOriginMatches(record.origin, origin))
+      .sort((a, b) => b.created_at - a.created_at);
+    if (matches.length === 0) {
+      return { status: "none" };
+    }
+    if (matches.length > 1) {
+      return { status: "ambiguous" };
+    }
+    return { status: "found", approval: matches[0]! };
   }
 
   getPendingApprovalEvents(): ApprovalRequiredEvent[] {
@@ -407,4 +426,14 @@ function approvalOriginMatches(expected: ApprovalOrigin | undefined, actual: App
 
 function requiredFieldMatches(expected: string | undefined, actual: string | undefined): boolean {
   return expected !== undefined && expected === actual;
+}
+
+function conversationalApprovalOriginMatches(expected: ApprovalOrigin | undefined, actual: ApprovalOrigin): boolean {
+  if (!expected) {
+    return false;
+  }
+  return expected.channel === actual.channel
+    && expected.conversation_id === actual.conversation_id
+    && requiredFieldMatches(expected.user_id, actual.user_id)
+    && requiredFieldMatches(expected.session_id, actual.session_id);
 }

--- a/src/runtime/conversational-approval-decision.ts
+++ b/src/runtime/conversational-approval-decision.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import type { ILLMClient } from "../base/llm/llm-client.js";
+import { getInternalIdentityPrefix } from "../base/config/identity-loader.js";
+import type { ApprovalOrigin, ApprovalRecord } from "./store/runtime-schemas.js";
+
+const MIN_CONVERSATIONAL_APPROVAL_CONFIDENCE = 0.7;
+
+export const ConversationalApprovalDecisionSchema = z.object({
+  decision: z.enum(["approve", "reject", "clarify", "unknown"]),
+  confidence: z.number().min(0).max(1),
+  clarification: z.string().optional(),
+  rationale: z.string().optional(),
+});
+
+export type ConversationalApprovalDecision = z.infer<typeof ConversationalApprovalDecisionSchema>;
+
+export interface ConversationalApprovalDecisionContext {
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;
+  approval: ApprovalRecord;
+  replyOrigin: ApprovalOrigin;
+  priorTurnState?: string;
+}
+
+export async function classifyConversationalApprovalDecision(
+  input: string,
+  context: ConversationalApprovalDecisionContext
+): Promise<ConversationalApprovalDecision> {
+  const commandDecision = parseExactApprovalCommand(input);
+  if (commandDecision) return commandDecision;
+
+  const trimmed = input.trim();
+  const llmClient = context.llmClient;
+  if (!trimmed || !llmClient) {
+    return unknownDecision("Approval reply classification is unavailable.");
+  }
+
+  try {
+    const response = await llmClient.sendMessage(
+      [{ role: "user", content: trimmed }],
+      { system: getConversationalApprovalDecisionPrompt(context), max_tokens: 600, temperature: 0 }
+    );
+    const parsed = llmClient.parseJSON(response.content, ConversationalApprovalDecisionSchema);
+    if (parsed.decision !== "unknown" && parsed.confidence < MIN_CONVERSATIONAL_APPROVAL_CONFIDENCE) {
+      return unknownDecision(parsed.clarification ?? "The approval reply was ambiguous.");
+    }
+    return parsed;
+  } catch {
+    return unknownDecision("Approval reply could not be classified.");
+  }
+}
+
+function parseExactApprovalCommand(input: string): ConversationalApprovalDecision | null {
+  const command = input.trim();
+  if (command === "/approve") {
+    return { decision: "approve", confidence: 1 };
+  }
+  if (command === "/reject") {
+    return { decision: "reject", confidence: 1 };
+  }
+  if (command === "/clarify") {
+    return { decision: "clarify", confidence: 1 };
+  }
+  return null;
+}
+
+function getConversationalApprovalDecisionPrompt(context: ConversationalApprovalDecisionContext): string {
+  return `${getInternalIdentityPrefix("assistant")} Classify the operator's reply inside one active conversational approval context.
+
+This is a safety decision. Use only the active approval context below as the guard. Do not approve from vague enthusiasm, acknowledgement, side comments, unrelated chat, stale approval IDs, or mismatched target context. Low-confidence replies must be unknown.
+
+Decision meanings:
+- approve: explicitly approves the active approval request.
+- reject: explicitly denies, rejects, cancels, or stops the active approval request.
+- clarify: asks a question or requests explanation while keeping the approval pending.
+- unknown: ambiguous, unrelated, stale, wrong-context, or too low-confidence.
+
+Active approval context:
+${describeApprovalContext(context.approval)}
+
+Reply origin:
+${JSON.stringify(context.replyOrigin, null, 2)}
+
+Prior turn state:
+${context.priorTurnState ?? "none"}
+
+Respond only as JSON:
+{
+  "decision": "approve" | "reject" | "clarify" | "unknown",
+  "confidence": 0.0-1.0,
+  "clarification": "short clarification prompt when clarify or unknown",
+  "rationale": "short rationale"
+}`;
+}
+
+function describeApprovalContext(approval: ApprovalRecord): string {
+  return JSON.stringify({
+    approval_id: approval.approval_id,
+    goal_id: approval.goal_id,
+    state: approval.state,
+    created_at: approval.created_at,
+    expires_at: approval.expires_at,
+    origin: approval.origin,
+    payload: approval.payload,
+  }, null, 2);
+}
+
+export function unknownDecision(clarification: string): ConversationalApprovalDecision {
+  return {
+    decision: "unknown",
+    confidence: 0,
+    clarification,
+  };
+}


### PR DESCRIPTION
Closes #969

## Summary
- adds a shared conversational approval decision contract for approve, reject, clarify, and unknown
- classifies freeform approval replies with structured model output against the active approval context, with exact slash commands limited to protocol shortcuts
- routes same-conversation replies through the approval layer before regular chat execution when one active approval matches the channel/user/session origin
- keeps clarify, unknown, wrong-context, and ambiguous multi-approval cases pending instead of executing

## Verification
- npm run typecheck
- npx vitest run src/runtime/__tests__/conversational-approval-decision.test.ts src/runtime/__tests__/approval-broker.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts
- npm run lint:boundaries (passes with existing warnings only)
- npm run test:changed
- git diff --check

## Known unresolved risks
- Mechanical approval UI removal remains intentionally scoped to #970 after this conversational parity PR lands.
- The shared classifier depends on the configured LLM for freeform replies; when unavailable or low-confidence it returns unknown and leaves approval pending.