### PR TITLE
test(longrun): cover natural-language daemon handoff paths

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -4715,6 +4715,65 @@ describe("ChatRunner", () => {
       expect(stored.status).toBe("cancelled");
     });
 
+    it("does not reuse a previous goal or background run for a new natural-language request", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-fresh-run-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const daemonClient = { startGoal: vi.fn().mockResolvedValue({ ok: true }) };
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        daemonClient: daemonClient as never,
+        llmClient: createMockLLMClient([
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision({
+            objective: "Continue Kaggle optimization until score exceeds 0.98",
+          }),
+          runSpecConfirmationDecision("approve"),
+          freeformRouteDecision("run_spec"),
+          runSpecDraftDecision({
+            objective: "Run a separate long-running benchmark until memory usage stays below target",
+            profile: "generic",
+            metric: {
+              name: "memory_usage",
+              direction: "minimize",
+              target: 512,
+              target_rank_percent: null,
+              datasource: "benchmark",
+              confidence: "high",
+            },
+            progress_contract: {
+              kind: "metric_target",
+              dimension: "memory_usage",
+              threshold: 512,
+              semantics: "Memory usage remains below target.",
+              confidence: "high",
+            },
+          }),
+          runSpecConfirmationDecision("approve"),
+        ]),
+        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
+      }));
+
+      await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
+      await runner.execute("approve", "/repo/kaggle");
+      await runner.execute("Keep running the benchmark in the background until memory is below 512 MB", "/repo/bench");
+      await runner.execute("approve", "/repo/bench");
+
+      expect(daemonClient.startGoal).toHaveBeenCalledTimes(2);
+      const firstGoalId = daemonClient.startGoal.mock.calls[0][0];
+      const secondGoalId = daemonClient.startGoal.mock.calls[1][0];
+      const firstRunId = daemonClient.startGoal.mock.calls[0][1].backgroundRun.backgroundRunId;
+      const secondRunId = daemonClient.startGoal.mock.calls[1][1].backgroundRun.backgroundRunId;
+      expect(secondGoalId).not.toBe(firstGoalId);
+      expect(secondRunId).not.toBe(firstRunId);
+
+      const registry = createRuntimeSessionRegistry({ stateManager });
+      const snapshot = await registry.snapshot();
+      expect(snapshot.background_runs).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: firstRunId, goal_id: firstGoalId, workspace: "/repo/kaggle" }),
+        expect.objectContaining({ id: secondRunId, goal_id: secondGoalId, workspace: "/repo/bench" }),
+      ]));
+    });
+
     it("preserves pending RunSpec confirmation across session reload before approval", async () => {
       const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-reload-"));
       const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -92,7 +92,13 @@ function runSpecDraftDecision(): string {
       semantics: "Kaggle score exceeds 0.98.",
       confidence: "high",
     },
-    deadline: null,
+    deadline: {
+      raw: "tomorrow morning",
+      iso_at: "2026-05-04T00:00:00.000Z",
+      timezone: "Asia/Tokyo",
+      finalization_buffer_minutes: 30,
+      confidence: "high",
+    },
     budget: { max_trials: null, max_wall_clock_minutes: null, resident_policy: "best_effort" },
     approval_policy: {
       submit: "approval_required",
@@ -102,6 +108,14 @@ function runSpecDraftDecision(): string {
       irreversible_action: "approval_required",
     },
     missing_fields: [],
+  });
+}
+
+function runSpecConfirmationDecision(decision: "approve" | "cancel" | "unknown" | "revise"): string {
+  return JSON.stringify({
+    decision,
+    confidence: 0.94,
+    rationale: "Typed RunSpec confirmation",
   });
 }
 
@@ -146,6 +160,100 @@ describe("CrossPlatformChatSessionManager", () => {
         message_id: "message-1",
         identity_key: "telegram:user-1",
       });
