### PR TITLE
feat(policy): add host-owned execution decisions

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/response-item-tool-router.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/response-item-tool-router.test.ts
@@ -72,6 +72,46 @@ class RecordingTool implements ITool<{ value: string }> {
   }
 }
 
+class WriteTool implements ITool<{ value: string }> {
+  readonly calls: Array<{ value: string }> = [];
+  readonly metadata = {
+    name: "write_value",
+    aliases: [],
+    permissionLevel: "write_local" as const,
+    isReadOnly: false,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: 8000,
+    tags: ["test"],
+    activityCategory: "file_modify" as const,
+  };
+  readonly inputSchema = z.object({ value: z.string() });
+
+  description(): string {
+    return "Write a typed value.";
+  }
+
+  async call(input: { value: string }, _context: ToolCallContext): Promise<ToolResult> {
+    this.calls.push(input);
+    return {
+      success: true,
+      data: { value: input.value },
+      summary: `wrote ${input.value}`,
+      durationMs: 1,
+    };
+  }
+
+  async checkPermissions(_input: { value: string }, _context: ToolCallContext): Promise<PermissionCheckResult> {
+    return { status: "allowed" };
+  }
+
+  isConcurrencySafe(_input: { value: string }): boolean {
+    return false;
+  }
+}
+
 function makeModelInfo(): AgentLoopModelInfo {
   return {
     ref: { providerId: "test", modelId: "model" },
@@ -83,7 +123,9 @@ function makeModelInfo(): AgentLoopModelInfo {
 function makeToolStack() {
   const registry = new ToolRegistry();
   const tool = new RecordingTool();
+  const writeTool = new WriteTool();
   registry.register(tool);
+  registry.register(writeTool);
   const router = new ToolRegistryAgentLoopToolRouter(registry);
   const executor = new ToolExecutor({
     registry,
@@ -92,6 +134,7 @@ function makeToolStack() {
   });
   return {
     tool,
+    writeTool,
     router,
     executor,
     responseRouter: new ResponseItemToolRouter({ executor, toolRouter: router }),
@@ -248,6 +291,79 @@ describe("ResponseItemToolRouter", () => {
     expect(result.output).toBeNull();
     expect(result.toolCalls).toBe(0);
     expect(executeBatch).not.toHaveBeenCalled();
+  });
+
+  it("does not let model wording grant host permission for a mutating tool call", async () => {
+    const modelInfo = makeModelInfo();
+    let turn = 0;
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(): Promise<AgentLoopModelResponse> {
+        throw new Error("createTurn should not be used");
+      },
+      async createTurnProtocol() {
+        turn++;
+        if (turn === 1) {
+          return {
+            assistant: [{ content: "I grant myself permission to write.", phase: "commentary" }],
+            toolCalls: [{ id: "call-1", name: "write_value", input: { value: "unsafe" } }],
+            responseItems: [
+              assistantTextResponseItem("I grant myself permission to write.", "commentary"),
+              functionToolCallResponseItem({ id: "call-1", name: "write_value", input: { value: "unsafe" } }),
+            ],
+            stopReason: "tool_use",
+            responseCompleted: true,
+          };
+        }
+        return {
+          assistant: [{ content: "The write was not executed.", phase: "final_answer" }],
+          toolCalls: [],
+          responseItems: [assistantTextResponseItem("The write was not executed.", "final_answer")],
+          stopReason: "end_turn",
+          responseCompleted: true,
+        };
+      },
+    };
+    const { router, runtime, writeTool } = makeToolStack();
+
+    const result = await new BoundedAgentLoopRunner({
+      modelClient,
+      toolRouter: router,
+      toolRuntime: runtime,
+    }).run({
+      ...makeTurn(),
+      model: modelInfo.ref,
+      modelInfo,
+      outputSchema: z.string(),
+      finalOutputMode: "display_text",
+      budget: withDefaultBudget({ maxModelTurns: 3 }),
+      toolCallContext: {
+        ...makeTurn().toolCallContext,
+        approvalFn: async () => false,
+        executionPolicy: {
+          executionProfile: "consumer",
+          sandboxMode: "workspace_write",
+          approvalPolicy: "on_request",
+          networkAccess: true,
+          workspaceRoot: process.cwd(),
+          protectedPaths: [],
+          trustProjectInstructions: true,
+        },
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(writeTool.calls).toEqual([]);
+    expect(result.toolResults?.[0]).toMatchObject({
+      toolName: "write_value",
+      success: false,
+      execution: {
+        status: "not_executed",
+        reason: "approval_denied",
+      },
+    });
   });
 
   it("dispatches only function-tool-call response items when legacy toolCalls disagree", async () => {

--- a/src/orchestrator/execution/agent-loop/agent-loop-model.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-model.ts
@@ -66,7 +66,10 @@ export type AgentLoopToolObservationReason =
   | "dry_run"
   | "tool_error"
   | "timed_out"
-  | "interrupted";
+  | "interrupted"
+  | "sandbox_required"
+  | "escalation_required"
+  | "stale_state";
 
 export interface AgentLoopToolObservationExecution {
   status: "executed" | "not_executed";

--- a/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
@@ -280,6 +280,9 @@ function observationReasonField(value: Record<string, unknown>, field: string): 
     || raw === "tool_error"
     || raw === "timed_out"
     || raw === "interrupted"
+    || raw === "sandbox_required"
+    || raw === "escalation_required"
+    || raw === "stale_state"
     ? raw
     : null;
 }

--- a/src/orchestrator/execution/agent-loop/response-item.ts
+++ b/src/orchestrator/execution/agent-loop/response-item.ts
@@ -27,7 +27,7 @@ export const FunctionToolCallResponseItemSchema = z.object({
 
 export const ToolExecutionStateSchema = z.object({
   status: z.enum(["executed", "not_executed"]),
-  reason: z.enum(["approval_denied", "permission_denied", "policy_blocked", "dry_run", "tool_error", "timed_out", "interrupted"]).optional(),
+  reason: z.enum(["approval_denied", "permission_denied", "policy_blocked", "dry_run", "tool_error", "timed_out", "interrupted", "sandbox_required", "escalation_required", "stale_state"]).optional(),
   message: z.string().optional(),
 });
 

--- a/src/tools/__tests__/execution-orchestrator.test.ts
+++ b/src/tools/__tests__/execution-orchestrator.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import { decideHostToolExecution } from "../execution-orchestrator.js";
+import type { ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
+import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../types.js";
+
+function makePolicy(overrides: Partial<ExecutionPolicy> = {}): ExecutionPolicy {
+  return {
+    executionProfile: "consumer",
+    sandboxMode: "workspace_write",
+    approvalPolicy: "on_request",
+    networkAccess: true,
+    workspaceRoot: "/repo",
+    protectedPaths: [],
+    trustProjectInstructions: true,
+    ...overrides,
+  };
+}
+
+function makeTool(overrides: Partial<ToolMetadata> = {}): ITool {
+  const metadata: ToolMetadata = {
+    name: "tool",
+    aliases: [],
+    permissionLevel: "read_only",
+    isReadOnly: true,
+    isDestructive: false,
+    shouldDefer: false,
+    alwaysLoad: false,
+    maxConcurrency: 0,
+    maxOutputChars: 8000,
+    tags: [],
+    ...overrides,
+  };
+  return {
+    metadata,
+    inputSchema: z.unknown(),
+    description: () => metadata.name,
+    call: vi.fn(async (): Promise<ToolResult> => ({
+      success: true,
+      data: null,
+      summary: "ok",
+      durationMs: 1,
+    })),
+    checkPermissions: vi.fn(async (): Promise<PermissionCheckResult> => ({ status: "allowed" })),
+    isConcurrencySafe: () => true,
+  };
+}
+
+function makeContext(overrides: Partial<ToolCallContext> = {}): ToolCallContext {
+  return {
+    cwd: "/repo",
+    goalId: "goal-1",
+    trustBalance: 0,
+    preApproved: false,
+    approvalFn: async () => false,
+    executionPolicy: makePolicy(),
+    ...overrides,
+  };
+}
+
+describe("decideHostToolExecution", () => {
+  it("allows read-only typed requests under the current host policy", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ permissionLevel: "read_only", isReadOnly: true }),
+      input: {},
+      context: makeContext(),
+    });
+
+    expect(decision.status).toBe("allowed");
+  });
+
+  it("denies unsafe shell protocol requests without consulting model wording", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ name: "shell", permissionLevel: "read_metrics", isReadOnly: false }),
+      input: { command: "echo ok && sudo reboot" },
+      context: makeContext(),
+    });
+
+    expect(decision.status).toBe("denied");
+    expect(decision.executionReason).toBe("policy_blocked");
+  });
+
+  it("requires permission for local writes when approval is on-request", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ permissionLevel: "write_local", isReadOnly: false }),
+      input: { path: "notes.md" },
+      context: makeContext({ executionPolicy: makePolicy({ approvalPolicy: "on_request" }) }),
+    });
+
+    expect(decision.status).toBe("needs_permission");
+    expect(decision.requiredApprovalPolicy).toBe("on_request");
+  });
+
+  it("requires sandbox changes for mutating tools in read-only sandbox", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ permissionLevel: "write_local", isReadOnly: false }),
+      input: { path: "notes.md" },
+      context: makeContext({ executionPolicy: makePolicy({ sandboxMode: "read_only" }) }),
+    });
+
+    expect(decision.status).toBe("needs_sandbox");
+    expect(decision.executionReason).toBe("sandbox_required");
+  });
+
+  it("requires escalation for high-risk tools under untrusted policy", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ permissionLevel: "execute", isReadOnly: false, isDestructive: true }),
+      input: { command: "deploy" },
+      context: makeContext({ executionPolicy: makePolicy({ approvalPolicy: "untrusted" }) }),
+    });
+
+    expect(decision.status).toBe("needs_escalation");
+    expect(decision.executionReason).toBe("escalation_required");
+  });
+
+  it("fails closed when the typed host state epoch is stale", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ permissionLevel: "read_only", isReadOnly: true }),
+      input: {},
+      context: makeContext({
+        hostToolState: {
+          observedEpoch: "epoch-before",
+          currentEpoch: "epoch-after",
+        },
+      }),
+    });
+
+    expect(decision.status).toBe("fail_closed");
+    expect(decision.executionReason).toBe("stale_state");
+  });
+});

