### PR TITLE
feat(longrun): route natural language to RunSpec drafts

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -159,7 +159,43 @@ function interruptDecision(kind: "diff" | "review" | "summary" | "background" | 
   return JSON.stringify({ kind, confidence, rationale: `test ${kind}` });
 }
 
-function freeformRouteDecision(kind: "assist" | "configure" | "execute" | "clarify", confidence = 0.93): string {
+function runSpecDraftDecision(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    decision: "run_spec_request",
+    confidence: 0.92,
+    profile: "kaggle",
+    objective: "Kaggle score 0.98を超えるまで長期で改善する",
+    execution_target: { kind: "daemon", remote_host: null, confidence: "medium" },
+    metric: {
+      name: "kaggle_score",
+      direction: "maximize",
+      target: 0.98,
+      target_rank_percent: null,
+      datasource: "kaggle_leaderboard",
+      confidence: "high",
+    },
+    progress_contract: {
+      kind: "metric_target",
+      dimension: "kaggle_score",
+      threshold: 0.98,
+      semantics: "Kaggle score exceeds 0.98.",
+      confidence: "high",
+    },
+    deadline: null,
+    budget: { max_trials: null, max_wall_clock_minutes: null, resident_policy: "best_effort" },
+    approval_policy: {
+      submit: "approval_required",
+      publish: "unspecified",
+      secret: "approval_required",
+      external_action: "approval_required",
+      irreversible_action: "approval_required",
+    },
+    missing_fields: [],
+    ...overrides,
+  });
+}
+
+function freeformRouteDecision(kind: "assist" | "configure" | "execute" | "run_spec" | "clarify", confidence = 0.93): string {
   return JSON.stringify({ kind, confidence, rationale: `test ${kind}` });
 }
 
@@ -4373,6 +4409,117 @@ describe("ChatRunner", () => {
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Tool-aware response");
+    });
+  });
+
+  describe("natural-language RunSpec draft routing", () => {
+    it("derives and persists a typed RunSpec draft through the production chat route", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const adapter = makeMockAdapter();
+      const llmClient = createMockLLMClient([
+        freeformRouteDecision("run_spec"),
+        runSpecDraftDecision(),
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        adapter,
+        llmClient,
+        chatAgentLoopRunner: {
+          execute: vi.fn(),
+        } as unknown as ChatAgentLoopRunner,
+      }));
+
+      const result = await runner.execute(
+        "Kaggle score 0.98を超えるまで長期で回して",
+        "/repo/kaggle",
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("Proposed long-running run:");
+      expect(result.output).toContain("Kaggle score 0.98");
+      expect(result.output).toContain("It has not started a daemon run.");
+      expect(adapter.execute).not.toHaveBeenCalled();
+      const runSpecDir = path.join(baseDir, "run-specs");
+      const [fileName] = fs.readdirSync(runSpecDir);
+      const stored = JSON.parse(fs.readFileSync(path.join(runSpecDir, fileName), "utf8"));
+      expect(stored.status).toBe("draft");
+      expect(stored.source_text).toBe("Kaggle score 0.98を超えるまで長期で回して");
+      expect(stored.workspace).toMatchObject({ path: "/repo/kaggle", source: "context" });
+      expect(stored.origin).toMatchObject({
+        channel: "cli",
+        session_id: expect.any(String),
+      });
+    });
+
+    it("keeps explanatory long-running questions on the ordinary chat path", async () => {
+      const adapter = makeMockAdapter();
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "assist",
+          confidence: 0.91,
+          rationale: "Explanation question",
+          requires_action: false,
+        }),
+        "Long-running tasks usually fail because constraints, state, or dependencies change.",
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        adapter,
+        llmClient,
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      const result = await runner.execute("Why do long-running tasks fail?", "/repo");
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("Long-running tasks usually fail");
+      expect(adapter.execute).not.toHaveBeenCalled();
+    });
+
+    it("preserves gateway reply target metadata on a RunSpec draft route", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-gateway-runspec-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const llmClient = createMockLLMClient([
+        freeformRouteDecision("run_spec"),
+        runSpecDraftDecision({
+          objective: "Continue Kaggle optimization until score exceeds 0.98",
+        }),
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        llmClient,
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+      const ingress = {
+        ...makeIngress("Please keep improving this Kaggle run until score exceeds 0.98."),
+        cwd: "/repo/kaggle",
+        runtimeControl: { allowed: true, approvalMode: "interactive" as const },
+        metadata: { routed_goal_id: "goal-current", gateway_message: true },
+        replyTarget: {
+          ...makeIngress("").replyTarget,
+          response_channel: "telegram-chat-1",
+          metadata: { gateway_message: true },
+        },
+      };
+
+      const selectedRoute = await (runner as unknown as {
+        resolveRouteFromIngress(message: ChatIngressMessage): Promise<SelectedChatRoute>;
+      }).resolveRouteFromIngress(ingress);
+      expect(selectedRoute.kind).toBe("run_spec_draft");
+      const result = await runner.executeIngressMessage(ingress, "/repo/kaggle", 120_000, selectedRoute);
+
+      expect(result.success).toBe(true);
+      const [fileName] = fs.readdirSync(path.join(baseDir, "run-specs"));
+      const stored = JSON.parse(fs.readFileSync(path.join(baseDir, "run-specs", fileName), "utf8"));
+      expect(stored.origin.channel).toBe("plugin_gateway");
+      expect(stored.origin.reply_target).toMatchObject({
+        conversation_id: "chat-1",
+        response_channel: "telegram-chat-1",
+      });
+      expect(stored.origin.metadata).toMatchObject({
+        platform: "telegram",
+        message_id: "message-1",
+      });
     });
   });
 });

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import * as fs from "node:fs";
 import { CrossPlatformChatSessionManager } from "../cross-platform-session.js";
 import type { CrossPlatformChatSessionOptions } from "../cross-platform-session.js";
 import type { ChatRunnerDeps } from "../chat-runner.js";
