### PR TITLE
feat(protocol): formalize exact command grammar boundaries

### DIFF
--- a/docs/design/execution/codex-like-interaction-contract.md
+++ b/docs/design/execution/codex-like-interaction-contract.md
@@ -23,8 +23,8 @@ same contract in a machine-checkable form for later production tests.
 ## Non-Goals
 
 - This contract does not add new tool execution behavior.
-- This contract does not define exact command grammar beyond saying exact
-  protocol surfaces can remain deterministic.
+- Exact protocol grammar is defined separately in
+  [Exact Protocol Grammar Boundaries](exact-protocol-boundaries.md).
 - This contract does not allow keyword lists, regex phrase tables, string
   `includes`, title matching, or language-specific shortcuts to become the
   primary decision mechanism for freeform semantic behavior.

--- a/docs/design/execution/exact-protocol-boundaries.md
+++ b/docs/design/execution/exact-protocol-boundaries.md
@@ -1,0 +1,66 @@
+# Exact Protocol Grammar Boundaries
+
+Status: Wave 1 contract for #1119 under the Codex-like interaction epic.
+
+This note defines where deterministic parsing is allowed. It is intentionally
+separate from freeform semantic routing: exact protocol parsers recognize
+explicit tokens, command grammar, ids, paths, URLs, schema values, feature
+flags, wire tokens, and mention syntax. They do not decide what ordinary prose
+means.
+
+## Allowed Deterministic Surfaces
+
+| Surface | Allowed | Boundary |
+| --- | --- | --- |
+| Slash command | Leading slash or exact symbol command owned by the surface. | Bare words such as `help`, `run`, or `status` are not commands. Sentences that mention command words stay freeform. |
+| CLI flag | Flags after an already selected CLI command. | Flags do not select a user intent outside that command grammar. |
+| ID | Exact goal, task, run, session, approval, or persisted record id. | IDs fill typed fields; they do not route freeform turns by themselves. |
+| Path | Filesystem path validated by the owning operation. | Path parsing validates an operation field, not the whole user intent. |
+| URL | URL parsed by a URL-aware caller. | URLs are exact references, not keyword shortcuts. |
+| Enum/schema | Literal values accepted by a schema or typed API. | Invalid values fail closed instead of guessing from prose. |
+| Feature flag | Named config/env switch and exact value. | Flags are config fields, not natural-language labels. |
+| Wire token | Transport/event token inside its protocol envelope. | Tokens are meaningful only inside that envelope. |
+| Mention | Exact structured target token such as `@run:run-123`. | Do not select targets by fuzzy labels, titles, or prose references. |
+
+The canonical source for this list is
+`src/base/protocol/exact-protocol.ts`.
+
+## Parser Rules
+
+- Exact parsers must be anchored to the explicit protocol surface they own.
+- Unknown exact slash commands return a typed command error. They do not fall
+  back to matching nearby freeform words.
+- Freeform paraphrases, multilingual requests, and ambiguous text stay as text
+  input unless a model/tool-schema boundary classifies them.
+- Mention parsing is token-level and structured. `@run:run-123` can produce a
+  `mention` item; `latest run`, `current session`, and title-like labels are
+  freeform references unless a typed resolver handles them.
+- Exact parser failures must return null, unknown, invalid-context, or schema
+  errors. They must not call a keyword fallback.
+
+## Review Guidance
+
+When reviewing protocol or semantic routing changes:
+
+- Check that deterministic parsing is limited to the allowed surface list.
+- Look for keyword lists, regex phrase tables, string `includes`, title
+  matching, and language-specific phrase shortcuts on freeform paths.
+- Require at least one caller-path test that sends ordinary text through the
+  real routing surface instead of passing a precomputed route.
+- Include paraphrases and multilingual examples when the behavior is
+  user-facing.
+- Treat command words embedded in prose as ordinary text.
+- Treat exact protocol tests as deterministic parser tests, not semantic
+  classifier coverage.
+
+## Test Requirements
+
+Exact protocol tests should cover positive grammar cases and negative freeform
+cases:
+
+- `/help` is a command; `help` is not.
+- `/status goal-123` is command grammar only where the owning command accepts an
+  argument; `show me status` is not.
+- `@run:run-123` is a mention token; `please mention run-123` is not.
+- A TUI or chat caller-path test must prove freeform paraphrases go to the
+  ordinary text/model path rather than a slash, mention, or keyword fallback.

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -38,3 +38,4 @@ The design index is a pointer into background material, not a replacement for th
 ## Active Interaction Contracts
 
 - [Codex-Like User Interaction Contract](execution/codex-like-interaction-contract.md)
