### PR TITLE
Remove /models alias

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -36,11 +36,11 @@ Supported chat slash commands:
 
 - Session: `/help`, `/clear`, `/sessions`, `/history [id|title]`, `/title <title>`, `/resume [id|title]`, `/cleanup [--dry-run]`, `/compact`, `/exit`
 - Goals and tasks: `/status [goal-id]`, `/goals`, `/tasks [goal-id]`, `/task <task-id> [goal-id]`, `/track`, `/tend`
-- Configuration: `/config`, `/model`, `/models`, `/model <model> [effort]`, `/plugins`
+- Configuration: `/config`, `/model`, `/model <model> [effort]`, `/plugins`
 - Usage: `/usage [session|goal <goal-id>|daemon <goal-id>|schedule [24h|7d|2w]]`
 
 `/compact` summarizes older chat turns into the saved session summary and keeps the latest user and assistant turns available for continuation.
-`/config` is read-only and masks secrets. `/model` and `/models` mirror Codex-style model selection: without arguments they show the active model and available choices; `/model <model> [effort]` updates the OpenAI model and optional reasoning effort for subsequent chat turns.
+`/config` is read-only and masks secrets. `/model` mirrors Codex-style model selection: without arguments it shows the active model and available choices; `/model <model> [effort]` updates the OpenAI model and optional reasoning effort for subsequent chat turns.
 
 Deferred command: `/retry` is intentionally not supported yet.
 

--- a/src/interface/chat/__tests__/chat-runner-policy.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-policy.test.ts
@@ -157,7 +157,7 @@ describe("ChatRunner policy commands", () => {
     const runner = new ChatRunner(makeDeps());
     runner.startSession("/repo");
 
-    const result = await runner.execute("/models high", "/repo");
+    const result = await runner.execute("/model high", "/repo");
 
     expect(result.success).toBe(true);
     const saved = providerConfigMock.save.mock.calls[0]?.[0] as Record<string, unknown>;

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -2377,7 +2377,7 @@ describe("ChatRunner", () => {
         });
         const runner = new ChatRunner(makeDeps({ stateManager, adapter: makeMockAdapter() }));
 
-        const reasoningResult = await runner.execute("/models high", "/repo");
+        const reasoningResult = await runner.execute("/model high", "/repo");
         const afterReasoning = await stateManager.readRaw("provider.json") as Record<string, unknown>;
         const modelResult = await runner.execute("/model gpt-5.5", "/repo");
         const afterModel = await stateManager.readRaw("provider.json") as Record<string, unknown>;

--- a/src/interface/chat/chat-runner-commands.ts
+++ b/src/interface/chat/chat-runner-commands.ts
@@ -90,7 +90,6 @@ Configuration
   /model                Show model and reasoning choices
   /model <model> [effort]
                         Select OpenAI model and optional reasoning effort
-  /models               Alias for /model
   /permissions [args]   Show or update session execution policy
   /plugins              List installed plugins when plugin metadata is available
   /usage [scope]        Show usage summary (session, goal <id>, daemon <goal-id>, schedule [7d|24h|2w])
@@ -194,8 +193,8 @@ export class ChatRunnerCommandHandler {
     if (cmd === "/config") {
       return this.handleConfig(start);
     }
-    if (cmd === "/model" || cmd === "/models") {
-      return this.handleModel(trimmed.slice(cmd.length).trim(), start);
+    if (cmd === "/model") {
+      return this.handleModel(trimmed.slice("/model".length).trim(), start);
     }
     if (cmd === "/permissions") {
       return this.handlePermissions(trimmed.slice("/permissions".length).trim(), start);

--- a/src/interface/tui/__tests__/app-routing.test.ts
+++ b/src/interface/tui/__tests__/app-routing.test.ts
@@ -40,7 +40,7 @@ describe("TUI app routing helpers", () => {
     expect(isChatRunnerOwnedSlashCommand("/tend")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/config")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/model")).toBe(true);
-    expect(isChatRunnerOwnedSlashCommand("/models")).toBe(true);
+    expect(isChatRunnerOwnedSlashCommand("/models")).toBe(false);
     expect(isChatRunnerOwnedSlashCommand("/permissions read-only")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/plugins")).toBe(true);
     expect(isChatRunnerOwnedSlashCommand("/usage session")).toBe(true);

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -147,7 +147,6 @@ const CHAT_RUNNER_OWNED_COMMANDS = new Set([
   "/tend",
   "/config",
   "/model",
-  "/models",
   "/permissions",
   "/plugins",
   "/usage",

--- a/src/interface/tui/chat/suggestions.ts
+++ b/src/interface/tui/chat/suggestions.ts
@@ -136,7 +136,7 @@ const COMMANDS: Suggestion[] = [
   },
   {
     name: "/model",
-    aliases: ["/models"],
+    aliases: [],
     description: "Choose model and reasoning effort",
     type: "command",
   },


### PR DESCRIPTION
## Summary
- remove the redundant `/models` chat command alias
- keep `/model` as the single Codex-style command for model and reasoning selection
- update TUI routing, suggestions, docs, and coverage to treat `/models` as unsupported

## Verification
- npm run typecheck
- npm test -- --run src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-runner-policy.test.ts src/interface/tui/__tests__/app-routing.test.ts (unit config finds only chat tests)
- npm run test:integration -- --run src/interface/tui/__tests__/app-routing.test.ts
- npm test
- npm run test:integration
- npm run lint:boundaries (0 errors, existing warnings)
- fresh review agent: LGTM

## Mac mini note
Investigated the Mac mini report that the current PulSeed provider schema had no dedicated reasoning effort field. The installed global package has `ProviderConfig.reasoning_effort` and `pulseed provider set --reasoning-effort`, but its chat `/model` handler is still the pre-#1087 read-only implementation. That points to a stale global install for the chat command surface rather than a missing provider schema field.