### PR TITLE
fix(agentloop): gate dirty worktree completion

### DIFF
--- a/src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts
@@ -148,6 +148,46 @@ function makeNativeTimeoutRunner(): TaskAgentLoopRunner {
   } as unknown as TaskAgentLoopRunner;
 }
 
+function makeNativeDirtyHandoffRunner(): TaskAgentLoopRunner {
+  const result: AgentLoopResult<TaskAgentLoopOutput> = {
+    success: true,
+    output: {
+      status: "done",
+      finalAnswer: "done in isolated worktree",
+      summary: "done",
+      filesChanged: ["tracked.txt"],
+      testsRun: [],
+      completionEvidence: ["model reported success"],
+      verificationHints: [],
+      blockers: [],
+    },
+    finalText: "done in isolated worktree",
+    stopReason: "completed",
+    elapsedMs: 100,
+    modelTurns: 1,
+    toolCalls: 1,
+    compactions: 0,
+    filesChanged: true,
+    changedFiles: ["tracked.txt"],
+    commandResults: [],
+    workspace: {
+      requestedCwd: "/repo",
+      executionCwd: "/worktrees/task-1",
+      isolated: true,
+      cleanupStatus: "kept",
+      cleanupReason: "worktree has changes",
+      dirty: true,
+      disposition: "handoff_required",
+    },
+    traceId: "trace-1",
+    sessionId: "session-1",
+    turnId: "turn-1",
+  };
+  return {
+    runTask: async () => result,
+  } as unknown as TaskAgentLoopRunner;
+}
+
 function makeGapVector(goalId: string, dimensionName: string): GapVector {
   return {
     goal_id: goalId,
@@ -490,6 +530,56 @@ describe("TaskLifecycle — persistence", () => {
       error: 0,
       unknown: 0,
       other: 0,
+    });
+  });
+
+  it("runTaskCycle returns and persists guarded fail verdict for dirty isolated worktree handoff", async () => {
+    const llm = createMockLLMClient([VALID_TASK_RESPONSE, LLM_REVIEW_PASS]);
+    const lifecycle = createLifecycle(llm, {
+      approvalFn: async () => true,
+      agentLoopRunner: makeNativeDirtyHandoffRunner(),
+      execFileSyncFn: () => "",
+    });
+    const adapter: import("../task/task-lifecycle.js").IAdapter = {
+      adapterType: "mock",
+      async execute() {
+        throw new Error("native path should not call adapter.execute");
+      },
+    };
+
+    const result = await lifecycle.runTaskCycle(
+      "goal-1",
+      makeGapVector("goal-1", "dim"),
+      makeDriveContext("dim"),
+      adapter
+    );
+
+    const ledger = await stateManager.readRaw(`tasks/goal-1/ledger/${result.task.id}.json`) as {
+      summary: Record<string, unknown>;
+      events: Array<Record<string, unknown>>;
+    };
+    const verification = await stateManager.readRaw(`verification/${result.task.id}/verification-result.json`) as Record<string, unknown>;
+
+    expect(result.action).toBe("escalate");
+    expect(result.verificationResult.verdict).toBe("fail");
+    expect(result.verificationResult.evidence[0]!.description).toContain("dirty isolated worktree retained");
+    expect(ledger.summary).toMatchObject({
+      latest_event_type: "abandoned",
+      task_status: "error",
+      verification_verdict: "fail",
+      action: "escalate",
+    });
+    expect(ledger.events.at(-1)!.reason).toContain("/worktrees/task-1");
+    expect(verification.verdict).toBe("fail");
+    expect(verification.evidence).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        layer: "mechanical",
+        description: expect.stringContaining("dirty isolated worktree retained"),
+      }),
+    ]));
+    expect(verification.agent_loop).toMatchObject({
+      isolatedWorkspace: true,
+      workspaceDisposition: "handoff_required",
     });
   });
 

