### PR TITLE
Move agent timeline activity classification into tool metadata

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -52,6 +52,7 @@ class EchoTool implements ITool<{ value: string }> {
     maxConcurrency: 0,
     maxOutputChars: 8000,
     tags: ["test"],
+    activityCategory: "read" as const,
   };
   readonly inputSchema = z.object({ value: z.string() });
 
@@ -89,6 +90,7 @@ class VerifyTool implements ITool<{ command: string; cwd?: string }> {
     maxConcurrency: 0,
     maxOutputChars: 8000,
     tags: ["test", "verification"],
+    activityCategory: "test" as const,
   };
   readonly inputSchema = z.object({ command: z.string(), cwd: z.string().optional() });
 
@@ -488,6 +490,14 @@ describe("agentloop phase 1", () => {
     expect(modelClient.calls[1].messages.some((message) => message.role === "tool")).toBe(true);
     const events = await session.traceStore.list(session.traceId);
     expect(events.some((event) => event.type === "final")).toBe(true);
+    expect(events.find((event) => event.type === "tool_call_started")).toMatchObject({
+      toolName: "echo",
+      activityCategory: "read",
+    });
+    expect(events.find((event) => event.type === "tool_call_finished")).toMatchObject({
+      toolName: "echo",
+      activityCategory: "read",
+    });
     const assistantMessages = events.filter((event) => event.type === "assistant_message");
     expect(assistantMessages).toHaveLength(2);
     expect(assistantMessages[0]).toMatchObject({ phase: "commentary" });

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
@@ -17,7 +17,12 @@ function baseEvent(input: Partial<AgentLoopEvent> & { type: AgentLoopEvent["type
   } as AgentLoopEvent;
 }
 
-function finishedTool(eventId: string, toolName: string, inputPreview: string): AgentLoopEvent {
+function finishedTool(
+  eventId: string,
+  toolName: string,
+  inputPreview: string,
+  activityCategory?: "search" | "read" | "command" | "file_create" | "file_modify" | "test" | "approval",
+): AgentLoopEvent {
   return baseEvent({
     type: "tool_call_finished",
     eventId,
@@ -27,6 +32,7 @@ function finishedTool(eventId: string, toolName: string, inputPreview: string): 
     inputPreview,
     outputPreview: "ok",
     durationMs: 1,
+    ...(activityCategory ? { activityCategory } : {}),
   } as Partial<AgentLoopEvent> & { type: AgentLoopEvent["type"]; eventId: string });
 }
 
@@ -34,10 +40,10 @@ describe("agent timeline activity summaries", () => {
   it("classifies structured activity deterministically", () => {
     const items = [
       finishedTool("search-1", "shell_command", JSON.stringify({ command: "rg ChatRunner src/interface/chat" })),
-      finishedTool("read-1", "read_file", JSON.stringify({ path: "src/interface/chat/chat-runner.ts" })),
+      finishedTool("read-1", "read_file", JSON.stringify({ path: "src/interface/chat/chat-runner.ts" }), "read"),
       finishedTool("command-1", "shell_command", JSON.stringify({ command: "node scripts/build.js" })),
-      finishedTool("create-1", "file_write", JSON.stringify({ path: "src/new-file.ts" })),
-      finishedTool("modify-1", "apply_patch", JSON.stringify({ path: "src/existing.ts" })),
+      finishedTool("create-1", "file_write", JSON.stringify({ path: "src/new-file.ts" }), "file_create"),
+      finishedTool("modify-1", "apply_patch", JSON.stringify({ path: "src/existing.ts" }), "file_modify"),
       finishedTool("test-1", "shell_command", JSON.stringify({ command: "npm run typecheck" })),
       baseEvent({
         type: "approval_request",
@@ -58,6 +64,40 @@ describe("agent timeline activity summaries", () => {
       { kind: "file_modify", count: 1 },
       { kind: "test", count: 1 },
       { kind: "approval", count: 1 },
+    ]);
+  });
+
+  it("prefers declared tool metadata over tool-name substrings", () => {
+    const items = [
+      finishedTool("metadata-1", "search_like_name", JSON.stringify({ path: "src/created.ts" }), "file_create"),
+      finishedTool("metadata-2", "verify_like_name", JSON.stringify({ path: "src/read.ts" }), "read"),
+    ].map(projectAgentLoopEventToTimeline);
+
+    expect(summarizeAgentTimelineActivity(items)).toEqual([
+      { kind: "read", count: 1 },
+      { kind: "file_create", count: 1 },
+    ]);
+  });
+
+  it("uses shell command parsing for explicit command protocol input", () => {
+    const items = [
+      finishedTool("shell-search", "shell_command", JSON.stringify({ command: "rg Timeline src" }), "command"),
+      finishedTool("shell-test", "shell_command", JSON.stringify({ command: "npm run test:changed" }), "command"),
+    ].map(projectAgentLoopEventToTimeline);
+
+    expect(summarizeAgentTimelineActivity(items)).toEqual([
+      { kind: "search", count: 1 },
+      { kind: "test", count: 1 },
+    ]);
+  });
+
+  it("keeps unknown tool fallback conservative", () => {
+    const items = [
+      finishedTool("unknown-1", "mystery_search_writer", JSON.stringify({ path: "src/file.ts" })),
+    ].map(projectAgentLoopEventToTimeline);
+
+    expect(summarizeAgentTimelineActivity(items)).toEqual([
+      { kind: "command", count: 1 },
     ]);
   });
 

--- a/src/orchestrator/execution/agent-loop/agent-loop-events.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-events.ts
@@ -1,3 +1,5 @@
+import type { ToolActivityCategory } from "../../../tools/types.js";
+
 export type AgentLoopEvent =
   | AgentLoopStartedEvent
   | AgentLoopResumedEvent
@@ -68,6 +70,7 @@ export interface AgentLoopToolCallStartedEvent extends AgentLoopBaseEvent {
   callId: string;
   toolName: string;
   inputPreview: string;
+  activityCategory?: ToolActivityCategory;
 }
 
 export interface AgentLoopToolCallFinishedEvent extends AgentLoopBaseEvent {
@@ -84,6 +87,7 @@ export interface AgentLoopToolCallFinishedEvent extends AgentLoopBaseEvent {
     originalChars: number;
     overflowPath?: string;
   };
+  activityCategory?: ToolActivityCategory;
 }
 
 export interface AgentLoopPlanUpdateEvent extends AgentLoopBaseEvent {

--- a/src/orchestrator/execution/agent-loop/agent-loop-tool-output.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-tool-output.ts
@@ -1,4 +1,5 @@
 import type { ToolResult } from "../../../tools/types.js";
+import type { ToolActivityCategory } from "../../../tools/types.js";
 
 export type AgentLoopToolDisposition =
   | "respond_to_model"
@@ -23,5 +24,6 @@ export interface AgentLoopToolOutput {
     originalChars: number;
     overflowPath?: string;
   };
+  activityCategory?: ToolActivityCategory;
   fatal?: boolean;
 }

--- a/src/orchestrator/execution/agent-loop/agent-loop-tool-runtime.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-tool-runtime.ts
@@ -67,6 +67,7 @@ export class ToolExecutorAgentLoopToolRuntime implements AgentLoopToolRuntime {
         : { status: "executed" as const });
       const command = this.extractCommand(call.name, call.input);
       const resolvedCwd = this.extractCwd(call.input) ?? turn.cwd;
+      const activityCategory = this.router.resolveTool(call.name)?.metadata.activityCategory;
       return {
         callId: call.id,
         toolName: call.name,
@@ -78,6 +79,7 @@ export class ToolExecutorAgentLoopToolRuntime implements AgentLoopToolRuntime {
         ...(result.contextModifier ? { contextModifier: result.contextModifier } : {}),
         rawResult: result,
         ...(command ? { command, cwd: resolvedCwd } : {}),
+        ...(activityCategory ? { activityCategory } : {}),
         ...(result.artifacts ? { artifacts: result.artifacts } : {}),
         ...(result.truncated ? { truncated: result.truncated } : {}),
       };
@@ -104,6 +106,9 @@ export class ToolExecutorAgentLoopToolRuntime implements AgentLoopToolRuntime {
       content: message,
       durationMs,
       disposition,
+      ...(this.router.resolveTool(call.name)?.metadata.activityCategory
+        ? { activityCategory: this.router.resolveTool(call.name)?.metadata.activityCategory }
+        : {}),
     };
   }
 

--- a/src/orchestrator/execution/agent-loop/agent-timeline.ts
+++ b/src/orchestrator/execution/agent-loop/agent-timeline.ts
@@ -1,4 +1,5 @@
 import type { AgentLoopEvent } from "./agent-loop-events.js";
+import type { ToolActivityCategory } from "../../../tools/types.js";
 
 export type AgentTimelineItem =
   | AgentTimelineLifecycleItem
@@ -13,14 +14,7 @@ export type AgentTimelineItem =
   | AgentTimelineFinalItem
   | AgentTimelineStoppedItem;
 
-export type AgentTimelineActivityKind =
-  | "search"
-  | "read"
-  | "command"
-  | "file_create"
-  | "file_modify"
-  | "test"
-  | "approval";
+export type AgentTimelineActivityKind = ToolActivityCategory;
 
 export interface AgentTimelineBaseItem {
   id: string;
@@ -67,6 +61,7 @@ export interface AgentTimelineToolItem extends AgentTimelineBaseItem {
   status: "started" | "finished";
   callId: string;
   toolName: string;
+  activityCategory?: AgentTimelineActivityKind;
   inputPreview?: string;
   success?: boolean;
   disposition?: "respond_to_model" | "fatal" | "approval_denied" | "cancelled";
@@ -181,6 +176,7 @@ export function projectAgentLoopEventToTimeline(event: AgentLoopEvent): AgentTim
         status: "started",
         callId: event.callId,
         toolName: event.toolName,
+        ...(event.activityCategory ? { activityCategory: event.activityCategory } : {}),
         inputPreview: event.inputPreview,
       };
     case "tool_call_finished":
@@ -190,6 +186,7 @@ export function projectAgentLoopEventToTimeline(event: AgentLoopEvent): AgentTim
         status: "finished",
         callId: event.callId,
         toolName: event.toolName,
+        ...(event.activityCategory ? { activityCategory: event.activityCategory } : {}),
         success: event.success,
         ...(event.inputPreview ? { inputPreview: event.inputPreview } : {}),
         ...(event.disposition ? { disposition: event.disposition } : {}),
@@ -298,19 +295,19 @@ export function formatAgentTimelineActivitySummary(buckets: AgentTimelineActivit
 function classifyTimelineActivity(item: AgentTimelineItem): AgentTimelineActivityKind | null {
   if (item.kind === "approval" && item.status === "requested") return "approval";
   if (item.kind !== "tool" || item.status !== "finished") return null;
-  return classifyToolActivity(item.toolName, item.inputPreview);
+  return classifyToolActivity(item.activityCategory, item.inputPreview);
 }
 
-function classifyToolActivity(toolName: string, inputPreview?: string): AgentTimelineActivityKind {
-  const normalizedTool = normalizeToolToken(toolName);
+function classifyToolActivity(
+  activityCategory: AgentTimelineActivityKind | undefined,
+  inputPreview?: string,
+): AgentTimelineActivityKind {
   const input = parseToolInputPreview(inputPreview);
   const command = stringField(input, "command") ?? stringField(input, "cmd");
-  if (command) return classifyCommandActivity(command);
-  if (hasAny(normalizedTool, ["test", "verify", "check"])) return "test";
-  if (hasAny(normalizedTool, ["search", "grep", "query"])) return "search";
-  if (hasAny(normalizedTool, ["read", "list", "dir", "log", "diff"])) return "read";
-  if (hasAny(normalizedTool, ["write", "create"])) return "file_create";
-  if (hasAny(normalizedTool, ["edit", "patch", "apply"])) return "file_modify";
+  if (command && (!activityCategory || activityCategory === "command")) {
+    return classifyCommandActivity(command);
+  }
+  if (activityCategory) return activityCategory;
   return "command";
 }
 
@@ -348,14 +345,6 @@ function parseToolInputPreview(inputPreview?: string): Record<string, unknown> |
 function stringField(input: Record<string, unknown> | null, field: string): string | null {
   const value = input?.[field];
   return typeof value === "string" ? value : null;
-}
-
-function normalizeToolToken(value: string): string {
-  return value.toLowerCase().replace(/[-_]/g, "");
-}
-
-function hasAny(value: string, needles: string[]): boolean {
-  return needles.some((needle) => value.includes(needle));
 }
 
 function firstCommandToken(command: string): string {

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -299,12 +299,14 @@ export class BoundedAgentLoopRunner {
       }
 
       for (const call of response.toolCalls) {
+        const activityCategory = this.deps.toolRouter.resolveTool(call.name)?.metadata.activityCategory;
         await this.record(turn, {
           type: "tool_call_started",
           ...this.baseEvent(turn),
           callId: call.id,
           toolName: call.name,
           inputPreview: this.preview(this.stringify(call.input)),
+          ...(activityCategory ? { activityCategory } : {}),
         });
       }
 
@@ -342,6 +344,7 @@ export class BoundedAgentLoopRunner {
           durationMs: result.durationMs,
           ...(result.artifacts ? { artifacts: result.artifacts } : {}),
           ...(result.truncated ? { truncated: result.truncated } : {}),
+          ...(result.activityCategory ? { activityCategory: result.activityCategory } : {}),
         });
 
         if (result.disposition === "approval_denied") {

--- a/src/tools/__tests__/types.test.ts
+++ b/src/tools/__tests__/types.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   ToolResultSchema,
   ToolPermissionLevelSchema,
+  ToolActivityCategorySchema,
   ToolMetadataSchema,
   PermissionCheckResultSchema,
 } from "../types.js";
@@ -80,6 +81,15 @@ describe("ToolPermissionLevelSchema", () => {
   });
 });
 
+describe("ToolActivityCategorySchema", () => {
+  it.each(["search", "read", "command", "file_create", "file_modify", "test", "approval"] as const)(
+    "parses activity category: %s",
+    (category) => {
+      expect(ToolActivityCategorySchema.parse(category)).toBe(category);
+    },
+  );
+});
+
 describe("ToolMetadataSchema", () => {
   const validMeta = {
     name: "glob",
@@ -111,6 +121,7 @@ describe("ToolMetadataSchema", () => {
       maxConcurrency: 5,
       maxOutputChars: 4000,
       tags: ["file", "search"],
+      activityCategory: "search",
     };
     const result = ToolMetadataSchema.parse(meta);
     expect(result.aliases).toEqual(["find", "search"]);
@@ -118,6 +129,7 @@ describe("ToolMetadataSchema", () => {
     expect(result.maxConcurrency).toBe(5);
     expect(result.maxOutputChars).toBe(4000);
     expect(result.tags).toEqual(["file", "search"]);
+    expect(result.activityCategory).toBe("search");
   });
 
   it("rejects when name is missing", () => {

--- a/src/tools/fs/ApplyPatchTool/ApplyPatchTool.ts
+++ b/src/tools/fs/ApplyPatchTool/ApplyPatchTool.ts
@@ -24,6 +24,7 @@ export class ApplyPatchTool implements ITool<ApplyPatchInput> {
     maxConcurrency: 1,
     maxOutputChars: 8000,
     tags: ["agentloop", "filesystem", "edit"],
+    activityCategory: "file_modify",
   };
 
   readonly inputSchema = ApplyPatchInputSchema;

--- a/src/tools/fs/FileEditTool/FileEditTool.ts
+++ b/src/tools/fs/FileEditTool/FileEditTool.ts
@@ -41,6 +41,7 @@ export class FileEditTool implements ITool<FileEditInput, FileEditOutput> {
     maxConcurrency: 3,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "file_modify",
   };
   readonly inputSchema = FileEditInputSchema;
 

--- a/src/tools/fs/FileWriteTool/FileWriteTool.ts
+++ b/src/tools/fs/FileWriteTool/FileWriteTool.ts
@@ -30,6 +30,7 @@ export class FileWriteTool implements ITool<FileWriteInput, FileWriteOutput> {
     maxConcurrency: 3,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "file_create",
   };
   readonly inputSchema = FileWriteInputSchema;
 

--- a/src/tools/fs/GlobTool/GlobTool.ts
+++ b/src/tools/fs/GlobTool/GlobTool.ts
@@ -25,6 +25,7 @@ export class GlobTool implements ITool<GlobInput, string[]> {
     maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "search",
   };
   readonly inputSchema = GlobInputSchema;
 

--- a/src/tools/fs/GrepTool/GrepTool.ts
+++ b/src/tools/fs/GrepTool/GrepTool.ts
@@ -28,6 +28,7 @@ export class GrepTool implements ITool<GrepInput, string> {
     maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "search",
   };
   readonly inputSchema = GrepInputSchema;
 

--- a/src/tools/fs/JsonQueryTool/JsonQueryTool.ts
+++ b/src/tools/fs/JsonQueryTool/JsonQueryTool.ts
@@ -18,6 +18,7 @@ export class JsonQueryTool implements ITool<JsonQueryInput, unknown> {
     permissionLevel: PERMISSION_LEVEL, isReadOnly: READ_ONLY, isDestructive: false,
     shouldDefer: true, alwaysLoad: false, maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS, tags: [...TAGS],
+    activityCategory: "read",
   };
   readonly inputSchema = JsonQueryInputSchema;
 

--- a/src/tools/fs/ListDirTool/ListDirTool.ts
+++ b/src/tools/fs/ListDirTool/ListDirTool.ts
@@ -33,6 +33,7 @@ export class ListDirTool implements ITool<ListDirInput, DirEntry[]> {
     maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "read",
   };
   readonly inputSchema = ListDirInputSchema;
 

--- a/src/tools/fs/ReadTool/ReadTool.ts
+++ b/src/tools/fs/ReadTool/ReadTool.ts
@@ -25,6 +25,7 @@ export class ReadTool implements ITool<ReadInput, string> {
     maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "read",
   };
   readonly inputSchema = ReadInputSchema;
 

--- a/src/tools/network/HttpFetchTool/HttpFetchTool.ts
+++ b/src/tools/network/HttpFetchTool/HttpFetchTool.ts
@@ -237,6 +237,7 @@ export class HttpFetchTool implements ITool<HttpFetchInput, HttpFetchOutput> {
     permissionLevel: PERMISSION_LEVEL, isReadOnly: true, isDestructive: false,
     shouldDefer: true, alwaysLoad: false, maxConcurrency: 5,
     maxOutputChars: MAX_OUTPUT_CHARS, tags: [...TAGS], requiresNetwork: true,
+    activityCategory: "read",
   };
   readonly inputSchema = HttpFetchInputSchema;
 

--- a/src/tools/network/WebSearchTool/WebSearchTool.ts
+++ b/src/tools/network/WebSearchTool/WebSearchTool.ts
@@ -71,6 +71,7 @@ export class WebSearchTool implements ITool<WebSearchInput, SearchResult[]> {
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
     requiresNetwork: true,
+    activityCategory: "search",
   };
 
   readonly inputSchema = WebSearchInputSchema;

--- a/src/tools/query/CodeReadContextTool/CodeReadContextTool.ts
+++ b/src/tools/query/CodeReadContextTool/CodeReadContextTool.ts
@@ -77,6 +77,7 @@ export class CodeReadContextTool implements ITool<CodeReadContextInput, unknown>
     maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "read",
   };
   readonly inputSchema = CodeReadContextInputSchema;
 

--- a/src/tools/query/CodeSearchRepairTool/CodeSearchRepairTool.ts
+++ b/src/tools/query/CodeSearchRepairTool/CodeSearchRepairTool.ts
@@ -36,6 +36,7 @@ export class CodeSearchRepairTool implements ITool<CodeSearchRepairInput, unknow
     maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "search",
   };
   readonly inputSchema = CodeSearchRepairInputSchema;
 

--- a/src/tools/query/CodeSearchTool/CodeSearchTool.ts
+++ b/src/tools/query/CodeSearchTool/CodeSearchTool.ts
@@ -56,6 +56,7 @@ export class CodeSearchTool implements ITool<CodeSearchInput, unknown> {
     maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "search",
   };
   readonly inputSchema = CodeSearchInputSchema;
 

--- a/src/tools/query/KnowledgeQueryTool/KnowledgeQueryTool.ts
+++ b/src/tools/query/KnowledgeQueryTool/KnowledgeQueryTool.ts
@@ -75,6 +75,7 @@ export class KnowledgeQueryTool
     maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "search",
   };
 
   readonly inputSchema = KnowledgeQueryInputSchema;

--- a/src/tools/query/SkillSearchTool/SkillSearchTool.ts
+++ b/src/tools/query/SkillSearchTool/SkillSearchTool.ts
@@ -19,6 +19,7 @@ export class SkillSearchTool implements ITool<SkillSearchInput> {
     maxConcurrency: 10,
     maxOutputChars: 8000,
     tags: ["skills", "query"],
+    activityCategory: "search",
   };
   readonly inputSchema = SkillSearchInputSchema;
 

--- a/src/tools/query/ToolSearchTool/ToolSearchTool.ts
+++ b/src/tools/query/ToolSearchTool/ToolSearchTool.ts
@@ -29,6 +29,7 @@ export class ToolSearchTool implements ITool<ToolSearchInput, ToolSearchResult[]
     maxConcurrency: 10,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "search",
   };
 
   readonly inputSchema = ToolSearchInputSchema;

--- a/src/tools/system/GitDiffTool/GitDiffTool.ts
+++ b/src/tools/system/GitDiffTool/GitDiffTool.ts
@@ -40,6 +40,7 @@ export class GitDiffTool implements ITool<GitDiffInput, string> {
     maxConcurrency: 5,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "read",
   };
 
   readonly inputSchema = GitDiffInputSchema;

--- a/src/tools/system/GitLogTool/GitLogTool.ts
+++ b/src/tools/system/GitLogTool/GitLogTool.ts
@@ -33,6 +33,7 @@ export class GitLogTool implements ITool<GitLogInput, string[] | GitLogEntryFull
     maxConcurrency: 0,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "read",
   };
   readonly inputSchema = GitLogInputSchema;
 

--- a/src/tools/system/ShellTool/ShellTool.ts
+++ b/src/tools/system/ShellTool/ShellTool.ts
@@ -22,6 +22,7 @@ export class ShellTool implements ITool<ShellInput, ShellOutput> {
     permissionLevel: PERMISSION_LEVEL, isReadOnly: false, isDestructive: false,
     shouldDefer: false, alwaysLoad: true, maxConcurrency: 3,
     maxOutputChars: MAX_OUTPUT_CHARS, tags: [...TAGS],
+    activityCategory: "command",
   };
   readonly inputSchema = ShellInputSchema;
 

--- a/src/tools/system/TestRunnerTool/TestRunnerTool.ts
+++ b/src/tools/system/TestRunnerTool/TestRunnerTool.ts
@@ -122,6 +122,7 @@ export class TestRunnerTool implements ITool<TestRunnerInput, TestRunnerOutput> 
     maxConcurrency: 1,
     maxOutputChars: MAX_OUTPUT_CHARS,
     tags: [...TAGS],
+    activityCategory: "test",
   };
 
   readonly inputSchema = TestRunnerInputSchema;

--- a/src/tools/system/UpdatePlanTool/UpdatePlanTool.ts
+++ b/src/tools/system/UpdatePlanTool/UpdatePlanTool.ts
@@ -22,6 +22,7 @@ export class UpdatePlanTool implements ITool<UpdatePlanInput> {
     maxConcurrency: 0,
     maxOutputChars: 4000,
     tags: ["agentloop", "planning"],
+    activityCategory: "read",
   };
 
   readonly inputSchema = UpdatePlanInputSchema;

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -51,6 +51,20 @@ export const ToolPermissionLevelSchema = z.enum([
 
 export type ToolPermissionLevel = z.infer<typeof ToolPermissionLevelSchema>;
 
+// --- Tool Activity Category ---
+
+export const ToolActivityCategorySchema = z.enum([
+  "search",
+  "read",
+  "command",
+  "file_create",
+  "file_modify",
+  "test",
+  "approval",
+]);
+
+export type ToolActivityCategory = z.infer<typeof ToolActivityCategorySchema>;
+
 // --- Tool Metadata ---
 
 export const ToolMetadataSchema = z.object({
@@ -84,6 +98,12 @@ export const ToolMetadataSchema = z.object({
   tags: z.array(z.string()).default([]),
   /** Whether this tool requires network access even if it is otherwise read-only. */
   requiresNetwork: z.boolean().optional(),
+  /**
+   * Channel-agnostic activity category used by shared agent timeline summaries.
+   * Tools should declare this instead of requiring timeline consumers to infer
+   * semantics from tool names.
+   */
+  activityCategory: ToolActivityCategorySchema.optional(),
 });
 
 export type ToolMetadata = z.infer<typeof ToolMetadataSchema>;

--- a/tmp/nightly-agent-timeline-runtime-foundation-status.md
+++ b/tmp/nightly-agent-timeline-runtime-foundation-status.md
@@ -1,0 +1,17 @@
+# Nightly agent timeline/runtime foundation status
+
+## 2026-05-04
+- Startup: `git switch main && git pull --ff-only` succeeded; main was already up to date.
+- Startup: `gh issue list --state open --limit 100` confirmed #957, #956, and #935 are open. Other open issues are treated as out of scope unless they block these three.
+
+## #957 Move agent timeline activity classification into tool metadata
+- Status: in progress.
+- Plan: add typed `activityCategory` to `ToolMetadata`, carry it on agent-loop tool events, prefer it in shared timeline summaries, keep command-string parsing only for explicit shell/command protocol input, and update core/default tool metadata plus focused tests.
+- Implementation: added `ToolMetadata.activityCategory`, propagated it on tool loop events, updated shared timeline classification to prefer metadata, retained explicit command-string parsing for shell/command calls, and added core builtin metadata for search/read/write/test/command tools.
+- Verification so far: focused timeline/types Vitest passed; `npm run typecheck` passed.
+- Verification: focused runner/timeline/types Vitest passed after adding event propagation coverage; `npm run typecheck` passed again; `npm run lint:boundaries --if-present` exited 0 with existing warnings.
+- `npm run test:changed --if-present` failed in unrelated Telegram setup guidance expectations while using existing `.pulseed-sandbox` state; failing assertions expected unconfigured setup guidance but output reported configured Telegram config/home chat. No changed files in #957 touch that path.
+- Review: fresh review agent started for material issue review.
+- Review finding addressed: added activity metadata to additional builtin search/read tools that previously relied on name-based classification (`code_search`, `code_search_repair`, `code_read_context`, `json_query`, `skill_search`, `knowledge_query`).
+- Review: second fresh review completed with no findings.
+- Status: ready for commit/PR.


### PR DESCRIPTION
Closes #957

## Summary
- Add typed `ToolMetadata.activityCategory` and carry it on agent-loop tool events.
- Update shared timeline summaries to prefer declared metadata and keep command parsing only for explicit command/cmd input.
- Declare activity categories for default/core search, read, command, write, and test tools.
- Add coverage for metadata-first classification, shell command fallback, unknown-tool fallback, existing summary categories, and production event propagation.

## Verification
- `npx vitest run src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/tools/__tests__/types.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries --if-present`
- `npm run test:changed --if-present` failed in unrelated Telegram setup guidance expectations while using existing `.pulseed-sandbox` state; failing assertions expected unconfigured setup guidance but output reported configured Telegram config/home chat. No changed files in this PR touch that path.

## Known unresolved risks
- Third-party/plugin tools without `activityCategory` intentionally fall back to conservative `command` summaries until they declare metadata.