### PR TITLE
feat(turns): add typed turn start and steer

### DIFF
--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1326,6 +1326,45 @@ describe("ChatRunner", () => {
       expect(adapter.execute).toHaveBeenCalledOnce();
     });
 
+    it("emits a typed TurnStart operation for idle user input", async () => {
+      const adapter = makeMockAdapter();
+      const events: ChatEvent[] = [];
+      const runner = new ChatRunner(makeDeps({
+        adapter,
+        onEvent: (event) => {
+          events.push(event);
+        },
+      }));
+      runner.startSession("/repo");
+
+      const result = await runner.execute("ordinary chat", "/repo");
+
+      expect(result.success).toBe(true);
+      const start = events.find((event): event is Extract<ChatEvent, { type: "lifecycle_start" }> =>
+        event.type === "lifecycle_start"
+      );
+      expect(start).toBeDefined();
+      expect(start?.operation.kind).toBe("TurnStart");
+      if (start?.operation.kind !== "TurnStart") {
+        throw new Error("expected TurnStart operation");
+      }
+      expect(start?.operation).toMatchObject({
+        kind: "TurnStart",
+        runId: start?.runId,
+        turnId: start?.turnId,
+        cwd: "/repo",
+        userInput: {
+          schema_version: "user-input-v1",
+          rawText: "ordinary chat",
+          items: [{
+            kind: "text",
+            text: "ordinary chat",
+          }],
+        },
+      });
+      expect(start.operation.inputId).toEqual(expect.any(String));
+    });
+
     it("clears the active turn when an adapter turn times out", async () => {
       const adapter = {
         adapterType: "mock",
@@ -3221,21 +3260,60 @@ describe("ChatRunner", () => {
           });
         }),
       } as unknown as ChatAgentLoopRunner;
+      const events: ChatEvent[] = [];
       const runner = new ChatRunner(makeDeps({
         stateManager: makeMockStateManager(),
         chatAgentLoopRunner,
+        onEvent: (event) => {
+          events.push(event);
+        },
       }));
       runner.startSession("/repo");
 
       const active = runner.execute("Implement a feature", "/repo");
       await vi.waitFor(() => expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce());
 
-      const interrupted = await runner.interruptAndRedirect("stop and summarize", "/repo");
+      const interrupted = await runner.interruptAndRedirect(
+        "stop and summarize",
+        "/stale-repo",
+        30_000,
+        { userInput: createTextUserInput("stop and summarize") },
+      );
 
       expect(capturedSignal?.aborted).toBe(true);
       expect(interrupted.success).toBe(true);
       expect(interrupted.output).toContain("Interrupted the active turn");
       expect(interrupted.output).toContain("Activity before interruption");
