### PR TITLE
fix(task): honor goal workspace in native agent loop

### DIFF
--- a/src/orchestrator/execution/__tests__/task-verifier-guards.test.ts
+++ b/src/orchestrator/execution/__tests__/task-verifier-guards.test.ts
@@ -18,6 +18,7 @@ import type { Task, VerificationResult } from "../../../base/types/task.js";
 import type { Logger } from "../../../runtime/logger.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { makeGoal } from "../../../../tests/helpers/fixtures.js";
 
 // ─── Fixtures ───
 
@@ -503,6 +504,46 @@ describe("attemptRevert safety", () => {
       expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("original\n");
     } finally {
       fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses goal workspace_path instead of stale daemon revertCwd", async () => {
+    const daemonRepo = fs.mkdtempSync(path.join(os.tmpdir(), "attempt-revert-daemon-"));
+    const goalRepo = fs.mkdtempSync(path.join(os.tmpdir(), "attempt-revert-goal-"));
+    initGitRepo(daemonRepo);
+    initGitRepo(goalRepo);
+    fs.writeFileSync(path.join(daemonRepo, "tracked.txt"), "daemon changed\n", "utf-8");
+    fs.writeFileSync(path.join(goalRepo, "tracked.txt"), "goal changed\n", "utf-8");
+
+    const deps: VerifierDeps = {
+      stateManager,
+      llmClient: createMockLLMClient([]),
+      sessionManager,
+      trustManager,
+      stallDetector,
+      durationToMs: (d) => d.value * (d.unit === "hours" ? 3600000 : 60000),
+      revertCwd: daemonRepo,
+    };
+    const task = makeTask({
+      scope_boundary: { in_scope: ["tracked.txt"], out_of_scope: [], blast_radius: "low" },
+      reversibility: "reversible",
+    });
+
+    try {
+      await stateManager.saveGoal(makeGoal({
+        id: task.goal_id,
+        constraints: [`workspace_path:${goalRepo}`],
+      }));
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+
+      const result = await handleFailure(deps, task, makeFailureVerificationResult());
+
+      expect(result.action).toBe("discard");
+      expect(fs.readFileSync(path.join(goalRepo, "tracked.txt"), "utf-8")).toBe("original\n");
+      expect(fs.readFileSync(path.join(daemonRepo, "tracked.txt"), "utf-8")).toBe("daemon changed\n");
+    } finally {
+      fs.rmSync(daemonRepo, { recursive: true, force: true });
+      fs.rmSync(goalRepo, { recursive: true, force: true });
     }
   });
 });

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -16,6 +16,7 @@ import { StallDetector } from "../../../../platform/drive/stall-detector.js";
 import { TaskLifecycle } from "../../task/task-lifecycle.js";
 import type { Task } from "../../../../base/types/task.js";
 import { makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
+import { makeGoal } from "../../../../../tests/helpers/fixtures.js";
 import {
   BoundedAgentLoopRunner,
   buildAgentLoopBaseInstructions,
@@ -896,6 +897,90 @@ describe("agentloop phase 2", () => {
       verificationHints: ["hint"],
       filesChangedPaths: ["src/example.ts"],
     });
+  });
+
+  it("uses the goal workspace_path for native task execution when daemon cwd differs", async () => {
+    const daemonDir = tmpDir;
+    const goalWorkspace = makeTempDir();
+    try {
+      fs.mkdirSync(goalWorkspace, { recursive: true });
+      const modelInfo = makeModelInfo();
+      const modelClient = new ScriptedModelClient(modelInfo, [
+        {
+          content: "",
+          toolCalls: [{ id: "call-1", name: "verify", input: { command: "test -d ." } }],
+          stopReason: "tool_use",
+        },
+        {
+          content: finalJson(),
+          toolCalls: [],
+          stopReason: "end_turn",
+        },
+      ]);
+      const registry = new ToolRegistry();
+      registry.register(new EchoTool());
+      registry.register(new VerifyTool());
+      const router = new ToolRegistryAgentLoopToolRouter(registry);
+      const executor = new ToolExecutor({
+        registry,
+        permissionManager: new ToolPermissionManager({}),
+        concurrency: new ConcurrencyController(),
+      });
+      const runtime = new ToolExecutorAgentLoopToolRuntime(executor, router);
+      const boundedRunner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+      const taskRunner = new TaskAgentLoopRunner({
+        boundedRunner,
+        modelClient,
+        modelRegistry: new StaticAgentLoopModelRegistry([modelInfo]),
+        defaultModel: modelInfo.ref,
+        defaultToolPolicy: { allowedTools: ["echo", "verify"] },
+        cwd: daemonDir,
+      });
+      const diffCwds: string[] = [];
+      const stateManager = new StateManager(daemonDir);
+      await stateManager.saveGoal(makeGoal({
+        id: "goal-1",
+        constraints: [`workspace_path:${goalWorkspace}`],
+      }));
+      const llmClient: ILLMClient = {
+        async sendMessage(): Promise<LLMResponse> {
+          return { content: finalJson(), usage: { input_tokens: 1, output_tokens: 1 }, stop_reason: "end_turn" };
+        },
+        parseJSON<T>(content: string, schema: z.ZodSchema<T>): T {
+          return schema.parse(JSON.parse(content));
+        },
+        supportsToolCalling: () => true,
+      };
+      const sessionManager = new SessionManager(stateManager);
+      const lifecycle = new TaskLifecycle(
+        stateManager,
+        llmClient,
+        sessionManager,
+        new TrustManager(stateManager),
+        new StrategyManager(stateManager, llmClient),
+        new StallDetector(stateManager),
+        {
+          agentLoopRunner: taskRunner,
+          execFileSyncFn: (_cmd, args, opts) => {
+            diffCwds.push(opts.cwd);
+            return args[0] === "diff" || args[0] === "ls-files" ? "" : "";
+          },
+        },
+      );
+      const task = makeTask();
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+
+      const result = await lifecycle.executeTaskWithAgentLoop(task, "workspace context", "knowledge context");
+
+      expect(result.success).toBe(true);
+      expect(result.agentLoop?.requestedCwd).toBe(fs.realpathSync(goalWorkspace));
+      expect(result.agentLoop?.executionCwd).toBe(fs.realpathSync(goalWorkspace));
+      expect(result.agentLoop?.requestedCwd).not.toBe(fs.realpathSync(daemonDir));
+      expect(diffCwds).toEqual(expect.arrayContaining([fs.realpathSync(goalWorkspace)]));
+      expect(diffCwds).not.toContain(fs.realpathSync(daemonDir));
+    } finally {
+      fs.rmSync(goalWorkspace, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
   });
 
   it("rejects premature done until runtime verification evidence exists", async () => {

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -52,6 +52,7 @@ import type { KnowledgeTransfer } from "../../../platform/knowledge/transfer/kno
 import type { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
 import type { MemoryLifecycleManager } from "../../../platform/knowledge/memory/memory-lifecycle.js";
 import { captureExecutionDiffArtifacts } from "./task-diff-capture.js";
+import { resolveTaskWorkspacePath } from "./task-workspace.js";
 import type { GuardrailRunner } from "../../../platform/traits/guardrail-runner.js";
 import type { HookManager } from "../../../runtime/hook-manager.js";
 import type { ToolExecutor } from "../../../tools/executor.js";
@@ -534,10 +535,15 @@ export class TaskLifecycle {
 
     let result: AgentResult;
     try {
+      const taskCwd = await resolveTaskWorkspacePath({
+        stateManager: this.stateManager,
+        task: runningTask,
+      });
       const agentLoopResult = await this.agentLoopRunner.runTask({
         task: runningTask,
         workspaceContext,
         knowledgeContext,
+        cwd: taskCwd,
       });
       result = taskAgentLoopResultToAgentResult(agentLoopResult);
       if (agentLoopResult.workspace?.executionCwd) {

--- a/src/orchestrator/execution/task/task-verifier-rules.ts
+++ b/src/orchestrator/execution/task/task-verifier-rules.ts
@@ -4,6 +4,7 @@ import type { VerificationResult } from "../../../base/types/task.js";
 import type { AgentTask, AgentResult, IAdapter } from "../adapter-layer.js";
 import type { VerifierDeps } from "./task-verifier-types.js";
 import { syncTaskOutcomeSummary } from "./task-outcome-ledger.js";
+import { resolveTaskWorkspacePath } from "./task-workspace.js";
 
 // ─── runMechanicalVerification ───
 
@@ -238,37 +239,11 @@ export function isDirectionCorrect(verificationResult: VerificationResult): bool
 // ─── attemptRevert ───
 
 async function resolveRevertCwd(deps: VerifierDeps, task: Task): Promise<string | null> {
-  const explicitCwd = deps.revertCwd?.trim();
-  if (explicitCwd) {
-    return explicitCwd;
-  }
-
-  const taskWorkspaceConstraint = task.constraints.find((constraint) =>
-    constraint.startsWith("workspace_path:")
-  );
-  if (taskWorkspaceConstraint) {
-    const taskWorkspace = taskWorkspaceConstraint.slice("workspace_path:".length).trim();
-    if (taskWorkspace) {
-      return taskWorkspace;
-    }
-  }
-
-  try {
-    const goal = await deps.stateManager.loadGoal(task.goal_id);
-    const goalWorkspaceConstraint = goal?.constraints.find((constraint) =>
-      constraint.startsWith("workspace_path:")
-    );
-    if (goalWorkspaceConstraint) {
-      const goalWorkspace = goalWorkspaceConstraint.slice("workspace_path:".length).trim();
-      if (goalWorkspace) {
-        return goalWorkspace;
-      }
-    }
-  } catch {
-    // Non-fatal: absence of goal state should just disable raw git restore.
-  }
-
-  return null;
+  return await resolveTaskWorkspacePath({
+    stateManager: deps.stateManager,
+    task,
+    fallbackCwd: deps.revertCwd?.trim() || undefined,
+  }) ?? null;
 }
 
 export async function attemptRevert(deps: VerifierDeps, task: Task): Promise<boolean> {

--- a/src/orchestrator/execution/task/task-verifier.ts
+++ b/src/orchestrator/execution/task/task-verifier.ts
@@ -53,6 +53,7 @@ import {
 } from "./task-verifier-rules.js";
 import { runLLMReview } from "./task-verifier-llm.js";
 import { appendTaskOutcomeEvent } from "./task-outcome-ledger.js";
+import { resolveTaskWorkspacePath } from "./task-workspace.js";
 
 function formatSelfReportEvidence(executorReport: import("./task-verifier-types.js").ExecutorReport): string {
   const segments = [
@@ -90,7 +91,7 @@ async function collectVerificationDiffs(
   const cwd =
     executionResult.agentLoop?.requestedCwd ??
     executionResult.agentLoop?.executionCwd ??
-    task.constraints.find((constraint) => constraint.startsWith("workspace_path:"))?.slice("workspace_path:".length) ??
+    await resolveTaskWorkspacePath({ stateManager: deps.stateManager, task }) ??
     process.cwd();
 
   const changedPaths = [

--- a/src/orchestrator/execution/task/task-workspace.ts
+++ b/src/orchestrator/execution/task/task-workspace.ts
@@ -1,0 +1,32 @@
+import type { StateManager } from "../../../base/state/state-manager.js";
+import type { Task } from "../../../base/types/task.js";
+
+const WORKSPACE_PATH_CONSTRAINT_PREFIX = "workspace_path:";
+
+function workspacePathFromConstraints(constraints: readonly string[] | undefined): string | null {
+  const constraint = constraints?.find((value) => value.startsWith(WORKSPACE_PATH_CONSTRAINT_PREFIX));
+  const workspacePath = constraint?.slice(WORKSPACE_PATH_CONSTRAINT_PREFIX.length).trim();
+  return workspacePath && workspacePath.length > 0 ? workspacePath : null;
+}
+
+export async function resolveTaskWorkspacePath(
+  input: {
+    stateManager: StateManager;
+    task: Task;
+    fallbackCwd?: string;
+  },
+): Promise<string | undefined> {
+  const taskWorkspacePath = workspacePathFromConstraints(input.task.constraints);
+  if (taskWorkspacePath) return taskWorkspacePath;
+
+  try {
+    const goal = await input.stateManager.loadGoal(input.task.goal_id);
+    const goalWorkspacePath = workspacePathFromConstraints(goal?.constraints);
+    if (goalWorkspacePath) return goalWorkspacePath;
+  } catch {
+    // Missing or unreadable goal state should not block task execution.
+  }
+
+  return input.fallbackCwd;
+}
+

--- a/tmp/kaggle-durable-loop-issues-status.md
+++ b/tmp/kaggle-durable-loop-issues-status.md
@@ -1,0 +1,36 @@
+# Kaggle Durable Loop Issues Status
+
+Updated: 2026-05-06 Asia/Tokyo
+
+## Startup
+
+- Ran `git switch main && git pull --ff-only`: already on up-to-date `main`.
+- Ran `gh issue list --state open --limit 100`: target issues #1089, #1090, #1091, and #1093 are open.
+- New adjacent open issues #1094 and #1095 exist, but current work remains focused on #1089/#1090/#1091/#1093 unless they become blockers.
+
+## #1089
+
+Status: implementation verified locally; preparing PR.
+
+Plan:
+- Resolve effective task workspace from task `workspace_path` constraint, then goal `workspace_path` constraint, then existing lifecycle default.
+- Pass that cwd into `TaskAgentLoopRunner.runTask()` for native task execution.
+- Keep diff capture on the runner-reported execution cwd, which should now be the goal workspace.
+- Preserve revert safety by passing the same effective workspace into verifier deps.
+- Add a production caller-path test with daemon tmp cwd different from goal workspace.
+
+Implemented:
+- Added shared `resolveTaskWorkspacePath()` helper.
+- Native task lifecycle now passes the effective task/goal workspace cwd into `TaskAgentLoopRunner.runTask()`.
+- Verification diff fallback and revert cwd resolution now prefer task/goal `workspace_path` over stale daemon defaults.
+- Added production-path native agent-loop test for daemon cwd != goal workspace.
+- Added revert regression test for goal workspace overriding stale daemon `revertCwd`.
+
+Verification:
+- `npm test -- --run src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/orchestrator/execution/__tests__/task-verifier-guards.test.ts`
+- `npm run typecheck`
+- `npm run lint:boundaries` (exit 0; existing warnings only)
+- `npm run test:changed`
+
+Review:
+- Fresh review agent: no material findings.


### PR DESCRIPTION
Closes #1089

## Summary
- resolve task execution workspace from task/goal `workspace_path` constraints before falling back to daemon defaults
- pass the resolved cwd into native `TaskAgentLoopRunner.runTask()` so execution, verification evidence, and diff capture use the goal workspace
- reuse the same workspace resolution for verification diff fallback and revert safety so stale daemon `revertCwd` does not win over a goal workspace
- add regression coverage for daemon cwd differing from the goal workspace and for revert choosing the goal workspace

## Verification
- `npm test -- --run src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/orchestrator/execution/__tests__/task-verifier-guards.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (exit 0; existing warnings only)
- `npm run test:changed`

## Known unresolved risks
- Existing lint warnings remain outside this issue scope.
- The `workspace_path` contract remains the existing exact `workspace_path:<path>` constraint token; broader typed goal workspace modeling is out of scope for this PR.
