### PR TITLE
Persist replayable chat rollout journal

### DIFF
--- a/src/interface/chat/__tests__/chat-history.test.ts
+++ b/src/interface/chat/__tests__/chat-history.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { ChatHistory } from "../chat-history.js";
+import {
+  ChatHistory,
+  reconstructModelVisibleMessagesFromRolloutJournal,
+} from "../chat-history.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 
 function makeMockStateManager(): StateManager {
@@ -146,5 +149,103 @@ describe("ChatHistory", () => {
         })],
       }),
     );
+  });
+
+  it("persists replayable rollout records and reconstructs model-visible history from them", async () => {
+    const history = new ChatHistory(stateManager, SESSION_ID, CWD);
+    const eventContext = { runId: "run-1", turnId: "turn-1" };
+    const createdAt = "2026-05-06T00:00:00.000Z";
+
+    await history.appendUserMessage("Please inspect the rollout journal.", {
+      eventContext,
+      userInput: {
+        schema_version: "user-input-v1",
+        rawText: "Please inspect the rollout journal.",
+        items: [
+          { kind: "text", text: "Please inspect the rollout journal." },
+          { kind: "local_image", path: "/Users/example/private-screenshot.png", name: "private-screenshot.png" },
+        ],
+      },
+    });
+    await history.recordTurnContext({
+      schema_version: "chat-turn-context-v1",
+      modelVisible: {
+        turn: eventContext,
+        conversation: { priorTurns: [] },
+      },
+    });
+    await history.recordChatEvent({
+      type: "tool_start",
+      toolCallId: "call-1",
+      toolName: "read_file",
+      args: { apiKey: "sk-abcdefghijklmnopqrstuvwxyz123456" },
+      runId: eventContext.runId,
+      turnId: eventContext.turnId,
+      createdAt,
+    });
+    await history.recordChatEvent({
+      type: "tool_end",
+      toolCallId: "call-1",
+      toolName: "read_file",
+      success: true,
+      summary: "read complete",
+      durationMs: 7,
+      runId: eventContext.runId,
+      turnId: eventContext.turnId,
+      createdAt,
+    });
+    await history.recordChatEvent({
+      type: "tool_update",
+      toolCallId: "call-approval",
+      toolName: "write_file",
+      status: "awaiting_approval",
+      message: "write requires approval",
+      runId: eventContext.runId,
+      turnId: eventContext.turnId,
+      createdAt,
+    });
+    await history.recordChatEvent({
+      type: "activity",
+      kind: "checkpoint",
+      message: "Context gathered",
+      runId: eventContext.runId,
+      turnId: eventContext.turnId,
+      createdAt,
+    });
+    await history.appendAssistantMessage("The rollout journal is replayable.", { eventContext });
+    await history.recordChatEvent({
+      type: "lifecycle_end",
+      status: "completed",
+      elapsedMs: 42,
+      persisted: true,
+      runId: eventContext.runId,
+      turnId: eventContext.turnId,
+      createdAt,
+    });
+
+    const session = history.getSessionData();
+    const rolloutJournal = session.rolloutJournal ?? [];
+    expect(rolloutJournal.map((record) => record.kind)).toEqual(expect.arrayContaining([
+      "user_input",
+      "turn_context",
+      "tool_call",
+      "tool_result",
+      "permission_decision",
+      "display_event",
+      "model_output",
+      "completion_state",
+    ]));
+    expect(JSON.stringify(rolloutJournal)).not.toContain("sk-abcdefghijklmnopqrstuvwxyz123456");
+    expect(JSON.stringify(rolloutJournal)).not.toContain("/Users/example/private-screenshot.png");
+
+    const reconstructed = reconstructModelVisibleMessagesFromRolloutJournal(rolloutJournal);
+    expect(reconstructed?.map((message) => [message.role, message.content])).toEqual([
+      ["user", "Please inspect the rollout journal."],
+      ["assistant", "The rollout journal is replayable."],
+    ]);
+    expect(history.getModelVisibleMessages().map((message) => message.content)).toEqual([
+      "Please inspect the rollout journal.",
+      "The rollout journal is replayable.",
+    ]);
   });
 });

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -1761,12 +1761,16 @@ describe("ChatRunner", () => {
       expect(input.resumeStatePath).toMatch(/^chat\/agentloop\//);
 
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
-      expect(writeRawMock).toHaveBeenCalledTimes(2);
-      expect(writeRawMock.mock.calls[0][1]).toMatchObject({
-        turnContexts: [expect.objectContaining({
-          schema_version: "chat-turn-context-v1",
-        })],
-      });
+      expect(writeRawMock.mock.calls.some((call) => {
+        const data = call[1] as { turnContexts?: Array<{ schema_version?: string }> };
+        return data.turnContexts?.some((context) => context.schema_version === "chat-turn-context-v1") === true;
+      })).toBe(true);
+      expect(writeRawMock.mock.calls.some((call) => {
+        const data = call[1] as { messages?: Array<{ role: string; content: string }> };
+        return data.messages?.some((message) =>
+          message.role === "assistant" && message.content === "Resumed successfully"
+        ) === true;
+      })).toBe(true);
       expect((stateManager.readRaw as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(1);
     });
 
@@ -2586,7 +2590,8 @@ describe("ChatRunner", () => {
 
       const finalTask = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as { prompt: string };
       expect(finalTask.prompt).toContain("Compacted previous conversation summary");
-      expect(finalTask.prompt).toContain("Turn 1");
+      expect(finalTask.prompt).toContain("user: Turn 1");
+      expect(finalTask.prompt).not.toContain("User: Turn 1");
       expect(finalTask.prompt).toContain("Current message:");
       expect(finalTask.prompt).toContain("Continue");
     });
@@ -2607,6 +2612,23 @@ describe("ChatRunner", () => {
       const finalTask = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as { prompt: string };
       expect(finalTask.prompt).not.toContain("Compacted previous conversation summary");
       expect(finalTask.prompt).not.toContain("Turn 1");
+      expect(finalTask.prompt).toContain("Fresh start");
+    });
+
+    it("/undo removes the last turn from journal-backed prompts", async () => {
+      const stateManager = makeMockStateManager();
+      const adapter = makeMockAdapter();
+      const runner = new ChatRunner(makeDeps({ stateManager, adapter }));
+      runner.startSession("/repo");
+
+      await runner.execute("Turn 1", "/repo");
+      await runner.execute("Turn 2", "/repo");
+      await runner.execute("/undo", "/repo");
+      await runner.execute("Fresh start", "/repo");
+
+      const finalTask = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] as { prompt: string };
+      expect(finalTask.prompt).toContain("User: Turn 1");
+      expect(finalTask.prompt).not.toContain("Turn 2");
       expect(finalTask.prompt).toContain("Fresh start");
     });
   });
