### PR TITLE
Disable inert code-search semantic retrieval

### DIFF
--- a/src/platform/code-search/__tests__/code-search.test.ts
+++ b/src/platform/code-search/__tests__/code-search.test.ts
@@ -4,10 +4,13 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { SearchOrchestrator } from "../orchestrator.js";
 import { ProgressiveReader } from "../progressive-reader.js";
+import { rerankCandidates } from "../reranker.js";
 import { buildFileIndex } from "../indexes/file-index.js";
 import { getCodeSearchIndexes } from "../indexes/index-store.js";
 import { planCodeSearchTask } from "../query-planner.js";
 import { parseVerificationSignal } from "../verification-retrieval.js";
+import type { FusedCandidate } from "../fusion.js";
+import { DEFAULT_CANDIDATE_PENALTIES, DEFAULT_CANDIDATE_SIGNALS } from "../contracts.js";
 
 describe("code search platform", () => {
   let root: string;
@@ -50,6 +53,50 @@ describe("code search platform", () => {
     expect(candidates[0]).toHaveProperty("reasons");
     expect(candidates[0]).toHaveProperty("signals");
     expect(candidates[0]).toHaveProperty("penalties");
+  });
+
+  it("does not advertise semantic retrieval when no embedding-backed index is configured", async () => {
+    const result = await new SearchOrchestrator(root).searchWithState({
+      task: "explain findWidget",
+      intent: "explain",
+      cwd: root,
+    });
+
+    expect(result.trace.retrieversUsed).not.toContain("semantic");
+    expect(result.trace.candidatesReturnedByRetriever).not.toHaveProperty("semantic");
+    expect(result.trace.warnings).toContain("semantic retrieval disabled: no embedding-backed code-search index configured");
+    expect(result.candidates.every((candidate) => !candidate.reasons.some((reason) => reason.includes("semantic")))).toBe(true);
+  });
+
+  it("ignores semantic similarity during reranking when semantic retrieval is disabled", () => {
+    const makeCandidate = (id: string, lexicalMatch: number, semanticSimilarity: number): FusedCandidate => ({
+      id,
+      file: `src/${id}.ts`,
+      range: { startLine: 1, endLine: 1 },
+      preview: id,
+      signals: {
+        ...DEFAULT_CANDIDATE_SIGNALS,
+        lexicalMatch,
+        semanticSimilarity,
+      },
+      ranks: { retrieverRanks: { lexical: 1 } },
+      penalties: DEFAULT_CANDIDATE_PENALTIES,
+      reasons: [],
+      sourceRetrievers: ["lexical"],
+      indexVersion: "test",
+      indexedAt: 1,
+      fileHashAtIndex: id,
+      rrfScore: 0,
+    });
+    const candidates = [
+      makeCandidate("lexical", 1, 0),
+      makeCandidate("semantic-only", 0, 1),
+    ];
+
+    const ranked = rerankCandidates(candidates, "explain", 2, { semanticRetrieval: "disabled" });
+
+    expect(ranked.map((candidate) => candidate.id)).toEqual(["lexical", "semantic-only"]);
+    expect(ranked[1]!.rerankScore).toBe(0);
   });
 
   it("reads bounded context ranges with budget and trace state", async () => {

--- a/src/platform/code-search/contracts.ts
+++ b/src/platform/code-search/contracts.ts
@@ -265,6 +265,9 @@ export interface IndexedSymbol {
 export interface CodeSearchIndexes {
   version: string;
   indexedAt: number;
+  capabilities: {
+    semanticRetrieval: "disabled" | "embedding_index";
+  };
   files: IndexedFile[];
   symbols: IndexedSymbol[];
   repoMap: RepoMapSlice;

--- a/src/platform/code-search/indexes/indexer.ts
+++ b/src/platform/code-search/indexes/indexer.ts
@@ -18,6 +18,9 @@ export async function buildCodeSearchIndexes(root: string, maxFiles?: number): P
   return {
     version: "code-search-v1",
     indexedAt: Date.now(),
+    capabilities: {
+      semanticRetrieval: "disabled",
+    },
     files,
     symbols,
     repoMap,

--- a/src/platform/code-search/indexes/semantic-index.ts
+++ b/src/platform/code-search/indexes/semantic-index.ts
@@ -1,5 +1,9 @@
 import type { CodeCandidate, CodeSearchIndexes, SearchRequest } from "../contracts.js";
 
 export async function semanticCandidates(_req: SearchRequest, _indexes: CodeSearchIndexes): Promise<CodeCandidate[]> {
+  if (_indexes.capabilities.semanticRetrieval === "disabled") {
+    return [];
+  }
+
   return [];
 }

--- a/src/platform/code-search/orchestrator.ts
+++ b/src/platform/code-search/orchestrator.ts
@@ -1,5 +1,5 @@
 import * as path from "node:path";
-import type { CodeSearchTask, RankedCandidate, SearchSessionState, VerificationSignal } from "./contracts.js";
+import type { CodeSearchIndexes, CodeSearchTask, RankedCandidate, Retriever, SearchSessionState, VerificationSignal } from "./contracts.js";
 import { normalizeCandidates } from "./candidate-normalizer.js";
 import { fuseCandidates } from "./fusion.js";
 import { getCodeSearchIndexes } from "./indexes/index-store.js";
@@ -25,8 +25,14 @@ const DEFAULT_RETRIEVERS = [
   new PackageRetriever(),
   new RepoMapRetriever(),
   new CallgraphRetriever(),
-  new SemanticRetriever(),
 ];
+
+function activeRetrievers(indexes: CodeSearchIndexes): Retriever[] {
+  if (indexes.capabilities.semanticRetrieval === "embedding_index") {
+    return [...DEFAULT_RETRIEVERS, new SemanticRetriever()];
+  }
+  return DEFAULT_RETRIEVERS;
+}
 
 export class SearchOrchestrator {
   constructor(private readonly root = process.cwd()) {}
@@ -42,7 +48,11 @@ export class SearchOrchestrator {
     trace.indexVersions.push(indexes.version);
 
     const all = [];
-    for (const retriever of DEFAULT_RETRIEVERS) {
+    const retrievers = activeRetrievers(indexes);
+    if (indexes.capabilities.semanticRetrieval === "disabled") {
+      trace.warnings.push("semantic retrieval disabled: no embedding-backed code-search index configured");
+    }
+    for (const retriever of retrievers) {
       trace.retrieversUsed.push(retriever.name);
       try {
         const candidates = await retriever.search(req, indexes);
@@ -55,7 +65,9 @@ export class SearchOrchestrator {
 
     const normalized = normalizeCandidates(all);
     const fused = fuseCandidates(normalized, req.budget.maxFusionCandidates);
-    const ranked = rerankCandidates(fused, req.intent, req.budget.maxRerankCandidates);
+    const ranked = rerankCandidates(fused, req.intent, req.budget.maxRerankCandidates, {
+      semanticRetrieval: indexes.capabilities.semanticRetrieval,
+    });
     trace.fusedCandidates = fused.map((candidate) => candidate.id);
     trace.rerankedCandidates = ranked.map((candidate) => candidate.id);
     for (const candidate of ranked) {

--- a/src/platform/code-search/reranker.ts
+++ b/src/platform/code-search/reranker.ts
@@ -1,13 +1,22 @@
 import type { Intent, RankedCandidate, ReadRecommendation } from "./contracts.js";
 import type { FusedCandidate } from "./fusion.js";
 
-function signalScore(candidate: FusedCandidate, intent: Intent): number {
+interface RerankOptions {
+  semanticRetrieval?: "disabled" | "embedding_index";
+}
+
+function semanticSignal(candidate: FusedCandidate, options: RerankOptions): number {
+  return options.semanticRetrieval === "embedding_index" ? candidate.signals.semanticSimilarity : 0;
+}
+
+function signalScore(candidate: FusedCandidate, intent: Intent, options: RerankOptions): number {
   const s = candidate.signals;
+  const semanticSimilarity = semanticSignal(candidate, options);
   const intentBoost =
     intent === "test_failure" ? s.failingTestAffinity + s.stacktraceMatch + s.testRelation
     : intent === "config_fix" ? s.configAffinity + s.packageBoundaryFit
     : intent === "refactor" ? s.exactSymbolMatch + s.callgraphProximity + s.packageBoundaryFit
-    : intent === "explain" ? s.repoMapCentrality + s.semanticSimilarity + s.exactSymbolMatch
+    : intent === "explain" ? s.repoMapCentrality + semanticSimilarity + s.exactSymbolMatch
     : intent === "security_review" ? s.lexicalMatch + s.configAffinity + s.callgraphProximity
     : s.lexicalMatch + s.exactSymbolMatch + s.pathPrior;
   return (
@@ -22,7 +31,7 @@ function signalScore(candidate: FusedCandidate, intent: Intent): number {
     + s.repoMapCentrality * 0.8
     + s.callgraphProximity * 1.2
     + s.pathPrior * 2
-    + s.semanticSimilarity * 0.7
+    + semanticSimilarity * 0.7
     + intentBoost
   );
 }
@@ -40,10 +49,15 @@ function recommendation(candidate: FusedCandidate, score: number): ReadRecommend
   return "reference_only";
 }
 
-export function rerankCandidates(candidates: FusedCandidate[], intent: Intent, limit: number): RankedCandidate[] {
+export function rerankCandidates(
+  candidates: FusedCandidate[],
+  intent: Intent,
+  limit: number,
+  options: RerankOptions = {}
+): RankedCandidate[] {
   return candidates
     .map((candidate) => {
-      const rerankScore = signalScore(candidate, intent) - penaltyScore(candidate);
+      const rerankScore = signalScore(candidate, intent, options) - penaltyScore(candidate);
       const ranked: RankedCandidate = {
         ...candidate,
         rerankScore,

--- a/tmp/semantic-heuristic-issues-status.md
+++ b/tmp/semantic-heuristic-issues-status.md
@@ -42,3 +42,9 @@
 - Plan: route `generateProposals()` through concrete semantic-transfer search evidence, add typed proposal transfer evidence with source goal/dimension/similarity/evidence refs, include that evidence in proposal prompts, and only assign `embedding_similarity` when admitted vector results exist.
 - Review: fresh review agent found model-provided `embedding_similarity` could be accepted without vector evidence and gateway prompt assembly could drop transfer evidence; fixed by sanitizing detection methods without evidence and using the concrete proposal prompt path.
 - Verification: `npm run typecheck`; `npx vitest run src/platform/traits/__tests__/curiosity-engine-budget.test.ts src/platform/traits/__tests__/curiosity-engine-proposals.test.ts`; `npm run lint:boundaries` (warnings only, pre-existing); `npm run test:changed`.
+
+## #1035
+- Status: implementation verified locally; preparing PR.
+- Plan: make semantic retrieval capability explicit in `CodeSearchIndexes`, default it to disabled, exclude the semantic retriever from the orchestrator unless capability is enabled, and make reranking ignore semantic similarity when disabled so ranking/reasons are unaffected.
+- Review: fresh review agent reported no material findings.
+- Verification: `npm run typecheck`; `npx vitest run src/platform/code-search/__tests__/code-search.test.ts`; `npm run lint:boundaries` (warnings only, pre-existing); `npm run test:changed` (exit 0; included pre-existing `ps: process id too large: 999999999` output).


### PR DESCRIPTION
Closes #1035

## Implementation summary
- Added an explicit code-search index capability for semantic retrieval and defaulted it to disabled.
- Removed the semantic retriever from the default retrieval set unless an embedding-backed index capability is configured.
- Made reranking ignore semanticSimilarity when semantic retrieval is disabled.
- Added tests proving semantic retrieval is not advertised in traces/reasons and disabled semantic signals do not affect ranking.

## Verification
- `npm run typecheck`
- `npx vitest run src/platform/code-search/__tests__/code-search.test.ts`
- `npm run lint:boundaries` (0 errors, pre-existing warnings)
- `npm run test:changed` (exit 0; included pre-existing `ps: process id too large: 999999999` output)

## Review
- Fresh review agent reported no material findings and reran typecheck plus the code-search test.

## Known unresolved risks
- Real semantic retrieval remains disabled until a concrete embedding-backed code-search index is implemented.