### PR TITLE
refactor(runtime): split evidence ledger types

### DIFF
--- a/src/runtime/store/artifact-retention.ts
+++ b/src/runtime/store/artifact-retention.ts
@@ -1,24 +1,18 @@
-import { z } from "zod";
 import type {
+  RuntimeArtifactRetentionClass,
   RuntimeEvidenceArtifactRef,
   RuntimeEvidenceCandidateRecord,
   RuntimeEvidenceEntry,
-} from "./evidence-ledger.js";
-import type { RuntimeReproducibilityManifest } from "./reproducibility-manifest.js";
+} from "./evidence-types.js";
 
-export const RuntimeArtifactRetentionClassSchema = z.enum([
-  "final_deliverable",
-  "best_candidate",
-  "robust_candidate",
-  "near_miss",
-  "reproducibility_critical",
-  "evidence_report",
-  "low_value_smoke",
-  "cache_intermediate",
-  "duplicate_superseded",
-  "other",
-]);
-export type RuntimeArtifactRetentionClass = z.infer<typeof RuntimeArtifactRetentionClassSchema>;
+interface RuntimeArtifactRetentionManifest {
+  artifacts?: Array<{
+    label: string;
+    path?: string;
+    state_relative_path?: string;
+    url?: string;
+  }>;
+}
 
 export type RuntimeArtifactCleanupActionKind =
   | "protect"
