### PR TITLE
fix(daemon): bound stop and propagate aborts

### DIFF
--- a/src/base/llm/__tests__/codex-llm-client.test.ts
+++ b/src/base/llm/__tests__/codex-llm-client.test.ts
@@ -431,6 +431,39 @@ describe("CodexLLMClient", () => {
   // ─── Timeout ───
 
   describe("sendMessage: timeout", () => {
+    it("kills the spawned codex process when aborted by operator stop", async () => {
+      vi.useFakeTimers();
+
+      const controller = new AbortController();
+      const client = new CodexLLMClient({ timeoutMs: 1000, idleTimeoutMs: 1000 });
+      const child = makeFakeChild();
+      mockSpawn.mockImplementation(() => child);
+      child.kill.mockImplementation(() => {
+        setTimeout(() => child.emit("close", null), 5);
+        return true;
+      });
+
+      const promise = client
+        .sendMessage([{ role: "user", content: "hi" }], { abortSignal: controller.signal })
+        .catch((e) => e);
+      await vi.advanceTimersByTimeAsync(0);
+      controller.abort();
+      await vi.advanceTimersByTimeAsync(5);
+      await vi.runAllTimersAsync();
+      const err = await promise;
+
+      vi.useRealTimers();
+
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+      expect(mockSpawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({ detached: process.platform !== "win32" })
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toContain("aborted by operator stop");
+    });
+
     it("rejects with total timeout error when timeoutMs elapses", async () => {
       vi.useFakeTimers();
 

--- a/src/base/llm/__tests__/ollama-client.test.ts
+++ b/src/base/llm/__tests__/ollama-client.test.ts
@@ -199,6 +199,26 @@ describe("OllamaLLMClient", () => {
       const body = JSON.parse(fetchSpy.mock.calls[0][1].body as string);
       expect(body.stream).toBe(false);
     });
+
+    it("passes operator stop aborts into the active fetch request", async () => {
+      const client = new OllamaLLMClient({ baseUrl: "http://localhost:11434" });
+      const controller = new AbortController();
+      let capturedSignal: AbortSignal | undefined;
+      fetchSpy.mockImplementationOnce((_url: string, init: RequestInit) => {
+        capturedSignal = init.signal as AbortSignal;
+        return new Promise<Response>((_resolve, reject) => {
+          capturedSignal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+        });
+      });
+
+      const promise = client.sendMessage([{ role: "user", content: "hi" }], { abortSignal: controller.signal });
+
+      await vi.waitFor(() => expect(capturedSignal).toBeDefined());
+      controller.abort(new Error("operator stop requested"));
+
+      expect(capturedSignal?.aborted).toBe(true);
+      await expect(promise).rejects.toThrow("OllamaLLMClient: request aborted by operator stop");
+    });
   });
 
   // ─── Retry logic ───

--- a/src/base/llm/__tests__/openai-client.test.ts
+++ b/src/base/llm/__tests__/openai-client.test.ts
@@ -408,6 +408,31 @@ describe("OpenAILLMClient", () => {
         reasoning: { effort: "high" },
       }));
     });
+
+    it("clears the Responses API fallback timeout when an abort rejects the request", async () => {
+      const client = new OpenAILLMClient({ apiKey: "sk-test", model: "codex-mini-latest" });
+      const controller = new AbortController();
+      mockStream.mockImplementationOnce(() => {
+        throw new Error("This is not a chat model and not supported in the v1/chat/completions endpoint");
+      });
+      mockResponsesCreate.mockImplementationOnce(async () => {
+        controller.abort(new Error("operator stop requested"));
+        throw new DOMException("operator stop requested", "AbortError");
+      });
+
+      vi.useFakeTimers();
+      const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout");
+      await expect(
+        client.sendMessageStream(
+          [{ role: "user", content: "hello" }],
+          { abortSignal: controller.signal },
+          { onTextDelta: vi.fn() }
+        )
+      ).rejects.toThrow("operator stop requested");
+      vi.useRealTimers();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
   });
 
   // ─── parseJSON ───

--- a/src/base/llm/codex-llm-client.ts
+++ b/src/base/llm/codex-llm-client.ts
@@ -127,7 +127,7 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
 
     for (let attempt = 0; attempt < this.retryAttempts; attempt++) {
       try {
-        const content = await this._spawnCodex(prompt, model);
+        const content = await this._spawnCodex(prompt, model, options?.abortSignal);
         return {
           content,
           usage: {
@@ -142,7 +142,7 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
           break;
         }
         if (attempt < this.retryAttempts - 1) {
-          await sleep(RETRY_DELAYS_MS[attempt] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1]!);
+          await sleepWithAbort(RETRY_DELAYS_MS[attempt] ?? RETRY_DELAYS_MS[RETRY_DELAYS_MS.length - 1]!, options?.abortSignal);
         }
       }
     }
@@ -157,7 +157,10 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
    * Spawn `codex exec -s <sandbox> [-o <tmpfile>] [--model <model>] "PROMPT"`
    * and return the response content read from the temp output file.
    */
-  private async _spawnCodex(prompt: string, model?: string): Promise<string> {
+  private async _spawnCodex(prompt: string, model?: string, abortSignal?: AbortSignal): Promise<string> {
+    if (abortSignal?.aborted) {
+      throw new LLMError("CodexLLMClient: request aborted by operator stop");
+    }
     // Create a temporary directory asynchronously to avoid blocking the event loop
     const tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-codex-"));
     const tmpFile = path.join(tmpDir, "response.txt");
@@ -193,11 +196,12 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, TERM: "dumb" },
         cwd: this.repoPath,
+        detached: process.platform !== "win32",
       });
 
       let timedOut = false;
+      let aborted = false;
       let timeoutReason: "total" | "idle" | undefined;
-      let totalTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
       let idleTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
       let sigkillHandle: ReturnType<typeof setTimeout> | undefined;
       let stderrData = "";
@@ -206,8 +210,20 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
         if (idleTimeoutHandle) clearTimeout(idleTimeoutHandle);
         if (sigkillHandle) clearTimeout(sigkillHandle);
       };
+      const killChild = (signal: NodeJS.Signals): void => {
+        if (process.platform !== "win32" && typeof child.pid === "number") {
+          try {
+            process.kill(-child.pid, signal);
+            return;
+          } catch {
+            // Fall back to the immediate child below.
+          }
+        }
+        child.kill(signal);
+      };
       const cleanupTmp = (): void => {
         clearTimers();
+        abortSignal?.removeEventListener("abort", triggerAbort);
         void _cleanupTmp(tmpDir, tmpFile).catch((cleanupErr) => {
           console.debug("CodexLLMClient: _cleanupTmp failed (non-critical)", String(cleanupErr));
         });
@@ -216,15 +232,32 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
         if (timedOut) return;
         timedOut = true;
         timeoutReason = reason;
-        child.kill("SIGTERM");
+        killChild("SIGTERM");
         sigkillHandle = setTimeout(() => {
           try {
-            child.kill("SIGKILL");
+            killChild("SIGKILL");
           } catch {
             // process already exited
           }
         }, SIGKILL_DELAY_MS);
       };
+      const triggerAbort = (): void => {
+        if (aborted || timedOut) return;
+        aborted = true;
+        killChild("SIGTERM");
+        sigkillHandle = setTimeout(() => {
+          try {
+            killChild("SIGKILL");
+          } catch {
+            // process already exited
+          }
+        }, SIGKILL_DELAY_MS);
+      };
+      if (abortSignal?.aborted) {
+        triggerAbort();
+      } else {
+        abortSignal?.addEventListener("abort", triggerAbort, { once: true });
+      }
       const armIdleTimeout = (): void => {
         if (this.idleTimeoutMs <= 0) return;
         if (idleTimeoutHandle) clearTimeout(idleTimeoutHandle);
@@ -234,7 +267,7 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
         armIdleTimeout();
       };
 
-      totalTimeoutHandle = setTimeout(() => triggerTimeout("total"), this.totalTimeoutMs);
+      const totalTimeoutHandle = setTimeout(() => triggerTimeout("total"), this.totalTimeoutMs);
 
       child.stdout?.on("data", markActivity);
       child.stderr.on("data", (chunk: Buffer) => {
@@ -267,6 +300,11 @@ export class CodexLLMClient extends BaseLLMClient implements ILLMClient {
               `CodexLLMClient: ${timeoutLabel} after ${timeoutReason === "idle" ? this.idleTimeoutMs : this.totalTimeoutMs}ms`
             )
           );
+          return;
+        }
+        if (aborted) {
+          cleanupTmp();
+          reject(new LLMError("CodexLLMClient: request aborted by operator stop"));
           return;
         }
 