--- a/src/tools/__tests__/executor.test.ts
+++ b/src/tools/__tests__/executor.test.ts
@@ -6,6 +6,8 @@ import { ToolExecutor } from "../executor.js";
 import { ToolRegistry } from "../registry.js";
 import { ToolPermissionManager } from "../permission.js";
 import { ConcurrencyController } from "../concurrency.js";
+import { ShellTool } from "../system/ShellTool/ShellTool.js";
+import type { ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 import type {
   ITool,
   ToolResult,
@@ -60,6 +62,19 @@ function createMockContext(overrides: Partial<ToolCallContext> = {}): ToolCallCo
     trustBalance: 50,
     preApproved: false,
     approvalFn: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+function createExecutionPolicy(overrides: Partial<ExecutionPolicy> = {}): ExecutionPolicy {
+  return {
+    executionProfile: "consumer",
+    sandboxMode: "workspace_write",
+    approvalPolicy: "on_request",
+    networkAccess: true,
+    workspaceRoot: "/tmp",
+    protectedPaths: [],
+    trustProjectInstructions: true,
     ...overrides,
   };
 }
@@ -208,6 +223,62 @@ describe("ToolExecutor", () => {
         const result = await executor.execute("write-tool2", { value: "x" }, ctx);
         expect(result.success).toBe(false);
         expect(result.error).toContain("User denied approval");
+      });
+
+      it("does not execute escalation-required tools by ordinary approval", async () => {
+        const tool = createMockTool({
+          name: "execute-tool",
+          metadata: {
+            name: "execute-tool",
+            aliases: [],
+            permissionLevel: "execute",
+            isReadOnly: false,
+            isDestructive: true,
+            shouldDefer: false,
+            alwaysLoad: false,
+            maxConcurrency: 0,
+            maxOutputChars: 8000,
+            tags: [],
+          } as ITool["metadata"],
+        });
+        const { executor } = createExecutor([tool]);
+        const approvalFn = vi.fn().mockResolvedValue(true);
+        const ctx = createMockContext({
+          approvalFn,
+          executionPolicy: createExecutionPolicy({ approvalPolicy: "untrusted" }),
+        });
+
+        const result = await executor.execute("execute-tool", { value: "x" }, ctx);
+
+        expect(result.success).toBe(false);
+        expect(result.execution).toMatchObject({
+          status: "not_executed",
+          reason: "escalation_required",
+        });
+        expect(approvalFn).not.toHaveBeenCalled();
+        expect(tool.call).not.toHaveBeenCalled();
+      });
+
+      it("returns typed sandbox-required execution for shell commands before shell-local denial", async () => {
+        const shellTool = new ShellTool();
+        const { executor } = createExecutor([shellTool]);
+        const approvalFn = vi.fn().mockResolvedValue(true);
+        const ctx = createMockContext({
+          approvalFn,
+          executionPolicy: createExecutionPolicy({
+            sandboxMode: "read_only",
+            approvalPolicy: "on_request",
+          }),
+        });
+
+        const result = await executor.execute("shell", { command: "touch file.txt" }, ctx);
+
+        expect(result.success).toBe(false);
+        expect(result.execution).toMatchObject({
+          status: "not_executed",
+          reason: "sandbox_required",
+        });
+        expect(approvalFn).not.toHaveBeenCalled();
       });
     });
 

