### PR TITLE
fix(agent-loop): make Soil embedding failures non-fatal

### DIFF
--- a/src/base/llm/provider-config.ts
+++ b/src/base/llm/provider-config.ts
@@ -662,14 +662,14 @@ export async function loadProviderConfigFile(options: { baseDir?: string } = {})
   return fileConfig;
 }
 
-export async function resolveOpenAIApiKey(): Promise<string | undefined> {
-  const envFile = await readProviderEnvFile();
+export async function resolveOpenAIApiKey(options: { baseDir?: string } = {}): Promise<string | undefined> {
+  const envFile = await readProviderEnvFile(options.baseDir);
   const envKey = process.env["OPENAI_API_KEY"] ?? envFile["OPENAI_API_KEY"];
   if (envKey) {
     return envKey;
   }
 
-  const fileConfig = await readProviderConfigFile();
+  const fileConfig = await readProviderConfigFile(options.baseDir);
   if (fileConfig.provider === "openai" || fileConfig.adapter === "openai_api") {
     return fileConfig.api_key;
   }

--- a/src/interface/cli/__tests__/cli-doctor.test.ts
+++ b/src/interface/cli/__tests__/cli-doctor.test.ts
@@ -23,6 +23,7 @@ import {
   checkPulseedDir,
   checkProviderConfig,
   checkApiKey,
+  checkEmbeddingAuth,
   checkStateDirectoryPermissions,
   checkProviderConfigPermissions,
   checkPluginPermissionWarnings,
@@ -142,6 +143,101 @@ describe("checkApiKey", () => {
     const result = checkApiKey(tmpDir);
     expect(result.status).toBe("pass");
     expect(result.detail).toContain("provider.json");
+  });
+});
+
+describe("checkEmbeddingAuth", () => {
+  let tmpDir: string;
+  const savedOpenaiKey = process.env["OPENAI_API_KEY"];
+
+  beforeEach(() => {
+    tmpDir = makeTempDir("pulseed-doctor-embedding-auth-");
+    delete process.env["OPENAI_API_KEY"];
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+    } as Response)));
+  });
+
+  afterEach(() => {
+    if (savedOpenaiKey !== undefined) process.env["OPENAI_API_KEY"] = savedOpenaiKey;
+    else delete process.env["OPENAI_API_KEY"];
+    vi.unstubAllGlobals();
+    cleanupTempDir(tmpDir);
+  });
+
+  function jwtWithExp(exp: number): string {
+    const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+    const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+    return `${header}.${payload}.signature`;
+  }
+
+  it("warns when provider OpenAI embedding token is expired", async () => {
+    fs.writeFileSync(path.join(tmpDir, "provider.json"), JSON.stringify({
+      provider: "openai",
+      adapter: "openai_codex_cli",
+      api_key: jwtWithExp(Math.floor(Date.now() / 1000) - 60),
+    }));
+
+    const result = await checkEmbeddingAuth(tmpDir);
+
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("expired token");
+    expect(result.detail).not.toContain(".signature");
+  });
+
+  it("passes without exposing a configured OpenAI key", async () => {
+    fs.writeFileSync(path.join(tmpDir, "provider.json"), JSON.stringify({
+      provider: "openai",
+      adapter: "openai_codex_cli",
+      api_key: "sk-secret-value",
+    }));
+
+    const result = await checkEmbeddingAuth(tmpDir);
+
+    expect(result.status).toBe("pass");
+    expect(result.detail).toContain("OpenAI embeddings request succeeded");
+    expect(result.detail).not.toContain("sk-secret-value");
+  });
+
+  it("warns when the OpenAI embedding probe rejects the key", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+    } as Response);
+    fs.writeFileSync(path.join(tmpDir, "provider.json"), JSON.stringify({
+      provider: "openai",
+      adapter: "openai_codex_cli",
+      api_key: "sk-bad-secret",
+    }));
+
+    const result = await checkEmbeddingAuth(tmpDir);
+
+    expect(result.status).toBe("warn");
+    expect(result.detail).toContain("401 Unauthorized");
+    expect(result.detail).not.toContain("sk-bad-secret");
+  });
+
+  it("uses provider .env OpenAI key before a stale provider.json key", async () => {
+    fs.writeFileSync(path.join(tmpDir, ".env"), "OPENAI_API_KEY=sk-env-secret\n");
+    fs.writeFileSync(path.join(tmpDir, "provider.json"), JSON.stringify({
+      provider: "openai",
+      adapter: "openai_codex_cli",
+      api_key: jwtWithExp(Math.floor(Date.now() / 1000) - 60),
+    }));
+
+    const result = await checkEmbeddingAuth(tmpDir);
+
+    expect(result.status).toBe("pass");
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer sk-env-secret" }),
+      }),
+    );
+    expect(result.detail).not.toContain("sk-env-secret");
   });
 });
 
