### PR TITLE
feat(protocol): introduce typed UserInput ingress

### DIFF
--- a/src/interface/chat/__tests__/chat-runner-gateway-runtime-control.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-gateway-runtime-control.test.ts
@@ -28,6 +28,7 @@ import { createRunSpecHandoffTools } from "../../../tools/runtime/RunSpecHandoff
 import { createSetupRuntimeControlTools } from "../../../tools/runtime/SetupRuntimeControlTools.js";
 import type { ApprovalRequest, ToolCallContext } from "../../../tools/types.js";
 import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
+import { createTextUserInput } from "../user-input.js";
 // Mock context-provider so tests don't walk the real filesystem
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -65,6 +66,7 @@ function makeIngress(text: string): ChatIngressMessage {
     conversation_id: "chat-1",
     message_id: "message-1",
     text,
+    userInput: createTextUserInput(text),
     actor: {
       surface: "gateway",
       identity_key: "telegram:user-1",

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -28,6 +28,7 @@ import { createRunSpecHandoffTools } from "../../../tools/runtime/RunSpecHandoff
 import { createSetupRuntimeControlTools } from "../../../tools/runtime/SetupRuntimeControlTools.js";
 import type { ApprovalRequest, ToolCallContext } from "../../../tools/types.js";
 import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
+import { createTextUserInput } from "../user-input.js";
 // Mock context-provider so tests don't walk the real filesystem
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -65,6 +66,7 @@ function makeIngress(text: string): ChatIngressMessage {
     conversation_id: "chat-1",
     message_id: "message-1",
     text,
+    userInput: createTextUserInput(text),
     actor: {
       surface: "gateway",
       identity_key: "telegram:user-1",
@@ -3731,6 +3733,7 @@ describe("ChatRunner", () => {
 
       const result = await runner.executeIngressMessage({
         text: "PulSeed を再起動して",
+        userInput: createTextUserInput("PulSeed を再起動して"),
         channel: "tui",
         platform: "local_tui",
         actor: {

--- a/src/interface/chat/__tests__/ingress-router.test.ts
+++ b/src/interface/chat/__tests__/ingress-router.test.ts
@@ -1,9 +1,22 @@
 import { describe, expect, it } from "vitest";
 import { IngressRouter, buildStandaloneIngressMessage } from "../ingress-router.js";
+import { createTextUserInput } from "../user-input.js";
 import type { RunSpec } from "../../../runtime/run-spec/index.js";
 
 describe("IngressRouter", () => {
   const router = new IngressRouter();
+
+  it("normalizes ordinary natural language into canonical UserInput text items", () => {
+    const message = buildStandaloneIngressMessage({
+      text: "今の作業フォルダを確認して",
+      channel: "plugin_gateway",
+      platform: "slack",
+    });
+
+    expect(message.userInput).toEqual(createTextUserInput("今の作業フォルダを確認して"));
+    expect(message.userInput).not.toHaveProperty("intent");
+    expect(message.userInput).not.toHaveProperty("route");
+  });
 
   it("routes ordinary natural-language input to agent_loop when available", () => {
     const route = router.selectRoute(

--- a/src/interface/chat/__tests__/user-input.test.ts
+++ b/src/interface/chat/__tests__/user-input.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  USER_INPUT_SCHEMA_VERSION,
+  createTextUserInput,
+  getUserInputText,
+  normalizeUserInput,
+  replaceUserInputText,
+  type UserInput,
+} from "../user-input.js";
+
+describe("UserInput contract", () => {
+  it("preserves ordinary freeform text as a text item without semantic pre-classification", () => {
+    const input = createTextUserInput("Can you look at the current repo?");
+
+    expect(input).toEqual({
+      schema_version: USER_INPUT_SCHEMA_VERSION,
+      items: [{ kind: "text", text: "Can you look at the current repo?" }],
+      rawText: "Can you look at the current repo?",
+    });
+    expect(input).not.toHaveProperty("intent");
+    expect(input).not.toHaveProperty("route");
+  });
+
+  it("keeps multilingual paraphrases as equivalent text input shape", () => {
+    const english = createTextUserInput("Please inspect the current workspace.");
+    const japanese = createTextUserInput("今の作業フォルダを確認して");
+
+    expect(english.items[0]?.kind).toBe("text");
+    expect(japanese.items[0]?.kind).toBe("text");
+    expect(Object.keys(english).sort()).toEqual(Object.keys(japanese).sort());
+  });
+
+  it("normalizes explicit structured items without deriving freeform intent", () => {
+    const explicit: UserInput = {
+      schema_version: USER_INPUT_SCHEMA_VERSION,
+      rawText: "check this",
+      items: [
+        { kind: "text", text: "check this" },
+        { kind: "mention", target: "session:conversation:abc", label: "current chat" },
+        { kind: "local_image", path: "/tmp/screenshot.png", name: "screenshot" },
+      ],
+    };
+
+    const normalized = normalizeUserInput(explicit, "fallback");
+
+    expect(normalized.items).toEqual(explicit.items);
+    expect(getUserInputText(normalized)).toBe("check this");
+    expect(normalized).not.toHaveProperty("runtimeControlIntent");
+  });
+
+  it("redacts text items while preserving non-text structured items", () => {
+    const input: UserInput = {
+      schema_version: USER_INPUT_SCHEMA_VERSION,
+      rawText: "token secret",
+      items: [
+        { kind: "text", text: "token secret" },
+        { kind: "tool", name: "http_fetch", id: "tool-http-fetch" },
+      ],
+    };
+
+    expect(replaceUserInputText(input, "token [redacted]")).toEqual({
+      schema_version: USER_INPUT_SCHEMA_VERSION,
+      rawText: "token [redacted]",
+      items: [
+        { kind: "text", text: "token [redacted]" },
+        { kind: "tool", name: "http_fetch", id: "tool-http-fetch" },
+      ],
+    });
+  });
+});

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -2,6 +2,7 @@ import type { FailureRecoveryGuidance } from "./failure-recovery.js";
 import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
 import type { TurnLanguageHint } from "./turn-language.js";
 import type { OperationProgressItem } from "./operation-progress.js";
+import type { UserInput } from "./user-input.js";
 
 export interface ChatEventBase {
   runId: string;
@@ -13,6 +14,7 @@ export interface ChatEventBase {
 export interface LifecycleStartEvent extends ChatEventBase {
   type: "lifecycle_start";
   input: string;
+  userInput: UserInput;
 }
 
 export interface AssistantDeltaEvent extends ChatEventBase {

--- a/src/interface/chat/chat-runner-contracts.ts
+++ b/src/interface/chat/chat-runner-contracts.ts
@@ -25,6 +25,7 @@ import type { RunSpecConfirmationState } from "./chat-history.js";
 import type { ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 import type { ChatHistory } from "./chat-history.js";
 import type { EventSubscriber } from "./event-subscriber.js";
+import type { UserInput } from "./user-input.js";
 
 export type ChatRunnerTelegramSetupState = "unconfigured" | "partially_configured" | "configured";
 
@@ -104,6 +105,7 @@ export interface ChatRunnerExecutionOptions {
   selectedRoute?: SelectedChatRoute;
   runtimeControlContext?: RuntimeControlChatContext | null;
   goalId?: string;
+  userInput?: UserInput;
 }
 
 export interface PendingTendState {

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -30,6 +30,7 @@ import {
   operationProgressFromAgentActivitySummary,
   type OperationProgressItem,
 } from "./operation-progress.js";
+import { createTextUserInput } from "./user-input.js";
 
 export interface AssistantBuffer {
   text: string;
@@ -118,6 +119,7 @@ export class ChatRunnerEventBridge {
     this.emitEvent({
       type: "lifecycle_start",
       input,
+      userInput: createTextUserInput(input),
       ...this.eventBase(context),
     });
     this.emitEvent({

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -73,6 +73,7 @@ import {
 } from "./chat-runner-routes.js";
 import { classifyFreeformRouteIntent } from "./freeform-route-classifier.js";
 import { deriveRunSpecFromText } from "../../runtime/run-spec/index.js";
+import { createTextUserInput, replaceUserInputText } from "./user-input.js";
 import {
   createRunSpecStore,
   formatRunSpecSetupProposal,
@@ -326,6 +327,7 @@ export class ChatRunner {
       selectedRoute,
       runtimeControlContext,
       goalId: ingress.goal_id,
+      userInput: ingress.userInput,
     });
   }
 
@@ -343,6 +345,9 @@ export class ChatRunner {
     const setupSecretIntake = intakeSetupSecrets(input);
     this.setupSecretIntake = setupSecretIntake;
     const safeInput = setupSecretIntake.redactedText;
+    const safeUserInput = options.userInput
+      ? replaceUserInputText(options.userInput, safeInput)
+      : createTextUserInput(safeInput);
     this.turnLanguageHint = detectTurnLanguageHint(safeInput);
     eventContext.languageHint = this.turnLanguageHint;
     const persistedSecretIntake = setupSecretIntake.suppliedSecrets.map(({ value: _value, ...metadata }) => metadata);
@@ -415,6 +420,7 @@ export class ChatRunner {
     this.eventBridge.emitEvent({
       type: "lifecycle_start",
       input: safeInput,
+      userInput: safeUserInput,
       ...this.eventBridge.eventBase(eventContext),
     });
 

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -61,6 +61,7 @@ import type {
   ConversationInputModality,
   ConversationOutputMode,
 } from "../../runtime/types/companion.js";
+import { normalizeUserInput, type UserInput } from "./user-input.js";
 
 export interface CrossPlatformChatSessionOptions {
   /**
@@ -105,10 +106,13 @@ export interface CrossPlatformChatSessionOptions {
   metadata?: Record<string, unknown>;
   /** Optional streaming callback for ChatEvent updates. */
   onEvent?: ChatEventHandler;
+  /** Canonical typed user input. If omitted, text is preserved as one text item. */
+  userInput?: UserInput;
 }
 
 export interface CrossPlatformIncomingChatMessage {
   text: string;
+  userInput?: UserInput;
   channel?: ChatIngressChannel;
   identity_key?: string;
   platform?: string;
@@ -397,6 +401,7 @@ export class CrossPlatformChatSessionManager {
         ...(options.runtimeControl ? { runtime_control_explicit: true } : {}),
       },
       onEvent: options.onEvent,
+      userInput: options.userInput,
     });
     const approvalReply = await this.tryResolveConversationalApprovalReply(ingress);
     if (approvalReply) {
@@ -614,6 +619,7 @@ export class CrossPlatformChatSessionManager {
       ...(goalId ? { goal_id: goalId } : {}),
       ...(userId ? { user_id: userId } : {}),
       text: input.text,
+      userInput: normalizeUserInput(input.userInput, input.text),
       actor: normalizeActor(channel, {
         platform,
         conversation_id: conversationId,

--- a/src/interface/chat/ingress-router.ts
+++ b/src/interface/chat/ingress-router.ts
@@ -4,6 +4,7 @@ import type { RuntimeControlIntent } from "../../runtime/control/index.js";
 import type { FreeformRouteIntent } from "./freeform-route-classifier.js";
 import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
 import type { RunSpec } from "../../runtime/run-spec/index.js";
+import { normalizeUserInput, type UserInput } from "./user-input.js";
 import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
@@ -42,6 +43,7 @@ export interface ChatIngressMessage {
   user_id?: string;
   user_name?: string;
   text: string;
+  userInput: UserInput;
   actor: RuntimeControlActor;
   runtimeControl: ChatIngressRuntimeControl;
   companion?: CompanionRuntimeContract;
@@ -318,6 +320,7 @@ function inferActorSurface(channel: IngressChannel): RuntimeControlActor["surfac
 
 export interface NormalizeLegacyIngressInput {
   text: string;
+  userInput?: UserInput;
   channel?: IngressChannel;
   ingress_id?: string;
   received_at?: string;
@@ -357,6 +360,7 @@ export function normalizeLegacyIngressInput(input: NormalizeLegacyIngressInput):
     ...(input.metadata ?? {}),
     ...(goalId ? { goal_id: goalId } : {}),
   };
+  const userInput = normalizeUserInput(input.userInput, input.text);
   const preapproved = input.runtimeControl?.approvalMode === "preapproved"
     || input.runtimeControl?.approval_mode === "preapproved"
     || metadata["runtime_control_approved"] === true;
@@ -398,6 +402,7 @@ export function normalizeLegacyIngressInput(input: NormalizeLegacyIngressInput):
     ...(userId ? { user_id: userId } : {}),
     ...(input.user_name ? { user_name: input.user_name } : {}),
     text: input.text,
+    userInput,
     actor,
     runtimeControl: {
       allowed,

--- a/src/interface/chat/user-input.ts
+++ b/src/interface/chat/user-input.ts
@@ -1,0 +1,74 @@
+export const USER_INPUT_SCHEMA_VERSION = "user-input-v1" as const;
+
+export type UserInputItem =
+  | { kind: "text"; text: string }
+  | { kind: "image"; url: string; name?: string; metadata?: Record<string, unknown> }
+  | { kind: "local_image"; path: string; name?: string; metadata?: Record<string, unknown> }
+  | { kind: "mention"; target: string; label?: string; metadata?: Record<string, unknown> }
+  | { kind: "skill"; name: string; path?: string; metadata?: Record<string, unknown> }
+  | { kind: "plugin"; name: string; id?: string; metadata?: Record<string, unknown> }
+  | { kind: "tool"; name: string; id?: string; metadata?: Record<string, unknown> }
+  | { kind: "attachment"; id: string; name?: string; mimeType?: string; path?: string; url?: string; metadata?: Record<string, unknown> };
+
+export interface UserInput {
+  schema_version: typeof USER_INPUT_SCHEMA_VERSION;
+  items: UserInputItem[];
+  rawText?: string;
+  metadata?: Record<string, unknown>;
+}
+
+function cloneItem(item: UserInputItem): UserInputItem {
+  return {
+    ...item,
+    ...("metadata" in item && item.metadata ? { metadata: { ...item.metadata } } : {}),
+  } as UserInputItem;
+}
+
+export function createTextUserInput(text: string, metadata?: Record<string, unknown>): UserInput {
+  return {
+    schema_version: USER_INPUT_SCHEMA_VERSION,
+    items: [{ kind: "text", text }],
+    rawText: text,
+    ...(metadata ? { metadata: { ...metadata } } : {}),
+  };
+}
+
+export function cloneUserInput(input: UserInput): UserInput {
+  return {
+    schema_version: USER_INPUT_SCHEMA_VERSION,
+    items: input.items.map(cloneItem),
+    ...(input.rawText !== undefined ? { rawText: input.rawText } : {}),
+    ...(input.metadata ? { metadata: { ...input.metadata } } : {}),
+  };
+}
+
+export function normalizeUserInput(input: UserInput | undefined, fallbackText: string): UserInput {
+  if (!input) {
+    return createTextUserInput(fallbackText);
+  }
+  return {
+    schema_version: USER_INPUT_SCHEMA_VERSION,
+    items: input.items.length > 0 ? input.items.map(cloneItem) : [{ kind: "text", text: fallbackText }],
+    rawText: input.rawText ?? fallbackText,
+    ...(input.metadata ? { metadata: { ...input.metadata } } : {}),
+  };
+}
+
+export function replaceUserInputText(input: UserInput, text: string): UserInput {
+  const normalized = normalizeUserInput(input, text);
+  return {
+    ...normalized,
+    rawText: text,
+    items: normalized.items.map((item) => item.kind === "text" ? { ...item, text } : cloneItem(item)),
+  };
+}
+
+export function getUserInputText(input: UserInput): string {
+  const textItems = input.items
+    .filter((item): item is Extract<UserInputItem, { kind: "text" }> => item.kind === "text")
+    .map((item) => item.text);
+  if (textItems.length > 0) {
+    return textItems.join("\n");
+  }
+  return input.rawText ?? "";
+}

--- a/src/interface/tui/__tests__/chat-surface.test.ts
+++ b/src/interface/tui/__tests__/chat-surface.test.ts
@@ -2,6 +2,9 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter, AgentResult } from "../../../orchestrator/execution/adapter-layer.js";
 import type { ChatRunnerDeps } from "../../chat/chat-runner.js";
+import type { ChatEvent } from "../../chat/chat-events.js";
+import { CrossPlatformChatSessionManager } from "../../chat/cross-platform-session.js";
+import { createTextUserInput } from "../../chat/user-input.js";
 import { SharedManagerTuiChatSurface } from "../chat-surface.js";
 import { createMockLLMClient, createSingleMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
@@ -67,6 +70,7 @@ describe("SharedManagerTuiChatSurface", () => {
 
     await surface.executeIngressMessage({
       text: "first",
+      userInput: createTextUserInput("first"),
       channel: "tui",
       platform: "local_tui",
       actor: { surface: "tui", platform: "local_tui" },
@@ -77,6 +81,7 @@ describe("SharedManagerTuiChatSurface", () => {
 
     await surface.executeIngressMessage({
       text: "second",
+      userInput: createTextUserInput("second"),
       channel: "tui",
       platform: "local_tui",
       actor: { surface: "tui", platform: "local_tui" },
@@ -200,5 +205,35 @@ describe("SharedManagerTuiChatSurface", () => {
         conversation_id: surface.getConversationId(),
       }),
     });
+  });
+
+  it("emits equivalent typed UserInput for TUI and non-TUI ingress", async () => {
+    const text = "Please inspect the current workspace.";
+    const tuiEvents: ChatEvent[] = [];
+    const gatewayEvents: ChatEvent[] = [];
+    const surface = new SharedManagerTuiChatSurface(makeDeps());
+    surface.onEvent = (event) => {
+      tuiEvents.push(event);
+    };
+    surface.startSession("/repo");
+    const manager = new CrossPlatformChatSessionManager(makeDeps());
+
+    await surface.execute(text, "/repo");
+    await manager.execute(text, {
+      channel: "plugin_gateway",
+      platform: "slack",
+      conversation_id: "slack-thread-1",
+      user_id: "user-1",
+      message_id: "msg-1",
+      onEvent: (event) => {
+        gatewayEvents.push(event);
+      },
+    });
+
+    const tuiStart = tuiEvents.find((event) => event.type === "lifecycle_start");
+    const gatewayStart = gatewayEvents.find((event) => event.type === "lifecycle_start");
+    expect(tuiStart?.userInput).toEqual(createTextUserInput(text));
+    expect(gatewayStart?.userInput).toEqual(createTextUserInput(text));
+    expect(gatewayStart?.userInput).toEqual(tuiStart?.userInput);
   });
 	});

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -55,6 +55,7 @@ import {
   type RunSpec,
 } from "../../runtime/run-spec/index.js";
 import { answerRuntimeEvidenceQuestion } from "../../runtime/evidence-answer.js";
+import { createTextUserInput } from "../chat/user-input.js";
 
 const MAX_MESSAGES = 200;
 const PULSEED_VERSION = getPulseedVersion(import.meta.url);
@@ -176,6 +177,7 @@ function buildRunSpecIngress(input: string, spec: RunSpec, effectiveCwd: string)
     channel: "tui" as const,
     platform: "local_tui",
     text: input,
+    userInput: createTextUserInput(input),
     actor: {
       surface: "tui" as const,
       platform: "local_tui",

--- a/src/runtime/gateway/chat-session-dispatch.ts
+++ b/src/runtime/gateway/chat-session-dispatch.ts
@@ -14,6 +14,7 @@ export async function dispatchGatewayChatInput(
     const port = await portGetter();
     const result = await port.processIncomingMessage({
       text: input.text,
+      userInput: input.userInput,
       platform: input.platform,
       identity_key: input.identity_key,
       conversation_id: input.conversation_id,

--- a/src/runtime/gateway/chat-session-port.ts
+++ b/src/runtime/gateway/chat-session-port.ts
@@ -1,7 +1,10 @@
+import type { UserInput } from "../../interface/chat/user-input.js";
+
 export type GatewayChatEventHandler = <T extends { type?: unknown; text?: unknown }>(event: T) => void | Promise<void>;
 
 export interface GatewayChatDispatchInput {
   text: string;
+  userInput?: UserInput;
   platform: string;
   identity_key?: string;
   conversation_id: string;


### PR DESCRIPTION
Closes #1106

## Summary
- Add a canonical UserInput item contract for chat ingress while retaining text as a compatibility field.
- Thread typed user input through ChatIngressMessage, cross-platform/gateway dispatch, TUI RunSpec ingress, ChatRunner execution, and lifecycle_start events.
- Add TUI and non-TUI caller-path coverage proving ordinary freeform text produces the same typed input shape without semantic pre-classification.

## Tests
- npm test -- src/interface/chat/__tests__/user-input.test.ts src/interface/chat/__tests__/ingress-router.test.ts
- npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/chat-surface.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known risks
- Route selection still consumes the compatibility text field until #1107-#1109 move more turn/model behavior to typed operations and request construction.