--- a/src/tools/execution-orchestrator.ts
+++ b/src/tools/execution-orchestrator.ts
@@ -1,0 +1,179 @@
+import type { ITool, ToolCallContext, ToolResult } from "./types.js";
+import { assessShellCommand } from "./system/ShellTool/command-policy.js";
+
+export type HostToolExecutionDecisionStatus =
+  | "allowed"
+  | "denied"
+  | "needs_permission"
+  | "needs_sandbox"
+  | "needs_escalation"
+  | "fail_closed";
+
+export interface HostToolExecutionDecision {
+  status: HostToolExecutionDecisionStatus;
+  reason: string;
+  executionReason?: NonNullable<ToolResult["execution"]>["reason"];
+  requiredSandboxMode?: "workspace_write" | "danger_full_access";
+  requiredApprovalPolicy?: "on_request";
+}
+
+export interface HostToolExecutionRequest {
+  tool: ITool;
+  input: unknown;
+  context: ToolCallContext;
+}
+
+export function decideHostToolExecution(
+  request: HostToolExecutionRequest
+): HostToolExecutionDecision {
+  const staleStateDecision = decideStateFreshness(request.context);
+  if (staleStateDecision) return staleStateDecision;
+
+  const policy = request.context.executionPolicy;
+  if (!policy) {
+    return { status: "allowed", reason: "No host execution policy is attached to this call." };
+  }
+
+  const shellDecision = decideShellExecution(request);
+  if (shellDecision) return shellDecision;
+
+  const needsNetwork = request.tool.metadata.permissionLevel === "write_remote"
+    || request.tool.metadata.requiresNetwork === true
+    || request.tool.metadata.tags.includes("network");
+  if (needsNetwork && !policy.networkAccess) {
+    return {
+      status: "needs_sandbox",
+      reason: "Network access is disabled for this session.",
+      executionReason: "sandbox_required",
+      requiredSandboxMode: "danger_full_access",
+    };
+  }
+
+  if (policy.sandboxMode === "read_only" && !request.tool.metadata.isReadOnly) {
+    return {
+      status: "needs_sandbox",
+      reason: "Read-only sandbox blocks mutating tools.",
+      executionReason: "sandbox_required",
+      requiredSandboxMode: "workspace_write",
+    };
+  }
+
+  if (
+    policy.approvalPolicy === "untrusted"
+    && (request.tool.metadata.isDestructive
+      || request.tool.metadata.permissionLevel === "execute"
+      || request.tool.metadata.permissionLevel === "write_remote")
+  ) {
+    return {
+      status: "needs_escalation",
+      reason: `Host policy requires escalation for ${request.tool.metadata.permissionLevel} tools.`,
+      executionReason: "escalation_required",
+      requiredApprovalPolicy: "on_request",
+    };
+  }
+
+  if (
+    request.tool.metadata.permissionLevel === "write_local"
+    || request.tool.metadata.permissionLevel === "execute"
+    || request.tool.metadata.permissionLevel === "write_remote"
+  ) {
+    if (policy.approvalPolicy !== "never") {
+      return {
+        status: "needs_permission",
+        reason: `Host policy requires permission for ${request.tool.metadata.permissionLevel} tools.`,
+        executionReason: "approval_denied",
+        requiredApprovalPolicy: "on_request",
+      };
+    }
+  }
+
+  return { status: "allowed", reason: "Host policy allows this typed tool request." };
+}
+
+function decideStateFreshness(context: ToolCallContext): HostToolExecutionDecision | null {
+  const state = context.hostToolState;
+  if (!state?.observedEpoch) return null;
+  if (state.observedEpoch === state.currentEpoch) return null;
+  return {
+    status: "fail_closed",
+    reason: `Tool request observed state epoch ${state.observedEpoch}, but host state is now ${state.currentEpoch}.`,
+    executionReason: "stale_state",
+  };
+}
+
+function decideShellExecution(
+  request: HostToolExecutionRequest
+): HostToolExecutionDecision | null {
+  if (request.tool.metadata.name !== "shell" || typeof request.input !== "object" || request.input === null) {
+    return null;
+  }
+  const command = (request.input as { command?: unknown }).command;
+  if (typeof command !== "string") return null;
+
+  const assessment = assessShellCommand(
+    command,
+    request.context.executionPolicy,
+    request.context.trusted === true,
+    request.context.cwd
+  );
+  if (assessment.status === "allowed") {
+    return { status: "allowed", reason: "Shell command is allowed by host policy." };
+  }
+  if (assessment.status === "needs_approval") {
+    return {
+      status: "needs_permission",
+      reason: assessment.reason ?? "Shell command requires permission.",
+      executionReason: "approval_denied",
+      requiredApprovalPolicy: "on_request",
+    };
+  }
+  if (
+    (assessment.capabilities.localWrite && request.context.executionPolicy?.sandboxMode === "read_only")
+    || (assessment.capabilities.network && request.context.executionPolicy?.networkAccess === false)
+  ) {
+    const reason = assessment.capabilities.network
+      ? "Network access is disabled for this session."
+      : "Read-only sandbox blocks mutating shell commands.";
+    return {
+      status: "needs_sandbox",
+      reason,
+      executionReason: "sandbox_required",
+      requiredSandboxMode: assessment.capabilities.network ? "danger_full_access" : "workspace_write",
+    };
+  }
+  return {
+    status: "denied",
+    reason: assessment.reason ?? "Shell command denied by host policy.",
+    executionReason: "policy_blocked",
+  };
+}
+
+export function permissionResultFromHostDecision(decision: HostToolExecutionDecision): {
+  status: "allowed";
+} | {
+  status: "denied";
+  reason: string;
+  executionReason?: NonNullable<ToolResult["execution"]>["reason"];
+  policyDecision: HostToolExecutionDecision;
+} | {
+  status: "needs_approval";
+  reason: string;
+  executionReason?: NonNullable<ToolResult["execution"]>["reason"];
+  policyDecision: HostToolExecutionDecision;
+} {
+  if (decision.status === "allowed") return { status: "allowed" };
+  if (decision.status === "needs_permission") {
+    return {
+      status: "needs_approval",
+      reason: decision.reason,
+      ...(decision.executionReason ? { executionReason: decision.executionReason } : {}),
+      policyDecision: decision,
+    };
+  }
+  return {
+    status: "denied",
+    reason: decision.reason,
+    ...(decision.executionReason ? { executionReason: decision.executionReason } : {}),
+    policyDecision: decision,
+  };
+}

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -12,6 +12,10 @@ import type {
 import type { ToolRegistry } from "./registry.js";
 import type { ToolPermissionManager } from "./permission.js";
 import type { ConcurrencyController } from "./concurrency.js";
+import {
+  decideHostToolExecution,
+  permissionResultFromHostDecision,
+} from "./execution-orchestrator.js";
 
 /**
  * 5-gate execution pipeline for tool invocations.
@@ -63,6 +67,9 @@ export class ToolExecutor {
     }
     const input = parseResult.data;
 
+    const hostPreflightResult = this.checkHostPolicyPreflight(tool, input, context, startTime);
+    if (hostPreflightResult) return hostPreflightResult;
+
     // --- Gate 2: Semantic Validation (tool-specific) ---
     const semanticResult = await tool.checkPermissions(input, context);
     if (semanticResult.status === "denied") {
@@ -99,7 +106,7 @@ export class ToolExecutor {
       return this.failResult(
         `Permission denied by policy: ${permResult.reason}`,
         Date.now() - startTime,
-        { status: "not_executed", reason: "policy_blocked", message: permResult.reason },
+        { status: "not_executed", reason: permResult.executionReason ?? "policy_blocked", message: permResult.reason },
       );
     }
     if (permResult.status === "needs_approval") {
@@ -222,6 +229,33 @@ export class ToolExecutor {
   }
 
   // --- Private Helpers ---
+
+  private checkHostPolicyPreflight(
+    tool: ITool,
+    input: unknown,
+    context: ToolCallContext,
+    startTime: number,
+  ): ToolResult | null {
+    const decision = decideHostToolExecution({ tool, input, context });
+    if (decision.status === "allowed" || decision.status === "needs_permission") {
+      return null;
+    }
+
+    const policyResult = permissionResultFromHostDecision(decision);
+    if (policyResult.status !== "denied") {
+      return null;
+    }
+
+    return this.failResult(
+      `Permission denied by host policy: ${policyResult.reason}`,
+      Date.now() - startTime,
+      {
+        status: "not_executed",
+        reason: policyResult.executionReason ?? "policy_blocked",
+        message: policyResult.reason,
+      },
+    );
+  }
 
   private sanitizeInput(tool: ITool, input: unknown): string | null {
     if (tool.metadata.name === "shell" && typeof input === "object" && input !== null) {

--- a/src/tools/permission.ts
+++ b/src/tools/permission.ts
@@ -4,7 +4,10 @@ import type {
   PermissionCheckResult,
   ToolPermissionLevel,
 } from "./types.js";
-import { assessShellCommand } from "./system/ShellTool/command-policy.js";
+import {
+  decideHostToolExecution,
+  permissionResultFromHostDecision,
+} from "./execution-orchestrator.js";
 
 /**
  * 3-layer permission model for tool invocations.
@@ -31,8 +34,9 @@ export class ToolPermissionManager {
     input: unknown,
     context: ToolCallContext,
   ): Promise<PermissionCheckResult> {
-    const policyResult = this.checkExecutionPolicy(tool, input, context);
-    if (policyResult) return policyResult;
+    const hostDecision = decideHostToolExecution({ tool, input, context });
+    const hostPolicyResult = permissionResultFromHostDecision(hostDecision);
+    if (hostDecision.status === "fail_closed") return hostPolicyResult;
 
     // --- Layer 1: Registry Deny-List ---
     for (const rule of this.denyList) {
@@ -40,6 +44,9 @@ export class ToolPermissionManager {
         return { status: "denied", reason: rule.reason };
       }
     }
+
+    if (hostPolicyResult.status !== "allowed") return hostPolicyResult;
+    if (context.executionPolicy) return hostPolicyResult;
 
     // Read-only tools are always allowed after deny-list check
     if (tool.metadata.isReadOnly) {
@@ -126,39 +133,6 @@ export class ToolPermissionManager {
     return true;
   }
 
-  private checkExecutionPolicy(
-    tool: ITool,
-    input: unknown,
-    context: ToolCallContext,
-  ): PermissionCheckResult | null {
-    const policy = context.executionPolicy;
-    if (!policy) return null;
-
-    if (tool.metadata.name === "shell" && typeof input === "object" && input !== null) {
-      const command = (input as { command?: unknown }).command;
-      if (typeof command === "string") {
-        const assessment = assessShellCommand(command, policy, context.trusted === true);
-        if (assessment.status === "allowed") return { status: "allowed" };
-        if (assessment.status === "needs_approval") {
-          return { status: "needs_approval", reason: assessment.reason ?? "Shell command requires approval" };
-        }
-        return { status: "denied", reason: assessment.reason ?? "Shell command denied by execution policy" };
-      }
-    }
-
-    if (policy.sandboxMode === "read_only" && !tool.metadata.isReadOnly) {
-      return { status: "denied", reason: "Read-only sandbox blocks mutating tools" };
-    }
-    if (!policy.networkAccess && (tool.metadata.permissionLevel === "write_remote" || tool.metadata.requiresNetwork === true || tool.metadata.tags.includes("network"))) {
-      return { status: "denied", reason: "Network access is disabled for this session" };
-    }
-    if (tool.metadata.permissionLevel === "write_local" || tool.metadata.permissionLevel === "execute" || tool.metadata.permissionLevel === "write_remote") {
-      if (policy.approvalPolicy !== "never") {
-        return { status: "needs_approval", reason: `Execution policy requires approval for ${tool.metadata.permissionLevel} tools` };
-      }
-    }
-    return null;
-  }
 }
 
 // --- Supporting Types ---

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -1,7 +1,21 @@
 import { z } from "zod";
 import type { ExecutionPolicy, SubagentRole } from "../orchestrator/execution/agent-loop/execution-policy.js";
+import type { HostToolExecutionDecision } from "./execution-orchestrator.js";
 
 // --- Tool Result ---
+
+export const ToolExecutionReasonSchema = z.enum([
+  "approval_denied",
+  "permission_denied",
+  "policy_blocked",
+  "dry_run",
+  "tool_error",
+  "timed_out",
+  "interrupted",
+  "sandbox_required",
+  "escalation_required",
+  "stale_state",
+]);
 
 export const ToolResultSchema = z.object({
   /** Whether the tool invocation succeeded */
@@ -18,7 +32,7 @@ export const ToolResultSchema = z.object({
    */
   execution: z.object({
     status: z.enum(["executed", "not_executed"]),
-    reason: z.enum(["approval_denied", "permission_denied", "policy_blocked", "dry_run", "tool_error", "timed_out", "interrupted"]).optional(),
+    reason: ToolExecutionReasonSchema.optional(),
     message: z.string().optional(),
   }).optional(),
   /** Duration of the tool call in milliseconds */
@@ -184,6 +198,11 @@ export interface ToolCallContext {
   trusted?: boolean;
   /** Shared execution policy for chat/agent-loop sessions. */
   executionPolicy?: ExecutionPolicy;
+  /** Host-owned typed state used to fail closed when a request was based on stale runtime/session state. */
+  hostToolState?: {
+    currentEpoch: string;
+    observedEpoch?: string;
+  };
   /** Optional subagent role for delegated runs. */
   agentRole?: SubagentRole;
   /** Abort signal for cancellation */
@@ -240,8 +259,20 @@ export interface ApprovalRequest {
 
 export const PermissionCheckResultSchema = z.discriminatedUnion("status", [
   z.object({ status: z.literal("allowed") }),
-  z.object({ status: z.literal("denied"), reason: z.string() }),
-  z.object({ status: z.literal("needs_approval"), reason: z.string() }),
+  z.object({
+    status: z.literal("denied"),
+    reason: z.string(),
+    executionReason: ToolExecutionReasonSchema.optional(),
+    policyDecision: z.unknown().optional(),
+  }),
+  z.object({
+    status: z.literal("needs_approval"),
+    reason: z.string(),
+    executionReason: ToolExecutionReasonSchema.optional(),
+    policyDecision: z.unknown().optional(),
+  }),
 ]);
 
-export type PermissionCheckResult = z.infer<typeof PermissionCheckResultSchema>;
+export type PermissionCheckResult = z.infer<typeof PermissionCheckResultSchema> & {
+  policyDecision?: HostToolExecutionDecision;
+};


### PR DESCRIPTION
## Summary
- add a typed host-owned tool execution decision state machine for allowed/denied/permission/sandbox/escalation/fail-closed outcomes
- propagate policy execution reasons through permission and tool execution results, including stale state and sandbox/escalation blocks
- cover model self-permission rejection plus executor caller paths for escalation and shell sandbox handling

Closes #1112

## Verification
- npx vitest run --config vitest.unit.config.ts src/tools/__tests__/execution-orchestrator.test.ts src/tools/__tests__/permission.test.ts src/tools/__tests__/executor.test.ts src/orchestrator/execution/agent-loop/__tests__/response-item-tool-router.test.ts
- npm run typecheck
- npm run lint:boundaries (0 errors, existing warnings)
- npm run test:changed
- npm run test:unit

## Review
- Fresh review initially found two P1s; both fixed. Re-review reported no high-confidence material findings.