### PR TITLE
refactor(goal): preserve typed dimension mappings

### DIFF
--- a/src/interface/cli/setup.ts
+++ b/src/interface/cli/setup.ts
@@ -139,7 +139,10 @@ export async function buildDeps(
             desc = `${desc}\n${parent.description}`;
           }
         }
-        return desc;
+        const dimensionMappings = Object.fromEntries(
+          goal.dimensions.map((dimension) => [dimension.name, dimension.observation_mapping ?? null])
+        );
+        return { description: desc, dimensionMappings };
       } catch (err) {
         getCliLogger().error(formatOperationError(`resolve workspace context goal description for "${goalId}"`, err));
         return undefined;

--- a/src/interface/tui/entry-deps.ts
+++ b/src/interface/tui/entry-deps.ts
@@ -95,7 +95,10 @@ export async function buildStandaloneTuiDeps() {
             desc = `${desc}\n${parent.description}`;
           }
         }
-        return desc;
+        const dimensionMappings = Object.fromEntries(
+          goal.dimensions.map((dimension) => [dimension.name, dimension.observation_mapping ?? null])
+        );
+        return { description: desc, dimensionMappings };
       } catch (err) {
         getCliLogger().error(`[pulseed] Failed to resolve goal description for "${goalId}": ${err instanceof Error ? err.message : String(err)}`);
         return undefined;

--- a/src/orchestrator/goal/__tests__/goal-negotiator-decompose.test.ts
+++ b/src/orchestrator/goal/__tests__/goal-negotiator-decompose.test.ts
@@ -1026,7 +1026,7 @@ describe("GoalNegotiator", () => {
       await negotiator.negotiate("Maintain comfortable environment");
 
       expect(capturedPrompt).toContain("DataSources");
-      expect(capturedPrompt).toContain("use exact dimension names");
+      expect(capturedPrompt).toContain("exact DataSource dimension");
       expect(capturedPrompt).toContain("temperature_celsius");
       expect(capturedPrompt).toContain("humidity_percent");
     });

--- a/src/orchestrator/goal/__tests__/goal-negotiator-negotiate.test.ts
+++ b/src/orchestrator/goal/__tests__/goal-negotiator-negotiate.test.ts
@@ -194,6 +194,111 @@ describe("GoalNegotiator", () => {
       expect(result.goal.dimensions).toHaveLength(1);
       expect(result.goal.dimensions[0]!.name).toBe("completion_rate");
     });
+
+    it("does not silently map paraphrased dimensions to unrelated DataSource dimensions", async () => {
+      const paraphrasedDimension = JSON.stringify([
+        {
+          name: "shipping_readiness",
+          label: "Shipping Readiness",
+          threshold_type: "min",
+          threshold_value: 0.9,
+          observation_method_hint: "Review release checklist evidence",
+          dimension_mapping: null,
+        },
+      ]);
+      const mockLLM = createMockLLMClient([
+        PASS_VERDICT,
+        paraphrasedDimension,
+        FEASIBILITY_REALISTIC,
+        RESPONSE_MESSAGE_ACCEPT,
+      ]);
+      const mockObsEngine = {
+        getAvailableDimensionInfo(): Array<{ name: string; dimensions: string[] }> {
+          return [{ name: "github_issues", dimensions: ["completion_ratio", "open_issue_count"] }];
+        },
+      } as unknown as ObservationEngine;
+      const ethicsGate = new EthicsGate(stateManager, mockLLM);
+      const negotiator = new GoalNegotiator(stateManager, mockLLM, ethicsGate, mockObsEngine);
+
+      const result = await negotiator.negotiate("Confirm the release is ready to ship");
+
+      expect(result.goal.dimensions[0]?.name).toBe("shipping_readiness");
+      expect(result.log.step2_decomposition?.dimensions[0]?.dimension_mapping).toBeNull();
+    });
+
+    it("keeps substring collisions unknown instead of mutating the dimension name", async () => {
+      const substringCollision = JSON.stringify([
+        {
+          name: "coverage",
+          label: "Coverage",
+          threshold_type: "min",
+          threshold_value: 0.95,
+          observation_method_hint: "Review narrative coverage of requirements",
+          dimension_mapping: null,
+        },
+      ]);
+      const mockLLM = createMockLLMClient([
+        PASS_VERDICT,
+        substringCollision,
+        FEASIBILITY_REALISTIC,
+        RESPONSE_MESSAGE_ACCEPT,
+      ]);
+      const mockObsEngine = {
+        getAvailableDimensionInfo(): Array<{ name: string; dimensions: string[] }> {
+          return [{ name: "ci", dimensions: ["test_coverage_percent", "branch_coverage_percent"] }];
+        },
+      } as unknown as ObservationEngine;
+      const ethicsGate = new EthicsGate(stateManager, mockLLM);
+      const negotiator = new GoalNegotiator(stateManager, mockLLM, ethicsGate, mockObsEngine);
+
+      const result = await negotiator.negotiate("Improve requirement coverage");
+
+      expect(result.goal.dimensions[0]?.name).toBe("coverage");
+      expect(result.log.step2_decomposition?.dimensions[0]?.dimension_mapping).toBeNull();
+    });
+
+    it("preserves explicit typed DataSource mapping metadata in the production negotiation log", async () => {
+      const typedMappedDimension = JSON.stringify([
+        {
+          name: "test_coverage",
+          label: "Test Coverage",
+          threshold_type: "min",
+          threshold_value: 80,
+          observation_method_hint: "Use CI coverage report",
+          dimension_mapping: {
+            kind: "data_source",
+            data_source: "ci",
+            dimension: "test_coverage_percent",
+            confidence: "high",
+            rationale: "CI exposes the exact coverage percentage",
+          },
+        },
+      ]);
+      const mockLLM = createMockLLMClient([
+        PASS_VERDICT,
+        typedMappedDimension,
+        FEASIBILITY_REALISTIC,
+        RESPONSE_MESSAGE_ACCEPT,
+      ]);
+      const mockObsEngine = {
+        getAvailableDimensionInfo(): Array<{ name: string; dimensions: string[] }> {
+          return [{ name: "ci", dimensions: ["test_coverage_percent"] }];
+        },
+      } as unknown as ObservationEngine;
+      const ethicsGate = new EthicsGate(stateManager, mockLLM);
+      const negotiator = new GoalNegotiator(stateManager, mockLLM, ethicsGate, mockObsEngine);
+
+      const result = await negotiator.negotiate("Raise automated test coverage");
+
+      expect(result.goal.dimensions[0]?.name).toBe("test_coverage");
+      expect(result.log.step2_decomposition?.dimensions[0]?.dimension_mapping).toEqual({
+        kind: "data_source",
+        data_source: "ci",
+        dimension: "test_coverage_percent",
+        confidence: "high",
+        rationale: "CI exposes the exact coverage percentage",
+      });
+    });
   });
 
   // ─── negotiate() — Baseline Observation ───

