### PR TITLE
Expose operator binding status

### DIFF
--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -13,6 +13,8 @@ import { BackgroundRunLedger } from "../../../runtime/store/background-run-store
 import { RuntimeEvidenceLedger } from "../../../runtime/store/evidence-ledger.js";
 import { RuntimeExperimentQueueStore } from "../../../runtime/store/experiment-queue-store.js";
 import { RuntimeBudgetStore } from "../../../runtime/store/budget-store.js";
+import { RuntimeHealthStore } from "../../../runtime/store/health-store.js";
+import * as daemonClient from "../../../runtime/daemon/client.js";
 
 describe("runtime registry CLI commands", () => {
   let tmpDir: string;
@@ -110,6 +112,182 @@ describe("runtime registry CLI commands", () => {
         status: "failed",
       }),
     ]);
+  });
+
+  it("surfaces operator channel bindings, runtime-control warnings, and pinned reply targets", async () => {
+    vi.spyOn(daemonClient, "isDaemonRunning").mockResolvedValue({ running: true, port: 47321 });
+    const runtimeRoot = path.join(tmpDir, "resident-runtime");
+    await stateManager.writeRaw("daemon.json", { runtime_root: "resident-runtime" });
+    await new RuntimeHealthStore(runtimeRoot).saveSnapshot({
+      status: "ok",
+      leader: true,
+      checked_at: Date.parse("2026-05-03T00:00:00.000Z"),
+      components: {
+        gateway: "ok",
+        queue: "ok",
+        leases: "ok",
+        approval: "ok",
+        outbox: "ok",
+        supervisor: "ok",
+      },
+    });
+    await stateManager.writeRaw("gateway/channels/telegram-bot/config.json", {
+      bot_token: "token",
+      chat_id: 12345,
+      allowed_user_ids: [67890],
+      denied_user_ids: [],
+      allowed_chat_ids: [],
+      denied_chat_ids: [],
+      runtime_control_allowed_user_ids: [],
+      chat_goal_map: { "12345": "goal-home" },
+      user_goal_map: {},
+      default_goal_id: "goal-home",
+      allow_all: false,
+      polling_timeout: 20,
+      identity_key: "personal",
+    });
+    await stateManager.writeRaw("gateway/channels/discord-bot/config.json", {
+      application_id: "app",
+      bot_token: "token",
+      channel_id: "channel-1",
+      identity_key: "discord:team",
+      command_name: "pulseed",
+      host: "127.0.0.1",
+      port: 9000,
+      ephemeral: false,
+      runtime_control_allowed_sender_ids: ["user-1"],
+      allowed_sender_ids: ["user-1"],
+      denied_sender_ids: [],
+      allowed_conversation_ids: [],
+      denied_conversation_ids: [],
+      conversation_goal_map: {},
+      sender_goal_map: {},
+    });
+    await new BackgroundRunLedger(runtimeRoot).create({
+      id: "run:coreloop:pinned",
+      kind: "coreloop_run",
+      status: "running",
+      notify_policy: "done_only",
+      reply_target_source: "pinned_run",
+      pinned_reply_target: { channel: "telegram", target_id: "12345" },
+      parent_session_id: "session:conversation:chat-a",
+      goal_id: "goal-home",
+      title: "Pinned home run",
+      workspace: "/repo",
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("runtime", "bindings", "--json");
+    const output = logSpy.mock.calls.map((call) => call.join("\n")).join("\n");
+    const parsed = JSON.parse(output) as {
+      daemon: { running: boolean; runtime_root: string };
+      channels: Array<{
+        name: string;
+        state: string;
+        home_target: { target_id?: string } | null;
+        goal_bindings: Array<{ scope: string; subject_id: string | null; goal_id: string }>;
+        runtime_control: { state: string };
+      }>;
+      background_runs: Array<{ id: string; pinned_reply_target: { channel: string; target_id?: string } | null }>;
+      warnings: string[];
+    };
+
+    expect(code).toBe(0);
+    expect(parsed.daemon.running).toBe(true);
+    expect(parsed.channels).toContainEqual(expect.objectContaining({
+      name: "telegram-bot",
+      state: "active",
+      home_target: expect.objectContaining({ target_id: "12345" }),
+      goal_bindings: expect.arrayContaining([
+        { scope: "conversation", subject_id: "12345", goal_id: "goal-home" },
+        { scope: "default", subject_id: null, goal_id: "goal-home" },
+      ]),
+      runtime_control: { state: "missing_allowlist", allowed_count: 0 },
+    }));
+    expect(parsed.daemon.runtime_root).toBe(runtimeRoot);
+    expect(parsed.channels).toContainEqual(expect.objectContaining({
+      name: "discord-bot",
+      state: "active",
+      runtime_control: { state: "allowed", allowed_count: 1 },
+    }));
+    expect(parsed.channels).toContainEqual(expect.objectContaining({
+      name: "signal-bridge",
+      state: "missing",
+    }));
+    expect(parsed.background_runs).toContainEqual(expect.objectContaining({
+      id: "run:coreloop:pinned",
+      pinned_reply_target: expect.objectContaining({ channel: "telegram", target_id: "12345" }),
+    }));
+    expect(parsed.warnings).toContain("telegram-bot: Missing Telegram runtime-control allowed user list.");
+  });
+
+  it("marks configured channels inactive when daemon health is missing", async () => {
+    vi.spyOn(daemonClient, "isDaemonRunning").mockResolvedValue({ running: false, port: 0 });
+    await stateManager.writeRaw("gateway/channels/telegram-bot/config.json", {
+      bot_token: "token",
+      allowed_user_ids: [67890],
+      denied_user_ids: [],
+      allowed_chat_ids: [],
+      denied_chat_ids: [],
+      runtime_control_allowed_user_ids: [67890],
+      chat_goal_map: {},
+      user_goal_map: {},
+      allow_all: false,
+      polling_timeout: 20,
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("runtime", "bindings", "--json");
+    const parsed = JSON.parse(logSpy.mock.calls.map((call) => call.join("\n")).join("\n")) as {
+      channels: Array<{ name: string; state: string; home_target: unknown }>;
+      warnings: string[];
+    };
+
+    expect(code).toBe(0);
+    expect(parsed.channels).toContainEqual(expect.objectContaining({
+      name: "telegram-bot",
+      state: "configured",
+      home_target: null,
+    }));
+    expect(parsed.warnings).toContain("telegram-bot: Missing Telegram home chat. Send /sethome from the target chat.");
+    expect(parsed.warnings).toContain("Daemon is not running.");
+  });
+
+  it("marks partially invalid non-Telegram channel config as degraded", async () => {
+    vi.spyOn(daemonClient, "isDaemonRunning").mockResolvedValue({ running: true, port: 47321 });
+    await new RuntimeHealthStore(path.join(tmpDir, "runtime")).saveSnapshot({
+      status: "ok",
+      leader: true,
+      checked_at: Date.parse("2026-05-03T00:00:00.000Z"),
+      components: {
+        gateway: "ok",
+        queue: "ok",
+        leases: "ok",
+        approval: "ok",
+        outbox: "ok",
+        supervisor: "ok",
+      },
+    });
+    await stateManager.writeRaw("gateway/channels/discord-bot/config.json", {
+      channel_id: "channel-1",
+      identity_key: "discord:team",
+      runtime_control_allowed_sender_ids: ["user-1"],
+    });
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const code = await runCLI("runtime", "bindings", "--json");
+    const parsed = JSON.parse(logSpy.mock.calls.map((call) => call.join("\n")).join("\n")) as {
+      channels: Array<{ name: string; state: string; degraded: boolean }>;
+      warnings: string[];
+    };
+
+    expect(code).toBe(0);
+    expect(parsed.channels).toContainEqual(expect.objectContaining({
+      name: "discord-bot",
+      state: "degraded",
+      degraded: true,
+    }));
+    expect(parsed.warnings).toContain("discord-bot: Invalid discord-bot config: missing application_id, bot_token, command_name, host.");
   });
 
   it("shows one runtime session as JSON", async () => {

--- a/src/interface/cli/commands/operator-binding-status.ts
+++ b/src/interface/cli/commands/operator-binding-status.ts
@@ -1,0 +1,310 @@
+import * as path from "node:path";
+
+import type { StateManager } from "../../../base/state/state-manager.js";
+import { readJsonFileOrNull } from "../../../base/utils/json-io.js";
+import { getGatewayChannelDir } from "../../../base/utils/paths.js";
+import { isDaemonRunning } from "../../../runtime/daemon/client.js";
+import { resolveConfiguredDaemonRuntimeRoot } from "../../../runtime/daemon/runtime-root.js";
+import { BUILTIN_GATEWAY_CHANNEL_NAMES, type BuiltinGatewayChannelName } from "../../../runtime/gateway/builtin-channel-names.js";
+import { createRuntimeSessionRegistry } from "../../../runtime/session-registry/index.js";
+import type { BackgroundRun, RuntimeReplyTarget, RuntimeSession } from "../../../runtime/session-registry/types.js";
+import { BackgroundRunLedger } from "../../../runtime/store/background-run-store.js";
+import { RuntimeHealthStore } from "../../../runtime/store/health-store.js";
+import type { RuntimeHealthSnapshot } from "../../../runtime/store/runtime-schemas.js";
+
+export type OperatorChannelState = "missing" | "configured" | "active" | "degraded";
+export type RuntimeControlPermissionState = "allowed" | "missing_allowlist" | "unrestricted" | "unsupported";
+
+export interface OperatorChannelBindingStatus {
+  name: BuiltinGatewayChannelName | "slack";
+  state: OperatorChannelState;
+  config_path: string;
+  configured: boolean;
+  active: boolean;
+  degraded: boolean;
+  home_target: RuntimeReplyTarget | null;
+  identity_key: string | null;
+  default_goal_id: string | null;
+  goal_bindings: OperatorChannelGoalBinding[];
+  runtime_control: {
+    state: RuntimeControlPermissionState;
+    allowed_count: number;
+  };
+  health: {
+    daemon_running: boolean;
+    gateway: RuntimeHealthSnapshot["status"] | "missing";
+    checked_at: number | null;
+  };
+  warnings: string[];
+}
+
+export interface OperatorBindingStatus {
+  schema_version: "operator-binding-status-v1";
+  generated_at: string;
+  daemon: {
+    running: boolean;
+    port: number;
+    health: RuntimeHealthSnapshot["status"] | "missing";
+    runtime_root: string;
+  };
+  channels: OperatorChannelBindingStatus[];
+  sessions: RuntimeSession[];
+  background_runs: BackgroundRun[];
+  warnings: string[];
+}
+
+interface ChannelConfigSummary {
+  configured: boolean;
+  valid: boolean;
+  homeTarget: RuntimeReplyTarget | null;
+  identityKey: string | null;
+  defaultGoalId: string | null;
+  goalBindings: OperatorChannelGoalBinding[];
+  runtimeControlAllowedCount: number;
+  runtimeControlState: RuntimeControlPermissionState;
+  warnings: string[];
+}
+
+export interface OperatorChannelGoalBinding {
+  scope: "conversation" | "sender" | "default";
+  subject_id: string | null;
+  goal_id: string;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function arrayCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+function goalBindingsFromMap(scope: "conversation" | "sender", value: unknown): OperatorChannelGoalBinding[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+  return Object.entries(value as Record<string, unknown>).flatMap(([subjectId, goalId]) => {
+    const normalizedGoalId = nonEmptyString(goalId);
+    return normalizedGoalId ? [{ scope, subject_id: subjectId, goal_id: normalizedGoalId }] : [];
+  });
+}
+
+function defaultGoalBinding(goalId: string | null): OperatorChannelGoalBinding[] {
+  return goalId ? [{ scope: "default", subject_id: null, goal_id: goalId }] : [];
+}
+
+const REQUIRED_SENDER_CONFIG_FIELDS = {
+  "discord-bot": ["application_id", "bot_token", "channel_id", "identity_key", "command_name", "host"],
+  "signal-bridge": ["bridge_url", "account", "recipient_id", "identity_key"],
+  "whatsapp-webhook": ["phone_number_id", "access_token", "verify_token", "recipient_id", "identity_key", "host", "path"],
+} as const satisfies Record<Exclude<BuiltinGatewayChannelName, "telegram-bot">, readonly string[]>;
+
+function missingRequiredFields(raw: Record<string, unknown>, channel: Exclude<BuiltinGatewayChannelName, "telegram-bot">): string[] {
+  return REQUIRED_SENDER_CONFIG_FIELDS[channel].filter((field) => nonEmptyString(raw[field]) === null);
+}
+
+function telegramSummary(raw: Record<string, unknown> | null): ChannelConfigSummary {
+  if (!raw) return missingSummary();
+  const hasBotToken = nonEmptyString(raw["bot_token"]) !== null;
+  const warnings: string[] = [];
+  const chatId = typeof raw["chat_id"] === "number" ? String(raw["chat_id"]) : null;
+  const runtimeAllowedCount = arrayCount(raw["runtime_control_allowed_user_ids"]);
+  const defaultGoalId = nonEmptyString(raw["default_goal_id"]);
+  if (!chatId) warnings.push("Missing Telegram home chat. Send /sethome from the target chat.");
+  if (runtimeAllowedCount === 0) warnings.push("Missing Telegram runtime-control allowed user list.");
+  return {
+    configured: true,
+    valid: hasBotToken,
+    homeTarget: chatId ? { channel: "telegram", target_id: chatId } : null,
+    identityKey: nonEmptyString(raw["identity_key"]),
+    defaultGoalId,
+    goalBindings: [
+      ...goalBindingsFromMap("conversation", raw["chat_goal_map"]),
+      ...goalBindingsFromMap("sender", raw["user_goal_map"]),
+      ...defaultGoalBinding(defaultGoalId),
+    ],
+    runtimeControlAllowedCount: runtimeAllowedCount,
+    runtimeControlState: raw["allow_all"] === true
+      ? "unrestricted"
+      : runtimeAllowedCount > 0
+        ? "allowed"
+        : "missing_allowlist",
+    warnings: [
+      ...warnings,
+      ...(!hasBotToken ? ["Invalid Telegram config: bot_token is missing."] : []),
+      ...(raw["allow_all"] === true ? ["Telegram unrestricted allow_all is enabled."] : []),
+    ],
+  };
+}
+
+function senderSummary(raw: Record<string, unknown> | null, channel: Exclude<BuiltinGatewayChannelName, "telegram-bot">): ChannelConfigSummary {
+  if (!raw) return missingSummary();
+  const runtimeAllowedCount = arrayCount(raw["runtime_control_allowed_sender_ids"]);
+  const identityKey = nonEmptyString(raw["identity_key"]);
+  const defaultGoalId = nonEmptyString(raw["default_goal_id"]);
+  const missingFields = missingRequiredFields(raw, channel);
+  const targetId =
+    nonEmptyString(raw["channel_id"])
+    ?? nonEmptyString(raw["recipient_id"])
+    ?? nonEmptyString(raw["account"]);
+  const warnings: string[] = [];
+  if (runtimeAllowedCount === 0) warnings.push(`Missing ${channel} runtime-control allowed sender list.`);
+  if (!targetId) warnings.push(`Missing ${channel} default reply target.`);
+  return {
+    configured: true,
+    valid: missingFields.length === 0,
+    homeTarget: targetId ? { channel, target_id: targetId } : null,
+    identityKey,
+    defaultGoalId,
+    goalBindings: [
+      ...goalBindingsFromMap("conversation", raw["conversation_goal_map"]),
+      ...goalBindingsFromMap("sender", raw["sender_goal_map"]),
+      ...defaultGoalBinding(defaultGoalId),
+    ],
+    runtimeControlAllowedCount: runtimeAllowedCount,
+    runtimeControlState: runtimeAllowedCount > 0 ? "allowed" : "missing_allowlist",
+    warnings: [
+      ...warnings,
+      ...(missingFields.length > 0 ? [`Invalid ${channel} config: missing ${missingFields.join(", ")}.`] : []),
+    ],
+  };
+}
+
+function missingSummary(): ChannelConfigSummary {
+  return {
+    configured: false,
+    valid: false,
+    homeTarget: null,
+    identityKey: null,
+    defaultGoalId: null,
+    goalBindings: [],
+    runtimeControlAllowedCount: 0,
+    runtimeControlState: "unsupported",
+    warnings: [],
+  };
+}
+
+function channelConfigPath(baseDir: string, channel: BuiltinGatewayChannelName): string {
+  return path.join(getGatewayChannelDir(channel, baseDir), "config.json");
+}
+
+async function loadRawConfig(filePath: string): Promise<Record<string, unknown> | null> {
+  const raw = await readJsonFileOrNull<unknown>(filePath);
+  return raw && typeof raw === "object" && !Array.isArray(raw) ? raw as Record<string, unknown> : null;
+}
+
+function channelState(summary: ChannelConfigSummary, daemonRunning: boolean, gatewayHealth: RuntimeHealthSnapshot["status"] | "missing"): OperatorChannelState {
+  if (!summary.configured) return "missing";
+  if (!summary.valid || gatewayHealth === "failed" || gatewayHealth === "degraded") return "degraded";
+  if (daemonRunning && gatewayHealth === "ok") return "active";
+  return "configured";
+}
+
+function activeRun(run: BackgroundRun): boolean {
+  return run.status === "queued" || run.status === "running" || run.status === "failed" || run.status === "timed_out" || run.status === "lost";
+}
+
+function formatReplyTarget(target: RuntimeReplyTarget | null): string {
+  if (!target) return "-";
+  const targetId = target.target_id ?? target.thread_id ?? null;
+  return targetId ? `${target.channel}:${targetId}` : target.channel;
+}
+
+export async function collectOperatorBindingStatus(stateManager: StateManager): Promise<OperatorBindingStatus> {
+  const baseDir = stateManager.getBaseDir();
+  const runtimeRoot = resolveConfiguredDaemonRuntimeRoot(baseDir);
+  const [daemon, health, registrySnapshot] = await Promise.all([
+    isDaemonRunning(baseDir),
+    new RuntimeHealthStore(runtimeRoot).loadSnapshot(),
+    createRuntimeSessionRegistry({
+      stateManager,
+      backgroundRunLedger: new BackgroundRunLedger(runtimeRoot),
+    }).snapshot(),
+  ]);
+  const gatewayHealth = health?.components.gateway ?? "missing";
+  const channels: OperatorChannelBindingStatus[] = [];
+  for (const name of BUILTIN_GATEWAY_CHANNEL_NAMES) {
+    const configPath = channelConfigPath(baseDir, name);
+    const raw = await loadRawConfig(configPath);
+    const summary = name === "telegram-bot" ? telegramSummary(raw) : senderSummary(raw, name);
+    const state = channelState(summary, daemon.running, gatewayHealth);
+    channels.push({
+      name,
+      state,
+      config_path: configPath,
+      configured: summary.configured,
+      active: state === "active",
+      degraded: state === "degraded",
+      home_target: summary.homeTarget,
+      identity_key: summary.identityKey,
+      default_goal_id: summary.defaultGoalId,
+      goal_bindings: summary.goalBindings,
+      runtime_control: {
+        state: summary.runtimeControlState,
+        allowed_count: summary.runtimeControlAllowedCount,
+      },
+      health: {
+        daemon_running: daemon.running,
+        gateway: gatewayHealth,
+        checked_at: health?.checked_at ?? null,
+      },
+      warnings: summary.warnings,
+    });
+  }
+
+  const warnings = [
+    ...registrySnapshot.warnings.map((warning) => warning.message),
+    ...channels.flatMap((channel) => channel.warnings.map((warning) => `${channel.name}: ${warning}`)),
+    ...(!daemon.running ? ["Daemon is not running."] : []),
+  ];
+
+  return {
+    schema_version: "operator-binding-status-v1",
+    generated_at: new Date().toISOString(),
+    daemon: {
+      running: daemon.running,
+      port: daemon.port,
+      health: health?.status ?? "missing",
+      runtime_root: runtimeRoot,
+    },
+    channels,
+    sessions: registrySnapshot.sessions,
+    background_runs: registrySnapshot.background_runs.filter(activeRun),
+    warnings,
+  };
+}
+
+export function printOperatorBindingStatus(status: OperatorBindingStatus): void {
+  console.log("Operator bindings:");
+  console.log(`Daemon: ${status.daemon.running ? "running" : "down"} (port ${status.daemon.port || "-"}) health=${status.daemon.health} runtime_root=${status.daemon.runtime_root}`);
+  console.log("\nChannels:");
+  for (const channel of status.channels) {
+    console.log(
+      `- ${channel.name}: ${channel.state}; home=${formatReplyTarget(channel.home_target)}; identity=${channel.identity_key ?? "-"}; runtime_control=${channel.runtime_control.state} (${channel.runtime_control.allowed_count})`
+    );
+    for (const binding of channel.goal_bindings) {
+      const subject = binding.subject_id ? `${binding.scope}:${binding.subject_id}` : binding.scope;
+      console.log(`  goal_binding ${subject} -> ${binding.goal_id}`);
+    }
+  }
+  console.log("\nSessions:");
+  if (status.sessions.length === 0) {
+    console.log("- none");
+  } else {
+    for (const session of status.sessions) {
+      console.log(`- ${session.id} [${session.kind}/${session.status}] workspace=${session.workspace ?? "-"} reply=${formatReplyTarget(session.reply_target)}`);
+    }
+  }
+  console.log("\nBackground runs:");
+  if (status.background_runs.length === 0) {
+    console.log("- none");
+  } else {
+    for (const run of status.background_runs) {
+      console.log(
+        `- ${run.id} [${run.kind}/${run.status}] parent=${run.parent_session_id ?? "-"} goal=${run.goal_id ?? "-"} pinned_reply=${formatReplyTarget(run.pinned_reply_target)}`
+      );
+    }
+  }
+  if (status.warnings.length > 0) {
+    console.log("\nWarnings:");
+    for (const warning of status.warnings) console.log(`- ${warning}`);
+  }
+}

--- a/src/interface/cli/commands/runtime.ts
+++ b/src/interface/cli/commands/runtime.ts
@@ -40,6 +40,7 @@ import type {
 import { getCliLogger } from "../cli-logger.js";
 import { formatOperationError } from "../utils.js";
 import { resolveConfiguredDaemonRuntimeRoot } from "../../../runtime/daemon/runtime-root.js";
+import { collectOperatorBindingStatus, printOperatorBindingStatus } from "./operator-binding-status.js";
 
 const ID_WIDTH = 34;
 const KIND_WIDTH = 12;
@@ -425,11 +426,18 @@ export async function cmdRuntime(stateManager: StateManager, args: string[]): Pr
   const runtimeSubcommand = args[0];
 
   if (!runtimeSubcommand) {
-    logger.error("Error: runtime subcommand required. Available: runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime postmortem <goal-id|run-id>, runtime dream-review <run-id>, runtime proactive-quality, runtime proactive-feedback");
+    logger.error("Error: runtime subcommand required. Available: runtime bindings, runtime sessions, runtime runs, runtime session <id>, runtime run <id>, runtime experiment-queues, runtime experiment-queue <id>, runtime budgets, runtime budget <id>, runtime evidence <goal-id|run-id>, runtime postmortem <goal-id|run-id>, runtime dream-review <run-id>, runtime proactive-quality, runtime proactive-feedback");
     return 1;
   }
 
   const registry = createRuntimeSessionRegistry({ stateManager });
+
+  if (runtimeSubcommand === "bindings") {
+    const values = parseListArgs(args.slice(1), "bindings");
+    const status = await collectOperatorBindingStatus(stateManager);
+    values.json ? printJson(status) : printOperatorBindingStatus(status);
+    return 0;
+  }
 
   if (runtimeSubcommand === "sessions") {
     const values = parseListArgs(args.slice(1), "sessions");

--- a/tmp/resident-channel-readiness-status.md
+++ b/tmp/resident-channel-readiness-status.md
@@ -1,0 +1,20 @@
+# Resident Channel Readiness Status
+
+## #987 Expose channel, session, and runtime binding status for operators
+- Status: in progress
+- Branch: codex/issue-987-operator-bindings-status
+- Initial sync: main was up to date; target issue #987 is open as of 2026-05-03.
+- Plan: inspect existing CLI/runtime status surfaces, add one typed operator binding status collector/formatter, cover configured inactive, active home chat, missing runtime-control allowlist, and background run pinned reply target.
+- Implementation: added `pulseed runtime bindings` typed JSON/text status surface using runtime session registry, background run ledger projection, daemon running state, runtime health snapshot, and gateway channel config files.
+- Verification: `npm run typecheck` passed; `npm test -- src/interface/cli/__tests__/runtime-command.test.ts --runInBand` passed (npm warned runInBand is unknown but Vitest lane passed).
+- Notes: no durable per-channel health store exists yet; active means valid channel config + daemon running + gateway component health ok. Missing home chat and missing runtime-control allowlists are warnings.
+- Verification: `npm run lint:boundaries` exited 0 with pre-existing warnings only.
+- Review: separate review agent found two material gaps: custom daemon runtime root and missing configured goal bindings.
+- Fix after review: `runtime bindings` now resolves configured daemon runtime root for health/background-run ledger and exposes conversation/sender/default goal bindings; focused test covers custom runtime root and chat_goal_map output.
+- Verification after review fixes: focused runtime CLI test passed again; `npm run typecheck` passed; `npm run lint:boundaries` exited 0 with existing warnings.
+- Second review: found non-Telegram partial config could be misreported active.
+- Fix after second review: built-in non-Telegram channels now validate required transport fields before active; partial Discord config is covered as degraded.
+- Verification after second review fix: focused runtime CLI test passed (19 tests); `npm run typecheck` passed.
+- Verification after required-fields fix: `npm run lint:boundaries` exited 0 with existing warnings only.
+- Verification: `npm run test:changed` passed (11 files, 246 tests).
+- Status: implementation complete; preparing commit and PR.


### PR DESCRIPTION
Closes #987

## Summary
- Add `pulseed runtime bindings` as one operator-facing status surface for daemon, gateway channels, reply targets, identity keys, goal bindings, runtime-control permission state, sessions, and active/attention background runs.
- Resolve daemon runtime root before reading runtime health/background-run state, and distinguish missing/configured/active/degraded channel state from real config + daemon/gateway health.
- Surface warnings for daemon down, missing Telegram home chat, missing runtime-control allowlists, unrestricted Telegram mode, invalid channel configs, and pinned reply targets.

## Verification
- `npm test -- src/interface/cli/__tests__/runtime-command.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint:boundaries` (exit 0; existing warnings only)
- `npm run test:changed`

## Known unresolved risks
- There is no durable per-channel health store yet, so active means valid channel config plus daemon running and gateway component health `ok`; per-channel adapter liveness remains a future refinement.