### PR TITLE
feat(longrun): gate unsafe RunSpec approvals

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -4561,6 +4561,105 @@ describe("ChatRunner", () => {
       }));
     });
 
+    it("blocks approved RunSpecs with unresolved required fields before daemon start", async () => {
+      const stateManager = new StateManager(fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-required-")), undefined, { walEnabled: false });
+      const daemonClient = { startGoal: vi.fn().mockResolvedValue({ ok: true }) };
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        daemonClient: daemonClient as never,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision({
+            metric: {
+              name: "kaggle_score",
+              direction: "unknown",
+              target: 0.98,
+              target_rank_percent: null,
+              datasource: "kaggle_leaderboard",
+              confidence: "medium",
+            },
+          }),
+          runSpecConfirmationDecision("approve"),
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
+      const result = await runner.execute("approve", "/repo/kaggle");
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Run cannot start until required fields are resolved");
+      expect(daemonClient.startGoal).not.toHaveBeenCalled();
+    });
+
+    it("blocks disallowed external or irreversible actions before daemon start", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-disallowed-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const daemonClient = { startGoal: vi.fn().mockResolvedValue({ ok: true }) };
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        daemonClient: daemonClient as never,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision({
+            approval_policy: {
+              submit: "disallowed",
+              publish: "unspecified",
+              secret: "approval_required",
+              external_action: "disallowed",
+              irreversible_action: "disallowed",
+            },
+          }),
+          runSpecConfirmationDecision("approve"),
+          runSpecConfirmationDecision("cancel"),
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      await runner.execute("本番に不可逆な変更を入れる長期実行を開始して", "/repo/app");
+      const result = await runner.execute("approve", "/repo/app");
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Blocked safety policy");
+      expect(result.output).toContain("disallowed external");
+      expect(daemonClient.startGoal).not.toHaveBeenCalled();
+      const [fileName] = fs.readdirSync(path.join(baseDir, "run-specs"));
+      const stored = JSON.parse(fs.readFileSync(path.join(baseDir, "run-specs", fileName), "utf8"));
+      expect(stored.status).toBe("draft");
+
+      const cancelResult = await runner.execute("cancel", "/repo/app");
+      expect(cancelResult.output).toContain("RunSpec cancelled:");
+      expect(daemonClient.startGoal).not.toHaveBeenCalled();
+    });
+
+    it("blocks low-confidence workspace before daemon start", async () => {
+      const stateManager = new StateManager(fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-workspace-")), undefined, { walEnabled: false });
+      const daemonClient = { startGoal: vi.fn().mockResolvedValue({ ok: true }) };
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        daemonClient: daemonClient as never,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision({
+            workspace: {
+              path: "/repo/maybe",
+              source: "context",
+              confidence: "low",
+            },
+          }),
+          runSpecConfirmationDecision("approve"),
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      await runner.execute("このワークスペースで長期実行して", "/repo/maybe");
+      const result = await runner.execute("approve", "/repo/maybe");
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("Workspace is missing or ambiguous");
+      expect(daemonClient.startGoal).not.toHaveBeenCalled();
+    });
+
     it("cancels a pending RunSpec without starting a background run", async () => {
       const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-cancel-"));
       const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -224,6 +224,44 @@ function goalConstraintsFromRunSpec(spec: RunSpec): string[] {
     `Irreversible actions: ${spec.approval_policy.irreversible_action}`,
   ];
 }
+
+function validateRunSpecStartSafety(spec: RunSpec): string | null {
+  const required = spec.missing_fields.filter((field) => field.severity === "required");
+  if (required.length > 0) {
+    return [
+      `RunSpec confirmed but not started: ${spec.id}`,
+      "Required RunSpec details are unresolved.",
+      ...required.map((field) => `- ${field.question}`),
+      "Reply with the missing workspace, deadline, metric, or approval details, then approve again.",
+    ].join("\n");
+  }
+
+  if (!spec.workspace?.path || spec.workspace.confidence === "low") {
+    return [
+      `RunSpec confirmed but not started: ${spec.id}`,
+      "Workspace is missing or ambiguous.",
+      "Reply with the exact local or remote workspace path before starting background CoreLoop work.",
+    ].join("\n");
+  }
+
+  const blockedPolicies = [
+    spec.approval_policy.submit === "disallowed" ? "submit" : null,
+    spec.approval_policy.publish === "disallowed" ? "publish" : null,
+    spec.approval_policy.external_action === "disallowed" ? "external action" : null,
+    spec.approval_policy.irreversible_action === "disallowed" ? "irreversible action" : null,
+    spec.approval_policy.secret === "disallowed" ? "secret transmission" : null,
+  ].filter((value): value is string => value !== null);
+  if (blockedPolicies.length > 0) {
+    return [
+      `RunSpec confirmed but not started: ${spec.id}`,
+      `Blocked safety policy: ${blockedPolicies.join(", ")}.`,
+      "PulSeed will not start a long-running handoff that requires a disallowed external, secret, production, destructive, or irreversible action.",
+      "Revise the RunSpec to remove the blocked action or mark it approval-required for a later explicit approval gate.",
+    ].join("\n");
+  }
+
+  return null;
+}
 const standaloneIngressRouter = createIngressRouter();
 
 function resolveSelfIdentityResponse(input: string, baseDir: string): string | null {
@@ -929,6 +967,26 @@ export class ChatRunner {
     await store.save(result.spec);
 
     if (result.kind === "confirmed") {
+      const safetyBlock = validateRunSpecStartSafety(result.spec);
+      if (safetyBlock) {
+        const pendingSpec: RunSpec = {
+          ...result.spec,
+          status: "draft",
+        };
+        await store.save(pendingSpec);
+        this.history?.setRunSpecConfirmation({
+          ...pending,
+          state: "pending",
+          spec: pendingSpec,
+          updatedAt: pendingSpec.updated_at,
+        });
+        await this.history?.persist();
+        return {
+          success: false,
+          output: safetyBlock,
+          elapsed_ms: Date.now() - start,
+        };
+      }
       const started = await this.startConfirmedRunSpec(result.spec);
       this.history?.setRunSpecConfirmation({
         ...pending,
@@ -993,6 +1051,14 @@ export class ChatRunner {
 
   private async startConfirmedRunSpec(spec: RunSpec): Promise<ChatRunResult> {
     const start = Date.now();
+    const safetyBlock = validateRunSpecStartSafety(spec);
+    if (safetyBlock) {
+      return {
+        success: false,
+        output: safetyBlock,
+        elapsed_ms: Date.now() - start,
+      };
+    }
     if (!this.deps.daemonClient) {
       return {
         success: false,

--- a/tmp/natural-language-longrun-handoff-status.md
+++ b/tmp/natural-language-longrun-handoff-status.md
@@ -51,3 +51,16 @@
   - `npm run test:unit -- src/runtime/session-registry/__tests__/runtime-session-registry.test.ts -t "background"`: not applicable in unit config because runtime tests are excluded.
   - `npm run test:integration -- src/runtime/session-registry/__tests__/runtime-session-registry.test.ts -t "background"`: suite was skipped by filter/config.
 - Review: first review found configured daemon runtime ledger records could be invisible or stale in `/sessions`. Fixed by mirroring initial records and updating RuntimeSessionRegistry to read/merge both state-base and configured daemon runtime ledgers. Re-review: no material findings.
+
+## #1000
+
+- Branch: `codex/issue-1000-runspec-safety`.
+- Plan: add a typed pre-start safety validation for confirmed RunSpecs so unresolved required fields, missing/ambiguous workspace, and disallowed external/secret/irreversible policies fail before daemon start or background-run creation.
+- Current status: implemented locally; review pending.
+- Verification:
+  - `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"`: pass after review fixes (12 pass, 118 skipped).
+  - `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "blocks approved RunSpecs"`: pass.
+  - `npm run typecheck`: pass.
+  - `npm run lint:boundaries`: pass with existing warnings only.
+  - `git diff --check`: pass.
+- Review: first review found safety-blocked approvals were persisted as confirmed and low-confidence workspaces were not treated as ambiguous. Fixed by keeping safety-blocked specs pending/draft and blocking low-confidence workspaces before daemon start.


### PR DESCRIPTION
Closes #1000

Parent #986 progress:
- Adds the safety/failure handling layer for natural-language RunSpec confirmation before daemon-backed CoreLoop handoff.

Implementation summary:
- Blocks confirmed RunSpecs before daemon start when required fields remain unresolved.
- Blocks missing or low-confidence workspace before daemon start.
- Blocks disallowed submit/publish/external/secret/irreversible policies before daemon start.
- Keeps safety-blocked RunSpecs pending/draft so the user can revise or cancel from the same chat surface.
- Preserves existing daemon unavailable/start failure behavior without reporting started state.

Verification commands:
- `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"`
- `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "blocks approved RunSpecs"`
- `npm run typecheck`
- `npm run lint:boundaries`
- `git diff --check`

Review:
- Fresh review agent found two material issues: safety-blocked approvals were persisted as confirmed, and low-confidence workspaces were not blocked.
- Both were fixed and re-reviewed with no material findings.

Known unresolved risks:
- Local `lint:boundaries` still reports existing repository warnings, but exits 0.