+      const steer = events.find((event): event is Extract<ChatEvent, { type: "turn_steer" }> =>
+        event.type === "turn_steer"
+      );
+      expect(steer).toBeDefined();
+      expect(steer?.operation).toMatchObject({
+        kind: "TurnSteer",
+        runId: steer?.runId,
+        turnId: steer?.turnId,
+        activeTurn: {
+          cwd: "/repo",
+        },
+        userInput: {
+          schema_version: "user-input-v1",
+          rawText: "stop and summarize",
+          items: [{
+            kind: "text",
+            text: "stop and summarize",
+          }],
+        },
+      });
+      expect(steer?.operation.steerInputId).toEqual(expect.any(String));
+      const steerLifecycleStart = events.find((event): event is Extract<ChatEvent, { type: "lifecycle_start" }> =>
+        event.type === "lifecycle_start" && event.operation.kind === "TurnSteer"
+      );
+      expect(steerLifecycleStart?.operation).toMatchObject({
+        kind: "TurnSteer",
+        steerInputId: steer?.operation.steerInputId,
+      });
+      expect(steerLifecycleStart?.runId).toBe(steer?.operation.runId);
+      expect(steerLifecycleStart?.turnId).toBe(steer?.operation.turnId);
       await active;
     });
 

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -11,7 +11,8 @@ import { createMockLLMClient, createSingleMockLLMClient } from "../../../../test
 import { makeTempDir, cleanupTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { StateManager as RealStateManager } from "../../../base/state/state-manager.js";
 import { createSetupRuntimeControlTools } from "../../../tools/runtime/SetupRuntimeControlTools.js";
-import type { ToolCallContext } from "../../../tools/types.js";
+import type { ApprovalRequest, ToolCallContext } from "../../../tools/types.js";
+import type { ChatEvent } from "../chat-events.js";
 
 vi.mock("../../../platform/observation/context-provider.js", () => ({
   resolveGitRoot: (cwd: string) => cwd,
@@ -62,6 +63,10 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
     resolve = innerResolve;
   });
   return { promise, resolve };
+}
+
+function interruptDecision(kind: "diff" | "review" | "summary" | "background" | "redirect" | "unknown", confidence = 0.93): string {
+  return JSON.stringify({ kind, confidence, rationale: `test ${kind}` });
 }
 
 function runSpecFreeformDecision(): string {
@@ -462,6 +467,188 @@ describe("CrossPlatformChatSessionManager", () => {
     finalDelivery.resolve();
     await expect(run).resolves.toBe("Task completed successfully.");
     expect(finalDelivered).toBe(true);
+  });
+
+  it("steers active gateway input without starting a second agent-loop turn or reusing a stale reply target", async () => {
+    let resolveActive: ((value: AgentResult) => void) | undefined;
+    const chatAgentLoopRunner = {
+      execute: vi.fn().mockImplementation((input: { abortSignal?: AbortSignal }) => {
+        return new Promise<AgentResult>((resolve) => {
+          resolveActive = resolve;
+          input.abortSignal?.addEventListener("abort", () => {
+            resolve({
+              success: false,
+              output: "cancelled",
+              error: "cancelled",
+              exit_code: null,
+              elapsed_ms: 10,
+              stopped_reason: "error",
+            });
+          }, { once: true });
+        });
+      }),
+    };
+    const events: ChatEvent[] = [];
+    const manager = new CrossPlatformChatSessionManager(makeDeps({
+      stateManager: makeMockStateManager(),
+      chatAgentLoopRunner: chatAgentLoopRunner as never,
+    }));
+
+    const active = manager.execute("Implement a feature", {
+      identity_key: "shared-user",
+      platform: "slack",
+      conversation_id: "stale-thread",
+      user_id: "U123",
+      message_id: "stale-message",
+      cwd: "/repo",
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+    await vi.waitFor(() => expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce());
+
+    const steered = await manager.execute("このターンを止めて要約して", {
+      identity_key: "shared-user",
+      platform: "slack",
+      conversation_id: "current-thread",
+      user_id: "U123",
+      message_id: "current-message",
+      cwd: "/stale-cwd",
+      onEvent: (event) => {
+        events.push(event);
+      },
+    });
+
+    expect(steered.success).toBe(true);
+    expect(steered.output).toContain("Interrupted the active turn");
+    expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
+    const steer = events.find((event): event is Extract<ChatEvent, { type: "turn_steer" }> =>
+      event.type === "turn_steer"
+    );
+    expect(steer).toBeDefined();
+    expect(steer?.operation).toMatchObject({
+      kind: "TurnSteer",
+      activeTurn: {
+        cwd: "/repo",
+      },
+      userInput: {
+        schema_version: "user-input-v1",
+        rawText: "このターンを止めて要約して",
+        items: [{
+          kind: "text",
+          text: "このターンを止めて要約して",
+        }],
+      },
+    });
+    const info = manager.getSessionInfo({ identity_key: "shared-user" });
+    expect(info?.last_message_id).toBe("current-message");
+    expect(info?.active_reply_target).toMatchObject({
+      platform: "slack",
+      conversation_id: "current-thread",
+      identity_key: "shared-user",
+      user_id: "U123",
+    });
+
+    resolveActive?.(CANNED_RESULT);
+    await active;
+  });
+
+  it("uses the current steer handler for approvals while the active turn keeps running", async () => {
+    const tmpDir = makeTempDir();
+    try {
+      let capturedApprovalFn: ((request: ApprovalRequest) => Promise<boolean>) | undefined;
+      let resolveActive: ((value: AgentResult) => void) | undefined;
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockImplementation((input: {
+          approvalFn?: (request: ApprovalRequest) => Promise<boolean>;
+        }) => {
+          capturedApprovalFn = input.approvalFn;
+          return new Promise<AgentResult>((resolve) => {
+            resolveActive = resolve;
+          });
+        }),
+      };
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "approval-steer-current",
+      });
+      const staleEvents: ChatEvent[] = [];
+      const currentEvents: ChatEvent[] = [];
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager: makeMockStateManager(),
+        chatAgentLoopRunner: chatAgentLoopRunner as never,
+        llmClient: createMockLLMClient([interruptDecision("background")]),
+        approvalBroker,
+      }));
+
+      const active = manager.execute("Implement a feature", {
+        identity_key: "shared-user",
+        platform: "slack",
+        conversation_id: "stale-thread",
+        user_id: "U123",
+        message_id: "stale-message",
+        cwd: "/repo",
+        onEvent: (event) => {
+          staleEvents.push(event);
+        },
+      });
+      await vi.waitFor(() => expect(capturedApprovalFn).toBeDefined());
+
+      const redirected = await manager.execute("continúa esto en segundo plano", {
+        identity_key: "shared-user",
+        platform: "slack",
+        conversation_id: "current-thread",
+        user_id: "U123",
+        message_id: "current-message",
+        cwd: "/repo",
+        onEvent: (event) => {
+          currentEvents.push(event);
+        },
+      });
+
+      expect(redirected.success).toBe(true);
+      expect(redirected.output).toContain("background is not available yet");
+      const approval = capturedApprovalFn!({
+        toolName: "edit",
+        input: {},
+        reason: "Needs current approval.",
+        permissionLevel: "write_local",
+        isDestructive: false,
+        reversibility: "reversible",
+      });
+
+      await vi.waitFor(() => {
+        expect(currentEvents.some((event) =>
+          event.type === "activity"
+          && event.message.includes("Approval ID: approval-steer-current")
+        )).toBe(true);
+      });
+      expect(staleEvents.some((event) =>
+        event.type === "activity"
+        && event.message.includes("Approval ID: approval-steer-current")
+      )).toBe(false);
+
+      await expect(manager.processIncomingMessage({
+        text: "",
+        platform: "slack",
+        identity_key: "shared-user",
+        conversation_id: "current-thread",
+        sender_id: "U123",
+        message_id: "current-message",
+        cwd: "/repo",
+        approvalResponse: {
+          approval_id: "approval-steer-current",
+          approved: true,
+        },
+      })).resolves.toBe("Approval response recorded.");
+      await expect(approval).resolves.toBe(true);
+
+      resolveActive?.(CANNED_RESULT);
+      await active;
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
   });
 
   it("isolates async event delivery failures and still returns the chat result", async () => {

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -3,6 +3,7 @@ import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/
 import type { TurnLanguageHint } from "./turn-language.js";
 import type { OperationProgressItem } from "./operation-progress.js";
 import type { UserInput } from "./user-input.js";
+import type { TurnOperation, TurnSteerOperation } from "./turn-protocol.js";
 
 export interface ChatEventBase {
   runId: string;
@@ -15,6 +16,14 @@ export interface LifecycleStartEvent extends ChatEventBase {
   type: "lifecycle_start";
   input: string;
   userInput: UserInput;
+  operation: TurnOperation;
+}
+
+export interface TurnSteerEvent extends ChatEventBase {
+  type: "turn_steer";
+  input: string;
+  userInput: UserInput;
+  operation: TurnSteerOperation;
 }
 
 export interface AssistantDeltaEvent extends ChatEventBase {
@@ -99,6 +108,7 @@ export interface LifecycleErrorEvent extends ChatEventBase {
 
 export type ChatEvent =
   | LifecycleStartEvent
+  | TurnSteerEvent
   | AssistantDeltaEvent
   | AssistantFinalEvent
   | ActivityEvent

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -30,7 +30,8 @@ import {
   operationProgressFromAgentActivitySummary,
   type OperationProgressItem,
 } from "./operation-progress.js";
-import { createTextUserInput } from "./user-input.js";
+import { createTextUserInput, type UserInput } from "./user-input.js";
+import { createTurnStartOperation, type TurnOperation } from "./turn-protocol.js";
 
 export interface AssistantBuffer {
   text: string;
@@ -110,16 +111,36 @@ export class ChatRunnerEventBridge {
     ]);
   }
 
-  emitEphemeralAssistantResult(input: string, output: string, success: boolean, start: number): {
+  emitEphemeralAssistantResult(
+    input: string,
+    output: string,
+    success: boolean,
+    start: number,
+    options: {
+      context?: ChatEventContext;
+      finishActiveTurn?: boolean;
+      operation?: TurnOperation;
+      userInput?: UserInput;
+    } = {},
+  ): {
     success: boolean;
     output: string;
     elapsed_ms: number;
   } {
-    const context = this.createEventContext();
+    const context = options.context
+      ?? (options.operation
+        ? { runId: options.operation.runId, turnId: options.operation.turnId }
+        : this.createEventContext());
+    const userInput = options.userInput ?? createTextUserInput(input);
     this.emitEvent({
       type: "lifecycle_start",
       input,
-      userInput: createTextUserInput(input),
+      userInput,
+      operation: options.operation ?? createTurnStartOperation({
+        context,
+        cwd: "",
+        userInput,
+      }),
       ...this.eventBase(context),
     });
     this.emitEvent({
@@ -129,7 +150,17 @@ export class ChatRunnerEventBridge {
       ...this.eventBase(context),
     });
     const elapsed_ms = Date.now() - start;
-    this.emitLifecycleEndEvent(success ? "completed" : "error", elapsed_ms, context, false);
+    this.emitEvent({
+      type: "lifecycle_end",
+      status: success ? "completed" : "error",
+      elapsedMs: elapsed_ms,
+      persisted: false,
+      ...this.eventBase(context),
+    });
+    const shouldFinishActiveTurn = options.finishActiveTurn ?? options.operation?.kind !== "TurnSteer";
+    if (shouldFinishActiveTurn) {
+      this.finishActiveTurn(context);
+    }
     return { success, output, elapsed_ms };
   }
 

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -73,7 +73,8 @@ import {
 } from "./chat-runner-routes.js";
 import { classifyFreeformRouteIntent } from "./freeform-route-classifier.js";
 import { deriveRunSpecFromText } from "../../runtime/run-spec/index.js";
-import { createTextUserInput, replaceUserInputText } from "./user-input.js";
+import { createTextUserInput, normalizeUserInput, replaceUserInputText, type UserInput } from "./user-input.js";
+import { createTurnStartOperation, createTurnSteerOperation } from "./turn-protocol.js";
 import {
   createRunSpecStore,
   formatRunSpecSetupProposal,
@@ -234,13 +235,30 @@ export class ChatRunner {
     return this.eventBridge.hasActiveTurn();
   }
 
-  async interruptAndRedirect(input: string, cwd: string, timeoutMs = DEFAULT_TIMEOUT_MS): Promise<ChatRunResult> {
+  async interruptAndRedirect(
+    input: string,
+    cwd: string,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    options: { userInput?: UserInput } = {},
+  ): Promise<ChatRunResult> {
+    const steerUserInput = normalizeUserInput(options.userInput, input);
     const activeTurn = this.eventBridge.getActiveTurn();
     if (!activeTurn) {
-      return this.execute(input, cwd, timeoutMs);
+      return this.execute(input, cwd, timeoutMs, { userInput: steerUserInput });
     }
 
     const start = Date.now();
+    const steerOperation = createTurnSteerOperation({
+      activeTurn,
+      userInput: steerUserInput,
+    });
+    this.eventBridge.emitEvent({
+      type: "turn_steer",
+      input,
+      userInput: steerUserInput,
+      operation: steerOperation,
+      ...this.eventBridge.eventBase(activeTurn.context),
+    });
     const redirect = await classifyInterruptRedirect(input, {
       llmClient: this.deps.llmClient,
       cwd: activeTurn.cwd,
@@ -249,7 +267,7 @@ export class ChatRunner {
       sessionId: this.getSessionId(),
     });
     if (this.eventBridge.getActiveTurn() !== activeTurn) {
-      return this.execute(input, cwd, timeoutMs);
+      return this.execute(input, cwd, timeoutMs, { userInput: steerUserInput });
     }
     if (redirect === "background") {
       return this.eventBridge.emitEphemeralAssistantResult(input, [
@@ -257,7 +275,11 @@ export class ChatRunner {
         "",
         "The active turn is still running in the foreground.",
         "Use /tend for daemon-backed work, or send a narrower follow-up request.",
-      ].join("\n"), true, start);
+      ].join("\n"), true, start, {
+        context: activeTurn.context,
+        operation: steerOperation,
+        userInput: steerUserInput,
+      });
     }
 
     activeTurn.interruptRequested = true;
@@ -272,7 +294,12 @@ export class ChatRunner {
         input,
         "Interrupt requested. The active turn will stop at the next safe point.",
         false,
-        start
+        start,
+        {
+          context: activeTurn.context,
+          operation: steerOperation,
+          userInput: steerUserInput,
+        },
       );
     }
 
@@ -304,7 +331,17 @@ export class ChatRunner {
       ].join("\n");
     }
 
-    return this.eventBridge.emitEphemeralAssistantResult(input, output, true, start);
+    return this.eventBridge.emitEphemeralAssistantResult(
+      input,
+      output,
+      true,
+      start,
+      {
+        context: activeTurn.context,
+        operation: steerOperation,
+        userInput: steerUserInput,
+      },
+    );
   }
 
   setRuntimeControlContext(context: RuntimeControlChatContext | null): void {
@@ -421,6 +458,11 @@ export class ChatRunner {
       type: "lifecycle_start",
       input: safeInput,
       userInput: safeUserInput,
+      operation: createTurnStartOperation({
+        context: eventContext,
+        cwd: gitRoot,
+        userInput: safeUserInput,
+      }),
       ...this.eventBridge.eventBase(eventContext),
     });
 

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -415,6 +415,9 @@ export class CrossPlatformChatSessionManager {
     if (ingress.ingress_id && this.approvalSideTurnIngressIds.delete(ingress.ingress_id)) {
       return this.executeInSession(session, ingress, options);
     }
+    if (session.runner.hasActiveTurn()) {
+      return this.steerActiveSession(session, ingress, options);
+    }
     const queueEntry = session.queue.then(() => this.executeInSession(session, ingress, options));
     session.queue = queueEntry.then(() => undefined, () => undefined);
     return queueEntry;
@@ -452,18 +455,7 @@ export class CrossPlatformChatSessionManager {
         elapsed_ms: 0,
       };
     }
-    const previousOnEvent = session.runner.onEvent;
-    let deliveryQueue: ChatEventDeliveryQueue | null = null;
-    if (input.onEvent) {
-      deliveryQueue = new ChatEventDeliveryQueue(input.onEvent, this.deps.onEvent);
-      session.runner.onEvent = deliveryQueue.dispatch;
-    }
-    try {
-      return await session.runner.interruptAndRedirect(input.text, session.info.cwd, input.timeoutMs);
-    } finally {
-      await deliveryQueue?.drain();
-      session.runner.onEvent = previousOnEvent;
-    }
+    return this.steerActiveSession(session, ingress, input);
   }
 
   async executeIngress(
@@ -482,6 +474,9 @@ export class CrossPlatformChatSessionManager {
     const session = this.getOrCreateSession(normalizedIngress, options.cwd);
     if (normalizedIngress.ingress_id && this.approvalSideTurnIngressIds.delete(normalizedIngress.ingress_id)) {
       return this.executeInSession(session, normalizedIngress, options);
+    }
+    if (session.runner.hasActiveTurn()) {
+      return this.steerActiveSession(session, normalizedIngress, options);
     }
     const queueEntry = session.queue.then(() => this.executeInSession(session, normalizedIngress, options));
     session.queue = queueEntry.then(() => undefined, () => undefined);
@@ -805,27 +800,7 @@ export class CrossPlatformChatSessionManager {
     ingress: CrossPlatformIngressMessage,
     options: Pick<CrossPlatformIncomingChatMessage, "timeoutMs" | "onEvent" | "conversation_name" | "user_name"> = {}
   ): Promise<ChatRunResult> {
-    session.info.last_used_at = new Date().toISOString();
-    session.info.conversation_name = options.conversation_name?.trim() || session.info.conversation_name;
-    session.info.user_id = session.info.user_id ?? (normalizeIdentity(ingress.user_id) ?? undefined);
-    session.info.user_name = options.user_name?.trim() || session.info.user_name;
-    session.info.last_message_id = normalizeIdentity(ingress.message_id) ?? session.info.last_message_id;
-    session.info.active_reply_target = {
-      ...ingress.replyTarget,
-      metadata: cloneMetadata(ingress.replyTarget.metadata),
-    };
-    if (ingress.companion) {
-      session.info.active_companion_contract = ingress.companion;
-    }
-    session.info.metadata = cloneMetadata(buildSessionMetadata({
-      metadata: ingress.metadata,
-      channel: ingress.channel,
-      platform: ingress.platform,
-      conversation_id: ingress.conversation_id,
-      conversation_name: options.conversation_name,
-      user_id: ingress.user_id,
-      user_name: options.user_name,
-    }));
+    this.updateSessionInfoForIngress(session, ingress, options);
 
     const capabilities = {
       hasAgentLoop: this.deps.chatAgentLoopRunner !== undefined,
@@ -931,6 +906,78 @@ export class CrossPlatformChatSessionManager {
       await deliveryQueue?.drain();
       this.activeApprovalEventHandlers.delete(session.info.session_key);
       session.runner.onEvent = previousOnEvent;
+    }
+  }
+
+  private updateSessionInfoForIngress(
+    session: ManagedChatSession,
+    ingress: CrossPlatformIngressMessage,
+    options: Pick<CrossPlatformIncomingChatMessage, "conversation_name" | "user_name"> = {},
+  ): void {
+    session.info.last_used_at = new Date().toISOString();
+    session.info.conversation_name = options.conversation_name?.trim() || session.info.conversation_name;
+    session.info.user_id = session.info.user_id ?? (normalizeIdentity(ingress.user_id) ?? undefined);
+    session.info.user_name = options.user_name?.trim() || session.info.user_name;
+    session.info.last_message_id = normalizeIdentity(ingress.message_id) ?? session.info.last_message_id;
+    session.info.active_reply_target = {
+      ...ingress.replyTarget,
+      metadata: cloneMetadata(ingress.replyTarget.metadata),
+    };
+    if (ingress.companion) {
+      session.info.active_companion_contract = ingress.companion;
+    }
+    session.info.metadata = cloneMetadata(buildSessionMetadata({
+      metadata: ingress.metadata,
+      channel: ingress.channel,
+      platform: ingress.platform,
+      conversation_id: ingress.conversation_id,
+      conversation_name: options.conversation_name,
+      user_id: ingress.user_id,
+      user_name: options.user_name,
+    }));
+  }
+
+  private async steerActiveSession(
+    session: ManagedChatSession,
+    ingress: CrossPlatformIngressMessage,
+    options: Pick<CrossPlatformIncomingChatMessage, "timeoutMs" | "onEvent" | "conversation_name" | "user_name"> = {},
+  ): Promise<ChatRunResult> {
+    this.updateSessionInfoForIngress(session, ingress, options);
+
+    const previousOnEvent = session.runner.onEvent;
+    const approvalHandlerKey = session.info.session_key;
+    const hadPreviousApprovalHandler = this.activeApprovalEventHandlers.has(approvalHandlerKey);
+    const previousApprovalHandler = this.activeApprovalEventHandlers.get(approvalHandlerKey);
+    let deliveryQueue: ChatEventDeliveryQueue | null = null;
+    if (options.onEvent) {
+      deliveryQueue = new ChatEventDeliveryQueue(options.onEvent, this.deps.onEvent);
+      session.runner.onEvent = deliveryQueue.dispatch;
+      this.activeApprovalEventHandlers.set(approvalHandlerKey, options.onEvent);
+    }
+    try {
+      return await session.runner.interruptAndRedirect(
+        ingress.text,
+        session.info.cwd,
+        options.timeoutMs,
+        { userInput: ingress.userInput },
+      );
+    } finally {
+      await deliveryQueue?.drain();
+      const activeStillRunning = session.runner.hasActiveTurn();
+      if (activeStillRunning && deliveryQueue && options.onEvent) {
+        session.runner.onEvent = deliveryQueue.dispatch;
+        this.activeApprovalEventHandlers.set(approvalHandlerKey, options.onEvent);
+      } else if (activeStillRunning) {
+        session.runner.onEvent = previousOnEvent;
+        if (hadPreviousApprovalHandler && previousApprovalHandler) {
+          this.activeApprovalEventHandlers.set(approvalHandlerKey, previousApprovalHandler);
+        } else {
+          this.activeApprovalEventHandlers.delete(approvalHandlerKey);
+        }
+      } else {
+        session.runner.onEvent = undefined;
+        this.activeApprovalEventHandlers.delete(approvalHandlerKey);
+      }
     }
   }
 }

--- a/src/interface/chat/turn-protocol.ts
+++ b/src/interface/chat/turn-protocol.ts
@@ -1,0 +1,63 @@
+import type { ChatEventContext } from "./chat-events.js";
+import type { ActiveChatTurn } from "./chat-runner-event-bridge.js";
+import type { UserInput } from "./user-input.js";
+
+export type TurnOperation = TurnStartOperation | TurnSteerOperation;
+
+export interface TurnStartOperation {
+  kind: "TurnStart";
+  turnId: string;
+  runId: string;
+  inputId: string;
+  cwd: string;
+  userInput: UserInput;
+}
+
+export interface TurnSteerOperation {
+  kind: "TurnSteer";
+  turnId: string;
+  runId: string;
+  steerInputId: string;
+  activeTurn: {
+    turnId: string;
+    runId: string;
+    cwd: string;
+    startedAt: string;
+  };
+  userInput: UserInput;
+}
+
+export function createTurnStartOperation(input: {
+  context: ChatEventContext;
+  cwd: string;
+  userInput: UserInput;
+}): TurnStartOperation {
+  return {
+    kind: "TurnStart",
+    turnId: input.context.turnId,
+    runId: input.context.runId,
+    inputId: crypto.randomUUID(),
+    cwd: input.cwd,
+    userInput: input.userInput,
+  };
+}
+
+export function createTurnSteerOperation(input: {
+  activeTurn: ActiveChatTurn;
+  userInput: UserInput;
+}): TurnSteerOperation {
+  const { activeTurn } = input;
+  return {
+    kind: "TurnSteer",
+    turnId: activeTurn.context.turnId,
+    runId: activeTurn.context.runId,
+    steerInputId: crypto.randomUUID(),
+    activeTurn: {
+      turnId: activeTurn.context.turnId,
+      runId: activeTurn.context.runId,
+      cwd: activeTurn.cwd,
+      startedAt: new Date(activeTurn.startedAt).toISOString(),
+    },
+    userInput: input.userInput,
+  };
+}


### PR DESCRIPTION
Closes #1107

## Summary
- Add typed TurnStart and TurnSteer operations to chat events.
- Route active cross-platform input through a TurnSteer path instead of starting/queueing a second turn.
- Preserve current steer reply/approval handlers while active work continues and reject stale cwd/reply-target reuse.

## Tests
- npm test -- src/interface/chat/__tests__/chat-runner.test.ts
- npm test -- src/interface/chat/__tests__/cross-platform-session.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known risks
- Model request consumption of typed turn operations is deferred to #1108/#1109.
