### PR TITLE
feat(context): add typed chat turn context

### DIFF
--- a/src/interface/chat/__tests__/chat-history.test.ts
+++ b/src/interface/chat/__tests__/chat-history.test.ts
@@ -122,4 +122,29 @@ describe("ChatHistory", () => {
     callOrder.push("after-await");
     expect(callOrder).toEqual(["writeRaw", "after-await"]);
   });
+
+  it("recordTurnContext persists the snapshot before returning", async () => {
+    const callOrder: string[] = [];
+    const mockWriteRaw = vi.fn().mockImplementation(async () => {
+      callOrder.push("writeRaw");
+    });
+    const sm = { writeRaw: mockWriteRaw, readRaw: vi.fn() } as unknown as StateManager;
+
+    const history = new ChatHistory(sm, SESSION_ID, CWD);
+    await history.recordTurnContext({
+      schema_version: "chat-turn-context-v1",
+      modelVisible: { turn: { turnId: "turn-1" } },
+    });
+
+    callOrder.push("after-await");
+    expect(callOrder).toEqual(["writeRaw", "after-await"]);
+    expect(mockWriteRaw).toHaveBeenCalledWith(
+      `chat/sessions/${SESSION_ID}.json`,
+      expect.objectContaining({
+        turnContexts: [expect.objectContaining({
+          schema_version: "chat-turn-context-v1",
+        })],
+      }),
+    );
+  });
 });

--- a/src/interface/chat/__tests__/chat-runner-runtime.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-runtime.test.ts
@@ -7,6 +7,7 @@ import { StateManager } from "../../../base/state/state-manager.js";
 import {
   buildRuntimeControlContextFromIngress,
   buildStandaloneIngressMessageFromContext,
+  loadedSessionToChatSession,
   resolveChatResumeSelector,
   type ChatRunnerRuntimeDeps,
 } from "../chat-runner-runtime.js";