+- [Exact Protocol Grammar Boundaries](execution/exact-protocol-boundaries.md)

--- a/src/base/protocol/__tests__/exact-protocol.test.ts
+++ b/src/base/protocol/__tests__/exact-protocol.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXACT_PROTOCOL_SURFACE_DEFINITIONS,
+  EXACT_PROTOCOL_SURFACES,
+  isExactProtocolSurface,
+  isExactSlashCommandInput,
+  parseExactMentionToken,
+  parseExactSlashCommand,
+  parseExactSlashCommandToken,
+} from "../exact-protocol.js";
+
+describe("exact protocol boundary", () => {
+  it("declares the deterministic surfaces allowed by the semantic policy", () => {
+    expect(EXACT_PROTOCOL_SURFACES).toEqual([
+      "slash_command",
+      "cli_flag",
+      "id",
+      "path",
+      "url",
+      "enum_schema",
+      "feature_flag",
+      "wire_token",
+      "mention",
+    ]);
+    expect(EXACT_PROTOCOL_SURFACE_DEFINITIONS.map((definition) => definition.surface)).toEqual(
+      EXACT_PROTOCOL_SURFACES,
+    );
+    expect(isExactProtocolSurface("mention")).toBe(true);
+    expect(isExactProtocolSurface("freeform_keyword")).toBe(false);
+  });
+
+  it("parses exact slash commands without accepting bare command-like words", () => {
+    const definitions = [
+      { command: "/help" },
+      { command: "/status", allowArguments: true },
+      { command: "/goals", aliases: ["/goal list"] },
+    ] as const;
+
+    expect(parseExactSlashCommand("/HELP", definitions)).toMatchObject({
+      command: "/help",
+      alias: "/help",
+      rawArgs: "",
+    });
+    expect(parseExactSlashCommand("/status goal-123", definitions)).toMatchObject({
+      command: "/status",
+      rawArgs: "goal-123",
+    });
+    expect(parseExactSlashCommand("/goal list", definitions)).toMatchObject({
+      command: "/goals",
+      alias: "/goal list",
+    });
+
+    expect(parseExactSlashCommand("help", definitions)).toBeNull();
+    expect(parseExactSlashCommand("show me status", definitions)).toBeNull();
+    expect(parseExactSlashCommand("statusを見せて", definitions)).toBeNull();
+    expect(parseExactSlashCommand("please run /status", definitions)).toBeNull();
+  });
+
+  it("keeps slash token parsing limited to leading slash grammar", () => {
+    expect(isExactSlashCommandInput("/settings")).toBe(true);
+    expect(parseExactSlashCommandToken("  /settings open  ")).toMatchObject({
+      command: "/settings",
+      rawArgs: "open",
+    });
+    expect(isExactSlashCommandInput("open settings")).toBe(false);
+    expect(isExactSlashCommandInput("設定を開いて")).toBe(false);
+    expect(parseExactSlashCommandToken("please use /settings")).toBeNull();
+  });
+
+  it("parses exact mention tokens without deriving targets from prose", () => {
+    expect(parseExactMentionToken("@run:run-123")).toEqual({
+      surface: "mention",
+      rawInput: "@run:run-123",
+      kind: "run",
+      id: "run-123",
+      target: "run:run-123",
+    });
+    expect(parseExactMentionToken("@session:conversation:abc")).toMatchObject({
+      kind: "session",
+      id: "conversation:abc",
+      target: "session:conversation:abc",
+    });
+
+    expect(parseExactMentionToken("run-123")).toBeNull();
+    expect(parseExactMentionToken("please mention @run:run-123")).toBeNull();
+    expect(parseExactMentionToken("@latest")).toBeNull();
+    expect(parseExactMentionToken("@title:Current Work")).toBeNull();
+  });
+});

