### PR TITLE
Fix non-interactive task smoke command policy

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts
@@ -1,0 +1,427 @@
+import { afterEach, describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+import type { Task } from "../../../../base/types/task.js";
+import { makeTempDir } from "../../../../../tests/helpers/temp-dir.js";
+import { ConcurrencyController } from "../../../../tools/concurrency.js";
+import { ToolExecutor } from "../../../../tools/executor.js";
+import { ApplyPatchTool } from "../../../../tools/fs/ApplyPatchTool/ApplyPatchTool.js";
+import { ToolPermissionManager } from "../../../../tools/permission.js";
+import { ToolRegistry } from "../../../../tools/registry.js";
+import { ShellCommandTool } from "../../../../tools/system/ShellCommandTool/ShellCommandTool.js";
+import {
+  BoundedAgentLoopRunner,
+  StaticAgentLoopModelRegistry,
+  TaskAgentLoopRunner,
+  ToolExecutorAgentLoopToolRuntime,
+  ToolRegistryAgentLoopToolRouter,
+  defaultAgentLoopCapabilities,
+  defaultExecutionPolicy,
+  withExecutionPolicyOverrides,
+  type AgentLoopBudget,
+  type AgentLoopModelClient,
+  type AgentLoopModelInfo,
+  type AgentLoopModelRequest,
+  type AgentLoopModelResponse,
+  type AgentLoopWorktreePolicy,
+} from "../index.js";
+
+class ScriptedModelClient implements AgentLoopModelClient {
+  readonly calls: AgentLoopModelRequest[] = [];
+  private index = 0;
+
+  constructor(
+    private readonly modelInfo: AgentLoopModelInfo,
+    private readonly responses: AgentLoopModelResponse[],
+  ) {}
+
+  async getModelInfo(): Promise<AgentLoopModelInfo> {
+    return this.modelInfo;
+  }
+
+  async createTurn(input: AgentLoopModelRequest): Promise<AgentLoopModelResponse> {
+    this.calls.push(input);
+    return this.responses[this.index++] ?? this.responses[this.responses.length - 1];
+  }
+}
+
+const SMOKE_COMMAND = ".venv/bin/python src/experiments/train_hgb_engineered_auc.py --smoke-rows 2000";
+const SMOKE_ARTIFACT = "reports/smoke-metrics.json";
+const DENIED_COMMAND = "pip install forbidden-package";
+
+describe("TaskAgentLoopRunner non-interactive smoke command policy", () => {
+  const tmpDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    }
+  });
+
+  it("runs workspace-local smoke commands under approvalPolicy=never without interactive approval", async () => {
+    const workspace = makeWorkspace();
+    writeSmokePythonShim(workspace);
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{
+          id: "smoke-1",
+          name: "shell_command",
+          input: { command: SMOKE_COMMAND, cwd: workspace, timeoutMs: 30_000 },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{
+          id: "verify-1",
+          name: "shell_command",
+          input: { command: `test -f ${SMOKE_ARTIFACT}`, cwd: workspace },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "smoke completed",
+          summary: "smoke command and artifact verification completed",
+          filesChanged: [],
+          testsRun: [{ command: `test -f ${SMOKE_ARTIFACT}`, passed: true, outputSummary: "artifact exists" }],
+          completionEvidence: ["smoke command completed and fresh artifact exists"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const policy = withExecutionPolicyOverrides(defaultExecutionPolicy(workspace), {
+      approvalPolicy: "never",
+    });
+    const runner = makeRunner({ workspace, modelInfo, modelClient, defaultExecutionPolicy: policy });
+
+    const result = await runner.runTask({ task: makeTask(), cwd: workspace });
+
+    expect(result.success).toBe(true);
+    expect(result.executionPolicy?.approvalPolicy).toBe("never");
+    expect(fs.existsSync(path.join(workspace, SMOKE_ARTIFACT))).toBe(true);
+    expect(result.commandResults[0]).toMatchObject({
+      toolName: "shell_command",
+      command: SMOKE_COMMAND,
+      success: true,
+      execution: { status: "executed" },
+    });
+    expect(result.commandResults.some((entry) => entry.execution?.reason === "approval_denied")).toBe(false);
+  });
+
+  it("returns denied smoke commands as actionable blockers instead of only max turns", async () => {
+    const workspace = makeWorkspace();
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{
+          id: "smoke-1",
+          name: "shell_command",
+          input: { command: DENIED_COMMAND, cwd: workspace, timeoutMs: 30_000 },
+        }],
+        stopReason: "tool_use",
+      },
+    ]);
+    const policy = withExecutionPolicyOverrides(defaultExecutionPolicy(workspace), {
+      networkAccess: true,
+    });
+    const runner = makeRunner({
+      workspace,
+      modelInfo,
+      modelClient,
+      defaultExecutionPolicy: policy,
+      defaultBudget: { maxModelTurns: 1, maxToolCalls: 1 },
+    });
+
+    const result = await runner.runTaskAsAgentResult({ task: makeTask(), cwd: workspace });
+
+    expect(result.success).toBe(false);
+    expect(result.output).toContain("Command shell_command was not executed (approval_denied)");
+    expect(result.output).toContain(DENIED_COMMAND);
+    expect(result.output).not.toBe("max_model_turns");
+    expect(result.error).toContain("Shell command requires approval under current execution policy");
+    expect(result.agentLoop?.approvalPolicy).toBe("on_request");
+  });
+
+  it("keeps isolated workspaces when a denied command is followed by premature done", async () => {
+    const policyRoot = makeTempDir();
+    tmpDirs.push(policyRoot);
+    const workspace = makeGitWorkspace(policyRoot);
+    const isolatedBaseDir = path.join(policyRoot, "worktrees");
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{
+          id: "smoke-1",
+          name: "shell_command",
+          input: { command: DENIED_COMMAND, timeoutMs: 30_000 },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "claimed done after denied command",
+          summary: "premature success",
+          filesChanged: [],
+          testsRun: [],
+          completionEvidence: ["claimed evidence"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const policy = withExecutionPolicyOverrides(defaultExecutionPolicy(policyRoot), {
+      networkAccess: true,
+    });
+    const runner = makeRunner({
+      workspace,
+      modelInfo,
+      modelClient,
+      defaultExecutionPolicy: policy,
+      defaultBudget: { maxModelTurns: 3, maxToolCalls: 3 },
+      defaultWorktreePolicy: {
+        enabled: true,
+        baseDir: isolatedBaseDir,
+        cleanupPolicy: "on_success",
+      },
+    });
+
+    const result = await runner.runTask({ task: makeTask(), cwd: workspace });
+
+    expect(result.success).toBe(false);
+    expect(result.output?.status).toBe("done");
+    expect(result.workspace).toMatchObject({
+      isolated: true,
+      cleanupStatus: "kept",
+      cleanupReason: "task did not succeed",
+    });
+    expect(result.workspace?.executionCwd).not.toBe(result.workspace?.requestedCwd);
+    expect(fs.existsSync(result.workspace!.executionCwd)).toBe(true);
+  });
+
+  it("does not keep isolated workspaces when a later typed tool recovers after denial", async () => {
+    const policyRoot = makeTempDir();
+    tmpDirs.push(policyRoot);
+    const workspace = makeGitWorkspace(policyRoot);
+    const isolatedBaseDir = path.join(policyRoot, "worktrees");
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{
+          id: "blocked-1",
+          name: "shell_command",
+          input: { command: "cat dogfood.txt", timeoutMs: 30_000 },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{
+          id: "recover-1",
+          name: "apply_patch",
+          input: {
+            checkOnly: true,
+            patch: [
+              "*** Begin Patch",
+              "*** Update File: README.md",
+              "@@",
+              "-fixture",
+              "+fixture checked",
+              "*** End Patch",
+            ].join("\n"),
+          },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "recovered with typed tool",
+          summary: "typed tool supplied fresh recovery evidence",
+          filesChanged: [],
+          testsRun: [],
+          completionEvidence: ["apply_patch check-only recovery evidence"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const policy = withExecutionPolicyOverrides(defaultExecutionPolicy(policyRoot), {
+      approvalPolicy: "never",
+    });
+    const runner = makeRunner({
+      workspace,
+      modelInfo,
+      modelClient,
+      defaultExecutionPolicy: policy,
+      defaultWorktreePolicy: {
+        enabled: true,
+        baseDir: isolatedBaseDir,
+        cleanupPolicy: "on_success",
+      },
+      denyShellCommand: (command) => command === "cat dogfood.txt",
+    });
+
+    const result = await runner.runTask({ task: makeTask(), cwd: workspace });
+
+    expect(result.success).toBe(true);
+    expect(result.toolResults?.map((entry) => entry.toolName)).toEqual(["shell_command", "apply_patch"]);
+    expect(result.workspace).toMatchObject({
+      isolated: true,
+      cleanupStatus: "cleaned_up",
+    });
+    expect(fs.existsSync(result.workspace!.executionCwd)).toBe(false);
+  });
+
+  function makeWorkspace(): string {
+    const workspace = makeTempDir();
+    tmpDirs.push(workspace);
+    fs.mkdirSync(path.join(workspace, "src/experiments"), { recursive: true });
+    fs.writeFileSync(path.join(workspace, "src/experiments/train_hgb_engineered_auc.py"), "print('placeholder')\n");
+    return workspace;
+  }
+
+  function makeGitWorkspace(root?: string): string {
+    const workspace = root ? path.join(root, "repo") : makeWorkspace();
+    if (root) {
+      fs.mkdirSync(path.join(workspace, "src/experiments"), { recursive: true });
+      fs.writeFileSync(path.join(workspace, "src/experiments/train_hgb_engineered_auc.py"), "print('placeholder')\n");
+    }
+    execFileSync("git", ["init"], { cwd: workspace, stdio: "ignore" });
+    fs.writeFileSync(path.join(workspace, "README.md"), "fixture\n");
+    execFileSync("git", ["add", "README.md"], { cwd: workspace, stdio: "ignore" });
+    execFileSync("git", [
+      "-c",
+      "user.email=codex@example.com",
+      "-c",
+      "user.name=Codex",
+      "commit",
+      "-m",
+      "fixture",
+    ], { cwd: workspace, stdio: "ignore" });
+    return workspace;
+  }
+});
+
+function makeRunner(input: {
+  workspace: string;
+  modelInfo: AgentLoopModelInfo;
+  modelClient: AgentLoopModelClient;
+  defaultExecutionPolicy: ReturnType<typeof defaultExecutionPolicy>;
+  defaultBudget?: Partial<AgentLoopBudget>;
+  defaultWorktreePolicy?: AgentLoopWorktreePolicy;
+  denyShellCommand?: (command: string) => boolean;
+}): TaskAgentLoopRunner {
+  const registry = new ToolRegistry();
+  registry.register(new ApplyPatchTool());
+  registry.register(new ShellCommandTool());
+  const router = new ToolRegistryAgentLoopToolRouter(registry);
+  const executor = new ToolExecutor({
+    registry,
+    permissionManager: new ToolPermissionManager({
+      denyRules: input.denyShellCommand
+        ? [{
+            toolName: "shell_command",
+            inputMatcher: (toolInput) =>
+              toolInput !== null
+              && typeof toolInput === "object"
+              && typeof (toolInput as Record<string, unknown>)["command"] === "string"
+              && input.denyShellCommand!((toolInput as Record<string, string>)["command"]),
+            reason: "test denied shell command",
+          }]
+        : [],
+    }),
+    concurrency: new ConcurrencyController(),
+  });
+  const runtime = new ToolExecutorAgentLoopToolRuntime(executor, router);
+  const boundedRunner = new BoundedAgentLoopRunner({
+    modelClient: input.modelClient,
+    toolRouter: router,
+    toolRuntime: runtime,
+  });
+  return new TaskAgentLoopRunner({
+    boundedRunner,
+    modelClient: input.modelClient,
+    modelRegistry: new StaticAgentLoopModelRegistry([input.modelInfo]),
+    defaultModel: input.modelInfo.ref,
+    defaultToolPolicy: { allowedTools: ["shell_command", "apply_patch"] },
+    defaultBudget: {
+      maxModelTurns: 4,
+      maxToolCalls: 4,
+      maxCompletionValidationAttempts: 1,
+      ...input.defaultBudget,
+    },
+    ...(input.defaultWorktreePolicy ? { defaultWorktreePolicy: input.defaultWorktreePolicy } : {}),
+    defaultExecutionPolicy: input.defaultExecutionPolicy,
+    cwd: input.workspace,
+  });
+}
+
+function writeSmokePythonShim(workspace: string): void {
+  const binDir = path.join(workspace, ".venv/bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  const shimPath = path.join(binDir, "python");
+  fs.writeFileSync(shimPath, [
+    "#!/bin/sh",
+    "mkdir -p reports",
+    "printf '{\"auc\":0.70}\\n' > reports/smoke-metrics.json",
+    "echo smoke-ok \"$@\"",
+    "",
+  ].join("\n"));
+  fs.chmodSync(shimPath, 0o755);
+}
+
+function makeModelInfo(): AgentLoopModelInfo {
+  return {
+    ref: { providerId: "test", modelId: "smoke-policy" },
+    displayName: "test/smoke-policy",
+    capabilities: { ...defaultAgentLoopCapabilities },
+  };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "smoke-task",
+    goal_id: "smoke-goal",
+    strategy_id: null,
+    target_dimensions: ["execution"],
+    primary_dimension: "execution",
+    work_description: "Run Kaggle smoke training in the configured workspace.",
+    rationale: "Exercise non-interactive task shell policy.",
+    approach: "Run workspace-local smoke training and verify the artifact.",
+    success_criteria: [{
+      description: "smoke metrics artifact exists",
+      verification_method: `test -f ${SMOKE_ARTIFACT}`,
+      is_blocking: true,
+    }],
+    scope_boundary: { in_scope: ["."], out_of_scope: [], blast_radius: "low" },
+    constraints: [],
+    plateau_until: null,
+    estimated_duration: { value: 1, unit: "hours" },
+    consecutive_failure_count: 0,
+    reversibility: "reversible",
+    task_category: "normal",
+    status: "pending",
+    started_at: null,
+    completed_at: null,
+    timeout_at: null,
+    heartbeat_at: null,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}

--- a/src/orchestrator/execution/agent-loop/agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-result.ts
@@ -5,6 +5,7 @@ import type { AgentLoopStopReason } from "./agent-loop-budget.js";
 export type AgentLoopCommandResultCategory = "verification" | "observation" | "other";
 
 export interface AgentLoopCommandResult {
+  sequence?: number;
   toolName: string;
   command: string;
   cwd: string;
@@ -18,6 +19,7 @@ export interface AgentLoopCommandResult {
 }
 
 export interface AgentLoopToolResultSummary {
+  sequence?: number;
   toolName: string;
   success: boolean;
   execution?: AgentLoopToolObservationExecution;

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -426,11 +426,13 @@ export class BoundedAgentLoopRunner {
           calledTools.add(result.toolName);
         }
         toolCalls++;
+        const toolResultSequence = toolCalls;
         if (result.success) consecutiveToolErrors = 0;
         else consecutiveToolErrors++;
 
         const checkOnly = readToolResultCheckOnly(result);
         toolResultSummaries.push({
+          sequence: toolResultSequence,
           toolName: result.toolName,
           success: result.success,
           ...(result.execution ? { execution: result.execution } : {}),
@@ -493,6 +495,7 @@ export class BoundedAgentLoopRunner {
             command: result.command,
           });
           commandResults.push({
+            sequence: toolResultSequence,
             toolName: result.toolName,
             command: result.command,
             cwd: result.cwd,
@@ -605,6 +608,9 @@ export class BoundedAgentLoopRunner {
       traceId: turn.session.traceId,
       sessionId: turn.session.sessionId,
       turnId: turn.turnId,
+      ...(turn.profileName ? { profileName: turn.profileName } : {}),
+      ...(turn.reasoningEffort ? { reasoningEffort: turn.reasoningEffort } : {}),
+      ...(turn.executionPolicy ? { executionPolicy: turn.executionPolicy } : {}),
     };
   }
 

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-context.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-context.ts
@@ -3,7 +3,7 @@ import { cwd as processCwd } from "node:process";
 import type { Task } from "../../../base/types/task.js";
 import type { ToolCallContext } from "../../../tools/types.js";
 import type { AgentLoopBudget } from "./agent-loop-budget.js";
-import type { AgentLoopModelInfo, AgentLoopModelRef } from "./agent-loop-model.js";
+import type { AgentLoopModelInfo, AgentLoopModelRef, AgentLoopReasoningEffort } from "./agent-loop-model.js";
 import type { AgentLoopCompletionValidationResult } from "./agent-loop-result.js";
 import type { AgentLoopSession } from "./agent-loop-session.js";
 import type { AgentLoopSessionState } from "./agent-loop-session-state.js";
@@ -12,7 +12,7 @@ import { withDefaultBudget } from "./agent-loop-turn-context.js";
 import { TaskAgentLoopOutputSchema, type TaskAgentLoopOutput } from "./task-agent-loop-result.js";
 import { buildAgentLoopBaseInstructions } from "./agent-loop-prompts.js";
 import { isTaskRelevantVerificationCommand } from "./task-agent-loop-verification.js";
-import type { SubagentRole } from "./execution-policy.js";
+import type { ExecutionPolicy, SubagentRole } from "./execution-policy.js";
 
 export interface TaskAgentLoopContextInput {
   task: Task;
@@ -30,12 +30,16 @@ export interface TaskAgentLoopContextInput {
   resumeState?: AgentLoopSessionState;
   abortSignal?: AbortSignal;
   role?: SubagentRole;
+  profileName?: string;
+  reasoningEffort?: AgentLoopReasoningEffort;
+  executionPolicy?: ExecutionPolicy;
 }
 
 export function buildTaskAgentLoopTurnContext(
   input: TaskAgentLoopContextInput,
 ): AgentLoopTurnContext<TaskAgentLoopOutput> {
   const cwd = input.cwd ?? processCwd();
+  const executionPolicy = input.toolCallContext?.executionPolicy ?? input.executionPolicy;
   const baseSystemPrompt = buildAgentLoopBaseInstructions({
     mode: "task",
     extraRules: [
@@ -59,9 +63,12 @@ export function buildTaskAgentLoopTurnContext(
     turnId: randomUUID(),
     goalId: input.task.goal_id,
     taskId: input.task.id,
+    ...(input.profileName ? { profileName: input.profileName } : {}),
     cwd,
     model: input.model,
     modelInfo: input.modelInfo,
+    ...(input.reasoningEffort ? { reasoningEffort: input.reasoningEffort } : {}),
+    ...(executionPolicy ? { executionPolicy } : {}),
     messages: [
       {
         role: "system",
@@ -108,6 +115,7 @@ export function buildTaskAgentLoopTurnContext(
       trustBalance: 0,
       preApproved: true,
       approvalFn: async () => false,
+      ...(executionPolicy ? { executionPolicy } : {}),
       agentRole: input.role,
       ...input.toolCallContext,
     },

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
@@ -43,22 +43,102 @@ function collectAgentLoopChangedPaths(
   ];
 }
 
+function isBlockingNotExecutedReason(reason: string | undefined): boolean {
+  return reason !== "dry_run";
+}
+
+function formatNotExecutedDetail(input: {
+  kind: "Command" | "Tool";
+  name: string;
+  reason?: string;
+  message?: string;
+  command?: string;
+  cwd?: string;
+}): string {
+  const reason = input.reason ? ` (${input.reason})` : "";
+  const command = input.command ? `: ${input.command}` : "";
+  const cwd = input.cwd ? ` in ${input.cwd}` : "";
+  const message = input.message?.trim() ? `. ${input.message.trim()}` : "";
+  return `${input.kind} ${input.name} was not executed${reason}${cwd}${command}${message}`;
+}
+
+function entrySequence(entry: { sequence?: number }, fallbackIndex: number): number {
+  return entry.sequence ?? fallbackIndex;
+}
+
+export function collectTaskAgentLoopNotExecutedBlockers(
+  result: AgentLoopResult<TaskAgentLoopOutput>,
+): string[] {
+  const toolResults = result.toolResults ?? [];
+  const lastSuccessfulSequence = Math.max(
+    -1,
+    ...result.commandResults
+      .map((entry, index) => ({ entry, index }))
+      .filter(({ entry }) => entry.success)
+      .map(({ entry, index }) => entrySequence(entry, index)),
+    ...toolResults
+      .map((entry, index) => ({ entry, index }))
+      .filter(({ entry }) => entry.success)
+      .map(({ entry, index }) => entrySequence(entry, index)),
+  );
+  const commandBlockers = result.commandResults
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry, index }) =>
+      entrySequence(entry, index) > lastSuccessfulSequence
+      && entry.execution?.status === "not_executed"
+      && isBlockingNotExecutedReason(entry.execution.reason)
+    )
+    .map(({ entry }) => formatNotExecutedDetail({
+      kind: "Command",
+      name: entry.toolName,
+      reason: entry.execution?.reason,
+      message: entry.execution?.message || entry.outputSummary,
+      command: entry.command,
+      cwd: entry.cwd,
+    }));
+  const commandToolNames = new Set(
+    result.commandResults
+      .filter((entry) => entry.execution?.status === "not_executed")
+      .map((entry) => entry.toolName),
+  );
+  const toolBlockers = toolResults
+    .map((entry, index) => ({ entry, index }))
+    .filter(({ entry, index }) =>
+      entrySequence(entry, index) > lastSuccessfulSequence
+      && entry.execution?.status === "not_executed"
+      && isBlockingNotExecutedReason(entry.execution.reason)
+      && !commandToolNames.has(entry.toolName)
+    )
+    .map(({ entry }) => formatNotExecutedDetail({
+      kind: "Tool",
+      name: entry.toolName,
+      reason: entry.execution?.reason,
+      message: entry.execution?.message || entry.outputSummary,
+    }));
+  return [...new Set([...commandBlockers, ...toolBlockers])];
+}
+
 export function taskAgentLoopResultToAgentResult(
   result: AgentLoopResult<TaskAgentLoopOutput>,
 ): AgentResult {
-  const done = result.success && result.output?.status === "done";
+  const notExecutedBlockers = collectTaskAgentLoopNotExecutedBlockers(result);
+  const blockers = [
+    ...(result.output?.blockers ?? []),
+    ...notExecutedBlockers,
+  ];
+  const done = result.success && result.output?.status === "done" && blockers.length === 0;
   const runtimeVerificationCommands = result.commandResults.filter((command) =>
     command.evidenceEligible && command.relevantToTask !== false
   );
   const filesChangedPaths = collectAgentLoopChangedPaths(result);
-  const fallbackOutput = result.output?.finalAnswer
-    ?? result.finalText
-    ?? result.output?.blockers.join("; ")
-    ?? result.stopReason;
+  const blockerOutput = blockers.join("; ");
+  const fallbackOutput = done
+    ? result.output?.finalAnswer ?? result.finalText ?? result.stopReason
+    : blockerOutput || result.output?.finalAnswer || result.finalText || result.stopReason;
   return {
     success: done,
     output: fallbackOutput,
-    error: done ? null : result.output?.blockers.join("; ") || result.finalText || result.stopReason,
+    error: done ? null : blockerOutput || result.finalText || result.stopReason,
     exit_code: null,
     elapsed_ms: result.elapsedMs,
     stopped_reason:
@@ -85,6 +165,7 @@ export function taskAgentLoopResultToAgentResult(
       verificationHints: [
         ...(result.output?.verificationHints ?? []),
         ...runtimeVerificationCommands.filter((command) => !command.success).map((command) => `failed command: ${command.command}`),
+        ...notExecutedBlockers,
       ],
       filesChangedPaths,
       ...(result.workspace

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-runner.ts
@@ -14,6 +14,7 @@ import type { AgentLoopToolPolicy } from "./agent-loop-turn-context.js";
 import { AgentLoopContextAssembler, type SoilPrefetchQuery, type SoilPrefetchResult } from "./agent-loop-context-assembler.js";
 import { buildTaskAgentLoopTurnContext } from "./task-agent-loop-context.js";
 import {
+  collectTaskAgentLoopNotExecutedBlockers,
   taskAgentLoopResultToAgentResult,
   type TaskAgentLoopOutput,
 } from "./task-agent-loop-result.js";
@@ -77,13 +78,15 @@ export class TaskAgentLoopRunner {
     let finalResult: AgentLoopResult<TaskAgentLoopOutput> | null = null;
     let runError: unknown = null;
     try {
+      const executionPolicy = this.deps.defaultToolCallContext?.executionPolicy
+        ?? this.deps.defaultExecutionPolicy;
       const assembled = await contextAssembler.assembleTask({
         task: input.task,
         workspaceContext: input.workspaceContext,
         knowledgeContext: input.knowledgeContext,
         cwd: workspace.executionCwd,
         soilPrefetch: this.deps.soilPrefetch,
-        trustProjectInstructions: this.deps.defaultToolCallContext?.executionPolicy?.trustProjectInstructions,
+        trustProjectInstructions: executionPolicy?.trustProjectInstructions,
       });
       const turn = buildTaskAgentLoopTurnContext({
         task: input.task,
@@ -100,14 +103,15 @@ export class TaskAgentLoopRunner {
         toolCallContext: this.deps.defaultToolCallContext,
         ...(this.deps.defaultProfileName ? { profileName: this.deps.defaultProfileName } : {}),
         ...(this.deps.defaultReasoningEffort ? { reasoningEffort: this.deps.defaultReasoningEffort } : {}),
-        ...(this.deps.defaultExecutionPolicy ? { executionPolicy: this.deps.defaultExecutionPolicy } : {}),
+        ...(executionPolicy ? { executionPolicy } : {}),
         ...(input.resumeState ? { resumeState: input.resumeState } : {}),
         abortSignal: input.abortSignal,
         role: input.role,
       });
       const result = await this.deps.boundedRunner.run(turn);
+      const success = result.success && collectTaskAgentLoopNotExecutedBlockers(result).length === 0;
       finalizationInput = {
-        success: result.success,
+        success,
         changedFiles: result.changedFiles,
       };
       const commandResults = result.commandResults.map((commandResult) => ({
@@ -116,6 +120,7 @@ export class TaskAgentLoopRunner {
       }));
       finalResult = {
         ...result,
+        success,
         commandResults,
       };
     } catch (error) {


### PR DESCRIPTION
## Summary
- propagate task AgentLoop execution policy/profile metadata into turn, tool, and result surfaces
- surface unresolved not-executed commands/tools as actionable task blockers instead of generic loop stops
- keep isolated workspaces for premature denied-command completion, while allowing later typed-tool recovery to clean up

## Verification
- npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts
- npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-runner.test.ts
- npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts src/orchestrator/execution/agent-loop/__tests__/agent-loop-dogfood-benchmark.test.ts -t "denied command"
- npm run typecheck
- npm run lint:boundaries (0 errors, existing warnings)
- npm run test:changed (one transient chat permission test failed once, focused retry passed, full retry passed)