### PR TITLE
feat: enforce typed workspace tool policies

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
@@ -294,7 +294,7 @@ describe("agentloop phase 3 tools", () => {
           },
         ], turn);
         expect(outsideOutput[0].success).toBe(false);
-        expect(outsideOutput[0].content).toContain("protected PulSeed source root");
+        expect(outsideOutput[0].content).toContain("cwd escapes workspace root");
         expect(fs.existsSync(path.join(tmpDir, "absolute-blocked.txt"))).toBe(false);
       } finally {
         fs.rmSync(outsideDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
@@ -101,6 +101,45 @@ describe("agent timeline activity summaries", () => {
     ]);
   });
 
+  it("projects full typed tool observations for display-layer consumers", () => {
+    const item = projectAgentLoopEventToTimeline(baseEvent({
+      type: "tool_observation",
+      eventId: "observation-1",
+      observation: {
+        type: "tool_observation",
+        callId: "call-1",
+        toolName: "shell_command",
+        arguments: { command: "echo ok" },
+        state: "success",
+        success: true,
+        execution: { status: "executed" },
+        durationMs: 5,
+        output: {
+          content: "Command succeeded",
+          summary: "Command succeeded",
+          data: { stdout: "ok\n", stderr: "", exitCode: 0 },
+        },
+        command: "echo ok",
+        cwd: "/repo",
+        activityCategory: "command",
+      },
+    }));
+
+    expect(item).toMatchObject({
+      kind: "tool_observation",
+      callId: "call-1",
+      toolName: "shell_command",
+      observation: {
+        type: "tool_observation",
+        arguments: { command: "echo ok" },
+        execution: { status: "executed" },
+        output: {
+          data: { stdout: "ok\n", stderr: "", exitCode: 0 },
+        },
+      },
+    });
+  });
+
   it("creates a shared summary item separate from detailed timeline items", () => {
     const items = [
       finishedTool("search-1", "shell_command", JSON.stringify({ command: "rg Timeline src" })),

--- a/src/orchestrator/execution/agent-loop/agent-timeline.ts
+++ b/src/orchestrator/execution/agent-loop/agent-timeline.ts
@@ -1,4 +1,5 @@
 import type { AgentLoopEvent } from "./agent-loop-events.js";
+import type { AgentLoopToolObservation } from "./agent-loop-model.js";
 import type { ToolActivityCategory } from "../../../tools/types.js";
 
 export type AgentTimelineItem =
@@ -83,6 +84,7 @@ export interface AgentTimelineToolObservationItem extends AgentTimelineBaseItem 
   success: boolean;
   outputPreview: string;
   durationMs: number;
+  observation: AgentLoopToolObservation;
 }
 
 export interface AgentTimelinePlanItem extends AgentTimelineBaseItem {
@@ -217,6 +219,7 @@ export function projectAgentLoopEventToTimeline(event: AgentLoopEvent): AgentTim
         success: event.observation.success,
         outputPreview: event.observation.output.content,
         durationMs: event.observation.durationMs,
+        observation: event.observation,
       };
     case "plan_update":
       return { ...base, kind: "plan", summary: event.summary };

--- a/src/tools/__tests__/workspace-actions.test.ts
+++ b/src/tools/__tests__/workspace-actions.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ToolExecutor } from "../executor.js";
+import { ToolRegistry } from "../registry.js";
+import { ToolPermissionManager } from "../permission.js";
+import { ConcurrencyController } from "../concurrency.js";
+import { ShellCommandTool } from "../system/ShellCommandTool/ShellCommandTool.js";
+import { ApplyPatchTool } from "../fs/ApplyPatchTool/ApplyPatchTool.js";
+import { TestRunnerTool } from "../system/TestRunnerTool/TestRunnerTool.js";
+import type { ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
+import type { ToolCallContext } from "../types.js";
+import * as execMod from "../../base/utils/execFileNoThrow.js";
+
+function makePolicy(workspaceRoot: string, overrides: Partial<ExecutionPolicy> = {}): ExecutionPolicy {
+  return {
+    executionProfile: "consumer",
+    sandboxMode: "workspace_write",
+    approvalPolicy: "never",
+    networkAccess: true,
+    workspaceRoot,
+    protectedPaths: [],
+    trustProjectInstructions: true,
+    ...overrides,
+  };
+}
+
+function makeContext(
+  workspaceRoot: string,
+  overrides: Partial<ToolCallContext> = {},
+): ToolCallContext {
+  return {
+    cwd: workspaceRoot,
+    goalId: "goal-1",
+    trustBalance: 0,
+    preApproved: false,
+    approvalFn: async () => false,
+    executionPolicy: makePolicy(workspaceRoot),
+    ...overrides,
+  };
+}
+
+function makeExecutor(): ToolExecutor {
+  const registry = new ToolRegistry();
+  registry.register(new ShellCommandTool());
+  registry.register(new ApplyPatchTool());
+  registry.register(new TestRunnerTool());
+  return new ToolExecutor({
+    registry,
+    permissionManager: new ToolPermissionManager({}),
+    concurrency: new ConcurrencyController(),
+  });
+}
+
+async function makeTempWorkspace(): Promise<string> {
+  return fsp.mkdtemp(path.join(os.tmpdir(), "pulseed-workspace-tools-"));
+}
+
+describe("workspace action typed tools", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("executes a safe shell command through the typed shell tool", async () => {
+    const workspace = await makeTempWorkspace();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValueOnce({
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await makeExecutor().execute(
+      "shell_command",
+      { command: "echo ok", cwd: workspace },
+      makeContext(workspace),
+    );
+
+    expect(result.success).toBe(true);
+    expect(execSpy).toHaveBeenCalledOnce();
+    expect(execSpy.mock.calls[0]?.[2]).toMatchObject({ cwd: await fsp.realpath(workspace) });
+    await fsp.rm(workspace, { recursive: true, force: true });
+  });
+
+  it("fails closed for a denied shell command before process execution", async () => {
+    const workspace = await makeTempWorkspace();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await makeExecutor().execute(
+      "shell_command",
+      { command: "git push origin main", cwd: workspace },
+      makeContext(workspace),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.execution).toMatchObject({
+      status: "not_executed",
+      reason: "policy_blocked",
+    });
+    expect(execSpy).not.toHaveBeenCalled();
+    await fsp.rm(workspace, { recursive: true, force: true });
+  });
+
+  it("preserves approval-denied non-execution for patch actions", async () => {
+    const workspace = await makeTempWorkspace();
+    const approvalFn = vi.fn(async () => false);
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: approved.txt",
+      "+should-not-exist",
+      "*** End Patch",
+      "",
+    ].join("\n");
+
+    const result = await makeExecutor().execute(
+      "apply_patch",
+      { patch, cwd: workspace },
+      makeContext(workspace, {
+        approvalFn,
+        executionPolicy: makePolicy(workspace, { approvalPolicy: "on_request" }),
+      }),
+    );
+
+    expect(approvalFn).toHaveBeenCalledOnce();
+    expect(result.execution).toMatchObject({
+      status: "not_executed",
+      reason: "approval_denied",
+    });
+    await expect(fsp.access(path.join(workspace, "approved.txt"))).rejects.toThrow();
+    await fsp.rm(workspace, { recursive: true, force: true });
+  });
+
+  it("blocks protected patch paths without writing", async () => {
+    const workspace = await makeTempWorkspace();
+    const approvalFn = vi.fn(async () => true);
+    const patch = [
+      "*** Begin Patch",
+      "*** Add File: .env",
+      "+SECRET=value",
+      "*** End Patch",
+      "",
+    ].join("\n");
+
+    const result = await makeExecutor().execute(
+      "apply_patch",
+      { patch, cwd: workspace },
+      makeContext(workspace, {
+        approvalFn,
+        executionPolicy: makePolicy(workspace, { approvalPolicy: "on_request" }),
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.execution).toMatchObject({
+      status: "not_executed",
+      reason: "policy_blocked",
+    });
+    expect(approvalFn).not.toHaveBeenCalled();
+    await expect(fsp.access(path.join(workspace, ".env"))).rejects.toThrow();
+    await fsp.rm(workspace, { recursive: true, force: true });
+  });
+
+  it("blocks rename-only patches that target protected paths without approval", async () => {
+    const workspace = await makeTempWorkspace();
+    const approvalFn = vi.fn(async () => true);
+    await fsp.writeFile(path.join(workspace, "safe.txt"), "safe\n", "utf-8");
+    const patch = [
+      "diff --git a/safe.txt b/.env",
+      "similarity index 100%",
+      "rename from safe.txt",
+      "rename to .env",
+      "",
+    ].join("\n");
+
+    const result = await makeExecutor().execute(
+      "apply_patch",
+      { patch, cwd: workspace },
+      makeContext(workspace, {
+        approvalFn,
+        executionPolicy: makePolicy(workspace, { approvalPolicy: "on_request" }),
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.execution).toMatchObject({
+      status: "not_executed",
+      reason: "policy_blocked",
+    });
+    expect(approvalFn).not.toHaveBeenCalled();
+    await expect(fsp.readFile(path.join(workspace, "safe.txt"), "utf-8")).resolves.toBe("safe\n");
+    await expect(fsp.access(path.join(workspace, ".env"))).rejects.toThrow();
+    await fsp.rm(workspace, { recursive: true, force: true });
+  });
+
+  it("rejects non-test command args before invoking the test runner", async () => {
+    const workspace = await makeTempWorkspace();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await makeExecutor().execute(
+      "test-runner",
+      { command: "npm install", cwd: workspace },
+      makeContext(workspace),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.execution).toMatchObject({
+      status: "not_executed",
+      reason: "policy_blocked",
+    });
+    expect(execSpy).not.toHaveBeenCalled();
+    await fsp.rm(workspace, { recursive: true, force: true });
+  });
+
+  it("rejects test-runner path args that escape the workspace before invoking the runner", async () => {
+    const workspace = await makeTempWorkspace();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await makeExecutor().execute(
+      "test-runner",
+      { command: "npx vitest run --config /tmp/evil-vitest.config.ts", cwd: workspace },
+      makeContext(workspace),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.execution).toMatchObject({
+      status: "not_executed",
+      reason: "policy_blocked",
+    });
+    expect(execSpy).not.toHaveBeenCalled();
+    await fsp.rm(workspace, { recursive: true, force: true });
+  });
+
+  it("rejects equal-form test-runner path args that escape the workspace", async () => {
+    const workspace = await makeTempWorkspace();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValue({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await makeExecutor().execute(
+      "test-runner",
+      { command: "npx vitest run --reporter=/tmp/evil-reporter.js", cwd: workspace },
+      makeContext(workspace),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.execution).toMatchObject({
+      status: "not_executed",
+      reason: "policy_blocked",
+    });
+    expect(execSpy).not.toHaveBeenCalled();
+    await fsp.rm(workspace, { recursive: true, force: true });
+  });
+});

--- a/src/tools/execution-orchestrator.ts
+++ b/src/tools/execution-orchestrator.ts
@@ -1,5 +1,6 @@
 import type { ITool, ToolCallContext, ToolResult } from "./types.js";
 import { assessShellCommand } from "./system/ShellTool/command-policy.js";
+import { resolveWorkspaceCwd } from "./workspace-scope.js";
 
 export type HostToolExecutionDecisionStatus =
   | "allowed"
@@ -33,6 +34,9 @@ export function decideHostToolExecution(
   if (!policy) {
     return { status: "allowed", reason: "No host execution policy is attached to this call." };
   }
+
+  const cwdDecision = decideWorkspaceCwd(request);
+  if (cwdDecision) return cwdDecision;
 
   const shellDecision = decideShellExecution(request);
   if (shellDecision) return shellDecision;
@@ -101,20 +105,46 @@ function decideStateFreshness(context: ToolCallContext): HostToolExecutionDecisi
   };
 }
 
+function decideWorkspaceCwd(request: HostToolExecutionRequest): HostToolExecutionDecision | null {
+  if (typeof request.input !== "object" || request.input === null) return null;
+  const cwd = (request.input as { cwd?: unknown }).cwd;
+  if (cwd !== undefined && typeof cwd !== "string") {
+    return {
+      status: "fail_closed",
+      reason: "Tool cwd must be a string when provided.",
+      executionReason: "policy_blocked",
+    };
+  }
+  const validation = resolveWorkspaceCwd(cwd, request.context);
+  if (validation.valid) return null;
+  return {
+    status: "fail_closed",
+    reason: validation.error ?? `Tool cwd escapes workspace root: ${validation.resolved}`,
+    executionReason: "policy_blocked",
+  };
+}
+
 function decideShellExecution(
   request: HostToolExecutionRequest
 ): HostToolExecutionDecision | null {
-  if (request.tool.metadata.name !== "shell" || typeof request.input !== "object" || request.input === null) {
+  if (
+    request.tool.metadata.name !== "shell"
+    && request.tool.metadata.name !== "shell_command"
+  ) {
+    return null;
+  }
+  if (typeof request.input !== "object" || request.input === null) {
     return null;
   }
   const command = (request.input as { command?: unknown }).command;
   if (typeof command !== "string") return null;
+  const cwdValidation = resolveWorkspaceCwd((request.input as { cwd?: unknown }).cwd as string | undefined, request.context);
 
   const assessment = assessShellCommand(
     command,
     request.context.executionPolicy,
     request.context.trusted === true,
-    request.context.cwd
+    cwdValidation.resolved
   );
   if (assessment.status === "allowed") {
     return { status: "allowed", reason: "Shell command is allowed by host policy." };

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -76,7 +76,7 @@ export class ToolExecutor {
       return this.failResult(
         `Permission denied: ${semanticResult.reason}`,
         Date.now() - startTime,
-        { status: "not_executed", reason: "permission_denied", message: semanticResult.reason },
+        { status: "not_executed", reason: semanticResult.executionReason ?? "permission_denied", message: semanticResult.reason },
       );
     }
     if (semanticResult.status === "needs_approval" && tool.metadata.tags.includes("automation")) {

--- a/src/tools/fs/ApplyPatchTool/ApplyPatchTool.ts
+++ b/src/tools/fs/ApplyPatchTool/ApplyPatchTool.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { z } from "zod";
 import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../types.js";
 import { validateProtectedPath } from "../FileValidationTool/protected-path-policy.js";
+import { resolveWorkspaceCwd } from "../../workspace-scope.js";
 
 export const ApplyPatchInputSchema = z.object({
   patch: z.string().min(1),
@@ -35,18 +36,44 @@ export class ApplyPatchTool implements ITool<ApplyPatchInput> {
 
   async call(input: ApplyPatchInput, context: ToolCallContext): Promise<ToolResult> {
     const started = Date.now();
-    const cwd = input.cwd ?? context.cwd;
-    if (input.patch.trimStart().startsWith("*** Begin Patch")) {
-      return this.callCodexPatch(input, cwd, started, context.executionPolicy?.protectedPaths);
+    const cwdValidation = resolveWorkspaceCwd(input.cwd, context);
+    if (!cwdValidation.valid) {
+      return {
+        success: false,
+        data: { changedPaths: [], stdout: "", stderr: cwdValidation.error ?? "Invalid cwd", checkOnly: input.checkOnly },
+        summary: `Patch blocked: ${cwdValidation.error ?? "Invalid cwd"}`,
+        error: cwdValidation.error ?? "Invalid cwd",
+        execution: { status: "not_executed", reason: "policy_blocked", message: cwdValidation.error ?? "Invalid cwd" },
+        durationMs: Date.now() - started,
+        artifacts: [],
+      };
     }
-    const changedPaths = extractPatchPaths(input.patch);
-    const blockedPath = findBlockedPatchPath(changedPaths, cwd, context.executionPolicy?.protectedPaths);
+    const cwd = cwdValidation.resolved;
+    const workspaceRoot = cwdValidation.workspaceRoot;
+    if (input.patch.trimStart().startsWith("*** Begin Patch")) {
+      return this.callCodexPatch(input, cwd, workspaceRoot, started, context.executionPolicy?.protectedPaths);
+    }
+    const patchPaths = inspectUnifiedPatchPaths(input.patch);
+    if (patchPaths.error) {
+      return {
+        success: false,
+        data: { changedPaths: [], stdout: "", stderr: patchPaths.error, checkOnly: input.checkOnly },
+        summary: `Patch blocked: ${patchPaths.error}`,
+        error: patchPaths.error,
+        execution: { status: "not_executed", reason: "policy_blocked", message: patchPaths.error },
+        durationMs: Date.now() - started,
+        artifacts: [],
+      };
+    }
+    const changedPaths = patchPaths.paths;
+    const blockedPath = findBlockedPatchPath(changedPaths, cwd, workspaceRoot, context.executionPolicy?.protectedPaths);
     if (blockedPath) {
       return {
         success: false,
         data: { changedPaths, stdout: "", stderr: blockedPath.error, checkOnly: input.checkOnly },
         summary: `Patch blocked: ${blockedPath.error}`,
         error: blockedPath.error,
+        execution: { status: "not_executed", reason: "policy_blocked", message: blockedPath.error },
         durationMs: Date.now() - started,
         artifacts: changedPaths,
       };
@@ -70,13 +97,27 @@ export class ApplyPatchTool implements ITool<ApplyPatchInput> {
     };
   }
 
-  private async callCodexPatch(input: ApplyPatchInput, cwd: string, started: number, protectedPaths?: string[]): Promise<ToolResult> {
+  private async callCodexPatch(input: ApplyPatchInput, cwd: string, workspaceRoot: string, started: number, protectedPaths?: string[]): Promise<ToolResult> {
     try {
       const operations = parseCodexPatch(input.patch);
       const changedPaths = operations.map((operation) => operation.filePath);
-      const blockedPath = findBlockedPatchPath(changedPaths, cwd, protectedPaths);
+      const blockedPath = findBlockedPatchPath(changedPaths, cwd, workspaceRoot, protectedPaths);
       if (blockedPath) {
-        throw new Error(blockedPath.error);
+        return {
+          success: false,
+          data: {
+            changedPaths,
+            stdout: "",
+            stderr: blockedPath.error,
+            checkOnly: input.checkOnly,
+            format: "codex",
+          },
+          summary: `Patch blocked: ${blockedPath.error}`,
+          error: blockedPath.error,
+          execution: { status: "not_executed", reason: "policy_blocked", message: blockedPath.error },
+          durationMs: Date.now() - started,
+          artifacts: changedPaths,
+        };
       }
       if (input.checkOnly) {
         for (const operation of operations) {
@@ -120,6 +161,26 @@ export class ApplyPatchTool implements ITool<ApplyPatchInput> {
   }
 
   async checkPermissions(_input: ApplyPatchInput, _context: ToolCallContext): Promise<PermissionCheckResult> {
+    const cwdValidation = resolveWorkspaceCwd(_input.cwd, _context);
+    if (!cwdValidation.valid) {
+      return { status: "denied", reason: cwdValidation.error ?? "Invalid cwd", executionReason: "policy_blocked" };
+    }
+
+    const changedPaths = _input.patch.trimStart().startsWith("*** Begin Patch")
+      ? inspectCodexPatchPaths(_input.patch)
+      : inspectUnifiedPatchPaths(_input.patch);
+    if (changedPaths.error) {
+      return { status: "denied", reason: changedPaths.error, executionReason: "policy_blocked" };
+    }
+    const blockedPath = findBlockedPatchPath(
+      changedPaths.paths,
+      cwdValidation.resolved,
+      cwdValidation.workspaceRoot,
+      _context.executionPolicy?.protectedPaths,
+    );
+    if (blockedPath) {
+      return { status: "denied", reason: blockedPath.error, executionReason: "policy_blocked" };
+    }
     return { status: "allowed" };
   }
 
@@ -142,30 +203,89 @@ function runGitApply(args: string[], patch: string, cwd: string): Promise<{ stdo
   });
 }
 
-function extractPatchPaths(patch: string): string[] {
+function inspectUnifiedPatchPaths(patch: string): { paths: string[]; error?: string } {
   const paths = new Set<string>();
   for (const line of patch.split("\n")) {
-    const match = line.match(/^\+\+\+\s+b\/(.+)$/);
-    if (match?.[1] && match[1] !== "/dev/null") {
-      paths.add(match[1]);
+    const diffGitPaths = parseDiffGitPaths(line);
+    if (diffGitPaths?.error) {
+      return { paths: [], error: diffGitPaths.error };
     }
-    const deletedMatch = line.match(/^---\s+a\/(.+)$/);
-    if (deletedMatch?.[1] && deletedMatch[1] !== "/dev/null") {
-      paths.add(deletedMatch[1]);
+    for (const filePath of diffGitPaths?.paths ?? []) {
+      addPatchPath(paths, filePath);
+    }
+
+    const newFileMatch = line.match(/^\+\+\+\s+(.+)$/);
+    if (newFileMatch?.[1]) addPatchPath(paths, newFileMatch[1]);
+
+    const deletedFileMatch = line.match(/^---\s+(.+)$/);
+    if (deletedFileMatch?.[1]) addPatchPath(paths, deletedFileMatch[1]);
+
+    const renameOrCopyMatch = line.match(/^(?:rename|copy) (?:from|to)\s+(.+)$/);
+    if (renameOrCopyMatch?.[1]) addPatchPath(paths, renameOrCopyMatch[1]);
+  }
+  if (patch.trim().length > 0 && paths.size === 0) {
+    return { paths: [], error: "Patch paths could not be determined; refusing to apply." };
+  }
+  return { paths: [...paths] };
+}
+
+function parseDiffGitPaths(line: string): { paths: string[]; error?: string } | null {
+  if (!line.startsWith("diff --git ")) return null;
+  const rest = line.slice("diff --git ".length);
+  if (!rest.startsWith("a/")) {
+    return { paths: [], error: `Unsupported diff header path format: ${line}` };
+  }
+  const splitIndex = rest.lastIndexOf(" b/");
+  if (splitIndex <= 0) {
+    return { paths: [], error: `Unsupported diff header path format: ${line}` };
+  }
+  return {
+    paths: [
+      rest.slice(0, splitIndex),
+      rest.slice(splitIndex + 1),
+    ],
+  };
+}
+
+function addPatchPath(paths: Set<string>, rawPath: string): void {
+  const filePath = normalizePatchPath(rawPath);
+  if (filePath.length === 0 || filePath === "/dev/null") return;
+  paths.add(filePath);
+}
+
+function normalizePatchPath(rawPath: string): string {
+  let filePath = rawPath.trim().split("\t", 1)[0] ?? "";
+  if (filePath.startsWith("\"") && filePath.endsWith("\"")) {
+    try {
+      filePath = JSON.parse(filePath) as string;
+    } catch {
+      filePath = filePath.slice(1, -1);
     }
   }
-  return [...paths];
+  if (filePath.startsWith("a/") || filePath.startsWith("b/")) {
+    return filePath.slice(2);
+  }
+  return filePath;
+}
+
+function inspectCodexPatchPaths(patch: string): { paths: string[]; error?: string } {
+  try {
+    return { paths: parseCodexPatch(patch).map((operation) => operation.filePath) };
+  } catch (err) {
+    return { paths: [], error: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 function findBlockedPatchPath(
   changedPaths: string[],
   cwd: string,
+  workspaceRoot: string,
   protectedPaths?: string[],
 ): { path: string; error: string } | null {
   for (const changedPath of changedPaths) {
     const validation = validateProtectedPath(changedPath, {
       cwd,
-      workspaceRoot: cwd,
+      workspaceRoot,
       protectedPaths,
     });
     if (!validation.valid) {

--- a/src/tools/system/ShellCommandTool/ShellCommandTool.ts
+++ b/src/tools/system/ShellCommandTool/ShellCommandTool.ts
@@ -33,6 +33,11 @@ export class ShellCommandTool implements ITool<ShellCommandInput> {
         data: null,
         summary: "Use the apply_patch tool for patch edits instead of shell_command.",
         error: "apply_patch must be called via the apply_patch tool",
+        execution: {
+          status: "not_executed",
+          reason: "policy_blocked",
+          message: "apply_patch must be called via the apply_patch tool",
+        },
         durationMs: 0,
       };
     }

--- a/src/tools/system/ShellTool/ShellTool.ts
+++ b/src/tools/system/ShellTool/ShellTool.ts
@@ -5,6 +5,7 @@ import { expandTildePath } from "../../fs/FileValidationTool/protected-path-poli
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, MAX_OUTPUT_CHARS, PERMISSION_LEVEL } from "./constants.js";
 import { assessShellCommand } from "./command-policy.js";
+import { resolveWorkspaceCwd } from "../../workspace-scope.js";
 
 export const ShellInputSchema = z.object({
   command: z.string().min(1),
@@ -32,7 +33,18 @@ export class ShellTool implements ITool<ShellInput, ShellOutput> {
 
   async call(input: ShellInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
-    const cwd = expandTildePath(input.cwd ?? context.cwd);
+    const cwdValidation = resolveWorkspaceCwd(input.cwd, context);
+    if (!cwdValidation.valid) {
+      return {
+        success: false,
+        data: { stdout: "", stderr: cwdValidation.error ?? "Invalid cwd", exitCode: -1 },
+        summary: `Shell command blocked: ${cwdValidation.error ?? "Invalid cwd"}`,
+        error: cwdValidation.error ?? "Invalid cwd",
+        execution: { status: "not_executed", reason: "policy_blocked", message: cwdValidation.error ?? "Invalid cwd" },
+        durationMs: Date.now() - startTime,
+      };
+    }
+    const cwd = expandTildePath(cwdValidation.resolved);
     try {
       const shell = process.env.SHELL ?? "/bin/zsh";
       const result = await execFileNoThrow(shell, ["-c", input.command], { cwd, timeoutMs: input.timeoutMs, signal: context.abortSignal, killProcessGroup: true });
@@ -57,11 +69,19 @@ export class ShellTool implements ITool<ShellInput, ShellOutput> {
   }
 
   async checkPermissions(input: ShellInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
+    let assessmentCwd = input.cwd ?? context?.cwd;
+    if (context) {
+      const cwdValidation = resolveWorkspaceCwd(input.cwd, context);
+      if (!cwdValidation.valid) {
+        return { status: "denied", reason: cwdValidation.error ?? "Invalid cwd", executionReason: "policy_blocked" };
+      }
+      assessmentCwd = cwdValidation.resolved;
+    }
     const assessment = assessShellCommand(
       input.command,
       context?.executionPolicy,
       context?.trusted === true,
-      input.cwd ?? context?.cwd,
+      assessmentCwd,
     );
     if (assessment.status === "allowed") return { status: "allowed" };
     if (assessment.status === "needs_approval") {

--- a/src/tools/system/TestRunnerTool/TestRunnerTool.ts
+++ b/src/tools/system/TestRunnerTool/TestRunnerTool.ts
@@ -3,6 +3,7 @@ import type { ITool, ToolResult, ToolCallContext, PermissionCheckResult, ToolMet
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, MAX_OUTPUT_CHARS, PERMISSION_LEVEL } from "./constants.js";
+import { resolveWorkspaceCwd, resolveWorkspacePath } from "../../workspace-scope.js";
 
 export const TestRunnerInputSchema = z.object({
   command: z.string().default("npx vitest run"),
@@ -110,6 +111,111 @@ function buildTestCommand(command: string, pattern?: string): { cmd: string; arg
   return { cmd, args };
 }
 
+function validateTestCommand(
+  input: TestRunnerInput,
+  scope?: { cwd: string; workspaceRoot: string },
+): string | null {
+  const command = input.command;
+  const parts = command.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "Test command must not be empty.";
+  if (/[;&|`$<>]/.test(command)) return "Test command contains shell control characters.";
+  const [cmd, first, second] = parts;
+  let argsStart: number | null = null;
+  if (cmd === "npx" && first === "vitest" && ["run", "list"].includes(second ?? "run")) argsStart = second ? 3 : 2;
+  if (cmd === "npx" && first === "vitest" && second === "--reporter") argsStart = 2;
+  if (cmd === "npx" && first === "jest") argsStart = 2;
+  if (cmd === "npm" && first === "test") argsStart = 2;
+  if (cmd === "npm" && first === "run" && typeof second === "string" && /^test(?::|$)/.test(second)) argsStart = 3;
+  if (cmd === "vitest" && ["run", "list"].includes(first ?? "run")) argsStart = first ? 2 : 1;
+  if (cmd === "vitest" && first === "--reporter") argsStart = 1;
+  if (cmd === "jest") argsStart = 1;
+  if (cmd === "mocha") argsStart = 1;
+  if (argsStart !== null) {
+    return validateTestArgs([...parts.slice(argsStart), ...(input.pattern ? [input.pattern] : [])], scope);
+  }
+  return `Command is not a recognized test runner invocation: ${command.trim()}`;
+}
+
+const PATH_VALUE_OPTIONS = new Set([
+  "--config",
+  "-c",
+  "--root",
+  "--dir",
+  "--project",
+  "--workspace",
+  "--globalSetup",
+  "--setupFiles",
+  "--setupFilesAfterEnv",
+  "--testMatch",
+  "--testRegex",
+  "--testPathPattern",
+  "--runTestsByPath",
+  "--require",
+  "-r",
+  "--file",
+  "--spec",
+]);
+
+function validateTestArgs(args: string[], scope?: { cwd: string; workspaceRoot: string }): string | null {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "--") continue;
+
+    const equalsIndex = arg.indexOf("=");
+    if (equalsIndex > 0) {
+      const option = arg.slice(0, equalsIndex);
+      const value = arg.slice(equalsIndex + 1);
+      if (PATH_VALUE_OPTIONS.has(option) || isPathLikeArg(value) || /^[a-z][a-z0-9+.-]*:\/\//i.test(value)) {
+        const error = validateWorkspaceArgPath(value, scope, option);
+        if (error) return error;
+        continue;
+      }
+    }
+
+    if (PATH_VALUE_OPTIONS.has(arg)) {
+      const value = args[i + 1];
+      if (!value || value.startsWith("-")) return `Test command option ${arg} requires a workspace path value.`;
+      const error = validateWorkspaceArgPath(value, scope, arg);
+      if (error) return error;
+      i++;
+      continue;
+    }
+
+    if (isPathLikeArg(arg)) {
+      const error = validateWorkspaceArgPath(arg, scope, "test argument");
+      if (error) return error;
+    }
+  }
+  return null;
+}
+
+function validateWorkspaceArgPath(
+  value: string,
+  scope: { cwd: string; workspaceRoot: string } | undefined,
+  source: string,
+): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return `Test command ${source} must not be empty.`;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) {
+    return `Test command ${source} must be a workspace path, not a URL.`;
+  }
+  if (!scope) return null;
+  const validation = resolveWorkspacePath(trimmed, scope.cwd, scope.workspaceRoot);
+  if (validation.valid) return null;
+  return `Test command ${source} escapes workspace root: ${validation.resolved}`;
+}
+
+function isPathLikeArg(arg: string): boolean {
+  if (arg.startsWith("-")) return false;
+  return arg.startsWith("/")
+    || arg.startsWith("./")
+    || arg.startsWith("../")
+    || arg === ".."
+    || arg.startsWith("~/")
+    || arg.includes("/")
+    || /\.(?:[cm]?[jt]sx?|json)$/.test(arg);
+}
+
 export class TestRunnerTool implements ITool<TestRunnerInput, TestRunnerOutput> {
   readonly metadata: ToolMetadata = {
     name: "test-runner",
@@ -133,7 +239,32 @@ export class TestRunnerTool implements ITool<TestRunnerInput, TestRunnerOutput> 
 
   async call(input: TestRunnerInput, context: ToolCallContext): Promise<ToolResult> {
     const startTime = Date.now();
-    const cwd = input.cwd ?? context.cwd;
+    const cwdValidation = resolveWorkspaceCwd(input.cwd, context);
+    if (!cwdValidation.valid) {
+      return {
+        success: false,
+        data: { passed: 0, failed: 0, skipped: 0, total: 0, success: false, rawOutput: "" },
+        summary: `Test runner blocked: ${cwdValidation.error ?? "Invalid cwd"}`,
+        error: cwdValidation.error ?? "Invalid cwd",
+        execution: { status: "not_executed", reason: "policy_blocked", message: cwdValidation.error ?? "Invalid cwd" },
+        durationMs: Date.now() - startTime,
+      };
+    }
+    const commandError = validateTestCommand(input, {
+      cwd: cwdValidation.resolved,
+      workspaceRoot: cwdValidation.workspaceRoot,
+    });
+    if (commandError) {
+      return {
+        success: false,
+        data: { passed: 0, failed: 0, skipped: 0, total: 0, success: false, rawOutput: "" },
+        summary: `Test runner blocked: ${commandError}`,
+        error: commandError,
+        execution: { status: "not_executed", reason: "policy_blocked", message: commandError },
+        durationMs: Date.now() - startTime,
+      };
+    }
+    const cwd = cwdValidation.resolved;
     const { cmd, args } = buildTestCommand(input.command, input.pattern);
 
     try {
@@ -180,13 +311,21 @@ export class TestRunnerTool implements ITool<TestRunnerInput, TestRunnerOutput> 
     }
   }
 
-  async checkPermissions(input: TestRunnerInput): Promise<PermissionCheckResult> {
-    // Only allow safe test runners — validate first token to prevent bypass (e.g., "jest; rm -rf /")
-    const ALLOWED_BINARIES = ["npx", "npm", "node", "mocha", "jest", "vitest"];
-    const parts = input.command.trim().split(/\s+/);
-    const allowed = ALLOWED_BINARIES.includes(parts[0]);
-    if (!allowed) {
-      return { status: "needs_approval", reason: `Custom test command requires approval: ${input.command.trim()}` };
+  async checkPermissions(input: TestRunnerInput, context?: ToolCallContext): Promise<PermissionCheckResult> {
+    let scope: { cwd: string; workspaceRoot: string } | undefined;
+    if (context) {
+      const cwdValidation = resolveWorkspaceCwd(input.cwd, context);
+      if (!cwdValidation.valid) {
+        return { status: "denied", reason: cwdValidation.error ?? "Invalid cwd", executionReason: "policy_blocked" };
+      }
+      scope = {
+        cwd: cwdValidation.resolved,
+        workspaceRoot: cwdValidation.workspaceRoot,
+      };
+    }
+    const commandError = validateTestCommand(input, scope);
+    if (commandError) {
+      return { status: "denied", reason: commandError, executionReason: "policy_blocked" };
     }
     return { status: "allowed" };
   }

--- a/src/tools/system/TestRunnerTool/__tests__/TestRunnerTool.test.ts
+++ b/src/tools/system/TestRunnerTool/__tests__/TestRunnerTool.test.ts
@@ -118,9 +118,14 @@ describe("TestRunnerTool", () => {
       expect(result.status).toBe("allowed");
     });
 
-    it("needs_approval for unknown command", async () => {
+    it("denies unknown command", async () => {
       const result = await tool.checkPermissions({ command: "bash run-tests.sh", timeout: 60000 });
-      expect(result.status).toBe("needs_approval");
+      expect(result.status).toBe("denied");
+    });
+
+    it("denies non-test npm commands", async () => {
+      const result = await tool.checkPermissions({ command: "npm install", timeout: 60000 });
+      expect(result.status).toBe("denied");
     });
   });
 
@@ -269,11 +274,11 @@ describe("TestRunnerTool", () => {
       const spy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValueOnce({
         stdout: VITEST_PASS, stderr: "", exitCode: 0,
       });
-      await tool.call({ command: "npx vitest run", cwd: "/custom/path", timeout: 60000 }, makeContext("/other"));
+      await tool.call({ command: "npx vitest run", cwd: "/tmp/custom/path", timeout: 60000 }, makeContext("/tmp"));
       expect(spy).toHaveBeenCalledWith(
         expect.anything(),
         expect.anything(),
-        expect.objectContaining({ cwd: "/custom/path" })
+        expect.objectContaining({ cwd: expect.stringMatching(/\/tmp\/custom\/path$/) })
       );
     });
   });

--- a/src/tools/workspace-scope.ts
+++ b/src/tools/workspace-scope.ts
@@ -1,0 +1,97 @@
+import { realpathSync } from "node:fs";
+import { basename, dirname, isAbsolute, relative, resolve } from "node:path";
+import type { ToolCallContext } from "./types.js";
+import { expandTildePath } from "./fs/FileValidationTool/protected-path-policy.js";
+
+export interface WorkspaceScopeValidationResult {
+  valid: boolean;
+  resolved: string;
+  workspaceRoot: string;
+  error?: string;
+}
+
+export function resolveWorkspaceCwd(
+  requestedCwd: string | undefined,
+  context: ToolCallContext,
+): WorkspaceScopeValidationResult {
+  const baseCwd = canonicalPath(context.cwd);
+  const workspaceRoot = canonicalPath(context.executionPolicy?.workspaceRoot ?? baseCwd);
+  const rawCwd = requestedCwd?.trim() ? expandTildePath(requestedCwd.trim()) : baseCwd;
+  const resolved = canonicalPath(isAbsolute(rawCwd) ? rawCwd : resolve(baseCwd, rawCwd));
+
+  if (!context.executionPolicy) {
+    return {
+      valid: true,
+      resolved,
+      workspaceRoot,
+    };
+  }
+
+  if (!isInsideOrEqual(resolved, workspaceRoot)) {
+    return {
+      valid: false,
+      resolved,
+      workspaceRoot,
+      error: `cwd escapes workspace root: ${resolved}`,
+    };
+  }
+
+  return {
+    valid: true,
+    resolved,
+    workspaceRoot,
+  };
+}
+
+export function isInsideOrEqual(candidate: string, root: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+export function resolveWorkspacePath(
+  requestedPath: string,
+  cwd: string,
+  workspaceRoot: string,
+): WorkspaceScopeValidationResult {
+  const root = canonicalPath(workspaceRoot);
+  const baseCwd = canonicalPath(cwd);
+  const rawPath = expandTildePath(requestedPath.trim());
+  const resolved = canonicalPath(isAbsolute(rawPath) ? rawPath : resolve(baseCwd, rawPath));
+
+  if (!isInsideOrEqual(resolved, root)) {
+    return {
+      valid: false,
+      resolved,
+      workspaceRoot: root,
+      error: `path escapes workspace root: ${resolved}`,
+    };
+  }
+
+  return {
+    valid: true,
+    resolved,
+    workspaceRoot: root,
+  };
+}
+
+function canonicalPath(value: string): string {
+  const expanded = expandTildePath(value);
+  const resolved = resolve(expanded);
+  try {
+    return realpathSync(resolved);
+  } catch {
+    const missingParts: string[] = [];
+    let current = resolved;
+    while (true) {
+      const parent = dirname(current);
+      if (parent === current) return resolved;
+      missingParts.unshift(basename(current));
+      current = parent;
+      try {
+        return resolve(realpathSync(current), ...missingParts);
+      } catch {
+        continue;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add shared workspace cwd/path validation for typed tool calls
- enforce host policy for shell_command, apply_patch, and test-runner before execution
- preserve typed tool observations in agent timeline display items
- add regression coverage for safe shell, denied shell, approval-denied patch, protected/rename-only patch blocks, test arg validation, and typed observation projection

## Verification
- npm exec vitest run src/tools/__tests__/workspace-actions.test.ts src/tools/__tests__/execution-orchestrator.test.ts src/tools/system/TestRunnerTool/__tests__/TestRunnerTool.test.ts src/tools/fs/ApplyPatchTool/__tests__/ApplyPatchTool.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts src/interface/chat/__tests__/chat-runner-tools.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/orchestrator/execution/agent-loop/__tests__/response-item-tool-router.test.ts
- npm run typecheck
- npm run lint:boundaries (0 errors, existing warnings only)
- npm run test:changed
- git diff --check

Closes #1115