@@ -2679,15 +2701,20 @@ describe("ChatRunner", () => {
       await runner.execute("Stream this", "/repo");
 
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
-      expect(writeRawMock).toHaveBeenCalledTimes(3);
-      const firstWrite = writes[0]!;
-      const secondWrite = writes[1]!;
-      const thirdWrite = writes[2]!;
-      expect(firstWrite.messages).toHaveLength(1);
-      expect(secondWrite.messages).toHaveLength(1);
-      expect(secondWrite.turnContexts).toHaveLength(1);
-      expect(thirdWrite.messages).toHaveLength(2);
-      expect(thirdWrite.messages[1]?.content).toBe("Hello world");
+      expect(writeRawMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+      const firstWrite = writes.find((write) => write.messages.length === 1 && !write.turnContexts);
+      const secondWrite = writes.find((write) => write.messages.length === 1 && write.turnContexts?.length === 1);
+      const thirdWrite = writes.find((write) =>
+        write.messages.length === 2 && write.messages[1]?.content === "Hello world"
+      );
+      expect(firstWrite).toBeDefined();
+      expect(secondWrite).toBeDefined();
+      expect(thirdWrite).toBeDefined();
+      expect(firstWrite!.messages).toHaveLength(1);
+      expect(secondWrite!.messages).toHaveLength(1);
+      expect(secondWrite!.turnContexts).toHaveLength(1);
+      expect(thirdWrite!.messages).toHaveLength(2);
+      expect(thirdWrite!.messages[1]?.content).toBe("Hello world");
       expect(events).toContain("assistant_delta");
       expect(events).toContain("assistant_final");
     });
@@ -2721,8 +2748,8 @@ describe("ChatRunner", () => {
       expect(result.output).toContain("Recovery");
       expect(result.output).toContain("Type: Unclassified failure");
       const writeRawMock = stateManager.writeRaw as ReturnType<typeof vi.fn>;
-      expect(writeRawMock).toHaveBeenCalledTimes(2);
-      const lastWrite = writeRawMock.mock.calls[1][1] as {
+      expect(writeRawMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+      const lastWrite = writeRawMock.mock.calls.at(-1)?.[1] as {
         messages: Array<{ role: string; content: string }>;
         turnContexts?: unknown[];
       };

--- a/src/interface/chat/__tests__/chat-session-store.test.ts
+++ b/src/interface/chat/__tests__/chat-session-store.test.ts
@@ -318,6 +318,48 @@ describe("ChatSessionCatalog", () => {
     expect(loaded?.title).toBeNull();
   });
 
+  it("preserves rollout journal records through load and rename", async () => {
+    const rolloutRecord = {
+      schema_version: "chat-rollout-journal-record-v1",
+      id: "journal-session:0",
+      sessionId: "journal-session",
+      runId: "run-1",
+      turnId: "turn-1",
+      sequence: 0,
+      createdAt: "2026-05-06T00:00:00.000Z",
+      kind: "user_input",
+      source: "chat_history",
+      visibility: "model_visible",
+      payload: {
+        role: "user",
+        content: "persist me from structured journal",
+        turnIndex: 0,
+      },
+    };
+    await stateManager.writeRaw(
+      "chat/sessions/journal-session.json",
+      {
+        ...makeSession({
+          id: "journal-session",
+          cwd: "/repo",
+          createdAt: "2026-05-06T00:00:00.000Z",
+          messages: [
+            { role: "user", content: "legacy transcript", timestamp: "2026-05-06T00:00:00.000Z", turnIndex: 0 },
+          ],
+        }),
+        rolloutJournal: [rolloutRecord],
+      }
+    );
+
+    const loaded = await catalog.loadSession("journal-session");
+    expect(loaded?.rolloutJournal).toEqual([rolloutRecord]);
+
+    const renamed = await catalog.renameSession("journal-session", "Renamed journal session");
+    expect(renamed.rolloutJournal).toEqual([rolloutRecord]);
+    const reloaded = await catalog.loadSession("journal-session");
+    expect(reloaded?.rolloutJournal).toEqual([rolloutRecord]);
+  });
+
   it("uses agentloop updatedAt when deciding cleanup freshness", async () => {
     await stateManager.writeRaw(
       "chat/sessions/old-chat-fresh-agentloop.json",

--- a/src/interface/chat/__tests__/cross-platform-session.test.ts
+++ b/src/interface/chat/__tests__/cross-platform-session.test.ts
@@ -553,6 +553,108 @@ describe("CrossPlatformChatSessionManager", () => {
     await active;
   });
 
+  it("reconstructs resumed gateway history from the rollout journal instead of stale transcript messages", async () => {
+    const tmpDir = makeTempDir();
+    try {
+      const stateManager = new RealStateManager(tmpDir, undefined, { walEnabled: false });
+      await stateManager.init();
+      const firstAgentLoopRunner = {
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "First structured answer",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 12,
+          stopped_reason: "completed",
+        }),
+      };
+      const firstManager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager,
+        chatAgentLoopRunner: firstAgentLoopRunner as never,
+      }));
+
+      await expect(firstManager.processIncomingMessage({
+        text: "First structured question",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123",
+        sender_id: "U123",
+        message_id: "1700.1",
+        cwd: "/repo",
+      })).resolves.toBe("First structured answer");
+      const sessionInfo = firstManager.getSessionInfo({ identity_key: "workspace:U123" });
+      expect(sessionInfo?.chat_session_id).toBeTruthy();
+      const sessionPath = `chat/sessions/${sessionInfo!.chat_session_id}.json`;
+      const storedSession = await stateManager.readRaw(sessionPath) as Record<string, unknown>;
+      expect(Array.isArray(storedSession["rolloutJournal"])).toBe(true);
+      await stateManager.writeRaw(sessionPath, {
+        ...storedSession,
+        messages: [
+          {
+            role: "user",
+            content: "STALE transcript user text",
+            timestamp: "2026-05-06T00:00:00.000Z",
+            turnIndex: 0,
+          },
+          {
+            role: "assistant",
+            content: "STALE transcript assistant text",
+            timestamp: "2026-05-06T00:00:01.000Z",
+            turnIndex: 1,
+          },
+        ],
+      });
+
+      const secondAgentLoopRunner = {
+        execute: vi.fn().mockResolvedValue({
+          success: true,
+          output: "Second structured answer",
+          error: null,
+          exit_code: null,
+          elapsed_ms: 10,
+          stopped_reason: "completed",
+        }),
+      };
+      const secondManager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager,
+        chatAgentLoopRunner: secondAgentLoopRunner as never,
+      }));
+
+      await expect(secondManager.processIncomingMessage({
+        text: "Second structured question",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+      })).resolves.toBe("Second structured answer");
+
+      expect(secondAgentLoopRunner.execute).toHaveBeenCalledOnce();
+      const agentLoopInput = vi.mocked(secondAgentLoopRunner.execute).mock.calls[0][0] as {
+        history: Array<{ role: string; content: string }>;
+      };
+      expect(agentLoopInput.history).toEqual([
+        { role: "user", content: "First structured question" },
+        { role: "assistant", content: "First structured answer" },
+      ]);
+      expect(JSON.stringify(agentLoopInput.history)).not.toContain("STALE transcript");
+
+      const reconstructedSession = await stateManager.readRaw(sessionPath) as Record<string, unknown>;
+      const kinds = (reconstructedSession["rolloutJournal"] as Array<Record<string, unknown>>)
+        .map((record) => record["kind"]);
+      expect(kinds).toEqual(expect.arrayContaining([
+        "user_input",
+        "turn_context",
+        "model_output",
+        "display_event",
+        "completion_state",
+      ]));
+    } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
   it("uses the current steer handler for approvals while the active turn keeps running", async () => {
     const tmpDir = makeTempDir();
     try {
@@ -1613,6 +1715,142 @@ describe("CrossPlatformChatSessionManager", () => {
       });
       await expect(resultPromise).resolves.toContain("not approved");
     } finally {
+      cleanupTempDir(tmpDir);
+    }
+  });
+
+  it("reconstructs pending permission epoch after manager restart before rejecting stale typed approvals", async () => {
+    const tmpDir = makeTempDir();
+    let approvalBroker1: ApprovalBroker | undefined;
+    let approvalBroker2: ApprovalBroker | undefined;
+    let approvalBroker3: ApprovalBroker | undefined;
+    try {
+      const stateManager = new RealStateManager(tmpDir, undefined, { walEnabled: false });
+      await stateManager.init();
+      const store = new ApprovalStore(tmpDir);
+      approvalBroker1 = new ApprovalBroker({
+        store,
+        createId: () => "approval-reconstructed-epoch",
+      });
+      const runtimeControlService = {
+        request: vi.fn(async (request: {
+          approvalFn?: (description: string) => Promise<boolean>;
+        }) => {
+          const approved = await request.approvalFn?.("Restart the resident daemon.");
+          return {
+            success: approved === true,
+            message: approved === true ? "restart queued" : "not approved",
+            operationId: "op-reconstructed-epoch",
+            state: approved === true ? "acknowledged" as const : "blocked" as const,
+          };
+        }),
+      };
+      const firstManager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager,
+        llmClient: createMockLLMClient([
+          JSON.stringify({
+            intent: "restart_daemon",
+            reason: "PulSeed を再起動して",
+          }),
+        ]),
+        runtimeControlService,
+        approvalBroker: approvalBroker1,
+      }));
+
+      void firstManager.processIncomingMessage({
+        text: "PulSeed を再起動して",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.2",
+        cwd: "/repo",
+        onEvent: () => undefined,
+        runtimeControl: {
+          allowed: true,
+          approvalMode: "interactive",
+        },
+      });
+      const deadline = Date.now() + 1000;
+      while (Date.now() < deadline && (await store.loadPending("approval-reconstructed-epoch")) === null) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      await expect(store.loadPending("approval-reconstructed-epoch")).resolves.toMatchObject({
+        state: "pending",
+        payload: {
+          task: {
+            state_epoch: "1700.2",
+          },
+        },
+      });
+      await approvalBroker1.stop();
+
+      approvalBroker2 = new ApprovalBroker({
+        store,
+        createId: () => "unused-approval-id",
+      });
+      const secondManager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager,
+        llmClient: createMockLLMClient([
+          JSON.stringify({
+            decision: "side_question",
+            confidence: 0.93,
+            clarification: "Route the side question through normal chat.",
+          }),
+          JSON.stringify({
+            kind: "assist",
+            confidence: 0.9,
+            rationale: "side question",
+          }),
+          "The daemon restart target is the resident daemon.",
+        ]),
+        approvalBroker: approvalBroker2,
+      }));
+
+      await expect(secondManager.processIncomingMessage({
+        text: "Before deciding, which daemon will restart?",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.3",
+        cwd: "/repo",
+      })).resolves.toBe("The daemon restart target is the resident daemon.");
+      expect(secondManager.getSessionInfo({ identity_key: "workspace:U123" })?.last_message_id).toBe("1700.3");
+      await expect(store.loadPending("approval-reconstructed-epoch")).resolves.toMatchObject({
+        state: "pending",
+      });
+      await approvalBroker2.stop();
+
+      approvalBroker3 = new ApprovalBroker({
+        store,
+        createId: () => "unused-approval-id",
+      });
+      const thirdManager = new CrossPlatformChatSessionManager(makeDeps({
+        stateManager,
+        approvalBroker: approvalBroker3,
+      }));
+
+      await expect(thirdManager.processIncomingMessage({
+        text: "",
+        platform: "slack",
+        identity_key: "workspace:U123",
+        conversation_id: "C123:1700.1",
+        sender_id: "U123",
+        message_id: "1700.4",
+        cwd: "/repo",
+        approvalResponse: {
+          approval_id: "approval-reconstructed-epoch",
+          approved: true,
+        },
+      })).resolves.toContain("approval target changed after the prompt");
+      await expect(store.loadResolved("approval-reconstructed-epoch")).resolves.toMatchObject({
+        state: "denied",
+      });
+    } finally {
+      await approvalBroker1?.stop();
+      await approvalBroker2?.stop();
+      await approvalBroker3?.stop();
       cleanupTempDir(tmpDir);
     }
   });

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -6,9 +6,11 @@
 import { z } from "zod";
 import type { StateManager } from "../../base/state/state-manager.js";
 import { RuntimeReplyTargetSchema, type RuntimeReplyTarget } from "../../runtime/session-registry/types.js";
