### PR TITLE
feat(interaction): define Codex-like interaction contract

### DIFF
--- a/docs/design/execution/codex-like-interaction-contract.golden.json
+++ b/docs/design/execution/codex-like-interaction-contract.golden.json
@@ -1,0 +1,405 @@
+{
+  "schema": "pulseed.codex_like_interaction_contract.v1",
+  "status": "target_contract",
+  "principles": [
+    "display_text_is_user_visible_projection",
+    "structured_state_is_host_owned_data",
+    "ordinary_freeform_text_is_not_preclassified",
+    "exact_protocol_surfaces_may_use_deterministic_parsers",
+    "model_visible_context_is_separate_from_host_only_state"
+  ],
+  "userInputKinds": [
+    "text",
+    "image",
+    "local_image",
+    "mention",
+    "skill",
+    "tool",
+    "attachment"
+  ],
+  "turnOperations": [
+    {
+      "kind": "TurnStart",
+      "when": "conversation_idle",
+      "requiredState": [
+        "new_turn_id",
+        "current_reply_target",
+        "current_cwd",
+        "current_session_state",
+        "current_tool_selection"
+      ]
+    },
+    {
+      "kind": "TurnSteer",
+      "when": "conversation_active",
+      "requiredState": [
+        "existing_turn_id",
+        "steer_input_id",
+        "active_run_id",
+        "active_target_snapshot"
+      ]
+    }
+  ],
+  "transcriptEvents": [
+    {
+      "type": "turn_start",
+      "displayText": "user input plus optional start or progress line",
+      "structuredState": [
+        "turn_id",
+        "input_id",
+        "reply_target",
+        "operation"
+      ]
+    },
+    {
+      "type": "turn_steer",
+      "displayText": "mid-turn user message",
+      "structuredState": [
+        "turn_id",
+        "steer_input_id",
+        "active_run_snapshot"
+      ]
+    },
+    {
+      "type": "assistant_delta",
+      "displayText": "incremental assistant text",
+      "structuredState": [
+        "turn_id",
+        "stream_offset"
+      ]
+    },
+    {
+      "type": "activity",
+      "displayText": "short commentary or checkpoint",
+      "structuredState": [
+        "activity_kind",
+        "source_id",
+        "transient"
+      ]
+    },
+    {
+      "type": "tool_call",
+      "displayText": "short tool start text when useful",
+      "structuredState": [
+        "tool_call_id",
+        "tool_name",
+        "redacted_args",
+        "approval_level"
+      ]
+    },
+    {
+      "type": "tool_observation",
+      "displayText": "concise result or observation summary",
+      "structuredState": [
+        "tool_result_id",
+        "success",
+        "duration_ms",
+        "artifact_refs"
+      ]
+    },
+    {
+      "type": "permission_prompt",
+      "displayText": "human-readable prompt rendered from a pending record",
+      "structuredState": [
+        "approval_id",
+        "action",
+        "target",
+        "risk",
+        "origin",
+        "expiry"
+      ]
+    },
+    {
+      "type": "clarification",
+      "displayText": "one clear question",
+      "structuredState": [
+        "clarification_id",
+        "missing_fields",
+        "answer_protocol"
+      ]
+    },
+    {
+      "type": "error_recovery",
+      "displayText": "error explanation and next safe step",
+      "structuredState": [
+        "error_code",
+        "stopped_reason",
+        "retryability",
+        "partial_output_refs"
+      ]
+    },
+    {
+      "type": "turn_complete",
+      "displayText": "final answer as display text",
+      "structuredState": [
+        "final_status",
+        "elapsed_ms",
+        "persisted_refs",
+        "usage_summary"
+      ]
+    }
+  ],
+  "permissionDecisionDomain": [
+    "approve",
+    "reject",
+    "clarify",
+    "unknown"
+  ],
+  "permissionMatching": [
+    "same_channel",
+    "same_conversation_or_thread",
+    "authorized_sender",
+    "current_session_or_turn",
+    "pending_unexpired_approval_id",
+    "sufficient_decision_confidence"
+  ],
+  "contextBoundary": {
+    "modelVisible": [
+      "cwd",
+      "current_date",
+      "timezone",
+      "session_title",
+      "selected_model",
+      "selected_model_visible_tools",
+      "active_turn_or_run_summary",
+      "safe_runtime_evidence",
+      "outstanding_user_facing_confirmation"
+    ],
+    "hostOnly": [
+      "raw_policy_internals",
+      "secret_values",
+      "local_credential_paths",
+      "unredacted_attachments",
+      "stale_route_caches",
+      "rejected_previous_turn_targets",
+      "internal_audit_records"
+    ]
+  },
+  "workflows": [
+    {
+      "id": "ordinary-chat-en",
+      "language": "en",
+      "surface": "chat",
+      "input": {
+        "operation": "TurnStart",
+        "items": [
+          {
+            "kind": "text",
+            "text": "What can you see from the current repo?"
+          }
+        ]
+      },
+      "displayTranscript": [
+        {
+          "role": "user",
+          "text": "What can you see from the current repo?"
+        },
+        {
+          "role": "assistant",
+          "text": "This repo is PulSeed. I can inspect local files and tests when you ask me to work on it."
+        }
+      ],
+      "structuredState": {
+        "final_output_mode": "display_text",
+        "structured_output": null
+      }
+    },
+    {
+      "id": "tool-progress-en",
+      "language": "en",
+      "surface": "chat",
+      "input": {
+        "operation": "TurnStart",
+        "items": [
+          {
+            "kind": "text",
+            "text": "Check the failing test and fix it."
+          }
+        ]
+      },
+      "displayTranscript": [
+        {
+          "role": "user",
+          "text": "Check the failing test and fix it."
+        },
+        {
+          "role": "assistant",
+          "text": "I am checking the focused test and the code path it exercises."
+        },
+        {
+          "role": "tool",
+          "text": "npm test -- src/interface/chat/__tests__/chat-runner.test.ts"
+        },
+        {
+          "role": "observation",
+          "text": "The focused test fails because the pending confirmation is reused after a new intent."
+        },
+        {
+          "role": "assistant",
+          "text": "I fixed the confirmation reset and added a two-turn regression test."
+        }
+      ],
+      "structuredState": {
+        "tool_call_id": "tool-call-1",
+        "tool_result_id": "tool-result-1",
+        "duration_ms": 1200,
+        "artifact_refs": [
+          "test-log:focused"
+        ]
+      }
+    },
+    {
+      "id": "permission-prompt-en",
+      "language": "en",
+      "surface": "tui",
+      "input": {
+        "operation": "TurnStart",
+        "items": [
+          {
+            "kind": "text",
+            "text": "Prepare the npm publish dry run."
+          }
+        ]
+      },
+      "displayTranscript": [
+        {
+          "role": "permission_prompt",
+          "text": "PulSeed wants to run `npm publish --dry-run` in this workspace. This can read package metadata and contact the registry. Approve, reject, or ask for details."
+        }
+      ],
+      "structuredState": {
+        "approval_id": "approval-123",
+        "turn_id": "turn-7",
+        "operation": "shell_command",
+        "target": "npm publish --dry-run",
+        "risk": "external_network",
+        "origin": {
+          "channel": "tui",
+          "conversation_id": "local",
+          "user_id": "owner"
+        },
+        "expires_at": "2026-05-06T07:30:00.000Z",
+        "reply_matching": {
+          "same_channel": true,
+          "same_conversation_or_thread": true,
+          "authorized_sender": "owner",
+          "current_session_or_turn": "turn-7",
+          "pending_unexpired_approval_id": "approval-123",
+          "minimum_decision_confidence": 0.7
+        },
+        "decision_domain": [
+          "approve",
+          "reject",
+          "clarify",
+          "unknown"
+        ]
+      }
+    },
+    {
+      "id": "mid-turn-steer-ja",
+      "language": "ja",
+      "surface": "tui",
+      "input": {
+        "operation": "TurnSteer",
+        "turn_id": "turn-active",
+        "items": [
+          {
+            "kind": "text",
+            "text": "そのテストだけじゃなくて TUI 側も見て"
+          }
+        ]
+      },
+      "displayTranscript": [
+        {
+          "role": "user",
+          "text": "そのテストだけじゃなくて TUI 側も見て"
+        }
+      ],
+      "structuredState": {
+        "target_resolution": "current_typed_state_plus_new_input",
+        "stale_target_reuse": "rejected"
+      }
+    },
+    {
+      "id": "clarification-ja",
+      "language": "ja",
+      "surface": "gateway",
+      "input": {
+        "operation": "TurnStart",
+        "items": [
+          {
+            "kind": "text",
+            "text": "PR の確認をして"
+          }
+        ]
+      },
+      "displayTranscript": [
+        {
+          "role": "assistant",
+          "text": "どの PR を対象にしますか。番号か URL で指定してください。"
+        }
+      ],
+      "structuredState": {
+        "clarification_id": "clarify-1",
+        "missing_fields": [
+          "pull_request_ref"
+        ],
+        "answer_protocol": "github_pr_ref"
+      }
+    },
+    {
+      "id": "stale-target-rejection-ja",
+      "language": "ja",
+      "surface": "gateway",
+      "input": {
+        "operation": "TurnStart",
+        "previous_completed_target": "run-A",
+        "items": [
+          {
+            "kind": "text",
+            "text": "最新の方を止めて"
+          }
+        ]
+      },
+      "displayTranscript": [
+        {
+          "role": "assistant",
+          "text": "現在の対象を特定できません。停止する run を指定してください。"
+        }
+      ],
+      "structuredState": {
+        "latest_resolution_source": "typed_current_runtime_state",
+        "previous_completed_target_reused": false,
+        "outcome": "clarification_required"
+      }
+    },
+    {
+      "id": "resume-en",
+      "language": "en",
+      "surface": "cli",
+      "input": {
+        "operation": "TurnStart",
+        "items": [
+          {
+            "kind": "text",
+            "text": "Resume the previous coding session."
+          }
+        ]
+      },
+      "displayTranscript": [
+        {
+          "role": "assistant",
+          "text": "I found a resumable session and restored its safe summary into the current turn context."
+        }
+      ],
+      "structuredState": {
+        "resume": {
+          "session_id": "session-42",
+          "source": "persisted_session_store",
+          "state_path": "host-only"
+        },
+        "stale_route_cache_reused": false
+      }
+    }
+  ]
+}

