### PR TITLE
fix(observation): read Kaggle metrics from goal workspace

### DIFF
--- a/src/adapters/__tests__/artifact-metric-datasource.test.ts
+++ b/src/adapters/__tests__/artifact-metric-datasource.test.ts
@@ -59,6 +59,32 @@ describe("ArtifactMetricDataSourceAdapter", () => {
     });
   });
 
+  it("discovers Kaggle experiment metrics and maps plain metric_name to cv_score", async () => {
+    writeJson(path.join(workspace, "experiments", "smoke-hgb-50k", "metrics.json"), {
+      metric_name: "roc_auc",
+      direction: "maximize",
+      cv_score: 0.9331832527157385,
+      status: "completed",
+    });
+
+    const adapter = createWorkspaceArtifactMetricDataSource(workspace);
+    const result = await adapter.query({ dimension_name: "roc_auc", timeout_ms: 10000 });
+
+    expect(result.value).toBe(0.9331832527157385);
+    expect(result.raw).toMatchObject({
+      inspected_metric_files: 1,
+      selected_key: "roc_auc",
+      selected: {
+        relativePath: "experiments/smoke-hgb-50k/metrics.json",
+        key: "roc_auc",
+        keyPath: "cv_score",
+      },
+      discovery: {
+        artifact_roots: expect.arrayContaining(["experiments"]),
+      },
+    });
+  });
+
   it("counts validated metric artifacts when no experiment log exists", async () => {
     writeJson(path.join(workspace, "artifacts", "probe-a", "metrics.json"), { score: 0.8 });
     writeJson(path.join(workspace, "artifacts", "probe-b", "metrics.json"), { metrics: { accuracy: 0.7 } });

--- a/src/adapters/datasources/artifact-metric-datasource.ts
+++ b/src/adapters/datasources/artifact-metric-datasource.ts
@@ -60,7 +60,7 @@ interface MetricConflict {
 
 const BUILTIN_SOURCE_ID = "ds_builtin_workspace_artifacts";
 const DEFAULT_METRIC_FILE_NAMES = ["metrics.json", "result.json"];
-const DEFAULT_ARTIFACT_ROOTS = ["artifacts", "runs", "reports", "outputs", "results", "logs"];
+const DEFAULT_ARTIFACT_ROOTS = ["artifacts", "experiments", "runs", "reports", "outputs", "results", "logs"];
 const DEFAULT_EXCLUDE_DIRS = new Set([
   ".cache",
   ".git",
@@ -86,6 +86,28 @@ export function createWorkspaceArtifactMetricDataSource(workspacePath = process.
     connection: { path: workspacePath },
     enabled: true,
     created_at: new Date().toISOString(),
+  });
+}
+
+export function createGoalWorkspaceArtifactMetricDataSource(
+  goalId: string,
+  workspacePath: string,
+  dimensionMetrics: Record<string, string[]>,
+  dimensionAggregations: Record<string, Aggregation> = {},
+): ArtifactMetricDataSourceAdapter {
+  return new ArtifactMetricDataSourceAdapter({
+    id: `${BUILTIN_SOURCE_ID}:goal:${goalId}`,
+    name: "builtin:goal workspace artifact metrics",
+    type: "artifact_metric",
+    connection: {
+      path: workspacePath,
+      dimension_metrics: dimensionMetrics,
+      dimension_aggregations: dimensionAggregations,
+      require_metric_match: true,
+    },
+    enabled: true,
+    created_at: new Date().toISOString(),
+    scope_goal_id: goalId,
   });
 }
 
@@ -181,6 +203,9 @@ export class ArtifactMetricDataSourceAdapter implements IDataSourceAdapter {
     }
 
     const match = selectMetric(observations, keys, aggregation);
+    if (this.config.connection.require_metric_match && match === null) {
+      throw new Error(`No artifact metric found for dimension "${params.dimension_name}" using keys [${keys.join(", ")}]`);
+    }
     return {
       value: match?.value ?? 0,
       raw: {

--- a/src/platform/observation/__tests__/observation-engine.test.ts
+++ b/src/platform/observation/__tests__/observation-engine.test.ts
@@ -9,9 +9,11 @@ import type { ObservationLayer, ObservationMethod, ObservationTrigger } from "..
 import type { KnowledgeGapSignal } from "../../../base/types/knowledge.js";
 import type { IDataSourceAdapter } from "../data-source-adapter.js";
 import type { DataSourceConfig } from "../../../base/types/data-source.js";
+import type { ILLMClient } from "../../../base/llm/llm-client.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { makeGoal } from "../../../../tests/helpers/fixtures.js";
 import { randomUUID } from "node:crypto";
+import { createWorkspaceArtifactMetricDataSource } from "../../../adapters/datasources/artifact-metric-datasource.js";
 
 // ─── Helpers ───
 
@@ -52,6 +54,17 @@ function makeEntry(overrides: Partial<ObservationLogEntry> = {}): ObservationLog
     confidence: 0.9,
     notes: null,
     ...overrides,
+  };
+}
+
+function makeMockLLMClient(score = 0.25): ILLMClient {
+  return {
+    sendMessage: vi.fn().mockResolvedValue({
+      content: JSON.stringify({ score, reason: "llm fallback" }),
+      usage: { input_tokens: 100, output_tokens: 20 },
+      stop_reason: "end_turn",
+    }),
+    parseJSON: vi.fn().mockReturnValue({ score, reason: "llm fallback" }),
   };
 }
 
@@ -979,6 +992,157 @@ describe("observeFromDataSource", () => {
     expect(updated?.dimensions[0]?.current_value).toBe(83);
   });
 
+  it("observes goal-workspace Kaggle experiment metrics before LLM fallback", async () => {
+    const daemonWorkspace = path.join(tmpDir, "daemon-workspace");
+    const goalWorkspace = path.join(tmpDir, "kaggle-workspace");
+    fs.mkdirSync(daemonWorkspace, { recursive: true });
+    writeJsonFile(path.join(goalWorkspace, "experiments", "smoke-hgb-50k", "metrics.json"), {
+      metric_name: "roc_auc",
+      direction: "maximize",
+      cv_score: 0.9331832527157385,
+      status: "completed",
+    });
+    writeJsonFile(path.join(daemonWorkspace, "experiments", "wrong", "metrics.json"), {
+      metric_name: "roc_auc",
+      cv_score: 0.1,
+    });
+    const llmClient = makeMockLLMClient(0.2);
+    const engine = new ObservationEngine(
+      stateManager,
+      [createWorkspaceArtifactMetricDataSource(daemonWorkspace)],
+      llmClient,
+      async () => "workspace context exists",
+    );
+    const goal = makeGoal({
+      id: "goal-kaggle-roc-auc",
+      constraints: [`workspace_path:${goalWorkspace}`],
+      dimensions: [
+        {
+          name: "roc_auc",
+          label: "ROC AUC",
+          current_value: 0,
+          threshold: { type: "min", value: 0.95 },
+          confidence: 0.5,
+          observation_method: defaultMethod,
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await stateManager.saveGoal(goal);
+
+    await engine.observe("goal-kaggle-roc-auc", []);
+
+    const updated = await stateManager.loadGoal("goal-kaggle-roc-auc");
+    expect(updated?.dimensions[0]?.current_value).toBe(0.9331832527157385);
+    expect(updated?.dimensions[0]?.last_observed_layer).toBe("mechanical");
+    expect(llmClient.sendMessage).not.toHaveBeenCalled();
+    const log = await stateManager.loadObservationLog("goal-kaggle-roc-auc");
+    expect(log).not.toBeNull();
+    expect(log!.entries[0]?.raw_result).toMatchObject({
+      root: goalWorkspace,
+      selected: {
+        relativePath: "experiments/smoke-hgb-50k/metrics.json",
+        key: "roc_auc",
+        keyPath: "cv_score",
+      },
+    });
+  });
+
+  it("observes builtin-supported artifact metrics from the goal workspace over daemon datasource", async () => {
+    const daemonWorkspace = path.join(tmpDir, "daemon-workspace");
+    const goalWorkspace = path.join(tmpDir, "builtin-metric-workspace");
+    writeJsonFile(path.join(daemonWorkspace, "artifacts", "wrong", "metrics.json"), {
+      oof_balanced_accuracy: 0.1,
+    });
+    writeJsonFile(path.join(goalWorkspace, "artifacts", "probe-balanced", "metrics.json"), {
+      oof_balanced_accuracy: 0.88,
+    });
+    const engine = new ObservationEngine(
+      stateManager,
+      [createWorkspaceArtifactMetricDataSource(daemonWorkspace)],
+    );
+    const goal = makeGoal({
+      id: "goal-builtin-artifact-metrics",
+      constraints: [`workspace_path:${goalWorkspace}`],
+      dimensions: [
+        {
+          name: "best_oof_balanced_accuracy",
+          label: "Best OOF balanced accuracy",
+          current_value: 0,
+          threshold: { type: "min", value: 0.95 },
+          confidence: 0.5,
+          observation_method: defaultMethod,
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await stateManager.saveGoal(goal);
+
+    await engine.observe("goal-builtin-artifact-metrics", []);
+
+    const updated = await stateManager.loadGoal("goal-builtin-artifact-metrics");
+    expect(updated?.dimensions[0]?.current_value).toBe(0.88);
+    const log = await stateManager.loadObservationLog("goal-builtin-artifact-metrics");
+    expect(log).not.toBeNull();
+    expect(log!.entries[0]?.raw_result).toMatchObject({
+      root: goalWorkspace,
+      selected: {
+        relativePath: "artifacts/probe-balanced/metrics.json",
+        key: "oof_balanced_accuracy",
+      },
+    });
+  });
+
+  it("falls back to LLM when the goal-scoped artifact metric is absent", async () => {
+    const goalWorkspace = path.join(tmpDir, "kaggle-workspace-without-metrics");
+    fs.mkdirSync(goalWorkspace, { recursive: true });
+    const llmClient = makeMockLLMClient(0.42);
+    const engine = new ObservationEngine(
+      stateManager,
+      [],
+      llmClient,
+      async () => "workspace context exists",
+    );
+    const goal = makeGoal({
+      id: "goal-kaggle-llm-fallback",
+      constraints: [`workspace_path:${goalWorkspace}`],
+      dimensions: [
+        {
+          name: "roc_auc",
+          label: "ROC AUC",
+          current_value: 0,
+          threshold: { type: "min", value: 0.95 },
+          confidence: 0.5,
+          observation_method: defaultMethod,
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await stateManager.saveGoal(goal);
+
+    await engine.observe("goal-kaggle-llm-fallback", []);
+
+    const updated = await stateManager.loadGoal("goal-kaggle-llm-fallback");
+    expect(updated?.dimensions[0]?.current_value).toBe(0.42);
+    expect(updated?.dimensions[0]?.last_observed_layer).toBe("independent_review");
+    expect(llmClient.sendMessage).toHaveBeenCalled();
+  });
+
   it("handles non-numeric values from data source", async () => {
     const stringDs = makeMockDataSource({
       query: vi.fn().mockResolvedValue({
@@ -1016,3 +1180,8 @@ describe("observeFromDataSource", () => {
     expect(entry.extracted_value).toBe("healthy");
   });
 });
+
+function writeJsonFile(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}

--- a/src/platform/observation/observation-engine.ts
+++ b/src/platform/observation/observation-engine.ts
@@ -38,6 +38,7 @@ import { runToolObservationStage } from "./engine/observe-tool-stage.js";
 import { runDataSourceObservationStage } from "./engine/observe-datasource-stage.js";
 import { runLlmObservationStage } from "./engine/observe-llm-stage.js";
 import { runSelfReportStage } from "./engine/observe-self-report.js";
+import { createGoalWorkspaceArtifactMetricDataSource } from "../../adapters/datasources/artifact-metric-datasource.js";
 
 import type { ToolExecutor } from "../../tools/executor.js";
 import type { ToolCallContext } from "../../tools/types.js";
@@ -264,6 +265,10 @@ export class ObservationEngine {
 
     // Workspace path for pre-checker (extracted from contextProvider key heuristic)
     const workspacePath = goal.constraints.find((c) => c.startsWith("workspace_path:"))?.slice("workspace_path:".length);
+    const goalArtifactDataSource = createGoalScopedArtifactDataSource(goalId, goal, workspacePath);
+    const observationDataSources = goalArtifactDataSource
+      ? [...this.dataSources, goalArtifactDataSource]
+      : this.dataSources;
 
     for (let idx = 0; idx < observeCount; idx++) {
       const dim = goal.dimensions[idx]!;
@@ -298,7 +303,7 @@ export class ObservationEngine {
       }
 
       const dataSourceDimensionName = dim.observation_mapping?.dimension ?? dim.name;
-      const dataSource = this.findDataSourceForDimension(dataSourceDimensionName, goalId, dim.observation_mapping?.data_source);
+      const dataSource = findDataSourceForDimensionFn(observationDataSources, dataSourceDimensionName, goalId, dim.observation_mapping?.data_source);
       if (dataSource && await runDataSourceObservationStage({
         goalId,
         goal,
@@ -311,7 +316,14 @@ export class ObservationEngine {
         llmAvailable: !!this.llmClient,
         stateManager: this.stateManager,
         fetchWorkspaceContext,
-        observeFromDataSource: (gId, dimensionName, sourceId, queryDimensionName) => this.observeFromDataSource(gId, dimensionName, sourceId, queryDimensionName),
+        observeFromDataSource: (gId, dimensionName, sourceId, queryDimensionName) => observeFromDataSourceFn(
+          gId,
+          dimensionName,
+          sourceId,
+          observationDataSources,
+          (targetGoalId, entry) => this.applyObservation(targetGoalId, entry),
+          queryDimensionName,
+        ),
         observeWithLLM: (...args) => this.observeWithLLM(...args),
         crossValidate: (gId, dimensionName, mechanicalValue, llmValue) =>
           this.crossValidate(gId, dimensionName, mechanicalValue, llmValue),
@@ -337,7 +349,7 @@ export class ObservationEngine {
         })) {
           continue;
         }
-      } else if (this.dataSources.length > 0) {
+      } else if (observationDataSources.length > 0) {
         // DataSources exist but none match this dimension and no LLM client
         this.logger?.warn(
           `[ObservationEngine] Warning: dimension "${dim.name}" has no matching DataSource and no LLM client available for observation`
@@ -527,4 +539,40 @@ export class ObservationEngine {
     return observeWithTools(this.toolExecutor, dimension, context);
   }
 
+}
+
+function createGoalScopedArtifactDataSource(
+  goalId: string,
+  goal: { dimensions: Dimension[] },
+  workspacePath?: string,
+): IDataSourceAdapter | null {
+  if (!workspacePath) return null;
+
+  const dimensionMetrics: Record<string, string[]> = {};
+  const dimensionAggregations: Record<string, "max" | "min"> = {};
+  let supportedDimensionCount = 0;
+  for (const dimension of goal.dimensions) {
+    if (!isArtifactMetricDimension(dimension)) continue;
+    const queryDimensionName = dimension.observation_mapping?.dimension ?? dimension.name;
+    supportedDimensionCount += 1;
+    if (needsPlainMetricMapping(queryDimensionName)) {
+      dimensionMetrics[queryDimensionName] = [queryDimensionName];
+      dimensionAggregations[queryDimensionName] = dimension.threshold.type === "max" ? "min" : "max";
+    }
+  }
+
+  if (supportedDimensionCount === 0) return null;
+  return createGoalWorkspaceArtifactMetricDataSource(goalId, workspacePath, dimensionMetrics, dimensionAggregations);
+}
+
+function isArtifactMetricDimension(dimension: Dimension): boolean {
+  if (typeof dimension.current_value !== "number") return false;
+  return dimension.threshold.type === "min" || dimension.threshold.type === "max" || dimension.threshold.type === "range";
+}
+
+function needsPlainMetricMapping(dimensionName: string): boolean {
+  if (dimensionName === "validated_experiment_count" || dimensionName === "durable_artifact_count") return false;
+  if (dimensionName.startsWith("best_")) return false;
+  if (dimensionName.endsWith("_count")) return false;
+  return true;
 }

--- a/src/platform/observation/types/data-source.ts
+++ b/src/platform/observation/types/data-source.ts
@@ -39,6 +39,7 @@ export const DataSourceConfigSchema = z.object({
     stale_after_ms: z.number().int().positive().optional(),
     dimension_metrics: z.record(z.string(), z.array(z.string())).optional(),
     dimension_aggregations: z.record(z.string(), z.enum(["max", "min", "count", "file_count"])).optional(),
+    require_metric_match: z.boolean().optional(),
   }),
   polling: PollingConfigSchema.optional(),
   auth: z

--- a/tmp/kaggle-durable-loop-issues-status.md
+++ b/tmp/kaggle-durable-loop-issues-status.md
@@ -63,3 +63,36 @@ Verification:
 Review:
 - Initial fresh review found two preflight issues; both fixed.
 - Second fresh review: no material findings.
+
+PR:
+- #1097 merged after CI passed.
+
+## #1091
+
+Status: implementation verified locally; preparing PR.
+
+Plan:
+- Synthesize a goal-scoped artifact metric datasource during `ObservationEngine.observe()` when the goal has a `workspace_path:` constraint.
+- Scope the synthetic datasource to numeric goal dimensions and map each observed dimension name to the same artifact metric key, so plain metric names like `roc_auc` can match `metric_name: "roc_auc"` with `cv_score`/`score`.
+- Include `experiments` in builtin artifact metric search roots.
+- Make goal-scoped artifact metric observation fall through to LLM only when no matching artifact metric is found or parsed.
+- Add adapter coverage for `experiments/**/metrics.json` and production-path observation coverage with daemon state dir different from the goal workspace.
+
+Implemented:
+- `ObservationEngine.observe()` now synthesizes a goal-scoped artifact metric datasource from goal `workspace_path:` when no registered datasource already serves the numeric dimension.
+- Builtin artifact metric scanning now includes `experiments`.
+- Goal-scoped artifact metric datasources require a matching metric, so missing/unparseable artifacts fall through to LLM instead of persisting a mechanical zero.
+- Plain metric dimensions such as `roc_auc` map to `metric_name: "roc_auc"` with `cv_score` / `score` extraction.
+
+Verification:
+- `npm test -- --run src/adapters/__tests__/artifact-metric-datasource.test.ts src/platform/observation/__tests__/observation-engine.test.ts`
+- `npm run typecheck`
+- `npm run lint:boundaries` (exit 0; existing warnings only)
+- `npm run test:changed`
+
+Review:
+- Fresh review found a production-path test gap: the goal-workspace observation test did not include the daemon/setup builtin datasource.
+- Fixed the test to construct `ObservationEngine` with `createWorkspaceArtifactMetricDataSource(daemonWorkspace)` and assert the goal workspace metric wins.
+- Second fresh review found a remaining workspace-scoping gap for builtin-supported artifact dimensions when the daemon datasource already claims the dimension.
+- Fixed goal datasource synthesis to always prefer the goal workspace for numeric workspace goals, while only adding explicit metric mappings for plain metric names like `roc_auc`; added a `best_oof_balanced_accuracy` regression with a wrong daemon metric.
+- Final fresh review: no high-confidence material defects.


### PR DESCRIPTION
Closes #1091

## Summary
- synthesize a goal-scoped artifact metric datasource during observation when a goal has `workspace_path:`
- include `experiments` in artifact metric search roots and support plain metric dimensions such as `roc_auc` through `metric_name` + `cv_score`/`score` artifacts
- require goal-scoped metric matches so missing artifacts fall through to LLM instead of recording mechanical zero
- add production caller-path coverage with daemon datasource rooted elsewhere and goal workspace metrics winning

## Verification
- `npm test -- --run src/adapters/__tests__/artifact-metric-datasource.test.ts src/platform/observation/__tests__/observation-engine.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (exit 0; existing warnings only)
- `npm run test:changed`
- fresh review agent final pass: no high-confidence material defects

## Known unresolved risks
- Explicit `observation_mapping.data_source` can still intentionally force a specific datasource id; this is outside the #1091 acceptance slice.