@@ -319,4 +357,20 @@ async function _cleanupTmp(tmpDir: string, tmpFile: string): Promise<void> {
   } catch {
     // best-effort cleanup
   }
+}
+
+function sleepWithAbort(ms: number, abortSignal?: AbortSignal): Promise<void> {
+  if (!abortSignal) return sleep(ms);
+  if (abortSignal.aborted) return Promise.reject(new LLMError("CodexLLMClient: request aborted by operator stop"));
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(new LLMError("CodexLLMClient: request aborted by operator stop"));
+    };
+    const timer = setTimeout(() => {
+      abortSignal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/src/base/llm/llm-client.ts
+++ b/src/base/llm/llm-client.ts
@@ -43,6 +43,8 @@ export interface LLMRequestOptions {
   model_tier?: ModelTier;
   /** Tool definitions for function calling (tool use). */
   tools?: ToolDefinition[];
+  /** Optional cancellation signal for runtime/operator stop. */
+  abortSignal?: AbortSignal;
 }
 
 export interface LLMStreamHandlers {
@@ -188,7 +190,7 @@ export class LLMClient extends BaseLLMClient implements ILLMClient {
               content: m.content,
             })),
           },
-          { timeout: DEFAULT_LLM_TIMEOUT_MS }
+          { timeout: DEFAULT_LLM_TIMEOUT_MS, ...(options?.abortSignal ? { signal: options.abortSignal } : {}) }
         );
 
         // Extract text content from response
@@ -307,7 +309,7 @@ export class LLMClient extends BaseLLMClient implements ILLMClient {
           content: m.content,
         })),
       },
