### PR TITLE
feat(loop): add typed tool observations

### DIFF
--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -101,6 +101,8 @@ export function renderAgentTimelineItemForChat(item: AgentTimelineItem): string 
       const label = item.status === "started" ? "Started" : item.success ? "Finished" : "Failed";
       return detail ? `${label} ${item.toolName}: ${redactSetupSecrets(detail)}` : `${label} ${item.toolName}.`;
     }
+    case "tool_observation":
+      return `Observed ${item.toolName} (${item.state}): ${redactSetupSecrets(item.outputPreview)}`;
     case "plan":
       return `Plan changed: ${redactSetupSecrets(item.summary)}`;
     case "approval":

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -37,6 +37,7 @@ import {
   type AgentLoopModelInfo,
   type AgentLoopModelRequest,
   type AgentLoopModelResponse,
+  type AgentLoopToolCall,
   type AgentLoopToolOutput,
   type AgentLoopTurnContext,
 } from "../index.js";
@@ -488,8 +489,44 @@ describe("agentloop phase 1", () => {
     expect(result.success).toBe(true);
     expect(result.output?.finalAnswer).toBe("finished");
     expect(result.toolCalls).toBe(1);
-    expect(modelClient.calls[1].messages.some((message) => message.role === "tool")).toBe(true);
+    const followUpToolMessage = modelClient.calls[1].messages.find((message) => message.role === "tool");
+    expect(followUpToolMessage).toMatchObject({
+      toolCallId: "call-1",
+      toolName: "echo",
+      observation: {
+        type: "tool_observation",
+        callId: "call-1",
+        toolName: "echo",
+        state: "success",
+        execution: { status: "executed" },
+        output: {
+          summary: "echoed hello",
+          data: { echoed: "hello" },
+        },
+      },
+    });
+    const persisted = await session.stateStore.load();
+    expect(persisted?.messages.find((message) => message.role === "tool")).toMatchObject({
+      observation: {
+        type: "tool_observation",
+        callId: "call-1",
+        state: "success",
+      },
+    });
     const events = await session.traceStore.list(session.traceId);
+    expect(events.find((event) => event.type === "tool_observation")).toMatchObject({
+      observation: {
+        type: "tool_observation",
+        callId: "call-1",
+        state: "success",
+      },
+    });
+    expect(events.findIndex((event) => event.type === "tool_call_started")).toBeLessThan(
+      events.findIndex((event) => event.type === "tool_call_finished"),
+    );
+    expect(events.findIndex((event) => event.type === "tool_call_finished")).toBeLessThan(
+      events.findIndex((event) => event.type === "tool_observation"),
+    );
     expect(events.some((event) => event.type === "final")).toBe(true);
     expect(events.find((event) => event.type === "tool_call_started")).toMatchObject({
       toolName: "echo",
@@ -503,6 +540,141 @@ describe("agentloop phase 1", () => {
     expect(assistantMessages).toHaveLength(2);
     expect(assistantMessages[0]).toMatchObject({ phase: "commentary" });
     expect(assistantMessages[1]).toMatchObject({ phase: "final_candidate" });
+  });
+
+  it("persists typed tool observations for success, failure, denied, blocked, timed out, and interrupted results", async () => {
+    const modelInfo = makeModelInfo();
+    const toolCalls = [
+      { id: "success-1", name: "success_case", input: { value: "ok" } },
+      { id: "failure-1", name: "failure_case", input: { value: "fail" } },
+      { id: "denied-1", name: "denied_case", input: { value: "deny" } },
+      { id: "blocked-1", name: "blocked_case", input: { value: "block" } },
+      { id: "timed-1", name: "timed_case", input: { value: "slow" } },
+      { id: "interrupted-1", name: "interrupted_case", input: { value: "stop" } },
+    ];
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls,
+        stopReason: "tool_use",
+      },
+      { content: finalJson(), toolCalls: [], stopReason: "end_turn" },
+    ]);
+    const { router } = makeToolRuntime();
+    const runtime = {
+      executeBatch: vi.fn(async (calls: AgentLoopToolCall[]): Promise<AgentLoopToolOutput[]> => calls.map((call) => {
+        if (call.name === "success_case") {
+          return {
+            callId: call.id,
+            toolName: call.name,
+            success: true,
+            content: "success output",
+            durationMs: 1,
+            rawResult: {
+              success: true,
+              data: { ok: true },
+              summary: "success summary",
+              durationMs: 1,
+            },
+          };
+        }
+        if (call.name === "failure_case") {
+          return {
+            callId: call.id,
+            toolName: call.name,
+            success: false,
+            content: "failure output",
+            durationMs: 2,
+            rawResult: {
+              success: false,
+              data: null,
+              summary: "failure summary",
+              error: "failed",
+              durationMs: 2,
+            },
+          };
+        }
+        if (call.name === "denied_case") {
+          return {
+            callId: call.id,
+            toolName: call.name,
+            success: false,
+            content: "permission denied",
+            durationMs: 3,
+            execution: { status: "not_executed", reason: "permission_denied", message: "operator policy denied" },
+          };
+        }
+        if (call.name === "blocked_case") {
+          return {
+            callId: call.id,
+            toolName: call.name,
+            success: false,
+            content: "policy blocked",
+            durationMs: 4,
+            execution: { status: "not_executed", reason: "policy_blocked", message: "sandbox blocked" },
+          };
+        }
+        if (call.name === "timed_case") {
+          return {
+            callId: call.id,
+            toolName: call.name,
+            success: false,
+            content: "timed out",
+            durationMs: 5,
+            execution: { status: "executed", reason: "timed_out", message: "deadline exceeded" },
+          };
+        }
+        return {
+          callId: call.id,
+          toolName: call.name,
+          success: false,
+          content: "interrupted",
+          durationMs: 6,
+          execution: { status: "executed", reason: "interrupted", message: "operator interrupted" },
+        };
+      })),
+    };
+    const session = createAgentLoopSession();
+
+    const result = await new BoundedAgentLoopRunner({
+      modelClient,
+      toolRouter: router,
+      toolRuntime: runtime,
+    }).run({
+      session,
+      turnId: "turn-1",
+      goalId: "goal-1",
+      taskId: "task-1",
+      cwd: process.cwd(),
+      model: modelInfo.ref,
+      modelInfo,
+      messages: [{ role: "user", content: "run all cases" }],
+      outputSchema: z.object({ status: z.literal("done") }).passthrough(),
+      budget: withDefaultBudget({ maxModelTurns: 3, maxConsecutiveToolErrors: 10 }),
+      toolPolicy: {},
+      toolCallContext: {
+        cwd: process.cwd(),
+        goalId: "goal-1",
+        trustBalance: 0,
+        preApproved: true,
+        approvalFn: async () => false,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(modelClient.calls).toHaveLength(2);
+    const observedStates = modelClient.calls[1].messages
+      .filter((message) => message.role === "tool")
+      .map((message) => message.observation?.state);
+    expect(observedStates).toEqual(["success", "failure", "denied", "blocked", "timed_out", "interrupted"]);
+
+    const persisted = await session.stateStore.load();
+    expect(persisted?.messages
+      .filter((message) => message.role === "tool")
+      .map((message) => message.observation?.state)).toEqual(observedStates);
+    expect((await session.traceStore.list(session.traceId))
+      .filter((event) => event.type === "tool_observation")
+      .map((event) => event.observation.state)).toEqual(observedStates);
   });
 
   it("stops after an abort that arrives with the model response before running tools", async () => {
@@ -675,7 +847,9 @@ describe("agentloop phase 1", () => {
     expect(llmCalls[0]?.options?.system).toContain("You do not have native function/tool calling");
     expect(llmCalls[0]?.options?.system).toContain("Available tools:");
     expect(llmCalls[0]?.options?.system).toContain("avoid repo-wide glob or grep sweeps");
-    expect(llmCalls[1]?.messages.some((message) => message.role === "user" && message.content.startsWith("Tool result"))).toBe(true);
+    const fallbackToolResult = llmCalls[1]?.messages.find((message) => message.role === "user" && message.content.startsWith("Tool result"));
+    expect(fallbackToolResult?.content).toContain("\"type\": \"tool_observation\"");
+    expect(fallbackToolResult?.content).toContain("\"state\": \"success\"");
   });
 
   it("stops after the schema repair budget is exhausted", async () => {

--- a/src/orchestrator/execution/agent-loop/__tests__/anthropic-messages-agent-loop-model-client.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/anthropic-messages-agent-loop-model-client.test.ts
@@ -59,6 +59,21 @@ describe("AnthropicMessagesAgentLoopModelClient", () => {
           toolCallId: "call-1",
           toolName: "echo_tool",
           content: "Echoed old",
+          observation: {
+            type: "tool_observation",
+            callId: "call-1",
+            toolName: "echo_tool",
+            arguments: { value: "old" },
+            state: "success",
+            success: true,
+            execution: { status: "executed" },
+            durationMs: 1,
+            output: {
+              content: "Echoed old",
+              summary: "echoed old",
+              data: { value: "old" },
+            },
+          },
         },
       ],
       tools: [{
@@ -96,6 +111,9 @@ describe("AnthropicMessagesAgentLoopModelClient", () => {
       type: "tool_result",
       tool_use_id: "call-1",
     }));
+    const toolResult = request.messages[2]?.content.find((item) => item.type === "tool_result");
+    expect(toolResult?.content).toContain("\"type\": \"tool_observation\"");
+    expect(toolResult?.content).toContain("\"state\": \"success\"");
 
     expect(protocol.assistant).toEqual([{
       content: "Need one more tool call",

--- a/src/orchestrator/execution/agent-loop/__tests__/openai-responses-agent-loop-model-client.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/openai-responses-agent-loop-model-client.test.ts
@@ -16,12 +16,15 @@ describe("OpenAIResponsesAgentLoopModelClient", () => {
     const create = vi.fn(async (input: unknown) => {
       expect(JSON.stringify(input)).not.toContain("\"phase\"");
       expect(JSON.stringify(input)).not.toContain("\"strict\":true");
-      const inputItems = (input as { input: Array<{ type: string; call_id?: string }> }).input;
+      const inputItems = (input as { input: Array<{ type: string; call_id?: string; output?: string }> }).input;
       expect(inputItems.some((item) => item.type === "function_call" && item.call_id === "call-1")).toBe(true);
       expect(inputItems.some((item) => item.type === "function_call_output" && item.call_id === "call-1")).toBe(true);
       expect(inputItems.findIndex((item) => item.type === "function_call")).toBeLessThan(
         inputItems.findIndex((item) => item.type === "function_call_output"),
       );
+      const output = inputItems.find((item) => item.type === "function_call_output" && item.call_id === "call-1")?.output;
+      expect(output).toContain("\"type\": \"tool_observation\"");
+      expect(output).toContain("\"state\": \"success\"");
       return {
         id: "resp-1",
         status: "completed",
@@ -46,7 +49,27 @@ describe("OpenAIResponsesAgentLoopModelClient", () => {
           phase: "commentary",
           toolCalls: [{ id: "call-1", name: "echo", input: { value: "hello" } }],
         },
-        { role: "tool", toolCallId: "call-1", toolName: "echo", content: "tool output" },
+        {
+          role: "tool",
+          toolCallId: "call-1",
+          toolName: "echo",
+          content: "tool output",
+          observation: {
+            type: "tool_observation",
+            callId: "call-1",
+            toolName: "echo",
+            arguments: { value: "hello" },
+            state: "success",
+            success: true,
+            execution: { status: "executed" },
+            durationMs: 1,
+            output: {
+              content: "tool output",
+              summary: "echoed hello",
+              data: { echoed: "hello" },
+            },
+          },
+        },
         { role: "assistant", content: "{\"ok\":true}", phase: "final_answer" },
       ],
       tools: [],

--- a/src/orchestrator/execution/agent-loop/agent-loop-events.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-events.ts
@@ -1,4 +1,5 @@
 import type { ToolActivityCategory } from "../../../tools/types.js";
+import type { AgentLoopToolObservation } from "./agent-loop-model.js";
 
 export type AgentLoopEvent =
   | AgentLoopStartedEvent
@@ -8,6 +9,7 @@ export type AgentLoopEvent =
   | AgentLoopAssistantMessageEvent
   | AgentLoopApprovalRequestEvent
   | AgentLoopToolCallStartedEvent
+  | AgentLoopToolObservationEvent
   | AgentLoopToolCallFinishedEvent
   | AgentLoopPlanUpdateEvent
   | AgentLoopApprovalEvent
@@ -71,6 +73,11 @@ export interface AgentLoopToolCallStartedEvent extends AgentLoopBaseEvent {
   toolName: string;
   inputPreview: string;
   activityCategory?: ToolActivityCategory;
+}
+
+export interface AgentLoopToolObservationEvent extends AgentLoopBaseEvent {
+  type: "tool_observation";
+  observation: AgentLoopToolObservation;
 }
 
 export interface AgentLoopToolCallFinishedEvent extends AgentLoopBaseEvent {

--- a/src/orchestrator/execution/agent-loop/agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model-client.ts
@@ -15,6 +15,7 @@ import type {
   AgentLoopModelTurnProtocol,
   AgentLoopToolCall,
 } from "./agent-loop-model.js";
+import { formatAgentLoopToolMessageContent } from "./agent-loop-model.js";
 import {
   buildPromptedToolProtocolSystemPrompt,
   extractPromptedToolCalls,
@@ -92,7 +93,7 @@ export class ILLMClientAgentLoopModelClient implements AgentLoopModelClient {
       .map((message) => ({
         role: message.role === "assistant" ? "assistant" : "user",
         content: message.role === "tool"
-          ? `Tool result${message.toolName ? ` for ${message.toolName}` : ""}:\n${message.content}`
+          ? `Tool result${message.toolName ? ` for ${message.toolName}` : ""}:\n${formatAgentLoopToolMessageContent(message)}`
           : message.content,
       }));
   }

--- a/src/orchestrator/execution/agent-loop/agent-loop-model.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model.ts
@@ -1,4 +1,5 @@
 import type { ToolDefinition } from "../../../base/llm/llm-client.js";
+import type { ToolActivityCategory } from "../../../tools/types.js";
 import type { ResponseItem } from "./response-item.js";
 
 export interface AgentLoopModelRef {
@@ -41,12 +42,61 @@ export interface AgentLoopMessage {
   toolCallId?: string;
   toolName?: string;
   toolCalls?: AgentLoopToolCall[];
+  observation?: AgentLoopToolObservation;
 }
 
 export interface AgentLoopToolCall {
   id: string;
   name: string;
   input: unknown;
+}
+
+export type AgentLoopToolObservationState =
+  | "success"
+  | "failure"
+  | "denied"
+  | "blocked"
+  | "timed_out"
+  | "interrupted";
+
+export type AgentLoopToolObservationReason =
+  | "approval_denied"
+  | "permission_denied"
+  | "policy_blocked"
+  | "dry_run"
+  | "tool_error"
+  | "timed_out"
+  | "interrupted";
+
+export interface AgentLoopToolObservationExecution {
+  status: "executed" | "not_executed";
+  reason?: AgentLoopToolObservationReason;
+  message?: string;
+}
+
+export interface AgentLoopToolObservation {
+  type: "tool_observation";
+  callId: string;
+  toolName: string;
+  arguments: unknown;
+  state: AgentLoopToolObservationState;
+  success: boolean;
+  execution?: AgentLoopToolObservationExecution;
+  durationMs: number;
+  output: {
+    content: string;
+    summary?: string;
+    data?: unknown;
+    error?: string;
+  };
+  command?: string;
+  cwd?: string;
+  artifacts?: string[];
+  truncated?: {
+    originalChars: number;
+    overflowPath?: string;
+  };
+  activityCategory?: ToolActivityCategory;
 }
 
 export interface AgentLoopModelRequest {
@@ -123,4 +173,25 @@ export function parseAgentLoopModelRef(value: string): AgentLoopModelRef {
 
 export function formatAgentLoopModelRef(ref: AgentLoopModelRef): string {
   return `${ref.providerId}/${ref.modelId}${ref.variant ? `#${ref.variant}` : ""}`;
+}
+
+export function formatAgentLoopToolMessageContent(message: AgentLoopMessage): string {
+  if (message.role !== "tool" || !message.observation) return message.content;
+  return stringifyToolObservation(message.observation);
+}
+
+function stringifyToolObservation(observation: AgentLoopToolObservation): string {
+  try {
+    return JSON.stringify(observation, null, 2);
+  } catch {
+    return JSON.stringify({
+      type: "tool_observation",
+      callId: observation.callId,
+      toolName: observation.toolName,
+      state: observation.state,
+      success: observation.success,
+      durationMs: observation.durationMs,
+      output: observation.output.content,
+    }, null, 2);
+  }
 }

--- a/src/orchestrator/execution/agent-loop/agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-result.ts
@@ -1,4 +1,4 @@
-import type { AgentLoopReasoningEffort } from "./agent-loop-model.js";
+import type { AgentLoopReasoningEffort, AgentLoopToolObservationExecution } from "./agent-loop-model.js";
 import type { ExecutionPolicy } from "./execution-policy.js";
 import type { AgentLoopStopReason } from "./agent-loop-budget.js";
 
@@ -9,11 +9,7 @@ export interface AgentLoopCommandResult {
   command: string;
   cwd: string;
   success: boolean;
-  execution?: {
-    status: "executed" | "not_executed";
-    reason?: "approval_denied" | "permission_denied" | "policy_blocked" | "dry_run" | "tool_error";
-    message?: string;
-  };
+  execution?: AgentLoopToolObservationExecution;
   category: AgentLoopCommandResultCategory;
   evidenceEligible: boolean;
   relevantToTask?: boolean;
@@ -24,11 +20,7 @@ export interface AgentLoopCommandResult {
 export interface AgentLoopToolResultSummary {
   toolName: string;
   success: boolean;
-  execution?: {
-    status: "executed" | "not_executed";
-    reason?: "approval_denied" | "permission_denied" | "policy_blocked" | "dry_run" | "tool_error";
-    message?: string;
-  };
+  execution?: AgentLoopToolObservationExecution;
   outputSummary: string;
   durationMs: number;
 }

--- a/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
@@ -1,7 +1,16 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { AgentLoopStopReason } from "./agent-loop-budget.js";
-import type { AgentLoopMessage, AgentLoopMessagePhase, AgentLoopMessageRole, AgentLoopToolCall } from "./agent-loop-model.js";
+import type {
+  AgentLoopMessage,
+  AgentLoopMessagePhase,
+  AgentLoopMessageRole,
+  AgentLoopToolCall,
+  AgentLoopToolObservation,
+  AgentLoopToolObservationExecution,
+  AgentLoopToolObservationReason,
+  AgentLoopToolObservationState,
+} from "./agent-loop-model.js";
 
 export interface AgentLoopSessionState {
   sessionId: string;
@@ -124,6 +133,7 @@ function normalizeMessage(value: unknown): AgentLoopMessage | null {
   const role = roleField(value, "role");
   if (!role || typeof value["content"] !== "string") return null;
   const phase = phaseField(value, "phase");
+  const observation = normalizeToolObservation(value["observation"]);
 
   return {
     role,
@@ -132,6 +142,7 @@ function normalizeMessage(value: unknown): AgentLoopMessage | null {
     ...(typeof value["toolCallId"] === "string" ? { toolCallId: value["toolCallId"] } : {}),
     ...(typeof value["toolName"] === "string" ? { toolName: value["toolName"] } : {}),
     ...(Array.isArray(value["toolCalls"]) ? { toolCalls: value["toolCalls"].map(normalizeToolCall).filter((call): call is AgentLoopToolCall => call !== null) } : {}),
+    ...(observation ? { observation } : {}),
   };
 }
 
@@ -141,6 +152,62 @@ function normalizeToolCall(value: unknown): AgentLoopToolCall | null {
   const name = stringField(value, "name");
   if (!id || !name) return null;
   return { id, name, input: value["input"] };
+}
+
+function normalizeToolObservation(value: unknown): AgentLoopToolObservation | null {
+  if (!isRecord(value)) return null;
+  if (value["type"] !== "tool_observation") return null;
+  const callId = stringField(value, "callId");
+  const toolName = stringField(value, "toolName");
+  const state = observationStateField(value, "state");
+  if (!callId || !toolName || !state || typeof value["success"] !== "boolean") return null;
+  const output = isRecord(value["output"]) ? value["output"] : null;
+  if (!output || typeof output["content"] !== "string") return null;
+  const execution = normalizeObservationExecution(value["execution"]);
+  const truncated = normalizeTruncated(value["truncated"]);
+
+  return {
+    type: "tool_observation",
+    callId,
+    toolName,
+    arguments: value["arguments"],
+    state,
+    success: value["success"],
+    ...(execution ? { execution } : {}),
+    durationMs: nonNegativeNumberField(value, "durationMs"),
+    output: {
+      content: output["content"],
+      ...(typeof output["summary"] === "string" ? { summary: output["summary"] } : {}),
+      ...(Object.prototype.hasOwnProperty.call(output, "data") ? { data: output["data"] } : {}),
+      ...(typeof output["error"] === "string" ? { error: output["error"] } : {}),
+    },
+    ...(typeof value["command"] === "string" ? { command: value["command"] } : {}),
+    ...(typeof value["cwd"] === "string" ? { cwd: value["cwd"] } : {}),
+    ...(Array.isArray(value["artifacts"]) ? { artifacts: value["artifacts"].filter((item): item is string => typeof item === "string") } : {}),
+    ...(truncated ? { truncated } : {}),
+    ...(toolActivityCategoryField(value, "activityCategory") ? { activityCategory: toolActivityCategoryField(value, "activityCategory")! } : {}),
+  };
+}
+
+function normalizeObservationExecution(value: unknown): AgentLoopToolObservationExecution | null {
+  if (!isRecord(value)) return null;
+  const status = value["status"];
+  if (status !== "executed" && status !== "not_executed") return null;
+  const reason = observationReasonField(value, "reason");
+  return {
+    status,
+    ...(reason ? { reason } : {}),
+    ...(typeof value["message"] === "string" ? { message: value["message"] } : {}),
+  };
+}
+
+function normalizeTruncated(value: unknown): AgentLoopToolObservation["truncated"] | null {
+  if (!isRecord(value)) return null;
+  const originalChars = nonNegativeNumberField(value, "originalChars");
+  return {
+    originalChars,
+    ...(typeof value["overflowPath"] === "string" ? { overflowPath: value["overflowPath"] } : {}),
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -190,6 +257,44 @@ function roleField(value: Record<string, unknown>, field: string): AgentLoopMess
 function phaseField(value: Record<string, unknown>, field: string): AgentLoopMessagePhase | null {
   const raw = value[field];
   return raw === "commentary" || raw === "final_answer" ? raw : null;
+}
+
+function observationStateField(value: Record<string, unknown>, field: string): AgentLoopToolObservationState | null {
+  const raw = value[field];
+  return raw === "success"
+    || raw === "failure"
+    || raw === "denied"
+    || raw === "blocked"
+    || raw === "timed_out"
+    || raw === "interrupted"
+    ? raw
+    : null;
+}
+
+function observationReasonField(value: Record<string, unknown>, field: string): AgentLoopToolObservationReason | null {
+  const raw = value[field];
+  return raw === "approval_denied"
+    || raw === "permission_denied"
+    || raw === "policy_blocked"
+    || raw === "dry_run"
+    || raw === "tool_error"
+    || raw === "timed_out"
+    || raw === "interrupted"
+    ? raw
+    : null;
+}
+
+function toolActivityCategoryField(value: Record<string, unknown>, field: string): AgentLoopToolObservation["activityCategory"] | null {
+  const raw = value[field];
+  return raw === "search"
+    || raw === "read"
+    || raw === "command"
+    || raw === "file_create"
+    || raw === "file_modify"
+    || raw === "test"
+    || raw === "approval"
+    ? raw
+    : null;
 }
 
 function statusField(value: Record<string, unknown>, field: string): AgentLoopSessionState["status"] {

--- a/src/orchestrator/execution/agent-loop/agent-timeline.ts
+++ b/src/orchestrator/execution/agent-loop/agent-timeline.ts
@@ -7,6 +7,7 @@ export type AgentTimelineItem =
   | AgentTimelineModelRequestItem
   | AgentTimelineAssistantMessageItem
   | AgentTimelineToolItem
+  | AgentTimelineToolObservationItem
   | AgentTimelinePlanItem
   | AgentTimelineApprovalItem
   | AgentTimelineCompactionItem
@@ -72,6 +73,16 @@ export interface AgentTimelineToolItem extends AgentTimelineBaseItem {
     originalChars: number;
     overflowPath?: string;
   };
+}
+
+export interface AgentTimelineToolObservationItem extends AgentTimelineBaseItem {
+  kind: "tool_observation";
+  callId: string;
+  toolName: string;
+  state: "success" | "failure" | "denied" | "blocked" | "timed_out" | "interrupted";
+  success: boolean;
+  outputPreview: string;
+  durationMs: number;
 }
 
 export interface AgentTimelinePlanItem extends AgentTimelineBaseItem {
@@ -194,6 +205,18 @@ export function projectAgentLoopEventToTimeline(event: AgentLoopEvent): AgentTim
         durationMs: event.durationMs,
         ...(event.artifacts ? { artifacts: event.artifacts } : {}),
         ...(event.truncated ? { truncated: event.truncated } : {}),
+      };
+    case "tool_observation":
+      return {
+        ...base,
+        kind: "tool_observation",
+        visibility: "debug",
+        callId: event.observation.callId,
+        toolName: event.observation.toolName,
+        state: event.observation.state,
+        success: event.observation.success,
+        outputPreview: event.observation.output.content,
+        durationMs: event.observation.durationMs,
       };
     case "plan_update":
       return { ...base, kind: "plan", summary: event.summary };

--- a/src/orchestrator/execution/agent-loop/anthropic-messages-agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/anthropic-messages-agent-loop-model-client.ts
@@ -18,6 +18,7 @@ import type {
   AgentLoopModelTurnProtocol,
   AgentLoopToolCall,
 } from "./agent-loop-model.js";
+import { formatAgentLoopToolMessageContent } from "./agent-loop-model.js";
 import {
   assistantTextResponseItem,
   functionToolCallResponseItem,
@@ -118,13 +119,13 @@ export class AnthropicMessagesAgentLoopModelClient implements AgentLoopModelClie
 
       if (message.role === "tool") {
         if (!message.toolCallId) {
-          this.appendText(converted, "user", `Tool result${message.toolName ? ` for ${message.toolName}` : ""}:\n${message.content}`);
+          this.appendText(converted, "user", `Tool result${message.toolName ? ` for ${message.toolName}` : ""}:\n${formatAgentLoopToolMessageContent(message)}`);
           continue;
         }
         this.appendBlocks(converted, "user", [{
           type: "tool_result",
           tool_use_id: message.toolCallId,
-          content: message.content,
+          content: formatAgentLoopToolMessageContent(message),
           is_error: false,
         }]);
         continue;

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -2,7 +2,15 @@ import { randomUUID } from "node:crypto";
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import type { z } from "zod";
 import type { AgentLoopStopReason } from "./agent-loop-budget.js";
-import type { AgentLoopMessage, AgentLoopModelClient, AgentLoopModelTurnProtocol } from "./agent-loop-model.js";
+import type {
+  AgentLoopMessage,
+  AgentLoopModelClient,
+  AgentLoopModelTurnProtocol,
+  AgentLoopToolCall,
+  AgentLoopToolObservation,
+  AgentLoopToolObservationExecution,
+  AgentLoopToolObservationState,
+} from "./agent-loop-model.js";
 import type { AgentLoopCommandResult, AgentLoopResult, AgentLoopToolResultSummary } from "./agent-loop-result.js";
 import type { AgentLoopToolRuntime } from "./agent-loop-tool-runtime.js";
 import type { AgentLoopToolRouter } from "./agent-loop-tool-router.js";
@@ -320,6 +328,12 @@ export class BoundedAgentLoopRunner {
 
       const { results: toolResults, timedOut: toolBatchTimedOut } = await this.executeToolBatchWithinBudget(response.toolCalls, turn, startedAt);
       for (const result of toolResults) {
+        const sourceCall = response.toolCalls.find((call) => call.id === result.callId);
+        const observation = this.createToolObservation(
+          result,
+          sourceCall,
+          toolBatchTimedOut,
+        );
         if (result.execution?.status !== "not_executed") {
           calledTools.add(result.toolName);
         }
@@ -340,6 +354,7 @@ export class BoundedAgentLoopRunner {
           toolCallId: result.callId,
           toolName: result.toolName,
           content: result.content,
+          observation,
         });
 
         await this.record(turn, {
@@ -355,6 +370,12 @@ export class BoundedAgentLoopRunner {
           ...(result.artifacts ? { artifacts: result.artifacts } : {}),
           ...(result.truncated ? { truncated: result.truncated } : {}),
           ...(result.activityCategory ? { activityCategory: result.activityCategory } : {}),
+        });
+
+        await this.record(turn, {
+          type: "tool_observation",
+          ...this.baseEvent(turn),
+          observation,
         });
 
         if (result.disposition === "approval_denied") {
@@ -665,6 +686,69 @@ export class BoundedAgentLoopRunner {
     calledTools: Set<string>,
   ): string[] {
     return [...(turn.toolPolicy.requiredTools ?? [])].filter((toolName) => !calledTools.has(toolName));
+  }
+
+  private createToolObservation(
+    result: Awaited<ReturnType<AgentLoopToolRuntime["executeBatch"]>>[number],
+    sourceCall: AgentLoopToolCall | undefined,
+    toolBatchTimedOut: boolean,
+  ): AgentLoopToolObservation;
+  private createToolObservation(
+    result: Awaited<ReturnType<AgentLoopToolRuntime["executeBatch"]>>[number],
+    sourceCall: AgentLoopToolCall | undefined,
+    toolBatchTimedOut: boolean,
+  ): AgentLoopToolObservation {
+    const state = this.toolObservationState(result, toolBatchTimedOut);
+    const execution = this.toolObservationExecution(result, state);
+    const rawResult = result.rawResult;
+    return {
+      type: "tool_observation",
+      callId: result.callId,
+      toolName: result.toolName,
+      arguments: sourceCall?.input ?? {},
+      state,
+      success: result.success,
+      execution,
+      durationMs: result.durationMs,
+      output: {
+        content: result.content,
+        ...(rawResult?.summary ? { summary: rawResult.summary } : {}),
+        ...(rawResult && Object.prototype.hasOwnProperty.call(rawResult, "data") ? { data: rawResult.data } : {}),
+        ...(rawResult?.error ? { error: rawResult.error } : {}),
+      },
+      ...(result.command ? { command: result.command } : {}),
+      ...(result.cwd ? { cwd: result.cwd } : {}),
+      ...(result.artifacts ? { artifacts: result.artifacts } : {}),
+      ...(result.truncated ? { truncated: result.truncated } : {}),
+      ...(result.activityCategory ? { activityCategory: result.activityCategory } : {}),
+    };
+  }
+
+  private toolObservationState(
+    result: Awaited<ReturnType<AgentLoopToolRuntime["executeBatch"]>>[number],
+    toolBatchTimedOut: boolean,
+  ): AgentLoopToolObservationState {
+    const reason = result.execution?.reason;
+    if (reason === "timed_out" || (toolBatchTimedOut && result.disposition === "cancelled")) return "timed_out";
+    if (reason === "interrupted" || result.disposition === "cancelled") return "interrupted";
+    if (reason === "approval_denied" || reason === "permission_denied") return "denied";
+    if (reason === "policy_blocked" || reason === "dry_run") return "blocked";
+    return result.success ? "success" : "failure";
+  }
+
+  private toolObservationExecution(
+    result: Awaited<ReturnType<AgentLoopToolRuntime["executeBatch"]>>[number],
+    state: AgentLoopToolObservationState,
+  ): AgentLoopToolObservationExecution {
+    if (result.execution) return result.execution;
+    if (state === "timed_out" || state === "interrupted") {
+      return {
+        status: "executed",
+        reason: state === "timed_out" ? "timed_out" : "interrupted",
+        message: result.content,
+      };
+    }
+    return { status: "executed" };
   }
 
   private async createTurnProtocol<TOutput>(

--- a/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
+++ b/src/orchestrator/execution/agent-loop/openai-responses-agent-loop-model-client.ts
@@ -21,6 +21,7 @@ import type {
   AgentLoopModelTurnProtocol,
   AgentLoopToolCall,
 } from "./agent-loop-model.js";
+import { formatAgentLoopToolMessageContent } from "./agent-loop-model.js";
 import type { ResponseItem } from "./response-item.js";
 import {
   assistantTextResponseItem,
@@ -156,7 +157,7 @@ export class OpenAIResponsesAgentLoopModelClient implements AgentLoopModelClient
         const item: ResponseInputItem.FunctionCallOutput = {
           type: "function_call_output",
           call_id: message.toolCallId,
-          output: message.content,
+          output: formatAgentLoopToolMessageContent(message),
         };
         items.push(item);
         continue;

--- a/src/orchestrator/execution/agent-loop/response-item-tool-router.ts
+++ b/src/orchestrator/execution/agent-loop/response-item-tool-router.ts
@@ -1,5 +1,5 @@
 import type { z } from "zod";
-import type { ToolExecutor } from "../../../tools/executor.js";
+import { ToolExecutionTimeoutError, type ToolExecutor } from "../../../tools/executor.js";
 import type { ToolCallContext } from "../../../tools/types.js";
 import type { AgentLoopTurnContext } from "./agent-loop-turn-context.js";
 import type { AgentLoopToolRouter } from "./agent-loop-tool-router.js";
@@ -150,15 +150,12 @@ export class ResponseItemToolRouter {
         durationMs,
       });
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       return this.toolError(item, {
         code: "execution_failed",
-        message: err instanceof Error ? err.message : String(err),
+        message,
         durationMs: Date.now() - start,
-        execution: {
-          status: "not_executed",
-          reason: "tool_error",
-          message: err instanceof Error ? err.message : String(err),
-        },
+        execution: this.executionForException(message, turn, err),
       });
     }
   }
@@ -218,5 +215,31 @@ export class ResponseItemToolRouter {
         return `${path}: ${issue.message}`;
       })
       .join("; ");
+  }
+
+  private executionForException(
+    message: string,
+    turn: AgentLoopTurnContext<unknown>,
+    error?: unknown,
+  ): ToolErrorResponseItem["execution"] {
+    if (turn.abortSignal?.aborted) {
+      return {
+        status: "executed",
+        reason: "interrupted",
+        message,
+      };
+    }
+    if (error instanceof ToolExecutionTimeoutError) {
+      return {
+        status: "executed",
+        reason: "timed_out",
+        message,
+      };
+    }
+    return {
+      status: "not_executed",
+      reason: "tool_error",
+      message,
+    };
   }
 }

--- a/src/orchestrator/execution/agent-loop/response-item.ts
+++ b/src/orchestrator/execution/agent-loop/response-item.ts
@@ -27,7 +27,7 @@ export const FunctionToolCallResponseItemSchema = z.object({
 
 export const ToolExecutionStateSchema = z.object({
   status: z.enum(["executed", "not_executed"]),
-  reason: z.enum(["approval_denied", "permission_denied", "policy_blocked", "dry_run", "tool_error"]).optional(),
+  reason: z.enum(["approval_denied", "permission_denied", "policy_blocked", "dry_run", "tool_error", "timed_out", "interrupted"]).optional(),
   message: z.string().optional(),
 });
 

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -248,7 +248,7 @@ export class ToolExecutor {
       fn(),
       new Promise<ToolResult>((_, reject) =>
         setTimeout(
-          () => reject(new Error(`Tool call timed out after ${timeoutMs}ms`)),
+          () => reject(new ToolExecutionTimeoutError(timeoutMs)),
           timeoutMs,
         ),
       ),
@@ -288,12 +288,14 @@ export class ToolExecutor {
       } catch (err) {
         if (!isSafe || !isTransient(err) || attempt >= BACKOFFS.length) {
           const errMsg = err instanceof Error ? err.message : String(err);
+          const execution = this.executionForFailure(err, context);
           context.logger?.warn("tool.call.failure", { tool: toolName, callId: context.callId, error: errMsg });
           return {
             success: false,
             data: null,
             summary: `Tool ${toolName} failed: ${errMsg}`,
             error: errMsg,
+            ...(execution ? { execution } : {}),
             durationMs: 0,
           };
         }
@@ -321,6 +323,24 @@ export class ToolExecutor {
       ...(execution ? { execution } : {}),
       durationMs,
     };
+  }
+
+  private executionForFailure(error: unknown, context: ToolCallContext): ToolResult["execution"] | undefined {
+    const message = error instanceof Error ? error.message : String(error);
+    if (context.abortSignal?.aborted) {
+      return { status: "executed", reason: "interrupted", message };
+    }
+    if (error instanceof ToolExecutionTimeoutError) {
+      return { status: "executed", reason: "timed_out", message };
+    }
+    return undefined;
+  }
+}
+
+export class ToolExecutionTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Tool call timed out after ${timeoutMs}ms`);
+    this.name = "ToolExecutionTimeoutError";
   }
 }
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -18,7 +18,7 @@ export const ToolResultSchema = z.object({
    */
   execution: z.object({
     status: z.enum(["executed", "not_executed"]),
-    reason: z.enum(["approval_denied", "permission_denied", "policy_blocked", "dry_run", "tool_error"]).optional(),
+    reason: z.enum(["approval_denied", "permission_denied", "policy_blocked", "dry_run", "tool_error", "timed_out", "interrupted"]).optional(),
     message: z.string().optional(),
   }).optional(),
   /** Duration of the tool call in milliseconds */


### PR DESCRIPTION
## Summary

- add durable typed tool observations to AgentLoop tool messages and trace events
- replay typed observations into follow-up model turns for fallback, OpenAI Responses, and Anthropic Messages providers
- distinguish success, failure, denied, blocked, timed_out, and interrupted tool outcomes through typed state

Closes #1111

## Verification

- npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/orchestrator/execution/agent-loop/__tests__/response-item-tool-router.test.ts src/orchestrator/execution/agent-loop/__tests__/openai-responses-agent-loop-model-client.test.ts src/orchestrator/execution/agent-loop/__tests__/anthropic-messages-agent-loop-model-client.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- npm run test:unit

## Review

- Fresh review found two material issues: observation event ordering and timeout classification by error text.
- Both were fixed; re-review reported no material findings.
