### PR TITLE
Fix non-git revert evidence handling

### DIFF
--- a/src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts
+++ b/src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts
@@ -129,6 +129,7 @@ describe("executeTask protected paths", () => {
     } as unknown as IAdapter;
     execFileSyncFn = vi.fn().mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "diff" && args[1] === "--name-only") return "src/changed.ts\n.env";
+      if (args[0] === "diff" && args[1] === "--cached" && args[2] === "--name-only") return "";
       if (args[0] === "ls-files") return "";
       if (args[0] === "diff") return [
         `diff --git a/${args[3]} b/${args[3]}`,

--- a/src/orchestrator/execution/__tests__/task-lifecycle-cycle-failure.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-cycle-failure.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { SessionManager } from "../session-manager.js";
 import { TrustManager } from "../../../platform/traits/trust-manager.js";
@@ -40,8 +42,6 @@ function createSpyLLMClient(responses: string[]): ILLMClient {
 const LLM_REVIEW_PASS = '{"verdict": "pass", "reasoning": "All criteria satisfied", "criteria_met": 1, "criteria_total": 1}';
 const LLM_REVIEW_FAIL = '{"verdict": "fail", "reasoning": "Criteria not met", "criteria_met": 0, "criteria_total": 1}';
 const LLM_REVIEW_PARTIAL = '{"verdict": "partial", "reasoning": "Some criteria met", "criteria_met": 1, "criteria_total": 2}';
-const REVERT_SUCCESS = '```json\n{"success": true, "reason": "Changes have been reverted successfully"}\n```';
-
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
     id: "task-1",
@@ -118,7 +118,7 @@ describe("TaskLifecycle — failure handling", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
-  function createLifecycle(llmClient: ILLMClient): TaskLifecycle {
+  function createLifecycle(llmClient: ILLMClient, options: { revertCwd?: string } = {}): TaskLifecycle {
     strategyManager = new StrategyManager(stateManager, llmClient);
     return new TaskLifecycle(
       stateManager,
@@ -127,8 +127,21 @@ describe("TaskLifecycle — failure handling", () => {
       trustManager,
       strategyManager,
       stallDetector,
-      { healthCheckEnabled: false, adapterRegistry: makePassingAdapterRegistry() }
+      { healthCheckEnabled: false, adapterRegistry: makePassingAdapterRegistry(), ...options }
     );
+  }
+
+  function initRevertRepo(name: string): string {
+    const repoDir = path.join(tmpDir, name);
+    fs.mkdirSync(repoDir, { recursive: true });
+    execFileSync("git", ["init"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["config", "user.name", "Codex Test"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["config", "user.email", "codex@example.com"], { cwd: repoDir, stdio: "pipe" });
+    fs.writeFileSync(path.join(repoDir, "tracked.txt"), "original\n", "utf-8");
+    execFileSync("git", ["add", "tracked.txt"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["commit", "-m", "init"], { cwd: repoDir, stdio: "pipe" });
+    fs.writeFileSync(path.join(repoDir, "tracked.txt"), "changed\n", "utf-8");
+    return repoDir;
   }
 
   it("L1 mechanical criteria detected: evidence includes mechanical layer", async () => {
@@ -247,8 +260,9 @@ describe("TaskLifecycle — failure handling", () => {
   });
 
   it("fail verdict with reversible task → revert succeeds → action is discard", async () => {
-    const llm = createMockLLMClient([REVERT_SUCCESS]);
-    const lifecycle = createLifecycle(llm);
+    const repoDir = initRevertRepo("cycle-revert-success");
+    const llm = createMockLLMClient([]);
+    const lifecycle = createLifecycle(llm, { revertCwd: repoDir });
     const task = makeTask({
       id: "task-discard",
       reversibility: "reversible",
@@ -263,12 +277,14 @@ describe("TaskLifecycle — failure handling", () => {
         { layer: "independent_review", description: "Nothing worked", confidence: 0.8 },
       ],
       dimension_updates: [],
+      file_diffs: [{ path: "tracked.txt", patch: "diff --git a/tracked.txt b/tracked.txt" }],
       timestamp: new Date().toISOString(),
     };
 
     await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
     const result = await lifecycle.handleFailure(task, vr);
     expect(result.action).toBe("discard");
+    expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("original\n");
   });
 
   it("consecutive_failure_count reaches 3 → action is escalate", async () => {

--- a/src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { SessionManager } from "../session-manager.js";
 import { TrustManager } from "../../../platform/traits/trust-manager.js";
@@ -64,7 +66,6 @@ const VALID_TASK_RESPONSE = `\`\`\`json
 
 const LLM_REVIEW_PASS = '{"verdict": "pass", "reasoning": "All criteria satisfied", "criteria_met": 1, "criteria_total": 1}';
 const LLM_REVIEW_FAIL = '{"verdict": "fail", "reasoning": "Criteria not met", "criteria_met": 0, "criteria_total": 1}';
-const REVERT_SUCCESS = '```json\n{"success": true, "reason": "Changes have been reverted successfully"}\n```';
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -181,6 +182,19 @@ describe("TaskLifecycle — persistence", () => {
       stallDetector,
       { healthCheckEnabled: false, execFileSyncFn: () => "some-file.ts", ...options }
     );
+  }
+
+  function initRevertRepo(name: string): string {
+    const repoDir = path.join(tmpDir, name);
+    fs.mkdirSync(repoDir, { recursive: true });
+    execFileSync("git", ["init"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["config", "user.name", "Codex Test"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["config", "user.email", "codex@example.com"], { cwd: repoDir, stdio: "pipe" });
+    fs.writeFileSync(path.join(repoDir, "tracked.txt"), "original\n", "utf-8");
+    execFileSync("git", ["add", "tracked.txt"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["commit", "-m", "init"], { cwd: repoDir, stdio: "pipe" });
+    fs.writeFileSync(path.join(repoDir, "tracked.txt"), "changed\n", "utf-8");
+    return repoDir;
   }
 
   it("verification result saved to correct path", async () => {
@@ -362,7 +376,7 @@ describe("TaskLifecycle — persistence", () => {
   });
 
   it("runTaskCycle does not leave execution-success verification failures as completed", async () => {
-    const llm = createMockLLMClient([VALID_TASK_RESPONSE, LLM_REVIEW_FAIL, REVERT_SUCCESS]);
+    const llm = createMockLLMClient([VALID_TASK_RESPONSE, LLM_REVIEW_FAIL]);
     const lifecycle = createLifecycle(llm, { approvalFn: async () => true });
     const adapter: import("../task/task-lifecycle.js").IAdapter = {
       adapterType: "mock",
@@ -390,7 +404,7 @@ describe("TaskLifecycle — persistence", () => {
     const ledger = await stateManager.readRaw(`tasks/goal-1/ledger/${result.task.id}.json`) as Record<string, unknown>;
     const summary = ledger.summary as Record<string, unknown>;
 
-    expect(result.action).toBe("discard");
+    expect(result.action).toBe("escalate");
     expect(result.verificationResult.verdict).toBe("fail");
     expect(storedTask.status).toBe("error");
     expect(storedTask.verification_verdict).toBe("fail");
@@ -399,7 +413,7 @@ describe("TaskLifecycle — persistence", () => {
     expect(summary.task_status).toBe("error");
     expect(summary.verification_verdict).toBe("fail");
     expect(summary.latest_event_type).toBe("abandoned");
-    expect(summary.action).toBe("discard");
+    expect(summary.action).toBe("escalate");
   });
 
   it("handleFailure records failed and retried events for retryable failures", async () => {
@@ -473,15 +487,19 @@ describe("TaskLifecycle — persistence", () => {
   });
 
   it("handleFailure records discard outcomes without preserving completed status", async () => {
-    const llm = createMockLLMClient([REVERT_SUCCESS]);
-    const lifecycle = createLifecycle(llm);
+    const repoDir = initRevertRepo("persistence-revert-success");
+    const llm = createMockLLMClient([]);
+    const lifecycle = createLifecycle(llm, { revertCwd: repoDir });
     const task = makeTask({
       status: "completed",
       started_at: new Date(Date.now() - 1000).toISOString(),
       completed_at: new Date().toISOString(),
       reversibility: "reversible",
     });
-    const vr = makeVerificationResult({ task_id: task.id });
+    const vr = makeVerificationResult({
+      task_id: task.id,
+      file_diffs: [{ path: "tracked.txt", patch: "diff --git a/tracked.txt b/tracked.txt" }],
+    });
 
     await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
     const result = await lifecycle.handleFailure(task, vr);
@@ -492,6 +510,7 @@ describe("TaskLifecycle — persistence", () => {
     const summary = ledger.summary as Record<string, unknown>;
 
     expect(result.action).toBe("discard");
+    expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("original\n");
     expect(storedTask.status).toBe("error");
     expect(history[0]!.status).toBe("error");
     expect(summary.task_status).toBe("error");

--- a/src/orchestrator/execution/__tests__/task-lifecycle-execution-guards.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-execution-guards.test.ts
@@ -186,6 +186,7 @@ describe("TaskLifecycle — executeTask guardrail behavior", () => {
     });
     const execFileSyncFn = vi.fn().mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "diff" && args[1] === "--name-only") return "src/changed.ts\n.env";
+      if (args[0] === "diff" && args[1] === "--cached" && args[2] === "--name-only") return "";
       if (args[0] === "ls-files") return "";
       if (args[0] === "diff") return "";
       return "";
@@ -221,6 +222,7 @@ describe("TaskLifecycle — executeTask guardrail behavior", () => {
     });
     const execFileSyncFn = vi.fn().mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "diff" && args[1] === "--name-only") return ".env";
+      if (args[0] === "diff" && args[1] === "--cached" && args[2] === "--name-only") return "";
       if (args[0] === "ls-files") return "";
       if (args[0] === "diff") return "";
       return "";

--- a/src/orchestrator/execution/__tests__/task-lifecycle-verdict.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-verdict.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
 import { z } from "zod";
 import { StateManager } from "../../../base/state/state-manager.js";
 import { SessionManager } from "../session-manager.js";
@@ -118,6 +120,7 @@ describe("TaskLifecycle", async () => {
       logger?: import("../../../runtime/logger.js").Logger;
       adapterRegistry?: import("../task/task-lifecycle.js").AdapterRegistry;
       execFileSyncFn?: (cmd: string, args: string[], opts: { cwd: string; encoding: "utf-8" }) => string;
+      revertCwd?: string;
     }
   ): TaskLifecycle {
     strategyManager = new StrategyManager(stateManager, llmClient);
@@ -130,6 +133,19 @@ describe("TaskLifecycle", async () => {
       stallDetector,
       options
     );
+  }
+
+  function initRevertRepo(name: string): string {
+    const repoDir = path.join(tmpDir, name);
+    fs.mkdirSync(repoDir, { recursive: true });
+    execFileSync("git", ["init"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["config", "user.name", "Codex Test"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["config", "user.email", "codex@example.com"], { cwd: repoDir, stdio: "pipe" });
+    fs.writeFileSync(path.join(repoDir, "tracked.txt"), "original\n", "utf-8");
+    execFileSync("git", ["add", "tracked.txt"], { cwd: repoDir, stdio: "pipe" });
+    execFileSync("git", ["commit", "-m", "init"], { cwd: repoDir, stdio: "pipe" });
+    fs.writeFileSync(path.join(repoDir, "tracked.txt"), "changed\n", "utf-8");
+    return repoDir;
   }
 
   // ─────────────────────────────────────────────
@@ -672,8 +688,9 @@ describe("TaskLifecycle", async () => {
     });
 
     it("count < 3 with wrong direction and reversible attempts revert", async () => {
-      const llm = createMockLLMClient([REVERT_SUCCESS]);
-      const lifecycle = createLifecycle(llm);
+      const repoDir = initRevertRepo("wrong-direction-revert");
+      const llm = createMockLLMClient([]);
+      const lifecycle = createLifecycle(llm, { revertCwd: repoDir });
       const task = makeTask({
         consecutive_failure_count: 0,
         reversibility: "reversible",
@@ -683,17 +700,20 @@ describe("TaskLifecycle", async () => {
           { layer: "independent_review", description: "Wrong direction", confidence: 0.3 },
           { layer: "self_report", description: "Bad result", confidence: 0.3 },
         ],
+        file_diffs: [{ path: "tracked.txt", patch: "diff --git a/tracked.txt b/tracked.txt" }],
       });
 
       await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
       const result = await lifecycle.handleFailure(task, vr);
 
       expect(result.action).toBe("discard");
+      expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("original\n");
     });
 
     it("revert succeeds returns discard", async () => {
-      const llm = createMockLLMClient([REVERT_SUCCESS]);
-      const lifecycle = createLifecycle(llm);
+      const repoDir = initRevertRepo("successful-revert");
+      const llm = createMockLLMClient([]);
+      const lifecycle = createLifecycle(llm, { revertCwd: repoDir });
       const task = makeTask({
         consecutive_failure_count: 0,
         reversibility: "reversible",
@@ -703,12 +723,14 @@ describe("TaskLifecycle", async () => {
           { layer: "independent_review", description: "Wrong", confidence: 0.3 },
           { layer: "self_report", description: "Failed", confidence: 0.3 },
         ],
+        file_diffs: [{ path: "tracked.txt", patch: "diff --git a/tracked.txt b/tracked.txt" }],
       });
 
       await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
       const result = await lifecycle.handleFailure(task, vr);
 
       expect(result.action).toBe("discard");
+      expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("original\n");
     });
 
     it("revert fails sets state_integrity uncertain and returns escalate", async () => {

--- a/src/orchestrator/execution/__tests__/task-verifier-guards.test.ts
+++ b/src/orchestrator/execution/__tests__/task-verifier-guards.test.ts
@@ -454,9 +454,7 @@ describe("attemptRevert safety", () => {
     const originalCwd = process.cwd();
     process.chdir(repoDir);
     try {
-      const llmClient = createMockLLMClient([
-        '```json\n{"success": false, "reason": "Skip raw git restore in tests"}\n```',
-      ]);
+      const llmClient = createMockLLMClient([]);
       const deps: VerifierDeps = {
         stateManager,
         llmClient,
@@ -511,6 +509,42 @@ describe("attemptRevert safety", () => {
     }
   });
 
+  it("requires staged changes to be restored before discarding", async () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "attempt-revert-repo-"));
+    initGitRepo(repoDir);
+    fs.writeFileSync(path.join(repoDir, "report.md"), "staged output\n", "utf-8");
+    execFileSync("git", ["add", "report.md"], { cwd: repoDir, stdio: "pipe" });
+
+    const deps: VerifierDeps = {
+      stateManager,
+      llmClient: createMockLLMClient([]),
+      sessionManager,
+      trustManager,
+      stallDetector,
+      durationToMs: (d) => d.value * (d.unit === "hours" ? 3600000 : 60000),
+      revertCwd: repoDir,
+    };
+    const task = makeTask({
+      scope_boundary: { in_scope: ["report.md"], out_of_scope: [], blast_radius: "low" },
+      reversibility: "reversible",
+    });
+
+    try {
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+      const result = await handleFailure(deps, task, makeFailureVerificationResult(["report.md"]));
+
+      expect(result.action).toBe("discard");
+      expect(fs.existsSync(path.join(repoDir, "report.md"))).toBe(false);
+      expect(execFileSync("git", ["status", "--porcelain", "--", "report.md"], {
+        cwd: repoDir,
+        encoding: "utf-8",
+        stdio: "pipe",
+      })).toBe("");
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
   it("does not treat natural-language scope descriptions as revert file paths", async () => {
     const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "attempt-revert-repo-"));
     initGitRepo(repoDir);
@@ -523,9 +557,7 @@ describe("attemptRevert safety", () => {
     } as unknown as Logger;
     const deps: VerifierDeps = {
       stateManager,
-      llmClient: createMockLLMClient([
-        '```json\n{"success": false, "reason": "No concrete paths captured"}\n```',
-      ]),
+      llmClient: createMockLLMClient([]),
       sessionManager,
       trustManager,
       stallDetector,
@@ -559,6 +591,48 @@ describe("attemptRevert safety", () => {
       ).toBe(false);
     } finally {
       fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not discard non-git patch output when revert lacks concrete restore evidence", async () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "attempt-revert-non-git-"));
+    fs.writeFileSync(path.join(workspace, "report.md"), "fresh task output\n", "utf-8");
+    const llmClient = createMockLLMClient([]);
+    const logger = {
+      warn: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    } as unknown as Logger;
+    const deps: VerifierDeps = {
+      stateManager,
+      llmClient,
+      sessionManager,
+      trustManager,
+      stallDetector,
+      durationToMs: (d) => d.value * (d.unit === "hours" ? 3600000 : 60000),
+      revertCwd: workspace,
+      logger,
+    };
+    const task = makeTask({
+      scope_boundary: { in_scope: ["report.md"], out_of_scope: [], blast_radius: "low" },
+      reversibility: "reversible",
+    });
+
+    try {
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+      const result = await handleFailure(deps, task, makeFailureVerificationResult(["report.md"]));
+
+      expect(result.action).toBe("escalate");
+      expect(fs.readFileSync(path.join(workspace, "report.md"), "utf-8")).toBe("fresh task output\n");
+      expect(llmClient.callCount).toBe(0);
+      expect(logger.warn).toHaveBeenCalledWith("[task] revert attempted", expect.objectContaining({
+        taskId: task.id,
+        success: false,
+        concretePaths: ["report.md"],
+      }));
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
     }
   });
 

--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -618,6 +618,11 @@ describe("agentloop phase 1", () => {
       });
 
       expect(result.success).toBe(true);
+      expect(result.toolResults?.[0]).toMatchObject({
+        toolName: "apply_patch",
+        checkOnly: false,
+        artifacts: ["reports/hgb.json"],
+      });
       expect(result.changedFiles).toContain("reports/hgb.json");
       expect(fs.readFileSync(path.join(workspace, "reports", "hgb.json"), "utf-8")).toContain("0.95");
     } finally {

--- a/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { taskAgentLoopResultToAgentResult } from "../task-agent-loop-result.js";
+
+describe("taskAgentLoopResultToAgentResult", () => {
+  it("carries apply_patch artifacts as concrete changed paths", () => {
+    const result = taskAgentLoopResultToAgentResult({
+      success: true,
+      output: {
+        status: "done",
+        finalAnswer: "done",
+        summary: "done",
+        filesChanged: [],
+        testsRun: [],
+        completionEvidence: [],
+        verificationHints: [],
+        blockers: [],
+      },
+      finalText: "done",
+      stopReason: "completed",
+      elapsedMs: 1,
+      modelTurns: 1,
+      toolCalls: 1,
+      compactions: 0,
+      changedFiles: [],
+      toolResults: [{
+        toolName: "apply_patch",
+        success: true,
+        artifacts: ["reports/result.md", "../outside.md", "/tmp/outside.md"],
+        outputSummary: "Patch applied: reports/result.md",
+        durationMs: 1,
+      }],
+      commandResults: [],
+      traceId: "trace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    });
+
+    expect(result.filesChanged).toBe(true);
+    expect(result.filesChangedPaths).toEqual(["reports/result.md"]);
+    expect(result.agentLoop?.filesChangedPaths).toEqual(["reports/result.md"]);
+  });
+
+  it("does not carry check-only apply_patch artifacts as changed paths", () => {
+    const result = taskAgentLoopResultToAgentResult({
+      success: true,
+      output: {
+        status: "done",
+        finalAnswer: "done",
+        summary: "done",
+        filesChanged: [],
+        testsRun: [],
+        completionEvidence: [],
+        verificationHints: [],
+        blockers: [],
+      },
+      finalText: "done",
+      stopReason: "completed",
+      elapsedMs: 1,
+      modelTurns: 1,
+      toolCalls: 1,
+      compactions: 0,
+      changedFiles: [],
+      toolResults: [{
+        toolName: "apply_patch",
+        success: true,
+        artifacts: ["reports/check-only.md"],
+        checkOnly: true,
+        outputSummary: "Patch check passed: reports/check-only.md",
+        durationMs: 1,
+      }],
+      commandResults: [],
+      traceId: "trace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    });
+
+    expect(result.filesChanged).toBe(false);
+    expect(result.filesChangedPaths).toEqual([]);
+    expect(result.agentLoop?.filesChangedPaths).toEqual([]);
+  });
+});

--- a/src/orchestrator/execution/agent-loop/agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-result.ts
@@ -21,6 +21,8 @@ export interface AgentLoopToolResultSummary {
   toolName: string;
   success: boolean;
   execution?: AgentLoopToolObservationExecution;
+  artifacts?: string[];
+  checkOnly?: boolean;
   outputSummary: string;
   durationMs: number;
 }

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -15,6 +15,7 @@ import type {
   AgentLoopToolObservationState,
 } from "./agent-loop-model.js";
 import type { AgentLoopCommandResult, AgentLoopResult, AgentLoopToolResultSummary } from "./agent-loop-result.js";
+import type { AgentLoopToolOutput } from "./agent-loop-tool-output.js";
 import type { AgentLoopToolRuntime } from "./agent-loop-tool-runtime.js";
 import type { AgentLoopToolRouter } from "./agent-loop-tool-router.js";
 import type { AgentLoopTurnContext } from "./agent-loop-turn-context.js";
@@ -37,6 +38,20 @@ export interface BoundedAgentLoopRunnerDeps {
   toolRouter: AgentLoopToolRouter;
   toolRuntime: AgentLoopToolRuntime;
   compactor?: AgentLoopCompactor;
+}
+
+function readToolResultCheckOnly(result: AgentLoopToolOutput): boolean | undefined {
+  const data = result.rawResult?.data;
+  if (
+    result.toolName === "apply_patch" &&
+    data &&
+    typeof data === "object" &&
+    "checkOnly" in data &&
+    typeof (data as { checkOnly?: unknown }).checkOnly === "boolean"
+  ) {
+    return (data as { checkOnly: boolean }).checkOnly;
+  }
+  return undefined;
 }
 
 interface FilesystemSnapshotEntry {
@@ -414,10 +429,13 @@ export class BoundedAgentLoopRunner {
         if (result.success) consecutiveToolErrors = 0;
         else consecutiveToolErrors++;
 
+        const checkOnly = readToolResultCheckOnly(result);
         toolResultSummaries.push({
           toolName: result.toolName,
           success: result.success,
           ...(result.execution ? { execution: result.execution } : {}),
+          ...(result.artifacts ? { artifacts: result.artifacts } : {}),
+          ...(checkOnly !== undefined ? { checkOnly } : {}),
           outputSummary: this.preview(result.content),
           durationMs: result.durationMs,
         });

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import * as path from "node:path";
 import type { AgentResult } from "../adapter-layer.js";
 import type { AgentLoopResult } from "./agent-loop-result.js";
 
@@ -19,6 +20,29 @@ export const TaskAgentLoopOutputSchema = z.object({
 
 export type TaskAgentLoopOutput = z.infer<typeof TaskAgentLoopOutputSchema>;
 
+function isSafeRelativeArtifact(filePath: string): boolean {
+  const trimmed = filePath.trim();
+  if (!trimmed || trimmed.includes("\0") || path.isAbsolute(trimmed)) return false;
+  const segments = trimmed.replace(/\\/g, "/").split("/");
+  return !segments.includes("..");
+}
+
+function collectAgentLoopChangedPaths(
+  result: AgentLoopResult<TaskAgentLoopOutput>,
+): string[] {
+  const applyPatchArtifactPaths = (result.toolResults ?? []).flatMap((entry) => {
+    if (!entry.success || entry.toolName !== "apply_patch" || entry.checkOnly === true) return [];
+    return (entry.artifacts ?? []).map((artifact) => artifact.trim()).filter(isSafeRelativeArtifact);
+  });
+  return [
+    ...new Set([
+      ...(result.output?.filesChanged ?? []),
+      ...result.changedFiles,
+      ...applyPatchArtifactPaths,
+    ]),
+  ];
+}
+
 export function taskAgentLoopResultToAgentResult(
   result: AgentLoopResult<TaskAgentLoopOutput>,
 ): AgentResult {
@@ -26,6 +50,7 @@ export function taskAgentLoopResultToAgentResult(
   const runtimeVerificationCommands = result.commandResults.filter((command) =>
     command.evidenceEligible && command.relevantToTask !== false
   );
+  const filesChangedPaths = collectAgentLoopChangedPaths(result);
   const fallbackOutput = result.output?.finalAnswer
     ?? result.finalText
     ?? result.output?.blockers.join("; ")
@@ -40,8 +65,8 @@ export function taskAgentLoopResultToAgentResult(
       result.stopReason === "timeout" ? "timeout" :
       result.stopReason === "cancelled" ? "cancelled" :
       done ? "completed" : "error",
-    filesChanged: result.changedFiles.length > 0 || (result.output ? result.output.filesChanged.length > 0 : result.filesChanged),
-    filesChangedPaths: [...new Set([...(result.output?.filesChanged ?? []), ...result.changedFiles])],
+    filesChanged: filesChangedPaths.length > 0 || Boolean(result.filesChanged),
+    filesChangedPaths,
     agentLoop: {
       traceId: result.traceId,
       sessionId: result.sessionId,
@@ -61,7 +86,7 @@ export function taskAgentLoopResultToAgentResult(
         ...(result.output?.verificationHints ?? []),
         ...runtimeVerificationCommands.filter((command) => !command.success).map((command) => `failed command: ${command.command}`),
       ],
-      filesChangedPaths: [...new Set([...(result.output?.filesChanged ?? []), ...result.changedFiles])],
+      filesChangedPaths,
       ...(result.workspace
         ? {
             requestedCwd: result.workspace.requestedCwd,

--- a/src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts
+++ b/src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts
@@ -82,6 +82,45 @@ describe("captureExecutionDiffArtifacts", () => {
     }
   });
 
+  it("captures staged file diffs without counting fallback paths as git-backed changes", () => {
+    const workspace = makeGitWorkspace();
+    try {
+      fs.mkdirSync(path.join(workspace, "reports"), { recursive: true });
+      fs.writeFileSync(path.join(workspace, "reports", "clean.md"), "reported by tool\n", "utf-8");
+      const execFileSyncFn = makeExecFileSync({
+        "git diff --name-only": "",
+        "git diff --cached --name-only": "reports/staged.md\n",
+        "git ls-files --others --exclude-standard": "",
+        "git diff -- reports/staged.md": "",
+        "git diff --cached -- reports/staged.md": [
+          "diff --git a/reports/staged.md b/reports/staged.md",
+          "new file mode 100644",
+          "--- /dev/null",
+          "+++ b/reports/staged.md",
+          "@@ -0,0 +1 @@",
+          "+staged output",
+          "",
+        ].join("\n"),
+        "git diff -- reports/clean.md": "",
+        "git diff --cached -- reports/clean.md": "",
+      });
+
+      const result = captureExecutionDiffArtifacts(execFileSyncFn, workspace, {
+        fallbackChangedPaths: ["reports/clean.md", "../outside.md"],
+      });
+
+      expect(result.changedPaths).toEqual(["reports/staged.md"]);
+      expect(result.fileDiffs).toEqual([
+        expect.objectContaining({
+          path: "reports/staged.md",
+          patch: expect.stringContaining("+staged output"),
+        }),
+      ]);
+    } finally {
+      fs.rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
   it("ignores per-path diff read failures after collecting changed paths", () => {
     const workspace = makeGitWorkspace();
     try {

--- a/src/orchestrator/execution/task/task-diff-capture.ts
+++ b/src/orchestrator/execution/task/task-diff-capture.ts
@@ -71,23 +71,26 @@ export function captureExecutionDiffArtifacts(
   }
 
   const trackedOutput = runGitRead(execFileSyncFn, cwd, ["diff", "--name-only"]);
+  const stagedOutput = runGitRead(execFileSyncFn, cwd, ["diff", "--cached", "--name-only"]);
   const untrackedOutput = runGitRead(execFileSyncFn, cwd, ["ls-files", "--others", "--exclude-standard"]);
 
-  const available = trackedOutput !== null || untrackedOutput !== null;
+  const available = trackedOutput !== null || stagedOutput !== null || untrackedOutput !== null;
   if (!available) {
     return renderFallbackDiffArtifacts(cwd, fallbackPaths, options.maxFallbackDiffBytes);
   }
 
   const trackedPaths = (trackedOutput ?? "").split("\n");
+  const stagedPaths = (stagedOutput ?? "").split("\n");
   const untrackedPaths = (untrackedOutput ?? "").split("\n");
-  const changedPaths = uniqueNonEmpty([...trackedPaths, ...untrackedPaths]);
+  const changedPaths = uniqueNonEmpty([...trackedPaths, ...stagedPaths, ...untrackedPaths])
+    .filter((filePath) => isSafeRelativePath(cwd, filePath));
   const untrackedSet = new Set(uniqueNonEmpty(untrackedPaths));
 
   const fileDiffs = changedPaths.flatMap((path) => {
     const trackedPatch = runGitRead(execFileSyncFn, cwd, ["diff", "--", path])?.trim() ?? "";
-    if (trackedPatch.length > 0) {
-      return [{ path, patch: trackedPatch }];
-    }
+    const stagedPatch = runGitRead(execFileSyncFn, cwd, ["diff", "--cached", "--", path])?.trim() ?? "";
+    const patches = [trackedPatch, stagedPatch].filter((patch) => patch.length > 0);
+    if (patches.length > 0) return [{ path, patch: patches.join("\n") }];
 
     if (!untrackedSet.has(path)) {
       return [];

--- a/src/orchestrator/execution/task/task-verifier-rules.ts
+++ b/src/orchestrator/execution/task/task-verifier-rules.ts
@@ -1,9 +1,8 @@
-import { z } from "zod";
 import * as path from "node:path";
 import type { Task } from "../../../base/types/task.js";
 import type { VerificationResult } from "../../../base/types/task.js";
 import type { AgentTask, AgentResult, IAdapter } from "../adapter-layer.js";
-import type { VerifierDeps } from "./task-verifier-types.js";
+import type { RevertAttemptResult, VerifierDeps } from "./task-verifier-types.js";
 import { syncTaskOutcomeSummary } from "./task-outcome-ledger.js";
 import { resolveTaskWorkspacePath } from "./task-workspace.js";
 import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
@@ -462,101 +461,131 @@ function isRelativeGitPath(filePath: string): boolean {
   return !segments.includes("..");
 }
 
+function shellStdout(data: unknown): string {
+  return data &&
+    typeof data === "object" &&
+    "stdout" in data &&
+    typeof (data as { stdout?: unknown }).stdout === "string"
+    ? (data as { stdout: string }).stdout
+    : "";
+}
+
 export async function attemptRevert(
   deps: VerifierDeps,
   task: Task,
   opts: { concretePaths?: string[] } = {}
-): Promise<boolean> {
+): Promise<RevertAttemptResult> {
   const filesToRestore = [
     ...new Set((opts.concretePaths ?? []).map((filePath) => filePath.trim()).filter(Boolean)),
   ];
-  try {
-    if (filesToRestore.length > 0) {
-      const revertCwd = await resolveRevertCwd(deps, task);
-      if (!revertCwd) {
-        deps.logger?.warn?.("[attemptRevert] skipping raw git restore because no workspace_path/revertCwd was configured");
-        throw new Error("git restore disabled without explicit workspace");
-      }
-      if (deps.toolExecutor) {
-        // Use ToolExecutor (preferred): keeps all shell ops in the tool pipeline
-        const ctx: import("../../../tools/types.js").ToolCallContext = {
-          cwd: revertCwd,
-          goalId: task.goal_id,
-          trustBalance: 100,
-          preApproved: true,
-          trusted: true,
-          approvalFn: async () => true,
-        };
-        const allSafe = filesToRestore.every(isRelativeGitPath);
-        if (!allSafe) {
-          deps.logger?.warn?.(
-            "[attemptRevert] concrete changed path failed git-restore path validation; falling back to LLM revert"
-          );
-          throw new Error("git restore disabled for invalid concrete changed path");
-        } else {
-          const result = await deps.toolExecutor.execute(
-            "shell",
-            { command: "git restore -- " + filesToRestore.map(quoteShellArg).join(" ") },
-            ctx
-          );
-          if (result.success) {
-            deps.logger?.info?.(`[attemptRevert] git restore succeeded for ${filesToRestore.length} files (via ToolExecutor)`);
-            return true;
-          }
-          // Fall through to LLM-based revert if shell tool failed
-        }
-      } else {
-        // Fallback: raw child_process (no ToolExecutor available)
-        const { execFileSync } = await import("child_process");
-        execFileSync("git", ["restore", "--", ...filesToRestore], {
-          cwd: revertCwd,
-          encoding: "utf-8",
-          stdio: ["pipe", "pipe", "pipe"],
-        });
-        deps.logger?.info?.(`[attemptRevert] git restore succeeded for ${filesToRestore.length} files`);
-        return true;
-      }
-    } else {
-      deps.logger?.warn?.("[attemptRevert] skipping raw git restore because no concrete changed paths were captured");
-    }
-  } catch {
-    // git not available or failed — fall back to LLM-based revert
+  if (filesToRestore.length === 0) {
+    deps.logger?.warn?.("[attemptRevert] skipping raw git restore because no concrete changed paths were captured");
+    return {
+      success: false,
+      concretePaths: [],
+      reason: "no_concrete_changed_paths",
+    };
+  }
+
+  const revertCwd = await resolveRevertCwd(deps, task);
+  if (!revertCwd) {
+    deps.logger?.warn?.("[attemptRevert] skipping raw git restore because no workspace_path/revertCwd was configured");
+    return {
+      success: false,
+      concretePaths: filesToRestore,
+      reason: "missing_explicit_workspace",
+    };
+  }
+
+  const allSafe = filesToRestore.every(isRelativeGitPath);
+  if (!allSafe) {
+    deps.logger?.warn?.("[attemptRevert] concrete changed path failed git-restore path validation; refusing revert");
+    return {
+      success: false,
+      concretePaths: filesToRestore,
+      reason: "invalid_concrete_changed_path",
+    };
   }
 
   try {
-    const revertSession = await deps.sessionManager.createSession(
-      "task_execution",
-      task.goal_id,
-      task.id
-    );
-
-    const revertTargetSummary =
-      filesToRestore.length > 0
-        ? `Concrete changed paths: ${filesToRestore.join(", ")}.`
-        : "No concrete changed paths were captured. Do not treat task scope descriptions as file paths.";
-
-    const revertPrompt = `Revert task "${task.work_description}". ${revertTargetSummary}
-
-Return JSON: {"success": true|false, "reason": "..."}`;
-
-    const response = await deps.llmClient.sendMessage(
-      [{ role: "user", content: revertPrompt }],
-      { system: "Revert failed task changes. Respond with JSON only.", max_tokens: 512, model_tier: "main" }
-    );
-
-    await deps.sessionManager.endSession(revertSession.id, response.content);
-
-    try {
-      const parsed = deps.llmClient.parseJSON(
-        response.content,
-        z.object({ success: z.boolean(), reason: z.string() })
+    if (deps.toolExecutor) {
+      // Use ToolExecutor (preferred): keeps all shell ops in the tool pipeline.
+      const ctx: import("../../../tools/types.js").ToolCallContext = {
+        cwd: revertCwd,
+        goalId: task.goal_id,
+        trustBalance: 100,
+        preApproved: true,
+        trusted: true,
+        approvalFn: async () => true,
+      };
+      const pathArgs = filesToRestore.map(quoteShellArg).join(" ");
+      const result = await deps.toolExecutor.execute(
+        "shell",
+        { command: "git restore --staged --worktree -- " + pathArgs },
+        ctx
       );
-      return parsed.success;
-    } catch {
-      return false;
+      if (result.success) {
+        const statusResult = await deps.toolExecutor.execute(
+          "shell",
+          { command: "git status --porcelain -- " + pathArgs },
+          ctx
+        );
+        const statusOutput = shellStdout(statusResult.data).trim();
+        if (!statusResult.success || statusOutput.length > 0) {
+          return {
+            success: false,
+            concretePaths: filesToRestore,
+            reason: statusOutput.length > 0
+              ? `git restore left changes for concrete paths: ${statusOutput}`
+              : statusResult.error ?? statusResult.summary ?? "git_status_after_restore_failed",
+          };
+        }
+        deps.logger?.info?.(`[attemptRevert] git restore succeeded for ${filesToRestore.length} files (via ToolExecutor)`);
+        return {
+          success: true,
+          concretePaths: filesToRestore,
+          reason: "git_restore_succeeded",
+          method: "git_restore_tool",
+        };
+      }
+      return {
+        success: false,
+        concretePaths: filesToRestore,
+        reason: result.error ?? result.summary ?? "git_restore_failed",
+      };
     }
-  } catch {
-    return false;
+
+    const { execFileSync } = await import("child_process");
+    execFileSync("git", ["restore", "--staged", "--worktree", "--", ...filesToRestore], {
+      cwd: revertCwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const statusOutput = execFileSync("git", ["status", "--porcelain", "--", ...filesToRestore], {
+      cwd: revertCwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+    if (statusOutput.length > 0) {
+      return {
+        success: false,
+        concretePaths: filesToRestore,
+        reason: `git restore left changes for concrete paths: ${statusOutput}`,
+      };
+    }
+    deps.logger?.info?.(`[attemptRevert] git restore succeeded for ${filesToRestore.length} files`);
+    return {
+      success: true,
+      concretePaths: filesToRestore,
+      reason: "git_restore_succeeded",
+      method: "git_restore_child_process",
+    };
+  } catch (error) {
+    return {
+      success: false,
+      concretePaths: filesToRestore,
+      reason: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 

--- a/src/orchestrator/execution/task/task-verifier-types.ts
+++ b/src/orchestrator/execution/task/task-verifier-types.ts
@@ -34,6 +34,13 @@ export interface FailureResult {
   task: import("../../../base/types/task.js").Task;
 }
 
+export interface RevertAttemptResult {
+  success: boolean;
+  concretePaths: string[];
+  reason: string;
+  method?: "git_restore_tool" | "git_restore_child_process";
+}
+
 // ─── CompletionJudgerResponseSchema: Zod schema for LLM completion judgment response ───
 
 export const CompletionJudgerResponseSchema = z.object({

--- a/src/orchestrator/execution/task/task-verifier.ts
+++ b/src/orchestrator/execution/task/task-verifier.ts
@@ -748,8 +748,13 @@ export async function handleFailure(
     const revertSuccess = await attemptRevert(deps, updatedTask, {
       concretePaths: concreteRevertPaths,
     });
-    deps.logger?.warn(`[task] revert attempted`, { taskId: task.id, success: revertSuccess });
-    if (revertSuccess) {
+    deps.logger?.warn(`[task] revert attempted`, {
+      taskId: task.id,
+      success: revertSuccess.success,
+      reason: revertSuccess.reason,
+      concretePaths: revertSuccess.concretePaths,
+    });
+    if (revertSuccess.success) {
       await appendTaskHistory(deps, task.goal_id, updatedTask);
       await appendTaskOutcomeEvent(deps.stateManager, {
         task: updatedTask,
@@ -757,7 +762,7 @@ export async function handleFailure(
         attempt: updatedTask.consecutive_failure_count,
         action: "discard",
         verificationResult,
-        reason: "task discarded after successful revert",
+        reason: `task discarded after successful ${revertSuccess.method ?? "revert"} for ${revertSuccess.concretePaths.length} concrete paths`,
       });
       return { action: "discard", task: updatedTask };
     }
@@ -770,7 +775,9 @@ export async function handleFailure(
       attempt: updatedTask.consecutive_failure_count,
       action: "escalate",
       verificationResult,
-      reason: "revert failed after wrong-direction result",
+      reason: revertSuccess.concretePaths.length === 0
+        ? "revert skipped because no concrete changed paths were captured; task output requires operator review"
+        : `revert failed after wrong-direction result: ${revertSuccess.reason}`,
     });
     return { action: "escalate", task: updatedTask };
   }


### PR DESCRIPTION
## Summary
- require concrete revert evidence before discarding failed reversible task output
- remove LLM self-report revert fallback and require `git restore --staged --worktree` plus clean status proof
- preserve applied `apply_patch` artifacts as typed changed-path evidence while excluding check-only artifacts
- capture staged Git diffs and keep non-git filesystem fallback evidence without letting fallback paths bypass Git no-change detection

Fixes #1132

## Verification
- `npx vitest run src/orchestrator/execution/task/__tests__/task-diff-capture.test.ts src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts src/orchestrator/execution/__tests__/task-verifier-guards.test.ts src/orchestrator/execution/__tests__/task-lifecycle-execution-guards.test.ts src/orchestrator/execution/__tests__/task-executor-protected-paths.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries`
- `npm run test:changed`

## Review
- Fresh review agent found staged restore and fallback-path issues; both were fixed.
- Final fresh review pass reported no material findings.