### PR TITLE
refactor(runtime-control): move daemon request contracts

### DIFF
--- a/src/runtime/control/daemon-runtime-control-executor.ts
+++ b/src/runtime/control/daemon-runtime-control-executor.ts
@@ -1,5 +1,5 @@
 import { DaemonClient, isDaemonRunning } from "../daemon/client.js";
-import type { RuntimeControlOperationKind } from "../store/runtime-operation-schemas.js";
+import type { DaemonRuntimeControlRequestBody } from "../daemon/control-contracts.js";
 import type {
   RuntimeControlExecutor,
   RuntimeControlExecutorResult,
@@ -8,12 +8,6 @@ import type {
 export interface DaemonRuntimeControlExecutorOptions {
   baseDir: string;
   host?: string;
-}
-
-export interface DaemonRuntimeControlRequestBody {
-  operationId: string;
-  kind: RuntimeControlOperationKind;
-  reason: string;
 }
 
 export function createDaemonRuntimeControlExecutor(

--- a/src/runtime/control/index.ts
+++ b/src/runtime/control/index.ts
@@ -8,8 +8,8 @@ export {
 } from "./runtime-control-result-routing.js";
 export type {
   DaemonRuntimeControlExecutorOptions,
-  DaemonRuntimeControlRequestBody,
 } from "./daemon-runtime-control-executor.js";
+export type { DaemonRuntimeControlRequestBody } from "../daemon/control-contracts.js";
 export type {
   RuntimeControlExecutor,
   RuntimeControlExecutorResult,

--- a/src/runtime/daemon/client.ts
+++ b/src/runtime/daemon/client.ts
@@ -8,7 +8,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { DEFAULT_PORT } from "../port-utils.js";
-import type { DaemonRuntimeControlRequestBody } from "../control/index.js";
+import type { DaemonRuntimeControlRequestBody } from "./control-contracts.js";
 
 export interface DaemonClientConfig {
   host: string;

--- a/src/runtime/daemon/control-contracts.ts
+++ b/src/runtime/daemon/control-contracts.ts
@@ -1,0 +1,7 @@
+import type { RuntimeControlOperationKind } from "../store/runtime-operation-schemas.js";
+
+export interface DaemonRuntimeControlRequestBody {
+  operationId: string;
+  kind: RuntimeControlOperationKind;
+  reason: string;
+}


### PR DESCRIPTION
Closes #1052

## Summary
- Move the daemon runtime-control request body contract into `src/runtime/daemon/control-contracts.ts`.
- Repoint the daemon client away from the `runtime/control/index.ts` barrel while keeping the executor and public barrel type export available.
- Keep the `/daemon/runtime-control` request payload and response handling unchanged.

## Verification
- `npm run typecheck`
- `npx vitest run src/runtime/control/__tests__/daemon-runtime-control-executor.test.ts --config vitest.unit.config.ts` (current unit config excludes `src/runtime/**/*.test.ts`, so this discovers no files)
- `npx vitest run src/runtime/control/__tests__/daemon-runtime-control-executor.test.ts --config vitest.integration.config.ts`
- `npx madge --circular --extensions ts,tsx --ts-config tsconfig.json src/runtime/control src/runtime/daemon` (existing broad cycles remain; targeted control barrel -> daemon client cycle is gone)
- `git diff --check`

## Known unresolved risks
- The requested unit-config Vitest command is not runnable for this runtime test under the current repository config; integration config is the active focused lane for this file.
- Madge still reports unrelated pre-existing cycles outside the targeted #1052 barrel cycle.