### PR TITLE
feat(longrun): confirm natural language RunSpecs

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 import { ChatRunner } from "../chat-runner.js";
 import type { ChatRunnerDeps } from "../chat-runner.js";
 import { CrossPlatformChatSessionManager } from "../cross-platform-session.js";
+import { ChatSessionCatalog } from "../chat-session-store.js";
 import { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adapter-layer.js";
 import type { EscalationHandler, EscalationResult } from "../escalation.js";
@@ -181,7 +182,13 @@ function runSpecDraftDecision(overrides: Record<string, unknown> = {}): string {
       semantics: "Kaggle score exceeds 0.98.",
       confidence: "high",
     },
-    deadline: null,
+    deadline: {
+      raw: "until score exceeds 0.98",
+      iso_at: null,
+      timezone: null,
+      finalization_buffer_minutes: null,
+      confidence: "medium",
+    },
     budget: { max_trials: null, max_wall_clock_minutes: null, resident_policy: "best_effort" },
     approval_policy: {
       submit: "approval_required",
@@ -191,6 +198,14 @@ function runSpecDraftDecision(overrides: Record<string, unknown> = {}): string {
       irreversible_action: "approval_required",
     },
     missing_fields: [],
+    ...overrides,
+  });
+}
+
+function runSpecConfirmationDecision(decision: "approve" | "cancel" | "unknown" | "revise", overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    decision,
+    confidence: 0.93,
     ...overrides,
   });
 }
@@ -4439,6 +4454,7 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("Proposed long-running run:");
       expect(result.output).toContain("Kaggle score 0.98");
       expect(result.output).toContain("It has not started a daemon run.");
+      expect(result.output).toContain("Reply with approval");
       expect(adapter.execute).not.toHaveBeenCalled();
       const runSpecDir = path.join(baseDir, "run-specs");
       const [fileName] = fs.readdirSync(runSpecDir);
@@ -4450,6 +4466,155 @@ describe("ChatRunner", () => {
         channel: "cli",
         session_id: expect.any(String),
       });
