### PR TITLE
Replace divergent novelty scoring with typed lineage evidence

### DIFF
--- a/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
@@ -476,6 +476,20 @@ describe("detectStallsAndRebalance — reRefineLeaf on observation-failure stall
     deps.evidenceLedger = {
       append: vi.fn().mockResolvedValue([{ id: "evidence-divergent" }]),
       readByGoal: vi.fn().mockResolvedValue({ entries: [], warnings: [] }),
+      summarizeGoal: vi.fn().mockResolvedValue({
+        failed_lineages: [{
+          fingerprint: "threshold_sweep|dim1|threshold_sweep",
+          count: 2,
+          first_seen_at: "2026-04-30T00:00:00.000Z",
+          last_seen_at: "2026-04-30T00:05:00.000Z",
+          strategy_family: "threshold_sweep",
+          primary_dimension: "dim1",
+          task_action: "threshold_sweep",
+          representative_entry_id: "evidence-failed-latest",
+          representative_summary: "Threshold sweeps repeatedly failed.",
+          evidence_entry_ids: ["evidence-failed-1", "evidence-failed-2"],
+        }],
+      }),
     };
     const stallReport = makeStallReport({
       stall_type: "predicted_plateau",
@@ -513,6 +527,10 @@ describe("detectStallsAndRebalance — reRefineLeaf on observation-failure stall
       trigger: "predicted_plateau",
       stallCount: 2,
       primaryDimension: "dim1",
+      failedLineages: [expect.objectContaining({
+        fingerprint: "threshold_sweep|dim1|threshold_sweep",
+        strategy_family: "threshold_sweep",
+      })],
     }));
     expect(deps.strategyManager.onStallDetected).not.toHaveBeenCalled();
     expect(deps.evidenceLedger.append).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/orchestrator/loop/durable-loop/task-cycle-stall.ts
+++ b/src/orchestrator/loop/durable-loop/task-cycle-stall.ts
@@ -3,6 +3,7 @@ import type { Goal } from "../../../base/types/goal.js";
 import type { GapHistoryEntry } from "../../../base/types/gap.js";
 import type { StallReport } from "../../../base/types/stall.js";
 import type { MetricTrendContext } from "../../../platform/drive/metric-history.js";
+import type { RuntimeFailedLineageContext } from "../../../runtime/store/evidence-ledger.js";
 import type { GapObservation } from "../../../base/types/time-horizon.js";
 import {
   selectMetricTrendForDimension,
@@ -26,6 +27,7 @@ type StrategyStallArgs = [
   goalType?: string,
   activationContext?: WaitStrategyActivationContext,
   metricTrendContext?: MetricTrendContext,
+  failedLineages?: RuntimeFailedLineageContext[],
 ];
 
 type DivergentExplorationPlanner = {
@@ -38,6 +40,7 @@ type DivergentExplorationPlanner = {
       stallCount: number;
       trigger: "sustained_stall" | "predicted_plateau" | "predicted_regression";
       metricTrendContext?: MetricTrendContext;
+      failedLineages?: RuntimeFailedLineageContext[];
     }
   ) => Promise<unknown>;
 };
@@ -157,6 +160,7 @@ async function applyStallAction(
   const activeStrategyForRecord = await Promise.resolve(ctx.deps.strategyManager.getActiveStrategy(goalId)).catch(() => null);
   const strategyIdForRecord = activeStrategyForRecord?.id ?? "unknown";
   const metricTrendContext = stallReport.metric_trend_context;
+  const failedLineages = await loadFailedLineageContexts(ctx, goalId);
   if (metricTrendContext) {
     result.metricTrendContext = metricTrendContext;
     ctx.logger?.info(`CoreLoop: ${logPrefix}metric trend evidence — ${metricTrendContext.summary}`, {
@@ -204,6 +208,7 @@ async function applyStallAction(
       goal.origin ?? "general",
       waitActivationContext,
       metricTrendContext,
+      failedLineages,
     ]);
     await appendDivergentRecoveryEvidence(ctx, goalId, result, stallReport);
     result.pivotOccurred = true;
@@ -225,6 +230,7 @@ async function applyStallAction(
         goal.origin ?? "general",
         waitActivationContext,
         metricTrendContext,
+        failedLineages,
       ]);
       await appendDivergentRecoveryEvidence(ctx, goalId, result, stallReport);
       result.pivotOccurred = true;
@@ -235,6 +241,7 @@ async function applyStallAction(
         goal.origin ?? "general",
         waitActivationContext,
         metricTrendContext,
+        failedLineages,
       ]);
       if (newStrategy) {
         await appendDivergentRecoveryEvidence(ctx, goalId, result, stallReport);
@@ -288,16 +295,36 @@ async function callStrategyOnStall(
   args: StrategyStallArgs
 ) {
   const [goalId, stallCount, goalType, activationContext, metricTrendContext] = args;
+  const failedLineages = args[5];
+  const hasFailedLineages = failedLineages !== undefined && failedLineages.length > 0;
   if (metricTrendContext) {
-    return ctx.deps.strategyManager.onStallDetected(
+    return hasFailedLineages
+      ? ctx.deps.strategyManager.onStallDetected(
+        goalId,
+        stallCount,
+        goalType,
+        activationContext,
+        metricTrendContext,
+        failedLineages
+      )
+      : ctx.deps.strategyManager.onStallDetected(
+        goalId,
+        stallCount,
+        goalType,
+        activationContext,
+        metricTrendContext
+      );
+  }
+  return hasFailedLineages
+    ? ctx.deps.strategyManager.onStallDetected(
       goalId,
       stallCount,
       goalType,
       activationContext,
-      metricTrendContext
-    );
-  }
-  return ctx.deps.strategyManager.onStallDetected(goalId, stallCount, goalType, activationContext);
+      undefined,
+      failedLineages
+    )
+    : ctx.deps.strategyManager.onStallDetected(goalId, stallCount, goalType, activationContext);
 }
 
 async function loadMetricTrendContexts(ctx: PhaseCtx, goalId: string): Promise<MetricTrendContext[]> {
@@ -308,6 +335,21 @@ async function loadMetricTrendContexts(ctx: PhaseCtx, goalId: string): Promise<M
     return summarizeEvidenceMetricTrends(read.entries);
   } catch (err) {
     ctx.logger?.warn("CoreLoop: metric trend history unavailable (non-fatal)", {
+      goalId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
+}
+
+async function loadFailedLineageContexts(ctx: PhaseCtx, goalId: string): Promise<RuntimeFailedLineageContext[]> {
+  const summarizeGoal = ctx.deps.evidenceLedger?.summarizeGoal;
+  if (!summarizeGoal) return [];
+  try {
+    const summary = await summarizeGoal.call(ctx.deps.evidenceLedger, goalId);
+    return summary.failed_lineages;
+  } catch (err) {
+    ctx.logger?.warn("CoreLoop: failed lineage summary unavailable (non-fatal)", {
       goalId,
       error: err instanceof Error ? err.message : String(err),
     });
@@ -379,6 +421,7 @@ async function requestPredictedDivergentExploration(
   const planner = ctx.deps.strategyManager as unknown as DivergentExplorationPlanner;
   if (!planner.prepareDivergentExplorationOnStall) return;
   const dimension = stallReport.dimension_name ?? goal.dimensions[0]?.name ?? "";
+  const failedLineages = await loadFailedLineageContexts(ctx, goalId);
   try {
     await planner.prepareDivergentExplorationOnStall(goalId, {
       primaryDimension: dimension,
@@ -387,6 +430,7 @@ async function requestPredictedDivergentExploration(
       stallCount: Math.max(2, stallReport.escalation_level),
       trigger,
       ...(stallReport.metric_trend_context ? { metricTrendContext: stallReport.metric_trend_context } : {}),
+      ...(failedLineages.length > 0 ? { failedLineages } : {}),
     });
     await appendDivergentRecoveryEvidence(ctx, goalId, result, stallReport);
   } catch (err) {

--- a/src/orchestrator/strategy/__tests__/strategy-manager-stall.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-stall.test.ts
@@ -105,6 +105,96 @@ const NEAR_STALL_RECOVERY_RESPONSE = `\`\`\`json
 ]
 \`\`\``;
 
+const PARAPHRASE_MULTILINGUAL_RECOVERY_RESPONSE = `\`\`\`json
+[
+  {
+    "hypothesis": "Adjust the learner cutoff and rebalance weights around the same validation plateau",
+    "expected_effect": [
+      { "dimension": "balanced_accuracy", "direction": "increase", "magnitude": "small" }
+    ],
+    "resource_estimate": {
+      "sessions": 2,
+      "duration": { "value": 3, "unit": "hours" },
+      "llm_calls": 1
+    },
+    "allocation": 0.3
+  },
+  {
+    "hypothesis": "現在の分類器のしきい値を少し調整して停滞を確認する",
+    "expected_effect": [
+      { "dimension": "balanced_accuracy", "direction": "increase", "magnitude": "small" }
+    ],
+    "resource_estimate": {
+      "sessions": 2,
+      "duration": { "value": 3, "unit": "hours" },
+      "llm_calls": 1
+    },
+    "allocation": 0.3
+  }
+]
+\`\`\``;
+
+const TYPED_LINEAGE_RECOVERY_RESPONSE = `\`\`\`json
+[
+  {
+    "hypothesis": "Run distribution-shift audit against validation folds before another model refinement",
+    "expected_effect": [
+      { "dimension": "balanced_accuracy", "direction": "increase", "magnitude": "medium" }
+    ],
+    "resource_estimate": {
+      "sessions": 1,
+      "duration": { "value": 45, "unit": "minutes" },
+      "llm_calls": 1
+    },
+    "allocation": 0.3,
+    "exploration": {
+      "schema_version": "strategy-exploration-v1",
+      "phase": "divergent_stall_recovery",
+      "role": "divergent_exploration",
+      "strategy_family": "fold-distribution-audit",
+      "novelty_score": 0.84,
+      "similarity_to_recent_failures": 0,
+      "expected_cost": "low",
+      "relationship_to_lineage": "different_assumption",
+      "smoke": {
+        "status": "not_run",
+        "reason": "Run a smoke-scale fold audit before expensive execution."
+      },
+      "speculative": true,
+      "evidence_authority": "speculative_hypothesis"
+    }
+  },
+  {
+    "hypothesis": "Repeat threshold sweep with a tighter calibration grid",
+    "expected_effect": [
+      { "dimension": "balanced_accuracy", "direction": "increase", "magnitude": "small" }
+    ],
+    "resource_estimate": {
+      "sessions": 2,
+      "duration": { "value": 4, "unit": "hours" },
+      "llm_calls": 1
+    },
+    "allocation": 0.3,
+    "exploration": {
+      "schema_version": "strategy-exploration-v1",
+      "phase": "divergent_stall_recovery",
+      "role": "adjacent_exploration",
+      "strategy_family": "threshold_sweep",
+      "novelty_score": 0.58,
+      "similarity_to_recent_failures": 0,
+      "expected_cost": "medium",
+      "relationship_to_lineage": "neighbor",
+      "smoke": {
+        "status": "not_run",
+        "reason": "Needs smoke evidence before promotion."
+      },
+      "speculative": true,
+      "evidence_authority": "speculative_hypothesis"
+    }
+  }
+]
+\`\`\``;
+
 // ─── Test Setup ───
 
 let tempDir: string;
@@ -314,8 +404,89 @@ describe("onStallDetected", () => {
       }),
     }));
     expect(recoveryCandidates.some((strategy) =>
-      strategy.exploration?.downrank_reason === "similar_to_recent_failed_lineage_without_new_evidence"
+      strategy.exploration?.downrank_reason === "low_confidence_lineage_assessment"
     )).toBe(true);
+  });
+
+  it("keeps paraphrased and multilingual novelty ambiguous when no typed lineage evidence exists", async () => {
+    const mock = createMockLLMClient([KAGGLE_LOCAL_SEARCH_RESPONSE, PARAPHRASE_MULTILINGUAL_RECOVERY_RESPONSE]);
+    const manager = new StrategyManager(stateManager, mock);
+
+    await manager.generateCandidates("goal-1", "balanced_accuracy", ["balanced_accuracy"], {
+      currentGap: 0.2,
+      pastStrategies: [],
+    });
+    await manager.activateBestCandidate("goal-1");
+
+    await manager.onStallDetected("goal-1", 2, "kaggle");
+
+    const portfolio = await manager.getPortfolio("goal-1");
+    const recoveryCandidates = portfolio?.strategies.filter(
+      (strategy) => strategy.exploration?.phase === "divergent_stall_recovery"
+    ) ?? [];
+    const rawCandidates = recoveryCandidates.filter((strategy) =>
+      strategy.exploration?.lineage_assessment?.novelty_basis === "diagnostic_text_overlap"
+      || strategy.exploration?.lineage_assessment?.novelty_basis === "unknown"
+    );
+    expect(rawCandidates).toHaveLength(2);
+    expect(rawCandidates.every((strategy) =>
+      strategy.exploration?.role !== "divergent_exploration"
+      && (strategy.exploration?.lineage_assessment?.confidence ?? 1) < 0.65
+      && strategy.exploration?.downrank_reason === "low_confidence_lineage_assessment"
+    )).toBe(true);
+    expect(recoveryCandidates.some((strategy) =>
+      strategy.exploration?.lineage_assessment?.summary ===
+        "Fallback smoke audit is intentionally separated from recorded failed lineage keys."
+    )).toBe(true);
+  });
+
+  it("uses typed failed-lineage evidence and strategy metadata in production stall recovery ranking", async () => {
+    const mock = createMockLLMClient([KAGGLE_LOCAL_SEARCH_RESPONSE, TYPED_LINEAGE_RECOVERY_RESPONSE]);
+    const manager = new StrategyManager(stateManager, mock);
+
+    await manager.generateCandidates("goal-1", "balanced_accuracy", ["balanced_accuracy"], {
+      currentGap: 0.2,
+      pastStrategies: [],
+    });
+    await manager.activateBestCandidate("goal-1");
+
+    await manager.onStallDetected("goal-1", 2, "kaggle", undefined, undefined, [{
+      fingerprint: "threshold_sweep|balanced_accuracy|threshold_sweep",
+      count: 3,
+      first_seen_at: "2026-04-30T00:00:00.000Z",
+      last_seen_at: "2026-05-01T00:00:00.000Z",
+      strategy_family: "threshold_sweep",
+      primary_dimension: "balanced_accuracy",
+      task_action: "threshold_sweep",
+      representative_entry_id: "evidence://failed-lineage/latest",
+      representative_summary: "Threshold sweeps repeatedly failed.",
+      evidence_entry_ids: ["evidence://failed-lineage/1", "evidence://failed-lineage/2"],
+    }]);
+
+    const portfolio = await manager.getPortfolio("goal-1");
+    const recoveryCandidates = portfolio?.strategies.filter(
+      (strategy) => strategy.exploration?.phase === "divergent_stall_recovery"
+    ) ?? [];
+    const divergent = recoveryCandidates.find((strategy) =>
+      strategy.exploration?.strategy_family === "fold-distribution-audit"
+    );
+    const failedLineage = recoveryCandidates.find((strategy) =>
+      strategy.exploration?.strategy_family === "threshold_sweep"
+    );
+
+    expect(divergent?.exploration?.lineage_assessment).toMatchObject({
+      confidence: 0.72,
+      novelty_basis: "strategy_metadata",
+      relationship_to_lineage: "different_assumption",
+    });
+    expect(failedLineage?.exploration?.lineage_assessment).toMatchObject({
+      confidence: 0.9,
+      novelty_basis: "typed_lineage_evidence",
+      relationship_to_lineage: "failed_lineage",
+      matched_failed_lineage_fingerprints: ["threshold_sweep|balanced_accuracy|threshold_sweep"],
+    });
+    expect(failedLineage?.exploration?.downrank_reason).toBe("similar_to_recent_failed_lineage_without_new_evidence");
+    expect((divergent?.exploration?.novelty_score ?? 0) > (failedLineage?.exploration?.novelty_score ?? 1)).toBe(true);
   });
 
   it("records smoke promote defer and retire decisions without treating speculative candidates as proven", async () => {

--- a/src/orchestrator/strategy/divergent-exploration.ts
+++ b/src/orchestrator/strategy/divergent-exploration.ts
@@ -4,11 +4,14 @@ import type {
   Strategy,
   StrategyExplorationExpectedCost,
   StrategyExplorationRole,
-  StrategyLineageRelationship,
+  StrategyLineageAssessment,
   StrategySmokeStatus,
 } from "../../base/types/strategy.js";
 import type { MetricTrendContext } from "../../platform/drive/metric-history.js";
-import type { RuntimeEvidenceDivergentHypothesis } from "../../runtime/store/evidence-ledger.js";
+import type {
+  RuntimeEvidenceDivergentHypothesis,
+  RuntimeFailedLineageContext,
+} from "../../runtime/store/evidence-ledger.js";
 
 export interface DivergentRecoveryInput {
   goalId: string;
@@ -20,6 +23,7 @@ export interface DivergentRecoveryInput {
   stallCount: number;
   trigger?: "sustained_stall" | "predicted_plateau" | "predicted_regression";
   metricTrendContext?: MetricTrendContext;
+  failedLineages?: RuntimeFailedLineageContext[];
   minDivergentCandidates?: number;
   minNoveltyScore?: number;
 }
@@ -39,6 +43,7 @@ export interface DivergentSmokeResultInput {
 
 const DEFAULT_MIN_DIVERGENT_CANDIDATES = 1;
 const DEFAULT_MIN_NOVELTY_SCORE = 0.72;
+const LOW_CONFIDENCE_DIVERGENCE_THRESHOLD = 0.65;
 const TOKEN_STOP_WORDS = new Set([
   "a",
   "an",
@@ -127,7 +132,7 @@ export function applySmokeResult(strategy: Strategy, input: DivergentSmokeResult
         schema_version: "strategy-exploration-v1",
         phase: "divergent_stall_recovery",
         role: "adjacent_exploration",
-        strategy_family: inferStrategyFamily(strategy.hypothesis),
+        strategy_family: strategy.exploration?.strategy_family ?? "unclassified",
         novelty_score: 0.5,
         similarity_to_recent_failures: 0,
         expected_cost: inferExpectedCost(strategy),
@@ -188,22 +193,26 @@ function annotateCandidate(
   lineage: Strategy[],
   minNoveltyScore: number
 ): Strategy {
-  const maxSimilarity = Math.max(0, ...lineage.map((strategy) => similarity(candidate.hypothesis, strategy.hypothesis)));
-  const family = candidate.exploration?.strategy_family ?? inferStrategyFamily(candidate.hypothesis);
-  const lineageFamilies = new Set(lineage.map((strategy) => inferStrategyFamily(strategy.hypothesis)));
+  const assessment = assessStrategyLineage(candidate, input, lineage);
+  const family = candidate.exploration?.strategy_family ?? "unclassified";
   const hasNewEvidence = Boolean(candidate.exploration?.prior_evidence)
     || input.metricTrendContext?.trend === "breakthrough"
     || candidate.exploration?.smoke.status === "promote";
-  const noveltyScore = clamp01(
-    candidate.exploration?.novelty_score
-    ?? (1 - maxSimilarity + (lineageFamilies.has(family) ? -0.1 : 0.15))
-  );
-  const relationship = candidate.exploration?.relationship_to_lineage
-    ?? inferRelationship(maxSimilarity, family, lineageFamilies);
-  const role = candidate.exploration?.role ?? roleFromNovelty(noveltyScore, minNoveltyScore);
+  const lowConfidence = assessment.confidence < LOW_CONFIDENCE_DIVERGENCE_THRESHOLD;
+  const noveltyScore = lowConfidence
+    ? Math.min(candidate.exploration?.novelty_score ?? 0.5, minNoveltyScore - 0.01)
+    : assessment.relationship_to_lineage === "failed_lineage"
+      ? noveltyFromAssessment(assessment)
+    : clamp01(candidate.exploration?.novelty_score ?? noveltyFromAssessment(assessment));
+  const relationship = assessment.relationship_to_lineage;
+  const role = lowConfidence
+    ? "adjacent_exploration"
+    : candidate.exploration?.role ?? roleFromNovelty(noveltyScore, minNoveltyScore);
   const downrankReason = candidate.exploration?.downrank_reason
-    ?? (!hasNewEvidence && (maxSimilarity >= 0.5 || relationship === "failed_lineage")
+    ?? (!hasNewEvidence && (assessment.matched_failed_lineage_fingerprints.length > 0 || relationship === "failed_lineage")
       ? "similar_to_recent_failed_lineage_without_new_evidence"
+      : lowConfidence
+        ? "low_confidence_lineage_assessment"
       : undefined);
 
   return parseStrategy({
@@ -217,7 +226,7 @@ function annotateCandidate(
       role,
       strategy_family: family,
       novelty_score: noveltyScore,
-      similarity_to_recent_failures: clamp01(maxSimilarity),
+      similarity_to_recent_failures: assessment.relationship_to_lineage === "failed_lineage" ? assessment.confidence : 0,
       expected_cost: candidate.exploration?.expected_cost ?? inferExpectedCost(candidate),
       relationship_to_lineage: relationship,
       prior_evidence: candidate.exploration?.prior_evidence ?? input.metricTrendContext?.summary,
@@ -230,6 +239,7 @@ function annotateCandidate(
       },
       speculative: true,
       evidence_authority: "speculative_hypothesis",
+      lineage_assessment: assessment,
     },
   });
 }
@@ -239,7 +249,10 @@ function buildFallbackDivergentCandidate(
   lineage: Strategy[],
   minNoveltyScore: number
 ): Strategy {
-  const failedFamilies = [...new Set(lineage.map((strategy) => inferStrategyFamily(strategy.hypothesis)))]
+  const failedFamilies = [...new Set([
+    ...(input.failedLineages ?? []).map((lineageContext) => lineageContext.strategy_family),
+    ...lineage.map((strategy) => strategy.exploration?.strategy_family),
+  ])]
     .filter(Boolean)
     .slice(0, 3);
   const dimension = input.primaryDimension || input.targetDimensions[0] || "primary_outcome";
@@ -287,6 +300,17 @@ function buildFallbackDivergentCandidate(
       },
       speculative: true,
       evidence_authority: "speculative_hypothesis",
+      lineage_assessment: {
+        schema_version: "strategy-lineage-assessment-v1",
+        confidence: 0.8,
+        relationship_to_lineage: "different_assumption",
+        novelty_basis: input.metricTrendContext ? "metric_trend_context" : "typed_lineage_evidence",
+        matched_failed_lineage_fingerprints: [],
+        matched_strategy_ids: lineage.map((strategy) => strategy.id).filter(Boolean),
+        evidence_refs: (input.failedLineages ?? []).flatMap((failed) => failed.evidence_entry_ids).slice(0, 5),
+        ...(input.metricTrendContext ? { metric_trend: input.metricTrendContext.trend } : {}),
+        summary: "Fallback smoke audit is intentionally separated from recorded failed lineage keys.",
+      },
     },
   });
 }
@@ -326,15 +350,90 @@ function scoreCandidate(strategy: Strategy): number {
   return roleScore + smokeScore + downrank + costPenalty + exploration.novelty_score - exploration.similarity_to_recent_failures;
 }
 
-function inferStrategyFamily(hypothesis: string): string {
-  const normalized = hypothesis.toLowerCase();
-  if (/\b(stack|ensemble|blend|multi[- ]model|probability)\b/.test(normalized)) return "model-stack";
-  if (/\b(feature|cross|interaction|encoding|embedding)\b/.test(normalized)) return "feature-engineering";
-  if (/\b(audit|distribution|leakage|label|noise|data)\b/.test(normalized)) return "data-audit";
-  if (/\b(calibration|threshold|bias|class[- ]weight|weight)\b/.test(normalized)) return "calibration-threshold";
-  if (/\b(catboost|xgboost|lightgbm|model|classifier)\b/.test(normalized)) return "model-family";
-  if (/\b(research|public|paper|writeup|source)\b/.test(normalized)) return "source-research";
-  return tokens(hypothesis).slice(0, 3).join("-") || "general";
+function assessStrategyLineage(
+  candidate: Strategy,
+  input: DivergentRecoveryInput,
+  lineage: Strategy[]
+): StrategyLineageAssessment {
+  const family = candidate.exploration?.strategy_family;
+  const relationship = candidate.exploration?.relationship_to_lineage;
+  const smoke = candidate.exploration?.smoke;
+  const matchedFailedLineages = (input.failedLineages ?? []).filter((failed) =>
+    (family && failed.strategy_family === family)
+    || failed.fingerprint === candidate.id
+    || (candidate.source_template_id !== null && failed.fingerprint === candidate.source_template_id)
+  );
+  const matchedStrategyIds = lineage
+    .filter((strategy) =>
+      strategy.id === candidate.id
+      || (family && strategy.exploration?.strategy_family === family)
+      || (candidate.source_template_id !== null && strategy.source_template_id === candidate.source_template_id)
+    )
+    .map((strategy) => strategy.id);
+  const lexicalDiagnostic = Math.max(0, ...lineage.map((strategy) => similarity(candidate.hypothesis, strategy.hypothesis)));
+  const evidenceRefs = [
+    ...matchedFailedLineages.flatMap((failed) => failed.evidence_entry_ids),
+    ...(smoke?.evidence_ref ? [smoke.evidence_ref] : []),
+    ...(input.metricTrendContext?.source_refs.map((ref) => ref.entry_id).filter((ref): ref is string => Boolean(ref)) ?? []),
+  ];
+
+  if (matchedFailedLineages.length > 0) {
+    return {
+      schema_version: "strategy-lineage-assessment-v1",
+      confidence: 0.9,
+      relationship_to_lineage: "failed_lineage",
+      novelty_basis: "typed_lineage_evidence",
+      matched_failed_lineage_fingerprints: matchedFailedLineages.map((failed) => failed.fingerprint),
+      matched_strategy_ids: matchedStrategyIds,
+      evidence_refs: [...new Set(evidenceRefs)].slice(0, 8),
+      ...(input.metricTrendContext ? { metric_trend: input.metricTrendContext.trend } : {}),
+      lexical_similarity_diagnostic: lexicalDiagnostic,
+      summary: "Candidate matches failed lineage keys from the evidence ledger.",
+    };
+  }
+
+  if (smoke?.status === "promote") {
+    return {
+      schema_version: "strategy-lineage-assessment-v1",
+      confidence: 0.82,
+      relationship_to_lineage: relationship ?? "different_mechanism",
+      novelty_basis: "smoke_evidence",
+      matched_failed_lineage_fingerprints: [],
+      matched_strategy_ids: matchedStrategyIds,
+      evidence_refs: [...new Set(evidenceRefs)].slice(0, 8),
+      ...(input.metricTrendContext ? { metric_trend: input.metricTrendContext.trend } : {}),
+      lexical_similarity_diagnostic: lexicalDiagnostic,
+      summary: "Smoke evidence provides typed support for the proposed lineage relationship.",
+    };
+  }
+
+  if (family && relationship && relationship !== "unknown") {
+    return {
+      schema_version: "strategy-lineage-assessment-v1",
+      confidence: 0.72,
+      relationship_to_lineage: relationship,
+      novelty_basis: "strategy_metadata",
+      matched_failed_lineage_fingerprints: [],
+      matched_strategy_ids: matchedStrategyIds,
+      evidence_refs: [...new Set(evidenceRefs)].slice(0, 8),
+      ...(input.metricTrendContext ? { metric_trend: input.metricTrendContext.trend } : {}),
+      lexical_similarity_diagnostic: lexicalDiagnostic,
+      summary: "Candidate supplied typed exploration metadata for lineage assessment.",
+    };
+  }
+
+  return {
+    schema_version: "strategy-lineage-assessment-v1",
+    confidence: 0.35,
+    relationship_to_lineage: "unknown",
+    novelty_basis: lexicalDiagnostic > 0 ? "diagnostic_text_overlap" : "unknown",
+    matched_failed_lineage_fingerprints: [],
+    matched_strategy_ids: matchedStrategyIds,
+    evidence_refs: [...new Set(evidenceRefs)].slice(0, 8),
+    ...(input.metricTrendContext ? { metric_trend: input.metricTrendContext.trend } : {}),
+    lexical_similarity_diagnostic: lexicalDiagnostic,
+    summary: "No authoritative typed lineage evidence was available; text overlap is diagnostic only.",
+  };
 }
 
 function inferExpectedCost(strategy: Strategy): StrategyExplorationExpectedCost {
@@ -350,15 +449,13 @@ function inferExpectedCost(strategy: Strategy): StrategyExplorationExpectedCost 
   return "medium";
 }
 
-function inferRelationship(
-  maxSimilarity: number,
-  family: string,
-  lineageFamilies: ReadonlySet<string>
-): StrategyLineageRelationship {
-  if (maxSimilarity >= 0.7) return "failed_lineage";
-  if (maxSimilarity >= 0.45 || lineageFamilies.has(family)) return "neighbor";
-  if (/audit|research|framing/.test(family)) return "different_assumption";
-  return "different_mechanism";
+function noveltyFromAssessment(assessment: StrategyLineageAssessment): number {
+  if (assessment.relationship_to_lineage === "different_assumption") return 0.84;
+  if (assessment.relationship_to_lineage === "different_mechanism") return 0.78;
+  if (assessment.relationship_to_lineage === "neighbor") return 0.55;
+  if (assessment.relationship_to_lineage === "current_best") return 0.35;
+  if (assessment.relationship_to_lineage === "failed_lineage") return 0.2;
+  return 0.45;
 }
 
 function roleFromNovelty(noveltyScore: number, minNoveltyScore: number): StrategyExplorationRole {

--- a/src/orchestrator/strategy/strategy-manager-base.ts
+++ b/src/orchestrator/strategy/strategy-manager-base.ts
@@ -14,6 +14,7 @@ import type { ToolExecutor } from "../../tools/executor.js";
 import type { ToolCallContext } from "../../tools/types.js";
 import type { ToolRegistry } from "../../tools/registry.js";
 import type { MetricTrendContext } from "../../platform/drive/metric-history.js";
+import type { RuntimeFailedLineageContext } from "../../runtime/store/evidence-ledger.js";
 import {
   applySmokeResult,
   buildDivergentRecoveryPortfolio,
@@ -167,6 +168,7 @@ export class StrategyManagerBase {
         minNoveltyScore: number;
         activeStrategy?: Strategy | null;
         stallCount: number;
+        failedLineages?: RuntimeFailedLineageContext[];
       };
     },
     enrichment?: { templatesBlock?: string; lessonsBlock?: string },
@@ -264,6 +266,7 @@ export class StrategyManagerBase {
         stallCount: context.divergentExploration.stallCount,
         trigger: context.divergentExploration.trigger,
         metricTrendContext: context.metricTrendContext,
+        failedLineages: context.divergentExploration.failedLineages,
         minDivergentCandidates: context.divergentExploration.minDivergentCandidates,
         minNoveltyScore: context.divergentExploration.minNoveltyScore,
       });
@@ -442,6 +445,7 @@ export class StrategyManagerBase {
       stallCount: number;
       trigger: "sustained_stall" | "predicted_plateau" | "predicted_regression";
       metricTrendContext?: MetricTrendContext;
+      failedLineages?: RuntimeFailedLineageContext[];
     }
   ): Promise<Strategy[]> {
     if (!shouldRequestDivergentExploration(input)) {
@@ -463,6 +467,7 @@ export class StrategyManagerBase {
           minNoveltyScore: 0.72,
           activeStrategy: active,
           stallCount: input.stallCount,
+          failedLineages: input.failedLineages,
         },
       }
     );
@@ -583,7 +588,8 @@ export class StrategyManagerBase {
     stallCount: number,
     goalType?: string,
     activationContext?: WaitStrategyActivationContext,
-    metricTrendContext?: MetricTrendContext
+    metricTrendContext?: MetricTrendContext,
+    failedLineages?: RuntimeFailedLineageContext[]
   ): Promise<Strategy | null> {
     if (stallCount < 2) {
       return null;
@@ -638,6 +644,7 @@ export class StrategyManagerBase {
           minNoveltyScore: 0.72,
           activeStrategy: active,
           stallCount,
+          failedLineages,
         }
       : undefined;
     try {

--- a/src/orchestrator/strategy/types/strategy.ts
+++ b/src/orchestrator/strategy/types/strategy.ts
@@ -57,6 +57,27 @@ export const StrategySmokeMetadataSchema = z.object({
 }).strict();
 export type StrategySmokeMetadata = z.infer<typeof StrategySmokeMetadataSchema>;
 
+export const StrategyLineageAssessmentSchema = z.object({
+  schema_version: z.literal("strategy-lineage-assessment-v1").default("strategy-lineage-assessment-v1"),
+  confidence: z.number().min(0).max(1),
+  relationship_to_lineage: StrategyLineageRelationshipSchema,
+  novelty_basis: z.enum([
+    "typed_lineage_evidence",
+    "strategy_metadata",
+    "metric_trend_context",
+    "smoke_evidence",
+    "diagnostic_text_overlap",
+    "unknown",
+  ]),
+  matched_failed_lineage_fingerprints: z.array(z.string().min(1)).default([]),
+  matched_strategy_ids: z.array(z.string().min(1)).default([]),
+  evidence_refs: z.array(z.string().min(1)).default([]),
+  metric_trend: z.enum(["improving", "stalled", "noisy", "regressing", "breakthrough"]).optional(),
+  lexical_similarity_diagnostic: z.number().min(0).max(1).optional(),
+  summary: z.string().min(1),
+}).strict();
+export type StrategyLineageAssessment = z.infer<typeof StrategyLineageAssessmentSchema>;
+
 export const StrategyExplorationMetadataSchema = z.object({
   schema_version: z.literal("strategy-exploration-v1").default("strategy-exploration-v1"),
   phase: z.enum(["normal", "divergent_stall_recovery"]).default("normal"),
@@ -71,6 +92,7 @@ export const StrategyExplorationMetadataSchema = z.object({
   smoke: StrategySmokeMetadataSchema.default({ status: "not_run" }),
   speculative: z.literal(true).default(true),
   evidence_authority: z.literal("speculative_hypothesis").default("speculative_hypothesis"),
+  lineage_assessment: StrategyLineageAssessmentSchema.optional(),
 }).strict();
 export type StrategyExplorationMetadata = z.infer<typeof StrategyExplorationMetadataSchema>;
 

--- a/tmp/semantic-heuristic-issues-status.md
+++ b/tmp/semantic-heuristic-issues-status.md
@@ -1,0 +1,11 @@
+# Semantic heuristic issue status
+
+## Startup
+- 2026-05-04: Ran `git switch main && git pull --ff-only`; main was already up to date.
+- 2026-05-04: Ran `gh issue list --state open --limit 100`; target issues #1029, #1030, #1031, #1032, #1033, #1034, and #1035 are open. Other open issues are not blockers/prerequisites for this batch.
+
+## #1029
+- Status: implementation verified locally; preparing PR.
+- Plan: add a typed `StrategyLineageAssessment` contract in divergent recovery, prefer existing exploration metadata plus evidence-ledger failed lineage fingerprints and metric trend/smoke evidence, demote text overlap to diagnostic fallback, and pass failed lineage context through the production durable stall path.
+- Review: fresh review agent found lexical diagnostics still affected ranking and predicted recovery lacked failed-lineage plumbing/test coverage; fixed both before PR.
+- Verification: `npm run typecheck`; `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-stall.test.ts src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts`; `npm run test:changed`; `npm run lint:boundaries` (warnings only, pre-existing).


### PR DESCRIPTION
Closes #1029

## Implementation summary
- Added a typed `StrategyLineageAssessment` contract to strategy exploration metadata.
- Reworked divergent stall recovery to prefer typed strategy metadata, smoke evidence, metric context, and evidence-ledger failed lineage fingerprints.
- Kept lexical overlap as diagnostic-only context; low-confidence assessments no longer silently promote candidates as divergent.
- Passed failed-lineage summaries through sustained and predicted production stall recovery paths.
- Added caller-path and semantic regression tests for paraphrased, multilingual, ambiguous, and evidence-backed lineage behavior.

## Verification commands
- `npm run typecheck`
- `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-stall.test.ts src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts`
- `npm run test:changed`
- `npm run lint:boundaries` (0 errors; existing warnings remain)

## Known unresolved risks
- `npm run lint:boundaries` still reports pre-existing warnings across the repository; this PR does not address unrelated lint cleanup.
- `test:changed` reports pre-existing untracked `.pulseed-sandbox/` files as changed inputs, but they are not included in this PR.