### PR TITLE
Update DurableLoop user-facing labels

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -2652,7 +2652,7 @@ describe("ChatRunner", () => {
                 notify_policy: "done_only",
                 reply_target_source: "none",
                 pinned_reply_target: null,
-                title: "CoreLoop goal goal-1",
+                title: "DurableLoop goal goal-1",
                 workspace: "/repo",
                 created_at: "2026-05-02T00:00:00.000Z",
                 started_at: "2026-05-02T00:00:00.000Z",
@@ -2778,7 +2778,7 @@ describe("ChatRunner", () => {
                 notify_policy: "done_only",
                 reply_target_source: "none",
                 pinned_reply_target: null,
-                title: "CoreLoop goal goal-1",
+                title: "DurableLoop goal goal-1",
                 workspace: "/repo",
                 created_at: "2026-05-02T00:00:00.000Z",
                 started_at: "2026-05-02T00:00:00.000Z",
@@ -4493,7 +4493,7 @@ describe("ChatRunner", () => {
 
       expect(approveResult.success).toBe(true);
       expect(approveResult.output).toContain("RunSpec confirmed:");
-      expect(approveResult.output).toContain("Started daemon-backed CoreLoop goal:");
+      expect(approveResult.output).toContain("Started daemon-backed DurableLoop goal:");
       expect(approveResult.output).toContain("Background run: run:coreloop:");
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(daemonClient.startGoal).toHaveBeenCalledOnce();
@@ -4550,7 +4550,7 @@ describe("ChatRunner", () => {
 
       expect(result.success).toBe(false);
       expect(result.output).toContain("Daemon start failed");
-      expect(result.output).toContain("no CoreLoop run was started");
+      expect(result.output).toContain("no DurableLoop run was started");
       expect(result.output).toContain("Connection refused");
       expect(daemonClient.startGoal).toHaveBeenCalledOnce();
       const registry = createRuntimeSessionRegistry({ stateManager });

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -207,7 +207,7 @@ describe("CrossPlatformChatSessionManager", () => {
       expect(draft.success).toBe(true);
       expect(draft.output).toContain("It has not started a daemon run.");
       expect(approved.success).toBe(true);
-      expect(approved.output).toContain("Started daemon-backed CoreLoop goal:");
+      expect(approved.output).toContain("Started daemon-backed DurableLoop goal:");
       expect(daemonClient.startGoal).toHaveBeenCalledOnce();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
@@ -1221,7 +1221,7 @@ describe("CrossPlatformChatSessionManager", () => {
     const chatAgentLoopRunner = {
       execute: vi.fn().mockResolvedValue({
         success: true,
-        output: "Agent loop can choose core_tend_goal when durable CoreLoop handoff is needed.",
+        output: "Agent loop can choose core_tend_goal when durable DurableLoop handoff is needed.",
         error: null,
         exit_code: null,
         elapsed_ms: 42,

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -240,7 +240,7 @@ function validateRunSpecStartSafety(spec: RunSpec): string | null {
     return [
       `RunSpec confirmed but not started: ${spec.id}`,
       "Workspace is missing or ambiguous.",
-      "Reply with the exact local or remote workspace path before starting background CoreLoop work.",
+      "Reply with the exact local or remote workspace path before starting background DurableLoop work.",
     ].join("\n");
   }
 
@@ -1088,7 +1088,7 @@ export class ChatRunner {
         success: true,
         output: [
           `RunSpec confirmed: ${spec.id}`,
-          `Started daemon-backed CoreLoop goal: ${goal.id}`,
+          `Started daemon-backed DurableLoop goal: ${goal.id}`,
           `Background run: ${run.id}`,
           "Run `pulseed status` or `/sessions` to check progress.",
         ].join("\n"),
@@ -1106,7 +1106,7 @@ export class ChatRunner {
         output: [
           `RunSpec confirmed: ${spec.id}`,
           "",
-          `Daemon start failed, so no CoreLoop run was started: ${message}`,
+          `Daemon start failed, so no DurableLoop run was started: ${message}`,
           "Start the daemon with `pulseed daemon start`, then approve the RunSpec again from a daemon-capable chat surface.",
           `Background run record marked failed: ${run.id}`,
         ].join("\n"),

--- a/src/interface/chat/freeform-route-classifier.ts
+++ b/src/interface/chat/freeform-route-classifier.ts
@@ -43,7 +43,7 @@ Routing contract:
 - assist: questions, how-to, status explanation, read-only guidance.
 - configure: setup/configuration of Telegram, Slack, daemon, provider, notifications, gateway, or channels.
 - execute: concrete repo edits, tests, implementation, commands, or goal execution that should enter the coding agent loop.
-- run_spec: clear natural-language requests for PulSeed to run, continue, optimize, evaluate, monitor, or work toward an outcome over time as a long-running background/CoreLoop run.
+- run_spec: clear natural-language requests for PulSeed to run, continue, optimize, evaluate, monitor, or work toward an outcome over time as a long-running background/DurableLoop run.
 - clarify: ambiguous or underspecified input where executing code would be unsafe.
 
 Use semantic intent, not literal phrase matching. Multilingual paraphrases should route by meaning.

--- a/src/interface/cli/cli-runner.ts
+++ b/src/interface/cli/cli-runner.ts
@@ -2,7 +2,7 @@
 // ─── CLIRunner ───
 //
 // PulSeed CLI entry point. Wires all dependencies and exposes subcommands:
-//   pulseed run --goal <id>            Run CoreLoop once for a given goal
+//   pulseed run --goal <id>            Run DurableLoop once for a given goal
 //   pulseed goal add "<description>"   Negotiate and register a new goal (interactive)
 //   pulseed goal list                  List all registered goals
 //   pulseed goal archive <id>          Archive a completed goal

--- a/src/interface/cli/utils.ts
+++ b/src/interface/cli/utils.ts
@@ -26,7 +26,7 @@ export function printUsage(): void {
 Usage:
   pulseed                                               Launch interactive TUI (default)
   pulseed --version, -v                Show version and exit
-  pulseed run --goal <id>              Run CoreLoop for a goal
+  pulseed run --goal <id>              Run DurableLoop for a goal
   pulseed improve [path]               Analyze path, suggest goals, and optionally run improvement loop
   pulseed suggest "<context>"          Suggest improvement goals for a project context
   pulseed goal add --title "<t>" --dim "name:type:val"  Register a goal (raw mode, no LLM)

--- a/src/orchestrator/execution/agent-loop/durable-loop-control-tools.ts
+++ b/src/orchestrator/execution/agent-loop/durable-loop-control-tools.ts
@@ -47,17 +47,17 @@ type CoreToolName = keyof typeof schemas;
 
 export function createDurableLoopControlTools(service: DurableLoopControlToolset): ITool[] {
   const tools: ITool[] = [
-    new CoreLoopControlTool("core_goal_status", "Read CoreLoop goal status.", "read_only", (input) => service.goalStatus(input), schemas.core_goal_status),
+    new CoreLoopControlTool("core_goal_status", "Read DurableLoop goal status.", "read_only", (input) => service.goalStatus(input), schemas.core_goal_status),
   ];
-  if (service.goalCreate) tools.push(new CoreLoopControlTool("core_goal_create", "Create a CoreLoop goal.", "write_local", (input) => service.goalCreate!(input), schemas.core_goal_create));
-  if (service.tendGoal) tools.push(new CoreLoopControlTool("core_tend_goal", "Create a CoreLoop goal and start it in the daemon for long-running background execution.", "write_local", (input) => service.tendGoal!(input), schemas.core_tend_goal));
-  if (service.goalStart) tools.push(new CoreLoopControlTool("core_goal_start", "Start or resume a CoreLoop goal in the daemon.", "write_local", (input) => service.goalStart!(input), schemas.core_goal_start));
-  if (service.goalPause) tools.push(new CoreLoopControlTool("core_goal_pause", "Pause a CoreLoop goal.", "write_local", (input) => service.goalPause!(input), schemas.core_goal_pause));
-  if (service.goalResume) tools.push(new CoreLoopControlTool("core_goal_resume", "Start or resume a CoreLoop goal in the daemon.", "write_local", (input) => service.goalResume!(input), schemas.core_goal_resume));
-  if (service.goalCancel) tools.push(new CoreLoopControlTool("core_goal_cancel", "Cancel a CoreLoop goal.", "write_local", (input) => service.goalCancel!(input), schemas.core_goal_cancel));
-  if (service.taskStatus) tools.push(new CoreLoopControlTool("core_task_status", "Read CoreLoop task status.", "read_only", (input) => service.taskStatus!(input), schemas.core_task_status));
-  if (service.taskPrioritize) tools.push(new CoreLoopControlTool("core_task_prioritize", "Set CoreLoop task priority.", "write_local", (input) => service.taskPrioritize!(input), schemas.core_task_prioritize));
-  if (service.runCycle) tools.push(new CoreLoopControlTool("core_run_cycle", "Run one bounded CoreLoop cycle.", "write_local", (input) => service.runCycle!(input), schemas.core_run_cycle));
+  if (service.goalCreate) tools.push(new CoreLoopControlTool("core_goal_create", "Create a DurableLoop goal.", "write_local", (input) => service.goalCreate!(input), schemas.core_goal_create));
+  if (service.tendGoal) tools.push(new CoreLoopControlTool("core_tend_goal", "Create a DurableLoop goal and start it in the daemon for long-running background execution.", "write_local", (input) => service.tendGoal!(input), schemas.core_tend_goal));
+  if (service.goalStart) tools.push(new CoreLoopControlTool("core_goal_start", "Start or resume a DurableLoop goal in the daemon.", "write_local", (input) => service.goalStart!(input), schemas.core_goal_start));
+  if (service.goalPause) tools.push(new CoreLoopControlTool("core_goal_pause", "Pause a DurableLoop goal.", "write_local", (input) => service.goalPause!(input), schemas.core_goal_pause));
+  if (service.goalResume) tools.push(new CoreLoopControlTool("core_goal_resume", "Start or resume a DurableLoop goal in the daemon.", "write_local", (input) => service.goalResume!(input), schemas.core_goal_resume));
+  if (service.goalCancel) tools.push(new CoreLoopControlTool("core_goal_cancel", "Cancel a DurableLoop goal.", "write_local", (input) => service.goalCancel!(input), schemas.core_goal_cancel));
+  if (service.taskStatus) tools.push(new CoreLoopControlTool("core_task_status", "Read DurableLoop task status.", "read_only", (input) => service.taskStatus!(input), schemas.core_task_status));
+  if (service.taskPrioritize) tools.push(new CoreLoopControlTool("core_task_prioritize", "Set DurableLoop task priority.", "write_local", (input) => service.taskPrioritize!(input), schemas.core_task_prioritize));
+  if (service.runCycle) tools.push(new CoreLoopControlTool("core_run_cycle", "Run one bounded DurableLoop cycle.", "write_local", (input) => service.runCycle!(input), schemas.core_run_cycle));
   return tools;
 }
 
@@ -117,7 +117,7 @@ class CoreLoopControlTool<TInput> implements ITool<TInput> {
     if (this.metadata.isReadOnly) return { status: "allowed" };
     return context.preApproved
       ? { status: "allowed" }
-      : { status: "needs_approval", reason: `${this.metadata.name} changes CoreLoop state` };
+      : { status: "needs_approval", reason: `${this.metadata.name} changes DurableLoop state` };
   }
 
   isConcurrencySafe(_input: TInput): boolean {
@@ -140,7 +140,7 @@ export function createDaemonBackedDurableLoopControlToolset(
   const createGoal = async (description: string): Promise<{ goalId: string; goal: Goal }> => {
     const normalizedDescription = description.trim();
     if (!normalizedDescription) {
-      throw new Error("CoreLoop goal description is required.");
+      throw new Error("DurableLoop goal description is required.");
     }
     const now = new Date().toISOString();
     const goalId = randomUUID();
@@ -180,7 +180,7 @@ export function createDaemonBackedDurableLoopControlToolset(
     const baseDir = deps.stateManager.getBaseDir();
     const info = await isDaemonRunning(baseDir);
     if (!info.running) {
-      throw new Error("PulSeed daemon is not running; CoreLoop start/stop was not requested.");
+      throw new Error("PulSeed daemon is not running; DurableLoop start/stop was not requested.");
     }
     return new DaemonClient({
       host: deps.host ?? "127.0.0.1",

--- a/src/runtime/__tests__/loop-supervisor.test.ts
+++ b/src/runtime/__tests__/loop-supervisor.test.ts
@@ -452,7 +452,7 @@ describe("LoopSupervisor", () => {
     }
   });
 
-  it("links CoreLoop background runs to the worker session and marks terminal", async () => {
+  it("links DurableLoop background runs to the worker session and marks terminal", async () => {
     const runId = "run:coreloop:bg";
     const { supervisor, deps, runtimeRoot } = makeSupervisor(async (goalId: string) => {
       await new Promise((resolve) => setTimeout(resolve, 120));
@@ -466,7 +466,7 @@ describe("LoopSupervisor", () => {
       parent_session_id: "session:conversation:chat-bg",
       notify_policy: "silent",
       reply_target_source: "none",
-      title: "Background CoreLoop",
+      title: "Background DurableLoop",
       workspace: "/repo",
     });
     (deps as { backgroundRunLedger?: BackgroundRunLedger }).backgroundRunLedger = ledger;
@@ -499,7 +499,7 @@ describe("LoopSupervisor", () => {
         id: runId,
         parent_session_id: "session:conversation:chat-bg",
         status: "succeeded",
-        summary: "CoreLoop completed after 2 iteration(s).",
+        summary: "DurableLoop completed after 2 iteration(s).",
       });
       expect(terminal.source_refs).toContainEqual(expect.objectContaining({
         kind: "supervisor_state",
@@ -540,7 +540,7 @@ describe("LoopSupervisor", () => {
       const runFile = path.join(runtimeRoot, "background-runs", `${encodeURIComponent(runId)}.json`);
       const terminal = await pollForJsonMatch<any>(runFile, (value) =>
         value.status === "succeeded" &&
-        value.summary === "CoreLoop finalization after 1 iteration(s)."
+        value.summary === "DurableLoop finalization after 1 iteration(s)."
       );
       await supervisor.shutdown();
 
@@ -551,7 +551,7 @@ describe("LoopSupervisor", () => {
     }
   });
 
-  it("settles coalesced CoreLoop background runs instead of leaving them queued", async () => {
+  it("settles coalesced DurableLoop background runs instead of leaving them queued", async () => {
     const initialRunId = "run:coreloop:bg-initial";
     const coalescedRunId = "run:coreloop:bg-coalesced";
     const { supervisor, deps, runtimeRoot } = makeSupervisor(async (goalId: string) => {

--- a/src/runtime/control/__tests__/runtime-control-service.test.ts
+++ b/src/runtime/control/__tests__/runtime-control-service.test.ts
@@ -28,7 +28,7 @@ function makeRun(input: Partial<RuntimeSessionRegistrySnapshot["background_runs"
     notify_policy: "done_only",
     reply_target_source: "none",
     pinned_reply_target: null,
-    title: "CoreLoop goal goal-1",
+    title: "DurableLoop goal goal-1",
     workspace: "/repo",
     created_at: "2026-05-02T00:00:00.000Z",
     started_at: "2026-05-02T00:00:00.000Z",

--- a/src/runtime/control/runtime-control-service.ts
+++ b/src/runtime/control/runtime-control-service.ts
@@ -586,7 +586,7 @@ function resolveGoalId(run: BackgroundRun, snapshot: RuntimeSessionRegistrySnaps
     ? snapshot.sessions.find((session) => session.id === run.child_session_id)
     : null;
   const title = child?.title ?? run.title ?? "";
-  const match = title.match(/^CoreLoop goal\s+(.+)$/);
+  const match = title.match(/^(?:DurableLoop|CoreLoop) goal\s+(.+)$/);
   return match?.[1]?.trim() || null;
 }
 

--- a/src/runtime/executor/loop-supervisor.ts
+++ b/src/runtime/executor/loop-supervisor.ts
@@ -603,7 +603,7 @@ export class LoopSupervisor {
     try {
       const run = await this.deps.backgroundRunLedger.terminal(runId, {
         status: workerStatusToBackgroundRunStatus(result.status),
-        summary: `CoreLoop ${result.status} after ${result.totalIterations} iteration(s).`,
+        summary: `DurableLoop ${result.status} after ${result.totalIterations} iteration(s).`,
         error: result.error ?? null,
         source_refs: sourceRefs,
       });
@@ -639,7 +639,7 @@ export class LoopSupervisor {
       });
       const run = await this.deps.backgroundRunLedger.terminal(runId, {
         status: "cancelled",
-        summary: `CoreLoop activation coalesced into active worker ${activeWorker.id}.`,
+        summary: `DurableLoop activation coalesced into active worker ${activeWorker.id}.`,
         source_refs: sourceRefs,
       });
       if (run.notify_policy !== 'silent' && run.pinned_reply_target) {

--- a/src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
+++ b/src/runtime/session-registry/__tests__/runtime-session-registry.test.ts
@@ -352,13 +352,13 @@ describe("RuntimeSessionRegistry", () => {
     }));
   });
 
-  it("projects a completed CoreLoop handoff graph from durable ledger records", async () => {
+  it("projects a completed DurableLoop handoff graph from durable ledger records", async () => {
     await stateManager.writeRaw("chat/sessions/chat-coreloop.json", {
       id: "chat-coreloop",
       cwd: "/repo",
       createdAt: "2026-04-25T00:00:00.000Z",
       updatedAt: "2026-04-25T00:01:00.000Z",
-      title: "CoreLoop handoff",
+      title: "DurableLoop handoff",
       messages: [],
     });
 
@@ -371,7 +371,7 @@ describe("RuntimeSessionRegistry", () => {
       reply_target_source: "none",
       parent_session_id: "session:conversation:chat-coreloop",
       child_session_id: "session:coreloop:worker-handoff",
-      title: "CoreLoop handoff",
+      title: "DurableLoop handoff",
       workspace: "/repo",
       created_at: "2026-04-25T00:02:00.000Z",
       started_at: "2026-04-25T00:03:00.000Z",
@@ -387,7 +387,7 @@ describe("RuntimeSessionRegistry", () => {
     await ledger.terminal("run:coreloop:handoff", {
       status: "succeeded",
       completed_at: "2026-04-25T00:04:00.000Z",
-      summary: "CoreLoop completed.",
+      summary: "DurableLoop completed.",
     });
 
     const snapshot = await new RuntimeSessionRegistry({ stateManager }).snapshot();

--- a/src/runtime/session-registry/registry.ts
+++ b/src/runtime/session-registry/registry.ts
@@ -431,7 +431,7 @@ export class RuntimeSessionRegistry {
       const sessionId = stringField(worker, "sessionId") ?? coreLoopSessionId(workerId);
       const runId = stringField(worker, "backgroundRunId") ?? coreLoopRunId(workerId);
       const parentSessionId = stringField(worker, "parentSessionId");
-      const title = goalId ? `CoreLoop goal ${goalId}` : `CoreLoop worker ${workerId}`;
+      const title = goalId ? `DurableLoop goal ${goalId}` : `DurableLoop worker ${workerId}`;
       sessions.push({
         schema_version: "runtime-session-v1",
         id: sessionId,

--- a/tmp/durable-loop-migration-status.md
+++ b/tmp/durable-loop-migration-status.md
@@ -39,3 +39,15 @@
 - `rg -n "from .*core-loop|import\\(.*core-loop|\\.\\/core-loop|\\.\\.\\/core-loop" src -g '*.ts'` returned no remaining source imports after migration.
 - Intentional leftovers from `rg -n "CoreLoop|core-loop|coreloop" src/orchestrator/loop src/orchestrator/execution/agent-loop -g '*.ts'`: legacy compatibility shims, deprecated compatibility export names, compatibility alias tests, unchanged persisted/wire names such as `core_*` tool names and `run:coreloop:*`, and log/message text deferred to #1018.
 - Review: separate review agent found no material issues and confirmed old/new compiled ESM import paths still resolve.
+
+## #1018 Rename runtime, session, and user-facing CoreLoop labels to DurableLoop with legacy compatibility
+
+- Status: in progress.
+- Branch: `codex/issue-1018-durable-loop-user-labels`.
+- Issue body reviewed with `gh issue view 1018`.
+- Plan: update user-facing labels in chat/CLI/tool descriptions/runtime session titles/background run summaries to `DurableLoop`; keep legacy persisted IDs and kinds (`run:coreloop:*`, `session:coreloop:*`, `coreloop_run`, `coreloop`) unchanged and readable.
+- Compatibility note: runtime-control goal ID fallback now accepts both `DurableLoop goal <id>` and legacy `CoreLoop goal <id>` titles. This is deterministic parsing of an internal title compatibility surface, not freeform semantic routing.
+- Verification: `npm run typecheck` passed. `npm run lint:boundaries` passed with existing warnings and no errors. Runtime/session/control focused tests in the bundle passed. Chat caller-path DurableLoop label tests passed with targeted `-t` runs for `starts a confirmed RunSpec only after next-turn approval` and `starts a gateway natural-language RunSpec after approval and retains reply target metadata`.
+- Full chat focused bundle also ran but failed in unrelated Telegram setup tests because existing untracked `.pulseed-sandbox` local state reports Telegram/Home chat configured; this is the same local-state issue seen in #1016 and not caused by DurableLoop label changes.
+- Review: separate review agent found one missed user-facing chat safety response label. Fixed `background CoreLoop work` to `background DurableLoop work`.
+- Re-verification after review fix: `npm run typecheck`, `npm run lint:boundaries`, runtime/session/control/agent-loop focused tests, and targeted chat/cross-platform DurableLoop caller-path tests passed.


### PR DESCRIPTION
Closes #1018

## Summary

- Update user-facing DurableLoop labels in chat RunSpec approval output, CLI usage text, runtime session titles, background run summaries, and agent-loop control tool descriptions/errors.
- Keep legacy persisted IDs and kinds unchanged: `run:coreloop:*`, `session:coreloop:*`, `coreloop_run`, `coreloop`, and `core_*` tool names.
- Preserve legacy runtime-control title fallback by accepting both `DurableLoop goal <id>` and legacy `CoreLoop goal <id>` generated titles.

## Verification

- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings, no errors)
- `npx vitest run src/runtime/session-registry/__tests__/runtime-session-registry.test.ts src/runtime/control/__tests__/runtime-control-service.test.ts src/runtime/__tests__/loop-supervisor.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts`
- `npx vitest run src/interface/chat/__tests__/chat-runner.test.ts -t "starts a confirmed RunSpec only after next-turn approval"`
- `npx vitest run src/interface/chat/__tests__/cross-platform-session.test.ts -t "starts a gateway natural-language RunSpec after approval and retains reply target metadata"`
- Review agent checked compatibility and found one missed label; fixed and re-ran verification.

The broader chat-focused bundle was also attempted, but unrelated Telegram setup tests failed because local untracked `.pulseed-sandbox` state reports Telegram/Home chat configured.

## Known unresolved risks

- Some internal type names, legacy tests, and docs still say `CoreLoop`; current-facing docs are handled by #1019.

## Remaining `CoreLoop|core-loop|coreloop`

- Legacy persisted/wire identifiers: `run:coreloop:*`, `session:coreloop:*`, `coreloop_run`, `coreloop`, `core_*`.
- Type/API compatibility names such as `CoreLoop`.
- Historical/internal tests and docs to be cleaned in #1019 where current-facing.
- Deterministic compatibility parser for legacy generated title `CoreLoop goal <id>`.