--- a/src/orchestrator/execution/__tests__/task-lifecycle-execution.test.ts
+++ b/src/orchestrator/execution/__tests__/task-lifecycle-execution.test.ts
@@ -586,6 +586,50 @@ describe("TaskLifecycle", async () => {
   });
 
   describe("executeTaskWithAgentLoop", () => {
+    it("records dirty isolated worktree handoff as non-completed execution", async () => {
+      const llm = createMockLLMClient([]);
+      const lifecycle = createLifecycle(llm, {
+        agentLoopRunner: makeAgentLoopRunner(makeAgentLoopResult("completed", {
+          filesChanged: true,
+          changedFiles: ["README.md"],
+          workspace: {
+            requestedCwd: "/repo",
+            executionCwd: "/worktrees/task-1",
+            isolated: true,
+            cleanupStatus: "kept",
+            cleanupReason: "worktree has changes",
+            dirty: true,
+            disposition: "handoff_required",
+          },
+        })),
+        execFileSyncFn: () => "",
+      });
+      const task = makeTask();
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+
+      const result = await lifecycle.executeTaskWithAgentLoop(task, "workspace context", "knowledge context");
+
+      const persisted = await stateManager.readRaw(`tasks/${task.goal_id}/${task.id}.json`) as Record<string, unknown>;
+      const ledger = await stateManager.readRaw(`tasks/${task.goal_id}/ledger/${task.id}.json`) as {
+        events: Array<Record<string, unknown>>;
+        summary: Record<string, unknown>;
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.stopped_reason).toBe("error");
+      expect(result.output).toContain("/worktrees/task-1");
+      expect(result.agentLoop).toMatchObject({
+        isolatedWorkspace: true,
+        workspaceDirty: true,
+        workspaceDisposition: "handoff_required",
+      });
+      expect(persisted.status).toBe("error");
+      expect(persisted.completed_at).toBeNull();
+      expect(ledger.events.map((event) => event.type)).toEqual(["started", "failed"]);
+      expect(ledger.events.at(-1)!.reason).toContain("operator handoff");
+      expect(ledger.summary.task_status).toBe("error");
+    });
+
     it.each([
       {
         stopReason: "timeout" as const,

--- a/src/orchestrator/execution/__tests__/task-verifier-guards.test.ts
+++ b/src/orchestrator/execution/__tests__/task-verifier-guards.test.ts
@@ -509,6 +509,107 @@ describe("attemptRevert safety", () => {
     }
   });
 
+  it("does not revert the requested workspace when dirty isolated worktree handoff is required", async () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "attempt-revert-repo-"));
+    initGitRepo(repoDir);
+    fs.writeFileSync(path.join(repoDir, "tracked.txt"), "requested workspace local change\n", "utf-8");
+    const isolatedWorktree = path.join(tmpDir, "isolated-worktree");
+    fs.mkdirSync(isolatedWorktree, { recursive: true });
+
+    const deps: VerifierDeps = {
+      stateManager,
+      llmClient: createMockLLMClient([]),
+      sessionManager,
+      trustManager,
+      stallDetector,
+      durationToMs: (d) => d.value * (d.unit === "hours" ? 3600000 : 60000),
+      revertCwd: repoDir,
+    };
+    const task = makeTask({
+      scope_boundary: { in_scope: ["tracked.txt"], out_of_scope: [], blast_radius: "low" },
+      reversibility: "reversible",
+    });
+
+    try {
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+      const result = await handleFailure(deps, task, makeFailureVerificationResult(["tracked.txt"]), {
+        stoppedReason: "error",
+        agentLoopWorkspace: {
+          requestedCwd: repoDir,
+          executionCwd: isolatedWorktree,
+          isolatedWorkspace: true,
+          workspaceCleanupStatus: "kept",
+          workspaceCleanupReason: "worktree has changes",
+          workspaceDirty: true,
+          workspaceDisposition: "handoff_required",
+        },
+      });
+
+      const ledger = await stateManager.readRaw(`tasks/${task.goal_id}/ledger/${task.id}.json`) as {
+        events: Array<Record<string, unknown>>;
+      };
+      const abandoned = ledger.events.at(-1)!;
+
+      expect(result.action).toBe("escalate");
+      expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("requested workspace local change\n");
+      expect(abandoned.action).toBe("escalate");
+      expect(abandoned.reason).toContain(isolatedWorktree);
+      expect(abandoned.reason).toContain("was not reverted or discarded");
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
+  it("records dirty isolated worktree discard without reverting the requested workspace", async () => {
+    const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "attempt-revert-repo-"));
+    initGitRepo(repoDir);
+    fs.writeFileSync(path.join(repoDir, "tracked.txt"), "requested workspace local change\n", "utf-8");
+    const isolatedWorktree = path.join(tmpDir, "discarded-isolated-worktree");
+
+    const deps: VerifierDeps = {
+      stateManager,
+      llmClient: createMockLLMClient([]),
+      sessionManager,
+      trustManager,
+      stallDetector,
+      durationToMs: (d) => d.value * (d.unit === "hours" ? 3600000 : 60000),
+      revertCwd: repoDir,
+    };
+    const task = makeTask({
+      scope_boundary: { in_scope: ["tracked.txt"], out_of_scope: [], blast_radius: "low" },
+      reversibility: "reversible",
+    });
+
+    try {
+      await stateManager.writeRaw(`tasks/${task.goal_id}/${task.id}.json`, task);
+      const result = await handleFailure(deps, task, makeFailureVerificationResult(["tracked.txt"]), {
+        stoppedReason: "error",
+        agentLoopWorkspace: {
+          requestedCwd: repoDir,
+          executionCwd: isolatedWorktree,
+          isolatedWorkspace: true,
+          workspaceCleanupStatus: "cleaned_up",
+          workspaceCleanupReason: "cleanup policy set to always",
+          workspaceDirty: true,
+          workspaceDisposition: "discarded",
+        },
+      });
+
+      const ledger = await stateManager.readRaw(`tasks/${task.goal_id}/ledger/${task.id}.json`) as {
+        events: Array<Record<string, unknown>>;
+      };
+      const abandoned = ledger.events.at(-1)!;
+
+      expect(result.action).toBe("discard");
+      expect(fs.readFileSync(path.join(repoDir, "tracked.txt"), "utf-8")).toBe("requested workspace local change\n");
+      expect(abandoned.action).toBe("discard");
+      expect(abandoned.reason).toContain("dirty isolated worktree changes were discarded");
+      expect(abandoned.reason).toContain("was not reverted or discarded");
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
+
   it("requires staged changes to be restored before discarding", async () => {
     const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "attempt-revert-repo-"));
     initGitRepo(repoDir);

--- a/src/orchestrator/execution/adapter-layer.ts
+++ b/src/orchestrator/execution/adapter-layer.ts
@@ -8,6 +8,7 @@
 import { AdapterError } from "../../base/utils/errors.js";
 import type { VerificationFileDiff } from "../../base/types/task.js";
 import type { AgentLoopReasoningEffort } from "./agent-loop/agent-loop-model.js";
+import type { AgentLoopWorkspaceDisposition } from "./agent-loop/agent-loop-result.js";
 
 // ─── Types ───
 
@@ -47,6 +48,8 @@ export interface AgentLoopExecutionInfo {
   isolatedWorkspace?: boolean;
   workspaceCleanupStatus?: "not_requested" | "cleaned_up" | "kept";
   workspaceCleanupReason?: string;
+  workspaceDirty?: boolean;
+  workspaceDisposition?: AgentLoopWorkspaceDisposition;
   profileName?: string;
   reasoningEffort?: AgentLoopReasoningEffort;
   sandboxMode?: string;

--- a/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts
@@ -78,4 +78,52 @@ describe("taskAgentLoopResultToAgentResult", () => {
     expect(result.filesChangedPaths).toEqual([]);
     expect(result.agentLoop?.filesChangedPaths).toEqual([]);
   });
+
+  it("does not mark a dirty isolated worktree as completed without handoff", () => {
+    const result = taskAgentLoopResultToAgentResult({
+      success: true,
+      output: {
+        status: "done",
+        finalAnswer: "done",
+        summary: "done",
+        filesChanged: ["README.md"],
+        testsRun: [],
+        completionEvidence: ["model claimed completion"],
+        verificationHints: [],
+        blockers: [],
+      },
+      finalText: "done",
+      stopReason: "completed",
+      elapsedMs: 1,
+      modelTurns: 1,
+      toolCalls: 0,
+      compactions: 0,
+      changedFiles: ["README.md"],
+      commandResults: [],
+      workspace: {
+        requestedCwd: "/repo",
+        executionCwd: "/worktrees/task-1",
+        isolated: true,
+        cleanupStatus: "kept",
+        cleanupReason: "worktree has changes",
+        dirty: true,
+        disposition: "handoff_required",
+      },
+      traceId: "trace-1",
+      sessionId: "session-1",
+      turnId: "turn-1",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.stopped_reason).toBe("error");
+    expect(result.output).toContain("/worktrees/task-1");
+    expect(result.error).toContain("operator handoff");
+    expect(result.agentLoop).toMatchObject({
+      requestedCwd: "/repo",
+      executionCwd: "/worktrees/task-1",
+      isolatedWorkspace: true,
+      workspaceDirty: true,
+      workspaceDisposition: "handoff_required",
+    });
+  });
 });

--- a/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts
+++ b/src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts
@@ -211,6 +211,97 @@ describe("TaskAgentLoopRunner non-interactive smoke command policy", () => {
     expect(fs.existsSync(result.workspace!.executionCwd)).toBe(true);
   });
 
+  it("requires handoff instead of completion when successful work leaves a dirty isolated worktree", async () => {
+    const policyRoot = makeTempDir();
+    tmpDirs.push(policyRoot);
+    const workspace = makeGitWorkspace(policyRoot);
+    const isolatedBaseDir = path.join(policyRoot, "worktrees");
+    const modelInfo = makeModelInfo();
+    const modelClient = new ScriptedModelClient(modelInfo, [
+      {
+        content: "",
+        toolCalls: [{
+          id: "edit-1",
+          name: "apply_patch",
+          input: {
+            patch: [
+              "*** Begin Patch",
+              "*** Update File: README.md",
+              "@@",
+              "-fixture",
+              "+fixture changed in isolated worktree",
+              "*** End Patch",
+            ].join("\n"),
+          },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: "",
+        toolCalls: [{
+          id: "verify-1",
+          name: "shell_command",
+          input: { command: "grep -q 'fixture changed in isolated worktree' README.md", timeoutMs: 30_000 },
+        }],
+        stopReason: "tool_use",
+      },
+      {
+        content: JSON.stringify({
+          status: "done",
+          finalAnswer: "implemented change",
+          summary: "README updated",
+          filesChanged: ["README.md"],
+          testsRun: [],
+          completionEvidence: ["README.md was updated"],
+          verificationHints: [],
+          blockers: [],
+        }),
+        toolCalls: [],
+        stopReason: "end_turn",
+      },
+    ]);
+    const task = makeTask({
+      success_criteria: [{
+        description: "README contains the isolated worktree change",
+        verification_method: "grep -q 'fixture changed in isolated worktree' README.md",
+        is_blocking: true,
+      }],
+    });
+    const runner = makeRunner({
+      workspace,
+      modelInfo,
+      modelClient,
+      defaultExecutionPolicy: withExecutionPolicyOverrides(defaultExecutionPolicy(policyRoot), {
+        approvalPolicy: "never",
+      }),
+      defaultWorktreePolicy: {
+        enabled: true,
+        baseDir: isolatedBaseDir,
+        cleanupPolicy: "on_success",
+      },
+    });
+
+    const result = await runner.runTaskAsAgentResult({ task, cwd: workspace });
+
+    expect(result.success).toBe(false);
+    expect(result.stopped_reason).toBe("error");
+    expect(result.output).toContain("operator handoff");
+    expect(result.output).toContain(result.agentLoop!.executionCwd!);
+    expect(result.agentLoop).toMatchObject({
+      requestedCwd: fs.realpathSync(workspace),
+      isolatedWorkspace: true,
+      workspaceCleanupStatus: "kept",
+      workspaceCleanupReason: "worktree has changes",
+      workspaceDirty: true,
+      workspaceDisposition: "handoff_required",
+    });
+    expect(result.agentLoop!.executionCwd).not.toBe(workspace);
+    expect(fs.readFileSync(path.join(workspace, "README.md"), "utf-8")).toBe("fixture\n");
+    expect(fs.readFileSync(path.join(result.agentLoop!.executionCwd!, "README.md"), "utf-8")).toBe(
+      "fixture changed in isolated worktree\n",
+    );
+  });
+
   it("does not keep isolated workspaces when a later typed tool recovers after denial", async () => {
     const policyRoot = makeTempDir();
     tmpDirs.push(policyRoot);

--- a/src/orchestrator/execution/agent-loop/agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/agent-loop-result.ts
@@ -29,12 +29,21 @@ export interface AgentLoopToolResultSummary {
   durationMs: number;
 }
 
+export type AgentLoopWorkspaceDisposition =
+  | "not_isolated"
+  | "cleaned_up"
+  | "kept_clean"
+  | "handoff_required"
+  | "discarded";
+
 export interface AgentLoopWorkspaceInfo {
   requestedCwd: string;
   executionCwd: string;
   isolated: boolean;
   cleanupStatus?: "not_requested" | "cleaned_up" | "kept";
   cleanupReason?: string;
+  dirty?: boolean;
+  disposition?: AgentLoopWorkspaceDisposition;
 }
 
 export interface AgentLoopTokenUsage {

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-result.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import * as path from "node:path";
 import type { AgentResult } from "../adapter-layer.js";
-import type { AgentLoopResult } from "./agent-loop-result.js";
+import type { AgentLoopResult, AgentLoopWorkspaceInfo } from "./agent-loop-result.js";
 
 export const TaskAgentLoopOutputSchema = z.object({
   status: z.enum(["done", "blocked", "partial", "failed"]),
@@ -60,6 +60,16 @@ function formatNotExecutedDetail(input: {
   const cwd = input.cwd ? ` in ${input.cwd}` : "";
   const message = input.message?.trim() ? `. ${input.message.trim()}` : "";
   return `${input.kind} ${input.name} was not executed${reason}${cwd}${command}${message}`;
+}
+
+export function requiresIsolatedWorkspaceHandoff(
+  workspace: Pick<AgentLoopWorkspaceInfo, "isolated" | "disposition"> | undefined,
+): boolean {
+  return workspace?.isolated === true && workspace.disposition === "handoff_required";
+}
+
+function formatIsolatedWorkspaceHandoffBlocker(workspace: AgentLoopWorkspaceInfo): string {
+  return `Isolated agent loop worktree has unintegrated changes; completion requires operator handoff: ${workspace.executionCwd}`;
 }
 
 function entrySequence(entry: { sequence?: number }, fallbackIndex: number): number {
@@ -122,9 +132,13 @@ export function taskAgentLoopResultToAgentResult(
   result: AgentLoopResult<TaskAgentLoopOutput>,
 ): AgentResult {
   const notExecutedBlockers = collectTaskAgentLoopNotExecutedBlockers(result);
+  const workspaceHandoffBlockers = requiresIsolatedWorkspaceHandoff(result.workspace)
+    ? [formatIsolatedWorkspaceHandoffBlocker(result.workspace!)]
+    : [];
   const blockers = [
     ...(result.output?.blockers ?? []),
     ...notExecutedBlockers,
+    ...workspaceHandoffBlockers,
   ];
   const done = result.success && result.output?.status === "done" && blockers.length === 0;
   const runtimeVerificationCommands = result.commandResults.filter((command) =>
@@ -166,6 +180,7 @@ export function taskAgentLoopResultToAgentResult(
         ...(result.output?.verificationHints ?? []),
         ...runtimeVerificationCommands.filter((command) => !command.success).map((command) => `failed command: ${command.command}`),
         ...notExecutedBlockers,
+        ...workspaceHandoffBlockers,
       ],
       filesChangedPaths,
       ...(result.workspace
@@ -175,6 +190,8 @@ export function taskAgentLoopResultToAgentResult(
             isolatedWorkspace: result.workspace.isolated,
             workspaceCleanupStatus: result.workspace.cleanupStatus,
             workspaceCleanupReason: result.workspace.cleanupReason,
+            workspaceDirty: result.workspace.dirty,
+            workspaceDisposition: result.workspace.disposition,
           }
         : {}),
       ...(result.executionPolicy

--- a/src/orchestrator/execution/agent-loop/task-agent-loop-worktree.ts
+++ b/src/orchestrator/execution/agent-loop/task-agent-loop-worktree.ts
@@ -36,6 +36,8 @@ export async function prepareTaskAgentLoopWorkspace(input: {
         executionCwd: requestedCwd,
         isolated: false,
         cleanupStatus: "not_requested",
+        dirty: false,
+        disposition: "not_isolated",
       }),
     };
   }
@@ -52,6 +54,8 @@ export async function prepareTaskAgentLoopWorkspace(input: {
         isolated: false,
         cleanupStatus: "not_requested",
         cleanupReason: "cwd is not inside a git repository",
+        dirty: false,
+        disposition: "not_isolated",
       }),
     };
   }
@@ -68,6 +72,8 @@ export async function prepareTaskAgentLoopWorkspace(input: {
         isolated: false,
         cleanupStatus: "not_requested",
         cleanupReason: "git HEAD could not be resolved",
+        dirty: false,
+        disposition: "not_isolated",
       }),
     };
   }
@@ -116,6 +122,18 @@ export async function prepareTaskAgentLoopWorkspace(input: {
       const shouldKeepForDebug = policy.keepForDebug === true;
       const isDirty = changedFiles.length > 0 || await isGitWorktreeDirty(worktreePath);
 
+      if (success && isDirty) {
+        return {
+          requestedCwd,
+          executionCwd,
+          isolated: true,
+          cleanupStatus: "kept",
+          cleanupReason: "worktree has changes",
+          dirty: true,
+          disposition: "handoff_required",
+        };
+      }
+
       if (shouldKeepForDebug) {
         return {
           requestedCwd,
@@ -123,6 +141,8 @@ export async function prepareTaskAgentLoopWorkspace(input: {
           isolated: true,
           cleanupStatus: "kept",
           cleanupReason: "keepForDebug enabled",
+          dirty: isDirty,
+          disposition: isDirty ? "handoff_required" : "kept_clean",
         };
       }
 
@@ -133,6 +153,8 @@ export async function prepareTaskAgentLoopWorkspace(input: {
           isolated: true,
           cleanupStatus: "kept",
           cleanupReason: "cleanup policy set to never",
+          dirty: isDirty,
+          disposition: isDirty ? "handoff_required" : "kept_clean",
         };
       }
 
@@ -143,6 +165,8 @@ export async function prepareTaskAgentLoopWorkspace(input: {
           isolated: true,
           cleanupStatus: "kept",
           cleanupReason: !success ? "task did not succeed" : "worktree has changes",
+          dirty: isDirty,
+          disposition: isDirty ? "handoff_required" : "kept_clean",
         };
       }
 
@@ -152,6 +176,8 @@ export async function prepareTaskAgentLoopWorkspace(input: {
         executionCwd,
         isolated: true,
         cleanupStatus: "cleaned_up",
+        dirty: isDirty,
+        disposition: isDirty ? "discarded" : "cleaned_up",
       };
     },
   };

--- a/src/orchestrator/execution/task/task-lifecycle-runner.ts
+++ b/src/orchestrator/execution/task/task-lifecycle-runner.ts
@@ -23,6 +23,7 @@ import { reloadTaskFromDisk, verifyExecutionWithGitDiff } from "./task-execution
 import { appendTaskOutcomeEvent, setTaskOutcomeTokens } from "./task-outcome-ledger.js";
 import { createSkippedTaskResult } from "./task-execution-types.js";
 import type { ExecutionModeState } from "../../../platform/time/execution-mode.js";
+import { applyVerdictHandlingContextGuards } from "./task-verifier.js";
 
 export interface TaskGenerationResult {
   task: Task | null;
@@ -100,6 +101,24 @@ export interface TaskLifecycleTaskCycleContext {
     abortSignal?: AbortSignal,
   ) => Promise<AgentResult>;
   handleVerdict: (task: Task, verificationResult: VerificationResult, context?: VerdictHandlingContext) => Promise<VerdictResult>;
+}
+
+function buildVerdictHandlingContext(executionResult: AgentResult): VerdictHandlingContext {
+  const context: VerdictHandlingContext = {
+    stoppedReason: executionResult.success ? null : executionResult.stopped_reason,
+  };
+  if (executionResult.agentLoop) {
+    context.agentLoopWorkspace = {
+      requestedCwd: executionResult.agentLoop.requestedCwd,
+      executionCwd: executionResult.agentLoop.executionCwd,
+      isolatedWorkspace: executionResult.agentLoop.isolatedWorkspace,
+      workspaceCleanupStatus: executionResult.agentLoop.workspaceCleanupStatus,
+      workspaceCleanupReason: executionResult.agentLoop.workspaceCleanupReason,
+      workspaceDirty: executionResult.agentLoop.workspaceDirty,
+      workspaceDisposition: executionResult.agentLoop.workspaceDisposition,
+    };
+  }
+  return context;
 }
 
 export async function runTaskLifecycleCycle(context: TaskLifecycleTaskCycleContext): Promise<TaskCycleResult> {
@@ -311,13 +330,25 @@ export async function runTaskLifecycleCycle(context: TaskLifecycleTaskCycleConte
     )
   );
   taskCycleTokens += verifierTokenAccumulator.tokensUsed;
-  logger?.debug(`[DEBUG-TL] Verification: verdict=${verificationResult.verdict}, evidence=${verificationResult.evidence.map((e) => e.description).join("; ").substring(0, 300)}`);
+  const verdictContext = buildVerdictHandlingContext(executionResult);
+  const effectiveVerificationResult = applyVerdictHandlingContextGuards(verificationResult, verdictContext);
+  const effectiveVerdictContext = { ...verdictContext, verificationGuardsApplied: true };
+  if (effectiveVerificationResult !== verificationResult) {
+    const rawVerification = await stateManager.readRaw(`verification/${taskForVerification.id}/verification-result.json`);
+    await stateManager.writeRaw(
+      `verification/${taskForVerification.id}/verification-result.json`,
+      rawVerification && typeof rawVerification === "object"
+        ? { ...rawVerification, ...effectiveVerificationResult }
+        : effectiveVerificationResult
+    );
+  }
+  logger?.debug(`[DEBUG-TL] Verification: verdict=${effectiveVerificationResult.verdict}, evidence=${effectiveVerificationResult.evidence.map((e) => e.description).join("; ").substring(0, 300)}`);
 
   const verdictResult = await runPhase("handle-verdict", () =>
     context.handleVerdict(
       taskForVerification,
-      verificationResult,
-      { stoppedReason: executionResult.success ? null : executionResult.stopped_reason }
+      effectiveVerificationResult,
+      effectiveVerdictContext
     )
   );
   logger?.info(`[task] verdict: ${verdictResult.action}`, { taskId: task.id });
@@ -328,7 +359,7 @@ export async function runTaskLifecycleCycle(context: TaskLifecycleTaskCycleConte
       targetDimension,
       task: verdictResult.task,
       action: verdictResult.action,
-      verificationResult,
+      verificationResult: effectiveVerificationResult,
       executionResult,
       adapter,
       ...context.sideEffectDeps(),
@@ -342,7 +373,7 @@ export async function runTaskLifecycleCycle(context: TaskLifecycleTaskCycleConte
 
   return {
     task: verdictResult.task,
-    verificationResult,
+    verificationResult: effectiveVerificationResult,
     action: verdictResult.action,
     tokensUsed: taskCycleTokens,
   };

--- a/src/orchestrator/execution/task/task-verifier-types.ts
+++ b/src/orchestrator/execution/task/task-verifier-types.ts
@@ -44,6 +44,17 @@ export interface RevertAttemptResult {
 
 export interface VerdictHandlingContext {
   stoppedReason?: AgentResult["stopped_reason"] | null;
+  verificationGuardsApplied?: boolean;
+  agentLoopWorkspace?: Pick<
+    NonNullable<AgentResult["agentLoop"]>,
+    | "requestedCwd"
+    | "executionCwd"
+    | "isolatedWorkspace"
+    | "workspaceCleanupStatus"
+    | "workspaceCleanupReason"
+    | "workspaceDirty"
+    | "workspaceDisposition"
+  >;
 }
 
 // ─── CompletionJudgerResponseSchema: Zod schema for LLM completion judgment response ───

--- a/src/orchestrator/execution/task/task-verifier.ts
+++ b/src/orchestrator/execution/task/task-verifier.ts
@@ -79,6 +79,88 @@ function statusAfterIncompleteVerification(task: Task): Task["status"] {
   return "error";
 }
 
+function isolatedWorkspaceHandoff(
+  context: VerdictHandlingContext,
+): NonNullable<VerdictHandlingContext["agentLoopWorkspace"]> | null {
+  const workspace = context.agentLoopWorkspace;
+  if (
+    workspace?.isolatedWorkspace === true &&
+    workspace.workspaceDisposition === "handoff_required"
+  ) {
+    return workspace;
+  }
+  return null;
+}
+
+function discardedDirtyIsolatedWorkspace(
+  context: VerdictHandlingContext,
+): NonNullable<VerdictHandlingContext["agentLoopWorkspace"]> | null {
+  const workspace = context.agentLoopWorkspace;
+  if (
+    workspace?.isolatedWorkspace === true &&
+    workspace.workspaceDirty === true &&
+    workspace.workspaceDisposition === "discarded"
+  ) {
+    return workspace;
+  }
+  return null;
+}
+
+function shouldCollectDiffsFromRequestedWorkspace(executionResult: AgentResult): boolean {
+  if (executionResult.agentLoop?.isolatedWorkspace !== true) return true;
+  if (executionResult.agentLoop.workspaceDirty !== true) return true;
+  return executionResult.agentLoop.workspaceDisposition !== "handoff_required" &&
+    executionResult.agentLoop.workspaceDisposition !== "discarded";
+}
+
+function formatIsolatedWorkspaceHandoffReason(
+  workspace: NonNullable<VerdictHandlingContext["agentLoopWorkspace"]>,
+): string {
+  const executionCwd = workspace.executionCwd ?? "unknown isolated worktree";
+  const requestedCwd = workspace.requestedCwd ?? "unknown requested workspace";
+  return [
+    `dirty isolated worktree retained at ${executionCwd}`,
+    `requested workspace ${requestedCwd} was not reverted or discarded`,
+    "operator review is required before completion",
+  ].join("; ");
+}
+
+function formatDiscardedDirtyIsolatedWorkspaceReason(
+  workspace: NonNullable<VerdictHandlingContext["agentLoopWorkspace"]>,
+): string {
+  const executionCwd = workspace.executionCwd ?? "unknown isolated worktree";
+  const requestedCwd = workspace.requestedCwd ?? "unknown requested workspace";
+  return [
+    `dirty isolated worktree changes were discarded from ${executionCwd}`,
+    `requested workspace ${requestedCwd} was not reverted or discarded`,
+    "task must be retried from the requested workspace",
+  ].join("; ");
+}
+
+export function applyVerdictHandlingContextGuards(
+  verificationResult: VerificationResult,
+  context: VerdictHandlingContext,
+): VerificationResult {
+  const workspace = isolatedWorkspaceHandoff(context) ?? discardedDirtyIsolatedWorkspace(context);
+  if (!workspace) return verificationResult;
+  const reason = workspace.workspaceDisposition === "discarded"
+    ? formatDiscardedDirtyIsolatedWorkspaceReason(workspace)
+    : formatIsolatedWorkspaceHandoffReason(workspace);
+  return {
+    ...verificationResult,
+    verdict: "fail",
+    confidence: Math.max(verificationResult.confidence ?? 0, 0.95),
+    evidence: [
+      {
+        layer: "mechanical" as const,
+        description: reason,
+        confidence: 0.95,
+      },
+      ...(verificationResult.evidence ?? []),
+    ],
+  };
+}
+
 function quoteShellArg(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
 }
@@ -91,6 +173,8 @@ async function collectVerificationDiffs(
   if (executionResult.fileDiffs && executionResult.fileDiffs.length > 0) {
     return executionResult.fileDiffs;
   }
+
+  if (!shouldCollectDiffsFromRequestedWorkspace(executionResult)) return [];
 
   if (!deps.toolExecutor) return [];
 
@@ -518,6 +602,10 @@ export async function handleVerdict(
     }
   }
 
+  if (context.verificationGuardsApplied !== true) {
+    verificationResult = applyVerdictHandlingContextGuards(verificationResult, context);
+  }
+
   // Save failure context for fail/partial verdicts (§4.7)
   if (verificationResult.verdict === "fail" || verificationResult.verdict === "partial") {
     const firstEvidence = verificationResult.evidence?.[0];
@@ -726,6 +814,38 @@ export async function handleFailure(
       stoppedReason: context.stoppedReason ?? undefined,
     });
     return { action: "escalate", task: updatedTask };
+  }
+
+  const handoffWorkspace = isolatedWorkspaceHandoff(context);
+  if (handoffWorkspace) {
+    const reason = formatIsolatedWorkspaceHandoffReason(handoffWorkspace);
+    await appendTaskHistory(deps, task.goal_id, updatedTask);
+    await appendTaskOutcomeEvent(deps.stateManager, {
+      task: updatedTask,
+      type: "abandoned",
+      attempt: updatedTask.consecutive_failure_count,
+      action: "escalate",
+      verificationResult,
+      reason,
+      stoppedReason: context.stoppedReason ?? undefined,
+    });
+    return { action: "escalate", task: updatedTask };
+  }
+
+  const discardedWorkspace = discardedDirtyIsolatedWorkspace(context);
+  if (discardedWorkspace) {
+    const reason = formatDiscardedDirtyIsolatedWorkspaceReason(discardedWorkspace);
+    await appendTaskHistory(deps, task.goal_id, updatedTask);
+    await appendTaskOutcomeEvent(deps.stateManager, {
+      task: updatedTask,
+      type: "abandoned",
+      attempt: updatedTask.consecutive_failure_count,
+      action: "discard",
+      verificationResult,
+      reason,
+      stoppedReason: context.stoppedReason ?? undefined,
+    });
+    return { action: "discard", task: updatedTask };
   }
 
   const directionCorrect = isDirectionCorrect(verificationResult);


### PR DESCRIPTION
Closes #1146

## Summary
- Add typed isolated-worktree disposition metadata (`workspaceDirty`, `workspaceDisposition`) from agent-loop worktree finalization through `AgentResult`.
- Treat dirty successful isolated worktrees as `handoff_required`, keeping the worktree path visible and preventing completed status unless changes are integrated elsewhere.
- Treat dirty discarded isolated worktrees as a typed discard outcome, without reverting or discarding the requested workspace based on isolated worktree diffs.
- Apply the guarded verification result before verdict handling, side effects, persisted verification evidence, and returned `runTaskCycle()` results.

## Verification
- `npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts`
- `npm run test:unit -- src/orchestrator/execution/__tests__/task-lifecycle-execution.test.ts src/orchestrator/execution/__tests__/task-verifier-guards.test.ts`
- `npm run test:unit -- src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts src/orchestrator/execution/__tests__/task-verifier-guards.test.ts`
- `npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts src/orchestrator/execution/__tests__/task-lifecycle-execution.test.ts`
- Post-rebase: `npm run test:unit -- src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-result.test.ts src/orchestrator/execution/agent-loop/__tests__/task-agent-loop-smoke-policy.test.ts src/orchestrator/execution/__tests__/task-lifecycle-cycle-persistence.test.ts src/orchestrator/execution/__tests__/task-lifecycle-execution.test.ts src/orchestrator/execution/__tests__/task-verifier-guards.test.ts`
- Post-rebase: `npm run typecheck`
- Post-rebase: `npm run test:changed` (fast unit lane: 442 passed, 3 skipped)
- Post-rebase: `npm run lint:boundaries` (0 errors, existing warnings)
- `git diff --check origin/main...HEAD`

## Known unresolved risks
- This intentionally records handoff/discard state instead of auto-integrating isolated worktree changes into the requested workspace.
- `lint:boundaries` still reports existing warning-only findings unrelated to this PR.

## Parallel PR dependency / incorporation status
- Rebased onto `origin/main` after #1173 merged.
- #1171 remains open but touches shell policy/TUI surfaces, with no direct worktree lifecycle conflict found.
- Fresh review found two material issues in the first pass; both were fixed and follow-up fresh review reported no material findings.
