### PR TITLE
fix(runtime): ignore fuzzy evidence target labels

### DIFF
--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -755,6 +755,80 @@ describe("standalone slash command routing", () => {
     screen.unmount();
   });
 
+  it("does not let fuzzy runtime labels block TUI evidence answers as missing exact runs", async () => {
+    const stateManager = createStateManagerMock();
+    const chatRunner = createChatRunnerMock();
+    const llmClient = createSingleMockLLMClient(JSON.stringify({
+      decision: "runtime_evidence_question",
+      topics: ["progress", "metric", "blocker"],
+      confidence: 0.93,
+      targetRunId: "durableloop",
+    }));
+    testState.runtimeSessionSnapshots = [{
+      schema_version: "runtime-session-registry-v1",
+      generated_at: "2026-05-02T00:00:00.000Z",
+      sessions: [],
+      background_runs: [{
+        schema_version: "background-run-v1",
+        id: "run-evidence",
+        kind: "coreloop_run",
+        parent_session_id: null,
+        child_session_id: null,
+        process_session_id: null,
+        status: "running",
+        notify_policy: "done_only",
+        reply_target_source: "none",
+        pinned_reply_target: null,
+        title: "Kaggle DurableLoop run",
+        workspace: "/repo",
+        created_at: "2026-05-02T00:00:00.000Z",
+        started_at: "2026-05-02T00:00:00.000Z",
+        updated_at: "2026-05-02T00:00:00.000Z",
+        completed_at: null,
+        summary: "Kaggle run is executing",
+        error: null,
+        artifacts: [],
+        source_refs: [],
+      }],
+      warnings: [],
+    }];
+    testState.runtimeEvidenceSummaries = {
+      "run-evidence": createEvidenceSummary(),
+    };
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      llmClient,
+      chatRunner: chatRunner as unknown as TuiChatSurface,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/work/kaggle",
+      gitBranch: "main",
+      providerName: "claude",
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("kaggleタスクdurableloopの方で回す準備できてる？このまま回し始めても大丈夫？");
+    await flush();
+
+    const visibleText = testState.lastChatMessages.map((message) => message.text).join("\n");
+    expect(chatRunner.execute).not.toHaveBeenCalled();
+    expect(chatRunner.executeIngressMessage).not.toHaveBeenCalled();
+    expect(testState.summarizedRunIds).toEqual(["run-evidence"]);
+    expect(visibleText).toContain("Runtime evidence answer for run run-evidence");
+    expect(visibleText).toContain("balanced_accuracy");
+    expect(visibleText).toContain("Requested target \"durableloop\" did not match");
+    expect(visibleText).not.toContain("requested run was not found");
+
+    screen.unmount();
+  });
+
   it("routes non-evidence multilingual chat through ChatRunner when classifier says not evidence", async () => {
     const stateManager = createStateManagerMock();
     const chatRunner = createChatRunnerMock();

--- a/src/runtime/__tests__/runtime-evidence-answer.test.ts
+++ b/src/runtime/__tests__/runtime-evidence-answer.test.ts
@@ -522,6 +522,52 @@ describe("buildRuntimeEvidenceAnswer", () => {
     expect(result.message).not.toContain("0.12");
   });
 
+  it("does not treat model-extracted freeform labels as exact missing run ids", async () => {
+    const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-evidence-fuzzy-target-"));
+    const stateManager = { getBaseDir: () => tmp };
+    const ledger = new RuntimeEvidenceLedger(path.join(tmp, "runtime"));
+    const runLedger = new BackgroundRunLedger(path.join(tmp, "runtime"));
+    await ledger.append({
+      kind: "metric",
+      scope: { run_id: "run-active" },
+      occurred_at: "2026-05-02T00:20:00.000Z",
+      metrics: [{ label: "score", value: 0.88, direction: "maximize", observed_at: "2026-05-02T00:20:00.000Z" }],
+      summary: "active run evidence",
+    });
+    await runLedger.create({
+      id: "run-active",
+      kind: "coreloop_run",
+      status: "running",
+      notify_policy: "silent",
+      title: "Kaggle DurableLoop run",
+      workspace: "/repo",
+      created_at: "2026-05-02T00:00:00.000Z",
+      started_at: "2026-05-02T00:00:00.000Z",
+      updated_at: "2026-05-02T00:25:00.000Z",
+    });
+
+    const result = await answerRuntimeEvidenceQuestion({
+      text: "kaggle task durableloop readiness check",
+      stateManager,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "runtime_evidence_question",
+        topics: ["progress", "metric", "blocker"],
+        confidence: 0.9,
+        targetRunId: "durableloop",
+      })),
+      now: NOW,
+    });
+
+    expect(result.kind).toBe("answered");
+    expect(result.targetRunId).toBe("run-active");
+    expect(result.messageType).toBe("warning");
+    expect(result.message).toContain("Runtime evidence answer for run run-active");
+    expect(result.message).toContain("score");
+    expect(result.message).toContain("0.88");
+    expect(result.message).toContain("Requested target \"durableloop\" did not match");
+    expect(result.message).not.toContain("requested run was not found");
+  });
+
   it("redacts evaluator gap summaries in blocker output", () => {
     const result = buildRuntimeEvidenceAnswer({
       text: "What is blocked?",

--- a/src/runtime/evidence-answer.ts
+++ b/src/runtime/evidence-answer.ts
@@ -77,6 +77,7 @@ Runtime evidence questions ask about a current or recent background run using Ru
 - report: what should be included in a report/postmortem/writeup
 
 Return not_runtime_evidence_question for ordinary chat, requests to start/stop/pause/control a run, instructions to do new work, explanatory questions not asking for persisted runtime evidence, or ambiguous/low-confidence text.
+Set targetRunId only when the user copied an exact runtime catalog run id. Do not put natural-language labels, titles, task names, component names, tool names, "current", "latest", or "previous" in targetRunId.
 
 Respond only as JSON: { "decision": "runtime_evidence_question" | "not_runtime_evidence_question", "topics": ["progress"], "confidence": 0.0-1.0, "targetRunId": "optional exact run id if explicitly named", "rationale": "short" }`;
 }
@@ -137,18 +138,23 @@ export async function answerRuntimeEvidenceQuestion(input: RuntimeEvidenceAnswer
     healthStore.loadSnapshot().catch(() => null),
   ]);
   const candidates = selectCandidateRuns(snapshot);
-  const targetRun = query.targetRunId
-    ? candidates.find((run) => run.id === query.targetRunId)
+  const queryTargetRunId = query.targetRunId?.trim();
+  const targetRun = queryTargetRunId
+    ? candidates.find((run) => run.id === queryTargetRunId)
     : undefined;
-  if (query.targetRunId && !targetRun) {
+  if (
+    queryTargetRunId
+    && !targetRun
+    && isExactMissingRunIdReference(input.text, queryTargetRunId)
+  ) {
     return {
       kind: "answered",
       message: [
-        `Runtime evidence answer for run ${query.targetRunId}.`,
+        `Runtime evidence answer for run ${queryTargetRunId}.`,
         "Evidence missing: the requested run was not found in the Runtime Session Catalog.",
       ].join("\n"),
       messageType: "warning",
-      targetRunId: query.targetRunId,
+      targetRunId: queryTargetRunId,
       topics: query.topics,
       confidence: query.confidence,
     };
@@ -158,8 +164,8 @@ export async function answerRuntimeEvidenceQuestion(input: RuntimeEvidenceAnswer
     const summary = await ledger.summarizeRun(run.id).catch(() => null);
     return { run, summary };
   }));
-  const selected = selectUnderstoodRun(summaries, query.targetRunId);
-  return buildRuntimeEvidenceAnswer({
+  const selected = selectUnderstoodRun(summaries, queryTargetRunId);
+  const result = buildRuntimeEvidenceAnswer({
     text: input.text,
     topics: query.topics,
     snapshot,
@@ -168,6 +174,7 @@ export async function answerRuntimeEvidenceQuestion(input: RuntimeEvidenceAnswer
     summary: selected.summary,
     now: input.now,
   }, query.confidence);
+  return appendIgnoredTargetRunCaveat(result, queryTargetRunId && !targetRun ? queryTargetRunId : undefined);
 }
 
 export function buildRuntimeEvidenceAnswer(input: RuntimeEvidenceAnswerModelInput, confidence?: number): RuntimeEvidenceAnswerResult {
@@ -250,6 +257,28 @@ function selectUnderstoodRun(
     if (matched) return matched;
   }
   return summaries[0] ?? { run: null, summary: null };
+}
+
+function isExactMissingRunIdReference(text: string, targetRunId: string): boolean {
+  const target = targetRunId.trim();
+  if (!target || !text.includes(target)) return false;
+  return /^run(?::|-)[A-Za-z0-9][A-Za-z0-9_.:-]*$/.test(target);
+}
+
+function appendIgnoredTargetRunCaveat(
+  result: RuntimeEvidenceAnswerResult,
+  ignoredTargetRunId: string | undefined,
+): RuntimeEvidenceAnswerResult {
+  if (!ignoredTargetRunId || result.kind !== "answered" || !result.message) return result;
+  const caveat = `Requested target "${sanitizeOneLine(ignoredTargetRunId)}" did not match an exact Runtime Session Catalog run id; selected the active or most recent run instead.`;
+  const message = result.message.includes("Evidence caveats:\n")
+    ? `${result.message}\n- ${caveat}.`
+    : `${result.message}\nEvidence caveats:\n- ${caveat}.`;
+  return {
+    ...result,
+    message,
+    messageType: "warning",
+  };
 }
 
 function selectCandidateRuns(snapshot: RuntimeSessionRegistrySnapshot | null): BackgroundRun[] {
@@ -430,4 +459,8 @@ function sanitize(value: string): string {
     .replace(/xox[baprs]-[A-Za-z0-9-]{12,}/g, "xox-[REDACTED]")
     .replace(/([?&](?:token|key|secret|password)=)[^&\s]+/gi, "$1[REDACTED]")
     .replace(/(^|\s)(?:token|secret|password|api_key)=\S+/gi, "$1[REDACTED]");
+}
+
+function sanitizeOneLine(value: string): string {
+  return sanitize(value).replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
## Summary

- Treat model-extracted freeform runtime labels as fuzzy targets instead of exact missing run ids.
- Keep missing-run answers limited to explicit exact runtime catalog id references like `run-...` or `run:...`.
- Add runtime evidence and TUI caller-path regression coverage for the `durableloop` natural-language label case.

## Tests

- `npx vitest run --config vitest.config.ts src/runtime/__tests__/runtime-evidence-answer.test.ts`
- `npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/app.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed`
- `git diff --check`

## Review

- Fresh review agent: no material findings.

## Risks

- The `includes`/regex check is intentionally scoped to exact protocol-looking run ids after the model has already returned a target id; it is not used for freeform semantic routing.