### PR TITLE
Fix non-git task diff evidence

### DIFF
--- a/src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts
+++ b/src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import type { AgentResult, IAdapter } from "../adapter-layer.js";
 import { executeTask, type TaskExecutorDeps } from "../task/task-executor.js";
 import type { Task } from "../../../base/types/task.js";
 import type { SessionManager } from "../session-manager.js";
+import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 
 vi.mock("../../../base/llm/provider-config.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../../base/llm/provider-config.js")>();
@@ -54,10 +57,13 @@ describe("executeTask protected paths", () => {
   let sessionManager: SessionManager;
   let adapter: IAdapter;
   let execFileSyncFn: TaskExecutorDeps["execFileSyncFn"];
+  let workspace: string;
 
   beforeEach(() => {
+    workspace = makeTempDir();
+    fs.mkdirSync(path.join(workspace, ".git"), { recursive: true });
     stateManager = {
-      loadGoal: vi.fn().mockResolvedValue({ constraints: ["workspace_path:/repo"] }),
+      loadGoal: vi.fn().mockResolvedValue({ constraints: [`workspace_path:${workspace}`] }),
       readRaw: vi.fn().mockResolvedValue(null),
       writeRaw: vi.fn().mockResolvedValue(undefined),
     } as unknown as TaskExecutorDeps["stateManager"];
@@ -84,6 +90,10 @@ describe("executeTask protected paths", () => {
     });
   });
 
+  afterEach(() => {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
   it("fails successful task results when configured protected paths are modified", async () => {
     const result = await executeTask(
       {
@@ -100,8 +110,10 @@ describe("executeTask protected paths", () => {
   });
 
   it("uses task workspace_path before goal workspace_path for adapter cwd, diff capture, and protected-path checks", async () => {
-    const goalWorkspace = "/repo/goal-workspace";
-    const taskWorkspace = "/repo/task-workspace";
+    const goalWorkspace = path.join(workspace, "goal-workspace");
+    const taskWorkspace = path.join(workspace, "task-workspace");
+    fs.mkdirSync(path.join(goalWorkspace, ".git"), { recursive: true });
+    fs.mkdirSync(path.join(taskWorkspace, ".git"), { recursive: true });
     vi.mocked(stateManager.loadGoal).mockResolvedValue({ constraints: [`workspace_path:${goalWorkspace}`] } as never);
     const execute = vi.fn().mockResolvedValue({
       success: true,

--- a/src/orchestrator/execution/__tests__/task-lifecycle-execution-guards.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-execution-guards.test.ts
@@ -161,6 +161,8 @@ describe("TaskLifecycle — executeTask guardrail behavior", () => {
   it("passes task workspace_path through the run-adapter caller path and diff capture", async () => {
     const goalWorkspace = `${tmpDir}/goal-workspace`;
     const taskWorkspace = `${tmpDir}/task-workspace`;
+    fs.mkdirSync(`${goalWorkspace}/.git`, { recursive: true });
+    fs.mkdirSync(`${taskWorkspace}/.git`, { recursive: true });
     await stateManager.writeRaw("goals/goal-1/goal.json", {
       id: "goal-1",
       title: "Test goal",

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { z } from "zod";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import type { ILLMClient, LLMMessage, LLMRequestOptions, LLMResponse } from "../../../../base/llm/llm-client.js";
 import type { ITool, PermissionCheckResult, ToolCallContext, ToolResult } from "../../../../tools/types.js";
 import { ToolRegistry } from "../../../../tools/registry.js";
@@ -8,6 +9,7 @@ import { ToolPermissionManager } from "../../../../tools/permission.js";
 import { ConcurrencyController } from "../../../../tools/concurrency.js";
 import { ToolExecutor } from "../../../../tools/executor.js";
 import { ToolSearchTool } from "../../../../tools/query/ToolSearchTool/ToolSearchTool.js";
+import { ApplyPatchTool } from "../../../../tools/fs/ApplyPatchTool/ApplyPatchTool.js";
 import { StateManager } from "../../../../base/state/state-manager.js";
 import { SessionManager } from "../../session-manager.js";
 import { TrustManager } from "../../../../platform/traits/trust-manager.js";
@@ -540,6 +542,87 @@ describe("agentloop phase 1", () => {
     expect(assistantMessages).toHaveLength(2);
     expect(assistantMessages[0]).toMatchObject({ phase: "commentary" });
     expect(assistantMessages[1]).toMatchObject({ phase: "final_candidate" });
+  });
+
+  it("captures changed paths for apply_patch in a non-git workspace", async () => {
+    const workspace = makeTempDir();
+    try {
+      const modelInfo = makeModelInfo();
+      const modelClient = new ScriptedModelClient(modelInfo, [
+        {
+          content: "",
+          toolCalls: [{
+            id: "patch-1",
+            name: "apply_patch",
+            input: {
+              cwd: workspace,
+              patch: [
+                "*** Begin Patch",
+                "*** Add File: reports/hgb.json",
+                "+{\"score\":0.95}",
+                "*** End Patch",
+              ].join("\n"),
+            },
+          }],
+          stopReason: "tool_use",
+        },
+        {
+          content: JSON.stringify({
+            status: "done",
+            finalAnswer: "finished",
+            summary: "created report",
+            filesChanged: [],
+            testsRun: [],
+            completionEvidence: [],
+            verificationHints: [],
+            blockers: [],
+          }),
+          toolCalls: [],
+          stopReason: "end_turn",
+        },
+      ]);
+      const registry = new ToolRegistry();
+      registry.register(new ApplyPatchTool());
+      const router = new ToolRegistryAgentLoopToolRouter(registry);
+      const executor = new ToolExecutor({
+        registry,
+        permissionManager: new ToolPermissionManager({}),
+        concurrency: new ConcurrencyController(),
+      });
+      const runner = new BoundedAgentLoopRunner({
+        modelClient,
+        toolRouter: router,
+        toolRuntime: new ToolExecutorAgentLoopToolRuntime(executor, router),
+      });
+
+      const result = await runner.run({
+        session: createAgentLoopSession(),
+        turnId: "turn-1",
+        goalId: "goal-1",
+        taskId: "task-1",
+        cwd: workspace,
+        model: modelInfo.ref,
+        modelInfo,
+        messages: [{ role: "user", content: "write report" }],
+        outputSchema: z.object({ status: z.literal("done"), finalAnswer: z.string() }).passthrough(),
+        budget: withDefaultBudget({ maxModelTurns: 4 }),
+        toolPolicy: { allowedTools: ["apply_patch"] },
+        toolCallContext: {
+          cwd: workspace,
+          goalId: "goal-1",
+          trustBalance: 100,
+          preApproved: true,
+          trusted: true,
+          approvalFn: async () => true,
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.changedFiles).toContain("reports/hgb.json");
+      expect(fs.readFileSync(path.join(workspace, "reports", "hgb.json"), "utf-8")).toContain("0.95");
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
   });
 
   it("persists typed tool observations for success, failure, denied, blocked, timed out, and interrupted results", async () => {
@@ -1164,6 +1247,7 @@ describe("agentloop phase 2", () => {
     const goalWorkspace = makeTempDir();
     try {
       fs.mkdirSync(goalWorkspace, { recursive: true });
+      fs.mkdirSync(path.join(goalWorkspace, ".git"), { recursive: true });
       const modelInfo = makeModelInfo();
       const modelClient = new ScriptedModelClient(modelInfo, [
         {
@@ -1238,6 +1322,115 @@ describe("agentloop phase 2", () => {
       expect(result.agentLoop?.requestedCwd).not.toBe(fs.realpathSync(daemonDir));
       expect(diffCwds).toEqual(expect.arrayContaining([fs.realpathSync(goalWorkspace)]));
       expect(diffCwds).not.toContain(fs.realpathSync(daemonDir));
+    } finally {
+      fs.rmSync(goalWorkspace, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it("populates file diffs for non-git native task execution through TaskLifecycle", async () => {
+    const daemonDir = tmpDir;
+    const goalWorkspace = makeTempDir();
+    try {
+      fs.mkdirSync(goalWorkspace, { recursive: true });
+      const modelInfo = makeModelInfo();
+      const modelClient = new ScriptedModelClient(modelInfo, [
+        {
+          content: "",
+          toolCalls: [{
+            id: "patch-1",
+            name: "apply_patch",
+            input: {
+              cwd: goalWorkspace,
+              patch: [
+                "*** Begin Patch",
+                "*** Add File: reports/hgb.json",
+                "+{\"score\":0.95}",
+                "*** End Patch",
+              ].join("\n"),
+            },
+          }],
+          stopReason: "tool_use",
+        },
+        {
+          content: "",
+          toolCalls: [{ id: "verify-1", name: "verify", input: { command: "test -f reports/hgb.json" } }],
+          stopReason: "tool_use",
+        },
+        {
+          content: JSON.stringify({
+            status: "done",
+            finalAnswer: "finished",
+            summary: "created report",
+            filesChanged: [],
+            testsRun: [],
+            completionEvidence: [],
+            verificationHints: [],
+            blockers: [],
+          }),
+          toolCalls: [],
+          stopReason: "end_turn",
+        },
+      ]);
+      const registry = new ToolRegistry();
+      registry.register(new ApplyPatchTool());
+      registry.register(new VerifyTool());
+      const router = new ToolRegistryAgentLoopToolRouter(registry);
+      const executor = new ToolExecutor({
+        registry,
+        permissionManager: new ToolPermissionManager({}),
+        concurrency: new ConcurrencyController(),
+      });
+      const runtime = new ToolExecutorAgentLoopToolRuntime(executor, router);
+      const boundedRunner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+      const taskRunner = new TaskAgentLoopRunner({
+        boundedRunner,
+        modelClient,
+        modelRegistry: new StaticAgentLoopModelRegistry([modelInfo]),
+        defaultModel: modelInfo.ref,
+        defaultToolPolicy: { allowedTools: ["apply_patch", "verify"] },
+        cwd: daemonDir,
+      });
+      const stateManager = new StateManager(daemonDir);
+      await stateManager.saveGoal(makeGoal({
+        id: "goal-1",
+        constraints: [`workspace_path:${goalWorkspace}`],
+      }));
+      const llmClient: ILLMClient = {
+        async sendMessage(): Promise<LLMResponse> {
+          return { content: finalJson(), usage: { input_tokens: 1, output_tokens: 1 }, stop_reason: "end_turn" };
+        },
+        parseJSON<T>(content: string, schema: z.ZodSchema<T>): T {
+          return schema.parse(JSON.parse(content));
+        },
+        supportsToolCalling: () => true,
+      };
+      const sessionManager = new SessionManager(stateManager);
+      const execFileSyncFn = vi.fn(() => {
+        throw new Error("git should not be probed for non-git fallback diff evidence");
+      });
+      const lifecycle = new TaskLifecycle(
+        stateManager,
+        llmClient,
+        sessionManager,
+        new TrustManager(stateManager),
+        new StrategyManager(stateManager, llmClient),
+        new StallDetector(stateManager),
+        { agentLoopRunner: taskRunner, execFileSyncFn },
+      );
+      const task = makeTask();
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+
+      const result = await lifecycle.executeTaskWithAgentLoop(task, "workspace context", "knowledge context");
+
+      expect(result.success).toBe(true);
+      expect(result.filesChangedPaths).toEqual(["reports/hgb.json"]);
+      expect(result.fileDiffs).toEqual([
+        expect.objectContaining({
+          path: "reports/hgb.json",
+          patch: expect.stringContaining("+{\"score\":0.95}"),
+        }),
+      ]);
+      expect(execFileSyncFn).not.toHaveBeenCalled();
     } finally {
       fs.rmSync(goalWorkspace, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     }

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -1,4 +1,7 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import type { Dirent } from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as path from "node:path";
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import type { z } from "zod";
 import type { AgentLoopStopReason } from "./agent-loop-budget.js";
@@ -33,6 +36,29 @@ export interface BoundedAgentLoopRunnerDeps {
   toolRuntime: AgentLoopToolRuntime;
   compactor?: AgentLoopCompactor;
 }
+
+interface FilesystemSnapshotEntry {
+  size: number;
+  mtimeMs: number;
+  hash?: string;
+}
+
+type WorkspaceSnapshot =
+  | { kind: "git"; paths: Set<string> }
+  | { kind: "filesystem"; files: Map<string, FilesystemSnapshotEntry> };
+
+const FILESYSTEM_SNAPSHOT_EXCLUDED_DIRS = new Set([
+  ".git",
+  "node_modules",
+  ".venv",
+  "venv",
+  "__pycache__",
+  ".cache",
+  "dist",
+  "build",
+]);
+const FILESYSTEM_SNAPSHOT_MAX_FILES = 5_000;
+const FILESYSTEM_SNAPSHOT_HASH_MAX_BYTES = 1_000_000;
 
 export class BoundedAgentLoopRunner {
   private readonly compactor: AgentLoopCompactor;
@@ -851,18 +877,23 @@ export class BoundedAgentLoopRunner {
     await turn.session.stateStore.save(state);
   }
 
-  private async captureWorkspaceSnapshot(cwd: string): Promise<Set<string> | null> {
+  private async captureWorkspaceSnapshot(cwd: string): Promise<WorkspaceSnapshot | null> {
     const result = await execFileNoThrow("git", ["status", "--porcelain", "--untracked-files=all"], { cwd, timeoutMs: 10_000 });
-    if ((result.exitCode ?? 1) !== 0) return null;
-    return new Set(this.parseGitStatusPaths(result.stdout));
+    if ((result.exitCode ?? 1) === 0) {
+      return { kind: "git", paths: new Set(this.parseGitStatusPaths(result.stdout)) };
+    }
+    return { kind: "filesystem", files: await this.captureFilesystemSnapshot(cwd) };
   }
 
-  private async collectChangedFiles(cwd: string, before: Set<string> | null): Promise<string[]> {
+  private async collectChangedFiles(cwd: string, before: WorkspaceSnapshot | null): Promise<string[]> {
     const afterResult = await execFileNoThrow("git", ["status", "--porcelain", "--untracked-files=all"], { cwd, timeoutMs: 10_000 });
-    if ((afterResult.exitCode ?? 1) !== 0) return [];
+    if ((afterResult.exitCode ?? 1) !== 0) {
+      if (before?.kind !== "filesystem") return [];
+      return this.collectFilesystemChangedPaths(before.files, await this.captureFilesystemSnapshot(cwd));
+    }
     const after = new Set(this.parseGitStatusPaths(afterResult.stdout));
-    if (!before) return [...after];
-    return [...after].filter((file) => !before.has(file));
+    if (!before || before.kind !== "git") return [...after];
+    return [...after].filter((file) => !before.paths.has(file));
   }
 
   private parseGitStatusPaths(stdout: string): string[] {
@@ -872,5 +903,73 @@ export class BoundedAgentLoopRunner {
       .filter((line) => line.length >= 4)
       .map((line) => line.slice(3).trim())
       .map((filePath) => filePath.includes(" -> ") ? filePath.split(" -> ").at(-1) ?? filePath : filePath);
+  }
+
+  private async captureFilesystemSnapshot(cwd: string): Promise<Map<string, FilesystemSnapshotEntry>> {
+    const files = new Map<string, FilesystemSnapshotEntry>();
+    const root = path.resolve(cwd);
+    const visit = async (dir: string): Promise<void> => {
+      if (files.size >= FILESYSTEM_SNAPSHOT_MAX_FILES) return;
+      let entries: Dirent[];
+      try {
+        entries = await fsp.readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (files.size >= FILESYSTEM_SNAPSHOT_MAX_FILES) return;
+        if (entry.name.startsWith(".pulseed-")) continue;
+        const absolutePath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (!FILESYSTEM_SNAPSHOT_EXCLUDED_DIRS.has(entry.name)) {
+            await visit(absolutePath);
+          }
+          continue;
+        }
+        if (!entry.isFile()) continue;
+        const relativePath = path.relative(root, absolutePath).replace(/\\/g, "/");
+        try {
+          const stat = await fsp.stat(absolutePath);
+          const snapshotEntry: FilesystemSnapshotEntry = {
+            size: stat.size,
+            mtimeMs: stat.mtimeMs,
+          };
+          if (stat.size <= FILESYSTEM_SNAPSHOT_HASH_MAX_BYTES) {
+            snapshotEntry.hash = createHash("sha256")
+              .update(await fsp.readFile(absolutePath))
+              .digest("hex");
+          }
+          files.set(relativePath, snapshotEntry);
+        } catch {
+          // File may have changed while scanning; skip and let the next scan observe it.
+        }
+      }
+    };
+    await visit(root);
+    return files;
+  }
+
+  private collectFilesystemChangedPaths(
+    before: Map<string, FilesystemSnapshotEntry>,
+    after: Map<string, FilesystemSnapshotEntry>,
+  ): string[] {
+    const changed = new Set<string>();
+    for (const [filePath, afterEntry] of after) {
+      const beforeEntry = before.get(filePath);
+      if (!beforeEntry || !this.sameFilesystemEntry(beforeEntry, afterEntry)) {
+        changed.add(filePath);
+      }
+    }
+    for (const filePath of before.keys()) {
+      if (!after.has(filePath)) {
+        changed.add(filePath);
+      }
+    }
+    return [...changed].sort();
+  }
+
+  private sameFilesystemEntry(left: FilesystemSnapshotEntry, right: FilesystemSnapshotEntry): boolean {
+    if (left.hash && right.hash) return left.hash === right.hash;
+    return left.size === right.size && left.mtimeMs === right.mtimeMs;
   }
 }

--- a/src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts
+++ b/src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { captureExecutionDiffArtifacts, type ExecFileSyncFn } from "../task-diff-capture.js";
+import { makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
+
+function makeGitWorkspace(): string {
+  const workspace = makeTempDir();
+  fs.mkdirSync(path.join(workspace, ".git"), { recursive: true });
+  return workspace;
+}
 
 function makeExecFileSync(outputs: Record<string, string>, thrownOutputs: Record<string, string> = {}): ExecFileSyncFn {
   return ((cmd, args) => {
@@ -15,69 +24,139 @@ function makeExecFileSync(outputs: Record<string, string>, thrownOutputs: Record
 
 describe("captureExecutionDiffArtifacts", () => {
   it("collects tracked file diffs and changed paths", () => {
-    const execFileSyncFn = makeExecFileSync({
-      "git diff --name-only": "src/example.ts\n",
-      "git ls-files --others --exclude-standard": "",
-      "git diff -- src/example.ts": "diff --git a/src/example.ts b/src/example.ts\n@@ -1 +1 @@\n-old\n+new\n",
-    });
+    const workspace = makeGitWorkspace();
+    try {
+      const execFileSyncFn = makeExecFileSync({
+        "git diff --name-only": "src/example.ts\n",
+        "git ls-files --others --exclude-standard": "",
+        "git diff -- src/example.ts": "diff --git a/src/example.ts b/src/example.ts\n@@ -1 +1 @@\n-old\n+new\n",
+      });
 
-    const result = captureExecutionDiffArtifacts(execFileSyncFn, "/repo");
+      const result = captureExecutionDiffArtifacts(execFileSyncFn, workspace);
 
-    expect(result.changedPaths).toEqual(["src/example.ts"]);
-    expect(result.fileDiffs).toEqual([
-      expect.objectContaining({
-        path: "src/example.ts",
-        patch: expect.stringContaining("+new"),
-      }),
-    ]);
+      expect(result.changedPaths).toEqual(["src/example.ts"]);
+      expect(result.fileDiffs).toEqual([
+        expect.objectContaining({
+          path: "src/example.ts",
+          patch: expect.stringContaining("+new"),
+        }),
+      ]);
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
   });
 
   it("captures untracked file diffs from git diff --no-index output", () => {
-    const execFileSyncFn = makeExecFileSync(
-      {
-        "git diff --name-only": "",
-        "git ls-files --others --exclude-standard": "src/new-file.ts\n",
-        "git diff -- src/new-file.ts": "",
-      },
-      {
-        "git diff --no-index -- /dev/null src/new-file.ts": [
-          "diff --git a/src/new-file.ts b/src/new-file.ts",
-          "new file mode 100644",
-          "--- /dev/null",
-          "+++ b/src/new-file.ts",
-          "@@ -0,0 +1 @@",
-          "+export const created = true;",
-          "",
-        ].join("\n"),
-      },
-    );
+    const workspace = makeGitWorkspace();
+    try {
+      const execFileSyncFn = makeExecFileSync(
+        {
+          "git diff --name-only": "",
+          "git ls-files --others --exclude-standard": "src/new-file.ts\n",
+          "git diff -- src/new-file.ts": "",
+        },
+        {
+          "git diff --no-index -- /dev/null src/new-file.ts": [
+            "diff --git a/src/new-file.ts b/src/new-file.ts",
+            "new file mode 100644",
+            "--- /dev/null",
+            "+++ b/src/new-file.ts",
+            "@@ -0,0 +1 @@",
+            "+export const created = true;",
+            "",
+          ].join("\n"),
+        },
+      );
 
-    const result = captureExecutionDiffArtifacts(execFileSyncFn, "/repo");
+      const result = captureExecutionDiffArtifacts(execFileSyncFn, workspace);
 
-    expect(result.changedPaths).toEqual(["src/new-file.ts"]);
-    expect(result.fileDiffs).toEqual([
-      expect.objectContaining({
-        path: "src/new-file.ts",
-        patch: expect.stringContaining("new file mode 100644"),
-      }),
-    ]);
+      expect(result.changedPaths).toEqual(["src/new-file.ts"]);
+      expect(result.fileDiffs).toEqual([
+        expect.objectContaining({
+          path: "src/new-file.ts",
+          patch: expect.stringContaining("new file mode 100644"),
+        }),
+      ]);
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
   });
 
   it("ignores per-path diff read failures after collecting changed paths", () => {
-    const execFileSyncFn = makeExecFileSync(
-      {
-        "git diff --name-only": "src/example.ts\n",
+    const workspace = makeGitWorkspace();
+    try {
+      const execFileSyncFn = makeExecFileSync(
+        {
+          "git diff --name-only": "src/example.ts\n",
+          "git ls-files --others --exclude-standard": "",
+        },
+        {
+          "git diff -- src/example.ts": "",
+        },
+      );
+
+      const result = captureExecutionDiffArtifacts(execFileSyncFn, workspace);
+
+      expect(result.available).toBe(true);
+      expect(result.changedPaths).toEqual(["src/example.ts"]);
+      expect(result.fileDiffs).toEqual([]);
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("renders non-git fallback file diffs from concrete changed paths without probing git", () => {
+    const workspace = makeTempDir();
+    try {
+      fs.mkdirSync(path.join(workspace, "reports"), { recursive: true });
+      fs.writeFileSync(path.join(workspace, "reports", "hgb.json"), "{\"score\":0.95}\n", "utf-8");
+      const execFileSyncFn = vi.fn(makeExecFileSync({}, {
+        "git diff --name-only": "",
         "git ls-files --others --exclude-standard": "",
-      },
-      {
-        "git diff -- src/example.ts": "",
-      },
-    );
+      }));
 
-    const result = captureExecutionDiffArtifacts(execFileSyncFn, "/repo");
+      const result = captureExecutionDiffArtifacts(execFileSyncFn, workspace, {
+        fallbackChangedPaths: ["reports/hgb.json"],
+      });
 
-    expect(result.available).toBe(true);
-    expect(result.changedPaths).toEqual(["src/example.ts"]);
-    expect(result.fileDiffs).toEqual([]);
+      expect(result.available).toBe(true);
+      expect(result.changedPaths).toEqual(["reports/hgb.json"]);
+      expect(result.fileDiffs).toEqual([
+        expect.objectContaining({
+          path: "reports/hgb.json",
+          patch: expect.stringContaining("+{\"score\":0.95}"),
+        }),
+      ]);
+      expect(execFileSyncFn).not.toHaveBeenCalled();
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("omits non-git fallback content when a changed path resolves outside the workspace", () => {
+    const workspace = makeTempDir();
+    const outside = makeTempDir();
+    try {
+      fs.mkdirSync(path.join(workspace, "reports"), { recursive: true });
+      fs.writeFileSync(path.join(outside, "secret.txt"), "outside-secret\n", "utf-8");
+      fs.symlinkSync(path.join(outside, "secret.txt"), path.join(workspace, "reports", "secret.txt"));
+
+      const result = captureExecutionDiffArtifacts(vi.fn(), workspace, {
+        fallbackChangedPaths: ["reports/secret.txt"],
+      });
+
+      expect(result.available).toBe(true);
+      expect(result.changedPaths).toEqual(["reports/secret.txt"]);
+      expect(result.fileDiffs).toEqual([
+        expect.objectContaining({
+          path: "reports/secret.txt",
+          patch: expect.stringContaining("path resolves outside the workspace"),
+        }),
+      ]);
+      expect(result.fileDiffs[0]?.patch).not.toContain("outside-secret");
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
   });
 });

--- a/src/orchestrator/execution/task/task-diff-capture.ts
+++ b/src/orchestrator/execution/task/task-diff-capture.ts
@@ -1,15 +1,22 @@
 import type { VerificationFileDiff } from "../../../base/types/task.js";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 export type ExecFileSyncFn = (
   cmd: string,
   args: string[],
-  opts: { cwd: string; encoding: "utf-8" }
+  opts: { cwd: string; encoding: "utf-8"; stdio?: "pipe" }
 ) => string;
 
 export interface ExecutionDiffArtifacts {
   available: boolean;
   changedPaths: string[];
   fileDiffs: VerificationFileDiff[];
+}
+
+export interface CaptureExecutionDiffOptions {
+  fallbackChangedPaths?: string[];
+  maxFallbackDiffBytes?: number;
 }
 
 function uniqueNonEmpty(values: string[]): string[] {
@@ -23,7 +30,8 @@ function readStdoutFromExecError(error: unknown): string | null {
     "stdout" in error &&
     typeof (error as { stdout?: unknown }).stdout === "string"
   ) {
-    return (error as { stdout: string }).stdout;
+    const stdout = (error as { stdout: string }).stdout;
+    return stdout.length > 0 ? stdout : null;
   }
 
   if (
@@ -32,7 +40,8 @@ function readStdoutFromExecError(error: unknown): string | null {
     "stdout" in error &&
     Buffer.isBuffer((error as { stdout?: unknown }).stdout)
   ) {
-    return ((error as { stdout: Buffer }).stdout).toString("utf-8");
+    const stdout = ((error as { stdout: Buffer }).stdout).toString("utf-8");
+    return stdout.length > 0 ? stdout : null;
   }
 
   return null;
@@ -44,7 +53,7 @@ function runGitRead(
   args: string[],
 ): string | null {
   try {
-    return execFileSyncFn("git", args, { cwd, encoding: "utf-8" });
+    return execFileSyncFn("git", args, { cwd, encoding: "utf-8", stdio: "pipe" });
   } catch (error) {
     return readStdoutFromExecError(error);
   }
@@ -53,13 +62,20 @@ function runGitRead(
 export function captureExecutionDiffArtifacts(
   execFileSyncFn: ExecFileSyncFn,
   cwd: string,
+  options: CaptureExecutionDiffOptions = {},
 ): ExecutionDiffArtifacts {
+  const fallbackPaths = uniqueNonEmpty(options.fallbackChangedPaths ?? [])
+    .filter((filePath) => isSafeRelativePath(cwd, filePath));
+  if (!hasGitMetadata(cwd)) {
+    return renderFallbackDiffArtifacts(cwd, fallbackPaths, options.maxFallbackDiffBytes);
+  }
+
   const trackedOutput = runGitRead(execFileSyncFn, cwd, ["diff", "--name-only"]);
   const untrackedOutput = runGitRead(execFileSyncFn, cwd, ["ls-files", "--others", "--exclude-standard"]);
 
   const available = trackedOutput !== null || untrackedOutput !== null;
   if (!available) {
-    return { available: false, changedPaths: [], fileDiffs: [] };
+    return renderFallbackDiffArtifacts(cwd, fallbackPaths, options.maxFallbackDiffBytes);
   }
 
   const trackedPaths = (trackedOutput ?? "").split("\n");
@@ -82,4 +98,132 @@ export function captureExecutionDiffArtifacts(
   });
 
   return { available: true, changedPaths, fileDiffs };
+}
+
+function renderFallbackDiffArtifacts(
+  cwd: string,
+  fallbackPaths: string[],
+  maxFallbackDiffBytes = 200_000,
+): ExecutionDiffArtifacts {
+  if (fallbackPaths.length === 0) {
+    return { available: false, changedPaths: [], fileDiffs: [] };
+  }
+  return {
+    available: true,
+    changedPaths: fallbackPaths,
+    fileDiffs: fallbackPaths.flatMap((filePath) =>
+      renderCurrentFileDiff(cwd, filePath, maxFallbackDiffBytes)
+    ),
+  };
+}
+
+function hasGitMetadata(cwd: string): boolean {
+  let current = path.resolve(cwd);
+  while (true) {
+    if (fs.existsSync(path.join(current, ".git"))) return true;
+    const parent = path.dirname(current);
+    if (parent === current) return false;
+    current = parent;
+  }
+}
+
+function isSafeRelativePath(cwd: string, filePath: string): boolean {
+  if (!filePath || filePath.includes("\0") || path.isAbsolute(filePath)) return false;
+  const root = path.resolve(cwd);
+  const resolved = path.resolve(root, filePath);
+  return resolved === root || resolved.startsWith(root + path.sep);
+}
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  return candidate === root || candidate.startsWith(root + path.sep);
+}
+
+function renderCurrentFileDiff(cwd: string, filePath: string, maxBytes: number): VerificationFileDiff[] {
+  const resolved = path.resolve(cwd, filePath);
+  try {
+    const root = fs.realpathSync(cwd);
+    const realResolved = fs.realpathSync(resolved);
+    if (!isWithinRoot(root, realResolved)) {
+      return [{
+        path: filePath,
+        patch: [
+          `diff --git a/${filePath} b/${filePath}`,
+          `--- a/${filePath}`,
+          `+++ b/${filePath}`,
+          "@@ -0,0 +1 @@",
+          "+[non-git evidence] path resolves outside the workspace; content omitted",
+          "",
+        ].join("\n"),
+      }];
+    }
+    const stat = fs.statSync(realResolved);
+    if (!stat.isFile()) {
+      return [{
+        path: filePath,
+        patch: [
+          `diff --git a/${filePath} b/${filePath}`,
+          `--- a/${filePath}`,
+          `+++ b/${filePath}`,
+          "@@ -0,0 +1 @@",
+          `+[non-git evidence] path exists but is not a regular file (${stat.isDirectory() ? "directory" : "special file"})`,
+          "",
+        ].join("\n"),
+      }];
+    }
+    if (stat.size > maxBytes) {
+      return [{
+        path: filePath,
+        patch: [
+          `diff --git a/${filePath} b/${filePath}`,
+          `--- a/${filePath}`,
+          `+++ b/${filePath}`,
+          "@@ -0,0 +1 @@",
+          `+[non-git evidence] file exists; diff omitted because size ${stat.size} exceeds ${maxBytes} bytes`,
+          "",
+        ].join("\n"),
+      }];
+    }
+    const content = fs.readFileSync(realResolved, "utf-8");
+    if (content.includes("\0")) {
+      return [{
+        path: filePath,
+        patch: [
+          `diff --git a/${filePath} b/${filePath}`,
+          "new file mode 100644",
+          "--- /dev/null",
+          `+++ b/${filePath}`,
+          "@@ -0,0 +1 @@",
+          `+[non-git evidence] binary file exists; size ${stat.size} bytes`,
+          "",
+        ].join("\n"),
+      }];
+    }
+    const lines = content.length === 0
+      ? []
+      : content.replace(/\n$/, "").split("\n");
+    return [{
+      path: filePath,
+      patch: [
+        `diff --git a/${filePath} b/${filePath}`,
+        "new file mode 100644",
+        "--- /dev/null",
+        `+++ b/${filePath}`,
+        `@@ -0,0 +1,${lines.length} @@`,
+        ...lines.map((line) => `+${line}`),
+        "",
+      ].join("\n"),
+    }];
+  } catch {
+    return [{
+      path: filePath,
+      patch: [
+        `diff --git a/${filePath} b/${filePath}`,
+        `--- a/${filePath}`,
+        "+++ /dev/null",
+        "@@ -1 +0,0 @@",
+        "-[non-git evidence] path was reported changed but is absent after execution",
+        "",
+      ].join("\n"),
+    }];
+  }
 }

--- a/src/orchestrator/execution/task/task-execution-helpers.ts
+++ b/src/orchestrator/execution/task/task-execution-helpers.ts
@@ -94,6 +94,7 @@ export async function executeTaskWithGuards(
             cwd: workspaceCwd ?? process.cwd(),
             execFileSyncFn,
             logger,
+            fallbackChangedPaths: result.filesChangedPaths,
           });
           return result;
         }

--- a/src/orchestrator/execution/task/task-executor.ts
+++ b/src/orchestrator/execution/task/task-executor.ts
@@ -170,6 +170,7 @@ export async function executeTask(
     cwd: workspaceCwd ?? process.cwd(),
     execFileSyncFn,
     logger,
+    fallbackChangedPaths: result.filesChangedPaths,
   });
 
   // End session
@@ -207,11 +208,14 @@ export async function applyPostExecutionDiffScopeChecks(input: {
   cwd: string;
   execFileSyncFn: TaskExecutorDeps["execFileSyncFn"];
   logger?: Logger;
+  fallbackChangedPaths?: string[];
 }): Promise<void> {
   if (!input.result.success) return;
 
   try {
-    const diffArtifacts = captureExecutionDiffArtifacts(input.execFileSyncFn, input.cwd);
+    const diffArtifacts = captureExecutionDiffArtifacts(input.execFileSyncFn, input.cwd, {
+      fallbackChangedPaths: input.fallbackChangedPaths,
+    });
     if (diffArtifacts.available) {
       const changedFiles = diffArtifacts.changedPaths;
       input.result.filesChangedPaths = changedFiles;

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -550,9 +550,16 @@ export class TaskLifecycle {
       });
       result = taskAgentLoopResultToAgentResult(agentLoopResult);
       if (agentLoopResult.workspace?.executionCwd) {
+        const fallbackChangedPaths = [
+          ...new Set([
+            ...(result.filesChangedPaths ?? []),
+            ...agentLoopResult.changedFiles,
+          ]),
+        ];
         const diffArtifacts = captureExecutionDiffArtifacts(
           this.execFileSyncFn,
           agentLoopResult.workspace.executionCwd,
+          { fallbackChangedPaths },
         );
         if (diffArtifacts.available) {
           result.filesChangedPaths = diffArtifacts.changedPaths;


### PR DESCRIPTION
## Summary
- add filesystem snapshot changed-path capture for native agent-loop runs when the task workspace is not a git repository
- render non-git fallback file diffs from concrete changed paths without probing git in expected non-git workspaces
- guard fallback diff rendering with workspace-relative path and realpath containment checks

Closes #1131

## Verification
- npx vitest run src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts
- npm run typecheck
- npm run lint:boundaries (0 errors, existing warnings)
- npm run test:changed

## Review
- fresh review found git stderr noise in non-git fallback; fixed
- fresh review found symlink escape content leak risk; fixed
- fresh review found missing TaskLifecycle caller-path coverage; fixed
- final reviewer follow-up found no remaining material issue