-import { redactSetupSecrets, SetupSecretIntakeItemSchema } from "./setup-secret-intake.js";
+import { redactSetupSecrets, redactSetupSecretsDeep, SetupSecretIntakeItemSchema } from "./setup-secret-intake.js";
 import { SetupDialoguePublicStateSchema, type SetupDialoguePublicState } from "./setup-dialogue.js";
 import { RunSpecSchema } from "../../runtime/run-spec/index.js";
+import type { ChatEvent, ChatEventContext } from "./chat-events.js";
+import type { UserInput } from "./user-input.js";
 
 // ─── Schemas ───
 
@@ -52,6 +54,33 @@ export const ChatTurnContextSnapshotSchema = z.object({
   modelVisible: z.unknown(),
 }).passthrough();
 export type ChatTurnContextSnapshot = z.infer<typeof ChatTurnContextSnapshotSchema>;
+
+export const ChatRolloutJournalRecordKindSchema = z.enum([
+  "user_input",
+  "turn_context",
+  "model_output",
+  "tool_call",
+  "tool_result",
+  "permission_decision",
+  "display_event",
+  "completion_state",
+]);
+export type ChatRolloutJournalRecordKind = z.infer<typeof ChatRolloutJournalRecordKindSchema>;
+
+export const ChatRolloutJournalRecordSchema = z.object({
+  schema_version: z.literal("chat-rollout-journal-record-v1"),
+  id: z.string(),
+  sessionId: z.string(),
+  runId: z.string().nullable(),
+  turnId: z.string().nullable(),
+  sequence: z.number().int().nonnegative(),
+  createdAt: z.string(),
+  kind: ChatRolloutJournalRecordKindSchema,
+  source: z.enum(["chat_history", "chat_event", "agent_timeline", "approval_store"]).default("chat_history"),
+  visibility: z.enum(["model_visible", "display", "debug", "host_only"]),
+  payload: z.unknown(),
+}).passthrough();
+export type ChatRolloutJournalRecord = z.infer<typeof ChatRolloutJournalRecordSchema>;
 
 export const RunSpecConfirmationStateSchema = z.object({
   state: z.enum(["pending", "confirmed", "cancelled"]),
@@ -99,6 +128,7 @@ export const ChatSessionSchema = z.object({
   agentLoopUpdatedAt: z.string().nullable().optional(),
   agentLoop: ChatSessionAgentLoopMetadataSchema.optional(),
   turnContexts: z.array(ChatTurnContextSnapshotSchema).optional(),
+  rolloutJournal: z.array(ChatRolloutJournalRecordSchema).optional(),
   usage: ChatSessionUsageSchema.optional(),
 }).passthrough();
 export type ChatSession = z.infer<typeof ChatSessionSchema>;
@@ -121,6 +151,7 @@ export class ChatHistory {
         updatedAt: existingSession.updatedAt ?? existingSession.createdAt,
         messages: [...existingSession.messages],
         ...(existingSession.turnContexts ? { turnContexts: [...existingSession.turnContexts] } : {}),
+        ...(existingSession.rolloutJournal ? { rolloutJournal: [...existingSession.rolloutJournal] } : {}),
         ...(existingSession.usage ? { usage: cloneUsage(existingSession.usage) } : {}),
       };
     } else {
@@ -140,26 +171,59 @@ export class ChatHistory {
   }
 
   /** Append a user message and persist to disk BEFORE adapter execution. */
-  async appendUserMessage(content: string, options: { setupSecretIntake?: Array<Omit<z.infer<typeof SetupSecretIntakeItemSchema>, "value">> } = {}): Promise<void> {
+  async appendUserMessage(content: string, options: {
+    setupSecretIntake?: Array<Omit<z.infer<typeof SetupSecretIntakeItemSchema>, "value">>;
+    eventContext?: ChatEventContext;
+    userInput?: UserInput;
+  } = {}): Promise<void> {
+    const turnIndex = this.session.messages.length;
     this.session.messages.push({
       role: "user",
       content,
       timestamp: new Date().toISOString(),
-      turnIndex: this.session.messages.length,
+      turnIndex,
       ...(options.setupSecretIntake && options.setupSecretIntake.length > 0
         ? { setupSecretIntake: options.setupSecretIntake }
         : {}),
+    });
+    this.pushRolloutRecord({
+      kind: "user_input",
+      source: "chat_history",
+      visibility: "model_visible",
+      eventContext: options.eventContext,
+      payload: {
+        role: "user",
+        content,
+        turnIndex,
+        ...(options.userInput ? { userInput: toReplayableUserInput(options.userInput) } : {}),
+        ...(options.setupSecretIntake && options.setupSecretIntake.length > 0
+          ? { setupSecretIntake: options.setupSecretIntake }
+          : {}),
+      },
     });
     await this.persist();
   }
 
   /** Append an assistant message and persist it as the committed assistant turn. */
-  async appendAssistantMessage(content: string): Promise<void> {
+  async appendAssistantMessage(content: string, options: { eventContext?: ChatEventContext } = {}): Promise<void> {
+    const safeContent = redactSetupSecrets(content);
+    const turnIndex = this.session.messages.length;
     this.session.messages.push({
       role: "assistant",
-      content: redactSetupSecrets(content),
+      content: safeContent,
       timestamp: new Date().toISOString(),
-      turnIndex: this.session.messages.length,
+      turnIndex,
+    });
+    this.pushRolloutRecord({
+      kind: "model_output",
+      source: "chat_history",
+      visibility: "model_visible",
+      eventContext: options.eventContext,
+      payload: {
+        role: "assistant",
+        content: safeContent,
+        turnIndex,
+      },
     });
     await this.persist();
   }
@@ -168,6 +232,7 @@ export class ChatHistory {
   async clear(): Promise<void> {
     this.session.messages = [];
     delete this.session.compactionSummary;
+    this.replaceModelVisibleJournalFromMessages("clear");
     await this.persist();
   }
 
@@ -181,6 +246,7 @@ export class ChatHistory {
       turnIndex: index,
     }));
     this.session.compactionSummary = summary;
+    this.replaceModelVisibleJournalFromMessages("compact");
     await this.persist();
     return { before, after: this.session.messages.length };
   }
@@ -200,6 +266,7 @@ export class ChatHistory {
       ...message,
       turnIndex: index,
     }));
