### PR TITLE
refactor(state): extract write fence contracts

### DIFF
--- a/src/base/state/state-manager-goal-write.ts
+++ b/src/base/state/state-manager-goal-write.ts
@@ -4,7 +4,7 @@ import { acquireLock, releaseLock } from "./state-lock.js";
 import { appendWALRecord, compactWAL } from "./state-wal.js";
 import { writeSnapshot } from "./state-snapshot.js";
 import type { Goal } from "../types/goal.js";
-import type { StateWriteFence, StateWriteFenceContext } from "./state-manager.js";
+import type { StateWriteFence, StateWriteFenceContext } from "./state-write-fence.js";
 
 export interface GoalWriteCoordinatorOptions {
   baseDir: string;

--- a/src/base/state/state-manager.ts
+++ b/src/base/state/state-manager.ts
@@ -17,6 +17,7 @@ import type { CheckpointTrustPort } from "./checkpoint-trust-port.js";
 import { initDirs, atomicWrite, atomicRead } from "./state-persistence.js";
 import { GoalWriteCoordinator } from "./state-manager-goal-write.js";
 import { recoverStateManagerWAL } from "./state-manager-wal.js";
+import type { StateWriteFence } from "./state-write-fence.js";
 import {
   archiveCompleteMarkerPath,
   archiveGoalDir,
@@ -33,14 +34,7 @@ import {
 } from "./state-manager-goal-state.js";
 
 export { initDirs, atomicWrite, atomicRead };
-
-export interface StateWriteFenceContext {
-  goalId: string;
-  op: string;
-  data: unknown;
-}
-
-export type StateWriteFence = (context: StateWriteFenceContext) => Promise<void> | void;
+export type { StateWriteFence, StateWriteFenceContext } from "./state-write-fence.js";
 
 const MAX_HISTORY_ENTRIES = 500;
 

--- a/src/base/state/state-write-fence.ts
+++ b/src/base/state/state-write-fence.ts
@@ -1,0 +1,7 @@
+export interface StateWriteFenceContext {
+  goalId: string;
+  op: string;
+  data: unknown;
+}
+
+export type StateWriteFence = (context: StateWriteFenceContext) => Promise<void> | void;


### PR DESCRIPTION
Closes #1051

## Summary
- Extract `StateWriteFence` and `StateWriteFenceContext` into `src/base/state/state-write-fence.ts`.
- Re-export the write-fence types from `StateManager` to preserve existing public imports.
- Repoint `state-manager-goal-write.ts` to the lower-level contract module to remove the direct state-manager cycle without changing write behavior.

## Verification
- `npm run typecheck`
- `npx vitest run src/base/state --config vitest.unit.config.ts`
- `npx madge --circular --extensions ts,tsx --ts-config tsconfig.json src/base/state`
- `git diff --check`

## Known unresolved risks
- None known for the scoped extraction.