### PR TITLE
Report resident readiness after setup

### DIFF
--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -64,6 +64,182 @@ describe("setup notification step", () => {
     multiselectMock.mockResolvedValue([]);
   });
 
+  it("classifies resident readiness as ready when daemon and Telegram bindings are complete", async () => {
+    const { buildResidentReadinessReport } = await import("../commands/setup-wizard.js");
+    const report = buildResidentReadinessReport(
+      {
+        startDaemon: true,
+        daemonPort: 41701,
+        notificationConfig: null,
+        gatewaySetup: null,
+      },
+      makeBindingStatus({
+        daemon: { running: true, port: 41701, health: "ok", runtime_root: "/tmp/runtime" },
+        channels: [{
+          name: "telegram-bot",
+          state: "active",
+          configured: true,
+          active: true,
+          degraded: false,
+          home_target: { channel: "telegram", target_id: "123" },
+          runtime_control: { state: "allowed", allowed_count: 1 },
+          recent_health: {
+            inbound_at: "2026-05-03T00:01:00.000Z",
+            outbound_at: "2026-05-03T00:02:00.000Z",
+            last_error: null,
+          },
+        }],
+      }),
+      null
+    );
+
+    expect(report.state).toBe("ready");
+    expect(report.checks.every((check) => check.ok)).toBe(true);
+  });
+
+  it("classifies resident readiness as blocked when daemon startup failed", async () => {
+    const { buildResidentReadinessReport } = await import("../commands/setup-wizard.js");
+    const report = buildResidentReadinessReport(
+      {
+        startDaemon: true,
+        daemonPort: 41701,
+        notificationConfig: null,
+        gatewaySetup: null,
+      },
+      makeBindingStatus({
+        daemon: { running: false, port: 0, health: "missing", runtime_root: "/tmp/runtime" },
+      }),
+      "Daemon did not respond on port 41701 within 10000ms."
+    );
+
+    expect(report.state).toBe("blocked");
+    expect(report.checks).toContainEqual(expect.objectContaining({
+      name: "daemon",
+      ok: false,
+      recovery: "pulseed daemon start --detach",
+    }));
+  });
+
+  it("does not report ready when daemon health is degraded", async () => {
+    const { buildResidentReadinessReport } = await import("../commands/setup-wizard.js");
+    const report = buildResidentReadinessReport(
+      {
+        startDaemon: true,
+        daemonPort: 41701,
+        notificationConfig: null,
+        gatewaySetup: null,
+      },
+      makeBindingStatus({
+        daemon: { running: true, port: 41701, health: "degraded", runtime_root: "/tmp/runtime" },
+      }),
+      null
+    );
+
+    expect(report.state).toBe("blocked");
+    expect(report.checks).toContainEqual(expect.objectContaining({
+      name: "daemon",
+      ok: false,
+      detail: expect.stringContaining("health=degraded"),
+    }));
+  });
+
+  it("does not report ready for Telegram before channel round trip evidence exists", async () => {
+    const { buildResidentReadinessReport } = await import("../commands/setup-wizard.js");
+    const report = buildResidentReadinessReport(
+      {
+        startDaemon: true,
+        daemonPort: 41701,
+        notificationConfig: null,
+        gatewaySetup: null,
+      },
+      makeBindingStatus({
+        daemon: { running: true, port: 41701, health: "ok", runtime_root: "/tmp/runtime" },
+        channels: [{
+          name: "telegram-bot",
+          state: "active",
+          configured: true,
+          active: true,
+          degraded: false,
+          home_target: { channel: "telegram", target_id: "123" },
+          runtime_control: { state: "allowed", allowed_count: 1 },
+          recent_health: { inbound_at: null, outbound_at: null, last_error: null },
+        }],
+      }),
+      null
+    );
+
+    expect(report.state).toBe("partial");
+    expect(report.checks).toContainEqual(expect.objectContaining({
+      name: "telegram-bot channel round trip",
+      ok: false,
+      recovery: "send a message to the Telegram bot after daemon start",
+    }));
+  });
+
+  it("classifies resident readiness as partial when Telegram lacks home chat and runtime-control permission", async () => {
+    const { buildResidentReadinessReport } = await import("../commands/setup-wizard.js");
+    const report = buildResidentReadinessReport(
+      {
+        startDaemon: true,
+        daemonPort: 41701,
+        notificationConfig: null,
+        gatewaySetup: null,
+      },
+      makeBindingStatus({
+        daemon: { running: true, port: 41701, health: "ok", runtime_root: "/tmp/runtime" },
+        channels: [{
+          name: "telegram-bot",
+          state: "active",
+          configured: true,
+          active: true,
+          degraded: false,
+          home_target: null,
+          runtime_control: { state: "missing_allowlist", allowed_count: 0 },
+        }],
+      }),
+      null
+    );
+
+    expect(report.state).toBe("partial");
+    expect(report.checks).toContainEqual(expect.objectContaining({
+      name: "telegram-bot reply target",
+      ok: false,
+      recovery: "send /sethome to the Telegram bot",
+    }));
+    expect(report.checks).toContainEqual(expect.objectContaining({
+      name: "telegram-bot runtime-control",
+      ok: false,
+    }));
+  });
+
+  it("classifies saved gateway config without daemon readiness as blocked", async () => {
+    const { buildResidentReadinessReport } = await import("../commands/setup-wizard.js");
+    const report = buildResidentReadinessReport(
+      {
+        startDaemon: false,
+        daemonPort: 41701,
+        notificationConfig: null,
+        gatewaySetup: null,
+      },
+      makeBindingStatus({
+        daemon: { running: false, port: 0, health: "missing", runtime_root: "/tmp/runtime" },
+        channels: [{
+          name: "telegram-bot",
+          state: "configured",
+          configured: true,
+          active: false,
+          degraded: false,
+          home_target: { channel: "telegram", target_id: "123" },
+          runtime_control: { state: "allowed", allowed_count: 1 },
+        }],
+      }),
+      null
+    );
+
+    expect(report.state).toBe("blocked");
+    expect(report.checks).toContainEqual(expect.objectContaining({ name: "daemon", ok: false }));
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
@@ -1683,3 +1859,43 @@ describe("setup notification step", () => {
     );
   });
 });
