### PR TITLE
fix(runtime-control): fail closed for lifecycle chat intent

### DIFF
--- a/src/interface/chat/__tests__/chat-boundary-contract.test.ts
+++ b/src/interface/chat/__tests__/chat-boundary-contract.test.ts
@@ -228,7 +228,6 @@ describe("chat boundary contracts", () => {
         }),
       } as never,
       llmClient: createMockLLMClient([
-        JSON.stringify({ intent: "none", reason: "ordinary greeting" }),
         JSON.stringify({ kind: "execute", confidence: 0.93, rationale: "ordinary greeting" }),
         JSON.stringify({ intent: "restart_daemon", reason: "PulSeed を再起動して" }),
       ]),
@@ -249,6 +248,7 @@ describe("chat boundary contracts", () => {
       conversation_id: "telegram-chat-1",
       user_id: "user-1",
       cwd: workspaceDir,
+      metadata: { runtime_control_approved: true },
     });
 
     expect(runtimeControlService.request).toHaveBeenCalledOnce();

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -562,7 +562,8 @@ describe("ChatRunner", () => {
       expect(config.bot_token).toBe(telegramToken);
       expect(config.allow_all).toBe(false);
       expect(confirmResult.output).toContain("runtime control is unavailable");
-      expect(confirmResult.output).toContain("pulseed daemon restart");
+      expect(confirmResult.output).toContain("typed runtime-control");
+      expect(confirmResult.output).not.toContain("pulseed daemon restart");
       expect(confirmResult.output).toContain("Access remains closed");
       fs.rmSync(baseDir, { recursive: true, force: true });
     });
@@ -617,7 +618,7 @@ describe("ChatRunner", () => {
       fs.rmSync(baseDir, { recursive: true, force: true });
     });
 
