### PR TITLE
Use typed Dream decision heuristic selectors

### DIFF
--- a/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
@@ -136,6 +136,17 @@ const STRATEGY_TEMPLATES_ACTIVATION = {
   graphTraversal: false,
 } as const;
 
+const DECISION_HEURISTICS_ACTIVATION = {
+  ...STRATEGY_TEMPLATES_ACTIVATION,
+  strategyTemplates: false,
+  decisionHeuristics: true,
+} as const;
+
+const VERIFIED_HINTS_ONLY_HEURISTICS_ACTIVATION = {
+  ...DECISION_HEURISTICS_ACTIVATION,
+  verifiedPlannerHintsOnly: true,
+} as const;
+
 class TestableStrategyManager extends StrategyManager {
   rankByDecisionHistory(candidates: Strategy[], goalType: string): Promise<Strategy[]> {
     return this._rankCandidatesByDecisionHistory(candidates, goalType);
@@ -437,7 +448,7 @@ describe("generateCandidates", () => {
     expect(first[0]!.id).not.toBe(second[0]!.id);
   });
 
-  it("applies decision heuristics without double-counting prefer/avoid deltas", async () => {
+  it("ignores legacy substring-only decision heuristics when ranking candidates", async () => {
     const candidates = [
       makeStrategy({
         id: "cand-1",
@@ -477,7 +488,293 @@ describe("generateCandidates", () => {
       }
     );
 
-    expect(reordered[0]!.hypothesis).toContain("structured outline");
+    expect(reordered.map((candidate) => candidate.id)).toEqual(["cand-1", "cand-2"]);
+  });
+
+  it("applies typed decision heuristic selectors without relying on hypothesis text", async () => {
+    const candidates = [
+      makeStrategy({
+        id: "cand-threshold",
+        hypothesis: "現在の分類器のしきい値をもう一度細かく調整する",
+        exploration: {
+          schema_version: "strategy-exploration-v1",
+          phase: "divergent_stall_recovery",
+          role: "adjacent_exploration",
+          strategy_family: "threshold_sweep",
+          novelty_score: 0.45,
+          similarity_to_recent_failures: 0.9,
+          expected_cost: "medium",
+          relationship_to_lineage: "failed_lineage",
+          smoke: { status: "not_run", reason: "Smoke first." },
+          speculative: true,
+          evidence_authority: "speculative_hypothesis",
+          lineage_assessment: {
+            schema_version: "strategy-lineage-assessment-v1",
+            confidence: 0.9,
+            relationship_to_lineage: "failed_lineage",
+            novelty_basis: "typed_lineage_evidence",
+            matched_failed_lineage_fingerprints: ["threshold_sweep|balanced_accuracy"],
+            matched_strategy_ids: [],
+            evidence_refs: ["evidence-failed-1"],
+            metric_trend: "stalled",
+            summary: "Typed failed lineage.",
+          },
+        },
+      }),
+      makeStrategy({
+        id: "cand-audit",
+        hypothesis: "Audit fold distribution before another model refinement",
+        exploration: {
+          schema_version: "strategy-exploration-v1",
+          phase: "divergent_stall_recovery",
+          role: "divergent_exploration",
+          strategy_family: "fold_distribution_audit",
+          novelty_score: 0.82,
+          similarity_to_recent_failures: 0,
+          expected_cost: "low",
+          relationship_to_lineage: "different_assumption",
+          smoke: { status: "promote", reason: "Smoke passed.", evidence_ref: "evidence-smoke-1" },
+          speculative: true,
+          evidence_authority: "speculative_hypothesis",
+          lineage_assessment: {
+            schema_version: "strategy-lineage-assessment-v1",
+            confidence: 0.82,
+            relationship_to_lineage: "different_assumption",
+            novelty_basis: "smoke_evidence",
+            matched_failed_lineage_fingerprints: [],
+            matched_strategy_ids: [],
+            evidence_refs: ["evidence-smoke-1"],
+            metric_trend: "stalled",
+            summary: "Typed promoted smoke lineage.",
+          },
+        },
+      }),
+    ] satisfies Strategy[];
+
+    const reordered = applyDecisionHeuristicsToCandidates(
+      candidates,
+      [
+        {
+          id: "heur-prefer-audit",
+          prefer_candidate_selector: {
+            strategy_family: "fold_distribution_audit",
+            exploration_role: "divergent_exploration",
+            smoke_status: "promote",
+            metric_trend: "stalled",
+          },
+          score_delta: 0.4,
+          reason: "prefer promoted divergent smoke result",
+        },
+        {
+          id: "heur-avoid-failed",
+          avoid_candidate_selector: {
+            failed_lineage_fingerprint: "threshold_sweep|balanced_accuracy",
+          },
+          score_delta: 0.2,
+          reason: "avoid repeated failed lineage",
+        },
+      ],
+      {
+        stallCount: 0,
+        activeStrategyId: null,
+      }
+    );
+
+    expect(reordered.map((candidate) => candidate.id)).toEqual(["cand-audit", "cand-threshold"]);
+  });
+
+  it("applies typed decision heuristics through generateCandidates when unverified hints are allowed", async () => {
+    const response = `\`\`\`json
+[
+  {
+    "hypothesis": "現在の分類器のしきい値を少し調整する",
+    "expected_effect": [
+      { "dimension": "balanced_accuracy", "direction": "increase", "magnitude": "small" }
+    ],
+    "resource_estimate": {
+      "sessions": 2,
+      "duration": { "value": 3, "unit": "hours" },
+      "llm_calls": 1
+    },
+    "allocation": 0.3,
+    "exploration": {
+      "schema_version": "strategy-exploration-v1",
+      "phase": "divergent_stall_recovery",
+      "role": "adjacent_exploration",
+      "strategy_family": "threshold_sweep",
+      "novelty_score": 0.45,
+      "similarity_to_recent_failures": 0.9,
+      "expected_cost": "medium",
+      "relationship_to_lineage": "failed_lineage",
+      "smoke": { "status": "not_run", "reason": "Smoke first." },
+      "speculative": true,
+      "evidence_authority": "speculative_hypothesis",
+      "lineage_assessment": {
+        "schema_version": "strategy-lineage-assessment-v1",
+        "confidence": 0.9,
+        "relationship_to_lineage": "failed_lineage",
+        "novelty_basis": "typed_lineage_evidence",
+        "matched_failed_lineage_fingerprints": ["threshold_sweep|balanced_accuracy"],
+        "matched_strategy_ids": [],
+        "evidence_refs": ["evidence-failed-1"],
+        "metric_trend": "stalled",
+        "summary": "Typed failed lineage."
+      }
+    }
+  },
+  {
+    "hypothesis": "Audit validation fold distribution before more model refinement",
+    "expected_effect": [
+      { "dimension": "balanced_accuracy", "direction": "increase", "magnitude": "medium" }
+    ],
+    "resource_estimate": {
+      "sessions": 1,
+      "duration": { "value": 45, "unit": "minutes" },
+      "llm_calls": 1
+    },
+    "allocation": 0.3,
+    "exploration": {
+      "schema_version": "strategy-exploration-v1",
+      "phase": "divergent_stall_recovery",
+      "role": "divergent_exploration",
+      "strategy_family": "fold_distribution_audit",
+      "novelty_score": 0.82,
+      "similarity_to_recent_failures": 0,
+      "expected_cost": "low",
+      "relationship_to_lineage": "different_assumption",
+      "smoke": { "status": "promote", "reason": "Smoke passed.", "evidence_ref": "evidence-smoke-1" },
+      "speculative": true,
+      "evidence_authority": "speculative_hypothesis",
+      "lineage_assessment": {
+        "schema_version": "strategy-lineage-assessment-v1",
+        "confidence": 0.82,
+        "relationship_to_lineage": "different_assumption",
+        "novelty_basis": "smoke_evidence",
+        "matched_failed_lineage_fingerprints": [],
+        "matched_strategy_ids": [],
+        "evidence_refs": ["evidence-smoke-1"],
+        "metric_trend": "stalled",
+        "summary": "Typed promoted smoke lineage."
+      }
+    }
+  }
+]
+\`\`\``;
+    const manager = new StrategyManager(stateManager, createMockLLMClient([response]));
+    await saveDreamConfig(
+      { activation: DECISION_HEURISTICS_ACTIVATION },
+      stateManager.getBaseDir()
+    );
+    fs.mkdirSync(`${tempDir}/dream`, { recursive: true });
+    fs.writeFileSync(
+      `${tempDir}/dream/decision-heuristics.json`,
+      JSON.stringify({
+        heuristics: [{
+          id: "heur-prefer-audit",
+          prefer_candidate_selector: {
+            strategy_family: "fold_distribution_audit",
+            exploration_role: "divergent_exploration",
+            smoke_status: "promote",
+          },
+          score_delta: 0.5,
+          reason: "prefer promoted fold audit",
+        }],
+      }, null, 2)
+    );
+
+    const candidates = await manager.generateCandidates("goal-1", "balanced_accuracy", ["balanced_accuracy"], {
+      currentGap: 0.2,
+      pastStrategies: [],
+    });
+
+    expect(candidates.map((candidate) => candidate.exploration?.strategy_family)).toEqual([
+      "fold_distribution_audit",
+      "threshold_sweep",
+    ]);
+  });
+
+  it("blocks unverified decision heuristics through generateCandidates when verifiedPlannerHintsOnly is enabled", async () => {
+    const response = `\`\`\`json
+[
+  {
+    "hypothesis": "Audit validation fold distribution before more model refinement",
+    "expected_effect": [
+      { "dimension": "balanced_accuracy", "direction": "increase", "magnitude": "medium" }
+    ],
+    "resource_estimate": {
+      "sessions": 1,
+      "duration": { "value": 45, "unit": "minutes" },
+      "llm_calls": 1
+    },
+    "allocation": 0.3,
+    "exploration": {
+      "schema_version": "strategy-exploration-v1",
+      "phase": "divergent_stall_recovery",
+      "role": "divergent_exploration",
+      "strategy_family": "fold_distribution_audit",
+      "novelty_score": 0.82,
+      "similarity_to_recent_failures": 0,
+      "expected_cost": "low",
+      "relationship_to_lineage": "different_assumption",
+      "smoke": { "status": "promote", "reason": "Smoke passed." },
+      "speculative": true,
+      "evidence_authority": "speculative_hypothesis"
+    }
+  },
+  {
+    "hypothesis": "現在の分類器のしきい値を少し調整する",
+    "expected_effect": [
+      { "dimension": "balanced_accuracy", "direction": "increase", "magnitude": "small" }
+    ],
+    "resource_estimate": {
+      "sessions": 2,
+      "duration": { "value": 3, "unit": "hours" },
+      "llm_calls": 1
+    },
+    "allocation": 0.3,
+    "exploration": {
+      "schema_version": "strategy-exploration-v1",
+      "phase": "divergent_stall_recovery",
+      "role": "adjacent_exploration",
+      "strategy_family": "threshold_sweep",
+      "novelty_score": 0.45,
+      "similarity_to_recent_failures": 0.9,
+      "expected_cost": "medium",
+      "relationship_to_lineage": "failed_lineage",
+      "smoke": { "status": "not_run", "reason": "Smoke first." },
+      "speculative": true,
+      "evidence_authority": "speculative_hypothesis"
+    }
+  }
+]
+\`\`\``;
+    const manager = new StrategyManager(stateManager, createMockLLMClient([response]));
+    await saveDreamConfig(
+      { activation: VERIFIED_HINTS_ONLY_HEURISTICS_ACTIVATION },
+      stateManager.getBaseDir()
+    );
+    fs.mkdirSync(`${tempDir}/dream`, { recursive: true });
+    fs.writeFileSync(
+      `${tempDir}/dream/decision-heuristics.json`,
+      JSON.stringify({
+        heuristics: [{
+          id: "heur-prefer-threshold",
+          prefer_candidate_selector: { strategy_family: "threshold_sweep" },
+          score_delta: 0.5,
+          reason: "would prefer threshold if unverified hints were allowed",
+        }],
+      }, null, 2)
+    );
+
+    const candidates = await manager.generateCandidates("goal-1", "balanced_accuracy", ["balanced_accuracy"], {
+      currentGap: 0.2,
+      pastStrategies: [],
+    });
+
+    expect(candidates.map((candidate) => candidate.exploration?.strategy_family)).toEqual([
+      "fold_distribution_audit",
+      "threshold_sweep",
+    ]);
   });
 });
 

--- a/src/platform/dream/dream-activation.ts
+++ b/src/platform/dream/dream-activation.ts
@@ -18,10 +18,24 @@ export interface DreamActivationRuntimeState {
   flags: Awaited<ReturnType<typeof loadDreamConfig>>["activation"];
 }
 
+export const DreamStrategySelectorSchema = z.object({
+  strategy_id: z.string().optional(),
+  source_template_id: z.string().optional(),
+  strategy_family: z.string().optional(),
+  exploration_role: z.enum(["exploitation", "adjacent_exploration", "divergent_exploration"]).optional(),
+  smoke_status: z.enum(["not_run", "promote", "defer", "retire"]).optional(),
+  metric_trend: z.enum(["improving", "stalled", "noisy", "regressing", "breakthrough"]).optional(),
+  failed_lineage_fingerprint: z.string().optional(),
+}).strict();
+export type DreamStrategySelector = z.infer<typeof DreamStrategySelectorSchema>;
+
 export const DreamDecisionHeuristicSchema = z.object({
   id: z.string(),
   if_stall_count_gte: z.number().int().nonnegative().optional(),
   strategy_id: z.string().optional(),
+  candidate_selector: DreamStrategySelectorSchema.optional(),
+  prefer_candidate_selector: DreamStrategySelectorSchema.optional(),
+  avoid_candidate_selector: DreamStrategySelectorSchema.optional(),
   strategy_hypothesis_includes: z.string().optional(),
   prefer_strategy_hypothesis_includes: z.string().optional(),
   avoid_strategy_hypothesis_includes: z.string().optional(),
@@ -275,33 +289,44 @@ export function applyDecisionHeuristicsToCandidates(
       if (heuristic.strategy_id && heuristic.strategy_id !== context.activeStrategyId) {
         continue;
       }
-      if (
-        heuristic.strategy_hypothesis_includes &&
-        !candidate.hypothesis.toLowerCase().includes(heuristic.strategy_hypothesis_includes.toLowerCase())
-      ) {
+      if (heuristic.candidate_selector && !matchesStrategySelector(candidate, heuristic.candidate_selector)) {
         continue;
       }
-      if (
-        heuristic.prefer_strategy_hypothesis_includes &&
-        candidate.hypothesis.toLowerCase().includes(heuristic.prefer_strategy_hypothesis_includes.toLowerCase())
-      ) {
+      if (heuristic.prefer_candidate_selector && matchesStrategySelector(candidate, heuristic.prefer_candidate_selector)) {
         score += Math.abs(heuristic.score_delta || 0.15);
         continue;
       }
-      if (
-        heuristic.avoid_strategy_hypothesis_includes &&
-        candidate.hypothesis.toLowerCase().includes(heuristic.avoid_strategy_hypothesis_includes.toLowerCase())
-      ) {
+      if (heuristic.avoid_candidate_selector && matchesStrategySelector(candidate, heuristic.avoid_candidate_selector)) {
         score -= Math.abs(heuristic.score_delta || 0.15);
         continue;
       }
-      score += heuristic.score_delta;
+      if (heuristic.candidate_selector) {
+        score += heuristic.score_delta;
+      }
     }
     return { candidate, score, index };
   });
 
   scored.sort((a, b) => b.score - a.score || a.index - b.index);
   return scored.map(({ candidate }) => candidate);
+}
+
+function matchesStrategySelector(candidate: Strategy, selector: DreamStrategySelector): boolean {
+  if (selector.strategy_id && selector.strategy_id !== candidate.id) return false;
+  if (selector.source_template_id && selector.source_template_id !== candidate.source_template_id) return false;
+  if (selector.strategy_family && selector.strategy_family !== candidate.exploration?.strategy_family) return false;
+  if (selector.exploration_role && selector.exploration_role !== candidate.exploration?.role) return false;
+  if (selector.smoke_status && selector.smoke_status !== candidate.exploration?.smoke.status) return false;
+  if (selector.metric_trend && selector.metric_trend !== candidate.exploration?.lineage_assessment?.metric_trend) {
+    return false;
+  }
+  if (
+    selector.failed_lineage_fingerprint &&
+    !candidate.exploration?.lineage_assessment?.matched_failed_lineage_fingerprints.includes(selector.failed_lineage_fingerprint)
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function mergeUniqueKnowledgeEntries(

--- a/tmp/semantic-heuristic-issues-status.md
+++ b/tmp/semantic-heuristic-issues-status.md
@@ -16,3 +16,10 @@
 - Plan: extend `DecisionRecord` with typed lineage metadata, record lineage metadata from active strategies in the durable stall path, and replace exact-hypothesis ranking in `StrategyManagerBase` with typed lineage-key scoring. Exact hypothesis remains diagnostic-only.
 - Review: fresh review agent reported no material findings.
 - Verification: `npm run typecheck`; `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts src/orchestrator/loop/__tests__/core-loop-stall-refine.test.ts src/platform/knowledge/__tests__/decision-record.test.ts`; `npm run test:changed`; `npm run lint:boundaries` (warnings only, pre-existing).
+- Result: PR #1037 merged; CI unit (22) and integration (24) passed.
+
+## #1030
+- Status: implementation verified locally; preparing PR.
+- Plan: deprecate `*_hypothesis_includes` as production selectors, add typed Dream decision heuristic selectors, keep `verifiedPlannerHintsOnly` as the caller-path gate, and cover direct heuristic behavior plus `StrategyManagerBase.generateCandidates()`.
+- Review: fresh review agent reported no material findings.
+- Verification: `npm run typecheck`; `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts`; `npm run test:changed`; `npm run lint:boundaries` (warnings only, pre-existing).


### PR DESCRIPTION
Closes #1030

## Implementation summary
- Added typed Dream decision heuristic selectors for strategy id, source template id, strategy family, exploration role, smoke status, metric trend, and failed lineage fingerprint.
- Stopped legacy `*_hypothesis_includes` fields from affecting production candidate ordering.
- Preserved the existing `verifiedPlannerHintsOnly` caller-path gate for unverified decision heuristics.
- Added direct and `StrategyManager.generateCandidates()` tests for typed selectors, multilingual/paraphrase-safe behavior, and verified-hints-only blocking.

## Verification commands
- `npm run typecheck`
- `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts`
- `npm run test:changed`
- `npm run lint:boundaries` (0 errors; existing warnings remain)

## Known unresolved risks
- `npm run lint:boundaries` still reports pre-existing warnings across the repository; this PR does not address unrelated lint cleanup.
- Existing untracked `.pulseed-sandbox/` files remain local workspace artifacts and are not included in this PR.