@@ -74,7 +68,7 @@ interface ArtifactRecord {
 
 export function summarizeArtifactRetention(
   entries: RuntimeEvidenceEntry[],
-  options: { manifests?: RuntimeReproducibilityManifest[] } = {}
+  options: { manifests?: RuntimeArtifactRetentionManifest[] } = {}
 ): RuntimeArtifactRetentionSummary {
   const records = collectArtifactRecords(entries, options.manifests ?? []);
   const decisions = [...records.values()].map(classifyArtifactRecord);
@@ -107,7 +101,7 @@ export function summarizeArtifactRetention(
 
 function collectArtifactRecords(
   entries: RuntimeEvidenceEntry[],
-  manifests: RuntimeReproducibilityManifest[]
+  manifests: RuntimeArtifactRetentionManifest[]
 ): Map<string, ArtifactRecord> {
   const candidateRoles = candidateRoleMap(entries);
   const manifestArtifactKeys = new Set<string>();

--- a/src/runtime/store/dream-checkpoints.ts
+++ b/src/runtime/store/dream-checkpoints.ts
@@ -1,7 +1,7 @@
 import type {
   RuntimeEvidenceDreamCheckpoint,
   RuntimeEvidenceEntry,
-} from "./evidence-ledger.js";
+} from "./evidence-types.js";
 
 export interface RuntimeDreamCheckpointContext extends RuntimeEvidenceDreamCheckpoint {
   entry_id: string;

--- a/src/runtime/store/evaluator-results.ts
+++ b/src/runtime/store/evaluator-results.ts
@@ -9,7 +9,7 @@ import type {
   RuntimeEvidenceEvaluatorPublishAction,
   RuntimeEvidenceEvaluatorStatus,
   RuntimeEvidenceMetric,
-} from "./evidence-ledger.js";
+} from "./evidence-types.js";
 
 type EvaluatorDirection = "maximize" | "minimize" | "neutral";
 

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import * as fsp from "node:fs/promises";
 import * as path from "node:path";
-import { z } from "zod";
 import {
   createRuntimeStorePaths,
   ensureRuntimeStorePaths,
@@ -18,9 +17,6 @@ import {
   type MemoryCorrectionTargetRef,
 } from "../../platform/corrections/memory-correction-ledger.js";
 import {
-  MemoryProvenanceSchema,
-  MemoryQuarantineStateSchema,
-  MemoryVerificationStatusSchema,
   type MemoryProvenance,
 } from "../../platform/corrections/memory-quarantine.js";
 import {
@@ -44,535 +40,125 @@ import {
 } from "./dream-checkpoints.js";
 import {
   summarizeArtifactRetention,
-  RuntimeArtifactRetentionClassSchema,
   type RuntimeArtifactRetentionSummary,
 } from "./artifact-retention.js";
-import type { RuntimeReproducibilityManifest } from "./reproducibility-manifest.js";
 
-export const RuntimeEvidenceOutcomeSchema = z.enum([
-  "improved",
-  "regressed",
-  "inconclusive",
-  "failed",
-  "blocked",
-  "continued",
-]);
-export type RuntimeEvidenceOutcome = z.infer<typeof RuntimeEvidenceOutcomeSchema>;
+interface RuntimeEvidenceReproducibilityManifest {
+  schema_version: "runtime-reproducibility-manifest-v1";
+  scope: {
+    goal_id?: string;
+    run_id?: string;
+  };
+  artifacts: Array<{
+    label: string;
+    path?: string;
+    state_relative_path?: string;
+    url?: string;
+  }>;
+}
 
-export const RuntimeEvidenceEntryKindSchema = z.enum([
-  "observation",
-  "strategy",
-  "task_generation",
-  "execution",
-  "verification",
-  "decision",
-  "metric",
-  "evaluator",
-  "research",
-  "dream_checkpoint",
-  "artifact",
-  "failure",
-  "correction",
-  "other",
-]);
-export type RuntimeEvidenceEntryKind = z.infer<typeof RuntimeEvidenceEntryKindSchema>;
-
-export const RuntimeEvidenceArtifactRefSchema = z.object({
-  label: z.string().min(1),
-  path: z.string().min(1).optional(),
-  state_relative_path: z.string().min(1).optional(),
-  url: z.string().url().optional(),
-  kind: z.enum(["log", "metrics", "report", "diff", "url", "other"]).default("other"),
-  retention_class: RuntimeArtifactRetentionClassSchema.optional(),
-  size_bytes: z.number().int().nonnegative().optional(),
-  source: z.string().min(1).optional(),
-  dependency_refs: z.array(z.string().min(1)).optional(),
-}).strict();
-export type RuntimeEvidenceArtifactRef = z.infer<typeof RuntimeEvidenceArtifactRefSchema>;
-
-export const RuntimeEvidenceMetricSchema = z.object({
-  label: z.string().min(1),
-  value: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
-  unit: z.string().min(1).optional(),
-  direction: z.enum(["maximize", "minimize", "neutral"]).optional(),
-  confidence: z.number().min(0).max(1).optional(),
-  observed_at: z.string().datetime().optional(),
-  source: z.string().min(1).optional(),
-  summary: z.string().min(1).optional(),
-}).strict();
-export type RuntimeEvidenceMetric = z.infer<typeof RuntimeEvidenceMetricSchema>;
-
-export const RuntimeEvidenceCandidateDispositionSchema = z.enum(["retained", "promoted", "retired"]);
-export type RuntimeEvidenceCandidateDisposition = z.infer<typeof RuntimeEvidenceCandidateDispositionSchema>;
-
-export const RuntimeEvidenceCandidateLineageSchema = z.object({
-  parent_candidate_id: z.string().min(1).optional(),
-  source_candidate_id: z.string().min(1).optional(),
-  source_strategy_id: z.string().min(1).optional(),
-  source_strategy: z.string().min(1).optional(),
-  strategy_family: z.string().min(1),
-  feature_lineage: z.array(z.string().min(1)).default([]),
-  model_lineage: z.array(z.string().min(1)).default([]),
-  config_lineage: z.array(z.string().min(1)).default([]),
-  seed_lineage: z.array(z.string().min(1)).default([]),
-  fold_lineage: z.array(z.string().min(1)).default([]),
-  postprocess_lineage: z.array(z.string().min(1)).default([]),
-  notes: z.string().min(1).optional(),
-}).strict();
-export type RuntimeEvidenceCandidateLineage = z.infer<typeof RuntimeEvidenceCandidateLineageSchema>;
-
-export const RuntimeEvidenceCandidateSimilaritySchema = z.object({
-  candidate_id: z.string().min(1),
-  similarity: z.number().min(0).max(1),
-  signal: z.enum(["declared", "lineage", "metric_correlation", "artifact_overlap", "other"]).default("declared"),
-  summary: z.string().min(1).optional(),
-}).strict();
-export type RuntimeEvidenceCandidateSimilarity = z.infer<typeof RuntimeEvidenceCandidateSimilaritySchema>;
-
-export const RuntimeEvidenceCandidateNearMissReasonSchema = z.enum([
-  "close_to_best",
-  "stability",
-  "novelty",
-  "weak_dimension_improvement",
-  "complementarity",
-  "ensemble_potential",
-]);
-export type RuntimeEvidenceCandidateNearMissReason = z.infer<typeof RuntimeEvidenceCandidateNearMissReasonSchema>;
-
-export const RuntimeEvidenceCandidateNearMissSchema = z.object({
-  status: z.enum(["retained", "promoted", "rejected"]).default("retained"),
-  reason_to_keep: z.array(RuntimeEvidenceCandidateNearMissReasonSchema).min(1),
-  margin_to_best: z.number().min(0).optional(),
-  weak_dimensions: z.array(z.string().min(1)).default([]),
-  complementary_candidate_ids: z.array(z.string().min(1)).default([]),
-  follow_up: z.object({
-    title: z.string().min(1),
-    rationale: z.string().min(1),
-    target_dimensions: z.array(z.string().min(1)).default([]),
-    expected_evidence_gain: z.string().min(1).optional(),
-  }).strict().optional(),
-  evidence_refs: z.array(z.string().min(1)).default([]),
-  summary: z.string().min(1).optional(),
-}).strict();
-export type RuntimeEvidenceCandidateNearMiss = z.infer<typeof RuntimeEvidenceCandidateNearMissSchema>;
-
-export const RuntimeEvidenceCandidateRecordSchema = z.object({
-  candidate_id: z.string().min(1),
-  label: z.string().min(1).optional(),
-  lineage: RuntimeEvidenceCandidateLineageSchema,
-  metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
-  artifacts: z.array(RuntimeEvidenceArtifactRefSchema).default([]),
-  similarity: z.array(RuntimeEvidenceCandidateSimilaritySchema).default([]),
-  robustness: z.object({
-    stability_score: z.number().min(0).max(1).optional(),
-    diversity_score: z.number().min(0).max(1).optional(),
-    risk_penalty: z.number().min(0).max(1).optional(),
-    robust_score: z.number().min(0).max(1).optional(),
-    evidence_confidence: z.number().min(0).max(1).optional(),
-    repeated_evaluations: z.number().int().nonnegative().optional(),
-    mean_score: z.number().optional(),
-    max_score: z.number().optional(),
-    score_stddev: z.number().min(0).optional(),
-    fold_score_range: z.number().min(0).optional(),
-    seed_score_range: z.number().min(0).optional(),
-    weak_dimensions: z.array(z.string().min(1)).default([]),
-    provenance_refs: z.array(z.string().min(1)).default([]),
-    summary: z.string().min(1).optional(),
-  }).strict().optional(),
-  near_miss: RuntimeEvidenceCandidateNearMissSchema.optional(),
-  disposition: RuntimeEvidenceCandidateDispositionSchema.default("retained"),
-  disposition_reason: z.string().min(1).optional(),
-  produced_at: z.string().datetime().optional(),
-}).strict();
-export type RuntimeEvidenceCandidateRecord = z.infer<typeof RuntimeEvidenceCandidateRecordSchema>;
-
-export const RuntimeEvidenceEvaluatorSignalSchema = z.enum(["local", "external"]);
-export type RuntimeEvidenceEvaluatorSignal = z.infer<typeof RuntimeEvidenceEvaluatorSignalSchema>;
-
-export const RuntimeEvidenceEvaluatorStatusSchema = z.enum([
-  "pending",
-  "ready",
-  "approval_required",
-  "submitted",
-  "passed",
-  "succeeded",
-  "completed",
-  "failed",
-  "regressed",
-  "blocked",
-  "unknown",
-]);
-export type RuntimeEvidenceEvaluatorStatus = z.infer<typeof RuntimeEvidenceEvaluatorStatusSchema>;
-
-export const RuntimeEvidenceEvaluatorPublishActionSchema = z.object({
-  id: z.string().min(1),
-  label: z.string().min(1),
-  tool_name: z.string().min(1).optional(),
-  payload_ref: z.string().min(1).optional(),
-  approval_required: z.literal(true).default(true),
-  status: z.enum(["approval_required", "approved", "submitted", "completed", "blocked"]).optional(),
-}).strict();
-export type RuntimeEvidenceEvaluatorPublishAction = z.infer<typeof RuntimeEvidenceEvaluatorPublishActionSchema>;
-
-export const RuntimeEvidenceEvaluatorValidationSchema = z.object({
-  status: z.enum(["pending", "passed", "failed", "blocked", "unknown"]).default("unknown"),
-  command: z.string().min(1).optional(),
-  summary: z.string().min(1).optional(),
-}).strict();
-export type RuntimeEvidenceEvaluatorValidation = z.infer<typeof RuntimeEvidenceEvaluatorValidationSchema>;
-
-export const RuntimeEvidenceEvaluatorProvenanceSchema = z.object({
-  kind: z.enum(["local_command", "external_url", "ci", "benchmark", "human_review", "other"]).default("other"),
-  command: z.string().min(1).optional(),
-  url: z.string().url().optional(),
-  run_id: z.string().min(1).optional(),
-  external_id: z.string().min(1).optional(),
-  raw_ref: z.string().min(1).optional(),
-  retrieved_at: z.string().datetime().optional(),
-}).strict();
-export type RuntimeEvidenceEvaluatorProvenance = z.infer<typeof RuntimeEvidenceEvaluatorProvenanceSchema>;
-
-export const RuntimeEvidenceEvaluatorBudgetSchema = z.object({
-  policy_id: z.string().min(1).optional(),
-  max_attempts: z.number().int().positive().optional(),
-  used_attempts: z.number().int().nonnegative().optional(),
-  remaining_attempts: z.number().int().nonnegative(),
-  approval_required: z.boolean().default(true),
-  deadline_at: z.string().datetime().optional(),
-  phase: z.enum(["exploration", "consolidation", "finalization", "other"]).optional(),
-  portfolio_policy: z.object({
-    diversified_portfolio_required: z.boolean().default(false),
-    reserve_for_finalization: z.boolean().default(false),
-    min_strategy_families: z.number().int().positive().optional(),
-  }).strict().optional(),
-}).strict();
-export type RuntimeEvidenceEvaluatorBudget = z.infer<typeof RuntimeEvidenceEvaluatorBudgetSchema>;
-
-export const RuntimeEvidenceEvaluatorCandidateSnapshotSchema = z.object({
-  evidence_entry_id: z.string().min(1).optional(),
-  primary_metric_label: z.string().min(1).optional(),
-  local_metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
-  robust_selection: z.object({
-    raw_rank: z.number().int().positive().optional(),
-    robust_score: z.number().min(0).max(1).optional(),
-    stability_score: z.number().min(0).max(1).optional(),
-    diversity_score: z.number().min(0).max(1).optional(),
-    risk_penalty: z.number().min(0).max(1).optional(),
-    portfolio_role: z.enum(["raw_best", "robust_best", "safe", "aggressive", "diverse", "near_miss", "other"]).optional(),
-  }).strict().optional(),
-  summary: z.string().min(1).optional(),
-}).strict();
-export type RuntimeEvidenceEvaluatorCandidateSnapshot = z.infer<typeof RuntimeEvidenceEvaluatorCandidateSnapshotSchema>;
-
-export const RuntimeEvidenceEvaluatorCalibrationSchema = z.object({
-  mode: z.literal("calibration_only").default("calibration_only"),
-  use_for_selection: z.boolean().default(false),
-  direct_optimization_allowed: z.literal(false).default(false),
-  minimum_observations: z.number().int().positive().default(1),
-  conclusion: z.string().min(1).optional(),
-}).strict();
-export type RuntimeEvidenceEvaluatorCalibration = z.infer<typeof RuntimeEvidenceEvaluatorCalibrationSchema>;
-
-export const RuntimeEvidenceEvaluatorObservationSchema = z.object({
-  evaluator_id: z.string().min(1),
-  signal: RuntimeEvidenceEvaluatorSignalSchema,
-  source: z.string().min(1),
-  candidate_id: z.string().min(1),
-  candidate_label: z.string().min(1).optional(),
-  artifact_labels: z.array(z.string().min(1)).optional(),
-  status: RuntimeEvidenceEvaluatorStatusSchema.default("unknown"),
-  score: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
-  score_label: z.string().min(1).optional(),
-  direction: z.enum(["maximize", "minimize", "neutral"]).optional(),
-  observed_at: z.string().datetime().optional(),
-  expected_score: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
-  expected_status: RuntimeEvidenceEvaluatorStatusSchema.optional(),
-  expectation_source: z.string().min(1).optional(),
-  validation: RuntimeEvidenceEvaluatorValidationSchema.optional(),
-  publish_action: RuntimeEvidenceEvaluatorPublishActionSchema.optional(),
-  provenance: RuntimeEvidenceEvaluatorProvenanceSchema.optional(),
-  budget: RuntimeEvidenceEvaluatorBudgetSchema.optional(),
-  candidate_snapshot: RuntimeEvidenceEvaluatorCandidateSnapshotSchema.optional(),
-  calibration: RuntimeEvidenceEvaluatorCalibrationSchema.optional(),
-  summary: z.string().min(1).optional(),
-}).strict();
-export type RuntimeEvidenceEvaluatorObservation = z.infer<typeof RuntimeEvidenceEvaluatorObservationSchema>;
-
-export const RuntimeEvidenceResearchSourceSchema = z.object({
-  url: z.string().url(),
-  title: z.string().min(1).optional(),
-  source_type: z.enum(["official_docs", "maintainer", "paper", "issue_thread", "example", "writeup", "other"]).default("other"),
-  provenance: z.enum(["quoted", "paraphrased", "summarized"]).default("summarized"),
-  relevance: z.string().min(1).optional(),
-}).strict();
-export type RuntimeEvidenceResearchSource = z.infer<typeof RuntimeEvidenceResearchSourceSchema>;
-
-export const RuntimeEvidenceResearchFindingSchema = z.object({
-  finding: z.string().min(1),
-  source_urls: z.array(z.string().url()).min(1),
-  applicability: z.string().min(1),
-  risks_constraints: z.array(z.string().min(1)).default([]),
-  proposed_experiment: z.string().min(1),
-  expected_metric_impact: z.string().min(1),
-  fact_vs_adaptation: z.object({
-    facts: z.array(z.string().min(1)).default([]),
-    adaptation: z.string().min(1),
-  }).strict(),
-}).strict();
-export type RuntimeEvidenceResearchFinding = z.infer<typeof RuntimeEvidenceResearchFindingSchema>;
-
-export const RuntimeEvidenceResearchExternalActionSchema = z.object({
-  label: z.string().min(1),
-  reason: z.string().min(1),
-  approval_required: z.literal(true).default(true),
-}).strict();
-export type RuntimeEvidenceResearchExternalAction = z.infer<typeof RuntimeEvidenceResearchExternalActionSchema>;
-
-export const RuntimeEvidenceResearchMemoSchema = z.object({
-  trigger: z.enum(["plateau", "uncertainty", "knowledge_gap"]),
-  query: z.string().min(1),
-  summary: z.string().min(1),
-  sources: z.array(RuntimeEvidenceResearchSourceSchema).min(1),
-  findings: z.array(RuntimeEvidenceResearchFindingSchema).min(1),
-  candidate_playbook: z.object({
-    title: z.string().min(1),
-    steps: z.array(z.string().min(1)).default([]),
-    source_urls: z.array(z.string().url()).default([]),
-  }).strict().optional(),
-  untrusted_content_policy: z.literal("webpage_instructions_are_untrusted").default("webpage_instructions_are_untrusted"),
-  external_actions: z.array(RuntimeEvidenceResearchExternalActionSchema).default([]),
-  confidence: z.number().min(0).max(1).default(0.5),
-}).strict();
-export type RuntimeEvidenceResearchMemo = z.infer<typeof RuntimeEvidenceResearchMemoSchema>;
-
-export const RuntimeEvidenceDreamCheckpointTriggerSchema = z.enum([
-  "iteration",
-  "plateau",
-  "breakthrough",
-  "pre_finalization",
-]);
-export type RuntimeEvidenceDreamCheckpointTrigger = z.infer<typeof RuntimeEvidenceDreamCheckpointTriggerSchema>;
-
-export const RuntimeEvidenceMemoryUsageStatsSchema = z.object({
-  last_used_at: z.string().datetime().nullable().default(null),
-  use_count: z.number().int().nonnegative().default(0),
-  validated_count: z.number().int().nonnegative().default(0),
-  negative_outcome_count: z.number().int().nonnegative().default(0),
-}).strict();
-export type RuntimeEvidenceMemoryUsageStats = z.infer<typeof RuntimeEvidenceMemoryUsageStatsSchema>;
-
-export const RuntimeEvidenceDreamCheckpointMemoryRefSchema = z.object({
-  source_type: z.enum(["soil", "playbook", "runtime_evidence", "other"]),
-  ref: z.string().min(1).optional(),
-  summary: z.string().min(1),
-  authority: z.literal("advisory_only").default("advisory_only"),
-  relevance_score: z.number().min(0).max(1).optional(),
-  source_reliability: z.number().min(0).max(1).optional(),
-  verification_status: MemoryVerificationStatusSchema.optional(),
-  provenance: MemoryProvenanceSchema.optional(),
-  quarantine_state: MemoryQuarantineStateSchema.optional(),
-  recency_score: z.number().min(0).max(1).optional(),
-  prior_success_contribution: z.number().min(0).max(1).optional(),
-  retrieval: z.object({
-    kind: z.enum(["route_hit", "fallback_hit", "checkpoint", "manual", "unknown"]).default("unknown"),
-    score: z.number().min(0).max(1).optional(),
-    confidence: z.number().min(0).max(1).optional(),
-  }).strict().optional(),
-  usage_stats: RuntimeEvidenceMemoryUsageStatsSchema.optional(),
-  ranking_trace: z.object({
-    score: z.number().min(0).max(1),
-    decision: z.enum(["admitted", "rejected"]),
-    reason: z.string().min(1),
-  }).strict().optional(),
-}).strict();
-export type RuntimeEvidenceDreamCheckpointMemoryRef = z.infer<typeof RuntimeEvidenceDreamCheckpointMemoryRefSchema>;
-
-export const RuntimeEvidenceDreamCheckpointStrategyCandidateSchema = z.object({
-  candidate_ref: z.string().min(1).optional(),
-  title: z.string().min(1),
-  rationale: z.string().min(1),
-  target_dimensions: z.array(z.string().min(1)).default([]),
-  expected_evidence_gain: z.string().min(1).optional(),
-  retry_reason: z.string().min(1).optional(),
-  failed_lineage_warning: z.object({
-    fingerprint: z.string().min(1),
-    count: z.number().int().positive(),
-    reason: z.string().min(1),
-  }).strict().optional(),
-}).strict();
-export type RuntimeEvidenceDreamCheckpointStrategyCandidate = z.infer<typeof RuntimeEvidenceDreamCheckpointStrategyCandidateSchema>;
-
-export const RuntimeEvidenceDreamCheckpointActiveHypothesisSchema = z.object({
-  hypothesis: z.string().min(1),
-  supporting_evidence_ref: z.string().min(1).optional(),
-  target_metric_or_dimension: z.string().min(1),
-  expected_next_observation: z.string().min(1),
-  status: z.enum(["active", "testing", "supported", "weakened"]).default("active"),
-}).strict();
-export type RuntimeEvidenceDreamCheckpointActiveHypothesis = z.infer<typeof RuntimeEvidenceDreamCheckpointActiveHypothesisSchema>;
-
-export const RuntimeEvidenceDreamCheckpointRejectedApproachSchema = z.object({
-  approach: z.string().min(1),
-  rejection_reason: z.string().min(1),
-  candidate_ref: z.string().min(1).optional(),
-  evidence_ref: z.string().min(1).optional(),
-  revisit_condition: z.string().min(1).optional(),
-  confidence: z.number().min(0).max(1).default(0.5),
-}).strict();
-export type RuntimeEvidenceDreamCheckpointRejectedApproach = z.infer<typeof RuntimeEvidenceDreamCheckpointRejectedApproachSchema>;
-
-export const RuntimeEvidenceDreamRunControlRecommendationSchema = z.object({
-  id: z.string().min(1).optional(),
-  action: z.enum([
-    "stay_current_mode",
-    "widen_exploration",
-    "consolidate_candidates",
-    "freeze_experiment_queue",
-    "enter_finalization",
-    "preserve_near_miss_candidates",
-    "retire_low_value_lineage",
-    "request_operator_approval",
-  ]),
-  rationale: z.string().min(1),
-  evidence: z.array(z.object({
-    kind: z.enum(["metric", "artifact", "lineage", "task_history", "deadline", "external_feedback", "memory", "runtime_state"]),
-    ref: z.string().min(1).optional(),
-    summary: z.string().min(1),
-  }).strict()).min(1),
-  target_mode: z.enum(["exploration", "consolidation", "finalization"]).optional(),
-  target_strategy_family: z.string().min(1).optional(),
-  candidate_refs: z.array(z.string().min(1)).default([]),
-  lineage_refs: z.array(z.string().min(1)).default([]),
-  approval_required: z.boolean().default(false),
-  risk: z.enum(["low", "medium", "high"]).default("medium"),
-  confidence: z.number().min(0).max(1).default(0.5),
-  policy_decision: z.object({
-    disposition: z.enum(["auto_apply", "approval_required", "advisory_only"]),
-    reason: z.string().min(1),
-  }).strict().optional(),
-}).strict();
-export type RuntimeEvidenceDreamRunControlRecommendation = z.infer<typeof RuntimeEvidenceDreamRunControlRecommendationSchema>;
-
-export const RuntimeEvidenceDreamCheckpointSchema = z.object({
-  trigger: RuntimeEvidenceDreamCheckpointTriggerSchema,
-  summary: z.string().min(1),
-  current_goal: z.string().min(1),
-  active_dimensions: z.array(z.string().min(1)).default([]),
-  best_evidence_so_far: z.string().min(1).optional(),
-  recent_strategy_families: z.array(z.string().min(1)).default([]),
-  exhausted: z.array(z.string().min(1)).default([]),
-  promising: z.array(z.string().min(1)).default([]),
-  relevant_memories: z.array(RuntimeEvidenceDreamCheckpointMemoryRefSchema).default([]),
-  active_hypotheses: z.array(RuntimeEvidenceDreamCheckpointActiveHypothesisSchema).default([]),
-  rejected_approaches: z.array(RuntimeEvidenceDreamCheckpointRejectedApproachSchema).default([]),
-  next_strategy_candidates: z.array(RuntimeEvidenceDreamCheckpointStrategyCandidateSchema).default([]),
-  run_control_recommendations: z.array(RuntimeEvidenceDreamRunControlRecommendationSchema).optional(),
-  guidance: z.string().min(1),
-  uncertainty: z.array(z.string().min(1)).default([]),
-  context_authority: z.literal("advisory_only").default("advisory_only"),
-  confidence: z.number().min(0).max(1).default(0.5),
-}).strict();
-export type RuntimeEvidenceDreamCheckpoint = z.infer<typeof RuntimeEvidenceDreamCheckpointSchema>;
-
-export const RuntimeEvidenceDivergentHypothesisSchema = z.object({
-  strategy_id: z.string().min(1).optional(),
-  hypothesis: z.string().min(1),
-  strategy_family: z.string().min(1),
-  role: z.enum(["exploitation", "adjacent_exploration", "divergent_exploration"]),
-  novelty_score: z.number().min(0).max(1),
-  similarity_to_recent_failures: z.number().min(0).max(1).default(0),
-  expected_cost: z.enum(["low", "medium", "high"]),
-  relationship_to_lineage: z.enum([
-    "current_best",
-    "neighbor",
-    "failed_lineage",
-    "different_mechanism",
-    "different_assumption",
-    "unknown",
-  ]),
-  prior_evidence: z.string().min(1).optional(),
-  downrank_reason: z.string().min(1).optional(),
-  smoke_status: z.enum(["not_run", "promote", "defer", "retire"]).default("not_run"),
-  smoke_reason: z.string().min(1).optional(),
-  smoke_evidence_ref: z.string().min(1).optional(),
-  evidence_authority: z.literal("speculative_hypothesis").default("speculative_hypothesis"),
-}).strict();
-export type RuntimeEvidenceDivergentHypothesis = z.infer<typeof RuntimeEvidenceDivergentHypothesisSchema>;
-
-export const RuntimeEvidenceEntrySchema = z.object({
-  schema_version: z.literal("runtime-evidence-entry-v1"),
-  id: z.string().min(1),
-  occurred_at: z.string().datetime(),
-  kind: RuntimeEvidenceEntryKindSchema,
-  scope: z.object({
-    goal_id: z.string().min(1).optional(),
-    run_id: z.string().min(1).optional(),
-    task_id: z.string().min(1).optional(),
-    loop_index: z.number().int().nonnegative().optional(),
-    phase: z.string().min(1).optional(),
-  }).strict(),
-  hypothesis: z.string().min(1).optional(),
-  strategy: z.string().min(1).optional(),
-  task: z.object({
-    id: z.string().min(1).optional(),
-    description: z.string().min(1).optional(),
-    action: z.string().min(1).optional(),
-    primary_dimension: z.string().min(1).optional(),
-  }).strict().optional(),
-  verification: z.object({
-    command: z.string().min(1).optional(),
-    verdict: z.string().min(1).optional(),
-    confidence: z.number().min(0).max(1).optional(),
-    summary: z.string().min(1).optional(),
-  }).strict().optional(),
-  metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
-  evaluators: z.array(RuntimeEvidenceEvaluatorObservationSchema).optional(),
-  research: z.array(RuntimeEvidenceResearchMemoSchema).optional(),
-  dream_checkpoints: z.array(RuntimeEvidenceDreamCheckpointSchema).optional(),
-  divergent_exploration: z.array(RuntimeEvidenceDivergentHypothesisSchema).optional(),
-  correction: MemoryCorrectionEntrySchema.optional(),
-  correction_state: MemoryCorrectionTargetStateSchema.optional(),
-  verification_status: MemoryVerificationStatusSchema.optional(),
-  provenance: MemoryProvenanceSchema.optional(),
-  quarantine_state: MemoryQuarantineStateSchema.optional(),
-  candidates: z.array(RuntimeEvidenceCandidateRecordSchema).optional(),
-  artifacts: z.array(RuntimeEvidenceArtifactRefSchema).default([]),
-  result: z.object({
-    status: z.string().min(1).optional(),
-    summary: z.string().min(1).optional(),
-    error: z.string().min(1).optional(),
-  }).strict().optional(),
-  outcome: RuntimeEvidenceOutcomeSchema.optional(),
-  decision_reason: z.string().min(1).optional(),
-  raw_refs: z.array(z.object({
-    kind: z.string().min(1),
-    id: z.string().min(1).optional(),
-    path: z.string().min(1).optional(),
-    state_relative_path: z.string().min(1).optional(),
-    url: z.string().url().optional(),
-  }).strict()).default([]),
-  summary: z.string().min(1).optional(),
-}).strict().refine((entry) => entry.scope.goal_id || entry.scope.run_id, {
-  message: "goal_id or run_id is required",
-  path: ["scope"],
-});
-export type RuntimeEvidenceEntry = z.infer<typeof RuntimeEvidenceEntrySchema>;
-export type RuntimeEvidenceEntryInput = Omit<
+import {
+  RuntimeEvidenceEntrySchema,
+  RuntimeEvidenceOutcomeSchema,
+  type RuntimeEvidenceArtifactRef,
+  type RuntimeEvidenceCandidateDisposition,
+  type RuntimeEvidenceCandidateNearMiss,
+  type RuntimeEvidenceCandidateNearMissReason,
+  type RuntimeEvidenceCandidateRecord,
+  type RuntimeEvidenceCandidateSimilarity,
+  type RuntimeEvidenceDivergentHypothesis,
+  type RuntimeEvidenceDreamCheckpoint,
+  type RuntimeEvidenceEntry,
+  type RuntimeEvidenceEntryInput,
+  type RuntimeEvidenceEntryKind,
+  type RuntimeEvidenceEvaluatorBudget,
+  type RuntimeEvidenceEvaluatorCalibration,
+  type RuntimeEvidenceEvaluatorCandidateSnapshot,
+  type RuntimeEvidenceEvaluatorObservation,
+  type RuntimeEvidenceEvaluatorProvenance,
+  type RuntimeEvidenceEvaluatorPublishAction,
+  type RuntimeEvidenceEvaluatorStatus,
+  type RuntimeEvidenceMetric,
+  type RuntimeEvidenceOutcome,
+  type RuntimeEvidenceReadResult,
+  type RuntimeEvidenceReadWarning,
+  type RuntimeEvidenceResearchMemo,
+} from "./evidence-types.js";
+export {
+  RuntimeArtifactRetentionClassSchema,
+  RuntimeEvidenceArtifactRefSchema,
+  RuntimeEvidenceCandidateDispositionSchema,
+  RuntimeEvidenceCandidateLineageSchema,
+  RuntimeEvidenceCandidateNearMissReasonSchema,
+  RuntimeEvidenceCandidateNearMissSchema,
+  RuntimeEvidenceCandidateRecordSchema,
+  RuntimeEvidenceCandidateSimilaritySchema,
+  RuntimeEvidenceDivergentHypothesisSchema,
+  RuntimeEvidenceDreamCheckpointSchema,
+  RuntimeEvidenceDreamCheckpointActiveHypothesisSchema,
+  RuntimeEvidenceDreamCheckpointMemoryRefSchema,
+  RuntimeEvidenceDreamCheckpointRejectedApproachSchema,
+  RuntimeEvidenceDreamCheckpointStrategyCandidateSchema,
+  RuntimeEvidenceDreamCheckpointTriggerSchema,
+  RuntimeEvidenceDreamRunControlRecommendationSchema,
+  RuntimeEvidenceEntryKindSchema,
+  RuntimeEvidenceEntrySchema,
+  RuntimeEvidenceEvaluatorBudgetSchema,
+  RuntimeEvidenceEvaluatorCalibrationSchema,
+  RuntimeEvidenceEvaluatorCandidateSnapshotSchema,
+  RuntimeEvidenceEvaluatorObservationSchema,
+  RuntimeEvidenceEvaluatorProvenanceSchema,
+  RuntimeEvidenceEvaluatorPublishActionSchema,
+  RuntimeEvidenceEvaluatorSignalSchema,
+  RuntimeEvidenceEvaluatorStatusSchema,
+  RuntimeEvidenceEvaluatorValidationSchema,
+  RuntimeEvidenceMetricSchema,
+  RuntimeEvidenceMemoryUsageStatsSchema,
+  RuntimeEvidenceOutcomeSchema,
+  RuntimeEvidenceResearchExternalActionSchema,
+  RuntimeEvidenceResearchFindingSchema,
+  RuntimeEvidenceResearchMemoSchema,
+  RuntimeEvidenceResearchSourceSchema,
+} from "./evidence-types.js";
+export type {
+  RuntimeArtifactRetentionClass,
+  RuntimeEvidenceArtifactRef,
+  RuntimeEvidenceCandidateDisposition,
+  RuntimeEvidenceCandidateLineage,
+  RuntimeEvidenceCandidateNearMiss,
+  RuntimeEvidenceCandidateNearMissReason,
+  RuntimeEvidenceCandidateRecord,
+  RuntimeEvidenceCandidateSimilarity,
+  RuntimeEvidenceDivergentHypothesis,
+  RuntimeEvidenceDreamCheckpoint,
+  RuntimeEvidenceDreamCheckpointActiveHypothesis,
+  RuntimeEvidenceDreamCheckpointMemoryRef,
+  RuntimeEvidenceDreamCheckpointRejectedApproach,
+  RuntimeEvidenceDreamCheckpointStrategyCandidate,
+  RuntimeEvidenceDreamCheckpointTrigger,
+  RuntimeEvidenceDreamRunControlRecommendation,
   RuntimeEvidenceEntry,
-  "schema_version" | "id" | "occurred_at" | "metrics" | "evaluators" | "research" | "dream_checkpoints" | "divergent_exploration" | "artifacts" | "raw_refs"
-> & Partial<Pick<RuntimeEvidenceEntry, "id" | "occurred_at" | "metrics" | "evaluators" | "research" | "dream_checkpoints" | "divergent_exploration" | "artifacts" | "raw_refs">>;
-
-export interface RuntimeEvidenceReadWarning {
-  file: string;
-  line: number;
-  message: string;
-}
-
-export interface RuntimeEvidenceReadResult {
-  entries: RuntimeEvidenceEntry[];
-  warnings: RuntimeEvidenceReadWarning[];
-}
-
+  RuntimeEvidenceEntryInput,
+  RuntimeEvidenceEntryKind,
+  RuntimeEvidenceEvaluatorBudget,
+  RuntimeEvidenceEvaluatorCalibration,
+  RuntimeEvidenceEvaluatorCandidateSnapshot,
+  RuntimeEvidenceEvaluatorObservation,
+  RuntimeEvidenceEvaluatorProvenance,
+  RuntimeEvidenceEvaluatorPublishAction,
+  RuntimeEvidenceEvaluatorSignal,
+  RuntimeEvidenceEvaluatorStatus,
+  RuntimeEvidenceEvaluatorValidation,
+  RuntimeEvidenceMetric,
+  RuntimeEvidenceMemoryUsageStats,
+  RuntimeEvidenceOutcome,
+  RuntimeEvidenceReadResult,
+  RuntimeEvidenceReadWarning,
+  RuntimeEvidenceResearchMemo,
+  RuntimeEvidenceResearchExternalAction,
+  RuntimeEvidenceResearchFinding,
+  RuntimeEvidenceResearchSource,
+} from "./evidence-types.js";
 export interface RuntimeFailedLineageContext {
   fingerprint: string;
   count: number;
@@ -976,7 +562,7 @@ function summaryScopeFromPath(canonicalPath: string): RuntimeEvidenceSummary["sc
 async function readReproducibilityManifests(
   paths: RuntimeStorePaths,
   scope: RuntimeEvidenceSummary["scope"]
-): Promise<RuntimeReproducibilityManifest[]> {
+): Promise<RuntimeEvidenceReproducibilityManifest[]> {
   let fileNames: string[];
   try {
     fileNames = await fsp.readdir(paths.reproducibilityManifestsDir);
@@ -985,18 +571,18 @@ async function readReproducibilityManifests(
     throw err;
   }
 
-  const manifests: RuntimeReproducibilityManifest[] = [];
+  const manifests: RuntimeEvidenceReproducibilityManifest[] = [];
   for (const fileName of fileNames) {
     if (!fileName.endsWith(".json")) continue;
     try {
-      const parsed = JSON.parse(await fsp.readFile(path.join(paths.reproducibilityManifestsDir, fileName), "utf8")) as Partial<RuntimeReproducibilityManifest>;
+      const parsed = JSON.parse(await fsp.readFile(path.join(paths.reproducibilityManifestsDir, fileName), "utf8")) as Partial<RuntimeEvidenceReproducibilityManifest>;
       if (parsed.schema_version !== "runtime-reproducibility-manifest-v1") continue;
       if (scope.goal_id && parsed.scope?.goal_id !== scope.goal_id) continue;
       if (scope.run_id && parsed.scope?.run_id !== scope.run_id) continue;
       manifests.push({
         ...parsed,
         artifacts: Array.isArray(parsed.artifacts) ? parsed.artifacts.filter(isManifestArtifactRef) : [],
-      } as RuntimeReproducibilityManifest);
+      } as RuntimeEvidenceReproducibilityManifest);
     } catch {
       continue;
     }
@@ -1004,7 +590,7 @@ async function readReproducibilityManifests(
   return manifests;
 }
 
-function isManifestArtifactRef(value: unknown): value is RuntimeReproducibilityManifest["artifacts"][number] {
+function isManifestArtifactRef(value: unknown): value is RuntimeEvidenceReproducibilityManifest["artifacts"][number] {
   return typeof value === "object"
     && value !== null
     && typeof (value as { label?: unknown }).label === "string";
@@ -1605,7 +1191,7 @@ async function readEvidenceFile(filePath: string): Promise<RuntimeEvidenceReadRe
 function summarizeEvidence(
   scope: RuntimeEvidenceSummary["scope"],
   read: RuntimeEvidenceReadResult,
-  manifests: RuntimeReproducibilityManifest[] = []
+  manifests: RuntimeEvidenceReproducibilityManifest[] = []
 ): RuntimeEvidenceSummary {
   const entries = [...read.entries].sort((a, b) => a.occurred_at.localeCompare(b.occurred_at));
   const corrections = entries.flatMap((entry) => entry.correction ? [entry.correction] : []);

--- a/src/runtime/store/evidence-types.ts
+++ b/src/runtime/store/evidence-types.ts
@@ -1,0 +1,549 @@
+import { z } from "zod";
+import {
+  MemoryCorrectionEntrySchema,
+  type MemoryCorrectionEntry,
+  MemoryCorrectionTargetStateSchema,
+} from "../../platform/corrections/memory-correction-ledger.js";
+import {
+  MemoryProvenanceSchema,
+  MemoryQuarantineStateSchema,
+  MemoryVerificationStatusSchema,
+} from "../../platform/corrections/memory-quarantine.js";
+
+export const RuntimeArtifactRetentionClassSchema = z.enum([
+  "final_deliverable",
+  "best_candidate",
+  "robust_candidate",
+  "near_miss",
+  "reproducibility_critical",
+  "evidence_report",
+  "low_value_smoke",
+  "cache_intermediate",
+  "duplicate_superseded",
+  "other",
+]);
+export type RuntimeArtifactRetentionClass = z.infer<typeof RuntimeArtifactRetentionClassSchema>;
+
+export const RuntimeEvidenceOutcomeSchema = z.enum([
+  "improved",
+  "regressed",
+  "inconclusive",
+  "failed",
+  "blocked",
+  "continued",
+]);
+export type RuntimeEvidenceOutcome = z.infer<typeof RuntimeEvidenceOutcomeSchema>;
+
+export const RuntimeEvidenceEntryKindSchema = z.enum([
+  "observation",
+  "strategy",
+  "task_generation",
+  "execution",
+  "verification",
+  "decision",
+  "metric",
+  "evaluator",
+  "research",
+  "dream_checkpoint",
+  "artifact",
+  "failure",
+  "correction",
+  "other",
+]);
+export type RuntimeEvidenceEntryKind = z.infer<typeof RuntimeEvidenceEntryKindSchema>;
+
+export const RuntimeEvidenceArtifactRefSchema = z.object({
+  label: z.string().min(1),
+  path: z.string().min(1).optional(),
+  state_relative_path: z.string().min(1).optional(),
+  url: z.string().url().optional(),
+  kind: z.enum(["log", "metrics", "report", "diff", "url", "other"]).default("other"),
+  retention_class: RuntimeArtifactRetentionClassSchema.optional(),
+  size_bytes: z.number().int().nonnegative().optional(),
+  source: z.string().min(1).optional(),
+  dependency_refs: z.array(z.string().min(1)).optional(),
+}).strict();
+export type RuntimeEvidenceArtifactRef = z.infer<typeof RuntimeEvidenceArtifactRefSchema>;
+
+export const RuntimeEvidenceMetricSchema = z.object({
+  label: z.string().min(1),
+  value: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+  unit: z.string().min(1).optional(),
+  direction: z.enum(["maximize", "minimize", "neutral"]).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  observed_at: z.string().datetime().optional(),
+  source: z.string().min(1).optional(),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceMetric = z.infer<typeof RuntimeEvidenceMetricSchema>;
+
+export const RuntimeEvidenceCandidateDispositionSchema = z.enum(["retained", "promoted", "retired"]);
+export type RuntimeEvidenceCandidateDisposition = z.infer<typeof RuntimeEvidenceCandidateDispositionSchema>;
+
+export const RuntimeEvidenceCandidateLineageSchema = z.object({
+  parent_candidate_id: z.string().min(1).optional(),
+  source_candidate_id: z.string().min(1).optional(),
+  source_strategy_id: z.string().min(1).optional(),
+  source_strategy: z.string().min(1).optional(),
+  strategy_family: z.string().min(1),
+  feature_lineage: z.array(z.string().min(1)).default([]),
+  model_lineage: z.array(z.string().min(1)).default([]),
+  config_lineage: z.array(z.string().min(1)).default([]),
+  seed_lineage: z.array(z.string().min(1)).default([]),
+  fold_lineage: z.array(z.string().min(1)).default([]),
+  postprocess_lineage: z.array(z.string().min(1)).default([]),
+  notes: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceCandidateLineage = z.infer<typeof RuntimeEvidenceCandidateLineageSchema>;
+
+export const RuntimeEvidenceCandidateSimilaritySchema = z.object({
+  candidate_id: z.string().min(1),
+  similarity: z.number().min(0).max(1),
+  signal: z.enum(["declared", "lineage", "metric_correlation", "artifact_overlap", "other"]).default("declared"),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceCandidateSimilarity = z.infer<typeof RuntimeEvidenceCandidateSimilaritySchema>;
+
+export const RuntimeEvidenceCandidateNearMissReasonSchema = z.enum([
+  "close_to_best",
+  "stability",
+  "novelty",
+  "weak_dimension_improvement",
+  "complementarity",
+  "ensemble_potential",
+]);
+export type RuntimeEvidenceCandidateNearMissReason = z.infer<typeof RuntimeEvidenceCandidateNearMissReasonSchema>;
+
+export const RuntimeEvidenceCandidateNearMissSchema = z.object({
+  status: z.enum(["retained", "promoted", "rejected"]).default("retained"),
+  reason_to_keep: z.array(RuntimeEvidenceCandidateNearMissReasonSchema).min(1),
+  margin_to_best: z.number().min(0).optional(),
+  weak_dimensions: z.array(z.string().min(1)).default([]),
+  complementary_candidate_ids: z.array(z.string().min(1)).default([]),
+  follow_up: z.object({
+    title: z.string().min(1),
+    rationale: z.string().min(1),
+    target_dimensions: z.array(z.string().min(1)).default([]),
+    expected_evidence_gain: z.string().min(1).optional(),
+  }).strict().optional(),
+  evidence_refs: z.array(z.string().min(1)).default([]),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceCandidateNearMiss = z.infer<typeof RuntimeEvidenceCandidateNearMissSchema>;
+
+export const RuntimeEvidenceCandidateRecordSchema = z.object({
+  candidate_id: z.string().min(1),
+  label: z.string().min(1).optional(),
+  lineage: RuntimeEvidenceCandidateLineageSchema,
+  metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
+  artifacts: z.array(RuntimeEvidenceArtifactRefSchema).default([]),
+  similarity: z.array(RuntimeEvidenceCandidateSimilaritySchema).default([]),
+  robustness: z.object({
+    stability_score: z.number().min(0).max(1).optional(),
+    diversity_score: z.number().min(0).max(1).optional(),
+    risk_penalty: z.number().min(0).max(1).optional(),
+    robust_score: z.number().min(0).max(1).optional(),
+    evidence_confidence: z.number().min(0).max(1).optional(),
+    repeated_evaluations: z.number().int().nonnegative().optional(),
+    mean_score: z.number().optional(),
+    max_score: z.number().optional(),
+    score_stddev: z.number().min(0).optional(),
+    fold_score_range: z.number().min(0).optional(),
+    seed_score_range: z.number().min(0).optional(),
+    weak_dimensions: z.array(z.string().min(1)).default([]),
+    provenance_refs: z.array(z.string().min(1)).default([]),
+    summary: z.string().min(1).optional(),
+  }).strict().optional(),
+  near_miss: RuntimeEvidenceCandidateNearMissSchema.optional(),
+  disposition: RuntimeEvidenceCandidateDispositionSchema.default("retained"),
+  disposition_reason: z.string().min(1).optional(),
+  produced_at: z.string().datetime().optional(),
+}).strict();
+export type RuntimeEvidenceCandidateRecord = z.infer<typeof RuntimeEvidenceCandidateRecordSchema>;
+
+export const RuntimeEvidenceEvaluatorSignalSchema = z.enum(["local", "external"]);
+export type RuntimeEvidenceEvaluatorSignal = z.infer<typeof RuntimeEvidenceEvaluatorSignalSchema>;
+
+export const RuntimeEvidenceEvaluatorStatusSchema = z.enum([
+  "pending",
+  "ready",
+  "approval_required",
+  "submitted",
+  "passed",
+  "succeeded",
+  "completed",
+  "failed",
+  "regressed",
+  "blocked",
+  "unknown",
+]);
+export type RuntimeEvidenceEvaluatorStatus = z.infer<typeof RuntimeEvidenceEvaluatorStatusSchema>;
+
+export const RuntimeEvidenceEvaluatorPublishActionSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  tool_name: z.string().min(1).optional(),
+  payload_ref: z.string().min(1).optional(),
+  approval_required: z.literal(true).default(true),
+  status: z.enum(["approval_required", "approved", "submitted", "completed", "blocked"]).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorPublishAction = z.infer<typeof RuntimeEvidenceEvaluatorPublishActionSchema>;
+
+export const RuntimeEvidenceEvaluatorValidationSchema = z.object({
+  status: z.enum(["pending", "passed", "failed", "blocked", "unknown"]).default("unknown"),
+  command: z.string().min(1).optional(),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorValidation = z.infer<typeof RuntimeEvidenceEvaluatorValidationSchema>;
+
+export const RuntimeEvidenceEvaluatorProvenanceSchema = z.object({
+  kind: z.enum(["local_command", "external_url", "ci", "benchmark", "human_review", "other"]).default("other"),
+  command: z.string().min(1).optional(),
+  url: z.string().url().optional(),
+  run_id: z.string().min(1).optional(),
+  external_id: z.string().min(1).optional(),
+  raw_ref: z.string().min(1).optional(),
+  retrieved_at: z.string().datetime().optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorProvenance = z.infer<typeof RuntimeEvidenceEvaluatorProvenanceSchema>;
+
+export const RuntimeEvidenceEvaluatorBudgetSchema = z.object({
+  policy_id: z.string().min(1).optional(),
+  max_attempts: z.number().int().positive().optional(),
+  used_attempts: z.number().int().nonnegative().optional(),
+  remaining_attempts: z.number().int().nonnegative(),
+  approval_required: z.boolean().default(true),
+  deadline_at: z.string().datetime().optional(),
+  phase: z.enum(["exploration", "consolidation", "finalization", "other"]).optional(),
+  portfolio_policy: z.object({
+    diversified_portfolio_required: z.boolean().default(false),
+    reserve_for_finalization: z.boolean().default(false),
+    min_strategy_families: z.number().int().positive().optional(),
+  }).strict().optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorBudget = z.infer<typeof RuntimeEvidenceEvaluatorBudgetSchema>;
+
+export const RuntimeEvidenceEvaluatorCandidateSnapshotSchema = z.object({
+  evidence_entry_id: z.string().min(1).optional(),
+  primary_metric_label: z.string().min(1).optional(),
+  local_metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
+  robust_selection: z.object({
+    raw_rank: z.number().int().positive().optional(),
+    robust_score: z.number().min(0).max(1).optional(),
+    stability_score: z.number().min(0).max(1).optional(),
+    diversity_score: z.number().min(0).max(1).optional(),
+    risk_penalty: z.number().min(0).max(1).optional(),
+    portfolio_role: z.enum(["raw_best", "robust_best", "safe", "aggressive", "diverse", "near_miss", "other"]).optional(),
+  }).strict().optional(),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorCandidateSnapshot = z.infer<typeof RuntimeEvidenceEvaluatorCandidateSnapshotSchema>;
+
+export const RuntimeEvidenceEvaluatorCalibrationSchema = z.object({
+  mode: z.literal("calibration_only").default("calibration_only"),
+  use_for_selection: z.boolean().default(false),
+  direct_optimization_allowed: z.literal(false).default(false),
+  minimum_observations: z.number().int().positive().default(1),
+  conclusion: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorCalibration = z.infer<typeof RuntimeEvidenceEvaluatorCalibrationSchema>;
+
+export const RuntimeEvidenceEvaluatorObservationSchema = z.object({
+  evaluator_id: z.string().min(1),
+  signal: RuntimeEvidenceEvaluatorSignalSchema,
+  source: z.string().min(1),
+  candidate_id: z.string().min(1),
+  candidate_label: z.string().min(1).optional(),
+  artifact_labels: z.array(z.string().min(1)).optional(),
+  status: RuntimeEvidenceEvaluatorStatusSchema.default("unknown"),
+  score: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+  score_label: z.string().min(1).optional(),
+  direction: z.enum(["maximize", "minimize", "neutral"]).optional(),
+  observed_at: z.string().datetime().optional(),
+  expected_score: z.union([z.string(), z.number(), z.boolean(), z.null()]).optional(),
+  expected_status: RuntimeEvidenceEvaluatorStatusSchema.optional(),
+  expectation_source: z.string().min(1).optional(),
+  validation: RuntimeEvidenceEvaluatorValidationSchema.optional(),
+  publish_action: RuntimeEvidenceEvaluatorPublishActionSchema.optional(),
+  provenance: RuntimeEvidenceEvaluatorProvenanceSchema.optional(),
+  budget: RuntimeEvidenceEvaluatorBudgetSchema.optional(),
+  candidate_snapshot: RuntimeEvidenceEvaluatorCandidateSnapshotSchema.optional(),
+  calibration: RuntimeEvidenceEvaluatorCalibrationSchema.optional(),
+  summary: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceEvaluatorObservation = z.infer<typeof RuntimeEvidenceEvaluatorObservationSchema>;
+
+export const RuntimeEvidenceResearchSourceSchema = z.object({
+  url: z.string().url(),
+  title: z.string().min(1).optional(),
+  source_type: z.enum(["official_docs", "maintainer", "paper", "issue_thread", "example", "writeup", "other"]).default("other"),
+  provenance: z.enum(["quoted", "paraphrased", "summarized"]).default("summarized"),
+  relevance: z.string().min(1).optional(),
+}).strict();
+export type RuntimeEvidenceResearchSource = z.infer<typeof RuntimeEvidenceResearchSourceSchema>;
+
+export const RuntimeEvidenceResearchFindingSchema = z.object({
+  finding: z.string().min(1),
+  source_urls: z.array(z.string().url()).min(1),
+  applicability: z.string().min(1),
+  risks_constraints: z.array(z.string().min(1)).default([]),
+  proposed_experiment: z.string().min(1),
+  expected_metric_impact: z.string().min(1),
+  fact_vs_adaptation: z.object({
+    facts: z.array(z.string().min(1)).default([]),
+    adaptation: z.string().min(1),
+  }).strict(),
+}).strict();
+export type RuntimeEvidenceResearchFinding = z.infer<typeof RuntimeEvidenceResearchFindingSchema>;
+
+export const RuntimeEvidenceResearchExternalActionSchema = z.object({
+  label: z.string().min(1),
+  reason: z.string().min(1),
+  approval_required: z.literal(true).default(true),
+}).strict();
+export type RuntimeEvidenceResearchExternalAction = z.infer<typeof RuntimeEvidenceResearchExternalActionSchema>;
+
+export const RuntimeEvidenceResearchMemoSchema = z.object({
+  trigger: z.enum(["plateau", "uncertainty", "knowledge_gap"]),
+  query: z.string().min(1),
+  summary: z.string().min(1),
+  sources: z.array(RuntimeEvidenceResearchSourceSchema).min(1),
+  findings: z.array(RuntimeEvidenceResearchFindingSchema).min(1),
+  candidate_playbook: z.object({
+    title: z.string().min(1),
+    steps: z.array(z.string().min(1)).default([]),
+    source_urls: z.array(z.string().url()).default([]),
+  }).strict().optional(),
+  untrusted_content_policy: z.literal("webpage_instructions_are_untrusted").default("webpage_instructions_are_untrusted"),
+  external_actions: z.array(RuntimeEvidenceResearchExternalActionSchema).default([]),
+  confidence: z.number().min(0).max(1).default(0.5),
+}).strict();
+export type RuntimeEvidenceResearchMemo = z.infer<typeof RuntimeEvidenceResearchMemoSchema>;
+
+export const RuntimeEvidenceDreamCheckpointTriggerSchema = z.enum([
+  "iteration",
+  "plateau",
+  "breakthrough",
+  "pre_finalization",
+]);
+export type RuntimeEvidenceDreamCheckpointTrigger = z.infer<typeof RuntimeEvidenceDreamCheckpointTriggerSchema>;
+
+export const RuntimeEvidenceMemoryUsageStatsSchema = z.object({
+  last_used_at: z.string().datetime().nullable().default(null),
+  use_count: z.number().int().nonnegative().default(0),
+  validated_count: z.number().int().nonnegative().default(0),
+  negative_outcome_count: z.number().int().nonnegative().default(0),
+}).strict();
+export type RuntimeEvidenceMemoryUsageStats = z.infer<typeof RuntimeEvidenceMemoryUsageStatsSchema>;
+
+export const RuntimeEvidenceDreamCheckpointMemoryRefSchema = z.object({
+  source_type: z.enum(["soil", "playbook", "runtime_evidence", "other"]),
+  ref: z.string().min(1).optional(),
+  summary: z.string().min(1),
+  authority: z.literal("advisory_only").default("advisory_only"),
+  relevance_score: z.number().min(0).max(1).optional(),
+  source_reliability: z.number().min(0).max(1).optional(),
+  verification_status: MemoryVerificationStatusSchema.optional(),
+  provenance: MemoryProvenanceSchema.optional(),
+  quarantine_state: MemoryQuarantineStateSchema.optional(),
+  recency_score: z.number().min(0).max(1).optional(),
+  prior_success_contribution: z.number().min(0).max(1).optional(),
+  retrieval: z.object({
+    kind: z.enum(["route_hit", "fallback_hit", "checkpoint", "manual", "unknown"]).default("unknown"),
+    score: z.number().min(0).max(1).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+  }).strict().optional(),
+  usage_stats: RuntimeEvidenceMemoryUsageStatsSchema.optional(),
+  ranking_trace: z.object({
+    score: z.number().min(0).max(1),
+    decision: z.enum(["admitted", "rejected"]),
+    reason: z.string().min(1),
+  }).strict().optional(),
+}).strict();
+export type RuntimeEvidenceDreamCheckpointMemoryRef = z.infer<typeof RuntimeEvidenceDreamCheckpointMemoryRefSchema>;
+
+export const RuntimeEvidenceDreamCheckpointStrategyCandidateSchema = z.object({
+  candidate_ref: z.string().min(1).optional(),
+  title: z.string().min(1),
+  rationale: z.string().min(1),
+  target_dimensions: z.array(z.string().min(1)).default([]),
+  expected_evidence_gain: z.string().min(1).optional(),
+  retry_reason: z.string().min(1).optional(),
+  failed_lineage_warning: z.object({
+    fingerprint: z.string().min(1),
+    count: z.number().int().positive(),
+    reason: z.string().min(1),
+  }).strict().optional(),
+}).strict();
+export type RuntimeEvidenceDreamCheckpointStrategyCandidate = z.infer<typeof RuntimeEvidenceDreamCheckpointStrategyCandidateSchema>;
+
+export const RuntimeEvidenceDreamCheckpointActiveHypothesisSchema = z.object({
+  hypothesis: z.string().min(1),
+  supporting_evidence_ref: z.string().min(1).optional(),
+  target_metric_or_dimension: z.string().min(1),
+  expected_next_observation: z.string().min(1),
+  status: z.enum(["active", "testing", "supported", "weakened"]).default("active"),
+}).strict();
+export type RuntimeEvidenceDreamCheckpointActiveHypothesis = z.infer<typeof RuntimeEvidenceDreamCheckpointActiveHypothesisSchema>;
+
+export const RuntimeEvidenceDreamCheckpointRejectedApproachSchema = z.object({
+  approach: z.string().min(1),
+  rejection_reason: z.string().min(1),
+  candidate_ref: z.string().min(1).optional(),
+  evidence_ref: z.string().min(1).optional(),
+  revisit_condition: z.string().min(1).optional(),
+  confidence: z.number().min(0).max(1).default(0.5),
+}).strict();
+export type RuntimeEvidenceDreamCheckpointRejectedApproach = z.infer<typeof RuntimeEvidenceDreamCheckpointRejectedApproachSchema>;
+
+export const RuntimeEvidenceDreamRunControlRecommendationSchema = z.object({
+  id: z.string().min(1).optional(),
+  action: z.enum([
+    "stay_current_mode",
+    "widen_exploration",
+    "consolidate_candidates",
+    "freeze_experiment_queue",
+    "enter_finalization",
+    "preserve_near_miss_candidates",
+    "retire_low_value_lineage",
+    "request_operator_approval",
+  ]),
+  rationale: z.string().min(1),
+  evidence: z.array(z.object({
+    kind: z.enum(["metric", "artifact", "lineage", "task_history", "deadline", "external_feedback", "memory", "runtime_state"]),
+    ref: z.string().min(1).optional(),
+    summary: z.string().min(1),
+  }).strict()).min(1),
+  target_mode: z.enum(["exploration", "consolidation", "finalization"]).optional(),
+  target_strategy_family: z.string().min(1).optional(),
+  candidate_refs: z.array(z.string().min(1)).default([]),
+  lineage_refs: z.array(z.string().min(1)).default([]),
+  approval_required: z.boolean().default(false),
+  risk: z.enum(["low", "medium", "high"]).default("medium"),
+  confidence: z.number().min(0).max(1).default(0.5),
+  policy_decision: z.object({
+    disposition: z.enum(["auto_apply", "approval_required", "advisory_only"]),
+    reason: z.string().min(1),
+  }).strict().optional(),
+}).strict();
+export type RuntimeEvidenceDreamRunControlRecommendation = z.infer<typeof RuntimeEvidenceDreamRunControlRecommendationSchema>;
+
+export const RuntimeEvidenceDreamCheckpointSchema = z.object({
+  trigger: RuntimeEvidenceDreamCheckpointTriggerSchema,
+  summary: z.string().min(1),
+  current_goal: z.string().min(1),
+  active_dimensions: z.array(z.string().min(1)).default([]),
+  best_evidence_so_far: z.string().min(1).optional(),
+  recent_strategy_families: z.array(z.string().min(1)).default([]),
+  exhausted: z.array(z.string().min(1)).default([]),
+  promising: z.array(z.string().min(1)).default([]),
+  relevant_memories: z.array(RuntimeEvidenceDreamCheckpointMemoryRefSchema).default([]),
+  active_hypotheses: z.array(RuntimeEvidenceDreamCheckpointActiveHypothesisSchema).default([]),
+  rejected_approaches: z.array(RuntimeEvidenceDreamCheckpointRejectedApproachSchema).default([]),
+  next_strategy_candidates: z.array(RuntimeEvidenceDreamCheckpointStrategyCandidateSchema).default([]),
+  run_control_recommendations: z.array(RuntimeEvidenceDreamRunControlRecommendationSchema).optional(),
+  guidance: z.string().min(1),
+  uncertainty: z.array(z.string().min(1)).default([]),
+  context_authority: z.literal("advisory_only").default("advisory_only"),
+  confidence: z.number().min(0).max(1).default(0.5),
+}).strict();
+export type RuntimeEvidenceDreamCheckpoint = z.infer<typeof RuntimeEvidenceDreamCheckpointSchema>;
+
+export const RuntimeEvidenceDivergentHypothesisSchema = z.object({
+  strategy_id: z.string().min(1).optional(),
+  hypothesis: z.string().min(1),
+  strategy_family: z.string().min(1),
+  role: z.enum(["exploitation", "adjacent_exploration", "divergent_exploration"]),
+  novelty_score: z.number().min(0).max(1),
+  similarity_to_recent_failures: z.number().min(0).max(1).default(0),
+  expected_cost: z.enum(["low", "medium", "high"]),
+  relationship_to_lineage: z.enum([
+    "current_best",
+    "neighbor",
+    "failed_lineage",
+    "different_mechanism",
+    "different_assumption",
+    "unknown",
+  ]),
+  prior_evidence: z.string().min(1).optional(),
+  downrank_reason: z.string().min(1).optional(),
+  smoke_status: z.enum(["not_run", "promote", "defer", "retire"]).default("not_run"),
+  smoke_reason: z.string().min(1).optional(),
+  smoke_evidence_ref: z.string().min(1).optional(),
+  evidence_authority: z.literal("speculative_hypothesis").default("speculative_hypothesis"),
+}).strict();
+export type RuntimeEvidenceDivergentHypothesis = z.infer<typeof RuntimeEvidenceDivergentHypothesisSchema>;
+
+export const RuntimeEvidenceEntrySchema = z.object({
+  schema_version: z.literal("runtime-evidence-entry-v1"),
+  id: z.string().min(1),
+  occurred_at: z.string().datetime(),
+  kind: RuntimeEvidenceEntryKindSchema,
+  scope: z.object({
+    goal_id: z.string().min(1).optional(),
+    run_id: z.string().min(1).optional(),
+    task_id: z.string().min(1).optional(),
+    loop_index: z.number().int().nonnegative().optional(),
+    phase: z.string().min(1).optional(),
+  }).strict(),
+  hypothesis: z.string().min(1).optional(),
+  strategy: z.string().min(1).optional(),
+  task: z.object({
+    id: z.string().min(1).optional(),
+    description: z.string().min(1).optional(),
+    action: z.string().min(1).optional(),
+    primary_dimension: z.string().min(1).optional(),
+  }).strict().optional(),
+  verification: z.object({
+    command: z.string().min(1).optional(),
+    verdict: z.string().min(1).optional(),
+    confidence: z.number().min(0).max(1).optional(),
+    summary: z.string().min(1).optional(),
+  }).strict().optional(),
+  metrics: z.array(RuntimeEvidenceMetricSchema).default([]),
+  evaluators: z.array(RuntimeEvidenceEvaluatorObservationSchema).optional(),
+  research: z.array(RuntimeEvidenceResearchMemoSchema).optional(),
+  dream_checkpoints: z.array(RuntimeEvidenceDreamCheckpointSchema).optional(),
+  divergent_exploration: z.array(RuntimeEvidenceDivergentHypothesisSchema).optional(),
+  correction: MemoryCorrectionEntrySchema.optional(),
+  correction_state: MemoryCorrectionTargetStateSchema.optional(),
+  verification_status: MemoryVerificationStatusSchema.optional(),
+  provenance: MemoryProvenanceSchema.optional(),
+  quarantine_state: MemoryQuarantineStateSchema.optional(),
+  candidates: z.array(RuntimeEvidenceCandidateRecordSchema).optional(),
+  artifacts: z.array(RuntimeEvidenceArtifactRefSchema).default([]),
+  result: z.object({
+    status: z.string().min(1).optional(),
+    summary: z.string().min(1).optional(),
+    error: z.string().min(1).optional(),
+  }).strict().optional(),
+  outcome: RuntimeEvidenceOutcomeSchema.optional(),
+  decision_reason: z.string().min(1).optional(),
+  raw_refs: z.array(z.object({
+    kind: z.string().min(1),
+    id: z.string().min(1).optional(),
+    path: z.string().min(1).optional(),
+    state_relative_path: z.string().min(1).optional(),
+    url: z.string().url().optional(),
+  }).strict()).default([]),
+  summary: z.string().min(1).optional(),
+}).strict().refine((entry) => entry.scope.goal_id || entry.scope.run_id, {
+  message: "goal_id or run_id is required",
+  path: ["scope"],
+});
+export type RuntimeEvidenceEntry = z.infer<typeof RuntimeEvidenceEntrySchema>;
+export type RuntimeEvidenceEntryInput = Omit<
+  RuntimeEvidenceEntry,
+  "schema_version" | "id" | "occurred_at" | "metrics" | "evaluators" | "research" | "dream_checkpoints" | "divergent_exploration" | "artifacts" | "raw_refs"
+> & Partial<Pick<RuntimeEvidenceEntry, "id" | "occurred_at" | "metrics" | "evaluators" | "research" | "dream_checkpoints" | "divergent_exploration" | "artifacts" | "raw_refs">>;
+
+export interface RuntimeEvidenceReadWarning {
+  file: string;
+  line: number;
+  message: string;
+}
+
+export interface RuntimeEvidenceReadResult {
+  entries: RuntimeEvidenceEntry[];
+  warnings: RuntimeEvidenceReadWarning[];
+}

--- a/src/runtime/store/experiment-queue-store.ts
+++ b/src/runtime/store/experiment-queue-store.ts
@@ -9,7 +9,7 @@ import {
   RuntimeEvidenceMetricSchema,
   type RuntimeEvidenceArtifactRef,
   type RuntimeEvidenceMetric,
-} from "./evidence-ledger.js";
+} from "./evidence-types.js";
 
 export const RuntimeExperimentQueuePhaseSchema = z.enum(["designing", "executing_frozen_queue"]);
 export type RuntimeExperimentQueuePhase = z.infer<typeof RuntimeExperimentQueuePhaseSchema>;

--- a/src/runtime/store/index.ts
+++ b/src/runtime/store/index.ts
@@ -103,6 +103,7 @@ export {
 } from "./runtime-operation-schemas.js";
 
 export {
+  RuntimeArtifactRetentionClassSchema,
   RuntimeEvidenceArtifactRefSchema,
   RuntimeEvidenceEvaluatorBudgetSchema,
   RuntimeEvidenceEvaluatorCalibrationSchema,
@@ -231,15 +232,14 @@ export type {
   RuntimeEvidenceReadResult,
   RuntimeEvidenceReadWarning,
   RuntimeEvidenceSummary,
+  RuntimeArtifactRetentionClass,
 } from "./evidence-ledger.js";
 export {
-  RuntimeArtifactRetentionClassSchema,
   summarizeArtifactRetention,
 } from "./artifact-retention.js";
 export type {
   RuntimeArtifactCleanupActionKind,
   RuntimeArtifactCleanupPlan,
-  RuntimeArtifactRetentionClass,
   RuntimeArtifactRetentionDecision,
   RuntimeArtifactRetentionSummary,
 } from "./artifact-retention.js";

--- a/src/runtime/store/metric-history.ts
+++ b/src/runtime/store/metric-history.ts
@@ -1,4 +1,4 @@
-import type { RuntimeEvidenceEntry } from "./evidence-ledger.js";
+import type { RuntimeEvidenceEntry } from "./evidence-types.js";
 import {
   summarizeMetricTrends,
   type MetricDirection,

--- a/src/runtime/store/postmortem-report.ts
+++ b/src/runtime/store/postmortem-report.ts
@@ -9,9 +9,9 @@ import {
 } from "./runtime-paths.js";
 import {
   RuntimeEvidenceLedger,
-  type RuntimeEvidenceEntry,
   type RuntimeEvidenceSummary,
 } from "./evidence-ledger.js";
+import type { RuntimeEvidenceEntry } from "./evidence-types.js";
 import { extractMetricObservationsFromEvidence } from "./metric-history.js";
 import {
   RuntimeReproducibilityManifestSchema,

--- a/src/runtime/store/reproducibility-manifest.ts
+++ b/src/runtime/store/reproducibility-manifest.ts
@@ -9,11 +9,13 @@ import {
 } from "./runtime-paths.js";
 import {
   RuntimeEvidenceLedger,
-  type RuntimeEvidenceArtifactRef,
-  type RuntimeEvidenceCandidateRecord,
-  type RuntimeEvidenceEntry,
-  type RuntimeEvidenceEvaluatorObservation,
 } from "./evidence-ledger.js";
+import type {
+  RuntimeEvidenceArtifactRef,
+  RuntimeEvidenceCandidateRecord,
+  RuntimeEvidenceEntry,
+  RuntimeEvidenceEvaluatorObservation,
+} from "./evidence-types.js";
 
 export const RuntimeReproducibilityFileRefSchema = z.object({
   label: z.string().min(1),

--- a/src/runtime/store/research-evidence.ts
+++ b/src/runtime/store/research-evidence.ts
@@ -1,7 +1,7 @@
 import type {
   RuntimeEvidenceEntry,
   RuntimeEvidenceResearchMemo,
-} from "./evidence-ledger.js";
+} from "./evidence-types.js";
 
 export interface RuntimeResearchMemoContext extends RuntimeEvidenceResearchMemo {
   entry_id: string;

--- a/tmp/runtime-evidence-refactor-status.md
+++ b/tmp/runtime-evidence-refactor-status.md
@@ -8,7 +8,7 @@
 
 ## #1054: CoreLoop Real-Store Evidence Contract
 
-Status: in progress on `codex/issue-1054-coreloop-evidence-contract`.
+Status: merged via PR #1069.
 
 Plan:
 - Keep existing mock-heavy integration tests intact.
@@ -28,3 +28,28 @@ Verification:
 Review:
 - Fresh review found that the initial contract tests were excluded from the requested integration lane, had an unwired ApprovalStore assertion, and did not pin the failed append kinds tightly enough.
 - Fixed by including the test in the integration lane, routing a wait approval through a real `ApprovalBroker` backed by real `ApprovalStore`, and asserting failed `task_generation` and `verification` append warnings.
+
+## #1044: Runtime Evidence Schema/Type Split
+
+Status: in progress on `codex/issue-1044-evidence-type-split`.
+
+Plan:
+- Extract runtime evidence schemas and entry/read types from `src/runtime/store/evidence-ledger.ts` to `src/runtime/store/evidence-types.ts`.
+- Keep public re-exports from `evidence-ledger.ts` stable for existing imports.
+- Move store helper modules that only need entry/schema contracts to import `evidence-types.ts`.
+- Avoid candidate ranking, append/read/index, or summary behavior changes.
+
+Implementation notes:
+- Added `evidence-types.ts` for evidence schemas/types and moved `RuntimeArtifactRetentionClassSchema` there so artifact refs do not depend on the artifact-retention summarizer.
+- Updated helper imports in `metric-history.ts`, `artifact-retention.ts`, `evaluator-results.ts`, `research-evidence.ts`, `dream-checkpoints.ts`, `experiment-queue-store.ts`, `postmortem-report.ts`, and `reproducibility-manifest.ts` where they only need lower-level contracts.
+- Replaced type-only reproducibility manifest imports in ledger/artifact retention with local minimal manifest shapes to remove store-helper cycles without changing runtime parsing behavior.
+- `src/runtime/store/evidence-ledger.ts` shrank from 2682 lines to 2253 lines; `evidence-types.ts` is 549 lines.
+
+Verification:
+- `npm run typecheck`: pass.
+- `npx vitest run src/runtime/__tests__/runtime-evidence-ledger.test.ts --config vitest.integration.config.ts`: pass, 41 tests.
+- `npx madge --circular --extensions ts,tsx --ts-config tsconfig.json src/runtime/store`: pass, no circular dependency found.
+
+Review:
+- Fresh review found two public export regressions: missing `RuntimeEvidenceMemoryUsageStats*` re-exports from `evidence-ledger.ts` and missing retention-class exports from the `runtime/store` barrel.
+- Restored those re-exports while keeping helper imports pointed at lower-level contracts.


### PR DESCRIPTION
Closes #1044

## Summary
- Extracts RuntimeEvidenceLedger schemas and low-level evidence contracts into `src/runtime/store/evidence-types.ts`.
- Updates runtime store helper modules to import lower-level evidence contracts instead of the ledger implementation where possible.
- Preserves public re-exports from `evidence-ledger.ts` and the `runtime/store` barrel while removing the reported `src/runtime/store` madge cycles.

## Verification
- npm run typecheck
- npx vitest run src/runtime/__tests__/runtime-evidence-ledger.test.ts --config vitest.integration.config.ts
- npx madge --circular --extensions ts,tsx --ts-config tsconfig.json src/runtime/store
- git diff --check

## Known unresolved risks
- This PR intentionally avoids changing candidate ranking, append/read/index behavior, or summary-index performance. Those remain separate scopes.