### PR TITLE
refactor(runtime-gateway): add chat dispatch port

### DIFF
--- a/src/interface/chat/cross-platform-session-global.ts
+++ b/src/interface/chat/cross-platform-session-global.ts
@@ -1,27 +1,22 @@
-export type GlobalCrossPlatformChatSessionManagerGetter = () => Promise<unknown>;
+import {
+  clearRegisteredGatewayChatSessionPort,
+  exposeRegisteredGatewayChatSessionPort,
+  registerGatewayChatSessionPort,
+  type GatewayChatSessionPortGetter,
+} from "../../runtime/gateway/chat-session-port.js";
 
-interface PulseedRuntimeGlobal {
-  __pulseedGetGlobalCrossPlatformChatSessionManager?: GlobalCrossPlatformChatSessionManagerGetter;
-}
-
-let registeredGetter: GlobalCrossPlatformChatSessionManagerGetter | undefined;
+export type GlobalCrossPlatformChatSessionManagerGetter = GatewayChatSessionPortGetter;
 
 export function registerGlobalCrossPlatformChatSessionManager(
   getter: GlobalCrossPlatformChatSessionManagerGetter,
 ): void {
-  registeredGetter = getter;
+  registerGatewayChatSessionPort(getter);
 }
 
 export function exposeRegisteredCrossPlatformChatSessionManager(): void {
-  const runtimeGlobal = globalThis as typeof globalThis & PulseedRuntimeGlobal;
-  if (registeredGetter) {
-    runtimeGlobal.__pulseedGetGlobalCrossPlatformChatSessionManager = registeredGetter;
-    return;
-  }
-  delete runtimeGlobal.__pulseedGetGlobalCrossPlatformChatSessionManager;
+  exposeRegisteredGatewayChatSessionPort();
 }
 
 export function clearRegisteredCrossPlatformChatSessionManager(): void {
-  registeredGetter = undefined;
-  delete (globalThis as typeof globalThis & PulseedRuntimeGlobal).__pulseedGetGlobalCrossPlatformChatSessionManager;
+  clearRegisteredGatewayChatSessionPort();
 }

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -30,6 +30,8 @@ import { NotificationDispatcher } from "../../../runtime/notification-dispatcher
 import { getNotificationConfigPath, loadNotificationConfig } from "../../../runtime/notification-routing.js";
 import { getProviderRuntimeFingerprint } from "../../../base/llm/provider-config.js";
 import { buildDeps } from "../setup.js";
+import { getGlobalCrossPlatformChatSessionManager } from "../../chat/cross-platform-session.js";
+import { registerGlobalCrossPlatformChatSessionManager } from "../../chat/cross-platform-session-global.js";
 import { formatOperationError } from "../utils.js";
 import { getCliLogger } from "../cli-logger.js";
 import { getPulseedDirPath, getLogsDir, getEventsDir } from "../../../base/utils/paths.js";
@@ -296,6 +298,7 @@ export async function cmdStart(
   };
 
   const pluginLoader = await loadPluginsIntoDeps(deps);
+  registerGlobalCrossPlatformChatSessionManager(getGlobalCrossPlatformChatSessionManager);
   const daemonBaseDir = deps.stateManager.getBaseDir();
   const notificationConfig = await loadNotificationConfig(getNotificationConfigPath(daemonBaseDir));
   const notificationDispatcher = new NotificationDispatcher(notificationConfig, notifierRegistry);

--- a/src/runtime/gateway/__tests__/ingress-runtime-control-contract.test.ts
+++ b/src/runtime/gateway/__tests__/ingress-runtime-control-contract.test.ts
@@ -11,6 +11,11 @@ import { RuntimeOperationStore } from "../../store/runtime-operation-store.js";
 import type { Envelope } from "../../types/envelope.js";
 import { createEnvelope } from "../../types/envelope.js";
 import type { ChannelAdapter, EnvelopeHandler, ReplyChannel } from "../channel-adapter.js";
+import { dispatchGatewayChatInput } from "../chat-session-dispatch.js";
+import {
+  clearRegisteredGatewayChatSessionPort,
+  registerGatewayChatSessionPort,
+} from "../chat-session-port.js";
 import { IngressGateway } from "../ingress-gateway.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 
@@ -103,12 +108,13 @@ describe("IngressGateway runtime-control contract", () => {
         ]),
         runtimeControlService,
       }));
