### PR TITLE
feat(setup): self-apply telegram refresh

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -561,8 +561,97 @@ describe("ChatRunner", () => {
       expect(JSON.stringify(persistedDialogue)).not.toContain(telegramToken);
       expect(config.bot_token).toBe(telegramToken);
       expect(config.allow_all).toBe(false);
-      expect(confirmResult.output).toContain("Restart the daemon");
+      expect(confirmResult.output).toContain("runtime control is unavailable");
+      expect(confirmResult.output).toContain("pulseed daemon restart");
       expect(confirmResult.output).toContain("Access remains closed");
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it("requests an internal gateway refresh after approved Telegram config write", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-refresh-"));
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const approvalFn = vi.fn().mockResolvedValue(true);
+      const runtimeControlService = {
+        request: vi.fn(async (request: { approvalFn?: (description: string) => Promise<boolean> }) => {
+          await request.approvalFn?.("Runtime control restart_gateway: Apply updated Telegram gateway config after approved setup write.");
+          return {
+            success: true,
+            message: "gateway restart is being handled by a daemon restart because the gateway runs in-process.",
+            operationId: "op-refresh-1",
+            state: "acknowledged" as const,
+          };
+        }),
+      };
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        approvalFn,
+        runtimeControlService,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "unconfigured",
+          configPath: path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"),
+          daemon: { running: true, port: 41700 },
+        })),
+      }));
+
+      await runner.execute(telegramToken, "/repo", 30_000);
+      const confirmResult = await runner.execute("/confirm-setup-write", "/repo", 30_000);
+
+      expect(confirmResult.success).toBe(true);
+      expect(confirmResult.output).toContain("Telegram gateway config was written");
+      expect(confirmResult.output).toContain("PulSeed requested an internal gateway refresh");
+      expect(confirmResult.output).toContain("op-refresh-1");
+      expect(confirmResult.output).not.toContain("Restart the daemon so the gateway loads");
+      expect(runtimeControlService.request).toHaveBeenCalledWith(expect.objectContaining({
+        cwd: baseDir,
+        intent: {
+          kind: "restart_gateway",
+          reason: "Apply updated Telegram gateway config after approved setup write.",
+        },
+        approvalFn,
+      }));
+      expect(approvalFn).toHaveBeenCalledTimes(2);
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    });
+
+    it("reports refresh failure with a manual fallback after Telegram config write", async () => {
+      const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-refresh-fail-"));
+      const stateManager = {
+        ...makeMockStateManager(),
+        getBaseDir: () => baseDir,
+      } as unknown as StateManager;
+      const approvalFn = vi.fn().mockResolvedValue(true);
+      const runtimeControlService = {
+        request: vi.fn().mockResolvedValue({
+          success: false,
+          message: "Runtime control executor is not configured; operation was recorded but not started.",
+          operationId: "op-refresh-failed",
+          state: "failed" as const,
+        }),
+      };
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        approvalFn,
+        runtimeControlService,
+        gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
+          state: "unconfigured",
+          configPath: path.join(baseDir, "gateway", "channels", "telegram-bot", "config.json"),
+          daemon: { running: true, port: 41700 },
+        })),
+      }));
+
+      await runner.execute(telegramToken, "/repo", 30_000);
+      const confirmResult = await runner.execute("/confirm-setup-write", "/repo", 30_000);
+
+      expect(confirmResult.success).toBe(true);
+      expect(confirmResult.output).toContain("PulSeed attempted an internal gateway refresh, but it failed");
+      expect(confirmResult.output).toContain("pulseed daemon restart");
+      expect(confirmResult.output).toContain("pulseed daemon status");
+      expect(runtimeControlService.request).toHaveBeenCalledOnce();
       fs.rmSync(baseDir, { recursive: true, force: true });
     });
 

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -855,8 +855,7 @@ function formatTelegramConfigureGuidance(
       "",
       "Verification:",
       "- Send a message to the Telegram bot.",
-      "- Run `pulseed daemon status` if delivery does not work.",
-      "- If this config was added or changed while the daemon was already running, restart the daemon so the gateway loads the updated config."
+      "- Run `pulseed daemon status` if delivery does not work."
     );
   }
 
