### PR TITLE
docs: clean up DurableLoop documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ PulSeed will guide provider and adapter setup when needed.
 
 ## What It Does
 
-- `CoreLoop` keeps a goal moving and decides whether to continue, refine,
+- `DurableLoop` keeps a goal moving and decides whether to continue, refine,
   verify, or stop
 - `AgentLoop` handles bounded tool-using work for task execution, chat, and
   selected runtime phases

--- a/docs/architecture-map.md
+++ b/docs/architecture-map.md
@@ -10,7 +10,7 @@ user / daemon / chat / tui
     interface layer
           |
           v
-      CoreLoop
+      DurableLoop
           |
     +-----+-------------------+
     |                         |
@@ -55,7 +55,7 @@ Cross-cutting domain services:
 
 Long-lived orchestration logic:
 
-- `loop/`: CoreLoop, iteration kernel, tree/multi-goal runners
+- `loop/`: DurableLoop, iteration kernel, tree/multi-goal runners
 - `execution/`: task lifecycle, session management, native AgentLoop runtime
 - `goal/`: goal negotiation, tree orchestration, aggregation
 - `strategy/`: strategy and portfolio management
@@ -92,18 +92,18 @@ Resident runtime support:
 - schedule engine
 - runtime health store
 
-## 3. CoreLoop map
+## 3. DurableLoop map
 
-CoreLoop is the main long-lived controller.
+DurableLoop is the main long-lived controller.
 
 Important public subparts:
 
-- `src/orchestrator/loop/core-loop.ts`
-- `src/orchestrator/loop/core-loop/iteration-kernel.ts`
+- `src/orchestrator/loop/durable-loop.ts`
+- `src/orchestrator/loop/durable-loop/iteration-kernel.ts`
 - `src/orchestrator/loop/tree-loop-runner.ts`
 - `src/orchestrator/goal/tree-loop-orchestrator.ts`
 
-What CoreLoop owns:
+What DurableLoop owns:
 
 - observation to completion flow
 - tree-mode and multi-goal scheduling
@@ -132,9 +132,9 @@ What AgentLoop owns:
 - repeated tool loop detection
 - task/chat session traces
 
-## 5. How CoreLoop and AgentLoop connect
+## 5. How DurableLoop and AgentLoop connect
 
-CoreLoop uses AgentLoop in two ways.
+DurableLoop uses AgentLoop in two ways.
 
 ### Task execution path
 
@@ -142,7 +142,7 @@ When the active adapter is `agent_loop`, `TaskLifecycle` routes execution throug
 
 ### Core phase path
 
-CoreLoop can run bounded agentic phases such as:
+DurableLoop can run bounded agentic phases such as:
 
 - `knowledge_refresh`
 - `replanning_options`
@@ -183,7 +183,7 @@ Good for:
 
 - bounded interactive work
 - tool-driven conversations
-- operating CoreLoop through tools
+- operating DurableLoop through tools
 
 ### TUI
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,9 +229,9 @@ Common scriptable commands:
 |---|---|
 | `pulseed setup` | Configure provider, model, and adapter |
 | `pulseed goal add "<text>"` | Create a goal |
-| `pulseed run --goal <id>` | Execute CoreLoop for one goal with bounded policy (default max 100 iterations) |
-| `pulseed run --goal <id> --resident` | Execute CoreLoop with resident policy; iteration count is telemetry, not a lifecycle cap |
-| `pulseed daemon start --iterations-per-cycle <n>` | Start daemon workers in bounded canary mode with `<n>` as the CoreLoop cap |
+| `pulseed run --goal <id>` | Execute DurableLoop for one goal with bounded policy (default max 100 iterations) |
+| `pulseed run --goal <id> --resident` | Execute DurableLoop with resident policy; iteration count is telemetry, not a lifecycle cap |
+| `pulseed daemon start --iterations-per-cycle <n>` | Start daemon workers in bounded canary mode with `<n>` as the DurableLoop cap |
 | `pulseed daemon start --resident --iterations-per-cycle <n>` | Start daemon workers in resident mode with `<n>` as a telemetry window |
 | `pulseed status --goal <id>` | Inspect goal state |
 | `pulseed report --goal <id>` | Read the latest report |

--- a/docs/design/core/self-knowledge.md
+++ b/docs/design/core/self-knowledge.md
@@ -128,7 +128,7 @@ Returns a static description of PulSeed's architecture and capabilities.
 - Layer structure (Layer 0-15) with module names
 - Module responsibilities summary
 - Execution boundary: "PulSeed orchestrates goal pursuit. It uses available tools directly for safe local work and delegates when specialization, parallelism, or context isolation helps."
-- Runtime shape: CoreLoop for long-lived control plus AgentLoop for bounded tool-using execution- 4-element model: Goal -> Current State -> Gap -> Constraints
+- Runtime shape: DurableLoop for long-lived control plus AgentLoop for bounded tool-using execution- 4-element model: Goal -> Current State -> Gap -> Constraints
 
 **Data source**: Hardcoded text
 

--- a/docs/design/core/stall-detection.md
+++ b/docs/design/core/stall-detection.md
@@ -117,7 +117,7 @@ plateau_until is set AND current_time < plateau_until
   → None of the detection types from §2.1–§2.4 are triggered
 ```
 
-**WaitStrategy mapping**: In the current CoreLoop integration, an active
+**WaitStrategy mapping**: In the current DurableLoop integration, an active
 `WaitStrategy` contributes suppression only for its `primary_dimension`. Its
 `target_dimensions` are not suppressed automatically. This matches wait expiry,
 which also evaluates a single canonical dimension rather than a bundle of

--- a/docs/design/core/time-horizon.md
+++ b/docs/design/core/time-horizon.md
@@ -2,7 +2,7 @@
 
 How PulSeed develops temporal awareness: evaluating whether goal progress is on pace relative to deadlines, projecting completion dates, and emitting signals that influence drive scoring and strategy selection. TimeHorizonEngine is the bridge between "how far are we from the goal?" (gap) and "do we have enough time?" (temporal budget).
 
-> Current implementation note: TimeHorizonEngine now influences a CoreLoop that may also run bounded agentic phases and native AgentLoop task execution. The temporal model still applies, but the surrounding orchestration is no longer a single flat loop body.
+> Current implementation note: TimeHorizonEngine now influences a DurableLoop that may also run bounded agentic phases and native AgentLoop task execution. The temporal model still applies, but the surrounding orchestration is no longer a single flat loop body.
 
 As a prerequisite, see `drive-scoring.md` for the drive scoring structure and `stall-detection.md` for stall detection.
 
@@ -322,7 +322,7 @@ TimeHorizonEngine does **not** modify StallDetector directly. Instead, it provid
 
 The connection point: StallDetector flags a stall -> WaitStrategy (future) checks `timeBudget.canAffordWait(estimatedEffectDelay)` -> if affordable, suppress the stall signal.
 
-### 5.4 CoreLoop
+### 5.4 DurableLoop
 
 TimeHorizonEngine is called in the **drive-scoring phase**, after gap calculation but before task generation:
 
@@ -330,7 +330,7 @@ TimeHorizonEngine is called in the **drive-scoring phase**, after gap calculatio
 observe -> gap calculation -> [TIME HORIZON] -> drive scoring -> task generation -> execute -> verify
 ```
 
-The CoreLoop passes:
+The DurableLoop passes:
 1. Current gap (from gap calculation)
 2. Goal deadline
 3. Recent observation history
@@ -391,7 +391,7 @@ Based on pacing status, TimeHorizonEngine suggests adjusting the loop interval:
 | `ahead` | 2.0 | Reduce cost — things are going well |
 | `no_deadline` | 1.5 | Slightly relaxed |
 
-> **Note**: Values < 1.0 shorten the interval (more frequent observations). Values > 1.0 lengthen it (less frequent). The multiplier is applied to the base observation interval configured for the goal. This is a suggestion — CoreLoop may override based on other factors.
+> **Note**: Values < 1.0 shorten the interval (more frequent observations). Values > 1.0 lengthen it (less frequent). The multiplier is applied to the base observation interval configured for the goal. This is a suggestion — DurableLoop may override based on other factors.
 
 ---
 