--- a/docs/design/execution/codex-like-interaction-contract.md
+++ b/docs/design/execution/codex-like-interaction-contract.md
@@ -1,0 +1,326 @@
+# Codex-Like User Interaction Contract
+
+Status: target contract for #1104 child issues
+
+This document defines the target interaction contract for PulSeed's
+Codex-like natural-language chat surfaces. It is an implementation-facing
+contract, not a claim that all behavior already exists. The golden fixture next
+to this document, `codex-like-interaction-contract.golden.json`, contains the
+same contract in a machine-checkable form for later production tests.
+
+## Goals
+
+- Ordinary chat, TUI chat, gateway messages, and CLI/chat ingress should submit
+  the same typed user input shape.
+- The transcript should be display-first: the user sees text, progress, tool
+  observations, permission prompts, clarification, recovery, and final answers.
+- Host state should stay structured: turn ids, run ids, tool calls, pending
+  permissions, current targets, selected tools, and replay metadata are data,
+  not prose hidden in the transcript.
+- Freeform user intent should reach the model/tool schema boundary as natural
+  language unless a deterministic protocol surface was used.
+
+## Non-Goals
+
+- This contract does not add new tool execution behavior.
+- This contract does not define exact command grammar beyond saying exact
+  protocol surfaces can remain deterministic.
+- This contract does not allow keyword lists, regex phrase tables, string
+  `includes`, title matching, or language-specific shortcuts to become the
+  primary decision mechanism for freeform semantic behavior.
+
+## Layers
+
+### UserInput
+
+Every surface creates a `UserInput` item list before route or model execution.
+The initial #1106 shape should support at least these item kinds:
+
+| Kind | Contents | Notes |
+| --- | --- | --- |
+| `text` | freeform user text | Preserve as ordinary text. Do not pre-classify natural language into runtime/edit/test/shell/approval intent. |
+| `image` | remote image URL plus optional label | Future-facing. Model-visible only if the selected model supports it. |
+| `local_image` | host path plus optional label | Host validates access; model receives safe attachment metadata/content only through the request builder. |
+| `mention` | structured target reference | Deterministic parsing is allowed for exact mention syntax. |
+| `skill` | structured skill reference | Deterministic parsing is allowed for exact skill syntax. |
+| `tool` | explicit tool reference | Deterministic parsing is allowed for exact tool ids. |
+| `attachment` | future file/blob reference | Host-owned access and redaction. |
+
+### Turn Operation
+
+The conversation owner converts user input into one of two operations:
+
+| Operation | When | Required state |
+| --- | --- | --- |
+| `TurnStart` | No active turn exists for the conversation/session. | New `turn_id`, current reply target, current cwd, current session state, current tool selection. |
+| `TurnSteer` | A turn is active and the input belongs to the same conversation/session. | Existing `turn_id`, steer input id, current reply target, active run id, active target snapshot. |
+
+Steering input must not re-use a stale previous-turn target. If the steer text
+introduces a new target or asks an ordinary side question, the active turn
+receives the text as steering context and any target decision is made from the
+current typed state plus the new input, not from a cached route.
+
+### TurnContext
+
+The request builder receives a first-class `TurnContext` assembled for this
+turn. It separates model-visible state from host-only state.
+
+Model-visible examples:
+
+- cwd, current date, timezone, session title, selected model, selected
+  model-visible tools, active turn/run summary, relevant AGENTS/user/developer
+  instructions, safe runtime evidence, outstanding user-facing confirmation.
+
+Host-only examples:
+
+- raw approval policy internals, secret values, local credential paths,
+  unredacted attachments, cross-user identity details not needed by the model,
+  stale route caches, rejected previous-turn targets, and internal audit
+  records.
+
+### Model Request
+
+Ordinary chat requests should combine conversation history, base instructions,
+`TurnContext`, and typed tool schemas. They should not ask for schema-shaped
+final JSON unless the caller explicitly requested structured output. Tool calls
+are structured at the tool boundary; final assistant text is display text.
+
+## Transcript Model
+
+The transcript is an ordered projection of structured events:
+
+| Event | Display text | Structured state |
+| --- | --- | --- |
+| `turn_start` | The user's text and optional start/progress line. | `turn_id`, `input_id`, `reply_target`, `operation=TurnStart`. |
+| `turn_steer` | The user's mid-turn message. | Existing `turn_id`, `steer_input_id`, active run snapshot. |
+| `assistant_delta` | Incremental assistant text. | Current `turn_id`, stream offsets. |
+| `activity` | Short commentary/checkpoint. | Activity kind, source id, transient flag. |
+| `tool_call` | Short tool start text when useful. | Tool call id, typed tool name, redacted args, approval level. |
+| `tool_observation` | Concise result/observation summary. | Tool result id, success/error, duration, artifact refs. |
+| `permission_prompt` | Human-readable prompt in the originating conversation. | Pending permission/approval record id, action, target, risk, expiry, origin. |
+| `clarification` | One clear question. | Clarification id, unknown field(s), allowed answer shape if deterministic. |
+| `error_recovery` | Error explanation and next safe step. | Error code, stopped reason, retryability, partial output refs. |
+| `turn_complete` | Final answer as display text. | Final status, elapsed time, persisted/replay refs, usage summary. |
+
+The display projection may be suppressed for noisy internal tool chatter, but
+the structured state remains available for replay, audit, and model context.
+
+## Permission Dialogue
+
+Permission prompts are rendered from a typed pending record, never improvised by
+the model. The visible prompt names the operation, target, risk, and possible
+outcomes. A reply resolves only the matching pending record.
+
+The structured decision domain is:
+
+- `approve`: execute only the matching pending record.
+- `reject`: do not execute and persist the denial.
+- `clarify`: keep the same pending record open and ask/answer about it.
+- `unknown`: fail closed or continue asking, depending on the owning policy.
+
+The approval resolver must verify channel, conversation/thread, sender,
+session/turn, `approval_id`, expiry, and confidence. Cross-channel replies,
+stale session replies, previous-turn approvals, and replies to already resolved
+records do not execute the action.
+
+## Clarification
+
+Clarification is a typed state, not a generic fallback string. A clarification
+must preserve:
+
+- what is missing or ambiguous,
+- what operation is paused,
+- the current turn/run ids,
+- whether the answer can be parsed deterministically,
+- and when the clarification expires or is superseded.
+
+Ordinary side questions during an active turn should be preserved as steering
+input. If they are not sufficient to resolve the active turn, the model can
+answer or ask a typed clarification without losing the active run context.
+
+## Resume And Stale Target Rules
+
+Resume creates or restores a current typed target from persisted state. It does
+not silently reuse the most recent route, approval, run, cwd, or reply target.
+
+Required stale rejection rules:
+
+- A current input without an explicit target must not inherit a previous turn's
+  target if the previous turn completed.
+- A steer input that introduces a different target must not be forced back onto
+  the old target by route cache.
+- A pending permission reply must match the pending record and origin; otherwise
+  it is `unknown` or invalid-context.
+- "latest", "current", and "active" are resolved from typed current state and
+  rejected when the state is absent or ambiguous.
+
+## Examples
+
+### Ordinary Chat, English
+
+User display:
+
+```text
+What can you see from the current repo?
+```
+
+Structured input:
+
+```json
+{
+  "operation": "TurnStart",
+  "input": { "items": [{ "kind": "text", "text": "What can you see from the current repo?" }] },
+  "route": { "kind": "model_request" }
+}
+```
+
+Assistant display:
+
+```text
+This repo is PulSeed. I can inspect local files and tests when you ask me to
+work on it.
+```
+
+Final state:
+
+```json
+{ "final_output_mode": "display_text", "structured_output": null }
+```
+
+### Tool Progress And Observation, English
+
+Display transcript:
+
+```text
+User: Check the failing test and fix it.
+Assistant: I am checking the focused test and the code path it exercises.
+Tool: npm test -- src/interface/chat/__tests__/chat-runner.test.ts
+Observation: The focused test fails because the pending confirmation is reused after a new intent.
+Assistant: I fixed the confirmation reset and added a two-turn regression test.
+```
+
+Structured state keeps `tool_call_id`, command args, duration, exit status,
+artifact refs, changed files, and verification commands separately from those
+display lines.
+
+### Permission Prompt, English
+
+Display prompt:
+
+```text
+PulSeed wants to run `npm publish --dry-run` in this workspace. This can read
+package metadata and contact the registry. Approve, reject, or ask for details.
+```
+
+Structured pending record:
+
+```json
+{
+  "approval_id": "approval-123",
+  "turn_id": "turn-7",
+  "operation": "shell_command",
+  "target": "npm publish --dry-run",
+  "risk": "external_network",
+  "origin": { "channel": "tui", "conversation_id": "local", "user_id": "owner" },
+  "expires_at": "2026-05-06T07:30:00.000Z",
+  "reply_matching": {
+    "same_channel": true,
+    "same_conversation_or_thread": true,
+    "authorized_sender": "owner",
+    "current_session_or_turn": "turn-7",
+    "pending_unexpired_approval_id": "approval-123"
+  },
+  "decision_domain": ["approve", "reject", "clarify", "unknown"]
+}
+```
+
+### Mid-Turn Steering, Japanese
+
+User display:
+
+```text
+そのテストだけじゃなくて TUI 側も見て
+```
+
+Structured operation:
+
+```json
+{
+  "operation": "TurnSteer",
+  "turn_id": "turn-active",
+  "input": { "items": [{ "kind": "text", "text": "そのテストだけじゃなくて TUI 側も見て" }] },
+  "target_resolution": "current_typed_state_plus_new_input"
+}
+```
+
+The text is not classified by Japanese phrase matching. It is preserved as
+steering context for the active model/tool turn.
+
+### Clarification, Japanese
+
+Assistant display:
+
+```text
+どの PR を対象にしますか。番号か URL で指定してください。
+```
+
+Structured state:
+
+```json
+{
+  "clarification_id": "clarify-1",
+  "missing_fields": ["pull_request_ref"],
+  "answer_protocol": "github_pr_ref"
+}
+```
+
+The answer protocol is deterministic because PR numbers and URLs are exact
+protocol surfaces.
+
+### Stale Target Rejection, Japanese
+
+If the previous turn targeted `run-A` and completed, this new user display:
+
+```text
+最新の方を止めて
+```
+
+must not silently reuse `run-A`. The host resolves "latest/current/active" from
+typed runtime state. If there is no unambiguous active run, the assistant asks a
+clarifying question or reports that no current target exists.
+
+### Resume, English
+
+User display:
+
+```text
+Resume the previous coding session.
+```
+
+Resume loads persisted session state and creates a current typed target:
+
+```json
+{
+  "operation": "TurnStart",
+  "resume": {
+    "session_id": "session-42",
+    "source": "persisted_session_store",
+    "state_path": "host-only"
+  }
+}
+```
+
+The model-visible context receives the safe summary, not raw host-only state
+paths or stale route caches.
+
+## Implementation Order
+
+1. #1106: introduce canonical `UserInput` and make TUI/non-TUI ingress produce
+   equivalent typed input without freeform pre-classification.
+2. #1107: introduce or unify `TurnStart` and `TurnSteer` so active work is
+   steered and idle input starts a new turn.
+3. #1108: assemble first-class `TurnContext` and separate model-visible from
+   host-only state.
+4. #1109: route ordinary chat model calls through a central request builder
+   that combines history, base instructions, `TurnContext`, and typed tool
+   schemas.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -34,3 +34,7 @@ Do not treat it as current guidance.
 
 Prefer the public docs before reading subsystem-specific design notes.
 The design index is a pointer into background material, not a replacement for the public documentation map.