@@ -777,10 +873,16 @@ describe("cmdDoctor summary counts", () => {
   beforeEach(() => {
     tmpDir = makeTempDir("pulseed-doctor-cmd-");
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+    } as Response)));
   });
 
   afterEach(() => {
     consoleSpy.mockRestore();
+    vi.unstubAllGlobals();
     cleanupTempDir(tmpDir);
   });
 

--- a/src/interface/cli/commands/doctor.ts
+++ b/src/interface/cli/commands/doctor.ts
@@ -7,6 +7,7 @@ import { getPulseedDirPath, getLogsDir, getGoalsDir, getPluginsDir } from "../..
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import { getCliRunnerBuildPath } from "../../../base/utils/pulseed-meta.js";
 import { readJsonFileOrNull } from "../../../base/utils/json-io.js";
+import { isJwtExpired, resolveOpenAIApiKey } from "../../../base/llm/provider-config.js";
 import { DaemonConfigSchema } from "../../../base/types/daemon.js";
 import { PluginManifestSchema } from "../../../base/types/plugin.js";
 import { PIDManager } from "../../../runtime/pid-manager.js";
@@ -173,6 +174,78 @@ export function checkApiKey(baseDir?: string): CheckResult {
     name: "API key",
     status: "fail",
     detail: "ANTHROPIC_API_KEY / OPENAI_API_KEY not set (checked env + provider.json)",
+  };
+}
+
+function isJwtLike(value: string): boolean {
+  return value.split(".").length >= 3;
+}
+
+async function probeOpenAIEmbeddingAuth(apiKey: string, timeoutMs = 3000): Promise<{ ok: boolean; detail: string }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch("https://api.openai.com/v1/embeddings", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: process.env["OPENAI_EMBEDDING_MODEL"] ?? "text-embedding-3-small",
+        input: "pulseed doctor embedding auth preflight",
+      }),
+      signal: controller.signal,
+    });
+    if (response.ok) {
+      return { ok: true, detail: "OpenAI embeddings request succeeded" };
+    }
+    return {
+      ok: false,
+      detail: `OpenAI embeddings request failed: ${response.status} ${response.statusText}`,
+    };
+  } catch (error) {
+    const detail = error instanceof Error && error.name === "AbortError"
+      ? `OpenAI embeddings request timed out after ${timeoutMs}ms`
+      : `OpenAI embeddings request failed: ${error instanceof Error ? error.message : String(error)}`;
+    return { ok: false, detail };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function checkEmbeddingAuth(baseDir?: string): Promise<CheckResult> {
+  const openaiKey = await resolveOpenAIApiKey({ baseDir });
+
+  if (!openaiKey) {
+    return {
+      name: "Embedding auth",
+      status: "warn",
+      detail: "No OpenAI key for embeddings; Soil vector retrieval will use non-vector fallback",
+    };
+  }
+
+  if (isJwtLike(openaiKey) && isJwtExpired(openaiKey)) {
+    return {
+      name: "Embedding auth",
+      status: "warn",
+      detail: "OpenAI embedding key appears to be an expired token; refresh auth before durable vector-backed runs",
+    };
+  }
+
+  const probe = await probeOpenAIEmbeddingAuth(openaiKey);
+  if (!probe.ok) {
+    return {
+      name: "Embedding auth",
+      status: "warn",
+      detail: `${probe.detail}; Soil vector retrieval will use non-vector fallback`,
+    };
+  }
+
+  return {
+    name: "Embedding auth",
+    status: "pass",
+    detail: probe.detail,
   };
 }
 
@@ -596,6 +669,7 @@ export async function cmdDoctor(_args: string[]): Promise<number> {
     checkPulseedDir(baseDir),
     checkProviderConfig(baseDir),
     checkApiKey(baseDir),
+    await checkEmbeddingAuth(baseDir),
     checkStateDirectoryPermissions(baseDir),
     checkProviderConfigPermissions(baseDir),
     checkPluginPermissionWarnings(baseDir),

--- a/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-runner.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-runner.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Task } from "../../../../base/types/task.js";
 import type { BoundedAgentLoopRunner } from "../bounded-agent-loop-runner.js";
 import type { AgentLoopModelClient, AgentLoopModelRegistry } from "../agent-loop-model.js";
 import { TaskAgentLoopRunner } from "../task-agent-loop-runner.js";
+import { AgentLoopContextAssembler } from "../agent-loop-context-assembler.js";
 
 const { finalize, prepareTaskAgentLoopWorkspace } = vi.hoisted(() => ({
   finalize: vi.fn(),
@@ -24,6 +25,10 @@ function makeTask(): Task {
 }
 
 describe("TaskAgentLoopRunner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("finalizes the workspace when grounding assembly throws before execution", async () => {
     finalize.mockResolvedValue({
       requestedCwd: "/repo",
@@ -63,5 +68,79 @@ describe("TaskAgentLoopRunner", () => {
     await expect(runner.runTask({ task: makeTask(), cwd: "/repo" })).rejects.toThrow("grounding failed");
     expect((boundedRunner.run as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
     expect(finalize).toHaveBeenCalledWith({ success: false, changedFiles: [] });
+  });
+
+  it("continues into the bounded runner when Soil vector prefetch fails auth", async () => {
+    const cwd = process.cwd();
+    finalize.mockResolvedValue({
+      requestedCwd: cwd,
+      executionCwd: cwd,
+      isolated: false,
+      cleanupStatus: "not_requested",
+    });
+    prepareTaskAgentLoopWorkspace.mockResolvedValue({
+      requestedCwd: cwd,
+      executionCwd: cwd,
+      isolated: false,
+      finalize,
+    });
+    const boundedRunner = {
+      run: vi.fn().mockResolvedValue({
+        success: true,
+        output: {
+          status: "done",
+          finalAnswer: "finished",
+          summary: "summary",
+          filesChanged: [],
+          testsRun: [],
+          completionEvidence: ["bounded runner reached"],
+          verificationHints: [],
+          blockers: [],
+        },
+        finalText: "finished",
+        stopReason: "completed",
+        elapsedMs: 1,
+        modelTurns: 1,
+        toolCalls: 0,
+        compactions: 0,
+        changedFiles: [],
+        commandResults: [],
+        traceId: "trace-1",
+        sessionId: "session-1",
+        turnId: "turn-1",
+      }),
+    } as unknown as BoundedAgentLoopRunner;
+    const modelInfo = {
+      ref: { providerId: "test", modelId: "model" },
+      displayName: "test/model",
+      capabilities: {},
+    };
+    const vectorIndex = {
+      search: vi.fn().mockRejectedValue(new Error("OpenAI embedding request failed: 401 Unauthorized")),
+    };
+    const runner = new TaskAgentLoopRunner({
+      boundedRunner,
+      modelClient: {
+        getModelInfo: vi.fn().mockResolvedValue(modelInfo),
+      } as unknown as AgentLoopModelClient,
+      modelRegistry: {
+        defaultModel: vi.fn().mockResolvedValue(modelInfo.ref),
+      } as unknown as AgentLoopModelRegistry,
+      contextAssembler: new AgentLoopContextAssembler(),
+      soilPrefetch: async () => {
+        await vectorIndex.search("query", 5, 0);
+        return null;
+      },
+    });
+
+    const result = await runner.runTask({ task: makeTask(), cwd });
+
+    expect(vectorIndex.search).toHaveBeenCalled();
+    expect(boundedRunner.run).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+    const turn = (boundedRunner.run as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    const userMessage = turn.messages.find((message: { role: string }) => message.role === "user")?.content;
+    expect(userMessage).toContain("Soil prefetch failed; continuing without Soil context");
+    expect(userMessage).toContain("OpenAI embedding request failed: 401 Unauthorized");
   });
 });

--- a/src/orchestrator/execution/agent-loop/agent-loop-context-assembler.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-context-assembler.ts
@@ -62,7 +62,17 @@ export class AgentLoopContextAssembler {
     const cwd = resolve(input.cwd ?? process.cwd());
     const soilQuery = input.soilPrefetch
       ? async ({ query, rootDir, limit }: { query: string; rootDir: string; limit: number }) => {
-          const soil = await input.soilPrefetch!({ query, rootDir, limit });
+          let soil: SoilPrefetchResult | null;
+          try {
+            soil = await input.soilPrefetch!({ query, rootDir, limit });
+          } catch (error) {
+            const detail = error instanceof Error ? error.message : String(error);
+            return {
+              retrievalSource: "prefetch" as const,
+              warnings: [`Soil prefetch failed; continuing without Soil context: ${detail}`],
+              hits: [],
+            };
+          }
           if (!soil?.content.trim()) {
             return null;
           }

--- a/src/platform/knowledge/__tests__/memory-lifecycle-phase2.test.ts
+++ b/src/platform/knowledge/__tests__/memory-lifecycle-phase2.test.ts
@@ -536,6 +536,43 @@ describe("searchCrossGoalLessons", () => {
     expect(mockVI.search).toHaveBeenCalled();
     expect(results.some((l) => l.lesson_id === lessonId)).toBe(true);
   });
+
+  it("falls back to manifest lessons when VectorIndex search fails", async () => {
+    const mockVI = makeMockVectorIndex();
+    vi.mocked(mockVI.search).mockRejectedValue(new Error("OpenAI embedding request failed: 401 Unauthorized"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const mgr = new MemoryLifecycleManager(
+      tmpDir,
+      createMockLLMClient([]),
+      undefined,
+      undefined,
+      mockVI
+    );
+    await mgr.initializeDirectories();
+    const globalPath = path.join(tmpDir, "memory", "long-term", "lessons", "global.json");
+    const lesson: LessonEntry = {
+      lesson_id: "lesson-fallback",
+      type: "strategy_outcome",
+      goal_id: "goal-a",
+      context: "fallback context",
+      lesson: "Fallback Lesson",
+      source_loops: ["loop_1"],
+      extracted_at: new Date().toISOString(),
+      relevance_tags: ["fallback"],
+      status: "active",
+    };
+    fs.writeFileSync(globalPath, JSON.stringify([lesson]));
+
+    try {
+      const results = await mgr.searchCrossGoalLessons("Fallback Lesson", 5);
+
+      expect(mockVI.search).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Vector lesson search failed"));
+      expect(results.map((entry) => entry.lesson_id)).toContain("lesson-fallback");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 // ═══════════════════════════════════════════════════════

--- a/src/platform/knowledge/memory/memory-selection.ts
+++ b/src/platform/knowledge/memory/memory-selection.ts
@@ -360,38 +360,43 @@ export async function searchCrossGoalLessons(
   const { LessonEntrySchema } = await import("../../../base/types/memory-lifecycle.js");
 
   if (deps.vectorIndex) {
-    // Semantic search in vector index
-    const results = await deps.vectorIndex.search(query, topK * 2, 0.0);
+    try {
+      // Semantic search in vector index
+      const results = await deps.vectorIndex.search(query, topK * 2, 0.0);
 
-    // Filter to lesson entries (metadata.is_lesson === true)
-    const lessonResults = results.filter((r) => r.metadata.is_lesson === true);
+      // Filter to lesson entries (metadata.is_lesson === true)
+      const lessonResults = results.filter((r) => r.metadata.is_lesson === true);
 
-    // Load actual lessons from global file
-    const globalPath = path.join(
-      deps.memoryDir,
-      "long-term",
-      "lessons",
-      "global.json"
-    );
-    const globalLessons =
-      (await readJsonFileAsync<LessonEntry[]>(
-        globalPath,
-        z.array(LessonEntrySchema)
-      )) ?? [];
+      // Load actual lessons from global file
+      const globalPath = path.join(
+        deps.memoryDir,
+        "long-term",
+        "lessons",
+        "global.json"
+      );
+      const globalLessons =
+        (await readJsonFileAsync<LessonEntry[]>(
+          globalPath,
+          z.array(LessonEntrySchema)
+        )) ?? [];
 
-    const lessonMap = new Map(globalLessons.map((l) => [l.lesson_id, l]));
-    const matched: LessonEntry[] = [];
-    for (const r of lessonResults) {
-      const lesson = lessonMap.get(r.id);
-      if (lesson && lesson.status === "active") {
-        matched.push(lesson);
-        if (matched.length >= topK) break;
+      const lessonMap = new Map(globalLessons.map((l) => [l.lesson_id, l]));
+      const matched: LessonEntry[] = [];
+      for (const r of lessonResults) {
+        const lesson = lessonMap.get(r.id);
+        if (lesson && lesson.status === "active") {
+          matched.push(lesson);
+          if (matched.length >= topK) break;
+        }
       }
-    }
 
-    // If we got enough results from semantic search, return them
-    if (matched.length > 0) {
-      return matched;
+      // If we got enough results from semantic search, return them
+      if (matched.length > 0) {
+        return matched;
+      }
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      console.warn(`[memory] Vector lesson search failed; falling back to manifest lessons: ${detail}`);
     }
   }
 
@@ -521,4 +526,3 @@ export async function selectForWorkingMemorySemantic(
 
   return { shortTerm: shortTermEntries, lessons };
 }
-

--- a/tmp/kaggle-durable-loop-issues-status.md
+++ b/tmp/kaggle-durable-loop-issues-status.md
@@ -34,3 +34,32 @@ Verification:
 
 Review:
 - Fresh review agent: no material findings.
+
+PR:
+- #1096 merged after CI rerun. Initial integration failure was unrelated `loop-supervisor` timing; exact file passed locally and rerun passed.
+
+## #1090
+
+Status: implementation verified locally; preparing PR.
+
+Plan:
+- Catch `soilPrefetch` failures in `AgentLoopContextAssembler` and return empty Soil context with a warning so task execution can continue.
+- Keep vector search failures non-fatal in `searchCrossGoalLessons()` by falling back to existing non-vector lesson selection.
+- Add focused native task runner coverage where Soil/vector prefetch throws `OpenAI embedding request failed: 401 Unauthorized` and bounded runner is reached.
+- Add bounded provider/embedding preflight to `doctor` that warns on invalid/expired embedding auth without exposing key material.
+
+Implemented:
+- Agent-loop context assembly now converts Soil prefetch exceptions into grounding warnings and continues with empty Soil context.
+- Cross-goal lesson search catches vector search failures and falls back to existing manifest/text lesson search.
+- `pulseed doctor` now resolves OpenAI embedding auth through the same provider `.env`/provider config path and probes the embeddings endpoint with a bounded timeout.
+- Doctor warning paths avoid logging key material.
+
+Verification:
+- `npm test -- --run src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-runner.test.ts src/platform/knowledge/__tests__/memory-lifecycle-phase2.test.ts src/interface/cli/__tests__/cli-doctor.test.ts src/base/llm/__tests__/provider-config.test.ts`
+- `npm run typecheck`
+- `npm run lint:boundaries` (exit 0; existing warnings only)
+- `npm run test:changed`
+
+Review:
+- Initial fresh review found two preflight issues; both fixed.
+- Second fresh review: no material findings.


### PR DESCRIPTION
Closes #1090

## Summary
- convert Soil prefetch exceptions during native agent-loop context assembly into grounding warnings so task execution continues without Soil context
- catch vector-index lesson search failures and fall back to existing manifest lesson search
- add embedding auth doctor preflight using the same OpenAI key resolution path as runtime setup, including provider `.env` precedence and expired JWT detection
- add regression coverage for vector search 401 reaching the bounded runner, manifest fallback, and doctor auth warnings without exposing secrets

## Verification
- `npm test -- --run src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-runner.test.ts src/platform/knowledge/__tests__/memory-lifecycle-phase2.test.ts src/interface/cli/__tests__/cli-doctor.test.ts src/base/llm/__tests__/provider-config.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (exit 0; existing warnings only)
- `npm run test:changed`

## Known unresolved risks
- Doctor embedding preflight performs a bounded live OpenAI embeddings request when an OpenAI key is configured; network/auth failures are reported as warnings and do not block the command.
- Existing repo-wide lint warnings remain outside this issue scope.
