### PR TITLE
refactor(tui): extract input action resolver

### DIFF
--- a/src/interface/tui/__tests__/input-action.test.ts
+++ b/src/interface/tui/__tests__/input-action.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { resolveTuiInputAction } from "../input-action.js";
+
+const chatRunnerSlash = (input: string): boolean => input.trim().toLowerCase().split(/\s+/)[0] === "/status";
+
+function baseContext(overrides: Partial<Parameters<typeof resolveTuiInputAction>[1]> = {}): Parameters<typeof resolveTuiInputAction>[1] {
+  return {
+    isProcessing: false,
+    hasChatRunner: true,
+    hasPendingRunSpec: false,
+    hasStandaloneSlashHandlers: true,
+    isDaemonMode: false,
+    daemonGoalId: null,
+    isChatRunnerOwnedSlashCommand: chatRunnerSlash,
+    ...overrides,
+  };
+}
+
+describe("resolveTuiInputAction", () => {
+  it("routes processing input to interrupt redirect only when ChatRunner is available", () => {
+    expect(resolveTuiInputAction("show me the diff", baseContext({ isProcessing: true }))).toMatchObject({
+      kind: "interrupt_redirect",
+    });
+    expect(resolveTuiInputAction("show me the diff", baseContext({ isProcessing: true, hasChatRunner: false }))).toMatchObject({
+      kind: "ignore_processing",
+    });
+  });
+
+  it("keeps shell mode ahead of slash, RunSpec, and freeform routing", () => {
+    expect(resolveTuiInputAction("!pwd", baseContext({
+      hasPendingRunSpec: true,
+      isDaemonMode: true,
+      daemonGoalId: "goal-1",
+    }))).toEqual({
+      kind: "shell",
+      input: "!pwd",
+      command: "pwd",
+    });
+    expect(resolveTuiInputAction("!", baseContext())).toMatchObject({
+      kind: "shell_missing_command",
+    });
+  });
+
+  it("routes ChatRunner-owned slash commands before pending RunSpec and standalone slash handling", () => {
+    expect(resolveTuiInputAction("/status", baseContext({ hasPendingRunSpec: true }))).toMatchObject({
+      kind: "chat_runner_slash",
+    });
+  });
+
+  it("routes pending RunSpec confirmation before generic slash handlers", () => {
+    expect(resolveTuiInputAction("confirm", baseContext({ hasPendingRunSpec: true }))).toMatchObject({
+      kind: "pending_run_spec_confirmation",
+    });
+    expect(resolveTuiInputAction("/start goal-1", baseContext({ hasPendingRunSpec: true }))).toMatchObject({
+      kind: "pending_run_spec_confirmation",
+    });
+  });
+
+  it("routes non-ChatRunner slash commands to standalone handlers before daemon slash handlers", () => {
+    expect(resolveTuiInputAction("/settings", baseContext({ isDaemonMode: true }))).toMatchObject({
+      kind: "standalone_slash",
+      trimmedInput: "/settings",
+    });
+  });
+
+  it("routes daemon slash commands when standalone handlers are unavailable", () => {
+    expect(resolveTuiInputAction("/start goal-1", baseContext({
+      hasStandaloneSlashHandlers: false,
+      isDaemonMode: true,
+    }))).toMatchObject({
+      kind: "daemon_slash",
+      trimmedInput: "/start goal-1",
+    });
+  });
+
+  it("keeps AgentLoop-capable chat surfaces on ChatRunner before daemon goal fallback", () => {
+    expect(resolveTuiInputAction("Run this Kaggle competition", baseContext({
+      isDaemonMode: true,
+      daemonGoalId: "goal-1",
+      hasChatRunner: true,
+    }))).toMatchObject({
+      kind: "freeform",
+      route: "chat_runner",
+    });
+  });
+
+  it("falls back to daemon goal chat only without ChatRunner and with a current daemon goal", () => {
+    expect(resolveTuiInputAction("status?", baseContext({
+      hasChatRunner: false,
+      isDaemonMode: true,
+      daemonGoalId: "goal-current",
+    }))).toMatchObject({
+      kind: "freeform",
+      route: "daemon_goal_chat",
+    });
+  });
+
+  it("rejects stale or missing daemon targets instead of reusing a previous target", () => {
+    expect(resolveTuiInputAction("status?", baseContext({
+      hasChatRunner: false,
+      isDaemonMode: true,
+      daemonGoalId: null,
+    }))).toMatchObject({
+      kind: "freeform",
+      route: "unavailable",
+    });
+  });
+});

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -21,7 +21,12 @@ import { HelpOverlay } from "./help-overlay.js";
 import { SettingsOverlay } from "./settings-overlay.js";
 import { ReportView } from "./report-view.js";
 import { SEEDY_PIXEL } from "./seedy-art.js";
