### PR TITLE
Add gateway typing indicator capability

### DIFF
--- a/src/runtime/gateway/__tests__/discord-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/discord-gateway-adapter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { dispatchGatewayChatInput } from "../chat-session-dispatch.js";
+import { DiscordGatewayAdapter, type DiscordGatewayConfig } from "../discord-gateway-adapter.js";
+
+vi.mock("../chat-session-dispatch.js", () => ({
+  dispatchGatewayChatInput: vi.fn().mockResolvedValue("Discord reply"),
+}));
+
+beforeEach(() => {
+  vi.mocked(dispatchGatewayChatInput).mockReset();
+  vi.mocked(dispatchGatewayChatInput).mockResolvedValue("Discord reply");
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DiscordGatewayAdapter", () => {
+  it("triggers native Discord typing while processing a chat turn", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    vi.stubGlobal("fetch", vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init });
+      return okResponse({});
+    }));
+    const adapter = new DiscordGatewayAdapter(makeConfig());
+
+    await (adapter as unknown as {
+      processIncomingMessage(payload: unknown, input: Parameters<typeof dispatchGatewayChatInput>[0]): Promise<void>;
+    }).processIncomingMessage(
+      { application_id: "app-1", token: "token-1" },
+      {
+        text: "hello",
+        platform: "discord",
+        identity_key: "discord:user",
+        conversation_id: "channel-1",
+        sender_id: "user-1",
+        metadata: { channel_id: "channel-1" },
+      }
+    );
+
+    expect(calls).toContainEqual(expect.objectContaining({
+      url: "https://discord.com/api/v10/channels/channel-1/typing",
+      init: expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bot discord-token" }),
+      }),
+    }));
+    expect(calls).toContainEqual(expect.objectContaining({
+      url: "https://discord.com/api/v10/webhooks/app-1/token-1",
+    }));
+  });
+});
+
+function makeConfig(): DiscordGatewayConfig {
+  return {
+    application_id: "app-1",
+    bot_token: "discord-token",
+    channel_id: "channel-1",
+    identity_key: "discord:user",
+    allowed_sender_ids: [],
+    denied_sender_ids: [],
+    allowed_conversation_ids: [],
+    denied_conversation_ids: [],
+    runtime_control_allowed_sender_ids: [],
+    conversation_goal_map: {},
+    sender_goal_map: {},
+    command_name: "pulseed",
+    host: "127.0.0.1",
+    port: 8787,
+    ephemeral: false,
+  };
+}
+
+function okResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    json: async () => payload,
+    text: async () => JSON.stringify(payload),
+  } as Response;
+}

