### PR TITLE
feat(display): normalize gateway chat output

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -3,6 +3,7 @@ import { applyChatEventToMessages } from "../chat-event-state.js";
 import { ChatRunnerEventBridge } from "../chat-runner-event-bridge.js";
 import type { ChatEvent } from "../chat-events.js";
 import { classifyFailureRecovery } from "../failure-recovery.js";
+import type { AgentLoopEvent } from "../../../orchestrator/execution/agent-loop/agent-loop-events.js";
 
 describe("applyChatEventToMessages", () => {
   it("keeps activity as one updatable row per turn", () => {
@@ -663,6 +664,55 @@ describe("applyChatEventToMessages", () => {
 
     expect(messages.map((message) => message.text)).toContain("Started shell_command: {\"command\":\"pwd\"}");
     expect(messages.map((message) => message.text)).toContain("Done");
+  });
+
+  it("renders denied typed tool observations from the production bridge path", async () => {
+    const events: ChatEvent[] = [];
+    const bridge = new ChatRunnerEventBridge(() => (event) => {
+      events.push(event);
+    });
+    const sink = bridge.createAgentLoopEventSink({ runId: "run-1", turnId: "turn-1" });
+    const base = {
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "agent-turn-1",
+      goalId: "goal-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+    };
+
+    await sink.emit({
+      ...base,
+      type: "tool_observation",
+      eventId: "observation-denied-1",
+      observation: {
+        type: "tool_observation",
+        callId: "call-denied",
+        toolName: "apply_patch",
+        arguments: { path: "src/example.ts" },
+        state: "denied",
+        success: false,
+        execution: {
+          status: "not_executed",
+          reason: "approval_denied",
+          message: "Write access was denied.",
+        },
+        durationMs: 7,
+        output: {
+          content: "TOOL NOT EXECUTED (approval_denied): Write access was denied.",
+        },
+        activityCategory: "file_modify",
+      },
+    } as AgentLoopEvent);
+
+    const messages = events.reduce(
+      (current, event) => applyChatEventToMessages(current, event, 20),
+      [] as ReturnType<typeof applyChatEventToMessages>
+    );
+
+    expect(messages.map((message) => message.text)).toEqual([
+      "Observed apply_patch (denied): TOOL NOT EXECUTED (approval_denied): Write access was denied.",
+    ]);
+    expect(messages[0]!.text).not.toContain("\"observation\"");
   });
 
   it("removes transient activity when assistant final arrives", () => {

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
@@ -127,6 +127,7 @@ describe("agent timeline activity summaries", () => {
 
     expect(item).toMatchObject({
       kind: "tool_observation",
+      visibility: "debug",
       callId: "call-1",
       toolName: "shell_command",
       observation: {
@@ -135,6 +136,43 @@ describe("agent timeline activity summaries", () => {
         execution: { status: "executed" },
         output: {
           data: { stdout: "ok\n", stderr: "", exitCode: 0 },
+        },
+      },
+    });
+  });
+
+  it("makes denied typed tool observations user visible without relying on text matching", () => {
+    const item = projectAgentLoopEventToTimeline(baseEvent({
+      type: "tool_observation",
+      eventId: "observation-denied-1",
+      observation: {
+        type: "tool_observation",
+        callId: "call-denied",
+        toolName: "apply_patch",
+        arguments: { path: "src/example.ts" },
+        state: "denied",
+        success: false,
+        execution: {
+          status: "not_executed",
+          reason: "approval_denied",
+          message: "Write access was denied.",
+        },
+        durationMs: 5,
+        output: {
+          content: "TOOL NOT EXECUTED (approval_denied): Write access was denied.",
+        },
+        activityCategory: "file_modify",
+      },
+    }));
+
+    expect(item).toMatchObject({
+      kind: "tool_observation",
+      visibility: "user",
+      state: "denied",
+      observation: {
+        execution: {
+          status: "not_executed",
+          reason: "approval_denied",
         },
       },
     });

--- a/src/orchestrator/execution/agent-loop/agent-timeline.ts
+++ b/src/orchestrator/execution/agent-loop/agent-timeline.ts
@@ -212,7 +212,7 @@ export function projectAgentLoopEventToTimeline(event: AgentLoopEvent): AgentTim
       return {
         ...base,
         kind: "tool_observation",
-        visibility: "debug",
+        visibility: isUserVisibleToolObservation(event.observation) ? "user" : "debug",
         callId: event.observation.callId,
         toolName: event.observation.toolName,
         state: event.observation.state,
@@ -375,6 +375,10 @@ function stringField(input: Record<string, unknown> | null, field: string): stri
 
 function firstCommandToken(command: string): string {
   return command.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? "";
+}
+
+function isUserVisibleToolObservation(observation: AgentLoopToolObservation): boolean {
+  return observation.execution?.status === "not_executed" || observation.state === "denied" || observation.state === "blocked";
 }
 
 const ACTIVITY_SUMMARY_ORDER: AgentTimelineActivityKind[] = [

--- a/src/orchestrator/execution/agent-loop/chat-display-output.ts
+++ b/src/orchestrator/execution/agent-loop/chat-display-output.ts
@@ -14,6 +14,7 @@ export interface ChatDisplayFinalAnswer {
 
 export interface ChatDisplayOutput {
   status?: unknown;
+  text?: unknown;
   message?: unknown;
   answer?: unknown;
   evidence?: unknown;
@@ -48,11 +49,12 @@ function formatChatOutput(output?: ChatDisplayOutput | null): string | null {
   const outputBlockers = stringArray(output.blockers);
   const summary = firstDisplayText([
     finalAnswer ? displayTextFromValue(finalAnswer.summary) : null,
+    displayTextFromValue(output.text),
     displayTextFromValue(output.message),
     displayTextFromValue(output.answer),
   ]);
   const sections: string[] = [];
-  const handledKeys = new Set<string>(["status", "message", "answer", "evidence", "blockers", "finalAnswer"]);
+  const handledKeys = new Set<string>(["status", "text", "message", "answer", "evidence", "blockers", "finalAnswer"]);
 
   if (summary) {
     sections.push(summary);
@@ -125,6 +127,7 @@ function displayTextFromValue(value: unknown): string | null {
 
   return firstDisplayText([
     displayTextFromValue(parsed.message),
+    displayTextFromValue(parsed.text),
     displayTextFromValue(parsed.answer),
     isRecord(parsed.finalAnswer) ? displayTextFromValue(parsed.finalAnswer.summary) : null,
   ]);

--- a/src/runtime/gateway/__tests__/chat-session-dispatch.test.ts
+++ b/src/runtime/gateway/__tests__/chat-session-dispatch.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { dispatchGatewayChatInput } from "../chat-session-dispatch.js";
+import { renderGatewayAgentTimelineItem } from "../chat-event-rendering.js";
+import {
+  clearRegisteredGatewayChatSessionPort,
+  registerGatewayChatSessionPort,
+} from "../chat-session-port.js";
+
+const baseInput = {
+  text: "status?",
+  platform: "telegram",
+  conversation_id: "chat-1",
+  sender_id: "user-1",
+};
+
+afterEach(() => {
+  clearRegisteredGatewayChatSessionPort();
+});
+
+describe("dispatchGatewayChatInput display contract", () => {
+  it("projects answer-shaped fallback strings to gateway display text", async () => {
+    registerGatewayChatSessionPort(async () => ({
+      processIncomingMessage: async () => JSON.stringify({
+        answer: "Gateway **Markdown** answer.",
+      }),
+    }));
+
+    const result = await dispatchGatewayChatInput(baseInput);
+
+    expect(result).toBe("Gateway **Markdown** answer.");
+    expect(result).not.toContain("\"answer\"");
+  });
+
+  it("preserves plain text fallback objects from gateway session ports", async () => {
+    registerGatewayChatSessionPort(async () => ({
+      processIncomingMessage: async () => ({ text: "Plain gateway reply." }),
+    }));
+
+    await expect(dispatchGatewayChatInput(baseInput)).resolves.toBe("Plain gateway reply.");
+  });
+
+  it("formats structured fallback objects without exposing raw schema payloads", async () => {
+    registerGatewayChatSessionPort(async () => ({
+      processIncomingMessage: async () => ({
+        status: "done",
+        message: "",
+        finalAnswer: {
+          summary: "Runtime evidence is current.",
+          sections: [{ title: "Checks", bullets: ["Read the active run record."] }],
+          evidence: ["run:active matched the selected session"],
+          blockers: [],
+          nextActions: ["Continue monitoring the run."],
+        },
+      }),
+    }));
+
+    const result = await dispatchGatewayChatInput(baseInput);
+
+    expect(result).toContain("Runtime evidence is current.");
+    expect(result).toContain("### Checks");
+    expect(result).toContain("### Evidence");
+    expect(result).toContain("### Next steps");
+    expect(result).not.toContain("\"finalAnswer\"");
+  });
+
+  it("does not invent display text for unwrappable manager objects", async () => {
+    registerGatewayChatSessionPort(async () => ({
+      processIncomingMessage: async () => ({ internal_payload: { raw: true } }),
+    }));
+
+    await expect(dispatchGatewayChatInput(baseInput)).resolves.toBeNull();
+  });
+
+  it("renders denied typed tool observations as gateway display text", () => {
+    const result = renderGatewayAgentTimelineItem({
+      kind: "tool_observation",
+      toolName: "apply_patch",
+      state: "denied",
+      outputPreview: "TOOL NOT EXECUTED (approval_denied): write access was denied.",
+    });
+
+    expect(result).toBe("Observed apply_patch (denied): TOOL NOT EXECUTED (approval_denied): write access was denied.");
+    expect(result).not.toContain("\"observation\"");
+  });
+});

--- a/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
@@ -300,6 +300,28 @@ describe("TelegramGatewayAdapter", () => {
         isDestructive: false,
       });
       await emit({
+        type: "tool_observation",
+        eventId: "observation-denied-1",
+        observation: {
+          type: "tool_observation",
+          callId: "call-2",
+          toolName: "shell_command",
+          arguments: { command: "npm run release" },
+          state: "denied",
+          success: false,
+          execution: {
+            status: "not_executed",
+            reason: "approval_denied",
+            message: "Operator denied release execution.",
+          },
+          durationMs: 3,
+          output: {
+            content: "TOOL NOT EXECUTED (approval_denied): Operator denied release execution.",
+          },
+          activityCategory: "command",
+        },
+      });
+      await emit({
         type: "context_compaction",
         eventId: "compaction-1",
         phase: "mid_turn",
@@ -327,6 +349,7 @@ describe("TelegramGatewayAdapter", () => {
         `Started shell_command: ${JSON.stringify({ command: "rg Timeline src/interface/chat" })}`,
         "Finished shell_command: src/interface/chat/chat-events.ts",
         "Approval requested for shell_command: run a write command",
+        "Observed shell_command (denied): TOOL NOT EXECUTED (approval_denied): Operator denied release execution.",
         "Compacted context (mid_turn, context_limit): 12 -> 4.",
         "searched 1 search, requested 1 approval",
       ]));

--- a/src/runtime/gateway/chat-event-rendering.ts
+++ b/src/runtime/gateway/chat-event-rendering.ts
@@ -10,7 +10,7 @@ interface FailureRecoveryGuidanceLike {
 }
 
 interface AgentTimelineItemLike {
-  kind: "lifecycle" | "turn_context" | "model_request" | "assistant_message" | "tool" | "plan" | "approval" | "compaction" | "activity_summary" | "final" | "stopped";
+  kind: "lifecycle" | "turn_context" | "model_request" | "assistant_message" | "tool" | "tool_observation" | "plan" | "approval" | "compaction" | "activity_summary" | "final" | "stopped";
   status?: string;
   restoredMessages?: number;
   fromUpdatedAt?: string;
@@ -22,6 +22,7 @@ interface AgentTimelineItemLike {
   outputPreview?: string;
   success?: boolean;
   toolName?: string;
+  state?: string;
   summary?: string;
   reason?: string;
   phase?: string;
@@ -52,6 +53,8 @@ export function renderGatewayAgentTimelineItem(item: AgentTimelineItemLike): str
       const label = item.status === "started" ? "Started" : item.success ? "Finished" : "Failed";
       return detail ? `${label} ${item.toolName ?? "tool"}: ${redactSetupSecrets(detail)}` : `${label} ${item.toolName ?? "tool"}.`;
     }
+    case "tool_observation":
+      return `Observed ${item.toolName ?? "tool"} (${item.state ?? "unknown"}): ${redactSetupSecrets(item.outputPreview ?? "")}`;
     case "plan":
       return `Plan changed: ${redactSetupSecrets(item.summary ?? "")}`;
     case "approval":

--- a/src/runtime/gateway/chat-session-dispatch.ts
+++ b/src/runtime/gateway/chat-session-dispatch.ts
@@ -2,6 +2,7 @@ import {
   getRegisteredGatewayChatSessionPort,
   type GatewayChatDispatchInput,
 } from "./chat-session-port.js";
+import { normalizeAssistantDisplayText } from "../../orchestrator/execution/agent-loop/chat-display-output.js";
 
 export type { GatewayChatDispatchInput } from "./chat-session-port.js";
 
@@ -33,17 +34,10 @@ export async function dispatchGatewayChatInput(
 
 function normalizeManagerResult(result: unknown): string | null {
   if (typeof result === "string") {
-    const trimmed = result.trim();
-    return trimmed.length > 0 ? trimmed : null;
+    return normalizeAssistantDisplayText({ finalText: result, output: null });
   }
   if (typeof result === "object" && result !== null) {
-    const record = result as Record<string, unknown>;
-    for (const key of ["text", "message"] as const) {
-      const value = record[key];
-      if (typeof value === "string" && value.trim().length > 0) {
-        return value;
-      }
-    }
+    return normalizeAssistantDisplayText({ output: result as Record<string, unknown> });
   }
   return null;
 }

--- a/src/runtime/gateway/telegram-gateway-adapter.ts
+++ b/src/runtime/gateway/telegram-gateway-adapter.ts
@@ -538,7 +538,7 @@ type GatewayChatEvent =
       type: "agent_timeline";
       item: {
         visibility?: string;
-        kind: "lifecycle" | "turn_context" | "model_request" | "assistant_message" | "tool" | "plan" | "approval" | "compaction" | "activity_summary" | "final" | "stopped";
+        kind: "lifecycle" | "turn_context" | "model_request" | "assistant_message" | "tool" | "tool_observation" | "plan" | "approval" | "compaction" | "activity_summary" | "final" | "stopped";
         status?: string;
         restoredMessages?: number;
         fromUpdatedAt?: string;
@@ -550,6 +550,7 @@ type GatewayChatEvent =
         outputPreview?: string;
         success?: boolean;
         toolName?: string;
+        state?: string;
         summary?: string;
         reason?: string;
         phase?: string;


### PR DESCRIPTION
## Summary

- normalize gateway fallback chat results through the shared display-first projection
- preserve plain `text` fallback objects while unwrapping answer/message/finalAnswer schema-shaped payloads
- make denied or non-executed typed tool observations user-visible and render them in chat/TUI/gateway timeline paths

## Validation

- `npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts src/interface/chat/__tests__/chat-event-state.test.ts --reporter verbose`
- `npx vitest run --config vitest.config.ts src/runtime/gateway/__tests__/chat-session-dispatch.test.ts src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts --reporter verbose`
- `npx vitest run --config vitest.config.ts src/interface/tui/__tests__/app.test.ts -t "runtime evidence" --reporter verbose`
- `npm run typecheck`
- `npm run lint:boundaries` (0 errors; existing warnings only)
- `npm run test:changed`

Closes #1118.
