### PR TITLE
refactor(evidence): prefer structured candidate ranking fields

### DIFF
--- a/src/runtime/__tests__/runtime-evidence-ledger.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-ledger.test.ts
@@ -1341,8 +1341,8 @@ describe("RuntimeEvidenceLedger", () => {
             postprocess_lineage: [],
           },
           metrics: [
-            { label: "balanced_accuracy", value: 0.97, direction: "maximize" },
-            { label: "public_lb", value: 0.94, direction: "maximize" },
+            { label: "balanced_accuracy", value: 0.97, direction: "maximize", source: "public leaderboard external validation feed" },
+            { label: "public_lb", value: 0.94, direction: "maximize", source: "local validation source" },
           ],
           artifacts: [],
           similarity: [],
@@ -1360,8 +1360,8 @@ describe("RuntimeEvidenceLedger", () => {
             postprocess_lineage: [],
           },
           metrics: [
-            { label: "public_lb", value: 0.999, direction: "maximize" },
-            { label: "balanced_accuracy", value: 0.91, direction: "maximize" },
+            { label: "public_lb", value: 0.999, direction: "maximize", source: "local validation source" },
+            { label: "balanced_accuracy", value: 0.91, direction: "maximize", source: "external public leaderboard source" },
           ],
           artifacts: [],
           similarity: [],
@@ -1374,6 +1374,10 @@ describe("RuntimeEvidenceLedger", () => {
 
     const summary = await ledger.summarizeGoal("goal-candidate-primary-metric");
 
+    expect(summary.candidate_selection_summary.primary_metric).toEqual({
+      label: "balanced_accuracy",
+      direction: "maximize",
+    });
     expect(summary.recommended_candidate_portfolio[0]).toMatchObject({
       candidate_id: "local-best",
       metric: {
@@ -1612,6 +1616,143 @@ describe("RuntimeEvidenceLedger", () => {
     expect(selection.final_portfolio.diverse).toBeNull();
     expect(selection.ranked.find((candidate) => candidate.candidate_id === "renamed-near-duplicate")).toMatchObject({
       diversity_score: 0.05,
+    });
+  });
+
+  it("uses structured candidate ranking fields without penalizing harmless lineage labels", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "structured-ranking-harmless-labels",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-structured-ranking-labels" },
+      candidates: [
+        {
+          candidate_id: "manual-threshold-public-name-only",
+          label: "Manual threshold public leaderboard external stack blend label",
+          lineage: {
+            strategy_family: "candidate_manual_threshold_public",
+            feature_lineage: ["public_feature_name"],
+            model_lineage: ["stack_named_model"],
+            config_lineage: ["manual_threshold_label_only"],
+            seed_lineage: ["seed-1"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: ["postprocess_label_only"],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.9, direction: "maximize", confidence: 0.9 }],
+          artifacts: [],
+          similarity: [],
+          robustness: {
+            stability_score: 0.9,
+            diversity_score: 0.5,
+            evidence_confidence: 0.9,
+            weak_dimensions: [],
+            provenance_refs: [],
+          },
+          disposition: "retained",
+        },
+        {
+          candidate_id: "structured-risk",
+          label: "Structured risk candidate",
+          lineage: {
+            strategy_family: "structured",
+            feature_lineage: [],
+            model_lineage: ["catboost"],
+            config_lineage: [],
+            seed_lineage: ["seed-2"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.89, direction: "maximize", confidence: 0.9 }],
+          artifacts: [],
+          similarity: [],
+          robustness: {
+            stability_score: 0.9,
+            diversity_score: 0.5,
+            risk_penalty: 0.2,
+            evidence_confidence: 0.9,
+            weak_dimensions: [],
+            provenance_refs: [],
+          },
+          disposition: "retained",
+        },
+      ],
+      summary: "Candidate labels contain old heuristic words but structured fields own ranking.",
+      outcome: "continued",
+    });
+
+    const selection = (await ledger.summarizeGoal("goal-structured-ranking-labels")).candidate_selection_summary;
+
+    expect(selection.ranked.find((candidate) => candidate.candidate_id === "manual-threshold-public-name-only")).toMatchObject({
+      risk_penalty: 0,
+    });
+    expect(selection.ranked.find((candidate) => candidate.candidate_id === "structured-risk")).toMatchObject({
+      risk_penalty: 0.2,
+    });
+    expect(selection.robust_best?.candidate_id).toBe("manual-threshold-public-name-only");
+  });
+
+  it("keeps explicit near-miss reasons stable when labels contain ensemble hint words", async () => {
+    const ledger = new RuntimeEvidenceLedger(runtimeRoot);
+    await ledger.append({
+      id: "structured-near-miss-reasons",
+      occurred_at: "2026-04-30T00:00:00.000Z",
+      kind: "metric",
+      scope: { goal_id: "goal-structured-near-miss" },
+      candidates: [
+        {
+          candidate_id: "raw-best",
+          label: "Raw best",
+          lineage: {
+            strategy_family: "baseline",
+            feature_lineage: [],
+            model_lineage: ["catboost"],
+            config_lineage: [],
+            seed_lineage: ["seed-1"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.92, direction: "maximize", confidence: 0.9 }],
+          artifacts: [],
+          similarity: [],
+          robustness: { stability_score: 0.8, evidence_confidence: 0.9, weak_dimensions: [], provenance_refs: [] },
+          disposition: "promoted",
+        },
+        {
+          candidate_id: "explicit-near-miss",
+          label: "Stack ensemble blend public label",
+          lineage: {
+            strategy_family: "alternate",
+            feature_lineage: [],
+            model_lineage: ["ensemble_named_model"],
+            config_lineage: ["blend_named_config"],
+            seed_lineage: ["seed-2"],
+            fold_lineage: ["5-fold"],
+            postprocess_lineage: [],
+          },
+          metrics: [{ label: "balanced_accuracy", value: 0.91, direction: "maximize", confidence: 0.9 }],
+          artifacts: [],
+          similarity: [],
+          robustness: { stability_score: 0.9, evidence_confidence: 0.9, weak_dimensions: [], provenance_refs: [] },
+          near_miss: {
+            status: "retained",
+            reason_to_keep: ["stability"],
+            weak_dimensions: [],
+            complementary_candidate_ids: [],
+            evidence_refs: ["runs/explicit-near-miss/metrics.json"],
+          },
+          disposition: "retained",
+        },
+      ],
+      summary: "Explicit near miss reason should not be expanded by label text.",
+      outcome: "continued",
+    });
+
+    const nearMiss = (await ledger.summarizeGoal("goal-structured-near-miss")).near_miss_candidates[0];
+
+    expect(nearMiss).toMatchObject({
+      candidate_id: "explicit-near-miss",
+      reason_to_keep: ["stability"],
     });
   });
 

--- a/src/runtime/store/evidence-ledger.ts
+++ b/src/runtime/store/evidence-ledger.ts
@@ -1457,7 +1457,7 @@ function scoreCandidateSelectionContexts(
     const diversityScore = clamp01(candidate.robustness?.diversity_score === undefined
       ? inferredDiversity
       : Math.min(candidate.robustness.diversity_score, inferredDiversity));
-    const riskPenalty = clamp01(candidate.robustness?.risk_penalty ?? inferredCandidateRiskPenalty(candidate));
+    const riskPenalty = clamp01(candidate.robustness?.risk_penalty ?? 0);
     const evidenceConfidence = clamp01(candidate.robustness?.evidence_confidence ?? context.metric?.confidence ?? 0.5);
     const calibrationAdjustment = evaluatorCalibrationAdjustment(candidate.candidate_id, calibration);
     const robustScore = clamp01(candidate.robustness?.robust_score
@@ -1543,20 +1543,6 @@ function highestKnownSimilarity(
     }
   }
   return highest;
-}
-
-function inferredCandidateRiskPenalty(candidate: RuntimeEvidenceCandidateRecord): number {
-  const lineageText = [
-    ...candidate.lineage.config_lineage,
-    ...candidate.lineage.postprocess_lineage,
-  ].map(normalizeLineageText).join(" ");
-  if (lineageText.includes("manual") || lineageText.includes("threshold") || lineageText.includes("postprocess")) {
-    return 0.15;
-  }
-  if (lineageText.includes("calibration") || lineageText.includes("weight")) {
-    return 0.08;
-  }
-  return 0;
 }
 
 function candidateSelectionReasons(
@@ -1658,6 +1644,7 @@ function nearMissReasonsForCandidate(
   scored: RuntimeCandidateSelectionCandidate | undefined
 ): RuntimeEvidenceCandidateNearMissReason[] {
   const explicit = context.candidate.near_miss?.reason_to_keep ?? [];
+  if (explicit.length > 0) return [...explicit];
   const reasons = new Set<RuntimeEvidenceCandidateNearMissReason>(explicit);
   if (context.candidate.near_miss?.status === "retained" || context.candidate.near_miss?.status === "promoted") {
     for (const reason of inferredNearMissReasons(context, rawBest, scored)) reasons.add(reason);
@@ -1687,14 +1674,6 @@ function inferredNearMissReasons(
   }
   if (complementaryCandidateIds(context.candidate).length > 0 || highestKnownSimilarity(context.candidate, [context.candidate, rawBest.candidate]) <= 0.5) {
     reasons.push("complementarity");
-  }
-  const lineageText = [
-    ...context.candidate.lineage.model_lineage,
-    ...context.candidate.lineage.config_lineage,
-    ...(context.candidate.near_miss?.summary ? [context.candidate.near_miss.summary] : []),
-  ].map(normalizeLineageText).join(" ");
-  if (lineageText.includes("stack") || lineageText.includes("ensemble") || lineageText.includes("blend")) {
-    reasons.push("ensemble_potential");
   }
   return reasons;
 }
@@ -1876,23 +1855,10 @@ function resolvePrimaryCandidateMetricKey(entriesOldestFirst: RuntimeEvidenceEnt
   return [...byMetric.values()].sort((a, b) => {
     const coverageDelta = b.candidate_count - a.candidate_count;
     if (coverageDelta !== 0) return coverageDelta;
-    const localityDelta = Number(isLocalValidationMetricLabel(b.key.label)) - Number(isLocalValidationMetricLabel(a.key.label));
-    if (localityDelta !== 0) return localityDelta;
     const positionDelta = a.position_sum / a.candidate_count - b.position_sum / b.candidate_count;
     if (positionDelta !== 0) return positionDelta;
     return b.latest_index - a.latest_index;
   })[0]?.key ?? null;
-}
-
-function isLocalValidationMetricLabel(label: string): boolean {
-  const normalized = normalizeLineageText(label);
-  const externalHints = ["public", "private", "leaderboard", "external", "lb", "submission"];
-  for (const hint of externalHints) {
-    if (normalized === hint || normalized.includes(hint)) {
-      return false;
-    }
-  }
-  return true;
 }
 
 function candidateComparableMetric(

--- a/tmp/runtime-evidence-refactor-status.md
+++ b/tmp/runtime-evidence-refactor-status.md
@@ -31,7 +31,7 @@ Review:
 
 ## #1044: Runtime Evidence Schema/Type Split
 
-Status: in progress on `codex/issue-1044-evidence-type-split`.
+Status: merged via PR #1070.
 
 Plan:
 - Extract runtime evidence schemas and entry/read types from `src/runtime/store/evidence-ledger.ts` to `src/runtime/store/evidence-types.ts`.
@@ -53,3 +53,33 @@ Verification:
 Review:
 - Fresh review found two public export regressions: missing `RuntimeEvidenceMemoryUsageStats*` re-exports from `evidence-ledger.ts` and missing retention-class exports from the `runtime/store` barrel.
 - Restored those re-exports while keeping helper imports pointed at lower-level contracts.
+
+CI:
+- Initial integration CI hit an unrelated `src/runtime/__tests__/loop-supervisor.test.ts` timeout after the runtime evidence ledger lane passed locally and in CI context.
+- Local focused rerun of `loop-supervisor.test.ts` passed; reran the failed CI job, which passed before merge.
+
+## #1050: Structured Candidate Ranking Fields
+
+Status: in progress on `codex/issue-1050-structured-candidate-ranking`.
+
+Plan:
+- Keep the candidate summary shape stable.
+- Replace lineage/label-derived ranking penalties with explicit structured candidate fields.
+- Make explicit `near_miss.reason_to_keep` authoritative when present instead of expanding it from label/lineage text.
+- Remove primary metric selection preference based on metric label text and cover metric source labels with summary-level tests.
+- Avoid schema migration beyond existing structured fields.
+
+Implementation notes:
+- Candidate risk now uses `candidate.robustness.risk_penalty` when provided, otherwise no inferred text penalty.
+- Near-miss reasons preserve explicit `near_miss.reason_to_keep` exactly; inferred reasons remain only for textless structured status/similarity/score/family evidence.
+- Candidate primary metric selection now breaks ties structurally by coverage, metric position, then recency, without local/public/leaderboard label heuristics.
+- Added runtime evidence summary tests covering harmless manual/threshold/postprocess/stack/ensemble/blend/public/leaderboard/external labels, explicit near-miss reasons, and public/external metric source text.
+
+Verification:
+- `npm run typecheck`: pass.
+- `npx vitest run src/runtime/__tests__/runtime-evidence-ledger.test.ts --config vitest.integration.config.ts`: pass, 43 tests.
+- `npm run lint:boundaries`: pass with existing warnings.
+- `npm run test:changed`: pass, 57 related test files and 8 smoke test files.
+
+Review:
+- Fresh review found no material issues.


### PR DESCRIPTION
Closes #1050

## Summary
- remove lineage/text-derived candidate risk penalties and use structured `robustness.risk_penalty` only
- preserve explicit `near_miss.reason_to_keep` instead of expanding it from lineage labels
- remove public/local metric label heuristics from candidate primary metric selection and cover metric source text in summary tests

## Verification
- `git diff --check`
- `npm run typecheck`
- `npx vitest run src/runtime/__tests__/runtime-evidence-ledger.test.ts --config vitest.integration.config.ts`
- `npm run lint:boundaries` (passes with existing warnings)
- `npm run test:changed`

## Known unresolved risks
- Existing lint warnings remain outside this issue scope.
- No schema migration was added; the change intentionally relies on existing structured candidate fields.