### PR TITLE
refactor(semantic): route shell safety through typed tool policy

### DIFF
--- a/src/interface/tui/__tests__/app.test.ts
+++ b/src/interface/tui/__tests__/app.test.ts
@@ -12,6 +12,13 @@ import { createMockLLMClient, createSingleMockLLMClient } from "../../../../test
 import type { TelegramSetupStatus } from "../../chat/gateway-setup-status.js";
 import { createSetupRuntimeControlTools } from "../../../tools/runtime/SetupRuntimeControlTools.js";
 import type { ToolCallContext } from "../../../tools/types.js";
+import { ToolExecutor } from "../../../tools/executor.js";
+import { ToolRegistry } from "../../../tools/registry.js";
+import { ToolPermissionManager } from "../../../tools/permission.js";
+import { ConcurrencyController } from "../../../tools/concurrency.js";
+import { ShellTool } from "../../../tools/system/ShellTool/ShellTool.js";
+import type { ExecutionPolicy } from "../../../orchestrator/execution/agent-loop/execution-policy.js";
+import * as execMod from "../../../base/utils/execFileNoThrow.js";
 
 const testState = vi.hoisted(() => ({
   lastChatProps: null as null | { onSubmit: (value: string) => Promise<void> },
@@ -137,6 +144,29 @@ function createChatRunnerMock() {
     executeIngressMessage: vi.fn(async () => ({ success: true, output: "", elapsed_ms: 0 })),
     getConversationId: vi.fn(() => "tui-conversation-test"),
     onEvent: undefined,
+  };
+}
+
+function createShellToolExecutor(): ToolExecutor {
+  const registry = new ToolRegistry();
+  registry.register(new ShellTool());
+  return new ToolExecutor({
+    registry,
+    permissionManager: new ToolPermissionManager({}),
+    concurrency: new ConcurrencyController(),
+  });
+}
+
+function createShellExecutionPolicy(workspaceRoot = "/tmp/pulseed-tui-shell-test", overrides: Partial<ExecutionPolicy> = {}): ExecutionPolicy {
+  return {
+    executionProfile: "consumer",
+    sandboxMode: "workspace_write",
+    approvalPolicy: "on_request",
+    networkAccess: true,
+    workspaceRoot,
+    protectedPaths: [],
+    trustProjectInstructions: true,
+    ...overrides,
   };
 }
 
@@ -345,6 +375,135 @@ describe("formatDaemonConnectionState", () => {
 
   it("omits the badge when no daemon state is available", () => {
     expect(formatDaemonConnectionState(undefined)).toBeUndefined();
+  });
+});
+
+describe("TUI shell execution", () => {
+  beforeEach(() => {
+    testState.lastChatProps = null;
+    testState.lastChatMessages = [];
+    testState.runtimeSessionSnapshots = [];
+    testState.runtimeSessionSnapshotCalls = 0;
+    testState.summarizedRunIds = [];
+    testState.runtimeEvidenceSummaries = {};
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes safe read-only bang commands through the typed tool executor", async () => {
+    const stateManager = createStateManagerMock();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValueOnce({
+      stdout: "/tmp\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    const shellApprovalFn = vi.fn(async () => false);
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/tmp",
+      gitBranch: "main",
+      providerName: "claude",
+      toolExecutor: createShellToolExecutor(),
+      shellApprovalFn,
+      shellExecutionPolicy: createShellExecutionPolicy("/tmp"),
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("!pwd");
+    await flush();
+
+    expect(execSpy).toHaveBeenCalledOnce();
+    expect(shellApprovalFn).not.toHaveBeenCalled();
+    expect(testState.lastChatMessages.map((message) => message.text).join("\n")).toContain("$ pwd");
+
+    screen.unmount();
+  });
+
+  it("keeps bang shell writes approval-denied and not executed", async () => {
+    const stateManager = createStateManagerMock();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValue({
+      stdout: "should-not-run",
+      stderr: "",
+      exitCode: 0,
+    });
+    const shellApprovalFn = vi.fn(async () => false);
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/tmp",
+      gitBranch: "main",
+      providerName: "claude",
+      toolExecutor: createShellToolExecutor(),
+      shellApprovalFn,
+      shellExecutionPolicy: createShellExecutionPolicy("/tmp"),
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("!echo ok > denied.txt");
+    await flush();
+
+    expect(shellApprovalFn).toHaveBeenCalledOnce();
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(testState.lastChatMessages.map((message) => message.text).join("\n")).toContain("User denied approval");
+
+    screen.unmount();
+  });
+
+  it("blocks quoted command substitution in bang shell commands before execution", async () => {
+    const stateManager = createStateManagerMock();
+    const execSpy = vi.spyOn(execMod, "execFileNoThrow").mockResolvedValue({
+      stdout: "should-not-run",
+      stderr: "",
+      exitCode: 0,
+    });
+    const shellApprovalFn = vi.fn(async () => true);
+
+    const screen = render(React.createElement(App, {
+      stateManager: stateManager as unknown as StateManager,
+      noFlicker: false,
+      controlStream: process.stdout,
+      cwd: "/tmp",
+      gitBranch: "main",
+      providerName: "claude",
+      toolExecutor: createShellToolExecutor(),
+      shellApprovalFn,
+      shellExecutionPolicy: createShellExecutionPolicy("/tmp"),
+    }), {
+      patchConsole: false,
+      stdout: process.stdout,
+      stderr: process.stderr,
+    });
+
+    await flush();
+    expect(testState.lastChatProps).not.toBeNull();
+
+    await testState.lastChatProps!.onSubmit("!echo \"$(touch denied.txt)\"");
+    await flush();
+
+    expect(execSpy).not.toHaveBeenCalled();
+    expect(shellApprovalFn).not.toHaveBeenCalled();
+    expect(testState.lastChatMessages.map((message) => message.text).join("\n")).toContain("unsupported command substitution syntax");
+
+    screen.unmount();
   });
 });
 

--- a/src/interface/tui/app.tsx
+++ b/src/interface/tui/app.tsx
@@ -21,7 +21,7 @@ import { HelpOverlay } from "./help-overlay.js";
 import { SettingsOverlay } from "./settings-overlay.js";
 import { ReportView } from "./report-view.js";
 import { SEEDY_PIXEL } from "./seedy-art.js";
-import { formatShellOutput } from "./bash-mode.js";
+import { createShellApprovalTask, formatShellOutput } from "./bash-mode.js";
 import {
   resolveFreeformInputRoute,
   resolveTuiInputAction,
@@ -39,7 +39,6 @@ import type { TrustManager } from "../../platform/traits/trust-manager.js";
 import type { Task } from "../../base/types/task.js";
 import type { TuiChatSurface } from "./chat-surface.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
-import { ShellTool } from "../../tools/system/ShellTool/ShellTool.js";
 import { getPulseedVersion } from "../../base/utils/pulseed-meta.js";
 import { parseExactSlashCommandToken } from "../../base/protocol/exact-protocol.js";
 import { applyChatEventToMessages } from "../chat/chat-event-state.js";
@@ -57,6 +56,9 @@ import {
 } from "../../runtime/run-spec/index.js";
 import { answerRuntimeEvidenceQuestion } from "../../runtime/evidence-answer.js";
 import { createTextUserInput } from "../chat/user-input.js";
+import type { ToolExecutor } from "../../tools/executor.js";
+import type { ApprovalRequest as ToolApprovalRequest } from "../../tools/types.js";
+import { defaultExecutionPolicy, type ExecutionPolicy } from "../../orchestrator/execution/agent-loop/execution-policy.js";
 
 const MAX_MESSAGES = 200;
 const PULSEED_VERSION = getPulseedVersion(import.meta.url);
@@ -221,6 +223,9 @@ interface AppProps {
   llmClient?: Pick<ILLMClient, "sendMessage" | "parseJSON">;
   chatRunner?: TuiChatSurface;
   onApprovalReady?: (requestFn: (req: ApprovalRequest) => void) => void;
+  shellApprovalFn?: (task: Task) => Promise<boolean>;
+  toolExecutor?: Pick<ToolExecutor, "execute">;
+  shellExecutionPolicy?: ExecutionPolicy;
   // Shared
   stateManager: StateManager;
   cwd?: string;
@@ -275,6 +280,9 @@ export function App({
   llmClient,
   chatRunner,
   onApprovalReady,
+  shellApprovalFn,
+  toolExecutor,
+  shellExecutionPolicy,
   cwd,
   gitBranch,
   providerName,
@@ -612,15 +620,28 @@ export function App({
         }
 
         if (action.kind === "shell") {
-          const shellInput = { command: action.command, cwd: process.cwd(), timeoutMs: 120_000 };
-          const shellTool = new ShellTool();
-          const result = await shellTool.call(shellInput, {
-            cwd: process.cwd(),
+          const effectiveCwd = cwd ?? process.cwd();
+          if (!toolExecutor) {
+            setMessages((prev) => [...prev, {
+              id: randomUUID(),
+              role: "pulseed" as const,
+              text: "Shell execution unavailable: typed tool executor is not configured.",
+              timestamp: new Date(),
+              messageType: "error" as const,
+            }].slice(-MAX_MESSAGES));
+            return;
+          }
+          const shellInput = { command: action.command, cwd: effectiveCwd, timeoutMs: 120_000 };
+          const result = await toolExecutor.execute("shell", shellInput, {
+            cwd: effectiveCwd,
             goalId: "shell-mode",
             trustBalance: 0,
-            preApproved: true,
-            approvalFn: async () => true,
-            trusted: true,
+            preApproved: false,
+            approvalFn: (request: ToolApprovalRequest) => {
+              if (!shellApprovalFn) return Promise.resolve(false);
+              return shellApprovalFn(createShellApprovalTask(action.command, effectiveCwd, request.reason));
+            },
+            executionPolicy: shellExecutionPolicy ?? defaultExecutionPolicy(effectiveCwd),
           });
           const shellOutput = result.data as { stdout?: string; stderr?: string; exitCode?: number } | null;
           const text = shellOutput

--- a/src/interface/tui/bash-mode.ts
+++ b/src/interface/tui/bash-mode.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { Task } from "../../orchestrator/execution/types/task.js";
+import { isReadOnlyShellCommand } from "../../tools/system/ShellTool/command-policy.js";
 
 export function isBashModeInput(input: string): boolean {
   return input.trimStart().startsWith("!");
@@ -12,15 +13,7 @@ export function extractBashCommand(input: string): string | null {
 }
 
 export function isSafeBashCommand(command: string): boolean {
-  const SAFE_PATTERNS = [
-    /^(cat|head|tail|wc|ls|pwd|echo|date|hostname|which|type|file)/,
-    /^git\s+(status|log|diff|show|branch|rev-parse|rev-list|describe|tag\s+-l)/,
-    /^npm\s+(ls|list|view|info|outdated|audit)/,
-    /^npx\s+vitest\s+(run|list|--reporter)/,
-    /^npx\s+tsc\s+--noEmit/,
-    /^rg\s/, /^find\s/, /^du\s/, /^df\s/, /^tree\s/,
-  ];
-  return SAFE_PATTERNS.some((pattern) => pattern.test(command.trim()));
+  return isReadOnlyShellCommand(command);
 }
 
 export function createShellApprovalTask(command: string, cwd: string, reason?: string): Task {

--- a/src/interface/tui/entry-deps.ts
+++ b/src/interface/tui/entry-deps.ts
@@ -10,6 +10,7 @@ import type { Task } from "../../base/types/task.js";
 import { createApprovalQueue } from "./entry-approval.js";
 import type { DaemonClient } from "../../runtime/daemon/client.js";
 import type { ILLMClient } from "../../base/llm/llm-client.js";
+import type { ToolExecutor } from "../../tools/executor.js";
 import { ApprovalBroker } from "../../runtime/approval-broker.js";
 import { ApprovalStore, createRuntimeStorePaths } from "../../runtime/store/index.js";
 
@@ -386,6 +387,7 @@ export async function buildStandaloneTuiDeps() {
     goalNegotiator,
     reportingEngine,
     setRequestApproval: approvalQueue.setRequestApproval,
+    approvalFn,
     chatRunner,
     actionHandler,
     intentRecognizer,
@@ -402,6 +404,8 @@ export async function buildDaemonModeChatSurface(
   chatRunner: TuiChatSurface | undefined;
   llmClient: ILLMClient | undefined;
   setRequestApproval: (fn: (req: ApprovalRequest) => void) => void;
+  approvalFn: (task: Task) => Promise<boolean>;
+  toolExecutor: ToolExecutor;
 }> {
   const { TrustManager } = await import("../../platform/traits/trust-manager.js");
   const { ScheduleEngine } = await import("../../runtime/schedule/engine.js");
@@ -542,5 +546,7 @@ export async function buildDaemonModeChatSurface(
     chatRunner,
     llmClient,
     setRequestApproval: approvalQueue.setRequestApproval,
+    approvalFn: approvalQueue.enqueueApproval,
+    toolExecutor,
   };
 }

--- a/src/interface/tui/entry.ts
+++ b/src/interface/tui/entry.ts
@@ -55,7 +55,7 @@ async function startTUIStandaloneMode(): Promise<void> {
       process.exit(1);
     }
 
-    const { stateManager, llmClient, trustManager, coreLoop, actionHandler, intentRecognizer, setRequestApproval, chatRunner } = deps;
+    const { stateManager, llmClient, trustManager, coreLoop, actionHandler, intentRecognizer, setRequestApproval, approvalFn, chatRunner, toolExecutor } = deps;
 
     process.on("SIGTERM", () => { coreLoop.stop(); process.exit(0); });
 
@@ -83,6 +83,8 @@ async function startTUIStandaloneMode(): Promise<void> {
       llmClient,
       chatRunner,
       onApprovalReady: setRequestApproval,
+      shellApprovalFn: approvalFn,
+      toolExecutor,
       noFlicker,
       controlStream: terminalStream,
       ...breadcrumb,
@@ -162,7 +164,7 @@ async function startTUIDaemonMode(): Promise<void> {
 
     const stateManager = new StateManager(baseDir);
     await stateManager.init();
-    const { chatRunner, llmClient, setRequestApproval } = await buildDaemonModeChatSurface(
+    const { chatRunner, llmClient, setRequestApproval, approvalFn, toolExecutor } = await buildDaemonModeChatSurface(
       baseDir,
       stateManager,
       daemonClient,
@@ -197,6 +199,8 @@ async function startTUIDaemonMode(): Promise<void> {
       noFlicker,
       chatRunner,
       onApprovalReady: setRequestApproval,
+      shellApprovalFn: approvalFn,
+      toolExecutor,
       controlStream: terminalStream,
     });
 

--- a/src/tools/__tests__/execution-orchestrator.test.ts
+++ b/src/tools/__tests__/execution-orchestrator.test.ts
@@ -80,6 +80,61 @@ describe("decideHostToolExecution", () => {
     expect(decision.executionReason).toBe("policy_blocked");
   });
 
+  it("allows safe read-only shell protocol requests through typed command metadata", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ name: "shell", permissionLevel: "read_metrics", isReadOnly: false }),
+      input: { command: "git status --short" },
+      context: makeContext(),
+    });
+
+    expect(decision.status).toBe("allowed");
+  });
+
+  it("requires approval for shell protocol local writes", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ name: "shell", permissionLevel: "read_metrics", isReadOnly: false }),
+      input: { command: "echo ok > output.txt" },
+      context: makeContext({ executionPolicy: makePolicy({ approvalPolicy: "on_request" }) }),
+    });
+
+    expect(decision.status).toBe("needs_permission");
+    expect(decision.requiredApprovalPolicy).toBe("on_request");
+  });
+
+  it("requires a sandbox change for shell protocol network commands when network is disabled", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ name: "shell", permissionLevel: "read_metrics", isReadOnly: false }),
+      input: { command: "git fetch origin" },
+      context: makeContext({ executionPolicy: makePolicy({ networkAccess: false }) }),
+    });
+
+    expect(decision.status).toBe("needs_sandbox");
+    expect(decision.executionReason).toBe("sandbox_required");
+    expect(decision.requiredSandboxMode).toBe("danger_full_access");
+  });
+
+  it("denies destructive shell protocol commands before approval", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ name: "shell", permissionLevel: "read_metrics", isReadOnly: false }),
+      input: { command: "git reset --hard HEAD" },
+      context: makeContext(),
+    });
+
+    expect(decision.status).toBe("denied");
+    expect(decision.executionReason).toBe("policy_blocked");
+  });
+
+  it("denies shell writes to protected paths before approval", () => {
+    const decision = decideHostToolExecution({
+      tool: makeTool({ name: "shell", permissionLevel: "read_metrics", isReadOnly: false }),
+      input: { command: "touch .env" },
+      context: makeContext({ executionPolicy: makePolicy({ protectedPaths: ["/repo/.env"] }) }),
+    });
+
+    expect(decision.status).toBe("denied");
+    expect(decision.executionReason).toBe("policy_blocked");
+  });
+
   it("requires permission for local writes when approval is on-request", () => {
     const decision = decideHostToolExecution({
       tool: makeTool({ permissionLevel: "write_local", isReadOnly: false }),

--- a/src/tools/__tests__/executor.test.ts
+++ b/src/tools/__tests__/executor.test.ts
@@ -625,7 +625,7 @@ describe("ToolExecutor", () => {
     });
   });
 
-  describe("Expanded shell injection patterns", () => {
+  describe("Shell sanitizer typed policy fallback", () => {
     function createShellExecutor() {
       const shellTool = createMockTool({
         name: "shell",
@@ -654,10 +654,17 @@ describe("ToolExecutor", () => {
       return { executor };
     }
 
-    it.each(["&&", "||", "> /", ">> "])("blocks pattern %s in shell command", async (pattern) => {
+    it.each([
+      "ls && rm dangerous",
+      "ls || sudo reboot",
+      "echo $(pwd)",
+      "echo `pwd`",
+      "echo \"$(pwd)\"",
+      "echo \"`pwd`\"",
+    ])("blocks denied shell command %s", async (command) => {
       const { executor } = createShellExecutor();
       const ctx = createMockContext({ trustBalance: 100 });
-      const result = await executor.execute("shell", { value: "x", command: `ls ${pattern} dangerous` }, ctx);
+      const result = await executor.execute("shell", { value: "x", command }, ctx);
       expect(result.success).toBe(false);
       expect(result.error).toContain("sanitization failed");
     });

--- a/src/tools/executor.ts
+++ b/src/tools/executor.ts
@@ -16,6 +16,7 @@ import {
   decideHostToolExecution,
   permissionResultFromHostDecision,
 } from "./execution-orchestrator.js";
+import { assessShellCommand } from "./system/ShellTool/command-policy.js";
 
 /**
  * 5-gate execution pipeline for tool invocations.
@@ -131,7 +132,7 @@ export class ToolExecutor {
     }
 
     // --- Gate 4: Input Sanitization ---
-    const sanitizeError = this.sanitizeInput(tool, input);
+    const sanitizeError = this.sanitizeInput(tool, input, context);
     if (sanitizeError) {
       return this.failResult(
         `Input sanitization failed: ${sanitizeError}`,
@@ -257,17 +258,13 @@ export class ToolExecutor {
     );
   }
 
-  private sanitizeInput(tool: ITool, input: unknown): string | null {
+  private sanitizeInput(tool: ITool, input: unknown, context: ToolCallContext): string | null {
     if (tool.metadata.name === "shell" && typeof input === "object" && input !== null) {
       const obj = input as Record<string, unknown>;
       const cmd = obj["command"];
       if (typeof cmd === "string") {
-        const dangerous = ["; rm ", "; curl ", "| bash", "eval ", "$(", "\`", "&&", "||", "> /", ">> ", "\n"];
-        for (const pattern of dangerous) {
-          if (cmd.includes(pattern)) {
-            return `Potentially dangerous shell command detected: "${pattern}"`;
-          }
-        }
+        const assessment = assessShellCommand(cmd, context.executionPolicy, context.trusted === true, context.cwd);
+        if (assessment.status === "denied") return assessment.reason ?? "Shell command denied by policy";
       }
     }
 

--- a/src/tools/system/ShellCommandTool/ShellCommandTool.ts
+++ b/src/tools/system/ShellCommandTool/ShellCommandTool.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { ITool, PermissionCheckResult, ToolCallContext, ToolMetadata, ToolResult } from "../../types.js";
 import { ShellTool } from "../ShellTool/ShellTool.js";
+import { containsShellExecutable } from "../ShellTool/command-policy.js";
 
 export const ShellCommandInputSchema = z.object({
   command: z.string().min(1),
@@ -27,7 +28,7 @@ export class ShellCommandTool implements ITool<ShellCommandInput> {
   }
 
   async call(input: ShellCommandInput, context: ToolCallContext): Promise<ToolResult> {
-    if (input.command.includes("apply_patch")) {
+    if (containsShellExecutable(input.command, "apply_patch")) {
       return {
         success: false,
         data: null,

--- a/src/tools/system/ShellTool/ShellTool.ts
+++ b/src/tools/system/ShellTool/ShellTool.ts
@@ -4,7 +4,7 @@ import { execFileNoThrow } from "../../../base/utils/execFileNoThrow.js";
 import { expandTildePath } from "../../fs/FileValidationTool/protected-path-policy.js";
 import { DESCRIPTION } from "./prompt.js";
 import { TAGS, MAX_OUTPUT_CHARS, PERMISSION_LEVEL } from "./constants.js";
-import { assessShellCommand } from "./command-policy.js";
+import { assessShellCommand, isReadOnlyShellCommand } from "./command-policy.js";
 import { resolveWorkspaceCwd } from "../../workspace-scope.js";
 
 export const ShellInputSchema = z.object({
@@ -91,12 +91,6 @@ export class ShellTool implements ITool<ShellInput, ShellOutput> {
   }
 
   isConcurrencySafe(input: ShellInput): boolean {
-    const cmd = input.command.trim();
-    const readOnlyPatterns = [
-      /^(cat|head|tail|wc|ls|pwd|echo|date)/,
-      /^git\s+(status|log|diff|show|branch)/,
-      /^rg\s/, /^find\s/,
-    ];
-    return readOnlyPatterns.some((re) => re.test(cmd));
+    return isReadOnlyShellCommand(input.command);
   }
 }

--- a/src/tools/system/ShellTool/__tests__/ShellTool.test.ts
+++ b/src/tools/system/ShellTool/__tests__/ShellTool.test.ts
@@ -68,9 +68,9 @@ describe("ShellTool", () => {
       expect(result.status).toBe("denied");
     });
 
-    it("denies compound command with mkdir", async () => {
+    it("requires approval for compound commands with local writes", async () => {
       const result = await tool.checkPermissions({ command: "ls ; mkdir newdir", timeoutMs: 120_000 });
-      expect(result.status).toBe("denied");
+      expect(result.status).toBe("needs_approval");
     });
 
     it("needs_approval for unknown command", async () => {
@@ -78,9 +78,9 @@ describe("ShellTool", () => {
       expect(result.status).toBe("needs_approval");
     });
 
-    it("denies redirect operator", async () => {
+    it("requires approval for output redirection", async () => {
       const result = await tool.checkPermissions({ command: "echo hello > file.txt", timeoutMs: 120_000 });
-      expect(result.status).toBe("denied");
+      expect(result.status).toBe("needs_approval");
     });
 
     describe("trusted mode", () => {
@@ -93,43 +93,43 @@ describe("ShellTool", () => {
         trusted: true,
       };
 
-      it("allows normally-denied commands when trusted", async () => {
+      it("does not bypass approval for local writes when trusted", async () => {
         const result = await tool.checkPermissions(
           { command: "npm run build", timeoutMs: 120_000 },
           trustedCtx,
         );
-        expect(result.status).toBe("allowed");
+        expect(result.status).toBe("needs_approval");
       });
 
-      it("allows git push when trusted", async () => {
+      it("does not bypass destructive denial when trusted", async () => {
         const result = await tool.checkPermissions(
           { command: "git push origin main", timeoutMs: 120_000 },
           trustedCtx,
         );
-        expect(result.status).toBe("allowed");
+        expect(result.status).toBe("denied");
       });
 
-      it("still denies redirect operators even when trusted", async () => {
+      it("still requires approval for redirect operators when trusted", async () => {
         const result = await tool.checkPermissions(
           { command: "echo hello > file.txt", timeoutMs: 120_000 },
           trustedCtx,
         );
-        expect(result.status).toBe("denied");
+        expect(result.status).toBe("needs_approval");
       });
 
-      it("still denies pipe injection even when trusted", async () => {
+      it("still routes pipe writes to approval even when trusted", async () => {
         const result = await tool.checkPermissions(
           { command: "cat foo | tee bar", timeoutMs: 120_000 },
           trustedCtx,
         );
-        expect(result.status).toBe("denied");
+        expect(result.status).toBe("needs_approval");
       });
 
-      it("still denied without trusted flag", async () => {
+      it("still requires approval without trusted flag", async () => {
         const result = await tool.checkPermissions(
           { command: "npm run build", timeoutMs: 120_000 },
         );
-        expect(result.status).toBe("denied");
+        expect(result.status).toBe("needs_approval");
       });
     });
   });
@@ -155,8 +155,8 @@ describe("ShellTool", () => {
       expect(tool.isConcurrencySafe({ command: "ps aux", timeoutMs: 120_000 })).toBe(false);
     });
 
-    it("returns false for npm ls (not in readOnly patterns)", () => {
-      expect(tool.isConcurrencySafe({ command: "npm ls", timeoutMs: 120_000 })).toBe(false);
+    it("returns true for typed read-only npm metadata", () => {
+      expect(tool.isConcurrencySafe({ command: "npm ls", timeoutMs: 120_000 })).toBe(true);
     });
   });
 

--- a/src/tools/system/ShellTool/command-policy.ts
+++ b/src/tools/system/ShellTool/command-policy.ts
@@ -2,125 +2,115 @@ import { isAbsolute, resolve } from "node:path";
 import type { ExecutionPolicy } from "../../../orchestrator/execution/agent-loop/execution-policy.js";
 import { isPathInsideProtectedRoots } from "../../../orchestrator/execution/agent-loop/self-protection.js";
 
+export interface ShellCommandCapabilities {
+  readOnly: boolean;
+  localWrite: boolean;
+  network: boolean;
+  destructive: boolean;
+  protectedTarget: boolean;
+}
+
 export interface ShellCommandAssessment {
   status: "allowed" | "needs_approval" | "denied";
   reason?: string;
-  capabilities: {
-    readOnly: boolean;
-    localWrite: boolean;
-    network: boolean;
-    destructive: boolean;
-    protectedTarget: boolean;
-  };
+  capabilities: ShellCommandCapabilities;
 }
 
-const SAFE_PATTERNS = [
-  /^(cat|head|tail|wc|ls|pwd|echo|date|hostname|which|type|file)\b/,
-  /^git\s+(status|log|diff|show|branch|rev-parse|rev-list|describe|tag\s+-l)\b/,
-  /^npm\s+(ls|list|view|info|outdated|audit)\b/,
-  /^npx\s+vitest\s+(run|list|--reporter)\b/,
-  /^npx\s+tsc\s+--noemit\b/i,
-  /^rg\b/, /^find\b/, /^du\b/, /^df\b/, /^tree\b/,
-];
+type ShellToken =
+  | { kind: "word"; value: string }
+  | { kind: "operator"; value: ShellOperator };
 
-const LOCAL_WRITE_PATTERNS = [
-  /\brm\b/, /\bmv\b/, /\bcp\b/, /\bmkdir\b/, /\btouch\b/, /\bchmod\b/, /\bchown\b/,
-  /\bsed\s+-i\b/, /\bperl\s+-i\b/, /\btee\b/, />/, /\bapply_patch\b/,
-  /\bgit\s+(apply|checkout|restore)\b/,
-  /\bnpm\s+(install|uninstall|run|exec)\b/,
-];
+type ShellOperator =
+  | "and"
+  | "or"
+  | "sequence"
+  | "pipe"
+  | "stdout_redirect"
+  | "stdout_append"
+  | "stderr_redirect"
+  | "stderr_append"
+  | "combined_redirect"
+  | "stdin_redirect";
 
-const NETWORK_PATTERNS = [
-  /\bcurl\b/, /\bwget\b/, /\bssh\b/, /\bscp\b/, /\brsync\b/, /\bpip\s+install\b/,
-  /\bnpm\s+(install|publish)\b/, /\bgit\s+(fetch|pull|push|clone)\b/,
-];
+interface ShellSimpleCommand {
+  executable: string;
+  args: string[];
+}
 
-const DESTRUCTIVE_PATTERNS = [
-  /\brm\b/, /\bmkfs\b/, /\bdd\s+if=/, /\bshutdown\b/, /\breboot\b/,
-  /\bgit\s+(push|commit|merge|rebase|reset|clean|stash)\b/,
-  /\bsudo\b/,
-];
+interface ShellCommandAnalysis {
+  commands: ShellSimpleCommand[];
+  pathTokens: string[];
+  capabilities: ShellCommandCapabilities;
+  unsupportedReason?: string;
+}
 
-const BLOCKED_PATTERNS = [
-  /\brm\b/, /\bmv\b/, /\bcp\b/, /\bmkdir\b/, /\btouch\b/, /\bchmod\b/, /\bchown\b/,
-  /\bgit\s+(push|commit|merge|rebase|reset|checkout|clean|stash)\b/,
-  /\bnpm\s+(install|uninstall|publish|run|exec)\b/,
-  /\bcurl\b/, /\bwget\b/, /\bsudo\b/, /\bmkfs\b/, /\bdd\s+if=/, /\bshutdown\b/, /\breboot\b/,
-];
+const READ_ONLY_COMMANDS = new Set([
+  "cat",
+  "head",
+  "tail",
+  "wc",
+  "ls",
+  "pwd",
+  "echo",
+  "date",
+  "hostname",
+  "which",
+  "type",
+  "file",
+  "rg",
+  "find",
+  "du",
+  "df",
+  "tree",
+]);
 
-const INJECTION_PATTERNS = [/>/, /\$\(/, /`/, /\|.*(tee|dd|rm|mv)\b/];
-const PROTECTED_TARGET_PATTERNS = [
-  /\.git\b/i,
-  /\.codex\b/i,
-  /\.agents\b/i,
-  /\.pulseed\b/i,
-  /\bagents\.md\b/i,
-  /\.env(\.[a-z0-9_-]+)?\b/i,
-  /\bnode_modules\b/i,
-  /\bpackage\.json\b/i,
-  /\btsconfig(\.[^/\s]+)?\.json\b/i,
-];
+const LOCAL_WRITE_COMMANDS = new Set([
+  "mv",
+  "cp",
+  "mkdir",
+  "touch",
+  "chmod",
+  "chown",
+  "tee",
+  "apply_patch",
+]);
+
+const NETWORK_COMMANDS = new Set(["curl", "wget", "ssh", "scp", "rsync"]);
+const DESTRUCTIVE_COMMANDS = new Set(["rm", "mkfs", "dd", "shutdown", "reboot", "sudo"]);
+const GIT_READ_SUBCOMMANDS = new Set(["status", "log", "diff", "show", "branch", "rev-parse", "rev-list", "describe"]);
+const GIT_WRITE_SUBCOMMANDS = new Set(["apply", "checkout", "restore"]);
+const GIT_NETWORK_SUBCOMMANDS = new Set(["fetch", "pull", "clone"]);
+const GIT_DESTRUCTIVE_SUBCOMMANDS = new Set(["push", "commit", "merge", "rebase", "reset", "clean", "stash"]);
+const NPM_READ_SUBCOMMANDS = new Set(["ls", "list", "view", "info", "outdated", "audit"]);
+const NPM_WRITE_SUBCOMMANDS = new Set(["uninstall", "run", "exec"]);
+const NPM_NETWORK_SUBCOMMANDS = new Set(["install", "publish"]);
 
 export function assessShellCommand(
   command: string,
   policy?: ExecutionPolicy,
-  trusted = false,
+  _trusted = false,
   cwd?: string,
 ): ShellCommandAssessment {
-  const trimmed = command.trim();
-  const segments = trimmed.split(/\s*(?:&&|\|\||;)\s*/).map((segment) => segment.trim()).filter(Boolean);
-  const capabilities = {
-    readOnly: true,
-    localWrite: false,
-    network: false,
-    destructive: false,
-    protectedTarget: false,
-  };
+  const analysis = analyzeShellCommand(command);
+  const capabilities = { ...analysis.capabilities };
 
-  for (const segment of segments) {
-    if (INJECTION_PATTERNS.some((pattern) => pattern.test(segment))) {
-      return {
-        status: "denied",
-        reason: `Denied command segment (injection risk): ${segment}`,
-        capabilities,
-      };
-    }
-
-    const isSafe = SAFE_PATTERNS.some((pattern) => pattern.test(segment));
-    const writes = LOCAL_WRITE_PATTERNS.some((pattern) => pattern.test(segment));
-    const network = NETWORK_PATTERNS.some((pattern) => pattern.test(segment));
-    const destructive = DESTRUCTIVE_PATTERNS.some((pattern) => pattern.test(segment));
-    const protectedTarget = PROTECTED_TARGET_PATTERNS.some((pattern) => pattern.test(segment));
-
-    if (!isSafe) capabilities.readOnly = false;
-    if (writes) capabilities.localWrite = true;
-    if (network) capabilities.network = true;
-    if (destructive) capabilities.destructive = true;
-    if (protectedTarget) capabilities.protectedTarget = true;
-  }
-
-  if ((capabilities.localWrite || !capabilities.readOnly) && targetsProtectedRoot(trimmed, policy, cwd)) {
-    return { status: "denied", reason: "Shell command would mutate a protected PulSeed source root", capabilities };
-  }
-
-  if (trusted && !capabilities.protectedTarget) {
-    return { status: "allowed", capabilities };
-  }
-
-  if (segments.some((segment) => INJECTION_PATTERNS.some((pattern) => pattern.test(segment)))) {
+  if (analysis.unsupportedReason) {
     return {
       status: "denied",
-      reason: `Denied command segment (injection risk): ${segments.find((segment) => INJECTION_PATTERNS.some((pattern) => pattern.test(segment)))}`,
+      reason: analysis.unsupportedReason,
       capabilities,
     };
   }
-  if (segments.some((segment) => BLOCKED_PATTERNS.some((pattern) => pattern.test(segment)))) {
-    return { status: "denied", reason: `Denied command segment: ${segments.find((segment) => BLOCKED_PATTERNS.some((pattern) => pattern.test(segment)))}`, capabilities };
+
+  if ((capabilities.localWrite || !capabilities.readOnly) && targetsProtectedRoot(analysis.pathTokens, policy, cwd)) {
+    capabilities.protectedTarget = true;
+    return { status: "denied", reason: "Shell command would mutate a protected PulSeed source root", capabilities };
   }
+
   if (capabilities.destructive) {
-    return { status: "denied", reason: "Denied command segment: destructive shell command", capabilities };
+    return { status: "denied", reason: "Denied destructive shell command", capabilities };
   }
-  if (capabilities.protectedTarget && capabilities.localWrite) {
+  if (capabilities.protectedTarget && (capabilities.localWrite || !capabilities.readOnly)) {
     return { status: "denied", reason: "Shell command targets a protected path", capabilities };
   }
   if (capabilities.network && policy && !policy.networkAccess) {
@@ -137,13 +127,13 @@ export function assessShellCommand(
   if (!policy) {
     return {
       status: capabilities.localWrite || capabilities.network || !capabilities.readOnly ? "needs_approval" : "allowed",
-      reason: capabilities.localWrite || capabilities.network || !capabilities.readOnly ? "Unknown command segment requires approval" : undefined,
+      reason: capabilities.localWrite || capabilities.network || !capabilities.readOnly ? "Shell command requires approval" : undefined,
       capabilities,
     };
   }
 
   const needsApproval = policy.approvalPolicy !== "never";
-  if (capabilities.localWrite || capabilities.network) {
+  if (capabilities.localWrite || capabilities.network || !capabilities.readOnly) {
     return {
       status: needsApproval ? "needs_approval" : "allowed",
       reason: needsApproval ? "Shell command requires approval under current execution policy" : undefined,
@@ -154,23 +144,384 @@ export function assessShellCommand(
   return { status: "allowed", capabilities };
 }
 
-function targetsProtectedRoot(command: string, policy: ExecutionPolicy | undefined, cwd: string | undefined): boolean {
+export function isReadOnlyShellCommand(command: string): boolean {
+  const assessment = assessShellCommand(command);
+  return assessment.status === "allowed"
+    && assessment.capabilities.readOnly
+    && !assessment.capabilities.localWrite
+    && !assessment.capabilities.network
+    && !assessment.capabilities.destructive
+    && !assessment.capabilities.protectedTarget;
+}
+
+export function containsShellExecutable(command: string, executable: string): boolean {
+  const analysis = analyzeShellCommand(command);
+  return analysis.commands.some((entry) => entry.executable === executable);
+}
+
+function analyzeShellCommand(command: string): ShellCommandAnalysis {
+  const tokenized = tokenizeShellCommand(command.trim());
+  const capabilities = emptyCapabilities();
+  if (tokenized.error) {
+    return { commands: [], pathTokens: [], capabilities, unsupportedReason: tokenized.error };
+  }
+
+  const commands: ShellSimpleCommand[] = [];
+  const pathTokens: string[] = [];
+  let currentWords: string[] = [];
+
+  const flushCommand = (): void => {
+    const simpleCommand = buildSimpleCommand(currentWords);
+    currentWords = [];
+    if (!simpleCommand) return;
+    commands.push(simpleCommand);
+    const commandCapabilities = classifySimpleCommand(simpleCommand);
+    mergeCapabilities(capabilities, commandCapabilities);
+    pathTokens.push(...collectPotentialPathTokens(simpleCommand));
+  };
+
+  for (let index = 0; index < tokenized.tokens.length; index += 1) {
+    const token = tokenized.tokens[index]!;
+    if (token.kind === "word") {
+      currentWords.push(token.value);
+      continue;
+    }
+
+    if (isCommandBoundary(token.value)) {
+      flushCommand();
+      continue;
+    }
+
+    if (isOutputRedirection(token.value)) {
+      capabilities.readOnly = false;
+      capabilities.localWrite = true;
+      const target = tokenized.tokens[index + 1];
+      if (target?.kind === "word") {
+        pathTokens.push(target.value);
+        index += 1;
+      }
+      continue;
+    }
+
+    if (token.value === "stdin_redirect") {
+      const target = tokenized.tokens[index + 1];
+      if (target?.kind === "word") {
+        pathTokens.push(target.value);
+        index += 1;
+      }
+    }
+  }
+
+  flushCommand();
+
+  return { commands, pathTokens, capabilities };
+}
+
+function tokenizeShellCommand(command: string): { tokens: ShellToken[]; error?: string } {
+  const tokens: ShellToken[] = [];
+  let current = "";
+  let quote: "'" | "\"" | null = null;
+
+  const pushWord = (): void => {
+    if (current.length === 0) return;
+    tokens.push({ kind: "word", value: current });
+    current = "";
+  };
+
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]!;
+    const next = command[index + 1];
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+        continue;
+      }
+      if (quote === "\"" && char === "`") {
+        return { tokens, error: "Shell command contains unsupported command substitution syntax" };
+      }
+      if (quote === "\"" && char === "$" && next === "(") {
+        return { tokens, error: "Shell command contains unsupported command substitution syntax" };
+      }
+      if (char === "\\" && next !== undefined) {
+        current += next;
+        index += 1;
+        continue;
+      }
+      current += char;
+      continue;
+    }
+
+    if (char === "'" || char === "\"") {
+      quote = char;
+      continue;
+    }
+    if (char === "\n" || char === "\r") {
+      return { tokens, error: "Shell command contains unsupported multiline syntax" };
+    }
+    if (char === "`") {
+      return { tokens, error: "Shell command contains unsupported command substitution syntax" };
+    }
+    if (char === "$" && next === "(") {
+      return { tokens, error: "Shell command contains unsupported command substitution syntax" };
+    }
+    if (char === "\\" && next !== undefined) {
+      current += next;
+      index += 1;
+      continue;
+    }
+    if (isShellWhitespace(char)) {
+      pushWord();
+      continue;
+    }
+    if (char === "&" && next === "&") {
+      pushWord();
+      tokens.push({ kind: "operator", value: "and" });
+      index += 1;
+      continue;
+    }
+    if (char === "|" && next === "|") {
+      pushWord();
+      tokens.push({ kind: "operator", value: "or" });
+      index += 1;
+      continue;
+    }
+    if (char === "|") {
+      pushWord();
+      tokens.push({ kind: "operator", value: "pipe" });
+      continue;
+    }
+    if (char === ";") {
+      pushWord();
+      tokens.push({ kind: "operator", value: "sequence" });
+      continue;
+    }
+    if (char === ">" || char === "<") {
+      const redirectedDescriptor = takeRedirectDescriptor(current);
+      if (redirectedDescriptor) {
+        tokens.push({ kind: "operator", value: redirectedDescriptor });
+        current = "";
+      } else {
+        pushWord();
+        tokens.push({ kind: "operator", value: redirectOperator(char, next) });
+      }
+      if (char === ">" && next === ">") {
+        index += 1;
+      }
+      continue;
+    }
+    if (char === "&" && next === ">") {
+      pushWord();
+      tokens.push({ kind: "operator", value: "combined_redirect" });
+      index += 1;
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (quote) {
+    return { tokens, error: "Shell command contains unterminated quoted text" };
+  }
+  pushWord();
+  return { tokens };
+}
+
+function redirectOperator(char: string, next: string | undefined): ShellOperator {
+  if (char === "<") return "stdin_redirect";
+  return next === ">" ? "stdout_append" : "stdout_redirect";
+}
+
+function takeRedirectDescriptor(current: string): ShellOperator | null {
+  if (current === "1") return "stdout_redirect";
+  if (current === "2") return "stderr_redirect";
+  return null;
+}
+
+function isShellWhitespace(char: string): boolean {
+  return char === " " || char === "\t";
+}
+
+function isCommandBoundary(operator: ShellOperator): boolean {
+  return operator === "and" || operator === "or" || operator === "sequence" || operator === "pipe";
+}
+
+function isOutputRedirection(operator: ShellOperator): boolean {
+  return operator === "stdout_redirect"
+    || operator === "stdout_append"
+    || operator === "stderr_redirect"
+    || operator === "stderr_append"
+    || operator === "combined_redirect";
+}
+
+function buildSimpleCommand(words: string[]): ShellSimpleCommand | null {
+  let executableIndex = 0;
+  while (executableIndex < words.length && isEnvironmentAssignment(words[executableIndex]!)) {
+    executableIndex += 1;
+  }
+  const executable = words[executableIndex];
+  if (!executable) return null;
+  return {
+    executable,
+    args: words.slice(executableIndex + 1),
+  };
+}
+
+function isEnvironmentAssignment(value: string): boolean {
+  const equalsIndex = value.indexOf("=");
+  if (equalsIndex <= 0) return false;
+  const key = value.slice(0, equalsIndex);
+  if (key.length === 0) return false;
+  return [...key].every((char, index) =>
+    char === "_" || isAsciiAlpha(char) || (index > 0 && isAsciiDigit(char))
+  );
+}
+
+function classifySimpleCommand(command: ShellSimpleCommand): ShellCommandCapabilities {
+  if (command.executable.indexOf("/") >= 0) return unknownCapabilities();
+  if (READ_ONLY_COMMANDS.has(command.executable)) {
+    if (command.executable === "find" && command.args.some(isFindMutationOption)) return localWriteCapabilities();
+    return readOnlyCapabilities();
+  }
+  if (LOCAL_WRITE_COMMANDS.has(command.executable)) return localWriteCapabilities();
+  if (NETWORK_COMMANDS.has(command.executable)) return networkCapabilities();
+  if (DESTRUCTIVE_COMMANDS.has(command.executable)) return destructiveCapabilities();
+
+  switch (command.executable) {
+    case "git":
+      return classifyGitCommand(command.args);
+    case "npm":
+      return classifyNpmCommand(command.args);
+    case "npx":
+      return classifyNpxCommand(command.args);
+    case "pip":
+    case "pip3":
+      return command.args[0] === "install" ? networkCapabilities({ localWrite: true }) : unknownCapabilities();
+    case "sed":
+    case "perl":
+      return command.args.some(isInPlaceEditOption) ? localWriteCapabilities() : unknownCapabilities();
+    default:
+      return unknownCapabilities();
+  }
+}
+
+function classifyGitCommand(args: string[]): ShellCommandCapabilities {
+  const subcommand = args[0];
+  if (!subcommand) return unknownCapabilities();
+  if (GIT_READ_SUBCOMMANDS.has(subcommand)) return readOnlyCapabilities();
+  if (subcommand === "tag" && (args.length === 1 || args[1] === "-l" || args[1] === "--list")) return readOnlyCapabilities();
+  if (GIT_WRITE_SUBCOMMANDS.has(subcommand)) return localWriteCapabilities();
+  if (GIT_NETWORK_SUBCOMMANDS.has(subcommand)) return networkCapabilities();
+  if (GIT_DESTRUCTIVE_SUBCOMMANDS.has(subcommand)) {
+    return destructiveCapabilities({ network: subcommand === "push" });
+  }
+  return unknownCapabilities();
+}
+
+function classifyNpmCommand(args: string[]): ShellCommandCapabilities {
+  const subcommand = args[0];
+  if (!subcommand) return unknownCapabilities();
+  if (NPM_READ_SUBCOMMANDS.has(subcommand)) return readOnlyCapabilities();
+  if (NPM_WRITE_SUBCOMMANDS.has(subcommand)) return localWriteCapabilities();
+  if (NPM_NETWORK_SUBCOMMANDS.has(subcommand)) return networkCapabilities({ localWrite: true });
+  return unknownCapabilities();
+}
+
+function classifyNpxCommand(args: string[]): ShellCommandCapabilities {
+  const executable = args[0];
+  const subcommand = args[1];
+  if (executable === "vitest" && (subcommand === "run" || subcommand === "list" || subcommand === "--reporter")) {
+    return readOnlyCapabilities();
+  }
+  if (executable === "tsc" && args.some(isNoEmitOption)) return readOnlyCapabilities();
+  return unknownCapabilities();
+}
+
+function isFindMutationOption(arg: string): boolean {
+  return arg === "-delete" || arg === "-exec" || arg === "-execdir" || arg === "-ok" || arg === "-okdir";
+}
+
+function isInPlaceEditOption(arg: string): boolean {
+  return arg === "-i" || arg.startsWith("-i.");
+}
+
+function isNoEmitOption(arg: string): boolean {
+  return arg.toLowerCase() === "--noemit";
+}
+
+function collectPotentialPathTokens(command: ShellSimpleCommand): string[] {
+  return command.args.filter((arg) => arg.length > 0 && !arg.startsWith("-"));
+}
+
+function emptyCapabilities(): ShellCommandCapabilities {
+  return {
+    readOnly: true,
+    localWrite: false,
+    network: false,
+    destructive: false,
+    protectedTarget: false,
+  };
+}
+
+function readOnlyCapabilities(): ShellCommandCapabilities {
+  return emptyCapabilities();
+}
+
+function unknownCapabilities(): ShellCommandCapabilities {
+  return {
+    ...emptyCapabilities(),
+    readOnly: false,
+  };
+}
+
+function localWriteCapabilities(overrides: Partial<ShellCommandCapabilities> = {}): ShellCommandCapabilities {
+  return {
+    ...unknownCapabilities(),
+    localWrite: true,
+    ...overrides,
+  };
+}
+
+function networkCapabilities(overrides: Partial<ShellCommandCapabilities> = {}): ShellCommandCapabilities {
+  return {
+    ...unknownCapabilities(),
+    network: true,
+    ...overrides,
+  };
+}
+
+function destructiveCapabilities(overrides: Partial<ShellCommandCapabilities> = {}): ShellCommandCapabilities {
+  return {
+    ...unknownCapabilities(),
+    destructive: true,
+    ...overrides,
+  };
+}
+
+function mergeCapabilities(target: ShellCommandCapabilities, source: ShellCommandCapabilities): void {
+  target.readOnly = target.readOnly && source.readOnly;
+  target.localWrite = target.localWrite || source.localWrite;
+  target.network = target.network || source.network;
+  target.destructive = target.destructive || source.destructive;
+  target.protectedTarget = target.protectedTarget || source.protectedTarget;
+}
+
+function targetsProtectedRoot(pathTokens: string[], policy: ExecutionPolicy | undefined, cwd: string | undefined): boolean {
   if (!policy?.protectedPaths || policy.protectedPaths.length === 0) return false;
   const effectiveCwd = cwd ?? policy.workspaceRoot;
   if (isPathInsideProtectedRoots(effectiveCwd, policy.protectedPaths)) return true;
-  return extractPathLikeTokens(command).some((token) => {
+  return pathTokens.some((token) => {
     const resolved = isAbsolute(token) ? token : resolve(effectiveCwd, token);
     return isPathInsideProtectedRoots(resolved, policy.protectedPaths);
   });
 }
 
-function extractPathLikeTokens(command: string): string[] {
-  return command
-    .split(/\s+/)
-    .map((token) => token.replace(/^['"]|['"]$/g, ""))
-    .filter((token) =>
-      token.length > 0
-      && !token.startsWith("-")
-      && (token.startsWith("/") || token.startsWith("./") || token.startsWith("../") || token.includes("/"))
-    );
+function isAsciiAlpha(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+function isAsciiDigit(char: string): boolean {
+  const code = char.charCodeAt(0);
+  return code >= 48 && code <= 57;
 }

--- a/tmp/issue-1120-semantic-purge-remaining-status.md
+++ b/tmp/issue-1120-semantic-purge-remaining-status.md
@@ -1,0 +1,105 @@
+# Issue #1120 Semantic Purge Remaining Status
+
+## Startup
+
+- Base repository synced to `origin/main` at `6d8b3842`.
+- Worktree: `/Users/yuyoshimuta/Documents/dev/PulSeed-worktrees/issue-1120-semantic-purge-remaining`.
+- PR #1159 is merged and present on `main`.
+- PR #1161 is merged and present on `main`; no open PRs were reported by `gh pr list --state open --limit 50`.
+- `tmp/wave1-semantic-purge-audit.md` is present and was read.
+
+## Child Issues
+
+- #1162 `refactor(semantic): route shell safety and TUI bang execution through typed tool policy`
+  - Parent: #1120
+  - Risk lane: auth-security + runtime-state
+  - Execution lane: serial
+  - Mode: independent PR
+- #1163 `refactor(semantic): replace agent-loop command-result evidence classification with typed tool/result metadata`
+  - Parent: #1120
+  - Risk lane: shared-api-schema + runtime-state
+  - Execution lane: serial
+  - Mode: independent PR after checking #1159 is on main
+- #1164 `refactor(semantic): replace agent-loop error-text fallback with typed failure reasons`
+  - Parent: #1120
+  - Risk lane: runtime-state
+  - Execution lane: serial
+  - Mode: independent PR
+- #1165 `refactor(semantic): replace chat context keyword grep with typed context query planning`
+  - Parent: #1120
+  - Risk lane: shared-api-schema
+  - Execution lane: serial
+  - Mode: independent PR
+- #1166 `refactor(semantic): remove runtime typed-field text fallbacks`
+  - Parent: #1120
+  - Risk lane: runtime-state
+  - Execution lane: serial
+  - Mode: independent PR
+- #1167 `refactor(semantic): type artifact retention metadata before cleanup decisions`
+  - Parent: #1120
+  - Risk lane: persistence-migration + runtime-state
+  - Execution lane: serial
+  - Mode: independent PR, or blocked if a shared artifact schema migration is required
+
+## Active Slice: #1162
+
+- Branch: `codex/issue-1162-shell-policy`
+- Base branch: `main`
+- Base SHA at start: `6d8b3842932a54a9d4b917ca8f69e6c3585e9a50`
+
+Implementation plan:
+
+1. Replace regex shell safety lists in `src/tools/system/ShellTool/command-policy.ts` with a deterministic command analyzer that emits typed capabilities for read-only, local-write, network, destructive, and protected-target outcomes.
+2. Reuse the typed analyzer from `ShellTool`, `ShellCommandTool`, `ToolExecutor` sanitization, `ShellTool.isConcurrencySafe`, and TUI/CLI safe-shell allow rules.
+3. Remove the direct trusted/preapproved TUI `!` path in `src/interface/tui/app.tsx`; execute `!` commands through `ToolExecutor` with `preApproved: false`, a real approval adapter, and a default execution policy.
+4. Add focused tests for typed shell policy outcomes and a production TUI caller path that proves `resolveTuiInputAction` to `App` to `ToolExecutor` does not bypass approval.
+
+Implementation summary:
+
+- Replaced shipped regex safe/write/network/destructive shell policy lists with a deterministic shell-token analyzer that produces typed shell capabilities.
+- Routed `ShellTool.isConcurrencySafe`, TUI/CLI `isSafeBashCommand`, `ShellCommandTool` apply-patch blocking, and `ToolExecutor` shell sanitization through the same typed analyzer.
+- Removed direct trusted/preapproved `ShellTool.call` from TUI bang execution. TUI `!` commands now execute through `ToolExecutor` with `preApproved: false`, typed execution policy, and approval queue bridging.
+- Added TUI caller-path tests for safe read-only execution, approval-denied writes, and quoted command-substitution denial before approval/process execution.
+
+Review:
+
+- Fresh review found a P1 command-substitution bypass inside double quotes.
+- Fixed by rejecting `$(` and backticks inside double-quoted shell text, then added unit and TUI production-caller regression coverage.
+
+Validation:
+
+- `npx vitest run --config vitest.unit.config.ts src/tools/system/ShellTool/__tests__/ShellTool.test.ts src/tools/__tests__/execution-orchestrator.test.ts src/tools/__tests__/executor.test.ts src/tools/__tests__/workspace-actions.test.ts --reporter verbose` - passed, 84 tests.
+- `npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/app.test.ts src/interface/tui/__tests__/chat.test.ts --reporter verbose` - passed, 72 tests.
+- `npm run typecheck` - passed.
+- `npm run lint:boundaries` - passed with existing warnings only: 0 errors, 657 warnings.
+- `npm run test:changed` - passed: related unit 51 files passed / 3 skipped, 869 passed / 3 skipped; related integration 11 files passed, 132 passed; smoke 8 files passed, 204 passed.
+- `git diff --check` - passed.
+
+## PR Readiness Manifest
+
+- pr: pending
+  issues: [1162]
+  mode: independent
+  risk_lanes: [auth-security, runtime-state]
+  head_branch: codex/issue-1162-shell-policy
+  base_branch: main
+  base_sha_at_handoff: 8611d9272048e2147f0f22abf1c0a14c8e15307d
+  head_sha_at_handoff: unknown
+  stack_parent: none
+  stack_order: none
+  replay_required: false
+  replay_plan: none
+  replay_owner: none
+  validation:
+    - npx vitest run --config vitest.unit.config.ts src/tools/system/ShellTool/__tests__/ShellTool.test.ts src/tools/__tests__/execution-orchestrator.test.ts src/tools/__tests__/executor.test.ts src/tools/__tests__/workspace-actions.test.ts --reporter verbose: passed
+    - npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/app.test.ts src/interface/tui/__tests__/chat.test.ts --reporter verbose: passed
+    - npm run typecheck: passed
+    - npm run lint:boundaries: passed with existing warnings only
+    - npm run test:changed: passed
+    - git diff --check: passed
+  ci_state_observed: not-run
+  review_state_observed: findings-fixed
+  machine_review_signals: present
+  unresolved_risks: []
+  human_action_required: false
+  next_action: check-merge


### PR DESCRIPTION
Closes #1162
Refs #1120

## Summary
- Replace shipped shell safety regex/list classification with deterministic shell-token analysis that produces typed capabilities: `readOnly`, `localWrite`, `network`, `destructive`, and `protectedTarget`.
- Route TUI `!` shell execution through `ToolExecutor` and `ExecutionPolicy` instead of directly invoking `ShellTool` with trusted/pre-approved bypasses.
- Reuse the typed shell policy in the executor sanitizer and shell-command tool detection, with production caller-path coverage for safe read-only, approval-denied write, and quoted command-substitution denial.

## Risk lane and execution lane
- Risk lane: auth-security + runtime-state
- Execution lane: serial
- Execution mode: independent PR

## Validation
- `npm run typecheck` - passed
- `npx vitest run --config vitest.unit.config.ts src/tools/system/ShellTool/__tests__/ShellTool.test.ts src/tools/__tests__/execution-orchestrator.test.ts src/tools/__tests__/executor.test.ts src/tools/__tests__/workspace-actions.test.ts --reporter verbose` - passed, 4 files / 84 tests
- `npx vitest run --config vitest.integration.config.ts src/interface/tui/__tests__/app.test.ts src/interface/tui/__tests__/chat.test.ts --reporter verbose` - passed, 2 files / 72 tests
- `npm run lint:boundaries` - passed with 0 errors and 658 existing warnings
- `npm run test:changed` - passed; changed-test runner fell back to fast unit lane, 442 files passed / 3 skipped, 7111 tests passed / 3 skipped; emitted existing `ps: process id too large: 999999999` line
- `git diff --check origin/main...HEAD` - passed
- GitHub CI `unit (22)` - passed
- GitHub CI `integration (24)` - passed

## Review
- Independent review found one material issue: command substitution inside double quotes could be classified read-only.
- Fixed by rejecting `$(` and backticks inside double-quoted shell tokens and adding unit plus TUI caller-path regressions.

## Known unresolved risks
- #1120 remains open. This PR completes only the shell policy/TUI bypass slice.
- Remaining #1120 slices are #1163, #1164, #1165, #1166, and #1167.
- Destructive cleanup behavior is not touched in this PR.

## Base/head
- Base SHA at handoff: `8611d9272048e2147f0f22abf1c0a14c8e15307d`
- Head SHA at handoff: `aeec86bacc78501b7047f5e6d04c5bb136c14933`

## PR readiness manifest
```yaml
pr: 1171
issues: [1162]
mode: independent
risk_lanes: [auth-security, runtime-state]
head_branch: codex/issue-1162-shell-policy
base_branch: main
base_sha_at_handoff: 8611d9272048e2147f0f22abf1c0a14c8e15307d
head_sha_at_handoff: aeec86bacc78501b7047f5e6d04c5bb136c14933
stack_parent: none
stack_order: none
replay_required: false
replay_plan: none
replay_owner: none
validation:
  - npm run typecheck: passed
  - focused unit Vitest shell/tool tests: passed
  - focused integration Vitest TUI tests: passed
  - npm run lint:boundaries: passed with 0 errors and 658 existing warnings
  - npm run test:changed: passed, fast unit fallback
  - git diff --check origin/main...HEAD: passed
  - GitHub CI unit (22): passed
  - GitHub CI integration (24): passed
ci_state_observed: passing
review_state_observed: findings-fixed
machine_review_signals: present
unresolved_risks:
  - '#1120 remains open; #1163-#1167 remain for later PRs.'
human_action_required: true
next_action: human-review
```
