### PR TITLE
fix(runtime): preserve ledger stop reasons

### DIFF
--- a/src/interface/cli/commands/daemon-shared.ts
+++ b/src/interface/cli/commands/daemon-shared.ts
@@ -155,7 +155,28 @@ export interface RuntimeTaskOutcomeDetails {
     abandoned: number;
     retried: number;
   };
+  failure_reasons?: {
+    timeout: number;
+    cancelled: number;
+    error: number;
+    unknown: number;
+    other: number;
+  };
   healthy_at_0_95: boolean | null;
+}
+
+export function formatTaskFailureReasonCounts(
+  failureReasons: RuntimeTaskOutcomeDetails["failure_reasons"] | undefined
+): string | null {
+  if (!failureReasons) return null;
+  const total =
+    failureReasons.timeout +
+    failureReasons.cancelled +
+    failureReasons.error +
+    failureReasons.unknown +
+    failureReasons.other;
+  if (total === 0) return null;
+  return `timeout=${failureReasons.timeout}, cancelled=${failureReasons.cancelled}, error=${failureReasons.error}, unknown=${failureReasons.unknown}, other=${failureReasons.other}`;
 }
 
 export function formatTaskOutcomeLine(taskOutcome: RuntimeTaskOutcomeDetails): string {
@@ -165,9 +186,11 @@ export function formatTaskOutcomeLine(taskOutcome: RuntimeTaskOutcomeDetails): s
     taskOutcome.healthy_at_0_95 === null
       ? "threshold n/a"
       : taskOutcome.healthy_at_0_95
-        ? "healthy @ 0.95"
-        : "degraded @ 0.95";
-  return `${rate} (${terminalCounts.succeeded}/${terminalCounts.terminal_tasks} terminal, ${thresholdLabel})`;
+      ? "healthy @ 0.95"
+      : "degraded @ 0.95";
+  const failureReasons = formatTaskFailureReasonCounts(taskOutcome.failure_reasons);
+  const failureSuffix = failureReasons ? `, failures: ${failureReasons}` : "";
+  return `${rate} (${terminalCounts.succeeded}/${terminalCounts.terminal_tasks} terminal, ${thresholdLabel}${failureSuffix})`;
 }
 
 export function formatTaskSuccessRateLine(
@@ -186,7 +209,9 @@ export function formatTaskSuccessRateLine(
       : taskOutcome.healthy_at_0_95
         ? "healthy @ 0.95"
         : "degraded @ 0.95";
-  return `task_success_rate: ${rate} (${terminalCounts.succeeded}/${terminalCounts.terminal_tasks} terminal, ${thresholdLabel})`;
+  const failureReasons = formatTaskFailureReasonCounts(taskOutcome.failure_reasons);
+  const failureSuffix = failureReasons ? `, failures: ${failureReasons}` : "";
+  return `task_success_rate: ${rate} (${terminalCounts.succeeded}/${terminalCounts.terminal_tasks} terminal, ${thresholdLabel}${failureSuffix})`;
 }
 
 export function isPidAlive(pidStatus: Awaited<ReturnType<PIDManager["inspect"]>>, pid?: number | null): boolean {

--- a/src/interface/cli/commands/daemon.ts
+++ b/src/interface/cli/commands/daemon.ts
@@ -47,6 +47,7 @@ import {
   formatPercent,
   formatRelativeTime,
   formatRelativeTimestamp,
+  formatTaskFailureReasonCounts,
   formatTaskOutcomeLine,
   formatTaskSuccessRateLine,
   formatUptime,
@@ -730,6 +731,10 @@ export async function cmdDaemonStatus(_args: string[]): Promise<void> {
     lines.push(
       `  Abandoned rate:  ${taskKpis.abandoned}/${taskKpis.terminal_tasks} (${formatPercent(taskKpis.abandoned_rate)})`
     );
+    const failureReasons = formatTaskFailureReasonCounts(taskKpis.failure_stopped_reasons);
+    if (failureReasons) {
+      lines.push(`  Failure reasons:${" ".repeat(1)}${failureReasons}`);
+    }
     if (taskKpis.p95_created_to_acked_ms !== null) {
       lines.push(`  Ack latency:     p95 ${formatDurationMs(taskKpis.p95_created_to_acked_ms)}`);
     }

--- a/src/interface/cli/commands/doctor.ts
+++ b/src/interface/cli/commands/doctor.ts
@@ -82,6 +82,23 @@ function formatPercent(value: number | null): string {
   return value === null ? "n/a" : `${(value * 100).toFixed(1)}%`;
 }
 
+function formatFailureReasonCounts(failureReasons: {
+  timeout: number;
+  cancelled: number;
+  error: number;
+  unknown: number;
+  other: number;
+}): string | null {
+  const total =
+    failureReasons.timeout +
+    failureReasons.cancelled +
+    failureReasons.error +
+    failureReasons.unknown +
+    failureReasons.other;
+  if (total === 0) return null;
+  return `failures timeout=${failureReasons.timeout}, cancelled=${failureReasons.cancelled}, error=${failureReasons.error}, unknown=${failureReasons.unknown}, other=${failureReasons.other}`;
+}
+
 function formatLivePingDetail(latencyMs: number, error?: string): string {
   const latency = formatDurationMs(latencyMs);
   return error ? `live ping failed (${latency}; ${error})` : `live ping ok (${latency})`;
@@ -471,9 +488,14 @@ export async function checkDaemon(baseDir?: string): Promise<CheckResult> {
     ? compactRuntimeHealthKpi(runtimeKpi)?.status ?? "degraded"
     : "degraded";
   const taskKpis = await summarizeTaskOutcomeLedgers(dir);
+  const failureReasonSummary = formatFailureReasonCounts(taskKpis.failure_stopped_reasons);
   const taskSummary =
     taskKpis.total_tasks > 0
       ? `task success=${taskKpis.succeeded}/${taskKpis.terminal_tasks} (${formatPercent(taskKpis.success_rate)}), in-flight=${taskKpis.inflight_tasks}/${taskKpis.total_tasks}, retry=${taskKpis.retried}/${taskKpis.total_tasks} (${formatPercent(taskKpis.retry_rate)})${
+          failureReasonSummary !== null
+            ? `, ${failureReasonSummary}`
+            : ""
+        }${
           taskKpis.p95_created_to_completed_ms !== null
             ? `, total p95=${formatDurationMs(taskKpis.p95_created_to_completed_ms)}`
             : ""

--- a/src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts
@@ -9,6 +9,9 @@ import { StrategyManager } from "../../strategy/strategy-manager.js";
 import { StallDetector } from "../../../platform/drive/stall-detector.js";
 import { TaskLifecycle } from "../task/task-lifecycle.js";
 import type { Task } from "../../../base/types/task.js";
+import type { AgentLoopResult } from "../agent-loop/agent-loop-result.js";
+import type { TaskAgentLoopOutput } from "../agent-loop/task-agent-loop-result.js";
+import type { TaskAgentLoopRunner } from "../agent-loop/task-agent-loop-runner.js";
 import type { GapVector } from "../../../base/types/gap.js";
 import type { DriveContext } from "../../../base/types/drive.js";
 import type {
@@ -19,6 +22,7 @@ import type {
 } from "../../../base/llm/llm-client.js";
 import { createMockLLMClient } from "../../../../tests/helpers/mock-llm.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+import { summarizeTaskOutcomeLedgers } from "../task/task-outcome-ledger.js";
 import { z } from "zod";
 
 function createSpyLLMClient(responses: string[]): ILLMClient {
@@ -120,6 +124,28 @@ function makeVerificationResult(
     timestamp: new Date().toISOString(),
     ...overrides,
   };
+}
+
+function makeNativeTimeoutRunner(): TaskAgentLoopRunner {
+  const result: AgentLoopResult<TaskAgentLoopOutput> = {
+    success: false,
+    output: null,
+    finalText: "timeout",
+    stopReason: "timeout",
+    elapsedMs: 100,
+    modelTurns: 1,
+    toolCalls: 0,
+    compactions: 0,
+    filesChanged: false,
+    changedFiles: [],
+    commandResults: [],
+    traceId: "trace-1",
+    sessionId: "session-1",
+    turnId: "turn-1",
+  };
+  return {
+    runTask: async () => result,
+  } as unknown as TaskAgentLoopRunner;
 }
 
 function makeGapVector(goalId: string, dimensionName: string): GapVector {
@@ -414,6 +440,57 @@ describe("TaskLifecycle — persistence", () => {
     expect(summary.verification_verdict).toBe("fail");
     expect(summary.latest_event_type).toBe("abandoned");
     expect(summary.action).toBe("escalate");
+  });
+
+  it("runTaskCycle preserves native timeout stop reason through final ledger outcome", async () => {
+    const llm = createMockLLMClient([VALID_TASK_RESPONSE, LLM_REVIEW_FAIL]);
+    const lifecycle = createLifecycle(llm, {
+      approvalFn: async () => true,
+      agentLoopRunner: makeNativeTimeoutRunner(),
+    });
+    const adapter: import("../task/task-lifecycle.js").IAdapter = {
+      adapterType: "mock",
+      async execute() {
+        throw new Error("native path should not call adapter.execute");
+      },
+    };
+
+    const result = await lifecycle.runTaskCycle(
+      "goal-1",
+      makeGapVector("goal-1", "dim"),
+      makeDriveContext("dim"),
+      adapter
+    );
+
+    const ledger = await stateManager.readRaw(`tasks/goal-1/ledger/${result.task.id}.json`) as {
+      events: Array<{ type: string; stopped_reason: string | null }>;
+      summary: { latest_event_type: string | null; task_status: string; stopped_reason: string | null; action?: string };
+    };
+
+    expect(result.action).toBe("escalate");
+    expect(result.task.status).toBe("timed_out");
+    expect(ledger.events.map((event) => [event.type, event.stopped_reason])).toEqual([
+      ["acked", null],
+      ["started", null],
+      ["failed", "timeout"],
+      ["failed", "timeout"],
+      ["abandoned", "timeout"],
+    ]);
+    expect(ledger.summary).toMatchObject({
+      latest_event_type: "abandoned",
+      task_status: "timed_out",
+      stopped_reason: "timeout",
+      action: "escalate",
+    });
+
+    const aggregate = await summarizeTaskOutcomeLedgers(tmpDir);
+    expect(aggregate.failure_stopped_reasons).toEqual({
+      timeout: 1,
+      cancelled: 0,
+      error: 0,
+      unknown: 0,
+      other: 0,
+    });
   });
 
   it("handleFailure records failed and retried events for retryable failures", async () => {

--- a/src/orchestrator/execution/__tests__/task-lifecycle-execution.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-execution.test.ts
@@ -8,6 +8,10 @@ import { StrategyManager } from "../../strategy/strategy-manager.js";
 import { StallDetector } from "../../../platform/drive/stall-detector.js";
 import { TaskLifecycle } from "../task/task-lifecycle.js";
 import type { Task } from "../../../base/types/task.js";
+import type { AgentLoopStopReason } from "../agent-loop/agent-loop-budget.js";
+import type { AgentLoopResult } from "../agent-loop/agent-loop-result.js";
+import type { TaskAgentLoopOutput } from "../agent-loop/task-agent-loop-result.js";
+import type { TaskAgentLoopRunner } from "../agent-loop/task-agent-loop-runner.js";
 import type {
   ILLMClient,
   LLMMessage,
@@ -108,6 +112,48 @@ function createMockAdapter(
   };
 }
 
+function makeAgentLoopResult(
+  stopReason: AgentLoopStopReason,
+  overrides: Partial<AgentLoopResult<TaskAgentLoopOutput>> = {}
+): AgentLoopResult<TaskAgentLoopOutput> {
+  return {
+    success: stopReason === "completed",
+    output: stopReason === "completed"
+      ? {
+          status: "done",
+          finalAnswer: "done",
+          summary: "done",
+          filesChanged: [],
+          testsRun: [],
+          completionEvidence: [],
+          verificationHints: [],
+          blockers: [],
+        }
+      : null,
+    finalText: stopReason,
+    stopReason,
+    elapsedMs: 100,
+    modelTurns: 1,
+    toolCalls: 0,
+    compactions: 0,
+    filesChanged: false,
+    changedFiles: [],
+    commandResults: [],
+    traceId: "trace-1",
+    sessionId: "session-1",
+    turnId: "turn-1",
+    ...overrides,
+  };
+}
+
+function makeAgentLoopRunner(
+  result: AgentLoopResult<TaskAgentLoopOutput>
+): TaskAgentLoopRunner {
+  return {
+    runTask: vi.fn().mockResolvedValue(result),
+  } as unknown as TaskAgentLoopRunner;
+}
+
 // ─── Test Suite ───
 
 describe("TaskLifecycle", async () => {
@@ -140,6 +186,7 @@ describe("TaskLifecycle", async () => {
       approvalFn?: (task: Task) => Promise<boolean>;
       logger?: import("../../../runtime/logger.js").Logger;
       adapterRegistry?: import("../task/task-lifecycle.js").AdapterRegistry;
+      agentLoopRunner?: TaskAgentLoopRunner;
       execFileSyncFn?: (cmd: string, args: string[], opts: { cwd: string; encoding: "utf-8" }) => string;
     }
   ): TaskLifecycle {
@@ -535,6 +582,52 @@ describe("TaskLifecycle", async () => {
       // Git diff check is skipped for failed tasks
       expect(result.filesChanged).toBeUndefined();
       expect(mockExecFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("executeTaskWithAgentLoop", () => {
+    it.each([
+      {
+        stopReason: "timeout" as const,
+        expectedTaskStatus: "timed_out",
+        expectedTimestampField: "timeout_at",
+      },
+      {
+        stopReason: "cancelled" as const,
+        expectedTaskStatus: "cancelled",
+        expectedTimestampField: "stopped_at",
+      },
+    ])("records native $stopReason stop reason in task ledger", async ({
+      stopReason,
+      expectedTaskStatus,
+      expectedTimestampField,
+    }) => {
+      const llm = createMockLLMClient([]);
+      const lifecycle = createLifecycle(llm, {
+        agentLoopRunner: makeAgentLoopRunner(makeAgentLoopResult(stopReason)),
+        execFileSyncFn: () => "",
+      });
+      const task = makeTask();
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+
+      const result = await lifecycle.executeTaskWithAgentLoop(task, "workspace context", "knowledge context");
+
+      const persisted = await stateManager.readRaw(`tasks/${task.goal_id}/${task.id}.json`) as Record<string, unknown>;
+      const ledger = await stateManager.readRaw(`tasks/${task.goal_id}/ledger/${task.id}.json`) as {
+        events: Array<Record<string, unknown>>;
+        summary: Record<string, unknown>;
+      };
+      const failedEvent = ledger.events.at(-1)!;
+
+      expect(result.success).toBe(false);
+      expect(result.stopped_reason).toBe(stopReason);
+      expect(persisted.status).toBe(expectedTaskStatus);
+      expect(persisted[expectedTimestampField]).toEqual(expect.any(String));
+      expect(ledger.events.map((event) => event.type)).toEqual(["started", "failed"]);
+      expect(failedEvent.stopped_reason).toBe(stopReason);
+      expect(ledger.summary.task_status).toBe(expectedTaskStatus);
+      expect(ledger.summary.latest_event_type).toBe("failed");
+      expect(ledger.summary.stopped_reason).toBe(stopReason);
     });
   });
 });

--- a/src/orchestrator/execution/__tests__/task-outcome-ledger.test.ts
+++ b/src/orchestrator/execution/__tests__/task-outcome-ledger.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import { StateManager } from "../../../base/state/state-manager.js";
+import type { Task } from "../../../base/types/task.js";
+import {
+  appendTaskOutcomeEvent,
+  summarizeTaskOutcomeLedgers,
+} from "../task/task-outcome-ledger.js";
+import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    goal_id: "goal-1",
+    strategy_id: null,
+    target_dimensions: ["dim"],
+    primary_dimension: "dim",
+    work_description: "test task",
+    rationale: "test rationale",
+    approach: "test approach",
+    success_criteria: [],
+    scope_boundary: {
+      in_scope: ["module A"],
+      out_of_scope: ["module B"],
+      blast_radius: "low",
+    },
+    constraints: [],
+    plateau_until: null,
+    estimated_duration: { value: 2, unit: "hours" },
+    consecutive_failure_count: 0,
+    reversibility: "reversible",
+    task_category: "normal",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("task outcome ledger", () => {
+  let tmpDir: string;
+  let stateManager: StateManager;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    stateManager = new StateManager(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it("preserves stopped reasons in summaries and aggregate failure counts", async () => {
+    await appendTaskOutcomeEvent(stateManager, {
+      task: makeTask({ id: "timeout-task", status: "timed_out" }),
+      type: "failed",
+      stoppedReason: "timeout",
+    });
+    await appendTaskOutcomeEvent(stateManager, {
+      task: makeTask({ id: "cancelled-task", status: "cancelled" }),
+      type: "failed",
+      stoppedReason: "cancelled",
+    });
+    await appendTaskOutcomeEvent(stateManager, {
+      task: makeTask({ id: "error-task", status: "error" }),
+      type: "failed",
+      stoppedReason: "error",
+    });
+    await appendTaskOutcomeEvent(stateManager, {
+      task: makeTask({ id: "discarded-timeout-task", status: "timed_out" }),
+      type: "abandoned",
+      stoppedReason: "timeout",
+    });
+
+    const timeoutLedger = await stateManager.readRaw("tasks/goal-1/ledger/timeout-task.json") as {
+      summary: { stopped_reason: string | null };
+    };
+    const aggregate = await summarizeTaskOutcomeLedgers(tmpDir);
+
+    expect(timeoutLedger.summary.stopped_reason).toBe("timeout");
+    expect(aggregate.failed).toBe(3);
+    expect(aggregate.abandoned).toBe(1);
+    expect(aggregate.failure_stopped_reasons).toEqual({
+      timeout: 2,
+      cancelled: 1,
+      error: 1,
+      unknown: 0,
+      other: 0,
+    });
+  });
+
+  it("does not reuse an older stopped reason for a later ordinary failure", async () => {
+    const task = makeTask({ id: "task-stale", status: "timed_out" });
+    await appendTaskOutcomeEvent(stateManager, {
+      task,
+      type: "failed",
+      stoppedReason: "timeout",
+    });
+    const ordinaryFailure = { ...task, status: "error" as const };
+    await appendTaskOutcomeEvent(stateManager, {
+      task: ordinaryFailure,
+      type: "failed",
+    });
+
+    const ledger = await stateManager.readRaw("tasks/goal-1/ledger/task-stale.json") as {
+      events: Array<{ stopped_reason: string | null }>;
+      summary: { stopped_reason: string | null };
+    };
+    const aggregate = await summarizeTaskOutcomeLedgers(tmpDir);
+
+    expect(ledger.events.at(-1)?.stopped_reason).toBeNull();
+    expect(ledger.summary.stopped_reason).toBeNull();
+    expect(aggregate.failure_stopped_reasons).toEqual({
+      timeout: 0,
+      cancelled: 0,
+      error: 0,
+      unknown: 1,
+      other: 0,
+    });
+  });
+});

--- a/src/orchestrator/execution/task/task-lifecycle-runner.ts
+++ b/src/orchestrator/execution/task/task-lifecycle-runner.ts
@@ -13,7 +13,7 @@ import type { EthicsGate } from "../../../platform/traits/ethics-gate.js";
 import type { CapabilityDetector } from "../../../platform/observation/capability-detector.js";
 import type { KnowledgeTransfer } from "../../../platform/knowledge/transfer/knowledge-transfer.js";
 import type { KnowledgeManager } from "../../../platform/knowledge/knowledge-manager.js";
-import type { VerifierDeps, VerdictResult } from "./task-verifier-types.js";
+import type { VerifierDeps, VerdictResult, VerdictHandlingContext } from "./task-verifier-types.js";
 import { _verifyTask as verifyTaskWithDeps } from "./task-verifier-internal.js";
 import { buildEnrichedKnowledgeContext } from "./task-context-enricher.js";
 import { runPreExecutionChecks } from "./task-approval.js";
@@ -99,7 +99,7 @@ export interface TaskLifecycleTaskCycleContext {
     knowledgeContext?: string,
     abortSignal?: AbortSignal,
   ) => Promise<AgentResult>;
-  handleVerdict: (task: Task, verificationResult: VerificationResult) => Promise<VerdictResult>;
+  handleVerdict: (task: Task, verificationResult: VerificationResult, context?: VerdictHandlingContext) => Promise<VerdictResult>;
 }
 
 export async function runTaskLifecycleCycle(context: TaskLifecycleTaskCycleContext): Promise<TaskCycleResult> {
@@ -314,7 +314,11 @@ export async function runTaskLifecycleCycle(context: TaskLifecycleTaskCycleConte
   logger?.debug(`[DEBUG-TL] Verification: verdict=${verificationResult.verdict}, evidence=${verificationResult.evidence.map((e) => e.description).join("; ").substring(0, 300)}`);
 
   const verdictResult = await runPhase("handle-verdict", () =>
-    context.handleVerdict(taskForVerification, verificationResult)
+    context.handleVerdict(
+      taskForVerification,
+      verificationResult,
+      { stoppedReason: executionResult.success ? null : executionResult.stopped_reason }
+    )
   );
   logger?.info(`[task] verdict: ${verdictResult.action}`, { taskId: task.id });
 

--- a/src/orchestrator/execution/task/task-lifecycle.ts
+++ b/src/orchestrator/execution/task/task-lifecycle.ts
@@ -27,6 +27,7 @@ import {
   type VerdictResult,
   type FailureResult,
   type CompletionJudgerConfig,
+  type VerdictHandlingContext,
 } from "./task-verifier.js";
 export type { CompletionJudgerConfig } from "./task-verifier.js";
 export type {
@@ -598,6 +599,7 @@ export class TaskLifecycle {
       type: result.success ? "succeeded" : "failed",
       attempt: task.consecutive_failure_count + 1,
       reason: result.error ?? undefined,
+      stoppedReason: result.success ? undefined : result.stopped_reason,
     });
 
     return result;
@@ -615,17 +617,19 @@ export class TaskLifecycle {
   /** Handle a verification verdict (pass/partial/fail). */
   async handleVerdict(
     task: Task,
-    verificationResult: VerificationResult
+    verificationResult: VerificationResult,
+    context?: VerdictHandlingContext
   ): Promise<VerdictResult> {
-    return _handleVerdict(this.verifierDeps(), task, verificationResult);
+    return _handleVerdict(this.verifierDeps(), task, verificationResult, context);
   }
 
   /** Handle a task failure: increment failure count, record failure, decide keep/discard/escalate. */
   async handleFailure(
     task: Task,
-    verificationResult: VerificationResult
+    verificationResult: VerificationResult,
+    context?: VerdictHandlingContext
   ): Promise<FailureResult> {
-    return _handleFailure(this.verifierDeps(), task, verificationResult);
+    return _handleFailure(this.verifierDeps(), task, verificationResult, context);
   }
 
   /** Run a full task cycle: select → generate → approve → execute → verify → verdict. */
@@ -673,7 +677,7 @@ export class TaskLifecycle {
       executeTask: (task, runAdapter, runWorkspaceContext) => this.executeTask(task, runAdapter, runWorkspaceContext),
       executeTaskWithAgentLoop: (task, runWorkspaceContext, runKnowledgeContext, abortSignal) =>
         this.executeTaskWithAgentLoop(task, runWorkspaceContext, runKnowledgeContext, abortSignal),
-      handleVerdict: (task, verificationResult) => this.handleVerdict(task, verificationResult),
+      handleVerdict: (task, verificationResult, handleContext) => this.handleVerdict(task, verificationResult, handleContext),
     });
   }
 

--- a/src/orchestrator/execution/task/task-outcome-ledger.ts
+++ b/src/orchestrator/execution/task/task-outcome-ledger.ts
@@ -39,6 +39,7 @@ export interface TaskOutcomeSummary {
   task_status: Task["status"];
   verification_verdict?: VerificationResult["verdict"];
   action?: string;
+  stopped_reason: string | null;
   created_at: string | null;
   acked_at: string | null;
   started_at: string | null;
@@ -72,6 +73,13 @@ export interface TaskOutcomeAggregateSummary {
   failed: number;
   abandoned: number;
   retried: number;
+  failure_stopped_reasons: {
+    timeout: number;
+    cancelled: number;
+    error: number;
+    unknown: number;
+    other: number;
+  };
   total_tokens_used: number;
   success_rate: number | null;
   retry_rate: number | null;
@@ -161,11 +169,25 @@ function findLastEvent(
   return null;
 }
 
+function summarizeStoppedReason(task: Task, events: TaskOutcomeEvent[], lastEvent: TaskOutcomeEvent | null): string | null {
+  if (lastEvent?.stopped_reason !== null && lastEvent?.stopped_reason !== undefined) {
+    return lastEvent.stopped_reason;
+  }
+  if (task.status === "timed_out") {
+    return "timeout";
+  }
+  if (task.status === "cancelled") {
+    return "cancelled";
+  }
+  return null;
+}
+
 function buildSummary(task: Task, events: TaskOutcomeEvent[]): TaskOutcomeSummary {
   const ackedAt = findLastEvent(events, (event) => event.type === "acked")?.acked_at ?? null;
   const lastEvent = events.at(-1) ?? null;
   const lastFailure = findLastEvent(events, (event) => event.type === "failed");
   const lastAbandoned = findLastEvent(events, (event) => event.type === "abandoned");
+  const latestStoppedReason = summarizeStoppedReason(task, events, lastEvent);
   const verificationAt =
     lastEvent?.verification_at ??
     findLastEvent(events, (event) => event.verification_at !== null)?.verification_at ??
@@ -181,6 +203,7 @@ function buildSummary(task: Task, events: TaskOutcomeEvent[]): TaskOutcomeSummar
     task_status: task.status,
     verification_verdict: task.verification_verdict,
     action: lastEvent?.action,
+    stopped_reason: latestStoppedReason,
     created_at: task.created_at ?? null,
     acked_at: ackedAt,
     started_at: task.started_at ?? null,
@@ -350,6 +373,13 @@ export async function summarizeTaskOutcomeLedgers(baseDir: string): Promise<Task
         failed: 0,
         abandoned: 0,
         retried: 0,
+        failure_stopped_reasons: {
+          timeout: 0,
+          cancelled: 0,
+          error: 0,
+          unknown: 0,
+          other: 0,
+        },
         total_tokens_used: 0,
         success_rate: null,
         retry_rate: null,
@@ -381,6 +411,33 @@ export async function summarizeTaskOutcomeLedgers(baseDir: string): Promise<Task
   const failed = records.filter((record) => record.summary.latest_event_type === "failed").length;
   const abandoned = records.filter((record) => record.summary.latest_event_type === "abandoned").length;
   const retried = records.filter((record) => record.events.some((event) => event.type === "retried")).length;
+  const failureStoppedReasons = records
+    .filter((record) => record.summary.latest_event_type === "failed" || record.summary.latest_event_type === "abandoned")
+    .reduce<TaskOutcomeAggregateSummary["failure_stopped_reasons"]>((counts, record) => {
+      const latestEvent = record.events.at(-1) ?? null;
+      const stoppedReason =
+        record.summary.stopped_reason ??
+        latestEvent?.stopped_reason ??
+        null;
+      if (stoppedReason === "timeout" || record.summary.task_status === "timed_out") {
+        counts.timeout += 1;
+      } else if (stoppedReason === "cancelled" || record.summary.task_status === "cancelled") {
+        counts.cancelled += 1;
+      } else if (stoppedReason === "error") {
+        counts.error += 1;
+      } else if (stoppedReason === null) {
+        counts.unknown += 1;
+      } else {
+        counts.other += 1;
+      }
+      return counts;
+    }, {
+      timeout: 0,
+      cancelled: 0,
+      error: 0,
+      unknown: 0,
+      other: 0,
+    });
   const totalTokensUsed = records.reduce((sum, record) => sum + (record.summary.tokens_used ?? 0), 0);
   const inflightTasks = records.filter((record) => {
     const latestEvent = record.summary.latest_event_type;
@@ -396,6 +453,7 @@ export async function summarizeTaskOutcomeLedgers(baseDir: string): Promise<Task
     failed,
     abandoned,
     retried,
+    failure_stopped_reasons: failureStoppedReasons,
     total_tokens_used: totalTokensUsed,
     success_rate: terminalTasks > 0 ? succeeded / terminalTasks : null,
     retry_rate: records.length > 0 ? retried / records.length : null,

--- a/src/orchestrator/execution/task/task-verifier-types.ts
+++ b/src/orchestrator/execution/task/task-verifier-types.ts
@@ -5,6 +5,7 @@ import { SessionManager } from "../session-manager.js";
 import { TrustManager } from "../../../platform/traits/trust-manager.js";
 import { StallDetector } from "../../../platform/drive/stall-detector.js";
 import { AdapterRegistry } from "../adapter-layer.js";
+import type { AgentResult } from "../adapter-layer.js";
 import type { Logger } from "../../../runtime/logger.js";
 import type { IPromptGateway } from "../../../prompt/gateway.js";
 import type { ToolExecutor } from "../../../tools/executor.js";
@@ -39,6 +40,10 @@ export interface RevertAttemptResult {
   concretePaths: string[];
   reason: string;
   method?: "git_restore_tool" | "git_restore_child_process";
+}
+
+export interface VerdictHandlingContext {
+  stoppedReason?: AgentResult["stopped_reason"] | null;
 }
 
 // ─── CompletionJudgerResponseSchema: Zod schema for LLM completion judgment response ───

--- a/src/orchestrator/execution/task/task-verifier.ts
+++ b/src/orchestrator/execution/task/task-verifier.ts
@@ -29,6 +29,7 @@ export type {
   ExecutorReport,
   VerdictResult,
   FailureResult,
+  VerdictHandlingContext,
   CompletionJudgerConfig,
   VerifierDeps,
 } from "./task-verifier-types.js";
@@ -40,7 +41,7 @@ export {
   checkDimensionDirection,
 } from "./task-verifier-rules.js";
 
-import type { VerifierDeps, VerdictResult, FailureResult } from "./task-verifier-types.js";
+import type { VerifierDeps, VerdictResult, FailureResult, VerdictHandlingContext } from "./task-verifier-types.js";
 import {
   runMechanicalVerification,
   clampDimensionUpdate,
@@ -477,7 +478,8 @@ export async function verifyTask(
 export async function handleVerdict(
   deps: VerifierDeps,
   task: Task,
-  verificationResult: VerificationResult
+  verificationResult: VerificationResult,
+  context: VerdictHandlingContext = {}
 ): Promise<VerdictResult> {
   // P0: Progress-verdict contradiction check (§4.1)
   if (verificationResult.verdict === "pass" && verificationResult.dimension_updates?.length > 0) {
@@ -661,13 +663,14 @@ export async function handleVerdict(
           action: "keep",
           verificationResult,
           reason: "partial progress kept for follow-up work",
+          stoppedReason: context.stoppedReason ?? undefined,
         });
         return { action: "keep", task: partialTask };
       }
-      return handleFailure(deps, task, verificationResult);
+      return handleFailure(deps, task, verificationResult, context);
     }
     case "fail": {
-      return handleFailure(deps, task, verificationResult);
+      return handleFailure(deps, task, verificationResult, context);
     }
   }
 }
@@ -681,7 +684,8 @@ export async function handleVerdict(
 export async function handleFailure(
   deps: VerifierDeps,
   task: Task,
-  verificationResult: VerificationResult
+  verificationResult: VerificationResult,
+  context: VerdictHandlingContext = {}
 ): Promise<FailureResult> {
   const updatedTask = {
     ...task,
@@ -702,6 +706,7 @@ export async function handleFailure(
     type: "failed",
     attempt: updatedTask.consecutive_failure_count,
     verificationResult,
+    stoppedReason: context.stoppedReason ?? undefined,
   });
 
   if (updatedTask.consecutive_failure_count >= 3) {
@@ -718,6 +723,7 @@ export async function handleFailure(
       action: "escalate",
       verificationResult,
       reason: "consecutive failure threshold reached",
+      stoppedReason: context.stoppedReason ?? undefined,
     });
     return { action: "escalate", task: updatedTask };
   }
@@ -733,6 +739,7 @@ export async function handleFailure(
       action: "keep",
       verificationResult,
       reason: "failure kept for retry because direction remained correct",
+      stoppedReason: context.stoppedReason ?? undefined,
     });
     return { action: "keep", task: updatedTask };
   }
@@ -763,6 +770,7 @@ export async function handleFailure(
         action: "discard",
         verificationResult,
         reason: `task discarded after successful ${revertSuccess.method ?? "revert"} for ${revertSuccess.concretePaths.length} concrete paths`,
+        stoppedReason: context.stoppedReason ?? undefined,
       });
       return { action: "discard", task: updatedTask };
     }
@@ -778,6 +786,7 @@ export async function handleFailure(
       reason: revertSuccess.concretePaths.length === 0
         ? "revert skipped because no concrete changed paths were captured; task output requires operator review"
         : `revert failed after wrong-direction result: ${revertSuccess.reason}`,
+      stoppedReason: context.stoppedReason ?? undefined,
     });
     return { action: "escalate", task: updatedTask };
   }
@@ -790,6 +799,7 @@ export async function handleFailure(
     action: "escalate",
     verificationResult,
     reason: "task cannot be safely retried or reverted",
+    stoppedReason: context.stoppedReason ?? undefined,
   });
   return { action: "escalate", task: updatedTask };
 }

--- a/src/runtime/daemon/runtime-ownership.ts
+++ b/src/runtime/daemon/runtime-ownership.ts
@@ -41,6 +41,13 @@ interface RuntimeTaskOutcomeDetails {
     abandoned: number;
     retried: number;
   };
+  failure_reasons: {
+    timeout: number;
+    cancelled: number;
+    error: number;
+    unknown: number;
+    other: number;
+  };
   healthy_at_0_95: boolean | null;
 }
 
@@ -109,6 +116,7 @@ export class RuntimeOwnershipCoordinator {
         abandoned: summary.abandoned,
         retried: summary.retried,
       },
+      failure_reasons: summary.failure_stopped_reasons,
       healthy_at_0_95: summary.success_rate === null ? null : summary.success_rate >= 0.95,
     };
   }


### PR DESCRIPTION
Closes #1150

## Summary
- carry native execution stopped_reason through runTaskCycle verification and final verdict/failure ledger events
- preserve latest typed stopped_reason in task ledger summaries and aggregate timeout/cancel/error/unknown/other failure counts
- surface failure reason counts in daemon health details plus daemon/doctor reporting
- add native timeout/cancelled caller-path tests, production-shaped runTaskCycle timeout coverage, and aggregate stale-fallback regressions

## Verification
- npm run test:unit -- src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts src/orchestrator/execution/__tests__/task-lifecycle-execution.test.ts src/orchestrator/execution/__tests__/task-outcome-ledger.test.ts
- npm run test:unit -- src/runtime/__tests__/daemon-task-success-rate.test.ts src/interface/cli/__tests__/cli-daemon-status.test.ts src/interface/cli/__tests__/cli-doctor.test.ts
- npm run typecheck
- npm run lint:boundaries
- npm run test:changed
- git diff --check

## Known unresolved risks
- `npm run lint:boundaries` reports existing warnings, but exits 0.

## Parallel PR dependency status
- Built from origin/main after #1160 merged.
- No open PRs were present before starting #1150.