### PR TITLE
fix(cli): reconcile resident startup interruptions

### DIFF
--- a/src/interface/cli/__tests__/cli-runner.test.ts
+++ b/src/interface/cli/__tests__/cli-runner.test.ts
@@ -176,6 +176,7 @@ import { ProactiveInterventionStore } from "../../../runtime/store/proactive-int
 import { createRelationshipProfileChangeProposal } from "../../../platform/profile/profile-change-proposal.js";
 import type { LoopResult } from "../../../orchestrator/loop/durable-loop.js";
 import type { Goal } from "../../../base/types/goal.js";
+import type { Task } from "../../../base/types/task.js";
 import { makeTempDir } from "../../../../tests/helpers/temp-dir.js";
 import { makeDimension, makeGoal } from "../../../../tests/helpers/fixtures.js";
 
@@ -222,6 +223,44 @@ function makeApproval(overrides: Record<string, unknown> = {}) {
     response_channel: "chat",
     ...overrides,
   });
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "task-1",
+    goal_id: "goal-1",
+    strategy_id: null,
+    target_dimensions: ["dim"],
+    primary_dimension: "dim",
+    work_description: "test task",
+    rationale: "test rationale",
+    approach: "test approach",
+    success_criteria: [
+      {
+        description: "Tests pass",
+        verification_method: "npx vitest run",
+        is_blocking: true,
+      },
+    ],
+    scope_boundary: {
+      in_scope: ["module A"],
+      out_of_scope: ["module B"],
+      blast_radius: "low",
+    },
+    constraints: [],
+    plateau_until: null,
+    estimated_duration: { value: 2, unit: "hours" },
+    consecutive_failure_count: 0,
+    reversibility: "reversible",
+    task_category: "normal",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
 }
 
 // No argv wrapper needed — run() accepts pure subcommand args directly.
@@ -679,6 +718,56 @@ describe("run subcommand", async () => {
         runPolicy: { mode: "resident", maxIterations: null },
       })
     );
+  });
+
+  it("reconciles interrupted task records before resident CoreLoop.run starts", async () => {
+    await stateManager.saveGoal(makeGoal({ id: "g-resident-recover" }));
+    const runningTask = makeTask({
+      id: "task-resident-recover",
+      goal_id: "g-resident-recover",
+      status: "running",
+      started_at: new Date(Date.now() - 5_000).toISOString(),
+    });
+    await stateManager.writeRaw(`tasks/${runningTask.goal_id}/${runningTask.id}.json`, runningTask);
+
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const mockRun = vi.fn().mockImplementation(async () => {
+      const taskAtLoopStart = await stateManager.readRaw(`tasks/${runningTask.goal_id}/${runningTask.id}.json`) as Task;
+      expect(taskAtLoopStart.status).toBe("error");
+      expect(taskAtLoopStart.execution_output).toContain("[RECOVERED]");
+      return makeLoopResult({ goalId: "g-resident-recover" });
+    });
+    vi.mocked(CoreLoop).mockImplementation(function() { return {
+      run: mockRun,
+      stop: vi.fn(),
+      setTimeHorizonEngine: vi.fn(),
+    } as unknown as CoreLoop; });
+
+    const code = await runCLI("run", "--goal", "g-resident-recover", "--resident", "--yes");
+
+    expect(code).toBe(0);
+    expect(mockRun).toHaveBeenCalledWith("g-resident-recover");
+    const output = consoleSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("Recovered interrupted task executions for 1 goal(s) before resident loop startup.");
+
+    const history = await stateManager.readRaw(`tasks/${runningTask.goal_id}/task-history.json`) as Array<Record<string, unknown>>;
+    expect(history.at(-1)).toMatchObject({
+      task_id: "task-resident-recover",
+      status: "error",
+      recovery_source: "resident_cli_startup",
+      recovery_reason: "task execution interrupted before resident CLI startup",
+      retry_intent: "resident CLI startup preserved task for retry",
+    });
+    const ledger = await stateManager.readRaw(`tasks/${runningTask.goal_id}/ledger/${runningTask.id}.json`) as {
+      events: Array<{ type: string; action?: string; reason?: string }>;
+    };
+    expect(ledger.events.map((event) => event.type)).toEqual(["failed", "retried"]);
+    expect(ledger.events[0]?.reason).toBe("task execution interrupted before resident CLI startup");
+    expect(ledger.events[1]).toMatchObject({
+      action: "keep",
+      reason: "resident CLI startup preserved task for retry",
+    });
+    consoleSpy.mockRestore();
   });
 });
 

--- a/src/interface/cli/commands/run.ts
+++ b/src/interface/cli/commands/run.ts
@@ -6,7 +6,9 @@ import { StateManager } from "../../../base/state/state-manager.js";
 import { CharacterConfigManager } from "../../../platform/traits/character-config.js";
 import { ensureProviderConfig } from "../ensure-api-key.js";
 import type { LoopConfig } from "../../../orchestrator/loop/durable-loop.js";