-import { extractBashCommand, formatShellOutput } from "./bash-mode.js";
+import { formatShellOutput } from "./bash-mode.js";
+import {
+  resolveFreeformInputRoute,
+  resolveTuiInputAction,
+  type FreeformInputRoute,
+} from "./input-action.js";
 import type { Report } from "../../base/types/report.js";
 import { useLoop } from "./use-loop.js";
 import type { LoopState } from "./use-loop.js";
@@ -122,25 +127,7 @@ function formatApprovalNotice(task: Task): string {
   ].join("\n");
 }
 
-export type FreeformInputRoute = "daemon_goal_chat" | "chat_runner" | "unavailable";
-
-export function resolveFreeformInputRoute({
-  isDaemonMode,
-  daemonGoalId,
-  hasChatRunner,
-}: {
-  isDaemonMode: boolean;
-  daemonGoalId: string | null;
-  hasChatRunner: boolean;
-}): FreeformInputRoute {
-  if (hasChatRunner) {
-    return "chat_runner";
-  }
-  if (isDaemonMode && daemonGoalId) {
-    return "daemon_goal_chat";
-  }
-  return "unavailable";
-}
+export { resolveFreeformInputRoute, type FreeformInputRoute } from "./input-action.js";
 
 const CHAT_RUNNER_OWNED_COMMANDS = new Set([
   "/resume",
@@ -572,7 +559,21 @@ export function App({
 
   const handleInput = useCallback(
     async (input: string) => {
-      if (isProcessing) {
+      const action = resolveTuiInputAction(input, {
+        isProcessing,
+        hasChatRunner: chatRunner !== undefined,
+        hasPendingRunSpec: pendingRunSpec !== null,
+        hasStandaloneSlashHandlers: intentRecognizer !== undefined && actionHandler !== undefined,
+        isDaemonMode,
+        daemonGoalId: daemonLoopState.goalId,
+        isChatRunnerOwnedSlashCommand,
+      });
+
+      if (action.kind === "ignore_processing") {
+        return;
+      }
+
+      if (action.kind === "interrupt_redirect") {
         if (!chatRunner) return;
         setMessages((prev) => [...prev, { id: randomUUID(), role: "user" as const, text: input, timestamp: new Date() }].slice(-MAX_MESSAGES));
         try {
@@ -595,21 +596,19 @@ export function App({
 
       try {
         // Local-only commands — no LLM round-trip needed
-        const trimmedInput = input.trim().toLowerCase();
-        const bashCommand = extractBashCommand(input);
-        if (bashCommand !== null) {
-          if (!bashCommand) {
-            setMessages((prev) => [...prev, {
-              id: randomUUID(),
-              role: "pulseed" as const,
-              text: "Shell command required after !",
-              timestamp: new Date(),
-              messageType: "warning" as const,
-            }].slice(-MAX_MESSAGES));
-            return;
-          }
+        if (action.kind === "shell_missing_command") {
+          setMessages((prev) => [...prev, {
+            id: randomUUID(),
+            role: "pulseed" as const,
+            text: "Shell command required after !",
+            timestamp: new Date(),
+            messageType: "warning" as const,
+          }].slice(-MAX_MESSAGES));
+          return;
+        }
 
-          const shellInput = { command: bashCommand, cwd: process.cwd(), timeoutMs: 120_000 };
+        if (action.kind === "shell") {
+          const shellInput = { command: action.command, cwd: process.cwd(), timeoutMs: 120_000 };
           const shellTool = new ShellTool();
           const result = await shellTool.call(shellInput, {
             cwd: process.cwd(),
@@ -621,7 +620,7 @@ export function App({
           });
           const shellOutput = result.data as { stdout?: string; stderr?: string; exitCode?: number } | null;
           const text = shellOutput
-            ? formatShellOutput(bashCommand, {
+            ? formatShellOutput(action.command, {
                 stdout: shellOutput.stdout ?? "",
                 stderr: shellOutput.stderr ?? "",
                 exitCode: shellOutput.exitCode ?? (result.success ? 0 : 1),
@@ -638,12 +637,12 @@ export function App({
           return;
         }
 
-        if (chatRunner && isChatRunnerOwnedSlashCommand(input)) {
+        if (action.kind === "chat_runner_slash" && chatRunner) {
           await chatRunner.execute(input, cwd ?? process.cwd());
           return;
         }
 
-        if (pendingRunSpec && chatRunner) {
+        if (action.kind === "pending_run_spec_confirmation" && pendingRunSpec && chatRunner) {
           const effectiveCwd = cwd ?? process.cwd();
           const result = await handleRunSpecConfirmationInput(pendingRunSpec, input, {
             timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -676,7 +675,7 @@ export function App({
 
         // Slash commands go through IntentRecognizer -> ActionHandler (standalone)
         // or through daemon REST API (daemon mode)
-        if (input.startsWith("/") && intentRecognizer && actionHandler) {
+        if (action.kind === "standalone_slash" && intentRecognizer && actionHandler) {
           const intent = await intentRecognizer.recognize(input);
           const result = await actionHandler.handle(intent);
 
@@ -685,7 +684,7 @@ export function App({
             return;
           }
 
-          if (trimmedInput === "/settings" || trimmedInput === "/config") {
+          if (action.trimmedInput === "/settings" || action.trimmedInput === "/config") {
             setShowSettings(true);
             return;
           }
@@ -716,9 +715,9 @@ export function App({
           if (result.stopLoop) {
             stopLoop();
           }
-        } else if (input.startsWith("/") && isDaemonMode) {
+        } else if (action.kind === "daemon_slash") {
           // Daemon mode: handle basic slash commands locally
-          const trimmed = input.trim().toLowerCase();
+          const trimmed = action.trimmedInput;
           if (trimmed === "/help" || trimmed === "/?") {
             setShowHelp(true);
           } else if (trimmed === "/settings" || trimmed === "/config") {
@@ -765,7 +764,7 @@ export function App({
             return;
           }
 
-          const freeformRoute = resolveFreeformInputRoute({
+          const freeformRoute = action.kind === "freeform" ? action.route : resolveFreeformInputRoute({
             isDaemonMode,
             daemonGoalId: daemonLoopState.goalId,
             hasChatRunner: chatRunner !== undefined,

--- a/src/interface/tui/input-action.ts
+++ b/src/interface/tui/input-action.ts
@@ -1,0 +1,84 @@
+import { extractBashCommand } from "./bash-mode.js";
+
+export type FreeformInputRoute = "daemon_goal_chat" | "chat_runner" | "unavailable";
+
+export type TuiInputAction =
+  | { kind: "interrupt_redirect"; input: string }
+  | { kind: "ignore_processing"; input: string }
+  | { kind: "shell"; input: string; command: string }
+  | { kind: "shell_missing_command"; input: string }
+  | { kind: "chat_runner_slash"; input: string }
+  | { kind: "pending_run_spec_confirmation"; input: string }
+  | { kind: "standalone_slash"; input: string; trimmedInput: string }
+  | { kind: "daemon_slash"; input: string; trimmedInput: string }
+  | { kind: "freeform"; input: string; route: FreeformInputRoute };
+
+export interface TuiInputActionContext {
+  isProcessing: boolean;
+  hasChatRunner: boolean;
+  hasPendingRunSpec: boolean;
+  hasStandaloneSlashHandlers: boolean;
+  isDaemonMode: boolean;
+  daemonGoalId: string | null;
+  isChatRunnerOwnedSlashCommand: (input: string) => boolean;
+}
+
+export function resolveFreeformInputRoute({
+  isDaemonMode,
+  daemonGoalId,
+  hasChatRunner,
+}: {
+  isDaemonMode: boolean;
+  daemonGoalId: string | null;
+  hasChatRunner: boolean;
+}): FreeformInputRoute {
+  if (hasChatRunner) {
+    return "chat_runner";
+  }
+  if (isDaemonMode && daemonGoalId) {
+    return "daemon_goal_chat";
+  }
+  return "unavailable";
+}
+
+export function resolveTuiInputAction(input: string, context: TuiInputActionContext): TuiInputAction {
+  if (context.isProcessing) {
+    return context.hasChatRunner
+      ? { kind: "interrupt_redirect", input }
+      : { kind: "ignore_processing", input };
+  }
+
+  const trimmedInput = input.trim().toLowerCase();
+  const bashCommand = extractBashCommand(input);
+  if (bashCommand !== null) {
+    return bashCommand
+      ? { kind: "shell", input, command: bashCommand }
+      : { kind: "shell_missing_command", input };
+  }
+
+  if (context.hasChatRunner && context.isChatRunnerOwnedSlashCommand(input)) {
+    return { kind: "chat_runner_slash", input };
+  }
+
+  if (context.hasPendingRunSpec && context.hasChatRunner) {
+    return { kind: "pending_run_spec_confirmation", input };
+  }
+
+  if (input.startsWith("/") && context.hasStandaloneSlashHandlers) {
+    return { kind: "standalone_slash", input, trimmedInput };
+  }
+
+  if (input.startsWith("/") && context.isDaemonMode) {
+    return { kind: "daemon_slash", input, trimmedInput };
+  }
+
+  return {
+    kind: "freeform",
+    input,
+    route: resolveFreeformInputRoute({
+      isDaemonMode: context.isDaemonMode,
+      daemonGoalId: context.daemonGoalId,
+      hasChatRunner: context.hasChatRunner,
+    }),
+  };
+}


### PR DESCRIPTION
Closes #1046

## Summary
- Extract pure typed `resolveTuiInputAction()` and freeform route resolution into `src/interface/tui/input-action.ts`.
- Update `app.tsx` to resolve the input action once while preserving the existing execution branch bodies and visible behavior.
- Add resolver tests covering processing interrupt redirect, shell priority, ChatRunner slash priority, pending RunSpec priority, standalone/daemon slash routing, AgentLoop-first ChatRunner routing, daemon-goal fallback, unavailable chat, and stale/no-target rejection.

## Verification
- `npm run typecheck`
- `npx vitest run src/interface/tui/__tests__/input-action.test.ts --config vitest.integration.config.ts`
- `npx vitest run src/interface/tui/__tests__/app-routing.test.ts --config vitest.integration.config.ts`
- `npx vitest run src/interface/tui/__tests__/app.test.ts --config vitest.integration.config.ts`
- `npm run tui:test -- --build-only`

## Known unresolved risks
- `npm run tui:test` without a PTY fails in this environment because Ink raw mode is unsupported on the current stdin. With a PTY, it launches the interactive TUI and waits for manual input; I killed it after confirming startup. The build-only TUI test path passed.
