### PR TITLE
Support OpenAI reasoning effort selection

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,8 @@ Typical shape:
 ```json
 {
   "provider": "openai",
-  "model": "gpt-5.4-mini",
+  "model": "gpt-5.5",
+  "reasoning_effort": "low",
   "adapter": "agent_loop",
   "api_key": "sk-...",
   "agent_loop": {
@@ -54,6 +55,7 @@ Important top-level fields:
 
 - `provider`: `openai`, `anthropic`, or `ollama`
 - `model`: provider-specific model name
+- `reasoning_effort`: optional OpenAI reasoning effort: `none`, `minimal`, `low`, `medium`, `high`, or `xhigh`
 - `adapter`: `agent_loop`, `openai_codex_cli`, `claude_code_cli`, `openai_api`, `claude_api`, or other registered adapters
 - `api_key`: when required by the provider
 - `base_url`: optional provider override
@@ -98,6 +100,8 @@ Environment variables override file config.
 | `ANTHROPIC_API_KEY` | Anthropic key |
 | `OPENAI_BASE_URL` | Optional OpenAI-compatible endpoint override |
 | `OLLAMA_BASE_URL` | Optional Ollama endpoint override |
+| `PULSEED_REASONING_EFFORT` | OpenAI reasoning effort override |
+| `OPENAI_REASONING_EFFORT` | OpenAI-specific reasoning effort override |
 
 ### Notes
 

--- a/src/adapters/__tests__/openai-codex-adapter.test.ts
+++ b/src/adapters/__tests__/openai-codex-adapter.test.ts
@@ -117,6 +117,19 @@ describe("OpenAICodexCLIAdapter", () => {
       expect(child.stdin.write).toHaveBeenCalledWith("do task", "utf8");
     });
 
+    it("includes model_reasoning_effort config when reasoning effort is configured", async () => {
+      const adapter = new OpenAICodexCLIAdapter({ model: "gpt-5.5", reasoningEffort: "low" });
+      const child = makeFakeChild();
+
+      const executePromise = adapter.execute(makeTask({ prompt: "do task" }));
+      child.emit("close", 0);
+      await executePromise;
+
+      const [, spawnArgs] = mockSpawn.mock.calls[0] as [string, string[]];
+      expect(spawnArgs).toContain("-c");
+      expect(spawnArgs).toContain('model_reasoning_effort="low"');
+    });
+
     it("omits --model flag when no model is configured", async () => {
       const adapter = new OpenAICodexCLIAdapter();
       const child = makeFakeChild();

--- a/src/adapters/agents/openai-codex.ts
+++ b/src/adapters/agents/openai-codex.ts
@@ -31,6 +31,8 @@ export interface OpenAICodexCLIAdapterConfig {
   sandboxPolicy?: string | null;
   /** If set, pass -m <model> to the CLI. */
   model?: string;
+  /** If set, pass Codex model_reasoning_effort through -c. */
+  reasoningEffort?: string;
   /** Repository path passed to Codex for workspace-aware execution. Default: "." */
   repoPath?: string;
   /** Pass --skip-git-repo-check. Default: true for daemon/test workspaces. */
@@ -46,6 +48,7 @@ export class OpenAICodexCLIAdapter implements IAdapter {
   private readonly cliPath: string;
   private readonly sandboxPolicy: string | null;
   private readonly model: string | undefined;
+  private readonly reasoningEffort: string | undefined;
   private readonly repoPath: string;
   private readonly skipGitRepoCheck: boolean;
   private readonly terminalBackend?: TerminalBackendConfig;
@@ -56,6 +59,7 @@ export class OpenAICodexCLIAdapter implements IAdapter {
     this.sandboxPolicy =
       config.sandboxPolicy !== undefined ? config.sandboxPolicy : "workspace-write";
     this.model = config.model;
+    this.reasoningEffort = config.reasoningEffort;
     this.repoPath = config.repoPath?.trim() || ".";
     this.skipGitRepoCheck = config.skipGitRepoCheck ?? true;
     this.terminalBackend = config.terminalBackend;
@@ -75,6 +79,10 @@ export class OpenAICodexCLIAdapter implements IAdapter {
 
     if (this.model) {
       spawnArgs.push("-m", this.model);
+    }
+
+    if (this.reasoningEffort) {
+      spawnArgs.push("-c", `model_reasoning_effort="${this.reasoningEffort}"`);
     }
 
     if (this.skipGitRepoCheck) {

--- a/src/base/llm/__tests__/codex-llm-client.test.ts
+++ b/src/base/llm/__tests__/codex-llm-client.test.ts
@@ -155,6 +155,20 @@ describe("CodexLLMClient", () => {
       expect(spawnArgs[modelIdx + 1]).toBe("o4-mini");
     });
 
+    it("includes model_reasoning_effort config when reasoning effort is configured", async () => {
+      const client = new CodexLLMClient({ model: "gpt-5.5", reasoningEffort: "low" });
+      const child = makeFakeChild();
+
+      const promise = client.sendMessage([{ role: "user", content: "hi" }]);
+      await flushMicrotasks();
+      child.emit("close", 0);
+      await promise;
+
+      const [, spawnArgs] = mockSpawn.mock.calls[0] as [string, string[]];
+      expect(spawnArgs).toContain("-c");
+      expect(spawnArgs).toContain('model_reasoning_effort="low"');
+    });
+
     it("omits --model flag when no model is configured", async () => {
       vi.stubEnv("OPENAI_MODEL", "");
       const client = new CodexLLMClient();

--- a/src/base/llm/__tests__/openai-client.test.ts
+++ b/src/base/llm/__tests__/openai-client.test.ts
@@ -200,6 +200,44 @@ describe("OpenAILLMClient", () => {
       expect(callArgs).not.toHaveProperty("temperature");
     });
 
+    it("omits temperature for GPT-5 reasoning models", async () => {
+      const client = new OpenAILLMClient({ apiKey: "sk-test", model: "gpt-5.5" });
+      mockCreate.mockResolvedValueOnce(makeCompletionResponse("ok"));
+
+      await client.sendMessage([{ role: "user", content: "hi" }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty("temperature");
+    });
+
+    it("passes configured reasoning effort to chat completions", async () => {
+      const client = new OpenAILLMClient({
+        apiKey: "sk-test",
+        model: "gpt-5.5",
+        reasoningEffort: "low",
+      });
+      mockCreate.mockResolvedValueOnce(makeCompletionResponse("ok"));
+
+      await client.sendMessage([{ role: "user", content: "hi" }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs.reasoning_effort).toBe("low");
+    });
+
+    it("does not pass reasoning effort to non-reasoning models", async () => {
+      const client = new OpenAILLMClient({
+        apiKey: "sk-test",
+        model: "gpt-4o",
+        reasoningEffort: "low",
+      });
+      mockCreate.mockResolvedValueOnce(makeCompletionResponse("ok"));
+
+      await client.sendMessage([{ role: "user", content: "hi" }]);
+
+      const callArgs = mockCreate.mock.calls[0][0];
+      expect(callArgs).not.toHaveProperty("reasoning_effort");
+    });
+
     it("includes temperature for non-reasoning models", async () => {
       const client = new OpenAILLMClient({ apiKey: "sk-test", model: "gpt-4o" });
       mockCreate.mockResolvedValueOnce(makeCompletionResponse("ok"));
@@ -340,6 +378,35 @@ describe("OpenAILLMClient", () => {
 
       expect(result.content).toBe("fallback output");
       expect(mockResponsesCreate).toHaveBeenCalledOnce();
+    });
+
+    it("passes reasoning effort to the Responses API fallback", async () => {
+      const client = new OpenAILLMClient({
+        apiKey: "sk-test",
+        model: "codex-mini-latest",
+        reasoningEffort: "high",
+      });
+      mockStream.mockImplementationOnce(() => {
+        throw new Error("This is not a chat model and not supported in the v1/chat/completions endpoint");
+      });
+      mockResponsesCreate.mockResolvedValueOnce({
+        output_text: "fallback output",
+        status: "completed",
+        usage: {
+          input_tokens: 12,
+          output_tokens: 7,
+        },
+      });
+
+      await client.sendMessageStream(
+        [{ role: "user", content: "hello" }],
+        undefined,
+        { onTextDelta: vi.fn() }
+      );
+
+      expect(mockResponsesCreate).toHaveBeenCalledWith(expect.objectContaining({
+        reasoning: { effort: "high" },
+      }));
     });
   });
 

--- a/src/base/llm/__tests__/provider-config.test.ts
+++ b/src/base/llm/__tests__/provider-config.test.ts
@@ -318,10 +318,17 @@ describe("resolveProviderNativeAgentLoopDefaults", () => {
 
 describe("MODEL_REGISTRY", () => {
   it("contains expected models", () => {
+    expect(MODEL_REGISTRY["gpt-5.5"]).toBeDefined();
     expect(MODEL_REGISTRY["gpt-5.4-mini"]).toBeDefined();
     expect(MODEL_REGISTRY["gpt-4.1"]).toBeDefined();
     expect(MODEL_REGISTRY["claude-sonnet-4-6"]).toBeDefined();
     expect(MODEL_REGISTRY["claude-haiku-4-5"]).toBeDefined();
+  });
+
+  it("gpt-5.5 is compatible with OpenAI execution adapters", () => {
+    const entry = MODEL_REGISTRY["gpt-5.5"];
+    expect(entry.provider).toBe("openai");
+    expect(entry.adapters).toEqual(expect.arrayContaining(["openai_codex_cli", "openai_api", "agent_loop"]));
   });
 
   it("gpt-4o-mini is not compatible with codex adapter", () => {
@@ -366,8 +373,8 @@ describe("loadProviderConfig", () => {
   const envKeys = [
     "PULSEED_PROVIDER", "PULSEED_LLM_PROVIDER",
     "PULSEED_ADAPTER", "PULSEED_DEFAULT_ADAPTER",
-    "PULSEED_MODEL", "PULSEED_LIGHT_MODEL",
-    "OPENAI_API_KEY", "OPENAI_MODEL", "OPENAI_BASE_URL",
+    "PULSEED_MODEL", "PULSEED_LIGHT_MODEL", "PULSEED_REASONING_EFFORT",
+    "OPENAI_API_KEY", "OPENAI_MODEL", "OPENAI_BASE_URL", "OPENAI_REASONING_EFFORT",
     "ANTHROPIC_API_KEY", "ANTHROPIC_MODEL",
     "OLLAMA_BASE_URL", "OLLAMA_MODEL",
   ];
@@ -556,6 +563,52 @@ describe("loadProviderConfig", () => {
 
     const config = await loadProviderConfig();
     expect(config.light_model).toBe("gpt-env-light");
+  });
+
+  it("loads OpenAI reasoning effort from flat config", async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      provider: "openai",
+      model: "gpt-5.5",
+      reasoning_effort: "low",
+      adapter: "openai_api",
+      api_key: "sk-test",
+    }));
+
+    const config = await loadProviderConfig();
+
+    expect(config.reasoning_effort).toBe("low");
+  });
+
+  it("PULSEED_REASONING_EFFORT overrides file reasoning_effort", async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      provider: "openai",
+      model: "gpt-5.5",
+      reasoning_effort: "high",
+      adapter: "openai_api",
+      api_key: "sk-test",
+    }));
+    process.env["PULSEED_REASONING_EFFORT"] = "xhigh";
+
+    const config = await loadProviderConfig();
+
+    expect(config.reasoning_effort).toBe("xhigh");
+  });
+
+  it("drops reasoning_effort for non-OpenAI providers", async () => {
+    mockAccess.mockResolvedValue(undefined);
+    mockReadFile.mockResolvedValue(JSON.stringify({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      reasoning_effort: "low",
+      adapter: "claude_api",
+      api_key: "sk-ant-test",
+    }));
+
+    const config = await loadProviderConfig();
+
+    expect(config.reasoning_effort).toBeUndefined();
   });
 
   it("resolves OpenAI API key from env file for embeddings", async () => {

--- a/src/base/llm/__tests__/provider-factory.test.ts
+++ b/src/base/llm/__tests__/provider-factory.test.ts
@@ -34,6 +34,10 @@ vi.mock("../../adapters/agents/openai-codex.js", () => ({
   OpenAICodexCLIAdapter: vi.fn().mockImplementation(function() { return {}; }),
 }));
 
+vi.mock("../../../adapters/agents/openai-codex.js", () => ({
+  OpenAICodexCLIAdapter: vi.fn().mockImplementation(function() { return {}; }),
+}));
+
 vi.mock("../../adapters/github-issue.js", () => ({
   GitHubIssueAdapter: vi.fn().mockImplementation(function() { return {}; }),
 }));
@@ -46,10 +50,11 @@ vi.mock("../provider-config.js", () => ({
   loadProviderConfig: () => mockLoadProviderConfig(),
 }));
 
-import { buildLLMClient } from "../provider-factory.js";
+import { buildAdapterRegistry, buildLLMClient } from "../provider-factory.js";
 import { LLMClient } from "../llm-client.js";
 import { OpenAILLMClient } from "../openai-client.js";
 import { CodexLLMClient } from "../codex-llm-client.js";
+import { OpenAICodexCLIAdapter } from "../../../adapters/agents/openai-codex.js";
 
 // ─── Tests ───
 
@@ -159,6 +164,25 @@ describe("buildLLMClient — early API key validation", () => {
 
       expect(MockedOpenAILLMClient).toHaveBeenCalledOnce();
     });
+
+    it("passes reasoning effort to OpenAILLMClient", async () => {
+      const MockedOpenAILLMClient = vi.mocked(OpenAILLMClient);
+      MockedOpenAILLMClient.mockClear();
+      mockLoadProviderConfig.mockResolvedValue({
+        provider: "openai",
+        model: "gpt-5.5",
+        reasoning_effort: "low",
+        adapter: "agent_loop",
+        api_key: "sk-test",
+      });
+
+      await buildLLMClient();
+
+      expect(MockedOpenAILLMClient).toHaveBeenCalledWith(expect.objectContaining({
+        model: "gpt-5.5",
+        reasoningEffort: "low",
+      }));
+    });
   });
 
   // ── openai with codex adapter ─────────────────────────────────────────────
@@ -186,6 +210,7 @@ describe("buildLLMClient — early API key validation", () => {
         codex_timeout_ms: 180000,
         codex_idle_timeout_ms: 30000,
         codex_retry_attempts: 4,
+        reasoning_effort: "high",
       });
 
       await buildLLMClient();
@@ -197,6 +222,7 @@ describe("buildLLMClient — early API key validation", () => {
         timeoutMs: 180000,
         idleTimeoutMs: 30000,
         retryAttempts: 4,
+        reasoningEffort: "high",
       }));
     });
 
@@ -209,6 +235,25 @@ describe("buildLLMClient — early API key validation", () => {
       });
 
       await expect(buildLLMClient()).resolves.not.toThrow();
+    });
+  });
+
+  describe("adapter registry", () => {
+    it("passes reasoning effort to OpenAICodexCLIAdapter", async () => {
+      const MockedOpenAICodexCLIAdapter = vi.mocked(OpenAICodexCLIAdapter);
+      MockedOpenAICodexCLIAdapter.mockClear();
+
+      await buildAdapterRegistry({} as never, {
+        provider: "openai",
+        model: "gpt-5.5",
+        reasoning_effort: "xhigh",
+        adapter: "openai_codex_cli",
+      });
+
+      expect(MockedOpenAICodexCLIAdapter).toHaveBeenCalledWith(expect.objectContaining({
+        model: "gpt-5.5",
+        reasoningEffort: "xhigh",
+      }));
     });
   });
 

--- a/src/base/llm/__tests__/provider-oauth.test.ts
+++ b/src/base/llm/__tests__/provider-oauth.test.ts
@@ -178,4 +178,36 @@ describe("loadProviderConfig OAuth fallback", () => {
 
     accessSpy.mockRestore();
   });
+
+  it("changes fingerprint when OpenAI reasoning effort changes", async () => {
+    const providerJsonPath = path.join(os.homedir(), ".pulseed", "provider.json");
+    const providerConfig = (reasoning_effort: string) => JSON.stringify({
+      provider: "openai",
+      model: "gpt-5.5",
+      reasoning_effort,
+      adapter: "openai_codex_cli",
+      api_key: "sk-test",
+    });
+
+    let providerReadCount = 0;
+    mockReadFile.mockImplementation(async (filePath: unknown) => {
+      if (filePath === providerJsonPath) {
+        providerReadCount += 1;
+        return providerConfig(providerReadCount === 1 ? "low" : "high");
+      }
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+
+    const fspModule = await import("node:fs/promises");
+    const accessSpy = vi.spyOn(fspModule, "access").mockResolvedValue(undefined);
+
+    const fingerprintA = await getProviderRuntimeFingerprint();
+    const fingerprintB = await getProviderRuntimeFingerprint();
+
+    expect(fingerprintA).not.toBe(fingerprintB);
+    expect(fingerprintA).toContain('"reasoning_effort":"low"');
+    expect(fingerprintB).toContain('"reasoning_effort":"high"');
+
+    accessSpy.mockRestore();
+  });
 });

--- a/src/base/llm/codex-llm-client.ts
+++ b/src/base/llm/codex-llm-client.ts
@@ -53,6 +53,8 @@ export interface CodexLLMClientConfig {
   model?: string;
   /** Light model for routine/cheap calls (model_tier: 'light'). Optional. */
   lightModel?: string;
+  /** Optional Codex reasoning effort override for supported models. */
+  reasoningEffort?: string;
   /** Repository path passed to Codex for workspace-aware execution. Default: "." */
   repoPath?: string;
   /** Total request timeout per call in milliseconds. Default: 120000 (2 minutes) */
@@ -82,6 +84,7 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
   private readonly cliPath: string;
   private readonly model: string | undefined;
   private readonly repoPath: string;
+  private readonly reasoningEffort: string | undefined;
   private readonly totalTimeoutMs: number;
   private readonly idleTimeoutMs: number;
   private readonly retryAttempts: number;
@@ -93,6 +96,7 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
     this.cliPath = config.cliPath ?? "codex";
     this.model = config.model;
     this.lightModel = config.lightModel;
+    this.reasoningEffort = config.reasoningEffort;
     this.repoPath = config.repoPath?.trim() || ".";
     this.totalTimeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.idleTimeoutMs = typeof config.idleTimeoutMs === "number" && Number.isFinite(config.idleTimeoutMs)
@@ -177,6 +181,10 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
 
       if (model) {
         spawnArgs.push("--model", model);
+      }
+
+      if (this.reasoningEffort) {
+        spawnArgs.push("-c", `model_reasoning_effort="${this.reasoningEffort}"`);
       }
 
       spawnArgs.push("-");

--- a/src/base/llm/openai-client.ts
+++ b/src/base/llm/openai-client.ts
@@ -9,11 +9,17 @@ import { LLMError } from "../utils/errors.js";
 const DEFAULT_MODEL = "gpt-4o";
 const DEFAULT_TEMPERATURE = 0.2;
 
+export type OpenAIReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
 /** Model prefixes that do not support the temperature parameter */
-const REASONING_MODEL_PREFIXES = ["o1", "o3", "o4"];
+const REASONING_MODEL_PREFIXES = ["o1", "o3", "o4", "gpt-5"];
 
 function isReasoningModel(model: string): boolean {
   return REASONING_MODEL_PREFIXES.some((prefix) => model.startsWith(prefix));
+}
+
+function shouldSendReasoningEffort(model: string, effort: OpenAIReasoningEffort | undefined): effort is OpenAIReasoningEffort {
+  return Boolean(effort) && (isReasoningModel(model) || model.includes("codex"));
 }
 
 function shouldFallbackToResponses(err: unknown): boolean {
@@ -36,6 +42,8 @@ export interface OpenAIClientConfig {
   baseURL?: string;
   /** Optional lighter model for routine tasks (observation, verification, etc.) */
   lightModel?: string;
+  /** Optional reasoning effort for supported OpenAI reasoning models. */
+  reasoningEffort?: OpenAIReasoningEffort;
 }
 
 /**
@@ -51,6 +59,7 @@ export interface OpenAIClientConfig {
 export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
   private readonly client: OpenAI;
   private readonly model: string;
+  private readonly reasoningEffort: OpenAIReasoningEffort | undefined;
 
   constructor(config: OpenAIClientConfig = {}) {
     super();
@@ -65,6 +74,7 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
       ...(config.baseURL ? { baseURL: config.baseURL } : {}),
     });
     this.lightModel = config.lightModel;
+    this.reasoningEffort = config.reasoningEffort;
   }
 
   /**
@@ -111,6 +121,7 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
           }
         : {}),
       ...(isReasoningModel(model) ? {} : { temperature }),
+      ...(shouldSendReasoningEffort(model, this.reasoningEffort) ? { reasoning_effort: this.reasoningEffort } : {}),
     };
 
     let lastError: unknown;
@@ -140,7 +151,7 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
           // Some models (notably Codex-style) are not compatible with the
           // chat completions endpoint. In that case, fall back to Responses API.
           if (!shouldFallbackToResponses(err)) throw err;
-          return this.sendViaResponsesApi(model, messages, { max_tokens, temperature, system });
+          return this.sendViaResponsesApi(model, messages, { max_tokens, temperature, system, reasoningEffort: this.reasoningEffort });
         }
       } catch (err) {
         lastError = err;
@@ -204,6 +215,7 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
           }
         : {}),
       ...(isReasoningModel(model) ? {} : { temperature }),
+      ...(shouldSendReasoningEffort(model, this.reasoningEffort) ? { reasoning_effort: this.reasoningEffort } : {}),
     };
 
     try {
@@ -230,14 +242,14 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
       };
     } catch (err) {
       if (!shouldFallbackToResponses(err)) throw err;
-      return this.sendViaResponsesApi(model, messages, { max_tokens, temperature, system });
+      return this.sendViaResponsesApi(model, messages, { max_tokens, temperature, system, reasoningEffort: this.reasoningEffort });
     }
   }
 
   private async sendViaResponsesApi(
     model: string,
     messages: LLMMessage[],
-    options: { max_tokens: number; temperature: number; system?: string }
+    options: { max_tokens: number; temperature: number; system?: string; reasoningEffort?: OpenAIReasoningEffort }
   ): Promise<LLMResponse> {
     const input = [
       options.system ? `SYSTEM:\n${options.system}` : null,
@@ -263,6 +275,7 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
         input,
         max_output_tokens: options.max_tokens,
         ...(isReasoningModel(model) ? {} : { temperature: options.temperature }),
+        ...(shouldSendReasoningEffort(model, options.reasoningEffort) ? { reasoning: { effort: options.reasoningEffort } } : {}),
       }),
       timeout,
     ]) as Record<string, unknown>;

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -53,6 +53,7 @@ export async function readCodexOAuthToken(): Promise<string | undefined> {
  * Ollama models are dynamic and not listed here.
  */
 export const MODEL_REGISTRY: Record<string, { provider: string; adapters: string[] }> = {
+  "gpt-5.5": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
   "gpt-5.4": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
   "gpt-5.2-codex": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
   "gpt-5.1-codex-max": { provider: "openai", adapters: ["openai_codex_cli", "openai_api", "agent_loop"] },
@@ -80,6 +81,9 @@ export interface ProviderConfig {
   /** Optional lighter model for routine tasks (observation, verification, reflection).
    *  When not set, all calls use `model`. */
   light_model?: string;
+
+  /** Optional OpenAI reasoning effort for supported reasoning models. */
+  reasoning_effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
   /** Which adapter to use by default for task execution */
   adapter: "claude_code_cli" | "claude_api" | "openai_codex_cli" | "openai_api" | "agent_loop";
@@ -303,6 +307,15 @@ export function validateProviderConfig(config: ProviderConfig): ValidationResult
     errors.push(`API key required for ${providerLabel}. Set ${envName} or add api_key to config.`);
   }
 
+  if (config.reasoning_effort !== undefined) {
+    if (config.provider !== "openai") {
+      errors.push("reasoning_effort is only supported for provider \"openai\".");
+    }
+    if (!isReasoningEffort(config.reasoning_effort)) {
+      errors.push(`Invalid reasoning_effort "${String(config.reasoning_effort)}". Valid: none, minimal, low, medium, high, xhigh`);
+    }
+  }
+
   return { valid: errors.length === 0, errors };
 }
 
@@ -404,6 +417,32 @@ function resolveLightModel(
   envFile: Record<string, string>
 ): string | undefined {
   return process.env["PULSEED_LIGHT_MODEL"] ?? envFile["PULSEED_LIGHT_MODEL"] ?? fileLightModel;
+}
+
+export function isReasoningEffort(value: unknown): value is NonNullable<ProviderConfig["reasoning_effort"]> {
+  return value === "none"
+    || value === "minimal"
+    || value === "low"
+    || value === "medium"
+    || value === "high"
+    || value === "xhigh";
+}
+
+function resolveReasoningEffort(
+  fileReasoningEffort: ProviderConfig["reasoning_effort"] | undefined,
+  provider: ProviderConfig["provider"],
+  envFile: Record<string, string>
+): ProviderConfig["reasoning_effort"] | undefined {
+  if (provider !== "openai") return undefined;
+  const envValue = process.env["PULSEED_REASONING_EFFORT"]
+    ?? process.env["OPENAI_REASONING_EFFORT"]
+    ?? envFile["PULSEED_REASONING_EFFORT"]
+    ?? envFile["OPENAI_REASONING_EFFORT"];
+  if (isReasoningEffort(envValue)) return envValue;
+  if (envValue) {
+    console.warn(`[provider-config] Ignoring invalid reasoning effort "${envValue}".`);
+  }
+  return isReasoningEffort(fileReasoningEffort) ? fileReasoningEffort : undefined;
 }
 
 function parseEnvFile(raw: string): Record<string, string> {
@@ -523,6 +562,7 @@ async function resolveProviderConfig(
   const apiKey = await resolveApiKeyWithFallback(fileConfig.api_key, provider, adapter, envFile);
   const baseUrl = resolveBaseUrl(fileConfig.base_url, provider, envFile);
   const lightModel = resolveLightModel(fileConfig.light_model, envFile);
+  const reasoningEffort = resolveReasoningEffort(fileConfig.reasoning_effort, provider, envFile);
 
   const config: ProviderConfig = { provider, model, adapter };
   if (apiKey !== undefined) config.api_key = apiKey;
@@ -534,6 +574,7 @@ async function resolveProviderConfig(
   if (fileConfig.terminal_backend !== undefined) config.terminal_backend = fileConfig.terminal_backend;
   if (fileConfig.a2a !== undefined) config.a2a = fileConfig.a2a;
   if (lightModel !== undefined) config.light_model = lightModel;
+  if (reasoningEffort !== undefined) config.reasoning_effort = reasoningEffort;
   if (fileConfig.openclaw !== undefined) config.openclaw = fileConfig.openclaw;
   config.agent_loop = resolveProviderNativeAgentLoopConfigShape(fileConfig);
   return config;
@@ -578,6 +619,7 @@ function providerFileOnlyConfig(fileConfig: Partial<ProviderConfig>): ProviderCo
   if (fileConfig.codex_retry_attempts !== undefined) fileOnly.codex_retry_attempts = fileConfig.codex_retry_attempts;
   if (fileConfig.terminal_backend !== undefined) fileOnly.terminal_backend = fileConfig.terminal_backend;
   if (fileConfig.a2a !== undefined) fileOnly.a2a = fileConfig.a2a;
+  if (fileConfig.reasoning_effort !== undefined) fileOnly.reasoning_effort = fileConfig.reasoning_effort;
   if (fileConfig.agent_loop !== undefined) fileOnly.agent_loop = fileConfig.agent_loop;
   return fileOnly;
 }
@@ -636,6 +678,7 @@ export async function getProviderRuntimeFingerprint(): Promise<string> {
     model: config.model,
     adapter: config.adapter,
     light_model: config.light_model ?? null,
+    reasoning_effort: config.reasoning_effort ?? null,
     base_url: config.base_url ?? null,
     codex_cli_path: config.codex_cli_path ?? null,
     codex_timeout_ms: config.codex_timeout_ms ?? null,

--- a/src/base/llm/provider-factory.ts
+++ b/src/base/llm/provider-factory.ts
@@ -52,6 +52,7 @@ export async function buildLLMClient(): Promise<ILLMClient> {
           timeoutMs: config.codex_timeout_ms,
           idleTimeoutMs: config.codex_idle_timeout_ms,
           retryAttempts: config.codex_retry_attempts,
+          reasoningEffort: config.reasoning_effort,
           sandboxPolicy: executionPolicy.sandboxMode === "danger_full_access" ? "danger-full-access" : executionPolicy.sandboxMode.replace("_", "-"),
         });
       }
@@ -66,6 +67,7 @@ export async function buildLLMClient(): Promise<ILLMClient> {
         model: config.model,
         baseURL: config.base_url,
         lightModel: config.light_model,
+        reasoningEffort: config.reasoning_effort,
       });
     }
 
@@ -96,6 +98,7 @@ export async function buildLLMClient(): Promise<ILLMClient> {
         model: config.model,
         baseURL: config.base_url,
         lightModel: config.light_model,
+        reasoningEffort: config.reasoning_effort,
       });
   }
 }
@@ -118,6 +121,7 @@ export async function buildAdapterRegistry(
   registry.register(new OpenAICodexCLIAdapter({
     cliPath: config.codex_cli_path,
     model: config.model,
+    reasoningEffort: config.reasoning_effort,
     sandboxPolicy: resolveExecutionPolicy({
       workspaceRoot: process.cwd(),
       security: config.agent_loop?.security,

--- a/src/interface/chat/chat-runner-command-helpers.ts
+++ b/src/interface/chat/chat-runner-command-helpers.ts
@@ -18,6 +18,7 @@ export interface ProviderConfigSummary {
   model: string;
   adapter: string;
   light_model?: string;
+  reasoning_effort?: string;
   base_url?: string;
   codex_cli_path?: string;
   has_api_key: boolean;
@@ -152,6 +153,7 @@ export async function readProviderConfigSummary(stateManager: StateManager): Pro
     model: config.model,
     adapter: config.adapter,
     light_model: config.light_model,
+    reasoning_effort: config.reasoning_effort,
     base_url: config.base_url,
     codex_cli_path: config.codex_cli_path,
     has_api_key: Boolean(config.api_key),

--- a/src/interface/chat/chat-state-service.ts
+++ b/src/interface/chat/chat-state-service.ts
@@ -9,6 +9,7 @@ export interface ProviderConfigSummary {
   model: string;
   adapter: string;
   light_model?: string;
+  reasoning_effort?: string;
   base_url?: string;
   codex_cli_path?: string;
   has_api_key: boolean;
@@ -84,6 +85,7 @@ export class ChatStateService {
       model: config.model,
       adapter: config.adapter,
       light_model: config.light_model,
+      reasoning_effort: config.reasoning_effort,
       base_url: config.base_url,
       codex_cli_path: config.codex_cli_path,
       has_api_key: Boolean(config.api_key),

--- a/src/interface/cli/__tests__/cli-setup-notification.test.ts
+++ b/src/interface/cli/__tests__/cli-setup-notification.test.ts
@@ -352,6 +352,7 @@ describe("setup notification step", () => {
       options: Array<{ label: string; value: string; hint?: string }>;
     };
     expect(prompt.options.map((option) => option.label)).toEqual([
+      "GPT-5.5",
       "GPT-5.4",
       "GPT-5.2-Codex",
       "GPT-5.1-Codex-Max",

--- a/src/interface/cli/__tests__/cli-setup.test.ts
+++ b/src/interface/cli/__tests__/cli-setup.test.ts
@@ -93,8 +93,27 @@ describe("cmdSetup non-interactive", () => {
 
     const config = await readConfig();
     expect(config.provider).toBe("openai");
-    expect(config.model).toBe("gpt-5.4-mini");
+    expect(config.model).toBe("gpt-5.5");
     expect(config.adapter).toBe("agent_loop");
+  });
+
+  it("saves OpenAI reasoning effort when provided", async () => {
+    process.env["OPENAI_API_KEY"] = "sk-test-key-12345678";
+    const { cmdSetup } = await import("../commands/setup.js");
+
+    const result = await cmdSetup([
+      "--provider", "openai",
+      "--model", "gpt-5.5",
+      "--adapter", "openai_api",
+      "--reasoning-effort", "low",
+    ]);
+
+    expect(result).toBe(0);
+
+    const config = await readConfig();
+    expect(config.provider).toBe("openai");
+    expect(config.model).toBe("gpt-5.5");
+    expect(config.reasoning_effort).toBe("low");
   });
 
   it("uses default model for anthropic when --model is not provided", async () => {

--- a/src/interface/cli/__tests__/setup-shared.test.ts
+++ b/src/interface/cli/__tests__/setup-shared.test.ts
@@ -61,6 +61,7 @@ describe("getModelsForProvider", () => {
     const models = getModelsForProvider("openai");
     expect(models.length).toBeGreaterThan(0);
     expect(models).toEqual([
+      "gpt-5.5",
       "gpt-5.4",
       "gpt-5.2-codex",
       "gpt-5.1-codex-max",

--- a/src/interface/cli/commands/config.ts
+++ b/src/interface/cli/commands/config.ts
@@ -9,7 +9,7 @@ import { writeJsonFile, readJsonFile } from "../../../base/utils/json-io.js";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { CharacterConfigManager } from "../../../platform/traits/character-config.js";
 
-import { loadProviderConfig, saveProviderConfig } from "../../../base/llm/provider-config.js";
+import { isReasoningEffort, loadProviderConfig, saveProviderConfig } from "../../../base/llm/provider-config.js";
 import type { ProviderConfig } from "../../../base/llm/provider-config.js";
 import { buildLLMClient } from "../../../base/llm/provider-factory.js";
 import { ReportingEngine } from "../../../reporting/reporting-engine.js";
@@ -45,6 +45,7 @@ export async function cmdProvider(argv: string[]): Promise<number> {
       "agentloop-worktree-base-dir"?: string;
       "agentloop-worktree-keep-debug"?: string;
       "agentloop-worktree-cleanup"?: string;
+      "reasoning-effort"?: string;
     };
     try {
       ({ values } = parseArgs({
@@ -58,6 +59,7 @@ export async function cmdProvider(argv: string[]): Promise<number> {
           "agentloop-worktree-base-dir": { type: "string" },
           "agentloop-worktree-keep-debug": { type: "string" },
           "agentloop-worktree-cleanup": { type: "string" },
+          "reasoning-effort": { type: "string" },
         },
         strict: false,
       }) as {
@@ -70,6 +72,7 @@ export async function cmdProvider(argv: string[]): Promise<number> {
           "agentloop-worktree-base-dir"?: string;
           "agentloop-worktree-keep-debug"?: string;
           "agentloop-worktree-cleanup"?: string;
+          "reasoning-effort"?: string;
         };
       });
     } catch (err) {
@@ -113,6 +116,10 @@ export async function cmdProvider(argv: string[]): Promise<number> {
       getCliLogger().error('Error: --agentloop-worktree-cleanup must be one of "on_success", "always", "never".');
       return 1;
     }
+    if (values["reasoning-effort"] && !isReasoningEffort(values["reasoning-effort"])) {
+      getCliLogger().error('Error: --reasoning-effort must be one of "none", "minimal", "low", "medium", "high", "xhigh".');
+      return 1;
+    }
 
     const current = await loadProviderConfig();
     const resolvedProvider = (values.provider ?? providerValue) as ProviderConfig["provider"] | undefined;
@@ -127,6 +134,9 @@ export async function cmdProvider(argv: string[]): Promise<number> {
       ...current,
       ...(resolvedProvider ? { provider: resolvedProvider } : {}),
       ...(values.model ? { model: values.model } : {}),
+      ...(values["reasoning-effort"] && (resolvedProvider ?? current.provider) === "openai"
+        ? { reasoning_effort: values["reasoning-effort"] as ProviderConfig["reasoning_effort"] }
+        : {}),
       ...(values.adapter ? { adapter: values.adapter as ProviderConfig["adapter"] } : {}),
       ...((values["agentloop-worktree"]
         || values["agentloop-worktree-base-dir"] !== undefined
@@ -135,6 +145,9 @@ export async function cmdProvider(argv: string[]): Promise<number> {
         ? { agent_loop: { ...(current.agent_loop ?? {}), worktree: nextWorktree } }
         : {}),
     };
+    if ((resolvedProvider ?? updated.provider) !== "openai") {
+      delete updated.reasoning_effort;
+    }
 
     await saveProviderConfig(updated);
     console.log("Provider config updated:");

--- a/src/interface/cli/commands/setup-shared.ts
+++ b/src/interface/cli/commands/setup-shared.ts
@@ -22,12 +22,13 @@ export const ENV_KEY_NAMES: Partial<Record<Provider, string>> = {
 };
 
 export const RECOMMENDED_MODELS: Record<string, string> = {
-  openai: "gpt-5.4-mini",
+  openai: "gpt-5.5",
   anthropic: "claude-sonnet-4-6",
   ollama: "qwen3:4b",
 };
 
 const OPENAI_MODEL_ORDER = [
+  "gpt-5.5",
   "gpt-5.4",
   "gpt-5.2-codex",
   "gpt-5.1-codex-max",
@@ -39,6 +40,7 @@ const OPENAI_MODEL_ORDER = [
 ] as const;
 
 const OPENAI_MODEL_LABELS: Record<string, string> = {
+  "gpt-5.5": "GPT-5.5",
   "gpt-5.4": "GPT-5.4",
   "gpt-5.2-codex": "GPT-5.2-Codex",
   "gpt-5.1-codex-max": "GPT-5.1-Codex-Max",
@@ -48,6 +50,9 @@ const OPENAI_MODEL_LABELS: Record<string, string> = {
   "gpt-5.2": "GPT-5.2",
   "gpt-5.1-codex-mini": "GPT-5.1-Codex-Mini",
 };
+
+export const REASONING_EFFORTS = ["none", "minimal", "low", "medium", "high", "xhigh"] as const;
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
 
 export const RECOMMENDED_ADAPTERS: Partial<Record<Provider, string>> = {
   openai: "agent_loop",

--- a/src/interface/cli/commands/setup-wizard.ts
+++ b/src/interface/cli/commands/setup-wizard.ts
@@ -19,7 +19,7 @@ import { readCodexOAuthToken } from "../../../base/llm/provider-config.js";
 import { isDaemonRunning } from "../../../runtime/daemon/client.js";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { ROOT_PRESETS } from "./presets/root-presets.js";
-import { MODEL_REGISTRY, detectApiKeys, getAdaptersForModel, maskKey } from "./setup-shared.js";
+import { MODEL_REGISTRY, REASONING_EFFORTS, detectApiKeys, getAdaptersForModel, maskKey } from "./setup-shared.js";
 import type { Provider } from "./setup-shared.js";
 import { getBanner, stepExistingConfig, stepUserName, stepSeedyName } from "./setup/steps-identity.js";
 import { stepRootPreset, stepProvider, stepModel, stepApiKey, runCodexOAuthLogin, stepOpenAIAuthMethod } from "./setup/steps-provider.js";
@@ -44,6 +44,7 @@ type SetupAnswers = {
   importedUserContent?: string;
   provider: Provider;
   model: string;
+  reasoningEffort?: ProviderConfig["reasoning_effort"];
   adapter: string;
   apiKey?: string;
   startDaemon: boolean;
@@ -53,7 +54,7 @@ type SetupAnswers = {
 };
 
 type IdentityAnswers = Pick<SetupAnswers, "userName" | "agentName" | "rootPreset">;
-type ExecutionAnswers = Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">;
+type ExecutionAnswers = Pick<SetupAnswers, "provider" | "model" | "reasoningEffort" | "adapter" | "apiKey">;
 type RuntimeAnswers = Pick<SetupAnswers, "startDaemon" | "daemonPort" | "notificationConfig" | "gatewaySetup">;
 type FullSetupSection = "identity" | "execution" | "runtime" | "review";
 type ResidentReadinessState = "ready" | "partial" | "blocked";
@@ -80,6 +81,7 @@ function formatSummary(answers: SetupAnswers): string {
     `Style:     ${ROOT_PRESETS[answers.rootPreset].name}`,
     `Provider:  ${answers.provider}`,
     `Model:     ${answers.model}`,
+    ...(answers.reasoningEffort ? [`Reasoning: ${answers.reasoningEffort}`] : []),
     formatAuthSummary(answers),
     formatCredentialSummary(answers),
     `Daemon:    ${answers.startDaemon ? `configured (port ${answers.daemonPort})` : "not configured"}`,
@@ -89,11 +91,12 @@ function formatSummary(answers: SetupAnswers): string {
 }
 
 function formatExecutionSummary(
-  execution: Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">
+  execution: Pick<SetupAnswers, "provider" | "model" | "reasoningEffort" | "adapter" | "apiKey">
 ): string {
   return [
     `Provider:  ${execution.provider}`,
     `Model:     ${execution.model}`,
+    ...(execution.reasoningEffort ? [`Reasoning: ${execution.reasoningEffort}`] : []),
     formatAuthSummary(execution),
     formatCredentialSummary(execution),
   ].join("\n");
@@ -145,6 +148,7 @@ function formatImportSetupSummary(
     `Source:    ${sourceNames}`,
     `Provider:  ${providerPatch.provider}`,
     `Model:     ${providerPatch.model ?? "not found"}`,
+    ...(providerPatch.reasoning_effort ? [`Reasoning: ${providerPatch.reasoning_effort}`] : []),
     formatAuthSummary({
       provider: providerPatch.provider,
       adapter: providerPatch.adapter ?? "agent_loop",
@@ -156,7 +160,7 @@ function formatImportSetupSummary(
 }
 
 function buildProviderConfig(
-  execution: Pick<SetupAnswers, "provider" | "model" | "adapter" | "apiKey">,
+  execution: Pick<SetupAnswers, "provider" | "model" | "reasoningEffort" | "adapter" | "apiKey">,
   base?: Partial<ProviderConfig>
 ): ProviderConfig {
   const config: ProviderConfig = {
@@ -165,6 +169,11 @@ function buildProviderConfig(
     model: execution.model,
     adapter: execution.adapter as ProviderConfig["adapter"],
   };
+  if (execution.provider === "openai" && execution.reasoningEffort) {
+    config.reasoning_effort = execution.reasoningEffort;
+  } else {
+    delete config.reasoning_effort;
+  }
 
   if (execution.apiKey) {
     config.api_key = execution.apiKey;
@@ -296,6 +305,29 @@ function defaultExecutionAdapter(provider: Provider, model: string): string {
   return adapters[0] ?? "";
 }
 
+async function stepReasoningEffort(
+  provider: Provider,
+  model: string,
+  initialReasoningEffort?: ProviderConfig["reasoning_effort"]
+): Promise<ProviderConfig["reasoning_effort"] | undefined> {
+  if (provider !== "openai") return undefined;
+  if (!initialReasoningEffort && model !== "gpt-5.5") return undefined;
+  const choice = guardCancel(
+    await p.select({
+      message: "Select OpenAI reasoning effort:",
+      options: [
+        { value: "__unset__" as const, label: "Default", hint: "use provider/model default" },
+        ...REASONING_EFFORTS.map((effort) => ({
+          value: effort,
+          label: effort,
+        })),
+      ],
+      initialValue: initialReasoningEffort ?? "__unset__",
+    })
+  );
+  return choice === "__unset__" ? undefined : choice as ProviderConfig["reasoning_effort"];
+}
+
 async function stepExecutionConfig(
   current?: ExecutionAnswers,
   mode: "interactive" | "imported" = "interactive"
@@ -309,13 +341,20 @@ async function stepExecutionConfig(
           provider,
           mode === "interactive" && current?.provider === provider ? current.model : undefined
         );
+  const reasoningEffort = mode === "imported"
+    ? current?.reasoningEffort
+    : await stepReasoningEffort(
+        provider,
+        model,
+        current?.provider === provider ? current.reasoningEffort : undefined
+      );
   const adaptersForModel = getAdaptersForModel(model, provider);
   const compatibleCurrentAdapter =
     current?.adapter && adaptersForModel.includes(current.adapter)
       ? current.adapter
       : undefined;
   let adapter = compatibleCurrentAdapter ?? defaultExecutionAdapter(provider, model);
-  if (!adapter) return { provider, model, adapter, apiKey: current?.apiKey };
+  if (!adapter) return { provider, model, reasoningEffort, adapter, apiKey: current?.apiKey };
 
   if (
     provider === "openai" &&
@@ -348,7 +387,7 @@ async function stepExecutionConfig(
     !validImportedApiKey
   ) {
     const auth = await stepMissingOpenAiAuth(model, adapter, adaptersForModel, current?.apiKey);
-    return { provider, model, adapter: auth.adapter, apiKey: auth.apiKey };
+    return { provider, model, reasoningEffort, adapter: auth.adapter, apiKey: auth.apiKey };
   }
 
   const apiKey =
@@ -357,7 +396,7 @@ async function stepExecutionConfig(
       : current?.provider === provider
         ? await stepApiKey(provider, detectedKeys, current.apiKey, adapter)
         : await stepApiKey(provider, detectedKeys, undefined, adapter);
-  return { provider, model, adapter, apiKey };
+  return { provider, model, reasoningEffort, adapter, apiKey };
 }
 
 async function stepIdentityConfig(
@@ -633,6 +672,7 @@ export async function runSetupWizard(): Promise<number> {
       let execution = await stepExecutionConfig({
         provider: existingConfig.provider,
         model: existingConfig.model,
+        reasoningEffort: existingConfig.reasoning_effort,
         adapter: existingConfig.adapter,
         apiKey: existingConfig.api_key,
       });
@@ -676,6 +716,7 @@ export async function runSetupWizard(): Promise<number> {
     importedUserContent: importSelection?.userSettings?.content,
     provider: importedProviderPatch?.provider ?? "openai",
     model: importedProviderPatch?.model ?? "",
+    reasoningEffort: importedProviderPatch?.reasoning_effort,
     adapter: importedProviderPatch?.adapter ?? "",
     apiKey: importedProviderPatch?.api_key,
     startDaemon: false,

--- a/src/interface/cli/commands/setup.ts
+++ b/src/interface/cli/commands/setup.ts
@@ -14,6 +14,7 @@ import {
   RECOMMENDED_MODELS,
   RECOMMENDED_ADAPTERS,
   MODEL_REGISTRY,
+  REASONING_EFFORTS,
   getAdaptersForModel,
 } from "./setup-shared.js";
 import type { Provider } from "./setup-shared.js";
@@ -30,6 +31,7 @@ async function runNonInteractive(argv: string[]): Promise<number> {
     "agentloop-worktree-base-dir"?: string;
     "agentloop-worktree-keep-debug"?: string;
     "agentloop-worktree-cleanup"?: string;
+    "reasoning-effort"?: string;
   };
   try {
     ({ values } = parseArgs({
@@ -42,6 +44,7 @@ async function runNonInteractive(argv: string[]): Promise<number> {
         "agentloop-worktree-base-dir": { type: "string" },
         "agentloop-worktree-keep-debug": { type: "string" },
         "agentloop-worktree-cleanup": { type: "string" },
+        "reasoning-effort": { type: "string" },
       },
       strict: false,
     }) as {
@@ -52,7 +55,8 @@ async function runNonInteractive(argv: string[]): Promise<number> {
         "agentloop-worktree"?: string;
         "agentloop-worktree-base-dir"?: string;
         "agentloop-worktree-keep-debug"?: string;
-        "agentloop-worktree-cleanup"?: string;
+          "agentloop-worktree-cleanup"?: string;
+          "reasoning-effort"?: string;
       };
     });
   } catch {
@@ -105,6 +109,10 @@ async function runNonInteractive(argv: string[]): Promise<number> {
     console.error('Error: --agentloop-worktree-cleanup must be one of "on_success", "always", "never".');
     return 1;
   }
+  if (values["reasoning-effort"] && !REASONING_EFFORTS.includes(values["reasoning-effort"] as (typeof REASONING_EFFORTS)[number])) {
+    console.error(`Error: --reasoning-effort must be one of ${REASONING_EFFORTS.join(", ")}.`);
+    return 1;
+  }
 
   // Validate adapter compatibility
   if (registryEntry && !registryEntry.adapters.includes(adapter)) {
@@ -141,6 +149,9 @@ async function runNonInteractive(argv: string[]): Promise<number> {
       },
     };
   }
+  if (provider === "openai" && values["reasoning-effort"]) {
+    config.reasoning_effort = values["reasoning-effort"] as ProviderConfig["reasoning_effort"];
+  }
 
   const validation = validateProviderConfig(config);
   if (!validation.valid) {
@@ -154,6 +165,7 @@ async function runNonInteractive(argv: string[]): Promise<number> {
   console.log("Setup complete! Configuration saved to ~/.pulseed/provider.json");
   console.log(`  Provider: ${config.provider}`);
   console.log(`  Model:    ${config.model}`);
+  if (config.reasoning_effort) console.log(`  Reasoning:${config.reasoning_effort}`);
   console.log(`  Auth:     ${formatAuthForSetup(config)}`);
   return 0;
 }
@@ -175,6 +187,8 @@ Interactive setup wizard for provider configuration.
 Options:
   --provider <name>   LLM provider (openai, anthropic, ollama)
   --model <name>      Model name (e.g., gpt-5.4-mini)
+  --reasoning-effort <effort>
+                      OpenAI reasoning effort (none, minimal, low, medium, high, xhigh)
   --agentloop-worktree <on|off>
                       Enable isolated git worktrees for native task agentloop
   --agentloop-worktree-base-dir <path>

--- a/src/interface/cli/commands/setup/import/flow.ts
+++ b/src/interface/cli/commands/setup/import/flow.ts
@@ -31,6 +31,7 @@ function providerPreview(settings: SetupImportProviderSettings | undefined): str
   return [
     settings.provider ? `provider=${settings.provider}` : undefined,
     settings.model ? `model=${settings.model}` : undefined,
+    settings.reasoningEffort ? `reasoning_effort=${settings.reasoningEffort}` : undefined,
     settings.adapter ? `adapter=${settings.adapter}` : undefined,
     settings.apiKey ? `api_key=${maskKey(settings.apiKey)}` : undefined,
     settings.baseUrl ? `base_url=${settings.baseUrl}` : undefined,
@@ -87,6 +88,7 @@ function defaultProviderConfigFromImport(
   return {
     ...(settings.provider ? { provider: settings.provider } : {}),
     ...(settings.model ? { model: settings.model } : {}),
+    ...(settings.reasoningEffort ? { reasoning_effort: settings.reasoningEffort } : {}),
     ...(settings.adapter ? { adapter: settings.adapter } : {}),
     ...(settings.apiKey ? { api_key: settings.apiKey } : {}),
     ...(settings.baseUrl ? { base_url: settings.baseUrl } : {}),

--- a/src/interface/cli/commands/setup/import/provider.ts
+++ b/src/interface/cli/commands/setup/import/provider.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 import type { ProviderConfig } from "../../../../../base/llm/provider-config.js";
-import { MODEL_REGISTRY } from "../../../../../base/llm/provider-config.js";
+import { MODEL_REGISTRY, isReasoningEffort } from "../../../../../base/llm/provider-config.js";
 import { PROVIDERS, getAdaptersForModel } from "../../setup-shared.js";
 import type { Provider } from "../../setup-shared.js";
 import { SOURCE_LABELS } from "./constants.js";
@@ -21,6 +21,7 @@ const PROVIDER_KEYS = [
 ];
 
 const MODEL_KEYS = ["model", "default_model", "defaultModel", "modelName"];
+const REASONING_EFFORT_KEYS = ["reasoning_effort", "reasoningEffort", "model_reasoning_effort", "modelReasoningEffort"];
 const ADAPTER_KEYS = ["adapter", "default_adapter", "defaultAdapter", "backend", "terminalBackend"];
 const API_KEY_KEYS = ["api_key", "apiKey", "openai_api_key", "anthropic_api_key", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"];
 const SECTION_API_KEY_KEYS = [
@@ -214,10 +215,12 @@ export function extractProviderSettings(
   const apiKey = providerApiKey(provider, searchable, env);
   const baseUrl = firstString(searchable, BASE_URL_KEYS);
   const codexCliPath = firstString(searchable, CLI_PATH_KEYS);
+  const reasoningEffort = firstString(searchable, REASONING_EFFORT_KEYS);
 
   const settings: SetupImportProviderSettings = {};
   if (provider) settings.provider = provider;
   if (model) settings.model = model;
+  if (isReasoningEffort(reasoningEffort)) settings.reasoningEffort = reasoningEffort;
   if (adapter) settings.adapter = adapter;
   if (apiKey) settings.apiKey = apiKey;
   if (baseUrl) settings.baseUrl = baseUrl;

--- a/src/interface/cli/commands/setup/import/types.ts
+++ b/src/interface/cli/commands/setup/import/types.ts
@@ -11,6 +11,7 @@ export type SetupImportDecision = "import" | "copy_disabled" | "skip";
 export interface SetupImportProviderSettings {
   provider?: ProviderConfig["provider"];
   model?: string;
+  reasoningEffort?: ProviderConfig["reasoning_effort"];
   adapter?: ProviderConfig["adapter"];
   apiKey?: string;
   baseUrl?: string;

--- a/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-factory.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-factory.test.ts
@@ -17,8 +17,9 @@ import {
 function makeProviderConfig(): ProviderConfig {
   return {
     provider: "openai",
-    model: "gpt-5.4-mini",
+    model: "gpt-5.5",
     adapter: "openai_codex_cli",
+    reasoning_effort: "high",
     agent_loop: {
       security: {
         sandbox_mode: "workspace_write",
@@ -39,8 +40,9 @@ function makeProviderConfig(): ProviderConfig {
 function makeProviderConfigWithoutAgentLoop(): ProviderConfig {
   return {
     provider: "openai",
-    model: "gpt-5.4-mini",
+    model: "gpt-5.5",
     adapter: "openai_codex_cli",
+    reasoning_effort: "minimal",
   } as ProviderConfig;
 }
 
@@ -80,6 +82,7 @@ describe("createNative*AgentLoopRunner", () => {
     expect(deps.defaultBudget).toEqual(profile.budget);
     expect(deps.defaultToolPolicy).toEqual(profile.toolPolicy);
     expect(deps.defaultReasoningEffort).toBe(profile.reasoningEffort);
+    expect(deps.defaultReasoningEffort).toBe("high");
     expect(deps.defaultProfileName).toBe(profile.name);
     expect(deps.defaultExecutionPolicy).toEqual(profile.executionPolicy);
     expect(deps.defaultWorktreePolicy).toEqual(profile.worktreePolicy);
@@ -112,6 +115,7 @@ describe("createNative*AgentLoopRunner", () => {
     expect(deps.defaultBudget).toEqual(profile.budget);
     expect(deps.defaultToolPolicy).toEqual(profile.toolPolicy);
     expect(deps.defaultReasoningEffort).toBe(profile.reasoningEffort);
+    expect(deps.defaultReasoningEffort).toBe("minimal");
     expect(deps.defaultProfileName).toBe(profile.name);
     expect(deps.defaultExecutionPolicy).toEqual(profile.executionPolicy);
     expect(deps.defaultWorktreePolicy).toEqual(profile.worktreePolicy);
@@ -148,6 +152,7 @@ describe("createNative*AgentLoopRunner", () => {
     expect(deps.defaultBudget).toEqual(profile.budget);
     expect(deps.defaultToolPolicy).toEqual(profile.toolPolicy);
     expect(deps.defaultReasoningEffort).toBe(profile.reasoningEffort);
+    expect(deps.defaultReasoningEffort).toBe("high");
     expect(deps.defaultProfileName).toBe(profile.name);
     expect(deps.defaultExecutionPolicy).toEqual(profile.executionPolicy);
     expect(profile.toolPolicy.allowedTools).toEqual(
@@ -274,6 +279,19 @@ describe("createNative*AgentLoopRunner", () => {
     expect(deps.defaultBudget).toEqual(profile.budget);
     expect(deps.defaultToolPolicy).toEqual(profile.toolPolicy);
     expect(deps.defaultReasoningEffort).toBe(profile.reasoningEffort);
+    expect(deps.defaultReasoningEffort).toBe("high");
     expect(deps.defaultExecutionPolicy).toEqual(profile.executionPolicy);
+  });
+
+  it("keeps explicit native profile reasoning above provider config reasoning", () => {
+    const providerConfig = makeProviderConfig();
+    const profile = resolveAgentLoopDefaultProfileFromProviderConfig({
+      surface: "task",
+      workspaceRoot: "/repo",
+      providerConfig,
+      reasoningEffort: "low",
+    });
+
+    expect(profile.reasoningEffort).toBe("low");
   });
 });

--- a/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-default-profile.ts
@@ -69,7 +69,7 @@ export type ResolveAgentLoopDefaultProfileInput =
 export interface ResolveAgentLoopDefaultProfileFromProviderConfigInput {
   surface: "task" | "chat" | "review";
   workspaceRoot: string;
-  providerConfig?: Pick<ProviderConfig, "agent_loop">;
+  providerConfig?: Pick<ProviderConfig, "agent_loop" | "provider" | "reasoning_effort">;
   budget?: Partial<AgentLoopBudget>;
   toolPolicy?: AgentLoopToolPolicy;
   worktreePolicy?: AgentLoopWorktreePolicy;
@@ -425,6 +425,10 @@ export function resolveAgentLoopDefaultProfileFromProviderConfig(
   input: ResolveAgentLoopDefaultProfileFromProviderConfigInput,
 ): AgentLoopResolvedProfile {
   const providerDefaults = resolveProviderNativeAgentLoopDefaults(input.providerConfig);
+  const providerReasoningEffort =
+    input.providerConfig?.provider === "openai"
+      ? input.providerConfig.reasoning_effort
+      : undefined;
   return resolveAgentLoopDefaultProfile({
     surface: input.surface,
     workspaceRoot: input.workspaceRoot,
@@ -432,7 +436,7 @@ export function resolveAgentLoopDefaultProfileFromProviderConfig(
     budget: input.budget,
     toolPolicy: input.toolPolicy,
     worktreePolicy: mergeWorktreePolicy(providerDefaults.worktreePolicy, input.worktreePolicy),
-    reasoningEffort: input.reasoningEffort,
+    reasoningEffort: input.reasoningEffort ?? providerReasoningEffort,
   });
 }
 

--- a/src/orchestrator/execution/agent-loop/agent-loop-model.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model.ts
@@ -31,7 +31,7 @@ export interface AgentLoopModelInfo {
 
 export type AgentLoopMessageRole = "system" | "user" | "assistant" | "tool";
 export type AgentLoopMessagePhase = "commentary" | "final_answer";
-export type AgentLoopReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
+export type AgentLoopReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
 export interface AgentLoopMessage {
   role: AgentLoopMessageRole;

--- a/src/tools/query/ConfigTool/ConfigTool.ts
+++ b/src/tools/query/ConfigTool/ConfigTool.ts
@@ -14,6 +14,7 @@ export type ConfigToolInput = z.infer<typeof ConfigToolInputSchema>;
 interface ProviderConfig {
   provider?: unknown;
   model?: unknown;
+  reasoning_effort?: unknown;
   default_adapter?: unknown;
   pulseed_home_dir?: unknown;
   [key: string]: unknown;
@@ -57,6 +58,7 @@ export class ConfigTool implements ITool<ConfigToolInput, unknown> {
           config = {
             provider: parsed["provider"] ?? defaults.provider,
             model: parsed["model"] ?? defaults.model,
+            reasoning_effort: parsed["reasoning_effort"],
             default_adapter: parsed["default_adapter"] ?? defaults.default_adapter,
             pulseed_home_dir: defaults.pulseed_home_dir,
           };


### PR DESCRIPTION
## Summary
- add OpenAI `reasoning_effort` config support across setup/import/config/chat display surfaces
- wire reasoning effort into OpenAI API, Codex CLI, Codex adapter, runtime fingerprinting, and native agent_loop task/chat/review runners
- add GPT-5.5 to OpenAI model registries and setup defaults

## Verification
- `npm run typecheck`
- `npm test`
- `npm run lint:boundaries` (0 errors, existing warnings only)
- fresh sub-agent review: LGTM after targeted verification (141 tests passed)