+import { resolveLoopRunPolicy } from "../../../orchestrator/loop/run-policy.js";
 import type { Task } from "../../../base/types/task.js";
+import { reconcileInterruptedExecutions } from "../../../runtime/daemon/runner-recovery.js";
 import { buildDeps } from "../setup.js";
 import { formatOperationError } from "../utils.js";
 import { getCliLogger } from "../cli-logger.js";
@@ -92,6 +94,29 @@ export async function cmdRun(
 
   if (activeCoreLoopRef) {
     activeCoreLoopRef.value = coreLoop;
+  }
+
+  const runPolicy = resolveLoopRunPolicy(loopConfig);
+  if (runPolicy.mode === "resident") {
+    try {
+      const recoveredGoalIds = await reconcileInterruptedExecutions({
+        baseDir: stateManager.getBaseDir(),
+        stateManager,
+        logger,
+        interruptedOutputMessage: "[RECOVERED] Task execution was interrupted before resident CLI startup.",
+        failedEventReason: "task execution interrupted before resident CLI startup",
+        retryEventReason: "resident CLI startup preserved task for retry",
+        recoverySource: "resident_cli_startup",
+      });
+      if (recoveredGoalIds.length > 0) {
+        console.log(`Recovered interrupted task executions for ${recoveredGoalIds.length} goal(s) before resident loop startup.`);
+      }
+    } catch (err) {
+      logger.error(formatOperationError("reconcile interrupted resident tasks", err));
+      if (activeCoreLoopRef) activeCoreLoopRef.value = null;
+      rl?.close();
+      return 1;
+    }
   }
 
   let result: Awaited<ReturnType<typeof coreLoop.run>>;

--- a/src/orchestrator/execution/__tests__/task-prompt-builder.test.ts
+++ b/src/orchestrator/execution/__tests__/task-prompt-builder.test.ts
@@ -328,6 +328,8 @@ describe("buildTaskGenerationPrompt — recent failed task history", () => {
               verification_verdict: "fail",
               consecutive_failure_count: 1,
               verification_evidence: ["execution failed before applying a durable recovery change"],
+              recovery_reason: "task execution interrupted before resident CLI startup",
+              retry_intent: "resident CLI startup preserved task for retry",
             },
           ];
         }
@@ -345,6 +347,8 @@ describe("buildTaskGenerationPrompt — recent failed task history", () => {
     expect(prompt).toContain("Recent Failed/Discarded Task Attempts");
     expect(prompt).toContain("Add focused daemon recovery regression test");
     expect(prompt).toContain("execution failed before applying a durable recovery change");
+    expect(prompt).toContain("recovery: task execution interrupted before resident CLI startup");
+    expect(prompt).toContain("retry intent: resident CLI startup preserved task for retry");
     expect(prompt).toContain("Do not generate another task that repeats the same edit/test direction");
   });
 });

--- a/src/orchestrator/execution/task/task-generation.ts
+++ b/src/orchestrator/execution/task/task-generation.ts
@@ -168,6 +168,8 @@ interface TaskHistoryEntry {
   status: string;
   verification_verdict?: string | null;
   consecutive_failure_count?: number;
+  recovery_reason?: string;
+  retry_intent?: string;
 }
 
 const DUPLICATE_HISTORY_WINDOW = 30;

