### PR TITLE
Fix agent loop tool budget exhaustion

### DIFF
--- a/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts
@@ -876,6 +876,147 @@ describe("agentloop phase 1", () => {
     expect(capturedSignalAborted).toBe(true);
   });
 
+  it("does not start mutating tools when the remaining wall-clock budget is exhausted", async () => {
+    const modelInfo = makeModelInfo();
+    let nowMs = 0;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(): Promise<AgentLoopModelResponse> {
+        nowMs = 60;
+        return {
+          content: "",
+          toolCalls: [{
+            id: "call-1",
+            name: "apply_patch",
+            input: {
+              patch: [
+                "*** Begin Patch",
+                "*** Add File: wall-clock-budget.txt",
+                "+patched",
+                "*** End Patch",
+              ].join("\n"),
+            },
+          }],
+          stopReason: "tool_use",
+        };
+      },
+    };
+    const registry = new ToolRegistry();
+    registry.register(new ApplyPatchTool());
+    const router = new ToolRegistryAgentLoopToolRouter(registry);
+    const runtime = {
+      executeBatch: vi.fn(async (): Promise<AgentLoopToolOutput[]> => {
+        throw new Error("mutating tool runtime should not be called");
+      }),
+    };
+    const session = createAgentLoopSession();
+    const runner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+
+    try {
+      const result = await runner.run({
+        session,
+        turnId: "turn-1",
+        goalId: "goal-1",
+        taskId: "task-1",
+        cwd: process.cwd(),
+        model: modelInfo.ref,
+        modelInfo,
+        messages: [{ role: "user", content: "patch it" }],
+        outputSchema: z.object({ status: z.literal("done"), finalAnswer: z.string() }),
+        budget: withDefaultBudget({ maxWallClockMs: 50, maxModelTurns: 4, maxToolCalls: 2 }),
+        toolPolicy: { allowedTools: ["apply_patch"] },
+        toolCallContext: {
+          cwd: process.cwd(),
+          goalId: "goal-1",
+          trustBalance: 0,
+          preApproved: true,
+          approvalFn: async () => false,
+        },
+      });
+
+      expect(runtime.executeBatch).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.stopReason).toBe("timeout");
+      expect(result.toolCalls).toBe(0);
+      expect(result.finalText).toContain("wall-clock budget is exhausted");
+      expect(result.finalText).not.toContain("Calling apply_patch");
+      const persisted = await session.stateStore.load();
+      expect(persisted?.finalText).toContain("wall-clock budget is exhausted");
+      expect(persisted?.finalText).not.toContain("Calling apply_patch");
+      const events = await session.traceStore.list(session.traceId);
+      expect(events.some((event) => event.type === "tool_call_started")).toBe(false);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("does not start mutating tools when remaining wall-clock is below the minimum budget", async () => {
+    const modelInfo = makeModelInfo();
+    let nowMs = 0;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    const modelClient: AgentLoopModelClient = {
+      async getModelInfo(): Promise<AgentLoopModelInfo> {
+        return modelInfo;
+      },
+      async createTurn(): Promise<AgentLoopModelResponse> {
+        nowMs = 100;
+        return {
+          content: "",
+          toolCalls: [{ id: "call-1", name: "apply_patch", input: { patch: "*** Begin Patch\n*** End Patch" } }],
+          stopReason: "tool_use",
+        };
+      },
+    };
+    const registry = new ToolRegistry();
+    registry.register(new ApplyPatchTool());
+    const router = new ToolRegistryAgentLoopToolRouter(registry);
+    const runtime = {
+      executeBatch: vi.fn(async (): Promise<AgentLoopToolOutput[]> => {
+        throw new Error("mutating tool runtime should not be called");
+      }),
+    };
+    const session = createAgentLoopSession();
+    const runner = new BoundedAgentLoopRunner({ modelClient, toolRouter: router, toolRuntime: runtime });
+
+    try {
+      const result = await runner.run({
+        session,
+        turnId: "turn-1",
+        goalId: "goal-1",
+        taskId: "task-1",
+        cwd: process.cwd(),
+        model: modelInfo.ref,
+        modelInfo,
+        messages: [{ role: "user", content: "patch it" }],
+        outputSchema: z.object({ status: z.literal("done"), finalAnswer: z.string() }),
+        budget: withDefaultBudget({ maxWallClockMs: 999, maxModelTurns: 4, maxToolCalls: 2 }),
+        toolPolicy: { allowedTools: ["apply_patch"] },
+        toolCallContext: {
+          cwd: process.cwd(),
+          goalId: "goal-1",
+          trustBalance: 0,
+          preApproved: true,
+          approvalFn: async () => false,
+        },
+      });
+
+      expect(runtime.executeBatch).not.toHaveBeenCalled();
+      expect(result.success).toBe(false);
+      expect(result.stopReason).toBe("timeout");
+      expect(result.toolCalls).toBe(0);
+      expect(result.finalText).toContain("below the 1000ms minimum");
+      expect(result.finalText).toContain("apply_patch");
+      expect(result.finalText).not.toContain("Calling apply_patch");
+      const events = await session.traceStore.list(session.traceId);
+      expect(events.some((event) => event.type === "tool_call_started")).toBe(false);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
   it("falls back to a text protocol when the LLM client cannot use native tools", async () => {
     const modelInfo = makeModelInfo({ capabilities: { ...defaultAgentLoopCapabilities, toolCalling: false } });
     const llmCalls: Array<{ messages: LLMMessage[]; options?: LLMRequestOptions }> = [];

--- a/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
+++ b/src/orchestrator/execution/agent-loop/bounded-agent-loop-runner.ts
@@ -76,6 +76,7 @@ const FILESYSTEM_SNAPSHOT_EXCLUDED_DIRS = new Set([
 ]);
 const FILESYSTEM_SNAPSHOT_MAX_FILES = 5_000;
 const FILESYSTEM_SNAPSHOT_HASH_MAX_BYTES = 1_000_000;
+const MIN_MUTATING_TOOL_BATCH_REMAINING_MS = 1_000;
 
 export class BoundedAgentLoopRunner {
   private readonly compactor: AgentLoopCompactor;
@@ -379,6 +380,11 @@ export class BoundedAgentLoopRunner {
         continue;
       }
 
+      const toolBatchBudgetRefusal = this.toolBatchBudgetRefusalReason(response.toolCalls, turn, startedAt);
+      if (toolBatchBudgetRefusal) {
+        return stop("timeout", startedAt, modelTurns, toolCalls, toolBatchBudgetRefusal, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts, toolBatchBudgetRefusal);
+      }
+
       messages.push({
         role: "assistant",
         content: response.content || `Calling ${response.toolCalls.map((call) => call.name).join(", ")}`,
@@ -415,6 +421,10 @@ export class BoundedAgentLoopRunner {
       }
 
       const { results: toolResults, timedOut: toolBatchTimedOut } = await this.executeToolBatchWithinBudget(response.toolCalls, turn, startedAt);
+      if (toolBatchTimedOut && toolResults.length === 0) {
+        const timeoutReason = this.formatToolBatchWallClockExhaustedReason(response.toolCalls, turn.budget.maxWallClockMs);
+        return stop("timeout", startedAt, modelTurns, toolCalls, timeoutReason, null, false, compactions, await this.collectChangedFiles(turn.cwd, initialWorkspaceSnapshot), toolResultSummaries, commandResults, messages, calledTools, lastToolLoopSignature, repeatedToolLoopCount, completionValidationAttempts, timeoutReason);
+      }
       for (const result of toolResults) {
         const sourceCall = response.toolCalls.find((call) => call.id === result.callId);
         const observation = this.createToolObservation(
@@ -752,7 +762,10 @@ export class BoundedAgentLoopRunner {
     turn: AgentLoopTurnContext<TOutput>,
     startedAt: number,
   ): Promise<{ results: Awaited<ReturnType<AgentLoopToolRuntime["executeBatch"]>>; timedOut: boolean }> {
-    const remainingMs = Math.max(1, turn.budget.maxWallClockMs - (Date.now() - startedAt));
+    const remainingMs = turn.budget.maxWallClockMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      return { results: [], timedOut: true };
+    }
     const controller = new AbortController();
     const parentSignal = turn.abortSignal;
     let timedOut = false;
@@ -783,6 +796,43 @@ export class BoundedAgentLoopRunner {
       clearTimeout(timer);
       parentSignal?.removeEventListener("abort", abortFromParent);
     }
+  }
+
+  private toolBatchBudgetRefusalReason<TOutput>(
+    calls: AgentLoopToolCall[],
+    turn: AgentLoopTurnContext<TOutput>,
+    startedAt: number,
+  ): string | null {
+    const remainingMs = turn.budget.maxWallClockMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) {
+      return this.formatToolBatchWallClockExhaustedReason(calls, turn.budget.maxWallClockMs);
+    }
+
+    const mutatingToolNames = calls
+      .filter((call) => this.isMutatingToolCall(call))
+      .map((call) => call.name);
+    if (mutatingToolNames.length === 0 || remainingMs >= MIN_MUTATING_TOOL_BATCH_REMAINING_MS) {
+      return null;
+    }
+
+    return [
+      "Tool batch was not started because the remaining wall-clock budget",
+      `(${Math.floor(remainingMs)}ms) is below the ${MIN_MUTATING_TOOL_BATCH_REMAINING_MS}ms minimum`,
+      `for mutating tools: ${[...new Set(mutatingToolNames)].join(", ")}.`,
+    ].join(" ");
+  }
+
+  private formatToolBatchWallClockExhaustedReason(calls: AgentLoopToolCall[], maxWallClockMs: number): string {
+    return [
+      "Tool batch was not started because the agent loop wall-clock budget is exhausted",
+      `(0ms remaining; limit ${maxWallClockMs}ms).`,
+      `Requested tools: ${calls.map((call) => call.name).join(", ")}.`,
+    ].join(" ");
+  }
+
+  private isMutatingToolCall(call: AgentLoopToolCall): boolean {
+    const metadata = this.deps.toolRouter.resolveTool(call.name)?.metadata;
+    return metadata?.isReadOnly !== true;
   }
 
   private responseUsageTokens(response: { usage?: { inputTokens: number; outputTokens: number } }): number | undefined {


### PR DESCRIPTION
## Summary

Fixes #1134.

- Refuse tool batches when the agent loop wall-clock budget is already exhausted before runtime execution starts.
- Refuse mutating tool batches when the remaining budget is below the minimum mutating-tool budget, using typed tool metadata (`isReadOnly`) instead of freeform tool-name matching.
- Persist the real wall-clock exhaustion/minimum-budget reason as the durable final text and stop detail, avoiding stale `Calling apply_patch` output.
- Remove the previous `Math.max(1, ...)` timeout floor so exhausted-budget races do not start tool runtime with a 1ms timeout.

## Verification

- `npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts -t "wall-clock"`
- `npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/agent-loop.test.ts`
- `npm run typecheck`
- `npm run lint:boundaries` (0 errors, existing warnings only)
- `npm run test:changed`
- `git diff --check`

## Review

- Fresh review agent `019dfdbf-67cb-7de2-97c1-78e6ebc7d226`: no material findings.
- Fresh review agent `019dfdc2-32af-7201-a052-0b889fdc8c2f`: no material findings.
