### PR TITLE
refactor(chat): extract runner contracts

### DIFF
--- a/src/interface/chat/__tests__/chat-grounding.test.ts
+++ b/src/interface/chat/__tests__/chat-grounding.test.ts
@@ -37,7 +37,7 @@ import { ClaudeAPIAdapter } from "../../../adapters/agents/claude-api.js";
 import { ClaudeCodeCLIAdapter } from "../../../adapters/agents/claude-code-cli.js";
 import { OpenAICodexCLIAdapter } from "../../../adapters/agents/openai-codex.js";
 import { ChatRunner } from "../chat-runner.js";
-import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adapter-layer.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { ILLMClient } from "../../../base/llm/llm-client.js";

--- a/src/interface/chat/__tests__/chat-runner-gateway-runtime-control.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-gateway-runtime-control.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { z } from "zod";
 import { ChatRunner } from "../chat-runner.js";
-import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import { CrossPlatformChatSessionManager } from "../cross-platform-session.js";
 import { ChatSessionCatalog } from "../chat-session-store.js";
 import { StateManager } from "../../../base/state/state-manager.js";

--- a/src/interface/chat/__tests__/chat-runner-permissions.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-permissions.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ChatRunner } from "../chat-runner.js";
-import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
 import type { ITool, ToolCallContext, PermissionCheckResult, ToolResult } from "../../../tools/types.js";

--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ChatRunner } from "../chat-runner.js";
-import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import { StateManager as RealStateManager } from "../../../base/state/state-manager.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";

--- a/src/interface/chat/__tests__/chat-runner-tools.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ChatRunner } from "../chat-runner.js";
-import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient, LLMResponse } from "../../../base/llm/llm-client.js";

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -5,7 +5,7 @@ import { execFileSync } from "node:child_process";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { z } from "zod";
 import { ChatRunner } from "../chat-runner.js";
-import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import { CrossPlatformChatSessionManager } from "../cross-platform-session.js";
 import { ChatSessionCatalog } from "../chat-session-store.js";
 import { StateManager } from "../../../base/state/state-manager.js";

--- a/src/interface/chat/__tests__/chat-schedule-integration.test.ts
+++ b/src/interface/chat/__tests__/chat-schedule-integration.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { z } from "zod";
 
 import { ChatRunner } from "../chat-runner.js";
-import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
 import { ToolRegistry } from "../../../tools/registry.js";

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import * as fs from "node:fs";
 import { CrossPlatformChatSessionManager } from "../cross-platform-session.js";
 import type { CrossPlatformChatSessionOptions } from "../cross-platform-session.js";
-import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import { ApprovalBroker } from "../../../runtime/approval-broker.js";
 import { ApprovalStore } from "../../../runtime/store/approval-store.js";
 import type { StateManager } from "../../../base/state/state-manager.js";

--- a/src/interface/chat/__tests__/tool-filtering.test.ts
+++ b/src/interface/chat/__tests__/tool-filtering.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { toToolDefinitionsFiltered } from "../../../tools/tool-definition-adapter.js";
 import { ChatRunner } from "../chat-runner.js";
-import type { ChatRunnerDeps } from "../chat-runner.js";
+import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
 import type { ILLMClient, LLMResponse } from "../../../base/llm/llm-client.js";

--- a/src/interface/chat/chat-runner-commands.ts
+++ b/src/interface/chat/chat-runner-commands.ts
@@ -40,8 +40,12 @@ import {
   type ExecutionPolicy,
 } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 import { formatRoute, formatRuntimeSessionsList, formatRuntimeStatus } from "./chat-runner-runtime.js";
-import type { ChatRunnerDeps, ChatRunResult, RuntimeControlChatContext } from "./chat-runner.js";
-import type { SelectedChatRoute } from "./ingress-router.js";
+import type {
+  ChatRunResult,
+  ChatRunnerCommandHost,
+  PendingTendState,
+  ResumeCommand,
+} from "./chat-runner-contracts.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
 import type { DaemonSnapshot } from "../../runtime/daemon/client.js";
 import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
