### PR TITLE
feat(model): add chat model request builder

### DIFF
--- a/src/interface/chat/__tests__/chat-runner-tools.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-tools.test.ts
@@ -3,7 +3,7 @@ import { ChatRunner } from "../chat-runner.js";
 import type { ChatRunnerDeps } from "../chat-runner-contracts.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js";
-import type { ILLMClient, LLMResponse } from "../../../base/llm/llm-client.js";
+import type { ILLMClient, LLMMessage, LLMRequestOptions, LLMResponse } from "../../../base/llm/llm-client.js";
 import type { ToolRegistry } from "../../../tools/registry.js";
 import type { ToolExecutor } from "../../../tools/executor.js";
 import type { ITool, ToolResult, ToolCallContext } from "../../../tools/types.js";
@@ -394,5 +394,105 @@ describe("ChatRunner — tool status callbacks", () => {
       expect(onToolStart).not.toHaveBeenCalled();
       expect(onToolEnd).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe("ChatRunner — Codex-like model request builder path", () => {
+  it("presents the same typed tool schema for paraphrased English and Japanese freeform requests", async () => {
+    const capturedToolRequests: Array<{ messages: LLMMessage[]; options?: LLMRequestOptions }> = [];
+    const tool = {
+      metadata: {
+        name: "workspace_status",
+        aliases: [],
+        permissionLevel: "read_only",
+        isReadOnly: true,
+        isDestructive: false,
+        shouldDefer: false,
+        alwaysLoad: false,
+        maxConcurrency: 0,
+        maxOutputChars: 4000,
+        tags: [],
+      },
+      inputSchema: z.object({
+        scope: z.enum(["workspace"]),
+      }),
+      description: () => "Read workspace status through the typed tool boundary.",
+      call: vi.fn().mockResolvedValue({
+        success: true,
+        data: { clean: true },
+        summary: "workspace clean",
+        durationMs: 1,
+      }),
+      checkPermissions: vi.fn().mockResolvedValue({ status: "allowed" }),
+      isConcurrencySafe: () => true,
+    } as unknown as ITool;
+    let callIndex = 0;
+    const llmClient = {
+      supportsToolCalling: () => true,
+      sendMessage: vi.fn().mockImplementation(async (messages: LLMMessage[], options?: LLMRequestOptions) => {
+        callIndex += 1;
+        const stage = ((callIndex - 1) % 3) + 1;
+        if (stage === 1) {
+          return {
+            content: JSON.stringify({
+              kind: "execute",
+              confidence: 0.94,
+              rationale: "tool-backed workspace status request",
+            }),
+            usage: { input_tokens: 1, output_tokens: 1 },
+            stop_reason: "end_turn",
+            tool_calls: [],
+          } satisfies LLMResponse;
+        }
+        if (stage === 2) {
+          capturedToolRequests.push({ messages, options });
+          return {
+            content: "",
+            usage: { input_tokens: 1, output_tokens: 1 },
+            stop_reason: "tool_calls",
+            tool_calls: [{
+              id: `tc-${callIndex}`,
+              type: "function",
+              function: {
+                name: "workspace_status",
+                arguments: JSON.stringify({ scope: "workspace" }),
+              },
+            }],
+          } satisfies LLMResponse;
+        }
+        return {
+          content: "workspace clean",
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "completed",
+          tool_calls: [],
+        } satisfies LLMResponse;
+      }),
+      parseJSON: vi.fn((content: string, schema: z.ZodSchema) => schema.parse(JSON.parse(content))),
+    } as unknown as ILLMClient;
+
+    const runner = new ChatRunner(makeDeps({
+      llmClient,
+      registry: makeMockRegistry(tool),
+    }));
+
+    await runner.execute("Could you inspect the workspace state?", "/repo");
+    await runner.execute("作業ツリーの状態を確認して", "/repo");
+
+    expect(tool.call).toHaveBeenCalledTimes(2);
+    expect(capturedToolRequests).toHaveLength(2);
+    for (const request of capturedToolRequests) {
+      expect(request.options?.tools?.map((definition) => definition.function.name)).toEqual(["workspace_status"]);
+      expect(request.options?.tools?.[0]?.function.parameters).toMatchObject({
+        type: "object",
+        properties: {
+          scope: expect.objectContaining({ enum: ["workspace"] }),
+        },
+        required: ["scope"],
+      });
+      expect(request.options?.system).toContain("## Turn Context");
+      expect(request.options?.system).not.toContain("return exactly one JSON object");
+    }
+    expect(capturedToolRequests[0].messages.at(-1)?.content).toContain("Could you inspect the workspace state?");
+    expect(capturedToolRequests[1].messages.at(-1)?.content).toContain("作業ツリーの状態を確認して");
   });
 });

--- a/src/interface/chat/__tests__/model-request-builder.test.ts
+++ b/src/interface/chat/__tests__/model-request-builder.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { defaultExecutionPolicy } from "../../../orchestrator/execution/agent-loop/execution-policy.js";
+import type { ITool, ToolCallContext, ToolResult } from "../../../tools/types.js";
+import {
+  buildChatModelRequest,
+} from "../model-request-builder.js";
+import {
+  buildChatTurnContext,
+  type ChatTurnContext,
+} from "../turn-context.js";
+import { createTextUserInput } from "../user-input.js";
+
+function makeTurnContext(): ChatTurnContext {
+  return buildChatTurnContext({
+    eventContext: { runId: "run-model", turnId: "turn-model" },
+    startedAt: new Date("2026-05-06T08:30:00.000Z"),
+    timezone: "Asia/Tokyo",
+    sessionId: "session-model",
+    cwd: "/repo",
+    gitRoot: "/repo",
+    executionCwd: "/repo",
+    nativeAgentLoopStatePath: "chat/agentloop/session-model.state.json",
+    selectedRoute: {
+      kind: "tool_loop",
+      reason: "tool_loop_available",
+      replyTargetPolicy: "turn_reply_target",
+      eventProjectionPolicy: "turn_only",
+      concurrencyPolicy: "session_serial",
+    },
+    input: "Check the workspace state",
+    userInput: createTextUserInput("Check the workspace state"),
+    priorTurns: [
+      { role: "user", content: "Earlier question", timestamp: "2026-05-06T08:29:00.000Z", turnIndex: 0 },
+      { role: "assistant", content: "Earlier answer", timestamp: "2026-05-06T08:29:01.000Z", turnIndex: 1 },
+    ],
+    basePrompt: "Check the workspace state",
+    prompt: "Previous conversation:\nUser: Earlier question\nAssistant: Earlier answer\n\nCurrent message:\nCheck the workspace state",
+    systemPrompt: "Base instructions",
+    agentLoopSystemPrompt: "Agent loop instructions",
+    runtimeControlContext: null,
+    executionPolicy: defaultExecutionPolicy("/repo"),
+    setupDialogue: null,
+    runSpecConfirmation: null,
+    setupSecretIntake: null,
+    activatedTools: new Set(),
+  });
+}
+
+function makeTool(name: string): ITool {
+  return {
+    metadata: {
+      name,
+      aliases: [],
+      permissionLevel: "read_only",
+      isReadOnly: true,
+      isDestructive: false,
+      shouldDefer: false,
+      alwaysLoad: false,
+      maxConcurrency: 0,
+      maxOutputChars: 4000,
+      tags: [],
+    },
+    inputSchema: z.object({
+      scope: z.enum(["workspace", "session"]),
+    }),
+    description: () => "Read typed workspace status.",
+    call: vi.fn(async (_input: unknown, _context: ToolCallContext): Promise<ToolResult> => ({
+      success: true,
+      data: null,
+      summary: "ok",
+      durationMs: 1,
+    })),
+    checkPermissions: vi.fn().mockResolvedValue({ status: "allowed" }),
+    isConcurrencySafe: () => true,
+  } as unknown as ITool;
+}
+
+describe("buildChatModelRequest", () => {
+  it("builds ordinary chat requests without requiring schema-shaped final JSON", () => {
+    const request = buildChatModelRequest({
+      purpose: "ordinary_chat",
+      turnContext: makeTurnContext(),
+      systemPrompt: "Answer normally.",
+    });
+
+    expect(request.purpose).toBe("ordinary_chat");
+    expect(request.toolMode).toBe("none");
+    expect(request.structuredOutput).toEqual({
+      finalJsonRequired: false,
+      reason: "ordinary_text",
+    });
+    expect(request.toolDefinitions).toEqual([]);
+    expect(request.options.tools).toBeUndefined();
+    expect(request.options.system).toContain("## Turn Context");
+    expect(request.options.system).not.toContain("Return only JSON");
+    expect(request.messages).toEqual([
+      { role: "user", content: "Earlier question" },
+      { role: "assistant", content: "Earlier answer" },
+      { role: "user", content: "Check the workspace state" },
+    ]);
+  });
+
+  it("builds native tool-call requests from typed tool schemas", () => {
+    const request = buildChatModelRequest({
+      purpose: "tool_call",
+      turnContext: makeTurnContext(),
+      systemPrompt: "Use tools when needed.",
+      availableTools: [makeTool("workspace_status")],
+      supportsNativeToolCalling: true,
+    });
+
+    expect(request.toolMode).toBe("native");
+    expect(request.structuredOutput).toEqual({
+      finalJsonRequired: false,
+      reason: "native_tool_calls",
+    });
+    expect(request.options.tools?.[0]).toMatchObject({
+      type: "function",
+      function: {
+        name: "workspace_status",
+        description: "Read typed workspace status.",
+      },
+    });
+    expect(request.options.tools?.[0]?.function.parameters).toMatchObject({
+      type: "object",
+      properties: {
+        scope: expect.objectContaining({ enum: ["workspace", "session"] }),
+      },
+      required: ["scope"],
+    });
+    expect(request.options.system).toContain("## Turn Context");
+    expect(request.options.system).not.toContain("return exactly one JSON object");
+  });
+
+  it("keeps prompted tool JSON mode explicit for clients without native tool calling", () => {
+    const request = buildChatModelRequest({
+      purpose: "tool_call",
+      turnContext: makeTurnContext(),
+      systemPrompt: "Use tools when needed.",
+      availableTools: [makeTool("workspace_status")],
+      supportsNativeToolCalling: false,
+    });
+
+    expect(request.toolMode).toBe("prompted");
+    expect(request.structuredOutput).toEqual({
+      finalJsonRequired: true,
+      reason: "prompted_tool_protocol",
+    });
+    expect(request.options.tools).toBeUndefined();
+    expect(request.options.system).toContain("workspace_status");
+    expect(request.options.system).toContain("return exactly one JSON object");
+  });
+});

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -2,11 +2,7 @@ import type { IAdapter, AgentTask } from "../../orchestrator/execution/adapter-l
 import type { ILLMClient, LLMMessage, LLMRequestOptions, LLMResponse, ToolCallResult } from "../../base/llm/llm-client.js";
 import { loadProviderConfig } from "../../base/llm/provider-config.js";
 import type { ApprovalRequest, ToolCallContext } from "../../tools/types.js";
-import { toToolDefinitionsFiltered } from "../../tools/tool-definition-adapter.js";
-import {
-  buildPromptedToolProtocolSystemPrompt,
-  extractPromptedToolCalls,
-} from "../../orchestrator/execution/agent-loop/prompted-tool-protocol.js";
+import { extractPromptedToolCalls } from "../../orchestrator/execution/agent-loop/prompted-tool-protocol.js";
 import { verifyChatAction } from "./chat-verifier.js";
 import {
   collectGitDiffArtifact,
@@ -25,6 +21,7 @@ import {
   renderSystemPromptWithTurnContext,
   type ChatTurnContext,
 } from "./turn-context.js";
+import { buildChatModelRequest } from "./model-request-builder.js";
 import {
   createDiscordAdapterPlanDialogue,
   createTelegramConfirmWriteDialogue,
@@ -184,18 +181,19 @@ export async function executeAssistRoute(
     );
   }
   host.eventBridge.emitCheckpoint("Read-only assist selected", "The message will be answered without coding-agent execution.", params.eventContext, "route");
-  const messages: LLMMessage[] = [
-    ...params.turnContext.modelVisible.conversation.priorTurns.map((m): LLMMessage => ({ role: m.role, content: m.content })),
-    { role: "user", content: params.turnContext.modelVisible.input.text },
-  ];
-  const response = await sendLLMMessage(host, host.deps.llmClient, messages, {
-    system: renderSystemPromptWithTurnContext([
+  const modelRequest = buildChatModelRequest({
+    purpose: "ordinary_chat",
+    turnContext: params.turnContext,
+    systemPrompt: [
       params.turnContext.modelVisible.instructions.systemPrompt || buildStaticSystemPrompt(host.getProviderConfigBaseDir()),
       "Answer read-only. Provide concise operational guidance. Do not ask to edit files or run commands unless the user explicitly asks for execution.",
       sameLanguageResponseInstruction(host.getTurnLanguageHint()),
-    ].join(" "), params.turnContext.modelVisible),
-    max_tokens: 1000,
+    ].join(" "),
+    maxTokens: 1000,
     temperature: 0,
+  });
+  const response = await sendLLMMessage(host, host.deps.llmClient, modelRequest.messages, {
+    ...modelRequest.options,
   }, params.assistantBuffer, params.eventContext);
   const usage = usageFromLLMResponse(response);
   if (hasUsage(usage)) params.history.recordUsage("assist", usage);
@@ -585,23 +583,33 @@ async function executeWithTools(
   start?: number,
 ): Promise<{ output: string; usage: ChatUsageCounter }> {
   const llmClient = host.deps.llmClient!;
-  const messages: LLMMessage[] = [{ role: "user", content: turnContext.modelVisible.prompts.prompt }];
+  const supportsNativeToolCalling = llmClient.supportsToolCalling?.() !== false;
+  const initialModelRequest = buildChatModelRequest({
+    purpose: "tool_call",
+    turnContext,
+    systemPrompt,
+    availableTools: host.deps.registry?.listAll() ?? [],
+    activatedTools: host.activatedTools,
+    supportsNativeToolCalling,
+  });
+  const messages: LLMMessage[] = [...initialModelRequest.messages];
   const toolCallContext = await buildToolCallContext(host, goalId, runtimeControlContext, start, turnContext);
   const usage = zeroUsageCounter();
 
   for (let loop = 0; loop < MAX_TOOL_LOOPS; loop++) {
-    const tools = host.deps.registry
-      ? toToolDefinitionsFiltered(host.deps.registry.listAll(), { activatedTools: host.activatedTools })
-      : [];
-    const supportsNativeToolCalling = llmClient.supportsToolCalling?.() !== false;
+    const modelRequest = buildChatModelRequest({
+      purpose: "tool_call",
+      turnContext,
+      systemPrompt,
+      availableTools: host.deps.registry?.listAll() ?? [],
+      activatedTools: host.activatedTools,
+      supportsNativeToolCalling,
+      messages,
+    });
     let response: LLMResponse;
     try {
       host.eventBridge.emitActivity("lifecycle", "Calling model...", eventContext, "lifecycle:model");
-      response = await sendLLMMessage(host, llmClient, messages, {
-        ...(supportsNativeToolCalling
-          ? { tools, ...(systemPrompt ? { system: systemPrompt } : {}) }
-          : { system: buildPromptedToolProtocolSystemPrompt({ systemPrompt, tools }) }),
-      }, assistantBuffer, eventContext);
+      response = await sendLLMMessage(host, llmClient, modelRequest.messages, modelRequest.options, assistantBuffer, eventContext);
     } catch (err) {
       console.error("[chat-runner] executeWithTools error:", err);
       const hint = err instanceof Error ? `: ${err.message}` : "";
@@ -615,7 +623,7 @@ async function executeWithTools(
         ? []
         : extractPromptedToolCalls({
             content: response.content,
-            tools,
+            tools: modelRequest.toolDefinitions,
             createId: () => `prompted-${loop}-${crypto.randomUUID()}`,
           }).map((call): ToolCallResult => ({
             id: call.id,

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -699,7 +699,7 @@ export class ChatRunner {
         turnContext,
         eventContext,
         assistantBuffer,
-        systemPrompt: renderSystemPromptWithTurnContext(systemPrompt || undefined, turnContext.modelVisible),
+        systemPrompt: systemPrompt || undefined,
         executionGoalId,
         history,
         gitRoot,

--- a/src/interface/chat/model-request-builder.ts
+++ b/src/interface/chat/model-request-builder.ts
@@ -1,0 +1,130 @@
+import type {
+  LLMMessage,
+  LLMRequestOptions,
+  ToolDefinition,
+} from "../../base/llm/llm-client.js";
+import {
+  buildPromptedToolProtocolSystemPrompt,
+} from "../../orchestrator/execution/agent-loop/prompted-tool-protocol.js";
+import { toToolDefinitionsFiltered } from "../../tools/tool-definition-adapter.js";
+import type { ITool } from "../../tools/types.js";
+import {
+  renderSystemPromptWithTurnContext,
+  type ChatTurnContext,
+} from "./turn-context.js";
+
+export const CHAT_MODEL_REQUEST_SCHEMA_VERSION = "chat-model-request-v1";
+
+export type ChatModelRequestPurpose = "ordinary_chat" | "tool_call";
+export type ChatToolMode = "none" | "native" | "prompted";
+
+export interface ChatModelRequest {
+  schema_version: typeof CHAT_MODEL_REQUEST_SCHEMA_VERSION;
+  purpose: ChatModelRequestPurpose;
+  messages: LLMMessage[];
+  options: LLMRequestOptions;
+  toolDefinitions: ToolDefinition[];
+  toolMode: ChatToolMode;
+  structuredOutput: {
+    finalJsonRequired: boolean;
+    reason: "ordinary_text" | "native_tool_calls" | "prompted_tool_protocol";
+  };
+}
+
+export interface BuildOrdinaryChatModelRequestInput {
+  purpose: "ordinary_chat";
+  turnContext: ChatTurnContext;
+  systemPrompt?: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface BuildToolCallModelRequestInput {
+  purpose: "tool_call";
+  turnContext: ChatTurnContext;
+  systemPrompt?: string;
+  availableTools: ITool[];
+  activatedTools?: Set<string>;
+  supportsNativeToolCalling: boolean;
+  messages?: LLMMessage[];
+}
+
+export type BuildChatModelRequestInput =
+  | BuildOrdinaryChatModelRequestInput
+  | BuildToolCallModelRequestInput;
+
+export function buildChatModelRequest(input: BuildChatModelRequestInput): ChatModelRequest {
+  if (input.purpose === "ordinary_chat") {
+    return buildOrdinaryChatRequest(input);
+  }
+  return buildToolCallRequest(input);
+}
+
+function buildOrdinaryChatRequest(input: BuildOrdinaryChatModelRequestInput): ChatModelRequest {
+  return {
+    schema_version: CHAT_MODEL_REQUEST_SCHEMA_VERSION,
+    purpose: "ordinary_chat",
+    messages: [
+      ...input.turnContext.modelVisible.conversation.priorTurns,
+      { role: "user", content: input.turnContext.modelVisible.input.text },
+    ],
+    options: {
+      system: renderSystemPromptWithTurnContext(input.systemPrompt, input.turnContext.modelVisible),
+      max_tokens: input.maxTokens ?? 1000,
+      temperature: input.temperature ?? 0,
+    },
+    toolDefinitions: [],
+    toolMode: "none",
+    structuredOutput: {
+      finalJsonRequired: false,
+      reason: "ordinary_text",
+    },
+  };
+}
+
+function buildToolCallRequest(input: BuildToolCallModelRequestInput): ChatModelRequest {
+  const activatedTools = input.activatedTools ?? new Set(input.turnContext.modelVisible.tools.activatedTools);
+  const toolDefinitions = toToolDefinitionsFiltered(input.availableTools, {
+    activatedTools,
+  });
+  const baseSystemPrompt = renderSystemPromptWithTurnContext(input.systemPrompt, input.turnContext.modelVisible);
+  const messages: LLMMessage[] = input.messages
+    ? [...input.messages]
+    : [{ role: "user", content: input.turnContext.modelVisible.prompts.prompt }];
+
+  if (input.supportsNativeToolCalling) {
+    return {
+      schema_version: CHAT_MODEL_REQUEST_SCHEMA_VERSION,
+      purpose: "tool_call",
+      messages,
+      options: {
+        ...(toolDefinitions.length > 0 ? { tools: toolDefinitions } : {}),
+        ...(baseSystemPrompt ? { system: baseSystemPrompt } : {}),
+      },
+      toolDefinitions,
+      toolMode: "native",
+      structuredOutput: {
+        finalJsonRequired: false,
+        reason: "native_tool_calls",
+      },
+    };
+  }
+
+  return {
+    schema_version: CHAT_MODEL_REQUEST_SCHEMA_VERSION,
+    purpose: "tool_call",
+    messages,
+    options: {
+      system: buildPromptedToolProtocolSystemPrompt({
+        systemPrompt: baseSystemPrompt,
+        tools: toolDefinitions,
+      }),
+    },
+    toolDefinitions,
+    toolMode: "prompted",
+    structuredOutput: {
+      finalJsonRequired: true,
+      reason: "prompted_tool_protocol",
+    },
+  };
+}


### PR DESCRIPTION
Closes #1109

Summary:
- Add a central chat model request builder that combines conversation history, base instructions, TurnContext, and model-visible tool schemas.
- Route ordinary assist and tool-loop model calls through the builder while keeping ordinary chat as text output, not schema-shaped final JSON.
- Keep native tool calling and prompted tool JSON protocol explicit, with tool schemas generated from typed ITool definitions.

Tests:
- npm test -- src/interface/chat/__tests__/model-request-builder.test.ts src/interface/chat/__tests__/chat-runner-tools.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

Review:
- Fresh review reported no material findings.

Known risks:
- This centralizes chat assist/tool-loop request construction; native agent-loop request assembly remains on its dedicated runtime path.