--- a/src/base/protocol/exact-protocol.ts
+++ b/src/base/protocol/exact-protocol.ts
@@ -1,0 +1,232 @@
+export const EXACT_PROTOCOL_SURFACES = [
+  "slash_command",
+  "cli_flag",
+  "id",
+  "path",
+  "url",
+  "enum_schema",
+  "feature_flag",
+  "wire_token",
+  "mention",
+] as const;
+
+export type ExactProtocolSurface = typeof EXACT_PROTOCOL_SURFACES[number];
+
+export interface ExactProtocolSurfaceDefinition {
+  surface: ExactProtocolSurface;
+  allowed: string;
+  boundary: string;
+  examples: readonly string[];
+}
+
+export const EXACT_PROTOCOL_SURFACE_DEFINITIONS: readonly ExactProtocolSurfaceDefinition[] = [
+  {
+    surface: "slash_command",
+    allowed: "Leading slash or exact symbol commands with command-owned arguments.",
+    boundary: "Do not treat bare words or sentences that mention command words as commands.",
+    examples: ["/help", "/status goal-123", "?"],
+  },
+  {
+    surface: "cli_flag",
+    allowed: "CLI flags and their command-owned values.",
+    boundary: "Flags are parsed only inside an already selected CLI or command grammar.",
+    examples: ["--json", "--goal goal-123", "-y"],
+  },
+  {
+    surface: "id",
+    allowed: "Exact ids for goals, tasks, sessions, runs, approvals, and persisted records.",
+    boundary: "Ids select typed fields; they do not infer a freeform user intent by themselves.",
+    examples: ["goal-123", "session:conversation:abc", "approval-123"],
+  },
+  {
+    surface: "path",
+    allowed: "Filesystem paths validated by the owning operation.",
+    boundary: "Paths validate operation fields; they are not a fallback semantic router for ordinary text.",
+    examples: ["./src/index.ts", "/tmp/report.md", "~/workspace"],
+  },
+  {
+    surface: "url",
+    allowed: "URLs parsed by URL-aware callers.",
+    boundary: "URLs can be extracted as exact references, not as intent keywords.",
+    examples: ["https://example.com", "file:///tmp/report.md"],
+  },
+  {
+    surface: "enum_schema",
+    allowed: "Enum values and schema literals accepted by typed APIs.",
+    boundary: "Schema validation must fail closed instead of guessing from prose.",
+    examples: ["approve", "reject", "read_only"],
+  },
+  {
+    surface: "feature_flag",
+    allowed: "Named feature switches and boolean-like config values at config boundaries.",
+    boundary: "Feature flags are exact config fields, not natural-language routing rules.",
+    examples: ["agentloop-worktree=on", "PULSEED_DEV_MODE=1"],
+  },
+  {
+    surface: "wire_token",
+    allowed: "Protocol tokens from external transports and internal event streams.",
+    boundary: "Wire tokens are interpreted only within their protocol envelope.",
+    examples: ["event: notification_report", "tool_call", "app_mention"],
+  },
+  {
+    surface: "mention",
+    allowed: "Exact structured mention tokens that name a target namespace and id.",
+    boundary: "Do not select targets by fuzzy labels, titles, or prose references.",
+    examples: ["@run:run-123", "@session:conversation:abc", "@goal:goal-123"],
+  },
+] as const;
+
+export interface ExactSlashCommandDefinition<TCommand extends string = string> {
+  command: TCommand;
+  aliases?: readonly string[];
+  allowArguments?: boolean;
+}
+
+export interface ExactSlashCommandOptions<TCommand extends string = string> {
+  bareSymbolCommands?: Readonly<Record<string, TCommand>>;
+}
+
+export interface ParsedExactSlashCommand<TCommand extends string = string> {
+  surface: "slash_command";
+  rawInput: string;
+  normalizedInput: string;
+  command: TCommand;
+  alias: string;
+  rawArgs: string;
+}
+
+export interface ParsedExactSlashCommandToken {
+  surface: "slash_command";
+  rawInput: string;
+  command: string;
+  rawArgs: string;
+}
+
+export const EXACT_MENTION_KINDS = [
+  "session",
+  "run",
+  "goal",
+  "task",
+  "file",
+  "url",
+  "tool",
+  "skill",
+  "plugin",
+] as const;
+
+export type ExactMentionKind = typeof EXACT_MENTION_KINDS[number];
+
+export interface ParsedExactMentionToken {
+  surface: "mention";
+  rawInput: string;
+  kind: ExactMentionKind;
+  id: string;
+  target: string;
+}
+
+const WHITESPACE_PATTERN = /\s+/g;
+const HAS_WHITESPACE_PATTERN = /\s/;
+const MENTION_KIND_PATTERN = /^[a-z][a-z0-9_-]{0,31}$/;
+const MENTION_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$/;
+const mentionKinds = new Set<string>(EXACT_MENTION_KINDS);
+
+export function normalizeExactProtocolText(input: string): string {
+  return input.trim().toLowerCase().replace(WHITESPACE_PATTERN, " ");
+}
+
+export function isExactProtocolSurface(value: string): value is ExactProtocolSurface {
+  return (EXACT_PROTOCOL_SURFACES as readonly string[]).includes(value);
+}
+
+export function parseExactSlashCommandToken(input: string): ParsedExactSlashCommandToken | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("/") || trimmed === "/") return null;
+  const [rawCommand = "", ...argTokens] = trimmed.split(WHITESPACE_PATTERN);
+  const command = rawCommand.toLowerCase();
+  if (!command || command === "/") return null;
+  return {
+    surface: "slash_command",
+    rawInput: input,
+    command,
+    rawArgs: argTokens.join(" "),
+  };
+}
+
+export function isExactSlashCommandInput(input: string): boolean {
+  return parseExactSlashCommandToken(input) !== null;
+}
+
+export function parseExactSlashCommand<TCommand extends string>(
+  input: string,
+  definitions: readonly ExactSlashCommandDefinition<TCommand>[],
+  options: ExactSlashCommandOptions<TCommand> = {},
+): ParsedExactSlashCommand<TCommand> | null {
+  const trimmed = input.trim();
+  const normalizedInput = normalizeExactProtocolText(input);
+  if (!normalizedInput) return null;
+
+  const bareCommand = options.bareSymbolCommands?.[normalizedInput];
+  if (bareCommand) {
+    return {
+      surface: "slash_command",
+      rawInput: input,
+      normalizedInput,
+      command: bareCommand,
+      alias: normalizedInput,
+      rawArgs: "",
+    };
+  }
+
+  if (!normalizedInput.startsWith("/")) return null;
+
+  const normalizedTokens = normalizedInput.split(" ");
+  const rawTokens = trimmed.split(WHITESPACE_PATTERN);
+  const candidates = definitions.flatMap((definition) => {
+    const aliases = [definition.command, ...(definition.aliases ?? [])];
+    return aliases.map((alias) => ({
+      definition,
+      alias: normalizeExactProtocolText(alias),
+    }));
+  }).sort((a, b) => b.alias.split(" ").length - a.alias.split(" ").length);
+
+  for (const candidate of candidates) {
+    const aliasTokens = candidate.alias.split(" ");
+    const aliasMatches = aliasTokens.every((token, index) => normalizedTokens[index] === token);
+    if (!aliasMatches) continue;
+
+    const hasExtraArgs = normalizedTokens.length > aliasTokens.length;
+    if (hasExtraArgs && !candidate.definition.allowArguments) continue;
+
+    return {
+      surface: "slash_command",
+      rawInput: input,
+      normalizedInput,
+      command: candidate.definition.command,
+      alias: candidate.alias,
+      rawArgs: rawTokens.slice(aliasTokens.length).join(" ").trim(),
+    };
+  }
+
+  return null;
+}
+
+export function parseExactMentionToken(input: string): ParsedExactMentionToken | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith("@") || trimmed.length <= 1 || HAS_WHITESPACE_PATTERN.test(trimmed)) return null;
+
+  const separatorIndex = trimmed.indexOf(":");
+  if (separatorIndex <= 1 || separatorIndex === trimmed.length - 1) return null;
+
+  const kind = trimmed.slice(1, separatorIndex).toLowerCase();
+  const id = trimmed.slice(separatorIndex + 1);
+  if (!MENTION_KIND_PATTERN.test(kind) || !mentionKinds.has(kind)) return null;
+  if (!MENTION_ID_PATTERN.test(id)) return null;
+
+  return {
+    surface: "mention",
+    rawInput: input,
+    kind: kind as ExactMentionKind,
+    id,
+    target: `${kind}:${id}`,
+  };
+}

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1686,6 +1686,17 @@ describe("ChatRunner", () => {
       expect(adapter.execute).not.toHaveBeenCalled();
     });
 