-    it("reports refresh failure with a manual fallback after Telegram config write", async () => {
+    it("reports refresh failure without shell lifecycle fallback after Telegram config write", async () => {
       const telegramToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
       const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-telegram-refresh-fail-"));
       const stateManager = {
@@ -649,8 +650,9 @@ describe("ChatRunner", () => {
 
       expect(confirmResult.success).toBe(true);
       expect(confirmResult.output).toContain("PulSeed attempted an internal gateway refresh, but it failed");
-      expect(confirmResult.output).toContain("pulseed daemon restart");
-      expect(confirmResult.output).toContain("pulseed daemon status");
+      expect(confirmResult.output).toContain("typed runtime-control");
+      expect(confirmResult.output).not.toContain("pulseed daemon restart");
+      expect(confirmResult.output).not.toContain("pulseed daemon status");
       expect(runtimeControlService.request).toHaveBeenCalledOnce();
       fs.rmSync(baseDir, { recursive: true, force: true });
     });

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -83,6 +83,7 @@ describe("CrossPlatformChatSessionManager", () => {
       conversation_id: "telegram-chat-1",
       user_id: "user-1",
       cwd: "/repo",
+      metadata: { runtime_control_approved: true },
     });
 
     expect(result.success).toBe(true);
@@ -311,6 +312,7 @@ describe("CrossPlatformChatSessionManager", () => {
       conversation_id: "telegram-chat-1",
       user_id: "user-1",
       cwd: "/repo",
+      metadata: { runtime_control_approved: true },
     });
 
     expect(result.success).toBe(true);
@@ -342,6 +344,187 @@ describe("CrossPlatformChatSessionManager", () => {
       identity_key: "owner",
       user_id: "user-1",
     });
+  });
+
+  it("fails closed for natural-language daemon restart when runtime control is unavailable", async () => {
+    const stateManager = makeMockStateManager();
+    const adapter = makeMockAdapter();
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "agent loop should not run shell fallback",
+        error: null,
+        exit_code: null,
+        elapsed_ms: 42,
+        stopped_reason: "completed",
+      }),
+    };
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager,
+      adapter,
+      chatAgentLoopRunner: chatAgentLoopRunner as never,
+      llmClient: createMockLLMClient([
+        JSON.stringify({
+          intent: "restart_daemon",
+          reason: "PulSeed を再起動して",
+        }),
+      ]),
+    }));
+
+    const result = await manager.execute("PulSeed を再起動して", {
+      identity_key: "owner",
+      platform: "telegram",
+      conversation_id: "telegram-chat-1",
+      user_id: "user-1",
+      cwd: "/repo",
+      runtimeControl: {
+        allowed: true,
+        approvalMode: "interactive",
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("runtime-control service is not available");
+    expect(result.output).toContain("operation was not executed");
+    expect(result.output).toContain("will not fall back to shell tools");
+    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for default local daemon restart when runtime control is unavailable", async () => {
+    const stateManager = makeMockStateManager();
+    const adapter = makeMockAdapter();
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "agent loop should not run shell fallback",
+        error: null,
+        exit_code: null,
+        elapsed_ms: 42,
+        stopped_reason: "completed",
+      }),
+    };
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager,
+      adapter,
+      chatAgentLoopRunner: chatAgentLoopRunner as never,
+      llmClient: createMockLLMClient([
+        JSON.stringify({
+          intent: "restart_daemon",
+          reason: "PulSeed を再起動して",
+        }),
+      ]),
+    }));
+
+    const result = await manager.execute("PulSeed を再起動して", {
+      identity_key: "local",
+      cwd: "/repo",
+      runtimeControl: {
+        allowed: true,
+        approvalMode: "interactive",
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("runtime-control service is not available");
+    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+
+  it("does not preempt ordinary disallowed gateway setup when runtime-control service is wired", async () => {
+    const stateManager = makeMockStateManager();
+    const adapter = makeMockAdapter();
+    const runtimeControlService = {
+      request: vi.fn().mockResolvedValue({
+        success: true,
+        message: "runtime control should not run",
+      }),
+    };
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "agent loop should not run",
+        error: null,
+        exit_code: null,
+        elapsed_ms: 42,
+        stopped_reason: "completed",
+      }),
+    };
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager,
+      adapter,
+      chatAgentLoopRunner: chatAgentLoopRunner as never,
+      llmClient: createMockLLMClient([
+        JSON.stringify({ kind: "configure", confidence: 0.9, configure_target: "telegram_gateway", rationale: "setup request" }),
+      ]),
+      runtimeControlService,
+    }));
+
+    const result = await manager.execute("Telegram bot setup help", {
+      identity_key: "owner",
+      platform: "telegram",
+      conversation_id: "telegram-chat-1",
+      user_id: "user-1",
+      cwd: "/repo",
+      metadata: { runtime_control_denied: true },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("@BotFather");
+    expect(runtimeControlService.request).not.toHaveBeenCalled();
+    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for unauthorized gateway daemon restart instead of using agent-loop shell fallback", async () => {
+    const stateManager = makeMockStateManager();
+    const adapter = makeMockAdapter();
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "agent loop should not run shell fallback",
+        error: null,
+        exit_code: null,
+        elapsed_ms: 42,
+        stopped_reason: "completed",
+      }),
+    };
+    const runtimeControlService = {
+      request: vi.fn().mockResolvedValue({
+        success: true,
+        message: "runtime control should not run",
+      }),
+    };
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager,
+      adapter,
+      chatAgentLoopRunner: chatAgentLoopRunner as never,
+      llmClient: createMockLLMClient([
+        "not a freeform route decision",
+        JSON.stringify({
+          intent: "restart_daemon",
+          reason: "PulSeed を再起動して",
+        }),
+      ]),
+      runtimeControlService,
+    }));
+
+    const result = await manager.execute("PulSeed を再起動して", {
+      identity_key: "owner",
+      platform: "telegram",
+      conversation_id: "telegram-chat-1",
+      user_id: "user-1",
+      cwd: "/repo",
+      metadata: { runtime_control_denied: true },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("not authorized for runtime-control lifecycle actions");
+    expect(result.output).toContain("operation was not executed");
+    expect(result.output).toContain("will not fall back to shell tools");
+    expect(runtimeControlService.request).not.toHaveBeenCalled();
+    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
   });
 
   it("routes gateway natural-language run pause to runtime control with current reply target", async () => {

--- a/src/interface/chat/__tests__/ingress-router.test.ts
+++ b/src/interface/chat/__tests__/ingress-router.test.ts
@@ -65,7 +65,7 @@ describe("IngressRouter", () => {
 	    expect(route.eventProjectionPolicy).toBe("latest_active_reply_target");
 	  });
 
-	  it("does not route runtime-control text to runtime_control when the service is not wired", () => {
+	  it("fails closed for runtime-control text when the service is not wired", () => {
 	    const route = router.selectRoute(
 	      buildStandaloneIngressMessage({
 	        text: "PulSeed を再起動して",
@@ -87,10 +87,11 @@ describe("IngressRouter", () => {
 	      }
 	    );
 
-	    expect(route.kind).toBe("agent_loop");
+	    expect(route.kind).toBe("runtime_control_blocked");
+      expect(route.reason).toBe("runtime_control_unavailable");
 	  });
 
-  it("does not route runtime-control text to runtime_control when ingress policy disallows it", () => {
+  it("fails closed for runtime-control text when ingress policy disallows it", () => {
     const route = router.selectRoute(
       buildStandaloneIngressMessage({
         text: "PulSeed を再起動して",
@@ -112,7 +113,8 @@ describe("IngressRouter", () => {
       }
     );
 
-    expect(route.kind).toBe("agent_loop");
+    expect(route.kind).toBe("runtime_control_blocked");
+    expect(route.reason).toBe("runtime_control_disallowed");
   });
 
   it("keeps long-running natural-language work on agent_loop so tools can decide handoff", () => {

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -393,7 +393,7 @@ export class ChatRunnerEventBridge {
     const subject = formatIntentInput(input);
     let nextStep = "resume the saved agent loop state before continuing.";
     let reason = "resume needs the prior runtime context before any further action.";
-    if (selectedRoute?.kind === "runtime_control" && selectedRoute.intent) {
+    if ((selectedRoute?.kind === "runtime_control" || selectedRoute?.kind === "runtime_control_blocked") && selectedRoute.intent) {
       nextStep = `prepare the ${selectedRoute.intent.kind} runtime-control request.`;
       reason = "runtime changes need an explicit operation plan and approval path.";
     } else if (selectedRoute?.kind === "configure") {

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -93,6 +93,19 @@ export async function executeRuntimeControlRoute(
   };
 }
 
+export function formatBlockedRuntimeControlRoute(route: Extract<SelectedChatRoute, { kind: "runtime_control_blocked" }>): string {
+  if (route.reason === "runtime_control_disallowed") {
+    return [
+      `Runtime control ${route.intent.kind} was recognized, but this chat surface is not authorized for runtime-control lifecycle actions.`,
+      "The operation was not executed, and PulSeed will not fall back to shell tools for daemon or gateway lifecycle control.",
+    ].join("\n");
+  }
+  return [
+    `Runtime control ${route.intent.kind} was recognized, but the runtime-control service is not available in this chat surface.`,
+    "The operation was not executed, and PulSeed will not fall back to shell tools for daemon or gateway lifecycle control.",
+  ].join("\n");
+}
+
 export async function executeConfigureRoute(
   host: ChatRunnerRouteHost,
   route: SelectedChatRoute,

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -78,6 +78,7 @@ import {
   executeClarifyRoute,
   executeConfigureRoute,
   executeAgentLoopRoute,
+  formatBlockedRuntimeControlRoute,
   executeRuntimeControlRoute,
   executeToolLoopRoute,
   resolveSessionExecutionPolicy,
@@ -558,6 +559,25 @@ export class ChatRunner {
       return runtimeControlResult;
     }
 
+    if (selectedRoute?.kind === "runtime_control_blocked") {
+      const output = formatBlockedRuntimeControlRoute(selectedRoute);
+      this.eventBridge.pushAssistantDelta(output, assistantBuffer, eventContext);
+      await history.appendAssistantMessage(output);
+      this.eventBridge.emitEvent({
+        type: "assistant_final",
+        text: output,
+        persisted: true,
+        ...this.eventBridge.eventBase(eventContext),
+      });
+      const elapsed_ms = Date.now() - start;
+      this.eventBridge.emitLifecycleEndEvent("error", elapsed_ms, eventContext, true);
+      return {
+        success: false,
+        output,
+        elapsed_ms,
+      };
+    }
+
     if (selectedRoute?.kind === "configure") {
       const result = await executeConfigureRoute(this.routeHost(), selectedRoute, eventContext, assistantBuffer, history, start);
       return result;
@@ -723,19 +743,25 @@ export class ChatRunner {
 
   private async resolveRouteFromIngress(ingress: ChatIngressMessage): Promise<SelectedChatRoute> {
     const capabilities = getRouteCapabilities(this.deps);
-    const runtimeControlAllowed =
-      ingress.runtimeControl.allowed
-      && ingress.runtimeControl.approvalMode !== "disallowed"
-      && (
-        capabilities.hasRuntimeControlService
-        || (!capabilities.hasAgentLoop && !capabilities.hasToolLoop)
-      );
-    const runtimeControlIntent = runtimeControlAllowed
-      ? await recognizeRuntimeControlIntent(ingress.text, this.deps.llmClient)
-      : null;
-    const freeformRouteIntent = runtimeControlIntent === null && capabilities.hasAgentLoop
+    const shouldPreferFreeformBeforeDeniedRuntimeControl =
+      ingress.metadata["runtime_control_denied"] === true
+      && ingress.metadata["runtime_control_approved"] !== true
+      && ingress.metadata["runtime_control_explicit"] !== true
+      && capabilities.hasAgentLoop;
+    let freeformRouteIntent = shouldPreferFreeformBeforeDeniedRuntimeControl
       ? await classifyFreeformRouteIntent(ingress.text, this.deps.llmClient)
       : null;
+    const shouldClassifyRuntimeControl =
+      (capabilities.hasRuntimeControlService && ingress.runtimeControl.approvalMode !== "disallowed")
+      || ingress.metadata["runtime_control_approved"] === true
+      || ingress.metadata["runtime_control_denied"] === true
+      || ingress.metadata["runtime_control_explicit"] === true;
+    const runtimeControlIntent = freeformRouteIntent === null && shouldClassifyRuntimeControl
+      ? await recognizeRuntimeControlIntent(ingress.text, this.deps.llmClient)
+      : null;
+    if (freeformRouteIntent === null && runtimeControlIntent === null && capabilities.hasAgentLoop) {
+      freeformRouteIntent = await classifyFreeformRouteIntent(ingress.text, this.deps.llmClient);
+    }
     return standaloneIngressRouter.selectRoute(ingress, {
       ...capabilities,
       runtimeControlIntent,
@@ -922,8 +948,8 @@ export class ChatRunner {
             ? "- Telegram bot にメッセージを送って動作確認してください。"
             : "- Send a message to the Telegram bot to verify delivery."
           : this.turnLanguageHint.language === "ja"
-            ? "- 自動反映できなかったため、fallback として `pulseed daemon restart` を実行してから `pulseed daemon status` で確認してください。"
-            : "- Automatic refresh was not applied; as a fallback, run `pulseed daemon restart`, then `pulseed daemon status`.",
+            ? "- 自動反映できませんでした。daemon lifecycle 操作は typed runtime-control が利用可能な chat surface から再実行してください。"
+            : "- Automatic refresh was not applied. Retry the lifecycle refresh from a chat surface with typed runtime-control available.",
       ].join("\n"),
       elapsed_ms: 0,
     };

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -229,6 +229,8 @@ function resolveRuntimeControl(
   const approvalMode = runtimeControl?.approvalMode
     ?? (metadata?.["runtime_control_approved"] === true
       ? "preapproved"
+      : metadata?.["runtime_control_denied"] === true
+        ? "disallowed"
       : channel === "tui" || channel === "cli"
         ? "interactive"
         : "disallowed");
@@ -359,13 +361,13 @@ export class CrossPlatformChatSessionManager {
       channel: options.channel ?? (options.platform ? "plugin_gateway" : "cli"),
       actor: options.actor,
       replyTarget: options.replyTarget,
-      runtimeControl: options.runtimeControl ?? {
-        allowed: true,
-        approvalMode: "interactive",
-      },
+      runtimeControl: options.runtimeControl,
       cwd: options.cwd,
       timeoutMs: options.timeoutMs,
-      metadata: options.metadata,
+      metadata: {
+        ...(options.metadata ?? {}),
+        ...(options.runtimeControl ? { runtime_control_explicit: true } : {}),
+      },
       onEvent: options.onEvent,
     });
     const approvalReply = await this.tryResolveConversationalApprovalReply(ingress);
@@ -705,21 +707,27 @@ export class CrossPlatformChatSessionManager {
       hasToolLoop: this.deps.llmClient !== undefined,
       hasRuntimeControlService: this.deps.runtimeControlService !== undefined,
     };
-    const runtimeControlAllowed =
-      ingress.runtimeControl.allowed
-      && ingress.runtimeControl.approvalMode !== "disallowed"
-      && (
-        capabilities.hasRuntimeControlService
-        || (!capabilities.hasAgentLoop && !capabilities.hasToolLoop)
-      );
     const setupSecretIntake = intakeSetupSecrets(ingress.text);
     const safeIngressText = setupSecretIntake.redactedText;
-    const runtimeControlIntent = runtimeControlAllowed
-      ? await recognizeRuntimeControlIntent(safeIngressText, this.deps.llmClient)
-      : null;
-    const freeformRouteIntent = runtimeControlIntent === null && capabilities.hasAgentLoop
+    const shouldPreferFreeformBeforeDeniedRuntimeControl =
+      ingress.metadata["runtime_control_denied"] === true
+      && ingress.metadata["runtime_control_approved"] !== true
+      && ingress.metadata["runtime_control_explicit"] !== true
+      && capabilities.hasAgentLoop;
+    let freeformRouteIntent = shouldPreferFreeformBeforeDeniedRuntimeControl
       ? await classifyFreeformRouteIntent(safeIngressText, this.deps.llmClient)
       : null;
+    const shouldClassifyRuntimeControl =
+      (capabilities.hasRuntimeControlService && ingress.runtimeControl.approvalMode !== "disallowed")
+      || ingress.metadata["runtime_control_approved"] === true
+      || ingress.metadata["runtime_control_denied"] === true
+      || ingress.metadata["runtime_control_explicit"] === true;
+    const runtimeControlIntent = freeformRouteIntent === null && shouldClassifyRuntimeControl
+      ? await recognizeRuntimeControlIntent(safeIngressText, this.deps.llmClient)
+      : null;
+    if (freeformRouteIntent === null && runtimeControlIntent === null && capabilities.hasAgentLoop) {
+      freeformRouteIntent = await classifyFreeformRouteIntent(safeIngressText, this.deps.llmClient);
+    }
     const selectedRoute = this.ingressRouter.selectRoute(ingress, {
       ...capabilities,
       runtimeControlIntent,

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -73,6 +73,14 @@ export type SelectedChatRoute =
       replyTargetPolicy: ReplyTargetPolicy;
       eventProjectionPolicy: EventProjectionPolicy;
       concurrencyPolicy: ConcurrencyPolicy;
+    }
+  | {
+      kind: "runtime_control_blocked";
+      reason: "runtime_control_unavailable" | "runtime_control_disallowed";
+      intent: RuntimeControlIntent;
+      replyTargetPolicy: ReplyTargetPolicy;
+      eventProjectionPolicy: EventProjectionPolicy;
+      concurrencyPolicy: ConcurrencyPolicy;
     };
 
 export interface IngressRouterCapabilities {
@@ -104,16 +112,28 @@ function selectRouteForText(
 
   if (canUseRuntimeControlRoute) {
     const intent = deps.runtimeControlIntent ?? null;
-    if (
-      intent !== null
-      && (
-        deps.hasRuntimeControlService === true
-        || (!deps.hasAgentLoop && !deps.hasToolLoop)
-      )
-    ) {
+    if (intent !== null && deps.hasRuntimeControlService === true) {
       return {
         kind: "runtime_control",
         reason: "runtime_control_intent",
+        intent,
+        ...runtimeControlPolicy,
+      };
+    }
+    if (intent !== null) {
+      return {
+        kind: "runtime_control_blocked",
+        reason: "runtime_control_unavailable",
+        intent,
+        ...runtimeControlPolicy,
+      };
+    }
+  } else {
+    const intent = deps.runtimeControlIntent ?? null;
+    if (intent !== null) {
+      return {
+        kind: "runtime_control_blocked",
+        reason: "runtime_control_disallowed",
         intent,
         ...runtimeControlPolicy,
       };
@@ -270,11 +290,12 @@ export function normalizeLegacyIngressInput(input: NormalizeLegacyIngressInput):
   const preapproved = input.runtimeControl?.approvalMode === "preapproved"
     || input.runtimeControl?.approval_mode === "preapproved"
     || metadata["runtime_control_approved"] === true;
+  const disallowedByMetadata = metadata["runtime_control_denied"] === true;
   const interactiveDefault = channel === "tui" || channel === "cli";
   const allowed = input.runtimeControl?.allowed ?? (preapproved || interactiveDefault);
   const approvalMode = input.runtimeControl?.approvalMode
     ?? input.runtimeControl?.approval_mode
-    ?? (preapproved ? "preapproved" : interactiveDefault ? "interactive" : "disallowed");
+    ?? (preapproved ? "preapproved" : disallowedByMetadata ? "disallowed" : interactiveDefault ? "interactive" : "disallowed");
 
   const actor: RuntimeControlActor = input.actor ?? {
     surface: actorSurface,

--- a/src/runtime/control/runtime-control-intent.ts
+++ b/src/runtime/control/runtime-control-intent.ts
@@ -83,8 +83,12 @@ export async function recognizeRuntimeControlIntent(
       model_tier: "light",
     }
   );
-  const decision = llmClient.parseJSON(response.content, RuntimeControlIntentDecisionSchema);
-  return toRuntimeControlIntent(trimmed, decision);
+  try {
+    const decision = llmClient.parseJSON(response.content, RuntimeControlIntentDecisionSchema);
+    return toRuntimeControlIntent(trimmed, decision);
+  } catch {
+    return null;
+  }
 }
 
 function toRuntimeControlIntent(

--- a/src/runtime/gateway/__tests__/channel-policy.test.ts
+++ b/src/runtime/gateway/__tests__/channel-policy.test.ts
@@ -26,7 +26,16 @@ describe("channel policy", () => {
       { platform: "slack", senderId: "admin" }
     );
 
-    expect(decision).toEqual({ allowed: true, runtimeControlApproved: true });
+    expect(decision).toEqual({ allowed: true, runtimeControlApproved: true, runtimeControlConfigured: true });
+  });
+
+  it("marks runtime control as configured when sender is not approved for it", () => {
+    const decision = evaluateChannelAccess(
+      { allowAll: true, runtimeControlAllowedSenderIds: ["admin"] },
+      { platform: "slack", senderId: "user-2" }
+    );
+
+    expect(decision).toEqual({ allowed: true, runtimeControlApproved: false, runtimeControlConfigured: true });
   });
 
   it("routes conversation before sender and default", () => {

--- a/src/runtime/gateway/channel-policy.ts
+++ b/src/runtime/gateway/channel-policy.ts
@@ -32,6 +32,7 @@ export interface ChannelAccessDecision {
   allowed: boolean;
   reason?: "sender_denied" | "sender_not_allowed" | "conversation_denied" | "conversation_not_allowed";
   runtimeControlApproved: boolean;
+  runtimeControlConfigured: boolean;
 }
 
 export interface ChannelRouteDecision {
@@ -59,7 +60,7 @@ export function evaluateChannelAccess(
 ): ChannelAccessDecision {
   const denySenders = policy?.deniedSenderIds;
   if (includes(denySenders, context.senderId)) {
-    return { allowed: false, reason: "sender_denied", runtimeControlApproved: false };
+    return { allowed: false, reason: "sender_denied", runtimeControlApproved: false, runtimeControlConfigured: false };
   }
 
   const denyConversations = policy?.deniedConversationIds;
@@ -67,13 +68,13 @@ export function evaluateChannelAccess(
     includes(denyConversations, context.conversationId) ||
     includes(denyConversations, context.channelId)
   ) {
-    return { allowed: false, reason: "conversation_denied", runtimeControlApproved: false };
+    return { allowed: false, reason: "conversation_denied", runtimeControlApproved: false, runtimeControlConfigured: false };
   }
 
   const allowAll = policy?.allowAll ?? false;
   const allowSenders = policy?.allowedSenderIds;
   if (!allowAll && isRestrictedByAllowlist(allowSenders) && !includes(allowSenders, context.senderId)) {
-    return { allowed: false, reason: "sender_not_allowed", runtimeControlApproved: false };
+    return { allowed: false, reason: "sender_not_allowed", runtimeControlApproved: false, runtimeControlConfigured: false };
   }
 
   const allowConversations = policy?.allowedConversationIds;
@@ -82,12 +83,14 @@ export function evaluateChannelAccess(
     !includes(allowConversations, context.conversationId) &&
     !includes(allowConversations, context.channelId)
   ) {
-    return { allowed: false, reason: "conversation_not_allowed", runtimeControlApproved: false };
+    return { allowed: false, reason: "conversation_not_allowed", runtimeControlApproved: false, runtimeControlConfigured: false };
   }
+  const runtimeControlConfigured = isRestrictedByAllowlist(policy?.runtimeControlAllowedSenderIds);
 
   return {
     allowed: true,
     runtimeControlApproved: includes(policy?.runtimeControlAllowedSenderIds, context.senderId),
+    runtimeControlConfigured,
   };
 }
 

--- a/src/runtime/gateway/discord-gateway-adapter.ts
+++ b/src/runtime/gateway/discord-gateway-adapter.ts
@@ -218,6 +218,7 @@ export class DiscordGatewayAdapter implements ChannelAdapter {
         guild_id: payload.guild_id,
         ...(route.goalId ? { goal_id: route.goalId } : {}),
         ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+        ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
       },
     }).catch(() => undefined);
 

--- a/src/runtime/gateway/ingress-gateway.ts
+++ b/src/runtime/gateway/ingress-gateway.ts
@@ -140,6 +140,7 @@ export class IngressGateway {
     setEnvelopeMetadata(envelope, {
       ...route.metadata,
       ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+      ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
     });
     return true;
   }

--- a/src/runtime/gateway/signal-gateway-adapter.ts
+++ b/src/runtime/gateway/signal-gateway-adapter.ts
@@ -143,6 +143,7 @@ export class SignalGatewayAdapter implements ChannelAdapter {
           ...normalized.metadata,
           ...(route.goalId ? { goal_id: route.goalId } : {}),
           ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+          ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
         },
       });
 

--- a/src/runtime/gateway/slack-channel-adapter.ts
+++ b/src/runtime/gateway/slack-channel-adapter.ts
@@ -175,6 +175,7 @@ export class SlackChannelAdapter implements ChannelAdapter {
       slack_event_id: parsed["event_id"],
       ...(route.goalId ? { goal_id: route.goalId } : {}),
       ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+      ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
     };
 
     if (isSlackChatTextEvent(slackEvent, eventType) && this.api) {

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -175,6 +175,7 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
         chat_id: chatId,
         ...(route.goalId ? { goal_id: route.goalId } : {}),
         ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+        ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
       },
     });
 

--- a/src/runtime/gateway/whatsapp-gateway-adapter.ts
+++ b/src/runtime/gateway/whatsapp-gateway-adapter.ts
@@ -199,6 +199,7 @@ export class WhatsAppGatewayAdapter implements ChannelAdapter {
         timestamp: message.timestamp,
         ...(route.goalId ? { goal_id: route.goalId } : {}),
         ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+        ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
       },
     });
 

--- a/src/runtime/gateway/ws-channel-adapter.ts
+++ b/src/runtime/gateway/ws-channel-adapter.ts
@@ -128,6 +128,7 @@ export class WsChannelAdapter implements ChannelAdapter {
     (envelope as Record<string, unknown>)["metadata"] = {
       ...route.metadata,
       ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+      ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
     };
 
     const reply: ReplyChannel = {

--- a/tmp/autonomous-runtime-control-safety-status.md
+++ b/tmp/autonomous-runtime-control-safety-status.md
@@ -4,14 +4,14 @@ Started: 2026-05-03
 
 ## Scope
 
-- #996: open, active first. Goal is to preserve approval-denied/not-executed tool facts through chat agent-loop final output.
-- #995: open, queued after #996. Goal is to route daemon lifecycle intent through typed runtime-control or fail closed.
+- #996: merged via PR #1002. Goal was to preserve approval-denied/not-executed tool facts through chat agent-loop final output.
+- #995: open, active. Goal is to route daemon lifecycle intent through typed runtime-control or fail closed.
 
 ## Working Notes
 
 - Main was refreshed with `git switch main && git pull --ff-only`.
 - Open issue list was checked with `gh issue list --state open --limit 100`.
-- Existing unrelated worktree change observed: `tmp/autonomous-chat-setup-ux-status.md`. It will not be touched.
+- Existing unrelated worktree change observed: `tmp/autonomous-chat-setup-ux-status.md`. It will not be staged or included.
 
 ## #996 Plan
 
@@ -38,3 +38,48 @@ Started: 2026-05-03
   - `npm run lint:boundaries`: passed with existing warnings, no errors.
   - `npm run test:changed`: passed, 35 files passed and 3 skipped in related tests.
 - Second fresh review after fixes: no findings.
+- PR #1002 CI: `unit (22)` passed, `integration (24)` passed.
+- PR #1002 merged with squash and branch deletion.
+
+## #995 Plan
+
+1. Done: inspected the current ingress/runtime-control route and production caller tests.
+2. Done: identified fallback risk where runtime-control intent was only classified when service/policy allowed runtime-control route.
+3. Done: added/adjusted production caller-path tests for runtime-control available and unavailable/not allowed.
+4. Done: implemented `runtime_control_blocked` fail-closed routing without adding keyword/regex/includes freeform classifiers.
+5. In progress: verification and fresh review.
+
+## #995 Verification
+
+- `npm test -- src/interface/chat/__tests__/ingress-router.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/runtime/control/__tests__/runtime-control-intent.test.ts`: passed.
+- `npm run typecheck`: passed.
+- `npm run lint:boundaries`: passed with existing warnings, no errors.
+- `npm run test:changed`: passed, including related unit/integration and smoke lanes.
+- `git diff --check`: passed.
+- First fresh review agent: found one material issue.
+  - Fixed P1: disallowed gateway messages no longer all pay runtime-control classification first. Gateway policies now emit typed `runtime_control_denied` metadata only when runtime-control allowlist is configured and the sender is not approved. Fail-closed classification uses that metadata or an explicit runtime-control request, while ordinary setup/chat routing is not preempted.
+- Re-verification after review fix:
+  - `npm test -- src/interface/chat/__tests__/chat-boundary-contract.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/ingress-router.test.ts src/runtime/gateway/__tests__/channel-policy.test.ts`: passed.
+  - `npm run typecheck`: passed.
+  - `npm run lint:boundaries`: passed with existing warnings, no errors.
+  - `npm run test:changed`: passed, including related unit/integration and smoke lanes.
+  - `git diff --check`: passed.
+- Second fresh review agent: found two material issues.
+  - Fixed P1: runtime-control classification no longer preempts all ordinary disallowed gateway messages just because the runtime-control service is wired.
+  - Fixed P1: unavailable runtime-control fail-closed coverage now uses an explicit runtime-control contract instead of relying on broad CLI/TUI channel heuristics.
+- Re-verification after second review fix:
+  - `npm test -- src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/chat-boundary-contract.test.ts src/interface/chat/__tests__/ingress-router.test.ts`: passed, 35 tests.
+  - `npm run test:changed`: passed, including related unit/integration and smoke lanes.
+  - `npm run typecheck`: passed.
+  - `npm run lint:boundaries`: passed with existing warnings, no errors.
+  - `git diff --check`: passed.
+- Final fresh review after second fix: found two material issues.
+  - Fixed P1: post-setup refresh failure/unavailable responses no longer tell the operator to use `pulseed daemon restart/status` as shell lifecycle fallback.
+  - Fixed P1: denied gateway metadata no longer blocks setup/configure routing before the runtime-control classifier; denied lifecycle messages still fail closed after setup/configure is ruled out.
+- Re-verification after final review fixes:
+  - `npm test -- src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/chat-runner.test.ts`: passed, 140 tests.
+  - `npm run typecheck`: passed.
+  - `npm run lint:boundaries`: passed with existing warnings, no errors.
+  - `npm run test:changed`: passed, including related unit/integration and smoke lanes.
+  - `git diff --check`: passed.
+- Final re-review after fixes: no findings.


### PR DESCRIPTION
Closes #995

## Summary
- add a typed `runtime_control_blocked` route so recognized daemon/gateway lifecycle intent fails closed when runtime control is unavailable or disallowed
- preserve gateway approval metadata while preventing denied runtime-control metadata from preempting ordinary setup/configure routing
- remove shell lifecycle fallback text from chat-assisted setup refresh failure paths
- add production caller-path tests for available, unavailable, and unauthorized runtime-control routing without agent-loop shell fallback

## Verification
- `npm test -- src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/chat-runner.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (existing warnings, 0 errors)
- `npm run test:changed`
- `git diff --check`
- fresh review agent re-review: no findings

## Known unresolved risks
- Existing repository-wide lint warnings remain unchanged.