### PR TITLE
Rank decision history by typed lineage keys

### DIFF
--- a/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts
@@ -442,6 +442,69 @@ describe("detectStallsAndRebalance — reRefineLeaf on observation-failure stall
     expect(result.metricTrendContext).toMatchObject({ metric_key: "dim1", trend: "breakthrough" });
   });
 
+  it("records typed strategy lineage keys with stall decisions", async () => {
+    const deps = createBaseDeps(tmpDir);
+    const goal = makeGoal({ id: "goal-1", origin: "manual" });
+    await deps.stateManager.saveGoal(goal);
+    await deps.stateManager.saveGapHistory("goal-1", makeGapHistoryWithStall("dim1", 5));
+
+    (deps.strategyManager.getActiveStrategy as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "strategy-active",
+      hypothesis: "Repeat threshold tuning around the same plateau",
+      primary_dimension: "dim1",
+      target_dimensions: ["dim1"],
+      exploration: {
+        schema_version: "strategy-exploration-v1",
+        phase: "divergent_stall_recovery",
+        role: "adjacent_exploration",
+        strategy_family: "threshold_sweep",
+        novelty_score: 0.5,
+        similarity_to_recent_failures: 0.9,
+        expected_cost: "medium",
+        relationship_to_lineage: "failed_lineage",
+        smoke: { status: "not_run", reason: "Smoke first." },
+        speculative: true,
+        evidence_authority: "speculative_hypothesis",
+        lineage_assessment: {
+          schema_version: "strategy-lineage-assessment-v1",
+          confidence: 0.9,
+          relationship_to_lineage: "failed_lineage",
+          novelty_basis: "typed_lineage_evidence",
+          matched_failed_lineage_fingerprints: ["threshold_sweep|dim1|threshold_sweep"],
+          matched_strategy_ids: ["strategy-active"],
+          evidence_refs: ["evidence-failed-1"],
+          summary: "Matched failed lineage.",
+        },
+      },
+    });
+    const knowledgeManager = {
+      recordDecision: vi.fn().mockResolvedValue(undefined),
+    };
+    deps.knowledgeManager = knowledgeManager as never;
+    (deps.stallDetector.checkDimensionStall as ReturnType<typeof vi.fn>).mockReturnValue(makeStallReport({
+      goal_id: "goal-1",
+      dimension_name: "dim1",
+      escalation_level: 2,
+    }));
+    (deps.strategyManager.onStallDetected as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "strategy-next", state: "active" });
+
+    const ctx = buildPhaseCtx(deps, { maxIterations: 10, adapterType: "openai_codex_cli" });
+    const result = makeIterationResult();
+
+    await detectStallsAndRebalance(ctx, "goal-1", goal, result);
+
+    expect(knowledgeManager.recordDecision).toHaveBeenCalledWith(expect.objectContaining({
+      strategy_id: "strategy-active",
+      hypothesis: "Repeat threshold tuning around the same plateau",
+      lineage: expect.objectContaining({
+        strategy_family: "threshold_sweep",
+        relationship_to_lineage: "failed_lineage",
+        failed_lineage_fingerprints: ["threshold_sweep|dim1|threshold_sweep"],
+        lineage_evidence_refs: ["evidence-failed-1"],
+      }),
+    }));
+  });
+
   it("requests divergent exploration on predicted plateau without pivoting and writes speculative evidence", async () => {
     const deps = createBaseDeps(tmpDir);
     const goal = makeGoal({ id: "goal-1" });

--- a/src/orchestrator/loop/durable-loop/task-cycle-stall.ts
+++ b/src/orchestrator/loop/durable-loop/task-cycle-stall.ts
@@ -13,7 +13,10 @@ import { gatherStallEvidence } from "../stall-evidence.js";
 import type { LoopIterationResult } from "./contracts.js";
 import type { PhaseCtx } from "./preparation.js";
 import type { StallActionHints } from "./task-cycle.js";
-import type { WaitStrategyActivationContext } from "../../strategy/strategy-manager-base.js";
+import {
+  buildDecisionLineageForStrategy,
+  type WaitStrategyActivationContext,
+} from "../../strategy/strategy-manager-base.js";
 import { collectDivergentHypotheses } from "../../strategy/divergent-exploration.js";
 
 type DimensionGapSample = {
@@ -261,12 +264,14 @@ async function applyStallAction(
     try {
       const latestGap = dimHistory[dimHistory.length - 1]?.normalized_gap ?? 1;
       const recordedDecision = selectedAction === "continue" ? "proceed" : selectedAction;
+      const decisionLineage = buildDecisionLineageForStrategy(activeStrategyForRecord);
       await ctx.deps.knowledgeManager.recordDecision({
         id: randomUUID(),
         goal_id: goalId,
         goal_type: goal.origin ?? "general",
         strategy_id: strategyIdForRecord,
         hypothesis: activeStrategyForRecord?.hypothesis,
+        ...(decisionLineage ? { lineage: decisionLineage } : {}),
         decision: recordedDecision,
         context: {
           gap_value: latestGap,

--- a/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
@@ -5,6 +5,7 @@ import { StateManager } from "../../../base/state/state-manager.js";
 import { StrategyManager } from "../strategy-manager.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import type { Strategy } from "../../../base/types/strategy.js";
+import type { DecisionRecord } from "../../../base/types/knowledge.js";
 import { applyDecisionHeuristicsToCandidates } from "../../../platform/dream/dream-activation.js";
 import { saveDreamConfig } from "../../../platform/dream/dream-config.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
@@ -88,6 +89,39 @@ function makeStrategy(overrides: Partial<Strategy> = {}): Strategy {
   };
 }
 
+function makeDecisionRecord(overrides: Partial<DecisionRecord> = {}): DecisionRecord {
+  return {
+    id: "decision-1",
+    goal_id: "goal-1",
+    goal_type: "kaggle",
+    strategy_id: "strategy-old",
+    hypothesis: "historical diagnostic text",
+    decision: "pivot",
+    context: {
+      gap_value: 0.4,
+      stall_count: 2,
+      cycle_count: 5,
+      trust_score: 0,
+    },
+    outcome: "failure",
+    timestamp: "2026-05-04T00:00:00.000Z",
+    what_worked: [],
+    what_failed: [],
+    suggested_next: [],
+    ...overrides,
+  };
+}
+
+function makeDecisionHistoryManager(records: DecisionRecord[]): TestableStrategyManager {
+  return new TestableStrategyManager(
+    stateManager,
+    createMockLLMClient([]),
+    {
+      queryDecisions: vi.fn().mockResolvedValue(records),
+    } as never
+  );
+}
+
 const STRATEGY_TEMPLATES_ACTIVATION = {
   verifiedPlannerHintsOnly: false,
   semanticWorkingMemory: false,
@@ -102,6 +136,12 @@ const STRATEGY_TEMPLATES_ACTIVATION = {
   graphTraversal: false,
 } as const;
 
+class TestableStrategyManager extends StrategyManager {
+  rankByDecisionHistory(candidates: Strategy[], goalType: string): Promise<Strategy[]> {
+    return this._rankCandidatesByDecisionHistory(candidates, goalType);
+  }
+}
+
 // ─── Test Setup ───
 
 let tempDir: string;
@@ -114,6 +154,97 @@ beforeEach(() => {
 
 afterEach(() => {
   fs.rmSync(tempDir, { recursive: true, force: true , maxRetries: 3, retryDelay: 100 });
+});
+
+describe("decision history lineage ranking", () => {
+  it("downranks a paraphrased candidate from a failed typed lineage", async () => {
+    const failedLineageCandidate = makeStrategy({
+      id: "candidate-threshold",
+      hypothesis: "Explore a narrower cutoff calibration sweep around the plateau",
+      exploration: {
+        schema_version: "strategy-exploration-v1",
+        phase: "divergent_stall_recovery",
+        role: "adjacent_exploration",
+        strategy_family: "threshold_sweep",
+        novelty_score: 0.55,
+        similarity_to_recent_failures: 0,
+        expected_cost: "medium",
+        relationship_to_lineage: "neighbor",
+        smoke: { status: "not_run", reason: "Smoke before full run." },
+        speculative: true,
+        evidence_authority: "speculative_hypothesis",
+      },
+    });
+    const unrelatedCandidate = makeStrategy({
+      id: "candidate-audit",
+      hypothesis: "Audit validation fold distribution before more tuning",
+      exploration: {
+        schema_version: "strategy-exploration-v1",
+        phase: "divergent_stall_recovery",
+        role: "divergent_exploration",
+        strategy_family: "fold_distribution_audit",
+        novelty_score: 0.82,
+        similarity_to_recent_failures: 0,
+        expected_cost: "low",
+        relationship_to_lineage: "different_assumption",
+        smoke: { status: "not_run", reason: "Smoke before full run." },
+        speculative: true,
+        evidence_authority: "speculative_hypothesis",
+      },
+    });
+    const manager = makeDecisionHistoryManager([
+      makeDecisionRecord({ id: "d1", lineage: { strategy_family: "threshold_sweep", failed_lineage_fingerprints: [], lineage_evidence_refs: [] } }),
+      makeDecisionRecord({ id: "d2", lineage: { strategy_family: "threshold_sweep", failed_lineage_fingerprints: [], lineage_evidence_refs: [] } }),
+      makeDecisionRecord({ id: "d3", decision: "proceed", outcome: "success", lineage: { strategy_family: "fold_distribution_audit", failed_lineage_fingerprints: [], lineage_evidence_refs: [] } }),
+    ]);
+
+    const ranked = await manager.rankByDecisionHistory([failedLineageCandidate, unrelatedCandidate], "kaggle");
+
+    expect(ranked.map((strategy) => strategy.id)).toEqual(["candidate-audit", "candidate-threshold"]);
+  });
+
+  it("does not penalize unrelated candidates that only overlap hypothesis tokens", async () => {
+    const failedText = "Tune threshold calibration around current model";
+    const overlappingButTypedDifferent = makeStrategy({
+      id: "candidate-overlap",
+      hypothesis: "Calibrate reporting threshold for documentation coverage",
+      exploration: {
+        schema_version: "strategy-exploration-v1",
+        phase: "normal",
+        role: "exploitation",
+        strategy_family: "documentation_quality",
+        novelty_score: 0.4,
+        similarity_to_recent_failures: 0,
+        expected_cost: "low",
+        relationship_to_lineage: "current_best",
+        smoke: { status: "not_run", reason: "No smoke required." },
+        speculative: true,
+        evidence_authority: "speculative_hypothesis",
+      },
+    });
+    const manager = makeDecisionHistoryManager([
+      makeDecisionRecord({ id: "d1", hypothesis: failedText, lineage: { strategy_family: "model_threshold_sweep", failed_lineage_fingerprints: [], lineage_evidence_refs: [] } }),
+      makeDecisionRecord({ id: "d2", hypothesis: failedText, lineage: { strategy_family: "model_threshold_sweep", failed_lineage_fingerprints: [], lineage_evidence_refs: [] } }),
+      makeDecisionRecord({ id: "d3", hypothesis: failedText, lineage: { strategy_family: "model_threshold_sweep", failed_lineage_fingerprints: [], lineage_evidence_refs: [] } }),
+    ]);
+
+    const ranked = await manager.rankByDecisionHistory([overlappingButTypedDifferent], "coding");
+
+    expect(ranked[0]?.id).toBe("candidate-overlap");
+  });
+
+  it("preserves existing order when fewer than three decision records exist", async () => {
+    const first = makeStrategy({ id: "candidate-first", hypothesis: "First candidate" });
+    const second = makeStrategy({ id: "candidate-second", hypothesis: "Second candidate" });
+    const manager = makeDecisionHistoryManager([
+      makeDecisionRecord({ id: "d1", lineage: { strategy_family: "candidate-second-family", failed_lineage_fingerprints: [], lineage_evidence_refs: [] } }),
+      makeDecisionRecord({ id: "d2", lineage: { strategy_family: "candidate-second-family", failed_lineage_fingerprints: [], lineage_evidence_refs: [] } }),
+    ]);
+
+    const ranked = await manager.rankByDecisionHistory([first, second], "general");
+
+    expect(ranked.map((strategy) => strategy.id)).toEqual(["candidate-first", "candidate-second"]);
+  });
 });
 
 // ─── generateCandidates ───

--- a/src/orchestrator/strategy/strategy-manager-base.ts
+++ b/src/orchestrator/strategy/strategy-manager-base.ts
@@ -6,7 +6,7 @@ import type { Strategy, Portfolio } from "../../base/types/strategy.js";
 import type { StrategyState } from "../../base/types/core.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import type { IPromptGateway } from "../../prompt/gateway.js";
-import type { KnowledgeGapSignal } from "../../base/types/knowledge.js";
+import type { DecisionLineage, DecisionRecord, KnowledgeGapSignal } from "../../base/types/knowledge.js";
 import type { KnowledgeManager } from "../../platform/knowledge/knowledge-manager.js";
 import type { StrategyTemplateRegistry } from "./strategy-template-registry.js";
 import type { Logger } from "../../runtime/logger.js";
@@ -51,6 +51,47 @@ export interface ExecutionFeedback {
   verificationPassed: boolean;
   duration_ms: number;
   timestamp: number;
+}
+
+export function buildDecisionLineageForStrategy(strategy: Strategy | null | undefined): DecisionLineage | undefined {
+  if (!strategy) return undefined;
+  const exploration = strategy.exploration;
+  const lineage: DecisionLineage = {
+    failed_lineage_fingerprints: exploration?.lineage_assessment?.matched_failed_lineage_fingerprints ?? [],
+    lineage_evidence_refs: exploration?.lineage_assessment?.evidence_refs ?? [],
+  };
+  if (exploration?.strategy_family) {
+    lineage.strategy_family = exploration.strategy_family;
+  }
+  if (strategy.source_template_id) {
+    lineage.source_template_id = strategy.source_template_id;
+  }
+  if (exploration?.relationship_to_lineage && exploration.relationship_to_lineage !== "unknown") {
+    lineage.relationship_to_lineage = exploration.relationship_to_lineage;
+  }
+  return decisionLineageKeys(lineage).length > 0 ? lineage : undefined;
+}
+
+function decisionRecordLineageKeys(record: DecisionRecord): string[] {
+  const keys = record.lineage ? decisionLineageKeys(record.lineage) : [];
+  if (keys.length > 0) return keys;
+  return record.strategy_id ? [`strategy:${record.strategy_id}`] : [];
+}
+
+function strategyDecisionLineageKeys(strategy: Strategy): string[] {
+  return [
+    `strategy:${strategy.id}`,
+    ...decisionLineageKeys(buildDecisionLineageForStrategy(strategy)),
+  ];
+}
+
+function decisionLineageKeys(lineage: DecisionLineage | undefined): string[] {
+  if (!lineage) return [];
+  return [
+    lineage.source_template_id ? `template:${lineage.source_template_id}` : null,
+    lineage.strategy_family ? `family:${lineage.strategy_family}` : null,
+    ...(lineage.failed_lineage_fingerprints ?? []).map((fingerprint) => `failed:${fingerprint}`),
+  ].filter((key): key is string => Boolean(key));
 }
 
 export interface WaitStrategyActivationContext {
@@ -721,24 +762,34 @@ export class StrategyManagerBase {
       return candidates;
     }
 
-    // Build score map: hypothesis text → adjustment
-    // Pivot → -1, Success → +1, Others → 0
+    // Build score map from stable typed lineage keys. Exact hypothesis text is
+    // retained on DecisionRecord only as diagnostic context.
     const scoreMap = new Map<string, number>();
     for (const record of records) {
-      const key = record.hypothesis;
-      if (!key) continue;
-      const existing = scoreMap.get(key) ?? 0;
-      if (record.decision === "pivot" && record.outcome !== "success") {
-        scoreMap.set(key, existing - 1);
-      } else if (record.outcome === "success") {
-        scoreMap.set(key, existing + 1);
+      const keys = decisionRecordLineageKeys(record);
+      if (keys.length === 0) continue;
+      const delta = record.decision === "pivot" && record.outcome !== "success"
+        ? -1
+        : record.outcome === "success"
+          ? 1
+          : 0;
+      if (delta === 0) continue;
+      for (const key of keys) {
+        scoreMap.set(key, (scoreMap.get(key) ?? 0) + delta);
       }
     }
 
-    const scored = candidates.map((c) => ({
-      candidate: c,
-      score: scoreMap.get(c.hypothesis) ?? 0,
-    }));
+    const scored = candidates.map((candidate) => {
+      const candidateKeys = strategyDecisionLineageKeys(candidate);
+      let score = 0;
+      for (const key of candidateKeys) {
+        score += scoreMap.get(key) ?? 0;
+      }
+      return {
+        candidate,
+        score,
+      };
+    });
 
     // Stable sort: higher score first (ties keep original order)
     scored.sort((a, b) => b.score - a.score);

--- a/src/platform/knowledge/types/knowledge.ts
+++ b/src/platform/knowledge/types/knowledge.ts
@@ -135,12 +135,29 @@ export const DecisionContextSchema = z.object({
 });
 export type DecisionContext = z.infer<typeof DecisionContextSchema>;
 
+export const DecisionLineageSchema = z.object({
+  strategy_family: z.string().min(1).optional(),
+  source_template_id: z.string().min(1).optional(),
+  relationship_to_lineage: z.enum([
+    "current_best",
+    "neighbor",
+    "failed_lineage",
+    "different_mechanism",
+    "different_assumption",
+    "unknown",
+  ]).optional(),
+  failed_lineage_fingerprints: z.array(z.string().min(1)).default([]),
+  lineage_evidence_refs: z.array(z.string().min(1)).default([]),
+}).strict();
+export type DecisionLineage = z.infer<typeof DecisionLineageSchema>;
+
 export const DecisionRecordSchema = z.object({
   id: z.string(),
   goal_id: z.string(),
   goal_type: z.string(),
   strategy_id: z.string(),
   hypothesis: z.string().optional(),
+  lineage: DecisionLineageSchema.optional(),
   decision: z.enum(["proceed", "refine", "pivot", "escalate"]),
   context: DecisionContextSchema,
   outcome: z.enum(["success", "failure", "pending"]),

--- a/tmp/semantic-heuristic-issues-status.md
+++ b/tmp/semantic-heuristic-issues-status.md
@@ -9,3 +9,10 @@
 - Plan: add a typed `StrategyLineageAssessment` contract in divergent recovery, prefer existing exploration metadata plus evidence-ledger failed lineage fingerprints and metric trend/smoke evidence, demote text overlap to diagnostic fallback, and pass failed lineage context through the production durable stall path.
 - Review: fresh review agent found lexical diagnostics still affected ranking and predicted recovery lacked failed-lineage plumbing/test coverage; fixed both before PR.
 - Verification: `npm run typecheck`; `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-stall.test.ts src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts`; `npm run test:changed`; `npm run lint:boundaries` (warnings only, pre-existing).
+- Result: PR #1036 merged; CI unit (22) and integration (24) passed.
+
+## #1034
+- Status: implementation verified locally; preparing PR.
+- Plan: extend `DecisionRecord` with typed lineage metadata, record lineage metadata from active strategies in the durable stall path, and replace exact-hypothesis ranking in `StrategyManagerBase` with typed lineage-key scoring. Exact hypothesis remains diagnostic-only.
+- Review: fresh review agent reported no material findings.
+- Verification: `npm run typecheck`; `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts src/platform/knowledge/__tests__/decision-record.test.ts`; `npm run test:changed`; `npm run lint:boundaries` (warnings only, pre-existing).


### PR DESCRIPTION
Closes #1034

## Implementation summary
- Added typed lineage metadata to `DecisionRecord` while keeping `hypothesis` as diagnostic context.
- Recorded active strategy lineage metadata from the production stall decision path.
- Replaced exact-hypothesis decision-history scoring in `StrategyManagerBase` with stable lineage keys from strategy family, source template id, failed-lineage fingerprints, and strategy id fallback.
- Added tests for shared failed lineage paraphrases, unrelated token overlap, fewer-than-three-record fallback, and caller-path decision recording.

## Verification commands
- `npm run typecheck`
- `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts src/platform/knowledge/__tests__/decision-record.test.ts`
- `npm run test:changed`
- `npm run lint:boundaries` (0 errors; existing warnings remain)

## Known unresolved risks
- `npm run lint:boundaries` still reports pre-existing warnings across the repository; this PR does not address unrelated lint cleanup.
- `npm run test:changed` emitted `ps: process id too large: 999999999` during the run, but the command exited 0 with 149 passed and 3 skipped test files.
- Existing untracked `.pulseed-sandbox/` files remain local workspace artifacts and are not included in this PR.