### PR TITLE
Add DurableLoop compatibility aliases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,8 +85,8 @@ export {
 } from "./platform/knowledge/index.js";
 export { CapabilityDetector } from "./platform/observation/capability-detector.js";
 export { PortfolioManager } from "./orchestrator/strategy/portfolio-manager.js";
-export { CoreLoop } from "./orchestrator/loop/core-loop.js";
-export type { CoreLoopDeps, LoopConfig, LoopResult } from "./orchestrator/loop/core-loop.js";
+export { DurableLoop, CoreLoop } from "./orchestrator/loop/core-loop.js";
+export type { DurableLoopDeps, CoreLoopDeps, LoopConfig, LoopResult } from "./orchestrator/loop/core-loop.js";
 export { RuntimeSessionRegistry, createRuntimeSessionRegistry } from "./runtime/session-registry/index.js";
 export { deriveRunSpecFromText, understandRunSpecDraft, createRunSpecStore } from "./runtime/run-spec/index.js";
 export {

--- a/src/orchestrator/execution/agent-loop/core-loop-control-tools.ts
+++ b/src/orchestrator/execution/agent-loop/core-loop-control-tools.ts
@@ -5,7 +5,7 @@ import type { Goal } from "../../../base/types/goal.js";
 import { DaemonClient, isDaemonRunning, type DaemonStartGoalOptions } from "../../../runtime/daemon/client.js";
 import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../../tools/types.js";
 
-export interface CoreLoopControlToolset {
+export interface DurableLoopControlToolset {
   goalStatus(input: { goalId: string }): Promise<unknown>;
   goalCreate?(input: { description: string }): Promise<unknown>;
   tendGoal?(input: { description: string; parentSessionId?: string; notifyPolicy?: "silent" | "done_only" | "state_changes" }): Promise<unknown>;
@@ -17,6 +17,9 @@ export interface CoreLoopControlToolset {
   taskPrioritize?(input: { goalId: string; taskId: string; priority: number }): Promise<unknown>;
   runCycle?(input: { goalId: string; maxIterations?: number }): Promise<unknown>;
 }
+
+/** @deprecated Use DurableLoopControlToolset. */
+export type CoreLoopControlToolset = DurableLoopControlToolset;
 
 const schemas = {
   core_goal_status: z.object({ goalId: z.string().min(1) }),
@@ -42,7 +45,7 @@ const schemas = {
 
 type CoreToolName = keyof typeof schemas;
 
-export function createCoreLoopControlTools(service: CoreLoopControlToolset): ITool[] {
+export function createDurableLoopControlTools(service: DurableLoopControlToolset): ITool[] {
   const tools: ITool[] = [
     new CoreLoopControlTool("core_goal_status", "Read CoreLoop goal status.", "read_only", (input) => service.goalStatus(input), schemas.core_goal_status),
   ];
@@ -57,6 +60,9 @@ export function createCoreLoopControlTools(service: CoreLoopControlToolset): ITo
   if (service.runCycle) tools.push(new CoreLoopControlTool("core_run_cycle", "Run one bounded CoreLoop cycle.", "write_local", (input) => service.runCycle!(input), schemas.core_run_cycle));
   return tools;
 }
+
+/** @deprecated Use createDurableLoopControlTools. */
+export const createCoreLoopControlTools = createDurableLoopControlTools;
 
 class CoreLoopControlTool<TInput> implements ITool<TInput> {
   readonly metadata: ToolMetadata;
@@ -119,15 +125,18 @@ class CoreLoopControlTool<TInput> implements ITool<TInput> {
   }
 }
 
-export interface DaemonBackedCoreLoopControlDeps {
+export interface DaemonBackedDurableLoopControlDeps {
   stateManager: StateManager;
   host?: string;
   daemonClientFactory?: () => Promise<Pick<DaemonClient, "startGoal" | "stopGoal" | "pauseGoal" | "resumeGoal" | "getSnapshot">>;
 }
 
-export function createDaemonBackedCoreLoopControlToolset(
-  deps: DaemonBackedCoreLoopControlDeps,
-): CoreLoopControlToolset {
+/** @deprecated Use DaemonBackedDurableLoopControlDeps. */
+export type DaemonBackedCoreLoopControlDeps = DaemonBackedDurableLoopControlDeps;
+
+export function createDaemonBackedDurableLoopControlToolset(
+  deps: DaemonBackedDurableLoopControlDeps,
+): DurableLoopControlToolset {
   const createGoal = async (description: string): Promise<{ goalId: string; goal: Goal }> => {
     const normalizedDescription = description.trim();
     if (!normalizedDescription) {
@@ -266,3 +275,6 @@ export function createDaemonBackedCoreLoopControlToolset(
     },
   };
 }
+
+/** @deprecated Use createDaemonBackedDurableLoopControlToolset. */
+export const createDaemonBackedCoreLoopControlToolset = createDaemonBackedDurableLoopControlToolset;

--- a/src/orchestrator/loop/__tests__/durable-loop-aliases.test.ts
+++ b/src/orchestrator/loop/__tests__/durable-loop-aliases.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CoreLoop,
+  DurableLoop,
+  type CoreLoopDeps,
+  type DurableLoopDeps,
+} from "../core-loop.js";
+import {
+  createCoreLoopControlTools,
+  createDaemonBackedCoreLoopControlToolset,
+  createDaemonBackedDurableLoopControlToolset,
+  createDurableLoopControlTools,
+  type CoreLoopControlToolset,
+  type DurableLoopControlToolset,
+} from "../../execution/agent-loop/core-loop-control-tools.js";
+
+function makeDeps(): DurableLoopDeps {
+  return {
+    stateManager: {
+      loadGoal: vi.fn(),
+      saveGoal: vi.fn(),
+      archiveGoal: vi.fn(),
+      restoreFromCheckpoint: vi.fn(async () => 0),
+    },
+    stallDetector: {
+      resetEscalation: vi.fn(),
+    },
+    strategyManager: {
+      setStrategyTemplateRegistry: vi.fn(),
+    },
+  } as unknown as DurableLoopDeps;
+}
+
+describe("DurableLoop compatibility aliases", () => {
+  it("exports DurableLoop as the same constructor as the legacy CoreLoop name", () => {
+    const durableLoopDeps: DurableLoopDeps = makeDeps();
+    const legacyDeps: CoreLoopDeps = durableLoopDeps;
+
+    const durableLoop = new DurableLoop(durableLoopDeps, { dryRun: true });
+    const legacyLoop = new CoreLoop(legacyDeps, { dryRun: true });
+
+    expect(DurableLoop).toBe(CoreLoop);
+    expect(durableLoop).toBeInstanceOf(CoreLoop);
+    expect(legacyLoop).toBeInstanceOf(DurableLoop);
+  });
+
+  it("keeps DurableLoop and legacy CoreLoop control factories behaviorally identical", () => {
+    const service: DurableLoopControlToolset = {
+      goalStatus: async (input) => ({ goalId: input.goalId, loopStatus: "idle" }),
+      goalStart: async (input) => ({ goalId: input.goalId, started: true }),
+    };
+    const legacyService: CoreLoopControlToolset = service;
+
+    const durableTools = createDurableLoopControlTools(service);
+    const legacyTools = createCoreLoopControlTools(legacyService);
+
+    expect(createCoreLoopControlTools).toBe(createDurableLoopControlTools);
+    expect(durableTools.map((tool) => tool.metadata.name)).toEqual(
+      legacyTools.map((tool) => tool.metadata.name),
+    );
+    expect(durableTools.map((tool) => tool.description())).toEqual(
+      legacyTools.map((tool) => tool.description()),
+    );
+  });
+
+  it("keeps daemon-backed DurableLoop and legacy CoreLoop toolset factories behaviorally identical", () => {
+    const deps = {
+      stateManager: {
+        getBaseDir: () => "/tmp/pulseed-test",
+        loadGoal: async (goalId: string) => ({
+          id: goalId,
+          title: "Goal",
+          status: "active",
+          loop_status: "idle",
+          dimensions: [],
+          updated_at: "now",
+        }),
+        saveGoal: vi.fn(),
+        listTasks: async () => [],
+        loadTask: async () => null,
+      },
+      daemonClientFactory: async () => ({
+        startGoal: async () => ({ ok: true }),
+        stopGoal: async () => ({ ok: true }),
+        pauseGoal: async () => ({ ok: true }),
+        resumeGoal: async () => ({ ok: true }),
+        getSnapshot: async () => ({ active_workers: [] }),
+      }),
+    };
+
+    const durableTools = createDurableLoopControlTools(
+      createDaemonBackedDurableLoopControlToolset(deps as never),
+    );
+    const legacyTools = createCoreLoopControlTools(
+      createDaemonBackedCoreLoopControlToolset(deps as never),
+    );
+
+    expect(createDaemonBackedCoreLoopControlToolset).toBe(createDaemonBackedDurableLoopControlToolset);
+    expect(durableTools.map((tool) => tool.metadata.name)).toEqual(
+      legacyTools.map((tool) => tool.metadata.name),
+    );
+  });
+});

--- a/src/orchestrator/loop/core-loop.ts
+++ b/src/orchestrator/loop/core-loop.ts
@@ -36,7 +36,7 @@ import type {
   RuntimeOperatorHandoffTrigger,
 } from "../../runtime/store/operator-handoff-store.js";
 
-// Re-export types for backward compatibility
+// Re-export types for compatibility while DurableLoop naming is introduced.
 export type {
   GapCalculatorModule,
   DriveScorerModule,
@@ -49,6 +49,9 @@ export type {
   ProgressEvent,
   ProgressPhase,
   LoopRunPolicyMode,
+} from "./core-loop/contracts.js";
+export type {
+  CoreLoopDeps as DurableLoopDeps,
 } from "./core-loop/contracts.js";
 export type {
   LoopIterationResult,
@@ -75,10 +78,14 @@ const DEFAULT_CONFIG: Required<Omit<LoopConfig, "iterationBudget" | "runtimeBudg
   consolidationRawThreshold: 20,
 };
 
-// ─── CoreLoop ───
+// ─── DurableLoop ───
 
 /**
- * CoreLoop is the heart of PulSeed — it orchestrates one full iteration of the
+ * DurableLoop is the daemon-backed resilient long-running execution loop. The
+ * legacy CoreLoop export remains available as a compatibility name during the
+ * migration.
+ *
+ * CoreLoop orchestrates one full iteration of the
  * task discovery loop: observe → gap → score → completion check → stall check → task → report.
  *
  * It runs multiple iterations until the goal is complete (SatisficingJudge),
@@ -125,7 +132,6 @@ export class CoreLoop {
       deps.strategyManager.setStrategyTemplateRegistry(deps.strategyTemplateRegistry);
     }
   }
-
   // ─── Public API ───
 
   /**
@@ -754,3 +760,5 @@ export class CoreLoop {
 function uniqueTriggers(triggers: RuntimeOperatorHandoffTrigger[]): RuntimeOperatorHandoffTrigger[] {
   return [...new Set(triggers)];
 }
+
+export { CoreLoop as DurableLoop };

--- a/tmp/durable-loop-migration-status.md
+++ b/tmp/durable-loop-migration-status.md
@@ -17,3 +17,13 @@
 - Plan: add a short naming contract note only. Do not perform implementation renames in this issue.
 - Review: separate review agent found one material issue: `tmp/` is gitignored, so the files must be committed with `git add -f`. The note content otherwise satisfies the acceptance criteria.
 - Verification: `npm run typecheck` passed. `npm run lint:boundaries` passed with existing warnings and no errors.
+
+## #1016 Introduce DurableLoop aliases while preserving CoreLoop callers
+
+- Status: in progress.
+- Branch: `codex/issue-1016-durable-loop-aliases`.
+- Issue body reviewed with `gh issue view 1016`.
+- Plan: add `DurableLoop` class/type aliases at the existing `core-loop` module, add DurableLoop-named agent-loop control tool factories, keep legacy `CoreLoop` names as deprecated compatibility exports, and add focused alias tests. No file moves or persisted ID changes in this issue.
+- Verification: `npm run typecheck` passed. `npx vitest run src/orchestrator/loop/__tests__/durable-loop-aliases.test.ts` passed. `npx vitest run src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts` passed. `npm run lint:boundaries` passed with existing warnings and no errors. `rg -n "DurableLoop" src/orchestrator/loop src/orchestrator/execution/agent-loop/core-loop-control-tools.ts` confirmed new names.
+- `npm run test:changed` failed because existing untracked `.pulseed-sandbox` local state was included and changed Telegram setup expectations in unrelated chat tests; focused tests for changed code passed.
+- Review: separate review agent found no material issues.


### PR DESCRIPTION
Closes #1016

## Summary

- Export `DurableLoop` as the new name for the existing `CoreLoop` constructor without moving files.
- Add `DurableLoopDeps` and root package exports while preserving `CoreLoop` compatibility exports.
- Add DurableLoop-named agent-loop control tool factories and daemon-backed toolset factories.
- Keep legacy CoreLoop factory/type exports as deprecated compatibility aliases.
- Add focused tests proving old and new names share the same behavior.

## Verification

- `npm run typecheck`
- `npx vitest run src/orchestrator/loop/__tests__/durable-loop-aliases.test.ts`
- `npx vitest run src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts`
- `npm run lint:boundaries` (passes with existing warnings, no errors)
- `rg -n "DurableLoop" src/orchestrator/loop src/orchestrator/execution/agent-loop/core-loop-control-tools.ts`

`npm run test:changed` was attempted but failed because existing untracked `.pulseed-sandbox` local state was included and changed unrelated Telegram setup expectations in chat tests. The focused tests for the changed code passed.

## Known unresolved risks

- None for the alias-only implementation slice.

## Remaining `CoreLoop|core-loop|coreloop`

- Existing module paths, tool names, persisted IDs, and compatibility exports remain intentionally unchanged.
- `CoreLoop` exports remain as deprecated compatibility aliases.
- `core_*` tool names and `run:coreloop:*`/`coreloop_run` persisted identifiers are unchanged by design for #1016.
