### PR TITLE
Make Dream planner hints typed and provenance-aware

### DIFF
--- a/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
+++ b/src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts
@@ -6,7 +6,10 @@ import { StrategyManager } from "../strategy-manager.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import type { Strategy } from "../../../base/types/strategy.js";
 import type { DecisionRecord } from "../../../base/types/knowledge.js";
-import { applyDecisionHeuristicsToCandidates } from "../../../platform/dream/dream-activation.js";
+import {
+  applyDecisionHeuristicsToCandidates,
+  selectTemplateCandidatesWithTrace,
+} from "../../../platform/dream/dream-activation.js";
 import { saveDreamConfig } from "../../../platform/dream/dream-config.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
@@ -398,6 +401,109 @@ describe("generateCandidates", () => {
 
     expect(candidates[0]!.source_template_id).toBe("tmpl-1");
     expect(candidates[0]!.hypothesis).toContain("structured research checklist");
+    expect(candidates[0]!.planner_hint_trace).toMatchObject({
+      source: "dream_template_typed_applicability",
+      source_id: "tmpl-1",
+      lexical_overlap_used: false,
+      matched_dimensions: ["research_depth"],
+    });
+  });
+
+  it("does not materialize templates from paraphrased text or stored embedding ids without typed applicability", async () => {
+    const matches = selectTemplateCandidatesWithTrace(
+      [{
+        template_id: "tmpl-text-only",
+        source_goal_id: "goal-src",
+        source_strategy_id: "strat-src",
+        hypothesis_pattern: "監査で分類器の停滞を調べる",
+        domain_tags: ["audit"],
+        effectiveness_score: 0.95,
+        applicable_dimensions: ["unrelated_dimension"],
+        embedding_id: "emb-text-only",
+        created_at: new Date().toISOString(),
+      }],
+      "Audit model plateau for balanced accuracy",
+      ["balanced_accuracy"],
+      1
+    );
+
+    expect(matches).toEqual([]);
+  });
+
+  it("keeps advisory hints from overriding typed template materialization", async () => {
+    const mock = createMockLLMClient([CANDIDATE_RESPONSE_ONE]);
+    const manager = new StrategyManager(stateManager, mock);
+    await saveDreamConfig(
+      {
+        activation: {
+          ...STRATEGY_TEMPLATES_ACTIVATION,
+          learnedPatternHints: true,
+        },
+      },
+      stateManager.getBaseDir()
+    );
+    await stateManager.saveGoal({
+      id: "goal-1",
+      title: "Improve balanced accuracy",
+      description: "Need a fold audit",
+      status: "active",
+      dimensions: [],
+      parent_id: null,
+      child_goal_ids: [],
+      success_criteria: [],
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    } as any);
+    fs.mkdirSync(`${tempDir}/learning`, { recursive: true });
+    fs.writeFileSync(
+      `${tempDir}/learning/goal-1_patterns.json`,
+      JSON.stringify([{
+        pattern_id: "pattern-advisory",
+        type: "strategy_selection",
+        description: "Prefer text-only threshold tuning",
+        source_goal_ids: ["goal-1"],
+        applicable_domains: ["kaggle"],
+        confidence: 0.99,
+        evidence_count: 10,
+        created_at: new Date().toISOString(),
+        last_applied_at: null,
+      }], null, 2)
+    );
+    fs.writeFileSync(
+      `${tempDir}/strategy-templates.json`,
+      JSON.stringify([
+        {
+          template_id: "tmpl-audit",
+          source_goal_id: "goal-src",
+          source_strategy_id: "strat-src",
+          hypothesis_pattern: "Run fold distribution audit",
+          domain_tags: ["audit"],
+          effectiveness_score: 0.8,
+          applicable_dimensions: ["balanced_accuracy"],
+          embedding_id: null,
+          created_at: new Date().toISOString(),
+        },
+        {
+          template_id: "tmpl-text-only",
+          source_goal_id: "goal-src",
+          source_strategy_id: "strat-src-2",
+          hypothesis_pattern: "Prefer text-only threshold tuning",
+          domain_tags: ["kaggle"],
+          effectiveness_score: 0.99,
+          applicable_dimensions: ["other_dimension"],
+          embedding_id: null,
+          created_at: new Date().toISOString(),
+        },
+      ], null, 2)
+    );
+
+    const candidates = await manager.generateCandidates("goal-1", "balanced_accuracy", ["balanced_accuracy"], {
+      currentGap: 0.2,
+      pastStrategies: [],
+    });
+
+    expect(candidates[0]!.source_template_id).toBe("tmpl-audit");
+    expect(candidates.some((candidate) => candidate.source_template_id === "tmpl-text-only")).toBe(false);
   });
 
   it("assigns unique ids to repeated template-backed candidates", async () => {

--- a/src/orchestrator/strategy/strategy-manager-base.ts
+++ b/src/orchestrator/strategy/strategy-manager-base.ts
@@ -30,7 +30,7 @@ import {
   loadDreamActivationState,
   loadStrategyTemplates,
   materializeTemplateCandidate,
-  selectTemplateCandidates,
+  selectTemplateCandidatesWithTrace,
 } from "../../platform/dream/dream-activation.js";
 import {
   VALID_TRANSITIONS,
@@ -320,7 +320,7 @@ export class StrategyManagerBase {
       if (activation.flags.strategyTemplates && !verifiedPlannerHintsOnly) {
         const goal = await this.stateManager.loadGoal(goalId);
         const templates = await loadStrategyTemplates(this.stateManager.getBaseDir());
-        const matchedTemplates = selectTemplateCandidates(
+        const matchedTemplates = selectTemplateCandidatesWithTrace(
           templates,
           [
             goal?.title ?? "",
@@ -333,8 +333,8 @@ export class StrategyManagerBase {
         );
 
         if (matchedTemplates.length > 0) {
-          const templateCandidates = matchedTemplates.map((template) =>
-            materializeTemplateCandidate(template, goalId, primaryDimension, targetDimensions)
+          const templateCandidates = matchedTemplates.map(({ template, trace }) =>
+            materializeTemplateCandidate(template, goalId, primaryDimension, targetDimensions, trace)
           );
           candidates = [
             ...templateCandidates,

--- a/src/orchestrator/strategy/types/strategy.ts
+++ b/src/orchestrator/strategy/types/strategy.ts
@@ -78,6 +78,16 @@ export const StrategyLineageAssessmentSchema = z.object({
 }).strict();
 export type StrategyLineageAssessment = z.infer<typeof StrategyLineageAssessmentSchema>;
 
+export const StrategyPlannerHintTraceSchema = z.object({
+  source: z.enum(["dream_template_typed_applicability", "dream_template_embedding"]),
+  source_id: z.string().min(1),
+  confidence: z.number().min(0).max(1),
+  lexical_overlap_used: z.boolean(),
+  matched_dimensions: z.array(z.string()).default([]),
+  evidence_refs: z.array(z.string().min(1)).default([]),
+}).strict();
+export type StrategyPlannerHintTrace = z.infer<typeof StrategyPlannerHintTraceSchema>;
+
 export const StrategyExplorationMetadataSchema = z.object({
   schema_version: z.literal("strategy-exploration-v1").default("strategy-exploration-v1"),
   phase: z.enum(["normal", "divergent_stall_recovery"]).default("normal"),
@@ -138,6 +148,9 @@ export const StrategySchema = z.object({
 
   // Curiosity-driven stall recovery metadata. Speculative unless promoted by smoke evidence.
   exploration: StrategyExplorationMetadataSchema.nullable().optional(),
+
+  // Provenance for advisory/materialized planner hints that shaped this candidate.
+  planner_hint_trace: StrategyPlannerHintTraceSchema.optional(),
 });
 export type Strategy = z.infer<typeof StrategySchema>;
 

--- a/src/platform/dream/dream-activation.ts
+++ b/src/platform/dream/dream-activation.ts
@@ -206,29 +206,58 @@ export function selectTemplateCandidates(
   targetDimensions: string[],
   limit = 1
 ): StrategyTemplate[] {
+  return selectTemplateCandidatesWithTrace(templates, query, targetDimensions, limit).map(({ template }) => template);
+}
+
+export interface DreamTemplateCandidateTrace {
+  template: StrategyTemplate;
+  trace: NonNullable<Strategy["planner_hint_trace"]>;
+}
+
+export function selectTemplateCandidatesWithTrace(
+  templates: StrategyTemplate[],
+  _query: string,
+  targetDimensions: string[],
+  limit = 1
+): DreamTemplateCandidateTrace[] {
   const dimensionSet = new Set(targetDimensions.map((dimension) => dimension.toLowerCase()));
   return [...templates]
     .map((template) => {
       const dimensionOverlap = template.applicable_dimensions.filter((dimension) =>
         dimensionSet.has(dimension.toLowerCase())
-      ).length;
+      );
+      const hasTypedApplicability = dimensionOverlap.length > 0;
+      if (!hasTypedApplicability) {
+        return null;
+      }
       const score =
         template.effectiveness_score * 0.6 +
-        scoreTextOverlap(query, `${template.hypothesis_pattern} ${template.domain_tags.join(" ")}`) * 0.4 +
-        Math.min(dimensionOverlap, 2) * 0.1;
-      return { template, score };
+        Math.min(dimensionOverlap.length, 2) * 0.2;
+      return {
+        template,
+        score,
+        trace: {
+          source: "dream_template_typed_applicability",
+          source_id: template.template_id,
+          confidence: Math.min(1, score),
+          lexical_overlap_used: false,
+          matched_dimensions: dimensionOverlap,
+          evidence_refs: [template.source_strategy_id],
+        } satisfies NonNullable<Strategy["planner_hint_trace"]>,
+      };
     })
-    .filter(({ score }) => score >= 0.35)
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== null && entry.score >= 0.35)
     .sort((a, b) => b.score - a.score)
     .slice(0, limit)
-    .map(({ template }) => template);
+    .map(({ template, trace }) => ({ template, trace }));
 }
 
 export function materializeTemplateCandidate(
   template: StrategyTemplate,
   goalId: string,
   primaryDimension: string,
-  targetDimensions: string[]
+  targetDimensions: string[],
+  plannerHintTrace?: Strategy["planner_hint_trace"]
 ): Strategy {
   const now = new Date().toISOString();
   return {
@@ -264,6 +293,7 @@ export function materializeTemplateCandidate(
     toolset_locked: false,
     allowed_tools: [],
     required_tools: [],
+    ...(plannerHintTrace ? { planner_hint_trace: plannerHintTrace } : {}),
   };
 }
 

--- a/tmp/semantic-heuristic-issues-status.md
+++ b/tmp/semantic-heuristic-issues-status.md
@@ -23,3 +23,10 @@
 - Plan: deprecate `*_hypothesis_includes` as production selectors, add typed Dream decision heuristic selectors, keep `verifiedPlannerHintsOnly` as the caller-path gate, and cover direct heuristic behavior plus `StrategyManagerBase.generateCandidates()`.
 - Review: fresh review agent reported no material findings.
 - Verification: `npm run typecheck`; `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts`; `npm run test:changed`; `npm run lint:boundaries` (warnings only, pre-existing).
+- Result: PR #1038 merged; CI unit (22) and integration (24) passed.
+
+## #1031
+- Status: implementation verified locally after review fix.
+- Plan: keep learned pattern/workflow retrieval advisory-only, require typed template applicability for strategy-materializing candidates, and attach template ranking trace provenance showing source/confidence/lexical-overlap usage.
+- Review: fresh review agent found stored `embedding_id` was incorrectly treated as embedding-backed retrieval; fixed selector to require typed applicability in the current production path and added coverage with a non-null stored embedding id.
+- Verification: `npm run typecheck`; `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts`; `npm run test:changed`; `npm run lint:boundaries` (warnings only, pre-existing).


### PR DESCRIPTION
Closes #1031

## Implementation summary
- Added a typed planner hint trace contract on generated strategies, including source, confidence, lexical-overlap usage, matched dimensions, and evidence refs.
- Split template candidate selection into traced materialization while keeping advisory learned-pattern/workflow hints out of template selection.
- Required typed dimension applicability for current template materialization; stored embedding ids alone do not count as embedding-backed retrieval evidence.
- Added tests for paraphrased/multilingual text with unrelated applicability and advisory hints not overriding typed template selection through `StrategyManagerBase.generateCandidates()`.

## Verification
- `npm run typecheck`
- `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts`
- `npm run lint:boundaries` (0 errors, pre-existing warnings)
- `npm run test:changed`

## Review
- Fresh review agent found an initial material issue where stored `embedding_id` was treated as embedding-backed retrieval. Fixed and reverified; reviewer confirmed no remaining material issue for that finding.

## Known unresolved risks
- Embedding-backed template materialization remains effectively disabled in this path until a real vector retrieval result can provide provenance.