### PR TITLE
[codex] Fix RunSpec routing after configure misclassification

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -4462,6 +4462,46 @@ describe("ChatRunner", () => {
       });
     });
 
+    it("lets typed RunSpec derivation override an over-broad configure route", async () => {
+      const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-configure-override-"));
+      const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
+      const adapter = makeMockAdapter();
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
+      } as unknown as ChatAgentLoopRunner;
+      const llmClient = createMockLLMClient([
+        JSON.stringify({
+          kind: "configure",
+          confidence: 0.91,
+          configure_target: "unknown",
+          rationale: "misread DurableLoop request as configuration",
+        }),
+        runSpecDraftDecision(),
+      ]);
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        adapter,
+        chatAgentLoopRunner,
+        llmClient,
+      }));
+
+      const result = await runner.execute(
+        "DurableloopのほうでKaggleのタスクに取り組んで",
+        "/repo/kaggle",
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("Proposed long-running run:");
+      expect(result.output).toContain("It has not started a daemon run.");
+      expect(result.output).not.toContain("setup/configuration");
+      expect(adapter.execute).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      const [fileName] = fs.readdirSync(path.join(baseDir, "run-specs"));
+      const stored = JSON.parse(fs.readFileSync(path.join(baseDir, "run-specs", fileName), "utf8"));
+      expect(stored.status).toBe("draft");
+      expect(stored.profile).toBe("kaggle");
+    });
+
     it("starts a confirmed RunSpec only after next-turn approval", async () => {
       const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-confirm-"));
       const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -70,6 +70,15 @@ function runSpecFreeformDecision(): string {
   });
 }
 
+function configureFreeformDecision(): string {
+  return JSON.stringify({
+    kind: "configure",
+    confidence: 0.91,
+    configure_target: "unknown",
+    rationale: "Misclassified long-running work as configuration",
+  });
+}
+
 function runSpecDraftDecision(): string {
   return JSON.stringify({
     decision: "run_spec_request",
@@ -160,6 +169,42 @@ describe("CrossPlatformChatSessionManager", () => {
         message_id: "message-1",
         identity_key: "telegram:user-1",
       });
+    } finally {
+      cleanupTempDir(baseDir);
+    }
+  });
+
+  it("keeps gateway long-running requests on RunSpec when freeform routing over-classifies configuration", async () => {
+    const baseDir = makeTempDir();
+    try {
+      const stateManager = new RealStateManager(baseDir, undefined, { walEnabled: false });
+      const adapter = makeMockAdapter();
+      const chatAgentLoopRunner = { execute: vi.fn() };
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager,
+        adapter,
+        chatAgentLoopRunner: chatAgentLoopRunner as never,
+        llmClient: createMockLLMClient([
+          configureFreeformDecision(),
+          runSpecDraftDecision(),
+        ]),
+      }));
+
+      const result = await manager.execute("DurableloopのほうでKaggleのタスクに取り組んで", {
+        identity_key: "telegram:user-1",
+        channel: "plugin_gateway",
+        platform: "telegram",
+        conversation_id: "telegram-chat-1",
+        cwd: "/repo/kaggle",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.output).toContain("Proposed long-running run:");
+      expect(result.output).toContain("It has not started a daemon run.");
+      expect(result.output).not.toContain("setup/configuration");
+      expect(adapter.execute).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      expect(fs.readdirSync(`${baseDir}/run-specs`)).toHaveLength(1);
     } finally {
       cleanupTempDir(baseDir);
     }

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -885,7 +885,12 @@ export class ChatRunner {
     }
     const shouldDeriveRunSpecDraft =
       runtimeControlIntent === null
-      && freeformRouteIntent?.kind === "run_spec"
+      && freeformRouteIntent !== null
+      && (
+        freeformRouteIntent.kind === "run_spec"
+        || freeformRouteIntent.kind === "configure"
+        || freeformRouteIntent.kind === "clarify"
+      )
       && freeformRouteIntent.confidence >= 0.7;
     const runSpecDraft = shouldDeriveRunSpecDraft
       ? await deriveRunSpecFromText(ingress.text, {

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -836,7 +836,12 @@ export class CrossPlatformChatSessionManager {
     }
     const shouldDeriveRunSpecDraft =
       runtimeControlIntent === null
-      && freeformRouteIntent?.kind === "run_spec"
+      && freeformRouteIntent !== null
+      && (
+        freeformRouteIntent.kind === "run_spec"
+        || freeformRouteIntent.kind === "configure"
+        || freeformRouteIntent.kind === "clarify"
+      )
       && freeformRouteIntent.confidence >= 0.7;
     const runSpecDraft = shouldDeriveRunSpecDraft
       ? await deriveRunSpecFromText(safeIngressText, {


### PR DESCRIPTION
## Summary
- Let typed RunSpec derivation run for high-confidence configure/clarify routes, so a long-running DurableLoop request can recover from an over-broad setup/configuration classification.
- Apply the same fallback in standalone ChatRunner and CrossPlatformChatSessionManager gateway/TUI routing.
- Add regression coverage for Japanese DurableLoop/Kaggle phrasing that was previously sent to setup guidance.

## Root Cause
The freeform route classifier could return `configure` with high confidence for phrases like asking DurableLoop to work on a Kaggle task. That blocked RunSpec derivation entirely, so the message resolved to setup/configuration guidance instead of a long-running run proposal.

## Validation
- `npm run test:unit -- --run src/interface/chat/__tests__/chat-runner.test.ts`
- `npm run test:unit -- --run src/interface/chat/__tests__/cross-platform-session.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries -- --quiet`
