### PR TITLE
fix(goal): preserve raw add deadlines

### DIFF
--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -953,6 +953,45 @@ describe("goal add raw mode", async () => {
     expect(code).toBe(0);
   });
 
+  it("persists deadline and target_date for a raw --dim goal", async () => {
+    const deadline = "2026-06-01";
+    const normalizedDeadline = "2026-06-01T00:00:00.000Z";
+
+    const code = await runCLI(
+      "goal",
+      "add",
+      "--title",
+      "raw deadline goal",
+      "--dim",
+      "todo_count:max:0",
+      "--deadline",
+      deadline
+    );
+
+    expect(code).toBe(0);
+    const goalIds = await stateManager.listGoalIds();
+    expect(goalIds).toHaveLength(1);
+    const savedGoal = await stateManager.loadGoal(goalIds[0]!);
+    expect(savedGoal?.deadline).toBe(normalizedDeadline);
+    expect(savedGoal?.target_date).toBe(normalizedDeadline);
+  });
+
+  it("rejects invalid calendar datetimes for raw --dim goals", async () => {
+    const code = await runCLI(
+      "goal",
+      "add",
+      "--title",
+      "invalid raw deadline goal",
+      "--dim",
+      "todo_count:max:0",
+      "--deadline",
+      "2026-02-30T00:00:00Z"
+    );
+
+    expect(code).toBe(1);
+    expect(await stateManager.listGoalIds()).toEqual([]);
+  });
+
   it("outputs Goal ID and title after successful raw add", async () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     await runCLI("goal", "add", "--title", "my raw goal", "--dim", "todo_count:max:0");

--- a/src/interface/cli/__tests__/goal-dispatch-infer.test.ts
+++ b/src/interface/cli/__tests__/goal-dispatch-infer.test.ts
@@ -77,6 +77,7 @@ describe("dispatchGoalCommand — auto-infer flow", () => {
   });
 
   it("calls cmdGoalAddRaw with inferred dims after user accepts", async () => {
+    const deadline = "2026-06-01T00:00:00.000Z";
     vi.mocked(goalInfer.inferDimensionsFromTitle).mockResolvedValue([
       { name: "fluency_score", type: "min", value: "80" },
     ]);
@@ -86,7 +87,7 @@ describe("dispatchGoalCommand — auto-infer flow", () => {
 
     const result = await dispatchGoalCommand(
       "add",
-      ["--title", "英語ペラペラになりたい"],
+      ["--title", "英語ペラペラになりたい", "--deadline", deadline],
       false,
       makeStateManager(),
       makeCharacterConfigManager()
@@ -98,6 +99,7 @@ describe("dispatchGoalCommand — auto-infer flow", () => {
       expect.objectContaining({
         title: "英語ペラペラになりたい",
         rawDimensions: ["fluency_score:min:80"],
+        deadline,
       })
     );
     expect(result).toBe(0);
@@ -144,9 +146,10 @@ describe("dispatchGoalCommand — auto-infer flow", () => {
   });
 
   it("skips inference when --dim is provided (existing raw mode)", async () => {
+    const deadline = "2026-06-02T00:00:00.000Z";
     const result = await dispatchGoalCommand(
       "add",
-      ["--title", "fix errors", "--dim", "error_count:min:0"],
+      ["--title", "fix errors", "--dim", "error_count:min:0", "--deadline", deadline],
       false,
       makeStateManager(),
       makeCharacterConfigManager()
@@ -157,7 +160,30 @@ describe("dispatchGoalCommand — auto-infer flow", () => {
       expect.anything(),
       expect.objectContaining({
         rawDimensions: ["error_count:min:0"],
+        deadline,
       })
+    );
+    expect(result).toBe(0);
+  });
+
+  it("passes --deadline through the non-raw refine path when inference is not accepted", async () => {
+    const deadline = "2026-06-03T00:00:00.000Z";
+    vi.mocked(goalInfer.inferDimensionsFromTitle).mockResolvedValue([]);
+
+    const result = await dispatchGoalCommand(
+      "add",
+      ["keep docs current", "--deadline", deadline],
+      false,
+      makeStateManager(),
+      makeCharacterConfigManager()
+    );
+
+    expect(goalRaw.cmdGoalAddRaw).not.toHaveBeenCalled();
+    expect(goal.cmdGoalAdd).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "keep docs current",
+      expect.objectContaining({ deadline })
     );
     expect(result).toBe(0);
   });

--- a/src/interface/cli/commands/goal-dispatch.ts
+++ b/src/interface/cli/commands/goal-dispatch.ts
@@ -125,6 +125,7 @@ export async function dispatchGoalCommand(
               rawDimensions: rawDims,
               parent_id: addValues.parent,
               constraints: inferConstraints,
+              deadline: addValues.deadline,
             });
           }
           // If rejected, fall through to refine mode
@@ -145,7 +146,14 @@ export async function dispatchGoalCommand(
       if (addValues.workspace) {
         rawConstraints.push(`workspace_path:${addValues.workspace}`);
       }
-      return await cmdGoalAddRaw(stateManager, { title, description, rawDimensions, parent_id: addValues.parent, constraints: rawConstraints });
+      return await cmdGoalAddRaw(stateManager, {
+        title,
+        description,
+        rawDimensions,
+        parent_id: addValues.parent,
+        constraints: rawConstraints,
+        deadline: addValues.deadline,
+      });
     }
 
     // Refine/negotiate mode: requires description

--- a/src/interface/cli/commands/goal-raw.ts
+++ b/src/interface/cli/commands/goal-raw.ts
@@ -1,5 +1,6 @@
 // ─── goal-raw.ts: cmdGoalAddRaw — add a goal without LLM negotiation ───
 
+import { z } from "zod";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { getCliLogger } from "../cli-logger.js";
 import {
@@ -10,9 +11,33 @@ import {
   autoRegisterShellDataSources,
 } from "./goal-utils.js";
 
+const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_DATETIME_RE = /^\d{4}-\d{2}-\d{2}T.+/;
+const DeadlineDateTimeSchema = z.string().datetime();
+
+function normalizeDeadlineOption(deadline: string | undefined): string | null {
+  if (!deadline) return null;
+  if (ISO_DATE_ONLY_RE.test(deadline)) {
+    const normalized = `${deadline}T00:00:00.000Z`;
+    const parsed = new Date(normalized);
+    if (parsed.toISOString().slice(0, 10) !== deadline) {
+      throw new Error(`invalid --deadline value "${deadline}". Expected an ISO date or datetime.`);
+    }
+    return normalized;
+  }
+  if (!ISO_DATETIME_RE.test(deadline)) {
+    throw new Error(`invalid --deadline value "${deadline}". Expected an ISO date or datetime.`);
+  }
+  const parsed = DeadlineDateTimeSchema.safeParse(deadline);
+  if (!parsed.success) {
+    throw new Error(`invalid --deadline value "${deadline}". Expected an ISO date or datetime.`);
+  }
+  return new Date(parsed.data).toISOString();
+}
+
 export async function cmdGoalAddRaw(
   stateManager: StateManager,
-  opts: { title?: string; description?: string; rawDimensions: string[]; parent_id?: string; constraints?: string[] }
+  opts: { title?: string; description?: string; rawDimensions: string[]; parent_id?: string; constraints?: string[]; deadline?: string }
 ): Promise<number> {
   const title = opts.title || opts.description;
   if (!title) {
@@ -38,6 +63,13 @@ export async function cmdGoalAddRaw(
 
   const now = new Date().toISOString();
   const goalId = `goal_${Date.now()}`;
+  let deadline: string | null;
+  try {
+    deadline = normalizeDeadlineOption(opts.deadline);
+  } catch (err) {
+    getCliLogger().error(err instanceof Error ? `Error: ${err.message}` : String(err));
+    return 1;
+  }
 
   const dimensions = dimSpecs.map((spec) => {
     const threshold = buildThreshold(spec)!;
@@ -76,10 +108,10 @@ export async function cmdGoalAddRaw(
     dimension_mapping: null,
     constraints: opts.constraints ?? [],
     children_ids: [],
-    target_date: null,
+    target_date: deadline,
     origin: "manual" as const,
     pace_snapshot: null,
-    deadline: null,
+    deadline,
     confidence_flag: null,
     user_override: false,
     feasibility_note: null,


### PR DESCRIPTION
Closes #1092

## Summary
- Thread `--deadline` through explicit raw and accepted inferred-dimensions goal creation.
- Persist raw goal `deadline` and `target_date` using the normalized deadline value.
- Accept CLI-advertised date-only deadlines by normalizing them to schema-valid ISO datetimes, and reject invalid calendar datetimes before saving.

## Verification
- `npx vitest run --config vitest.unit.config.ts src/interface/cli/__tests__/goal-dispatch-infer.test.ts src/interface/cli/__tests__/cli-runner.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings)
- `npm run test:changed`
- Fresh review agent: no material findings after fixes

## Known unresolved risks
- Existing lint warnings remain outside this change.