-      { timeout: DEFAULT_LLM_TIMEOUT_MS }
+      { timeout: DEFAULT_LLM_TIMEOUT_MS, ...(options?.abortSignal ? { signal: options.abortSignal } : {}) }
     );
 
     stream.on("text", (delta: string) => {

--- a/src/base/llm/ollama-client.ts
+++ b/src/base/llm/ollama-client.ts
@@ -73,7 +73,12 @@ export class OllamaLLMClient extends BaseLLMClient implements ILLMClient {
 
     while (normalAttempts < MAX_RETRY_ATTEMPTS) {
       try {
+        if (options?.abortSignal?.aborted) {
+          throw new LLMError("OllamaLLMClient: request aborted by operator stop");
+        }
         const controller = new AbortController();
+        const abortFromParent = () => controller.abort();
+        options?.abortSignal?.addEventListener("abort", abortFromParent, { once: true });
         const timeoutId = setTimeout(() => controller.abort(), DEFAULT_LLM_TIMEOUT_MS);
         let response: Response;
         try {
@@ -87,6 +92,11 @@ export class OllamaLLMClient extends BaseLLMClient implements ILLMClient {
           });
         } finally {
           clearTimeout(timeoutId);
+          options?.abortSignal?.removeEventListener("abort", abortFromParent);
+        }
+
+        if (options?.abortSignal?.aborted) {
+          throw new LLMError("OllamaLLMClient: request aborted by operator stop");
         }
 
         if (!response.ok) {
@@ -121,6 +131,9 @@ export class OllamaLLMClient extends BaseLLMClient implements ILLMClient {
         };
       } catch (err) {
         lastError = err;
+        if (options?.abortSignal?.aborted) {
+          throw new LLMError("OllamaLLMClient: request aborted by operator stop");
+        }
         // Rate limit: retry with extended backoff (does not count against normalAttempts)
         if (isRateLimitError(err) && rateLimitAttempts < RATE_LIMIT_RETRY_DELAYS_MS.length) {
           await sleep(getRateLimitRetryDelay(err, rateLimitAttempts));

--- a/src/base/llm/openai-client.ts
+++ b/src/base/llm/openai-client.ts
@@ -131,7 +131,10 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
     while (normalAttempts < MAX_RETRY_ATTEMPTS) {
       try {
         try {
-          const response = await this.client.chat.completions.create(createParams, { timeout: DEFAULT_LLM_TIMEOUT_MS });
+          const response = await this.client.chat.completions.create(
+            createParams,
+            { timeout: DEFAULT_LLM_TIMEOUT_MS, ...(options?.abortSignal ? { signal: options.abortSignal } : {}) }
+          );
 
           const choice = response.choices[0];
           const content = choice?.message.content ?? "";
@@ -151,7 +154,7 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
           // Some models (notably Codex-style) are not compatible with the
           // chat completions endpoint. In that case, fall back to Responses API.
           if (!shouldFallbackToResponses(err)) throw err;
-          return this.sendViaResponsesApi(model, messages, { max_tokens, temperature, system, reasoningEffort: this.reasoningEffort });
+          return this.sendViaResponsesApi(model, messages, { max_tokens, temperature, system, reasoningEffort: this.reasoningEffort, abortSignal: options?.abortSignal });
         }
       } catch (err) {
         lastError = err;
@@ -219,7 +222,10 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
     };
 
     try {
-      const stream = this.client.chat.completions.stream(createParams, { timeout: DEFAULT_LLM_TIMEOUT_MS });
+      const stream = this.client.chat.completions.stream(
+        createParams,
+        { timeout: DEFAULT_LLM_TIMEOUT_MS, ...(options?.abortSignal ? { signal: options.abortSignal } : {}) }
+      );
       stream.on("content", (delta: string) => {
         handlers.onTextDelta?.(delta);
       });
@@ -242,14 +248,14 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
       };
     } catch (err) {
       if (!shouldFallbackToResponses(err)) throw err;
-      return this.sendViaResponsesApi(model, messages, { max_tokens, temperature, system, reasoningEffort: this.reasoningEffort });
+      return this.sendViaResponsesApi(model, messages, { max_tokens, temperature, system, reasoningEffort: this.reasoningEffort, abortSignal: options?.abortSignal });
     }
   }
 
   private async sendViaResponsesApi(
     model: string,
     messages: LLMMessage[],
-    options: { max_tokens: number; temperature: number; system?: string; reasoningEffort?: OpenAIReasoningEffort }
+    options: { max_tokens: number; temperature: number; system?: string; reasoningEffort?: OpenAIReasoningEffort; abortSignal?: AbortSignal }
   ): Promise<LLMResponse> {
     const input = [
       options.system ? `SYSTEM:\n${options.system}` : null,
@@ -261,7 +267,7 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
     // Use Responses API (SDK supports this as of openai v4+).
     // The TypeScript types for the Responses API are not yet in the openai
     // package typings, so we cast through unknown to access this endpoint.
-    const responsesApi = (this.client as unknown as { responses: { create: (params: Record<string, unknown>) => Promise<unknown> } }).responses;
+    const responsesApi = (this.client as unknown as { responses: { create: (params: Record<string, unknown>, requestOptions?: Record<string, unknown>) => Promise<unknown> } }).responses;
     let timer: ReturnType<typeof setTimeout>;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(
@@ -269,17 +275,22 @@ export class OpenAILLMClient extends BaseLLMClient implements ILLMClient {
         DEFAULT_LLM_TIMEOUT_MS
       );
     });
-    const resp = await Promise.race([
-      responsesApi.create({
-        model,
-        input,
-        max_output_tokens: options.max_tokens,
-        ...(isReasoningModel(model) ? {} : { temperature: options.temperature }),
-        ...(shouldSendReasoningEffort(model, options.reasoningEffort) ? { reasoning: { effort: options.reasoningEffort } } : {}),
-      }),
-      timeout,
-    ]) as Record<string, unknown>;
-    clearTimeout(timer!);
+    const responseParams = {
+      model,
+      input,
+      max_output_tokens: options.max_tokens,
+      ...(isReasoningModel(model) ? {} : { temperature: options.temperature }),
+      ...(shouldSendReasoningEffort(model, options.reasoningEffort) ? { reasoning: { effort: options.reasoningEffort } } : {}),
+    };
+    const responsePromise = options.abortSignal
+      ? responsesApi.create(responseParams, { signal: options.abortSignal })
+      : responsesApi.create(responseParams);
+    let resp: Record<string, unknown>;
+    try {
+      resp = await Promise.race([responsePromise, timeout]) as Record<string, unknown>;
+    } finally {
+      clearTimeout(timer!);
+    }
 
     const content =
       typeof resp["output_text"] === "string"

--- a/src/base/types/core.ts
+++ b/src/base/types/core.ts
@@ -147,6 +147,7 @@ export const TaskStatusEnum = z.enum([
   "running",
   "completed",
   "timed_out",
+  "cancelled",
   "error",
 ]);
 export type TaskStatus = z.infer<typeof TaskStatusEnum>;

--- a/src/base/utils/execFileNoThrow.ts
+++ b/src/base/utils/execFileNoThrow.ts
@@ -4,7 +4,7 @@
 // Returns { stdout, stderr, exitCode } on success/failure,
 // and { stdout: "", stderr: <message>, exitCode: null } on spawn errors.
 
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 
 export interface ExecFileResult {
   stdout: string;
@@ -19,6 +19,10 @@ export interface ExecFileOptions {
   cwd?: string;
   /** Environment variables. Default: process.env */
   env?: NodeJS.ProcessEnv;
+  /** Optional cancellation signal. */
+  signal?: AbortSignal;
+  /** Start a process group and terminate it on abort where the platform supports it. */
+  killProcessGroup?: boolean;
 }
 
 /**
@@ -31,7 +35,10 @@ export async function execFileNoThrow(
   args: string[],
   options: ExecFileOptions = {}
 ): Promise<ExecFileResult> {
-  const { timeoutMs = 10000, cwd, env } = options;
+  const { timeoutMs = 10000, cwd, env, signal, killProcessGroup = false } = options;
+  if (killProcessGroup) {
+    return spawnNoThrow(cmd, args, { timeoutMs, cwd, env, signal });
+  }
 
   return new Promise<ExecFileResult>((resolve) => {
     execFile(
@@ -41,6 +48,7 @@ export async function execFileNoThrow(
         timeout: timeoutMs,
         cwd,
         env,
+        signal,
         maxBuffer: 1024 * 1024, // 1 MB
       },
       (error, stdout, stderr) => {
@@ -56,5 +64,87 @@ export async function execFileNoThrow(
         resolve({ stdout, stderr, exitCode: 0 });
       }
     );
+  });
+}
+
+function spawnNoThrow(
+  cmd: string,
+  args: string[],
+  options: Required<Pick<ExecFileOptions, "timeoutMs">> & Pick<ExecFileOptions, "cwd" | "env" | "signal">
+): Promise<ExecFileResult> {
+  const detached = process.platform !== "win32";
+
+  return new Promise<ExecFileResult>((resolve) => {
+    let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    const child = spawn(
+      cmd,
+      args,
+      {
+        cwd: options.cwd,
+        env: options.env,
+        detached,
+        stdio: ["ignore", "pipe", "pipe"],
+      }
+    );
+    const groupTimeoutTimer = setTimeout(abortChild, options.timeoutMs);
+    groupTimeoutTimer.unref?.();
+    const cleanup = (): void => {
+      options.signal?.removeEventListener("abort", abortChild);
+      clearTimeout(groupTimeoutTimer);
+      if (forceKillTimer) clearTimeout(forceKillTimer);
+    };
+    const finish = (result: ExecFileResult): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
+      if (stdout.length > 1024 * 1024) stdout = stdout.slice(0, 1024 * 1024);
+    });
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
+      if (stderr.length > 1024 * 1024) stderr = stderr.slice(0, 1024 * 1024);
+    });
+    child.on("error", (error) => {
+      finish({ stdout, stderr: stderr || error.message, exitCode: null });
+    });
+    child.on("close", (code, signalName) => {
+      finish({
+        stdout,
+        stderr: stderr || (signalName ? `Process terminated by ${signalName}` : ""),
+        exitCode: code,
+      });
+    });
+
+    const killChild = (killSignal: NodeJS.Signals): void => {
+      if (detached && child.pid) {
+        try {
+          process.kill(-child.pid, killSignal);
+          return;
+        } catch {
+          // Fall back to the immediate child below.
+        }
+      }
+      child.kill(killSignal);
+    };
+
+    function abortChild(): void {
+      killChild("SIGTERM");
+      forceKillTimer = setTimeout(() => killChild("SIGKILL"), 1_000);
+      forceKillTimer.unref?.();
+    }
+
+    if (options.signal?.aborted) {
+      abortChild();
+    } else {
+      options.signal?.addEventListener("abort", abortChild, { once: true });
+    }
   });
 }

--- a/src/orchestrator/execution/adapter-layer.ts
+++ b/src/orchestrator/execution/adapter-layer.ts
@@ -68,7 +68,7 @@ export interface AgentResult {
   /** Wall-clock time from execute() call to resolution, in milliseconds */
   elapsed_ms: number;
   /** How execution ended */
-  stopped_reason: "completed" | "timeout" | "error";
+  stopped_reason: "completed" | "timeout" | "error" | "cancelled";
   /**
    * Whether the adapter actually modified any files, as detected by git diff --stat.
    * undefined = check was not performed (e.g., not a git repo, or adapter skipped).

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-command-classifier.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-command-classifier.test.ts
@@ -79,4 +79,27 @@ describe("taskAgentLoopResultToAgentResult command evidence filtering", () => {
 
     expect(agentResult.agentLoop?.completionEvidence).toEqual(["verified command: test -f src/app.ts"]);
   });
+
+  it("preserves cancelled native agent-loop results as cancelled task execution", () => {
+    const agentResult = taskAgentLoopResultToAgentResult({
+      success: false,
+      output: null,
+      finalText: "Agent loop stopped: operator stop aborted active model work.",
+      stopReason: "cancelled",
+      elapsedMs: 10,
+      modelTurns: 0,
+      toolCalls: 0,
+      compactions: 0,
+      filesChanged: false,
+      changedFiles: [],
+      commandResults: [],
+      traceId: "trace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    });
+
+    expect(agentResult.success).toBe(false);
+    expect(agentResult.stopped_reason).toBe("cancelled");
+    expect(agentResult.error).toContain("operator stop");
+  });
 });

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -801,6 +801,92 @@ describe("agentloop phase 1", () => {
     expect(stopped).toHaveProperty("reasonDetail");
     expect((stopped as { reasonDetail?: string }).reasonDetail).toContain("LLM timeout while waiting");
   });
+
+  it("records operator-aborted model work as cancelled instead of timeout", async () => {
+    const modelInfo = makeModelInfo();
+    const abortController = new AbortController();
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(): Promise<AgentLoopModelResponse> {
+        abortController.abort(new Error("operator stop requested"));
+        throw new DOMException("operator stop requested", "AbortError");
+      },
+    };
+    const { router, runtime } = makeToolRuntime();
+    const runner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+    const session = createAgentLoopSession();
+
+    const result = await runner.run({
+      session,
+      turnId: "turn-abort",
+      goalId: "goal-1",
+      cwd: process.cwd(),
+      model: modelInfo.ref,
+      modelInfo,
+      messages: [{ role: "user", content: "do it" }],
+      outputSchema: z.object({ status: z.literal("done"), finalAnswer: z.string() }),
+      budget: withDefaultBudget({ maxModelTurns: 4 }),
+      toolPolicy: {},
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+      abortSignal: abortController.signal,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.stopReason).toBe("cancelled");
+    expect(result.finalText).toContain("operator stop");
+    const stopped = (await session.traceStore.list(session.traceId)).at(-1);
+    expect(stopped).toMatchObject({
+      type: "stopped",
+      reason: "cancelled",
+    });
+  });
+
+  it("does not classify provider AbortError as operator cancellation when the turn was not aborted", async () => {
+    const modelInfo = makeModelInfo();
+    const abortController = new AbortController();
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(): Promise<AgentLoopModelResponse> {
+        throw new DOMException("provider aborted the request", "AbortError");
+      },
+    };
+    const { router, runtime } = makeToolRuntime();
+    const runner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+
+    const result = await runner.run({
+      session: createAgentLoopSession(),
+      turnId: "turn-provider-abort",
+      goalId: "goal-1",
+      cwd: process.cwd(),
+      model: modelInfo.ref,
+      modelInfo,
+      messages: [{ role: "user", content: "do it" }],
+      outputSchema: z.object({ status: z.literal("done"), finalAnswer: z.string() }),
+      budget: withDefaultBudget({ maxModelTurns: 4 }),
+      toolPolicy: {},
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+      abortSignal: abortController.signal,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.stopReason).toBe("timeout");
+  });
 });
 
 describe("agentloop phase 2", () => {

--- a/src/orchestrator/execution/agent-loop/agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model-client.ts
@@ -50,6 +50,7 @@ export class ILLMClientAgentLoopModelClient implements AgentLoopModelClient {
         ? { system: input.system }
         : { system: buildPromptedToolProtocolSystemPrompt({ systemPrompt: input.system, tools: input.tools }) }),
       max_tokens: input.maxOutputTokens,
+      abortSignal: input.abortSignal,
       ...(supportsNativeToolCalling ? { tools: input.tools } : {}),
     });
 

--- a/src/orchestrator/execution/agent-loop/agent-loop-model.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model.ts
@@ -55,6 +55,7 @@ export interface AgentLoopModelRequest {
   system?: string;
   maxOutputTokens?: number;
   reasoningEffort?: AgentLoopReasoningEffort;
+  abortSignal?: AbortSignal;
 }
 
 export interface AgentLoopAssistantOutput {

--- a/src/orchestrator/execution/agent-loop/anthropic-messages-agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/anthropic-messages-agent-loop-model-client.ts
@@ -56,13 +56,16 @@ export class AnthropicMessagesAgentLoopModelClient implements AgentLoopModelClie
   }
 
   async createTurnProtocol(input: AgentLoopModelRequest): Promise<AgentLoopModelTurnProtocol> {
-    const response = await this.client.messages.create({
+    const responseParams = {
       model: input.model.modelId,
       max_tokens: input.maxOutputTokens ?? this.defaultMaxTokens,
       ...(this.buildSystemPrompt(input) ? { system: this.buildSystemPrompt(input)! } : {}),
       messages: this.toAnthropicMessages(input.messages),
       ...(input.tools.length > 0 ? { tools: input.tools.map((tool) => this.toAnthropicTool(tool)) } : {}),
-    });
+    };
+    const response = await (input.abortSignal
+      ? this.client.messages.create(responseParams, { signal: input.abortSignal })
+      : this.client.messages.create(responseParams));
 
     const assistant = this.extractAssistantOutputs(response);
     const toolCalls = this.extractToolCalls(response);

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -104,6 +104,9 @@ export class BoundedAgentLoopRunner {
       try {
         protocol = await this.createTurnProtocol(turn, messages, tools);
       } catch (err) {
+        if (turn.abortSignal?.aborted) {
+          return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, "Agent loop stopped: operator stop aborted active model work.", null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts, err instanceof Error ? err.message : String(err));
+        }
         const failure = this.classifyRunFailure(err);
         return this.stop(
           turn,
@@ -667,6 +670,7 @@ export class BoundedAgentLoopRunner {
         model: turn.model,
         messages,
         tools,
+        abortSignal: turn.abortSignal,
       });
     }
 
@@ -674,6 +678,7 @@ export class BoundedAgentLoopRunner {
       model: turn.model,
       messages,
       tools,
+      abortSignal: turn.abortSignal,
     });
     return {
       assistant: response.content || response.toolCalls.length > 0 ? [{

--- a/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
@@ -56,13 +56,16 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
   }
 
   async createTurnProtocol(input: AgentLoopModelRequest): Promise<AgentLoopModelTurnProtocol> {
-    const response = await this.client.responses.create({
+    const responseParams = {
       model: input.model.modelId,
       input: this.toInputItems(input.messages),
       tools: input.tools.map((tool) => this.toFunctionTool(tool)),
       max_output_tokens: input.maxOutputTokens,
       ...(input.reasoningEffort ? { reasoning: { effort: input.reasoningEffort } } : {}),
-    }) as Response;
+    };
+    const response = await (input.abortSignal
+      ? this.client.responses.create(responseParams, { signal: input.abortSignal })
+      : this.client.responses.create(responseParams)) as Response;
 
     const assistant: AgentLoopAssistantOutput[] = [];
     const toolCalls: AgentLoopToolCall[] = [];

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
@@ -38,6 +38,7 @@ export function taskAgentLoopResultToAgentResult(
     elapsed_ms: result.elapsedMs,
     stopped_reason:
       result.stopReason === "timeout" ? "timeout" :
+      result.stopReason === "cancelled" ? "cancelled" :
       done ? "completed" : "error",
     filesChanged: result.changedFiles.length > 0 || (result.output ? result.output.filesChanged.length > 0 : result.filesChanged),
     filesChangedPaths: [...new Set([...(result.output?.filesChanged ?? []), ...result.changedFiles])],

--- a/src/orchestrator/execution/task/task-lifecycle-runner.ts
+++ b/src/orchestrator/execution/task/task-lifecycle-runner.ts
@@ -36,6 +36,7 @@ export interface TaskCycleRunOptionsShape {
   knowledgeContextPrefix?: string;
   executionMode?: ExecutionModeState;
   runControlRecommendationContext?: string;
+  abortSignal?: AbortSignal;
 }
 
 export interface TaskLifecycleTaskCycleContext {
@@ -95,7 +96,8 @@ export interface TaskLifecycleTaskCycleContext {
   executeTaskWithAgentLoop: (
     task: Task,
     workspaceContext?: string,
-    knowledgeContext?: string
+    knowledgeContext?: string,
+    abortSignal?: AbortSignal,
   ) => Promise<AgentResult>;
   handleVerdict: (task: Task, verificationResult: VerificationResult) => Promise<VerdictResult>;
 }
@@ -271,7 +273,7 @@ export async function runTaskLifecycleCycle(context: TaskLifecycleTaskCycleConte
   void hookManager?.emit("PreExecute", { goal_id: goalId, data: { task_id: task.id } });
   const executionResult = await runPhase("execute-task", () =>
     context.hasNativeAgentLoop
-      ? context.executeTaskWithAgentLoop(task, workspaceContext, enrichedKnowledgeContext)
+      ? context.executeTaskWithAgentLoop(task, workspaceContext, enrichedKnowledgeContext, options?.abortSignal)
       : context.executeTask(task, adapter, workspaceContext)
   );
   const nativeExecutionTokens = executionResult.agentLoop?.usage?.totalTokens;

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -139,6 +139,7 @@ export interface TaskCycleRunOptions {
   knowledgeContextPrefix?: string;
   executionMode?: ExecutionModeState;
   runControlRecommendationContext?: string;
+  abortSignal?: AbortSignal;
 }
 
 export interface TaskLifecycleDeps extends TaskLifecycleCoreDeps {
@@ -520,6 +521,7 @@ export class TaskLifecycle {
     task: Task,
     workspaceContext?: string,
     knowledgeContext?: string,
+    abortSignal?: AbortSignal,
   ): Promise<AgentResult> {
     if (!this.agentLoopRunner) {
       throw new Error("TaskLifecycle: agentLoopRunner is required for native agentloop execution.");
@@ -544,6 +546,7 @@ export class TaskLifecycle {
         workspaceContext,
         knowledgeContext,
         cwd: taskCwd,
+        ...(abortSignal ? { abortSignal } : {}),
       });
       result = taskAgentLoopResultToAgentResult(agentLoopResult);
       if (agentLoopResult.workspace?.executionCwd) {
@@ -572,6 +575,7 @@ export class TaskLifecycle {
     const nextStatus =
       result.success ? "completed" as const :
       result.stopped_reason === "timeout" ? "timed_out" as const :
+      result.stopped_reason === "cancelled" ? "cancelled" as const :
       "error" as const;
     await this.stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, {
       ...runningTask,
@@ -579,6 +583,7 @@ export class TaskLifecycle {
       execution_output: result.output,
       ...(nextStatus === "completed" ? { completed_at: completedAt } : {}),
       ...(nextStatus === "timed_out" ? { timeout_at: completedAt } : {}),
+      ...(nextStatus === "cancelled" ? { stopped_at: completedAt } : {}),
     });
 
     await appendTaskOutcomeEvent(this.stateManager, {
@@ -659,8 +664,8 @@ export class TaskLifecycle {
       },
       hasNativeAgentLoop: Boolean(this.agentLoopRunner),
       executeTask: (task, runAdapter, runWorkspaceContext) => this.executeTask(task, runAdapter, runWorkspaceContext),
-      executeTaskWithAgentLoop: (task, runWorkspaceContext, runKnowledgeContext) =>
-        this.executeTaskWithAgentLoop(task, runWorkspaceContext, runKnowledgeContext),
+      executeTaskWithAgentLoop: (task, runWorkspaceContext, runKnowledgeContext, abortSignal) =>
+        this.executeTaskWithAgentLoop(task, runWorkspaceContext, runKnowledgeContext, abortSignal),
       handleVerdict: (task, verificationResult) => this.handleVerdict(task, verificationResult),
     });
   }

--- a/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
+++ b/src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts
@@ -75,6 +75,21 @@ describe("CoreLoop run policies", () => {
     expect(result.totalIterations).toBe(3);
   });
 
+  it("does not convert provider AbortError into stopped without an operator abort signal", async () => {
+    const loop = new CoreLoop(makeDeps(), {
+      maxIterations: 1,
+      delayBetweenLoopsMs: 0,
+      dryRun: true,
+      autoDecompose: false,
+      maxConsecutiveErrors: 1,
+    });
+    vi.spyOn(loop, "runOneIteration").mockRejectedValue(new DOMException("provider aborted", "AbortError"));
+
+    const result = await loop.run("goal-provider-abort");
+
+    expect(result.finalStatus).toBe("error");
+  });
+
   it("treats a maxIterations null run override as resident even on a bounded loop", async () => {
     const loop = new CoreLoop(makeDeps(), {
       maxIterations: 100,

--- a/src/orchestrator/loop/durable-loop.ts
+++ b/src/orchestrator/loop/durable-loop.ts
@@ -140,7 +140,13 @@ export class CoreLoop {
    */
   async run(
     goalId: string,
-    options?: { maxIterations?: number | null; runPolicy?: LoopConfig["runPolicy"]; onProgress?: CoreLoopDeps["onProgress"]; activation?: GoalRunActivationContext }
+    options?: {
+      maxIterations?: number | null;
+      runPolicy?: LoopConfig["runPolicy"];
+      onProgress?: CoreLoopDeps["onProgress"];
+      activation?: GoalRunActivationContext;
+      abortSignal?: AbortSignal;
+    }
   ): Promise<LoopResult> {
     const depsWithMutableProgress = this.deps as CoreLoopDeps;
     const previousOnProgress = depsWithMutableProgress.onProgress;
@@ -158,6 +164,16 @@ export class CoreLoop {
       this.config.runPolicy = runPolicy;
     }
     this.currentActivationContext = options?.activation;
+    const abortSignal = options?.abortSignal;
+    const abortFromParent = (): void => {
+      this.logger?.warn("CoreLoop: abort requested by operator stop", { goalId });
+      this.stop();
+    };
+    if (abortSignal?.aborted) {
+      abortFromParent();
+    } else {
+      abortSignal?.addEventListener("abort", abortFromParent, { once: true });
+    }
 
     try {
     const startedAt = new Date().toISOString();
@@ -243,6 +259,10 @@ export class CoreLoop {
       hasIterationCap ? loopIndex < startLoopIndex + effectiveMaxIterations : true;
       loopIndex++
     ) {
+      if (abortSignal?.aborted) {
+        finalStatus = "stopped";
+        break;
+      }
       if (this.stopped) {
         finalStatus = "stopped";
         break;
@@ -266,9 +286,13 @@ export class CoreLoop {
       let iterationResult: LoopIterationResult;
       try {
         iterationResult = this.config.treeMode && this.deps.treeLoopOrchestrator
-          ? await this.runTreeIteration(goalId, loopIndex, nodeConsumedMap, runtimeBudgetId)
-          : await this.runOneIteration(goalId, loopIndex, loopIndex === startLoopIndex, runtimeBudgetId);
+          ? await this.runTreeIteration(goalId, loopIndex, nodeConsumedMap, runtimeBudgetId, abortSignal)
+          : await this.runOneIteration(goalId, loopIndex, loopIndex === startLoopIndex, runtimeBudgetId, abortSignal);
       } catch (err) {
+        if (abortSignal?.aborted) {
+          finalStatus = "stopped";
+          break;
+        }
         const msg = err instanceof Error ? err.message : String(err);
         this.logger?.error(`[CoreLoop] unexpected error in iteration ${loopIndex}: ${msg}`);
         decisionCounters = {
@@ -422,6 +446,7 @@ export class CoreLoop {
       tokensUsed: totalTokens,
     };
     } finally {
+      abortSignal?.removeEventListener("abort", abortFromParent);
       this.currentActivationContext = undefined;
       depsWithMutableProgress.onProgress = previousOnProgress;
       this.config.maxIterations = previousMaxIterations;
@@ -436,7 +461,8 @@ export class CoreLoop {
     goalId: string,
     loopIndex: number,
     isFirstIteration?: boolean,
-    runtimeBudgetId?: string | null
+    runtimeBudgetId?: string | null,
+    abortSignal?: AbortSignal
   ): Promise<LoopIterationResult> {
     const result = await new CoreIterationKernel({
       deps: this.deps,
@@ -456,7 +482,7 @@ export class CoreLoop {
       getPendingDirective: (id) => this.pendingIterationDirectives.get(id),
       getActivationContext: () => this.currentActivationContext,
       getRuntimeBudgetContext: () => this.loadRuntimeBudgetTaskContext(runtimeBudgetId),
-    }).run({ goalId, loopIndex, isFirstIteration });
+    }).run({ goalId, loopIndex, isFirstIteration, abortSignal });
     if (result.nextIterationDirective) {
       this.pendingIterationDirectives.set(goalId, result.nextIterationDirective);
     } else {
@@ -473,10 +499,11 @@ export class CoreLoop {
     rootId: string,
     loopIndex: number,
     nodeConsumedMap: Map<string, number>,
-    runtimeBudgetId?: string | null
+    runtimeBudgetId?: string | null,
+    abortSignal?: AbortSignal
   ): Promise<LoopIterationResult> {
     return runTreeIterationImpl(rootId, loopIndex, this.deps, this.config, this.logger,
-      (id, idx) => this.runOneIteration(id, idx, undefined, runtimeBudgetId), nodeConsumedMap, {
+      (id, idx) => this.runOneIteration(id, idx, undefined, runtimeBudgetId, abortSignal), nodeConsumedMap, {
         getPendingDirective: (id) => this.pendingIterationDirectives.get(id),
       });
   }

--- a/src/orchestrator/loop/durable-loop/iteration-kernel.ts
+++ b/src/orchestrator/loop/durable-loop/iteration-kernel.ts
@@ -106,13 +106,14 @@ export interface RunCoreIterationInput {
   goalId: string;
   loopIndex: number;
   isFirstIteration?: boolean;
+  abortSignal?: AbortSignal;
 }
 
 export class CoreIterationKernel {
   constructor(private readonly deps: CoreIterationKernelDeps) {}
 
   async run(input: RunCoreIterationInput): Promise<LoopIterationResult> {
-    const { goalId, loopIndex, isFirstIteration } = input;
+    const { goalId, loopIndex, isFirstIteration, abortSignal } = input;
     const startTime = Date.now();
     let config = this.deps.getConfig();
     const pendingDirective = this.deps.getPendingDirective(goalId);
@@ -777,6 +778,7 @@ export class CoreIterationKernel {
       loopCallbacks,
       evidenceLedger,
       mergedTaskGenerationHints,
+      abortSignal,
     );
     if (!taskCycleOk) return result;
 

--- a/src/orchestrator/loop/durable-loop/task-cycle.ts
+++ b/src/orchestrator/loop/durable-loop/task-cycle.ts
@@ -157,6 +157,7 @@ export interface TaskGenerationHints {
   budgetContext?: Record<string, unknown>;
   executionMode?: ExecutionModeState;
   runControlRecommendationContext?: string;
+  abortSignal?: AbortSignal;
 }
 
 export interface StallActionHints {
@@ -180,6 +181,7 @@ export async function runTaskCycleWithContext(
   callbacks: LoopCallbacks,
   evidenceLedger?: CoreLoopEvidenceLedger,
   taskGenerationHints?: TaskGenerationHints,
+  abortSignal?: AbortSignal,
 ): Promise<boolean> {
   const { handleCapabilityAcquisition, incrementTransferCounter, tryGenerateReport } = callbacks;
   try {
@@ -440,7 +442,7 @@ export async function runTaskCycleWithContext(
       knowledgeContext,
       existingTasks,
       workspaceContext,
-      taskGenerationHints,
+      { ...taskGenerationHints, ...(abortSignal ? { abortSignal } : {}) },
     );
     ctx.logger?.info("CoreLoop: task cycle result", { action: taskResult.action, taskId: taskResult.task.id });
     result.taskResult = taskResult;

--- a/src/runtime/__tests__/goal-worker.test.ts
+++ b/src/runtime/__tests__/goal-worker.test.ts
@@ -128,6 +128,32 @@ describe("GoalWorker", () => {
       expect(result.totalIterations).toBe(0);
     });
 
+    it("does not convert provider AbortError into stopped unless operator abort is signaled", async () => {
+      const worker = new GoalWorker(makeMockCoreLoop(new DOMException("provider aborted", "AbortError")) as any);
+
+      const result = await worker.execute("g1");
+
+      expect(result.status).toBe("error");
+      expect(result.error).toContain("provider aborted");
+    });
+
+    it("maps thrown errors to stopped when operator abort is signaled", async () => {
+      const controller = new AbortController();
+      const coreLoop = {
+        run: vi.fn().mockImplementation(async () => {
+          controller.abort(new Error("operator stop requested"));
+          throw new DOMException("operator stop requested", "AbortError");
+        }),
+        stop: vi.fn(),
+      };
+      const worker = new GoalWorker(coreLoop as any);
+
+      const result = await worker.execute("g1", { abortSignal: controller.signal });
+
+      expect(result.status).toBe("stopped");
+      expect(result.error).toContain("operator stop");
+    });
+
     it("does not convert a successful loop into worker error when onRunComplete throws", async () => {
       const loopResult = makeLoopResult({ goalId: "g1", totalIterations: 2, finalStatus: "completed" });
       const worker = new GoalWorker(

--- a/src/runtime/__tests__/loop-supervisor.test.ts
+++ b/src/runtime/__tests__/loop-supervisor.test.ts
@@ -252,6 +252,130 @@ describe("LoopSupervisor", () => {
     }
   });
 
+  it("shutdown() aborts active executions and returns without natural task completion", async () => {
+    let naturalCompletion = false;
+    let capturedSignal: AbortSignal | undefined;
+    const { supervisor, mockCoreLoop, runtimeRoot } = makeSupervisor(
+      (async (_goalId: string, options?: { abortSignal?: AbortSignal }) => {
+        capturedSignal = options?.abortSignal;
+        await new Promise<void>((resolve) => {
+          options?.abortSignal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+        return makeLoopResult({ goalId: "g-stop", finalStatus: "stopped" });
+      }) as unknown as (...args: any[]) => Promise<LoopResult>,
+      {},
+      { concurrency: 1, pollIntervalMs: 10, activeStopGraceMs: 25 }
+    );
+    try {
+      await supervisor.start(["g-stop"]);
+      await waitFor(() => capturedSignal !== undefined);
+
+      const startedAt = Date.now();
+      await supervisor.shutdown();
+      const elapsedMs = Date.now() - startedAt;
+
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(elapsedMs).toBeLessThan(500);
+      expect(naturalCompletion).toBe(false);
+      expect(mockCoreLoop.run).toHaveBeenCalledWith(
+        "g-stop",
+        expect.objectContaining({ abortSignal: capturedSignal })
+      );
+    } finally {
+      naturalCompletion = true;
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("shutdown() has a bounded wait even when active execution ignores abort", async () => {
+    let started = false;
+    let capturedSignal: AbortSignal | undefined;
+    const { supervisor, runtimeRoot } = makeSupervisor(
+      (async (_goalId: string, options?: { abortSignal?: AbortSignal }) => {
+        capturedSignal = options?.abortSignal;
+        started = true;
+        await new Promise<void>(() => undefined);
+        return makeLoopResult({ goalId: "g-hung" });
+      }) as unknown as (...args: any[]) => Promise<LoopResult>,
+      {},
+      { concurrency: 1, pollIntervalMs: 10, activeStopGraceMs: 30 }
+    );
+    try {
+      await supervisor.start(["g-hung"]);
+      await waitFor(() => started);
+
+      const startedAt = Date.now();
+      await supervisor.shutdown();
+      const elapsedMs = Date.now() - startedAt;
+
+      expect(capturedSignal?.aborted).toBe(true);
+      expect(elapsedMs).toBeLessThan(500);
+    } finally {
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("shutdown() does not start a new execution after an in-flight poll observes stop", async () => {
+    let leaseStarted = false;
+    let releaseLease: (() => void) | undefined;
+    const { supervisor, mockCoreLoop, runtimeRoot } = makeSupervisor(
+      (async () => makeLoopResult({ goalId: "g-race" })) as unknown as (...args: any[]) => Promise<LoopResult>,
+      {},
+      { concurrency: 1, pollIntervalMs: 10, activeStopGraceMs: 25 }
+    );
+    (supervisor as unknown as { acquireExecutionLease: (...args: unknown[]) => Promise<boolean> }).acquireExecutionLease =
+      vi.fn(async () => {
+        leaseStarted = true;
+        await new Promise<void>((resolve) => {
+          releaseLease = resolve;
+        });
+        return true;
+      });
+
+    try {
+      await supervisor.start(["g-race"]);
+      await waitFor(() => leaseStarted);
+
+      const shutdownPromise = supervisor.shutdown();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      releaseLease?.();
+      await shutdownPromise;
+
+      expect(mockCoreLoop.run).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("shutdown() bounds an in-flight poll before returning", async () => {
+    let leaseStarted = false;
+    const { supervisor, mockCoreLoop, runtimeRoot } = makeSupervisor(
+      (async () => makeLoopResult({ goalId: "g-stuck-poll" })) as unknown as (...args: any[]) => Promise<LoopResult>,
+      {},
+      { concurrency: 1, pollIntervalMs: 10, activeStopGraceMs: 30 }
+    );
+    (supervisor as unknown as { acquireExecutionLease: (...args: unknown[]) => Promise<boolean> }).acquireExecutionLease =
+      vi.fn(async () => {
+        leaseStarted = true;
+        await new Promise<void>(() => undefined);
+        return true;
+      });
+
+    try {
+      await supervisor.start(["g-stuck-poll"]);
+      await waitFor(() => leaseStarted);
+
+      const startedAt = Date.now();
+      await supervisor.shutdown();
+      const elapsedMs = Date.now() - startedAt;
+
+      expect(elapsedMs).toBeLessThan(500);
+      expect(mockCoreLoop.run).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(runtimeRoot, { recursive: true, force: true });
+    }
+  });
+
   // ─── 6. State persistence ───
 
   it("writes supervisor-state.json after execution", async () => {

--- a/src/runtime/executor/goal-worker.ts
+++ b/src/runtime/executor/goal-worker.ts
@@ -20,6 +20,12 @@ export interface WorkerResult {
   error?: string;
 }
 
+export interface GoalWorkerExecuteOptions {
+  backgroundRun?: GoalRunActivationContext["backgroundRun"];
+  waitResume?: GoalRunActivationContext["waitResume"];
+  abortSignal?: AbortSignal;
+}
+
 function toWorkerStatus(finalStatus: LoopResult['finalStatus']): WorkerResult['status'] {
   return finalStatus;
 }
@@ -43,7 +49,7 @@ export class GoalWorker {
     this.id = randomUUID();
   }
 
-  async execute(goalId: string, activation?: GoalRunActivationContext): Promise<WorkerResult> {
+  async execute(goalId: string, activation?: GoalWorkerExecuteOptions): Promise<WorkerResult> {
     this.status = 'running';
     this.currentGoalId = goalId;
     this.startedAt = Date.now();
@@ -63,7 +69,8 @@ export class GoalWorker {
         lastResult = await this.coreLoop.run(goalId, {
           maxIterations,
           ...(this.config.runPolicy ? { runPolicy: this.config.runPolicy } : {}),
-          ...(activation ? { activation } : {}),
+          ...(activation ? { activation: toGoalRunActivationContext(activation) } : {}),
+          ...(activation?.abortSignal ? { abortSignal: activation.abortSignal } : {}),
         });
         cumulativeIterations += lastResult.totalIterations;
         this.currentIterations = cumulativeIterations;
@@ -87,6 +94,16 @@ export class GoalWorker {
         error: lastResult.errorMessage,
       };
     } catch (err) {
+      if (activation?.abortSignal?.aborted) {
+        this.status = 'idle';
+        return {
+          goalId,
+          status: 'stopped',
+          totalIterations: this.currentIterations,
+          durationMs: Date.now() - this.startedAt,
+          error: 'operator stop aborted active execution',
+        };
+      }
       this.status = 'crashed';
       return {
         goalId,
@@ -127,4 +144,11 @@ export class GoalWorker {
   isIdle(): boolean {
     return this.status === 'idle';
   }
+}
+
+function toGoalRunActivationContext(options: GoalWorkerExecuteOptions): GoalRunActivationContext {
+  return {
+    ...(options.backgroundRun ? { backgroundRun: options.backgroundRun } : {}),
+    ...(options.waitResume ? { waitResume: options.waitResume } : {}),
+  };
 }

--- a/src/runtime/executor/loop-supervisor.ts
+++ b/src/runtime/executor/loop-supervisor.ts
@@ -26,6 +26,7 @@ export interface SupervisorConfig {
   claimLeaseMs: number;
   leaseRenewIntervalMs: number;
   runPolicy: LoopRunPolicyMode;
+  activeStopGraceMs: number;
 }
 
 export interface SupervisorDeps {
@@ -88,6 +89,7 @@ const DEFAULT_CONFIG: SupervisorConfig = {
   claimLeaseMs: 30_000,
   leaseRenewIntervalMs: 10_000,
   runPolicy: 'resident',
+  activeStopGraceMs: 5_000,
 };
 
 function workerStatusToBackgroundRunStatus(
@@ -115,7 +117,12 @@ export class LoopSupervisor {
   private readonly deps: SupervisorDeps;
   private polling: boolean = false;
   private currentPoll: Promise<void> | null = null;
-  private runningExecutions: Promise<void>[] = [];
+  private runningExecutions: Array<{
+    promise: Promise<void>;
+    controller: AbortController;
+    goalId: string;
+    workerId: string;
+  }> = [];
   private pendingTimers: Set<ReturnType<typeof setTimeout>> = new Set();
 
   constructor(deps: SupervisorDeps, config?: Partial<SupervisorConfig>) {
@@ -168,8 +175,35 @@ export class LoopSupervisor {
     }
     for (const timer of this.pendingTimers) clearTimeout(timer);
     this.pendingTimers.clear();
-    await this.currentPoll;
-    await Promise.allSettled(this.runningExecutions);
+    const pollCompleted = await waitForExecutions(
+      this.currentPoll ? [this.currentPoll] : [],
+      this.config.activeStopGraceMs
+    );
+    if (!pollCompleted) {
+      this.deps.logger?.warn('Supervisor shutdown returned before active poll settled', {
+        timeoutMs: this.config.activeStopGraceMs,
+      });
+    }
+    const activeExecutions = [...this.runningExecutions];
+    if (activeExecutions.length > 0) {
+      this.deps.logger?.warn('Aborting active goal executions during supervisor shutdown', {
+        activeCount: activeExecutions.length,
+        goalIds: activeExecutions.map((execution) => execution.goalId),
+      });
+      for (const execution of activeExecutions) {
+        execution.controller.abort(new Error('operator stop requested'));
+      }
+    }
+    const completed = await waitForExecutions(
+      activeExecutions.map((execution) => execution.promise),
+      this.config.activeStopGraceMs
+    );
+    if (!completed) {
+      this.deps.logger?.warn('Supervisor shutdown returned before active executions settled', {
+        activeCount: this.runningExecutions.length,
+        timeoutMs: this.config.activeStopGraceMs,
+      });
+    }
     this.persistState();
   }
 
@@ -319,12 +353,25 @@ export class LoopSupervisor {
           continue;
         }
 
+        if (!this.running) {
+          await this.failClaim(dispatch, 'supervisor stopping', true);
+          await this.releaseExecutionLease(dispatch);
+          break;
+        }
+
         this.activeGoals.set(goalId, worker);
-        const execution = this.executeWorker(worker, dispatch);
+        const controller = new AbortController();
+        const execution = this.executeWorker(worker, dispatch, controller.signal);
         this.persistState();
-        this.runningExecutions.push(execution);
+        const trackedExecution = {
+          promise: execution,
+          controller,
+          goalId,
+          workerId: worker.id,
+        };
+        this.runningExecutions.push(trackedExecution);
         execution.finally(() => {
-          const idx = this.runningExecutions.indexOf(execution);
+          const idx = this.runningExecutions.indexOf(trackedExecution);
           if (idx !== -1) this.runningExecutions.splice(idx, 1);
         });
       }
@@ -440,7 +487,7 @@ export class LoopSupervisor {
     };
   }
 
-  private async executeWorker(worker: GoalWorker, activation: GoalActivation): Promise<void> {
+  private async executeWorker(worker: GoalWorker, activation: GoalActivation, abortSignal?: AbortSignal): Promise<void> {
     const { goalId } = activation;
     let ownershipLost = false;
     this.installWriteFence(activation);
@@ -454,6 +501,7 @@ export class LoopSupervisor {
       const result: WorkerResult = await worker.execute(goalId, {
         ...(activation.backgroundRun ? { backgroundRun: activation.backgroundRun } : {}),
         ...(activation.waitResume ? { waitResume: activation.waitResume } : {}),
+        ...(abortSignal ? { abortSignal } : {}),
       });
 
       if (result.status === 'error') {
@@ -786,5 +834,20 @@ export class LoopSupervisor {
     } catch {
       // Corrupt or missing state — start fresh
     }
+  }
+}
+
+async function waitForExecutions(promises: Promise<void>[], timeoutMs: number): Promise<boolean> {
+  if (promises.length === 0) return true;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timeout = new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+      timer.unref?.();
+    });
+    const settled = Promise.allSettled(promises).then(() => true);
+    return await Promise.race([settled, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }

--- a/src/tools/system/ShellTool/ShellTool.ts
+++ b/src/tools/system/ShellTool/ShellTool.ts
@@ -35,7 +35,7 @@ export class ShellTool implements ITool<ShellInput, ShellOutput> {
     const cwd = expandTildePath(input.cwd ?? context.cwd);
     try {
       const shell = process.env.SHELL ?? "/bin/zsh";
-      const result = await execFileNoThrow(shell, ["-c", input.command], { cwd, timeoutMs: input.timeoutMs });
+      const result = await execFileNoThrow(shell, ["-c", input.command], { cwd, timeoutMs: input.timeoutMs, signal: context.abortSignal, killProcessGroup: true });
       const exitCode = result.exitCode ?? -1;
       const output: ShellOutput = { stdout: result.stdout, stderr: result.stderr, exitCode };
       return {

--- a/src/tools/system/ShellTool/__tests__/ShellTool.test.ts
+++ b/src/tools/system/ShellTool/__tests__/ShellTool.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { ShellTool } from "../ShellTool.js";
 import type { ToolCallContext } from "../../../types.js";
+import * as execMod from "../../../../base/utils/execFileNoThrow.js";
 
 const makeContext = (cwd = "/tmp"): ToolCallContext => ({
   cwd,
@@ -14,6 +15,10 @@ const makeContext = (cwd = "/tmp"): ToolCallContext => ({
 
 describe("ShellTool", () => {
   const tool = new ShellTool();
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
   describe("metadata", () => {
     it("has correct name", () => {
@@ -174,6 +179,23 @@ describe("ShellTool", () => {
       const result = await tool.call({ command: "ls /nonexistent_dir_xyz_abc", timeoutMs: 5_000 }, makeContext());
       expect(result.success).toBe(false);
       expect((result.data as { exitCode: number }).exitCode).not.toBe(0);
+    });
+
+    it("runs shell commands in a process group for operator abort cleanup", async () => {
+      const controller = new AbortController();
+      const spy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValueOnce({
+        stdout: "ok",
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await tool.call({ command: "echo ok", timeoutMs: 5_000 }, { ...makeContext(), abortSignal: controller.signal });
+
+      expect(spy).toHaveBeenCalledWith(
+        expect.any(String),
+        ["-c", "echo ok"],
+        expect.objectContaining({ signal: controller.signal, killProcessGroup: true })
+      );
     });
 
     it("includes contextModifier on success", async () => {

--- a/src/tools/system/TestRunnerTool/TestRunnerTool.ts
+++ b/src/tools/system/TestRunnerTool/TestRunnerTool.ts
@@ -137,7 +137,7 @@ export class TestRunnerTool implements ITool<TestRunnerInput, TestRunnerOutput> 
     const { cmd, args } = buildTestCommand(input.command, input.pattern);
 
     try {
-      const result = await execFileNoThrow(cmd, args, { cwd, timeoutMs: input.timeout });
+      const result = await execFileNoThrow(cmd, args, { cwd, timeoutMs: input.timeout, signal: context.abortSignal, killProcessGroup: true });
       const combined = [result.stdout, result.stderr].filter(Boolean).join("\n");
       const rawOutput = combined.length > MAX_RAW_OUTPUT ? combined.slice(0, MAX_RAW_OUTPUT) + "\n...[truncated]" : combined;
 

--- a/src/tools/system/TestRunnerTool/__tests__/TestRunnerTool.test.ts
+++ b/src/tools/system/TestRunnerTool/__tests__/TestRunnerTool.test.ts
@@ -150,6 +150,23 @@ describe("TestRunnerTool", () => {
       expect(data.success).toBe(true);
     });
 
+    it("runs test commands in a process group for operator abort cleanup", async () => {
+      const controller = new AbortController();
+      const spy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValueOnce({
+        stdout: VITEST_PASS,
+        stderr: "",
+        exitCode: 0,
+      });
+
+      await tool.call({ command: "npx vitest run", timeout: 60000 }, { ...makeContext(), abortSignal: controller.signal });
+
+      expect(spy).toHaveBeenCalledWith(
+        "npx",
+        expect.arrayContaining(["vitest", "run"]),
+        expect.objectContaining({ signal: controller.signal, killProcessGroup: true })
+      );
+    });
+
     it("parses failing vitest output", async () => {
       vi.spyOn(execMod, "execFileNoThrow").mockResolvedValueOnce({
         stdout: VITEST_FAIL, stderr: "", exitCode: 1,

--- a/tmp/kaggle-durable-loop-issues-status.md
+++ b/tmp/kaggle-durable-loop-issues-status.md
@@ -33,6 +33,15 @@ Verification:
 - `npm run test:changed`
 
 Review:
+- Fresh review found four material issues: shutdown could miss execution started by an in-flight poll, tree-mode did not pass the abort signal into node execution, operator abort during model request was classified as timeout, and shell/test tool abort only killed direct children.
+- Fixed shutdown ordering to wait for `currentPoll` before snapshotting/aborting active executions and added a stop guard after lease acquisition so shutdown does not start new executions from an in-flight poll.
+- Fixed tree-mode to pass the same abort signal through `runTreeIteration()` into node `runOneIteration()`.
+- Fixed model abort classification to `cancelled` with operator-stop text instead of timeout.
+- Switched shell/test command execution to an opt-in process-group `spawn` path that terminates the group on abort/timeout where supported, with direct-child fallback.
+- Added regressions for in-flight poll stop, aborted model request classification, and process-group options for shell/test commands.
+- `npm run test:changed`
+
+Review:
 - Fresh review agent: no material findings.
 
 PR:
@@ -96,3 +105,48 @@ Review:
 - Second fresh review found a remaining workspace-scoping gap for builtin-supported artifact dimensions when the daemon datasource already claims the dimension.
 - Fixed goal datasource synthesis to always prefer the goal workspace for numeric workspace goals, while only adding explicit metric mappings for plain metric names like `roc_auc`; added a `best_oof_balanced_accuracy` regression with a wrong daemon metric.
 - Final fresh review: no high-confidence material defects.
+
+PR:
+- #1098 merged after CI passed.
+
+## #1093
+
+Status: implementation verified locally; pending final review agent.
+
+Plan:
+- Add an active execution abort path in `LoopSupervisor.shutdown()` with bounded wait before returning.
+- Pass an `AbortSignal` through `GoalWorker.execute()` -> `CoreLoop.run()` -> task cycle -> `TaskLifecycle.runTaskCycle()` -> native `TaskAgentLoopRunner.runTask()`.
+- Pass agent-loop abort into model requests and LLM clients, and make `CodexLLMClient` terminate its spawned child on abort.
+- Pass tool abort signals into shell/test child execution through `execFileNoThrow`.
+- Add a regression test where shutdown occurs while a worker/core loop is hung and assert shutdown returns without natural completion.
+
+Implemented:
+- `LoopSupervisor.shutdown()` now aborts tracked active executions with a bounded grace wait instead of awaiting natural completion forever.
+- `GoalWorker.execute()` passes an operator-stop `AbortSignal` into `CoreLoop.run()`; `CoreLoop` propagates it through the iteration kernel, task lifecycle, and native task agent-loop execution.
+- Agent-loop model clients, provider LLM clients, Codex CLI child execution, Ollama fetch, OpenAI/Anthropic SDK requests, and shell/test tool child execution now receive the abort signal where applicable.
+- Shell/test command execution uses an opt-in process-group `spawn` path that terminates the group on abort/timeout where supported, with direct-child fallback; Codex CLI model child execution also starts detached where supported and kills the process group on abort/timeout.
+- Abort-triggered task execution returns/stops as operator stop rather than classifying it as a normal task failure.
+- Regression tests cover supervisor shutdown while active execution cooperates with abort, supervisor shutdown while active execution ignores abort, Codex CLI child termination on abort, and Ollama fetch abort propagation.
+
+Verification:
+- `npm test -- --run src/runtime/__tests__/loop-supervisor.test.ts src/base/llm/__tests__/codex-llm-client.test.ts src/base/llm/__tests__/ollama-client.test.ts`
+- `npm run test:integration -- --run src/runtime/__tests__/loop-supervisor.test.ts`
+- `npm run typecheck`
+- `npm run lint:boundaries` (exit 0; existing warnings only)
+- `npm run test:changed`
+
+Review:
+- Fresh review found four material issues: shutdown could miss execution started by an in-flight poll, tree-mode did not pass the abort signal into node execution, operator abort during model request was classified as timeout, and shell/test tool abort only killed direct children.
+- Fixed shutdown ordering to wait for `currentPoll` before snapshotting/aborting active executions and added a stop guard after lease acquisition so shutdown does not start new executions from an in-flight poll.
+- Fixed tree-mode to pass the same abort signal through `runTreeIteration()` into node `runOneIteration()`.
+- Fixed model abort classification to `cancelled` with operator-stop text instead of timeout.
+- Added process-group cleanup for shell/test command execution and Codex CLI model child execution where supported.
+- Added regressions for in-flight poll stop, aborted model request classification, and process-group options for shell/test/Codex commands.
+- Second fresh review found remaining issues: cancelled task execution was still mapped to error, OpenAI Responses fallback timeout timer was not cleared on abort/reject, `currentPoll` could still block before active abort, and AbortError text alone was treated as operator cancellation.
+- Fixed cancelled task propagation by adding `cancelled` to task/adapter status, mapping agent-loop `cancelled` to `stopped_reason: "cancelled"`, and persisting cancelled tasks without failed/error status.
+- Fixed Responses fallback timer cleanup with `finally`, bounded `currentPoll` wait using `activeStopGraceMs`, and restored non-operator AbortError classification to timeout unless the turn abort signal is actually aborted.
+- Added regressions for cancelled result mapping, Responses abort timer cleanup, provider AbortError without operator abort, and stuck currentPoll shutdown.
+- Re-ran focused unit tests, integration supervisor test, `npm run typecheck`, `npm run lint:boundaries`, `git diff --check`, and `npm run test:changed`; all passed. `lint:boundaries` exits 0 with existing warnings.
+- Final fresh review found two remaining broad AbortError classifiers in CoreLoop and GoalWorker.
+- Removed AbortError string/name classification from CoreLoop/GoalWorker cancellation paths; those boundaries now report stopped only when the propagated operator `AbortSignal` is actually aborted. Added regressions for provider AbortError staying error and operator-aborted GoalWorker errors becoming stopped.
+- After final review fixes, re-ran focused unit tests, `npm run typecheck`, `npm run lint:boundaries`, `git diff --check`, and `npm run test:changed`; all passed. `lint:boundaries` exits 0 with existing warnings.


### PR DESCRIPTION
Closes #1093

## Summary
- propagate operator stop AbortSignal from supervisor through CoreLoop, task lifecycle, native agent-loop model requests, LLM clients, and shell/test tool execution
- bound supervisor shutdown for active polls/executions and prevent in-flight polls from starting new work after stop
- terminate Codex CLI, ShellTool, and TestRunnerTool child process groups where supported, with direct-child fallback
- preserve operator-cancelled task status and avoid classifying provider AbortError as operator stop

## Verification
- npm test -- --run src/runtime/__tests__/goal-worker.test.ts src/orchestrator/loop/__tests__/core-loop-run-policy.test.ts src/runtime/__tests__/loop-supervisor.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-command-classifier.test.ts src/base/llm/__tests__/openai-client.test.ts src/base/llm/__tests__/codex-llm-client.test.ts
- npm run test:integration -- --run src/runtime/__tests__/loop-supervisor.test.ts
- npm run typecheck
- npm run lint:boundaries (exit 0; existing warnings)
- npm run test:changed
- git diff --check

## Known unresolved risks
- lint:boundaries still reports existing warnings unrelated to this PR.