### PR TITLE
Reduce keyword-based semantic decisions

### DIFF
--- a/src/interface/tui/__tests__/actions.test.ts
+++ b/src/interface/tui/__tests__/actions.test.ts
@@ -169,6 +169,65 @@ describe("ActionHandler — handle()", () => {
       const result = await handler.handle(intent);
       expect(result.startLoop).toEqual({ goalId: "explicit-id" });
     });
+
+    it("rejects stale explicit goalId instead of reusing a previous target", async () => {
+      const deps = makeDeps();
+      vi.mocked(deps.stateManager.loadGoal).mockResolvedValue(makeGoal({ id: "done-id", status: "completed" }));
+
+      const handler = new ActionHandler(deps);
+      const result = await handler.handle({
+        intent: "loop_start",
+        params: { goalId: "done-id" },
+        raw: "run done-id",
+      });
+
+      expect(result.startLoop).toBeUndefined();
+      expect(result.messages.join("\n")).toContain("No runnable goal found");
+    });
+
+    it("does not select a goal by title substring", async () => {
+      const goals = [
+        makeGoal({ id: "goal-alpha", title: "Improve alpha routing", status: "active" }),
+        makeGoal({ id: "goal-beta", title: "Improve beta routing", status: "active" }),
+      ];
+      const deps = makeDeps();
+      vi.mocked(deps.stateManager.listGoalIds).mockResolvedValue(goals.map((goal) => goal.id));
+      vi.mocked(deps.stateManager.loadGoal).mockImplementation(async (id) => goals.find((goal) => goal.id === id) ?? null);
+
+      const handler = new ActionHandler(deps);
+      const result = await handler.handle({
+        intent: "loop_start",
+        params: { goalArg: "routing" },
+        raw: "/start routing",
+      });
+
+      expect(result.startLoop).toBeUndefined();
+      expect(result.messages.join("\n")).toContain('No goal matching "routing"');
+    });
+
+    it("selects by exact title or list number", async () => {
+      const goals = [
+        makeGoal({ id: "goal-alpha", title: "Improve alpha routing", status: "active" }),
+        makeGoal({ id: "goal-beta", title: "Improve beta routing", status: "active" }),
+      ];
+      const deps = makeDeps();
+      vi.mocked(deps.stateManager.listGoalIds).mockResolvedValue(goals.map((goal) => goal.id));
+      vi.mocked(deps.stateManager.loadGoal).mockImplementation(async (id) => goals.find((goal) => goal.id === id) ?? null);
+
+      const handler = new ActionHandler(deps);
+
+      await expect(handler.handle({
+        intent: "loop_start",
+        params: { goalArg: "Improve beta routing" },
+        raw: "/start Improve beta routing",
+      })).resolves.toMatchObject({ startLoop: { goalId: "goal-beta" } });
+
+      await expect(handler.handle({
+        intent: "loop_start",
+        params: { goalArg: "1" },
+        raw: "/start 1",
+      })).resolves.toMatchObject({ startLoop: { goalId: "goal-alpha" } });
+    });
   });
 
   describe("status intent", () => {

--- a/src/interface/tui/actions.ts
+++ b/src/interface/tui/actions.ts
@@ -69,6 +69,12 @@ export class ActionHandler {
 
     if (explicitGoalId) {
       const goal = await this.deps.stateManager.loadGoal(explicitGoalId);
+      if (!goal || (goal.status !== "active" && goal.status !== "waiting")) {
+        return {
+          messages: [`No runnable goal found for ID "${explicitGoalId}".`],
+          messageType: "warning",
+        };
+      }
       const label = goal?.title ?? explicitGoalId;
       return { messages: [`Starting loop: ${label}`], startLoop: { goalId: explicitGoalId } };
     }
@@ -92,7 +98,7 @@ export class ActionHandler {
       };
     }
 
-    // If a goal argument was provided, match by number (1-indexed) or title substring
+    // If a goal argument was provided, match by number (1-indexed), exact ID, or exact title.
     if (goalArg) {
       const num = parseInt(goalArg, 10);
       let matched: { id: string; title: string } | undefined;
@@ -100,17 +106,32 @@ export class ActionHandler {
       if (!isNaN(num) && num >= 1 && num <= runnableGoals.length) {
         matched = runnableGoals[num - 1];
       } else {
-        const lower = goalArg.toLowerCase();
-        matched = runnableGoals.find((g) => g.title.toLowerCase().includes(lower));
+        const exactId = runnableGoals.find((g) => g.id === goalArg);
+        const exactTitleMatches = runnableGoals.filter((g) => g.title === goalArg);
+        if (exactId) {
+          matched = exactId;
+        } else if (exactTitleMatches.length === 1) {
+          matched = exactTitleMatches[0];
+        } else if (exactTitleMatches.length > 1) {
+          const list = exactTitleMatches.map((g, i) => `  ${i + 1}. ${g.title} (ID: ${g.id})`).join("\n");
+          return {
+            messages: [
+              `Ambiguous goal title "${goalArg}".`,
+              list,
+              "Use /start <goal-id> or /start <number>.",
+            ],
+            messageType: "warning",
+          };
+        }
       }
 
       if (!matched) {
-        const list = runnableGoals.map((g, i) => `  ${i + 1}. ${g.title}`).join("\n");
+        const list = runnableGoals.map((g, i) => `  ${i + 1}. ${g.title} (ID: ${g.id})`).join("\n");
         return {
           messages: [
             `No goal matching "${goalArg}". Available goals:`,
             list,
-            'Use /start <number> or /start <name>.',
+            "Use /start <number>, /start <goal-id>, or the exact title.",
           ],
           messageType: "warning",
         };
@@ -130,7 +151,7 @@ export class ActionHandler {
       messages: [
         "Multiple goals available. Specify which one to start:",
         list,
-        'Use /start <number> or /start <name>.',
+        "Use /start <number>, /start <goal-id>, or the exact title.",
       ],
     };
   }

--- a/src/orchestrator/execution/__tests__/task-lifecycle-generation.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-generation.test.ts
@@ -827,6 +827,14 @@ describe("TaskLifecycle", async () => {
           blast_radius: "low",
         },
         constraints: [],
+        risk_profile: {
+          external_action: {
+            required: false,
+            approval_required: false,
+            action_kind: "none",
+            rationale: "Test fixture task is local-only unless overridden.",
+          },
+        },
         plateau_until: null,
         estimated_duration: null,
         consecutive_failure_count: 0,
@@ -1000,9 +1008,17 @@ describe("TaskLifecycle", async () => {
       await trustManager.setOverride("normal", 50, "test");
 
       const task = makeTask({
-        work_description: "Submit the final Kaggle submission.csv to the external competition",
-        approach: "Upload submission.csv through the Kaggle submit workflow",
+        work_description: "Hand the final artifact to the competition scoring system",
+        approach: "Use the typed task risk profile to require operator approval before the handoff",
         reversibility: "reversible",
+        risk_profile: {
+          external_action: {
+            required: true,
+            approval_required: true,
+            action_kind: "submission",
+            rationale: "The task sends an artifact to an external competition system.",
+          },
+        },
       });
       const result = await lifecycle.checkIrreversibleApproval(task, 0.9);
 
@@ -1034,8 +1050,16 @@ describe("TaskLifecycle", async () => {
       await trustManager.setOverride("normal", 50, "test");
 
       const task = makeTask({
-        work_description: "Publish the final report to an external service",
+        work_description: "Make the final report visible outside the local workspace",
         reversibility: "reversible",
+        risk_profile: {
+          external_action: {
+            required: true,
+            approval_required: true,
+            action_kind: "publication",
+            rationale: "The task exposes a report outside the local workspace.",
+          },
+        },
       });
       const result = await lifecycle.checkIrreversibleApproval(task, 0.9);
 
@@ -1046,6 +1070,58 @@ describe("TaskLifecycle", async () => {
         status: "approved",
         triggers: ["external_action"],
       });
+    });
+
+    it("does not infer external approval from freeform task keywords without a typed risk profile", async () => {
+      let approvalCalled = false;
+      const llm = createMockLLMClient([]);
+      const lifecycle = createLifecycle(llm, {
+        approvalFn: async () => {
+          approvalCalled = true;
+          return true;
+        },
+      });
+      await trustManager.setOverride("normal", 50, "test");
+
+      const task = makeTask({
+        work_description: "Publish a local-only fixture named production-notify-sample.json",
+        approach: "Create a local test fixture; no external system is contacted.",
+        reversibility: "reversible",
+      });
+      const result = await lifecycle.checkIrreversibleApproval(task, 0.9);
+
+      expect(result).toBe(true);
+      expect(approvalCalled).toBe(false);
+    });
+
+    it("requires approval when the typed external action profile is missing or unknown", async () => {
+      let approvalCalls = 0;
+      const llm = createMockLLMClient([]);
+      const lifecycle = createLifecycle(llm, {
+        approvalFn: async () => {
+          approvalCalls += 1;
+          return false;
+        },
+      });
+      await trustManager.setOverride("normal", 50, "test");
+
+      const missingProfileTask = makeTask({ reversibility: "reversible" });
+      delete missingProfileTask.risk_profile;
+      await expect(lifecycle.checkIrreversibleApproval(missingProfileTask, 0.9)).resolves.toBe(false);
+
+      await expect(lifecycle.checkIrreversibleApproval(makeTask({
+        reversibility: "reversible",
+        risk_profile: {
+          external_action: {
+            required: false,
+            approval_required: false,
+            action_kind: "unknown",
+            rationale: "Classifier could not determine side effects.",
+          },
+        },
+      }), 0.9)).resolves.toBe(false);
+
+      expect(approvalCalls).toBe(2);
     });
 
     it("uses default confidence of 0.5 when not provided", async () => {

--- a/src/orchestrator/execution/task/task-generation.ts
+++ b/src/orchestrator/execution/task/task-generation.ts
@@ -39,6 +39,14 @@ export const LLMGeneratedTaskSchema = z.object({
     blast_radius: z.string(),
   }),
   constraints: z.array(z.string()),
+  risk_profile: z.object({
+    external_action: z.object({
+      required: z.boolean().default(true),
+      approval_required: z.boolean().default(true),
+      action_kind: z.enum(["none", "submission", "publication", "notification", "deployment", "external_mutation", "unknown"]).default("unknown"),
+      rationale: z.string().nullable().default(null),
+    }).default({}),
+  }).default({}),
   reversibility: z.enum(["reversible", "irreversible", "unknown"]).default("reversible"),
   intended_direction: z.enum(["increase", "decrease", "neutral"]).optional(),
   estimated_duration: z
@@ -462,6 +470,7 @@ export async function generateTask(
     success_criteria: generated.success_criteria,
     scope_boundary: generated.scope_boundary,
     constraints: generated.constraints,
+    risk_profile: generated.risk_profile,
     reversibility: generated.reversibility,
     intended_direction: generated.intended_direction,
     estimated_duration: generated.estimated_duration,
@@ -504,6 +513,14 @@ const LLMTaskGroupSchema = z.object({
         blast_radius: z.string(),
       }),
       constraints: z.array(z.string()).default([]),
+      risk_profile: z.object({
+        external_action: z.object({
+          required: z.boolean().default(true),
+          approval_required: z.boolean().default(true),
+          action_kind: z.enum(["none", "submission", "publication", "notification", "deployment", "external_mutation", "unknown"]).default("unknown"),
+          rationale: z.string().nullable().default(null),
+        }).default({}),
+      }).default({}),
       reversibility: z.enum(["reversible", "irreversible", "unknown"]).default("reversible"),
     })
   ).min(2),
@@ -551,13 +568,14 @@ export async function generateTaskGroup(
     ``,
     `Respond with a JSON object inside a markdown code block with this structure:`,
     `{`,
-    `  "subtasks": [ { "work_description", "rationale", "approach", "target_dimension", "success_criteria", "scope_boundary", "constraints", "reversibility" }, ... ],`,
+    `  "subtasks": [ { "work_description", "rationale", "approach", "target_dimension", "success_criteria", "scope_boundary", "constraints", "risk_profile", "reversibility" }, ... ],`,
     `  "dependencies": [ { "from": "<subtask index>", "to": "<subtask index>" }, ... ],`,
     `  "file_ownership": { "<subtask index>": ["file1", "file2"], ... },`,
     `  "shared_context": "<optional shared context for all subtasks>"`,
     `}`,
     ``,
-    `Use subtask array index (as string) for dependency/ownership keys. Ensure at least 2 subtasks.`
+    `Use subtask array index (as string) for dependency/ownership keys. Ensure at least 2 subtasks.`,
+    `Set risk_profile.external_action from each subtask's intended side effects. Use action_kind "none" only when the subtask stays local; use "unknown" with approval_required true when uncertain.`
   );
 
   const prompt = promptParts.join("\n");
@@ -625,6 +643,7 @@ export async function generateTaskGroup(
       success_criteria: sub.success_criteria,
       scope_boundary: sub.scope_boundary,
       constraints: sub.constraints,
+      risk_profile: sub.risk_profile,
       reversibility: sub.reversibility,
       estimated_duration: null,
       status: "pending",

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -782,17 +782,12 @@ export class TaskLifecycle {
 }
 
 function isExternalActionTask(task: Task): boolean {
-  const haystack = [
-    task.work_description,
-    task.approach,
-    task.rationale,
-    ...task.constraints,
-    ...task.success_criteria.map((criterion) => `${criterion.description} ${criterion.verification_method}`),
-    task.scope_boundary.blast_radius,
-    ...task.scope_boundary.in_scope,
-    ...task.scope_boundary.out_of_scope,
-  ].join("\n").toLowerCase();
-  return /\b(submit|submission|publish|deploy|release|upload|send|email|notify|external|production)\b/.test(haystack);
+  const externalAction = task.risk_profile?.external_action;
+  if (!externalAction) return true;
+  if (externalAction.action_kind === "unknown") return true;
+  return externalAction.action_kind !== "none"
+    || externalAction.required === true
+    || externalAction.approval_required === true;
 }
 
 function taskApprovalHandoffId(task: Task): string {

--- a/src/orchestrator/execution/task/task-prompt-builder.ts
+++ b/src/orchestrator/execution/task/task-prompt-builder.ts
@@ -350,6 +350,7 @@ Requirements:
 - work_description: target file path(s), specific changes (not "improve X" → "add section Y to file Z")
 - No vague review/triage tasks
 - Prefer minimal-change approach: make the smallest targeted change that moves the metric; avoid unrelated refactoring
+- Set risk_profile.external_action from the task's intended side effects, not from keywords. Mark approval_required true whenever the task requires submitting, publishing, notifying, deploying, uploading, sending, or mutating an external system outside the local workspace.
 
 Return JSON only (inside markdown code block):
 {
@@ -361,6 +362,14 @@ Return JSON only (inside markdown code block):
   ],
   "scope_boundary": {"in_scope": ["included"], "out_of_scope": ["excluded"], "blast_radius": "what could be affected"},
   "constraints": ["any constraints"],
+  "risk_profile": {
+    "external_action": {
+      "required": false,
+      "approval_required": false,
+      "action_kind": "none|submission|publication|notification|deployment|external_mutation|unknown",
+      "rationale": "why this is or is not an external action" | null
+    }
+  },
   "reversibility": "reversible|irreversible|unknown",
   "intended_direction": "increase|decrease|neutral — direction this task intends to move the primary dimension",
   "estimated_duration": {"value": number, "unit": "minutes|hours|days|weeks"} | null

--- a/src/orchestrator/execution/types/task.ts
+++ b/src/orchestrator/execution/types/task.ts
@@ -25,6 +25,19 @@ export const ScopeBoundarySchema = z.object({
 });
 export type ScopeBoundary = z.infer<typeof ScopeBoundarySchema>;
 
+export const TaskExternalActionSchema = z.object({
+  required: z.boolean().default(false),
+  approval_required: z.boolean().default(false),
+  action_kind: z.enum(["none", "submission", "publication", "notification", "deployment", "external_mutation", "unknown"]).default("none"),
+  rationale: z.string().nullable().default(null),
+});
+export type TaskExternalAction = z.infer<typeof TaskExternalActionSchema>;
+
+export const TaskRiskProfileSchema = z.object({
+  external_action: TaskExternalActionSchema.default({}),
+});
+export type TaskRiskProfile = z.infer<typeof TaskRiskProfileSchema>;
+
 export const VerificationFileDiffSchema = z.object({
   path: z.string(),
   patch: z.string(),
@@ -48,6 +61,7 @@ export const TaskSchema = z.object({
   success_criteria: z.array(CriterionSchema),
   scope_boundary: ScopeBoundarySchema,
   constraints: z.array(z.string()),
+  risk_profile: TaskRiskProfileSchema.optional(),
 
   plateau_until: z.string().nullable().default(null),
   estimated_duration: DurationSchema.nullable().default(null),

--- a/src/platform/code-search/__tests__/code-search.test.ts
+++ b/src/platform/code-search/__tests__/code-search.test.ts
@@ -6,6 +6,7 @@ import { SearchOrchestrator } from "../orchestrator.js";
 import { ProgressiveReader } from "../progressive-reader.js";
 import { buildFileIndex } from "../indexes/file-index.js";
 import { getCodeSearchIndexes } from "../indexes/index-store.js";
+import { planCodeSearchTask } from "../query-planner.js";
 import { parseVerificationSignal } from "../verification-retrieval.js";
 
 describe("code search platform", () => {
@@ -80,6 +81,16 @@ describe("code search platform", () => {
 
     expect(candidates.length).toBeGreaterThan(0);
     expect(candidates.some((candidate) => candidate.reasons.some((reason) => reason.includes("verification:")))).toBe(true);
+  });
+
+  it("does not classify freeform task intent from keywords without caller intent", () => {
+    const planned = planCodeSearchTask({
+      task: "調査してセキュリティっぽい設定名の説明コメントを追加する",
+      cwd: root,
+    });
+
+    expect(planned.intent).toBe("unknown");
+    expect(planned.task).toContain("セキュリティっぽい");
   });
 
   it("excludes hidden worktree directories before applying the file cap", async () => {

--- a/src/platform/code-search/query-planner.ts
+++ b/src/platform/code-search/query-planner.ts
@@ -19,15 +19,7 @@ const STACK_FRAME_RE = /(?:at\s+(?<symbol>[^\s(]+)\s+\()?((?<file>(?:\/|\.{1,2}\
 
 function inferIntent(task: string, explicit?: Intent): Intent {
   if (explicit) return explicit;
-  const lower = task.toLowerCase();
-  if (/security|ssrf|xss|attack|攻撃|セキュリティ/.test(lower)) return "security_review";
-  if (/test|spec|assert|failure|failing|失敗/.test(lower)) return "test_failure";
-  if (/refactor|cleanup|整理|債務/.test(lower)) return "refactor";
-  if (/config|tsconfig|eslint|package|設定/.test(lower)) return "config_fix";
-  if (/explain|どう|なぜ|説明/.test(lower)) return "explain";
-  if (/api|schema|route|contract/.test(lower)) return "api_change";
-  if (/bug|fix|error|例外|壊/.test(lower)) return "bugfix";
-  if (/add|implement|feature|実装|追加/.test(lower)) return "feature_addition";
+  void task;
   return "unknown";
 }
 


### PR DESCRIPTION
## Summary
- stop inferring code-search intent from freeform task keywords when caller intent is absent
- add typed task risk_profile.external_action and gate external approvals from that contract with fail-closed unknown/missing behavior
- remove TUI goal title substring selection for /start in favor of number, exact goal ID, or exact title

## Verification
- npm run typecheck
- npx vitest run --config vitest.unit.config.ts src/platform/code-search/__tests__/code-search.test.ts src/orchestrator/execution/__tests__/task-lifecycle-generation.test.ts src/interface/tui/__tests__/actions.test.ts
- npx vitest run src/interface/tui/__tests__/actions.test.ts

## Notes
- deterministic protocol parsing remains for paths, stacktraces, slash command arguments, IDs, and exact session/run prefixes per AGENTS.md exceptions
- .pulseed-sandbox/ was pre-existing untracked workspace state and is not included