### PR TITLE
Polish Telegram onboarding and home binding

### DIFF
--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -354,6 +354,7 @@ describe("setup notification step", () => {
     textMock
       .mockResolvedValueOnce("test-token")
       .mockResolvedValueOnce("777,888")
+      .mockResolvedValueOnce("999")
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce("personal");
     selectMock
@@ -372,7 +373,7 @@ describe("setup notification step", () => {
     expect(telegramConfig).toMatchObject({
       bot_token: "test-token",
       allowed_user_ids: [777, 888],
-      runtime_control_allowed_user_ids: [777, 888],
+      runtime_control_allowed_user_ids: [999],
       allow_all: false,
       identity_key: "personal",
     });

--- a/src/interface/cli/__tests__/gateway-setup.test.ts
+++ b/src/interface/cli/__tests__/gateway-setup.test.ts
@@ -83,6 +83,7 @@ describe("cmdGatewaySetup", () => {
     textMock
       .mockResolvedValueOnce("test-token")
       .mockResolvedValueOnce("777,888")
+      .mockResolvedValueOnce("999")
       .mockResolvedValueOnce("")
       .mockResolvedValueOnce("personal")
       .mockResolvedValueOnce("http://127.0.0.1:8080")
@@ -106,7 +107,7 @@ describe("cmdGatewaySetup", () => {
     expect(telegramConfig).toMatchObject({
       bot_token: "test-token",
       allowed_user_ids: [777, 888],
-      runtime_control_allowed_user_ids: [777, 888],
+      runtime_control_allowed_user_ids: [999],
       allow_all: false,
       polling_timeout: 30,
       identity_key: "personal",

--- a/src/interface/cli/__tests__/runtime-command.test.ts
+++ b/src/interface/cli/__tests__/runtime-command.test.ts
@@ -146,6 +146,11 @@ describe("runtime registry CLI commands", () => {
       polling_timeout: 20,
       identity_key: "personal",
     });
+    await stateManager.writeRaw("gateway/channels/telegram-bot/health.json", {
+      last_inbound_at: "2026-05-03T00:01:00.000Z",
+      last_outbound_at: "2026-05-03T00:02:00.000Z",
+      last_error: null,
+    });
     await stateManager.writeRaw("gateway/channels/discord-bot/config.json", {
       application_id: "app",
       bot_token: "token",
@@ -186,6 +191,8 @@ describe("runtime registry CLI commands", () => {
         state: string;
         home_target: { target_id?: string } | null;
         goal_bindings: Array<{ scope: string; subject_id: string | null; goal_id: string }>;
+        access: { allow_all: boolean; allowed_count: number };
+        recent_health: { inbound_at: string | null; outbound_at: string | null; last_error: string | null };
         runtime_control: { state: string };
       }>;
       background_runs: Array<{ id: string; pinned_reply_target: { channel: string; target_id?: string } | null }>;
@@ -202,6 +209,12 @@ describe("runtime registry CLI commands", () => {
         { scope: "conversation", subject_id: "12345", goal_id: "goal-home" },
         { scope: "default", subject_id: null, goal_id: "goal-home" },
       ]),
+      access: { allow_all: false, allowed_count: 1 },
+      recent_health: {
+        inbound_at: "2026-05-03T00:01:00.000Z",
+        outbound_at: "2026-05-03T00:02:00.000Z",
+        last_error: null,
+      },
       runtime_control: { state: "missing_allowlist", allowed_count: 0 },
     }));
     expect(parsed.daemon.runtime_root).toBe(runtimeRoot);

--- a/src/interface/cli/__tests__/telegram-setup.test.ts
+++ b/src/interface/cli/__tests__/telegram-setup.test.ts
@@ -46,7 +46,7 @@ describe("cmdTelegramSetup", () => {
   });
 
   it("writes optional identity_key for cross-platform continuation", async () => {
-    readlineState.answers = ["test-token", "777,888", "", "personal"];
+    readlineState.answers = ["test-token", "777,888", "999", "", "personal"];
     const { cmdTelegramSetup } = await import("../commands/telegram.js");
 
     const result = await cmdTelegramSetup([]);
@@ -60,10 +60,43 @@ describe("cmdTelegramSetup", () => {
     expect(config).toMatchObject({
       bot_token: "test-token",
       allowed_user_ids: [777, 888],
+      runtime_control_allowed_user_ids: [999],
       allow_all: false,
       polling_timeout: 30,
       identity_key: "personal",
     });
     expect(config.chat_id).toBeUndefined();
+  });
+
+  it("requires explicit unrestricted-mode confirmation when allowed users are blank", async () => {
+    readlineState.answers = ["test-token", "", "ALLOW ALL", "", "", ""];
+    const { cmdTelegramSetup } = await import("../commands/telegram.js");
+
+    const result = await cmdTelegramSetup([]);
+
+    expect(result).toBe(0);
+    const configPath = path.join(tmpDir, "gateway", "channels", "telegram-bot", "config.json");
+    const config = JSON.parse(await fsp.readFile(configPath, "utf-8")) as Record<string, unknown>;
+    expect(config).toMatchObject({
+      allowed_user_ids: [],
+      runtime_control_allowed_user_ids: [],
+      allow_all: true,
+    });
+  });
+
+  it("keeps access closed for first-use /sethome binding when unrestricted mode is not confirmed", async () => {
+    readlineState.answers = ["test-token", "", "", "", "", ""];
+    const { cmdTelegramSetup } = await import("../commands/telegram.js");
+
+    const result = await cmdTelegramSetup([]);
+
+    expect(result).toBe(0);
+    const configPath = path.join(tmpDir, "gateway", "channels", "telegram-bot", "config.json");
+    const config = JSON.parse(await fsp.readFile(configPath, "utf-8")) as Record<string, unknown>;
+    expect(config).toMatchObject({
+      allowed_user_ids: [],
+      runtime_control_allowed_user_ids: [],
+      allow_all: false,
+    });
   });
 });

--- a/src/interface/cli/commands/operator-binding-status.ts
+++ b/src/interface/cli/commands/operator-binding-status.ts
@@ -30,10 +30,19 @@ export interface OperatorChannelBindingStatus {
     state: RuntimeControlPermissionState;
     allowed_count: number;
   };
+  access: {
+    allow_all: boolean;
+    allowed_count: number;
+  };
   health: {
     daemon_running: boolean;
     gateway: RuntimeHealthSnapshot["status"] | "missing";
     checked_at: number | null;
+  };
+  recent_health: {
+    inbound_at: string | null;
+    outbound_at: string | null;
+    last_error: string | null;
   };
   warnings: string[];
 }
@@ -62,6 +71,8 @@ interface ChannelConfigSummary {
   goalBindings: OperatorChannelGoalBinding[];
   runtimeControlAllowedCount: number;
   runtimeControlState: RuntimeControlPermissionState;
+  accessAllowAll: boolean;
+  accessAllowedCount: number;
   warnings: string[];
 }
 
@@ -107,6 +118,7 @@ function telegramSummary(raw: Record<string, unknown> | null): ChannelConfigSumm
   const warnings: string[] = [];
   const chatId = typeof raw["chat_id"] === "number" ? String(raw["chat_id"]) : null;
   const runtimeAllowedCount = arrayCount(raw["runtime_control_allowed_user_ids"]);
+  const allowedUserCount = arrayCount(raw["allowed_user_ids"]);
   const defaultGoalId = nonEmptyString(raw["default_goal_id"]);
   if (!chatId) warnings.push("Missing Telegram home chat. Send /sethome from the target chat.");
   if (runtimeAllowedCount === 0) warnings.push("Missing Telegram runtime-control allowed user list.");
@@ -122,11 +134,9 @@ function telegramSummary(raw: Record<string, unknown> | null): ChannelConfigSumm
       ...defaultGoalBinding(defaultGoalId),
     ],
     runtimeControlAllowedCount: runtimeAllowedCount,
-    runtimeControlState: raw["allow_all"] === true
-      ? "unrestricted"
-      : runtimeAllowedCount > 0
-        ? "allowed"
-        : "missing_allowlist",
+    runtimeControlState: runtimeAllowedCount > 0 ? "allowed" : "missing_allowlist",
+    accessAllowAll: raw["allow_all"] === true,
+    accessAllowedCount: allowedUserCount,
     warnings: [
       ...warnings,
       ...(!hasBotToken ? ["Invalid Telegram config: bot_token is missing."] : []),
@@ -161,6 +171,8 @@ function senderSummary(raw: Record<string, unknown> | null, channel: Exclude<Bui
     ],
     runtimeControlAllowedCount: runtimeAllowedCount,
     runtimeControlState: runtimeAllowedCount > 0 ? "allowed" : "missing_allowlist",
+    accessAllowAll: false,
+    accessAllowedCount: arrayCount(raw["allowed_sender_ids"]),
     warnings: [
       ...warnings,
       ...(missingFields.length > 0 ? [`Invalid ${channel} config: missing ${missingFields.join(", ")}.`] : []),
@@ -178,6 +190,8 @@ function missingSummary(): ChannelConfigSummary {
     goalBindings: [],
     runtimeControlAllowedCount: 0,
     runtimeControlState: "unsupported",
+    accessAllowAll: false,
+    accessAllowedCount: 0,
     warnings: [],
   };
 }
@@ -189,6 +203,15 @@ function channelConfigPath(baseDir: string, channel: BuiltinGatewayChannelName):
 async function loadRawConfig(filePath: string): Promise<Record<string, unknown> | null> {
   const raw = await readJsonFileOrNull<unknown>(filePath);
   return raw && typeof raw === "object" && !Array.isArray(raw) ? raw as Record<string, unknown> : null;
+}
+
+async function loadRecentChannelHealth(configPath: string): Promise<OperatorChannelBindingStatus["recent_health"]> {
+  const raw = await readJsonFileOrNull<Record<string, unknown>>(path.join(path.dirname(configPath), "health.json"));
+  return {
+    inbound_at: nonEmptyString(raw?.["last_inbound_at"]),
+    outbound_at: nonEmptyString(raw?.["last_outbound_at"]),
+    last_error: nonEmptyString(raw?.["last_error"]),
+  };
 }
 
 function channelState(summary: ChannelConfigSummary, daemonRunning: boolean, gatewayHealth: RuntimeHealthSnapshot["status"] | "missing"): OperatorChannelState {
@@ -224,6 +247,7 @@ export async function collectOperatorBindingStatus(stateManager: StateManager): 
   for (const name of BUILTIN_GATEWAY_CHANNEL_NAMES) {
     const configPath = channelConfigPath(baseDir, name);
     const raw = await loadRawConfig(configPath);
+    const recentHealth = await loadRecentChannelHealth(configPath);
     const summary = name === "telegram-bot" ? telegramSummary(raw) : senderSummary(raw, name);
     const state = channelState(summary, daemon.running, gatewayHealth);
     channels.push({
@@ -241,11 +265,16 @@ export async function collectOperatorBindingStatus(stateManager: StateManager): 
         state: summary.runtimeControlState,
         allowed_count: summary.runtimeControlAllowedCount,
       },
+      access: {
+        allow_all: summary.accessAllowAll,
+        allowed_count: summary.accessAllowedCount,
+      },
       health: {
         daemon_running: daemon.running,
         gateway: gatewayHealth,
         checked_at: health?.checked_at ?? null,
       },
+      recent_health: recentHealth,
       warnings: summary.warnings,
     });
   }
@@ -280,6 +309,7 @@ export function printOperatorBindingStatus(status: OperatorBindingStatus): void 
     console.log(
       `- ${channel.name}: ${channel.state}; home=${formatReplyTarget(channel.home_target)}; identity=${channel.identity_key ?? "-"}; runtime_control=${channel.runtime_control.state} (${channel.runtime_control.allowed_count})`
     );
+    console.log(`  access allow_all=${channel.access.allow_all ? "yes" : "no"} allowed=${channel.access.allowed_count}`);
     for (const binding of channel.goal_bindings) {
       const subject = binding.subject_id ? `${binding.scope}:${binding.subject_id}` : binding.scope;
       console.log(`  goal_binding ${subject} -> ${binding.goal_id}`);

--- a/src/interface/cli/commands/setup/steps-gateway.ts
+++ b/src/interface/cli/commands/setup/steps-gateway.ts
@@ -166,12 +166,29 @@ async function promptTelegramChannelConfig(baseDir: string): Promise<TelegramGat
   const allowedUserIds = parseIntegerList(
     guardCancel(
       await p.text({
-        message: "Allowed Telegram user IDs (comma-separated, blank = allow all)",
+        message: "Allowed Telegram user IDs (comma-separated, blank = closed first-use / explicit unrestricted confirmation)",
         placeholder: "123456789,987654321",
         initialValue: current?.allowed_user_ids.join(",") ?? "",
       })
     )
   );
+  const runtimeControlAllowedUserIds = parseIntegerList(
+    guardCancel(
+      await p.text({
+        message: "Telegram runtime-control user IDs (comma-separated, blank = disabled)",
+        placeholder: "123456789",
+        initialValue: current?.runtime_control_allowed_user_ids.join(",") ?? "",
+      })
+    )
+  );
+  const allowAll = allowedUserIds.length === 0
+    ? guardCancel(
+      await p.confirm({
+        message: "Allow any Telegram user who can reach this bot to use normal chat? Choose No to keep access closed until /sethome binds the first sender.",
+        initialValue: false,
+      })
+    )
+    : false;
   const chatIdInput = guardCancel(
     await p.text({
       message: "Home chat ID (optional, blank = use /sethome later)",
@@ -199,11 +216,11 @@ async function promptTelegramChannelConfig(baseDir: string): Promise<TelegramGat
     denied_user_ids: current?.denied_user_ids ?? [],
     allowed_chat_ids: current?.allowed_chat_ids ?? [],
     denied_chat_ids: current?.denied_chat_ids ?? [],
-    runtime_control_allowed_user_ids: allowedUserIds,
+    runtime_control_allowed_user_ids: runtimeControlAllowedUserIds,
     chat_goal_map: current?.chat_goal_map ?? {},
     user_goal_map: current?.user_goal_map ?? {},
     default_goal_id: current?.default_goal_id,
-    allow_all: allowedUserIds.length === 0,
+    allow_all: allowAll,
     polling_timeout: current?.polling_timeout ?? 30,
     ...(identityKey ? { identity_key: identityKey } : {}),
   };

--- a/src/interface/cli/commands/telegram.ts
+++ b/src/interface/cli/commands/telegram.ts
@@ -98,13 +98,33 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
     console.log("  Hermes-style setup uses user IDs for access control instead of requiring chat_id up front.");
     console.log("  Message @userinfobot if you need your numeric user ID.\n");
 
-    const allowedStr = await ask(rl, "Allowed user IDs (e.g. 123456,789012) or press Enter to skip: ");
+    const allowedStr = await ask(rl, "Allowed user IDs (e.g. 123456,789012) or press Enter to bind first /sethome sender later: ");
     const allowedUserIds: number[] = [];
     if (allowedStr) {
       for (const part of allowedStr.split(",")) {
         const n = parseInt(part.trim(), 10);
         if (!isNaN(n)) {
           allowedUserIds.push(n);
+        }
+      }
+    }
+    let allowAll = false;
+    if (allowedUserIds.length === 0) {
+      console.log("\nNo allowed users were entered. By default, PulSeed will keep Telegram chat access closed until the first /sethome sender is bound.");
+      const unrestricted = await ask(rl, "Type ALLOW ALL to intentionally allow any Telegram user who can reach this bot: ");
+      allowAll = unrestricted === "ALLOW ALL";
+    }
+
+    console.log("\nRuntime control (optional)");
+    console.log("  Runtime-control permission is separate from ordinary Telegram chat access.");
+    console.log("  Leave blank to disable Telegram runtime-control approval.\n");
+    const runtimeControlStr = await ask(rl, "Runtime-control user IDs (comma-separated) or press Enter to disable: ");
+    const runtimeControlAllowedUserIds: number[] = [];
+    if (runtimeControlStr) {
+      for (const part of runtimeControlStr.split(",")) {
+        const n = parseInt(part.trim(), 10);
+        if (!isNaN(n)) {
+          runtimeControlAllowedUserIds.push(n);
         }
       }
     }
@@ -140,7 +160,8 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
     const config = {
       bot_token: token,
       allowed_user_ids: allowedUserIds,
-      allow_all: allowedUserIds.length === 0,
+      runtime_control_allowed_user_ids: runtimeControlAllowedUserIds,
+      allow_all: allowAll,
       polling_timeout: 30,
       ...(chatId !== undefined ? { chat_id: chatId } : {}),
       ...(identityKey ? { identity_key: identityKey } : {}),
@@ -156,14 +177,17 @@ export async function cmdTelegramSetup(_args: string[]): Promise<number> {
     console.log(`  Home:   ${chatId !== undefined ? chatId : "(send /sethome to set later)"}`);
     if (allowedUserIds.length > 0) {
       console.log(`  Allowed users: ${allowedUserIds.join(", ")}`);
+    } else if (allowAll) {
+      console.log("  Allowed users: (all; explicitly confirmed)");
     } else {
-      console.log("  Allowed users: (all)");
+      console.log("  Allowed users: (closed until first /sethome binding)");
     }
     if (identityKey) {
       console.log(`  Identity key: ${identityKey}`);
     } else {
       console.log("  Identity key: (not set)");
     }
+    console.log(`  Runtime-control users: ${runtimeControlAllowedUserIds.length > 0 ? runtimeControlAllowedUserIds.join(", ") : "(disabled)"}`);
     console.log("\nThe daemon will pick this up automatically as a built-in gateway channel.");
 
     return 0;

--- a/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
@@ -259,6 +259,56 @@ describe("TelegramGatewayAdapter", () => {
       expect(sentMessages.filter((message) => message === "Final setup guidance.")).toHaveLength(1);
     });
   });
+
+  it("binds first /sethome sender without enabling runtime control", async () => {
+    const configDir = await writeConfig({
+      bot_token: "test-token",
+      allowed_user_ids: [],
+      denied_user_ids: [],
+      allowed_chat_ids: [],
+      denied_chat_ids: [],
+      runtime_control_allowed_user_ids: [],
+      chat_goal_map: {},
+      user_goal_map: {},
+      allow_all: false,
+      polling_timeout: 30,
+    });
+    const sentMessages: string[] = [];
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const method = String(url).split("/").at(-1);
+      if (method === "getMe") return telegramResponse({ id: 1, username: "pulseed_test_bot" });
+      if (method === "getUpdates") {
+        return telegramResponse([{
+          update_id: 100,
+          message: { message_id: 2718, from: { id: 42 }, chat: { id: 314 }, text: "/sethome" },
+        }]);
+      }
+      if (method === "sendMessage") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+        sentMessages.push(body.text ?? "");
+        await adapter.stop();
+        return telegramResponse({ message_id: 9001 });
+      }
+      throw new Error(`unexpected Telegram method: ${method}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = TelegramGatewayAdapter.fromConfigDir(configDir);
+    adapters.push(adapter);
+
+    await adapter.start();
+
+    await vi.waitFor(async () => {
+      const config = JSON.parse(await fs.readFile(path.join(configDir, "config.json"), "utf-8")) as Record<string, unknown>;
+      expect(config).toMatchObject({
+        chat_id: 314,
+        allowed_user_ids: [42],
+        runtime_control_allowed_user_ids: [],
+        allow_all: false,
+      });
+    });
+    expect(dispatchGatewayChatInput).not.toHaveBeenCalled();
+    expect(sentMessages[0]).toContain("Runtime control still requires its own allow list.");
+  });
 });
 
 function createDeferred(): { promise: Promise<void>; resolve: () => void } {

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -55,12 +55,16 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
   private handler: EnvelopeHandler | null = null;
   private readonly api: TelegramAPI;
   private readonly config: TelegramGatewayConfig;
+  private readonly pluginDir: string;
   private readonly homeChatStore: TelegramHomeChatStore;
   private readonly notifier: TelegramGatewayNotifier;
   private running = false;
+  private loopPromise: Promise<void> | null = null;
+  private handlingUpdate = false;
   private offset = 0;
 
   constructor(pluginDir: string, config: TelegramGatewayConfig) {
+    this.pluginDir = pluginDir;
     this.config = config;
     this.api = new TelegramAPI(config.bot_token);
     this.homeChatStore = new TelegramHomeChatStore(pluginDir, config.chat_id);
@@ -83,11 +87,14 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
     if (this.running) return;
     await this.api.getMe();
     this.running = true;
-    void this.loop().catch(() => undefined);
+    this.loopPromise = this.loop().catch(() => undefined);
   }
 
   async stop(): Promise<void> {
     this.running = false;
+    if (this.handlingUpdate) return;
+    await this.loopPromise;
+    this.loopPromise = null;
   }
 
   private async loop(): Promise<void> {
@@ -106,10 +113,22 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
           if (this.config.denied_user_ids.includes(fromId)) continue;
           if (this.config.denied_chat_ids.includes(chatId)) continue;
           if (this.config.allowed_chat_ids.length > 0 && !this.config.allowed_chat_ids.includes(chatId)) continue;
-          if (!this.config.allow_all && !this.config.allowed_user_ids.includes(fromId)) continue;
-          await this.processMessage(msg.text, fromId, chatId, msg.message_id);
+          this.handlingUpdate = true;
+          try {
+            if (this.isFirstHomeBindingCommand(msg.text, fromId)) {
+              await this.recordHealth({ last_inbound_at: new Date().toISOString(), last_error: null });
+              await this.processMessage(msg.text, fromId, chatId, msg.message_id);
+              continue;
+            }
+            if (!this.config.allow_all && !this.config.allowed_user_ids.includes(fromId)) continue;
+            await this.recordHealth({ last_inbound_at: new Date().toISOString(), last_error: null });
+            await this.processMessage(msg.text, fromId, chatId, msg.message_id);
+          } finally {
+            this.handlingUpdate = false;
+          }
         }
-      } catch {
+      } catch (err) {
+        await this.recordHealth({ last_error: err instanceof Error ? err.message : String(err) });
         if (!this.running) break;
         const delay = BACKOFF_STEPS_MS[Math.min(backoffIndex, BACKOFF_STEPS_MS.length - 1)];
         backoffIndex++;
@@ -121,8 +140,17 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
   private async processMessage(text: string, fromUserId: number, chatId: number, messageId: number): Promise<void> {
     const normalized = text.trim().toLowerCase();
     if (normalized === "/sethome" || normalized.startsWith("/sethome@")) {
-      await this.homeChatStore.set(chatId);
-      await this.api.sendPlainMessage(chatId, "This chat is now the home channel for PulSeed notifications.");
+      const firstBinding = this.config.allowed_user_ids.length === 0 && this.config.chat_id === undefined && !this.config.allow_all;
+      await this.homeChatStore.set(chatId, firstBinding ? fromUserId : undefined);
+      this.config.chat_id = chatId;
+      if (firstBinding) this.config.allowed_user_ids.push(fromUserId);
+      await this.api.sendPlainMessage(
+        chatId,
+        firstBinding
+          ? "This chat is now the home channel for PulSeed notifications, and this Telegram user is allowed for normal chat. Runtime control still requires its own allow list."
+          : "This chat is now the home channel for PulSeed notifications."
+      );
+      await this.recordHealth({ last_outbound_at: new Date().toISOString(), last_error: null });
       return;
     }
 
@@ -182,6 +210,31 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
     if (!eventAdapter.renderedAssistantOutput) {
       await eventAdapter.sendFinalFallback(reply ?? "Received.");
     }
+    await this.recordHealth({ last_outbound_at: new Date().toISOString(), last_error: null });
+  }
+
+  private isFirstHomeBindingCommand(text: string, fromUserId: number): boolean {
+    const normalized = text.trim().toLowerCase();
+    return (normalized === "/sethome" || normalized.startsWith("/sethome@"))
+      && !this.config.allow_all
+      && this.config.chat_id === undefined
+      && this.config.allowed_user_ids.length === 0
+      && !this.config.denied_user_ids.includes(fromUserId);
+  }
+
+  private async recordHealth(update: Partial<{ last_inbound_at: string; last_outbound_at: string; last_error: string | null }>): Promise<void> {
+    const healthPath = path.join(this.pluginDir, "health.json");
+    let current: Record<string, unknown> = {};
+    try {
+      current = JSON.parse(fs.readFileSync(healthPath, "utf-8")) as Record<string, unknown>;
+    } catch {
+      current = {};
+    }
+    await writeJsonFileAtomic(healthPath, {
+      ...current,
+      ...update,
+      updated_at: new Date().toISOString(),
+    });
   }
 }
 
@@ -291,7 +344,7 @@ class TelegramHomeChatStore {
     return this.chatId;
   }
 
-  async set(chatId: number): Promise<void> {
+  async set(chatId: number, firstAllowedUserId?: number): Promise<void> {
     this.chatId = chatId;
     let current: Record<string, unknown> = {};
     try {
@@ -300,6 +353,12 @@ class TelegramHomeChatStore {
       current = {};
     }
     current["chat_id"] = chatId;
+    if (firstAllowedUserId !== undefined && !Array.isArray(current["allowed_user_ids"])) {
+      current["allowed_user_ids"] = [firstAllowedUserId];
+    } else if (firstAllowedUserId !== undefined) {
+      const ids = current["allowed_user_ids"] as unknown[];
+      if (!ids.includes(firstAllowedUserId)) current["allowed_user_ids"] = [...ids, firstAllowedUserId];
+    }
     await writeJsonFileAtomic(this.configPath, current);
   }
 }

--- a/tmp/resident-channel-readiness-status.md
+++ b/tmp/resident-channel-readiness-status.md
@@ -18,3 +18,20 @@
 - Verification after required-fields fix: `npm run lint:boundaries` exited 0 with existing warnings only.
 - Verification: `npm run test:changed` passed (11 files, 246 tests).
 - Status: implementation complete; preparing commit and PR.
+
+## #985 Polish Telegram daily-use onboarding and safe home-chat binding
+- Status: in progress
+- Branch: codex/issue-985-telegram-onboarding
+- Initial sync: main up to date; issue #985 is open as of 2026-05-03.
+- Plan: inspect Telegram setup/gateway paths, make unrestricted setup explicit, add safe first sender/home binding state, expose Telegram permissions/home/runtime-control through runtime bindings, and add focused production-path tests.
+- Implementation: Telegram setup now keeps access closed when allowed users are blank unless unrestricted mode is explicitly confirmed; CLI config writes runtime-control allowlist separately.
+- Implementation: first locked `/sethome` from Telegram binds home chat and the first normal-chat allowed user without granting runtime-control permission.
+- Implementation: `runtime bindings` now exposes normal chat access allow_all/allowed count alongside runtime-control count.
+- Verification: focused Telegram/setup/runtime status tests passed; `npm run typecheck` passed.
+- Review: separate review agent found runtime-control status/permissions were not separated enough and last inbound/outbound health was missing.
+- Fix after review: runtime-control allowlist now has separate prompts/config; `allow_all` no longer implies runtime-control; Telegram adapter persists last inbound/outbound/error health next to config and `runtime bindings` exposes it.
+- Verification after review fixes: focused Telegram/gateway/setup/runtime tests passed (46 tests).
+- Verification after runtime-control/health fixes: `npm run typecheck` passed; `npm run lint:boundaries` exited 0 with existing warnings only.
+- Verification: `npm run test:changed` passed after adapter stop/health cleanup fix.
+- Review: second review agent reported no material findings after runtime-control and health fixes.
+- Status: implementation complete; preparing commit and PR.


### PR DESCRIPTION
Closes #985

## Summary
- Keep fresh Telegram setup locked down unless unrestricted `allow_all` is explicitly confirmed.
- Split ordinary Telegram chat allowlist from runtime-control allowlist in CLI/setup wizard config.
- Allow the first locked `/sethome` message to bind home chat and the first normal-chat sender without granting runtime-control permission.
- Persist Telegram last inbound/outbound/error health and expose access/runtime-control/home health through `pulseed runtime bindings`.

## Verification
- `npm test -- src/interface/cli/__tests__/telegram-setup.test.ts src/interface/cli/__tests__/gateway-setup.test.ts src/interface/cli/__tests__/cli-setup-notification.test.ts src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts src/interface/cli/__tests__/runtime-command.test.ts --runInBand`
- `npx vitest run --config vitest.integration.config.ts src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (exit 0; existing warnings only)
- `npm run test:changed`

## Known unresolved risks
- Health is adapter-local `health.json` for Telegram last inbound/outbound/error events; a cross-channel durable health store can consolidate this later.