+    it("keeps freeform command paraphrases on the model path", async () => {
+      const adapter = makeMockAdapter();
+      const runner = new ChatRunner(makeDeps({ adapter }));
+
+      const result = await runner.execute("Can you show me the status of this repo?", "/repo");
+
+      expect(result.success).toBe(true);
+      expect(result.output).toBe("Task completed successfully.");
+      expect(adapter.execute).toHaveBeenCalledOnce();
+    });
+
     it("slash command comparison is case-insensitive", async () => {
       const adapter = makeMockAdapter();
       const runner = new ChatRunner(makeDeps({ adapter }));

--- a/src/interface/chat/chat-runner-commands.ts
+++ b/src/interface/chat/chat-runner-commands.ts
@@ -48,6 +48,7 @@ import {
   withExecutionPolicyOverrides,
   type ExecutionPolicy,
 } from "../../orchestrator/execution/agent-loop/execution-policy.js";
+import { parseExactSlashCommandToken } from "../../base/protocol/exact-protocol.js";
 import { formatRoute, formatRuntimeSessionsList, formatRuntimeStatus } from "./chat-runner-runtime.js";
 import type {
   ChatRunResult,
@@ -106,18 +107,19 @@ export class ChatRunnerCommandHandler {
   constructor(private readonly host: ChatRunnerCommandHost) {}
 
   parseResumeCommand(input: string): ResumeCommand | null {
-    const trimmed = input.trim();
-    const match = /^\/resume(?:\s+(.+))?$/i.exec(trimmed);
-    if (!match) return null;
-    const selector = match[1]?.trim();
+    const parsed = parseExactSlashCommandToken(input);
+    if (!parsed || parsed.command !== "/resume") return null;
+    const selector = parsed.rawArgs.trim();
     return selector ? { selector } : {};
   }
 
   async handleCommand(input: string, cwd?: string): Promise<ChatRunResult | null> {
-    const trimmed = input.trim();
-    if (!trimmed.startsWith("/")) return null;
+    const parsed = parseExactSlashCommandToken(input);
+    if (!parsed) return null;
 
-    const cmd = trimmed.toLowerCase().split(/\s+/)[0];
+    const trimmed = input.trim();
+    const cmd = parsed.command;
+    const args = parsed.rawArgs;
     const start = Date.now();
 
     if (cmd === "/help") {
@@ -134,7 +136,7 @@ export class ChatRunnerCommandHandler {
     }
     if (cmd === "/history") {
       const catalog = new ChatSessionCatalog(this.host.deps.stateManager);
-      const selector = trimmed.slice("/history".length).trim();
+      const selector = args.trim();
       const history = this.host.getHistory();
       const session = selector
         ? await catalog.loadSessionBySelector(selector)
@@ -147,7 +149,7 @@ export class ChatRunnerCommandHandler {
       return { success: true, output: this.formatHistory(session), elapsed_ms: Date.now() - start };
     }
     if (cmd === "/title") {
-      const title = trimmed.slice("/title".length).trim();
+      const title = args.trim();
       if (!title) {
         return { success: false, output: "Usage: /title <title>", elapsed_ms: Date.now() - start };
       }
@@ -179,31 +181,31 @@ export class ChatRunnerCommandHandler {
       return this.handleCompact(start);
     }
     if (cmd === "/status") {
-      return this.handleStatus(trimmed.slice("/status".length).trim(), start);
+      return this.handleStatus(args.trim(), start);
     }
     if (cmd === "/goals") {
       return this.handleGoals(start);
     }
     if (cmd === "/tasks") {
-      return this.handleTasks(trimmed.slice("/tasks".length).trim(), start);
+      return this.handleTasks(args.trim(), start);
     }
     if (cmd === "/task") {
-      return this.handleTask(trimmed.slice("/task".length).trim(), start);
+      return this.handleTask(args.trim(), start);
     }
     if (cmd === "/config") {
       return this.handleConfig(start);
     }
     if (cmd === "/model") {
-      return this.handleModel(trimmed.slice("/model".length).trim(), start);
+      return this.handleModel(args.trim(), start);
     }
     if (cmd === "/permissions") {
-      return this.handlePermissions(trimmed.slice("/permissions".length).trim(), start);
+      return this.handlePermissions(args.trim(), start);
     }
     if (cmd === "/plugins") {
       return this.handlePlugins(start);
     }
     if (cmd === "/usage") {
-      return this.handleUsage(trimmed.slice("/usage".length).trim(), start);
+      return this.handleUsage(args.trim(), start);
     }
     if (cmd === "/context" || cmd === "/working-memory") {
       return this.handleContext(start, cwd);
@@ -212,7 +214,7 @@ export class ChatRunnerCommandHandler {
       return this.handleReview(start);
     }
     if (cmd === "/fork") {
-      return this.handleFork(trimmed.slice("/fork".length).trim(), start);
+      return this.handleFork(args.trim(), start);
     }
     if (cmd === "/undo") {
       return this.handleUndo(start);
@@ -244,8 +246,7 @@ export class ChatRunnerCommandHandler {
       return this.handleTrack(start);
     }
     if (cmd === "/tend") {
-      const args = trimmed.slice("/tend".length).trim();
-      return this.handleTend(args, start);
+      return this.handleTend(args.trim(), start);
     }
 
     if (this.host.getPendingTend() !== null) {

--- a/src/interface/tui/__tests__/input-action.test.ts
+++ b/src/interface/tui/__tests__/input-action.test.ts
@@ -73,6 +73,24 @@ describe("resolveTuiInputAction", () => {
     });
   });
 
+  it("does not route freeform paraphrases through slash command fallback", () => {
+    expect(resolveTuiInputAction("statusを見せて", baseContext({
+      isDaemonMode: true,
+      daemonGoalId: "goal-current",
+    }))).toMatchObject({
+      kind: "freeform",
+      route: "chat_runner",
+    });
+    expect(resolveTuiInputAction("please use /status if useful", baseContext({
+      hasChatRunner: false,
+      isDaemonMode: true,
+      daemonGoalId: "goal-current",
+    }))).toMatchObject({
+      kind: "freeform",
+      route: "daemon_goal_chat",
+    });
+  });
+
   it("keeps AgentLoop-capable chat surfaces on ChatRunner before daemon goal fallback", () => {
     expect(resolveTuiInputAction("Run this Kaggle competition", baseContext({
       isDaemonMode: true,

--- a/src/interface/tui/__tests__/intent-recognizer.test.ts
+++ b/src/interface/tui/__tests__/intent-recognizer.test.ts
@@ -129,6 +129,22 @@ describe("IntentRecognizer — exact command grammar", () => {
     const result = await recognizer.recognize("/Dashboard");
     expect(result.intent).toBe("dashboard");
   });
+
+  it("fails closed on unknown slash commands without classifier fallback", async () => {
+    const llm = makeMockLLMClient(JSON.stringify({
+      intent: "loop_start",
+      confidence: 0.96,
+      params: { goalId: "goal-from-unknown-slash" },
+    }));
+    const classifierBackedRecognizer = new IntentRecognizer(llm);
+
+    const result = await classifierBackedRecognizer.recognize("/stats please start goal-from-unknown-slash");
+
+    expect(llm.callCount).toBe(0);
+    expect(result.intent).toBe("unknown");
+    expect(result.source).toBe("command");
+    expect(result.confidence).toBe(1);
+  });
 });
 
 // ─── Natural-language classifier ───

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -41,6 +41,7 @@ import type { TuiChatSurface } from "./chat-surface.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
 import { ShellTool } from "../../tools/system/ShellTool/ShellTool.js";
 import { getPulseedVersion } from "../../base/utils/pulseed-meta.js";
+import { parseExactSlashCommandToken } from "../../base/protocol/exact-protocol.js";
 import { applyChatEventToMessages } from "../chat/chat-event-state.js";
 import { setActiveCursorEscape } from "./cursor-tracker.js";
 import { createRuntimeSessionRegistry } from "../../runtime/session-registry/index.js";
@@ -158,8 +159,8 @@ const CHAT_RUNNER_OWNED_COMMANDS = new Set([
 ]);
 
 export function isChatRunnerOwnedSlashCommand(input: string): boolean {
-  const command = input.trim().toLowerCase().split(/\s+/)[0] ?? "";
-  return CHAT_RUNNER_OWNED_COMMANDS.has(command);
+  const parsed = parseExactSlashCommandToken(input);
+  return parsed ? CHAT_RUNNER_OWNED_COMMANDS.has(parsed.command) : false;
 }
 
 export function deriveDaemonGoalIdFromActiveGoals(

--- a/src/interface/tui/input-action.ts
+++ b/src/interface/tui/input-action.ts
@@ -1,4 +1,5 @@
 import { extractBashCommand } from "./bash-mode.js";
+import { isExactSlashCommandInput } from "../../base/protocol/exact-protocol.js";
 
 export type FreeformInputRoute = "daemon_goal_chat" | "chat_runner" | "unavailable";
 
@@ -64,11 +65,11 @@ export function resolveTuiInputAction(input: string, context: TuiInputActionCont
     return { kind: "pending_run_spec_confirmation", input };
   }
 
-  if (input.startsWith("/") && context.hasStandaloneSlashHandlers) {
+  if (isExactSlashCommandInput(input) && context.hasStandaloneSlashHandlers) {
     return { kind: "standalone_slash", input, trimmedInput };
   }
 
-  if (input.startsWith("/") && context.isDaemonMode) {
+  if (isExactSlashCommandInput(input) && context.isDaemonMode) {
     return { kind: "daemon_slash", input, trimmedInput };
   }
 

--- a/src/interface/tui/intent-recognizer.ts
+++ b/src/interface/tui/intent-recognizer.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
 import { getInternalIdentityPrefix } from "../../base/config/identity-loader.js";
+import {
+  parseExactSlashCommand,
+  parseExactSlashCommandToken,
+  type ExactSlashCommandDefinition,
+} from "../../base/protocol/exact-protocol.js";
 
 // ─── Types ───
 
@@ -27,24 +32,15 @@ export interface RecognizedIntent {
 
 // ─── Exact command grammar ───
 
-const COMMAND_ALIASES: Record<string, IntentType> = {
-  "?": "help",
-  "/?": "help",
-  "/help": "help",
-  "/stop": "loop_stop",
-  "/quit": "loop_stop",
-  "/exit": "loop_stop",
-  "/run": "loop_start",
-  "/start": "loop_start",
-  "/status": "status",
-  "/report": "report",
-  "/goals": "goal_list",
-  "/goal": "goal_list",
-  "/goals list": "goal_list",
-  "/goal list": "goal_list",
-  "/dashboard": "dashboard",
-  "/d": "dashboard",
-};
+const COMMAND_DEFINITIONS: readonly ExactSlashCommandDefinition<IntentType>[] = [
+  { command: "help", aliases: ["/?", "/help"] },
+  { command: "loop_stop", aliases: ["/stop", "/quit", "/exit"] },
+  { command: "loop_start", aliases: ["/run", "/start"], allowArguments: true },
+  { command: "status", aliases: ["/status"] },
+  { command: "report", aliases: ["/report"] },
+  { command: "goal_list", aliases: ["/goals", "/goal", "/goals list", "/goal list"] },
+  { command: "dashboard", aliases: ["/dashboard", "/d"] },
+];
 
 // ─── LLM response schema ───
 
@@ -94,24 +90,25 @@ export class IntentRecognizer {
     const commandResult = this.parseExactCommand(input);
     if (commandResult) return commandResult;
 
+    if (parseExactSlashCommandToken(input)) {
+      return { intent: "unknown", raw: input, source: "command", confidence: 1 };
+    }
+
     if (this.llmClient) return this.classifyNaturalLanguage(input);
 
     return { intent: "unknown", raw: input, source: "unavailable" };
   }
 
   private parseExactCommand(input: string): RecognizedIntent | null {
-    const trimmed = input.trim();
-    const normalized = trimmed.toLowerCase().replace(/\s+/g, " ");
-    const [commandToken, ...argTokens] = normalized.split(" ");
-    if (!commandToken) return null;
-    const command = COMMAND_ALIASES[normalized] ?? COMMAND_ALIASES[commandToken];
-    if (!command) return null;
+    const parsed = parseExactSlashCommand(input, COMMAND_DEFINITIONS, {
+      bareSymbolCommands: { "?": "help" },
+    });
+    if (!parsed) return null;
 
-    if (command === "loop_start" && (commandToken === "/run" || commandToken === "/start")) {
-      const originalTokens = trimmed.split(/\s+/);
-      const goalArg = originalTokens.slice(1).join(" ").trim();
+    if (parsed.command === "loop_start") {
+      const goalArg = parsed.rawArgs;
       return {
-        intent: command,
+        intent: parsed.command,
         params: goalArg ? { goalArg } : undefined,
         raw: input,
         source: "command",
@@ -119,12 +116,8 @@ export class IntentRecognizer {
       };
     }
 
-    if (argTokens.length > 0 && !COMMAND_ALIASES[normalized]) {
-      return null;
-    }
-
     return {
-      intent: command,
+      intent: parsed.command,
       raw: input,
       source: "command",
       confidence: 1,


### PR DESCRIPTION
## Summary
- add a central exact protocol boundary for slash commands, CLI flags, ids, paths, URLs, schema/enum values, feature flags, wire tokens, and mention syntax
- route existing TUI and ChatRunner slash command handling through the central exact parser
- document the #1119 review/audit contract and add caller-path tests for freeform paraphrases and unknown slash fail-closed behavior

## Verification
- npx vitest run --config vitest.unit.config.ts src/base/protocol/__tests__/exact-protocol.test.ts
- npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/intent-recognizer.test.ts --reporter=verbose
- npm run typecheck
- npm run lint:boundaries (passes with existing warnings)
- npm run test:changed
- git diff --check

## Review
- Fresh review found unknown standalone TUI slash commands could fall through to the classifier; fixed and retested.
- Second fresh review reported no material findings.

Closes #1119
