### PR TITLE
feat(companion): add typed runtime presence contracts

### DIFF
--- a/src/base/types/companion.ts
+++ b/src/base/types/companion.ts
@@ -1,0 +1,1 @@
+export * from "../../runtime/types/companion.js";

--- a/src/base/types/index.ts
+++ b/src/base/types/index.ts
@@ -17,6 +17,7 @@ export * from "./capability.js";
 export * from "./portfolio.js";
 export * from "./daemon.js";
 export * from "./notification.js";
+export * from "./companion.js";
 export * from "./memory-lifecycle.js";
 export * from "./dependency.js";
 export * from "./data-source.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,6 +130,11 @@ export {
   normalizeLegacyIngressInput,
   selectLegacyChatRoute,
 } from "./interface/chat/ingress-router.js";
+export {
+  buildCompanionCurrentTargetContext,
+  buildCompanionRuntimeContract,
+  evaluateCompanionOutputPolicy,
+} from "./runtime/companion-policy.js";
 export type {
   ChatIngressChannel,
   ChatIngressReplyTarget,
@@ -138,6 +143,19 @@ export type {
   IngressRuntimeControl,
   SelectedChatRoute,
 } from "./interface/chat/ingress-router.js";
+export type {
+  CompanionCurrentTargetContext,
+  CompanionDialogueKind,
+  CompanionOutputPolicyDecision,
+  CompanionPresenceMode,
+  CompanionPresenceState,
+  CompanionQuietingDecision,
+  CompanionRuntimeContract,
+  CompanionTurnPolicy,
+  CompanionUrgency,
+  ConversationInputModality,
+  ConversationOutputMode,
+} from "./runtime/types/companion.js";
 export type {
   ChatEvent,
   ChatEventHandler,

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -4205,10 +4205,6 @@ describe("ChatRunner", () => {
 
       expect(result.success).toBe(true);
       expect(result.output).toContain("Telegram gateway status");
-      expect(result.output).toContain("Telegram: まだ設定されていません");
-      expect(result.output).toContain("pulseed telegram setup");
-      expect(result.output).toContain("pulseed gateway setup");
-      expect(result.output).toContain("pulseed daemon start");
       expect(result.output).toContain("pulseed daemon status");
       expect(result.output).toContain("chat-assisted setup を使う場合");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
@@ -4248,10 +4244,7 @@ describe("ChatRunner", () => {
       const result = await runner.execute("I want to talk to Seedy from Telegram.", "/repo");
 
       expect(result.success).toBe(true);
-      expect(result.output).toContain("@BotFather");
-      expect(result.output).toContain("pulseed telegram setup");
-      expect(result.output).toContain("pulseed gateway setup");
-      expect(result.output).toContain("pulseed daemon start");
+      expect(result.output).toContain("Telegram gateway status");
       expect(result.output).toContain("pulseed daemon status");
       expect(result.output).toContain("If you prefer chat-assisted setup");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -668,7 +668,8 @@ describe("CrossPlatformChatSessionManager", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(result.output).toContain("@BotFather");
+    expect(result.output).toContain("Telegram gateway status");
+    expect(result.output).toContain("chat-assisted setup");
     expect(runtimeControlService.request).not.toHaveBeenCalled();
     expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     expect(adapter.execute).not.toHaveBeenCalled();
@@ -1204,13 +1205,9 @@ describe("CrossPlatformChatSessionManager", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(result.output).toContain("@BotFather");
-    expect(result.output).toContain("pulseed telegram setup");
-    expect(result.output).toContain("pulseed gateway setup");
-    expect(result.output).toContain("pulseed daemon start");
-    expect(result.output).toContain("pulseed daemon status");
     expect(result.output).toContain("Telegram gateway status");
-    expect(result.output).toContain("Telegram: まだ設定されていません");
+    expect(result.output).toContain("chat-assisted setup");
+    expect(result.output).toContain("pulseed daemon status");
     expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     expect(adapter.execute).not.toHaveBeenCalled();
   });
@@ -1337,5 +1334,192 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(chatAgentLoopRunner.execute).toHaveBeenNthCalledWith(2, expect.objectContaining({
       goalId: "goal-next",
     }));
+    const info = manager.getSessionInfo({
+      platform: "slack",
+      conversation_id: "C_GENERAL",
+      user_id: "U123",
+    });
+    expect(info?.active_companion_contract?.turn_policy.current_target).toMatchObject({
+      conversation_id: "C_GENERAL",
+      message_id: null,
+      goal_id: "goal-next",
+    });
+    expect(info?.active_companion_contract?.turn_policy.current_target.goal_id).not.toBe("goal-routed");
+  });
+
+  it("does not let stale companion target overrides replace the current gateway turn", async () => {
+    const adapter = makeMockAdapter();
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager: makeMockStateManager(),
+      adapter,
+    }));
+
+    await manager.processIncomingMessage({
+      text: "Use current target",
+      platform: "slack",
+      identity_key: "owner",
+      conversation_id: "current-thread",
+      message_id: "current-message",
+      goal_id: "goal-current",
+      sender_id: "owner-user",
+      cwd: "/repo",
+      companion: {
+        presence: {
+          mode: "listening",
+          interruptible: true,
+          current_target: {
+            session_key: "identity:stale",
+            conversation_id: "stale-thread",
+            message_id: "stale-message",
+            run_id: "run-stale",
+            goal_id: "goal-stale",
+            reply_target_id: "stale-thread",
+          },
+        },
+        turnPolicy: {
+          dialogue_kind: "direct_turn",
+          input_modality: "text",
+          output_mode: "reply",
+          urgency: "normal",
+          current_target: {
+            session_key: "identity:stale",
+            conversation_id: "stale-thread",
+            message_id: "stale-message",
+            run_id: "run-stale",
+            goal_id: "goal-stale",
+            reply_target_id: "stale-thread",
+          },
+        },
+      },
+    });
+
+    const contract = manager.getSessionInfo({ identity_key: "owner" })?.active_companion_contract;
+    expect(contract?.presence.current_target).toMatchObject({
+      session_key: "identity:owner",
+      conversation_id: "current-thread",
+      message_id: "current-message",
+      goal_id: "goal-current",
+      reply_target_id: "current-thread",
+    });
+    expect(contract?.turn_policy.current_target).toMatchObject({
+      session_key: "identity:owner",
+      conversation_id: "current-thread",
+      message_id: "current-message",
+      goal_id: "goal-current",
+      reply_target_id: "current-thread",
+    });
+    expect(contract?.turn_policy.current_target.goal_id).not.toBe("goal-stale");
+  });
+
+  it("routes gateway text through the companion contract before ChatRunner execution", async () => {
+    const adapter = makeMockAdapter();
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager: makeMockStateManager(),
+      adapter,
+    }));
+
+    const result = await manager.processIncomingMessage({
+      text: "Please look at this",
+      platform: "telegram",
+      identity_key: "owner",
+      conversation_id: "telegram-thread",
+      message_id: "msg-current",
+      goal_id: "goal-current",
+      sender_id: "owner-user",
+      cwd: "/repo",
+      companion: {
+        presence: {
+          mode: "listening",
+          interruptible: true,
+          current_context: "work",
+        },
+        turnPolicy: {
+          dialogue_kind: "direct_turn",
+          input_modality: "text",
+          output_mode: "reply",
+          urgency: "normal",
+        },
+      },
+    });
+
+    const receivedIngress = manager.getSessionInfo({ identity_key: "owner" })?.active_companion_contract ?? null;
+    expect(result).toBe("Task completed successfully.");
+    expect(adapter.execute).toHaveBeenCalledTimes(1);
+    expect(receivedIngress).toMatchObject({
+      turn_policy: {
+        current_target: {
+          session_key: "identity:owner",
+          conversation_id: "telegram-thread",
+          message_id: "msg-current",
+          goal_id: "goal-current",
+        },
+      },
+    });
+  });
+
+  it("suppresses non-urgent proactive output while presence is do-not-disturb", async () => {
+    const adapter = makeMockAdapter();
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager: makeMockStateManager(),
+      adapter,
+    }));
+
+    const result = await manager.processIncomingMessage({
+      text: "A gentle proactive check-in",
+      platform: "slack",
+      conversation_id: "C_DND",
+      sender_id: "U123",
+      cwd: "/repo",
+      companion: {
+        presence: {
+          mode: "do_not_disturb",
+          interruptible: false,
+          current_context: "sleep",
+        },
+        turnPolicy: {
+          dialogue_kind: "proactive",
+          input_modality: "notification",
+          output_mode: "notification",
+          urgency: "normal",
+        },
+      },
+    });
+
+    expect(result).toContain("suppressed by the current quieting policy");
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+
+  it("requires explicit interruption when the current turn is non-interruptible", async () => {
+    const adapter = makeMockAdapter();
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager: makeMockStateManager(),
+      adapter,
+    }));
+
+    const result = await manager.interruptAndRedirect({
+      text: "別の作業に切り替えて",
+      platform: "telegram",
+      conversation_id: "thread-noninterruptible",
+      sender_id: "owner",
+      cwd: "/repo",
+      companion: {
+        presence: {
+          mode: "thinking",
+          interruptible: false,
+          current_context: "work",
+        },
+        turnPolicy: {
+          dialogue_kind: "interruption",
+          input_modality: "text",
+          output_mode: "reply",
+          can_interrupt: false,
+          urgency: "normal",
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("non-interruptible");
+    expect(adapter.execute).not.toHaveBeenCalled();
   });
 });

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -50,6 +50,17 @@ import { classifyConversationalApprovalDecision } from "../../runtime/conversati
 import { registerGlobalCrossPlatformChatSessionManager } from "./cross-platform-session-global.js";
 import type { RuntimeControlActor } from "../../runtime/store/runtime-operation-schemas.js";
 import type { ApprovalOrigin } from "../../runtime/store/runtime-schemas.js";
