### PR TITLE
fix(status): reconcile stale daemon health display

### DIFF
--- a/src/interface/cli/__tests__/cli-daemon-status.test.ts
+++ b/src/interface/cli/__tests__/cli-daemon-status.test.ts
@@ -314,6 +314,97 @@ describe("cmdDaemonStatus", () => {
     expect(output).toContain("Ack latency:     p95 1.0s");
   });
 
+  it("reconciles stale runtime health with stopped live PID state", async () => {
+    const now = Date.now();
+    const stalePid = 999999991;
+    fs.mkdirSync(path.join(tmpDir, "runtime", "health"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "runtime", "health", "daemon.json"),
+      JSON.stringify({
+        status: "ok",
+        leader: true,
+        checked_at: now - 60_000,
+        kpi: {
+          process_alive: { status: "ok", checked_at: now - 60_000, last_ok_at: now - 60_000 },
+          command_acceptance: { status: "ok", checked_at: now - 60_000, last_ok_at: now - 60_000 },
+          task_execution: { status: "ok", checked_at: now - 60_000, last_ok_at: now - 60_000 },
+        },
+        long_running: {
+          summary: "alive_but_waiting",
+          checked_at: now - 60_000,
+          signals: {
+            process: { status: "alive", checked_at: now - 60_000, observed_at: now - 60_000, pid: stalePid },
+            child_activity: { status: "idle", checked_at: now - 60_000, observed_at: now - 60_000 },
+            log_freshness: { status: "fresh", checked_at: now - 60_000, observed_at: now - 60_000 },
+            artifact_freshness: { status: "fresh", checked_at: now - 60_000, observed_at: now - 60_000 },
+            metric_freshness: { status: "fresh", checked_at: now - 60_000, observed_at: now - 60_000 },
+            metric_progress: { status: "plateau", checked_at: now - 60_000, observed_at: now - 60_000 },
+            blocker: { status: "none", checked_at: now - 60_000, observed_at: now - 60_000 },
+            resumable: true,
+          },
+        },
+        details: { pid: stalePid },
+      })
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "runtime", "health", "components.json"),
+      JSON.stringify({
+        checked_at: now - 60_000,
+        components: {
+          gateway: "ok",
+          queue: "ok",
+          leases: "ok",
+          approval: "ok",
+          outbox: "ok",
+          supervisor: "ok",
+        },
+      })
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, "daemon-state.json"),
+      JSON.stringify({
+        pid: stalePid,
+        started_at: new Date(now - 120_000).toISOString(),
+        last_loop_at: new Date(now - 90_000).toISOString(),
+        loop_count: 4,
+        active_goals: ["goal-stale"],
+        status: "running",
+        crash_count: 0,
+        last_error: null,
+      })
+    );
+    const inspectSpy = vi.spyOn(PIDManager.prototype, "inspect").mockResolvedValue({
+      info: {
+        pid: stalePid,
+        runtime_pid: stalePid,
+        owner_pid: stalePid,
+        started_at: new Date(now - 120_000).toISOString(),
+        runtime_started_at: new Date(now - 120_000).toISOString(),
+        owner_started_at: new Date(now - 120_000).toISOString(),
+      },
+      running: false,
+      runtimePid: stalePid,
+      ownerPid: stalePid,
+      alivePids: [],
+      stalePids: [stalePid],
+      verifiedPids: [],
+      unverifiedLegacyPids: [],
+    });
+
+    await cmdDaemonStatus([]);
+    inspectSpy.mockRestore();
+
+    const output = consoleSpy.mock.calls[0]?.[0] as string;
+    expect(output).toContain(`stopped (PID: ${stalePid})`);
+    expect(output).toContain("Snapshot note:  live PID inspection reports runtime stopped");
+    expect(output).toContain("Process alive:   failed");
+    expect(output).toContain("KPI snapshot:    process=down accept=up execute=up (failed)");
+    expect(output).toContain("Summary:        dead but resumable");
+    expect(output).toContain(`Process:        dead pid=${stalePid}`);
+    expect(output).not.toContain("Process alive:   ok");
+    expect(output).not.toContain(`Process:        alive pid=${stalePid}`);
+  });
+
   it("shows in-flight worker progress from supervisor state when loops are still zero", async () => {
     const now = Date.now();
     fs.mkdirSync(path.join(tmpDir, "runtime"), { recursive: true });

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -23,6 +23,7 @@ import { ScheduleEngine } from "../../../runtime/schedule/engine.js";
 import { RuntimeWatchdog } from "../../../runtime/watchdog.js";
 import { LeaderLockManager } from "../../../runtime/leader-lock-manager.js";
 import { ProactiveInterventionStore, RuntimeHealthStore } from "../../../runtime/store/index.js";
+import type { RuntimeHealthSnapshot } from "../../../runtime/store/index.js";
 import { isDaemonRunning, probeDaemonHealth } from "../../../runtime/daemon/client.js";
 import { PluginLoader } from "../../../runtime/plugin-loader.js";
 import { NotifierRegistry } from "../../../runtime/notifier-registry.js";
@@ -57,6 +58,59 @@ import {
 } from "./daemon-shared.js";
 
 const WATCHDOG_CHILD_ENV = "PULSEED_WATCHDOG_CHILD";
+const STALE_RUNTIME_HEALTH_REASON = "live PID inspection reports runtime stopped; stored health snapshot is historical";
+
+function reconcileRuntimeHealthForDisplay(
+  snapshot: RuntimeHealthSnapshot | null,
+  opts: { runtimeAlive: boolean; runtimePid: number | null }
+): RuntimeHealthSnapshot | null {
+  if (!snapshot || opts.runtimeAlive) {
+    return snapshot;
+  }
+
+  const checkedAt = Date.now();
+  const staleRuntimePid = opts.runtimePid ?? snapshot.long_running?.signals.process.pid;
+  const kpi: RuntimeHealthSnapshot["kpi"] = snapshot.kpi
+    ? {
+      ...snapshot.kpi,
+      process_alive: {
+        ...snapshot.kpi.process_alive,
+        status: "failed",
+        checked_at: checkedAt,
+        last_failed_at: checkedAt,
+        reason: STALE_RUNTIME_HEALTH_REASON,
+      },
+      degraded_at: snapshot.kpi.degraded_at ?? checkedAt,
+    }
+    : undefined;
+
+  const longRunning: RuntimeHealthSnapshot["long_running"] = snapshot.long_running
+    ? {
+      ...snapshot.long_running,
+      summary: snapshot.long_running.signals.resumable ? "dead_but_resumable" : "dead_needs_intervention",
+      checked_at: checkedAt,
+      signals: {
+        ...snapshot.long_running.signals,
+        process: {
+          ...snapshot.long_running.signals.process,
+          status: "dead",
+          pid: staleRuntimePid,
+          checked_at: checkedAt,
+          observed_at: checkedAt,
+          reason: STALE_RUNTIME_HEALTH_REASON,
+        },
+      },
+    }
+    : undefined;
+
+  return {
+    ...snapshot,
+    status: "failed",
+    checked_at: checkedAt,
+    kpi,
+    long_running: longRunning,
+  };
+}
 
 export async function cmdStart(
   stateManager: StateManager,
@@ -474,7 +528,14 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   // Load daemon config for config section display
   const cfg = await loadDaemonConfig(baseDir);
   const runtimeRoot = resolveDaemonRuntimeRoot(baseDir, cfg.runtime_root);
-  const runtimeHealth = await new RuntimeHealthStore(runtimeRoot).loadSnapshot();
+  const storedRuntimeHealth = await new RuntimeHealthStore(runtimeRoot).loadSnapshot();
+  const runtimeHealth = reconcileRuntimeHealthForDisplay(storedRuntimeHealth, {
+    runtimeAlive: resolvedRuntimeAlive,
+    runtimePid: resolvedRuntimePid,
+  });
+  const runtimeHealthReconciled =
+    storedRuntimeHealth !== runtimeHealth
+    && (storedRuntimeHealth?.kpi !== undefined || storedRuntimeHealth?.long_running !== undefined);
   const proactiveSummary = await new ProactiveInterventionStore(runtimeRoot).summarize();
   const supervisorState = await readSupervisorState(runtimeRoot);
   const taskKpis = await summarizeTaskOutcomeLedgers(baseDir);
@@ -620,6 +681,9 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   if (runtimeHealth?.kpi) {
     lines.push("");
     lines.push("Runtime health:");
+    if (runtimeHealthReconciled) {
+      lines.push(`  Snapshot note:  ${STALE_RUNTIME_HEALTH_REASON}.`);
+    }
     lines.push(`  ${formatCapabilityLabel("Process alive:", runtimeHealth.kpi, "process_alive")}`);
     lines.push(`  ${formatCapabilityLabel("Accept command:", runtimeHealth.kpi, "command_acceptance")}`);
     lines.push(`  ${formatCapabilityLabel("Execute task:", runtimeHealth.kpi, "task_execution")}`);
@@ -647,6 +711,9 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
   if (runtimeHealth?.long_running) {
     lines.push("");
     lines.push("Long-run health:");
+    if (runtimeHealthReconciled) {
+      lines.push(`  Snapshot note:  ${STALE_RUNTIME_HEALTH_REASON}.`);
+    }
     lines.push(...formatLongRunHealthLines(runtimeHealth.long_running));
   }
 


### PR DESCRIPTION
Closes #1094

## Summary
- Reconcile loaded runtime health snapshots with live PID inspection before rendering `pulseed daemon status`.
- When the tracked runtime PID is stopped, display process liveness as failed and long-run process state as dead while preserving the historical snapshot details behind an explicit note.
- Add regression coverage for a stored ok/alive snapshot with `PIDManager.inspect()` reporting the PID stopped.

## Verification
- `npx vitest run --config vitest.integration.config.ts src/interface/cli/__tests__/cli-daemon-status.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings)
- `npm run test:changed`
- Fresh review agent: no material findings

## Known unresolved risks
- This is display-only reconciliation; stale `daemon-state.json` cleanup remains unchanged.
- Existing lint warnings remain outside this change.
