### PR TITLE
Make chat ingress AgentLoop-first

### DIFF
--- a/src/interface/chat/__tests__/chat-boundary-contract.test.ts
+++ b/src/interface/chat/__tests__/chat-boundary-contract.test.ts
@@ -228,7 +228,6 @@ describe("chat boundary contracts", () => {
         }),
       } as never,
       llmClient: createMockLLMClient([
-        JSON.stringify({ kind: "execute", confidence: 0.93, rationale: "ordinary greeting" }),
         JSON.stringify({ intent: "restart_daemon", reason: "PulSeed を再起動して" }),
       ]),
       runtimeControlService,

--- a/src/interface/chat/__tests__/chat-runner-permissions.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-permissions.test.ts
@@ -93,6 +93,16 @@ function makeLLMClientWithToolCall(toolName: string) {
     supportsToolCalling: () => true,
     sendMessage: vi.fn()
       .mockResolvedValueOnce({
+        content: JSON.stringify({
+          kind: "execute",
+          confidence: 0.93,
+          rationale: "tool-backed request",
+        }),
+        tool_calls: [],
+        usage: { input_tokens: 10, output_tokens: 10 },
+        stop_reason: "end_turn",
+      })
+      .mockResolvedValueOnce({
         content: "",
         tool_calls: [
           {
@@ -139,7 +149,7 @@ describe("ChatRunner — permission gate (Fix #505)", () => {
       expect(result.output).toBe("Final answer");
 
       // Verify the tool result message sent to LLM contains denial text
-      const secondCall = llmClient.sendMessage.mock.calls[1];
+      const secondCall = llmClient.sendMessage.mock.calls[2];
       const messages = secondCall[0] as Array<{ role: string; content: string }>;
       const toolResultMsg = messages.find((m) => m.role === "user" && m.content.includes("denied"));
       expect(toolResultMsg).toBeDefined();
@@ -177,7 +187,7 @@ describe("ChatRunner — permission gate (Fix #505)", () => {
       expect(tool.call).not.toHaveBeenCalled();
 
       // The tool result message sent to LLM should indicate "not approved"
-      const secondCall = llmClient.sendMessage.mock.calls[1];
+      const secondCall = llmClient.sendMessage.mock.calls[2];
       const messages = secondCall[0] as Array<{ role: string; content: string }>;
       const toolResultMsg = messages.find((m) => m.role === "user" && m.content.includes("not approved"));
       expect(toolResultMsg).toBeDefined();

--- a/src/interface/chat/__tests__/chat-runner-tools.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-tools.test.ts
@@ -62,7 +62,19 @@ function makeLLMClientWithToolCall(toolName: string, toolArgs: Record<string, un
     sendMessage: vi.fn().mockImplementation(async () => {
       callCount++;
       if (callCount === 1) {
-        // First call: return a tool_call response
+        return {
+          content: JSON.stringify({
+            kind: "execute",
+            confidence: 0.93,
+            rationale: "tool-backed request",
+          }),
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn",
+          tool_calls: [],
+        } satisfies LLMResponse;
+      }
+      if (callCount === 2) {
+        // Tool-loop call: return a tool_call response
         return {
           content: "",
           usage: { input_tokens: 1, output_tokens: 1 },
@@ -79,7 +91,7 @@ function makeLLMClientWithToolCall(toolName: string, toolArgs: Record<string, un
           ],
         } satisfies LLMResponse;
       }
-      // Second call: return final text (after tool result)
+      // Final call: return text after the tool result
       return {
         content: "Tool executed, here is the result.",
         usage: { input_tokens: 1, output_tokens: 1 },

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -465,7 +465,6 @@ describe("ChatRunner", () => {
       ]);
       const runner = new ChatRunner(makeDeps({
         llmClient,
-        chatAgentLoopRunner: { execute: vi.fn() } as never,
         gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
           state: "unconfigured",
           daemon: { running: true, port: 41700 },
@@ -493,7 +492,6 @@ describe("ChatRunner", () => {
       ]);
       const runner = new ChatRunner(makeDeps({
         llmClient,
-        chatAgentLoopRunner: { execute: vi.fn() } as never,
         gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
           state: "configured",
           daemon: { running: true, port: 41700 },
@@ -521,7 +519,6 @@ describe("ChatRunner", () => {
       ]);
       const runner = new ChatRunner(makeDeps({
         llmClient,
-        chatAgentLoopRunner: { execute: vi.fn() } as never,
         gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus({
           state: "partially_configured",
           daemon: { running: false, port: 41700 },
@@ -2968,7 +2965,7 @@ describe("ChatRunner", () => {
       expect(result.success).toBe(false);
       expect(result.output).toContain("Type: Adapter failure");
       expect(capturedEvents).toContainEqual({ type: "lifecycle_error", recoveryKind: "adapter" });
-      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+      expect(llmClient.sendMessage).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -3198,7 +3195,7 @@ describe("ChatRunner", () => {
       const result = await runner.execute("Do something", "/repo");
 
       expect((chatAgentLoopRunner.execute as ReturnType<typeof vi.fn>)).toHaveBeenCalledOnce();
-      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+      expect(llmClient.sendMessage).not.toHaveBeenCalled();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Native agentloop response");
@@ -3278,7 +3275,7 @@ describe("ChatRunner", () => {
       const result = await runner.execute("What route should answer this?", "/repo");
 
       expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
-      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+      expect(llmClient.sendMessage).not.toHaveBeenCalled();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Agentloop direct answer");
@@ -3462,7 +3459,7 @@ describe("ChatRunner", () => {
         expect(result.output).toBe("Agentloop handles handoff");
         expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
         expect(adapter.execute).not.toHaveBeenCalled();
-        expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+        expect(llmClient.sendMessage).not.toHaveBeenCalled();
         expect(goalNegotiator.negotiate).not.toHaveBeenCalled();
         expect(daemonClient.startGoal).not.toHaveBeenCalled();
       } finally {
@@ -3512,7 +3509,7 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner: interruptible.runner,
-        llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("background")]),
+        llmClient: createMockLLMClient([interruptDecision("background")]),
       }));
       runner.startSession("/repo");
 
@@ -3540,7 +3537,7 @@ describe("ChatRunner", () => {
         const runner = new ChatRunner(makeDeps({
           stateManager: makeMockStateManager(),
           chatAgentLoopRunner: interruptible.runner,
-          llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("diff")]),
+          llmClient: createMockLLMClient([interruptDecision("diff")]),
         }));
         runner.startSession(tmpDir);
 
@@ -3566,7 +3563,7 @@ describe("ChatRunner", () => {
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner: interruptible.runner,
         reviewAgentLoopRunner,
-        llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("review")]),
+        llmClient: createMockLLMClient([interruptDecision("review")]),
       }));
       runner.startSession("/repo");
 
@@ -3587,7 +3584,7 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner: interruptible.runner,
-        llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("summary")]),
+        llmClient: createMockLLMClient([interruptDecision("summary")]),
       }));
       runner.startSession("/repo");
 
@@ -3607,7 +3604,7 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner: interruptible.runner,
-        llmClient: createMockLLMClient([freeformExecuteDecision(), interruptDecision("unknown", 0.3)]),
+        llmClient: createMockLLMClient([interruptDecision("unknown", 0.3)]),
       }));
       runner.startSession("/repo");
 
@@ -3629,24 +3626,17 @@ describe("ChatRunner", () => {
         sendMessage: vi.fn(async () => {
           sendMessageCount += 1;
           if (sendMessageCount === 1) {
+            await new Promise<void>((resolve) => {
+              releaseClassification = resolve;
+            });
             return {
-              content: freeformExecuteDecision(),
+              content: interruptDecision("diff"),
               usage: { input_tokens: 1, output_tokens: 1 },
               stop_reason: "end_turn" as const,
             };
           }
-          if (sendMessageCount > 2) {
-            return {
-              content: freeformExecuteDecision(),
-              usage: { input_tokens: 1, output_tokens: 1 },
-              stop_reason: "end_turn" as const,
-            };
-          }
-          await new Promise<void>((resolve) => {
-            releaseClassification = resolve;
-          });
           return {
-            content: interruptDecision("diff"),
+            content: freeformExecuteDecision(),
             usage: { input_tokens: 1, output_tokens: 1 },
             stop_reason: "end_turn" as const,
           };
@@ -3678,7 +3668,7 @@ describe("ChatRunner", () => {
       const active = runner.execute("Implement a feature", "/repo");
       await vi.waitFor(() => expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce());
       const redirected = runner.interruptAndRedirect("muéstrame los cambios", "/repo");
-      await vi.waitFor(() => expect(llmClient.sendMessage).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(llmClient.sendMessage).toHaveBeenCalledOnce());
       finishActive();
       await active;
       releaseClassification();
@@ -3977,7 +3967,7 @@ describe("ChatRunner", () => {
 
         expect(result.success).toBe(true);
         expect(result.output).toBe("Plain answer");
-        expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+        expect(llmClient.sendMessage).toHaveBeenCalledTimes(2);
         const intentIndex = events.findIndex((event) =>
           event.type === "activity" && event.sourceId === "intent:first-step"
         );
@@ -3993,7 +3983,7 @@ describe("ChatRunner", () => {
           transient: false,
           message: expect.stringContaining("call the model with the tool catalog"),
         });
-        const options = llmClient.sendMessage.mock.calls[0]?.[1] as { system?: string } | undefined;
+        const options = llmClient.sendMessage.mock.calls[1]?.[1] as { system?: string } | undefined;
         expect(options?.system).toContain("StaticPromptSeed");
         expect(options?.system).toContain("configured agent identity running PulSeed");
         expect(adapter.execute).not.toHaveBeenCalled();
@@ -4143,7 +4133,7 @@ describe("ChatRunner", () => {
       const result = await runner.execute("What files changed?", "/repo");
 
       expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
-      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+      expect(llmClient.sendMessage).not.toHaveBeenCalled();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Agentloop checked it");
@@ -4179,7 +4169,7 @@ describe("ChatRunner", () => {
       const result = await runner.execute("Can you confirm whether this is safe?", "/repo");
 
       expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
-      expect(llmClient.sendMessage).toHaveBeenCalledOnce();
+      expect(llmClient.sendMessage).not.toHaveBeenCalled();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
       expect(result.output).toBe("Confirmed with tools");
@@ -4187,20 +4177,32 @@ describe("ChatRunner", () => {
 
     it("routes Japanese Telegram setup requests to Japanese guidance before agent-loop execution", async () => {
       const events: ChatEvent[] = [];
+      const stateManager = makeMockStateManager();
       const chatAgentLoopRunner = {
-        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
-      } as unknown as ChatAgentLoopRunner;
-      const llmClient = createMockLLMClient([
-        JSON.stringify({
-          kind: "configure",
-          confidence: 0.94,
-          configure_target: "telegram_gateway",
-          rationale: "operator wants Telegram chat setup",
+        execute: vi.fn().mockImplementation(async (input: { toolCallContext?: ToolCallContext }) => {
+          const guidanceTool = createSetupRuntimeControlTools({
+            stateManager,
+            gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus()),
+          }).find((tool) => tool.metadata.name === "prepare_gateway_setup_guidance")!;
+          const result = await guidanceTool.call({
+            channel: "telegram",
+            request: "telegram繋げたい",
+            language: "ja",
+          }, input.toolCallContext!);
+          return {
+            success: result.success,
+            output: result.summary,
+            error: null,
+            exit_code: null,
+            elapsed_ms: 1,
+            stopped_reason: "completed",
+          };
         }),
-      ]);
+      } as unknown as ChatAgentLoopRunner;
       const runner = new ChatRunner(makeDeps({
+        stateManager,
         chatAgentLoopRunner,
-        llmClient,
+        llmClient: createMockLLMClient([]),
         onEvent: (event) => { events.push(event); },
       }));
 
@@ -4210,39 +4212,44 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("Telegram gateway status");
       expect(result.output).toContain("pulseed daemon status");
       expect(result.output).toContain("chat-assisted setup を使う場合");
-      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
       const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
         event.type === "activity" && event.sourceId === "intent:first-step"
       );
-      expect(intent).toBeUndefined();
+      expect(intent?.message).toContain("agent loop");
       expect(events.map((event) => event.type === "activity" ? event.message : "").join("\n"))
         .not.toContain("I understand the request");
-      const progressEvents = events.filter((event): event is Extract<ChatEvent, { type: "operation_progress" }> =>
-        event.type === "operation_progress"
-      );
-      expect(progressEvents.map((event) => event.item.kind)).toEqual([
-        "started",
-        "checked_status",
-        "read_config",
-        "planned_action",
-      ]);
-      expect(progressEvents.map((event) => event.item.title).join("\n")).toContain("Daemon status を確認しました");
-      expect(JSON.stringify(progressEvents)).not.toContain("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi");
+      expect(JSON.stringify(events)).not.toContain("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi");
     });
 
     it("routes English Telegram setup paraphrases to guidance before agent-loop execution", async () => {
+      const stateManager = makeMockStateManager();
       const chatAgentLoopRunner = {
-        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
-      } as unknown as ChatAgentLoopRunner;
-      const llmClient = createMockLLMClient([
-        JSON.stringify({
-          kind: "configure",
-          confidence: 0.93,
-          configure_target: "telegram_gateway",
-          rationale: "operator wants Telegram gateway setup",
+        execute: vi.fn().mockImplementation(async (input: { toolCallContext?: ToolCallContext }) => {
+          const guidanceTool = createSetupRuntimeControlTools({
+            stateManager,
+            gatewaySetupStatusProvider: makeTelegramStatusProvider(makeTelegramSetupStatus()),
+          }).find((tool) => tool.metadata.name === "prepare_gateway_setup_guidance")!;
+          const result = await guidanceTool.call({
+            channel: "telegram",
+            request: "I want to talk to Seedy from Telegram.",
+            language: "en",
+          }, input.toolCallContext!);
+          return {
+            success: result.success,
+            output: result.summary,
+            error: null,
+            exit_code: null,
+            elapsed_ms: 1,
+            stopped_reason: "completed",
+          };
         }),
-      ]);
-      const runner = new ChatRunner(makeDeps({ chatAgentLoopRunner, llmClient }));
+      } as unknown as ChatAgentLoopRunner;
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        chatAgentLoopRunner,
+        llmClient: createMockLLMClient([]),
+      }));
 
       const result = await runner.execute("I want to talk to Seedy from Telegram.", "/repo");
 
@@ -4250,25 +4257,24 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("Telegram gateway status");
       expect(result.output).toContain("pulseed daemon status");
       expect(result.output).toContain("If you prefer chat-assisted setup");
-      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
     });
 
     it("asks for clarification on ambiguous freeform input instead of editing code", async () => {
       const events: ChatEvent[] = [];
       const chatAgentLoopRunner = {
-        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
-      } as unknown as ChatAgentLoopRunner;
-      const llmClient = createMockLLMClient([
-        JSON.stringify({
-          kind: "clarify",
-          confidence: 0.62,
-          configure_target: "unknown",
-          rationale: "unclear desired action",
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "Please give me one more detail.",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
         }),
-      ]);
+      } as unknown as ChatAgentLoopRunner;
       const runner = new ChatRunner(makeDeps({
         chatAgentLoopRunner,
-        llmClient,
+        llmClient: createMockLLMClient([]),
         onEvent: (event) => { events.push(event); },
       }));
 
@@ -4276,11 +4282,11 @@ describe("ChatRunner", () => {
 
       expect(result.success).toBe(true);
       expect(result.output).toContain("one more detail");
-      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
       const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
         event.type === "activity" && event.sourceId === "intent:first-step"
       );
-      expect(intent?.message).toContain("ask for the missing detail");
+      expect(intent?.message).toContain("agent loop");
       expect(intent?.message).not.toContain("resume the saved agent loop state");
     });
 
@@ -4323,15 +4329,16 @@ describe("ChatRunner", () => {
     it("routes direct assist without agent-loop resume intent copy", async () => {
       const events: ChatEvent[] = [];
       const llmClient = createMockLLMClient([
-        JSON.stringify({
-          kind: "assist",
-          confidence: 0.91,
-          rationale: "operator asks for explanatory help",
-        }),
-        "Here is the explanation.",
       ]);
       const chatAgentLoopRunner = {
-        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "Here is the explanation.",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
+        }),
       } as unknown as ChatAgentLoopRunner;
       const runner = new ChatRunner(makeDeps({
         chatAgentLoopRunner,
@@ -4343,11 +4350,11 @@ describe("ChatRunner", () => {
 
       expect(result.success).toBe(true);
       expect(result.output).toBe("Here is the explanation.");
-      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
       const intent = events.find((event): event is Extract<ChatEvent, { type: "activity" }> =>
         event.type === "activity" && event.sourceId === "intent:first-step"
       );
-      expect(intent?.message).toContain("answer directly from the current conversation context");
+      expect(intent?.message).toContain("agent loop");
       expect(intent?.message).not.toContain("resume the saved agent loop state");
     });
 
@@ -4380,6 +4387,11 @@ describe("ChatRunner", () => {
         supportsToolCalling: () => false,
         sendMessage: vi.fn()
           .mockResolvedValueOnce({
+            content: freeformExecuteDecision(),
+            usage: { input_tokens: 5, output_tokens: 5 },
+            stop_reason: "end_turn",
+          })
+          .mockResolvedValueOnce({
             content: '{ "tool_calls": [{ "name": "echo", "input": { "value": "hello", }, }] }',
             usage: { input_tokens: 5, output_tokens: 5 },
             stop_reason: "end_turn",
@@ -4395,7 +4407,7 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never, registry: registry as never }));
       const result = await runner.execute("Do something", "/repo");
 
-      expect(llmClient.sendMessage).toHaveBeenCalledTimes(2);
+      expect(llmClient.sendMessage).toHaveBeenCalledTimes(3);
       expect(echoTool.call).toHaveBeenCalledOnce();
       expect(adapter.execute).not.toHaveBeenCalled();
       expect(result.success).toBe(true);
@@ -4437,9 +4449,6 @@ describe("ChatRunner", () => {
         stateManager,
         adapter,
         llmClient,
-        chatAgentLoopRunner: {
-          execute: vi.fn(),
-        } as unknown as ChatAgentLoopRunner,
       }));
 
       const result = await runner.execute(
@@ -4469,9 +4478,6 @@ describe("ChatRunner", () => {
       const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-runspec-configure-override-"));
       const stateManager = new StateManager(baseDir, undefined, { walEnabled: false });
       const adapter = makeMockAdapter();
-      const chatAgentLoopRunner = {
-        execute: vi.fn().mockRejectedValue(new Error("agent loop must not run")),
-      } as unknown as ChatAgentLoopRunner;
       const llmClient = createMockLLMClient([
         JSON.stringify({
           kind: "configure",
@@ -4484,7 +4490,6 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         stateManager,
         adapter,
-        chatAgentLoopRunner,
         llmClient,
       }));
 
@@ -4498,7 +4503,6 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("It has not started a daemon run.");
       expect(result.output).not.toContain("setup/configuration");
       expect(adapter.execute).not.toHaveBeenCalled();
-      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
       const [fileName] = fs.readdirSync(path.join(baseDir, "run-specs"));
       const stored = JSON.parse(fs.readFileSync(path.join(baseDir, "run-specs", fileName), "utf8"));
       expect(stored.status).toBe("draft");
@@ -4519,7 +4523,6 @@ describe("ChatRunner", () => {
           runSpecDraftDecision(),
           runSpecConfirmationDecision("approve"),
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       const draftResult = await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
@@ -4578,7 +4581,6 @@ describe("ChatRunner", () => {
           runSpecDraftDecision(),
           runSpecConfirmationDecision("approve"),
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
@@ -4617,7 +4619,6 @@ describe("ChatRunner", () => {
           }),
           runSpecConfirmationDecision("approve"),
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
@@ -4649,7 +4650,6 @@ describe("ChatRunner", () => {
           runSpecConfirmationDecision("approve"),
           runSpecConfirmationDecision("cancel"),
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       await runner.execute("本番に不可逆な変更を入れる長期実行を開始して", "/repo/app");
@@ -4685,7 +4685,6 @@ describe("ChatRunner", () => {
           }),
           runSpecConfirmationDecision("approve"),
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       await runner.execute("このワークスペースで長期実行して", "/repo/maybe");
@@ -4708,7 +4707,6 @@ describe("ChatRunner", () => {
           runSpecDraftDecision(),
           runSpecConfirmationDecision("cancel"),
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
@@ -4737,7 +4735,6 @@ describe("ChatRunner", () => {
           freeformRouteDecision("assist"),
           "There is no pending RunSpec to approve.",
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
@@ -4786,7 +4783,6 @@ describe("ChatRunner", () => {
           }),
           runSpecConfirmationDecision("approve"),
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
@@ -4819,7 +4815,6 @@ describe("ChatRunner", () => {
           freeformRouteDecision("run_spec"),
           runSpecDraftDecision(),
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       await firstRunner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
@@ -4834,7 +4829,6 @@ describe("ChatRunner", () => {
         stateManager,
         daemonClient: { startGoal: vi.fn().mockResolvedValue({ ok: true }) } as never,
         llmClient: createSingleMockLLMClient(runSpecConfirmationDecision("approve")),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
       reloadedRunner.startSessionFromLoadedSession(loaded!);
 
@@ -4862,7 +4856,6 @@ describe("ChatRunner", () => {
           }),
           runSpecConfirmationDecision("approve"),
         ]),
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       await runner.execute("Kaggle score 0.98を超えるまで長期で回して", "/repo/kaggle");
@@ -4889,7 +4882,6 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         adapter,
         llmClient,
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
 
       const result = await runner.execute("Why do long-running tasks fail?", "/repo");
@@ -4911,7 +4903,6 @@ describe("ChatRunner", () => {
       const runner = new ChatRunner(makeDeps({
         stateManager,
         llmClient,
-        chatAgentLoopRunner: { execute: vi.fn() } as unknown as ChatAgentLoopRunner,
       }));
       const ingress = {
         ...makeIngress("Please keep improving this Kaggle run until score exceeds 0.98."),

--- a/src/interface/chat/__tests__/chat-schedule-integration.test.ts
+++ b/src/interface/chat/__tests__/chat-schedule-integration.test.ts
@@ -124,6 +124,18 @@ function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
   };
 }
 
+function parseMockJSON(content: string, schema: z.ZodTypeAny) {
+  return schema.parse(JSON.parse(content));
+}
+
+function freeformExecuteDecision(): string {
+  return JSON.stringify({
+    kind: "execute",
+    confidence: 0.95,
+    rationale: "operator asked to execute a chat tool",
+  });
+}
+
 describe("ChatRunner schedule integration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -161,6 +173,12 @@ describe("ChatRunner schedule integration", () => {
       supportsToolCalling: () => true,
       sendMessage: vi.fn()
         .mockResolvedValueOnce({
+          content: freeformExecuteDecision(),
+          tool_calls: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "completed",
+        })
+        .mockResolvedValueOnce({
           content: "",
           tool_calls: [
             {
@@ -180,13 +198,14 @@ describe("ChatRunner schedule integration", () => {
           usage: { input_tokens: 1, output_tokens: 1 },
           stop_reason: "completed",
         }),
+      parseJSON: vi.fn(parseMockJSON),
     };
 
     const runner = new ChatRunner(makeDeps({ registry, llmClient: llmClient as never }));
     await runner.execute("list schedules", "/tmp");
 
     expect(vi.mocked(scheduleEngine.getEntries)).toHaveBeenCalledTimes(1);
-    const secondCallMessages = llmClient.sendMessage.mock.calls[1]?.[0] as Array<{ role: string; content: string }>;
+    const secondCallMessages = llmClient.sendMessage.mock.calls[2]?.[0] as Array<{ role: string; content: string }>;
     const toolResultMessage = secondCallMessages.find(
       (message) => message.role === "user" && message.content.startsWith("Tool result for list_schedules:\n"),
     );
@@ -205,6 +224,12 @@ describe("ChatRunner schedule integration", () => {
     const llmClient = {
       supportsToolCalling: () => true,
       sendMessage: vi.fn()
+        .mockResolvedValueOnce({
+          content: freeformExecuteDecision(),
+          tool_calls: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "completed",
+        })
         .mockResolvedValueOnce({
           content: "",
           tool_calls: [
@@ -233,6 +258,7 @@ describe("ChatRunner schedule integration", () => {
           usage: { input_tokens: 1, output_tokens: 1 },
           stop_reason: "completed",
         }),
+      parseJSON: vi.fn(parseMockJSON),
     };
 
     const runner = new ChatRunner(makeDeps({
@@ -273,6 +299,12 @@ describe("ChatRunner schedule integration", () => {
       supportsToolCalling: () => true,
       sendMessage: vi.fn()
         .mockResolvedValueOnce({
+          content: freeformExecuteDecision(),
+          tool_calls: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "completed",
+        })
+        .mockResolvedValueOnce({
           content: "",
           tool_calls: [
             {
@@ -294,6 +326,7 @@ describe("ChatRunner schedule integration", () => {
           usage: { input_tokens: 1, output_tokens: 1 },
           stop_reason: "completed",
         }),
+      parseJSON: vi.fn(parseMockJSON),
     };
 
     const runner = new ChatRunner(makeDeps({
@@ -324,6 +357,12 @@ describe("ChatRunner schedule integration", () => {
       supportsToolCalling: () => true,
       sendMessage: vi.fn()
         .mockResolvedValueOnce({
+          content: freeformExecuteDecision(),
+          tool_calls: [],
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "completed",
+        })
+        .mockResolvedValueOnce({
           content: "",
           tool_calls: [
             {
@@ -345,6 +384,7 @@ describe("ChatRunner schedule integration", () => {
           usage: { input_tokens: 1, output_tokens: 1 },
           stop_reason: "completed",
         }),
+      parseJSON: vi.fn(parseMockJSON),
     };
 
     const runner = new ChatRunner(makeDeps({

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -10,6 +10,8 @@ import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adap
 import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { StateManager as RealStateManager } from "../../../base/state/state-manager.js";
+import { createSetupRuntimeControlTools } from "../../../tools/runtime/SetupRuntimeControlTools.js";
+import type { ToolCallContext } from "../../../tools/types.js";
 
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -134,11 +136,9 @@ describe("CrossPlatformChatSessionManager", () => {
     try {
       const stateManager = new RealStateManager(baseDir, undefined, { walEnabled: false });
       const adapter = makeMockAdapter();
-      const chatAgentLoopRunner = { execute: vi.fn() };
       const manager = new CrossPlatformChatSessionManager(makeDeps({
         stateManager,
         adapter,
-        chatAgentLoopRunner: chatAgentLoopRunner as never,
         llmClient: createMockLLMClient([
           runSpecFreeformDecision(),
           runSpecDraftDecision(),
@@ -159,7 +159,6 @@ describe("CrossPlatformChatSessionManager", () => {
       expect(result.output).toContain("Proposed long-running run:");
       expect(result.output).toContain("It has not started a daemon run.");
       expect(adapter.execute).not.toHaveBeenCalled();
-      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
       const [fileName] = fs.readdirSync(`${baseDir}/run-specs`);
       const stored = JSON.parse(fs.readFileSync(`${baseDir}/run-specs/${fileName}`, "utf8"));
       expect(stored.status).toBe("draft");
@@ -179,11 +178,9 @@ describe("CrossPlatformChatSessionManager", () => {
     try {
       const stateManager = new RealStateManager(baseDir, undefined, { walEnabled: false });
       const adapter = makeMockAdapter();
-      const chatAgentLoopRunner = { execute: vi.fn() };
       const manager = new CrossPlatformChatSessionManager(makeDeps({
         stateManager,
         adapter,
-        chatAgentLoopRunner: chatAgentLoopRunner as never,
         llmClient: createMockLLMClient([
           configureFreeformDecision(),
           runSpecDraftDecision(),
@@ -203,7 +200,6 @@ describe("CrossPlatformChatSessionManager", () => {
       expect(result.output).toContain("It has not started a daemon run.");
       expect(result.output).not.toContain("setup/configuration");
       expect(adapter.execute).not.toHaveBeenCalled();
-      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
       expect(fs.readdirSync(`${baseDir}/run-specs`)).toHaveLength(1);
     } finally {
       cleanupTempDir(baseDir);
@@ -215,12 +211,10 @@ describe("CrossPlatformChatSessionManager", () => {
     try {
       const stateManager = new RealStateManager(baseDir, undefined, { walEnabled: false });
       const adapter = makeMockAdapter();
-      const chatAgentLoopRunner = { execute: vi.fn() };
       const daemonClient = { startGoal: vi.fn().mockResolvedValue({ ok: true }) };
       const manager = new CrossPlatformChatSessionManager(makeDeps({
         stateManager,
         adapter,
-        chatAgentLoopRunner: chatAgentLoopRunner as never,
         daemonClient: daemonClient as never,
         llmClient: createMockLLMClient([
           runSpecFreeformDecision(),
@@ -255,7 +249,6 @@ describe("CrossPlatformChatSessionManager", () => {
       expect(approved.output).toContain("Started daemon-backed DurableLoop goal:");
       expect(daemonClient.startGoal).toHaveBeenCalledOnce();
       expect(adapter.execute).not.toHaveBeenCalled();
-      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
 
       const [runFileName] = fs.readdirSync(`${baseDir}/runtime/background-runs`);
       const run = JSON.parse(fs.readFileSync(`${baseDir}/runtime/background-runs/${runFileName}`, "utf8"));
@@ -315,9 +308,6 @@ describe("CrossPlatformChatSessionManager", () => {
       stateManager,
       adapter,
       llmClient,
-      chatAgentLoopRunner: {
-        execute: vi.fn(),
-      } as never,
     }));
 
     const result = await manager.execute(token, {
@@ -713,10 +703,9 @@ describe("CrossPlatformChatSessionManager", () => {
     });
 
     expect(result.success).toBe(true);
-    expect(result.output).toContain("Telegram gateway status");
-    expect(result.output).toContain("chat-assisted setup");
+    expect(result.output).toBe("agent loop should not run");
     expect(runtimeControlService.request).not.toHaveBeenCalled();
-    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
     expect(adapter.execute).not.toHaveBeenCalled();
   });
 
@@ -744,7 +733,6 @@ describe("CrossPlatformChatSessionManager", () => {
       adapter,
       chatAgentLoopRunner: chatAgentLoopRunner as never,
       llmClient: createMockLLMClient([
-        "not a freeform route decision",
         JSON.stringify({
           intent: "restart_daemon",
           reason: "PulSeed を再起動して",
@@ -765,6 +753,55 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(result.success).toBe(false);
     expect(result.output).toContain("not authorized for runtime-control lifecycle actions");
     expect(result.output).toContain("operation was not executed");
+    expect(result.output).toContain("will not fall back to shell tools");
+    expect(runtimeControlService.request).not.toHaveBeenCalled();
+    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(adapter.execute).not.toHaveBeenCalled();
+  });
+
+  it("blocks explicit runtime-control metadata when no typed operation can be derived", async () => {
+    const stateManager = makeMockStateManager();
+    const adapter = makeMockAdapter();
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockResolvedValue({
+        success: true,
+        output: "agent loop should not run shell fallback",
+        error: null,
+        exit_code: null,
+        elapsed_ms: 42,
+        stopped_reason: "completed",
+      }),
+    };
+    const runtimeControlService = {
+      request: vi.fn().mockResolvedValue({
+        success: true,
+        message: "runtime control should not run",
+      }),
+    };
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager,
+      adapter,
+      chatAgentLoopRunner: chatAgentLoopRunner as never,
+      llmClient: createMockLLMClient([
+        "{not valid runtime-control json",
+      ]),
+      runtimeControlService,
+    }));
+
+    const result = await manager.execute("その操作をやって", {
+      identity_key: "owner",
+      platform: "telegram",
+      conversation_id: "telegram-chat-1",
+      user_id: "user-1",
+      cwd: "/repo",
+      metadata: {
+        runtime_control_explicit: true,
+        runtime_control_denied: true,
+      },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("could not derive a typed runtime-control operation");
     expect(result.output).toContain("will not fall back to shell tools");
     expect(runtimeControlService.request).not.toHaveBeenCalled();
     expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
@@ -1218,27 +1255,48 @@ describe("CrossPlatformChatSessionManager", () => {
     const stateManager = makeMockStateManager();
     const adapter = makeMockAdapter();
     const chatAgentLoopRunner = {
-      execute: vi.fn().mockResolvedValue({
-        success: true,
-        output: "agent loop should not run",
-        error: null,
-        exit_code: null,
-        elapsed_ms: 42,
-        stopped_reason: "completed",
+      execute: vi.fn().mockImplementation(async (input: { toolCallContext?: ToolCallContext }) => {
+        const guidanceTool = createSetupRuntimeControlTools({
+          stateManager,
+          gatewaySetupStatusProvider: {
+            getTelegramStatus: vi.fn().mockResolvedValue({
+              channel: "telegram",
+              state: "unconfigured",
+              configPath: "/tmp/pulseed/gateway/channels/telegram-bot/config.json",
+              daemon: { running: true, port: 41700 },
+              gateway: { loadState: "unknown" },
+              config: {
+                exists: false,
+                hasBotToken: false,
+                hasHomeChat: false,
+                allowAll: false,
+                allowedUserCount: 0,
+                runtimeControlAllowedUserCount: 0,
+                identityKeyConfigured: false,
+              },
+            }),
+          },
+        }).find((tool) => tool.metadata.name === "prepare_gateway_setup_guidance")!;
+        const result = await guidanceTool.call({
+          channel: "telegram",
+          request: "telegramからseedyと会話できるようにしたい",
+          language: "ja",
+        }, input.toolCallContext!);
+        return {
+          success: result.success,
+          output: result.summary,
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
+        };
       }),
     };
     const manager = new CrossPlatformChatSessionManager(makeDeps({
       stateManager,
       adapter,
       chatAgentLoopRunner: chatAgentLoopRunner as never,
-      llmClient: createMockLLMClient([
-        JSON.stringify({
-          kind: "configure",
-          configure_target: "telegram_gateway",
-          confidence: 0.96,
-          rationale: "user wants Telegram chat setup",
-        }),
-      ]),
+      llmClient: createMockLLMClient([]),
     }));
 
     const result = await manager.execute("telegramからseedyと会話できるようにしたい", {
@@ -1253,7 +1311,7 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(result.output).toContain("Telegram gateway status");
     expect(result.output).toContain("chat-assisted setup");
     expect(result.output).toContain("pulseed daemon status");
-    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
     expect(adapter.execute).not.toHaveBeenCalled();
   });
 

--- a/src/interface/chat/__tests__/ingress-router.test.ts
+++ b/src/interface/chat/__tests__/ingress-router.test.ts
@@ -40,7 +40,7 @@ describe("IngressRouter", () => {
     expect(route.kind).toBe("tool_loop");
   });
 
-  it("routes explicit runtime-control requests when allowed", () => {
+  it("keeps allowed runtime-control intent on agent_loop when available", () => {
     const route = router.selectRoute(
       buildStandaloneIngressMessage({
         text: "PulSeed を再起動して",
@@ -118,6 +118,35 @@ describe("IngressRouter", () => {
     expect(route.reason).toBe("runtime_control_disallowed");
   });
 
+  it("blocks explicit runtime-control turns when no typed intent was derived", () => {
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: "that lifecycle operation",
+        channel: "plugin_gateway",
+        platform: "telegram",
+        runtimeControl: {
+          allowed: false,
+          approvalMode: "disallowed",
+        },
+        metadata: {
+          runtime_control_explicit: true,
+          runtime_control_denied: true,
+        },
+      }),
+      {
+        hasAgentLoop: true,
+        hasToolLoop: true,
+        hasRuntimeControlService: true,
+        runtimeControlIntent: null,
+        runtimeControlUnclassified: true,
+      }
+    );
+
+    expect(route.kind).toBe("runtime_control_blocked");
+    expect(route.reason).toBe("runtime_control_unclassified");
+    expect(route.eventProjectionPolicy).toBe("latest_active_reply_target");
+  });
+
   it("keeps long-running natural-language work on agent_loop so tools can decide handoff", () => {
     const route = router.selectRoute(
       buildStandaloneIngressMessage({
@@ -180,7 +209,7 @@ describe("IngressRouter", () => {
     expect(route.kind).toBe("agent_loop");
   });
 
-  it("routes a precomputed typed RunSpec draft without keyword-derived route logic", () => {
+  it("keeps precomputed typed RunSpec drafts on agent_loop when tools can decide handoff", () => {
     const draft = {
       schema_version: "run-spec-v1",
       id: "runspec-00000000-0000-4000-8000-000000000001",
@@ -231,6 +260,66 @@ describe("IngressRouter", () => {
       }),
       {
         hasAgentLoop: true,
+        hasToolLoop: true,
+        runSpecDraft: draft,
+      }
+    );
+
+    expect(route.kind).toBe("agent_loop");
+    expect(route.reason).toBe("agent_loop_available");
+  });
+
+  it("falls back to precomputed typed RunSpec drafts when agent_loop is unavailable", () => {
+    const draft = {
+      schema_version: "run-spec-v1",
+      id: "runspec-00000000-0000-4000-8000-000000000001",
+      status: "draft",
+      profile: "kaggle",
+      source_text: "Kaggle score 0.98を超えるまで長期で回して",
+      objective: "Improve Kaggle score until it exceeds 0.98",
+      workspace: { path: "/repo/kaggle", source: "context", confidence: "medium" },
+      execution_target: { kind: "daemon", remote_host: null, confidence: "medium" },
+      metric: {
+        name: "kaggle_score",
+        direction: "maximize",
+        target: 0.98,
+        target_rank_percent: null,
+        datasource: "kaggle_leaderboard",
+        confidence: "high",
+      },
+      progress_contract: {
+        kind: "metric_target",
+        dimension: "kaggle_score",
+        threshold: 0.98,
+        semantics: "Kaggle score exceeds 0.98.",
+        confidence: "high",
+      },
+      deadline: null,
+      budget: { max_trials: null, max_wall_clock_minutes: null, resident_policy: "best_effort" },
+      approval_policy: {
+        submit: "approval_required",
+        publish: "unspecified",
+        secret: "approval_required",
+        external_action: "approval_required",
+        irreversible_action: "approval_required",
+      },
+      artifact_contract: { expected_artifacts: [], discovery_globs: [], primary_outputs: [] },
+      risk_flags: ["external_submit_requires_approval"],
+      missing_fields: [],
+      confidence: "high",
+      links: { goal_id: null, runtime_session_id: null, conversation_id: "chat-1" },
+      origin: { channel: "plugin_gateway", session_id: "chat-1", reply_target: null, metadata: {} },
+      created_at: "2026-05-03T00:00:00.000Z",
+      updated_at: "2026-05-03T00:00:00.000Z",
+    } satisfies RunSpec;
+    const route = router.selectRoute(
+      buildStandaloneIngressMessage({
+        text: draft.source_text,
+        channel: "plugin_gateway",
+        platform: "telegram",
+      }),
+      {
+        hasAgentLoop: false,
         hasToolLoop: true,
         runSpecDraft: draft,
       }

--- a/src/interface/chat/__tests__/tool-filtering.test.ts
+++ b/src/interface/chat/__tests__/tool-filtering.test.ts
@@ -194,7 +194,19 @@ describe("ChatRunner tool filtering integration", () => {
         const toolNames = (opts?.tools ?? []).map((t: { function: { name: string } }) => t.function.name);
 
         if (callCount === 1) {
-          // First call: request tool_search
+          return {
+            content: JSON.stringify({
+              kind: "execute",
+              confidence: 0.93,
+              rationale: "tool-backed request",
+            }),
+            usage: { input_tokens: 1, output_tokens: 1 },
+            stop_reason: "end_turn",
+            tool_calls: [],
+          } satisfies LLMResponse;
+        }
+        if (callCount === 2) {
+          // Tool-loop call: request tool_search
           return {
             content: "",
             usage: { input_tokens: 1, output_tokens: 1 },

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -127,14 +127,20 @@ export async function executeRunSpecDraftRoute(
 }
 
 export function formatBlockedRuntimeControlRoute(route: Extract<SelectedChatRoute, { kind: "runtime_control_blocked" }>): string {
+  if (route.reason === "runtime_control_unclassified") {
+    return [
+      "Runtime control was explicitly requested, but PulSeed could not derive a typed runtime-control operation from this turn.",
+      "The operation was not executed, and PulSeed will not fall back to shell tools for daemon or gateway lifecycle control.",
+    ].join("\n");
+  }
   if (route.reason === "runtime_control_disallowed") {
     return [
-      `Runtime control ${route.intent.kind} was recognized, but this chat surface is not authorized for runtime-control lifecycle actions.`,
+      `Runtime control ${route.intent?.kind ?? "operation"} was recognized, but this chat surface is not authorized for runtime-control lifecycle actions.`,
       "The operation was not executed, and PulSeed will not fall back to shell tools for daemon or gateway lifecycle control.",
     ].join("\n");
   }
   return [
-    `Runtime control ${route.intent.kind} was recognized, but the runtime-control service is not available in this chat surface.`,
+    `Runtime control ${route.intent?.kind ?? "operation"} was recognized, but the runtime-control service is not available in this chat surface.`,
     "The operation was not executed, and PulSeed will not fall back to shell tools for daemon or gateway lifecycle control.",
   ].join("\n");
 }

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -29,7 +29,7 @@ import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loo
 import type { ReviewAgentLoopRunner } from "../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
 import type { RuntimeControlService } from "../../runtime/control/index.js";
 import type { ApprovalBroker } from "../../runtime/approval-broker.js";
-import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
+import { classifyRuntimeControlIntent } from "../../runtime/control/index.js";
 import { classifyConfirmationDecision } from "../../runtime/confirmation-decision.js";
 import type {
   RuntimeControlActor,
@@ -512,14 +512,6 @@ export class ChatRunner {
     }
     const historyBlock = historySections.length > 0 ? `${historySections.join("\n\n")}\n\nCurrent message:\n` : "";
 
-    const selectedRoute = resumeOnly
-      ? null
-      : (options.selectedRoute ?? await this.resolveRouteFromInput(safeInput, runtimeControlContext, resolvedCwd));
-    this.lastSelectedRoute = selectedRoute;
-    if (selectedRoute?.kind !== "configure") {
-      this.eventBridge.emitIntent(safeInput, selectedRoute, eventContext);
-    }
-
     const start = Date.now();
     const assistantBuffer: AssistantBuffer = { text: "" };
     const identityResponse = resumeOnly ? null : resolveSelfIdentityResponse(safeInput, this.providerConfigBaseDir());
@@ -540,6 +532,14 @@ export class ChatRunner {
         output: identityResponse,
         elapsed_ms,
       };
+    }
+
+    const selectedRoute = resumeOnly
+      ? null
+      : (options.selectedRoute ?? await this.resolveRouteFromInput(safeInput, runtimeControlContext, resolvedCwd));
+    this.lastSelectedRoute = selectedRoute;
+    if (selectedRoute?.kind !== "configure") {
+      this.eventBridge.emitIntent(safeInput, selectedRoute, eventContext);
     }
 
     if (selectedRoute?.kind === "runtime_control") {
@@ -766,28 +766,46 @@ export class ChatRunner {
 
   private async resolveRouteFromIngress(ingress: ChatIngressMessage): Promise<SelectedChatRoute> {
     const capabilities = getRouteCapabilities(this.deps);
+    const hasSetupSecret = (this.setupSecretIntake?.suppliedSecrets.length ?? 0) > 0;
     const shouldPreferFreeformBeforeDeniedRuntimeControl =
-      ingress.metadata["runtime_control_denied"] === true
+      !hasSetupSecret
+      && !capabilities.hasAgentLoop
+      && ingress.metadata["runtime_control_denied"] === true
       && ingress.metadata["runtime_control_approved"] !== true
-      && ingress.metadata["runtime_control_explicit"] !== true
-      && capabilities.hasAgentLoop;
+      && ingress.metadata["runtime_control_explicit"] !== true;
+    const shouldClassifyRuntimeControlForSafety =
+      !hasSetupSecret
+      && capabilities.hasAgentLoop
+      && (
+        ingress.metadata["runtime_control_approved"] === true
+        || ingress.metadata["runtime_control_denied"] === true
+        || ingress.metadata["runtime_control_explicit"] === true
+      );
+    const shouldClassifyRuntimeControl =
+      shouldClassifyRuntimeControlForSafety
+      || (!hasSetupSecret && !capabilities.hasAgentLoop && (
+        (capabilities.hasRuntimeControlService && ingress.runtimeControl.approvalMode !== "disallowed")
+        || ingress.metadata["runtime_control_approved"] === true
+        || ingress.metadata["runtime_control_denied"] === true
+        || ingress.metadata["runtime_control_explicit"] === true
+      ));
     let freeformRouteIntent = shouldPreferFreeformBeforeDeniedRuntimeControl
       ? await classifyFreeformRouteIntent(ingress.text, this.deps.llmClient)
       : null;
-    const shouldClassifyRuntimeControl =
-      (capabilities.hasRuntimeControlService && ingress.runtimeControl.approvalMode !== "disallowed")
-      || ingress.metadata["runtime_control_approved"] === true
-      || ingress.metadata["runtime_control_denied"] === true
-      || ingress.metadata["runtime_control_explicit"] === true;
-    const runtimeControlIntent = freeformRouteIntent === null && shouldClassifyRuntimeControl
-      ? await recognizeRuntimeControlIntent(ingress.text, this.deps.llmClient)
+    const runtimeControlClassification = freeformRouteIntent == null && shouldClassifyRuntimeControl
+      ? await classifyRuntimeControlIntent(ingress.text, this.deps.llmClient)
       : null;
-    if (freeformRouteIntent === null && runtimeControlIntent === null && capabilities.hasAgentLoop) {
+    const runtimeControlIntent = runtimeControlClassification?.status === "intent"
+      ? runtimeControlClassification.intent
+      : null;
+    if (!hasSetupSecret && !capabilities.hasAgentLoop && freeformRouteIntent == null && runtimeControlIntent === null) {
       freeformRouteIntent = await classifyFreeformRouteIntent(ingress.text, this.deps.llmClient);
     }
     const shouldDeriveRunSpecDraft =
-      runtimeControlIntent === null
-      && freeformRouteIntent !== null
+      !capabilities.hasAgentLoop
+      && !hasSetupSecret
+      && runtimeControlIntent === null
+      && freeformRouteIntent != null
       && (
         freeformRouteIntent.kind === "run_spec"
         || freeformRouteIntent.kind === "configure"
@@ -814,6 +832,9 @@ export class ChatRunner {
     return standaloneIngressRouter.selectRoute(ingress, {
       ...capabilities,
       runtimeControlIntent,
+      runtimeControlUnclassified: shouldClassifyRuntimeControlForSafety
+        && runtimeControlClassification?.status === "unclassified"
+        && ingress.metadata["runtime_control_explicit"] === true,
       freeformRouteIntent,
       setupSecretIntake: this.setupSecretIntake,
       runSpecDraft,

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -11,7 +11,7 @@ import {
   type ChatIngressRuntimeControl,
   type SelectedChatRoute,
 } from "./ingress-router.js";
-import { recognizeRuntimeControlIntent } from "../../runtime/control/index.js";
+import { classifyRuntimeControlIntent } from "../../runtime/control/index.js";
 import { classifyFreeformRouteIntent } from "./freeform-route-classifier.js";
 import { deriveRunSpecFromText } from "../../runtime/run-spec/index.js";
 import { intakeSetupSecrets } from "./setup-secret-intake.js";
@@ -815,28 +815,46 @@ export class CrossPlatformChatSessionManager {
     };
     const setupSecretIntake = intakeSetupSecrets(ingress.text);
     const safeIngressText = setupSecretIntake.redactedText;
+    const hasSetupSecret = setupSecretIntake.suppliedSecrets.length > 0;
     const shouldPreferFreeformBeforeDeniedRuntimeControl =
-      ingress.metadata["runtime_control_denied"] === true
+      !hasSetupSecret
+      && !capabilities.hasAgentLoop
+      && ingress.metadata["runtime_control_denied"] === true
       && ingress.metadata["runtime_control_approved"] !== true
-      && ingress.metadata["runtime_control_explicit"] !== true
-      && capabilities.hasAgentLoop;
+      && ingress.metadata["runtime_control_explicit"] !== true;
+    const shouldClassifyRuntimeControlForSafety =
+      !hasSetupSecret
+      && capabilities.hasAgentLoop
+      && (
+        ingress.metadata["runtime_control_approved"] === true
+        || ingress.metadata["runtime_control_denied"] === true
+        || ingress.metadata["runtime_control_explicit"] === true
+      );
+    const shouldClassifyRuntimeControl =
+      shouldClassifyRuntimeControlForSafety
+      || (!hasSetupSecret && !capabilities.hasAgentLoop && (
+        (capabilities.hasRuntimeControlService && ingress.runtimeControl.approvalMode !== "disallowed")
+        || ingress.metadata["runtime_control_approved"] === true
+        || ingress.metadata["runtime_control_denied"] === true
+        || ingress.metadata["runtime_control_explicit"] === true
+      ));
     let freeformRouteIntent = shouldPreferFreeformBeforeDeniedRuntimeControl
       ? await classifyFreeformRouteIntent(safeIngressText, this.deps.llmClient)
       : null;
-    const shouldClassifyRuntimeControl =
-      (capabilities.hasRuntimeControlService && ingress.runtimeControl.approvalMode !== "disallowed")
-      || ingress.metadata["runtime_control_approved"] === true
-      || ingress.metadata["runtime_control_denied"] === true
-      || ingress.metadata["runtime_control_explicit"] === true;
-    const runtimeControlIntent = freeformRouteIntent === null && shouldClassifyRuntimeControl
-      ? await recognizeRuntimeControlIntent(safeIngressText, this.deps.llmClient)
+    const runtimeControlClassification = freeformRouteIntent == null && shouldClassifyRuntimeControl
+      ? await classifyRuntimeControlIntent(safeIngressText, this.deps.llmClient)
       : null;
-    if (freeformRouteIntent === null && runtimeControlIntent === null && capabilities.hasAgentLoop) {
+    const runtimeControlIntent = runtimeControlClassification?.status === "intent"
+      ? runtimeControlClassification.intent
+      : null;
+    if (!hasSetupSecret && !capabilities.hasAgentLoop && freeformRouteIntent == null && runtimeControlIntent === null) {
       freeformRouteIntent = await classifyFreeformRouteIntent(safeIngressText, this.deps.llmClient);
     }
     const shouldDeriveRunSpecDraft =
-      runtimeControlIntent === null
-      && freeformRouteIntent !== null
+      !capabilities.hasAgentLoop
+      && !hasSetupSecret
+      && runtimeControlIntent === null
+      && freeformRouteIntent != null
       && (
         freeformRouteIntent.kind === "run_spec"
         || freeformRouteIntent.kind === "configure"
@@ -863,6 +881,9 @@ export class CrossPlatformChatSessionManager {
     const selectedRoute = this.ingressRouter.selectRoute(ingress, {
       ...capabilities,
       runtimeControlIntent,
+      runtimeControlUnclassified: shouldClassifyRuntimeControlForSafety
+        && runtimeControlClassification?.status === "unclassified"
+        && ingress.metadata["runtime_control_explicit"] === true,
       freeformRouteIntent,
       setupSecretIntake,
       runSpecDraft,

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -87,8 +87,8 @@ export type SelectedChatRoute =
     }
   | {
       kind: "runtime_control_blocked";
-      reason: "runtime_control_unavailable" | "runtime_control_disallowed";
-      intent: RuntimeControlIntent;
+      reason: "runtime_control_unavailable" | "runtime_control_disallowed" | "runtime_control_unclassified";
+      intent?: RuntimeControlIntent;
       replyTargetPolicy: ReplyTargetPolicy;
       eventProjectionPolicy: EventProjectionPolicy;
       concurrencyPolicy: ConcurrencyPolicy;
@@ -99,6 +99,7 @@ export interface IngressRouterCapabilities {
   hasToolLoop: boolean;
   hasRuntimeControlService?: boolean;
   runtimeControlIntent?: RuntimeControlIntent | null;
+  runtimeControlUnclassified?: boolean;
   freeformRouteIntent?: FreeformRouteIntent | null;
   setupSecretIntake?: SetupSecretIntakeResult | null;
   runSpecDraft?: RunSpec | null;
@@ -122,8 +123,55 @@ function selectRouteForText(
   const canUseRuntimeControlRoute =
     runtimeControl.allowed && runtimeControl.approvalMode !== "disallowed";
 
+  if (deps.hasAgentLoop) {
+    const intent = deps.runtimeControlIntent ?? null;
+    if (intent === null && deps.runtimeControlUnclassified === true) {
+      return {
+        kind: "runtime_control_blocked",
+        reason: "runtime_control_unclassified",
+        ...runtimeControlPolicy,
+      };
+    }
+    if (intent !== null && !canUseRuntimeControlRoute) {
+      return {
+        kind: "runtime_control_blocked",
+        reason: "runtime_control_disallowed",
+        intent,
+        ...runtimeControlPolicy,
+      };
+    }
+    if (intent !== null && deps.hasRuntimeControlService !== true) {
+      return {
+        kind: "runtime_control_blocked",
+        reason: "runtime_control_unavailable",
+        intent,
+        ...runtimeControlPolicy,
+      };
+    }
+    if (intent !== null) {
+      return {
+        kind: "runtime_control",
+        reason: "runtime_control_intent",
+        intent,
+        ...runtimeControlPolicy,
+      };
+    }
+    return {
+      kind: "agent_loop",
+      reason: "agent_loop_available",
+      ...baseTurnPolicy,
+    };
+  }
+
   if (canUseRuntimeControlRoute) {
     const intent = deps.runtimeControlIntent ?? null;
+    if (intent === null && deps.runtimeControlUnclassified === true) {
+      return {
+        kind: "runtime_control_blocked",
+        reason: "runtime_control_unclassified",
+        ...runtimeControlPolicy,
+      };
+    }
     if (intent !== null && deps.hasRuntimeControlService === true) {
       return {
         kind: "runtime_control",
@@ -142,6 +190,13 @@ function selectRouteForText(
     }
   } else {
     const intent = deps.runtimeControlIntent ?? null;
+    if (intent === null && deps.runtimeControlUnclassified === true) {
+      return {
+        kind: "runtime_control_blocked",
+        reason: "runtime_control_unclassified",
+        ...runtimeControlPolicy,
+      };
+    }
     if (intent !== null) {
       return {
         kind: "runtime_control_blocked",
@@ -206,14 +261,6 @@ function selectRouteForText(
       kind: "clarify",
       reason: "freeform_semantic_route",
       intent: { ...freeformIntent, kind: "clarify" },
-      ...baseTurnPolicy,
-    };
-  }
-
-  if (deps.hasAgentLoop) {
-    return {
-      kind: "agent_loop",
-      reason: "agent_loop_available",
       ...baseTurnPolicy,
     };
   }

--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -10,6 +10,8 @@ import type { ChatAgentLoopRunner } from "../../../orchestrator/execution/agent-
 import { App, DASHBOARD_REFRESH_INTERVAL_MS, formatDaemonConnectionState } from "../app.js";
 import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import type { TelegramSetupStatus } from "../../chat/gateway-setup-status.js";
+import { createSetupRuntimeControlTools } from "../../../tools/runtime/SetupRuntimeControlTools.js";
+import type { ToolCallContext } from "../../../tools/types.js";
 
 const testState = vi.hoisted(() => ({
   lastChatProps: null as null | { onSubmit: (value: string) => Promise<void> },
@@ -517,7 +519,7 @@ describe("standalone slash command routing", () => {
     screen.unmount();
   });
 
-  it("persists a RunSpec draft and waits for confirmation before forwarding long-running runs", async () => {
+  it("routes long-running freeform requests through ChatRunner for AgentLoop RunSpec tools", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
     const llmClient = createMockLLMClient([
@@ -546,29 +548,16 @@ describe("standalone slash command routing", () => {
 
     await testState.lastChatProps!.onSubmit("Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.");
 
-    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.execute).toHaveBeenCalledWith(
+      "Run this Kaggle competition until tomorrow morning and aim for top 15%. Keep submissions approval-gated.",
+      "/work/kaggle",
+    );
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
-
-    await flush();
-    await testState.lastChatProps!.onSubmit("confirm");
-
-    expect(chatRunner.executeIngressMessage).toHaveBeenCalledOnce();
-    const calls = chatRunner.executeIngressMessage.mock.calls as unknown as Array<[
-      { metadata: Record<string, unknown> },
-      string,
-    ]>;
-    const [ingress, cwd] = calls[0]!;
-    expect(cwd).toBe("/work/kaggle");
-    expect(ingress.metadata).toMatchObject({
-      run_spec_profile: "kaggle",
-      run_spec_status: "confirmed",
-    });
-    expect(String(ingress.metadata.run_spec_id)).toMatch(/^runspec-/);
 
     screen.unmount();
   });
 
-  it("executes a confirmed RunSpec in the structured workspace rather than the stale TUI cwd", async () => {
+  it("leaves workspace derivation to ChatRunner instead of creating a TUI RunSpec draft", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
     const llmClient = createMockLLMClient([
@@ -603,25 +592,17 @@ describe("standalone slash command routing", () => {
 
     await testState.lastChatProps!.onSubmit("Run the Kaggle competition in /work/explicit-kaggle until tomorrow morning.");
     await flush();
-    await testState.lastChatProps!.onSubmit("confirm");
 
-    expect(chatRunner.executeIngressMessage).toHaveBeenCalledOnce();
-    const calls = chatRunner.executeIngressMessage.mock.calls as unknown as Array<[
-      { cwd: string; metadata: Record<string, unknown> },
-      string,
-    ]>;
-    const [ingress, cwd] = calls[0]!;
-    expect(cwd).toBe("/work/explicit-kaggle");
-    expect(ingress.cwd).toBe("/work/explicit-kaggle");
-    expect(ingress.metadata).toMatchObject({
-      run_spec_profile: "kaggle",
-      run_spec_status: "confirmed",
-    });
+    expect(chatRunner.execute).toHaveBeenCalledWith(
+      "Run the Kaggle competition in /work/explicit-kaggle until tomorrow morning.",
+      "/work/stale-tui-cwd",
+    );
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
 
     screen.unmount();
   });
 
-  it("does not start a long-running run when required RunSpec fields remain unresolved", async () => {
+  it("does not pre-agent confirm a long-running run when no TUI RunSpec draft is pending", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
     const llmClient = createMockLLMClient([
@@ -654,7 +635,12 @@ describe("standalone slash command routing", () => {
     await flush();
     await testState.lastChatProps!.onSubmit("confirm");
 
-    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.execute).toHaveBeenNthCalledWith(
+      1,
+      "Run this Kaggle competition and aim for top 15%. Keep submissions approval-gated.",
+      "/work/kaggle",
+    );
+    expect(chatRunner.execute).toHaveBeenNthCalledWith(2, "confirm", "/work/kaggle");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
 
     screen.unmount();
@@ -663,7 +649,7 @@ describe("standalone slash command routing", () => {
   it.each([
     ["Japanese", "明日のレビューまでコンペの改善を進めて、提出は承認制にして"],
     ["Spanish", "Sigue trabajando en la competición hasta la revisión y no envíes nada sin aprobación."],
-  ])("persists a RunSpec draft for %s caller-path phrasing", async (_label, requestText) => {
+  ])("routes %s long-running caller-path phrasing through ChatRunner", async (_label, requestText) => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();
     const llmClient = createMockLLMClient([
@@ -692,10 +678,9 @@ describe("standalone slash command routing", () => {
     await testState.lastChatProps!.onSubmit(requestText);
     await flush();
 
-    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.execute).toHaveBeenCalledWith(requestText, "/work/kaggle");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
-    expect(llmClient.callCount).toBe(2);
-    expect(testState.lastChatMessages.map((message) => message.text).join("\n")).toContain("Proposed long-running run");
+    expect(llmClient.callCount).toBe(1);
 
     screen.unmount();
   });
@@ -808,7 +793,7 @@ describe("standalone slash command routing", () => {
     await testState.lastChatProps!.onSubmit("このタスクの進め方を説明して");
     await flush();
 
-    expect(llmClient.callCount).toBe(2);
+    expect(llmClient.callCount).toBe(1);
     expect(chatRunner.execute).toHaveBeenCalledWith("このタスクの進め方を説明して", "/work/kaggle");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
 
@@ -826,13 +811,24 @@ describe("standalone slash command routing", () => {
       }),
     };
     const chatAgentLoopRunner = {
-      execute: vi.fn().mockResolvedValue({
-        success: true,
-        output: "agent loop should not run",
-        error: null,
-        exit_code: null,
-        elapsed_ms: 42,
-        stopped_reason: "completed",
+      execute: vi.fn().mockImplementation(async (input: { toolCallContext?: ToolCallContext }) => {
+        const guidanceTool = createSetupRuntimeControlTools({
+          stateManager: stateManager as unknown as StateManager,
+          gatewaySetupStatusProvider,
+        }).find((tool) => tool.metadata.name === "prepare_gateway_setup_guidance")!;
+        const result = await guidanceTool.call({
+          channel: "telegram",
+          request: "telegramからseedyと会話できるようにしたい",
+          language: "ja",
+        }, input.toolCallContext!);
+        return {
+          success: result.success,
+          output: result.summary,
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
+        };
       }),
     } as unknown as ChatAgentLoopRunner;
     let tuiEventHandler: TuiChatSurface["onEvent"];
@@ -902,7 +898,7 @@ describe("standalone slash command routing", () => {
     const submit = testState.lastChatProps!.onSubmit("telegramからseedyと会話できるようにしたい");
     await vi.waitFor(() => {
       const visibleText = testState.lastChatMessages.map((message) => message.text).join("\n");
-      expect(visibleText).toContain("Telegram setup を開始しました");
+      expect(visibleText).toContain("Agent loop started");
       expect(visibleText).not.toContain("pulseed telegram setup");
     });
     statusLookupCanFinish.resolve();
@@ -917,14 +913,13 @@ describe("standalone slash command routing", () => {
     expect(chatRunnerOutput).toContain("pulseed gateway setup");
     await vi.waitFor(() => {
       const visibleText = testState.lastChatMessages.map((message) => message.text).join("\n");
-      expect(visibleText).toContain("Telegram setup を開始しました");
       expect(visibleText).toContain("pulseed telegram setup");
       expect(visibleText).not.toContain("I understand the request");
       expect(visibleText).not.toContain("Next I will");
       expect(visibleText).not.toContain("This is needed");
       expect(visibleText).not.toContain("resume the saved agent loop state");
     });
-    expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+    expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
     expect(adapter.execute).not.toHaveBeenCalled();
 
     screen.unmount();
@@ -970,7 +965,7 @@ describe("standalone slash command routing", () => {
 
     expect(chatRunner.execute).toHaveBeenCalledWith("この実行を一時停止して", "/work/kaggle");
     expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
-    expect(llmClient.callCount).toBe(2);
+    expect(llmClient.callCount).toBe(1);
 
     screen.unmount();
   });

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -45,8 +45,6 @@ import { RuntimeHealthStore } from "../../runtime/store/health-store.js";
 import type { RuntimeHealthSnapshot } from "../../runtime/store/runtime-schemas.js";
 import {
   createRunSpecStore,
-  deriveRunSpecFromText,
-  formatRunSpecSetupProposal,
   handleRunSpecConfirmationInput,
   type RunSpec,
 } from "../../runtime/run-spec/index.js";
@@ -789,25 +787,7 @@ export function App({
             }
           } else if (freeformRoute === "chat_runner" && chatRunner) {
             const effectiveCwd = cwd ?? process.cwd();
-            const runSpec = await deriveRunSpecFromText(input, {
-              cwd: effectiveCwd,
-              conversationId: chatRunner.getConversationId?.() ?? null,
-              timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-              llmClient,
-            });
-            if (runSpec) {
-              const savedRunSpec = await createRunSpecStore(stateManager).save(runSpec);
-              setPendingRunSpec(savedRunSpec);
-              setMessages((prev) => [...prev, {
-                id: randomUUID(),
-                role: "pulseed" as const,
-                text: formatRunSpecSetupProposal(savedRunSpec),
-                timestamp: new Date(),
-                messageType: savedRunSpec.missing_fields.length > 0 ? ("warning" as const) : ("info" as const),
-              }].slice(-MAX_MESSAGES));
-            } else {
-              await chatRunner.execute(input, effectiveCwd);
-            }
+            await chatRunner.execute(input, effectiveCwd);
           } else {
             setMessages((prev) => [...prev, {
               id: randomUUID(), role: "pulseed" as const,

--- a/src/runtime/control/index.ts
+++ b/src/runtime/control/index.ts
@@ -1,5 +1,5 @@
-export { recognizeRuntimeControlIntent } from "./runtime-control-intent.js";
-export type { RuntimeControlIntent } from "./runtime-control-intent.js";
+export { classifyRuntimeControlIntent, recognizeRuntimeControlIntent } from "./runtime-control-intent.js";
+export type { RuntimeControlIntent, RuntimeControlIntentClassification } from "./runtime-control-intent.js";
 export { RuntimeControlService } from "./runtime-control-service.js";
 export { createDaemonRuntimeControlExecutor } from "./daemon-runtime-control-executor.js";
 export {

--- a/src/runtime/control/runtime-control-intent.ts
+++ b/src/runtime/control/runtime-control-intent.ts
@@ -15,6 +15,11 @@ export interface RuntimeControlTargetHint {
   sessionId?: string;
 }
 
+export type RuntimeControlIntentClassification =
+  | { status: "intent"; intent: RuntimeControlIntent }
+  | { status: "none" }
+  | { status: "unclassified" };
+
 const RuntimeControlIntentDecisionSchema = z.object({
   intent: z.enum([
     "none",
@@ -71,8 +76,16 @@ export async function recognizeRuntimeControlIntent(
   input: string,
   llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">
 ): Promise<RuntimeControlIntent | null> {
+  const classification = await classifyRuntimeControlIntent(input, llmClient);
+  return classification.status === "intent" ? classification.intent : null;
+}
+
+export async function classifyRuntimeControlIntent(
+  input: string,
+  llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">
+): Promise<RuntimeControlIntentClassification> {
   const trimmed = input.trim();
-  if (!trimmed || !llmClient) return null;
+  if (!trimmed || !llmClient) return { status: "none" };
 
   const response = await llmClient.sendMessage(
     [{ role: "user", content: trimmed }],
@@ -85,9 +98,10 @@ export async function recognizeRuntimeControlIntent(
   );
   try {
     const decision = llmClient.parseJSON(response.content, RuntimeControlIntentDecisionSchema);
-    return toRuntimeControlIntent(trimmed, decision);
+    const intent = toRuntimeControlIntent(trimmed, decision);
+    return intent ? { status: "intent", intent } : { status: "none" };
   } catch {
-    return null;
+    return { status: "unclassified" };
   }
 }
 


### PR DESCRIPTION
Closes #1057

## Implementation summary
- Routes non-exact freeform chat turns to AgentLoop first when AgentLoop is available, after keeping exact commands, pending confirmations, setup secret redaction, and explicit runtime-control safety metadata outside the model path.
- Keeps fallback direct RunSpec/setup/runtime-control behavior only for surfaces without AgentLoop.
- Removes TUI-local freeform RunSpec derivation so TUI natural-language requests use the ChatRunner/AgentLoop tool path.
- Adds explicit unclassified runtime-control blocking for turns carrying runtime-control metadata, while ordinary non-runtime chat still reaches AgentLoop.

## Verification commands
- npm run typecheck
- npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/ingress-router.test.ts src/interface/tui/__tests__/app.test.ts src/interface/tui/__tests__/chat-surface.test.ts
- npx vitest run src/interface/chat/__tests__/chat-boundary-contract.test.ts src/interface/chat/__tests__/chat-runner-tools.test.ts src/interface/chat/__tests__/tool-filtering.test.ts src/interface/chat/__tests__/chat-runner-permissions.test.ts
- npx vitest run src/interface/chat/__tests__/chat-schedule-integration.test.ts
- npx vitest run src/runtime/control/__tests__/runtime-control-intent.test.ts
- npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/cross-platform-session.test.ts src/interface/chat/__tests__/ingress-router.test.ts src/interface/tui/__tests__/app.test.ts src/interface/tui/__tests__/chat-surface.test.ts src/interface/chat/__tests__/chat-boundary-contract.test.ts src/interface/chat/__tests__/chat-runner-tools.test.ts src/interface/chat/__tests__/tool-filtering.test.ts src/interface/chat/__tests__/chat-runner-permissions.test.ts src/runtime/control/__tests__/runtime-control-intent.test.ts
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known unresolved risks
- #1060 still needs the final shortcut inventory and cleanup after this ingress switch lands.
- Existing lint warnings remain unchanged; boundary lint reports warnings but no errors.