### PR TITLE
fix(runtime): resolve task workspace for adapter execution

### DIFF
--- a/src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts
+++ b/src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../../base/llm/provider-config.js", async (importOriginal) => {
   };
 });
 
-function makeTask(): Task {
+function makeTask(overrides: Partial<Task> = {}): Task {
   return {
     id: "task-1",
     goal_id: "goal-1",
@@ -45,6 +45,7 @@ function makeTask(): Task {
     timeout_at: null,
     heartbeat_at: null,
     created_at: new Date().toISOString(),
+    ...overrides,
   };
 }
 
@@ -96,5 +97,60 @@ describe("executeTask protected paths", () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain("build/output.txt");
+  });
+
+  it("uses task workspace_path before goal workspace_path for adapter cwd, diff capture, and protected-path checks", async () => {
+    const goalWorkspace = "/repo/goal-workspace";
+    const taskWorkspace = "/repo/task-workspace";
+    vi.mocked(stateManager.loadGoal).mockResolvedValue({ constraints: [`workspace_path:${goalWorkspace}`] } as never);
+    const execute = vi.fn().mockResolvedValue({
+      success: true,
+      output: "done",
+      error: null,
+      exit_code: 0,
+      elapsed_ms: 1,
+      stopped_reason: "completed",
+    } as AgentResult);
+    adapter = {
+      adapterType: "mock",
+      execute,
+    } as unknown as IAdapter;
+    execFileSyncFn = vi.fn().mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "diff" && args[1] === "--name-only") return "src/changed.ts\n.env";
+      if (args[0] === "ls-files") return "";
+      if (args[0] === "diff") return [
+        `diff --git a/${args[3]} b/${args[3]}`,
+        "@@ -1 +1 @@",
+        "-old",
+        "+new",
+      ].join("\n");
+      return "";
+    });
+
+    const result = await executeTask(
+      {
+        stateManager,
+        sessionManager,
+        execFileSyncFn,
+      },
+      makeTask({ constraints: [`workspace_path:${taskWorkspace}`] }),
+      adapter,
+    );
+
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({ cwd: taskWorkspace }));
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(".env");
+    expect(result.filesChangedPaths).toEqual(["src/changed.ts", ".env"]);
+    expect(result.fileDiffs).toEqual([
+      expect.objectContaining({
+        path: "src/changed.ts",
+        patch: expect.stringContaining("+new"),
+      }),
+      expect.objectContaining({
+        path: ".env",
+        patch: expect.stringContaining("+new"),
+      }),
+    ]);
+    expect(vi.mocked(execFileSyncFn).mock.calls.every((call) => call[2].cwd === taskWorkspace)).toBe(true);
   });
 });

