### PR TITLE
[codex] Fix restart completion reporting

### DIFF
--- a/src/runtime/__tests__/runtime-control-result-routing.test.ts
+++ b/src/runtime/__tests__/runtime-control-result-routing.test.ts
@@ -150,4 +150,40 @@ describe("runtime-control restart result routing", () => {
       cleanupTempDir(tmpDir);
     }
   });
+
+  it("verifies legacy restart operations that were left running before startup", async () => {
+    const tmpDir = makeTempDir("pulseed-runtime-control-result-running-");
+    try {
+      const runtimeRoot = path.join(tmpDir, "runtime");
+      const operationStore = new RuntimeOperationStore(runtimeRoot);
+      await operationStore.save(makeRestartingOperation({
+        operation_id: "op-running-restart",
+        state: "running",
+        result: {
+          ok: true,
+          message: "PulSeed daemon の再起動要求を送信しました。watchdog による復帰を確認します。",
+        },
+      }));
+
+      await reconcileRuntimeControlOperationsAfterStartup(
+        runtimeRoot,
+        { status: "idle" },
+        { info: vi.fn() },
+      );
+
+      expect(await operationStore.listPending()).toHaveLength(0);
+      const completed = await operationStore.listCompleted();
+      expect(completed).toHaveLength(1);
+      expect(completed[0]).toMatchObject({
+        operation_id: "op-running-restart",
+        state: "verified",
+        result: {
+          ok: true,
+          message: "PulSeed daemon の再起動を確認しました。",
+        },
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
 });

--- a/src/runtime/control/__tests__/daemon-runtime-control-executor.test.ts
+++ b/src/runtime/control/__tests__/daemon-runtime-control-executor.test.ts
@@ -58,7 +58,7 @@ describe("createDaemonRuntimeControlExecutor", () => {
       cwd: "/repo",
     })).resolves.toMatchObject({
       ok: true,
-      state: "running",
+      state: "restarting",
     });
 
     expect(DaemonClient).toHaveBeenCalledWith({

--- a/src/runtime/control/daemon-runtime-control-executor.ts
+++ b/src/runtime/control/daemon-runtime-control-executor.ts
@@ -93,7 +93,7 @@ export function createDaemonRuntimeControlExecutor(
 
     return {
       ok: true,
-      state: "running",
+      state: "restarting",
       message:
         operation.kind === "restart_gateway"
           ? "gateway の再起動要求を daemon に送信しました。daemon 全体の再起動として復帰を確認します。"

--- a/src/runtime/daemon/runner-startup.ts
+++ b/src/runtime/daemon/runner-startup.ts
@@ -366,7 +366,7 @@ export async function reconcileRuntimeControlOperationsAfterStartup(
   const now = new Date().toISOString();
   for (const operation of pending) {
     if (
-      operation.state !== "restarting" ||
+      (operation.state !== "restarting" && operation.state !== "running") ||
       (operation.kind !== "restart_daemon" && operation.kind !== "restart_gateway")
     ) {
       continue;


### PR DESCRIPTION
## Summary
- Preserve daemon restart operations in `restarting` state so startup reconciliation can mark them verified.
- Recover legacy pending restart operations that were left in `running` state before this fix.
- Cover both the executor state and startup reconciliation path with focused runtime tests.

## Root Cause
The daemon runtime-control executor returned `running` after submitting a restart request. Startup reconciliation only verified pending restart operations in `restarting`, so the operation stayed pending and no completion chat response was emitted.

## Validation
- `npx vitest run --config vitest.integration.config.ts src/runtime/control/__tests__/daemon-runtime-control-executor.test.ts src/runtime/__tests__/runtime-control-result-routing.test.ts`
- `npm run typecheck`
- `git diff --check`