+      registerGatewayChatSessionPort(async () => manager);
 
       gateway.registerAdapter(adapter);
       gateway.onEnvelope(async (envelope) => {
         const payload = envelope.payload as Record<string, unknown>;
         const metadata = (envelope as Envelope & { metadata?: Record<string, unknown> }).metadata ?? {};
-        await manager.processIncomingMessage({
+        await dispatchGatewayChatInput({
           text: String(payload["text"] ?? ""),
           platform: String(payload["platform"] ?? envelope.source),
           identity_key: String(payload["identity_key"] ?? ""),
@@ -200,6 +206,7 @@ describe("IngressGateway runtime-control contract", () => {
       expect(daemonRestart?.reply_target.platform).not.toBe(gatewayRestart?.reply_target.platform);
       expect(daemonRestart?.reply_target.conversation_id).not.toBe(gatewayRestart?.reply_target.conversation_id);
     } finally {
+      clearRegisteredGatewayChatSessionPort();
       cleanupTempDir(tmpDir);
     }
   });

--- a/src/runtime/gateway/chat-event-rendering.ts
+++ b/src/runtime/gateway/chat-event-rendering.ts
@@ -1,0 +1,100 @@
+interface OperationProgressItemLike {
+  title: string;
+  detail?: string;
+}
+
+interface FailureRecoveryGuidanceLike {
+  label: string;
+  summary: string;
+  nextActions: string[];
+}
+
+interface AgentTimelineItemLike {
+  kind: "lifecycle" | "turn_context" | "model_request" | "assistant_message" | "tool" | "plan" | "approval" | "compaction" | "activity_summary" | "final" | "stopped";
+  status?: string;
+  restoredMessages?: number;
+  fromUpdatedAt?: string;
+  model?: string;
+  visibleTools?: unknown[];
+  toolCount?: number;
+  text?: string;
+  inputPreview?: string;
+  outputPreview?: string;
+  success?: boolean;
+  toolName?: string;
+  summary?: string;
+  reason?: string;
+  phase?: string;
+  inputMessages?: number;
+  outputMessages?: number;
+  reasonDetail?: string;
+}
+
+export function renderGatewayOperationProgress(item: OperationProgressItemLike): string {
+  return redactSetupSecrets(`${item.title}${item.detail ? `: ${item.detail}` : ""}`);
+}
+
+export function renderGatewayAgentTimelineItem(item: AgentTimelineItemLike): string {
+  switch (item.kind) {
+    case "lifecycle":
+      if (item.status === "resumed") {
+        return `Resumed ${item.restoredMessages ?? 0} message(s) from ${item.fromUpdatedAt ?? "saved state"}.`;
+      }
+      return "Started work.";
+    case "turn_context":
+      return `Prepared turn context with ${item.model ?? "model"} and ${item.visibleTools?.length ?? 0} tool(s).`;
+    case "model_request":
+      return `Asked ${item.model ?? "model"} for the next step with ${item.toolCount ?? 0} available tool(s).`;
+    case "assistant_message":
+      return redactSetupSecrets(item.text ?? "");
+    case "tool": {
+      const detail = item.status === "started" ? item.inputPreview : item.outputPreview;
+      const label = item.status === "started" ? "Started" : item.success ? "Finished" : "Failed";
+      return detail ? `${label} ${item.toolName ?? "tool"}: ${redactSetupSecrets(detail)}` : `${label} ${item.toolName ?? "tool"}.`;
+    }
+    case "plan":
+      return `Plan changed: ${redactSetupSecrets(item.summary ?? "")}`;
+    case "approval":
+      return item.status === "requested"
+        ? `Approval requested for ${item.toolName ?? "tool"}: ${redactSetupSecrets(item.reason ?? "")}`
+        : `Approval denied for ${item.toolName ?? "tool"}: ${redactSetupSecrets(item.reason ?? "")}`;
+    case "compaction":
+      return `Compacted context (${item.phase ?? "unknown"}, ${item.reason ?? "unknown"}): ${item.inputMessages ?? 0} -> ${item.outputMessages ?? 0}.`;
+    case "activity_summary":
+      return redactSetupSecrets(item.text ?? "");
+    case "final":
+      return redactSetupSecrets(item.outputPreview ?? "");
+    case "stopped":
+      return item.reasonDetail ? `Stopped: ${item.reason ?? "unknown"} (${redactSetupSecrets(item.reasonDetail)})` : `Stopped: ${item.reason ?? "unknown"}`;
+  }
+}
+
+export function formatGatewayLifecycleFailureMessage(
+  error: string,
+  partialText: string,
+  guidance: FailureRecoveryGuidanceLike,
+): string {
+  const normalizedPartial = partialText.trim();
+  const normalizedError = error.trim();
+  const base = normalizedPartial && normalizedPartial !== normalizedError
+    ? `${partialText}\n\n[interrupted: ${error}]`
+    : normalizedPartial || `Error: ${error}`;
+  return `${base}\n\n${formatFailureRecovery(guidance)}`;
+}
+
+function formatFailureRecovery(guidance: FailureRecoveryGuidanceLike): string {
+  return [
+    "Recovery",
+    `Type: ${guidance.label}`,
+    guidance.summary,
+    "Next actions:",
+    ...guidance.nextActions.map((action) => `- ${action}`),
+  ].join("\n");
+}
+
+function redactSetupSecrets(value: string): string {
+  return value
+    .replace(/bot_token=([^\s&]+)/gi, "bot_token=[REDACTED:token]")
+    .replace(/([?&]token=)([^&\s]+)/gi, "$1[REDACTED:token]")
+    .replace(/(xox[baprs]-)[A-Za-z0-9-]+/g, "$1[REDACTED:token]");
+}

--- a/src/runtime/gateway/chat-session-dispatch.ts
+++ b/src/runtime/gateway/chat-session-dispatch.ts
@@ -1,25 +1,18 @@
-import type { ChatEventHandler } from "../../interface/chat/chat-events.js";
-import { getGlobalCrossPlatformChatSessionManager } from "../../interface/chat/cross-platform-session.js";
+import {
+  getRegisteredGatewayChatSessionPort,
+  type GatewayChatDispatchInput,
+} from "./chat-session-port.js";
 
-export interface GatewayChatDispatchInput {
-  text: string;
-  platform: string;
-  identity_key?: string;
-  conversation_id: string;
-  sender_id: string;
-  message_id?: string;
-  goal_id?: string;
-  cwd?: string;
-  metadata?: Record<string, unknown>;
-  onEvent?: ChatEventHandler;
-}
+export type { GatewayChatDispatchInput } from "./chat-session-port.js";
 
 export async function dispatchGatewayChatInput(
   input: GatewayChatDispatchInput
 ): Promise<string | null> {
   try {
-    const manager = await getGlobalCrossPlatformChatSessionManager();
-    const result = await manager.processIncomingMessage({
+    const portGetter = getRegisteredGatewayChatSessionPort();
+    if (!portGetter) return null;
+    const port = await portGetter();
+    const result = await port.processIncomingMessage({
       text: input.text,
       platform: input.platform,
       identity_key: input.identity_key,

--- a/src/runtime/gateway/chat-session-port.ts
+++ b/src/runtime/gateway/chat-session-port.ts
@@ -1,0 +1,48 @@
+export type GatewayChatEventHandler = <T extends { type?: unknown; text?: unknown }>(event: T) => void | Promise<void>;
+
+export interface GatewayChatDispatchInput {
+  text: string;
+  platform: string;
+  identity_key?: string;
+  conversation_id: string;
+  sender_id: string;
+  message_id?: string;
+  goal_id?: string;
+  cwd?: string;
+  metadata?: Record<string, unknown>;
+  onEvent?: GatewayChatEventHandler;
+}
+
+export interface GatewayChatSessionPort {
+  processIncomingMessage(input: GatewayChatDispatchInput): Promise<unknown>;
+}
+
+export type GatewayChatSessionPortGetter = () => Promise<GatewayChatSessionPort>;
+
+interface PulseedRuntimeGlobal {
+  __pulseedGetGlobalCrossPlatformChatSessionManager?: GatewayChatSessionPortGetter;
+}
+
+let registeredGetter: GatewayChatSessionPortGetter | undefined;
+
+export function registerGatewayChatSessionPort(getter: GatewayChatSessionPortGetter): void {
+  registeredGetter = getter;
+}
+
+export function getRegisteredGatewayChatSessionPort(): GatewayChatSessionPortGetter | undefined {
+  return registeredGetter;
+}
+
+export function exposeRegisteredGatewayChatSessionPort(): void {
+  const runtimeGlobal = globalThis as typeof globalThis & PulseedRuntimeGlobal;
+  if (registeredGetter) {
+    runtimeGlobal.__pulseedGetGlobalCrossPlatformChatSessionManager = registeredGetter;
+    return;
+  }
+  delete runtimeGlobal.__pulseedGetGlobalCrossPlatformChatSessionManager;
+}
+
+export function clearRegisteredGatewayChatSessionPort(): void {
+  registeredGetter = undefined;
+  delete (globalThis as typeof globalThis & PulseedRuntimeGlobal).__pulseedGetGlobalCrossPlatformChatSessionManager;
+}

--- a/src/runtime/gateway/slack-channel-adapter.ts
+++ b/src/runtime/gateway/slack-channel-adapter.ts
@@ -250,7 +250,7 @@ export class SlackChannelAdapter implements ChannelAdapter {
       goal_id: input.goalId,
       cwd: process.cwd(),
       onEvent: (event) => {
-        if (event.type === "assistant_final") {
+        if (event.type === "assistant_final" && typeof event.text === "string") {
           return sendReply(event.text).catch((err: unknown) => {
             console.warn("SlackChannelAdapter: failed to send assistant event", err);
           });

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -4,11 +4,12 @@ import type { ChannelAdapter, EnvelopeHandler, TypingIndicatorCapability } from 
 import { dispatchGatewayChatInput } from "./chat-session-dispatch.js";
 import { formatTelegramNotification, supportsCoreGatewayNotification } from "./core-channel-notification.js";
 import { writeJsonFileAtomic } from "../../base/utils/json-io.js";
-import type { ChatEvent } from "../../interface/chat/chat-events.js";
-import { renderOperationProgress } from "../../interface/chat/operation-progress.js";
-import { formatLifecycleFailureMessage } from "../../interface/chat/failure-recovery.js";
-import { renderAgentTimelineItemForChat } from "../../interface/chat/chat-event-state.js";
 import { evaluateChannelAccess, resolveChannelRoute } from "./channel-policy.js";
+import {
+  formatGatewayLifecycleFailureMessage,
+  renderGatewayAgentTimelineItem,
+  renderGatewayOperationProgress,
+} from "./chat-event-rendering.js";
 import { createRefreshingTypingIndicator, withTypingIndicator } from "./typing-indicator.js";
 import type { INotifier, NotificationEvent, NotificationEventType } from "../../base/types/plugin.js";
 
@@ -217,7 +218,12 @@ export class TelegramGatewayAdapter implements ChannelAdapter {
         message_id: String(messageId),
         goal_id: route.goalId,
         cwd: process.cwd(),
-        onEvent: (event) => eventAdapter.handle(event),
+        onEvent: (event) => {
+          if (isGatewayChatEvent(event)) {
+            return eventAdapter.handle(event);
+          }
+          return undefined;
+        },
         metadata: {
           ...route.metadata,
           chat_id: chatId,
@@ -407,7 +413,7 @@ class TelegramChatEventAdapter {
     return this.hasAssistantOutput;
   }
 
-  async handle(event: ChatEvent): Promise<void> {
+  async handle(event: GatewayChatEvent): Promise<void> {
     switch (event.type) {
       case "lifecycle_start":
         this.assistantMessage = null;
@@ -427,11 +433,11 @@ class TelegramChatEventAdapter {
         return;
       case "operation_progress":
         if (event.item.metadata?.["source"] === "agent_timeline_activity_summary") return;
-        await this.upsertActivityMessage(event.item.id, renderOperationProgress(event.item));
+        await this.upsertActivityMessage(event.item.id, renderGatewayOperationProgress(event.item));
         return;
       case "agent_timeline": {
         if (event.item.visibility !== "user") return;
-        const text = renderAgentTimelineItemForChat(event.item).trim();
+        const text = renderGatewayAgentTimelineItem(event.item).trim();
         if (!text) return;
         if (event.item.kind === "final") {
           this.hasAssistantOutput = true;
@@ -456,7 +462,7 @@ class TelegramChatEventAdapter {
         );
         return;
       case "lifecycle_error":
-        await this.sendFinalFallback(formatLifecycleFailureMessage(event.error, event.partialText, event.recovery));
+        await this.sendFinalFallback(formatGatewayLifecycleFailureMessage(event.error, event.partialText, event.recovery));
         return;
       case "lifecycle_end":
         return;
@@ -512,6 +518,64 @@ class TelegramChatEventAdapter {
     await this.api.editMessageText(this.chatId, existing.messageId, text);
     existing.text = text;
   }
+}
+
+type GatewayChatEvent =
+  | { type: "lifecycle_start" }
+  | { type: "assistant_delta"; text: string }
+  | { type: "assistant_final"; text: string }
+  | { type: "activity"; kind: string; sourceId?: string; message: string }
+  | {
+      type: "operation_progress";
+      item: {
+        id: string;
+        title: string;
+        detail?: string;
+        metadata?: Record<string, unknown>;
+      };
+    }
+  | {
+      type: "agent_timeline";
+      item: {
+        visibility?: string;
+        kind: "lifecycle" | "turn_context" | "model_request" | "assistant_message" | "tool" | "plan" | "approval" | "compaction" | "activity_summary" | "final" | "stopped";
+        status?: string;
+        restoredMessages?: number;
+        fromUpdatedAt?: string;
+        model?: string;
+        visibleTools?: unknown[];
+        toolCount?: number;
+        text?: string;
+        inputPreview?: string;
+        outputPreview?: string;
+        success?: boolean;
+        toolName?: string;
+        summary?: string;
+        reason?: string;
+        phase?: string;
+        inputMessages?: number;
+        outputMessages?: number;
+        reasonDetail?: string;
+        sourceEventId: string;
+      };
+    }
+  | { type: "tool_start"; presentation?: { suppressTranscript?: boolean }; toolCallId: string; toolName: string }
+  | { type: "tool_update"; presentation?: { suppressTranscript?: boolean }; toolCallId: string; toolName: string; status: string; message: string }
+  | { type: "tool_end"; presentation?: { suppressTranscript?: boolean }; toolCallId: string; toolName: string; success: boolean; summary: string }
+  | {
+      type: "lifecycle_error";
+      error: string;
+      partialText: string;
+      recovery: {
+        label: string;
+        summary: string;
+        nextActions: string[];
+      };
+    }
+  | { type: "lifecycle_end" };
+
+function isGatewayChatEvent(event: { type?: unknown }): event is GatewayChatEvent {
+  return typeof event.type === "string";
 }
 
 function loadTelegramGatewayConfig(pluginDir: string): TelegramGatewayConfig {

--- a/src/runtime/plugin-loader.ts
+++ b/src/runtime/plugin-loader.ts
@@ -5,7 +5,7 @@ import { getPluginsDir } from "../base/utils/paths.js";
 import { getPulseedVersion as getPackageVersion } from "../base/utils/pulseed-meta.js";
 import { writeJsonFileAtomic } from "../base/utils/json-io.js";
 import { ValidationError } from "../base/utils/errors.js";
-import { exposeRegisteredCrossPlatformChatSessionManager } from "../interface/chat/cross-platform-session-global.js";
+import { exposeRegisteredGatewayChatSessionPort } from "./gateway/chat-session-port.js";
 import type { Logger } from "./logger.js";
 import {
   PluginManifestSchema,
@@ -104,7 +104,7 @@ export class PluginLoader {
     }
 
     // 2. Dynamically import the entry point
-    exposeRegisteredCrossPlatformChatSessionManager();
+    exposeRegisteredGatewayChatSessionPort();
     const entryPath = path.resolve(pluginDir, manifest.entry_point);
     if (!entryPath.startsWith(pluginDir + path.sep) && entryPath !== pluginDir) {
       throw new ValidationError(`Plugin entry point escapes plugin directory: ${manifest.entry_point}`);


### PR DESCRIPTION
Closes #1045

## Summary
- Introduce a runtime-owned gateway chat session dispatch port and move `chat-session-dispatch` off direct `interface/chat/cross-platform-session` imports.
- Keep the interface global registration API as a compatibility wrapper over the runtime gateway port, and register the concrete chat manager from daemon startup composition.
- Move Telegram gateway event rendering off interface/chat helper imports while preserving dispatch payloads and fallback behavior.
- Update the gateway runtime-control contract test so `IngressGateway` exercises `dispatchGatewayChatInput` through the registered port.

## Verification
- `npm run typecheck`
- `rg -n 'from ".*interface/' src/runtime src/platform src/orchestrator`
- `npx vitest run src/runtime/gateway/__tests__/ingress-runtime-control-contract.test.ts src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts src/runtime/gateway/__tests__/slack-channel-adapter.test.ts src/runtime/gateway/__tests__/discord-gateway-adapter.test.ts src/runtime/gateway/__tests__/whatsapp-gateway-adapter.test.ts --config vitest.integration.config.ts`
- `npx vitest run src/runtime/__tests__/plugin-loader.test.ts --config vitest.integration.config.ts`
- `npx vitest run src/interface/chat/__tests__/cross-platform-session.test.ts --config vitest.unit.config.ts`
- `npx madge --circular --extensions ts,tsx --ts-config tsconfig.json src`

## Known unresolved risks
- `madge src` still reports two pre-existing cycles outside this change: `platform/drive/stall-detector.ts > platform/drive/stall-detector/repetitive.ts` and `orchestrator/loop/durable-loop/task-cycle.ts > orchestrator/loop/durable-loop/task-cycle-stall.ts`.
- `rg -n 'from ".*interface/' src/runtime src/platform src/orchestrator` still reports existing non-gateway production imports in `runtime/session-registry`, `runtime/logger`, and `orchestrator/execution/agent-loop/agent-loop-trace-store`, plus test imports. This PR removes the runtime gateway production dependency on interface/chat.