--- a/src/orchestrator/execution/task/task-prompt-builder.ts
+++ b/src/orchestrator/execution/task/task-prompt-builder.ts
@@ -28,6 +28,8 @@ interface PromptTaskHistoryEntry {
   verification_verdict?: string | null;
   verification_evidence?: string[];
   consecutive_failure_count?: number;
+  recovery_reason?: string;
+  retry_intent?: string;
 }
 
 function clampSection(content: string, maxChars: number, label: string): string {
@@ -156,7 +158,9 @@ async function buildRecentFailureHistorySection(
     const evidence = entry.verification_evidence?.length
       ? ` — evidence: ${entry.verification_evidence.slice(0, 2).join("; ")}`
       : "";
-    lines.push(`- [${entry.status ?? "unknown"}${verdict}] ${description}${evidence}`);
+    const recoveryReason = entry.recovery_reason ? ` — recovery: ${entry.recovery_reason}` : "";
+    const retryIntent = entry.retry_intent ? ` — retry intent: ${entry.retry_intent}` : "";
+    lines.push(`- [${entry.status ?? "unknown"}${verdict}] ${description}${evidence}${recoveryReason}${retryIntent}`);
   }
 
   if (lines.length === 0) return "";

--- a/src/runtime/daemon/__tests__/runner-recovery.test.ts
+++ b/src/runtime/daemon/__tests__/runner-recovery.test.ts
@@ -109,6 +109,9 @@ describe("runner-recovery", () => {
       status: "error",
       primary_dimension: "dim",
       consecutive_failure_count: 1,
+      recovery_source: "daemon_startup",
+      recovery_reason: "task execution interrupted by daemon recovery",
+      retry_intent: "daemon restarted; task preserved for retry",
     });
 
     const ledger = await stateManager.readRaw(`tasks/${runningTask.goal_id}/ledger/${runningTask.id}.json`) as { events: Array<{ type: string; action?: string }> };

--- a/src/runtime/daemon/runner-recovery.ts
+++ b/src/runtime/daemon/runner-recovery.ts
@@ -11,9 +11,19 @@ export async function reconcileInterruptedExecutions(params: {
   baseDir: string;
   stateManager: StateManager;
   logger: Pick<Logger, "warn">;
+  interruptedOutputMessage?: string;
+  failedEventReason?: string;
+  retryEventReason?: string;
+  recoverySource?: string;
 }): Promise<string[]> {
   const recoveredGoalIds = new Set<string>();
   const now = new Date().toISOString();
+  const interruptedOutputMessage =
+    params.interruptedOutputMessage ??
+    "[RECOVERED] Task execution was interrupted by daemon crash or restart before completion.";
+  const failedEventReason = params.failedEventReason ?? "task execution interrupted by daemon recovery";
+  const retryEventReason = params.retryEventReason ?? "daemon restarted; task preserved for retry";
+  const recoverySource = params.recoverySource ?? "daemon_startup";
 
   for (const task of await findRunningTasks(params.baseDir, params.stateManager)) {
     const recoveredTask: Task = TaskSchema.parse({
@@ -23,26 +33,30 @@ export async function reconcileInterruptedExecutions(params: {
       heartbeat_at: now,
       execution_output: [
         task.execution_output,
-        "[RECOVERED] Task execution was interrupted by daemon crash or restart before completion.",
+        interruptedOutputMessage,
       ]
         .filter((value): value is string => typeof value === "string" && value.length > 0)
         .join("\n"),
     });
 
     await params.stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, recoveredTask);
-    await appendRecoveredTaskHistory(params.stateManager, recoveredTask);
+    await appendRecoveredTaskHistory(params.stateManager, recoveredTask, {
+      recoverySource,
+      recovery_reason: failedEventReason,
+      retry_intent: retryEventReason,
+    });
     await appendTaskOutcomeEvent(params.stateManager, {
       task: recoveredTask,
       type: "failed",
       attempt: Math.max(task.consecutive_failure_count + 1, 1),
-      reason: "task execution interrupted by daemon recovery",
+      reason: failedEventReason,
     });
     await appendTaskOutcomeEvent(params.stateManager, {
       task: recoveredTask,
       type: "retried",
       attempt: Math.max(task.consecutive_failure_count + 1, 1),
       action: "keep",
-      reason: "daemon restarted; task preserved for retry",
+      reason: retryEventReason,
     });
     recoveredGoalIds.add(task.goal_id);
   }
@@ -107,7 +121,12 @@ export async function findRunningTasks(baseDir: string, stateManager: StateManag
 
 export async function appendRecoveredTaskHistory(
   stateManager: StateManager,
-  task: Task
+  task: Task,
+  recovery: {
+    recoverySource: string;
+    recovery_reason: string;
+    retry_intent: string;
+  }
 ): Promise<void> {
   const historyPath = `tasks/${task.goal_id}/task-history.json`;
   const existing = await stateManager.readRaw(historyPath);
@@ -125,6 +144,9 @@ export async function appendRecoveredTaskHistory(
     completed_at: task.completed_at ?? new Date().toISOString(),
     actual_elapsed_ms: actualElapsedMs,
     estimated_duration_ms: task.estimated_duration ? durationToMs(task.estimated_duration) : null,
+    recovery_source: recovery.recoverySource,
+    recovery_reason: recovery.recovery_reason,
+    retry_intent: recovery.retry_intent,
   });
   await stateManager.writeRaw(historyPath, history);
 }


### PR DESCRIPTION
Closes #1144

## Implementation summary
- Reconciles interrupted `running` task records before non-daemon `pulseed run --resident` starts the resident loop.
- Reuses the daemon interrupted-execution recovery service with caller-specific resident CLI evidence and retry intent.
- Persists `recovery_source`, `recovery_reason`, and `retry_intent` in task history and surfaces that recovery context in future task generation prompt history.
- Adds a production caller-path CLI regression that seeds a running task and verifies recovery happens before `CoreLoop.run()`.

## Verification commands
- `npm run test:unit -- src/interface/cli/__tests__/cli-runner.test.ts src/runtime/daemon/__tests__/runner-recovery.test.ts`
- `npm run test:integration -- src/runtime/daemon/__tests__/runner-recovery.test.ts`
- `npm run test:unit -- src/orchestrator/execution/__tests__/task-prompt-builder.test.ts src/interface/cli/__tests__/cli-runner.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings; 0 errors)
- `npm run test:changed`
- `git diff --check`

## Known unresolved risks
- Full suite was not run locally; `test:changed` covered related unit, related integration, and smoke lanes.

## Parallel PR dependency / incorporation status
- Related #1137 is an open issue, not a PR; there was no merged #1137 PR to incorporate.
- `gh pr list --state open --limit 50` showed no open PRs before starting this issue.
- Branch was based on current `origin/main` including prior merged runtime fixes through #1168.
