### PR TITLE
fix(progress): reject stale artifact metrics

### DIFF
--- a/src/adapters/__tests__/artifact-metric-datasource.test.ts
+++ b/src/adapters/__tests__/artifact-metric-datasource.test.ts
@@ -104,6 +104,7 @@ describe("ArtifactMetricDataSourceAdapter", () => {
   it("updates CoreLoop-observed goal dimensions through ObservationEngine.observe", async () => {
     writeJson(path.join(workspace, "artifacts", "probe-balanced", "metrics.json"), {
       oof_balanced_accuracy: 0.88,
+      status: "completed",
     });
     const stateManager = new StateManager(tmpDir);
     const goal = makeGoal({
@@ -241,6 +242,54 @@ describe("ArtifactMetricDataSourceAdapter", () => {
           path: "artifacts/old/metrics.json",
         },
       ],
+    });
+  });
+
+  it("requires completed current-progress artifacts unless live progress is explicitly allowed", async () => {
+    writeJson(path.join(workspace, "artifacts", "live", "metrics.json"), {
+      score: 0.7,
+      status: "running",
+    });
+    const completedOnly = new ArtifactMetricDataSourceAdapter({
+      id: "completed-only-artifacts",
+      name: "Completed-only artifacts",
+      type: "artifact_metric",
+      connection: {
+        path: workspace,
+        current_progress_policy: "completed_fresh_only",
+        dimension_metrics: { best_score: ["score"] },
+        require_metric_match: true,
+      },
+      enabled: true,
+      created_at: new Date().toISOString(),
+    });
+
+    await expect(completedOnly.query({ dimension_name: "best_score", timeout_ms: 10000 }))
+      .rejects.toThrow(/No artifact metric found/);
+
+    const liveAllowed = new ArtifactMetricDataSourceAdapter({
+      id: "live-artifacts",
+      name: "Live artifacts",
+      type: "artifact_metric",
+      connection: {
+        path: workspace,
+        current_progress_policy: "allow_live",
+        dimension_metrics: { best_score: ["score"] },
+      },
+      enabled: true,
+      created_at: new Date().toISOString(),
+    });
+
+    const result = await liveAllowed.query({ dimension_name: "best_score", timeout_ms: 10000 });
+
+    expect(result.value).toBe(0.7);
+    expect(result.raw).toMatchObject({
+      discovery: {
+        current_progress_policy: "allow_live",
+      },
+      selected: {
+        relativePath: "artifacts/live/metrics.json",
+      },
     });
   });
 

--- a/src/adapters/datasources/artifact-metric-datasource.ts
+++ b/src/adapters/datasources/artifact-metric-datasource.ts
@@ -10,6 +10,8 @@ import type {
 import type { IDataSourceAdapter } from "../../platform/observation/data-source-adapter.js";
 
 type Aggregation = "max" | "min" | "count" | "file_count";
+type CurrentProgressPolicy = "legacy" | "completed_fresh_only" | "allow_live";
+type ArtifactLifecycleState = "completed" | "running" | "failed" | "unknown";
 
 interface MetricExtraction {
   key: string;
@@ -31,6 +33,9 @@ interface MetricObservation extends MetricCandidate {
   parser: "json";
   metrics: MetricExtraction[];
   extractionConfidence: number;
+  lifecycle: ArtifactLifecycle;
+  eligibleForCurrentProgress: boolean;
+  ineligibleReason: string | null;
 }
 
 interface SelectedMetric {
@@ -58,6 +63,12 @@ interface MetricConflict {
   }>;
 }
 
+interface ArtifactLifecycle {
+  state: ArtifactLifecycleState;
+  status: string | null;
+  success: boolean | null;
+}
+
 const BUILTIN_SOURCE_ID = "ds_builtin_workspace_artifacts";
 const DEFAULT_METRIC_FILE_NAMES = ["metrics.json", "result.json"];
 const DEFAULT_ARTIFACT_ROOTS = ["artifacts", "experiments", "runs", "reports", "outputs", "results", "logs"];
@@ -76,6 +87,7 @@ const DEFAULT_EXCLUDE_PATHS = new Set(["data/raw"]);
 const DEFAULT_MAX_METRIC_FILES = 5_000;
 const DEFAULT_MAX_ARTIFACT_FILES = 100_000;
 const DEFAULT_MAX_CANDIDATES = 200;
+const DEFAULT_GOAL_SCOPED_STALE_AFTER_MS = 24 * 60 * 60 * 1000;
 const MAX_RAW_CANDIDATES = 25;
 
 export function createWorkspaceArtifactMetricDataSource(workspacePath = process.cwd()): ArtifactMetricDataSourceAdapter {
@@ -104,6 +116,8 @@ export function createGoalWorkspaceArtifactMetricDataSource(
       dimension_metrics: dimensionMetrics,
       dimension_aggregations: dimensionAggregations,
       require_metric_match: true,
+      stale_after_ms: DEFAULT_GOAL_SCOPED_STALE_AFTER_MS,
+      current_progress_policy: "completed_fresh_only",
     },
     enabled: true,
     created_at: new Date().toISOString(),
@@ -177,11 +191,11 @@ export class ArtifactMetricDataSourceAdapter implements IDataSourceAdapter {
 
     const keys = resolveMetricKeys(params.dimension_name, expression, this.config);
     const candidates = await discoverMetricCandidates(root, options, keys);
-    const observations = await readMetricObservations(candidates);
+    const observations = await readMetricObservations(candidates, options);
     const evidenceCandidates = buildEvidenceCandidates(observations, keys, aggregation === "min" ? "min" : "max");
 
     if (aggregation === "count") {
-      const matched = observations.filter((observation) => hasAnyMetric(observation, keys));
+      const matched = observations.filter((observation) => observation.eligibleForCurrentProgress && hasAnyMetric(observation, keys));
       return {
         value: matched.length,
         raw: {
@@ -195,6 +209,7 @@ export class ArtifactMetricDataSourceAdapter implements IDataSourceAdapter {
           evidence_candidates: evidenceCandidates,
           conflicts: detectMetricConflicts(params.dimension_name, observations, keys),
           stale_candidates: staleRaw(observations),
+          ineligible_candidates: ineligibleRaw(observations),
           strategic_correctness: "not_evaluated",
         },
         timestamp,
@@ -222,6 +237,7 @@ export class ArtifactMetricDataSourceAdapter implements IDataSourceAdapter {
         evidence_candidates: evidenceCandidates,
         conflicts: detectMetricConflicts(params.dimension_name, observations, keys),
         stale_candidates: staleRaw(observations),
+        ineligible_candidates: ineligibleRaw(observations),
         strategic_correctness: "not_evaluated",
       },
       timestamp,
@@ -252,6 +268,7 @@ export class ArtifactMetricDataSourceAdapter implements IDataSourceAdapter {
       maxArtifactFiles: this.config.connection.max_artifact_files ?? DEFAULT_MAX_ARTIFACT_FILES,
       maxCandidates: this.config.connection.max_candidates ?? DEFAULT_MAX_CANDIDATES,
       staleAfterMs: this.config.connection.stale_after_ms,
+      currentProgressPolicy: this.config.connection.current_progress_policy ?? "legacy",
     };
   }
 }
@@ -267,6 +284,7 @@ interface ScanOptions {
   maxArtifactFiles: number;
   maxCandidates: number;
   staleAfterMs?: number;
+  currentProgressPolicy: CurrentProgressPolicy;
 }
 
 async function discoverMetricCandidates(root: string, options: ScanOptions, keys: string[]): Promise<MetricCandidate[]> {
@@ -397,18 +415,23 @@ function shouldSkipDirectory(name: string, relPath: string, options: ScanOptions
   return false;
 }
 
-async function readMetricObservations(candidates: MetricCandidate[]): Promise<MetricObservation[]> {
+async function readMetricObservations(candidates: MetricCandidate[], options: ScanOptions): Promise<MetricObservation[]> {
   const observations: MetricObservation[] = [];
   for (const candidate of candidates) {
     try {
       const parsed = JSON.parse(await fs.readFile(candidate.path, "utf8")) as unknown;
       const metrics = extractNumericMetrics(parsed);
       if (metrics.length > 0) {
+        const lifecycle = extractArtifactLifecycle(parsed);
+        const ineligibleReason = currentProgressIneligibleReason(candidate, lifecycle, options);
         observations.push({
           ...candidate,
           parser: "json",
           metrics,
           extractionConfidence: Math.max(...metrics.map((metric) => metric.confidence)),
+          lifecycle,
+          eligibleForCurrentProgress: ineligibleReason === null,
+          ineligibleReason,
         });
       }
     } catch {
@@ -459,6 +482,40 @@ function extractNumericMetrics(value: unknown): MetricExtraction[] {
   return metrics;
 }
 
+function extractArtifactLifecycle(value: unknown): ArtifactLifecycle {
+  if (!isRecord(value)) return { state: "unknown", status: null, success: null };
+
+  const status = typeof value["status"] === "string" ? value["status"] : null;
+  const success = booleanOrNull(value["success"]);
+  if (status === "running") return { state: "running", status, success };
+  if (status === "failed") return { state: "failed", status, success };
+  if (success === false) return { state: "failed", status, success };
+  if (status === "completed") return { state: "completed", status, success };
+  if (success === true) return { state: "completed", status, success };
+  return { state: "unknown", status, success };
+}
+
+function booleanOrNull(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function currentProgressIneligibleReason(
+  candidate: MetricCandidate,
+  lifecycle: ArtifactLifecycle,
+  options: ScanOptions,
+): string | null {
+  if (options.currentProgressPolicy === "legacy") return null;
+  if (candidate.stale) return "artifact is stale for current progress";
+  if (options.currentProgressPolicy === "allow_live") {
+    return lifecycle.state === "completed" || lifecycle.state === "running"
+      ? null
+      : `artifact lifecycle is ${lifecycle.state}`;
+  }
+  return lifecycle.state === "completed"
+    ? null
+    : `artifact lifecycle is ${lifecycle.state}`;
+}
+
 function addNumber(metrics: MetricExtraction[], key: string, keyPath: string, value: unknown, confidence: number): void {
   if (typeof value === "number" && Number.isFinite(value)) {
     metrics.push({ key, keyPath, value, confidence });
@@ -497,6 +554,7 @@ function matchingMetrics(observations: MetricObservation[], keys: string[]): Arr
   const wanted = new Set(keys);
   const matches: Array<{ observation: MetricObservation; metric: MetricExtraction }> = [];
   for (const observation of observations) {
+    if (!observation.eligibleForCurrentProgress) continue;
     for (const metric of observation.metrics) {
       if (wanted.size === 0 || wanted.has(metric.key)) {
         matches.push({ observation, metric });
@@ -589,6 +647,7 @@ function buildEvidenceCandidates(
       extraction_confidence: metric.confidence,
       candidate_score: observation.candidateScore,
       stale: observation.stale,
+      current_progress_eligible: observation.eligibleForCurrentProgress,
       reasons: observation.reasons,
       strategic_correctness: "not_evaluated",
     }));
@@ -615,6 +674,21 @@ function staleRaw(observations: MetricObservation[]): Array<Record<string, unkno
     }));
 }
 
+function ineligibleRaw(observations: MetricObservation[]): Array<Record<string, unknown>> {
+  return observations
+    .filter((observation) => !observation.eligibleForCurrentProgress)
+    .slice(0, MAX_RAW_CANDIDATES)
+    .map((observation) => ({
+      path: observation.relativePath,
+      updated_time: observation.updatedTime,
+      stale: observation.stale,
+      lifecycle_state: observation.lifecycle.state,
+      lifecycle_status: observation.lifecycle.status,
+      success: observation.lifecycle.success,
+      reason: observation.ineligibleReason,
+    }));
+}
+
 function discoveryRaw(options: ScanOptions): Record<string, unknown> {
   return {
     artifact_roots: options.artifactRoots,
@@ -624,6 +698,7 @@ function discoveryRaw(options: ScanOptions): Record<string, unknown> {
     max_candidates: options.maxCandidates,
     parser_hints: Array.from(options.parserHints),
     stale_after_ms: options.staleAfterMs ?? null,
+    current_progress_policy: options.currentProgressPolicy,
   };
 }
 

--- a/src/platform/observation/__tests__/observation-engine.test.ts
+++ b/src/platform/observation/__tests__/observation-engine.test.ts
@@ -1061,6 +1061,7 @@ describe("observeFromDataSource", () => {
     });
     writeJsonFile(path.join(goalWorkspace, "artifacts", "probe-balanced", "metrics.json"), {
       oof_balanced_accuracy: 0.88,
+      status: "completed",
     });
     const engine = new ObservationEngine(
       stateManager,
@@ -1101,6 +1102,101 @@ describe("observeFromDataSource", () => {
         key: "oof_balanced_accuracy",
       },
     });
+  });
+
+  it("does not accept stale goal-scoped artifact metrics as mechanical progress", async () => {
+    const goalWorkspace = path.join(tmpDir, "stale-metric-workspace");
+    const staleMetricPath = path.join(goalWorkspace, "experiments", "old-run", "metrics.json");
+    writeJsonFile(staleMetricPath, {
+      metric_name: "roc_auc",
+      cv_score: 0.99,
+      status: "completed",
+    });
+    const staleTime = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    fs.utimesSync(staleMetricPath, staleTime, staleTime);
+    const llmClient = makeMockLLMClient(0.31);
+    const engine = new ObservationEngine(
+      stateManager,
+      [],
+      llmClient,
+      async () => "workspace context exists",
+    );
+    const goal = makeGoal({
+      id: "goal-stale-artifact-metric",
+      constraints: [`workspace_path:${goalWorkspace}`],
+      dimensions: [
+        {
+          name: "roc_auc",
+          label: "ROC AUC",
+          current_value: 0,
+          threshold: { type: "min", value: 0.95 },
+          confidence: 0.5,
+          observation_method: defaultMethod,
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await stateManager.saveGoal(goal);
+
+    await engine.observe("goal-stale-artifact-metric", []);
+
+    const updated = await stateManager.loadGoal("goal-stale-artifact-metric");
+    expect(updated?.dimensions[0]?.current_value).toBe(0.31);
+    expect(updated?.dimensions[0]?.last_observed_layer).toBe("independent_review");
+    expect(llmClient.sendMessage).toHaveBeenCalled();
+    const log = await stateManager.loadObservationLog("goal-stale-artifact-metric");
+    expect(log?.entries[0]?.layer).toBe("independent_review");
+  });
+
+  it("does not accept running goal-scoped artifact metrics as mechanical progress", async () => {
+    const goalWorkspace = path.join(tmpDir, "running-metric-workspace");
+    writeJsonFile(path.join(goalWorkspace, "experiments", "live-run", "metrics.json"), {
+      metric_name: "roc_auc",
+      cv_score: 0.98,
+      status: "running",
+    });
+    const llmClient = makeMockLLMClient(0.27);
+    const engine = new ObservationEngine(
+      stateManager,
+      [],
+      llmClient,
+      async () => "workspace context exists",
+    );
+    const goal = makeGoal({
+      id: "goal-running-artifact-metric",
+      constraints: [`workspace_path:${goalWorkspace}`],
+      dimensions: [
+        {
+          name: "roc_auc",
+          label: "ROC AUC",
+          current_value: 0,
+          threshold: { type: "min", value: 0.95 },
+          confidence: 0.5,
+          observation_method: defaultMethod,
+          last_updated: new Date().toISOString(),
+          history: [],
+          weight: 1.0,
+          uncertainty_weight: null,
+          state_integrity: "ok",
+          dimension_mapping: null,
+        },
+      ],
+    });
+    await stateManager.saveGoal(goal);
+
+    await engine.observe("goal-running-artifact-metric", []);
+
+    const updated = await stateManager.loadGoal("goal-running-artifact-metric");
+    expect(updated?.dimensions[0]?.current_value).toBe(0.27);
+    expect(updated?.dimensions[0]?.last_observed_layer).toBe("independent_review");
+    expect(llmClient.sendMessage).toHaveBeenCalled();
+    const log = await stateManager.loadObservationLog("goal-running-artifact-metric");
+    expect(log?.entries[0]?.layer).toBe("independent_review");
   });
 
   it("falls back to LLM when the goal-scoped artifact metric is absent", async () => {

--- a/src/platform/observation/types/data-source.ts
+++ b/src/platform/observation/types/data-source.ts
@@ -37,6 +37,7 @@ export const DataSourceConfigSchema = z.object({
     max_artifact_files: z.number().int().positive().optional(),
     max_candidates: z.number().int().positive().optional(),
     stale_after_ms: z.number().int().positive().optional(),
+    current_progress_policy: z.enum(["legacy", "completed_fresh_only", "allow_live"]).optional(),
     dimension_metrics: z.record(z.string(), z.array(z.string())).optional(),
     dimension_aggregations: z.record(z.string(), z.enum(["max", "min", "count", "file_count"])).optional(),
     require_metric_match: z.boolean().optional(),


### PR DESCRIPTION
Closes #1148

## Implementation summary
- Added a typed artifact metric `current_progress_policy` contract with `legacy`, `completed_fresh_only`, and `allow_live` modes.
- Made goal-scoped auto artifact metric datasources default to `completed_fresh_only` with a 24h stale threshold.
- Excluded stale or lifecycle-ineligible metric files from current mechanical progress selection/counts while recording ineligible candidates and lifecycle state in raw evidence.
- Added ObservationEngine caller-path regressions for stale completed artifacts and `status: "running"` artifacts so they fall through instead of being applied as mechanical progress.
- Added adapter coverage for explicit `allow_live` opt-in.

## Verification commands
- `npm run test:unit -- src/platform/observation/__tests__/observation-engine.test.ts src/adapters/__tests__/artifact-metric-datasource.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (passes with existing warnings; 0 errors)
- `npm run test:changed`
- `git diff --check`

## Known unresolved risks
- Full suite was not run locally; `test:changed` covered 61 related files / 1168 tests.
- `file_count` / `durable_artifact_count` remains inventory-style evidence rather than lifecycle-filtered current metric evidence.

## Parallel PR dependency / incorporation status
- Related #1136 is still an open issue, not a PR; there was no merged #1136 PR to incorporate.
- `gh pr list --state open --limit 50` showed no open PRs before starting this issue.
- Branch was based on current `origin/main` including #1169.
