### PR TITLE
Wire curiosity semantic transfer to evidence-backed proposals

### DIFF
--- a/src/platform/traits/__tests__/curiosity-engine-proposals.test.ts
+++ b/src/platform/traits/__tests__/curiosity-engine-proposals.test.ts
@@ -4,6 +4,7 @@ import type { CuriosityEngineDeps } from "../curiosity-engine.js";
 import type { CuriosityProposal, CuriosityTrigger } from "../../../base/types/curiosity.js";
 import type { StallState } from "../../../base/types/stall.js";
 import { makeGoal } from "../../../../tests/helpers/fixtures.js";
+import { generateProposals as generateProposalsImpl } from "../curiosity-proposals.js";
 
 // ─── Helper Factories ───
 
@@ -120,6 +121,203 @@ describe("CuriosityEngine — generateProposals", async () => {
     const proposals = await engine.generateProposals([makeTrigger()], []);
     expect(proposals).toHaveLength(1);
     expect(proposals[0]!.proposed_goal.description).toBe("Explore new testing patterns");
+  });
+
+  it("uses admitted vector results as embedding transfer evidence through generateProposals", async () => {
+    const vectorIndex = {
+      add: vi.fn(),
+      search: vi.fn().mockResolvedValue([
+        {
+          id: "dim:goal-source:balanced_accuracy",
+          text: "balanced accuracy",
+          similarity: 0.86,
+          metadata: { goal_id: "goal-source", dimension: "balanced_accuracy", type: "dimension" },
+        },
+      ]),
+    } as any;
+    const deps = createMockDeps({ vectorIndex });
+    (deps.llmClient.parseJSON as ReturnType<typeof vi.fn>).mockReturnValue([
+      {
+        description: "Transfer balanced accuracy audit",
+        rationale: "Use the similar source dimension evidence",
+        suggested_dimensions: [],
+        scope_domain: "classification",
+        detection_method: "llm_heuristic",
+      },
+    ]);
+    const engine = new CuriosityEngine(deps);
+    const goals = [
+      makeGoal({
+        id: "goal-target",
+        status: "active",
+        dimensions: [{ name: "balanced_accuracy", label: "Balanced accuracy", threshold: { type: "min", value: 0.8 }, current_value: 0.4, confidence: 0.2, history: [] } as any],
+      }),
+    ];
+
+    const proposals = await engine.generateProposals([
+      { type: "undefined_problem", detected_at: new Date().toISOString(), source_goal_id: "goal-target", details: "Low confidence", severity: 0.7 },
+    ], goals);
+
+    expect(vectorIndex.search).toHaveBeenCalledWith("balanced_accuracy", 5, 0.7);
+    expect(proposals[0]!.proposed_goal.detection_method).toBe("embedding_similarity");
+    expect(proposals[0]!.proposed_goal.transfer_evidence).toEqual([
+      {
+        source_goal_id: "goal-source",
+        source_dimension: "balanced_accuracy",
+        target_goal_id: "goal-target",
+        target_dimension: "balanced_accuracy",
+        similarity: 0.86,
+        evidence_refs: ["dim:goal-source:balanced_accuracy"],
+      },
+    ]);
+    const prompt = (deps.llmClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0]![0][0].content as string;
+    expect(prompt).toContain("Semantic Transfer Evidence");
+    expect(prompt).toContain("goal-source");
+    expect(prompt).toContain("similarity=0.860");
+    expect(prompt).toContain("dim:goal-source:balanced_accuracy");
+  });
+
+  it("does not assign embedding_similarity when vector search returns no transfer results", async () => {
+    const vectorIndex = {
+      add: vi.fn(),
+      search: vi.fn().mockResolvedValue([]),
+    } as any;
+    const deps = createMockDeps({ vectorIndex });
+    (deps.llmClient.parseJSON as ReturnType<typeof vi.fn>).mockReturnValue([
+      {
+        description: "Clarify weak signal",
+        rationale: "No semantic transfer evidence was admitted",
+        suggested_dimensions: [],
+        scope_domain: "classification",
+        detection_method: "llm_heuristic",
+      },
+    ]);
+    const engine = new CuriosityEngine(deps);
+    const goals = [
+      makeGoal({
+        id: "goal-target",
+        status: "active",
+        dimensions: [{ name: "calibration", label: "Calibration", threshold: { type: "min", value: 0.8 }, current_value: 0.4, confidence: 0.2, history: [] } as any],
+      }),
+    ];
+
+    const proposals = await engine.generateProposals([
+      { type: "undefined_problem", detected_at: new Date().toISOString(), source_goal_id: "goal-target", details: "Low confidence", severity: 0.7 },
+    ], goals);
+
+    expect(vectorIndex.search).toHaveBeenCalledWith("calibration", 5, 0.7);
+    expect(proposals[0]!.proposed_goal.detection_method).toBe("llm_heuristic");
+    expect(proposals[0]!.proposed_goal.transfer_evidence).toEqual([]);
+  });
+
+  it("downgrades model-provided embedding_similarity when no vector evidence is admitted", async () => {
+    const deps = createMockDeps();
+    (deps.llmClient.parseJSON as ReturnType<typeof vi.fn>).mockReturnValue([
+      {
+        description: "Claim semantic transfer",
+        rationale: "Model claimed vector similarity without evidence",
+        suggested_dimensions: [],
+        scope_domain: "classification",
+        detection_method: "embedding_similarity",
+      },
+    ]);
+    const engine = new CuriosityEngine(deps);
+
+    const proposals = await engine.generateProposals([
+      { type: "undefined_problem", detected_at: new Date().toISOString(), source_goal_id: "goal-target", details: "Low confidence", severity: 0.7 },
+    ], []);
+
+    expect(proposals[0]!.proposed_goal.detection_method).toBe("llm_heuristic");
+    expect(proposals[0]!.proposed_goal.transfer_evidence).toEqual([]);
+  });
+
+  it("does not assign embedding_similarity when semantic transfer is unavailable", async () => {
+    const deps = createMockDeps();
+    (deps.llmClient.parseJSON as ReturnType<typeof vi.fn>).mockReturnValue([
+      {
+        description: "Clarify weak signal",
+        rationale: "Vector transfer unavailable",
+        suggested_dimensions: [],
+        scope_domain: "classification",
+        detection_method: "llm_heuristic",
+      },
+    ]);
+    const engine = new CuriosityEngine(deps);
+    const goals = [
+      makeGoal({
+        id: "goal-target",
+        status: "active",
+        dimensions: [{ name: "calibration", label: "Calibration", threshold: { type: "min", value: 0.8 }, current_value: 0.4, confidence: 0.2, history: [] } as any],
+      }),
+    ];
+
+    const proposals = await engine.generateProposals([
+      { type: "undefined_problem", detected_at: new Date().toISOString(), source_goal_id: "goal-target", details: "Low confidence", severity: 0.7 },
+    ], goals);
+
+    expect(proposals[0]!.proposed_goal.detection_method).toBe("llm_heuristic");
+    expect(proposals[0]!.proposed_goal.transfer_evidence).toEqual([]);
+  });
+
+  it("sends semantic transfer evidence in the concrete proposal prompt even when a gateway dependency exists", async () => {
+    const vectorIndex = {
+      add: vi.fn(),
+      search: vi.fn().mockResolvedValue([
+        {
+          id: "dim:goal-source:recall",
+          text: "recall",
+          similarity: 0.91,
+          metadata: { goal_id: "goal-source", dimension: "recall", type: "dimension" },
+        },
+      ]),
+    } as any;
+    const gateway = {
+      execute: vi.fn().mockResolvedValue([]),
+      executeWithUsage: vi.fn().mockResolvedValue({ data: [], usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }, contextTokens: 0 }),
+    } as any;
+    const deps = createMockDeps({ vectorIndex });
+    (deps.llmClient.parseJSON as ReturnType<typeof vi.fn>).mockReturnValue([
+      {
+        description: "Transfer recall diagnostics",
+        rationale: "Use evidence refs",
+        suggested_dimensions: [],
+        scope_domain: "classification",
+        detection_method: "llm_heuristic",
+      },
+    ]);
+    const state = {
+      proposals: [],
+      learning_records: [],
+      last_exploration_at: null,
+      rejected_proposal_hashes: [],
+    };
+    const goals = [
+      makeGoal({
+        id: "goal-target",
+        status: "active",
+        dimensions: [{ name: "recall", label: "Recall", threshold: { type: "min", value: 0.8 }, current_value: 0.4, confidence: 0.2, history: [] } as any],
+      }),
+    ];
+
+    const proposals = await generateProposalsImpl(
+      [{ type: "undefined_problem", detected_at: new Date().toISOString(), source_goal_id: "goal-target", details: "Low confidence", severity: 0.7 }],
+      goals,
+      state,
+      0,
+      {
+        llmClient: deps.llmClient,
+        ethicsGate: deps.ethicsGate,
+        vectorIndex,
+        gateway,
+        config: deps.config as any,
+      }
+    );
+
+    expect(gateway.execute).not.toHaveBeenCalled();
+    const prompt = (deps.llmClient.sendMessage as ReturnType<typeof vi.fn>).mock.calls[0]![0][0].content as string;
+    expect(prompt).toContain("Semantic Transfer Evidence");
+    expect(prompt).toContain("dim:goal-source:recall");
+    expect(proposals[0]!.proposed_goal.detection_method).toBe("embedding_similarity");
   });
 
   it("returns empty array when triggers is empty", async () => {

--- a/src/platform/traits/curiosity-engine.ts
+++ b/src/platform/traits/curiosity-engine.ts
@@ -31,6 +31,7 @@ import {
   detectSemanticTransfer as detectSemanticTransferImpl,
   detectKnowledgeTransferOpportunities as detectKnowledgeTransferOpportunitiesImpl,
 } from "./curiosity-transfer.js";
+import type { SemanticTransferEvidence } from "./curiosity-transfer.js";
 
 // ─── Constants ───
 
@@ -636,7 +637,7 @@ export class CuriosityEngine {
   async detectSemanticTransfer(
     goalId: string,
     dimensions: string[]
-  ): Promise<Array<{ source_goal_id: string; dimension: string; similarity: number }>> {
+  ): Promise<SemanticTransferEvidence[]> {
     return detectSemanticTransferImpl(goalId, dimensions, {
       vectorIndex: this.vectorIndex,
     });

--- a/src/platform/traits/curiosity-proposals.ts
+++ b/src/platform/traits/curiosity-proposals.ts
@@ -20,6 +20,10 @@ import type {
   LearningRecord,
 } from "../../base/types/curiosity.js";
 import type { Goal } from "../../base/types/goal.js";
+import {
+  detectSemanticTransfer,
+  type SemanticTransferEvidence,
+} from "./curiosity-transfer.js";
 
 // ─── LLM Proposal Schema (for parsing LLM output) ───
 
@@ -75,7 +79,10 @@ export function buildProposalPrompt(
   trigger: CuriosityTrigger,
   goals: Goal[],
   learningRecords: LearningRecord[],
-  options: { relationshipProfileContext?: string } = {}
+  options: {
+    relationshipProfileContext?: string;
+    transferEvidence?: SemanticTransferEvidence[];
+  } = {}
 ): string {
   const relationshipProfileContext = options.relationshipProfileContext?.trim() ?? "";
   const activeGoalsSummary = goals
@@ -93,6 +100,11 @@ export function buildProposalPrompt(
         `- Goal ${r.goal_id}, dim "${r.dimension_name}", approach "${r.approach}": ${r.outcome} (improvement_ratio=${r.improvement_ratio.toFixed(2)})`
     )
     .join("\n");
+  const transferEvidence = (options.transferEvidence ?? [])
+    .map((e) =>
+      `- source_goal=${e.source_goal_id}, source_dimension="${e.source_dimension}", target_goal=${e.target_goal_id ?? "(unknown)"}, target_dimension="${e.target_dimension}", similarity=${e.similarity.toFixed(3)}, evidence_refs=[${e.evidence_refs.join(", ")}]`
+    )
+    .join("\n");
 
   return `Analyzing curiosity triggers to propose new exploration goals.
 
@@ -108,6 +120,9 @@ ${activeGoalsSummary || "(none)"}
 ## Recent Learning Records
 ${recentLearning || "(none)"}
 
+## Semantic Transfer Evidence
+${transferEvidence || "(none)"}
+
 ## Resident Relationship Profile Context
 ${relationshipProfileContext || "(none)"}
 
@@ -122,7 +137,9 @@ Return a JSON array of proposal objects. Each object must have:
 - rationale: string — why this is worth exploring (cite the trigger/learning evidence)
 - suggested_dimensions: array of { name: string, threshold_type: string, target: number }
 - scope_domain: string — domain this exploration belongs to
-- detection_method: one of "observation_log" | "stall_pattern" | "cross_goal_transfer" | "llm_heuristic" | "periodic_review"
+- detection_method: one of "observation_log" | "stall_pattern" | "cross_goal_transfer" | "llm_heuristic" | "periodic_review" | "embedding_similarity"
+
+Use detection_method "embedding_similarity" only when Semantic Transfer Evidence is present, and cite its source goal, dimension, similarity, and evidence refs in the rationale.
 
 Return only valid JSON array, no markdown, no explanation outside the JSON.`;
 }
@@ -202,28 +219,21 @@ export async function generateProposals(
     }
 
     let llmItems: LLMProposalItem[] = [];
+    const transferEvidence = await collectSemanticTransferEvidence(trigger, goals, deps);
 
     try {
       const prompt = buildProposalPrompt(trigger, goals, state.learning_records, {
         relationshipProfileContext: options.relationshipProfileContext,
+        transferEvidence,
       });
-      if (deps.gateway) {
-        llmItems = await deps.gateway.execute({
-          purpose: "curiosity_propose",
-          additionalContext: { proposal_prompt: prompt },
-          responseSchema: LLMProposalsResponseSchema,
-          temperature: 0.3,
-        }) as LLMProposalItem[];
-      } else {
-        const response = await deps.llmClient.sendMessage(
-          [{ role: "user", content: prompt }],
-          { temperature: 0.3, model_tier: 'light' }
-        );
-        llmItems = deps.llmClient.parseJSON(
-          response.content,
-          LLMProposalsResponseSchema
-        ) as LLMProposalItem[];
-      }
+      const response = await deps.llmClient.sendMessage(
+        [{ role: "user", content: prompt }],
+        { temperature: 0.3, model_tier: 'light' }
+      );
+      llmItems = deps.llmClient.parseJSON(
+        response.content,
+        LLMProposalsResponseSchema
+      ) as LLMProposalItem[];
     } catch (err) {
       // Don't throw on LLM failure — return what we have so far
       deps.logger?.warn(
@@ -267,12 +277,10 @@ export async function generateProposals(
         continue;
       }
 
-      // Phase 2: use embedding_similarity detection method when vectorIndex
-      // is available and the trigger is undefined_problem
       const detectionMethod =
-        deps.vectorIndex && trigger.type === "undefined_problem"
+        transferEvidence.length > 0
           ? "embedding_similarity"
-          : item.detection_method;
+          : item.detection_method === "embedding_similarity" ? "llm_heuristic" : item.detection_method;
 
       const proposal = CuriosityProposalSchema.parse({
         id: proposalId,
@@ -283,6 +291,7 @@ export async function generateProposals(
           suggested_dimensions: item.suggested_dimensions,
           scope_domain: item.scope_domain,
           detection_method: detectionMethod,
+          transfer_evidence: detectionMethod === "embedding_similarity" ? transferEvidence : [],
         },
         status: "pending",
         created_at: now.toISOString(),
@@ -371,4 +380,31 @@ export async function generateProposals(
   }
 
   return newProposals;
+}
+
+async function collectSemanticTransferEvidence(
+  trigger: CuriosityTrigger,
+  goals: Goal[],
+  deps: ProposalGenerationDeps
+): Promise<SemanticTransferEvidence[]> {
+  if (!deps.vectorIndex || trigger.type !== "undefined_problem" || !trigger.source_goal_id) {
+    return [];
+  }
+
+  const sourceGoal = goals.find((goal) => goal.id === trigger.source_goal_id);
+  const dimensions = sourceGoal?.dimensions.map((dimension) => dimension.name) ?? [];
+  if (dimensions.length === 0) {
+    return [];
+  }
+
+  try {
+    return await detectSemanticTransfer(trigger.source_goal_id, dimensions, {
+      vectorIndex: deps.vectorIndex,
+    });
+  } catch (err) {
+    deps.logger?.warn(
+      `CuriosityEngine: semantic transfer search failed for trigger "${trigger.type}": ${err}`
+    );
+    return [];
+  }
 }

--- a/src/platform/traits/curiosity-transfer.ts
+++ b/src/platform/traits/curiosity-transfer.ts
@@ -10,6 +10,15 @@ export interface TransferDetectionDeps {
   knowledgeTransfer?: KnowledgeTransfer;
 }
 
+export interface SemanticTransferEvidence {
+  source_goal_id: string;
+  source_dimension: string;
+  target_goal_id: string | null;
+  target_dimension: string;
+  similarity: number;
+  evidence_refs: string[];
+}
+
 // ─── Phase 2: Embedding-based Detection ───
 
 /**
@@ -20,10 +29,10 @@ export async function detectSemanticTransfer(
   goalId: string,
   dimensions: string[],
   deps: TransferDetectionDeps
-): Promise<Array<{ source_goal_id: string; dimension: string; similarity: number }>> {
+): Promise<SemanticTransferEvidence[]> {
   if (!deps.vectorIndex) return [];
 
-  const transfers: Array<{ source_goal_id: string; dimension: string; similarity: number }> = [];
+  const transfers: SemanticTransferEvidence[] = [];
 
   for (const dim of dimensions) {
     const results = await deps.vectorIndex.search(dim, 5, 0.7);
@@ -32,8 +41,11 @@ export async function detectSemanticTransfer(
       if (sourceGoalId && sourceGoalId !== goalId) {
         transfers.push({
           source_goal_id: sourceGoalId,
-          dimension: dim,
+          source_dimension: typeof result.metadata.dimension === "string" ? result.metadata.dimension : result.text,
+          target_goal_id: goalId,
+          target_dimension: dim,
           similarity: result.similarity,
+          evidence_refs: [result.id],
         });
       }
     }

--- a/src/platform/traits/types/curiosity.ts
+++ b/src/platform/traits/types/curiosity.ts
@@ -33,6 +33,18 @@ export const CuriosityProposalStatusEnum = z.enum([
 ]);
 export type CuriosityProposalStatus = z.infer<typeof CuriosityProposalStatusEnum>;
 
+// --- CuriosityTransferEvidence ---
+
+export const CuriosityTransferEvidenceSchema = z.object({
+  source_goal_id: z.string(),
+  source_dimension: z.string(),
+  target_goal_id: z.string().nullable(),
+  target_dimension: z.string(),
+  similarity: z.number().min(0).max(1),
+  evidence_refs: z.array(z.string()).default([]),
+});
+export type CuriosityTransferEvidence = z.infer<typeof CuriosityTransferEvidenceSchema>;
+
 // --- CuriosityProposal ---
 
 export const CuriosityProposalSchema = z.object({
@@ -57,6 +69,7 @@ export const CuriosityProposalSchema = z.object({
       "periodic_review",
       "embedding_similarity",
     ]),
+    transfer_evidence: z.array(CuriosityTransferEvidenceSchema).optional(),
   }),
   status: CuriosityProposalStatusEnum,
   created_at: z.string(),

--- a/tmp/semantic-heuristic-issues-status.md
+++ b/tmp/semantic-heuristic-issues-status.md
@@ -36,3 +36,9 @@
 - Plan: extend `StallTaskHistoryEntry` with optional typed task-result evidence, prefer typed no-op/material-change signals in `detectRepetitivePatterns()`, mark phrase/bigram text matching as low-confidence fallback with source, and cover the `StallDetector.detectRepetitivePatterns()` caller path.
 - Review: fresh review agent found mixed typed/untyped windows could still fall through to text fallback after one material change, and tool-call-only/not-run evidence was too weak for typed no-op; fixed both and added regression coverage.
 - Verification: `npm run typecheck`; `npx vitest run src/platform/drive/__tests__/stall-detector-repetitive.test.ts`; `npm run lint:boundaries` (warnings only, pre-existing); `npm run test:changed`.
+
+## #1032
+- Status: implementation verified locally after review fixes; preparing PR.
+- Plan: route `generateProposals()` through concrete semantic-transfer search evidence, add typed proposal transfer evidence with source goal/dimension/similarity/evidence refs, include that evidence in proposal prompts, and only assign `embedding_similarity` when admitted vector results exist.
+- Review: fresh review agent found model-provided `embedding_similarity` could be accepted without vector evidence and gateway prompt assembly could drop transfer evidence; fixed by sanitizing detection methods without evidence and using the concrete proposal prompt path.
+- Verification: `npm run typecheck`; `npx vitest run src/platform/traits/__tests__/curiosity-engine-budget.test.ts src/platform/traits/__tests__/curiosity-engine-proposals.test.ts`; `npm run lint:boundaries` (warnings only, pre-existing); `npm run test:changed`.


### PR DESCRIPTION
Closes #1032

## Implementation summary
- Added typed curiosity transfer evidence carrying source goal, source/target dimensions, similarity, and evidence refs.
- Routed proposal generation through concrete semantic-transfer vector search for undefined-problem triggers.
- Included admitted semantic transfer evidence in the proposal prompt and structured proposal payload.
- Assigned `embedding_similarity` only when concrete vector results are admitted; model-provided `embedding_similarity` is downgraded without evidence.
- Covered vector available, no-result, and unavailable paths through `generateProposals()`.

## Verification
- `npm run typecheck`
- `npx vitest run src/platform/traits/__tests__/curiosity-engine-budget.test.ts src/platform/traits/__tests__/curiosity-engine-proposals.test.ts`
- `npm run lint:boundaries` (0 errors, pre-existing warnings)
- `npm run test:changed`

## Review
- Fresh review agent found two material issues: model-provided `embedding_similarity` without evidence and gateway prompt/evidence loss. Both were fixed and the reviewer confirmed resolution.

## Known unresolved risks
- Gateway-backed curiosity proposal generation is bypassed in this path until PromptGateway has a first-class dynamic proposal prompt/evidence slot.