@@ -37,6 +38,28 @@ afterEach(async () => {
 });
 
 describe("chat-runner runtime helpers", () => {
+  it("preserves turn context snapshots when converting loaded sessions for resume", () => {
+    const session = loadedSessionToChatSession({
+      id: "session-with-context",
+      cwd: "/repo",
+      createdAt: "2026-05-06T07:00:00.000Z",
+      updatedAt: "2026-05-06T07:01:00.000Z",
+      title: null,
+      messages: [],
+      agentLoopStatePath: null,
+      agentLoopStatus: "missing",
+      agentLoopResumable: false,
+      turnContexts: [{
+        schema_version: "chat-turn-context-v1",
+        modelVisible: { turn: { turnId: "turn-current" } },
+      }],
+    });
+
+    expect(session.turnContexts).toEqual([expect.objectContaining({
+      schema_version: "chat-turn-context-v1",
+    })]);
+  });
+
   it("buildStandaloneIngressMessageFromContext prefers the current runtime reply target over stale fallback deps", () => {
     const message = buildStandaloneIngressMessageFromContext(
       "restart now",

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1750,7 +1750,12 @@ describe("ChatRunner", () => {
       expect(input.resumeStatePath).toMatch(/^chat\/agentloop\//);
 
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
-      expect(writeRawMock).toHaveBeenCalledTimes(1);
+      expect(writeRawMock).toHaveBeenCalledTimes(2);
+      expect(writeRawMock.mock.calls[0][1]).toMatchObject({
+        turnContexts: [expect.objectContaining({
+          schema_version: "chat-turn-context-v1",
+        })],
+      });
       expect((stateManager.readRaw as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(1);
     });
 
@@ -2632,7 +2637,10 @@ describe("ChatRunner", () => {
 
     it("persists assistant message only after streaming completes", async () => {
       const stateManager = makeMockStateManager();
-      const writes: Array<{ messages: Array<{ role: string; content: string }> }> = [];
+      const writes: Array<{
+        messages: Array<{ role: string; content: string }>;
+        turnContexts?: unknown[];
+      }> = [];
       (stateManager.writeRaw as ReturnType<typeof vi.fn>).mockImplementation(async (_path, data) => {
         writes.push(JSON.parse(JSON.stringify(data)));
       });
@@ -2660,12 +2668,15 @@ describe("ChatRunner", () => {
       await runner.execute("Stream this", "/repo");
 
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
-      expect(writeRawMock).toHaveBeenCalledTimes(2);
+      expect(writeRawMock).toHaveBeenCalledTimes(3);
       const firstWrite = writes[0]!;
       const secondWrite = writes[1]!;
+      const thirdWrite = writes[2]!;
       expect(firstWrite.messages).toHaveLength(1);
-      expect(secondWrite.messages).toHaveLength(2);
-      expect(secondWrite.messages[1]?.content).toBe("Hello world");
+      expect(secondWrite.messages).toHaveLength(1);
+      expect(secondWrite.turnContexts).toHaveLength(1);
+      expect(thirdWrite.messages).toHaveLength(2);
+      expect(thirdWrite.messages[1]?.content).toBe("Hello world");
       expect(events).toContain("assistant_delta");
       expect(events).toContain("assistant_final");
     });
@@ -2699,9 +2710,13 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("Recovery");
       expect(result.output).toContain("Type: Unclassified failure");
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
-      expect(writeRawMock).toHaveBeenCalledTimes(1);
-      const onlyWrite = writeRawMock.mock.calls[0][1] as { messages: Array<{ role: string; content: string }> };
-      expect(onlyWrite.messages).toHaveLength(1);
+      expect(writeRawMock).toHaveBeenCalledTimes(2);
+      const lastWrite = writeRawMock.mock.calls[1][1] as {
+        messages: Array<{ role: string; content: string }>;
+        turnContexts?: unknown[];
+      };
+      expect(lastWrite.messages).toHaveLength(1);
+      expect(lastWrite.turnContexts).toHaveLength(1);
       expect(capturedEvents).toContainEqual({ type: "lifecycle_error", partialText: "Partial answer" });
     });
 
@@ -3017,6 +3032,85 @@ describe("ChatRunner", () => {
       ]));
       expect(timelineSourceTypes.indexOf("assistant_message")).toBeLessThan(timelineSourceTypes.indexOf("tool_call_started"));
       expect(timelineSourceTypes.indexOf("tool_call_finished")).toBeLessThan(timelineSourceTypes.indexOf("final"));
+    });
+
+    it("builds agent-loop requests from current TurnContext instead of stale runtime deps", async () => {
+      const stateManager = makeMockStateManager();
+      const adapter = makeMockAdapter();
+      const chatAgentLoopRunner = {
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "Agentloop from current context",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 42,
+          stopped_reason: "completed",
+        }),
+      } as unknown as ChatAgentLoopRunner;
+      const runner = new ChatRunner(makeDeps({
+        stateManager,
+        adapter,
+        chatAgentLoopRunner,
+        runtimeReplyTarget: {
+          surface: "gateway",
+          platform: "slack",
+          conversation_id: "stale-thread",
+          message_id: "stale-message",
+          identity_key: "stale-user",
+        },
+      }));
+
+      const ingress = {
+        ...makeIngress("進捗を確認して"),
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "preapproved" as const,
+        },
+        replyTarget: {
+          ...makeIngress("").replyTarget,
+          platform: "slack",
+          conversation_id: "current-thread",
+          message_id: "current-message",
+          identity_key: "current-user",
+          user_id: "U-current",
+        },
+      };
+      const result = await runner.executeIngressMessage(ingress, "/repo", 120_000, {
+        kind: "agent_loop",
+        reason: "agent_loop_available",
+        replyTargetPolicy: "turn_reply_target",
+        eventProjectionPolicy: "turn_only",
+        concurrencyPolicy: "session_serial",
+      });
+
+      expect(result.success).toBe(true);
+      expect(chatAgentLoopRunner.execute).toHaveBeenCalledOnce();
+      const call = (chatAgentLoopRunner.execute as ReturnType<typeof vi.fn>).mock.calls[0][0] as {
+        systemPrompt?: string;
+        toolCallContext?: {
+          runtimeReplyTarget?: Record<string, unknown> | null;
+          runtimeControlApprovalMode?: string;
+        };
+      };
+      expect(call.systemPrompt).toContain("## Turn Context");
+      expect(call.systemPrompt).toContain("current-thread");
+      expect(call.systemPrompt).not.toContain("stale-thread");
+      expect(call.toolCallContext?.runtimeReplyTarget).toMatchObject({
+        conversation_id: "current-thread",
+        message_id: "current-message",
+      });
+      expect(call.toolCallContext?.runtimeControlApprovalMode).toBe("preapproved");
+
+      const persistedSession = (stateManager.writeRaw as ReturnType<typeof vi.fn>).mock.calls
+        .map(([, value]) => value)
+        .find((value) =>
+          value && typeof value === "object" && Array.isArray((value as { turnContexts?: unknown }).turnContexts)
+        ) as { turnContexts: unknown[] } | undefined;
+      expect(persistedSession?.turnContexts).toHaveLength(1);
+      const snapshotJson = JSON.stringify(persistedSession?.turnContexts[0]);
+      expect(snapshotJson).toContain("current-thread");
+      expect(snapshotJson).not.toContain("stale-thread");
+      expect(snapshotJson).not.toContain("approvalFn");
     });
 
     it("routes simple questions through chatAgentLoopRunner when configured", async () => {

--- a/src/interface/chat/__tests__/chat-session-store.test.ts
+++ b/src/interface/chat/__tests__/chat-session-store.test.ts
@@ -230,14 +230,23 @@ describe("ChatSessionCatalog", () => {
   it("renames a session and bumps updatedAt", async () => {
     await stateManager.writeRaw(
       "chat/sessions/rename-me.json",
-      makeSession({
-        id: "rename-me",
-        cwd: "/repo",
-        createdAt: "2025-01-01T00:00:00.000Z",
-        updatedAt: "2025-01-01T01:00:00.000Z",
-        title: "Original",
-        messages: [],
-      })
+      {
+        ...makeSession({
+          id: "rename-me",
+          cwd: "/repo",
+          createdAt: "2025-01-01T00:00:00.000Z",
+          updatedAt: "2025-01-01T01:00:00.000Z",
+          title: "Original",
+          messages: [],
+        }),
+        turnContexts: [{
+          schema_version: "chat-turn-context-v1",
+          modelVisible: {
+            turn: { turnId: "turn-1" },
+            session: { cwd: "/repo" },
+          },
+        }],
+      }
     );
 
     const renamed = await catalog.renameSession("rename-me", "Renamed Session");
@@ -246,6 +255,12 @@ describe("ChatSessionCatalog", () => {
 
     const loaded = await catalog.loadSession("rename-me");
     expect(loaded?.title).toBe("Renamed Session");
+    expect(loaded?.turnContexts).toEqual([expect.objectContaining({
+      schema_version: "chat-turn-context-v1",
+      modelVisible: expect.objectContaining({
+        turn: expect.objectContaining({ turnId: "turn-1" }),
+      }),
+    })]);
   });
 
   it("lists by cwd and returns the latest matching session", async () => {

--- a/src/interface/chat/__tests__/turn-context.test.ts
+++ b/src/interface/chat/__tests__/turn-context.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { defaultExecutionPolicy } from "../../../orchestrator/execution/agent-loop/execution-policy.js";
+import {
+  buildChatTurnContext,
+  renderModelVisibleTurnContext,
+  toTurnContextSnapshot,
+} from "../turn-context.js";
+import type { UserInput } from "../user-input.js";
+
+describe("Chat TurnContext", () => {
+  it("keeps current runtime target model-visible and leaves stale fallback plus approval functions host-only", () => {
+    const approvalFn = vi.fn().mockResolvedValue(true);
+    const context = buildChatTurnContext({
+      eventContext: { runId: "run-current", turnId: "turn-current" },
+      startedAt: new Date("2026-05-06T07:00:00.000Z"),
+      timezone: "Asia/Tokyo",
+      sessionId: "session-current",
+      cwd: "/repo",
+      gitRoot: "/repo",
+      executionCwd: "/repo",
+      nativeAgentLoopStatePath: "chat/agentloop/session-current.state.json",
+      selectedRoute: {
+        kind: "agent_loop",
+        reason: "agent_loop_available",
+        replyTargetPolicy: "turn_reply_target",
+        eventProjectionPolicy: "turn_only",
+        concurrencyPolicy: "session_serial",
+      },
+      input: "進捗を見て",
+      userInput: {
+        schema_version: "user-input-v1",
+        rawText: "進捗を見て",
+        metadata: { token: "secret-metadata" },
+        items: [
+          { kind: "text", text: "secret-text" },
+          {
+            kind: "attachment",
+            id: "attachment-1",
+            name: "debug.log",
+            mimeType: "text/plain",
+            path: "/private/secret.log",
+            url: "https://example.invalid/?token=secret-url",
+            metadata: { apiKey: "secret-item-metadata" },
+          },
+        ],
+      } satisfies UserInput,
+      priorTurns: [],
+      basePrompt: "Working directory: /repo\n\n進捗を見て",
+      prompt: "Working directory: /repo\n\n進捗を見て",
+      systemPrompt: "Developer instructions\n\nAGENTS instructions",
+      agentLoopSystemPrompt: "Developer instructions\n\nAGENTS instructions\n\nReply in Japanese.",
+      runtimeControlContext: {
+        approvalMode: "preapproved",
+        allowed: true,
+        approvalFn,
+        replyTarget: {
+          surface: "gateway",
+          platform: "slack",
+          conversation_id: "current-thread",
+          message_id: "current-message",
+          identity_key: "current-user",
+          user_id: "U-current",
+        },
+      },
+      fallbackReplyTarget: {
+        surface: "gateway",
+        platform: "slack",
+        conversation_id: "stale-thread",
+        message_id: "stale-message",
+        identity_key: "stale-user",
+      },
+      executionPolicy: defaultExecutionPolicy("/repo"),
+      setupDialogue: null,
+      runSpecConfirmation: null,
+      setupSecretIntake: {
+        redactedText: "進捗を見て",
+        suppliedSecrets: [{
+          id: "setup_secret_1",
+          kind: "telegram_bot_token",
+          value: "secret-token",
+          redaction: "[REDACTED]",
+          suppliedAt: "2026-05-06T07:00:00.000Z",
+        }],
+      },
+      activatedTools: new Set(["sessions_read"]),
+    });
+
+    expect(context.modelVisible.runtime.replyTarget).toMatchObject({
+      conversation_id: "current-thread",
+      message_id: "current-message",
+    });
+    expect(context.modelVisible.runtime.approvalMode).toBe("preapproved");
+    expect(context.hostOnly.runtime.fallbackReplyTarget).toMatchObject({
+      conversation_id: "stale-thread",
+    });
+
+    const rendered = renderModelVisibleTurnContext(context.modelVisible);
+    expect(rendered).toContain("current-thread");
+    expect(rendered).not.toContain("stale-thread");
+
+    const snapshotJson = JSON.stringify(toTurnContextSnapshot(context));
+    expect(snapshotJson).toContain("current-thread");
+    expect(snapshotJson).toContain("AGENTS instructions");
+    expect(snapshotJson).toContain("進捗を見て");
+    expect(snapshotJson).not.toContain("stale-thread");
+    expect(snapshotJson).not.toContain("secret-text");
+    expect(snapshotJson).not.toContain("secret-token");
+    expect(snapshotJson).not.toContain("secret-metadata");
+    expect(snapshotJson).not.toContain("secret-item-metadata");
+    expect(snapshotJson).not.toContain("secret-url");
+    expect(snapshotJson).not.toContain("/private/secret.log");
+    expect(snapshotJson).not.toContain("approvalFn");
+  });
+});

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -47,6 +47,12 @@ export const ChatSessionUsageSchema = z.object({
 }).passthrough();
 export type ChatSessionUsage = z.infer<typeof ChatSessionUsageSchema>;
 
+export const ChatTurnContextSnapshotSchema = z.object({
+  schema_version: z.string(),
+  modelVisible: z.unknown(),
+}).passthrough();
+export type ChatTurnContextSnapshot = z.infer<typeof ChatTurnContextSnapshotSchema>;
+
 export const RunSpecConfirmationStateSchema = z.object({
   state: z.enum(["pending", "confirmed", "cancelled"]),
   spec: RunSpecSchema,
@@ -92,6 +98,7 @@ export const ChatSessionSchema = z.object({
   agentLoopResumable: z.boolean().nullable().optional(),
   agentLoopUpdatedAt: z.string().nullable().optional(),
   agentLoop: ChatSessionAgentLoopMetadataSchema.optional(),
+  turnContexts: z.array(ChatTurnContextSnapshotSchema).optional(),
   usage: ChatSessionUsageSchema.optional(),
 }).passthrough();
 export type ChatSession = z.infer<typeof ChatSessionSchema>;
@@ -113,6 +120,7 @@ export class ChatHistory {
         cwd: existingSession.cwd,
         updatedAt: existingSession.updatedAt ?? existingSession.createdAt,
         messages: [...existingSession.messages],
+        ...(existingSession.turnContexts ? { turnContexts: [...existingSession.turnContexts] } : {}),
         ...(existingSession.usage ? { usage: cloneUsage(existingSession.usage) } : {}),
       };
     } else {
@@ -204,6 +212,7 @@ export class ChatHistory {
     return {
       ...this.session,
       messages: [...this.session.messages],
+      ...(this.session.turnContexts ? { turnContexts: [...this.session.turnContexts] } : {}),
       ...(this.session.usage ? { usage: cloneUsage(this.session.usage) } : {}),
     };
   }
@@ -258,6 +267,14 @@ export class ChatHistory {
     } else {
       delete this.session.runSpecConfirmation;
     }
+  }
+
+  async recordTurnContext(snapshot: { schema_version: string; modelVisible: unknown }): Promise<void> {
+    this.session.turnContexts = [
+      ...(this.session.turnContexts ?? []),
+      snapshot,
+    ].slice(-20);
+    await this.persist();
   }
 
   setSessionLifecycle(input: {

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -22,6 +22,10 @@ import type { AssistantBuffer } from "./chat-runner-event-bridge.js";
 import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
 import { createGatewaySetupStatusProvider, type TelegramSetupStatus } from "./gateway-setup-status.js";
 import {
+  renderSystemPromptWithTurnContext,
+  type ChatTurnContext,
+} from "./turn-context.js";
+import {
   createDiscordAdapterPlanDialogue,
   createTelegramConfirmWriteDialogue,
   SETUP_WRITE_CONFIRM_COMMAND,
@@ -162,8 +166,7 @@ export async function executeClarifyRoute(
 export async function executeAssistRoute(
   host: ChatRunnerRouteHost,
   params: {
-    input: string;
-    priorTurns: Array<{ role: string; content: string }>;
+    turnContext: ChatTurnContext;
     eventContext: ChatEventContext;
     assistantBuffer: AssistantBuffer;
     history: { appendAssistantMessage(message: string): Promise<void>; recordUsage(phase: string, usage: ChatUsageCounter): void };
@@ -182,15 +185,15 @@ export async function executeAssistRoute(
   }
   host.eventBridge.emitCheckpoint("Read-only assist selected", "The message will be answered without coding-agent execution.", params.eventContext, "route");
   const messages: LLMMessage[] = [
-    ...params.priorTurns.map((m): LLMMessage => ({ role: m.role === "assistant" ? "assistant" : "user", content: m.content })),
-    { role: "user", content: params.input },
+    ...params.turnContext.modelVisible.conversation.priorTurns.map((m): LLMMessage => ({ role: m.role, content: m.content })),
+    { role: "user", content: params.turnContext.modelVisible.input.text },
   ];
   const response = await sendLLMMessage(host, host.deps.llmClient, messages, {
-    system: [
-      buildStaticSystemPrompt(host.getProviderConfigBaseDir()),
+    system: renderSystemPromptWithTurnContext([
+      params.turnContext.modelVisible.instructions.systemPrompt || buildStaticSystemPrompt(host.getProviderConfigBaseDir()),
       "Answer read-only. Provide concise operational guidance. Do not ask to edit files or run commands unless the user explicitly asks for execution.",
       sameLanguageResponseInstruction(host.getTurnLanguageHint()),
-    ].join(" "),
+    ].join(" "), params.turnContext.modelVisible),
     max_tokens: 1000,
     temperature: 0,
   }, params.assistantBuffer, params.eventContext);
@@ -209,12 +212,8 @@ export async function executeAssistRoute(
 export async function executeAgentLoopRoute(
   host: ChatRunnerRouteHost,
   params: {
+    turnContext: ChatTurnContext;
     resumeOnly: boolean;
-    executionCwd: string;
-    executionGoalId?: string;
-    basePrompt: string;
-    priorTurns: Array<{ role: string; content: string }>;
-    agentLoopSystemPrompt: string;
     assistantBuffer: AssistantBuffer;
     eventContext: ChatEventContext;
     history: {
@@ -222,26 +221,21 @@ export async function executeAgentLoopRoute(
       recordUsage(phase: string, usage: ChatUsageCounter): void;
     };
     gitRoot: string;
-    runtimeControlContext: RuntimeControlChatContext | null;
     activeAbortSignal: AbortSignal;
     start: number;
   }
 ): Promise<ChatRunResult> {
   const {
     resumeOnly,
-    executionCwd,
-    executionGoalId,
-    basePrompt,
-    priorTurns,
-    agentLoopSystemPrompt,
     assistantBuffer,
     eventContext,
     history,
     gitRoot,
-    runtimeControlContext,
     activeAbortSignal,
     start,
   } = params;
+  const turnContext = params.turnContext;
+  const runtimeContext = turnContext.hostOnly.runtime.runtimeControlContext;
   try {
     const resumeState = resumeOnly ? await loadResumableAgentLoopState(host) : null;
     if (resumeOnly && !resumeState) {
@@ -268,17 +262,14 @@ export async function executeAgentLoopRoute(
       : "The agent loop can now inspect, plan, edit, or verify with visible tool activity.", eventContext, "execution");
     host.eventBridge.emitActivity("lifecycle", "Calling model...", eventContext, "lifecycle:model");
     const result = await host.deps.chatAgentLoopRunner!.execute({
-      message: basePrompt,
-      cwd: executionCwd,
-      goalId: executionGoalId,
-      history: priorTurns.map((m) => ({
-        role: m.role === "assistant" ? "assistant" : "user",
-        content: m.content,
-      })),
+      message: turnContext.modelVisible.prompts.basePrompt,
+      cwd: turnContext.hostOnly.execution.executionCwd,
+      goalId: turnContext.hostOnly.execution.goalId,
+      history: turnContext.modelVisible.conversation.priorTurns,
       eventSink: host.eventBridge.createAgentLoopEventSink(eventContext),
-      approvalFn: agentLoopApprovalFn(host, runtimeControlContext),
+      approvalFn: agentLoopApprovalFn(host, runtimeContext),
       toolCallContext: {
-        executionPolicy: await host.getSessionExecutionPolicy(),
+        executionPolicy: turnContext.hostOnly.execution.executionPolicy,
         ...(host.getConversationSessionId() ? { conversationSessionId: host.getConversationSessionId()! } : {}),
         providerConfigBaseDir: host.getProviderConfigBaseDir(),
         setupSecretIntake: host.getSetupSecretIntake(),
@@ -291,15 +282,18 @@ export async function executeAgentLoopRoute(
           set: (confirmation) => host.setPendingRunSpecConfirmation(confirmation as RunSpecConfirmationState | null),
           currentTurnStartedAt: new Date(start).toISOString(),
         },
-        runtimeReplyTarget: (runtimeControlContext?.replyTarget ?? host.deps.runtimeReplyTarget ?? null) as Record<string, unknown> | null,
-        runtimeControlActor: (runtimeControlContext?.actor ?? host.deps.runtimeControlActor ?? null) as Record<string, unknown> | null,
-        runtimeControlAllowed: runtimeControlContext?.allowed ?? true,
-        runtimeControlApprovalMode: runtimeControlContext?.approvalMode ?? "interactive",
+        runtimeReplyTarget: (runtimeContext?.replyTarget ?? turnContext.hostOnly.runtime.fallbackReplyTarget ?? null) as Record<string, unknown> | null,
+        runtimeControlActor: (runtimeContext?.actor ?? turnContext.hostOnly.runtime.fallbackActor ?? null) as Record<string, unknown> | null,
+        runtimeControlAllowed: turnContext.modelVisible.runtime.runtimeControlAllowed,
+        runtimeControlApprovalMode: turnContext.modelVisible.runtime.approvalMode,
       },
       ...(host.getNativeAgentLoopStatePath() ? { resumeStatePath: host.getNativeAgentLoopStatePath()! } : {}),
       ...(resumeState ? { resumeState } : {}),
       ...(resumeOnly ? { resumeOnly: true } : {}),
-      ...(agentLoopSystemPrompt ? { systemPrompt: agentLoopSystemPrompt } : {}),
+      systemPrompt: renderSystemPromptWithTurnContext(
+        turnContext.modelVisible.instructions.agentLoopSystemPrompt,
+        turnContext.modelVisible,
+      ),
       abortSignal: activeAbortSignal,
     });
     const elapsed_ms = Date.now() - start;
@@ -366,7 +360,7 @@ export async function executeAgentLoopRoute(
 export async function executeToolLoopRoute(
   host: ChatRunnerRouteHost,
   params: {
-    prompt: string;
+    turnContext: ChatTurnContext;
     eventContext: ChatEventContext;
     assistantBuffer: AssistantBuffer;
     systemPrompt?: string;
@@ -384,7 +378,7 @@ export async function executeToolLoopRoute(
     host.eventBridge.emitCheckpoint("Tool loop started", "The model will choose tools from the active catalog.", params.eventContext, "execution");
     const toolResult = await executeWithTools(
       host,
-      params.prompt,
+      params.turnContext,
       params.eventContext,
       params.assistantBuffer,
       params.systemPrompt,
@@ -432,8 +426,7 @@ export async function executeToolLoopRoute(
 export async function executeAdapterRoute(
   host: ChatRunnerRouteHost,
   params: {
-    prompt: string;
-    cwd: string;
+    turnContext: ChatTurnContext;
     timeoutMs: number;
     systemPrompt?: string;
     eventContext: ChatEventContext;
@@ -446,11 +439,16 @@ export async function executeAdapterRoute(
   }
 ): Promise<ChatRunResult> {
   const task: AgentTask = {
-    prompt: params.prompt,
+    prompt: params.turnContext.modelVisible.prompts.prompt,
     timeout_ms: params.timeoutMs,
     adapter_type: host.deps.adapter.adapterType,
-    cwd: params.cwd,
-    ...(params.systemPrompt ? { system_prompt: params.systemPrompt } : {}),
+    cwd: params.turnContext.hostOnly.execution.cwd,
+    ...(params.systemPrompt ? {
+      system_prompt: renderSystemPromptWithTurnContext(
+        params.turnContext.modelVisible.instructions.systemPrompt,
+        params.turnContext.modelVisible,
+      ),
+    } : {}),
   };
   const resolvedTimeoutMs = task.timeout_ms ?? DEFAULT_TIMEOUT_MS;
   host.eventBridge.emitCheckpoint("Adapter started", "The configured adapter has the current prompt and project context.", params.eventContext, "execution");
@@ -578,7 +576,7 @@ export async function executeAdapterRoute(
 
 async function executeWithTools(
   host: ChatRunnerRouteHost,
-  prompt: string,
+  turnContext: ChatTurnContext,
   eventContext: ChatEventContext,
   assistantBuffer: AssistantBuffer,
   systemPrompt?: string,
@@ -587,8 +585,8 @@ async function executeWithTools(
   start?: number,
 ): Promise<{ output: string; usage: ChatUsageCounter }> {
   const llmClient = host.deps.llmClient!;
-  const messages: LLMMessage[] = [{ role: "user", content: prompt }];
-  const toolCallContext = await buildToolCallContext(host, goalId, runtimeControlContext, start);
+  const messages: LLMMessage[] = [{ role: "user", content: turnContext.modelVisible.prompts.prompt }];
+  const toolCallContext = await buildToolCallContext(host, goalId, runtimeControlContext, start, turnContext);
   const usage = zeroUsageCounter();
 
   for (let loop = 0; loop < MAX_TOOL_LOOPS; loop++) {
@@ -1218,14 +1216,16 @@ async function buildToolCallContext(
   goalId = host.deps.goalId,
   runtimeControlContext?: RuntimeControlChatContext | null,
   start?: number,
+  turnContext?: ChatTurnContext,
 ): Promise<ToolCallContext> {
-  const executionPolicy = await host.getSessionExecutionPolicy();
+  const executionPolicy = turnContext?.hostOnly.execution.executionPolicy ?? await host.getSessionExecutionPolicy();
+  const runtimeContext = turnContext?.hostOnly.runtime.runtimeControlContext ?? runtimeControlContext;
   return {
-    cwd: host.getSessionCwd() ?? process.cwd(),
-    goalId: goalId ?? "",
+    cwd: turnContext?.hostOnly.execution.executionCwd ?? host.getSessionCwd() ?? process.cwd(),
+    goalId: turnContext?.hostOnly.execution.goalId ?? goalId ?? "",
     trustBalance: 0,
     preApproved: false,
-    approvalFn: agentLoopApprovalFn(host, runtimeControlContext),
+    approvalFn: agentLoopApprovalFn(host, runtimeContext),
     executionPolicy,
     ...(host.getConversationSessionId() ? { conversationSessionId: host.getConversationSessionId()! } : {}),
     providerConfigBaseDir: host.getProviderConfigBaseDir(),
@@ -1239,10 +1239,10 @@ async function buildToolCallContext(
       set: (confirmation) => host.setPendingRunSpecConfirmation(confirmation as RunSpecConfirmationState | null),
       ...(typeof start === "number" ? { currentTurnStartedAt: new Date(start).toISOString() } : {}),
     },
-    runtimeReplyTarget: (runtimeControlContext?.replyTarget ?? host.deps.runtimeReplyTarget ?? null) as Record<string, unknown> | null,
-    runtimeControlActor: (runtimeControlContext?.actor ?? host.deps.runtimeControlActor ?? null) as Record<string, unknown> | null,
-    runtimeControlAllowed: runtimeControlContext?.allowed ?? true,
-    runtimeControlApprovalMode: runtimeControlContext?.approvalMode ?? "interactive",
+    runtimeReplyTarget: (runtimeContext?.replyTarget ?? turnContext?.hostOnly.runtime.fallbackReplyTarget ?? host.deps.runtimeReplyTarget ?? null) as Record<string, unknown> | null,
+    runtimeControlActor: (runtimeContext?.actor ?? turnContext?.hostOnly.runtime.fallbackActor ?? host.deps.runtimeControlActor ?? null) as Record<string, unknown> | null,
+    runtimeControlAllowed: turnContext?.modelVisible.runtime.runtimeControlAllowed ?? runtimeContext?.allowed ?? true,
+    runtimeControlApprovalMode: turnContext?.modelVisible.runtime.approvalMode ?? runtimeContext?.approvalMode ?? "interactive",
   };
 }
 

--- a/src/interface/chat/chat-runner-runtime.ts
+++ b/src/interface/chat/chat-runner-runtime.ts
@@ -69,6 +69,8 @@ export function loadedSessionToChatSession(session: LoadedChatSession): ChatSess
     ...(session.agentLoopResumable ? { agentLoopResumable: true } : {}),
     ...(session.agentLoopUpdatedAt ? { agentLoopUpdatedAt: session.agentLoopUpdatedAt } : {}),
     ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
+    ...(session.turnContexts ? { turnContexts: [...session.turnContexts] } : {}),
+    ...(session.usage ? { usage: session.usage } : {}),
   };
 }
 

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -76,6 +76,11 @@ import { deriveRunSpecFromText } from "../../runtime/run-spec/index.js";
 import { createTextUserInput, normalizeUserInput, replaceUserInputText, type UserInput } from "./user-input.js";
 import { createTurnStartOperation, createTurnSteerOperation } from "./turn-protocol.js";
 import {
+  buildChatTurnContext,
+  renderSystemPromptWithTurnContext,
+  toTurnContextSnapshot,
+} from "./turn-context.js";
+import {
   createRunSpecStore,
   formatRunSpecSetupProposal,
   arbitrateRunSpecPendingDialogue,
@@ -569,19 +574,8 @@ export class ChatRunner {
       return result;
     }
 
-    if (selectedRoute?.kind === "assist") {
-      const result = await executeAssistRoute(this.routeHost(), {
-        input: safeInput,
-        priorTurns,
-        eventContext,
-        assistantBuffer,
-        history,
-        start,
-      });
-      return result;
-    }
-
     const usesNativeAgentLoop = resumeOnly || selectedRoute?.kind === "agent_loop";
+    const executionPolicy = await this.getSessionExecutionPolicy();
     const groundingWorkspaceContext = !resumeOnly && usesNativeAgentLoop
       ? await buildChatContext(safeInput, executionCwd)
       : undefined;
@@ -597,7 +591,7 @@ export class ChatRunner {
             workspaceRoot: executionCwd,
             goalId: executionGoalId,
             userMessage: safeInput,
-            trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
+            trustProjectInstructions: executionPolicy.trustProjectInstructions,
             workspaceContext: groundingWorkspaceContext,
           });
         } else {
@@ -608,7 +602,7 @@ export class ChatRunner {
             goalId: executionGoalId,
             userMessage: safeInput,
             query: safeInput,
-            trustProjectInstructions: this.sessionExecutionPolicy?.trustProjectInstructions ?? true,
+            trustProjectInstructions: executionPolicy.trustProjectInstructions,
           });
           systemPrompt = String(groundingBundle.render("prompt"));
         }
@@ -631,6 +625,34 @@ export class ChatRunner {
     const context = resumeOnly || usesNativeAgentLoop ? "" : await buildChatContext(safeInput, gitRoot);
     const basePrompt = resumeOnly ? "" : (context ? `${context}\n\n${safeInput}` : safeInput);
     const prompt = historyBlock ? `${historyBlock}${basePrompt}` : basePrompt;
+    const turnContext = buildChatTurnContext({
+      eventContext,
+      startedAt: new Date(start),
+      sessionId: history.getSessionId(),
+      cwd,
+      gitRoot,
+      executionCwd,
+      nativeAgentLoopStatePath: this.nativeAgentLoopStatePath,
+      selectedRoute,
+      input: safeInput,
+      userInput: safeUserInput,
+      compactionSummary,
+      priorTurns,
+      basePrompt,
+      prompt,
+      systemPrompt,
+      agentLoopSystemPrompt,
+      runtimeControlContext,
+      ...(this.deps.runtimeReplyTarget ? { fallbackReplyTarget: this.deps.runtimeReplyTarget } : {}),
+      ...(this.deps.runtimeControlActor ? { fallbackActor: this.deps.runtimeControlActor } : {}),
+      ...(executionGoalId ? { executionGoalId } : {}),
+      executionPolicy,
+      setupDialogue: history.getSetupDialogue(),
+      runSpecConfirmation: history.getRunSpecConfirmation(),
+      setupSecretIntake,
+      activatedTools: this.activatedTools,
+    });
+    await history.recordTurnContext(toTurnContextSnapshot(turnContext));
 
     if (resumeOnly && !this.deps.chatAgentLoopRunner) {
       const elapsed_ms = Date.now() - start;
@@ -648,19 +670,25 @@ export class ChatRunner {
       return { success: false, output, elapsed_ms };
     }
 
+    if (selectedRoute?.kind === "assist") {
+      const result = await executeAssistRoute(this.routeHost(), {
+        turnContext,
+        eventContext,
+        assistantBuffer,
+        history,
+        start,
+      });
+      return result;
+    }
+
     if (resumeOnly || selectedRoute?.kind === "agent_loop") {
       return executeAgentLoopRoute(this.routeHost(), {
+        turnContext,
         resumeOnly,
-        executionCwd,
-        executionGoalId,
-        basePrompt,
-        priorTurns,
-        agentLoopSystemPrompt,
         assistantBuffer,
         eventContext,
         history,
         gitRoot,
-        runtimeControlContext,
         activeAbortSignal: activeTurn.abortController.signal,
         start,
       });
@@ -668,10 +696,10 @@ export class ChatRunner {
 
     if (selectedRoute?.kind === "tool_loop") {
       return executeToolLoopRoute(this.routeHost(), {
-        prompt,
+        turnContext,
         eventContext,
         assistantBuffer,
-        systemPrompt: systemPrompt || undefined,
+        systemPrompt: renderSystemPromptWithTurnContext(systemPrompt || undefined, turnContext.modelVisible),
         executionGoalId,
         history,
         gitRoot,
@@ -694,10 +722,9 @@ export class ChatRunner {
     }
 
     return executeAdapterRoute(this.routeHost(), {
-      prompt,
-      cwd,
+      turnContext,
       timeoutMs,
-      systemPrompt: systemPrompt || undefined,
+      systemPrompt: renderSystemPromptWithTurnContext(systemPrompt || undefined, turnContext.modelVisible),
       eventContext,
       assistantBuffer,
       gitRoot,

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -71,6 +71,7 @@ export interface LoadedChatSession {
   agentLoopResumable: boolean;
   agentLoopUpdatedAt?: string | null;
   agentLoop?: ChatSession["agentLoop"];
+  turnContexts?: ChatSession["turnContexts"];
   usage?: ChatSession["usage"];
   [key: string]: unknown;
 }
@@ -347,6 +348,7 @@ async function readSessionRecordWithMetadata(
     agentLoopResumable: discovery.resumable,
     agentLoopUpdatedAt: discovery.updatedAt,
     ...(parsed.data.agentLoop ? { agentLoop: parsed.data.agentLoop } : {}),
+    ...(parsed.data.turnContexts ? { turnContexts: [...parsed.data.turnContexts] } : {}),
     ...(parsed.data.usage ? { usage: parsed.data.usage } : {}),
   };
 
@@ -419,6 +421,7 @@ function toPersistedSession(session: LoadedChatSession): ChatSession {
       ? { agentLoopUpdatedAt: session.agentLoopUpdatedAt }
       : {}),
     ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
+    ...(session.turnContexts ? { turnContexts: [...session.turnContexts] } : {}),
     ...(session.usage ? { usage: session.usage } : {}),
   };
 }
@@ -574,10 +577,12 @@ export class ChatSessionCatalog {
       ...(session.parentNotificationSummary ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
       ...(session.parentNotifiedAt ? { parentNotifiedAt: session.parentNotifiedAt } : {}),
       ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
+      ...(session.turnContexts ? { turnContexts: [...session.turnContexts] } : {}),
       agentLoopStatePath: session.agentLoopStatePath,
       agentLoopStatus: session.agentLoopStatus,
       agentLoopResumable: session.agentLoopResumable,
       ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
+      ...(session.usage ? { usage: session.usage } : {}),
     };
   }
 

--- a/src/interface/chat/turn-context.ts
+++ b/src/interface/chat/turn-context.ts
@@ -1,0 +1,383 @@
+import type { ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
+import type {
+  RuntimeControlActor,
+  RuntimeControlReplyTarget,
+} from "../../runtime/store/runtime-operation-schemas.js";
+import type { ChatEventContext } from "./chat-events.js";
+import type { ChatMessage, RunSpecConfirmationState } from "./chat-history.js";
+import type { RuntimeControlChatContext } from "./chat-runner-contracts.js";
+import type { SelectedChatRoute } from "./ingress-router.js";
+import type { SetupDialoguePublicState } from "./setup-dialogue.js";
+import type { SetupSecretIntakeResult } from "./setup-secret-intake.js";
+import { USER_INPUT_SCHEMA_VERSION, type UserInput } from "./user-input.js";
+
+export const CHAT_TURN_CONTEXT_SCHEMA_VERSION = "chat-turn-context-v1";
+
+export interface ChatTurnContext {
+  schema_version: typeof CHAT_TURN_CONTEXT_SCHEMA_VERSION;
+  modelVisible: ChatTurnModelVisibleContext;
+  hostOnly: ChatTurnHostOnlyContext;
+}
+
+export interface ChatTurnModelVisibleContext {
+  turn: {
+    runId: string;
+    turnId: string;
+    startedAt: string;
+    currentDate: string;
+    timezone: string;
+  };
+  session: {
+    sessionId: string | null;
+    cwd: string;
+    gitRoot: string;
+    nativeAgentLoopStatePath: string | null;
+    route: {
+      kind: string;
+      reason: string;
+    } | null;
+  };
+  input: {
+    text: string;
+    userInput: PublicUserInput;
+  };
+  conversation: {
+    compactionSummary: string | null;
+    priorTurns: Array<{ role: "user" | "assistant"; content: string }>;
+  };
+  prompts: {
+    basePrompt: string;
+    prompt: string;
+  };
+  instructions: {
+    systemPrompt: string;
+    agentLoopSystemPrompt: string;
+  };
+  runtime: {
+    approvalMode: "interactive" | "preapproved" | "disallowed";
+    runtimeControlAllowed: boolean;
+    replyTarget: PublicReplyTarget | null;
+    actor: PublicRuntimeActor | null;
+  };
+  tools: {
+    activatedTools: string[];
+    selectedRoute: string | null;
+  };
+  outstanding: {
+    setupDialogue: PublicSetupDialogueState | null;
+    runSpecConfirmation: PublicRunSpecConfirmationState | null;
+  };
+  runtimeEvidence: {
+    status: "not_requested" | "unavailable";
+    refs: string[];
+  };
+}
+
+export interface ChatTurnHostOnlyContext {
+  execution: {
+    cwd: string;
+    gitRoot: string;
+    executionCwd: string;
+    goalId?: string;
+    executionPolicy: ExecutionPolicy;
+  };
+  runtime: {
+    runtimeControlContext: RuntimeControlChatContext | null;
+    fallbackReplyTarget?: RuntimeControlReplyTarget;
+    fallbackActor?: RuntimeControlActor;
+  };
+  setupSecretIntake: SetupSecretIntakeResult | null;
+}
+
+export interface ChatTurnContextInput {
+  eventContext: ChatEventContext;
+  startedAt: Date;
+  timezone?: string;
+  sessionId: string | null;
+  cwd: string;
+  gitRoot: string;
+  executionCwd: string;
+  nativeAgentLoopStatePath: string | null;
+  selectedRoute: SelectedChatRoute | null;
+  input: string;
+  userInput: UserInput;
+  compactionSummary?: string | null;
+  priorTurns: ChatMessage[];
+  basePrompt: string;
+  prompt: string;
+  systemPrompt: string;
+  agentLoopSystemPrompt: string;
+  runtimeControlContext: RuntimeControlChatContext | null;
+  fallbackReplyTarget?: RuntimeControlReplyTarget;
+  fallbackActor?: RuntimeControlActor;
+  executionGoalId?: string;
+  executionPolicy: ExecutionPolicy;
+  setupDialogue: SetupDialoguePublicState | null;
+  runSpecConfirmation: RunSpecConfirmationState | null;
+  setupSecretIntake: SetupSecretIntakeResult | null;
+  activatedTools: Set<string>;
+}
+
+export interface ChatTurnContextSnapshot {
+  schema_version: typeof CHAT_TURN_CONTEXT_SCHEMA_VERSION;
+  modelVisible: ChatTurnModelVisibleContext;
+}
+
+interface PublicReplyTarget {
+  surface?: string;
+  platform?: string;
+  conversation_id?: string;
+  identity_key?: string;
+  user_id?: string;
+  message_id?: string;
+  deliveryMode?: string;
+}
+
+interface PublicRuntimeActor {
+  surface?: string;
+  platform?: string;
+  conversation_id?: string;
+  identity_key?: string;
+  user_id?: string;
+}
+
+interface PublicSetupDialogueState {
+  id: string;
+  channel: string;
+  state: string;
+  action?: string;
+  updatedAt?: string;
+}
+
+interface PublicRunSpecConfirmationState {
+  state: RunSpecConfirmationState["state"];
+  specId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface PublicUserInput {
+  schema_version: typeof USER_INPUT_SCHEMA_VERSION;
+  rawText?: string;
+  items: PublicUserInputItem[];
+}
+
+type PublicUserInputItem =
+  | { kind: "text"; text: string }
+  | { kind: "image"; name?: string }
+  | { kind: "local_image"; name?: string }
+  | { kind: "mention"; label?: string }
+  | { kind: "skill"; name: string }
+  | { kind: "plugin"; name: string }
+  | { kind: "tool"; name: string }
+  | { kind: "attachment"; id: string; name?: string; mimeType?: string };
+
+export function buildChatTurnContext(input: ChatTurnContextInput): ChatTurnContext {
+  const route = input.selectedRoute
+    ? { kind: input.selectedRoute.kind, reason: input.selectedRoute.reason }
+    : null;
+  const runtimeControlContext = input.runtimeControlContext;
+  return {
+    schema_version: CHAT_TURN_CONTEXT_SCHEMA_VERSION,
+    modelVisible: {
+      turn: {
+        runId: input.eventContext.runId,
+        turnId: input.eventContext.turnId,
+        startedAt: input.startedAt.toISOString(),
+        currentDate: input.startedAt.toISOString(),
+        timezone: input.timezone ?? resolveLocalTimezone(),
+      },
+      session: {
+        sessionId: input.sessionId,
+        cwd: input.cwd,
+        gitRoot: input.gitRoot,
+        nativeAgentLoopStatePath: input.nativeAgentLoopStatePath,
+        route,
+      },
+      input: {
+        text: input.input,
+        userInput: toPublicUserInput(input.userInput, input.input),
+      },
+      conversation: {
+        compactionSummary: input.compactionSummary?.trim() ? input.compactionSummary : null,
+        priorTurns: input.priorTurns.map((message) => ({
+          role: message.role === "assistant" ? "assistant" : "user",
+          content: message.content,
+        })),
+      },
+      prompts: {
+        basePrompt: input.basePrompt,
+        prompt: input.prompt,
+      },
+      instructions: {
+        systemPrompt: input.systemPrompt,
+        agentLoopSystemPrompt: input.agentLoopSystemPrompt,
+      },
+      runtime: {
+        approvalMode: runtimeControlContext?.approvalMode ?? "interactive",
+        runtimeControlAllowed: runtimeControlContext?.allowed ?? true,
+        replyTarget: toPublicReplyTarget(runtimeControlContext?.replyTarget ?? null),
+        actor: toPublicActor(runtimeControlContext?.actor ?? null),
+      },
+      tools: {
+        activatedTools: [...input.activatedTools].sort(),
+        selectedRoute: route?.kind ?? null,
+      },
+      outstanding: {
+        setupDialogue: toPublicSetupDialogue(input.setupDialogue),
+        runSpecConfirmation: toPublicRunSpecConfirmation(input.runSpecConfirmation),
+      },
+      runtimeEvidence: {
+        status: "not_requested",
+        refs: [],
+      },
+    },
+    hostOnly: {
+      execution: {
+        cwd: input.cwd,
+        gitRoot: input.gitRoot,
+        executionCwd: input.executionCwd,
+        ...(input.executionGoalId ? { goalId: input.executionGoalId } : {}),
+        executionPolicy: input.executionPolicy,
+      },
+      runtime: {
+        runtimeControlContext,
+        ...(input.fallbackReplyTarget ? { fallbackReplyTarget: input.fallbackReplyTarget } : {}),
+        ...(input.fallbackActor ? { fallbackActor: input.fallbackActor } : {}),
+      },
+      setupSecretIntake: input.setupSecretIntake,
+    },
+  };
+}
+
+export function renderModelVisibleTurnContext(context: ChatTurnModelVisibleContext): string {
+  const lines = [
+    "## Turn Context",
+    `- turn_id: ${context.turn.turnId}`,
+    `- run_id: ${context.turn.runId}`,
+    `- current_date: ${context.turn.currentDate}`,
+    `- timezone: ${context.turn.timezone}`,
+    `- cwd: ${context.session.cwd}`,
+    `- git_root: ${context.session.gitRoot}`,
+    `- session_id: ${context.session.sessionId ?? "none"}`,
+    `- route: ${context.session.route ? `${context.session.route.kind} (${context.session.route.reason})` : "none"}`,
+    `- runtime_control_allowed: ${context.runtime.runtimeControlAllowed}`,
+    `- approval_mode: ${context.runtime.approvalMode}`,
+    `- reply_target: ${formatReplyTarget(context.runtime.replyTarget)}`,
+    `- activated_tools: ${context.tools.activatedTools.length > 0 ? context.tools.activatedTools.join(", ") : "none"}`,
+    `- setup_dialogue: ${context.outstanding.setupDialogue ? `${context.outstanding.setupDialogue.channel}:${context.outstanding.setupDialogue.state}` : "none"}`,
+    `- run_spec_confirmation: ${context.outstanding.runSpecConfirmation ? `${context.outstanding.runSpecConfirmation.state}:${context.outstanding.runSpecConfirmation.specId}` : "none"}`,
+    `- runtime_evidence: ${context.runtimeEvidence.status}`,
+  ];
+  return lines.join("\n");
+}
+
+export function renderSystemPromptWithTurnContext(systemPrompt: string | undefined, context: ChatTurnModelVisibleContext): string {
+  return [
+    systemPrompt?.trim() ?? "",
+    renderModelVisibleTurnContext(context),
+  ].filter((section) => section.length > 0).join("\n\n");
+}
+
+export function toTurnContextSnapshot(context: ChatTurnContext): ChatTurnContextSnapshot {
+  return {
+    schema_version: context.schema_version,
+    modelVisible: context.modelVisible,
+  };
+}
+
+function toPublicReplyTarget(target: RuntimeControlReplyTarget | null): PublicReplyTarget | null {
+  if (!target) return null;
+  return {
+    ...(target.surface ? { surface: target.surface } : {}),
+    ...(target.platform ? { platform: target.platform } : {}),
+    ...(target.conversation_id ? { conversation_id: target.conversation_id } : {}),
+    ...(target.identity_key ? { identity_key: target.identity_key } : {}),
+    ...(target.user_id ? { user_id: target.user_id } : {}),
+    ...(target.message_id ? { message_id: target.message_id } : {}),
+    ...(target.deliveryMode ? { deliveryMode: target.deliveryMode } : {}),
+  };
+}
+
+function toPublicActor(actor: RuntimeControlActor | null): PublicRuntimeActor | null {
+  if (!actor) return null;
+  return {
+    ...(actor.surface ? { surface: actor.surface } : {}),
+    ...(actor.platform ? { platform: actor.platform } : {}),
+    ...(actor.conversation_id ? { conversation_id: actor.conversation_id } : {}),
+    ...(actor.identity_key ? { identity_key: actor.identity_key } : {}),
+    ...(actor.user_id ? { user_id: actor.user_id } : {}),
+  };
+}
+
+function toPublicSetupDialogue(dialogue: SetupDialoguePublicState | null): PublicSetupDialogueState | null {
+  if (!dialogue) return null;
+  return {
+    id: dialogue.id,
+    channel: dialogue.selectedChannel,
+    state: dialogue.state,
+    ...(dialogue.action ? { action: dialogue.action.kind } : {}),
+    updatedAt: dialogue.updatedAt,
+  };
+}
+
+function toPublicRunSpecConfirmation(confirmation: RunSpecConfirmationState | null): PublicRunSpecConfirmationState | null {
+  if (!confirmation) return null;
+  return {
+    state: confirmation.state,
+    specId: confirmation.spec.id,
+    createdAt: confirmation.createdAt,
+    updatedAt: confirmation.updatedAt,
+  };
+}
+
+function toPublicUserInput(input: UserInput, redactedText: string): PublicUserInput {
+  return {
+    schema_version: USER_INPUT_SCHEMA_VERSION,
+    rawText: redactedText,
+    items: input.items.map((item): PublicUserInputItem => {
+      if (item.kind === "text") {
+        return { kind: "text", text: redactedText };
+      }
+      if (item.kind === "image" || item.kind === "local_image") {
+        return {
+          kind: item.kind,
+          ...(item.name ? { name: item.name } : {}),
+        };
+      }
+      if (item.kind === "mention") {
+        return {
+          kind: "mention",
+          ...(item.label ? { label: item.label } : {}),
+        };
+      }
+      if (item.kind === "skill" || item.kind === "plugin" || item.kind === "tool") {
+        return { kind: item.kind, name: item.name };
+      }
+      return {
+        kind: "attachment",
+        id: item.id,
+        ...(item.name ? { name: item.name } : {}),
+        ...(item.mimeType ? { mimeType: item.mimeType } : {}),
+      };
+    }),
+  };
+}
+
+function formatReplyTarget(target: PublicReplyTarget | null): string {
+  if (!target) return "none";
+  return [
+    target.surface,
+    target.platform,
+    target.conversation_id,
+    target.message_id,
+  ].filter(Boolean).join(":") || "present";
+}
+
+function resolveLocalTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}


### PR DESCRIPTION
Closes #1108

Summary:
- Add a first-class typed Chat TurnContext with model-visible and host-only slices.
- Render TurnContext into assist, agent-loop, tool-loop, and adapter request construction while keeping approval functions, fallback targets, and setup secrets host-only.
- Persist sanitized per-turn context snapshots before model execution and preserve them across session load/rename/resume paths.

Tests:
- npm test -- src/interface/chat/__tests__/turn-context.test.ts src/interface/chat/__tests__/chat-runner.test.ts src/interface/chat/__tests__/chat-session-store.test.ts src/interface/chat/__tests__/chat-history.test.ts src/interface/chat/__tests__/chat-runner-runtime.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

Known risks:
- runtimeEvidence is represented as a typed TurnContext field in this slice, but richer evidence-ledger hydration is still future work.