@@ -86,34 +90,6 @@ Review and branching
 
 Deferred
   /retry is intentionally not supported yet.`;
-
-export interface PendingTendState {
-  goalId: string;
-  maxIterations?: number;
-}
-
-export interface ResumeCommand {
-  selector?: string;
-}
-
-export interface ChatRunnerCommandHost {
-  deps: ChatRunnerDeps;
-  onNotification?: (message: string) => void;
-  getHistory(): ChatHistory | null;
-  setHistory(history: ChatHistory | null): void;
-  getSessionCwd(): string | null;
-  setSessionCwd(cwd: string | null): void;
-  setSessionActive(active: boolean): void;
-  getNativeAgentLoopStatePath(): string | null;
-  setNativeAgentLoopStatePath(path: string | null): void;
-  getRuntimeControlContext(): RuntimeControlChatContext | null;
-  getPendingTend(): PendingTendState | null;
-  setPendingTend(value: PendingTendState | null): void;
-  getLastSelectedRoute(): SelectedChatRoute | null;
-  getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
-  emitEvent(event: ChatEvent): void;
-  getActiveSubscribers(): Map<string, EventSubscriber>;
-}
 
 export class ChatRunnerCommandHandler {
   constructor(private readonly host: ChatRunnerCommandHost) {}

--- a/src/interface/chat/chat-runner-contracts.ts
+++ b/src/interface/chat/chat-runner-contracts.ts
@@ -1,0 +1,153 @@
+import type { StateManager } from "../../base/state/state-manager.js";
+import type { IAdapter } from "../../orchestrator/execution/adapter-layer.js";
+import type { ILLMClient } from "../../base/llm/llm-client.js";
+import type { EscalationHandler } from "./escalation.js";
+import type { ApprovalLevel } from "./mutation-tool-defs.js";
+import type { ToolRegistry } from "../../tools/registry.js";
+import type { ToolExecutor } from "../../tools/executor.js";
+import type { DaemonClient } from "../../runtime/daemon/client.js";
+import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
+import type { ChatEvent, ChatEventHandler } from "./chat-events.js";
+import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
+import type { ReviewAgentLoopRunner } from "../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
+import type { RuntimeControlService } from "../../runtime/control/index.js";
+import type { ApprovalBroker } from "../../runtime/approval-broker.js";
+import type {
+  RuntimeControlActor,
+  RuntimeControlReplyTarget,
+} from "../../runtime/store/runtime-operation-schemas.js";
+import type { SelectedChatRoute } from "./ingress-router.js";
+import type { ChatRunnerEventBridge } from "./chat-runner-event-bridge.js";
+import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
+import type { SetupDialogueRuntimeState } from "./setup-dialogue.js";
+import type { TurnLanguageHint } from "./turn-language.js";
+import type { RunSpecConfirmationState } from "./chat-history.js";
+import type { ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
+import type { ChatHistory } from "./chat-history.js";
+import type { EventSubscriber } from "./event-subscriber.js";
+
+export type ChatRunnerTelegramSetupState = "unconfigured" | "partially_configured" | "configured";
+
+export interface ChatRunnerTelegramSetupStatus {
+  channel: "telegram";
+  state: ChatRunnerTelegramSetupState;
+  configPath: string;
+  daemon: {
+    running: boolean;
+    port: number;
+  };
+  gateway: {
+    loadState: "unknown";
+  };
+  config: {
+    exists: boolean;
+    hasBotToken: boolean;
+    hasHomeChat: boolean;
+    allowAll: boolean;
+    allowedUserCount: number;
+    runtimeControlAllowedUserCount: number;
+    identityKeyConfigured: boolean;
+  };
+}
+
+export interface ChatRunnerGatewaySetupStatusProvider {
+  getTelegramStatus(baseDir?: string): Promise<ChatRunnerTelegramSetupStatus>;
+}
+
+export interface ChatRunnerDeps {
+  stateManager: StateManager;
+  adapter: IAdapter;
+  llmClient?: ILLMClient;
+  escalationHandler?: EscalationHandler;
+  trustManager?: { getBalance(domain: string): Promise<{ balance: number }>; setOverride?(domain: string, balance: number, reason: string): Promise<void> };
+  pluginLoader?: { loadAll(): Promise<Array<{ name: string; type?: string; enabled?: boolean }>> };
+  approvalFn?: (description: string) => Promise<boolean>;
+  goalId?: string;
+  approvalConfig?: Record<string, ApprovalLevel>;
+  toolExecutor?: ToolExecutor;
+  registry?: ToolRegistry;
+  onToolStart?: (toolName: string, args: Record<string, unknown>) => void;
+  onToolEnd?: (toolName: string, result: { success: boolean; summary: string; durationMs: number }) => void;
+  daemonClient?: DaemonClient;
+  goalNegotiator?: GoalNegotiator;
+  onNotification?: (message: string) => void;
+  daemonBaseUrl?: string;
+  onEvent?: ChatEventHandler;
+  chatAgentLoopRunner?: ChatAgentLoopRunner;
+  reviewAgentLoopRunner?: Pick<ReviewAgentLoopRunner, "execute">;
+  runtimeControlService?: Pick<RuntimeControlService, "request">;
+  approvalBroker?: Pick<
+    ApprovalBroker,
+    "requestConversationalApproval" | "resolveConversationalApproval" | "findPendingConversationalApproval"
+  >;
+  runtimeControlApprovalFn?: (description: string) => Promise<boolean>;
+  runtimeReplyTarget?: RuntimeControlReplyTarget;
+  runtimeControlActor?: RuntimeControlActor;
+  gatewaySetupStatusProvider?: ChatRunnerGatewaySetupStatusProvider;
+}
+
+export interface ChatRunResult {
+  success: boolean;
+  output: string;
+  elapsed_ms: number;
+}
+
+export interface RuntimeControlChatContext {
+  replyTarget?: RuntimeControlReplyTarget;
+  actor?: RuntimeControlActor;
+  approvalFn?: (description: string) => Promise<boolean>;
+  allowed?: boolean;
+  approvalMode?: "interactive" | "preapproved" | "disallowed";
+}
+
+export interface ChatRunnerExecutionOptions {
+  selectedRoute?: SelectedChatRoute;
+  runtimeControlContext?: RuntimeControlChatContext | null;
+  goalId?: string;
+}
+
+export interface PendingTendState {
+  goalId: string;
+  maxIterations?: number;
+}
+
+export interface ResumeCommand {
+  selector?: string;
+}
+
+export interface ChatRunnerCommandHost {
+  deps: ChatRunnerDeps;
+  onNotification?: (message: string) => void;
+  getHistory(): ChatHistory | null;
+  setHistory(history: ChatHistory | null): void;
+  getSessionCwd(): string | null;
+  setSessionCwd(cwd: string | null): void;
+  setSessionActive(active: boolean): void;
+  getNativeAgentLoopStatePath(): string | null;
+  setNativeAgentLoopStatePath(path: string | null): void;
+  getRuntimeControlContext(): RuntimeControlChatContext | null;
+  getPendingTend(): PendingTendState | null;
+  setPendingTend(value: PendingTendState | null): void;
+  getLastSelectedRoute(): SelectedChatRoute | null;
+  getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
+  emitEvent(event: ChatEvent): void;
+  getActiveSubscribers(): Map<string, EventSubscriber>;
+}
+
+export interface ChatRunnerRouteHost {
+  deps: ChatRunnerDeps;
+  eventBridge: ChatRunnerEventBridge;
+  activatedTools: Set<string>;
+  getConversationSessionId(): string | null;
+  getSessionCwd(): string | null;
+  getNativeAgentLoopStatePath(): string | null;
+  getProviderConfigBaseDir(): string;
+  getSetupSecretIntake(): SetupSecretIntakeResult | null;
+  getTurnLanguageHint(): TurnLanguageHint;
+  setPendingSetupDialogue(dialogue: SetupDialogueRuntimeState | null): Promise<void>;
+  getPendingSetupDialogue(): SetupDialogueRuntimeState | null;
+  setPendingRunSpecConfirmation(confirmation: RunSpecConfirmationState | null): Promise<void>;
+  getPendingRunSpecConfirmation(): RunSpecConfirmationState | null;
+  getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
+  setSessionExecutionPolicy(policy: ExecutionPolicy): void;
+}

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -13,12 +13,12 @@ import {
   formatToolActivity,
 } from "./chat-runner-support.js";
 import type { ChatUsageCounter } from "./chat-history.js";
-import type { ChatRunResult, ChatRunnerDeps, RuntimeControlChatContext } from "./chat-runner.js";
+import type { ChatRunResult, ChatRunnerRouteHost, RuntimeControlChatContext } from "./chat-runner-contracts.js";
 import type { SelectedChatRoute } from "./ingress-router.js";
 import type { ChatEventContext } from "./chat-events.js";
 import type { AgentLoopSessionState } from "../../orchestrator/execution/agent-loop/agent-loop-session-state.js";
 import { resolveExecutionPolicy, type ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
-import type { AssistantBuffer, ChatRunnerEventBridge } from "./chat-runner-event-bridge.js";
+import type { AssistantBuffer } from "./chat-runner-event-bridge.js";
 import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
 import { createGatewaySetupStatusProvider, type TelegramSetupStatus } from "./gateway-setup-status.js";
 import {
@@ -40,24 +40,6 @@ import { buildStaticSystemPrompt } from "./grounding.js";
 const DEFAULT_TIMEOUT_MS = 120_000;
 const MAX_VERIFY_RETRIES = 2;
 const MAX_TOOL_LOOPS = 5;
-
-export interface ChatRunnerRouteHost {
-  deps: ChatRunnerDeps;
-  eventBridge: ChatRunnerEventBridge;
-  activatedTools: Set<string>;
-  getConversationSessionId(): string | null;
-  getSessionCwd(): string | null;
-  getNativeAgentLoopStatePath(): string | null;
-  getProviderConfigBaseDir(): string;
-  getSetupSecretIntake(): SetupSecretIntakeResult | null;
-  getTurnLanguageHint(): TurnLanguageHint;
-  setPendingSetupDialogue(dialogue: SetupDialogueRuntimeState | null): Promise<void>;
-  getPendingSetupDialogue(): SetupDialogueRuntimeState | null;
-  setPendingRunSpecConfirmation(confirmation: RunSpecConfirmationState | null): Promise<void>;
-  getPendingRunSpecConfirmation(): RunSpecConfirmationState | null;
-  getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
-  setSessionExecutionPolicy(policy: ExecutionPolicy): void;
-}
 
 export async function executeRuntimeControlRoute(
   host: ChatRunnerRouteHost,

--- a/src/interface/chat/chat-runner-runtime.ts
+++ b/src/interface/chat/chat-runner-runtime.ts
@@ -13,7 +13,7 @@ import type {
   RuntimeSessionRegistryWarning,
 } from "../../runtime/session-registry/types.js";
 import type { RuntimeControlActor, RuntimeControlReplyTarget } from "../../runtime/store/runtime-operation-schemas.js";
-import type { RuntimeControlChatContext } from "./chat-runner.js";
+import type { RuntimeControlChatContext } from "./chat-runner-contracts.js";
 import type { LoadedChatSession } from "./chat-session-store.js";
 import type { StateManager } from "../../base/state/state-manager.js";
 

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -4,8 +4,6 @@
 // Bypasses TaskLifecycle — calls adapter.execute() directly.
 
 import type { StateManager } from "../../base/state/state-manager.js";
-import type { IAdapter } from "../../orchestrator/execution/adapter-layer.js";
-import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { getPulseedDirPath } from "../../base/utils/paths.js";
 import { ChatHistory, type ChatSession } from "./chat-history.js";
 import {
@@ -14,26 +12,12 @@ import {
   type LoadedChatSession,
 } from "./chat-session-store.js";
 import { buildChatContext, resolveGitRoot } from "../../platform/observation/context-provider.js";
-import type { EscalationHandler } from "./escalation.js";
 import { buildChatAgentLoopSystemPrompt, buildStaticSystemPrompt, createChatGroundingGateway } from "./grounding.js";
 import type { GroundingGateway } from "../../grounding/gateway.js";
-import type { ApprovalLevel } from "./mutation-tool-defs.js";
-import type { ToolRegistry } from "../../tools/registry.js";
-import type { ToolExecutor } from "../../tools/executor.js";
-import type { DaemonClient } from "../../runtime/daemon/client.js";
-import type { GatewaySetupStatusProvider } from "./gateway-setup-status.js";
-import type { GoalNegotiator } from "../../orchestrator/goal/goal-negotiator.js";
 import type { ChatEventHandler } from "./chat-events.js";
-import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
-import type { ReviewAgentLoopRunner } from "../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
-import type { RuntimeControlService } from "../../runtime/control/index.js";
-import type { ApprovalBroker } from "../../runtime/approval-broker.js";
 import { classifyRuntimeControlIntent } from "../../runtime/control/index.js";
 import { classifyConfirmationDecision } from "../../runtime/confirmation-decision.js";
-import type {
-  RuntimeControlActor,
-  RuntimeControlReplyTarget,
-} from "../../runtime/store/runtime-operation-schemas.js";
+import type { RuntimeControlReplyTarget } from "../../runtime/store/runtime-operation-schemas.js";
 import type { RuntimeReplyTarget } from "../../runtime/session-registry/types.js";
 import type { ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 import {
@@ -45,9 +29,15 @@ import { classifyInterruptRedirect, collectGitDiffArtifact, previewActivityText 
 import {
   COMMAND_HELP,
   ChatRunnerCommandHandler,
-  type PendingTendState,
 } from "./chat-runner-commands.js";
 import { ChatRunnerEventBridge, type AssistantBuffer } from "./chat-runner-event-bridge.js";
+import type {
+  ChatRunResult,
+  ChatRunnerDeps,
+  ChatRunnerExecutionOptions,
+  PendingTendState,
+  RuntimeControlChatContext,
+} from "./chat-runner-contracts.js";
 import { intakeSetupSecrets } from "./setup-secret-intake.js";
 import {
   isSetupWriteConfirmCommand,
@@ -92,57 +82,12 @@ import {
   type RunSpec,
 } from "../../runtime/run-spec/index.js";
 
-export interface ChatRunnerDeps {
-  stateManager: StateManager;
-  adapter: IAdapter;
-  llmClient?: ILLMClient;
-  escalationHandler?: EscalationHandler;
-  trustManager?: { getBalance(domain: string): Promise<{ balance: number }>; setOverride?(domain: string, balance: number, reason: string): Promise<void> };
-  pluginLoader?: { loadAll(): Promise<Array<{ name: string; type?: string; enabled?: boolean }>> };
-  approvalFn?: (description: string) => Promise<boolean>;
-  goalId?: string;
-  approvalConfig?: Record<string, ApprovalLevel>;
-  toolExecutor?: ToolExecutor;
-  registry?: ToolRegistry;
-  onToolStart?: (toolName: string, args: Record<string, unknown>) => void;
-  onToolEnd?: (toolName: string, result: { success: boolean; summary: string; durationMs: number }) => void;
-  daemonClient?: DaemonClient;
-  goalNegotiator?: GoalNegotiator;
-  onNotification?: (message: string) => void;
-  daemonBaseUrl?: string;
-  onEvent?: ChatEventHandler;
-  chatAgentLoopRunner?: ChatAgentLoopRunner;
-  reviewAgentLoopRunner?: Pick<ReviewAgentLoopRunner, "execute">;
-  runtimeControlService?: Pick<RuntimeControlService, "request">;
-  approvalBroker?: Pick<
-    ApprovalBroker,
-    "requestConversationalApproval" | "resolveConversationalApproval" | "findPendingConversationalApproval"
-  >;
-  runtimeControlApprovalFn?: (description: string) => Promise<boolean>;
-  runtimeReplyTarget?: RuntimeControlReplyTarget;
-  runtimeControlActor?: RuntimeControlActor;
-  gatewaySetupStatusProvider?: GatewaySetupStatusProvider;
-}
-
-export interface ChatRunResult {
-  success: boolean;
-  output: string;
-  elapsed_ms: number;
-}
-
-export interface RuntimeControlChatContext {
-  replyTarget?: RuntimeControlReplyTarget;
-  actor?: RuntimeControlActor;
-  approvalFn?: (description: string) => Promise<boolean>;
-  allowed?: boolean;
-  approvalMode?: "interactive" | "preapproved" | "disallowed";
-}
-
-export interface ChatRunnerExecutionOptions {
-  selectedRoute?: SelectedChatRoute;
-  runtimeControlContext?: RuntimeControlChatContext | null;
-  goalId?: string;
-}
+export type {
+  ChatRunResult,
+  ChatRunnerDeps,
+  ChatRunnerExecutionOptions,
+  RuntimeControlChatContext,
+} from "./chat-runner-contracts.js";
 
 const DEFAULT_TIMEOUT_MS = 120_000;
 

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as path from "node:path";
 import { ChatRunner } from "./chat-runner.js";
-import type { ChatRunResult, ChatRunnerDeps } from "./chat-runner.js";
+import type { ChatRunResult, ChatRunnerDeps } from "./chat-runner-contracts.js";
 import type { ChatEvent, ChatEventHandler } from "./chat-events.js";
 import {
   createIngressRouter,

--- a/src/interface/chat/gateway-setup-status.ts
+++ b/src/interface/chat/gateway-setup-status.ts
@@ -2,7 +2,15 @@ import * as path from "node:path";
 import { readJsonFileOrNull } from "../../base/utils/json-io.js";
 import { getGatewayChannelDir, getPulseedDirPath } from "../../base/utils/paths.js";
 import { isDaemonRunning } from "../../runtime/daemon/client.js";
-import type { TelegramGatewayConfig } from "../../runtime/gateway/telegram-gateway-adapter.js";
+
+interface TelegramGatewaySetupConfig {
+  bot_token?: string;
+  chat_id?: number;
+  allow_all?: boolean;
+  allowed_user_ids?: unknown[];
+  runtime_control_allowed_user_ids?: unknown[];
+  identity_key?: string;
+}
 
 export type TelegramSetupState = "unconfigured" | "partially_configured" | "configured";
 
@@ -42,7 +50,7 @@ export function createGatewaySetupStatusProvider(
   return {
     async getTelegramStatus(baseDir = getPulseedDirPath()): Promise<TelegramSetupStatus> {
       const configPath = path.join(getGatewayChannelDir("telegram-bot", baseDir), "config.json");
-      const config = await readJsonFileOrNull<Partial<TelegramGatewayConfig>>(configPath);
+      const config = await readJsonFileOrNull<TelegramGatewaySetupConfig>(configPath);
       const daemon = await (deps.daemonStatus ?? isDaemonRunning)(baseDir);
       const hasBotToken = typeof config?.bot_token === "string" && config.bot_token.trim().length > 0;
       const hasHomeChat = typeof config?.chat_id === "number";

--- a/src/interface/chat/setup-config-write.ts
+++ b/src/interface/chat/setup-config-write.ts
@@ -1,12 +1,27 @@
 import { getGatewayChannelDir } from "../../base/utils/paths.js";
 import { readJsonFileOrNull, writeJsonFileAtomic } from "../../base/utils/json-io.js";
-import type { TelegramGatewayConfig } from "../../runtime/gateway/telegram-gateway-adapter.js";
 import type { RuntimeControlService } from "../../runtime/control/index.js";
 import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
 } from "../../runtime/store/runtime-operation-schemas.js";
 import type { SetupDialogueRuntimeState } from "./setup-dialogue.js";
+
+interface TelegramGatewayConfig {
+  bot_token: string;
+  chat_id?: number;
+  allowed_user_ids: unknown[];
+  denied_user_ids: unknown[];
+  allowed_chat_ids: unknown[];
+  denied_chat_ids: unknown[];
+  runtime_control_allowed_user_ids: unknown[];
+  chat_goal_map: Record<string, unknown>;
+  user_goal_map: Record<string, unknown>;
+  default_goal_id?: string;
+  allow_all: boolean;
+  polling_timeout: number;
+  identity_key?: string;
+}
 
 export interface TelegramGatewayConfigWriteRequest {
   pending: SetupDialogueRuntimeState;


### PR DESCRIPTION
Closes #1043

## Summary
- Extract ChatRunner shared route/command contracts into `chat-runner-contracts.ts`.
- Update runner, route, command, runtime helper, cross-platform session, and test type imports to depend on the contract module instead of runner implementation modules.
- Remove chat setup helper type imports from runtime gateway adapter shapes so `src/interface/chat` has no madge cycles.

## Verification
- `npm run typecheck`
- `npx vitest run src/interface/chat/__tests__/chat-runner.test.ts --config vitest.unit.config.ts`
- `npx vitest run src/interface/chat/__tests__/chat-boundary-contract.test.ts --config vitest.unit.config.ts`
- `npx madge --circular --extensions ts,tsx --ts-config tsconfig.json src/interface/chat`

## Known unresolved risks
- No known unresolved risks. This is intended to be behavior-preserving contract extraction only.
