### PR TITLE
Remove freeform semantic shortcuts

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1719,7 +1719,7 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("No resumable native agentloop state found");
       expect(result.output).toContain("Type: Resume failure");
       expect(result.output).toContain("/sessions");
-      expect(result.output).toContain("/resume <id|title>");
+      expect(result.output).toContain("/resume <id>");
       expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
     });
 
@@ -1770,7 +1770,7 @@ describe("ChatRunner", () => {
         } as unknown as ChatAgentLoopRunner;
         const runner = new ChatRunner(makeDeps({ stateManager, chatAgentLoopRunner }));
 
-        const result = await runner.execute("/resume Work Session", "/repo");
+        const result = await runner.execute("/resume saved-session", "/repo");
 
         expect(result.success).toBe(true);
         expect(result.output).toBe("Resumed selected session");
@@ -3784,67 +3784,30 @@ describe("ChatRunner", () => {
       expect(result.output).not.toContain("tool_loop");
     });
 
-    it("answers Japanese self-identity questions from PulSeed identity without calling the model", async () => {
-      const pulseedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-identity-"));
-      const previousHome = process.env["PULSEED_HOME"];
-      process.env["PULSEED_HOME"] = pulseedHome;
-      clearIdentityCache();
-      const adapter = makeMockAdapter();
-      const llmClient = {
-        sendMessage: vi.fn().mockResolvedValue({
-          content: "Codex",
-          usage: { input_tokens: 2, output_tokens: 3 },
-          stop_reason: "end_turn",
-        }),
-        parseJSON: vi.fn(),
-      };
-
-      try {
-        const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never }));
-        const result = await runner.execute("あなたは誰？", "/repo");
-
-        expect(result.success).toBe(true);
-        expect(result.output).toContain("Seedy");
-        expect(result.output).toContain("PulSeed");
-        expect(result.output).not.toContain("Codex");
-        expect(llmClient.sendMessage).not.toHaveBeenCalled();
-        expect(adapter.execute).not.toHaveBeenCalled();
-      } finally {
-        if (previousHome === undefined) {
-          delete process.env["PULSEED_HOME"];
-        } else {
-          process.env["PULSEED_HOME"] = previousHome;
-        }
-        clearIdentityCache();
-        fs.rmSync(pulseedHome, { recursive: true, force: true });
-      }
-    });
-
-    it("answers Japanese name questions from custom SEED.md identity without saying Codex", async () => {
+    it("answers Japanese self-identity questions through model-grounded chat instead of host phrase matching", async () => {
       const pulseedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-identity-"));
       const previousHome = process.env["PULSEED_HOME"];
       process.env["PULSEED_HOME"] = pulseedHome;
       clearIdentityCache();
       fs.writeFileSync(path.join(pulseedHome, "SEED.md"), "# Sprout\n\nCustom identity.\n", "utf-8");
       const adapter = makeMockAdapter();
-      const llmClient = {
-        sendMessage: vi.fn().mockResolvedValue({
-          content: "Codex",
-          usage: { input_tokens: 2, output_tokens: 3 },
-          stop_reason: "end_turn",
-        }),
-        parseJSON: vi.fn(),
-      };
+      const llmClient = createMockLLMClient([
+        freeformRouteDecision("assist"),
+        "Sprout is the configured PulSeed identity.",
+      ]);
 
       try {
-        const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never }));
-        const result = await runner.execute("名前は何？", "/repo");
+        const sendSpy = vi.spyOn(llmClient, "sendMessage");
+        const runner = new ChatRunner(makeDeps({ adapter, llmClient }));
+        const result = await runner.execute("あなたは誰？", "/repo");
 
         expect(result.success).toBe(true);
         expect(result.output).toContain("Sprout");
         expect(result.output).toContain("PulSeed");
-        expect(result.output).not.toContain("Codex");
-        expect(llmClient.sendMessage).not.toHaveBeenCalled();
+        expect(sendSpy).toHaveBeenCalledTimes(2);
+        const assistOptions = sendSpy.mock.calls[1]?.[1] as { system?: string } | undefined;
+        expect(assistOptions?.system).toContain("Sprout");
+        expect(assistOptions?.system).toContain("configured agent identity running PulSeed");
         expect(adapter.execute).not.toHaveBeenCalled();
       } finally {
         if (previousHome === undefined) {
@@ -3857,44 +3820,7 @@ describe("ChatRunner", () => {
       }
     });
 
-    it("answers English name questions from custom SEED.md identity without saying ChatGPT", async () => {
-      const pulseedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-identity-"));
-      const previousHome = process.env["PULSEED_HOME"];
-      process.env["PULSEED_HOME"] = pulseedHome;
-      clearIdentityCache();
-      fs.writeFileSync(path.join(pulseedHome, "SEED.md"), "# Sprout\n\nCustom identity.\n", "utf-8");
-      const adapter = makeMockAdapter();
-      const llmClient = {
-        sendMessage: vi.fn().mockResolvedValue({
-          content: "ChatGPT",
-          usage: { input_tokens: 2, output_tokens: 3 },
-          stop_reason: "end_turn",
-        }),
-        parseJSON: vi.fn(),
-      };
-
-      try {
-        const runner = new ChatRunner(makeDeps({ adapter, llmClient: llmClient as never }));
-        const result = await runner.execute("What is your name?", "/repo");
-
-        expect(result.success).toBe(true);
-        expect(result.output).toContain("I am Sprout");
-        expect(result.output).toContain("PulSeed");
-        expect(result.output).not.toContain("ChatGPT");
-        expect(llmClient.sendMessage).not.toHaveBeenCalled();
-        expect(adapter.execute).not.toHaveBeenCalled();
-      } finally {
-        if (previousHome === undefined) {
-          delete process.env["PULSEED_HOME"];
-        } else {
-          process.env["PULSEED_HOME"] = previousHome;
-        }
-        clearIdentityCache();
-        fs.rmSync(pulseedHome, { recursive: true, force: true });
-      }
-    });
-
-    it("resolves self-identity from the ChatRunner stateManager base dir", async () => {
+    it("grounds self-identity chat from the ChatRunner stateManager base dir", async () => {
       const pulseedHome = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-identity-"));
       const previousHome = process.env["PULSEED_HOME"];
       delete process.env["PULSEED_HOME"];
@@ -3905,24 +3831,22 @@ describe("ChatRunner", () => {
         getBaseDir: () => pulseedHome,
       } as unknown as StateManager;
       const adapter = makeMockAdapter();
-      const llmClient = {
-        sendMessage: vi.fn().mockResolvedValue({
-          content: "Codex",
-          usage: { input_tokens: 2, output_tokens: 3 },
-          stop_reason: "end_turn",
-        }),
-        parseJSON: vi.fn(),
-      };
+      const llmClient = createMockLLMClient([
+        freeformRouteDecision("assist"),
+        "BaseDirSeed is the configured PulSeed identity.",
+      ]);
 
       try {
-        const runner = new ChatRunner(makeDeps({ adapter, stateManager, llmClient: llmClient as never }));
+        const sendSpy = vi.spyOn(llmClient, "sendMessage");
+        const runner = new ChatRunner(makeDeps({ adapter, stateManager, llmClient }));
         const result = await runner.execute("あなたは誰？", "/repo");
 
         expect(result.success).toBe(true);
         expect(result.output).toContain("BaseDirSeed");
         expect(result.output).toContain("PulSeed");
-        expect(result.output).not.toContain("Codex");
-        expect(llmClient.sendMessage).not.toHaveBeenCalled();
+        expect(sendSpy).toHaveBeenCalledTimes(2);
+        const assistOptions = sendSpy.mock.calls[1]?.[1] as { system?: string } | undefined;
+        expect(assistOptions?.system).toContain("BaseDirSeed");
         expect(adapter.execute).not.toHaveBeenCalled();
       } finally {
         if (previousHome === undefined) {

--- a/src/interface/chat/__tests__/chat-session-store.test.ts
+++ b/src/interface/chat/__tests__/chat-session-store.test.ts
@@ -166,7 +166,7 @@ describe("ChatSessionCatalog", () => {
     });
   });
 
-  it("resolves selectors by id prefix and unique title with clear errors", async () => {
+  it("resolves selectors by exact id and id prefix with clear errors", async () => {
     await stateManager.writeRaw(
       "chat/sessions/alpha-001.json",
       makeSession({
@@ -211,17 +211,14 @@ describe("ChatSessionCatalog", () => {
     const resolvedByPrefix = await catalog.resolveSelector("alpha-001");
     expect(resolvedByPrefix.id).toBe("alpha-001");
 
-    const resolvedByTitle = await catalog.resolveSelector("Alpha Run");
-    expect(resolvedByTitle.id).toBe("alpha-001");
-
     await expect(catalog.resolveSelector("beta-00")).rejects.toMatchObject({
       kind: "ambiguous",
       selector: "beta-00",
     });
 
-    await expect(catalog.resolveSelector("Unique Title")).rejects.toMatchObject({
-      kind: "ambiguous",
-      selector: "Unique Title",
+    await expect(catalog.resolveSelector("Alpha Run")).rejects.toMatchObject({
+      kind: "not_found",
+      selector: "Alpha Run",
     });
 
     await expect(catalog.resolveSelector("missing")).rejects.toMatchObject({

--- a/src/interface/chat/__tests__/event-subscriber.test.ts
+++ b/src/interface/chat/__tests__/event-subscriber.test.ts
@@ -139,15 +139,14 @@ describe("EventSubscriber", () => {
       expect(n!.message).toContain("No state change detected");
     });
 
-    it("formats stall via stall keyword in phase", () => {
+    it("does not infer stall from a freeform phase label", () => {
       const sub = makeSubscriber("goal-abc", "normal");
       const n = format(sub, "progress", {
         iteration: 3,
         phase: "stall detected",
         skipReason: "agent did not progress",
       });
-      expect(n).not.toBeNull();
-      expect(n!.type).toBe("stall");
+      expect(n).toBeNull();
     });
   });
 

--- a/src/interface/chat/__tests__/failure-recovery.test.ts
+++ b/src/interface/chat/__tests__/failure-recovery.test.ts
@@ -26,7 +26,7 @@ describe("failure recovery guidance", () => {
 
     expect(guidance.kind).toBe("resume");
     expect(guidance.nextActions.join("\n")).toContain("/sessions");
-    expect(guidance.nextActions.join("\n")).toContain("/resume <id|title>");
+    expect(guidance.nextActions.join("\n")).toContain("/resume <id>");
   });
 
   it("classifies permission failures from approval and tool dispositions", () => {

--- a/src/interface/chat/chat-runner-commands.ts
+++ b/src/interface/chat/chat-runner-commands.ts
@@ -55,9 +55,9 @@ Session
   /help                 Show this help message
   /clear                Clear conversation history
   /sessions             List prior chat sessions
-  /history [id|title]   Show saved chat history
+  /history [id]         Show saved chat history
   /title <title>        Rename the current session
-  /resume [id|title]    Resume native agentloop state for the current or selected session
+  /resume [id]          Resume native agentloop state for the current or selected session
   /cleanup [--dry-run]  Clean up stale chat sessions
   /compact              Summarize older chat turns and keep the latest turns
   /context              Show active working context and session assumptions

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -35,6 +35,7 @@ import {
 import { createOperationProgressItem } from "./operation-progress.js";
 import { createRunSpecStore, formatRunSpecSetupProposal } from "../../runtime/run-spec/index.js";
 import type { RunSpecConfirmationState } from "./chat-history.js";
+import { buildStaticSystemPrompt } from "./grounding.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
@@ -204,6 +205,7 @@ export async function executeAssistRoute(
   ];
   const response = await sendLLMMessage(host, host.deps.llmClient, messages, {
     system: [
+      buildStaticSystemPrompt(host.getProviderConfigBaseDir()),
       "Answer read-only. Provide concise operational guidance. Do not ask to edit files or run commands unless the user explicitly asks for execution.",
       sameLanguageResponseInstruction(host.getTurnLanguageHint()),
     ].join(" "),

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -7,7 +7,6 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import type { IAdapter } from "../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { getPulseedDirPath } from "../../base/utils/paths.js";
-import { getSelfIdentityResponseForBaseDir } from "../../base/config/identity-loader.js";
 import { ChatHistory, type ChatSession } from "./chat-history.js";
 import {
   ChatSessionCatalog,
@@ -163,21 +162,6 @@ function normalizePinnedReplyTarget(replyTarget: RuntimeControlReplyTarget | nul
 }
 
 const standaloneIngressRouter = createIngressRouter();
-
-function resolveSelfIdentityResponse(input: string, baseDir: string): string | null {
-  const normalized = input.trim().toLowerCase().replace(/\s+/g, "");
-  if (!normalized) return null;
-
-  const isEnglishIdentityQuestion = /^(whoareyou|whatisyourname|what'syourname)[?]?$/.test(normalized);
-  const isIdentityQuestion = [
-    /^(あなた|君|きみ|お前|おまえ)(は|って)?(誰|だれ|何者|なにもの)(ですか|なの|です)?[？?]?$/,
-    /^(あなた|君|きみ|お前|おまえ)の名前(は|って)?(何|なに)(ですか|なの|です)?[？?]?$/,
-    /^名前(は|って)?(何|なに)(ですか|なの|です)?[？?]?$/,
-  ].some((pattern) => pattern.test(normalized));
-
-  if (!isIdentityQuestion && !isEnglishIdentityQuestion) return null;
-  return getSelfIdentityResponseForBaseDir(baseDir, isEnglishIdentityQuestion ? "en" : "ja");
-}
 
 function formatPendingSetupConfirmationSubject(publicState: SetupDialogueRuntimeState["publicState"]): string {
   const lines = [
@@ -514,25 +498,6 @@ export class ChatRunner {
 
     const start = Date.now();
     const assistantBuffer: AssistantBuffer = { text: "" };
-    const identityResponse = resumeOnly ? null : resolveSelfIdentityResponse(safeInput, this.providerConfigBaseDir());
-
-    if (identityResponse !== null) {
-      const elapsed_ms = Date.now() - start;
-      await history.appendAssistantMessage(identityResponse);
-      this.eventBridge.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
-      this.eventBridge.emitEvent({
-        type: "assistant_final",
-        text: identityResponse,
-        persisted: true,
-        ...this.eventBridge.eventBase(eventContext),
-      });
-      this.eventBridge.emitLifecycleEndEvent("completed", elapsed_ms, eventContext, true);
-      return {
-        success: true,
-        output: identityResponse,
-        elapsed_ms,
-      };
-    }
 
     const selectedRoute = resumeOnly
       ? null

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -501,17 +501,6 @@ export class ChatSessionCatalog {
     const exactId = sessions.find((session) => session.id === normalizedSelector);
     if (exactId) return exactId;
 
-    const exactTitleMatches = sessions.filter((session) => session.title === normalizedSelector);
-    if (exactTitleMatches.length === 1) return exactTitleMatches[0];
-    if (exactTitleMatches.length > 1) {
-      throw new ChatSessionSelectorError(
-        `Ambiguous chat session title "${normalizedSelector}" matches ${exactTitleMatches.length} sessions.`,
-        selector,
-        "ambiguous",
-        exactTitleMatches.map((session) => session.id),
-      );
-    }
-
     const prefixMatches = sessions.filter((session) => session.id.startsWith(normalizedSelector));
     if (prefixMatches.length === 1) return prefixMatches[0];
     if (prefixMatches.length > 1) {

--- a/src/interface/chat/event-subscriber.ts
+++ b/src/interface/chat/event-subscriber.ts
@@ -224,7 +224,7 @@ export class EventSubscriber extends EventEmitter {
       const phase = ev.phase ?? "";
 
       // Complete phase
-      if (phase === "complete" || phase.toLowerCase().includes("complete")) {
+      if (phase === "complete") {
         const msg = `✅ [tend] ${shortId}: Complete! gap: ${gap?.toFixed(2) ?? "?"}, ${iter ?? "?"} iterations`;
         const n: TendNotification = { type: "complete", goalId: this.goalId, message: msg, iteration: iter, maxIterations: max, gap };
         this.previousGap = undefined;
@@ -232,7 +232,7 @@ export class EventSubscriber extends EventEmitter {
       }
 
       // Stall / skip
-      if (phase === "Skipped" || phase === "Skipped (no state change)" || phase.toLowerCase().includes("stall")) {
+      if (phase === "Skipped" || phase === "Skipped (no state change)") {
         const reason = ev.skipReason ?? phase;
         const msg = `⚠️ [tend] ${shortId}: Stalled — "${reason}"`;
         return { type: "stall", goalId: this.goalId, message: msg, iteration: iter, maxIterations: max, gap };

--- a/src/interface/chat/failure-recovery.ts
+++ b/src/interface/chat/failure-recovery.ts
@@ -114,7 +114,7 @@ const GUIDANCE_BY_KIND: Record<FailureRecoveryKind, FailureRecoveryGuidance> = {
     summary: "PulSeed could not find or load the session state needed to continue this turn.",
     nextActions: [
       "Run /sessions to find the intended chat session.",
-      "Run /resume <id|title> when the target session is available.",
+      "Run /resume <id> when the target session is available.",
       "Start a new turn with the missing context if no resumable state exists.",
     ],
   },

--- a/src/interface/tui/__tests__/actions.test.ts
+++ b/src/interface/tui/__tests__/actions.test.ts
@@ -185,7 +185,7 @@ describe("ActionHandler — handle()", () => {
       expect(result.messages.join("\n")).toContain("No runnable goal found");
     });
 
-    it("does not select a goal by title substring", async () => {
+    it("does not select a goal by title text", async () => {
       const goals = [
         makeGoal({ id: "goal-alpha", title: "Improve alpha routing", status: "active" }),
         makeGoal({ id: "goal-beta", title: "Improve beta routing", status: "active" }),
@@ -195,17 +195,25 @@ describe("ActionHandler — handle()", () => {
       vi.mocked(deps.stateManager.loadGoal).mockImplementation(async (id) => goals.find((goal) => goal.id === id) ?? null);
 
       const handler = new ActionHandler(deps);
-      const result = await handler.handle({
+
+      const substringResult = await handler.handle({
         intent: "loop_start",
         params: { goalArg: "routing" },
         raw: "/start routing",
       });
+      const exactTitleResult = await handler.handle({
+        intent: "loop_start",
+        params: { goalArg: "Improve beta routing" },
+        raw: "/start Improve beta routing",
+      });
 
-      expect(result.startLoop).toBeUndefined();
-      expect(result.messages.join("\n")).toContain('No goal matching "routing"');
+      expect(substringResult.startLoop).toBeUndefined();
+      expect(substringResult.messages.join("\n")).toContain('No goal matching "routing"');
+      expect(exactTitleResult.startLoop).toBeUndefined();
+      expect(exactTitleResult.messages.join("\n")).toContain('No goal matching "Improve beta routing"');
     });
 
-    it("selects by exact title or list number", async () => {
+    it("selects by exact id or list number", async () => {
       const goals = [
         makeGoal({ id: "goal-alpha", title: "Improve alpha routing", status: "active" }),
         makeGoal({ id: "goal-beta", title: "Improve beta routing", status: "active" }),
@@ -218,8 +226,8 @@ describe("ActionHandler — handle()", () => {
 
       await expect(handler.handle({
         intent: "loop_start",
-        params: { goalArg: "Improve beta routing" },
-        raw: "/start Improve beta routing",
+        params: { goalArg: "goal-beta" },
+        raw: "/start goal-beta",
       })).resolves.toMatchObject({ startLoop: { goalId: "goal-beta" } });
 
       await expect(handler.handle({

--- a/src/interface/tui/actions.ts
+++ b/src/interface/tui/actions.ts
@@ -98,7 +98,7 @@ export class ActionHandler {
       };
     }
 
-    // If a goal argument was provided, match by number (1-indexed), exact ID, or exact title.
+    // If a goal argument was provided, match by number (1-indexed) or exact ID.
     if (goalArg) {
       const num = parseInt(goalArg, 10);
       let matched: { id: string; title: string } | undefined;
@@ -107,21 +107,8 @@ export class ActionHandler {
         matched = runnableGoals[num - 1];
       } else {
         const exactId = runnableGoals.find((g) => g.id === goalArg);
-        const exactTitleMatches = runnableGoals.filter((g) => g.title === goalArg);
         if (exactId) {
           matched = exactId;
-        } else if (exactTitleMatches.length === 1) {
-          matched = exactTitleMatches[0];
-        } else if (exactTitleMatches.length > 1) {
-          const list = exactTitleMatches.map((g, i) => `  ${i + 1}. ${g.title} (ID: ${g.id})`).join("\n");
-          return {
-            messages: [
-              `Ambiguous goal title "${goalArg}".`,
-              list,
-              "Use /start <goal-id> or /start <number>.",
-            ],
-            messageType: "warning",
-          };
         }
       }
 
@@ -131,7 +118,7 @@ export class ActionHandler {
           messages: [
             `No goal matching "${goalArg}". Available goals:`,
             list,
-            "Use /start <number>, /start <goal-id>, or the exact title.",
+            "Use /start <number> or /start <goal-id>.",
           ],
           messageType: "warning",
         };
@@ -151,7 +138,7 @@ export class ActionHandler {
       messages: [
         "Multiple goals available. Specify which one to start:",
         list,
-        "Use /start <number>, /start <goal-id>, or the exact title.",
+        "Use /start <number> or /start <goal-id>.",
       ],
     };
   }

--- a/src/runtime/control/__tests__/runtime-control-service.test.ts
+++ b/src/runtime/control/__tests__/runtime-control-service.test.ts
@@ -224,6 +224,39 @@ describe("RuntimeControlService", () => {
     }
   });
 
+  it("does not recover runtime-control goal targets from display titles", async () => {
+    const tmpDir = makeTempDir("pulseed-runtime-control-service-title-target-");
+    try {
+      const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+      const executor = vi.fn();
+      const service = new RuntimeControlService({
+        operationStore,
+        executor,
+        sessionRegistry: {
+          snapshot: vi.fn().mockResolvedValue(snapshotWithRuns([
+            makeRun({ goal_id: null, title: "DurableLoop goal goal-from-title" }),
+          ])),
+        },
+      });
+
+      const result = await service.pauseRun({
+        runId: "run:coreloop:active",
+        reason: "pause this run",
+        cwd: "/repo",
+        approvalFn: vi.fn().mockResolvedValue(true),
+      });
+
+      expect(result).toMatchObject({
+        success: false,
+        state: "blocked",
+        message: expect.stringContaining("no typed goal/runtime bridge"),
+      });
+      expect(executor).not.toHaveBeenCalled();
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
   it("asks for clarification instead of guessing among multiple active or attention runs", async () => {
     const tmpDir = makeTempDir("pulseed-runtime-control-service-run-ambiguous-");
     try {

--- a/src/runtime/control/runtime-control-service.ts
+++ b/src/runtime/control/runtime-control-service.ts
@@ -264,7 +264,7 @@ export class RuntimeControlService {
       return blocked(`Runtime run ${run.id} is stale or terminal for ${request.intent.kind}; refusing to reuse previous-session state.`);
     }
 
-    return { ok: true, run, goalId: resolveGoalId(run, snapshot) };
+    return { ok: true, run, goalId: resolveGoalId(run) };
   }
 
   private async proposeFinalize(
@@ -579,15 +579,10 @@ function isCurrentRunForControl(run: BackgroundRun, kind: RuntimeControlOperatio
   return false;
 }
 
-function resolveGoalId(run: BackgroundRun, snapshot: RuntimeSessionRegistrySnapshot): string | null {
+function resolveGoalId(run: BackgroundRun): string | null {
   if (run.kind !== "coreloop_run") return null;
   if (run.goal_id) return run.goal_id;
-  const child = run.child_session_id
-    ? snapshot.sessions.find((session) => session.id === run.child_session_id)
-    : null;
-  const title = child?.title ?? run.title ?? "";
-  const match = title.match(/^(?:DurableLoop|CoreLoop) goal\s+(.+)$/);
-  return match?.[1]?.trim() || null;
+  return null;
 }
 
 function compareUpdated(left: BackgroundRun, right: BackgroundRun): number {

--- a/src/runtime/interactive-automation/__tests__/interactive-automation.test.ts
+++ b/src/runtime/interactive-automation/__tests__/interactive-automation.test.ts
@@ -118,8 +118,26 @@ describe("providers", () => {
     );
   });
 
-  it("treats HTTP 403 login responses as auth handoff candidates", async () => {
+  it("treats Manus HTTP 403 as an auth handoff status without parsing freeform error text", async () => {
     const fetchMock = vi.fn(async () => new Response("Login required to continue", { status: 403 }));
+    const provider = new ManusBrowserProvider({
+      apiKey: "test-key",
+      baseUrl: "https://manus.test",
+      fetch: fetchMock,
+    });
+
+    await expect(provider.runBrowserWorkflow({ task: "Open inbox" })).resolves.toMatchObject({
+      success: false,
+      authRequired: true,
+      failureCode: "auth_required",
+    });
+  });
+
+  it("uses typed Manus failure codes instead of parsing freeform error text", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      error: "Login required to continue",
+      failure_code: "auth_required",
+    }), { status: 403 }));
     const provider = new ManusBrowserProvider({
       apiKey: "test-key",
       baseUrl: "https://manus.test",

--- a/src/runtime/interactive-automation/failure-classifier.ts
+++ b/src/runtime/interactive-automation/failure-classifier.ts
@@ -8,7 +8,6 @@ export interface ClassifiedAutomationFailure {
 
 export function classifyAutomationFailure(params: {
   status?: number;
-  error?: string;
   failureCode?: AutomationFailureCode;
 }): ClassifiedAutomationFailure {
   if (params.failureCode) {
@@ -20,13 +19,6 @@ export function classifyAutomationFailure(params: {
   }
 
   const status = params.status ?? 0;
-  const error = (params.error ?? "").toLowerCase();
-  if (error.includes("expired") && (error.includes("session") || error.includes("auth"))) {
-    return { failureCode: "auth_expired", authRequired: true, retryable: false };
-  }
-  if (error.includes("login") || error.includes("sign in") || error.includes("authenticate")) {
-    return { failureCode: "auth_required", authRequired: true, retryable: false };
-  }
   if (status === 401) {
     return { failureCode: "auth_required", authRequired: true, retryable: false };
   }
@@ -38,19 +30,6 @@ export function classifyAutomationFailure(params: {
   }
   if (status >= 500 && status <= 599) {
     return { failureCode: "provider_unavailable", authRequired: false, retryable: true };
-  }
-
-  if (error.includes("rate limit") || error.includes("too many requests")) {
-    return { failureCode: "rate_limited", authRequired: false, retryable: true };
-  }
-  if (error.includes("blocked") || error.includes("captcha") || error.includes("unsafe browser")) {
-    return { failureCode: "site_blocked", authRequired: false, retryable: true };
-  }
-  if (error.includes("navigate") || error.includes("navigation")) {
-    return { failureCode: "navigation_failed", authRequired: false, retryable: true };
-  }
-  if (error.includes("permission") || error.includes("forbidden")) {
-    return { failureCode: "permission_denied", authRequired: false, retryable: false };
   }
 
   return { failureCode: "unknown_automation_error", authRequired: false, retryable: true };

--- a/src/runtime/interactive-automation/providers/manus-browser.ts
+++ b/src/runtime/interactive-automation/providers/manus-browser.ts
@@ -1,4 +1,5 @@
 import type {
+  AutomationFailureCode,
   AutomationEnvironment,
   BrowserStateInput,
   BrowserWorkflowInput,
@@ -91,9 +92,10 @@ export class ManusBrowserProvider implements InteractiveAutomationProvider {
 
     if (!response.ok) {
       const rawText = await response.text().catch(() => "");
+      const typedFailureCode = extractFailureCode(rawText) ?? failureCodeForManusStatus(response.status);
       const classified = classifyAutomationFailure({
         status: response.status,
-        error: rawText,
+        ...(typedFailureCode ? { failureCode: typedFailureCode } : {}),
       });
       return {
         success: false,
@@ -106,6 +108,34 @@ export class ManusBrowserProvider implements InteractiveAutomationProvider {
 
     return response.json();
   }
+}
+
+function extractFailureCode(rawText: string): AutomationFailureCode | undefined {
+  if (!rawText.trim()) return undefined;
+  try {
+    const raw = JSON.parse(rawText) as Record<string, unknown>;
+    const candidate = raw["failure_code"] ?? raw["failureCode"];
+    return isAutomationFailureCode(candidate) ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function failureCodeForManusStatus(status: number): AutomationFailureCode | undefined {
+  if (status === 403) return "auth_required";
+  return undefined;
+}
+
+function isAutomationFailureCode(value: unknown): value is AutomationFailureCode {
+  return value === "auth_required"
+    || value === "auth_expired"
+    || value === "permission_denied"
+    || value === "provider_unavailable"
+    || value === "rate_limited"
+    || value === "site_blocked"
+    || value === "navigation_failed"
+    || value === "verification_failed"
+    || value === "unknown_automation_error";
 }
 
 function normalizeBrowserResult(raw: unknown, fallbackSummary: string): BrowserWorkflowResult {


### PR DESCRIPTION
Closes #1060

## Summary
- remove host-side identity phrase matching from chat ingress and rely on the model-visible PulSeed identity grounding instead
- remove title/display-text target selection from chat history/resume, TUI goal start, and runtime-control goal resolution
- remove substring-based event/failure classification from agent-facing paths while preserving typed/status-based provider contracts

## Verification
- npm run typecheck
- npx vitest run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-session-store.test.ts src/interface/chat/__tests__/failure-recovery.test.ts src/interface/chat/__tests__/event-subscriber.test.ts src/interface/tui/__tests__/actions.test.ts src/runtime/control/__tests__/runtime-control-service.test.ts src/runtime/interactive-automation/__tests__/interactive-automation.test.ts
- npx vitest run src/interface/tui/__tests__/actions.test.ts src/runtime/interactive-automation/__tests__/interactive-automation.test.ts
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known unresolved risks
- No known unresolved material risks. Remaining semantic classifiers outside this patch are structured classifier/tool paths or exact protocol parsing surfaces.