@@ -879,7 +878,8 @@ function formatTelegramConfigureGuidance(
   } else if (status.daemon.running && status.state !== "unconfigured") {
     lines.push(
       "",
-      "If Telegram was configured or changed after this daemon started, restart the daemon so the gateway loads the latest config."
+      "If Telegram was configured or changed through chat-assisted setup, PulSeed will request an internal gateway refresh after the approved write.",
+      "For config changes made outside PulSeed chat setup, run `pulseed daemon restart` if delivery does not pick up the updated gateway config."
     );
   }
 
@@ -932,8 +932,7 @@ function formatTelegramConfigureGuidanceJa(
       "",
       "Verification:",
       "- Telegram bot にメッセージを送ってください。",
-      "- 配信されない場合は `pulseed daemon status` を実行してください。",
-      "- daemon 起動後に config を追加または変更した場合は、daemon を再起動して gateway に最新 config を読み込ませてください。"
+      "- 配信されない場合は `pulseed daemon status` を実行してください。"
     );
   }
 
@@ -956,7 +955,8 @@ function formatTelegramConfigureGuidanceJa(
   } else if (status.daemon.running && status.state !== "unconfigured") {
     lines.push(
       "",
-      "Telegram config を daemon 起動後に追加または変更した場合は、daemon を再起動して最新 config を読み込ませてください。"
+      "chat-assisted setup で Telegram config を追加または変更した場合は、承認済み write 後に PulSeed が internal gateway refresh を要求します。",
+      "PulSeed chat setup 以外で config を変更した場合、配信が最新 gateway config を拾わなければ `pulseed daemon restart` を実行してください。"
     );
   }
 

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -188,6 +188,26 @@ function formatSetupConfirmationCancelled(languageHint: TurnLanguageHint): strin
   return "Telegram setup config write was cancelled. No token was written.";
 }
 