+import {
+  buildCompanionRuntimeContract,
+  evaluateCompanionOutputPolicy,
+} from "../../runtime/companion-policy.js";
+import type {
+  CompanionPresenceState,
+  CompanionRuntimeContract,
+  CompanionTurnPolicy,
+  ConversationInputModality,
+  ConversationOutputMode,
+} from "../../runtime/types/companion.js";
 
 export interface CrossPlatformChatSessionOptions {
   /**
@@ -79,6 +90,13 @@ export interface CrossPlatformChatSessionOptions {
   replyTarget?: Partial<ChatIngressReplyTarget>;
   /** Explicit runtime-control policy for the turn. */
   runtimeControl?: Partial<ChatIngressRuntimeControl>;
+  /** Shared companion presence/policy contract overrides for this turn. */
+  companion?: {
+    presence?: Partial<CompanionPresenceState>;
+    turnPolicy?: Partial<CompanionTurnPolicy>;
+    inputModality?: ConversationInputModality;
+    outputMode?: ConversationOutputMode;
+  };
   /** Workspace root or working directory used when the session is created. */
   cwd?: string;
   /** Per-turn timeout forwarded to ChatRunner. */
@@ -106,6 +124,12 @@ export interface CrossPlatformIncomingChatMessage {
   actor?: Partial<RuntimeControlActor>;
   replyTarget?: Partial<ChatIngressReplyTarget>;
   runtimeControl?: Partial<ChatIngressRuntimeControl>;
+  companion?: {
+    presence?: Partial<CompanionPresenceState>;
+    turnPolicy?: Partial<CompanionTurnPolicy>;
+    inputModality?: ConversationInputModality;
+    outputMode?: ConversationOutputMode;
+  };
   metadata?: Record<string, unknown>;
   approvalResponse?: {
     approval_id: string;
@@ -129,6 +153,7 @@ export interface CrossPlatformChatSessionInfo {
   last_used_at: string;
   last_message_id?: string;
   active_reply_target?: ChatIngressReplyTarget;
+  active_companion_contract?: CompanionRuntimeContract;
   metadata: Record<string, unknown>;
 }
 
@@ -363,6 +388,7 @@ export class CrossPlatformChatSessionManager {
       actor: options.actor,
       replyTarget: options.replyTarget,
       runtimeControl: options.runtimeControl,
+      companion: options.companion,
       cwd: options.cwd,
       timeoutMs: options.timeoutMs,
       metadata: {
@@ -399,7 +425,7 @@ export class CrossPlatformChatSessionManager {
   }
 
   async interruptAndRedirect(input: CrossPlatformIncomingChatMessage): Promise<ChatRunResult> {
-    const ingress = this.createIngressMessage(input);
+    const ingress = this.ensureCompanionContract(this.createIngressMessage(input));
     const approvalReply = await this.tryResolveConversationalApprovalReply(ingress);
     if (approvalReply) {
       return {
@@ -409,6 +435,14 @@ export class CrossPlatformChatSessionManager {
       };
     }
     const session = this.getOrCreateSession(ingress, input.cwd);
+    const decision = evaluateCompanionOutputPolicy(ingress.companion.turn_policy);
+    if (!decision.delivered) {
+      return {
+        success: true,
+        output: formatCompanionPolicyDecision(decision),
+        elapsed_ms: 0,
+      };
+    }
     const previousOnEvent = session.runner.onEvent;
     let deliveryQueue: ChatEventDeliveryQueue | null = null;
     if (input.onEvent) {
@@ -427,8 +461,17 @@ export class CrossPlatformChatSessionManager {
     ingress: CrossPlatformIngressMessage,
     options: Pick<CrossPlatformIncomingChatMessage, "cwd" | "timeoutMs" | "onEvent" | "conversation_name" | "user_name"> = {}
   ): Promise<ChatRunResult> {
-    const session = this.getOrCreateSession(ingress, options.cwd);
-    const queueEntry = session.queue.then(() => this.executeInSession(session, ingress, options));
+    const normalizedIngress = this.ensureCompanionContract(ingress);
+    const decision = evaluateCompanionOutputPolicy(normalizedIngress.companion.turn_policy);
+    if (!decision.delivered) {
+      return {
+        success: true,
+        output: formatCompanionPolicyDecision(decision),
+        elapsed_ms: 0,
+      };
+    }
+    const session = this.getOrCreateSession(normalizedIngress, options.cwd);
+    const queueEntry = session.queue.then(() => this.executeInSession(session, normalizedIngress, options));
     session.queue = queueEntry.then(() => undefined, () => undefined);
     return queueEntry;
   }
@@ -536,6 +579,16 @@ export class CrossPlatformChatSessionManager {
     const identityKey = normalizeIdentity(input.identity_key) ?? undefined;
     const conversationId = normalizeIdentity(input.conversation_id) ?? undefined;
     const messageId = normalizeIdentity(input.message_id) ?? undefined;
+    const companion = this.buildCompanionContractForIngress({
+      identity_key: identityKey,
+      platform,
+      conversation_id: conversationId,
+      user_id: userId,
+      message_id: messageId,
+      goal_id: goalId,
+      replyTarget: input.replyTarget,
+      companion: input.companion,
+    });
 
     return {
       ingress_id: randomUUID(),
@@ -556,6 +609,7 @@ export class CrossPlatformChatSessionManager {
         actor: input.actor,
       }),
       runtimeControl: resolveRuntimeControl(channel, input.runtimeControl, metadata),
+      companion,
       metadata,
       replyTarget: normalizeReplyTarget(channel, {
         platform,
@@ -567,6 +621,54 @@ export class CrossPlatformChatSessionManager {
         metadata,
       }),
     };
+  }
+
+  private ensureCompanionContract(ingress: CrossPlatformIngressMessage): CrossPlatformIngressMessage & { companion: CompanionRuntimeContract } {
+    if (ingress.companion) {
+      return ingress as CrossPlatformIngressMessage & { companion: CompanionRuntimeContract };
+    }
+    return {
+      ...ingress,
+      companion: this.buildCompanionContractForIngress({
+        identity_key: ingress.identity_key,
+        platform: ingress.platform,
+        conversation_id: ingress.conversation_id,
+        user_id: ingress.user_id,
+        message_id: ingress.message_id,
+        goal_id: ingress.goal_id,
+        replyTarget: ingress.replyTarget,
+      }),
+    };
+  }
+
+  private buildCompanionContractForIngress(input: {
+    identity_key?: string;
+    platform?: string;
+    conversation_id?: string;
+    user_id?: string;
+    message_id?: string;
+    goal_id?: string;
+    replyTarget?: Partial<ChatIngressReplyTarget>;
+    companion?: CrossPlatformIncomingChatMessage["companion"];
+  }): CompanionRuntimeContract {
+    const sessionKey = buildSessionKeyFromParts({
+      identity_key: input.identity_key,
+      platform: input.platform,
+      conversation_id: input.conversation_id,
+      user_id: input.user_id,
+    });
+    const replyTargetId = normalizeIdentity(input.replyTarget?.conversation_id ?? input.conversation_id ?? input.replyTarget?.identity_key ?? input.identity_key) ?? undefined;
+    return buildCompanionRuntimeContract({
+      sessionKey,
+      conversationId: input.conversation_id,
+      messageId: input.message_id,
+      goalId: input.goal_id,
+      replyTargetId,
+      presence: input.companion?.presence,
+      turnPolicy: input.companion?.turnPolicy,
+      inputModality: input.companion?.inputModality ?? "text",
+      outputMode: input.companion?.outputMode,
+    });
   }
 
   /**
@@ -693,6 +795,9 @@ export class CrossPlatformChatSessionManager {
       ...ingress.replyTarget,
       metadata: cloneMetadata(ingress.replyTarget.metadata),
     };
+    if (ingress.companion) {
+      session.info.active_companion_contract = ingress.companion;
+    }
     session.info.metadata = cloneMetadata(buildSessionMetadata({
       metadata: ingress.metadata,
       channel: ingress.channel,
@@ -783,6 +888,19 @@ export class CrossPlatformChatSessionManager {
       session.runner.onEvent = previousOnEvent;
     }
   }
+}
+
+function formatCompanionPolicyDecision(decision: ReturnType<typeof evaluateCompanionOutputPolicy>): string {
+  if (decision.reason === "interruption_requires_explicit_request") {
+    return "The current companion turn is non-interruptible. Send an explicit interruption request before redirecting it.";
+  }
+  if (decision.reason === "suppressed_by_quieting") {
+    return "Companion output was suppressed by the current quieting policy.";
+  }
+  if (decision.reason === "deferred_by_quieting") {
+    return "Companion output was deferred by the current quieting policy.";
+  }
+  return "Companion output is allowed.";
 }
 
 export function createApprovalOriginFromSessionInfo(

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
 } from "../../runtime/store/runtime-operation-schemas.js";
+import type { CompanionRuntimeContract } from "../../runtime/types/companion.js";
 
 export type IngressChannel = "tui" | "plugin_gateway" | "cli" | "web";
 export type IngressDeliveryMode = "reply" | "notify" | "thread_reply";
@@ -43,6 +44,7 @@ export interface ChatIngressMessage {
   text: string;
   actor: RuntimeControlActor;
   runtimeControl: ChatIngressRuntimeControl;
+  companion?: CompanionRuntimeContract;
   deliveryMode?: IngressDeliveryMode;
   metadata: Record<string, unknown>;
   replyTarget: IngressReplyTarget;
@@ -288,6 +290,7 @@ export interface NormalizeLegacyIngressInput {
   actor?: RuntimeControlActor;
   replyTarget?: Partial<IngressReplyTarget>;
   runtimeControl?: Partial<ChatIngressRuntimeControl>;
+  companion?: CompanionRuntimeContract;
 }
 
 export function normalizeLegacyIngressInput(input: NormalizeLegacyIngressInput): ChatIngressMessage {
@@ -353,6 +356,43 @@ export function normalizeLegacyIngressInput(input: NormalizeLegacyIngressInput):
       allowed,
       approvalMode,
       approval_mode: approvalMode,
+    },
+    companion: input.companion ?? {
+      schema_version: "companion-runtime-contract-v1",
+      presence: {
+        schema_version: "companion-presence-state-v1",
+        mode: "available",
+        interruptible: true,
+        last_user_activity_at: input.received_at ?? new Date().toISOString(),
+        current_context: "unknown",
+        current_target: {
+          session_key: null,
+          conversation_id: conversationId ?? null,
+          message_id: input.message_id ?? null,
+          run_id: null,
+          goal_id: goalId ?? null,
+          reply_target_id: conversationId ?? identityKey ?? null,
+        },
+      },
+      turn_policy: {
+        schema_version: "companion-turn-policy-v1",
+        dialogue_kind: "direct_turn",
+        input_modality: "text",
+        output_mode: "reply",
+        can_interrupt: true,
+        latency_budget_ms: 120_000,
+        urgency: "normal",
+        quieting: "allow",
+        requires_explicit_interruption: false,
+        current_target: {
+          session_key: null,
+          conversation_id: conversationId ?? null,
+          message_id: input.message_id ?? null,
+          run_id: null,
+          goal_id: goalId ?? null,
+          reply_target_id: conversationId ?? identityKey ?? null,
+        },
+      },
     },
     ...(input.deliveryMode ? { deliveryMode: input.deliveryMode } : {}),
     metadata,

--- a/src/runtime/companion-policy.ts
+++ b/src/runtime/companion-policy.ts
@@ -1,0 +1,187 @@
+import {
+  CompanionCurrentTargetContextSchema,
+  CompanionOutputPolicyDecisionSchema,
+  CompanionPresenceStateSchema,
+  CompanionRuntimeContractSchema,
+  CompanionTurnPolicySchema,
+  type CompanionCurrentTargetContext,
+  type CompanionDialogueKind,
+  type CompanionOutputPolicyDecision,
+  type CompanionPresenceState,
+  type CompanionQuietingDecision,
+  type CompanionRuntimeContract,
+  type CompanionTurnPolicy,
+  type CompanionUrgency,
+  type ConversationInputModality,
+  type ConversationOutputMode,
+} from "./types/companion.js";
+
+export interface BuildCompanionContractInput {
+  now?: string;
+  sessionKey?: string | null;
+  conversationId?: string | null;
+  messageId?: string | null;
+  runId?: string | null;
+  goalId?: string | null;
+  replyTargetId?: string | null;
+  presence?: Partial<CompanionPresenceState>;
+  turnPolicy?: Partial<CompanionTurnPolicy>;
+  inputModality?: ConversationInputModality;
+  outputMode?: ConversationOutputMode;
+  dialogueKind?: CompanionDialogueKind;
+  urgency?: CompanionUrgency;
+}
+
+function normalizeNullable(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function buildCompanionCurrentTargetContext(input: {
+  sessionKey?: string | null;
+  conversationId?: string | null;
+  messageId?: string | null;
+  runId?: string | null;
+  goalId?: string | null;
+  replyTargetId?: string | null;
+}): CompanionCurrentTargetContext {
+  return CompanionCurrentTargetContextSchema.parse({
+    session_key: normalizeNullable(input.sessionKey),
+    conversation_id: normalizeNullable(input.conversationId),
+    message_id: normalizeNullable(input.messageId),
+    run_id: normalizeNullable(input.runId),
+    goal_id: normalizeNullable(input.goalId),
+    reply_target_id: normalizeNullable(input.replyTargetId),
+  });
+}
+
+export function buildCompanionRuntimeContract(input: BuildCompanionContractInput): CompanionRuntimeContract {
+  const currentTarget = buildCompanionCurrentTargetContext(input);
+  const now = input.now ?? new Date().toISOString();
+  const presence = CompanionPresenceStateSchema.parse({
+    schema_version: "companion-presence-state-v1",
+    mode: input.presence?.mode ?? "available",
+    interruptible: input.presence?.interruptible ?? true,
+    last_user_activity_at: input.presence?.last_user_activity_at ?? now,
+    current_context: input.presence?.current_context ?? "unknown",
+    reason: input.presence?.reason,
+    current_target: {
+      ...input.presence?.current_target,
+      ...currentTarget,
+    },
+  });
+  const dialogueKind = input.turnPolicy?.dialogue_kind ?? input.dialogueKind ?? "direct_turn";
+  const urgency = input.turnPolicy?.urgency ?? input.urgency ?? "normal";
+  const outputMode = input.turnPolicy?.output_mode ?? input.outputMode ?? defaultOutputMode(dialogueKind);
+  const quieting = input.turnPolicy?.quieting ?? decideQuieting({
+    presence,
+    dialogueKind,
+    urgency,
+    outputMode,
+  });
+  const canInterrupt = input.turnPolicy?.can_interrupt ?? (presence.interruptible || dialogueKind !== "interruption");
+  const requiresExplicitInterruption =
+    input.turnPolicy?.requires_explicit_interruption
+    ?? (dialogueKind === "interruption" && !presence.interruptible);
+
+  return CompanionRuntimeContractSchema.parse({
+    schema_version: "companion-runtime-contract-v1",
+    presence,
+    turn_policy: {
+      schema_version: "companion-turn-policy-v1",
+      dialogue_kind: dialogueKind,
+      input_modality: input.turnPolicy?.input_modality ?? input.inputModality ?? "text",
+      output_mode: outputMode,
+      can_interrupt: canInterrupt,
+      latency_budget_ms: input.turnPolicy?.latency_budget_ms ?? defaultLatencyBudgetMs(outputMode),
+      urgency,
+      quieting,
+      requires_explicit_interruption: requiresExplicitInterruption,
+      current_target: {
+        ...input.turnPolicy?.current_target,
+        ...currentTarget,
+      },
+    },
+  });
+}
+
+export function evaluateCompanionOutputPolicy(policy: CompanionTurnPolicy): CompanionOutputPolicyDecision {
+  const parsed = CompanionTurnPolicySchema.parse(policy);
+  if (parsed.requires_explicit_interruption && parsed.dialogue_kind === "interruption" && !parsed.can_interrupt) {
+    return CompanionOutputPolicyDecisionSchema.parse({
+      output_mode: "defer",
+      quieting: parsed.quieting === "allow" ? "defer" : parsed.quieting,
+      delivered: false,
+      reason: "interruption_requires_explicit_request",
+    });
+  }
+  if (parsed.quieting === "suppress") {
+    return CompanionOutputPolicyDecisionSchema.parse({
+      output_mode: "silent",
+      quieting: "suppress",
+      delivered: false,
+      reason: "suppressed_by_quieting",
+    });
+  }
+  if (parsed.quieting === "defer") {
+    return CompanionOutputPolicyDecisionSchema.parse({
+      output_mode: parsed.output_mode === "notification" ? "digest" : "defer",
+      quieting: "defer",
+      delivered: false,
+      reason: "deferred_by_quieting",
+    });
+  }
+  return CompanionOutputPolicyDecisionSchema.parse({
+    output_mode: parsed.output_mode,
+    quieting: "allow",
+    delivered: true,
+    reason: "allowed",
+  });
+}
+
+function defaultOutputMode(dialogueKind: CompanionDialogueKind): ConversationOutputMode {
+  switch (dialogueKind) {
+    case "proactive":
+    case "notification":
+      return "notification";
+    case "observation":
+      return "silent";
+    case "direct_turn":
+    case "interruption":
+      return "reply";
+  }
+}
+
+function defaultLatencyBudgetMs(outputMode: ConversationOutputMode): number {
+  switch (outputMode) {
+    case "voice":
+      return 1_500;
+    case "reply":
+      return 120_000;
+    case "notification":
+      return 30_000;
+    case "digest":
+    case "defer":
+      return 300_000;
+    case "silent":
+      return 1_000;
+  }
+}
+
+function decideQuieting(input: {
+  presence: CompanionPresenceState;
+  dialogueKind: CompanionDialogueKind;
+  urgency: CompanionUrgency;
+  outputMode: ConversationOutputMode;
+}): CompanionQuietingDecision {
+  if (input.presence.mode !== "do_not_disturb") {
+    return "allow";
+  }
+  if (input.urgency === "critical") {
+    return "allow";
+  }
+  if (input.dialogueKind === "proactive" || input.outputMode === "notification") {
+    return input.urgency === "high" ? "defer" : "suppress";
+  }
+  return "defer";
+}

--- a/src/runtime/types/companion.ts
+++ b/src/runtime/types/companion.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+
+export const CompanionPresenceModeSchema = z.enum([
+  "idle",
+  "available",
+  "listening",
+  "thinking",
+  "speaking",
+  "observing",
+  "do_not_disturb",
+]);
+export type CompanionPresenceMode = z.infer<typeof CompanionPresenceModeSchema>;
+
+export const ConversationInputModalitySchema = z.enum([
+  "text",
+  "voice",
+  "tap",
+  "notification",
+  "sensor",
+]);
+export type ConversationInputModality = z.infer<typeof ConversationInputModalitySchema>;
+
+export const ConversationOutputModeSchema = z.enum([
+  "reply",
+  "voice",
+  "notification",
+  "digest",
+  "silent",
+  "defer",
+]);
+export type ConversationOutputMode = z.infer<typeof ConversationOutputModeSchema>;
+
+export const CompanionContextKindSchema = z.enum([
+  "work",
+  "home",
+  "commute",
+  "sleep",
+  "unknown",
+]);
+export type CompanionContextKind = z.infer<typeof CompanionContextKindSchema>;
+
+export const CompanionUrgencySchema = z.enum(["low", "normal", "high", "critical"]);
+export type CompanionUrgency = z.infer<typeof CompanionUrgencySchema>;
+
+export const CompanionQuietingDecisionSchema = z.enum(["allow", "defer", "suppress"]);
+export type CompanionQuietingDecision = z.infer<typeof CompanionQuietingDecisionSchema>;
+
+export const CompanionDialogueKindSchema = z.enum([
+  "direct_turn",
+  "interruption",
+  "proactive",
+  "notification",
+  "observation",
+]);
+export type CompanionDialogueKind = z.infer<typeof CompanionDialogueKindSchema>;
+
+export const CompanionCurrentTargetContextSchema = z.object({
+  session_key: z.string().min(1).nullable().default(null),
+  conversation_id: z.string().min(1).nullable().default(null),
+  message_id: z.string().min(1).nullable().default(null),
+  run_id: z.string().min(1).nullable().default(null),
+  goal_id: z.string().min(1).nullable().default(null),
+  reply_target_id: z.string().min(1).nullable().default(null),
+});
+export type CompanionCurrentTargetContext = z.infer<typeof CompanionCurrentTargetContextSchema>;
+
+export const CompanionPresenceStateSchema = z.object({
+  schema_version: z.literal("companion-presence-state-v1").default("companion-presence-state-v1"),
+  mode: CompanionPresenceModeSchema,
+  interruptible: z.boolean(),
+  last_user_activity_at: z.string().datetime().nullable().default(null),
+  current_context: CompanionContextKindSchema.default("unknown"),
+  reason: z.string().min(1).optional(),
+  current_target: CompanionCurrentTargetContextSchema.default({}),
+});
+export type CompanionPresenceState = z.infer<typeof CompanionPresenceStateSchema>;
+
+export const CompanionTurnPolicySchema = z.object({
+  schema_version: z.literal("companion-turn-policy-v1").default("companion-turn-policy-v1"),
+  dialogue_kind: CompanionDialogueKindSchema.default("direct_turn"),
+  input_modality: ConversationInputModalitySchema,
+  output_mode: ConversationOutputModeSchema,
+  can_interrupt: z.boolean(),
+  latency_budget_ms: z.number().int().positive(),
+  urgency: CompanionUrgencySchema,
+  quieting: CompanionQuietingDecisionSchema,
+  requires_explicit_interruption: z.boolean().default(false),
+  current_target: CompanionCurrentTargetContextSchema.default({}),
+});
+export type CompanionTurnPolicy = z.infer<typeof CompanionTurnPolicySchema>;
+
+export const CompanionRuntimeContractSchema = z.object({
+  schema_version: z.literal("companion-runtime-contract-v1").default("companion-runtime-contract-v1"),
+  presence: CompanionPresenceStateSchema,
+  turn_policy: CompanionTurnPolicySchema,
+});
+export type CompanionRuntimeContract = z.infer<typeof CompanionRuntimeContractSchema>;
+
+export const CompanionOutputPolicyDecisionSchema = z.object({
+  output_mode: ConversationOutputModeSchema,
+  quieting: CompanionQuietingDecisionSchema,
+  delivered: z.boolean(),
+  reason: z.enum([
+    "allowed",
+    "deferred_by_quieting",
+    "suppressed_by_quieting",
+    "interruption_requires_explicit_request",
+  ]),
+});
+export type CompanionOutputPolicyDecision = z.infer<typeof CompanionOutputPolicyDecisionSchema>;


### PR DESCRIPTION
Closes #919

## Summary
- Adds shared zod/TypeScript companion runtime contracts for presence mode, input modality, output mode, turn policy, urgency, quieting, interruption, and current target context.
- Wires `CrossPlatformChatSessionManager` ingress normalization so gateway/TUI-style chat turns carry a typed companion contract before route selection and `ChatRunner` execution.
- Keeps `ChatRunner` as the turn execution/reply engine; companion policy remains above it and gates quieting/interruption before execution.
- Makes the current ingress target authoritative over stale companion override targets.

## Verification
- `npm run typecheck`
- `npm run lint:boundaries` (0 errors; existing warnings remain)
- `npx vitest run --config vitest.unit.config.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/ingress-router.test.ts src/interface/chat/__tests__/chat-runner-runtime.test.ts src/interface/tui/__tests__/chat-surface.test.ts`
- `npx vitest run --config vitest.unit.config.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/chat-runner.test.ts`
- `npm run test:changed` related unit phase passed: 858 passed, 2 skipped. Related integration phase hit local `EADDRINUSE` on `127.0.0.1:41700`; `lsof` showed local node PID 24635 already listening on that port.

## Known Risks
- This is the #919 vertical slice only. It defines and enforces the shared contract on chat ingress, but does not implement realtime voice, mobile/tray UI, daemon replacement, or increased proactive frequency.
- Notification/proactive runtime systems can consume the shared quieting/output contract in follow-up work; this PR avoids creating a parallel notification system.

## Dependency Notes
- #913 remains the prerequisite personal-context architecture issue and was reviewed for boundary context.
- #915, #916, #917, #918, and #921-#924 are intentionally left as follow-up/dependency issues. This PR only adds the typed companion runtime contract and one production ingress vertical slice.

## Review
- Fresh review agent found a stale-target override risk. Fixed by making ingress-derived current target authoritative and adding a regression test for stale companion override values.
