### PR TITLE
feat(permissions): bind dialogue approvals to typed state

### DIFF
--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -1330,6 +1330,101 @@ describe("CrossPlatformChatSessionManager", () => {
     }
   });
 
+  it("persists tool permission prompts with typed target and risk metadata", async () => {
+    const tmpDir = makeTempDir();
+    const events: string[] = [];
+    try {
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "approval-tool-metadata",
+      });
+      const chatAgentLoopRunner = {
+        execute: vi.fn(async (input: {
+          approvalFn?: (request: ApprovalRequest) => Promise<boolean>;
+        }) => {
+          const approved = await input.approvalFn?.({
+            toolName: "write_file",
+            input: { path: "notes.md" },
+            reason: "Write notes.md in the workspace.",
+            permissionLevel: "write_local",
+            isDestructive: false,
+            reversibility: "reversible",
+            callId: "call-write-file",
+          });
+          return {
+            success: approved === true,
+            output: approved === true ? "write approved" : "not approved",
+            error: null,
+            exit_code: null,
+            elapsed_ms: 5,
+            stopped_reason: "completed",
+          };
+        }),
+      };
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        chatAgentLoopRunner: chatAgentLoopRunner as never,
+        approvalBroker,
+      }));
+
+      const resultPromise = manager.processIncomingMessage({
+        text: "Write the notes file",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        onEvent: (event) => {
+          if (event.type === "activity") {
+            events.push(event.message);
+          }
+        },
+      });
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline && (await store.loadPending("approval-tool-metadata")) === null) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      const pending = await store.loadPending("approval-tool-metadata");
+      expect(pending).toMatchObject({
+        payload: {
+          task: {
+            kind: "permission",
+            id: "call-write-file",
+            action: "write_file",
+            operation_summary: "Write notes.md in the workspace.",
+            risk_class: "medium",
+            target: {
+              session_id: "identity:workspace:U123",
+              tool_id: "write_file",
+              tool_call_id: "call-write-file",
+            },
+            state_epoch: "1700.2",
+            permission_level: "write_local",
+            is_destructive: false,
+          },
+        },
+      });
+      expect(events.some((message) =>
+        message.includes("Tool: write_file")
+        && message.includes("Tool call: call-write-file")
+        && message.includes("Risk: medium")
+      )).toBe(true);
+
+      await approvalBroker.resolveConversationalApproval("approval-tool-metadata", true, {
+        channel: "slack",
+        conversation_id: "C123:1700.1",
+        user_id: "U123",
+        session_id: "identity:workspace:U123",
+        turn_id: "1700.2",
+      });
+      await expect(resultPromise).resolves.toBe("write approved");
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
   it("keeps approvals pending for clarification replies and rejects wrong-context replies", async () => {
     const tmpDir = makeTempDir();
     try {
@@ -1517,6 +1612,313 @@ describe("CrossPlatformChatSessionManager", () => {
         turn_id: "1700.2",
       });
       await expect(resultPromise).resolves.toContain("not approved");
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("rejects natural-language approval after the pending target state epoch changes", async () => {
+    const tmpDir = makeTempDir();
+    try {
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "approval-stale-target",
+      });
+      const runtimeControlService = {
+        request: vi.fn(async (request: {
+          approvalFn?: (description: string) => Promise<boolean>;
+        }) => {
+          const approved = await request.approvalFn?.("Restart the resident daemon.");
+          return {
+            success: approved === true,
+            message: approved === true ? "restart queued" : "not approved",
+            operationId: "op-stale-target",
+            state: approved === true ? "acknowledged" as const : "blocked" as const,
+          };
+        }),
+      };
+      const adapter = makeMockAdapter({
+        ...CANNED_RESULT,
+        output: "The daemon restart target is the resident daemon.",
+      });
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        adapter,
+        llmClient: createMockLLMClient([
+          JSON.stringify({
+            intent: "restart_daemon",
+            reason: "PulSeed を再起動して",
+          }),
+          JSON.stringify({
+            decision: "side_question",
+            confidence: 0.93,
+            clarification: "Route the side question through normal chat.",
+          }),
+          JSON.stringify({
+            kind: "assist",
+            confidence: 0.9,
+            rationale: "side question",
+          }),
+          "The daemon restart target is the resident daemon.",
+        ]),
+        runtimeControlService,
+        approvalBroker,
+      }));
+
+      const resultPromise = manager.processIncomingMessage({
+        text: "PulSeed を再起動して",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        onEvent: () => undefined,
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      });
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline && (await store.loadPending("approval-stale-target")) === null) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      await expect(manager.processIncomingMessage({
+        text: "Before deciding, which daemon will restart?",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.3",
+        cwd: "/repo",
+      })).resolves.toBe("The daemon restart target is the resident daemon.");
+
+      await expect(manager.processIncomingMessage({
+        text: "問題ありません。進めてください",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.4",
+        cwd: "/repo",
+      })).resolves.toContain("approval target changed after the prompt");
+      await expect(resultPromise).resolves.toContain("not approved");
+      await expect(store.loadResolved("approval-stale-target")).resolves.toMatchObject({
+        state: "denied",
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("rejects typed approval responses after the pending target state epoch changes", async () => {
+    const tmpDir = makeTempDir();
+    try {
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "approval-stale-button",
+      });
+      const runtimeControlService = {
+        request: vi.fn(async (request: {
+          approvalFn?: (description: string) => Promise<boolean>;
+        }) => {
+          const approved = await request.approvalFn?.("Restart the resident daemon.");
+          return {
+            success: approved === true,
+            message: approved === true ? "restart queued" : "not approved",
+            operationId: "op-stale-button",
+            state: approved === true ? "acknowledged" as const : "blocked" as const,
+          };
+        }),
+      };
+      const adapter = makeMockAdapter({
+        ...CANNED_RESULT,
+        output: "The daemon restart target is the resident daemon.",
+      });
+      const manager = new CrossPlatformChatSessionManager(makeDeps({
+        adapter,
+        llmClient: createMockLLMClient([
+          JSON.stringify({
+            intent: "restart_daemon",
+            reason: "PulSeed を再起動して",
+          }),
+          JSON.stringify({
+            decision: "side_question",
+            confidence: 0.93,
+            clarification: "Route the side question through normal chat.",
+          }),
+          JSON.stringify({
+            kind: "assist",
+            confidence: 0.9,
+            rationale: "side question",
+          }),
+          "The daemon restart target is the resident daemon.",
+        ]),
+        runtimeControlService,
+        approvalBroker,
+      }));
+
+      const resultPromise = manager.processIncomingMessage({
+        text: "PulSeed を再起動して",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        onEvent: () => undefined,
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      });
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline && (await store.loadPending("approval-stale-button")) === null) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      await expect(manager.processIncomingMessage({
+        text: "Before deciding, which daemon will restart?",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.3",
+        cwd: "/repo",
+      })).resolves.toBe("The daemon restart target is the resident daemon.");
+
+      await expect(manager.processIncomingMessage({
+        text: "",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        approvalResponse: {
+          approval_id: "approval-stale-button",
+          approved: true,
+        },
+      })).resolves.toContain("approval target changed after the prompt");
+      await expect(resultPromise).resolves.toContain("not approved");
+      await expect(store.loadResolved("approval-stale-button")).resolves.toMatchObject({
+        state: "denied",
+      });
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("rejects stale typed approval responses even when another pending approval makes lookup ambiguous", async () => {
+    const tmpDir = makeTempDir();
+    try {
+      const store = new ApprovalStore(tmpDir);
+      const approvalBroker = new ApprovalBroker({
+        store,
+        createId: () => "unused",
+        deliverConversationalApproval: async () => ({ delivered: true }),
+      });
+      const manager = new CrossPlatformChatSessionManager(makeDeps({ approvalBroker }));
+      await manager.processIncomingMessage({
+        text: "ordinary state-changing turn",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.3",
+        cwd: "/repo",
+      });
+      const oldRequest = approvalBroker.requestConversationalApproval("goal-1", {
+        kind: "permission",
+        id: "call-old",
+        description: "Write the old file.",
+        action: "write_file",
+        operation_summary: "Write the old file.",
+        risk_class: "medium",
+        target: {
+          session_id: "identity:workspace:U123",
+          tool_id: "write_file",
+          tool_call_id: "call-old",
+        },
+        state_epoch: "1700.2",
+        state_version: "2026-05-06T00:00:00.000Z",
+      }, {
+        approvalId: "approval-old-stale",
+        timeoutMs: 30_000,
+        origin: {
+          channel: "slack",
+          conversation_id: "C123:1700.1",
+          user_id: "U123",
+          session_id: "identity:workspace:U123",
+          turn_id: "1700.2",
+        },
+      });
+      const newRequest = approvalBroker.requestConversationalApproval("goal-1", {
+        kind: "permission",
+        id: "call-new",
+        description: "Write the new file.",
+        action: "write_file",
+        operation_summary: "Write the new file.",
+        risk_class: "medium",
+        target: {
+          session_id: "identity:workspace:U123",
+          tool_id: "write_file",
+          tool_call_id: "call-new",
+        },
+        state_epoch: "1700.3",
+        state_version: "2026-05-06T00:00:01.000Z",
+      }, {
+        approvalId: "approval-new-pending",
+        timeoutMs: 30_000,
+        origin: {
+          channel: "slack",
+          conversation_id: "C123:1700.1",
+          user_id: "U123",
+          session_id: "identity:workspace:U123",
+          turn_id: "1700.3",
+        },
+      });
+      const deadline = Date.now() + 1000;
+      while (
+        Date.now() < deadline
+        && (
+          (await store.loadPending("approval-old-stale")) === null
+          || (await store.loadPending("approval-new-pending")) === null
+        )
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      await expect(manager.processIncomingMessage({
+        text: "",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        approvalResponse: {
+          approval_id: "approval-old-stale",
+          approved: true,
+        },
+      })).resolves.toContain("approval target changed after the prompt");
+      await expect(store.loadResolved("approval-old-stale")).resolves.toMatchObject({
+        state: "denied",
+      });
+      await expect(store.loadPending("approval-new-pending")).resolves.toMatchObject({
+        state: "pending",
+      });
+      await expect(oldRequest).resolves.toBe(false);
+      await approvalBroker.resolveConversationalApproval("approval-new-pending", false, {
+        channel: "slack",
+        conversation_id: "C123:1700.1",
+        user_id: "U123",
+        session_id: "identity:workspace:U123",
+        turn_id: "1700.3",
+      });
+      await expect(newRequest).resolves.toBe(false);
     } finally {
       cleanupTempDir(tmpDir);
     }

--- a/src/interface/chat/chat-runner-contracts.ts
+++ b/src/interface/chat/chat-runner-contracts.ts
@@ -12,6 +12,7 @@ import type { ChatAgentLoopRunner } from "../../orchestrator/execution/agent-loo
 import type { ReviewAgentLoopRunner } from "../../orchestrator/execution/agent-loop/review-agent-loop-runner.js";
 import type { RuntimeControlService } from "../../runtime/control/index.js";
 import type { ApprovalBroker } from "../../runtime/approval-broker.js";
+import type { ApprovalRequest } from "../../tools/types.js";
 import type {
   RuntimeControlActor,
   RuntimeControlReplyTarget,
@@ -63,6 +64,7 @@ export interface ChatRunnerDeps {
   trustManager?: { getBalance(domain: string): Promise<{ balance: number }>; setOverride?(domain: string, balance: number, reason: string): Promise<void> };
   pluginLoader?: { loadAll(): Promise<Array<{ name: string; type?: string; enabled?: boolean }>> };
   approvalFn?: (description: string) => Promise<boolean>;
+  approvalRequestFn?: (request: ApprovalRequest) => Promise<boolean>;
   goalId?: string;
   approvalConfig?: Record<string, ApprovalLevel>;
   toolExecutor?: ToolExecutor;
@@ -79,7 +81,7 @@ export interface ChatRunnerDeps {
   runtimeControlService?: Pick<RuntimeControlService, "request">;
   approvalBroker?: Pick<
     ApprovalBroker,
-    "requestConversationalApproval" | "resolveConversationalApproval" | "findPendingConversationalApproval"
+    "requestConversationalApproval" | "resolveConversationalApproval" | "findPendingConversationalApproval" | "loadPendingApproval"
   >;
   runtimeControlApprovalFn?: (description: string) => Promise<boolean>;
   runtimeReplyTarget?: RuntimeControlReplyTarget;

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -1262,6 +1262,9 @@ function agentLoopApprovalFn(
     if (request.toolName === "request_runtime_control" && runtimeControlContext?.approvalFn) {
       return runtimeControlContext.approvalFn(request.reason);
     }
+    if (host.deps.approvalRequestFn) {
+      return host.deps.approvalRequestFn(request);
+    }
     if (host.deps.approvalFn) {
       return host.deps.approvalFn(request.reason);
     }

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -49,7 +49,11 @@ import { ApprovalStore, createRuntimeStorePaths } from "../../runtime/store/inde
 import { classifyConversationalApprovalDecision } from "../../runtime/conversational-approval-decision.js";
 import { registerGlobalCrossPlatformChatSessionManager } from "./cross-platform-session-global.js";
 import type { RuntimeControlActor } from "../../runtime/store/runtime-operation-schemas.js";
-import type { ApprovalOrigin } from "../../runtime/store/runtime-schemas.js";
+import type { ApprovalOrigin, ApprovalRecord } from "../../runtime/store/runtime-schemas.js";
+import {
+  createPendingPermissionTask,
+  isPermissionApprovalStale,
+} from "../../runtime/permission-dialogue.js";
 import {
   buildCompanionRuntimeContract,
   evaluateCompanionOutputPolicy,
@@ -62,6 +66,7 @@ import type {
   ConversationOutputMode,
 } from "../../runtime/types/companion.js";
 import { normalizeUserInput, type UserInput } from "./user-input.js";
+import type { ApprovalRequest } from "../../tools/types.js";
 
 export interface CrossPlatformChatSessionOptions {
   /**
@@ -495,6 +500,13 @@ export class CrossPlatformChatSessionManager {
     if (!origin) {
       return "Approval response could not be recorded because the conversation origin is incomplete.";
     }
+    const pendingApproval = await broker.loadPendingApproval(response.approval_id);
+    if (pendingApproval) {
+      const staleReply = await this.rejectStalePermissionApprovalIfNeeded(pendingApproval, ingress, origin);
+      if (staleReply) {
+        return staleReply;
+      }
+    }
     const resolved = await broker.resolveConversationalApproval(
       response.approval_id,
       response.approved,
@@ -524,6 +536,10 @@ export class CrossPlatformChatSessionManager {
       return "Multiple active approvals match this conversation. Please use the specific approval response.";
     }
     const approval = lookup.approval;
+    const staleReply = await this.rejectStalePermissionApprovalIfNeeded(approval, ingress, origin);
+    if (staleReply) {
+      return staleReply;
+    }
 
     const decision = await classifyConversationalApprovalDecision(ingress.text, {
       approval,
@@ -551,6 +567,30 @@ export class CrossPlatformChatSessionManager {
       return null;
     }
     return decision.clarification ?? "Approval reply was ambiguous. The approval remains pending.";
+  }
+
+  private async rejectStalePermissionApprovalIfNeeded(
+    approval: ApprovalRecord,
+    ingress: CrossPlatformIngressMessage,
+    origin: ApprovalOrigin,
+  ): Promise<string | null> {
+    if (!isPermissionApprovalStale(approval, this.currentApprovalStateEpoch(ingress))) {
+      return null;
+    }
+    const broker = this.deps.approvalBroker;
+    const resolved = await broker?.resolveConversationalApproval(
+      approval.approval_id,
+      false,
+      approval.origin ?? origin,
+    );
+    return resolved
+      ? "The approval target changed after the prompt, so PulSeed did not execute it. Please ask again if you still want that action."
+      : "The approval target changed after the prompt, and the stale approval could not be resolved.";
+  }
+
+  private currentApprovalStateEpoch(ingress: CrossPlatformIngressMessage): string | null {
+    const session = this.sessions.get(buildSessionKeyFromParts(ingress));
+    return session?.info.last_message_id ?? null;
   }
 
   private describeLastRouteForApproval(ingress: CrossPlatformIngressMessage): string {
@@ -729,9 +769,11 @@ export class CrossPlatformChatSessionManager {
       metadata: {},
     };
     const approvalFn = this.createApprovalFn(info);
+    const approvalRequestFn = this.createApprovalRequestFn(info);
     const runner = new ChatRunner({
       ...this.deps,
       approvalFn: approvalFn ?? this.deps.approvalFn,
+      approvalRequestFn: approvalRequestFn ?? this.deps.approvalRequestFn,
       runtimeControlApprovalFn: approvalFn ?? this.deps.runtimeControlApprovalFn,
     });
     runner.startSession(cwd);
@@ -759,11 +801,15 @@ export class CrossPlatformChatSessionManager {
       const goalId = typeof info.metadata.goal_id === "string" && info.metadata.goal_id.trim()
         ? info.metadata.goal_id.trim()
         : "chat";
-      return broker.requestConversationalApproval(goalId, {
+      const stateEpoch = currentStateEpochFromSessionInfo(info);
+      return broker.requestConversationalApproval(goalId, createPendingPermissionTask({
         id: info.last_message_id ?? info.session_key,
         description,
         action: "chat_approval",
-      }, {
+        target: { session_id: info.session_key },
+        stateEpoch,
+        stateVersion: info.last_used_at,
+      }), {
         origin,
         deliverConversationalApproval: async ({ prompt }) => {
           const handler = this.activeApprovalEventHandlers.get(info.session_key);
@@ -779,6 +825,66 @@ export class CrossPlatformChatSessionManager {
               kind: "checkpoint",
               message: prompt,
               sourceId: `approval:${info.last_message_id ?? info.session_key}`,
+              runId: info.session_key,
+              turnId: info.last_message_id ?? info.session_key,
+              createdAt: new Date().toISOString(),
+            });
+            return { delivered: true };
+          } catch (err) {
+            return {
+              delivered: false,
+              reason: err instanceof Error ? err.message : "originating_conversation_unreachable",
+            };
+          }
+        },
+      });
+    };
+  }
+
+  private createApprovalRequestFn(info: CrossPlatformChatSessionInfo): ((request: ApprovalRequest) => Promise<boolean>) | null {
+    const broker = this.deps.approvalBroker;
+    if (!broker) {
+      return null;
+    }
+    return async (request: ApprovalRequest) => {
+      const origin = createApprovalOriginFromSessionInfo(info);
+      if (!origin) {
+        return false;
+      }
+      const goalId = typeof info.metadata.goal_id === "string" && info.metadata.goal_id.trim()
+        ? info.metadata.goal_id.trim()
+        : "chat";
+      const stateEpoch = currentStateEpochFromSessionInfo(info);
+      return broker.requestConversationalApproval(goalId, createPendingPermissionTask({
+        id: request.callId ?? info.last_message_id ?? info.session_key,
+        description: request.reason,
+        action: request.toolName,
+        target: {
+          session_id: info.session_key,
+          tool_id: request.toolName,
+          ...(request.callId ? { tool_call_id: request.callId } : {}),
+        },
+        stateEpoch,
+        stateVersion: info.last_used_at,
+        permissionLevel: request.permissionLevel,
+        isDestructive: request.isDestructive,
+        reversibility: request.reversibility,
+      }), {
+        origin,
+        deliverConversationalApproval: async ({ prompt }) => {
+          const handler = this.activeApprovalEventHandlers.get(info.session_key);
+          if (!handler) {
+            return {
+              delivered: false,
+              reason: "originating_conversation_unreachable",
+            };
+          }
+          try {
+            await handler({
+              type: "activity",
+              kind: "checkpoint",
+              message: prompt,
+              sourceId: `approval:${request.callId ?? info.last_message_id ?? info.session_key}`,
               runId: info.session_key,
               turnId: info.last_message_id ?? info.session_key,
               createdAt: new Date().toISOString(),
@@ -993,6 +1099,10 @@ function formatCompanionPolicyDecision(decision: ReturnType<typeof evaluateCompa
     return "Companion output was deferred by the current quieting policy.";
   }
   return "Companion output is allowed.";
+}
+
+function currentStateEpochFromSessionInfo(info: CrossPlatformChatSessionInfo): string {
+  return info.last_message_id ?? info.session_key;
 }
 
 export function createApprovalOriginFromSessionInfo(

--- a/src/runtime/__tests__/approval-broker.test.ts
+++ b/src/runtime/__tests__/approval-broker.test.ts
@@ -93,6 +93,39 @@ describe("ApprovalBroker", () => {
     );
   });
 
+  it("expires pending conversational approval records instead of resolving late replies", async () => {
+    tmpDir = makeTempDir();
+    const store = new ApprovalStore(tmpDir);
+    const broker = new ApprovalBroker({
+      store,
+      createId: () => "approval-expired",
+      defaultTimeoutMs: 5,
+      deliverConversationalApproval: async () => ({ delivered: true }),
+    });
+    const origin = {
+      channel: "slack",
+      conversation_id: "thread-1",
+      user_id: "user-1",
+      session_id: "session-1",
+      turn_id: "turn-1",
+    };
+
+    const request = broker.requestConversationalApproval("goal-1", {
+      id: "task-expired",
+      description: "Restart daemon",
+      action: "restart",
+    }, {
+      origin,
+    });
+
+    await expect(request).resolves.toBe(false);
+    await expect(store.loadPending("approval-expired")).resolves.toBeNull();
+    await expect(store.loadResolved("approval-expired")).resolves.toMatchObject({
+      state: "expired",
+    });
+    await expect(broker.resolveConversationalApproval("approval-expired", true, origin)).resolves.toBe(false);
+  });
+
   it("resolves requests when approval arrives while pending save is in flight", async () => {
     tmpDir = makeTempDir();
 

--- a/src/runtime/__tests__/conversational-approval-decision.test.ts
+++ b/src/runtime/__tests__/conversational-approval-decision.test.ts
@@ -53,6 +53,20 @@ describe("classifyConversationalApprovalDecision", () => {
     expect(decision).toMatchObject({ decision: "approve", confidence: 0.93 });
   });
 
+  it("classifies paraphrased denial replies through the shared contract", async () => {
+    const decision = await classifyConversationalApprovalDecision("やっぱり実行しないでください", {
+      approval,
+      replyOrigin: approval.origin!,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "reject",
+        confidence: 0.94,
+        rationale: "Explicit rejection for the active request.",
+      })),
+    });
+
+    expect(decision).toMatchObject({ decision: "reject", confidence: 0.94 });
+  });
+
   it("keeps clarification separate from approval or rejection", async () => {
     const decision = await classifyConversationalApprovalDecision("Before deciding, what target will change?", {
       approval,
@@ -86,5 +100,19 @@ describe("classifyConversationalApprovalDecision", () => {
       confidence: 0,
       clarification: "Please explicitly approve or reject the active request.",
     });
+  });
+
+  it("keeps unrelated new intents separate from approval or rejection", async () => {
+    const decision = await classifyConversationalApprovalDecision("Actually summarize yesterday's logs first.", {
+      approval,
+      replyOrigin: approval.origin!,
+      llmClient: createSingleMockLLMClient(JSON.stringify({
+        decision: "new_intent",
+        confidence: 0.91,
+        rationale: "The reply asks for a separate task.",
+      })),
+    });
+
+    expect(decision).toMatchObject({ decision: "new_intent", confidence: 0.91 });
   });
 });

--- a/src/runtime/approval-broker.ts
+++ b/src/runtime/approval-broker.ts
@@ -1,11 +1,27 @@
 import type { Logger } from "./logger.js";
 import { ApprovalStore } from "./store/approval-store.js";
 import type { ApprovalOrigin, ApprovalRecord } from "./store/runtime-schemas.js";
+import {
+  getPendingPermissionTask,
+  withPermissionExpiry,
+  type PendingPermissionTarget,
+  type PermissionRiskClass,
+} from "./permission-dialogue.js";
 
 export interface ApprovalTaskRequest {
   id: string;
   description: string;
   action: string;
+  kind?: "permission";
+  operation_summary?: string;
+  risk_class?: PermissionRiskClass;
+  target?: PendingPermissionTarget;
+  state_epoch?: string;
+  state_version?: string;
+  expires_at?: number;
+  permission_level?: string;
+  is_destructive?: boolean;
+  reversibility?: string;
 }
 
 export interface ApprovalRequiredEvent {
@@ -130,6 +146,8 @@ export class ApprovalBroker {
     await this.start();
 
     const createdAt = this.now();
+    const expiresAt = createdAt + timeoutMs;
+    const taskWithExpiry = withPermissionExpiry(task, expiresAt);
     const record: ApprovalRecord = {
       approval_id: approvalId,
       goal_id: goalId,
@@ -137,8 +155,8 @@ export class ApprovalBroker {
       correlation_id: approvalId,
       state: "pending",
       created_at: createdAt,
-      expires_at: createdAt + timeoutMs,
-      payload: { task },
+      expires_at: expiresAt,
+      payload: { task: taskWithExpiry },
     };
 
     return this.trackApprovalRequest(record);
@@ -154,6 +172,8 @@ export class ApprovalBroker {
     const approvalId = options.approvalId ?? this.createId();
     const timeoutMs = options.timeoutMs ?? this.defaultTimeoutMs;
     const createdAt = this.now();
+    const expiresAt = createdAt + timeoutMs;
+    const taskWithExpiry = withPermissionExpiry(task, expiresAt);
     const record: ApprovalRecord = {
       approval_id: approvalId,
       goal_id: goalId,
@@ -161,9 +181,9 @@ export class ApprovalBroker {
       correlation_id: approvalId,
       state: "pending",
       created_at: createdAt,
-      expires_at: createdAt + timeoutMs,
+      expires_at: expiresAt,
       origin: options.origin,
-      payload: { task },
+      payload: { task: taskWithExpiry },
     };
 
     return this.trackApprovalRequest(record, options.deliverConversationalApproval);
@@ -201,6 +221,11 @@ export class ApprovalBroker {
       responseChannel: origin.channel,
     });
     return resolved !== null;
+  }
+
+  async loadPendingApproval(approvalId: string): Promise<ApprovalRecord | null> {
+    await this.start();
+    return this.pending.get(approvalId)?.record ?? await this.store.loadPending(approvalId);
   }
 
   async findPendingConversationalApproval(origin: ApprovalOrigin): Promise<PendingConversationalApprovalLookup> {
@@ -403,14 +428,25 @@ export class ApprovalBroker {
 function renderConversationalApprovalPrompt(record: ApprovalRecord): string {
   const payload = record.payload as { task?: ApprovalTaskRequest };
   const task = payload.task ?? { id: record.approval_id, description: "Approval required", action: "unknown" };
-  return [
+  const permission = getPendingPermissionTask(record);
+  const lines = [
     "Approval required.",
     `Action: ${task.action}`,
     `Target: ${task.id}`,
     `Details: ${task.description}`,
     `Approval ID: ${record.approval_id}`,
-    "Reply in this conversation to approve, reject, or ask for clarification.",
-  ].join("\n");
+  ];
+  if (permission) {
+    lines.push(
+      `Operation: ${permission.operation_summary}`,
+      `Risk: ${permission.risk_class}`,
+    );
+    if (permission.target.tool_id) lines.push(`Tool: ${permission.target.tool_id}`);
+    if (permission.target.tool_call_id) lines.push(`Tool call: ${permission.target.tool_call_id}`);
+    if (permission.expires_at) lines.push(`Expires: ${new Date(permission.expires_at).toISOString()}`);
+  }
+  lines.push("Reply in this conversation to approve, reject, or ask for clarification.");
+  return lines.join("\n");
 }
 
 function approvalOriginMatches(expected: ApprovalOrigin | undefined, actual: ApprovalOrigin): boolean {

--- a/src/runtime/permission-dialogue.ts
+++ b/src/runtime/permission-dialogue.ts
@@ -1,0 +1,111 @@
+import { z } from "zod";
+import type { ApprovalRecord } from "./store/runtime-schemas.js";
+
+export const PermissionRiskClassSchema = z.enum(["low", "medium", "high", "critical", "unknown"]);
+export type PermissionRiskClass = z.infer<typeof PermissionRiskClassSchema>;
+
+export const PendingPermissionTargetSchema = z.object({
+  session_id: z.string().min(1).optional(),
+  run_id: z.string().min(1).optional(),
+  tool_id: z.string().min(1).optional(),
+  tool_call_id: z.string().min(1).optional(),
+});
+export type PendingPermissionTarget = z.infer<typeof PendingPermissionTargetSchema>;
+
+export const PendingPermissionTaskSchema = z.object({
+  kind: z.literal("permission"),
+  id: z.string().min(1),
+  description: z.string().min(1),
+  action: z.string().min(1),
+  operation_summary: z.string().min(1),
+  risk_class: PermissionRiskClassSchema,
+  target: PendingPermissionTargetSchema,
+  state_epoch: z.string().min(1),
+  state_version: z.string().min(1).optional(),
+  expires_at: z.number().int().nonnegative().optional(),
+  permission_level: z.string().min(1).optional(),
+  is_destructive: z.boolean().optional(),
+  reversibility: z.string().min(1).optional(),
+});
+export type PendingPermissionTask = z.infer<typeof PendingPermissionTaskSchema>;
+
+export function createPendingPermissionTask(input: {
+  id: string;
+  description: string;
+  action: string;
+  target: PendingPermissionTarget;
+  stateEpoch: string;
+  stateVersion?: string;
+  expiresAt?: number;
+  permissionLevel?: string;
+  isDestructive?: boolean;
+  reversibility?: string;
+}): PendingPermissionTask {
+  return PendingPermissionTaskSchema.parse({
+    kind: "permission",
+    id: input.id,
+    description: input.description,
+    action: input.action,
+    operation_summary: input.description,
+    risk_class: classifyPermissionRisk({
+      permissionLevel: input.permissionLevel,
+      isDestructive: input.isDestructive,
+    }),
+    target: input.target,
+    state_epoch: input.stateEpoch,
+    ...(input.stateVersion ? { state_version: input.stateVersion } : {}),
+    ...(input.expiresAt ? { expires_at: input.expiresAt } : {}),
+    ...(input.permissionLevel ? { permission_level: input.permissionLevel } : {}),
+    ...(typeof input.isDestructive === "boolean" ? { is_destructive: input.isDestructive } : {}),
+    ...(input.reversibility ? { reversibility: input.reversibility } : {}),
+  });
+}
+
+export function withPermissionExpiry<T extends { kind?: string; expires_at?: number }>(
+  task: T,
+  expiresAt: number,
+): T {
+  return task.kind === "permission"
+    ? { ...task, expires_at: expiresAt }
+    : task;
+}
+
+export function getPendingPermissionTask(record: ApprovalRecord): PendingPermissionTask | null {
+  const payload = record.payload;
+  if (!isRecord(payload)) return null;
+  const task = payload["task"];
+  const parsed = PendingPermissionTaskSchema.safeParse(task);
+  return parsed.success ? parsed.data : null;
+}
+
+export function isPermissionApprovalStale(
+  record: ApprovalRecord,
+  currentStateEpoch: string | null,
+): boolean {
+  const task = getPendingPermissionTask(record);
+  if (!task || !currentStateEpoch) return false;
+  return task.state_epoch !== currentStateEpoch;
+}
+
+export function classifyPermissionRisk(input: {
+  permissionLevel?: string;
+  isDestructive?: boolean;
+}): PermissionRiskClass {
+  if (input.isDestructive) return "critical";
+  switch (input.permissionLevel) {
+    case "write_remote":
+    case "execute":
+      return "high";
+    case "write_local":
+      return "medium";
+    case "read_metrics":
+    case "read_only":
+      return "low";
+    default:
+      return "unknown";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -255,6 +255,7 @@ export interface ApprovalRequest {
   permissionLevel: ToolPermissionLevel;
   isDestructive: boolean;
   reversibility: "reversible" | "irreversible" | "unknown";
+  callId?: string;
 }
 
 export const PermissionCheckResultSchema = z.discriminatedUnion("status", [


### PR DESCRIPTION
## Summary
- add typed pending permission records with target, risk, state epoch/version, and expiry metadata
- route chat/tool approval requests through conversational approval records while keeping natural-language decisions in the structured approval classifier
- reject stale natural-language and explicit approval responses when the pending permission target state changed

Closes #1113

## Verification
- npx vitest run --config vitest.unit.config.ts src/interface/chat/__tests__/cross-platform-session.test.ts
- npx vitest run --config vitest.integration.config.ts src/runtime/__tests__/approval-broker.test.ts src/runtime/__tests__/conversational-approval-decision.test.ts
- npm run typecheck
- npm run lint:boundaries (0 errors, existing warnings)
- npm run test:changed
- npm run test:unit

## Review
- Fresh review found stale explicit approval-response gaps; fixed both the single-pending and ambiguous-pending cases. Final re-review reported no high-confidence material findings.