### PR TITLE
feat(compaction): persist structured continuity records

### DIFF
--- a/src/interface/chat/__tests__/chat-history.test.ts
+++ b/src/interface/chat/__tests__/chat-history.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   ChatHistory,
   reconstructModelVisibleMessagesFromRolloutJournal,
+  type ChatSession,
 } from "../chat-history.js";
 import type { StateManager } from "../../../base/state/state-manager.js";
 
@@ -248,4 +249,157 @@ describe("ChatHistory", () => {
       "The rollout journal is replayable.",
     ]);
   });
+
+  it("compacts into structured records with invalidated pending permissions and retained active targets", async () => {
+    const history = new ChatHistory(stateManager, SESSION_ID, CWD);
+    const eventContext = { runId: "run-compact", turnId: "turn-compact" };
+    const createdAt = "2026-05-06T00:00:00.000Z";
+
+    await history.appendUserMessage("Turn 1: check stale run", { eventContext });
+    await history.recordChatEvent({
+      type: "tool_update",
+      toolCallId: "call-approval",
+      toolName: "shell_command",
+      status: "awaiting_approval",
+      message: "write requires approval",
+      runId: eventContext.runId,
+      turnId: eventContext.turnId,
+      createdAt,
+    });
+    await history.appendAssistantMessage("Turn 1 answer", { eventContext });
+    await history.appendUserMessage("Turn 2: current run is run-current", { eventContext });
+    await history.appendAssistantMessage("Turn 2 answer", { eventContext });
+    await history.appendUserMessage("Turn 3: continue", { eventContext });
+    await history.appendAssistantMessage("Turn 3 answer", { eventContext });
+
+    const result = await history.compact("Summary: Turn 1 established stale run, Turn 2 selected run-current.", 4);
+
+    expect(result).toEqual({ before: 6, after: 4 });
+    const session = history.getSessionData();
+    const record = session.compactionRecords?.[0];
+    expect(record).toMatchObject({
+      schema_version: "chat-compaction-record-v1",
+      inputMessageCount: 6,
+      outputMessageCount: 4,
+      removedMessageCount: 2,
+      retainedMessageCount: 4,
+      replacementHistory: {
+        removedTurnIndexes: [0, 1],
+        retainedOriginalTurnIndexes: [2, 3, 4, 5],
+        rewrittenTurnIndexes: [0, 1, 2, 3],
+      },
+    });
+    expect(record?.archivedUserMessages.map((message) => message.content)).toEqual([
+      "Turn 1: check stale run",
+    ]);
+    expect(record?.pendingPermissions).toEqual([
+      expect.objectContaining({
+        status: "requested",
+        invalidatedByCompaction: true,
+        source: "chat_event",
+      }),
+    ]);
+    expect(record?.decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: "permission_decision" }),
+    ]));
+    expect(record?.activeTargets).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        source: "retained_messages",
+        state: "retained",
+      }),
+    ]));
+    expect(history.getModelVisibleMessages().map((message) => message.content)).toEqual([
+      "Turn 2: current run is run-current",
+      "Turn 2 answer",
+      "Turn 3: continue",
+      "Turn 3 answer",
+    ]);
+  });
+
+  it("does not mark confirmed RunSpec confirmations as active compaction targets", async () => {
+    const createdAt = "2026-05-06T00:00:00.000Z";
+    const existingSession: ChatSession = {
+      id: SESSION_ID,
+      cwd: CWD,
+      createdAt,
+      updatedAt: createdAt,
+      runSpecConfirmation: {
+        state: "confirmed",
+        spec: makeRunSpec(createdAt),
+        prompt: "Start the confirmed run.",
+        createdAt,
+        updatedAt: createdAt,
+      },
+      messages: [
+        { role: "user", content: "Old run request", timestamp: createdAt, turnIndex: 0 },
+        { role: "assistant", content: "Confirmed and started", timestamp: createdAt, turnIndex: 1 },
+        { role: "user", content: "Current request", timestamp: createdAt, turnIndex: 2 },
+        { role: "assistant", content: "Current answer", timestamp: createdAt, turnIndex: 3 },
+        { role: "user", content: "Latest request", timestamp: createdAt, turnIndex: 4 },
+      ],
+    };
+    const history = ChatHistory.fromSession(stateManager, existingSession);
+
+    await history.compact("The old RunSpec confirmation has already been consumed.", 2);
+
+    const record = history.getSessionData().compactionRecords?.[0];
+    expect(record?.activeTargets).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ source: "run_spec_confirmation" }),
+    ]));
+  });
 });
+
+function makeRunSpec(now: string): NonNullable<ChatSession["runSpecConfirmation"]>["spec"] {
+  return {
+    schema_version: "run-spec-v1",
+    id: "runspec-12345678-1234-4234-9234-123456789abc",
+    status: "confirmed",
+    profile: "generic",
+    source_text: "Start the confirmed run.",
+    objective: "Start the confirmed run.",
+    workspace: { path: "/tmp/test-repo", source: "user", confidence: "high" },
+    execution_target: { kind: "daemon", remote_host: null, confidence: "high" },
+    metric: null,
+    progress_contract: {
+      kind: "open_ended",
+      dimension: null,
+      threshold: null,
+      semantics: "Complete the requested work.",
+      confidence: "high",
+    },
+    deadline: null,
+    budget: {
+      max_trials: null,
+      max_wall_clock_minutes: null,
+      resident_policy: "best_effort",
+    },
+    approval_policy: {
+      submit: "unspecified",
+      publish: "unspecified",
+      secret: "unspecified",
+      external_action: "approval_required",
+      irreversible_action: "approval_required",
+    },
+    artifact_contract: {
+      expected_artifacts: [],
+      discovery_globs: [],
+      primary_outputs: [],
+    },
+    risk_flags: [],
+    missing_fields: [],
+    confidence: "high",
+    links: {
+      goal_id: null,
+      runtime_session_id: null,
+      conversation_id: null,
+    },
+    origin: {
+      channel: "chat",
+      session_id: "test-session-123",
+      reply_target: null,
+      metadata: {},
+    },
+    created_at: now,
+    updated_at: now,
+  };
+}