+    } finally {
+      cleanupTempDir(baseDir);
+    }
+  });
+
+  it("starts a gateway natural-language RunSpec after approval and retains reply target metadata", async () => {
+    const baseDir = makeTempDir();
+    try {
+      const stateManager = new RealStateManager(baseDir, undefined, { walEnabled: false });
+      const adapter = makeMockAdapter();
+      const chatAgentLoopRunner = { execute: vi.fn() };
+      const daemonClient = { startGoal: vi.fn().mockResolvedValue({ ok: true }) };
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager,
+        adapter,
+        chatAgentLoopRunner: chatAgentLoopRunner as never,
+        daemonClient: daemonClient as never,
+        llmClient: createMockLLMClient([
+          runSpecFreeformDecision(),
+          runSpecDraftDecision(),
+          JSON.stringify({ kind: "assist", confidence: 0.9, rationale: "Approval turn is handled by pending confirmation." }),
+          runSpecConfirmationDecision("approve"),
+        ]),
+      }));
+
+      const draft = await manager.execute("Kaggle score 0.98を超えるまで長期で回して", {
+        identity_key: "telegram:user-longrun",
+        platform: "telegram",
+        conversation_id: "telegram-chat-longrun",
+        user_id: "user-longrun",
+        message_id: "message-draft",
+        cwd: "/repo/kaggle",
+        metadata: { gateway_message: true, request_id: "gateway-req-1" },
+      });
+      const approved = await manager.execute("承認します", {
+        identity_key: "telegram:user-longrun",
+        platform: "telegram",
+        conversation_id: "telegram-chat-longrun",
+        user_id: "user-longrun",
+        message_id: "message-approve",
+        cwd: "/repo/kaggle",
+        metadata: { gateway_message: true, request_id: "gateway-req-2" },
+      });
+
+      expect(draft.success).toBe(true);
+      expect(draft.output).toContain("It has not started a daemon run.");
+      expect(approved.success).toBe(true);
+      expect(approved.output).toContain("Started daemon-backed CoreLoop goal:");
+      expect(daemonClient.startGoal).toHaveBeenCalledOnce();
+      expect(adapter.execute).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+
+      const [runFileName] = fs.readdirSync(`${baseDir}/runtime/background-runs`);
+      const run = JSON.parse(fs.readFileSync(`${baseDir}/runtime/background-runs/${runFileName}`, "utf8"));
+      expect(run).toMatchObject({
+        status: "queued",
+        workspace: "/repo/kaggle",
+        parent_session_id: expect.stringMatching(/^session:conversation:/),
+        reply_target_source: "pinned_run",
+        pinned_reply_target: {
+          channel: "gateway",
+          target_id: "telegram-chat-longrun",
+          thread_id: "message-draft",
+          metadata: {
+            conversation_id: "telegram-chat-longrun",
+            message_id: "message-draft",
+            identity_key: "telegram:user-longrun",
+            request_id: "gateway-req-1",
+          },
+        },
+        origin_metadata: {
+          run_spec_origin: {
+            channel: "plugin_gateway",
+            reply_target: {
+              conversation_id: "telegram-chat-longrun",
+              message_id: "message-draft",
+              identity_key: "telegram:user-longrun",
+            },
+          },
+        },
+      });
+      expect(daemonClient.startGoal).toHaveBeenCalledWith(
+        expect.stringMatching(/^goal-runspec-/),
+        expect.objectContaining({
+          backgroundRun: expect.objectContaining({
+            backgroundRunId: run.id,
+            parentSessionId: run.parent_session_id,
+            replyTargetSource: "pinned_run",
+            pinnedReplyTarget: expect.objectContaining({
+              target_id: "telegram-chat-longrun",
+            }),
+          }),
+        }),
+      );
     } finally {
       cleanupTempDir(baseDir);
     }

--- a/tmp/natural-language-longrun-handoff-status.md
+++ b/tmp/natural-language-longrun-handoff-status.md
@@ -63,4 +63,17 @@
   - `npm run typecheck`: pass.
   - `npm run lint:boundaries`: pass with existing warnings only.
   - `git diff --check`: pass.
+- Review: fresh review found no material issues; new tests exercise real ChatRunner/CrossPlatform flows with appropriate mocked LLM/daemon boundaries and no brittle semantic decision logic.
 - Review: first review found safety-blocked approvals were persisted as confirmed and low-confidence workspaces were not treated as ambiguous. Fixed by keeping safety-blocked specs pending/draft and blocking low-confidence workspaces before daemon start.
+
+## #1001
+
+- Branch: `codex/issue-1001-production-path-tests`.
+- Plan: strengthen production caller-path tests for natural-language RunSpec handoff by asserting ChatRunner routes natural language through draft -> confirmation -> approved daemon start, CrossPlatform/gateway reply target metadata survives into the background run after approval, stale approvals do not reuse cancelled specs, and non-run questions stay on ordinary chat.
+- Current status: implemented locally; review pending.
+- Verification:
+  - `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"`: pass (13 pass, 118 skipped).
+  - `npm run test:unit -- src/interface/chat/__tests__/cross-platform-session.test.ts -t "RunSpec"`: pass (2 pass, 22 skipped).
+  - `npm run typecheck`: pass.
+  - `npm run lint:boundaries`: pass with existing warnings only.
+  - `git diff --check`: pass.


### PR DESCRIPTION
Closes #1001

Parent #986 progress:
- Adds production caller-path coverage for the complete natural-language long-running handoff: request, confirmation, approval, daemon-backed CoreLoop start, and background-run metadata.

Implementation summary:
- Strengthens ChatRunner RunSpec tests to assert fresh goal/background-run IDs for a second natural-language request instead of reusing stale prior state.
- Adds a CrossPlatform/gateway test that starts a natural-language RunSpec only after approval and verifies the originating reply target/session metadata survives into the background run and daemon start payload.
- Keeps existing coverage for multilingual request/approval, explanatory non-run questions on ordinary chat, cancellation, ambiguous confirmation, safety gates, and reload.

Verification commands:
- `npm run test:unit -- src/interface/chat/__tests__/chat-runner.test.ts -t "natural-language RunSpec draft routing"`
- `npm run test:unit -- src/interface/chat/__tests__/cross-platform-session.test.ts -t "RunSpec"`
- `npm run typecheck`
- `npm run lint:boundaries`
- `git diff --check`

Review:
- Fresh review agent found no material issues.

Known unresolved risks:
- Local `lint:boundaries` still reports existing repository warnings, but exits 0.