+
+## Active Interaction Contracts
+
+- [Codex-Like User Interaction Contract](execution/codex-like-interaction-contract.md)

--- a/src/interface/chat/__tests__/codex-like-interaction-contract.test.ts
+++ b/src/interface/chat/__tests__/codex-like-interaction-contract.test.ts
@@ -1,0 +1,148 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+interface ContractWorkflow {
+  id: string;
+  language: "en" | "ja";
+  surface: string;
+  input: {
+    operation: "TurnStart" | "TurnSteer";
+    items: Array<{ kind: string; text?: string }>;
+  };
+  displayTranscript: Array<{ role: string; text: string }>;
+  structuredState: Record<string, unknown>;
+}
+
+interface InteractionContract {
+  schema: string;
+  principles: string[];
+  userInputKinds: string[];
+  turnOperations: Array<{ kind: string; when: string; requiredState: string[] }>;
+  transcriptEvents: Array<{ type: string; displayText: string; structuredState: string[] }>;
+  permissionDecisionDomain: string[];
+  permissionMatching: string[];
+  contextBoundary: { modelVisible: string[]; hostOnly: string[] };
+  workflows: ContractWorkflow[];
+}
+
+function loadContract(): InteractionContract {
+  const contractPath = path.join(
+    process.cwd(),
+    "docs/design/execution/codex-like-interaction-contract.golden.json",
+  );
+  return JSON.parse(fs.readFileSync(contractPath, "utf8")) as InteractionContract;
+}
+
+describe("Codex-like interaction contract golden fixture", () => {
+  const contract = loadContract();
+
+  it("declares display text and structured host state as separate layers", () => {
+    expect(contract.schema).toBe("pulseed.codex_like_interaction_contract.v1");
+    expect(contract.principles).toEqual(expect.arrayContaining([
+      "display_text_is_user_visible_projection",
+      "structured_state_is_host_owned_data",
+      "ordinary_freeform_text_is_not_preclassified",
+      "model_visible_context_is_separate_from_host_only_state",
+    ]));
+
+    for (const event of contract.transcriptEvents) {
+      expect(event.displayText.trim().length).toBeGreaterThan(0);
+      expect(event.structuredState.length).toBeGreaterThan(0);
+    }
+    expect(contract.contextBoundary.modelVisible).toContain("safe_runtime_evidence");
+    expect(contract.contextBoundary.hostOnly).toEqual(expect.arrayContaining([
+      "secret_values",
+      "stale_route_caches",
+      "internal_audit_records",
+    ]));
+  });
+
+  it("covers canonical input kinds, turn start, and turn steer", () => {
+    expect(contract.userInputKinds).toEqual(expect.arrayContaining([
+      "text",
+      "image",
+      "local_image",
+      "mention",
+      "skill",
+      "tool",
+      "attachment",
+    ]));
+
+    expect(contract.turnOperations.map((operation) => operation.kind)).toEqual([
+      "TurnStart",
+      "TurnSteer",
+    ]);
+    expect(contract.workflows.some((workflow) => workflow.input.operation === "TurnStart")).toBe(true);
+    expect(contract.workflows.some((workflow) => workflow.input.operation === "TurnSteer")).toBe(true);
+  });
+
+  it("includes the required end-to-end workflows in English and Japanese", () => {
+    const workflowIds = contract.workflows.map((workflow) => workflow.id);
+    expect(workflowIds).toEqual(expect.arrayContaining([
+      "ordinary-chat-en",
+      "tool-progress-en",
+      "permission-prompt-en",
+      "mid-turn-steer-ja",
+      "clarification-ja",
+      "stale-target-rejection-ja",
+      "resume-en",
+    ]));
+
+    expect(contract.workflows.some((workflow) => workflow.language === "en")).toBe(true);
+    expect(contract.workflows.some((workflow) => workflow.language === "ja")).toBe(true);
+  });
+
+  it("maps permission dialogue to a typed pending approval record", () => {
+    expect(contract.permissionDecisionDomain).toEqual([
+      "approve",
+      "reject",
+      "clarify",
+      "unknown",
+    ]);
+    expect(contract.permissionMatching).toEqual(expect.arrayContaining([
+      "same_channel",
+      "same_conversation_or_thread",
+      "authorized_sender",
+      "current_session_or_turn",
+      "pending_unexpired_approval_id",
+      "sufficient_decision_confidence",
+    ]));
+
+    const workflow = contract.workflows.find((entry) => entry.id === "permission-prompt-en");
+    expect(workflow?.displayTranscript[0]?.role).toBe("permission_prompt");
+    expect(workflow?.structuredState).toMatchObject({
+      approval_id: "approval-123",
+      operation: "shell_command",
+      expires_at: "2026-05-06T07:30:00.000Z",
+      origin: {
+        channel: "tui",
+        conversation_id: "local",
+        user_id: "owner",
+      },
+      reply_matching: {
+        same_channel: true,
+        same_conversation_or_thread: true,
+        authorized_sender: "owner",
+        current_session_or_turn: "turn-7",
+        pending_unexpired_approval_id: "approval-123",
+        minimum_decision_confidence: 0.7,
+      },
+      decision_domain: ["approve", "reject", "clarify", "unknown"],
+    });
+  });
+
+  it("documents stale target rejection and resume without leaking host-only state into display", () => {
+    const stale = contract.workflows.find((entry) => entry.id === "stale-target-rejection-ja");
+    expect(stale?.structuredState).toMatchObject({
+      previous_completed_target_reused: false,
+      outcome: "clarification_required",
+    });
+
+    const resume = contract.workflows.find((entry) => entry.id === "resume-en");
+    expect(resume?.structuredState).toMatchObject({
+      stale_route_cache_reused: false,
+    });
+    expect(JSON.stringify(resume?.displayTranscript)).not.toContain("state_path");
+  });
+});


### PR DESCRIPTION
Closes #1105

## Summary
- Add a checked-in Codex-like user interaction contract for ordinary chat, tool progress, observations, permission prompts, clarification, stale-target handling, resume, and Japanese/English workflows.
- Add a golden JSON fixture that separates display text from host-owned structured state.
- Add a fixture contract test and link the contract from the design index.

## Tests
- npm test -- src/interface/chat/__tests__/codex-like-interaction-contract.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known risks
- This is a target contract and golden fixture. Runtime behavior migration is intentionally left to #1106-#1109.