### PR TITLE
Expose shared agent timeline to Telegram channel

### DIFF
--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -83,7 +83,7 @@ function getOperationProgressMessageId(turnId: string, itemId: string): string {
   return `operation-progress:${turnId}:${itemId}`;
 }
 
-function renderTimelineItem(item: AgentTimelineItem): string {
+export function renderAgentTimelineItemForChat(item: AgentTimelineItem): string {
   switch (item.kind) {
     case "lifecycle":
       if (item.status === "resumed") {
@@ -338,7 +338,7 @@ export function applyChatEventToMessages(
 
   if (event.type === "agent_timeline") {
     if (event.item.visibility !== "user") return messages;
-    const text = renderTimelineItem(event.item).trim();
+    const text = renderAgentTimelineItemForChat(event.item).trim();
     if (!text) return messages;
     return upsertMessage(messages, {
       id: getTimelineMessageId(event.turnId, event.item),

--- a/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { dispatchGatewayChatInput } from "../chat-session-dispatch.js";
 import { TelegramGatewayAdapter } from "../telegram-gateway-adapter.js";
+import { ChatRunnerEventBridge } from "../../../interface/chat/chat-runner-event-bridge.js";
+import type { AgentLoopEvent } from "../../../orchestrator/execution/agent-loop/agent-loop-events.js";
 
 vi.mock("../chat-session-dispatch.js", () => ({
   dispatchGatewayChatInput: vi.fn().mockResolvedValue("ok"),
@@ -20,7 +22,12 @@ beforeEach(() => {
 afterEach(async () => {
   await Promise.all(adapters.splice(0).map((adapter) => adapter.stop()));
   vi.unstubAllGlobals();
-  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, {
+    recursive: true,
+    force: true,
+    maxRetries: 3,
+    retryDelay: 10,
+  })));
 });
 
 describe("TelegramGatewayAdapter", () => {
@@ -201,6 +208,203 @@ describe("TelegramGatewayAdapter", () => {
       expect(sentMessages).toContain("Final setup guidance.");
     });
     expect(sentMessages.filter((message) => message === "Final setup guidance.")).toHaveLength(1);
+  });
+
+  it("renders shared agent timeline events in the Telegram channel without parsing TUI transcript text", async () => {
+    const configDir = await writeConfig({
+      bot_token: "test-token",
+      allowed_user_ids: [42],
+      denied_user_ids: [],
+      allowed_chat_ids: [],
+      denied_chat_ids: [],
+      runtime_control_allowed_user_ids: [42],
+      chat_goal_map: {},
+      user_goal_map: {},
+      allow_all: true,
+      polling_timeout: 30,
+      identity_key: "seedy",
+    });
+    const sentMessages: string[] = [];
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const method = String(url).split("/").at(-1);
+      if (method === "getMe") return telegramResponse({ id: 1, username: "pulseed_test_bot" });
+      if (method === "getUpdates") {
+        return telegramResponse([{
+          update_id: 100,
+          message: { message_id: 2718, from: { id: 42 }, chat: { id: 314 }, text: "work on timeline" },
+        }]);
+      }
+      if (method === "sendMessage") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+        sentMessages.push(body.text ?? "");
+        return telegramResponse({ message_id: 9000 + sentMessages.length });
+      }
+      if (method === "editMessageText") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+        sentMessages.push(body.text ?? "");
+        return telegramResponse({ message_id: 9100 + sentMessages.length });
+      }
+      if (method === "sendChatAction") return telegramResponse(true);
+      throw new Error(`unexpected Telegram method: ${method}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = TelegramGatewayAdapter.fromConfigDir(configDir);
+    adapters.push(adapter);
+    vi.mocked(dispatchGatewayChatInput).mockImplementationOnce(async (input) => {
+      const bridge = new ChatRunnerEventBridge(() => input.onEvent);
+      const sink = bridge.createAgentLoopEventSink({ runId: "run-1", turnId: "chat-turn-1" });
+      const emit = (event: Partial<AgentLoopEvent> & { type: AgentLoopEvent["type"]; eventId: string } & {
+        createdAt?: string;
+      }) => sink.emit({
+        sessionId: "session-1",
+        traceId: "trace-1",
+        turnId: "agent-turn-1",
+        goalId: "goal-1",
+        createdAt: event.createdAt ?? "2026-04-08T00:00:00.000Z",
+        ...event,
+      } as AgentLoopEvent);
+
+      await emit({
+        type: "assistant_message",
+        eventId: "commentary-1",
+        phase: "commentary",
+        contentPreview: "Reviewing the timeline path.",
+        toolCallCount: 1,
+      });
+      await emit({
+        type: "tool_call_started",
+        eventId: "tool-start-1",
+        callId: "call-1",
+        toolName: "shell_command",
+        activityCategory: "command",
+        inputPreview: JSON.stringify({ command: "rg Timeline src/interface/chat" }),
+      });
+      await emit({
+        type: "tool_call_finished",
+        eventId: "tool-finish-1",
+        callId: "call-1",
+        toolName: "shell_command",
+        activityCategory: "command",
+        inputPreview: JSON.stringify({ command: "rg Timeline src/interface/chat" }),
+        success: true,
+        outputPreview: "src/interface/chat/chat-events.ts",
+        durationMs: 12,
+      });
+      await emit({
+        type: "approval_request",
+        eventId: "approval-1",
+        callId: "call-2",
+        toolName: "shell_command",
+        reason: "run a write command",
+        permissionLevel: "execute",
+        isDestructive: false,
+      });
+      await emit({
+        type: "context_compaction",
+        eventId: "compaction-1",
+        phase: "mid_turn",
+        reason: "context_limit",
+        inputMessages: 12,
+        outputMessages: 4,
+        summaryPreview: "kept timeline facts",
+      });
+      await emit({
+        type: "final",
+        eventId: "final-1",
+        success: true,
+        outputPreview: "Done from final.",
+        createdAt: "2026-04-08T00:00:01.000Z",
+      });
+      await adapter.stop();
+      return "Done from fallback.";
+    });
+
+    await adapter.start();
+
+    await vi.waitFor(() => {
+      expect(sentMessages).toEqual(expect.arrayContaining([
+        "Reviewing the timeline path.",
+        `Started shell_command: ${JSON.stringify({ command: "rg Timeline src/interface/chat" })}`,
+        "Finished shell_command: src/interface/chat/chat-events.ts",
+        "Approval requested for shell_command: run a write command",
+        "Compacted context (mid_turn, context_limit): 12 -> 4.",
+        "searched 1 search, requested 1 approval",
+      ]));
+    });
+    expect(sentMessages.some((message) => message.includes("[tool]"))).toBe(false);
+    expect(sentMessages).not.toContain("Done from final.");
+    expect(sentMessages).not.toContain("Done from fallback.");
+    expect(sentMessages.join("\n")).not.toContain("Agent-loop activity summarized");
+    expect(sentMessages.join("\n")).not.toMatch(/\b(Checkpoint|Intent|Current activity|Recent activity)\b/);
+  });
+
+  it("does not send fallback after an agent_timeline final marks assistant output", async () => {
+    const configDir = await writeConfig({
+      bot_token: "test-token",
+      allowed_user_ids: [42],
+      denied_user_ids: [],
+      allowed_chat_ids: [],
+      denied_chat_ids: [],
+      runtime_control_allowed_user_ids: [42],
+      chat_goal_map: {},
+      user_goal_map: {},
+      allow_all: true,
+      polling_timeout: 30,
+      identity_key: "seedy",
+    });
+    const sentMessages: string[] = [];
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const method = String(url).split("/").at(-1);
+      if (method === "getMe") return telegramResponse({ id: 1, username: "pulseed_test_bot" });
+      if (method === "getUpdates") {
+        return telegramResponse([{
+          update_id: 100,
+          message: { message_id: 2718, from: { id: 42 }, chat: { id: 314 }, text: "hello" },
+        }]);
+      }
+      if (method === "sendMessage") {
+        const body = JSON.parse(String(init?.body ?? "{}")) as { text?: string };
+        sentMessages.push(body.text ?? "");
+        return telegramResponse({ message_id: 9000 + sentMessages.length });
+      }
+      if (method === "sendChatAction") return telegramResponse(true);
+      throw new Error(`unexpected Telegram method: ${method}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const adapter = TelegramGatewayAdapter.fromConfigDir(configDir);
+    adapters.push(adapter);
+    vi.mocked(dispatchGatewayChatInput).mockImplementationOnce(async (input) => {
+      void input.onEvent?.({
+        type: "agent_timeline",
+        runId: "run-1",
+        turnId: "turn-1",
+        createdAt: "2026-04-08T00:00:02.000Z",
+        item: {
+          id: "agent-timeline:final-1",
+          sourceEventId: "final-1",
+          sourceType: "final",
+          sessionId: "session-1",
+          traceId: "trace-1",
+          turnId: "agent-turn-1",
+          goalId: "goal-1",
+          createdAt: "2026-04-08T00:00:02.000Z",
+          visibility: "user",
+          kind: "final",
+          success: true,
+          outputPreview: "Final timeline answer.",
+        },
+      });
+      await adapter.stop();
+      return "Fallback should not send.";
+    });
+
+    await adapter.start();
+    expect(sentMessages).not.toContain("Final timeline answer.");
+    expect(sentMessages).not.toContain("Fallback should not send.");
+
+    await vi.waitFor(() => {
+      expect(sentMessages).not.toContain("Fallback should not send.");
+    });
   });
 
   it("does not send fallback while async assistant_final delivery is still draining", async () => {

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -7,6 +7,7 @@ import { writeJsonFileAtomic } from "../../base/utils/json-io.js";
 import type { ChatEvent } from "../../interface/chat/chat-events.js";
 import { renderOperationProgress } from "../../interface/chat/operation-progress.js";
 import { formatLifecycleFailureMessage } from "../../interface/chat/failure-recovery.js";
+import { renderAgentTimelineItemForChat } from "../../interface/chat/chat-event-state.js";
 import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
 import { createRefreshingTypingIndicator, withTypingIndicator } from "./typing-indicator.js";
 import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
@@ -394,6 +395,7 @@ class TelegramChatEventAdapter {
   private assistantMessage: { messageId: number; text: string } | null = null;
   private readonly toolMessages = new Map<string, { messageId: number; text: string }>();
   private readonly activityMessages = new Map<string, { messageId: number; text: string }>();
+  private readonly timelineMessages = new Map<string, { messageId: number; text: string }>();
   private hasAssistantOutput = false;
 
   constructor(
@@ -411,6 +413,7 @@ class TelegramChatEventAdapter {
         this.assistantMessage = null;
         this.toolMessages.clear();
         this.activityMessages.clear();
+        this.timelineMessages.clear();
         this.hasAssistantOutput = false;
         return;
       case "assistant_delta":
@@ -423,15 +426,30 @@ class TelegramChatEventAdapter {
         }
         return;
       case "operation_progress":
+        if (event.item.metadata?.["source"] === "agent_timeline_activity_summary") return;
         await this.upsertActivityMessage(event.item.id, renderOperationProgress(event.item));
         return;
+      case "agent_timeline": {
+        if (event.item.visibility !== "user") return;
+        const text = renderAgentTimelineItemForChat(event.item).trim();
+        if (!text) return;
+        if (event.item.kind === "final") {
+          this.hasAssistantOutput = true;
+          return;
+        }
+        await this.upsertTimelineMessage(event.item.sourceEventId, text);
+        return;
+      }
       case "tool_start":
+        if (event.presentation?.suppressTranscript) return;
         await this.upsertToolMessage(event.toolCallId, `[tool] ${event.toolName} started`);
         return;
       case "tool_update":
+        if (event.presentation?.suppressTranscript) return;
         await this.upsertToolMessage(event.toolCallId, `[tool] ${event.toolName} ${event.status}: ${event.message}`);
         return;
       case "tool_end":
+        if (event.presentation?.suppressTranscript) return;
         await this.upsertToolMessage(
           event.toolCallId,
           `[tool] ${event.toolName} ${event.success ? "done" : "failed"}: ${event.summary}`
@@ -478,6 +496,17 @@ class TelegramChatEventAdapter {
     if (!existing) {
       const messageId = await this.api.sendPlainMessage(this.chatId, text);
       this.activityMessages.set(activityId, { messageId, text });
+      return;
+    }
+    await this.api.editMessageText(this.chatId, existing.messageId, text);
+    existing.text = text;
+  }
+
+  private async upsertTimelineMessage(sourceEventId: string, text: string): Promise<void> {
+    const existing = this.timelineMessages.get(sourceEventId);
+    if (!existing) {
+      const messageId = await this.api.sendPlainMessage(this.chatId, text);
+      this.timelineMessages.set(sourceEventId, { messageId, text });
       return;
     }
     await this.api.editMessageText(this.chatId, existing.messageId, text);

--- a/tmp/nightly-agent-timeline-runtime-foundation-status.md
+++ b/tmp/nightly-agent-timeline-runtime-foundation-status.md
@@ -15,3 +15,19 @@
 - Review finding addressed: added activity metadata to additional builtin search/read tools that previously relied on name-based classification (`code_search`, `code_search_repair`, `code_read_context`, `json_query`, `skill_search`, `knowledge_query`).
 - Review: second fresh review completed with no findings.
 - Status: ready for commit/PR.
+
+## #956 Expose shared agent timeline to non-TUI channels
+- Status: in progress.
+- Plan: use Telegram gateway as the smallest production-facing non-TUI vertical slice; reuse the shared `agent_timeline` ChatEvent payload directly, render compact user-visible timeline text from the shared item, and stop rendering suppressed legacy tool_* events in Telegram so raw/debug tool traces stay separate from normal channel output.
+- Implementation: exported the shared chat timeline renderer and wired Telegram gateway `ChatEvent` handling to render `agent_timeline` items directly. Telegram now ignores `tool_*` events marked `presentation.suppressTranscript`, keeping raw/debug tool traces separate from normal channel output while using the shared event contract.
+- Test added: Telegram gateway production-facing path builds shared timeline ChatEvents from `ChatRunnerEventBridge`/agent-loop events and verifies commentary, tool start/finish, activity summary/final, approval, and compaction render without internal labels.
+- Verification so far: focused Telegram gateway/chat event state Vitest passed; `npm run typecheck` passed.
+- Verification: `npm run lint:boundaries --if-present` exited 0 with existing warnings.
+- `npm run test:changed --if-present` failed in unrelated/shared-environment paths: daemon e2e could not bind 127.0.0.1:41700 (EADDRINUSE), and one Telegram cleanup assertion failed with ENOTEMPTY in that run. Re-running `npx vitest run --config vitest.integration.config.ts src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts` passed.
+- Review finding addressed: Telegram marks shared `agent_timeline` final rows as assistant output so fallback replies are suppressed; test now asserts fallback text is not sent.
+- Review finding addressed: final timeline fallback suppression now happens before awaiting Telegram send, with an async-drain regression test for `agent_timeline` final delivery.
+- Stability fix: Telegram gateway test cleanup now retries temp-dir removal, and async `agent_timeline` final test covers the fallback race directly.
+- Review finding addressed: Telegram suppresses `operation_progress` rows derived from `agent_timeline_activity_summary`, relying on the shared `agent_timeline` summary rendering; test now asserts the internal title does not appear.
+- Review finding addressed: Telegram no longer renders shared `agent_timeline` final rows as separate messages; final timeline rows only mark assistant output as present to suppress fallback, leaving production assistant_final rendering as the single final reply.
+- Review: final fresh review completed with no findings.
+- Status: ready for commit/PR.


### PR DESCRIPTION
Closes #956

## Summary
- Expose the shared `agent_timeline` ChatEvent renderer for channel adapters.
- Wire Telegram gateway to consume `agent_timeline` events directly for commentary, tool activity, approvals, compaction, and activity summaries.
- Keep raw/debug `tool_*` events with `presentation.suppressTranscript` out of normal Telegram output.
- Suppress derived activity-summary `operation_progress` rows in Telegram to avoid internal duplicate labels.
- Treat `agent_timeline` final rows as fallback suppression only so production `assistant_final` remains the single final reply.

## Verification
- `npx vitest run src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts src/interface/chat/__tests__/chat-event-state.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries --if-present`
- `npm run test:changed --if-present` failed in unrelated/shared-environment paths: daemon e2e could not bind `127.0.0.1:41700` (`EADDRINUSE`), and one Telegram cleanup assertion failed with `ENOTEMPTY` during that run. Re-running `npx vitest run --config vitest.integration.config.ts src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts` passed.

## Known unresolved risks
- This PR intentionally covers Telegram as the first production-facing non-TUI vertical slice. Discord/Slack-specific timeline rendering remains future work.