### PR TITLE
fix(tui): flush direct route progress

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -342,7 +342,9 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         stateManager,
         adapter,
-        onEvent: (event) => events.push(event),
+        onEvent: (event) => {
+          events.push(event);
+        },
       }));
 
       await runner.executeIngressMessage(

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -1,4 +1,4 @@
-import type { ActivityKind, ChatEvent, ChatEventContext } from "./chat-events.js";
+import type { ActivityKind, ChatEvent, ChatEventContext, ChatEventHandler } from "./chat-events.js";
 import type {
   AgentLoopEvent,
   AgentLoopEventSink,
@@ -52,7 +52,7 @@ export class ChatRunnerEventBridge {
   private readonly timelineActivityItemsByRun = new Map<string, AgentTimelineItem[]>();
 
   constructor(
-    private readonly onEventGetter: () => ((event: ChatEvent) => void) | undefined,
+    private readonly onEventGetter: () => ChatEventHandler | undefined,
   ) {}
 
   hasActiveTurn(): boolean {
@@ -296,9 +296,24 @@ export class ChatRunnerEventBridge {
   }
 
   emitEvent(event: ChatEvent): void {
+    void this.deliverEvent(event);
+  }
+
+  async emitEventAndFlush(event: ChatEvent): Promise<void> {
+    await this.deliverEvent(event);
+  }
+
+  private async deliverEvent(event: ChatEvent): Promise<void> {
     const safeEvent = redactChatEvent(event);
     this.rememberActiveTurnEvent(safeEvent);
-    this.onEventGetter()?.(safeEvent);
+    try {
+      await this.onEventGetter()?.(safeEvent);
+    } catch (err) {
+      console.warn("[chat] event flush failed", {
+        eventType: safeEvent.type,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 
   private rememberTimelineActivityItem(eventContext: ChatEventContext, item: AgentTimelineItem): void {
@@ -332,15 +347,23 @@ export class ChatRunnerEventBridge {
   }
 
   emitOperationProgress(item: OperationProgressItem, eventContext: ChatEventContext): void {
+    this.emitEvent(this.createOperationProgressEvent(item, eventContext));
+  }
+
+  async emitOperationProgressAndFlush(item: OperationProgressItem, eventContext: ChatEventContext): Promise<void> {
+    await this.emitEventAndFlush(this.createOperationProgressEvent(item, eventContext));
+  }
+
+  private createOperationProgressEvent(item: OperationProgressItem, eventContext: ChatEventContext): ChatEvent {
     const safeItem = createOperationProgressItem({
       ...item,
       ...(eventContext.languageHint && !item.languageHint ? { languageHint: eventContext.languageHint } : {}),
     });
-    this.emitEvent({
+    return {
       type: "operation_progress",
       item: safeItem,
       ...this.eventBase(eventContext),
-    });
+    };
   }
 
   emitActivity(

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -651,7 +651,7 @@ async function formatConfigureGuidance(
   const suppliedSecretKinds = setupSecretIntake?.suppliedSecrets.map((secret) => secret.kind) ?? [];
   if (target === "telegram_gateway") {
     const provider = host.deps.gatewaySetupStatusProvider ?? createGatewaySetupStatusProvider();
-    host.eventBridge.emitOperationProgress(createOperationProgressItem({
+    await host.eventBridge.emitOperationProgressAndFlush(createOperationProgressItem({
       id: "telegram-configure:started",
       kind: "started",
       operation: "telegram_setup",
@@ -661,7 +661,7 @@ async function formatConfigureGuidance(
       languageHint,
     }), eventContext);
     const status = await provider.getTelegramStatus(host.getProviderConfigBaseDir());
-    host.eventBridge.emitOperationProgress(createOperationProgressItem({
+    await host.eventBridge.emitOperationProgressAndFlush(createOperationProgressItem({
       id: "telegram-configure:checked-status",
       kind: "checked_status",
       operation: "telegram_setup",
@@ -680,7 +680,7 @@ async function formatConfigureGuidance(
         daemon_port: status.daemon.port,
       },
     }), eventContext);
-    host.eventBridge.emitOperationProgress(createOperationProgressItem({
+    await host.eventBridge.emitOperationProgressAndFlush(createOperationProgressItem({
       id: "telegram-configure:read-config",
       kind: "read_config",
       operation: "telegram_setup",
@@ -701,7 +701,7 @@ async function formatConfigureGuidance(
         replacesExistingSecret: status.config.hasBotToken,
       }));
     }
-    host.eventBridge.emitOperationProgress(createOperationProgressItem({
+    await host.eventBridge.emitOperationProgressAndFlush(createOperationProgressItem({
       id: "telegram-configure:planned-action",
       kind: telegramSecret ? "awaiting_approval" : "planned_action",
       operation: "telegram_setup",

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -26,7 +26,7 @@ import type { ToolExecutor } from "../../tools/executor.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
 import type { GatewaySetupStatusProvider } from "./gateway-setup-status.js";
 import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
-import type { ChatEvent } from "./chat-events.js";
+import type { ChatEventHandler } from "./chat-events.js";
 import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
 import type { ReviewAgentLoopRunner } from "../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
 import type { RuntimeControlService } from "../../runtime/control/index.js";
@@ -102,7 +102,7 @@ export interface ChatRunnerDeps {
   goalNegotiator?: GoalNegotiator;
   onNotification?: (message: string) => void;
   daemonBaseUrl?: string;
-  onEvent?: (event: ChatEvent) => void;
+  onEvent?: ChatEventHandler;
   chatAgentLoopRunner?: ChatAgentLoopRunner;
   reviewAgentLoopRunner?: Pick<ReviewAgentLoopRunner, "execute">;
   runtimeControlService?: Pick<RuntimeControlService, "request">;
@@ -200,7 +200,7 @@ export class ChatRunner {
   private pendingTend: PendingTendState | null = null;
   private activeSubscribers = new Map<string, { unsubscribe(): void }>();
   onNotification: ((message: string) => void) | undefined = undefined;
-  onEvent: ((event: ChatEvent) => void) | undefined = undefined;
+  onEvent: ChatEventHandler | undefined = undefined;
   private nativeAgentLoopStatePath: string | null = null;
   private runtimeControlContext: RuntimeControlChatContext | null = null;
   private sessionExecutionPolicy: ExecutionPolicy | null = null;

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -9,6 +9,7 @@ import type { AgentResult, IAdapter } from "../../../orchestrator/execution/adap
 import type { ChatAgentLoopRunner } from "../../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
 import { App, DASHBOARD_REFRESH_INTERVAL_MS, formatDaemonConnectionState } from "../app.js";
 import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
+import type { TelegramSetupStatus } from "../../chat/gateway-setup-status.js";
 
 const testState = vi.hoisted(() => ({
   lastChatProps: null as null | { onSubmit: (value: string) => Promise<void> },
@@ -299,6 +300,38 @@ function createEvidenceSummary(overrides: Record<string, unknown> = {}) {
 
 async function flush() {
   await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
+}
+
+function createTelegramSetupStatus(): TelegramSetupStatus {
+  return {
+    channel: "telegram",
+    state: "unconfigured",
+    configPath: "/tmp/pulseed-tui-test/gateways/telegram-bot/config.json",
+    daemon: {
+      running: false,
+      port: 49876,
+    },
+    gateway: {
+      loadState: "unknown",
+    },
+    config: {
+      exists: false,
+      hasBotToken: false,
+      hasHomeChat: false,
+      allowAll: false,
+      allowedUserCount: 0,
+      runtimeControlAllowedUserCount: 0,
+      identityKeyConfigured: false,
+    },
+  };
 }
 
 describe("formatDaemonConnectionState", () => {
@@ -785,6 +818,13 @@ describe("standalone slash command routing", () => {
   it("routes Telegram setup freeform input through the production TUI ChatRunner path", async () => {
     const stateManager = createStateManagerMock();
     const adapter = createAdapterMock();
+    const statusLookupCanFinish = createDeferred();
+    const gatewaySetupStatusProvider = {
+      getTelegramStatus: vi.fn(async () => {
+        await statusLookupCanFinish.promise;
+        return createTelegramSetupStatus();
+      }),
+    };
     const chatAgentLoopRunner = {
       execute: vi.fn().mockResolvedValue({
         success: true,
@@ -800,6 +840,7 @@ describe("standalone slash command routing", () => {
       stateManager: stateManager as unknown as StateManager,
       adapter,
       chatAgentLoopRunner,
+      gatewaySetupStatusProvider,
       llmClient: createSingleMockLLMClient(JSON.stringify({
         kind: "configure",
         configure_target: "telegram_gateway",
@@ -858,11 +899,19 @@ describe("standalone slash command routing", () => {
     await flush();
     expect(testState.lastChatProps).not.toBeNull();
 
-    await testState.lastChatProps!.onSubmit("telegramからseedyと会話できるようにしたい");
+    const submit = testState.lastChatProps!.onSubmit("telegramからseedyと会話できるようにしたい");
+    await vi.waitFor(() => {
+      const visibleText = testState.lastChatMessages.map((message) => message.text).join("\n");
+      expect(visibleText).toContain("Telegram setup を開始しました");
+      expect(visibleText).not.toContain("pulseed telegram setup");
+    });
+    statusLookupCanFinish.resolve();
+    await submit;
     await flush();
 
     expect(chatRunner.execute).toHaveBeenCalledWith("telegramからseedyと会話できるようにしたい", "/work/pulseed");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+    expect(gatewaySetupStatusProvider.getTelegramStatus).toHaveBeenCalledWith("/tmp/pulseed-tui-test");
     await vi.waitFor(() => expect(chatRunnerOutput).toContain("pulseed telegram setup"));
     expect(chatRunnerOutput).toContain("pulseed telegram setup");
     expect(chatRunnerOutput).toContain("pulseed gateway setup");

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -500,8 +500,11 @@ export function App({
   useEffect(() => {
     if (chatRunner) {
       chatRunner.startSession(cwd ?? process.cwd());
-      chatRunner.onEvent = (event) => {
+      chatRunner.onEvent = async (event) => {
         setMessages((prev) => applyChatEventToMessages(prev, event, MAX_MESSAGES) as ChatMessage[]);
+        if (event.type === "operation_progress") {
+          await new Promise<void>((resolve) => setImmediate(resolve));
+        }
       };
     }
   }, [chatRunner, cwd]);


### PR DESCRIPTION
Closes #990

## Summary
- add an explicit async chat event flush path for user-visible progress events
- flush direct Telegram setup operation progress before continuing to final guidance
- let the TUI event handler yield the render loop after progress updates and cover the incremental behavior with an integration-style test

## Verification
- npm run typecheck
- npm test -- src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-event-state.test.ts
- npm run test:integration -- src/interface/tui/__tests__/app.test.ts
- npm run lint:boundaries (existing warnings only)
- npm run test:changed

## Known unresolved risks
- lint:boundaries still reports pre-existing warnings outside this change; no new lint errors were introduced.