+
+function makeBindingStatus(overrides: {
+  daemon?: { running: boolean; port: number; health: "ok" | "degraded" | "failed" | "missing"; runtime_root: string };
+    channels?: Array<Partial<{
+    name: "telegram-bot";
+    state: "missing" | "configured" | "active" | "degraded";
+    configured: boolean;
+    active: boolean;
+    degraded: boolean;
+    home_target: { channel: string; target_id?: string } | null;
+    runtime_control: { state: "allowed" | "missing_allowlist" | "unrestricted" | "unsupported"; allowed_count: number };
+    recent_health: { inbound_at: string | null; outbound_at: string | null; last_error: string | null };
+  }>>;
+}) {
+  return {
+    schema_version: "operator-binding-status-v1" as const,
+    generated_at: "2026-05-03T00:00:00.000Z",
+    daemon: overrides.daemon ?? { running: false, port: 0, health: "missing" as const, runtime_root: "/tmp/runtime" },
+    channels: (overrides.channels ?? []).map((channel) => ({
+      name: channel.name ?? "telegram-bot",
+      state: channel.state ?? "missing",
+      config_path: "/tmp/telegram/config.json",
+      configured: channel.configured ?? false,
+      active: channel.active ?? false,
+      degraded: channel.degraded ?? false,
+      home_target: channel.home_target ?? null,
+      identity_key: null,
+      default_goal_id: null,
+      goal_bindings: [],
+      runtime_control: channel.runtime_control ?? { state: "unsupported", allowed_count: 0 },
+      access: { allow_all: false, allowed_count: 0 },
+      health: { daemon_running: overrides.daemon?.running ?? false, gateway: "ok" as const, checked_at: null },
+      recent_health: channel.recent_health ?? { inbound_at: null, outbound_at: null, last_error: null },
+      warnings: [],
+    })),
+    sessions: [],
+    background_runs: [],
+    warnings: [],
+  };
+}

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -17,6 +17,7 @@ import { createRelationshipProfileProposalsFromUserMdImport } from "../../../pla
 import { updateGlobalConfig } from "../../../base/config/global-config.js";
 import { readCodexOAuthToken } from "../../../base/llm/provider-config.js";
 import { isDaemonRunning } from "../../../runtime/daemon/client.js";
+import { StateManager } from "../../../base/state/state-manager.js";
 import { ROOT_PRESETS } from "./presets/root-presets.js";
 import { MODEL_REGISTRY, detectApiKeys, getAdaptersForModel, maskKey } from "./setup-shared.js";
 import type { Provider } from "./setup-shared.js";
@@ -34,6 +35,7 @@ import { guardCancel } from "./setup/utils.js";
 import { applySetupImportSelection } from "./setup/import/apply.js";
 import { providerConfigPatchFromImport, stepSetupImport } from "./setup/import/flow.js";
 import type { SetupImportSelection } from "./setup/import/types.js";
