### PR TITLE
Fix gateway approval and runtime-control targeting

### DIFF
--- a/src/interface/chat/__tests__/chat-runner-gateway-runtime-control.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-gateway-runtime-control.test.ts
@@ -627,6 +627,45 @@ describe("ChatRunner gateway runtime-control routes", () => {
       }
     });
 
+    it("routes approved reload_config and self_update through RuntimeControlService", async () => {
+      for (const operation of ["reload_config", "self_update"] as const) {
+        const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `pulseed-runtime-control-${operation}-`));
+        try {
+          const adapter = makeMockAdapter();
+          const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+          const executor = vi.fn().mockResolvedValue({
+            ok: true,
+            state: "verified",
+            message: `${operation} requested`,
+          });
+          const runtimeControlService = new RuntimeControlService({
+            operationStore,
+            executor,
+          });
+          const runtimeControlApprovalFn = vi.fn().mockResolvedValue(true);
+          const runner = new ChatRunner(makeDeps({
+            adapter,
+            llmClient: createSingleMockLLMClient(JSON.stringify({
+              intent: operation,
+              reason: `please ${operation}`,
+            })),
+            runtimeControlApprovalFn,
+            runtimeControlService,
+            runtimeReplyTarget: { surface: "gateway", platform: "telegram" },
+          }));
+
+          const result = await runner.execute(`please ${operation}`, "/repo");
+
+          expect(result).toMatchObject({ success: true, output: `${operation} requested` });
+          expect(runtimeControlApprovalFn).toHaveBeenCalledWith(expect.stringContaining(operation));
+          expect(executor).toHaveBeenCalledWith(expect.objectContaining({ kind: operation }), expect.anything());
+          expect(adapter.execute).not.toHaveBeenCalled();
+        } finally {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+      }
+    });
+
     it("routes natural-language run pause to typed runtime control instead of the adapter", async () => {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-runtime-control-chat-pause-"));
       try {
@@ -677,6 +716,7 @@ describe("ChatRunner gateway runtime-control routes", () => {
           llmClient: createSingleMockLLMClient(JSON.stringify({
             intent: "pause_run",
             reason: "この実行を一時停止して",
+            targetSelector: { scope: "run", reference: "current", sourceText: "この実行" },
           })),
           runtimeControlService,
           runtimeControlApprovalFn: vi.fn().mockResolvedValue(true),
@@ -690,6 +730,99 @@ describe("ChatRunner gateway runtime-control routes", () => {
           kind: "pause_run",
           target: expect.objectContaining({ run_id: "run:coreloop:chat", goal_id: "goal-1" }),
         }), expect.anything());
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("resolves latest and previous natural-language run references through typed target selection", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-runtime-control-target-selector-"));
+      try {
+        const adapter = makeMockAdapter();
+        const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
+        const runtimeControlService = new RuntimeControlService({
+          operationStore,
+          sessionRegistry: {
+            snapshot: vi.fn().mockResolvedValue({
+              schema_version: "runtime-session-registry-v1",
+              generated_at: "2026-05-02T00:20:00.000Z",
+              sessions: [],
+              background_runs: [
+                {
+                  schema_version: "background-run-v1",
+                  id: "run:older",
+                  kind: "coreloop_run",
+                  parent_session_id: null,
+                  child_session_id: "session:coreloop:older",
+                  process_session_id: null,
+                  goal_id: "goal-older",
+                  status: "running",
+                  notify_policy: "done_only",
+                  reply_target_source: "none",
+                  pinned_reply_target: null,
+                  title: "older",
+                  workspace: "/repo",
+                  created_at: "2026-05-02T00:00:00.000Z",
+                  started_at: "2026-05-02T00:00:00.000Z",
+                  updated_at: "2026-05-02T00:00:00.000Z",
+                  completed_at: null,
+                  summary: null,
+                  error: null,
+                  artifacts: [],
+                  source_refs: [],
+                },
+                {
+                  schema_version: "background-run-v1",
+                  id: "run:newer",
+                  kind: "coreloop_run",
+                  parent_session_id: null,
+                  child_session_id: "session:coreloop:newer",
+                  process_session_id: null,
+                  goal_id: "goal-newer",
+                  status: "running",
+                  notify_policy: "done_only",
+                  reply_target_source: "none",
+                  pinned_reply_target: null,
+                  title: "newer",
+                  workspace: "/repo",
+                  created_at: "2026-05-02T00:10:00.000Z",
+                  started_at: "2026-05-02T00:10:00.000Z",
+                  updated_at: "2026-05-02T00:10:00.000Z",
+                  completed_at: null,
+                  summary: null,
+                  error: null,
+                  artifacts: [],
+                  source_refs: [],
+                },
+              ],
+              warnings: [],
+            }),
+          },
+        });
+        const runner = new ChatRunner(makeDeps({
+          adapter,
+          llmClient: createMockLLMClient([
+            JSON.stringify({
+              intent: "inspect_run",
+              reason: "latest session",
+              targetSelector: { scope: "run", reference: "latest", sourceText: "latest session" },
+            }),
+            JSON.stringify({
+              intent: "inspect_run",
+              reason: "前のバックグラウンドジョブ",
+              targetSelector: { scope: "run", reference: "previous", sourceText: "前のバックグラウンドジョブ" },
+            }),
+          ]),
+          runtimeControlService,
+          runtimeControlApprovalFn: vi.fn().mockResolvedValue(true),
+        }));
+
+        await expect(runner.execute("inspect latest session", "/repo")).resolves.toMatchObject({ success: true });
+        await expect(runner.execute("前のバックグラウンドジョブを確認して", "/repo")).resolves.toMatchObject({ success: true });
+
+        const completed = await operationStore.listCompleted();
+        expect(completed.map((operation) => operation.target?.run_id).sort()).toEqual(["run:newer", "run:older"].sort());
+        expect(adapter.execute).not.toHaveBeenCalled();
       } finally {
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -759,6 +759,54 @@ describe("CrossPlatformChatSessionManager", () => {
     expect(adapter.execute).not.toHaveBeenCalled();
   });
 
+  it("fails closed for denied reload_config and self_update runtime-control requests", async () => {
+    for (const operation of ["reload_config", "self_update"] as const) {
+      const stateManager = makeMockStateManager();
+      const adapter = makeMockAdapter();
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "agent loop should not run shell fallback",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
+        }),
+      };
+      const runtimeControlService = {
+        request: vi.fn().mockResolvedValue({
+          success: true,
+          message: "runtime control should not run",
+        }),
+      };
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager,
+        adapter,
+        chatAgentLoopRunner: chatAgentLoopRunner as never,
+        llmClient: createMockLLMClient([
+          JSON.stringify({ intent: operation, reason: `request ${operation}` }),
+        ]),
+        runtimeControlService,
+      }));
+
+      const result = await manager.execute(`Please ${operation}`, {
+        identity_key: "owner",
+        platform: "telegram",
+        conversation_id: "telegram-chat-1",
+        user_id: "user-1",
+        cwd: "/repo",
+        metadata: { runtime_control_denied: true },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.output).toContain("operation was not executed");
+      expect(result.output).toContain("will not fall back to shell tools");
+      expect(runtimeControlService.request).not.toHaveBeenCalled();
+      expect(chatAgentLoopRunner.execute).not.toHaveBeenCalled();
+      expect(adapter.execute).not.toHaveBeenCalled();
+    }
+  });
+
   it("blocks explicit runtime-control metadata when no typed operation can be derived", async () => {
     const stateManager = makeMockStateManager();
     const adapter = makeMockAdapter();
@@ -1182,6 +1230,99 @@ describe("CrossPlatformChatSessionManager", () => {
       });
 
       await approvalBroker.resolveConversationalApproval("approval-clarify", false, {
+        channel: "slack",
+        conversation_id: "C123:1700.1",
+        user_id: "U123",
+        session_id: "identity:workspace:U123",
+        turn_id: "1700.2",
+      });
+      await expect(resultPromise).resolves.toContain("not approved");
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("routes approval side questions through normal chat while keeping the approval pending", async () => {
+    const tmpDir = makeTempDir();
+    try {
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "approval-side-question",
+      });
+      const runtimeControlService = {
+        request: vi.fn(async (request: {
+          approvalFn?: (description: string) => Promise<boolean>;
+        }) => {
+          const approved = await request.approvalFn?.("Restart the resident daemon.");
+          return {
+            success: approved === true,
+            message: approved === true ? "restart queued" : "not approved",
+            operationId: "op-side-question",
+            state: approved === true ? "acknowledged" as const : "blocked" as const,
+          };
+        }),
+      };
+      const adapter = makeMockAdapter({
+        ...CANNED_RESULT,
+        output: "The daemon restart target is the resident daemon.",
+      });
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        adapter,
+        llmClient: createMockLLMClient([
+          JSON.stringify({
+            intent: "restart_daemon",
+            reason: "PulSeed を再起動して",
+          }),
+          JSON.stringify({
+            decision: "side_question",
+            confidence: 0.93,
+            clarification: "Route the side question through normal chat.",
+          }),
+          JSON.stringify({
+            kind: "assist",
+            confidence: 0.9,
+            rationale: "side question",
+          }),
+          "The daemon restart target is the resident daemon.",
+        ]),
+        runtimeControlService,
+        approvalBroker,
+      }));
+
+      const resultPromise = manager.processIncomingMessage({
+        text: "PulSeed を再起動して",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        onEvent: () => undefined,
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      });
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline && (await store.loadPending("approval-side-question")) === null) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      await expect(manager.processIncomingMessage({
+        text: "Before deciding, which daemon will restart?",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.3",
+        cwd: "/repo",
+      })).resolves.toBe("The daemon restart target is the resident daemon.");
+      await expect(store.loadPending("approval-side-question")).resolves.toMatchObject({
+        state: "pending",
+      });
+
+      await approvalBroker.resolveConversationalApproval("approval-side-question", false, {
         channel: "slack",
         conversation_id: "C123:1700.1",
         user_id: "U123",

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -364,6 +364,7 @@ class ChatEventDeliveryQueue {
 export class CrossPlatformChatSessionManager {
   private readonly sessions = new Map<string, ManagedChatSession>();
   private readonly activeApprovalEventHandlers = new Map<string, ChatEventHandler>();
+  private readonly approvalSideTurnIngressIds = new Set<string>();
   private readonly ingressRouter = createIngressRouter();
 
   constructor(private readonly deps: ChatRunnerDeps) {}
@@ -406,6 +407,9 @@ export class CrossPlatformChatSessionManager {
       };
     }
     const session = this.getOrCreateSession(ingress, options.cwd);
+    if (ingress.ingress_id && this.approvalSideTurnIngressIds.delete(ingress.ingress_id)) {
+      return this.executeInSession(session, ingress, options);
+    }
     const queueEntry = session.queue.then(() => this.executeInSession(session, ingress, options));
     session.queue = queueEntry.then(() => undefined, () => undefined);
     return queueEntry;
@@ -471,6 +475,9 @@ export class CrossPlatformChatSessionManager {
       };
     }
     const session = this.getOrCreateSession(normalizedIngress, options.cwd);
+    if (normalizedIngress.ingress_id && this.approvalSideTurnIngressIds.delete(normalizedIngress.ingress_id)) {
+      return this.executeInSession(session, normalizedIngress, options);
+    }
     const queueEntry = session.queue.then(() => this.executeInSession(session, normalizedIngress, options));
     session.queue = queueEntry.then(() => undefined, () => undefined);
     return queueEntry;
@@ -536,6 +543,12 @@ export class CrossPlatformChatSessionManager {
     }
     if (decision.decision === "clarify") {
       return decision.clarification ?? "Approval is still pending. Please clarify what you need before approving or rejecting.";
+    }
+    if (decision.decision === "side_question" || decision.decision === "new_intent") {
+      if (ingress.ingress_id) {
+        this.approvalSideTurnIngressIds.add(ingress.ingress_id);
+      }
+      return null;
     }
     return decision.clarification ?? "Approval reply was ambiguous. The approval remains pending.";
   }

--- a/src/runtime/control/__tests__/runtime-control-intent.test.ts
+++ b/src/runtime/control/__tests__/runtime-control-intent.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { recognizeRuntimeControlIntent } from "../runtime-control-intent.js";
+import { RuntimeControlOperationKindSchema } from "../../store/runtime-operation-schemas.js";
 import { createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 
 describe("recognizeRuntimeControlIntent", () => {
@@ -17,6 +18,18 @@ describe("recognizeRuntimeControlIntent", () => {
       "PulSeed を再起動して",
       createSingleMockLLMClient(JSON.stringify({ intent: "restart_daemon", reason: "restart daemon" }))
     )).resolves.toMatchObject({ kind: "restart_daemon" });
+  });
+
+  it("keeps classifier operation decisions aligned with the runtime operation schema", async () => {
+    for (const operation of RuntimeControlOperationKindSchema.options) {
+      const llm = createSingleMockLLMClient(JSON.stringify({
+        intent: operation,
+        reason: `classify ${operation}`,
+      }));
+      await expect(recognizeRuntimeControlIntent(`classify ${operation}`, llm)).resolves.toMatchObject({
+        kind: operation,
+      });
+    }
   });
 
   it("uses the LLM decision for natural-language run inspection", async () => {
@@ -51,6 +64,19 @@ describe("recognizeRuntimeControlIntent", () => {
 
     await expect(recognizeRuntimeControlIntent("この実行を続けて", llm)).resolves.toMatchObject({
       kind: "resume_run",
+    });
+  });
+
+  it("preserves typed natural-language target selectors for caller-path resolution", async () => {
+    const llm = createSingleMockLLMClient(JSON.stringify({
+      intent: "pause_run",
+      reason: "pause current run",
+      targetSelector: { scope: "run", reference: "current", sourceText: "この実行" },
+    }));
+
+    await expect(recognizeRuntimeControlIntent("この実行を止めて", llm)).resolves.toMatchObject({
+      kind: "pause_run",
+      targetSelector: { scope: "run", reference: "current", sourceText: "この実行" },
     });
   });
 

--- a/src/runtime/control/__tests__/runtime-control-service.test.ts
+++ b/src/runtime/control/__tests__/runtime-control-service.test.ts
@@ -82,26 +82,27 @@ describe("RuntimeControlService", () => {
     }
   });
 
-  it("rejects unsupported operation kinds before claiming executor support", async () => {
-    const tmpDir = makeTempDir("pulseed-runtime-control-service-unsupported-");
+  it("routes reload_config through approval and executor support", async () => {
+    const tmpDir = makeTempDir("pulseed-runtime-control-service-reload-config-");
     try {
       const operationStore = new RuntimeOperationStore(path.join(tmpDir, "runtime"));
-      const executor = vi.fn();
+      const executor = vi.fn().mockResolvedValue({ ok: true, state: "verified", message: "config reloaded" });
       const service = new RuntimeControlService({ operationStore, executor });
 
       const result = await service.request({
         intent: { kind: "reload_config", reason: "runtime 設定を再読み込みして" },
         cwd: "/repo",
+        approvalFn: vi.fn().mockResolvedValue(true),
       });
 
       expect(result).toMatchObject({
-        success: false,
-        state: "failed",
-        message: expect.stringContaining("not supported"),
+        success: true,
+        state: "verified",
+        message: "config reloaded",
       });
-      expect(executor).not.toHaveBeenCalled();
+      expect(executor).toHaveBeenCalledOnce();
       expect(await operationStore.listPending()).toHaveLength(0);
-      expect(await operationStore.listCompleted()).toHaveLength(0);
+      expect(await operationStore.listCompleted()).toHaveLength(1);
     } finally {
       cleanupTempDir(tmpDir);
     }
@@ -278,7 +279,7 @@ describe("RuntimeControlService", () => {
       expect(result).toMatchObject({
         success: false,
         state: "blocked",
-        message: expect.stringContaining("Multiple active/recent runtime runs"),
+        message: expect.stringContaining("Multiple runtime runs match this request"),
       });
     } finally {
       cleanupTempDir(tmpDir);

--- a/src/runtime/control/__tests__/runtime-target-resolver.test.ts
+++ b/src/runtime/control/__tests__/runtime-target-resolver.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { resolveRuntimeTarget } from "../runtime-target-resolver.js";
+import type { RuntimeSessionRegistrySnapshot } from "../../session-registry/index.js";
+
+function run(overrides: Partial<RuntimeSessionRegistrySnapshot["background_runs"][number]> = {}): RuntimeSessionRegistrySnapshot["background_runs"][number] {
+  return {
+    schema_version: "background-run-v1",
+    id: "run:coreloop:active",
+    kind: "coreloop_run",
+    parent_session_id: null,
+    child_session_id: "session:coreloop:active",
+    process_session_id: null,
+    goal_id: "goal-1",
+    status: "running",
+    notify_policy: "done_only",
+    reply_target_source: "none",
+    pinned_reply_target: null,
+    title: "DurableLoop goal goal-1",
+    workspace: "/repo",
+    created_at: "2026-05-02T00:00:00.000Z",
+    started_at: "2026-05-02T00:00:00.000Z",
+    updated_at: "2026-05-02T00:00:00.000Z",
+    completed_at: null,
+    summary: null,
+    error: null,
+    artifacts: [],
+    source_refs: [],
+    ...overrides,
+  };
+}
+
+function snapshot(runs: RuntimeSessionRegistrySnapshot["background_runs"]): RuntimeSessionRegistrySnapshot {
+  return {
+    schema_version: "runtime-session-registry-v1",
+    generated_at: "2026-05-02T01:00:00.000Z",
+    sessions: [],
+    background_runs: runs,
+    warnings: [],
+  };
+}
+
+describe("resolveRuntimeTarget", () => {
+  it("resolves current run by conversation scope with typed evidence", () => {
+    const result = resolveRuntimeTarget({
+      snapshot: snapshot([
+        run({ id: "run:coreloop:other", parent_session_id: "session:conversation:other" }),
+        run({ id: "run:coreloop:current", parent_session_id: "session:conversation:chat-1" }),
+      ]),
+      operation: "pause_run",
+      selector: { scope: "run", reference: "current", sourceText: "この実行" },
+      conversationId: "chat-1",
+    });
+
+    expect(result.status).toBe("resolved");
+    if (result.status === "resolved") {
+      expect(result.run.id).toBe("run:coreloop:current");
+      expect(result.evidence.selector).toMatchObject({ reference: "current" });
+    }
+  });
+
+  it("selects latest and previous by runtime timestamps without title matching", () => {
+    const runs = [
+      run({ id: "run:older", updated_at: "2026-05-02T00:00:00.000Z" }),
+      run({ id: "run:newer", updated_at: "2026-05-02T00:10:00.000Z" }),
+    ];
+
+    const latest = resolveRuntimeTarget({
+      snapshot: snapshot(runs),
+      operation: "inspect_run",
+      selector: { scope: "run", reference: "latest", sourceText: "latest session" },
+    });
+    const previous = resolveRuntimeTarget({
+      snapshot: snapshot(runs),
+      operation: "inspect_run",
+      selector: { scope: "run", reference: "previous", sourceText: "previous background job" },
+    });
+
+    expect(latest.status).toBe("resolved");
+    expect(previous.status).toBe("resolved");
+    if (latest.status === "resolved") expect(latest.run.id).toBe("run:newer");
+    if (previous.status === "resolved") expect(previous.run.id).toBe("run:older");
+  });
+
+  it("returns ambiguous for multiple current candidates instead of guessing", () => {
+    const result = resolveRuntimeTarget({
+      snapshot: snapshot([
+        run({ id: "run:a", parent_session_id: "session:conversation:chat-1" }),
+        run({ id: "run:b", parent_session_id: "session:conversation:chat-1" }),
+      ]),
+      operation: "resume_run",
+      selector: { scope: "run", reference: "current", sourceText: "that run" },
+      conversationId: "chat-1",
+    });
+
+    expect(result.status).toBe("ambiguous");
+    expect(result.evidence.candidates.map((candidate) => candidate.run_id)).toEqual(["run:a", "run:b"]);
+  });
+
+  it("returns stale for terminal exact targets", () => {
+    const result = resolveRuntimeTarget({
+      snapshot: snapshot([run({ id: "run:done", status: "succeeded" })]),
+      operation: "pause_run",
+      target: { runId: "run:done" },
+    });
+
+    expect(result.status).toBe("stale");
+  });
+});

--- a/src/runtime/control/index.ts
+++ b/src/runtime/control/index.ts
@@ -1,6 +1,8 @@
 export { classifyRuntimeControlIntent, recognizeRuntimeControlIntent } from "./runtime-control-intent.js";
 export type { RuntimeControlIntent, RuntimeControlIntentClassification } from "./runtime-control-intent.js";
 export { RuntimeControlService } from "./runtime-control-service.js";
+export { resolveRuntimeTarget } from "./runtime-target-resolver.js";
+export type { RuntimeTargetResolution } from "./runtime-target-resolver.js";
 export { createDaemonRuntimeControlExecutor } from "./daemon-runtime-control-executor.js";
 export {
   publishRuntimeControlResult,

--- a/src/runtime/control/runtime-control-intent.ts
+++ b/src/runtime/control/runtime-control-intent.ts
@@ -1,11 +1,15 @@
 import { z } from "zod";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
-import type { RuntimeControlOperationKind } from "../store/runtime-operation-schemas.js";
+import {
+  RuntimeControlOperationKindSchema,
+  type RuntimeControlOperationKind,
+} from "../store/runtime-operation-schemas.js";
 
 export interface RuntimeControlIntent {
   kind: RuntimeControlOperationKind;
   reason: string;
   target?: RuntimeControlTargetHint;
+  targetSelector?: RuntimeControlTargetSelector;
   externalActions?: string[];
   irreversible?: boolean;
 }
@@ -15,25 +19,28 @@ export interface RuntimeControlTargetHint {
   sessionId?: string;
 }
 
+export interface RuntimeControlTargetSelector {
+  scope: "run" | "session";
+  reference: "current" | "latest" | "previous" | "mentioned" | "exact";
+  sourceText: string;
+}
+
 export type RuntimeControlIntentClassification =
   | { status: "intent"; intent: RuntimeControlIntent }
   | { status: "none" }
   | { status: "unclassified" };
 
 const RuntimeControlIntentDecisionSchema = z.object({
-  intent: z.enum([
-    "none",
-    "inspect_run",
-    "pause_run",
-    "resume_run",
-    "finalize_run",
-    "restart_daemon",
-    "restart_gateway",
-  ]),
+  intent: z.enum(["none", ...RuntimeControlOperationKindSchema.options]),
   reason: z.string().min(1).optional(),
   target: z.object({
     runId: z.string().min(1).optional(),
     sessionId: z.string().min(1).optional(),
+  }).optional(),
+  targetSelector: z.object({
+    scope: z.enum(["run", "session"]),
+    reference: z.enum(["current", "latest", "previous", "mentioned", "exact"]),
+    sourceText: z.string().min(1),
   }).optional(),
   externalActions: z.array(z.enum([
     "submit",
@@ -54,9 +61,10 @@ Decide whether the user's primary intent is to operate on an existing active or 
 
 Return only JSON matching:
 {
-  "intent": "none" | "inspect_run" | "pause_run" | "resume_run" | "finalize_run" | "restart_daemon" | "restart_gateway",
+  "intent": "none" | "restart_daemon" | "restart_gateway" | "reload_config" | "self_update" | "inspect_run" | "pause_run" | "resume_run" | "finalize_run",
   "reason": "short reason using the user's words",
   "target": { "runId": "optional exact run id", "sessionId": "optional exact session id" },
+  "targetSelector": { "scope": "run" | "session", "reference": "current" | "latest" | "previous" | "mentioned" | "exact", "sourceText": "quoted user reference" },
   "externalActions": ["submit" | "publish" | "secret" | "production_mutation" | "destructive_cleanup"],
   "irreversible": true | false
 }
@@ -65,9 +73,12 @@ Classification rules:
 - Choose inspect_run, pause_run, resume_run, or finalize_run only when the user is asking to inspect/control/finalize an existing runtime run/session/execution.
 - Choose none for ordinary project work, coding requests, implementation continuation, evidence/progress Q&A, status questions, explanations, help, or requests to create/start new work.
 - Choose none for broad follow-ups like "continue", "finish the implementation", or "続けて" unless the message itself clearly refers to resuming/finalizing a runtime run/session/execution.
+- Choose reload_config when the user asks to reload PulSeed runtime/gateway/daemon configuration.
+- Choose self_update when the user asks PulSeed to update itself.
 - Choose finalize_run for closing/finalizing a run. Mark irreversible true.
 - If finalize would involve external submit/publish, secrets, production mutation, or destructive cleanup, include the matching externalActions. Do not assume these actions should execute.
 - If the user names a run id or session id, copy it exactly into target. Otherwise omit target.
+- If the user refers to a run/session by natural language such as current, latest, previous, or mentioned/that run, include targetSelector instead of inventing an id.
 - Use restart_daemon/restart_gateway only when the user is asking to restart the PulSeed daemon or gateway, not for run/session pause/resume/finalize.
 - When uncertain, choose none.`;
 }
@@ -115,6 +126,7 @@ function toRuntimeControlIntent(
     kind: decision.intent,
     reason: decision.reason?.trim() || input,
     ...(target ? { target } : {}),
+    ...(decision.targetSelector ? { targetSelector: decision.targetSelector } : {}),
     ...(decision.externalActions && decision.externalActions.length > 0
       ? { externalActions: [...new Set(decision.externalActions)] }
       : {}),

--- a/src/runtime/control/runtime-control-service.ts
+++ b/src/runtime/control/runtime-control-service.ts
@@ -3,7 +3,6 @@ import type { StateManager } from "../../base/state/state-manager.js";
 import {
   createRuntimeSessionRegistry,
   type BackgroundRun,
-  type RuntimeSessionRegistrySnapshot,
 } from "../session-registry/index.js";
 import { RuntimeEvidenceLedger, type RuntimeEvidenceLedgerPort } from "../store/evidence-ledger.js";
 import { RuntimeOperationStore } from "../store/runtime-operation-store.js";
@@ -16,6 +15,7 @@ import type {
   RuntimeControlReplyTarget,
 } from "../store/runtime-operation-schemas.js";
 import type { RuntimeControlIntent } from "./runtime-control-intent.js";
+import { resolveRuntimeTarget } from "./runtime-target-resolver.js";
 
 export interface RuntimeControlRequest {
   intent: RuntimeControlIntent;
@@ -76,9 +76,6 @@ type RuntimeControlStep =
 type TargetResolution =
   | { ok: true; run?: BackgroundRun; goalId?: string | null }
   | { ok: false; result: RuntimeControlResult };
-
-const ACTIVE_RUN_STATUSES = new Set(["queued", "running"]);
-const ATTENTION_RUN_STATUSES = new Set(["failed", "timed_out", "lost"]);
 
 export class RuntimeControlService {
   private readonly operationStore: RuntimeOperationStore;
@@ -244,27 +241,24 @@ export class RuntimeControlService {
     }
 
     const snapshot = await this.sessionRegistry.snapshot();
-    const explicitRunId = request.intent.target?.runId;
-    const explicitSessionId = request.intent.target?.sessionId;
-    const run = explicitRunId
-      ? snapshot.background_runs.find((candidate) => candidate.id === explicitRunId)
-      : explicitSessionId
-        ? snapshot.background_runs.find((candidate) => candidate.child_session_id === explicitSessionId)
-        : selectImplicitTarget(snapshot, request);
+    const resolution = resolveRuntimeTarget({
+      snapshot,
+      operation: request.intent.kind,
+      target: request.intent.target,
+      selector: request.intent.targetSelector,
+      conversationId: request.replyTarget?.conversation_id ?? request.requestedBy?.conversation_id ?? null,
+    });
 
-    if (!run) {
-      const candidates = selectableRuns(snapshot);
-      if (!explicitRunId && !explicitSessionId && candidates.length > 1) {
-        return blocked(`Multiple active/recent runtime runs match this request. Specify one run id: ${candidates.map((candidate) => candidate.id).join(", ")}`);
-      }
-      return blocked("No active or recent long-running runtime run matched this request.");
+    if (resolution.status === "ambiguous") {
+      return blocked(`Multiple runtime runs match this request. Specify one run id: ${resolution.evidence.candidates.map((candidate) => candidate.run_id).join(", ")}`);
     }
-
-    if (!isCurrentRunForControl(run, request.intent.kind)) {
-      return blocked(`Runtime run ${run.id} is stale or terminal for ${request.intent.kind}; refusing to reuse previous-session state.`);
+    if (resolution.status === "unknown") {
+      return blocked(`No runtime run matched this request: ${resolution.evidence.reason}.`);
     }
-
-    return { ok: true, run, goalId: resolveGoalId(run) };
+    if (resolution.status === "stale") {
+      return blocked(`${resolution.evidence.reason}; refusing to reuse previous-session state.`);
+    }
+    return { ok: true, run: resolution.run, goalId: resolution.goalId };
   }
 
   private async proposeFinalize(
@@ -464,8 +458,13 @@ export class RuntimeControlService {
 
 export function isExecutableRuntimeControlKind(
   kind: RuntimeControlOperationKind
-): kind is Extract<RuntimeControlOperationKind, "restart_daemon" | "restart_gateway" | "pause_run" | "resume_run"> {
-  return kind === "restart_daemon" || kind === "restart_gateway" || kind === "pause_run" || kind === "resume_run";
+): kind is Extract<RuntimeControlOperationKind, "restart_daemon" | "restart_gateway" | "reload_config" | "self_update" | "pause_run" | "resume_run"> {
+  return kind === "restart_daemon"
+    || kind === "restart_gateway"
+    || kind === "reload_config"
+    || kind === "self_update"
+    || kind === "pause_run"
+    || kind === "resume_run";
 }
 
 function isRunControlKind(
@@ -475,7 +474,13 @@ function isRunControlKind(
 }
 
 function requiresApproval(kind: RuntimeControlOperationKind): boolean {
-  return kind === "restart_daemon" || kind === "restart_gateway" || kind === "pause_run" || kind === "resume_run" || kind === "finalize_run";
+  return kind === "restart_daemon"
+    || kind === "restart_gateway"
+    || kind === "reload_config"
+    || kind === "self_update"
+    || kind === "pause_run"
+    || kind === "resume_run"
+    || kind === "finalize_run";
 }
 
 function normalizeReplyTarget(target: RuntimeControlReplyTarget): RuntimeControlReplyTarget {
@@ -548,45 +553,6 @@ function riskForIntent(intent: RuntimeControlIntent): RuntimeControlOperation["r
     irreversible: intent.irreversible ?? true,
     external_actions: intent.externalActions ?? [],
   };
-}
-
-function selectableRuns(snapshot: RuntimeSessionRegistrySnapshot): BackgroundRun[] {
-  return [...snapshot.background_runs]
-    .filter((run) => ACTIVE_RUN_STATUSES.has(run.status) || ATTENTION_RUN_STATUSES.has(run.status))
-    .sort((left, right) => compareUpdated(right, left));
-}
-
-function selectImplicitTarget(
-  snapshot: RuntimeSessionRegistrySnapshot,
-  request: RuntimeControlRequest
-): BackgroundRun | null {
-  const candidates = selectableRuns(snapshot);
-  const conversationId = request.replyTarget?.conversation_id ?? request.requestedBy?.conversation_id;
-  const currentSessionId = conversationId ? `session:conversation:${conversationId}` : null;
-  const scoped = currentSessionId
-    ? candidates.filter((run) => run.parent_session_id === currentSessionId)
-    : [];
-  if (scoped.length === 1) return scoped[0];
-  if (scoped.length > 1) return null;
-  return candidates.length === 1 ? candidates[0] : null;
-}
-
-function isCurrentRunForControl(run: BackgroundRun, kind: RuntimeControlOperationKind): boolean {
-  if (kind === "inspect_run") return ACTIVE_RUN_STATUSES.has(run.status) || ATTENTION_RUN_STATUSES.has(run.status);
-  if (kind === "pause_run") return ACTIVE_RUN_STATUSES.has(run.status);
-  if (kind === "resume_run") return ACTIVE_RUN_STATUSES.has(run.status) || ATTENTION_RUN_STATUSES.has(run.status);
-  if (kind === "finalize_run") return ACTIVE_RUN_STATUSES.has(run.status) || ATTENTION_RUN_STATUSES.has(run.status);
-  return false;
-}
-
-function resolveGoalId(run: BackgroundRun): string | null {
-  if (run.kind !== "coreloop_run") return null;
-  if (run.goal_id) return run.goal_id;
-  return null;
-}
-
-function compareUpdated(left: BackgroundRun, right: BackgroundRun): number {
-  return Date.parse(left.updated_at ?? left.started_at ?? left.created_at ?? "") - Date.parse(right.updated_at ?? right.started_at ?? right.created_at ?? "");
 }
 
 function blocked(message: string): TargetResolution {

--- a/src/runtime/control/runtime-target-resolver.ts
+++ b/src/runtime/control/runtime-target-resolver.ts
@@ -1,0 +1,180 @@
+import type {
+  BackgroundRun,
+  RuntimeSessionRegistrySnapshot,
+} from "../session-registry/index.js";
+import type { RuntimeControlOperationKind } from "../store/runtime-operation-schemas.js";
+import type {
+  RuntimeControlTargetHint,
+  RuntimeControlTargetSelector,
+} from "./runtime-control-intent.js";
+
+const ACTIVE_RUN_STATUSES = new Set(["queued", "running"]);
+const ATTENTION_RUN_STATUSES = new Set(["failed", "timed_out", "lost"]);
+
+export interface RuntimeTargetResolutionEvidence {
+  selector: RuntimeControlTargetSelector | null;
+  candidates: Array<{
+    run_id: string;
+    status: string;
+    updated_at: string | null;
+    parent_session_id: string | null;
+    child_session_id: string | null;
+    goal_id: string | null;
+  }>;
+  reason: string;
+}
+
+export type RuntimeTargetResolution =
+  | { status: "resolved"; run: BackgroundRun; goalId: string | null; evidence: RuntimeTargetResolutionEvidence }
+  | { status: "ambiguous"; evidence: RuntimeTargetResolutionEvidence }
+  | { status: "stale"; evidence: RuntimeTargetResolutionEvidence }
+  | { status: "unknown"; evidence: RuntimeTargetResolutionEvidence };
+
+export interface ResolveRuntimeTargetInput {
+  snapshot: RuntimeSessionRegistrySnapshot;
+  operation: RuntimeControlOperationKind;
+  target?: RuntimeControlTargetHint;
+  selector?: RuntimeControlTargetSelector;
+  conversationId?: string | null;
+}
+
+export function resolveRuntimeTarget(input: ResolveRuntimeTargetInput): RuntimeTargetResolution {
+  const selectable = selectableRuns(input.snapshot);
+  const explicit = resolveExplicitTarget(input.snapshot, input.target);
+  if (explicit.status === "resolved") {
+    return currentOrStale(explicit.run, input.operation, input.selector ?? null, selectable, "explicit target matched the runtime catalog");
+  }
+  if (explicit.status === "unknown") {
+    return unknown(input.selector ?? null, selectable, "explicit run/session id did not match the runtime catalog");
+  }
+
+  const selector = input.selector ?? {
+    scope: "run" as const,
+    reference: "current" as const,
+    sourceText: "implicit current runtime run",
+  };
+  const scoped = scopedConversationRuns(selectable, input.conversationId);
+  const candidates = scoped.length > 0 ? scoped : selectable;
+  if (candidates.length === 0) {
+    return unknown(selector, selectable, "no active or attention-needed runtime runs are available");
+  }
+
+  switch (selector.reference) {
+    case "current":
+    case "mentioned":
+      if (candidates.length === 1) {
+        return currentOrStale(candidates[0], input.operation, selector, candidates, "single current candidate resolved");
+      }
+      return ambiguous(selector, candidates, "multiple current candidates require clarification");
+    case "latest":
+      return currentOrStale(candidates[0], input.operation, selector, candidates, "latest candidate selected by runtime updated timestamp");
+    case "previous":
+      if (candidates.length < 2) {
+        return unknown(selector, candidates, "previous target was requested but there is no earlier candidate");
+      }
+      return currentOrStale(candidates[1], input.operation, selector, candidates, "previous candidate selected by runtime updated timestamp");
+    case "exact":
+      return unknown(selector, candidates, "exact target selector requires an explicit run or session id");
+  }
+}
+
+function resolveExplicitTarget(
+  snapshot: RuntimeSessionRegistrySnapshot,
+  target: RuntimeControlTargetHint | undefined
+): { status: "resolved"; run: BackgroundRun } | { status: "unknown" } | { status: "none" } {
+  if (!target?.runId && !target?.sessionId) return { status: "none" };
+  const run = target.runId
+    ? snapshot.background_runs.find((candidate) => candidate.id === target.runId)
+    : snapshot.background_runs.find((candidate) => candidate.child_session_id === target.sessionId);
+  return run ? { status: "resolved", run } : { status: "unknown" };
+}
+
+function currentOrStale(
+  run: BackgroundRun,
+  operation: RuntimeControlOperationKind,
+  selector: RuntimeControlTargetSelector | null,
+  candidates: BackgroundRun[],
+  reason: string
+): RuntimeTargetResolution {
+  if (!isCurrentRunForControl(run, operation)) {
+    return stale(selector, candidates, `runtime run ${run.id} is stale or terminal for ${operation}`);
+  }
+  return {
+    status: "resolved",
+    run,
+    goalId: resolveGoalId(run),
+    evidence: evidence(selector, candidates, reason),
+  };
+}
+
+function selectableRuns(snapshot: RuntimeSessionRegistrySnapshot): BackgroundRun[] {
+  return [...snapshot.background_runs]
+    .filter((run) => ACTIVE_RUN_STATUSES.has(run.status) || ATTENTION_RUN_STATUSES.has(run.status))
+    .sort((left, right) => compareUpdated(right, left));
+}
+
+function scopedConversationRuns(candidates: BackgroundRun[], conversationId: string | null | undefined): BackgroundRun[] {
+  if (!conversationId) return [];
+  const currentSessionId = `session:conversation:${conversationId}`;
+  return candidates.filter((run) => run.parent_session_id === currentSessionId);
+}
+
+function isCurrentRunForControl(run: BackgroundRun, kind: RuntimeControlOperationKind): boolean {
+  if (kind === "inspect_run") return ACTIVE_RUN_STATUSES.has(run.status) || ATTENTION_RUN_STATUSES.has(run.status);
+  if (kind === "pause_run") return ACTIVE_RUN_STATUSES.has(run.status);
+  if (kind === "resume_run") return ACTIVE_RUN_STATUSES.has(run.status) || ATTENTION_RUN_STATUSES.has(run.status);
+  if (kind === "finalize_run") return ACTIVE_RUN_STATUSES.has(run.status) || ATTENTION_RUN_STATUSES.has(run.status);
+  return false;
+}
+
+function resolveGoalId(run: BackgroundRun): string | null {
+  if (run.kind !== "coreloop_run") return null;
+  return run.goal_id ?? null;
+}
+
+function compareUpdated(left: BackgroundRun, right: BackgroundRun): number {
+  return Date.parse(left.updated_at ?? left.started_at ?? left.created_at ?? "") - Date.parse(right.updated_at ?? right.started_at ?? right.created_at ?? "");
+}
+
+function ambiguous(
+  selector: RuntimeControlTargetSelector,
+  candidates: BackgroundRun[],
+  reason: string
+): RuntimeTargetResolution {
+  return { status: "ambiguous", evidence: evidence(selector, candidates, reason) };
+}
+
+function stale(
+  selector: RuntimeControlTargetSelector | null,
+  candidates: BackgroundRun[],
+  reason: string
+): RuntimeTargetResolution {
+  return { status: "stale", evidence: evidence(selector, candidates, reason) };
+}
+
+function unknown(
+  selector: RuntimeControlTargetSelector | null,
+  candidates: BackgroundRun[],
+  reason: string
+): RuntimeTargetResolution {
+  return { status: "unknown", evidence: evidence(selector, candidates, reason) };
+}
+
+function evidence(
+  selector: RuntimeControlTargetSelector | null,
+  candidates: BackgroundRun[],
+  reason: string
+): RuntimeTargetResolutionEvidence {
+  return {
+    selector,
+    candidates: candidates.map((run) => ({
+      run_id: run.id,
+      status: run.status,
+      updated_at: run.updated_at,
+      parent_session_id: run.parent_session_id,
+      child_session_id: run.child_session_id,
+      goal_id: run.goal_id ?? null,
+    })),
+    reason,
+  };
+}

--- a/src/runtime/conversational-approval-decision.ts
+++ b/src/runtime/conversational-approval-decision.ts
@@ -6,7 +6,7 @@ import type { ApprovalOrigin, ApprovalRecord } from "./store/runtime-schemas.js"
 const MIN_CONVERSATIONAL_APPROVAL_CONFIDENCE = 0.7;
 
 export const ConversationalApprovalDecisionSchema = z.object({
-  decision: z.enum(["approve", "reject", "clarify", "unknown"]),
+  decision: z.enum(["approve", "reject", "clarify", "side_question", "new_intent", "unknown"]),
   confidence: z.number().min(0).max(1),
   clarification: z.string().optional(),
   rationale: z.string().optional(),
@@ -72,7 +72,9 @@ Decision meanings:
 - approve: explicitly approves the active approval request.
 - reject: explicitly denies, rejects, cancels, or stops the active approval request.
 - clarify: asks a question or requests explanation while keeping the approval pending.
-- unknown: ambiguous, unrelated, stale, wrong-context, or too low-confidence.
+- side_question: asks about the active approval or nearby runtime/setup status without approving or rejecting it.
+- new_intent: asks PulSeed to handle an unrelated task or conversation turn while the approval remains pending.
+- unknown: ambiguous approval/rejection, stale, wrong-context, or too low-confidence.
 
 Active approval context:
 ${describeApprovalContext(context.approval)}
@@ -85,7 +87,7 @@ ${context.priorTurnState ?? "none"}
 
 Respond only as JSON:
 {
-  "decision": "approve" | "reject" | "clarify" | "unknown",
+  "decision": "approve" | "reject" | "clarify" | "side_question" | "new_intent" | "unknown",
   "confidence": 0.0-1.0,
   "clarification": "short clarification prompt when clarify or unknown",
   "rationale": "short rationale"


### PR DESCRIPTION
## Summary

Closes #1081
Closes #1082
Closes #1083

## #1081 Add approval side-question and new-intent handling for gateway conversations

### Changes
- Extended the conversational approval arbiter with typed `side_question` and `new_intent` decisions.
- Preserved same-conversation approve/reject resolution and ambiguous fail-closed behavior.
- Allowed side-question/new-intent gateway turns to reach the normal ChatRunner path while the active approval remains pending.
- Avoided shell fallback and did not report approval-denied or ambiguous approval states as executed.

### Added tests
- Added a cross-platform caller-path test where an active approval remains pending while a same-conversation side question routes through normal chat.
- Kept existing approval resolution and clarification/wrong-context coverage intact.

### Verification commands
- `npx vitest run src/interface/chat/__tests__/cross-platform-session.test.ts --config vitest.unit.config.ts`
- `npx vitest run src/runtime/gateway/__tests__ --config vitest.integration.config.ts`

## #1082 Align runtime-control intent classification with operation schema

### Changes
- Derived runtime-control classifier operation decisions from `RuntimeControlOperationKindSchema` plus `none`.
- Added typed classifier support for `reload_config` and `self_update`.
- Routed approved `reload_config` and `self_update` through `RuntimeControlService` with approval and executor gates.
- Kept denied/unavailable/unclassified runtime-control paths fail-closed with no shell fallback.

### Added tests
- Added schema-parity coverage for every `RuntimeControlOperationKindSchema` operation.
- Added approved `reload_config` / `self_update` RuntimeControlService path coverage.
- Added denied gateway coverage for `reload_config` / `self_update` to ensure no AgentLoop shell fallback.

### Verification commands
- `npx vitest run src/interface/chat/__tests__/ingress-router.test.ts src/interface/chat/__tests__/chat-runner-gateway-runtime-control.test.ts src/interface/chat/__tests__/chat-runner*.test.ts --config vitest.unit.config.ts`
- `npx vitest run src/interface/chat/__tests__/cross-platform-session.test.ts --config vitest.unit.config.ts`
- `npx vitest run src/runtime/gateway/__tests__ --config vitest.integration.config.ts`

## #1083 Add typed runtime target selection for natural-language run/session references

### Changes
- Added a typed runtime target resolver returning `resolved`, `ambiguous`, `stale`, or `unknown` with evidence.
- Added typed `targetSelector` support to runtime-control intent classification for natural-language references such as current/latest/previous/mentioned.
- Moved RuntimeControlService run target selection onto the typed resolver, using runtime registry snapshots and provenance instead of title matching.
- Kept stale and ambiguous targets blocked instead of guessing or reusing previous-turn state.

### Added tests
- Added direct resolver tests for current, latest, previous, ambiguous, and stale exact-target behavior.
- Added ChatRunner caller-path coverage for current, latest, and Japanese previous-background-job references.

### Verification commands
- `npx vitest run src/runtime/control/__tests__/runtime-control-intent.test.ts src/runtime/control/__tests__/runtime-target-resolver.test.ts --config vitest.integration.config.ts`
- `npx vitest run src/interface/chat/__tests__/chat-runner-gateway-runtime-control.test.ts --config vitest.unit.config.ts`

## Full verification

- `npm run typecheck`
- `npx vitest run src/interface/chat/__tests__/cross-platform-session.test.ts --config vitest.unit.config.ts`
- `npx vitest run src/interface/chat/__tests__/ingress-router.test.ts src/interface/chat/__tests__/chat-runner-gateway-runtime-control.test.ts src/interface/chat/__tests__/chat-runner*.test.ts --config vitest.unit.config.ts`
- `npx vitest run src/runtime/gateway/__tests__ --config vitest.integration.config.ts`
- `npx vitest run src/runtime/control/__tests__/runtime-control-intent.test.ts src/runtime/control/__tests__/runtime-target-resolver.test.ts --config vitest.integration.config.ts`
- `npm run test:smoke`

## Review

Fresh review agent checked the local diff for semantic shortcut violations, approval gate regressions, stale target reuse, and caller-path coverage. Result: no findings.
