### PR TITLE
feat(longrun): start confirmed RunSpecs

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -14,6 +14,7 @@ import type { EscalationHandler, EscalationResult } from "../escalation.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import type { ChatAgentLoopRunner } from "../../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
 import { RuntimeControlService } from "../../../runtime/control/index.js";
+import { createRuntimeSessionRegistry } from "../../../runtime/session-registry/index.js";
 import { RuntimeOperationStore } from "../../../runtime/store/runtime-operation-store.js";
 import type { Goal } from "../../../base/types/goal.js";
 import type { Task } from "../../../base/types/task.js";
@@ -4468,11 +4469,11 @@ describe("ChatRunner", () => {
       });
     });
 
-    it("keeps a RunSpec pending until the next turn approves it", async () => {
+    it("starts a confirmed RunSpec only after next-turn approval", async () => {
       const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-confirm-"));
       const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
       const adapter = makeMockAdapter();
-      const daemonClient = { startGoal: vi.fn() };
+      const daemonClient = { startGoal: vi.fn().mockResolvedValue({ ok: true }) };
       const runner = new ChatRunner(makeDeps({
         stateManager,
         adapter,
@@ -4486,17 +4487,78 @@ describe("ChatRunner", () => {
       }));
 
       const draftResult = await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
+      expect(draftResult.success).toBe(true);
+      expect(daemonClient.startGoal).not.toHaveBeenCalled();
       const approveResult = await runner.execute("承認します", "/repo/kaggle");
 
-      expect(draftResult.success).toBe(true);
       expect(approveResult.success).toBe(true);
       expect(approveResult.output).toContain("RunSpec confirmed:");
-      expect(approveResult.output).toContain("no background run has been started yet");
+      expect(approveResult.output).toContain("Started daemon-backed CoreLoop goal:");
+      expect(approveResult.output).toContain("Background run: run:coreloop:");
       expect(adapter.execute).not.toHaveBeenCalled();
-      expect(daemonClient.startGoal).not.toHaveBeenCalled();
+      expect(daemonClient.startGoal).toHaveBeenCalledOnce();
+      expect(daemonClient.startGoal).toHaveBeenCalledWith(
+        expect.stringMatching(/^goal-runspec-/),
+        expect.objectContaining({
+          backgroundRun: expect.objectContaining({
+            backgroundRunId: expect.stringMatching(/^run:coreloop:/),
+            notifyPolicy: "done_only",
+            parentSessionId: expect.stringMatching(/^session:conversation:/),
+            replyTargetSource: "pinned_run",
+          }),
+        }),
+      );
       const [fileName] = fs.readdirSync(path.join(baseDir, "run-specs"));
       const stored = JSON.parse(fs.readFileSync(path.join(baseDir, "run-specs", fileName), "utf8"));
       expect(stored.status).toBe("confirmed");
+      const runId = (daemonClient.startGoal as ReturnType<typeof vi.fn>).mock.calls[0][1].backgroundRun.backgroundRunId;
+      const run = JSON.parse(fs.readFileSync(path.join(baseDir, "runtime", "background-runs", `${encodeURIComponent(runId)}.json`), "utf8"));
+      expect(run).toMatchObject({
+        id: runId,
+        status: "queued",
+        workspace: "/repo/kaggle",
+        origin_metadata: {
+          run_spec_id: stored.id,
+        },
+      });
+      const registry = createRuntimeSessionRegistry({ stateManager });
+      const snapshot = await registry.snapshot();
+      expect(snapshot.background_runs).toContainEqual(expect.objectContaining({
+        id: runId,
+        goal_id: expect.stringMatching(/^goal-runspec-/),
+        workspace: "/repo/kaggle",
+      }));
+    });
+
+    it("does not report started when daemon start fails after RunSpec approval", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-daemon-fail-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const daemonClient = { startGoal: vi.fn().mockRejectedValue(new Error("Connection refused")) };
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        daemonClient: daemonClient as never,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision(),
+          runSpecConfirmationDecision("approve"),
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
+      const result = await runner.execute("approve", "/repo/kaggle");
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Daemon start failed");
+      expect(result.output).toContain("no CoreLoop run was started");
+      expect(result.output).toContain("Connection refused");
+      expect(daemonClient.startGoal).toHaveBeenCalledOnce();
+      const registry = createRuntimeSessionRegistry({ stateManager });
+      const snapshot = await registry.snapshot();
+      expect(snapshot.background_runs).toContainEqual(expect.objectContaining({
+        status: "failed",
+        error: "Connection refused",
+      }));
     });
 
     it("cancels a pending RunSpec without starting a background run", async () => {
@@ -4576,6 +4638,7 @@ describe("ChatRunner", () => {
 
       const reloadedRunner = new ChatRunner(makeDeps({
         stateManager,
+        daemonClient: { startGoal: vi.fn().mockResolvedValue({ ok: true }) } as never,
         llmClient: createSingleMockLLMClient(runSpecConfirmationDecision("approve")),
         chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
@@ -4595,6 +4658,7 @@ describe("ChatRunner", () => {
       const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
       const runner = new ChatRunner(makeDeps({
         stateManager,
+        daemonClient: { startGoal: vi.fn().mockResolvedValue({ ok: true }) } as never,
         llmClient: createMockLLMClient([
           freeformRouteDecision("run_spec"),
           runSpecDraftDecision(),

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -3,6 +3,7 @@
 // Central coordinator for 1-shot chat execution (Tier 1).
 // Bypasses TaskLifecycle — calls adapter.execute() directly.
 
+import { randomUUID } from "node:crypto";
 import type { StateManager } from "../../base/state/state-manager.js";
 import type { IAdapter } from "../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
@@ -39,6 +40,9 @@ import type {
 } from "../../runtime/store/runtime-operation-schemas.js";
 import type { RuntimeReplyTarget } from "../../runtime/session-registry/types.js";
 import type { ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
+import { GoalSchema, type Goal } from "../../base/types/goal.js";
+import { BackgroundRunLedger, type BackgroundRunCreateInput } from "../../runtime/store/background-run-store.js";
+import { resolveConfiguredDaemonRuntimeRoot } from "../../runtime/daemon/runtime-root.js";
 import {
   createIngressRouter,
   type ChatIngressMessage,
@@ -90,6 +94,7 @@ import {
   createRunSpecStore,
   formatRunSpecSetupProposal,
   handleRunSpecConfirmationInput,
+  type RunSpec,
 } from "../../runtime/run-spec/index.js";
 
 export interface ChatRunnerDeps {
@@ -157,6 +162,67 @@ function normalizePinnedReplyTarget(replyTarget: RuntimeControlReplyTarget | nul
       ...(replyTarget.metadata ?? {}),
     },
   };
+}
+
+function normalizePinnedReplyTargetForRunSpec(replyTarget: RuntimeControlReplyTarget | null): RuntimeReplyTarget | null {
+  if (!replyTarget) return null;
+  const channel = replyTarget.channel ?? replyTarget.surface;
+  if (!channel) return null;
+  return {
+    channel,
+    target_id: replyTarget.conversation_id ?? replyTarget.identity_key ?? replyTarget.response_channel ?? null,
+    thread_id: replyTarget.message_id ?? null,
+    metadata: {
+      ...replyTarget,
+      ...(replyTarget.metadata ?? {}),
+    },
+  };
+}
+
+function goalDimensionFromRunSpec(spec: RunSpec, now: string): Goal["dimensions"][number] {
+  const metric = spec.metric;
+  const progress = spec.progress_contract;
+  const thresholdValue = metric?.target ?? metric?.target_rank_percent ?? progress.threshold;
+  const direction = metric?.direction ?? "unknown";
+  const threshold = typeof thresholdValue === "number"
+    ? direction === "minimize"
+      ? { type: "max" as const, value: thresholdValue }
+      : { type: "min" as const, value: thresholdValue }
+    : { type: "present" as const };
+  return {
+    name: progress.dimension ?? metric?.name ?? "runspec_progress",
+    label: progress.semantics,
+    current_value: null,
+    threshold,
+    confidence: spec.confidence === "high" ? 0.85 : spec.confidence === "medium" ? 0.65 : 0.4,
+    observation_method: {
+      type: "llm_review",
+      source: "natural_language_runspec",
+      schedule: null,
+      endpoint: null,
+      confidence_tier: "self_report",
+    },
+    last_updated: now,
+    history: [],
+    weight: 1,
+    uncertainty_weight: null,
+    state_integrity: "ok",
+    dimension_mapping: null,
+  };
+}
+
+function goalConstraintsFromRunSpec(spec: RunSpec): string[] {
+  return [
+    `RunSpec: ${spec.id}`,
+    `Profile: ${spec.profile}`,
+    `Workspace: ${spec.workspace?.path ?? "unresolved"}`,
+    `Progress: ${spec.progress_contract.semantics}`,
+    `Submit policy: ${spec.approval_policy.submit}`,
+    `Publish policy: ${spec.approval_policy.publish}`,
+    `External actions: ${spec.approval_policy.external_action}`,
+    `Secret policy: ${spec.approval_policy.secret}`,
+    `Irreversible actions: ${spec.approval_policy.irreversible_action}`,
+  ];
 }
 const standaloneIngressRouter = createIngressRouter();
 
@@ -863,6 +929,7 @@ export class ChatRunner {
     await store.save(result.spec);
 
     if (result.kind === "confirmed") {
+      const started = await this.startConfirmedRunSpec(result.spec);
       this.history?.setRunSpecConfirmation({
         ...pending,
         state: "confirmed",
@@ -870,15 +937,7 @@ export class ChatRunner {
         updatedAt: result.spec.updated_at,
       });
       await this.history?.persist();
-      return {
-        success: true,
-        output: [
-          result.message,
-          "",
-          "The RunSpec is confirmed. Daemon start is not wired in this step, so no background run has been started yet.",
-        ].join("\n"),
-        elapsed_ms: Date.now() - start,
-      };
+      return { ...started, elapsed_ms: Date.now() - start };
     }
 
     if (result.kind === "cancelled") {
@@ -930,6 +989,164 @@ export class ChatRunner {
       output: result.message,
       elapsed_ms: Date.now() - start,
     };
+  }
+
+  private async startConfirmedRunSpec(spec: RunSpec): Promise<ChatRunResult> {
+    const start = Date.now();
+    if (!this.deps.daemonClient) {
+      return {
+        success: false,
+        output: [
+          `RunSpec confirmed: ${spec.id}`,
+          "",
+          "Daemon start is unavailable in this chat surface, so no background run was started.",
+          "Start or connect the PulSeed daemon, then approve from a daemon-capable chat surface.",
+        ].join("\n"),
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    const goal = await this.createGoalFromRunSpec(spec);
+    const run = await this.createRunSpecBackgroundRun(spec, goal);
+    try {
+      await this.deps.daemonClient.startGoal(goal.id, {
+        backgroundRun: {
+          backgroundRunId: run.id,
+          parentSessionId: run.parent_session_id,
+          notifyPolicy: run.notify_policy,
+          replyTargetSource: run.reply_target_source,
+          pinnedReplyTarget: run.pinned_reply_target,
+        },
+      });
+      return {
+        success: true,
+        output: [
+          `RunSpec confirmed: ${spec.id}`,
+          `Started daemon-backed CoreLoop goal: ${goal.id}`,
+          `Background run: ${run.id}`,
+          "Run `pulseed status` or `/sessions` to check progress.",
+        ].join("\n"),
+        elapsed_ms: Date.now() - start,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await Promise.all(this.getBackgroundRunLedgers().map((ledger) => ledger.terminal(run.id, {
+        status: "failed",
+        completed_at: new Date().toISOString(),
+        error: message,
+      }).catch(() => undefined)));
+      return {
+        success: false,
+        output: [
+          `RunSpec confirmed: ${spec.id}`,
+          "",
+          `Daemon start failed, so no CoreLoop run was started: ${message}`,
+          "Start the daemon with `pulseed daemon start`, then approve the RunSpec again from a daemon-capable chat surface.",
+          `Background run record marked failed: ${run.id}`,
+        ].join("\n"),
+        elapsed_ms: Date.now() - start,
+      };
+    }
+  }
+
+  private async createGoalFromRunSpec(spec: RunSpec): Promise<Goal> {
+    if (spec.links.goal_id) {
+      const existing = await this.deps.stateManager.loadGoal(spec.links.goal_id);
+      if (existing) return existing;
+    }
+    const now = new Date().toISOString();
+    const goal = GoalSchema.parse({
+      id: `goal-runspec-${randomUUID()}`,
+      parent_id: null,
+      node_type: "goal",
+      title: spec.objective,
+      description: [
+        spec.objective,
+        "",
+        `Source RunSpec: ${spec.id}`,
+        `Original request: ${spec.source_text}`,
+      ].join("\n"),
+      status: "active",
+      dimensions: [goalDimensionFromRunSpec(spec, now)],
+      gap_aggregation: "max",
+      dimension_mapping: null,
+      constraints: goalConstraintsFromRunSpec(spec),
+      children_ids: [],
+      target_date: spec.deadline?.iso_at ?? null,
+      origin: "manual",
+      pace_snapshot: null,
+      deadline: spec.deadline?.iso_at ?? null,
+      confidence_flag: spec.confidence,
+      user_override: false,
+      feasibility_note: `Derived from natural-language RunSpec ${spec.id}`,
+      uncertainty_weight: 1,
+      created_at: now,
+      updated_at: now,
+    });
+    await this.deps.stateManager.saveGoal(goal);
+    const updatedSpec = {
+      ...spec,
+      links: {
+        ...spec.links,
+        goal_id: goal.id,
+      },
+      updated_at: now,
+    };
+    await createRunSpecStore(this.deps.stateManager).save(updatedSpec);
+    return goal;
+  }
+
+  private async createRunSpecBackgroundRun(spec: RunSpec, goal: Goal) {
+    const sessionId = this.history?.getSessionId() ?? spec.origin.session_id;
+    const pinnedReplyTarget = normalizePinnedReplyTargetForRunSpec(
+      this.runtimeControlContext?.replyTarget
+      ?? this.deps.runtimeReplyTarget
+      ?? (spec.origin.reply_target as RuntimeControlReplyTarget | null)
+      ?? null,
+    );
+    const input: BackgroundRunCreateInput = {
+      id: `run:coreloop:${randomUUID()}`,
+      kind: "coreloop_run",
+      goal_id: goal.id,
+      parent_session_id: sessionId ? `session:conversation:${sessionId}` : null,
+      notify_policy: pinnedReplyTarget ? "done_only" : "silent",
+      reply_target_source: pinnedReplyTarget ? "pinned_run" : "none",
+      pinned_reply_target: pinnedReplyTarget,
+      title: goal.title,
+      workspace: spec.workspace?.path ?? this.sessionCwd ?? null,
+      source_refs: [
+        ...(sessionId ? [{
+          kind: "chat_session" as const,
+          id: sessionId,
+          path: null,
+          relative_path: `chat/sessions/${sessionId}.json`,
+          updated_at: null,
+        }] : []),
+        {
+          kind: "artifact",
+          id: spec.id,
+          path: null,
+          relative_path: `run-specs/${spec.id}.json`,
+          updated_at: spec.updated_at,
+        },
+      ],
+      origin_metadata: {
+        run_spec_id: spec.id,
+        run_spec_origin: spec.origin,
+        source_text: spec.source_text,
+      },
+    };
+    const [primary, ...mirrors] = this.getBackgroundRunLedgers();
+    const run = await primary.create(input);
+    await Promise.all(mirrors.map((ledger) => ledger.create(input).catch(() => undefined)));
+    return run;
+  }
+
+  private getBackgroundRunLedgers(): BackgroundRunLedger[] {
+    const baseRuntimeRoot = `${this.deps.stateManager.getBaseDir()}/runtime`;
+    const configuredRuntimeRoot = resolveConfiguredDaemonRuntimeRoot(this.deps.stateManager.getBaseDir());
+    const roots = [...new Set([configuredRuntimeRoot, baseRuntimeRoot])];
+    return roots.map((root) => new BackgroundRunLedger(root));
   }
 
   private async handlePendingSetupConfirmation(

--- a/src/runtime/session-registry/registry.ts
+++ b/src/runtime/session-registry/registry.ts
@@ -5,6 +5,7 @@ import { ChatSessionCatalog } from "../../interface/chat/chat-session-store.js";
 import { normalizeAgentLoopSessionState } from "../../orchestrator/execution/agent-loop/agent-loop-session-state.js";
 import type { ProcessSessionManager, ProcessSessionSnapshot } from "../../tools/system/ProcessSessionTool/ProcessSessionTool.js";
 import { BackgroundRunLedger } from "../store/background-run-store.js";
+import { resolveConfiguredDaemonRuntimeRoot } from "../daemon/runtime-root.js";
 import {
   BackgroundRunSchema,
   RuntimeSessionRegistrySnapshotSchema,
@@ -66,6 +67,29 @@ function chatLifecycleToRuntimeStatus(status: string | null | undefined): Runtim
 
 const PROCESS_SESSION_DIR = path.join("runtime", "process-sessions");
 
+class CompositeBackgroundRunLedger {
+  constructor(private readonly ledgers: Array<Pick<BackgroundRunLedger, "list">>) {}
+
+  async list(): Promise<BackgroundRun[]> {
+    const byId = new Map<string, BackgroundRun>();
+    for (const ledger of this.ledgers) {
+      const runs = await ledger.list();
+      for (const run of runs) {
+        byId.set(run.id, mergeLedgerRunWithProjection(run, byId.get(run.id)));
+      }
+    }
+    return [...byId.values()];
+  }
+}
+
+function createDefaultBackgroundRunLedger(stateBaseDir: string): Pick<BackgroundRunLedger, "list"> {
+  const stateRuntimeRoot = path.join(stateBaseDir, "runtime");
+  const configuredRuntimeRoot = resolveConfiguredDaemonRuntimeRoot(stateBaseDir);
+  const roots = [...new Set([stateRuntimeRoot, configuredRuntimeRoot])];
+  if (roots.length === 1) return new BackgroundRunLedger(roots[0]);
+  return new CompositeBackgroundRunLedger(roots.map((root) => new BackgroundRunLedger(root)));
+}
+
 export class RuntimeSessionRegistry {
   private readonly stateManager: StateManager;
   private readonly stateBaseDir: string;
@@ -80,7 +104,7 @@ export class RuntimeSessionRegistry {
     this.stateBaseDir = deps.stateBaseDir ?? deps.stateManager.getBaseDir();
     this.chatCatalog = new ChatSessionCatalog(this.stateManager);
     this.processSessionManager = deps.processSessionManager;
-    this.backgroundRunLedger = deps.backgroundRunLedger ?? new BackgroundRunLedger(path.join(this.stateBaseDir, "runtime"));
+    this.backgroundRunLedger = deps.backgroundRunLedger ?? createDefaultBackgroundRunLedger(this.stateBaseDir);
     this.now = deps.now ?? (() => new Date());
     this.isPidAlive = deps.isPidAlive ?? defaultIsPidAlive;
   }

--- a/src/runtime/session-registry/types.ts
+++ b/src/runtime/session-registry/types.ts
@@ -119,6 +119,7 @@ export const BackgroundRunSchema = z.object({
   error: z.string().nullable(),
   artifacts: z.array(RuntimeArtifactRefSchema),
   source_refs: z.array(RuntimeSessionRefSchema),
+  origin_metadata: z.record(z.unknown()).optional(),
 });
 export type BackgroundRun = z.infer<typeof BackgroundRunSchema>;
 

--- a/src/runtime/store/background-run-store.ts
+++ b/src/runtime/store/background-run-store.ts
@@ -74,6 +74,7 @@ export interface BackgroundRunCreateInput {
   error?: string | null;
   artifacts?: RuntimeArtifactRef[];
   source_refs?: RuntimeSessionRef[];
+  origin_metadata?: Record<string, unknown>;
 }
 
 export interface BackgroundRunLinkInput {
@@ -150,6 +151,7 @@ export class BackgroundRunLedger {
       error: input.error ?? null,
       artifacts: input.artifacts ?? [],
       source_refs: input.source_refs ?? [],
+      ...(input.origin_metadata ? { origin_metadata: input.origin_metadata } : {}),
     });
   }
 

--- a/tmp/natural-language-longrun-handoff-status.md
+++ b/tmp/natural-language-longrun-handoff-status.md
@@ -35,3 +35,19 @@
   - `npm run test:unit -- src/interface/chat/__tests__/chat-session-store.test.ts src/interface/chat/__tests__/chat-history.test.ts`: pass.
   - `git diff --check`: pass.
 - Review: first review found `runSpecConfirmation` was persisted in raw chat history but dropped through `LoadedChatSession`/resume conversion. Fixed by threading the field through session load/save conversion and adding a reload-before-approval test. Re-review: no material findings.
+
+## #999
+
+- Branch: `codex/issue-999-start-confirmed-runs`.
+- Plan: after typed approval, derive/save a CoreLoop goal from the confirmed RunSpec, create a durable `run:coreloop:*` background run record, then call `DaemonClient.startGoal` with the background-run metadata.
+- Current status: implemented locally.
+- Verification:
+  - `npm run typecheck`: pass.
+  - `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"`: pass.
+  - `npm run test:unit -- src/interface/chat/__tests__/cross-platform-session.test.ts -t "RunSpec draft"`: pass.
+  - `npm run test:integration -- src/runtime/session-registry/__tests__/runtime-session-registry.test.ts`: pass.
+  - `npm run lint:boundaries`: pass with existing warnings.
+  - `git diff --check`: pass.
+  - `npm run test:unit -- src/runtime/session-registry/__tests__/runtime-session-registry.test.ts -t "background"`: not applicable in unit config because runtime tests are excluded.
+  - `npm run test:integration -- src/runtime/session-registry/__tests__/runtime-session-registry.test.ts -t "background"`: suite was skipped by filter/config.
+- Review: first review found configured daemon runtime ledger records could be invisible or stale in `/sessions`. Fixed by mirroring initial records and updating RuntimeSessionRegistry to read/merge both state-base and configured daemon runtime ledgers. Re-review: no material findings.


### PR DESCRIPTION
Closes #999

Parent: #986. This advances the daemon-backed start slice: confirmed natural-language RunSpecs now create a CoreLoop goal, create durable background-run metadata, and call daemon start only after approval.

## Summary
- Converts confirmed RunSpecs into saved CoreLoop goals.
- Creates durable `run:coreloop:*` background run records with parent chat session, workspace, reply target, RunSpec source refs, and origin metadata.
- Calls `DaemonClient.startGoal` only after typed approval; draft creation still never starts daemon work.
- Marks background runs failed and reports not-started guidance when daemon start fails.
- Extends runtime session registry projection to read and merge state-base and configured daemon runtime ledgers so `/sessions` can see configured daemon runs.

## Verification
- `npm run typecheck` PASS
- `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"` PASS
- `npm run test:unit -- src/interface/chat/__tests__/cross-platform-session.test.ts -t "RunSpec draft"` PASS
- `npm run test:integration -- src/runtime/session-registry/__tests__/runtime-session-registry.test.ts` PASS
- `npm run lint:boundaries` PASS with existing warnings
- `git diff --check` PASS

## Review
- Separate review agent found configured daemon runtime ledger records could be missing/stale in `/sessions`.
- Fixed by mirroring initial records and making RuntimeSessionRegistry merge state-base and configured daemon runtime ledgers.
- Re-review: no material findings.

## Known risks
- Safety/failure hardening beyond daemon start failure remains for #1000.
- Broader end-to-end production caller-path coverage remains for #1001.
