### PR TITLE
fix(revert): use concrete changed paths

### DIFF
--- a/src/orchestrator/execution/__tests__/task-verifier-guards.test.ts
+++ b/src/orchestrator/execution/__tests__/task-verifier-guards.test.ts
@@ -432,13 +432,17 @@ describe("attemptRevert safety", () => {
     execFileSync("git", ["commit", "-m", "init"], { cwd: repoDir, stdio: "pipe" });
   }
 
-  function makeFailureVerificationResult(): VerificationResult {
+  function makeFailureVerificationResult(fileDiffPaths: string[] = []): VerificationResult {
     return makeVerificationResult({
       verdict: "fail",
       evidence: [
         { layer: "independent_review", description: "Wrong direction", confidence: 0.3 },
         { layer: "self_report", description: "Failed", confidence: 0.3 },
       ],
+      file_diffs: fileDiffPaths.map((filePath) => ({
+        path: filePath,
+        patch: `diff -- ${filePath}`,
+      })),
     });
   }
 
@@ -467,7 +471,7 @@ describe("attemptRevert safety", () => {
       });
 
       await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
-      const result = await handleFailure(deps, task, makeFailureVerificationResult());
+      const result = await handleFailure(deps, task, makeFailureVerificationResult(["tracked.txt"]));
 
       expect(result.action).toBe("escalate");
       expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("changed\n");
@@ -498,10 +502,61 @@ describe("attemptRevert safety", () => {
 
     try {
       await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
-      const result = await handleFailure(deps, task, makeFailureVerificationResult());
+      const result = await handleFailure(deps, task, makeFailureVerificationResult(["tracked.txt"]));
 
       expect(result.action).toBe("discard");
       expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("original\n");
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat natural-language scope descriptions as revert file paths", async () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "attempt-revert-repo-"));
+    initGitRepo(repoDir);
+    fs.writeFileSync(path.join(repoDir, "tracked.txt"), "changed\n", "utf-8");
+    const logger = {
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger;
+    const deps: VerifierDeps = {
+      stateManager,
+      llmClient: createMockLLMClient([
+        '```json\n{"success": false, "reason": "No concrete paths captured"}\n```',
+      ]),
+      sessionManager,
+      trustManager,
+      stallDetector,
+      durationToMs: (d) => d.value * (d.unit === "hours" ? 3600000 : 60000),
+      revertCwd: repoDir,
+      logger,
+    };
+    const task = makeTask({
+      scope_boundary: {
+        in_scope: ["Create one new sklearn-based experiment script", "Generate one local JSON report"],
+        out_of_scope: [],
+        blast_radius: "low",
+      },
+      reversibility: "reversible",
+    });
+
+    try {
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+
+      const result = await handleFailure(deps, task, makeFailureVerificationResult());
+
+      expect(result.action).toBe("escalate");
+      expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("changed\n");
+      expect(logger.warn).toHaveBeenCalledWith(
+        "[attemptRevert] skipping raw git restore because no concrete changed paths were captured"
+      );
+      expect(
+        (logger.warn as ReturnType<typeof vi.fn>).mock.calls.some(([message]) =>
+          String(message).includes("unsafe file path detected")
+        )
+      ).toBe(false);
     } finally {
       fs.rmSync(repoDir, { recursive: true, force: true });
     }
@@ -523,9 +578,19 @@ describe("attemptRevert safety", () => {
       stallDetector,
       durationToMs: (d) => d.value * (d.unit === "hours" ? 3600000 : 60000),
       revertCwd: daemonRepo,
+      logger: {
+        warn: vi.fn(),
+        info: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      } as unknown as Logger,
     };
     const task = makeTask({
-      scope_boundary: { in_scope: ["tracked.txt"], out_of_scope: [], blast_radius: "low" },
+      scope_boundary: {
+        in_scope: ["Create one local report", "Update task output summary"],
+        out_of_scope: [],
+        blast_radius: "low",
+      },
       reversibility: "reversible",
     });
 
@@ -536,11 +601,16 @@ describe("attemptRevert safety", () => {
       }));
       await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
 
-      const result = await handleFailure(deps, task, makeFailureVerificationResult());
+      const result = await handleFailure(deps, task, makeFailureVerificationResult(["tracked.txt"]));
 
       expect(result.action).toBe("discard");
       expect(fs.readFileSync(path.join(goalRepo, "tracked.txt"), "utf-8")).toBe("original\n");
       expect(fs.readFileSync(path.join(daemonRepo, "tracked.txt"), "utf-8")).toBe("daemon changed\n");
+      expect(
+        ((deps.logger?.warn as ReturnType<typeof vi.fn>)?.mock.calls ?? []).some(([message]) =>
+          String(message).includes("unsafe file path detected")
+        )
+      ).toBe(false);
     } finally {
       fs.rmSync(daemonRepo, { recursive: true, force: true });
       fs.rmSync(goalRepo, { recursive: true, force: true });

--- a/src/orchestrator/execution/task/task-verifier-rules.ts
+++ b/src/orchestrator/execution/task/task-verifier-rules.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import * as path from "node:path";
 import type { Task } from "../../../base/types/task.js";
 import type { VerificationResult } from "../../../base/types/task.js";
 import type { AgentTask, AgentResult, IAdapter } from "../adapter-layer.js";
@@ -246,9 +247,28 @@ async function resolveRevertCwd(deps: VerifierDeps, task: Task): Promise<string 
   }) ?? null;
 }
 
-export async function attemptRevert(deps: VerifierDeps, task: Task): Promise<boolean> {
+function quoteShellArg(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function isRelativeGitPath(filePath: string): boolean {
+  const trimmed = filePath.trim();
+  if (!trimmed || trimmed.includes("\0") || path.isAbsolute(trimmed)) {
+    return false;
+  }
+  const segments = trimmed.replace(/\\/g, "/").split("/");
+  return !segments.includes("..");
+}
+
+export async function attemptRevert(
+  deps: VerifierDeps,
+  task: Task,
+  opts: { concretePaths?: string[] } = {}
+): Promise<boolean> {
+  const filesToRestore = [
+    ...new Set((opts.concretePaths ?? []).map((filePath) => filePath.trim()).filter(Boolean)),
+  ];
   try {
-    const filesToRestore = task.scope_boundary.in_scope;
     if (filesToRestore.length > 0) {
       const revertCwd = await resolveRevertCwd(deps, task);
       if (!revertCwd) {
@@ -265,15 +285,16 @@ export async function attemptRevert(deps: VerifierDeps, task: Task): Promise<boo
           trusted: true,
           approvalFn: async () => true,
         };
-        const SAFE_PATH = /^[\w./@\-]+$/;
-        const allSafe = filesToRestore.every((f) => SAFE_PATH.test(f));
+        const allSafe = filesToRestore.every(isRelativeGitPath);
         if (!allSafe) {
-          deps.logger?.warn?.("[attemptRevert] unsafe file path detected, falling back to execFileSync");
-          // Fall through to execFileSync fallback below
+          deps.logger?.warn?.(
+            "[attemptRevert] concrete changed path failed git-restore path validation; falling back to LLM revert"
+          );
+          throw new Error("git restore disabled for invalid concrete changed path");
         } else {
           const result = await deps.toolExecutor.execute(
             "shell",
-            { command: "git restore " + filesToRestore.join(" ") },
+            { command: "git restore -- " + filesToRestore.map(quoteShellArg).join(" ") },
             ctx
           );
           if (result.success) {
@@ -285,10 +306,16 @@ export async function attemptRevert(deps: VerifierDeps, task: Task): Promise<boo
       } else {
         // Fallback: raw child_process (no ToolExecutor available)
         const { execFileSync } = await import("child_process");
-        execFileSync("git", ["restore", ...filesToRestore], { cwd: revertCwd, encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+        execFileSync("git", ["restore", "--", ...filesToRestore], {
+          cwd: revertCwd,
+          encoding: "utf-8",
+          stdio: ["pipe", "pipe", "pipe"],
+        });
         deps.logger?.info?.(`[attemptRevert] git restore succeeded for ${filesToRestore.length} files`);
         return true;
       }
+    } else {
+      deps.logger?.warn?.("[attemptRevert] skipping raw git restore because no concrete changed paths were captured");
     }
   } catch {
     // git not available or failed — fall back to LLM-based revert
@@ -301,7 +328,12 @@ export async function attemptRevert(deps: VerifierDeps, task: Task): Promise<boo
       task.id
     );
 
-    const revertPrompt = `Revert task "${task.work_description}". Undo all changes in: ${task.scope_boundary.in_scope.join(", ")}.
+    const revertTargetSummary =
+      filesToRestore.length > 0
+        ? `Concrete changed paths: ${filesToRestore.join(", ")}.`
+        : "No concrete changed paths were captured. Do not treat task scope descriptions as file paths.";
+
+    const revertPrompt = `Revert task "${task.work_description}". ${revertTargetSummary}
 
 Return JSON: {"success": true|false, "reason": "..."}`;
 

--- a/src/orchestrator/execution/task/task-verifier.ts
+++ b/src/orchestrator/execution/task/task-verifier.ts
@@ -731,7 +731,16 @@ export async function handleFailure(
   }
 
   if (updatedTask.reversibility === "reversible") {
-    const revertSuccess = await attemptRevert(deps, updatedTask);
+    const concreteRevertPaths = [
+      ...new Set(
+        (verificationResult.file_diffs ?? [])
+          .map((diff) => diff.path)
+          .filter((filePath) => filePath.trim().length > 0)
+      ),
+    ];
+    const revertSuccess = await attemptRevert(deps, updatedTask, {
+      concretePaths: concreteRevertPaths,
+    });
     deps.logger?.warn(`[task] revert attempted`, { taskId: task.id, success: revertSuccess });
     if (revertSuccess) {
       await appendTaskHistory(deps, task.goal_id, updatedTask);


### PR DESCRIPTION
Closes #1095

## Summary
- Stop treating `scope_boundary.in_scope` natural-language descriptions as revert file paths.
- Pass concrete `verificationResult.file_diffs[].path` values into `attemptRevert()` for raw git restore.
- Keep task/goal `workspace_path` resolution ahead of stale `revertCwd`, and update fallback logging to match the actual LLM-revert path.
- Add regression coverage for natural-language scope entries and concrete changed paths in the goal workspace.

## Verification
- `npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/__tests__/task-verifier-guards.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed`
- `npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts`
- `git diff --check`

## Known unresolved risks
- No known unresolved implementation risk. `npm run lint:boundaries` still reports existing warnings only.