--- a/src/orchestrator/execution/__tests__/task-lifecycle-execution-guards.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-execution-guards.test.ts
@@ -1,7 +1,7 @@
 /**
  * Focused coverage for executeTask guardrail behavior.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "node:fs";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { SessionManager } from "../session-manager.js";
@@ -12,6 +12,7 @@ import { TaskLifecycle } from "../task/task-lifecycle.js";
 import { GuardrailRunner } from "../../../platform/traits/guardrail-runner.js";
 import type { Task } from "../../../base/types/task.js";
 import type { IGuardrailHook } from "../../../base/types/guardrail.js";
+import type { ToolExecutor } from "../../../tools/executor.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 
@@ -86,6 +87,8 @@ describe("TaskLifecycle — executeTask guardrail behavior", () => {
     options?: {
       approvalFn?: (task: Task) => Promise<boolean>;
       guardrailRunner?: GuardrailRunner;
+      toolExecutor?: ToolExecutor;
+      execFileSyncFn?: (cmd: string, args: string[], opts: { cwd: string; encoding: "utf-8" }) => string;
     }
   ): TaskLifecycle {
     strategyManager = new StrategyManager(stateManager, llmClient);
@@ -96,7 +99,11 @@ describe("TaskLifecycle — executeTask guardrail behavior", () => {
       trustManager,
       strategyManager,
       stallDetector,
-      { healthCheckEnabled: false, execFileSyncFn: () => "some-file.ts", ...options }
+      {
+        healthCheckEnabled: false,
+        execFileSyncFn: options?.execFileSyncFn ?? (() => "some-file.ts"),
+        ...options,
+      }
     );
   }
 
@@ -149,6 +156,95 @@ describe("TaskLifecycle — executeTask guardrail behavior", () => {
 
     expect(result.success).toBe(true);
     expect(result.output).toBe("all good");
+  });
+
+  it("passes task workspace_path through the run-adapter caller path and diff capture", async () => {
+    const goalWorkspace = `${tmpDir}/goal-workspace`;
+    const taskWorkspace = `${tmpDir}/task-workspace`;
+    await stateManager.writeRaw("goals/goal-1/goal.json", {
+      id: "goal-1",
+      title: "Test goal",
+      dimensions: [],
+      constraints: [`workspace_path:${goalWorkspace}`],
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    });
+    const execute = vi.fn().mockResolvedValue({
+      success: true,
+      data: {
+        success: true,
+        output: "tool path done",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 7,
+        stopped_reason: "completed",
+      },
+      summary: "ok",
+      durationMs: 1,
+    });
+    const execFileSyncFn = vi.fn().mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "diff" && args[1] === "--name-only") return "src/changed.ts\n.env";
+      if (args[0] === "ls-files") return "";
+      if (args[0] === "diff") return "";
+      return "";
+    });
+    const lifecycle = createLifecycle(createMockLLMClient([]), {
+      toolExecutor: { execute } as unknown as ToolExecutor,
+      execFileSyncFn,
+    });
+
+    const result = await lifecycle.executeTask(
+      makeTask({ constraints: [`workspace_path:${taskWorkspace}`] }),
+      createMockAdapter("direct adapter should not run"),
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      "run-adapter",
+      expect.objectContaining({ cwd: taskWorkspace }),
+      expect.objectContaining({ cwd: taskWorkspace }),
+    );
+    expect(result.output).toContain("tool path done");
+    expect(result.success).toBe(false);
+    expect(result.error).toContain(".env");
+    expect(result.filesChangedPaths).toEqual(["src/changed.ts", ".env"]);
+    expect(execFileSyncFn.mock.calls.every((call) => call[2].cwd === taskWorkspace)).toBe(true);
+  });
+
+  it("fails closed without re-running the adapter when run-adapter returns truncated non-result data", async () => {
+    const execute = vi.fn().mockResolvedValue({
+      success: true,
+      data: "truncated adapter result",
+      summary: "truncated",
+      durationMs: 1,
+    });
+    const execFileSyncFn = vi.fn().mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "diff" && args[1] === "--name-only") return ".env";
+      if (args[0] === "ls-files") return "";
+      if (args[0] === "diff") return "";
+      return "";
+    });
+    const lifecycle = createLifecycle(createMockLLMClient([]), {
+      toolExecutor: { execute } as unknown as ToolExecutor,
+      execFileSyncFn,
+    });
+    const directExecute = vi.fn();
+    const adapter = {
+      adapterType: "mock",
+      execute: directExecute,
+    };
+
+    const result = await lifecycle.executeTask(
+      makeTask(),
+      adapter,
+    );
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(directExecute).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("invalid or truncated");
+    expect(result.error).toContain(".env");
+    expect(result.filesChangedPaths).toEqual([".env"]);
+    expect(execFileSyncFn).toHaveBeenCalled();
   });
 
   it("preserves elapsed_ms when the after_tool guardrail rejects", async () => {

--- a/src/orchestrator/execution/task/task-execution-helpers.ts
+++ b/src/orchestrator/execution/task/task-execution-helpers.ts
@@ -3,10 +3,13 @@ import type { Task } from "../../../base/types/task.js";
 import type { AdapterRegistry, AgentResult, IAdapter } from "../adapter-layer.js";
 import type { GuardrailRunner } from "../../../platform/traits/guardrail-runner.js";
 import type { ToolExecutor } from "../../../tools/executor.js";
-import { executeTask as executeTaskDirect } from "./task-executor.js";
+import {
+  applyPostExecutionDiffScopeChecks,
+  executeTask as executeTaskDirect,
+} from "./task-executor.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 import type { SessionManager } from "../session-manager.js";
-import { captureExecutionDiffArtifacts } from "./task-diff-capture.js";
+import { resolveTaskWorkspacePath } from "./task-workspace.js";
 
 interface ExecuteTaskWithGuardsParams {
   task: Task;
@@ -58,6 +61,7 @@ export async function executeTaskWithGuards(
 
   if (toolExecutor) {
     try {
+      const workspaceCwd = await resolveTaskWorkspacePath({ stateManager, task });
       let trustBalance = 0;
       try {
         await stateManager.loadGoal(task.goal_id);
@@ -65,7 +69,7 @@ export async function executeTaskWithGuards(
         // non-fatal, keep default trust balance
       }
       const toolCtx = {
-        cwd: process.cwd(),
+        cwd: workspaceCwd ?? process.cwd(),
         goalId: task.goal_id,
         trustBalance,
         preApproved: true,
@@ -77,23 +81,34 @@ export async function executeTaskWithGuards(
           adapter_id: adapter.adapterType,
           task_description: task.work_description ?? "",
           goal_id: task.goal_id,
+          ...(workspaceCwd !== undefined ? { cwd: workspaceCwd } : {}),
         },
         toolCtx
       );
-      if (toolResult.success && toolResult.data != null) {
-        const result = toolResult.data as AgentResult;
-        const goal = await stateManager.loadGoal(task.goal_id).catch(() => null);
-        const workspaceCwd = goal?.constraints.find((constraint) => constraint.startsWith("workspace_path:"))
-          ?.slice("workspace_path:".length);
-        const diffArtifacts = captureExecutionDiffArtifacts(execFileSyncFn, workspaceCwd ?? process.cwd());
-        if (diffArtifacts.available) {
-          result.filesChangedPaths = diffArtifacts.changedPaths;
-          result.fileDiffs = diffArtifacts.fileDiffs;
-          result.filesChanged = diffArtifacts.changedPaths.length > 0;
+      if (toolResult.data != null) {
+        if (isAgentResult(toolResult.data)) {
+          const result = toolResult.data;
+          await applyPostExecutionDiffScopeChecks({
+            result,
+            taskId: task.id,
+            cwd: workspaceCwd ?? process.cwd(),
+            execFileSyncFn,
+            logger,
+          });
+          return result;
         }
-        return result;
+
+        logger?.warn?.("[TaskLifecycle] run-adapter tool returned an invalid adapter result after execution");
+        return await buildInvalidRunAdapterResult({
+          taskId: task.id,
+          cwd: workspaceCwd ?? process.cwd(),
+          execFileSyncFn,
+          logger,
+          reason: "run-adapter returned invalid or truncated adapter result",
+        });
+      } else {
+        logger?.warn?.(`[TaskLifecycle] run-adapter tool failed, falling back to direct call: ${toolResult.error ?? "unknown"}`);
       }
-      logger?.warn?.(`[TaskLifecycle] run-adapter tool failed, falling back to direct call: ${toolResult.error ?? "unknown"}`);
     } catch (err) {
       logger?.warn?.(`[TaskLifecycle] run-adapter tool threw, falling back to direct call: ${(err as Error).message}`);
     }
@@ -132,6 +147,54 @@ export async function executeTaskWithGuards(
   }
 
   return result;
+}
+
+async function buildInvalidRunAdapterResult(input: {
+  taskId: string;
+  cwd: string;
+  execFileSyncFn: ExecuteTaskWithGuardsParams["execFileSyncFn"];
+  logger?: Logger;
+  reason: string;
+}): Promise<AgentResult> {
+  const result: AgentResult = {
+    success: true,
+    output: "",
+    error: null,
+    exit_code: null,
+    elapsed_ms: 0,
+    stopped_reason: "completed",
+  };
+  await applyPostExecutionDiffScopeChecks({
+    result,
+    taskId: input.taskId,
+    cwd: input.cwd,
+    execFileSyncFn: input.execFileSyncFn,
+    logger: input.logger,
+  });
+
+  const scopeError = result.error;
+  result.success = false;
+  result.error = scopeError ? `${input.reason}; ${scopeError}` : input.reason;
+  result.output = [
+    result.output,
+    `[Execution Result] ${input.reason}`,
+  ].filter((value) => value.length > 0).join("\n");
+  result.exit_code = null;
+  result.stopped_reason = "error";
+  return result;
+}
+
+function isAgentResult(value: unknown): value is AgentResult {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<AgentResult>;
+  return (
+    typeof candidate.success === "boolean"
+    && typeof candidate.output === "string"
+    && (typeof candidate.error === "string" || candidate.error === null)
+    && (typeof candidate.exit_code === "number" || candidate.exit_code === null)
+    && typeof candidate.elapsed_ms === "number"
+    && typeof candidate.stopped_reason === "string"
+  );
 }
 
 function recordAdapterCircuitOutcome(

--- a/src/orchestrator/execution/task/task-executor.ts
+++ b/src/orchestrator/execution/task/task-executor.ts
@@ -9,6 +9,7 @@ import { appendTaskOutcomeEvent } from "./task-outcome-ledger.js";
 import { validateProtectedPath } from "../../../tools/fs/FileValidationTool/protected-path-policy.js";
 import { loadProviderConfig } from "../../../base/llm/provider-config.js";
 import { captureExecutionDiffArtifacts } from "./task-diff-capture.js";
+import { resolveTaskWorkspacePath } from "./task-workspace.js";
 const DEBUG = process.env.PULSEED_DEBUG === "true";
 
 // ─── Deps interface ───
@@ -49,17 +50,7 @@ export async function executeTask(
 ): Promise<AgentResult> {
   const { stateManager, sessionManager, logger, execFileSyncFn } = deps;
 
-  // Resolve workspace path from goal constraints (workspace_path:<path>)
-  let workspaceCwd: string | undefined;
-  try {
-    const goal = await stateManager.loadGoal(task.goal_id);
-    const wpConstraint = goal?.constraints.find((c) => c.startsWith("workspace_path:"));
-    if (wpConstraint) {
-      workspaceCwd = wpConstraint.slice("workspace_path:".length);
-    }
-  } catch {
-    // Non-fatal: fall back to process.cwd()
-  }
+  const workspaceCwd = await resolveTaskWorkspacePath({ stateManager, task });
 
   // Create execution session
   const session = await sessionManager.createSession(
@@ -173,47 +164,13 @@ export async function executeTask(
     };
   }
 
-  // Post-execution scope check: revert changes to protected files,
-  // and annotate result.filesChanged from the same git diff --name-only call.
-  if (result.success) {
-    try {
-      const gitCwd = workspaceCwd ?? process.cwd();
-      const diffArtifacts = captureExecutionDiffArtifacts(execFileSyncFn, gitCwd);
-      if (diffArtifacts.available) {
-        const changedFiles = diffArtifacts.changedPaths;
-        result.filesChangedPaths = changedFiles;
-        result.fileDiffs = diffArtifacts.fileDiffs;
-        result.filesChanged = changedFiles.length > 0;
-        if (!result.filesChanged) {
-          logger?.warn(
-            "[TaskLifecycle] Adapter reported success but no files were modified",
-            { taskId: task.id }
-          );
-          result.success = false;
-          result.error = "No files were modified";
-          result.stopped_reason = "completed";
-        }
-      }
-
-      if (diffArtifacts.available && diffArtifacts.changedPaths.length > 0) {
-        const providerConfig = await loadProviderConfig({ saveMigration: false });
-        const protectedPaths = providerConfig.agent_loop?.security?.protected_paths;
-        const protectedChanges = diffArtifacts.changedPaths.filter((changedFile) =>
-          !validateProtectedPath(changedFile, { cwd: gitCwd, workspaceRoot: gitCwd, protectedPaths }).valid
-        );
-
-        if (protectedChanges.length > 0) {
-          result.success = false;
-          result.error = `Protected files were modified: ${protectedChanges.join(", ")}`;
-          result.output = (result.output || "") +
-            `\n[Scope Check] Protected files were modified: ${protectedChanges.join(", ")}`;
-          result.stopped_reason = "error";
-        }
-      }
-    } catch {
-      // Non-fatal: scope check failure should not break execution
-    }
-  }
+  await applyPostExecutionDiffScopeChecks({
+    result,
+    taskId: task.id,
+    cwd: workspaceCwd ?? process.cwd(),
+    execFileSyncFn,
+    logger,
+  });
 
   // End session
   const summary = result.success
@@ -242,6 +199,57 @@ export async function executeTask(
   await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, updatedTask);
 
   return result;
+}
+
+export async function applyPostExecutionDiffScopeChecks(input: {
+  result: AgentResult;
+  taskId: string;
+  cwd: string;
+  execFileSyncFn: TaskExecutorDeps["execFileSyncFn"];
+  logger?: Logger;
+}): Promise<void> {
+  if (!input.result.success) return;
+
+  try {
+    const diffArtifacts = captureExecutionDiffArtifacts(input.execFileSyncFn, input.cwd);
+    if (diffArtifacts.available) {
+      const changedFiles = diffArtifacts.changedPaths;
+      input.result.filesChangedPaths = changedFiles;
+      input.result.fileDiffs = diffArtifacts.fileDiffs;
+      input.result.filesChanged = changedFiles.length > 0;
+      if (!input.result.filesChanged) {
+        input.logger?.warn(
+          "[TaskLifecycle] Adapter reported success but no files were modified",
+          { taskId: input.taskId }
+        );
+        input.result.success = false;
+        input.result.error = "No files were modified";
+        input.result.stopped_reason = "completed";
+      }
+    }
+
+    if (diffArtifacts.available && diffArtifacts.changedPaths.length > 0) {
+      const providerConfig = await loadProviderConfig({ saveMigration: false });
+      const protectedPaths = providerConfig.agent_loop?.security?.protected_paths;
+      const protectedChanges = diffArtifacts.changedPaths.filter((changedFile) =>
+        !validateProtectedPath(changedFile, {
+          cwd: input.cwd,
+          workspaceRoot: input.cwd,
+          protectedPaths,
+        }).valid
+      );
+
+      if (protectedChanges.length > 0) {
+        input.result.success = false;
+        input.result.error = `Protected files were modified: ${protectedChanges.join(", ")}`;
+        input.result.output = (input.result.output || "") +
+          `\n[Scope Check] Protected files were modified: ${protectedChanges.join(", ")}`;
+        input.result.stopped_reason = "error";
+      }
+    }
+  } catch {
+    // Non-fatal: scope check failure should not break execution.
+  }
 }
 
 // ─── reloadTaskFromDisk ───

--- a/src/tools/execution/RunAdapterTool/RunAdapterTool.ts
+++ b/src/tools/execution/RunAdapterTool/RunAdapterTool.ts
@@ -8,6 +8,7 @@ export const RunAdapterInputSchema = z.object({
   adapter_id: z.string().min(1, "adapter_id is required"),
   task_description: z.string().min(1, "task_description is required"),
   goal_id: z.string().optional(),
+  cwd: z.string().optional(),
 });
 export type RunAdapterInput = z.infer<typeof RunAdapterInputSchema>;
 
@@ -51,6 +52,7 @@ export class RunAdapterTool implements ITool<RunAdapterInput, unknown> {
         prompt: input.task_description,
         timeout_ms: 60_000,
         adapter_type: input.adapter_id,
+        ...(input.cwd !== undefined ? { cwd: input.cwd } : {}),
       };
       const result = await adapter.execute(task);
       if (result.success) {

--- a/src/tools/execution/RunAdapterTool/__tests__/RunAdapterTool.test.ts
+++ b/src/tools/execution/RunAdapterTool/__tests__/RunAdapterTool.test.ts
@@ -73,6 +73,21 @@ describe("RunAdapterTool", () => {
     expect(registry.recordSuccess).toHaveBeenCalledWith("claude");
   });
 
+  it("passes cwd through to the adapter task when provided", async () => {
+    const mockAdapter = { execute: vi.fn().mockResolvedValue(mockResult) };
+    vi.mocked(registry.getAdapter).mockReturnValue(mockAdapter as any);
+
+    const result = await tool.call(
+      { adapter_id: "claude", task_description: "write tests", cwd: "/workspace/task" },
+      makeContext(),
+    );
+
+    expect(result.success).toBe(true);
+    expect(mockAdapter.execute).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: "/workspace/task",
+    }));
+  });
+
   it("returns failure when adapter result is unsuccessful", async () => {
     const failResult = { ...mockResult, success: false, error: "timeout", stopped_reason: "timeout" as const };
     const mockAdapter = { execute: vi.fn().mockResolvedValue(failResult) };


### PR DESCRIPTION
Closes #1149

## Implementation summary
- Replaced goal-only adapter workspace parsing with the shared task-first resolveTaskWorkspacePath() contract in direct adapter execution.
- Passed the resolved task workspace through the production run-adapter ToolExecutor path and through RunAdapterTool into AgentTask.cwd.
- Shared direct executor post-execution diff/scope checks with the run-adapter path so changed-path capture and protected-path validation use the same resolved task workspace.
- Validated run-adapter ToolExecutor data before adopting it; invalid/truncated data now fails closed with current diff/scope evidence instead of re-running the adapter.

## Verification commands
- npm run test:unit -- src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts src/orchestrator/execution/__tests__/task-lifecycle-execution-guards.test.ts src/tools/execution/RunAdapterTool/__tests__/RunAdapterTool.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known unresolved risks
- lint:boundaries still reports existing warnings, but exits 0 with no errors.
- test:changed still prints the existing ps warning, but exits 0 with all related tests passing.

## Parallel PR dependency status
- PR #1154 (#1130 mechanical verification cwd) was open before this issue and touches task-lifecycle-verification.test.ts and task-verifier-rules.ts only.
- This PR does not depend on #1154 and does not edit those files.