### PR TITLE
Fix mechanical verification workspace cwd

### DIFF
--- a/src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { z } from "zod";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { SessionManager } from "../session-manager.js";
@@ -17,6 +18,7 @@ import type {
 import type { ToolExecutor } from "../../../tools/executor.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { makeGoal } from "../../../../tests/helpers/fixtures.js";
 
 // ─── Spy LLM Client ───
 
@@ -383,6 +385,317 @@ describe("TaskLifecycle", async () => {
       expect(fallbackAdapterCalls).toBe(0);
       expect(codexCalls).toBe(1);
       expect(verification.verdict).toBe("pass");
+    });
+
+    it("runs cheap mechanical verification in the resolved non-git workspace", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const workspace = path.join(tmpDir, "non-git-workspace");
+      const fakeBin = path.join(tmpDir, "bin");
+      fs.mkdirSync(workspace, { recursive: true });
+      fs.mkdirSync(fakeBin, { recursive: true });
+      fs.writeFileSync(path.join(workspace, "marker.txt"), "expected marker\n", "utf-8");
+      const fakeRg = path.join(fakeBin, "rg");
+      fs.writeFileSync(
+        fakeRg,
+        [
+          "#!/bin/sh",
+          "pwd > rg.cwd",
+          "if [ \"$1\" = \"-n\" ]; then shift; fi",
+          "grep -n \"$1\" \"$2\" >/dev/null",
+          "",
+        ].join("\n"),
+        "utf-8"
+      );
+      fs.chmodSync(fakeRg, 0o755);
+      const previousPath = process.env.PATH;
+      process.env.PATH = `${fakeBin}${path.delimiter}${previousPath ?? ""}`;
+
+      const registry = new AdapterRegistry();
+      let adapterCalls = 0;
+      registry.register({
+        adapterType: "openai_codex_cli",
+        async execute() {
+          adapterCalls += 1;
+          return {
+            success: false,
+            output: "",
+            error: "cheap command should run locally",
+            exit_code: 1,
+            elapsed_ms: 1,
+            stopped_reason: "error",
+          };
+        },
+      });
+      const lifecycle = createLifecycle(llm, { adapterRegistry: registry });
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Workspace marker exists and contains expected text",
+            verification_method: "test -f marker.txt && rg -n expected marker.txt",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      try {
+        await stateManager.saveGoal(makeGoal({
+          id: task.goal_id,
+          constraints: [`workspace_path:${workspace}`],
+        }));
+
+        const verification = await lifecycle.verifyTask(
+          task,
+          makeExecutionResult(),
+          "openai_codex_cli"
+        );
+
+        expect(adapterCalls).toBe(0);
+        expect(verification.verdict).toBe("pass");
+        expect(fs.realpathSync(fs.readFileSync(path.join(workspace, "rg.cwd"), "utf-8").trim())).toBe(
+          fs.realpathSync(workspace)
+        );
+      } finally {
+        process.env.PATH = previousPath;
+      }
+    });
+
+    it("keeps shell control operators on the adapter path while preserving workspace cwd", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const workspace = path.join(tmpDir, "non-git-workspace-control");
+      fs.mkdirSync(workspace, { recursive: true });
+      fs.writeFileSync(path.join(workspace, "marker.txt"), "expected marker\n", "utf-8");
+
+      const registry = new AdapterRegistry();
+      let adapterCwd: string | undefined;
+      registry.register({
+        adapterType: "openai_codex_cli",
+        async execute(agentTask) {
+          adapterCwd = agentTask.cwd;
+          return {
+            success: true,
+            output: "adapter handled control operator command",
+            error: null,
+            exit_code: 0,
+            elapsed_ms: 1,
+            stopped_reason: "completed",
+          };
+        },
+      });
+      const lifecycle = createLifecycle(llm, { adapterRegistry: registry });
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Workspace marker exists",
+            verification_method: "test -f marker.txt & touch should-not-run",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      await stateManager.saveGoal(makeGoal({
+        id: task.goal_id,
+        constraints: [`workspace_path:${workspace}`],
+      }));
+
+      const verification = await lifecycle.verifyTask(
+        task,
+        makeExecutionResult(),
+        "openai_codex_cli"
+      );
+
+      expect(verification.verdict).toBe("pass");
+      expect(adapterCwd).toBe(workspace);
+      expect(fs.existsSync(path.join(workspace, "should-not-run"))).toBe(false);
+    });
+
+    it("keeps rg execution options on the adapter path while preserving workspace cwd", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const workspace = path.join(tmpDir, "non-git-workspace-rg-pre");
+      fs.mkdirSync(workspace, { recursive: true });
+      fs.writeFileSync(path.join(workspace, "marker.txt"), "expected marker\n", "utf-8");
+      const preprocessor = path.join(workspace, "side-effect-preprocessor.sh");
+      fs.writeFileSync(
+        preprocessor,
+        [
+          "#!/bin/sh",
+          "touch rg-pre-side-effect",
+          "cat \"$1\"",
+          "",
+        ].join("\n"),
+        "utf-8"
+      );
+      fs.chmodSync(preprocessor, 0o755);
+
+      const registry = new AdapterRegistry();
+      let adapterCwd: string | undefined;
+      registry.register({
+        adapterType: "openai_codex_cli",
+        async execute(agentTask) {
+          adapterCwd = agentTask.cwd;
+          return {
+            success: true,
+            output: "adapter handled rg option command",
+            error: null,
+            exit_code: 0,
+            elapsed_ms: 1,
+            stopped_reason: "completed",
+          };
+        },
+      });
+      const lifecycle = createLifecycle(llm, { adapterRegistry: registry });
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Workspace marker contains expected text",
+            verification_method: "rg --pre ./side-effect-preprocessor.sh expected marker.txt",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      await stateManager.saveGoal(makeGoal({
+        id: task.goal_id,
+        constraints: [`workspace_path:${workspace}`],
+      }));
+
+      const verification = await lifecycle.verifyTask(
+        task,
+        makeExecutionResult(),
+        "openai_codex_cli"
+      );
+
+      expect(verification.verdict).toBe("pass");
+      expect(adapterCwd).toBe(workspace);
+      expect(fs.existsSync(path.join(workspace, "rg-pre-side-effect"))).toBe(false);
+    });
+
+    it("keeps escaped path operands on the adapter path while preserving workspace cwd", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const workspace = path.join(tmpDir, "non-git-workspace-path-scope");
+      const outside = path.join(tmpDir, "outside-workspace");
+      fs.mkdirSync(workspace, { recursive: true });
+      fs.mkdirSync(outside, { recursive: true });
+      fs.writeFileSync(path.join(outside, "marker.txt"), "expected marker\n", "utf-8");
+
+      const registry = new AdapterRegistry();
+      let adapterCwd: string | undefined;
+      registry.register({
+        adapterType: "openai_codex_cli",
+        async execute(agentTask) {
+          adapterCwd = agentTask.cwd;
+          return {
+            success: true,
+            output: "adapter handled escaped path command",
+            error: null,
+            exit_code: 0,
+            elapsed_ms: 1,
+            stopped_reason: "completed",
+          };
+        },
+      });
+      const lifecycle = createLifecycle(llm, { adapterRegistry: registry });
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Workspace marker contains expected text",
+            verification_method: "rg -n expected ../outside-workspace/marker.txt",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      await stateManager.saveGoal(makeGoal({
+        id: task.goal_id,
+        constraints: [`workspace_path:${workspace}`],
+      }));
+
+      const verification = await lifecycle.verifyTask(
+        task,
+        makeExecutionResult(),
+        "openai_codex_cli"
+      );
+
+      expect(verification.verdict).toBe("pass");
+      expect(adapterCwd).toBe(workspace);
+    });
+
+    it("still runs cheap local failures before assuming pass when adapter is unavailable", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const workspace = path.join(tmpDir, "non-git-workspace-no-adapter");
+      fs.mkdirSync(workspace, { recursive: true });
+      const lifecycle = createLifecycle(llm);
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Full test suite passes",
+            verification_method: "npm test",
+            is_blocking: true,
+          },
+          {
+            description: "Workspace marker exists",
+            verification_method: "test -f missing-marker.txt",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      await stateManager.saveGoal(makeGoal({
+        id: task.goal_id,
+        constraints: [`workspace_path:${workspace}`],
+      }));
+
+      const verification = await lifecycle.verifyTask(task, makeExecutionResult());
+
+      expect(verification.verdict).toBe("fail");
+      expect(verification.evidence[0]?.description).toContain("missing-marker.txt");
+    });
+
+    it("keeps glob path operands on the adapter path while preserving workspace cwd", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const workspace = path.join(tmpDir, "non-git-workspace-glob");
+      fs.mkdirSync(path.join(workspace, "reports"), { recursive: true });
+      fs.writeFileSync(path.join(workspace, "reports", "result.md"), "done\n", "utf-8");
+
+      const registry = new AdapterRegistry();
+      let adapterCwd: string | undefined;
+      registry.register({
+        adapterType: "openai_codex_cli",
+        async execute(agentTask) {
+          adapterCwd = agentTask.cwd;
+          return {
+            success: true,
+            output: "adapter handled glob command",
+            error: null,
+            exit_code: 0,
+            elapsed_ms: 1,
+            stopped_reason: "completed",
+          };
+        },
+      });
+      const lifecycle = createLifecycle(llm, { adapterRegistry: registry });
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Report exists",
+            verification_method: "ls reports/*.md",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      await stateManager.saveGoal(makeGoal({
+        id: task.goal_id,
+        constraints: [`workspace_path:${workspace}`],
+      }));
+
+      const verification = await lifecycle.verifyTask(
+        task,
+        makeExecutionResult(),
+        "openai_codex_cli"
+      );
+
+      expect(verification.verdict).toBe("pass");
+      expect(adapterCwd).toBe(workspace);
     });
 
     it("runs all mechanical blocking criteria instead of passing on the first match", async () => {

--- a/src/orchestrator/execution/task/task-verifier-rules.ts
+++ b/src/orchestrator/execution/task/task-verifier-rules.ts
@@ -6,6 +6,7 @@ import type { AgentTask, AgentResult, IAdapter } from "../adapter-layer.js";
 import type { VerifierDeps } from "./task-verifier-types.js";
 import { syncTaskOutcomeSummary } from "./task-outcome-ledger.js";
 import { resolveTaskWorkspacePath } from "./task-workspace.js";
+import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 
 // ─── runMechanicalVerification ───
 
@@ -55,8 +56,25 @@ export async function runMechanicalVerification(
     return Number(rightIsTestCommand) - Number(leftIsTestCommand);
   });
 
+  const verificationCwd = await resolveTaskWorkspacePath({
+    stateManager: deps.stateManager,
+    task,
+  });
+  const verificationTimeoutMs = 30_000; // 30 seconds default for L1 mechanical checks
+  const commandPlans = verificationCommands.map((command) => ({
+    command,
+    directLocal: Boolean(verificationCwd && canRunAsCheapLocalVerification(command)),
+  }));
+  const needsAdapter = commandPlans.some((plan) => !plan.directLocal);
+
   // If no adapter registry is available, fall back to assumed pass (backward compat)
-  if (!deps.adapterRegistry) {
+  if (needsAdapter && !deps.adapterRegistry) {
+    const directFailure = await runDirectLocalPlansBeforeAdapterFallback(
+      commandPlans,
+      verificationCwd,
+      verificationTimeoutMs
+    );
+    if (directFailure) return directFailure;
     return {
       applicable: true,
       passed: true,
@@ -65,8 +83,14 @@ export async function runMechanicalVerification(
   }
 
   // Select the first available adapter from the registry for command execution
-  const availableAdapters = deps.adapterRegistry.listAdapters();
-  if (availableAdapters.length === 0) {
+  const availableAdapters = deps.adapterRegistry?.listAdapters() ?? [];
+  if (needsAdapter && availableAdapters.length === 0) {
+    const directFailure = await runDirectLocalPlansBeforeAdapterFallback(
+      commandPlans,
+      verificationCwd,
+      verificationTimeoutMs
+    );
+    if (directFailure) return directFailure;
     return {
       applicable: true,
       passed: true,
@@ -78,10 +102,16 @@ export async function runMechanicalVerification(
     deps.preferredAdapterType && availableAdapters.includes(deps.preferredAdapterType)
       ? deps.preferredAdapterType
       : availableAdapters[0]!;
-  let adapter: IAdapter;
+  let adapter: IAdapter | undefined;
   try {
-    adapter = deps.adapterRegistry.getAdapter(adapterType);
+    adapter = needsAdapter ? deps.adapterRegistry?.getAdapter(adapterType) : undefined;
   } catch {
+    const directFailure = await runDirectLocalPlansBeforeAdapterFallback(
+      commandPlans,
+      verificationCwd,
+      verificationTimeoutMs
+    );
+    if (directFailure) return directFailure;
     return {
       applicable: true,
       passed: true,
@@ -89,14 +119,37 @@ export async function runMechanicalVerification(
     };
   }
 
-  const verificationTimeoutMs = 30_000; // 30 seconds default for L1 mechanical checks
   const passedCommands: string[] = [];
 
-  for (const verificationCommand of verificationCommands) {
+  for (const plan of commandPlans) {
+    const verificationCommand = plan.command;
+    if (plan.directLocal && verificationCwd) {
+      const result = await runCheapLocalVerification(verificationCommand, verificationCwd, verificationTimeoutMs);
+      if (!result.passed) {
+        const detail = formatMechanicalCommandError(result.errorText);
+        return {
+          applicable: true,
+          passed: false,
+          description: `Mechanical verification failed after ${passedCommands.length}/${verificationCommands.length} command(s) (exit ${result.exitCode ?? "null"}): ${verificationCommand}${detail}`,
+        };
+      }
+      passedCommands.push(verificationCommand);
+      continue;
+    }
+
+    if (!adapter) {
+      return {
+        applicable: true,
+        passed: true,
+        description: `Mechanical verification criteria detected (${verificationCommands.length} command(s), adapter unavailable: assumed pass)`,
+      };
+    }
+
     const agentTask: AgentTask = {
       prompt: verificationCommand,
       timeout_ms: verificationTimeoutMs,
       adapter_type: adapterType,
+      ...(verificationCwd ? { cwd: verificationCwd } : {}),
     };
 
     let result: AgentResult;
@@ -136,6 +189,150 @@ export async function runMechanicalVerification(
     passed: true,
     description: `Mechanical verification passed (${passedCommands.length} command(s)): ${passedCommands.join("; ")}`,
   };
+}
+
+interface CheapLocalCommand {
+  cmd: "test" | "rg" | "grep" | "ls";
+  args: string[];
+}
+
+async function runDirectLocalPlansBeforeAdapterFallback(
+  commandPlans: Array<{ command: string; directLocal: boolean }>,
+  verificationCwd: string | undefined,
+  timeoutMs: number
+): Promise<{ applicable: true; passed: false; description: string } | null> {
+  if (!verificationCwd) return null;
+  const passedCommands: string[] = [];
+  for (const plan of commandPlans) {
+    if (!plan.directLocal) continue;
+    const result = await runCheapLocalVerification(plan.command, verificationCwd, timeoutMs);
+    if (!result.passed) {
+      const detail = formatMechanicalCommandError(result.errorText);
+      return {
+        applicable: true,
+        passed: false,
+        description: `Mechanical verification failed after ${passedCommands.length}/${commandPlans.length} command(s) (exit ${result.exitCode ?? "null"}): ${plan.command}${detail}`,
+      };
+    }
+    passedCommands.push(plan.command);
+  }
+  return null;
+}
+
+async function runCheapLocalVerification(
+  command: string,
+  cwd: string,
+  timeoutMs: number
+): Promise<{ passed: boolean; exitCode: number | null; errorText: string }> {
+  const parsed = parseCheapLocalVerification(command);
+  if (!parsed) {
+    return { passed: false, exitCode: null, errorText: "cheap local verification command was not parseable" };
+  }
+  for (const step of parsed) {
+    const result = await execFileNoThrow(step.cmd, step.args, { cwd, timeoutMs });
+    if (result.exitCode !== 0) {
+      return { passed: false, exitCode: result.exitCode, errorText: result.stderr || result.stdout };
+    }
+  }
+  return { passed: true, exitCode: 0, errorText: "" };
+}
+
+function canRunAsCheapLocalVerification(command: string): boolean {
+  return parseCheapLocalVerification(command) !== null;
+}
+
+function parseCheapLocalVerification(command: string): CheapLocalCommand[] | null {
+  const segments = command.split(/\s+&&\s+/).map((segment) => segment.trim()).filter(Boolean);
+  if (segments.length === 0) return null;
+
+  const parsed: CheapLocalCommand[] = [];
+  for (const segment of segments) {
+    if (hasDisallowedShellToken(segment)) return null;
+    const tokens = tokenizeCheapCommandSegment(segment);
+    if (!tokens || tokens.length === 0) return null;
+    const [cmd, ...args] = tokens;
+    if (!isCheapCommandName(cmd)) return null;
+    if (!areSafeCheapCommandArgs(cmd, args)) return null;
+    parsed.push({ cmd, args });
+  }
+  return parsed;
+}
+
+function tokenizeCheapCommandSegment(segment: string): string[] | null {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+  for (let index = 0; index < segment.length; index += 1) {
+    const char = segment[index]!;
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === "'" || char === "\"") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (quote) return null;
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+function isCheapCommandName(value: string | undefined): value is CheapLocalCommand["cmd"] {
+  return value === "test" || value === "rg" || value === "grep" || value === "ls";
+}
+
+function areSafeCheapCommandArgs(cmd: CheapLocalCommand["cmd"], args: string[]): boolean {
+  if (args.some((arg) => arg.includes("\0"))) return false;
+  if (cmd === "test") {
+    return args.length === 2 && ["-f", "-d", "-e", "-s"].includes(args[0]!) && isWorkspaceRelativeOperand(args[1]!);
+  }
+  if (cmd === "rg" || cmd === "grep") {
+    const allowedFlags = new Set(["-n", "--line-number", "-q", "--quiet", "-i", "--ignore-case", "-F", "--fixed-strings"]);
+    const positionalArgs: string[] = [];
+    for (const arg of args) {
+      if (arg.startsWith("-")) {
+        if (!allowedFlags.has(arg)) return false;
+        continue;
+      }
+      positionalArgs.push(arg);
+    }
+    const pathOperands = positionalArgs.slice(1);
+    return positionalArgs.length >= 2 && pathOperands.every(isWorkspaceRelativeOperand);
+  }
+  const allowedLsFlags = new Set(["-a", "-l", "-la", "-al"]);
+  return args.every((arg) =>
+    arg.startsWith("-") ? allowedLsFlags.has(arg) : isWorkspaceRelativeOperand(arg)
+  );
+}
+
+function isWorkspaceRelativeOperand(value: string): boolean {
+  if (!value || value.includes("\0") || path.isAbsolute(value)) return false;
+  if (/[*?[\]{}]/.test(value)) return false;
+  const segments = value.replace(/\\/g, "/").split("/");
+  return !segments.includes("..");
+}
+
+function hasDisallowedShellToken(segment: string): boolean {
+  return /(&|;|\|\|?|\$\(|`|[<>]|\n|\r)/.test(segment);
+}
+
+function formatMechanicalCommandError(output: string): string {
+  const trimmed = output.trim();
+  if (!trimmed) return "";
+  return ` — ${trimmed.slice(0, 500)}`;
 }
 
 // ─── P0 Guard 1: dimension_updates change magnitude limit (§3.2) ───


### PR DESCRIPTION
## Summary
- resolve task/goal workspace_path for mechanical verification and pass it to adapter-backed checks
- run safe cheap local test/rg/grep/ls checks directly in the resolved workspace with bounded execFile calls
- add non-git workspace regressions for cwd, shell-control fallback, rg --pre fallback, path escape fallback, glob fallback, and mixed adapter-unavailable behavior

Closes #1130

## Verification
- npx vitest run src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts
- npm run typecheck
- npm run lint:boundaries (0 errors; existing warnings)
- npm run test:changed