### PR TITLE
fix(agent-loop): preserve approval-denied tool state

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
@@ -11,6 +11,7 @@ import type {
 } from "../agent-loop-model.js";
 import type { BoundedAgentLoopRunner } from "../bounded-agent-loop-runner.js";
 import { defaultAgentLoopCapabilities } from "../index.js";
+import type { AgentLoopCommandResult, AgentLoopToolResultSummary } from "../agent-loop-result.js";
 
 function makeModelRef(): AgentLoopModelRef {
   return { providerId: "test", modelId: "model" };
@@ -24,7 +25,18 @@ function makeModelInfo(): AgentLoopModelInfo {
   };
 }
 
-function makeRunner(returnOutput: unknown, finalText = JSON.stringify(returnOutput)) {
+function makeRunner(
+  returnOutput: unknown,
+  finalText = JSON.stringify(returnOutput),
+  commandResults: AgentLoopCommandResult[] = [],
+  toolResults: AgentLoopToolResultSummary[] = commandResults.map((entry) => ({
+    toolName: entry.toolName,
+    success: entry.success,
+    ...(entry.execution ? { execution: entry.execution } : {}),
+    outputSummary: entry.outputSummary,
+    durationMs: entry.durationMs,
+  })),
+) {
   const modelInfo = makeModelInfo();
   const boundedRunner = {
     run: vi.fn().mockResolvedValue({
@@ -40,7 +52,8 @@ function makeRunner(returnOutput: unknown, finalText = JSON.stringify(returnOutp
       usage: undefined,
       compactions: 0,
       changedFiles: [],
-      commandResults: [],
+      toolResults,
+      commandResults,
     }),
   } as unknown as BoundedAgentLoopRunner;
   const modelClient = {
@@ -217,6 +230,7 @@ describe("chat agentloop final-answer contract", () => {
         usage: undefined,
         compactions: 0,
         changedFiles: [],
+        toolResults: [],
         commandResults: [],
       }),
     } as unknown as BoundedAgentLoopRunner;
@@ -260,6 +274,117 @@ describe("chat agentloop final-answer contract", () => {
     expect(result.success).toBe(true);
     expect(result.output).toBe(finalText);
     expect(result.structuredOutput).toBeUndefined();
+  });
+
+  it("does not surface fabricated success after an approval-denied side-effect tool was not executed", async () => {
+    const { runner } = makeRunner(
+      null,
+      "I restarted the daemon and reproduced the EPERM error.",
+      [{
+        toolName: "dangerous_side_effect",
+        command: "restart-service",
+        cwd: "/tmp",
+        success: false,
+        execution: {
+          status: "not_executed",
+          reason: "approval_denied",
+          message: "Side-effect tool requires approval.",
+        },
+        category: "other",
+        evidenceEligible: false,
+        outputSummary: "TOOL NOT EXECUTED (approval_denied): Side-effect tool requires approval.",
+        durationMs: 1,
+      }],
+    );
+
+    const result = await runner.execute({ message: "restart it" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Approval was denied");
+    expect(result.output).toContain("operation was not executed");
+    expect(result.output).not.toContain("restarted the daemon");
+    expect(result.output).not.toContain("EPERM");
+  });
+
+  it("still returns genuine executed command failures for model summarization", async () => {
+    const finalText = "The command executed and failed with stderr: EPERM.";
+    const { runner } = makeRunner(
+      null,
+      finalText,
+      [{
+        toolName: "generic_side_effect",
+        command: "restart-service",
+        cwd: "/tmp",
+        success: false,
+        execution: { status: "executed" },
+        category: "other",
+        evidenceEligible: false,
+        outputSummary: "stderr: EPERM",
+        durationMs: 1,
+      }],
+    );
+
+    const result = await runner.execute({ message: "restart it" });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBe(finalText);
+  });
+
+  it("guards approval-denied non-command tools that do not appear in command results", async () => {
+    const { runner } = makeRunner(
+      null,
+      "I completed the side effect.",
+      [],
+      [{
+        toolName: "spawn-session",
+        success: false,
+        execution: {
+          status: "not_executed",
+          reason: "approval_denied",
+          message: "Session mutation requires approval.",
+        },
+        outputSummary: "TOOL NOT EXECUTED (approval_denied): Session mutation requires approval.",
+        durationMs: 1,
+      }],
+    );
+
+    const result = await runner.execute({ message: "start a new session" });
+
+    expect(result.output).toContain("Approval was denied");
+    expect(result.output).toContain("operation was not executed");
+    expect(result.output).not.toContain("completed the side effect");
+  });
+
+  it("keeps deterministic executed-result summaries when a denied tool also occurred", async () => {
+    const { runner } = makeRunner(
+      null,
+      "Everything was restarted successfully.",
+      [],
+      [{
+        toolName: "side_effect_tool",
+        success: false,
+        execution: {
+          status: "not_executed",
+          reason: "approval_denied",
+          message: "Restart requires approval.",
+        },
+        outputSummary: "TOOL NOT EXECUTED (approval_denied): Restart requires approval.",
+        durationMs: 1,
+      }, {
+        toolName: "status_reader",
+        success: true,
+        execution: { status: "executed" },
+        outputSummary: "status is running",
+        durationMs: 1,
+      }],
+    );
+
+    const result = await runner.execute({ message: "restart and check status" });
+
+    expect(result.output).toContain("operation was not executed");
+    expect(result.output).toContain("Executed tool results:");
+    expect(result.output).toContain("status_reader succeeded: status is running");
+    expect(result.output).not.toContain("Everything was restarted successfully");
   });
 
   it("biases chat mode prompts toward display markdown by default", () => {

--- a/src/orchestrator/execution/agent-loop/agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-result.ts
@@ -9,9 +9,26 @@ export interface AgentLoopCommandResult {
   command: string;
   cwd: string;
   success: boolean;
+  execution?: {
+    status: "executed" | "not_executed";
+    reason?: "approval_denied" | "permission_denied" | "policy_blocked" | "dry_run" | "tool_error";
+    message?: string;
+  };
   category: AgentLoopCommandResultCategory;
   evidenceEligible: boolean;
   relevantToTask?: boolean;
+  outputSummary: string;
+  durationMs: number;
+}
+
+export interface AgentLoopToolResultSummary {
+  toolName: string;
+  success: boolean;
+  execution?: {
+    status: "executed" | "not_executed";
+    reason?: "approval_denied" | "permission_denied" | "policy_blocked" | "dry_run" | "tool_error";
+    message?: string;
+  };
   outputSummary: string;
   durationMs: number;
 }
@@ -42,6 +59,7 @@ export interface AgentLoopResult<TOutput> {
   compactions: number;
   filesChanged?: boolean;
   changedFiles: string[];
+  toolResults?: AgentLoopToolResultSummary[];
   commandResults: AgentLoopCommandResult[];
   workspace?: AgentLoopWorkspaceInfo;
   traceId: string;

--- a/src/orchestrator/execution/agent-loop/agent-loop-tool-output.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-tool-output.ts
@@ -15,6 +15,7 @@ export interface AgentLoopToolOutput {
   disposition?: AgentLoopToolDisposition;
   contextModifier?: string;
   rawResult?: ToolResult;
+  execution?: ToolResult["execution"];
   command?: string;
   cwd?: string;
   artifacts?: string[];

--- a/src/orchestrator/execution/agent-loop/agent-loop-tool-runtime.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-tool-runtime.ts
@@ -62,17 +62,19 @@ export class ToolExecutorAgentLoopToolRuntime implements AgentLoopToolRuntime {
         abortSignal: turn.abortSignal,
       });
       const disposition = this.resolveDisposition(result.error, turn.abortSignal?.aborted === true);
+      const execution = result.execution ?? (disposition === "approval_denied"
+        ? { status: "not_executed" as const, reason: "approval_denied" as const, message: result.error ?? result.summary }
+        : { status: "executed" as const });
       const command = this.extractCommand(call.name, call.input);
       const resolvedCwd = this.extractCwd(call.input) ?? turn.cwd;
       return {
         callId: call.id,
         toolName: call.name,
         success: result.success,
-        content: result.success
-          ? `${result.summary}\n${this.stringify(result.data)}${result.contextModifier ? `\n${result.contextModifier}` : ""}`
-          : result.error ?? result.summary,
+        content: this.formatContent(result, execution),
         durationMs: result.durationMs || Date.now() - start,
         disposition,
+        execution,
         ...(result.contextModifier ? { contextModifier: result.contextModifier } : {}),
         rawResult: result,
         ...(command ? { command, cwd: resolvedCwd } : {}),
@@ -109,6 +111,17 @@ export class ToolExecutorAgentLoopToolRuntime implements AgentLoopToolRuntime {
     if (typeof value === "string") return value;
     if (value === undefined) return "";
     return JSON.stringify(value);
+  }
+
+  private formatContent(result: Awaited<ReturnType<ToolExecutor["execute"]>>, execution: NonNullable<AgentLoopToolOutput["execution"]>): string {
+    if (execution.status === "not_executed") {
+      const reason = execution.reason ? ` (${execution.reason})` : "";
+      const message = execution.message ?? result.error ?? result.summary;
+      return `TOOL NOT EXECUTED${reason}: ${message}`;
+    }
+    return result.success
+      ? `${result.summary}\n${this.stringify(result.data)}${result.contextModifier ? `\n${result.contextModifier}` : ""}`
+      : result.error ?? result.summary;
   }
 
   private resolveDisposition(

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -3,7 +3,7 @@ import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import type { z } from "zod";
 import type { AgentLoopStopReason } from "./agent-loop-budget.js";
 import type { AgentLoopMessage, AgentLoopModelClient, AgentLoopModelTurnProtocol } from "./agent-loop-model.js";
-import type { AgentLoopCommandResult, AgentLoopResult } from "./agent-loop-result.js";
+import type { AgentLoopCommandResult, AgentLoopResult, AgentLoopToolResultSummary } from "./agent-loop-result.js";
 import type { AgentLoopToolRuntime } from "./agent-loop-tool-runtime.js";
 import type { AgentLoopToolRouter } from "./agent-loop-tool-router.js";
 import type { AgentLoopTurnContext } from "./agent-loop-turn-context.js";
@@ -43,6 +43,7 @@ export class BoundedAgentLoopRunner {
     let lastToolLoopSignature: string | null = resumed?.lastToolLoopSignature ?? null;
     let repeatedToolLoopCount = resumed?.repeatedToolLoopCount ?? 0;
     const commandResults: AgentLoopCommandResult[] = [];
+    const toolResultSummaries: AgentLoopToolResultSummary[] = [];
     const initialWorkspaceSnapshot = await this.captureWorkspaceSnapshot(turn.cwd);
 
     await this.record(turn, {
@@ -62,7 +63,7 @@ export class BoundedAgentLoopRunner {
     let messages: AgentLoopMessage[] = resumed?.messages ? [...resumed.messages] : [...turn.messages];
     const preTurnCompaction = await this.compactIfNeeded(turn, messages, "pre_turn", "context_limit", undefined, compactions);
     if (preTurnCompaction.error) {
-      return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, [], commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, [], toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
     }
     messages = preTurnCompaction.messages;
     compactions += preTurnCompaction.compacted ? 1 : 0;
@@ -70,16 +71,16 @@ export class BoundedAgentLoopRunner {
 
     while (true) {
       if (Date.now() - startedAt > turn.budget.maxWallClockMs) {
-        return this.stop(turn, "timeout", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "timeout", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (modelTurns >= turn.budget.maxModelTurns) {
-        return this.stop(turn, "max_model_turns", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "max_model_turns", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (toolCalls >= turn.budget.maxToolCalls) {
-        return this.stop(turn, "max_tool_calls", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "max_tool_calls", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (turn.abortSignal?.aborted) {
-        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
 
       const tools = this.deps.toolRouter.modelVisibleTools(turn as AgentLoopTurnContext<unknown>);
@@ -115,6 +116,7 @@ export class BoundedAgentLoopRunner {
           false,
           compactions,
           await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot),
+          toolResultSummaries,
           commandResults,
           messages,
           calledTools,
@@ -125,10 +127,10 @@ export class BoundedAgentLoopRunner {
         );
       }
       if (!protocol.responseCompleted) {
-        return this.stop(turn, "protocol_incomplete", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "protocol_incomplete", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (turn.abortSignal?.aborted) {
-        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
 
       const response = this.protocolToResponse(protocol);
@@ -150,7 +152,7 @@ export class BoundedAgentLoopRunner {
           if (response.content.trim().length === 0) {
             schemaRepairAttempts++;
             if (schemaRepairAttempts > turn.budget.maxSchemaRepairAttempts) {
-              return this.stop(turn, "schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+              return this.stop(turn, "schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
             }
 
             messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
@@ -160,7 +162,7 @@ export class BoundedAgentLoopRunner {
             });
             const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
             }
             messages = compacted.messages;
             compactions += compacted.compacted ? 1 : 0;
@@ -177,7 +179,7 @@ export class BoundedAgentLoopRunner {
             });
             const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
             }
             messages = compacted.messages;
             compactions += compacted.compacted ? 1 : 0;
@@ -192,7 +194,7 @@ export class BoundedAgentLoopRunner {
             success: true,
             outputPreview: this.preview(response.content),
           });
-          return this.stop(turn, "completed", startedAt, modelTurns, toolCalls, response.content, null, true, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+          return this.stop(turn, "completed", startedAt, modelTurns, toolCalls, response.content, null, true, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
         }
 
         const parsed = this.parseFinal(response.content, turn.outputSchema);
@@ -206,7 +208,7 @@ export class BoundedAgentLoopRunner {
             });
             const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
             }
             messages = compacted.messages;
             compactions += compacted.compacted ? 1 : 0;
@@ -226,7 +228,7 @@ export class BoundedAgentLoopRunner {
           if (completionValidation && !completionValidation.ok) {
             completionValidationAttempts++;
             if (completionValidationAttempts > turn.budget.maxCompletionValidationAttempts) {
-              return this.stop(turn, "completion_gate_failed", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+              return this.stop(turn, "completion_gate_failed", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
             }
 
             messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
@@ -236,7 +238,7 @@ export class BoundedAgentLoopRunner {
             });
             const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
             }
             messages = compacted.messages;
             compactions += compacted.compacted ? 1 : 0;
@@ -250,12 +252,12 @@ export class BoundedAgentLoopRunner {
             success: true,
             outputPreview: this.preview(response.content),
           });
-          return this.stop(turn, "completed", startedAt, modelTurns, toolCalls, response.content, parsed.output, true, compactions, changedFiles, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+          return this.stop(turn, "completed", startedAt, modelTurns, toolCalls, response.content, parsed.output, true, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
         }
 
         schemaRepairAttempts++;
         if (schemaRepairAttempts > turn.budget.maxSchemaRepairAttempts) {
-          return this.stop(turn, "schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, "schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
 
         messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
@@ -265,7 +267,7 @@ export class BoundedAgentLoopRunner {
         });
         const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
         if (compacted.error) {
-          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         messages = compacted.messages;
         compactions += compacted.compacted ? 1 : 0;
@@ -290,10 +292,10 @@ export class BoundedAgentLoopRunner {
       }
 
       if (repeatedToolLoopCount > turn.budget.maxRepeatedToolCalls) {
-        return this.stop(turn, "stalled_tool_loop", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "stalled_tool_loop", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (turn.abortSignal?.aborted) {
-        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
 
       for (const call of response.toolCalls) {
@@ -312,6 +314,14 @@ export class BoundedAgentLoopRunner {
         toolCalls++;
         if (result.success) consecutiveToolErrors = 0;
         else consecutiveToolErrors++;
+
+        toolResultSummaries.push({
+          toolName: result.toolName,
+          success: result.success,
+          ...(result.execution ? { execution: result.execution } : {}),
+          outputSummary: this.preview(result.content),
+          durationMs: result.durationMs,
+        });
 
         messages.push({
           role: "tool",
@@ -362,6 +372,7 @@ export class BoundedAgentLoopRunner {
             command: result.command,
             cwd: result.cwd,
             success: result.success,
+            ...(result.execution ? { execution: result.execution } : {}),
             category: commandClassification.category,
             evidenceEligible: commandClassification.evidenceEligible,
             outputSummary: this.preview(result.content),
@@ -370,19 +381,19 @@ export class BoundedAgentLoopRunner {
         }
 
         if (result.disposition === "fatal" || result.fatal) {
-          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         if (result.disposition === "cancelled") {
-          return this.stop(turn, toolBatchTimedOut ? "timeout" : "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, toolBatchTimedOut ? "timeout" : "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         if (consecutiveToolErrors >= turn.budget.maxConsecutiveToolErrors) {
-          return this.stop(turn, "consecutive_tool_errors", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return this.stop(turn, "consecutive_tool_errors", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
       }
 
       const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
       if (compacted.error) {
-        return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       messages = compacted.messages;
       compactions += compacted.compacted ? 1 : 0;
@@ -418,6 +429,7 @@ export class BoundedAgentLoopRunner {
     success = false,
     compactions = 0,
     changedFiles: string[] = [],
+    toolResults: AgentLoopToolResultSummary[] = [],
     commandResults: AgentLoopCommandResult[] = [],
     messages?: AgentLoopMessage[],
     calledTools?: Set<string>,
@@ -460,6 +472,7 @@ export class BoundedAgentLoopRunner {
       compactions,
       filesChanged: changedFiles.length > 0,
       changedFiles,
+      toolResults,
       commandResults,
       traceId: turn.session.traceId,
       sessionId: turn.session.sessionId,

--- a/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/chat-agent-loop-runner.ts
@@ -204,12 +204,16 @@ export class ChatAgentLoopRunner {
       const success = outputMode.kind === "structured"
         ? result.success && outputStatus === "done"
         : result.success;
-      const hadApprovalDeniedError = result.commandResults.some((entry) =>
-        /approval denied|user denied approval|requires approval/i.test(entry.outputSummary),
+      const toolResults = result.toolResults ?? [];
+      const notExecutedApprovalDenied = toolResults.filter((entry) =>
+        entry.execution?.status === "not_executed" && entry.execution.reason === "approval_denied"
+      );
+      const executedToolResults = toolResults.filter((entry) =>
+        entry.execution?.status === "executed"
       );
       const fallbackOutput = success
-        ? this.buildSuccessfulOutput(result.finalText, chatOutput)
-        : this.buildFailureOutput(result.stopReason, hadApprovalDeniedError, result.finalText, chatOutput, extractStringArray(result.output, "blockers"));
+        ? this.buildSuccessfulOutput(result.finalText, chatOutput, notExecutedApprovalDenied, executedToolResults)
+        : this.buildFailureOutput(result.stopReason, notExecutedApprovalDenied.length > 0, result.finalText, chatOutput, extractStringArray(result.output, "blockers"));
       return {
         success,
         output: fallbackOutput,
@@ -273,7 +277,26 @@ export class ChatAgentLoopRunner {
     }
   }
 
-  private buildSuccessfulOutput(finalText: string, output?: ChatAgentLoopOutput | null): string {
+  private buildSuccessfulOutput(
+    finalText: string,
+    output?: ChatAgentLoopOutput | null,
+    notExecutedApprovalDenied: Array<{ toolName: string; execution?: { message?: string } }> = [],
+    executedToolResults: Array<{ toolName: string; success: boolean; outputSummary: string }> = [],
+  ): string {
+    if (notExecutedApprovalDenied.length > 0) {
+      const tools = [...new Set(notExecutedApprovalDenied.map((entry) => entry.toolName))].join(", ");
+      const detail = notExecutedApprovalDenied
+        .map((entry) => entry.execution?.message)
+        .find((message): message is string => typeof message === "string" && message.trim().length > 0);
+      const executedSummaries = executedToolResults
+        .map((entry) => `- ${entry.toolName} ${entry.success ? "succeeded" : "failed"}: ${entry.outputSummary}`)
+        .slice(0, 5);
+      return [
+        `Approval was denied for ${tools || "the requested tool action"}, so the operation was not executed.`,
+        detail ? `Reason: ${detail}` : "",
+        executedSummaries.length > 0 ? ["Executed tool results:", ...executedSummaries].join("\n") : "",
+      ].filter(Boolean).join("\n");
+    }
     const displayText = normalizeAssistantDisplayText({ finalText, output });
     if (displayText) return displayText;
     return "(no response)";

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -69,6 +69,7 @@ export class ToolExecutor {
       return this.failResult(
         `Permission denied: ${semanticResult.reason}`,
         Date.now() - startTime,
+        { status: "not_executed", reason: "permission_denied", message: semanticResult.reason },
       );
     }
     if (semanticResult.status === "needs_approval" && tool.metadata.tags.includes("automation")) {
@@ -87,6 +88,7 @@ export class ToolExecutor {
         return this.failResult(
           `User denied approval: ${semanticResult.reason}`,
           Date.now() - startTime,
+          { status: "not_executed", reason: "approval_denied", message: semanticResult.reason },
         );
       }
     }
@@ -97,6 +99,7 @@ export class ToolExecutor {
       return this.failResult(
         `Permission denied by policy: ${permResult.reason}`,
         Date.now() - startTime,
+        { status: "not_executed", reason: "policy_blocked", message: permResult.reason },
       );
     }
     if (permResult.status === "needs_approval") {
@@ -115,6 +118,7 @@ export class ToolExecutor {
         return this.failResult(
           `User denied approval: ${permResult.reason}`,
           Date.now() - startTime,
+          { status: "not_executed", reason: "approval_denied", message: permResult.reason },
         );
       }
     }
@@ -125,6 +129,7 @@ export class ToolExecutor {
       return this.failResult(
         `Input sanitization failed: ${sanitizeError}`,
         Date.now() - startTime,
+        { status: "not_executed", reason: "policy_blocked", message: sanitizeError },
       );
     }
 
@@ -140,6 +145,7 @@ export class ToolExecutor {
               success: true,
               data: null,
               summary: "dry-run: skipped",
+              execution: { status: "not_executed", reason: "dry_run", message: "dry-run skipped tool.call()" },
               durationMs: 0,
             };
           }
@@ -306,12 +312,13 @@ export class ToolExecutor {
     };
   }
 
-  private failResult(error: string, durationMs: number): ToolResult {
+  private failResult(error: string, durationMs: number, execution?: ToolResult["execution"]): ToolResult {
     return {
       success: false,
       data: null,
       summary: error,
       error,
+      ...(execution ? { execution } : {}),
       durationMs,
     };
   }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -12,6 +12,15 @@ export const ToolResultSchema = z.object({
   summary: z.string(),
   /** Optional error message on failure */
   error: z.string().optional(),
+  /**
+   * Whether the tool implementation actually ran.
+   * Approval-denied and policy-blocked calls are not executed side effects.
+   */
+  execution: z.object({
+    status: z.enum(["executed", "not_executed"]),
+    reason: z.enum(["approval_denied", "permission_denied", "policy_blocked", "dry_run", "tool_error"]).optional(),
+    message: z.string().optional(),
+  }).optional(),
   /** Duration of the tool call in milliseconds */
   durationMs: z.number(),
   /** Optional context modifier: instructions to append to subsequent LLM context */

--- a/tmp/autonomous-runtime-control-safety-status.md
+++ b/tmp/autonomous-runtime-control-safety-status.md
@@ -1,0 +1,40 @@
+# Autonomous Runtime-Control Safety Status
+
+Started: 2026-05-03
+
+## Scope
+
+- #996: open, active first. Goal is to preserve approval-denied/not-executed tool facts through chat agent-loop final output.
+- #995: open, queued after #996. Goal is to route daemon lifecycle intent through typed runtime-control or fail closed.
+
+## Working Notes
+
+- Main was refreshed with `git switch main && git pull --ff-only`.
+- Open issue list was checked with `gh issue list --state open --limit 100`.
+- Existing unrelated worktree change observed: `tmp/autonomous-chat-setup-ux-status.md`. It will not be touched.
+
+## #996 Plan
+
+1. Done: added typed not-executed execution state to tool results/agent-loop outputs.
+2. Done: approval-denied tool calls are marked `not_executed` at the executor/runtime boundary.
+3. Done: command results carry execution state without relying on command-output text.
+4. Done: added chat agent-loop contract tests for approval-denied not-executed results and genuine executed command failures.
+5. Done: verification and fresh review.
+
+## #996 Verification
+
+- `npm test -- src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts`: passed.
+- `npm run typecheck`: passed.
+- `npm run lint:boundaries`: passed with existing warnings, no errors.
+- `npm run test:changed`: passed, 35 files passed and 3 skipped in related tests.
+- `git diff --check`: passed.
+- Fresh review agent: found two material issues.
+  - Fixed P1: non-command approval-denied tools now flow through `AgentLoopResult.toolResults`, so final-output protection is not limited to command results.
+  - Fixed P2: deterministic approval-denied output now also includes summaries from executed tool results in the same turn, instead of discarding all later successful/failed executed observations.
+- Re-verification after review fixes:
+  - `npm test -- src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts`: passed, 16 tests.
+  - `npm run typecheck`: passed.
+  - `git diff --check`: passed.
+  - `npm run lint:boundaries`: passed with existing warnings, no errors.
+  - `npm run test:changed`: passed, 35 files passed and 3 skipped in related tests.
+- Second fresh review after fixes: no findings.


### PR DESCRIPTION
Closes #996

## Summary
- add typed tool execution state so approval-denied and policy-blocked calls are marked as not executed
- propagate tool execution summaries through the agent-loop, including non-command tools
- guard chat final output from surfacing fabricated side-effect results while preserving executed tool summaries
- add contract coverage for approval-denied side-effect calls, executed failures, non-command denied tools, and mixed denied/executed turns

## Verification
- npm test -- src/orchestrator/execution/agent-loop/__tests__/chat-agent-loop-contract.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check
- fresh review agent: fixed two findings, second review no findings

## Known unresolved risks
- The deterministic denial response is intentionally conservative when any approval-denied not-executed tool occurs in the turn; it avoids model fabrication and includes executed tool summaries, but does not attempt semantic dependency analysis between denied and executed actions.