+    });
+
+    it("keeps a RunSpec pending until the next turn approves it", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-confirm-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const adapter = makeMockAdapter();
+      const daemonClient = { startGoal: vi.fn() };
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        adapter,
+        daemonClient: daemonClient as never,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision(),
+          runSpecConfirmationDecision("approve"),
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      const draftResult = await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
+      const approveResult = await runner.execute("承認します", "/repo/kaggle");
+
+      expect(draftResult.success).toBe(true);
+      expect(approveResult.success).toBe(true);
+      expect(approveResult.output).toContain("RunSpec confirmed:");
+      expect(approveResult.output).toContain("no background run has been started yet");
+      expect(adapter.execute).not.toHaveBeenCalled();
+      expect(daemonClient.startGoal).not.toHaveBeenCalled();
+      const [fileName] = fs.readdirSync(path.join(baseDir, "run-specs"));
+      const stored = JSON.parse(fs.readFileSync(path.join(baseDir, "run-specs", fileName), "utf8"));
+      expect(stored.status).toBe("confirmed");
+    });
+
+    it("cancels a pending RunSpec without starting a background run", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-cancel-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const daemonClient = { startGoal: vi.fn() };
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        daemonClient: daemonClient as never,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision(),
+          runSpecConfirmationDecision("cancel"),
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
+      const cancelResult = await runner.execute("cancel it", "/repo/kaggle");
+
+      expect(cancelResult.success).toBe(false);
+      expect(cancelResult.output).toContain("RunSpec cancelled:");
+      expect(cancelResult.output).toContain("No background run was started.");
+      expect(daemonClient.startGoal).not.toHaveBeenCalled();
+      const [fileName] = fs.readdirSync(path.join(baseDir, "run-specs"));
+      const stored = JSON.parse(fs.readFileSync(path.join(baseDir, "run-specs", fileName), "utf8"));
+      expect(stored.status).toBe("cancelled");
+    });
+
+    it("does not reuse a stale cancelled RunSpec confirmation on a later approval", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-stale-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const adapter = makeMockAdapter();
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        adapter,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision(),
+          runSpecConfirmationDecision("cancel"),
+          freeformRouteDecision("assist"),
+          "There is no pending RunSpec to approve.",
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
+      await runner.execute("cancel it", "/repo/kaggle");
+      const staleApproval = await runner.execute("approve it now", "/repo/kaggle");
+
+      expect(staleApproval.success).toBe(true);
+      expect(staleApproval.output).toBe("There is no pending RunSpec to approve.");
+      const [fileName] = fs.readdirSync(path.join(baseDir, "run-specs"));
+      const stored = JSON.parse(fs.readFileSync(path.join(baseDir, "run-specs", fileName), "utf8"));
+      expect(stored.status).toBe("cancelled");
+    });
+
+    it("preserves pending RunSpec confirmation across session reload before approval", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-reload-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const firstRunner = new ChatRunner(makeDeps({
+        stateManager,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision(),
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      await firstRunner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
+      const sessionId = firstRunner.getSessionId();
+      expect(sessionId).toBeTruthy();
+
+      const catalog = new ChatSessionCatalog(stateManager);
+      const loaded = await catalog.loadSession(sessionId!);
+      expect(loaded?.runSpecConfirmation).toMatchObject({ state: "pending" });
+
+      const reloadedRunner = new ChatRunner(makeDeps({
+        stateManager,
+        llmClient: createSingleMockLLMClient(runSpecConfirmationDecision("approve")),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+      reloadedRunner.startSessionFromLoadedSession(loaded!);
+
+      const approved = await reloadedRunner.execute("approve", "/repo/kaggle");
+
+      expect(approved.success).toBe(true);
+      expect(approved.output).toContain("RunSpec confirmed:");
+      const [fileName] = fs.readdirSync(path.join(baseDir, "run-specs"));
+      const stored = JSON.parse(fs.readFileSync(path.join(baseDir, "run-specs", fileName), "utf8"));
+      expect(stored.status).toBe("confirmed");
+    });
+
+    it("keeps pending confirmation on ambiguous approval text", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-ambiguous-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision(),
+          runSpecConfirmationDecision("unknown", {
+            confidence: 0.41,
+            clarification: "Please explicitly approve or cancel.",
+          }),
+          runSpecConfirmationDecision("approve"),
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
+      const ambiguousResult = await runner.execute("looks good maybe", "/repo/kaggle");
+      const approvedResult = await runner.execute("approve", "/repo/kaggle");
+
+      expect(ambiguousResult.success).toBe(false);
+      expect(ambiguousResult.output).toContain("awaiting confirmation");
+      expect(approvedResult.success).toBe(true);
+      expect(approvedResult.output).toContain("RunSpec confirmed:");
     });
 
     it("keeps explanatory long-running questions on the ordinary chat path", async () => {

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -8,6 +8,7 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import { RuntimeReplyTargetSchema, type RuntimeReplyTarget } from "../../runtime/session-registry/types.js";
 import { redactSetupSecrets, SetupSecretIntakeItemSchema } from "./setup-secret-intake.js";
 import { SetupDialoguePublicStateSchema, type SetupDialoguePublicState } from "./setup-dialogue.js";
+import { RunSpecSchema } from "../../runtime/run-spec/index.js";
 
 // ─── Schemas ───
 
@@ -46,6 +47,15 @@ export const ChatSessionUsageSchema = z.object({
 }).passthrough();
 export type ChatSessionUsage = z.infer<typeof ChatSessionUsageSchema>;
 
+export const RunSpecConfirmationStateSchema = z.object({
+  state: z.enum(["pending", "confirmed", "cancelled"]),
+  spec: RunSpecSchema,
+  prompt: z.string(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+}).passthrough();
+export type RunSpecConfirmationState = z.infer<typeof RunSpecConfirmationStateSchema>;
+
 export const ChatSessionSchema = z.object({
   id: z.string(),
   cwd: z.string(), // git root at session start
@@ -74,6 +84,7 @@ export const ChatSessionSchema = z.object({
   parentNotificationSummary: z.string().nullable().optional(),
   parentNotifiedAt: z.string().nullable().optional(),
   setupDialogue: SetupDialoguePublicStateSchema.nullable().optional(),
+  runSpecConfirmation: RunSpecConfirmationStateSchema.nullable().optional(),
   messages: z.array(ChatMessageSchema),
   compactionSummary: z.string().optional(),
   agentLoopStatePath: z.string().nullable().optional(),
@@ -234,6 +245,18 @@ export class ChatHistory {
       this.session.setupDialogue = dialogue;
     } else {
       delete this.session.setupDialogue;
+    }
+  }
+
+  getRunSpecConfirmation(): RunSpecConfirmationState | null {
+    return this.session.runSpecConfirmation ?? null;
+  }
+
+  setRunSpecConfirmation(confirmation: RunSpecConfirmationState | null): void {
+    if (confirmation) {
+      this.session.runSpecConfirmation = confirmation;
+    } else {
+      delete this.session.runSpecConfirmation;
     }
   }
 

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -34,6 +34,7 @@ import {
 } from "./turn-language.js";
 import { createOperationProgressItem } from "./operation-progress.js";
 import { createRunSpecStore, formatRunSpecSetupProposal } from "../../runtime/run-spec/index.js";
+import type { RunSpecConfirmationState } from "./chat-history.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
@@ -50,6 +51,7 @@ export interface ChatRunnerRouteHost {
   getSetupSecretIntake(): SetupSecretIntakeResult | null;
   getTurnLanguageHint(): TurnLanguageHint;
   setPendingSetupDialogue(dialogue: SetupDialogueRuntimeState): Promise<void>;
+  setPendingRunSpecConfirmation(confirmation: RunSpecConfirmationState): Promise<void>;
   getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
   setSessionExecutionPolicy(policy: ExecutionPolicy): void;
 }
@@ -104,12 +106,21 @@ export async function executeRunSpecDraftRoute(
 ): Promise<ChatRunResult> {
   const store = createRunSpecStore(host.deps.stateManager);
   await store.save(route.draft);
-  host.eventBridge.emitCheckpoint("RunSpec draft prepared", `${route.draft.id} is awaiting confirmation wiring.`, eventContext, "route");
+  const proposal = formatRunSpecSetupProposal(route.draft);
   const output = [
-    formatRunSpecSetupProposal(route.draft),
+    proposal,
     "",
     "PulSeed prepared this as a typed long-running RunSpec draft. It has not started a daemon run.",
+    "Reply with approval to confirm, cancel to discard it, or provide updated workspace/deadline/metric details.",
   ].join("\n");
+  await host.setPendingRunSpecConfirmation({
+    state: "pending",
+    spec: route.draft,
+    prompt: output,
+    createdAt: route.draft.created_at,
+    updatedAt: route.draft.updated_at,
+  });
+  host.eventBridge.emitCheckpoint("RunSpec confirmation pending", `${route.draft.id} is awaiting confirmation.`, eventContext, "route");
   return persistDirectRouteResult(host, output, eventContext, assistantBuffer, history, start);
 }
 

--- a/src/interface/chat/chat-runner-runtime.ts
+++ b/src/interface/chat/chat-runner-runtime.ts
@@ -55,6 +55,7 @@ export function loadedSessionToChatSession(session: LoadedChatSession): ChatSess
     ...(session.lastRetryAt ? { lastRetryAt: session.lastRetryAt } : {}),
     ...(session.lastResumedAt ? { lastResumedAt: session.lastResumedAt } : {}),
     ...(session.notificationReplyTarget ? { notificationReplyTarget: session.notificationReplyTarget } : {}),
+    ...(session.runSpecConfirmation ? { runSpecConfirmation: session.runSpecConfirmation } : {}),
     ...(session.parentNotificationStatus ? { parentNotificationStatus: session.parentNotificationStatus } : {}),
     ...(session.parentNotificationSummary ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
     ...(session.parentNotifiedAt ? { parentNotifiedAt: session.parentNotifiedAt } : {}),

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -86,6 +86,11 @@ import {
 } from "./chat-runner-routes.js";
 import { classifyFreeformRouteIntent } from "./freeform-route-classifier.js";
 import { deriveRunSpecFromText } from "../../runtime/run-spec/index.js";
+import {
+  createRunSpecStore,
+  formatRunSpecSetupProposal,
+  handleRunSpecConfirmationInput,
+} from "../../runtime/run-spec/index.js";
 
 export interface ChatRunnerDeps {
   stateManager: StateManager;
@@ -412,6 +417,11 @@ export class ChatRunner {
     const pendingTelegramSetupResult = await this.handlePendingSetupConfirmation(safeInput, runtimeControlContext);
     if (pendingTelegramSetupResult !== null) {
       return this.finalizeNonPersistentResult(pendingTelegramSetupResult, eventContext);
+    }
+
+    const pendingRunSpecConfirmationResult = await this.handlePendingRunSpecConfirmation(safeInput);
+    if (pendingRunSpecConfirmationResult !== null) {
+      return this.finalizeNonPersistentResult(pendingRunSpecConfirmationResult, eventContext);
     }
 
     const commandResult = resumeOnly ? null : await this.commandHandler.handleCommand(safeInput, resolvedCwd);
@@ -828,6 +838,10 @@ export class ChatRunner {
         this.history?.setSetupDialogue(dialogue.publicState);
         await this.history?.persist();
       },
+      setPendingRunSpecConfirmation: async (confirmation: NonNullable<ReturnType<ChatHistory["getRunSpecConfirmation"]>>) => {
+        this.history?.setRunSpecConfirmation(confirmation);
+        await this.history?.persist();
+      },
       getSessionExecutionPolicy: () => this.getSessionExecutionPolicy(),
       setSessionExecutionPolicy: (policy: ExecutionPolicy) => { this.sessionExecutionPolicy = policy; },
     };
@@ -836,6 +850,86 @@ export class ChatRunner {
   private providerConfigBaseDir(): string {
     const stateManager = this.deps.stateManager as StateManager & { getBaseDir?: () => string };
     return typeof stateManager.getBaseDir === "function" ? stateManager.getBaseDir() : getPulseedDirPath();
+  }
+
+  private async handlePendingRunSpecConfirmation(input: string): Promise<ChatRunResult | null> {
+    const pending = this.history?.getRunSpecConfirmation() ?? null;
+    if (!pending || pending.state !== "pending") return null;
+    const start = Date.now();
+    const result = await handleRunSpecConfirmationInput(pending.spec, input, {
+      llmClient: this.deps.llmClient,
+    });
+    const store = createRunSpecStore(this.deps.stateManager);
+    await store.save(result.spec);
+
+    if (result.kind === "confirmed") {
+      this.history?.setRunSpecConfirmation({
+        ...pending,
+        state: "confirmed",
+        spec: result.spec,
+        updatedAt: result.spec.updated_at,
+      });
+      await this.history?.persist();
+      return {
+        success: true,
+        output: [
+          result.message,
+          "",
+          "The RunSpec is confirmed. Daemon start is not wired in this step, so no background run has been started yet.",
+        ].join("\n"),
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    if (result.kind === "cancelled") {
+      this.history?.setRunSpecConfirmation(null);
+      await this.history?.persist();
+      return {
+        success: false,
+        output: `${result.message}\nNo background run was started.`,
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    if (result.kind === "revised") {
+      const proposal = formatRunSpecSetupProposal(result.spec);
+      this.history?.setRunSpecConfirmation({
+        ...pending,
+        spec: result.spec,
+        prompt: proposal,
+        updatedAt: result.spec.updated_at,
+      });
+      await this.history?.persist();
+      return {
+        success: true,
+        output: [
+          proposal,
+          "",
+          "RunSpec updated. Reply with approval to confirm, cancel to discard it, or provide another update.",
+        ].join("\n"),
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    if (result.kind === "blocked") {
+      this.history?.setRunSpecConfirmation({
+        ...pending,
+        spec: result.spec,
+        updatedAt: result.spec.updated_at,
+      });
+      await this.history?.persist();
+      return {
+        success: false,
+        output: result.message,
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    return {
+      success: false,
+      output: result.message,
+      elapsed_ms: Date.now() - start,
+    };
   }
 
   private async handlePendingSetupConfirmation(

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -61,6 +61,7 @@ export interface LoadedChatSession {
   lastRetryAt?: string | null;
   lastResumedAt?: string | null;
   notificationReplyTarget?: ChatSession["notificationReplyTarget"];
+  runSpecConfirmation?: ChatSession["runSpecConfirmation"];
   parentNotificationStatus?: "none" | "pending" | "sent" | "failed" | null;
   parentNotificationSummary?: string | null;
   parentNotifiedAt?: string | null;
@@ -334,6 +335,7 @@ async function readSessionRecordWithMetadata(
     ...(optionalString(parsed.data.lastRetryAt) !== null ? { lastRetryAt: optionalString(parsed.data.lastRetryAt) } : {}),
     ...(optionalString(parsed.data.lastResumedAt) !== null ? { lastResumedAt: optionalString(parsed.data.lastResumedAt) } : {}),
     ...(parsed.data.notificationReplyTarget ? { notificationReplyTarget: parsed.data.notificationReplyTarget } : {}),
+    ...(parsed.data.runSpecConfirmation ? { runSpecConfirmation: parsed.data.runSpecConfirmation } : {}),
     ...(parsed.data.parentNotificationStatus ? { parentNotificationStatus: parsed.data.parentNotificationStatus } : {}),
     ...(optionalString(parsed.data.parentNotificationSummary) !== null ? { parentNotificationSummary: optionalString(parsed.data.parentNotificationSummary) } : {}),
     ...(optionalString(parsed.data.parentNotifiedAt) !== null ? { parentNotifiedAt: optionalString(parsed.data.parentNotifiedAt) } : {}),
@@ -400,6 +402,7 @@ function toPersistedSession(session: LoadedChatSession): ChatSession {
     ...(session.lastRetryAt !== null && session.lastRetryAt !== undefined ? { lastRetryAt: session.lastRetryAt } : {}),
     ...(session.lastResumedAt !== null && session.lastResumedAt !== undefined ? { lastResumedAt: session.lastResumedAt } : {}),
     ...(session.notificationReplyTarget !== null && session.notificationReplyTarget !== undefined ? { notificationReplyTarget: session.notificationReplyTarget } : {}),
+    ...(session.runSpecConfirmation !== null && session.runSpecConfirmation !== undefined ? { runSpecConfirmation: session.runSpecConfirmation } : {}),
     ...(session.parentNotificationStatus !== null && session.parentNotificationStatus !== undefined ? { parentNotificationStatus: session.parentNotificationStatus } : {}),
     ...(session.parentNotificationSummary !== null && session.parentNotificationSummary !== undefined ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
     ...(session.parentNotifiedAt !== null && session.parentNotifiedAt !== undefined ? { parentNotifiedAt: session.parentNotifiedAt } : {}),

--- a/tmp/natural-language-longrun-handoff-status.md
+++ b/tmp/natural-language-longrun-handoff-status.md
@@ -22,3 +22,16 @@
   - `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts`: 119 pass, 2 local Telegram setup expectation failures observed; failures assert unconfigured setup guidance while the local status provider reports configured Telegram config/home chat.
   - `npm run test:changed`: failed only on 4 Telegram setup guidance expectations (`chat-runner.test.ts` x2, `cross-platform-session.test.ts` x2) for the same local configured-Telegram status reason; related non-setup tests passed.
 - Review: first review found CrossPlatformChatSessionManager bypassed the new draft route because it preselected routes before ChatRunner. Fixed by deriving/passing `runSpecDraft` in the cross-platform route selection path and adding a gateway production-path test.
+
+## #998
+
+- Branch: `codex/issue-998-runspec-confirmation`.
+- Plan: persist pending RunSpec confirmation in chat session state, route next-turn input through the existing typed RunSpec confirmation state machine, and keep daemon start out of scope.
+- Current status: implemented locally.
+- Verification:
+  - `npm run typecheck`: pass.
+  - `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"`: pass.
+  - `npm run test:unit -- src/interface/chat/__tests__/cross-platform-session.test.ts -t "RunSpec draft"`: pass.
+  - `npm run test:unit -- src/interface/chat/__tests__/chat-session-store.test.ts src/interface/chat/__tests__/chat-history.test.ts`: pass.
+  - `git diff --check`: pass.
+- Review: first review found `runSpecConfirmation` was persisted in raw chat history but dropped through `LoadedChatSession`/resume conversion. Fixed by threading the field through session load/save conversion and adding a reload-before-approval test. Re-review: no material findings.


### PR DESCRIPTION
Closes #998

Parent: #986. This advances the confirmation slice: natural-language RunSpec drafts now become pending confirmations and wait for a later approve/cancel/update turn.

## Summary
- Persists pending RunSpec confirmation state in ChatHistory.
- Routes the next turn through the existing typed RunSpec confirmation state machine.
- Supports approve, cancel, revise/update, blocked required fields, and ambiguous confirmation responses.
- Clears cancelled confirmations so stale approvals do not reuse prior drafts.
- Threads pending confirmation state through chat session load/save/resume conversion.
- Keeps daemon start out of scope; approval confirms the RunSpec but does not start background work yet.

## Verification
- `npm run typecheck` PASS
- `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"` PASS
- `npm run test:unit -- src/interface/chat/__tests__/cross-platform-session.test.ts -t "RunSpec draft"` PASS
- `npm run test:unit -- src/interface/chat/__tests__/chat-session-store.test.ts src/interface/chat/__tests__/chat-history.test.ts` PASS
- `npm run lint:boundaries` PASS with existing warnings
- `git diff --check` PASS

## Review
- Separate review agent found pending `runSpecConfirmation` was dropped through `LoadedChatSession`/resume conversion; fixed in this PR.
- Re-review: no material findings.

## Known risks
- Confirmed RunSpecs still do not start daemon/CoreLoop runs. That is intentionally left to #999.
- Safety/failure hardening beyond the existing RunSpec approval policy remains for #1000.