+function formatTelegramSetupRefreshResult(
+  result: { success: boolean; message: string; operationId?: string; state?: string; unavailable?: boolean },
+  languageHint: TurnLanguageHint
+): string {
+  if (result.success) {
+    const suffix = result.operationId ? ` (${result.operationId})` : "";
+    return languageHint.language === "ja"
+      ? `PulSeed は更新済み Telegram gateway config を反映するため、internal gateway refresh を要求しました${suffix}: ${result.message}`
+      : `PulSeed requested an internal gateway refresh for the updated Telegram config${suffix}: ${result.message}`;
+  }
+  if (result.unavailable) {
+    return languageHint.language === "ja"
+      ? `PulSeed は internal gateway refresh を試みましたが、この chat surface では runtime control service が利用できません: ${result.message}`
+      : `PulSeed attempted an internal gateway refresh, but runtime control is unavailable in this chat surface: ${result.message}`;
+  }
+  return languageHint.language === "ja"
+    ? `PulSeed は internal gateway refresh を試みましたが失敗しました: ${result.message}`
+    : `PulSeed attempted an internal gateway refresh, but it failed: ${result.message}`;
+}
+
 export class ChatRunner {
   private readonly groundingGateway: GroundingGateway;
   private readonly eventBridge: ChatRunnerEventBridge;
@@ -866,10 +886,11 @@ export class ChatRunner {
       ...(current?.identity_key ? { identity_key: current.identity_key } : {}),
     };
     await writeJsonFileAtomic(configPath, nextConfig);
+    const refreshResult = await this.requestTelegramGatewayRefreshAfterSetup(runtimeControlContext, approvalFn, baseDir);
     this.pendingSetupDialogue = {
       publicState: {
         ...pending.publicState,
-        state: "restart_offer",
+        state: refreshResult.success ? "verify" : "restart_offer",
         updatedAt: new Date().toISOString(),
         action: pending.publicState.action
           ? { ...pending.publicState.action, status: "completed" }
@@ -885,10 +906,9 @@ export class ChatRunner {
           ? "redacted chat-supplied token から Telegram gateway config を書き込みました。"
           : "Telegram gateway config was written from the redacted chat-supplied token.",
         "",
+        formatTelegramSetupRefreshResult(refreshResult, this.turnLanguageHint),
+        "",
         this.turnLanguageHint.language === "ja" ? "Next steps:" : "Next steps:",
-        this.turnLanguageHint.language === "ja"
-          ? "- daemon を再起動して、gateway に updated config を読み込ませてください。"
-          : "- Restart the daemon so the gateway loads the updated config.",
         ...(accessClosedByDefault
           ? [this.turnLanguageHint.language === "ja"
             ? "- allowed Telegram user IDs を設定するか、`pulseed telegram setup` で意図的に `allow_all` を有効にするまで access は closed のままです。"
@@ -897,11 +917,45 @@ export class ChatRunner {
         this.turnLanguageHint.language === "ja"
           ? "- home chat が未設定なら Telegram から `/sethome` を送ってください。"
           : "- Send `/sethome` from Telegram if no home chat is configured yet.",
-        this.turnLanguageHint.language === "ja"
-          ? "- `pulseed daemon status` で確認してください。"
-          : "- Run `pulseed daemon status` to verify.",
+        refreshResult.success
+          ? this.turnLanguageHint.language === "ja"
+            ? "- Telegram bot にメッセージを送って動作確認してください。"
+            : "- Send a message to the Telegram bot to verify delivery."
+          : this.turnLanguageHint.language === "ja"
+            ? "- 自動反映できなかったため、fallback として `pulseed daemon restart` を実行してから `pulseed daemon status` で確認してください。"
+            : "- Automatic refresh was not applied; as a fallback, run `pulseed daemon restart`, then `pulseed daemon status`.",
       ].join("\n"),
       elapsed_ms: 0,
+    };
+  }
+
+  private async requestTelegramGatewayRefreshAfterSetup(
+    runtimeControlContext: RuntimeControlChatContext | null,
+    approvalFn: ((description: string) => Promise<boolean>) | undefined,
+    baseDir: string
+  ): Promise<{ success: boolean; message: string; operationId?: string; state?: string; unavailable?: boolean }> {
+    if (!this.deps.runtimeControlService) {
+      return {
+        success: false,
+        unavailable: true,
+        message: "Runtime control service is not available in this chat surface.",
+      };
+    }
+    const result = await this.deps.runtimeControlService.request({
+      intent: {
+        kind: "restart_gateway",
+        reason: "Apply updated Telegram gateway config after approved setup write.",
+      },
+      cwd: baseDir,
+      ...(runtimeControlContext?.actor ? { requestedBy: runtimeControlContext.actor } : {}),
+      ...(runtimeControlContext?.replyTarget ? { replyTarget: runtimeControlContext.replyTarget } : {}),
+      ...(approvalFn ? { approvalFn } : {}),
+    });
+    return {
+      success: result.success,
+      message: result.message,
+      ...(result.operationId ? { operationId: result.operationId } : {}),
+      ...(result.state ? { state: result.state } : {}),
     };
   }
 


### PR DESCRIPTION
Closes #988

## Summary
- request an internal `restart_gateway` runtime-control operation after approved chat-assisted Telegram config writes
- report PulSeed self-apply success, runtime-control unavailability, or refresh failure with manual fallback only when needed
- remove daemon restart as the normal next step for PulSeed-managed chat setup writes while preserving fallback guidance for config changes made outside chat-assisted setup

## Verification
- npm run typecheck
- npm test -- src/interface/chat/__tests__/chat-runner.test.ts
- npm run test:integration -- src/interface/tui/__tests__/app.test.ts
- npm run lint:boundaries (existing warnings only)
- npm run test:changed

## Known unresolved risks
- lint:boundaries still reports pre-existing warnings outside this change; no new lint errors were introduced.
- Gateway refresh execution depends on the configured runtime-control executor; unavailable/failure paths now return explicit fallback guidance.