### PR TITLE
feat(tools): add structured response tool router

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/response-item-tool-router.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/response-item-tool-router.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import type { ILLMClient, LLMMessage, LLMRequestOptions, LLMResponse } from "../../../../base/llm/llm-client.js";
+import { ConcurrencyController } from "../../../../tools/concurrency.js";
+import { ToolExecutor } from "../../../../tools/executor.js";
+import { ToolPermissionManager } from "../../../../tools/permission.js";
+import { ToolRegistry } from "../../../../tools/registry.js";
+import type {
+  ITool,
+  PermissionCheckResult,
+  ToolCallContext,
+  ToolResult,
+} from "../../../../tools/types.js";
+import {
+  BoundedAgentLoopRunner,
+  ILLMClientAgentLoopModelClient,
+  ResponseItemToolRouter,
+  StaticAgentLoopModelRegistry,
+  ToolExecutorAgentLoopToolRuntime,
+  ToolRegistryAgentLoopToolRouter,
+  assistantTextResponseItem,
+  createAgentLoopSession,
+  defaultAgentLoopCapabilities,
+  functionToolCallResponseItem,
+  withDefaultBudget,
+} from "../index.js";
+import type {
+  AgentLoopModelClient,
+  AgentLoopModelInfo,
+  AgentLoopModelRequest,
+  AgentLoopModelResponse,
+  AgentLoopTurnContext,
+} from "../index.js";
+
+class RecordingTool implements ITool<{ value: string }> {
+  readonly calls: Array<{ value: string }> = [];
+  readonly metadata = {
+    name: "record_value",
+    aliases: [],
+    permissionLevel: "read_only" as const,
+    isReadOnly: true,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: 8000,
+    tags: ["test"],
+    activityCategory: "read" as const,
+  };
+  readonly inputSchema = z.object({ value: z.string() });
+
+  description(): string {
+    return "Record a typed value.";
+  }
+
+  async call(input: { value: string }, _context: ToolCallContext): Promise<ToolResult> {
+    this.calls.push(input);
+    return {
+      success: true,
+      data: { value: input.value },
+      summary: `recorded ${input.value}`,
+      durationMs: 1,
+    };
+  }
+
+  async checkPermissions(_input: { value: string }, _context: ToolCallContext): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(_input: { value: string }): boolean {
+    return true;
+  }
+}
+
+function makeModelInfo(): AgentLoopModelInfo {
+  return {
+    ref: { providerId: "test", modelId: "model" },
+    displayName: "test/model",
+    capabilities: { ...defaultAgentLoopCapabilities },
+  };
+}
+
+function makeToolStack() {
+  const registry = new ToolRegistry();
+  const tool = new RecordingTool();
+  registry.register(tool);
+  const router = new ToolRegistryAgentLoopToolRouter(registry);
+  const executor = new ToolExecutor({
+    registry,
+    permissionManager: new ToolPermissionManager({}),
+    concurrency: new ConcurrencyController(),
+  });
+  return {
+    tool,
+    router,
+    executor,
+    responseRouter: new ResponseItemToolRouter({ executor, toolRouter: router }),
+    runtime: new ToolExecutorAgentLoopToolRuntime(executor, router),
+  };
+}
+
+function makeTurn(): AgentLoopTurnContext<unknown> {
+  const modelInfo = makeModelInfo();
+  return {
+    session: createAgentLoopSession(),
+    turnId: "turn-1",
+    goalId: "goal-1",
+    cwd: process.cwd(),
+    model: modelInfo.ref,
+    modelInfo,
+    messages: [{ role: "user", content: "Use structured tools only." }],
+    outputSchema: z.object({ ok: z.boolean() }),
+    budget: withDefaultBudget({ maxModelTurns: 2 }),
+    toolPolicy: {},
+    toolCallContext: {
+      cwd: process.cwd(),
+      goalId: "goal-1",
+      trustBalance: 0,
+      preApproved: true,
+      approvalFn: async () => false,
+    },
+  };
+}
+
+describe("ResponseItemToolRouter", () => {
+  it("preserves model text as assistant_text response items", async () => {
+    const modelInfo = makeModelInfo();
+    const llmClient: ILLMClient = {
+      async sendMessage(_messages: LLMMessage[], _options?: LLMRequestOptions): Promise<LLMResponse> {
+        return {
+          content: "Plain model text.",
+          usage: { input_tokens: 1, output_tokens: 1 },
+          stop_reason: "end_turn",
+        };
+      },
+      parseJSON<T>(content: string, schema: z.ZodSchema<T>): T {
+        return schema.parse(JSON.parse(content));
+      },
+      supportsToolCalling: () => true,
+    };
+    const client = new ILLMClientAgentLoopModelClient(llmClient, new StaticAgentLoopModelRegistry([modelInfo]));
+
+    const protocol = await client.createTurnProtocol({
+      model: modelInfo.ref,
+      messages: [{ role: "user", content: "Say hello." }],
+      tools: [],
+    });
+
+    expect(protocol.toolCalls).toEqual([]);
+    expect(protocol.responseItems).toEqual([{
+      type: "assistant_text",
+      content: "Plain model text.",
+      phase: "final_answer",
+    }]);
+  });
+
+  it("executes valid structured function-tool-call items", async () => {
+    const { responseRouter, tool } = makeToolStack();
+    const [observation] = await responseRouter.executeBatch([
+      functionToolCallResponseItem({
+        id: "call-1",
+        name: "record_value",
+        input: { value: "hello" },
+      }),
+    ], makeTurn());
+
+    expect(observation).toMatchObject({
+      type: "tool_result",
+      callId: "call-1",
+      toolName: "record_value",
+      result: {
+        success: true,
+        data: { value: "hello" },
+      },
+    });
+    expect(tool.calls).toEqual([{ value: "hello" }]);
+  });
+
+  it("fails closed on invalid structured tool arguments", async () => {
+    const { responseRouter, tool } = makeToolStack();
+    const [observation] = await responseRouter.executeBatch([
+      functionToolCallResponseItem({
+        id: "call-1",
+        name: "record_value",
+        input: { value: 123 },
+      }),
+    ], makeTurn());
+
+    expect(observation).toMatchObject({
+      type: "tool_error",
+      callId: "call-1",
+      toolName: "record_value",
+      error: { code: "invalid_arguments" },
+      execution: { status: "not_executed", reason: "tool_error" },
+    });
+    expect(tool.calls).toEqual([]);
+  });
+
+  it("returns unknown-tool observations without dispatching", async () => {
+    const { responseRouter, tool } = makeToolStack();
+    const [observation] = await responseRouter.executeBatch([
+      functionToolCallResponseItem({
+        id: "call-1",
+        name: "missing_tool",
+        input: { value: "hello" },
+      }),
+    ], makeTurn());
+
+    expect(observation).toMatchObject({
+      type: "unknown_tool",
+      callId: "call-1",
+      toolName: "missing_tool",
+      execution: { status: "not_executed", reason: "tool_error" },
+    });
+    expect(tool.calls).toEqual([]);
+  });
+
+  it("does not reinterpret freeform assistant text as a tool call", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(_input: AgentLoopModelRequest): Promise<AgentLoopModelResponse> {
+        return {
+          content: "Please call record_value with hello.",
+          toolCalls: [],
+          stopReason: "end_turn",
+        };
+      },
+    };
+    const { router, runtime } = makeToolStack();
+    const executeBatch = vi.spyOn(runtime, "executeBatch");
+
+    const result = await new BoundedAgentLoopRunner({
+      modelClient,
+      toolRouter: router,
+      toolRuntime: runtime,
+    }).run({
+      ...makeTurn(),
+      model: modelInfo.ref,
+      modelInfo,
+      outputSchema: z.string(),
+      finalOutputMode: "display_text",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.output).toBeNull();
+    expect(result.toolCalls).toBe(0);
+    expect(executeBatch).not.toHaveBeenCalled();
+  });
+
+  it("dispatches only function-tool-call response items when legacy toolCalls disagree", async () => {
+    const modelInfo = makeModelInfo();
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(): Promise<AgentLoopModelResponse> {
+        throw new Error("createTurn should not be used");
+      },
+      async createTurnProtocol() {
+        return {
+          assistant: [{ content: "Text only.", phase: "final_answer" }],
+          toolCalls: [{ id: "call-1", name: "record_value", input: { value: "legacy" } }],
+          responseItems: [assistantTextResponseItem("Text only.", "final_answer")],
+          stopReason: "end_turn",
+          responseCompleted: true,
+        };
+      },
+    };
+    const { router, runtime, tool } = makeToolStack();
+    const executeBatch = vi.spyOn(runtime, "executeBatch");
+
+    const result = await new BoundedAgentLoopRunner({
+      modelClient,
+      toolRouter: router,
+      toolRuntime: runtime,
+    }).run({
+      ...makeTurn(),
+      model: modelInfo.ref,
+      modelInfo,
+      outputSchema: z.string(),
+      finalOutputMode: "display_text",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.toolCalls).toBe(0);
+    expect(tool.calls).toEqual([]);
+    expect(executeBatch).not.toHaveBeenCalled();
+  });
+
+  it("does not count not-executed invalid tool observations toward required tools", async () => {
+    const modelInfo = makeModelInfo();
+    const scriptedResponses: AgentLoopModelResponse[] = [
+      {
+        content: "",
+        toolCalls: [{ id: "call-invalid", name: "record_value", input: { value: 123 } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "Premature final answer.",
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+      {
+        content: "",
+        toolCalls: [{ id: "call-valid", name: "record_value", input: { value: "fixed" } }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "Final answer after a real tool call.",
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ];
+    let turnIndex = 0;
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(_input: AgentLoopModelRequest): Promise<AgentLoopModelResponse> {
+        return scriptedResponses[turnIndex++] ?? scriptedResponses[scriptedResponses.length - 1];
+      },
+    };
+    const { router, runtime, tool } = makeToolStack();
+
+    const result = await new BoundedAgentLoopRunner({
+      modelClient,
+      toolRouter: router,
+      toolRuntime: runtime,
+    }).run({
+      ...makeTurn(),
+      model: modelInfo.ref,
+      modelInfo,
+      outputSchema: z.string(),
+      finalOutputMode: "display_text",
+      budget: withDefaultBudget({ maxModelTurns: 5 }),
+      toolPolicy: { requiredTools: ["record_value"] },
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.toolCalls).toBe(2);
+    expect(tool.calls).toEqual([{ value: "fixed" }]);
+    expect(turnIndex).toBe(4);
+  });
+});

--- a/src/orchestrator/execution/agent-loop/agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model-client.ts
@@ -19,6 +19,10 @@ import {
   buildPromptedToolProtocolSystemPrompt,
   extractPromptedToolCalls,
 } from "./prompted-tool-protocol.js";
+import {
+  assistantTextResponseItem,
+  functionToolCallResponseItem,
+} from "./response-item.js";
 
 export class ILLMClientAgentLoopModelClient implements AgentLoopModelClient {
   constructor(
@@ -69,6 +73,10 @@ export class ILLMClientAgentLoopModelClient implements AgentLoopModelClient {
     return {
       assistant,
       toolCalls,
+      responseItems: [
+        ...assistant.map((item) => assistantTextResponseItem(item.content, item.phase)),
+        ...toolCalls.map((call) => functionToolCallResponseItem(call)),
+      ],
       stopReason: response.stop_reason,
       responseCompleted: true,
       usage: {

--- a/src/orchestrator/execution/agent-loop/agent-loop-model.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from "../../../base/llm/llm-client.js";
+import type { ResponseItem } from "./response-item.js";
 
 export interface AgentLoopModelRef {
   providerId: string;
@@ -76,6 +77,8 @@ export interface AgentLoopModelResponse {
 export interface AgentLoopModelTurnProtocol {
   assistant: AgentLoopAssistantOutput[];
   toolCalls: AgentLoopToolCall[];
+  /** Canonical provider output items, preserving text/reasoning/tool-call boundaries. */
+  responseItems?: ResponseItem[];
   stopReason: string;
   responseCompleted: boolean;
   providerResponseId?: string;

--- a/src/orchestrator/execution/agent-loop/agent-loop-tool-runtime.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-tool-runtime.ts
@@ -3,6 +3,9 @@ import type { AgentLoopToolCall } from "./agent-loop-model.js";
 import type { AgentLoopToolOutput } from "./agent-loop-tool-output.js";
 import type { AgentLoopToolRouter } from "./agent-loop-tool-router.js";
 import type { AgentLoopTurnContext } from "./agent-loop-turn-context.js";
+import { ResponseItemToolRouter } from "./response-item-tool-router.js";
+import { functionToolCallResponseItem } from "./response-item.js";
+import type { ToolObservationResponseItem } from "./response-item.js";
 
 export interface AgentLoopToolRuntime {
   executeBatch(
@@ -12,103 +15,101 @@ export interface AgentLoopToolRuntime {
 }
 
 export class ToolExecutorAgentLoopToolRuntime implements AgentLoopToolRuntime {
+  private readonly responseItemToolRouter: ResponseItemToolRouter;
+
   constructor(
     private readonly executor: ToolExecutor,
     private readonly router: AgentLoopToolRouter,
-  ) {}
+  ) {
+    this.responseItemToolRouter = new ResponseItemToolRouter({
+      executor: this.executor,
+      toolRouter: this.router,
+    });
+  }
 
   async executeBatch(
     calls: AgentLoopToolCall[],
     turn: AgentLoopTurnContext<unknown>
   ): Promise<AgentLoopToolOutput[]> {
-    const safe: Array<{ call: AgentLoopToolCall; index: number }> = [];
-    const unsafe: Array<{ call: AgentLoopToolCall; index: number }> = [];
-
-    for (let index = 0; index < calls.length; index++) {
-      const call = calls[index];
-      if (!this.router.isToolAllowed(call.name, turn)) {
-        unsafe.push({ call, index });
-      } else if (this.router.supportsParallel(call.name, call.input)) {
-        safe.push({ call, index });
-      } else {
-        unsafe.push({ call, index });
-      }
-    }
-
-    const outputs = new Array<AgentLoopToolOutput>(calls.length);
-    const safeOutputs = await Promise.all(safe.map(({ call }) => this.executeOne(call, turn)));
-    for (let i = 0; i < safe.length; i++) outputs[safe[i].index] = safeOutputs[i];
-    for (const { call, index } of unsafe) outputs[index] = await this.executeOne(call, turn);
+    const observations = await this.responseItemToolRouter.executeBatch(
+      calls.map((call) => functionToolCallResponseItem(call)),
+      turn,
+    );
+    const outputs = observations.map((observation) =>
+      this.outputFromObservation(observation, turn)
+    );
     for (const output of outputs) {
       this.activateToolSearchResults(turn, output);
     }
     return outputs;
   }
 
-  private async executeOne(
-    call: AgentLoopToolCall,
+  private outputFromObservation(
+    observation: ToolObservationResponseItem,
     turn: AgentLoopTurnContext<unknown>,
-  ): Promise<AgentLoopToolOutput> {
-    if (!this.router.isToolAllowed(call.name, turn)) {
-      return this.failure(call, `Tool "${call.name}" is not allowed in this turn.`, 0);
+  ): AgentLoopToolOutput {
+    if (observation.type === "unknown_tool") {
+      return {
+        callId: observation.callId,
+        toolName: observation.toolName,
+        success: false,
+        content: `UNKNOWN TOOL: ${observation.message}`,
+        durationMs: observation.durationMs,
+        disposition: "respond_to_model",
+        execution: observation.execution,
+      };
     }
 
-    try {
-      const start = Date.now();
-      const result = await this.executor.execute(call.name, call.input, {
-        ...turn.toolCallContext,
-        callId: call.id,
-        sessionId: turn.session.sessionId,
-        abortSignal: turn.abortSignal,
-      });
-      const disposition = this.resolveDisposition(result.error, turn.abortSignal?.aborted === true);
-      const execution = result.execution ?? (disposition === "approval_denied"
-        ? { status: "not_executed" as const, reason: "approval_denied" as const, message: result.error ?? result.summary }
-        : { status: "executed" as const });
-      const command = this.extractCommand(call.name, call.input);
-      const resolvedCwd = this.extractCwd(call.input) ?? turn.cwd;
-      const activityCategory = this.router.resolveTool(call.name)?.metadata.activityCategory;
+    if (observation.type === "tool_error") {
+      const result = observation.result;
+      const execution = observation.execution ?? result?.execution ?? {
+        status: "not_executed" as const,
+        reason: "tool_error" as const,
+        message: observation.error.message,
+      };
+      const command = this.extractCommand(observation.toolName, observation.arguments);
+      const resolvedCwd = this.extractCwd(observation.arguments) ?? turn.cwd;
+      const activityCategory = this.router.resolveTool(observation.toolName)?.metadata.activityCategory;
       return {
-        callId: call.id,
-        toolName: call.name,
-        success: result.success,
-        content: this.formatContent(result, execution),
-        durationMs: result.durationMs || Date.now() - start,
-        disposition,
+        callId: observation.callId,
+        toolName: observation.toolName,
+        success: false,
+        content: result
+          ? this.formatContent(result, execution)
+          : this.formatToolErrorContent(observation, execution),
+        durationMs: observation.durationMs,
+        disposition: this.resolveDisposition(result?.error ?? observation.error.message, turn.abortSignal?.aborted === true),
         execution,
-        ...(result.contextModifier ? { contextModifier: result.contextModifier } : {}),
-        rawResult: result,
+        ...(result ? { rawResult: result } : {}),
         ...(command ? { command, cwd: resolvedCwd } : {}),
         ...(activityCategory ? { activityCategory } : {}),
-        ...(result.artifacts ? { artifacts: result.artifacts } : {}),
-        ...(result.truncated ? { truncated: result.truncated } : {}),
+        ...(result?.artifacts ? { artifacts: result.artifacts } : {}),
+        ...(result?.truncated ? { truncated: result.truncated } : {}),
       };
-    } catch (err) {
-      return this.failure(
-        call,
-        err instanceof Error ? err.message : String(err),
-        0,
-        turn.abortSignal?.aborted ? "cancelled" : "fatal",
-      );
     }
-  }
 
-  private failure(
-    call: AgentLoopToolCall,
-    message: string,
-    durationMs: number,
-    disposition: AgentLoopToolOutput["disposition"] = "respond_to_model",
-  ): AgentLoopToolOutput {
+    const result = observation.result;
+    const disposition = this.resolveDisposition(result.error, turn.abortSignal?.aborted === true);
+    const execution = result.execution ?? (disposition === "approval_denied"
+      ? { status: "not_executed" as const, reason: "approval_denied" as const, message: result.error ?? result.summary }
+      : { status: "executed" as const });
+    const command = this.extractCommand(observation.toolName, observation.arguments);
+    const resolvedCwd = this.extractCwd(observation.arguments) ?? turn.cwd;
+    const activityCategory = this.router.resolveTool(observation.toolName)?.metadata.activityCategory;
     return {
-      callId: call.id,
-      toolName: call.name,
-      success: false,
-      content: message,
-      durationMs,
+      callId: observation.callId,
+      toolName: observation.toolName,
+      success: result.success,
+      content: this.formatContent(result, execution),
+      durationMs: observation.durationMs,
       disposition,
-      ...(this.router.resolveTool(call.name)?.metadata.activityCategory
-        ? { activityCategory: this.router.resolveTool(call.name)?.metadata.activityCategory }
-        : {}),
+      execution,
+      ...(result.contextModifier ? { contextModifier: result.contextModifier } : {}),
+      rawResult: result,
+      ...(command ? { command, cwd: resolvedCwd } : {}),
+      ...(activityCategory ? { activityCategory } : {}),
+      ...(result.artifacts ? { artifacts: result.artifacts } : {}),
+      ...(result.truncated ? { truncated: result.truncated } : {}),
     };
   }
 
@@ -127,6 +128,17 @@ export class ToolExecutorAgentLoopToolRuntime implements AgentLoopToolRuntime {
     return result.success
       ? `${result.summary}\n${this.stringify(result.data)}${result.contextModifier ? `\n${result.contextModifier}` : ""}`
       : result.error ?? result.summary;
+  }
+
+  private formatToolErrorContent(
+    observation: Extract<ToolObservationResponseItem, { type: "tool_error" }>,
+    execution: NonNullable<AgentLoopToolOutput["execution"]>,
+  ): string {
+    if (execution.status === "not_executed") {
+      const reason = execution.reason ? ` (${execution.reason})` : "";
+      return `TOOL NOT EXECUTED${reason}: ${observation.error.message}`;
+    }
+    return observation.error.message;
   }
 
   private resolveDisposition(

--- a/src/orchestrator/execution/agent-loop/anthropic-messages-agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/anthropic-messages-agent-loop-model-client.ts
@@ -18,6 +18,10 @@ import type {
   AgentLoopModelTurnProtocol,
   AgentLoopToolCall,
 } from "./agent-loop-model.js";
+import {
+  assistantTextResponseItem,
+  functionToolCallResponseItem,
+} from "./response-item.js";
 
 export interface AnthropicMessagesAgentLoopModelClientOptions {
   apiKey: string;
@@ -79,6 +83,10 @@ export class AnthropicMessagesAgentLoopModelClient implements AgentLoopModelClie
     return {
       assistant,
       toolCalls,
+      responseItems: [
+        ...assistant.map((item) => assistantTextResponseItem(item.content, item.phase)),
+        ...toolCalls.map((call) => functionToolCallResponseItem(call)),
+      ],
       stopReason: response.stop_reason ?? "unknown",
       responseCompleted: response.stop_reason !== null,
       providerResponseId: response.id,

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -13,6 +13,11 @@ import type { AgentLoopCompactionPhase, AgentLoopCompactionReason, AgentLoopComp
 import { ExtractiveAgentLoopCompactor } from "./agent-loop-compactor.js";
 import { classifyAgentLoopCommandResult } from "./agent-loop-command-classifier.js";
 import type { AgentLoopSessionState } from "./agent-loop-session-state.js";
+import type { FunctionToolCallResponseItem } from "./response-item.js";
+import {
+  assistantTextResponseItem,
+  functionToolCallResponseItem,
+} from "./response-item.js";
 
 export interface BoundedAgentLoopRunnerDeps {
   modelClient: AgentLoopModelClient;
@@ -315,7 +320,9 @@ export class BoundedAgentLoopRunner {
 
       const { results: toolResults, timedOut: toolBatchTimedOut } = await this.executeToolBatchWithinBudget(response.toolCalls, turn, startedAt);
       for (const result of toolResults) {
-        calledTools.add(result.toolName);
+        if (result.execution?.status !== "not_executed") {
+          calledTools.add(result.toolName);
+        }
         toolCalls++;
         if (result.success) consecutiveToolErrors = 0;
         else consecutiveToolErrors++;
@@ -686,6 +693,15 @@ export class BoundedAgentLoopRunner {
         phase: response.toolCalls.length > 0 ? "commentary" : "final_answer",
       }] : [],
       toolCalls: response.toolCalls,
+      responseItems: [
+        ...(response.content || response.toolCalls.length > 0
+          ? [assistantTextResponseItem(
+              response.content || `Calling ${response.toolCalls.map((call) => call.name).join(", ")}`,
+              response.toolCalls.length > 0 ? "commentary" : "final_answer",
+            )]
+          : []),
+        ...response.toolCalls.map((call) => functionToolCallResponseItem(call)),
+      ],
       stopReason: response.stopReason,
       responseCompleted: true,
       usage: response.usage,
@@ -693,9 +709,21 @@ export class BoundedAgentLoopRunner {
   }
 
   private protocolToResponse(protocol: AgentLoopModelTurnProtocol): { content: string; toolCalls: AgentLoopModelTurnProtocol["toolCalls"] } {
+    const responseItemText = protocol.responseItems
+      ?.filter((item) => item.type === "assistant_text")
+      .map((item) => item.content)
+      .filter(Boolean)
+      .join("\n");
+    const responseItemToolCalls = protocol.responseItems
+      ?.filter((item): item is FunctionToolCallResponseItem => item.type === "function_tool_call")
+      .map((item) => ({
+        id: item.id,
+        name: item.name,
+        input: item.arguments,
+      }));
     return {
-      content: protocol.assistant.map((item) => item.content).filter(Boolean).join("\n"),
-      toolCalls: protocol.toolCalls,
+      content: protocol.assistant.map((item) => item.content).filter(Boolean).join("\n") || responseItemText || "",
+      toolCalls: protocol.responseItems ? responseItemToolCalls ?? [] : protocol.toolCalls,
     };
   }
 

--- a/src/orchestrator/execution/agent-loop/index.ts
+++ b/src/orchestrator/execution/agent-loop/index.ts
@@ -30,6 +30,8 @@ export * from "./core-phase-runner.js";
 export * from "./openai-responses-agent-loop-model-client.js";
 export * from "./agent-loop-prompts.js";
 export * from "./prompted-tool-protocol.js";
+export * from "./response-item.js";
+export * from "./response-item-tool-router.js";
 export * from "./review-agent-loop-runner.js";
 export * from "./task-agent-loop-context.js";
 export * from "./task-agent-loop-factory.js";

--- a/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
@@ -21,6 +21,12 @@ import type {
   AgentLoopModelTurnProtocol,
   AgentLoopToolCall,
 } from "./agent-loop-model.js";
+import type { ResponseItem } from "./response-item.js";
+import {
+  assistantTextResponseItem,
+  functionToolCallResponseItem,
+  reasoningProgressResponseItem,
+} from "./response-item.js";
 
 export interface OpenAIResponsesAgentLoopModelClientOptions {
   apiKey: string;
@@ -69,6 +75,7 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
 
     const assistant: AgentLoopAssistantOutput[] = [];
     const toolCalls: AgentLoopToolCall[] = [];
+    const responseItems: ResponseItem[] = [];
 
     for (const item of response.output ?? []) {
       if (item.type === "message") {
@@ -78,40 +85,57 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
           .filter((part) => part.length > 0)
           .join("\n");
         if (text.trim()) {
-          assistant.push({
+          const assistantItem = {
             content: text,
             phase: message.phase ?? "final_answer",
-          });
+          } satisfies AgentLoopAssistantOutput;
+          assistant.push(assistantItem);
+          responseItems.push(assistantTextResponseItem(assistantItem.content, assistantItem.phase));
+        }
+        continue;
+      }
+
+      if (item.type === "reasoning") {
+        const reasoningText = this.extractReasoningProgress(item);
+        if (reasoningText) {
+          responseItems.push(reasoningProgressResponseItem(reasoningText));
         }
         continue;
       }
 
       if (item.type === "function_call" && item.name && item.call_id) {
         const toolCall = item as ResponseFunctionToolCall;
-        toolCalls.push({
+        const call = {
           id: toolCall.call_id,
           name: toolCall.name,
           input: this.parseJson(toolCall.arguments),
-        });
+        };
+        toolCalls.push(call);
+        responseItems.push(functionToolCallResponseItem(call));
       }
     }
 
     if (assistant.length === 0 && response.output_text?.trim()) {
-      assistant.push({
+      const assistantItem = {
         content: response.output_text,
         phase: toolCalls.length > 0 ? "commentary" : "final_answer",
-      });
+      } satisfies AgentLoopAssistantOutput;
+      assistant.push(assistantItem);
+      responseItems.push(assistantTextResponseItem(assistantItem.content, assistantItem.phase));
     }
     if (assistant.length === 0 && toolCalls.length > 0) {
-      assistant.push({
+      const assistantItem = {
         content: `Calling ${toolCalls.map((call) => call.name).join(", ")}`,
         phase: "commentary",
-      });
+      } satisfies AgentLoopAssistantOutput;
+      assistant.push(assistantItem);
+      responseItems.unshift(assistantTextResponseItem(assistantItem.content, assistantItem.phase));
     }
 
     return {
       assistant,
       toolCalls,
+      responseItems,
       stopReason: response.status ?? "unknown",
       responseCompleted: response.status === "completed",
       providerResponseId: response.id,
@@ -186,5 +210,26 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
     } catch {
       return "{}";
     }
+  }
+
+  private extractReasoningProgress(item: unknown): string {
+    if (!item || typeof item !== "object") return "";
+    const record = item as Record<string, unknown>;
+    const summary = record["summary"];
+    if (typeof summary === "string") return summary.trim();
+    if (Array.isArray(summary)) {
+      return summary
+        .map((part) => {
+          if (typeof part === "string") return part;
+          if (part && typeof part === "object" && typeof (part as Record<string, unknown>)["text"] === "string") {
+            return (part as Record<string, string>)["text"];
+          }
+          return "";
+        })
+        .filter((part) => part.length > 0)
+        .join("\n")
+        .trim();
+    }
+    return "";
   }
 }

--- a/src/orchestrator/execution/agent-loop/response-item-tool-router.ts
+++ b/src/orchestrator/execution/agent-loop/response-item-tool-router.ts
@@ -1,0 +1,222 @@
+import type { z } from "zod";
+import type { ToolExecutor } from "../../../tools/executor.js";
+import type { ToolCallContext } from "../../../tools/types.js";
+import type { AgentLoopTurnContext } from "./agent-loop-turn-context.js";
+import type { AgentLoopToolRouter } from "./agent-loop-tool-router.js";
+import type {
+  FunctionToolCallResponseItem,
+  ToolErrorResponseItem,
+  ToolObservationResponseItem,
+  UnknownToolResponseItem,
+} from "./response-item.js";
+import { toolResultResponseItem } from "./response-item.js";
+
+export interface ResponseItemToolRouterDeps {
+  executor: ToolExecutor;
+  toolRouter: AgentLoopToolRouter;
+}
+
+type PreparedToolCall =
+  | {
+      status: "ready";
+      item: FunctionToolCallResponseItem;
+      arguments: unknown;
+      index: number;
+    }
+  | {
+      status: "observation";
+      observation: ToolObservationResponseItem;
+      index: number;
+    };
+
+export class ResponseItemToolRouter {
+  constructor(private readonly deps: ResponseItemToolRouterDeps) {}
+
+  async executeBatch(
+    calls: FunctionToolCallResponseItem[],
+    turn: AgentLoopTurnContext<unknown>,
+  ): Promise<ToolObservationResponseItem[]> {
+    const prepared = calls.map((item, index) => this.prepare(item, turn, index));
+    const observations = new Array<ToolObservationResponseItem>(calls.length);
+    const safe: Extract<PreparedToolCall, { status: "ready" }>[] = [];
+    const unsafe: Extract<PreparedToolCall, { status: "ready" }>[] = [];
+
+    for (const item of prepared) {
+      if (item.status === "observation") {
+        observations[item.index] = item.observation;
+        continue;
+      }
+      if (this.deps.toolRouter.supportsParallel(item.item.name, item.arguments)) {
+        safe.push(item);
+      } else {
+        unsafe.push(item);
+      }
+    }
+
+    const safeResults = await Promise.all(
+      safe.map((item) => this.executePrepared(item.item, item.arguments, turn)),
+    );
+    for (let index = 0; index < safe.length; index++) {
+      observations[safe[index].index] = safeResults[index];
+    }
+    for (const item of unsafe) {
+      observations[item.index] = await this.executePrepared(item.item, item.arguments, turn);
+    }
+
+    return observations;
+  }
+
+  private prepare(
+    item: FunctionToolCallResponseItem,
+    turn: AgentLoopTurnContext<unknown>,
+    index: number,
+  ): PreparedToolCall {
+    const tool = this.deps.toolRouter.resolveTool(item.name);
+    if (!tool) {
+      return {
+        status: "observation",
+        index,
+        observation: this.unknownTool(item),
+      };
+    }
+
+    if (!this.deps.toolRouter.isToolAllowed(item.name, turn)) {
+      return {
+        status: "observation",
+        index,
+        observation: this.toolError(item, {
+          code: "not_allowed",
+          message: `Tool "${item.name}" is not allowed in this turn.`,
+          executionReason: "policy_blocked",
+        }),
+      };
+    }
+
+    const parsed = tool.inputSchema.safeParse(item.arguments);
+    if (!parsed.success) {
+      return {
+        status: "observation",
+        index,
+        observation: this.toolError(item, {
+          code: "invalid_arguments",
+          message: `Invalid arguments for tool "${item.name}": ${this.formatZodError(parsed.error)}`,
+          details: parsed.error.issues.map((issue) => ({
+            path: issue.path,
+            code: issue.code,
+            message: issue.message,
+          })),
+          executionReason: "tool_error",
+        }),
+      };
+    }
+
+    return {
+      status: "ready",
+      item,
+      arguments: parsed.data,
+      index,
+    };
+  }
+
+  private async executePrepared(
+    item: FunctionToolCallResponseItem,
+    parsedArguments: unknown,
+    turn: AgentLoopTurnContext<unknown>,
+  ): Promise<ToolObservationResponseItem> {
+    const start = Date.now();
+    const context: ToolCallContext = {
+      ...turn.toolCallContext,
+      callId: item.id,
+      sessionId: turn.session.sessionId,
+      abortSignal: turn.abortSignal,
+    };
+
+    try {
+      const result = await this.deps.executor.execute(item.name, parsedArguments, context);
+      const durationMs = result.durationMs || Date.now() - start;
+      if (!result.success) {
+        return this.toolError(item, {
+          code: "execution_failed",
+          message: result.error ?? result.summary,
+          result,
+          durationMs,
+          execution: result.execution ?? { status: "executed" },
+        });
+      }
+      return toolResultResponseItem({
+        call: item,
+        arguments: parsedArguments,
+        result,
+        durationMs,
+      });
+    } catch (err) {
+      return this.toolError(item, {
+        code: "execution_failed",
+        message: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+        execution: {
+          status: "not_executed",
+          reason: "tool_error",
+          message: err instanceof Error ? err.message : String(err),
+        },
+      });
+    }
+  }
+
+  private unknownTool(item: FunctionToolCallResponseItem): UnknownToolResponseItem {
+    return {
+      type: "unknown_tool",
+      callId: item.id,
+      toolName: item.name,
+      arguments: item.arguments,
+      message: `Tool "${item.name}" is not registered.`,
+      execution: {
+        status: "not_executed",
+        reason: "tool_error",
+        message: `Tool "${item.name}" is not registered.`,
+      },
+      durationMs: 0,
+    };
+  }
+
+  private toolError(
+    item: FunctionToolCallResponseItem,
+    input: {
+      code: ToolErrorResponseItem["error"]["code"];
+      message: string;
+      details?: unknown;
+      result?: ToolErrorResponseItem["result"];
+      durationMs?: number;
+      execution?: ToolErrorResponseItem["execution"];
+      executionReason?: NonNullable<ToolErrorResponseItem["execution"]>["reason"];
+    },
+  ): ToolErrorResponseItem {
+    return {
+      type: "tool_error",
+      callId: item.id,
+      toolName: item.name,
+      arguments: item.arguments,
+      error: {
+        code: input.code,
+        message: input.message,
+        ...(input.details === undefined ? {} : { details: input.details }),
+      },
+      ...(input.result ? { result: input.result } : {}),
+      execution: input.execution ?? {
+        status: "not_executed",
+        ...(input.executionReason ? { reason: input.executionReason } : {}),
+        message: input.message,
+      },
+      durationMs: input.durationMs ?? 0,
+    };
+  }
+
+  private formatZodError(error: z.ZodError): string {
+    return error.issues
+      .map((issue) => {
+        const path = issue.path.length > 0 ? issue.path.join(".") : "<root>";
+        return `${path}: ${issue.message}`;
+      })
+      .join("; ");
+  }
+}

--- a/src/orchestrator/execution/agent-loop/response-item.ts
+++ b/src/orchestrator/execution/agent-loop/response-item.ts
@@ -1,0 +1,139 @@
+import { z } from "zod";
+import { ToolResultSchema } from "../../../tools/types.js";
+import type { ToolResult } from "../../../tools/types.js";
+import type { AgentLoopMessagePhase, AgentLoopToolCall } from "./agent-loop-model.js";
+
+export const ResponseItemPhaseSchema = z.enum(["commentary", "final_answer"]);
+
+export const AssistantTextResponseItemSchema = z.object({
+  type: z.literal("assistant_text"),
+  id: z.string().optional(),
+  content: z.string(),
+  phase: ResponseItemPhaseSchema.optional(),
+});
+
+export const ReasoningProgressResponseItemSchema = z.object({
+  type: z.literal("reasoning_progress"),
+  id: z.string().optional(),
+  content: z.string(),
+});
+
+export const FunctionToolCallResponseItemSchema = z.object({
+  type: z.literal("function_tool_call"),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  arguments: z.unknown(),
+});
+
+export const ToolExecutionStateSchema = z.object({
+  status: z.enum(["executed", "not_executed"]),
+  reason: z.enum(["approval_denied", "permission_denied", "policy_blocked", "dry_run", "tool_error"]).optional(),
+  message: z.string().optional(),
+});
+
+export const ToolErrorCodeSchema = z.enum([
+  "invalid_arguments",
+  "not_allowed",
+  "execution_failed",
+]);
+
+export const ToolResultResponseItemSchema = z.object({
+  type: z.literal("tool_result"),
+  id: z.string().optional(),
+  callId: z.string().min(1),
+  toolName: z.string().min(1),
+  arguments: z.unknown(),
+  result: ToolResultSchema,
+  durationMs: z.number(),
+});
+
+export const ToolErrorResponseItemSchema = z.object({
+  type: z.literal("tool_error"),
+  id: z.string().optional(),
+  callId: z.string().min(1),
+  toolName: z.string().min(1),
+  arguments: z.unknown(),
+  error: z.object({
+    code: ToolErrorCodeSchema,
+    message: z.string(),
+    details: z.unknown().optional(),
+  }),
+  result: ToolResultSchema.optional(),
+  execution: ToolExecutionStateSchema.optional(),
+  durationMs: z.number(),
+});
+
+export const UnknownToolResponseItemSchema = z.object({
+  type: z.literal("unknown_tool"),
+  id: z.string().optional(),
+  callId: z.string().min(1),
+  toolName: z.string().min(1),
+  arguments: z.unknown(),
+  message: z.string(),
+  execution: ToolExecutionStateSchema,
+  durationMs: z.number(),
+});
+
+export const ResponseItemSchema = z.discriminatedUnion("type", [
+  AssistantTextResponseItemSchema,
+  ReasoningProgressResponseItemSchema,
+  FunctionToolCallResponseItemSchema,
+  ToolResultResponseItemSchema,
+  ToolErrorResponseItemSchema,
+  UnknownToolResponseItemSchema,
+]);
+
+export type AssistantTextResponseItem = z.infer<typeof AssistantTextResponseItemSchema>;
+export type ReasoningProgressResponseItem = z.infer<typeof ReasoningProgressResponseItemSchema>;
+export type FunctionToolCallResponseItem = z.infer<typeof FunctionToolCallResponseItemSchema>;
+export type ToolResultResponseItem = z.infer<typeof ToolResultResponseItemSchema>;
+export type ToolErrorResponseItem = z.infer<typeof ToolErrorResponseItemSchema>;
+export type UnknownToolResponseItem = z.infer<typeof UnknownToolResponseItemSchema>;
+export type ResponseItem = z.infer<typeof ResponseItemSchema>;
+export type ToolObservationResponseItem =
+  | ToolResultResponseItem
+  | ToolErrorResponseItem
+  | UnknownToolResponseItem;
+
+export function assistantTextResponseItem(
+  content: string,
+  phase?: AgentLoopMessagePhase,
+): AssistantTextResponseItem {
+  return {
+    type: "assistant_text",
+    content,
+    ...(phase ? { phase } : {}),
+  };
+}
+
+export function reasoningProgressResponseItem(content: string): ReasoningProgressResponseItem {
+  return {
+    type: "reasoning_progress",
+    content,
+  };
+}
+
+export function functionToolCallResponseItem(call: AgentLoopToolCall): FunctionToolCallResponseItem {
+  return {
+    type: "function_tool_call",
+    id: call.id,
+    name: call.name,
+    arguments: call.input,
+  };
+}
+
+export function toolResultResponseItem(input: {
+  call: FunctionToolCallResponseItem;
+  arguments: unknown;
+  result: ToolResult;
+  durationMs: number;
+}): ToolResultResponseItem {
+  return {
+    type: "tool_result",
+    callId: input.call.id,
+    toolName: input.call.name,
+    arguments: input.arguments,
+    result: input.result,
+    durationMs: input.durationMs,
+  };
+}


### PR DESCRIPTION
## Summary
- add canonical agent-loop ResponseItem schemas for assistant text, reasoning progress, structured function tool calls, tool results, tool errors, and unknown tools
- route agent-loop execution through ResponseItemToolRouter with fail-closed argument validation before dispatch
- derive production dispatch from structured function_tool_call response items and avoid counting not_executed observations toward required tools

## Verification
- npx vitest run src/orchestrator/execution/agent-loop/__tests__/response-item-tool-router.test.ts
- npx vitest run src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/orchestrator/execution/agent-loop/__tests__/openai-responses-agent-loop-model-client.test.ts src/orchestrator/execution/agent-loop/__tests__/anthropic-messages-agent-loop-model-client.test.ts src/orchestrator/execution/agent-loop/__tests__/response-item-tool-router.test.ts
- npm run typecheck
- npm run lint:boundaries (0 errors; pre-existing warnings remain)
- npm run test:changed
- git diff --check

Closes #1110