@@ -445,7 +445,7 @@ All values have sensible defaults. Configuration is per-engine instance (not per
 | Tests | `src/platform/time/__tests__/time-horizon-engine.test.ts` |
 | Config | Merged into `DriveConfig` or standalone `TimeHorizonConfig` |
 
-Injected via DI into CoreLoop, following the same pattern as DriveScorer and StallDetector.
+Injected via DI into DurableLoop, following the same pattern as DriveScorer and StallDetector.
 
 ---
 

--- a/docs/design/core/tool-system.md
+++ b/docs/design/core/tool-system.md
@@ -68,7 +68,7 @@ New boundary: "PulSeed does LLM calls, state I/O, and read-only tool invocations
 **In scope (this document)**:
 - Tool system core (registry, executor, permission, concurrency)
 - Read-only built-in tools (Glob, Grep, Read, Shell for metrics, HttpFetch GET, JsonQuery)
-- Integration with ObservationEngine, GapCalculator, KnowledgeManager, StrategyManager, CoreLoop verification
+- Integration with ObservationEngine, GapCalculator, KnowledgeManager, StrategyManager, DurableLoop verification
 - Permission model for read-only and read-with-side-effects (Shell) tools
 
 **Future work (not this document)**:
@@ -85,7 +85,7 @@ New boundary: "PulSeed does LLM calls, state I/O, and read-only tool invocations
 
 ```
                               +----------------------------------------------+
-                              |              CoreLoop                         |
+                              |              DurableLoop                         |
                               |  observe -> gap -> score -> task -> verify    |
                               +-------+------+------+------+------+----------+
                                       |      |      |      |      |
@@ -126,7 +126,7 @@ New boundary: "PulSeed does LLM calls, state I/O, and read-only tool invocations
 
 **Before: Observation cycle**
 ```
-CoreLoop -> ObservationEngine -> LLM call (interpret what to observe)
+DurableLoop -> ObservationEngine -> LLM call (interpret what to observe)
          -> SessionManager -> AdapterLayer -> Agent session (do the observation)
          -> Agent runs commands, reads files, calls APIs
          -> Agent returns results
@@ -138,7 +138,7 @@ Cost: ~30s, ~10,000 tokens, agent session overhead
 
 **After: Observation cycle (tool-enhanced)**
 ```
-CoreLoop -> ObservationEngine -> Tool calls (Glob, Read, Shell, HttpFetch)
+DurableLoop -> ObservationEngine -> Tool calls (Glob, Read, Shell, HttpFetch)
          -> Direct results (file contents, command output, API responses)
          -> LLM call (interpret results)
          -> State update
@@ -149,17 +149,17 @@ Cost: ~2s, ~2,000 tokens, no agent session for common cases
 
 **Before: Verification cycle**
 ```
-CoreLoop -> Spawn verification agent session
+DurableLoop -> Spawn verification agent session
          -> Agent runs tests, checks files
          -> Agent reports results
-         -> CoreLoop interprets
+         -> DurableLoop interprets
 
 Cost: ~30s, ~8,000 tokens
 ```
 
 **After: Verification cycle (tool-enhanced)**
 ```
-CoreLoop -> Shell tool (run tests) + Glob tool (check outputs) + Read tool (check content)
+DurableLoop -> Shell tool (run tests) + Glob tool (check outputs) + Read tool (check content)
          -> Direct results
          -> LLM call (interpret if needed, or pure mechanical check)
 
@@ -1746,7 +1746,7 @@ With workspace context, the LLM generates more specific strategies:
 
 ### 7.4 Workspace Context Caching
 
-WorkspaceContext is relatively expensive to build (5 parallel tool calls). It should be cached per CoreLoop iteration and invalidated when:
+WorkspaceContext is relatively expensive to build (5 parallel tool calls). It should be cached per DurableLoop iteration and invalidated when:
 
 1. A task execution completes (files may have changed)
 2. An observation detects external changes
@@ -1786,7 +1786,7 @@ class WorkspaceContextCache {
 The task verification flow (task-lifecycle.md Section 5) currently uses a 3-layer structure: mechanical verification, task reviewer, executor self-report. The tool system dramatically improves Layer 1 (mechanical verification) by making it direct rather than requiring a verification agent session.
 
 ```
-CoreLoop.verify(taskResult)
+DurableLoop.verify(taskResult)
   |
   +-- Layer 1: Mechanical Verification via Tools (ENHANCED)
   |   +-- Shell: run test suite -> pass/fail + coverage numbers
@@ -1871,10 +1871,10 @@ function mapCriteriaToToolCalls(
 }
 ```
 
-### 8.4 Verification Integration in CoreLoop
+### 8.4 Verification Integration in DurableLoop
 
 ```typescript
-// Addition to CoreLoop verification phase
+// Addition to DurableLoop verification phase
 
 async verifyWithTools(
   task: Task,
@@ -1918,7 +1918,7 @@ interface VerificationDetail {
 
 ### 8.5 Reduced Iteration Latency
 
-With tool-based verification, the CoreLoop completes iterations significantly faster:
+With tool-based verification, the DurableLoop completes iterations significantly faster:
 
 | Phase | Before | After | Savings |
 |-------|--------|-------|---------|
@@ -2844,24 +2844,24 @@ permissionManager.addDenyRule({
 | **GapCalculator** | Add `measureDirectly()` for stale-data refresh | Small (optional path, no existing logic changes) |
 | **KnowledgeManager** | Add tool-based research before agent delegation | Medium (new method + priority ordering) |
 | **StrategyManager** | Accept workspace context from tools | Small (context injection, no logic changes) |
-| **CoreLoop** | Wire ToolExecutor into deps; use tools in verify phase | Medium (new dep + verification enhancement) |
+| **DurableLoop** | Wire ToolExecutor into deps; use tools in verify phase | Medium (new dep + verification enhancement) |
 | **TaskLifecycle** | No changes (agent delegation path unchanged) | None |
 | **EthicsGate** | No changes (tools call EthicsGate, not the reverse) | None |
 | **TrustManager** | No changes (tools call TrustManager, not the reverse) | None |
 | **AdapterLayer** | No changes (agent path remains intact) | None |
 | **SessionManager** | Minor: include tool-gathered context in sessions | Small |
 | **ReportingEngine** | Add tool execution events to reports | Small |
-| **CoreLoopDeps** | Add `toolExecutor?: ToolExecutor` field | Trivial |
+| **DurableLoopDeps** | Add `toolExecutor?: ToolExecutor` field | Trivial |
 
-### 12.2 CoreLoopDeps Extension
+### 12.2 DurableLoopDeps Extension
 
 ```typescript
-export interface CoreLoopDeps extends ObservationDeps, TreeDeps, StallDeps, TaskCycleDeps {
+export interface DurableLoopDeps extends ObservationDeps, TreeDeps, StallDeps, TaskCycleDeps {
   // ... existing fields ...
 
   /**
    * Optional ToolExecutor for direct tool-based operations.
-   * When provided, CoreLoop uses tools for observation, verification,
+   * When provided, DurableLoop uses tools for observation, verification,
    * and knowledge acquisition. When absent, all operations fall through
    * to agent delegation (backward-compatible).
    */
@@ -2888,11 +2888,11 @@ This means the tool system provides incremental value: even with just Glob + Rea
 
 ### 12.4 Backward Compatibility
 
-The `toolExecutor` field on CoreLoopDeps is optional. When not provided:
+The `toolExecutor` field on DurableLoopDeps is optional. When not provided:
 - ObservationEngine skips `observeWithTools()` and uses existing paths.
 - GapCalculator skips `measureDirectly()` and uses stored values only.
 - KnowledgeManager skips tool-based research and delegates to agents.
-- CoreLoop verification uses existing agent-based verification.
+- DurableLoop verification uses existing agent-based verification.
 
 This means the tool system is a **purely additive** change. No existing behavior is modified. Tools only activate when explicitly provided.
 
@@ -2985,7 +2985,7 @@ This means the tool system is a **purely additive** change. No existing behavior
 - ObservationEngine: `observeWithTools()` method + tool-first fallback chain
 - KnowledgeManager: tool-based research path (`acquireWithTools()`)
 - Observation allow-list auto-registration from dimension configs
-- CoreLoopDeps: add `toolExecutor` and `toolRegistry` fields
+- DurableLoopDeps: add `toolExecutor` and `toolRegistry` fields
 - Integration tests: observation with tools, knowledge acquisition with tools
 
 **Estimated size**: ~800 lines production, ~600 lines tests
@@ -3000,7 +3000,7 @@ This means the tool system is a **purely additive** change. No existing behavior
 
 **Deliverables**:
 - GapCalculator: `measureDirectly()` for stale-data refresh
-- CoreLoop verification: tool-based Layer 1 mechanical verification
+- DurableLoop verification: tool-based Layer 1 mechanical verification
 - StrategyManager: workspace context gathering (`buildWorkspaceContext()`)
 - WorkspaceContextCache for per-iteration caching
 - Integration tests: verification with tools, strategy with workspace context
@@ -3055,7 +3055,7 @@ This means the tool system is a **purely additive** change. No existing behavior
 
 ### 15.3 Caching
 
-**Decision** (resolved): Implement per-iteration cache keyed by `(toolName, JSON.stringify(input))`. Cache expires at end of each CoreLoop iteration. All read-only tools are cacheable. ShellTool results cacheable only for safe-list commands. This is a PulSeed differentiation — CC does NOT cache tool results (only API-level prompt caching). PulSeed's core loop calls the same tools multiple times per iteration (observe → gap → verify), making caching high-value.
+**Decision** (resolved): Implement per-iteration cache keyed by `(toolName, JSON.stringify(input))`. Cache expires at end of each DurableLoop iteration. All read-only tools are cacheable. ShellTool results cacheable only for safe-list commands. This is a PulSeed differentiation — CC does NOT cache tool results (only API-level prompt caching). PulSeed's core loop calls the same tools multiple times per iteration (observe → gap → verify), making caching high-value.
 
 **CC Reference**: CC performs API-level prompt caching only. No tool result caching. PulSeed's multi-phase iteration pattern (observe → gap → verify) makes in-iteration caching significantly more valuable than in CC's single-pass model.
 

--- a/docs/design/core/wait-strategy.md
+++ b/docs/design/core/wait-strategy.md
@@ -6,7 +6,7 @@
 > the integration seams. For schema details see portfolio-management.md §7; for
 > stall suppression see stall-detection.md §2.5.
 
-> Current implementation note: file paths and loop-phase names in this document predate parts of the CoreLoop redesign. Read the intent as current, but verify exact ownership against `src/orchestrator/strategy/`, `src/orchestrator/loop/`, and `src/platform/drive/`.
+> Current implementation note: file paths and loop-phase names in this document predate parts of the DurableLoop redesign. Read the intent as current, but verify exact ownership against `src/orchestrator/strategy/`, `src/orchestrator/loop/`, and `src/platform/drive/`.
 
 ---
 
@@ -29,7 +29,7 @@ for meaningful results — this sense of timing is also part of strategy.")
 | **PortfolioManager** | "Should we wait?" — expiry handling via `handleWaitStrategyExpiry`, duck-type check via `isWaitStrategy` (portfolio-management.md §7) |
 | **StallDetector** | Evaluates `isSuppressed(plateauUntil)` when the loop decides whether a dimension should participate in stall detection (stall-detection.md §2.5) |
 | **StrategyManager** | Creates WaitStrategy instances via `createWaitStrategy()` with `state=candidate`, `allocation=0`, and mirrors `wait_until` into the active task's `plateau_until` on activation |
-| **CoreLoop task cycle** | Collects active WaitStrategies, suppresses stalled dimensions whose wait window is still open, and later calls expiry handling |
+| **DurableLoop task cycle** | Collects active WaitStrategies, suppresses stalled dimensions whose wait window is still open, and later calls expiry handling |
 
 No single module owns the full wait lifecycle. This is intentional — each module
 answers exactly one question.
@@ -110,9 +110,9 @@ See portfolio-management.md §7.3 for the full wait execution flow.
 
 ---
 
-## 5. CoreLoop Integration
+## 5. DurableLoop Integration
 
-In the current CoreLoop implementation, `iteration-kernel.ts` first checks
+In the current DurableLoop implementation, `iteration-kernel.ts` first checks
 whether an active wait should keep the loop in observe-only mode. If the loop
 does proceed, `task-cycle.ts` performs stall suppression and
 `portfolio-manager.ts` handles WaitStrategy expiry:
@@ -142,7 +142,7 @@ and expiry judgment are all anchored to one canonical dimension. The task field
 portfolio. Suppression lifts automatically once the wait timestamp becomes past.
 
 **Current gap**: The `canAffordWait` gate from TimeHorizonEngine is now wired
-through CoreLoop stall recovery and wait-expiry fallback activation using
+through DurableLoop stall recovery and wait-expiry fallback activation using
 dimension-specific gap history. The remaining limitation is architectural:
 external/manual activation paths can still omit the hook, and goals without
 usable per-dimension history currently fail closed (the wait cannot be afforded)
@@ -154,9 +154,9 @@ rather than falling back to a softer heuristic.
 
 | Gap | Description |
 |-----|-------------|
-| **canAffordWait coverage outside CoreLoop** | CoreLoop now passes a dimension-specific `canAffordWait` closure into wait activation and fallback activation, but callers outside that path can still invoke activation without supplying the hook. |
+| **canAffordWait coverage outside DurableLoop** | DurableLoop now passes a dimension-specific `canAffordWait` closure into wait activation and fallback activation, but callers outside that path can still invoke activation without supplying the hook. |
 | **History-poor wait activation policy** | When a wait candidate has insufficient per-dimension gap history to estimate velocity, the current policy is fail-closed (`canAffordWait` returns false). This is safer than silently allowing waits, but it may be too strict for very new goals. |
-| **Authoritative wait state is split across portfolio + task mirror** | The portfolio WaitStrategy is authoritative for CoreLoop suppression and expiry, while `task.plateau_until` is a best-effort mirror for task-local consumers. Consumers that only read task state must tolerate stale mirrors. |
+| **Authoritative wait state is split across portfolio + task mirror** | The portfolio WaitStrategy is authoritative for DurableLoop suppression and expiry, while `task.plateau_until` is a best-effort mirror for task-local consumers. Consumers that only read task state must tolerate stale mirrors. |
 | **Effect latency estimation** | Heuristic categorization of action types (e.g., "deploy" → hours, "marketing" → days) to auto-suggest `wait_until` durations. Currently the LLM proposes durations without structured guidance. |
 | **Adaptive observation frequency** | Reducing observation frequency during waits to save tokens. `TimeHorizonEngine.suggestObservationInterval` exists (time-horizon.md §7) but is not connected to wait state. |
 | **LLM-assisted duration estimation** | Using the LLM to estimate effect latency based on action type and domain context. |
@@ -176,7 +176,7 @@ rather than falling back to a softer heuristic.
 | `canAffordWait` closure | `src/platform/time/time-horizon-engine.ts` (`getTimeBudget` return value) |
 | `TimeBudgetWithWait` type | `src/base/types/time-horizon.ts` |
 | `isSuppressed` (plateau_until) | `src/platform/drive/stall-detector.ts` |
-| CoreLoop wait iteration + stall suppression | `src/orchestrator/loop/core-loop/task-cycle.ts` / `src/orchestrator/loop/core-loop/iteration-kernel.ts` |
+| DurableLoop wait iteration + stall suppression | `src/orchestrator/loop/durable-loop/task-cycle.ts` / `src/orchestrator/loop/durable-loop/iteration-kernel.ts` |
 
 ---
 

--- a/docs/design/core/write-tool-integration.md
+++ b/docs/design/core/write-tool-integration.md
@@ -1,12 +1,12 @@
 # Tool Integration Design
 
-> Current implementation note: much of this integration has already happened. ChatRunner no longer represents the only tool-using path; the native AgentLoop runtime, CoreLoop phases, and task execution all share the built-in tool substrate. Read this document as a migration/design rationale, not as an untouched future plan.
+> Current implementation note: much of this integration has already happened. ChatRunner no longer represents the only tool-using path; the native AgentLoop runtime, DurableLoop phases, and task execution all share the built-in tool substrate. Read this document as a migration/design rationale, not as an untouched future plan.
 
 ## 1. Overview
 
 PulSeed has two existing tool systems that need to be unified:
 
-**System A** (`src/tools/`): ITool class-based registry with ToolRegistry, ToolExecutor, ToolPermissionManager. Used by CoreLoop and ObservationEngine. Contains 20+ tools across `filesystem/`, `git/`, `state/`, `network/`, `system/`, `meta/` categories.
+**System A** (`src/tools/`): ITool class-based registry with ToolRegistry, ToolExecutor, ToolPermissionManager. Used by DurableLoop and ObservationEngine. Contains 20+ tools across `filesystem/`, `git/`, `state/`, `network/`, `system/`, `meta/` categories.
 
 **System B** (`src/interface/chat/`): Raw ToolDefinition JSON schemas used by ChatRunner for LLM function calling. Contains 6 self-knowledge read tools and 7 mutation tools.
 
@@ -22,7 +22,7 @@ PulSeed has two existing tool systems that need to be unified:
 └──────────┬───────────────┬───────────┘
            │               │
     ┌──────▼──────┐  ┌─────▼──────────────┐
-    │  CoreLoop   │  │  ChatRunner         │
+    │  DurableLoop   │  │  ChatRunner         │
     │  Goal-driven│  │  LLM function calls │
     │  (existing) │  │  via toToolDef()    │
     └─────────────┘  └────────────────────┘
@@ -30,7 +30,7 @@ PulSeed has two existing tool systems that need to be unified:
 
 **AgentLoop** (interactive): ChatRunner exposes ITool instances as ToolDefinition JSON for LLM function calling. LLM freely picks tools.
 
-**CoreLoop** (autonomous): deterministic control plus bounded agentic phases using tool policy and ToolExecutor-backed execution.
+**DurableLoop** (autonomous): deterministic control plus bounded agentic phases using tool policy and ToolExecutor-backed execution.
 
 ---
 
@@ -246,11 +246,11 @@ Add tools not currently in System A, using ITool interface.
 
 Files: ~5-7 new tools in existing categories | Tests: unit tests per tool + AgentLoop integration
 
-**Phase B: CoreLoop Migration**
+**Phase B: DurableLoop Migration**
 
-Refactor CoreLoop to call tool primitives via ToolExecutor instead of module methods directly. Both loops verified sharing tools correctly.
+Refactor DurableLoop to call tool primitives via ToolExecutor instead of module methods directly. Both loops verified sharing tools correctly.
 
-Files: 3-5 modified (core-loop.ts, observation-engine.ts) | Tests: CoreLoop integration tests
+Files: 3-5 modified (durable-loop.ts, observation-engine.ts) | Tests: DurableLoop integration tests
 
 **Phase C: Concurrency & Polish**
 
@@ -286,7 +286,7 @@ Files: 2-3 modified | Tests: concurrency, overflow
 | src/tools/interaction/ask-human.ts | A | Create |
 | src/tools/interaction/create-plan.ts | A | Create |
 | src/tools/interaction/read-plan.ts | A | Create |
-| src/orchestrator/loop/core-loop.ts | B | Modify |
+| src/orchestrator/loop/durable-loop.ts | B | Modify |
 | src/platform/observation/observation-engine.ts | B | Modify |
 
 ---
@@ -296,5 +296,5 @@ Files: 2-3 modified | Tests: concurrency, overflow
 - **Unit**: each new tool tested independently with mock dependencies (same pattern as existing state/ tests)
 - **Migration**: chat-runner and task/state integration tests preserve the same behavior through the registry-backed tools
 - **Integration (ChatRunner)**: LLM tool calls routed through registry produce same results as before
-- **Integration (CoreLoop)**: CoreLoop with tool layer, full round-trip (Phase B)
+- **Integration (DurableLoop)**: DurableLoop with tool layer, full round-trip (Phase B)
 - **Concurrency**: parallel read-only tools execute simultaneously via existing concurrency.ts (Phase C)

--- a/docs/design/execution/multi-agent-delegation.md
+++ b/docs/design/execution/multi-agent-delegation.md
@@ -3,7 +3,7 @@
 > Issue #33. Defines how PulSeed delegates a single task across multiple agents with divided responsibilities.
 > Core principle: **Define appropriate roles and delegate to appropriate capabilities. Roles are domain-agnostic and extensible.**
 
-> Current implementation note: the codebase layout referenced below has since moved under `src/orchestrator/` and `src/interface/`. Also, native `agent_loop` now covers a substantial part of bounded execution. Read this document as a design for larger multi-agent/task-group orchestration on top of the current CoreLoop + AgentLoop baseline.
+> Current implementation note: the codebase layout referenced below has since moved under `src/orchestrator/` and `src/interface/`. Also, native `agent_loop` now covers a substantial part of bounded execution. Read this document as a design for larger multi-agent/task-group orchestration on top of the current DurableLoop + AgentLoop baseline.
 
 ---
 
@@ -187,7 +187,7 @@ If a task has the `irreversible: true` flag, approval must be obtained before ex
 
 ### Pipeline persistence
 
-`PipelineExecutor` writes `PipelineState` to disk via `StateManager` after each stage completes. On restart, `CoreLoop` detects pipelines with `status: "interrupted"` and resumes from `current_stage_index`.
+`PipelineExecutor` writes `PipelineState` to disk via `StateManager` after each stage completes. On restart, `DurableLoop` detects pipelines with `status: "interrupted"` and resumes from `current_stage_index`.
 
 Idempotency guarantee: before executing a stage, check whether the `idempotency_key` (`${task_id}:${stage_index}:${attempt}`) already exists in `completed_stages`; if so, skip.
 
@@ -244,7 +244,7 @@ Flow of `runPipelineTaskCycle()`:
 
 **Modified files:**
 - `src/orchestrator/execution/task/task-generation.ts` — TaskGroup + plan generation. LLM evaluates task complexity and decides between single task vs TaskGroup.
-- `src/orchestrator/loop/core-loop.ts` — `runOneIteration()` detects TaskGroup and hands it to `ParallelExecutor`
+- `src/orchestrator/loop/durable-loop.ts` — `runOneIteration()` detects TaskGroup and hands it to `ParallelExecutor`
 - `src/orchestrator/execution/pipeline-executor.ts` — Plan Approval Gate + three-strike escalation + `strategy_id` feedback
 
 **Tests:** `tests/execution/parallel-executor.test.ts`

--- a/docs/design/execution/tend-command.md
+++ b/docs/design/execution/tend-command.md
@@ -1,10 +1,10 @@
-# `/tend` — Chat-to-CoreLoop Handoff Command
+# `/tend` — Chat-to-DurableLoop Handoff Command
 
 > Current implementation note: chat/TUI are now built on a stronger native AgentLoop path, and daemon/runtime ownership has evolved since this document was written. Treat `/tend` here as a handoff pattern from bounded chat execution into long-lived goal control, not as a precise wire-level description of the current UI/runtime code.
 
 ## 1. Overview
 
-`/tend` is a slash command within PulSeed's chat/TUI mode that transitions a conversational context into autonomous CoreLoop execution via the daemon.
+`/tend` is a slash command within PulSeed's chat/TUI mode that transitions a conversational context into autonomous DurableLoop execution via the daemon.
 
 **Metaphor**: "Tend to this goal" — let PulSeed autonomously nurture a goal, like a gardener tending seedlings.
 
@@ -16,7 +16,7 @@ User chats in TUI
   → Auto-generates a Goal from the summary
   → "テストカバレッジ90%達成 で開始します。いいですか？"
   → User approves
-  → Daemon starts CoreLoop for the goal (background)
+  → Daemon starts DurableLoop for the goal (background)
   → Chat remains interactive — not blocked
   → Progress notifications flow into chat:
       🌱 [tend] goal-abc: Iteration 3/10 — gap 0.72→0.45
@@ -78,7 +78,7 @@ Display the generated goal to the user:
 If user declines, return to chat. User can refine via conversation and retry `/tend`.
 
 ### Step 4: Daemon Launch
-Start CoreLoop for the goal as a daemon process:
+Start DurableLoop for the goal as a daemon process:
 ```typescript
 // Reuse existing daemon infrastructure
 await daemonClient.start({ goalId: goal.id, maxIterations });
@@ -125,7 +125,7 @@ Tasks executed:
 
 | Command | Purpose | Execution |
 |---------|---------|-----------|
-| `pulseed run --goal <id>` | CLI one-shot CoreLoop | Foreground, blocking |
+| `pulseed run --goal <id>` | CLI one-shot DurableLoop | Foreground, blocking |
 | `pulseed start --goal <id>` | Start daemon | Background, no chat |
 | `/tend` | Chat→daemon handoff | Background, with chat notifications |
 | `pulseed improve` | Analyze + suggest + optionally run | Foreground, blocking |
@@ -166,7 +166,7 @@ Tasks executed:
 ┌─────────────────────────────────────────┐
 │  Daemon Process                         │
 │  ┌───────────────────────────────────┐  │
-│  │  CoreLoop.run(goalId)             │  │
+│  │  DurableLoop.run(goalId)             │  │
 │  │  observe→gap→score→task→execute   │  │
 │  └──────────┬────────────────────────┘  │
 │             │ emits                     │
@@ -209,7 +209,7 @@ Tasks executed:
 | Scenario | Behavior |
 |----------|----------|
 | Daemon already running for goal | Show status, ask if user wants to restart |
-| Daemon not installed/available | Fall back to in-process CoreLoop (blocking, with warning) |
+| Daemon not installed/available | Fall back to in-process DurableLoop (blocking, with warning) |
 | No chat history (empty `/tend`) | Ask user to describe what they want first |
 | Goal generation fails (LLM error) | Show error, suggest manual goal creation |
 | EventServer unreachable | Degrade gracefully — no notifications, suggest `pulseed status` |

--- a/docs/design/goal/goal-refinement-pipeline.md
+++ b/docs/design/goal/goal-refinement-pipeline.md
@@ -51,7 +51,7 @@ refine(goal, config):
      b. config.tokenBudget exhausted → force leaf
      c. Already has validated dimensions (manual or prior negotiate) → skip
 
-  5. Runtime fallback (called from CoreLoop, not during initial refine):
+  5. Runtime fallback (called from DurableLoop, not during initial refine):
      Observation failure on a leaf → re-refine that leaf with updated context
 ```
 
@@ -166,7 +166,7 @@ class GoalRefiner {
 | Caller | Current | After |
 |--------|---------|-------|
 | `goal add "desc"` CLI | `--negotiate` flag → `negotiate()`, `--tree` flag → `decomposeGoal()` | Single `refine()` call. `--no-refine` to skip. |
-| `run --tree` (CoreLoop) | Auto-calls `decomposeGoal()` if no children | Calls `refine()` if goal has no validated leaves |
+| `run --tree` (DurableLoop) | Auto-calls `decomposeGoal()` if no children | Calls `refine()` if goal has no validated leaves |
 | `renegotiate()` | Standalone 6-step flow | Unchanged (renegotiation is for existing goals with prior observations) |
 | Stall detection | Triggers `renegotiate()` | Triggers `reRefineLeaf()` for observation-failure stalls, `renegotiate()` for progress stalls |
 
@@ -183,7 +183,7 @@ Each step is independently testable and deployable. No breaking changes until st
 3. **Add GoalRefiner** — `src/orchestrator/goal/goal-refiner.ts` implementing `refine()`. Calls GoalNegotiator and GoalTreeManager internally. Integration tests against mock LLM. Old paths still work.
 4. **Wire CLI** — `goal add` calls `refine()` by default. `--negotiate` and `--tree` flags become aliases / deprecated. `--no-refine` skips refinement entirely.
 
-5. **Wire CoreLoop** — `tree-loop-runner` calls `refine()` instead of raw `decomposeGoal()`. Add `reRefineLeaf()` path to stall handler.
+5. **Wire DurableLoop** — `tree-loop-runner` calls `refine()` instead of raw `decomposeGoal()`. Add `reRefineLeaf()` path to stall handler.
 
 6. **Deprecation** — Mark standalone `negotiate()` for new goals and standalone `decomposeGoal()` as internal. Keep them callable for backward compat and renegotiation.
 

--- a/docs/design/goal/goal-tree.md
+++ b/docs/design/goal/goal-tree.md
@@ -2,13 +2,13 @@
 
 > Related: `portfolio-management.md`, `gap-calculation.md`, `satisficing.md`, `drive-scoring.md`, `session-and-context.md`
 
-> Current implementation note: the goal tree is now scheduled by CoreLoop together with next-iteration directives emitted from bounded agentic phases. Tree nodes are not just passive decomposition artifacts; the scheduler can prefer nodes that carry pending knowledge-refresh or replanning intent.
+> Current implementation note: the goal tree is now scheduled by DurableLoop together with next-iteration directives emitted from bounded agentic phases. Tree nodes are not just passive decomposition artifacts; the scheduler can prefer nodes that carry pending knowledge-refresh or replanning intent.
 
 ---
 
 ## 1. Overview
 
-The goal tree is an **N-layer automatic goal decomposition system**. It recursively decomposes ambiguous top-level goals into concrete sub-goals, while CoreLoop schedules which node should receive the next bounded iteration.
+The goal tree is an **N-layer automatic goal decomposition system**. It recursively decomposes ambiguous top-level goals into concrete sub-goals, while DurableLoop schedules which node should receive the next bounded iteration.
 
 ```
 User goal (root)
@@ -21,7 +21,7 @@ User goal (root)
         └── Sub-goal B-1 (depth 2 / leaf)
 ```
 
-**Purpose of decomposition**: Passing an abstract top-level goal directly to bounded task execution makes task generation too vague. The goal tree resolves goal ambiguity into nodes that CoreLoop can schedule, verify, and aggregate over time.
+**Purpose of decomposition**: Passing an abstract top-level goal directly to bounded task execution makes task generation too vague. The goal tree resolves goal ambiguity into nodes that DurableLoop can schedule, verify, and aggregate over time.
 
 ---
 

--- a/docs/design/infrastructure/daemon-client-architecture.md
+++ b/docs/design/infrastructure/daemon-client-architecture.md
@@ -4,7 +4,7 @@
 **Author:** Auto-generated
 **Date:** 2026-04-05
 
-> Current implementation note: the runtime has evolved beyond the exact TUI/daemon split described below. TUI, chat, daemon, and schedule flows now all sit on top of the shared CoreLoop + AgentLoop runtime stack. Read this document as a direction for daemon/client ownership, not a line-by-line map of the current interface code.
+> Current implementation note: the runtime has evolved beyond the exact TUI/daemon split described below. TUI, chat, daemon, and schedule flows now all sit on top of the shared DurableLoop + AgentLoop runtime stack. Read this document as a direction for daemon/client ownership, not a line-by-line map of the current interface code.
 
 ## Overview
 
@@ -26,7 +26,7 @@ This design makes the daemon the single owner of long-lived goal execution, with
               │   │ EventServer     │ │
               │   │ :41700          │ │
               │   ├─────────────────┤ │
-              │   │ CoreLoop(s)     │ │
+              │   │ DurableLoop(s)     │ │
               │   │ per-goal        │ │
               │   ├─────────────────┤ │
               │   │ ApprovalQueue   │ │
@@ -48,7 +48,7 @@ This design makes the daemon the single owner of long-lived goal execution, with
 
 | Event | Data | When |
 |-------|------|------|
-| `iteration_complete` | `{ goalId, iteration, gapScore, driveScore }` | After each CoreLoop iteration |
+| `iteration_complete` | `{ goalId, iteration, gapScore, driveScore }` | After each DurableLoop iteration |
 | `goal_updated` | `{ goalId, status, progress }` | Goal state changes |
 | `approval_required` | `{ requestId, goalId, task, description }` | Daemon needs human approval; clients may display status only |
 | `approval_resolved` | `{ requestId, approved }` | Approval answered |
@@ -82,7 +82,7 @@ Conversational approval flow:
 1. Runtime encounters an action requiring approval.
 2. `ApprovalBroker` writes a pending approval record with origin metadata for channel, conversation, session, user, and reply target.
 3. The broker delivers the approval prompt through the originating conversation adapter.
-4. CoreLoop or runtime-control execution blocks while the approval remains pending.
+4. DurableLoop or runtime-control execution blocks while the approval remains pending.
 5. A reply in the same conversation is classified as `approve`, `reject`, `clarify`, or `unknown` with the active approval context.
 6. Only an origin-matched `approve` or `reject` resolves the stored approval; `clarify` and `unknown` keep the original record pending.
 7. The broker emits status/audit events such as `approval_required` and `approval_resolved`.
@@ -133,7 +133,7 @@ Startup flow:
 
 ## Migration Strategy
 
-**Backward compatibility:** Keep `pulseed run --goal <id>` as standalone CoreLoop execution (no daemon). Only `pulseed` (TUI) uses daemon mode.
+**Backward compatibility:** Keep `pulseed run --goal <id>` as standalone DurableLoop execution (no daemon). Only `pulseed` (TUI) uses daemon mode.
 
 **Standalone fallback:** If daemon can't start (port conflict, etc.), TUI falls back to current standalone mode with a warning.
 

--- a/docs/design/infrastructure/llm-fault-tolerance.md
+++ b/docs/design/infrastructure/llm-fault-tolerance.md
@@ -326,11 +326,11 @@ On task verification failure (verdict = "fail" or "partial"):
 
 ---
 
-### 4.8 CoreLoop Checkpoint (AutoGen-inspired)
+### 4.8 DurableLoop Checkpoint (AutoGen-inspired)
 
-**Purpose**: Allow recovery to the last known-good state after a crash or interruption during CoreLoop execution.
+**Purpose**: Allow recovery to the last known-good state after a crash or interruption during DurableLoop execution.
 
-**Current state**: If CoreLoop crashes mid-loop, intermediate state is lost. An auto-archive mechanism exists (moves goal state to `~/.pulseed/archive/<goalId>/` on completion), but there are no mid-loop checkpoints.
+**Current state**: If DurableLoop crashes mid-loop, intermediate state is lost. An auto-archive mechanism exists (moves goal state to `~/.pulseed/archive/<goalId>/` on completion), but there are no mid-loop checkpoints.
 
 **Definition**:
 
@@ -345,15 +345,15 @@ Contents:
   - timestamp: ISO format
 
 Recovery behavior:
-  - On CoreLoop startup, check for the existence of checkpoint.json
+  - On DurableLoop startup, check for the existence of checkpoint.json
   - If found, restore state from dimension_snapshot and trust_snapshot
   - Treat tasks after last_verified_task_id as pending re-execution
   - WARN log: "Resuming from checkpoint (cycle ${cycle_number}, task ${last_verified_task_id})"
 ```
 
 **Implementation locations**:
-- Checkpoint write: after successful verify in `src/core/core-loop.ts`
-- Checkpoint read: at loop startup in `src/core/core-loop.ts`
+- Checkpoint write: after successful verify in `src/orchestrator/loop/durable-loop.ts`
+- Checkpoint read: at loop startup in `src/orchestrator/loop/durable-loop.ts`
 
 **Behavior when guard fires**: Normal operation (this is a recovery mechanism, not a guard). If no checkpoint exists, performs a normal cold start.
 
@@ -374,7 +374,7 @@ Recovery behavior:
 | P1 | 4.2 Duplicate task guard | `task-generation.ts` |
 | P1 | 4.6 `completion_judger` Zod validation | `task-verifier.ts` |
 | P1 | 4.7 Verification failure injection into next cycle | `task-verifier.ts`, `task-generation.ts` |
-| P1 | 4.8 CoreLoop checkpoint | `core-loop.ts` |
+| P1 | 4.8 DurableLoop checkpoint | `durable-loop.ts` |
 | P2 | 4.5 `dimension_updates` direction check | `task-verifier.ts` + schema change |
 
 ---

--- a/docs/design/infrastructure/multi-channel-runtime.md
+++ b/docs/design/infrastructure/multi-channel-runtime.md
@@ -173,7 +173,7 @@ The Executor replaces the sequential goal loop in `daemon-runner.ts` with a supe
 
 The **LoopSupervisor** is the entry point. It starts when the daemon starts and stops when the daemon stops. Its responsibilities: maintain the worker pool, pull activation events from the Queue, assign events to workers, restart crashed workers, and report health.
 
-A **GoalWorker** wraps exactly one `CoreLoop` instance running against one goal. When the LoopSupervisor assigns a `goal_activated` event to a worker, the worker calls `coreLoop.run(goalId)` and waits for the result. While the worker is running, it is unavailable for other events. When it finishes, it signals readiness back to the Supervisor, which assigns the next pending activation.
+A **GoalWorker** wraps exactly one `DurableLoop` instance running against one goal. When the LoopSupervisor assigns a `goal_activated` event to a worker, the worker calls `coreLoop.run(goalId)` and waits for the result. While the worker is running, it is unavailable for other events. When it finishes, it signals readiness back to the Supervisor, which assigns the next pending activation.
 
 ### Goal Exclusivity Invariant
 
@@ -183,7 +183,7 @@ A **GoalWorker** wraps exactly one `CoreLoop` instance running against one goal.
 
 **Coalescing**: If a `goal_activated` event arrives for an already-running goal, the event is coalesced: the existing worker is notified to extend its run (e.g., reset its iteration cap), rather than a duplicate worker being spawned. The event is not re-queued.
 
-This invariant is distinct from the per-goal advisory locks in the State layer (section 6). The State locks protect concurrent file writes within a single goal's directory. The Goal Exclusivity Invariant prevents a higher-level problem: two CoreLoop instances issuing conflicting decisions about the same goal simultaneously.
+This invariant is distinct from the per-goal advisory locks in the State layer (section 6). The State locks protect concurrent file writes within a single goal's directory. The Goal Exclusivity Invariant prevents a higher-level problem: two DurableLoop instances issuing conflicting decisions about the same goal simultaneously.
 
 GoalWorkers are **pool-allocated**: the Supervisor spawns a generic worker and assigns it a goal at activation time. When the goal's loop iteration completes and no immediate re-activation is pending, the worker is returned to the pool. There is no persistent affinity between a worker instance and a goal.
 

--- a/docs/design/infrastructure/plugin-architecture.md
+++ b/docs/design/infrastructure/plugin-architecture.md
@@ -16,7 +16,7 @@
 
 In Claude Code and legacy tool-centric systems, plugins are "tools the user explicitly calls." The user runs a command and the tool responds. The user is the active agent.
 
-PulSeed plugins are different. PulSeed's long-lived control runtime runs autonomously without user instructions. Therefore, plugins must also be things **PulSeed autonomously selects and integrates into CoreLoop, AgentLoop, or runtime services**. Not requiring user instructions like "please call this plugin" is the starting point of PulSeed's plugin design.
+PulSeed plugins are different. PulSeed's long-lived control runtime runs autonomously without user instructions. Therefore, plugins must also be things **PulSeed autonomously selects and integrates into DurableLoop, AgentLoop, or runtime services**. Not requiring user instructions like "please call this plugin" is the starting point of PulSeed's plugin design.
 ```
 Claude Code / legacy tool plugins:
   User → "Search Jira" → Jira plugin → returns result to user
@@ -34,7 +34,7 @@ What belongs in PulSeed's core should be minimal. Use the following criteria:
 
 | Criterion | Location | Example |
 |-----------|----------|----|
-| Essential to the core control/execution substrate | Core | CoreLoop, AgentLoop, ToolRegistry, GapCalculator, DriveScorer |
+| Essential to the core control/execution substrate | Core | DurableLoop, AgentLoop, ToolRegistry, GapCalculator, DriveScorer |
 | Zero external dependencies, highly generic | Can be bundled with core | FileDataSourceAdapter, FileExistenceDataSourceAdapter |
 | Depends on specific external services or SaaS | Plugin | JiraAdapter, SlackNotifier, LinearDataSource |
 | Future expansion expected but not currently needed | Plugin candidate | Webhook adapter, custom LLM backend |
@@ -702,7 +702,7 @@ Clarifying how each existing module connects to the plugin architecture.
 
 | Module | Changes | Connection method |
 |--------|---------|------------------|
-| `CoreLoop` | No change | Used indirectly via registered adapters and data sources |
+| `DurableLoop` | No change | Used indirectly via registered adapters and data sources |
 | `ObservationEngine` | Add plugin matching to `findDataSourceForDimension()` | Via `DataSourceRegistry` (extended in Phase 2) |
 | `TaskLifecycle` | No change | Via `AdapterRegistry` (plugins auto-registered) |
 | `NotificationDispatcher` | Add routing from `NotifierRegistry` | Calls `NotifierRegistry.findForEvent()` |
@@ -710,10 +710,10 @@ Clarifying how each existing module connects to the plugin architecture.
 | `TrustManager` | Add plugin trust_score tracking | Updates `PluginState.trust_score` (Phase 3) |
 | `KnowledgeManager` | Record and share plugin effectiveness | Receives `onPluginSuccess/Failure()` hooks (Phase 3) |
 
-### Full picture from CoreLoop
+### Full picture from DurableLoop
 
 ```
-CoreLoop (unchanged)
+DurableLoop (unchanged)
     │
     ├── ObservationEngine
     │     └── DataSourceRegistry (includes plugin data_sources)

--- a/docs/design/infrastructure/schedule-engine.md
+++ b/docs/design/infrastructure/schedule-engine.md
@@ -5,7 +5,7 @@
 
 > Related: `plugin-architecture.md`, `reporting.md`, `daemon-client-architecture.md`, `docs/design/core/observation.md`, `docs/design/execution/data-source.md`
 
-> Current implementation note: scheduling now coexists with the dual-loop architecture. A scheduled activation may ultimately drive CoreLoop, which in turn may invoke bounded AgentLoop phases and native task execution. Read "full CoreLoop" in this document as "long-lived control path," not as a single flat sequence without internal agentic phases.
+> Current implementation note: scheduling now coexists with the dual-loop architecture. A scheduled activation may ultimately drive DurableLoop, which in turn may invoke bounded AgentLoop phases and native task execution. Read "full DurableLoop" in this document as "long-lived control path," not as a single flat sequence without internal agentic phases.
 
 ---
 
@@ -13,7 +13,7 @@
 
 ### Why ScheduleEngine
 
-PulSeed already has a CoreLoop that runs continuously when the daemon is active. But "continuously" is not the same as "proactively." The CoreLoop processes goals that are already active — it does not initiate new observations, generate unprompted reports, or monitor external systems on a cadence.
+PulSeed already has a DurableLoop that runs continuously when the daemon is active. But "continuously" is not the same as "proactively." The DurableLoop processes goals that are already active — it does not initiate new observations, generate unprompted reports, or monitor external systems on a cadence.
 
 The ScheduleEngine fills this gap. It introduces time-based triggers that cause PulSeed to act at specific moments: checking email every 30 minutes, generating a morning summary at 8am, running a weekly code quality review, or pinging a health endpoint every minute.
 
@@ -35,7 +35,7 @@ PulSeed ScheduleEngine:
   Cost model: most executions cost zero LLM tokens
 ```
 
-The key insight is that not all scheduled actions require the same weight of processing. A health check does not need an LLM. An email check only needs an LLM when something important arrives. A morning summary always needs an LLM. A weekly code review needs the full CoreLoop. The 4-layer architecture matches processing weight to the task.
+The key insight is that not all scheduled actions require the same weight of processing. A health check does not need an LLM. An email check only needs an LLM when something important arrives. A morning summary always needs an LLM. A weekly code review needs the full DurableLoop. The 4-layer architecture matches processing weight to the task.
 
 ### "Thin core, extend with plugins" principle
 
@@ -57,9 +57,9 @@ The ScheduleEngine core handles scheduling mechanics (when to fire) and layer di
 
 ```
 DaemonRunner
-  |-- CoreLoop (existing -- goal pursuit)
+  |-- DurableLoop (existing -- goal pursuit)
   +-- ScheduleEngine (proactive scheduling + internal future activations)
-       |-- GoalTrigger  -> CoreLoop.run(goal)
+       |-- GoalTrigger  -> DurableLoop.run(goal)
        |-- Probe        -> DataSource.fetch() -> conditional LLM -> maybe escalate
        |-- Cron         -> LLM processing every time (human rhythm)
        +-- Heartbeat    -> mechanical check only -> escalate on failure
@@ -78,7 +78,7 @@ Legacy cron task categories map cleanly to ScheduleEngine layers:
 |------------------------|---------------------|-----------|
 | `reflection` | Cron | Always produces LLM output |
 | `consolidation` | Cron | Always produces LLM output |
-| `custom` | Cron or GoalTrigger | Depends on whether full CoreLoop is needed |
+| `custom` | Cron or GoalTrigger | Depends on whether full DurableLoop is needed |
 
 Migration status: legacy cron tasks are migrated into `schedules.json`, and the
 daemon now runs ScheduleEngine as the single runtime for scheduled work.
@@ -114,9 +114,9 @@ Operator visibility follows that split:
 
 ### 3.1 GoalTrigger (Heavy)
 
-**Weight**: Full CoreLoop execution. High LLM cost.
+**Weight**: Full DurableLoop execution. High LLM cost.
 
-**Behavior**: Triggers `CoreLoop.run(goal)` on schedule. The goal must be pre-defined in PulSeed's goal store. The GoalTrigger simply activates it at the scheduled time.
+**Behavior**: Triggers `DurableLoop.run(goal)` on schedule. The goal must be pre-defined in PulSeed's goal store. The GoalTrigger simply activates it at the scheduled time.
 
 **Use cases**:
 - Weekly code quality review ("Run code quality review every Monday at 9am")
@@ -127,7 +127,7 @@ Operator visibility follows that split:
 ```
 Schedule fires
   -> Load goal definition from StateManager
-  -> CoreLoop.run(goalId, { maxIterations })
+  -> DurableLoop.run(goalId, { maxIterations })
   -> LoopResult recorded in goal history
   -> NotificationDispatcher.dispatch(goal_progress event)
 ```
@@ -137,12 +137,12 @@ Schedule fires
 {
   layer: "goal_trigger",
   goal_id: string,              // existing goal to activate
-  max_iterations: number,       // cap CoreLoop iterations (default: 10)
+  max_iterations: number,       // cap DurableLoop iterations (default: 10)
   skip_if_active: boolean,      // skip if goal is already being pursued (default: true)
 }
 ```
 
-**Cost**: 5,000-50,000+ tokens per execution (full CoreLoop with LLM observation, gap analysis, task generation).
+**Cost**: 5,000-50,000+ tokens per execution (full DurableLoop with LLM observation, gap analysis, task generation).
 
 ### 3.2 Probe (Medium, conditional)
 
@@ -191,7 +191,7 @@ Schedule fires
 }
 ```
 
-**Cost**: 0 tokens for most executions. 500-2,000 tokens when change is detected (LLM significance analysis). Full CoreLoop cost if escalated to GoalTrigger.
+**Cost**: 0 tokens for most executions. 500-2,000 tokens when change is detected (LLM significance analysis). Full DurableLoop cost if escalated to GoalTrigger.
 
 ### 3.3 Cron (Medium, guaranteed execution)
 
@@ -492,9 +492,9 @@ for (const entry of dueEntries) {
 }
 ```
 
-### 6.2 CoreLoop
+### 6.2 DurableLoop
 
-GoalTrigger invokes `CoreLoop.run(goalId, { maxIterations })` directly. No changes to CoreLoop are required — it already accepts a `goalId` and options.
+GoalTrigger invokes `DurableLoop.run(goalId, { maxIterations })` directly. No changes to DurableLoop are required — it already accepts a `goalId` and options.
 
 ### 6.3 ObservationEngine and DataSourceAdapter
 
@@ -509,7 +509,7 @@ ScheduleEngine dispatches notifications through the existing `NotificationDispat
 - Probe: change detection notifications
 - Cron: report delivery notifications
 - Heartbeat: failure and escalation notifications
-- GoalTrigger: goal progress notifications (handled by CoreLoop internally)
+- GoalTrigger: goal progress notifications (handled by DurableLoop internally)
 
 New notification event types added:
 
@@ -531,7 +531,7 @@ Cron layer integrates with `ReportingEngine` when `output_format` is `"report"` 
 | Module | Changes required | Integration method |
 |--------|-----------------|-------------------|
 | `DaemonRunner` | Add ScheduleEngine initialization and tick | Direct dependency injection |
-| `CoreLoop` | No change | Called by GoalTrigger via `coreLoop.run()` |
+| `DurableLoop` | No change | Called by GoalTrigger via `coreLoop.run()` |
 | `ObservationEngine` | No change | Probe queries data sources through DataSourceRegistry |
 | `DataSourceAdapter` | No change | Probe calls `query()` on registered adapters |
 | `NotificationDispatcher` | Add 4 new event types | Called by all layers for notifications |
@@ -869,14 +869,14 @@ ScheduleEngine tracks cumulative token usage per entry in `total_tokens_used`. T
 **Scope**:
 - Cron layer: prompt template interpolation, context gathering, LLM execution
 - Cron + ReportingEngine integration
-- GoalTrigger layer: CoreLoop.run() invocation
+- GoalTrigger layer: DurableLoop.run() invocation
 - GoalTrigger skip_if_active logic
 - Cost tracking and budget controls
 - CLI: `pulseed schedule history`, `pulseed schedule cost`
 
 **Completion criteria**:
 - Cron produces LLM-generated output on schedule
-- GoalTrigger activates CoreLoop for a goal on schedule
+- GoalTrigger activates DurableLoop for a goal on schedule
 - Cost tracking accurately reflects token usage per entry
 - Budget limits auto-disable entries when exceeded
 
@@ -901,10 +901,10 @@ ScheduleEngine tracks cumulative token usage per entry in `total_tokens_used`. T
 | Principle | Concrete design decision |
 |-----------|------------------------|
 | PulSeed acts on time, not just on demand | ScheduleEngine adds proactive time-based triggers to the daemon |
-| Match processing weight to the task | 4 layers: Heartbeat (zero cost) to Probe (conditional) to Cron (always LLM) to GoalTrigger (full CoreLoop) |
+| Match processing weight to the task | 4 layers: Heartbeat (zero cost) to Probe (conditional) to Cron (always LLM) to GoalTrigger (full DurableLoop) |
 | Most checks cost nothing | Heartbeat and Probe (no change) use zero LLM tokens |
 | Escalation, not duplication | Lower layers escalate to higher layers rather than reimplementing their logic |
-| Reuse existing infrastructure | Probe uses DataSourceAdapter, GoalTrigger uses CoreLoop, notifications use NotificationDispatcher |
+| Reuse existing infrastructure | Probe uses DataSourceAdapter, GoalTrigger uses DurableLoop, notifications use NotificationDispatcher |
 | Extend with plugins | External schedule sources (calendar, webhook) are plugins, not core |
 | Cost transparency | Per-entry token tracking, budget controls, cost reporting CLI |
 | Failures do not stop PulSeed | Schedule entry failures are logged and retried, not fatal |

--- a/docs/design/infrastructure/token-optimization.md
+++ b/docs/design/infrastructure/token-optimization.md
@@ -2,7 +2,7 @@
 
 > Token cost is the primary barrier to PulSeed adoption. A single loop iteration makes 3-7 LLM calls, meaning a goal with 3 dimensions and 10 iterations costs 50-70 API calls before any real work is done. This document defines three independent optimization pillars that together reduce LLM token consumption by an estimated 60-80% without degrading observation quality or loop correctness.
 
-> Current implementation note: this document predates the current dual-loop architecture and the reorganized source tree. Optimizations here now apply across CoreLoop, bounded AgentLoop phases, chat compaction, and native task execution rather than only a single flat loop body.
+> Current implementation note: this document predates the current dual-loop architecture and the reorganized source tree. Optimizations here now apply across DurableLoop, bounded AgentLoop phases, chat compaction, and native task execution rather than only a single flat loop body.
 
 ---
 
@@ -219,7 +219,7 @@ After 5 consecutive skips, the full loop runs regardless of state diff. This int
 
 **Files to change:**
 - `src/loop/state-diff.ts` -- NEW file, implements `StateDiffCalculator`
-- `src/orchestrator/loop/core-loop.ts` -- add diff check after observation phase, before gap calculation
+- `src/orchestrator/loop/durable-loop.ts` -- add diff check after observation phase, before gap calculation
 - `src/types/loop.ts` -- add `IterationSnapshot` and `StateDiffThresholds` schemas
 **Integration point in `runOneIteration`:**
 
@@ -439,7 +439,7 @@ Estimated effort: 2-3 days. Requires integration tests with real file-system cha
 
 Scope:
 1. Implement `StateDiffCalculator`
-2. Integrate into `core-loop.ts` after observation phase
+2. Integrate into `durable-loop.ts` after observation phase
 3. Add consecutive skip limit and interaction with stall detection
 4. Add integration tests for skip behavior
 

--- a/docs/design/knowledge/hypothesis-verification.md
+++ b/docs/design/knowledge/hypothesis-verification.md
@@ -21,7 +21,7 @@
 ### PulSeedtion for Applying This to PulSeed
 
 PulSeed's orchestration runtime is structurally sound, but the following questions remain important:
-1. **No defined action after stall detection** — Even when StallDetector determines "it has stalled," CoreLoop has only limited branching
+1. **No defined action after stall detection** — Even when StallDetector determines "it has stalled," DurableLoop has only limited branching
 2. **Zero meta-knowledge for strategy decisions** — There is no record of which strategies were effective for similar goals in the past, and no way to look that up
 3. **Cannot distinguish convergence from stagnation** — An absolute threshold check on `gap < threshold` alone cannot handle the case where progress is "close but not quite there"
 
@@ -31,7 +31,7 @@ AutoResearchClaw's approach directly addresses these three issues. However, PulS
 
 ## Improvement 1: Structured PIVOT/REFINE Decision
 
-**Affected modules**: `stall-detector.ts`, `strategy-manager.ts`, `core-loop.ts`, `types/`
+**Affected modules**: `stall-detector.ts`, `strategy-manager.ts`, `durable-loop.ts`, `types/`
 **Effort**: Medium (2–3 days)
 
 ### Current Problem
@@ -86,7 +86,7 @@ interface StrategyDefinition {
 }
 ```
 
-### CoreLoop Changes
+### DurableLoop Changes
 
 Extend the existing stall branch to three directions:
 

--- a/docs/design/knowledge/knowledge-acquisition.md
+++ b/docs/design/knowledge/knowledge-acquisition.md
@@ -5,7 +5,7 @@
 
 > Related: `observation.md`, `task-lifecycle.md`, `execution-boundary.md`, `session-and-context.md`, `curiosity.md`, `stall-detection.md`
 
-> Current implementation note: knowledge acquisition now spans both deterministic CoreLoop control and bounded agentic phases. The current runtime can use direct tools, Soil, memory recall, and native AgentLoop phases before falling back to heavier investigation work.
+> Current implementation note: knowledge acquisition now spans both deterministic DurableLoop control and bounded agentic phases. The current runtime can use direct tools, Soil, memory recall, and native AgentLoop phases before falling back to heavier investigation work.
 
 ---
 
@@ -13,7 +13,7 @@
 
 ### Role in the Core Loop
 
-Knowledge acquisition cuts across CoreLoop control and bounded agentic execution, but it is triggered primarily at two points.
+Knowledge acquisition cuts across DurableLoop control and bounded agentic execution, but it is triggered primarily at two points.
 
 ```
 Observation / evidence collection -> gap interpretation -> replanning / strategy selection -> task definition
@@ -41,7 +41,7 @@ Knowledge acquisition is a means to achieving a goal, not an end in itself. PulS
 
 ## 2. Detecting Knowledge Gaps
 
-Knowledge gaps are detected via multiple signals. They can arise in deterministic CoreLoop logic, in bounded core phases such as `knowledge_refresh`, or during task generation.
+Knowledge gaps are detected via multiple signals. They can arise in deterministic DurableLoop logic, in bounded core phases such as `knowledge_refresh`, or during task generation.
 
 ### 2.1 Difficulty Interpreting Observations
 

--- a/docs/design/knowledge/memory-lifecycle.md
+++ b/docs/design/knowledge/memory-lifecycle.md
@@ -5,7 +5,7 @@
 
 > Related: `session-and-context.md`, `knowledge-acquisition.md`, `reporting.md`, `state-vector.md`, `drive-system.md`, `curiosity.md`, `stall-detection.md`
 
-> Current implementation note: long-term memory is now consumed not only by session context builders but also by the native AgentLoop and Soil query path. Memory should be read as part of a shared substrate used by CoreLoop, AgentLoop, chat, and Soil rather than as a passive store behind one flat loop.
+> Current implementation note: long-term memory is now consumed not only by session context builders but also by the native AgentLoop and Soil query path. Memory should be read as part of a shared substrate used by DurableLoop, AgentLoop, chat, and Soil rather than as a passive store behind one flat loop.
 
 ---
 
@@ -17,7 +17,7 @@ Under long-term operation, PulSeed continuously accumulates the following data:
 
 | Data type | Source | Growth rate |
 |-----------|--------|------------|
-| Experience log | CoreLoop iterations and task execution outcomes, including bounded agent runs and verification evidence | 1 entry per loop/task outcome || Observation history | ObservationEngine periodic and event-driven observations | dimensions × observation frequency |
+| Experience log | DurableLoop iterations and task execution outcomes, including bounded agent runs and verification evidence | 1 entry per loop/task outcome || Observation history | ObservationEngine periodic and event-driven observations | dimensions × observation frequency |
 | Knowledge base | Results of KnowledgeManager research tasks | Multiple entries per research task |
 | Strategy history | Strategy execution results from StrategyManager/PortfolioManager | 1 entry per strategy change |
 | Task history | Past tasks from TaskLifecycle | 1 entry per task |
@@ -115,7 +115,7 @@ Long-term Memory
 
 ### 3.1 Experience Log
 
-Records of CoreLoop iteration outcomes, task execution, verification evidence, and related bounded agent activity. These records feed the learning pipeline and Soil projections.
+Records of DurableLoop iteration outcomes, task execution, verification evidence, and related bounded agent activity. These records feed the learning pipeline and Soil projections.
 | Layer | What is retained | Format |
 |-------|----------------|--------|
 | Working | Summary of the last 2–3 loops of experience relevant to the current task | Text summary |

--- a/docs/design/knowledge/soil-system.md
+++ b/docs/design/knowledge/soil-system.md
@@ -6,7 +6,7 @@
 
 > Related: `memory-lifecycle.md`, `learning-pipeline.md`, `knowledge-acquisition.md`, `../core/dream-mode.md`
 
-> Current implementation note: Soil is not just a documentation surface. `soil_query` is now available to the native AgentLoop and to selected CoreLoop phases such as `knowledge_refresh`, `replanning_options`, and `verification_evidence`, making Soil part of live execution rather than a passive export.
+> Current implementation note: Soil is not just a documentation surface. `soil_query` is now available to the native AgentLoop and to selected DurableLoop phases such as `knowledge_refresh`, `replanning_options`, and `verification_evidence`, making Soil part of live execution rather than a passive export.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,7 +87,7 @@ The default public path is `pulseed` plus natural language. Lower-level subcomma
 
 ## 4. What runs where
 
-- `CoreLoop` handles goal-level control, including continuation, refinement, verification, and completion checks
+- `DurableLoop` handles goal-level control, including continuation, refinement, verification, and completion checks
 - `AgentLoop` handles bounded tool use for tasks, chat, and runtime phases that need a short-lived executor
 - Local state lives under `~/.pulseed/`
 

--- a/docs/mechanism.md
+++ b/docs/mechanism.md
@@ -3,16 +3,16 @@
 This page is the canonical conceptual explanation of how PulSeed works.
 For runtime surfaces and commands, see [Runtime](runtime.md). For the public map, see [docs/index.md](index.md).
 
-## CoreLoop and AgentLoop
+## DurableLoop and AgentLoop
 
 PulSeed is easiest to understand as two cooperating loops.
 
-### CoreLoop
+### DurableLoop
 
-`CoreLoop` is the long-lived controller.
+`DurableLoop` is the long-lived controller.
 It owns durable decisions about goal progress, scheduling, stall handling, reprioritization, verification, and completion.
 
-CoreLoop answers questions such as:
+DurableLoop answers questions such as:
 
 - Is the goal still viable?
 - What should be worked on next?
@@ -30,7 +30,7 @@ AgentLoop is used for:
 
 - task execution through the native `agent_loop` path
 - chat turns
-- selected CoreLoop phases that need targeted evidence gathering
+- selected DurableLoop phases that need targeted evidence gathering
 
 ## Tools
 
@@ -93,11 +93,11 @@ Completion is decided from a combination of:
 - stall and error boundaries
 
 AgentLoop stops when the bounded task or chat turn is done.
-CoreLoop stops when the longer-running goal or iteration plan is done.
+DurableLoop stops when the longer-running goal or iteration plan is done.
 
-## Bounded phases inside CoreLoop
+## Bounded phases inside DurableLoop
 
-CoreLoop can invoke bounded AgentLoop phases for targeted evidence and planning support.
+DurableLoop can invoke bounded AgentLoop phases for targeted evidence and planning support.
 
 The current public phases are:
 
@@ -114,7 +114,7 @@ They do not replace it.
 
 The split keeps two concerns separate:
 
-- CoreLoop manages durable control over a goal over time
+- DurableLoop manages durable control over a goal over time
 - AgentLoop manages local tool use over a bounded window
 
 That separation is what lets PulSeed keep running across sessions while still doing short, tool-driven work inside a single turn or task.

--- a/docs/module-map.md
+++ b/docs/module-map.md
@@ -11,7 +11,7 @@ It is intentionally oriented around stable directories and major entry points ra
 
 Main exported surfaces include:
 
-- `CoreLoop`
+- `DurableLoop`
 - `TaskLifecycle`
 - `TaskAgentLoopRunner`
 - `ChatAgentLoopRunner`
@@ -79,18 +79,18 @@ Use this area for long-lived orchestration and control.
 
 #### `src/orchestrator/loop`
 
-CoreLoop and scheduling logic.
+DurableLoop and scheduling logic.
 
 Important files:
 
-- `core-loop.ts`
+- `durable-loop.ts`
 - `tree-loop-runner.ts`
 - `iteration-budget.ts`
 - `loop-result-types.ts`
-- `core-loop/iteration-kernel.ts`
-- `core-loop/decision-engine.ts`
-- `core-loop/phase-policy.ts`
-- `core-loop/phase-runtime.ts`
+- `durable-loop/iteration-kernel.ts`
+- `durable-loop/decision-engine.ts`
+- `durable-loop/phase-policy.ts`
+- `durable-loop/phase-runtime.ts`
 
 #### `src/orchestrator/execution`
 
@@ -172,10 +172,10 @@ Important subdirectories:
 
 ## 3. Where to look by feature
 
-### CoreLoop behavior
+### DurableLoop behavior
 
-- `src/orchestrator/loop/core-loop.ts`
-- `src/orchestrator/loop/core-loop/`
+- `src/orchestrator/loop/durable-loop.ts`
+- `src/orchestrator/loop/durable-loop/`
 - `src/orchestrator/loop/tree-loop-runner.ts`
 
 ### AgentLoop behavior
@@ -244,7 +244,7 @@ High-signal suites for current architecture:
 
 ## 5. Current naming conventions
 
-- `CoreLoop` means long-lived control
+- `DurableLoop` means long-lived control
 - `AgentLoop` means bounded tool-using execution
 - `TaskLifecycle` is the task generation/execution/verification pipeline
 - `Soil` means the readable derived memory surface

--- a/docs/status.md
+++ b/docs/status.md
@@ -9,7 +9,7 @@ For broader navigation, see [Architecture Map](architecture-map.md).
 
 ## In active use
 
-- long-lived `CoreLoop` control
+- long-lived `DurableLoop` control
 - bounded `AgentLoop` execution
 - shared tool substrate
 - Soil as a long-lived memory surface

--- a/src/tools/query/ArchitectureTool/ArchitectureTool.ts
+++ b/src/tools/query/ArchitectureTool/ArchitectureTool.ts
@@ -14,7 +14,7 @@ const LAYERS: Record<string, string> = {
   "Layer 2": "ObservationEngine, DriveScorer, SatisficingJudge, StallDetector",
   "Layer 3": "SessionManager, GoalNegotiator, StrategyManager",
   "Layer 4": "TaskLifecycle",
-  "Layer 5": "CoreLoop, ReportingEngine",
+  "Layer 5": "DurableLoop, ReportingEngine",
   "Layer 6": "CLIRunner",
   "Layer 7": "TUI (Ink/React dashboard, approval UI, chat)",
   "Layer 8": "KnowledgeManager (cross-cutting)",
@@ -37,7 +37,7 @@ const MODULE_DESCRIPTIONS: Record<string, string> = {
   StallDetector: "Detects stall conditions (repetition, timeout, loop)",
   SessionManager: "Manages agent session lifecycle",
   TaskLifecycle: "Task selection, execution delegation, verification",
-  CoreLoop: "Main orchestration loop: observe -> gap -> score -> task -> execute -> verify (NEVER STOP)",
+  DurableLoop: "Main orchestration loop: observe -> gap -> score -> task -> execute -> verify (NEVER STOP)",
   EthicsGate: "L1 mechanical safety checks before irreversible actions",
   KnowledgeManager: "Hierarchical memory with LLM page-in/out and semantic archival",
   PortfolioManager: "Orchestrates parallel strategies between DriveScorer and TaskLifecycle",
@@ -87,7 +87,7 @@ export class ArchitectureTool implements ITool<ArchitectureToolInput, unknown> {
     const data = {
       core_concept: {
         model: "4-element: Goal (with thresholds) -> Current State (observation + confidence) -> Gap -> Constraints",
-        core_loop: "observe -> gap -> score -> task -> execute -> verify (NEVER STOP)",
+        durable_loop: "observe -> gap -> score -> task -> execute -> verify (NEVER STOP)",
         execution_boundary: "PulSeed uses available tools directly for safe local work and delegates when specialization, parallelism, or context isolation helps.",
       },
       layers: LAYERS,

--- a/src/tools/query/ArchitectureTool/__tests__/ArchitectureTool.test.ts
+++ b/src/tools/query/ArchitectureTool/__tests__/ArchitectureTool.test.ts
@@ -15,10 +15,19 @@ describe("ArchitectureTool", () => {
     expect(result.success).toBe(true);
     expect(result.data).toMatchObject({
       core_concept: {
+        durable_loop: expect.stringContaining("observe"),
         execution_boundary: expect.stringContaining("uses available tools directly"),
       },
+      layers: {
+        "Layer 5": expect.stringContaining("DurableLoop"),
+      },
+      modules: {
+        DurableLoop: expect.stringContaining("Main orchestration loop"),
+      },
     });
+    expect(result.data).not.toHaveProperty("core_concept.core_loop");
     expect(JSON.stringify(result.data)).not.toContain("PulSeed always delegates");
     expect(JSON.stringify(result.data)).not.toContain("state read/write only");
+    expect(JSON.stringify(result.data)).not.toContain("CoreLoop");
   });
 });

--- a/tmp/durable-loop-migration-status.md
+++ b/tmp/durable-loop-migration-status.md
@@ -51,3 +51,14 @@
 - Full chat focused bundle also ran but failed in unrelated Telegram setup tests because existing untracked `.pulseed-sandbox` local state reports Telegram/Home chat configured; this is the same local-state issue seen in #1016 and not caused by DurableLoop label changes.
 - Review: separate review agent found one missed user-facing chat safety response label. Fixed `background CoreLoop work` to `background DurableLoop work`.
 - Re-verification after review fix: `npm run typecheck`, `npm run lint:boundaries`, runtime/session/control/agent-loop focused tests, and targeted chat/cross-platform DurableLoop caller-path tests passed.
+
+## #1019 Clean up DurableLoop documentation and retire obsolete CoreLoop aliases
+
+- Status: in progress.
+- Branch: `codex/issue-1019-durable-loop-doc-cleanup`.
+- Issue body reviewed with `gh issue view 1019`.
+- Plan: update current-facing README/docs/architecture text and ArchitectureTool labels to DurableLoop. Keep compatibility shims, public deprecated API names, legacy persisted identifiers (`run:coreloop:*`, `session:coreloop:*`, `coreloop_run`, `coreloop`), and tests that document compatibility.
+- Alias decision: keep deprecated TypeScript aliases and shims for this migration because downstream callers and legacy import paths still need compatibility after #1017/#1018. Do not remove persisted/wire compatibility surfaces.
+- Review: separate review agent found one stale `core_concept.core_loop` ArchitectureTool output key. Fixed to `core_concept.durable_loop` and added a regression assertion.
+- Verification after review fix: `npm run check:docs`, `npx vitest run src/tools/query/ArchitectureTool/__tests__/ArchitectureTool.test.ts`, `npm run typecheck`, and `npm run lint:boundaries` passed. `lint:boundaries` reports existing warnings only.
+- `npm run test:changed` ran and passed docs/ArchitectureTool related checks, then failed in unrelated Telegram chat setup expectations because untracked `.pulseed-sandbox` runtime/config state reports Telegram/Home chat configured. This is the same local-state issue recorded in earlier migration PRs and is not caused by #1019 docs/tool label changes.


### PR DESCRIPTION
Closes #1019

## Summary

- Updates README, docs, module/architecture maps, and current design descriptions to present `DurableLoop` as the official durable execution mechanism.
- Updates ArchitectureTool user-facing output from `CoreLoop`/`core_loop` to `DurableLoop`/`durable_loop` and adds a regression assertion.
- Keeps legacy compatibility surfaces intentionally: deprecated TypeScript `CoreLoop` aliases/shims, legacy import shims, and persisted/wire identifiers remain readable and unchanged.

## Verification

- `npm run check:docs`
- `npx vitest run src/tools/query/ArchitectureTool/__tests__/ArchitectureTool.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings)
- `rg -n "CoreLoop|core-loop|coreloop|core_loop" README.md docs src/tools/query/ArchitectureTool/ArchitectureTool.ts src/tools/query/ArchitectureTool/__tests__/ArchitectureTool.test.ts`

## Known unresolved risks

- `npm run test:changed` was attempted. It passed docs/ArchitectureTool related checks, then failed in unrelated Telegram chat setup expectations because existing untracked local `.pulseed-sandbox` runtime/config state reports Telegram/Home chat configured. This same local-state issue was observed in earlier DurableLoop migration PRs and is not caused by this docs/tool label change.

## Remaining CoreLoop/core-loop/coreloop references

- `README.md`, `docs/`, and ArchitectureTool production output no longer contain current-facing `CoreLoop`, `core-loop`, `coreloop`, or `core_loop` references.
- `src` and `tests` still intentionally retain compatibility names for deprecated public TypeScript aliases, migration re-export shims, legacy persisted identifiers such as `run:coreloop:*`, `session:coreloop:*`, `coreloop_run`, the `coreloop` session kind, legacy tool names like `core_goal_status`, and tests that document those compatibility surfaces.
