### PR TITLE
fix(gateway): drain async chat events

### DIFF
--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -52,6 +52,14 @@ function getSessionPaths(stateManager: StateManager): string[] {
     .filter((path: string) => path.startsWith("chat/sessions/"));
 }
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
 describe("CrossPlatformChatSessionManager", () => {
   it("routes token-only setup follow-up through typed secret intake instead of adapter execution", async () => {
     const token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
@@ -184,6 +192,69 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(events.some((event) => event.type === "assistant_delta")).toBe(true);
     expect(events.some((event) => event.type === "assistant_final")).toBe(true);
     expect(events.at(-1)?.type).toBe("lifecycle_end");
+  });
+
+  it("drains async per-turn event delivery before returning to gateway callers", async () => {
+    const stateManager = makeMockStateManager();
+    const manager = new CrossPlatformChatSessionManager(makeDeps({ stateManager }));
+    const finalDelivery = createDeferred();
+    let finalHandlerEntered = false;
+    let finalDelivered = false;
+
+    const run = manager.processIncomingMessage({
+      text: "stream this gateway turn",
+      platform: "slack",
+      identity_key: "workspace:U123",
+      conversation_id: "C123:1700.1",
+      sender_id: "U123",
+      message_id: "1700.2",
+      cwd: "/repo",
+      onEvent: async (event) => {
+        if (event.type !== "assistant_final") return;
+        finalHandlerEntered = true;
+        await finalDelivery.promise;
+        finalDelivered = true;
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(finalHandlerEntered).toBe(true);
+    });
+    await expect(Promise.race([
+      run.then(() => "returned"),
+      Promise.resolve().then(() => "pending"),
+    ])).resolves.toBe("pending");
+
+    finalDelivery.resolve();
+    await expect(run).resolves.toBe("Task completed successfully.");
+    expect(finalDelivered).toBe(true);
+  });
+
+  it("isolates async event delivery failures and still returns the chat result", async () => {
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager: makeMockStateManager(),
+    }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = await manager.processIncomingMessage({
+      text: "stream this gateway turn",
+      platform: "discord",
+      conversation_id: "D123",
+      sender_id: "U123",
+      cwd: "/repo",
+      onEvent: async (event) => {
+        if (event.type === "assistant_final") {
+          throw new Error("discord delivery failed");
+        }
+      },
+    });
+
+    expect(result).toBe("Task completed successfully.");
+    expect(warnSpy).toHaveBeenCalledWith("[chat] event delivery failed", expect.objectContaining({
+      eventType: "assistant_final",
+      error: "discord delivery failed",
+    }));
+    warnSpy.mockRestore();
   });
 
   it("returns recovery guidance for gateway-visible failures", async () => {

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -297,15 +297,39 @@ function normalizeActor(
   };
 }
 
-function safeInvoke(handler: ChatEventHandler | undefined, event: ChatEvent): void {
+async function safeInvoke(handler: ChatEventHandler | undefined, event: ChatEvent): Promise<void> {
   if (!handler) return;
   try {
-    const result = handler(event);
-    if (result && typeof (result as Promise<void>).catch === "function") {
-      void (result as Promise<void>).catch(() => undefined);
-    }
-  } catch {
+    await handler(event);
+  } catch (err) {
     // Event streaming should not break chat delivery.
+    console.warn("[chat] event delivery failed", {
+      eventType: event.type,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+class ChatEventDeliveryQueue {
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly handler: ChatEventHandler | undefined,
+    private readonly upstream: ChatEventHandler | undefined
+  ) {}
+
+  dispatch = (event: ChatEvent): Promise<void> => {
+    this.queue = this.queue.then(async () => {
+      await safeInvoke(this.handler, event);
+      if (this.upstream && this.upstream !== this.handler) {
+        await safeInvoke(this.upstream, event);
+      }
+    });
+    return this.queue;
+  };
+
+  async drain(): Promise<void> {
+    await this.queue;
   }
 }
 
@@ -383,19 +407,15 @@ export class CrossPlatformChatSessionManager {
     }
     const session = this.getOrCreateSession(ingress, input.cwd);
     const previousOnEvent = session.runner.onEvent;
+    let deliveryQueue: ChatEventDeliveryQueue | null = null;
     if (input.onEvent) {
-      const handler = input.onEvent;
-      const upstream = this.deps.onEvent;
-      session.runner.onEvent = (event: ChatEvent) => {
-        safeInvoke(handler, event);
-        if (upstream && upstream !== handler) {
-          safeInvoke(upstream, event);
-        }
-      };
+      deliveryQueue = new ChatEventDeliveryQueue(input.onEvent, this.deps.onEvent);
+      session.runner.onEvent = deliveryQueue.dispatch;
     }
     try {
       return await session.runner.interruptAndRedirect(input.text, session.info.cwd, input.timeoutMs);
     } finally {
+      await deliveryQueue?.drain();
       session.runner.onEvent = previousOnEvent;
     }
   }
@@ -709,16 +729,11 @@ export class CrossPlatformChatSessionManager {
     session.lastRoute = selectedRoute;
 
     const previousOnEvent = session.runner.onEvent;
+    let deliveryQueue: ChatEventDeliveryQueue | null = null;
     if (options.onEvent) {
-      const handler = options.onEvent;
-      this.activeApprovalEventHandlers.set(session.info.session_key, handler);
-      const upstream = this.deps.onEvent;
-      session.runner.onEvent = (event: ChatEvent) => {
-        safeInvoke(handler, event);
-        if (upstream && upstream !== handler) {
-          safeInvoke(upstream, event);
-        }
-      };
+      deliveryQueue = new ChatEventDeliveryQueue(options.onEvent, this.deps.onEvent);
+      this.activeApprovalEventHandlers.set(session.info.session_key, options.onEvent);
+      session.runner.onEvent = deliveryQueue.dispatch;
     } else {
       this.activeApprovalEventHandlers.delete(session.info.session_key);
       session.runner.onEvent = undefined;
@@ -732,6 +747,7 @@ export class CrossPlatformChatSessionManager {
         selectedRoute
       );
     } finally {
+      await deliveryQueue?.drain();
       this.activeApprovalEventHandlers.delete(session.info.session_key);
       session.runner.onEvent = previousOnEvent;
     }

--- a/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
@@ -185,8 +185,89 @@ describe("TelegramGatewayAdapter", () => {
       expect(sentMessages).toContain("Read Telegram config: Config file does not exist yet.");
       expect(sentMessages).toContain("Final setup guidance.");
     });
+    expect(sentMessages.filter((message) => message === "Final setup guidance.")).toHaveLength(1);
+  });
+
+  it("does not send fallback while async assistant_final delivery is still draining", async () => {
+    const configDir = await writeConfig({
+      bot_token: "test-token",
+      allowed_user_ids: [42],
+      denied_user_ids: [],
+      allowed_chat_ids: [],
+      denied_chat_ids: [],
+      runtime_control_allowed_user_ids: [42],
+      chat_goal_map: {},
+      user_goal_map: {},
+      allow_all: true,
+      polling_timeout: 30,
+      identity_key: "seedy",
+    });
+    const finalSendStarted = createDeferred();
+    const finalSendCanFinish = createDeferred();
+    const sentMessages: string[] = [];
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const method = String(url).split("/").at(-1);
+      if (method === "getMe") {
+        return telegramResponse({ id: 1, username: "pulseed_test_bot" });
+      }
+      if (method === "getUpdates") {
+        return telegramResponse([
+          {
+            update_id: 100,
+            message: {
+              message_id: 2718,
+              from: { id: 42 },
+              chat: { id: 314 },
+              text: "hello",
+            },
+          },
+        ]);
+      }
+      if (method === "sendMessage") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+        sentMessages.push(body.text ?? "");
+        if (body.text === "Final setup guidance.") {
+          finalSendStarted.resolve();
+          await finalSendCanFinish.promise;
+        }
+        return telegramResponse({ message_id: 9000 + sentMessages.length });
+      }
+      throw new Error(`unexpected Telegram method: ${method}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = TelegramGatewayAdapter.fromConfigDir(configDir);
+    adapters.push(adapter);
+    vi.mocked(dispatchGatewayChatInput).mockImplementationOnce(async (input) => {
+      await input.onEvent?.({
+        type: "assistant_final",
+        runId: "run-1",
+        turnId: "turn-1",
+        createdAt: "2026-04-08T00:00:02.000Z",
+        text: "Final setup guidance.",
+        persisted: true,
+      });
+      await adapter.stop();
+      return "Final setup guidance.";
+    });
+
+    await adapter.start();
+    await finalSendStarted.promise;
+    expect(sentMessages.filter((message) => message === "Final setup guidance.")).toHaveLength(1);
+    finalSendCanFinish.resolve();
+
+    await vi.waitFor(() => {
+      expect(sentMessages.filter((message) => message === "Final setup guidance.")).toHaveLength(1);
+    });
   });
 });
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
 
 async function writeConfig(config: Record<string, unknown>): Promise<string> {
   const configDir = await fs.mkdtemp(path.join(os.tmpdir(), "pulseed-telegram-gateway-"));

--- a/src/runtime/gateway/slack-channel-adapter.ts
+++ b/src/runtime/gateway/slack-channel-adapter.ts
@@ -246,10 +246,11 @@ export class SlackChannelAdapter implements ChannelAdapter {
       cwd: process.cwd(),
       onEvent: (event) => {
         if (event.type === "assistant_final") {
-          void sendReply(event.text).catch((err: unknown) => {
+          return sendReply(event.text).catch((err: unknown) => {
             console.warn("SlackChannelAdapter: failed to send assistant event", err);
           });
         }
+        return undefined;
       },
       metadata: input.metadata,
     });


### PR DESCRIPTION
Closes #989

## Summary
- add a shared per-turn chat event delivery queue and drain it before gateway dispatch returns
- preserve approval prompt failure semantics while isolating ordinary event delivery failures
- return Slack final-reply sends through the shared async event drain path and add Telegram/shared regression tests

## Verification
- npm test -- src/interface/chat/__tests__/cross-platform-session.test.ts
- npm run test:integration -- src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
- npm run typecheck
- npm run lint:boundaries (existing warnings only)
- npm run test:changed

## Known unresolved risks
- lint:boundaries still reports pre-existing warnings outside this change; no new lint errors were introduced.