+import { collectOperatorBindingStatus, type OperatorBindingStatus } from "./operator-binding-status.js";
 
 type SetupAnswers = {
   userName: string;
@@ -54,6 +56,12 @@ type IdentityAnswers = Pick<SetupAnswers, "userName" | "agentName" | "rootPreset
 type ExecutionAnswers = Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">;
 type RuntimeAnswers = Pick<SetupAnswers, "startDaemon" | "daemonPort" | "notificationConfig" | "gatewaySetup">;
 type FullSetupSection = "identity" | "execution" | "runtime" | "review";
+type ResidentReadinessState = "ready" | "partial" | "blocked";
+
+interface ResidentReadinessReport {
+  state: ResidentReadinessState;
+  checks: Array<{ name: string; ok: boolean; detail: string; recovery?: string }>;
+}
 type IdentityConfigOptions = {
   skipRootPreset?: boolean;
   skipUserName?: boolean;
@@ -508,6 +516,86 @@ async function startDaemonAfterSetup(baseDir: string, port: number): Promise<voi
   p.log.success(`Daemon and gateway started${pid ? ` (PID: ${pid})` : ""} on port ${port}.`);
 }
 
+export function buildResidentReadinessReport(
+  answers: Pick<SetupAnswers, "startDaemon" | "daemonPort" | "notificationConfig" | "gatewaySetup">,
+  status: OperatorBindingStatus,
+  daemonStartupError: string | null
+): ResidentReadinessReport {
+  const configuredChannels = status.channels.filter((channel) => channel.configured);
+  const checks: ResidentReadinessReport["checks"] = [];
+  const daemonReady = status.daemon.running && status.daemon.health === "ok" && (!answers.startDaemon || status.daemon.port === answers.daemonPort);
+  checks.push({
+    name: "daemon",
+    ok: daemonReady,
+    detail: daemonStartupError ?? (daemonReady ? `daemon responding on port ${status.daemon.port} with ok health` : `daemon is not ready (running=${status.daemon.running}, port=${status.daemon.port || "-"}, health=${status.daemon.health})`),
+    recovery: daemonReady ? undefined : "pulseed daemon start --detach",
+  });
+  checks.push({
+    name: "gateway",
+    ok: configuredChannels.length === 0 || configuredChannels.every((channel) => channel.state === "active"),
+    detail: configuredChannels.length === 0
+      ? "no messaging channels configured"
+      : configuredChannels.map((channel) => `${channel.name}:${channel.state}`).join(", "),
+    recovery: configuredChannels.some((channel) => channel.degraded) ? "pulseed gateway setup" : undefined,
+  });
+  checks.push({
+    name: "notification routing",
+    ok: answers.notificationConfig !== null || configuredChannels.some((channel) => channel.home_target !== null),
+    detail: answers.notificationConfig !== null
+      ? "notification config saved"
+      : configuredChannels.some((channel) => channel.home_target !== null)
+        ? "gateway home/default reply target available"
+        : "no notification config or gateway home/default reply target",
+    recovery: "pulseed notify add <slack|webhook|email> or send /sethome to the Telegram bot",
+  });
+  for (const channel of configuredChannels) {
+    checks.push({
+      name: `${channel.name} reply target`,
+      ok: channel.home_target !== null,
+      detail: channel.home_target ? "home/default reply target configured" : "missing home/default reply target",
+      recovery: channel.name === "telegram-bot" ? "send /sethome to the Telegram bot" : "pulseed gateway setup",
+    });
+    checks.push({
+      name: `${channel.name} runtime-control`,
+      ok: channel.runtime_control.state === "allowed",
+      detail: `${channel.runtime_control.allowed_count} runtime-control user/sender id(s) configured`,
+      recovery: "pulseed gateway setup",
+    });
+    if (channel.name === "telegram-bot") {
+      const roundTripOk = channel.recent_health.inbound_at !== null
+        && channel.recent_health.outbound_at !== null
+        && channel.recent_health.last_error === null;
+      checks.push({
+        name: "telegram-bot channel round trip",
+        ok: roundTripOk,
+        detail: roundTripOk
+          ? `last inbound ${channel.recent_health.inbound_at}, last outbound ${channel.recent_health.outbound_at}`
+          : `last inbound ${channel.recent_health.inbound_at ?? "-"}, last outbound ${channel.recent_health.outbound_at ?? "-"}, last error ${channel.recent_health.last_error ?? "-"}`,
+        recovery: "send a message to the Telegram bot after daemon start",
+      });
+    }
+  }
+  const failed = checks.filter((check) => !check.ok);
+  const state: ResidentReadinessState = daemonStartupError !== null || failed.some((check) => check.name === "daemon")
+    ? "blocked"
+    : failed.length > 0
+      ? "partial"
+      : "ready";
+  return { state, checks };
+}
+
+function printResidentReadinessReport(report: ResidentReadinessReport): void {
+  const line = `Resident readiness: ${report.state}`;
+  if (report.state === "ready") p.log.success(line);
+  else if (report.state === "partial") p.log.warn(line);
+  else p.log.error(line);
+  for (const check of report.checks) {
+    const prefix = check.ok ? "ok" : "failed";
+    const recovery = !check.ok && check.recovery ? ` Recovery: ${check.recovery}` : "";
+    p.log.info(`- ${prefix}: ${check.name} - ${check.detail}.${recovery}`);
+  }
+}
+
 export async function runSetupWizard(): Promise<number> {
   console.log(getBanner());
   p.intro("PulSeed Setup");
@@ -734,6 +822,7 @@ export async function runSetupWizard(): Promise<number> {
   }
   clearIdentityCache();
 
+  let daemonStartupError: string | null = null;
   if (finalAnswers.startDaemon) {
     const daemonConfigPath = path.join(dir, "daemon.json");
     try {
@@ -791,11 +880,23 @@ export async function runSetupWizard(): Promise<number> {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      daemonStartupError = message;
       p.log.warn(
         `Setup saved, but daemon/gateway did not start: ${message}. ` +
           "Run `pulseed daemon start --detach` to try again."
       );
     }
+  }
+
+  try {
+    const readiness = buildResidentReadinessReport(
+      finalAnswers,
+      await collectOperatorBindingStatus(new StateManager(dir)),
+      daemonStartupError
+    );
+    printResidentReadinessReport(readiness);
+  } catch (err) {
+    p.log.warn(`Setup saved, but resident readiness check failed: ${err instanceof Error ? err.message : String(err)}`);
   }
 
   p.outro("\ud83c\udf31 Seeds planted. Time to grow.");

--- a/tmp/resident-channel-readiness-status.md
+++ b/tmp/resident-channel-readiness-status.md
@@ -35,3 +35,15 @@
 - Verification: `npm run test:changed` passed after adapter stop/health cleanup fix.
 - Review: second review agent reported no material findings after runtime-control and health fixes.
 - Status: implementation complete; preparing commit and PR.
+
+## #984 Harden setup wizard completion for resident daemon and gateway readiness
+- Status: in progress
+- Branch: codex/issue-984-setup-readiness
+- Initial sync: main up to date; issue #984 is open as of 2026-05-03.
+- Plan: inspect setup wizard completion/startup path, reuse operator binding status for final ready/partial/blocked checks, print failed checks and recovery commands, and add focused setup completion tests.
+- Implementation: setup wizard now builds and prints resident readiness as ready/partial/blocked using operator binding status, daemon response, gateway channel state, notification routing, reply target, and runtime-control checks.
+- Recovery output: failed checks include concrete commands such as `pulseed daemon start --detach`, `pulseed gateway setup`, and Telegram `/sethome` guidance.
+- Verification: focused setup readiness tests passed; `npm run typecheck` passed.
+- Review: separate review agent found daemon health was not included in readiness and Telegram configured channels could report ready before any inbound/outbound health evidence.
+- Fix after review: daemon readiness now requires `health=ok`; Telegram readiness requires recent inbound and outbound health with no last error before reporting ready.
+- Verification after review fixes: focused setup readiness tests passed (28 tests); `npm run typecheck` passed; `npm run lint:boundaries` exited 0 with existing warnings; `npm run test:changed` passed (17 files, 346 tests).


### PR DESCRIPTION
Closes #984

## Summary
- Adds a final resident readiness report to `pulseed setup` with `ready`, `partial`, or `blocked` state.
- Reuses the operator binding status surface for daemon health, gateway channel state, home/default reply targets, runtime-control allowlists, and Telegram recent inbound/outbound health.
- Prints concrete recovery commands for failed daemon, gateway, notification routing, reply target, runtime-control, and Telegram round-trip checks.

## Verification
- `npm test -- src/interface/cli/__tests__/cli-setup-notification.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed`
- Review agent: no material findings after daemon health and Telegram round-trip fixes.

## Known unresolved risks
- No external Telegram/daemon smoke test was run; coverage uses unit/contract tests and mocked/local status inputs.
- `npm run lint:boundaries` still reports pre-existing warnings but exits 0.