### PR TITLE
fix(verification): fail closed unavailable mechanical checks

### DIFF
--- a/src/orchestrator/execution/__tests__/task-lifecycle-cycle-failure.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-cycle-failure.test.ts
@@ -5,7 +5,7 @@ import { SessionManager } from "../session-manager.js";
 import { TrustManager } from "../../../platform/traits/trust-manager.js";
 import { StrategyManager } from "../../strategy/strategy-manager.js";
 import { StallDetector } from "../../../platform/drive/stall-detector.js";
-import { TaskLifecycle } from "../task/task-lifecycle.js";
+import { AdapterRegistry, TaskLifecycle } from "../task/task-lifecycle.js";
 import type { Task } from "../../../base/types/task.js";
 import type {
   ILLMClient,
@@ -80,6 +80,24 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   };
 }
 
+function makePassingAdapterRegistry(): AdapterRegistry {
+  const registry = new AdapterRegistry();
+  registry.register({
+    adapterType: "openai_codex_cli",
+    async execute() {
+      return {
+        success: true,
+        output: "mechanical verification passed",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 1,
+        stopped_reason: "completed",
+      };
+    },
+  });
+  return registry;
+}
+
 describe("TaskLifecycle — failure handling", () => {
   let tmpDir: string;
   let stateManager: StateManager;
@@ -109,7 +127,7 @@ describe("TaskLifecycle — failure handling", () => {
       trustManager,
       strategyManager,
       stallDetector,
-      { healthCheckEnabled: false }
+      { healthCheckEnabled: false, adapterRegistry: makePassingAdapterRegistry() }
     );
   }
 

--- a/src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts
@@ -102,6 +102,24 @@ function makeExecutionResult(
   };
 }
 
+function makePassingAdapterRegistry(adapterType = "openai_codex_cli"): AdapterRegistry {
+  const registry = new AdapterRegistry();
+  registry.register({
+    adapterType,
+    async execute() {
+      return {
+        success: true,
+        output: "mechanical verification passed",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 1,
+        stopped_reason: "completed",
+      };
+    },
+  });
+  return registry;
+}
+
 // LLM responses for verification
 const LLM_REVIEW_PASS = '{"verdict": "pass", "reasoning": "All criteria satisfied", "criteria_met": 1, "criteria_total": 1}';
 const LLM_REVIEW_FAIL = '{"verdict": "fail", "reasoning": "Criteria not met", "criteria_met": 0, "criteria_total": 1}';
@@ -134,12 +152,18 @@ describe("TaskLifecycle", async () => {
     options?: {
       approvalFn?: (task: Task) => Promise<boolean>;
       logger?: import("../../../runtime/logger.js").Logger;
-      adapterRegistry?: import("../task/task-lifecycle.js").AdapterRegistry;
+      adapterRegistry?: import("../task/task-lifecycle.js").AdapterRegistry | null;
       execFileSyncFn?: (cmd: string, args: string[], opts: { cwd: string; encoding: "utf-8" }) => string;
       toolExecutor?: ToolExecutor;
     }
   ): TaskLifecycle {
     strategyManager = new StrategyManager(stateManager, llmClient);
+    const hasAdapterRegistryOption = options
+      ? Object.prototype.hasOwnProperty.call(options, "adapterRegistry")
+      : false;
+    const adapterRegistry = hasAdapterRegistryOption
+      ? options?.adapterRegistry ?? undefined
+      : makePassingAdapterRegistry();
     return new TaskLifecycle(
       stateManager,
       llmClient,
@@ -147,7 +171,7 @@ describe("TaskLifecycle", async () => {
       trustManager,
       strategyManager,
       stallDetector,
-      options
+      { ...options, adapterRegistry }
     );
   }
 
@@ -619,11 +643,11 @@ describe("TaskLifecycle", async () => {
       expect(adapterCwd).toBe(workspace);
     });
 
-    it("still runs cheap local failures before assuming pass when adapter is unavailable", async () => {
+    it("still runs cheap local failures before fail-closed adapter-unavailable evidence", async () => {
       const llm = createMockLLMClient([LLM_REVIEW_PASS]);
       const workspace = path.join(tmpDir, "non-git-workspace-no-adapter");
       fs.mkdirSync(workspace, { recursive: true });
-      const lifecycle = createLifecycle(llm);
+      const lifecycle = createLifecycle(llm, { adapterRegistry: null });
       const task = makeTask({
         success_criteria: [
           {
@@ -648,6 +672,128 @@ describe("TaskLifecycle", async () => {
 
       expect(verification.verdict).toBe("fail");
       expect(verification.evidence[0]?.description).toContain("missing-marker.txt");
+    });
+
+    it("fails closed when blocking mechanical commands need an adapter but no registry is configured", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const lifecycle = createLifecycle(llm, { adapterRegistry: null });
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Full test suite passes",
+            verification_method: "npm test",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      const verification = await lifecycle.verifyTask(task, makeExecutionResult());
+      const mechanicalEvidence = verification.evidence.find((entry) => entry.layer === "mechanical");
+
+      expect(verification.verdict).toBe("fail");
+      expect(mechanicalEvidence?.description).toContain("could not execute");
+      expect(mechanicalEvidence?.description).toContain("no adapter registry is configured");
+      expect(mechanicalEvidence?.description).toContain("command(s) did not run: npm test");
+      expect(mechanicalEvidence?.description).toContain("unknown/Uncertain");
+    });
+
+    it("fails closed when the adapter registry is empty for a blocking mechanical command", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const lifecycle = createLifecycle(llm, { adapterRegistry: new AdapterRegistry() });
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Full test suite passes",
+            verification_method: "npm test",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      const verification = await lifecycle.verifyTask(task, makeExecutionResult());
+      const mechanicalEvidence = verification.evidence.find((entry) => entry.layer === "mechanical");
+
+      expect(verification.verdict).toBe("fail");
+      expect(mechanicalEvidence?.description).toContain("no adapters are registered");
+      expect(mechanicalEvidence?.description).toContain("command(s) did not run: npm test");
+      expect(mechanicalEvidence?.description).toContain("fails closed");
+    });
+
+    it("fails closed when adapter lookup fails for a blocking mechanical command", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const registry = new AdapterRegistry();
+      const execute = vi.fn(async () => ({
+        success: true,
+        output: "should not execute",
+        error: null,
+        exit_code: 0,
+        elapsed_ms: 1,
+        stopped_reason: "completed" as const,
+      }));
+      registry.register({
+        adapterType: "openai_codex_cli",
+        execute,
+      });
+      vi.spyOn(registry, "getAdapter").mockImplementation(() => {
+        throw new Error("lookup unavailable");
+      });
+      const lifecycle = createLifecycle(llm, { adapterRegistry: registry });
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Full test suite passes",
+            verification_method: "npm test",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      const verification = await lifecycle.verifyTask(
+        task,
+        makeExecutionResult(),
+        "openai_codex_cli"
+      );
+      const mechanicalEvidence = verification.evidence.find((entry) => entry.layer === "mechanical");
+
+      expect(execute).not.toHaveBeenCalled();
+      expect(verification.verdict).toBe("fail");
+      expect(mechanicalEvidence?.description).toContain("adapter lookup failed for openai_codex_cli");
+      expect(mechanicalEvidence?.description).toContain("command(s) did not run: npm test");
+    });
+
+    it("fails closed with unknown evidence when adapter execution throws for a blocking mechanical command", async () => {
+      const llm = createMockLLMClient([LLM_REVIEW_PASS]);
+      const registry = new AdapterRegistry();
+      const execute = vi.fn(async () => {
+        throw new Error("adapter process unavailable");
+      });
+      registry.register({
+        adapterType: "openai_codex_cli",
+        execute,
+      });
+      const lifecycle = createLifecycle(llm, { adapterRegistry: registry });
+      const task = makeTask({
+        success_criteria: [
+          {
+            description: "Full test suite passes",
+            verification_method: "npm test",
+            is_blocking: true,
+          },
+        ],
+      });
+
+      const verification = await lifecycle.verifyTask(
+        task,
+        makeExecutionResult(),
+        "openai_codex_cli"
+      );
+      const mechanicalEvidence = verification.evidence.find((entry) => entry.layer === "mechanical");
+
+      expect(execute).toHaveBeenCalledOnce();
+      expect(verification.verdict).toBe("fail");
+      expect(mechanicalEvidence?.description).toContain("adapter execution failed for openai_codex_cli");
+      expect(mechanicalEvidence?.description).toContain("command(s) did not run to completion: npm test");
+      expect(mechanicalEvidence?.description).toContain("unknown/Uncertain");
     });
 
     it("keeps glob path operands on the adapter path while preserving workspace cwd", async () => {

--- a/src/orchestrator/execution/task/task-verifier-rules.ts
+++ b/src/orchestrator/execution/task/task-verifier-rules.ts
@@ -67,7 +67,6 @@ export async function runMechanicalVerification(
   }));
   const needsAdapter = commandPlans.some((plan) => !plan.directLocal);
 
-  // If no adapter registry is available, fall back to assumed pass (backward compat)
   if (needsAdapter && !deps.adapterRegistry) {
     const directFailure = await runDirectLocalPlansBeforeAdapterFallback(
       commandPlans,
@@ -75,11 +74,7 @@ export async function runMechanicalVerification(
       verificationTimeoutMs
     );
     if (directFailure) return directFailure;
-    return {
-      applicable: true,
-      passed: true,
-      description: `Mechanical verification criteria detected (${verificationCommands.length} command(s), no adapter: assumed pass)`,
-    };
+    return failClosedMechanicalVerification(commandPlans, "no adapter registry is configured");
   }
 
   // Select the first available adapter from the registry for command execution
@@ -91,11 +86,7 @@ export async function runMechanicalVerification(
       verificationTimeoutMs
     );
     if (directFailure) return directFailure;
-    return {
-      applicable: true,
-      passed: true,
-      description: `Mechanical verification criteria detected (${verificationCommands.length} command(s), no adapters registered: assumed pass)`,
-    };
+    return failClosedMechanicalVerification(commandPlans, "no adapters are registered");
   }
 
   const adapterType =
@@ -112,11 +103,7 @@ export async function runMechanicalVerification(
       verificationTimeoutMs
     );
     if (directFailure) return directFailure;
-    return {
-      applicable: true,
-      passed: true,
-      description: `Mechanical verification criteria detected (${verificationCommands.length} command(s), adapter lookup failed: assumed pass)`,
-    };
+    return failClosedMechanicalVerification(commandPlans, `adapter lookup failed for ${adapterType}`);
   }
 
   const passedCommands: string[] = [];
@@ -138,11 +125,7 @@ export async function runMechanicalVerification(
     }
 
     if (!adapter) {
-      return {
-        applicable: true,
-        passed: true,
-        description: `Mechanical verification criteria detected (${verificationCommands.length} command(s), adapter unavailable: assumed pass)`,
-      };
+      return failClosedMechanicalVerification(commandPlans, `adapter unavailable for ${adapterType}`);
     }
 
     const agentTask: AgentTask = {
@@ -158,11 +141,11 @@ export async function runMechanicalVerification(
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       deps.logger?.error("runMechanicalVerification: adapter.execute() threw", { error: errMsg });
-      return {
-        applicable: true,
-        passed: false,
-        description: `Mechanical verification command threw: ${verificationCommand} — ${errMsg}`,
-      };
+      return failClosedMechanicalVerification(
+        [{ command: verificationCommand, directLocal: false }],
+        `adapter execution failed for ${adapterType}: ${errMsg}`,
+        "command(s) did not run to completion"
+      );
     }
 
     if (result.stopped_reason === "timeout") {
@@ -188,6 +171,28 @@ export async function runMechanicalVerification(
     applicable: true,
     passed: true,
     description: `Mechanical verification passed (${passedCommands.length} command(s)): ${passedCommands.join("; ")}`,
+  };
+}
+
+function failClosedMechanicalVerification(
+  commandPlans: Array<{ command: string; directLocal: boolean }>,
+  reason: string,
+  commandStatus = "command(s) did not run"
+): { applicable: true; passed: false; description: string } {
+  const unexecutedCommands = commandPlans
+    .filter((plan) => !plan.directLocal)
+    .map((plan) => plan.command);
+  const commandSummary =
+    unexecutedCommands.length > 0
+      ? `${commandStatus}: ${unexecutedCommands.join("; ")}`
+      : "blocking command did not run";
+  return {
+    applicable: true,
+    passed: false,
+    description:
+      `Mechanical verification could not execute blocking command(s) (${reason}); ` +
+      `${unexecutedCommands.length}/${commandPlans.length} ${commandSummary}. ` +
+      "Result is unknown/Uncertain and fails closed.",
   };
 }
 

--- a/tests/e2e/r3-adapter-execution.test.ts
+++ b/tests/e2e/r3-adapter-execution.test.ts
@@ -195,6 +195,18 @@ class TrackingMockAdapter implements IAdapter {
   }
 }
 
+function makeAdapterRegistry(adapter: IAdapter): AdapterRegistry {
+  const adapterRegistry = new AdapterRegistry();
+  adapterRegistry.register(adapter);
+  return adapterRegistry;
+}
+
+function expectTaskAndMechanicalAdapterCalls(adapter: TrackingMockAdapter): void {
+  expect(adapter.executeCalls).toHaveLength(2);
+  expect(adapter.executeCalls[0]!.prompt).toContain("README");
+  expect(adapter.executeCalls[1]!.prompt).toBe("grep -c 'example' README.md");
+}
+
 // ─── Setup ───
 
 let tmpDir: string;
@@ -230,6 +242,7 @@ describe("R3: runTaskCycle generates task, executes via adapter, and verifies", 
     const stallDetector = new StallDetector(stateManager);
 
     const adapter = new TrackingMockAdapter(true);
+    const adapterRegistry = makeAdapterRegistry(adapter);
 
     const taskLifecycle = new TaskLifecycle(
       stateManager,
@@ -238,7 +251,7 @@ describe("R3: runTaskCycle generates task, executes via adapter, and verifies", 
       trustManager,
       strategyManager,
       stallDetector,
-      { approvalFn: async (_task) => true, healthCheckEnabled: false }
+      { approvalFn: async (_task) => true, healthCheckEnabled: false, adapterRegistry }
     );
 
     const gapVector = makeGapVector(goal.id);
@@ -257,9 +270,8 @@ describe("R3: runTaskCycle generates task, executes via adapter, and verifies", 
     expect(result.task.primary_dimension).toBe("quality");
     expect(result.task.work_description).toContain("README");
 
-    // adapter.execute() was called with work_description content
-    expect(adapter.executeCalls).toHaveLength(1);
-    expect(adapter.executeCalls[0]!.prompt).toContain("README");
+    // adapter.execute() ran both task execution and L1 mechanical verification.
+    expectTaskAndMechanicalAdapterCalls(adapter);
 
     // Verification returned pass
     expect(result.verificationResult).toBeDefined();
@@ -294,6 +306,7 @@ describe("R3: runTaskCycle handles adapter execution failure", () => {
 
     // Adapter that returns failure
     const adapter = new TrackingMockAdapter(false);
+    const adapterRegistry = makeAdapterRegistry(adapter);
 
     const taskLifecycle = new TaskLifecycle(
       stateManager,
@@ -302,7 +315,7 @@ describe("R3: runTaskCycle handles adapter execution failure", () => {
       trustManager,
       strategyManager,
       stallDetector,
-      { approvalFn: async (_task) => true, healthCheckEnabled: false }
+      { approvalFn: async (_task) => true, healthCheckEnabled: false, adapterRegistry }
     );
 
     const gapVector = makeGapVector(goal.id);
@@ -315,8 +328,8 @@ describe("R3: runTaskCycle handles adapter execution failure", () => {
       adapter
     );
 
-    // adapter.execute() was still called
-    expect(adapter.executeCalls).toHaveLength(1);
+    // adapter.execute() still ran task execution and attempted L1 mechanical verification.
+    expectTaskAndMechanicalAdapterCalls(adapter);
 
     // Verification returned fail
     expect(result.verificationResult.verdict).toBe("fail");
@@ -380,6 +393,7 @@ describe("R3: runTaskCycle passes existingTasks for dedup", () => {
     const strategyManager = new StrategyManager(stateManager, mockLLM as Parameters<typeof StrategyManager>[1]);
     const stallDetector = new StallDetector(stateManager);
     const adapter = new TrackingMockAdapter(true);
+    const adapterRegistry = makeAdapterRegistry(adapter);
 
     const taskLifecycle = new TaskLifecycle(
       stateManager,
@@ -388,7 +402,7 @@ describe("R3: runTaskCycle passes existingTasks for dedup", () => {
       trustManager,
       strategyManager,
       stallDetector,
-      { approvalFn: async (_task) => true, healthCheckEnabled: false }
+      { approvalFn: async (_task) => true, healthCheckEnabled: false, adapterRegistry }
     );
 
     const existingTasks = [
@@ -439,6 +453,7 @@ describe("R3: full pipeline with CoreLoop — task results update goal state", (
     const strategyManager = new StrategyManager(stateManager, mockLLM);
     const stallDetector = new StallDetector(stateManager);
     const adapter = new TrackingMockAdapter(true);
+    const adapterRegistry = makeAdapterRegistry(adapter);
 
     const taskLifecycle = new TaskLifecycle(
       stateManager,
@@ -447,7 +462,7 @@ describe("R3: full pipeline with CoreLoop — task results update goal state", (
       trustManager,
       strategyManager,
       stallDetector,
-      { approvalFn: async (_task) => true, healthCheckEnabled: false }
+      { approvalFn: async (_task) => true, healthCheckEnabled: false, adapterRegistry }
     );
 
     const gapVector = makeGapVector(goal.id);
@@ -489,6 +504,7 @@ describe("R3: full pipeline with CoreLoop — task results update goal state", (
     const strategyManager = new StrategyManager(stateManager, mockLLM);
     const stallDetector = new StallDetector(stateManager);
     const adapter = new TrackingMockAdapter(true);
+    const adapterRegistry = makeAdapterRegistry(adapter);
 
     const taskLifecycle = new TaskLifecycle(
       stateManager,
@@ -497,11 +513,8 @@ describe("R3: full pipeline with CoreLoop — task results update goal state", (
       trustManager,
       strategyManager,
       stallDetector,
-      { approvalFn: async (_task) => true, healthCheckEnabled: false }
+      { approvalFn: async (_task) => true, healthCheckEnabled: false, adapterRegistry }
     );
-
-    const adapterRegistry = new AdapterRegistry();
-    adapterRegistry.register(adapter);
 
     // Use mocks for the non-TaskLifecycle CoreLoop deps
     const goalId = goal.id;
@@ -597,8 +610,8 @@ describe("R3: full pipeline with CoreLoop — task results update goal state", (
     expect(loopResult.totalIterations).toBeGreaterThanOrEqual(1);
     expect(["max_iterations", "completed"]).toContain(loopResult.finalStatus);
 
-    // adapter.execute() was called through the real TaskLifecycle
-    expect(adapter.executeCalls).toHaveLength(1);
+    // adapter.execute() was called through the real TaskLifecycle for execution and verification.
+    expectTaskAndMechanicalAdapterCalls(adapter);
 
     // Goal dimension was updated after the pass verdict
     const updatedGoal = await stateManager.loadGoal(goalId);


### PR DESCRIPTION
Closes #1151

## Implementation Summary
- Replaced mechanical verification assumed-pass fallbacks with fail-closed results when an adapter-required blocking check cannot execute because the adapter registry is missing, empty, lookup fails, the adapter is unavailable, or adapter execution throws.
- Added mechanical evidence that records the command did not run or did not run to completion and marks the result unknown/Uncertain.
- Updated verifier caller-path tests so normal L1/L2 evidence paths use an explicit passing adapter registry, and added regressions for missing, empty, lookup-failing, and throwing adapter paths.

## Verification Commands
- npm run test:unit -- src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts
- npm run test:unit -- src/orchestrator/execution/__tests__/task-lifecycle-verification.test.ts src/orchestrator/execution/__tests__/task-lifecycle-cycle-failure.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known Unresolved Risks
- `npm run lint:boundaries` still reports the existing project warnings, but exits 0 with no errors.

## Parallel PR Dependency Status
- Related #1130 / PR #1154 was merged before this branch and is included in this base.
- Open PR #1157 touches adjacent task execution/diff files but not `task-verifier-rules.ts`; no direct conflict found for this PR.
- Open PR #1156 is in chat/agent-loop compaction files; no direct conflict found.

## Review
- Fresh review found the initial adapter `execute()` throw branch lacked unknown/did-not-run evidence.
- Fixed that branch and added a regression; follow-up review reported no material findings.