--- a/src/runtime/gateway/__tests__/signal-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/signal-gateway-adapter.test.ts
@@ -20,6 +20,18 @@ function makeConfig(): SignalGatewayConfig {
 }
 
 describe("SignalGatewayAdapter", () => {
+  it("exposes explicit unsupported typing capability", async () => {
+    const adapter = new SignalGatewayAdapter(makeConfig());
+    const session = await adapter.typingIndicator.start({
+      platform: "signal",
+      conversation_id: "+10000000002",
+    });
+
+    expect(adapter.typingIndicator.status).toBe("unsupported");
+    expect(adapter.typingIndicator.reason).toContain("no configured typing endpoint");
+    expect(session.status).toBe("unsupported");
+  });
+
   it("does not include token-only message text in fallback message ids", () => {
     const token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
     const adapter = new SignalGatewayAdapter(makeConfig());

--- a/src/runtime/gateway/__tests__/slack-channel-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/slack-channel-adapter.test.ts
@@ -47,6 +47,18 @@ describe("SlackChannelAdapter — properties", () => {
     expect(makeAdapter().name).toBe("slack");
   });
 
+  it("exposes explicit unsupported typing capability", async () => {
+    const adapter = makeAdapter();
+    const session = await adapter.typingIndicator.start({
+      platform: "slack",
+      conversation_id: "C_GENERAL",
+    });
+
+    expect(adapter.typingIndicator.status).toBe("unsupported");
+    expect(adapter.typingIndicator.reason).toContain("no native bot typing indicator");
+    expect(session.status).toBe("unsupported");
+  });
+
   it("start() resolves without error", async () => {
     await expect(makeAdapter().start()).resolves.toBeUndefined();
   });

--- a/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
@@ -59,6 +59,9 @@ describe("TelegramGatewayAdapter", () => {
       if (method === "sendMessage") {
         return telegramResponse({ message_id: 9001 });
       }
+      if (method === "sendChatAction") {
+        return telegramResponse(true);
+      }
       throw new Error(`unexpected Telegram method: ${method}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -85,6 +88,15 @@ describe("TelegramGatewayAdapter", () => {
         }),
       }));
     });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.telegram.org/bottest-token/sendChatAction",
+      expect.objectContaining({
+        body: JSON.stringify({
+          chat_id: 314,
+          action: "typing",
+        }),
+      })
+    );
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.telegram.org/bottest-token/getUpdates",
       expect.objectContaining({
@@ -139,6 +151,9 @@ describe("TelegramGatewayAdapter", () => {
         const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
         sentMessages.push(body.text ?? "");
         return telegramResponse({ message_id: 9100 + sentMessages.length });
+      }
+      if (method === "sendChatAction") {
+        return telegramResponse(true);
       }
       throw new Error(`unexpected Telegram method: ${method}`);
     });
@@ -231,6 +246,9 @@ describe("TelegramGatewayAdapter", () => {
           await finalSendCanFinish.promise;
         }
         return telegramResponse({ message_id: 9000 + sentMessages.length });
+      }
+      if (method === "sendChatAction") {
+        return telegramResponse(true);
       }
       throw new Error(`unexpected Telegram method: ${method}`);
     });

--- a/src/runtime/gateway/__tests__/typing-indicator.test.ts
+++ b/src/runtime/gateway/__tests__/typing-indicator.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TypingIndicatorCapability } from "../channel-adapter.js";
+import {
+  createUnsupportedTypingIndicator,
+  withTypingIndicator,
+} from "../typing-indicator.js";
+
+describe("typing indicator capability", () => {
+  it("reports unsupported no-op capability explicitly", async () => {
+    const capability = createUnsupportedTypingIndicator("not available");
+    const session = await capability.start({
+      platform: "signal",
+      conversation_id: "conversation-1",
+    });
+
+    expect(capability.status).toBe("unsupported");
+    expect(capability.reason).toBe("not available");
+    expect(session.status).toBe("unsupported");
+    await expect(session.stop()).resolves.toBeUndefined();
+  });
+
+  it("does not fail the chat turn when typing start fails", async () => {
+    const capability: TypingIndicatorCapability = {
+      status: "native",
+      start: vi.fn().mockRejectedValue(new Error("typing unavailable")),
+    };
+    const turn = vi.fn().mockResolvedValue("reply");
+
+    await expect(withTypingIndicator(capability, {
+      platform: "telegram",
+      conversation_id: "314",
+    }, turn)).resolves.toBe("reply");
+
+    expect(turn).toHaveBeenCalledOnce();
+  });
+
+  it("stops the indicator when the chat turn fails", async () => {
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const capability: TypingIndicatorCapability = {
+      status: "native",
+      start: vi.fn().mockResolvedValue({ status: "native", stop }),
+    };
+
+    await expect(withTypingIndicator(capability, {
+      platform: "discord",
+      conversation_id: "channel-1",
+    }, async () => {
+      throw new Error("turn failed");
+    })).rejects.toThrow("turn failed");
+
+    expect(stop).toHaveBeenCalledOnce();
+  });
+});

--- a/src/runtime/gateway/__tests__/whatsapp-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/whatsapp-gateway-adapter.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { WhatsAppGatewayAdapter, type WhatsAppGatewayConfig } from "../whatsapp-gateway-adapter.js";
+
+describe("WhatsAppGatewayAdapter", () => {
+  it("exposes explicit unsupported typing capability", async () => {
+    const adapter = new WhatsAppGatewayAdapter(makeConfig());
+    const session = await adapter.typingIndicator.start({
+      platform: "whatsapp",
+      conversation_id: "15551234567",
+    });
+
+    expect(adapter.typingIndicator.status).toBe("unsupported");
+    expect(adapter.typingIndicator.reason).toContain("no native typing endpoint");
+    expect(session.status).toBe("unsupported");
+  });
+});
+
+function makeConfig(): WhatsAppGatewayConfig {
+  return {
+    phone_number_id: "phone-1",
+    access_token: "token-1",
+    verify_token: "verify-1",
+    recipient_id: "15551234567",
+    identity_key: "whatsapp:user",
+    allowed_sender_ids: [],
+    denied_sender_ids: [],
+    runtime_control_allowed_sender_ids: [],
+    sender_goal_map: {},
+    host: "127.0.0.1",
+    port: 8788,
+    path: "/webhook",
+  };
+}

--- a/src/runtime/gateway/channel-adapter.ts
+++ b/src/runtime/gateway/channel-adapter.ts
@@ -7,6 +7,27 @@ export interface ReplyChannel {
 
 export type EnvelopeHandler = (envelope: Envelope, reply?: ReplyChannel) => void | Promise<void>;
 
+export type TypingIndicatorStatus = "native" | "fallback" | "unsupported";
+
+export interface TypingIndicatorContext {
+  platform: string;
+  conversation_id: string;
+  sender_id?: string;
+  message_id?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface TypingIndicatorSession {
+  readonly status: TypingIndicatorStatus;
+  stop(): Promise<void>;
+}
+
+export interface TypingIndicatorCapability {
+  readonly status: TypingIndicatorStatus;
+  readonly reason?: string;
+  start(context: TypingIndicatorContext): Promise<TypingIndicatorSession>;
+}
+
 /**
  * A ChannelAdapter receives protocol-specific input and emits Envelopes.
  * Each adapter handles one external protocol (HTTP, WebSocket, CLI, MCP, Slack, etc.).
@@ -23,4 +44,7 @@ export interface ChannelAdapter {
 
   /** Register the handler that receives Envelopes from this adapter */
   onEnvelope(handler: EnvelopeHandler): void;
+
+  /** Optional platform typing/presence feedback while a chat turn is active */
+  readonly typingIndicator?: TypingIndicatorCapability;
 }

--- a/src/runtime/gateway/discord-gateway-adapter.ts
+++ b/src/runtime/gateway/discord-gateway-adapter.ts
@@ -1,11 +1,12 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as http from "node:http";
-import { createHash, webcrypto } from "node:crypto";
-import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
+import { webcrypto } from "node:crypto";
+import type { ChannelAdapter, EnvelopeHandler, TypingIndicatorCapability } from "./channel-adapter.js";
 import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
 import { formatPlaintextNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
 import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
+import { createRefreshingTypingIndicator, withTypingIndicator } from "./typing-indicator.js";
 import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
 
 const MAX_DISCORD_ACTIVITY_MESSAGES = 8;
@@ -82,6 +83,7 @@ export class DiscordGatewayNotifier implements INotifier {
 
 export class DiscordGatewayAdapter implements ChannelAdapter {
   readonly name = "discord";
+  readonly typingIndicator: TypingIndicatorCapability;
 
   private handler: EnvelopeHandler | null = null;
   private server: http.Server | null = null;
@@ -90,6 +92,17 @@ export class DiscordGatewayAdapter implements ChannelAdapter {
 
   constructor(private readonly config: DiscordGatewayConfig) {
     this.api = new DiscordAPI(config.bot_token);
+    this.typingIndicator = createRefreshingTypingIndicator({
+      intervalMs: 8_000,
+      refresh: async (context) => {
+        const channelId = typeof context.metadata?.["channel_id"] === "string"
+          ? context.metadata["channel_id"]
+          : context.conversation_id;
+        if (!channelId) return;
+        await this.api.triggerTyping(channelId);
+      },
+      onError: (err) => console.warn("DiscordGatewayAdapter: typing indicator failed", err),
+    });
     this.notifier = new DiscordGatewayNotifier(this.api, config);
   }
 
@@ -234,25 +247,35 @@ export class DiscordGatewayAdapter implements ChannelAdapter {
   ): Promise<void> {
     let sentActivityCount = 0;
     let lastActivity = "";
-    const reply = await dispatchGatewayChatInput({
-      ...input,
-      onEvent: async (event: unknown) => {
-        if (
-          !isActivityChatEvent(event) ||
-          (event.kind !== "tool" && event.kind !== "plugin" && event.kind !== "skill") ||
-          payload.application_id === undefined ||
-          payload.token === undefined ||
-          sentActivityCount >= MAX_DISCORD_ACTIVITY_MESSAGES
-        ) {
-          return;
-        }
-        const content = truncateDiscordActivity(event.message);
-        if (content === lastActivity) return;
-        lastActivity = content;
-        sentActivityCount++;
-        await this.api.sendInteractionFollowUp(payload.application_id, payload.token, content);
+    const reply = await withTypingIndicator(
+      this.typingIndicator,
+      {
+        platform: "discord",
+        conversation_id: input.conversation_id,
+        sender_id: input.sender_id,
+        message_id: input.message_id,
+        metadata: input.metadata,
       },
-    });
+      () => dispatchGatewayChatInput({
+        ...input,
+        onEvent: async (event: unknown) => {
+          if (
+            !isActivityChatEvent(event) ||
+            (event.kind !== "tool" && event.kind !== "plugin" && event.kind !== "skill") ||
+            payload.application_id === undefined ||
+            payload.token === undefined ||
+            sentActivityCount >= MAX_DISCORD_ACTIVITY_MESSAGES
+          ) {
+            return;
+          }
+          const content = truncateDiscordActivity(event.message);
+          if (content === lastActivity) return;
+          lastActivity = content;
+          sentActivityCount++;
+          await this.api.sendInteractionFollowUp(payload.application_id, payload.token, content);
+        },
+      })
+    );
     const content = reply ?? "Received.";
 
     if (payload.application_id !== undefined && payload.token !== undefined) {
@@ -347,6 +370,18 @@ class DiscordAPI {
     });
     if (!response.ok) {
       throw new Error(`discord-bot: follow-up send failed with ${response.status}`);
+    }
+  }
+
+  async triggerTyping(channelId: string): Promise<void> {
+    const response = await this.fetchImpl(`https://discord.com/api/v10/channels/${channelId}/typing`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bot ${this.botToken}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`discord-bot: typing failed with ${response.status}`);
     }
   }
 }

--- a/src/runtime/gateway/index.ts
+++ b/src/runtime/gateway/index.ts
@@ -10,6 +10,17 @@ export {
 export { HttpChannelAdapter } from "./http-channel-adapter.js";
 export { SlackChannelAdapter } from "./slack-channel-adapter.js";
 export type { ChannelAdapter, EnvelopeHandler, ReplyChannel } from "./channel-adapter.js";
+export type {
+  TypingIndicatorCapability,
+  TypingIndicatorContext,
+  TypingIndicatorSession,
+  TypingIndicatorStatus,
+} from "./channel-adapter.js";
+export {
+  createRefreshingTypingIndicator,
+  createUnsupportedTypingIndicator,
+  withTypingIndicator,
+} from "./typing-indicator.js";
 export type { SlackChannelAdapterConfig, SlackResponse } from "./slack-channel-adapter.js";
 export { WsChannelAdapter } from "./ws-channel-adapter.js";
 export type { WsLike, WsSocketLike } from "./ws-channel-adapter.js";

--- a/src/runtime/gateway/signal-gateway-adapter.ts
+++ b/src/runtime/gateway/signal-gateway-adapter.ts
@@ -1,10 +1,11 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { randomUUID } from "node:crypto";
-import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
+import type { ChannelAdapter, EnvelopeHandler, TypingIndicatorCapability } from "./channel-adapter.js";
 import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
 import { formatPlaintextNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
 import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
+import { createUnsupportedTypingIndicator, withTypingIndicator } from "./typing-indicator.js";
 import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
 
 export interface SignalGatewayConfig {
@@ -58,6 +59,9 @@ export class SignalGatewayNotifier implements INotifier {
 
 export class SignalGatewayAdapter implements ChannelAdapter {
   readonly name = "signal";
+  readonly typingIndicator: TypingIndicatorCapability = createUnsupportedTypingIndicator(
+    "signal-bridge adapter has no configured typing endpoint"
+  );
 
   private handler: EnvelopeHandler | null = null;
   private readonly client: SignalBridgeClient;
@@ -130,22 +134,32 @@ export class SignalGatewayAdapter implements ChannelAdapter {
         },
         channelContext
       );
-      const reply = await dispatchGatewayChatInput({
-        text: normalized.text,
-        platform: "signal",
-        identity_key: route.identityKey ?? this.config.identity_key,
-        conversation_id: normalized.conversationId,
-        sender_id: normalized.senderId,
-        message_id: normalized.messageId,
-        goal_id: route.goalId,
-        metadata: {
-          ...route.metadata,
-          ...normalized.metadata,
-          ...(route.goalId ? { goal_id: route.goalId } : {}),
-          ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
-          ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
+      const reply = await withTypingIndicator(
+        this.typingIndicator,
+        {
+          platform: "signal",
+          conversation_id: normalized.conversationId,
+          sender_id: normalized.senderId,
+          message_id: normalized.messageId,
+          metadata: normalized.metadata,
         },
-      });
+        () => dispatchGatewayChatInput({
+          text: normalized.text,
+          platform: "signal",
+          identity_key: route.identityKey ?? this.config.identity_key,
+          conversation_id: normalized.conversationId,
+          sender_id: normalized.senderId,
+          message_id: normalized.messageId,
+          goal_id: route.goalId,
+          metadata: {
+            ...route.metadata,
+            ...normalized.metadata,
+            ...(route.goalId ? { goal_id: route.goalId } : {}),
+            ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+            ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
+          },
+        })
+      );
 
       if (reply !== null) {
         await this.client.sendTextMessage({

--- a/src/runtime/gateway/slack-channel-adapter.ts
+++ b/src/runtime/gateway/slack-channel-adapter.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from "crypto";
-import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
+import type { ChannelAdapter, EnvelopeHandler, TypingIndicatorCapability } from "./channel-adapter.js";
 import { createEnvelope } from "../types/envelope.js";
 import {
   evaluateChannelAccess,
@@ -8,6 +8,7 @@ import {
   type ChannelRoutingPolicy,
 } from "./channel-policy.js";
 import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
+import { createUnsupportedTypingIndicator } from "./typing-indicator.js";
 
 export interface SlackChannelAdapterConfig {
   signingSecret: string;
@@ -37,6 +38,9 @@ const MAX_TIMESTAMP_AGE_SEC = 5 * 60;
  */
 export class SlackChannelAdapter implements ChannelAdapter {
   readonly name = "slack";
+  readonly typingIndicator: TypingIndicatorCapability = createUnsupportedTypingIndicator(
+    "slack events adapter has no native bot typing indicator in the current API path"
+  );
   private handler: EnvelopeHandler | null = null;
   private readonly config: SlackChannelAdapterConfig;
   private readonly api: SlackAPI | null;

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
+import type { ChannelAdapter, EnvelopeHandler, TypingIndicatorCapability } from "./channel-adapter.js";
 import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
 import { formatTelegramNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
 import { writeJsonFileAtomic } from "../../base/utils/json-io.js";
@@ -8,6 +8,7 @@ import type { ChatEvent } from "../../interface/chat/chat-events.js";
 import { renderOperationProgress } from "../../interface/chat/operation-progress.js";
 import { formatLifecycleFailureMessage } from "../../interface/chat/failure-recovery.js";
 import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
+import { createRefreshingTypingIndicator, withTypingIndicator } from "./typing-indicator.js";
 import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
 
 const BACKOFF_STEPS_MS = [5_000, 10_000, 20_000, 40_000, 60_000];
@@ -51,6 +52,7 @@ export class TelegramGatewayNotifier implements INotifier {
 
 export class TelegramGatewayAdapter implements ChannelAdapter {
   readonly name = "telegram";
+  readonly typingIndicator: TypingIndicatorCapability;
 
   private handler: EnvelopeHandler | null = null;
   private readonly api: TelegramAPI;
@@ -67,6 +69,15 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
     this.pluginDir = pluginDir;
     this.config = config;
     this.api = new TelegramAPI(config.bot_token);
+    this.typingIndicator = createRefreshingTypingIndicator({
+      intervalMs: 4_000,
+      refresh: async (context) => {
+        const chatId = Number(context.conversation_id);
+        if (!Number.isInteger(chatId)) return;
+        await this.api.sendChatAction(chatId, "typing");
+      },
+      onError: (err) => console.warn("TelegramGatewayAdapter: typing indicator failed", err),
+    });
     this.homeChatStore = new TelegramHomeChatStore(pluginDir, config.chat_id);
     this.notifier = new TelegramGatewayNotifier(this.api, this.homeChatStore);
   }
@@ -188,24 +199,33 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
       return;
     }
 
-    const reply = await dispatchGatewayChatInput({
-      text,
-      platform: "telegram",
-      identity_key: route.identityKey ?? this.config.identity_key,
-      conversation_id: String(chatId),
-      sender_id: String(fromUserId),
-      message_id: String(messageId),
-      goal_id: route.goalId,
-      cwd: process.cwd(),
-      onEvent: (event) => eventAdapter.handle(event),
-      metadata: {
-        ...route.metadata,
-        chat_id: chatId,
-        ...(route.goalId ? { goal_id: route.goalId } : {}),
-        ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
-        ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
+    const reply = await withTypingIndicator(
+      this.typingIndicator,
+      {
+        platform: "telegram",
+        conversation_id: String(chatId),
+        sender_id: String(fromUserId),
+        message_id: String(messageId),
       },
-    });
+      () => dispatchGatewayChatInput({
+        text,
+        platform: "telegram",
+        identity_key: route.identityKey ?? this.config.identity_key,
+        conversation_id: String(chatId),
+        sender_id: String(fromUserId),
+        message_id: String(messageId),
+        goal_id: route.goalId,
+        cwd: process.cwd(),
+        onEvent: (event) => eventAdapter.handle(event),
+        metadata: {
+          ...route.metadata,
+          chat_id: chatId,
+          ...(route.goalId ? { goal_id: route.goalId } : {}),
+          ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+          ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
+        },
+      })
+    );
 
     if (!eventAdapter.renderedAssistantOutput) {
       await eventAdapter.sendFinalFallback(reply ?? "Received.");
@@ -279,6 +299,13 @@ class TelegramAPI {
 
   async sendPlainMessage(chatId: number, text: string): Promise<number> {
     return this.sendMessageInternal(chatId, text, null);
+  }
+
+  async sendChatAction(chatId: number, action: "typing"): Promise<void> {
+    await this.call("sendChatAction", {
+      chat_id: chatId,
+      action,
+    });
   }
 
   async editMessageText(chatId: number, messageId: number, text: string): Promise<void> {

--- a/src/runtime/gateway/typing-indicator.ts
+++ b/src/runtime/gateway/typing-indicator.ts
@@ -1,0 +1,94 @@
+import type {
+  TypingIndicatorCapability,
+  TypingIndicatorContext,
+  TypingIndicatorSession,
+  TypingIndicatorStatus,
+} from "./channel-adapter.js";
+
+export interface RefreshingTypingIndicatorOptions {
+  status?: Extract<TypingIndicatorStatus, "native" | "fallback">;
+  intervalMs: number;
+  refresh: (context: TypingIndicatorContext) => Promise<void>;
+  onError?: (err: unknown) => void;
+}
+
+export function createRefreshingTypingIndicator(
+  options: RefreshingTypingIndicatorOptions
+): TypingIndicatorCapability {
+  return {
+    status: options.status ?? "native",
+    async start(context) {
+      return startRefreshingTypingIndicator(context, options);
+    },
+  };
+}
+
+export function createUnsupportedTypingIndicator(reason: string): TypingIndicatorCapability {
+  return {
+    status: "unsupported",
+    reason,
+    async start() {
+      return {
+        status: "unsupported",
+        async stop() {},
+      };
+    },
+  };
+}
+
+async function startRefreshingTypingIndicator(
+  context: TypingIndicatorContext,
+  options: RefreshingTypingIndicatorOptions
+): Promise<TypingIndicatorSession> {
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const refreshOnce = async (): Promise<void> => {
+    try {
+      await options.refresh(context);
+    } catch (err) {
+      options.onError?.(err);
+    }
+  };
+
+  const schedule = (): void => {
+    if (stopped) return;
+    timer = setTimeout(() => {
+      timer = null;
+      void refreshOnce().finally(schedule);
+    }, options.intervalMs);
+    timer.unref?.();
+  };
+
+  await refreshOnce();
+  schedule();
+
+  return {
+    status: options.status ?? "native",
+    async stop() {
+      stopped = true;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}
+
+export async function withTypingIndicator<T>(
+  capability: TypingIndicatorCapability | undefined,
+  context: TypingIndicatorContext,
+  fn: () => Promise<T>
+): Promise<T> {
+  const session = await capability?.start(context).catch((err: unknown) => {
+    console.warn("typing-indicator: start failed", err);
+    return null;
+  });
+  try {
+    return await fn();
+  } finally {
+    await session?.stop().catch((err: unknown) => {
+      console.warn("typing-indicator: stop failed", err);
+    });
+  }
+}

--- a/src/runtime/gateway/whatsapp-gateway-adapter.ts
+++ b/src/runtime/gateway/whatsapp-gateway-adapter.ts
@@ -2,10 +2,11 @@ import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as http from "node:http";
 import * as path from "node:path";
-import type { ChannelAdapter, EnvelopeHandler } from "./channel-adapter.js";
+import type { ChannelAdapter, EnvelopeHandler, TypingIndicatorCapability } from "./channel-adapter.js";
 import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
 import { formatPlaintextNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
 import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
+import { createUnsupportedTypingIndicator, withTypingIndicator } from "./typing-indicator.js";
 import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
 
 interface WhatsAppWebhookPayload {
@@ -63,6 +64,9 @@ export class WhatsAppGatewayNotifier implements INotifier {
 
 export class WhatsAppGatewayAdapter implements ChannelAdapter {
   readonly name = "whatsapp";
+  readonly typingIndicator: TypingIndicatorCapability = createUnsupportedTypingIndicator(
+    "whatsapp cloud adapter has no native typing endpoint in the current contract"
+  );
 
   private handler: EnvelopeHandler | null = null;
   private server: http.Server | null = null;
@@ -162,10 +166,12 @@ export class WhatsAppGatewayAdapter implements ChannelAdapter {
     if (message.from === undefined || message.text?.body === undefined || message.text.body.trim().length === 0) {
       return;
     }
+    const senderId = message.from;
+    const text = message.text.body;
     const channelContext = {
       platform: "whatsapp",
-      senderId: message.from,
-      conversationId: message.from,
+      senderId,
+      conversationId: senderId,
     };
     const access = evaluateChannelAccess(
       {
@@ -185,26 +191,39 @@ export class WhatsAppGatewayAdapter implements ChannelAdapter {
       },
       channelContext
     );
-    const reply = await dispatchGatewayChatInput({
-      text: message.text.body,
-      platform: "whatsapp",
-      identity_key: route.identityKey ?? this.config.identity_key,
-      conversation_id: message.from,
-      sender_id: message.from,
-      message_id: message.id,
-      goal_id: route.goalId,
-      metadata: {
-        ...route.metadata,
-        message_type: message.type,
-        timestamp: message.timestamp,
-        ...(route.goalId ? { goal_id: route.goalId } : {}),
-        ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
-        ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
+    const reply = await withTypingIndicator(
+      this.typingIndicator,
+      {
+        platform: "whatsapp",
+        conversation_id: senderId,
+        sender_id: senderId,
+        message_id: message.id,
+        metadata: {
+          message_type: message.type,
+          timestamp: message.timestamp,
+        },
       },
-    });
+      () => dispatchGatewayChatInput({
+        text,
+        platform: "whatsapp",
+        identity_key: route.identityKey ?? this.config.identity_key,
+        conversation_id: senderId,
+        sender_id: senderId,
+        message_id: message.id,
+        goal_id: route.goalId,
+        metadata: {
+          ...route.metadata,
+          message_type: message.type,
+          timestamp: message.timestamp,
+          ...(route.goalId ? { goal_id: route.goalId } : {}),
+          ...(access.runtimeControlApproved ? { runtime_control_approved: true } : {}),
+          ...(access.runtimeControlConfigured && !access.runtimeControlApproved ? { runtime_control_denied: true } : {}),
+        },
+      })
+    );
 
     await this.client.sendTextMessage({
-      to: message.from,
+      to: senderId,
       body: reply ?? "Received.",
     });
   }

--- a/tmp/resident-channel-readiness-status.md
+++ b/tmp/resident-channel-readiness-status.md
@@ -47,3 +47,16 @@
 - Review: separate review agent found daemon health was not included in readiness and Telegram configured channels could report ready before any inbound/outbound health evidence.
 - Fix after review: daemon readiness now requires `health=ok`; Telegram readiness requires recent inbound and outbound health with no last error before reporting ready.
 - Verification after review fixes: focused setup readiness tests passed (28 tests); `npm run typecheck` passed; `npm run lint:boundaries` exited 0 with existing warnings; `npm run test:changed` passed (17 files, 346 tests).
+- Review: second review agent reported no material findings.
+- CI: PR #1006 unit and integration checks passed; PR merged.
+
+## #994 Add typing indicators for all supported messaging input channels
+- Status: in progress
+- Branch: codex/issue-994-typing-indicators
+- Initial sync: main up to date; issue #994 is open as of 2026-05-03.
+- Open issue scan: newer long-running issues #997-#1001 are open but outside this target set; #986 remains out of scope.
+- Plan: add a typed optional typing indicator capability at the channel adapter boundary, use native Telegram `sendChatAction` and Discord typing endpoint refresh loops around gateway chat dispatch, and expose explicit unsupported no-op capability for Signal, WhatsApp, and Slack with focused adapter tests.
+- Implementation: added typed `TypingIndicatorCapability`, refresh/no-op helpers, Telegram `sendChatAction` refresh, Discord `/channels/{id}/typing` refresh, and explicit unsupported capabilities for Signal, WhatsApp, and Slack.
+- Verification: focused runtime gateway integration tests passed (6 files, 47 tests); `npm run typecheck` passed.
+- Verification: `npm run lint:boundaries` exited 0 with existing warnings; `npm run test:changed` passed related integration and smoke lanes.
+- Review: separate review agent reported no material findings.


### PR DESCRIPTION
Closes #994

## Summary
- Adds a typed optional `TypingIndicatorCapability` at the gateway channel adapter boundary.
- Implements native Telegram `sendChatAction(typing)` and Discord channel typing refresh around active gateway chat turns.
- Exposes explicit unsupported no-op typing capability for Signal, WhatsApp, and Slack while leaving local TUI/CLI progress behavior unchanged.
- Isolates typing start/refresh/stop errors from chat turn success and stops active sessions in `finally`.

## Verification
- `npm run typecheck`
- `npm run test:integration -- src/runtime/gateway/__tests__/typing-indicator.test.ts src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts src/runtime/gateway/__tests__/discord-gateway-adapter.test.ts src/runtime/gateway/__tests__/signal-gateway-adapter.test.ts src/runtime/gateway/__tests__/whatsapp-gateway-adapter.test.ts src/runtime/gateway/__tests__/slack-channel-adapter.test.ts`
- `npm run lint:boundaries`
- `npm run test:changed`
- Review agent: no material findings.

## Known unresolved risks
- No real Telegram/Discord/Slack/WhatsApp/Signal API calls were made; tests use adapter mocks and mocked fetch.
- Slack, Signal, and WhatsApp are explicit unsupported/no-op in the current adapter contracts.
- `npm run lint:boundaries` still reports pre-existing warnings but exits 0.