--- a/src/orchestrator/goal/goal-validation.ts
+++ b/src/orchestrator/goal/goal-validation.ts
@@ -28,6 +28,7 @@ export function decompositionToDimension(d: DimensionDecomposition): Dimension {
     weight: 1.0,
     uncertainty_weight: null,
     state_integrity: "ok",
+    observation_mapping: d.dimension_mapping ?? null,
     dimension_mapping: null,
   };
 }
@@ -83,25 +84,21 @@ export function deduplicateDimensionKeys(dimensions: DimensionDecomposition[]): 
   return dimensions;
 }
 
-/**
- * Find the best matching DataSource dimension name for a given dimension name.
- * Uses simple keyword overlap matching.
- */
-export function findBestDimensionMatch(name: string, candidates: string[]): string | null {
-  const nameTokens = name.toLowerCase().split(/[_\s-]+/);
-  let bestMatch: string | null = null;
-  let bestScore = 0;
+export function validateDataSourceDimensionMappings(
+  dimensions: DimensionDecomposition[],
+  availableDataSources: Array<{ name: string; dimensions: string[] }>
+): DimensionDecomposition[] {
+  const sources = new Map(availableDataSources.map((source) => [source.name, new Set(source.dimensions)]));
 
-  for (const candidate of candidates) {
-    const candidateTokens = candidate.toLowerCase().split(/[_\s-]+/);
-    // Count overlapping tokens
-    const overlap = nameTokens.filter(t => candidateTokens.includes(t)).length;
-    const score = overlap / Math.max(nameTokens.length, candidateTokens.length);
-    if (score > bestScore && score >= 0.6) {  // At least 60% token overlap
-      bestScore = score;
-      bestMatch = candidate;
+  for (const dimension of dimensions) {
+    const mapping = dimension.dimension_mapping;
+    if (!mapping) continue;
+
+    const sourceDimensions = sources.get(mapping.data_source);
+    if (!sourceDimensions?.has(mapping.dimension)) {
+      dimension.dimension_mapping = null;
     }
   }
 
-  return bestMatch;
+  return dimensions;
 }

--- a/src/orchestrator/goal/negotiator-prompts.ts
+++ b/src/orchestrator/goal/negotiator-prompts.ts
@@ -16,8 +16,12 @@ export function buildDecompositionPrompt(
 
   const dataSourcesSection =
     availableDataSources && availableDataSources.length > 0
-      ? `DataSources (use exact dimension names for overlap; add 1-2 extra only if shell-measurable):
+      ? `DataSources (optional typed mapping targets; do not rename an unrelated goal dimension just because words overlap):
 ${availableDataSources.map((ds) => `- "${ds.name}": ${ds.dimensions.join(", ")}`).join("\n")}
+
+When a dimension is intentionally measured by one of these DataSource dimensions, keep the goal dimension name semantic and add:
+  "dimension_mapping": {"kind":"data_source","data_source":"<source name>","dimension":"<exact DataSource dimension>","confidence":"high"|"medium"|"low","rationale":"..."}
+If the mapping is uncertain or ambiguous, use null.
 
 `
       : "";
@@ -30,7 +34,7 @@ ${availableDataSources.map((ds) => `- "${ds.name}": ${ds.dimensions.join(", ")}`
 
 Goal: ${description}${constraintsSection}${workspaceSection}
 
-Each dimension needs: name (snake_case, prefer exact DataSource name), label, threshold_type ("min"|"max"|"range"|"present"|"match"), threshold_value (number/string/bool or null), observation_method_hint.
+Each dimension needs: name (snake_case), label, threshold_type ("min"|"max"|"range"|"present"|"match"), threshold_value (number/string/bool or null), observation_method_hint, dimension_mapping (typed DataSource mapping or null).
 
 Rules:
 - 100 dimensions max; prefer fewer focused dimensions over many vague ones; prefer mechanically measurable (shell/grep/test runner)
@@ -39,8 +43,8 @@ Rules:
 
 Example:
 [
-  {"name":"test_coverage","label":"Test Coverage","threshold_type":"min","threshold_value":80,"observation_method_hint":"Run test suite, check coverage %"},
-  {"name":"license_file_exists","label":"License File","threshold_type":"present","threshold_value":true,"observation_method_hint":"Check for LICENSE file in root"}
+  {"name":"test_coverage","label":"Test Coverage","threshold_type":"min","threshold_value":80,"observation_method_hint":"Run test suite, check coverage %","dimension_mapping":{"kind":"data_source","data_source":"ci","dimension":"test_coverage_percent","confidence":"high","rationale":"CI exposes exact coverage percent"}},
+  {"name":"license_file_exists","label":"License File","threshold_type":"present","threshold_value":true,"observation_method_hint":"Check for LICENSE file in root","dimension_mapping":null}
 ]`;
 }
 

--- a/src/orchestrator/goal/negotiator-steps.ts
+++ b/src/orchestrator/goal/negotiator-steps.ts
@@ -32,7 +32,7 @@ import {
 } from "./goal-suggest.js";
 import {
   deduplicateDimensionKeys,
-  findBestDimensionMatch,
+  validateDataSourceDimensionMappings,
 } from "./goal-validation.js";
 import { REALISTIC_TARGET_ACCELERATION_FACTOR } from "./negotiator-feasibility.js";
 export {
@@ -87,19 +87,16 @@ export async function runDecompositionStep(
     );
   }
 
-  // Post-process: map dimension names to DataSource dimensions when similar
-  if (availableDataSources.length > 0) {
-    const allDsNames = availableDataSources.flatMap((ds) => ds.dimensions);
-    for (const dim of dimensions) {
-      if (!allDsNames.includes(dim.name)) {
-        const match = findBestDimensionMatch(dim.name, allDsNames);
-        if (match) {
-          dim.name = match;
-        }
-      }
-    }
+  for (const dim of dimensions) {
+    dim.dimension_mapping ??= null;
+  }
 
-    // Warn if all dimensions were remapped to DataSource dimensions
+  // Post-process: validate explicit typed DataSource mappings without changing
+  // the goal dimension names. Unknown or ambiguous mappings remain null.
+  if (availableDataSources.length > 0) {
+    validateDataSourceDimensionMappings(dimensions, availableDataSources);
+
+    const allDsNames = availableDataSources.flatMap((ds) => ds.dimensions);
     const allRemapped =
       dimensions.length > 0 && dimensions.every((dim) => allDsNames.includes(dim.name));
     if (allRemapped) {

--- a/src/orchestrator/goal/types/goal.ts
+++ b/src/orchestrator/goal/types/goal.ts
@@ -30,6 +30,15 @@ export type HistoryEntry = z.infer<typeof HistoryEntrySchema>;
 export const SatisficingAggregationEnum = z.enum(["min", "avg", "max", "all_required"]);
 export type SatisficingAggregation = z.infer<typeof SatisficingAggregationEnum>;
 
+export const DimensionObservationMappingSchema = z.object({
+  kind: z.literal("data_source"),
+  data_source: z.string().min(1),
+  dimension: z.string().min(1),
+  confidence: z.enum(["high", "medium", "low"]),
+  rationale: z.string().optional(),
+}).strict();
+export type DimensionObservationMapping = z.infer<typeof DimensionObservationMappingSchema>;
+
 // --- Dimension ---
 
 export const DimensionSchema = z.object({
@@ -59,6 +68,7 @@ export const DimensionSchema = z.object({
   last_observed_layer: z
     .enum(["self_report", "independent_review", "mechanical"])
     .optional(),
+  observation_mapping: DimensionObservationMappingSchema.nullable().optional(),
   /**
    * Maps this subgoal dimension to a parent goal dimension with an aggregation strategy.
    * When set, propagateSubgoalCompletion uses parent_dimension (not name matching)

--- a/src/orchestrator/goal/types/negotiation.ts
+++ b/src/orchestrator/goal/types/negotiation.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { NegotiationResponseTypeEnum } from "../../../base/types/core.js";
+import { DimensionObservationMappingSchema } from "./goal.js";
 
 export const NegotiationStepEnum = z.enum([
   "ethics_check",
@@ -14,12 +15,16 @@ export type NegotiationStep = z.infer<typeof NegotiationStepEnum>;
 export const FeasibilityPathEnum = z.enum(["quantitative", "qualitative", "hybrid"]);
 export type FeasibilityPath = z.infer<typeof FeasibilityPathEnum>;
 
+export const DataSourceDimensionMappingSchema = DimensionObservationMappingSchema;
+export type DataSourceDimensionMapping = z.infer<typeof DataSourceDimensionMappingSchema>;
+
 export const DimensionDecompositionSchema = z.object({
   name: z.string(),
   label: z.string(),
   threshold_type: z.enum(["min", "max", "range", "present", "match"]),
   threshold_value: z.union([z.number(), z.string(), z.boolean(), z.array(z.union([z.number(), z.string()]))]).nullable(),
   observation_method_hint: z.string(),
+  dimension_mapping: DataSourceDimensionMappingSchema.nullable().optional(),
 });
 export type DimensionDecomposition = z.infer<typeof DimensionDecompositionSchema>;
 

--- a/src/platform/drive/__tests__/example.test.ts
+++ b/src/platform/drive/__tests__/example.test.ts
@@ -19,7 +19,7 @@ import {
   buildThreshold,
   deduplicateDimensionKeys,
   decompositionToDimension,
-  findBestDimensionMatch,
+  validateDataSourceDimensionMappings,
 } from "../../../orchestrator/goal/goal-validation.js";
 import { MockEmbeddingClient } from "../../knowledge/embedding-client.js";
 import { StateManager } from "../../../base/state/state-manager.js";
@@ -142,10 +142,37 @@ describe("example unit coverage", () => {
     ]);
 
     expect(deduped.map((item) => item.name)).toEqual(["coverage", "coverage_2", "coverage_3"]);
-    expect(findBestDimensionMatch("test_coverage_percent", ["latency", "test_coverage"])).toBe(
-      "test_coverage"
-    );
-    expect(findBestDimensionMatch("revenue_growth", ["burn_rate", "latency"])).toBeNull();
+    const mapped = deduplicateDimensionKeys([
+      {
+        name: "coverage",
+        label: "Coverage",
+        threshold_type: "min",
+        threshold_value: 80,
+        observation_method_hint: "ci",
+        dimension_mapping: {
+          kind: "data_source",
+          data_source: "ci",
+          dimension: "test_coverage_percent",
+          confidence: "high",
+        },
+      },
+      {
+        name: "unknown",
+        label: "Unknown",
+        threshold_type: "present",
+        threshold_value: null,
+        observation_method_hint: "ci",
+        dimension_mapping: {
+          kind: "data_source",
+          data_source: "ci",
+          dimension: "missing",
+          confidence: "low",
+        },
+      },
+    ]);
+    validateDataSourceDimensionMappings(mapped, [{ name: "ci", dimensions: ["test_coverage_percent"] }]);
+    expect(mapped[0]?.dimension_mapping?.dimension).toBe("test_coverage_percent");
+    expect(mapped[1]?.dimension_mapping).toBeNull();
   });
 
   it("covers gap calculation pipeline and aggregation branches", () => {

--- a/src/platform/observation/__tests__/context-provider.test.ts
+++ b/src/platform/observation/__tests__/context-provider.test.ts
@@ -583,6 +583,27 @@ describe("collectContextItems with toolExecutor", () => {
     expect(result).toContain("const alpha = 1;");
     expect(result).not.toContain("10\tconst alpha = 1;");
   });
+
+  it("prefers typed search terms and explicit paths over dimension-name keyword hits", async () => {
+    const executor = createMockExecutor();
+    const executeFn = executor.execute as ReturnType<typeof vi.fn>;
+
+    const result = await buildWorkspaceContext("goal-typed-context", "test_coverage", {
+      cwd: projectRoot,
+      toolExecutor: executor,
+      explicitPaths: ["src/platform/observation/context-provider.ts"],
+      searchTerms: ["structured-mapping"],
+    });
+
+    expect(result).toContain('[explicit_path "src/platform/observation/context-provider.ts"]');
+    const codeSearchCall = executeFn.mock.calls.find((call: unknown[]) => call[0] === "code_search");
+    expect(codeSearchCall?.[1]).toMatchObject({
+      queryTerms: ["structured-mapping", "test_coverage"],
+    });
+    expect(executeFn.mock.calls.some((call: unknown[]) =>
+      call[0] === "grep" && (call[1] as { pattern?: string }).pattern === "coverage"
+    )).toBe(false);
+  });
 });
 
 describe("buildChatContext with toolExecutor", () => {

--- a/src/platform/observation/__tests__/observation-engine.test.ts
+++ b/src/platform/observation/__tests__/observation-engine.test.ts
@@ -915,6 +915,70 @@ describe("observeFromDataSource", () => {
     );
   });
 
+  it("observes semantic dimensions through typed DataSource observation mappings", async () => {
+    const wrongDs = makeMockDataSource({
+      sourceId: "wrong-ds",
+      config: makeDsConfig({ id: "wrong-ds", name: "wrong" }),
+      getSupportedDimensions: () => ["test_coverage_percent"],
+      query: vi.fn().mockResolvedValue({
+        value: 1,
+        raw: { coverage: 1 },
+        timestamp: new Date().toISOString(),
+        source_id: "wrong-ds",
+      }),
+    });
+    const typedMappedDs = makeMockDataSource({
+      sourceId: "ci-ds",
+      config: makeDsConfig({ id: "ci-ds", name: "ci" }),
+      getSupportedDimensions: () => ["test_coverage_percent"],
+      query: vi.fn().mockResolvedValue({
+        value: 83,
+        raw: { coverage: 83 },
+        timestamp: new Date().toISOString(),
+        source_id: "ci-ds",
+      }),
+    });
+    const engineMapped = new ObservationEngine(stateManager, [wrongDs, typedMappedDs]);
+
+    const goal = makeGoal({
+      id: "goal-observation-mapping",
+      dimensions: [
+        {
+          name: "test_coverage",
+          label: "Test Coverage",
+          current_value: 0,
+          threshold: { type: "min", value: 80 },
+          confidence: 0.6,
+          observation_method: defaultMethod,
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          observation_mapping: {
+            kind: "data_source",
+            data_source: "ci",
+            dimension: "test_coverage_percent",
+            confidence: "high",
+          },
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await stateManager.saveGoal(goal);
+
+    await engineMapped.observe("goal-observation-mapping", []);
+
+    const queryMock = typedMappedDs.query as ReturnType<typeof vi.fn>;
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dimension_name: "test_coverage_percent" })
+    );
+    expect(wrongDs.query).not.toHaveBeenCalled();
+    const updated = await stateManager.loadGoal("goal-observation-mapping");
+    expect(updated?.dimensions[0]?.name).toBe("test_coverage");
+    expect(updated?.dimensions[0]?.current_value).toBe(83);
+  });
+
   it("handles non-numeric values from data source", async () => {
     const stringDs = makeMockDataSource({
       query: vi.fn().mockResolvedValue({

--- a/src/platform/observation/__tests__/workspace-context.test.ts
+++ b/src/platform/observation/__tests__/workspace-context.test.ts
@@ -411,6 +411,35 @@ describe("createWorkspaceContextProvider — Phase 3 grep content match", () => 
     expect(result).toContain("impl.ts");
     expect(result).toContain("TODO: finish this implementation");
   });
+
+  it("uses typed DataSource mapping terms instead of dimension-name keyword terms", async () => {
+    for (let i = 1; i <= 10; i++) {
+      fs.writeFileSync(path.join(tmpWorkDir, `unrelated${i}.ts`), `// file ${i}`, "utf-8");
+    }
+    fs.writeFileSync(path.join(tmpWorkDir, "coverage-keyword.ts"), "// keyword-only coverage hit", "utf-8");
+    fs.writeFileSync(path.join(tmpWorkDir, "typed-metric.ts"), "// metric emitted as ci.branch_coverage_percent", "utf-8");
+
+    const provider = createWorkspaceContextProvider(
+      { workDir: tmpWorkDir },
+      () => ({
+        description: "Improve coverage",
+        dimensionMappings: {
+          coverage: {
+            kind: "data_source",
+            data_source: "ci",
+            dimension: "branch_coverage_percent",
+            confidence: "high",
+          },
+        },
+      })
+    );
+
+    const result = await provider("goal-grep-typed", "coverage");
+    expect(result).toContain("typed-metric.ts");
+    expect(result).toContain("branch_coverage_percent");
+    expect(result).not.toContain("## coverage-keyword.ts");
+    expect(result).not.toContain("keyword-only coverage hit");
+  });
 });
 
 describe("createWorkspaceContextProvider — existing workspace behavior unchanged", () => {

--- a/src/platform/observation/context-provider.ts
+++ b/src/platform/observation/context-provider.ts
@@ -24,6 +24,8 @@ export async function buildWorkspaceContext(
     cwd?: string;
     maxFileContentLines?: number; // default: 100
     maxTotalChars?: number; // default: WORKSPACE_CONTEXT_MAX_CHARS
+    searchTerms?: string[];
+    explicitPaths?: string[];
     toolExecutor?: ToolExecutor;
     toolContext?: Partial<ToolCallContext>;
   }
@@ -48,6 +50,8 @@ export async function buildWorkspaceContextItems(
     maxFileContentLines?: number;
     maxItems?: number; // default: unlimited
     maxTotalChars?: number; // default: WORKSPACE_CONTEXT_MAX_CHARS
+    searchTerms?: string[];
+    explicitPaths?: string[];
     toolExecutor?: ToolExecutor;
     toolContext?: Partial<ToolCallContext>;
   }

--- a/src/platform/observation/context-provider/collector.ts
+++ b/src/platform/observation/context-provider/collector.ts
@@ -1,4 +1,5 @@
 import { execFile } from "node:child_process";
+import * as path from "node:path";
 import { promisify } from "node:util";
 import { readFile } from "fs/promises";
 import type { ToolExecutor } from "../../../tools/executor.js";
@@ -29,6 +30,8 @@ export type CollectorOptions = {
   cwd?: string;
   maxFileContentLines?: number;
   maxTotalChars?: number;
+  searchTerms?: string[];
+  explicitPaths?: string[];
   toolExecutor?: ToolExecutor;
   toolContext?: Partial<ToolCallContext>;
 };
@@ -50,7 +53,7 @@ type CodeSearchBundle = {
 };
 
 function createCollector(goalId: string, options?: CollectorOptions): ContextCollector {
-  const cwd = options?.cwd || process.cwd();
+  const cwd = path.resolve(options?.cwd || process.cwd());
   return {
     cwd,
     toolExecutor: options?.toolExecutor,
@@ -292,6 +295,32 @@ async function collectSearchTermItems(
   return { items, addedChars };
 }
 
+async function collectExplicitPathItems(
+  collector: ContextCollector,
+  paths: string[],
+  readMaxLines: () => number
+): Promise<ContextItem[]> {
+  const items: ContextItem[] = [];
+  for (const explicitPath of paths) {
+    const filePath = path.resolve(collector.cwd, explicitPath);
+    if (!filePath.startsWith(collector.cwd + path.sep) && filePath !== collector.cwd) {
+      continue;
+    }
+    try {
+      const lines = await readFileExcerpt(collector, filePath, readMaxLines());
+      if (lines.length > 0) {
+        items.push(toContextItem(
+          `[explicit_path "${toRelativePath(collector.cwd, filePath)}"]`,
+          lines.join("\n")
+        ));
+      }
+    } catch {
+      // skip unreadable explicit paths
+    }
+  }
+  return items;
+}
+
 async function maybeAppendContextItem(
   items: ContextItem[],
   cumulativeChars: number,
@@ -332,7 +361,13 @@ export async function collectContextItems(
       : (options?.maxFileContentLines ?? DEFAULT_FILE_CONTENT_LINES);
   };
 
-  const searchTerms = dimensionNameToSearchTerms(dimensionName);
+  const explicitItems = await collectExplicitPathItems(collector, options?.explicitPaths ?? [], effectiveMaxLines);
+  items.push(...explicitItems);
+  cumulativeChars += explicitItems.reduce((total, item) => total + item.label.length + item.content.length, 0);
+
+  const searchTerms = options?.searchTerms?.length
+    ? options.searchTerms
+    : dimensionNameToSearchTerms(dimensionName);
   for (const term of searchTerms) {
     if (cumulativeChars >= maxTotalChars) {
       break;

--- a/src/platform/observation/engine/observe-datasource-stage.ts
+++ b/src/platform/observation/engine/observe-datasource-stage.ts
@@ -9,7 +9,7 @@ import type { ObservationLogEntry } from "../../../base/types/state.js";
 import type { WorkspaceContextFetcher } from "./observe-context.js";
 import type { CrossValidationResult } from "../observation-helpers.js";
 
-type ObserveFromDataSource = (goalId: string, dimensionName: string, sourceId: string) => Promise<ObservationLogEntry>;
+type ObserveFromDataSource = (goalId: string, dimensionName: string, sourceId: string, queryDimensionName?: string) => Promise<ObservationLogEntry>;
 type ObserveWithLLM = (
   goalId: string,
   dimensionName: string,
@@ -34,6 +34,7 @@ interface ObserveDataSourceStageParams {
   goalId: string;
   goal: Goal;
   dimension: Dimension;
+  queryDimensionName?: string;
   method: ObservationMethod;
   dataSource: IDataSourceAdapter;
   workspacePath?: string;
@@ -52,6 +53,7 @@ export async function runDataSourceObservationStage({
   goalId,
   goal,
   dimension,
+  queryDimensionName,
   dataSource,
   workspacePath,
   crossValidationEnabled,
@@ -65,7 +67,7 @@ export async function runDataSourceObservationStage({
   hookManager,
 }: ObserveDataSourceStageParams): Promise<boolean> {
   try {
-    await observeFromDataSource(goalId, dimension.name, dataSource.sourceId);
+    await observeFromDataSource(goalId, dimension.name, dataSource.sourceId, queryDimensionName);
 
     if (crossValidationEnabled && llmAvailable) {
       await runCrossValidation({

--- a/src/platform/observation/observation-apply.ts
+++ b/src/platform/observation/observation-apply.ts
@@ -150,7 +150,8 @@ export async function observeFromDataSource(
   dimensionName: string,
   sourceId: string,
   dataSources: IDataSourceAdapter[],
-  applyFn: (goalId: string, entry: ObservationLogEntry) => Promise<void>
+  applyFn: (goalId: string, entry: ObservationLogEntry) => Promise<void>,
+  queryDimensionName = dimensionName
 ): Promise<ObservationLogEntry> {
   const source = dataSources.find((s) => s.sourceId === sourceId);
   if (!source) {
@@ -161,11 +162,11 @@ export async function observeFromDataSource(
   }
 
   const query: DataSourceQuery = {
-    dimension_name: dimensionName,
+    dimension_name: queryDimensionName,
     timeout_ms: 10000,
   };
 
-  const expression = source.config.dimension_mapping?.[dimensionName];
+  const expression = source.config.dimension_mapping?.[queryDimensionName];
   if (expression !== undefined) {
     query.expression = expression;
   }

--- a/src/platform/observation/observation-datasource.ts
+++ b/src/platform/observation/observation-datasource.ts
@@ -12,7 +12,8 @@ import type { DataSourceQuery } from "../../base/types/data-source.js";
 export function findDataSourceForDimension(
   dataSources: IDataSourceAdapter[],
   dimensionName: string,
-  goalId?: string
+  goalId?: string,
+  preferredSourceName?: string
 ): IDataSourceAdapter | null {
   const matches = (ds: IDataSourceAdapter): boolean => {
     if (ds.supportsDimension?.(dimensionName, goalId)) return true;
@@ -21,15 +22,22 @@ export function findDataSourceForDimension(
     if (ds.config?.dimension_mapping && dimensionName in ds.config.dimension_mapping) return true;
     return false;
   };
+  const sourceMatches = (ds: IDataSourceAdapter): boolean =>
+    preferredSourceName === undefined ||
+    ds.config.name === preferredSourceName ||
+    ds.sourceId === preferredSourceName;
+  const candidates = preferredSourceName
+    ? dataSources.filter(sourceMatches)
+    : dataSources;
 
   // First pass: prefer a datasource explicitly scoped to this goalId
-  for (const ds of dataSources) {
+  for (const ds of candidates) {
     const scopeGoalId = ds.config?.scope_goal_id as string | undefined;
     if (scopeGoalId === goalId && goalId !== undefined && matches(ds)) return ds;
   }
 
   // Second pass: fall back to an unscoped datasource
-  for (const ds of dataSources) {
+  for (const ds of candidates) {
     const scopeGoalId = ds.config?.scope_goal_id as string | undefined;
     if (scopeGoalId === undefined && matches(ds)) return ds;
   }
@@ -37,7 +45,7 @@ export function findDataSourceForDimension(
   // Third pass: fall back to a datasource scoped to a different goal.
   // This handles the case where dedup prevented creating a goal-specific
   // datasource because an identical one already exists for another goal.
-  for (const ds of dataSources) {
+  for (const ds of candidates) {
     if (matches(ds)) return ds;
   }
 
@@ -60,7 +68,8 @@ export async function observeFromDataSource(
   goalId: string,
   dimensionName: string,
   sourceId: string,
-  applyObservation: (goalId: string, entry: ObservationLogEntry) => void
+  applyObservation: (goalId: string, entry: ObservationLogEntry) => void,
+  queryDimensionName = dimensionName
 ): Promise<ObservationLogEntry> {
   const source = dataSources.find((s) => s.sourceId === sourceId);
   if (!source) {
@@ -71,11 +80,11 @@ export async function observeFromDataSource(
   }
 
   const query: DataSourceQuery = {
-    dimension_name: dimensionName,
+    dimension_name: queryDimensionName,
     timeout_ms: 10000,
   };
 
-  const expression = source.config.dimension_mapping?.[dimensionName];
+  const expression = source.config.dimension_mapping?.[queryDimensionName];
   if (expression !== undefined) {
     query.expression = expression;
   }

--- a/src/platform/observation/observation-engine.ts
+++ b/src/platform/observation/observation-engine.ts
@@ -297,11 +297,13 @@ export class ObservationEngine {
         continue;
       }
 
-      const dataSource = this.findDataSourceForDimension(dim.name, goalId);
+      const dataSourceDimensionName = dim.observation_mapping?.dimension ?? dim.name;
+      const dataSource = this.findDataSourceForDimension(dataSourceDimensionName, goalId, dim.observation_mapping?.data_source);
       if (dataSource && await runDataSourceObservationStage({
         goalId,
         goal,
         dimension: dim,
+        queryDimensionName: dataSourceDimensionName,
         method,
         dataSource,
         workspacePath,
@@ -309,7 +311,7 @@ export class ObservationEngine {
         llmAvailable: !!this.llmClient,
         stateManager: this.stateManager,
         fetchWorkspaceContext,
-        observeFromDataSource: (gId, dimensionName, sourceId) => this.observeFromDataSource(gId, dimensionName, sourceId),
+        observeFromDataSource: (gId, dimensionName, sourceId, queryDimensionName) => this.observeFromDataSource(gId, dimensionName, sourceId, queryDimensionName),
         observeWithLLM: (...args) => this.observeWithLLM(...args),
         crossValidate: (gId, dimensionName, mechanicalValue, llmValue) =>
           this.crossValidate(gId, dimensionName, mechanicalValue, llmValue),
@@ -362,14 +364,16 @@ export class ObservationEngine {
   async observeFromDataSource(
     goalId: string,
     dimensionName: string,
-    sourceId: string
+    sourceId: string,
+    queryDimensionName?: string
   ): Promise<ObservationLogEntry> {
     return observeFromDataSourceFn(
       goalId,
       dimensionName,
       sourceId,
       this.dataSources,
-      (gId, entry) => this.applyObservation(gId, entry)
+      (gId, entry) => this.applyObservation(gId, entry),
+      queryDimensionName
     );
   }
 
@@ -378,8 +382,8 @@ export class ObservationEngine {
   /**
    * Find the first DataSource adapter that can serve the given dimension name.
    */
-  private findDataSourceForDimension(dimensionName: string, goalId?: string): IDataSourceAdapter | null {
-    return findDataSourceForDimensionFn(this.dataSources, dimensionName, goalId);
+  private findDataSourceForDimension(dimensionName: string, goalId?: string, preferredSourceName?: string): IDataSourceAdapter | null {
+    return findDataSourceForDimensionFn(this.dataSources, dimensionName, goalId, preferredSourceName);
   }
 
   // ─── LLM Observation ───

--- a/src/platform/observation/workspace-context.ts
+++ b/src/platform/observation/workspace-context.ts
@@ -7,6 +7,7 @@ import { getCodeSearchIndexes } from "../code-search/indexes/index-store.js";
 import { SearchOrchestrator } from "../code-search/orchestrator.js";
 import { ProgressiveReader } from "../code-search/progressive-reader.js";
 import { dimensionNameToSearchTerms } from "./context-provider.js";
+import type { DimensionObservationMapping } from "../../base/types/goal.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -16,6 +17,13 @@ export interface WorkspaceContextOptions {
   maxCharsPerFile?: number; // default: 4000
   externalFileMaxBytes?: number; // default: 10240 (10KB)
   cacheTtlMs?: number; // default: 0 (disabled to avoid stale daemon task context)
+}
+
+export interface WorkspaceContextGoalInfo {
+  description?: string;
+  dimensionMappings?: Record<string, DimensionObservationMapping | null | undefined>;
+  explicitPaths?: string[];
+  searchTerms?: string[];
 }
 
 const ALLOWED_EXTERNAL_PREFIXES = [os.homedir(), "/tmp"];
@@ -155,7 +163,7 @@ async function readFileSection(filePath: string, maxChars: number): Promise<stri
 
 export function createWorkspaceContextProvider(
   options: WorkspaceContextOptions,
-  getGoalDescription: (goalId: string) => string | undefined | Promise<string | undefined>,
+  getGoalDescription: (goalId: string) => string | WorkspaceContextGoalInfo | undefined | Promise<string | WorkspaceContextGoalInfo | undefined>,
   getGoalConstraints?: (goalId: string) => string[] | undefined | Promise<string[] | undefined>
 ): (goalId: string, dimensionName: string) => Promise<string> {
   const {
@@ -168,8 +176,22 @@ export function createWorkspaceContextProvider(
   const cache = new Map<string, { value: string; expiresAt: number }>();
 
   return async (goalId: string, dimensionName: string): Promise<string> => {
-    const goalDescription = (await getGoalDescription(goalId)) ?? "";
-    const keywords = extractKeywords(goalDescription + " " + dimensionName);
+    const goalInfo = await getGoalDescription(goalId);
+    const goalDescription = typeof goalInfo === "string"
+      ? goalInfo
+      : (goalInfo?.description ?? "");
+    const typedMapping = typeof goalInfo === "string"
+      ? null
+      : (goalInfo?.dimensionMappings?.[dimensionName] ?? null);
+    const typedSearchTerms = typeof goalInfo === "string"
+      ? []
+      : (goalInfo?.searchTerms ?? []);
+    const explicitGoalPaths = typeof goalInfo === "string"
+      ? []
+      : (goalInfo?.explicitPaths ?? []);
+    const keywords = typedMapping
+      ? [typedMapping.dimension, typedMapping.data_source]
+      : extractKeywords(goalDescription + " " + dimensionName);
 
     // Resolve effective workDir: use workspace_path constraint from goal if available
     let effectiveWorkDir = workDir;
@@ -181,7 +203,7 @@ export function createWorkspaceContextProvider(
       }
     }
 
-    const cacheKey = `${effectiveWorkDir}\u0000${goalId}\u0000${dimensionName}`;
+    const cacheKey = `${effectiveWorkDir}\u0000${goalId}\u0000${dimensionName}\u0000${typedMapping?.data_source ?? ""}\u0000${typedMapping?.dimension ?? ""}\u0000${explicitGoalPaths.join("|")}\u0000${typedSearchTerms.join("|")}`;
     if (cacheTtlMs > 0) {
       const cached = cache.get(cacheKey);
       if (cached && cached.expiresAt > Date.now()) {
@@ -192,7 +214,7 @@ export function createWorkspaceContextProvider(
     const parts: string[] = [`# Workspace: ${effectiveWorkDir}`];
 
     // Read external absolute-path files mentioned in goal description
-    const externalPaths = extractAbsolutePaths(goalDescription);
+    const externalPaths = [...new Set([...extractAbsolutePaths(goalDescription), ...explicitGoalPaths.filter((p) => path.isAbsolute(p))])];
     for (const extPath of externalPaths) {
       const content = await readExternalFile(extPath, externalFileMaxBytes);
       if (content !== null) {
@@ -210,8 +232,11 @@ export function createWorkspaceContextProvider(
 
     try {
       const orchestrator = new SearchOrchestrator(effectiveWorkDir);
+      const typedTask = typedMapping
+        ? `DataSource mapping: ${typedMapping.data_source}.${typedMapping.dimension}\nDimension: ${dimensionName}`
+        : `${goalDescription}\n${dimensionName}`;
       const candidates = await orchestrator.search({
-        task: `${goalDescription}\n${dimensionName}`,
+        task: typedTask,
         intent: "explain",
         cwd: effectiveWorkDir,
         budget: { maxRerankCandidates: Math.min(maxFiles, 10), maxCandidatesPerRetriever: 20 },
@@ -248,7 +273,7 @@ export function createWorkspaceContextProvider(
     }
 
     // Relative path exact-match: files explicitly mentioned in goal description
-    const relativePathsInGoal = extractRelativePaths(goalDescription);
+    const relativePathsInGoal = [...new Set([...extractRelativePaths(goalDescription), ...explicitGoalPaths.filter((p) => !path.isAbsolute(p))])];
     const pathMatchedPaths: string[] = [];
     for (const rel of relativePathsInGoal) {
       const fp = path.join(effectiveWorkDir, rel);
@@ -287,7 +312,7 @@ export function createWorkspaceContextProvider(
       .split("_")
       .filter((w) => w.length >= 4 && !STOPWORDS.has(w));
     const dimHintPaths: string[] = [];
-    if (dimSegments.length >= 2) {
+    if (!typedMapping && dimSegments.length >= 2) {
       for (let i = 0; i < dimSegments.length - 1; i++) {
         const pattern = `${dimSegments[i]}-${dimSegments[i + 1]}`;
         const matched = allFiles.filter((fp) => path.basename(fp).toLowerCase().includes(pattern));
@@ -295,10 +320,12 @@ export function createWorkspaceContextProvider(
       }
     }
     // Also try single segments for direct matches (e.g. "verifier" → "task-verifier.ts")
-    for (const seg of dimSegments) {
-      if (seg.length >= 5) {
-        const matched = allFiles.filter((fp) => path.basename(fp).toLowerCase().includes(seg) && !dimHintPaths.includes(fp));
-        dimHintPaths.push(...matched);
+    if (!typedMapping) {
+      for (const seg of dimSegments) {
+        if (seg.length >= 5) {
+          const matched = allFiles.filter((fp) => path.basename(fp).toLowerCase().includes(seg) && !dimHintPaths.includes(fp));
+          dimHintPaths.push(...matched);
+        }
       }
     }
 
@@ -309,7 +336,7 @@ export function createWorkspaceContextProvider(
     const candidates = allFiles.filter((fp) => !alwaysSet.has(fp) && !pathMatchSet.has(fp) && !dimHintSet.has(fp));
 
     // Phase 1: filename match
-    const nameMatched = candidates.filter((fp) => fileMatchesKeywords(fp, keywords));
+    const nameMatched = typedMapping ? [] : candidates.filter((fp) => fileMatchesKeywords(fp, keywords));
 
     // Phase 2: content match (only if we still need more)
     // alwaysInclude and pathMatch are treated as priority (outside maxFiles cap),
@@ -322,7 +349,7 @@ export function createWorkspaceContextProvider(
       const contentMatched: string[] = [];
       for (const fp of remaining) {
         if (contentMatched.length >= neededFromCandidates - selected.length) break;
-        if (await fileContentMatchesKeywords(fp, keywords)) {
+        if (!typedMapping && await fileContentMatchesKeywords(fp, keywords)) {
           contentMatched.push(fp);
         }
       }
@@ -332,7 +359,9 @@ export function createWorkspaceContextProvider(
     // Phase 3: grep content match — find files whose content contains dimension-derived terms
     // but weren't caught by filename or keyword matching above
     if (selected.length < neededFromCandidates) {
-      const searchTerms = dimensionNameToSearchTerms(dimensionName);
+      const searchTerms = typedMapping
+        ? [typedMapping.dimension, typedMapping.data_source]
+        : (typedSearchTerms.length > 0 ? typedSearchTerms : dimensionNameToSearchTerms(dimensionName));
       const alreadySelected = new Set([
         ...alwaysIncludePaths, ...pathMatchedPaths, ...dimHintPaths, ...selected,
       ]);


### PR DESCRIPTION
Closes #1049

## Summary
- Replace token-overlap DataSource dimension name remapping with explicit typed mapping metadata on goal decomposition.
- Preserve typed mappings on persisted goal dimensions as observation_mapping, and use them in DataSource observation while keeping semantic dimension names stable.
- Let production workspace context prefer typed mapping terms or explicit paths over dimension-name keyword hits.

## Verification
- `npm run typecheck`
- `npx vitest run src/orchestrator/goal/__tests__/goal-negotiator-negotiate.test.ts src/orchestrator/goal/__tests__/goal-negotiator-decompose.test.ts src/orchestrator/goal/__tests__/goal-negotiator-character.test.ts --config vitest.unit.config.ts`
- `npx vitest run src/platform/observation/__tests__/observation-engine.test.ts --config vitest.config.ts`
- `npx vitest run src/platform/observation/__tests__/context-provider.test.ts src/platform/observation/__tests__/workspace-context.test.ts src/platform/observation/__tests__/observation-engine-context.test.ts --config vitest.config.ts`
- `npx vitest run src/platform/drive/__tests__/example.test.ts --config vitest.config.ts`

## Known unresolved risks
- None known. Existing keyword fallback remains only when no typed mapping or explicit terms are available.