+    this.replaceModelVisibleJournalFromMessages("remove_last_turn");
     await this.persist();
     return removed;
   }
@@ -208,11 +275,16 @@ export class ChatHistory {
     return [...this.session.messages];
   }
 
+  getModelVisibleMessages(): ChatMessage[] {
+    return reconstructModelVisibleMessagesFromRolloutJournal(this.session.rolloutJournal) ?? this.getMessages();
+  }
+
   getSessionData(): ChatSession {
     return {
       ...this.session,
       messages: [...this.session.messages],
       ...(this.session.turnContexts ? { turnContexts: [...this.session.turnContexts] } : {}),
+      ...(this.session.rolloutJournal ? { rolloutJournal: [...this.session.rolloutJournal] } : {}),
       ...(this.session.usage ? { usage: cloneUsage(this.session.usage) } : {}),
     };
   }
@@ -274,7 +346,29 @@ export class ChatHistory {
       ...(this.session.turnContexts ?? []),
       snapshot,
     ].slice(-20);
+    this.pushRolloutRecord({
+      kind: "turn_context",
+      source: "chat_history",
+      visibility: "model_visible",
+      eventContext: extractTurnContextEventContext(snapshot),
+      payload: snapshot,
+    });
     await this.persist();
+  }
+
+  async recordChatEvent(event: ChatEvent, options: { persist?: boolean } = {}): Promise<void> {
+    const projection = rolloutProjectionFromChatEvent(event);
+    this.pushRolloutRecord({
+      kind: projection.kind,
+      source: projection.source,
+      visibility: projection.visibility,
+      eventContext: event,
+      createdAt: event.createdAt,
+      payload: projection.payload,
+    });
+    if (options.persist !== false) {
+      await this.persist();
+    }
   }
 
   setSessionLifecycle(input: {
@@ -394,6 +488,266 @@ export class ChatHistory {
       this.session
     );
   }
+
+  private pushRolloutRecord(input: {
+    kind: ChatRolloutJournalRecordKind;
+    source: ChatRolloutJournalRecord["source"];
+    visibility: ChatRolloutJournalRecord["visibility"];
+    payload: unknown;
+    eventContext?: Partial<ChatEventContext>;
+    createdAt?: string;
+  }): void {
+    const current = this.session.rolloutJournal ?? [];
+    const sequence = nextRolloutSequence(current);
+    const runId = typeof input.eventContext?.runId === "string" ? input.eventContext.runId : null;
+    const turnId = typeof input.eventContext?.turnId === "string" ? input.eventContext.turnId : null;
+    const record = ChatRolloutJournalRecordSchema.parse({
+      schema_version: "chat-rollout-journal-record-v1",
+      id: `${this.sessionId}:${sequence}`,
+      sessionId: this.sessionId,
+      runId,
+      turnId,
+      sequence,
+      createdAt: input.createdAt ?? new Date().toISOString(),
+      kind: input.kind,
+      source: input.source,
+      visibility: input.visibility,
+      payload: redactSetupSecretsDeep(input.payload),
+    });
+    this.session.rolloutJournal = [...current, record].slice(-500);
+  }
+
+  private replaceModelVisibleJournalFromMessages(reason: "clear" | "compact" | "remove_last_turn"): void {
+    const demoted = (this.session.rolloutJournal ?? []).map((record) =>
+      record.source === "chat_history"
+        && record.visibility === "model_visible"
+        && (record.kind === "user_input" || record.kind === "model_output")
+        ? {
+            ...record,
+            visibility: "debug" as const,
+            payload: {
+              ...(isRecord(record.payload) ? record.payload : {}),
+              modelVisibleUntil: reason,
+            },
+          }
+        : record
+    );
+    this.session.rolloutJournal = demoted;
+    for (const message of this.session.messages) {
+      this.pushRolloutRecord({
+        kind: message.role === "assistant" ? "model_output" : "user_input",
+        source: "chat_history",
+        visibility: "model_visible",
+        payload: {
+          role: message.role,
+          content: message.content,
+          turnIndex: message.turnIndex,
+          historyMutation: reason,
+          ...(message.setupSecretIntake && message.setupSecretIntake.length > 0
+            ? { setupSecretIntake: message.setupSecretIntake }
+            : {}),
+        },
+      });
+    }
+  }
+}
+
+export function reconstructModelVisibleMessagesFromRolloutJournal(
+  records: ChatRolloutJournalRecord[] | undefined,
+): ChatMessage[] | null {
+  const modelRecords = (records ?? [])
+    .filter((record) =>
+      record.source === "chat_history"
+      && record.visibility === "model_visible"
+      && (record.kind === "user_input" || record.kind === "model_output")
+    )
+    .sort((left, right) => left.sequence - right.sequence);
+  if (modelRecords.length === 0) return null;
+
+  return modelRecords.flatMap((record, index): ChatMessage[] => {
+    const payload = isRecord(record.payload) ? record.payload : {};
+    const role = payload["role"] === "assistant" ? "assistant" : payload["role"] === "user" ? "user" : null;
+    const content = typeof payload["content"] === "string" ? payload["content"] : null;
+    if (!role || content === null) return [];
+    const setupSecretIntake = Array.isArray(payload["setupSecretIntake"])
+      ? { setupSecretIntake: payload["setupSecretIntake"] as ChatMessage["setupSecretIntake"] }
+      : {};
+    return [{
+      role,
+      content,
+      timestamp: record.createdAt,
+      turnIndex: index,
+      ...setupSecretIntake,
+    }];
+  });
+}
+
+function nextRolloutSequence(records: ChatRolloutJournalRecord[]): number {
+  return records.reduce((max, record) => Math.max(max, record.sequence), -1) + 1;
+}
+
+function extractTurnContextEventContext(snapshot: { modelVisible: unknown }): ChatEventContext | undefined {
+  const modelVisible = isRecord(snapshot.modelVisible) ? snapshot.modelVisible : null;
+  const turn = modelVisible && isRecord(modelVisible["turn"]) ? modelVisible["turn"] : null;
+  const runId = typeof turn?.["runId"] === "string" ? turn["runId"] : undefined;
+  const turnId = typeof turn?.["turnId"] === "string" ? turn["turnId"] : undefined;
+  return runId && turnId ? { runId, turnId } : undefined;
+}
+
+function toReplayableUserInput(input: UserInput): unknown {
+  return {
+    schema_version: input.schema_version,
+    ...(input.rawText !== undefined ? { rawText: input.rawText } : {}),
+    items: input.items.map((item) => {
+      switch (item.kind) {
+        case "text":
+          return { kind: "text", text: item.text };
+        case "image":
+        case "local_image":
+          return {
+            kind: item.kind,
+            ...(item.name ? { name: item.name } : {}),
+          };
+        case "mention":
+          return {
+            kind: "mention",
+            ...(item.label ? { label: item.label } : {}),
+          };
+        case "skill":
+        case "plugin":
+        case "tool":
+          return { kind: item.kind, name: item.name };
+        case "attachment":
+          return {
+            kind: "attachment",
+            id: item.id,
+            ...(item.name ? { name: item.name } : {}),
+            ...(item.mimeType ? { mimeType: item.mimeType } : {}),
+          };
+      }
+    }),
+  };
+}
+
+function rolloutProjectionFromChatEvent(event: ChatEvent): {
+  kind: ChatRolloutJournalRecordKind;
+  source: ChatRolloutJournalRecord["source"];
+  visibility: ChatRolloutJournalRecord["visibility"];
+  payload: unknown;
+} {
+  if (event.type === "tool_start") {
+    return {
+      kind: "tool_call",
+      source: "chat_event",
+      visibility: "debug",
+      payload: { event },
+    };
+  }
+  if (event.type === "tool_end") {
+    return {
+      kind: "tool_result",
+      source: "chat_event",
+      visibility: "debug",
+      payload: { event },
+    };
+  }
+  if (event.type === "tool_update" && event.status === "awaiting_approval") {
+    return {
+      kind: "permission_decision",
+      source: "chat_event",
+      visibility: "host_only",
+      payload: { state: "requested", event },
+    };
+  }
+  if (event.type === "agent_timeline") {
+    return rolloutProjectionFromAgentTimelineEvent(event);
+  }
+  if (event.type === "assistant_final") {
+    return {
+      kind: "model_output",
+      source: "chat_event",
+      visibility: "model_visible",
+      payload: {
+        role: "assistant",
+        content: event.text,
+        persisted: event.persisted,
+        event,
+      },
+    };
+  }
+  if (event.type === "lifecycle_end" || event.type === "lifecycle_error") {
+    return {
+      kind: "completion_state",
+      source: "chat_event",
+      visibility: "debug",
+      payload: { event },
+    };
+  }
+  return {
+    kind: "display_event",
+    source: "chat_event",
+    visibility: "display",
+    payload: { event },
+  };
+}
+
+function rolloutProjectionFromAgentTimelineEvent(event: Extract<ChatEvent, { type: "agent_timeline" }>): {
+  kind: ChatRolloutJournalRecordKind;
+  source: "agent_timeline";
+  visibility: ChatRolloutJournalRecord["visibility"];
+  payload: unknown;
+} {
+  const item = event.item;
+  if (item.kind === "model_request" || item.kind === "assistant_message") {
+    return {
+      kind: "model_output",
+      source: "agent_timeline",
+      visibility: item.visibility === "debug" ? "debug" : "model_visible",
+      payload: { item },
+    };
+  }
+  if (item.kind === "tool" && item.status === "started") {
+    return {
+      kind: "tool_call",
+      source: "agent_timeline",
+      visibility: "debug",
+      payload: { item },
+    };
+  }
+  if (item.kind === "tool" || item.kind === "tool_observation") {
+    return {
+      kind: "tool_result",
+      source: "agent_timeline",
+      visibility: item.visibility === "debug" ? "debug" : "display",
+      payload: { item },
+    };
+  }
+  if (item.kind === "approval") {
+    return {
+      kind: "permission_decision",
+      source: "agent_timeline",
+      visibility: "host_only",
+      payload: { item },
+    };
+  }
+  if (item.kind === "final" || item.kind === "stopped") {
+    return {
+      kind: "completion_state",
+      source: "agent_timeline",
+      visibility: "debug",
+      payload: { item },
+    };
+  }
+  return {
+    kind: "display_event",
+    source: "agent_timeline",
+    visibility: item.visibility === "debug" ? "debug" : "display",
+    payload: { item },
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function normalizeUsageCounter(usage: ChatUsageCounter): ChatUsageCounter {

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -52,6 +52,8 @@ export interface ActiveChatTurn {
 export class ChatRunnerEventBridge {
   private activeTurn: ActiveChatTurn | null = null;
   private readonly timelineActivityItemsByRun = new Map<string, AgentTimelineItem[]>();
+  private eventRecorder: ((event: ChatEvent) => Promise<void> | void) | null = null;
+  private eventRecorderQueue: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly onEventGetter: () => ChatEventHandler | undefined,
@@ -63,6 +65,14 @@ export class ChatRunnerEventBridge {
 
   getActiveTurn(): ActiveChatTurn | null {
     return this.activeTurn;
+  }
+
+  setEventRecorder(recorder: ((event: ChatEvent) => Promise<void> | void) | null): void {
+    this.eventRecorder = recorder;
+  }
+
+  async flushEventRecorder(): Promise<void> {
+    await this.eventRecorderQueue;
   }
 
   createEventContext(): ChatEventContext {
@@ -339,6 +349,7 @@ export class ChatRunnerEventBridge {
   private async deliverEvent(event: ChatEvent): Promise<void> {
     const safeEvent = redactChatEvent(event);
     this.rememberActiveTurnEvent(safeEvent);
+    this.enqueueRecordedEvent(safeEvent);
     try {
       await this.onEventGetter()?.(safeEvent);
     } catch (err) {
@@ -347,6 +358,19 @@ export class ChatRunnerEventBridge {
         error: err instanceof Error ? err.message : String(err),
       });
     }
+  }
+
+  private enqueueRecordedEvent(event: ChatEvent): void {
+    const recorder = this.eventRecorder;
+    if (!recorder) return;
+    this.eventRecorderQueue = this.eventRecorderQueue.then(async () => {
+      await recorder(event);
+    }).catch((err) => {
+      console.warn("[chat] event journal persist failed", {
+        eventType: event.type,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
   }
 
   private rememberTimelineActivityItem(eventContext: ChatEventContext, item: AgentTimelineItem): void {

--- a/src/interface/chat/chat-runner-runtime.ts
+++ b/src/interface/chat/chat-runner-runtime.ts
@@ -70,6 +70,7 @@ export function loadedSessionToChatSession(session: LoadedChatSession): ChatSess
     ...(session.agentLoopUpdatedAt ? { agentLoopUpdatedAt: session.agentLoopUpdatedAt } : {}),
     ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
     ...(session.turnContexts ? { turnContexts: [...session.turnContexts] } : {}),
+    ...(session.rolloutJournal ? { rolloutJournal: [...session.rolloutJournal] } : {}),
     ...(session.usage ? { usage: session.usage } : {}),
   };
 }

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -177,6 +177,8 @@ export class ChatRunner {
   private setupSecretIntake: ReturnType<typeof intakeSetupSecrets> | null = null;
   private turnLanguageHint: TurnLanguageHint = UNKNOWN_TURN_LANGUAGE_HINT;
   private pendingSetupDialogue: SetupDialogueRuntimeState | null = null;
+  private eventJournalHistory: ChatHistory | null = null;
+  private eventJournalDirty = false;
 
   constructor(private readonly deps: ChatRunnerDeps) {
     this.groundingGateway = createChatGroundingGateway({
@@ -382,6 +384,9 @@ export class ChatRunner {
     const eventContext = this.eventBridge.createEventContext();
     const resolvedCwd = resolveGitRoot(cwd);
     const activeTurn = this.eventBridge.beginActiveTurn(eventContext, resolvedCwd);
+    this.eventBridge.setEventRecorder(null);
+    this.eventJournalHistory = null;
+    this.eventJournalDirty = false;
     const resumeCommand = this.commandHandler.parseResumeCommand(input);
     const resumeOnly = resumeCommand !== null;
     const setupSecretIntake = intakeSetupSecrets(input);
@@ -452,6 +457,11 @@ export class ChatRunner {
     const gitRoot = this.sessionCwd ?? resolvedCwd;
     activeTurn.cwd = gitRoot;
     const history = this.history!;
+    this.eventJournalHistory = history;
+    this.eventBridge.setEventRecorder((event) => {
+      this.eventJournalDirty = true;
+      return history.recordChatEvent(event, { persist: false });
+    });
     const pinnedReplyTarget = normalizePinnedReplyTarget(
       runtimeControlContext?.replyTarget ?? this.deps.runtimeReplyTarget ?? null,
     );
@@ -472,7 +482,11 @@ export class ChatRunner {
     });
 
     if (!resumeOnly) {
-      await history.appendUserMessage(safeInput, { setupSecretIntake: persistedSecretIntake });
+      await history.appendUserMessage(safeInput, {
+        setupSecretIntake: persistedSecretIntake,
+        eventContext,
+        userInput: safeUserInput,
+      });
     }
 
     if (this.cachedStaticSystemPrompt === null) {
@@ -483,7 +497,7 @@ export class ChatRunner {
       }
     }
 
-    const messages = history.getMessages();
+    const messages = history.getModelVisibleMessages();
     const compactionSummary = history.getSessionData().compactionSummary;
     const priorTurns = resumeOnly ? messages.slice(-10) : messages.slice(0, -1).slice(-10);
     const historySections: string[] = [];
@@ -511,7 +525,7 @@ export class ChatRunner {
       this.eventBridge.emitCheckpoint("Runtime control selected", `${selectedRoute.intent.kind} request recognized.`, eventContext, "route");
       const runtimeControlResult = await executeRuntimeControlRoute(this.routeHost(), selectedRoute, runtimeControlContext, executionCwd, start);
       if (runtimeControlResult.success) {
-        await history.appendAssistantMessage(runtimeControlResult.output);
+        await history.appendAssistantMessage(runtimeControlResult.output, { eventContext });
         this.eventBridge.emitCheckpoint("Runtime control completed", "The runtime-control operation produced a result.", eventContext, "complete");
         this.eventBridge.emitActivity("lifecycle", "Finalizing response...", eventContext, "lifecycle:finalizing");
         this.eventBridge.emitEvent({
@@ -537,13 +551,13 @@ export class ChatRunner {
         );
         this.eventBridge.emitLifecycleEndEvent("error", runtimeControlResult.elapsed_ms, eventContext, false);
       }
-      return runtimeControlResult;
+      return this.flushAndReturn(runtimeControlResult);
     }
 
     if (selectedRoute?.kind === "runtime_control_blocked") {
       const output = formatBlockedRuntimeControlRoute(selectedRoute);
       this.eventBridge.pushAssistantDelta(output, assistantBuffer, eventContext);
-      await history.appendAssistantMessage(output);
+      await history.appendAssistantMessage(output, { eventContext });
       this.eventBridge.emitEvent({
         type: "assistant_final",
         text: output,
@@ -552,26 +566,26 @@ export class ChatRunner {
       });
       const elapsed_ms = Date.now() - start;
       this.eventBridge.emitLifecycleEndEvent("error", elapsed_ms, eventContext, true);
-      return {
+      return this.flushAndReturn({
         success: false,
         output,
         elapsed_ms,
-      };
+      });
     }
 
     if (selectedRoute?.kind === "run_spec_draft") {
       const result = await executeRunSpecDraftRoute(this.routeHost(), selectedRoute, eventContext, assistantBuffer, history, start);
-      return result;
+      return this.flushAndReturn(result);
     }
 
     if (selectedRoute?.kind === "configure") {
       const result = await executeConfigureRoute(this.routeHost(), selectedRoute, eventContext, assistantBuffer, history, start);
-      return result;
+      return this.flushAndReturn(result);
     }
 
     if (selectedRoute?.kind === "clarify") {
       const result = await executeClarifyRoute(this.routeHost(), selectedRoute, eventContext, assistantBuffer, history, start);
-      return result;
+      return this.flushAndReturn(result);
     }
 
     const usesNativeAgentLoop = resumeOnly || selectedRoute?.kind === "agent_loop";
@@ -667,7 +681,7 @@ export class ChatRunner {
         this.deps.llmClient
       );
       this.eventBridge.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
-      return { success: false, output, elapsed_ms };
+      return this.flushAndReturn({ success: false, output, elapsed_ms });
     }
 
     if (selectedRoute?.kind === "assist") {
@@ -678,11 +692,11 @@ export class ChatRunner {
         history,
         start,
       });
-      return result;
+      return this.flushAndReturn(result);
     }
 
     if (resumeOnly || selectedRoute?.kind === "agent_loop") {
-      return executeAgentLoopRoute(this.routeHost(), {
+      return this.flushAndReturn(executeAgentLoopRoute(this.routeHost(), {
         turnContext,
         resumeOnly,
         assistantBuffer,
@@ -691,11 +705,11 @@ export class ChatRunner {
         gitRoot,
         activeAbortSignal: activeTurn.abortController.signal,
         start,
-      });
+      }));
     }
 
     if (selectedRoute?.kind === "tool_loop") {
-      return executeToolLoopRoute(this.routeHost(), {
+      return this.flushAndReturn(executeToolLoopRoute(this.routeHost(), {
         turnContext,
         eventContext,
         assistantBuffer,
@@ -705,7 +719,7 @@ export class ChatRunner {
         gitRoot,
         runtimeControlContext,
         start,
-      });
+      }));
     }
 
     if (!resumeOnly && selectedRoute && selectedRoute.kind !== "adapter") {
@@ -718,10 +732,10 @@ export class ChatRunner {
         this.deps.llmClient
       );
       this.eventBridge.emitLifecycleEndEvent("error", elapsed_ms, eventContext, false);
-      return { success: false, output, elapsed_ms };
+      return this.flushAndReturn({ success: false, output, elapsed_ms });
     }
 
-    return executeAdapterRoute(this.routeHost(), {
+    return this.flushAndReturn(executeAdapterRoute(this.routeHost(), {
       turnContext,
       timeoutMs,
       systemPrompt: renderSystemPromptWithTurnContext(systemPrompt || undefined, turnContext.modelVisible),
@@ -730,7 +744,7 @@ export class ChatRunner {
       gitRoot,
       start,
       history,
-    });
+    }));
   }
 
   getSessionCwd(): string | null {
@@ -1155,7 +1169,17 @@ export class ChatRunner {
     };
   }
 
-  private finalizeNonPersistentResult(result: ChatRunResult, eventContext: Parameters<ChatRunnerEventBridge["eventBase"]>[0]): ChatRunResult {
+  private async flushAndReturn(result: ChatRunResult | Promise<ChatRunResult>): Promise<ChatRunResult> {
+    const resolved = await result;
+    await this.eventBridge.flushEventRecorder();
+    if (this.eventJournalDirty && this.eventJournalHistory) {
+      this.eventJournalDirty = false;
+      await this.eventJournalHistory.persist();
+    }
+    return resolved;
+  }
+
+  private async finalizeNonPersistentResult(result: ChatRunResult, eventContext: Parameters<ChatRunnerEventBridge["eventBase"]>[0]): Promise<ChatRunResult> {
     if (result.output) {
       this.eventBridge.emitEvent({
         type: "assistant_final",
@@ -1165,6 +1189,7 @@ export class ChatRunner {
       });
     }
     this.eventBridge.emitLifecycleEndEvent(result.success ? "completed" : "error", result.elapsed_ms, eventContext, false);
+    await this.eventBridge.flushEventRecorder();
     return result;
   }
 }

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -72,6 +72,7 @@ export interface LoadedChatSession {
   agentLoopUpdatedAt?: string | null;
   agentLoop?: ChatSession["agentLoop"];
   turnContexts?: ChatSession["turnContexts"];
+  rolloutJournal?: ChatSession["rolloutJournal"];
   usage?: ChatSession["usage"];
   [key: string]: unknown;
 }
@@ -349,6 +350,7 @@ async function readSessionRecordWithMetadata(
     agentLoopUpdatedAt: discovery.updatedAt,
     ...(parsed.data.agentLoop ? { agentLoop: parsed.data.agentLoop } : {}),
     ...(parsed.data.turnContexts ? { turnContexts: [...parsed.data.turnContexts] } : {}),
+    ...(parsed.data.rolloutJournal ? { rolloutJournal: [...parsed.data.rolloutJournal] } : {}),
     ...(parsed.data.usage ? { usage: parsed.data.usage } : {}),
   };
 
@@ -406,6 +408,7 @@ function toPersistedSession(session: LoadedChatSession): ChatSession {
     ...(session.lastRetryAt !== null && session.lastRetryAt !== undefined ? { lastRetryAt: session.lastRetryAt } : {}),
     ...(session.lastResumedAt !== null && session.lastResumedAt !== undefined ? { lastResumedAt: session.lastResumedAt } : {}),
     ...(session.notificationReplyTarget !== null && session.notificationReplyTarget !== undefined ? { notificationReplyTarget: session.notificationReplyTarget } : {}),
+    ...(session.setupDialogue !== null && session.setupDialogue !== undefined ? { setupDialogue: session.setupDialogue } : {}),
     ...(session.runSpecConfirmation !== null && session.runSpecConfirmation !== undefined ? { runSpecConfirmation: session.runSpecConfirmation } : {}),
     ...(session.parentNotificationStatus !== null && session.parentNotificationStatus !== undefined ? { parentNotificationStatus: session.parentNotificationStatus } : {}),
     ...(session.parentNotificationSummary !== null && session.parentNotificationSummary !== undefined ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
@@ -422,6 +425,7 @@ function toPersistedSession(session: LoadedChatSession): ChatSession {
       : {}),
     ...(session.agentLoop ? { agentLoop: session.agentLoop } : {}),
     ...(session.turnContexts ? { turnContexts: [...session.turnContexts] } : {}),
+    ...(session.rolloutJournal ? { rolloutJournal: [...session.rolloutJournal] } : {}),
     ...(session.usage ? { usage: session.usage } : {}),
   };
 }
@@ -573,11 +577,13 @@ export class ChatSessionCatalog {
       ...(session.lastRetryAt ? { lastRetryAt: session.lastRetryAt } : {}),
       ...(session.lastResumedAt ? { lastResumedAt: session.lastResumedAt } : {}),
       ...(session.notificationReplyTarget ? { notificationReplyTarget: session.notificationReplyTarget } : {}),
+      ...(session.setupDialogue ? { setupDialogue: session.setupDialogue } : {}),
       ...(session.parentNotificationStatus ? { parentNotificationStatus: session.parentNotificationStatus } : {}),
       ...(session.parentNotificationSummary ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
       ...(session.parentNotifiedAt ? { parentNotifiedAt: session.parentNotifiedAt } : {}),
       ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
       ...(session.turnContexts ? { turnContexts: [...session.turnContexts] } : {}),
+      ...(session.rolloutJournal ? { rolloutJournal: [...session.rolloutJournal] } : {}),
       agentLoopStatePath: session.agentLoopStatePath,
       agentLoopStatus: session.agentLoopStatus,
       agentLoopResumable: session.agentLoopResumable,

--- a/src/interface/chat/cross-platform-session.ts
+++ b/src/interface/chat/cross-platform-session.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as path from "node:path";
 import { ChatRunner } from "./chat-runner.js";
+import { ChatSessionCatalog } from "./chat-session-store.js";
 import type { ChatRunResult, ChatRunnerDeps } from "./chat-runner-contracts.js";
 import type { ChatEvent, ChatEventHandler } from "./chat-events.js";
 import {
@@ -161,6 +162,7 @@ export interface CrossPlatformChatSessionInfo {
   created_at: string;
   last_used_at: string;
   last_message_id?: string;
+  chat_session_id?: string;
   active_reply_target?: ChatIngressReplyTarget;
   active_companion_contract?: CompanionRuntimeContract;
   metadata: Record<string, unknown>;
@@ -214,6 +216,17 @@ function buildSessionKey(options: CrossPlatformChatSessionOptions): string {
 
 function cloneMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> {
   return metadata ? { ...metadata } : {};
+}
+
+function cloneReplyTarget(target: Record<string, unknown> | ChatIngressReplyTarget): ChatIngressReplyTarget {
+  return {
+    ...target,
+    metadata: isRecord(target.metadata) ? cloneMetadata(target.metadata) : {},
+  } as ChatIngressReplyTarget;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function buildSessionMetadata(options: {
@@ -372,6 +385,7 @@ class ChatEventDeliveryQueue {
 
 export class CrossPlatformChatSessionManager {
   private readonly sessions = new Map<string, ManagedChatSession>();
+  private readonly sessionInitializers = new Map<string, Promise<ManagedChatSession>>();
   private readonly activeApprovalEventHandlers = new Map<string, ChatEventHandler>();
   private readonly approvalSideTurnIngressIds = new Set<string>();
   private readonly ingressRouter = createIngressRouter();
@@ -416,7 +430,7 @@ export class CrossPlatformChatSessionManager {
         elapsed_ms: 0,
       };
     }
-    const session = this.getOrCreateSession(ingress, options.cwd);
+    const session = await this.getOrCreateSession(ingress, options.cwd);
     if (ingress.ingress_id && this.approvalSideTurnIngressIds.delete(ingress.ingress_id)) {
       return this.executeInSession(session, ingress, options);
     }
@@ -451,7 +465,7 @@ export class CrossPlatformChatSessionManager {
         elapsed_ms: 0,
       };
     }
-    const session = this.getOrCreateSession(ingress, input.cwd);
+    const session = await this.getOrCreateSession(ingress, input.cwd);
     const decision = evaluateCompanionOutputPolicy(ingress.companion.turn_policy);
     if (!decision.delivered) {
       return {
@@ -476,7 +490,7 @@ export class CrossPlatformChatSessionManager {
         elapsed_ms: 0,
       };
     }
-    const session = this.getOrCreateSession(normalizedIngress, options.cwd);
+    const session = await this.getOrCreateSession(normalizedIngress, options.cwd);
     if (normalizedIngress.ingress_id && this.approvalSideTurnIngressIds.delete(normalizedIngress.ingress_id)) {
       return this.executeInSession(session, normalizedIngress, options);
     }
@@ -574,7 +588,7 @@ export class CrossPlatformChatSessionManager {
     ingress: CrossPlatformIngressMessage,
     origin: ApprovalOrigin,
   ): Promise<string | null> {
-    if (!isPermissionApprovalStale(approval, this.currentApprovalStateEpoch(ingress))) {
+    if (!isPermissionApprovalStale(approval, await this.currentApprovalStateEpoch(ingress))) {
       return null;
     }
     const broker = this.deps.approvalBroker;
@@ -588,9 +602,12 @@ export class CrossPlatformChatSessionManager {
       : "The approval target changed after the prompt, and the stale approval could not be resolved.";
   }
 
-  private currentApprovalStateEpoch(ingress: CrossPlatformIngressMessage): string | null {
-    const session = this.sessions.get(buildSessionKeyFromParts(ingress));
-    return session?.info.last_message_id ?? null;
+  private async currentApprovalStateEpoch(ingress: CrossPlatformIngressMessage): Promise<string | null> {
+    const sessionKey = buildSessionKeyFromParts(ingress);
+    const session = this.sessions.get(sessionKey);
+    if (session) return session.info.last_message_id ?? null;
+    const persisted = await this.loadPersistedSessionInfo(sessionKey);
+    return persisted?.last_message_id ?? null;
   }
 
   private describeLastRouteForApproval(ingress: CrossPlatformIngressMessage): string {
@@ -745,19 +762,80 @@ export class CrossPlatformChatSessionManager {
       : null;
   }
 
-  private getOrCreateSession(
+  private sessionInfoRelativePath(sessionKey: string): string {
+    const encoded = Buffer.from(sessionKey, "utf-8").toString("base64url");
+    return path.join("chat", "cross-platform-sessions", `${encoded}.json`);
+  }
+
+  private async loadPersistedSessionInfo(sessionKey: string): Promise<CrossPlatformChatSessionInfo | null> {
+    const raw = await this.deps.stateManager.readRaw(this.sessionInfoRelativePath(sessionKey));
+    if (!isRecord(raw) || raw["session_key"] !== sessionKey) return null;
+    const cwd = typeof raw["cwd"] === "string" && raw["cwd"].trim() ? raw["cwd"] : null;
+    const createdAt = typeof raw["created_at"] === "string" && raw["created_at"].trim() ? raw["created_at"] : null;
+    const lastUsedAt = typeof raw["last_used_at"] === "string" && raw["last_used_at"].trim() ? raw["last_used_at"] : null;
+    if (!cwd || !createdAt || !lastUsedAt) return null;
+    return {
+      session_key: sessionKey,
+      ...(typeof raw["identity_key"] === "string" ? { identity_key: raw["identity_key"] } : {}),
+      ...(typeof raw["platform"] === "string" ? { platform: raw["platform"] } : {}),
+      ...(typeof raw["conversation_id"] === "string" ? { conversation_id: raw["conversation_id"] } : {}),
+      ...(typeof raw["conversation_name"] === "string" ? { conversation_name: raw["conversation_name"] } : {}),
+      ...(typeof raw["user_id"] === "string" ? { user_id: raw["user_id"] } : {}),
+      ...(typeof raw["user_name"] === "string" ? { user_name: raw["user_name"] } : {}),
+      cwd,
+      created_at: createdAt,
+      last_used_at: lastUsedAt,
+      ...(typeof raw["last_message_id"] === "string" ? { last_message_id: raw["last_message_id"] } : {}),
+      ...(typeof raw["chat_session_id"] === "string" ? { chat_session_id: raw["chat_session_id"] } : {}),
+      ...(isRecord(raw["active_reply_target"])
+        ? { active_reply_target: cloneReplyTarget(raw["active_reply_target"]) }
+        : {}),
+      ...(isRecord(raw["active_companion_contract"])
+        ? { active_companion_contract: raw["active_companion_contract"] as CompanionRuntimeContract }
+        : {}),
+      metadata: isRecord(raw["metadata"]) ? cloneMetadata(raw["metadata"]) : {},
+    };
+  }
+
+  private async persistSessionInfo(info: CrossPlatformChatSessionInfo): Promise<void> {
+    await this.deps.stateManager.writeRaw(this.sessionInfoRelativePath(info.session_key), {
+      ...info,
+      metadata: cloneMetadata(info.metadata),
+      active_reply_target: info.active_reply_target ? cloneReplyTarget(info.active_reply_target) : undefined,
+    });
+  }
+
+  private async getOrCreateSession(
     ingress: Pick<ChatIngressMessage, "identity_key" | "platform" | "conversation_id" | "user_id">,
     cwdOverride?: string
-  ): ManagedChatSession {
+  ): Promise<ManagedChatSession> {
     const sessionKey = buildSessionKeyFromParts(ingress);
     const existing = this.sessions.get(sessionKey);
     if (existing) {
       return existing;
     }
+    const pending = this.sessionInitializers.get(sessionKey);
+    if (pending) {
+      return pending;
+    }
 
+    const initializer = this.createManagedSession(sessionKey, ingress, cwdOverride)
+      .finally(() => {
+        this.sessionInitializers.delete(sessionKey);
+      });
+    this.sessionInitializers.set(sessionKey, initializer);
+    return initializer;
+  }
+
+  private async createManagedSession(
+    sessionKey: string,
+    ingress: Pick<ChatIngressMessage, "identity_key" | "platform" | "conversation_id" | "user_id">,
+    cwdOverride?: string,
+  ): Promise<ManagedChatSession> {
     const cwd = resolveGitRoot(cwdOverride?.trim() || process.cwd());
     const now = new Date().toISOString();
-    const info: CrossPlatformChatSessionInfo = {
+    const persisted = await this.loadPersistedSessionInfo(sessionKey);
+    const info: CrossPlatformChatSessionInfo = persisted ?? {
       session_key: sessionKey,
       identity_key: normalizeIdentity(ingress.identity_key) ?? undefined,
       platform: normalizePlatform(ingress.platform) ?? undefined,
@@ -776,7 +854,17 @@ export class CrossPlatformChatSessionManager {
       approvalRequestFn: approvalRequestFn ?? this.deps.approvalRequestFn,
       runtimeControlApprovalFn: approvalFn ?? this.deps.runtimeControlApprovalFn,
     });
-    runner.startSession(cwd);
+    if (info.chat_session_id) {
+      const loaded = await new ChatSessionCatalog(this.deps.stateManager).loadSession(info.chat_session_id);
+      if (loaded) {
+        runner.startSessionFromLoadedSession(loaded);
+      } else {
+        runner.startSession(info.cwd);
+      }
+    } else {
+      runner.startSession(info.cwd);
+    }
+    info.chat_session_id = runner.getSessionId() ?? info.chat_session_id;
 
     const created: ManagedChatSession = {
       runner,
@@ -785,6 +873,7 @@ export class CrossPlatformChatSessionManager {
       lastRoute: undefined,
     };
     this.sessions.set(sessionKey, created);
+    await this.persistSessionInfo(info);
     return created;
   }
 
@@ -907,6 +996,7 @@ export class CrossPlatformChatSessionManager {
     options: Pick<CrossPlatformIncomingChatMessage, "timeoutMs" | "onEvent" | "conversation_name" | "user_name"> = {}
   ): Promise<ChatRunResult> {
     this.updateSessionInfoForIngress(session, ingress, options);
+    await this.persistSessionInfo(session.info);
 
     const capabilities = {
       hasAgentLoop: this.deps.chatAgentLoopRunner !== undefined,
@@ -1021,6 +1111,7 @@ export class CrossPlatformChatSessionManager {
     options: Pick<CrossPlatformIncomingChatMessage, "conversation_name" | "user_name"> = {},
   ): void {
     session.info.last_used_at = new Date().toISOString();
+    session.info.chat_session_id = session.runner.getSessionId() ?? session.info.chat_session_id;
     session.info.conversation_name = options.conversation_name?.trim() || session.info.conversation_name;
     session.info.user_id = session.info.user_id ?? (normalizeIdentity(ingress.user_id) ?? undefined);
     session.info.user_name = options.user_name?.trim() || session.info.user_name;
@@ -1049,6 +1140,7 @@ export class CrossPlatformChatSessionManager {
     options: Pick<CrossPlatformIncomingChatMessage, "timeoutMs" | "onEvent" | "conversation_name" | "user_name"> = {},
   ): Promise<ChatRunResult> {
     this.updateSessionInfoForIngress(session, ingress, options);
+    await this.persistSessionInfo(session.info);
 
     const previousOnEvent = session.runner.onEvent;
     const approvalHandlerKey = session.info.session_key;


### PR DESCRIPTION
## Summary
- add structured rolloutJournal records for chat user input, turn context, model output, tools, permission/display events, and completion state
- reconstruct model-visible history from structured journal records instead of legacy transcript messages, while keeping compact/undo/clear history mutations aligned
- persist cross-platform chat session metadata so restart reconstruction preserves chat session id, reply target, and stale approval epoch behavior

## Verification
- npm test -- src/interface/chat/__tests__/chat-history.test.ts
- npm test -- src/interface/chat/__tests__/chat-session-store.test.ts
- npm test -- src/interface/chat/__tests__/cross-platform-session.test.ts
- npm test -- src/interface/chat/__tests__/chat-runner.test.ts
- npm run typecheck
- npm run lint:boundaries (passes with existing warnings)
- npm run test:changed
- git diff --check

Closes #1116