--- a/src/interface/chat/__tests__/chat-runner.test.ts
+++ b/src/interface/chat/__tests__/chat-runner.test.ts
@@ -2549,7 +2549,15 @@ describe("ChatRunner", () => {
 
     it("/compact falls back to deterministic summary and keeps latest turns", async () => {
       const stateManager = makeMockStateManager();
-      const writes: Array<{ messages: Array<{ role: string; content: string }>; compactionSummary?: string }> = [];
+      const writes: Array<{
+        messages: Array<{ role: string; content: string }>;
+        compactionSummary?: string;
+        compactionRecords?: Array<{
+          schema_version: string;
+          pendingPermissions: Array<{ status: string; invalidatedByCompaction: boolean }>;
+          replacementHistory: { retainedOriginalTurnIndexes: number[] };
+        }>;
+      }> = [];
       (stateManager.writeRaw as ReturnType<typeof vi.fn>).mockImplementation(async (_path, data) => {
         writes.push(JSON.parse(JSON.stringify(data)));
       });
@@ -2574,6 +2582,12 @@ describe("ChatRunner", () => {
         "Task completed successfully.",
       ]);
       expect(lastWrite.compactionSummary).toContain("Turn 1");
+      expect(lastWrite.compactionRecords?.[0]).toMatchObject({
+        schema_version: "chat-compaction-record-v1",
+        replacementHistory: {
+          retainedOriginalTurnIndexes: [2, 3, 4, 5],
+        },
+      });
     });
 
     it("/compact summary is included in the next adapter prompt", async () => {

--- a/src/interface/chat/__tests__/turn-context.test.ts
+++ b/src/interface/chat/__tests__/turn-context.test.ts
@@ -44,6 +44,44 @@ describe("Chat TurnContext", () => {
           },
         ],
       } satisfies UserInput,
+      compactionSummary: "Archived stale target; retained current target from structured state.",
+      compactionRecords: [{
+        schema_version: "chat-compaction-record-v1",
+        id: "session-current:compaction:0",
+        sessionId: "session-current",
+        sequence: 0,
+        createdAt: "2026-05-06T06:59:00.000Z",
+        reason: "manual_command",
+        inputMessageCount: 8,
+        outputMessageCount: 4,
+        removedMessageCount: 4,
+        retainedMessageCount: 4,
+        summary: "Archived stale target; retained current target from structured state.",
+        modelVisibleSummary: "Archived stale target; retained current target from structured state.",
+        archivedUserMessages: [],
+        archivedAssistantMessages: [],
+        retainedMessages: [],
+        pendingPermissions: [{
+          sequence: 2,
+          source: "chat_event",
+          status: "requested",
+          invalidatedByCompaction: true,
+          payload: { state: "requested" },
+        }],
+        decisions: [],
+        activeTargets: [{
+          source: "notification_reply_target",
+          state: "session",
+          payload: { surface: "gateway", platform: "slack", conversation_id: "current-thread" },
+        }],
+        replacementHistory: {
+          removedTurnIndexes: [0, 1, 2, 3],
+          retainedOriginalTurnIndexes: [4, 5, 6, 7],
+          rewrittenTurnIndexes: [0, 1, 2, 3],
+          rolloutJournalSequences: [0, 1, 2],
+          turnContextCount: 1,
+        },
+      }],
       priorTurns: [],
       basePrompt: "Working directory: /repo\n\n進捗を見て",
       prompt: "Working directory: /repo\n\n進捗を見て",
@@ -90,12 +128,29 @@ describe("Chat TurnContext", () => {
       message_id: "current-message",
     });
     expect(context.modelVisible.runtime.approvalMode).toBe("preapproved");
+    expect(context.modelVisible.conversation.compactionRecords).toEqual([
+      expect.objectContaining({
+        sequence: 0,
+        pendingPermissions: [
+          expect.objectContaining({ status: "requested", invalidatedByCompaction: true }),
+        ],
+        activeTargets: [
+          expect.objectContaining({ source: "notification_reply_target" }),
+        ],
+      }),
+    ]);
     expect(context.hostOnly.runtime.fallbackReplyTarget).toMatchObject({
       conversation_id: "stale-thread",
     });
 
     const rendered = renderModelVisibleTurnContext(context.modelVisible);
     expect(rendered).toContain("current-thread");
+    expect(rendered).toContain("compaction_records: 1");
+    expect(rendered).toContain("pending_permissions:");
+    expect(rendered).toContain("invalidatedByCompaction");
+    expect(rendered).toContain("active_targets:");
+    expect(rendered).toContain("notification_reply_target");
+    expect(rendered).toContain("replacement_history:");
     expect(rendered).not.toContain("stale-thread");
 
     const snapshotJson = JSON.stringify(toTurnContextSnapshot(context));

--- a/src/interface/chat/chat-history.ts
+++ b/src/interface/chat/chat-history.ts
@@ -82,6 +82,53 @@ export const ChatRolloutJournalRecordSchema = z.object({
 }).passthrough();
 export type ChatRolloutJournalRecord = z.infer<typeof ChatRolloutJournalRecordSchema>;
 
+export const CHAT_COMPACTION_RECORD_SCHEMA_VERSION = "chat-compaction-record-v1";
+
+export const ChatCompactionRecordSchema = z.object({
+  schema_version: z.literal(CHAT_COMPACTION_RECORD_SCHEMA_VERSION),
+  id: z.string(),
+  sessionId: z.string(),
+  sequence: z.number().int().nonnegative(),
+  createdAt: z.string(),
+  reason: z.enum(["manual_command", "auto_context_limit"]).default("manual_command"),
+  inputMessageCount: z.number().int().nonnegative(),
+  outputMessageCount: z.number().int().nonnegative(),
+  removedMessageCount: z.number().int().nonnegative(),
+  retainedMessageCount: z.number().int().nonnegative(),
+  summary: z.string(),
+  modelVisibleSummary: z.string(),
+  archivedUserMessages: z.array(ChatMessageSchema),
+  archivedAssistantMessages: z.array(ChatMessageSchema),
+  retainedMessages: z.array(ChatMessageSchema),
+  pendingPermissions: z.array(z.object({
+    sequence: z.number().int().nonnegative(),
+    source: z.string(),
+    status: z.enum(["requested", "resolved", "unknown"]),
+    invalidatedByCompaction: z.boolean(),
+    payload: z.unknown(),
+  }).passthrough()),
+  decisions: z.array(z.object({
+    sequence: z.number().int().nonnegative(),
+    kind: ChatRolloutJournalRecordKindSchema,
+    source: z.string(),
+    visibility: z.string(),
+    payload: z.unknown(),
+  }).passthrough()),
+  activeTargets: z.array(z.object({
+    source: z.string(),
+    state: z.enum(["retained", "session"]),
+    payload: z.unknown(),
+  }).passthrough()),
+  replacementHistory: z.object({
+    removedTurnIndexes: z.array(z.number().int().nonnegative()),
+    retainedOriginalTurnIndexes: z.array(z.number().int().nonnegative()),
+    rewrittenTurnIndexes: z.array(z.number().int().nonnegative()),
+    rolloutJournalSequences: z.array(z.number().int().nonnegative()),
+    turnContextCount: z.number().int().nonnegative(),
+  }).passthrough(),
+}).passthrough();
+export type ChatCompactionRecord = z.infer<typeof ChatCompactionRecordSchema>;
+
 export const RunSpecConfirmationStateSchema = z.object({
   state: z.enum(["pending", "confirmed", "cancelled"]),
   spec: RunSpecSchema,
@@ -122,6 +169,7 @@ export const ChatSessionSchema = z.object({
   runSpecConfirmation: RunSpecConfirmationStateSchema.nullable().optional(),
   messages: z.array(ChatMessageSchema),
   compactionSummary: z.string().optional(),
+  compactionRecords: z.array(ChatCompactionRecordSchema).optional(),
   agentLoopStatePath: z.string().nullable().optional(),
   agentLoopStatus: z.enum(["running", "completed", "failed"]).nullable().optional(),
   agentLoopResumable: z.boolean().nullable().optional(),
@@ -150,6 +198,7 @@ export class ChatHistory {
         cwd: existingSession.cwd,
         updatedAt: existingSession.updatedAt ?? existingSession.createdAt,
         messages: [...existingSession.messages],
+        ...(existingSession.compactionRecords ? { compactionRecords: cloneCompactionRecords(existingSession.compactionRecords) } : {}),
         ...(existingSession.turnContexts ? { turnContexts: [...existingSession.turnContexts] } : {}),
         ...(existingSession.rolloutJournal ? { rolloutJournal: [...existingSession.rolloutJournal] } : {}),
         ...(existingSession.usage ? { usage: cloneUsage(existingSession.usage) } : {}),
@@ -232,6 +281,7 @@ export class ChatHistory {
   async clear(): Promise<void> {
     this.session.messages = [];
     delete this.session.compactionSummary;
+    delete this.session.compactionRecords;
     this.replaceModelVisibleJournalFromMessages("clear");
     await this.persist();
   }
@@ -240,12 +290,19 @@ export class ChatHistory {
   async compact(summary: string, keepMessageCount = 4): Promise<{ before: number; after: number }> {
     const before = this.session.messages.length;
     const keepCount = Math.max(0, keepMessageCount);
+    const originalMessages = [...this.session.messages];
     const kept = keepCount === 0 ? [] : this.session.messages.slice(-keepCount);
+    const removed = keepCount === 0 ? originalMessages : originalMessages.slice(0, -keepCount);
+    const record = this.buildCompactionRecord(summary, originalMessages, removed, kept);
     this.session.messages = kept.map((message, index) => ({
       ...message,
       turnIndex: index,
     }));
     this.session.compactionSummary = summary;
+    this.session.compactionRecords = [
+      ...(this.session.compactionRecords ?? []),
+      record,
+    ].slice(-50);
     this.replaceModelVisibleJournalFromMessages("compact");
     await this.persist();
     return { before, after: this.session.messages.length };
@@ -283,6 +340,7 @@ export class ChatHistory {
     return {
       ...this.session,
       messages: [...this.session.messages],
+      ...(this.session.compactionRecords ? { compactionRecords: cloneCompactionRecords(this.session.compactionRecords) } : {}),
       ...(this.session.turnContexts ? { turnContexts: [...this.session.turnContexts] } : {}),
       ...(this.session.rolloutJournal ? { rolloutJournal: [...this.session.rolloutJournal] } : {}),
       ...(this.session.usage ? { usage: cloneUsage(this.session.usage) } : {}),
@@ -550,6 +608,46 @@ export class ChatHistory {
       });
     }
   }
+
+  private buildCompactionRecord(
+    summary: string,
+    originalMessages: ChatMessage[],
+    removed: ChatMessage[],
+    retained: ChatMessage[],
+  ): ChatCompactionRecord {
+    const current = this.session.compactionRecords ?? [];
+    const sequence = nextCompactionSequence(current);
+    const rewrittenTurnIndexes = retained.map((_message, index) => index);
+    const rolloutJournal = this.session.rolloutJournal ?? [];
+    const record = ChatCompactionRecordSchema.parse({
+      schema_version: CHAT_COMPACTION_RECORD_SCHEMA_VERSION,
+      id: `${this.sessionId}:compaction:${sequence}`,
+      sessionId: this.sessionId,
+      sequence,
+      createdAt: new Date().toISOString(),
+      reason: "manual_command",
+      inputMessageCount: originalMessages.length,
+      outputMessageCount: retained.length,
+      removedMessageCount: removed.length,
+      retainedMessageCount: retained.length,
+      summary,
+      modelVisibleSummary: summary,
+      archivedUserMessages: removed.filter((message) => message.role === "user"),
+      archivedAssistantMessages: removed.filter((message) => message.role === "assistant"),
+      retainedMessages: retained,
+      pendingPermissions: collectPendingPermissionRecords(rolloutJournal),
+      decisions: collectDecisionRecords(rolloutJournal),
+      activeTargets: collectActiveTargets(this.session, retained),
+      replacementHistory: {
+        removedTurnIndexes: removed.map((message) => message.turnIndex),
+        retainedOriginalTurnIndexes: retained.map((message) => message.turnIndex),
+        rewrittenTurnIndexes,
+        rolloutJournalSequences: rolloutJournal.map((record) => record.sequence),
+        turnContextCount: this.session.turnContexts?.length ?? 0,
+      },
+    });
+    return record;
+  }
 }
 
 export function reconstructModelVisibleMessagesFromRolloutJournal(
@@ -584,6 +682,118 @@ export function reconstructModelVisibleMessagesFromRolloutJournal(
 
 function nextRolloutSequence(records: ChatRolloutJournalRecord[]): number {
   return records.reduce((max, record) => Math.max(max, record.sequence), -1) + 1;
+}
+
+function nextCompactionSequence(records: ChatCompactionRecord[]): number {
+  return records.reduce((max, record) => Math.max(max, record.sequence), -1) + 1;
+}
+
+function cloneCompactionRecords(records: readonly ChatCompactionRecord[]): ChatCompactionRecord[] {
+  return records.map((record) => ChatCompactionRecordSchema.parse(cloneJson(record)));
+}
+
+function collectPendingPermissionRecords(records: ChatRolloutJournalRecord[]): ChatCompactionRecord["pendingPermissions"] {
+  return records.flatMap((record) => {
+    if (record.kind !== "permission_decision") return [];
+    const payload = isRecord(record.payload) ? record.payload : {};
+    const status = permissionStatus(payload);
+    return [{
+      sequence: record.sequence,
+      source: record.source,
+      status,
+      invalidatedByCompaction: status === "requested",
+      payload: cloneJson(record.payload),
+    }];
+  });
+}
+
+function collectDecisionRecords(records: ChatRolloutJournalRecord[]): ChatCompactionRecord["decisions"] {
+  return records.flatMap((record) => {
+    if (
+      record.kind !== "turn_context"
+      && record.kind !== "permission_decision"
+      && record.kind !== "completion_state"
+    ) {
+      return [];
+    }
+    return [{
+      sequence: record.sequence,
+      kind: record.kind,
+      source: record.source,
+      visibility: record.visibility,
+      payload: cloneJson(record.payload),
+    }];
+  });
+}
+
+function collectActiveTargets(
+  session: ChatSession,
+  retainedMessages: ChatMessage[],
+): ChatCompactionRecord["activeTargets"] {
+  const targets: ChatCompactionRecord["activeTargets"] = [{
+    source: "retained_messages",
+    state: "retained",
+    payload: retainedMessages.map((message) => ({
+      role: message.role,
+      turnIndex: message.turnIndex,
+      timestamp: message.timestamp,
+    })),
+  }];
+  if (session.notificationReplyTarget) {
+    targets.push({
+      source: "notification_reply_target",
+      state: "session",
+      payload: cloneJson(session.notificationReplyTarget),
+    });
+  }
+  if (session.agentLoopStatePath || session.agentLoop) {
+    targets.push({
+      source: "agent_loop",
+      state: "session",
+      payload: {
+        statePath: session.agentLoopStatePath ?? session.agentLoop?.statePath ?? null,
+        status: session.agentLoopStatus ?? session.agentLoop?.status ?? null,
+        resumable: session.agentLoopResumable ?? session.agentLoop?.resumable ?? null,
+        updatedAt: session.agentLoopUpdatedAt ?? session.agentLoop?.updatedAt ?? null,
+      },
+    });
+  }
+  if (session.runSpecConfirmation?.state === "pending") {
+    targets.push({
+      source: "run_spec_confirmation",
+      state: "session",
+      payload: {
+        state: session.runSpecConfirmation.state,
+        specId: session.runSpecConfirmation.spec.id,
+        createdAt: session.runSpecConfirmation.createdAt,
+        updatedAt: session.runSpecConfirmation.updatedAt,
+      },
+    });
+  }
+  if (session.setupDialogue) {
+    targets.push({
+      source: "setup_dialogue",
+      state: "session",
+      payload: {
+        id: session.setupDialogue.id,
+        channel: session.setupDialogue.selectedChannel,
+        state: session.setupDialogue.state,
+        updatedAt: session.setupDialogue.updatedAt,
+      },
+    });
+  }
+  return targets;
+}
+
+function permissionStatus(payload: Record<string, unknown>): "requested" | "resolved" | "unknown" {
+  if (payload["state"] === "requested") return "requested";
+  if (payload["state"] === "approved" || payload["state"] === "denied" || payload["state"] === "resolved") {
+    return "resolved";
+  }
+  const item = isRecord(payload["item"]) ? payload["item"] : null;
+  if (item?.["status"] === "requested" || item?.["status"] === "awaiting_approval") return "requested";
+  if (item?.["status"] === "approved" || item?.["status"] === "denied") return "resolved";
+  return "unknown";
 }
 
 function extractTurnContextEventContext(snapshot: { modelVisible: unknown }): ChatEventContext | undefined {
@@ -780,4 +990,9 @@ function cloneUsage(usage: ChatSessionUsage): ChatSessionUsage {
     ),
     ...(usage.updatedAt ? { updatedAt: usage.updatedAt } : {}),
   };
+}
+
+function cloneJson<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
 }

--- a/src/interface/chat/chat-runner-commands.ts
+++ b/src/interface/chat/chat-runner-commands.ts
@@ -894,6 +894,7 @@ export class ChatRunnerCommandHandler {
     const userTurns = messages.filter((message) => message.role === "user").length;
     const assistantTurns = messages.filter((message) => message.role === "assistant").length;
     const compactionSummary = session?.compactionSummary?.trim() ?? "";
+    const compactionRecords = session?.compactionRecords ?? [];
     const agentLoopPath = this.host.getNativeAgentLoopStatePath() ?? session?.agentLoopStatePath ?? null;
     const replyTarget = this.host.getRuntimeControlContext()?.replyTarget ?? this.host.deps.runtimeReplyTarget ?? null;
     const routeCapabilities = {
@@ -913,6 +914,7 @@ export class ChatRunnerCommandHandler {
       `- messages: ${messages.length} (${userTurns} user, ${assistantTurns} assistant)`,
       `- recent_turns_retained: ${recentMessages.length}`,
       `- compaction_summary: ${compactionSummary ? "present" : "none"}`,
+      `- compaction_records: ${compactionRecords.length}`,
       `- agentloop_state_path: ${agentLoopPath ?? "none"}`,
       "",
       "Turn context",
@@ -932,6 +934,7 @@ export class ChatRunnerCommandHandler {
       "- current session cwd and execution policy because they constrain tool and route behavior",
       `- ${recentMessages.length} latest persisted message(s)`,
       `- ${compactionSummary ? "compacted older chat summary because older turns were summarized" : "no compacted older chat summary because none is stored"}`,
+      `- ${compactionRecords.length > 0 ? "structured compaction records because compacted chat state was retained for replay" : "no structured compaction records because no compaction has run"}`,
       `- ${agentLoopPath ? "native agent-loop resume path because this session can persist agent-loop state" : "no native agent-loop resume path because none is active"}`,
       "",
       "Not included",

--- a/src/interface/chat/chat-runner-runtime.ts
+++ b/src/interface/chat/chat-runner-runtime.ts
@@ -61,6 +61,7 @@ export function loadedSessionToChatSession(session: LoadedChatSession): ChatSess
     ...(session.parentNotificationSummary ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
     ...(session.parentNotifiedAt ? { parentNotifiedAt: session.parentNotifiedAt } : {}),
     ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
+    ...(session.compactionRecords ? { compactionRecords: [...session.compactionRecords] } : {}),
     ...(session.title ? { title: session.title } : {}),
     ...(session.agentLoopStatePath ? { agentLoopStatePath: session.agentLoopStatePath } : {}),
     ...(session.agentLoopStatus === "running" || session.agentLoopStatus === "completed" || session.agentLoopStatus === "failed"

--- a/src/interface/chat/chat-runner.ts
+++ b/src/interface/chat/chat-runner.ts
@@ -498,7 +498,9 @@ export class ChatRunner {
     }
 
     const messages = history.getModelVisibleMessages();
-    const compactionSummary = history.getSessionData().compactionSummary;
+    const sessionData = history.getSessionData();
+    const compactionSummary = sessionData.compactionSummary;
+    const compactionRecords = sessionData.compactionRecords ?? [];
     const priorTurns = resumeOnly ? messages.slice(-10) : messages.slice(0, -1).slice(-10);
     const historySections: string[] = [];
     if (compactionSummary) {
@@ -651,6 +653,7 @@ export class ChatRunner {
       input: safeInput,
       userInput: safeUserInput,
       compactionSummary,
+      compactionRecords,
       priorTurns,
       basePrompt,
       prompt,

--- a/src/interface/chat/chat-session-store.ts
+++ b/src/interface/chat/chat-session-store.ts
@@ -43,6 +43,7 @@ export interface LoadedChatSession {
   title: string | null;
   messages: ChatSession["messages"];
   compactionSummary?: string;
+  compactionRecords?: ChatSession["compactionRecords"];
   parentSessionId?: string | null;
   spawnedBySessionId?: string | null;
   spawnedByRuntimeSessionId?: string | null;
@@ -344,6 +345,7 @@ async function readSessionRecordWithMetadata(
     ...(optionalString(parsed.data.parentNotificationSummary) !== null ? { parentNotificationSummary: optionalString(parsed.data.parentNotificationSummary) } : {}),
     ...(optionalString(parsed.data.parentNotifiedAt) !== null ? { parentNotifiedAt: optionalString(parsed.data.parentNotifiedAt) } : {}),
     ...(parsed.data.compactionSummary ? { compactionSummary: parsed.data.compactionSummary } : {}),
+    ...(parsed.data.compactionRecords ? { compactionRecords: [...parsed.data.compactionRecords] } : {}),
     agentLoopStatePath: discovery.statePath,
     agentLoopStatus: discovery.status,
     agentLoopResumable: discovery.resumable,
@@ -414,6 +416,7 @@ function toPersistedSession(session: LoadedChatSession): ChatSession {
     ...(session.parentNotificationSummary !== null && session.parentNotificationSummary !== undefined ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
     ...(session.parentNotifiedAt !== null && session.parentNotifiedAt !== undefined ? { parentNotifiedAt: session.parentNotifiedAt } : {}),
     ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
+    ...(session.compactionRecords ? { compactionRecords: [...session.compactionRecords] } : {}),
     ...(session.title !== null ? { title: session.title } : {}),
     ...(session.agentLoopStatePath !== null ? { agentLoopStatePath: session.agentLoopStatePath } : {}),
     ...(session.agentLoopStatus === "running" || session.agentLoopStatus === "completed" || session.agentLoopStatus === "failed"
@@ -582,6 +585,7 @@ export class ChatSessionCatalog {
       ...(session.parentNotificationSummary ? { parentNotificationSummary: session.parentNotificationSummary } : {}),
       ...(session.parentNotifiedAt ? { parentNotifiedAt: session.parentNotifiedAt } : {}),
       ...(session.compactionSummary ? { compactionSummary: session.compactionSummary } : {}),
+      ...(session.compactionRecords ? { compactionRecords: [...session.compactionRecords] } : {}),
       ...(session.turnContexts ? { turnContexts: [...session.turnContexts] } : {}),
       ...(session.rolloutJournal ? { rolloutJournal: [...session.rolloutJournal] } : {}),
       agentLoopStatePath: session.agentLoopStatePath,

--- a/src/interface/chat/turn-context.ts
+++ b/src/interface/chat/turn-context.ts
@@ -4,7 +4,7 @@ import type {
   RuntimeControlReplyTarget,
 } from "../../runtime/store/runtime-operation-schemas.js";
 import type { ChatEventContext } from "./chat-events.js";
-import type { ChatMessage, RunSpecConfirmationState } from "./chat-history.js";
+import type { ChatCompactionRecord, ChatMessage, RunSpecConfirmationState } from "./chat-history.js";
 import type { RuntimeControlChatContext } from "./chat-runner-contracts.js";
 import type { SelectedChatRoute } from "./ingress-router.js";
 import type { SetupDialoguePublicState } from "./setup-dialogue.js";
@@ -43,6 +43,7 @@ export interface ChatTurnModelVisibleContext {
   };
   conversation: {
     compactionSummary: string | null;
+    compactionRecords: PublicCompactionRecord[];
     priorTurns: Array<{ role: "user" | "assistant"; content: string }>;
   };
   prompts: {
@@ -102,6 +103,7 @@ export interface ChatTurnContextInput {
   input: string;
   userInput: UserInput;
   compactionSummary?: string | null;
+  compactionRecords?: ChatCompactionRecord[] | null;
   priorTurns: ChatMessage[];
   basePrompt: string;
   prompt: string;
@@ -156,6 +158,20 @@ interface PublicRunSpecConfirmationState {
   updatedAt: string;
 }
 
+interface PublicCompactionRecord {
+  sequence: number;
+  createdAt: string;
+  reason: string;
+  summary: string;
+  inputMessageCount: number;
+  outputMessageCount: number;
+  removedMessageCount: number;
+  retainedMessageCount: number;
+  pendingPermissions: ChatCompactionRecord["pendingPermissions"];
+  activeTargets: ChatCompactionRecord["activeTargets"];
+  replacementHistory: ChatCompactionRecord["replacementHistory"];
+}
+
 interface PublicUserInput {
   schema_version: typeof USER_INPUT_SCHEMA_VERSION;
   rawText?: string;
@@ -200,6 +216,7 @@ export function buildChatTurnContext(input: ChatTurnContextInput): ChatTurnConte
       },
       conversation: {
         compactionSummary: input.compactionSummary?.trim() ? input.compactionSummary : null,
+        compactionRecords: toPublicCompactionRecords(input.compactionRecords),
         priorTurns: input.priorTurns.map((message) => ({
           role: message.role === "assistant" ? "assistant" : "user",
           content: message.content,
@@ -251,6 +268,7 @@ export function buildChatTurnContext(input: ChatTurnContextInput): ChatTurnConte
 }
 
 export function renderModelVisibleTurnContext(context: ChatTurnModelVisibleContext): string {
+  const compactionRecordLines = context.conversation.compactionRecords.flatMap(renderCompactionRecord);
   const lines = [
     "## Turn Context",
     `- turn_id: ${context.turn.turnId}`,
@@ -267,6 +285,8 @@ export function renderModelVisibleTurnContext(context: ChatTurnModelVisibleConte
     `- activated_tools: ${context.tools.activatedTools.length > 0 ? context.tools.activatedTools.join(", ") : "none"}`,
     `- setup_dialogue: ${context.outstanding.setupDialogue ? `${context.outstanding.setupDialogue.channel}:${context.outstanding.setupDialogue.state}` : "none"}`,
     `- run_spec_confirmation: ${context.outstanding.runSpecConfirmation ? `${context.outstanding.runSpecConfirmation.state}:${context.outstanding.runSpecConfirmation.specId}` : "none"}`,
+    `- compaction_records: ${context.conversation.compactionRecords.length}`,
+    ...compactionRecordLines,
     `- runtime_evidence: ${context.runtimeEvidence.status}`,
   ];
   return lines.join("\n");
@@ -329,6 +349,46 @@ function toPublicRunSpecConfirmation(confirmation: RunSpecConfirmationState | nu
     createdAt: confirmation.createdAt,
     updatedAt: confirmation.updatedAt,
   };
+}
+
+function toPublicCompactionRecords(records: ChatCompactionRecord[] | null | undefined): PublicCompactionRecord[] {
+  return (records ?? []).slice(-5).map((record) => ({
+    sequence: record.sequence,
+    createdAt: record.createdAt,
+    reason: record.reason,
+    summary: record.modelVisibleSummary || record.summary,
+    inputMessageCount: record.inputMessageCount,
+    outputMessageCount: record.outputMessageCount,
+    removedMessageCount: record.removedMessageCount,
+    retainedMessageCount: record.retainedMessageCount,
+    pendingPermissions: record.pendingPermissions,
+    activeTargets: record.activeTargets,
+    replacementHistory: record.replacementHistory,
+  }));
+}
+
+function renderCompactionRecord(record: PublicCompactionRecord, index: number): string[] {
+  return [
+    `  - compaction_record[${index}].sequence: ${record.sequence}`,
+    `    reason: ${record.reason}`,
+    `    summary: ${preview(record.summary, 700)}`,
+    `    counts: input=${record.inputMessageCount} output=${record.outputMessageCount} removed=${record.removedMessageCount} retained=${record.retainedMessageCount}`,
+    `    pending_permissions: ${previewJson(record.pendingPermissions, 1200)}`,
+    `    active_targets: ${previewJson(record.activeTargets, 1200)}`,
+    `    replacement_history: ${previewJson(record.replacementHistory, 800)}`,
+  ];
+}
+
+function previewJson(value: unknown, maxChars: number): string {
+  try {
+    return preview(JSON.stringify(value), maxChars);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+function preview(value: string, maxChars: number): string {
+  return value.length > maxChars ? `${value.slice(0, maxChars)}...` : value;
 }
 
 function toPublicUserInput(input: UserInput, redactedText: string): PublicUserInput {

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts
@@ -444,9 +444,10 @@ describe("agentloop phase 5 compaction", () => {
       toolRuntime: runtime,
       compactor: new ExtractiveAgentLoopCompactor(),
     });
+    const session = createAgentLoopSession();
 
     const result = await runner.run({
-      session: createAgentLoopSession(),
+      session,
       turnId: "turn-1",
       goalId: "goal-1",
       cwd: process.cwd(),
@@ -455,9 +456,57 @@ describe("agentloop phase 5 compaction", () => {
       messages: [
         { role: "system", content: "system" },
         { role: "user", content: "one ".repeat(120) },
-        { role: "assistant", content: "two ".repeat(120) },
-        { role: "user", content: "three ".repeat(120) },
-        { role: "assistant", content: "four ".repeat(120) },
+        {
+          role: "assistant",
+          content: "observe stale run",
+          phase: "commentary",
+          toolCalls: [{ id: "stale-call", name: "run_observe", input: { runId: "run-stale" } }],
+        },
+        {
+          role: "tool",
+          toolCallId: "stale-call",
+          toolName: "run_observe",
+          content: "stale run finished",
+          observation: {
+            type: "tool_observation",
+            callId: "stale-call",
+            toolName: "run_observe",
+            arguments: { runId: "run-stale" },
+            state: "success",
+            success: true,
+            durationMs: 1,
+            output: { content: "stale run finished", data: { runId: "run-stale" } },
+          },
+        },
+        {
+          role: "assistant",
+          content: "needs operator approval",
+          phase: "commentary",
+          toolCalls: [{ id: "denied-call", name: "shell_command", input: { command: "rm -rf tmp" } }],
+        },
+        {
+          role: "tool",
+          toolCallId: "denied-call",
+          toolName: "shell_command",
+          content: "approval denied",
+          observation: {
+            type: "tool_observation",
+            callId: "denied-call",
+            toolName: "shell_command",
+            arguments: { command: "rm -rf tmp" },
+            state: "denied",
+            success: false,
+            execution: { status: "not_executed", reason: "approval_denied", message: "operator denied" },
+            durationMs: 1,
+            output: { content: "approval denied", error: "approval denied" },
+          },
+        },
+        {
+          role: "assistant",
+          content: "observe retained current run",
+          phase: "commentary",
+          toolCalls: [{ id: "active-call", name: "run_observe", input: { runId: "run-current" } }],
+        },
         { role: "user", content: "latest request" },
       ],
       outputSchema: z.object({ status: z.literal("done"), message: z.string(), evidence: z.array(z.string()), blockers: z.array(z.string()) }),
@@ -474,8 +523,29 @@ describe("agentloop phase 5 compaction", () => {
 
     expect(result.success).toBe(true);
     expect(result.compactions).toBe(1);
-    expect(modelClient.calls[0].messages.some((m) => m.content.includes("Summary of earlier agentloop context"))).toBe(true);
+    const summaryMessage = modelClient.calls[0].messages.find((m) => m.content.includes("Summary of earlier agentloop context"));
+    expect(summaryMessage?.content).toContain("Pending permissions");
+    expect(summaryMessage?.content).toContain("Archived stale targets");
+    expect(summaryMessage?.content).toContain("Retained active targets");
     expect(modelClient.calls[0].messages.length).toBeLessThan(6);
+    const state = await session.stateStore.load();
+    const record = state?.compactionRecords?.[0];
+    expect(record?.pendingPermissions).toEqual([
+      expect.objectContaining({
+        toolName: "shell_command",
+        execution: expect.objectContaining({ status: "not_executed", reason: "approval_denied" }),
+      }),
+    ]);
+    expect(record?.archivedTargets).toEqual(expect.arrayContaining([
+      expect.objectContaining({ state: "archived", toolName: "run_observe", callId: "stale-call" }),
+    ]));
+    expect(record?.activeTargets).toEqual(expect.arrayContaining([
+      expect.objectContaining({ state: "retained", toolName: "run_observe", callId: "active-call" }),
+    ]));
+    expect(record?.activeTargets).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ callId: "stale-call" }),
+    ]));
+    expect(record?.replacementHistory.retainedIndexes).toEqual([6, 7]);
   });
 
   it("mid-turn auto compaction continues after tool output when usage crosses the limit", async () => {
@@ -587,6 +657,22 @@ describe("agentloop phase 5 compaction", () => {
     expect(first.success).toBe(false);
     expect(first.stopReason).toBe("max_tool_calls");
     expect(first.compactions).toBeGreaterThanOrEqual(1);
+    const persistedAfterFirst = JSON.parse(await fsp.readFile(statePath, "utf-8")) as {
+      compactionRecords?: Array<{
+        schemaVersion: string;
+        modelVisibleSummary: string;
+        toolObservations: Array<{ toolName: string }>;
+        replacementHistory: { summarizedIndexes: number[]; retainedIndexes: number[] };
+      }>;
+    };
+    expect(persistedAfterFirst.compactionRecords?.[0]).toMatchObject({
+      schemaVersion: "agent-loop-compaction-record-v1",
+      replacementHistory: {
+        summarizedIndexes: expect.arrayContaining([1, 2]),
+        retainedIndexes: expect.arrayContaining([3, 4]),
+      },
+    });
+    expect(persistedAfterFirst.compactionRecords?.[0]?.modelVisibleSummary).toContain("User messages");
 
     const secondModelClient = new ScriptedModelClient(modelInfo, [
       { content: JSON.stringify({ status: "done", message: "resumed", evidence: ["plan update"], blockers: [] }), toolCalls: [], stopReason: "end_turn" },
@@ -626,6 +712,8 @@ describe("agentloop phase 5 compaction", () => {
     expect(second.compactions).toBeGreaterThanOrEqual(first.compactions);
     expect(secondModelClient.calls[0].messages.some((m) => m.content.includes("Summary of earlier agentloop context"))).toBe(true);
     expect(secondModelClient.calls[0].messages.some((m) => m.role === "tool" && m.toolName === "update_plan")).toBe(true);
+    const resumedState = await new JsonAgentLoopSessionStateStore(statePath).load();
+    expect(resumedState?.compactionRecords?.[0]?.modelVisibleSummary).toContain("Replacement history");
   });
 });
 

--- a/src/orchestrator/execution/agent-loop/agent-loop-compaction-record.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-compaction-record.ts
@@ -1,0 +1,97 @@
+import type {
+  AgentLoopMessage,
+  AgentLoopMessagePhase,
+  AgentLoopMessageRole,
+  AgentLoopToolCall,
+  AgentLoopToolObservation,
+  AgentLoopToolObservationExecution,
+} from "./agent-loop-model.js";
+
+export const AGENT_LOOP_COMPACTION_RECORD_SCHEMA_VERSION = "agent-loop-compaction-record-v1";
+
+export type AgentLoopCompactionPhase = "pre_turn" | "mid_turn" | "standalone_turn";
+export type AgentLoopCompactionReason = "context_limit" | "model_downshift" | "manual";
+export type AgentLoopCompactionTargetState = "archived" | "retained";
+
+export interface AgentLoopCompactionMessageRef {
+  index: number;
+  role: AgentLoopMessageRole;
+  content: string;
+  phase?: AgentLoopMessagePhase;
+  toolCallId?: string;
+  toolName?: string;
+}
+
+export interface AgentLoopCompactionToolObservationRef {
+  index: number;
+  callId: string;
+  toolName: string;
+  state: AgentLoopToolObservation["state"];
+  success: boolean;
+  execution?: AgentLoopToolObservationExecution;
+  arguments: unknown;
+  output: AgentLoopToolObservation["output"];
+  command?: string;
+  cwd?: string;
+  artifacts?: string[];
+  activityCategory?: AgentLoopToolObservation["activityCategory"];
+}
+
+export interface AgentLoopCompactionPendingPermission {
+  index: number;
+  callId: string;
+  toolName: string;
+  state: AgentLoopToolObservation["state"];
+  execution?: AgentLoopToolObservationExecution;
+  output: AgentLoopToolObservation["output"];
+}
+
+export interface AgentLoopCompactionToolTarget {
+  state: AgentLoopCompactionTargetState;
+  source: "assistant_tool_call" | "tool_observation";
+  index: number;
+  callId: string;
+  toolName: string;
+  input?: unknown;
+  arguments?: unknown;
+  outputData?: unknown;
+}
+
+export interface AgentLoopCompactionReplacementHistory {
+  summarizedIndexes: number[];
+  retainedIndexes: number[];
+  systemIndexes: number[];
+  summaryMessageInserted: boolean;
+}
+
+export interface AgentLoopCompactionRecord {
+  schemaVersion: typeof AGENT_LOOP_COMPACTION_RECORD_SCHEMA_VERSION;
+  sequence: number;
+  createdAt: string;
+  phase: AgentLoopCompactionPhase;
+  reason: AgentLoopCompactionReason;
+  inputMessageCount: number;
+  outputMessageCount: number;
+  summarizedMessageCount: number;
+  retainedTailCount: number;
+  summary: string;
+  modelVisibleSummary: string;
+  userMessages: AgentLoopCompactionMessageRef[];
+  assistantDecisions: Array<AgentLoopCompactionMessageRef & { toolCalls?: AgentLoopToolCall[] }>;
+  toolObservations: AgentLoopCompactionToolObservationRef[];
+  pendingPermissions: AgentLoopCompactionPendingPermission[];
+  activeTargets: AgentLoopCompactionToolTarget[];
+  archivedTargets: AgentLoopCompactionToolTarget[];
+  replacementHistory: AgentLoopCompactionReplacementHistory;
+}
+
+export function cloneAgentLoopCompactionRecords(
+  records: readonly AgentLoopCompactionRecord[] | undefined,
+): AgentLoopCompactionRecord[] {
+  return records ? records.map((record) => cloneJson(record)) : [];
+}
+
+function cloneJson<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
+}

--- a/src/orchestrator/execution/agent-loop/agent-loop-compactor.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-compactor.ts
@@ -1,8 +1,17 @@
-import type { AgentLoopMessage } from "./agent-loop-model.js";
+import type { AgentLoopMessage, AgentLoopToolObservation } from "./agent-loop-model.js";
 import type { AgentLoopHistory } from "./agent-loop-history.js";
+import type {
+  AgentLoopCompactionPhase,
+  AgentLoopCompactionReason,
+  AgentLoopCompactionRecord,
+  AgentLoopCompactionToolObservationRef,
+  AgentLoopCompactionToolTarget,
+  AgentLoopCompactionMessageRef,
+  AgentLoopCompactionPendingPermission,
+} from "./agent-loop-compaction-record.js";
+import { AGENT_LOOP_COMPACTION_RECORD_SCHEMA_VERSION } from "./agent-loop-compaction-record.js";
 
-export type AgentLoopCompactionPhase = "pre_turn" | "mid_turn" | "standalone_turn";
-export type AgentLoopCompactionReason = "context_limit" | "model_downshift" | "manual";
+export type { AgentLoopCompactionPhase, AgentLoopCompactionReason } from "./agent-loop-compaction-record.js";
 
 export interface AgentLoopCompactionInput {
   history: AgentLoopHistory;
@@ -23,7 +32,14 @@ export interface AgentLoopCompactor {
 
 export class NoopAgentLoopCompactor implements AgentLoopCompactor {
   async compact(input: AgentLoopCompactionInput): Promise<AgentLoopCompactionResult> {
-    return { history: input.history, compacted: false };
+    return {
+      history: {
+        ...input.history,
+        messages: [...input.history.messages],
+        compactionRecords: [...input.history.compactionRecords],
+      },
+      compacted: false,
+    };
   }
 }
 
@@ -50,53 +66,271 @@ export class ExtractiveAgentLoopCompactor implements AgentLoopCompactor {
       return { history: input.history, compacted: false };
     }
 
-    const systemMessages = messages.filter((message) => message.role === "system");
-    const nonSystemMessages = messages.filter((message) => message.role !== "system");
+    const indexedMessages = messages.map((message, index) => ({ message, index }));
+    const systemEntries = indexedMessages.filter(({ message }) => message.role === "system");
+    const nonSystemEntries = indexedMessages.filter(({ message }) => message.role !== "system");
+    const systemMessages = systemEntries.map(({ message }) => message);
     const tailCount = Math.max(2, maxMessages - systemMessages.length - 1);
-    const rawTail = nonSystemMessages.slice(-tailCount);
-    const tail = rawTail.filter((message) => !isCompactionSummaryMessage(message));
-    const tailSet = new Set(rawTail);
-    const summarized = nonSystemMessages
-      .filter((message) => !tailSet.has(message))
-      .filter((message) => !isCompactionSummaryMessage(message));
+    const rawTailEntries = nonSystemEntries.slice(-tailCount);
+    const tailEntries = rawTailEntries.filter(({ message }) => !isCompactionSummaryMessage(message));
+    const tailIndexSet = new Set(rawTailEntries.map(({ index }) => index));
+    const summarizedEntries = nonSystemEntries
+      .filter(({ index }) => !tailIndexSet.has(index))
+      .filter(({ message }) => !isCompactionSummaryMessage(message));
+    const tail = tailEntries.map(({ message }) => message);
+    const summarized = summarizedEntries.map(({ message }) => message);
 
     if (summarized.length === 0) {
       return {
-        history: { messages: [...systemMessages, ...tail], compacted: input.history.compacted },
+        history: {
+          messages: [...systemMessages, ...tail],
+          compacted: input.history.compacted,
+          compactionRecords: [...input.history.compactionRecords],
+        },
         compacted: false,
       };
     }
 
-    const summary = this.buildSummary(summarized, input);
+    const recordDraft = this.buildRecordDraft(summarizedEntries, tailEntries, systemEntries, input);
+    const summary = this.buildSummary(recordDraft, input);
+    const modelVisibleSummary = `${AGENT_LOOP_COMPACTION_SUMMARY_PREFIX}\n${summary}`;
     const replacement: AgentLoopMessage[] = [
       ...systemMessages,
-      { role: "user", content: `${AGENT_LOOP_COMPACTION_SUMMARY_PREFIX}\n${summary}` },
+      { role: "user", content: modelVisibleSummary },
       ...tail,
     ];
-
+    const record: AgentLoopCompactionRecord = {
+      schemaVersion: AGENT_LOOP_COMPACTION_RECORD_SCHEMA_VERSION,
+      sequence: input.history.compactionRecords.length,
+      createdAt: new Date().toISOString(),
+      phase: input.phase ?? "standalone_turn",
+      reason: input.reason ?? "context_limit",
+      inputMessageCount: messages.length,
+      outputMessageCount: replacement.length,
+      summarizedMessageCount: summarizedEntries.length,
+      retainedTailCount: tailEntries.length,
+      summary,
+      modelVisibleSummary,
+      ...recordDraft,
+    };
     return {
-      history: { messages: replacement, compacted: true },
+      history: {
+        messages: replacement,
+        compacted: true,
+        compactionRecords: [...input.history.compactionRecords, record],
+      },
       compacted: true,
       summary,
     };
   }
 
+  private buildRecordDraft(
+    summarizedEntries: Array<{ message: AgentLoopMessage; index: number }>,
+    tailEntries: Array<{ message: AgentLoopMessage; index: number }>,
+    systemEntries: Array<{ message: AgentLoopMessage; index: number }>,
+    input: AgentLoopCompactionInput,
+  ): Omit<
+    AgentLoopCompactionRecord,
+    | "schemaVersion"
+    | "sequence"
+    | "createdAt"
+    | "phase"
+    | "reason"
+    | "inputMessageCount"
+    | "outputMessageCount"
+    | "summarizedMessageCount"
+    | "retainedTailCount"
+    | "summary"
+    | "modelVisibleSummary"
+  > {
+    const targetEntries = [
+      ...summarizedEntries.map((entry) => ({ ...entry, state: "archived" as const })),
+      ...tailEntries.map((entry) => ({ ...entry, state: "retained" as const })),
+    ];
+    return {
+      userMessages: summarizedEntries
+        .filter(({ message }) => message.role === "user")
+        .map(({ message, index }) => messageRef(message, index)),
+      assistantDecisions: summarizedEntries
+        .filter(({ message }) => message.role === "assistant")
+        .map(({ message, index }) => ({
+          ...messageRef(message, index),
+          ...(message.toolCalls && message.toolCalls.length > 0 ? { toolCalls: cloneJson(message.toolCalls) } : {}),
+        })),
+      toolObservations: summarizedEntries.flatMap(({ message, index }) =>
+        message.observation ? [toolObservationRef(message.observation, index)] : []
+      ),
+      pendingPermissions: summarizedEntries.flatMap(({ message, index }) =>
+        message.observation && isPermissionConstraint(message.observation)
+          ? [pendingPermissionRef(message.observation, index)]
+          : []
+      ),
+      activeTargets: targetEntries.flatMap(({ message, index, state }) =>
+        state === "retained" ? toolTargets(message, index, state) : []
+      ),
+      archivedTargets: targetEntries.flatMap(({ message, index, state }) =>
+        state === "archived" ? toolTargets(message, index, state) : []
+      ),
+      replacementHistory: {
+        summarizedIndexes: summarizedEntries.map(({ index }) => index),
+        retainedIndexes: tailEntries.map(({ index }) => index),
+        systemIndexes: systemEntries.map(({ index }) => index),
+        summaryMessageInserted: summarizedEntries.length > 0,
+      },
+    };
+  }
+
   private buildSummary(
-    messages: AgentLoopMessage[],
+    record: Omit<
+      AgentLoopCompactionRecord,
+      | "schemaVersion"
+      | "sequence"
+      | "createdAt"
+      | "phase"
+      | "reason"
+      | "inputMessageCount"
+      | "outputMessageCount"
+      | "summarizedMessageCount"
+      | "retainedTailCount"
+      | "summary"
+      | "modelVisibleSummary"
+    >,
     input: AgentLoopCompactionInput,
   ): string {
     const header = [
       `phase: ${input.phase ?? "standalone_turn"}`,
       `reason: ${input.reason ?? "context_limit"}`,
-      "Preserve task intent, tool results, files, failures, and pending constraints.",
+      "Preserve task intent, tool results, files, failures, permissions, retained current targets, and archived stale targets.",
     ].join("\n");
-    const body = messages.map((message, index) => {
-      const label = [index + 1, message.role, message.toolName ? `tool=${message.toolName}` : ""]
-        .filter(Boolean)
-        .join(" ");
-      return `- ${label}: ${preview(message.content, 900)}`;
-    }).join("\n");
-    return preview(`${header}\n${body}`, this.maxSummaryChars);
+    const userMessages = record.userMessages.map((message) =>
+      `- message_index=${message.index}: ${preview(message.content, 700)}`
+    );
+    const assistantDecisions = record.assistantDecisions.map((message) => {
+      const tools = message.toolCalls?.map((call) => call.name).join(", ");
+      return `- message_index=${message.index}${tools ? ` tool_calls=${tools}` : ""}: ${preview(message.content, 700)}`;
+    });
+    const toolObservations = record.toolObservations.map((observation) =>
+      `- message_index=${observation.index} tool=${observation.toolName} state=${observation.state} executed=${observation.execution?.status ?? "unknown"}: ${preview(observation.output.summary ?? observation.output.content, 700)}`
+    );
+    const pendingPermissions = record.pendingPermissions.map((permission) =>
+      `- message_index=${permission.index} tool=${permission.toolName} state=${permission.state} reason=${permission.execution?.reason ?? "unknown"}: ${preview(permission.output.summary ?? permission.output.content, 500)}`
+    );
+    const activeTargets = record.activeTargets.map((target) =>
+      `- retained message_index=${target.index} tool=${target.toolName} call_id=${target.callId}: ${preview(stringify(target.input ?? target.arguments ?? target.outputData ?? {}), 500)}`
+    );
+    const archivedTargets = record.archivedTargets.map((target) =>
+      `- archived message_index=${target.index} tool=${target.toolName} call_id=${target.callId}; do not treat as current unless a later retained message re-selects it.`
+    );
+    const replacement = [
+      `- summarized_indexes: ${record.replacementHistory.summarizedIndexes.join(", ") || "none"}`,
+      `- retained_indexes: ${record.replacementHistory.retainedIndexes.join(", ") || "none"}`,
+    ];
+    const sections = [
+      section("User messages", userMessages),
+      section("Assistant decisions", assistantDecisions),
+      section("Tool observations", toolObservations),
+      section("Pending permissions", pendingPermissions),
+      section("Retained active targets", activeTargets),
+      section("Archived stale targets", archivedTargets),
+      section("Replacement history", replacement),
+    ].filter(Boolean);
+    return preview(`${header}\n${sections.join("\n")}`, this.maxSummaryChars);
+  }
+}
+
+function messageRef(message: AgentLoopMessage, index: number): AgentLoopCompactionMessageRef {
+  return {
+    index,
+    role: message.role,
+    content: message.content,
+    ...(message.phase ? { phase: message.phase } : {}),
+    ...(message.toolCallId ? { toolCallId: message.toolCallId } : {}),
+    ...(message.toolName ? { toolName: message.toolName } : {}),
+  };
+}
+
+function toolObservationRef(
+  observation: AgentLoopToolObservation,
+  index: number,
+): AgentLoopCompactionToolObservationRef {
+  return {
+    index,
+    callId: observation.callId,
+    toolName: observation.toolName,
+    state: observation.state,
+    success: observation.success,
+    ...(observation.execution ? { execution: { ...observation.execution } } : {}),
+    arguments: cloneJson(observation.arguments),
+    output: cloneJson(observation.output),
+    ...(observation.command ? { command: observation.command } : {}),
+    ...(observation.cwd ? { cwd: observation.cwd } : {}),
+    ...(observation.artifacts ? { artifacts: [...observation.artifacts] } : {}),
+    ...(observation.activityCategory ? { activityCategory: observation.activityCategory } : {}),
+  };
+}
+
+function pendingPermissionRef(
+  observation: NonNullable<AgentLoopMessage["observation"]>,
+  index: number,
+): AgentLoopCompactionPendingPermission {
+  return {
+    index,
+    callId: observation.callId,
+    toolName: observation.toolName,
+    state: observation.state,
+    ...(observation.execution ? { execution: { ...observation.execution } } : {}),
+    output: cloneJson(observation.output),
+  };
+}
+
+function isPermissionConstraint(observation: NonNullable<AgentLoopMessage["observation"]>): boolean {
+  if (observation.execution?.status !== "not_executed") return false;
+  return observation.state === "denied" || observation.state === "blocked";
+}
+
+function toolTargets(
+  message: AgentLoopMessage,
+  index: number,
+  state: AgentLoopCompactionToolTarget["state"],
+): AgentLoopCompactionToolTarget[] {
+  const assistantTargets = (message.toolCalls ?? []).map((call): AgentLoopCompactionToolTarget => ({
+    state,
+    source: "assistant_tool_call",
+    index,
+    callId: call.id,
+    toolName: call.name,
+    input: cloneJson(call.input),
+  }));
+  const observation = message.observation;
+  const observationTargets = observation ? [{
+    state,
+    source: "tool_observation" as const,
+    index,
+    callId: observation.callId,
+    toolName: observation.toolName,
+    arguments: cloneJson(observation.arguments),
+    ...(Object.prototype.hasOwnProperty.call(observation.output, "data")
+      ? { outputData: cloneJson(observation.output.data) }
+      : {}),
+  }] : [];
+  return [...assistantTargets, ...observationTargets];
+}
+
+function section(title: string, lines: string[]): string {
+  return lines.length > 0 ? `${title}:\n${lines.join("\n")}` : "";
+}
+
+function cloneJson<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function stringify(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
   }
 }
 

--- a/src/orchestrator/execution/agent-loop/agent-loop-history.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-history.ts
@@ -1,14 +1,28 @@
 import type { AgentLoopMessage } from "./agent-loop-model.js";
+import type { AgentLoopCompactionRecord } from "./agent-loop-compaction-record.js";
+import { cloneAgentLoopCompactionRecords } from "./agent-loop-compaction-record.js";
 
 export interface AgentLoopHistory {
   messages: AgentLoopMessage[];
   compacted: boolean;
+  compactionRecords: AgentLoopCompactionRecord[];
 }
 
-export function createAgentLoopHistory(messages: AgentLoopMessage[] = []): AgentLoopHistory {
-  return { messages: [...messages], compacted: false };
+export function createAgentLoopHistory(
+  messages: AgentLoopMessage[] = [],
+  compactionRecords: readonly AgentLoopCompactionRecord[] = [],
+): AgentLoopHistory {
+  return {
+    messages: [...messages],
+    compacted: compactionRecords.length > 0,
+    compactionRecords: cloneAgentLoopCompactionRecords(compactionRecords),
+  };
 }
 
 export function appendAgentLoopHistory(history: AgentLoopHistory, messages: AgentLoopMessage[]): AgentLoopHistory {
-  return { ...history, messages: [...history.messages, ...messages] };
+  return {
+    ...history,
+    messages: [...history.messages, ...messages],
+    compactionRecords: cloneAgentLoopCompactionRecords(history.compactionRecords),
+  };
 }

--- a/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-session-state.ts
@@ -11,6 +11,11 @@ import type {
   AgentLoopToolObservationReason,
   AgentLoopToolObservationState,
 } from "./agent-loop-model.js";
+import type { AgentLoopCompactionRecord } from "./agent-loop-compaction-record.js";
+import {
+  AGENT_LOOP_COMPACTION_RECORD_SCHEMA_VERSION,
+  cloneAgentLoopCompactionRecords,
+} from "./agent-loop-compaction-record.js";
 
 export interface AgentLoopSessionState {
   sessionId: string;
@@ -21,6 +26,7 @@ export interface AgentLoopSessionState {
   cwd: string;
   modelRef: string;
   messages: AgentLoopMessage[];
+  compactionRecords?: AgentLoopCompactionRecord[];
   modelTurns: number;
   toolCalls: number;
   usage?: {
@@ -53,6 +59,7 @@ export class InMemoryAgentLoopSessionStateStore implements AgentLoopSessionState
       ? {
           ...this.state,
           messages: [...this.state.messages],
+          compactionRecords: cloneAgentLoopCompactionRecords(this.state.compactionRecords),
           calledTools: [...this.state.calledTools],
           ...(this.state.usage ? { usage: { ...this.state.usage } } : {}),
         }
@@ -63,6 +70,7 @@ export class InMemoryAgentLoopSessionStateStore implements AgentLoopSessionState
     this.state = {
       ...state,
       messages: [...state.messages],
+      compactionRecords: cloneAgentLoopCompactionRecords(state.compactionRecords),
       calledTools: [...state.calledTools],
       ...(state.usage ? { usage: { ...state.usage } } : {}),
     };
@@ -112,6 +120,7 @@ export function normalizeAgentLoopSessionState(value: unknown): AgentLoopSession
     cwd,
     modelRef,
     messages,
+    compactionRecords: normalizeCompactionRecords(value["compactionRecords"]),
     modelTurns: nonNegativeNumberField(value, "modelTurns"),
     toolCalls: nonNegativeNumberField(value, "toolCalls"),
     usage: usageField(value),
@@ -187,6 +196,30 @@ function normalizeToolObservation(value: unknown): AgentLoopToolObservation | nu
     ...(truncated ? { truncated } : {}),
     ...(toolActivityCategoryField(value, "activityCategory") ? { activityCategory: toolActivityCategoryField(value, "activityCategory")! } : {}),
   };
+}
+
+function normalizeCompactionRecords(value: unknown): AgentLoopCompactionRecord[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter(isAgentLoopCompactionRecord)
+    .map((record) => cloneJson(record));
+}
+
+function isAgentLoopCompactionRecord(value: unknown): value is AgentLoopCompactionRecord {
+  if (!isRecord(value)) return false;
+  if (value["schemaVersion"] !== AGENT_LOOP_COMPACTION_RECORD_SCHEMA_VERSION) return false;
+  if (typeof value["sequence"] !== "number" || !Number.isFinite(value["sequence"]) || value["sequence"] < 0) return false;
+  if (typeof value["createdAt"] !== "string") return false;
+  if (typeof value["summary"] !== "string" || typeof value["modelVisibleSummary"] !== "string") return false;
+  if (!Array.isArray(value["userMessages"]) || !Array.isArray(value["toolObservations"])) return false;
+  if (!Array.isArray(value["pendingPermissions"]) || !Array.isArray(value["activeTargets"])) return false;
+  if (!Array.isArray(value["archivedTargets"]) || !isRecord(value["replacementHistory"])) return false;
+  return true;
+}
+
+function cloneJson<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
 }
 
 function normalizeObservationExecution(value: unknown): AgentLoopToolObservationExecution | null {

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -19,6 +19,8 @@ import { createAgentLoopHistory } from "./agent-loop-history.js";
 import { formatAgentLoopModelRef } from "./agent-loop-model.js";
 import type { AgentLoopCompactionPhase, AgentLoopCompactionReason, AgentLoopCompactor } from "./agent-loop-compactor.js";
 import { ExtractiveAgentLoopCompactor } from "./agent-loop-compactor.js";
+import type { AgentLoopCompactionRecord } from "./agent-loop-compaction-record.js";
+import { cloneAgentLoopCompactionRecords } from "./agent-loop-compaction-record.js";
 import { classifyAgentLoopCommandResult } from "./agent-loop-command-classifier.js";
 import type { AgentLoopSessionState } from "./agent-loop-session-state.js";
 import type { FunctionToolCallResponseItem } from "./response-item.js";
@@ -52,12 +54,52 @@ export class BoundedAgentLoopRunner {
     let completionValidationAttempts = resumed?.completionValidationAttempts ?? 0;
     let finalText = resumed?.finalText ?? "";
     let compactions = resumed?.compactions ?? 0;
+    let compactionRecords = cloneAgentLoopCompactionRecords(resumed?.compactionRecords);
     const calledTools = new Set<string>(resumed?.calledTools ?? []);
     let lastToolLoopSignature: string | null = resumed?.lastToolLoopSignature ?? null;
     let repeatedToolLoopCount = resumed?.repeatedToolLoopCount ?? 0;
     const commandResults: AgentLoopCommandResult[] = [];
     const toolResultSummaries: AgentLoopToolResultSummary[] = [];
     const initialWorkspaceSnapshot = await this.captureWorkspaceSnapshot(turn.cwd);
+    const stop = (
+      reason: AgentLoopStopReason,
+      startedAt: number,
+      modelTurns: number,
+      toolCalls: number,
+      finalText: string,
+      output: TOutput | null,
+      success = false,
+      compactions = 0,
+      changedFiles: string[] = [],
+      toolResults: AgentLoopToolResultSummary[] = [],
+      commandResults: AgentLoopCommandResult[] = [],
+      messages?: AgentLoopMessage[],
+      calledTools?: Set<string>,
+      lastToolLoopSignature?: string | null,
+      repeatedToolLoopCount?: number,
+      completionValidationAttempts?: number,
+      reasonDetail?: string,
+    ): Promise<AgentLoopResult<TOutput>> => this.stop(
+      turn,
+      reason,
+      startedAt,
+      modelTurns,
+      toolCalls,
+      finalText,
+      output,
+      success,
+      compactions,
+      changedFiles,
+      toolResults,
+      commandResults,
+      messages,
+      calledTools,
+      lastToolLoopSignature,
+      repeatedToolLoopCount,
+      completionValidationAttempts,
+      reasonDetail,
+      compactionRecords,
+    );
 
     await this.record(turn, {
       type: "started",
@@ -74,26 +116,27 @@ export class BoundedAgentLoopRunner {
     }
 
     let messages: AgentLoopMessage[] = resumed?.messages ? [...resumed.messages] : [...turn.messages];
-    const preTurnCompaction = await this.compactIfNeeded(turn, messages, "pre_turn", "context_limit", undefined, compactions);
+    const preTurnCompaction = await this.compactIfNeeded(turn, messages, "pre_turn", "context_limit", undefined, compactions, compactionRecords);
     if (preTurnCompaction.error) {
-        return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, [], toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, [], toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
     }
     messages = preTurnCompaction.messages;
+    compactionRecords = preTurnCompaction.compactionRecords;
     compactions += preTurnCompaction.compacted ? 1 : 0;
-    await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+    await this.saveState(turn, messages, compactionRecords, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
 
     while (true) {
       if (Date.now() - startedAt > turn.budget.maxWallClockMs) {
-        return this.stop(turn, "timeout", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("timeout", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (modelTurns >= turn.budget.maxModelTurns) {
-        return this.stop(turn, "max_model_turns", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("max_model_turns", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (toolCalls >= turn.budget.maxToolCalls) {
-        return this.stop(turn, "max_tool_calls", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("max_tool_calls", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (turn.abortSignal?.aborted) {
-        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
 
       const tools = this.deps.toolRouter.modelVisibleTools(turn as AgentLoopTurnContext<unknown>);
@@ -118,11 +161,10 @@ export class BoundedAgentLoopRunner {
         protocol = await this.createTurnProtocol(turn, messages, tools);
       } catch (err) {
         if (turn.abortSignal?.aborted) {
-          return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, "Agent loop stopped: operator stop aborted active model work.", null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts, err instanceof Error ? err.message : String(err));
+          return stop("cancelled", startedAt, modelTurns, toolCalls, "Agent loop stopped: operator stop aborted active model work.", null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts, err instanceof Error ? err.message : String(err));
         }
         const failure = this.classifyRunFailure(err);
-        return this.stop(
-          turn,
+        return stop(
           failure.reason,
           startedAt,
           modelTurns,
@@ -143,10 +185,10 @@ export class BoundedAgentLoopRunner {
         );
       }
       if (!protocol.responseCompleted) {
-        return this.stop(turn, "protocol_incomplete", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("protocol_incomplete", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (turn.abortSignal?.aborted) {
-        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
 
       const response = this.protocolToResponse(protocol);
@@ -168,7 +210,7 @@ export class BoundedAgentLoopRunner {
           if (response.content.trim().length === 0) {
             schemaRepairAttempts++;
             if (schemaRepairAttempts > turn.budget.maxSchemaRepairAttempts) {
-              return this.stop(turn, "schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+              return stop("schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
             }
 
             messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
@@ -176,13 +218,14 @@ export class BoundedAgentLoopRunner {
               role: "user",
               content: "Your final answer was empty. Return a user-visible Markdown or plain text answer for the user.",
             });
-            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
+            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions, compactionRecords);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+              return stop("fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
             }
             messages = compacted.messages;
+            compactionRecords = compacted.compactionRecords;
             compactions += compacted.compacted ? 1 : 0;
-            await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+            await this.saveState(turn, messages, compactionRecords, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
             continue;
           }
 
@@ -193,13 +236,14 @@ export class BoundedAgentLoopRunner {
               role: "user",
               content: `Before the final answer, call these required tool(s) at least once: ${missingRequiredTools.join(", ")}.`,
             });
-            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
+            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions, compactionRecords);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+              return stop("fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
             }
             messages = compacted.messages;
+            compactionRecords = compacted.compactionRecords;
             compactions += compacted.compacted ? 1 : 0;
-            await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+            await this.saveState(turn, messages, compactionRecords, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
             continue;
           }
 
@@ -210,7 +254,7 @@ export class BoundedAgentLoopRunner {
             success: true,
             outputPreview: this.preview(response.content),
           });
-          return this.stop(turn, "completed", startedAt, modelTurns, toolCalls, response.content, null, true, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+          return stop("completed", startedAt, modelTurns, toolCalls, response.content, null, true, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
         }
 
         const parsed = this.parseFinal(response.content, turn.outputSchema);
@@ -222,13 +266,14 @@ export class BoundedAgentLoopRunner {
               role: "user",
               content: `Before the final answer, call these required tool(s) at least once: ${missingRequiredTools.join(", ")}.`,
             });
-            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
+            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions, compactionRecords);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+              return stop("fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
             }
             messages = compacted.messages;
+            compactionRecords = compacted.compactionRecords;
             compactions += compacted.compacted ? 1 : 0;
-            await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+            await this.saveState(turn, messages, compactionRecords, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
             continue;
           }
 
@@ -244,7 +289,7 @@ export class BoundedAgentLoopRunner {
           if (completionValidation && !completionValidation.ok) {
             completionValidationAttempts++;
             if (completionValidationAttempts > turn.budget.maxCompletionValidationAttempts) {
-              return this.stop(turn, "completion_gate_failed", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+              return stop("completion_gate_failed", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
             }
 
             messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
@@ -252,13 +297,14 @@ export class BoundedAgentLoopRunner {
               role: "user",
               content: this.buildCompletionRepairPrompt(completionValidation.reasons),
             });
-            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
+            const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions, compactionRecords);
             if (compacted.error) {
-              return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+              return stop("fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
             }
             messages = compacted.messages;
+            compactionRecords = compacted.compactionRecords;
             compactions += compacted.compacted ? 1 : 0;
-            await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+            await this.saveState(turn, messages, compactionRecords, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
             continue;
           }
 
@@ -268,12 +314,12 @@ export class BoundedAgentLoopRunner {
             success: true,
             outputPreview: this.preview(response.content),
           });
-          return this.stop(turn, "completed", startedAt, modelTurns, toolCalls, response.content, parsed.output, true, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
+          return stop("completed", startedAt, modelTurns, toolCalls, response.content, parsed.output, true, compactions, changedFiles, toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts);
         }
 
         schemaRepairAttempts++;
         if (schemaRepairAttempts > turn.budget.maxSchemaRepairAttempts) {
-          return this.stop(turn, "schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return stop("schema_error", startedAt, modelTurns, toolCalls, response.content, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
 
         messages.push({ role: "assistant", content: response.content, phase: "final_answer" });
@@ -281,13 +327,14 @@ export class BoundedAgentLoopRunner {
           role: "user",
           content: `Your final answer did not match the required JSON schema. Return only valid JSON. Parse error: ${parsed.error}`,
         });
-        const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
+        const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions, compactionRecords);
         if (compacted.error) {
-          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return stop("fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         messages = compacted.messages;
+        compactionRecords = compacted.compactionRecords;
         compactions += compacted.compacted ? 1 : 0;
-        await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+        await this.saveState(turn, messages, compactionRecords, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
         continue;
       }
 
@@ -308,10 +355,10 @@ export class BoundedAgentLoopRunner {
       }
 
       if (repeatedToolLoopCount > turn.budget.maxRepeatedToolCalls) {
-        return this.stop(turn, "stalled_tool_loop", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("stalled_tool_loop", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       if (turn.abortSignal?.aborted) {
-        return this.stop(turn, "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
 
       for (const call of response.toolCalls) {
@@ -415,23 +462,24 @@ export class BoundedAgentLoopRunner {
         }
 
         if (result.disposition === "fatal" || result.fatal) {
-          return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return stop("fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         if (result.disposition === "cancelled") {
-          return this.stop(turn, toolBatchTimedOut ? "timeout" : "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return stop(toolBatchTimedOut ? "timeout" : "cancelled", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
         if (consecutiveToolErrors >= turn.budget.maxConsecutiveToolErrors) {
-          return this.stop(turn, "consecutive_tool_errors", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+          return stop("consecutive_tool_errors", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
         }
       }
 
-      const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions);
+      const compacted = await this.compactIfNeeded(turn, messages, "mid_turn", "context_limit", this.responseUsageTokens(protocol), compactions, compactionRecords);
       if (compacted.error) {
-        return this.stop(turn, "fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
+        return stop("fatal_error", startedAt, modelTurns, toolCalls, finalText, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount);
       }
       messages = compacted.messages;
+      compactionRecords = compacted.compactionRecords;
       compactions += compacted.compacted ? 1 : 0;
-      await this.saveState(turn, messages, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
+      await this.saveState(turn, messages, compactionRecords, modelTurns, toolCalls, compactions, completionValidationAttempts, calledTools, lastToolLoopSignature, repeatedToolLoopCount, finalText, "running");
     }
   }
 
@@ -471,10 +519,12 @@ export class BoundedAgentLoopRunner {
     repeatedToolLoopCount?: number,
     completionValidationAttempts?: number,
     reasonDetail?: string,
+    compactionRecords: readonly AgentLoopCompactionRecord[] = [],
   ): Promise<AgentLoopResult<TOutput>> {
     await this.saveState(
       turn,
       messages ?? turn.messages,
+      compactionRecords,
       modelTurns,
       toolCalls,
       compactions,
@@ -589,26 +639,31 @@ export class BoundedAgentLoopRunner {
     reason: AgentLoopCompactionReason,
     usageTokens: number | undefined,
     compactions: number,
-  ): Promise<{ messages: AgentLoopMessage[]; compacted: boolean; error?: string }> {
+    compactionRecords: readonly AgentLoopCompactionRecord[],
+  ): Promise<{ messages: AgentLoopMessage[]; compactionRecords: AgentLoopCompactionRecord[]; compacted: boolean; error?: string }> {
     const limit = this.autoCompactLimit(turn);
     if (!limit || compactions >= turn.budget.maxCompactions) {
-      return { messages, compacted: false };
+      return { messages, compactionRecords: cloneAgentLoopCompactionRecords(compactionRecords), compacted: false };
     }
 
     const tokens = usageTokens && usageTokens > 0 ? usageTokens : this.estimateTokens(messages);
     if (tokens < limit) {
-      return { messages, compacted: false };
+      return { messages, compactionRecords: cloneAgentLoopCompactionRecords(compactionRecords), compacted: false };
     }
 
     try {
       const result = await this.compactor.compact({
-        history: createAgentLoopHistory(messages),
+        history: createAgentLoopHistory(messages, compactionRecords),
         maxMessages: turn.budget.compactionMaxMessages,
         phase,
         reason,
       });
       if (!result.compacted) {
-        return { messages: result.history.messages, compacted: false };
+        return {
+          messages: result.history.messages,
+          compactionRecords: cloneAgentLoopCompactionRecords(result.history.compactionRecords),
+          compacted: false,
+        };
       }
       await this.record(turn, {
         type: "context_compaction",
@@ -619,9 +674,18 @@ export class BoundedAgentLoopRunner {
         outputMessages: result.history.messages.length,
         summaryPreview: this.preview(result.summary ?? ""),
       });
-      return { messages: result.history.messages, compacted: true };
+      return {
+        messages: result.history.messages,
+        compactionRecords: cloneAgentLoopCompactionRecords(result.history.compactionRecords),
+        compacted: true,
+      };
     } catch (err) {
-      return { messages, compacted: false, error: err instanceof Error ? err.message : String(err) };
+      return {
+        messages,
+        compactionRecords: cloneAgentLoopCompactionRecords(compactionRecords),
+        compacted: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
     }
   }
 
@@ -814,6 +878,7 @@ export class BoundedAgentLoopRunner {
   private async saveState<TOutput>(
     turn: AgentLoopTurnContext<TOutput>,
     messages: AgentLoopMessage[],
+    compactionRecords: readonly AgentLoopCompactionRecord[],
     modelTurns: number,
     toolCalls: number,
     compactions: number,
@@ -835,6 +900,7 @@ export class BoundedAgentLoopRunner {
       cwd: turn.cwd,
       modelRef: formatAgentLoopModelRef(turn.model),
       messages,
+      compactionRecords: cloneAgentLoopCompactionRecords(compactionRecords),
       modelTurns,
       toolCalls,
       compactions,

--- a/src/orchestrator/execution/agent-loop/index.ts
+++ b/src/orchestrator/execution/agent-loop/index.ts
@@ -1,6 +1,7 @@
 export * from "./agent-loop-budget.js";
 export * from "./agent-loop-command-classifier.js";
 export * from "./agent-loop-compactor.js";
+export * from "./agent-loop-compaction-record.js";
 export * from "./agent-loop-context-assembler.js";
 export * from "./agent-loop-default-profile.js";
 export * from "./agent-loop-dogfood-benchmark.js";


### PR DESCRIPTION
## Summary

- add structured compaction records for bounded agent-loop history with archived messages, tool observations, pending permission constraints, retained active targets, archived stale targets, and replacement history
- persist agent-loop compaction records through resume state and expose chat compaction records through session loading/saving
- make chat `/compact` store typed replay/audit metadata and render bounded compaction record details in model-visible turn context

Closes #1117

## Verification

- `npm run typecheck`
- `npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-phases-3-7.test.ts -t "agentloop phase 5 compaction" --reporter verbose`
- `npx vitest run --config vitest.config.ts src/interface/chat/__tests__/chat-history.test.ts src/interface/chat/__tests__/turn-context.test.ts src/interface/chat/__tests__/chat-runner.test.ts -t "compacts|compaction|/compact" --reporter verbose`
- `npm run test:changed`
- `npm run lint:boundaries` (0 errors, existing warnings only)

## Review

- fresh review found two material issues; both fixed
- second fresh review after fixes reported no findings