@@ -8,6 +9,7 @@ import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adapter-layer.js";
 import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { StateManager as RealStateManager } from "../../../base/state/state-manager.js";
 
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -60,7 +62,95 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
   return { promise, resolve };
 }
 
+function runSpecFreeformDecision(): string {
+  return JSON.stringify({
+    kind: "run_spec",
+    confidence: 0.93,
+    rationale: "Long-running background work request",
+  });
+}
+
+function runSpecDraftDecision(): string {
+  return JSON.stringify({
+    decision: "run_spec_request",
+    confidence: 0.92,
+    profile: "kaggle",
+    objective: "Continue Kaggle optimization until score exceeds 0.98",
+    execution_target: { kind: "daemon", remote_host: null, confidence: "medium" },
+    metric: {
+      name: "kaggle_score",
+      direction: "maximize",
+      target: 0.98,
+      target_rank_percent: null,
+      datasource: "kaggle_leaderboard",
+      confidence: "high",
+    },
+    progress_contract: {
+      kind: "metric_target",
+      dimension: "kaggle_score",
+      threshold: 0.98,
+      semantics: "Kaggle score exceeds 0.98.",
+      confidence: "high",
+    },
+    deadline: null,
+    budget: { max_trials: null, max_wall_clock_minutes: null, resident_policy: "best_effort" },
+    approval_policy: {
+      submit: "approval_required",
+      publish: "unspecified",
+      secret: "approval_required",
+      external_action: "approval_required",
+      irreversible_action: "approval_required",
+    },
+    missing_fields: [],
+  });
+}
+
 describe("CrossPlatformChatSessionManager", () => {
+  it("routes gateway natural-language long-running requests into a typed RunSpec draft", async () => {
+    const baseDir = makeTempDir();
+    try {
+      const stateManager = new RealStateManager(baseDir, undefined, { walEnabled: false });
+      const adapter = makeMockAdapter();
+      const chatAgentLoopRunner = { execute: vi.fn() };
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager,
+        adapter,
+        chatAgentLoopRunner: chatAgentLoopRunner as never,
+        llmClient: createMockLLMClient([
+          runSpecFreeformDecision(),
+          runSpecDraftDecision(),
+        ]),
+      }));
+
+      const result = await manager.execute("Please keep improving this Kaggle run until score exceeds 0.98.", {
+        identity_key: "telegram:user-1",
+        platform: "telegram",
+        conversation_id: "telegram-chat-1",
+        user_id: "user-1",
+        message_id: "message-1",
+        cwd: "/repo/kaggle",
+        metadata: { gateway_message: true },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("Proposed long-running run:");
+      expect(result.output).toContain("It has not started a daemon run.");
+      expect(adapter.execute).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      const [fileName] = fs.readdirSync(`${baseDir}/run-specs`);
+      const stored = JSON.parse(fs.readFileSync(`${baseDir}/run-specs/${fileName}`, "utf8"));
+      expect(stored.status).toBe("draft");
+      expect(stored.origin.channel).toBe("plugin_gateway");
+      expect(stored.origin.reply_target).toMatchObject({
+        conversation_id: "telegram-chat-1",
+        message_id: "message-1",
+        identity_key: "telegram:user-1",
+      });
+    } finally {
+      cleanupTempDir(baseDir);
+    }
+  });
+
   it("routes token-only setup follow-up through typed secret intake instead of adapter execution", async () => {
     const token = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi";
     const stateManager = makeMockStateManager();

--- a/src/interface/chat/__tests__/ingress-router.test.ts
+++ b/src/interface/chat/__tests__/ingress-router.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { IngressRouter, buildStandaloneIngressMessage } from "../ingress-router.js";
+import type { RunSpec } from "../../../runtime/run-spec/index.js";
 
 describe("IngressRouter", () => {
   const router = new IngressRouter();
@@ -177,6 +178,66 @@ describe("IngressRouter", () => {
     );
 
     expect(route.kind).toBe("agent_loop");
+  });
+
+  it("routes a precomputed typed RunSpec draft without keyword-derived route logic", () => {
+    const draft = {
+      schema_version: "run-spec-v1",
+      id: "runspec-00000000-0000-4000-8000-000000000001",
+      status: "draft",
+      profile: "kaggle",
+      source_text: "Kaggle score 0.98を超えるまで長期で回して",
+      objective: "Improve Kaggle score until it exceeds 0.98",
+      workspace: { path: "/repo/kaggle", source: "context", confidence: "medium" },
+      execution_target: { kind: "daemon", remote_host: null, confidence: "medium" },
+      metric: {
+        name: "kaggle_score",
+        direction: "maximize",
+        target: 0.98,
+        target_rank_percent: null,
+        datasource: "kaggle_leaderboard",
+        confidence: "high",
+      },
+      progress_contract: {
+        kind: "metric_target",
+        dimension: "kaggle_score",
+        threshold: 0.98,
+        semantics: "Kaggle score exceeds 0.98.",
+        confidence: "high",
+      },
+      deadline: null,
+      budget: { max_trials: null, max_wall_clock_minutes: null, resident_policy: "best_effort" },
+      approval_policy: {
+        submit: "approval_required",
+        publish: "unspecified",
+        secret: "approval_required",
+        external_action: "approval_required",
+        irreversible_action: "approval_required",
+      },
+      artifact_contract: { expected_artifacts: [], discovery_globs: [], primary_outputs: [] },
+      risk_flags: ["external_submit_requires_approval"],
+      missing_fields: [],
+      confidence: "high",
+      links: { goal_id: null, runtime_session_id: null, conversation_id: "chat-1" },
+      origin: { channel: "plugin_gateway", session_id: "chat-1", reply_target: null, metadata: {} },
+      created_at: "2026-05-03T00:00:00.000Z",
+      updated_at: "2026-05-03T00:00:00.000Z",
+    } satisfies RunSpec;
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: draft.source_text,
+        channel: "plugin_gateway",
+        platform: "telegram",
+      }),
+      {
+        hasAgentLoop: true,
+        hasToolLoop: true,
+        runSpecDraft: draft,
+      }
+    );
+
+    expect(route.kind).toBe("run_spec_draft");
+    expect(route.reason).toBe("run_spec_draft_intent");
   });
 
   it("keeps long-running work on agent_loop when runtime control is disallowed", () => {

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -33,6 +33,7 @@ import {
   type TurnLanguageHint,
 } from "./turn-language.js";
 import { createOperationProgressItem } from "./operation-progress.js";
+import { createRunSpecStore, formatRunSpecSetupProposal } from "../../runtime/run-spec/index.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
@@ -91,6 +92,25 @@ export async function executeRuntimeControlRoute(
     output: result.message,
     elapsed_ms: Date.now() - start,
   };
+}
+
+export async function executeRunSpecDraftRoute(
+  host: ChatRunnerRouteHost,
+  route: Extract<SelectedChatRoute, { kind: "run_spec_draft" }>,
+  eventContext: ChatEventContext,
+  assistantBuffer: AssistantBuffer,
+  history: { appendAssistantMessage(message: string): Promise<void> },
+  start: number,
+): Promise<ChatRunResult> {
+  const store = createRunSpecStore(host.deps.stateManager);
+  await store.save(route.draft);
+  host.eventBridge.emitCheckpoint("RunSpec draft prepared", `${route.draft.id} is awaiting confirmation wiring.`, eventContext, "route");
+  const output = [
+    formatRunSpecSetupProposal(route.draft),
+    "",
+    "PulSeed prepared this as a typed long-running RunSpec draft. It has not started a daemon run.",
+  ].join("\n");
+  return persistDirectRouteResult(host, output, eventContext, assistantBuffer, history, start);
 }
 
 export function formatBlockedRuntimeControlRoute(route: Extract<SelectedChatRoute, { kind: "runtime_control_blocked" }>): string {

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -77,6 +77,7 @@ import {
   executeAssistRoute,
   executeClarifyRoute,
   executeConfigureRoute,
+  executeRunSpecDraftRoute,
   executeAgentLoopRoute,
   formatBlockedRuntimeControlRoute,
   executeRuntimeControlRoute,
@@ -84,6 +85,7 @@ import {
   resolveSessionExecutionPolicy,
 } from "./chat-runner-routes.js";
 import { classifyFreeformRouteIntent } from "./freeform-route-classifier.js";
+import { deriveRunSpecFromText } from "../../runtime/run-spec/index.js";
 
 export interface ChatRunnerDeps {
   stateManager: StateManager;
@@ -498,7 +500,7 @@ export class ChatRunner {
 
     const selectedRoute = resumeOnly
       ? null
-      : (options.selectedRoute ?? await this.resolveRouteFromInput(safeInput, runtimeControlContext));
+      : (options.selectedRoute ?? await this.resolveRouteFromInput(safeInput, runtimeControlContext, resolvedCwd));
     this.lastSelectedRoute = selectedRoute;
     if (selectedRoute?.kind !== "configure") {
       this.eventBridge.emitIntent(safeInput, selectedRoute, eventContext);
@@ -576,6 +578,11 @@ export class ChatRunner {
         output,
         elapsed_ms,
       };
+    }
+
+    if (selectedRoute?.kind === "run_spec_draft") {
+      const result = await executeRunSpecDraftRoute(this.routeHost(), selectedRoute, eventContext, assistantBuffer, history, start);
+      return result;
     }
 
     if (selectedRoute?.kind === "configure") {
@@ -762,21 +769,43 @@ export class ChatRunner {
     if (freeformRouteIntent === null && runtimeControlIntent === null && capabilities.hasAgentLoop) {
       freeformRouteIntent = await classifyFreeformRouteIntent(ingress.text, this.deps.llmClient);
     }
+    const shouldDeriveRunSpecDraft =
+      runtimeControlIntent === null
+      && freeformRouteIntent?.kind === "run_spec"
+      && freeformRouteIntent.confidence >= 0.7;
+    const runSpecDraft = shouldDeriveRunSpecDraft
+      ? await deriveRunSpecFromText(ingress.text, {
+        cwd: ingress.cwd ?? this.sessionCwd ?? undefined,
+        conversationId: ingress.conversation_id ?? null,
+        channel: ingress.channel,
+        sessionId: this.history?.getSessionId() ?? ingress.conversation_id ?? null,
+        replyTarget: ingress.replyTarget as unknown as Record<string, unknown>,
+        originMetadata: {
+          ingress_id: ingress.ingress_id ?? null,
+          platform: ingress.platform ?? null,
+          message_id: ingress.message_id ?? null,
+          deliveryMode: ingress.deliveryMode ?? null,
+          metadata: ingress.metadata,
+        },
+        llmClient: this.deps.llmClient,
+      })
+      : null;
     return standaloneIngressRouter.selectRoute(ingress, {
       ...capabilities,
       runtimeControlIntent,
       freeformRouteIntent,
       setupSecretIntake: this.setupSecretIntake,
+      runSpecDraft,
     });
   }
 
   private async resolveRouteFromInput(
     input: string,
-    runtimeControlContext: RuntimeControlChatContext | null
+    runtimeControlContext: RuntimeControlChatContext | null,
+    cwd?: string
   ): Promise<SelectedChatRoute> {
-    return this.resolveRouteFromIngress(
-      buildStandaloneIngressMessageFromContext(input, runtimeControlContext, this.deps)
-    );
+    const ingress = buildStandaloneIngressMessageFromContext(input, runtimeControlContext, this.deps);
+    return this.resolveRouteFromIngress(cwd ? { ...ingress, cwd } : ingress);
   }
 
   private loadedSessionToChatSession(session: LoadedChatSession): ChatSession {

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -13,6 +13,7 @@ import {
 } from "./ingress-router.js";
 import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
 import { classifyFreeformRouteIntent } from "./freeform-route-classifier.js";
+import { deriveRunSpecFromText } from "../../runtime/run-spec/index.js";
 import { intakeSetupSecrets } from "./setup-secret-intake.js";
 import { StateManager } from "../../base/state/state-manager.js";
 import { buildAdapterRegistry, buildLLMClient } from "../../base/llm/provider-factory.js";
@@ -728,11 +729,33 @@ export class CrossPlatformChatSessionManager {
     if (freeformRouteIntent === null && runtimeControlIntent === null && capabilities.hasAgentLoop) {
       freeformRouteIntent = await classifyFreeformRouteIntent(safeIngressText, this.deps.llmClient);
     }
+    const shouldDeriveRunSpecDraft =
+      runtimeControlIntent === null
+      && freeformRouteIntent?.kind === "run_spec"
+      && freeformRouteIntent.confidence >= 0.7;
+    const runSpecDraft = shouldDeriveRunSpecDraft
+      ? await deriveRunSpecFromText(safeIngressText, {
+        cwd: ingress.cwd ?? session.info.cwd,
+        conversationId: ingress.conversation_id ?? null,
+        channel: ingress.channel,
+        sessionId: session.runner.getSessionId() ?? ingress.conversation_id ?? null,
+        replyTarget: ingress.replyTarget as unknown as Record<string, unknown>,
+        originMetadata: {
+          ingress_id: ingress.ingress_id ?? null,
+          platform: ingress.platform ?? null,
+          message_id: ingress.message_id ?? null,
+          deliveryMode: ingress.deliveryMode ?? null,
+          metadata: ingress.metadata,
+        },
+        llmClient: this.deps.llmClient,
+      })
+      : null;
     const selectedRoute = this.ingressRouter.selectRoute(ingress, {
       ...capabilities,
       runtimeControlIntent,
       freeformRouteIntent,
       setupSecretIntake,
+      runSpecDraft,
     });
     session.lastRoute = selectedRoute;
 

--- a/src/interface/chat/freeform-route-classifier.ts
+++ b/src/interface/chat/freeform-route-classifier.ts
@@ -3,7 +3,7 @@ import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { getInternalIdentityPrefix } from "../../base/config/identity-loader.js";
 
 export const FreeformRouteIntentSchema = z.object({
-  kind: z.enum(["assist", "configure", "execute", "clarify"]),
+  kind: z.enum(["assist", "configure", "execute", "run_spec", "clarify"]),
   confidence: z.number().min(0).max(1),
   configure_target: z.enum(["telegram_gateway", "gateway", "provider", "daemon", "notification", "slack", "unknown"]).optional(),
   rationale: z.string().max(240),
@@ -33,7 +33,7 @@ function getFreeformRoutePrompt(): string {
 
 Return only JSON:
 {
-  "kind": "assist" | "configure" | "execute" | "clarify",
+  "kind": "assist" | "configure" | "execute" | "run_spec" | "clarify",
   "confidence": 0.0-1.0,
   "configure_target": "telegram_gateway" | "gateway" | "provider" | "daemon" | "notification" | "slack" | "unknown",
   "rationale": "short"
@@ -43,6 +43,7 @@ Routing contract:
 - assist: questions, how-to, status explanation, read-only guidance.
 - configure: setup/configuration of Telegram, Slack, daemon, provider, notifications, gateway, or channels.
 - execute: concrete repo edits, tests, implementation, commands, or goal execution that should enter the coding agent loop.
+- run_spec: clear natural-language requests for PulSeed to run, continue, optimize, evaluate, monitor, or work toward an outcome over time as a long-running background/CoreLoop run.
 - clarify: ambiguous or underspecified input where executing code would be unsafe.
 
 Use semantic intent, not literal phrase matching. Multilingual paraphrases should route by meaning.

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -3,6 +3,7 @@ import type { ChatEventHandler } from "./chat-events.js";
 import type { RuntimeControlIntent } from "../../runtime/control/index.js";
 import type { FreeformRouteIntent } from "./freeform-route-classifier.js";
 import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
+import type { RunSpec } from "../../runtime/run-spec/index.js";
 import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
@@ -67,6 +68,14 @@ export type SelectedChatRoute =
       concurrencyPolicy: ConcurrencyPolicy;
     }
   | {
+      kind: "run_spec_draft";
+      reason: "run_spec_draft_intent";
+      draft: RunSpec;
+      replyTargetPolicy: ReplyTargetPolicy;
+      eventProjectionPolicy: EventProjectionPolicy;
+      concurrencyPolicy: ConcurrencyPolicy;
+    }
+  | {
       kind: "runtime_control";
       reason: "runtime_control_intent";
       intent: RuntimeControlIntent;
@@ -90,6 +99,7 @@ export interface IngressRouterCapabilities {
   runtimeControlIntent?: RuntimeControlIntent | null;
   freeformRouteIntent?: FreeformRouteIntent | null;
   setupSecretIntake?: SetupSecretIntakeResult | null;
+  runSpecDraft?: RunSpec | null;
 }
 
 function selectRouteForText(
@@ -164,6 +174,16 @@ function selectRouteForText(
         configure_target: "gateway",
         rationale: "typed setup secret intake detected a Discord bot token",
       },
+      ...baseTurnPolicy,
+    };
+  }
+
+  const runSpecDraft = deps.runSpecDraft ?? null;
+  if (runSpecDraft) {
+    return {
+      kind: "run_spec_draft",
+      reason: "run_spec_draft_intent",
+      draft: runSpecDraft,
       ...baseTurnPolicy,
     };
   }

--- a/src/runtime/run-spec/derive.ts
+++ b/src/runtime/run-spec/derive.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
-import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { getInternalIdentityPrefix } from "../../base/config/identity-loader.js";
 import type {
   RunSpec,
@@ -217,6 +216,12 @@ export async function deriveRunSpecFromText(
       goal_id: null,
       runtime_session_id: null,
       conversation_id: context.conversationId ?? null,
+    },
+    origin: {
+      channel: context.channel ?? null,
+      session_id: context.sessionId ?? context.conversationId ?? null,
+      reply_target: context.replyTarget ?? null,
+      metadata: context.originMetadata ?? {},
     },
     created_at: createdAt,
     updated_at: createdAt,

--- a/src/runtime/run-spec/types.ts
+++ b/src/runtime/run-spec/types.ts
@@ -94,6 +94,14 @@ export const RunSpecLinksSchema = z.object({
 });
 export type RunSpecLinks = z.infer<typeof RunSpecLinksSchema>;
 
+export const RunSpecOriginSchema = z.object({
+  channel: z.string().nullable(),
+  session_id: z.string().nullable(),
+  reply_target: z.record(z.string(), z.unknown()).nullable(),
+  metadata: z.record(z.string(), z.unknown()),
+});
+export type RunSpecOrigin = z.infer<typeof RunSpecOriginSchema>;
+
 export const RunSpecSchema = z.object({
   schema_version: z.literal("run-spec-v1"),
   id: RunSpecIdSchema,
@@ -113,6 +121,7 @@ export const RunSpecSchema = z.object({
   missing_fields: z.array(RunSpecMissingFieldSchema),
   confidence: RunSpecConfidenceSchema,
   links: RunSpecLinksSchema,
+  origin: RunSpecOriginSchema,
   created_at: z.string(),
   updated_at: z.string(),
 });
@@ -121,6 +130,10 @@ export type RunSpec = z.infer<typeof RunSpecSchema>;
 export interface RunSpecDerivationContext {
   cwd?: string;
   conversationId?: string | null;
+  channel?: string | null;
+  sessionId?: string | null;
+  replyTarget?: Record<string, unknown> | null;
+  originMetadata?: Record<string, unknown>;
   now?: Date;
   timezone?: string;
   llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;

--- a/tmp/natural-language-longrun-handoff-status.md
+++ b/tmp/natural-language-longrun-handoff-status.md
@@ -1,0 +1,24 @@
+# Natural-language Longrun Handoff Status
+
+## 2026-05-03
+
+- Start state: `/Users/yuyoshimuta/Documents/dev/SeedPulse` did not exist in this environment, so work continues in `/Users/yuyoshimuta/PulSeed`.
+- Ran `git switch main && git pull --ff-only`: main was current.
+- Ran `gh issue list --state open --limit 100`: #997, #998, #999, #1000, #1001, and parent #986 are open.
+- Scope guard: not touching resident channel readiness issues #984/#985/#987/#994.
+
+## #997
+
+- Branch: `codex/issue-997-runspec-draft-route`.
+- Plan: reuse existing structured `runtime/run-spec` LLM derivation, extend RunSpec origin metadata, add a typed `run_spec_draft` chat route, and persist/display the draft without starting daemon work.
+- Current status: implemented locally.
+- Verification:
+  - `npm run typecheck`: pass.
+  - `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"`: pass.
+  - `npm run test:unit -- src/interface/chat/__tests__/cross-platform-session.test.ts -t "RunSpec draft"`: pass.
+  - `npm run test:unit -- src/interface/chat/__tests__/ingress-router.test.ts src/runtime/run-spec/__tests__/run-spec.test.ts`: pass.
+  - `npm run lint:boundaries`: pass with existing warnings only.
+  - `git diff --check`: pass.
+  - `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts`: 119 pass, 2 local Telegram setup expectation failures observed; failures assert unconfigured setup guidance while the local status provider reports configured Telegram config/home chat.
+  - `npm run test:changed`: failed only on 4 Telegram setup guidance expectations (`chat-runner.test.ts` x2, `cross-platform-session.test.ts` x2) for the same local configured-Telegram status reason; related non-setup tests passed.
+- Review: first review found CrossPlatformChatSessionManager bypassed the new draft route because it preselected routes before ChatRunner. Fixed by deriving/passing `runSpecDraft` in the cross-platform route selection path and adding a gateway production-path test.


### PR DESCRIPTION
Closes #997

Parent: #986. This advances the first slice of natural-language long-running handoff by deriving typed RunSpec drafts from clear freeform long-running requests before any daemon start path exists.

## Summary
- Adds a typed `run_spec` freeform route intent and `run_spec_draft` selected route.
- Reuses existing `runtime/run-spec` structured LLM derivation to build drafts; no keyword/regex/includes semantic routing was added.
- Persists and displays draft RunSpecs without starting daemon work.
- Preserves origin context for later confirmation/start: source text, workspace, channel/session, reply target, conversation, and ingress metadata.
- Wires both direct ChatRunner and CrossPlatformChatSessionManager gateway production paths.

## Verification
- `npm run typecheck` PASS
- `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"` PASS
- `npm run test:unit -- src/interface/chat/__tests__/cross-platform-session.test.ts -t "RunSpec draft"` PASS
- `npm run test:unit -- src/interface/chat/__tests__/ingress-router.test.ts src/runtime/run-spec/__tests__/run-spec.test.ts` PASS
- `npm run lint:boundaries` PASS with existing warnings
- `git diff --check` PASS
- `npm run test:changed` FAILS only on 4 Telegram setup guidance expectations in chat/cross-platform tests because this local environment reports Telegram config/home chat as already configured; RunSpec-related related tests pass.

## Review
- Separate review agent found a CrossPlatformChatSessionManager bypass; fixed in this PR.
- Re-review: no material findings.

## Known risks
- This PR stops at draft creation and persistence. Confirmation, daemon start, and safety/failure handling are intentionally left to #998-#1000.
- The freeform route classifier now has a `run_spec` semantic intent, so providers must return that enum to enter this product path.
