### PR TITLE
Add typed task-result signals to repetitive stall detection

### DIFF
--- a/src/platform/drive/__tests__/stall-detector-repetitive.test.ts
+++ b/src/platform/drive/__tests__/stall-detector-repetitive.test.ts
@@ -28,9 +28,10 @@ describe("detectRepetitivePatterns", () => {
     const result = detector.detectRepetitivePatterns(history);
     expect(result.isRepetitive).toBe(false);
     expect(result.pattern).toBeNull();
+    expect(result.source).toBe("none");
   });
 
-  it("detects identical_actions when same strategy and similar output repeated 3+ times", () => {
+  it("detects identical_actions as a text fallback when same strategy and similar output repeated 3+ times", () => {
     const output = "Ran the test suite and updated 3 files with the same approach each time.";
     const history: StallTaskHistoryEntry[] = [
       { strategy_id: "strategy-abc", output },
@@ -40,10 +41,11 @@ describe("detectRepetitivePatterns", () => {
     const result = detector.detectRepetitivePatterns(history);
     expect(result.isRepetitive).toBe(true);
     expect(result.pattern).toBe("identical_actions");
-    expect(result.confidence).toBeGreaterThan(0.8);
+    expect(result.confidence).toBeLessThanOrEqual(0.6);
+    expect(result.source).toBe("text_fallback");
   });
 
-  it("detects oscillating pattern when outputs alternate A→B→A→B", () => {
+  it("detects oscillating pattern as a text fallback when outputs alternate A→B→A→B", () => {
     const history: StallTaskHistoryEntry[] = [
       { strategy_id: "s1", output: "output-alpha" },
       { strategy_id: "s2", output: "output-beta" },
@@ -53,10 +55,11 @@ describe("detectRepetitivePatterns", () => {
     const result = detector.detectRepetitivePatterns(history);
     expect(result.isRepetitive).toBe(true);
     expect(result.pattern).toBe("oscillating");
-    expect(result.confidence).toBeGreaterThanOrEqual(0.8);
+    expect(result.confidence).toBeLessThanOrEqual(0.6);
+    expect(result.source).toBe("text_fallback");
   });
 
-  it("detects no_change when outputs repeatedly say no changes made", () => {
+  it("detects no_change as a low-confidence fallback when outputs repeatedly say no changes made", () => {
     const history: StallTaskHistoryEntry[] = [
       { strategy_id: "s1", output: "Checked files. No changes made." },
       { strategy_id: "s1", output: "Reviewed code. No changes made to the codebase." },
@@ -65,7 +68,163 @@ describe("detectRepetitivePatterns", () => {
     const result = detector.detectRepetitivePatterns(history);
     expect(result.isRepetitive).toBe(true);
     expect(result.pattern).toBe("no_change");
+    expect(result.confidence).toBeLessThanOrEqual(0.6);
+    expect(result.source).toBe("text_fallback");
+  });
+
+  it("uses typed no-op task result evidence to detect repeated no-change work", () => {
+    const history: StallTaskHistoryEntry[] = [
+      {
+        strategy_id: "s1",
+        output: "Checked repository state.",
+        task_result: {
+          changed_files: [],
+          diff_stats: { files_changed: 0, insertions: 0, deletions: 0 },
+          tool_calls: [{ tool_name: "ReadPulseedFileTool", status: "success" }],
+          verification_status: "passed",
+          artifact_changes: [],
+        },
+      },
+      {
+        strategy_id: "s1",
+        output: "Inspected implementation status.",
+        task_result: {
+          changed_files: [],
+          diff_stats: { files_changed: 0, insertions: 0, deletions: 0 },
+          tool_calls: [{ tool_name: "GitDiffTool", status: "success" }],
+          verification_status: "passed",
+          artifact_changes: [],
+        },
+      },
+      {
+        strategy_id: "s2",
+        output: "Verified there is still no persisted work.",
+        task_result: {
+          changed_files: [],
+          diff_stats: { files_changed: 0, insertions: 0, deletions: 0 },
+          tool_calls: [{ tool_name: "TestRunnerTool", status: "success" }],
+          verification_status: "passed",
+          artifact_changes: [],
+        },
+      },
+    ];
+
+    const result = detector.detectRepetitivePatterns(history);
+
+    expect(result).toMatchObject({
+      isRepetitive: true,
+      pattern: "no_change",
+      source: "typed_task_result",
+    });
     expect(result.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it("does not treat boilerplate-similar output as repeated action when typed evidence has real file changes", () => {
+    const output = "Ran command. Exit code 0.";
+    const history: StallTaskHistoryEntry[] = [
+      {
+        strategy_id: "s1",
+        output,
+        task_result: {
+          changed_files: ["src/a.ts"],
+          diff_stats: { files_changed: 1, insertions: 8, deletions: 0 },
+          tool_calls: [{ tool_name: "WritePulseedFileTool", status: "success" }],
+          verification_status: "not_run",
+          artifact_changes: [],
+        },
+      },
+      {
+        strategy_id: "s1",
+        output,
+        task_result: {
+          changed_files: ["src/b.ts"],
+          diff_stats: { files_changed: 1, insertions: 0, deletions: 3 },
+          tool_calls: [{ tool_name: "WritePulseedFileTool", status: "success" }],
+          verification_status: "not_run",
+          artifact_changes: [],
+        },
+      },
+      {
+        strategy_id: "s1",
+        output,
+        task_result: {
+          changed_files: ["docs/result.md"],
+          diff_stats: { files_changed: 1, insertions: 2, deletions: 1 },
+          tool_calls: [{ tool_name: "WritePulseedFileTool", status: "success" }],
+          verification_status: "passed",
+          artifact_changes: [{ artifact_id: "docs/result.md", change_type: "updated" }],
+        },
+      },
+    ];
+
+    const result = detector.detectRepetitivePatterns(history);
+
+    expect(result).toMatchObject({
+      isRepetitive: false,
+      pattern: null,
+      source: "typed_task_result",
+    });
+  });
+
+  it("lets a single typed material-change entry suppress text fallback in a mixed history window", () => {
+    const output = "Ran command. Exit code 0.";
+    const history: StallTaskHistoryEntry[] = [
+      { strategy_id: "s1", output },
+      {
+        strategy_id: "s1",
+        output,
+        task_result: {
+          changed_files: ["src/progress.ts"],
+          diff_stats: { files_changed: 1, insertions: 4, deletions: 0 },
+        },
+      },
+      { strategy_id: "s1", output },
+    ];
+
+    const result = detector.detectRepetitivePatterns(history);
+
+    expect(result).toMatchObject({
+      isRepetitive: false,
+      pattern: null,
+      source: "typed_task_result",
+    });
+  });
+
+  it("does not classify tool-call-only task results as typed no-op evidence", () => {
+    const history: StallTaskHistoryEntry[] = [
+      {
+        strategy_id: "s1",
+        output: "Inspected runtime state.",
+        task_result: {
+          tool_calls: [{ tool_name: "ReadPulseedFileTool", status: "success" }],
+          verification_status: "not_run",
+        },
+      },
+      {
+        strategy_id: "s2",
+        output: "Checked queue state.",
+        task_result: {
+          tool_calls: [{ tool_name: "GitDiffTool", status: "success" }],
+          verification_status: "not_run",
+        },
+      },
+      {
+        strategy_id: "s3",
+        output: "Read logs.",
+        task_result: {
+          tool_calls: [{ tool_name: "ProcessStatusTool", status: "success" }],
+          verification_status: "not_run",
+        },
+      },
+    ];
+
+    const result = detector.detectRepetitivePatterns(history);
+
+    expect(result).toMatchObject({
+      isRepetitive: false,
+      pattern: null,
+      source: "none",
+    });
   });
 
   it("returns not repetitive for genuinely different outputs", () => {
@@ -77,6 +236,7 @@ describe("detectRepetitivePatterns", () => {
     const result = detector.detectRepetitivePatterns(history);
     expect(result.isRepetitive).toBe(false);
     expect(result.pattern).toBeNull();
+    expect(result.source).toBe("none");
   });
 
   it("does not flag identical_actions when strategy_id is null", () => {

--- a/src/platform/drive/stall-detector.ts
+++ b/src/platform/drive/stall-detector.ts
@@ -44,12 +44,32 @@ const RECOVERY_SCHEDULE: Array<{ loops: number; factor: number }> = [
 export interface StallTaskHistoryEntry {
   strategy_id: string | null;
   output: string;
+  task_result?: StallTaskResultEvidence;
+}
+
+export interface StallTaskResultEvidence {
+  changed_files?: string[];
+  diff_stats?: {
+    files_changed?: number;
+    insertions?: number;
+    deletions?: number;
+  };
+  tool_calls?: Array<{
+    tool_name: string;
+    status?: "success" | "failed" | "skipped";
+  }>;
+  verification_status?: "passed" | "failed" | "not_run" | "unknown";
+  artifact_changes?: Array<{
+    artifact_id: string;
+    change_type: "created" | "updated" | "deleted";
+  }>;
 }
 
 export interface RepetitivePatternResult {
   isRepetitive: boolean;
   pattern: 'identical_actions' | 'oscillating' | 'no_change' | null;
   confidence: number;
+  source?: "typed_task_result" | "text_fallback" | "none";
 }
 
 /**

--- a/src/platform/drive/stall-detector/repetitive.ts
+++ b/src/platform/drive/stall-detector/repetitive.ts
@@ -3,6 +3,7 @@ import type { RepetitivePatternResult, StallTaskHistoryEntry } from "../stall-de
 const REPETITIVE_WINDOW = 3;
 const SIMILARITY_THRESHOLD = 0.8;
 const NO_CHANGE_PATTERNS = ["no changes made", "no modifications", "nothing to change", "no action taken"];
+const TEXT_FALLBACK_MAX_CONFIDENCE = 0.6;
 
 function stringSimilarity(a: string, b: string): number {
   if (a.length === 0 || b.length === 0) {
@@ -42,17 +43,29 @@ function stringSimilarity(a: string, b: string): number {
 
 export function detectRepetitivePatterns(taskHistory: StallTaskHistoryEntry[]): RepetitivePatternResult {
   if (taskHistory.length < REPETITIVE_WINDOW) {
-    return { isRepetitive: false, pattern: null, confidence: 0 };
+    return { isRepetitive: false, pattern: null, confidence: 0, source: "none" };
   }
 
   const recent = taskHistory.slice(-REPETITIVE_WINDOW);
   const outputs = recent.map((entry) => entry.output);
+  const typedEvidence = recent.map((entry) => entry.task_result).filter((result) => result !== undefined);
+  const anyMaterialChange = recent.some((entry) => hasMaterialTaskChange(entry));
+  if (anyMaterialChange) {
+    return { isRepetitive: false, pattern: null, confidence: 0, source: "typed_task_result" };
+  }
+
+  if (typedEvidence.length === REPETITIVE_WINDOW) {
+    const allNoOp = recent.every((entry) => hasTypedNoOpEvidence(entry));
+    if (allNoOp) {
+      return { isRepetitive: true, pattern: "no_change", confidence: 0.9, source: "typed_task_result" };
+    }
+  }
 
   const noChangeCount = recent.filter((entry) =>
     NO_CHANGE_PATTERNS.some((pattern) => entry.output.toLowerCase().includes(pattern))
   ).length;
   if (noChangeCount >= REPETITIVE_WINDOW) {
-    return { isRepetitive: true, pattern: "no_change", confidence: 0.95 };
+    return { isRepetitive: true, pattern: "no_change", confidence: TEXT_FALLBACK_MAX_CONFIDENCE, source: "text_fallback" };
   }
 
   const strategyIds = recent.map((entry) => entry.strategy_id);
@@ -62,7 +75,12 @@ export function detectRepetitivePatterns(taskHistory: StallTaskHistoryEntry[]): 
     const similarity12 = stringSimilarity(outputs[1], outputs[2]);
     const averageSimilarity = (similarity01 + similarity12) / 2;
     if (averageSimilarity >= SIMILARITY_THRESHOLD) {
-      return { isRepetitive: true, pattern: "identical_actions", confidence: averageSimilarity };
+      return {
+        isRepetitive: true,
+        pattern: "identical_actions",
+        confidence: Math.min(averageSimilarity, TEXT_FALLBACK_MAX_CONFIDENCE),
+        source: "text_fallback",
+      };
     }
   }
 
@@ -80,11 +98,41 @@ export function detectRepetitivePatterns(taskHistory: StallTaskHistoryEntry[]): 
       return {
         isRepetitive: true,
         pattern: "oscillating",
-        confidence: Math.min(similarity02, similarity13),
+        confidence: Math.min(Math.min(similarity02, similarity13), TEXT_FALLBACK_MAX_CONFIDENCE),
+        source: "text_fallback",
       };
     }
   }
 
-  return { isRepetitive: false, pattern: null, confidence: 0 };
+  return { isRepetitive: false, pattern: null, confidence: 0, source: "none" };
 }
 
+function hasMaterialTaskChange(entry: StallTaskHistoryEntry): boolean {
+  const result = entry.task_result;
+  if (!result) return false;
+
+  if ((result.changed_files?.length ?? 0) > 0) return true;
+  if ((result.artifact_changes?.length ?? 0) > 0) return true;
+
+  const diffStats = result.diff_stats;
+  if (!diffStats) return false;
+  return (
+    (diffStats.files_changed ?? 0) > 0 ||
+    (diffStats.insertions ?? 0) > 0 ||
+    (diffStats.deletions ?? 0) > 0
+  );
+}
+
+function hasTypedNoOpEvidence(entry: StallTaskHistoryEntry): boolean {
+  const result = entry.task_result;
+  if (!result || hasMaterialTaskChange(entry)) return false;
+
+  const hasZeroChangedFiles = result.changed_files !== undefined && result.changed_files.length === 0;
+  const hasZeroArtifactChanges = result.artifact_changes !== undefined && result.artifact_changes.length === 0;
+  const hasZeroDiffStats = result.diff_stats !== undefined &&
+    (result.diff_stats.files_changed ?? 0) === 0 &&
+    (result.diff_stats.insertions ?? 0) === 0 &&
+    (result.diff_stats.deletions ?? 0) === 0;
+
+  return hasZeroChangedFiles || hasZeroArtifactChanges || hasZeroDiffStats;
+}

--- a/tmp/semantic-heuristic-issues-status.md
+++ b/tmp/semantic-heuristic-issues-status.md
@@ -30,3 +30,9 @@
 - Plan: keep learned pattern/workflow retrieval advisory-only, require typed template applicability for strategy-materializing candidates, and attach template ranking trace provenance showing source/confidence/lexical-overlap usage.
 - Review: fresh review agent found stored `embedding_id` was incorrectly treated as embedding-backed retrieval; fixed selector to require typed applicability in the current production path and added coverage with a non-null stored embedding id.
 - Verification: `npm run typecheck`; `npx vitest run src/orchestrator/strategy/__tests__/strategy-manager-core.test.ts`; `npm run test:changed`; `npm run lint:boundaries` (warnings only, pre-existing).
+
+## #1033
+- Status: implementation verified locally after review fixes; preparing PR.
+- Plan: extend `StallTaskHistoryEntry` with optional typed task-result evidence, prefer typed no-op/material-change signals in `detectRepetitivePatterns()`, mark phrase/bigram text matching as low-confidence fallback with source, and cover the `StallDetector.detectRepetitivePatterns()` caller path.
+- Review: fresh review agent found mixed typed/untyped windows could still fall through to text fallback after one material change, and tool-call-only/not-run evidence was too weak for typed no-op; fixed both and added regression coverage.
+- Verification: `npm run typecheck`; `npx vitest run src/platform/drive/__tests__/stall-detector-repetitive.test.ts`; `npm run lint:boundaries` (warnings only, pre-existing); `npm run test:changed`.


### PR DESCRIPTION
Closes #1033

## Implementation summary
- Extended repetitive stall history entries with optional typed task-result evidence for changed files, diff stats, tool calls, verification status, and artifact changes.
- Made typed material-change evidence suppress phrase/bigram fallback classification, including mixed typed/untyped windows.
- Added high-confidence typed no-op classification only when explicit zero-change evidence is present.
- Downgraded phrase and bigram text matching to low-confidence `text_fallback` results with source metadata.
- Added public `StallDetector.detectRepetitivePatterns()` tests for typed no-op, real-change suppression, mixed history, weak tool-call-only evidence, and fallback source/confidence.

## Verification
- `npm run typecheck`
- `npx vitest run src/platform/drive/__tests__/stall-detector-repetitive.test.ts`
- `npm run lint:boundaries` (0 errors, pre-existing warnings)
- `npm run test:changed`

## Review
- Fresh review agent found two material issues around mixed typed evidence and weak no-op proof. Both were fixed, covered by tests, and the reviewer confirmed resolution.

## Known unresolved risks
- Existing callers must populate `task_result` for high-confidence typed classification; legacy entries continue to use low-confidence text fallback.