### PR TITLE
Implement Codex-style /model switching

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -36,11 +36,11 @@ Supported chat slash commands:
 
 - Session: `/help`, `/clear`, `/sessions`, `/history [id|title]`, `/title <title>`, `/resume [id|title]`, `/cleanup [--dry-run]`, `/compact`, `/exit`
 - Goals and tasks: `/status [goal-id]`, `/goals`, `/tasks [goal-id]`, `/task <task-id> [goal-id]`, `/track`, `/tend`
-- Configuration: `/config`, `/model`, `/plugins`
+- Configuration: `/config`, `/model`, `/models`, `/model <model> [effort]`, `/plugins`
 - Usage: `/usage [session|goal <goal-id>|daemon <goal-id>|schedule [24h|7d|2w]]`
 
 `/compact` summarizes older chat turns into the saved session summary and keeps the latest user and assistant turns available for continuation.
-`/config` and `/model` are read-only and mask secrets.
+`/config` is read-only and masks secrets. `/model` and `/models` mirror Codex-style model selection: without arguments they show the active model and available choices; `/model <model> [effort]` updates the OpenAI model and optional reasoning effort for subsequent chat turns.
 
 Deferred command: `/retry` is intentionally not supported yet.
 

--- a/src/adapters/agents/claude-api.ts
+++ b/src/adapters/agents/claude-api.ts
@@ -8,12 +8,11 @@ import type { IAdapter, AgentTask, AgentResult } from "../../orchestrator/execut
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 
 export class ClaudeAPIAdapter implements IAdapter {
-  readonly adapterType = "claude_api";
   readonly capabilities = ["text_generation", "analysis", "planning"] as const;
 
   private readonly llmClient: ILLMClient;
 
-  constructor(llmClient: ILLMClient) {
+  constructor(llmClient: ILLMClient, readonly adapterType = "claude_api") {
     this.llmClient = llmClient;
   }
 

--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -657,6 +657,11 @@ export async function loadProviderConfig(options: LoadProviderConfigOptions = {}
   return config;
 }
 
+export async function loadProviderConfigFile(options: { baseDir?: string } = {}): Promise<Partial<ProviderConfig>> {
+  const { fileConfig } = await loadProviderFileConfig(providerConfigPath(options.baseDir));
+  return fileConfig;
+}
+
 export async function resolveOpenAIApiKey(): Promise<string | undefined> {
   const envFile = await readProviderEnvFile();
   const envKey = process.env["OPENAI_API_KEY"] ?? envFile["OPENAI_API_KEY"];
@@ -700,8 +705,8 @@ export async function getProviderRuntimeFingerprint(): Promise<string> {
  * Save provider configuration to ~/.pulseed/provider.json.
  * Creates the ~/.pulseed directory if it does not exist.
  */
-export async function saveProviderConfig(config: ProviderConfig): Promise<void> {
-  await writeJsonFileAtomic(providerConfigPath(), config, {
+export async function saveProviderConfig(config: ProviderConfig | Partial<ProviderConfig>, options: { baseDir?: string } = {}): Promise<void> {
+  await writeJsonFileAtomic(providerConfigPath(options.baseDir), config, {
     mode: 0o600,
     directoryMode: 0o700,
   });

--- a/src/base/llm/provider-factory.ts
+++ b/src/base/llm/provider-factory.ts
@@ -32,8 +32,8 @@ import { resolveExecutionPolicy } from "../../orchestrator/execution/agent-loop/
  *   - "openai"    → OpenAILLMClient or CodexLLMClient depending on adapter
  *   - "ollama"    → OllamaLLMClient
  */
-export async function buildLLMClient(): Promise<ILLMClient> {
-  const config = await loadProviderConfig();
+export async function buildLLMClient(providerConfig?: ProviderConfig): Promise<ILLMClient> {
+  const config = providerConfig ?? await loadProviderConfig();
 
   switch (config.provider) {
     case "openai": {
@@ -118,6 +118,7 @@ export async function buildAdapterRegistry(
   const config = providerConfig ?? await loadProviderConfig();
   registry.register(new ClaudeCodeCLIAdapter({ terminalBackend: config.terminal_backend }));
   registry.register(new ClaudeAPIAdapter(llmClient));
+  registry.register(new ClaudeAPIAdapter(llmClient, "openai_api"));
   registry.register(new OpenAICodexCLIAdapter({
     cliPath: config.codex_cli_path,
     model: config.model,

--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChatRunner } from "../chat-runner.js";
 import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import { StateManager as RealStateManager } from "../../../base/state/state-manager.js";
@@ -9,7 +9,26 @@ import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
 import type { ChatAgentLoopRunner } from "../../../orchestrator/execution/agent-loop/chat-agent-loop-runner.js";
 import type { ReviewAgentLoopRunner } from "../../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
+import type { ProviderConfig } from "../../../base/llm/provider-config.js";
 import { ChatSessionCatalog } from "../chat-session-store.js";
+
+const providerConfigMock = vi.hoisted(() => ({
+  current: {
+    provider: "openai" as const,
+    model: "gpt-5.4-mini",
+    adapter: "openai_codex_cli" as const,
+    agent_loop: {
+      security: {
+        sandbox_mode: "workspace_write" as const,
+        approval_policy: "on_request" as const,
+        network_access: false,
+        trust_project_instructions: true,
+      },
+    },
+  } as ProviderConfig,
+  load: vi.fn(),
+  save: vi.fn(),
+}));
 
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -20,19 +39,9 @@ vi.mock("../../../base/llm/provider-config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../base/llm/provider-config.js")>();
   return {
     ...actual,
-    loadProviderConfig: vi.fn().mockResolvedValue({
-      provider: "openai",
-      model: "gpt-5.4-mini",
-      adapter: "openai_codex_cli",
-      agent_loop: {
-        security: {
-          sandbox_mode: "workspace_write",
-          approval_policy: "on_request",
-          network_access: false,
-          trust_project_instructions: true,
-        },
-      },
-    }),
+    loadProviderConfig: providerConfigMock.load,
+    loadProviderConfigFile: providerConfigMock.load,
+    saveProviderConfig: providerConfigMock.save,
   };
 });
 
@@ -40,6 +49,7 @@ function makeMockStateManager(): StateManager {
   return {
     writeRaw: vi.fn().mockResolvedValue(undefined),
     readRaw: vi.fn().mockResolvedValue(null),
+    getBaseDir: vi.fn().mockReturnValue(os.tmpdir()),
   } as unknown as StateManager;
 }
 
@@ -66,10 +76,36 @@ function makeDeps(overrides: Partial<ChatRunnerDeps> = {}): ChatRunnerDeps {
 }
 
 afterEach(() => {
+  providerConfigMock.current = {
+    provider: "openai",
+    model: "gpt-5.4-mini",
+    adapter: "openai_codex_cli",
+    agent_loop: {
+      security: {
+        sandbox_mode: "workspace_write",
+        approval_policy: "on_request",
+        network_access: false,
+        trust_project_instructions: true,
+      },
+    },
+  };
+  providerConfigMock.load.mockReset();
+  providerConfigMock.load.mockImplementation(async () => providerConfigMock.current);
+  providerConfigMock.save.mockReset();
+  providerConfigMock.save.mockImplementation(async (config: ProviderConfig) => {
+    providerConfigMock.current = config;
+  });
   vi.restoreAllMocks();
 });
 
 describe("ChatRunner policy commands", () => {
+  beforeEach(() => {
+    providerConfigMock.load.mockImplementation(async () => providerConfigMock.current);
+    providerConfigMock.save.mockImplementation(async (config: ProviderConfig) => {
+      providerConfigMock.current = config;
+    });
+  });
+
   it("/permissions shows the current execution policy", async () => {
     const runner = new ChatRunner(makeDeps());
     runner.startSession("/repo");
@@ -91,6 +127,42 @@ describe("ChatRunner policy commands", () => {
     expect(result.output).toContain("sandbox_mode: read_only");
     expect(result.output).toContain("network_access: on");
     expect(result.output).toContain("approval_policy: never");
+  });
+
+  it("/model updates the OpenAI model and reasoning effort through the chat runner command path", async () => {
+    const runner = new ChatRunner(makeDeps());
+    runner.startSession("/repo");
+
+    const result = await runner.execute("/model gpt-5.5 high", "/repo");
+
+    expect(result.success).toBe(true);
+    expect(result.output).toContain("Model: gpt-5.5");
+    expect(result.output).toContain("Reasoning: high");
+    expect(providerConfigMock.save).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        model: "gpt-5.5",
+        reasoning_effort: "high",
+      }),
+      { baseDir: os.tmpdir() },
+    );
+  });
+
+  it("/model accepts reasoning-only changes through the chat runner command path", async () => {
+    providerConfigMock.current = {
+      ...providerConfigMock.current,
+      model: "gpt-5.5",
+      reasoning_effort: "xhigh",
+    };
+    const runner = new ChatRunner(makeDeps());
+    runner.startSession("/repo");
+
+    const result = await runner.execute("/models high", "/repo");
+
+    expect(result.success).toBe(true);
+    const saved = providerConfigMock.save.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(saved["model"]).toBe("gpt-5.5");
+    expect(saved["reasoning_effort"]).toBe("high");
   });
 
   it("/review falls back to a read-only summary when no runner is configured", async () => {

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -2161,7 +2161,7 @@ describe("ChatRunner", () => {
       }
     });
 
-    it("/config, /model, and /plugins are read-only command surfaces", async () => {
+    it("/config, /model without arguments, and /plugins do not invoke the execution adapter", async () => {
       const adapter = makeMockAdapter();
       const pluginLoader = {
         loadAll: vi.fn().mockResolvedValue([{ name: "demo", type: "notifier", enabled: true }]),
@@ -2310,6 +2310,168 @@ describe("ChatRunner", () => {
           delete process.env["PULSEED_MODEL"];
         } else {
           process.env["PULSEED_MODEL"] = oldModel;
+        }
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/model updates file-owned fields without persisting env-resolved secrets", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-model-edit-"));
+      const oldEnv = {
+        OPENAI_API_KEY: process.env["OPENAI_API_KEY"],
+        OPENAI_BASE_URL: process.env["OPENAI_BASE_URL"],
+        PULSEED_LIGHT_MODEL: process.env["PULSEED_LIGHT_MODEL"],
+      };
+      try {
+        process.env["OPENAI_API_KEY"] = "sk-env-secret";
+        process.env["OPENAI_BASE_URL"] = "https://env.example.test/v1";
+        process.env["PULSEED_LIGHT_MODEL"] = "gpt-env-light";
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("provider.json", {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          adapter: "openai_codex_cli",
+        });
+        const runner = new ChatRunner(makeDeps({ stateManager, adapter: makeMockAdapter() }));
+
+        const result = await runner.execute("/model gpt-5.5 high", "/repo");
+        const raw = await stateManager.readRaw("provider.json") as Record<string, unknown>;
+
+        expect(result.success).toBe(true);
+        expect(raw).toMatchObject({
+          provider: "openai",
+          model: "gpt-5.5",
+          adapter: "openai_codex_cli",
+          reasoning_effort: "high",
+        });
+        expect(raw).not.toHaveProperty("api_key");
+        expect(raw).not.toHaveProperty("base_url");
+        expect(raw).not.toHaveProperty("light_model");
+      } finally {
+        for (const [key, value] of Object.entries(oldEnv)) {
+          if (value === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = value;
+          }
+        }
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/model does not persist env-derived model or reasoning defaults", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-model-env-runtime-"));
+      const oldEnv = {
+        PULSEED_MODEL: process.env["PULSEED_MODEL"],
+        OPENAI_REASONING_EFFORT: process.env["OPENAI_REASONING_EFFORT"],
+      };
+      try {
+        process.env["PULSEED_MODEL"] = "gpt-env-model";
+        process.env["OPENAI_REASONING_EFFORT"] = "xhigh";
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("provider.json", {
+          provider: "openai",
+          adapter: "openai_codex_cli",
+        });
+        const runner = new ChatRunner(makeDeps({ stateManager, adapter: makeMockAdapter() }));
+
+        const reasoningResult = await runner.execute("/models high", "/repo");
+        const afterReasoning = await stateManager.readRaw("provider.json") as Record<string, unknown>;
+        const modelResult = await runner.execute("/model gpt-5.5", "/repo");
+        const afterModel = await stateManager.readRaw("provider.json") as Record<string, unknown>;
+
+        expect(reasoningResult.success).toBe(true);
+        expect(afterReasoning).not.toHaveProperty("model");
+        expect(afterReasoning["reasoning_effort"]).toBe("high");
+        expect(modelResult.success).toBe(true);
+        expect(afterModel["model"]).toBe("gpt-5.5");
+        expect(afterModel["reasoning_effort"]).toBe("high");
+      } finally {
+        for (const [key, value] of Object.entries(oldEnv)) {
+          if (value === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = value;
+          }
+        }
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/model rejects env-only OpenAI provider overrides before saving", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-model-env-provider-"));
+      const oldEnv = {
+        PULSEED_PROVIDER: process.env["PULSEED_PROVIDER"],
+        PULSEED_ADAPTER: process.env["PULSEED_ADAPTER"],
+      };
+      try {
+        process.env["PULSEED_PROVIDER"] = "openai";
+        process.env["PULSEED_ADAPTER"] = "openai_codex_cli";
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("provider.json", {
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          adapter: "anthropic_api",
+          api_key: "sk-file-secret",
+        });
+        const runner = new ChatRunner(makeDeps({ stateManager, adapter: makeMockAdapter() }));
+
+        const result = await runner.execute("/model gpt-5.5 high", "/repo");
+        const raw = await stateManager.readRaw("provider.json") as Record<string, unknown>;
+
+        expect(result.success).toBe(false);
+        expect(result.output).toContain("file-owned OpenAI provider configuration");
+        expect(raw).toMatchObject({
+          provider: "anthropic",
+          model: "claude-haiku-4-5",
+          adapter: "anthropic_api",
+        });
+        expect(raw).not.toHaveProperty("reasoning_effort");
+      } finally {
+        for (const [key, value] of Object.entries(oldEnv)) {
+          if (value === undefined) {
+            delete process.env[key];
+          } else {
+            process.env[key] = value;
+          }
+        }
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("/model keeps secret-free OpenAI API config valid when the key comes from env", async () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pulseed-chat-model-env-key-"));
+      const oldApiKey = process.env["OPENAI_API_KEY"];
+      try {
+        process.env["OPENAI_API_KEY"] = "sk-env-secret";
+        const stateManager = new StateManager(tmpDir);
+        await stateManager.init();
+        await stateManager.writeRaw("provider.json", {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+          adapter: "openai_api",
+        });
+        const runner = new ChatRunner(makeDeps({ stateManager, adapter: makeMockAdapter() }));
+
+        const result = await runner.execute("/model gpt-5.5 high", "/repo");
+        const raw = await stateManager.readRaw("provider.json") as Record<string, unknown>;
+
+        expect(result.success).toBe(true);
+        expect(raw).toMatchObject({
+          provider: "openai",
+          model: "gpt-5.5",
+          adapter: "openai_api",
+          reasoning_effort: "high",
+        });
+        expect(raw).not.toHaveProperty("api_key");
+      } finally {
+        if (oldApiKey === undefined) {
+          delete process.env["OPENAI_API_KEY"];
+        } else {
+          process.env["OPENAI_API_KEY"] = oldApiKey;
         }
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }

--- a/src/interface/chat/chat-runner-commands.ts
+++ b/src/interface/chat/chat-runner-commands.ts
@@ -35,6 +35,15 @@ import {
 import { checkGitChanges } from "./chat-runner-support.js";
 import { formatFailureRecovery } from "./failure-recovery.js";
 import {
+  isReasoningEffort,
+  loadProviderConfig,
+  loadProviderConfigFile,
+  MODEL_REGISTRY,
+  saveProviderConfig,
+  validateProviderConfig,
+  type ProviderConfig,
+} from "../../base/llm/provider-config.js";
+import {
   summarizeExecutionPolicy,
   withExecutionPolicyOverrides,
   type ExecutionPolicy,
@@ -78,7 +87,10 @@ Goals and tasks
 
 Configuration
   /config               Show provider configuration with secrets masked
-  /model                Show the active provider/model/adapter
+  /model                Show model and reasoning choices
+  /model <model> [effort]
+                        Select OpenAI model and optional reasoning effort
+  /models               Alias for /model
   /permissions [args]   Show or update session execution policy
   /plugins              List installed plugins when plugin metadata is available
   /usage [scope]        Show usage summary (session, goal <id>, daemon <goal-id>, schedule [7d|24h|2w])
@@ -182,8 +194,8 @@ export class ChatRunnerCommandHandler {
     if (cmd === "/config") {
       return this.handleConfig(start);
     }
-    if (cmd === "/model") {
-      return this.handleModel(start);
+    if (cmd === "/model" || cmd === "/models") {
+      return this.handleModel(trimmed.slice(cmd.length).trim(), start);
     }
     if (cmd === "/permissions") {
       return this.handlePermissions(trimmed.slice("/permissions".length).trim(), start);
@@ -575,11 +587,155 @@ export class ChatRunnerCommandHandler {
     return { success: true, output: `Provider configuration:\n${this.formatConfig(config)}`, elapsed_ms: Date.now() - start };
   }
 
-  private async handleModel(start: number): Promise<ChatRunResult> {
-    const config = await this.readProviderConfigSummary();
+  private parseModelArgs(args: string): { model?: string; reasoning?: ProviderConfig["reasoning_effort"]; error?: string } {
+    const tokens = args.split(/\s+/).filter(Boolean);
+    if (tokens.length === 0) return {};
+
+    if (tokens.length === 1 && isReasoningEffort(tokens[0])) {
+      return { reasoning: tokens[0] };
+    }
+
+    const model = tokens[0];
+    if (tokens.length > 2) {
+      return { error: "Usage: /model <model> [none|minimal|low|medium|high|xhigh]" };
+    }
+    const reasoning = tokens[1];
+    if (reasoning !== undefined && !isReasoningEffort(reasoning)) {
+      return { error: `Invalid reasoning effort "${reasoning}". Valid: none, minimal, low, medium, high, xhigh` };
+    }
+    return { model, reasoning };
+  }
+
+  private formatModelSummary(config: ProviderConfigSummary): string {
+    return [
+      `Model: ${config.model}`,
+      `Provider: ${config.provider}`,
+      `Adapter: ${config.adapter}`,
+      `Reasoning: ${config.reasoning_effort ?? "default"}`,
+    ].join("\n");
+  }
+
+  private async handleModel(args: string, start: number): Promise<ChatRunResult> {
+    if (!args) {
+      const config = await this.readProviderConfigSummary();
+      return {
+        success: true,
+        output: [
+          "Select Model and Effort",
+          this.formatModelSummary(config),
+          "",
+          "Usage:",
+          "  /model <model>",
+          "  /model <model> <none|minimal|low|medium|high|xhigh>",
+          "  /model <none|minimal|low|medium|high|xhigh>",
+          "",
+          `Available OpenAI models: ${Object.keys(MODEL_REGISTRY).filter((model) => MODEL_REGISTRY[model]?.provider === "openai").join(", ")}`,
+        ].join("\n"),
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    const parsed = this.parseModelArgs(args);
+    if (parsed.error) {
+      return { success: false, output: parsed.error, elapsed_ms: Date.now() - start };
+    }
+
+    const baseDir = this.host.deps.stateManager.getBaseDir();
+    const [current, fileConfig] = await Promise.all([
+      loadProviderConfig({ baseDir, saveMigration: false }),
+      loadProviderConfigFile({ baseDir }),
+    ]);
+    if (current.provider !== "openai") {
+      return {
+        success: false,
+        output: `/model switching is currently available for provider "openai". Current provider: ${current.provider}`,
+        elapsed_ms: Date.now() - start,
+      };
+    }
+    const fileProvider = fileConfig.provider ?? "openai";
+    const fileAdapter = fileConfig.adapter ?? "openai_codex_cli";
+    const fileTargetModel = parsed.model ?? fileConfig.model ?? current.model;
+    const fileRegistryEntry = MODEL_REGISTRY[fileTargetModel];
+    const fileAdapterSupportsModel = !fileRegistryEntry
+      || (fileRegistryEntry.provider === fileProvider && fileRegistryEntry.adapters.includes(fileAdapter));
+    if (fileProvider !== "openai" || !fileAdapterSupportsModel) {
+      return {
+        success: false,
+        output: [
+          "/model can only update a file-owned OpenAI provider configuration.",
+          `Current runtime provider is openai, but provider.json resolves as provider "${fileProvider}" with adapter "${fileAdapter}".`,
+          "Update provider.json to OpenAI first, then run /model again.",
+        ].join("\n"),
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    const nextResolved: ProviderConfig = {
+      ...current,
+      ...(parsed.model ? { model: parsed.model } : {}),
+    };
+    const nextFile: Partial<ProviderConfig> = {
+      provider: fileProvider,
+      adapter: fileAdapter,
+    };
+    if (parsed.model ?? fileConfig.model) {
+      nextFile.model = parsed.model ?? fileConfig.model;
+    }
+    if (parsed.reasoning !== undefined) {
+      nextResolved.reasoning_effort = parsed.reasoning;
+    }
+    if (parsed.reasoning !== undefined && parsed.reasoning !== null) {
+      nextFile.reasoning_effort = parsed.reasoning;
+    } else if (fileConfig.reasoning_effort !== undefined) {
+      nextFile.reasoning_effort = fileConfig.reasoning_effort;
+    }
+    if (fileConfig.api_key !== undefined) nextFile.api_key = fileConfig.api_key;
+    if (fileConfig.base_url !== undefined) nextFile.base_url = fileConfig.base_url;
+    if (fileConfig.light_model !== undefined) nextFile.light_model = fileConfig.light_model;
+    if (fileConfig.codex_cli_path !== undefined) nextFile.codex_cli_path = fileConfig.codex_cli_path;
+    if (fileConfig.codex_timeout_ms !== undefined) nextFile.codex_timeout_ms = fileConfig.codex_timeout_ms;
+    if (fileConfig.codex_idle_timeout_ms !== undefined) nextFile.codex_idle_timeout_ms = fileConfig.codex_idle_timeout_ms;
+    if (fileConfig.codex_retry_attempts !== undefined) nextFile.codex_retry_attempts = fileConfig.codex_retry_attempts;
+    if (fileConfig.terminal_backend !== undefined) nextFile.terminal_backend = fileConfig.terminal_backend;
+    if (fileConfig.a2a !== undefined) nextFile.a2a = fileConfig.a2a;
+    if (fileConfig.openclaw !== undefined) nextFile.openclaw = fileConfig.openclaw;
+    if (fileConfig.agent_loop !== undefined) {
+      nextFile.agent_loop = fileConfig.agent_loop;
+    }
+
+    const registryEntry = parsed.model ? MODEL_REGISTRY[parsed.model] : undefined;
+    if (registryEntry && registryEntry.provider !== nextResolved.provider) {
+      return {
+        success: false,
+        output: `Model "${parsed.model}" requires provider "${registryEntry.provider}" but current provider is "${nextResolved.provider}".`,
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    const validation = validateProviderConfig(nextResolved);
+    if (!validation.valid) {
+      return {
+        success: false,
+        output: `Model configuration was not saved:\n${validation.errors.map((error) => `- ${error}`).join("\n")}`,
+        elapsed_ms: Date.now() - start,
+      };
+    }
+
+    await saveProviderConfig(nextFile, { baseDir });
+    await this.host.reloadProviderRuntime?.();
+    const effective = await this.readProviderConfigSummary();
+    const saved = this.formatModelSummary({
+      ...effective,
+      model: nextFile.model ?? "(unchanged)",
+      reasoning_effort: nextFile.reasoning_effort,
+    });
+    const effectiveSummary = this.formatModelSummary(effective);
+    const envOverrideNote = saved === effectiveSummary
+      ? ""
+      : `\n\nEffective config still differs, likely due to environment overrides:\n${effectiveSummary}`;
     return {
       success: true,
-      output: `Model: ${config.model}\nProvider: ${config.provider}\nAdapter: ${config.adapter}`,
+      output: `Updated model configuration:\n${saved}${envOverrideNote}`,
       elapsed_ms: Date.now() - start,
     };
   }

--- a/src/interface/chat/chat-runner-contracts.ts
+++ b/src/interface/chat/chat-runner-contracts.ts
@@ -130,6 +130,7 @@ export interface ChatRunnerCommandHost {
   setPendingTend(value: PendingTendState | null): void;
   getLastSelectedRoute(): SelectedChatRoute | null;
   getSessionExecutionPolicy(): Promise<ExecutionPolicy>;
+  reloadProviderRuntime?(): Promise<void>;
   emitEvent(event: ChatEvent): void;
   getActiveSubscribers(): Map<string, EventSubscriber>;
 }

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -192,6 +192,7 @@ export class ChatRunner {
       setPendingTend: (value) => { this.pendingTend = value; },
       getLastSelectedRoute: () => this.lastSelectedRoute,
       getSessionExecutionPolicy: () => this.getSessionExecutionPolicy(),
+      reloadProviderRuntime: () => this.reloadProviderRuntime(),
       emitEvent: (event) => this.eventBridge.emitEvent(event),
       getActiveSubscribers: () => this.activeSubscribers as Map<string, never>,
       setSessionExecutionPolicy: (policy: ExecutionPolicy) => { this.sessionExecutionPolicy = policy; },
@@ -795,6 +796,51 @@ export class ChatRunner {
   private providerConfigBaseDir(): string {
     const stateManager = this.deps.stateManager as StateManager & { getBaseDir?: () => string };
     return typeof stateManager.getBaseDir === "function" ? stateManager.getBaseDir() : getPulseedDirPath();
+  }
+
+  private async reloadProviderRuntime(): Promise<void> {
+    const [
+      { buildAdapterRegistry, buildLLMClient },
+      { loadProviderConfig },
+      {
+        createNativeChatAgentLoopRunner,
+        createNativeReviewAgentLoopRunner,
+        shouldUseNativeTaskAgentLoop,
+      },
+    ] = await Promise.all([
+      import("../../base/llm/provider-factory.js"),
+      import("../../base/llm/provider-config.js"),
+      import("../../orchestrator/execution/agent-loop/index.js"),
+    ]);
+    const providerConfig = await loadProviderConfig({
+      baseDir: this.providerConfigBaseDir(),
+      saveMigration: false,
+    });
+    const llmClient = await buildLLMClient(providerConfig);
+    const adapterRegistry = await buildAdapterRegistry(llmClient, providerConfig);
+    this.deps.llmClient = llmClient;
+    this.deps.adapter = adapterRegistry.getAdapter(providerConfig.adapter);
+    this.deps.chatAgentLoopRunner = this.deps.registry && this.deps.toolExecutor && shouldUseNativeTaskAgentLoop(providerConfig, llmClient)
+      ? createNativeChatAgentLoopRunner({
+          llmClient,
+          providerConfig,
+          toolRegistry: this.deps.registry,
+          toolExecutor: this.deps.toolExecutor,
+          cwd: this.sessionCwd ?? process.cwd(),
+          traceBaseDir: this.providerConfigBaseDir(),
+        })
+      : undefined;
+    this.deps.reviewAgentLoopRunner = this.deps.registry && this.deps.toolExecutor && shouldUseNativeTaskAgentLoop(providerConfig, llmClient)
+      ? createNativeReviewAgentLoopRunner({
+          llmClient,
+          providerConfig,
+          toolRegistry: this.deps.registry,
+          toolExecutor: this.deps.toolExecutor,
+          cwd: this.sessionCwd ?? process.cwd(),
+          traceBaseDir: this.providerConfigBaseDir(),
+        })
+      : undefined;
+    this.cachedStaticSystemPrompt = null;
   }
 
   private async handlePendingRunSpecConfirmation(input: string): Promise<ChatRunResult | null> {

--- a/src/interface/tui/__tests__/app-routing.test.ts
+++ b/src/interface/tui/__tests__/app-routing.test.ts
@@ -40,6 +40,7 @@ describe("TUI app routing helpers", () => {
     expect(isChatRunnerOwnedSlashCommand("/tend")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/config")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/model")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/models")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/permissions read-only")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/plugins")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/usage session")).toBe(true);

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -147,6 +147,7 @@ const CHAT_RUNNER_OWNED_COMMANDS = new Set([
   "/tend",
   "/config",
   "/model",
+  "/models",
   "/permissions",
   "/plugins",
   "/usage",

--- a/src/interface/tui/chat/suggestions.ts
+++ b/src/interface/tui/chat/suggestions.ts
@@ -136,8 +136,8 @@ const COMMANDS: Suggestion[] = [
   },
   {
     name: "/model",
-    aliases: [],
-    description: "Show active model",
+    aliases: ["/models"],
+    description: "Choose model and reasoning effort",
     type: "command",
   },
   {


### PR DESCRIPTION
## Summary
- add Codex-style `/model` and `/models` handling for model plus reasoning effort selection
- reload provider runtime after model changes and preserve secret-free provider config behavior
- support openai_api adapter reloads and add regression coverage for env override/secret handling

## Verification
- npm run typecheck
- npm test -- --run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-runner-policy.test.ts src/interface/tui/__tests__/app-routing.test.ts src/base/llm/__tests__/provider-config.test.ts src/base/llm/__tests__/provider-factory.test.ts
- npm test
- npm run lint:boundaries (0 errors, existing warnings)
- fresh sub-agent review: LGTM