### PR TITLE
refactor(semantic): use typed tool activity categories

### DIFF
--- a/src/interface/chat/__tests__/chat-event-state.test.ts
+++ b/src/interface/chat/__tests__/chat-event-state.test.ts
@@ -100,6 +100,7 @@ describe("applyChatEventToMessages", () => {
       toolCallId: "tool-1",
       toolName: "shell_command",
       args: { command: "rg ChatEvent src/interface/chat", cwd: "/repo" },
+      activityCategory: "search",
     }, 20);
 
     expect(messages).toHaveLength(1);
@@ -296,6 +297,7 @@ describe("applyChatEventToMessages", () => {
       eventId: "tool-start-1",
       callId: "call-1",
       toolName: "shell_command",
+      activityCategory: "search",
       inputPreview: "{\"command\":\"rg ChatRunner src/interface/chat\"}",
     });
     await sink.emit({
@@ -304,6 +306,7 @@ describe("applyChatEventToMessages", () => {
       eventId: "tool-finish-1",
       callId: "call-1",
       toolName: "shell_command",
+      activityCategory: "search",
       success: true,
       inputPreview: "{\"command\":\"rg ChatRunner src/interface/chat\"}",
       outputPreview: "src/interface/chat/chat-runner.ts",
@@ -715,6 +718,41 @@ describe("applyChatEventToMessages", () => {
     expect(messages[0]!.text).not.toContain("\"observation\"");
   });
 
+  it("emits plan_update bridge events with typed planning metadata", async () => {
+    const events: ChatEvent[] = [];
+    const bridge = new ChatRunnerEventBridge(() => (event) => {
+      events.push(event);
+    });
+    const sink = bridge.createAgentLoopEventSink({ runId: "run-1", turnId: "turn-1" });
+    const base = {
+      sessionId: "session-1",
+      traceId: "trace-1",
+      turnId: "agent-turn-1",
+      goalId: "goal-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+    };
+
+    await sink.emit({
+      ...base,
+      type: "plan_update",
+      eventId: "plan-1",
+      summary: "inspect files, then verify behavior",
+    });
+
+    const toolUpdate = events.find((event): event is Extract<ChatEvent, { type: "tool_update" }> =>
+      event.type === "tool_update"
+    );
+
+    expect(toolUpdate).toMatchObject({
+      type: "tool_update",
+      toolName: "update_plan",
+      status: "result",
+      message: "inspect files, then verify behavior",
+      activityCategory: "planning",
+      presentation: { suppressTranscript: true },
+    });
+  });
+
   it("removes transient activity when assistant final arrives", () => {
     const withActivity = applyChatEventToMessages([], {
       type: "activity",
@@ -955,6 +993,7 @@ describe("applyChatEventToMessages", () => {
         toolCallId: `tool-${index}`,
         toolName: "read_file",
         args: { path: `src/file-${index}.ts` },
+        activityCategory: "read",
       }, 20);
     }
 
@@ -988,6 +1027,7 @@ describe("applyChatEventToMessages", () => {
       toolCallId: "tool-1",
       toolName: "shell_command",
       args: { command: "npm run test:changed -- --run" },
+      activityCategory: "test",
     }, 20);
 
     const running = applyChatEventToMessages(started, {
@@ -1013,9 +1053,25 @@ describe("applyChatEventToMessages", () => {
       toolName: "apply_patch",
       status: "awaiting_approval",
       message: "write src/example.ts",
+      activityCategory: "file_modify",
     }, 20);
 
     expect(waiting[0]!.text).toContain("Waiting for approval apply_patch - write src/example.ts");
+  });
+
+  it("renders update_plan as planning from typed tool metadata", () => {
+    const messages = applyChatEventToMessages([], {
+      type: "tool_start",
+      runId: "run-1",
+      turnId: "turn-1",
+      createdAt: "2026-04-08T00:00:00.000Z",
+      toolCallId: "tool-plan",
+      toolName: "update_plan",
+      args: { steps: [{ step: "inspect", status: "in_progress" }] },
+      activityCategory: "planning",
+    }, 20);
+
+    expect(messages[0]!.text).toContain("Planning update_plan");
   });
 
   it("moves a tool out of waiting once execution resumes after approval", () => {
@@ -1028,6 +1084,7 @@ describe("applyChatEventToMessages", () => {
       toolName: "apply_patch",
       status: "awaiting_approval",
       message: "write src/example.ts",
+      activityCategory: "file_modify",
     }, 20);
 
     const running = applyChatEventToMessages(waiting, {

--- a/src/interface/chat/__tests__/chat-runner-tools.test.ts
+++ b/src/interface/chat/__tests__/chat-runner-tools.test.ts
@@ -6,7 +6,8 @@ import type { IAdapter } from "../../../orchestrator/execution/adapter-layer.js"
 import type { ILLMClient, LLMMessage, LLMRequestOptions, LLMResponse } from "../../../base/llm/llm-client.js";
 import type { ToolRegistry } from "../../../tools/registry.js";
 import type { ToolExecutor } from "../../../tools/executor.js";
-import type { ITool, ToolResult, ToolCallContext } from "../../../tools/types.js";
+import type { ITool, ToolActivityCategory, ToolResult, ToolCallContext } from "../../../tools/types.js";
+import type { ChatEvent } from "../chat-events.js";
 import { z } from "zod";
 
 // Mock context-provider so tests don't walk the real filesystem
@@ -32,7 +33,11 @@ function makeMockAdapter(): IAdapter {
 }
 
 /** Create a minimal mock ITool with controllable call behavior. */
-function makeMockTool(name: string, callImpl: (input: Record<string, unknown>, ctx: ToolCallContext) => Promise<ToolResult>): ITool {
+function makeMockTool(
+  name: string,
+  callImpl: (input: Record<string, unknown>, ctx: ToolCallContext) => Promise<ToolResult>,
+  activityCategory?: ToolActivityCategory
+): ITool {
   return {
     metadata: {
       name,
@@ -45,6 +50,7 @@ function makeMockTool(name: string, callImpl: (input: Record<string, unknown>, c
       maxConcurrency: 0,
       maxOutputChars: 4000,
       tags: [],
+      ...(activityCategory ? { activityCategory } : {}),
     },
     inputSchema: z.object({}),
     description: () => "mock tool",
@@ -280,6 +286,33 @@ describe("ChatRunner — tool status callbacks", () => {
       const [, result] = (onToolEnd as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(result.summary).toBe("...");
     });
+  });
+
+  it("emits typed activity categories through the production tool-loop event path", async () => {
+    const events: ChatEvent[] = [];
+    const tool = makeMockTool("ambiguous-tool", async () => ({
+      success: true,
+      data: null,
+      summary: "done",
+      durationMs: 5,
+    }), "search");
+    const deps = makeDeps({
+      llmClient: makeLLMClientWithToolCall("ambiguous-tool", {}),
+      registry: makeMockRegistry(tool),
+      onEvent: (event) => { events.push(event); },
+    });
+    const runner = new ChatRunner(deps);
+
+    await runner.execute("Could you inspect the workspace surface?", "/repo");
+
+    const toolEvents = events.filter((event): event is Extract<ChatEvent, { type: "tool_start" | "tool_update" | "tool_end" }> =>
+      event.type === "tool_start" || event.type === "tool_update" || event.type === "tool_end"
+    );
+    expect(toolEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "tool_start", toolName: "ambiguous-tool", activityCategory: "search" }),
+      expect.objectContaining({ type: "tool_update", toolName: "ambiguous-tool", activityCategory: "search" }),
+      expect.objectContaining({ type: "tool_end", toolName: "ambiguous-tool", activityCategory: "search" }),
+    ]));
   });
 
   describe("onToolEnd callback — failure path", () => {

--- a/src/interface/chat/chat-event-state.ts
+++ b/src/interface/chat/chat-event-state.ts
@@ -1,6 +1,7 @@
 import type { ChatEvent } from "./chat-events.js";
 import { formatLifecycleFailureMessage } from "./failure-recovery.js";
 import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
+import type { ToolActivityCategory } from "../../tools/types.js";
 import { renderOperationProgress } from "./operation-progress.js";
 import { redactSetupSecrets } from "./setup-secret-intake.js";
 
@@ -11,6 +12,7 @@ interface StreamToolActivity {
   toolName: string;
   state: ToolActivityState;
   detail: string;
+  activityCategory?: ToolActivityCategory;
   timestamp: Date;
 }
 
@@ -170,48 +172,28 @@ function summarizeToolArgs(args: Record<string, unknown>): string {
   return keys.slice(0, 3).map((key) => `${key}=${summarizeValue(args[key])}`).filter(Boolean).join(", ");
 }
 
-function classifyCommand(command: string): ToolActivityState {
-  const normalized = command.trim().toLowerCase();
-  if (/^(rg|grep|cat|sed|awk|ls|find|pwd|git (show|log|status|diff\b|grep))\b/.test(normalized)) {
-    return "reading";
-  }
-  if (/(npm|pnpm|yarn|bun) (run )?(test|check|typecheck|lint|verify)\b|pytest\b|vitest\b|cargo test\b|go test\b/.test(normalized)) {
-    return "verifying";
-  }
-  if (/^(apply_patch|git apply|python .*write|node .*write)\b/.test(normalized)) {
-    return "editing";
-  }
-  return "running";
-}
-
-function classifyTool(toolName: string, args: Record<string, unknown>, status?: "awaiting_approval" | "running" | "result"): ToolActivityState {
+function stateFromToolActivityCategory(
+  activityCategory: ToolActivityCategory | undefined,
+  status?: "awaiting_approval" | "running" | "result",
+): ToolActivityState {
   if (status === "awaiting_approval") return "waiting";
-  const normalized = toolName.toLowerCase().replace(/[-_]/g, "");
-  const command = typeof args["command"] === "string"
-    ? args["command"]
-    : typeof args["cmd"] === "string"
-      ? args["cmd"]
-      : null;
-  if (command) return classifyCommand(command);
-  if (normalized.includes("plan")) return "planning";
-  if (normalized.includes("write") || normalized.includes("edit") || normalized.includes("patch") || normalized.includes("delete")) {
-    return "editing";
+  switch (activityCategory) {
+    case "search":
+    case "read":
+      return "reading";
+    case "planning":
+      return "planning";
+    case "file_create":
+    case "file_modify":
+      return "editing";
+    case "test":
+      return "verifying";
+    case "approval":
+      return "waiting";
+    case "command":
+    case undefined:
+      return "running";
   }
-  if (normalized.includes("test") || normalized.includes("verify") || normalized.includes("check")) {
-    return "verifying";
-  }
-  if (
-    normalized.includes("read") ||
-    normalized.includes("list") ||
-    normalized.includes("search") ||
-    normalized.includes("grep") ||
-    normalized.includes("diff") ||
-    normalized.includes("log") ||
-    normalized.includes("status")
-  ) {
-    return "reading";
-  }
-  return "running";
 }
 
 function formatToolActivityState(state: ToolActivityState): string {
@@ -265,23 +247,24 @@ function upsertToolActivity(
   const previous = messages.find((message) => message.id === toolLogId);
   const previousActivities = previous?.toolActivities ?? [];
   const existing = previousActivities.find((activity) => activity.id === event.toolCallId);
-  const args = event.type === "tool_start" ? event.args : {};
   const fallbackDetail = event.type === "tool_start"
     ? summarizeToolArgs(event.args)
     : event.type === "tool_update"
       ? (event.status === "running" ? existing?.detail ?? event.message : event.message)
       : event.summary;
   const detail = fallbackDetail || existing?.detail || "";
+  const activityCategory = event.activityCategory ?? existing?.activityCategory;
   const state = event.type === "tool_end"
     ? event.success ? "completed" : "failed"
     : event.type === "tool_update" && event.status !== "awaiting_approval" && existing && existing.state !== "waiting"
       ? existing.state
-      : classifyTool(event.toolName, args, event.type === "tool_update" ? event.status : "running");
+      : stateFromToolActivityCategory(activityCategory, event.type === "tool_update" ? event.status : "running");
   const nextActivity: StreamToolActivity = {
     id: event.toolCallId,
     toolName: event.toolName,
     state,
     detail,
+    ...(activityCategory ? { activityCategory } : {}),
     timestamp,
   };
   const nextActivities = [

--- a/src/interface/chat/chat-events.ts
+++ b/src/interface/chat/chat-events.ts
@@ -1,4 +1,5 @@
 import type { FailureRecoveryGuidance } from "./failure-recovery.js";
+import type { ToolActivityCategory } from "../../tools/types.js";
 import type { AgentTimelineItem } from "../../orchestrator/execution/agent-loop/agent-timeline.js";
 import type { TurnLanguageHint } from "./turn-language.js";
 import type { OperationProgressItem } from "./operation-progress.js";
@@ -53,6 +54,7 @@ export interface ToolStartEvent extends ChatEventBase {
   toolCallId: string;
   toolName: string;
   args: Record<string, unknown>;
+  activityCategory?: ToolActivityCategory;
   presentation?: {
     suppressTranscript?: boolean;
   };
@@ -64,6 +66,7 @@ export interface ToolUpdateEvent extends ChatEventBase {
   toolName: string;
   status: "awaiting_approval" | "running" | "result";
   message: string;
+  activityCategory?: ToolActivityCategory;
   presentation?: {
     suppressTranscript?: boolean;
   };
@@ -76,6 +79,7 @@ export interface ToolEndEvent extends ChatEventBase {
   success: boolean;
   summary: string;
   durationMs: number;
+  activityCategory?: ToolActivityCategory;
   presentation?: {
     suppressTranscript?: boolean;
   };

--- a/src/interface/chat/chat-runner-event-bridge.ts
+++ b/src/interface/chat/chat-runner-event-bridge.ts
@@ -194,6 +194,7 @@ export class ChatRunnerEventBridge {
             toolCallId: event.callId,
             toolName: event.toolName,
             args: this.parseAgentLoopPreview(event.inputPreview),
+            ...(event.activityCategory ? { activityCategory: event.activityCategory } : {}),
             presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
@@ -203,6 +204,7 @@ export class ChatRunnerEventBridge {
             toolName: event.toolName,
             status: "running",
             message: "started",
+            ...(event.activityCategory ? { activityCategory: event.activityCategory } : {}),
             presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
@@ -235,6 +237,7 @@ export class ChatRunnerEventBridge {
             success: event.success,
             summary: event.outputPreview,
             durationMs: event.durationMs,
+            ...(event.activityCategory ? { activityCategory: event.activityCategory } : {}),
             presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });
@@ -255,6 +258,7 @@ export class ChatRunnerEventBridge {
             toolName: "update_plan",
             status: "result",
             message: event.summary,
+            activityCategory: "planning",
             presentation: { suppressTranscript: true },
             ...this.eventBase(eventContext),
           });

--- a/src/interface/chat/chat-runner-routes.ts
+++ b/src/interface/chat/chat-runner-routes.ts
@@ -1051,6 +1051,7 @@ async function dispatchToolCall(
     host.eventBridge.emitActivity("tool", formatToolActivity("Failed", name, `Unknown tool: ${name}`), eventContext, toolCallId);
     return JSON.stringify({ error: `Unknown tool: ${name}` });
   }
+  const activityCategory = tool.metadata.activityCategory;
   const startTime = Date.now();
   try {
     const parsed = tool.inputSchema.safeParse(args);
@@ -1063,6 +1064,7 @@ async function dispatchToolCall(
         success: false,
         summary: `Invalid input: ${parsed.error.message}`,
         durationMs: Date.now() - startTime,
+        ...(activityCategory ? { activityCategory } : {}),
         ...host.eventBridge.eventBase(eventContext),
       });
       return JSON.stringify({ error: `Invalid input: ${parsed.error.message}` });
@@ -1073,6 +1075,7 @@ async function dispatchToolCall(
       toolCallId,
       toolName: name,
       args,
+      ...(activityCategory ? { activityCategory } : {}),
       ...host.eventBridge.eventBase(eventContext),
     });
     host.eventBridge.emitActivity("tool", formatToolActivity("Running", name, JSON.stringify(args)), eventContext, toolCallId);
@@ -1085,6 +1088,7 @@ async function dispatchToolCall(
         toolName: name,
         status: "running",
         message: "running",
+        ...(activityCategory ? { activityCategory } : {}),
         ...host.eventBridge.eventBase(eventContext),
       });
       host.deps.onToolStart?.(name, args);
@@ -1099,6 +1103,7 @@ async function dispatchToolCall(
           success: false,
           summary: permResult.reason,
           durationMs: Date.now() - startTime,
+          ...(activityCategory ? { activityCategory } : {}),
           ...host.eventBridge.eventBase(eventContext),
         });
         return `Tool ${name} denied: ${permResult.reason}`;
@@ -1111,6 +1116,7 @@ async function dispatchToolCall(
           toolName: name,
           status: "awaiting_approval",
           message: permResult.reason,
+          ...(activityCategory ? { activityCategory } : {}),
           ...host.eventBridge.eventBase(eventContext),
         });
         const approved = await context.approvalFn({
@@ -1129,6 +1135,7 @@ async function dispatchToolCall(
             success: false,
             summary: `Not approved: ${permResult.reason}`,
             durationMs: Date.now() - startTime,
+            ...(activityCategory ? { activityCategory } : {}),
             ...host.eventBridge.eventBase(eventContext),
           });
           return `Tool ${name} not approved: ${permResult.reason}`;
@@ -1140,6 +1147,7 @@ async function dispatchToolCall(
         toolName: name,
         status: "running",
         message: "running",
+        ...(activityCategory ? { activityCategory } : {}),
         ...host.eventBridge.eventBase(eventContext),
       });
       host.deps.onToolStart?.(name, args);
@@ -1160,6 +1168,7 @@ async function dispatchToolCall(
       toolName: name,
       status: "result",
       message: result.summary || "...",
+      ...(activityCategory ? { activityCategory } : {}),
       ...host.eventBridge.eventBase(eventContext),
     });
     host.eventBridge.emitEvent({
@@ -1169,6 +1178,7 @@ async function dispatchToolCall(
       success: result.success,
       summary: result.summary || "...",
       durationMs,
+      ...(activityCategory ? { activityCategory } : {}),
       ...host.eventBridge.eventBase(eventContext),
     });
     return result.data != null ? JSON.stringify(result.data) : (result.summary ?? "(no result)");
@@ -1184,6 +1194,7 @@ async function dispatchToolCall(
       success: false,
       summary: message,
       durationMs,
+      ...(activityCategory ? { activityCategory } : {}),
       ...host.eventBridge.eventBase(eventContext),
     });
     return JSON.stringify({ error: `Tool ${name} failed: ${message}` });

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts
@@ -21,7 +21,7 @@ function finishedTool(
   eventId: string,
   toolName: string,
   inputPreview: string,
-  activityCategory?: "search" | "read" | "command" | "file_create" | "file_modify" | "test" | "approval",
+  activityCategory?: "search" | "read" | "planning" | "command" | "file_create" | "file_modify" | "test" | "approval",
 ): AgentLoopEvent {
   return baseEvent({
     type: "tool_call_finished",
@@ -39,12 +39,13 @@ function finishedTool(
 describe("agent timeline activity summaries", () => {
   it("classifies structured activity deterministically", () => {
     const items = [
-      finishedTool("search-1", "shell_command", JSON.stringify({ command: "rg ChatRunner src/interface/chat" })),
+      finishedTool("search-1", "shell_command", JSON.stringify({ command: "rg ChatRunner src/interface/chat" }), "search"),
       finishedTool("read-1", "read_file", JSON.stringify({ path: "src/interface/chat/chat-runner.ts" }), "read"),
+      finishedTool("plan-1", "update_plan", JSON.stringify({ steps: [{ step: "inspect", status: "in_progress" }] }), "planning"),
       finishedTool("command-1", "shell_command", JSON.stringify({ command: "node scripts/build.js" })),
       finishedTool("create-1", "file_write", JSON.stringify({ path: "src/new-file.ts" }), "file_create"),
       finishedTool("modify-1", "apply_patch", JSON.stringify({ path: "src/existing.ts" }), "file_modify"),
-      finishedTool("test-1", "shell_command", JSON.stringify({ command: "npm run typecheck" })),
+      finishedTool("test-1", "shell_command", JSON.stringify({ command: "npm run typecheck" }), "test"),
       baseEvent({
         type: "approval_request",
         eventId: "approval-1",
@@ -59,6 +60,7 @@ describe("agent timeline activity summaries", () => {
     expect(summarizeAgentTimelineActivity(items)).toEqual([
       { kind: "search", count: 1 },
       { kind: "read", count: 1 },
+      { kind: "planning", count: 1 },
       { kind: "command", count: 1 },
       { kind: "file_create", count: 1 },
       { kind: "file_modify", count: 1 },
@@ -79,14 +81,16 @@ describe("agent timeline activity summaries", () => {
     ]);
   });
 
-  it("uses shell command parsing for explicit command protocol input", () => {
+  it("uses declared shell command activity categories instead of parsing command text", () => {
     const items = [
-      finishedTool("shell-search", "shell_command", JSON.stringify({ command: "rg Timeline src" }), "command"),
-      finishedTool("shell-test", "shell_command", JSON.stringify({ command: "npm run test:changed" }), "command"),
+      finishedTool("shell-search", "shell_command", JSON.stringify({ command: "semantic paraphrase without command cues" }), "search"),
+      finishedTool("shell-test", "shell_command", JSON.stringify({ command: "semantic paraphrase without test cues" }), "test"),
+      finishedTool("shell-command", "shell_command", JSON.stringify({ command: "npm run test:changed" }), "command"),
     ].map(projectAgentLoopEventToTimeline);
 
     expect(summarizeAgentTimelineActivity(items)).toEqual([
       { kind: "search", count: 1 },
+      { kind: "command", count: 1 },
       { kind: "test", count: 1 },
     ]);
   });
@@ -180,7 +184,7 @@ describe("agent timeline activity summaries", () => {
 
   it("creates a shared summary item separate from detailed timeline items", () => {
     const items = [
-      finishedTool("search-1", "shell_command", JSON.stringify({ command: "rg Timeline src" })),
+      finishedTool("search-1", "shell_command", JSON.stringify({ command: "rg Timeline src" }), "search"),
       finishedTool("command-1", "shell_command", JSON.stringify({ command: "node scripts/build.js" })),
     ].map(projectAgentLoopEventToTimeline);
 

--- a/src/orchestrator/execution/agent-loop/agent-timeline.ts
+++ b/src/orchestrator/execution/agent-loop/agent-timeline.ts
@@ -321,60 +321,7 @@ export function formatAgentTimelineActivitySummary(buckets: AgentTimelineActivit
 function classifyTimelineActivity(item: AgentTimelineItem): AgentTimelineActivityKind | null {
   if (item.kind === "approval" && item.status === "requested") return "approval";
   if (item.kind !== "tool" || item.status !== "finished") return null;
-  return classifyToolActivity(item.activityCategory, item.inputPreview);
-}
-
-function classifyToolActivity(
-  activityCategory: AgentTimelineActivityKind | undefined,
-  inputPreview?: string,
-): AgentTimelineActivityKind {
-  const input = parseToolInputPreview(inputPreview);
-  const command = stringField(input, "command") ?? stringField(input, "cmd");
-  if (command && (!activityCategory || activityCategory === "command")) {
-    return classifyCommandActivity(command);
-  }
-  if (activityCategory) return activityCategory;
-  return "command";
-}
-
-function classifyCommandActivity(command: string): AgentTimelineActivityKind {
-  const trimmed = command.trim();
-  const executable = firstCommandToken(trimmed);
-  if (["rg", "grep", "ag", "ack"].includes(executable)) return "search";
-  if (["cat", "sed", "awk", "ls", "find", "pwd", "head", "tail"].includes(executable)) return "read";
-  if (executable === "git") {
-    const subcommand = firstCommandToken(trimmed.split(/\s+/).slice(1).join(" "));
-    if (["grep"].includes(subcommand)) return "search";
-    if (["show", "log", "status", "diff", "ls-files"].includes(subcommand)) return "read";
-  }
-  if (["npm", "pnpm", "yarn", "bun"].includes(executable)) {
-    if (/\b(test|vitest|jest|typecheck|lint|check|verify)\b/.test(trimmed)) return "test";
-  }
-  if (["pytest", "vitest", "jest"].includes(executable)) return "test";
-  if (executable === "go" && /\btest\b/.test(trimmed)) return "test";
-  if (executable === "cargo" && /\btest\b/.test(trimmed)) return "test";
-  return "command";
-}
-
-function parseToolInputPreview(inputPreview?: string): Record<string, unknown> | null {
-  if (!inputPreview) return null;
-  try {
-    const parsed = JSON.parse(inputPreview);
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? parsed as Record<string, unknown>
-      : null;
-  } catch {
-    return null;
-  }
-}
-
-function stringField(input: Record<string, unknown> | null, field: string): string | null {
-  const value = input?.[field];
-  return typeof value === "string" ? value : null;
-}
-
-function firstCommandToken(command: string): string {
-  return command.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? "";
+  return item.activityCategory ?? "command";
 }
 
 function isUserVisibleToolObservation(observation: AgentLoopToolObservation): boolean {
@@ -384,6 +331,7 @@ function isUserVisibleToolObservation(observation: AgentLoopToolObservation): bo
 const ACTIVITY_SUMMARY_ORDER: AgentTimelineActivityKind[] = [
   "search",
   "read",
+  "planning",
   "command",
   "file_create",
   "file_modify",
@@ -394,6 +342,7 @@ const ACTIVITY_SUMMARY_ORDER: AgentTimelineActivityKind[] = [
 const ACTIVITY_SUMMARY_LABELS: Record<AgentTimelineActivityKind, string> = {
   search: "searched",
   read: "read",
+  planning: "planned",
   command: "ran",
   file_create: "created",
   file_modify: "modified",
@@ -404,6 +353,7 @@ const ACTIVITY_SUMMARY_LABELS: Record<AgentTimelineActivityKind, string> = {
 const ACTIVITY_SUMMARY_NOUNS: Record<AgentTimelineActivityKind, { singular: string; plural: string }> = {
   search: { singular: "search", plural: "searches" },
   read: { singular: "file", plural: "files" },
+  planning: { singular: "plan", plural: "plans" },
   command: { singular: "command", plural: "commands" },
   file_create: { singular: "file", plural: "files" },
   file_modify: { singular: "file", plural: "files" },

--- a/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
+++ b/src/runtime/gateway/__tests__/telegram-gateway-adapter.test.ts
@@ -351,7 +351,7 @@ describe("TelegramGatewayAdapter", () => {
         "Approval requested for shell_command: run a write command",
         "Observed shell_command (denied): TOOL NOT EXECUTED (approval_denied): Operator denied release execution.",
         "Compacted context (mid_turn, context_limit): 12 -> 4.",
-        "searched 1 search, requested 1 approval",
+        "ran 1 command, requested 1 approval",
       ]));
     });
     expect(sentMessages.some((message) => message.includes("[tool]"))).toBe(false);

--- a/src/tools/__tests__/types.test.ts
+++ b/src/tools/__tests__/types.test.ts
@@ -82,7 +82,7 @@ describe("ToolPermissionLevelSchema", () => {
 });
 
 describe("ToolActivityCategorySchema", () => {
-  it.each(["search", "read", "command", "file_create", "file_modify", "test", "approval"] as const)(
+  it.each(["search", "read", "planning", "command", "file_create", "file_modify", "test", "approval"] as const)(
     "parses activity category: %s",
     (category) => {
       expect(ToolActivityCategorySchema.parse(category)).toBe(category);

--- a/src/tools/system/UpdatePlanTool/UpdatePlanTool.ts
+++ b/src/tools/system/UpdatePlanTool/UpdatePlanTool.ts
@@ -22,7 +22,7 @@ export class UpdatePlanTool implements ITool<UpdatePlanInput> {
     maxConcurrency: 0,
     maxOutputChars: 4000,
     tags: ["agentloop", "planning"],
-    activityCategory: "read",
+    activityCategory: "planning",
   };
 
   readonly inputSchema = UpdatePlanInputSchema;

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -70,6 +70,7 @@ export type ToolPermissionLevel = z.infer<typeof ToolPermissionLevelSchema>;
 export const ToolActivityCategorySchema = z.enum([
   "search",
   "read",
+  "planning",
   "command",
   "file_create",
   "file_modify",


### PR DESCRIPTION
Refs #1120

## Summary
- remove chat/tool activity classification that inferred status from shell command text or tool-name substrings
- propagate typed `ToolActivityCategory` through ChatRunner tool events and the agent-loop bridge
- add a typed `planning` category so `update_plan` and synthetic plan updates keep the existing Planning operator status
- keep unknown activity conservative as `command` instead of guessing from names or arguments

## Validation
- `npx vitest run --config vitest.config.ts src/interface/chat/__tests__/chat-event-state.test.ts src/interface/chat/__tests__/chat-runner-tools.test.ts src/tools/__tests__/types.test.ts --reporter verbose`
- `npx vitest run --config vitest.unit.config.ts src/orchestrator/execution/agent-loop/__tests__/agent-timeline.test.ts --reporter verbose`
- `npm run typecheck`
- `npm run test:changed`
- `npm run lint:boundaries` (0 errors; existing warnings only)

## Review
- Fresh review found `update_plan` needed a durable planning category; fixed.
- Fresh follow-up review found synthetic plan updates needed planning metadata; fixed.
- Final fresh review found no material issues.

## Remaining #1120 acceptance
This is a Wave 2 slice and intentionally does not close #1120. Remaining work includes shell policy/TUI bypass, command-result evidence classification, chat context keyword grep, typed-field text fallbacks, artifact retention label/path fallback, and error-text fallback.